### PR TITLE
feat(designs): admin moodboard parity — insert-block palette + construction picker [#1113]

### DIFF
--- a/apps/backend/src/admin/components/designs/design-moodboard-section.tsx
+++ b/apps/backend/src/admin/components/designs/design-moodboard-section.tsx
@@ -1,13 +1,50 @@
 // @ts-ignore - Excalidraw is an ESM module, dynamic import not feasible here
 import { Excalidraw } from "@excalidraw/excalidraw";
 import "@excalidraw/excalidraw/index.css";
-import { useState, useCallback, useEffect, useRef } from "react";
+import { Fragment, useState, useCallback, useEffect, useMemo, useRef } from "react";
 import { useNavigate, useParams } from "react-router-dom";
-import { useDesign, useGenerateMoodboard, useSeedMoodboard } from "../../hooks/api/designs";
+import {
+  useDesign,
+  useGenerateMoodboard,
+  useInsertMoodboardBlock,
+  useMoodboardBlocks,
+  useSeedMoodboard,
+  type MoodboardBlockListing,
+} from "../../hooks/api/designs";
 import { RouteNonFocusModal } from "../modal/route-non-focus";
 import { useMoodboard } from "../../hooks/use-moodboard";
-import { Button, toast } from "@medusajs/ui";
+import { Button, DropdownMenu, toast } from "@medusajs/ui";
 import { FashionPanel } from "./fashion-panel";
+import { MoodboardConstructionPicker } from "./moodboard-construction-picker";
+
+// Must match the frame name emitted by buildConstructionDetailsFrame on the
+// backend, so re-inserting replaces the existing construction frame in place.
+const CONSTRUCTION_FRAME_NAME = "4 · Construction details";
+
+const genId = (): string =>
+  typeof crypto !== "undefined" && "randomUUID" in crypto
+    ? crypto.randomUUID()
+    : `el-${Math.random().toString(36).slice(2)}-${Date.now().toString(36)}`;
+
+/**
+ * Re-id a block's elements (remapping frameId/containerId/boundElements) and
+ * translate them by (dx, dy) so a drop-in never collides with existing ids.
+ */
+const reidAndTranslate = (elements: readonly any[], dx: number, dy: number): any[] => {
+  const idMap = new Map<string, string>();
+  elements.forEach((el) => idMap.set(el.id, genId()));
+  return elements.map((el) => {
+    const next: any = { ...el, id: idMap.get(el.id), x: (el.x ?? 0) + dx, y: (el.y ?? 0) + dy };
+    if (el.frameId && idMap.has(el.frameId)) next.frameId = idMap.get(el.frameId);
+    if (el.containerId && idMap.has(el.containerId)) next.containerId = idMap.get(el.containerId);
+    if (Array.isArray(el.boundElements)) {
+      next.boundElements = el.boundElements.map((b: any) =>
+        b?.id && idMap.has(b.id) ? { ...b, id: idMap.get(b.id) } : b,
+      );
+    }
+    return next;
+  });
+};
 
 export function DesignMoodboardSection() {
   const { id } = useParams<{ id: string }>();
@@ -41,6 +78,10 @@ export function DesignMoodboardSection() {
   const { mutate: generateMoodboard, isPending: isGenerating } =
     useGenerateMoodboard(id);
   const { mutateAsync: seedMoodboard } = useSeedMoodboard(id);
+  const { data: blocksData } = useMoodboardBlocks(id);
+  const { mutateAsync: insertBlock, isPending: isInserting } =
+    useInsertMoodboardBlock(id);
+  const [constructionOpen, setConstructionOpen] = useState(false);
   const didSeedRef = useRef(false);
 
   // Load a built scene straight into the canvas so it's editable immediately.
@@ -112,6 +153,74 @@ export function DesignMoodboardSection() {
     })();
   }, [design, seedMoodboard, loadMoodboardIntoCanvas]);
 
