### PR TITLE
feat(partner): self-serve Google Search Console verification token [#349]

### DIFF
--- a/apps/backend/src/api/partners/storefront/website/analytics/route.ts
+++ b/apps/backend/src/api/partners/storefront/website/analytics/route.ts
@@ -16,6 +16,10 @@ type AnalyticsView = {
   provider: "in_house" | "custom" | "off"
   custom_head: string | null
   custom_body_end: string | null
+  // SEO (not analytics) — shares this storefront-<head>-settings surface (#349).
+  // Google Search Console verification token; the storefront always injects it
+  // as <meta name="google-site-verification"> regardless of analytics provider.
+  google_site_verification: string | null
 }
 
 function shape(website: any): AnalyticsView {
@@ -25,6 +29,7 @@ function shape(website: any): AnalyticsView {
     provider: website.analytics_provider ?? "in_house",
     custom_head: website.analytics_custom_head ?? null,
     custom_body_end: website.analytics_custom_body_end ?? null,
+    google_site_verification: website.google_site_verification ?? null,
   }
 }
 
@@ -151,6 +156,24 @@ export const PUT = async (
       )
     }
     update.analytics_custom_body_end = body.custom_body_end
+  }
+
+  if (body.google_site_verification !== undefined) {
+    if (
+      body.google_site_verification !== null &&
+      typeof body.google_site_verification !== "string"
+    ) {
+      throw new MedusaError(
+        MedusaError.Types.INVALID_DATA,
+        "google_site_verification must be a string or null",
+      )
+    }
+    // Collapse empty/whitespace to null so "cleared" is distinct from a token.
+    const token =
+      typeof body.google_site_verification === "string"
+        ? body.google_site_verification.trim()
+        : body.google_site_verification
+    update.google_site_verification = token ? token : null
   }
 
   // Nothing to apply — return the current view.

--- a/apps/backend/src/workflows/website/update-website.ts
+++ b/apps/backend/src/workflows/website/update-website.ts
@@ -23,6 +23,7 @@ export type UpdateWebsiteStepInput = {
   analytics_provider?: "in_house" | "custom" | "off";
   analytics_custom_head?: string | null;
   analytics_custom_body_end?: string | null;
+  google_site_verification?: string | null;
   theme?: Record<string, unknown> | null;
   metadata?: Record<string, unknown> | null;
 };

--- a/apps/partner-ui/src/hooks/api/website-analytics.tsx
+++ b/apps/partner-ui/src/hooks/api/website-analytics.tsx
@@ -23,6 +23,9 @@ export type WebsiteAnalytics = {
   provider: AnalyticsProvider
   custom_head: string | null
   custom_body_end: string | null
+  // SEO — Google Search Console verification token (#349). Shares this
+  // storefront-<head>-settings surface; not gated by the analytics provider.
+  google_site_verification: string | null
 }
 
 export type WebsiteAnalyticsResponse = { analytics: WebsiteAnalytics }
@@ -31,6 +34,7 @@ export type UpdateWebsiteAnalyticsPayload = {
   provider?: AnalyticsProvider
   custom_head?: string | null
   custom_body_end?: string | null
+  google_site_verification?: string | null
 }
 
 export const useWebsiteAnalytics = (

--- a/apps/partner-ui/src/routes/webstore/analytics/analytics.tsx
+++ b/apps/partner-ui/src/routes/webstore/analytics/analytics.tsx
@@ -8,6 +8,7 @@ import {
   Button,
   Container,
   Heading,
+  Input,
   RadioGroup,
   Text,
   Textarea,
@@ -29,6 +30,7 @@ const analyticsSchema = z.object({
   provider: z.enum(PROVIDER_VALUES),
   custom_head: z.string().nullable(),
   custom_body_end: z.string().nullable(),
+  google_site_verification: z.string().nullable(),
 })
 
 type AnalyticsFormValues = z.infer<typeof analyticsSchema>
@@ -54,6 +56,7 @@ const AnalyticsInner = () => {
       provider: "in_house",
       custom_head: "",
       custom_body_end: "",
+      google_site_verification: "",
     },
     resolver: zodResolver(analyticsSchema),
   })
