### PR TITLE
feat(production-runs): partner-UI provenance mirror + admin widget polish [#1124]

### DIFF
--- a/apps/backend/integration-tests/http/partner-store-products-api.spec.ts
+++ b/apps/backend/integration-tests/http/partner-store-products-api.spec.ts
@@ -195,6 +195,9 @@ setupSharedTestSuite(() => {
         expect(res.status).toBe(200)
         expect(res.data.product).toBeDefined()
         expect(res.data.product.id).toBe(partner.productId)
+        // #1124 — the provenance trail (product↔production_run link) is wired
+        // through the remap as an array (empty here — no fulfilled orders yet).
+        expect(Array.isArray(res.data.product.production_runs)).toBe(true)
       })
 
       it("POST /partners/stores/:id/products/:productId updates the product", async () => {

--- a/apps/backend/src/admin/widgets/product-designs.tsx
+++ b/apps/backend/src/admin/widgets/product-designs.tsx
@@ -1,4 +1,5 @@
 import { defineWidgetConfig } from "@medusajs/admin-sdk"
+import { useState } from "react"
 import { Container, Text, Badge, StatusBadge, usePrompt, Skeleton, Button, Heading } from "@medusajs/ui"
 import { DetailWidgetProps } from "@medusajs/framework/types"
 import { useNavigate } from "react-router-dom"
@@ -184,17 +185,33 @@ function DesignAdminProductionRunsSection({ designId }: { designId: string }) {
 // the product's "design trail" — the runs that produced sold-and-fulfilled
 // stock. Design-backed runs are excluded here (they already appear under their
 // design above), so there's no double-listing.
+const PROVENANCE_RUNS_PAGE = 20
+
 function ProductProvenanceRunsSection({ productId }: { productId: string }) {
   const navigate = useNavigate()
-  const { production_runs: runs = [], isLoading } = useProductionRuns({
+  // #1124 — paginate instead of a hard 50-run cap: bump the limit on demand.
+  const [limit, setLimit] = useState(PROVENANCE_RUNS_PAGE)
+  const { production_runs: runs = [], count = 0, isLoading } = useProductionRuns({
     product_id: productId,
-    limit: 50,
+    limit,
   })
 
-  if (isLoading) return null
+  // #1124 — show a skeleton while loading (was `return null`, unlike the
+  // sibling design-runs section) so the section doesn't pop in.
+  if (isLoading && !runs.length) {
+    return (
+      <div className="flex flex-col gap-y-3 px-6 py-4">
+        <Skeleton className="h-5 w-40" />
+        <Skeleton className="h-16 w-full" />
+      </div>
+    )
+  }
 
   const productOnly = (runs as AdminProductionRun[]).filter((r) => !r.design_id)
   if (!productOnly.length) return null
+
+  // More runs exist server-side for this product than we've loaded.
+  const hasMore = count > runs.length
 
   return (
     <div className="flex flex-col gap-y-3 px-6 py-4">
@@ -240,6 +257,19 @@ function ProductProvenanceRunsSection({ productId }: { productId: string }) {
           </div>
         ))}
       </div>
+
+      {hasMore && (
+        <div className="flex justify-center">
+          <Button
+            size="small"
+            variant="transparent"
+            isLoading={isLoading}
+            onClick={() => setLimit((l) => l + PROVENANCE_RUNS_PAGE)}
+          >
+            Show more
+          </Button>
+        </div>
+      )}
     </div>
   )
 }
@@ -398,8 +428,12 @@ const ProductDesignsWidget = ({ data }: DetailWidgetProps<AdminProduct>) => {
                 {/* Inventory & Production sub-section */}
                 <div className="flex flex-col gap-y-4 px-6 pb-5 bg-ui-bg-subtle border-t border-ui-border-base">
                   <div className="flex flex-col gap-y-2 pt-4">
+                    {/* #1124 — "Design Production Runs" (not just "Production
+                        Runs") so it reads distinctly from the product-level
+                        provenance "Production Runs" section below when a product
+                        has both a linked design and retail-fulfillment runs. */}
                     <Text size="xsmall" weight="plus" className="text-ui-fg-subtle uppercase tracking-wide">
-                      Production Runs
+                      Design Production Runs
                     </Text>
                     <DesignAdminProductionRunsSection designId={design.id} />
                   </div>

--- a/apps/backend/src/api/partners/stores/[id]/products/[productId]/route.ts
+++ b/apps/backend/src/api/partners/stores/[id]/products/[productId]/route.ts
@@ -39,6 +39,16 @@ export const GET = async (
       "type.*",
       "collection.*",
       "sales_channels.*",
+      // #1124 — provenance trail: the production runs that produced this
+      // product's sold-and-fulfilled stock (product-as-spine link, #1112).
+      "production_runs.id",
+      "production_runs.status",
+      "production_runs.order_id",
+      "production_runs.design_id",
+      "production_runs.partner_id",
+      "production_runs.quantity",
+      "production_runs.produced_quantity",
+      "production_runs.created_at",
     ],
     filters: { id: req.params.productId },
   })
@@ -65,6 +75,9 @@ export const GET = async (
 
   scopeAndAggregateVariantInventory(product.variants || [], store?.default_location_id)
   const remapped: any = remapProductResponse(product)
+  // `remapProductResponse` only copies a hand-picked allow-list of relations,
+  // so `production_runs` (like `fx_price_meta` above) is dropped — re-attach it.
+  remapped.production_runs = product.production_runs || []
   if (fxMetaByPriceId.size) {
     for (const variant of remapped.variants || []) {
       for (const price of variant.prices || []) {

--- a/apps/partner-ui/src/routes/products/product-detail/components/product-production-runs-section/index.ts
+++ b/apps/partner-ui/src/routes/products/product-detail/components/product-production-runs-section/index.ts
@@ -1,0 +1,1 @@
+export * from "./product-production-runs-section"

--- a/apps/partner-ui/src/routes/products/product-detail/components/product-production-runs-section/product-production-runs-section.tsx
+++ b/apps/partner-ui/src/routes/products/product-detail/components/product-production-runs-section/product-production-runs-section.tsx
@@ -1,0 +1,110 @@
+import { Badge, Container, Heading, StatusBadge, Text } from "@medusajs/ui"
+import { useNavigate } from "react-router-dom"
+
+// #1124 — mirror of the admin product "Production Runs" provenance trail on the
+// partner product page: the runs that produced this product's sold-and-fulfilled
+// stock (#1112 product-as-spine link). Product-only runs (design_id null) are
+// the retail-fulfillment provenance; design-backed runs already surface under
+// their design elsewhere, so they're excluded here to avoid double-listing.
+
+type ProductionRun = {
+  id: string
+  status?: string | null
+  order_id?: string | null
+  design_id?: string | null
+  quantity?: number | null
+  produced_quantity?: number | null
+}
+
+type Props = {
+  product: { production_runs?: ProductionRun[] } & Record<string, any>
+}
+
+const RUN_STATUS_COLOR: Record<string, "green" | "orange" | "grey" | "red"> = {
+  completed: "green",
+  in_progress: "orange",
+  pending_review: "grey",
+  draft: "grey",
+  cancelled: "red",
+}
+
+const runStatusLabel = (status: string) =>
+  status ? status.replace(/_/g, " ").replace(/\b\w/g, (c) => c.toUpperCase()) : "—"
+
+export const ProductProductionRunsSection = ({ product }: Props) => {
+  const navigate = useNavigate()
+
+  const productOnly = (product.production_runs || []).filter(
+    (r) => !r.design_id
+  )
+  if (!productOnly.length) {
+    return null
+  }
+
+  return (
+    <Container className="divide-y p-0">
+      <div className="flex items-center gap-x-2 px-6 py-4">
+        <Heading level="h2">Production Runs</Heading>
+        <Badge size="2xsmall" color="grey">
+          {productOnly.length}
+        </Badge>
+        <Text size="small" className="text-ui-fg-muted">
+          from fulfilled orders
+        </Text>
+      </div>
+
+      <div className="px-6 py-4">
+        <div className="flex flex-col divide-y divide-ui-border-base rounded-lg border border-ui-border-base overflow-hidden">
+          <div className="grid grid-cols-3 px-3 py-1.5 bg-ui-bg-subtle">
+            <Text size="xsmall" weight="plus" className="text-ui-fg-subtle">
+              Status
+            </Text>
+            <Text size="xsmall" weight="plus" className="text-ui-fg-subtle">
+              Order
+            </Text>
+            <Text
+              size="xsmall"
+              weight="plus"
+              className="text-ui-fg-subtle text-right"
+            >
+              Produced
+            </Text>
+          </div>
+          {productOnly.map((run) => (
+            <div
+              key={run.id}
+              className="grid grid-cols-3 px-3 py-2 items-center"
+            >
+              <StatusBadge
+                color={RUN_STATUS_COLOR[run.status ?? ""] ?? "grey"}
+              >
+                {runStatusLabel(run.status ?? "")}
+              </StatusBadge>
+              {run.order_id ? (
+                <button
+                  type="button"
+                  onClick={() => navigate(`/orders/${run.order_id}`)}
+                  className="text-left"
+                >
+                  <Text
+                    size="xsmall"
+                    className="text-ui-fg-interactive truncate"
+                  >
+                    {run.order_id.slice(0, 14)}…
+                  </Text>
+                </button>
+              ) : (
+                <Text size="xsmall" className="text-ui-fg-muted">
+                  —
+                </Text>
+              )}
+              <Text size="xsmall" className="text-right">
+                {(run.produced_quantity ?? run.quantity ?? 0).toLocaleString()}
+              </Text>
+            </div>
+          ))}
+        </div>
+      </div>
+    </Container>
+  )
+}

--- a/apps/partner-ui/src/routes/products/product-detail/product-detail.tsx
+++ b/apps/partner-ui/src/routes/products/product-detail/product-detail.tsx
@@ -10,6 +10,7 @@ import { ProductReviewBanner } from "./components/product-review-banner/product-
 import { ProductMediaSection } from "./components/product-media-section"
 import { ProductOptionSection } from "./components/product-option-section"
 import { ProductOrganizationSection } from "./components/product-organization-section"
+import { ProductProductionRunsSection } from "./components/product-production-runs-section"
 import { ProductSalesChannelSection } from "./components/product-sales-channel-section"
 import { ProductVariantSection } from "./components/product-variant-section"
 import { PRODUCT_DETAIL_FIELDS } from "./constants"
@@ -72,6 +73,7 @@ export const ProductDetail = () => {
         <ProductMediaSection product={product} />
         <ProductOptionSection product={product} />
         <ProductVariantSection product={product} />
+        <ProductProductionRunsSection product={product} />
         <ProductArtisanSection product={product} />
       </TwoColumnPage.Main>
       <TwoColumnPage.Sidebar>


### PR DESCRIPTION
Closes #1124. The last #1112 tail (nice-to-have).

## Partner-UI mirror
The partner product detail page now shows the same **Production Runs** provenance trail the admin has — the runs that produced this product's sold-and-fulfilled stock (#1112 product-as-spine).
- `GET /partners/stores/:id/products/:productId` returns `production_runs` (re-attached after `remapProductResponse`, which only copies an allow-list of relations — same handling as `fx_price_meta`).
- New `ProductProductionRunsSection` renders product-only runs (design_id null; design-backed runs already surface under their design) with status, order link, and produced qty. Partner column dropped — it's always the partner themselves.

## Admin widget polish (`product-designs.tsx`)
- **Skeleton on load** — was `return null` (section popped in), now matches the sibling design-runs section.
- **Pagination** — replaces the hard 50-run cap with a "Show more" that bumps the limit by 20 while the server reports more runs for the product.
- **De-duped headings** — the per-design sub-heading "Production Runs" → **"Design Production Runs"**, so it reads distinctly from the product-level provenance "Production Runs" section when a product has both a linked design and retail-fulfillment runs. (Product-level heading + "from fulfilled orders" kept verbatim — the e2e `product-production-runs.spec.ts` pins them.)

## Test
`partner-store-products-api.spec.ts` — the detail GET asserts `production_runs` comes back as an array (proves it survives the remap). **17/17 green.** Typecheck clean on both backend and partner-ui.

🤖 Generated with [Claude Code](https://claude.com/claude-code)