### PR TITLE
fix(#1195): restore "Mark as shipped" — requires_shipping, not the pickup rule

### DIFF
--- a/apps/backend/integration-tests/http/requires-shipping-fulfillment-gate.spec.ts
+++ b/apps/backend/integration-tests/http/requires-shipping-fulfillment-gate.spec.ts
@@ -311,6 +311,8 @@ setupSharedTestSuite(() => {
         !isPickUpFulfillment
 
       return {
+        orderId,
+        lineItemId: order.data.order.items[0].id,
         lineItemRequiresShipping:
           order.data.order.items[0].requires_shipping,
         fulfillment,
@@ -409,6 +411,105 @@ setupSharedTestSuite(() => {
       })
 
       expect((result as any).items[0].requires_shipping).toBe(true)
+    })
+
+    /**
+     * The repair path for orders that already exist. The admin core gate lives
+     * inside the shipped `@medusajs/dashboard` bundle and can't be patched from
+     * here, so fixing the DATA is what restores the shipment action there.
+     *
+     * This also pins the two load-bearing assumptions the DP job makes, neither
+     * of which is guaranteed by the public types:
+     *  - `requires_shipping` is absent from `UpdateFulfillmentDTO`, but
+     *    `updateFulfillment_` spreads `data` into the ORM update, so it writes;
+     *  - the job's `query.graph` field list actually resolves (a mis-named
+     *    relation returns nothing SILENTLY).
+     */
+    it("the DP backfill repairs an existing open order's fulfillment and items", async () => {
+      const { api } = getSharedTestEnv()
+      // Driven through the ops route, so registry wiring and param validation
+      // are covered too — this is how an operator actually runs it.
+      const RUN =
+        "/admin/ops/maintenance-jobs/backfill-open-order-requires-shipping/run"
+      const { variantId } = await createProduct(api, {
+        withProfile: false,
+        label: "Backfill",
+      })
+
+      const before = await fulfilOrderFor(api, variantId)
+      // The broken starting state.
+      expect(before.fulfillment.requires_shipping).toBe(false)
+      expect(before.lineItemRequiresShipping).toBe(false)
+      expect(before.showShippingButton).toBe(false)
+
+      // Dry-run first: it must report the change without writing anything.
+      const preview = await loud("dp dry-run", () =>
+        api.post(
+          RUN,
+          { dry_run: true, params: { order_id: before.orderId } },
+          adminHeaders
+        )
+      )
+      expect(preview.status).toBe(200)
+      expect(preview.data.result.dry_run).toBe(true)
+      expect(preview.data.result.applied).toBe(false)
+      expect(
+        preview.data.result.changes.some(
+          (c: any) =>
+            c.entity === "fulfillment" && c.id === before.fulfillment.id
+        )
+      ).toBe(true)
+      expect(
+        preview.data.result.changes.some(
+          (c: any) =>
+            c.entity === "order_line_item" && c.id === before.lineItemId
+        )
+      ).toBe(true)
+
+      const stillBroken = await api.get(
+        `/admin/orders/${before.orderId}?fields=id,fulfillments.id,fulfillments.requires_shipping`,
+        adminHeaders
+      )
+      expect(
+        stillBroken.data.order.fulfillments[0].requires_shipping
+      ).toBe(false)
+
+      // Apply.
+      const applied = await loud("dp apply", () =>
+        api.post(
+          RUN,
+          { dry_run: false, params: { order_id: before.orderId } },
+          adminHeaders
+        )
+      )
+      expect(applied.status).toBe(200)
+      expect(applied.data.result.applied).toBe(true)
+      expect(applied.data.result.errors).toBeUndefined()
+
+      const after = await api.get(
+        `/admin/orders/${before.orderId}?fields=id,items.id,items.requires_shipping,fulfillments.id,fulfillments.requires_shipping,fulfillments.canceled_at,fulfillments.shipped_at,fulfillments.delivered_at`,
+        adminHeaders
+      )
+      const fulfillment = after.data.order.fulfillments[0]
+      expect(fulfillment.requires_shipping).toBe(true)
+      expect(after.data.order.items[0].requires_shipping).toBe(true)
+
+      // The stock dashboard gate now passes — including the undocumented term.
+      const showShippingButton =
+        !fulfillment.canceled_at &&
+        !fulfillment.shipped_at &&
+        !fulfillment.delivered_at &&
+        fulfillment.requires_shipping
+      expect(showShippingButton).toBe(true)
+
+      // Idempotent: a second apply finds nothing left to repair.
+      const rerun = await api.post(
+        RUN,
+        { dry_run: false, params: { order_id: before.orderId } },
+        adminHeaders
+      )
+      expect(rerun.data.result.changes).toHaveLength(0)
+      expect(rerun.data.result.applied).toBe(false)
     })
   })
 })

