### PR TITLE
feat(partner): stamp owning partner on retail provenance runs [#1121]

### DIFF
--- a/apps/backend/integration-tests/http/order-fulfillment-production-runs.spec.ts
+++ b/apps/backend/integration-tests/http/order-fulfillment-production-runs.spec.ts
@@ -77,10 +77,12 @@ setupSharedTestSuite(() => {
     }
 
     // Create an order (not yet fulfilled) with the given product line items.
+    // An optional sales channel scopes the order to a partner's store (#1121).
     const createOrder = async (
       container: any,
       unique: number,
-      productIds: string[]
+      productIds: string[],
+      salesChannelId?: string
     ) => {
       const orderService = container.resolve(
         Modules.ORDER
@@ -89,6 +91,7 @@ setupSharedTestSuite(() => {
         region_id: regionId,
         currency_code: "usd",
         email: `fulfill-${unique}@jyt.test`,
+        ...(salesChannelId ? { sales_channel_id: salesChannelId } : {}),
         // Title-only line items carrying product_id (no variant → no inventory
         // reservation, so the manual fulfillment path just works — same shape
         // the order-placed subscriber test uses).
@@ -100,6 +103,71 @@ setupSharedTestSuite(() => {
         })),
       } as any)
       return createdOrder.id as string
+    }
+
+    // #1121 — a partner with a store whose default sales channel defines retail
+    // ownership. Returns the partner id + that channel id so an order placed in
+    // the channel resolves back to the partner.
+    const createPartnerWithStore = async (
+      api: any,
+      container: any,
+      unique: number
+    ) => {
+      const email = `fulfill-partner-${unique}@jyt.test`
+      const password = "supersecret"
+      await api.post("/auth/partner/emailpass/register", { email, password })
+      let login = await api.post("/auth/partner/emailpass", { email, password })
+      let headers = { Authorization: `Bearer ${login.data.token}` }
+
+      const partnerRes = await api.post(
+        "/partners",
+        {
+          name: `Fulfill Partner ${unique}`,
+          handle: `fulfill-partner-${unique}`,
+          admin: { email, first_name: "Priya", last_name: "Partner" },
+        },
+        { headers }
+      )
+      const partnerId = partnerRes.data.partner.id as string
+
+      // Re-login to pick up partner context, then create a store.
+      login = await api.post("/auth/partner/emailpass", { email, password })
+      headers = { Authorization: `Bearer ${login.data.token}` }
+
+      await api.post(
+        "/partners/stores",
+        {
+          store: {
+            name: `Fulfill Store ${unique}`,
+            supported_currencies: [{ currency_code: "usd", is_default: true }],
+          },
+          region: {
+            name: "Fulfill Partner Region",
+            currency_code: "usd",
+            countries: ["us"],
+          },
+          location: {
+            name: "Fulfill Partner Warehouse",
+            address: {
+              address_1: "1 Loom Lane",
+              city: "Jaipur",
+              postal_code: "302001",
+              country_code: "IN",
+            },
+          },
+        },
+        { headers }
+      )
+
+      const q = container.resolve(ContainerRegistrationKeys.QUERY) as any
+      const { data: partners } = await q.graph({
+        entity: "partners",
+        fields: ["id", "stores.default_sales_channel_id"],
+        filters: { id: partnerId },
+      })
+      const salesChannelId = partners?.[0]?.stores?.[0]
+        ?.default_sales_channel_id as string
+      return { partnerId, salesChannelId }
     }
 
     // Fulfill the whole order via the shared helper (resolves shipping option +
@@ -200,6 +268,43 @@ setupSharedTestSuite(() => {
         filters: { order_id: orderId },
       })
       expect((runs2 || []).length).toBe(1)
+    })
+
+    // #1121 — a retail order placed in a partner store's default sales channel
+    // must stamp the owning partner on the minted provenance run (product +
+    // partner + order provenance). Previously partner_id was always null.
+    it("stamps the owning partner on a retail (sales-channel-scoped) run", async () => {
+      const { api, getContainer } = getSharedTestEnv()
+      const container = getContainer()
+      const query = container.resolve(ContainerRegistrationKeys.QUERY) as any
+      const unique = Date.now()
+
+      const { partnerId, salesChannelId } = await createPartnerWithStore(
+        api,
+        container,
+        unique
+      )
+      expect(salesChannelId).toBeTruthy()
+
+      const productId = await createProduct(api, unique, "retail")
+      const orderId = await createOrder(
+        container,
+        unique,
+        [productId],
+        salesChannelId
+      )
+      await fulfillOrder(container, orderId)
+
+      const runs = await waitForRuns(query, orderId, 1, [
+        "id",
+        "product_id",
+        "order_id",
+        "partner_id",
+        "status",
+      ])
+      expect(runs.length).toBe(1)
+      expect(runs[0].product_id).toBe(productId)
+      expect(runs[0].partner_id).toBe(partnerId)
     })
 
     it("completes (not double-creates) the design-backed run order.placed minted, and mints the bare product's run", async () => {

--- a/apps/backend/src/admin/widgets/product-designs.tsx
+++ b/apps/backend/src/admin/widgets/product-designs.tsx
@@ -205,13 +205,14 @@ function ProductProvenanceRunsSection({ productId }: { productId: string }) {
       </div>
 
       <div className="flex flex-col divide-y divide-ui-border-base rounded-lg border border-ui-border-base overflow-hidden">
-        <div className="grid grid-cols-3 px-3 py-1.5 bg-ui-bg-subtle">
+        <div className="grid grid-cols-4 px-3 py-1.5 bg-ui-bg-subtle">
           <Text size="xsmall" weight="plus" className="text-ui-fg-subtle">Status</Text>
           <Text size="xsmall" weight="plus" className="text-ui-fg-subtle">Order</Text>
+          <Text size="xsmall" weight="plus" className="text-ui-fg-subtle">Partner</Text>
           <Text size="xsmall" weight="plus" className="text-ui-fg-subtle text-right">Produced</Text>
         </div>
         {productOnly.map((run) => (
-          <div key={run.id} className="grid grid-cols-3 px-3 py-2 items-center">
+          <div key={run.id} className="grid grid-cols-4 px-3 py-2 items-center">
             <StatusBadge color={RUN_STATUS_COLOR[run.status ?? ""] ?? "grey"}>
               {runStatusLabel(run.status ?? "")}
             </StatusBadge>
@@ -228,6 +229,11 @@ function ProductProvenanceRunsSection({ productId }: { productId: string }) {
             ) : (
               <Text size="xsmall" className="text-ui-fg-muted">—</Text>
             )}
+            {/* #1121 — retail runs now carry the owning partner (resolved from
+                the order's sales channel), so provenance is product+partner+order. */}
+            <Text size="xsmall" className="text-ui-fg-subtle truncate">
+              {run.partner_id ? run.partner_id.slice(0, 8) + "…" : "—"}
+            </Text>
             <Text size="xsmall" className="text-right">
               {(run.produced_quantity ?? run.quantity ?? 0).toLocaleString()}
             </Text>

--- a/apps/backend/src/modules/partner_billing/resolve-retail-partner.ts
+++ b/apps/backend/src/modules/partner_billing/resolve-retail-partner.ts
@@ -1,4 +1,5 @@
 import { ContainerRegistrationKeys } from "@medusajs/framework/utils"
+import partnerOrderLink from "../../links/partner-order"
 
 /**
  * Resolve the owning partner for a RETAIL order from its sales channel.
@@ -23,6 +24,40 @@ export async function resolveRetailPartnerId(
   if (!salesChannelId) return null
   const map = await buildRetailPartnerBySalesChannel(container)
   return map.get(salesChannelId) || null
+}
+
+/**
+ * Resolve the owning partner for ANY order — the same two-rule ownership the
+ * partner API enforces (`validatePartnerOrderOwnership`) and the partner-order
+ * email uses:
+ *   1. Work order: the explicit partner↔order link (source of truth) — a
+ *      partner can serve another partner's store, so work-orders need the link.
+ *   2. Retail order: `order.sales_channel_id === partner.store.default_sales_channel_id`.
+ *
+ * Shared seam for provenance-run partner attribution (#1121) and #1111 S4.
+ * Never throws — returns null when no partner owns the order.
+ */
+export async function resolveOwningPartnerId(
+  container: any,
+  input: { orderId: string; salesChannelId?: string | null }
+): Promise<string | null> {
+  // 1) Work order: explicit partner↔order link.
+  try {
+    const query = container.resolve(ContainerRegistrationKeys.QUERY) as any
+    const { data: links } = await query.graph({
+      entity: partnerOrderLink.entryPoint,
+      fields: ["partner_id"],
+      filters: { order_id: input.orderId },
+      pagination: { skip: 0, take: 1 },
+    })
+    const linked = (links?.[0] as any)?.partner_id
+    if (linked) return linked
+  } catch {
+    // link table absent / empty — fall through to the retail rule
+  }
+
+  // 2) Retail order: sales-channel ownership rule.
+  return resolveRetailPartnerId(container, input.salesChannelId)
 }
 
 /**

--- a/apps/backend/src/subscribers/order-fullfilled.ts
+++ b/apps/backend/src/subscribers/order-fullfilled.ts
@@ -6,6 +6,7 @@ import { sendPartnerOrderFulfilledWorkflow } from "../workflows/email/workflows/
 import { createProductionRunWorkflow } from "../workflows/production-runs/create-production-run"
 import { completeProvenanceRunWorkflow } from "../workflows/production-runs/complete-provenance-run"
 import { planLineItemRunAction } from "../lib/plan-fulfillment-production-runs"
+import { resolveOwningPartnerId } from "../modules/partner_billing/resolve-retail-partner"
 
 // #1112 — "fulfilled from produced stock" ⇒ retroactively mint a COMPLETED
 // production run per fulfilled line item, hung off the Product spine, carrying
@@ -40,6 +41,7 @@ async function createFulfillmentProductionRuns(
       entity: "order",
       fields: [
         "id",
+        "sales_channel_id",
         "items.id",
         "items.product_id",
         "items.variant_id",
@@ -50,6 +52,15 @@ async function createFulfillmentProductionRuns(
     const itemById = new Map<string, any>(
       (order?.items || []).map((it: any) => [it.id, it])
     )
+
+    // #1121 — resolve the owning partner once for the whole order so every
+    // provenance run carries product + partner + order provenance (retail runs
+    // were previously minted with partner_id null). Same two-rule ownership the
+    // partner API enforces: work-order link → retail sales-channel rule.
+    const partnerId = await resolveOwningPartnerId(container, {
+      orderId: data.order_id,
+      salesChannelId: order?.sales_channel_id,
+    })
 
     for (const fi of fulfilledItems) {
       const lineItemId = fi.line_item_id as string
@@ -89,6 +100,7 @@ async function createFulfillmentProductionRuns(
           produced_quantity: plan.quantity,
           product_id: plan.product_id,
           variant_id: plan.variant_id,
+          partner_id: partnerId ?? undefined,
           order_id: data.order_id,
           order_line_item_id: lineItemId,
           // Born terminal — the goods are already produced & shipping.


### PR DESCRIPTION
Closes #1121. Follow-up to #1112 (PR #1120).

## Problem
Retail-fulfillment provenance runs were minted with **`partner_id` null** — we never resolved the owning partner for a retail (sales-channel-scoped) order. The epic's vision is *product + partner + order* provenance, but the trail showed order + status + qty with **no partner**, and the admin "Production Runs" section had no partner column for these runs.

## Fix
Resolve the owning partner **once per order** in `subscribers/order-fullfilled.ts` (before `createProductionRunWorkflow`) and stamp `partner_id` on each minted run. Ownership uses the same two rules the partner API enforces (`validatePartnerOrderOwnership`):
1. **Work order** — explicit partner↔order link (source of truth).
2. **Retail order** — `order.sales_channel_id === partner.store.default_sales_channel_id`.

### Changes
- **Shared resolver** `resolveOwningPartnerId(container, { orderId, salesChannelId })` added next to `resolveRetailPartnerId` in `modules/partner_billing/resolve-retail-partner.ts` — the same seam #1111 S4 (retail partner-origin) needs, so the two paths can't drift.
- **Subscriber** fetches `sales_channel_id`, resolves the partner once, stamps `partner_id: partnerId ?? undefined` on the run input.
- **Admin surface** (`admin/widgets/product-designs.tsx`) — product-only "Production Runs" section gains a **Partner** column (matches the sibling design-runs section's `partner_id` display), now populated.

## Test
New case in `order-fulfillment-production-runs.spec.ts`: a retail order placed in a partner store's default sales channel mints a run whose `partner_id` === the owning partner. Full suite green:

```
✓ mints a COMPLETED product-only run … for a design-less product
✓ stamps the owning partner on a retail (sales-channel-scoped) run   ← new
✓ completes (not double-creates) the design-backed run …
```

## Notes / follow-ups (separate issues)
- Admin column shows the truncated `partner_id` (consistent with the existing sibling section); a human-readable partner **name** would need the runs API to expose it — not in scope here.
- Partner-UI mirror of this trail is deferred to **#1124**.
- Historical retail runs minted before this change keep `partner_id` null; a one-off backfill (reuse `buildRetailPartnerBySalesChannel`) can be filed if we want the trail retroactively complete.

🤖 Generated with [Claude Code](https://claude.com/claude-code)