### PR TITLE
feat(admin): partner inspection mirror — read-proxy orders + onboarding profile [#843]

### DIFF
--- a/apps/backend/integration-tests/http/admin-partner-inspection.spec.ts
+++ b/apps/backend/integration-tests/http/admin-partner-inspection.spec.ts
@@ -1,0 +1,185 @@
+/**
+ * #843 (approach #2) — the admin → partner read-proxy.
+ *
+ * These routes read a partner's internals through the partner portal's OWN
+ * scoping helpers, driven by a synthesized `{ actor_id: partnerId }` context.
+ * The contract worth pinning is exactly that: admin sees what the partner sees,
+ * without a partner login, and cannot write through it.
+ */
+import { getSharedTestEnv, setupSharedTestSuite } from "./shared-test-setup"
+import { createAdminUser, getAuthHeaders } from "../helpers/create-admin-user"
+
+const TEST_PARTNER_PASSWORD = "supersecret"
+
+jest.setTimeout(90 * 1000)
+
+async function createPartner(api: any) {
+  const unique = Date.now() + Math.random().toString(36).slice(2, 6)
+  const email = `partner-inspect-${unique}@medusa-test.com`
+
+  await api.post("/auth/partner/emailpass/register", {
+    email,
+    password: TEST_PARTNER_PASSWORD,
+  })
+  const login1 = await api.post("/auth/partner/emailpass", {
+    email,
+    password: TEST_PARTNER_PASSWORD,
+  })
+  let headers: Record<string, string> = {
+    Authorization: `Bearer ${login1.data.token}`,
+  }
+
+  const partnerRes = await api.post(
+    "/partners",
+    {
+      name: `InspectTest ${unique}`,
+      handle: `inspecttest-${unique}`,
+      admin: { email, first_name: "Admin", last_name: "Inspect" },
+    },
+    { headers }
+  )
+  const partnerId = partnerRes.data.partner.id
+
+  // Re-login so the bearer token carries partner actor context.
+  const login2 = await api.post("/auth/partner/emailpass", {
+    email,
+    password: TEST_PARTNER_PASSWORD,
+  })
+  headers = { Authorization: `Bearer ${login2.data.token}` }
+
+  return { headers, partnerId }
+}
+
+setupSharedTestSuite(() => {
+  const { api, getContainer } = getSharedTestEnv()
+
+  describe("Admin partner inspection read-proxy (#843)", () => {
+    let adminHeaders: any
+    let partner: Awaited<ReturnType<typeof createPartner>>
+
+    beforeEach(async () => {
+      const container = getContainer()
+      await createAdminUser(container)
+      adminHeaders = await getAuthHeaders(api)
+      partner = await createPartner(api)
+    })
+
+    describe("GET /admin/partners/:id/orders", () => {
+      it("returns the partner's order list without a partner login", async () => {
+        const res = await api.get(
+          `/admin/partners/${partner.partnerId}/orders`,
+          adminHeaders
+        )
+
+        expect(res.status).toBe(200)
+        expect(Array.isArray(res.data.orders)).toBe(true)
+        expect(res.data).toHaveProperty("count")
+        expect(res.data).toHaveProperty("offset")
+        expect(res.data).toHaveProperty("limit")
+      })
+
+      it("mirrors GET /partners/orders for the same partner and kind", async () => {
+        // The whole point of the read-proxy: identical payload shape from the
+        // two surfaces. If these ever diverge, the mirror has drifted and the
+        // console is lying about what the partner sees.
+        for (const kind of ["retail", "design", "inventory", "all"]) {
+          const viaAdmin = await api.get(
+            `/admin/partners/${partner.partnerId}/orders?kind=${kind}`,
+            adminHeaders
+          )
+          const viaPartner = await api.get(`/partners/orders?kind=${kind}`, {
+            headers: partner.headers,
+          })
+
+          expect(viaAdmin.status).toBe(200)
+          expect(viaPartner.status).toBe(200)
+          expect(viaAdmin.data.count).toBe(viaPartner.data.count)
+          expect(viaAdmin.data.orders.map((o: any) => o.id)).toEqual(
+            viaPartner.data.orders.map((o: any) => o.id)
+          )
+        }
+      })
+
+      it("rejects an unknown kind rather than silently defaulting", async () => {
+        const err = await api
+          .get(
+            `/admin/partners/${partner.partnerId}/orders?kind=nonsense`,
+            adminHeaders
+          )
+          .catch((e: any) => e)
+
+        expect(err.response.status).toBe(400)
+      })
+
+      it("404s for an unknown partner instead of a partner-voiced 401", async () => {
+        const err = await api
+          .get("/admin/partners/partner_does_not_exist/orders", adminHeaders)
+          .catch((e: any) => e)
+
+        expect(err.response.status).toBe(404)
+        expect(err.response.data.message).toBe("Partner not found")
+      })
+
+      it("requires admin auth", async () => {
+        const err = await api
+          .get(`/admin/partners/${partner.partnerId}/orders`)
+          .catch((e: any) => e)
+
+        expect(err.response.status).toBe(401)
+      })
+
+      it("is read-only — no write verb is exposed", async () => {
+        const err = await api
+          .post(`/admin/partners/${partner.partnerId}/orders`, {}, adminHeaders)
+          .catch((e: any) => e)
+
+        expect(err.response.status).toBe(404)
+      })
+    })
+
+    describe("GET /admin/partners/:id/onboarding-profile", () => {
+      it("returns null when the partner never started the wizard", async () => {
+        const res = await api.get(
+          `/admin/partners/${partner.partnerId}/onboarding-profile`,
+          adminHeaders
+        )
+
+        expect(res.status).toBe(200)
+        expect(res.data.onboarding_profile).toBeNull()
+      })
+
+      it("reads back what the partner saved", async () => {
+        const body = {
+          what_they_sell: "apparel",
+          person_type: "manufacturer",
+          team_size: 12,
+          does_weaving: true,
+          completed: true,
+        }
+        await api.put("/partners/onboarding-profile", body, {
+          headers: partner.headers,
+        })
+
+        const res = await api.get(
+          `/admin/partners/${partner.partnerId}/onboarding-profile`,
+          adminHeaders
+        )
+
+        expect(res.status).toBe(200)
+        expect(res.data.onboarding_profile).toMatchObject(body)
+        expect(res.data.onboarding_profile.partner_id).toBe(partner.partnerId)
+      })
+
+      it("404s for an unknown partner", async () => {
+        const err = await api
+          .get(
+            "/admin/partners/partner_does_not_exist/onboarding-profile",
+            adminHeaders
+          )
+          .catch((e: any) => e)
+
+        expect(err.response.status).toBe(404)
+      })
+    })
+  })
+})

--- a/apps/backend/src/admin/components/partners/partner-inspection-section.tsx
+++ b/apps/backend/src/admin/components/partners/partner-inspection-section.tsx
@@ -1,0 +1,228 @@
+/**
+ * Partner inspection mirror (#843, approach #2) — the read-only "what's going
+ * on with this partner" view, rendered from the admin read-proxy routes rather
+ * than from admin's own order tables, so it shows the partner's scoping (their
+ * sales channel for retail, their work-order links for design/inventory).
+ *
+ * Read-only by construction: no action menus, no mutations. Acting on a
+ * partner's behalf is the separate audited-impersonation track.
+ */
+import { Badge, Container, Heading, Table, Tabs, Text } from "@medusajs/ui"
+import { useState } from "react"
+import { Link } from "react-router-dom"
+import { Skeleton } from "../table/skeleton"
+import {
+  PartnerOrderKind,
+  usePartnerInspectionOrders,
+  usePartnerOnboardingProfile,
+} from "../../hooks/api/partner-inspection"
+
+interface PartnerInspectionSectionProps {
+  partnerId: string
+}
+
+const KINDS: { value: PartnerOrderKind; label: string }[] = [
+  { value: "retail", label: "Retail" },
+  { value: "design", label: "Design" },
+  { value: "inventory", label: "Inventory" },
+  { value: "all", label: "All" },
+]
+
+const PAGE_SIZE = 10
+
+const formatTotal = (total?: number, currency?: string) => {
+  if (typeof total !== "number") {
+    return "—"
+  }
+  try {
+    return new Intl.NumberFormat(undefined, {
+      style: "currency",
+      currency: (currency || "usd").toUpperCase(),
+    }).format(total)
+  } catch {
+    return `${total} ${(currency || "").toUpperCase()}`.trim()
+  }
+}
+
+const statusColor = (status?: string) => {
+  switch (status) {
+    case "completed":
+    case "captured":
+    case "fulfilled":
+      return "green" as const
+    case "canceled":
+      return "red" as const
+    case "pending":
+    case "not_fulfilled":
+      return "orange" as const
+    default:
+      return "grey" as const
+  }
+}
+
+export const PartnerInspectionSection = ({
+  partnerId,
+}: PartnerInspectionSectionProps) => {
+  const [kind, setKind] = useState<PartnerOrderKind>("retail")
+
+  const { orders, count, isLoading, isError, error } =
+    usePartnerInspectionOrders(partnerId, { kind, limit: PAGE_SIZE })
+
+  const { onboardingProfile, isLoading: isProfileLoading } =
+    usePartnerOnboardingProfile(partnerId)
+
+  if (isError) {
+    throw error
+  }
+
+  return (
+    <Container className="divide-y p-0">
+      <div className="flex items-center justify-between px-6 py-4">
+        <div className="flex items-center gap-x-2">
+          <Heading level="h2">Inspect</Heading>
+          {count > 0 && (
+            <Badge size="2xsmall" color="grey">
+              {count}
+            </Badge>
+          )}
+        </div>
+        <Text size="small" className="text-ui-fg-muted">
+          Read-only — as the partner sees it
+        </Text>
+      </div>
+
+      <div className="px-6 py-4">
+        <Tabs value={kind} onValueChange={(v) => setKind(v as PartnerOrderKind)}>
+          <Tabs.List>
+            {KINDS.map((k) => (
+              <Tabs.Trigger key={k.value} value={k.value}>
+                {k.label}
+              </Tabs.Trigger>
+            ))}
+          </Tabs.List>
+        </Tabs>
+      </div>
+
+      {isLoading ? (
+        <div className="flex flex-col gap-y-2 px-6 py-4">
+          <Skeleton className="h-8 w-full rounded-md" />
+          <Skeleton className="h-8 w-full rounded-md" />
+          <Skeleton className="h-8 w-full rounded-md" />
+        </div>
+      ) : orders.length === 0 ? (
+        <div className="px-6 py-8 text-center">
+          <Text size="small" className="text-ui-fg-muted">
+            No {kind === "all" ? "" : `${kind} `}orders for this partner
+          </Text>
+        </div>
+      ) : (
+        <div className="overflow-x-auto">
+          <Table className="w-full">
+            <Table.Header>
+              <Table.Row>
+                <Table.HeaderCell>Order</Table.HeaderCell>
+                <Table.HeaderCell>Customer</Table.HeaderCell>
+                <Table.HeaderCell>Status</Table.HeaderCell>
+                <Table.HeaderCell>Payment</Table.HeaderCell>
+                <Table.HeaderCell>Fulfillment</Table.HeaderCell>
+                <Table.HeaderCell className="text-right">Total</Table.HeaderCell>
+              </Table.Row>
+            </Table.Header>
+            <Table.Body>
+              {orders.map((order) => (
+                <Table.Row key={order.id}>
+                  <Table.Cell>
+                    <Link
+                      to={`/orders/${order.id}`}
+                      className="text-ui-fg-interactive"
+                    >
+                      #{order.custom_display_id || order.display_id || order.id}
+                    </Link>
+                  </Table.Cell>
+                  <Table.Cell>
+                    <Text size="small" className="text-ui-fg-subtle">
+                      {order.customer
+                        ? [order.customer.first_name, order.customer.last_name]
+                            .filter(Boolean)
+                            .join(" ") ||
+                          order.customer.email ||
+                          "—"
+                        : order.email || "—"}
+                    </Text>
+                  </Table.Cell>
+                  <Table.Cell>
+                    <Badge size="2xsmall" color={statusColor(order.status)}>
+                      {order.unified_order_status?.partner_status ||
+                        order.status ||
+                        "—"}
+                    </Badge>
+                  </Table.Cell>
+                  <Table.Cell>
+                    <Badge
+                      size="2xsmall"
+                      color={statusColor(order.payment_status)}
+                    >
+                      {order.payment_status || "—"}
+                    </Badge>
+                  </Table.Cell>
+                  <Table.Cell>
+                    <Badge
+                      size="2xsmall"
+                      color={statusColor(order.fulfillment_status)}
+                    >
+                      {order.fulfillment_status || "—"}
+                    </Badge>
+                  </Table.Cell>
+                  <Table.Cell className="text-right">
+                    <Text size="small">
+                      {formatTotal(order.total, order.currency_code)}
+                    </Text>
+                  </Table.Cell>
+                </Table.Row>
+              ))}
+            </Table.Body>
+          </Table>
+        </div>
+      )}
+
+      <div className="px-6 py-4">
+        <Text size="small" weight="plus" className="mb-2">
+          Onboarding profile
+        </Text>
+        {isProfileLoading ? (
+          <Skeleton className="h-8 w-full rounded-md" />
+        ) : !onboardingProfile ? (
+          <Text size="small" className="text-ui-fg-muted">
+            Not started — this partner has never saved the onboarding
+            questionnaire.
+          </Text>
+        ) : (
+          <div className="grid grid-cols-2 gap-x-4 gap-y-2">
+            {Object.entries(onboardingProfile)
+              .filter(
+                ([key, value]) =>
+                  !["id", "partner_id", "created_at", "updated_at", "deleted_at"].includes(
+                    key
+                  ) &&
+                  value !== null &&
+                  value !== undefined &&
+                  value !== ""
+              )
+              .map(([key, value]) => (
+                <div key={key} className="flex flex-col">
+                  <Text size="xsmall" className="text-ui-fg-muted">
+                    {key.replace(/_/g, " ")}
+                  </Text>
+                  <Text size="small" className="text-ui-fg-subtle">
+                    {typeof value === "object"
+                      ? JSON.stringify(value)
+                      : String(value)}
+                  </Text>
+                </div>
+              ))}
+          </div>
+        )}
+      </div>
+    </Container>
+  )
+}

--- a/apps/backend/src/admin/hooks/api/partner-inspection.ts
+++ b/apps/backend/src/admin/hooks/api/partner-inspection.ts
@@ -1,0 +1,109 @@
+/**
+ * Read-only hooks for the partner inspection mirror (#843, approach #2).
+ *
+ * These hit the admin read-proxy routes (`/admin/partners/:id/{orders,
+ * onboarding-profile}`), which run the partner portal's own scoping helpers
+ * against a synthesized partner context — so what renders here is what the
+ * partner sees. There are deliberately no mutation hooks in this file.
+ */
+import { FetchError } from "@medusajs/js-sdk"
+import { QueryKey, UseQueryOptions, useQuery } from "@tanstack/react-query"
+import { sdk } from "../../lib/config"
+import { queryKeysFactory } from "../../lib/query-key-factory"
+
+export type PartnerOrderKind = "retail" | "design" | "inventory" | "all"
+
+export interface PartnerInspectionOrder {
+  id: string
+  display_id?: number
+  custom_display_id?: string | null
+  status?: string
+  payment_status?: string
+  fulfillment_status?: string
+  total?: number
+  currency_code?: string
+  email?: string | null
+  created_at?: string
+  customer?: { id: string; email?: string; first_name?: string; last_name?: string } | null
+  unified_order_status?: { partner_status?: string | null } | null
+}
+
+export interface PartnerInspectionOrdersResponse {
+  orders: PartnerInspectionOrder[]
+  count: number
+  offset: number
+  limit: number
+}
+
+export interface PartnerOnboardingProfile {
+  id: string
+  partner_id: string
+  created_at?: string
+  updated_at?: string
+  [key: string]: unknown
+}
+
+const PARTNER_INSPECTION_QUERY_KEY = "partner_inspection" as const
+export const partnerInspectionQueryKeys = queryKeysFactory(
+  PARTNER_INSPECTION_QUERY_KEY
+)
+
+export const usePartnerInspectionOrders = (
+  partnerId: string,
+  query?: { kind?: PartnerOrderKind; limit?: number; offset?: number; order?: string },
+  options?: Omit<
+    UseQueryOptions<
+      PartnerInspectionOrdersResponse,
+      FetchError,
+      PartnerInspectionOrdersResponse,
+      QueryKey
+    >,
+    "queryFn" | "queryKey"
+  >
+) => {
+  const { data, ...rest } = useQuery({
+    queryFn: async () =>
+      sdk.client.fetch<PartnerInspectionOrdersResponse>(
+        `/admin/partners/${partnerId}/orders`,
+        { method: "GET", query }
+      ),
+    queryKey: partnerInspectionQueryKeys.detail(partnerId, { orders: query }),
+    enabled: !!partnerId,
+    ...options,
+  })
+
+  return {
+    orders: data?.orders || [],
+    count: data?.count || 0,
+    ...rest,
+  }
+}
+
+export const usePartnerOnboardingProfile = (
+  partnerId: string,
+  options?: Omit<
+    UseQueryOptions<
+      { onboarding_profile: PartnerOnboardingProfile | null },
+      FetchError,
+      { onboarding_profile: PartnerOnboardingProfile | null },
+      QueryKey
+    >,
+    "queryFn" | "queryKey"
+  >
+) => {
+  const { data, ...rest } = useQuery({
+    queryFn: async () =>
+      sdk.client.fetch<{ onboarding_profile: PartnerOnboardingProfile | null }>(
+        `/admin/partners/${partnerId}/onboarding-profile`,
+        { method: "GET" }
+      ),
+    queryKey: partnerInspectionQueryKeys.detail(partnerId, { onboarding: true }),
+    enabled: !!partnerId,
+    ...options,
+  })
+
+  return {
+    onboardingProfile: data?.onboarding_profile ?? null,
+    ...rest,
+  }
+}

--- a/apps/backend/src/admin/routes/partners/[id]/page.tsx
+++ b/apps/backend/src/admin/routes/partners/[id]/page.tsx
@@ -9,6 +9,7 @@ import { PartnerPaymentsSection } from "../../../components/partners/partner-pay
 import { PartnerTasksSection } from "../../../components/partners/partner-tasks-section"
 import { PartnerFeedbacksSection } from "../../../components/partners/partner-feedbacks-section"
 import { PartnerStorefrontSection } from "../../../components/partners/partner-storefront-section"
+import { PartnerInspectionSection } from "../../../components/partners/partner-inspection-section"
 import { PartnerSubscriptionSection } from "../../../components/partners/partner-subscription-section"
 import { PartnerPeopleSection } from "../../../components/partners/partner-people-section"
 import { PartnerWhatsAppSection } from "../../../components/partners/partner-whatsapp-section"
@@ -42,6 +43,7 @@ const PartnerDetailPage = () => {
       <TwoColumnPage data={partner} hasOutlet={true} showJSON showMetadata>
         <TwoColumnPage.Main>
           <PartnerGeneralSection partner={partner} />
+          <PartnerInspectionSection partnerId={partner.id} />
           <PartnerTasksSection partnerId={partner.id} />
           <PartnerStorefrontSection partnerId={partner.id} />
         </TwoColumnPage.Main>

--- a/apps/backend/src/api/admin/partners/[id]/lib/partner-inspection.ts
+++ b/apps/backend/src/api/admin/partners/[id]/lib/partner-inspection.ts
@@ -1,0 +1,88 @@
+/**
+ * @file Admin → partner read-proxy primitive (#843, approach #2).
+ * @description Lets admin-side inspection routes read a partner's operational
+ *   internals *as the partner sees them*, by reusing the partner portal's own
+ *   scoping helpers (`src/api/partners/helpers.ts`) instead of re-deriving the
+ *   scoping rules admin-side — which is how the two surfaces drift apart.
+ * @module API/Admin/Partners/Inspection
+ */
+import { MedusaContainer } from "@medusajs/framework"
+import { ContainerRegistrationKeys, MedusaError } from "@medusajs/framework/utils"
+
+/**
+ * The shape `src/api/partners/helpers.ts` reads off `req.auth_context`.
+ *
+ * Every partner-portal ownership helper (`getPartnerFromAuthContext`,
+ * `getPartnerStore`, `tryGetPartnerSalesChannelId`, `validatePartnerOrderOwnership`,
+ * …) keys off `actor_id` == the partner id and nothing else, so an admin route
+ * can hand them a synthesized context and transparently inherit the entire
+ * partner scoping chain.
+ *
+ * `actor_type`/`app_metadata` are set for parity with a genuine partner bearer
+ * (and so anything logging the context reads sensibly) — they are not what the
+ * helpers dispatch on.
+ */
+export type SynthesizedPartnerAuthContext = {
+  actor_id: string
+  actor_type: "partner"
+  app_metadata: { partner_id: string }
+}
+
+/**
+ * READ-ONLY BY CONSTRUCTION — deliberately.
+ *
+ * This mints a plain object, never a bearer token, and is only ever passed to
+ * partner *read* helpers from `GET` handlers. It is NOT impersonation: nothing
+ * here can authenticate a request, so it cannot be replayed or leaked as a
+ * credential. The audited act-as-partner token (approach #1 on #843) is a
+ * separate, later, RBAC-gated thing — do not grow this into it.
+ */
+export const synthesizePartnerAuthContext = (
+  partnerId: string
+): SynthesizedPartnerAuthContext => ({
+  actor_id: partnerId,
+  actor_type: "partner",
+  app_metadata: { partner_id: partnerId },
+})
+
+/**
+ * Assert the partner exists before proxying, and return it.
+ *
+ * Without this the partner helpers would surface a partner-voiced
+ * `UNAUTHORIZED "No partner associated with this account"` for an unknown id,
+ * which is both the wrong status and a nonsense message for an admin caller.
+ * Mirrors the 404 the sibling admin partner sub-routes throw.
+ */
+export const assertPartnerExists = async (
+  partnerId: string,
+  container: MedusaContainer
+): Promise<{ id: string; name?: string }> => {
+  const query = container.resolve(ContainerRegistrationKeys.QUERY)
+  const { data } = await query.graph({
+    entity: "partner",
+    fields: ["id", "name"],
+    filters: { id: partnerId },
+  })
+
+  const partner = data?.[0] as { id: string; name?: string } | undefined
+  if (!partner) {
+    throw new MedusaError(MedusaError.Types.NOT_FOUND, "Partner not found")
+  }
+
+  return partner
+}
+
+/**
+ * The two together: 404 on an unknown partner, otherwise the synthesized
+ * context the partner helpers expect.
+ */
+export const resolvePartnerInspectionContext = async (
+  partnerId: string,
+  container: MedusaContainer
+): Promise<{
+  partner: { id: string; name?: string }
+  authContext: SynthesizedPartnerAuthContext
+}> => {
+  const partner = await assertPartnerExists(partnerId, container)
+  return { partner, authContext: synthesizePartnerAuthContext(partner.id) }
+}

--- a/apps/backend/src/api/admin/partners/[id]/onboarding-profile/route.ts
+++ b/apps/backend/src/api/admin/partners/[id]/onboarding-profile/route.ts
@@ -1,0 +1,30 @@
+/**
+ * @file Admin read-proxy: a partner's onboarding questionnaire (#843).
+ * @description The onboarding profile (#648) is captured at registration but
+ *   has never had an admin-side read surface — it was write-only from the
+ *   platform's point of view. This exposes it for inspection.
+ * @module API/Admin/Partners/OnboardingProfile
+ */
+import { MedusaRequest, MedusaResponse } from "@medusajs/framework/http"
+import { PARTNER_ONBOARDING_PROFILE_MODULE } from "../../../../../modules/partner-onboarding-profile"
+import { assertPartnerExists } from "../lib/partner-inspection"
+
+/**
+ * GET /admin/partners/:id/onboarding-profile
+ *
+ * Mirrors `GET /partners/onboarding-profile`. Returns `null` when the partner
+ * has not started the wizard — a partner with no profile is an ordinary state
+ * (and, for the console, a useful signal), not a 404.
+ *
+ * READ-ONLY: the partner owns their own answers; admin does not edit them here.
+ */
+export const GET = async (req: MedusaRequest, res: MedusaResponse) => {
+  const { id: partnerId } = req.params
+
+  await assertPartnerExists(partnerId, req.scope)
+
+  const service: any = req.scope.resolve(PARTNER_ONBOARDING_PROFILE_MODULE)
+  const profile = await service.findByPartner(partnerId)
+
+  return res.status(200).json({ onboarding_profile: profile ?? null })
+}

--- a/apps/backend/src/api/admin/partners/[id]/orders/route.ts
+++ b/apps/backend/src/api/admin/partners/[id]/orders/route.ts
@@ -1,0 +1,65 @@
+/**
+ * @file Admin read-proxy: a partner's orders, as the partner sees them (#843).
+ * @module API/Admin/Partners/Orders
+ */
+import { MedusaRequest, MedusaResponse } from "@medusajs/framework/http"
+import { tryGetPartnerSalesChannelId } from "../../../../partners/helpers"
+import { PartnerGetOrdersKindParam } from "../../../../partners/orders/validators"
+import {
+  buildPartnerOrderListParams,
+  PARTNER_ORDER_LIST_FIELDS,
+} from "../../../../partners/orders/list-params"
+import { listPartnerOrdersWorkflow } from "../../../../../workflows/orders/list-partner-orders"
+import { resolvePartnerInspectionContext } from "../lib/partner-inspection"
+
+/**
+ * GET /admin/partners/:id/orders
+ *
+ * The inspection mirror of `GET /partners/orders`: same `?kind=` discriminator,
+ * same filters/sort/pagination, same field set, same scoping — because it runs
+ * the same param helper and the same workflow, just with the partner resolved
+ * from `:id` instead of from a partner bearer.
+ *
+ * READ-ONLY. There is deliberately no POST/PATCH here: writing on a partner's
+ * behalf is the audited impersonation track (approach #1 on #843), not this one.
+ */
+export const GET = async (req: MedusaRequest, res: MedusaResponse) => {
+  const { id: partnerId } = req.params
+
+  const { kind } = PartnerGetOrdersKindParam.parse({
+    kind: (req.query as Record<string, unknown>)?.kind,
+  })
+  const resolvedKind = kind ?? "retail"
+
+  // 404s on an unknown partner before any partner helper can voice a
+  // partner-shaped UNAUTHORIZED at an admin caller.
+  const { authContext } = await resolvePartnerInspectionContext(
+    partnerId,
+    req.scope
+  )
+
+  const { partner, salesChannelId } = await tryGetPartnerSalesChannelId(
+    authContext,
+    req.scope
+  )
+
+  const { baseFilters, order, skip, take } = buildPartnerOrderListParams(
+    (req.query as Record<string, unknown>) || {},
+    resolvedKind
+  )
+
+  const { result } = await listPartnerOrdersWorkflow(req.scope).run({
+    input: {
+      partnerId: partner?.id ?? null,
+      salesChannelId,
+      kind: resolvedKind,
+      fields: PARTNER_ORDER_LIST_FIELDS,
+      baseFilters,
+      order,
+      skip,
+      take,
+    },
+  })
+
+  res.json(result)
+}

--- a/apps/backend/src/api/partners/orders/list-params.ts
+++ b/apps/backend/src/api/partners/orders/list-params.ts
@@ -8,6 +8,46 @@ import type { PartnerOrderKind } from "./validators"
 // that middleware (the `?kind=` discriminator must not reach the orders filters),
 // so we map the same params here, by hand, in a pure + unit-testable helper.
 
+// The field set the partner orders list is read with. Lives here, next to the
+// param mapping, because it is part of the partner order-list *contract* rather
+// than of any one route: the admin read-proxy (`GET /admin/partners/:id/orders`,
+// #843) reads with exactly these fields so the inspection mirror cannot drift
+// from what the partner actually sees.
+//
+// IMPORTANT: use the `relation.*` suffix syntax, not `*relation` prefix.
+//
+// `getOrdersListWorkflow` -> `useRemoteQueryStep` -> `query.graph` only
+// understands `relation.*` (expand all fields of a relation). The
+// `*relation` form is admin's user-facing convention, but the admin
+// middleware (`validateAndTransformQuery` -> `prepareListQuery`) rewrites
+// it to `relation.*` before handing it to the workflow — see
+// node_modules/@medusajs/framework/.../get-query-config.js#prepareListQuery.
+// We don't run that middleware here, so we have to write the canonical
+// form ourselves.
+//
+// Symptom of getting this wrong: `customer`, `sales_channel`, and
+// `shipping_address` all come back as `null` in the response and even
+// their `_id` scalars get dropped — the orders list table renders blank
+// cells for those columns.
+export const PARTNER_ORDER_LIST_FIELDS = [
+  "id", "status", "created_at", "email", "display_id",
+  "custom_display_id", "payment_status", "fulfillment_status",
+  "total", "currency_code",
+  "customer_id",
+  "sales_channel_id",
+  "shipping_address_id",
+  "customer.*",
+  "sales_channel.*",
+  "payment_collections.*",
+  "shipping_address.*",
+  // Chunk 5 (T3.4): kind is the route `?kind=` param (link-derived, Chunk 6).
+  // Chunk 9b / PR-G + PR-H: the work-status badge reads the typed
+  // `unified_order_status.partner_status` column (PR-F sidecar) via the link
+  // accessor — now the SOLE source (PR-H retired the `metadata.partner_status`
+  // copy and its transitional fallback).
+  "unified_order_status.partner_status",
+]
+
 // Filters that apply to EVERY order row regardless of kind.
 const UNIVERSAL_FILTER_KEYS = ["status", "q", "created_at", "updated_at"] as const
 

--- a/apps/backend/src/api/partners/orders/route.ts
+++ b/apps/backend/src/api/partners/orders/route.ts
@@ -1,42 +1,11 @@
 import { AuthenticatedMedusaRequest, MedusaResponse } from "@medusajs/framework/http"
 import { tryGetPartnerSalesChannelId } from "../helpers"
 import { PartnerGetOrdersKindParam } from "./validators"
-import { buildPartnerOrderListParams } from "./list-params"
+import {
+  buildPartnerOrderListParams,
+  PARTNER_ORDER_LIST_FIELDS as DEFAULT_FIELDS,
+} from "./list-params"
 import { listPartnerOrdersWorkflow } from "../../../workflows/orders/list-partner-orders"
-
-// IMPORTANT: use the `relation.*` suffix syntax, not `*relation` prefix.
-//
-// `getOrdersListWorkflow` -> `useRemoteQueryStep` -> `query.graph` only
-// understands `relation.*` (expand all fields of a relation). The
-// `*relation` form is admin's user-facing convention, but the admin
-// middleware (`validateAndTransformQuery` -> `prepareListQuery`) rewrites
-// it to `relation.*` before handing it to the workflow — see
-// node_modules/@medusajs/framework/.../get-query-config.js#prepareListQuery.
-// We don't run that middleware here, so we have to write the canonical
-// form ourselves.
-//
-// Symptom of getting this wrong: `customer`, `sales_channel`, and
-// `shipping_address` all come back as `null` in the response and even
-// their `_id` scalars get dropped — the orders list table renders blank
-// cells for those columns.
-const DEFAULT_FIELDS = [
-  "id", "status", "created_at", "email", "display_id",
-  "custom_display_id", "payment_status", "fulfillment_status",
-  "total", "currency_code",
-  "customer_id",
-  "sales_channel_id",
-  "shipping_address_id",
-  "customer.*",
-  "sales_channel.*",
-  "payment_collections.*",
-  "shipping_address.*",
-  // Chunk 5 (T3.4): kind is the route `?kind=` param (link-derived, Chunk 6).
-  // Chunk 9b / PR-G + PR-H: the work-status badge reads the typed
-  // `unified_order_status.partner_status` column (PR-F sidecar) via the link
-  // accessor — now the SOLE source (PR-H retired the `metadata.partner_status`
-  // copy and its transitional fallback).
-  "unified_order_status.partner_status",
-]
 
 // Chunk 5 (T3.4, #342): the partner orders list is `?kind=`-aware (retail |
 // design | inventory | all), mirroring admin's Chunk 4 contract. The route is


### PR DESCRIPTION
First slice of **#843 approach #2** (read-proxy tabs). Records the decision — approach #2 over audited impersonation — and proves the synthesized-partner-context pattern the rest of the console will be built on.

## Why

Admin already has a partner **management/config** surface. What's missing is a read-only **inspection mirror** — "what's going on with this partner" without a portal login.

The obvious way to build that is to write admin-side queries over partner data. That's how two surfaces drift apart. Instead these routes hand the partner portal's *own* ownership helpers (`src/api/partners/helpers.ts`) a synthesized `{ actor_id: partnerId }` context and reuse the entire scoping chain — every partner helper keys off `actor_id` and nothing else, so it works transparently.

## What's here

- **`[id]/lib/partner-inspection.ts`** — the primitive.
  - `synthesizePartnerAuthContext` mints a plain object, **never a bearer token**. It cannot authenticate a request, so it can't be replayed or leaked as a credential. This is *not* impersonation; the audited act-as-partner token (approach #1) stays a separate, later, RBAC-gated thing.
  - `assertPartnerExists` — an unknown id 404s, instead of the partner helpers voicing `UNAUTHORIZED "No partner associated with this account"` at an admin caller (wrong status, nonsense message).
- **`GET /admin/partners/:id/orders`** — mirrors `GET /partners/orders`: same `?kind=` discriminator (retail/design/inventory/all), same filters, sort, pagination, field set, same `listPartnerOrdersWorkflow`. Only the partner resolution differs.
- **`GET /admin/partners/:id/onboarding-profile`** — the #648 questionnaire is captured at registration and has never had an admin read surface; it was write-only from the platform's point of view.
- **Admin UI** — `PartnerInspectionSection` on the partner detail page: kind tabs, order table, onboarding answers. Read-only by construction — no action menus, no mutation hooks in `hooks/api/partner-inspection.ts`.

`PARTNER_ORDER_LIST_FIELDS` moves out of the partner route into `list-params.ts` so both surfaces read with one field set. A divergence there silently blanks columns (the `relation.*` vs `*relation` trap documented on that constant), which in a mirror means lying about what the partner sees.

## Scope held

Writing on a partner's behalf is deliberately not built. No `POST`/`PATCH` — a test pins that.

## Verification

- `pnpm test:integration:http:shared ./integration-tests/http/admin-partner-inspection` — **9/9**, including a test that asserts the admin proxy and the partner route return the **same order ids and count for all four kinds** (the anti-drift guard).
- `TEST_TYPE=unit jest --testPathPattern="partners/orders"` — 8/8 (field-set move).
- `pnpm test:integration:http:shared ./integration-tests/http/admin-partners-api` — 2/2.
- `pnpm run check:prod-build` — green. `tsc --noEmit` clean on all touched files.

## ⚠️ Unrelated pre-existing red found

`integration-tests/http/partner-orders-api.spec.ts` is **14 failed / 4 passed on clean `main`** — every failure a 400 out of the order fixture. Verified pre-existing by stashing; untouched by this PR. CI only runs *changed* specs, so it's been dormant. Worth its own issue.

🤖 Generated with [Claude Code](https://claude.com/claude-code)