### PR TITLE
test(#1195): house the shipment-gate checks in e2e, admin fixture runs on CI

### DIFF
--- a/e2e/helpers/e2e-seed.ts
+++ b/e2e/helpers/e2e-seed.ts
@@ -254,6 +254,228 @@ async function seedDesignerInviteDesign(container: any): Promise<string> {
   return design.id
 }
 
+/**
+ * #1195 — an order in the exact shape that hid "Mark as shipped": a line item
+ * the derivation stamps `requires_shipping: false` (title-only, so no shipping
+ * profile and no inventory to vote true), fulfilled against a NON-pickup manual
+ * option. The pickup rule the Medusa user guide documents is therefore NOT what
+ * suppresses the action — the undocumented `requires_shipping` term is.
+ *
+ * Deliberately built with `orderModule.createOrders` + the fulfillment
+ * workflow, NOT `createOrderWorkflow` (no tax provider on a fresh CI DB) and
+ * NOT through a cart (which would emit `order.placed`, whose subscriber repairs
+ * profiled items — this fixture must stay broken for the specs to mean
+ * anything).
+ */
+export async function seedShipmentGateOrder(container: any): Promise<{
+  orderId: string
+  fulfillmentId: string
+}> {
+  const query = container.resolve(ContainerRegistrationKeys.QUERY)
+  const orderModule: any = container.resolve(Modules.ORDER)
+
+  const { data: regions } = await query.graph({
+    entity: "region",
+    fields: ["id", "currency_code", "countries.iso_2"],
+  })
+  const region = regions?.[0]
+  const { data: channels } = await query.graph({
+    entity: "sales_channel",
+    fields: ["id"],
+  })
+  const salesChannelId = channels?.[0]?.id
+  if (!region || !salesChannelId) {
+    throw new Error(
+      "E2E seed: no region/sales channel found. Run the demo seed first."
+    )
+  }
+
+  const created: any = await orderModule.createOrders({
+    status: "pending",
+    region_id: region.id,
+    currency_code: region.currency_code,
+    sales_channel_id: salesChannelId,
+    email: "e2e-gate@jyt.test",
+    shipping_address: {
+      first_name: "Gate",
+      last_name: "Check",
+      address_1: "1 Loom St",
+      city: "London",
+      postal_code: "EC1A 1BB",
+      country_code: region.countries?.[0]?.iso_2 || "gb",
+      phone: "8887776665",
+    },
+    items: [
+      {
+        title: "Tangaliya Stole (#1195 gate)",
+        quantity: 1,
+        unit_price: 1500,
+        // Explicit, so the fixture cannot drift if the derivation is fixed
+        // upstream — the spec's whole point is this value being false.
+        requires_shipping: false,
+      },
+    ],
+    metadata: { source: "e2e-shipment-gate" },
+  })
+  const order = Array.isArray(created) ? created[0] : created
+
+  const { data: withItems } = await query.graph({
+    entity: "order",
+    fields: ["id", "items.id"],
+    filters: { id: order.id },
+  })
+  const itemId = withItems?.[0]?.items?.[0]?.id
+  if (!itemId) throw new Error("E2E seed: gate order line item not created")
+
+  const { data: opts } = await query.graph({
+    entity: "shipping_option",
+    fields: [
+      "id",
+      "provider_id",
+      "service_zone.fulfillment_set.type",
+      "service_zone.fulfillment_set.location.id",
+    ],
+  })
+  const manual = (opts || []).find(
+    (o: any) =>
+      typeof o?.provider_id === "string" &&
+      o.provider_id.startsWith("manual") &&
+      o.service_zone?.fulfillment_set?.location?.id &&
+      o.service_zone?.fulfillment_set?.type !== "pickup"
+  )
+  if (!manual) {
+    throw new Error(
+      "E2E seed: no manual NON-pickup shipping option found. Run the demo seed first."
+    )
+  }
+
+  await createOrderFulfillmentWorkflow(container).run({
+    input: {
+      order_id: order.id,
+      items: [{ id: itemId, quantity: 1 }],
+      shipping_option_id: manual.id,
+      location_id: manual.service_zone?.fulfillment_set?.location?.id,
+      no_notification: true,
+    } as any,
+  })
+
+  const { data: refetched } = await query.graph({
+    entity: "order",
+    fields: ["fulfillments.id", "fulfillments.requires_shipping"],
+    filters: { id: order.id },
+  })
+  const fulfillment = refetched?.[0]?.fulfillments?.[0]
+  if (!fulfillment?.id) {
+    throw new Error("E2E seed: gate fulfillment not created")
+  }
+  if (fulfillment.requires_shipping !== false) {
+    // If this ever trips, upstream changed the derivation — the specs that use
+    // this fixture are asserting a bug that no longer exists. Fail loudly here
+    // rather than let them pass for the wrong reason.
+    throw new Error(
+      `E2E seed: gate fulfillment expected requires_shipping=false, got ${fulfillment.requires_shipping}`
+    )
+  }
+
+  return { orderId: order.id, fulfillmentId: fulfillment.id }
+}
+
+/**
+ * #1195 — a partner that can open the gate order in the partner-UI. Mirrors the
+ * admin identity seeding above (Scrypt-hashed emailpass identity), then links
+ * the store and the order.
+ *
+ * The store link is NOT optional: without one the partner order-detail route
+ * requests `/partners/stores/undefined/locations/<id>` and error-boundaries the
+ * whole page into a 400, so the fulfillment section never renders.
+ */
+export async function seedShipmentGatePartner(
+  container: any,
+  orderId: string
+): Promise<{ email: string; password: string; partnerId: string }> {
+  const query = container.resolve(ContainerRegistrationKeys.QUERY)
+  const authModule = container.resolve(Modules.AUTH)
+  const link: any = container.resolve(ContainerRegistrationKeys.LINK)
+  const partnerModule: any = container.resolve("partner")
+
+  const email = `e2e-partner-gate-${Date.now()}@jyt.test`
+  const partner = await partnerModule.createPartners({
+    name: "E2E Gate Partner",
+    handle: `e2e-gate-${Date.now()}`,
+    // Active + verified, else the app parks the session on /onboarding.
+    status: "active",
+    is_verified: true,
+  })
+  const partnerId = Array.isArray(partner) ? partner[0].id : partner.id
+
+  await partnerModule.createPartnerAdmins({
+    email,
+    first_name: "E2E",
+    last_name: "Partner",
+    role: "admin",
+    partner_id: partnerId,
+  })
+
+  const hashConfig = { logN: 15, r: 8, p: 1 }
+  const passwordHash = await Scrypt.kdf(SEED_PASSWORD, hashConfig)
+  const authIdentity: any = await authModule.createAuthIdentities({
+    provider_identities: [
+      {
+        provider: "emailpass",
+        entity_id: email,
+        provider_metadata: { password: passwordHash.toString("base64") },
+      },
+    ],
+    app_metadata: { partner_id: partnerId },
+  })
+  const authIdentityId = Array.isArray(authIdentity)
+    ? authIdentity[0].id
+    : authIdentity.id
+
+  // PARTNER_EMAIL_VERIFICATION: without a VERIFIED auth_verification row the
+  // login returns `{ verification_required: true }` with an actorless token,
+  // and the partner UI deliberately does not persist that token — so the seeded
+  // partner would appear to log in and then 401 on every request. Same row the
+  // `backfill-partner-email-verified` DP job writes.
+  const now = new Date()
+  await authModule.createAuthVerifications([
+    {
+      auth_identity_id: authIdentityId,
+      entity_id: email,
+      entity_type: "email",
+      code_provider: "emailpass",
+      requested_at: now,
+      verified_at: now,
+    },
+  ])
+
+  // A DEDICATED store, not the demo one: the partner↔store link is one store
+  // per partner (`defineLink(partner, { store, isList: true })`), so reusing an
+  // already-linked store throws "Cannot create multiple links between 'partner'
+  // and 'store'" the second time the seed runs.
+  const storeModule: any = container.resolve(Modules.STORE)
+  const createdStore: any = await storeModule.createStores({
+    name: `E2E Gate Store ${Date.now()}`,
+  })
+  const storeId = Array.isArray(createdStore)
+    ? createdStore[0].id
+    : createdStore.id
+
+  await link.create({
+    partner: { partner_id: partnerId },
+    store: { store_id: storeId },
+  })
+  await link.create({
+    partner: { partner_id: partnerId },
+    order: { order_id: orderId },
+  })
+
+  // Password returned explicitly rather than letting the spec reuse the admin
+  // `password` field — they happen to be the same constant today, and a spec
+  // that silently depends on that fails with "Invalid email or password".
+  return { email, password: SEED_PASSWORD, partnerId }
+}
+
 const SEED_PASSWORD = "e2etest123!"
 const SEED_FILE = path.resolve(__dirname, "../../apps/backend/.e2e-seed.json")
 
@@ -361,6 +583,12 @@ export default async function e2eSeed({ container }: ExecArgs) {
   logger.info("E2E seed: creating design with a full brief for the designer-invite flow (#1113)...")
   const inviteDesignId = await seedDesignerInviteDesign(container)
 
+  logger.info("E2E seed: creating the #1195 requires_shipping gate order...")
+  const gate = await seedShipmentGateOrder(container)
+
+  logger.info("E2E seed: creating the #1195 gate partner (partner-UI spec)...")
+  const gatePartner = await seedShipmentGatePartner(container, gate.orderId)
+
   const seedData = {
     email,
     password: SEED_PASSWORD,
@@ -369,6 +597,13 @@ export default async function e2eSeed({ container }: ExecArgs) {
     shipmentOrderId,
     provenanceProductId,
     inviteDesignId,
+    // #1195 gate fixture — consumed by order-shipment-gate.spec.ts (admin, CI)
+    // and partner-shipment-gate.spec.ts (@partnerui, local).
+    gateOrderId: gate.orderId,
+    gateFulfillmentId: gate.fulfillmentId,
+    gatePartnerEmail: gatePartner.email,
+    gatePartnerPassword: gatePartner.password,
+    gatePartnerId: gatePartner.partnerId,
   }
 
   fs.writeFileSync(SEED_FILE, JSON.stringify(seedData, null, 2))

--- a/e2e/specs/order-shipment-gate.spec.ts
+++ b/e2e/specs/order-shipment-gate.spec.ts
@@ -1,0 +1,129 @@
+import { test, expect } from "@playwright/test"
+import * as fs from "fs"
+import * as path from "path"
+
+/**
+ * #1195 — the admin half of the "Mark as shipped" gate.
+ *
+ * The admin dashboard gate lives inside the SHIPPED `@medusajs/dashboard`
+ * bundle (`order-detail-*.mjs`), so unlike the partner UI we cannot patch it:
+ *
+ *   !canceled_at && !shipped_at && !delivered_at
+ *   && fulfillment.requires_shipping && !isPickUpFulfillment
+ *
+ * `requires_shipping` is derived (`hasShippingProfile ||
+ * someInventoryRequiresShipping`) and copied onto the fulfillment, so most of
+ * our catalogue lands on `false` and the action vanishes — with the pickup rule,
+ * the only restriction Medusa documents, never coming into play.
+ *
+ * Repairing the DATA is therefore the only lever in admin, which is what the
+ * `backfill-open-order-requires-shipping` maintenance job does. This spec pins
+ * the whole loop end-to-end in a real browser:
+ *
+ *   1. the seeded fixture (requires_shipping=false, NON-pickup) hides the action
+ *   2. the DP job repairs the fulfillment
+ *   3. the action appears, with nothing else about the order changed
+ *
+ * Step 1 asserts stock upstream behaviour. If a Medusa upgrade drops the
+ * undocumented term, this fails — and that failure is GOOD NEWS: it means the
+ * backfill is no longer needed.
+ */
+
+const SEED_FILE = path.resolve(__dirname, "../../apps/backend/.e2e-seed.json")
+
+type Seed = {
+  email: string
+  password: string
+  gateOrderId: string
+  gateFulfillmentId: string
+}
+
+const seed: Seed = JSON.parse(fs.readFileSync(SEED_FILE, "utf-8"))
+
+const MARK_AS_SHIPPED = /mark as shipped/i
+
+test.describe("#1195 requires_shipping gate — admin order detail", () => {
+  test.beforeEach(async ({ page }) => {
+    await page.goto("/app/login")
+    await page.locator('input[name="email"]').fill(seed.email)
+    await page.locator('input[name="password"]').fill(seed.password)
+    await page.locator('button[type="submit"]').click()
+    await page.waitForURL(/\/app(?!\/login)/, { timeout: 60_000 })
+  })
+
+  test("the DP backfill restores the hidden shipment action", async ({
+    page,
+    request,
+  }) => {
+    const orderUrl = `/app/orders/${seed.gateOrderId}`
+
+    const auth = await request.post("/auth/user/emailpass", {
+      data: { email: seed.email, password: seed.password },
+    })
+    expect(auth.ok()).toBeTruthy()
+    const token = (await auth.json()).token
+
+    // This spec REPAIRS its own fixture, so it only means anything on a fresh
+    // seed. CI re-seeds every run; locally, re-run `pnpm e2e:seed` first. Assert
+    // the precondition explicitly rather than failing later on a confusing
+    // "button already visible".
+    const precheck = await request.get(
+      `/admin/orders/${seed.gateOrderId}?fields=id,fulfillments.id,fulfillments.requires_shipping`,
+      { headers: { Authorization: `Bearer ${token}` } }
+    )
+    const seededFulfillment = (await precheck.json()).order.fulfillments.find(
+      (f: any) => f.id === seed.gateFulfillmentId
+    )
+    expect(
+      seededFulfillment?.requires_shipping,
+      "gate fixture already repaired — re-run `pnpm e2e:seed` (this spec mutates it)"
+    ).toBe(false)
+
+    // ── 1. broken: the fulfillment is there, the action is not ────────────
+    await page.goto(orderUrl)
+    await expect(page.getByText(/fulfilled/i).first()).toBeVisible()
+    await expect(
+      page.getByRole("button", { name: MARK_AS_SHIPPED })
+    ).toHaveCount(0)
+
+    // ── 2. repair, through the ops route an operator would use ────────────
+    const dry = await request.post(
+      "/admin/ops/maintenance-jobs/backfill-open-order-requires-shipping/run",
+      {
+        headers: { Authorization: `Bearer ${token}` },
+        data: { dry_run: true, params: { order_id: seed.gateOrderId } },
+      }
+    )
+    expect(dry.ok()).toBeTruthy()
+    const dryResult = (await dry.json()).result
+    expect(dryResult.applied).toBe(false)
+    expect(
+      dryResult.changes.some(
+        (c: any) =>
+          c.entity === "fulfillment" && c.id === seed.gateFulfillmentId
+      )
+    ).toBe(true)
+
+    // Dry-run must not have moved anything.
+    await page.reload()
+    await expect(
+      page.getByRole("button", { name: MARK_AS_SHIPPED })
+    ).toHaveCount(0)
+
+    const applied = await request.post(
+      "/admin/ops/maintenance-jobs/backfill-open-order-requires-shipping/run",
+      {
+        headers: { Authorization: `Bearer ${token}` },
+        data: { dry_run: false, params: { order_id: seed.gateOrderId } },
+      }
+    )
+    expect(applied.ok()).toBeTruthy()
+    expect((await applied.json()).result.applied).toBe(true)
+
+    // ── 3. fixed: the action the operator was missing ─────────────────────
+    await page.reload()
+    await expect(
+      page.getByRole("button", { name: MARK_AS_SHIPPED })
+    ).toBeVisible({ timeout: 30_000 })
+  })
+})

--- a/e2e/specs/partner-shipment-gate.spec.ts
+++ b/e2e/specs/partner-shipment-gate.spec.ts
@@ -1,0 +1,92 @@
+import { test, expect } from "@playwright/test"
+import * as fs from "fs"
+import * as path from "path"
+
+/**
+ * #1195 — the partner-UI half of the "Mark as shipped" gate.
+ *
+ * Unlike admin (see `order-shipment-gate.spec.ts`, which can only repair the
+ * DATA because its gate is inside the shipped `@medusajs/dashboard` bundle), the
+ * partner UI is ours: the fix removes `requires_shipping` from the gate
+ * entirely, leaving the pickup rule — the only restriction Medusa documents —
+ * as the sole condition.
+ *
+ * So this spec asserts the OPPOSITE of the admin one on the SAME fixture: an
+ * untouched `requires_shipping: false` fulfillment must still offer the action.
+ * It also walks the route the button navigates to, which was independently
+ * broken: the map had `shipment/:fulfillmentId` while the screen reads `f_id`
+ * and the section navigates to `./<id>/create-shipment`, so it resolved from
+ * neither direction.
+ *
+ * @partnerui — needs the partner-UI dev server on :5173, which the e2e config
+ * does not boot (it serves admin on :9000 only), so this is excluded on CI via
+ * `grepInvert`. Run locally with:
+ *   (cd apps/partner-ui && pnpm dev) &
+ *   pnpm --filter @jyt/backend e2e:test -- partner-shipment-gate
+ */
+
+const SEED_FILE = path.resolve(__dirname, "../../apps/backend/.e2e-seed.json")
+const PARTNER_UI = process.env.PARTNER_UI_URL || "http://localhost:5173"
+
+type Seed = {
+  gateOrderId: string
+  gateFulfillmentId: string
+  gatePartnerEmail: string
+  gatePartnerPassword: string
+}
+
+const seed: Seed = JSON.parse(fs.readFileSync(SEED_FILE, "utf-8"))
+
+const MARK_AS_SHIPPED = /mark as shipped/i
+
+test.describe("#1195 requires_shipping gate — partner UI @partnerui", () => {
+  test.beforeEach(async ({ page }) => {
+    // `networkidle` matters: the form's submit handler is attached on hydration,
+    // and a click that lands before it is silently swallowed — the page just
+    // sits on /login until the test times out.
+    await page.goto(`${PARTNER_UI}/login`, { waitUntil: "networkidle" })
+    await page.locator('input[name="email"]').fill(seed.gatePartnerEmail)
+    await page.locator('input[name="password"]').fill(seed.gatePartnerPassword)
+    await page.locator('button[type="submit"]').click()
+
+    // Wait on the PERSISTED TOKEN, not the URL. A `/\/(?!login)/` URL match
+    // resolves instantly against the "//" in "http://" and races past the
+    // login, producing 401s that look like an auth bug.
+    await page.waitForFunction(
+      () => !!localStorage.getItem("partner_ui_auth_token"),
+      // Under the 30s per-test budget, so a failed login reports as a login
+      // failure rather than eating the whole test timeout in beforeEach.
+      { timeout: 15_000 }
+    )
+  })
+
+  test("offers the shipment action on a requires_shipping=false fulfillment", async ({
+    page,
+  }) => {
+    await page.goto(`${PARTNER_UI}/orders/${seed.gateOrderId}`)
+
+    // The fulfillment section renders (a partner with no linked store 400s the
+    // whole route on `/partners/stores/undefined/locations/...` — the seed
+    // links one for exactly this reason).
+    await expect(page.getByText(/fulfillment/i).first()).toBeVisible({
+      timeout: 30_000,
+    })
+
+    // Status is keyed off the fulfillment set type now, not the flag — it used
+    // to read "Awaiting delivery" next to a shipment action.
+    await expect(page.getByText(/awaiting shipping/i).first()).toBeVisible()
+
+    // The fix itself: visible despite requires_shipping === false.
+    const button = page.getByRole("button", { name: MARK_AS_SHIPPED })
+    await expect(button.first()).toBeVisible()
+
+    // ...and the route it navigates to resolves (`:f_id/create-shipment`).
+    await button.first().click()
+    await expect(page).toHaveURL(
+      new RegExp(`${seed.gateFulfillmentId}/create-shipment`)
+    )
+    await expect(page.getByText(/shipment|tracking/i).first()).toBeVisible({
+      timeout: 30_000,
+    })
+  })
+})


### PR DESCRIPTION
Follow-up to #1196 (merged). The "Mark as shipped" gate was only ever verified by hand in a browser; this puts both halves in the Playwright suite so a regression is caught rather than rediscovered.

## Two specs that assert opposite things about the same fixture

That asymmetry is the whole point of the #1195 fix:

**`order-shipment-gate.spec.ts` — admin, runs on CI.** The admin gate lives inside the shipped `@medusajs/dashboard` bundle (`order-detail-*.mjs`) and cannot be patched from source, so the action stays hidden until the **data** is repaired. The spec drives the full operator loop in a real browser: action hidden → dry-run changes nothing → apply → action visible.

**`partner-shipment-gate.spec.ts` — partner UI, `@partnerui`, local only.** That gate is ours, so an untouched `requires_shipping: false` fulfillment must offer the action. It also clicks through to `:f_id/create-shipment` — the route that previously resolved from neither direction (map said `shipment/:fulfillmentId`, screen reads `f_id`, section navigates `./<id>/create-shipment`). Excluded on CI via the existing `grepInvert`, since the config only boots admin on :9000.

Step 1 of the admin spec asserts *stock upstream behaviour*. If a Medusa upgrade drops the undocumented `requires_shipping` term, it fails — and that failure is good news: the backfill is no longer needed.

## Seed fixture

Adds the bug-shape order (explicit `requires_shipping: false`, NON-pickup manual option) and a partner that can open it. Four things had to be right, and each one failed first:

- **The fixture must stay broken.** Built via `orderModule.createOrders`, not a cart, so `order.placed` doesn't repair it. A tripwire throws if it ever comes out `true` rather than letting the specs pass for the wrong reason.
- **The gate partner needs its own store.** `defineLink(partner, { store })` is one store per partner, so reusing the demo store throws `Cannot create multiple links between 'partner' and 'store'` on the second seed run.
- **It needs a verified `auth_verification` row.** Otherwise login returns `verification_required`, the partner UI deliberately declines to persist that token, and every request 401s — which reads as an auth bug.
- **Its password is returned explicitly** instead of reusing the admin `password` field. Same constant today; a silent "Invalid email or password" the day that changes.

## Two Playwright traps, documented in the specs

- `waitForURL(/\/(?!login)/)` matches the `//` in `http://` and races straight past login. Wait on the persisted token instead.
- Clicking submit before `networkidle` is silently swallowed — the handler attaches on hydration, so the page just sits on `/login` until timeout.

The admin spec repairs its own fixture, so it asserts that precondition up front with a "re-run `pnpm e2e:seed`" message rather than failing later on a confusing already-visible button. CI re-seeds every run, so this only bites locally.

## Verification

Full local Playwright run: **9 passed, 2 failed** — both failures are the pre-existing `theme-editor-chat` specs, which need a live LLM and a hardcoded #339 partner. Seed re-run twice to confirm it is repeatable.

## Note

The `e2e.yml` trigger paths cover `e2e/**` but not `apps/backend/src/api/**`, so a future change to the `backfill-open-order-requires-shipping` job won't re-run this spec. Worth widening separately if that matters.

🤖 Generated with [Claude Code](https://claude.com/claude-code)