### PR TITLE
fix(partner-designs): gate owner-only surfaces on real ownership [#920]

### DIFF
--- a/apps/backend/integration-tests/http/partner-design-crud.spec.ts
+++ b/apps/backend/integration-tests/http/partner-design-crud.spec.ts
@@ -14,6 +14,8 @@ import { ContainerRegistrationKeys } from "@medusajs/framework/utils"
 import { createAdminUser, getAuthHeaders } from "../helpers/create-admin-user"
 import { getSharedTestEnv, setupSharedTestSuite } from "./shared-test-setup"
 import designPartnersLink from "../../src/links/design-partners-link"
+import { DESIGN_MODULE } from "../../src/modules/designs"
+import { PARTNER_MODULE } from "../../src/modules/partner"
 
 const PARTNER_PASSWORD = "supersecret"
 
@@ -131,6 +133,80 @@ setupSharedTestSuite(() => {
         validateStatus: () => true,
       })
       expect(otherDetail.status).toBe(404)
+    })
+
+    // #920 — `is_owner` must reflect whether the *current* partner owns the
+    // design, not merely that it has some owner. An assigned (linked but not
+    // owning) partner sees the design but must get is_owner=false so the UI
+    // hides owner-only surfaces (cost estimate, BOM add/remove) instead of
+    // rendering panels whose backend calls would 403.
+    it("emits is_owner per viewer: true for the owner, false for an assigned non-owner", async () => {
+      const { partnerId: ownerId, partnerHeaders: ownerHeaders } =
+        await createPartner(api, "iso-owner")
+      const { partnerId: assigneeId, partnerHeaders: assigneeHeaders } =
+        await createPartner(api, "iso-assignee")
+
+      const createRes = await api.post(
+        "/partners/designs",
+        { name: "Ownership Signal Jacket", design_type: "Original" },
+        { headers: ownerHeaders }
+      )
+      expect(createRes.status).toBe(201)
+      const designId = createRes.data.design.id
+
+      // Assign (link) the owner's design to a second partner — mirrors the
+      // admin assign / production-run auto-link path. The assignee can now read
+      // the detail but does NOT own it.
+      const remoteLink = getContainer().resolve(
+        ContainerRegistrationKeys.LINK
+      ) as any
+      await remoteLink.create({
+        [DESIGN_MODULE]: { design_id: designId },
+        [PARTNER_MODULE]: { partner_id: assigneeId },
+      })
+
+      // Owner detail → is_owner true, owner_partner_id is theirs.
+      const ownerDetail = await api.get(`/partners/designs/${designId}`, {
+        headers: ownerHeaders,
+      })
+      expect(ownerDetail.status).toBe(200)
+      expect(ownerDetail.data.design.is_owner).toBe(true)
+      expect(ownerDetail.data.design.owner_partner_id).toBe(ownerId)
+
+      // Assignee detail → 200 (linked, can view), but is_owner false even
+      // though owner_partner_id is set (it belongs to the owner).
+      const assigneeDetail = await api.get(`/partners/designs/${designId}`, {
+        headers: assigneeHeaders,
+      })
+      expect(assigneeDetail.status).toBe(200)
+      expect(assigneeDetail.data.design.is_owner).toBe(false)
+      expect(assigneeDetail.data.design.owner_partner_id).toBe(ownerId)
+
+      // List route mirrors the same signal + the "yours" bucket keys on it.
+      const ownerList = await api.get("/partners/designs?limit=100", {
+        headers: ownerHeaders,
+      })
+      expect(
+        (ownerList.data.designs || []).find((d: any) => d.id === designId)
+          ?.is_owner
+      ).toBe(true)
+
+      const assigneeList = await api.get("/partners/designs?limit=100", {
+        headers: assigneeHeaders,
+      })
+      const assigneeRow = (assigneeList.data.designs || []).find(
+        (d: any) => d.id === designId
+      )
+      expect(assigneeRow?.is_owner).toBe(false)
+
+      // The assigned non-owner's design is NOT in their "yours" bucket.
+      const assigneeYours = await api.get(
+        "/partners/designs?limit=100&bucket=yours",
+        { headers: assigneeHeaders }
+      )
+      expect(
+        (assigneeYours.data.designs || []).map((d: any) => d.id)
+      ).not.toContain(designId)
     })
 
     it("excludes partner-owned designs from the admin global list by default", async () => {

--- a/apps/backend/src/api/partners/designs/[designId]/route.ts
+++ b/apps/backend/src/api/partners/designs/[designId]/route.ts
@@ -254,10 +254,22 @@ export const GET = async (
 
   const invNode = (invResult?.data || [])[0] || {}
 
+  // Whether the *current* partner owns this design (vs merely being assigned to
+  // it via the design-partners link). This is the sole ownership signal — there
+  // is no `supplies_to_platform` flag. The partner-ui gates owner-only surfaces
+  // (cost estimate, BOM add/remove) on this rather than a truthiness check on
+  // `owner_partner_id`, which is true for any owned design regardless of viewer.
+  const owner_partner_id =
+    (workflowDesign as any)?.owner_partner_id ??
+    (linkData.design as any)?.owner_partner_id ??
+    null
+  const is_owner = owner_partner_id != null && owner_partner_id === partner.id
+
   // Merge partner_info and inventory_items into the design payload
   const design = {
     ...(workflowDesign || linkData.design),
     partner_info,
+    is_owner,
     inventory_items: invNode?.inventory_items || [],
   }
 

--- a/apps/backend/src/api/partners/designs/__tests__/list-filters.unit.spec.ts
+++ b/apps/backend/src/api/partners/designs/__tests__/list-filters.unit.spec.ts
@@ -11,12 +11,18 @@ const make = (
     status: string
     partner_status: string
     owner_partner_id: string | null
+    is_owner: boolean
   }> = {}
 ) => ({
   id: over.id ?? "design_1",
   name: over.name ?? "Untitled",
   status: over.status ?? "Conceptual",
   owner_partner_id: over.owner_partner_id ?? null,
+  // `is_owner` is what the route computes (owner === current partner); the
+  // "yours" bucket keys on it, not on `owner_partner_id` presence. Defaults to
+  // whether an owner is set unless overridden — lets tests model the
+  // assigned-but-owned-by-another-partner case (owner set, is_owner false).
+  is_owner: over.is_owner ?? over.owner_partner_id != null,
   partner_info: { partner_status: over.partner_status ?? "incoming" },
 })
 
@@ -115,9 +121,14 @@ describe("design work buckets (#6 partner tabs)", () => {
     expect(matchesBucket(make({ partner_status: "incoming" }), "completed")).toBe(false)
   })
 
-  it("yours keys on ownership regardless of status", () => {
-    expect(matchesBucket(make({ owner_partner_id: "p" }), "yours")).toBe(true)
+  it("yours keys on ownership (is_owner) regardless of status", () => {
+    expect(matchesBucket(make({ owner_partner_id: "p", is_owner: true }), "yours")).toBe(true)
     expect(matchesBucket(make({ owner_partner_id: null }), "yours")).toBe(false)
+    // #920 — assigned to this partner but owned by ANOTHER: owner_partner_id is
+    // set, yet is_owner is false → NOT "yours" (the bug the fix closes).
+    expect(
+      matchesBucket(make({ owner_partner_id: "other_partner", is_owner: false }), "yours")
+    ).toBe(false)
   })
 
   it("computes facet counts over the full set (yours cross-cuts status)", () => {

--- a/apps/backend/src/api/partners/designs/list-filters.ts
+++ b/apps/backend/src/api/partners/designs/list-filters.ts
@@ -18,6 +18,8 @@ export type PartnerDesignView = {
   name?: string | null
   status?: string | null
   owner_partner_id?: string | null
+  /** Set by the list route: true when the *current* partner owns this design. */
+  is_owner?: boolean
   partner_info?: { partner_status?: string | null } | null
   [key: string]: unknown
 }
@@ -44,12 +46,15 @@ export type DesignListFilters = {
  *   incoming    → partner_status ∈ {incoming, assigned}       (needs acceptance)
  *   in_progress → partner_status ∈ {in_progress, awaiting_review}
  *   completed   → partner_status ∈ {finished, completed}
- *   yours       → owner_partner_id set (designs the partner created), any status
+ *   yours       → owned by the current partner (created via self-serve), any status
  *   all         → everything
  */
 export function matchesBucket(design: PartnerDesignView, bucket: DesignBucket): boolean {
   if (bucket === "all") return true
-  if (bucket === "yours") return !!design.owner_partner_id
+  // Keyed on `is_owner` (owner_partner_id === current partner), NOT a bare
+  // truthiness check on owner_partner_id — an assigned design owned by another
+  // partner would otherwise be counted as "yours".
+  if (bucket === "yours") return !!design.is_owner
   const ps = String(design.partner_info?.partner_status || "")
   switch (bucket) {
     case "incoming":

--- a/apps/backend/src/api/partners/designs/route.ts
+++ b/apps/backend/src/api/partners/designs/route.ts
@@ -327,6 +327,13 @@ export async function GET(
     return {
       ...design,
       partner_info,
+      // Whether the *current* partner owns this design (vs merely being assigned
+      // to it). Mirrors the detail route so the UI's "Yours"/"Assigned" source
+      // badge is accurate — a bare truthiness check on `owner_partner_id` would
+      // mislabel a design owned by another partner but assigned to this one.
+      is_owner:
+        design.owner_partner_id != null &&
+        design.owner_partner_id === partner.id,
     }
   })
 

--- a/apps/partner-ui/src/components/work-orders/collated-design-detail.tsx
+++ b/apps/partner-ui/src/components/work-orders/collated-design-detail.tsx
@@ -164,7 +164,7 @@ export const DesignSpecs = ({ design }: { design: any }) => {
       <DesignInventoryBomSection design={design} />
       {/* Cost estimate only matters for partner-owned designs — hide it for
           JYT-owned work-orders (#5). */}
-      {!!design?.owner_partner_id && <DesignCostSection design={design} />}
+      {!!design?.is_owner && <DesignCostSection design={design} />}
     </>
   )
 }

--- a/apps/partner-ui/src/hooks/api/partner-designs.tsx
+++ b/apps/partner-ui/src/hooks/api/partner-designs.tsx
@@ -33,6 +33,14 @@ export type PartnerDesign = Record<string, any> & {
   updated_at?: string
   partner_info?: PartnerDesignPartnerInfo
   inventory_items?: Array<Record<string, any>>
+  /**
+   * True when the *current* partner owns this design (not merely assigned to it
+   * via the design-partners link). Set by `GET /partners/designs/:id`. Owner-only
+   * surfaces (cost estimate, BOM add/remove) gate on this — do NOT infer ownership
+   * from a truthiness check on `owner_partner_id`, which is true for any owned
+   * design regardless of who is viewing.
+   */
+  is_owner?: boolean
 }
 
 /** #6 — the partner "work" tab buckets (server-side lens over the same set). */

--- a/apps/partner-ui/src/routes/designs/design-detail/components/design-cost-section.tsx
+++ b/apps/partner-ui/src/routes/designs/design-detail/components/design-cost-section.tsx
@@ -33,7 +33,7 @@ const fmt = (v?: number | null, currency?: string | null) =>
  * their own production cost, which overrides the auto estimate.
  */
 export const DesignCostSection = ({ design }: Props) => {
-  const isOwner = !!(design as any).owner_partner_id
+  const isOwner = !!design.is_owner
   const { cost, isLoading } = usePartnerDesignCost(design.id)
   const { mutateAsync: recalc, isPending } = useRecalculatePartnerDesignCost(
     design.id

--- a/apps/partner-ui/src/routes/designs/design-detail/components/design-inventory-bom-section.tsx
+++ b/apps/partner-ui/src/routes/designs/design-detail/components/design-inventory-bom-section.tsx
@@ -53,7 +53,7 @@ function extractMedia(line: PartnerDesignInventoryItem): string[] {
 
 export const DesignInventoryBomSection = ({ design }: Props) => {
   const prompt = usePrompt()
-  const isOwner = !!(design as any).owner_partner_id
+  const isOwner = !!design.is_owner
   const { inventory_items, isLoading } = usePartnerDesignInventory(design.id)
   const { mutateAsync: delink } = useDelinkPartnerDesignInventory(design.id)
 

--- a/apps/partner-ui/src/routes/designs/design-detail/components/design-owner-actions-section.tsx
+++ b/apps/partner-ui/src/routes/designs/design-detail/components/design-owner-actions-section.tsx
@@ -25,7 +25,7 @@ export const DesignOwnerActionsSection = ({ design }: Props) => {
   const prompt = usePrompt()
   const { mutateAsync } = useDeletePartnerDesign(design.id)
 
-  const isOwner = !!(design as any).owner_partner_id
+  const isOwner = !!design.is_owner
   const { production_runs = [] } = usePartnerProductionRuns(
     { design_id: design.id, limit: 50 },
     { enabled: isOwner }

--- a/apps/partner-ui/src/routes/designs/design-detail/design-detail.tsx
+++ b/apps/partner-ui/src/routes/designs/design-detail/design-detail.tsx
@@ -497,7 +497,10 @@ export const DesignDetail = ({ designId, backTo }: DesignDetailProps = {}) => {
         {/* Production & Material Usage — highest priority for partners */}
         {design && <DesignInventoryBomSection design={design} />}
 
-        {design && <DesignCostSection design={design} />}
+        {/* Cost estimate (incl. the JYT platform fee) is owner-only — hidden
+            for partners merely assigned to the design, whose cost fetch would
+            403 anyway (#920). */}
+        {design && design.is_owner && <DesignCostSection design={design} />}
 
         {/* Start production now lives in the owner command header above
             (DesignOwnerActionsSection); the run list follows. */}

--- a/apps/partner-ui/src/routes/designs/design-list/design-list.tsx
+++ b/apps/partner-ui/src/routes/designs/design-list/design-list.tsx
@@ -234,7 +234,7 @@ export const DesignList = () => {
           <span className="font-medium">{getValue() || "-"}</span>
         ),
       }),
-      columnHelper.accessor((row) => (row as any)?.owner_partner_id, {
+      columnHelper.accessor((row) => (row as any)?.is_owner, {
         id: "source",
         header: () => "Source",
         cell: ({ getValue }) => (

--- a/apps/partner-ui/src/routes/orders/order-detail/order-detail.tsx
+++ b/apps/partner-ui/src/routes/orders/order-detail/order-detail.tsx
@@ -195,7 +195,7 @@ export const OrderDetail = () => {
                   <DesignSizeSetsSection design={design} />
                   <DesignInventoryBomSection design={design} />
                   {/* Cost estimate only for partner-owned designs (#5). */}
-                  {!!(design as any)?.owner_partner_id && (
+                  {!!design?.is_owner && (
                     <DesignCostSection design={design} />
                   )}
                 </>


### PR DESCRIPTION
Closes #920.

## Problem
The partner design detail page is reachable by any **assigned** partner (via `design_partners_link`), but the UI inferred ownership from `!!design.owner_partner_id` — a truthiness check that is true for **any** owned design regardless of who is viewing. So an assigned non-owner saw:
- the **cost estimate** panel (whose fetch 403s → broken/empty), and
- owner-only **BOM add/remove** controls (mutations 403).

The design list also mislabelled such designs as **"Yours"**, and the server-side `bucket=yours` facet counted them.

## Fix
Backend emits an accurate **per-viewer `is_owner`** (`owner_partner_id === current partner`) from both the detail (`GET /partners/designs/:id`) and list (`GET /partners/designs`) routes; the "yours" bucket + facet key on it too. The partner-ui reads `design.is_owner` everywhere ownership is gated:
- cost section render gated (hidden entirely for non-owners) + internal controls
- BOM add/remove controls
- owner action header (Start production / Edit / Delete)
- order detail + collated work-order design views
- design-list "Source" (Yours / Assigned) badge

`owner_partner_id` is the sole ownership signal — no `supplies_to_platform` flag exists.

## Tests
- `list-filters` unit: adds the **assigned-but-owned-by-another** case (owner set, `is_owner` false → not "yours").
- `partner-design-crud` integration: asserts `is_owner` is **true for the owner** and **false for an assigned non-owner** across detail, list, and the yours bucket. **5/5 green.**

Verify: `pnpm test:integration:http:shared ./integration-tests/http/partner-design-crud`

🤖 Generated with [Claude Code](https://claude.com/claude-code)