### PR TITLE
feat(partner): wire real global search fan-out [#806]

### DIFF
--- a/apps/partner-ui/src/components/search/constants.ts
+++ b/apps/partner-ui/src/components/search/constants.ts
@@ -2,6 +2,18 @@ export const SEARCH_AREAS = [
   "all",
   "command",
   "navigation",
+  "orders",
+  "designs",
+  "inventory",
+  "customers",
+] as const
+
+// Data-entity areas (subset of SEARCH_AREAS) that fan out to the partner APIs.
+export const DATA_SEARCH_AREAS = [
+  "orders",
+  "designs",
+  "inventory",
+  "customers",
 ] as const
 
 export const DEFAULT_SEARCH_LIMIT = 3

--- a/apps/partner-ui/src/components/search/use-search-results.tsx
+++ b/apps/partner-ui/src/components/search/use-search-results.tsx
@@ -1,7 +1,14 @@
-import { useMemo } from "react"
+import { useEffect, useMemo, useState } from "react"
+import { useQueries } from "@tanstack/react-query"
 import { Shortcut, ShortcutType } from "../../providers/keybind-provider"
 import { useGlobalShortcuts } from "../../providers/keybind-provider/hooks"
-import { DynamicSearchResult, SearchArea } from "./types"
+import { sdk } from "../../lib/client"
+import { DATA_SEARCH_AREAS } from "./constants"
+import {
+  DynamicSearchResult,
+  DynamicSearchResultItem,
+  SearchArea,
+} from "./types"
 
 type UseSearchProps = {
   q?: string
@@ -9,15 +16,164 @@ type UseSearchProps = {
   area?: SearchArea
 }
 
+type DataSearchArea = (typeof DATA_SEARCH_AREAS)[number]
+
+type EntityConfig = {
+  area: DataSearchArea
+  title: string
+  endpoint: string
+  listKey: string
+  mapItem: (item: any, area: DataSearchArea) => DynamicSearchResultItem
+}
+
+const displayName = (customer: any): string => {
+  const name = [customer.first_name, customer.last_name]
+    .filter(Boolean)
+    .join(" ")
+    .trim()
+
+  return name || customer.company_name || customer.email || customer.id
+}
+
+const ENTITY_CONFIGS: EntityConfig[] = [
+  {
+    area: "orders",
+    title: "Orders",
+    endpoint: "/partners/orders",
+    listKey: "orders",
+    mapItem: (order, area) => ({
+      id: order.id,
+      title: `#${order.display_id ?? order.id}`,
+      subtitle: order.email ?? undefined,
+      to: `/orders/${order.id}`,
+      value: `${area}:${order.id}`,
+    }),
+  },
+  {
+    area: "designs",
+    title: "Designs",
+    endpoint: "/partners/designs",
+    listKey: "designs",
+    mapItem: (design, area) => ({
+      id: design.id,
+      title: design.name ?? design.id,
+      subtitle: design.status ?? undefined,
+      to: `/designs/${design.id}`,
+      thumbnail: design.thumbnail ?? undefined,
+      value: `${area}:${design.id}`,
+    }),
+  },
+  {
+    area: "inventory",
+    title: "Inventory",
+    endpoint: "/partners/inventory-items",
+    listKey: "inventory_items",
+    mapItem: (item, area) => ({
+      id: item.id,
+      title: item.title ?? item.sku ?? item.id,
+      subtitle: item.sku ?? undefined,
+      to: `/inventory/${item.id}`,
+      thumbnail: item.thumbnail ?? undefined,
+      value: `${area}:${item.id}`,
+    }),
+  },
+  {
+    area: "customers",
+    title: "Customers",
+    endpoint: "/partners/customers",
+    listKey: "customers",
+    mapItem: (customer, area) => ({
+      id: customer.id,
+      title: displayName(customer),
+      subtitle: customer.email ?? undefined,
+      to: `/customers/${customer.id}`,
+      value: `${area}:${customer.id}`,
+    }),
+  },
+]
+
+const useDebouncedValue = <T,>(value: T, delay = 300): T => {
+  const [debounced, setDebounced] = useState(value)
+
+  useEffect(() => {
+    const handle = setTimeout(() => setDebounced(value), delay)
+    return () => clearTimeout(handle)
+  }, [value, delay])
+
+  return debounced
+}
+
 export const useSearchResults = (props: UseSearchProps) => {
   const area = props.area ?? "all"
   const staticResults = useStaticSearchResults(area)
+  const dynamic = useDynamicSearchResults(props.q, props.limit, area)
 
   return {
     staticResults,
-    dynamicResults: [] as DynamicSearchResult[],
-    isFetching: false,
+    dynamicResults: dynamic.results,
+    isFetching: dynamic.isFetching,
   }
+}
+
+const useDynamicSearchResults = (
+  rawQuery: string | undefined,
+  limit: number,
+  area: SearchArea
+) => {
+  const q = useDebouncedValue((rawQuery ?? "").trim())
+  const enabled = q.length > 0
+
+  // "all" fans out to every entity; a specific data area targets just that one.
+  const activeConfigs = useMemo(() => {
+    if (area === "all") {
+      return ENTITY_CONFIGS
+    }
+
+    return ENTITY_CONFIGS.filter((config) => config.area === area)
+  }, [area])
+
+  const queries = useQueries({
+    queries: activeConfigs.map((config) => ({
+      queryKey: ["partner-search", config.area, q, limit] as const,
+      queryFn: () =>
+        sdk.client.fetch<Record<string, any>>(config.endpoint, {
+          method: "GET",
+          query: { q, limit },
+        }),
+      enabled,
+      staleTime: 30_000,
+    })),
+  })
+
+  const dataUpdatedAt = queries.map((query) => query.dataUpdatedAt).join(",")
+
+  const results = useMemo<DynamicSearchResult[]>(() => {
+    return activeConfigs.reduce<DynamicSearchResult[]>((acc, config, index) => {
+      const data = queries[index]?.data
+      const items = (data?.[config.listKey] ?? []) as any[]
+
+      if (!items.length) {
+        return acc
+      }
+
+      const count = typeof data?.count === "number" ? data.count : items.length
+
+      acc.push({
+        area: config.area,
+        title: config.title,
+        count,
+        hasMore: count > items.length,
+        items: items.map((item) => config.mapItem(item, config.area)),
+      })
+
+      return acc
+    }, [])
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [activeConfigs, dataUpdatedAt])
+
+  const isFetching = enabled && queries.some((query) => query.isFetching)
+
+  return { results, isFetching }
 }
 
 const useStaticSearchResults = (currentArea: SearchArea) => {
@@ -51,12 +207,12 @@ const useStaticSearchResults = (currentArea: SearchArea) => {
       default:
         filteredGroups = []
     }
- 
+
     return filteredGroups.map(([title, items]) => ({
       title,
       items,
     }))
   }, [globalCommands, currentArea])
- 
+
   return results
 }

--- a/apps/partner-ui/src/i18n/translations/en.json
+++ b/apps/partner-ui/src/i18n/translations/en.json
@@ -188,7 +188,10 @@
         "publishableApiKey": "Publishable API Keys",
         "secretApiKey": "Secret API Keys",
         "command": "Commands",
-        "navigation": "Navigation"
+        "navigation": "Navigation",
+        "orders": "Orders",
+        "designs": "Designs",
+        "customers": "Customers"
       }
     },
     "keyboardShortcuts": {


### PR DESCRIPTION
Closes #806.

## What
The partner-ui command palette (`cmdk`) was a de-dynamized fork of the stock Medusa admin search. `useSearchResults` hardcoded `dynamicResults: []` and never issued a network request — only static nav/command shortcuts showed. The whole UI (groups, thumbnails, "show more", loading state) was already built and the backing per-entity partner APIs already support `q`; only the fetch layer was stubbed.

## How
Re-dynamized `useSearchResults` with a **debounced parallel fan-out** (`useQueries`) to the `q`-supporting partner endpoints, mapping each response into the `DynamicSearchResult` shape the UI already consumes:

| Group | Endpoint | Link |
|---|---|---|
| Orders | `/partners/orders` | `/orders/:id` |
| Designs | `/partners/designs` | `/designs/:id` |
| Inventory | `/partners/inventory-items` | `/inventory/:id` |
| Customers | `/partners/customers` | `/customers/:id` |

- Added data-entity values to `SEARCH_AREAS` so the existing per-entity **"show more"** affordance and area filter dropdown work. `all` fans out to every entity (3 each); selecting a specific area targets just that one with the larger limit and supports load-more.
- Real `isFetching` now drives the input spinner + loading state.
- Added i18n `app.search.groups.{orders,designs,customers}` labels (`inventory` already existed).

## Notes
- 300ms debounce; queries only fire when the query string is non-empty; `staleTime: 30s`.
- Products deliberately left out for now — the partner products list route is store-scoped (`/partners/stores/:id/products`) and doesn't accept `q`; adding it is a separate backend touch noted in #806.
- Existing partner `q` filters are in-app substring matching (no index) — fine for a search box, matching the pre-existing behavior.

## Verify
Open the partner dashboard, hit the search palette (⌘K), type an order #/design name/SKU/customer email → grouped live results appear; "show more" narrows to that entity.

🤖 Generated with [Claude Code](https://claude.com/claude-code)