### PR TITLE
feat(admin,partners): inspection mirror for products + inventory [#843]

### DIFF
--- a/apps/backend/integration-tests/http/admin-partner-inspection.spec.ts
+++ b/apps/backend/integration-tests/http/admin-partner-inspection.spec.ts
@@ -137,6 +137,182 @@ setupSharedTestSuite(() => {
       })
     })
 
+    describe("GET /admin/partners/:id/products", () => {
+      // Provision a store (with its default sales channel) and put a product in
+      // it. The partner catalog is sales-channel-scoped, so without a real store
+      // + product both surfaces return empty and the mirror comparison would
+      // pass against a broken proxy.
+      const provisionStoreWithProduct = async () => {
+        const unique = Date.now() + Math.random().toString(36).slice(2, 6)
+
+        const currenciesRes = await api.get("/admin/currencies", adminHeaders)
+        const currencies = currenciesRes.data.currencies || []
+        const usd = currencies.find((c: any) => c.code?.toLowerCase() === "usd")
+        const currencyCode = String((usd || currencies[0]).code).toLowerCase()
+
+        const storeRes = await api.post(
+          "/partners/stores",
+          {
+            store: {
+              name: `InspectStore ${unique}`,
+              supported_currencies: [
+                { currency_code: currencyCode, is_default: true },
+              ],
+            },
+            sales_channel: {
+              name: `InspectChannel ${unique}`,
+              description: "Default",
+            },
+            region: {
+              name: "Default Region",
+              currency_code: currencyCode,
+              countries: ["us"],
+            },
+            location: {
+              name: "Warehouse",
+              address: {
+                address_1: "1 Main St",
+                city: "NY",
+                postal_code: "10001",
+                country_code: "US",
+              },
+            },
+          },
+          { headers: partner.headers }
+        )
+        const storeId = storeRes.data.store.id
+
+        const productRes = await api.post(
+          `/partners/stores/${storeId}/products`,
+          {
+            title: `Inspect Product ${unique}`,
+            handle: `inspect-prod-${unique}`,
+            status: "published",
+            options: [{ title: "Color", values: ["Red"] }],
+            variants: [
+              {
+                title: "Red",
+                sku: `INSPECT-SKU-${unique}`,
+                options: { Color: "Red" },
+                prices: [{ amount: 1500, currency_code: currencyCode }],
+              },
+            ],
+          },
+          { headers: partner.headers }
+        )
+
+        return { storeId, productId: productRes.data.product?.id }
+      }
+
+      it("mirrors GET /partners/stores/:id/products — same ids and count", async () => {
+        const { storeId, productId } = await provisionStoreWithProduct()
+        expect(productId).toBeTruthy()
+
+        const viaAdmin = await api.get(
+          `/admin/partners/${partner.partnerId}/products`,
+          adminHeaders
+        )
+        const viaPartner = await api.get(
+          `/partners/stores/${storeId}/products`,
+          { headers: partner.headers }
+        )
+
+        expect(viaAdmin.status).toBe(200)
+        expect(viaAdmin.data.count).toBe(viaPartner.data.count)
+        expect(viaAdmin.data.products.map((p: any) => p.id)).toEqual(
+          viaPartner.data.products.map((p: any) => p.id)
+        )
+        expect(viaAdmin.data.products.length).toBeGreaterThan(0)
+        expect(viaAdmin.data.store_id).toBe(storeId)
+      })
+
+      it("mirrors an explicitly selected store", async () => {
+        const { storeId } = await provisionStoreWithProduct()
+
+        const viaAdmin = await api.get(
+          `/admin/partners/${partner.partnerId}/products?store_id=${storeId}`,
+          adminHeaders
+        )
+        const viaPartner = await api.get(
+          `/partners/stores/${storeId}/products`,
+          { headers: partner.headers }
+        )
+
+        expect(viaAdmin.data.count).toBe(viaPartner.data.count)
+        expect(viaAdmin.data.products.map((p: any) => p.id)).toEqual(
+          viaPartner.data.products.map((p: any) => p.id)
+        )
+      })
+
+      it("scopes to the partner — another partner's catalog never leaks in", async () => {
+        const { productId } = await provisionStoreWithProduct()
+        const other = await createPartner(api)
+
+        const res = await api.get(
+          `/admin/partners/${other.partnerId}/products`,
+          adminHeaders
+        )
+
+        expect(res.status).toBe(200)
+        expect(
+          res.data.products.some((p: any) => p.id === productId)
+        ).toBe(false)
+      })
+
+      it("404s on a store belonging to someone else, not a partner-voiced 401", async () => {
+        const { storeId } = await provisionStoreWithProduct()
+        const other = await createPartner(api)
+
+        const err = await api
+          .get(
+            `/admin/partners/${other.partnerId}/products?store_id=${storeId}`,
+            adminHeaders
+          )
+          .catch((e: any) => e)
+
+        expect(err.response.status).toBe(404)
+      })
+
+      it("returns an empty catalog for a partner with no store yet", async () => {
+        const res = await api.get(
+          `/admin/partners/${partner.partnerId}/products`,
+          adminHeaders
+        )
+
+        expect(res.status).toBe(200)
+        expect(res.data.products).toHaveLength(0)
+        expect(res.data.store_id).toBeNull()
+      })
+
+      it("404s for an unknown partner", async () => {
+        const err = await api
+          .get("/admin/partners/partner_does_not_exist/products", adminHeaders)
+          .catch((e: any) => e)
+
+        expect(err.response.status).toBe(404)
+      })
+
+      it("requires admin auth", async () => {
+        const err = await api
+          .get(`/admin/partners/${partner.partnerId}/products`)
+          .catch((e: any) => e)
+
+        expect(err.response.status).toBe(401)
+      })
+
+      it("is read-only — no write verb is exposed", async () => {
+        const err = await api
+          .post(
+            `/admin/partners/${partner.partnerId}/products`,
+            {},
+            adminHeaders
+          )
+          .catch((e: any) => e)
+
+        expect(err.response.status).toBe(404)
+      })
+    })
+
     describe("GET /admin/partners/:id/onboarding-profile", () => {
       it("returns null when the partner never started the wizard", async () => {
         const res = await api.get(

--- a/apps/backend/integration-tests/http/admin-partner-inspection.spec.ts
+++ b/apps/backend/integration-tests/http/admin-partner-inspection.spec.ts
@@ -224,6 +224,7 @@ setupSharedTestSuite(() => {
         )
         expect(viaAdmin.data.products.length).toBeGreaterThan(0)
         expect(viaAdmin.data.store_id).toBe(storeId)
+        expect(viaAdmin.data.partner_id).toBe(partner.partnerId)
       })
 
       it("mirrors an explicitly selected store", async () => {

--- a/apps/backend/integration-tests/http/admin-partner-inspection.spec.ts
+++ b/apps/backend/integration-tests/http/admin-partner-inspection.spec.ts
@@ -137,15 +137,15 @@ setupSharedTestSuite(() => {
       })
     })
 
-    describe("GET /admin/partners/:id/products", () => {
-      // Provision a store (with its default sales channel) and put a product in
-      // it. The partner catalog is sales-channel-scoped, so without a real store
-      // + product both surfaces return empty and the mirror comparison would
-      // pass against a broken proxy.
-      const provisionStoreWithProduct = async () => {
-        const unique = Date.now() + Math.random().toString(36).slice(2, 6)
+    // Provision a store (with its default sales channel and stock location) and
+    // put a product in it. The partner catalog is sales-channel-scoped and the
+    // inventory surface is location-scoped, so without a real store both
+    // surfaces return empty and a mirror comparison would pass against a
+    // broken proxy — two empty lists always agree.
+    const provisionStoreWithProduct = async () => {
+      const unique = Date.now() + Math.random().toString(36).slice(2, 6)
 
-        const currenciesRes = await api.get("/admin/currencies", adminHeaders)
+      const currenciesRes = await api.get("/admin/currencies", adminHeaders)
         const currencies = currenciesRes.data.currencies || []
         const usd = currencies.find((c: any) => c.code?.toLowerCase() === "usd")
         const currencyCode = String((usd || currencies[0]).code).toLowerCase()
@@ -202,8 +202,9 @@ setupSharedTestSuite(() => {
         )
 
         return { storeId, productId: productRes.data.product?.id }
-      }
+    }
 
+    describe("GET /admin/partners/:id/products", () => {
       it("mirrors GET /partners/stores/:id/products — same ids and count", async () => {
         const { storeId, productId } = await provisionStoreWithProduct()
         expect(productId).toBeTruthy()
@@ -306,6 +307,240 @@ setupSharedTestSuite(() => {
           .post(
             `/admin/partners/${partner.partnerId}/products`,
             {},
+            adminHeaders
+          )
+          .catch((e: any) => e)
+
+        expect(err.response.status).toBe(404)
+      })
+    })
+
+    describe("GET /admin/partners/:id/inventory-orders", () => {
+      it("mirrors GET /partners/inventory-orders — same ids and count", async () => {
+        const viaAdmin = await api.get(
+          `/admin/partners/${partner.partnerId}/inventory-orders`,
+          adminHeaders
+        )
+        const viaPartner = await api.get("/partners/inventory-orders", {
+          headers: partner.headers,
+        })
+
+        expect(viaAdmin.status).toBe(200)
+        expect(viaAdmin.data.count).toBe(viaPartner.data.count)
+        expect(viaAdmin.data.inventory_orders.map((o: any) => o.id)).toEqual(
+          viaPartner.data.inventory_orders.map((o: any) => o.id)
+        )
+      })
+
+      it("mirrors the status + q filters, not just the unfiltered list", async () => {
+        // Filters are where a re-implementation diverges, so they are checked
+        // even when the set is empty for this partner — an admin-side filter
+        // that silently ignored `status` would still show up as a count or id
+        // mismatch the moment rows exist.
+        // `Pending`, capitalised — the status enum is the canonical set in
+        // modules/inventory_orders/constants.ts, and lowercase is rejected.
+        for (const qs of ["status=Pending", "q=warehouse", "limit=5&offset=0"]) {
+          const viaAdmin = await api.get(
+            `/admin/partners/${partner.partnerId}/inventory-orders?${qs}`,
+            adminHeaders
+          )
+          const viaPartner = await api.get(
+            `/partners/inventory-orders?${qs}`,
+            { headers: partner.headers }
+          )
+
+          expect(viaAdmin.data.count).toBe(viaPartner.data.count)
+          expect(viaAdmin.data.inventory_orders.map((o: any) => o.id)).toEqual(
+            viaPartner.data.inventory_orders.map((o: any) => o.id)
+          )
+        }
+      })
+
+      it("rejects an invalid status exactly as the partner surface does", async () => {
+        // The mirror must not be MORE PERMISSIVE than what it mirrors. This
+        // caught a real bug: the proxy first parsed the loose schema in
+        // `partners/inventory-orders/validators.ts` (status: string) while the
+        // partner matcher validates with the admin schema (status: enum), so
+        // `?status=pending` returned 200 here and 400 there.
+        const viaAdmin = await api
+          .get(
+            `/admin/partners/${partner.partnerId}/inventory-orders?status=pending`,
+            adminHeaders
+          )
+          .catch((e: any) => e)
+        const viaPartner = await api
+          .get("/partners/inventory-orders?status=pending", {
+            headers: partner.headers,
+          })
+          .catch((e: any) => e)
+
+        expect(viaAdmin.response.status).toBe(400)
+        expect(viaPartner.response.status).toBe(400)
+      })
+
+      it("echoes the pagination contract", async () => {
+        const res = await api.get(
+          `/admin/partners/${partner.partnerId}/inventory-orders?limit=5&offset=0`,
+          adminHeaders
+        )
+
+        expect(res.status).toBe(200)
+        expect(res.data.limit).toBe(5)
+        expect(res.data.offset).toBe(0)
+      })
+
+      it("404s for an unknown partner", async () => {
+        const err = await api
+          .get(
+            "/admin/partners/partner_does_not_exist/inventory-orders",
+            adminHeaders
+          )
+          .catch((e: any) => e)
+
+        expect(err.response.status).toBe(404)
+      })
+
+      it("requires admin auth", async () => {
+        const err = await api
+          .get(`/admin/partners/${partner.partnerId}/inventory-orders`)
+          .catch((e: any) => e)
+
+        expect(err.response.status).toBe(401)
+      })
+
+      it("is read-only — no write verb is exposed", async () => {
+        const err = await api
+          .post(
+            `/admin/partners/${partner.partnerId}/inventory-orders`,
+            {},
+            adminHeaders
+          )
+          .catch((e: any) => e)
+
+        expect(err.response.status).toBe(404)
+      })
+    })
+
+    describe("GET /admin/partners/:id/inventory-items", () => {
+      // Seed real stock: the store gives the partner a location, and the
+      // partner's own POST creates the item plus a level at that location.
+      // Without it both surfaces return empty and agree for the wrong reason.
+      const seedStock = async () => {
+        await provisionStoreWithProduct()
+        const unique = Date.now() + Math.random().toString(36).slice(2, 6)
+        const created = await api.post(
+          "/partners/inventory-items",
+          { sku: `INSPECT-INV-${unique}`, title: `Inspect Item ${unique}` },
+          { headers: partner.headers }
+        )
+        return created.data.inventory_item?.id
+      }
+
+      it("mirrors GET /partners/inventory-items — same ids and count", async () => {
+        const itemId = await seedStock()
+        expect(itemId).toBeTruthy()
+
+        const viaAdmin = await api.get(
+          `/admin/partners/${partner.partnerId}/inventory-items`,
+          adminHeaders
+        )
+        const viaPartner = await api.get("/partners/inventory-items", {
+          headers: partner.headers,
+        })
+
+        expect(viaAdmin.status).toBe(200)
+        expect(viaAdmin.data.count).toBe(viaPartner.data.count)
+        expect(viaAdmin.data.inventory_items.map((i: any) => i.id)).toEqual(
+          viaPartner.data.inventory_items.map((i: any) => i.id)
+        )
+        expect(
+          viaAdmin.data.inventory_items.some((i: any) => i.id === itemId)
+        ).toBe(true)
+      })
+
+      it("carries the location-scoped quantity aggregation through the proxy", async () => {
+        // The top-level quantities are computed by the workflow (the inventory
+        // service returns them null), and they are location-scoped — a global
+        // figure here would be a different, misleading number.
+        await seedStock()
+
+        const res = await api.get(
+          `/admin/partners/${partner.partnerId}/inventory-items`,
+          adminHeaders
+        )
+
+        const item = res.data.inventory_items[0]
+        expect(item).toBeTruthy()
+        expect(typeof item.stocked_quantity).toBe("number")
+        expect(Array.isArray(item.location_levels)).toBe(true)
+      })
+
+      it("scopes to the partner — another partner's stock never leaks in", async () => {
+        const itemId = await seedStock()
+        const other = await createPartner(api)
+
+        const res = await api.get(
+          `/admin/partners/${other.partnerId}/inventory-items`,
+          adminHeaders
+        )
+
+        expect(res.status).toBe(200)
+        expect(
+          res.data.inventory_items.some((i: any) => i.id === itemId)
+        ).toBe(false)
+      })
+
+      it("returns an empty list for a partner with no store or location", async () => {
+        const res = await api.get(
+          `/admin/partners/${partner.partnerId}/inventory-items`,
+          adminHeaders
+        )
+
+        expect(res.status).toBe(200)
+        expect(res.data.inventory_items).toHaveLength(0)
+        expect(res.data.count).toBe(0)
+      })
+
+      it("mirrors the q filter", async () => {
+        const viaAdmin = await api.get(
+          `/admin/partners/${partner.partnerId}/inventory-items?q=nothingmatches`,
+          adminHeaders
+        )
+        const viaPartner = await api.get(
+          "/partners/inventory-items?q=nothingmatches",
+          { headers: partner.headers }
+        )
+
+        expect(viaAdmin.data.count).toBe(viaPartner.data.count)
+        expect(viaAdmin.data.inventory_items.map((i: any) => i.id)).toEqual(
+          viaPartner.data.inventory_items.map((i: any) => i.id)
+        )
+      })
+
+      it("404s for an unknown partner", async () => {
+        const err = await api
+          .get(
+            "/admin/partners/partner_does_not_exist/inventory-items",
+            adminHeaders
+          )
+          .catch((e: any) => e)
+
+        expect(err.response.status).toBe(404)
+      })
+
+      it("requires admin auth", async () => {
+        const err = await api
+          .get(`/admin/partners/${partner.partnerId}/inventory-items`)
+          .catch((e: any) => e)
+
+        expect(err.response.status).toBe(401)
+      })
+
+      it("is read-only — the partner route's POST is NOT mirrored", async () => {
+        const err = await api
+          .post(
+            `/admin/partners/${partner.partnerId}/inventory-items`,
+            { sku: "SHOULD-NOT-EXIST" },
             adminHeaders
           )
           .catch((e: any) => e)

--- a/apps/backend/integration-tests/http/partner-store-products-api.spec.ts
+++ b/apps/backend/integration-tests/http/partner-store-products-api.spec.ts
@@ -121,6 +121,11 @@ setupSharedTestSuite(() => {
         const products = res.data.products || []
         expect(Array.isArray(products)).toBe(true)
         expect(products.length).toBeGreaterThanOrEqual(1)
+        // The payload is now shaped by `list-store-products` itself so the admin
+        // inspection mirror serves the identical body (#843); `store_id` says
+        // which store the catalog came from.
+        expect(res.data.count).toBe(products.length)
+        expect(res.data.store_id).toBe(partner.storeId)
       })
 
       it("POST /partners/stores/:id/products/quick creates product + variant + price + stock in one shot", async () => {

--- a/apps/backend/integration-tests/http/partners-products.spec.ts
+++ b/apps/backend/integration-tests/http/partners-products.spec.ts
@@ -166,8 +166,9 @@ setupSharedTestSuite(() => {
       expect(listRes.data.store_id).toBe(storeId)
       const products = listRes.data.products || []
       expect(Array.isArray(products)).toBe(true)
-      // Ensure the created product is present in listing
-      expect(products.some((p: any) => p?.product?.id === product.id)).toBe(true)
+      // Ensure the created product is present in listing — the listing returns
+      // products, not link rows (see the note in the isolation test below).
+      expect(products.some((p: any) => p?.id === product.id)).toBe(true)
     })
 
     it("isolates products and store access across multiple partners", async () => {

--- a/apps/backend/integration-tests/http/partners-products.spec.ts
+++ b/apps/backend/integration-tests/http/partners-products.spec.ts
@@ -283,16 +283,20 @@ setupSharedTestSuite(() => {
       // Partner 1 listing must only include P1
       const p1List = await api.get(`/partners/stores/${storeId}/products`, { headers: partnerHeaders })
       expect(p1List.status).toBe(200)
+      // The listing returns PRODUCTS, not link rows — `p.product.id` was a stale
+      // read of an older payload, and since it could only ever be undefined both
+      // `some()` calls were false. It went unnoticed because CI runs only the
+      // spec files a PR changes, so this one had not run in a long time.
       const p1Products = p1List.data.products || []
-      expect(p1Products.some((l: any) => l?.product?.id === p1Product.id)).toBe(true)
-      expect(p1Products.some((l: any) => l?.product?.id === p2Product.id)).toBe(false)
+      expect(p1Products.some((p: any) => p?.id === p1Product.id)).toBe(true)
+      expect(p1Products.some((p: any) => p?.id === p2Product.id)).toBe(false)
 
       // Partner 2 listing must only include P2
       const p2List = await api.get(`/partners/stores/${store2Id}/products`, { headers: partner2Headers })
       expect(p2List.status).toBe(200)
       const p2Products = p2List.data.products || []
-      expect(p2Products.some((l: any) => l?.product?.id === p2Product.id)).toBe(true)
-      expect(p2Products.some((l: any) => l?.product?.id === p1Product.id)).toBe(false)
+      expect(p2Products.some((p: any) => p?.id === p2Product.id)).toBe(true)
+      expect(p2Products.some((p: any) => p?.id === p1Product.id)).toBe(false)
 
       // Cross-access should be unauthorized
       const cross1 = await api.get(`/partners/stores/${store2Id}/products`, { headers: partnerHeaders, validateStatus: () => true })

--- a/apps/backend/src/admin/components/partners/partner-inspection-section.tsx
+++ b/apps/backend/src/admin/components/partners/partner-inspection-section.tsx
@@ -8,8 +8,9 @@
  * Read-only by construction: no action menus, no mutations. Acting on a
  * partner's behalf is the separate audited-impersonation track.
  *
- * The top-level tabs are the SURFACE (orders / designs / runs); the order-kind
- * discriminator is a sub-tab of Orders, since it only means anything there.
+ * The top-level tabs are the SURFACE (orders / designs / runs / products); the
+ * order-kind discriminator is a sub-tab of Orders, since it only means anything
+ * there.
  */
 import { Badge, Container, Heading, Table, Tabs, Text } from "@medusajs/ui"
 import { useState } from "react"
@@ -21,6 +22,7 @@ import {
   usePartnerInspectionDesigns,
   usePartnerInspectionOrders,
   usePartnerInspectionProductionRuns,
+  usePartnerInspectionProducts,
   usePartnerOnboardingProfile,
 } from "../../hooks/api/partner-inspection"
 
@@ -28,12 +30,13 @@ interface PartnerInspectionSectionProps {
   partnerId: string
 }
 
-type InspectionSurface = "orders" | "designs" | "runs"
+type InspectionSurface = "orders" | "designs" | "runs" | "products"
 
 const SURFACES: { value: InspectionSurface; label: string }[] = [
   { value: "orders", label: "Orders" },
   { value: "designs", label: "Designs" },
   { value: "runs", label: "Production runs" },
+  { value: "products", label: "Products" },
 ]
 
 const KINDS: { value: PartnerOrderKind; label: string }[] = [
@@ -389,6 +392,90 @@ const ProductionRunsPanel = ({ partnerId }: { partnerId: string }) => {
   )
 }
 
+const ProductsPanel = ({ partnerId }: { partnerId: string }) => {
+  const { products, storeId, isLoading, isError, error } =
+    usePartnerInspectionProducts(partnerId)
+
+  if (isError) {
+    throw error
+  }
+
+  if (isLoading) {
+    return <LoadingRows />
+  }
+
+  // No store at all is a different fact from an empty catalog, and it is the
+  // one an operator can act on (it's what the onboarding flow fixes) — so say
+  // which it is rather than showing the same "nothing here" for both.
+  if (!storeId) {
+    return (
+      <EmptyRow>
+        This partner has not provisioned a store yet — no catalog to show.
+      </EmptyRow>
+    )
+  }
+
+  if (products.length === 0) {
+    return <EmptyRow>No products in this partner&apos;s store</EmptyRow>
+  }
+
+  return (
+    <div className="overflow-x-auto">
+      <Table className="w-full">
+        <Table.Header>
+          <Table.Row>
+            <Table.HeaderCell>Product</Table.HeaderCell>
+            <Table.HeaderCell>Handle</Table.HeaderCell>
+            <Table.HeaderCell>Status</Table.HeaderCell>
+            <Table.HeaderCell>Collection</Table.HeaderCell>
+            <Table.HeaderCell className="text-right">Variants</Table.HeaderCell>
+            <Table.HeaderCell className="text-right">Created</Table.HeaderCell>
+          </Table.Row>
+        </Table.Header>
+        <Table.Body>
+          {products.map((product) => (
+            <Table.Row key={product.id}>
+              <Table.Cell>
+                <Link
+                  to={`/products/${product.id}`}
+                  className="text-ui-fg-interactive"
+                >
+                  {product.title || product.id}
+                </Link>
+              </Table.Cell>
+              <Table.Cell>
+                <Text size="small" className="text-ui-fg-subtle">
+                  {product.handle || "—"}
+                </Text>
+              </Table.Cell>
+              <Table.Cell>
+                <Badge size="2xsmall" color={statusColor(product.status)}>
+                  {product.status || "—"}
+                </Badge>
+              </Table.Cell>
+              <Table.Cell>
+                <Text size="small" className="text-ui-fg-subtle">
+                  {product.collection?.title || "—"}
+                </Text>
+              </Table.Cell>
+              <Table.Cell className="text-right">
+                <Text size="small" className="text-ui-fg-subtle">
+                  {product.variants?.length ?? 0}
+                </Text>
+              </Table.Cell>
+              <Table.Cell className="text-right">
+                <Text size="small" className="text-ui-fg-subtle">
+                  {formatDate(product.created_at)}
+                </Text>
+              </Table.Cell>
+            </Table.Row>
+          ))}
+        </Table.Body>
+      </Table>
+    </div>
+  )
+}
+
 export const PartnerInspectionSection = ({
   partnerId,
 }: PartnerInspectionSectionProps) => {
@@ -426,6 +513,7 @@ export const PartnerInspectionSection = ({
       {surface === "orders" && <OrdersPanel partnerId={partnerId} />}
       {surface === "designs" && <DesignsPanel partnerId={partnerId} />}
       {surface === "runs" && <ProductionRunsPanel partnerId={partnerId} />}
+      {surface === "products" && <ProductsPanel partnerId={partnerId} />}
 
       <div className="px-6 py-4">
         <Text size="small" weight="plus" className="mb-2">

--- a/apps/backend/src/admin/components/partners/partner-inspection-section.tsx
+++ b/apps/backend/src/admin/components/partners/partner-inspection-section.tsx
@@ -23,6 +23,8 @@ import {
   usePartnerInspectionOrders,
   usePartnerInspectionProductionRuns,
   usePartnerInspectionProducts,
+  usePartnerInspectionInventoryItems,
+  usePartnerInspectionInventoryOrders,
   usePartnerOnboardingProfile,
 } from "../../hooks/api/partner-inspection"
 
@@ -30,13 +32,27 @@ interface PartnerInspectionSectionProps {
   partnerId: string
 }
 
-type InspectionSurface = "orders" | "designs" | "runs" | "products"
+type InspectionSurface =
+  | "orders"
+  | "designs"
+  | "runs"
+  | "products"
+  | "inventory"
 
 const SURFACES: { value: InspectionSurface; label: string }[] = [
   { value: "orders", label: "Orders" },
   { value: "designs", label: "Designs" },
   { value: "runs", label: "Production runs" },
   { value: "products", label: "Products" },
+  { value: "inventory", label: "Inventory" },
+]
+
+/** Inventory splits two ways the partner portal itself splits them. */
+type InventoryView = "items" | "orders"
+
+const INVENTORY_VIEWS: { value: InventoryView; label: string }[] = [
+  { value: "items", label: "Stock" },
+  { value: "orders", label: "Inventory orders" },
 ]
 
 const KINDS: { value: PartnerOrderKind; label: string }[] = [
@@ -476,6 +492,178 @@ const ProductsPanel = ({ partnerId }: { partnerId: string }) => {
   )
 }
 
+const InventoryItemsTable = ({ partnerId }: { partnerId: string }) => {
+  const { inventoryItems, isLoading, isError, error } =
+    usePartnerInspectionInventoryItems(partnerId, { limit: PAGE_SIZE })
+
+  if (isError) {
+    throw error
+  }
+
+  if (isLoading) {
+    return <LoadingRows />
+  }
+
+  if (inventoryItems.length === 0) {
+    return <EmptyRow>No stock at this partner&apos;s location</EmptyRow>
+  }
+
+  return (
+    <div className="overflow-x-auto">
+      <Table className="w-full">
+        <Table.Header>
+          <Table.Row>
+            <Table.HeaderCell>Item</Table.HeaderCell>
+            <Table.HeaderCell>SKU</Table.HeaderCell>
+            <Table.HeaderCell className="text-right">Stocked</Table.HeaderCell>
+            <Table.HeaderCell className="text-right">Reserved</Table.HeaderCell>
+            <Table.HeaderCell className="text-right">Incoming</Table.HeaderCell>
+          </Table.Row>
+        </Table.Header>
+        <Table.Body>
+          {inventoryItems.map((item) => (
+            <Table.Row key={item.id}>
+              <Table.Cell>
+                <Link
+                  to={`/inventory/${item.id}`}
+                  className="text-ui-fg-interactive"
+                >
+                  {item.title || item.sku || item.id}
+                </Link>
+              </Table.Cell>
+              <Table.Cell>
+                <Text size="small" className="text-ui-fg-subtle">
+                  {item.sku || "—"}
+                </Text>
+              </Table.Cell>
+              {/* Quantities are aggregated over the partner's location only —
+                  the global figure would be a different (and misleading)
+                  number here. */}
+              <Table.Cell className="text-right">
+                <Text size="small">{item.stocked_quantity ?? 0}</Text>
+              </Table.Cell>
+              <Table.Cell className="text-right">
+                <Text size="small" className="text-ui-fg-subtle">
+                  {item.reserved_quantity ?? 0}
+                </Text>
+              </Table.Cell>
+              <Table.Cell className="text-right">
+                <Text size="small" className="text-ui-fg-subtle">
+                  {item.incoming_quantity ?? 0}
+                </Text>
+              </Table.Cell>
+            </Table.Row>
+          ))}
+        </Table.Body>
+      </Table>
+    </div>
+  )
+}
+
+const InventoryOrdersTable = ({ partnerId }: { partnerId: string }) => {
+  const { inventoryOrders, isLoading, isError, error } =
+    usePartnerInspectionInventoryOrders(partnerId, { limit: PAGE_SIZE })
+
+  if (isError) {
+    throw error
+  }
+
+  if (isLoading) {
+    return <LoadingRows />
+  }
+
+  if (inventoryOrders.length === 0) {
+    return <EmptyRow>No inventory orders assigned to this partner</EmptyRow>
+  }
+
+  return (
+    <div className="overflow-x-auto">
+      <Table className="w-full">
+        <Table.Header>
+          <Table.Row>
+            <Table.HeaderCell>Order</Table.HeaderCell>
+            <Table.HeaderCell>Location</Table.HeaderCell>
+            <Table.HeaderCell>Partner status</Table.HeaderCell>
+            <Table.HeaderCell>Order status</Table.HeaderCell>
+            <Table.HeaderCell className="text-right">Qty</Table.HeaderCell>
+            <Table.HeaderCell className="text-right">Expected</Table.HeaderCell>
+          </Table.Row>
+        </Table.Header>
+        <Table.Body>
+          {inventoryOrders.map((order) => (
+            <Table.Row key={order.id}>
+              <Table.Cell>
+                <Link
+                  to={`/inventory-orders/${order.id}`}
+                  className="text-ui-fg-interactive"
+                >
+                  {order.id}
+                </Link>
+              </Table.Cell>
+              <Table.Cell>
+                <Text size="small" className="text-ui-fg-subtle">
+                  {order.stock_location || "—"}
+                </Text>
+              </Table.Cell>
+              <Table.Cell>
+                {/* Derived from the partner_assignment tasks — this is the
+                    column an operator opens this surface for. */}
+                <Badge
+                  size="2xsmall"
+                  color={statusColor(order.partner_info?.partner_status)}
+                >
+                  {order.partner_info?.partner_status || "—"}
+                </Badge>
+              </Table.Cell>
+              <Table.Cell>
+                <Text size="small" className="text-ui-fg-subtle">
+                  {order.status || "—"}
+                </Text>
+              </Table.Cell>
+              <Table.Cell className="text-right">
+                <Text size="small" className="text-ui-fg-subtle">
+                  {order.quantity ?? "—"}
+                </Text>
+              </Table.Cell>
+              <Table.Cell className="text-right">
+                <Text size="small" className="text-ui-fg-subtle">
+                  {formatDate(order.expected_delivery_date)}
+                </Text>
+              </Table.Cell>
+            </Table.Row>
+          ))}
+        </Table.Body>
+      </Table>
+    </div>
+  )
+}
+
+const InventoryPanel = ({ partnerId }: { partnerId: string }) => {
+  const [view, setView] = useState<InventoryView>("items")
+
+  return (
+    <>
+      <div className="px-6 py-4">
+        <Tabs value={view} onValueChange={(v) => setView(v as InventoryView)}>
+          <Tabs.List>
+            {INVENTORY_VIEWS.map((v) => (
+              <Tabs.Trigger key={v.value} value={v.value}>
+                {v.label}
+              </Tabs.Trigger>
+            ))}
+          </Tabs.List>
+        </Tabs>
+      </div>
+
+      {view === "items" ? (
+        <InventoryItemsTable partnerId={partnerId} />
+      ) : (
+        <InventoryOrdersTable partnerId={partnerId} />
+      )}
+    </>
+  )
+}
+
 export const PartnerInspectionSection = ({
   partnerId,
 }: PartnerInspectionSectionProps) => {
@@ -514,6 +702,7 @@ export const PartnerInspectionSection = ({
       {surface === "designs" && <DesignsPanel partnerId={partnerId} />}
       {surface === "runs" && <ProductionRunsPanel partnerId={partnerId} />}
       {surface === "products" && <ProductsPanel partnerId={partnerId} />}
+      {surface === "inventory" && <InventoryPanel partnerId={partnerId} />}
 
       <div className="px-6 py-4">
         <Text size="small" weight="plus" className="mb-2">

--- a/apps/backend/src/admin/hooks/api/partner-inspection.ts
+++ b/apps/backend/src/admin/hooks/api/partner-inspection.ts
@@ -2,7 +2,8 @@
  * Read-only hooks for the partner inspection mirror (#843, approach #2).
  *
  * These hit the admin read-proxy routes (`/admin/partners/:id/{orders, designs,
- * production-runs, products, onboarding-profile}`), which run the partner portal's own
+ * production-runs, products, inventory-items, inventory-orders,
+ * onboarding-profile}`), which run the partner portal's own
  * scoping helpers and listing workflows against a synthesized partner context —
  * so what renders here is what the partner sees. There are deliberately no
  * mutation hooks in this file.
@@ -262,6 +263,118 @@ export const usePartnerInspectionProducts = (
     products: data?.products || [],
     count: data?.count || 0,
     storeId: data?.store_id ?? null,
+    ...rest,
+  }
+}
+
+export interface PartnerInspectionInventoryOrder {
+  id: string
+  status?: string
+  quantity?: number
+  total_price?: number
+  order_date?: string
+  expected_delivery_date?: string
+  is_sample?: boolean
+  order_lines_count?: number
+  stock_location?: string
+  partner_info?: {
+    assigned_partner_id?: string
+    /** Derived from the partner_assignment TASKS, not from metadata. */
+    partner_status?: string
+    partner_started_at?: string | null
+    partner_completed_at?: string | null
+    workflow_tasks_count?: number
+  }
+  created_at?: string
+}
+
+export interface PartnerInspectionInventoryOrdersResponse {
+  inventory_orders: PartnerInspectionInventoryOrder[]
+  count: number
+  offset: number
+  limit: number
+}
+
+export const usePartnerInspectionInventoryOrders = (
+  partnerId: string,
+  query?: { status?: string; q?: string; limit?: number; offset?: number },
+  options?: Omit<
+    UseQueryOptions<
+      PartnerInspectionInventoryOrdersResponse,
+      FetchError,
+      PartnerInspectionInventoryOrdersResponse,
+      QueryKey
+    >,
+    "queryFn" | "queryKey"
+  >
+) => {
+  const { data, ...rest } = useQuery({
+    queryFn: async () =>
+      sdk.client.fetch<PartnerInspectionInventoryOrdersResponse>(
+        `/admin/partners/${partnerId}/inventory-orders`,
+        { method: "GET", query }
+      ),
+    queryKey: partnerInspectionQueryKeys.detail(partnerId, {
+      inventoryOrders: query,
+    }),
+    enabled: !!partnerId,
+    ...options,
+  })
+
+  return {
+    inventoryOrders: data?.inventory_orders || [],
+    count: data?.count || 0,
+    ...rest,
+  }
+}
+
+export interface PartnerInspectionInventoryItem {
+  id: string
+  sku?: string
+  title?: string
+  /** Aggregated over the partner's location only — see the workflow. */
+  stocked_quantity?: number
+  reserved_quantity?: number
+  incoming_quantity?: number
+  location_levels?: { id: string; location_id: string }[]
+}
+
+export interface PartnerInspectionInventoryItemsResponse {
+  inventory_items: PartnerInspectionInventoryItem[]
+  count: number
+  offset: number
+  limit: number
+}
+
+export const usePartnerInspectionInventoryItems = (
+  partnerId: string,
+  query?: { q?: string; limit?: number; offset?: number },
+  options?: Omit<
+    UseQueryOptions<
+      PartnerInspectionInventoryItemsResponse,
+      FetchError,
+      PartnerInspectionInventoryItemsResponse,
+      QueryKey
+    >,
+    "queryFn" | "queryKey"
+  >
+) => {
+  const { data, ...rest } = useQuery({
+    queryFn: async () =>
+      sdk.client.fetch<PartnerInspectionInventoryItemsResponse>(
+        `/admin/partners/${partnerId}/inventory-items`,
+        { method: "GET", query }
+      ),
+    queryKey: partnerInspectionQueryKeys.detail(partnerId, {
+      inventoryItems: query,
+    }),
+    enabled: !!partnerId,
+    ...options,
+  })
+
+  return {
+    inventoryItems: data?.inventory_items || [],
+    count: data?.count || 0,
     ...rest,
   }
 }

--- a/apps/backend/src/admin/hooks/api/partner-inspection.ts
+++ b/apps/backend/src/admin/hooks/api/partner-inspection.ts
@@ -2,7 +2,7 @@
  * Read-only hooks for the partner inspection mirror (#843, approach #2).
  *
  * These hit the admin read-proxy routes (`/admin/partners/:id/{orders, designs,
- * production-runs, onboarding-profile}`), which run the partner portal's own
+ * production-runs, products, onboarding-profile}`), which run the partner portal's own
  * scoping helpers and listing workflows against a synthesized partner context —
  * so what renders here is what the partner sees. There are deliberately no
  * mutation hooks in this file.
@@ -208,6 +208,59 @@ export const usePartnerInspectionProductionRuns = (
   return {
     productionRuns: data?.production_runs || [],
     count: data?.count || 0,
+    ...rest,
+  }
+}
+
+export interface PartnerInspectionProduct {
+  id: string
+  title?: string
+  handle?: string
+  status?: string
+  thumbnail?: string | null
+  created_at?: string
+  collection?: { id: string; title?: string } | null
+  variants?: { id: string; title?: string }[]
+  images?: { id: string; url?: string }[]
+}
+
+export interface PartnerInspectionProductsResponse {
+  products: PartnerInspectionProduct[]
+  count: number
+  offset: number
+  limit: number
+  /** Which of the partner's stores the catalog was read from; null if they have none. */
+  store_id: string | null
+}
+
+export const usePartnerInspectionProducts = (
+  partnerId: string,
+  query?: { store_id?: string },
+  options?: Omit<
+    UseQueryOptions<
+      PartnerInspectionProductsResponse,
+      FetchError,
+      PartnerInspectionProductsResponse,
+      QueryKey
+    >,
+    "queryFn" | "queryKey"
+  >
+) => {
+  const { data, ...rest } = useQuery({
+    queryFn: async () =>
+      sdk.client.fetch<PartnerInspectionProductsResponse>(
+        `/admin/partners/${partnerId}/products`,
+        { method: "GET", query }
+      ),
+    queryKey: partnerInspectionQueryKeys.detail(partnerId, { products: query }),
+    enabled: !!partnerId,
+    ...options,
+  })
+
+  return {
+    products: data?.products || [],
+    count: data?.count || 0,
+    storeId: data?.store_id ?? null,
     ...rest,
   }
 }

--- a/apps/backend/src/admin/hooks/api/partner-inspection.ts
+++ b/apps/backend/src/admin/hooks/api/partner-inspection.ts
@@ -229,6 +229,7 @@ export interface PartnerInspectionProductsResponse {
   count: number
   offset: number
   limit: number
+  partner_id: string
   /** Which of the partner's stores the catalog was read from; null if they have none. */
   store_id: string | null
 }

--- a/apps/backend/src/api/admin/partners/[id]/inventory-items/route.ts
+++ b/apps/backend/src/api/admin/partners/[id]/inventory-items/route.ts
@@ -1,0 +1,72 @@
+/**
+ * @file Admin read-proxy: a partner's inventory, as the partner sees it (#843).
+ * @module API/Admin/Partners/InventoryItems
+ */
+import { MedusaRequest, MedusaResponse } from "@medusajs/framework/http"
+import { z } from "zod"
+import { listPartnerInventoryItemsWorkflow } from "../../../../../workflows/inventory/list-partner-inventory-items"
+import { resolvePartnerInspectionContext } from "../lib/partner-inspection"
+import { tryGetPartnerStore } from "../../../../partners/helpers"
+
+/**
+ * The partner route reads `q`/`limit`/`offset` straight off the request with no
+ * schema of its own, so there is none to reuse here.
+ *
+ * Deliberately NO `store_id` selector, unlike the products mirror: the partner
+ * inventory surface has no multi-store notion at all — it reads the partner's
+ * first store's default location and nothing else. Offering a store picker here
+ * would make the mirror show something the partner cannot see, which is the one
+ * thing it must never do.
+ */
+const inspectInventoryQuerySchema = z.object({
+  q: z.string().optional(),
+  limit: z.coerce.number().optional(),
+  offset: z.coerce.number().optional(),
+})
+
+/**
+ * GET /admin/partners/:id/inventory-items
+ *
+ * The inspection mirror of `GET /partners/inventory-items`: the same stock
+ * location scoping, the same per-location quantity aggregation, the same
+ * search-then-paginate semantics — because it runs the same workflow, just with
+ * the partner resolved from `:id` instead of from a partner bearer.
+ *
+ * A partner with no store, or a store with no default location, has no
+ * inventory to show — an empty list, not an error. That is exactly what the
+ * partner route returns them, and it is a state the operator wants to SEE.
+ *
+ * READ-ONLY. There is deliberately no POST here (the partner route has one);
+ * writing stock on a partner's behalf is the audited impersonation track.
+ */
+export const GET = async (req: MedusaRequest, res: MedusaResponse) => {
+  const {
+    q,
+    limit = 20,
+    offset = 0,
+  } = inspectInventoryQuerySchema.parse(
+    (req.query as Record<string, unknown>) || {}
+  )
+
+  // 404s on an unknown partner before any partner helper can voice a
+  // partner-shaped UNAUTHORIZED at an admin caller.
+  const { authContext } = await resolvePartnerInspectionContext(
+    req.params.id,
+    req.scope
+  )
+
+  // The location — not the store — is this surface's scoping rule, resolved via
+  // the partner portal's own helper so admin cannot scope it differently.
+  const { store } = await tryGetPartnerStore(authContext, req.scope)
+  const locationId = store?.default_location_id
+
+  if (!locationId) {
+    return res.json({ inventory_items: [], count: 0, offset, limit })
+  }
+
+  const { result } = await listPartnerInventoryItemsWorkflow(req.scope).run({
+    input: { locationId, q, offset, limit },
+  })
+
+  res.json(result)
+}

--- a/apps/backend/src/api/admin/partners/[id]/inventory-orders/route.ts
+++ b/apps/backend/src/api/admin/partners/[id]/inventory-orders/route.ts
@@ -1,0 +1,58 @@
+/**
+ * @file Admin read-proxy: a partner's inventory orders, as the partner sees
+ *   them (#843).
+ * @module API/Admin/Partners/InventoryOrders
+ */
+import { MedusaRequest, MedusaResponse } from "@medusajs/framework/http"
+import { listInventoryOrdersQuerySchema } from "../../../inventory-orders/validators"
+import { listPartnerInventoryOrdersWorkflow } from "../../../../../workflows/inventory_orders/list-partner-inventory-orders"
+import { resolvePartnerInspectionContext } from "../lib/partner-inspection"
+
+/**
+ * GET /admin/partners/:id/inventory-orders
+ *
+ * The inspection mirror of `GET /partners/inventory-orders`: same query
+ * contract (`status`, `q`, `limit`, `offset`), same task-derived
+ * `partner_info`, same in-app filter-then-paginate semantics — because it runs
+ * the same workflow, just with the partner resolved from `:id` instead of from
+ * a partner bearer.
+ *
+ * READ-ONLY. Acting on a partner's inventory orders is the audited
+ * impersonation track (approach #1 on #843), not this one.
+ */
+export const GET = async (req: MedusaRequest, res: MedusaResponse) => {
+  const { id: partnerId } = req.params
+
+  // Parsed here rather than via `validateAndTransformQuery` middleware so this
+  // route reads the partner's contract itself — one contract, not two that can
+  // drift apart.
+  //
+  // That contract is the ADMIN `listInventoryOrdersQuerySchema`, which is what
+  // the `/partners/inventory-orders` matcher validates with — NOT the schema in
+  // `partners/inventory-orders/validators.ts`, which only supplies a type and
+  // is far looser (`status: string` vs the real status enum). Parsing the loose
+  // one made this mirror accept `?status=pending`, which the partner surface
+  // rejects with a 400 — the mirror being more permissive than the thing it
+  // mirrors. The drift guard caught it; keep it pointed here.
+  const { limit = 20, offset = 0, status, q } =
+    listInventoryOrdersQuerySchema.parse(
+      (req.query as Record<string, unknown>) || {}
+    )
+
+  // 404s on an unknown partner before any partner helper can voice a
+  // partner-shaped UNAUTHORIZED at an admin caller.
+  const { partner } = await resolvePartnerInspectionContext(partnerId, req.scope)
+
+  const { result } = await listPartnerInventoryOrdersWorkflow(req.scope).run({
+    input: {
+      partnerId: partner.id,
+      q,
+      status,
+      offset,
+      limit,
+      locale: req.locale,
+    },
+  })
+
+  res.json(result)
+}

--- a/apps/backend/src/api/admin/partners/[id]/lib/partner-inspection.ts
+++ b/apps/backend/src/api/admin/partners/[id]/lib/partner-inspection.ts
@@ -8,6 +8,7 @@
  */
 import { MedusaContainer } from "@medusajs/framework"
 import { ContainerRegistrationKeys, MedusaError } from "@medusajs/framework/utils"
+import { tryGetPartnerStore } from "../../../../partners/helpers"
 
 /**
  * The shape `src/api/partners/helpers.ts` reads off `req.auth_context`.
@@ -70,6 +71,49 @@ export const assertPartnerExists = async (
   }
 
   return partner
+}
+
+/**
+ * Which of the partner's stores an inspection route should read.
+ *
+ * Defaults to the partner's first store — the one the partner portal itself
+ * lands on — via the portal's own helper. An explicit `store_id` is checked
+ * against the partner's stores HERE so a foreign id reads as a 404 to an admin,
+ * instead of the partner-voiced `UNAUTHORIZED "Store … is not associated with
+ * this partner"` the downstream partner code would throw. Same reason
+ * `assertPartnerExists` exists.
+ *
+ * Returns `storeId: null` for a partner that has never provisioned a store:
+ * that is a normal state an operator wants to see (it is what the onboarding
+ * flow exists to fix), not an error (#1158).
+ */
+export const resolvePartnerInspectionStoreId = async (
+  authContext: SynthesizedPartnerAuthContext,
+  container: MedusaContainer,
+  requestedStoreId?: string
+): Promise<{ partner: any; storeId: string | null }> => {
+  const { partner, store } = await tryGetPartnerStore(authContext, container)
+
+  if (!requestedStoreId) {
+    return { partner, storeId: store?.id ?? null }
+  }
+
+  const query = container.resolve(ContainerRegistrationKeys.QUERY)
+  const { data } = await query.graph({
+    entity: "partners",
+    fields: ["id", "stores.id"],
+    filters: { id: partner.id },
+  })
+
+  const stores = ((data?.[0] as any)?.stores || []) as Array<{ id: string }>
+  if (!stores.some((s) => s.id === requestedStoreId)) {
+    throw new MedusaError(
+      MedusaError.Types.NOT_FOUND,
+      "Store not found for this partner"
+    )
+  }
+
+  return { partner, storeId: requestedStoreId }
 }
 
 /**

--- a/apps/backend/src/api/admin/partners/[id]/products/route.ts
+++ b/apps/backend/src/api/admin/partners/[id]/products/route.ts
@@ -1,0 +1,79 @@
+/**
+ * @file Admin read-proxy: a partner's catalog, as the partner sees it (#843).
+ * @module API/Admin/Partners/Products
+ */
+import { MedusaRequest, MedusaResponse } from "@medusajs/framework/http"
+import { z } from "zod"
+import { listStoreProductsWorkflow } from "../../../../../workflows/partner/list-store-products"
+import {
+  resolvePartnerInspectionContext,
+  resolvePartnerInspectionStoreId,
+} from "../lib/partner-inspection"
+
+/**
+ * On the partner side the store is a PATH param (`GET /partners/stores/:id/
+ * products`), so there is no partner query schema to reuse here — unlike the
+ * orders/designs/runs mirrors, which parse the partner's own schema. `store_id`
+ * is this route's way of spelling that path param, and nothing else is accepted.
+ */
+const inspectProductsQuerySchema = z.object({
+  store_id: z.string().optional(),
+})
+
+/**
+ * GET /admin/partners/:id/products
+ *
+ * The inspection mirror of `GET /partners/stores/:storeId/products`: the same
+ * sales-channel-scoped catalog, the same field set, the same payload — because
+ * it runs the same workflow, just with the partner resolved from `:id` instead
+ * of from a partner bearer.
+ *
+ * Store selection: `?store_id=` picks a specific store; otherwise the partner's
+ * first store is used, which is the one the partner portal itself lands on. A
+ * `store_id` belonging to another partner 404s — the mirror is never more
+ * permissive than the surface it mirrors.
+ *
+ * READ-ONLY. There is deliberately no POST here: creating a product on a
+ * partner's behalf is the audited impersonation track (approach #1 on #843).
+ */
+export const GET = async (req: MedusaRequest, res: MedusaResponse) => {
+  const { id: partnerId } = req.params
+
+  const { store_id: requestedStoreId } = inspectProductsQuerySchema.parse(
+    (req.query as Record<string, unknown>) || {}
+  )
+
+  // 404s on an unknown partner before any partner helper can voice a
+  // partner-shaped UNAUTHORIZED at an admin caller.
+  const { authContext } = await resolvePartnerInspectionContext(
+    partnerId,
+    req.scope
+  )
+
+  const { partner, storeId } = await resolvePartnerInspectionStoreId(
+    authContext,
+    req.scope,
+    requestedStoreId
+  )
+
+  // A partner with no store yet is a normal state an operator wants to SEE (it
+  // is what the onboarding flow exists to fix), not an error (#1158).
+  if (!storeId) {
+    return res.json({
+      products: [],
+      count: 0,
+      offset: 0,
+      limit: 20,
+      store_id: null,
+    })
+  }
+
+  const { result } = await listStoreProductsWorkflow(req.scope).run({
+    input: {
+      partnerId: partner.id,
+      storeId,
+    },
+  })
+
+  res.json(result)
+}

--- a/apps/backend/src/api/admin/partners/[id]/products/route.ts
+++ b/apps/backend/src/api/admin/partners/[id]/products/route.ts
@@ -64,6 +64,7 @@ export const GET = async (req: MedusaRequest, res: MedusaResponse) => {
       count: 0,
       offset: 0,
       limit: 20,
+      partner_id: partner.id,
       store_id: null,
     })
   }

--- a/apps/backend/src/api/partners/inventory-items/route.ts
+++ b/apps/backend/src/api/partners/inventory-items/route.ts
@@ -1,6 +1,7 @@
 import { AuthenticatedMedusaRequest, MedusaResponse } from "@medusajs/framework/http"
 import { ContainerRegistrationKeys, MedusaError, Modules } from "@medusajs/framework/utils"
 import { getPartnerFromAuthContext, getPartnerStore, tryGetPartnerStore } from "../helpers"
+import { listPartnerInventoryItemsWorkflow } from "../../../workflows/inventory/list-partner-inventory-items"
 
 export const GET = async (
   req: AuthenticatedMedusaRequest,
@@ -30,71 +31,14 @@ export const GET = async (
   const limit = Number.isFinite(Number(qv.limit)) ? Number(qv.limit) : 20
   const offset = Number.isFinite(Number(qv.offset)) ? Number(qv.offset) : 0
 
-  const inventoryService = req.scope.resolve(Modules.INVENTORY) as any
-
-  // Get inventory levels at the partner's location to find their item IDs
-  const [levels] = await inventoryService.listAndCountInventoryLevels(
-    { location_id: locationId },
-    { take: 1000 }
-  )
-
-  const itemIds = [...new Set((levels || []).map((l: any) => l.inventory_item_id).filter(Boolean))] as string[]
-
-  if (itemIds.length === 0) {
-    return res.json({ inventory_items: [], count: 0, offset, limit })
-  }
-
-  // Fetch full inventory items with their levels (filtered to partner's location)
-  const [items] = await inventoryService.listAndCountInventoryItems(
-    { id: itemIds },
-    { take: itemIds.length, relations: ["location_levels"] }
-  )
-
-  // Filter location_levels to partner's location AND aggregate totals onto
-  // the item itself. listAndCountInventoryItems doesn't populate the
-  // top-level stocked/reserved/incoming quantities (they come back null),
-  // but the partner UI list + detail read them from the item directly.
-  const scoped = (items || []).map((item: any) => {
-    const levels = (item.location_levels || []).filter(
-      (ll: any) => ll.location_id === locationId
-    )
-    const sum = (field: "stocked_quantity" | "reserved_quantity" | "incoming_quantity") =>
-      levels.reduce((acc: number, lvl: any) => acc + (Number(lvl?.[field]) || 0), 0)
-
-    return {
-      ...item,
-      location_levels: levels,
-      stocked_quantity: sum("stocked_quantity"),
-      reserved_quantity: sum("reserved_quantity"),
-      incoming_quantity: sum("incoming_quantity"),
-    }
+  // Auth + "which location is theirs" is all this route contributes — the
+  // listing itself belongs to the workflow so the admin inspection mirror runs
+  // the same code rather than a second copy of it (#843).
+  const { result } = await listPartnerInventoryItemsWorkflow(req.scope).run({
+    input: { locationId, q, offset, limit },
   })
 
-  // Apply free-text search (q) against sku/title — the inventory service's
-  // location-scoped fetch above can't filter on these, so we post-filter
-  // in-app (same approach as the raw-materials route). Without this the
-  // partner UI search box silently returns the full list (#484).
-  const needle = q.toLowerCase()
-  const matched = needle
-    ? scoped.filter((item: any) => {
-        const candidates: Array<string | undefined> = [item?.sku, item?.title]
-        return candidates.some(
-          (c) => typeof c === "string" && c.toLowerCase().includes(needle)
-        )
-      })
-    : scoped
-
-  // Respect offset/limit pagination so the UI's page controls work.
-  const safeOffset = offset > 0 ? offset : 0
-  const safeLimit = limit > 0 ? limit : matched.length
-  const paginated = matched.slice(safeOffset, safeOffset + safeLimit)
-
-  res.json({
-    inventory_items: paginated,
-    count: matched.length,
-    offset: safeOffset,
-    limit: safeLimit,
-  })
+  res.json(result)
 }
 
 export const POST = async (

--- a/apps/backend/src/api/partners/inventory-orders/route.ts
+++ b/apps/backend/src/api/partners/inventory-orders/route.ts
@@ -128,8 +128,7 @@ import { AuthenticatedMedusaRequest, MedusaResponse } from "@medusajs/framework"
 import { ContainerRegistrationKeys } from "@medusajs/framework/utils";
 import { getPartnerFromAuthContext } from "../helpers";
 import { ListInventoryOrdersQuery } from "./validators";
-import { applyInventoryOrderListFilters } from "./list-filters";
-import InventoryOrderPartnerLink from "../../../links/partner-inventory-order"
+import { listPartnerInventoryOrdersWorkflow } from "../../../workflows/inventory_orders/list-partner-inventory-orders"
 
 
 export async function GET(
@@ -140,8 +139,6 @@ export async function GET(
         const { limit = 20, offset = 0, status, q } =
             req.validatedQuery as ListInventoryOrdersQuery;
 
-        const query = req.scope.resolve(ContainerRegistrationKeys.QUERY);
-        
         // Get the authenticated partner from auth context
         const actorId = req.auth_context?.actor_id;
         
@@ -159,108 +156,22 @@ export async function GET(
             });
         }
         
-        const partnerId = partner.id;
-        
-        // Build filters for orders assigned to this partner
-        // Note: Cannot filter on linked module properties (inventory_orders.status)
-        // due to MedusaJS limitation - filters only work on link table columns
-        const filters: any = {
-            partner_id: partnerId
-        };
-        
-        // Status filtering will be done after query, not in filters
-        
-        // Use query.graph to get orders linked to this partner with associated tasks.
-        // NOTE: pagination is intentionally NOT applied here. `query.graph` cannot
-        // filter on linked-module columns (inventory_orders.status) and the partner
-        // route has no free-text index, so status/`q` are matched in-app below.
-        // Paginating here would slice BEFORE those filters run, returning the wrong
-        // page and a per-page (not total) count — the #484 page-vs-set bug.
-        const { data: orders } = await query.graph({
-            entity: InventoryOrderPartnerLink.entryPoint,
-            fields: [
-                "inventory_orders.*",
-                "inventory_orders.orderlines.*",
-                "inventory_orders.stock_locations.*",
-                "inventory_orders.tasks.*",
-                "partner.*",
-              ],
-            filters,
-        }, { locale: req.locale });
-
-        // Format the response for partner view - now using task-based status
-        const formattedOrders = orders.map((linkData: any) => {
-            const order = linkData.inventory_orders;
-            
-            // Extract partner workflow status from tasks instead of metadata
-            const partnerTasks = order.tasks || [];
-            const workflowTasks = partnerTasks.filter((task: any) => 
-                task && task.metadata?.workflow_type === 'partner_assignment'
-            );
-            
-            // Determine partner status based on task completion
-            let partnerStatus = 'assigned';
-            let partnerStartedAt: string | null = null;
-            let partnerCompletedAt: string | null = null;
-            
-            if (workflowTasks.length > 0) {
-                const sentTask = workflowTasks.find((task: any) => 
-                    task.title?.includes('sent') && task.status === 'completed'
-                );
-                const receivedTask = workflowTasks.find((task: any) => 
-                    task.title?.includes('received') && task.status === 'completed'
-                );
-                const shippedTask = workflowTasks.find((task: any) => 
-                    task.title?.includes('shipped') && task.status === 'completed'
-                );
-                
-                if (shippedTask) {
-                    partnerStatus = 'completed';
-                    partnerCompletedAt = shippedTask.updated_at ? String(shippedTask.updated_at) : null;
-                } else if (receivedTask) {
-                    partnerStatus = 'in_progress';
-                    partnerStartedAt = receivedTask.updated_at ? String(receivedTask.updated_at) : null;
-                } else if (sentTask) {
-                    partnerStatus = 'assigned';
-                }
-            }
-            
-            return {
-                id: order.id,
-                status: order.status,
-                quantity: order.quantity,
-                total_price: order.total_price,
-                expected_delivery_date: order.expected_delivery_date,
-                order_date: order.order_date,
-                is_sample: order.is_sample,
-                order_lines_count: order.orderlines?.length || 0,
-                stock_location: order.stock_locations?.[0]?.name || 'Unknown',
-                partner_info: {
-                    assigned_partner_id: linkData.partner?.id || partnerId,
-                    partner_status: partnerStatus,
-                    partner_started_at: partnerStartedAt,
-                    partner_completed_at: partnerCompletedAt,
-                    workflow_tasks_count: workflowTasks.length
-                },
-                created_at: order.created_at,
-                updated_at: order.updated_at
-            };
+        // Auth is all this route contributes — the listing (partner_info
+        // derivation, q/status filtering, pagination) belongs to the workflow so
+        // the admin inspection mirror runs the same code rather than a second
+        // copy of it (#843).
+        const { result } = await listPartnerInventoryOrdersWorkflow(req.scope).run({
+            input: {
+                partnerId: partner.id,
+                q,
+                status,
+                offset,
+                limit,
+                locale: req.locale,
+            },
         });
-        
-        // Apply status + free-text (`q`) filtering, THEN paginate, over the full
-        // partner-scoped set. count = total matched (pre-pagination) so the UI
-        // pager is correct. Pure + unit-tested in ./list-filters.
-        const { items: partnerOrders, count } = applyInventoryOrderListFilters(
-            formattedOrders,
-            { q, status, offset, limit }
-        );
 
-        res.status(200).json({
-            inventory_orders: partnerOrders,
-            count,
-            limit,
-            offset
-        });
+        res.status(200).json(result);
     } catch (error) {
         const logger = req.scope.resolve(ContainerRegistrationKeys.LOGGER)
         logger.error(

--- a/apps/backend/src/api/partners/inventory-orders/validators.ts
+++ b/apps/backend/src/api/partners/inventory-orders/validators.ts
@@ -1,5 +1,10 @@
 import { z } from "@medusajs/framework/zod";
 
+// NOTE: this schema is NOT what validates the route. The
+// `/partners/inventory-orders` matcher validates with the ADMIN
+// `listInventoryOrdersQuerySchema` (see src/api/middlewares.ts), which is
+// stricter — `status` there is the real status enum. This one only supplies the
+// handler's type, so do not treat it as the query contract (#843).
 const querySchema = z.object({
   limit: z.string().transform(Number).optional(),
   offset: z.string().transform(Number).optional(),

--- a/apps/backend/src/api/partners/stores/[id]/products/route.ts
+++ b/apps/backend/src/api/partners/stores/[id]/products/route.ts
@@ -21,23 +21,17 @@ export const GET = async (
     req.scope
   )
 
-  const { result: links } = await listStoreProductsWorkflow(req.scope).run({
+  // Auth is all this route contributes — the listing (and its response shape)
+  // belongs to the workflow so the admin inspection mirror runs the same code
+  // rather than a second copy of it (#843).
+  const { result } = await listStoreProductsWorkflow(req.scope).run({
     input: {
       partnerId: partner.id,
       storeId: store.id,
     },
   })
 
-  const products = ((links as any[]) || [])
-    .map((l: any) => l?.product)
-    .filter(Boolean)
-
-  res.json({
-    products,
-    count: products.length,
-    offset: 0,
-    limit: 20,
-  })
+  res.json(result)
 }
 
 export const POST = async (

--- a/apps/backend/src/workflows/inventory/list-partner-inventory-items.ts
+++ b/apps/backend/src/workflows/inventory/list-partner-inventory-items.ts
@@ -1,0 +1,122 @@
+import {
+  createStep,
+  createWorkflow,
+  StepResponse,
+  transform,
+  WorkflowResponse,
+} from "@medusajs/framework/workflows-sdk"
+import { Modules } from "@medusajs/framework/utils"
+
+// #843 — the partner inventory listing, lifted out of
+// `GET /partners/inventory-items` into a workflow so the admin inspection
+// mirror (`GET /admin/partners/:id/inventory-items`) runs the SAME logic
+// rather than re-deriving it. The route keeps auth and resolving WHICH stock
+// location is the partner's; everything after that lives here.
+
+export type ListPartnerInventoryItemsWorkflowInput = {
+  /** The partner's stock location — the whole scoping rule for this surface. */
+  locationId: string
+  q?: string
+  offset: number
+  limit: number
+}
+
+/**
+ * Every inventory item that has a level at the partner's location, with its
+ * levels scoped to that location and the per-location totals aggregated onto
+ * the item.
+ *
+ * `listAndCountInventoryItems` does NOT populate the top-level
+ * stocked/reserved/incoming quantities (they come back null) but the partner UI
+ * list AND detail read them off the item directly — hence the aggregation.
+ */
+export const resolvePartnerInventoryItemsStep = createStep(
+  "resolve-partner-inventory-items",
+  async (input: { locationId: string }, { container }) => {
+    const inventoryService = container.resolve(Modules.INVENTORY) as any
+
+    // Levels at the partner's location give us their item ids.
+    const [levels] = await inventoryService.listAndCountInventoryLevels(
+      { location_id: input.locationId },
+      { take: 1000 }
+    )
+
+    const itemIds = [
+      ...new Set(
+        (levels || []).map((l: any) => l.inventory_item_id).filter(Boolean)
+      ),
+    ] as string[]
+
+    if (itemIds.length === 0) {
+      return new StepResponse([] as any[])
+    }
+
+    const [items] = await inventoryService.listAndCountInventoryItems(
+      { id: itemIds },
+      { take: itemIds.length, relations: ["location_levels"] }
+    )
+
+    const scoped = (items || []).map((item: any) => {
+      const itemLevels = (item.location_levels || []).filter(
+        (ll: any) => ll.location_id === input.locationId
+      )
+      const sum = (
+        field: "stocked_quantity" | "reserved_quantity" | "incoming_quantity"
+      ) =>
+        itemLevels.reduce(
+          (acc: number, lvl: any) => acc + (Number(lvl?.[field]) || 0),
+          0
+        )
+
+      return {
+        ...item,
+        location_levels: itemLevels,
+        stocked_quantity: sum("stocked_quantity"),
+        reserved_quantity: sum("reserved_quantity"),
+        incoming_quantity: sum("incoming_quantity"),
+      }
+    })
+
+    return new StepResponse(scoped as any[])
+  }
+)
+
+export const listPartnerInventoryItemsWorkflow = createWorkflow(
+  "list-partner-inventory-items",
+  (input: ListPartnerInventoryItemsWorkflowInput) => {
+    const items = resolvePartnerInventoryItemsStep({
+      locationId: input.locationId,
+    })
+
+    const output = transform({ items, input }, ({ items, input }) => {
+      // Free-text search over sku/title. The location-scoped fetch above can't
+      // filter on these, so it is matched in-app (same approach as the
+      // raw-materials route). Without it the partner UI search box silently
+      // returns the full list (#484).
+      const needle = input.q?.trim().toLowerCase()
+      const matched = needle
+        ? (items as any[]).filter((item: any) =>
+            [item?.sku, item?.title].some(
+              (c) => typeof c === "string" && c.toLowerCase().includes(needle)
+            )
+          )
+        : (items as any[])
+
+      // Paginate AFTER filtering, so `count` is the total matched and the UI
+      // pager is correct (#484).
+      const safeOffset = input.offset > 0 ? input.offset : 0
+      const safeLimit = input.limit > 0 ? input.limit : matched.length
+
+      return {
+        inventory_items: matched.slice(safeOffset, safeOffset + safeLimit),
+        count: matched.length,
+        offset: safeOffset,
+        limit: safeLimit,
+      }
+    })
+
+    return new WorkflowResponse(output)
+  }
+)
+
+export default listPartnerInventoryItemsWorkflow

--- a/apps/backend/src/workflows/inventory_orders/list-partner-inventory-orders.ts
+++ b/apps/backend/src/workflows/inventory_orders/list-partner-inventory-orders.ts
@@ -1,0 +1,171 @@
+import {
+  createStep,
+  createWorkflow,
+  StepResponse,
+  transform,
+  WorkflowResponse,
+} from "@medusajs/framework/workflows-sdk"
+import { ContainerRegistrationKeys } from "@medusajs/framework/utils"
+import InventoryOrderPartnerLink from "../../links/partner-inventory-order"
+import { applyInventoryOrderListFilters } from "../../api/partners/inventory-orders/list-filters"
+
+// #843 — the partner inventory-orders listing, lifted out of
+// `GET /partners/inventory-orders` into a workflow so the admin inspection
+// mirror (`GET /admin/partners/:id/inventory-orders`) runs the SAME logic
+// rather than re-deriving it. Re-deriving is how two surfaces drift, and the
+// mirror is only worth having if it cannot lie.
+//
+// The route keeps auth (resolve the partner from the bearer) and hands the rest
+// here. The admin proxy resolves the partner from `:id` and calls this same
+// workflow — that is the entire difference between the two surfaces.
+
+export type ListPartnerInventoryOrdersWorkflowInput = {
+  partnerId: string
+  q?: string
+  status?: string
+  offset: number
+  limit: number
+  /** Forwarded to `query.graph` for translated fields; the route reads it off the request. */
+  locale?: string
+}
+
+/**
+ * The partner-scoped inventory-order set: every order linked to this partner.
+ *
+ * Pagination is deliberately NOT applied here. `query.graph` cannot filter on
+ * the linked module's own columns (`inventory_orders.status`) and the partner
+ * route has no free-text index, so status/`q` are matched in-app downstream.
+ * Slicing here would cut BEFORE those filters run, returning the wrong page and
+ * a per-page (not total) count — the #484 page-vs-set bug.
+ */
+export const resolvePartnerInventoryOrderRowsStep = createStep(
+  "resolve-partner-inventory-order-rows",
+  async (input: { partnerId: string; locale?: string }, { container }) => {
+    const query: any = container.resolve(ContainerRegistrationKeys.QUERY)
+
+    const { data } = await query.graph(
+      {
+        entity: InventoryOrderPartnerLink.entryPoint,
+        fields: [
+          "inventory_orders.*",
+          "inventory_orders.orderlines.*",
+          "inventory_orders.stock_locations.*",
+          "inventory_orders.tasks.*",
+          "partner.*",
+        ],
+        filters: { partner_id: input.partnerId },
+      },
+      { locale: input.locale }
+    )
+
+    return new StepResponse((data || []) as any[])
+  }
+)
+
+/**
+ * The partner's view of one inventory order — status derived from the
+ * `partner_assignment` workflow TASKS, not from metadata (see #778 / the
+ * no-critical-data-in-metadata rule).
+ */
+export const buildPartnerInventoryOrderView = (
+  linkData: any,
+  partnerId: string
+) => {
+  const order = linkData.inventory_orders
+
+  const partnerTasks = order.tasks || []
+  const workflowTasks = partnerTasks.filter(
+    (task: any) => task && task.metadata?.workflow_type === "partner_assignment"
+  )
+
+  let partnerStatus = "assigned"
+  let partnerStartedAt: string | null = null
+  let partnerCompletedAt: string | null = null
+
+  if (workflowTasks.length > 0) {
+    const sentTask = workflowTasks.find(
+      (task: any) => task.title?.includes("sent") && task.status === "completed"
+    )
+    const receivedTask = workflowTasks.find(
+      (task: any) =>
+        task.title?.includes("received") && task.status === "completed"
+    )
+    const shippedTask = workflowTasks.find(
+      (task: any) =>
+        task.title?.includes("shipped") && task.status === "completed"
+    )
+
+    if (shippedTask) {
+      partnerStatus = "completed"
+      partnerCompletedAt = shippedTask.updated_at
+        ? String(shippedTask.updated_at)
+        : null
+    } else if (receivedTask) {
+      partnerStatus = "in_progress"
+      partnerStartedAt = receivedTask.updated_at
+        ? String(receivedTask.updated_at)
+        : null
+    } else if (sentTask) {
+      partnerStatus = "assigned"
+    }
+  }
+
+  return {
+    id: order.id,
+    status: order.status,
+    quantity: order.quantity,
+    total_price: order.total_price,
+    expected_delivery_date: order.expected_delivery_date,
+    order_date: order.order_date,
+    is_sample: order.is_sample,
+    order_lines_count: order.orderlines?.length || 0,
+    stock_location: order.stock_locations?.[0]?.name || "Unknown",
+    partner_info: {
+      assigned_partner_id: linkData.partner?.id || partnerId,
+      partner_status: partnerStatus,
+      partner_started_at: partnerStartedAt,
+      partner_completed_at: partnerCompletedAt,
+      workflow_tasks_count: workflowTasks.length,
+    },
+    created_at: order.created_at,
+    updated_at: order.updated_at,
+  }
+}
+
+export const listPartnerInventoryOrdersWorkflow = createWorkflow(
+  "list-partner-inventory-orders",
+  (input: ListPartnerInventoryOrdersWorkflowInput) => {
+    const rows = resolvePartnerInventoryOrderRowsStep({
+      partnerId: input.partnerId,
+      locale: input.locale,
+    })
+
+    // status + free-text (`q`) filtering runs AFTER the mapping (so `q` can
+    // match the resolved view's fields), THEN paginates — over the full
+    // partner-scoped set, so `count` is the total matched and the UI pager is
+    // correct. `applyInventoryOrderListFilters` is pure and unit-tested.
+    const output = transform({ rows, input }, ({ rows, input }) => {
+      const mapped = (rows as any[]).map((row) =>
+        buildPartnerInventoryOrderView(row, input.partnerId)
+      )
+
+      const { items, count } = applyInventoryOrderListFilters(mapped, {
+        q: input.q,
+        status: input.status,
+        offset: input.offset,
+        limit: input.limit,
+      })
+
+      return {
+        inventory_orders: items,
+        count,
+        limit: input.limit,
+        offset: input.offset,
+      }
+    })
+
+    return new WorkflowResponse(output)
+  }
+)
+
+export default listPartnerInventoryOrdersWorkflow

--- a/apps/backend/src/workflows/partner/list-store-products.ts
+++ b/apps/backend/src/workflows/partner/list-store-products.ts
@@ -90,6 +90,8 @@ export type ListStoreProductsOutput = {
   count: number
   offset: number
   limit: number
+  /** Whose catalog this is — the admin mirror serves several partners. */
+  partner_id: string
   /** Which of the partner's stores this listing came from. */
   store_id: string
 }
@@ -120,6 +122,7 @@ export const listStoreProductsWorkflow = createWorkflow(
         // slice, and changing that is a separate (partner-visible) decision.
         offset: 0,
         limit: 20,
+        partner_id: input.partnerId,
         store_id: input.storeId,
       } as ListStoreProductsOutput
     })

--- a/apps/backend/src/workflows/partner/list-store-products.ts
+++ b/apps/backend/src/workflows/partner/list-store-products.ts
@@ -1,5 +1,11 @@
 import { ContainerRegistrationKeys, MedusaError } from "@medusajs/framework/utils"
-import { createStep, createWorkflow, StepResponse, WorkflowResponse } from "@medusajs/framework/workflows-sdk"
+import {
+  createStep,
+  createWorkflow,
+  StepResponse,
+  transform,
+  WorkflowResponse,
+} from "@medusajs/framework/workflows-sdk"
 import type { RemoteQueryFunction } from "@medusajs/types"
 
 export type ListStoreProductsInput = {
@@ -79,14 +85,46 @@ const listStoreProductsStep = createStep(
   }
 )
 
+export type ListStoreProductsOutput = {
+  products: any[]
+  count: number
+  offset: number
+  limit: number
+  /** Which of the partner's stores this listing came from. */
+  store_id: string
+}
+
 export const listStoreProductsWorkflow = createWorkflow(
   {
     name: "list-store-products",
     store: true,
   },
   (input: ListStoreProductsInput) => {
-    const products = listStoreProductsStep(input)
-    return new WorkflowResponse(products)
+    const links = listStoreProductsStep(input)
+
+    // #843 — the response shaping lives HERE rather than in the route, so the
+    // admin inspection mirror (`GET /admin/partners/:id/products`) can serve the
+    // exact payload the partner portal serves. Re-mapping links→products a
+    // second time admin-side is precisely the seam the mirror exists to close.
+    const output = transform({ links, input }, ({ links, input }) => {
+      const products = ((links as any[]) || [])
+        .map((l: any) => l?.product)
+        .filter(Boolean)
+
+      return {
+        products,
+        count: products.length,
+        // The partner products listing is unpaginated — the step returns the
+        // store's whole channel-linked set. `offset`/`limit` are echoed for
+        // response-shape parity with the other partner listings; they do NOT
+        // slice, and changing that is a separate (partner-visible) decision.
+        offset: 0,
+        limit: 20,
+        store_id: input.storeId,
+      } as ListStoreProductsOutput
+    })
+
+    return new WorkflowResponse(output)
   }
 )
 

--- a/apps/backend/workflow-schemas.json
+++ b/apps/backend/workflow-schemas.json
@@ -3773,6 +3773,37 @@
     "source": "custom_ts",
     "sourceFile": "src/workflows/internal_payments/update-payment.ts"
   },
+  "list-partner-inventory-items": {
+    "fields": [
+      {
+        "name": "locationId",
+        "type": "string",
+        "required": true,
+        "placeholder": "{{ $last.locationId }}",
+        "description": "The partner's stock location — the whole scoping rule for this surface."
+      },
+      {
+        "name": "q",
+        "type": "string",
+        "required": false,
+        "placeholder": "{{ $last.q }}"
+      },
+      {
+        "name": "offset",
+        "type": "number",
+        "required": true,
+        "placeholder": "0"
+      },
+      {
+        "name": "limit",
+        "type": "number",
+        "required": true,
+        "placeholder": "0"
+      }
+    ],
+    "source": "custom_ts",
+    "sourceFile": "src/workflows/inventory/list-partner-inventory-items.ts"
+  },
   "split-inventory-item": {
     "fields": [
       {
@@ -3941,6 +3972,49 @@
     ],
     "source": "custom_ts",
     "sourceFile": "src/workflows/inventory_orders/get-inventory-order-tasks.ts"
+  },
+  "list-partner-inventory-orders": {
+    "fields": [
+      {
+        "name": "partnerId",
+        "type": "string",
+        "required": true,
+        "placeholder": "{{ $last.partnerId }}"
+      },
+      {
+        "name": "q",
+        "type": "string",
+        "required": false,
+        "placeholder": "{{ $last.q }}"
+      },
+      {
+        "name": "status",
+        "type": "string",
+        "required": false,
+        "placeholder": "{{ $last.status }}"
+      },
+      {
+        "name": "offset",
+        "type": "number",
+        "required": true,
+        "placeholder": "0"
+      },
+      {
+        "name": "limit",
+        "type": "number",
+        "required": true,
+        "placeholder": "0"
+      },
+      {
+        "name": "locale",
+        "type": "string",
+        "required": false,
+        "placeholder": "{{ $last.locale }}",
+        "description": "Forwarded to `query.graph` for translated fields; the route reads it off the request."
+      }
+    ],
+    "source": "custom_ts",
+    "sourceFile": "src/workflows/inventory_orders/list-partner-inventory-orders.ts"
   },
   "sync-inventory-shipment-tracking": {
     "fields": [


### PR DESCRIPTION
Read-proxy slices 3 and 4 for #843: **products**, **inventory** and **inventory orders**.

## Products

The listing was already a workflow (`list-store-products`), so there was no logic to lift — only the links→products **response shaping**, which lived in the partner route. That moved into the workflow, so both surfaces return the same body. The payload now also carries `partner_id` and `store_id`.

- `GET /admin/partners/:id/products` — read-only.
- `?store_id=` picks a store; otherwise the partner's first, which is where the portal itself lands. Another partner's store 404s.
- No store yet → empty catalog with `store_id: null`. That's a state operators want to see, not an error (#1158). The UI says "hasn't provisioned a store" rather than "no products", because only the first is actionable.

## Inventory + inventory orders

The designs-shaped lift the handoff predicted — both listings had their logic inline in the route:

- **`list-partner-inventory-orders`** — the link query, the task-derived `partner_info` (assigned / in_progress / completed), and the in-app filter-then-paginate contract from `list-filters.ts`.
- **`list-partner-inventory-items`** — the location-scoped fetch and the per-location quantity aggregation (the inventory service returns the top-level quantities `null`; the UI reads them off the item).
- `GET /admin/partners/:id/{inventory-orders,inventory-items}`, read-only — the partner route's inventory-items `POST` is deliberately **not** mirrored.
- The inventory-items mirror deliberately has **no `store_id` selector**: the partner surface has no multi-store notion at all, so a picker would show the operator something the partner cannot see.
- Admin UI: **Products** and **Inventory** tabs, the latter splitting Stock / Inventory orders the way the portal does.

## The guard earned itself

The inventory-orders proxy first parsed the schema in `partners/inventory-orders/validators.ts` — but that file only supplies a *type*. The `/partners/inventory-orders` matcher validates with the stricter **admin** `listInventoryOrdersQuerySchema`, where `status` is the real enum. So the mirror returned 200 for `?status=pending` while the partner surface 400s: **more permissive than the thing it mirrors**. Caught on the guard's first run, fixed, and pinned by a test asserting both surfaces reject it. The misleading validators file is now labelled.

## Tests

Run locally against Postgres — the mirror guard plus the partner-side regression suite for every rewired route:

- `admin-partner-inspection.spec.ts`, `partner-inventory-api.spec.ts`, `inventory-order-partner-security.spec.ts` → **58/58 green**
- `admin-partner-inspection.spec.ts`, `partner-store-products-api.spec.ts`, `partners-products.spec.ts` → **48/48 green**

Guard cases per surface, over seeded rows (two empty lists agree even when the mirror is broken): unfiltered mirror, each surface's filters, cross-partner isolation, unknown partner → 404, admin auth required, read-only.

**Pre-existing failures, untouched by this PR:** 5 in `send-to-partner-error-cases` and `orders-unification-dual-write`, verified identical with these changes stashed.

**Also fixed — two stale assertions in `partners-products.spec.ts`.** It read `products[i].product.id` on a payload that has returned products, not link rows, for some time (so both `some()` calls could only ever be `false`), and expected `partner_id`/`store_id` fields that had been dropped. Rather than delete the expectation, the workflow now carries both — the admin mirror wants them anyway. This survived because CI runs only the spec files a PR changes, so that file hadn't run in a long time.

## Checks

- `workflow-schemas.json` regenerated and committed: 266 → **268** entries (the two new workflows).
- `tsc --noEmit`: **79, unchanged from the `main` baseline** (#1179); none in touched files.

🤖 Generated with [Claude Code](https://claude.com/claude-code)