### PR TITLE
feat(admin,partners): inspection mirror for designs + production runs [#843]

### DIFF
--- a/apps/backend/integration-tests/http/admin-partner-inspection.spec.ts
+++ b/apps/backend/integration-tests/http/admin-partner-inspection.spec.ts
@@ -181,5 +181,219 @@ setupSharedTestSuite(() => {
         expect(err.response.status).toBe(404)
       })
     })
+
+    describe("GET /admin/partners/:id/designs", () => {
+      it("mirrors GET /partners/designs — same ids, count and facets", async () => {
+        // Seed a design the partner OWNS (self-serve create) so the comparison
+        // runs over real rows rather than two empty lists agreeing with each
+        // other, which would pass even if the mirror were broken.
+        const created = await api.post(
+          "/partners/designs",
+          { name: `Inspect Design ${Date.now()}`, description: "mirror test" },
+          { headers: partner.headers }
+        )
+        expect(created.status).toBe(201)
+
+        const viaAdmin = await api.get(
+          `/admin/partners/${partner.partnerId}/designs`,
+          adminHeaders
+        )
+        const viaPartner = await api.get("/partners/designs", {
+          headers: partner.headers,
+        })
+
+        expect(viaAdmin.status).toBe(200)
+        expect(viaAdmin.data.count).toBe(viaPartner.data.count)
+        expect(viaAdmin.data.designs.map((d: any) => d.id)).toEqual(
+          viaPartner.data.designs.map((d: any) => d.id)
+        )
+        expect(viaAdmin.data.facets).toEqual(viaPartner.data.facets)
+        expect(viaAdmin.data.designs.length).toBeGreaterThan(0)
+      })
+
+      it("carries partner_info and is_owner through the proxy", async () => {
+        // `is_owner` is per-viewer (#920) and the derived `partner_info` block is
+        // the whole reason an operator opens this surface — if the proxy dropped
+        // either, the list would render but say nothing useful.
+        await api.post(
+          "/partners/designs",
+          { name: `Owned Design ${Date.now()}`, description: "ownership test" },
+          { headers: partner.headers }
+        )
+
+        const res = await api.get(
+          `/admin/partners/${partner.partnerId}/designs`,
+          adminHeaders
+        )
+
+        const design = res.data.designs[0]
+        expect(design.is_owner).toBe(true)
+        expect(design.partner_info).toMatchObject({
+          assigned_partner_id: partner.partnerId,
+          partner_status: "incoming",
+        })
+      })
+
+      it("mirrors the bucket + q filters, not just the unfiltered list", async () => {
+        await api.post(
+          "/partners/designs",
+          { name: `Bucketed ${Date.now()}`, description: "filter test" },
+          { headers: partner.headers }
+        )
+
+        for (const qs of ["bucket=yours", "bucket=completed", "q=Bucketed"]) {
+          const viaAdmin = await api.get(
+            `/admin/partners/${partner.partnerId}/designs?${qs}`,
+            adminHeaders
+          )
+          const viaPartner = await api.get(`/partners/designs?${qs}`, {
+            headers: partner.headers,
+          })
+
+          expect(viaAdmin.data.count).toBe(viaPartner.data.count)
+          expect(viaAdmin.data.designs.map((d: any) => d.id)).toEqual(
+            viaPartner.data.designs.map((d: any) => d.id)
+          )
+        }
+      })
+
+      it("404s for an unknown partner", async () => {
+        const err = await api
+          .get("/admin/partners/partner_does_not_exist/designs", adminHeaders)
+          .catch((e: any) => e)
+
+        expect(err.response.status).toBe(404)
+      })
+
+      it("requires admin auth", async () => {
+        const err = await api
+          .get(`/admin/partners/${partner.partnerId}/designs`)
+          .catch((e: any) => e)
+
+        expect(err.response.status).toBe(401)
+      })
+
+      it("is read-only — no write verb is exposed", async () => {
+        const err = await api
+          .post(`/admin/partners/${partner.partnerId}/designs`, {}, adminHeaders)
+          .catch((e: any) => e)
+
+        expect(err.response.status).toBe(404)
+      })
+    })
+
+    describe("GET /admin/partners/:id/production-runs", () => {
+      // Assign real work to the partner: admin creates a design, opens a
+      // production run on it, and approves an assignment to this partner. That
+      // is the only path that produces a partner-scoped run, and it is what an
+      // operator would be inspecting.
+      const assignRunToPartner = async () => {
+        const design = await api.post(
+          "/admin/designs",
+          { name: `Run Design ${Date.now()}`, description: "run mirror test" },
+          adminHeaders
+        )
+        const parent = await api.post(
+          "/admin/production-runs",
+          { design_id: design.data.design.id, quantity: 4 },
+          adminHeaders
+        )
+        const approved = await api.post(
+          `/admin/production-runs/${parent.data.production_run.id}/approve`,
+          {
+            assignments: [
+              { partner_id: partner.partnerId, role: "stitching", quantity: 4 },
+            ],
+          },
+          adminHeaders
+        )
+        expect(approved.status).toBe(200)
+        return approved.data.result?.children?.[0]?.id
+      }
+
+      it("mirrors GET /partners/production-runs for an assigned run", async () => {
+        const runId = await assignRunToPartner()
+        expect(runId).toBeTruthy()
+
+        const viaAdmin = await api.get(
+          `/admin/partners/${partner.partnerId}/production-runs`,
+          adminHeaders
+        )
+        const viaPartner = await api.get("/partners/production-runs", {
+          headers: partner.headers,
+        })
+
+        expect(viaAdmin.status).toBe(200)
+        expect(viaAdmin.data.count).toBe(viaPartner.data.count)
+        expect(viaAdmin.data.production_runs.map((r: any) => r.id)).toEqual(
+          viaPartner.data.production_runs.map((r: any) => r.id)
+        )
+        expect(
+          viaAdmin.data.production_runs.some((r: any) => r.id === runId)
+        ).toBe(true)
+      })
+
+      it("scopes to the partner — another partner's runs never leak in", async () => {
+        await assignRunToPartner()
+        const other = await createPartner(api)
+
+        const res = await api.get(
+          `/admin/partners/${other.partnerId}/production-runs`,
+          adminHeaders
+        )
+
+        expect(res.status).toBe(200)
+        expect(res.data.production_runs).toHaveLength(0)
+      })
+
+      it("mirrors the status filter", async () => {
+        await assignRunToPartner()
+
+        const viaAdmin = await api.get(
+          `/admin/partners/${partner.partnerId}/production-runs?status=pending`,
+          adminHeaders
+        )
+        const viaPartner = await api.get(
+          "/partners/production-runs?status=pending",
+          { headers: partner.headers }
+        )
+
+        expect(viaAdmin.data.count).toBe(viaPartner.data.count)
+        expect(viaAdmin.data.production_runs.map((r: any) => r.id)).toEqual(
+          viaPartner.data.production_runs.map((r: any) => r.id)
+        )
+      })
+
+      it("404s for an unknown partner", async () => {
+        const err = await api
+          .get(
+            "/admin/partners/partner_does_not_exist/production-runs",
+            adminHeaders
+          )
+          .catch((e: any) => e)
+
+        expect(err.response.status).toBe(404)
+      })
+
+      it("requires admin auth", async () => {
+        const err = await api
+          .get(`/admin/partners/${partner.partnerId}/production-runs`)
+          .catch((e: any) => e)
+
+        expect(err.response.status).toBe(401)
+      })
+
+      it("is read-only — no write verb is exposed", async () => {
+        const err = await api
+          .post(
+            `/admin/partners/${partner.partnerId}/production-runs`,
+            {},
+            adminHeaders
+          )
+          .catch((e: any) => e)
+
+        expect(err.response.status).toBe(404)
+      })
+    })
   })
 })