+  // The insert-block palette, grouped for the dropdown menu.
+  const groupedBlocks = useMemo(() => {
+    const blocks: MoodboardBlockListing[] = blocksData?.blocks ?? [];
+    const order = ["Brief", "Tech-pack", "Workspace"];
+    const byGroup: Record<string, MoodboardBlockListing[]> = {};
+    for (const b of blocks) (byGroup[b.group] ??= []).push(b);
+    return order.filter((g) => byGroup[g]?.length).map((g) => ({ group: g, items: byGroup[g] }));
+  }, [blocksData]);
+
+  // Drop one pre-filled block onto the canvas (re-id'd, placed right of existing
+  // content). `replaceFrameNamed` strips an existing frame of that name first —
+  // a "refresh this frame" used to re-render the construction glyph.
+  const handleInsert = useCallback(
+    async (key: string, label: string, replaceFrameNamed?: string) => {
+      const api = excalidrawAPIRef.current;
+      if (!api) return;
+      try {
+        const { block } = await insertBlock(key);
+        const els = ((block as any)?.elements ?? []) as any[];
+        if (!els.length) {
+          toast.info(`Nothing to insert for "${label}" yet.`);
+          return;
+        }
+        let existing = api.getSceneElements().filter((e: any) => !e.isDeleted);
+        if (replaceFrameNamed) {
+          const removeIds = new Set(
+            existing
+              .filter((e: any) => e.type === "frame" && e.name === replaceFrameNamed)
+              .map((e: any) => e.id),
+          );
+          if (removeIds.size) {
+            existing = existing.filter(
+              (e: any) => !removeIds.has(e.id) && !removeIds.has(e.frameId),
+            );
+          }
+        }
+        let dx = 0;
+        let dy = 0;
+        if (existing.length) {
+          const maxX = Math.max(...existing.map((e: any) => (e.x ?? 0) + (e.width ?? 0)));
+          const minY = Math.min(...existing.map((e: any) => e.y ?? 0));
+          dx = maxX + 120;
+          dy = minY;
+        }
+        const placed = reidAndTranslate(els, dx, dy);
+        const files = (block as any)?.files ?? {};
+        const fileList = Object.entries(files).map(([fid, f]: [string, any]) => ({
+          id: fid,
+          dataURL: f.dataURL,
+          mimeType: f.mimeType || "image/png",
+          created: f.created || Date.now(),
+          lastRetrieved: Date.now(),
+        }));
+        if (fileList.length) api.addFiles(fileList as any);
+        api.updateScene({ elements: [...existing, ...placed] as any });
+        api.scrollToContent(placed as any, { fitToContent: true });
+        if (!replaceFrameNamed) toast.success(`Inserted "${label}"`);
+      } catch (err: any) {
+        toast.error(err?.message || "Failed to insert block");
+      }
+    },
+    [insertBlock, excalidrawAPIRef],
+  );
+
+  const handleConstructionAdded = useCallback(() => {
+    handleInsert("construction", "Construction details", CONSTRUCTION_FRAME_NAME);
+  }, [handleInsert]);
+
   // Track when an image element is selected on the canvas
   const handleSelectionChange = useCallback(() => {
     const api = excalidrawAPIRef.current;
@@ -154,6 +263,54 @@ export function DesignMoodboardSection() {
       <RouteNonFocusModal.Header onClick={handleCloseSave}>
         <div className="flex items-center justify-end w-full">
           <div className="flex items-end justify-end gap-x-2">
+            <DropdownMenu>
+              <DropdownMenu.Trigger asChild>
+                <Button
+                  variant="secondary"
+                  size="base"
+                  onClick={(e) => e.stopPropagation()}
+                  disabled={isSaving || isInserting}
+                  isLoading={isInserting}
+                >
+                  Insert block
+                </Button>
+              </DropdownMenu.Trigger>
+              <DropdownMenu.Content onClick={(e) => e.stopPropagation()}>
+                {groupedBlocks.length === 0 ? (
+                  <DropdownMenu.Item disabled>No blocks available</DropdownMenu.Item>
+                ) : (
+                  groupedBlocks.map((grp, gi) => (
+                    <Fragment key={grp.group}>
+                      {gi > 0 ? <DropdownMenu.Separator /> : null}
+                      <DropdownMenu.Label>{grp.group}</DropdownMenu.Label>
+                      {grp.items.map((b) => (
+                        <DropdownMenu.Item
+                          key={b.key}
+                          disabled={!b.available}
+                          onClick={() => handleInsert(b.key, b.label)}
+                        >
+                          {b.label}
+                          {!b.available ? (
+                            <span className="text-ui-fg-muted ml-1">· empty</span>
+                          ) : null}
+                        </DropdownMenu.Item>
+                      ))}
+                    </Fragment>
+                  ))
+                )}
+              </DropdownMenu.Content>
+            </DropdownMenu>
+            <Button
+              variant="secondary"
+              size="base"
+              onClick={(e) => {
+                e.stopPropagation();
+                setConstructionOpen(true);
+              }}
+              disabled={isSaving}
+            >
+              Add construction
+            </Button>
             <Button
               variant="secondary"
               size="base"
@@ -289,6 +446,13 @@ export function DesignMoodboardSection() {
           />
         </div>
       </RouteNonFocusModal.Body>
+
+      <MoodboardConstructionPicker
+        designId={id}
+        open={constructionOpen}
+        onOpenChange={setConstructionOpen}
+        onAdded={handleConstructionAdded}
+      />
     </RouteNonFocusModal>
   );
 }

--- a/apps/backend/src/admin/components/designs/moodboard-construction-picker.tsx
+++ b/apps/backend/src/admin/components/designs/moodboard-construction-picker.tsx
@@ -1,0 +1,256 @@
+import { Badge, Button, FocusModal, Heading, Input, Label, Text, Textarea, toast } from "@medusajs/ui";
+import { useMemo, useState } from "react";
+import {
+  useConstructionTechniques,
+  useCreateConstructionDetail,
+  type ConstructionPreset,
+  type ConstructionTechnique,
+} from "../../hooks/api/designs";
+
+/** Parse a textarea into a trimmed, non-empty list (one rule per line). */
+const parseLines = (text: string): string[] =>
+  text
+    .split("\n")
+    .map((l) => l.trim())
+    .filter(Boolean);
+
+type Props = {
+  designId: string;
+  open: boolean;
+  onOpenChange: (open: boolean) => void;
+  /** Called after a detail is created so the parent can refresh the canvas frame. */
+  onAdded: () => void;
+};
+
+/**
+ * #1113 Feature B (admin) — categorized construction picker. Pick a technique
+ * (grouped by family), which auto-fills its params + default fabric rules;
+ * presets fully pre-fill the form. Creating a detail persists it and hands
+ * control back so the moodboard refreshes its construction glyph.
+ */
+export function MoodboardConstructionPicker({ designId, open, onOpenChange, onAdded }: Props) {
+  const { data: catalog, isLoading } = useConstructionTechniques(designId, {
+    enabled: open && !!designId,
+  });
+  const { mutateAsync: createDetail, isPending: isCreating } =
+    useCreateConstructionDetail(designId);
+
+  const [selectedSlug, setSelectedSlug] = useState<string | null>(null);
+  const [label, setLabel] = useState("");
+  const [note, setNote] = useState("");
+  const [params, setParams] = useState<Record<string, number>>({});
+  const [rulesText, setRulesText] = useState("");
+
+  const techniques = catalog?.techniques ?? [];
+  const families = catalog?.families ?? [];
+
+  const selected = useMemo(
+    () => techniques.find((t) => t.slug === selectedSlug),
+    [techniques, selectedSlug],
+  );
+
+  const grouped = useMemo(() => {
+    const byFamily: Record<string, ConstructionTechnique[]> = {};
+    for (const t of techniques) {
+      (byFamily[t.family] ??= []).push(t);
+    }
+    return families
+      .filter((f) => byFamily[f]?.length)
+      .map((f) => ({ family: f, items: byFamily[f] }));
+  }, [techniques, families]);
+
+  const chooseTechnique = (t: ConstructionTechnique) => {
+    setSelectedSlug(t.slug);
+    setLabel(t.label);
+    setNote("");
+    setParams(Object.fromEntries(t.params.map((p) => [p.key, p.default])));
+    setRulesText(t.defaultFabricRules.join("\n"));
+  };
+
+  const applyPreset = (t: ConstructionTechnique, preset: ConstructionPreset) => {
+    setSelectedSlug(t.slug);
+    setLabel(preset.detailLabel || t.label);
+    setNote(preset.note ?? "");
+    setParams({
+      ...Object.fromEntries(t.params.map((p) => [p.key, p.default])),
+      ...(preset.params ?? {}),
+    });
+    setRulesText((preset.fabricRules ?? t.defaultFabricRules).join("\n"));
+  };
+
+  const reset = () => {
+    setSelectedSlug(null);
+    setLabel("");
+    setNote("");
+    setParams({});
+    setRulesText("");
+  };
+
+  const handleAdd = async () => {
+    if (!selected) return;
+    try {
+      await createDetail({
+        technique: selected.slug,
+        label: label.trim() || undefined,
+        params: Object.keys(params).length ? params : undefined,
+        fabricRules: parseLines(rulesText).length ? parseLines(rulesText) : undefined,
+        note: note.trim() || undefined,
+      });
+      toast.success(`Added "${label.trim() || selected.label}"`);
+      reset();
+      onOpenChange(false);
+      onAdded();
+    } catch (err: any) {
+      toast.error(err?.message || "Failed to add construction detail");
+    }
+  };
+
+  return (
+    <FocusModal
+      open={open}
+      onOpenChange={(o) => {
+        if (!o) reset();
+        onOpenChange(o);
+      }}
+    >
+      <FocusModal.Content>
+        <FocusModal.Header>
+          <Heading level="h2">Add construction detail</Heading>
+        </FocusModal.Header>
+        <FocusModal.Body className="flex min-h-0 flex-1 overflow-hidden">
+          {isLoading ? (
+            <div className="p-6">
+              <Text size="small" className="text-ui-fg-subtle">
+                Loading techniques…
+              </Text>
+            </div>
+          ) : (
+            <div className="flex h-full w-full min-h-0">
+              {/* Left — categorized technique catalog */}
+              <div className="w-1/2 min-h-0 overflow-y-auto border-r p-6">
+                {grouped.map((grp) => (
+                  <div key={grp.family} className="mb-6">
+                    <Text size="xsmall" weight="plus" className="text-ui-fg-muted mb-2 uppercase">
+                      {grp.family}
+                    </Text>
+                    <div className="flex flex-col gap-y-3">
+                      {grp.items.map((t) => (
+                        <div
+                          key={t.slug}
+                          className={`rounded-lg border p-3 ${
+                            selectedSlug === t.slug
+                              ? "border-ui-border-interactive bg-ui-bg-base-pressed"
+                              : "border-ui-border-base"
+                          }`}
+                        >
+                          <button
+                            type="button"
+                            className="flex w-full items-center justify-between text-left"
+                            onClick={() => chooseTechnique(t)}
+                          >
+                            <Text size="small" weight="plus">
+                              {t.label}
+                            </Text>
+                            <Text size="xsmall" className="text-ui-fg-subtle">
+                              {t.garmentAreas.join(" · ")}
+                            </Text>
+                          </button>
+                          {t.presets.length ? (
+                            <div className="mt-2 flex flex-wrap gap-1">
+                              {t.presets.map((p) => (
+                                <button key={p.value} type="button" onClick={() => applyPreset(t, p)}>
+                                  <Badge size="2xsmall" className="cursor-pointer">
+                                    {p.label}
+                                  </Badge>
+                                </button>
+                              ))}
+                            </div>
+                          ) : null}
+                        </div>
+                      ))}
+                    </div>
+                  </div>
+                ))}
+              </div>
+
+              {/* Right — auto-filled form for the chosen technique */}
+              <div className="w-1/2 min-h-0 overflow-y-auto p-6">
+                {!selected ? (
+                  <Text size="small" className="text-ui-fg-subtle">
+                    Pick a technique or a preset on the left — its parameters and
+                    fabric rules auto-fill here.
+                  </Text>
+                ) : (
+                  <div className="flex flex-col gap-y-4">
+                    <div className="flex flex-col gap-y-1">
+                      <Label size="small">Label</Label>
+                      <Input value={label} onChange={(e) => setLabel(e.target.value)} placeholder={selected.label} />
+                    </div>
+
+                    {selected.params.length ? (
+                      <div className="flex flex-col gap-y-2">
+                        <Label size="small">Parameters</Label>
+                        {selected.params.map((p) => (
+                          <div key={p.key} className="flex items-center gap-x-3">
+                            <Text size="small" className="w-32 shrink-0">
+                              {p.label}
+                            </Text>
+                            <Input
+                              type="number"
+                              min={p.min}
+                              max={p.max}
+                              step={p.step}
+                              value={params[p.key] ?? p.default}
+                              onChange={(e) =>
+                                setParams((prev) => ({ ...prev, [p.key]: Number(e.target.value) }))
+                              }
+                            />
+                          </div>
+                        ))}
+                      </div>
+                    ) : (
+                      <Text size="xsmall" className="text-ui-fg-muted">
+                        This technique has fixed geometry — no parameters to set.
+                      </Text>
+                    )}
+
+                    <div className="flex flex-col gap-y-1">
+                      <Label size="small">Fabric / sewing rules</Label>
+                      <Textarea
+                        rows={4}
+                        value={rulesText}
+                        onChange={(e) => setRulesText(e.target.value)}
+                        placeholder="one rule per line"
+                      />
+                    </div>
+
+                    <div className="flex flex-col gap-y-1">
+                      <Label size="small">Note</Label>
+                      <Input value={note} onChange={(e) => setNote(e.target.value)} placeholder="optional" />
+                    </div>
+                  </div>
+                )}
+              </div>
+            </div>
+          )}
+        </FocusModal.Body>
+        <FocusModal.Footer>
+          <div className="flex items-center justify-end gap-x-2">
+            <Button size="small" variant="secondary" onClick={() => onOpenChange(false)}>
+              Cancel
+            </Button>
+            <Button
+              size="small"
+              variant="primary"
+              onClick={handleAdd}
+              disabled={!selected || isCreating}
+              isLoading={isCreating}
+            >
+              Add detail
+            </Button>
+          </div>
+        </FocusModal.Footer>
+      </FocusModal.Content>
+    </FocusModal>
+  );
+}

--- a/apps/backend/src/admin/hooks/api/designs.ts
+++ b/apps/backend/src/admin/hooks/api/designs.ts
@@ -272,6 +272,95 @@ export interface SeedMoodboardResponse {
   moodboard: GenerateMoodboardResponse["moodboard"] | null;
 }
 
+// ── Insert-block palette + construction catalog (#1113 Feature A/B) ────────────
+
+export interface MoodboardBlockListing {
+  key: string;
+  label: string;
+  group: string;
+  available: boolean;
+}
+
+/** The insert-block palette: every drop-in frame + whether the design has data. */
+export const useMoodboardBlocks = (
+  id: string,
+  options?: Omit<UseQueryOptions<{ blocks: MoodboardBlockListing[] }, FetchError>, "queryKey" | "queryFn">,
+) => {
+  return useQuery({
+    queryKey: [...designQueryKeys.detail(id), "moodboard-blocks"],
+    queryFn: async () =>
+      sdk.client.fetch<{ blocks: MoodboardBlockListing[] }>(
+        `/admin/designs/${id}/moodboard/blocks`,
+        { method: "GET" },
+      ),
+    enabled: !!id,
+    ...options,
+  });
+};
+
+/** Build ONE block from the design's data (origin-positioned). Not persisted. */
+export const useInsertMoodboardBlock = (
+  id: string,
+  options?: UseMutationOptions<{ block: GenerateMoodboardResponse["moodboard"] }, FetchError, string>,
+) => {
+  return useMutation({
+    mutationFn: async (block: string) =>
+      sdk.client.fetch<{ block: GenerateMoodboardResponse["moodboard"] }>(
+        `/admin/designs/${id}/moodboard/blocks`,
+        { method: "POST", body: { block } },
+      ),
+    ...options,
+  });
+};
+
+export interface ConstructionParamDef {
+  key: string;
+  label: string;
+  min: number;
+  max: number;
+  step: number;
+  default: number;
+}
+export interface ConstructionPreset {
+  value: string;
+  label: string;
+  detailLabel: string;
+  params?: Record<string, number>;
+  fabricRules?: string[];
+  note?: string;
+}
+export interface ConstructionTechnique {
+  slug: string;
+  label: string;
+  family: string;
+  garmentAreas: string[];
+  params: ConstructionParamDef[];
+  defaultFabricRules: string[];
+  presets: ConstructionPreset[];
+}
+export interface ConstructionCatalog {
+  families: string[];
+  techniques: ConstructionTechnique[];
+}
+
+/** The categorized construction catalog the admin picker renders (#1113 Feature B). */
+export const useConstructionTechniques = (
+  id: string,
+  options?: Omit<UseQueryOptions<ConstructionCatalog, FetchError>, "queryKey" | "queryFn">,
+) => {
+  return useQuery({
+    queryKey: [...designQueryKeys.detail(id), "construction-techniques"],
+    queryFn: async () =>
+      sdk.client.fetch<ConstructionCatalog>(
+        `/admin/designs/${id}/construction-techniques`,
+        { method: "GET" },
+      ),
+    enabled: !!id,
+    staleTime: Infinity,
+    ...options,
+  });
+};
+
 /**
  * Idempotent, brief-friendly seed (#1113): fills an EMPTY `design.moodboard`
  * from the brief so the editor opens onto an editable snapshot without a manual

--- a/apps/backend/src/api/admin/designs/[id]/construction-techniques/route.ts
+++ b/apps/backend/src/api/admin/designs/[id]/construction-techniques/route.ts
@@ -1,0 +1,19 @@
+import { MedusaRequest, MedusaResponse } from "@medusajs/framework/http"
+import {
+  CONSTRUCTION_FAMILIES,
+  CONSTRUCTION_TECHNIQUES,
+} from "../../../../../modules/designs/construction-techniques"
+
+/**
+ * GET /admin/designs/:id/construction-techniques
+ *
+ * The construction catalog the admin picker renders (#1113 Feature B) — the same
+ * canonical, categorized techniques (param defs, default fabric rules, presets)
+ * served to the partner picker.
+ */
+export const GET = async (_req: MedusaRequest, res: MedusaResponse) => {
+  res.json({
+    families: CONSTRUCTION_FAMILIES,
+    techniques: CONSTRUCTION_TECHNIQUES,
+  })
+}

--- a/apps/backend/src/api/admin/designs/[id]/moodboard/blocks/route.ts
+++ b/apps/backend/src/api/admin/designs/[id]/moodboard/blocks/route.ts
@@ -1,0 +1,45 @@
+import { MedusaRequest, MedusaResponse } from "@medusajs/framework/http"
+import { MedusaError } from "@medusajs/framework/utils"
+import {
+  buildMoodboardBlock,
+  listMoodboardBlocks,
+} from "../../../../../../workflows/designs/moodboard/build-moodboard-scene"
+import { loadDesignForMoodboard } from "../../../../../../workflows/designs/moodboard/seed-design-moodboard"
+import { buildTechPackInputFromDesign } from "../../../../../../workflows/designs/moodboard/techpack-input-from-design"
+
+/**
+ * Admin mirror of the partner insert-block palette (#1113 Feature A).
+ * GET lists the drop-in blocks (with data-availability flags); POST builds one
+ * block from the design's current data at origin. Not persisted — the admin
+ * editor translates + re-ids the elements onto the live canvas, then saves.
+ */
+export const GET = async (
+  req: MedusaRequest & { params: { id: string } },
+  res: MedusaResponse
+) => {
+  const design = await loadDesignForMoodboard(req.scope, req.params.id)
+  const input = buildTechPackInputFromDesign(design)
+  res.json({ blocks: listMoodboardBlocks(input) })
+}
+
+export const POST = async (
+  req: MedusaRequest & { params: { id: string } },
+  res: MedusaResponse
+) => {
+  const key = (req.body as { block?: unknown } | undefined)?.block
+  if (typeof key !== "string" || !key.trim()) {
+    throw new MedusaError(
+      MedusaError.Types.INVALID_DATA,
+      "Missing 'block' — pass the key of the block to insert."
+    )
+  }
+
+  const design = await loadDesignForMoodboard(req.scope, req.params.id)
+  const input = buildTechPackInputFromDesign(design)
+  const block = buildMoodboardBlock(input, key)
+  if (!block) {
+    throw new MedusaError(MedusaError.Types.INVALID_DATA, `Unknown block '${key}'.`)
+  }
+
+  res.json({ block })
+}

--- a/e2e/specs/moodboard-blocks-construction.spec.ts
+++ b/e2e/specs/moodboard-blocks-construction.spec.ts
@@ -180,4 +180,40 @@ test.describe("Moodboard insert blocks + construction (#1113 A/B)", () => {
 
     await partner.dispose()
   })
+
+  test("admin editor gets the same insert palette + construction catalog", async ({
+    baseURL,
+  }) => {
+    const admin = await pwRequest.newContext({
+      baseURL,
+      extraHTTPHeaders: { authorization: `Bearer ${adminToken}` },
+    })
+    const designId = seed.inviteDesignId
+
+    // Feature A — admin palette lists + builds a brief block.
+    const listRes = await admin.get(`/admin/designs/${designId}/moodboard/blocks`)
+    expect(listRes.status()).toBe(200)
+    const { blocks } = await listRes.json()
+    expect(blocks.find((b: any) => b.key === "brief-concept").available).toBe(true)
+
+    const blockRes = await admin.post(
+      `/admin/designs/${designId}/moodboard/blocks`,
+      { data: { block: "brief-concept" } }
+    )
+    expect(blockRes.status()).toBe(200)
+    const { block } = await blockRes.json()
+    const frames = block.elements.filter((e: any) => e.type === "frame")
+    expect(frames).toHaveLength(1)
+    expect(frames[0].name).toBe("Brief · Concept & Identity")
+
+    // Feature B — admin construction catalog.
+    const catRes = await admin.get(
+      `/admin/designs/${designId}/construction-techniques`
+    )
+    expect(catRes.status()).toBe(200)
+    const catalog = await catRes.json()
+    expect(catalog.techniques.some((t: any) => t.slug === "dart")).toBe(true)
+
+    await admin.dispose()
+  })
 })