@@ -66,6 +69,7 @@ const AnalyticsInner = () => {
       provider: analytics.provider,
       custom_head: analytics.custom_head ?? "",
       custom_body_end: analytics.custom_body_end ?? "",
+      google_site_verification: analytics.google_site_verification ?? "",
     })
   }, [analytics, form])
 
@@ -85,6 +89,11 @@ const AnalyticsInner = () => {
           values.provider === "custom" && values.custom_body_end?.trim()
             ? values.custom_body_end
             : null,
+        // SEO verification is independent of the analytics provider — persist
+        // it whenever set, collapsing empty to null so "cleared" is explicit.
+        google_site_verification: values.google_site_verification?.trim()
+          ? values.google_site_verification.trim()
+          : null,
       },
       {
         onSuccess: () => {
@@ -292,6 +301,54 @@ const AnalyticsInner = () => {
                 />
               </>
             )}
+
+            {/* SEO — Search Console verification. Independent of the analytics
+                provider: the storefront always injects this as
+                <meta name="google-site-verification">. (#349) */}
+            <div className="border-t pt-6 flex flex-col gap-y-1">
+              <Text size="small" weight="plus">
+                {t(
+                  "webstore.analytics.seo.heading",
+                  "Search Console verification"
+                )}
+              </Text>
+              <Text size="small" className="text-ui-fg-subtle">
+                {t(
+                  "webstore.analytics.seo.subtitle",
+                  "Verify your storefront in Google Search Console using the HTML-tag method. Paste the token from the <meta name=\"google-site-verification\" content=\"…\"> tag Google gives you — just the content value, not the whole tag."
+                )}
+              </Text>
+            </div>
+
+            <Form.Field
+              control={form.control}
+              name="google_site_verification"
+              render={({ field }) => (
+                <Form.Item>
+                  <Form.Label optional>
+                    {t(
+                      "webstore.analytics.fields.google_site_verification.label",
+                      "Verification token"
+                    )}
+                  </Form.Label>
+                  <Form.Hint>
+                    {t(
+                      "webstore.analytics.fields.google_site_verification.hint",
+                      "Each storefront domain is its own Search Console property. Leave blank to remove."
+                    )}
+                  </Form.Hint>
+                  <Form.Control>
+                    <Input
+                      {...field}
+                      value={field.value ?? ""}
+                      placeholder="e.g. AbCdEf1234_gHiJkLmNoPqRsTuVwXyZ0123456789"
+                      className="font-mono text-xs"
+                    />
+                  </Form.Control>
+                  <Form.ErrorMessage />
+                </Form.Item>
+              )}
+            />
           </div>
 
           <div className="flex justify-end gap-x-2 px-6 py-4 border-t">


### PR DESCRIPTION
**PR-4** of #349 — the last slice. Partners can now self-serve their Google Search Console verification token from storefront settings.

Completes the loop: backend token (#1139) → public API `seo` bag → storefront `<meta name="google-site-verification">` render (#1142) → **partner self-serve (this)**.

### Changes
- **Partner API** (`/partners/storefront/website/analytics`): `GET` returns `google_site_verification`; `PUT` accepts it (string|null, empty→null). Persists via the same `updateWebsiteWorkflow` the admin path uses; added the field to `UpdateWebsiteStepInput`.
- **Partner-ui** (webstore → analytics settings): new always-visible **"Search Console verification"** field. It's independent of the analytics provider (the token is injected regardless), so it renders as its own section with an `Input` for the short token; clearing it removes the token.

### Verification
- Backend + partner-ui typecheck clean (the 4 partner-ui errors are pre-existing, in unrelated order-create forms).
- No `.spec.ts` changed → CI "changed specs" step is a no-op (test check passes); prod-build validates backend compilation.
- Persistence is covered transitively — the partner route writes the same column via the same workflow the admin path uses, which the `website-public-api` round-trip test already exercises.

Closes the #349 build-out (Method A). Method B (DNS TXT) remains a manual fallback; Method C (Search Console API) stays deferred.

🤖 Generated with [Claude Code](https://claude.com/claude-code)