### PR TITLE
feat(designs): editable Concept & Identity, in-canvas toolbar + layers panel [#1113]

### DIFF
--- a/apps/backend/src/admin/components/designs/__tests__/moodboard-brief.unit.spec.ts
+++ b/apps/backend/src/admin/components/designs/__tests__/moodboard-brief.unit.spec.ts
@@ -1,0 +1,42 @@
+import { buildMoodboardBlock } from "../../../../workflows/designs/moodboard/build-moodboard-scene"
+import { extractBriefEdits } from "../moodboard-brief"
+
+/**
+ * #1113 — round-trip: the Concept & Identity block the server builds must be
+ * parseable back into brief edits by the editors' shared parser, so on-canvas
+ * edits persist to concept_theme + aesthetic_keywords.
+ */
+describe("moodboard brief round-trip parser", () => {
+  const buildConcept = (brief: Record<string, any>) =>
+    buildMoodboardBlock({ brief, seed: 1 } as any, "brief-concept")!
+
+  it("parses concept_theme + aesthetic_keywords from a filled concept block", () => {
+    const block = buildConcept({
+      concept_theme: "Coastal minimalism",
+      aesthetic_keywords: ["airy", "muted", "linen"],
+    })
+    expect(extractBriefEdits(block.elements)).toEqual({
+      concept_theme: "Coastal minimalism",
+      aesthetic_keywords: ["airy", "muted", "linen"],
+    })
+  })
+
+  it("returns null for an empty concept template (placeholder only)", () => {
+    const block = buildConcept({})
+    // The template still renders (insertable when empty) but carries no real
+    // values, so nothing is written back.
+    expect(extractBriefEdits(block.elements)).toBeNull()
+  })
+
+  it("parses keywords a designer typed onto the editable line", () => {
+    const block = buildConcept({})
+    const els = block.elements.map((el: any) =>
+      el.customData?.field === "aesthetic_keywords"
+        ? { ...el, text: "Aesthetic keywords: bold, saturated,  ,neon" }
+        : el
+    )
+    const edits = extractBriefEdits(els)
+    expect(edits?.aesthetic_keywords).toEqual(["bold", "saturated", "neon"])
+    expect(edits?.concept_theme).toBeUndefined()
+  })
+})

--- a/apps/backend/src/admin/components/designs/design-moodboard-section.tsx
+++ b/apps/backend/src/admin/components/designs/design-moodboard-section.tsx
@@ -16,6 +16,7 @@ import { useMoodboard } from "../../hooks/use-moodboard";
 import { Button, DropdownMenu, toast } from "@medusajs/ui";
 import { FashionPanel } from "./fashion-panel";
 import { MoodboardConstructionPicker } from "./moodboard-construction-picker";
+import { MoodboardLayersPanel } from "./moodboard-layers-panel";
 
 // Must match the frame name emitted by buildConstructionDetailsFrame on the
 // backend, so re-inserting replaces the existing construction frame in place.
@@ -62,6 +63,14 @@ export function DesignMoodboardSection() {
   const [fashionPanelOpen, setFashionPanelOpen] = useState(false);
   const [fashionPanelInitialTab, setFashionPanelInitialTab] = useState<string | undefined>(undefined);
   const [selectedImageId, setSelectedImageId] = useState<string | null>(null);
+  const [layersOpen, setLayersOpen] = useState(false);
+  // Bumped on canvas change (only while the layers panel is open) so the panel
+  // re-reads frames without re-rendering the editor on every pointer move.
+  const [layersTick, setLayersTick] = useState(0);
+  const layersOpenRef = useRef(false);
+  useEffect(() => {
+    layersOpenRef.current = layersOpen;
+  }, [layersOpen]);
 
   const {
     isSaving,
@@ -262,79 +271,10 @@ export function DesignMoodboardSection() {
     <RouteNonFocusModal>
       <RouteNonFocusModal.Header onClick={handleCloseSave}>
         <div className="flex items-center justify-end w-full">
-          <div className="flex items-end justify-end gap-x-2">
-            <DropdownMenu>
-              <DropdownMenu.Trigger asChild>
-                <Button
-                  variant="secondary"
-                  size="base"
-                  onClick={(e) => e.stopPropagation()}
-                  disabled={isSaving || isInserting}
-                  isLoading={isInserting}
-                >
-                  Insert block
-                </Button>
-              </DropdownMenu.Trigger>
-              <DropdownMenu.Content onClick={(e) => e.stopPropagation()}>
-                {groupedBlocks.length === 0 ? (
-                  <DropdownMenu.Item disabled>No blocks available</DropdownMenu.Item>
-                ) : (
-                  groupedBlocks.map((grp, gi) => (
-                    <Fragment key={grp.group}>
-                      {gi > 0 ? <DropdownMenu.Separator /> : null}
-                      <DropdownMenu.Label>{grp.group}</DropdownMenu.Label>
-                      {grp.items.map((b) => (
-                        <DropdownMenu.Item
-                          key={b.key}
-                          disabled={!b.available}
-                          onClick={() => handleInsert(b.key, b.label)}
-                        >
-                          {b.label}
-                          {!b.available ? (
-                            <span className="text-ui-fg-muted ml-1">· empty</span>
-                          ) : null}
-                        </DropdownMenu.Item>
-                      ))}
-                    </Fragment>
-                  ))
-                )}
-              </DropdownMenu.Content>
-            </DropdownMenu>
-            <Button
-              variant="secondary"
-              size="base"
-              onClick={(e) => {
-                e.stopPropagation();
-                setConstructionOpen(true);
-              }}
-              disabled={isSaving}
-            >
-              Add construction
-            </Button>
-            <Button
-              variant="secondary"
-              size="base"
-              onClick={(e) => {
-                e.stopPropagation();
-                handleGenerate();
-              }}
-              disabled={isGenerating || isSaving}
-              isLoading={isGenerating}
-            >
-              Generate tech-pack
-            </Button>
-            <Button
-              variant="primary"
-              size="base"
-              onClick={(e) => {
-                e.stopPropagation();
-                handleSave();
-              }}
-              disabled={isSaving || !hasChanges}
-            >
-              {isSaving ? "Saving..." : hasChanges ? "Save Changes" : "No Changes"}
-            </Button>
-          </div>
+          <span className="text-ui-fg-muted text-sm">
+            Insert · construction · generate · layers · save are in the canvas
+            toolbar (top-right)
+          </span>
         </div>
       </RouteNonFocusModal.Header>
       <RouteNonFocusModal.Body>
@@ -349,6 +289,15 @@ export function DesignMoodboardSection() {
                   setFashionPanelInitialTab(undefined);
                 }}
                 initialTab={fashionPanelInitialTab}
+              />
+            </div>
+          )}
+          {layersOpen && (
+            <div className="absolute top-14 left-2 z-50 w-64">
+              <MoodboardLayersPanel
+                excalidrawAPI={excalidrawAPIRef.current}
+                tick={layersTick}
+                onClose={() => setLayersOpen(false)}
               />
             </div>
           )}
@@ -424,15 +373,88 @@ export function DesignMoodboardSection() {
             onChange={(elements, appState, files) => {
               handleExcalidrawChange(elements, appState, files);
               handleSelectionChange();
+              if (layersOpenRef.current) setLayersTick((t) => t + 1);
             }}
             renderTopRightUI={() => (
-              <button
-                className="rounded px-3 py-1 text-sm font-medium bg-ui-bg-subtle border border-ui-border-base hover:bg-ui-bg-base"
-                onClick={() => setFashionPanelOpen(v => !v)}
-                title="Fashion Library"
-              >
-                Fashion Library
-              </button>
+              <div className="flex items-center gap-1.5 flex-wrap justify-end max-w-[62vw]">
+                <DropdownMenu>
+                  <DropdownMenu.Trigger asChild>
+                    <Button
+                      variant="secondary"
+                      size="small"
+                      disabled={isSaving || isInserting}
+                      isLoading={isInserting}
+                    >
+                      Insert block
+                    </Button>
+                  </DropdownMenu.Trigger>
+                  <DropdownMenu.Content>
+                    {groupedBlocks.length === 0 ? (
+                      <DropdownMenu.Item disabled>No blocks available</DropdownMenu.Item>
+                    ) : (
+                      groupedBlocks.map((grp, gi) => (
+                        <Fragment key={grp.group}>
+                          {gi > 0 ? <DropdownMenu.Separator /> : null}
+                          <DropdownMenu.Label>{grp.group}</DropdownMenu.Label>
+                          {grp.items.map((b) => (
+                            <DropdownMenu.Item
+                              key={b.key}
+                              // Brief blocks stay insertable even when empty —
+                              // they drop an editable template you fill in place.
+                              disabled={b.group !== "Brief" && !b.available}
+                              onClick={() => handleInsert(b.key, b.label)}
+                            >
+                              {b.label}
+                              {!b.available ? (
+                                <span className="text-ui-fg-muted ml-1">· empty</span>
+                              ) : null}
+                            </DropdownMenu.Item>
+                          ))}
+                        </Fragment>
+                      ))
+                    )}
+                  </DropdownMenu.Content>
+                </DropdownMenu>
+                <Button
+                  variant="secondary"
+                  size="small"
+                  onClick={() => setConstructionOpen(true)}
+                  disabled={isSaving}
+                >
+                  Add construction
+                </Button>
+                <Button
+                  variant="secondary"
+                  size="small"
+                  onClick={() => handleGenerate()}
+                  disabled={isGenerating || isSaving}
+                  isLoading={isGenerating}
+                >
+                  Generate
+                </Button>
+                <Button
+                  variant={layersOpen ? "primary" : "secondary"}
+                  size="small"
+                  onClick={() => setLayersOpen((v) => !v)}
+                >
+                  Layers
+                </Button>
+                <Button
+                  variant="secondary"
+                  size="small"
+                  onClick={() => setFashionPanelOpen((v) => !v)}
+                >
+                  Fashion Library
+                </Button>
+                <Button
+                  variant="primary"
+                  size="small"
+                  onClick={() => handleSave()}
+                  disabled={isSaving || !hasChanges}
+                >
+                  {isSaving ? "Saving..." : hasChanges ? "Save" : "No Changes"}
+                </Button>
+              </div>
             )}
             UIOptions={{
               canvasActions: {

--- a/apps/backend/src/admin/components/designs/moodboard-brief.ts
+++ b/apps/backend/src/admin/components/designs/moodboard-brief.ts
@@ -1,0 +1,82 @@
+/**
+ * #1113 — read Concept & Identity edits back out of the moodboard canvas so they
+ * round-trip to the design's brief columns. Mirrors the partner editor's parser
+ * (apps/partner-ui/.../design-moodboard.tsx); the two apps are separate bundles
+ * so the small pure logic is duplicated rather than shared.
+ */
+
+// Placeholder copy the generator writes when the concept card is empty — never
+// persist it back as a real value.
+const CONCEPT_PLACEHOLDER = "Set the overarching story or inspiration.";
+
+// Must match KEYWORDS_LINE_LABEL in build-moodboard-scene.ts.
+const KEYWORDS_LINE_LABEL = "Aesthetic keywords:";
+
+export type MoodboardBriefUpdate = {
+  concept_theme?: string;
+  aesthetic_keywords?: string[];
+};
+
+const readConceptTheme = (elements: readonly any[]): string | null => {
+  const rect = elements.find(
+    (el) =>
+      !el.isDeleted &&
+      el.type === "rectangle" &&
+      el.customData?.kind === "brief-field" &&
+      el.customData?.field === "concept_theme",
+  );
+  if (!rect) return null;
+  const rx = rect.x;
+  const ry = rect.y;
+  const rw = rect.width ?? 0;
+  const rh = rect.height ?? 0;
+  const body = elements
+    .filter(
+      (el) =>
+        !el.isDeleted &&
+        el.type === "text" &&
+        typeof el.text === "string" &&
+        el.x >= rx - 4 &&
+        el.x <= rx + rw &&
+        el.y > ry + 30 &&
+        el.y < ry + rh,
+    )
+    .sort((a, b) => b.y - a.y)[0];
+  if (!body) return null;
+  const value = String(body.text).trim();
+  if (!value || value === CONCEPT_PLACEHOLDER) return null;
+  return value;
+};
+
+const readAestheticKeywords = (elements: readonly any[]): string[] | null => {
+  const line = elements.find(
+    (el) =>
+      !el.isDeleted &&
+      el.type === "text" &&
+      el.customData?.kind === "brief-field" &&
+      el.customData?.field === "aesthetic_keywords",
+  );
+  if (!line || typeof line.text !== "string") return null;
+  let raw = String(line.text);
+  if (raw.startsWith(KEYWORDS_LINE_LABEL)) {
+    raw = raw.slice(KEYWORDS_LINE_LABEL.length);
+  }
+  const kws = raw
+    .split(",")
+    .map((s) => s.trim())
+    .filter(Boolean)
+    .slice(0, 8);
+  return kws.length ? kws : null;
+};
+
+/** Returns the round-trippable brief edits, or null when nothing is present. */
+export const extractBriefEdits = (
+  elements: readonly any[],
+): MoodboardBriefUpdate | null => {
+  const edits: MoodboardBriefUpdate = {};
+  const concept = readConceptTheme(elements);
+  if (concept != null) edits.concept_theme = concept;
+  const keywords = readAestheticKeywords(elements);
+  if (keywords != null) edits.aesthetic_keywords = keywords;
+  return Object.keys(edits).length ? edits : null;
+};

--- a/apps/backend/src/admin/components/designs/moodboard-layers-panel.tsx
+++ b/apps/backend/src/admin/components/designs/moodboard-layers-panel.tsx
@@ -1,0 +1,172 @@
+import { Text } from "@medusajs/ui";
+import { useCallback, useEffect, useRef, useState } from "react";
+
+/**
+ * #1113 — Figma-style layers panel over the moodboard canvas (admin twin of the
+ * partner panel). Moodboard blocks are top-level Excalidraw frames, so "layers"
+ * == the frame list. Each row jumps-to (scrollToContent), toggles visibility,
+ * and locks. Excalidraw has no native hidden flag, so hide = opacity 0 + locked
+ * (keeps an invisible frame non-interactive); show restores it. opacity/locked
+ * are persisted in the moodboard JSON, so hidden state survives save/reload.
+ */
+type FrameRow = {
+  id: string;
+  name: string;
+  hidden: boolean;
+  locked: boolean;
+  hasContent: boolean;
+};
+
+const readFrames = (api: any): FrameRow[] => {
+  const els = api.getSceneElements().filter((e: any) => !e.isDeleted);
+  return els
+    .filter((e: any) => e.type === "frame")
+    .map((f: any) => ({
+      id: f.id,
+      name: f.name || "Untitled frame",
+      hidden: (f.opacity ?? 100) === 0,
+      locked: !!f.locked,
+      hasContent: els.some((c: any) => c.frameId === f.id),
+    }));
+};
+
+export function MoodboardLayersPanel({
+  excalidrawAPI,
+  tick,
+  onClose,
+}: {
+  excalidrawAPI: any;
+  tick: number;
+  onClose: () => void;
+}) {
+  const [frames, setFrames] = useState<FrameRow[]>([]);
+  const prevLockedRef = useRef<Record<string, boolean>>({});
+
+  const refresh = useCallback(() => {
+    if (!excalidrawAPI) {
+      setFrames([]);
+      return;
+    }
+    setFrames(readFrames(excalidrawAPI));
+  }, [excalidrawAPI]);
+
+  useEffect(() => {
+    refresh();
+  }, [refresh, tick]);
+
+  const applyToFrame = useCallback(
+    (frameId: string, patch: Record<string, any>) => {
+      const api = excalidrawAPI;
+      if (!api) return;
+      const next = api.getSceneElements().map((el: any) =>
+        el.id === frameId || el.frameId === frameId ? { ...el, ...patch } : el,
+      );
+      api.updateScene({ elements: next });
+      refresh();
+    },
+    [excalidrawAPI, refresh],
+  );
+
+  const toggleHidden = useCallback(
+    (f: FrameRow) => {
+      if (!f.hidden) {
+        prevLockedRef.current[f.id] = f.locked;
+        applyToFrame(f.id, { opacity: 0, locked: true });
+      } else {
+        const prev = prevLockedRef.current[f.id] ?? false;
+        delete prevLockedRef.current[f.id];
+        applyToFrame(f.id, { opacity: 100, locked: prev });
+      }
+    },
+    [applyToFrame],
+  );
+
+  const toggleLock = useCallback(
+    (f: FrameRow) => applyToFrame(f.id, { locked: !f.locked }),
+    [applyToFrame],
+  );
+
+  const jump = useCallback(
+    (f: FrameRow) => {
+      const api = excalidrawAPI;
+      if (!api) return;
+      const el = api.getSceneElements().find((e: any) => e.id === f.id);
+      if (el) api.scrollToContent(el, { fitToContent: true, animate: true });
+    },
+    [excalidrawAPI],
+  );
+
+  return (
+    <div className="rounded-lg border border-ui-border-base bg-ui-bg-base shadow-elevation-flyout overflow-hidden">
+      <div className="flex items-center justify-between px-3 py-2 border-b border-ui-border-base">
+        <Text size="small" weight="plus">
+          Layers
+        </Text>
+        <div className="flex items-center gap-1">
+          <button
+            type="button"
+            onClick={refresh}
+            title="Refresh"
+            className="px-1 text-ui-fg-muted hover:text-ui-fg-base"
+          >
+            ⟳
+          </button>
+          <button
+            type="button"
+            onClick={onClose}
+            title="Close"
+            className="px-1 text-ui-fg-muted hover:text-ui-fg-base"
+          >
+            ✕
+          </button>
+        </div>
+      </div>
+      <div className="max-h-[420px] overflow-y-auto py-1">
+        {frames.length === 0 ? (
+          <div className="px-3 py-4 text-ui-fg-muted text-sm">No frames yet.</div>
+        ) : (
+          frames.map((f) => (
+            <div
+              key={f.id}
+              className="flex items-center gap-2 px-3 py-1.5 hover:bg-ui-bg-base-hover"
+            >
+              <span
+                className={`h-1.5 w-1.5 rounded-full shrink-0 ${
+                  f.hasContent ? "bg-ui-fg-interactive" : "bg-ui-border-base"
+                }`}
+                title={f.hasContent ? "Has content" : "Empty"}
+              />
+              <button
+                type="button"
+                onClick={() => jump(f)}
+                title="Jump to frame"
+                className={`flex-1 min-w-0 text-left text-sm truncate ${
+                  f.hidden ? "text-ui-fg-muted line-through" : "text-ui-fg-base"
+                }`}
+              >
+                {f.name}
+              </button>
+              <button
+                type="button"
+                onClick={() => toggleHidden(f)}
+                title={f.hidden ? "Show" : "Hide"}
+                className="text-sm leading-none opacity-80 hover:opacity-100"
+              >
+                {f.hidden ? "🚫" : "👁"}
+              </button>
+              <button
+                type="button"
+                onClick={() => toggleLock(f)}
+                disabled={f.hidden}
+                title={f.hidden ? "Locked while hidden" : f.locked ? "Unlock" : "Lock"}
+                className="text-sm leading-none opacity-80 hover:opacity-100 disabled:opacity-30"
+              >
+                {f.locked ? "🔒" : "🔓"}
+              </button>
+            </div>
+          ))
+        )}
+      </div>
+    </div>
+  );
+}

--- a/apps/backend/src/admin/hooks/api/designs.ts
+++ b/apps/backend/src/admin/hooks/api/designs.ts
@@ -231,6 +231,36 @@ export const useUpdateDesign = (
   });
 };
 
+/** #1113 — the subset of brief columns the moodboard Concept & Identity frame round-trips to. */
+export type DesignBriefUpdate = {
+  concept_theme?: string | null;
+  aesthetic_keywords?: string[] | null;
+};
+
+/**
+ * #1113 — partial brief update driven by Concept & Identity card edits on the
+ * moodboard canvas (concept_theme + aesthetic_keywords). Backed by the existing
+ * PUT /admin/designs/:id/brief route + UpdateDesignBriefSchema.
+ */
+export const useUpdateDesignBrief = (
+  id: string,
+  options?: UseMutationOptions<{ brief: Record<string, any> }, FetchError, DesignBriefUpdate>,
+) => {
+  const queryClient = useQueryClient();
+  return useMutation({
+    mutationFn: async (payload: DesignBriefUpdate) =>
+      sdk.client.fetch<{ brief: Record<string, any> }>(`/admin/designs/${id}/brief`, {
+        method: "PUT",
+        body: payload,
+      }),
+    onSuccess: (data, variables, _mutateResult, context) => {
+      queryClient.invalidateQueries({ queryKey: designQueryKeys.detail(id) });
+      options?.onSuccess?.(data, variables, _mutateResult, context);
+    },
+    ...options,
+  });
+};
+
 /** Response of POST /admin/designs/:id/moodboard/generate — the freshly-built scene. */
 export interface GenerateMoodboardResponse {
   moodboard: {

--- a/apps/backend/src/admin/hooks/use-moodboard.ts
+++ b/apps/backend/src/admin/hooks/use-moodboard.ts
@@ -1,7 +1,8 @@
 import { useCallback, useEffect, useRef, useState } from "react";
 import { toast } from "@medusajs/ui";
-import { useUpdateDesign, useDesign } from "./api/designs";
+import { useUpdateDesign, useDesign, useUpdateDesignBrief } from "./api/designs";
 import { useMoodboardFiles } from "./use-moodboard-files";
+import { extractBriefEdits } from "../components/designs/moodboard-brief";
 import { isEqual } from "lodash";
 
 
@@ -18,6 +19,7 @@ export const useMoodboard = ({
   const [isSaving, setIsSaving] = useState(false);
   const [hasChanges, setHasChanges] = useState(false);
   const { mutate: updateDesign } = useUpdateDesign(designId);
+  const { mutateAsync: updateBrief } = useUpdateDesignBrief(designId);
   const { design } = useDesign(designId, { fields: ["moodboard"] });
 
   const originalStateRef = useRef<any>(null);
@@ -57,7 +59,7 @@ export const useMoodboard = ({
     [handleExcalidrawChange]
   );
 
-  const saveExcalidrawState = useCallback(async () => {
+  const saveExcalidrawState = useCallback(async (opts?: { persistBrief?: boolean }) => {
     setIsSaving(true);
     try {
       const api = excalidrawAPIRef.current;
@@ -157,14 +159,29 @@ export const useMoodboard = ({
           }
         );
       });
-      
+
+      // #1113 — round-trip Concept & Identity edits (concept_theme +
+      // aesthetic_keywords) back to the brief columns. Only on explicit saves
+      // (not the 30s autosave / on-add), and best-effort so a brief failure
+      // never loses the already-saved moodboard.
+      if (opts?.persistBrief) {
+        try {
+          const briefEdits = extractBriefEdits(processedElements);
+          if (briefEdits) {
+            await updateBrief(briefEdits);
+          }
+        } catch (briefErr) {
+          console.error("Brief write-back failed (moodboard still saved):", briefErr);
+        }
+      }
+
     } catch (error) {
       console.error("Error in saveExcalidrawState:", error);
       throw error;
     } finally {
       setIsSaving(false);
     }
-  }, [updateDesign, processImageElements, fileUrlMappingRef, excalidrawAPIRef]);
+  }, [updateDesign, updateBrief, processImageElements, fileUrlMappingRef, excalidrawAPIRef]);
   
   // Update the save ref when the save function changes
   useEffect(() => {
@@ -174,8 +191,8 @@ export const useMoodboard = ({
   const handleSave = useCallback(() => {
     setIsSaving(true);
     toast.loading("Saving moodboard...");
-    
-    saveExcalidrawState()
+
+    saveExcalidrawState({ persistBrief: true })
       .then(() => {
         toast.dismiss();
         toast.success("Moodboard saved successfully");
@@ -199,7 +216,7 @@ export const useMoodboard = ({
     }
     
     setIsSaving(true);
-    saveExcalidrawState()
+    saveExcalidrawState({ persistBrief: true })
       .then(() => {
         toast.success("Moodboard saved successfully");
         onClose?.();

--- a/apps/backend/src/workflows/designs/moodboard/__tests__/build-brief-frames.unit.spec.ts
+++ b/apps/backend/src/workflows/designs/moodboard/__tests__/build-brief-frames.unit.spec.ts
@@ -70,13 +70,16 @@ describe("buildMoodboardScene with a brief", () => {
     expect(frameNames).toContain("1 · Header & Flats")
   })
 
-  it("renders the concept theme + aesthetic keyword pills", () => {
+  it("renders the concept theme + a single editable, parseable keyword line", () => {
     const texts = scene.elements.filter((e) => e.type === "text").map((e) => e.text)
     expect(texts).toContain("90s Tokyo Streetwear")
-    // Each keyword is its own pill label.
-    expect(texts).toContain("utilitarian")
-    expect(texts).toContain("sleek")
-    expect(texts).toContain("nostalgic")
+    // Keywords now live on one editable line prefixed with KEYWORDS_LINE_LABEL,
+    // so they round-trip back to the brief (parsed by the editors).
+    expect(texts).toContain("Aesthetic keywords: utilitarian, sleek, nostalgic")
+    const line = scene.elements.find(
+      (e) => e.type === "text" && (e as any).customData?.field === "aesthetic_keywords"
+    )
+    expect(line).toBeTruthy()
   })
 
   it("renders persona, competitors and price point", () => {

--- a/apps/backend/src/workflows/designs/moodboard/build-moodboard-scene.ts
+++ b/apps/backend/src/workflows/designs/moodboard/build-moodboard-scene.ts
@@ -1250,6 +1250,14 @@ export function briefHasContent(b?: TechPackBrief): boolean {
   return hasConceptSection(b) || hasAudienceSection(b) || hasTimelineSection(b)
 }
 
+/**
+ * Stable prefix for the editable aesthetic-keywords line in the Concept &
+ * Identity frame. The partner + admin editors strip this prefix and split the
+ * remainder on commas to round-trip `aesthetic_keywords` back to the brief, so
+ * keep it in sync with their local copies of this constant.
+ */
+export const KEYWORDS_LINE_LABEL = "Aesthetic keywords:"
+
 /** Brief Frame 1 — Core Identity & Concept (concept/theme + aesthetic anchor). */
 export function buildBriefConceptFrame(
   input: TechPackSceneInput,
@@ -1277,7 +1285,10 @@ export function buildBriefConceptFrame(
     customData: { kind: "brief-field", field: "concept_theme" },
   })
 
-  // Aesthetic Anchor — keywords as pills.
+  // Aesthetic Anchor — a single editable, comma-separated line so keyword edits
+  // round-trip back to the brief. The text element carries
+  // customData.field = "aesthetic_keywords" so the editors' parser finds it
+  // unambiguously (see extractBriefEdits) and strips KEYWORDS_LINE_LABEL.
   const keywords = (b.aesthetic_keywords ?? []).filter(Boolean)
   const anchorX = originX + FRAME.pad
   const anchorY = cardY + 260
@@ -1288,40 +1299,31 @@ export function buildBriefConceptFrame(
       frameId
     )
   )
-  if (keywords.length) {
-    let px = anchorX
-    let py = anchorY + 34
-    keywords.forEach((kw) => {
-      const pillW = Math.max(90, kw.length * 11 + 32)
-      if (px + pillW > anchorX + 700) {
-        px = anchorX
-        py += 54
-      }
-      elements.push(
-        makeElement(
-          { type: "rectangle", x: px, y: py, width: pillW, height: 40, backgroundColor: "#e0e7ff", fillStyle: "solid", strokeColor: "#a5b4fc", roundness: { type: 3 }, customData: { kind: "brief-field", field: "aesthetic_keywords" } },
-          rng,
-          frameId
-        )
-      )
-      elements.push(
-        makeElement(
-          { type: "text", x: px + 16, y: py + 11, width: pillW - 32, height: 20, text: kw, fontSize: 15, textAlign: "center" },
-          rng,
-          frameId
-        )
-      )
-      px += pillW + 16
-    })
-  } else {
-    elements.push(
-      makeElement(
-        { type: "text", x: anchorX, y: anchorY + 34, width: 700, height: 20, text: "3–5 keywords that define the look & feel (e.g. utilitarian, sleek, nostalgic).", fontSize: 14, opacity: 60 },
-        rng,
-        frameId
-      )
+  elements.push(
+    makeElement(
+      {
+        type: "text",
+        x: anchorX,
+        y: anchorY + 34,
+        width: 700,
+        height: 26,
+        text: keywords.length
+          ? `${KEYWORDS_LINE_LABEL} ${keywords.join(", ")}`
+          : `${KEYWORDS_LINE_LABEL} `,
+        fontSize: 18,
+        customData: { kind: "brief-field", field: "aesthetic_keywords" },
+      },
+      rng,
+      frameId
     )
-  }
+  )
+  elements.push(
+    makeElement(
+      { type: "text", x: anchorX, y: anchorY + 74, width: 700, height: 20, text: "Comma-separated · 3–5 keywords that define the look & feel (e.g. utilitarian, sleek, nostalgic).", fontSize: 14, opacity: 60 },
+      rng,
+      frameId
+    )
+  )
 
   return { elements, files: {} }
 }

--- a/apps/partner-ui/src/routes/designs/design-moodboard/design-moodboard.tsx
+++ b/apps/partner-ui/src/routes/designs/design-moodboard/design-moodboard.tsx
@@ -19,6 +19,7 @@ import {
 } from "../../../hooks/api/partner-designs"
 import { useResolvedDesignId } from "../../../hooks/use-resolved-design-id"
 import { ConstructionPicker } from "./construction-picker"
+import { MoodboardLayersPanel } from "./moodboard-layers-panel"
 
 // Must match the frame name emitted by buildConstructionDetailsFrame on the
 // backend, so re-inserting replaces the existing construction frame in place.
@@ -102,19 +103,13 @@ const normalizeMoodboard = (raw: unknown): MoodboardData | null => {
 // persist it back as a real value.
 const CONCEPT_PLACEHOLDER = "Set the overarching story or inspiration."
 
-/**
- * #1113 S3 — read the designer's edits to `brief-field` cards back out of the
- * canvas so they round-trip to the brief columns.
- *
- * Only the free-text `concept_theme` card is round-tripped: its value lives in a
- * standalone text element sitting inside the card rectangle (the rectangle
- * carries `customData.field`; the text is positioned, not bound). Structured
- * fields (persona/competitors/aesthetic_keywords/milestones) are visual-only
- * edits here — they're JSON, not naive text, so we never guess them back.
- */
-const extractBriefEdits = (
-  elements: readonly any[]
-): PartnerBriefUpdate | null => {
+// Must match KEYWORDS_LINE_LABEL in build-moodboard-scene.ts — the stable prefix
+// on the editable aesthetic-keywords line in the Concept & Identity frame.
+const KEYWORDS_LINE_LABEL = "Aesthetic keywords:"
+
+// Read the free-text concept_theme card body out of the canvas (positioned text
+// element inside the `brief-field` rectangle).
+const readConceptTheme = (elements: readonly any[]): string | null => {
   const rect = elements.find(
     (el) =>
       !el.isDeleted &&
@@ -125,13 +120,11 @@ const extractBriefEdits = (
   if (!rect) {
     return null
   }
-
-  // Find the body text element geometrically inside the card, below the heading.
   const rx = rect.x
   const ry = rect.y
   const rw = rect.width ?? 0
   const rh = rect.height ?? 0
-  const bodies = elements
+  const body = elements
     .filter(
       (el) =>
         !el.isDeleted &&
@@ -143,19 +136,63 @@ const extractBriefEdits = (
         el.y < ry + rh
     )
     // The body text is the lower one (y ~+46); heading sits at y ~+16.
-    .sort((a, b) => b.y - a.y)
-
-  const body = bodies[0]
+    .sort((a, b) => b.y - a.y)[0]
   if (!body) {
     return null
   }
-
   const value = String(body.text).trim()
   if (!value || value === CONCEPT_PLACEHOLDER) {
     return null
   }
+  return value
+}
 
-  return { concept_theme: value }
+// Read the comma-separated aesthetic-keywords line (a text element tagged with
+// customData.field === "aesthetic_keywords") back into a string[] (max 8, per
+// the brief schema). Returns null when the line is absent or empty.
+const readAestheticKeywords = (elements: readonly any[]): string[] | null => {
+  const line = elements.find(
+    (el) =>
+      !el.isDeleted &&
+      el.type === "text" &&
+      el.customData?.kind === "brief-field" &&
+      el.customData?.field === "aesthetic_keywords"
+  )
+  if (!line || typeof line.text !== "string") {
+    return null
+  }
+  let raw = String(line.text)
+  if (raw.startsWith(KEYWORDS_LINE_LABEL)) {
+    raw = raw.slice(KEYWORDS_LINE_LABEL.length)
+  }
+  const kws = raw
+    .split(",")
+    .map((s) => s.trim())
+    .filter(Boolean)
+    .slice(0, 8)
+  return kws.length ? kws : null
+}
+
+/**
+ * #1113 — read the designer's edits to the Concept & Identity frame back out of
+ * the canvas so they round-trip to the brief columns. Handles the free-text
+ * `concept_theme` card and the editable `aesthetic_keywords` line. Other
+ * structured fields (persona/competitors/milestones) remain visual-only.
+ * Returns null when nothing round-trippable is present.
+ */
+const extractBriefEdits = (
+  elements: readonly any[]
+): PartnerBriefUpdate | null => {
+  const edits: PartnerBriefUpdate = {}
+  const concept = readConceptTheme(elements)
+  if (concept != null) {
+    edits.concept_theme = concept
+  }
+  const keywords = readAestheticKeywords(elements)
+  if (keywords != null) {
+    edits.aesthetic_keywords = keywords
+  }
+  return Object.keys(edits).length ? edits : null
 }
 
 // Fresh element id — insert-block elements come from the server built at origin
@@ -208,6 +245,14 @@ export const DesignMoodboard = () => {
   const didSeedRef = useRef(false)
   const [isDirty, setIsDirty] = useState(false)
   const [constructionOpen, setConstructionOpen] = useState(false)
+  const [layersOpen, setLayersOpen] = useState(false)
+  // Bumped on canvas change (only while the layers panel is open) so the panel
+  // re-reads frames without re-rendering the whole editor on every pointer move.
+  const [layersTick, setLayersTick] = useState(0)
+  const layersOpenRef = useRef(false)
+  useEffect(() => {
+    layersOpenRef.current = layersOpen
+  }, [layersOpen])
 
   const { design, isPending, isError, error } = usePartnerDesign(id || "")
 
@@ -253,6 +298,9 @@ export const DesignMoodboard = () => {
       return
     }
     setIsDirty(true)
+    if (layersOpenRef.current) {
+      setLayersTick((t) => t + 1)
+    }
   }, [])
 
   // Load a freshly-generated scene straight into the canvas so it's editable.
@@ -452,15 +500,26 @@ export const DesignMoodboard = () => {
 
       await saveMoodboard(scene)
 
-      // Round-trip concept-card text edits back to the brief column.
+      // Round-trip Concept & Identity edits (concept_theme + aesthetic_keywords)
+      // back to the brief columns.
       const briefEdits = extractBriefEdits(elements)
-      if (briefEdits && briefEdits.concept_theme !== (design as any)?.concept_theme) {
-        try {
-          await updateBrief(briefEdits)
-        } catch {
-          // A brief write-back failure shouldn't lose the saved scene; surface
-          // softly and keep the moodboard save.
-          toast.warning("Moodboard saved, but the brief edit couldn't be synced.")
+      if (briefEdits) {
+        const cur = (design as any) || {}
+        const conceptChanged =
+          "concept_theme" in briefEdits &&
+          briefEdits.concept_theme !== cur.concept_theme
+        const keywordsChanged =
+          "aesthetic_keywords" in briefEdits &&
+          JSON.stringify(briefEdits.aesthetic_keywords ?? []) !==
+            JSON.stringify(cur.aesthetic_keywords ?? [])
+        if (conceptChanged || keywordsChanged) {
+          try {
+            await updateBrief(briefEdits)
+          } catch {
+            // A brief write-back failure shouldn't lose the saved scene; surface
+            // softly and keep the moodboard save.
+            toast.warning("Moodboard saved, but the brief edit couldn't be synced.")
+          }
         }
       }
 
@@ -501,6 +560,15 @@ export const DesignMoodboard = () => {
           </div>
         ) : (
           <div className="relative w-full h-[calc(100dvh-160px)]">
+            {layersOpen ? (
+              <div className="absolute top-14 left-2 z-50 w-64">
+                <MoodboardLayersPanel
+                  excalidrawAPI={apiRef.current}
+                  tick={layersTick}
+                  onClose={() => setLayersOpen(false)}
+                />
+              </div>
+            ) : null}
             <Excalidraw
               excalidrawAPI={(api) => {
                 apiRef.current = api
@@ -517,6 +585,84 @@ export const DesignMoodboard = () => {
               }
               viewModeEnabled={false}
               onChange={handleChange}
+              renderTopRightUI={() => (
+                <div className="flex items-center gap-1.5 flex-wrap justify-end max-w-[62vw]">
+                  <DropdownMenu>
+                    <DropdownMenu.Trigger asChild>
+                      <Button
+                        size="small"
+                        variant="secondary"
+                        disabled={!id || isSaving || isInserting}
+                        isLoading={isInserting}
+                      >
+                        Insert block
+                      </Button>
+                    </DropdownMenu.Trigger>
+                    <DropdownMenu.Content>
+                      {groupedBlocks.length === 0 ? (
+                        <DropdownMenu.Item disabled>
+                          No blocks available
+                        </DropdownMenu.Item>
+                      ) : (
+                        groupedBlocks.map((grp, gi) => (
+                          <Fragment key={grp.group}>
+                            {gi > 0 ? <DropdownMenu.Separator /> : null}
+                            <DropdownMenu.Label>{grp.group}</DropdownMenu.Label>
+                            {grp.items.map((b) => (
+                              <DropdownMenu.Item
+                                key={b.key}
+                                // Brief blocks stay insertable even when empty —
+                                // they drop an editable template you fill in place.
+                                disabled={b.group !== "Brief" && !b.available}
+                                onClick={() => handleInsert(b.key, b.label)}
+                              >
+                                {b.label}
+                                {!b.available ? (
+                                  <span className="text-ui-fg-muted ml-1">· empty</span>
+                                ) : null}
+                              </DropdownMenu.Item>
+                            ))}
+                          </Fragment>
+                        ))
+                      )}
+                    </DropdownMenu.Content>
+                  </DropdownMenu>
+                  <Button
+                    size="small"
+                    variant="secondary"
+                    onClick={() => setConstructionOpen(true)}
+                    disabled={!id || isSaving}
+                  >
+                    Add construction
+                  </Button>
+                  <Button
+                    size="small"
+                    variant="secondary"
+                    onClick={handleGenerate}
+                    disabled={!id || isGenerating || isSaving}
+                    isLoading={isGenerating}
+                  >
+                    Generate
+                  </Button>
+                  <Button
+                    size="small"
+                    variant={layersOpen ? "primary" : "secondary"}
+                    onClick={() => setLayersOpen((v) => !v)}
+                    disabled={!id}
+                  >
+                    Layers
+                  </Button>
+                  <Button
+                    size="small"
+                    variant="primary"
+                    onClick={handleSave}
+                    disabled={!id || isSaving || !isDirty}
+                    isLoading={isSaving}
+                  >
+                    {isDirty ? "Save" : "Saved"}
+                  </Button>
+                </div>
+              )}
               UIOptions={{
                 canvasActions: {
                   changeViewBackgroundColor: true,
@@ -535,74 +681,16 @@ export const DesignMoodboard = () => {
       </RouteFocusModal.Body>
 
       <RouteFocusModal.Footer>
-        <div className="flex items-center justify-end gap-x-2">
+        <div className="flex items-center justify-between w-full gap-x-2">
+          <Text size="xsmall" className="text-ui-fg-muted">
+            Insert, construction, generate, layers &amp; save are in the canvas
+            toolbar (top-right).
+          </Text>
           <RouteFocusModal.Close asChild>
             <Button size="small" variant="secondary">
               Close
             </Button>
           </RouteFocusModal.Close>
-          <DropdownMenu>
-            <DropdownMenu.Trigger asChild>
-              <Button
-                size="small"
-                variant="secondary"
-                disabled={!id || isSaving || isInserting}
-                isLoading={isInserting}
-              >
-                Insert block
-              </Button>
-            </DropdownMenu.Trigger>
-            <DropdownMenu.Content>
-              {groupedBlocks.length === 0 ? (
-                <DropdownMenu.Item disabled>No blocks available</DropdownMenu.Item>
-              ) : (
-                groupedBlocks.map((grp, gi) => (
-                  <Fragment key={grp.group}>
-                    {gi > 0 ? <DropdownMenu.Separator /> : null}
-                    <DropdownMenu.Label>{grp.group}</DropdownMenu.Label>
-                    {grp.items.map((b) => (
-                      <DropdownMenu.Item
-                        key={b.key}
-                        disabled={!b.available}
-                        onClick={() => handleInsert(b.key, b.label)}
-                      >
-                        {b.label}
-                        {!b.available ? (
-                          <span className="text-ui-fg-muted ml-1">· empty</span>
-                        ) : null}
-                      </DropdownMenu.Item>
-                    ))}
-                  </Fragment>
-                ))
-              )}
-            </DropdownMenu.Content>
-          </DropdownMenu>
-          <Button
-            size="small"
-            variant="secondary"
-            onClick={() => setConstructionOpen(true)}
-            disabled={!id || isSaving}
-          >
-            Add construction
-          </Button>
-          <Button
-            size="small"
-            variant="secondary"
-            onClick={handleGenerate}
-            disabled={!id || isGenerating || isSaving}
-            isLoading={isGenerating}
-          >
-            Generate from brief
-          </Button>
-          <Button
-            size="small"
-            variant="primary"
-            onClick={handleSave}
-            disabled={!id || isSaving || !isDirty}
-            isLoading={isSaving}
-          >
-            {isDirty ? "Save changes" : "Saved"}
-          </Button>
         </div>
       </RouteFocusModal.Footer>
 

--- a/apps/partner-ui/src/routes/designs/design-moodboard/moodboard-layers-panel.tsx
+++ b/apps/partner-ui/src/routes/designs/design-moodboard/moodboard-layers-panel.tsx
@@ -1,0 +1,181 @@
+import { Text } from "@medusajs/ui"
+import { useCallback, useEffect, useRef, useState } from "react"
+import type { ExcalidrawImperativeAPI } from "@excalidraw/excalidraw/types"
+
+/**
+ * #1113 — a Figma-style layers panel over the moodboard canvas. Moodboard blocks
+ * are top-level Excalidraw frames, so "layers" == the frame list. Each row can
+ * jump-to (scrollToContent), toggle visibility, and lock. Excalidraw has no
+ * native hidden flag, so visibility is synthesized: hide = opacity 0 + locked
+ * (so an invisible frame stays non-interactive); show restores it. Because
+ * opacity/locked are real element props persisted in the moodboard JSON, hidden
+ * state survives save/reload for free.
+ */
+type FrameRow = {
+  id: string
+  name: string
+  hidden: boolean
+  locked: boolean
+  hasContent: boolean
+}
+
+const readFrames = (api: ExcalidrawImperativeAPI): FrameRow[] => {
+  const els = api.getSceneElements().filter((e: any) => !e.isDeleted)
+  return els
+    .filter((e: any) => e.type === "frame")
+    .map((f: any) => ({
+      id: f.id,
+      name: f.name || "Untitled frame",
+      hidden: (f.opacity ?? 100) === 0,
+      locked: !!f.locked,
+      hasContent: els.some((c: any) => c.frameId === f.id),
+    }))
+}
+
+export const MoodboardLayersPanel = ({
+  excalidrawAPI,
+  tick,
+  onClose,
+}: {
+  excalidrawAPI: ExcalidrawImperativeAPI | null
+  tick: number
+  onClose: () => void
+}) => {
+  const [frames, setFrames] = useState<FrameRow[]>([])
+  // Remember a frame's lock state before hide so show can restore it.
+  const prevLockedRef = useRef<Record<string, boolean>>({})
+
+  const refresh = useCallback(() => {
+    if (!excalidrawAPI) {
+      setFrames([])
+      return
+    }
+    setFrames(readFrames(excalidrawAPI))
+  }, [excalidrawAPI])
+
+  useEffect(() => {
+    refresh()
+  }, [refresh, tick])
+
+  const applyToFrame = useCallback(
+    (frameId: string, patch: Record<string, any>) => {
+      const api = excalidrawAPI
+      if (!api) {
+        return
+      }
+      const next = api.getSceneElements().map((el: any) =>
+        el.id === frameId || el.frameId === frameId ? { ...el, ...patch } : el
+      )
+      api.updateScene({ elements: next as any })
+      refresh()
+    },
+    [excalidrawAPI, refresh]
+  )
+
+  const toggleHidden = useCallback(
+    (f: FrameRow) => {
+      if (!f.hidden) {
+        prevLockedRef.current[f.id] = f.locked
+        applyToFrame(f.id, { opacity: 0, locked: true })
+      } else {
+        const prev = prevLockedRef.current[f.id] ?? false
+        delete prevLockedRef.current[f.id]
+        applyToFrame(f.id, { opacity: 100, locked: prev })
+      }
+    },
+    [applyToFrame]
+  )
+
+  const toggleLock = useCallback(
+    (f: FrameRow) => applyToFrame(f.id, { locked: !f.locked }),
+    [applyToFrame]
+  )
+
+  const jump = useCallback(
+    (f: FrameRow) => {
+      const api = excalidrawAPI
+      if (!api) {
+        return
+      }
+      const el = api.getSceneElements().find((e: any) => e.id === f.id)
+      if (el) {
+        api.scrollToContent(el as any, { fitToContent: true, animate: true })
+      }
+    },
+    [excalidrawAPI]
+  )
+
+  return (
+    <div className="rounded-lg border border-ui-border-base bg-ui-bg-base shadow-elevation-flyout overflow-hidden">
+      <div className="flex items-center justify-between px-3 py-2 border-b border-ui-border-base">
+        <Text size="small" weight="plus">
+          Layers
+        </Text>
+        <div className="flex items-center gap-1">
+          <button
+            type="button"
+            onClick={refresh}
+            title="Refresh"
+            className="px-1 text-ui-fg-muted hover:text-ui-fg-base"
+          >
+            ⟳
+          </button>
+          <button
+            type="button"
+            onClick={onClose}
+            title="Close"
+            className="px-1 text-ui-fg-muted hover:text-ui-fg-base"
+          >
+            ✕
+          </button>
+        </div>
+      </div>
+      <div className="max-h-[420px] overflow-y-auto py-1">
+        {frames.length === 0 ? (
+          <div className="px-3 py-4 text-ui-fg-muted text-sm">No frames yet.</div>
+        ) : (
+          frames.map((f) => (
+            <div
+              key={f.id}
+              className="flex items-center gap-2 px-3 py-1.5 hover:bg-ui-bg-base-hover"
+            >
+              <span
+                className={`h-1.5 w-1.5 rounded-full shrink-0 ${
+                  f.hasContent ? "bg-ui-fg-interactive" : "bg-ui-border-base"
+                }`}
+                title={f.hasContent ? "Has content" : "Empty"}
+              />
+              <button
+                type="button"
+                onClick={() => jump(f)}
+                title="Jump to frame"
+                className={`flex-1 min-w-0 text-left text-sm truncate ${
+                  f.hidden ? "text-ui-fg-muted line-through" : "text-ui-fg-base"
+                }`}
+              >
+                {f.name}
+              </button>
+              <button
+                type="button"
+                onClick={() => toggleHidden(f)}
+                title={f.hidden ? "Show" : "Hide"}
+                className="text-sm leading-none opacity-80 hover:opacity-100"
+              >
+                {f.hidden ? "🚫" : "👁"}
+              </button>
+              <button
+                type="button"
+                onClick={() => toggleLock(f)}
+                disabled={f.hidden}
+                title={f.hidden ? "Locked while hidden" : f.locked ? "Unlock" : "Lock"}
+                className="text-sm leading-none opacity-80 hover:opacity-100 disabled:opacity-30"
+              >
+                {f.locked ? "🔒" : "🔓"}
+              </button>
+            </div>
+          ))
+        )}
+      </div>
+    </div>
+  )
+}

--- a/e2e/specs/moodboard-blocks-construction.spec.ts
+++ b/e2e/specs/moodboard-blocks-construction.spec.ts
@@ -216,4 +216,123 @@ test.describe("Moodboard insert blocks + construction (#1113 A/B)", () => {
 
     await admin.dispose()
   })
+
+  test("concept & identity round-trips to the brief; hidden frame persists (#1113 A/C)", async ({
+    baseURL,
+  }) => {
+    const partner = await assignedDesignerContext(baseURL!)
+    const admin = await pwRequest.newContext({
+      baseURL,
+      extraHTTPHeaders: { authorization: `Bearer ${adminToken}` },
+    })
+    const designId = seed.inviteDesignId
+
+    // Capture originals so this shared-seed design is restored for later specs.
+    const origBrief = (
+      await (await partner.get(`/partners/designs/${designId}/brief`)).json()
+    ).brief
+    const origDesign = (
+      await (await admin.get(`/admin/designs/${designId}`)).json()
+    ).design
+    const origMoodboard = origDesign?.moodboard ?? null
+
+    const buildConcept = async () =>
+      (
+        await (
+          await partner.post(`/partners/designs/${designId}/moodboard/blocks`, {
+            data: { block: "brief-concept" },
+          })
+        ).json()
+      ).block
+
+    try {
+      // ── A1 — the built concept block carries a single parseable keyword line ──
+      const block1 = await buildConcept()
+      const kwLine1 = block1.elements.find(
+        (e: any) =>
+          e.type === "text" &&
+          e.customData?.kind === "brief-field" &&
+          e.customData?.field === "aesthetic_keywords"
+      )
+      expect(kwLine1).toBeTruthy()
+      expect(String(kwLine1.text).startsWith("Aesthetic keywords:")).toBe(true)
+
+      // ── A3/A4 — write concept + keywords through the brief route, read back ──
+      const kws = ["airy", "muted", "linen"]
+      const concept = `E2E concept ${Date.now()}`
+      const putRes = await partner.put(`/partners/designs/${designId}/brief`, {
+        data: { concept_theme: concept, aesthetic_keywords: kws },
+      })
+      expect(putRes.status()).toBe(200)
+
+      const brief = (
+        await (await partner.get(`/partners/designs/${designId}/brief`)).json()
+      ).brief
+      expect(brief.concept_theme).toBe(concept)
+      expect(brief.aesthetic_keywords).toEqual(kws)
+
+      // The rebuilt block reflects the persisted brief — keywords on the editable
+      // line, concept in the card body (proves the full canvas → brief → canvas loop).
+      const block2 = await buildConcept()
+      const kwLine2 = block2.elements.find(
+        (e: any) => e.customData?.field === "aesthetic_keywords"
+      )
+      expect(kwLine2.text).toBe(`Aesthetic keywords: ${kws.join(", ")}`)
+      const texts = block2.elements
+        .filter((e: any) => e.type === "text")
+        .map((e: any) => e.text)
+      expect(texts).toContain(concept)
+
+      // ── C — hidden state (opacity 0 + locked) survives save + reload ────────
+      const scene = {
+        type: "excalidraw",
+        version: 2,
+        source: "https://excalidraw.com",
+        elements: block2.elements.map((e: any) =>
+          e.type === "frame" ? { ...e, opacity: 0, locked: true } : e
+        ),
+        appState: { viewBackgroundColor: "#ffffff" },
+        files: {},
+      }
+      const saveRes = await partner.put(
+        `/partners/designs/${designId}/moodboard`,
+        { data: { moodboard: scene } }
+      )
+      expect(saveRes.status()).toBe(200)
+
+      // Reload through a fresh (admin) client to prove it's persisted, not echoed.
+      const reloaded = (
+        await (await admin.get(`/admin/designs/${designId}`)).json()
+      ).design
+      const savedFrame = (reloaded.moodboard?.elements ?? []).find(
+        (e: any) => e.type === "frame"
+      )
+      expect(savedFrame).toBeTruthy()
+      expect(savedFrame.opacity).toBe(0)
+      expect(savedFrame.locked).toBe(true)
+    } finally {
+      // Restore shared-seed state for downstream specs.
+      await partner.put(`/partners/designs/${designId}/brief`, {
+        data: {
+          concept_theme: origBrief?.concept_theme ?? null,
+          aesthetic_keywords: origBrief?.aesthetic_keywords ?? null,
+        },
+      })
+      await partner.put(`/partners/designs/${designId}/moodboard`, {
+        data: {
+          moodboard:
+            origMoodboard ?? {
+              type: "excalidraw",
+              version: 2,
+              source: "https://excalidraw.com",
+              elements: [],
+              appState: {},
+              files: {},
+            },
+        },
+      })
+      await partner.dispose()
+      await admin.dispose()
+    }
+  })
 })


### PR DESCRIPTION
Follow-up to #1113 (designer-invite draggable moodboard). Three usability gaps in the partner + admin moodboard editors, plus a note on live collaboration.

## A — Concept & Identity: editable template + persist
- **Empty was a dead end**: the frame showed placeholder text, the Insert menu *disabled* it when empty, and on-canvas keyword edits were visual-only.
- Scene builder now renders `aesthetic_keywords` as **one editable, comma-separated line** (`KEYWORDS_LINE_LABEL`) instead of unparseable pills → keyword edits round-trip.
- Brief blocks stay **insertable when empty** (drop a fillable template; keeps the `· empty` badge).
- Partner now persists `aesthetic_keywords` (previously only `concept_theme`); **admin gains brief write-back** on explicit save via new `useUpdateDesignBrief` + shared parser (`moodboard-brief.ts`). **No backend route/schema changes** — `/brief` already accepts these fields.

## B — Toolbar moved into the Excalidraw canvas
- Insert-block / Add-construction / Generate / Layers / Save now live in the canvas top-right via `renderTopRightUI` (the admin Fashion-Library pattern), on both editors. Footer/header slimmed to a hint + Close.

## C — Layers panel (`moodboard-layers-panel.tsx`, partner + admin)
- Lists every frame with **jump-to** (`scrollToContent`), **hide/show** (Excalidraw has no native hidden flag → synthesized as opacity-0 + lock, persisted in the scene JSON so it **survives save/reload**), and independent lock.

## Out of scope — live collaboration
Confirmed **not wired up** today (only the required-empty `collaborators: new Map()`). Excalidraw ships no turnkey collab (needs a WebSocket room server + scene broadcast, or WebRTC/Hyperbee P2P). Filing as a **separate epic + PR**.

## Verification
- **Unit 63/63** (`build-moodboard-block|construction-techniques|moodboard|brief-frames`) — +3 brief round-trip tests, updated the pill assertion to the new parseable line.
- **Backend + partner-ui tsc**: zero errors in any touched file (pre-existing errors elsewhere are unrelated).
- **e2e 3/3 green locally** against live `:9000` — extended `moodboard-blocks-construction.spec.ts` with a concept/keyword round-trip (built block → `/brief` PUT → rebuilt block reflects it) + hidden-frame persistence (opacity-0 + locked survives reload).

## Watch-outs
- `KEYWORDS_LINE_LABEL` is duplicated in 3 places (scene builder + 2 editors, separate bundles) — kept in sync via comments + the round-trip test.
- Hidden = opacity-0 + locked is synthesized; frames still appear in PNG export.

🤖 Generated with [Claude Code](https://claude.com/claude-code)