### PR TITLE
fix(api): map MedusaError types to real HTTP statuses instead of collapsing to 400 [#1202]

### DIFF
--- a/apps/backend/integration-tests/http/admin-partners-api.spec.ts
+++ b/apps/backend/integration-tests/http/admin-partners-api.spec.ts
@@ -67,7 +67,7 @@ setupSharedTestSuite(({ api, getContainer }) => {
       expect(res.data.partner_admin.email).toBe(payload.admin.email)
     })
 
-    test("POST /admin/partners with duplicate handle returns 400", async () => {
+    test("POST /admin/partners with duplicate handle returns 422", async () => {
       const unique = Date.now()
       const baseHandle = `acme-admin-dupe-${unique}`
       const first = {
@@ -106,7 +106,7 @@ setupSharedTestSuite(({ api, getContainer }) => {
         console.log("[TEST][UNEXPECTED] Second POST status:", resp.status)
         console.log("[TEST][UNEXPECTED] Second POST data:", JSON.stringify(resp.data))
         // If it gets here, fail explicitly
-        expect(resp.status).toBe(400)
+        expect(resp.status).toBe(422)
       } catch (err: any) {
         const res = err?.response || {}
         console.log("[TEST] Second POST error status:", res?.status)
@@ -114,7 +114,8 @@ setupSharedTestSuite(({ api, getContainer }) => {
         console.log("[TEST] Second POST error headers:", JSON.stringify(res?.headers))
         console.log("[TEST] Second POST request URL:", res?.config?.url)
         console.log("[TEST] Second POST request data:", JSON.stringify(res?.config?.data))
-        expect(res.status).toBe(400)
+        // 422 since #1202 — DUPLICATE_ERROR, not a validation failure.
+        expect(res.status).toBe(422)
         expect(res.data?.message).toBe(
           `A partner with handle "${baseHandle}" already exists. Please use a unique handle.`
         )

--- a/apps/backend/integration-tests/http/blocks-api.spec.ts
+++ b/apps/backend/integration-tests/http/blocks-api.spec.ts
@@ -356,7 +356,9 @@ setupSharedTestSuite(() => {
             )
             .catch((e) => e.response);
 
-          expect(response.status).toBe(400);
+          // 422 since #1202: DUPLICATE_ERROR. Was 400 only because the custom
+          // errorHandler collapsed every non-404 MedusaError into 400.
+          expect(response.status).toBe(422);
           expect(response.data.message).toContain("A block of type Hero already exists for this page");
         });
       });

--- a/apps/backend/integration-tests/http/investors-api.spec.ts
+++ b/apps/backend/integration-tests/http/investors-api.spec.ts
@@ -156,7 +156,8 @@ setupSharedTestSuite(() => {
         email: otherEmail,
         admin: { email: otherEmail },
       })
-      expect(dup.status).toBe(400)
+      // 422 since #1202 — DUPLICATE_ERROR, not a validation failure.
+      expect(dup.status).toBe(422)
     })
   })
 

--- a/apps/backend/integration-tests/http/orders-unification-partner-detail.spec.ts
+++ b/apps/backend/integration-tests/http/orders-unification-partner-detail.spec.ts
@@ -411,12 +411,11 @@ setupSharedTestSuite(() => {
         )
         .catch((e: any) => e.response)
 
-      // 400, not the 401 the throw asks for. `validatePartnerStoreAccess`
-      // raises `MedusaError.Types.UNAUTHORIZED`, which the framework maps to
-      // 401 — but this app's custom `errorHandler` (src/api/middlewares.ts)
-      // collapses every MedusaError that isn't `not_found` into 400. Asserting
-      // the status the API actually returns, not the one it intends. See #1202.
-      expect(res.status).toBe(400)
+      // 401 since #1202. `validatePartnerStoreAccess` raises
+      // `MedusaError.Types.UNAUTHORIZED`; the custom errorHandler used to
+      // collapse every non-`not_found` MedusaError into 400, so this asserted
+      // 400 when first written. It now maps types properly.
+      expect(res.status).toBe(401)
       expect(res.data.message).toContain("not associated with this partner")
     })
 

--- a/apps/backend/integration-tests/http/partner-shiprocket-routes.spec.ts
+++ b/apps/backend/integration-tests/http/partner-shiprocket-routes.spec.ts
@@ -141,7 +141,15 @@ setupSharedTestSuite(() => {
           {},
           { headers: intruder.headers }
         )
-      ).rejects.toMatchObject({ response: { status: 400 } })
+        // 401 since #1202 (was 400 via the collapsed error handler).
+        //
+        // ⚠️ This assertion passes for the WRONG REASON. `/partners/orders/:id/
+        // fulfillment-label` has NO matcher in src/api/middlewares.ts, so
+        // `authenticate` never runs, `auth_context` is always undefined, and the
+        // route refuses EVERY caller — the legitimate owner included. It has
+        // therefore never tested ownership. Tracked in #1204; once the matcher
+        // exists a genuine intruder should get 404, like the two routes above.
+      ).rejects.toMatchObject({ response: { status: 401 } })
     })
   })
 })