--- a/apps/backend/src/admin/components/partners/partner-inspection-section.tsx
+++ b/apps/backend/src/admin/components/partners/partner-inspection-section.tsx
@@ -1,19 +1,26 @@
 /**
  * Partner inspection mirror (#843, approach #2) — the read-only "what's going
  * on with this partner" view, rendered from the admin read-proxy routes rather
- * than from admin's own order tables, so it shows the partner's scoping (their
- * sales channel for retail, their work-order links for design/inventory).
+ * than from admin's own tables, so it shows the partner's scoping (their sales
+ * channel for retail, their work-order links for design/inventory, their own
+ * design assignments and production runs).
  *
  * Read-only by construction: no action menus, no mutations. Acting on a
  * partner's behalf is the separate audited-impersonation track.
+ *
+ * The top-level tabs are the SURFACE (orders / designs / runs); the order-kind
+ * discriminator is a sub-tab of Orders, since it only means anything there.
  */
 import { Badge, Container, Heading, Table, Tabs, Text } from "@medusajs/ui"
 import { useState } from "react"
 import { Link } from "react-router-dom"
 import { Skeleton } from "../table/skeleton"
 import {
+  PartnerDesignBucket,
   PartnerOrderKind,
+  usePartnerInspectionDesigns,
   usePartnerInspectionOrders,
+  usePartnerInspectionProductionRuns,
   usePartnerOnboardingProfile,
 } from "../../hooks/api/partner-inspection"
 
@@ -21,11 +28,27 @@ interface PartnerInspectionSectionProps {
   partnerId: string
 }
 
+type InspectionSurface = "orders" | "designs" | "runs"
+
+const SURFACES: { value: InspectionSurface; label: string }[] = [
+  { value: "orders", label: "Orders" },
+  { value: "designs", label: "Designs" },
+  { value: "runs", label: "Production runs" },
+]
+
 const KINDS: { value: PartnerOrderKind; label: string }[] = [
   { value: "retail", label: "Retail" },
   { value: "design", label: "Design" },
   { value: "inventory", label: "Inventory" },
   { value: "all", label: "All" },
+]
+
+const BUCKETS: { value: PartnerDesignBucket; label: string }[] = [
+  { value: "all", label: "All" },
+  { value: "incoming", label: "Incoming" },
+  { value: "in_progress", label: "In progress" },
+  { value: "completed", label: "Completed" },
+  { value: "yours", label: "Theirs" },
 ]
 
 const PAGE_SIZE = 10
@@ -44,6 +67,9 @@ const formatTotal = (total?: number, currency?: string) => {
   }
 }
 
