### PR TITLE
test(website): fix 4 stale assertions in public-api spec

### DIFF
--- a/apps/backend/integration-tests/http/website-public-api.spec.ts
+++ b/apps/backend/integration-tests/http/website-public-api.spec.ts
@@ -157,8 +157,10 @@ setupSharedTestSuite(() =>{
         const response = await api.get("/web/website/test-public.example.com");
         expect(response.status).toBe(200);
         
-        // Verify sensitive fields are not exposed
-        expect(response.data).not.toHaveProperty("id");
+        // `id` IS intentionally exposed — storefronts stamp it on outbound
+        // analytics events (the in-house tracker's `data-website-id`).
+        expect(response.data).toHaveProperty("id");
+        // Verify genuinely sensitive fields are not exposed
         expect(response.data).not.toHaveProperty("metadata");
         expect(response.data).not.toHaveProperty("created_at");
         expect(response.data).not.toHaveProperty("updated_at");
@@ -176,23 +178,24 @@ setupSharedTestSuite(() =>{
       it("should return all published blogs", async () => {
         const response = await api.get("/web/website/test-public.example.com/blogs");
         expect(response.status).toBe(200);
-        // Check blogs data
-        expect(response.data).toBeDefined();
-        expect(response.data).toHaveLength(2);
+        // Blogs list is paginated: { data: [...] }
+        const blogs = response.data.data;
+        expect(blogs).toBeDefined();
+        expect(blogs).toHaveLength(2);
 
         // Check that both expected blogs are present
         const expectedBlogTitles = ["Published Blog 1", "Published Blog 2"];
-        const foundTitles = response.data.map(blog => blog.title);
+        const foundTitles = blogs.map(blog => blog.title);
         expect(foundTitles).toEqual(expect.arrayContaining(expectedBlogTitles));
 
         // Verify each blog has the required published properties
-        response.data.forEach(blog => {
+        blogs.forEach(blog => {
           expect(blog.published_at).toBeDefined();
           expect(blog.status).toBe("Published");
         });
-        
+
         // Verify draft and archived blogs are not included
-        const actualBlogTitles = response.data.map(b => b.title);
+        const actualBlogTitles = blogs.map(b => b.title);
         expect(actualBlogTitles).not.toContain("Draft Blog");
         expect(actualBlogTitles).not.toContain("Archived Blog");
       });
@@ -331,7 +334,11 @@ setupSharedTestSuite(() =>{
         const subscriptionData = {
           first_name: "Test",
           last_name: "Subscriber",
-          email: "test.subscriber@example.com"
+          email: "test.subscriber@example.com",
+          // subscriptionSchema requires these (nativeEnum + email_subscribed)
+          subscription_type: "email",
+          network: "jaalyantra",
+          email_subscribed: "test.subscriber@example.com",
         };
 
         const response = await api.post(
@@ -359,11 +366,20 @@ setupSharedTestSuite(() =>{
         expect(person.first_name).toBe(subscriptionData.first_name);
         expect(person.last_name).toBe(subscriptionData.last_name);
         expect(person.email).toBe(subscriptionData.email);
-        
-        // Verify the person has metadata about the subscription
-        expect(person.metadata).toHaveProperty("is_subscriber", true);
-        expect(person.metadata).toHaveProperty("subscribed_to_website", "Test Public Website");
-        expect(person.metadata).toHaveProperty("subscribed_to_domain", "test-public.example.com");
+
+        // Subscription state now lives in a dedicated person-subscription
+        // record (createPersonSubWorkflow), not on person.metadata. Verify it
+        // via the person's `subscribed` relation.
+        const detail = await api.get(
+          `/admin/persons/${person.id}?fields=id,subscribed.*`,
+          adminHeaders
+        );
+        expect(detail.status).toBe(200);
+        // `subscribed` is a hasOne relation → a single subscription object.
+        const sub = detail.data.person.subscribed;
+        expect(sub).toBeTruthy();
+        expect(sub.subscription_type).toBe(subscriptionData.subscription_type);
+        expect(sub.network).toBe(subscriptionData.network);
       });
 
       it("should return 400 for invalid subscription data", async () => {
@@ -385,7 +401,11 @@ setupSharedTestSuite(() =>{
         const subscriptionData = {
           first_name: "Test",
           last_name: "Subscriber",
-          email: "test.subscriber2@example.com"
+          email: "test.subscriber2@example.com",
+          // Valid body so it passes validation and reaches the domain check
+          subscription_type: "email",
+          network: "jaalyantra",
+          email_subscribed: "test.subscriber2@example.com",
         };
 
         const response = await api.post(


### PR DESCRIPTION
Follow-up to #349 / #1139 / #1140.

`website-public-api.spec.ts` hadn't run in CI for a long time (CI runs only *changed* specs). #1139 touched it and #1140 fixed its boot timeout, so it now executes — surfacing 4 long-stale assertions that reflect API drift, all unrelated to #349:

- **sensitive-data**: `id` is intentionally exposed now (storefronts use it as the analytics `data-website-id`) — assert it's present, not absent.
- **blogs list**: the endpoint returns `{ data: [...] }` (paginated), not a bare array.
- **subscribe (×2)**: `subscriptionSchema` now requires `subscription_type` / `network` / `email_subscribed` — add them so the success + non-existent-domain (404) cases get past validation. Verify the subscription via the person's `subscribed` (hasOne) relation instead of the removed `person.metadata` flags.

Spec is **16/16 green locally** (`test:integration:http:shared`). No production code changes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)