### PR TITLE
chore(visual-flows): refresh workflow-schemas.json for cost_currency [#1162]

### DIFF
--- a/apps/backend/workflow-schemas.json
+++ b/apps/backend/workflow-schemas.json
@@ -2052,6 +2052,12 @@
         "placeholder": "0"
       },
       {
+        "name": "cost_currency",
+        "type": "string",
+        "required": false,
+        "placeholder": "{{ $last.cost_currency }}"
+      },
+      {
         "name": "designer_notes",
         "type": "string",
         "required": false,
@@ -2487,6 +2493,12 @@
         "type": "number",
         "required": false,
         "placeholder": "0"
+      },
+      {
+        "name": "cost_currency",
+        "type": "string",
+        "required": false,
+        "placeholder": "{{ $last.cost_currency }}"
       },
       {
         "name": "designer_notes",


### PR DESCRIPTION
`workflow-schemas.json` is generated by `pnpm build:schemas`, but it is not a throwaway artifact — `GET /admin/visual-flows/metadata` reads it at runtime to populate the visual flow node registry. When it drifts, flow authors can't see fields the workflows actually accept.

It had been stale since #1162 added `cost_currency` to the design workflows. Regenerated here.

**Diff is additive only** — two `cost_currency` entries on the design workflow schemas. Entry count and source mix unchanged: 264 total, 237 `custom_ts` / 27 `inferred`, 0 `core` (the local generator skips the core scan; the committed file already had 0 core entries, so this is not a regression).

🤖 Generated with [Claude Code](https://claude.com/claude-code)