### PR TITLE
feat(designs): moodboard insert-block palette + categorized construction picker [#1113]

### DIFF
--- a/apps/backend/src/admin/components/designs/design-construction-section.tsx
+++ b/apps/backend/src/admin/components/designs/design-construction-section.tsx
@@ -21,23 +21,22 @@ import {
   useCreateConstructionDetail,
   useDeleteConstructionDetail,
 } from "../../hooks/api/designs"
+import { CONSTRUCTION_TECHNIQUES } from "../../../modules/designs/construction-techniques"
 
-// Keep in sync with SUPPORTED_TECHNIQUES on the backend route / DETAIL_RENDERERS.
-// `paramHint` documents the parameter the renderer reads, shown as a placeholder.
-const TECHNIQUES: { value: string; label: string; paramHint: string }[] = [
-  { value: "dart", label: "Dart", paramHint: "intake = 0.6" },
-  { value: "knife-pleat", label: "Knife pleat", paramHint: "count = 5" },
-  { value: "box-pleat", label: "Box pleat", paramHint: "count = 3" },
-  { value: "gathers", label: "Gathers", paramHint: "ratio = 1.6" },
-  { value: "tucks", label: "Tucks", paramHint: "count = 4" },
-  { value: "topstitch", label: "Topstitch", paramHint: "rows = 2" },
-  { value: "yoke", label: "Yoke", paramHint: "drop = 0.4" },
-  { value: "embroidery", label: "Embroidery", paramHint: "motif = 6" },
-]
+// Derived from the canonical construction-techniques module (#1113 Feature B) —
+// the single source shared with the backend route, renderer and partner picker.
+// `paramHint` documents the params the renderer reads, shown as a placeholder.
+const TECHNIQUES: { value: string; label: string; paramHint: string }[] =
+  CONSTRUCTION_TECHNIQUES.map((t) => ({
+    value: t.slug,
+    label: t.label,
+    paramHint: t.params.length
+      ? t.params.map((p) => `${p.key} = ${p.default}`).join(", ")
+      : "no params",
+  }))
 
 // Ready-made construction details for common garment features. Selecting one
 // pre-fills the form so the same detail isn't re-authored from scratch each time.
-// All techniques below must exist in TECHNIQUES / the backend SUPPORTED_TECHNIQUES.
 type ConstructionSample = {
   value: string
   label: string
@@ -48,97 +47,17 @@ type ConstructionSample = {
   note?: string
 }
 
-const SAMPLES: ConstructionSample[] = [
-  {
-    value: "waist-dart",
-    label: "Waist dart",
-    technique: "dart",
-    detailLabel: "Waist dart",
-    params: { intake: 0.6 },
-    fabricRules: ["press toward centre front", "taper to nothing at apex"],
-    note: "Backstitch at waist seam, leave apex un-backstitched",
-  },
-  {
-    value: "bust-dart",
-    label: "Bust dart",
-    technique: "dart",
-    detailLabel: "Bust dart",
-    params: { intake: 0.5 },
-    fabricRules: ["press downward", "end 2.5 cm short of apex"],
-  },
-  {
-    value: "knife-pleat-skirt",
-    label: "Knife pleats (skirt)",
-    technique: "knife-pleat",
-    detailLabel: "Knife pleats",
-    params: { count: 6 },
-    fabricRules: ["all pleats face one direction", "press sharp, edge-stitch top 8 cm"],
-  },
-  {
-    value: "box-pleat-center",
-    label: "Centre box pleat",
-    technique: "box-pleat",
-    detailLabel: "Centre box pleat",
-    params: { count: 1 },
-    fabricRules: ["centre on CF", "tack at waist"],
-  },
-  {
-    value: "gathered-sleeve-head",
-    label: "Gathered sleeve head",
-    technique: "gathers",
-    detailLabel: "Sleeve-head gathers",
-    params: { ratio: 1.4 },
-    fabricRules: ["two rows of ease stitching", "distribute fullness between notches"],
-  },
-  {
-    value: "gathered-skirt-waist",
-    label: "Gathered skirt waist",
-    technique: "gathers",
-    detailLabel: "Waist gathers",
-    params: { ratio: 2 },
-    fabricRules: ["gather evenly to waistband length"],
-  },
-  {
-    value: "pin-tucks-bodice",
-    label: "Pin tucks (bodice)",
-    technique: "tucks",
-    detailLabel: "Pin tucks",
-    params: { count: 5 },
-    fabricRules: ["6 mm spacing", "press to one side"],
-  },
-  {
-    value: "double-topstitch-hem",
-    label: "Double topstitch hem",
-    technique: "topstitch",
-    detailLabel: "Double topstitch",
-    params: { rows: 2 },
-    fabricRules: ["6 mm row spacing", "matching thread"],
-  },
-  {
-    value: "edge-topstitch",
-    label: "Edge topstitch",
-    technique: "topstitch",
-    detailLabel: "Edge topstitch",
-    params: { rows: 1 },
-    fabricRules: ["1.5 mm from edge"],
-  },
-  {
-    value: "back-yoke",
-    label: "Back yoke",
-    technique: "yoke",
-    detailLabel: "Back yoke",
-    params: { drop: 0.4 },
-    fabricRules: ["burrito method", "understitch yoke seam"],
-  },
-  {
-    value: "chain-embroidery",
-    label: "Chain-stitch embroidery",
-    technique: "embroidery",
-    detailLabel: "Chain-stitch motif",
-    params: { motif: 6 },
-    fabricRules: ["stabilise reverse before stitching"],
-  },
-]
+const SAMPLES: ConstructionSample[] = CONSTRUCTION_TECHNIQUES.flatMap((t) =>
+  t.presets.map((p) => ({
+    value: p.value,
+    label: p.label,
+    technique: t.slug,
+    detailLabel: p.detailLabel,
+    params: p.params,
+    fabricRules: p.fabricRules,
+    note: p.note,
+  }))
+)
 
 /** Parse a textarea of `key = value` lines into a numeric param map (non-numeric dropped). */
 function parseParams(text: string): Record<string, number> {

--- a/apps/backend/src/api/middlewares.ts
+++ b/apps/backend/src/api/middlewares.ts
@@ -4611,6 +4611,42 @@ export default defineMiddlewares({
       middlewares: [authenticate("partner", ["session", "bearer"])],
     },
     {
+      // #1113 Feature A — insert-block palette: list drop-in blocks.
+      matcher: "/partners/designs/:designId/moodboard/blocks",
+      method: "GET",
+      middlewares: [authenticate("partner", ["session", "bearer"])],
+    },
+    {
+      // #1113 Feature A — build one drop-in block from the design's data.
+      matcher: "/partners/designs/:designId/moodboard/blocks",
+      method: "POST",
+      middlewares: [authenticate("partner", ["session", "bearer"])],
+    },
+    {
+      // #1113 Feature B — construction catalog for the categorized picker.
+      matcher: "/partners/designs/:designId/construction-techniques",
+      method: "GET",
+      middlewares: [authenticate("partner", ["session", "bearer"])],
+    },
+    {
+      // #1113 Feature B — list the design's construction details.
+      matcher: "/partners/designs/:designId/construction-details",
+      method: "GET",
+      middlewares: [authenticate("partner", ["session", "bearer"])],
+    },
+    {
+      // #1113 Feature B — add a construction detail (author-scoped guard).
+      matcher: "/partners/designs/:designId/construction-details",
+      method: "POST",
+      middlewares: [authenticate("partner", ["session", "bearer"])],
+    },
+    {
+      // #1113 Feature B — delete a construction detail.
+      matcher: "/partners/designs/:designId/construction-details/:detailId",
+      method: "DELETE",
+      middlewares: [authenticate("partner", ["session", "bearer"])],
+    },
+    {
       // #1113 S3 — partner saves the moodboard scene edited on the canvas.
       // Owner OR assigned designer (author-scoped guard in the route), scoped
       // to just the `moodboard` column.

--- a/apps/backend/src/api/partners/designs/[designId]/construction-details/[detailId]/route.ts
+++ b/apps/backend/src/api/partners/designs/[designId]/construction-details/[detailId]/route.ts
@@ -1,0 +1,36 @@
+import { AuthenticatedMedusaRequest, MedusaResponse } from "@medusajs/framework/http"
+import { MedusaError } from "@medusajs/framework/utils"
+import { DESIGN_MODULE } from "../../../../../../modules/designs"
+import type DesignService from "../../../../../../modules/designs/service"
+import { assertPartnerCanAuthorDesign } from "../../../helpers"
+
+/**
+ * DELETE /partners/designs/:designId/construction-details/:detailId
+ *
+ * Remove a construction detail the designer added. Author-scoped; guarded so a
+ * detail is only deletable when it belongs to this design and is a Construction
+ * spec (never another design's or a non-construction spec).
+ */
+export const DELETE = async (
+  req: AuthenticatedMedusaRequest & { params: { designId: string; detailId: string } },
+  res: MedusaResponse
+) => {
+  const { designId, detailId } = req.params
+  await assertPartnerCanAuthorDesign(req, designId)
+
+  const designService = req.scope.resolve(DESIGN_MODULE) as DesignService
+  const [spec] = await designService.listDesignSpecifications({
+    id: detailId,
+    design_id: designId,
+    category: "Construction",
+  })
+  if (!spec) {
+    throw new MedusaError(
+      MedusaError.Types.NOT_FOUND,
+      `Construction detail ${detailId} not found on this design`
+    )
+  }
+
+  await designService.deleteDesignSpecifications(detailId)
+  res.json({ id: detailId, deleted: true })
+}

--- a/apps/backend/src/api/partners/designs/[designId]/construction-details/route.ts
+++ b/apps/backend/src/api/partners/designs/[designId]/construction-details/route.ts
@@ -1,4 +1,4 @@
-import { MedusaRequest, MedusaResponse } from "@medusajs/framework/http"
+import { AuthenticatedMedusaRequest, MedusaResponse } from "@medusajs/framework/http"
 import { MedusaError } from "@medusajs/framework/utils"
 import { z } from "@medusajs/framework/zod"
 import { DESIGN_MODULE } from "../../../../../modules/designs"
@@ -7,22 +7,18 @@ import {
   SUPPORTED_TECHNIQUES,
   techniqueLabel,
 } from "../../../../../modules/designs/construction-techniques"
+import { assertPartnerCanAuthorDesign } from "../../helpers"
 
 /**
- * Construction details = DesignSpecifications with category "Construction" whose
- * metadata carries { technique, params, fabricRules } — the source the #892
- * tech-pack generator reads for the "Construction details" frame. These routes let
- * the admin manage them on a real design (instead of via seed scripts), so a design
- * can satisfy the generation completeness gate.
- *
- * Techniques + presets come from the canonical construction-techniques module
- * (#1113 Feature B) — the single source shared with the renderer, admin UI and
- * partner picker.
+ * Partner mirror of the admin construction-details routes (#1113 Feature B).
+ * Lets the invited designer author construction details (technique + params +
+ * fabricRules) straight from the moodboard picker. Author-scoped: owner OR
+ * assigned/invited designer. Stored as DesignSpecifications(category:"Construction")
+ * exactly like the admin path, so the tech-pack generator + DETAIL_RENDERERS
+ * pick them up unchanged.
  */
 
-export { SUPPORTED_TECHNIQUES }
-
-export const ConstructionDetailBodySchema = z.object({
+const ConstructionDetailBodySchema = z.object({
   technique: z.enum(SUPPORTED_TECHNIQUES),
   label: z.string().trim().min(1).optional(),
   params: z.record(z.string(), z.number()).optional(),
@@ -30,28 +26,27 @@ export const ConstructionDetailBodySchema = z.object({
   note: z.string().trim().optional(),
 })
 
-/**
- * GET /admin/designs/:id/construction-details
- * List this design's Construction specs (the renderable construction details).
- */
-export const GET = async (req: MedusaRequest, res: MedusaResponse) => {
-  const { id } = req.params
-  const designService = req.scope.resolve(DESIGN_MODULE) as DesignService
+export const GET = async (
+  req: AuthenticatedMedusaRequest & { params: { designId: string } },
+  res: MedusaResponse
+) => {
+  const designId = req.params.designId
+  await assertPartnerCanAuthorDesign(req, designId)
 
+  const designService = req.scope.resolve(DESIGN_MODULE) as DesignService
   const specs = await designService.listDesignSpecifications({
-    design_id: id,
+    design_id: designId,
     category: "Construction",
   })
-
   res.json({ construction_details: specs, count: specs.length })
 }
 
-/**
- * POST /admin/designs/:id/construction-details
- * Attach a construction detail. Body: { technique, label?, params?, fabricRules?, note? }
- */
-export const POST = async (req: MedusaRequest, res: MedusaResponse) => {
-  const { id } = req.params
+export const POST = async (
+  req: AuthenticatedMedusaRequest & { params: { designId: string } },
+  res: MedusaResponse
+) => {
+  const designId = req.params.designId
+  await assertPartnerCanAuthorDesign(req, designId)
 
   const parsed = ConstructionDetailBodySchema.safeParse(req.body)
   if (!parsed.success) {
@@ -63,18 +58,11 @@ export const POST = async (req: MedusaRequest, res: MedusaResponse) => {
   const { technique, label, params, fabricRules, note } = parsed.data
 
   const designService = req.scope.resolve(DESIGN_MODULE) as DesignService
-
-  const design = await designService.retrieveDesign(id).catch(() => null)
-  if (!design) {
-    throw new MedusaError(MedusaError.Types.NOT_FOUND, `Design ${id} not found`)
-  }
-
   const title = label ?? techniqueLabel(technique)
   const created = await designService.createDesignSpecifications({
-    design_id: id,
+    design_id: designId,
     title,
     category: "Construction",
-    // `details` is required on the model; fall back to a derived description.
     details: note ?? `${title} (${technique})`,
     special_instructions: note ?? null,
     version: "1",

--- a/apps/backend/src/api/partners/designs/[designId]/construction-techniques/route.ts
+++ b/apps/backend/src/api/partners/designs/[designId]/construction-techniques/route.ts
@@ -1,0 +1,26 @@
+import { AuthenticatedMedusaRequest, MedusaResponse } from "@medusajs/framework/http"
+import {
+  CONSTRUCTION_FAMILIES,
+  CONSTRUCTION_TECHNIQUES,
+} from "../../../../../modules/designs/construction-techniques"
+import { assertPartnerCanAuthorDesign } from "../../helpers"
+
+/**
+ * GET /partners/designs/:designId/construction-techniques
+ *
+ * The construction catalog the partner-ui picker renders (#1113 Feature B):
+ * categorized techniques with param defs, default fabric rules and presets —
+ * served verbatim from the canonical construction-techniques module so the
+ * picker never hardcodes the list. Author-scoped for consistency with the rest
+ * of the moodboard surface (the payload itself is static).
+ */
+export const GET = async (
+  req: AuthenticatedMedusaRequest & { params: { designId: string } },
+  res: MedusaResponse
+) => {
+  await assertPartnerCanAuthorDesign(req, req.params.designId)
+  res.json({
+    families: CONSTRUCTION_FAMILIES,
+    techniques: CONSTRUCTION_TECHNIQUES,
+  })
+}

--- a/apps/backend/src/api/partners/designs/[designId]/moodboard/blocks/route.ts
+++ b/apps/backend/src/api/partners/designs/[designId]/moodboard/blocks/route.ts
@@ -1,0 +1,65 @@
+import { AuthenticatedMedusaRequest, MedusaResponse } from "@medusajs/framework/http"
+import { MedusaError } from "@medusajs/framework/utils"
+import {
+  buildMoodboardBlock,
+  listMoodboardBlocks,
+} from "../../../../../../workflows/designs/moodboard/build-moodboard-scene"
+import { loadDesignForMoodboard } from "../../../../../../workflows/designs/moodboard/seed-design-moodboard"
+import { buildTechPackInputFromDesign } from "../../../../../../workflows/designs/moodboard/techpack-input-from-design"
+import { assertPartnerCanAuthorDesign } from "../../../helpers"
+
+/**
+ * GET /partners/designs/:designId/moodboard/blocks
+ *
+ * The insert-block palette (#1113 S3+): lists every drop-in frame the designer
+ * can insert on the canvas, flagging which ones the design currently has data
+ * for. Owner OR assigned/invited designer.
+ */
+export const GET = async (
+  req: AuthenticatedMedusaRequest & { params: { designId: string } },
+  res: MedusaResponse
+) => {
+  const designId = req.params.designId
+  await assertPartnerCanAuthorDesign(req, designId)
+
+  const design = await loadDesignForMoodboard(req.scope, designId)
+  const input = buildTechPackInputFromDesign(design)
+  res.json({ blocks: listMoodboardBlocks(input) })
+}
+
+/**
+ * POST /partners/designs/:designId/moodboard/blocks  { block: "<key>" }
+ *
+ * Build ONE block from the design's current data, positioned at origin. Does
+ * NOT persist — the partner-ui translates + re-ids the returned elements onto
+ * the live Excalidraw scene, then the designer arranges and saves via the
+ * existing author-scoped moodboard PUT. This is the "drop-in element" path that
+ * bypasses the monolithic Generate.
+ */
+export const POST = async (
+  req: AuthenticatedMedusaRequest & { params: { designId: string } },
+  res: MedusaResponse
+) => {
+  const designId = req.params.designId
+  await assertPartnerCanAuthorDesign(req, designId)
+
+  const key = (req.body as { block?: unknown } | undefined)?.block
+  if (typeof key !== "string" || !key.trim()) {
+    throw new MedusaError(
+      MedusaError.Types.INVALID_DATA,
+      "Missing 'block' — pass the key of the block to insert."
+    )
+  }
+
+  const design = await loadDesignForMoodboard(req.scope, designId)
+  const input = buildTechPackInputFromDesign(design)
+  const block = buildMoodboardBlock(input, key)
+  if (!block) {
+    throw new MedusaError(
+      MedusaError.Types.INVALID_DATA,
+      `Unknown block '${key}'.`
+    )
+  }
+
+  res.json({ block })
+}

--- a/apps/backend/src/modules/designs/construction-techniques.ts
+++ b/apps/backend/src/modules/designs/construction-techniques.ts
@@ -1,0 +1,259 @@
+/**
+ * construction-techniques.ts — the ONE canonical catalog of construction
+ * techniques (#1113 Feature B).
+ *
+ * Historically the technique list was triplicated (hand-synced) across:
+ *   - the admin/partner construction-details route (Zod validation),
+ *   - DETAIL_RENDERERS in build-moodboard-scene.ts (the editable glyphs),
+ *   - the admin design-construction-section dropdown + presets.
+ *
+ * This module is the single source of truth. It is a PURE data module (no server
+ * imports) so it is safe to import from API routes, the moodboard scene builder,
+ * the admin bundle, AND to serialize verbatim to the partner-ui picker over the
+ * `construction-techniques` endpoint. Everything downstream derives from it.
+ */
+
+/** A tunable parameter the renderer reads, with UI metadata for auto-fill inputs. */
+export interface ConstructionParamDef {
+  key: string
+  label: string
+  min: number
+  max: number
+  step: number
+  default: number
+}
+
+/** A ready-made detail — picking one auto-fills the whole form. */
+export interface ConstructionPreset {
+  value: string
+  label: string
+  detailLabel: string
+  params?: Record<string, number>
+  fabricRules?: string[]
+  note?: string
+}
+
+/** Coarse grouping for the categorized picker. */
+export type ConstructionFamily =
+  | "Darts & Pleats"
+  | "Gathers & Tucks"
+  | "Seams & Topstitch"
+  | "Panels & Yokes"
+  | "Embellishment"
+
+export interface ConstructionTechnique {
+  slug: string
+  label: string
+  family: ConstructionFamily
+  /** Where on the garment this typically applies — a hint for the picker. */
+  garmentAreas: string[]
+  /** Tunable params (empty = fixed geometry); each carries its own default. */
+  params: ConstructionParamDef[]
+  /** Sensible fabric/sewing rules pre-checked when the technique is chosen. */
+  defaultFabricRules: string[]
+  /** Named presets that fully auto-fill the form. */
+  presets: ConstructionPreset[]
+}
+
+/** Ordered families for the picker's section headers. */
+export const CONSTRUCTION_FAMILIES: ConstructionFamily[] = [
+  "Darts & Pleats",
+  "Gathers & Tucks",
+  "Seams & Topstitch",
+  "Panels & Yokes",
+  "Embellishment",
+]
+
+export const CONSTRUCTION_TECHNIQUES: ConstructionTechnique[] = [
+  {
+    slug: "dart",
+    label: "Dart",
+    family: "Darts & Pleats",
+    garmentAreas: ["Bust", "Waist", "Back"],
+    params: [{ key: "intake", label: "Intake", min: 0.2, max: 1, step: 0.05, default: 0.6 }],
+    defaultFabricRules: ["press toward centre front", "taper to nothing at apex"],
+    presets: [
+      {
+        value: "waist-dart",
+        label: "Waist dart",
+        detailLabel: "Waist dart",
+        params: { intake: 0.6 },
+        fabricRules: ["press toward centre front", "taper to nothing at apex"],
+        note: "Backstitch at waist seam, leave apex un-backstitched",
+      },
+      {
+        value: "bust-dart",
+        label: "Bust dart",
+        detailLabel: "Bust dart",
+        params: { intake: 0.5 },
+        fabricRules: ["press downward", "end 2.5 cm short of apex"],
+      },
+    ],
+  },
+  {
+    slug: "knife-pleat",
+    label: "Knife pleat",
+    family: "Darts & Pleats",
+    garmentAreas: ["Skirt", "Sleeve"],
+    params: [{ key: "count", label: "Pleat count", min: 2, max: 7, step: 1, default: 5 }],
+    defaultFabricRules: ["all pleats face one direction", "press sharp"],
+    presets: [
+      {
+        value: "knife-pleat-skirt",
+        label: "Knife pleats (skirt)",
+        detailLabel: "Knife pleats",
+        params: { count: 6 },
+        fabricRules: ["all pleats face one direction", "press sharp, edge-stitch top 8 cm"],
+      },
+    ],
+  },
+  {
+    slug: "box-pleat",
+    label: "Box pleat",
+    family: "Darts & Pleats",
+    garmentAreas: ["Skirt", "Centre front", "Back"],
+    params: [],
+    defaultFabricRules: ["centre on CF", "tack at waist"],
+    presets: [
+      {
+        value: "box-pleat-center",
+        label: "Centre box pleat",
+        detailLabel: "Centre box pleat",
+        params: { count: 1 },
+        fabricRules: ["centre on CF", "tack at waist"],
+      },
+    ],
+  },
+  {
+    slug: "gathers",
+    label: "Gathers",
+    family: "Gathers & Tucks",
+    garmentAreas: ["Sleeve head", "Waist", "Neckline"],
+    params: [{ key: "ratio", label: "Fullness ratio", min: 1, max: 3, step: 0.1, default: 1.6 }],
+    defaultFabricRules: ["two rows of ease stitching", "distribute fullness evenly"],
+    presets: [
+      {
+        value: "gathered-sleeve-head",
+        label: "Gathered sleeve head",
+        detailLabel: "Sleeve-head gathers",
+        params: { ratio: 1.4 },
+        fabricRules: ["two rows of ease stitching", "distribute fullness between notches"],
+      },
+      {
+        value: "gathered-skirt-waist",
+        label: "Gathered skirt waist",
+        detailLabel: "Waist gathers",
+        params: { ratio: 2 },
+        fabricRules: ["gather evenly to waistband length"],
+      },
+    ],
+  },
+  {
+    slug: "tucks",
+    label: "Tucks",
+    family: "Gathers & Tucks",
+    garmentAreas: ["Bodice", "Cuff", "Yoke"],
+    params: [{ key: "count", label: "Tuck count", min: 2, max: 6, step: 1, default: 4 }],
+    defaultFabricRules: ["press to one side"],
+    presets: [
+      {
+        value: "pin-tucks-bodice",
+        label: "Pin tucks (bodice)",
+        detailLabel: "Pin tucks",
+        params: { count: 5 },
+        fabricRules: ["6 mm spacing", "press to one side"],
+      },
+    ],
+  },
+  {
+    slug: "topstitch",
+    label: "Topstitch",
+    family: "Seams & Topstitch",
+    garmentAreas: ["Hem", "Edges", "Seams"],
+    params: [{ key: "rows", label: "Stitch rows", min: 1, max: 3, step: 1, default: 2 }],
+    defaultFabricRules: ["matching thread"],
+    presets: [
+      {
+        value: "double-topstitch-hem",
+        label: "Double topstitch hem",
+        detailLabel: "Double topstitch",
+        params: { rows: 2 },
+        fabricRules: ["6 mm row spacing", "matching thread"],
+      },
+      {
+        value: "edge-topstitch",
+        label: "Edge topstitch",
+        detailLabel: "Edge topstitch",
+        params: { rows: 1 },
+        fabricRules: ["1.5 mm from edge"],
+      },
+    ],
+  },
+  {
+    slug: "yoke",
+    label: "Yoke",
+    family: "Panels & Yokes",
+    garmentAreas: ["Back", "Shoulder"],
+    params: [{ key: "drop", label: "Seam drop", min: 0.1, max: 1, step: 0.05, default: 0.4 }],
+    defaultFabricRules: ["understitch yoke seam"],
+    presets: [
+      {
+        value: "back-yoke",
+        label: "Back yoke",
+        detailLabel: "Back yoke",
+        params: { drop: 0.4 },
+        fabricRules: ["burrito method", "understitch yoke seam"],
+      },
+    ],
+  },
+  {
+    slug: "embroidery",
+    label: "Embroidery",
+    family: "Embellishment",
+    garmentAreas: ["Placement", "Panel"],
+    params: [{ key: "motif", label: "Motif petals", min: 3, max: 8, step: 1, default: 6 }],
+    defaultFabricRules: ["stabilise reverse before stitching"],
+    presets: [
+      {
+        value: "chain-embroidery",
+        label: "Chain-stitch embroidery",
+        detailLabel: "Chain-stitch motif",
+        params: { motif: 6 },
+        fabricRules: ["stabilise reverse before stitching"],
+      },
+    ],
+  },
+]
+
+/** Every valid technique slug — the Zod enum + renderer-key source of truth. */
+export const SUPPORTED_TECHNIQUES = CONSTRUCTION_TECHNIQUES.map((t) => t.slug) as [
+  string,
+  ...string[]
+]
+
+const BY_SLUG: Record<string, ConstructionTechnique> = Object.fromEntries(
+  CONSTRUCTION_TECHNIQUES.map((t) => [t.slug, t])
+)
+
+export function getTechnique(slug: string): ConstructionTechnique | undefined {
+  return BY_SLUG[slug]
+}
+
+/** The auto-fill default params for a technique (from each param's `default`). */
+export function defaultParamsFor(slug: string): Record<string, number> {
+  const t = BY_SLUG[slug]
+  if (!t) {
+    return {}
+  }
+  return Object.fromEntries(t.params.map((p) => [p.key, p.default]))
+}
+
+/** Readable default title, e.g. knife-pleat → "Knife pleat". */
+export function techniqueLabel(slug: string): string {
+  const t = BY_SLUG[slug]
+  if (t) {
+    return t.label
+  }
+  const spaced = slug.replace(/-/g, " ")
+  return spaced.charAt(0).toUpperCase() + spaced.slice(1)
+}

--- a/apps/backend/src/workflows/designs/moodboard/__tests__/build-moodboard-block.unit.spec.ts
+++ b/apps/backend/src/workflows/designs/moodboard/__tests__/build-moodboard-block.unit.spec.ts
@@ -1,0 +1,96 @@
+/**
+ * Unit test — insert-block palette (#1113 S3+).
+ *
+ * The drop-in blocks: listMoodboardBlocks (availability) + buildMoodboardBlock
+ * (one frame at origin, preserving customData; unknown key → null).
+ *
+ * Run:
+ *   TEST_TYPE=unit npx jest --testPathPattern="build-moodboard-block"
+ */
+import {
+  buildMoodboardBlock,
+  listMoodboardBlocks,
+  MOODBOARD_BLOCKS,
+  type TechPackBrief,
+  type TechPackSceneInput,
+} from "../build-moodboard-scene"
+
+const FULL_BRIEF: TechPackBrief = {
+  concept_theme: "90s Tokyo Streetwear",
+  aesthetic_keywords: ["utilitarian", "sleek"],
+  price_point: "mid_market",
+  design_budget: 250000,
+  cost_currency: "inr",
+}
+
+const baseInput = (brief?: TechPackBrief): TechPackSceneInput => ({
+  design: { title: "Block Test" },
+  garment_type: "top",
+  flats: {},
+  ...(brief ? { brief } : {}),
+})
+
+describe("listMoodboardBlocks", () => {
+  it("lists every block; scaffolds always available, data blocks gated", () => {
+    const listing = listMoodboardBlocks(baseInput(FULL_BRIEF))
+    expect(listing).toHaveLength(MOODBOARD_BLOCKS.length)
+
+    const byKey = Object.fromEntries(listing.map((b) => [b.key, b]))
+    // Brief sections present in FULL_BRIEF → available.
+    expect(byKey["brief-concept"].available).toBe(true)
+    expect(byKey["brief-timeline"].available).toBe(true)
+    // Scaffolds are always insertable.
+    expect(byKey["header-flats"].available).toBe(true)
+    expect(byKey["workspace"].available).toBe(true)
+    // No specs/materials/construction data → not available.
+    expect(byKey["design-specs"].available).toBe(false)
+    expect(byKey["construction"].available).toBe(false)
+    expect(byKey["materials"].available).toBe(false)
+  })
+
+  it("gates brief blocks off when the brief is empty", () => {
+    const byKey = Object.fromEntries(
+      listMoodboardBlocks(baseInput()).map((b) => [b.key, b])
+    )
+    expect(byKey["brief-concept"].available).toBe(false)
+    expect(byKey["brief-audience"].available).toBe(false)
+    // Scaffold still available with no data at all.
+    expect(byKey["workspace"].available).toBe(true)
+  })
+})
+
+describe("buildMoodboardBlock", () => {
+  it("builds exactly one frame at origin (x=0), preserving brief-field customData", () => {
+    const scene = buildMoodboardBlock(baseInput(FULL_BRIEF), "brief-concept")
+    expect(scene).not.toBeNull()
+
+    const frames = scene!.elements.filter((e) => e.type === "frame")
+    expect(frames).toHaveLength(1)
+    expect(frames[0].name).toBe("Brief · Concept & Identity")
+    expect(frames[0].x).toBe(0)
+
+    // The concept card round-trip contract survives on the drop-in block.
+    const conceptRect = scene!.elements.find(
+      (e) =>
+        e.type === "rectangle" &&
+        (e.customData as any)?.kind === "brief-field" &&
+        (e.customData as any)?.field === "concept_theme"
+    )
+    expect(conceptRect).toBeTruthy()
+
+    // Every child element belongs to the single frame.
+    const frameId = frames[0].id
+    const children = scene!.elements.filter((e) => e.type !== "frame")
+    expect(children.every((e) => e.frameId === frameId)).toBe(true)
+  })
+
+  it("is deterministic for the same input", () => {
+    const a = buildMoodboardBlock(baseInput(FULL_BRIEF), "brief-concept")
+    const b = buildMoodboardBlock(baseInput(FULL_BRIEF), "brief-concept")
+    expect(JSON.stringify(a)).toBe(JSON.stringify(b))
+  })
+
+  it("returns null for an unknown block key", () => {
+    expect(buildMoodboardBlock(baseInput(FULL_BRIEF), "nope")).toBeNull()
+  })
+})

--- a/apps/backend/src/workflows/designs/moodboard/__tests__/construction-techniques.unit.spec.ts
+++ b/apps/backend/src/workflows/designs/moodboard/__tests__/construction-techniques.unit.spec.ts
@@ -1,0 +1,70 @@
+/**
+ * Unit test — canonical construction-techniques catalog (#1113 Feature B).
+ *
+ * Guards the single-source-of-truth invariants: the catalog's slugs match the
+ * renderer's glyph map (no drift), presets reference real techniques, and the
+ * auto-fill defaults are well-formed.
+ *
+ * Run:
+ *   TEST_TYPE=unit npx jest --testPathPattern="construction-techniques"
+ */
+import {
+  CONSTRUCTION_FAMILIES,
+  CONSTRUCTION_TECHNIQUES,
+  SUPPORTED_TECHNIQUES,
+  defaultParamsFor,
+  getTechnique,
+} from "../../../../modules/designs/construction-techniques"
+import { DETAIL_RENDERERS } from "../build-moodboard-scene"
+
+describe("construction-techniques canonical catalog", () => {
+  it("every technique has a renderer glyph (no triplication drift)", () => {
+    for (const slug of SUPPORTED_TECHNIQUES) {
+      expect(typeof DETAIL_RENDERERS[slug]).toBe("function")
+    }
+  })
+
+  it("SUPPORTED_TECHNIQUES mirrors the catalog slugs", () => {
+    expect([...SUPPORTED_TECHNIQUES].sort()).toEqual(
+      CONSTRUCTION_TECHNIQUES.map((t) => t.slug).sort()
+    )
+  })
+
+  it("every technique belongs to a known family", () => {
+    for (const t of CONSTRUCTION_TECHNIQUES) {
+      expect(CONSTRUCTION_FAMILIES).toContain(t.family)
+    }
+  })
+
+  it("param defaults sit within [min,max] and auto-fill resolves them", () => {
+    for (const t of CONSTRUCTION_TECHNIQUES) {
+      const filled = defaultParamsFor(t.slug)
+      for (const p of t.params) {
+        expect(p.default).toBeGreaterThanOrEqual(p.min)
+        expect(p.default).toBeLessThanOrEqual(p.max)
+        expect(filled[p.key]).toBe(p.default)
+      }
+    }
+  })
+
+  it("presets reference valid param keys for their technique", () => {
+    for (const t of CONSTRUCTION_TECHNIQUES) {
+      const keys = new Set(t.params.map((p) => p.key))
+      for (const preset of t.presets) {
+        for (const k of Object.keys(preset.params ?? {})) {
+          // Presets may carry cosmetic params (e.g. box-pleat count) the
+          // renderer ignores — only assert known keys stay numeric.
+          expect(typeof preset.params![k]).toBe("number")
+          if (keys.size) {
+            // when the technique has params, at least the declared ones exist
+            expect(keys.has(k) || k === "count").toBe(true)
+          }
+        }
+      }
+    }
+  })
+
+  it("getTechnique returns undefined for unknown slugs", () => {
+    expect(getTechnique("nope")).toBeUndefined()
+  })
+})

--- a/apps/backend/src/workflows/designs/moodboard/build-moodboard-scene.ts
+++ b/apps/backend/src/workflows/designs/moodboard/build-moodboard-scene.ts
@@ -1808,3 +1808,79 @@ export function mergeFramesIntoScene(
     files: { ...existing.files, ...incoming.files },
   }
 }
+
+// ── Insert-block palette (#1113 S3+) ──────────────────────────────────────────────
+//
+// The monolithic generate rebuilds the whole board. The palette instead exposes
+// each frame as an individual drop-in: the designer inserts one pre-filled block
+// at a time and arranges it themselves. Every block is one existing frame builder
+// run at origin (x=0) — the caller (partner-ui) translates + re-ids the elements
+// onto the live canvas, then saves via the normal moodboard PUT. Nothing here
+// persists, so a drop-in is non-destructive and repeatable.
+
+type FrameBuilder = (i: TechPackSceneInput, r: SceneRng, x: number) => FrameResult
+
+export interface MoodboardBlockDef {
+  key: string
+  label: string
+  /** Grouping for the palette menu. */
+  group: "Brief" | "Tech-pack" | "Workspace"
+  build: FrameBuilder
+  /** Whether the design currently has data backing this block (scaffolds → always). */
+  available: (i: TechPackSceneInput) => boolean
+}
+
+export const MOODBOARD_BLOCKS: MoodboardBlockDef[] = [
+  { key: "brief-concept", label: "Concept & Identity", group: "Brief", build: buildBriefConceptFrame, available: (i) => hasConceptSection(i.brief) },
+  { key: "brief-audience", label: "Audience & Positioning", group: "Brief", build: buildBriefAudienceFrame, available: (i) => hasAudienceSection(i.brief) },
+  { key: "brief-timeline", label: "Timeline & Budget", group: "Brief", build: buildBriefTimelineFrame, available: (i) => hasTimelineSection(i.brief) },
+  { key: "header-flats", label: "Header & Flats", group: "Tech-pack", build: buildHeaderFlatsFrame, available: () => true },
+  { key: "design-specs", label: "Design Specs", group: "Tech-pack", build: buildDesignSpecsFrame, available: (i) => !!i.specs?.length },
+  { key: "construction", label: "Construction details", group: "Tech-pack", build: buildConstructionDetailsFrame, available: (i) => !!i.details?.length },
+  { key: "measurements", label: "Measurements", group: "Tech-pack", build: buildMeasurementFrame, available: (i) => !!i.sizeSet },
+  { key: "materials", label: "Materials", group: "Tech-pack", build: buildMaterialsFrame, available: (i) => !!i.materials?.length },
+  { key: "colorways", label: "Colorways", group: "Tech-pack", build: buildColorwayFrame, available: (i) => !!i.colorways?.length },
+  { key: "workspace", label: "Workspace zone", group: "Workspace", build: buildWorkspaceScaffoldFrame, available: () => true },
+]
+
+export interface MoodboardBlockListing {
+  key: string
+  label: string
+  group: string
+  available: boolean
+}
+
+/** The palette: every insertable block + whether the design has data for it. */
+export function listMoodboardBlocks(input: TechPackSceneInput): MoodboardBlockListing[] {
+  return MOODBOARD_BLOCKS.map(({ key, label, group, available }) => ({
+    key,
+    label,
+    group,
+    available: available(input),
+  }))
+}
+
+/**
+ * Build a SINGLE moodboard block as a standalone scene, positioned at origin
+ * (x=0). The caller translates + re-ids the elements onto the live canvas.
+ * Returns null for an unknown key.
+ */
+export function buildMoodboardBlock(
+  input: TechPackSceneInput,
+  key: string
+): MoodboardScene | null {
+  const def = MOODBOARD_BLOCKS.find((b) => b.key === key)
+  if (!def) {
+    return null
+  }
+  const rng = new SceneRng(input.seed ?? 1)
+  const res = def.build(input, rng, 0)
+  return {
+    type: "excalidraw",
+    version: 2,
+    source: "jyt:moodboard-block",
+    elements: res.elements,
+    appState: { viewBackgroundColor: "#ffffff", gridSize: null, theme: "light" },
+    files: res.files,
+  }
+}

--- a/apps/partner-ui/src/hooks/api/partner-designs.tsx
+++ b/apps/partner-ui/src/hooks/api/partner-designs.tsx
@@ -246,6 +246,197 @@ export const useGenerateMoodboard = (
   })
 }
 
+/** #1113 S3+ — one insertable moodboard block in the palette. */
+export type MoodboardBlockListing = {
+  key: string
+  label: string
+  group: string
+  available: boolean
+}
+
+/**
+ * #1113 S3+ — the insert-block palette: every drop-in frame the designer can
+ * add to the canvas, flagged by whether the design has data for it. Owner OR
+ * assigned/invited designer.
+ */
+export const useMoodboardBlocks = (
+  id: string,
+  options?: Omit<
+    UseQueryOptions<{ blocks: MoodboardBlockListing[] }, FetchError>,
+    "queryKey" | "queryFn"
+  >
+) => {
+  return useQuery({
+    queryKey: [...partnerDesignsQueryKeys.detail(id), "moodboard-blocks"],
+    queryFn: async () =>
+      sdk.client.fetch<{ blocks: MoodboardBlockListing[] }>(
+        `/partners/designs/${id}/moodboard/blocks`,
+        { method: "GET" }
+      ),
+    enabled: !!id,
+    ...options,
+  })
+}
+
+/**
+ * #1113 S3+ — build ONE block from the design's current data (positioned at
+ * origin). Not persisted server-side: the caller translates + re-ids it onto
+ * the live canvas, then saves via useSaveMoodboard.
+ */
+export const useInsertMoodboardBlock = (
+  id: string,
+  options?: UseMutationOptions<{ block: MoodboardScene }, FetchError, string>
+) => {
+  return useMutation({
+    mutationFn: async (block: string) =>
+      sdk.client.fetch<{ block: MoodboardScene }>(
+        `/partners/designs/${id}/moodboard/blocks`,
+        { method: "POST", body: { block } }
+      ),
+    ...options,
+  })
+}
+
+// ── Construction techniques (#1113 Feature B) ────────────────────────────────
+
+export type ConstructionParamDef = {
+  key: string
+  label: string
+  min: number
+  max: number
+  step: number
+  default: number
+}
+export type ConstructionPreset = {
+  value: string
+  label: string
+  detailLabel: string
+  params?: Record<string, number>
+  fabricRules?: string[]
+  note?: string
+}
+export type ConstructionTechnique = {
+  slug: string
+  label: string
+  family: string
+  garmentAreas: string[]
+  params: ConstructionParamDef[]
+  defaultFabricRules: string[]
+  presets: ConstructionPreset[]
+}
+export type ConstructionCatalog = {
+  families: string[]
+  techniques: ConstructionTechnique[]
+}
+export type ConstructionDetailRecord = {
+  id: string
+  title?: string | null
+  details?: string | null
+  metadata?: {
+    technique?: string
+    params?: Record<string, number>
+    fabricRules?: string[]
+  } | null
+}
+export type CreateConstructionPayload = {
+  technique: string
+  label?: string
+  params?: Record<string, number>
+  fabricRules?: string[]
+  note?: string
+}
+
+/**
+ * #1113 Feature B — the categorized construction catalog the picker renders
+ * (families + techniques with param defs, default fabric rules, presets). Served
+ * verbatim from the canonical backend module, so the picker never hardcodes it.
+ */
+export const useConstructionTechniques = (
+  id: string,
+  options?: Omit<
+    UseQueryOptions<ConstructionCatalog, FetchError>,
+    "queryKey" | "queryFn"
+  >
+) => {
+  return useQuery({
+    queryKey: [...partnerDesignsQueryKeys.detail(id), "construction-techniques"],
+    queryFn: async () =>
+      sdk.client.fetch<ConstructionCatalog>(
+        `/partners/designs/${id}/construction-techniques`,
+        { method: "GET" }
+      ),
+    enabled: !!id,
+    staleTime: Infinity, // static catalog
+    ...options,
+  })
+}
+
+/** #1113 Feature B — this design's authored construction details. */
+export const useConstructionDetails = (
+  id: string,
+  options?: Omit<
+    UseQueryOptions<
+      { construction_details: ConstructionDetailRecord[]; count: number },
+      FetchError
+    >,
+    "queryKey" | "queryFn"
+  >
+) => {
+  return useQuery({
+    queryKey: [...partnerDesignsQueryKeys.detail(id), "construction-details"],
+    queryFn: async () =>
+      sdk.client.fetch<{
+        construction_details: ConstructionDetailRecord[]
+        count: number
+      }>(`/partners/designs/${id}/construction-details`, { method: "GET" }),
+    enabled: !!id,
+    ...options,
+  })
+}
+
+/** #1113 Feature B — add a construction detail (author-scoped). */
+export const useCreateConstructionDetail = (
+  id: string,
+  options?: UseMutationOptions<
+    { construction_detail: ConstructionDetailRecord },
+    FetchError,
+    CreateConstructionPayload
+  >
+) => {
+  return useMutation({
+    mutationFn: async (body: CreateConstructionPayload) =>
+      sdk.client.fetch<{ construction_detail: ConstructionDetailRecord }>(
+        `/partners/designs/${id}/construction-details`,
+        { method: "POST", body }
+      ),
+    onSuccess: async (data, variables, context) => {
+      // Refreshes the detail list, the block-availability list and the catalog.
+      await queryClient.invalidateQueries({ queryKey: partnerDesignsQueryKeys.detail(id) })
+      options?.onSuccess?.(data, variables, context)
+    },
+    ...options,
+  })
+}
+
+/** #1113 Feature B — remove a construction detail (author-scoped). */
+export const useDeleteConstructionDetail = (
+  id: string,
+  options?: UseMutationOptions<{ id: string; deleted: boolean }, FetchError, string>
+) => {
+  return useMutation({
+    mutationFn: async (detailId: string) =>
+      sdk.client.fetch<{ id: string; deleted: boolean }>(
+        `/partners/designs/${id}/construction-details/${detailId}`,
+        { method: "DELETE" }
+      ),
+    onSuccess: async (data, variables, context) => {
+      await queryClient.invalidateQueries({ queryKey: partnerDesignsQueryKeys.detail(id) })
+      options?.onSuccess?.(data, variables, context)
+    },
+    ...options,
+  })
+}
+
 /**
  * #1113 — idempotent, brief-friendly seed: fills an EMPTY moodboard from the
  * brief so the designer opens onto an editable snapshot (Figma-style) without a

--- a/apps/partner-ui/src/routes/designer-invite/designer-invite.tsx
+++ b/apps/partner-ui/src/routes/designer-invite/designer-invite.tsx
@@ -1,10 +1,11 @@
 import { zodResolver } from "@hookform/resolvers/zod"
 import "@excalidraw/excalidraw/index.css"
 import { Excalidraw } from "@excalidraw/excalidraw"
-import { Alert, Badge, Button, Heading, Hint, Input, Text, toast } from "@medusajs/ui"
+import { Alert, Badge, Button, Heading, Hint, IconButton, Input, Text, toast } from "@medusajs/ui"
+import { ArrowsPointingOut, XMark } from "@medusajs/icons"
 import { z } from "@medusajs/framework/zod"
 import { useMutation, useQuery } from "@tanstack/react-query"
-import { useMemo } from "react"
+import { useEffect, useMemo, useState } from "react"
 import { useForm } from "react-hook-form"
 import { Link, useNavigate, useParams } from "react-router-dom"
 
@@ -105,6 +106,26 @@ export const DesignerInvite = () => {
   })
 
   const scene = useMemo(() => toScene(data?.design?.moodboard), [data])
+  const [expanded, setExpanded] = useState(false)
+
+  // Escape exits fullscreen; lock body scroll while the overlay is open.
+  useEffect(() => {
+    if (!expanded) {
+      return
+    }
+    const onKey = (e: KeyboardEvent) => {
+      if (e.key === "Escape") {
+        setExpanded(false)
+      }
+    }
+    window.addEventListener("keydown", onKey)
+    const prevOverflow = document.body.style.overflow
+    document.body.style.overflow = "hidden"
+    return () => {
+      window.removeEventListener("keydown", onKey)
+      document.body.style.overflow = prevOverflow
+    }
+  }, [expanded])
 
   const acceptMutation = useMutation<AcceptResponse, unknown, z.infer<typeof AcceptSchema>>({
     mutationFn: async (values) =>
@@ -192,12 +213,42 @@ export const DesignerInvite = () => {
                 </Text>
               ) : null}
 
-              <Text size="small" weight="plus" className="text-ui-fg-subtle mb-2">
-                Moodboard preview
-              </Text>
+              <div className="mb-2 flex items-center justify-between">
+                <Text size="small" weight="plus" className="text-ui-fg-subtle">
+                  Moodboard preview
+                </Text>
+                {scene ? (
+                  <IconButton
+                    size="small"
+                    variant="transparent"
+                    onClick={() => setExpanded(true)}
+                    aria-label="View moodboard fullscreen"
+                  >
+                    <ArrowsPointingOut />
+                  </IconButton>
+                ) : null}
+              </div>
               {scene ? (
-                <div className="relative h-[420px] w-full overflow-hidden rounded-md border">
+                <div
+                  className={
+                    expanded
+                      ? "bg-ui-bg-base fixed inset-0 z-50"
+                      : "relative h-[420px] w-full overflow-hidden rounded-md border"
+                  }
+                >
+                  {expanded ? (
+                    <IconButton
+                      size="small"
+                      variant="primary"
+                      onClick={() => setExpanded(false)}
+                      aria-label="Exit fullscreen"
+                      className="absolute right-4 top-4 z-[60] shadow-elevation-card-rest"
+                    >
+                      <XMark />
+                    </IconButton>
+                  ) : null}
                   <Excalidraw
+                    key={expanded ? "moodboard-fs" : "moodboard-inline"}
                     initialData={scene as any}
                     viewModeEnabled={true}
                     excalidrawAPI={(api) => {

--- a/apps/partner-ui/src/routes/designs/design-moodboard/construction-picker.tsx
+++ b/apps/partner-ui/src/routes/designs/design-moodboard/construction-picker.tsx
@@ -1,0 +1,286 @@
+import { Badge, Button, FocusModal, Heading, Input, Label, Text, Textarea, toast } from "@medusajs/ui"
+import { useMemo, useState } from "react"
+
+import {
+  useConstructionTechniques,
+  useCreateConstructionDetail,
+  type ConstructionPreset,
+  type ConstructionTechnique,
+} from "../../../hooks/api/partner-designs"
+
+/** Parse a textarea into a trimmed, non-empty list (one rule per line). */
+const parseLines = (text: string): string[] =>
+  text
+    .split("\n")
+    .map((l) => l.trim())
+    .filter(Boolean)
+
+type Props = {
+  designId: string
+  open: boolean
+  onOpenChange: (open: boolean) => void
+  /** Called after a detail is created so the parent can refresh the canvas frame. */
+  onAdded: () => void
+}
+
+/**
+ * #1113 Feature B — categorized construction picker. Pick a technique (grouped by
+ * family), which auto-fills its params + default fabric rules; presets fully
+ * pre-fill the form. Creating a detail persists it and hands control back so the
+ * moodboard refreshes its construction glyph.
+ */
+export const ConstructionPicker = ({ designId, open, onOpenChange, onAdded }: Props) => {
+  const { data: catalog, isPending } = useConstructionTechniques(designId, {
+    enabled: open && !!designId,
+  })
+  const { mutateAsync: createDetail, isPending: isCreating } =
+    useCreateConstructionDetail(designId)
+
+  const [selectedSlug, setSelectedSlug] = useState<string | null>(null)
+  const [label, setLabel] = useState("")
+  const [note, setNote] = useState("")
+  const [params, setParams] = useState<Record<string, number>>({})
+  const [rulesText, setRulesText] = useState("")
+
+  const techniques = catalog?.techniques ?? []
+  const families = catalog?.families ?? []
+
+  const selected: ConstructionTechnique | undefined = useMemo(
+    () => techniques.find((t) => t.slug === selectedSlug),
+    [techniques, selectedSlug]
+  )
+
+  const grouped = useMemo(() => {
+    const byFamily: Record<string, ConstructionTechnique[]> = {}
+    for (const t of techniques) {
+      ;(byFamily[t.family] ??= []).push(t)
+    }
+    return families
+      .filter((f) => byFamily[f]?.length)
+      .map((f) => ({ family: f, items: byFamily[f] }))
+  }, [techniques, families])
+
+  // Choosing a technique auto-fills params (defaults) + default fabric rules.
+  const chooseTechnique = (t: ConstructionTechnique) => {
+    setSelectedSlug(t.slug)
+    setLabel(t.label)
+    setNote("")
+    setParams(Object.fromEntries(t.params.map((p) => [p.key, p.default])))
+    setRulesText(t.defaultFabricRules.join("\n"))
+  }
+
+  // A preset fully pre-fills the form on top of its technique.
+  const applyPreset = (t: ConstructionTechnique, preset: ConstructionPreset) => {
+    setSelectedSlug(t.slug)
+    setLabel(preset.detailLabel || t.label)
+    setNote(preset.note ?? "")
+    setParams({
+      ...Object.fromEntries(t.params.map((p) => [p.key, p.default])),
+      ...(preset.params ?? {}),
+    })
+    setRulesText((preset.fabricRules ?? t.defaultFabricRules).join("\n"))
+  }
+
+  const reset = () => {
+    setSelectedSlug(null)
+    setLabel("")
+    setNote("")
+    setParams({})
+    setRulesText("")
+  }
+
+  const handleAdd = async () => {
+    if (!selected) {
+      return
+    }
+    try {
+      await createDetail({
+        technique: selected.slug,
+        label: label.trim() || undefined,
+        params: Object.keys(params).length ? params : undefined,
+        fabricRules: parseLines(rulesText).length ? parseLines(rulesText) : undefined,
+        note: note.trim() || undefined,
+      })
+      toast.success(`Added "${label.trim() || selected.label}"`)
+      reset()
+      onOpenChange(false)
+      onAdded()
+    } catch (err: any) {
+      toast.error(err?.message || "Failed to add construction detail")
+    }
+  }
+
+  return (
+    <FocusModal
+      open={open}
+      onOpenChange={(o) => {
+        if (!o) {
+          reset()
+        }
+        onOpenChange(o)
+      }}
+    >
+      <FocusModal.Content>
+        <FocusModal.Header>
+          <Heading level="h2">Add construction detail</Heading>
+        </FocusModal.Header>
+        <FocusModal.Body className="flex min-h-0 flex-1 overflow-hidden">
+          {isPending ? (
+            <div className="p-6">
+              <Text size="small" className="text-ui-fg-subtle">
+                Loading techniques…
+              </Text>
+            </div>
+          ) : (
+            <div className="flex h-full w-full min-h-0">
+              {/* Left — categorized technique catalog */}
+              <div className="w-1/2 min-h-0 overflow-y-auto border-r p-6">
+                {grouped.map((grp) => (
+                  <div key={grp.family} className="mb-6">
+                    <Text
+                      size="xsmall"
+                      weight="plus"
+                      className="text-ui-fg-muted mb-2 uppercase"
+                    >
+                      {grp.family}
+                    </Text>
+                    <div className="flex flex-col gap-y-3">
+                      {grp.items.map((t) => (
+                        <div
+                          key={t.slug}
+                          className={`rounded-lg border p-3 ${
+                            selectedSlug === t.slug
+                              ? "border-ui-border-interactive bg-ui-bg-base-pressed"
+                              : "border-ui-border-base"
+                          }`}
+                        >
+                          <button
+                            type="button"
+                            className="flex w-full items-center justify-between text-left"
+                            onClick={() => chooseTechnique(t)}
+                          >
+                            <Text size="small" weight="plus">
+                              {t.label}
+                            </Text>
+                            <Text size="xsmall" className="text-ui-fg-subtle">
+                              {t.garmentAreas.join(" · ")}
+                            </Text>
+                          </button>
+                          {t.presets.length ? (
+                            <div className="mt-2 flex flex-wrap gap-1">
+                              {t.presets.map((p) => (
+                                <button
+                                  key={p.value}
+                                  type="button"
+                                  onClick={() => applyPreset(t, p)}
+                                >
+                                  <Badge size="2xsmall" className="cursor-pointer">
+                                    {p.label}
+                                  </Badge>
+                                </button>
+                              ))}
+                            </div>
+                          ) : null}
+                        </div>
+                      ))}
+                    </div>
+                  </div>
+                ))}
+              </div>
+
+              {/* Right — auto-filled form for the chosen technique */}
+              <div className="w-1/2 min-h-0 overflow-y-auto p-6">
+                {!selected ? (
+                  <Text size="small" className="text-ui-fg-subtle">
+                    Pick a technique or a preset on the left — its parameters and
+                    fabric rules auto-fill here.
+                  </Text>
+                ) : (
+                  <div className="flex flex-col gap-y-4">
+                    <div className="flex flex-col gap-y-1">
+                      <Label size="small">Label</Label>
+                      <Input
+                        value={label}
+                        onChange={(e) => setLabel(e.target.value)}
+                        placeholder={selected.label}
+                      />
+                    </div>
+
+                    {selected.params.length ? (
+                      <div className="flex flex-col gap-y-2">
+                        <Label size="small">Parameters</Label>
+                        {selected.params.map((p) => (
+                          <div key={p.key} className="flex items-center gap-x-3">
+                            <Text size="small" className="w-32 shrink-0">
+                              {p.label}
+                            </Text>
+                            <Input
+                              type="number"
+                              min={p.min}
+                              max={p.max}
+                              step={p.step}
+                              value={params[p.key] ?? p.default}
+                              onChange={(e) =>
+                                setParams((prev) => ({
+                                  ...prev,
+                                  [p.key]: Number(e.target.value),
+                                }))
+                              }
+                            />
+                          </div>
+                        ))}
+                      </div>
+                    ) : (
+                      <Text size="xsmall" className="text-ui-fg-muted">
+                        This technique has fixed geometry — no parameters to set.
+                      </Text>
+                    )}
+
+                    <div className="flex flex-col gap-y-1">
+                      <Label size="small">Fabric / sewing rules</Label>
+                      <Textarea
+                        rows={4}
+                        value={rulesText}
+                        onChange={(e) => setRulesText(e.target.value)}
+                        placeholder="one rule per line"
+                      />
+                    </div>
+
+                    <div className="flex flex-col gap-y-1">
+                      <Label size="small">Note</Label>
+                      <Input
+                        value={note}
+                        onChange={(e) => setNote(e.target.value)}
+                        placeholder="optional"
+                      />
+                    </div>
+                  </div>
+                )}
+              </div>
+            </div>
+          )}
+        </FocusModal.Body>
+        <FocusModal.Footer>
+          <div className="flex items-center justify-end gap-x-2">
+            <Button
+              size="small"
+              variant="secondary"
+              onClick={() => onOpenChange(false)}
+            >
+              Cancel
+            </Button>
+            <Button
+              size="small"
+              variant="primary"
+              onClick={handleAdd}
+              disabled={!selected || isCreating}
+              isLoading={isCreating}
+            >
+              Add detail
+            </Button>
+          </div>
+        </FocusModal.Footer>
+      </FocusModal.Content>
+    </FocusModal>
+  )
+}

--- a/apps/partner-ui/src/routes/designs/design-moodboard/design-moodboard.tsx
+++ b/apps/partner-ui/src/routes/designs/design-moodboard/design-moodboard.tsx
@@ -1,6 +1,6 @@
-import { Button, Heading, Text, toast } from "@medusajs/ui"
+import { Button, DropdownMenu, Heading, Text, toast } from "@medusajs/ui"
 import "@excalidraw/excalidraw/index.css"
-import { useCallback, useEffect, useMemo, useRef, useState } from "react"
+import { Fragment, useCallback, useEffect, useMemo, useRef, useState } from "react"
 import { Excalidraw } from "@excalidraw/excalidraw"
 import type { ExcalidrawElement } from "@excalidraw/excalidraw/element/types"
 import type { BinaryFileData, ExcalidrawImperativeAPI } from "@excalidraw/excalidraw/types"
@@ -9,12 +9,20 @@ import { RouteFocusModal } from "../../../components/modals"
 import {
   usePartnerDesign,
   useGenerateMoodboard,
+  useMoodboardBlocks,
+  useInsertMoodboardBlock,
   useSeedMoodboard,
   useSaveMoodboard,
   useUpdatePartnerBrief,
+  type MoodboardBlockListing,
   type PartnerBriefUpdate,
 } from "../../../hooks/api/partner-designs"
 import { useResolvedDesignId } from "../../../hooks/use-resolved-design-id"
+import { ConstructionPicker } from "./construction-picker"
+
+// Must match the frame name emitted by buildConstructionDetailsFrame on the
+// backend, so re-inserting replaces the existing construction frame in place.
+const CONSTRUCTION_FRAME_NAME = "4 · Construction details"
 
 type MoodboardData = {
   type?: string
@@ -150,6 +158,48 @@ const extractBriefEdits = (
   return { concept_theme: value }
 }
 
+// Fresh element id — insert-block elements come from the server built at origin
+// with deterministic ids, so re-id on every insert to avoid collisions and to
+// allow inserting the same block twice.
+const genId = (): string =>
+  typeof crypto !== "undefined" && "randomUUID" in crypto
+    ? crypto.randomUUID()
+    : `el-${Math.random().toString(36).slice(2)}-${Date.now().toString(36)}`
+
+/**
+ * Re-id a block's elements (remapping internal frameId/containerId/boundElements
+ * references) and translate them by (dx, dy) so the block drops into open space
+ * on the live canvas without clobbering existing element ids.
+ */
+const reidAndTranslate = (
+  elements: readonly any[],
+  dx: number,
+  dy: number
+): any[] => {
+  const idMap = new Map<string, string>()
+  elements.forEach((el) => idMap.set(el.id, genId()))
+  return elements.map((el) => {
+    const next: any = {
+      ...el,
+      id: idMap.get(el.id),
+      x: (el.x ?? 0) + dx,
+      y: (el.y ?? 0) + dy,
+    }
+    if (el.frameId && idMap.has(el.frameId)) {
+      next.frameId = idMap.get(el.frameId)
+    }
+    if (el.containerId && idMap.has(el.containerId)) {
+      next.containerId = idMap.get(el.containerId)
+    }
+    if (Array.isArray(el.boundElements)) {
+      next.boundElements = el.boundElements.map((b: any) =>
+        b?.id && idMap.has(b.id) ? { ...b, id: idMap.get(b.id) } : b
+      )
+    }
+    return next
+  })
+}
+
 export const DesignMoodboard = () => {
   const id = useResolvedDesignId()
 
@@ -157,11 +207,15 @@ export const DesignMoodboard = () => {
   const didInitRef = useRef(false)
   const didSeedRef = useRef(false)
   const [isDirty, setIsDirty] = useState(false)
+  const [constructionOpen, setConstructionOpen] = useState(false)
 
   const { design, isPending, isError, error } = usePartnerDesign(id || "")
 
   const { mutateAsync: generateMoodboard, isPending: isGenerating } =
     useGenerateMoodboard(id || "")
+  const { data: blocksData } = useMoodboardBlocks(id || "")
+  const { mutateAsync: insertBlock, isPending: isInserting } =
+    useInsertMoodboardBlock(id || "")
   const { mutateAsync: seedMoodboard } = useSeedMoodboard(id || "")
   const { mutateAsync: saveMoodboard, isPending: isSavingScene } = useSaveMoodboard(
     id || ""
@@ -278,6 +332,100 @@ export const DesignMoodboard = () => {
     }
   }, [id, generateMoodboard, loadScene])
 
+  // The insert-block palette, grouped for the dropdown menu.
+  const groupedBlocks = useMemo(() => {
+    const blocks: MoodboardBlockListing[] = blocksData?.blocks ?? []
+    const order = ["Brief", "Tech-pack", "Workspace"]
+    const byGroup: Record<string, MoodboardBlockListing[]> = {}
+    for (const b of blocks) {
+      ;(byGroup[b.group] ??= []).push(b)
+    }
+    return order
+      .filter((g) => byGroup[g]?.length)
+      .map((g) => ({ group: g, items: byGroup[g] }))
+  }, [blocksData])
+
+  // Drop one pre-filled block onto the canvas, placed to the right of existing
+  // content, re-id'd so it never collides. Non-destructive: the designer arranges
+  // it and saves via the normal Save button. `replaceFrameNamed` strips any
+  // existing frame with that name first — a "refresh this frame" (used to
+  // re-render the construction glyph after a detail is added) rather than an
+  // additive drop-in.
+  const handleInsert = useCallback(
+    async (key: string, label: string, replaceFrameNamed?: string) => {
+      const api = apiRef.current
+      if (!api || !id) {
+        return
+      }
+      try {
+        const { block } = await insertBlock(key)
+        const els = (block?.elements ?? []) as any[]
+        if (!els.length) {
+          toast.info(`Nothing to insert for "${label}" yet.`)
+          return
+        }
+
+        let existing = api.getSceneElements().filter((e: any) => !e.isDeleted)
+        if (replaceFrameNamed) {
+          const removeIds = new Set(
+            existing
+              .filter(
+                (e: any) => e.type === "frame" && e.name === replaceFrameNamed
+              )
+              .map((e: any) => e.id)
+          )
+          if (removeIds.size) {
+            existing = existing.filter(
+              (e: any) => !removeIds.has(e.id) && !removeIds.has(e.frameId)
+            )
+          }
+        }
+
+        let dx = 0
+        let dy = 0
+        if (existing.length) {
+          const maxX = Math.max(
+            ...existing.map((e: any) => (e.x ?? 0) + (e.width ?? 0))
+          )
+          const minY = Math.min(...existing.map((e: any) => e.y ?? 0))
+          dx = maxX + 120 // one frame gap to the right
+          dy = minY
+        }
+        const placed = reidAndTranslate(els, dx, dy)
+
+        const files = block?.files ?? {}
+        const fileList = Object.entries(files).map(
+          ([fid, f]: [string, any]) => ({
+            id: fid,
+            dataURL: f.dataURL,
+            mimeType: f.mimeType || "image/png",
+            created: f.created || Date.now(),
+            lastRetrieved: Date.now(),
+          })
+        )
+        if (fileList.length) {
+          api.addFiles(fileList as any)
+        }
+
+        api.updateScene({ elements: [...existing, ...placed] as any })
+        api.scrollToContent(placed as any, { fitToContent: true })
+        setIsDirty(true)
+        if (!replaceFrameNamed) {
+          toast.success(`Inserted "${label}"`)
+        }
+      } catch (err: any) {
+        toast.error(err?.message || "Failed to insert block")
+      }
+    },
+    [id, insertBlock]
+  )
+
+  // After a construction detail is added, re-render the construction frame from
+  // the design's fresh data (replacing the existing one in place).
+  const handleConstructionAdded = useCallback(() => {
+    handleInsert("construction", "Construction details", CONSTRUCTION_FRAME_NAME)
+  }, [handleInsert])
+
   const handleSave = useCallback(async () => {
     const api = apiRef.current
     if (!api || !id) {
@@ -393,6 +541,50 @@ export const DesignMoodboard = () => {
               Close
             </Button>
           </RouteFocusModal.Close>
+          <DropdownMenu>
+            <DropdownMenu.Trigger asChild>
+              <Button
+                size="small"
+                variant="secondary"
+                disabled={!id || isSaving || isInserting}
+                isLoading={isInserting}
+              >
+                Insert block
+              </Button>
+            </DropdownMenu.Trigger>
+            <DropdownMenu.Content>
+              {groupedBlocks.length === 0 ? (
+                <DropdownMenu.Item disabled>No blocks available</DropdownMenu.Item>
+              ) : (
+                groupedBlocks.map((grp, gi) => (
+                  <Fragment key={grp.group}>
+                    {gi > 0 ? <DropdownMenu.Separator /> : null}
+                    <DropdownMenu.Label>{grp.group}</DropdownMenu.Label>
+                    {grp.items.map((b) => (
+                      <DropdownMenu.Item
+                        key={b.key}
+                        disabled={!b.available}
+                        onClick={() => handleInsert(b.key, b.label)}
+                      >
+                        {b.label}
+                        {!b.available ? (
+                          <span className="text-ui-fg-muted ml-1">· empty</span>
+                        ) : null}
+                      </DropdownMenu.Item>
+                    ))}
+                  </Fragment>
+                ))
+              )}
+            </DropdownMenu.Content>
+          </DropdownMenu>
+          <Button
+            size="small"
+            variant="secondary"
+            onClick={() => setConstructionOpen(true)}
+            disabled={!id || isSaving}
+          >
+            Add construction
+          </Button>
           <Button
             size="small"
             variant="secondary"
@@ -413,6 +605,15 @@ export const DesignMoodboard = () => {
           </Button>
         </div>
       </RouteFocusModal.Footer>
+
+      {id ? (
+        <ConstructionPicker
+          designId={id}
+          open={constructionOpen}
+          onOpenChange={setConstructionOpen}
+          onAdded={handleConstructionAdded}
+        />
+      ) : null}
     </RouteFocusModal>
   )
 }

--- a/e2e/specs/moodboard-blocks-construction.spec.ts
+++ b/e2e/specs/moodboard-blocks-construction.spec.ts
@@ -1,0 +1,183 @@
+import { test, expect, request as pwRequest } from "@playwright/test"
+import * as fs from "fs"
+import * as path from "path"
+
+const SEED_FILE = path.resolve(__dirname, "../../apps/backend/.e2e-seed.json")
+
+/**
+ * #1113 Feature A + B — insert-block palette and construction picker, end-to-end
+ * against the live server.
+ *
+ * Pure HTTP (no browser), so it runs headless + on CI over :9000 alongside the
+ * designer-invite flow. Reuses the same seeded design (a full brief, no tech-pack
+ * data yet) and the real invite→accept path to obtain an assigned-designer
+ * bearer, then exercises the new author-scoped routes:
+ *   - GET/POST /partners/designs/:id/moodboard/blocks          (Feature A)
+ *   - GET      /partners/designs/:id/construction-techniques   (Feature B)
+ *   - GET/POST/DELETE /partners/designs/:id/construction-details (Feature B)
+ * and proves the A↔B tie-in: adding a construction detail makes the construction
+ * block build its glyph frame.
+ */
+test.describe("Moodboard insert blocks + construction (#1113 A/B)", () => {
+  let seed: { email: string; password: string; inviteDesignId: string }
+  let adminToken: string
+
+  test.beforeAll(async ({ baseURL }) => {
+    if (!fs.existsSync(SEED_FILE)) {
+      throw new Error(`E2E seed file not found at ${SEED_FILE}. Run "pnpm e2e:seed" first.`)
+    }
+    seed = JSON.parse(fs.readFileSync(SEED_FILE, "utf-8"))
+    if (!seed.inviteDesignId) {
+      throw new Error("E2E seed missing inviteDesignId — re-run the seed.")
+    }
+
+    const api = await pwRequest.newContext({ baseURL })
+    const res = await api.post("/auth/user/emailpass", {
+      data: { email: seed.email, password: seed.password },
+    })
+    expect(res.ok()).toBeTruthy()
+    adminToken = (await res.json()).token
+    await api.dispose()
+  })
+
+  /** Mint an invite and accept it → a partner request context (assigned designer). */
+  async function assignedDesignerContext(baseURL: string) {
+    const admin = await pwRequest.newContext({
+      baseURL,
+      extraHTTPHeaders: { authorization: `Bearer ${adminToken}` },
+    })
+    const mintRes = await admin.post(
+      `/admin/designs/${seed.inviteDesignId}/designer-invites`,
+      { data: { inviter_name: "Studio JYT" } }
+    )
+    expect(mintRes.status()).toBe(201)
+    const { token } = await mintRes.json()
+
+    const pub = await pwRequest.newContext({ baseURL })
+    const email = `e2e-blocks-${Date.now()}@jyt.test`
+    const acceptRes = await pub.post(`/partners/designer-invites/${token}/accept`, {
+      data: { name: "Ada Weaver", email, password: "supersecret123" },
+    })
+    expect(acceptRes.status()).toBe(201)
+    const accept = await acceptRes.json()
+
+    const partner = await pwRequest.newContext({
+      baseURL,
+      extraHTTPHeaders: { authorization: `Bearer ${accept.token}` },
+    })
+    await admin.dispose()
+    await pub.dispose()
+    return partner
+  }
+
+  test("insert palette lists + builds blocks; construction picker round-trips", async ({
+    baseURL,
+  }) => {
+    const partner = await assignedDesignerContext(baseURL!)
+    const designId = seed.inviteDesignId
+
+    // ── Feature A — the palette ────────────────────────────────────────────
+    const listRes = await partner.get(`/partners/designs/${designId}/moodboard/blocks`)
+    expect(listRes.status()).toBe(200)
+    const { blocks } = await listRes.json()
+    const byKey: Record<string, any> = Object.fromEntries(
+      blocks.map((b: any) => [b.key, b])
+    )
+    // The seeded brief backs the three brief blocks; scaffolds are always on;
+    // tech-pack blocks with no data yet are unavailable.
+    expect(byKey["brief-concept"].available).toBe(true)
+    expect(byKey["workspace"].available).toBe(true)
+    expect(byKey["construction"].available).toBe(false)
+
+    // Build one brief block — a single frame carrying the round-trip customData.
+    const blockRes = await partner.post(
+      `/partners/designs/${designId}/moodboard/blocks`,
+      { data: { block: "brief-concept" } }
+    )
+    expect(blockRes.status()).toBe(200)
+    const { block } = await blockRes.json()
+    const frames = block.elements.filter((e: any) => e.type === "frame")
+    expect(frames).toHaveLength(1)
+    expect(frames[0].name).toBe("Brief · Concept & Identity")
+    const conceptRect = block.elements.find(
+      (e: any) =>
+        e.type === "rectangle" &&
+        e.customData?.kind === "brief-field" &&
+        e.customData?.field === "concept_theme"
+    )
+    expect(conceptRect).toBeTruthy()
+
+    // Unknown block → 400.
+    const badRes = await partner.post(
+      `/partners/designs/${designId}/moodboard/blocks`,
+      { data: { block: "does-not-exist" } }
+    )
+    expect(badRes.status()).toBe(400)
+
+    // ── Feature B — the construction catalog + create ──────────────────────
+    const catRes = await partner.get(
+      `/partners/designs/${designId}/construction-techniques`
+    )
+    expect(catRes.status()).toBe(200)
+    const catalog = await catRes.json()
+    expect(Array.isArray(catalog.families)).toBe(true)
+    const dart = catalog.techniques.find((t: any) => t.slug === "dart")
+    expect(dart).toBeTruthy()
+    expect(dart.params.some((p: any) => p.key === "intake")).toBe(true)
+
+    // Add a construction detail (auto-fill defaults the picker would submit).
+    const createRes = await partner.post(
+      `/partners/designs/${designId}/construction-details`,
+      {
+        data: {
+          technique: "dart",
+          label: "Waist dart (e2e)",
+          params: { intake: 0.6 },
+          fabricRules: ["press toward centre front"],
+        },
+      }
+    )
+    expect(createRes.status()).toBe(201)
+    const { construction_detail } = await createRes.json()
+    expect(construction_detail.metadata.technique).toBe("dart")
+
+    // ── The A↔B tie-in — construction block now builds its glyph ────────────
+    const list2 = await (
+      await partner.get(`/partners/designs/${designId}/moodboard/blocks`)
+    ).json()
+    const construction2 = list2.blocks.find((b: any) => b.key === "construction")
+    expect(construction2.available).toBe(true)
+
+    const consBlockRes = await partner.post(
+      `/partners/designs/${designId}/moodboard/blocks`,
+      { data: { block: "construction" } }
+    )
+    expect(consBlockRes.status()).toBe(200)
+    const consBlock = await consBlockRes.json()
+    const consFrame = consBlock.block.elements.find(
+      (e: any) => e.type === "frame" && e.name === "4 · Construction details"
+    )
+    expect(consFrame).toBeTruthy()
+    // The dart renders as native, editable line polylines.
+    expect(consBlock.block.elements.some((e: any) => e.type === "line")).toBe(true)
+
+    // ── List + delete the detail ───────────────────────────────────────────
+    const detailsRes = await partner.get(
+      `/partners/designs/${designId}/construction-details`
+    )
+    expect(detailsRes.status()).toBe(200)
+    const { construction_details } = await detailsRes.json()
+    const mine = construction_details.find(
+      (d: any) => d.id === construction_detail.id
+    )
+    expect(mine).toBeTruthy()
+
+    const delRes = await partner.delete(
+      `/partners/designs/${designId}/construction-details/${construction_detail.id}`
+    )
+    expect(delRes.status()).toBe(200)
+    expect((await delRes.json()).deleted).toBe(true)
+
+    await partner.dispose()
+  })
+})


### PR DESCRIPTION
## What & why

Two founder-requested moodboard upgrades on the designer-invite surface (#1113), plus a full-screenable invite preview.

### Feature A — drop-in blocks
Compose the moodboard instead of the monolithic **Generate**. Each existing frame builder is exposed as an individual block (`MOODBOARD_BLOCKS` + `buildMoodboardBlock`/`listMoodboardBlocks`), served author-scoped via `GET/POST /partners/designs/:id/moodboard/blocks`. The partner editor gets a **"+ Insert block"** menu (grouped Brief / Tech-pack / Workspace); picking one re-ids + translates the block onto the live canvas — non-destructive, saved via the normal Save button. Blocks with no backing data show disabled.

### Feature B — construction, un-confused
- **One canonical `construction-techniques` module** kills the technique-list triplication: the route Zod enum, `DETAIL_RENDERERS`, and the admin dropdown/presets now all derive from it (a unit test asserts renderer-key parity so it can't drift again).
- Adds **family + garment-area categorization** and **per-param auto-fill defaults**.
- New author-scoped partner routes (`construction-techniques` catalog + `construction-details` GET/POST/DELETE) back a **categorized picker** in the partner moodboard editor: pick a technique → params + fabric rules auto-fill → add → the construction glyph frame **refreshes in place** (the A↔B tie-in). Partners could not enter construction at all before.

### Also
- Full-screenable moodboard preview on the `/designer-invite/:token` landing.

## The auth-matcher fix (real bug)
The new partner routes had to be registered in the `authenticate("partner")` matcher in `middlewares.ts` — without it `auth_context` never populates and even a valid bearer returns `400 "Partner authentication required"` (the known partner route auth-matcher gotcha). Caught by the e2e; would have broken the feature in the app too.

## Tests
- **+11 unit** — `build-moodboard-block` (5), `construction-techniques` (6, incl. renderer parity). 60/60 moodboard/techpack unit green.
- **e2e** — `e2e/specs/moodboard-blocks-construction.spec.ts` drives the whole flow over real HTTP (invite→accept→blocks→construction→tie-in→delete). Pure HTTP, **runs on CI** (not `@partnerui`). Passes locally against the live server.
- Backend + partner-ui typecheck clean on touched files.

🤖 Generated with [Claude Code](https://claude.com/claude-code)