### PR TITLE
feat(store-chat): capture shopper name+email as a lead (supersedes #835)

### DIFF
--- a/apps/backend/integration-tests/http/storefront-chat-tools.spec.ts
+++ b/apps/backend/integration-tests/http/storefront-chat-tools.spec.ts
@@ -6,6 +6,11 @@ import {
   runGetCategoryProducts,
   runGetProductDetails,
 } from "../../src/mastra/agents/tools/storefront-catalog-tools"
+import { PERSON_MODULE } from "../../src/modules/person"
+import {
+  runCaptureContact,
+  STOREFRONT_CHAT_LEAD_SOURCE,
+} from "../../src/mastra/agents/tools/storefront-capture-contact"
 
 jest.setTimeout(120000)
 
@@ -92,6 +97,56 @@ setupSharedTestSuite(() => {
       const details = await runGetProductDetails({ handle: "no-such-product-xyz" }, container)
       expect(details.products).toEqual([])
       expect(details.error).toMatch(/no published product/i)
+    })
+
+    it("capture_contact creates a lead person tagged with the storefront_chat source", async () => {
+      const container = getContainer()
+      const personService: any = container.resolve(PERSON_MODULE)
+      const email = `chat-lead-${Date.now()}@example.com`
+
+      const res = await runCaptureContact(
+        { email, name: "Asha Rao", interest: "indigo cotton kurta" },
+        container,
+        "visitor-abc"
+      )
+      expect(res).toEqual({ saved: true, already_known: false })
+
+      const [person] = await personService.listPeople({ email })
+      expect(person).toBeTruthy()
+      expect(person.first_name).toBe("Asha")
+      expect(person.last_name).toBe("Rao")
+      expect(person.metadata?.source).toBe(STOREFRONT_CHAT_LEAD_SOURCE)
+      expect(person.metadata?.visitor_id).toBe("visitor-abc")
+      expect(person.metadata?.interest).toBe("indigo cotton kurta")
+    })
+
+    it("capture_contact is idempotent per email and never overwrites an existing source", async () => {
+      const container = getContainer()
+      const personService: any = container.resolve(PERSON_MODULE)
+      const email = `chat-existing-${Date.now()}@example.com`
+
+      // A person already acquired via another surface, with no name yet.
+      const seeded = await personService.createPeople({
+        first_name: "",
+        last_name: "",
+        email,
+        metadata: { source: "ad_planning_order_placed" },
+      })
+
+      const res = await runCaptureContact(
+        { email: email.toUpperCase(), name: "Meera Iyer" },
+        container
+      )
+      expect(res).toEqual({ saved: true, already_known: true })
+
+      const people = await personService.listPeople({ email })
+      // Still one row (dedup on the unique email, case-insensitive input).
+      expect(people).toHaveLength(1)
+      expect(people[0].id).toBe(seeded.id)
+      // Missing name enriched…
+      expect(people[0].first_name).toBe("Meera")
+      // …but the original acquisition source is preserved, not relabelled.
+      expect(people[0].metadata?.source).toBe("ad_planning_order_placed")
     })
   })
 })

--- a/apps/backend/src/api/store/ai/chat/route.ts
+++ b/apps/backend/src/api/store/ai/chat/route.ts
@@ -38,6 +38,7 @@ import {
   createGetCategoryProductsTool,
   createGetProductDetailsTool,
 } from "../../../../mastra/agents/tools/storefront-catalog-tools"
+import { createCaptureContactTool } from "../../../../mastra/agents/tools/storefront-capture-contact"
 import { foldSystemForProvider } from "./system-fold-lib"
 import { parseChatProvider } from "./chat-usage-lib"
 import { logAiUsage } from "../../../../mastra/services/ai-platforms"
@@ -62,6 +63,7 @@ export const POST = async (req: MedusaRequest, res: MedusaResponse) => {
     get_categories: createGetCategoriesTool(req.scope as any),
     get_category_products: createGetCategoryProductsTool(req.scope as any),
     get_product_details: createGetProductDetailsTool(req.scope as any),
+    capture_contact: createCaptureContactTool(req.scope as any, body.visitor_id),
   }
 
   // Normalise the inbound UI messages.