--- a/apps/backend/integration-tests/http/partner-store-products-api.spec.ts
+++ b/apps/backend/integration-tests/http/partner-store-products-api.spec.ts
@@ -551,7 +551,7 @@ setupSharedTestSuite(() => {
             validateStatus: () => true,
           }
         )
-        expect([400, 403]).toContain(res.status)
+        expect([401, 403]).toContain(res.status)
       })
     })
 

--- a/apps/backend/integration-tests/http/partner-stores-api.spec.ts
+++ b/apps/backend/integration-tests/http/partner-stores-api.spec.ts
@@ -121,7 +121,7 @@ setupSharedTestSuite(() => {
             headers: partner.headers,
             validateStatus: () => true,
           })
-        expect([400, 403]).toContain(res.status)
+        expect([401, 403]).toContain(res.status)
       })
     })
 

--- a/apps/backend/integration-tests/http/partners-api.spec.ts
+++ b/apps/backend/integration-tests/http/partners-api.spec.ts
@@ -82,7 +82,8 @@ setupSharedTestSuite(() => {
                     duplicate,
                     { headers: partnerHeaders }
                 ).catch((err) => err.response).then(res => {
-                    expect(res.status).toBe(400)
+                    // 422 since #1202 — DUPLICATE_ERROR, not a validation failure.
+                    expect(res.status).toBe(422)
                     expect(res.data.message).toBe("A partner with handle \"acme-2\" already exists. Please use a unique handle.")
                 })
             })

--- a/apps/backend/integration-tests/http/partners-products.spec.ts
+++ b/apps/backend/integration-tests/http/partners-products.spec.ts
@@ -301,9 +301,9 @@ setupSharedTestSuite(() => {
 
       // Cross-access should be unauthorized
       const cross1 = await api.get(`/partners/stores/${store2Id}/products`, { headers: partnerHeaders, validateStatus: () => true })
-      expect([400, 403]).toContain(cross1.status)
+      expect([401, 403]).toContain(cross1.status)
       const cross2 = await api.get(`/partners/stores/${storeId}/products`, { headers: partner2Headers, validateStatus: () => true })
-      expect([400, 403]).toContain(cross2.status)
+      expect([401, 403]).toContain(cross2.status)
     })
   })
 })

