### PR TITLE
test(website): raise public-api spec timeout 30s→90s (CI cold-boot)

### DIFF
--- a/apps/backend/integration-tests/http/website-public-api.spec.ts
+++ b/apps/backend/integration-tests/http/website-public-api.spec.ts
@@ -1,7 +1,7 @@
 import { createAdminUser, getAuthHeaders } from "../helpers/create-admin-user";
 import { getSharedTestEnv, setupSharedTestSuite } from "./shared-test-setup";
 
-jest.setTimeout(30000);
+jest.setTimeout(90000);
 
 setupSharedTestSuite(() =>{
 


### PR DESCRIPTION
Follow-up to #349 / #1139.

`website-public-api.spec.ts` used `jest.setTimeout(30000)` while every other http integration spec uses **90s**. CI only runs *changed* specs, so this long-untouched spec hadn't exercised the fresh-DB harness recently. #1139 touched it and surfaced that 30s is too tight for the cold Medusa app boot on a CI runner — `beforeAll` timed out before bootstrap finished, failing all 16 cases (including the pre-existing ones, which pass locally on the shared DB).

One-line change to the repo-wide 90s convention. No logic change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)