### PR TITLE
fix(handloom-import): HTTP Basic auth for Medusa sk_ keys + richer person import [#1030]

### DIFF
--- a/scripts/handloom-scrape/import_to_persons.py
+++ b/scripts/handloom-scrape/import_to_persons.py
@@ -44,19 +44,36 @@ def load_approved_records(data_dir: Path) -> list[dict]:
 
 
 def map_weaver_to_person(weaver: dict) -> dict:
-    """Map census weaver record to Person API payload."""
+    """Map census weaver record to Person API payload.
+
+    The POST /admin/persons schema (personSchema) only accepts:
+      first_name*, last_name*, email*, addresses[], state, public_metadata
+      (* = required)
+
+    contact_details and tags must be created via separate endpoints
+    after the person record exists.
+    """
     name = (weaver.get("name") or "").strip()
     name_parts = name.split(" ", 1)
     first_name = name_parts[0] if name_parts else name
-    last_name = name_parts[1] if len(name_parts) > 1 else ""
+    # personSchema requires first_name.min(1); a nameless record can't be a valid
+    # Person, so reject it here (caller skips it) rather than 422 at the API.
+    if not first_name:
+        raise ValueError("record has no usable name")
+    # personSchema requires last_name.min(1); single-word names (common for
+    # rural weavers) have no surname, so fall back to a filterable placeholder.
+    last_name = name_parts[1] if len(name_parts) > 1 else "(not provided)"
+
+    census_id = weaver.get("census_id")
 
     person = {
         "first_name": first_name,
         "last_name": last_name,
+        "email": f"weaver.{census_id}@handloom.gov.in",
         "state": "Onboarding",
         "public_metadata": {
             "source": "census_portal",
-            "census_id": weaver.get("census_id"),
+            "census_id": census_id,
             "survey_date": weaver.get("survey_date"),
             "age": weaver.get("age"),
             "gender": weaver.get("gender"),
@@ -117,67 +134,116 @@ def map_weaver_to_person(weaver: dict) -> dict:
     if addresses:
         person["addresses"] = addresses
 
-    contact_details = []
+    return person
+
+
+def build_contact_payload(weaver: dict) -> Optional[dict]:
     phone = weaver.get("mobile")
     if phone and phone != "91XXXXXXXXXX":
-        contact_details.append({"phone_number": phone, "type": "mobile"})
+        return {"phone_number": phone, "type": "mobile"}
+    return None
 
-    if contact_details:
-        person["contact_details"] = contact_details
 
+def build_tag_payloads(weaver: dict) -> list[str]:
+    """Return the tag names for a weaver.
+
+    POST /admin/persons/{id}/tags (tagSchema) expects `{ "name": [str, ...] }`
+    — a single request with an array of names, NOT one request per tag.
+    """
     tags = []
     if weaver.get("own_looms") is True:
-        tags.append({"name": "loom-owner"})
+        tags.append("loom-owner")
     if weaver.get("own_looms") is False:
-        tags.append({"name": "contract-weaver"})
+        tags.append("contract-weaver")
     if weaver.get("natural_dye_used"):
-        tags.append({"name": "natural-dye"})
+        tags.append("natural-dye")
     if weaver.get("social_group"):
-        tags.append({"name": weaver["social_group"].lower().replace(" ", "-")})
+        tags.append(weaver["social_group"].lower().replace(" ", "-"))
     if weaver.get("religion"):
-        tags.append({"name": weaver["religion"].lower().replace(" ", "-")})
+        tags.append(weaver["religion"].lower().replace(" ", "-"))
     if weaver.get("gender"):
-        tags.append({"name": weaver["gender"].lower()})
+        tags.append(weaver["gender"].lower())
     if weaver.get("state"):
-        tags.append({"name": f"state-{weaver['state'].lower().replace(' ', '-')}"})
-
-    if tags:
-        person["tags"] = tags
-
-    return person
+        tags.append(f"state-{weaver['state'].lower().replace(' ', '-')}")
+    return tags
 
 
 async def import_persons(
     api_url: str,
     api_key: str,
+    records: list[dict],
     persons: list[dict],
     dry_run: bool = False,
 ) -> tuple[int, int]:
     created = 0
     errors = 0
 
-    headers = {
-        "Content-Type": "application/json",
-        "x-api-key": api_key,
-    }
-    if not api_key.startswith("Bearer "):
-        headers["Authorization"] = f"Bearer {api_key}"
+    headers = {"Content-Type": "application/json"}
+    # Medusa admin API keys are SECRET keys (sk_...) and authenticate via HTTP
+    # Basic auth — the key is the username, password is empty. Bearer/x-api-key
+    # are rejected with 401. A raw JWT (from an admin session) still uses Bearer.
+    auth = None
+    token = api_key[len("Bearer ") :] if api_key.startswith("Bearer ") else api_key
+    if token.startswith("sk_") or token.startswith("pk_"):
+        auth = httpx.BasicAuth(token, "")
+    elif token:
+        headers["Authorization"] = f"Bearer {token}"
 
-    async with httpx.AsyncClient(timeout=60.0, headers=headers) as client:
-        for i, person in enumerate(persons):
+    console.print(f"[dim]API calls per record:[/dim]")
+    console.print(f"[dim]  1. POST /admin/persons (basic fields + addresses + public_metadata)[/dim]")
+    console.print(f"[dim]  2. POST /admin/persons/{{id}}/contacts (phone, if available)[/dim]")
+    console.print(f"[dim]  3. POST /admin/persons/{{id}}/tags (inferred tags, if any)[/dim]")
+    console.print()
+
+    async with httpx.AsyncClient(timeout=60.0, headers=headers, auth=auth) as client:
+        for record, person in zip(records, persons):
+            name = f"{person['first_name']} {person['last_name']}"
+
             if dry_run:
-                console.print(f"[dim]DRY RUN: Would create person {person['first_name']} {person['last_name']}[/dim]")
+                console.print(f"[dim]DRY RUN: {name} → email={person['email']}, "
+                              f"addr={len(person.get('addresses', []))}, "
+                              f"contact={bool(build_contact_payload(record))}, "
+                              f"tags={len(build_tag_payloads(record))}[/dim]")
                 continue
 
             try:
+                # Step 1: Create person
                 resp = await client.post(f"{api_url}/admin/persons", json=person)
-                if resp.status_code in (200, 201):
-                    created += 1
-                else:
-                    console.print(f"[red]Error creating person: {resp.status_code} {resp.text[:200]}[/red]")
+                if resp.status_code not in (200, 201):
+                    console.print(f"[red]Error creating {name}: {resp.status_code} {resp.text[:200]}[/red]")
                     errors += 1
+                    continue
+
+                person_id = resp.json().get("person", {}).get("id")
+                if not person_id:
+                    console.print(f"[red]No person ID returned for {name}, response: {resp.text[:200]}[/red]")
+                    errors += 1
+                    continue
+
+                # Step 2: Create contact detail (phone)
+                contact = build_contact_payload(record)
+                if contact:
+                    cr = await client.post(
+                        f"{api_url}/admin/persons/{person_id}/contacts",
+                        json=contact,
+                    )
+                    if cr.status_code not in (200, 201):
+                        console.print(f"[yellow]Warn: contact failed for {name}: {cr.status_code}[/yellow]")
+
+                # Step 3: Create tags — one request with an array of names
+                tags = build_tag_payloads(record)
+                if tags:
+                    tr = await client.post(
+                        f"{api_url}/admin/persons/{person_id}/tags",
+                        json={"name": tags},
+                    )
+                    if tr.status_code not in (200, 201):
+                        console.print(f"[yellow]Warn: tags {tags} failed for {name}: {tr.status_code} {tr.text[:150]}[/yellow]")
+
+                created += 1
+
             except httpx.RequestError as e:
-                console.print(f"[red]Request failed: {e}[/red]")
+                console.print(f"[red]Request failed for {name}: {e}[/red]")
                 errors += 1
 
     return created, errors
@@ -202,10 +268,14 @@ def run(
     console.print(f"  API URL: {api_url}")
     console.print(f"  Dry Run: {dry_run}")
 
+    # Keep record<->person pairs aligned: import_persons zips them to attach the
+    # right contacts/tags, so a skipped mapping must drop BOTH, not just the person.
+    mapped_records = []
     persons = []
     for r in records:
         try:
             persons.append(map_weaver_to_person(r))
+            mapped_records.append(r)
         except Exception as e:
             console.print(f"[red]Error mapping record {r.get('census_id')}: {e}[/red]")
 
@@ -213,7 +283,7 @@ def run(
 
     import asyncio
 
-    created, errors = asyncio.run(import_persons(api_url, api_key, persons, dry_run))
+    created, errors = asyncio.run(import_persons(api_url, api_key, mapped_records, persons, dry_run))
 
     table = Table(title="Import Results")
     table.add_column("Metric", style="cyan")

--- a/scripts/handloom-scrape/parser.py
+++ b/scripts/handloom-scrape/parser.py
@@ -34,7 +34,8 @@ class WeaverRecord(BaseModel):
     education: Optional[str] = None
     religion: Optional[str] = None
     social_group: Optional[str] = None
-    mobile: Optional[str] = None
+    mobile: Optional[str] = None          # real number (stored privately)
+    mobile_masked: Optional[str] = None   # portal's public mask, e.g. 91XXXXXXXXXX
     aadhaar_issued: Optional[bool] = None
 
     latitude: Optional[float] = None
@@ -58,6 +59,7 @@ class WeaverRecord(BaseModel):
     # Loom details
     own_looms: Optional[bool] = None
     total_looms_owned: Optional[int] = None
+    total_looms_worked: Optional[int] = None  # operated but not owned
     pit_loom_count: Optional[int] = 0
     frame_loom_count: Optional[int] = 0
     loin_loom_count: Optional[int] = 0
@@ -92,6 +94,24 @@ class WeaverRecord(BaseModel):
 def parse_value(cell) -> str:
     text = cell.get_text(strip=True)
     return text
+
+
+def _extract_mobile(html: str) -> tuple[Optional[str], Optional[str]]:
+    """Return (real, masked) mobile.
+
+    The portal renders a masked mobile and keeps the real number in an adjacent
+    HTML comment: `<!-- <td...>8295880181</td> --> <td...>91XXXXXXXXXX</td>`.
+    """
+    m = re.search(
+        r'Mobile no</td>\s*<!--\s*<td[^>]*>([0-9Xx]+)</td>\s*-->\s*<td[^>]*>([0-9Xx]+)</td>',
+        html,
+    )
+    if m:
+        return m.group(1), m.group(2)
+    m2 = re.search(r'Mobile no</td>\s*<td[^>]*>([0-9Xx]+)</td>', html)
+    if m2:
+        return None, m2.group(1)
+    return None, None
 
 
 def clean_phone(phone: str) -> Optional[str]:
@@ -155,9 +175,13 @@ def parse_weaver_page(html: str, census_id: int) -> Optional[WeaverRecord]:
     record.education = td_pairs.get("1.6")
     record.aadhaar_issued = _parse_bool(td_pairs.get("1.8"))
 
-    raw_phone = td_pairs.get("1.9") or ""
-    if raw_phone and raw_phone not in ('', '91XXXXXXXXXX'):
-        record.mobile = clean_phone(raw_phone)
+    # The portal masks the mobile in the rendered cell (e.g. "91XXXXXXXXXX")
+    # and keeps the real number in an adjacent HTML comment. We store the real
+    # number privately and the mask for public display (status quo preserved).
+    real_mobile, masked_mobile = _extract_mobile(html)
+    if real_mobile:
+        record.mobile = clean_phone(real_mobile)
+    record.mobile_masked = masked_mobile or (td_pairs.get("1.9") or None)
 
     # Section 2: Address
     record.rural_urban = td_pairs.get("2.1")
@@ -250,55 +274,56 @@ def _parse_yarn_consumption(td_pairs: dict) -> dict:
 
 
 def _parse_loom_details(soup: BeautifulSoup, record: WeaverRecord):
-    loom_tables = soup.find_all('table')
-    for table in loom_tables:
-        header = table.find_previous(['h4', 'h5'])
-        if header and 'loom' not in header.get_text(strip=True).lower():
+    """Parse the loom table (section 5.1).
+
+    Live layout (a category cell rowspans, so column count is 6 or 7):
+      [category?] | Type | Code | Own(Yes/No) | No.Owned | No.Working | No.Idle
+    We key off the trailing 4 columns [own, owned, working, idle] rather than
+    fixed indices, and categorise from the row's leading text.
+    """
+    total_owned = 0
+    total_worked = 0
+    found = False
+
+    for tr in soup.find_all('tr'):
+        texts = [c.get_text(strip=True) for c in tr.find_all(['td', 'th'])]
+        if len(texts) < 5:
             continue
-        rows = table.find_all('tr')
-        for row in rows:
-            cells = row.find_all(['td', 'th'])
-            texts = [c.get_text(strip=True) for c in cells]
+        own, owned_s, working_s, idle_s = texts[-4:]
+        if own.strip().lower() not in ('yes', 'no'):
+            continue
+        owned = _parse_int(owned_s)
+        working = _parse_int(working_s)
+        if owned is None or working is None:
+            continue  # trailing cells aren't the loom count triplet
+        label = " ".join(texts[:-4]).lower()
+        if 'loom' not in label:
+            continue
 
-            if not texts:
-                continue
+        found = True
+        total_owned += owned
+        total_worked += working
+        if 'pit' in label:
+            record.pit_loom_count = (record.pit_loom_count or 0) + owned
+        elif 'frame' in label:
+            record.frame_loom_count = (record.frame_loom_count or 0) + owned
+        elif 'loin' in label:
+            record.loin_loom_count = (record.loin_loom_count or 0) + owned
+        else:
+            record.other_loom_count = (record.other_loom_count or 0) + owned
 
-            combined = " ".join(texts).lower()
+    if found:
+        record.total_looms_owned = total_owned
+        record.total_looms_worked = total_worked
+        record.own_looms = total_owned > 0
 
-            # Check for "own looms" row
-            if 'pit loom with' in combined or 'other pit looms' in combined:
-                if len(texts) >= 5:
-                    owns = texts[3].lower()
-                    count = _parse_int(texts[4])
-                    if owns == 'yes':
-                        record.total_looms_owned = (record.total_looms_owned or 0) + (count or 0)
-                        record.pit_loom_count = (record.pit_loom_count or 0) + (count or 0)
-            elif 'frame loom with' in combined or 'other frame looms' in combined:
-                if len(texts) >= 5:
-                    owns = texts[3].lower()
-                    count = _parse_int(texts[4])
-                    if owns == 'yes':
-                        record.total_looms_owned = (record.total_looms_owned or 0) + (count or 0)
-                        record.frame_loom_count = (record.frame_loom_count or 0) + (count or 0)
-            elif 'loin looms' in combined:
-                if len(texts) >= 5:
-                    owns = texts[3].lower()
-                    count = _parse_int(texts[4])
-                    if owns == 'yes':
-                        record.total_looms_owned = (record.total_looms_owned or 0) + (count or 0)
-                        record.loin_loom_count = (record.loin_loom_count or 0) + (count or 0)
-            elif combined == 'others' or combined.startswith('others\t'):
-                if len(texts) >= 5:
-                    owns = texts[3].lower()
-                    count = _parse_int(texts[4])
-                    if owns == 'yes':
-                        record.total_looms_owned = (record.total_looms_owned or 0) + (count or 0)
-                        record.other_loom_count = (record.other_loom_count or 0) + (count or 0)
-
-    if record.total_looms_owned and record.total_looms_owned > 0:
-        record.own_looms = True
-    elif record.total_looms_owned == 0:
-        record.own_looms = False
+    # Fallback from household type when the table is absent/ambiguous.
+    if record.own_looms is None and record.household_type:
+        ht = record.household_type.lower()
+        if "don" in ht and "own loom" in ht:      # "Don't own looms ..."
+            record.own_looms = False
+        elif "own loom" in ht:
+            record.own_looms = True
 
 
 def _parse_input_sources(soup: BeautifulSoup, record: WeaverRecord):


### PR DESCRIPTION
Supersedes #1030 (which conflicts with main and is 96% a stale duplicate of the #1031 census/Hyperbee infra already on main).

## What this lands
The only genuinely un-landed value from `feat/handloom-scrape-fixes-1028` — two self-contained scripts:

- **`import_to_persons.py`** — the census→`/admin/persons` importer authed with `Bearer`/`x-api-key`, which Medusa's admin API **rejects with 401** for secret keys. Medusa `sk_` keys authenticate via **HTTP Basic** (key = username, empty password). Now picks Basic for `sk_`/`pk_` keys, keeps Bearer only for raw admin JWTs. Also threads the source record through so each import creates the person's **contact (phone) + inferred tags**.
- **`parser.py`** — live-portal parser fixes (mobile-comment field, loom columns).

## Why not merge #1030 directly
Main already contains the full `scripts/handloom-scrape/` tree (landed via #1031). #1030's other 48 files (hyperbee-slice, reader-service, deploy, 5.6k insertions) duplicate that already-merged work and conflict. Merging it would resurrect superseded code. Verified main still carries the Bearer bug; this extracts just the fix onto a clean branch.

Both scripts `py_compile` clean and import nothing from the dropped files.

🤖 Generated with [Claude Code](https://claude.com/claude-code)