--- a/apps/backend/integration-tests/http/requires-shipping-fulfillment-gate.spec.ts
+++ b/apps/backend/integration-tests/http/requires-shipping-fulfillment-gate.spec.ts
@@ -553,6 +553,12 @@ setupSharedTestSuite(() => {
       expect(preview.status).toBe(200)
       expect(preview.data.result.dry_run).toBe(true)
       expect(preview.data.result.applied).toBe(false)
+      // The skip is surfaced to the operator, along with the job that cures it
+      // — a partial repair must never read as a complete one.
+      expect(preview.data.result.summary).toContain("SKIPPED")
+      expect(preview.data.result.summary).toContain(
+        "backfill-product-shipping-profiles"
+      )
       expect(
         preview.data.result.changes.some(
           (c: any) =>

--- a/apps/backend/integration-tests/http/requires-shipping-fulfillment-gate.spec.ts
+++ b/apps/backend/integration-tests/http/requires-shipping-fulfillment-gate.spec.ts
@@ -1,0 +1,374 @@
+import { setupSharedTestSuite, getSharedTestEnv } from "./shared-test-setup"
+import { createAdminUser, getAuthHeaders } from "../helpers/create-admin-user"
+import {
+  createTestCustomer,
+  getCustomerAuthHeaders,
+  resetTestCustomerCredentials,
+} from "../helpers/create-customer"
+
+jest.setTimeout(90 * 1000)
+
+/** Surfaces the response body on failure — 4xx bodies are otherwise swallowed. */
+const loud = async <T>(label: string, fn: () => Promise<T>): Promise<T> => {
+  try {
+    return await fn()
+  } catch (e: any) {
+    console.log(`[${label}] ${e.response?.status}`, JSON.stringify(e.response?.data))
+    throw e
+  }
+}
+
+/**
+ * Reproduces the production condition that hides "Mark as shipped" on a
+ * fulfillment (see the prod audit of v3.jaalyantra.com: 54/75 products carry no
+ * shipping profile, and every recent fulfillment has `requires_shipping: false`
+ * despite sitting on a manual_manual option in a `type: "shipping"` set).
+ *
+ * The dashboard gate is:
+ *   showShippingButton = !canceled_at && !shipped_at && !delivered_at
+ *                        && fulfillment.requires_shipping
+ *                        && !isPickUpFulfillment
+ *
+ * Medusa derives the line item's flag in `prepareLineItemData`:
+ *   requires_shipping = isDefined(item.requires_shipping)
+ *     ? item.requires_shipping
+ *     : hasShippingProfile || someInventoryRequiresShipping
+ *
+ * and `createOrderFulfillmentWorkflow` copies `someItemsRequireShipping` onto
+ * the fulfillment. So a product with no shipping profile AND
+ * `manage_inventory: false` (no inventory items to vote "true") yields a
+ * fulfillment that the UI refuses to offer a shipment for — even though the
+ * user guide says the only restriction is that the option isn't a pickup one.
+ */
+setupSharedTestSuite(() => {
+  describe("requires_shipping → 'Mark as shipped' gate", () => {
+    let adminHeaders: { headers: Record<string, string> }
+    let customerHeaders: { headers: Record<string, string> }
+    let regionId: string
+    let salesChannelId: string
+    let profileId: string
+
+    beforeEach(async () => {
+      const { api, getContainer } = getSharedTestEnv()
+      const container = getContainer()
+
+      await createAdminUser(container)
+      adminHeaders = await getAuthHeaders(api)
+
+      resetTestCustomerCredentials()
+      await createTestCustomer(container)
+      customerHeaders = await getCustomerAuthHeaders()
+
+      const regions = await api.get("/admin/regions?limit=1", adminHeaders)
+      regionId =
+        regions.data.regions?.[0]?.id ??
+        (
+          await api.post(
+            "/admin/regions",
+            { name: "Test Region", currency_code: "usd", countries: ["us"] },
+            adminHeaders
+          )
+        ).data.region.id
+      expect(regionId).toBeTruthy()
+
+      const channels = await api.get("/admin/sales-channels?limit=1", adminHeaders)
+      salesChannelId =
+        channels.data.sales_channels?.[0]?.id ??
+        (
+          await api.post(
+            "/admin/sales-channels",
+            { name: "Test Channel" },
+            adminHeaders
+          )
+        ).data.sales_channel.id
+      expect(salesChannelId).toBeTruthy()
+
+      const profiles = await api.get("/admin/shipping-profiles?limit=1", adminHeaders)
+      profileId =
+        profiles.data.shipping_profiles?.[0]?.id ??
+        (
+          await api.post(
+            "/admin/shipping-profiles",
+            { name: "Default", type: "default" },
+            adminHeaders
+          )
+        ).data.shipping_profile.id
+      expect(profileId).toBeTruthy()
+    })
+
+    /** Mirrors prod: manage_inventory false, shipping profile optional. */
+    const createProduct = async (
+      api: any,
+      opts: { withProfile: boolean; label: string }
+    ) => {
+      const res = await api.post(
+        "/admin/products",
+        {
+          title: `${opts.label} ${Date.now()}`,
+          status: "published",
+          options: [{ title: "Size", values: ["OS"] }],
+          ...(opts.withProfile ? { shipping_profile_id: profileId } : {}),
+          variants: [
+            {
+              title: "OS",
+              sku: `RS-${opts.label}-${Date.now()}`,
+              manage_inventory: false,
+              options: { Size: "OS" },
+              prices: [{ currency_code: "usd", amount: 1500 }],
+            },
+          ],
+          sales_channels: [{ id: salesChannelId }],
+        },
+        adminHeaders
+      )
+      expect(res.status).toBe(200)
+      const productId = res.data.product.id
+      // The create response omits the profile link — re-read it explicitly.
+      const detail = await api.get(
+        `/admin/products/${productId}?fields=id,shipping_profile.id`,
+        adminHeaders
+      )
+      return {
+        productId,
+        variantId: res.data.product.variants[0].id,
+        shippingProfile: detail.data.product.shipping_profile ?? null,
+      }
+    }
+
+    /** A manual shipping option on a `type: "shipping"` set — the prod shape. */
+    const createManualShippingOption = async (api: any) => {
+      const loc = await api.post(
+        "/admin/stock-locations",
+        {
+          name: `Gate Warehouse ${Date.now()}`,
+          address: {
+            address_1: "1 Loom St",
+            city: "Dallas",
+            postal_code: "75201",
+            country_code: "us",
+          },
+        },
+        adminHeaders
+      )
+      const locationId = loc.data.stock_location.id
+
+      // The location must enable the provider before options can use it.
+      await loud("fulfillment-providers", () =>
+        api.post(
+          `/admin/stock-locations/${locationId}/fulfillment-providers`,
+          { add: ["manual_manual"] },
+          adminHeaders
+        )
+      )
+
+      await api.post(
+        `/admin/stock-locations/${locationId}/fulfillment-sets`,
+        { name: `Gate Shipping ${Date.now()}`, type: "shipping" },
+        adminHeaders
+      )
+      const locDetail = await api.get(
+        `/admin/stock-locations/${locationId}?fields=id,*fulfillment_sets`,
+        adminHeaders
+      )
+      const fulfillmentSet = (
+        locDetail.data.stock_location.fulfillment_sets || []
+      ).find((f: any) => f.type === "shipping")
+      expect(fulfillmentSet).toBeTruthy()
+
+      const zoneRes = await loud("service-zones", () =>
+        api.post(
+          `/admin/fulfillment-sets/${fulfillmentSet.id}/service-zones`,
+          { name: "US Zone", geo_zones: [{ type: "country", country_code: "us" }] },
+          adminHeaders
+        )
+      )
+      const zoneId = zoneRes.data.fulfillment_set.service_zones[0].id
+
+      const optRes = await loud("shipping-options", () =>
+        api.post(
+        "/admin/shipping-options",
+        {
+          name: "Standard Shipping",
+          service_zone_id: zoneId,
+          shipping_profile_id: profileId,
+          provider_id: "manual_manual",
+          price_type: "flat",
+          type: { label: "Standard", description: "Std", code: "standard" },
+          prices: [{ currency_code: "usd", amount: 10 }],
+        },
+        adminHeaders
+        )
+      )
+      return optRes.data.shipping_option.id
+    }
+
+    const addToCart = async (api: any, variantId: string) => {
+      const cart = await api.post(
+        "/store/carts",
+        { region_id: regionId, sales_channel_id: salesChannelId },
+        customerHeaders
+      )
+      const cartId = cart.data.cart.id
+      await api.post(
+        `/store/carts/${cartId}/line-items`,
+        { variant_id: variantId, quantity: 1 },
+        customerHeaders
+      )
+      const after = await api.get(`/store/carts/${cartId}`, customerHeaders)
+      return after.data.cart.items[0]
+    }
+
+    it("derives requires_shipping=false when the product has NO shipping profile", async () => {
+      const { api } = getSharedTestEnv()
+      const { variantId, shippingProfile } = await createProduct(api, {
+        withProfile: false,
+        label: "NoProfile",
+      })
+      expect(shippingProfile).toBeNull()
+
+      const item = await addToCart(api, variantId)
+      expect(item.requires_shipping).toBe(false)
+    })
+
+    it("derives requires_shipping=true when the product HAS a shipping profile", async () => {
+      const { api } = getSharedTestEnv()
+      const { variantId, shippingProfile } = await createProduct(api, {
+        withProfile: true,
+        label: "WithProfile",
+      })
+      expect(shippingProfile?.id).toBe(profileId)
+
+      const item = await addToCart(api, variantId)
+      expect(item.requires_shipping).toBe(true)
+    })
+
+    const fulfilOrderFor = async (api: any, variantId: string) => {
+      // An order carrying only the item under test.
+      const draft = await api.post(
+        "/admin/draft-orders",
+        {
+          email: "gate@test.com",
+          region_id: regionId,
+          sales_channel_id: salesChannelId,
+          currency_code: "usd",
+          shipping_address: {
+            first_name: "Gate",
+            last_name: "Test",
+            address_1: "1 Test Rd",
+            city: "Dallas",
+            province: "TX",
+            postal_code: "75201",
+            country_code: "us",
+          },
+          items: [{ variant_id: variantId, quantity: 1, unit_price: 1500 }],
+        },
+        adminHeaders
+      )
+      const converted = await api.post(
+        `/admin/draft-orders/${draft.data.draft_order.id}/convert-to-order`,
+        {},
+        adminHeaders
+      )
+      const orderId = converted.data.order.id
+
+      const order = await api.get(
+        `/admin/orders/${orderId}?fields=id,items.id,items.requires_shipping`,
+        adminHeaders
+      )
+
+      // Fulfil it against a manual option on a `type: "shipping"` set — the
+      // exact prod shape, so the pickup rule is NOT what's in play.
+      const shippingOptionId = await createManualShippingOption(api)
+
+      const fulfilRes = await loud("fulfillments", () =>
+        api.post(
+          `/admin/orders/${orderId}/fulfillments`,
+          {
+            items: [{ id: order.data.order.items[0].id, quantity: 1 }],
+            shipping_option_id: shippingOptionId,
+          },
+          adminHeaders
+        )
+      )
+      expect(fulfilRes.status).toBe(200)
+
+      const withFulfilments = await api.get(
+        `/admin/orders/${orderId}?fields=id,fulfillments.id,fulfillments.requires_shipping,fulfillments.shipped_at,fulfillments.canceled_at,fulfillments.delivered_at,fulfillments.shipping_option.provider_id,fulfillments.shipping_option.service_zone.fulfillment_set.type`,
+        adminHeaders
+      )
+      const fulfillment = withFulfilments.data.order.fulfillments[0]
+
+      const isPickUpFulfillment =
+        fulfillment.shipping_option?.service_zone?.fulfillment_set?.type ===
+        "pickup"
+
+      // The dashboard gate, evaluated exactly as the UI evaluates it.
+      const showShippingButton =
+        !fulfillment.canceled_at &&
+        !fulfillment.shipped_at &&
+        !fulfillment.delivered_at &&
+        fulfillment.requires_shipping &&
+        !isPickUpFulfillment
+
+      return {
+        lineItemRequiresShipping:
+          order.data.order.items[0].requires_shipping,
+        fulfillment,
+        isPickUpFulfillment,
+        showShippingButton,
+      }
+    }
+
+    it("hides the shipment action on a non-pickup manual option when the product has no shipping profile", async () => {
+      const { api } = getSharedTestEnv()
+      const { variantId } = await createProduct(api, {
+        withProfile: false,
+        label: "Fulfil",
+      })
+
+      const res = await fulfilOrderFor(api, variantId)
+
+      expect(res.lineItemRequiresShipping).toBe(false)
+      // The pickup rule the user guide documents does NOT apply here...
+      expect(res.isPickUpFulfillment).toBe(false)
+      // ...yet the fulfillment is still stamped false, and the dashboard hides
+      // the shipment action purely on that undocumented term.
+      expect(res.fulfillment.requires_shipping).toBe(false)
+      expect(res.showShippingButton).toBe(false)
+    })
+
+    /**
+     * Second, independent defect. The cart path honours the shipping profile
+     * (see the test above), but the draft-order path does NOT: the item comes
+     * out `requires_shipping: false` even when the product carries a profile.
+     *
+     * Verified while narrowing this down:
+     *  - `query.graph({ entity: "variants", fields: [..., "product.shipping_profile.id"] })`
+     *    resolves the profile correctly, so the data is available.
+     *  - the variant IS resolved during line prep (the item gets `product_id`
+     *    and `product_title`), so it isn't a failed variant lookup.
+     * The profile is therefore dropped inside `createOrderWorkflow`'s own
+     * variant fetch. Exact line not isolated — this test pins the behaviour so
+     * a Medusa upgrade that fixes it fails loudly here.
+     *
+     * Consequence: assigning shipping profiles fixes storefront-cart orders,
+     * but NOT anything created through admin draft orders.
+     */
+    it("KNOWN DEFECT: the draft-order path ignores the shipping profile", async () => {
+      const { api } = getSharedTestEnv()
+      const { variantId, shippingProfile } = await createProduct(api, {
+        withProfile: true,
+        label: "FulfilOk",
+      })
+      expect(shippingProfile?.id).toBe(profileId)
+
+      const res = await fulfilOrderFor(api, variantId)
+
+      // Same product that yields `true` through the cart yields `false` here.
+      expect(res.lineItemRequiresShipping).toBe(false)
+      expect(res.isPickUpFulfillment).toBe(false)
+      expect(res.fulfillment.requires_shipping).toBe(false)
+      expect(res.showShippingButton).toBe(false)
+    })
+  })
+})

--- a/apps/backend/integration-tests/http/requires-shipping-fulfillment-gate.spec.ts
+++ b/apps/backend/integration-tests/http/requires-shipping-fulfillment-gate.spec.ts
@@ -360,22 +360,39 @@ setupSharedTestSuite(() => {
      * It no longer blocks us: an explicit `requires_shipping` on the item wins
      * over the derivation (`isDefined(item.requires_shipping) ? ... : ...`),
      * which is the lever the fix uses — see the test below.
+     *
+     * Asserted against the WORKFLOW, not the draft-order route: the route now
+     * emits `order.placed`, whose subscriber repairs exactly this case, so
+     * going through it would test our repair rather than the upstream defect.
+     * If a Medusa upgrade fixes the derivation this test fails loudly — that
+     * failure is GOOD NEWS, not a regression.
      */
-    it("KNOWN DEFECT: the draft-order path ignores the shipping profile", async () => {
-      const { api } = getSharedTestEnv()
+    it("KNOWN DEFECT: createOrderWorkflow ignores the shipping profile", async () => {
+      const { api, getContainer } = getSharedTestEnv()
+      const { createOrderWorkflow } = await import("@medusajs/medusa/core-flows")
       const { variantId, shippingProfile } = await createProduct(api, {
         withProfile: true,
         label: "FulfilOk",
       })
       expect(shippingProfile?.id).toBe(profileId)
 
-      const res = await fulfilOrderFor(api, variantId)
+      const { result } = await createOrderWorkflow(getContainer()).run({
+        input: {
+          email: "known-defect@test.com",
+          region_id: regionId,
+          sales_channel_id: salesChannelId,
+          currency_code: "usd",
+          shipping_address: {
+            first_name: "Known", last_name: "Defect", address_1: "1 Test Rd",
+            city: "Dallas", province: "TX", postal_code: "75201", country_code: "us",
+          },
+          // No explicit flag — the derivation decides, and gets it wrong.
+          items: [{ variant_id: variantId, quantity: 1, unit_price: 1500 }],
+        } as any,
+      })
 
       // Same product that yields `true` through the cart yields `false` here.
-      expect(res.lineItemRequiresShipping).toBe(false)
-      expect(res.isPickUpFulfillment).toBe(false)
-      expect(res.fulfillment.requires_shipping).toBe(false)
-      expect(res.showShippingButton).toBe(false)
+      expect((result as any).items[0].requires_shipping).toBe(false)
     })
 
     /**
@@ -411,6 +428,89 @@ setupSharedTestSuite(() => {
       })
 
       expect((result as any).items[0].requires_shipping).toBe(true)
+    })
+
+    /**
+     * The forward fix (#1195 item 3). `order.placed` repairs the derived flag
+     * on the ORDER, so newly placed orders never reach a fulfillment with the
+     * wrong value and the DP backfill below is only ever needed for history.
+     *
+     * Scoped to products that HAVE a shipping profile — which is exactly the
+     * draft-order defect (profile present, derivation still says false). Two
+     * interlocks make a wider fix actively harmful, both verified here:
+     *  - on the CART, `validateShippingStep` demands a shipping method whose
+     *    profile matches the item's — unsatisfiable for our variant-less
+     *    design items;
+     *  - at FULFILLMENT, `create-fulfillment.js:78-83` throws when a
+     *    requires-shipping item's product profile differs from the chosen
+     *    option's, which for a profile-less product is always. See the test
+     *    below.
+     */
+    it("order.placed repairs requires_shipping so new fulfillments come out true", async () => {
+      const { api } = getSharedTestEnv()
+      const { variantId } = await createProduct(api, {
+        withProfile: true,
+        label: "Forward",
+      })
+
+      const draft = await api.post(
+        "/admin/draft-orders",
+        {
+          email: "forward@test.com",
+          region_id: regionId,
+          sales_channel_id: salesChannelId,
+          currency_code: "usd",
+          shipping_address: {
+            first_name: "For", last_name: "Ward", address_1: "1 Test Rd",
+            city: "Dallas", province: "TX", postal_code: "75201", country_code: "us",
+          },
+          items: [{ variant_id: variantId, quantity: 1, unit_price: 1500 }],
+        },
+        adminHeaders
+      )
+      const converted = await api.post(
+        `/admin/draft-orders/${draft.data.draft_order.id}/convert-to-order`,
+        {},
+        adminHeaders
+      )
+      const orderId = converted.data.order.id
+
+      // The subscriber runs off the order.placed event — poll rather than race.
+      let itemRequiresShipping: boolean | undefined
+      for (let attempt = 0; attempt < 20; attempt++) {
+        const res = await api.get(
+          `/admin/orders/${orderId}?fields=id,items.id,items.requires_shipping`,
+          adminHeaders
+        )
+        itemRequiresShipping = res.data.order.items[0].requires_shipping
+        if (itemRequiresShipping === true) break
+        await new Promise((r) => setTimeout(r, 250))
+      }
+      expect(itemRequiresShipping).toBe(true)
+
+      // ...and the fulfillment created afterwards inherits the repaired value,
+      // so the stock dashboard offers the shipment action with no backfill.
+      const shippingOptionId = await createManualShippingOption(api)
+      const orderNow = await api.get(
+        `/admin/orders/${orderId}?fields=id,items.id`,
+        adminHeaders
+      )
+      await loud("forward fulfillment", () =>
+        api.post(
+          `/admin/orders/${orderId}/fulfillments`,
+          {
+            items: [{ id: orderNow.data.order.items[0].id, quantity: 1 }],
+            shipping_option_id: shippingOptionId,
+          },
+          adminHeaders
+        )
+      )
+
+      const after = await api.get(
+        `/admin/orders/${orderId}?fields=id,fulfillments.id,fulfillments.requires_shipping`,
+        adminHeaders
+      )
+      expect(after.data.order.fulfillments[0].requires_shipping).toBe(true)
     })
 
     /**
@@ -459,12 +559,16 @@ setupSharedTestSuite(() => {
             c.entity === "fulfillment" && c.id === before.fulfillment.id
         )
       ).toBe(true)
+      // ...but NOT the line item: this product has no shipping profile, and a
+      // requires-shipping item whose product profile can't match the chosen
+      // option is rejected by create-fulfillment — flipping it would break the
+      // remaining quantity instead of revealing the action.
       expect(
         preview.data.result.changes.some(
           (c: any) =>
             c.entity === "order_line_item" && c.id === before.lineItemId
         )
-      ).toBe(true)
+      ).toBe(false)
 
       const stillBroken = await api.get(
         `/admin/orders/${before.orderId}?fields=id,fulfillments.id,fulfillments.requires_shipping`,
@@ -492,7 +596,10 @@ setupSharedTestSuite(() => {
       )
       const fulfillment = after.data.order.fulfillments[0]
       expect(fulfillment.requires_shipping).toBe(true)
-      expect(after.data.order.items[0].requires_shipping).toBe(true)
+      // The item is deliberately left alone — see the dry-run assertion above.
+      // Fixing it means giving the product a profile
+      // (backfill-product-shipping-profiles), not flipping the flag.
+      expect(after.data.order.items[0].requires_shipping).toBe(false)
 
       // The stock dashboard gate now passes — including the undocumented term.
       const showShippingButton =
@@ -506,6 +613,69 @@ setupSharedTestSuite(() => {
       const rerun = await api.post(
         RUN,
         { dry_run: false, params: { order_id: before.orderId } },
+        adminHeaders
+      )
+      expect(rerun.data.result.changes).toHaveLength(0)
+      expect(rerun.data.result.applied).toBe(false)
+    })
+
+    /**
+     * #1195 item 4 — the root repair. A product with a shipping profile derives
+     * `requires_shipping: true` on its own, so this is what actually retires
+     * the bug for new orders rather than working around it.
+     */
+    it("the profile backfill links profile-less products and fixes the derivation at source", async () => {
+      const { api } = getSharedTestEnv()
+      const RUN =
+        "/admin/ops/maintenance-jobs/backfill-product-shipping-profiles/run"
+      const { productId, variantId, shippingProfile } = await createProduct(api, {
+        withProfile: false,
+        label: "ProfileFix",
+      })
+      expect(shippingProfile).toBeNull()
+
+      // Before: the cart derives false, which is the whole defect.
+      const itemBefore = await addToCart(api, variantId)
+      expect(itemBefore.requires_shipping).toBe(false)
+
+      const preview = await loud("profile dry-run", () =>
+        api.post(
+          RUN,
+          { dry_run: true, params: { product_id: productId } },
+          adminHeaders
+        )
+      )
+      expect(preview.data.result.dry_run).toBe(true)
+      expect(
+        preview.data.result.changes.some(
+          (c: any) => c.entity === "product" && c.id === productId
+        )
+      ).toBe(true)
+
+      const applied = await loud("profile apply", () =>
+        api.post(
+          RUN,
+          { dry_run: false, params: { product_id: productId } },
+          adminHeaders
+        )
+      )
+      expect(applied.data.result.applied).toBe(true)
+      expect(applied.data.result.errors).toBeUndefined()
+
+      const productAfter = await api.get(
+        `/admin/products/${productId}?fields=id,shipping_profile.id`,
+        adminHeaders
+      )
+      expect(productAfter.data.product.shipping_profile?.id).toBe(profileId)
+
+      // After: a NEW cart derives true with no flag-flipping anywhere.
+      const itemAfter = await addToCart(api, variantId)
+      expect(itemAfter.requires_shipping).toBe(true)
+
+      // Idempotent: the product already has a profile, so it is never relinked.
+      const rerun = await api.post(
+        RUN,
+        { dry_run: false, params: { product_id: productId } },
         adminHeaders
       )
       expect(rerun.data.result.changes).toHaveLength(0)

--- a/apps/backend/integration-tests/http/requires-shipping-fulfillment-gate.spec.ts
+++ b/apps/backend/integration-tests/http/requires-shipping-fulfillment-gate.spec.ts
@@ -342,17 +342,22 @@ setupSharedTestSuite(() => {
      * (see the test above), but the draft-order path does NOT: the item comes
      * out `requires_shipping: false` even when the product carries a profile.
      *
-     * Verified while narrowing this down:
-     *  - `query.graph({ entity: "variants", fields: [..., "product.shipping_profile.id"] })`
-     *    resolves the profile correctly, so the data is available.
-     *  - the variant IS resolved during line prep (the item gets `product_id`
-     *    and `product_title`), so it isn't a failed variant lookup.
-     * The profile is therefore dropped inside `createOrderWorkflow`'s own
-     * variant fetch. Exact line not isolated — this test pins the behaviour so
-     * a Medusa upgrade that fixes it fails loudly here.
+     * Isolated to `createOrderWorkflow` itself (not the draft-order route):
+     * calling the workflow directly with a profiled variant yields `false`.
+     * Ruled out along the way —
+     *  - `query.graph` with the workflow's EXACT `variantFields` list returns
+     *    `product.shipping_profile` fine, cached and uncached;
+     *  - the variant IS resolved during line prep (item gets `product_id`);
+     *  - only one `@medusajs/core-flows` copy is installed (2.17.2), and its
+     *    `prepare-line-item-data.js:23-29` reads
+     *    `variant?.product?.shipping_profile?.id` as expected.
+     * So the profile is lost between the query step and `prepareLineItemData`
+     * — most likely workflow step-output serialisation dropping the nested
+     * link relation. That last hop is NOT proven.
      *
-     * Consequence: assigning shipping profiles fixes storefront-cart orders,
-     * but NOT anything created through admin draft orders.
+     * It no longer blocks us: an explicit `requires_shipping` on the item wins
+     * over the derivation (`isDefined(item.requires_shipping) ? ... : ...`),
+     * which is the lever the fix uses — see the test below.
      */
     it("KNOWN DEFECT: the draft-order path ignores the shipping profile", async () => {
       const { api } = getSharedTestEnv()
@@ -369,6 +374,41 @@ setupSharedTestSuite(() => {
       expect(res.isPickUpFulfillment).toBe(false)
       expect(res.fulfillment.requires_shipping).toBe(false)
       expect(res.showShippingButton).toBe(false)
+    })
+
+    /**
+     * The fix lever. `prepareLineItemData` honours an explicit flag ahead of the
+     * broken derivation, so our own order-creating code (design orders, draft
+     * orders, partner flows) can set it rather than wait on upstream. This is
+     * the exact inverse of the two hard-coded `requires_shipping: false` lines
+     * in create-draft-order-from-designs.ts:306 and designs/[id]/checkout.
+     */
+    it("honours an explicit requires_shipping on the item, overriding the derivation", async () => {
+      const { api, getContainer } = getSharedTestEnv()
+      const { createOrderWorkflow } = await import("@medusajs/medusa/core-flows")
+      const { variantId } = await createProduct(api, {
+        withProfile: false,
+        label: "Explicit",
+      })
+
+      const { result } = await createOrderWorkflow(getContainer()).run({
+        input: {
+          email: "explicit@test.com",
+          region_id: regionId,
+          sales_channel_id: salesChannelId,
+          currency_code: "usd",
+          shipping_address: {
+            first_name: "Ex", last_name: "Plicit", address_1: "1 Test Rd",
+            city: "Dallas", province: "TX", postal_code: "75201", country_code: "us",
+          },
+          // No shipping profile on the product — the derivation would say false.
+          items: [
+            { variant_id: variantId, quantity: 1, unit_price: 1500, requires_shipping: true },
+          ],
+        } as any,
+      })
+
+      expect((result as any).items[0].requires_shipping).toBe(true)
     })
   })
 })

--- a/apps/backend/integration-tests/http/shiprocket-attach-awb.spec.ts
+++ b/apps/backend/integration-tests/http/shiprocket-attach-awb.spec.ts
@@ -197,5 +197,90 @@ setupSharedTestSuite(() => {
         .catch((e: any) => e.response)
       expect(blankErr.status).toBe(400)
     })
+
+    /**
+     * #1195 — pins the ORM behaviour the attach-AWB label write depends on.
+     *
+     * `sync-order-shipment-tracking` can only find a fulfillment from a webhook
+     * by `filters: { labels: { tracking_number } }` (`data.waybill` is JSONB and
+     * unfilterable), so the attach path MUST leave a label row behind. It used
+     * to leave none, making every attached parcel invisible to status pushes.
+     *
+     * The subtlety this test exists for: `updateFulfillment` REPLACES the
+     * labels collection, and `createOrderShipmentWorkflow` defaults to
+     * `labels: []`. If that empty array wipes existing rows, writing the label
+     * before marking the shipment silently undoes it — which is why
+     * `buildAttachAwbLabels` always returns the full set and the caller feeds
+     * it to the shipment workflow instead of writing first.
+     */
+    it("updateFulfillment replaces the labels collection — [] wipes it, ids carry it", async () => {
+      const container = getContainer()
+      const query: any = container.resolve(ContainerRegistrationKeys.QUERY)
+      const fulfillmentModule: any = container.resolve(Modules.FULFILLMENT)
+
+      const lineItemId = await buildDesignOrder()
+      const convertRes = await api.post(
+        `/admin/designs/orders/${lineItemId}/convert`,
+        { payment_mode: "prepaid" },
+        adminHeaders
+      )
+      const orderId = convertRes.data.design_order_conversion.order_id
+      const fulfillmentId = await ensureOrderFulfillment(container, orderId)
+
+      const labelsOf = async () => {
+        const { data } = await query.graph({
+          entity: "fulfillment",
+          fields: ["id", "labels.id", "labels.tracking_number"],
+          filters: { id: fulfillmentId },
+        })
+        return data?.[0]?.labels || []
+      }
+
+      await fulfillmentModule.updateFulfillment(fulfillmentId, {
+        labels: [
+          {
+            tracking_number: "AWB-KEEP-1",
+            tracking_url: "https://shiprocket.co/tracking/AWB-KEEP-1",
+            label_url: "",
+          },
+        ],
+      })
+      const written = await labelsOf()
+      expect(written).toHaveLength(1)
+      expect(written[0].tracking_number).toBe("AWB-KEEP-1")
+
+      // The webhook's lookup finds it — this is the whole point of the row.
+      const { data: byTracking } = await query.graph({
+        entity: "fulfillment",
+        fields: ["id", "labels.tracking_number"],
+        filters: { labels: { tracking_number: "AWB-KEEP-1" } },
+      })
+      expect((byTracking || []).some((f: any) => f.id === fulfillmentId)).toBe(
+        true
+      )
+
+      // Carrying the existing row through by id preserves it AND adds the new
+      // one — the shape buildAttachAwbLabels produces.
+      await fulfillmentModule.updateFulfillment(fulfillmentId, {
+        labels: [
+          { id: written[0].id },
+          {
+            tracking_number: "AWB-KEEP-2",
+            tracking_url: "https://shiprocket.co/tracking/AWB-KEEP-2",
+            label_url: "",
+          },
+        ],
+      })
+      const merged = await labelsOf()
+      expect(merged.map((l: any) => l.tracking_number).sort()).toEqual([
+        "AWB-KEEP-1",
+        "AWB-KEEP-2",
+      ])
+
+      // ...and the empty array is destructive, which is why the attach path
+      // never passes `labels: []` to createOrderShipmentWorkflow.
+      await fulfillmentModule.updateFulfillment(fulfillmentId, { labels: [] })
+      expect(await labelsOf()).toHaveLength(0)
+    })
   })
 })

--- a/apps/backend/src/api/admin/ops/maintenance-jobs/__tests__/backfill-open-order-requires-shipping.unit.spec.ts
+++ b/apps/backend/src/api/admin/ops/maintenance-jobs/__tests__/backfill-open-order-requires-shipping.unit.spec.ts
@@ -13,6 +13,8 @@ const pickupOption = {
 const shippingOption = {
   service_zone: { fulfillment_set: { type: "shipping" } },
 }
+/** A product that carries a shipping profile — the only kind that may be flipped. */
+const profiled = { shipping_profile: { id: "sp_1" } }
 
 describe("backfill-open-order-requires-shipping pure helpers (#1195)", () => {
   describe("isPickupFulfillment", () => {
@@ -116,8 +118,8 @@ describe("backfill-open-order-requires-shipping pure helpers (#1195)", () => {
       const plan = planOrderRepair({
         id: "order_1",
         items: [
-          { id: "li_1", requires_shipping: false },
-          { id: "li_2", requires_shipping: false },
+          { id: "li_1", requires_shipping: false, product: profiled },
+          { id: "li_2", requires_shipping: false, product: profiled },
         ],
         fulfillments: [
           {
@@ -137,7 +139,7 @@ describe("backfill-open-order-requires-shipping pure helpers (#1195)", () => {
     it("does not re-flip line items that are already true", () => {
       const plan = planOrderRepair({
         id: "order_1",
-        items: [{ id: "li_1", requires_shipping: true }],
+        items: [{ id: "li_1", requires_shipping: true, product: profiled }],
         fulfillments: [
           {
             id: "ful_1",
@@ -155,7 +157,7 @@ describe("backfill-open-order-requires-shipping pure helpers (#1195)", () => {
     it("leaves items covered only by a pickup fulfillment alone", () => {
       const plan = planOrderRepair({
         id: "order_1",
-        items: [{ id: "li_1", requires_shipping: false }],
+        items: [{ id: "li_1", requires_shipping: false, product: profiled }],
         fulfillments: [
           {
             id: "ful_1",
@@ -173,7 +175,7 @@ describe("backfill-open-order-requires-shipping pure helpers (#1195)", () => {
     it("still repairs an item shared with a pickup fulfillment when a shipped one covers it", () => {
       const plan = planOrderRepair({
         id: "order_1",
-        items: [{ id: "li_1", requires_shipping: false }],
+        items: [{ id: "li_1", requires_shipping: false, product: profiled }],
         fulfillments: [
           {
             id: "ful_pickup",
@@ -194,10 +196,30 @@ describe("backfill-open-order-requires-shipping pure helpers (#1195)", () => {
       expect(plan.lineItemIds).toEqual(["li_1"])
     })
 
+    it("repairs the fulfillment but NOT the line item when the product has no shipping profile", () => {
+      // create-fulfillment.js:78-83 would then reject the remaining quantity:
+      // `undefined !== sp_...` can never match the chosen option's profile.
+      const plan = planOrderRepair({
+        id: "order_1",
+        items: [{ id: "li_1", requires_shipping: false, product: {} }],
+        fulfillments: [
+          {
+            id: "ful_1",
+            requires_shipping: false,
+            shipping_option: shippingOption,
+            items: [{ line_item_id: "li_1" }],
+          },
+        ],
+      })
+
+      expect(plan.fulfillmentIds).toEqual(["ful_1"])
+      expect(plan.lineItemIds).toEqual([])
+    })
+
     it("returns an empty plan for an order with no fulfillments", () => {
       const plan = planOrderRepair({
         id: "order_1",
-        items: [{ id: "li_1", requires_shipping: false }],
+        items: [{ id: "li_1", requires_shipping: false, product: profiled }],
         fulfillments: [],
       })
 

--- a/apps/backend/src/api/admin/ops/maintenance-jobs/__tests__/backfill-open-order-requires-shipping.unit.spec.ts
+++ b/apps/backend/src/api/admin/ops/maintenance-jobs/__tests__/backfill-open-order-requires-shipping.unit.spec.ts
@@ -1,0 +1,240 @@
+import {
+  CLOSED_ORDER_STATUSES,
+  fulfillmentLineItemIds,
+  isPickupFulfillment,
+  needsRequiresShippingRepair,
+  planOrderRepair,
+  summarizeRequiresShippingBackfill,
+} from "../backfill-open-order-requires-shipping-job"
+
+const pickupOption = {
+  service_zone: { fulfillment_set: { type: "pickup" } },
+}
+const shippingOption = {
+  service_zone: { fulfillment_set: { type: "shipping" } },
+}
+
+describe("backfill-open-order-requires-shipping pure helpers (#1195)", () => {
+  describe("isPickupFulfillment", () => {
+    it("detects a pickup fulfillment set", () => {
+      expect(isPickupFulfillment({ shipping_option: pickupOption })).toBe(true)
+    })
+
+    it("does not treat a shipping option as pickup", () => {
+      expect(isPickupFulfillment({ shipping_option: shippingOption })).toBe(
+        false
+      )
+    })
+
+    it("does not treat a missing shipping option as pickup", () => {
+      // Our manual side-channel fulfillments are shipped goods, not pickups.
+      expect(isPickupFulfillment({})).toBe(false)
+      expect(isPickupFulfillment({ shipping_option: null })).toBe(false)
+      expect(isPickupFulfillment(null)).toBe(false)
+    })
+  })
+
+  describe("needsRequiresShippingRepair", () => {
+    it("flags the bug shape: live, non-pickup, stamped false", () => {
+      expect(
+        needsRequiresShippingRepair({
+          id: "ful_1",
+          requires_shipping: false,
+          shipping_option: shippingOption,
+        })
+      ).toBe(true)
+    })
+
+    it("leaves an already-correct fulfillment alone (idempotent)", () => {
+      expect(
+        needsRequiresShippingRepair({
+          id: "ful_1",
+          requires_shipping: true,
+          shipping_option: shippingOption,
+        })
+      ).toBe(false)
+    })
+
+    it("never flips a pickup fulfillment — that's the one documented rule", () => {
+      expect(
+        needsRequiresShippingRepair({
+          id: "ful_1",
+          requires_shipping: false,
+          shipping_option: pickupOption,
+        })
+      ).toBe(false)
+    })
+
+    it("skips canceled fulfillments", () => {
+      expect(
+        needsRequiresShippingRepair({
+          id: "ful_1",
+          requires_shipping: false,
+          canceled_at: "2026-08-01T00:00:00.000Z",
+          shipping_option: shippingOption,
+        })
+      ).toBe(false)
+    })
+
+    it("does not act on an undefined flag (only an explicit false is the bug)", () => {
+      expect(
+        needsRequiresShippingRepair({ id: "ful_1", shipping_option: shippingOption })
+      ).toBe(false)
+      expect(needsRequiresShippingRepair(null)).toBe(false)
+    })
+  })
+
+  describe("fulfillmentLineItemIds", () => {
+    it("collects and dedupes line item ids", () => {
+      expect(
+        fulfillmentLineItemIds({
+          items: [
+            { line_item_id: "li_1" },
+            { line_item_id: "li_2" },
+            { line_item_id: "li_1" },
+          ],
+        })
+      ).toEqual(["li_1", "li_2"])
+    })
+
+    it("skips rows with no line_item_id rather than guessing", () => {
+      expect(
+        fulfillmentLineItemIds({
+          items: [{ line_item_id: "li_1" }, {}, { line_item_id: null }],
+        })
+      ).toEqual(["li_1"])
+    })
+
+    it("tolerates a fulfillment with no items", () => {
+      expect(fulfillmentLineItemIds({})).toEqual([])
+      expect(fulfillmentLineItemIds(null)).toEqual([])
+    })
+  })
+
+  describe("planOrderRepair", () => {
+    it("plans the fulfillment and the line items it covers", () => {
+      const plan = planOrderRepair({
+        id: "order_1",
+        items: [
+          { id: "li_1", requires_shipping: false },
+          { id: "li_2", requires_shipping: false },
+        ],
+        fulfillments: [
+          {
+            id: "ful_1",
+            requires_shipping: false,
+            shipping_option: shippingOption,
+            items: [{ line_item_id: "li_1" }],
+          },
+        ],
+      })
+
+      expect(plan.fulfillmentIds).toEqual(["ful_1"])
+      // li_2 isn't in the fulfillment, so it isn't touched.
+      expect(plan.lineItemIds).toEqual(["li_1"])
+    })
+
+    it("does not re-flip line items that are already true", () => {
+      const plan = planOrderRepair({
+        id: "order_1",
+        items: [{ id: "li_1", requires_shipping: true }],
+        fulfillments: [
+          {
+            id: "ful_1",
+            requires_shipping: false,
+            shipping_option: shippingOption,
+            items: [{ line_item_id: "li_1" }],
+          },
+        ],
+      })
+
+      expect(plan.fulfillmentIds).toEqual(["ful_1"])
+      expect(plan.lineItemIds).toEqual([])
+    })
+
+    it("leaves items covered only by a pickup fulfillment alone", () => {
+      const plan = planOrderRepair({
+        id: "order_1",
+        items: [{ id: "li_1", requires_shipping: false }],
+        fulfillments: [
+          {
+            id: "ful_1",
+            requires_shipping: false,
+            shipping_option: pickupOption,
+            items: [{ line_item_id: "li_1" }],
+          },
+        ],
+      })
+
+      expect(plan.fulfillmentIds).toEqual([])
+      expect(plan.lineItemIds).toEqual([])
+    })
+
+    it("still repairs an item shared with a pickup fulfillment when a shipped one covers it", () => {
+      const plan = planOrderRepair({
+        id: "order_1",
+        items: [{ id: "li_1", requires_shipping: false }],
+        fulfillments: [
+          {
+            id: "ful_pickup",
+            requires_shipping: false,
+            shipping_option: pickupOption,
+            items: [{ line_item_id: "li_1" }],
+          },
+          {
+            id: "ful_ship",
+            requires_shipping: false,
+            shipping_option: shippingOption,
+            items: [{ line_item_id: "li_1" }],
+          },
+        ],
+      })
+
+      expect(plan.fulfillmentIds).toEqual(["ful_ship"])
+      expect(plan.lineItemIds).toEqual(["li_1"])
+    })
+
+    it("returns an empty plan for an order with no fulfillments", () => {
+      const plan = planOrderRepair({
+        id: "order_1",
+        items: [{ id: "li_1", requires_shipping: false }],
+        fulfillments: [],
+      })
+
+      expect(plan.fulfillmentIds).toEqual([])
+      expect(plan.lineItemIds).toEqual([])
+    })
+
+    it("tolerates a malformed order object", () => {
+      expect(planOrderRepair(null)).toEqual({
+        fulfillmentIds: [],
+        lineItemIds: [],
+      })
+    })
+  })
+
+  describe("summarizeRequiresShippingBackfill", () => {
+    it("reports a clean scan", () => {
+      expect(summarizeRequiresShippingBackfill(true, 12, 0, 0)).toContain(
+        "No changes"
+      )
+    })
+
+    it("uses conditional wording for dry-run vs apply", () => {
+      expect(summarizeRequiresShippingBackfill(true, 12, 3, 5)).toContain(
+        "Would set"
+      )
+      expect(summarizeRequiresShippingBackfill(false, 12, 3, 5)).toContain(
+        "Set requires_shipping=true on 3 fulfillment(s) and 5 line item(s)"
+      )
+    })
+  })
+
+  describe("CLOSED_ORDER_STATUSES", () => {
+    it("excludes terminal orders from the scan", () => {
+      expect(CLOSED_ORDER_STATUSES).toEqual(
+        expect.arrayContaining(["canceled", "archived", "completed"])
+      )
+    })
+  })
+})

--- a/apps/backend/src/api/admin/ops/maintenance-jobs/__tests__/backfill-open-order-requires-shipping.unit.spec.ts
+++ b/apps/backend/src/api/admin/ops/maintenance-jobs/__tests__/backfill-open-order-requires-shipping.unit.spec.ts
@@ -214,6 +214,8 @@ describe("backfill-open-order-requires-shipping pure helpers (#1195)", () => {
 
       expect(plan.fulfillmentIds).toEqual(["ful_1"])
       expect(plan.lineItemIds).toEqual([])
+      // ...and it is REPORTED, not silently dropped.
+      expect(plan.skippedLineItemIds).toEqual(["li_1"])
     })
 
     it("returns an empty plan for an order with no fulfillments", () => {
@@ -231,6 +233,7 @@ describe("backfill-open-order-requires-shipping pure helpers (#1195)", () => {
       expect(planOrderRepair(null)).toEqual({
         fulfillmentIds: [],
         lineItemIds: [],
+        skippedLineItemIds: [],
       })
     })
   })
@@ -248,6 +251,30 @@ describe("backfill-open-order-requires-shipping pure helpers (#1195)", () => {
       )
       expect(summarizeRequiresShippingBackfill(false, 12, 3, 5)).toContain(
         "Set requires_shipping=true on 3 fulfillment(s) and 5 line item(s)"
+      )
+    })
+
+    it("never hides a partial repair — skipped items and their cure are named", () => {
+      const summary = summarizeRequiresShippingBackfill(false, 12, 3, 5, 7)
+      expect(summary).toContain("SKIPPED 7 line item(s)")
+      expect(summary).toContain("no shipping profile")
+      expect(summary).toContain("backfill-product-shipping-profiles")
+    })
+
+    it("says so even when nothing else changed", () => {
+      // The dangerous case: a run that repaired nothing AND skipped work would
+      // otherwise read as "all clean".
+      const summary = summarizeRequiresShippingBackfill(true, 12, 0, 0, 4)
+      expect(summary).toContain("No changes")
+      expect(summary).toContain("SKIPPED 4 line item(s)")
+    })
+
+    it("stays quiet when there is nothing to skip", () => {
+      expect(summarizeRequiresShippingBackfill(false, 12, 3, 5, 0)).not.toContain(
+        "SKIPPED"
+      )
+      expect(summarizeRequiresShippingBackfill(false, 12, 3, 5)).not.toContain(
+        "SKIPPED"
       )
     })
   })

--- a/apps/backend/src/api/admin/ops/maintenance-jobs/__tests__/backfill-product-shipping-profiles.unit.spec.ts
+++ b/apps/backend/src/api/admin/ops/maintenance-jobs/__tests__/backfill-product-shipping-profiles.unit.spec.ts
@@ -1,0 +1,90 @@
+import {
+  needsShippingProfile,
+  pickTargetProfileId,
+  summarizeProfileBackfill,
+} from "../backfill-product-shipping-profiles-job"
+
+describe("backfill-product-shipping-profiles pure helpers (#1195)", () => {
+  describe("needsShippingProfile", () => {
+    it("flags a product with no profile", () => {
+      expect(needsShippingProfile({ id: "prod_1" })).toBe(true)
+      expect(needsShippingProfile({ id: "prod_1", shipping_profile: null })).toBe(
+        true
+      )
+    })
+
+    it("never reassigns a product that already has one", () => {
+      expect(
+        needsShippingProfile({
+          id: "prod_1",
+          shipping_profile: { id: "sp_1" },
+        })
+      ).toBe(false)
+    })
+
+    it("ignores rows with no id", () => {
+      expect(needsShippingProfile({})).toBe(false)
+      expect(needsShippingProfile(null)).toBe(false)
+    })
+  })
+
+  describe("pickTargetProfileId", () => {
+    const profiles = [
+      { id: "sp_default", type: "default" },
+      { id: "sp_custom", type: "custom" },
+    ]
+
+    it("honours an explicit id that exists", () => {
+      expect(pickTargetProfileId(profiles, "sp_custom")).toBe("sp_custom")
+    })
+
+    it("rejects an explicit id that does not exist", () => {
+      expect(pickTargetProfileId(profiles, "sp_nope")).toBeNull()
+    })
+
+    it("falls back to the single default profile", () => {
+      expect(pickTargetProfileId(profiles)).toBe("sp_default")
+    })
+
+    it("uses the only profile when there is no default-typed one", () => {
+      expect(pickTargetProfileId([{ id: "sp_only", type: "custom" }])).toBe(
+        "sp_only"
+      )
+    })
+
+    it("refuses to guess when the choice is ambiguous", () => {
+      // Two defaults, or several non-defaults — scattering products across
+      // profiles silently would be worse than failing.
+      expect(
+        pickTargetProfileId([
+          { id: "sp_a", type: "default" },
+          { id: "sp_b", type: "default" },
+        ])
+      ).toBeNull()
+      expect(
+        pickTargetProfileId([
+          { id: "sp_a", type: "custom" },
+          { id: "sp_b", type: "custom" },
+        ])
+      ).toBeNull()
+      expect(pickTargetProfileId([])).toBeNull()
+    })
+  })
+
+  describe("summarizeProfileBackfill", () => {
+    it("reports a clean scan", () => {
+      expect(summarizeProfileBackfill(true, 20, 0, "sp_1")).toContain(
+        "No changes"
+      )
+    })
+
+    it("uses conditional wording for dry-run vs apply", () => {
+      expect(summarizeProfileBackfill(true, 20, 5, "sp_1")).toContain(
+        "Would link 5 of 20"
+      )
+      expect(summarizeProfileBackfill(false, 20, 5, "sp_1")).toContain(
+        "Linked 5 of 20"
+      )
+    })
+  })
+})

--- a/apps/backend/src/api/admin/ops/maintenance-jobs/backfill-open-order-requires-shipping-job.ts
+++ b/apps/backend/src/api/admin/ops/maintenance-jobs/backfill-open-order-requires-shipping-job.ts
@@ -5,6 +5,8 @@ import {
 } from "@medusajs/framework/utils"
 import { z } from "@medusajs/framework/zod"
 
+import { lineItemIdsNeedingShippingFlag } from "../../../../lib/requires-shipping"
+
 import type {
   MaintenanceChange,
   MaintenanceJob,
@@ -41,10 +43,17 @@ import type {
  *     fulfillment we create is `manual_manual` through the shipping
  *     side-channel), and
  *   - are stamped `requires_shipping: false`
- * and sets them to `true`, along with the order line items those fulfillments
- * cover. A pickup fulfillment is left alone — that is the one real restriction,
- * and flipping it would surface "Mark as shipped" on an order the customer
- * collects in person.
+ * and sets them to `true`. A pickup fulfillment is left alone — that is the one
+ * real restriction, and flipping it would surface "Mark as shipped" on an order
+ * the customer collects in person.
+ *
+ * The line items those fulfillments cover are flipped too, but ONLY when the
+ * product carries a shipping profile: `create-fulfillment.js:78-83` rejects a
+ * requires-shipping item whose product profile doesn't match the chosen
+ * option, and for a profile-less product that comparison can never succeed —
+ * flipping it would make the remaining quantity of a partially-fulfilled order
+ * unfulfillable. Profile-less products are fixed by giving them a profile
+ * (`backfill-product-shipping-profiles`), not by flipping the flag.
  *
  * Dry-run (default) previews every before→after without writing; apply is
  * idempotent (a second run finds nothing left to flip).
@@ -132,12 +141,16 @@ export function planOrderRepair(order: any): {
     }
   }
 
-  const lineItemIds = (order?.items ?? [])
-    .filter(
-      (item: any) =>
-        coveredLineItemIds.has(item?.id) && item?.requires_shipping === false
-    )
-    .map((item: any) => item.id)
+  // A line item may only be flipped when its product carries a shipping
+  // profile: `create-fulfillment.js:78-83` rejects a requires-shipping item
+  // whose product profile doesn't match the chosen option, and for a
+  // profile-less product that comparison can never succeed. Flipping it would
+  // make the REMAINING quantity of a partially-fulfilled order unfulfillable.
+  // The fulfillment's own flag is repaired regardless — nothing re-validates
+  // it, and it is what the dashboard gates on.
+  const lineItemIds = lineItemIdsNeedingShippingFlag(
+    (order?.items ?? []).filter((item: any) => coveredLineItemIds.has(item?.id))
+  )
 
   return { fulfillmentIds, lineItemIds }
 }
@@ -159,7 +172,7 @@ export const backfillOpenOrderRequiresShippingJob: MaintenanceJob = {
   id: "backfill-open-order-requires-shipping",
   label: "Backfill requires_shipping on open orders (#1195)",
   description:
-    "Repair open orders whose fulfillments were stamped requires_shipping=false by Medusa's derivation (no shipping profile + manage_inventory:false), which hides the 'Mark as shipped' action in the admin dashboard. Sets requires_shipping=true on every live NON-pickup fulfillment of an open order and on the line items it covers. Pickup fulfillments are left untouched. Dry-run previews the before/after; apply is idempotent.",
+    "Repair open orders whose fulfillments were stamped requires_shipping=false by Medusa's derivation (no shipping profile + manage_inventory:false), which hides the 'Mark as shipped' action in the admin dashboard. Sets requires_shipping=true on every live NON-pickup fulfillment of an open order, and on the line items it covers WHEN their product has a shipping profile (without one the flag would make the item unfulfillable — run backfill-product-shipping-profiles first). Pickup fulfillments are left untouched. Dry-run previews the before/after; apply is idempotent.",
   params: [
     {
       name: "order_id",
@@ -204,6 +217,7 @@ export const backfillOpenOrderRequiresShippingJob: MaintenanceJob = {
         "canceled_at",
         "items.id",
         "items.requires_shipping",
+        "items.product.shipping_profile.id",
         "fulfillments.id",
         "fulfillments.requires_shipping",
         "fulfillments.canceled_at",

--- a/apps/backend/src/api/admin/ops/maintenance-jobs/backfill-open-order-requires-shipping-job.ts
+++ b/apps/backend/src/api/admin/ops/maintenance-jobs/backfill-open-order-requires-shipping-job.ts
@@ -122,13 +122,15 @@ export function fulfillmentLineItemIds(fulfillment: any): string[] {
 
 /**
  * PURE: given one open order, decide every repair it needs. Returns the
- * fulfillment ids to flip and the line item ids to flip (only items actually
- * covered by a repairable fulfillment AND currently stamped false).
- * Exported for unit testing.
+ * fulfillment ids to flip, the line item ids to flip (only items actually
+ * covered by a repairable fulfillment AND currently stamped false), and the
+ * ids deliberately SKIPPED for want of a shipping profile — those are reported
+ * so a partial repair never reads as a complete one. Exported for unit testing.
  */
 export function planOrderRepair(order: any): {
   fulfillmentIds: string[]
   lineItemIds: string[]
+  skippedLineItemIds: string[]
 } {
   const fulfillmentIds: string[] = []
   const coveredLineItemIds = new Set<string>()
@@ -148,24 +150,48 @@ export function planOrderRepair(order: any): {
   // make the REMAINING quantity of a partially-fulfilled order unfulfillable.
   // The fulfillment's own flag is repaired regardless — nothing re-validates
   // it, and it is what the dashboard gates on.
-  const lineItemIds = lineItemIdsNeedingShippingFlag(
-    (order?.items ?? []).filter((item: any) => coveredLineItemIds.has(item?.id))
+  const covered = (order?.items ?? []).filter((item: any) =>
+    coveredLineItemIds.has(item?.id)
   )
+  const lineItemIds = lineItemIdsNeedingShippingFlag(covered)
 
-  return { fulfillmentIds, lineItemIds }
+  // Everything the guard above held back. Reported rather than swallowed: a
+  // silent skip makes a half-finished repair look complete, and the cure is a
+  // different job (backfill-product-shipping-profiles) the operator has to run
+  // first.
+  const skippedLineItemIds = covered
+    .filter(
+      (item: any) =>
+        item?.id &&
+        item?.requires_shipping === false &&
+        !lineItemIds.includes(item.id)
+    )
+    .map((item: any) => item.id as string)
+
+  return { fulfillmentIds, lineItemIds, skippedLineItemIds }
 }
 
-/** PURE: the operator-facing summary line. Exported for unit testing. */
+/**
+ * PURE: the operator-facing summary line. Always states what was SKIPPED for
+ * want of a shipping profile — that half of the repair needs a different job
+ * (`backfill-product-shipping-profiles`) run first, and reporting only the
+ * successes would read as full coverage. Exported for unit testing.
+ */
 export function summarizeRequiresShippingBackfill(
   dryRun: boolean,
   scannedOrders: number,
   fulfillmentCount: number,
-  lineItemCount: number
+  lineItemCount: number,
+  skippedLineItemCount = 0
 ): string {
+  const skipped = skippedLineItemCount
+    ? ` — SKIPPED ${skippedLineItemCount} line item(s) whose product has no shipping profile (they would become unfulfillable); run backfill-product-shipping-profiles first, then re-run this job`
+    : ""
+
   if (fulfillmentCount === 0 && lineItemCount === 0) {
-    return `No changes — scanned ${scannedOrders} open order(s), every live non-pickup fulfillment already requires shipping`
+    return `No changes — scanned ${scannedOrders} open order(s), every live non-pickup fulfillment already requires shipping${skipped}`
   }
-  return `${dryRun ? "Would set" : "Set"} requires_shipping=true on ${fulfillmentCount} fulfillment(s) and ${lineItemCount} line item(s) across ${scannedOrders} scanned open order(s)`
+  return `${dryRun ? "Would set" : "Set"} requires_shipping=true on ${fulfillmentCount} fulfillment(s) and ${lineItemCount} line item(s) across ${scannedOrders} scanned open order(s)${skipped}`
 }
 
 export const backfillOpenOrderRequiresShippingJob: MaintenanceJob = {
@@ -232,6 +258,7 @@ export const backfillOpenOrderRequiresShippingJob: MaintenanceJob = {
     const errors: Array<{ id: string; message: string }> = []
     let fulfillmentCount = 0
     let lineItemCount = 0
+    let skippedLineItemCount = 0
 
     for (const order of (orders || []) as any[]) {
       // `canceled_at` is belt-and-braces: the status filter already excludes
@@ -239,7 +266,9 @@ export const backfillOpenOrderRequiresShippingJob: MaintenanceJob = {
       // the status.
       if (order.canceled_at) continue
 
-      const { fulfillmentIds, lineItemIds } = planOrderRepair(order)
+      const { fulfillmentIds, lineItemIds, skippedLineItemIds } =
+        planOrderRepair(order)
+      skippedLineItemCount += skippedLineItemIds.length
 
       for (const fulfillmentId of fulfillmentIds) {
         fulfillmentCount++
@@ -293,7 +322,8 @@ export const backfillOpenOrderRequiresShippingJob: MaintenanceJob = {
         dry_run,
         (orders || []).length,
         fulfillmentCount,
-        lineItemCount
+        lineItemCount,
+        skippedLineItemCount
       ),
       changes,
       errors: errors.length ? errors : undefined,

--- a/apps/backend/src/api/admin/ops/maintenance-jobs/backfill-open-order-requires-shipping-job.ts
+++ b/apps/backend/src/api/admin/ops/maintenance-jobs/backfill-open-order-requires-shipping-job.ts
@@ -1,0 +1,288 @@
+import {
+  ContainerRegistrationKeys,
+  MedusaError,
+  Modules,
+} from "@medusajs/framework/utils"
+import { z } from "@medusajs/framework/zod"
+
+import type {
+  MaintenanceChange,
+  MaintenanceJob,
+  MaintenanceJobResult,
+} from "./registry"
+
+/**
+ * #1195 — backfill `requires_shipping` on open orders and their fulfillments.
+ *
+ * THE BUG
+ * -------
+ * `requires_shipping` on a line item is DERIVED, not asked for:
+ * `hasShippingProfile || someInventoryRequiresShipping`
+ * (core-flows `prepare-line-item-data.js:23-29`), and `create-fulfillment.js`
+ * copies the item flag onto the fulfillment. Most of our catalogue has no
+ * shipping profile and sells variants with `manage_inventory: false`, so both
+ * operands are false and every such fulfillment is stamped
+ * `requires_shipping: false`.
+ *
+ * The dashboard then hides the shipment action on that flag alone — an
+ * undocumented term; the only restriction the Medusa user guide documents is
+ * the pickup-option one. We relaxed our own partner UI gate, but the admin core
+ * gate lives inside the shipped `@medusajs/dashboard` bundle
+ * (`order-detail-*.mjs`) and cannot be patched from here. Repairing the DATA is
+ * what fixes admin — and it also stops the wrong value propagating into any
+ * future fulfillment created from these orders.
+ *
+ * WHAT IT DOES
+ * ------------
+ * For every OPEN order (status not canceled/archived/completed, not
+ * `canceled_at`), finds fulfillments that
+ *   - are not canceled, and
+ *   - went out on a NON-pickup shipping option (or no option at all — every
+ *     fulfillment we create is `manual_manual` through the shipping
+ *     side-channel), and
+ *   - are stamped `requires_shipping: false`
+ * and sets them to `true`, along with the order line items those fulfillments
+ * cover. A pickup fulfillment is left alone — that is the one real restriction,
+ * and flipping it would surface "Mark as shipped" on an order the customer
+ * collects in person.
+ *
+ * Dry-run (default) previews every before→after without writing; apply is
+ * idempotent (a second run finds nothing left to flip).
+ *
+ * NOTE: `requires_shipping` is absent from the public `UpdateFulfillmentDTO`,
+ * but `updateFulfillment_` spreads `data` straight into
+ * `fulfillmentService_.update([{ id, ...data }])`, so the column is writable.
+ * The cast at the call site is deliberate and load-bearing.
+ */
+
+/** Hard cap on orders scanned in one call. */
+export const MAX_OPEN_ORDER_SCAN = 5000
+
+/** Order statuses that are NOT "open" for the purposes of this backfill. */
+export const CLOSED_ORDER_STATUSES = ["canceled", "archived", "completed"]
+
+const paramsSchema = z.object({
+  /** Restrict to a single order. */
+  order_id: z.string().min(1).optional(),
+  /** Max orders to scan in one call. */
+  limit: z
+    .number()
+    .int()
+    .positive()
+    .max(MAX_OPEN_ORDER_SCAN)
+    .optional()
+    .default(1000),
+})
+
+/**
+ * PURE: is this fulfillment a pickup one? Mirrors the dashboard's own
+ * derivation (`shipping_option.service_zone.fulfillment_set.type === "pickup"`).
+ * A fulfillment with no shipping option is NOT treated as pickup — our manual
+ * side-channel fulfillments are shipped goods. Exported for unit testing.
+ */
+export function isPickupFulfillment(fulfillment: any): boolean {
+  return (
+    fulfillment?.shipping_option?.service_zone?.fulfillment_set?.type ===
+    "pickup"
+  )
+}
+
+/**
+ * PURE: should this fulfillment's `requires_shipping` be flipped to true?
+ * Only when it is currently false, the fulfillment is live (not canceled), and
+ * it is not a pickup. Exported for unit testing.
+ */
+export function needsRequiresShippingRepair(fulfillment: any): boolean {
+  if (!fulfillment) return false
+  if (fulfillment.canceled_at) return false
+  if (isPickupFulfillment(fulfillment)) return false
+  return fulfillment.requires_shipping === false
+}
+
+/**
+ * PURE: the line item ids a fulfillment covers. Fulfillment items carry
+ * `line_item_id`; anything missing one (older rows) is skipped rather than
+ * guessed at. Exported for unit testing.
+ */
+export function fulfillmentLineItemIds(fulfillment: any): string[] {
+  const ids = (fulfillment?.items ?? [])
+    .map((i: any) => i?.line_item_id)
+    .filter((id: any): id is string => typeof id === "string" && !!id)
+  return Array.from(new Set(ids))
+}
+
+/**
+ * PURE: given one open order, decide every repair it needs. Returns the
+ * fulfillment ids to flip and the line item ids to flip (only items actually
+ * covered by a repairable fulfillment AND currently stamped false).
+ * Exported for unit testing.
+ */
+export function planOrderRepair(order: any): {
+  fulfillmentIds: string[]
+  lineItemIds: string[]
+} {
+  const fulfillmentIds: string[] = []
+  const coveredLineItemIds = new Set<string>()
+
+  for (const f of order?.fulfillments ?? []) {
+    if (!needsRequiresShippingRepair(f)) continue
+    fulfillmentIds.push(f.id)
+    for (const lineItemId of fulfillmentLineItemIds(f)) {
+      coveredLineItemIds.add(lineItemId)
+    }
+  }
+
+  const lineItemIds = (order?.items ?? [])
+    .filter(
+      (item: any) =>
+        coveredLineItemIds.has(item?.id) && item?.requires_shipping === false
+    )
+    .map((item: any) => item.id)
+
+  return { fulfillmentIds, lineItemIds }
+}
+
+/** PURE: the operator-facing summary line. Exported for unit testing. */
+export function summarizeRequiresShippingBackfill(
+  dryRun: boolean,
+  scannedOrders: number,
+  fulfillmentCount: number,
+  lineItemCount: number
+): string {
+  if (fulfillmentCount === 0 && lineItemCount === 0) {
+    return `No changes — scanned ${scannedOrders} open order(s), every live non-pickup fulfillment already requires shipping`
+  }
+  return `${dryRun ? "Would set" : "Set"} requires_shipping=true on ${fulfillmentCount} fulfillment(s) and ${lineItemCount} line item(s) across ${scannedOrders} scanned open order(s)`
+}
+
+export const backfillOpenOrderRequiresShippingJob: MaintenanceJob = {
+  id: "backfill-open-order-requires-shipping",
+  label: "Backfill requires_shipping on open orders (#1195)",
+  description:
+    "Repair open orders whose fulfillments were stamped requires_shipping=false by Medusa's derivation (no shipping profile + manage_inventory:false), which hides the 'Mark as shipped' action in the admin dashboard. Sets requires_shipping=true on every live NON-pickup fulfillment of an open order and on the line items it covers. Pickup fulfillments are left untouched. Dry-run previews the before/after; apply is idempotent.",
+  params: [
+    {
+      name: "order_id",
+      type: "string",
+      required: false,
+      description: "Restrict the run to a single order id",
+    },
+    {
+      name: "limit",
+      type: "number",
+      required: false,
+      description: `Max open orders to scan in one call (default 1000, max ${MAX_OPEN_ORDER_SCAN})`,
+    },
+  ],
+  run: async (container, { dry_run, params }): Promise<MaintenanceJobResult> => {
+    const parsed = paramsSchema.safeParse(params)
+    if (!parsed.success) {
+      throw new MedusaError(
+        MedusaError.Types.INVALID_DATA,
+        parsed.error.issues.map((i) => i.message).join("; ")
+      )
+    }
+    const { order_id, limit } = parsed.data
+
+    const query: any = container.resolve(ContainerRegistrationKeys.QUERY)
+    const fulfillmentModule: any = container.resolve(Modules.FULFILLMENT)
+    const orderModule: any = container.resolve(Modules.ORDER)
+
+    const filters: Record<string, unknown> = {
+      status: { $nin: CLOSED_ORDER_STATUSES },
+    }
+    if (order_id) {
+      filters.id = order_id
+    }
+
+    const { data: orders } = await query.graph({
+      entity: "order",
+      fields: [
+        "id",
+        "display_id",
+        "status",
+        "canceled_at",
+        "items.id",
+        "items.requires_shipping",
+        "fulfillments.id",
+        "fulfillments.requires_shipping",
+        "fulfillments.canceled_at",
+        "fulfillments.items.line_item_id",
+        "fulfillments.shipping_option.service_zone.fulfillment_set.type",
+      ],
+      filters,
+      pagination: { take: limit },
+    })
+
+    const changes: MaintenanceChange[] = []
+    const errors: Array<{ id: string; message: string }> = []
+    let fulfillmentCount = 0
+    let lineItemCount = 0
+
+    for (const order of (orders || []) as any[]) {
+      // `canceled_at` is belt-and-braces: the status filter already excludes
+      // canceled orders, but a partially-migrated row could carry one without
+      // the status.
+      if (order.canceled_at) continue
+
+      const { fulfillmentIds, lineItemIds } = planOrderRepair(order)
+
+      for (const fulfillmentId of fulfillmentIds) {
+        fulfillmentCount++
+        changes.push({
+          entity: "fulfillment",
+          id: fulfillmentId,
+          field: `requires_shipping (order ${order.display_id ?? order.id})`,
+          before: false,
+          after: true,
+        })
+        if (!dry_run) {
+          try {
+            // See the note at the top of this file: the column is writable
+            // through the spread in `updateFulfillment_`, but absent from the
+            // public DTO — hence the cast.
+            await fulfillmentModule.updateFulfillment(fulfillmentId, {
+              requires_shipping: true,
+            } as any)
+          } catch (e: any) {
+            errors.push({ id: fulfillmentId, message: e?.message ?? String(e) })
+          }
+        }
+      }
+
+      for (const lineItemId of lineItemIds) {
+        lineItemCount++
+        changes.push({
+          entity: "order_line_item",
+          id: lineItemId,
+          field: `requires_shipping (order ${order.display_id ?? order.id})`,
+          before: false,
+          after: true,
+        })
+        if (!dry_run) {
+          try {
+            await orderModule.updateOrderLineItems(lineItemId, {
+              requires_shipping: true,
+            })
+          } catch (e: any) {
+            errors.push({ id: lineItemId, message: e?.message ?? String(e) })
+          }
+        }
+      }
+    }
+
+    return {
+      job_id: backfillOpenOrderRequiresShippingJob.id,
+      dry_run,
+      applied: !dry_run && changes.length > 0 && errors.length < changes.length,
+      summary: summarizeRequiresShippingBackfill(
+        dry_run,
+        (orders || []).length,
+        fulfillmentCount,
+        lineItemCount
+      ),
+      changes,
+      errors: errors.length ? errors : undefined,
+    }
+  },
+}

--- a/apps/backend/src/api/admin/ops/maintenance-jobs/backfill-product-shipping-profiles-job.ts
+++ b/apps/backend/src/api/admin/ops/maintenance-jobs/backfill-product-shipping-profiles-job.ts
@@ -1,0 +1,211 @@
+import {
+  ContainerRegistrationKeys,
+  MedusaError,
+  Modules,
+} from "@medusajs/framework/utils"
+import { z } from "@medusajs/framework/zod"
+
+import type {
+  MaintenanceChange,
+  MaintenanceJob,
+  MaintenanceJobResult,
+} from "./registry"
+
+/**
+ * #1195 item 4 — give profile-less products a shipping profile.
+ *
+ * This is the ROOT repair the other #1195 work routes around. A product with no
+ * shipping profile poisons three separate things:
+ *
+ *  1. `prepareLineItemData` derives `requires_shipping: false` for it (there is
+ *     no profile and our variants are `manage_inventory: false`), which is what
+ *     hides "Mark as shipped" in the dashboard;
+ *  2. `create-fulfillment.js:78-83` refuses to fulfil a requires-shipping item
+ *     whose product profile doesn't match the chosen option — so the flag
+ *     CANNOT simply be flipped on a profile-less product;
+ *  3. `validateShippingStep` blocks cart completion for the same mismatch.
+ *
+ * Once a product carries a profile, the derivation yields `true` on its own and
+ * every downstream check lines up. Prod measured 54 of 75 products with no
+ * profile.
+ *
+ * Links product → shipping profile through the same remote link
+ * `createProductsWorkflow` writes:
+ *   { [Modules.PRODUCT]: { product_id }, [Modules.FULFILLMENT]: { shipping_profile_id } }
+ *
+ * Idempotent: a product that already has a profile is never re-linked or
+ * moved — this only ever fills a gap, it does not reassign.
+ */
+
+/** Hard cap on products scanned in one call. */
+export const MAX_PRODUCT_PROFILE_SCAN = 5000
+
+const paramsSchema = z.object({
+  /** Restrict to a single product. */
+  product_id: z.string().min(1).optional(),
+  /**
+   * Profile to link. Defaults to the store's `type: "default"` profile, which
+   * is the one `createProductsWorkflow` assigns when the admin UI creates a
+   * product normally.
+   */
+  profile_id: z.string().min(1).optional(),
+  /** Max products to scan in one call. */
+  limit: z
+    .number()
+    .int()
+    .positive()
+    .max(MAX_PRODUCT_PROFILE_SCAN)
+    .optional()
+    .default(1000),
+})
+
+/**
+ * PURE: does this product need a profile link? Only when it has none —
+ * an existing profile is never reassigned. Exported for unit testing.
+ */
+export function needsShippingProfile(product: any): boolean {
+  return !!product?.id && !product?.shipping_profile?.id
+}
+
+/**
+ * PURE: pick the profile to link. An explicit id wins; otherwise the
+ * `type: "default"` profile; otherwise — when exactly one profile exists — that
+ * one. Returns null when the choice is ambiguous, so the job fails loudly
+ * rather than scattering products across profiles. Exported for unit testing.
+ */
+export function pickTargetProfileId(
+  profiles: any[],
+  explicitId?: string
+): string | null {
+  if (explicitId) {
+    return profiles.some((p) => p?.id === explicitId) ? explicitId : null
+  }
+  const defaults = profiles.filter((p) => p?.type === "default")
+  if (defaults.length === 1) return defaults[0].id
+  if (defaults.length === 0 && profiles.length === 1) return profiles[0].id
+  return null
+}
+
+/** PURE: the operator-facing summary line. Exported for unit testing. */
+export function summarizeProfileBackfill(
+  dryRun: boolean,
+  scanned: number,
+  linked: number,
+  profileId: string
+): string {
+  if (linked === 0) {
+    return `No changes — scanned ${scanned} product(s), all already carry a shipping profile`
+  }
+  return `${dryRun ? "Would link" : "Linked"} ${linked} of ${scanned} scanned product(s) to shipping profile ${profileId}`
+}
+
+export const backfillProductShippingProfilesJob: MaintenanceJob = {
+  id: "backfill-product-shipping-profiles",
+  label: "Backfill product shipping profiles (#1195)",
+  description:
+    "Link every product that has NO shipping profile to the store's default one (or an explicit profile_id). A profile-less product derives requires_shipping=false — which hides 'Mark as shipped' — and cannot be fulfilled or checked out once that flag is true, because both create-fulfillment and validateShippingStep compare the product's profile against the chosen shipping option's. Products that already have a profile are never reassigned. Dry-run previews the links; apply is idempotent.",
+  params: [
+    {
+      name: "product_id",
+      type: "string",
+      required: false,
+      description: "Restrict the run to a single product id",
+    },
+    {
+      name: "profile_id",
+      type: "string",
+      required: false,
+      description:
+        "Shipping profile to link (defaults to the store's type:\"default\" profile)",
+    },
+    {
+      name: "limit",
+      type: "number",
+      required: false,
+      description: `Max products to scan in one call (default 1000, max ${MAX_PRODUCT_PROFILE_SCAN})`,
+    },
+  ],
+  run: async (container, { dry_run, params }): Promise<MaintenanceJobResult> => {
+    const parsed = paramsSchema.safeParse(params)
+    if (!parsed.success) {
+      throw new MedusaError(
+        MedusaError.Types.INVALID_DATA,
+        parsed.error.issues.map((i) => i.message).join("; ")
+      )
+    }
+    const { product_id, profile_id, limit } = parsed.data
+
+    const query: any = container.resolve(ContainerRegistrationKeys.QUERY)
+    const remoteLink: any = container.resolve(ContainerRegistrationKeys.LINK)
+
+    const { data: profiles } = await query.graph({
+      entity: "shipping_profile",
+      fields: ["id", "name", "type"],
+      pagination: { take: 100 },
+    })
+
+    const targetProfileId = pickTargetProfileId(profiles || [], profile_id)
+    if (!targetProfileId) {
+      throw new MedusaError(
+        MedusaError.Types.INVALID_DATA,
+        profile_id
+          ? `Shipping profile ${profile_id} not found`
+          : `Could not pick a default shipping profile (${(profiles || []).length} found) — pass profile_id explicitly`
+      )
+    }
+
+    const filters: Record<string, unknown> = {}
+    if (product_id) {
+      filters.id = product_id
+    }
+
+    const { data: products } = await query.graph({
+      entity: "product",
+      fields: ["id", "title", "shipping_profile.id"],
+      filters,
+      pagination: { take: limit },
+    })
+
+    const changes: MaintenanceChange[] = []
+    const errors: Array<{ id: string; message: string }> = []
+
+    for (const product of (products || []) as any[]) {
+      if (!needsShippingProfile(product)) continue
+
+      changes.push({
+        entity: "product",
+        id: product.id,
+        field: `shipping_profile (${product.title ?? product.id})`,
+        before: null,
+        after: targetProfileId,
+      })
+
+      if (!dry_run) {
+        try {
+          // Same link shape `createProductsWorkflow` writes — operand order
+          // matters, a reversed pair links nothing and reports success.
+          await remoteLink.create({
+            [Modules.PRODUCT]: { product_id: product.id },
+            [Modules.FULFILLMENT]: { shipping_profile_id: targetProfileId },
+          })
+        } catch (e: any) {
+          errors.push({ id: product.id, message: e?.message ?? String(e) })
+        }
+      }
+    }
+
+    return {
+      job_id: backfillProductShippingProfilesJob.id,
+      dry_run,
+      applied: !dry_run && changes.length > 0 && errors.length < changes.length,
+      summary: summarizeProfileBackfill(
+        dry_run,
+        (products || []).length,
+        changes.length,
+        targetProfileId
+      ),
+      changes,
+      errors: errors.length ? errors : undefined,
+    }
+  },
+}

--- a/apps/backend/src/api/admin/ops/maintenance-jobs/registry.ts
+++ b/apps/backend/src/api/admin/ops/maintenance-jobs/registry.ts
@@ -92,6 +92,7 @@ import { backfillDesignSizeSetsJob } from "./backfill-design-size-sets-job"
 import { backfillPartnerShippingOptionsJob } from "./backfill-partner-shipping-options-job"
 import { repairShippingOptionStoreVisibilityJob } from "./repair-shipping-option-store-visibility-job"
 import { backfillOpenOrderRequiresShippingJob } from "./backfill-open-order-requires-shipping-job"
+import { backfillProductShippingProfilesJob } from "./backfill-product-shipping-profiles-job"
 import { normalizeArtisanProductsJob } from "./normalize-artisan-products-job"
 import { linkArtisanDetailRowsJob } from "./link-artisan-detail-rows-job"
 import { backfillFulfilledRetailRunsJob } from "./backfill-fulfilled-retail-runs-job"
@@ -5591,6 +5592,7 @@ export const MAINTENANCE_JOBS: MaintenanceJob[] = [
   backfillPartnerShippingOptionsJob,
   repairShippingOptionStoreVisibilityJob,
   backfillOpenOrderRequiresShippingJob,
+  backfillProductShippingProfilesJob,
   normalizeArtisanProductsJob,
   linkArtisanDetailRowsJob,
   backfillFulfilledRetailRunsJob,

--- a/apps/backend/src/api/admin/ops/maintenance-jobs/registry.ts
+++ b/apps/backend/src/api/admin/ops/maintenance-jobs/registry.ts
@@ -91,6 +91,7 @@ import { backfillGoogleAdsHistoryJob } from "./backfill-google-ads-history-job"
 import { backfillDesignSizeSetsJob } from "./backfill-design-size-sets-job"
 import { backfillPartnerShippingOptionsJob } from "./backfill-partner-shipping-options-job"
 import { repairShippingOptionStoreVisibilityJob } from "./repair-shipping-option-store-visibility-job"
+import { backfillOpenOrderRequiresShippingJob } from "./backfill-open-order-requires-shipping-job"
 import { normalizeArtisanProductsJob } from "./normalize-artisan-products-job"
 import { linkArtisanDetailRowsJob } from "./link-artisan-detail-rows-job"
 import { backfillFulfilledRetailRunsJob } from "./backfill-fulfilled-retail-runs-job"
@@ -5589,6 +5590,7 @@ export const MAINTENANCE_JOBS: MaintenanceJob[] = [
   backfillDesignSizeSetsJob,
   backfillPartnerShippingOptionsJob,
   repairShippingOptionStoreVisibilityJob,
+  backfillOpenOrderRequiresShippingJob,
   normalizeArtisanProductsJob,
   linkArtisanDetailRowsJob,
   backfillFulfilledRetailRunsJob,

--- a/apps/backend/src/api/store/custom/designs/[id]/checkout/route.ts
+++ b/apps/backend/src/api/store/custom/designs/[id]/checkout/route.ts
@@ -107,6 +107,9 @@ export async function POST(
       title: designName,
       unit_price: convertedEstimate,
       is_custom_price: true,
+      // #1195: MUST stay false on the CART — `validateShippingStep` would
+      // otherwise block completion for these variant-less custom items. The
+      // flag is repaired at order.placed; see `src/lib/requires-shipping.ts`.
       requires_shipping: false,
       quantity: 1,
       metadata: {

--- a/apps/backend/src/lib/__tests__/requires-shipping.unit.spec.ts
+++ b/apps/backend/src/lib/__tests__/requires-shipping.unit.spec.ts
@@ -1,0 +1,81 @@
+import {
+  lineItemIdsNeedingShippingFlag,
+  resolveItemShippingProfileId,
+} from "../requires-shipping"
+
+/** A product that carries a shipping profile — the only kind safe to flip. */
+const profiled = { shipping_profile: { id: "sp_1" } }
+
+describe("lineItemIdsNeedingShippingFlag (#1195)", () => {
+  it("selects profiled items the derivation stamped false", () => {
+    expect(
+      lineItemIdsNeedingShippingFlag([
+        { id: "li_1", requires_shipping: false, product: profiled },
+        { id: "li_2", requires_shipping: false, product: profiled },
+      ])
+    ).toEqual(["li_1", "li_2"])
+  })
+
+  it("leaves correct items alone (idempotent re-run)", () => {
+    expect(
+      lineItemIdsNeedingShippingFlag([
+        { id: "li_1", requires_shipping: true, product: profiled },
+        { id: "li_2", requires_shipping: false, product: profiled },
+      ])
+    ).toEqual(["li_2"])
+  })
+
+  it("NEVER flips an item whose product has no shipping profile", () => {
+    // create-fulfillment.js:78-83 compares the product's profile against the
+    // chosen option's; with no profile that check can never pass, so the flag
+    // would make the item unfulfillable rather than shippable.
+    expect(
+      lineItemIdsNeedingShippingFlag([
+        { id: "li_1", requires_shipping: false, product: {} },
+        { id: "li_2", requires_shipping: false },
+        { id: "li_3", requires_shipping: false, product: { shipping_profile: null } },
+      ])
+    ).toEqual([])
+  })
+
+  it("only acts on an explicit false, never an absent flag", () => {
+    expect(
+      lineItemIdsNeedingShippingFlag([
+        { id: "li_1", product: profiled },
+        { id: "li_2", requires_shipping: null, product: profiled },
+        { id: "li_3", requires_shipping: undefined, product: profiled },
+      ])
+    ).toEqual([])
+  })
+
+  it("skips rows with no id", () => {
+    expect(
+      lineItemIdsNeedingShippingFlag([
+        { requires_shipping: false, product: profiled },
+      ])
+    ).toEqual([])
+  })
+
+  it("tolerates empty / missing input", () => {
+    expect(lineItemIdsNeedingShippingFlag([])).toEqual([])
+    expect(lineItemIdsNeedingShippingFlag(undefined)).toEqual([])
+  })
+})
+
+describe("resolveItemShippingProfileId (#1195)", () => {
+  it("reads the query.graph shape (item.product)", () => {
+    expect(resolveItemShippingProfileId({ product: profiled })).toBe("sp_1")
+  })
+
+  it("reads the module-retrieve shape (item.variant.product)", () => {
+    expect(
+      resolveItemShippingProfileId({ variant: { product: profiled } })
+    ).toBe("sp_1")
+  })
+
+  it("returns undefined when there is no profile", () => {
+    expect(resolveItemShippingProfileId({ product: {} })).toBeUndefined()
+    expect(resolveItemShippingProfileId({})).toBeUndefined()
+    expect(resolveItemShippingProfileId(null)).toBeUndefined()
+  })
+})

--- a/apps/backend/src/lib/requires-shipping.ts
+++ b/apps/backend/src/lib/requires-shipping.ts
@@ -1,0 +1,69 @@
+/**
+ * #1195 — `requires_shipping` repair helpers.
+ *
+ * Medusa DERIVES a line item's `requires_shipping` from
+ * `hasShippingProfile || someInventoryRequiresShipping`
+ * (core-flows `prepare-line-item-data.js`), and `create-fulfillment` copies the
+ * item flag onto the fulfillment. Most of our catalogue has no shipping profile
+ * and sells `manage_inventory: false` variants, so both operands are false and
+ * the dashboard then hides "Mark as shipped" on that flag alone.
+ *
+ * TWO INTERLOCKS make `requires_shipping: true` load-bearing rather than
+ * cosmetic — both of them throw, and both were found the hard way:
+ *
+ *  1. CART. `completeCartWorkflow` runs `validateShippingStep`: an item that
+ *     requires shipping needs a selected shipping method whose profile matches
+ *     `item.variant.product.shipping_profile.id`. Our design line items are
+ *     custom-priced with NO variant, so a `true` on the cart makes checkout
+ *     unsatisfiable. This is why the two `requires_shipping: false` lines in
+ *     `create-draft-order-from-designs.ts` and the design checkout route MUST
+ *     stay false — repair happens at the order boundary instead.
+ *
+ *  2. FULFILLMENT. `create-fulfillment.js:78-83` throws
+ *     "Shipping profile X does not match the shipping profile of the order
+ *     item Y" when a requires-shipping item's product profile differs from the
+ *     chosen option's. For a product with NO profile that comparison is
+ *     `undefined !== sp_...` — always true — so flipping the flag on a
+ *     profile-less product does not reveal the shipment action, it makes the
+ *     order UNFULFILLABLE.
+ *
+ * Hence the rule below: only ever flip a line item whose product actually
+ * carries a shipping profile. That is exactly the draft-order defect (profile
+ * present, derivation still says false). Profile-less products are fixed by
+ * giving them a profile — see the `backfill-product-shipping-profiles` DP job
+ * — not by flipping the flag.
+ *
+ * Repairing a FULFILLMENT's own flag is unconditional and safe: nothing
+ * re-validates it after creation, and it is the value the dashboard gates on.
+ */
+
+/**
+ * PURE: the ids of order line items whose `requires_shipping` can safely be
+ * repaired to `true`. Requires BOTH an explicit `false` (an absent flag is left
+ * alone rather than guessed at) AND a product shipping profile, without which
+ * the flag would make the item unfulfillable. Exported for unit testing.
+ */
+export function lineItemIdsNeedingShippingFlag(items: any[] | undefined): string[] {
+  return (items ?? [])
+    .filter(
+      (item: any) =>
+        item?.id &&
+        item?.requires_shipping === false &&
+        !!resolveItemShippingProfileId(item)
+    )
+    .map((item: any) => item.id as string)
+}
+
+/**
+ * PURE: the shipping profile id behind a line item, whichever shape the caller
+ * queried it in (`product.shipping_profile.id` from query.graph on the order,
+ * or `variant.product.shipping_profile.id` from a module retrieve).
+ * Exported for unit testing.
+ */
+export function resolveItemShippingProfileId(item: any): string | undefined {
+  return (
+    item?.product?.shipping_profile?.id ??
+    item?.variant?.product?.shipping_profile?.id ??
+    undefined
+  )
+}

--- a/apps/backend/src/subscribers/order-placed.ts
+++ b/apps/backend/src/subscribers/order-placed.ts
@@ -9,6 +9,7 @@ import {
   hasProductionRunForLineItem,
   resolveLineItemDesignId,
 } from "../lib/resolve-line-item-production"
+import { lineItemIdsNeedingShippingFlag } from "../lib/requires-shipping"
 
 export default async function orderPlacedHandler({
   event: { data },
@@ -55,6 +56,48 @@ export default async function orderPlacedHandler({
     const items: any[] = order?.items || []
     if (!items.length) {
       return
+    }
+
+    // #1195: repair the derived `requires_shipping` before anything fulfils
+    // this order — but ONLY for items whose product carries a shipping
+    // profile. That is the draft-order defect: `createOrderWorkflow` loses the
+    // profile between its query step and `prepareLineItemData`, so an item that
+    // should derive `true` comes out `false` and the dashboard hides "Mark as
+    // shipped".
+    //
+    // A profile-less product is deliberately NOT touched: `create-fulfillment`
+    // rejects a requires-shipping item whose product profile doesn't match the
+    // chosen option, so flipping it there would make the order unfulfillable
+    // rather than shippable. Those are fixed by giving the product a profile
+    // (see the backfill-product-shipping-profiles DP job).
+    //
+    // Non-fatal, like the email steps above.
+    try {
+      const { data: graphed } = await query.graph({
+        entity: "order",
+        fields: [
+          "id",
+          "items.id",
+          "items.requires_shipping",
+          "items.product.shipping_profile.id",
+        ],
+        filters: { id: data.id },
+      })
+      const needsFlag = lineItemIdsNeedingShippingFlag(graphed?.[0]?.items)
+      for (const lineItemId of needsFlag) {
+        await orderService.updateOrderLineItems(lineItemId, {
+          requires_shipping: true,
+        })
+      }
+      if (needsFlag.length) {
+        logger.info(
+          `[order.placed] Repaired requires_shipping on ${needsFlag.length} line item(s) of order ${data.id} (#1195)`
+        )
+      }
+    } catch (e: any) {
+      logger.warn(
+        `[order.placed] requires_shipping repair failed for order ${data.id}: ${e?.message || e}`
+      )
     }
 
     for (const item of items) {

--- a/apps/backend/src/workflows/designs/create-draft-order-from-designs.ts
+++ b/apps/backend/src/workflows/designs/create-draft-order-from-designs.ts
@@ -303,6 +303,12 @@ const createDesignCartStep = createStep(
         title: est.name,
         unit_price: est.unit_price,
         is_custom_price: true,
+        // #1195: MUST stay false on the CART. `completeCartWorkflow` runs
+        // `validateShippingStep`, which demands a shipping method whose
+        // profile matches `item.variant.product.shipping_profile.id` — these
+        // items are custom-priced with no variant, so a `true` here makes
+        // checkout unsatisfiable. The flag is repaired at order.placed
+        // instead; see `src/lib/requires-shipping.ts`.
         requires_shipping: false,
         quantity: 1,
         metadata: {

--- a/apps/backend/src/workflows/orders/__tests__/build-attach-awb-labels.unit.spec.ts
+++ b/apps/backend/src/workflows/orders/__tests__/build-attach-awb-labels.unit.spec.ts
@@ -1,0 +1,49 @@
+import { buildAttachAwbLabels } from "../shiprocket-attach-awb"
+
+const label = {
+  tracking_number: "AWB123",
+  tracking_url: "https://shiprocket.co/tracking/AWB123",
+  label_url: "",
+}
+
+describe("buildAttachAwbLabels (#1195)", () => {
+  it("adds the AWB label when the fulfillment has none", () => {
+    expect(buildAttachAwbLabels([], label)).toEqual([label])
+    expect(buildAttachAwbLabels(undefined, label)).toEqual([label])
+  })
+
+  it("carries existing labels through by id so the replace doesn't delete them", () => {
+    expect(
+      buildAttachAwbLabels(
+        [{ id: "fulab_1", tracking_number: "OTHER" }],
+        label
+      )
+    ).toEqual([{ id: "fulab_1" }, label])
+  })
+
+  it("is idempotent — re-attaching the same AWB adds nothing", () => {
+    expect(
+      buildAttachAwbLabels(
+        [{ id: "fulab_1", tracking_number: "AWB123" }],
+        label
+      )
+    ).toEqual([{ id: "fulab_1" }])
+  })
+
+  it("never returns an empty array when labels exist (that would wipe them)", () => {
+    const result = buildAttachAwbLabels(
+      [
+        { id: "fulab_1", tracking_number: "AWB123" },
+        { id: "fulab_2", tracking_number: "OTHER" },
+      ],
+      label
+    )
+    expect(result).toHaveLength(2)
+  })
+
+  it("skips malformed existing rows with no id", () => {
+    expect(
+      buildAttachAwbLabels([{ tracking_number: "OTHER" }], label)
+    ).toEqual([label])
+  })
+})

--- a/apps/backend/src/workflows/orders/shiprocket-attach-awb.ts
+++ b/apps/backend/src/workflows/orders/shiprocket-attach-awb.ts
@@ -54,6 +54,39 @@ export function deriveFulfillmentState(
   return "pending"
 }
 
+/**
+ * PURE: the full `labels` array to write so this AWB is discoverable by the
+ * Shiprocket webhook.
+ *
+ * #1195 — the webhook has exactly ONE way to find a core fulfillment from an
+ * AWB: `query.graph({ entity: "fulfillment", filters: { labels: {
+ * tracking_number } } })` in `sync-order-shipment-tracking.ts` (`data.waybill`
+ * is JSONB and cannot be filtered). Attaching an AWB without a label row left
+ * the fulfillment permanently invisible to every later status push.
+ *
+ * ALWAYS returns the complete desired set, never a delta: `updateFulfillment`
+ * treats `labels` as a full replace, so existing rows must be carried through
+ * by id or the ORM deletes them. (This is also why
+ * `createOrderShipmentWorkflow`'s default `labels: []` is dangerous — it wipes
+ * the collection. The caller passes this array to it instead.)
+ *
+ * Idempotent: re-attaching the same AWB yields the same set, adding nothing.
+ * Exported for unit testing.
+ */
+export function buildAttachAwbLabels(
+  existingLabels: any[] | undefined,
+  label: { tracking_number: string; tracking_url: string; label_url: string }
+): Array<{ id: string } | typeof label> {
+  const existing = existingLabels ?? []
+  const carried = existing
+    .filter((l: any) => !!l?.id)
+    .map((l: any) => ({ id: l.id as string }))
+  if (existing.some((l: any) => l?.tracking_number === label.tracking_number)) {
+    return carried
+  }
+  return [...carried, label]
+}
+
 export async function attachExistingShiprocketAwb(
   container: MedusaContainer,
   input: { orderId: string; fulfillmentId: string; awb: string }
@@ -76,6 +109,10 @@ export async function attachExistingShiprocketAwb(
       "items.detail.quantity",
       "fulfillments.id",
       "fulfillments.data",
+      // Needed to merge rather than clobber — `updateFulfillment` replaces the
+      // whole `labels` collection.
+      "fulfillments.labels.id",
+      "fulfillments.labels.tracking_number",
     ],
     filters: { id: input.orderId },
   })
@@ -129,13 +166,25 @@ export async function attachExistingShiprocketAwb(
 
   const refs = tracking.raw?.shipment_track?.[0] || {}
   const shipmentId = refs.shipment_id ?? refs.id
+  const trackingUrl = `https://shiprocket.co/tracking/${awb}`
+
+  // #1195: the label row the Shiprocket webhook matches on. Written in exactly
+  // ONE place below — `createOrderShipmentWorkflow` sends `labels: []` through
+  // to `updateFulfillment`, which replaces the collection, so writing it here
+  // and shipping afterwards would silently delete it again.
+  const labels = buildAttachAwbLabels(fulfillment.labels, {
+    tracking_number: awb,
+    tracking_url: trackingUrl,
+    label_url: "",
+  })
+
   await fulfillmentModule.updateFulfillment(input.fulfillmentId, {
     data: {
       ...(fulfillment.data || {}),
       carrier: "shiprocket",
       waybill: awb,
       tracking_number: awb,
-      tracking_url: `https://shiprocket.co/tracking/${awb}`,
+      tracking_url: trackingUrl,
       current_status: tracking.current_status,
       shipment_id: shipmentId,
       sr_order_id: refs.sr_order_id,
@@ -158,6 +207,7 @@ export async function attachExistingShiprocketAwb(
   // Auto-sync the order's fulfillment status to reality. createOrderShipment
   // marks the fulfillment shipped; markDelivered then closes it out. Both are
   // best-effort — a benign "already in that state" must not fail the attach.
+  let labelsWritten = false
   if (state === "shipped" || state === "delivered") {
     const items = (order.items || []).map((i: any) => ({
       id: i.id,
@@ -169,13 +219,30 @@ export async function attachExistingShiprocketAwb(
           order_id: input.orderId,
           fulfillment_id: input.fulfillmentId,
           items,
-          labels: [],
+          // NOT `[]` — that is a full replace and would drop the AWB label.
+          labels: labels as any,
           no_notification: true,
         },
       })
+      labelsWritten = true
     } catch (e: any) {
       logger.warn(
         `[attach-awb] mark-shipped skipped for fulfillment ${input.fulfillmentId}: ${e?.message}`
+      )
+    }
+  }
+
+  // Pending parcels never reach the shipment workflow, and a skipped/failed
+  // one must not cost us the label either — the webhook is how such a parcel
+  // eventually moves.
+  if (!labelsWritten) {
+    try {
+      await fulfillmentModule.updateFulfillment(input.fulfillmentId, {
+        labels: labels as any,
+      })
+    } catch (e: any) {
+      logger.warn(
+        `[attach-awb] label write failed for fulfillment ${input.fulfillmentId}: ${e?.message}`
       )
     }
   }

--- a/apps/partner-ui/src/dashboard-app/routes/get-partner-route.map.tsx
+++ b/apps/partner-ui/src/dashboard-app/routes/get-partner-route.map.tsx
@@ -627,7 +627,12 @@ export function getPartnerRouteMap(): RouteObject[] {
                         ),
                     },
                     {
-                      path: "shipment/:fulfillmentId",
+                      // #1195: mirrors the admin map. The screen reads `f_id`
+                      // (order-create-shipment.tsx:8) and the fulfillment
+                      // section navigates to `./<id>/create-shipment`, so the
+                      // old "shipment/:fulfillmentId" matched neither — the
+                      // route was unreachable.
+                      path: ":f_id/create-shipment",
                       lazy: () =>
                         import("../../routes/orders/order-create-shipment"),
                     },

--- a/apps/partner-ui/src/routes/orders/order-detail/components/order-fulfillment-section/order-fulfillment-section.tsx
+++ b/apps/partner-ui/src/routes/orders/order-detail/components/order-fulfillment-section/order-fulfillment-section.tsx
@@ -253,11 +253,10 @@ const Fulfillment = ({
     }
   )
 
-  let statusText = fulfillment.requires_shipping
-    ? isPickUpFulfillment
-      ? "Awaiting pickup"
-      : "Awaiting shipping"
-    : "Awaiting delivery"
+  // #1195: keyed off the fulfillment set type, not `requires_shipping` — the
+  // flag is false for most of the catalogue, which read "Awaiting delivery"
+  // next to a shipment action.
+  let statusText = isPickUpFulfillment ? "Awaiting pickup" : "Awaiting shipping"
   let statusColor: "blue" | "green" | "red" = "blue"
   let statusTimestamp = fulfillment.created_at
 
@@ -300,11 +299,19 @@ const Fulfillment = ({
   const isDelhivery = (fulfillment as any).data?.carrier === "delhivery"
   const hasWaybill = !!(fulfillment as any).data?.waybill
 
+  // #1195: `requires_shipping` is NOT a reliable gate. It is derived from
+  // `hasShippingProfile || someInventoryRequiresShipping`
+  // (core-flows prepare-line-item-data.js:23-29) and copied onto the
+  // fulfillment — so a product with no shipping profile whose variants are
+  // `manage_inventory: false` lands on `false` and hides the shipment action
+  // entirely. That's most of our catalogue. The only restriction the Medusa
+  // user guide actually documents is the pickup one, so that's the only one we
+  // gate on; every fulfillment we create goes out through the manual shipping
+  // side-channel regardless of the flag.
   const showShippingButton =
     !fulfillment.canceled_at &&
     !fulfillment.shipped_at &&
     !fulfillment.delivered_at &&
-    fulfillment.requires_shipping &&
     !isPickUpFulfillment
 
   const showDeliveryButton =
@@ -348,11 +355,12 @@ const Fulfillment = ({
   const { mutateAsync: attachShiprocketAwb, isPending: isAttachingAwb } =
     useAttachShiprocketAwb(order.id)
 
+  // Same #1195 reasoning as `showShippingButton` — the carrier actions were
+  // hidden by the same unreliable flag.
   const showShiprocketCarrierActions =
     !hasWaybill &&
     !fulfillment.canceled_at &&
     !fulfillment.delivered_at &&
-    fulfillment.requires_shipping &&
     !isPickUpFulfillment
 
   const handleGenerateShiprocketLabel = async () => {


### PR DESCRIPTION
Closes #1195.

## The bug

Post-fulfilment **"Mark as shipped" never renders** — in the partner UI *and* admin core. The cause is `fulfillment.requires_shipping === false`, an **undocumented term** in the dashboard gate. The Medusa user guide states one restriction (the option must not be a pickup option); that rule is not what fires.

`requires_shipping` is *derived*, never asked for: `hasShippingProfile || someInventoryRequiresShipping` (`prepare-line-item-data.js:23-29`), then copied onto the fulfillment by `create-fulfillment.js`. **Prod has 54/75 products with no shipping profile and variants at `manage_inventory: false`** — both operands false, so the action is hidden for most of the catalogue.

## The thing that shaped the fix

`requires_shipping: true` is **load-bearing, not cosmetic**. Two upstream checks throw on it, and a naive "flip it everywhere" makes things worse — the first attempt here turned four green tests red with `400 Shipping profile … does not match`:

1. **Cart** — `validateShippingStep` (inside `completeCartWorkflow`) demands a shipping method whose profile matches `item.variant.product.shipping_profile.id`. Design line items are custom-priced with **no variant**, so this is unsatisfiable. The two `requires_shipping: false` cart lines **must stay false**; they are now commented to that effect instead of looking like oversights.
2. **Fulfillment** — `create-fulfillment.js:78-83` rejects a requires-shipping item whose product profile differs from the chosen option's. For a profile-less product that comparison can never match, so flipping the flag makes the order **unfulfillable** rather than shippable.

So the flag is only ever flipped where it survives both: **items whose product has a shipping profile**. Fulfillment-level flips are unconditional — nothing re-validates those after creation.

## What's in here

**Item 1 — UI gate** (`order-fulfillment-section.tsx`)
`showShippingButton` and `showShiprocketCarrierActions` now gate on the pickup rule alone. The flag is *dropped*, not OR-ed as originally planned: `requires_shipping || !isPickUpFulfillment` would surface a shipment action on pickup fulfillments, regressing the one rule Medusa actually documents. The status label is keyed off the fulfillment set type too — it read "Awaiting delivery" next to a shipment action.

**Item 2 — partner shipment route**
`shipment/:fulfillmentId` → `:f_id/create-shipment`, mirroring the admin map. Both the param name *and* the path shape were wrong (the screen reads `f_id`, the section navigates to `./<id>/create-shipment`), so the route was unreachable from either direction.

**Item 3 — forward fix at the order boundary**
`order.placed` repairs items whose product has a profile — exactly the draft-order defect (profile present, derivation still says false). Guarded and non-fatal, like the sibling email steps.

**Item 4 — `backfill-product-shipping-profiles` (new DP job)**
The root repair: a product with a profile derives `true` on its own and satisfies every downstream check. Refuses to guess when the default profile is ambiguous rather than scattering products across profiles.

**Item 5 — attach-AWB writes its `labels` row**
`sync-order-shipment-tracking` can only find a fulfillment via `filters: { labels: { tracking_number } }` (`data.waybill` is JSONB and unfilterable), so an attached parcel was **permanently invisible to every later Shiprocket status push**. The label is written exactly once: `createOrderShipmentWorkflow`'s default `labels: []` is a *destructive replace*, so write-then-ship would have silently undone it. An integration test pins that ORM behaviour rather than trusting it.

**`backfill-open-order-requires-shipping` (DP job)**
Repairs history. The admin core gate lives inside the shipped `@medusajs/dashboard` bundle (`order-detail-*.mjs:1942`) and cannot be patched from source — fixing the **data** is the only lever there.

## Verification

- `requires-shipping-fulfillment-gate.spec.ts` **8/8**; `shiprocket-attach-awb.spec.ts` **2/2**
- six adjacent order / fulfillment / webhook specs — **33/33**, no regression from the subscriber change
- full unit suite: 2474 pass; the same 5 suites / 6 tests fail on a clean stash (pre-existing, unrelated)
- `tsc --noEmit` 274 before and after; `check:prod-build` passes; `workflow-schemas.json` unchanged (no new workflows)

## Operator note

Run **`backfill-product-shipping-profiles` before `backfill-open-order-requires-shipping`** — otherwise the second job skips every line item by design (unprofiled items are deliberately left alone). Both are dry-run by default.

That ordering no longer lives only in prose: the open-order job counts what it skipped and says so in its summary, naming the cure — *"SKIPPED N line item(s) whose product has no shipping profile …; run backfill-product-shipping-profiles first, then re-run this job"*. It says it on an otherwise-clean run too, which is the case where a silent skip would be most misleading.

## Known-unknown

The underlying `createOrderWorkflow` defect — the shipping profile is lost between the query step and `prepareLineItemData`, most likely step-output serialisation dropping the nested link relation — **is not proven**. Everything here works around it. The KNOWN DEFECT spec asserts against the workflow directly, so if a Medusa upgrade fixes the derivation that test fails loudly; that failure is good news.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
