### PR TITLE
feat(admin-mcp): partner ops read+write tools via chat [#843]

### DIFF
--- a/apps/backend/integration-tests/http/admin-mcp/admin-mcp-partner-ops.spec.ts
+++ b/apps/backend/integration-tests/http/admin-mcp/admin-mcp-partner-ops.spec.ts
@@ -1,0 +1,228 @@
+import { getSharedTestEnv, setupSharedTestSuite } from "../shared-test-setup"
+import { createAdminUser, getAuthHeaders } from "../../helpers/create-admin-user"
+
+jest.setTimeout(120000)
+
+// Streamable HTTP requires the client to accept BOTH json and the SSE stream;
+// our transport runs with enableJsonResponse so the body comes back as JSON.
+const MCP_HEADERS = {
+  "Content-Type": "application/json",
+  Accept: "application/json, text/event-stream",
+}
+
+const rpc = (method: string, params: Record<string, unknown>, id = 1) => ({
+  jsonrpc: "2.0",
+  id,
+  method,
+  params,
+})
+
+setupSharedTestSuite(() => {
+  describe("Admin MCP — partner ops tools (#843: inspect + act on a partner via chat)", () => {
+    const { api, getContainer } = getSharedTestEnv()
+
+    let auth: { headers: Record<string, string> }
+    let partnerId: string
+
+    beforeEach(async () => {
+      await createAdminUser(getContainer())
+      auth = await getAuthHeaders(api)
+
+      const container = getContainer()
+      const unique = `${Date.now()}-${Math.floor(Math.random() * 1e6)}`
+      const partnerService: any = container.resolve("partner")
+      const partner = await partnerService.createPartners({
+        name: `Partner Ops MCP ${unique}`,
+        handle: `partner-ops-mcp-${unique}`,
+      })
+      partnerId = partner.id
+    })
+
+    const mcp = (body: any) =>
+      api.post("/admin/mcp", body, {
+        headers: { ...MCP_HEADERS, ...auth.headers },
+      })
+
+    const parse = (res: any) => JSON.parse(res.data.result.content[0].text)
+
+    const callTool = (name: string, args: Record<string, unknown>) =>
+      mcp(rpc("tools/call", { name, arguments: args }))
+
+    it("tools/list exposes the partner ops reads and writes", async () => {
+      const res = await mcp(rpc("tools/list", {}))
+      expect(res.status).toBe(200)
+      const names = (res.data?.result?.tools ?? []).map((t: any) => t.name)
+
+      for (const name of [
+        "list_partner_tasks",
+        "get_partner_task",
+        "list_partner_feedbacks",
+        "list_partner_people",
+        "get_partner_fees",
+        "get_partner_subscription",
+        "create_partner_task",
+        "update_partner_task",
+        "create_partner_feedback",
+        "link_partner_people",
+        "create_partner_subscription",
+      ]) {
+        expect(names).toContain(name)
+      }
+    })
+
+    it("list_partner_tasks reads back a task created via create_partner_task (confirm required)", async () => {
+      const empty = await callTool("list_partner_tasks", { id: partnerId })
+      expect(parse(empty).data.tasks).toEqual([])
+
+      // Without confirm: sensitive write is only planned, never executed.
+      const unconfirmed = await callTool("create_partner_task", {
+        id: partnerId,
+        title: "Inspect via chat",
+      })
+      const unconfirmedPayload = parse(unconfirmed)
+      expect(unconfirmedPayload.requires_confirmation).toBe(true)
+      expect(unconfirmedPayload.plan.method).toBe("POST")
+      expect(unconfirmedPayload.plan.path).toBe(`/admin/partners/${partnerId}/tasks`)
+
+      const stillEmpty = await callTool("list_partner_tasks", { id: partnerId })
+      expect(parse(stillEmpty).data.tasks).toEqual([])
+
+      // With confirm: executes for real against the wrapped route.
+      const created = await callTool("create_partner_task", {
+        id: partnerId,
+        title: "Inspect via chat",
+        priority: "high",
+        confirm: true,
+      })
+      const createdPayload = parse(created)
+      expect(createdPayload.ok).toBe(true)
+      const taskId = createdPayload.data.task.id
+      expect(taskId).toBeTruthy()
+
+      const listed = await callTool("list_partner_tasks", { id: partnerId })
+      const tasks = parse(listed).data.tasks
+      expect(tasks).toHaveLength(1)
+      expect(tasks[0].id).toBe(taskId)
+      expect(tasks[0].title).toBe("Inspect via chat")
+
+      const got = await callTool("get_partner_task", { id: partnerId, taskId })
+      expect(parse(got).data.task.id).toBe(taskId)
+    })
+
+    it("update_partner_task dry_run previews the current task without mutating it", async () => {
+      const created = await callTool("create_partner_task", {
+        id: partnerId,
+        title: "Original title",
+        confirm: true,
+      })
+      const taskId = parse(created).data.task.id
+
+      const preview = await callTool("update_partner_task", {
+        id: partnerId,
+        taskId,
+        title: "New title",
+        dry_run: true,
+      })
+      const previewPayload = parse(preview)
+      expect(previewPayload.dry_run).toBe(true)
+      expect(previewPayload.plan.path).toBe(`/admin/partners/${partnerId}/tasks/${taskId}`)
+      expect(previewPayload.current.task.title).toBe("Original title")
+
+      const stillOriginal = await callTool("get_partner_task", { id: partnerId, taskId })
+      expect(parse(stillOriginal).data.task.title).toBe("Original title")
+
+      const updated = await callTool("update_partner_task", {
+        id: partnerId,
+        taskId,
+        title: "New title",
+        confirm: true,
+      })
+      expect(parse(updated).ok).toBe(true)
+
+      const refetched = await callTool("get_partner_task", { id: partnerId, taskId })
+      expect(parse(refetched).data.task.title).toBe("New title")
+    })
+
+    it("create_partner_feedback writes a feedback entry visible via list_partner_feedbacks", async () => {
+      const before = await callTool("list_partner_feedbacks", { id: partnerId })
+      expect(parse(before).data.feedbacks).toEqual([])
+
+      const res = await callTool("create_partner_feedback", {
+        id: partnerId,
+        rating: "five",
+        comment: "Great work",
+        status: "pending",
+        submitted_by: "admin_test",
+        submitted_at: new Date().toISOString(),
+        confirm: true,
+      })
+      expect(parse(res).ok).toBe(true)
+
+      const after = await callTool("list_partner_feedbacks", { id: partnerId })
+      const feedbacks = parse(after).data.feedbacks
+      expect(feedbacks).toHaveLength(1)
+      expect(feedbacks[0].comment).toBe("Great work")
+    })
+
+    it("link_partner_people links a real person and shows up via list_partner_people", async () => {
+      const container = getContainer()
+      const personService: any = container.resolve("person")
+      const unique = `${Date.now()}-${Math.floor(Math.random() * 1e6)}`
+      const person = await personService.createPeople({
+        first_name: "Test",
+        last_name: "Contact",
+        email: `contact-${unique}@example.com`,
+      })
+
+      const before = await callTool("list_partner_people", { id: partnerId })
+      expect(parse(before).data.people).toEqual([])
+
+      const linked = await callTool("link_partner_people", {
+        id: partnerId,
+        person_ids: [person.id],
+        confirm: true,
+      })
+      expect(parse(linked).ok).toBe(true)
+
+      const after = await callTool("list_partner_people", { id: partnerId })
+      const people = parse(after).data.people
+      expect(people).toHaveLength(1)
+      expect(people[0].id).toBe(person.id)
+    })
+
+    it("create_partner_subscription assigns a plan, readable via get_partner_subscription", async () => {
+      const container = getContainer()
+      const partnerPlanService: any = container.resolve("partnerPlan")
+      const unique = `${Date.now()}-${Math.floor(Math.random() * 1e6)}`
+      const plan = await partnerPlanService.createPartnerPlans({
+        name: `Free Plan ${unique}`,
+        slug: `free-plan-${unique}`,
+        price: 0,
+        is_active: true,
+      })
+
+      const before = await callTool("get_partner_subscription", { id: partnerId })
+      expect(parse(before).data.subscriptions).toEqual([])
+
+      const assigned = await callTool("create_partner_subscription", {
+        id: partnerId,
+        plan_id: plan.id,
+        confirm: true,
+      })
+      expect(parse(assigned).ok).toBe(true)
+
+      const after = await callTool("get_partner_subscription", { id: partnerId })
+      const subscriptions = parse(after).data.subscriptions
+      expect(subscriptions).toHaveLength(1)
+      expect(subscriptions[0].plan_id).toBe(plan.id)
+    })
+
+    it("get_partner_fees returns the (empty) fee ledger + summary roll-up for a fresh partner", async () => {
+      const res = await callTool("get_partner_fees", { id: partnerId })
+      const payload = parse(res)
+      expect(payload.ok).toBe(true)
+      expect(payload.data.fees).toEqual([])
+      expect(payload.data.summary).toBeDefined()
+    })
+  })
+})

--- a/apps/backend/src/api/admin/mcp/lib/__tests__/dispatch.unit.spec.ts
+++ b/apps/backend/src/api/admin/mcp/lib/__tests__/dispatch.unit.spec.ts
@@ -66,6 +66,85 @@ describe("admin-mcp registry + dispatch", () => {
     })
   })
 
