### PR TITLE
fix(partners,tests): repair 6 dormant-spec failures on main [#1184]

### DIFF
--- a/apps/backend/integration-tests/http/orders-unification-dual-write.spec.ts
+++ b/apps/backend/integration-tests/http/orders-unification-dual-write.spec.ts
@@ -46,7 +46,10 @@ setupSharedTestSuite(() => {
           { inventory_item_id: inventoryItemId, quantity: 2.5, price: 100 },
         ],
         quantity: 2.5,
-        total_price: 100,
+        // Consistent with the per-unit convention: 2.5 × 100. The old fixture
+        // said 100 here, which only made sense under the retired line-total
+        // reading and made the totals-parity assertion below vacuous.
+        total_price: 250,
         status: "Pending",
         expected_delivery_date: new Date().toISOString(),
         order_date: new Date().toISOString(),
@@ -191,11 +194,12 @@ setupSharedTestSuite(() => {
       // Work-orders live on the internal channel, not a storefront channel
       expect(unified.sales_channel?.name).toBe("Partner Work Orders")
 
-      // GAP-1: decimal quantity survives end-to-end; legacy line price is the
-      // line total, so unit_price = 100 / 2.5 = 40
+      // GAP-1: decimal quantity survives end-to-end. Legacy line `price` is the
+      // PER-UNIT price (#778 H9 — dividing by quantity was the money bug), so it
+      // passes straight through to core's unit_price.
       expect(unified.items).toHaveLength(1)
       expect(Number(unified.items[0].quantity)).toBe(2.5)
-      expect(Number(unified.items[0].unit_price)).toBe(40)
+      expect(Number(unified.items[0].unit_price)).toBe(100)
       expect(unified.items[0].title).toBe("Raw Cotton")
       expect(unified.items[0].metadata.inventory_item_id).toBe(inventoryItemId)
 
@@ -210,7 +214,7 @@ setupSharedTestSuite(() => {
       // onto it; the link is the sole pointer.
       expect(legacyRow.status).toBe("Pending")
       expect(Number(legacyRow.quantity)).toBe(2.5)
-      expect(Number(legacyRow.total_price)).toBe(100)
+      expect(Number(legacyRow.total_price)).toBe(250)
       expect(legacyRow.orderlines).toHaveLength(1)
       expect(legacyRow.metadata?.unified_order_id ?? null).toBeNull()
 

--- a/apps/backend/integration-tests/http/send-to-partner-error-cases.spec.ts
+++ b/apps/backend/integration-tests/http/send-to-partner-error-cases.spec.ts
@@ -190,8 +190,10 @@ setupSharedTestSuite(() =>{
             headers: partnerHeaders
           }).catch((err) => err.response)
 
-          expect(response.status).toBe(400)
-          expect(response.data.message).toBe(`Inventory order ${unassignedOrderId} is not assigned to your partner account`)
+          // #778 C1 — the ownership guard answers "not yours" and "does not exist"
+          // identically (404, same message) so partners can't enumerate order IDs.
+          expect(response.status).toBe(404)
+          expect(response.data.message).toBe(`Inventory order ${unassignedOrderId} not found`)
         })
 
         it("should fail without partner authentication", async () => {
@@ -208,7 +210,9 @@ setupSharedTestSuite(() =>{
           }).catch((err) => err.response)
 
           expect(response.status).toBe(404)
-          expect(response.data.message).toBe("InventoryOrders with id: non-existent-id was not found")
+          // The ownership guard now runs before the service retrieve, so the
+          // message is the guard's, not MikroORM's.
+          expect(response.data.message).toBe("Inventory order non-existent-id not found")
         })
 
         it("should fail to start unassigned order", async () => {
@@ -239,8 +243,11 @@ setupSharedTestSuite(() =>{
             headers: partnerHeaders
           }).catch((err) => err.response)
 
-          expect(response.status).toBe(400)
-          expect(response.data.error).toBe("Order is not assigned to a partner workflow")
+          // Guarded before the transaction-id lookup, so this is 404 (not the
+          // route's own "not assigned to a partner workflow" 400, which now only
+          // fires for an owned order whose workflow tasks are missing).
+          expect(response.status).toBe(404)
+          expect(response.data.message).toBe(`Inventory order ${separateOrderId} not found`)
         })
       })
 
@@ -288,8 +295,10 @@ setupSharedTestSuite(() =>{
             headers: partnerHeaders
           }).catch((err) => err.response)
 
-          expect(response.status).toBe(400)
-          expect(response.data.message).toBe(`Inventory order ${separateOrderId} not in an updatable state (status: Pending)`)
+          // Ownership is checked before state, so a non-owned Pending order is
+          // 404 rather than the "not in an updatable state" 400.
+          expect(response.status).toBe(404)
+          expect(response.data.message).toBe(`Inventory order ${separateOrderId} not found`)
         })
       })
 