--- a/apps/backend/src/mastra/agents/storefront-chat.ts
+++ b/apps/backend/src/mastra/agents/storefront-chat.ts
@@ -83,8 +83,10 @@ export const buildStorefrontChatSystem = (prefs?: UserPrefs): string => {
   - get_categories — the shopper asks what you sell or how the catalogue is organised. Summarise the categories in prose (no cards render for this one).
   - get_category_products — the shopper wants to browse a named category ("show me your sarees").
   - get_product_details — the shopper asks about one specific item (use its handle from a previous result).
+  - capture_contact — once the shopper has actually shared their name and email, call this to save them for follow-up. Only call it after they give an email, and only once.
 - Before a tool call, briefly say what you're doing ("Looking for indigo handwoven cottons…") so the wait feels intentional.
 - After product results come back, write a one or two sentence summary in prose ("I found a few cotton handwoven pieces — the ivory kurta and the indigo set both look like what you described."). The UI renders the product cards below your text, so don't list them by hand.
+- After showing pieces the shopper seems interested in, you may gently ask for their name and email so the team can follow up ("By the way, could I grab your name and email? I can follow up about these pieces if you'd like."). Ask at most once — don't repeat it if they decline or have already shared it. When they do give an email, call capture_contact to save it (pass a short note of what they liked as \`interest\`), then thank them briefly and carry on.
 - For brand questions (custom design, sizing, materials, partners, shipping), answer from the BRAND KNOWLEDGE below. If something isn't covered, say so and point to hello@cicilabel.com.
 - For custom design: route the shopper to /design — that's the self-service editor. Don't fabricate a custom-design intake form.
 - Never give prices or stock numbers unless they come from the search_products tool.

--- a/apps/backend/src/mastra/agents/tools/storefront-capture-contact.ts
+++ b/apps/backend/src/mastra/agents/tools/storefront-capture-contact.ts
@@ -1,0 +1,129 @@
+/**
+ * capture_contact — AI SDK tool for the storefront chat agent.
+ *
+ * When a shopper volunteers their name + email in the conversation (so the
+ * team can follow up about pieces they liked), this persists them as a lead:
+ * an upsert into the `person` module keyed on the unique email, tagged
+ * `metadata.source = "storefront_chat"`. That source lets the audience
+ * classifier ([[audience]] grouping, #881) fold the contact into the
+ * organic-lead segment without any bespoke lead table.
+ *
+ * Mirrors the container-bound tool factory pattern of
+ * `storefront-search-products.ts` and the race-safe person upsert of
+ * `workflows/ad-planning/conversions/track-purchase-conversion.ts`.
+ *
+ * The model is instructed (see `storefront-chat.ts`) to call this ONCE, only
+ * after the shopper has actually shared an email — never speculatively.
+ */
+import type { MedusaContainer } from "@medusajs/framework"
+import { ContainerRegistrationKeys } from "@medusajs/framework/utils"
+import { tool } from "ai"
+import { z } from "zod"
+import { PERSON_MODULE } from "../../../modules/person"
+import { splitName } from "../../../workflows/leads/lib/email-lead"
+
+/** Acquisition source stamped on people captured through the storefront chat. */
+export const STOREFRONT_CHAT_LEAD_SOURCE = "storefront_chat"
+
+const CaptureArgsSchema = z.object({
+  email: z
+    .string()
+    .email()
+    .max(200)
+    .describe("The shopper's email address, exactly as they typed it."),
+  name: z
+    .string()
+    .min(1)
+    .max(120)
+    .optional()
+    .describe("The shopper's name, if they gave one."),
+  interest: z
+    .string()
+    .max(280)
+    .optional()
+    .describe(
+      "A short note on which pieces or topics the shopper was interested in, for follow-up context."
+    ),
+})
+
+export type CaptureContactArgs = z.infer<typeof CaptureArgsSchema>
+
+export type CaptureContactResult = {
+  saved: boolean
+  already_known?: boolean
+}
+
+/**
+ * Upsert a storefront-chat lead into the `person` module. Exported separately
+ * from the tool wrapper so it's unit-testable without the AI-SDK plumbing
+ * (mirrors the `run*` helpers in `storefront-catalog-tools.ts`).
+ */
+export const runCaptureContact = async (
+  args: CaptureContactArgs,
+  container: MedusaContainer,
+  visitorId?: string
+): Promise<CaptureContactResult> => {
+  const logger: any = container.resolve(ContainerRegistrationKeys.LOGGER)
+  const personService: any = container.resolve(PERSON_MODULE)
+
+  const normalizedEmail = args.email.trim().toLowerCase()
+  const { first_name, last_name } = splitName(args.name)
+  const { interest } = args
+
+  try {
+    const existing = await personService.listPeople({ email: normalizedEmail })
+
+    if (existing?.length > 0) {
+      // Already a known person — enrich a missing name and record the
+      // touchpoint, but never overwrite an existing acquisition source.
+      const person = existing[0]
+      const metadata: Record<string, unknown> = { ...(person.metadata || {}) }
+      if (!metadata.source) metadata.source = STOREFRONT_CHAT_LEAD_SOURCE
+      if (visitorId) metadata.visitor_id = visitorId
+      if (interest) metadata.interest = interest
+
+      await personService.updatePeople({
+        id: person.id,
+        ...(first_name && !person.first_name ? { first_name } : {}),
+        ...(last_name && !person.last_name ? { last_name } : {}),
+        metadata,
+      })
+      return { saved: true, already_known: true }
+    }
+
+    await personService.createPeople({
+      first_name: first_name || "",
+      last_name: last_name || "",
+      email: normalizedEmail,
+      metadata: {
+        source: STOREFRONT_CHAT_LEAD_SOURCE,
+        ...(visitorId ? { visitor_id: visitorId } : {}),
+        ...(interest ? { interest } : {}),
+      },
+    })
+    return { saved: true, already_known: false }
+  } catch (e: any) {
+    // A concurrent turn may win the unique-email race — re-read and reuse.
+    try {
+      const retry = await personService.listPeople({ email: normalizedEmail })
+      if (retry?.length > 0) return { saved: true, already_known: true }
+    } catch {
+      /* fall through to the failure path */
+    }
+    logger?.warn?.(
+      `[store/ai/chat] capture_contact failed for ${normalizedEmail}: ${e?.message ?? e}`
+    )
+    return { saved: false }
+  }
+}
+
+export const createCaptureContactTool = (
+  container: MedusaContainer,
+  visitorId?: string
+) =>
+  tool({
+    description:
+      "Save the shopper's name and email as a follow-up lead. Call this ONCE, and only after the shopper has actually shared an email address in the conversation — never before they've given one. It returns whether the contact was saved.",
+    inputSchema: CaptureArgsSchema,
+    execute: async (args) => runCaptureContact(args, container, visitorId),
+  })


### PR DESCRIPTION
## What

The storefront chat now **stores** the shopper's name + email as a lead, not just asks for it.

Closes the gap in #835, which only appended a system-prompt line telling the agent to *ask* — nothing persisted the reply.

## Changes
- **New `capture_contact` tool** (`mastra/agents/tools/storefront-capture-contact.ts`) — upserts the shopper into the `person` module on the unique email, tagged `metadata.source = "storefront_chat"` so the audience classifier (#881) folds them into the organic-lead segment. No bespoke lead table.
  - Race-safe on the unique-email constraint (re-reads on conflict).
  - Enriches a missing name **without** overwriting an existing acquisition source (a person acquired via ads/orders keeps their source).
  - Stamps `visitor_id` (funnel join) + a short `interest` note for follow-up.
- **Registered** on `POST /store/ai/chat`, bound to the request container + `visitor_id`, mirroring the catalog tools.
- **System prompt** tells the agent to ask once, then call `capture_contact` only after the shopper actually shares an email.
- **Testable `runCaptureContact`** + 2 integration tests (create; idempotent + source-preserving upsert). Injected logger, not console.

## Verification
`pnpm test:integration:http:shared ./integration-tests/http/storefront-chat-tools` → **4/4 pass** (2 pre-existing + 2 new). `tsc` clean (no new errors vs main baseline).

Once merged, close #835 as superseded.

🤖 Generated with [Claude Code](https://claude.com/claude-code)