### PR TITLE
feat(website): per-storefront Google Search Console verification token [#349]

### DIFF
--- a/apps/backend/integration-tests/http/website-public-api.spec.ts
+++ b/apps/backend/integration-tests/http/website-public-api.spec.ts
@@ -133,6 +133,26 @@ setupSharedTestSuite(() =>{
         expect(actualPageTitles).not.toContain("Archived Page");
       });
   
+      it("should default seo.google_site_verification to null when unset", async () => {
+        const response = await api.get("/web/website/test-public.example.com");
+        expect(response.status).toBe(200);
+        expect(response.data.seo).toEqual({ google_site_verification: null });
+      });
+
+      it("should expose the Google Search Console token set via admin update (#349)", async () => {
+        const token = "google-site-verification=abc123XYZ_token";
+        const update = await api.put(
+          `/admin/websites/${websiteId}`,
+          { google_site_verification: token },
+          headers
+        );
+        expect(update.status).toBe(200);
+
+        const response = await api.get("/web/website/test-public.example.com");
+        expect(response.status).toBe(200);
+        expect(response.data.seo.google_site_verification).toBe(token);
+      });
+
       it("should not expose sensitive website data", async () => {
         const response = await api.get("/web/website/test-public.example.com");
         expect(response.status).toBe(200);

--- a/apps/backend/src/api/admin/websites/validators.ts
+++ b/apps/backend/src/api/admin/websites/validators.ts
@@ -14,6 +14,7 @@ export const websiteSchema = z.object({
   analytics_provider: z.enum(ANALYTICS_PROVIDER_VALUES).optional(),
   analytics_custom_head: z.string().nullish(),
   analytics_custom_body_end: z.string().nullish(),
+  google_site_verification: z.string().nullish(),
   metadata: z.record(z.string(), z.unknown()).optional(),
 });
 
@@ -33,6 +34,7 @@ export const updateWebsiteSchema = z.object({
   analytics_provider: z.enum(ANALYTICS_PROVIDER_VALUES).optional(),
   analytics_custom_head: z.string().nullish(),
   analytics_custom_body_end: z.string().nullish(),
+  google_site_verification: z.string().nullish(),
   metadata: z.record(z.string(), z.unknown()).optional().nullish(),
 });
 

--- a/apps/backend/src/api/web/website/[domain]/route.ts
+++ b/apps/backend/src/api/web/website/[domain]/route.ts
@@ -31,6 +31,14 @@ export const GET = async (
         custom_head: (result as any).analytics_custom_head ?? null,
         custom_body_end: (result as any).analytics_custom_body_end ?? null,
       },
+      // SEO tokens the storefront injects into <head> regardless of analytics
+      // provider (#349). google_site_verification → <meta name="google-site-
+      // verification">. Grouped in an `seo` bag to leave room for more tokens
+      // (bing, pinterest, …) without another API shape change.
+      seo: {
+        google_site_verification:
+          (result as any).google_site_verification ?? null,
+      },
       pages: result.pages?.map(page => ({
         title: page.title,
         slug: page.slug,

--- a/apps/backend/src/modules/website/migrations/Migration20260722172206.ts
+++ b/apps/backend/src/modules/website/migrations/Migration20260722172206.ts
@@ -1,0 +1,15 @@
+import { Migration } from "@medusajs/framework/mikro-orm/migrations";
+
+export class Migration20260722172206 extends Migration {
+
+  override async up(): Promise<void> {
+    // #349: per-Website Google Search Console site-verification token, injected
+    // into the storefront <head> independent of the analytics provider.
+    this.addSql(`alter table if exists "website" add column if not exists "google_site_verification" text null;`);
+  }
+
+  override async down(): Promise<void> {
+    this.addSql(`alter table if exists "website" drop column if exists "google_site_verification";`);
+  }
+
+}

--- a/apps/backend/src/modules/website/models/website.ts
+++ b/apps/backend/src/modules/website/models/website.ts
@@ -33,6 +33,14 @@ const Website = model.define("website", {
   // Useful for GTM noscript fallbacks and providers that want a body-end tag.
   analytics_custom_body_end: model.text().nullable(),
 
+  // Google Search Console site-verification token (#349). Each storefront domain
+  // is a separate GSC property, so this is per-Website. The storefront-starter
+  // reads it from the public /web/website/[domain] API and always injects
+  // <meta name="google-site-verification" content="…"> into <head> — independent
+  // of analytics_provider (analytics_custom_head only renders for the "custom"
+  // provider, so it can't double as the SEO hook).
+  google_site_verification: model.text().nullable(),
+
   // Relationship with Pages
   pages: model.hasMany(() => Page),
   // Extra domains that resolve to this website (aliases, custom domains, etc.)


### PR DESCRIPTION
**PR-1** of #349 — Google Search Console verification for partner storefronts. Method A (dynamic, backend-served meta tag), per the founder decision recorded on the issue.

### Context
The SEO plumbing for partner storefronts (product/breadcrumb/org JSON-LD, sitemap, robots, canonical+hreflang) is already shipped and rendering. The only remaining blocker was **how each storefront verifies ownership in Search Console** — each domain is a separate GSC property. Decision: store a per-Website token in the backend, expose it via the public API, and have the storefront-starter always inject `<meta name="google-site-verification">` into `<head>` (independent of analytics provider — `analytics_custom_head` only renders for `custom`-analytics partners, so it can't double as the SEO hook).

### This slice (backend)
- **Model:** nullable `google_site_verification` text column on `website` + incremental migration.
- **Migration note:** hand-written `ALTER TABLE … add column if not exists` rather than the full `create table if not exists` that `db:generate` emitted — the latter would no-op on the existing prod table and never add the column (the documented create-if-not-exists hazard).
- **Validators:** accepted on admin website create + update so it's settable.
- **Public API:** exposed in `/web/website/[domain]` under a new `seo: { google_site_verification }` bag (room for future tokens — bing, pinterest…).
- **Tests:** defaults to `null` when unset; round-trips admin `PUT` → public API. (Both new tests pass; 4 unrelated failures in the same spec — blog counts + subscribe validation — are pre-existing on `main`, confirmed by running the spec on a clean tree.)

### Follow-ups (not in this PR)
- PR-3: storefront-starter `<head>` render of the token.
- PR-4: partner-ui paste field so partners self-serve the token.
- Method B (DNS TXT) remains a manual fallback; Method C (Search Console API) deferred.

🤖 Generated with [Claude Code](https://claude.com/claude-code)