### PR TITLE
fix(migrations): make the ad-planning FK idempotent so the prod migrate task can complete

### DIFF
--- a/apps/backend/src/modules/ad-planning/migrations/Migration20260730101243.ts
+++ b/apps/backend/src/modules/ad-planning/migrations/Migration20260730101243.ts
@@ -67,7 +67,37 @@ export class Migration20260730101243 extends Migration {
     this.addSql(`CREATE INDEX IF NOT EXISTS "idx_sentiment_time" ON "sentiment_analysis" ("analyzed_at") WHERE deleted_at IS NULL;`);
     this.addSql(`CREATE INDEX IF NOT EXISTS "idx_sentiment_person" ON "sentiment_analysis" ("person_id") WHERE deleted_at IS NULL;`);
 
-    this.addSql(`alter table if exists "segment_member" add constraint "segment_member_segment_id_foreign" foreign key ("segment_id") references "customer_segment" ("id") on update cascade;`);
+    // `alter table IF EXISTS ... ADD CONSTRAINT` guards the TABLE, not the
+    // CONSTRAINT, and Postgres has no ADD CONSTRAINT IF NOT EXISTS. Every other
+    // statement in this migration is re-runnable (`create table if not exists`,
+    // `CREATE INDEX IF NOT EXISTS`), so on a database where these tables already
+    // exist the whole thing no-ops until this line, which then errors with
+    // `constraint ... already exists` and fails the entire migrate run — taking
+    // every other module's pending migration down with it.
+    //
+    // That is exactly what wedged the prod deploy: the migrate job is gated and
+    // auto-skips when no schema paths change, so this sat undetected from
+    // 2026-07-30 until the first push that touched a schema path.
+    //
+    // Guard on the catalog instead, scoped to the table (conname is unique per
+    // relation, not globally).
+    this.addSql(`
+      DO $$
+      BEGIN
+        IF NOT EXISTS (
+          SELECT 1
+          FROM pg_constraint c
+          JOIN pg_class t ON t.oid = c.conrelid
+          WHERE c.conname = 'segment_member_segment_id_foreign'
+            AND t.relname = 'segment_member'
+        ) THEN
+          ALTER TABLE "segment_member"
+            ADD CONSTRAINT "segment_member_segment_id_foreign"
+            FOREIGN KEY ("segment_id") REFERENCES "customer_segment" ("id")
+            ON UPDATE CASCADE;
+        END IF;
+      END $$;
+    `);
   }
 
   override async down(): Promise<void> {


### PR DESCRIPTION
## The failure

The prod migrate task has been failing:

```
Migration20260730101243 (up) failed: Original error:
alter table if exists "segment_member" add constraint "segment_member_segment_id_foreign" ...
- constraint "segment_member_segment_id_foreign" for relation "segment_member" already exists
```

`alter table IF EXISTS ... ADD CONSTRAINT` guards the **table**, not the **constraint**, and Postgres has no `ADD CONSTRAINT IF NOT EXISTS`. Every other statement in that migration is deliberately re-runnable (`create table if not exists`, `CREATE INDEX IF NOT EXISTS`), so against a database where the tables already exist the whole migration no-ops until this final line — which then errors and fails the **entire** migrate run, taking every other module's pending migration with it.

## Why it went unnoticed for a week

The migrate job is gated: it auto-skips when a push touches no schema-affecting paths. Every deploy since 2026-07-30 skipped it and reported success. #1206 was the first push to touch a schema path, so it was the first to actually run migrations — and it inherited this. The fail-safe worked correctly: the deploy jobs skipped, so **prod stayed on the old image**.

## The fix

Guard on `pg_constraint`, scoped to the relation (`conname` is unique per table, not globally).

## Verification

Against a throwaway Postgres 16:

- the **original** statement, re-run against a DB that already has the constraint → `ERROR: constraint ... already exists` (exact reproduction of the prod failure);
- the **guarded** version → applies once, `fk_count = 1`; re-run → no error, still `fk_count = 1`.

## Follow-up, not in this PR

42 migrations across the repo share the same "looks idempotent but isn't" signature — `create table if not exists` alongside a bare `add constraint`. They're dormant while recorded as applied, and only bite when pending. I've deliberately not swept them: without visibility into which are pending in prod (the DB is VPC-locked) that would be a large blind change. Worth a tracked task.

🤖 Generated with [Claude Code](https://claude.com/claude-code)