--- a/apps/backend/integration-tests/http/user-suspend-api.spec.ts
+++ b/apps/backend/integration-tests/http/user-suspend-api.spec.ts
@@ -100,7 +100,8 @@ setupSharedTestSuite(() => {
             })
           ).rejects.toMatchObject({
             response: {
-              status: 400,
+              // 401 since #1202 — the framework auth route throws UNAUTHORIZED.
+              status: 401,
               data: {
                 message: "Invalid email or password",
               },

--- a/apps/backend/integration-tests/http/user-unsuspend-api.spec.ts
+++ b/apps/backend/integration-tests/http/user-unsuspend-api.spec.ts
@@ -84,7 +84,8 @@ setupSharedTestSuite(() => {
             })
           ).rejects.toMatchObject({
             response: {
-              status: 400,
+              // 401 since #1202 — the framework auth route throws UNAUTHORIZED.
+              status: 401,
               data: {
                 message: "Invalid email or password",
               },

--- a/apps/backend/src/api/middlewares.ts
+++ b/apps/backend/src/api/middlewares.ts
@@ -41,6 +41,54 @@ import { resolveStorefrontUrl } from "./ucp/lib/context";
 // access .partial / .extend / etc. on the underlying ZodObject.
 const wrapSchema = <T extends z.ZodType>(schema: T) => schema as any;
 
+/**
+ * HTTP status for a MedusaError `type`, mirroring the framework's own handler
+ * (`@medusajs/framework/dist/http/middlewares/error-handler.js`).
+ *
+ * This map exists because the custom `errorHandler` at the bottom of this file
+ * has to re-implement the mapping: it returns a `{ message }`-only body that
+ * clients already depend on, so it cannot simply delegate to the framework
+ * handler (which returns `{ code, type, message }`).
+ *
+ * It previously had exactly two branches — `not_found` → 404, EVERYTHING else
+ * → 400 — which meant no partner or admin endpoint could ever answer 401, 403,
+ * 409, 422 or 500. An expired session was indistinguishable from a malformed
+ * body, so client interceptors that key off 401 were dead code, and database
+ * faults were reported as client errors and never tripped 5xx alerting (#1202).
+ *
+ * DELIBERATE DIVERGENCE — unmapped types keep today's 400 rather than the
+ * framework's 500. The unmapped set is `unexpected_state`, `invalid_argument`
+ * and `unknown_modules`, and there are ~157 throw sites across src (99 under
+ * api/ alone). The framework calls those server faults and 500s them; that is
+ * defensible, but flipping 157 endpoints to 5xx in the same change that fixes
+ * auth statuses would bury the real fix under an alerting flood, and some of
+ * those sites are genuinely client-caused. Keeping 400 makes this change
+ * strictly "wrong statuses become right", with nothing else moving.
+ *
+ * Re-classifying `unexpected_state` / `invalid_argument` is worth doing on its
+ * own, site by site, and is tracked separately — do NOT do it by changing this
+ * default.
+ *
+ * One more divergence: `payment_requires_more_error` → 422. The framework has
+ * no case for it and would 500; 422 is the semantically right answer and there
+ * are currently zero throw sites, so this is a no-op that avoids a future trap.
+ */
+const MEDUSA_ERROR_STATUS: Record<string, number> = {
+  not_found: 404,
+  invalid_data: 400,
+  not_allowed: 400,
+  unauthorized: 401,
+  forbidden: 403,
+  conflict: 409,
+  duplicate_error: 422,
+  payment_authorization_error: 422,
+  payment_requires_more_error: 422,
+  database_error: 500,
+};
+
+const medusaErrorStatus = (type: string | undefined): number =>
+  (type && MEDUSA_ERROR_STATUS[type]) || 400;
+
 const buildPersonResourceValidator =
   (type: "create" | "update") =>
     (req: MedusaRequest, res: MedusaResponse, next: MedusaNextFunction) => {
@@ -5942,15 +5990,9 @@ export default defineMiddlewares({
     // if (error.name === "ZodError") {
     // Option 2: check if error is an instance of ZodError
     if (error.__isMedusaError) {
-      if (error.type == 'not_found') {
-        return res.status(404).json({
-          message: error.message,
-        });
-      } else {
-        return res.status(400).json({
-          message: error.message,
-        });
-      }
+      return res.status(medusaErrorStatus(error.type)).json({
+        message: error.message,
+      });
     }
     if (error instanceof z.ZodError) {
       /*
@@ -5977,17 +6019,15 @@ export default defineMiddlewares({
       });
     }
 
-    // Handle custom errors
-    if (error.type === "not_found") {
-      return res.status(404).json({
+    // Non-MedusaError objects that still carry a Medusa-shaped `type` (ORM
+    // errors, module errors). Route them through the SAME map so a
+    // `duplicate_error` doesn't answer 422 when thrown as a MedusaError and
+    // 400 when thrown as a plain object — which is what the two hand-written
+    // branches here used to do.
+    if (typeof error.type === "string" && error.type in MEDUSA_ERROR_STATUS) {
+      return res.status(MEDUSA_ERROR_STATUS[error.type]).json({
         message: error.message,
       });
-    }
-
-    if (error.type === "duplicate_error") {
-      return res.status(400).json({
-        message: error.message,
-      })
     }
 
     // For everything else, fall back to the default error handler


### PR DESCRIPTION
Closes #1202.

## The bug

The custom `errorHandler` in `src/api/middlewares.ts` had two branches: `not_found` → 404, and **everything else** → 400.

So no endpoint in this app — admin or partner, 150+ of them — could answer 401, 403, 409, 422 or 500. Concretely:

| MedusaError | Framework | Before | After |
|---|---|---|---|
| `unauthorized` | 401 | 400 | **401** |
| `forbidden` | 403 | 400 | **403** |
| `conflict` | 409 | 400 | **409** |
| `duplicate_error` | 422 | 400 | **422** |
| `payment_authorization_error` | 422 | 400 | **422** |
| `database_error` | 500 | 400 | **500** |
| `not_allowed` / `invalid_data` | 400 | 400 | 400 |
| `not_found` | 404 | 404 | 404 |

An expired session was indistinguishable from a malformed body. Every client interceptor keyed on 401 was dead code. Database faults were reported as client errors and never tripped 5xx alerting.

## The fix

A type→status map mirroring the framework's own handler. The `{ message }`-only body is **unchanged** — only the status moves. Clients already depend on that shape, and this shouldn't also be a body change.

Also unified the two hand-written trailing branches (for non-`MedusaError` objects carrying a Medusa-shaped `type`) through the same map. They had drifted: `duplicate_error` answered 400 there and 422 above.

## The one judgment call

**Unmapped types keep 400 rather than the framework's 500.** That set is `unexpected_state`, `invalid_argument`, `unknown_modules` — **~157 throw sites**, 99 under `api/` alone. Flipping those to 5xx in the same commit that fixes auth statuses would bury the real fix under an alerting flood, and a good share are genuinely client-caused.

Re-classifying them is worth doing, but site by site — not via a default. The docstring says so explicitly so the next reader doesn't "helpfully" restore the fall-through.

## Spec updates — 12 assertions across 9 files

Each traced to the error type actually thrown, not pattern-matched:

- **`DUPLICATE_ERROR` → 422** — duplicate partner handle (admin + partner routes), duplicate investor handle, duplicate page block. One test's *title* also claimed 400; renamed.
- **`UNAUTHORIZED` → 401** — cross-partner store access, and **every failed login on every surface**: the framework auth route throws `UNAUTHORIZED`, so admin, partner, investor and customer logins all move.
- Three specs used tolerant `expect([400, 403])` arrays that looked safe on a grep but contained neither the old nor the new value.

Genuine `invalid_data` 400s were left alone — e.g. `partner-shiprocket-routes.spec.ts:126`, where the *owner* passes the ownership guard and then trips body validation. That one staying 400 is precisely what proves the guard admitted them.

## Verification

Ran **all 87 specs** that assert an affected status, in heap-safe batches of 8:

```
PARSED 87 spec files
11 batches — 10×8 + 7 = 87 suites executed   ← tripwire satisfied
Zero status mismatches
```

The only failures are three suites that fail **identically on clean `main`**: `ai-chat-workflow` (LLM output), `ai-imagegen-e2e` (external providers), `editor-files-integration` (enumerates a real S3 bucket — `2324` vs `2339` objects). Confirmed by re-running the two fast ones against a stashed tree and getting byte-identical failures.

The tripwire is not decoration: my first attempt at this sweep exited **0 having run nothing**, because macOS bash 3.2 has no `mapfile` and the file array came out empty — the same "green gate that proves nothing" as #1187.

## What this does NOT cover

No backend test can reach the frontend half. `partner-ui/src/routes/login/login.tsx:62` and the investor-ui equivalent will start attaching login failures to the email field instead of a root banner, because the 401 branch finally executes. That's an improvement, but it is a visible behaviour change — worth a staging look before this goes out.

## Found while auditing, filed not fixed

**#1204** — `POST /partners/orders/:id/fulfillment-label` has no matcher in `middlewares.ts`, so `authenticate` never runs and the route rejects **every** caller including the legitimate owner. Its ownership spec has therefore been passing for the wrong reason. Third instance of the #1187 "a route file is not a route" class.

🤖 Generated with [Claude Code](https://claude.com/claude-code)