### PR TITLE
feat(production-runs): aggregate qty, cancel reversal, race guard [#1123]

### DIFF
--- a/apps/backend/integration-tests/http/order-fulfillment-production-runs.spec.ts
+++ b/apps/backend/integration-tests/http/order-fulfillment-production-runs.spec.ts
@@ -5,9 +5,14 @@ import { setupSharedTestSuite, getSharedTestEnv } from "./shared-test-setup"
 import { createAdminUser, getAuthHeaders } from "../helpers/create-admin-user"
 import { seedCommonEmailTemplates } from "../helpers/seed-email-templates"
 import { setupCheckoutInfrastructure } from "../helpers/setup-checkout-infrastructure"
-import { ensureOrderFulfillment } from "../../src/workflows/orders/fulfillment-context"
+import { createOrderFulfillmentWorkflow } from "@medusajs/medusa/core-flows"
+import {
+  ensureOrderFulfillment,
+  resolvePlainFulfillmentContext,
+} from "../../src/workflows/orders/fulfillment-context"
 import orderPlacedHandler from "../../src/subscribers/order-placed"
 import orderFulfilledHandler from "../../src/subscribers/order-fullfilled"
+import orderCanceledProvenanceRunsHandler from "../../src/subscribers/order-canceled-provenance-runs"
 
 jest.setTimeout(60 * 1000)
 
@@ -189,6 +194,70 @@ setupSharedTestSuite(() => {
       return { orderId, fulfillmentId }
     }
 
+    // Create a single-line order with an explicit quantity (for partial
+    // fulfillment). Returns the order id + the line item id.
+    const createSingleLineOrder = async (
+      container: any,
+      unique: number,
+      productId: string,
+      quantity: number
+    ) => {
+      const orderService = container.resolve(
+        Modules.ORDER
+      ) as IOrderModuleService
+      const createdOrder: any = await orderService.createOrders({
+        region_id: regionId,
+        currency_code: "usd",
+        email: `fulfill-partial-${unique}@jyt.test`,
+        items: [
+          { title: "Partial Line", quantity, unit_price: 1000, product_id: productId },
+        ],
+      } as any)
+      const lineItemId = createdOrder.items[0].id as string
+      return { orderId: createdOrder.id as string, lineItemId }
+    }
+
+    // Fulfill a specific quantity of one line item (a partial shipment). Emits
+    // `order.fulfillment_created`, firing the real subscriber.
+    const fulfillPartial = async (
+      container: any,
+      orderId: string,
+      lineItemId: string,
+      quantity: number
+    ) => {
+      const { shippingOptionId, locationId } =
+        await resolvePlainFulfillmentContext(container)
+      await createOrderFulfillmentWorkflow(container).run({
+        input: {
+          order_id: orderId,
+          items: [{ id: lineItemId, quantity }],
+          shipping_option_id: shippingOptionId,
+          location_id: locationId,
+          no_notification: true,
+        } as any,
+      })
+    }
+
+    // Poll a single line item's run until it reaches an expected produced qty.
+    const waitForProducedQuantity = async (
+      query: any,
+      orderId: string,
+      expected: number
+    ) => {
+      let run: any
+      for (let i = 0; i < 40; i++) {
+        const { data } = await query.graph({
+          entity: "production_runs",
+          fields: ["id", "produced_quantity", "status"],
+          filters: { order_id: orderId },
+        })
+        run = (data || [])[0]
+        if (run && Number(run.produced_quantity) === expected) break
+        await new Promise((r) => setTimeout(r, 150))
+      }
+      return run
+    }
+
     // The real `order.fulfillment_created` subscriber fires (async) when
     // ensureOrderFulfillment emits the event — poll until the runs settle.
     const waitForRuns = async (
@@ -305,6 +374,72 @@ setupSharedTestSuite(() => {
       expect(runs.length).toBe(1)
       expect(runs[0].product_id).toBe(productId)
       expect(runs[0].partner_id).toBe(partnerId)
+    })
+
+    // #1123 — a line fulfilled in two shipments (1 then 2) must end with a single
+    // run whose produced_quantity is the CUMULATIVE 3, not the first shipment's 1.
+    it("aggregates produced_quantity across partial fulfillments", async () => {
+      const { api, getContainer } = getSharedTestEnv()
+      const container = getContainer()
+      const query = container.resolve(ContainerRegistrationKeys.QUERY) as any
+      const unique = Date.now()
+
+      const productId = await createProduct(api, unique, "partial")
+      const { orderId, lineItemId } = await createSingleLineOrder(
+        container,
+        unique,
+        productId,
+        3
+      )
+
+      // First shipment: qty 1 → run minted at produced_quantity 1.
+      await fulfillPartial(container, orderId, lineItemId, 1)
+      const afterFirst = await waitForProducedQuantity(query, orderId, 1)
+      expect(afterFirst).toBeTruthy()
+      expect(Number(afterFirst.produced_quantity)).toBe(1)
+
+      // Second shipment: qty 2 → same run bumped to cumulative 3 (not a 2nd run).
+      await fulfillPartial(container, orderId, lineItemId, 2)
+      const afterSecond = await waitForProducedQuantity(query, orderId, 3)
+      expect(afterSecond).toBeTruthy()
+      expect(Number(afterSecond.produced_quantity)).toBe(3)
+
+      const { data: allRuns } = await query.graph({
+        entity: "production_runs",
+        fields: ["id"],
+        filters: { order_id: orderId },
+      })
+      expect((allRuns || []).length).toBe(1)
+    })
+
+    // #1123 — canceling the order voids its provenance run (nothing shipped),
+    // soft-deleting it so the trail doesn't claim stock was produced.
+    it("soft-deletes the provenance run when the order is canceled", async () => {
+      const { api, getContainer } = getSharedTestEnv()
+      const container = getContainer()
+      const query = container.resolve(ContainerRegistrationKeys.QUERY) as any
+      const unique = Date.now()
+
+      const productId = await createProduct(api, unique, "cancel")
+      const { orderId } = await createAndFulfillOrder(container, unique, [
+        productId,
+      ])
+      const runs = await waitForRuns(query, orderId, 1, ["id", "status"])
+      expect(runs.length).toBe(1)
+
+      // Fire the real order.canceled provenance handler.
+      await orderCanceledProvenanceRunsHandler({
+        event: { data: { id: orderId } },
+        container,
+      } as any)
+
+      // The run is soft-deleted → query.graph excludes it by default.
+      const { data: after } = await query.graph({
+        entity: "production_runs",
+        fields: ["id"],
+        filters: { order_id: orderId },
+      })
+      expect((after || []).length).toBe(0)
     })
 
     it("completes (not double-creates) the design-backed run order.placed minted, and mints the bare product's run", async () => {

--- a/apps/backend/src/lib/reconcile-provenance-runs.ts
+++ b/apps/backend/src/lib/reconcile-provenance-runs.ts
@@ -1,0 +1,203 @@
+// #1123 — reconcile the provenance production runs for a set of retail order
+// line items against the CURRENT cumulative fulfilled quantity. Shared by the
+// fulfillment-created / fulfillment-canceled / order-canceled subscribers so
+// the three paths can never drift.
+//
+// Cumulative quantity = the sum of quantities across all NON-canceled
+// fulfillments of the order for a line item. This is the accurate produced/
+// shipped yield: a line qty 10 fulfilled 4-then-6 reconciles to 10; if the 6 is
+// later canceled it reconciles back down to 4; if everything is canceled (or the
+// order is voided) it reconciles to 0 → the run is soft-deleted (no stock
+// shipped, so the provenance trail must not claim otherwise).
+//
+// Only runs THIS system minted as retail provenance (`isOwnedProvenanceRun`) are
+// quantity-adjusted or soft-deleted. Real production runs (design work-orders,
+// runs that went through the shop) are never touched here.
+
+import { ContainerRegistrationKeys } from "@medusajs/framework/utils"
+import type { Logger } from "@medusajs/types"
+import { PRODUCTION_RUNS_MODULE } from "../modules/production_runs"
+import type ProductionRunService from "../modules/production_runs/service"
+import { createProductionRunWorkflow } from "../workflows/production-runs/create-production-run"
+import { completeProvenanceRunWorkflow } from "../workflows/production-runs/complete-provenance-run"
+import { resolveOwningPartnerId } from "../modules/partner_billing/resolve-retail-partner"
+import {
+  getProductionRunForLineItem,
+  isOwnedProvenanceRun,
+  PLAN_UNIQUE_VIOLATION,
+} from "./resolve-line-item-production"
+import { planLineItemRunAction } from "./plan-fulfillment-production-runs"
+
+type ReconcileInput = {
+  orderId: string
+  /** Line items to reconcile (this fulfillment's items, or the whole order). */
+  lineItemIds: string[]
+  /** Order-level cancellation: force cumulative 0 so every owned run is voided. */
+  voided?: boolean
+}
+
+/**
+ * Sum the fulfilled quantity per line item across all non-canceled fulfillments
+ * of the order. Fulfillments are reached THROUGH the order (they carry no
+ * queryable `order_id` of their own — the relation is a link). Returns a
+ * `line_item_id → quantity` map.
+ */
+function buildCumulativeFulfilledByLine(order: any): Map<string, number> {
+  const map = new Map<string, number>()
+  for (const f of order?.fulfillments || []) {
+    // A canceled fulfillment contributed no shipped stock.
+    if (f?.canceled_at) continue
+    for (const it of f?.items || []) {
+      if (!it?.line_item_id) continue
+      const prev = map.get(it.line_item_id) || 0
+      map.set(it.line_item_id, prev + (Number(it.quantity) || 0))
+    }
+  }
+  return map
+}
+
+export async function reconcileProvenanceRunsForOrderLines(
+  container: any,
+  input: ReconcileInput,
+  logger: Logger
+): Promise<void> {
+  const { orderId, lineItemIds, voided = false } = input
+  if (!lineItemIds.length) return
+
+  try {
+    const query = container.resolve(ContainerRegistrationKeys.QUERY) as any
+    const service: ProductionRunService = container.resolve(
+      PRODUCTION_RUNS_MODULE
+    )
+
+    // Resolve line_item_id → { product_id, variant_id } + the sales channel for
+    // partner attribution (#1121), in one order read.
+    const { data: orders } = await query.graph({
+      entity: "order",
+      fields: [
+        "id",
+        "sales_channel_id",
+        "items.id",
+        "items.product_id",
+        "items.variant_id",
+        "fulfillments.canceled_at",
+        "fulfillments.items.line_item_id",
+        "fulfillments.items.quantity",
+      ],
+      filters: { id: orderId },
+    })
+    const order = (orders || [])[0]
+    const itemById = new Map<string, any>(
+      (order?.items || []).map((it: any) => [it.id, it])
+    )
+
+    const partnerId = await resolveOwningPartnerId(container, {
+      orderId,
+      salesChannelId: order?.sales_channel_id,
+    })
+
+    const cumulativeByLine = voided
+      ? new Map<string, number>()
+      : buildCumulativeFulfilledByLine(order)
+
+    for (const lineItemId of lineItemIds) {
+      try {
+        const orderItem = itemById.get(lineItemId)
+        const cumulative = voided ? 0 : cumulativeByLine.get(lineItemId) || 0
+
+        if (cumulative <= 0) {
+          // Nothing shipped for this line (fulfillment fully canceled or order
+          // voided) → soft-delete the run we minted, if any. Never touch a real
+          // production run.
+          const existing = await getProductionRunForLineItem(query, lineItemId)
+          if (isOwnedProvenanceRun(existing)) {
+            await service.softDeleteProductionRuns([existing!.id])
+            logger.info(
+              `[provenance-reconcile] Soft-deleted provenance run ${existing!.id} for line item ${lineItemId} (cumulative fulfilled qty 0)`
+            )
+          }
+          continue
+        }
+
+        const plan = await planLineItemRunAction(query, {
+          lineItemId,
+          productId: orderItem?.product_id,
+          variantId: orderItem?.variant_id,
+          quantity: cumulative,
+        })
+
+        if (plan?.action === "create") {
+          await createProductionRunWorkflow(container).run({
+            input: {
+              design_id: plan.design_id ?? undefined,
+              quantity: plan.quantity,
+              produced_quantity: plan.quantity,
+              product_id: plan.product_id,
+              variant_id: plan.variant_id,
+              partner_id: partnerId ?? undefined,
+              order_id: orderId,
+              order_line_item_id: lineItemId,
+              status: "completed",
+              skip_unified_projection: true,
+              metadata: {
+                source: "order.fulfillment_created",
+                is_custom_design: plan.is_custom_design,
+                design_backed: Boolean(plan.design_id),
+              },
+            },
+          })
+          logger.info(
+            `[provenance-reconcile] Minted ${
+              plan.design_id ? "design-backed" : "product-only"
+            } production run for line item ${lineItemId} (qty ${plan.quantity}, product ${plan.product_id})`
+          )
+        } else if (plan?.action === "complete") {
+          await completeProvenanceRunWorkflow(container).run({
+            input: {
+              production_run_id: plan.production_run_id,
+              produced_quantity: plan.quantity,
+            },
+          })
+          logger.info(
+            `[provenance-reconcile] Completed pre-production run ${plan.production_run_id} for line item ${lineItemId} (qty ${plan.quantity}, shipped from stock)`
+          )
+        } else {
+          // No create/complete → a run already exists that's completed or in
+          // production. If it's OUR provenance run and the cumulative fulfilled
+          // qty has since grown/shrunk, bump it to match (#1123 aggregate).
+          const existing = await getProductionRunForLineItem(query, lineItemId)
+          if (
+            isOwnedProvenanceRun(existing) &&
+            (existing!.produced_quantity ?? 0) !== cumulative
+          ) {
+            await completeProvenanceRunWorkflow(container).run({
+              input: {
+                production_run_id: existing!.id,
+                produced_quantity: cumulative,
+              },
+            })
+            logger.info(
+              `[provenance-reconcile] Adjusted provenance run ${existing!.id} produced_quantity → ${cumulative} for line item ${lineItemId}`
+            )
+          }
+        }
+      } catch (e: any) {
+        // A concurrent/redelivered event lost the create race against the new
+        // unique index — the run exists, so this is a no-op, not a failure.
+        if (e?.code === PLAN_UNIQUE_VIOLATION || /unique/i.test(e?.message || "")) {
+          logger.info(
+            `[provenance-reconcile] Line item ${lineItemId} already has a run (unique guard) — skipping`
+          )
+          continue
+        }
+        logger.warn(
+          `[provenance-reconcile] Failed to reconcile line item ${lineItemId} for order ${orderId}: ${e?.message || e}`
+        )
+      }
+    }
+  } catch (e: any) {
+    logger.warn(
+      `[provenance-reconcile] Failed to reconcile order ${orderId}: ${e?.message || e}`
+    )
+  }
+}

--- a/apps/backend/src/lib/resolve-line-item-production.ts
+++ b/apps/backend/src/lib/resolve-line-item-production.ts
@@ -4,6 +4,10 @@
 // paths use. Keeping it in one place guarantees the two paths agree so they
 // never double-create a run for the same line item.
 
+// Postgres unique_violation SQLSTATE — raised when the partial unique index on
+// production_runs.order_line_item_id catches a concurrent double-create (#1123).
+export const PLAN_UNIQUE_VIOLATION = "23505"
+
 export type ResolvedLineItemDesign = {
   designId: string | null
   isCustomDesign: boolean
@@ -58,22 +62,57 @@ export async function hasProductionRunForLineItem(
   return (await getProductionRunForLineItem(query, lineItemId)) !== null
 }
 
+export type LineItemProductionRun = {
+  id: string
+  status: string
+  produced_quantity: number | null
+  design_id: string | null
+  metadata: Record<string, any> | null
+}
+
 /**
  * Like {@link hasProductionRunForLineItem} but returns the existing run's id +
- * status so the fulfillment path can decide whether to complete it (still
- * pre-production, i.e. shipped from stock) vs leave it (production already
- * underway). #1126.
+ * status (and the fields the reconcile path needs) so the fulfillment path can
+ * decide whether to complete it (still pre-production, i.e. shipped from stock)
+ * vs leave it (production already underway, #1126), bump its produced quantity
+ * on a later fulfillment, or soft-delete it on cancellation (#1123).
  */
 export async function getProductionRunForLineItem(
   query: any,
   lineItemId: string
-): Promise<{ id: string; status: string } | null> {
+): Promise<LineItemProductionRun | null> {
   const { data: existing } = await query.graph({
     entity: "production_runs",
-    fields: ["id", "status"],
+    fields: ["id", "status", "produced_quantity", "design_id", "metadata"],
     filters: { order_line_item_id: lineItemId },
     pagination: { skip: 0, take: 1 },
   })
   const run = (existing || [])[0]
-  return run ? { id: run.id, status: run.status } : null
+  return run
+    ? {
+        id: run.id,
+        status: run.status,
+        produced_quantity: run.produced_quantity ?? null,
+        design_id: run.design_id ?? null,
+        metadata: run.metadata ?? null,
+      }
+    : null
+}
+
+/**
+ * A provenance run this system minted from retail fulfillment (product-only,
+ * born terminal). ONLY these are quantity-reconciled / soft-deleted by the
+ * fulfillment + cancellation paths — a real production run (design work-order,
+ * or a run that actually went through the shop) is never touched. Identified by
+ * the create-side marker `metadata.source === "order.fulfillment_created"` and
+ * the absence of a backing design.
+ */
+export function isOwnedProvenanceRun(
+  run: Pick<LineItemProductionRun, "design_id" | "metadata"> | null | undefined
+): boolean {
+  if (!run) return false
+  return (
+    run.design_id == null &&
+    run.metadata?.source === "order.fulfillment_created"
+  )
 }

--- a/apps/backend/src/modules/production_runs/migrations/Migration20260722120000.ts
+++ b/apps/backend/src/modules/production_runs/migrations/Migration20260722120000.ts
@@ -1,0 +1,32 @@
+import { Migration } from "@medusajs/framework/mikro-orm/migrations";
+
+/**
+ * #1123 — enforce "at most one ACTIVE production run per order line item" at the
+ * database level. The idempotency guard (`getProductionRunForLineItem`) is a
+ * read-then-write check with no constraint, so concurrent / redelivered
+ * `order.fulfillment_created` events (or order.placed racing fulfillment) could
+ * both pass it and double-create. This partial unique index closes that race —
+ * the loser gets a unique_violation, which the reconcile path treats as a no-op.
+ *
+ * Partial on two predicates:
+ *   - `order_line_item_id is not null` — design/partner runs without a line item
+ *     (parent runs, samples) are unconstrained.
+ *   - `deleted_at is null` — a soft-deleted provenance run (canceled fulfillment)
+ *     must not block re-minting if the line is fulfilled again later.
+ *
+ * Hand-written incremental (the generator emits a full snapshot). See memory
+ * `reference_medusa_migration_create_if_not_exists_hazard`.
+ */
+export class Migration20260722120000 extends Migration {
+  override async up(): Promise<void> {
+    this.addSql(
+      `create unique index if not exists "IDX_production_runs_order_line_item_active" on "production_runs" ("order_line_item_id") where "order_line_item_id" is not null and "deleted_at" is null;`
+    );
+  }
+
+  override async down(): Promise<void> {
+    this.addSql(
+      `drop index if exists "IDX_production_runs_order_line_item_active";`
+    );
+  }
+}

--- a/apps/backend/src/subscribers/order-canceled-provenance-runs.ts
+++ b/apps/backend/src/subscribers/order-canceled-provenance-runs.ts
@@ -1,0 +1,45 @@
+import { SubscriberArgs, type SubscriberConfig } from "@medusajs/framework"
+import { ContainerRegistrationKeys } from "@medusajs/framework/utils"
+import type { Logger } from "@medusajs/types"
+import { reconcileProvenanceRunsForOrderLines } from "../lib/reconcile-provenance-runs"
+
+// #1123 — a canceled order voids its retail provenance runs: nothing produced
+// for it ever shipped, so the trail must not claim otherwise. Reconcile every
+// line item with `voided: true` (cumulative forced to 0), which soft-deletes the
+// runs THIS system minted. Real production runs (design work-orders) are left
+// alone. A separate subscriber (not folded into the existing order-canceled
+// email handler) so provenance stays isolated from notifications.
+export default async function orderCanceledProvenanceRunsHandler({
+  event: { data },
+  container,
+}: SubscriberArgs<{ id: string; no_notification?: boolean }>) {
+  const logger = container.resolve(ContainerRegistrationKeys.LOGGER) as Logger
+
+  try {
+    const query = container.resolve(ContainerRegistrationKeys.QUERY) as any
+
+    const { data: orders } = await query.graph({
+      entity: "order",
+      fields: ["id", "items.id"],
+      filters: { id: data.id },
+    })
+    const lineItemIds: string[] = ((orders || [])[0]?.items || [])
+      .map((it: any) => it?.id)
+      .filter(Boolean)
+    if (!lineItemIds.length) return
+
+    await reconcileProvenanceRunsForOrderLines(
+      container,
+      { orderId: data.id, lineItemIds, voided: true },
+      logger
+    )
+  } catch (e: any) {
+    logger.warn(
+      `[order.canceled] Failed to void provenance runs for order ${data.id}: ${e?.message || e}`
+    )
+  }
+}
+
+export const config: SubscriberConfig = {
+  event: "order.canceled",
+}

--- a/apps/backend/src/subscribers/order-fulfillment-canceled.ts
+++ b/apps/backend/src/subscribers/order-fulfillment-canceled.ts
@@ -1,0 +1,49 @@
+import { SubscriberArgs, type SubscriberConfig } from "@medusajs/framework"
+import { ContainerRegistrationKeys } from "@medusajs/framework/utils"
+import type { Logger } from "@medusajs/types"
+import { reconcileProvenanceRunsForOrderLines } from "../lib/reconcile-provenance-runs"
+
+// #1123 — a canceled fulfillment means its stock never shipped. Reconcile the
+// affected line items: the reconcile recomputes the cumulative fulfilled qty
+// across the order's NON-canceled fulfillments, so the provenance run either
+// drops to the reduced qty (line still partly fulfilled) or is soft-deleted
+// (nothing left shipped). Only runs THIS system minted are touched.
+export default async function orderFulfillmentCanceledHandler({
+  event: { data },
+  container,
+}: SubscriberArgs<{
+  order_id: string
+  fulfillment_id: string
+  no_notification?: boolean
+}>) {
+  const logger = container.resolve(ContainerRegistrationKeys.LOGGER) as Logger
+
+  try {
+    const query = container.resolve(ContainerRegistrationKeys.QUERY) as any
+
+    // The line items the canceled fulfillment covered.
+    const { data: fulfillments } = await query.graph({
+      entity: "fulfillment",
+      fields: ["id", "items.line_item_id"],
+      filters: { id: data.fulfillment_id },
+    })
+    const lineItemIds: string[] = ((fulfillments || [])[0]?.items || [])
+      .map((fi: any) => fi?.line_item_id)
+      .filter(Boolean)
+    if (!lineItemIds.length) return
+
+    await reconcileProvenanceRunsForOrderLines(
+      container,
+      { orderId: data.order_id, lineItemIds },
+      logger
+    )
+  } catch (e: any) {
+    logger.warn(
+      `[order.fulfillment_canceled] Failed to reconcile provenance runs for order ${data.order_id}: ${e?.message || e}`
+    )
+  }
+}
+
+export const config: SubscriberConfig = {
+  event: "order.fulfillment_canceled",
+}

--- a/apps/backend/src/subscribers/order-fullfilled.ts
+++ b/apps/backend/src/subscribers/order-fullfilled.ts
@@ -3,132 +3,40 @@ import { ContainerRegistrationKeys } from "@medusajs/framework/utils"
 import type { Logger } from "@medusajs/types"
 import { sendOrderFulfillmentEmail } from "../workflows/email/send-notification-email"
 import { sendPartnerOrderFulfilledWorkflow } from "../workflows/email/workflows/send-partner-order-email"
-import { createProductionRunWorkflow } from "../workflows/production-runs/create-production-run"
-import { completeProvenanceRunWorkflow } from "../workflows/production-runs/complete-provenance-run"
-import { planLineItemRunAction } from "../lib/plan-fulfillment-production-runs"
-import { resolveOwningPartnerId } from "../modules/partner_billing/resolve-retail-partner"
+import { reconcileProvenanceRunsForOrderLines } from "../lib/reconcile-provenance-runs"
 
-// #1112 — "fulfilled from produced stock" ⇒ retroactively mint a COMPLETED
-// production run per fulfilled line item, hung off the Product spine, carrying
-// order/partner provenance. Runs on `order.fulfillment_created` (the intent
-// signal). The per-line decision (create / complete an existing pre-production
-// run / skip) lives in the shared `planLineItemRunAction` so this path and the
-// historical backfill job (#1122) can never drift or double-create.
+// #1112 / #1123 — "fulfilled from produced stock" ⇒ retroactively mint a
+// COMPLETED production run per fulfilled line item, hung off the Product spine,
+// carrying order/partner provenance. Runs on `order.fulfillment_created`.
+//
+// Delegates to the shared `reconcileProvenanceRunsForOrderLines`, which stamps
+// each run's produced_quantity from the CUMULATIVE fulfilled qty across all of
+// the order's non-canceled fulfillments (so a partial 4-then-6 fulfillment ends
+// at 10, not 4). The same reconcile drives the fulfillment-canceled and
+// order-canceled paths, so the three can never drift or double-create.
 async function createFulfillmentProductionRuns(
   container: SubscriberArgs<any>["container"],
   data: { order_id: string; fulfillment_id: string },
   logger: Logger
 ): Promise<void> {
-  try {
-    const query = container.resolve(ContainerRegistrationKeys.QUERY) as any
+  const query = container.resolve(ContainerRegistrationKeys.QUERY) as any
 
-    // Which line items (and how many) did THIS fulfillment cover.
-    const { data: fulfillments } = await query.graph({
-      entity: "fulfillment",
-      fields: ["id", "items.line_item_id", "items.quantity"],
-      filters: { id: data.fulfillment_id },
-    })
-    const fulfillment = (fulfillments || [])[0]
-    const fulfilledItems: any[] = (fulfillment?.items || []).filter(
-      (fi: any) => fi?.line_item_id
-    )
-    if (!fulfilledItems.length) {
-      return
-    }
+  // Which line items did THIS fulfillment cover.
+  const { data: fulfillments } = await query.graph({
+    entity: "fulfillment",
+    fields: ["id", "items.line_item_id"],
+    filters: { id: data.fulfillment_id },
+  })
+  const lineItemIds: string[] = ((fulfillments || [])[0]?.items || [])
+    .map((fi: any) => fi?.line_item_id)
+    .filter(Boolean)
+  if (!lineItemIds.length) return
 
-    // Resolve line_item_id → { product_id, variant_id } from the order.
-    const { data: orders } = await query.graph({
-      entity: "order",
-      fields: [
-        "id",
-        "sales_channel_id",
-        "items.id",
-        "items.product_id",
-        "items.variant_id",
-      ],
-      filters: { id: data.order_id },
-    })
-    const order = (orders || [])[0]
-    const itemById = new Map<string, any>(
-      (order?.items || []).map((it: any) => [it.id, it])
-    )
-
-    // #1121 — resolve the owning partner once for the whole order so every
-    // provenance run carries product + partner + order provenance (retail runs
-    // were previously minted with partner_id null). Same two-rule ownership the
-    // partner API enforces: work-order link → retail sales-channel rule.
-    const partnerId = await resolveOwningPartnerId(container, {
-      orderId: data.order_id,
-      salesChannelId: order?.sales_channel_id,
-    })
-
-    for (const fi of fulfilledItems) {
-      const lineItemId = fi.line_item_id as string
-      const orderItem = itemById.get(lineItemId)
-      const quantity = Number(fi.quantity) || 1
-
-      const plan = await planLineItemRunAction(query, {
-        lineItemId,
-        productId: orderItem?.product_id,
-        variantId: orderItem?.variant_id,
-        quantity,
-      })
-      if (!plan) {
-        continue
-      }
-
-      // A design-backed run from order.placed that never went through
-      // production → the goods shipped from stock, so complete it (#1126)
-      // instead of leaving it `pending_review` forever.
-      if (plan.action === "complete") {
-        await completeProvenanceRunWorkflow(container).run({
-          input: {
-            production_run_id: plan.production_run_id,
-            produced_quantity: plan.quantity,
-          },
-        })
-        logger.info(
-          `[order.fulfillment_created] Completed design-backed provenance run ${plan.production_run_id} for line item ${lineItemId} (shipped from stock)`
-        )
-        continue
-      }
-
-      await createProductionRunWorkflow(container).run({
-        input: {
-          design_id: plan.design_id ?? undefined,
-          quantity: plan.quantity,
-          produced_quantity: plan.quantity,
-          product_id: plan.product_id,
-          variant_id: plan.variant_id,
-          partner_id: partnerId ?? undefined,
-          order_id: data.order_id,
-          order_line_item_id: lineItemId,
-          // Born terminal — the goods are already produced & shipping.
-          status: "completed",
-          // Provenance runs are not partner work-orders; don't project them
-          // onto the unified #342 order (would mis-discriminate the retail
-          // order as a design work-order).
-          skip_unified_projection: true,
-          metadata: {
-            source: "order.fulfillment_created",
-            fulfillment_id: data.fulfillment_id,
-            is_custom_design: plan.is_custom_design,
-            design_backed: Boolean(plan.design_id),
-          },
-        },
-      })
-
-      logger.info(
-        `[order.fulfillment_created] Minted ${
-          plan.design_id ? "design-backed" : "product-only"
-        } production run for line item ${lineItemId} (product ${plan.product_id})`
-      )
-    }
-  } catch (e: any) {
-    logger.warn(
-      `[order.fulfillment_created] Failed to create production runs for order ${data.order_id}: ${e?.message || e}`
-    )
-  }
+  await reconcileProvenanceRunsForOrderLines(
+    container,
+    { orderId: data.order_id, lineItemIds },
+    logger
+  )
 }
 
 export default async function orderFulfillment_createdHandler({


### PR DESCRIPTION
Closes #1123. Follow-up to #1112. (Supersedes #1146, which auto-closed when its stacked base #1145/#1121 merged; rebased onto main.)

Three edge cases in the fulfillment-triggered provenance runs, unified behind one shared reconcile (`reconcileProvenanceRunsForOrderLines`) so the create / fulfillment-cancel / order-cancel paths can never drift.

## 1. Aggregate produced_quantity across fulfillments
A line qty 10 fulfilled **4-then-6** minted one run stuck at `produced_quantity = 4` (first fulfillment's qty). Now every fulfillment event reconciles the run to the **cumulative** fulfilled qty across all the order's non-canceled fulfillments → **10**.

## 2. Cancellation reversal (soft-delete)
Two new subscribers:
- **`order.fulfillment_canceled`** — recompute cumulative (canceled fulfillment excluded); drop qty, or soft-delete if nothing's left shipped.
- **`order.canceled`** — `voided: true` → cumulative 0 → soft-delete the order's provenance runs.

Only runs this system minted (`isOwnedProvenanceRun`: product-only + `metadata.source === "order.fulfillment_created"`) are ever adjusted/deleted. Real production runs and design work-orders are untouched.

## 3. Double-create race
Partial unique index on `production_runs.order_line_item_id` `where order_line_item_id is not null and deleted_at is null` (`Migration20260722120000`); reconcile treats the `unique_violation` (23505) as a no-op. The `deleted_at is null` predicate lets a soft-deleted run be re-minted if the line is fulfilled again.

## Shape
- `src/lib/reconcile-provenance-runs.ts` (new) — shared reconcile. Cumulative traverses `order.fulfillments.items` (fulfillments carry no queryable `order_id`).
- `src/subscribers/order-fullfilled.ts` — delegates to the reconcile.
- `src/subscribers/order-fulfillment-canceled.ts`, `order-canceled-provenance-runs.ts` (new).
- `src/lib/resolve-line-item-production.ts` — `getProductionRunForLineItem` returns produced_quantity/design_id/metadata; adds `isOwnedProvenanceRun` + unique-violation constant.
- `src/modules/production_runs/migrations/Migration20260722120000.ts` — partial unique index.

## Tests
`order-fulfillment-production-runs.spec.ts`: **aggregates produced_quantity across partial fulfillments** (1→3) and **soft-deletes the provenance run when the order is canceled** — full suite 5/5 green; backfill spec still green.

## Notes
- Aggregate/cancel apply to product-only provenance runs; design-backed runs completed-from-stock (#1126) keep first-set qty and aren't cancel-reverted here (a distinct concern).
- Historical runs unaffected; #1122 backfill can re-run if retroactive cleanup is wanted.

🤖 Generated with [Claude Code](https://claude.com/claude-code)