### PR TITLE
fix(customs): scope HS-code routes through the sales-channel pivot, not a product filter

### DIFF
--- a/apps/backend/integration-tests/http/customs-hs-codes-api.spec.ts
+++ b/apps/backend/integration-tests/http/customs-hs-codes-api.spec.ts
@@ -1,0 +1,260 @@
+import { getSharedTestEnv, setupSharedTestSuite } from "./shared-test-setup"
+import { createAdminUser, getAuthHeaders } from "../helpers/create-admin-user"
+import { ProductStatus } from "@medusajs/framework/utils"
+
+/**
+ * Bulk HS/HSN customs codes — admin routes and their partner mirrors.
+ *
+ * These exist because the unit tests around `scanMissingHsCodes` /
+ * `partitionAssignmentsByStore` mock `query.graph`, and a mock accepts any
+ * filter you hand it. The partner routes shipped scoping products with
+ * `filters: { sales_channels: { id } }`, which mikro-orm rejects at runtime
+ * ("Trying to query by not existing property Product.sales_channels"), so BOTH
+ * partner routes 500'd on every call while the unit suite stayed green. Only a
+ * spec that runs the query against a real database can catch that class of bug,
+ * so the assertions below deliberately go through HTTP end to end.
+ */
+
+const TEST_PARTNER_PASSWORD = "supersecret"
+
+jest.setTimeout(120 * 1000)
+
+async function createPartnerWithStoreAndProduct(
+  api: any,
+  adminHeaders: Record<string, any>
+) {
+  const unique = Date.now() + Math.random().toString(36).slice(2, 6)
+  const email = `partner-hs-${unique}@medusa-test.com`
+
+  await api.post("/auth/partner/emailpass/register", {
+    email,
+    password: TEST_PARTNER_PASSWORD,
+  })
+  const login1 = await api.post("/auth/partner/emailpass", {
+    email,
+    password: TEST_PARTNER_PASSWORD,
+  })
+  let headers: Record<string, string> = {
+    Authorization: `Bearer ${login1.data.token}`,
+  }
+
+  await api.post(
+    "/partners",
+    {
+      name: `HSTest ${unique}`,
+      handle: `hstest-${unique}`,
+      admin: { email, first_name: "Admin", last_name: "HS" },
+    },
+    { headers }
+  )
+
+  const login2 = await api.post("/auth/partner/emailpass", {
+    email,
+    password: TEST_PARTNER_PASSWORD,
+  })
+  headers = { Authorization: `Bearer ${login2.data.token}` }
+
+  const currenciesRes = await api.get("/admin/currencies", adminHeaders)
+  const currencies = currenciesRes.data.currencies || []
+  const usd = currencies.find((c: any) => c.code?.toLowerCase() === "usd")
+  const currencyCode = String((usd || currencies[0]).code).toLowerCase()
+
+  const storeRes = await api.post(
+    "/partners/stores",
+    {
+      store: {
+        name: `HSStore ${unique}`,
+        supported_currencies: [{ currency_code: currencyCode, is_default: true }],
+      },
+      sales_channel: { name: `HSChannel ${unique}`, description: "Default" },
+      region: {
+        name: "Default Region",
+        currency_code: currencyCode,
+        countries: ["us"],
+      },
+      location: {
+        name: "Warehouse",
+        address: {
+          address_1: "1 Main St",
+          city: "NY",
+          postal_code: "10001",
+          country_code: "US",
+        },
+      },
+    },
+    { headers }
+  )
+
+  const storeId = storeRes.data.store.id
+
+  const productRes = await api.post(
+    "/partners/products",
+    {
+      store_id: storeId,
+      product: {
+        title: `Kala Cotton Shirt ${unique}`,
+        description: "Handwoven kala cotton shirt, men's woven.",
+        handle: `hs-prod-${unique}`,
+        status: ProductStatus.PUBLISHED,
+        options: [{ title: "Size", values: ["S", "M"] }],
+        variants: [
+          {
+            title: "Small",
+            sku: `HS-S-${unique}`,
+            options: { Size: "S" },
+            prices: [{ amount: 1000, currency_code: currencyCode }],
+          },
+        ],
+      },
+    },
+    { headers }
+  )
+
+  const product = productRes.data.product
+
+  return {
+    headers,
+    storeId,
+    productId: product?.id as string,
+    variantIds: ((product?.variants || []) as any[]).map((v) => v.id),
+  }
+}
+
+setupSharedTestSuite(() => {
+  const { api, getContainer } = getSharedTestEnv()
+
+  describe("Customs HS codes API", () => {
+    let adminHeaders: Record<string, any>
+    let partner: Awaited<ReturnType<typeof createPartnerWithStoreAndProduct>>
+
+    beforeEach(async () => {
+      const container = getContainer()
+      await createAdminUser(container)
+      adminHeaders = await getAuthHeaders(api)
+      partner = await createPartnerWithStoreAndProduct(api, adminHeaders)
+    })
+
+    it("GET /partners/stores/:id/customs/hs-codes/missing scopes to the store's channel", async () => {
+      const res = await api.get(
+        `/partners/stores/${partner.storeId}/customs/hs-codes/missing`,
+        { headers: partner.headers }
+      )
+
+      expect(res.status).toBe(200)
+      expect(res.data.scanned).toBeGreaterThan(0)
+
+      const gap = (res.data.gaps || []).find(
+        (g: any) => g.product_id === partner.productId
+      )
+      expect(gap).toBeDefined()
+      // The scan must carry enough context to classify the goods — a caller that
+      // only gets ids has nothing to declare a customs code from.
+      expect(gap.description).toContain("kala cotton")
+      expect(gap.suggested_target).toMatchObject({ id: expect.any(String) })
+
+      // Scoped means scoped: nothing outside this partner's channel may appear.
+      const foreign = (res.data.gaps || []).filter(
+        (g: any) => g.product_id !== partner.productId
+      )
+      expect(foreign).toHaveLength(0)
+    })
+
+    it("POST /partners/stores/:id/customs/hs-codes fills a gap the scan reported", async () => {
+      const scan = await api.get(
+        `/partners/stores/${partner.storeId}/customs/hs-codes/missing`,
+        { headers: partner.headers }
+      )
+      const target = (scan.data.gaps || []).find(
+        (g: any) => g.product_id === partner.productId
+      ).suggested_target
+
+      const apply = await api.post(
+        `/partners/stores/${partner.storeId}/customs/hs-codes`,
+        {
+          assignments: [
+            { level: target.level, id: target.id, hs_code: "62052000" },
+          ],
+        },
+        { headers: partner.headers }
+      )
+
+      expect(apply.status).toBe(200)
+      expect(apply.data.applied).toBe(1)
+      expect(apply.data.errors).toBe(0)
+
+      // A written code must make the item disappear from the scan — the two
+      // halves resolve through the same chain, so a level that "applies" but
+      // stays missing means the write landed somewhere a label can't read.
+      const rescan = await api.get(
+        `/partners/stores/${partner.storeId}/customs/hs-codes/missing`,
+        { headers: partner.headers }
+      )
+      expect(
+        (rescan.data.gaps || []).find((g: any) => g.product_id === partner.productId)
+      ).toBeUndefined()
+    })
+
+    it("rejects an id outside the store's catalogue without failing the batch", async () => {
+      const scan = await api.get(
+        `/partners/stores/${partner.storeId}/customs/hs-codes/missing`,
+        { headers: partner.headers }
+      )
+      const target = (scan.data.gaps || []).find(
+        (g: any) => g.product_id === partner.productId
+      ).suggested_target
+
+      const res = await api.post(
+        `/partners/stores/${partner.storeId}/customs/hs-codes`,
+        {
+          assignments: [
+            { level: target.level, id: target.id, hs_code: "62052000" },
+            { level: "product", id: "prod_not_mine", hs_code: "62052000" },
+          ],
+        },
+        { headers: partner.headers }
+      )
+
+      expect(res.status).toBe(200)
+      expect(res.data.applied).toBe(1)
+      expect(res.data.errors).toBe(1)
+      expect(
+        res.data.results.find((r: any) => r.id === "prod_not_mine").reason
+      ).toMatch(/not part of your store's catalogue/i)
+    })
+
+    it("GET /admin/customs/hs-codes/missing scans unscoped and paginates", async () => {
+      const res = await api.get(
+        "/admin/customs/hs-codes/missing?limit=5",
+        adminHeaders
+      )
+
+      expect(res.status).toBe(200)
+      expect(res.data.limit).toBe(5)
+      expect(Array.isArray(res.data.gaps)).toBe(true)
+    })
+
+    it("POST /admin/customs/hs-codes writes at the level it is told to", async () => {
+      const res = await api.post(
+        "/admin/customs/hs-codes",
+        {
+          assignments: [
+            {
+              level: "variant",
+              id: partner.variantIds[0],
+              hs_code: "62052000",
+              origin_country: "IN",
+            },
+            { level: "variant", id: "variant_nope", hs_code: "62052000" },
+          ],
+        },
+        adminHeaders
+      )
+
+      // Per-row outcomes, not an all-or-nothing status: a bad id in a big batch
+      // must not discard the good writes.
+      expect(res.status).toBe(200)
+      expect(res.data.applied).toBe(1)
+      expect(res.data.errors).toBe(1)
+    })
+  })
+})

--- a/apps/backend/src/workflows/customs/__tests__/apply-hs-codes.unit.spec.ts
+++ b/apps/backend/src/workflows/customs/__tests__/apply-hs-codes.unit.spec.ts
@@ -8,7 +8,11 @@ jest.mock("@medusajs/medusa/core-flows", () => ({
   updateProductsWorkflow: () => ({ run: updateProductsRun }),
 }))
 
-import { applyHsCodes, partitionAssignmentsByStore } from "../hs-codes"
+import {
+  applyHsCodes,
+  partitionAssignmentsByStore,
+  scanMissingHsCodes,
+} from "../hs-codes"
 
 /**
  * The bulk HS-code apply is deliberately NOT transactional: one bad id in a
@@ -129,22 +133,83 @@ describe("applyHsCodes", () => {
   })
 })
 
+/**
+ * Store scoping goes through the sales_channel → products_link pivot, NOT a
+ * `sales_channels` filter on product. The filter shape reads fine and passes a
+ * mocked query, but mikro-orm rejects it at runtime ("Trying to query by not
+ * existing property Product.sales_channels") and every partner-scoped call
+ * 500s. Since a mock can't reject it for us, these tests assert the query SHAPE
+ * — that's the only place the regression is visible from a unit test.
+ */
+const makeChannelQuery = (
+  products: any[],
+  linkedIds = products.map((p) => p.id)
+) => {
+  const graph = jest.fn(async ({ entity }: any) => {
+    if (entity === "sales_channel") {
+      return {
+        data: [
+          {
+            id: "sc_1",
+            products_link: linkedIds.map((id: string) => ({ product_id: id })),
+          },
+        ],
+      }
+    }
+    return { data: products }
+  })
+  return { graph }
+}
+
+const productCall = (query: any) =>
+  query.graph.mock.calls.map(([a]: any[]) => a).find((a: any) => a.entity === "product")
+
 describe("partitionAssignmentsByStore", () => {
-  const query = {
-    graph: jest.fn().mockResolvedValue({
-      data: [
+  const storeProducts = [
+    {
+      id: "prod_mine",
+      variants: [
         {
-          id: "prod_mine",
-          variants: [
-            {
-              id: "var_mine",
-              inventory_items: [{ inventory: { id: "iitem_mine" } }],
-            },
-          ],
+          id: "var_mine",
+          inventory_items: [{ inventory: { id: "iitem_mine" } }],
         },
       ],
-    }),
-  }
+    },
+  ]
+  let query = makeChannelQuery(storeProducts)
+
+  beforeEach(() => {
+    query = makeChannelQuery(storeProducts)
+  })
+
+  it("scopes by the channel pivot, never by a sales_channels filter on product", async () => {
+    await partitionAssignmentsByStore(makeContainer({ query }), "sc_1", [
+      { level: "product", id: "prod_mine", hs_code: "1" },
+    ])
+
+    expect(query.graph).toHaveBeenCalledWith(
+      expect.objectContaining({
+        entity: "sales_channel",
+        filters: { id: "sc_1" },
+      })
+    )
+    expect(productCall(query).filters).toEqual({ id: ["prod_mine"] })
+  })
+
+  it("rejects everything when the channel links no products", async () => {
+    // An empty `id` filter matches the whole catalogue, so this must short out
+    // before the product query rather than fall through to one.
+    const empty = makeChannelQuery([], [])
+    const { owned, foreign } = await partitionAssignmentsByStore(
+      makeContainer({ query: empty }),
+      "sc_1",
+      [{ level: "product", id: "prod_anything", hs_code: "1" }]
+    )
+
+    expect(owned).toHaveLength(0)
+    expect(foreign).toHaveLength(1)
+    expect(productCall(empty)).toBeUndefined()
+  })
 
   it("keeps ids in the store's catalogue and rejects everything else", async () => {
     const { owned, foreign } = await partitionAssignmentsByStore(
@@ -187,5 +252,61 @@ describe("partitionAssignmentsByStore", () => {
     )
     expect(owned).toHaveLength(0)
     expect(foreign).toHaveLength(1)
+  })
+})
+
+describe("scanMissingHsCodes", () => {
+  const gapProduct = {
+    id: "prod_mine",
+    title: "Kala Cotton Shirt",
+    hs_code: null,
+    variants: [
+      { id: "var_mine", manage_inventory: false, hs_code: null, inventory_items: [] },
+    ],
+  }
+
+  it("scopes a store scan through the channel pivot and pages over its ids", async () => {
+    const query = makeChannelQuery([gapProduct], ["prod_b", "prod_mine", "prod_a"])
+
+    const out = await scanMissingHsCodes(makeContainer({ query }), {
+      salesChannelId: "sc_1",
+      limit: 2,
+    })
+
+    expect(query.graph).toHaveBeenCalledWith(
+      expect.objectContaining({ entity: "sales_channel", filters: { id: "sc_1" } })
+    )
+    const call = productCall(query)
+    // Sorted so the page boundary is stable across calls, and paged here rather
+    // than in the DB — the ids came from the pivot, not from a product filter.
+    expect(call.filters).toEqual({ id: ["prod_a", "prod_b"] })
+    expect(call.pagination).toBeUndefined()
+    expect(out.has_more).toBe(true)
+  })
+
+  it("returns an empty page without querying products when the channel is empty", async () => {
+    const query = makeChannelQuery([], [])
+
+    const out = await scanMissingHsCodes(makeContainer({ query }), {
+      salesChannelId: "sc_1",
+    })
+
+    expect(out).toMatchObject({ gaps: [], scanned: 0, covered: 0, has_more: false })
+    expect(productCall(query)).toBeUndefined()
+  })
+
+  it("keeps DB-side pagination for the unscoped admin scan", async () => {
+    const query = makeChannelQuery([gapProduct])
+
+    const out = await scanMissingHsCodes(makeContainer({ query }), {
+      limit: 10,
+      offset: 20,
+    })
+
+    const call = productCall(query)
+    expect(call.filters).toEqual({})
+    expect(call.pagination).toEqual({ skip: 20, take: 10 })
+    expect(out.gaps).toHaveLength(1)
+    expect(out.gaps[0].suggested_target).toEqual({ level: "product", id: "prod_mine" })
   })
 })

--- a/apps/backend/src/workflows/customs/hs-codes.ts
+++ b/apps/backend/src/workflows/customs/hs-codes.ts
@@ -39,6 +39,41 @@ import {
 const DEFAULT_LIMIT = 50
 const MAX_LIMIT = 200
 
+/**
+ * Ids of the products linked to a sales channel.
+ *
+ * Scoping a product query with `filters: { sales_channels: { id } }` READS
+ * correctly and is what both halves of this file originally shipped with, but
+ * mikro-orm rejects it at runtime — "Trying to query by not existing property
+ * Product.sales_channels" — because the relation lives on the link entity, not
+ * on Product. Every partner-scoped call 500'd; nothing caught it because the
+ * unit tests mock `query.graph` and so never see the filter rejected.
+ *
+ * The working shape is to pivot from the channel and walk `products_link`,
+ * which is what `listStoreProductsWorkflow` and the price-fanout script already
+ * do. Two hops (`product_variants` filtered by `"product.sales_channels.id"`)
+ * fails differently — postgres "missing FROM-clause entry" — so don't reach for
+ * that either.
+ */
+async function channelProductIds(
+  query: any,
+  salesChannelId: string
+): Promise<string[]> {
+  const { data } = await query.graph({
+    entity: "sales_channel",
+    fields: ["id", "products_link.product_id"],
+    filters: { id: salesChannelId },
+  })
+
+  const links = ((data?.[0] as any)?.products_link || []) as Array<{
+    product_id?: string
+  }>
+
+  return Array.from(
+    new Set(links.map((l) => l?.product_id).filter(Boolean) as string[])
+  )
+}
+
 export type HsCodeGap = {
   product_id: string
   product_title: string
@@ -98,6 +133,23 @@ export async function scanMissingHsCodes(
   const limit = Math.min(Math.max(Number(input.limit) || DEFAULT_LIMIT, 1), MAX_LIMIT)
   const offset = Math.max(Number(input.offset) || 0, 0)
 
+  // Channel-scoped scans page over the id list HERE rather than in the product
+  // query: the channel pivot is the only way to resolve the set (see
+  // `channelProductIds`), and once we hold it, `pagination` on the id-filtered
+  // query would page a page. Unscoped (admin) scans page in the DB as before.
+  let pagedIds: string[] | null = null
+  let totalScopedProducts = 0
+
+  if (input.salesChannelId) {
+    const ids = await channelProductIds(query, input.salesChannelId)
+    totalScopedProducts = ids.length
+    pagedIds = ids.slice().sort().slice(offset, offset + limit)
+
+    if (!pagedIds.length) {
+      return { gaps: [], scanned: 0, covered: 0, limit, offset, has_more: false }
+    }
+  }
+
   const { data: products } = await query.graph({
     entity: "product",
     fields: [
@@ -122,11 +174,9 @@ export async function scanMissingHsCodes(
       "variants.inventory_items.inventory.hs_code",
     ],
     filters: {
-      ...(input.salesChannelId
-        ? { sales_channels: { id: input.salesChannelId } }
-        : {}),
+      ...(pagedIds ? { id: pagedIds } : {}),
     },
-    pagination: { skip: offset, take: limit },
+    ...(pagedIds ? {} : { pagination: { skip: offset, take: limit } }),
   })
 
   const gaps: HsCodeGap[] = []
@@ -184,7 +234,9 @@ export async function scanMissingHsCodes(
     covered,
     limit,
     offset,
-    has_more: (products || []).length === limit,
+    has_more: pagedIds
+      ? offset + pagedIds.length < totalScopedProducts
+      : (products || []).length === limit,
   }
 }
 
@@ -210,6 +262,14 @@ export async function partitionAssignmentsByStore(
   }
 
   const query: any = container.resolve(ContainerRegistrationKeys.QUERY)
+
+  const productIds = await channelProductIds(query, salesChannelId)
+  if (!productIds.length) {
+    // An empty `id` filter is not a no-op — it would match the whole catalogue
+    // and hand this partner every product on the platform.
+    return { owned: [], foreign: [...(assignments || [])] }
+  }
+
   const { data: products } = await query.graph({
     entity: "product",
     fields: [
@@ -218,7 +278,7 @@ export async function partitionAssignmentsByStore(
       "variants.inventory_items.inventory_item_id",
       "variants.inventory_items.inventory.id",
     ],
-    filters: { sales_channels: { id: salesChannelId } },
+    filters: { id: productIds },
   })
 
   const ownedIds: Record<HsCodeLevel, Set<string>> = {


### PR DESCRIPTION
## What was broken

Both partner HS-code routes returned **500 on every call** since #1206 shipped. The assistant surfaced it as:

```
Route /partners/stores/store_.../customs/hs-codes responded 500: HTTP 500
```

Prod logs give the cause:

```
Error: Trying to query by not existing property Product.sales_channels
    at new CriteriaNode (@mikro-orm/knex/query/CriteriaNode.js:37:27)
```

`scanMissingHsCodes` and `partitionAssignmentsByStore` both scoped the catalogue with `filters: { sales_channels: { id } }` on the `product` entity. The relation lives on the link entity, not on Product, so mikro-orm rejects the filter. `GET /partners/stores/:id/customs/hs-codes/missing` and its POST mirror were both unusable — i.e. `list_missing_hs_codes` and `bulk_set_hs_codes` never worked.

The admin routes were fine: they pass no `salesChannelId` and so never built the bad filter.

This exact shape is already documented as known-bad in `src/scripts/fanout-existing-variant-prices.ts:132`, alongside the two-hop variant that fails differently.

## Fix

Pivot from `sales_channel` → `products_link`, the shape `listStoreProductsWorkflow` and the price-fanout script use.

- Channel-scoped scans page over the resolved id list rather than in the DB — the ids come from the pivot, so a `pagination` on the id-filtered query would page a page. The unscoped admin scan keeps DB-side pagination, unchanged.
- An empty channel short-circuits before the product query: an empty `id` filter matches the **whole catalogue** and would hand a partner every product on the platform.

## Why it shipped green

The unit tests mock `query.graph`, and a mock accepts any filter you give it. They now assert the query *shape* — the only thing visible from a unit test.

New integration spec `customs-hs-codes-api.spec.ts` runs both surfaces against a real database. Verified both directions:

- with the fix: **5/5 pass**
- with `src/workflows/customs/hs-codes.ts` reverted: the **3 partner cases fail with 500**, the 2 admin cases still pass

## Verify

```bash
pnpm test:integration:http:shared ./integration-tests/http/customs-hs-codes-api.spec.ts
TEST_TYPE=unit npx jest --testPathPattern="apply-hs-codes"
```

`tsc --noEmit` still at the documented 79 baseline.

Unblocks step 2 of the #1206 tail (fill remaining HS codes via the assistant).

🤖 Generated with [Claude Code](https://claude.com/claude-code)