### PR TITLE
fix(partner-orders): storeless partner can load work-order detail [#342]

### DIFF
--- a/apps/backend/integration-tests/http/orders-unification-partner-detail.spec.ts
+++ b/apps/backend/integration-tests/http/orders-unification-partner-detail.spec.ts
@@ -24,8 +24,9 @@ const TEST_PARTNER_PASSWORD = "supersecret"
 type PartnerCtx = {
   headers: any
   partnerId: string
-  salesChannelId: string
-  regionId: string
+  // undefined for a storeless partner (work-order-only, no retail store)
+  salesChannelId?: string
+  regionId?: string
   currencyCode: string
   tag: string
 }
@@ -117,6 +118,49 @@ setupSharedTestSuite(() => {
         currencyCode: cc,
         salesChannelId: storeRes.data.sales_channel?.id,
         regionId: storeRes.data.region?.id,
+        tag,
+      }
+    }
+
+    // A partner with NO store (e.g. a design/production partner who only ever
+    // works work-orders and never sells retail). Same registration path, minus
+    // the `/partners/stores` provisioning. Used to prove work-order ownership
+    // does not require a store.
+    const createPartnerWithoutStore = async (tag: string): Promise<PartnerCtx> => {
+      const email = `partner-detail-nostore-${tag}-${unique}@jyt.test`
+      await post("/auth/partner/emailpass/register", {
+        email,
+        password: TEST_PARTNER_PASSWORD,
+      })
+      const login1 = await post("/auth/partner/emailpass", {
+        email,
+        password: TEST_PARTNER_PASSWORD,
+      })
+      const headers1 = { headers: { Authorization: `Bearer ${login1.data.token}` } }
+
+      const partnerRes = await post(
+        "/partners",
+        {
+          name: `Detail NoStore ${tag} ${unique}`,
+          handle: `detail-nostore-${tag}-${unique}`,
+          admin: { email, first_name: "NoStore", last_name: tag },
+        },
+        headers1
+      )
+      const pid = partnerRes.data.partner.id
+
+      const login2 = await post("/auth/partner/emailpass", {
+        email,
+        password: TEST_PARTNER_PASSWORD,
+      })
+      const headers2 = { headers: { Authorization: `Bearer ${login2.data.token}` } }
+
+      return {
+        headers: headers2,
+        partnerId: pid,
+        currencyCode: "inr",
+        salesChannelId: undefined,
+        regionId: undefined,
         tag,
       }
     }
@@ -327,6 +371,22 @@ setupSharedTestSuite(() => {
       expect(order.metadata?.legacy_id).toBe(legacyId)
       expect(linked(order.production_runs)).toBe(true)
       expect(linked(order.inventory_orders)).toBe(false)
+    })
+
+    it("STORELESS partner CAN GET its own design work-order detail (no store required)", async () => {
+      // Regression: a design/production partner with no store owns work orders
+      // purely via the D3 partner↔order link. The ownership check used the
+      // throwing store lookup, so it 404'd with "No store configured for this
+      // partner" before the work-ownership check ran — their design orders
+      // never loaded. Now the storeless partner gets their order.
+      const storeless = await createPartnerWithoutStore("nostore")
+      const { unifiedId, legacyId } = await createDesignWorkOrder(storeless)
+
+      const res = await getDetail(unifiedId, storeless.headers)
+      expect(res.status).toBe(200)
+      const order = res.data.order
+      expect(order.metadata?.legacy_id).toBe(legacyId)
+      expect(linked(order.production_runs)).toBe(true)
     })
 
     it("partner CAN GET its own retail order detail (kind=retail, no links)", async () => {

--- a/apps/backend/src/api/partners/helpers.ts
+++ b/apps/backend/src/api/partners/helpers.ts
@@ -295,8 +295,14 @@ export const validatePartnerOrderOwnership = async (
     authContext: { actor_id?: string | null } | undefined,
     orderId: string,
     container: MedusaContainer,
-): Promise<{ partner: any; store: any }> => {
-    const { partner, store } = await getPartnerStore(authContext, container)
+): Promise<{ partner: any; store: any | null }> => {
+    // A partner can own an order two ways: retail (it's in their store's sales
+    // channel) OR work (the D3 partner↔order link, for design/inventory work
+    // orders). The work path needs NO store — a designer/producer partner may
+    // have no store at all. Use the NON-throwing store lookup so a storeless
+    // partner still reaches the work-ownership check instead of being 404'd by
+    // "No store configured for this partner" before we ever look at the link.
+    const { partner, store } = await tryGetPartnerStore(authContext, container)
 
     const query = container.resolve(ContainerRegistrationKeys.QUERY)
     const { data: orders } = await query.graph({
@@ -312,7 +318,7 @@ export const validatePartnerOrderOwnership = async (
 
     // Retail ownership: order is in the partner's store sales channel.
     const ownsRetail =
-        !!store.default_sales_channel_id &&
+        !!store?.default_sales_channel_id &&
         order.sales_channel_id === store.default_sales_channel_id
 
     // Work ownership: the D3 partner↔order link (read by entryPoint, the source


### PR DESCRIPTION
## Problem
A partner with **no store** (a design/production partner who only works work-orders and never sells retail) got a **404 "No store configured for this partner"** when opening any order detail — reported live for `GET /partners/orders/order_01KW74KC4R84Q1W0PVT5J1MANF`. Their design orders never loaded.

## Root cause
`validatePartnerOrderOwnership` (`api/partners/helpers.ts`) grants access two ways:
- **retail** — order is in the partner's store sales channel, or
- **work** — the D3 `partner ↔ order` link (design/inventory work orders; needs no store).

But it called the **throwing** `getPartnerStore` first, so a storeless partner was 404'd *before* the work-ownership check ever ran.

## Fix
Switch to the non-throwing `tryGetPartnerStore` and null-guard the retail branch (`store?.default_sales_channel_id`). A storeless partner now falls through to the work-ownership check and gets their design/inventory orders. Retail scoping is unchanged for partners that do have a store. This guards every order sub-route too (fulfillments, shipping, cancel, label, edits, …) since they all share this helper.

## Test
`orders-unification-partner-detail.spec.ts` gains a **storeless-partner** case asserting `GET /partners/orders/:id` returns **200** for a design work-order owned via the link (was 404 before). Full suite: **7/7 green**.

Verify: `pnpm test:integration:http:shared ./integration-tests/http/orders-unification-partner-detail`

🤖 Generated with [Claude Code](https://claude.com/claude-code)