+  describe("partner ops tools (#843): wrap existing /admin/partners/:id/* routes", () => {
+    it("registers read tools for tasks, feedbacks, people, fees and subscription", () => {
+      const reads = [
+        ["list_partner_tasks", "/admin/partners/:id/tasks"],
+        ["get_partner_task", "/admin/partners/:id/tasks/:taskId"],
+        ["list_partner_feedbacks", "/admin/partners/:id/feedbacks"],
+        ["list_partner_people", "/admin/partners/:id/people"],
+        ["get_partner_fees", "/admin/partners/:id/fees"],
+        ["get_partner_subscription", "/admin/partners/:id/subscription"],
+      ] as const
+      for (const [name, path] of reads) {
+        const def = ADMIN_MCP_TOOLS.find((t) => t.name === name)
+        expect(def).toBeTruthy()
+        expect(def!.method ?? "GET").toBe("GET")
+        expect(def!.path).toBe(path)
+        expect(def!.write).toBeFalsy()
+        expect(isSensitive(def!)).toBe(false)
+      }
+    })
+
+    it("registers write tools for tasks, feedbacks, people and subscription, all sensitive", () => {
+      const writes = [
+        ["create_partner_task", "POST", "/admin/partners/:id/tasks"],
+        ["update_partner_task", "PATCH", "/admin/partners/:id/tasks/:taskId"],
+        ["create_partner_feedback", "POST", "/admin/partners/:id/feedbacks"],
+        ["link_partner_people", "POST", "/admin/partners/:id/people"],
+        ["create_partner_subscription", "POST", "/admin/partners/:id/subscription"],
+      ] as const
+      for (const [name, method, path] of writes) {
+        const def = ADMIN_MCP_TOOLS.find((t) => t.name === name)
+        expect(def).toBeTruthy()
+        expect(def!.write).toBe(true)
+        expect(def!.method).toBe(method)
+        expect(def!.path).toBe(path)
+        expect(isSensitive(def!)).toBe(true)
+        expect(isDangerous(def!)).toBe(false)
+      }
+    })
+
+    it("update_partner_task declares a previewPath matching its own route (dry_run shows current task)", () => {
+      const def = ADMIN_MCP_TOOLS.find((t) => t.name === "update_partner_task")!
+      expect(def.previewPath).toBe("/admin/partners/:id/tasks/:taskId")
+      expect(def.pathParams).toEqual(["id", "taskId"])
+    })
+
+    it("get_partner_task requires both id and taskId path params", async () => {
+      const missingTaskId = await dispatchAdminTool(
+        { baseUrl: "http://localhost:9999" },
+        "get_partner_task",
+        { id: "partner_1" }
+      )
+      expect(missingTaskId.ok).toBe(false)
+      expect(missingTaskId.error).toMatch(/taskId/)
+    })
+
+    it("dry_run on create_partner_task previews the plan without executing", async () => {
+      const res = await dispatchAdminTool(
+        { baseUrl: "http://localhost:9999" },
+        "create_partner_task",
+        { id: "partner_1", title: "Inspect this partner", dry_run: true }
+      )
+      expect(res.ok).toBe(true)
+      expect(res.dry_run).toBe(true)
+      expect(res.plan?.method).toBe("POST")
+      expect(res.plan?.path).toBe("/admin/partners/partner_1/tasks")
+      expect((res.plan?.body as any)?.title).toBe("Inspect this partner")
+    })
+
+    it("link_partner_people without confirm returns requires_confirmation, not executed", async () => {
+      const res = await dispatchAdminTool(
+        { baseUrl: "http://localhost:9999" },
+        "link_partner_people",
+        { id: "partner_1", person_ids: ["person_1"] }
+      )
+      expect(res.requires_confirmation).toBe(true)
+      expect(res.plan?.path).toBe("/admin/partners/partner_1/people")
+    })
+  })
+
   describe("framework args — parity with the partner dispatcher", () => {
     it("injects context + dry_run onto EVERY tool's input schema", () => {
       for (const def of ADMIN_MCP_TOOLS) {

--- a/apps/backend/src/api/admin/mcp/lib/registry.ts
+++ b/apps/backend/src/api/admin/mcp/lib/registry.ts
@@ -324,6 +324,242 @@ export const ADMIN_MCP_TOOLS: AdminMcpToolDef[] = [
     ),
   },
 
+  // ===== Partner ops (#843): inspect + act on a partner's sub-resources ===
+  // These wrap ALREADY-EXISTING /admin/partners/:id/* routes — no new backend
+  // surface, just registry rows exposing what admins can already do via the
+  // partner detail page as chat-invokable tools (read + write).
+  {
+    name: "list_partner_tasks",
+    description: "List all tasks assigned to a partner.",
+    method: "GET",
+    path: "/admin/partners/:id/tasks",
+    pathParams: ["id"],
+    inputSchema: obj({ id: STR("Partner id, e.g. 'partner_...'.") }, ["id"]),
+  },
+  {
+    name: "get_partner_task",
+    description: "Get a single task assigned to a partner by task id.",
+    method: "GET",
+    path: "/admin/partners/:id/tasks/:taskId",
+    pathParams: ["id", "taskId"],
+    inputSchema: obj(
+      {
+        id: STR("Partner id, e.g. 'partner_...'."),
+        taskId: STR("Task id, e.g. 'task_...'."),
+      },
+      ["id", "taskId"]
+    ),
+  },
+  {
+    name: "list_partner_feedbacks",
+    description: "List feedback entries linked to a partner.",
+    method: "GET",
+    path: "/admin/partners/:id/feedbacks",
+    pathParams: ["id"],
+    inputSchema: obj({ id: STR("Partner id, e.g. 'partner_...'.") }, ["id"]),
+  },
+  {
+    name: "list_partner_people",
+    description: "List persons (contacts) linked to a partner.",
+    method: "GET",
+    path: "/admin/partners/:id/people",
+    pathParams: ["id"],
+    inputSchema: obj({ id: STR("Partner id, e.g. 'partner_...'.") }, ["id"]),
+  },
+  {
+    name: "get_partner_fees",
+    description:
+      "Get a partner's transaction-fee (commission) ledger and roll-up summary (totals, by-status, by-currency).",
+    method: "GET",
+    path: "/admin/partners/:id/fees",
+    pathParams: ["id"],
+    queryParams: ["limit", "offset", "status"],
+    inputSchema: obj(
+      {
+        id: STR("Partner id, e.g. 'partner_...'."),
+        limit: { type: "integer", description: "Max results (default 50)." },
+        offset: { type: "integer", description: "Pagination offset." },
+        status: STR("Optional fee status filter."),
+      },
+      ["id"]
+    ),
+  },
+  {
+    name: "get_partner_subscription",
+    description: "Get a partner's subscriptions (with plan and payments) plus the list of active plans.",
+    method: "GET",
+    path: "/admin/partners/:id/subscription",
+    pathParams: ["id"],
+    inputSchema: obj({ id: STR("Partner id, e.g. 'partner_...'.") }, ["id"]),
+  },
+
+  // ---- Partner ops writes -------------------------------------------------
+  {
+    name: "create_partner_task",
+    description:
+      "Create a new task and assign it to a partner. Sensitive: requires confirm:true.",
+    method: "POST",
+    path: "/admin/partners/:id/tasks",
+    pathParams: ["id"],
+    write: true,
+    sensitive: true,
+    bodyParams: [
+      "title",
+      "description",
+      "status",
+      "priority",
+      "start_date",
+      "end_date",
+      "estimated_cost",
+      "cost_currency",
+      "cost_type",
+      "metadata",
+    ],
+    inputSchema: obj(
+      {
+        id: STR("Partner id, e.g. 'partner_...'."),
+        title: STR("Task title (required)."),
+        description: STR("Task description."),
+        status: STR("Task status."),
+        priority: STR("Task priority: 'low' | 'medium' | 'high'."),
+        start_date: STR("Start date (ISO string)."),
+        end_date: STR("Due date (ISO string)."),
+        estimated_cost: { type: "number", description: "Estimated cost, set at creation." },
+        cost_currency: STR("Currency code for estimated/actual cost."),
+        cost_type: STR("'per_unit' | 'total'."),
+        metadata: { type: "object", description: "Optional key/value metadata." },
+      },
+      ["id", "title"]
+    ),
+    sideEffects: "Creates and assigns a new task to the partner.",
+    nextSteps: ["get_partner_task", "update_partner_task"],
+  },
+  {
+    name: "update_partner_task",
+    description:
+      "Update a task assigned to a partner (title/description/status/priority/dates/cost fields). Sensitive: requires confirm:true. Use dry_run to see the current task first.",
+    method: "PATCH",
+    path: "/admin/partners/:id/tasks/:taskId",
+    pathParams: ["id", "taskId"],
+    previewPath: "/admin/partners/:id/tasks/:taskId",
+    write: true,
+    sensitive: true,
+    bodyParams: [
+      "title",
+      "description",
+      "status",
+      "priority",
+      "start_date",
+      "end_date",
+      "estimated_cost",
+      "actual_cost",
+      "cost_currency",
+      "cost_type",
+      "metadata",
+    ],
+    inputSchema: obj(
+      {
+        id: STR("Partner id, e.g. 'partner_...'."),
+        taskId: STR("Task id, e.g. 'task_...'."),
+        title: STR("New title."),
+        description: STR("New description."),
+        status: STR("New status."),
+        priority: STR("New priority: 'low' | 'medium' | 'high'."),
+        start_date: STR("New start date (ISO string)."),
+        end_date: STR("New due date (ISO string)."),
+        estimated_cost: { type: "number", description: "New estimated cost." },
+        actual_cost: { type: "number", description: "New actual cost (recorded at finish)." },
+        cost_currency: STR("Currency code for cost fields."),
+        cost_type: STR("'per_unit' | 'total'."),
+        metadata: { type: "object", description: "Metadata to merge." },
+      },
+      ["id", "taskId"]
+    ),
+  },
+  {
+    name: "create_partner_feedback",
+    description:
+      "Create a feedback entry linked to a partner. Sensitive: requires confirm:true.",
+    method: "POST",
+    path: "/admin/partners/:id/feedbacks",
+    pathParams: ["id"],
+    write: true,
+    sensitive: true,
+    bodyParams: [
+      "rating",
+      "comment",
+      "status",
+      "submitted_by",
+      "submitted_at",
+      "reviewed_by",
+      "reviewed_at",
+      "metadata",
+    ],
+    inputSchema: obj(
+      {
+        id: STR("Partner id, e.g. 'partner_...'."),
+        rating: STR("'one' | 'two' | 'three' | 'four' | 'five' (required)."),
+        comment: STR("Feedback comment."),
+        status: STR("'pending' | 'reviewed' | 'resolved' (required)."),
+        submitted_by: STR("Who submitted the feedback (required)."),
+        submitted_at: STR("Submission timestamp (ISO string, required)."),
+        reviewed_by: STR("Who reviewed the feedback."),
+        reviewed_at: STR("Review timestamp (ISO string)."),
+        metadata: { type: "object", description: "Optional key/value metadata." },
+      },
+      ["id", "rating", "status", "submitted_by", "submitted_at"]
+    ),
+    sideEffects: "Creates a feedback record linked to the partner.",
+  },
+  {
+    name: "link_partner_people",
+    description:
+      "Link existing persons (contacts) to a partner by id. Sensitive: requires confirm:true.",
+    method: "POST",
+    path: "/admin/partners/:id/people",
+    pathParams: ["id"],
+    write: true,
+    sensitive: true,
+    bodyParams: ["person_ids"],
+    inputSchema: obj(
+      {
+        id: STR("Partner id, e.g. 'partner_...'."),
+        person_ids: {
+          type: "array",
+          items: { type: "string" },
+          description: "Person ids to link to the partner (required, non-empty).",
+        },
+      },
+      ["id", "person_ids"]
+    ),
+    sideEffects: "Links the given persons to the partner as contacts.",
+  },
+  {
+    name: "create_partner_subscription",
+    description:
+      "Assign a subscription plan to a partner (admin can comp/trial via skip_payment). Sensitive: requires confirm:true.",
+    method: "POST",
+    path: "/admin/partners/:id/subscription",
+    pathParams: ["id"],
+    write: true,
+    sensitive: true,
+    bodyParams: ["plan_id", "payment_provider", "skip_payment", "notes"],
+    inputSchema: obj(
+      {
+        id: STR("Partner id, e.g. 'partner_...'."),
+        plan_id: STR("Plan id to assign (required)."),
+        payment_provider: STR("Payment provider, e.g. 'manual' (defaults to 'manual')."),
+        skip_payment: {
+          type: "boolean",
+          description: "If true and the plan has a cost, record a manual comp/trial payment instead of requiring real payment.",
+        },
+        notes: STR("Optional admin notes, recorded on the payment/metadata."),
+      },
+      ["id", "plan_id"]
+    ),
+    sideEffects: "Creates an active subscription for the partner, optionally recording a manual payment.",
+  },
+
   // ===== Tier 2: the first dangerous action ==============================
   // Platform-destructive: hidden + refused unless ADMIN_MCP_ENABLE_DANGEROUS is
   // on, and even then requires BOTH confirm:true AND a human-supplied reason.

--- a/apps/backend/src/lib/mcp-core/proxy.ts
+++ b/apps/backend/src/lib/mcp-core/proxy.ts
@@ -15,7 +15,7 @@ export type McpProxyArgs = {
   /** Base origin of this backend, e.g. http://localhost:9000 (no trailing slash). */
   baseUrl: string
   /** HTTP method. Defaults to GET (read tools). */
-  method?: "GET" | "POST" | "PUT" | "DELETE"
+  method?: "GET" | "POST" | "PUT" | "PATCH" | "DELETE"
   /** Route path with params already substituted, e.g. /admin/orders/order_1. */
   path: string
   /** Query params to forward. Arrays are serialized as key[]=a&key[]=b. */

--- a/apps/backend/src/lib/mcp-core/types.ts
+++ b/apps/backend/src/lib/mcp-core/types.ts
@@ -13,7 +13,7 @@
  */
 
 /** HTTP verb of the wrapped route. GET = read (always exposed). */
-export type McpMethod = "GET" | "POST" | "PUT" | "DELETE"
+export type McpMethod = "GET" | "POST" | "PUT" | "PATCH" | "DELETE"
 
 export type McpToolDef = {
   /** Tool name surfaced to the agent (snake_case). */


### PR DESCRIPTION
## Summary
- Adds 11 admin-MCP chat tools that expose partner sub-resource inspection + action (tasks, feedbacks, people, fees, subscription) by wrapping **already-existing** `/admin/partners/:id/*` routes — no new backend routes, per the #843 codebase-grounding recommendation. Reads: `list_partner_tasks`, `get_partner_task`, `list_partner_feedbacks`, `list_partner_people`, `get_partner_fees`, `get_partner_subscription`. Writes (`sensitive`, require `confirm:true`): `create_partner_task`, `update_partner_task`, `create_partner_feedback`, `link_partner_people`, `create_partner_subscription`.
- Widens the shared `mcp-core` proxy's `McpMethod` to include `PATCH` — caught by the integration test (`update_partner_task` wraps a PATCH-only route; the old GET/POST/PUT/DELETE-only type silently 404'd it).

## Test plan
- [x] Unit: `apps/backend/src/api/admin/mcp/lib/__tests__/dispatch.unit.spec.ts` — registry shape, path-param validation, dry_run/confirm gating (20/20 passing)
- [x] Integration (new): `apps/backend/integration-tests/http/admin-mcp/admin-mcp-partner-ops.spec.ts` — full create→list→get round trips through `/admin/mcp` for all 5 domains, unconfirmed-write-doesn't-execute, dry_run-doesn't-mutate (7/7 passing)
- [x] Full `admin-mcp` suite re-run: 14/14 passing, no regressions

🤖 Generated with [Claude Code](https://claude.com/claude-code)