### PR TITLE
feat(admin,partners): inspection mirror for website + storefront [#843]

### DIFF
--- a/apps/backend/integration-tests/http/admin-partner-inspection.spec.ts
+++ b/apps/backend/integration-tests/http/admin-partner-inspection.spec.ts
@@ -807,5 +807,238 @@ setupSharedTestSuite(() => {
         expect(err.response.status).toBe(404)
       })
     })
+
+    /**
+     * Slice 5 — the storefront surface.
+     *
+     * Two things make it unlike the other four. First, the admin storefront
+     * route PRE-DATES the mirror and used to hand-roll the partner logic, so
+     * these tests pin a reconciliation, not just a new route. Second, both
+     * partner routes here WRITE off the back of their read (stale-ref cleanup,
+     * website_id backfill) — the mirror must produce the same view without
+     * performing either, which is asserted directly rather than assumed.
+     *
+     * Hosting cannot be provisioned in tests (no Vercel/Cloudflare creds), so
+     * the seed sets the partner's storefront_domain + a real website record —
+     * the state a provisioned partner is in from the website surface's point of
+     * view, which is the part this slice mirrors.
+     */
+    describe("storefront / website", () => {
+      const seedWebsite = async (partnerId: string) => {
+        const unique = Date.now() + Math.random().toString(36).slice(2, 6)
+        const domain = `inspect-${unique}.example.com`
+
+        const websiteRes = await api.post(
+          "/admin/websites",
+          { domain, name: `Inspect Site ${unique}` },
+          adminHeaders
+        )
+        const websiteId = websiteRes.data.website.id
+
+        await api.post(
+          `/admin/websites/${websiteId}/pages`,
+          {
+            title: `Inspect Page ${unique}`,
+            slug: `inspect-page-${unique}`,
+            content: "seeded for the inspection mirror",
+            page_type: "Custom",
+            status: "Published",
+          },
+          adminHeaders
+        )
+
+        // Point the partner at it the way provisioning would. Done through the
+        // module rather than an API because storefront provisioning needs
+        // hosting credentials this suite does not have.
+        const partnerService: any = getContainer().resolve("partner")
+        await partnerService.updatePartners({
+          id: partnerId,
+          storefront_domain: domain,
+          website_id: websiteId,
+        })
+
+        return { domain, websiteId }
+      }
+
+      it("mirrors GET /partners/storefront/website over a seeded website", async () => {
+        const { websiteId, domain } = await seedWebsite(partner.partnerId)
+
+        const viaAdmin = await api.get(
+          `/admin/partners/${partner.partnerId}/storefront/website`,
+          adminHeaders
+        )
+        const viaPartner = await api.get("/partners/storefront/website", {
+          headers: partner.headers,
+        })
+
+        expect(viaAdmin.status).toBe(200)
+        expect(viaAdmin.data.website.id).toBe(viaPartner.data.website.id)
+        expect(viaAdmin.data.website.id).toBe(websiteId)
+        expect(viaAdmin.data.website.domain).toBe(domain)
+      })
+
+      it("mirrors GET /partners/storefront/pages over seeded pages", async () => {
+        await seedWebsite(partner.partnerId)
+
+        const viaAdmin = await api.get(
+          `/admin/partners/${partner.partnerId}/storefront/pages`,
+          adminHeaders
+        )
+        const viaPartner = await api.get("/partners/storefront/pages", {
+          headers: partner.headers,
+        })
+
+        expect(viaAdmin.status).toBe(200)
+        // Seeded, so this is a comparison of NON-empty lists — two empty ones
+        // agree even against a completely broken mirror.
+        expect(viaAdmin.data.count).toBeGreaterThan(0)
+        expect(viaAdmin.data.count).toBe(viaPartner.data.count)
+        expect(viaAdmin.data.pages.map((p: any) => p.id)).toEqual(
+          viaPartner.data.pages.map((p: any) => p.id)
+        )
+      })
+
+      it("mirrors the pages status filter", async () => {
+        await seedWebsite(partner.partnerId)
+
+        const viaAdmin = await api.get(
+          `/admin/partners/${partner.partnerId}/storefront/pages?status=Published`,
+          adminHeaders
+        )
+        const viaPartner = await api.get(
+          "/partners/storefront/pages?status=Published",
+          { headers: partner.headers }
+        )
+
+        expect(viaAdmin.data.count).toBe(viaPartner.data.count)
+        expect(viaAdmin.data.pages.map((p: any) => p.id)).toEqual(
+          viaPartner.data.pages.map((p: any) => p.id)
+        )
+      })
+
+      it("exposes the partner theme editor's own preview URL", async () => {
+        const { domain } = await seedWebsite(partner.partnerId)
+
+        const res = await api.get(
+          `/admin/partners/${partner.partnerId}/storefront/website`,
+          adminHeaders
+        )
+
+        // Same URL apps/partner-ui builds for its theme-editor iframe, so the
+        // operator sees the storefront as the partner is editing it.
+        expect(res.data.preview_url).toBe(`https://${domain}/?theme_editor=true`)
+      })
+
+      it("reports an unprovisioned storefront as a state, not an error", async () => {
+        // The partner surface 404s here; the mirror deliberately does not —
+        // "no storefront yet" is the normal state the onboarding flow exists to
+        // fix, and an operator has to be able to see it.
+        const website = await api.get(
+          `/admin/partners/${partner.partnerId}/storefront/website`,
+          adminHeaders
+        )
+        expect(website.status).toBe(200)
+        expect(website.data.website).toBeNull()
+        expect(website.data.reason).toBe("not_provisioned")
+
+        const pages = await api.get(
+          `/admin/partners/${partner.partnerId}/storefront/pages`,
+          adminHeaders
+        )
+        expect(pages.status).toBe(200)
+        expect(pages.data.pages).toHaveLength(0)
+        expect(pages.data.website_id).toBeNull()
+      })
+
+      it("does NOT backfill website_id — the mirror never writes", async () => {
+        const { websiteId, domain } = await seedWebsite(partner.partnerId)
+
+        // Clear website_id so resolution has to fall back to the domain lookup.
+        // That fallback is exactly what makes the PARTNER route write.
+        const partnerService: any = getContainer().resolve("partner")
+        await partnerService.updatePartners({
+          id: partner.partnerId,
+          website_id: null,
+        })
+
+        const viaAdmin = await api.get(
+          `/admin/partners/${partner.partnerId}/storefront/website`,
+          adminHeaders
+        )
+        expect(viaAdmin.data.website.id).toBe(websiteId)
+        expect(viaAdmin.data.resolved_by).toBe("domain")
+
+        // Still null: the admin read resolved via the domain but wrote nothing.
+        const after = await partnerService.retrievePartner(partner.partnerId)
+        expect(after.website_id ?? null).toBeNull()
+        expect(after.storefront_domain).toBe(domain)
+      })
+
+      it("mirrors GET /partners/storefront hosting status", async () => {
+        const viaAdmin = await api.get(
+          `/admin/partners/${partner.partnerId}/storefront`,
+          adminHeaders
+        )
+        const viaPartner = await api.get("/partners/storefront", {
+          headers: partner.headers,
+        })
+
+        expect(viaAdmin.status).toBe(200)
+        expect(viaAdmin.data.provisioned).toBe(viaPartner.data.provisioned)
+        expect(viaAdmin.data.provider).toBe(viaPartner.data.provider)
+        // The flags the pre-mirror admin copy silently omitted — pinned so the
+        // reconciliation cannot quietly regress.
+        expect(viaAdmin.data.vercel_configured).toBe(
+          viaPartner.data.vercel_configured
+        )
+        expect(viaAdmin.data.cloudflare_configured).toBe(
+          viaPartner.data.cloudflare_configured
+        )
+      })
+
+      it("scopes to the partner — another partner's website never leaks in", async () => {
+        await seedWebsite(partner.partnerId)
+        const other = await createPartner(api)
+
+        const res = await api.get(
+          `/admin/partners/${other.partnerId}/storefront/website`,
+          adminHeaders
+        )
+
+        expect(res.status).toBe(200)
+        expect(res.data.website).toBeNull()
+      })
+
+      it("404s for an unknown partner", async () => {
+        const err = await api
+          .get(
+            "/admin/partners/partner_does_not_exist/storefront/website",
+            adminHeaders
+          )
+          .catch((e: any) => e)
+
+        expect(err.response.status).toBe(404)
+      })
+
+      it("requires admin auth", async () => {
+        const err = await api
+          .get(`/admin/partners/${partner.partnerId}/storefront/website`)
+          .catch((e: any) => e)
+
+        expect(err.response.status).toBe(401)
+      })
+
+      it("is read-only — no write verb is exposed", async () => {
+        const err = await api
+          .post(
+            `/admin/partners/${partner.partnerId}/storefront/pages`,
+            { title: "nope", slug: "nope", content: "nope" },
+            adminHeaders
+          )
+          .catch((e: any) => e)
+
+        expect(err.response.status).toBe(404)
+      })
+    })
   })
 })

