### PR TITLE
feat(shipping): friendly intl-prerequisites gate before label generation [#1118]

### DIFF
--- a/apps/backend/src/modules/shipping-providers/shiprocket/__tests__/describe-intl-prereq-error.unit.spec.ts
+++ b/apps/backend/src/modules/shipping-providers/shiprocket/__tests__/describe-intl-prereq-error.unit.spec.ts
@@ -1,0 +1,63 @@
+import { describeIntlPrereqError } from "../client"
+
+/**
+ * #1118 — the intl-prerequisites gate turns Shiprocket's opaque KYC / bank /
+ * pickup rejections into actionable admin guidance. These assert the keyword
+ * matching on representative Shiprocket wording, and that unrelated errors pass
+ * through untouched (null → caller rethrows the original).
+ */
+describe("describeIntlPrereqError (#1118)", () => {
+  it("detects an unverified-KYC rejection", () => {
+    const g = describeIntlPrereqError({
+      message: "Your KYC is not verified. Please complete KYC to ship internationally.",
+    })
+    expect(g?.reason).toBe("kyc")
+    expect(g?.message).toMatch(/KYC/i)
+    expect(g?.message).toMatch(/retry/i)
+  })
+
+  it("detects missing settlement bank details", () => {
+    const g = describeIntlPrereqError({
+      message: "Bank account details are not updated for your account.",
+    })
+    expect(g?.reason).toBe("bank_details")
+    expect(g?.message).toMatch(/bank details/i)
+  })
+
+  it("detects a pickup not enabled for international shipping", () => {
+    const g = describeIntlPrereqError({
+      message: "Pickup location is not enabled for international shipping.",
+    })
+    expect(g?.reason).toBe("pickup_not_intl")
+    expect(g?.message).toMatch(/pickup/i)
+  })
+
+  it("prefers the pickup reason when wording mentions both pickup and international", () => {
+    // Pickup-not-intl wording often also says "international" — make sure it
+    // doesn't fall through to a less-specific match.
+    const g = describeIntlPrereqError({
+      message: "This pickup address is not allowed for international orders.",
+    })
+    expect(g?.reason).toBe("pickup_not_intl")
+  })
+
+  it("reads messages out of a Shiprocket field-error bag", () => {
+    const g = describeIntlPrereqError({
+      fieldErrors: { kyc_status: ["KYC pending, cannot create international shipment"] },
+    })
+    expect(g?.reason).toBe("kyc")
+  })
+
+  it("returns null for an unrelated error (caller rethrows untouched)", () => {
+    expect(
+      describeIntlPrereqError({ message: "HSN code is required for international shipments" })
+    ).toBeNull()
+    expect(describeIntlPrereqError({ message: "Invalid pincode" })).toBeNull()
+    expect(describeIntlPrereqError({})).toBeNull()
+  })
+
+  it("does not treat a bare 'bank' mention without detail/account/settlement as a gate", () => {
+    // Avoid false positives on incidental wording.
+    expect(describeIntlPrereqError({ message: "riverbank warehouse closed" })).toBeNull()
+  })
+})

--- a/apps/backend/src/modules/shipping-providers/shiprocket/client.ts
+++ b/apps/backend/src/modules/shipping-providers/shiprocket/client.ts
@@ -127,6 +127,75 @@ export function parseShiprocketError(raw: string): {
 }
 
 /**
+ * Known Shiprocket *international prerequisite* failures, turned into friendly,
+ * actionable admin guidance (#1118). Shiprocket rejects an international
+ * create/label when the account isn't set up for cross-border shipping — KYC
+ * not verified, settlement bank details missing, or the pickup location isn't
+ * international-enabled. These come back as opaque `ShiprocketApiError`
+ * messages that mean nothing to an admin; this maps the known signatures onto a
+ * clear "here's what to fix" step.
+ *
+ * Keyword-based (Shiprocket's wording drifts and isn't documented as codes), so
+ * it's deliberately conservative: returns `null` for anything unrecognised, and
+ * the caller rethrows the original error untouched. Pure + unit-tested.
+ */
+export type IntlPrereqReason = "kyc" | "bank_details" | "pickup_not_intl"
+
+export type IntlPrereqGate = { reason: IntlPrereqReason; message: string }
+
+export function describeIntlPrereqError(err: {
+  message?: string
+  fieldErrors?: Record<string, string[]>
+}): IntlPrereqGate | null {
+  const parts: string[] = []
+  if (err?.message) parts.push(err.message)
+  if (err?.fieldErrors) {
+    for (const msgs of Object.values(err.fieldErrors)) parts.push(...msgs)
+  }
+  const text = parts.join(" ").toLowerCase()
+  if (!text) return null
+
+  // Pickup-not-international-enabled — check first: its wording often also
+  // mentions "international", which the bare KYC/bank checks don't key on.
+  if (
+    text.includes("pickup") &&
+    (text.includes("international") ||
+      text.includes("not enabled") ||
+      text.includes("not allowed") ||
+      text.includes("not activated"))
+  ) {
+    return {
+      reason: "pickup_not_intl",
+      message:
+        "This pickup location isn't enabled for international shipping in Shiprocket. Enable international shipping for the pickup address in your Shiprocket dashboard (Settings → Pickup Addresses), or choose an international-capable pickup, then retry generating the label.",
+    }
+  }
+
+  if (text.includes("kyc")) {
+    return {
+      reason: "kyc",
+      message:
+        "International shipping requires your Shiprocket KYC to be verified. Complete KYC in your Shiprocket dashboard (Settings → KYC), then retry generating the label.",
+    }
+  }
+
+  if (
+    text.includes("bank") &&
+    (text.includes("detail") ||
+      text.includes("account") ||
+      text.includes("settlement"))
+  ) {
+    return {
+      reason: "bank_details",
+      message:
+        "International shipping requires your settlement bank details on file with Shiprocket. Add them in your Shiprocket dashboard (Settings → Company → Bank Details), then retry generating the label.",
+    }
+  }
+
+  return null
+}
+
+/**
  * Normalize a Shiprocket `data.shipping_address[]` row into our PickupLocation.
  *
  * Shiprocket exposes `phone_verified` (0/1) — its OTP signal — but per the

--- a/apps/backend/src/workflows/orders/shiprocket-shipment.ts
+++ b/apps/backend/src/workflows/orders/shiprocket-shipment.ts
@@ -18,7 +18,10 @@ import {
 } from "../../modules/shipping-providers/pickup-locations"
 import { resolveSellerTaxIdForOrder } from "../../modules/shipping-providers/seller-tax-id"
 import { resolveOrderShipFromLocation } from "../../modules/shipping-providers/order-partner-origin"
-import { isInternationalDestination } from "../../modules/shipping-providers/shiprocket/client"
+import {
+  describeIntlPrereqError,
+  isInternationalDestination,
+} from "../../modules/shipping-providers/shiprocket/client"
 import {
   SHIPROCKET_FX_TARGET,
   SHIPROCKET_SUPPORTED_CURRENCIES,
@@ -331,7 +334,26 @@ export async function createShiprocketShipmentForFulfillment(
     }
   }
 
-  const result = await provider.createShipment(shipmentInput)
+  // #1118 intl-prerequisites gate: Shiprocket rejects an international
+  // create/label when the account isn't cross-border ready (KYC unverified,
+  // bank details missing, pickup not international-enabled). Turn those opaque
+  // ShiprocketApiError messages into an actionable admin error before they
+  // reach the UI toast; anything unrecognised rethrows untouched.
+  let result
+  try {
+    result = await provider.createShipment(shipmentInput)
+  } catch (e: any) {
+    if (isInternationalDestination(shipmentInput.to.country)) {
+      const gate = describeIntlPrereqError({
+        message: e?.message,
+        fieldErrors: e?.fieldErrors,
+      })
+      if (gate) {
+        throw new MedusaError(MedusaError.Types.NOT_ALLOWED, gate.message)
+      }
+    }
+    throw e
+  }
 
   // Persist the carrier refs onto fulfillment.data (what label/tracking read),
   // AND stamp the AWB as a fulfillment_label tracking number — the queryable


### PR DESCRIPTION
## What
Item 2 of the #1118 tail. When Shiprocket rejects an **international** create/label because the account isn't cross-border ready — **KYC unverified**, **settlement bank details missing**, or the **pickup location not international-enabled** — the raw `ShiprocketApiError` used to go straight into the admin UI toast, meaning nothing to the operator. This turns those into an actionable "here's what to fix, and where" gate.

## Changes
- **`describeIntlPrereqError()`** (`shiprocket/client.ts`) — pure, keyword-based mapping of the known prerequisite signatures onto friendly guidance. Conservative: returns `null` for anything unrecognised so the caller rethrows the original error untouched. Checks the pickup-not-intl case first (its wording often also says "international").
- **`shiprocket-shipment` workflow** — wraps the intl `createShipment` call: on an international destination, a matched prerequisite failure becomes a `NOT_ALLOWED` MedusaError with the friendly message. Domestic + unrecognised errors are unchanged.
- **+7 unit tests** — KYC / bank / pickup / field-error bag / precedence / no-false-positives.

## Scope of #1118
- Item 1 (admin UI shipment/tracking widget) — already shipped in **#1119**.
- **Item 2 (this PR)** — the intl-prerequisites gate.
- Item 3 (last-mile enrichment for `/international/orders/track`) — stays **optional**; AWB tracking is already at domestic parity.

Closes #1118.

## Verification
`TEST_TYPE=unit … jest --testPathPattern="describe-intl-prereq-error"` → **7/7 pass** (15/15 with the existing parse-error suite). `tsc` clean — 79 errors, identical to main baseline (zero new).

🤖 Generated with [Claude Code](https://claude.com/claude-code)