### PR TITLE
chore(emailkit): wire Kit secrets into prod manifests [#1059]

### DIFF
--- a/deploy/aws/copilot/medusa-server/manifest.yml
+++ b/deploy/aws/copilot/medusa-server/manifest.yml
@@ -150,6 +150,12 @@ secrets:
   FRONTEND_URL: /jyt/prod/FRONTEND_URL
   GOOGLE_REDIRECT_URI: /jyt/prod/GOOGLE_REDIRECT_URI
   JWT_SECRET: /jyt/prod/JWT_SECRET
+  # #1059 EmailKit — mass blog/newsletter broadcasts via Kit (kit.com). Gated by
+  # EMAILKIT_ENABLED; KIT_WEBHOOK_SECRET auths /webhooks/kit (?token=).
+  EMAILKIT_ENABLED: /jyt/prod/EMAILKIT_ENABLED
+  KIT_API_KEY: /jyt/prod/KIT_API_KEY
+  KIT_BLOG_TAG_ID: /jyt/prod/KIT_BLOG_TAG_ID
+  KIT_WEBHOOK_SECRET: /jyt/prod/KIT_WEBHOOK_SECRET
   MAILEROO_API_KEY: /jyt/prod/MAILEROO_API_KEY
   MAILEROO_FROM_DOMAIN: /jyt/prod/MAILEROO_FROM_DOMAIN
   MAILEROO_FROM_EMAIL: /jyt/prod/MAILEROO_FROM_EMAIL

--- a/deploy/aws/copilot/medusa-worker/manifest.yml
+++ b/deploy/aws/copilot/medusa-worker/manifest.yml
@@ -61,6 +61,12 @@ secrets:
   FACEBOOK_CLIENT_SECRET: /jyt/prod/FACEBOOK_CLIENT_SECRET
   FACEBOOK_WEBHOOK_VERIFY_TOKEN: /jyt/prod/FACEBOOK_WEBHOOK_VERIFY_TOKEN
   FAL_KEY: /jyt/prod/FAL_KEY
+  # #1059 EmailKit — the blog broadcast workflow (sync + create broadcast) may
+  # run on the worker, so it needs the Kit creds + flag too.
+  EMAILKIT_ENABLED: /jyt/prod/EMAILKIT_ENABLED
+  KIT_API_KEY: /jyt/prod/KIT_API_KEY
+  KIT_BLOG_TAG_ID: /jyt/prod/KIT_BLOG_TAG_ID
+  KIT_WEBHOOK_SECRET: /jyt/prod/KIT_WEBHOOK_SECRET
   MAILEROO_API_KEY: /jyt/prod/MAILEROO_API_KEY
   MAILEROO_FROM_DOMAIN: /jyt/prod/MAILEROO_FROM_DOMAIN
   MAILEROO_FROM_EMAIL: /jyt/prod/MAILEROO_FROM_EMAIL


### PR DESCRIPTION
Maps the 4 Kit SSM params (already created at `/jyt/prod/*`) into both ECS services so the blog broadcast lane + `/webhooks/kit` get their creds. `copilot svc deploy` applies the secrets block on merge.

- `EMAILKIT_ENABLED=true` → next blog send routes through Kit.
- Server needs it for `/webhooks/kit` + workflow trigger; worker for the background broadcast steps.

🤖 Generated with [Claude Code](https://claude.com/claude-code)