### PR DESCRIPTION
## What & why

Brings the **admin** moodboard editor to parity with the partner editor that #1134 shipped. Admin previously had only the monolithic **Generate tech-pack**.

### Feature A — insert-block palette (admin)
- `GET/POST /admin/designs/:id/moodboard/blocks` + `useMoodboardBlocks` / `useInsertMoodboardBlock`.
- A grouped **"Insert block"** menu in the admin editor header; picking a block re-ids + translates it onto the live canvas (non-destructive; Save via the existing button).

### Feature B — categorized construction picker (admin)
- `GET /admin/designs/:id/construction-techniques` + `useConstructionTechniques`.
- In-editor **"Add construction"** picker (`MoodboardConstructionPicker`) reusing the **existing** admin construction-details routes/hooks. Pick a technique → params + fabric rules auto-fill → add → the construction glyph frame **refreshes in place** (the A↔B tie-in).

Both reuse the canonical `construction-techniques` module + block builder from #1134, so admin and partner render identical blocks/catalog. Admin routes are auto-authed — no `middlewares.ts` matcher needed (unlike partner).

## Tests
- e2e `moodboard-blocks-construction.spec.ts` gains an admin-side case (palette list + block build + catalog); **partner + admin both pass** locally against the live server.
- 60/60 moodboard/techpack unit green; backend typecheck clean on touched files.

Stacked on #1134 (already merged to main).

🤖 Generated with [Claude Code](https://claude.com/claude-code)