### PR TITLE
fix(tests): the store-currency backfill spec raced the region.created subscriber [#1187]

### DIFF
--- a/apps/backend/integration-tests/http/partner-regions/backfill-store-currencies.spec.ts
+++ b/apps/backend/integration-tests/http/partner-regions/backfill-store-currencies.spec.ts
@@ -83,6 +83,32 @@ async function createPartnerWithStore(api: any, adminHeaders: Record<string, any
   }
 }
 
+/**
+ * Create a region the way the platform looked BEFORE the 0B auto-expand
+ * subscriber landed — i.e. the legacy state this whole spec exists to
+ * verify the backfill repairs.
+ *
+ * Deliberately NOT `POST /admin/regions`: that goes through core-flows'
+ * `createRegionsWorkflow`, which emits `region.created`, which
+ * `src/subscribers/region-propagate.ts` handles *asynchronously* by
+ * adding the region's currency to every partner store. That subscriber
+ * write lands at an unpredictable moment and silently repairs the very
+ * legacy state we're trying to construct — turning the dry-run
+ * assertions into a coin flip (see the shard-4 failure on 30990456155,
+ * where `zar` appeared after a dry run that wrote nothing).
+ *
+ * The module service performs no workflow and emits no event, so the
+ * state we build is the state the backfill sees. Subscriber behaviour
+ * itself is covered by region-propagate-subscriber.spec.ts.
+ */
+async function createLegacyRegion(
+  container: any,
+  opts: { name: string; currency_code: string; countries: string[] }
+) {
+  const regionService = container.resolve(Modules.REGION) as any
+  return await regionService.createRegions(opts)
+}
+
 async function readSupportedCurrencies(container: any, storeId: string) {
   const query = container.resolve(ContainerRegistrationKeys.QUERY)
   const { data: stores } = await query.graph({
@@ -116,15 +142,16 @@ setupSharedTestSuite(() => {
 
       // Simulate the legacy state: partner created an Africa/zar region
       // BEFORE the auto-expand code landed. We model that by creating
-      // a region via admin (skipping the partner auto-expand path),
-      // linking it to the partner, then forcing the store back to
-      // single-currency to mimic "this currency was never added".
-      const adminRegionRes = await api.post(
-        "/admin/regions",
-        { name: "Africa", currency_code: "zar", countries: ["za"] },
-        adminHeaders
-      )
-      const zarRegionId = adminRegionRes.data.region.id
+      // the region straight through the module service (no workflow, so
+      // no region.created subscriber), linking it to the partner, then
+      // forcing the store back to single-currency to mimic "this
+      // currency was never added".
+      const zarRegion = await createLegacyRegion(container, {
+        name: "Africa",
+        currency_code: "zar",
+        countries: ["za"],
+      })
+      const zarRegionId = zarRegion.id
       await remoteLink.create({
         partner: { partner_id: a.partnerId },
         [Modules.REGION]: { region_id: zarRegionId },
@@ -171,14 +198,14 @@ setupSharedTestSuite(() => {
       const storeService = container.resolve(Modules.STORE) as any
 
       // Same legacy-state setup as scenario 1.
-      const adminRegionRes = await api.post(
-        "/admin/regions",
-        { name: "Africa", currency_code: "zar", countries: ["za"] },
-        adminHeaders
-      )
+      const zarRegion = await createLegacyRegion(container, {
+        name: "Africa",
+        currency_code: "zar",
+        countries: ["za"],
+      })
       await remoteLink.create({
         partner: { partner_id: a.partnerId },
-        [Modules.REGION]: { region_id: adminRegionRes.data.region.id },
+        [Modules.REGION]: { region_id: zarRegion.id },
       })
       await storeService.updateStores({
         id: a.storeId,
@@ -204,14 +231,14 @@ setupSharedTestSuite(() => {
       const remoteLink = container.resolve(ContainerRegistrationKeys.LINK) as any
       const storeService = container.resolve(Modules.STORE) as any
 
-      const adminRegionRes = await api.post(
-        "/admin/regions",
-        { name: "Africa", currency_code: "zar", countries: ["za"] },
-        adminHeaders
-      )
+      const zarRegion = await createLegacyRegion(container, {
+        name: "Africa",
+        currency_code: "zar",
+        countries: ["za"],
+      })
       await remoteLink.create({
         partner: { partner_id: a.partnerId },
-        [Modules.REGION]: { region_id: adminRegionRes.data.region.id },
+        [Modules.REGION]: { region_id: zarRegion.id },
       })
       await storeService.updateStores({
         id: a.storeId,
@@ -237,14 +264,14 @@ setupSharedTestSuite(() => {
       const remoteLink = container.resolve(ContainerRegistrationKeys.LINK) as any
       const storeService = container.resolve(Modules.STORE) as any
 
-      const adminRegionRes = await api.post(
-        "/admin/regions",
-        { name: "Africa", currency_code: "zar", countries: ["za"] },
-        adminHeaders
-      )
+      const zarRegion = await createLegacyRegion(container, {
+        name: "Africa",
+        currency_code: "zar",
+        countries: ["za"],
+      })
       await remoteLink.create({
         partner: { partner_id: a.partnerId },
-        [Modules.REGION]: { region_id: adminRegionRes.data.region.id },
+        [Modules.REGION]: { region_id: zarRegion.id },
       })
       await storeService.updateStores({
         id: a.storeId,


### PR DESCRIPTION
Closes the last open loose thread from the shard migration: `backfill-store-currencies.spec.ts` failing Test-and-Release on shard 4.

## Root cause — not what we thought

The spec built its "legacy state" region with `POST /admin/regions`. That runs core-flows' `createRegionsWorkflow`, which emits `region.created` (`create-regions.js:88`). `src/subscribers/region-propagate.ts` handles that event **asynchronously and fire-and-forget**, adding the region's currency to *every* partner store via `updateStoresWorkflow`.

So the spec was racing a background writer against the exact state it was constructing. On shard 4 of run 30990456155 the subscriber's write landed between the `before` and `after` reads of the `DRY_RUN=1` test:

```
- Expected  - 0
+ Received  + 1
    "usd",
+   "zar",
```

The dry run wrote nothing. The subscriber added `zar`. The assertion blamed the dry run.

The failing test's own console output had the subscriber caught in the act:

```
[propagate-region] partner "CurTest 1785920242852fpmx" store store_01KZ8J8H...
  currency extend failed: ... at update-stores -> update-price-preferences-as-array
```

**The earlier diagnosis — shared state leaking a `zar` currency between tests — was wrong.** `medusaIntegrationTestRunner` restores the DB before *every* `test()`, so cross-test leakage is structurally impossible here. Sharding didn't introduce the bug; it just changed the timing enough to lose a race that was always there.

## Fix

Create the region through the region module service directly. It runs no workflow and emits no event, so no subscriber fires and the legacy state stays as written.

This is also what the spec's comments always *claimed* to be doing — "skipping the partner auto-expand path" was true when written and quietly became false when the 0B subscriber landed.

Subscriber behaviour keeps full coverage in `region-propagate-subscriber.spec.ts`, which already defends against this same race with its `waitForLink()` helper — that spec knew about the hazard, this one never got the treatment.

## Blast radius

Audited the other four specs that create admin regions *and* touch `supported_currencies` (`order-fulfillment-production-runs`, `tax-coverage-audit-and-cart`, `partner-api-parity/regions`, `design-currency-conversion`). All safe — each either creates regions via the module service, has no partner in scope at that moment, or never asserts on subscriber-mutated state. `partner-api-parity/regions` was the closest call: the subscriber does fire there, but its parity helpers compare key sets only, never values.

## Verification

```
partner-regions/region-propagate-subscriber.spec.ts   PASS
partner-regions/clone-and-refcount.spec.ts            PASS
partner-regions/backfill-link.spec.ts                 PASS
partner-regions/backfill-store-currencies.spec.ts     PASS
Test Suites: 4 passed  ·  Tests: 18 passed
```

The five specs in this file also drop from ~32s to ~0.5s each, now that they no longer boot the region workflow and its subscriber.

🤖 Generated with [Claude Code](https://claude.com/claude-code)