--- a/apps/backend/src/admin/components/partners/partner-inspection-section.tsx
+++ b/apps/backend/src/admin/components/partners/partner-inspection-section.tsx
@@ -8,9 +8,9 @@
  * Read-only by construction: no action menus, no mutations. Acting on a
  * partner's behalf is the separate audited-impersonation track.
  *
- * The top-level tabs are the SURFACE (orders / designs / runs / products); the
- * order-kind discriminator is a sub-tab of Orders, since it only means anything
- * there.
+ * The top-level tabs are the SURFACE (orders / designs / runs / products /
+ * inventory / website); the order-kind discriminator is a sub-tab of Orders,
+ * since it only means anything there.
  */
 import { Badge, Container, Heading, Table, Tabs, Text } from "@medusajs/ui"
 import { useState } from "react"
@@ -26,6 +26,9 @@ import {
   usePartnerInspectionInventoryItems,
   usePartnerInspectionInventoryOrders,
   usePartnerOnboardingProfile,
+  usePartnerInspectionStorefront,
+  usePartnerInspectionWebsite,
+  usePartnerInspectionPages,
 } from "../../hooks/api/partner-inspection"
 
 interface PartnerInspectionSectionProps {
@@ -38,6 +41,7 @@ type InspectionSurface =
   | "runs"
   | "products"
   | "inventory"
+  | "website"
 
 const SURFACES: { value: InspectionSurface; label: string }[] = [
   { value: "orders", label: "Orders" },
@@ -45,6 +49,7 @@ const SURFACES: { value: InspectionSurface; label: string }[] = [
   { value: "runs", label: "Production runs" },
   { value: "products", label: "Products" },
   { value: "inventory", label: "Inventory" },
+  { value: "website", label: "Website" },
 ]
 
 /** Inventory splits two ways the partner portal itself splits them. */
@@ -111,6 +116,24 @@ const statusColor = (status?: string) => {
       return "grey" as const
   }
 }
+
+/** Label-over-value pair, for the storefront surface's summary grids. */
+const Field = ({
+  label,
+  children,
+}: {
+  label: string
+  children: React.ReactNode
+}) => (
+  <div className="flex flex-col">
+    <Text size="xsmall" className="text-ui-fg-muted">
+      {label}
+    </Text>
+    <Text size="small" className="text-ui-fg-subtle" asChild>
+      <div>{children}</div>
+    </Text>
+  </div>
+)
 
 const EmptyRow = ({ children }: { children: React.ReactNode }) => (
   <div className="px-6 py-8 text-center">
@@ -664,6 +687,193 @@ const InventoryPanel = ({ partnerId }: { partnerId: string }) => {
   )
 }
 
+/**
+ * The storefront surface (#843 slice 5). Unlike the other panels this is not a
+ * single list — an operator asking "what's up with their storefront?" needs the
+ * hosting state, the site itself, and its pages together, because the useful
+ * answer is usually the relationship between them ("provisioned, but no website
+ * record" / "website exists but every page is draft").
+ */
+const WebsitePanel = ({ partnerId }: { partnerId: string }) => {
+  const {
+    storefrontStatus: status,
+    isLoading: isStatusLoading,
+    isError: isStatusError,
+    error: statusError,
+  } = usePartnerInspectionStorefront(partnerId)
+  const {
+    website,
+    previewUrl,
+    reason,
+    isLoading: isWebsiteLoading,
+  } = usePartnerInspectionWebsite(partnerId)
+  const { pages, count, isLoading: isPagesLoading } =
+    usePartnerInspectionPages(partnerId, { limit: PAGE_SIZE })
+
+  if (isStatusError) {
+    throw statusError
+  }
+
+  if (isStatusLoading || isWebsiteLoading) {
+    return <LoadingRows />
+  }
+
+  return (
+    <div className="divide-y">
+      <div className="grid grid-cols-2 gap-x-4 gap-y-2 px-6 py-4 md:grid-cols-4">
+        <Field label="Hosting">
+          <Badge
+            size="2xsmall"
+            color={status?.provisioned ? "green" : "grey"}
+          >
+            {status?.provisioned ? "Provisioned" : "Not provisioned"}
+          </Badge>
+        </Field>
+        <Field label="Provider">{status?.provider || "—"}</Field>
+        <Field label="Domain">
+          {status?.storefront_url ? (
+            // Opening a partner's own storefront is safe — it is a public page.
+            <a
+              href={status.storefront_url}
+              target="_blank"
+              rel="noreferrer"
+              className="text-ui-fg-interactive"
+            >
+              {status.domain}
+            </a>
+          ) : (
+            "—"
+          )}
+        </Field>
+        <Field label="Last deployment">
+          {status?.latest_deployment ? (
+            <Badge
+              size="2xsmall"
+              color={statusColor(status.latest_deployment.status)}
+            >
+              {status.latest_deployment.status}
+            </Badge>
+          ) : (
+            "—"
+          )}
+        </Field>
+      </div>
+
+      {/* Both of these are states an operator must be able to act on, and the
+          partner route repairs them silently on its next read — the mirror only
+          reports, so say so plainly here. */}
+      {status?.stale_project && (
+        <div className="px-6 py-3">
+          <Text size="small" className="text-ui-fg-error">
+            The hosting provider no longer knows this project — the partner&apos;s
+            stored references are stale. They are cleared the next time the
+            partner opens their own storefront page; this view never writes.
+          </Text>
+        </div>
+      )}
+      {status?.error && (
+        <div className="px-6 py-3">
+          <Text size="small" className="text-ui-fg-subtle">
+            {status.error}
+          </Text>
+        </div>
+      )}
+
+      <div className="px-6 py-4">
+        <Text size="small" weight="plus" className="mb-2">
+          Website
+        </Text>
+        {!website ? (
+          <Text size="small" className="text-ui-fg-muted">
+            {reason === "not_provisioned"
+              ? "No storefront provisioned yet — nothing to edit."
+              : "Storefront provisioned, but no website record exists yet. The partner creates one from their Content section."}
+          </Text>
+        ) : (
+          <div className="grid grid-cols-2 gap-x-4 gap-y-2 md:grid-cols-4">
+            <Field label="Name">{website.name || "—"}</Field>
+            <Field label="Status">
+              <Badge size="2xsmall" color={statusColor(website.status)}>
+                {website.status || "—"}
+              </Badge>
+            </Field>
+            <Field label="Pages">{count}</Field>
+            <Field label="Theme preview">
+              {previewUrl ? (
+                // The same URL the partner's own theme editor frames, so this
+                // shows the storefront as they are editing it, not as published.
+                <a
+                  href={previewUrl}
+                  target="_blank"
+                  rel="noreferrer"
+                  className="text-ui-fg-interactive"
+                >
+                  Open
+                </a>
+              ) : (
+                "—"
+              )}
+            </Field>
+          </div>
+        )}
+      </div>
+
+      {website && (
+        <div className="overflow-x-auto">
+          {isPagesLoading ? (
+            <LoadingRows />
+          ) : pages.length === 0 ? (
+            <EmptyRow>This website has no pages yet</EmptyRow>
+          ) : (
+            <Table className="w-full">
+              <Table.Header>
+                <Table.Row>
+                  <Table.HeaderCell>Page</Table.HeaderCell>
+                  <Table.HeaderCell>Slug</Table.HeaderCell>
+                  <Table.HeaderCell>Type</Table.HeaderCell>
+                  <Table.HeaderCell>Status</Table.HeaderCell>
+                  <Table.HeaderCell className="text-right">
+                    Updated
+                  </Table.HeaderCell>
+                </Table.Row>
+              </Table.Header>
+              <Table.Body>
+                {pages.map((page) => (
+                  <Table.Row key={page.id}>
+                    <Table.Cell>
+                      <Text size="small">{page.title || page.id}</Text>
+                    </Table.Cell>
+                    <Table.Cell>
+                      <Text size="small" className="text-ui-fg-subtle">
+                        {page.slug || "—"}
+                      </Text>
+                    </Table.Cell>
+                    <Table.Cell>
+                      <Text size="small" className="text-ui-fg-subtle">
+                        {page.page_type || "—"}
+                      </Text>
+                    </Table.Cell>
+                    <Table.Cell>
+                      <Badge size="2xsmall" color={statusColor(page.status)}>
+                        {page.status || "—"}
+                      </Badge>
+                    </Table.Cell>
+                    <Table.Cell className="text-right">
+                      <Text size="small" className="text-ui-fg-subtle">
+                        {formatDate(page.updated_at)}
+                      </Text>
+                    </Table.Cell>
+                  </Table.Row>
+                ))}
+              </Table.Body>
+            </Table>
+          )}
+        </div>
+      )}
+    </div>
+  )
+}
+
 export const PartnerInspectionSection = ({
   partnerId,
 }: PartnerInspectionSectionProps) => {
@@ -703,6 +913,7 @@ export const PartnerInspectionSection = ({
       {surface === "runs" && <ProductionRunsPanel partnerId={partnerId} />}
       {surface === "products" && <ProductsPanel partnerId={partnerId} />}
       {surface === "inventory" && <InventoryPanel partnerId={partnerId} />}
+      {surface === "website" && <WebsitePanel partnerId={partnerId} />}
 
       <div className="px-6 py-4">
         <Text size="small" weight="plus" className="mb-2">

--- a/apps/backend/src/admin/hooks/api/partner-inspection.ts
+++ b/apps/backend/src/admin/hooks/api/partner-inspection.ts
@@ -407,3 +407,159 @@ export const usePartnerOnboardingProfile = (
     ...rest,
   }
 }
+
+/**
+ * The storefront surface (#843 slice 5) reads three things: hosting status,
+ * the website + theme, and the pages. Status comes from the route that already
+ * existed for provisioning; the other two are the mirror proper.
+ */
+export interface PartnerInspectionStorefrontStatus {
+  provisioned: boolean
+  provider: string
+  message?: string
+  project?: { id: string | null; name: string | null }
+  domain?: string | null
+  storefront_url?: string | null
+  provisioned_at?: string | null
+  latest_deployment?: {
+    id: string
+    url: string
+    status: string
+    created_at: number
+  } | null
+  error?: string
+  vercel_configured?: boolean
+  cloudflare_configured?: boolean
+  /** Provider 404'd on a project we still reference. Reported, never repaired here. */
+  stale_project?: boolean
+}
+
+export const usePartnerInspectionStorefront = (
+  partnerId: string,
+  options?: Omit<
+    UseQueryOptions<
+      PartnerInspectionStorefrontStatus,
+      FetchError,
+      PartnerInspectionStorefrontStatus,
+      QueryKey
+    >,
+    "queryFn" | "queryKey"
+  >
+) => {
+  const { data, ...rest } = useQuery({
+    queryFn: async () =>
+      sdk.client.fetch<PartnerInspectionStorefrontStatus>(
+        `/admin/partners/${partnerId}/storefront`,
+        { method: "GET" }
+      ),
+    queryKey: partnerInspectionQueryKeys.detail(partnerId, {
+      storefront: true,
+    }),
+    enabled: !!partnerId,
+    ...options,
+  })
+
+  // NOT `status` — react-query puts its own `status` in `rest`, and spreading
+  // it last would silently overwrite ours with "success".
+  return { storefrontStatus: data ?? null, ...rest }
+}
+
+export interface PartnerInspectionWebsiteResponse {
+  website: {
+    id: string
+    name?: string
+    domain?: string
+    status?: string
+    theme?: Record<string, any> | null
+    metadata?: Record<string, any> | null
+  } | null
+  theme: Record<string, any> | null
+  /** The partner theme editor's own iframe URL (`?theme_editor=true`). */
+  preview_url: string | null
+  reason?: "not_provisioned" | "no_website"
+  message?: string
+  resolved_by?: "website_id" | "domain" | null
+}
+
+export const usePartnerInspectionWebsite = (
+  partnerId: string,
+  options?: Omit<
+    UseQueryOptions<
+      PartnerInspectionWebsiteResponse,
+      FetchError,
+      PartnerInspectionWebsiteResponse,
+      QueryKey
+    >,
+    "queryFn" | "queryKey"
+  >
+) => {
+  const { data, ...rest } = useQuery({
+    queryFn: async () =>
+      sdk.client.fetch<PartnerInspectionWebsiteResponse>(
+        `/admin/partners/${partnerId}/storefront/website`,
+        { method: "GET" }
+      ),
+    queryKey: partnerInspectionQueryKeys.detail(partnerId, { website: true }),
+    enabled: !!partnerId,
+    ...options,
+  })
+
+  return {
+    website: data?.website ?? null,
+    theme: data?.theme ?? null,
+    previewUrl: data?.preview_url ?? null,
+    reason: data?.reason,
+    ...rest,
+  }
+}
+
+export interface PartnerInspectionPage {
+  id: string
+  title?: string
+  slug?: string
+  status?: string
+  page_type?: string
+  updated_at?: string
+}
+
+export interface PartnerInspectionPagesResponse {
+  pages: PartnerInspectionPage[]
+  count: number
+  offset: number
+  limit: number
+  hasMore: boolean
+  website_id: string | null
+  reason?: "not_provisioned" | "no_website"
+}
+
+export const usePartnerInspectionPages = (
+  partnerId: string,
+  query?: { q?: string; status?: string; page_type?: string; limit?: number },
+  options?: Omit<
+    UseQueryOptions<
+      PartnerInspectionPagesResponse,
+      FetchError,
+      PartnerInspectionPagesResponse,
+      QueryKey
+    >,
+    "queryFn" | "queryKey"
+  >
+) => {
+  const { data, ...rest } = useQuery({
+    queryFn: async () =>
+      sdk.client.fetch<PartnerInspectionPagesResponse>(
+        `/admin/partners/${partnerId}/storefront/pages`,
+        { method: "GET", query }
+      ),
+    queryKey: partnerInspectionQueryKeys.detail(partnerId, { pages: query }),
+    enabled: !!partnerId,
+    ...options,
+  })
+
+  return {
+    pages: data?.pages || [],
+    count: data?.count || 0,
+    websiteId: data?.website_id ?? null,
+    ...rest,
+  }
+}

--- a/apps/backend/src/api/admin/partners/[id]/lib/partner-inspection.ts
+++ b/apps/backend/src/api/admin/partners/[id]/lib/partner-inspection.ts
@@ -117,6 +117,37 @@ export const resolvePartnerInspectionStoreId = async (
 }
 
 /**
+ * The FULL partner record, for the storefront surfaces (#843 slice 5).
+ *
+ * The other surfaces only ever need the partner's id — they hand the
+ * synthesized context to a partner helper and let it do the scoping. The
+ * storefront surfaces are different: their partner-side logic reads the
+ * record's own columns (`hosting_provider`, `vercel_project_id`,
+ * `storefront_domain`, `website_id`, and the pre-#884 `metadata` fallbacks), so
+ * the mirror has to pass the same record in rather than an id.
+ *
+ * 404s on an unknown partner for the same reason `assertPartnerExists` does.
+ */
+export const getPartnerInspectionRecord = async (
+  partnerId: string,
+  container: MedusaContainer
+): Promise<any> => {
+  const query = container.resolve(ContainerRegistrationKeys.QUERY)
+  const { data } = await query.graph({
+    entity: "partners",
+    fields: ["*"],
+    filters: { id: partnerId },
+  })
+
+  const partner = data?.[0]
+  if (!partner) {
+    throw new MedusaError(MedusaError.Types.NOT_FOUND, "Partner not found")
+  }
+
+  return partner
+}
+
+/**
  * The two together: 404 on an unknown partner, otherwise the synthesized
  * context the partner helpers expect.
  */

--- a/apps/backend/src/api/admin/partners/[id]/storefront/pages/route.ts
+++ b/apps/backend/src/api/admin/partners/[id]/storefront/pages/route.ts
@@ -1,0 +1,80 @@
+/**
+ * @file Admin read-proxy: a partner's storefront pages (#843).
+ * @module API/Admin/Partners/Storefront/Pages
+ */
+import { MedusaRequest, MedusaResponse } from "@medusajs/framework/http"
+
+import { listPageWorkflow } from "../../../../../../workflows/website/website-page/list-page"
+import { resolvePartnerWebsiteWorkflow } from "../../../../../../workflows/partners/resolve-partner-website"
+import { getPartnerInspectionRecord } from "../../lib/partner-inspection"
+
+/**
+ * GET /admin/partners/:id/storefront/pages
+ *
+ * The inspection mirror of `GET /partners/storefront/pages`: same query
+ * contract (`q`, `status`, `page_type`, `limit`, `offset`), same
+ * `listPageWorkflow`, same response shape — the partner route already ran that
+ * workflow, so only resolving WHICH website differs.
+ *
+ * A partner with no provisioned storefront (or a provisioned one with no
+ * website yet) reads as an EMPTY LIST here, not the 404 the partner surface
+ * throws. That is deliberate and follows the same call as
+ * `resolvePartnerInspectionStoreId`: "no storefront yet" is a normal state an
+ * operator needs to see — it is what the onboarding flow exists to fix — not an
+ * error. `website_id: null` makes the state explicit rather than implied by an
+ * empty list.
+ *
+ * READ-ONLY. There is deliberately no POST: creating a page on a partner's
+ * behalf is the audited impersonation track (approach #1 on #843).
+ */
+export const GET = async (req: MedusaRequest, res: MedusaResponse) => {
+  const { id: partnerId } = req.params
+
+  const { q, status, page_type } = req.query
+  const offset = parseInt(req.query.offset as string) || 0
+  const limit = parseInt(req.query.limit as string) || 20
+
+  const partner = await getPartnerInspectionRecord(partnerId, req.scope)
+
+  const { result: resolution } = await resolvePartnerWebsiteWorkflow(
+    req.scope
+  ).run({ input: { partner } })
+
+  if (!resolution.website) {
+    return res.json({
+      pages: [],
+      count: 0,
+      offset,
+      limit,
+      hasMore: false,
+      website_id: null,
+      reason: resolution.reason,
+    })
+  }
+
+  const { result } = await listPageWorkflow(req.scope).run({
+    input: {
+      website_id: resolution.website.id,
+      filters: {
+        title: q,
+        status,
+        page_type,
+      },
+      config: {
+        skip: offset,
+        take: limit,
+      },
+    },
+  })
+
+  const [pages, count] = result
+
+  res.json({
+    pages,
+    count,
+    offset,
+    limit,
+    hasMore: offset + pages.length < count,
+    website_id: resolution.website.id,
+  })
+}

--- a/apps/backend/src/api/admin/partners/[id]/storefront/route.ts
+++ b/apps/backend/src/api/admin/partners/[id]/storefront/route.ts
@@ -1,110 +1,37 @@
-import { AuthenticatedMedusaRequest, MedusaResponse } from "@medusajs/framework/http"
-import { ContainerRegistrationKeys, MedusaError } from "@medusajs/framework/utils"
-import { DEPLOYMENT_MODULE } from "../../../../../modules/deployment"
-import type DeploymentService from "../../../../../modules/deployment/service"
-import { resolveHostingProviderForPartner } from "../../../../../modules/deployment/providers/resolve-partner-provider"
-import { getStorefrontRefs } from "../../../../partners/storefront/helpers"
+/**
+ * @file Admin read-proxy: a partner's storefront hosting status (#843).
+ * @module API/Admin/Partners/Storefront
+ */
+import { MedusaRequest, MedusaResponse } from "@medusajs/framework/http"
 
-export const GET = async (
-  req: AuthenticatedMedusaRequest,
-  res: MedusaResponse
-) => {
+import { getPartnerStorefrontStatusWorkflow } from "../../../../../workflows/partners/get-partner-storefront-status"
+import { getPartnerInspectionRecord } from "../lib/partner-inspection"
+
+/**
+ * GET /admin/partners/:id/storefront
+ *
+ * The inspection mirror of `GET /partners/storefront`.
+ *
+ * This route PRE-DATES the #843 mirror and used to hand-roll its own copy of
+ * the partner logic — which had already drifted: it omitted the
+ * provider-not-resolvable branch, the `vercel_configured` /
+ * `cloudflare_configured` flags, and the stale-project detection. It now runs
+ * the same workflow the partner route runs, so the two cannot diverge again.
+ *
+ * READ-ONLY. The partner route clears a partner's stale provider refs when the
+ * project has vanished; this one reports that state via `stale_project` and
+ * writes nothing. An operator opening a tab must never mutate a partner record.
+ */
+export const GET = async (req: MedusaRequest, res: MedusaResponse) => {
   const { id: partnerId } = req.params
-  const query = req.scope.resolve(ContainerRegistrationKeys.QUERY)
 
-  const { data: partners } = await query.graph({
-    entity: "partners",
-    fields: ["*"],
-    filters: { id: partnerId },
-  })
+  // 404s on an unknown partner before any partner-voiced error can reach an
+  // admin caller.
+  const partner = await getPartnerInspectionRecord(partnerId, req.scope)
 
-  if (!partners?.length) {
-    throw new MedusaError(MedusaError.Types.NOT_FOUND, `Partner ${partnerId} not found`)
-  }
+  const { result: status } = await getPartnerStorefrontStatusWorkflow(
+    req.scope
+  ).run({ input: { partner } })
 
-  const partner = partners[0] as any
-  const refs = getStorefrontRefs(partner)
-
-  const { providerName, provider, projectRef } =
-    await resolveHostingProviderForPartner(partner, req.scope).catch(() => ({
-      providerName: "vercel" as const,
-      provider: null as any,
-      projectRef: null,
-    }))
-
-  if (!projectRef) {
-    return res.json({
-      provisioned: false,
-      message: "Storefront has not been provisioned yet",
-    })
-  }
-
-  try {
-    const project = await provider.getProject(projectRef)
-
-    // Vercel exposes latest-deployment detail; other providers don't (yet) —
-    // the provider interface's getProject stays minimal, so this richer status
-    // is a Vercel-only enhancement.
-    let deploymentInfo: {
-      id: string
-      url: string
-      status: string
-      created_at: number
-    } | null = null
-
-    if (providerName === "vercel") {
-      const deployment: DeploymentService = req.scope.resolve(DEPLOYMENT_MODULE)
-      const full = await deployment.getProject(projectRef)
-      const latestDeployment = full.latestDeployments?.[0]
-      if (latestDeployment) {
-        try {
-          const details = await deployment.getDeployment(latestDeployment.id)
-          deploymentInfo = {
-            id: details.id,
-            url: details.url,
-            status: details.readyState,
-            created_at: details.createdAt,
-          }
-        } catch {
-          deploymentInfo = {
-            id: latestDeployment.id,
-            url: latestDeployment.url,
-            status: latestDeployment.readyState,
-            created_at: latestDeployment.createdAt,
-          }
-        }
-      }
-    }
-
-    res.json({
-      provisioned: true,
-      provider: providerName,
-      project: {
-        id: project.id,
-        name: project.name,
-      },
-      domain: refs.storefrontDomain,
-      storefront_url: refs.storefrontDomain
-        ? `https://${refs.storefrontDomain}`
-        : null,
-      provisioned_at: refs.storefrontProvisionedAt,
-      latest_deployment: deploymentInfo,
-    })
-  } catch (e: any) {
-    res.json({
-      provisioned: true,
-      provider: providerName,
-      project: {
-        id: refs.vercelProjectId,
-        name: refs.vercelProjectName,
-      },
-      domain: refs.storefrontDomain,
-      storefront_url: refs.storefrontDomain
-        ? `https://${refs.storefrontDomain}`
-        : null,
-      provisioned_at: refs.storefrontProvisionedAt,
-      latest_deployment: null,
-      error: `Could not fetch storefront status: ${e.message}`,
-    })
-  }
+  res.json(status)
 }

--- a/apps/backend/src/api/admin/partners/[id]/storefront/website/route.ts
+++ b/apps/backend/src/api/admin/partners/[id]/storefront/website/route.ts
@@ -1,0 +1,58 @@
+/**
+ * @file Admin read-proxy: a partner's website + theme (#843).
+ * @module API/Admin/Partners/Storefront/Website
+ */
+import { MedusaRequest, MedusaResponse } from "@medusajs/framework/http"
+
+import { resolvePartnerWebsiteWorkflow } from "../../../../../../workflows/partners/resolve-partner-website"
+import { getPartnerInspectionRecord } from "../../lib/partner-inspection"
+
+/**
+ * GET /admin/partners/:id/storefront/website
+ *
+ * The inspection mirror of `GET /partners/storefront/website`, plus the theme
+ * that `GET /partners/storefront/website/theme` returns — folded into one
+ * response because the admin surface renders them together and both come from
+ * the same resolved website record. The theme is read exactly as the partner
+ * route reads it: dedicated `theme` column, legacy `metadata.theme` fallback.
+ *
+ * `preview_url` is the same URL the partner portal's theme editor builds for
+ * its iframe (`?theme_editor=true`), so an operator sees the storefront in the
+ * state the partner is editing it in, rather than the published state.
+ *
+ * READ-ONLY. The partner route backfills `website_id` when it resolves via the
+ * domain fallback; this one surfaces that as `resolved_by: "domain"` and writes
+ * nothing.
+ */
+export const GET = async (req: MedusaRequest, res: MedusaResponse) => {
+  const { id: partnerId } = req.params
+
+  const partner = await getPartnerInspectionRecord(partnerId, req.scope)
+
+  const { result: resolution } = await resolvePartnerWebsiteWorkflow(
+    req.scope
+  ).run({ input: { partner } })
+
+  if (!resolution.website) {
+    return res.json({
+      website: null,
+      theme: null,
+      preview_url: null,
+      reason: resolution.reason,
+      message: resolution.message,
+    })
+  }
+
+  const website = resolution.website
+  const domain = website.domain as string | null
+
+  res.json({
+    website,
+    theme: website.theme || website.metadata?.theme || {},
+    // Mirrors apps/partner-ui/src/routes/settings/theme/theme.tsx.
+    preview_url: domain
+      ? `${domain.startsWith("http") ? domain : `https://${domain}`}/?theme_editor=true`
+      : null,
+    resolved_by: resolution.resolved_by,
+  })
+}

--- a/apps/backend/src/api/partners/storefront/route.ts
+++ b/apps/backend/src/api/partners/storefront/route.ts
@@ -12,6 +12,7 @@ import {
 } from "../../../modules/deployment/providers/resolve-partner-provider"
 import updatePartnerWorkflow from "../../../workflows/partners/update-partner"
 import { getStorefrontRefs } from "./helpers"
+import { getPartnerStorefrontStatusWorkflow } from "../../../workflows/partners/get-partner-storefront-status"
 
 const STOREFRONT_META_KEYS = [
   "vercel_project_id",
@@ -31,6 +32,17 @@ function stripStorefrontKeys(metadata: any): Record<string, any> | null {
   return Object.keys(clean).length > 0 ? clean : null
 }
 
+/**
+ * GET /partners/storefront
+ *
+ * Hosting status for the partner's storefront. The resolution itself lives in
+ * `getPartnerStorefrontStatusWorkflow` so the admin inspection mirror
+ * (`GET /admin/partners/:id/storefront`) reports the identical state (#843).
+ *
+ * The one thing that stays here is the WRITE: when the provider no longer knows
+ * the project, the refs we hold are stale and the partner's record is cleaned
+ * up. The mirror deliberately reports `stale_project` without performing it.
+ */
 export const GET = async (
   req: AuthenticatedMedusaRequest,
   res: MedusaResponse
@@ -43,136 +55,39 @@ export const GET = async (
     )
   }
 
-  const deployment: DeploymentService = req.scope.resolve(DEPLOYMENT_MODULE)
-  const refs = getStorefrontRefs(partner)
+  const { result: status } = await getPartnerStorefrontStatusWorkflow(
+    req.scope
+  ).run({ input: { partner } })
 
-  if (!refs.projectRef) {
-    return res.json({
-      provisioned: false,
-      provider: refs.providerName,
-      message: "Storefront has not been provisioned yet",
-      vercel_configured: deployment.isVercelConfigured(),
-      cloudflare_configured: deployment.isCloudflareConfigured(),
-    })
-  }
-
-  // Resolve the partner's provider (Vercel/Cloudflare Pages/Netlify/Render) and
-  // confirm the project still exists. Vercel keeps its richer latest-deployment
-  // detail; other providers report existence + the stored deployment id.
-  let provider: Awaited<ReturnType<typeof resolveHostingProviderForPartner>>
-  try {
-    provider = await resolveHostingProviderForPartner(partner, req.scope)
-  } catch (e: any) {
-    return res.json({
-      provisioned: true,
-      provider: refs.providerName,
-      project: { id: refs.projectRef, name: refs.vercelProjectName },
-      domain: refs.storefrontDomain,
-      storefront_url: refs.storefrontDomain ? `https://${refs.storefrontDomain}` : null,
-      provisioned_at: refs.storefrontProvisionedAt,
-      latest_deployment: null,
-      error: `Hosting provider not resolvable: ${e.message}`,
-    })
-  }
-
-  try {
-    const project = await provider.provider.getProject(refs.projectRef)
-
-    let deploymentInfo: {
-      id: string
-      url: string
-      status: string
-      created_at: number
-    } | null = null
-
-    // Vercel exposes latest-deployment detail via the legacy service client.
-    if (refs.providerName === "vercel") {
-      try {
-        const vProject = await deployment.getProject(refs.projectRef)
-        const latest = vProject.latestDeployments?.[0]
-        if (latest) {
-          try {
-            const details = await deployment.getDeployment(latest.id)
-            deploymentInfo = {
-              id: details.id,
-              url: details.url,
-              status: details.readyState,
-              created_at: details.createdAt,
-            }
-          } catch {
-            deploymentInfo = {
-              id: latest.id,
-              url: latest.url,
-              status: latest.readyState,
-              created_at: latest.createdAt,
-            }
-          }
-        }
-      } catch {
-        // non-fatal — status still returns
-      }
-    }
-
-    res.json({
-      provisioned: true,
-      provider: refs.providerName,
-      project: { id: project.id, name: project.name },
-      domain: refs.storefrontDomain,
-      storefront_url: refs.storefrontDomain
-        ? `https://${refs.storefrontDomain}`
-        : null,
-      provisioned_at: refs.storefrontProvisionedAt,
-      latest_deployment: deploymentInfo,
-      vercel_configured: deployment.isVercelConfigured(),
-      cloudflare_configured: deployment.isCloudflareConfigured(),
-    })
-  } catch (e: any) {
-    // Project no longer exists on the provider (404) — treat as unprovisioned
-    // and clear stale references.
-    const is404 = e.message?.includes("(404)") || e.message?.includes("NOT_FOUND")
-    if (is404) {
-      try {
-        await updatePartnerWorkflow(req.scope).run({
-          input: {
-            id: partner.id,
-            data: {
-              metadata: stripStorefrontKeys(partner.metadata),
-              hosting_provider: null,
-              deployment_account_id: null,
-              deployment_project_id: null,
-              deployment_project_name: null,
-              vercel_project_id: null,
-              vercel_project_name: null,
-              vercel_last_deployment_id: null,
-              vercel_linked: false,
-              storefront_domain: null,
-            },
+  if (status.stale_project) {
+    try {
+      await updatePartnerWorkflow(req.scope).run({
+        input: {
+          id: partner.id,
+          data: {
+            metadata: stripStorefrontKeys(partner.metadata),
+            hosting_provider: null,
+            deployment_account_id: null,
+            deployment_project_id: null,
+            deployment_project_name: null,
+            vercel_project_id: null,
+            vercel_project_name: null,
+            vercel_last_deployment_id: null,
+            vercel_linked: false,
+            storefront_domain: null,
           },
-        })
-      } catch {
-        // best-effort cleanup
-      }
-
-      return res.json({
-        provisioned: false,
-        provider: refs.providerName,
-        message: "Storefront project no longer exists",
+        },
       })
+    } catch {
+      // best-effort cleanup
     }
-
-    res.json({
-      provisioned: true,
-      provider: refs.providerName,
-      project: { id: refs.projectRef, name: refs.vercelProjectName },
-      domain: refs.storefrontDomain,
-      storefront_url: refs.storefrontDomain
-        ? `https://${refs.storefrontDomain}`
-        : null,
-      provisioned_at: refs.storefrontProvisionedAt,
-      latest_deployment: null,
-      error: `Could not fetch status: ${e.message}`,
-    })
   }
+
+  // `stale_project` is an instruction to this route, not part of the partner
+  // contract — strip it so the response shape is unchanged.
+  const { stale_project: _staleProject, ...body } = status
+
+  res.json(body)
 }
 
 /**

--- a/apps/backend/src/api/partners/storefront/website/route.ts
+++ b/apps/backend/src/api/partners/storefront/website/route.ts
@@ -9,6 +9,7 @@ import WebsiteService from "../../../../modules/website/service"
 import { createWebsiteWorkflow } from "../../../../workflows/website/create-website"
 import { seedDefaultPagesWorkflow } from "../../../../workflows/website/seed-default-pages"
 import updatePartnerWorkflow from "../../../../workflows/partners/update-partner"
+import { resolvePartnerWebsiteWorkflow } from "../../../../workflows/partners/resolve-partner-website"
 
 type PartnerRecord = {
   id: string
@@ -98,7 +99,15 @@ export const POST = async (
 
 /**
  * GET /partners/storefront/website
- * Get the partner's website. Uses table columns first, falls back to domain lookup.
+ *
+ * The partner's website. The lookup (website_id first, storefront_domain
+ * fallback) lives in `resolvePartnerWebsiteWorkflow` so the admin inspection
+ * mirror (`GET /admin/partners/:id/storefront/website`) resolves it identically
+ * (#843).
+ *
+ * What stays here is the WRITE: resolving via the domain fallback means the
+ * partner's `website_id` is absent or stale, so it gets backfilled for next
+ * time. The mirror is read-only and deliberately skips it.
  */
 export const GET = async (
   req: AuthenticatedMedusaRequest,
@@ -112,47 +121,26 @@ export const GET = async (
     )
   }
 
-  const domain = getStorefrontDomain(partner)
-  if (!domain) {
-    return res.json({ website: null, message: "Storefront not provisioned" })
-  }
+  const { result: resolution } = await resolvePartnerWebsiteWorkflow(
+    req.scope
+  ).run({ input: { partner } })
 
-  const websiteService: WebsiteService = req.scope.resolve(WEBSITE_MODULE)
-
-  // 1. Direct lookup by website_id
-  const websiteId = getWebsiteId(partner)
-  if (websiteId) {
-    try {
-      const website = await websiteService.retrieveWebsite(websiteId)
-      return res.json({ website })
-    } catch {
-      // stale id, fall through to domain
-    }
-  }
-
-  // 2. Fallback: lookup by storefront_domain
-  const [websites] = await websiteService.listAndCountWebsites(
-    { domain },
-    { take: 1 }
-  )
-
-  if (websites.length) {
-    // Backfill website_id on partner for next time
+  if (resolution.website && resolution.resolved_by === "domain") {
     try {
       await updatePartnerWorkflow(req.scope).run({
         input: {
           id: partner.id,
-          data: { website_id: websites[0].id },
+          data: { website_id: resolution.website.id },
         },
       })
     } catch {
       // best-effort backfill
     }
-    return res.json({ website: websites[0] })
   }
 
-  return res.json({
-    website: null,
-    message: "No website found. Create one from the Content section.",
-  })
+  if (!resolution.website) {
+    return res.json({ website: null, message: resolution.message })
+  }
+
+  return res.json({ website: resolution.website })
 }

--- a/apps/backend/src/workflows/partners/get-partner-storefront-status.ts
+++ b/apps/backend/src/workflows/partners/get-partner-storefront-status.ts
@@ -1,0 +1,172 @@
+import {
+  createStep,
+  createWorkflow,
+  StepResponse,
+  WorkflowResponse,
+} from "@medusajs/framework/workflows-sdk"
+
+import { DEPLOYMENT_MODULE } from "../../modules/deployment"
+import type DeploymentService from "../../modules/deployment/service"
+import { resolveHostingProviderForPartner } from "../../modules/deployment/providers/resolve-partner-provider"
+import { getStorefrontRefs } from "../../api/partners/storefront/helpers"
+
+// #843 slice 5 — the partner storefront *hosting status*, lifted out of
+// `GET /partners/storefront` into a workflow so the admin inspection route
+// (`GET /admin/partners/:id/storefront`) runs the SAME logic instead of its own
+// hand-rolled copy. That copy had already drifted: it was missing the
+// shared-project handling, the `*_configured` flags, and the
+// provider-not-resolvable branch. This workflow is the single answer to
+// "what is the state of this partner's storefront hosting?".
+//
+// READ-ONLY BY CONSTRUCTION. The partner route performs two writes off the back
+// of this status — backfilling nothing here, but clearing stale provider refs
+// when the project has vanished. Those writes stay in the ROUTE, driven by the
+// `stale_project` flag below, precisely so the admin mirror can report the same
+// state without mutating a partner's record as a side effect of an operator
+// opening a tab.
+
+export type PartnerStorefrontStatus = {
+  provisioned: boolean
+  provider: string
+  message?: string
+  project?: { id: string | null; name: string | null }
+  domain?: string | null
+  storefront_url?: string | null
+  provisioned_at?: string | null
+  latest_deployment?: {
+    id: string
+    url: string
+    status: string
+    created_at: number
+  } | null
+  error?: string
+  vercel_configured?: boolean
+  cloudflare_configured?: boolean
+  /**
+   * The provider 404'd for a project we still hold a reference to — the refs are
+   * stale. The partner route clears them; the admin mirror only reports it.
+   */
+  stale_project?: boolean
+}
+
+export type GetPartnerStorefrontStatusWorkflowInput = {
+  /** The full partner record — read for its provider/project/domain columns. */
+  partner: any
+}
+
+export const resolvePartnerStorefrontStatusStep = createStep(
+  "resolve-partner-storefront-status",
+  async (input: GetPartnerStorefrontStatusWorkflowInput, { container }) => {
+    const { partner } = input
+    const deployment: DeploymentService = container.resolve(DEPLOYMENT_MODULE)
+    const refs = getStorefrontRefs(partner)
+
+    if (!refs.projectRef) {
+      return new StepResponse({
+        provisioned: false,
+        provider: refs.providerName,
+        message: "Storefront has not been provisioned yet",
+        vercel_configured: deployment.isVercelConfigured(),
+        cloudflare_configured: deployment.isCloudflareConfigured(),
+      } as PartnerStorefrontStatus)
+    }
+
+    // Everything below reports against the refs we already hold, so a provider
+    // outage degrades to "provisioned, detail unavailable" rather than an error.
+    const base = {
+      provisioned: true as const,
+      provider: refs.providerName,
+      domain: refs.storefrontDomain,
+      storefront_url: refs.storefrontDomain
+        ? `https://${refs.storefrontDomain}`
+        : null,
+      provisioned_at: refs.storefrontProvisionedAt,
+    }
+
+    let resolved: Awaited<ReturnType<typeof resolveHostingProviderForPartner>>
+    try {
+      resolved = await resolveHostingProviderForPartner(partner, container)
+    } catch (e: any) {
+      return new StepResponse({
+        ...base,
+        project: { id: refs.projectRef, name: refs.vercelProjectName },
+        latest_deployment: null,
+        error: `Hosting provider not resolvable: ${e.message}`,
+      } as PartnerStorefrontStatus)
+    }
+
+    try {
+      const project = await resolved.provider.getProject(refs.projectRef)
+
+      let deploymentInfo: PartnerStorefrontStatus["latest_deployment"] = null
+
+      // Vercel exposes latest-deployment detail via the legacy service client;
+      // the provider interface's getProject stays minimal, so this is a
+      // Vercel-only enhancement rather than part of the abstraction.
+      if (refs.providerName === "vercel") {
+        try {
+          const vProject = await deployment.getProject(refs.projectRef)
+          const latest = vProject.latestDeployments?.[0]
+          if (latest) {
+            try {
+              const details = await deployment.getDeployment(latest.id)
+              deploymentInfo = {
+                id: details.id,
+                url: details.url,
+                status: details.readyState,
+                created_at: details.createdAt,
+              }
+            } catch {
+              deploymentInfo = {
+                id: latest.id,
+                url: latest.url,
+                status: latest.readyState,
+                created_at: latest.createdAt,
+              }
+            }
+          }
+        } catch {
+          // non-fatal — status still returns
+        }
+      }
+
+      return new StepResponse({
+        ...base,
+        project: { id: project.id, name: project.name },
+        latest_deployment: deploymentInfo,
+        vercel_configured: deployment.isVercelConfigured(),
+        cloudflare_configured: deployment.isCloudflareConfigured(),
+      } as PartnerStorefrontStatus)
+    } catch (e: any) {
+      // Project no longer exists on the provider — the refs we hold are stale.
+      // Flagged, not acted on: see the module comment.
+      const is404 =
+        e.message?.includes("(404)") || e.message?.includes("NOT_FOUND")
+      if (is404) {
+        return new StepResponse({
+          provisioned: false,
+          provider: refs.providerName,
+          message: "Storefront project no longer exists",
+          stale_project: true,
+        } as PartnerStorefrontStatus)
+      }
+
+      return new StepResponse({
+        ...base,
+        project: { id: refs.vercelProjectId, name: refs.vercelProjectName },
+        latest_deployment: null,
+        error: `Could not fetch storefront status: ${e.message}`,
+      } as PartnerStorefrontStatus)
+    }
+  }
+)
+
+export const getPartnerStorefrontStatusWorkflow = createWorkflow(
+  "get-partner-storefront-status",
+  (input: GetPartnerStorefrontStatusWorkflowInput) => {
+    const status = resolvePartnerStorefrontStatusStep(input)
+    return new WorkflowResponse(status)
+  }
+)
+
+export default getPartnerStorefrontStatusWorkflow

--- a/apps/backend/src/workflows/partners/resolve-partner-website.ts
+++ b/apps/backend/src/workflows/partners/resolve-partner-website.ts
@@ -1,0 +1,108 @@
+import {
+  createStep,
+  createWorkflow,
+  StepResponse,
+  WorkflowResponse,
+} from "@medusajs/framework/workflows-sdk"
+
+import { WEBSITE_MODULE } from "../../modules/website"
+import type WebsiteService from "../../modules/website/service"
+
+// #843 slice 5 — resolving "which website is this partner's storefront",
+// lifted out of `GET /partners/storefront/website` so the admin inspection
+// mirror resolves it the same way.
+//
+// WHY THIS IS A *RESOLUTION* WORKFLOW AND NOT THE WHOLE ROUTE:
+// the partner route's GET has a WRITE in it — when it falls back to a
+// domain lookup it backfills `website_id` onto the partner record. A read-proxy
+// must never do that, so the lookup is what moves here and the backfill stays
+// in the partner route, driven by the `resolved_by` flag below. Same split as
+// `get-partner-storefront-status`.
+
+export type PartnerWebsiteResolution = {
+  website: any | null
+  /**
+   * How the website was found — `domain` means the partner's `website_id` was
+   * absent or stale, which is what the partner route backfills on. `null` when
+   * nothing was found.
+   */
+  resolved_by: "website_id" | "domain" | null
+  /** Present only when `website` is null, explaining which state this is. */
+  reason?: "not_provisioned" | "no_website"
+  message?: string
+}
+
+export type ResolvePartnerWebsiteWorkflowInput = {
+  partner: any
+}
+
+const storefrontDomain = (partner: any): string | null =>
+  partner?.storefront_domain || partner?.metadata?.storefront_domain || null
+
+const websiteIdOf = (partner: any): string | null =>
+  partner?.website_id || partner?.metadata?.website_id || null
+
+export const resolvePartnerWebsiteStep = createStep(
+  "resolve-partner-website",
+  async (input: ResolvePartnerWebsiteWorkflowInput, { container }) => {
+    const { partner } = input
+
+    const domain = storefrontDomain(partner)
+    if (!domain) {
+      return new StepResponse({
+        website: null,
+        resolved_by: null,
+        reason: "not_provisioned",
+        message: "Storefront not provisioned",
+      } as PartnerWebsiteResolution)
+    }
+
+    const websiteService: WebsiteService = container.resolve(WEBSITE_MODULE)
+
+    // 1. Direct lookup by website_id (table column, metadata fallback).
+    const websiteId = websiteIdOf(partner)
+    if (websiteId) {
+      try {
+        const website = await websiteService.retrieveWebsite(websiteId)
+        if (website) {
+          return new StepResponse({
+            website,
+            resolved_by: "website_id",
+          } as PartnerWebsiteResolution)
+        }
+      } catch {
+        // stale id — fall through to the domain lookup
+      }
+    }
+
+    // 2. Fallback: lookup by storefront_domain.
+    const [websites] = await websiteService.listAndCountWebsites(
+      { domain },
+      { take: 1 }
+    )
+
+    if (websites.length) {
+      return new StepResponse({
+        website: websites[0],
+        resolved_by: "domain",
+      } as PartnerWebsiteResolution)
+    }
+
+    return new StepResponse({
+      website: null,
+      resolved_by: null,
+      reason: "no_website",
+      message: "No website found. Create one from the Content section.",
+    } as PartnerWebsiteResolution)
+  }
+)
+
+export const resolvePartnerWebsiteWorkflow = createWorkflow(
+  "resolve-partner-website",
+  (input: ResolvePartnerWebsiteWorkflowInput) => {
+    const resolution = resolvePartnerWebsiteStep(input)
+    return new WorkflowResponse(resolution)
+  }
+)
+
+export default resolvePartnerWebsiteWorkflow

--- a/apps/backend/workflow-schemas.json
+++ b/apps/backend/workflow-schemas.json
@@ -5208,6 +5208,19 @@
     "source": "custom_ts",
     "sourceFile": "src/workflows/partners/delete-partner.ts"
   },
+  "get-partner-storefront-status": {
+    "fields": [
+      {
+        "name": "partner",
+        "type": "string",
+        "required": true,
+        "placeholder": "{{ $last.partner }}",
+        "description": "The provider 404'd for a project we still hold a reference to — the refs are stale. The partner route clears them; the admin mirror only reports it. / stale_project?: boolean } export type GetPartnerStorefrontStatusWorkflowInput = { /** The full partner record — read for its provider/project/domain columns."
+      }
+    ],
+    "source": "custom_ts",
+    "sourceFile": "src/workflows/partners/get-partner-storefront-status.ts"
+  },
   "list-partners": {
     "fields": [
       {
@@ -5243,6 +5256,18 @@
     ],
     "source": "custom_ts",
     "sourceFile": "src/workflows/partners/list-partners.ts"
+  },
+  "resolve-partner-website": {
+    "fields": [
+      {
+        "name": "partner",
+        "type": "string",
+        "required": true,
+        "placeholder": "{{ $last.partner }}"
+      }
+    ],
+    "source": "custom_ts",
+    "sourceFile": "src/workflows/partners/resolve-partner-website.ts"
   },
   "create-payment-report": {
     "fields": [


### PR DESCRIPTION
Slice 5 of the #843 read-proxy — the last surface, and the only one that **reconciles an existing admin route** rather than adding a new one.

## The health route had already drifted

`GET /admin/partners/:id/storefront` pre-dated the mirror and hand-rolled its own copy of the partner storefront logic. Compared with `GET /partners/storefront` it was missing:

- the provider-not-resolvable branch,
- the `vercel_configured` / `cloudflare_configured` flags,
- stale-project detection.

Both routes now run `get-partner-storefront-status`, so they cannot diverge again. This is the only slice that removes drift **already on `main`** rather than just preventing future drift.

## New surfaces

- `GET /admin/partners/:id/storefront/website` — website + theme + the partner theme editor's own `?theme_editor=true` preview URL, so an operator sees the storefront as the partner is *editing* it, not as published.
- `GET /admin/partners/:id/storefront/pages` — mirrors the partner pages listing (same `listPageWorkflow`, same query contract).
- Admin UI: a **Website** tab showing hosting state, the site, and its pages together — the useful answer is usually the relationship between them ("provisioned, but no website record" / "website exists but every page is draft").

## The read/write split

Both partner routes here **write off the back of their read**:

| Partner route | Its write |
|---|---|
| `GET /partners/storefront` | clears stale provider refs when the project has vanished |
| `GET /partners/storefront/website` | backfills `website_id` when it resolves via the domain fallback |

A read-proxy must do neither. So only the *pure resolution* moved into the workflows; each write stays in the partner route, driven by an explicit flag (`stale_project`, `resolved_by: "domain"`). The mirror reports those states and writes nothing.

Pinned directly: a test clears `website_id`, reads through the mirror, asserts `resolved_by === "domain"`, then asserts the column is **still null** afterwards.

## Unprovisioned is a state, not a 404

The partner surface 404s for an unprovisioned storefront; the mirror returns an empty state with an explicit `reason`. Same call as `resolvePartnerInspectionStoreId` — "no storefront yet" is what the onboarding flow exists to fix, and an operator has to be able to see it.

## Guard

Anti-drift assertions run **over seeded rows** (a real website + a published page), unfiltered and under the status filter — two empty lists agree even against a broken mirror. Plus the standard per-surface set: partner scoping, 404 on unknown partner, 401 without admin auth, and no write verb exposed.

`workflow-schemas.json` regenerated in-PR: 268 → **270**. `tsc --noEmit` holds at exactly **79** (the #1179 baseline).

## Verify

```
pnpm test:integration:http:shared \
  ./integration-tests/http/admin-partner-inspection.spec.ts \
  ./integration-tests/http/partner-storefront-api.spec.ts
```

**67 passed, 1 failed.** The failure is pre-existing on `main` and unrelated — `DELETE /partners/api-keys/:id` never revokes first, so Medusa's api-key module rejects it. Verified identical with these changes stashed; tracked on #1184.

Closes the read-proxy portion of #843. Remaining on #843: the guided onboarding flow.

🤖 Generated with [Claude Code](https://claude.com/claude-code)