### PR TITLE
fix(partner-ui): storeless partner order detail blanked on any fulfillment with a location_id

### DIFF
--- a/apps/backend/integration-tests/http/orders-unification-partner-detail.spec.ts
+++ b/apps/backend/integration-tests/http/orders-unification-partner-detail.spec.ts
@@ -389,6 +389,37 @@ setupSharedTestSuite(() => {
       expect(linked(order.production_runs)).toBe(true)
     })
 
+    it("STORELESS partner is rejected by the store-scoped locations route", async () => {
+      // Pins the contract the partner-ui's `useStockLocation` guard depends on.
+      //
+      // A storeless partner has no store id to put in the path, so the hook
+      // must not fire at all. It used to: `enabled: !!storeId && ...` was
+      // written BEFORE a `...options` spread, so a caller passing
+      // `{ enabled: showLocation }` clobbered the guard and the request went
+      // out with the literal string "undefined" as the store id. The order
+      // detail page then rethrew the failure into its error boundary and went
+      // blank for every work order whose fulfillment carried a location_id.
+      //
+      // The route is right to refuse — this asserts it keeps refusing, so the
+      // frontend guard stays load-bearing rather than decorative.
+      const storeless = await createPartnerWithoutStore("nostore-loc")
+
+      const res = await api
+        .get(
+          "/partners/stores/undefined/locations/sloc_01TEST",
+          storeless.headers
+        )
+        .catch((e: any) => e.response)
+
+      // 400, not the 401 the throw asks for. `validatePartnerStoreAccess`
+      // raises `MedusaError.Types.UNAUTHORIZED`, which the framework maps to
+      // 401 — but this app's custom `errorHandler` (src/api/middlewares.ts)
+      // collapses every MedusaError that isn't `not_found` into 400. Asserting
+      // the status the API actually returns, not the one it intends. See #1202.
+      expect(res.status).toBe(400)
+      expect(res.data.message).toContain("not associated with this partner")
+    })
+
     it("partner CAN GET its own retail order detail (kind=retail, no links)", async () => {
       const retailId = await createRetailOrder(partnerA)
 

--- a/apps/partner-ui/src/hooks/api/stock-locations.tsx
+++ b/apps/partner-ui/src/hooks/api/stock-locations.tsx
@@ -42,8 +42,14 @@ export const useStockLocation = (
         { method: "GET" }
       ),
     queryKey: stockLocationsQueryKeys.detail(id, query),
-    enabled: !!storeId && (options?.enabled !== false),
     ...options,
+    // MUST come after the spread. A caller passing `{ enabled: true }`
+    // used to clobber the `!!storeId` guard, firing a request at the
+    // literal URL `/partners/stores/undefined/locations/:id` — which the
+    // backend answers 401 ("Store undefined is not associated with this
+    // partner"). Storeless partners are legitimate: work orders are owned
+    // through the partner↔order link and need no store (see PR #1158).
+    enabled: !!storeId && (options?.enabled !== false),
   })
 
   return { ...data, ...rest }
@@ -71,8 +77,9 @@ export const useStockLocations = (
         { method: "GET" }
       ),
     queryKey: stockLocationsQueryKeys.list(query),
-    enabled: !!storeId && (options?.enabled !== false),
     ...options,
+    // After the spread — same clobbering hazard as useStockLocation above.
+    enabled: !!storeId && (options?.enabled !== false),
   })
 
   return { ...data, ...rest }

