### PR TITLE
fix(tests): tax-band spec asserted which actor won a race with a subscriber [#1187]

### DIFF
--- a/apps/backend/integration-tests/http/tax-in-textile-price-band.spec.ts
+++ b/apps/backend/integration-tests/http/tax-in-textile-price-band.spec.ts
@@ -176,7 +176,13 @@ setupSharedTestSuite(() => {
         input: { product_id: productId },
       })
 
-      expect(result.decision).toBe("assigned")
+      // The `product.created` subscriber classifies asynchronously and
+      // converges to the same answer, so whether THIS run does the assigning or
+      // merely confirms the subscriber's is a race — `no-change` here means
+      // "already the desired type", which is the same outcome. CI lost this
+      // race reproducibly; locally the manual run got there first. Assert the
+      // invariant, not who won.
+      expect(["assigned", "no-change"]).toContain(result.decision)
       expect(result.max_inr_price).toBe(3000)
       const typeValue = await readProductTypeValue(container, productId)
       expect(typeValue).toBe(TAX_CLASS_OVER_2500_VALUE)
@@ -246,7 +252,9 @@ setupSharedTestSuite(() => {
       const { result } = await classifyProductTaxClassWorkflow(container).run({
         input: { product_id: productId },
       })
-      expect(result.decision).toBe("cleared")
+      // Same race as above, in the other direction: the subscriber may have
+      // cleared it already, which reports `no-change`.
+      expect(["cleared", "no-change"]).toContain(result.decision)
       expect(await readProductTypeValue(container, productId)).toBeNull()
     })
 


### PR DESCRIPTION
The first full main run after #1193 came back **6 of 8 shards green**. Two failures, different in kind:

- **Shard 5 — infrastructure.** `Docker pull failed with exit code 1` after retries; the service container never came up and the shard ran no tests in 1 minute. Green on re-run, nothing to fix.
- **Shard 4 — this.** Reproducible: failed on the original run and again on re-run.

`assigns the over-2500 type when max INR price >= ₹2,500` expected `decision === "assigned"` and got `"no-change"`. It passes locally in isolation (8/8) and with its exact CI batch (28/28).

**Both values are correct.** The `product.created` subscriber classifies asynchronously and converges to the same class, and the workflow returns `no-change` when the product already carries the desired type. The test was asserting that the manual run beat the subscriber — not a property of the system. The file already knows this: the very next test carries a comment about there being "no stable mis-classified state to assert against without racing the subscriber".

Now asserts the invariant both paths share — the price resolves to 3000, and the product ends up in the over-2500 class. The "clears the type" test gets the same treatment: identical exposure in the other direction, and it had only been passing by winning the same race.

## Why it surfaced now

#1192 deleted `integration-tests/http/test-sample/` (generated output). Shard assignment is stride-based over the sorted file list, so removing one file re-indexes every spec and changes which ones share a runner and a batch. This spec's neighbours changed, and with them the timing it had been silently depending on.

## Verify

```
pnpm test:integration:http:shared ./integration-tests/http/tax-in-textile-price-band.spec.ts
```
8/8 locally.

🤖 Generated with [Claude Code](https://claude.com/claude-code)