### PR TITLE
style(moodboard): restyle Excalidraw canvas in Medusa primitives + bottom dock [#1113]

### DIFF
--- a/apps/partner-ui/src/routes/designs/design-moodboard/design-moodboard.tsx
+++ b/apps/partner-ui/src/routes/designs/design-moodboard/design-moodboard.tsx
@@ -1,5 +1,8 @@
 import { Button, DropdownMenu, Heading, Text, toast } from "@medusajs/ui"
 import "@excalidraw/excalidraw/index.css"
+// Scoped overrides that map Excalidraw's theme variables onto Medusa tokens —
+// must import after Excalidraw's own CSS so equal-specificity ties resolve to us.
+import "./moodboard.css"
 import { Fragment, useCallback, useEffect, useMemo, useRef, useState } from "react"
 import { Excalidraw } from "@excalidraw/excalidraw"
 import type { ExcalidrawElement } from "@excalidraw/excalidraw/element/types"
@@ -237,8 +240,37 @@ const reidAndTranslate = (
   })
 }
 
+// Resolve the effective admin theme so the canvas matches its surroundings
+// instead of Excalidraw's hard-coded light default. Medusa's admin (and this
+// embedded dashboard) toggles a `.dark` class on the document root, which itself
+// tracks the user's system/admin preference.
+const getAdminTheme = (): "light" | "dark" =>
+  typeof document !== "undefined" &&
+  document.documentElement.classList.contains("dark")
+    ? "dark"
+    : "light"
+
 export const DesignMoodboard = () => {
   const id = useResolvedDesignId()
+
+  // Follow the admin theme live — observe the root `.dark` class (and system
+  // preference as a fallback) so toggling dark mode reflows the canvas.
+  const [theme, setTheme] = useState<"light" | "dark">(getAdminTheme)
+  useEffect(() => {
+    const update = () => setTheme(getAdminTheme())
+    update()
+    const observer = new MutationObserver(update)
+    observer.observe(document.documentElement, {
+      attributes: true,
+      attributeFilter: ["class"],
+    })
+    const media = window.matchMedia?.("(prefers-color-scheme: dark)")
+    media?.addEventListener?.("change", update)
+    return () => {
+      observer.disconnect()
+      media?.removeEventListener?.("change", update)
+    }
+  }, [])
 
   const apiRef = useRef<ExcalidrawImperativeAPI | null>(null)
   const didInitRef = useRef(false)
@@ -559,7 +591,7 @@ export const DesignMoodboard = () => {
             </Text>
           </div>
         ) : (
-          <div className="relative w-full h-[calc(100dvh-160px)]">
+          <div className="jyt-moodboard relative w-full h-[calc(100dvh-160px)]">
             {layersOpen ? (
               <div className="absolute top-14 left-2 z-50 w-64">
                 <MoodboardLayersPanel
@@ -570,11 +602,12 @@ export const DesignMoodboard = () => {
               </div>
             ) : null}
             <Excalidraw
+              theme={theme}
               excalidrawAPI={(api) => {
                 apiRef.current = api
               }}
-              initialData={
-                (moodboard as any) || {
+              initialData={(() => {
+                const base = (moodboard as any) || {
                   type: "excalidraw",
                   version: 2,
                   source: "https://excalidraw.com",
@@ -582,87 +615,15 @@ export const DesignMoodboard = () => {
                   appState: {},
                   files: {},
                 }
-              }
+                // Force the live admin theme at mount so a stale saved
+                // appState.theme can't leave the canvas on the wrong theme.
+                return {
+                  ...base,
+                  appState: { ...(base.appState || {}), theme },
+                }
+              })()}
               viewModeEnabled={false}
               onChange={handleChange}
-              renderTopRightUI={() => (
-                <div className="flex items-center gap-1.5 flex-wrap justify-end max-w-[62vw]">
-                  <DropdownMenu>
-                    <DropdownMenu.Trigger asChild>
-                      <Button
-                        size="small"
-                        variant="secondary"
-                        disabled={!id || isSaving || isInserting}
-                        isLoading={isInserting}
-                      >
-                        Insert block
-                      </Button>
-                    </DropdownMenu.Trigger>
-                    <DropdownMenu.Content>
-                      {groupedBlocks.length === 0 ? (
-                        <DropdownMenu.Item disabled>
-                          No blocks available
-                        </DropdownMenu.Item>
-                      ) : (
-                        groupedBlocks.map((grp, gi) => (
-                          <Fragment key={grp.group}>
-                            {gi > 0 ? <DropdownMenu.Separator /> : null}
-                            <DropdownMenu.Label>{grp.group}</DropdownMenu.Label>
-                            {grp.items.map((b) => (
-                              <DropdownMenu.Item
-                                key={b.key}
-                                // Brief blocks stay insertable even when empty —
-                                // they drop an editable template you fill in place.
-                                disabled={b.group !== "Brief" && !b.available}
-                                onClick={() => handleInsert(b.key, b.label)}
-                              >
-                                {b.label}
-                                {!b.available ? (
-                                  <span className="text-ui-fg-muted ml-1">· empty</span>
-                                ) : null}
-                              </DropdownMenu.Item>
-                            ))}
-                          </Fragment>
-                        ))
-                      )}
-                    </DropdownMenu.Content>
-                  </DropdownMenu>
-                  <Button
-                    size="small"
-                    variant="secondary"
-                    onClick={() => setConstructionOpen(true)}
-                    disabled={!id || isSaving}
-                  >
-                    Add construction
-                  </Button>
-                  <Button
-                    size="small"
-                    variant="secondary"
-                    onClick={handleGenerate}
-                    disabled={!id || isGenerating || isSaving}
-                    isLoading={isGenerating}
-                  >
-                    Generate
-                  </Button>
-                  <Button
-                    size="small"
-                    variant={layersOpen ? "primary" : "secondary"}
-                    onClick={() => setLayersOpen((v) => !v)}
-                    disabled={!id}
-                  >
-                    Layers
-                  </Button>
-                  <Button
-                    size="small"
-                    variant="primary"
-                    onClick={handleSave}
-                    disabled={!id || isSaving || !isDirty}
-                    isLoading={isSaving}
-                  >
-                    {isDirty ? "Save" : "Saved"}
-                  </Button>
-                </div>
-              )}
               UIOptions={{
                 canvasActions: {
                   changeViewBackgroundColor: true,
@@ -671,11 +632,90 @@ export const DesignMoodboard = () => {
                   export: { saveFileToDisk: true },
                   loadScene: false,
                   clearCanvas: false,
-                  toggleTheme: true,
+                  // Theme is controlled to follow the admin — no manual toggle.
+                  toggleTheme: false,
                 },
               }}
               detectScroll={true}
             />
+
+            {/* Floating action dock — pinned bottom-center over the canvas. */}
+            <div className="absolute bottom-4 left-1/2 z-[60] -translate-x-1/2 flex items-center gap-1 flex-nowrap rounded-full border border-ui-border-base bg-ui-bg-base shadow-elevation-flyout px-1.5 py-1">
+              <DropdownMenu>
+                <DropdownMenu.Trigger asChild>
+                  <Button
+                    size="small"
+                    variant="secondary"
+                    disabled={!id || isSaving || isInserting}
+                    isLoading={isInserting}
+                  >
+                    Insert block
+                  </Button>
+                </DropdownMenu.Trigger>
+                <DropdownMenu.Content side="top" sideOffset={8}>
+                  {groupedBlocks.length === 0 ? (
+                    <DropdownMenu.Item disabled>
+                      No blocks available
+                    </DropdownMenu.Item>
+                  ) : (
+                    groupedBlocks.map((grp, gi) => (
+                      <Fragment key={grp.group}>
+                        {gi > 0 ? <DropdownMenu.Separator /> : null}
+                        <DropdownMenu.Label>{grp.group}</DropdownMenu.Label>
+                        {grp.items.map((b) => (
+                          <DropdownMenu.Item
+                            key={b.key}
+                            // Brief blocks stay insertable even when empty —
+                            // they drop an editable template you fill in place.
+                            disabled={b.group !== "Brief" && !b.available}
+                            onClick={() => handleInsert(b.key, b.label)}
+                          >
+                            {b.label}
+                            {!b.available ? (
+                              <span className="text-ui-fg-muted ml-1">· empty</span>
+                            ) : null}
+                          </DropdownMenu.Item>
+                        ))}
+                      </Fragment>
+                    ))
+                  )}
+                </DropdownMenu.Content>
+              </DropdownMenu>
+              <Button
+                size="small"
+                variant="secondary"
+                onClick={() => setConstructionOpen(true)}
+                disabled={!id || isSaving}
+              >
+                Add construction
+              </Button>
+              <Button
+                size="small"
+                variant="secondary"
+                onClick={handleGenerate}
+                disabled={!id || isGenerating || isSaving}
+                isLoading={isGenerating}
+              >
+                Generate
+              </Button>
+              <Button
+                size="small"
+                variant={layersOpen ? "primary" : "secondary"}
+                onClick={() => setLayersOpen((v) => !v)}
+                disabled={!id}
+              >
+                Layers
+              </Button>
+              <Button
+                size="small"
+                variant="primary"
+                onClick={handleSave}
+                disabled={!id || isSaving || !isDirty}
+                isLoading={isSaving}
+              >
+                {isDirty ? "Save" : "Saved"}
+              </Button>
+            </div>
           </div>
         )}
       </RouteFocusModal.Body>
@@ -683,8 +723,8 @@ export const DesignMoodboard = () => {
       <RouteFocusModal.Footer>
         <div className="flex items-center justify-between w-full gap-x-2">
           <Text size="xsmall" className="text-ui-fg-muted">
-            Insert, construction, generate, layers &amp; save are in the canvas
-            toolbar (top-right).
+            Insert, construction, generate, layers &amp; save are in the dock at
+            the bottom of the canvas.
           </Text>
           <RouteFocusModal.Close asChild>
             <Button size="small" variant="secondary">

--- a/apps/partner-ui/src/routes/designs/design-moodboard/moodboard.css
+++ b/apps/partner-ui/src/routes/designs/design-moodboard/moodboard.css
@@ -1,0 +1,103 @@
+/*
+ * #1113 — restyle the Excalidraw canvas chrome (island toolbar, shape picker,
+ * color popups, context menu, dialogs) with Medusa design tokens so the
+ * moodboard reads as part of the admin instead of stock Excalidraw.
+ *
+ * Everything is scoped under `.jyt-moodboard` so it only touches our editor,
+ * and it maps Excalidraw's public theming variables onto Medusa's global
+ * tokens (`--bg-*`, `--fg-*`, `--border-*`, `--button-*`). Because those Medusa
+ * tokens already flip between `:root` (light) and `.dark`, the chrome follows
+ * the admin theme automatically — we intentionally override both Excalidraw
+ * light and `.theme--dark` (this file is imported after Excalidraw's own CSS,
+ * so equal-specificity ties resolve in our favour).
+ *
+ * The drawing surface itself (canvas background, element colors) stays under
+ * Excalidraw's own theme toggle — we only restyle the UI.
+ */
+
+.jyt-moodboard .excalidraw,
+.jyt-moodboard .excalidraw.theme--dark {
+  /* Typography — match the admin's Inter stack. */
+  --ui-font: "Inter", "Inter var", -apple-system, BlinkMacSystemFont,
+    "Segoe UI", Roboto, Helvetica, Arial, sans-serif;
+
+  /* Corner radii — tighten to Medusa's 6/8px feel. */
+  --border-radius-md: 6px;
+  --border-radius-lg: 8px;
+
+  /* Accent — Excalidraw's purple → Medusa interactive blue. */
+  --color-primary: var(--fg-interactive);
+  --color-primary-darker: var(--fg-interactive-hover);
+  --color-primary-darkest: var(--fg-interactive-hover);
+  --color-primary-hover: var(--fg-interactive-hover);
+  --color-primary-light: var(--bg-highlight);
+  --color-primary-light-darker: var(--bg-highlight-hover);
+  --color-on-primary-container: var(--fg-interactive);
+  --color-surface-primary-container: var(--bg-highlight);
+
+  /* Surfaces — islands, popups and menus sit on Medusa base/subtle. */
+  --island-bg-color: var(--bg-base);
+  --popup-bg-color: var(--bg-base);
+  --popup-secondary-bg-color: var(--bg-subtle);
+  --popup-text-color: var(--fg-base);
+  --popup-text-inverted-color: var(--fg-on-color);
+  --default-border-color: var(--border-base);
+
+  --color-surface-high: var(--bg-subtle);
+  --color-surface-mid: var(--bg-base);
+  --color-surface-low: var(--bg-subtle);
+  --color-surface-lowest: var(--bg-base);
+  --color-on-surface: var(--fg-base);
+  --text-primary-color: var(--fg-base);
+
+  /* Inputs. */
+  --input-bg-color: var(--bg-field);
+  --input-hover-bg-color: var(--bg-field-hover);
+  --input-border-color: var(--border-base);
+  --input-label-color: var(--fg-subtle);
+
+  /* Toolbar / action buttons. */
+  --button-bg: var(--bg-base);
+  --button-color: var(--fg-base);
+  --button-border: var(--border-base);
+  --button-hover-bg: var(--bg-base-hover);
+  --button-hover-color: var(--fg-base);
+  --button-hover-border: var(--border-strong);
+  --button-active-bg: var(--bg-base-pressed);
+  --button-active-border: var(--border-strong);
+  --button-selected-bg: var(--bg-highlight);
+  --button-selected-border: var(--border-interactive);
+  --button-selected-hover-bg: var(--bg-highlight-hover);
+  --button-special-active-bg-color: var(--bg-highlight);
+
+  /* Destructive (delete, clear). */
+  --button-destructive-bg-color: var(--button-danger);
+  --button-destructive-color: var(--fg-on-color);
+}
+
+/*
+ * Give the floating islands + popups a single Medusa border and shadow. Scope
+ * strictly to the OUTER container — `.Island` nests `.Stack` layout wrappers, so
+ * bordering `.Stack` too draws a second box inside the first (the "stacked
+ * layers" look). Only the island shell gets the surface treatment.
+ */
+.jyt-moodboard .excalidraw .Island,
+.jyt-moodboard .excalidraw .dropdown-menu .dropdown-menu-container,
+.jyt-moodboard .excalidraw .popover {
+  border: 1px solid var(--border-base);
+  box-shadow: var(--elevation-flyout);
+}
+
+/* Inner layout stacks must stay flat so only the island shell reads as a
+ * surface — kills the doubled/stacked border around the shape & lock icons. */
+.jyt-moodboard .excalidraw .Island .Stack {
+  border: none;
+  box-shadow: none;
+  background: transparent;
+}
+
+/* Selected tool + active menu rows read as Medusa's subtle highlight. */
+.jyt-moodboard .excalidraw .ToolIcon__icon,
+.jyt-moodboard .excalidraw .dropdown-menu-item {
+  border-radius: var(--border-radius-md);
+}


### PR DESCRIPTION
Restyles the design moodboard so the Excalidraw editor reads as part of the Medusa admin instead of stock Excalidraw.

## What
- **Medusa-token theming** (`moodboard.css`): maps Excalidraw 0.18's public theme variables (islands, popups, inputs, buttons, accent) onto Medusa's global `--bg-*` / `--fg-*` / `--border-*` / `--button-*` tokens, plus the Inter stack and tighter 6/8px radii. Scoped under `.jyt-moodboard`; overrides both Excalidraw light and `.theme--dark`.
- **Canvas follows the admin theme**: observe the root `.dark` class (with `prefers-color-scheme` fallback) and drive Excalidraw's `theme` prop + `initialData.appState.theme`. Manual theme toggle removed (now controlled). Fixes the white-canvas-in-dark-admin mismatch.
- **Bottom dock**: the action group (Insert / Add construction / Generate / Layers / Save) moved out of `renderTopRightUI` into a floating rounded-full pill pinned bottom-center; Insert dropdown opens upward.
- **Fix stacked borders**: only the island shell gets a border/shadow now — the nested `.Stack` was being bordered too, drawing a box-in-a-box around the shape/lock icons.

## Verify
`cd apps/partner-ui && pnpm dev` → open `http://localhost:5173`, log in, open a design → Moodboard. Canvas + chrome should match the admin theme; toggling admin light/dark flips the canvas live; the dock sits at the bottom.

🤖 Generated with [Claude Code](https://claude.com/claude-code)