### PR TITLE
feat(admin-mcp): orders, production-run and design ops tools [#1165][#1166][#1167]

### DIFF
--- a/apps/backend/integration-tests/http/admin-mcp/admin-mcp-ops-domains.spec.ts
+++ b/apps/backend/integration-tests/http/admin-mcp/admin-mcp-ops-domains.spec.ts
@@ -1,0 +1,313 @@
+import { getSharedTestEnv, setupSharedTestSuite } from "../shared-test-setup"
+import { createAdminUser, getAuthHeaders } from "../../helpers/create-admin-user"
+
+jest.setTimeout(120000)
+
+// Streamable HTTP requires the client to accept BOTH json and the SSE stream;
+// our transport runs with enableJsonResponse so the body comes back as JSON.
+const MCP_HEADERS = {
+  "Content-Type": "application/json",
+  Accept: "application/json, text/event-stream",
+}
+
+const rpc = (method: string, params: Record<string, unknown>, id = 1) => ({
+  jsonrpc: "2.0",
+  id,
+  method,
+  params,
+})
+
+/**
+ * Coverage for the three operational tiers added on top of partner ops:
+ * orders/fulfillment + order edits (#1165), the production-run lifecycle
+ * (#1167) and the design -> production pipeline (#1166).
+ *
+ * The design pipeline is exercised end-to-end for real, because it needs
+ * nothing but the DB. Order fulfillment and shipping-label tools are asserted
+ * at the rail level (exposure + confirm/dangerous gating) rather than executed:
+ * they need a paid, stock-backed order and — for labels — a live carrier API.
+ */
+setupSharedTestSuite(() => {
+  describe("Admin MCP — orders / production-runs / designs ops tools", () => {
+    const { api, getContainer } = getSharedTestEnv()
+
+    let auth: { headers: Record<string, string> }
+    let partnerId: string
+
+    beforeEach(async () => {
+      await createAdminUser(getContainer())
+      auth = await getAuthHeaders(api)
+
+      const container = getContainer()
+      const unique = `${Date.now()}-${Math.floor(Math.random() * 1e6)}`
+      const partnerService: any = container.resolve("partner")
+      const partner = await partnerService.createPartners({
+        name: `Ops MCP Partner ${unique}`,
+        handle: `ops-mcp-partner-${unique}`,
+      })
+      partnerId = partner.id
+    })
+
+    const mcp = (body: any) =>
+      api.post("/admin/mcp", body, {
+        headers: { ...MCP_HEADERS, ...auth.headers },
+      })
+
+    const parse = (res: any) => JSON.parse(res.data.result.content[0].text)
+
+    const callTool = (name: string, args: Record<string, unknown>) =>
+      mcp(rpc("tools/call", { name, arguments: args }))
+
+    const createDesign = async (name: string) => {
+      const res = await callTool("create_design", {
+        name,
+        description: `Fixture design for ${name}`,
+        confirm: true,
+      })
+      const payload = parse(res)
+      // Surface the proxied route's error text rather than a bare `false`.
+      expect(payload.error ?? "ok").toBe("ok")
+      return payload.data.design.id as string
+    }
+
+    it("tools/list exposes the new ops tools and HIDES the dangerous ones by default", async () => {
+      const res = await mcp(rpc("tools/list", {}))
+      expect(res.status).toBe(200)
+      const names = (res.data?.result?.tools ?? []).map((t: any) => t.name)
+
+      for (const name of [
+        // #1165 orders
+        "list_order_changes",
+        "list_order_designs",
+        "create_order_fulfillment",
+        "create_order_shipment",
+        "mark_order_fulfillment_delivered",
+        "create_order_edit",
+        "add_order_edit_items",
+        "request_order_edit",
+        // #1167 production runs
+        "get_production_run",
+        "create_production_run",
+        "approve_production_run",
+        "send_production_run_to_production",
+        "start_production_run_dispatch",
+        "resume_production_run_dispatch",
+        "get_production_run_cost_summary",
+        // #1166 designs
+        "list_design_work_orders",
+        "create_design",
+        "update_design",
+        "produce_designs",
+        "link_design_partners",
+        "cancel_design_partner_assignment",
+      ]) {
+        expect(names).toContain(name)
+      }
+
+      // ADMIN_MCP_ENABLE_DANGEROUS is off in test, so the irreversible actions
+      // must not even be advertised to the model.
+      for (const name of [
+        "cancel_order",
+        "cancel_order_fulfillment",
+        "confirm_order_edit",
+        "cancel_production_run",
+      ]) {
+        expect(names).not.toContain(name)
+      }
+    })
+
+    it("refuses a dangerous order action outright when dangerous tools are disabled", async () => {
+      const res = await callTool("cancel_order", {
+        id: "order_does_not_matter",
+        reason: "customer asked",
+        confirm: true,
+      })
+      const payload = parse(res)
+      expect(payload.ok).toBe(false)
+      expect(payload.error).toMatch(/dangerous/i)
+    })
+
+    it("runs the design -> production pipeline: create_design, produce_designs, read it back", async () => {
+      const designId = await createDesign(`Pipeline Design ${Date.now()}`)
+
+      // Nothing in production yet for this design.
+      const before = await callTool("list_production_runs", { design_id: designId })
+      expect(parse(before).data.production_runs).toEqual([])
+
+      // Sensitive write: planned but NOT executed without confirm.
+      const unconfirmed = await callTool("produce_designs", {
+        design_ids: [designId],
+        partner_id: partnerId,
+      })
+      const unconfirmedPayload = parse(unconfirmed)
+      expect(unconfirmedPayload.requires_confirmation).toBe(true)
+      expect(unconfirmedPayload.plan.path).toBe("/admin/designs/produce")
+
+      const stillEmpty = await callTool("list_production_runs", { design_id: designId })
+      expect(parse(stillEmpty).data.production_runs).toEqual([])
+
+      // With confirm it executes against the real route.
+      const produced = await callTool("produce_designs", {
+        design_ids: [designId],
+        partner_id: partnerId,
+        confirm: true,
+      })
+      expect(parse(produced).ok).toBe(true)
+
+      const after = await callTool("list_production_runs", { design_id: designId })
+      const runs = parse(after).data.production_runs
+      expect(runs.length).toBeGreaterThan(0)
+
+      // The collated work-order read surfaces it too.
+      const workOrders = await callTool("list_design_work_orders", {})
+      expect(parse(workOrders).ok).toBe(true)
+    })
+
+    it("update_design dry_run shows the current design and does not mutate it", async () => {
+      const designId = await createDesign("Original Design Name")
+
+      const preview = await callTool("update_design", {
+        id: designId,
+        name: "Renamed Design",
+        priority: "Urgent",
+        dry_run: true,
+      })
+      const previewPayload = parse(preview)
+      expect(previewPayload.dry_run).toBe(true)
+      expect(previewPayload.plan.method).toBe("PUT")
+      expect(previewPayload.plan.path).toBe(`/admin/designs/${designId}`)
+      expect(previewPayload.current.design.name).toBe("Original Design Name")
+
+      const unchanged = await callTool("get_design", { id: designId })
+      expect(parse(unchanged).data.design.name).toBe("Original Design Name")
+
+      const updated = await callTool("update_design", {
+        id: designId,
+        name: "Renamed Design",
+        priority: "Urgent",
+        confirm: true,
+      })
+      expect(parse(updated).ok).toBe(true)
+
+      const refetched = await callTool("get_design", { id: designId })
+      expect(parse(refetched).data.design.name).toBe("Renamed Design")
+    })
+
+    it("update_design writes size_sets — the field no other tool can set", async () => {
+      const designId = await createDesign(`Sized Design ${Date.now()}`)
+
+      const res = await callTool("update_design", {
+        id: designId,
+        size_sets: [
+          { size_label: "M", measurements: { chest: 100, length: 70 } },
+          { size_label: "L", measurements: { chest: 108, length: 72 } },
+        ],
+        confirm: true,
+      })
+      expect(parse(res).ok).toBe(true)
+
+      const refetched = await callTool("get_design", { id: designId })
+      const sizeSets = parse(refetched).data.design.size_sets
+      expect(sizeSets).toHaveLength(2)
+      expect(sizeSets.map((s: any) => s.size_label).sort()).toEqual(["L", "M"])
+    })
+
+    it("create_production_run + get_production_run round-trips through the MCP surface", async () => {
+      const designId = await createDesign(`Run Design ${Date.now()}`)
+
+      const created = await callTool("create_production_run", {
+        design_id: designId,
+        quantity: 5,
+        run_type: "sample",
+        confirm: true,
+      })
+      const createdPayload = parse(created)
+      expect(createdPayload.ok).toBe(true)
+      const runId =
+        createdPayload.data.production_run.id
+      expect(runId).toBeTruthy()
+
+      const got = await callTool("get_production_run", { id: runId })
+      const run = parse(got).data.production_run
+      expect(run.id).toBe(runId)
+      expect(Number(run.quantity)).toBe(5)
+      expect(run.run_type).toBe("sample")
+
+      // The list filters we declared actually work against the route.
+      const filtered = await callTool("list_production_runs", {
+        design_id: designId,
+        run_type: "sample",
+      })
+      const ids = parse(filtered).data.production_runs.map((r: any) => r.id)
+      expect(ids).toContain(runId)
+    })
+
+    it("update_production_run is gated on confirm and previews the current run", async () => {
+      const designId = await createDesign(`Editable Run Design ${Date.now()}`)
+      const created = await callTool("create_production_run", {
+        design_id: designId,
+        quantity: 3,
+        confirm: true,
+      })
+      const runId =
+        parse(created).data.production_run?.id
+
+      const preview = await callTool("update_production_run", {
+        id: runId,
+        quantity: 9,
+        dry_run: true,
+      })
+      const previewPayload = parse(preview)
+      expect(previewPayload.dry_run).toBe(true)
+      expect(previewPayload.plan.path).toBe(`/admin/production-runs/${runId}`)
+      const currentRun =
+        previewPayload.current.production_run
+      expect(Number(currentRun.quantity)).toBe(3)
+
+      const updated = await callTool("update_production_run", {
+        id: runId,
+        quantity: 9,
+        confirm: true,
+      })
+      expect(parse(updated).ok).toBe(true)
+
+      const refetched = await callTool("get_production_run", { id: runId })
+      const run = parse(refetched).data.production_run
+      expect(Number(run.quantity)).toBe(9)
+    })
+
+    it("get_production_run_policy reads the lifecycle transition policy", async () => {
+      const res = await callTool("get_production_run_policy", {})
+      const payload = parse(res)
+      expect(payload.ok).toBe(true)
+      expect(payload.data).toBeDefined()
+    })
+
+    it("order fulfillment tools plan a correct request without executing (dry_run)", async () => {
+      const res = await callTool("create_order_fulfillment", {
+        id: "order_01TEST",
+        items: [{ id: "ordli_01TEST", quantity: 1 }],
+        location_id: "sloc_01TEST",
+        dry_run: true,
+      })
+      const payload = parse(res)
+      expect(payload.dry_run).toBe(true)
+      expect(payload.plan.method).toBe("POST")
+      expect(payload.plan.path).toBe("/admin/orders/order_01TEST/fulfillments")
+      expect(payload.plan.body.items).toHaveLength(1)
+      expect(payload.plan.body.location_id).toBe("sloc_01TEST")
+      expect(payload.warning).toMatch(/sensitive/i)
+    })
+
+    it("the staged order-edit loop requires confirmation at every step", async () => {
+      for (const [name, args] of [
+        ["create_order_edit", { order_id: "order_01TEST" }],
+        ["add_order_edit_items", { id: "ordch_01TEST", items: [{ variant_id: "v", quantity: 1 }] }],
+        ["request_order_edit", { id: "ordch_01TEST" }],
+      ] as const) {
+        const payload = parse(await callTool(name, args as Record<string, unknown>))
+        expect(payload.requires_confirmation).toBe(true)
+      }
+    })
+  })
+})

--- a/apps/backend/src/api/admin/mcp/lib/__tests__/dispatch.unit.spec.ts
+++ b/apps/backend/src/api/admin/mcp/lib/__tests__/dispatch.unit.spec.ts
@@ -260,6 +260,395 @@ describe("admin-mcp registry + dispatch", () => {
     })
   })
 