--- a/apps/partner-ui/src/routes/orders/order-detail/components/order-fulfillment-section/order-fulfillment-section.tsx
+++ b/apps/partner-ui/src/routes/orders/order-detail/components/order-fulfillment-section/order-fulfillment-section.tsx
@@ -245,7 +245,7 @@ const Fulfillment = ({
     fulfillment.shipping_option?.service_zone.fulfillment_set.type ===
     FulfillmentSetType.Pickup
 
-  const { stock_location, isError, error } = useStockLocation(
+  const { stock_location, isError, error, isLoading } = useStockLocation(
     fulfillment.location_id!,
     undefined,
     {
@@ -471,8 +471,23 @@ const Fulfillment = ({
     }
   }
 
+  // Deliberately NOT `throw error`. This is a decorative lookup — it supplies
+  // one warehouse name on the fulfillment card — but rethrowing sent it to the
+  // error boundary and blanked the ENTIRE order detail page.
+  //
+  // It fails for real, reachable orders: a partner whose store exists but whose
+  // fulfillment shipped from a location other than `store.default_location_id`
+  // gets a 404 from `/partners/stores/:id/locations/:locationId`, which
+  // hard-requires that equality. Work orders fulfilled from JYT's own warehouse
+  // are exactly that case.
+  //
+  // `stock_location` is already optional and `showLocation` gates the row, so
+  // degrading costs one line of the card instead of the whole page.
   if (isError) {
-    throw error
+    console.warn(
+      `[order-fulfillment] stock location ${fulfillment.location_id} unavailable:`,
+      error
+    )
   }
 
   const isValidUrl = (url?: string) => url && url.length > 0 && url !== "#"
@@ -553,8 +568,15 @@ const Fulfillment = ({
                 {stock_location.name}
               </Text>
             </Link>
-          ) : (
+          ) : isLoading ? (
             <Skeleton className="w-16" />
+          ) : (
+            // Unresolvable (storeless partner, or a location that isn't the
+            // store's default). A skeleton here shimmers forever and reads as
+            // "still loading"; say plainly that we don't have the name.
+            <Text size="small" leading="compact" className="text-ui-fg-muted">
+              &mdash;
+            </Text>
           )}
         </div>
       )}


### PR DESCRIPTION
Second of the two loose threads carried since the shard migration (the first was #1200). Previously unfiled, described only as *"a partner with no linked store gets a hard 400 on any order detail whose fulfillment has a `location_id`"*.

The report was accurate, including the 400 — though not for the reason anyone assumed.

## Root cause

An options-precedence bug in `apps/partner-ui/src/hooks/api/stock-locations.tsx`:

```ts
enabled: !!storeId && (options?.enabled !== false),
...options,        // ← the caller's `enabled` overwrites the guard
```

`order-fulfillment-section.tsx` calls it with `{ enabled: !!fulfillment.location_id }`, which clobbered the `!!storeId` guard completely. With no store, `storeId` is `undefined` and the template interpolated it literally:

```
GET /partners/stores/undefined/locations/sloc_xxx
→ 400 {"message":"Store undefined is not associated with this partner"}
```

The page then did `if (isError) throw error`, sending it to the React error boundary — so **the entire order detail went blank**. That's the "hard" in the original report. Both `useStockLocation` and `useStockLocations` had the defect.

Storeless partners are legitimate: design/production partners own work orders purely through the `partner ↔ order` link and never provision a store — the same premise as PR #1158. Every manual side-channel fulfillment carries a `location_id`, so this fired on essentially all of their orders.

## Changes

1. **Compute `enabled` after the spread** in both hooks, so the storeId guard can't be overridden. The actual fix.
2. **Stop rethrowing** in `order-fulfillment-section`. This is a decorative lookup supplying one warehouse name; it shouldn't be able to kill the page. It *also* fails for partners who **do** have a store, whenever the fulfillment shipped from a location other than `store.default_location_id` — the route hard-requires that equality (`stores/[id]/locations/[locationId]/route.ts:18`), and work orders fulfilled from JYT's own warehouse are exactly that case. Probably the more commonly hit of the two.
3. **Em-dash instead of a Skeleton** when the name is unresolvable — the old fallback shimmered forever and read as "still loading".

## About that 400

`validatePartnerStoreAccess` raises `MedusaError.Types.UNAUTHORIZED`, which the framework maps to **401**. The wire response is **400**, because this app's custom `errorHandler` (`src/api/middlewares.ts` ~5944) collapses *every* MedusaError that isn't `not_found` into 400 — so 401/403/409/422/500 are all indistinguishable app-wide.

That is a much wider defect than this thread. **Filed as #1202, deliberately not changed here** — flipping it is a cross-cutting behaviour change that needs a client audit first, and the issue documents the hazard.

The new spec therefore asserts the status the API **actually returns** (400), with a comment pointing at #1202 so whoever fixes the handler gets a failing test naming the reason rather than a silent client break.

## What I did NOT change

The backend `store.default_location_id !== locationId` equality check. Relaxing it to "any location linked to the partner's sales channel" would widen authorization on a route with `POST`/`DELETE` handlers, which isn't mine to decide. Change 2 already stops it from blanking the page. Noted in #1202's neighbourhood if you want it pursued.

## Verification

```
integration-tests/http/orders-unification-partner-detail.spec.ts   8/8 passed
```
including the new `"STORELESS partner is rejected by the store-scoped locations route"`.

`partner-ui` typecheck unchanged at 4 pre-existing errors (verified identical with changes stashed); none in the touched files.

🤖 Generated with [Claude Code](https://claude.com/claude-code)