### PR TITLE
perf(admin-mcp): slice the tool registry per ask instead of binding all of it [#1168]

### DIFF
--- a/apps/backend/src/api/admin/assistant/chat/route.ts
+++ b/apps/backend/src/api/admin/assistant/chat/route.ts
@@ -32,6 +32,12 @@ import { dynamicFreeToolTextModel } from "../../../../mastra/providers/dynamic-t
 import { foldSystemForProvider } from "../../../store/ai/chat/system-fold-lib"
 import { ADMIN_MCP_TOOLS, renderToolGuidance } from "../../mcp/lib/registry"
 import {
+  selectAdminToolSlice,
+  toolsInDomains,
+  toolDomain,
+  SELECTABLE_DOMAINS,
+} from "../../mcp/lib/tool-slice"
+import {
   dispatchAdminTool,
   buildToolInputSchema,
   isSensitive,
@@ -55,6 +61,9 @@ const SYSTEM_PROMPT = `You are the JYT admin assistant. You help platform operat
 - ALWAYS call \`get_admin_stats\` first to ground yourself in the platform's current shape before answering operational questions.
 - Use the read tools (list_orders, list_products, list_customers, list_partners, list_designs, list_production_runs, list_inventory_items, list_payments, ...) to answer "what's happening" questions. Fetch a single record with the get_* tools when you have an id.
 - Prefer doing (calling a tool) over describing. Chain tools to complete a goal, and set each tool's \`context\` to what you're ultimately trying to accomplish.
+
+## Your tools are loaded on demand
+You are given the tools for the domains this conversation appears to be about, not the full admin surface. If the tool you need is not in your list, DO NOT tell the user it is impossible or improvise with a different tool — call \`load_admin_tools\` with the relevant domains (orders, catalog, customers, partners, designs, production, inventory, money, marketing, observability) and the tools become callable on your next step. Loading a domain you turn out not to need is harmless.
 
 ## Safety rails (important)
 - Every tool accepts \`dry_run: true\`. Use it to PREVIEW a change and inspect the current object before you actually write.
@@ -102,12 +111,13 @@ export const POST = async (
   // Bind the registry as AI-SDK tools. One source of truth (JSON Schema) feeds
   // both this binding and the MCP endpoint's tools/list. Disabled tiers are
   // hidden from the model entirely (and refused at dispatch as a backstop).
-  const tools = Object.fromEntries(
-    ADMIN_MCP_TOOLS.filter(
-      (def) =>
-        (writeEnabled || !def.write) &&
-        (dangerousEnabled || !isDangerous(def))
-    ).map((def) => [
+  const enabled = ADMIN_MCP_TOOLS.filter(
+    (def) =>
+      (writeEnabled || !def.write) && (dangerousEnabled || !isDangerous(def))
+  )
+
+  const tools: Record<string, any> = Object.fromEntries(
+    enabled.map((def) => [
       def.name,
       tool({
         description:
@@ -142,6 +152,69 @@ export const POST = async (
     }
   })
 
+  // ---- Per-ask registry slicing -------------------------------------------
+  // All ~100 tools stay BOUND (so any of them can still execute), but only the
+  // slice this ask needs is serialised to the provider via `activeTools`.
+  // Without this every turn re-sends the whole registry, which is both the
+  // dominant token cost of a conversation and — because the free rotator ranks
+  // by context length — a lever on which model answers.
+  //
+  // `activated` is the live slice. It starts from keyword matching on the recent
+  // conversation and can only ever GROW, via load_admin_tools below, so a bad
+  // initial guess costs one round trip rather than a capability.
+  const recentText = messages
+    .slice(-6)
+    .map((m: any) => m.parts.map((p: any) => p.text).join(" "))
+    .join("\n")
+
+  const initialSlice = selectAdminToolSlice(recentText, enabled)
+  const activated = new Set<string>(initialSlice.names)
+
+  logger.debug?.(
+    `[${FEATURE}] tool slice: ${activated.size}/${enabled.length} tools` +
+      ` (domains: ${initialSlice.domains.join(", ") || "none matched"})`
+  )
+
+  // The escape hatch. Always active, so the model is never boxed in by a slice
+  // that guessed wrong — it names the domains it needs and they light up on the
+  // next step. This is also why the slice can be aggressive.
+  tools.load_admin_tools = tool({
+    description:
+      "Load the tools for one or more admin domains when the tool you need is not currently available to you. " +
+      `Valid domains: ${SELECTABLE_DOMAINS.join(", ")}. ` +
+      "Returns the names and descriptions of the tools that just became callable — call them on your next step. " +
+      "Use this instead of telling the user something is impossible.",
+    inputSchema: jsonSchema({
+      type: "object",
+      properties: {
+        domains: {
+          type: "array",
+          items: { type: "string", enum: SELECTABLE_DOMAINS },
+          description: "The admin domains to load tools for.",
+        },
+      },
+      required: ["domains"],
+      additionalProperties: false,
+    }),
+    execute: async ({ domains }: { domains: string[] }) => {
+      const names = toolsInDomains(domains ?? [], enabled)
+      names.forEach((n) => activated.add(n))
+      return {
+        ok: true,
+        loaded: names.length,
+        domains: domains ?? [],
+        tools: enabled
+          .filter((d) => names.includes(d.name))
+          .map((d) => ({
+            name: d.name,
+            domain: toolDomain(d),
+            description: d.description,
+          })),
+      }
+    },
+  })
+  activated.add("load_admin_tools")
+
   // This assistant REQUIRES tool calling. The free rotator ranks by context
   // length and can land on a text-only model, so on the free path use the
   // tool-capable variant. A DB-configured platform for this role overrides this.
@@ -169,6 +242,9 @@ export const POST = async (
         ...(folded.system ? { system: folded.system } : {}),
         messages: convertToModelMessages(folded.messages as any),
         tools,
+        // Re-read `activated` before every step so tools loaded via
+        // load_admin_tools become callable on the very next one.
+        prepareStep: () => ({ activeTools: [...activated] }),
         stopWhen: stepCountIs(8),
         temperature: 0.3,
         maxRetries: 3,

--- a/apps/backend/src/api/admin/mcp/lib/__tests__/tool-slice.unit.spec.ts
+++ b/apps/backend/src/api/admin/mcp/lib/__tests__/tool-slice.unit.spec.ts
@@ -1,0 +1,180 @@
+import {
+  selectAdminToolSlice,
+  matchDomains,
+  toolDomain,
+  toolsInDomains,
+  ALWAYS_ON_TOOLS,
+  SELECTABLE_DOMAINS,
+} from "../tool-slice"
+import { ADMIN_MCP_TOOLS } from "../registry"
+import { buildToolInputSchema } from "../dispatch"
+
+/** Rough token proxy — what actually gets serialised per tool definition. */
+const weigh = (names: string[]) => {
+  const byName = new Map(ADMIN_MCP_TOOLS.map((t) => [t.name, t]))
+  const defs = names
+    .map((n) => byName.get(n))
+    .filter(Boolean)
+    .map((d: any) => ({
+      name: d.name,
+      description: d.description,
+      schema: buildToolInputSchema(d),
+    }))
+  return Math.round(JSON.stringify(defs).length / 4)
+}
+
+describe("admin-mcp per-ask tool slicing", () => {
+  describe("domain classification", () => {
+    it("classifies EVERY registry tool — an unclassified tool would be unreachable", () => {
+      const orphans = ADMIN_MCP_TOOLS.filter((t) => !toolDomain(t)).map(
+        (t) => `${t.name} (${t.path})`
+      )
+      expect(orphans).toEqual([])
+    })
+
+    it("resolves the longest matching prefix, not the first", () => {
+      // /admin/production-run-policy must not be swallowed by a shorter prefix,
+      // and /admin/mcp/usage must land on observability rather than core.
+      expect(
+        toolDomain(ADMIN_MCP_TOOLS.find((t) => t.name === "get_production_run_policy")!)
+      ).toBe("production")
+      expect(
+        toolDomain(ADMIN_MCP_TOOLS.find((t) => t.name === "get_mcp_usage")!)
+      ).toBe("observability")
+      expect(
+        toolDomain(ADMIN_MCP_TOOLS.find((t) => t.name === "get_admin_stats")!)
+      ).toBe("core")
+    })
+
+    it("groups sibling route families under one domain", () => {
+      const domainOf = (name: string) =>
+        toolDomain(ADMIN_MCP_TOOLS.find((t) => t.name === name)!)
+      // order-edits belong with orders, design-work-orders with designs.
+      expect(domainOf("create_order_edit")).toBe("orders")
+      expect(domainOf("list_order_changes")).toBe("orders")
+      expect(domainOf("list_design_work_orders")).toBe("designs")
+      expect(domainOf("update_production_run_policy")).toBe("production")
+      // The artisan product tools live under /admin/partners, so they are
+      // partner tools even though they act on a product.
+      expect(domainOf("approve_partner_product")).toBe("partners")
+    })
+
+    it("every selectable domain actually owns tools", () => {
+      for (const domain of SELECTABLE_DOMAINS) {
+        expect({
+          domain,
+          count: toolsInDomains([domain], ADMIN_MCP_TOOLS).length,
+        }).toEqual({ domain, count: expect.any(Number) })
+        expect(toolsInDomains([domain], ADMIN_MCP_TOOLS).length).toBeGreaterThan(0)
+      }
+    })
+  })
+
+  describe("keyword matching", () => {
+    it("matches the domain an operator is obviously asking about", () => {
+      expect(matchDomains("ship order 123 and mark it delivered")).toContain("orders")
+      expect(matchDomains("which production runs are still open?")).toContain(
+        "production"
+      )
+      expect(matchDomains("set the size sets on this design")).toContain("designs")
+      expect(matchDomains("onboard a new manufacturer partner")).toContain("partners")
+      expect(matchDomains("how much raw material fabric is in stock")).toContain(
+        "inventory"
+      )
+    })
+
+    it("matches on word boundaries, not substrings", () => {
+      // "reorder" must not light up inventory via a bare "order" substring...
+      expect(matchDomains("reordering the dashboard widgets")).not.toContain("orders")
+      // ...but the real word still matches.
+      expect(matchDomains("cancel this order")).toContain("orders")
+    })
+
+    it("returns nothing for an ask with no operational vocabulary", () => {
+      expect(matchDomains("hi, what can you do?")).toEqual([])
+    })
+  })
+
+  describe("slice selection", () => {
+    it("always includes grounding + the top-level list reads, whatever the ask", () => {
+      const slice = selectAdminToolSlice("hi", ADMIN_MCP_TOOLS)
+      for (const name of ALWAYS_ON_TOOLS) {
+        expect(slice.names).toContain(name)
+      }
+      expect(slice.domains).toEqual([])
+    })
+
+    it("a focused ask yields a small slice, not the whole registry", () => {
+      const slice = selectAdminToolSlice(
+        "cancel the fulfillment on order_123 and refund it",
+        ADMIN_MCP_TOOLS
+      )
+      expect(slice.domains).toContain("orders")
+      expect(slice.names).toContain("cancel_order_fulfillment")
+      expect(slice.names).toContain("create_order_fulfillment")
+      // Unrelated domains stay out.
+      expect(slice.names).not.toContain("approve_production_run")
+      expect(slice.names).not.toContain("create_partner")
+      expect(slice.names.length).toBeLessThan(ADMIN_MCP_TOOLS.length / 2)
+    })
+
+    it("a multi-domain ask pulls in every domain it mentions", () => {
+      const slice = selectAdminToolSlice(
+        "approve the production run for this design and assign the partner",
+        ADMIN_MCP_TOOLS
+      )
+      expect(slice.domains).toEqual(
+        expect.arrayContaining(["production", "designs", "partners"])
+      )
+      expect(slice.names).toContain("approve_production_run")
+      expect(slice.names).toContain("create_design_production_run")
+      expect(slice.names).toContain("get_partner")
+    })
+
+    it("never re-admits a tool the write/dangerous gates removed", () => {
+      const readsOnly = ADMIN_MCP_TOOLS.filter((t) => !t.write)
+      const slice = selectAdminToolSlice(
+        "cancel order 123 and delete the partner",
+        readsOnly
+      )
+      expect(slice.names).not.toContain("cancel_order")
+      expect(slice.names).not.toContain("delete_partner")
+      // Everything it did pick is genuinely available.
+      const available = new Set(readsOnly.map((t) => t.name))
+      for (const n of slice.names) expect(available.has(n)).toBe(true)
+    })
+
+    it("cuts the serialised tool payload substantially for a focused ask", () => {
+      const full = weigh(ADMIN_MCP_TOOLS.map((t) => t.name))
+      const sliced = weigh(
+        selectAdminToolSlice("ship order_123 today", ADMIN_MCP_TOOLS).names
+      )
+      expect(sliced).toBeLessThan(full / 2)
+    })
+  })
+
+  describe("widening (the escape hatch)", () => {
+    it("toolsInDomains returns exactly that domain's tools", () => {
+      const names = toolsInDomains(["money"], ADMIN_MCP_TOOLS)
+      expect(names).toContain("list_payments")
+      expect(names).not.toContain("list_orders")
+    })
+
+    it("widening a slice can reach any tool the gates left enabled", () => {
+      const slice = selectAdminToolSlice("hi", ADMIN_MCP_TOOLS)
+      const activated = new Set(slice.names)
+      for (const domain of SELECTABLE_DOMAINS) {
+        toolsInDomains([domain], ADMIN_MCP_TOOLS).forEach((n) => activated.add(n))
+      }
+      // Core is always on, and every other domain is reachable on request, so
+      // the union must cover the whole registry — nothing is orphaned.
+      for (const def of ADMIN_MCP_TOOLS) {
+        expect(`${def.name}:${activated.has(def.name)}`).toBe(`${def.name}:true`)
+      }
+    })
+
+    it("ignores unknown domain names rather than throwing", () => {
+      expect(toolsInDomains(["not_a_domain"], ADMIN_MCP_TOOLS)).toEqual([])
+    })
+  })
+})

--- a/apps/backend/src/api/admin/mcp/lib/tool-slice.ts
+++ b/apps/backend/src/api/admin/mcp/lib/tool-slice.ts
@@ -1,0 +1,221 @@
+/**
+ * Per-ask registry slicing for the admin assistant.
+ *
+ * The registry is ~100 tools. The MCP JSON-RPC endpoint can afford to advertise
+ * all of them (external clients enumerate once and manage their own context),
+ * but the in-app assistant re-sends every bound tool definition on EVERY turn —
+ * so registry size becomes a per-request token cost, and the free-model rotator
+ * ranks by context length, which means it also influences which model answers.
+ *
+ * This module maps each tool to a domain and picks the domains an ask actually
+ * needs. The chat route binds the full registry (so every tool stays callable)
+ * but passes only the slice as `activeTools`, so only those definitions are
+ * serialised to the provider.
+ *
+ * Nothing here can make a tool permanently unreachable: the always-on core
+ * includes a discovery tool, and the chat route widens the slice mid-run when
+ * the model asks for a domain it wasn't given. Getting the slice wrong costs a
+ * round trip, not a capability.
+ */
+import type { McpToolDef } from "../../../../lib/mcp-core"
+
+export type AdminToolDomain =
+  | "core"
+  | "orders"
+  | "catalog"
+  | "customers"
+  | "partners"
+  | "designs"
+  | "production"
+  | "inventory"
+  | "money"
+  | "marketing"
+  | "observability"
+
+/**
+ * Route prefix -> domain. Longest prefix wins, so `/admin/production-run-policy`
+ * resolves before `/admin/production-runs` would otherwise shadow it. A new
+ * registry row under an existing prefix is classified automatically; a genuinely
+ * new route family needs one line here (and the invariant test below fails loudly
+ * until it gets one).
+ */
+const PREFIX_DOMAINS: ReadonlyArray<readonly [string, AdminToolDomain]> = [
+  ["/admin/mcp/usage", "observability"],
+  ["/admin/mcp", "core"],
+  ["/admin/orders", "orders"],
+  ["/admin/order-edits", "orders"],
+  ["/admin/products", "catalog"],
+  ["/admin/stores", "catalog"],
+  ["/admin/customers", "customers"],
+  ["/admin/partners", "partners"],
+  ["/admin/designs", "designs"],
+  ["/admin/design-work-orders", "designs"],
+  ["/admin/production-run-policy", "production"],
+  ["/admin/production-runs", "production"],
+  ["/admin/inventory-items", "inventory"],
+  ["/admin/inventory-orders", "inventory"],
+  ["/admin/payments", "money"],
+  ["/admin/publishing-campaigns", "marketing"],
+  ["/admin/notifications", "marketing"],
+]
+
+/** Classify one tool by the route it wraps. */
+export function toolDomain(def: McpToolDef): AdminToolDomain | undefined {
+  const path = def.path
+  if (!path) return "core" // native tools are grounding/discovery
+  let best: { len: number; domain: AdminToolDomain } | undefined
+  for (const [prefix, domain] of PREFIX_DOMAINS) {
+    if (
+      (path === prefix || path.startsWith(`${prefix}/`)) &&
+      (!best || prefix.length > best.len)
+    ) {
+      best = { len: prefix.length, domain }
+    }
+  }
+  return best?.domain
+}
+
+/**
+ * Trigger words per domain, matched case-insensitively on word boundaries
+ * against the recent conversation text. Deliberately generous — a false
+ * positive costs a few hundred tokens, a false negative costs a round trip.
+ */
+const DOMAIN_KEYWORDS: Record<Exclude<AdminToolDomain, "core">, string[]> = {
+  orders: [
+    "order", "orders", "fulfil", "fulfill", "fulfilment", "fulfillment",
+    "ship", "shipped", "shipping", "shipment", "deliver", "delivered",
+    "delivery", "courier", "awb", "waybill", "label", "tracking", "cancel",
+    "refund", "return", "line item", "line items", "checkout", "purchase",
+  ],
+  catalog: [
+    "product", "products", "variant", "variants", "sku", "catalog",
+    "catalogue", "publish", "published", "draft", "store", "stores",
+    "storefront", "listing", "listings", "price", "pricing",
+  ],
+  customers: ["customer", "customers", "buyer", "buyers", "shopper", "shoppers"],
+  partners: [
+    "partner", "partners", "seller", "sellers", "manufacturer", "manufacturers",
+    "maker", "makers", "artisan", "artisans", "weaver", "weavers", "vendor",
+    "vendors", "onboard", "onboarding", "whatsapp", "subscription", "plan",
+    "commission", "fee", "fees", "admin user", "verify", "verification",
+  ],
+  designs: [
+    "design", "designs", "designer", "moodboard", "tech pack", "techpack",
+    "size set", "size sets", "sizing", "measurement", "measurements",
+    "colourway", "colorway", "revision", "revisions", "bom",
+    "bill of materials", "work order", "work orders", "sample", "collection",
+  ],
+  production: [
+    "production", "production run", "production runs", "run", "runs",
+    "dispatch", "dispatched", "approve", "approval", "stage", "task", "tasks",
+    "template", "templates", "manufacture", "manufacturing", "factory",
+    "capacity", "wip", "in progress",
+  ],
+  inventory: [
+    "inventory", "stock", "stocks", "raw material", "raw materials",
+    "material", "materials", "fabric", "yarn", "warehouse", "location",
+    "restock", "reorder", "purchase order",
+  ],
+  money: [
+    "payment", "payments", "payout", "payouts", "invoice", "invoices",
+    "revenue", "settle", "settlement", "money", "paid", "unpaid", "balance",
+  ],
+  marketing: [
+    "campaign", "campaigns", "newsletter", "email", "emails", "notification",
+    "notifications", "marketing", "publish campaign", "blog", "subscriber",
+    "subscribers",
+  ],
+  observability: [
+    "mcp", "tool usage", "telemetry", "observability", "ledger", "audit",
+    "failing", "failures", "error rate",
+  ],
+}
+
+/**
+ * Always sent, regardless of the ask: grounding, the query planner, and the
+ * cheap top-level list read for each domain. Those seven list_* tools are what
+ * let an unclassifiable ask ("what's going on today?") still get somewhere, and
+ * they give the model the vocabulary to widen the slice deliberately.
+ */
+export const ALWAYS_ON_TOOLS: readonly string[] = [
+  "get_admin_stats",
+  "resolve_admin_query",
+  "list_orders",
+  "list_products",
+  "list_customers",
+  "list_partners",
+  "list_designs",
+  "list_production_runs",
+  "list_stores",
+]
+
+export type ToolSlice = {
+  /** Tool names to expose on this turn. */
+  names: string[]
+  /** Domains the ask matched (excludes the always-on core). */
+  domains: AdminToolDomain[]
+}
+
+const escapeRe = (s: string) => s.replace(/[.*+?^${}()|[\]\\]/g, "\\$&")
+
+/** Domains whose trigger words appear in the given text. */
+export function matchDomains(text: string): AdminToolDomain[] {
+  const haystack = text.toLowerCase()
+  const hits: AdminToolDomain[] = []
+  for (const [domain, keywords] of Object.entries(DOMAIN_KEYWORDS)) {
+    const hit = keywords.some((kw) =>
+      new RegExp(`\\b${escapeRe(kw)}\\b`).test(haystack)
+    )
+    if (hit) hits.push(domain as AdminToolDomain)
+  }
+  return hits
+}
+
+/**
+ * Pick the tools to expose for one ask.
+ *
+ * `tools` should already be filtered by the write/dangerous env gates — this
+ * only narrows further, it never re-admits a tool the surface disabled.
+ */
+export function selectAdminToolSlice(
+  text: string,
+  tools: McpToolDef[]
+): ToolSlice {
+  const available = new Set(tools.map((t) => t.name))
+  const domains = matchDomains(text)
+  const wanted = new Set<AdminToolDomain>([...domains, "core"])
+
+  const names = new Set<string>()
+  for (const name of ALWAYS_ON_TOOLS) {
+    if (available.has(name)) names.add(name)
+  }
+  for (const def of tools) {
+    const domain = toolDomain(def)
+    if (domain && wanted.has(domain)) names.add(def.name)
+  }
+
+  return { names: [...names], domains }
+}
+
+/** Every tool in a domain (used to widen the slice on request). */
+export function toolsInDomains(
+  domains: string[],
+  tools: McpToolDef[]
+): string[] {
+  const wanted = new Set(domains)
+  return tools.filter((t) => wanted.has(toolDomain(t) ?? "")).map((t) => t.name)
+}
+
+/** The domains an operator can ask to be widened into. */
+export const SELECTABLE_DOMAINS: AdminToolDomain[] = [
+  "orders",
+  "catalog",
+  "customers",
+  "partners",
+  "designs",
+  "production",
+  "inventory",
+  "money",
+  "marketing",
+  "observability",
+]


### PR DESCRIPTION
> **Stacked on #1170** (base is `feat/admin-mcp-ops-domains-round-3`, not `main`). Merge #1170 first, then retarget this to `main` **before** deleting that branch — otherwise this PR auto-closes and its branch conflicts with the squashed base.

## The problem

The assistant chat route binds **every** tool in `ADMIN_MCP_TOOLS` into **every** turn. With #1170 taking the registry to 99 tools that measures **28,413 tokens per request** — and because the free rotator ranks candidate models by context length, it was also a lever on *which model answered the question*.

## The approach

Tools are classified into domains by **longest-matching route prefix**, so sibling families group correctly (`/admin/order-edits` → orders, `/admin/design-work-orders` → designs, `/admin/production-run-policy` → production rather than being shadowed) and a new registry row under an existing prefix classifies itself with no extra work. Keyword matching over the last 6 messages picks the domains an ask needs.

The whole registry stays **bound** — only the slice is serialised to the provider via the AI SDK's `activeTools`. So nothing becomes uncallable; it just isn't advertised.

The escape hatch is what makes an aggressive slice safe: an always-on `load_admin_tools(domains)` tool, with `prepareStep` re-reading the live set before every step so anything it loads is callable on the very next one. **The slice only ever grows** — a wrong guess costs one round trip, never a capability. The system prompt tells the model to reach for it rather than claim something is impossible.

## Measured

Real serialised tool payload, not an estimate:

| Ask | Tools | Tokens | Δ |
|---|---|---|---|
| _full registry (before)_ | 99 | 28,413 | — |
| "hi, what can you do?" | 9 | 2,140 | −92% |
| "what happened on the platform today?" | 9 | 2,140 | −92% |
| "ship order_123 and mark it delivered" | 30 | 8,378 | −71% |
| "which production runs are still open?" | 23 | 6,410 | −77% |
| "how much fabric is in stock" | 11 | 2,572 | −91% |
| "set the size sets on this design then send it to production" | 39 | 11,651 | −59% |
| "approve the run for this design and assign the partner" | 67 | 19,394 | −32% |

Mean **−72%**. Worst case is a genuine three-domain ask, which still saves a third.

The 9 always-on tools are grounding (`get_admin_stats`), the query planner (`resolve_admin_query`), and the seven top-level `list_*` reads — enough that an unclassifiable ask still orients itself without loading anything.

## Deliberately NOT applied to the MCP JSON-RPC endpoint

`/admin/mcp` keeps advertising the full registry. External clients (Claude Desktop et al.) enumerate tools once and manage their own context, so slicing there would break them for no benefit. The cost problem is specific to the in-app assistant, which re-sends everything each turn.

## Adding a domain later

Needs **both** a `PREFIX_DOMAINS` line and `DOMAIN_KEYWORDS` triggers, or the domain is only reachable via an explicit `load_admin_tools` call. The classification test fails if you forget the first.

## Test plan

- [x] `TEST_TYPE=unit jest --testPathPattern="api/admin/mcp/lib/__tests__"` — **67/67** (+15 here)
- [x] `pnpm test:integration:http:shared ./integration-tests/http/admin-mcp` — **24/24**, unchanged (confirms no regression)
- [x] `pnpm run check:prod-build` — passes
- [x] `tsc --noEmit` clean on the touched files

The new tests cover longest-prefix resolution, word-boundary matching (`"reordering the dashboard"` must **not** trigger the orders domain), that slicing never re-admits a tool the write/dangerous gates removed, that **every** registry tool is classifiable (an unclassified tool would be unreachable), and that widening across all domains reaches **every** tool — so nothing can be orphaned.

🤖 Generated with [Claude Code](https://claude.com/claude-code)