+const formatDate = (value?: string | null) =>
+  value ? new Date(value).toLocaleDateString() : "—"
+
 const statusColor = (status?: string) => {
   switch (status) {
     case "completed":
@@ -51,46 +77,51 @@ const statusColor = (status?: string) => {
     case "fulfilled":
       return "green" as const
     case "canceled":
+    case "cancelled":
+    case "rejected":
       return "red" as const
     case "pending":
     case "not_fulfilled":
+    case "incoming":
+    case "assigned":
       return "orange" as const
+    case "in_progress":
+    case "awaiting_review":
+      return "blue" as const
     default:
       return "grey" as const
   }
 }
 
-export const PartnerInspectionSection = ({
-  partnerId,
-}: PartnerInspectionSectionProps) => {
+const EmptyRow = ({ children }: { children: React.ReactNode }) => (
+  <div className="px-6 py-8 text-center">
+    <Text size="small" className="text-ui-fg-muted">
+      {children}
+    </Text>
+  </div>
+)
+
+const LoadingRows = () => (
+  <div className="flex flex-col gap-y-2 px-6 py-4">
+    <Skeleton className="h-8 w-full rounded-md" />
+    <Skeleton className="h-8 w-full rounded-md" />
+    <Skeleton className="h-8 w-full rounded-md" />
+  </div>
+)
+
+const OrdersPanel = ({ partnerId }: { partnerId: string }) => {
   const [kind, setKind] = useState<PartnerOrderKind>("retail")
-
-  const { orders, count, isLoading, isError, error } =
-    usePartnerInspectionOrders(partnerId, { kind, limit: PAGE_SIZE })
-
-  const { onboardingProfile, isLoading: isProfileLoading } =
-    usePartnerOnboardingProfile(partnerId)
+  const { orders, isLoading, isError, error } = usePartnerInspectionOrders(
+    partnerId,
+    { kind, limit: PAGE_SIZE }
+  )
 
   if (isError) {
     throw error
   }
 
   return (
-    <Container className="divide-y p-0">
-      <div className="flex items-center justify-between px-6 py-4">
-        <div className="flex items-center gap-x-2">
-          <Heading level="h2">Inspect</Heading>
-          {count > 0 && (
-            <Badge size="2xsmall" color="grey">
-              {count}
-            </Badge>
-          )}
-        </div>
-        <Text size="small" className="text-ui-fg-muted">
-          Read-only — as the partner sees it
-        </Text>
-      </div>
-
+    <>
       <div className="px-6 py-4">
         <Tabs value={kind} onValueChange={(v) => setKind(v as PartnerOrderKind)}>
           <Tabs.List>
@@ -104,17 +135,11 @@ export const PartnerInspectionSection = ({
       </div>
 
       {isLoading ? (
-        <div className="flex flex-col gap-y-2 px-6 py-4">
-          <Skeleton className="h-8 w-full rounded-md" />
-          <Skeleton className="h-8 w-full rounded-md" />
-          <Skeleton className="h-8 w-full rounded-md" />
-        </div>
+        <LoadingRows />
       ) : orders.length === 0 ? (
-        <div className="px-6 py-8 text-center">
-          <Text size="small" className="text-ui-fg-muted">
-            No {kind === "all" ? "" : `${kind} `}orders for this partner
-          </Text>
-        </div>
+        <EmptyRow>
+          No {kind === "all" ? "" : `${kind} `}orders for this partner
+        </EmptyRow>
       ) : (
         <div className="overflow-x-auto">
           <Table className="w-full">
@@ -184,6 +209,223 @@ export const PartnerInspectionSection = ({
           </Table>
         </div>
       )}
+    </>
+  )
+}
+
+const DesignsPanel = ({ partnerId }: { partnerId: string }) => {
+  const [bucket, setBucket] = useState<PartnerDesignBucket>("all")
+  const { designs, facets, isLoading, isError, error } =
+    usePartnerInspectionDesigns(partnerId, { bucket, limit: PAGE_SIZE })
+
+  if (isError) {
+    throw error
+  }
+
+  return (
+    <>
+      <div className="px-6 py-4">
+        <Tabs
+          value={bucket}
+          onValueChange={(v) => setBucket(v as PartnerDesignBucket)}
+        >
+          <Tabs.List>
+            {BUCKETS.map((b) => (
+              <Tabs.Trigger key={b.value} value={b.value}>
+                {b.label}
+                {facets?.[b.value] ? (
+                  <Badge size="2xsmall" color="grey" className="ml-2">
+                    {facets[b.value]}
+                  </Badge>
+                ) : null}
+              </Tabs.Trigger>
+            ))}
+          </Tabs.List>
+        </Tabs>
+      </div>
+
+      {isLoading ? (
+        <LoadingRows />
+      ) : designs.length === 0 ? (
+        <EmptyRow>No designs in this view for this partner</EmptyRow>
+      ) : (
+        <div className="overflow-x-auto">
+          <Table className="w-full">
+            <Table.Header>
+              <Table.Row>
+                <Table.HeaderCell>Design</Table.HeaderCell>
+                <Table.HeaderCell>Source</Table.HeaderCell>
+                <Table.HeaderCell>Partner status</Table.HeaderCell>
+                <Table.HeaderCell>Design status</Table.HeaderCell>
+                <Table.HeaderCell className="text-right">
+                  Started
+                </Table.HeaderCell>
+              </Table.Row>
+            </Table.Header>
+            <Table.Body>
+              {designs.map((design) => (
+                <Table.Row key={design.id}>
+                  <Table.Cell>
+                    <Link
+                      to={`/designs/${design.id}`}
+                      className="text-ui-fg-interactive"
+                    >
+                      {design.name || design.id}
+                    </Link>
+                  </Table.Cell>
+                  <Table.Cell>
+                    {/* Keyed on the per-viewer `is_owner` the proxy carries
+                        through, never a bare owner_partner_id truthiness
+                        check — that mislabels another partner's design as
+                        theirs (#920). */}
+                    <Badge
+                      size="2xsmall"
+                      color={design.is_owner ? "blue" : "grey"}
+                    >
+                      {design.is_owner ? "Theirs" : "Assigned"}
+                    </Badge>
+                  </Table.Cell>
+                  <Table.Cell>
+                    <Badge
+                      size="2xsmall"
+                      color={statusColor(design.partner_info?.partner_status)}
+                    >
+                      {design.partner_info?.partner_status || "—"}
+                    </Badge>
+                  </Table.Cell>
+                  <Table.Cell>
+                    <Text size="small" className="text-ui-fg-subtle">
+                      {design.status || "—"}
+                    </Text>
+                  </Table.Cell>
+                  <Table.Cell className="text-right">
+                    <Text size="small" className="text-ui-fg-subtle">
+                      {formatDate(design.partner_info?.partner_started_at)}
+                    </Text>
+                  </Table.Cell>
+                </Table.Row>
+              ))}
+            </Table.Body>
+          </Table>
+        </div>
+      )}
+    </>
+  )
+}
+
+const ProductionRunsPanel = ({ partnerId }: { partnerId: string }) => {
+  const { productionRuns, isLoading, isError, error } =
+    usePartnerInspectionProductionRuns(partnerId, { limit: PAGE_SIZE })
+
+  if (isError) {
+    throw error
+  }
+
+  if (isLoading) {
+    return <LoadingRows />
+  }
+
+  if (productionRuns.length === 0) {
+    return <EmptyRow>No production runs assigned to this partner</EmptyRow>
+  }
+
+  return (
+    <div className="overflow-x-auto">
+      <Table className="w-full">
+        <Table.Header>
+          <Table.Row>
+            <Table.HeaderCell>Run</Table.HeaderCell>
+            <Table.HeaderCell>Type</Table.HeaderCell>
+            <Table.HeaderCell>Role</Table.HeaderCell>
+            <Table.HeaderCell>Status</Table.HeaderCell>
+            <Table.HeaderCell className="text-right">Qty</Table.HeaderCell>
+            <Table.HeaderCell className="text-right">Created</Table.HeaderCell>
+          </Table.Row>
+        </Table.Header>
+        <Table.Body>
+          {productionRuns.map((run) => (
+            <Table.Row key={run.id}>
+              <Table.Cell>
+                <Link
+                  to={`/production-runs/${run.id}`}
+                  className="text-ui-fg-interactive"
+                >
+                  {run.id}
+                </Link>
+              </Table.Cell>
+              <Table.Cell>
+                <Text size="small" className="text-ui-fg-subtle">
+                  {run.run_type || "—"}
+                </Text>
+              </Table.Cell>
+              <Table.Cell>
+                <Text size="small" className="text-ui-fg-subtle">
+                  {run.role || "—"}
+                </Text>
+              </Table.Cell>
+              <Table.Cell>
+                <Badge size="2xsmall" color={statusColor(run.status)}>
+                  {run.status || "—"}
+                </Badge>
+              </Table.Cell>
+              <Table.Cell className="text-right">
+                <Text size="small" className="text-ui-fg-subtle">
+                  {typeof run.produced_quantity === "number" &&
+                  typeof run.quantity === "number"
+                    ? `${run.produced_quantity}/${run.quantity}`
+                    : (run.quantity ?? "—")}
+                </Text>
+              </Table.Cell>
+              <Table.Cell className="text-right">
+                <Text size="small" className="text-ui-fg-subtle">
+                  {formatDate(run.created_at)}
+                </Text>
+              </Table.Cell>
+            </Table.Row>
+          ))}
+        </Table.Body>
+      </Table>
+    </div>
+  )
+}
+
+export const PartnerInspectionSection = ({
+  partnerId,
+}: PartnerInspectionSectionProps) => {
+  const [surface, setSurface] = useState<InspectionSurface>("orders")
+
+  const { onboardingProfile, isLoading: isProfileLoading } =
+    usePartnerOnboardingProfile(partnerId)
+
+  return (
+    <Container className="divide-y p-0">
+      <div className="flex items-center justify-between px-6 py-4">
+        <Heading level="h2">Inspect</Heading>
+        <Text size="small" className="text-ui-fg-muted">
+          Read-only — as the partner sees it
+        </Text>
+      </div>
+
+      <div className="px-6 py-4">
+        <Tabs
+          value={surface}
+          onValueChange={(v) => setSurface(v as InspectionSurface)}
+        >
+          <Tabs.List>
+            {SURFACES.map((s) => (
+              <Tabs.Trigger key={s.value} value={s.value}>
+                {s.label}
+              </Tabs.Trigger>
+            ))}
+          </Tabs.List>
+        </Tabs>
+      </div>
+
+      {/* Each panel owns its own query, so switching surfaces doesn't refetch
+          the others and an error in one can't blank the whole section. */}
+      {surface === "orders" && <OrdersPanel partnerId={partnerId} />}
+      {surface === "designs" && <DesignsPanel partnerId={partnerId} />}
+      {surface === "runs" && <ProductionRunsPanel partnerId={partnerId} />}
 
       <div className="px-6 py-4">
         <Text size="small" weight="plus" className="mb-2">

--- a/apps/backend/src/admin/hooks/api/partner-inspection.ts
+++ b/apps/backend/src/admin/hooks/api/partner-inspection.ts
@@ -1,10 +1,11 @@
 /**
  * Read-only hooks for the partner inspection mirror (#843, approach #2).
  *
- * These hit the admin read-proxy routes (`/admin/partners/:id/{orders,
- * onboarding-profile}`), which run the partner portal's own scoping helpers
- * against a synthesized partner context — so what renders here is what the
- * partner sees. There are deliberately no mutation hooks in this file.
+ * These hit the admin read-proxy routes (`/admin/partners/:id/{orders, designs,
+ * production-runs, onboarding-profile}`), which run the partner portal's own
+ * scoping helpers and listing workflows against a synthesized partner context —
+ * so what renders here is what the partner sees. There are deliberately no
+ * mutation hooks in this file.
  */
 import { FetchError } from "@medusajs/js-sdk"
 import { QueryKey, UseQueryOptions, useQuery } from "@tanstack/react-query"
@@ -74,6 +75,138 @@ export const usePartnerInspectionOrders = (
 
   return {
     orders: data?.orders || [],
+    count: data?.count || 0,
+    ...rest,
+  }
+}
+
+export interface PartnerInspectionDesign {
+  id: string
+  name?: string
+  status?: string
+  is_owner?: boolean
+  created_at?: string
+  partner_info?: {
+    partner_status?: string
+    partner_phase?: string | null
+    partner_started_at?: string | null
+    partner_finished_at?: string | null
+    partner_completed_at?: string | null
+    workflow_tasks_count?: number
+  }
+}
+
+export type PartnerDesignBucket =
+  | "all"
+  | "incoming"
+  | "in_progress"
+  | "completed"
+  | "yours"
+
+export interface PartnerInspectionDesignsResponse {
+  designs: PartnerInspectionDesign[]
+  count: number
+  /** Per-bucket totals, counted over the whole q+status set — see #6. */
+  facets?: Record<PartnerDesignBucket, number>
+  offset: number
+  limit: number
+}
+
+export const usePartnerInspectionDesigns = (
+  partnerId: string,
+  query?: {
+    bucket?: PartnerDesignBucket
+    status?: string
+    q?: string
+    limit?: number
+    offset?: number
+  },
+  options?: Omit<
+    UseQueryOptions<
+      PartnerInspectionDesignsResponse,
+      FetchError,
+      PartnerInspectionDesignsResponse,
+      QueryKey
+    >,
+    "queryFn" | "queryKey"
+  >
+) => {
+  const { data, ...rest } = useQuery({
+    queryFn: async () =>
+      sdk.client.fetch<PartnerInspectionDesignsResponse>(
+        `/admin/partners/${partnerId}/designs`,
+        { method: "GET", query }
+      ),
+    queryKey: partnerInspectionQueryKeys.detail(partnerId, { designs: query }),
+    enabled: !!partnerId,
+    ...options,
+  })
+
+  return {
+    designs: data?.designs || [],
+    count: data?.count || 0,
+    facets: data?.facets,
+    ...rest,
+  }
+}
+
+export interface PartnerInspectionProductionRun {
+  id: string
+  status?: string
+  run_type?: string
+  role?: string
+  quantity?: number
+  produced_quantity?: number
+  design_id?: string | null
+  /** Resolved from the order↔run link (#342 D5), not the legacy `order_id` column. */
+  unified_order_id?: string | null
+  accepted_at?: string | null
+  started_at?: string | null
+  finished_at?: string | null
+  completed_at?: string | null
+  created_at?: string
+}
+
+export interface PartnerInspectionProductionRunsResponse {
+  production_runs: PartnerInspectionProductionRun[]
+  count: number
+  offset: number
+  limit: number
+}
+
+export const usePartnerInspectionProductionRuns = (
+  partnerId: string,
+  query?: {
+    status?: string
+    role?: string
+    run_type?: "production" | "sample"
+    design_id?: string
+    limit?: number
+    offset?: number
+  },
+  options?: Omit<
+    UseQueryOptions<
+      PartnerInspectionProductionRunsResponse,
+      FetchError,
+      PartnerInspectionProductionRunsResponse,
+      QueryKey
+    >,
+    "queryFn" | "queryKey"
+  >
+) => {
+  const { data, ...rest } = useQuery({
+    queryFn: async () =>
+      sdk.client.fetch<PartnerInspectionProductionRunsResponse>(
+        `/admin/partners/${partnerId}/production-runs`,
+        { method: "GET", query }
+      ),
+    queryKey: partnerInspectionQueryKeys.detail(partnerId, { runs: query }),
+    enabled: !!partnerId,
+    ...options,
+  })
+
+  return {
+    productionRuns: data?.production_runs || [],
     count: data?.count || 0,
     ...rest,
   }

--- a/apps/backend/src/api/admin/partners/[id]/designs/route.ts
+++ b/apps/backend/src/api/admin/partners/[id]/designs/route.ts
@@ -1,0 +1,47 @@
+/**
+ * @file Admin read-proxy: a partner's designs, as the partner sees them (#843).
+ * @module API/Admin/Partners/Designs
+ */
+import { MedusaRequest, MedusaResponse } from "@medusajs/framework/http"
+import { listDesignsQuerySchema } from "../../../../partners/designs/validators"
+import { listPartnerDesignsWorkflow } from "../../../../../workflows/designs/list-partner-designs"
+import { resolvePartnerInspectionContext } from "../lib/partner-inspection"
+
+/**
+ * GET /admin/partners/:id/designs
+ *
+ * The inspection mirror of `GET /partners/designs`: same query contract
+ * (`status`, `q`, `bucket`, `limit`, `offset`), same partner_status derivation,
+ * same bucket facets — because it runs the same workflow, just with the partner
+ * resolved from `:id` instead of from a partner bearer.
+ *
+ * READ-ONLY. There is deliberately no POST here: creating a design on a
+ * partner's behalf is the audited impersonation track (approach #1 on #843).
+ */
+export const GET = async (req: MedusaRequest, res: MedusaResponse) => {
+  const { id: partnerId } = req.params
+
+  // Parsed here rather than via `validateAndTransformQuery` middleware so this
+  // route reads the partner schema itself — one contract, not two that can
+  // drift apart.
+  const { limit = 20, offset = 0, status, q, bucket } =
+    listDesignsQuerySchema.parse((req.query as Record<string, unknown>) || {})
+
+  // 404s on an unknown partner before any partner helper can voice a
+  // partner-shaped UNAUTHORIZED at an admin caller.
+  const { partner } = await resolvePartnerInspectionContext(partnerId, req.scope)
+
+  const { result } = await listPartnerDesignsWorkflow(req.scope).run({
+    input: {
+      partnerId: partner.id,
+      q,
+      status,
+      bucket,
+      offset,
+      limit,
+      locale: req.locale,
+    },
+  })
+
+  res.json(result)
+}

--- a/apps/backend/src/api/admin/partners/[id]/production-runs/route.ts
+++ b/apps/backend/src/api/admin/partners/[id]/production-runs/route.ts
@@ -1,0 +1,52 @@
+/**
+ * @file Admin read-proxy: a partner's production runs (#843).
+ * @module API/Admin/Partners/ProductionRuns
+ */
+import { MedusaRequest, MedusaResponse } from "@medusajs/framework/http"
+import { listProductionRunsQuerySchema } from "../../../../partners/production-runs/validators"
+import { listPartnerProductionRunsWorkflow } from "../../../../../workflows/production-runs/list-partner-production-runs"
+import { resolvePartnerInspectionContext } from "../lib/partner-inspection"
+
+/**
+ * GET /admin/partners/:id/production-runs
+ *
+ * The inspection mirror of `GET /partners/production-runs`: same filters
+ * (`status`, `role`, `run_type`, `design_id`), same field set, same
+ * `unified_order_id` flattening — because it runs the same workflow, just with
+ * the partner resolved from `:id` instead of from a partner bearer.
+ *
+ * Note this is scoped by the run's own `partner_id`, so it answers "what is
+ * this partner on the hook for", which is the question an operator chasing a
+ * late run actually has. Runs the partner merely *depends* on are out of scope
+ * here, exactly as they are on the partner side.
+ *
+ * READ-ONLY. Accept/start/finish/complete stay on the partner routes — moving a
+ * run on a partner's behalf is the audited impersonation track (approach #1).
+ */
+export const GET = async (req: MedusaRequest, res: MedusaResponse) => {
+  const { id: partnerId } = req.params
+
+  // Parsed against the partner schema itself so the two surfaces share one
+  // query contract rather than two that can drift.
+  const { limit = 20, offset = 0, status, role, run_type, design_id } =
+    listProductionRunsQuerySchema.parse(
+      (req.query as Record<string, unknown>) || {}
+    )
+
+  const { partner } = await resolvePartnerInspectionContext(partnerId, req.scope)
+
+  const { result } = await listPartnerProductionRunsWorkflow(req.scope).run({
+    input: {
+      partnerId: partner.id,
+      status,
+      role,
+      run_type,
+      design_id,
+      offset,
+      limit,
+      locale: req.locale,
+    },
+  })
+
+  res.json(result)
+}

--- a/apps/backend/src/api/partners/designs/route.ts
+++ b/apps/backend/src/api/partners/designs/route.ts
@@ -107,8 +107,7 @@ import { AuthenticatedMedusaRequest, MedusaResponse } from "@medusajs/framework"
 import { ContainerRegistrationKeys, MedusaError } from "@medusajs/framework/utils"
 import { getPartnerFromAuthContext } from "../helpers"
 import { ListDesignsQuery, PartnerCreateDesign } from "./validators"
-import { applyDesignListFilters } from "./list-filters"
-import designPartnersLink from "../../../links/design-partners-link"
+import { listPartnerDesignsWorkflow } from "../../../workflows/designs/list-partner-designs"
 import { createDesignWorkflow } from "../../../workflows/designs/create-design"
 import { linkDesignPartnerWorkflow } from "../../../workflows/designs/partner/link-design-to-partner"
 
@@ -116,247 +115,35 @@ export async function GET(
   req: AuthenticatedMedusaRequest<ListDesignsQuery>,
   res: MedusaResponse
 ) {
-  const { limit = 20, offset = 0, status, q, bucket } = req.validatedQuery as ListDesignsQuery
-
-  const query = req.scope.resolve(ContainerRegistrationKeys.QUERY)
+  const { limit = 20, offset = 0, status, q, bucket } =
+    req.validatedQuery as ListDesignsQuery
 
   // Authenticated partner
   if (!req.auth_context?.actor_id) {
     return res.status(401).json({ error: "Partner authentication required - no actor ID" })
   }
-  
+
   const partner = await getPartnerFromAuthContext(req.auth_context, req.scope)
   if (!partner) {
     return res.status(401).json({ error: "Partner authentication required - no partner found" })
   }
 
-  // Filters: cannot filter on linked design properties; filter post-query if needed
-  const filters: any = { partner_id: partner.id }
-
-  // Order newest-assigned first: the link row's `created_at` is when the
-  // design was assigned to (or created by) this partner. Without an
-  // explicit order the link query returns rows in an arbitrary order, so
-  // a freshly assigned/created design could fall past the `take` window
-  // and never reach page 1. Wrapped in a fallback so that if a runtime
-  // ever rejects `order` on a link entry point, the listing degrades to
-  // unordered instead of 500-ing.
-  //
-  // NOTE: pagination is intentionally NOT applied here. `query.graph` cannot
-  // filter on the linked design's columns (design.status) and the partner
-  // route has no free-text index, so status/`q` are matched in-app below.
-  // Paginating here would slice BEFORE the linked+owned merge and those
-  // filters run, returning the wrong page and a per-page (not total) count —
-  // the #484 page-vs-set bug. We fetch the full partner-scoped set (capped)
-  // and paginate in `applyDesignListFilters`.
-  const linkFields = ["created_at", "design.*", "design.tasks.*", "partner.*"]
-  let results: any[] = []
-  try {
-    const { data } = await query.graph({
-      entity: designPartnersLink.entryPoint,
-      fields: linkFields,
-      filters,
-      pagination: { skip: 0, take: 1000, order: { created_at: "DESC" } },
-    }, { locale: req.locale })
-    results = data
-  } catch {
-    const { data } = await query.graph({
-      entity: designPartnersLink.entryPoint,
-      fields: linkFields,
-      filters,
-      pagination: { skip: 0, take: 1000 },
-    }, { locale: req.locale })
-    results = data
-  }
-
-  // Include all linked designs for this partner.
-  // We'll compute assignment status based on presence of partner workflow tasks (by known titles).
-  // Guard against orphaned link rows: a soft-deleted design resolves to
-  // a null `design` on the link join (e.g. after DELETE /partners/designs/:id),
-  // and the mapping below dereferences `design.*` — drop those so the
-  // listing doesn't 500.
-  const allLinked = (results || [])
-    .filter((linkData: any) => !!linkData?.design)
-    .map((l: any) => ({
-      ...l,
-      _recency: l.created_at || l.design?.created_at || null,
-    }))
-
-  // Safety net: also pull designs this partner OWNS (created via
-  // self-serve). They ARE in the link table (POST creates the link), so
-  // the ordered query above already surfaces them — but if link ordering
-  // ever misses one, this guarantees a partner still sees what they
-  // created. Merged + re-sorted by recency below, never force-pinned.
-  // Always fetched now (no offset gate): pagination happens in-app AFTER
-  // the merge, so gating owned-fetch on offset===0 would drop owned
-  // designs from every page but the first. #484.
-  let ownedRows: any[] = []
-  {
-    try {
-      const { data: owned } = await query.graph(
-        {
-          entity: "design",
-          filters: { owner_partner_id: partner.id } as any,
-          fields: ["*", "tasks.*"],
-          pagination: { skip: 0, take: 50, order: { created_at: "DESC" } },
-        },
-        { locale: req.locale }
-      )
-      // Normalize to the {design, partner} shape the mapping below expects.
-      ownedRows = (owned || [])
-        .filter((d: any) => !!d?.id)
-        .map((d: any) => ({
-          design: d,
-          partner,
-          _recency: d.created_at || null,
-        }))
-    } catch {
-      // Non-fatal — owned designs still appear via the linked set.
-    }
-  }
-
-  // Merge linked + owned, deduped by design id, then sort newest-first by
-  // recency so the most recently assigned/created design is always on top.
-  const seenDesignIds = new Set<string>()
-  const merged: any[] = []
-  for (const item of [...allLinked, ...ownedRows]) {
-    const did = item?.design?.id
-    if (!did || seenDesignIds.has(did)) {
-      continue
-    }
-    seenDesignIds.add(did)
-    merged.push(item)
-  }
-  merged.sort((a: any, b: any) => {
-    const at = a._recency ? new Date(a._recency).getTime() : 0
-    const bt = b._recency ? new Date(b._recency).getTime() : 0
-    return bt - at
+  // The listing itself lives in a workflow so the admin inspection mirror
+  // (`GET /admin/partners/:id/designs`, #843) runs exactly this logic rather
+  // than a second copy of it. This route contributes auth and nothing else.
+  const { result } = await listPartnerDesignsWorkflow(req.scope).run({
+    input: {
+      partnerId: partner.id,
+      q,
+      status,
+      bucket,
+      offset,
+      limit,
+      locale: req.locale,
+    },
   })
 
-  // status + free-text (`q`) filtering and pagination are applied AFTER the
-  // designs are mapped (so `q` can match the resolved design fields), via
-  // applyDesignListFilters below. Map over the full merged set here.
-  const filtered = merged
-
-  // Pre-fetch all production runs for this partner (one query, not per-design)
-  let partnerRuns: any[] = []
-  try {
-    const { data: runs } = await query.graph({
-      entity: "production_runs",
-      // Include cancelled runs: production runs are the single source of
-      // truth for partner_status, so a cancelled run is how a cancelled
-      // assignment is represented (no separate metadata marker).
-      filters: { partner_id: partner.id },
-      fields: ["id", "design_id", "status", "accepted_at", "started_at", "finished_at", "completed_at", "created_at"],
-      pagination: { skip: 0, take: 200 },
-    }, { locale: req.locale })
-    partnerRuns = runs || []
-  } catch {
-    // Non-fatal
-  }
-
-  const mappedDesigns = filtered.map((linkData: any) => {
-    const design = linkData.design
-
-    const tasks = design.tasks || []
-    const isPartnerWorkflowTask = (t: any) =>
-      !!t && [
-        "partner-design-start",
-        "partner-design-redo",
-        "partner-design-finish",
-        "partner-design-completed",
-      ].includes(t.title)
-    const workflowTasks = tasks.filter(isPartnerWorkflowTask)
-
-    let partnerStatus: "incoming" | "assigned" | "in_progress" | "awaiting_review" | "finished" | "completed" | "cancelled" =
-      "incoming"
-    let partnerPhase: "redo" | null = null
-    let partnerStartedAt: string | null = null
-    let partnerFinishedAt: string | null = null
-    let partnerCompletedAt: string | null = null
-
-    // ── Single source of truth: production runs (incl. cancelled) ──────
-    const runsForDesign = partnerRuns
-      .filter((r: any) => r.design_id === design.id)
-      .sort((a: any, b: any) => new Date(b.created_at || 0).getTime() - new Date(a.created_at || 0).getTime())
-    const resolvedFromRun = runsForDesign.length > 0
-    if (resolvedFromRun) {
-      const activeRun = runsForDesign.find(
-        (r: any) => !["completed", "cancelled"].includes(String(r.status))
-      )
-      if (activeRun) {
-        const runStatus = String(activeRun.status)
-        if (runStatus === "in_progress") {
-          partnerStatus = activeRun.finished_at
-            ? "awaiting_review"
-            : activeRun.started_at
-              ? "in_progress"
-              : "assigned"
-        } else {
-          partnerStatus = "assigned"
-        }
-        if (activeRun.started_at) partnerStartedAt = String(activeRun.started_at)
-        if (activeRun.finished_at) partnerFinishedAt = String(activeRun.finished_at)
-      } else {
-        const newest = runsForDesign[0]
-        const runStatus = String(newest.status)
-        if (runStatus === "completed") {
-          partnerStatus = "completed"
-          partnerCompletedAt = newest.completed_at ? String(newest.completed_at) : null
-          if (newest.finished_at) partnerFinishedAt = String(newest.finished_at)
-        } else if (runStatus === "cancelled") {
-          partnerStatus = "cancelled"
-        }
-      }
-    }
-
-    // The legacy v1 fallback (cancel marker + partner-design-* task status
-    // inference for run-less designs) was removed 2026-06-09 after the
-    // backfill migrated all marked designs onto production runs. A design
-    // with no runs is "incoming". See V1_PARTNER_DESIGN_REMOVAL_PLAN.md.
-
-    const partner_info = {
-      assigned_partner_id: linkData.partner?.id || partner.id,
-      partner_status: partnerStatus,
-      partner_phase: partnerPhase,
-      partner_started_at: partnerStartedAt,
-      partner_finished_at: partnerFinishedAt,
-      partner_completed_at: partnerCompletedAt,
-      workflow_tasks_count: workflowTasks.length,
-    }
-
-    return {
-      ...design,
-      partner_info,
-      // Whether the *current* partner owns this design (vs merely being assigned
-      // to it). Mirrors the detail route so the UI's "Yours"/"Assigned" source
-      // badge is accurate — a bare truthiness check on `owner_partner_id` would
-      // mislabel a design owned by another partner but assigned to this one.
-      is_owner:
-        design.owner_partner_id != null &&
-        design.owner_partner_id === partner.id,
-    }
-  })
-
-  // Apply status + free-text (`q`) filtering, THEN paginate, over the full
-  // partner-scoped set. count = total matched (pre-pagination) so the UI
-  // pager is correct. Pure + unit-tested in ./list-filters.
-  const { items: designs, count, facets } = applyDesignListFilters(mappedDesigns, {
-    q,
-    status,
-    bucket,
-    offset,
-    limit,
-  })
-
-  res.status(200).json({
-    designs,
-    count,
-    // #6 — per-bucket counts for the partner work tabs (accurate across all
-    // pages, computed over the full q+status set before the active bucket).
-    facets,
-    limit,
-    offset,
-  })
+  res.status(200).json(result)
 }
 
 /**

--- a/apps/backend/src/api/partners/production-runs/route.ts
+++ b/apps/backend/src/api/partners/production-runs/route.ts
@@ -86,15 +86,16 @@
  * }
  */
 import { AuthenticatedMedusaRequest, MedusaResponse } from "@medusajs/framework/http"
-import { ContainerRegistrationKeys } from "@medusajs/framework/utils"
 
 import type { ListProductionRunsQuery } from "./validators"
+import { listPartnerProductionRunsWorkflow } from "../../../workflows/production-runs/list-partner-production-runs"
 
 export async function GET(
   req: AuthenticatedMedusaRequest<ListProductionRunsQuery>,
   res: MedusaResponse
 ) {
-  const { limit = 20, offset = 0, status, role, run_type, design_id } = req.validatedQuery || {}
+  const { limit = 20, offset = 0, status, role, run_type, design_id } =
+    (req.validatedQuery || {}) as ListProductionRunsQuery
 
   const partnerId = req.auth_context?.actor_id
   if (!partnerId) {
@@ -103,57 +104,21 @@ export async function GET(
       .json({ error: "Partner authentication required - no actor ID" })
   }
 
-  const query = req.scope.resolve(ContainerRegistrationKeys.QUERY)
-
-  const filters: any = { partner_id: partnerId }
-  if (status) {
-    filters.status = status
-  }
-  if (role) {
-    filters.role = role
-  }
-  if (run_type) {
-    filters.run_type = run_type
-  }
-  if (design_id) {
-    filters.design_id = design_id
-  }
-
-  const { data: runs, metadata } = await query.graph({
-    entity: "production_runs",
-    fields: [
-      "id", "status", "run_type", "quantity", "role",
-      "design_id", "partner_id", "parent_run_id",
-      "product_id", "variant_id", "order_id", "order_line_item_id",
-      "accepted_at", "started_at", "finished_at", "completed_at",
-      "cancelled_at", "cancelled_reason",
-      "finish_notes", "completion_notes",
-      "partner_cost_estimate", "cost_type",
-      "produced_quantity", "rejected_quantity", "rejection_reason", "rejection_notes",
-      "depends_on_run_ids", "metadata",
-      "created_at", "updated_at",
-      "tasks.*",
-      // `order.id` resolves the order↔production_run link (#342 D5) so the design
-      // page can deep-link each run to its unified order detail (`/orders/:id`).
-      // NB: this is the LINK accessor, distinct from the plain legacy `order_id`
-      // column above (the original retail order line the run was created from).
-      "order.id",
-    ],
-    filters,
-    pagination: { skip: offset, take: limit },
-  }, { locale: req.locale })
-
-  const list = (runs || []).map((run: any) => ({
-    ...run,
-    unified_order_id: Array.isArray(run?.order)
-      ? run.order[0]?.id
-      : run?.order?.id,
-  }))
-
-  return res.status(200).json({
-    production_runs: list,
-    count: (metadata as any)?.count ?? list.length,
-    limit,
-    offset,
+  // The read lives in a workflow so the admin inspection mirror
+  // (`GET /admin/partners/:id/production-runs`, #843) runs exactly this query
+  // and field set rather than a second copy. This route contributes auth only.
+  const { result } = await listPartnerProductionRunsWorkflow(req.scope).run({
+    input: {
+      partnerId,
+      status,
+      role,
+      run_type,
+      design_id,
+      offset,
+      limit,
+      locale: req.locale,
+    },
   })
+
+  return res.status(200).json(result)
 }

--- a/apps/backend/src/workflows/designs/list-partner-designs.ts
+++ b/apps/backend/src/workflows/designs/list-partner-designs.ts
@@ -1,0 +1,334 @@
+import {
+  createStep,
+  createWorkflow,
+  StepResponse,
+  WorkflowResponse,
+  transform,
+} from "@medusajs/framework/workflows-sdk"
+import { ContainerRegistrationKeys } from "@medusajs/framework/utils"
+import designPartnersLink from "../../links/design-partners-link"
+import {
+  applyDesignListFilters,
+  type DesignBucket,
+} from "../../api/partners/designs/list-filters"
+
+// #843 — the partner designs listing, lifted out of `GET /partners/designs`
+// into a workflow so the admin inspection mirror (`GET /admin/partners/:id/
+// designs`) can run the *same* logic instead of re-deriving it. Re-deriving is
+// how two surfaces drift; the mirror is only useful if it cannot lie.
+//
+// The route keeps auth (resolve the partner from the bearer) and hands the rest
+// here. The admin proxy resolves the partner from `:id` and calls the same
+// workflow — that is the entire difference between the two surfaces.
+
+export type ListPartnerDesignsWorkflowInput = {
+  partnerId: string
+  q?: string
+  status?: string
+  bucket?: DesignBucket
+  offset: number
+  limit: number
+  /** Forwarded to `query.graph` for translated fields; the route reads it off the request. */
+  locale?: string
+}
+
+/**
+ * The partner-scoped design set: every design LINKED to the partner, plus every
+ * design the partner OWNS, deduped and sorted newest-first.
+ *
+ * Pagination is deliberately NOT applied here. `query.graph` cannot filter on
+ * the linked design's own columns (`design.status`) and the partner route has no
+ * free-text index, so status/`q` are matched in-app downstream. Slicing here
+ * would cut BEFORE the merge and those filters run, returning the wrong page and
+ * a per-page (not total) count — the #484 page-vs-set bug.
+ */
+export const resolvePartnerDesignRowsStep = createStep(
+  "resolve-partner-design-rows",
+  async (
+    input: { partnerId: string; locale?: string },
+    { container }
+  ) => {
+    const { partnerId, locale } = input
+    const query: any = container.resolve(ContainerRegistrationKeys.QUERY)
+
+    // Order newest-assigned first: the link row's `created_at` is when the
+    // design was assigned to (or created by) this partner. Without an explicit
+    // order the link query returns rows in an arbitrary order, so a freshly
+    // assigned design could fall past the `take` window and never reach page 1.
+    // Wrapped in a fallback so that if a runtime ever rejects `order` on a link
+    // entry point, the listing degrades to unordered instead of 500-ing.
+    const linkFields = ["created_at", "design.*", "design.tasks.*", "partner.*"]
+    let linkRows: any[] = []
+    try {
+      const { data } = await query.graph(
+        {
+          entity: designPartnersLink.entryPoint,
+          fields: linkFields,
+          filters: { partner_id: partnerId },
+          pagination: { skip: 0, take: 1000, order: { created_at: "DESC" } },
+        },
+        { locale }
+      )
+      linkRows = data
+    } catch {
+      const { data } = await query.graph(
+        {
+          entity: designPartnersLink.entryPoint,
+          fields: linkFields,
+          filters: { partner_id: partnerId },
+          pagination: { skip: 0, take: 1000 },
+        },
+        { locale }
+      )
+      linkRows = data
+    }
+
+    // Guard against orphaned link rows: a soft-deleted design resolves to a null
+    // `design` on the link join (e.g. after DELETE /partners/designs/:id), and
+    // the mapping downstream dereferences `design.*` — drop those so the listing
+    // doesn't 500.
+    const allLinked = (linkRows || [])
+      .filter((row: any) => !!row?.design)
+      .map((row: any) => ({
+        ...row,
+        _recency: row.created_at || row.design?.created_at || null,
+      }))
+
+    // Safety net: also pull designs this partner OWNS (created via self-serve).
+    // They ARE in the link table (POST creates the link), so the ordered query
+    // above already surfaces them — but if link ordering ever misses one, this
+    // guarantees a partner still sees what they created. Merged + re-sorted by
+    // recency below, never force-pinned. Always fetched (no offset gate):
+    // pagination happens downstream AFTER the merge, so gating this on
+    // offset === 0 would drop owned designs from every page but the first. #484.
+    let ownedRows: any[] = []
+    try {
+      const { data: owned } = await query.graph(
+        {
+          entity: "design",
+          filters: { owner_partner_id: partnerId } as any,
+          fields: ["*", "tasks.*"],
+          pagination: { skip: 0, take: 50, order: { created_at: "DESC" } },
+        },
+        { locale }
+      )
+      ownedRows = (owned || [])
+        .filter((d: any) => !!d?.id)
+        .map((d: any) => ({
+          design: d,
+          partner: { id: partnerId },
+          _recency: d.created_at || null,
+        }))
+    } catch {
+      // Non-fatal — owned designs still appear via the linked set.
+    }
+
+    // Merge linked + owned, deduped by design id, then sort newest-first so the
+    // most recently assigned/created design is always on top.
+    const seen = new Set<string>()
+    const merged: any[] = []
+    for (const item of [...allLinked, ...ownedRows]) {
+      const designId = item?.design?.id
+      if (!designId || seen.has(designId)) {
+        continue
+      }
+      seen.add(designId)
+      merged.push(item)
+    }
+    merged.sort((a: any, b: any) => {
+      const at = a._recency ? new Date(a._recency).getTime() : 0
+      const bt = b._recency ? new Date(b._recency).getTime() : 0
+      return bt - at
+    })
+
+    return new StepResponse(merged)
+  }
+)
+
+/**
+ * Every production run belonging to the partner, in one read rather than one
+ * per design. Production runs are the single source of truth for
+ * `partner_status`, so cancelled runs are included — a cancelled run is how a
+ * cancelled assignment is represented (there is no separate metadata marker).
+ */
+export const resolvePartnerDesignRunsStep = createStep(
+  "resolve-partner-design-runs",
+  async (
+    input: { partnerId: string; locale?: string },
+    { container }
+  ) => {
+    const query: any = container.resolve(ContainerRegistrationKeys.QUERY)
+    try {
+      const { data: runs } = await query.graph(
+        {
+          entity: "production_runs",
+          filters: { partner_id: input.partnerId },
+          fields: [
+            "id",
+            "design_id",
+            "status",
+            "accepted_at",
+            "started_at",
+            "finished_at",
+            "completed_at",
+            "created_at",
+          ],
+          pagination: { skip: 0, take: 200 },
+        },
+        { locale: input.locale }
+      )
+      return new StepResponse(runs || [])
+    } catch {
+      // Non-fatal: a design with no resolvable runs reads as "incoming".
+      return new StepResponse([] as any[])
+    }
+  }
+)
+
+/**
+ * Derive the partner-facing view of one design from its production runs.
+ *
+ * The legacy v1 fallback (cancel marker + `partner-design-*` task-status
+ * inference for run-less designs) was removed 2026-06-09 after the backfill
+ * migrated all marked designs onto production runs. A design with no runs is
+ * "incoming". See V1_PARTNER_DESIGN_REMOVAL_PLAN.md.
+ */
+const buildPartnerDesignView = (
+  linkData: any,
+  partnerId: string,
+  partnerRuns: any[]
+) => {
+  const design = linkData.design
+
+  const tasks = design.tasks || []
+  const isPartnerWorkflowTask = (t: any) =>
+    !!t &&
+    [
+      "partner-design-start",
+      "partner-design-redo",
+      "partner-design-finish",
+      "partner-design-completed",
+    ].includes(t.title)
+  const workflowTasks = tasks.filter(isPartnerWorkflowTask)
+
+  let partnerStatus:
+    | "incoming"
+    | "assigned"
+    | "in_progress"
+    | "awaiting_review"
+    | "finished"
+    | "completed"
+    | "cancelled" = "incoming"
+  const partnerPhase: "redo" | null = null
+  let partnerStartedAt: string | null = null
+  let partnerFinishedAt: string | null = null
+  let partnerCompletedAt: string | null = null
+
+  const runsForDesign = partnerRuns
+    .filter((r: any) => r.design_id === design.id)
+    .sort(
+      (a: any, b: any) =>
+        new Date(b.created_at || 0).getTime() -
+        new Date(a.created_at || 0).getTime()
+    )
+
+  if (runsForDesign.length > 0) {
+    const activeRun = runsForDesign.find(
+      (r: any) => !["completed", "cancelled"].includes(String(r.status))
+    )
+    if (activeRun) {
+      const runStatus = String(activeRun.status)
+      if (runStatus === "in_progress") {
+        partnerStatus = activeRun.finished_at
+          ? "awaiting_review"
+          : activeRun.started_at
+            ? "in_progress"
+            : "assigned"
+      } else {
+        partnerStatus = "assigned"
+      }
+      if (activeRun.started_at) partnerStartedAt = String(activeRun.started_at)
+      if (activeRun.finished_at) partnerFinishedAt = String(activeRun.finished_at)
+    } else {
+      const newest = runsForDesign[0]
+      const runStatus = String(newest.status)
+      if (runStatus === "completed") {
+        partnerStatus = "completed"
+        partnerCompletedAt = newest.completed_at
+          ? String(newest.completed_at)
+          : null
+        if (newest.finished_at) partnerFinishedAt = String(newest.finished_at)
+      } else if (runStatus === "cancelled") {
+        partnerStatus = "cancelled"
+      }
+    }
+  }
+
+  return {
+    ...design,
+    partner_info: {
+      assigned_partner_id: linkData.partner?.id || partnerId,
+      partner_status: partnerStatus,
+      partner_phase: partnerPhase,
+      partner_started_at: partnerStartedAt,
+      partner_finished_at: partnerFinishedAt,
+      partner_completed_at: partnerCompletedAt,
+      workflow_tasks_count: workflowTasks.length,
+    },
+    // Whether the partner in scope OWNS this design (vs merely being assigned
+    // to it). A bare truthiness check on `owner_partner_id` would mislabel a
+    // design owned by another partner but assigned to this one — #920.
+    is_owner:
+      design.owner_partner_id != null &&
+      design.owner_partner_id === partnerId,
+  }
+}
+
+export const listPartnerDesignsWorkflow = createWorkflow(
+  "list-partner-designs",
+  (input: ListPartnerDesignsWorkflowInput) => {
+    const rows = resolvePartnerDesignRowsStep({
+      partnerId: input.partnerId,
+      locale: input.locale,
+    })
+
+    const partnerRuns = resolvePartnerDesignRunsStep({
+      partnerId: input.partnerId,
+      locale: input.locale,
+    })
+
+    // status + free-text (`q`) filtering runs AFTER the mapping (so `q` can
+    // match the resolved design fields), THEN paginates — over the full
+    // partner-scoped set, so `count` is the total matched and the UI pager is
+    // correct. `applyDesignListFilters` is pure and unit-tested.
+    const output = transform(
+      { rows, partnerRuns, input },
+      ({ rows, partnerRuns, input }) => {
+        const mapped = (rows as any[]).map((row) =>
+          buildPartnerDesignView(row, input.partnerId, partnerRuns as any[])
+        )
+
+        const { items, count, facets } = applyDesignListFilters(mapped, {
+          q: input.q,
+          status: input.status,
+          bucket: input.bucket,
+          offset: input.offset,
+          limit: input.limit,
+        })
+
+        return {
+          designs: items,
+          count,
+          // #6 — per-bucket counts for the partner work tabs (accurate across
+          // all pages, computed over the full q+status set before the active
+          // bucket).
+          facets,
+          limit: input.limit,
+          offset: input.offset,
+        }
+      }
+    )
+
+    return new WorkflowResponse(output)
+  }
+)

--- a/apps/backend/src/workflows/production-runs/list-partner-production-runs.ts
+++ b/apps/backend/src/workflows/production-runs/list-partner-production-runs.ts
@@ -1,0 +1,131 @@
+import {
+  createStep,
+  createWorkflow,
+  StepResponse,
+  WorkflowResponse,
+  transform,
+} from "@medusajs/framework/workflows-sdk"
+import { ContainerRegistrationKeys } from "@medusajs/framework/utils"
+
+// #843 — the partner production-run listing, lifted out of
+// `GET /partners/production-runs` into a workflow so the admin inspection
+// mirror (`GET /admin/partners/:id/production-runs`) runs the *same* read
+// instead of re-deriving the scoping and field set. A divergence in either
+// would silently blank columns in the mirror or, worse, show an operator a
+// different set of runs than the partner sees.
+
+export type ListPartnerProductionRunsWorkflowInput = {
+  partnerId: string
+  status?: string
+  role?: string
+  run_type?: "production" | "sample"
+  design_id?: string
+  offset: number
+  limit: number
+  /** Forwarded to `query.graph` for translated fields; the route reads it off the request. */
+  locale?: string
+}
+
+/**
+ * The field set both surfaces read with. Kept in one place for the same reason
+ * `PARTNER_ORDER_LIST_FIELDS` is (#1175): two copies drift, and the drift is
+ * invisible until a column blanks out in the mirror.
+ */
+export const PARTNER_PRODUCTION_RUN_LIST_FIELDS = [
+  "id",
+  "status",
+  "run_type",
+  "quantity",
+  "role",
+  "design_id",
+  "partner_id",
+  "parent_run_id",
+  "product_id",
+  "variant_id",
+  "order_id",
+  "order_line_item_id",
+  "accepted_at",
+  "started_at",
+  "finished_at",
+  "completed_at",
+  "cancelled_at",
+  "cancelled_reason",
+  "finish_notes",
+  "completion_notes",
+  "partner_cost_estimate",
+  "cost_type",
+  "produced_quantity",
+  "rejected_quantity",
+  "rejection_reason",
+  "rejection_notes",
+  "depends_on_run_ids",
+  "metadata",
+  "created_at",
+  "updated_at",
+  "tasks.*",
+  // `order.id` resolves the order↔production_run link (#342 D5) so the design
+  // page can deep-link each run to its unified order detail (`/orders/:id`).
+  // NB: this is the LINK accessor, distinct from the plain legacy `order_id`
+  // column above (the original retail order line the run was created from).
+  "order.id",
+]
+
+export const listPartnerProductionRunsStep = createStep(
+  "list-partner-production-runs",
+  async (input: ListPartnerProductionRunsWorkflowInput, { container }) => {
+    const query: any = container.resolve(ContainerRegistrationKeys.QUERY)
+
+    const filters: any = { partner_id: input.partnerId }
+    if (input.status) {
+      filters.status = input.status
+    }
+    if (input.role) {
+      filters.role = input.role
+    }
+    if (input.run_type) {
+      filters.run_type = input.run_type
+    }
+    if (input.design_id) {
+      filters.design_id = input.design_id
+    }
+
+    const { data: runs, metadata } = await query.graph(
+      {
+        entity: "production_runs",
+        fields: PARTNER_PRODUCTION_RUN_LIST_FIELDS,
+        filters,
+        pagination: { skip: input.offset, take: input.limit },
+      },
+      { locale: input.locale }
+    )
+
+    return new StepResponse({
+      runs: runs || [],
+      count: (metadata as any)?.count ?? (runs || []).length,
+    })
+  }
+)
+
+export const listPartnerProductionRunsWorkflow = createWorkflow(
+  "list-partner-production-runs",
+  (input: ListPartnerProductionRunsWorkflowInput) => {
+    const listed = listPartnerProductionRunsStep(input)
+
+    const output = transform({ listed, input }, ({ listed, input }) => ({
+      // `unified_order_id` flattens the 1:1 order link, which `query.graph`
+      // resolves to either an object or a single-element array depending on the
+      // accessor — tolerate both rather than betting on one shape.
+      production_runs: (listed.runs as any[]).map((run: any) => ({
+        ...run,
+        unified_order_id: Array.isArray(run?.order)
+          ? run.order[0]?.id
+          : run?.order?.id,
+      })),
+      count: listed.count,
+      limit: input.limit,
+      offset: input.offset,
+    }))
+
+    return new WorkflowResponse(output)
+  }
+)

--- a/apps/backend/workflow-schemas.json
+++ b/apps/backend/workflow-schemas.json
@@ -2312,6 +2312,55 @@
     "source": "custom_ts",
     "sourceFile": "src/workflows/designs/get-design-tasks.ts"
   },
+  "list-partner-designs": {
+    "fields": [
+      {
+        "name": "partnerId",
+        "type": "string",
+        "required": true,
+        "placeholder": "{{ $last.partnerId }}"
+      },
+      {
+        "name": "q",
+        "type": "string",
+        "required": false,
+        "placeholder": "{{ $last.q }}"
+      },
+      {
+        "name": "status",
+        "type": "string",
+        "required": false,
+        "placeholder": "{{ $last.status }}"
+      },
+      {
+        "name": "bucket",
+        "type": "string",
+        "required": false,
+        "placeholder": "{{ $last.bucket }}"
+      },
+      {
+        "name": "offset",
+        "type": "number",
+        "required": true,
+        "placeholder": "0"
+      },
+      {
+        "name": "limit",
+        "type": "number",
+        "required": true,
+        "placeholder": "0"
+      },
+      {
+        "name": "locale",
+        "type": "string",
+        "required": false,
+        "placeholder": "{{ $last.locale }}",
+        "description": "Forwarded to `query.graph` for translated fields; the route reads it off the request."
+      }
+    ],
+    "source": "custom_ts",
+    "sourceFile": "src/workflows/designs/list-partner-designs.ts"
+  },
   "list-single-design": {
     "fields": [
       {
@@ -5948,6 +5997,61 @@
     ],
     "source": "inferred",
     "sourceFile": "src/workflows/production-runs/finish-production-run.ts"
+  },
+  "list-partner-production-runs": {
+    "fields": [
+      {
+        "name": "partnerId",
+        "type": "string",
+        "required": true,
+        "placeholder": "{{ $last.partnerId }}"
+      },
+      {
+        "name": "status",
+        "type": "string",
+        "required": false,
+        "placeholder": "{{ $last.status }}"
+      },
+      {
+        "name": "role",
+        "type": "string",
+        "required": false,
+        "placeholder": "{{ $last.role }}"
+      },
+      {
+        "name": "run_type",
+        "type": "string",
+        "required": false,
+        "placeholder": "{{ $last.run_type }}"
+      },
+      {
+        "name": "design_id",
+        "type": "id",
+        "required": false,
+        "placeholder": "{{ $last.design_id }}"
+      },
+      {
+        "name": "offset",
+        "type": "number",
+        "required": true,
+        "placeholder": "0"
+      },
+      {
+        "name": "limit",
+        "type": "number",
+        "required": true,
+        "placeholder": "0"
+      },
+      {
+        "name": "locale",
+        "type": "string",
+        "required": false,
+        "placeholder": "{{ $last.locale }}",
+        "description": "Forwarded to `query.graph` for translated fields; the route reads it off the request."
+      }
+    ],
+    "source": "custom_ts",
+    "sourceFile": "src/workflows/production-runs/list-partner-production-runs.ts"
   },
   "signal-lifecycle-step-success": {
     "fields": [


### PR DESCRIPTION
Second slice of #843's read-proxy console (#1175 was the first).

## Why the listings moved into workflows

#1175's orders mirror was cheap because `listPartnerOrdersWorkflow` already existed. Designs and production runs had no such seam — both listings sat inline in the partner route handler, and the designs one is substantial: linked + owned merge, dedup, recency sort, `partner_status` derived from the partner's production runs, bucket facets.

Hand-mirroring that admin-side would have meant a second copy of the exact logic the mirror exists to reflect. So the listings become workflows and both surfaces call them:

- **`list-partner-designs`** — steps for the partner-scoped row set (link table + owned designs) and the partner's runs, then the pure, already unit-tested `applyDesignListFilters` in a transform. Pagination deliberately stays *after* the merge and in-app filters, preserving the #484 page-vs-set fix.
- **`list-partner-production-runs`** — the scoped read plus `unified_order_id` flattening. Field set exported for the same reason `PARTNER_ORDER_LIST_FIELDS` is: two copies drift, and the drift is invisible until a column silently blanks in the mirror.

`GET /partners/designs` and `GET /partners/production-runs` now contribute auth and nothing else — behaviour unchanged, verified against their existing specs.

## The mirror

`GET /admin/partners/:id/designs` and `GET /admin/partners/:id/production-runs` resolve the partner from `:id` instead of a bearer and run the same workflows. That difference is the entire mirror. Both parse the *partner* query schema directly rather than declaring their own, so there is one query contract, not two that can drift.

Read-only: no write verb on either route, asserted in the spec.

## Admin UI

Top-level tabs are now the **surface** (Orders / Designs / Production runs); the order-`kind` discriminator is demoted to a sub-tab of Orders, the only place it means anything. Each panel owns its query, so switching surfaces doesn't refetch the others and one failing surface can't blank the whole section.

The design source badge keys on the per-viewer `is_owner` the proxy carries through — never an `owner_partner_id` truthiness check, which mislabels another partner's design as theirs (#920).

## Anti-drift guard

Extended rather than merely preserved. Each new surface asserts the admin proxy and the partner route return identical ids and counts — unfiltered, **and** under the `bucket` / `q` / `status` filters, which is where a re-implementation would realistically diverge. Seeded with real rows first; comparing two empty lists would pass against a completely broken mirror.

## Side effect worth noting

Both workflows now appear in `workflow-schemas.json`, so they are selectable as visual-flow nodes — see #1180.

## Verify

- `pnpm test:integration:http:shared ./integration-tests/http/admin-partner-inspection` → **21/21**
- Partner-side regression: `partners-production-runs`, `partner-design-crud`, `partners-decline-run`, `design-production-runs-multi-partner`, `partner-production-run-create` → all green
- `pnpm run check:prod-build` → pass
- `tsc --noEmit` unchanged at the 79-error baseline recorded in #1179 (no new errors)

🤖 Generated with [Claude Code](https://claude.com/claude-code)