--- a/apps/backend/src/api/partners/api-keys/[id]/route.ts
+++ b/apps/backend/src/api/partners/api-keys/[id]/route.ts
@@ -1,6 +1,6 @@
 import { AuthenticatedMedusaRequest, MedusaResponse } from "@medusajs/framework/http"
 import { ContainerRegistrationKeys, MedusaError, Modules } from "@medusajs/framework/utils"
-import { updateApiKeysWorkflow, deleteApiKeysWorkflow } from "@medusajs/medusa/core-flows"
+import { updateApiKeysWorkflow, deleteApiKeysWorkflow, revokeApiKeysWorkflow } from "@medusajs/medusa/core-flows"
 import { getPartnerFromAuthContext } from "../../helpers"
 import { PartnerUpdateApiKeyReq } from "../validators"
 
@@ -102,7 +102,19 @@ export const DELETE = async (
   }
 
   const { id } = req.params
-  await validateApiKeyOwnership(partner, id, req.scope)
+  const apiKey = await validateApiKeyOwnership(partner, id, req.scope)
+
+  // #1184 — Medusa's api-key module refuses to delete a publishable key that is
+  // still live (NOT_ALLOWED → 400), so DELETE never actually deleted anything.
+  // Revoke first when needed; an already-revoked key skips straight to delete.
+  if (!apiKey.revoked_at) {
+    await revokeApiKeysWorkflow(req.scope).run({
+      input: {
+        selector: { id },
+        revoke: { revoked_by: partner.id },
+      },
+    })
+  }
 
   await deleteApiKeysWorkflow(req.scope).run({
     input: { ids: [id] },


### PR DESCRIPTION
Six tests across three files were failing on clean `main`. Three distinct causes — only one of them a real defect.

### 1. `send-to-partner-error-cases.spec.ts` — 4 failures, stale contract
The `#778 C1` IDOR guard (`assertPartnerOwnsInventoryOrder`) runs *before* the service retrieve on every partner inventory-order route, and deliberately answers "not yours" and "does not exist" identically (404, `Inventory order <id> not found`) so partners can't enumerate order IDs.

The spec still expected the pre-guard contract: 400 + `is not assigned to your partner account`, 400 + `Order is not assigned to a partner workflow`, 400 + `not in an updatable state`, and MikroORM's raw `InventoryOrders with id: X was not found`. Assertions updated to the current contract, each with a comment on *why* it's a 404 — so the next reader doesn't "fix" it back.

### 2. `orders-unification-dual-write.spec.ts` — 1 failure, retired premise
Asserted `unit_price === 40` on the comment "legacy line price is the line total, so 100 / 2.5 = 40". That divide is precisely what `#778 H9` removed as a money bug — legacy line `price` is **per-unit**, and dividing under-priced every multi-unit line on the unified order. The code passing `100` through is correct.

The fixture was also internally inconsistent (`quantity: 2.5, price: 100, total_price: 100`), which made the totals-parity assertion two lines down vacuous — it compared two numbers that were both wrong in the same direction. `total_price` is now `250` so parity actually tests something.

### 3. `partner-storefront-api.spec.ts` — 1 failure, **real defect**
`DELETE /partners/api-keys/:id` called `deleteApiKeysWorkflow` on a live key. Medusa's api-key module refuses to delete an unrevoked publishable key (`NOT_ALLOWED` → 400), so **that endpoint never deleted anything**. It now revokes first when `revoked_at` is null, then deletes. Low blast radius — `partner-ui` only ever calls `/revoke` — but it was a broken endpoint, not a bad assertion.

### Root cause
CI runs only *changed* specs, so these files hadn't run in a long time while the code moved underneath them. Two specs were describing a contract that security work had intentionally replaced; the third was hiding a genuine defect.

### Verify
```
pnpm test:integration:http:shared \
  ./integration-tests/http/send-to-partner-error-cases.spec.ts \
  ./integration-tests/http/orders-unification-dual-write.spec.ts \
  ./integration-tests/http/partner-storefront-api.spec.ts
```
31/31 pass. `tsc --noEmit` holds at exactly **79** (the #1179 baseline).

Closes #1184

🤖 Generated with [Claude Code](https://claude.com/claude-code)