### PR TITLE
chore(crm): gitignore local .crm-store Corestore dev artifact

### DIFF
--- a/apps/backend/.gitignore
+++ b/apps/backend/.gitignore
@@ -6,3 +6,6 @@
 .person-property-store/
 .pp-boot-verify-store/
 .pp-*-store/
+
+# CRM embedded Hyperbee DAL local Corestore (single-writer, dev only)
+.crm-store/


### PR DESCRIPTION
Small cleanup. The CRM embedded Hyperbee DAL loader (`src/modules/crm/loaders/hyperbee-dal.ts:66`) creates `./.crm-store` at boot — a local single-writer Corestore/leveldb store, dev-only. It was accidentally left untracked in the working tree.

- Ignore `.crm-store/` alongside the other local corestore/Hyperbee dev stores in `apps/backend/.gitignore`.
- Drop the accidentally-untracked copy.

No source or runtime change. Relates to the CRM autobase multi-writer work.

🤖 Generated with [Claude Code](https://claude.com/claude-code)