+  describe("orders ops (#1165): fulfillment, shipping and order edits", () => {
+    it("registers the order read companions", () => {
+      const reads = [
+        ["list_order_changes", "/admin/orders/:id/changes"],
+        ["list_order_designs", "/admin/orders/:id/design"],
+        ["list_order_shipping_rates", "/admin/orders/:id/fulfillment-rates"],
+        [
+          "get_order_fulfillment_label",
+          "/admin/orders/:id/fulfillments/:fulfillmentId/label",
+        ],
+      ] as const
+      for (const [name, path] of reads) {
+        const def = ADMIN_MCP_TOOLS.find((t) => t.name === name)
+        expect(def).toBeTruthy()
+        expect(def!.method ?? "GET").toBe("GET")
+        expect(def!.path).toBe(path)
+        expect(def!.write).toBeFalsy()
+        expect(isSensitive(def!)).toBe(false)
+      }
+    })
+
+    it("registers fulfillment/shipping writes as sensitive (confirm only)", () => {
+      const writes = [
+        ["update_order", "POST", "/admin/orders/:id"],
+        ["create_order_fulfillment", "POST", "/admin/orders/:id/fulfillments"],
+        [
+          "create_order_shipment",
+          "POST",
+          "/admin/orders/:id/fulfillments/:fulfillmentId/shipments",
+        ],
+        [
+          "mark_order_fulfillment_delivered",
+          "POST",
+          "/admin/orders/:id/fulfillments/:fulfillmentId/mark-as-delivered",
+        ],
+        ["complete_order", "POST", "/admin/orders/:id/complete"],
+        ["produce_order_designs", "POST", "/admin/orders/:id/design/produce"],
+        ["create_order_shipping_label", "POST", "/admin/orders/:id/fulfillment-label"],
+        ["attach_order_awb", "POST", "/admin/orders/:id/shiprocket-attach-awb"],
+      ] as const
+      for (const [name, method, path] of writes) {
+        const def = ADMIN_MCP_TOOLS.find((t) => t.name === name)
+        expect(def).toBeTruthy()
+        expect(def!.write).toBe(true)
+        expect(def!.method).toBe(method)
+        expect(def!.path).toBe(path)
+        expect(isSensitive(def!)).toBe(true)
+        expect(isDangerous(def!)).toBe(false)
+      }
+    })
+
+    it("flags the irreversible order actions as dangerous (confirm + reason)", () => {
+      const dangerous = [
+        ["cancel_order", "/admin/orders/:id/cancel"],
+        [
+          "cancel_order_fulfillment",
+          "/admin/orders/:id/fulfillments/:fulfillmentId/cancel",
+        ],
+        ["confirm_order_edit", "/admin/order-edits/:id/confirm"],
+      ] as const
+      for (const [name, path] of dangerous) {
+        const def = ADMIN_MCP_TOOLS.find((t) => t.name === name)
+        expect(def).toBeTruthy()
+        expect(def!.path).toBe(path)
+        expect(def!.write).toBe(true)
+        expect(isDangerous(def!)).toBe(true)
+        const schema = buildToolInputSchema(def!)
+        expect(schema.properties.reason).toBeDefined()
+        expect(schema.properties.confirm).toBeDefined()
+      }
+    })
+
+    it("registers the staged order-edit loop, with only confirm being dangerous", () => {
+      const staged = [
+        ["create_order_edit", "POST", "/admin/order-edits"],
+        ["add_order_edit_items", "POST", "/admin/order-edits/:id/items"],
+        [
+          "update_order_edit_item",
+          "POST",
+          "/admin/order-edits/:id/items/item/:itemId",
+        ],
+        ["request_order_edit", "POST", "/admin/order-edits/:id/request"],
+        ["cancel_order_edit", "DELETE", "/admin/order-edits/:id"],
+      ] as const
+      for (const [name, method, path] of staged) {
+        const def = ADMIN_MCP_TOOLS.find((t) => t.name === name)
+        expect(def).toBeTruthy()
+        expect(def!.method).toBe(method)
+        expect(def!.path).toBe(path)
+        expect(def!.write).toBe(true)
+        expect(isSensitive(def!)).toBe(true)
+        expect(isDangerous(def!)).toBe(false)
+      }
+    })
+
+    it("substitutes both order and fulfillment path params", async () => {
+      const res = await dispatchAdminTool(
+        { baseUrl: "http://localhost:9999" },
+        "create_order_shipment",
+        {
+          id: "order_1",
+          fulfillmentId: "ful_1",
+          items: [{ id: "item_1", quantity: 2 }],
+          dry_run: true,
+        }
+      )
+      expect(res.ok).toBe(true)
+      expect(res.plan?.path).toBe(
+        "/admin/orders/order_1/fulfillments/ful_1/shipments"
+      )
+      expect((res.plan?.body as any)?.items).toHaveLength(1)
+    })
+
+    it("create_order_fulfillment without confirm returns requires_confirmation", async () => {
+      const res = await dispatchAdminTool(
+        { baseUrl: "http://localhost:9999" },
+        "create_order_fulfillment",
+        { id: "order_1", items: [{ id: "item_1", quantity: 1 }] }
+      )
+      expect(res.requires_confirmation).toBe(true)
+      expect(res.plan?.path).toBe("/admin/orders/order_1/fulfillments")
+    })
+
+    it("list_orders exposes kind so the model can reach non-retail orders", () => {
+      const def = ADMIN_MCP_TOOLS.find((t) => t.name === "list_orders")!
+      expect(def.queryParams).toContain("kind")
+    })
+  })
+
+  describe("production runs (#1167): lifecycle levers", () => {
+    it("registers the run read companions", () => {
+      const reads = [
+        ["get_production_run", "/admin/production-runs/:id"],
+        ["list_production_run_activities", "/admin/production-runs/:id/activities"],
+        ["get_production_run_cost_summary", "/admin/production-runs/:id/cost-summary"],
+        ["get_production_run_task", "/admin/production-runs/:id/tasks/:taskId"],
+        ["get_production_run_policy", "/admin/production-run-policy"],
+      ] as const
+      for (const [name, path] of reads) {
+        const def = ADMIN_MCP_TOOLS.find((t) => t.name === name)
+        expect(def).toBeTruthy()
+        expect(def!.method ?? "GET").toBe("GET")
+        expect(def!.path).toBe(path)
+        expect(def!.write).toBeFalsy()
+      }
+    })
+
+    it("registers the lifecycle writes as sensitive", () => {
+      const writes = [
+        ["create_production_run", "POST", "/admin/production-runs"],
+        ["update_production_run", "POST", "/admin/production-runs/:id"],
+        ["approve_production_run", "POST", "/admin/production-runs/:id/approve"],
+        [
+          "send_production_run_to_production",
+          "POST",
+          "/admin/production-runs/:id/send-to-production",
+        ],
+        [
+          "start_production_run_dispatch",
+          "POST",
+          "/admin/production-runs/:id/start-dispatch",
+        ],
+        [
+          "resume_production_run_dispatch",
+          "POST",
+          "/admin/production-runs/:id/resume-dispatch",
+        ],
+        ["update_production_run_task", "POST", "/admin/production-runs/:id/tasks/:taskId"],
+        ["update_production_run_policy", "PUT", "/admin/production-run-policy"],
+      ] as const
+      for (const [name, method, path] of writes) {
+        const def = ADMIN_MCP_TOOLS.find((t) => t.name === name)
+        expect(def).toBeTruthy()
+        expect(def!.write).toBe(true)
+        expect(def!.method).toBe(method)
+        expect(def!.path).toBe(path)
+        expect(isSensitive(def!)).toBe(true)
+        expect(isDangerous(def!)).toBe(false)
+      }
+    })
+
+    it("cancel_production_run is dangerous and forwards the audited reason as the cancel reason", async () => {
+      const def = ADMIN_MCP_TOOLS.find((t) => t.name === "cancel_production_run")!
+      expect(isDangerous(def)).toBe(true)
+      expect(def.bodyParams).toContain("reason")
+
+      const res = await dispatchAdminTool(
+        { baseUrl: "http://localhost:9999" },
+        "cancel_production_run",
+        { id: "prun_1", reason: "partner dropped out", dry_run: true }
+      )
+      expect(res.ok).toBe(true)
+      expect(res.plan?.path).toBe("/admin/production-runs/prun_1/cancel")
+      expect((res.plan?.body as any)?.reason).toBe("partner dropped out")
+    })
+
+    it("list_production_runs drops the unsupported q filter and exposes the real ones", () => {
+      const def = ADMIN_MCP_TOOLS.find((t) => t.name === "list_production_runs")!
+      // The route has no free-text search — declaring `q` would silently
+      // swallow the model's search term.
+      expect(def.queryParams).not.toContain("q")
+      for (const p of ["status", "partner_id", "design_id", "run_type"]) {
+        expect(def.queryParams).toContain(p)
+      }
+    })
+
+    it("approve_production_run carries partner assignments in the body", async () => {
+      const res = await dispatchAdminTool(
+        { baseUrl: "http://localhost:9999" },
+        "approve_production_run",
+        {
+          id: "prun_1",
+          assignments: [{ partner_id: "partner_1", quantity: 10 }],
+          dry_run: true,
+        }
+      )
+      expect(res.ok).toBe(true)
+      expect(res.plan?.path).toBe("/admin/production-runs/prun_1/approve")
+      expect((res.plan?.body as any)?.assignments?.[0]?.partner_id).toBe("partner_1")
+    })
+
+    it("resume_production_run_dispatch requires the transaction_id from start", () => {
+      const def = ADMIN_MCP_TOOLS.find((t) => t.name === "resume_production_run_dispatch")!
+      expect(def.bodyParams).toContain("transaction_id")
+      expect(def.inputSchema.required).toEqual(
+        expect.arrayContaining(["id", "template_names", "transaction_id"])
+      )
+    })
+  })
+
+  describe("designs (#1166): design -> production pipeline", () => {
+    it("registers the design read companions", () => {
+      const reads = [
+        ["list_design_work_orders", "/admin/design-work-orders"],
+        ["list_design_revisions", "/admin/designs/:id/revisions"],
+        ["list_design_inventory", "/admin/designs/:id/inventory"],
+        ["list_design_tasks", "/admin/designs/:id/tasks"],
+        ["get_design_task", "/admin/designs/:id/tasks/:taskId"],
+      ] as const
+      for (const [name, path] of reads) {
+        const def = ADMIN_MCP_TOOLS.find((t) => t.name === name)
+        expect(def).toBeTruthy()
+        expect(def!.method ?? "GET").toBe("GET")
+        expect(def!.path).toBe(path)
+        expect(def!.write).toBeFalsy()
+      }
+    })
+
+    it("registers the pipeline writes as sensitive, none dangerous", () => {
+      const writes = [
+        ["create_design", "POST", "/admin/designs"],
+        ["update_design", "PUT", "/admin/designs/:id"],
+        ["link_design_partners", "POST", "/admin/designs/:id/partner"],
+        ["unlink_design_partner", "DELETE", "/admin/designs/:id/partner"],
+        ["create_design_production_run", "POST", "/admin/designs/:id/production-runs"],
+        ["produce_designs", "POST", "/admin/designs/produce"],
+        [
+          "recreate_design_production_run",
+          "POST",
+          "/admin/designs/recreate-production-run",
+        ],
+        [
+          "cancel_design_partner_assignment",
+          "POST",
+          "/admin/designs/:id/cancel-partner-assignment",
+        ],
+        ["update_design_task", "POST", "/admin/designs/:id/tasks/:taskId"],
+        ["assign_design_task", "POST", "/admin/designs/:id/tasks/:taskId/assign"],
+      ] as const
+      for (const [name, method, path] of writes) {
+        const def = ADMIN_MCP_TOOLS.find((t) => t.name === name)
+        expect(def).toBeTruthy()
+        expect(def!.write).toBe(true)
+        expect(def!.method).toBe(method)
+        expect(def!.path).toBe(path)
+        expect(isSensitive(def!)).toBe(true)
+        expect(isDangerous(def!)).toBe(false)
+      }
+    })
+
+    it("update_design carries size_sets — the only route that can set them", () => {
+      const def = ADMIN_MCP_TOOLS.find((t) => t.name === "update_design")!
+      expect(def.bodyParams).toContain("size_sets")
+      expect(def.previewPath).toBe("/admin/designs/:id")
+      expect(def.inputSchema.properties.size_sets).toBeDefined()
+    })
+
+    it("produce_designs previews a batch send-to-production without executing", async () => {
+      const res = await dispatchAdminTool(
+        { baseUrl: "http://localhost:9999" },
+        "produce_designs",
+        { design_ids: ["design_1", "design_2"], partner_id: "partner_1", dry_run: true }
+      )
+      expect(res.ok).toBe(true)
+      expect(res.dry_run).toBe(true)
+      expect(res.plan?.path).toBe("/admin/designs/produce")
+      expect((res.plan?.body as any)?.design_ids).toHaveLength(2)
+    })
+
+    it("assign_design_task sends taskId in BOTH the path and the body (route validator wants both)", async () => {
+      const def = ADMIN_MCP_TOOLS.find((t) => t.name === "assign_design_task")!
+      expect(def.pathParams).toEqual(["id", "taskId"])
+      expect(def.bodyParams).toEqual(expect.arrayContaining(["taskId", "partnerId"]))
+
+      const res = await dispatchAdminTool(
+        { baseUrl: "http://localhost:9999" },
+        "assign_design_task",
+        { id: "design_1", taskId: "task_1", partnerId: "partner_1", dry_run: true }
+      )
+      expect(res.plan?.path).toBe("/admin/designs/design_1/tasks/task_1/assign")
+      expect((res.plan?.body as any)?.taskId).toBe("task_1")
+    })
+
+    it("does NOT wrap the AI-generation / file-shaped design routes", () => {
+      // These cost money per call, need an uploaded image, or return payloads
+      // (SVG documents, Excalidraw scenes) that would blow the chat context.
+      const excluded = [
+        "/admin/designs/auto",
+        "/admin/designs/:id/segment",
+        "/admin/designs/:id/outline",
+        "/admin/designs/:id/redesign",
+        "/admin/designs/:id/moodboard/generate",
+        "/admin/designs/:id/pattern-blocks",
+      ]
+      for (const path of excluded) {
+        expect(ADMIN_MCP_TOOLS.find((t) => t.path === path)).toBeUndefined()
+      }
+    })
+  })
+
+  describe("registry-wide invariants across all tiers", () => {
+    it("every write tool declares a non-GET method and at least one guard", () => {
+      for (const def of ADMIN_MCP_TOOLS.filter((t) => t.write)) {
+        expect(def.method ?? "GET").not.toBe("GET")
+        expect(isSensitive(def)).toBe(true)
+      }
+    })
+
+    it("every previewPath is a subset of its tool's own path params", () => {
+      for (const def of ADMIN_MCP_TOOLS) {
+        if (!def.previewPath) continue
+        // Anything left as `:param` after substitution would produce a bogus
+        // preview URL, so the preview path must only use declared params.
+        const previewParams = [...def.previewPath.matchAll(/:([A-Za-z0-9_]+)/g)].map(
+          (m) => m[1]
+        )
+        for (const p of previewParams) {
+          expect(def.pathParams ?? []).toContain(p)
+        }
+      }
+    })
+
+    it("every declared path param actually appears in the tool's path", () => {
+      for (const def of ADMIN_MCP_TOOLS) {
+        for (const p of def.pathParams ?? []) {
+          expect(def.path).toContain(`:${p}`)
+        }
+      }
+    })
+
+    it("every path/body/query param is described in the tool's input schema", () => {
+      for (const def of ADMIN_MCP_TOOLS) {
+        const props = def.inputSchema?.properties ?? {}
+        for (const p of def.pathParams ?? []) {
+          expect(`${def.name}:${p}`).toBe(props[p] ? `${def.name}:${p}` : "MISSING")
+        }
+        for (const p of def.queryParams ?? []) {
+          expect(`${def.name}:${p}`).toBe(props[p] ? `${def.name}:${p}` : "MISSING")
+        }
+        for (const p of def.bodyParams ?? []) {
+          // `reason` is injected by the dangerous rail, not declared per-tool.
+          if (p === "reason" && isDangerous(def)) continue
+          expect(`${def.name}:${p}`).toBe(props[p] ? `${def.name}:${p}` : "MISSING")
+        }
+      }
+    })
+
+    it("every nextSteps hint points at a tool that exists", () => {
+      const names = new Set(ADMIN_MCP_TOOLS.map((t) => t.name))
+      for (const def of ADMIN_MCP_TOOLS) {
+        for (const step of def.nextSteps ?? []) {
+          expect(`${def.name} -> ${step}`).toBe(
+            names.has(step) ? `${def.name} -> ${step}` : "DANGLING"
+          )
+        }
+      }
+    })
+  })
+
   describe("framework args — parity with the partner dispatcher", () => {
     it("injects context + dry_run onto EVERY tool's input schema", () => {
       for (const def of ADMIN_MCP_TOOLS) {

--- a/apps/backend/src/api/admin/mcp/lib/handler.ts
+++ b/apps/backend/src/api/admin/mcp/lib/handler.ts
@@ -28,13 +28,15 @@ import { ADMIN_MCP_TOOLS } from "./registry"
 const SERVER_INFO = { name: "jyt-admin", version: "0.1.0" } as const
 
 const INSTRUCTIONS =
-  "JYT Admin MCP — drive the platform via the Admin API. Tools currently cover " +
-  "read-only breadth: orders, products, customers, partners, stores, designs, " +
-  "production runs, inventory, payments, campaigns and notifications. Every tool " +
-  "accepts a `dry_run` flag. Sensitive/destructive tools require `confirm: true`, " +
-  "and platform-destructive ('dangerous') tools additionally require a human " +
-  "`reason` — never confirm or invent a reason on the admin's behalf. Start by " +
-  "calling get_admin_stats to ground yourself."
+  "JYT Admin MCP — drive the platform via the Admin API. Tools cover reads across " +
+  "orders, products, customers, partners, stores, designs, production runs, " +
+  "inventory, payments, campaigns and notifications, plus writes for the catalog, " +
+  "partner ops, order fulfillment and order edits, the production-run lifecycle " +
+  "(create -> approve/assign -> dispatch -> cancel) and the design -> production " +
+  "pipeline. Every tool accepts a `dry_run` flag. Sensitive/destructive tools " +
+  "require `confirm: true`, and platform-destructive ('dangerous') tools " +
+  "additionally require a human `reason` — never confirm or invent a reason on " +
+  "the admin's behalf. Start by calling get_admin_stats to ground yourself."
 
 /** Write tools are on by default; a deployment can force read-only. */
 export function isAdminWriteEnabled(): boolean {

--- a/apps/backend/src/api/admin/mcp/lib/registry.ts
+++ b/apps/backend/src/api/admin/mcp/lib/registry.ts
@@ -14,12 +14,17 @@
  *  - `dangerous` (platform-destructive): additionally require a human `reason`;
  *    hidden + refused unless ADMIN_MCP_ENABLE_DANGEROUS is on.
  *
- * Tier 1 is read-only breadth. Tier 2 (below) adds the first writes — catalog
- * updates (sensitive: require confirm) and the first `dangerous` action
- * (delete_product: confirm + reason, gated by ADMIN_MCP_ENABLE_DANGEROUS) —
- * plus the MCP-observability read (`get_mcp_usage`) and the resolver capability
- * carried over from the deprecated V4 chat (`resolve_admin_query`). Later tiers
- * add production, money, CRM/investor and marketing tools (see epic #1092).
+ * Tier 1 is read-only breadth. Tier 2 adds the first writes — catalog updates
+ * (sensitive: require confirm) and the first `dangerous` action (delete_product:
+ * confirm + reason, gated by ADMIN_MCP_ENABLE_DANGEROUS) — plus the
+ * MCP-observability read (`get_mcp_usage`) and the resolver capability carried
+ * over from the deprecated V4 chat (`resolve_admin_query`). Tier 3 covers
+ * partner ops (#843) and then the three operational domains behind it:
+ * orders/fulfillment + order edits (#1165), production-run lifecycle (#1167)
+ * and the design -> production pipeline (#1166). Remaining uncovered domains
+ * are catalogued in #1168 — add them as real demand appears, not ahead of it:
+ * every row here is bound into EVERY admin-assistant turn, so the registry's
+ * size is a per-request token cost.
  */
 import type { McpToolDef } from "../../../../lib/mcp-core"
 
@@ -64,13 +69,16 @@ export const ADMIN_MCP_TOOLS: AdminMcpToolDef[] = [
   {
     name: "list_orders",
     description:
-      "List orders (paginated). Supports free-text search via q. Use to answer 'what orders came in', revenue/volume, and to find an order id.",
+      "List orders (paginated). Supports free-text search via q. Defaults to RETAIL orders only — pass kind to see design/inventory orders or all of them. Use to answer 'what orders came in', revenue/volume, and to find an order id.",
     method: "GET",
     path: "/admin/orders",
-    queryParams: ["limit", "offset", "q", "status"],
+    queryParams: ["limit", "offset", "q", "status", "kind"],
     inputSchema: obj({
       ...PAGINATION,
       status: STR("Optional order status filter."),
+      kind: STR(
+        "Which order family to list: 'retail' (default) | 'design' | 'inventory' | 'all'."
+      ),
     }),
   },
   {
@@ -157,13 +165,36 @@ export const ADMIN_MCP_TOOLS: AdminMcpToolDef[] = [
   {
     name: "list_production_runs",
     description:
-      "List production runs / work orders (paginated). Use to see open runs, their stage and assigned partner.",
+      "List production runs / work orders (paginated). Filter by status, partner, design, product, order, run type or parent run. Use to see open runs, their stage and assigned partner.",
     method: "GET",
     path: "/admin/production-runs",
-    queryParams: ["limit", "offset", "q", "status"],
+    // NB: this route has no free-text `q` — it filters on explicit ids/enums
+    // only. Declaring `q` here would silently drop the model's search term.
+    queryParams: [
+      "limit",
+      "offset",
+      "status",
+      "partner_id",
+      "design_id",
+      "product_id",
+      "order_id",
+      "parent_run_id",
+      "run_type",
+      "include_tasks",
+    ],
     inputSchema: obj({
-      ...PAGINATION,
-      status: STR("Optional run status filter."),
+      limit: { type: "integer", description: "Max results (default 20)." },
+      offset: { type: "integer", description: "Pagination offset." },
+      status: STR(
+        "Run status: 'draft' | 'pending_review' | 'approved' | 'sent_to_partner' | 'in_progress' | 'completed' | 'cancelled' | 'awaiting_reassignment'."
+      ),
+      partner_id: STR("Only runs assigned to this partner."),
+      design_id: STR("Only runs for this design."),
+      product_id: STR("Only runs for this product."),
+      order_id: STR("Only runs for this order."),
+      parent_run_id: STR("Only child runs of this parent run."),
+      run_type: STR("'production' | 'sample'."),
+      include_tasks: STR("Pass 'true' to include each run's tasks."),
     }),
   },
 
@@ -857,6 +888,1148 @@ export const ADMIN_MCP_TOOLS: AdminMcpToolDef[] = [
       ["id"]
     ),
     sideEffects: "Sets the product to 'rejected' and emits partner_product.rejected.",
+  },
+
+  // ===== Orders ops (#1165): fulfillment, shipping and order edits =======
+  // Wraps the order detail page's actions. Fulfilling and shipping are
+  // `sensitive` (they notify the customer and hit a live carrier API);
+  // cancelling an order or a fulfillment, and confirming an order edit, are
+  // `dangerous` — irreversible once the workflow runs.
+  {
+    name: "list_order_changes",
+    description:
+      "List the change history of an order (order edits, returns, exchanges, claims) with their status and type. Use to explain why an order's totals or line items differ from the original.",
+    method: "GET",
+    path: "/admin/orders/:id/changes",
+    pathParams: ["id"],
+    queryParams: ["status", "change_type"],
+    inputSchema: obj(
+      {
+        id: STR("Order id, e.g. 'order_...'."),
+        status: STR("Optional change status filter."),
+        change_type: STR("Optional change type filter, e.g. 'edit' | 'return' | 'exchange'."),
+      },
+      ["id"]
+    ),
+  },
+  {
+    name: "list_order_designs",
+    description:
+      "List the designs attached to an order's line items. Use before produce_order_designs to see what would be sent to production.",
+    method: "GET",
+    path: "/admin/orders/:id/design",
+    pathParams: ["id"],
+    inputSchema: obj({ id: STR("Order id, e.g. 'order_...'.") }, ["id"]),
+  },
+  {
+    name: "list_order_shipping_rates",
+    description:
+      "List the available courier options for an order (rate, ETA, recommended flag). Call this before create_order_shipping_label to pick a preferred_courier_id.",
+    method: "GET",
+    path: "/admin/orders/:id/fulfillment-rates",
+    pathParams: ["id"],
+    queryParams: ["carrier", "weight_grams"],
+    inputSchema: obj(
+      {
+        id: STR("Order id, e.g. 'order_...'."),
+        carrier: STR("Optional carrier to scope the quote to."),
+        weight_grams: { type: "number", description: "Override shipment weight in grams." },
+      },
+      ["id"]
+    ),
+    nextSteps: ["create_order_shipping_label"],
+  },
+  {
+    name: "get_order_fulfillment_label",
+    description:
+      "Get the shipping label for an existing fulfillment (label URL / waybill). Returns 404 if the fulfillment has no waybill yet.",
+    method: "GET",
+    path: "/admin/orders/:id/fulfillments/:fulfillmentId/label",
+    pathParams: ["id", "fulfillmentId"],
+    inputSchema: obj(
+      {
+        id: STR("Order id, e.g. 'order_...'."),
+        fulfillmentId: STR("Fulfillment id, e.g. 'ful_...'."),
+      },
+      ["id", "fulfillmentId"]
+    ),
+  },
+
+  // ---- Order writes -------------------------------------------------------
+  {
+    name: "update_order",
+    description:
+      "Update an order's email or shipping/billing address. Sensitive: requires confirm:true. Use dry_run to see the current order first. Does NOT change line items — use the order-edit tools for that.",
+    method: "POST",
+    path: "/admin/orders/:id",
+    pathParams: ["id"],
+    previewPath: "/admin/orders/:id",
+    write: true,
+    sensitive: true,
+    bodyParams: ["email", "shipping_address", "billing_address", "metadata"],
+    inputSchema: obj(
+      {
+        id: STR("Order id, e.g. 'order_...'."),
+        email: STR("New order email."),
+        shipping_address: {
+          type: "object",
+          description:
+            "Replacement shipping address: { first_name, last_name, phone, company, address_1, address_2, city, province, postal_code, country_code }.",
+        },
+        billing_address: {
+          type: "object",
+          description: "Replacement billing address (same shape as shipping_address).",
+        },
+        metadata: { type: "object", description: "Metadata to merge." },
+      },
+      ["id"]
+    ),
+  },
+  {
+    name: "create_order_fulfillment",
+    description:
+      "Fulfil items on an order — creates a fulfillment for the given line items at a stock location. Sensitive: requires confirm:true. Call get_order first to read the line item ids and quantities.",
+    method: "POST",
+    path: "/admin/orders/:id/fulfillments",
+    pathParams: ["id"],
+    previewPath: "/admin/orders/:id",
+    write: true,
+    sensitive: true,
+    bodyParams: ["items", "location_id", "shipping_option_id", "no_notification", "metadata"],
+    inputSchema: obj(
+      {
+        id: STR("Order id, e.g. 'order_...'."),
+        items: {
+          type: "array",
+          description:
+            "Line items to fulfil (required, non-empty). Each: { id: order line item id, quantity: number }.",
+          items: obj(
+            {
+              id: STR("Order line item id."),
+              quantity: { type: "number", description: "Quantity to fulfil." },
+            },
+            ["id", "quantity"]
+          ),
+        },
+        location_id: STR("Stock location to fulfil from."),
+        shipping_option_id: STR("Shipping option to use."),
+        no_notification: { type: "boolean", description: "Suppress the customer notification." },
+        metadata: { type: "object", description: "Optional key/value metadata." },
+      },
+      ["id", "items"]
+    ),
+    sideEffects: "Reserves/deducts inventory at the location and notifies the customer unless no_notification is set.",
+    nextSteps: ["create_order_shipment", "create_order_shipping_label"],
+  },
+  {
+    name: "create_order_shipment",
+    description:
+      "Mark a fulfillment as SHIPPED, optionally attaching tracking numbers/URLs. Sensitive: requires confirm:true.",
+    method: "POST",
+    path: "/admin/orders/:id/fulfillments/:fulfillmentId/shipments",
+    pathParams: ["id", "fulfillmentId"],
+    previewPath: "/admin/orders/:id",
+    write: true,
+    sensitive: true,
+    bodyParams: ["items", "labels", "no_notification", "metadata"],
+    inputSchema: obj(
+      {
+        id: STR("Order id, e.g. 'order_...'."),
+        fulfillmentId: STR("Fulfillment id, e.g. 'ful_...'."),
+        items: {
+          type: "array",
+          description: "Items being shipped (required; may be empty). Each: { id, quantity }.",
+          items: obj(
+            {
+              id: STR("Order line item id."),
+              quantity: { type: "number", description: "Quantity shipped." },
+            },
+            ["id", "quantity"]
+          ),
+        },
+        labels: {
+          type: "array",
+          description:
+            "Tracking labels. Each requires { tracking_number, tracking_url, label_url } — URLs must be http(s).",
+          items: obj(
+            {
+              tracking_number: STR("Carrier tracking number."),
+              tracking_url: STR("Tracking URL (http/https)."),
+              label_url: STR("Label PDF URL (http/https)."),
+            },
+            ["tracking_number", "tracking_url", "label_url"]
+          ),
+        },
+        no_notification: { type: "boolean", description: "Suppress the shipment email." },
+        metadata: { type: "object", description: "Optional key/value metadata." },
+      },
+      ["id", "fulfillmentId", "items"]
+    ),
+    sideEffects: "Marks the fulfillment shipped and emails the customer unless no_notification is set.",
+    nextSteps: ["mark_order_fulfillment_delivered"],
+  },
+  {
+    name: "mark_order_fulfillment_delivered",
+    description:
+      "Mark a fulfillment as DELIVERED. Sensitive: requires confirm:true.",
+    method: "POST",
+    path: "/admin/orders/:id/fulfillments/:fulfillmentId/mark-as-delivered",
+    pathParams: ["id", "fulfillmentId"],
+    previewPath: "/admin/orders/:id",
+    write: true,
+    sensitive: true,
+    bodyParams: ["no_notification"],
+    inputSchema: obj(
+      {
+        id: STR("Order id, e.g. 'order_...'."),
+        fulfillmentId: STR("Fulfillment id, e.g. 'ful_...'."),
+        no_notification: { type: "boolean", description: "Suppress the customer notification." },
+      },
+      ["id", "fulfillmentId"]
+    ),
+  },
+  {
+    name: "cancel_order_fulfillment",
+    description:
+      "Cancel a fulfillment and return its items to stock. PLATFORM-DESTRUCTIVE: requires confirm:true AND a human reason, and is only available when ADMIN_MCP_ENABLE_DANGEROUS is enabled. Cannot be undone — a cancelled fulfillment must be re-created. Always dry_run first.",
+    method: "POST",
+    path: "/admin/orders/:id/fulfillments/:fulfillmentId/cancel",
+    pathParams: ["id", "fulfillmentId"],
+    previewPath: "/admin/orders/:id",
+    write: true,
+    dangerous: true,
+    bodyParams: ["no_notification"],
+    inputSchema: obj(
+      {
+        id: STR("Order id, e.g. 'order_...'."),
+        fulfillmentId: STR("Fulfillment id, e.g. 'ful_...'."),
+        no_notification: { type: "boolean", description: "Suppress the customer notification." },
+      },
+      ["id", "fulfillmentId"]
+    ),
+    sideEffects: "Reverses the fulfillment and restocks its items. Already-shipped fulfillments cannot be cancelled.",
+  },
+  {
+    name: "cancel_order",
+    description:
+      "Cancel an entire order. PLATFORM-DESTRUCTIVE: requires confirm:true AND a human reason, and is only available when ADMIN_MCP_ENABLE_DANGEROUS is enabled. Irreversible — the order cannot be un-cancelled. Always dry_run first.",
+    method: "POST",
+    path: "/admin/orders/:id/cancel",
+    pathParams: ["id"],
+    previewPath: "/admin/orders/:id",
+    write: true,
+    dangerous: true,
+    inputSchema: obj({ id: STR("Order id to cancel, e.g. 'order_...'.") }, ["id"]),
+    sideEffects: "Cancels payments and fulfillments on the order and notifies the customer. Fails if the order is already fulfilled or captured.",
+  },
+  {
+    name: "complete_order",
+    description:
+      "Mark an order as complete (closes it for further edits). Sensitive: requires confirm:true.",
+    method: "POST",
+    path: "/admin/orders/:id/complete",
+    pathParams: ["id"],
+    previewPath: "/admin/orders/:id",
+    write: true,
+    sensitive: true,
+    inputSchema: obj({ id: STR("Order id, e.g. 'order_...'.") }, ["id"]),
+    sideEffects: "Sets the order to 'completed'; further order edits are blocked.",
+  },
+  {
+    name: "produce_order_designs",
+    description:
+      "Send an order's design line items to production: creates one production run per design, collated into a single design work-order. Idempotent — re-running does not duplicate runs. Sensitive: requires confirm:true. Call list_order_designs first.",
+    method: "POST",
+    path: "/admin/orders/:id/design/produce",
+    pathParams: ["id"],
+    previewPath: "/admin/orders/:id/design",
+    write: true,
+    sensitive: true,
+    bodyParams: ["partner_id"],
+    inputSchema: obj(
+      {
+        id: STR("Order id, e.g. 'order_...'."),
+        partner_id: STR("Optional partner to assign every created run to."),
+      },
+      ["id"]
+    ),
+    sideEffects: "Creates production runs and a collated design work-order for the order.",
+    nextSteps: ["list_production_runs", "approve_production_run"],
+  },
+  {
+    name: "create_order_shipping_label",
+    description:
+      "One-click ship: create (or reuse) a fulfillment for the whole order, book the carrier shipment and buy the label. Sensitive: requires confirm:true. Call list_order_shipping_rates first to choose preferred_courier_id.",
+    method: "POST",
+    path: "/admin/orders/:id/fulfillment-label",
+    pathParams: ["id"],
+    previewPath: "/admin/orders/:id",
+    write: true,
+    sensitive: true,
+    bodyParams: ["carrier", "preferred_courier_id"],
+    inputSchema: obj(
+      {
+        id: STR("Order id, e.g. 'order_...'."),
+        carrier: STR("Carrier to book with (defaults to the configured provider)."),
+        preferred_courier_id: STR("Courier id from list_order_shipping_rates."),
+      },
+      ["id"]
+    ),
+    sideEffects: "Calls the live carrier API, books a real shipment and buys a label — this costs money and is not undone by cancelling the fulfillment.",
+  },
+  {
+    name: "attach_order_awb",
+    description:
+      "Attach an EXISTING carrier waybill (AWB) to an order — reuses or creates a manual fulfillment, looks the AWB up read-only, and stamps the carrier refs. Use when a shipment was booked outside the platform. Sensitive: requires confirm:true.",
+    method: "POST",
+    path: "/admin/orders/:id/shiprocket-attach-awb",
+    pathParams: ["id"],
+    previewPath: "/admin/orders/:id",
+    write: true,
+    sensitive: true,
+    bodyParams: ["awb"],
+    inputSchema: obj(
+      {
+        id: STR("Order id, e.g. 'order_...'."),
+        awb: STR("The existing carrier waybill number (required)."),
+      },
+      ["id", "awb"]
+    ),
+    sideEffects: "Does NOT book a new shipment — it only links an already-booked AWB and syncs its status.",
+  },
+
+  // ---- Order edits (line-item changes on a placed order) ------------------
+  // A staged workflow: create an edit -> add/update items -> request ->
+  // confirm. Nothing touches the real order until confirm_order_edit runs,
+  // which is why only that last step is `dangerous`.
+  {
+    name: "create_order_edit",
+    description:
+      "Start an order edit — a staged draft for changing a placed order's line items. Nothing changes on the order until confirm_order_edit. Sensitive: requires confirm:true.",
+    method: "POST",
+    path: "/admin/order-edits",
+    write: true,
+    sensitive: true,
+    bodyParams: ["order_id", "description", "internal_note", "metadata"],
+    inputSchema: obj(
+      {
+        order_id: STR("Order id to edit, e.g. 'order_...' (required)."),
+        description: STR("Customer-facing description of the edit."),
+        internal_note: STR("Internal note for the ops team."),
+        metadata: { type: "object", description: "Optional key/value metadata." },
+      },
+      ["order_id"]
+    ),
+    sideEffects: "Creates a draft order-change. The order itself is untouched until the edit is confirmed.",
+    nextSteps: ["add_order_edit_items", "update_order_edit_item", "request_order_edit"],
+  },
+  {
+    name: "add_order_edit_items",
+    description:
+      "Add new line items to an in-progress order edit. Sensitive: requires confirm:true.",
+    method: "POST",
+    path: "/admin/order-edits/:id/items",
+    pathParams: ["id"],
+    write: true,
+    sensitive: true,
+    bodyParams: ["items"],
+    inputSchema: obj(
+      {
+        id: STR("Order edit (order-change) id."),
+        items: {
+          type: "array",
+          description: "Items to add. Each: { variant_id, quantity, unit_price?, internal_note? }.",
+          items: obj(
+            {
+              variant_id: STR("Product variant id to add."),
+              quantity: { type: "number", description: "Quantity to add." },
+              unit_price: { type: "number", description: "Override unit price." },
+              internal_note: STR("Internal note on the added item."),
+            },
+            ["variant_id", "quantity"]
+          ),
+        },
+      },
+      ["id", "items"]
+    ),
+  },
+  {
+    name: "update_order_edit_item",
+    description:
+      "Change the quantity or price of an EXISTING line item within an in-progress order edit (this is how you remove an item — set quantity to 0). Sensitive: requires confirm:true.",
+    method: "POST",
+    path: "/admin/order-edits/:id/items/item/:itemId",
+    pathParams: ["id", "itemId"],
+    write: true,
+    sensitive: true,
+    bodyParams: ["quantity", "unit_price", "internal_note"],
+    inputSchema: obj(
+      {
+        id: STR("Order edit (order-change) id."),
+        itemId: STR("The ORIGINAL order line item id being changed."),
+        quantity: { type: "number", description: "New quantity (required). 0 removes the item." },
+        unit_price: { type: "number", description: "New unit price." },
+        internal_note: STR("Internal note on the change."),
+      },
+      ["id", "itemId", "quantity"]
+    ),
+  },
+  {
+    name: "request_order_edit",
+    description:
+      "Move an order edit from draft to 'requested' (awaiting confirmation). Sensitive: requires confirm:true.",
+    method: "POST",
+    path: "/admin/order-edits/:id/request",
+    pathParams: ["id"],
+    write: true,
+    sensitive: true,
+    inputSchema: obj({ id: STR("Order edit (order-change) id.") }, ["id"]),
+    nextSteps: ["confirm_order_edit", "cancel_order_edit"],
+  },
+  {
+    name: "confirm_order_edit",
+    description:
+      "APPLY an order edit to the real order — recalculates totals and may create a payment or refund. PLATFORM-DESTRUCTIVE: requires confirm:true AND a human reason, and is only available when ADMIN_MCP_ENABLE_DANGEROUS is enabled. Always dry_run first.",
+    method: "POST",
+    path: "/admin/order-edits/:id/confirm",
+    pathParams: ["id"],
+    write: true,
+    dangerous: true,
+    inputSchema: obj({ id: STR("Order edit (order-change) id to apply.") }, ["id"]),
+    sideEffects: "Mutates the placed order's line items and totals, and can trigger an additional charge or a refund. Not reversible by cancelling the edit.",
+  },
+  {
+    name: "cancel_order_edit",
+    description:
+      "Discard an in-progress order edit without applying it. Safe to call on any unconfirmed edit. Sensitive: requires confirm:true.",
+    method: "DELETE",
+    path: "/admin/order-edits/:id",
+    pathParams: ["id"],
+    write: true,
+    inputSchema: obj({ id: STR("Order edit (order-change) id to discard.") }, ["id"]),
+    sideEffects: "Throws away the draft edit. The underlying order is unaffected.",
+  },
+
+  // ===== Production runs (#1167): the admin lifecycle levers =============
+  // create -> approve (this is where partners are assigned) -> either
+  // send-to-production (instantiate task templates) OR start/resume-dispatch
+  // -> cancel. Accept/start/finish are PARTNER-side routes and deliberately
+  // absent here. Statuses: draft | pending_review | approved | sent_to_partner
+  // | in_progress | completed | cancelled | awaiting_reassignment.
+  {
+    name: "get_production_run",
+    description:
+      "Get a single production run by id, with its linked tasks. Use to read the run's status, quantity, assigned partner, dispatch state and cost fields.",
+    method: "GET",
+    path: "/admin/production-runs/:id",
+    pathParams: ["id"],
+    inputSchema: obj({ id: STR("Production run id.") }, ["id"]),
+  },
+  {
+    name: "list_production_run_activities",
+    description:
+      "Read a production run's activity timeline (reminders sent, lifecycle events, notes), newest first. Use to answer 'what happened on this run'.",
+    method: "GET",
+    path: "/admin/production-runs/:id/activities",
+    pathParams: ["id"],
+    queryParams: ["limit", "offset", "activity_type", "kind"],
+    inputSchema: obj(
+      {
+        id: STR("Production run id."),
+        limit: { type: "integer", description: "Max rows (default 100, max 500)." },
+        offset: { type: "integer", description: "Pagination offset." },
+        activity_type: STR("'reminder_sent' | 'lifecycle_event' | 'note' | 'system'."),
+        kind: STR("Optional free-text activity kind filter."),
+      },
+      ["id"]
+    ),
+  },
+  {
+    name: "get_production_run_cost_summary",
+    description:
+      "Get a production run's computed cost rollup: material, energy, labour and partner cost, grand total and cost per unit.",
+    method: "GET",
+    path: "/admin/production-runs/:id/cost-summary",
+    pathParams: ["id"],
+    inputSchema: obj({ id: STR("Production run id.") }, ["id"]),
+  },
+  {
+    name: "get_production_run_task",
+    description: "Get a single task belonging to a production run.",
+    method: "GET",
+    path: "/admin/production-runs/:id/tasks/:taskId",
+    pathParams: ["id", "taskId"],
+    inputSchema: obj(
+      {
+        id: STR("Production run id."),
+        taskId: STR("Task id, e.g. 'task_...'."),
+      },
+      ["id", "taskId"]
+    ),
+  },
+  {
+    name: "get_production_run_policy",
+    description:
+      "Read the platform's production-run policy: which run statuses each lifecycle transition (approve, dispatch, send-to-production, accept, start, finish, decline) is allowed from.",
+    method: "GET",
+    path: "/admin/production-run-policy",
+    inputSchema: obj({}),
+  },
+
+  // ---- Production run writes ---------------------------------------------
+  {
+    name: "create_production_run",
+    description:
+      "Create a production run for a design. Sensitive: requires confirm:true. The run starts in 'pending_review' — partners are assigned later via approve_production_run, not here.",
+    method: "POST",
+    path: "/admin/production-runs",
+    write: true,
+    sensitive: true,
+    bodyParams: [
+      "design_id",
+      "partner_id",
+      "quantity",
+      "run_type",
+      "product_id",
+      "variant_id",
+      "order_id",
+      "order_line_item_id",
+      "metadata",
+    ],
+    inputSchema: obj(
+      {
+        design_id: STR("Design id to produce (required)."),
+        partner_id: STR("Optional partner to pre-assign."),
+        quantity: { type: "number", description: "Units to produce (defaults to 1)." },
+        run_type: STR("'production' (default) | 'sample'."),
+        product_id: STR("Optional linked product id."),
+        variant_id: STR("Optional linked variant id."),
+        order_id: STR("Optional originating order id."),
+        order_line_item_id: STR("Optional originating order line item id."),
+        metadata: { type: "object", description: "Optional key/value metadata." },
+      },
+      ["design_id"]
+    ),
+    sideEffects: "Creates a run in 'pending_review'. It does no work until it is approved.",
+    nextSteps: ["approve_production_run", "get_production_run"],
+  },
+  {
+    name: "update_production_run",
+    description:
+      "Update a production run's quantity, role, run type or partner cost estimate. Sensitive: requires confirm:true. Structural edits (quantity/role/run_type) are REJECTED once the run has been accepted or started, and any edit is rejected on a cancelled run. Use dry_run to see the current run first.",
+    method: "POST",
+    path: "/admin/production-runs/:id",
+    pathParams: ["id"],
+    previewPath: "/admin/production-runs/:id",
+    write: true,
+    sensitive: true,
+    bodyParams: ["quantity", "role", "run_type", "partner_cost_estimate", "cost_type"],
+    inputSchema: obj(
+      {
+        id: STR("Production run id."),
+        quantity: { type: "number", description: "New quantity (pre-acceptance only)." },
+        role: STR("New role for the run (pre-acceptance only)."),
+        run_type: STR("'production' | 'sample' (pre-acceptance only)."),
+        partner_cost_estimate: {
+          type: "number",
+          description:
+            "Partner cost estimate. Note: the dispatcher drops null arguments, so this tool can set a cost but not clear one — clear it from the admin UI.",
+        },
+        cost_type: STR("'total' | 'per_unit'."),
+      },
+      ["id"]
+    ),
+  },
+  {
+    name: "approve_production_run",
+    description:
+      "Approve a production run and assign partners to it. THIS is where partner assignment happens: each assignment fans out a child run, and children carrying template_names are auto-dispatched. Sensitive: requires confirm:true. Use dry_run to see the current run first.",
+    method: "POST",
+    path: "/admin/production-runs/:id/approve",
+    pathParams: ["id"],
+    previewPath: "/admin/production-runs/:id",
+    write: true,
+    sensitive: true,
+    bodyParams: ["assignments"],
+    inputSchema: obj(
+      {
+        id: STR("Production run id."),
+        assignments: {
+          type: "array",
+          description:
+            "Partner assignments. Each: { partner_id (required), role?, quantity?, order? (dispatch sequence), template_names? (task templates to auto-dispatch; omit or null for none) }.",
+          items: obj(
+            {
+              partner_id: STR("Partner to assign (required)."),
+              role: STR("Role this partner plays in the run."),
+              quantity: { type: "number", description: "Units for this partner." },
+              order: { type: "integer", description: "Dispatch sequence position." },
+              template_names: {
+                type: "array",
+                items: { type: "string" },
+                description: "Task templates to instantiate and auto-dispatch for this partner.",
+              },
+            },
+            ["partner_id"]
+          ),
+        },
+      },
+      ["id"]
+    ),
+    sideEffects: "Creates one child run per assignment and auto-dispatches those with template_names (skipped entirely if any child declares depends_on_run_ids).",
+    nextSteps: ["send_production_run_to_production", "start_production_run_dispatch"],
+  },
+  {
+    name: "send_production_run_to_production",
+    description:
+      "Instantiate task templates on an approved production run — this creates the partner's tasks and hands the run over. Sensitive: requires confirm:true.",
+    method: "POST",
+    path: "/admin/production-runs/:id/send-to-production",
+    pathParams: ["id"],
+    previewPath: "/admin/production-runs/:id",
+    write: true,
+    sensitive: true,
+    bodyParams: ["template_names"],
+    inputSchema: obj(
+      {
+        id: STR("Production run id."),
+        template_names: {
+          type: "array",
+          items: { type: "string" },
+          description: "Task template names to instantiate (required, non-empty).",
+        },
+      },
+      ["id", "template_names"]
+    ),
+    sideEffects: "Creates partner tasks from the templates and notifies the assigned partner.",
+  },
+  {
+    name: "start_production_run_dispatch",
+    description:
+      "Begin the interactive dispatch of a production run. Returns a transaction_id and PARKS the workflow with the run in 'awaiting_templates' — you MUST follow up with resume_production_run_dispatch or the run stays stuck. Sensitive: requires confirm:true.",
+    method: "POST",
+    path: "/admin/production-runs/:id/start-dispatch",
+    pathParams: ["id"],
+    previewPath: "/admin/production-runs/:id",
+    write: true,
+    sensitive: true,
+    inputSchema: obj({ id: STR("Production run id.") }, ["id"]),
+    sideEffects: "Leaves the run parked in dispatch_state 'awaiting_templates' until resume_production_run_dispatch is called with the returned transaction_id.",
+    nextSteps: ["resume_production_run_dispatch"],
+  },
+  {
+    name: "resume_production_run_dispatch",
+    description:
+      "Complete a parked dispatch by supplying the chosen task templates. Requires the transaction_id returned by start_production_run_dispatch. Sensitive: requires confirm:true.",
+    method: "POST",
+    path: "/admin/production-runs/:id/resume-dispatch",
+    pathParams: ["id"],
+    write: true,
+    sensitive: true,
+    bodyParams: ["template_names", "transaction_id"],
+    inputSchema: obj(
+      {
+        id: STR("Production run id."),
+        template_names: {
+          type: "array",
+          items: { type: "string" },
+          description: "Task template names to dispatch (required, non-empty).",
+        },
+        transaction_id: STR("The transaction_id returned by start_production_run_dispatch (required)."),
+      },
+      ["id", "template_names", "transaction_id"]
+    ),
+  },
+  {
+    name: "cancel_production_run",
+    description:
+      "Cancel a production run, its open tasks and all of its child runs. PLATFORM-DESTRUCTIVE: requires confirm:true AND a human reason, and is only available when ADMIN_MCP_ENABLE_DANGEROUS is enabled. Cascades to the parent run when every sibling is terminal. Always dry_run first.",
+    method: "POST",
+    path: "/admin/production-runs/:id/cancel",
+    pathParams: ["id"],
+    previewPath: "/admin/production-runs/:id",
+    write: true,
+    dangerous: true,
+    // The dangerous rail's `reason` doubles as the route's cancellation reason:
+    // it is injected onto the schema by buildToolInputSchema and picked up here
+    // as a body param, so the audited "why" is what gets persisted on the run.
+    bodyParams: ["reason"],
+    inputSchema: obj({ id: STR("Production run id to cancel.") }, ["id"]),
+    sideEffects: "Cancels the run's non-terminal tasks, cascades to child runs, mirrors the state to the unified order and emits production_run.cancelled. Cancelled runs are terminal — they cannot be reopened.",
+  },
+  {
+    name: "update_production_run_task",
+    description:
+      "Update a task on a production run (title, description, status, priority, dates). Sensitive: requires confirm:true. Use dry_run to see the current task first. NOTE: this route does not validate enums server-side — only send the documented values.",
+    method: "POST",
+    path: "/admin/production-runs/:id/tasks/:taskId",
+    pathParams: ["id", "taskId"],
+    previewPath: "/admin/production-runs/:id/tasks/:taskId",
+    write: true,
+    sensitive: true,
+    bodyParams: [
+      "title",
+      "description",
+      "status",
+      "priority",
+      "start_date",
+      "end_date",
+      "metadata",
+    ],
+    inputSchema: obj(
+      {
+        id: STR("Production run id."),
+        taskId: STR("Task id, e.g. 'task_...'."),
+        title: STR("New title."),
+        description: STR("New description."),
+        status: STR(
+          "New status — one of exactly: 'pending' | 'in_progress' | 'completed' | 'cancelled' | 'accepted' | 'blocked'."
+        ),
+        priority: STR("New priority — one of exactly: 'low' | 'medium' | 'high'."),
+        start_date: STR("New start date (ISO string)."),
+        end_date: STR("New due date (ISO string)."),
+        metadata: { type: "object", description: "Metadata to merge." },
+      },
+      ["id", "taskId"]
+    ),
+  },
+  {
+    name: "update_production_run_policy",
+    description:
+      "Replace the platform-wide production-run policy config (which statuses each lifecycle transition is allowed from). This is a FULL REPLACE, not a merge, and it affects every run on the platform. Sensitive: requires confirm:true. Always call get_production_run_policy and dry_run first.",
+    method: "PUT",
+    path: "/admin/production-run-policy",
+    previewPath: "/admin/production-run-policy",
+    write: true,
+    sensitive: true,
+    bodyParams: ["config"],
+    inputSchema: obj(
+      {
+        config: {
+          type: "object",
+          description:
+            "The COMPLETE replacement policy config, e.g. { transitions: { approve_from: [...], dispatch_from: [...] } }. Read the current one with get_production_run_policy and send it back with your edits applied.",
+        },
+      },
+      ["config"]
+    ),
+    sideEffects: "Overwrites the singleton policy for ALL production runs; omitted keys are lost, not preserved.",
+  },
+
+  // ===== Designs (#1166): the design -> production pipeline ==============
+  // The designs domain is large; this wraps the operationally meaningful
+  // slice — core CRUD (which is also the ONLY way to set size_sets/colors),
+  // the collated work-order read, the produce/recreate/cancel triangle, and
+  // task state. AI-generation, segmentation, outline/vectorize, moodboard and
+  // pattern-block routes are deliberately NOT wrapped: they are file-upload
+  // shaped, cost money per call, or return payloads (SVG documents, Excalidraw
+  // scenes) that would blow the chat context.
+  {
+    name: "list_design_work_orders",
+    description:
+      "List collated design work-orders — each with its per-design production runs, the designs themselves and the assigned partners. This is the single best read for 'what is in production right now'.",
+    method: "GET",
+    path: "/admin/design-work-orders",
+    queryParams: ["limit", "offset"],
+    inputSchema: obj({
+      limit: { type: "integer", description: "Max results (default 20)." },
+      offset: { type: "integer", description: "Pagination offset." },
+    }),
+  },
+  {
+    name: "list_design_revisions",
+    description:
+      "Get a design's full revision lineage (ancestors, current, descendants). Use to explain why a design is 'Superseded' or to find the live revision.",
+    method: "GET",
+    path: "/admin/designs/:id/revisions",
+    pathParams: ["id"],
+    inputSchema: obj({ id: STR("Design id, e.g. 'design_...'.") }, ["id"]),
+  },
+  {
+    name: "list_design_inventory",
+    description:
+      "List the inventory items linked to a design (its bill of materials) with planned quantities.",
+    method: "GET",
+    path: "/admin/designs/:id/inventory",
+    pathParams: ["id"],
+    inputSchema: obj({ id: STR("Design id, e.g. 'design_...'.") }, ["id"]),
+  },
+  {
+    name: "list_design_tasks",
+    description: "List the tasks attached to a design.",
+    method: "GET",
+    path: "/admin/designs/:id/tasks",
+    pathParams: ["id"],
+    inputSchema: obj({ id: STR("Design id, e.g. 'design_...'.") }, ["id"]),
+  },
+  {
+    name: "get_design_task",
+    description: "Get a single task on a design by task id.",
+    method: "GET",
+    path: "/admin/designs/:id/tasks/:taskId",
+    pathParams: ["id", "taskId"],
+    inputSchema: obj(
+      {
+        id: STR("Design id, e.g. 'design_...'."),
+        taskId: STR("Task id, e.g. 'task_...'."),
+      },
+      ["id", "taskId"]
+    ),
+  },
+
+  // ---- Design writes ------------------------------------------------------
+  {
+    name: "create_design",
+    description:
+      "Create a new design. Sensitive: requires confirm:true. Supply at least a name and a description; everything else can be filled in later with update_design.",
+    method: "POST",
+    path: "/admin/designs",
+    write: true,
+    sensitive: true,
+    bodyParams: [
+      "name",
+      "description",
+      "design_type",
+      "status",
+      "priority",
+      "target_completion_date",
+      "tags",
+      "designer_notes",
+      "estimated_cost",
+      "cost_currency",
+      "colors",
+      "size_sets",
+      "metadata",
+    ],
+    inputSchema: obj(
+      {
+        name: STR("Design name (required)."),
+        // `description` is optional in the route's Zod validator but NOT NULL on
+        // the model, so omitting it 500s instead of 400ing. Require it here so
+        // the agent gets a usable schema error rather than an opaque failure.
+        description: STR("Design description (required — the column is NOT NULL)."),
+        design_type: STR("'Original' | 'Derivative' | 'Custom' | 'Collaboration'."),
+        status: STR(
+          "'Conceptual' | 'In_Development' | 'Technical_Review' | 'Sample_Production' | 'Revision' | 'Approved' | 'Rejected' | 'On_Hold' | 'Commerce_Ready' | 'Superseded'."
+        ),
+        priority: STR("'Low' | 'Medium' | 'High' | 'Urgent'."),
+        target_completion_date: STR("Target completion date (ISO string)."),
+        tags: { type: "array", items: { type: "string" }, description: "Free-form tags." },
+        designer_notes: STR("Notes for the designer."),
+        estimated_cost: { type: "number", description: "Estimated cost." },
+        cost_currency: STR("Currency code for estimated_cost."),
+        colors: {
+          type: "array",
+          description: "Colourway. Each: { name, hex_code, usage_notes?, order? }.",
+          items: obj(
+            { name: STR("Colour name."), hex_code: STR("Hex code, e.g. '#1A2B3C'.") },
+            ["name", "hex_code"]
+          ),
+        },
+        size_sets: {
+          type: "array",
+          description:
+            "Size sets — the source of truth for sizing. Each: { size_label, measurements: { <point>: number } }.",
+          items: obj(
+            {
+              size_label: STR("Size label, e.g. 'M'."),
+              measurements: {
+                type: "object",
+                description: "Measurement point -> numeric value.",
+              },
+            },
+            ["size_label", "measurements"]
+          ),
+        },
+        metadata: { type: "object", description: "Optional key/value metadata." },
+      },
+      ["name", "description"]
+    ),
+    nextSteps: ["get_design", "update_design", "link_design_partners"],
+  },
+  {
+    name: "update_design",
+    description:
+      "Update a design — status, priority, target date, tags, notes, colours and SIZE SETS (this route is the only way to set size_sets). Sensitive: requires confirm:true. Use dry_run to see the current design first.",
+    method: "PUT",
+    path: "/admin/designs/:id",
+    pathParams: ["id"],
+    previewPath: "/admin/designs/:id",
+    write: true,
+    sensitive: true,
+    bodyParams: [
+      "name",
+      "description",
+      "design_type",
+      "status",
+      "priority",
+      "target_completion_date",
+      "tags",
+      "designer_notes",
+      "estimated_cost",
+      "cost_currency",
+      "colors",
+      "size_sets",
+      "metadata",
+    ],
+    inputSchema: obj(
+      {
+        id: STR("Design id, e.g. 'design_...'."),
+        name: STR("New name."),
+        description: STR("New description."),
+        design_type: STR("'Original' | 'Derivative' | 'Custom' | 'Collaboration'."),
+        status: STR(
+          "'Conceptual' | 'In_Development' | 'Technical_Review' | 'Sample_Production' | 'Revision' | 'Approved' | 'Rejected' | 'On_Hold' | 'Commerce_Ready' | 'Superseded'."
+        ),
+        priority: STR("'Low' | 'Medium' | 'High' | 'Urgent'."),
+        target_completion_date: STR("New target completion date (ISO string)."),
+        tags: { type: "array", items: { type: "string" }, description: "Replacement tag list." },
+        designer_notes: STR("New designer notes."),
+        estimated_cost: { type: "number", description: "New estimated cost." },
+        cost_currency: STR("Currency code for estimated_cost."),
+        colors: {
+          type: "array",
+          description: "Replacement colourway. Each: { name, hex_code, usage_notes?, order? }.",
+          items: obj(
+            { name: STR("Colour name."), hex_code: STR("Hex code.") },
+            ["name", "hex_code"]
+          ),
+        },
+        size_sets: {
+          type: "array",
+          description:
+            "Replacement size sets. Each: { size_label, measurements: { <point>: number } }. This REPLACES the existing sets — send the full list.",
+          items: obj(
+            {
+              size_label: STR("Size label, e.g. 'M'."),
+              measurements: { type: "object", description: "Measurement point -> numeric value." },
+            },
+            ["size_label", "measurements"]
+          ),
+        },
+        metadata: { type: "object", description: "Metadata to merge." },
+      },
+      ["id"]
+    ),
+    sideEffects: "Setting status to 'Approved' here does NOT create a product — that is a separate approval action in the UI.",
+  },
+  {
+    name: "link_design_partners",
+    description:
+      "Link one or more partners to a design, making them eligible for its production runs. Sensitive: requires confirm:true.",
+    method: "POST",
+    path: "/admin/designs/:id/partner",
+    pathParams: ["id"],
+    write: true,
+    sensitive: true,
+    bodyParams: ["partnerIds"],
+    inputSchema: obj(
+      {
+        id: STR("Design id, e.g. 'design_...'."),
+        partnerIds: {
+          type: "array",
+          items: { type: "string" },
+          description: "Partner ids to link to the design (required).",
+        },
+      },
+      ["id", "partnerIds"]
+    ),
+    nextSteps: ["create_design_production_run"],
+  },
+  {
+    name: "unlink_design_partner",
+    description:
+      "Unlink a partner from a design. Refused while that partner still has active production runs on the design — use cancel_design_partner_assignment for that. Sensitive: requires confirm:true.",
+    method: "DELETE",
+    path: "/admin/designs/:id/partner",
+    pathParams: ["id"],
+    write: true,
+    bodyParams: ["partnerId"],
+    inputSchema: obj(
+      {
+        id: STR("Design id, e.g. 'design_...'."),
+        partnerId: STR("Partner id to unlink (required)."),
+      },
+      ["id", "partnerId"]
+    ),
+  },
+  {
+    name: "create_design_production_run",
+    description:
+      "Create a production run for a design and, when assignments are supplied, approve it and auto-dispatch the named task templates in one shot. Sensitive: requires confirm:true.",
+    method: "POST",
+    path: "/admin/designs/:id/production-runs",
+    pathParams: ["id"],
+    previewPath: "/admin/designs/:id",
+    write: true,
+    sensitive: true,
+    bodyParams: ["quantity", "run_type", "assignments"],
+    inputSchema: obj(
+      {
+        id: STR("Design id, e.g. 'design_...'."),
+        quantity: {
+          type: "number",
+          description:
+            "Total units. If both quantity and assignments are given, the assignment quantities MUST sum to this.",
+        },
+        run_type: STR("'production' (default) | 'sample'."),
+        assignments: {
+          type: "array",
+          description:
+            "Partner assignments. Each: { partner_id (required), quantity (required), role?, order?, template_names? }. Omit entirely to create an unassigned run.",
+          items: obj(
+            {
+              partner_id: STR("Partner to assign (required)."),
+              quantity: { type: "number", description: "Units for this partner (required)." },
+              role: STR("Role this partner plays."),
+              order: { type: "integer", description: "Dispatch sequence position." },
+              template_names: {
+                type: "array",
+                items: { type: "string" },
+                description: "Task templates to auto-dispatch for this partner.",
+              },
+            },
+            ["partner_id", "quantity"]
+          ),
+        },
+      },
+      ["id"]
+    ),
+    sideEffects: "With assignments, this also approves the run and fans out child runs — not just a draft.",
+    nextSteps: ["list_production_runs", "get_production_run"],
+  },
+  {
+    name: "produce_designs",
+    description:
+      "Send a batch of designs to one partner for production (no customer order involved): creates one run per design, collated into a single work-order. Sensitive: requires confirm:true.",
+    method: "POST",
+    path: "/admin/designs/produce",
+    write: true,
+    sensitive: true,
+    bodyParams: ["design_ids", "partner_id"],
+    inputSchema: obj(
+      {
+        design_ids: {
+          type: "array",
+          items: { type: "string" },
+          description: "Design ids to produce (required, non-empty).",
+        },
+        partner_id: STR("Partner to assign every created run to (required)."),
+      },
+      ["design_ids", "partner_id"]
+    ),
+    nextSteps: ["list_design_work_orders"],
+  },
+  {
+    name: "recreate_design_production_run",
+    description:
+      "Redo / rework: create a fresh production run for a set of designs with one partner, on top of whatever already exists. Sensitive: requires confirm:true. Use this after a run went wrong, not to make the first run.",
+    method: "POST",
+    path: "/admin/designs/recreate-production-run",
+    write: true,
+    sensitive: true,
+    bodyParams: ["designs", "partner_id", "run_type", "notes", "metadata"],
+    inputSchema: obj(
+      {
+        designs: {
+          type: "array",
+          description: "Designs to remake. Each: { design_id, quantity, notes? }.",
+          items: obj(
+            {
+              design_id: STR("Design id."),
+              quantity: { type: "number", description: "Units to remake." },
+            },
+            ["design_id", "quantity"]
+          ),
+        },
+        partner_id: STR("Partner to assign the rework to (required)."),
+        run_type: STR("'production' (default) | 'sample'."),
+        notes: STR("Why this rework is happening."),
+        metadata: { type: "object", description: "Optional key/value metadata." },
+      },
+      ["designs", "partner_id"]
+    ),
+    sideEffects: "Adds NEW runs — it does not cancel or replace the original ones. Cancel those separately if they are dead.",
+  },
+  {
+    name: "cancel_design_partner_assignment",
+    description:
+      "Back out a partner from a design: cancels that partner's production runs and open tasks on it, and optionally unlinks them. This is the safe reversal for create_design_production_run / produce_designs. Sensitive: requires confirm:true.",
+    method: "POST",
+    path: "/admin/designs/:id/cancel-partner-assignment",
+    pathParams: ["id"],
+    previewPath: "/admin/designs/:id",
+    write: true,
+    sensitive: true,
+    bodyParams: ["partner_id", "unlink"],
+    inputSchema: obj(
+      {
+        id: STR("Design id, e.g. 'design_...'."),
+        partner_id: STR("Partner whose assignment is being cancelled (required)."),
+        unlink: {
+          type: "boolean",
+          description: "Also unlink the partner from the design (default false).",
+        },
+      },
+      ["id", "partner_id"]
+    ),
+    sideEffects: "Cancels the partner's runs and open tasks on this design. Cancelled runs are terminal.",
+  },
+  {
+    name: "update_design_task",
+    description:
+      "Update a task on a design (title, description, status, priority, dates). Sensitive: requires confirm:true. Use dry_run to see the current task first.",
+    method: "POST",
+    path: "/admin/designs/:id/tasks/:taskId",
+    pathParams: ["id", "taskId"],
+    previewPath: "/admin/designs/:id/tasks/:taskId",
+    write: true,
+    sensitive: true,
+    bodyParams: [
+      "title",
+      "description",
+      "status",
+      "priority",
+      "start_date",
+      "end_date",
+      "metadata",
+    ],
+    inputSchema: obj(
+      {
+        id: STR("Design id, e.g. 'design_...'."),
+        taskId: STR("Task id, e.g. 'task_...'."),
+        title: STR("New title."),
+        description: STR("New description."),
+        status: STR(
+          "New status — one of exactly: 'pending' | 'in_progress' | 'completed' | 'cancelled' | 'accepted'."
+        ),
+        priority: STR("New priority — one of exactly: 'low' | 'medium' | 'high'."),
+        start_date: STR("New start date (ISO string)."),
+        end_date: STR("New due date (ISO string)."),
+        metadata: { type: "object", description: "Metadata to merge." },
+      },
+      ["id", "taskId"]
+    ),
+  },
+  {
+    name: "assign_design_task",
+    description:
+      "Assign a design's task to a partner and notify them. Sensitive: requires confirm:true.",
+    method: "POST",
+    path: "/admin/designs/:id/tasks/:taskId/assign",
+    pathParams: ["id", "taskId"],
+    write: true,
+    sensitive: true,
+    bodyParams: ["taskId", "partnerId"],
+    inputSchema: obj(
+      {
+        id: STR("Design id, e.g. 'design_...'."),
+        taskId: STR("Task id to assign, e.g. 'task_...'."),
+        partnerId: STR("Partner id to assign the task to (required)."),
+      },
+      ["id", "taskId", "partnerId"]
+    ),
+    sideEffects: "Links the task to the partner and notifies them.",
   },
 
   // ===== Tier 2: the first dangerous action ==============================


### PR DESCRIPTION
## Summary

Closes the three follow-ups filed off #843 / PR #1169 by wrapping the remaining operational domains as chat/MCP tools — same declarative one-row-per-route loopback-proxy pattern as the partner-ops tiers, so every tool inherits its route's auth, validators and workflow logic.

**#1165 — orders** (4 reads + 10 writes + a 6-tool order-edit loop)
Fulfillment (create / mark shipped / mark delivered / cancel), order cancel + complete, the carrier label + attach-AWB recovery path, design produce, and the staged order-edit flow (`create → add/update items → request → confirm`). Nothing touches a placed order until `confirm_order_edit`, which is why only that last step is `dangerous`.

**#1167 — production-runs** (5 reads + 9 writes)
The full admin lifecycle: `create → approve` (this is where partners are assigned, not on create) `→ send-to-production` **or** `start/resume-dispatch → cancel`, plus run / task / cost-summary / activity reads and the transition policy. `start_production_run_dispatch` parks the workflow, so its description spells out that `resume_production_run_dispatch` is mandatory or the run stays stuck in `awaiting_templates`.

**#1166 — designs** (5 reads + 10 writes)
Core CRUD (the only route that can set `size_sets`), the collated work-order read, the produce / recreate / cancel-assignment triangle, partner linking and task state. The AI-generation, segmentation, outline and moodboard routes are deliberately **not** wrapped — they cost money per call, need an uploaded image, or return SVG/Excalidraw payloads that would blow the chat context. There's a test asserting they stay unwrapped so nobody adds them by reflex.

Irreversible actions (`cancel_order`, `cancel_order_fulfillment`, `confirm_order_edit`, `cancel_production_run`) are `dangerous`: confirm + a human reason, hidden and refused unless `ADMIN_MCP_ENABLE_DANGEROUS` is on. `cancel_production_run` reuses the audited reason as the persisted cancellation reason.

## Two pre-existing route bugs, worked around at the tool layer

- **`GET /admin/production-runs` has no free-text `q`**, but `list_production_runs` declared one — so the model's search term was being silently dropped on every call. Replaced with the filters the route actually supports (`status`, `partner_id`, `design_id`, `product_id`, `order_id`, `parent_run_id`, `run_type`, `include_tasks`).
- **`POST /admin/designs` makes `description` optional in Zod but the column is `NOT NULL`**, so a name-only create returns 500 rather than 400. `create_design` requires it so the agent gets a usable schema error instead of an opaque failure. The route itself still has the bug.

Also added `kind` to `list_orders` — the route defaults to retail-only, so without it the assistant simply could not see design or inventory orders.

## Follow-up, in its own PR

This takes the registry to 99 tools, which the chat route binds into every turn (~28.4k tokens/request). **Per-ask slicing that cuts that by a mean of 72% is stacked on this branch** — see the follow-up PR. Kept separate because it's a behaviour change to the assistant rather than more tool coverage.

## Test plan

- [x] `TEST_TYPE=unit jest --testPathPattern="api/admin/mcp/lib/__tests__/dispatch.unit.spec"` — **52/52** (was 28)
- [x] `pnpm test:integration:http:shared ./integration-tests/http/admin-mcp` — **24/24** (was 14), 3 suites
- [x] `pnpm run check:prod-build` — passes
- [x] `tsc --noEmit` clean on the touched files

New integration spec (`admin-mcp-ops-domains.spec.ts`) runs the design → production pipeline end-to-end for real (create design → produce → read back runs → work-orders), round-trips a production run, verifies `dry_run` shows the current object without mutating, and asserts dangerous tools are absent from `tools/list` and refused at dispatch when the env flag is off. Order fulfillment/label tools are asserted at the rail level rather than executed — they need a paid, stock-backed order and a live carrier API.

Five registry-wide invariant tests were added that cover the **older** tiers too: every declared path param appears in its path, every `previewPath` param is declared on the tool, every path/query/body param is described in the input schema, every `nextSteps` hint points at a tool that exists, and every write tool is non-GET and guarded.

🤖 Generated with [Claude Code](https://claude.com/claude-code)