### PR TITLE
fix(shipping): refuse Delhivery for international destinations, and send its HSN

### DIFF
--- a/apps/backend/integration-tests/http/customs-hs-codes-api.spec.ts
+++ b/apps/backend/integration-tests/http/customs-hs-codes-api.spec.ts
@@ -1,0 +1,260 @@
+import { getSharedTestEnv, setupSharedTestSuite } from "./shared-test-setup"
+import { createAdminUser, getAuthHeaders } from "../helpers/create-admin-user"
+import { ProductStatus } from "@medusajs/framework/utils"
+
+/**
+ * Bulk HS/HSN customs codes — admin routes and their partner mirrors.
+ *
+ * These exist because the unit tests around `scanMissingHsCodes` /
+ * `partitionAssignmentsByStore` mock `query.graph`, and a mock accepts any
+ * filter you hand it. The partner routes shipped scoping products with
+ * `filters: { sales_channels: { id } }`, which mikro-orm rejects at runtime
+ * ("Trying to query by not existing property Product.sales_channels"), so BOTH
+ * partner routes 500'd on every call while the unit suite stayed green. Only a
+ * spec that runs the query against a real database can catch that class of bug,
+ * so the assertions below deliberately go through HTTP end to end.
+ */
+
+const TEST_PARTNER_PASSWORD = "supersecret"
+
+jest.setTimeout(120 * 1000)
+
+async function createPartnerWithStoreAndProduct(
+  api: any,
+  adminHeaders: Record<string, any>
+) {
+  const unique = Date.now() + Math.random().toString(36).slice(2, 6)
+  const email = `partner-hs-${unique}@medusa-test.com`
+
+  await api.post("/auth/partner/emailpass/register", {
+    email,
+    password: TEST_PARTNER_PASSWORD,
+  })
+  const login1 = await api.post("/auth/partner/emailpass", {
+    email,
+    password: TEST_PARTNER_PASSWORD,
+  })
+  let headers: Record<string, string> = {
+    Authorization: `Bearer ${login1.data.token}`,
+  }
+
+  await api.post(
+    "/partners",
+    {
+      name: `HSTest ${unique}`,
+      handle: `hstest-${unique}`,
+      admin: { email, first_name: "Admin", last_name: "HS" },
+    },
+    { headers }
+  )
+
+  const login2 = await api.post("/auth/partner/emailpass", {
+    email,
+    password: TEST_PARTNER_PASSWORD,
+  })
+  headers = { Authorization: `Bearer ${login2.data.token}` }
+
+  const currenciesRes = await api.get("/admin/currencies", adminHeaders)
+  const currencies = currenciesRes.data.currencies || []
+  const usd = currencies.find((c: any) => c.code?.toLowerCase() === "usd")
+  const currencyCode = String((usd || currencies[0]).code).toLowerCase()
+
+  const storeRes = await api.post(
+    "/partners/stores",
+    {
+      store: {
+        name: `HSStore ${unique}`,
+        supported_currencies: [{ currency_code: currencyCode, is_default: true }],
+      },
+      sales_channel: { name: `HSChannel ${unique}`, description: "Default" },
+      region: {
+        name: "Default Region",
+        currency_code: currencyCode,
+        countries: ["us"],
+      },
+      location: {
+        name: "Warehouse",
+        address: {
+          address_1: "1 Main St",
+          city: "NY",
+          postal_code: "10001",
+          country_code: "US",
+        },
+      },
+    },
+    { headers }
+  )
+
+  const storeId = storeRes.data.store.id
+
+  const productRes = await api.post(
+    "/partners/products",
+    {
+      store_id: storeId,
+      product: {
+        title: `Kala Cotton Shirt ${unique}`,
+        description: "Handwoven kala cotton shirt, men's woven.",
+        handle: `hs-prod-${unique}`,
+        status: ProductStatus.PUBLISHED,
+        options: [{ title: "Size", values: ["S", "M"] }],
+        variants: [
+          {
+            title: "Small",
+            sku: `HS-S-${unique}`,
+            options: { Size: "S" },
+            prices: [{ amount: 1000, currency_code: currencyCode }],
+          },
+        ],
+      },
+    },
+    { headers }
+  )
+
+  const product = productRes.data.product
+
+  return {
+    headers,
+    storeId,
+    productId: product?.id as string,
+    variantIds: ((product?.variants || []) as any[]).map((v) => v.id),
+  }
+}
+
+setupSharedTestSuite(() => {
+  const { api, getContainer } = getSharedTestEnv()
+
+  describe("Customs HS codes API", () => {
+    let adminHeaders: Record<string, any>
+    let partner: Awaited<ReturnType<typeof createPartnerWithStoreAndProduct>>
+
+    beforeEach(async () => {
+      const container = getContainer()
+      await createAdminUser(container)
+      adminHeaders = await getAuthHeaders(api)
+      partner = await createPartnerWithStoreAndProduct(api, adminHeaders)
+    })
+
+    it("GET /partners/stores/:id/customs/hs-codes/missing scopes to the store's channel", async () => {
+      const res = await api.get(
+        `/partners/stores/${partner.storeId}/customs/hs-codes/missing`,
+        { headers: partner.headers }
+      )
+
+      expect(res.status).toBe(200)
+      expect(res.data.scanned).toBeGreaterThan(0)
+
+      const gap = (res.data.gaps || []).find(
+        (g: any) => g.product_id === partner.productId
+      )
+      expect(gap).toBeDefined()
+      // The scan must carry enough context to classify the goods — a caller that
+      // only gets ids has nothing to declare a customs code from.
+      expect(gap.description).toContain("kala cotton")
+      expect(gap.suggested_target).toMatchObject({ id: expect.any(String) })
+
+      // Scoped means scoped: nothing outside this partner's channel may appear.
+      const foreign = (res.data.gaps || []).filter(
+        (g: any) => g.product_id !== partner.productId
+      )
+      expect(foreign).toHaveLength(0)
+    })
+
+    it("POST /partners/stores/:id/customs/hs-codes fills a gap the scan reported", async () => {
+      const scan = await api.get(
+        `/partners/stores/${partner.storeId}/customs/hs-codes/missing`,
+        { headers: partner.headers }
+      )
+      const target = (scan.data.gaps || []).find(
+        (g: any) => g.product_id === partner.productId
+      ).suggested_target
+
+      const apply = await api.post(
+        `/partners/stores/${partner.storeId}/customs/hs-codes`,
+        {
+          assignments: [
+            { level: target.level, id: target.id, hs_code: "62052000" },
+          ],
+        },
+        { headers: partner.headers }
+      )
+
+      expect(apply.status).toBe(200)
+      expect(apply.data.applied).toBe(1)
+      expect(apply.data.errors).toBe(0)
+
+      // A written code must make the item disappear from the scan — the two
+      // halves resolve through the same chain, so a level that "applies" but
+      // stays missing means the write landed somewhere a label can't read.
+      const rescan = await api.get(
+        `/partners/stores/${partner.storeId}/customs/hs-codes/missing`,
+        { headers: partner.headers }
+      )
+      expect(
+        (rescan.data.gaps || []).find((g: any) => g.product_id === partner.productId)
+      ).toBeUndefined()
+    })
+
+    it("rejects an id outside the store's catalogue without failing the batch", async () => {
+      const scan = await api.get(
+        `/partners/stores/${partner.storeId}/customs/hs-codes/missing`,
+        { headers: partner.headers }
+      )
+      const target = (scan.data.gaps || []).find(
+        (g: any) => g.product_id === partner.productId
+      ).suggested_target
+
+      const res = await api.post(
+        `/partners/stores/${partner.storeId}/customs/hs-codes`,
+        {
+          assignments: [
+            { level: target.level, id: target.id, hs_code: "62052000" },
+            { level: "product", id: "prod_not_mine", hs_code: "62052000" },
+          ],
+        },
+        { headers: partner.headers }
+      )
+
+      expect(res.status).toBe(200)
+      expect(res.data.applied).toBe(1)
+      expect(res.data.errors).toBe(1)
+      expect(
+        res.data.results.find((r: any) => r.id === "prod_not_mine").reason
+      ).toMatch(/not part of your store's catalogue/i)
+    })
+
+    it("GET /admin/customs/hs-codes/missing scans unscoped and paginates", async () => {
+      const res = await api.get(
+        "/admin/customs/hs-codes/missing?limit=5",
+        adminHeaders
+      )
+
+      expect(res.status).toBe(200)
+      expect(res.data.limit).toBe(5)
+      expect(Array.isArray(res.data.gaps)).toBe(true)
+    })
+
+    it("POST /admin/customs/hs-codes writes at the level it is told to", async () => {
+      const res = await api.post(
+        "/admin/customs/hs-codes",
+        {
+          assignments: [
+            {
+              level: "variant",
+              id: partner.variantIds[0],
+              hs_code: "62052000",
+              origin_country: "IN",
+            },
+            { level: "variant", id: "variant_nope", hs_code: "62052000" },
+          ],
+        },
+        adminHeaders
+      )
+
+      // Per-row outcomes, not an all-or-nothing status: a bad id in a big batch
+      // must not discard the good writes.
+      expect(res.status).toBe(200)
+      expect(res.data.applied).toBe(1)
+      expect(res.data.errors).toBe(1)
+    })
+  })
+})

--- a/apps/backend/src/modules/shipping-providers/delhivery/__tests__/delhivery-adapter.unit.spec.ts
+++ b/apps/backend/src/modules/shipping-providers/delhivery/__tests__/delhivery-adapter.unit.spec.ts
@@ -1,0 +1,127 @@
+import { DelhiveryProviderAdapter } from "../adapter"
+import type { CreateShipmentInput } from "../../provider-interface"
+
+/**
+ * The Delhivery adapter drives Delhivery's DOMESTIC Express API. Two things it
+ * has to get right, both verified against the live account on 2026-08-06:
+ *
+ * 1. It must refuse an export. Delhivery's exports are Cross Border, a separate
+ *    Delhivery One service with its own KYC and order object, absent from the
+ *    Express API entirely. Handed a foreign destination the domestic API gives
+ *    nothing actionable — serviceability for a US ZIP returns
+ *    `{"delivery_codes": []}` and the rate API answers a bare
+ *    `400 "Unable to process request, Please contact: lastmile-integration@…"`.
+ * 2. It must send `hsn_code`, which Delhivery lists as mandatory on order
+ *    creation next to `seller_gst_tin`. The adapter was dropping it even though
+ *    the shared builder resolves one per line (#1206).
+ */
+
+const createShipment = jest.fn().mockResolvedValue({
+  packages: [{ waybill: "1411236369" }],
+})
+const calculateShippingCost = jest.fn().mockResolvedValue([{ total_amount: 56.79 }])
+
+jest.mock("../client", () => ({
+  DelhiveryClient: jest.fn().mockImplementation(() => ({
+    createShipment,
+    calculateShippingCost,
+  })),
+}))
+
+const adapter = () => new DelhiveryProviderAdapter({ api_token: "t" })
+
+const input = (overrides: Partial<CreateShipmentInput> = {}): CreateShipmentInput =>
+  ({
+    reference_id: "order_1",
+    payment_mode: "prepaid",
+    pickup_location_name: "JYT Warehouse",
+    to: {
+      name: "Test Consignee",
+      phone: "9999999999",
+      address_1: "1 Test Street",
+      city: "Mumbai",
+      pincode: "400001",
+      state: "Maharashtra",
+      country: "IN",
+    },
+    items: [{ name: "Kala Cotton Shirt", quantity: 1, unit_price: 1200 }],
+    weight_grams: 500,
+    ...overrides,
+  }) as CreateShipmentInput
+
+beforeEach(() => {
+  createShipment.mockClear()
+  calculateShippingCost.mockClear()
+})
+
+describe("international destinations", () => {
+  it("refuses to create a shipment and names the way out", async () => {
+    await expect(
+      adapter().createShipment(
+        input({ to: { ...input().to, country: "US", pincode: "10001" } as any })
+      )
+    ).rejects.toThrow(/Cross Border|Use Shiprocket/)
+
+    // Nothing may reach the domestic endpoint — a foreign postcode in `pin`
+    // would either be rejected opaquely or manifest something undeliverable.
+    expect(createShipment).not.toHaveBeenCalled()
+  })
+
+  it("refuses to quote a rate", async () => {
+    await expect(
+      adapter().getRates({
+        origin_pincode: "110001",
+        destination_pincode: "10001",
+        destination_country: "US",
+        weight_grams: 500,
+      })
+    ).rejects.toThrow(/Cross Border/)
+    expect(calculateShippingCost).not.toHaveBeenCalled()
+  })
+
+  it("still ships domestically — 'IN', 'India' and an absent country all pass", async () => {
+    for (const country of ["IN", "India", undefined]) {
+      await adapter().createShipment(
+        input({ to: { ...input().to, country } as any })
+      )
+    }
+    expect(createShipment).toHaveBeenCalledTimes(3)
+
+    // A rate query with no destination_country is domestic by definition — the
+    // field is optional and every existing caller omits it.
+    await adapter().getRates({
+      origin_pincode: "110001",
+      destination_pincode: "400001",
+      weight_grams: 500,
+    })
+    expect(calculateShippingCost).toHaveBeenCalled()
+  })
+})
+
+describe("hsn_code", () => {
+  it("forwards the first line that resolves one", async () => {
+    await adapter().createShipment(
+      input({
+        items: [
+          { name: "Ad-hoc line", quantity: 1, unit_price: 100 },
+          { name: "Shirt", quantity: 1, unit_price: 1200, hsn: "62052000" },
+          { name: "Scarf", quantity: 1, unit_price: 400, hsn: "62142000" },
+        ],
+      })
+    )
+    // Delhivery takes ONE code per shipment, not one per line.
+    expect(createShipment.mock.calls[0][0].hsn_code).toBe("62052000")
+  })
+
+  it("sends no hsn_code when no line has one, rather than an empty string", async () => {
+    await adapter().createShipment(input())
+    expect(createShipment.mock.calls[0][0].hsn_code).toBeUndefined()
+  })
+
+  it("ignores a blank code", async () => {
+    await adapter().createShipment(
+      input({ items: [{ name: "Shirt", quantity: 1, unit_price: 1, hsn: "   " }] })
+    )
+    expect(createShipment.mock.calls[0][0].hsn_code).toBeUndefined()
+  })
+})

--- a/apps/backend/src/modules/shipping-providers/delhivery/adapter.ts
+++ b/apps/backend/src/modules/shipping-providers/delhivery/adapter.ts
@@ -4,7 +4,10 @@
  * auto-assigns the waybill, so `createShipment` is a single round-trip; the
  * waybill is the only ref needed for label/track/cancel.
  */
+import { MedusaError } from "@medusajs/framework/utils"
+
 import { DelhiveryClient, DelhiveryOptions } from "./client"
+import { isInternationalDestination } from "../destination"
 import {
   CreateShipmentInput,
   LabelResult,
@@ -31,6 +34,34 @@ const STATUS_LABELS: Record<string, string> = {
   NFI: "Not Found",
 }
 
+/**
+ * Refuse an export up front, with the reason and the way out.
+ *
+ * This adapter drives Delhivery's Express last-mile API (`/api/cmu/create.json`)
+ * — the DOMESTIC product. Delhivery's exports run on Cross Border, a separate
+ * Delhivery One service with its own activation, seller KYC (PAN, GST, bank +
+ * IFSC, AD code, IEC) and a different order object (shipment type, INCO terms,
+ * invoice number/date, IGST payment status, per-item category/HSN/qty/price).
+ * None of it is in the Express API at all.
+ *
+ * Without this guard the domestic endpoint is handed a foreign postcode in
+ * `pin` and a `country` it does not serve. Measured against the live account
+ * 2026-08-06: serviceability for a US ZIP returns `{"delivery_codes": []}`, and
+ * the rate API answers `400 "Unable to process request, Please contact:
+ * lastmile-integration@delhivery.com"` — no indication that the real problem is
+ * "this carrier has no export product on this account". Fail here instead, so
+ * the operator is told to pick a carrier that can actually ship it.
+ */
+function assertDomestic(country: string | undefined, action: string): void {
+  if (!isInternationalDestination(country)) {
+    return
+  }
+  throw new MedusaError(
+    MedusaError.Types.NOT_ALLOWED,
+    `Delhivery cannot ${action} to ${country} — this integration drives Delhivery's domestic (Express) API, and international exports run on Delhivery Cross Border, which is a separate service. Use Shiprocket for this order, or contact Delhivery to enable Cross Border.`
+  )
+}
+
 export class DelhiveryProviderAdapter implements ShippingProviderClient {
   readonly carrier = "delhivery"
   private client: DelhiveryClient
@@ -45,6 +76,10 @@ export class DelhiveryProviderAdapter implements ShippingProviderClient {
   }
 
   async getRates(query: RateQuery): Promise<RateOption[]> {
+    // The Kinko invoice API takes two 6-digit INDIAN pincodes and quotes in INR.
+    // A foreign destination gets a bare 400 from Delhivery, so classify it here.
+    assertDomestic(query.destination_country, "quote a rate")
+
     const result = await this.client.calculateShippingCost({
       origin_pin: query.origin_pincode,
       destination_pin: query.destination_pincode,
@@ -62,7 +97,16 @@ export class DelhiveryProviderAdapter implements ShippingProviderClient {
   }
 
   async createShipment(input: CreateShipmentInput): Promise<ShipmentResult> {
+    assertDomestic(input.to.country, "create a shipment")
+
     const result = await this.client.createShipment({
+      // Delhivery makes `hsn_code` mandatory on order creation alongside
+      // `seller_gst_tin`, and it is ONE code per shipment, not one per line —
+      // so send the first line that resolves one. `items[].hsn` is filled by
+      // the shared variant → inventory item → product → line-metadata chain
+      // (#1206); this adapter was dropping it, which is why Delhivery labels
+      // carried a GSTIN but never an HSN.
+      hsn_code: input.items.map((i) => i.hsn).find((h) => !!h && String(h).trim()),
       waybill: "",
       name: input.to.name,
       phone: input.to.phone,

--- a/apps/backend/src/modules/shipping-providers/destination.ts
+++ b/apps/backend/src/modules/shipping-providers/destination.ts
@@ -1,0 +1,16 @@
+/**
+ * Destination classification shared by every carrier adapter.
+ *
+ * This lived in `shiprocket/client.ts` because Shiprocket was the first carrier
+ * to need it, but "is this shipment leaving India" is not a Shiprocket fact —
+ * it decides which product a carrier has to be driven through, and a carrier
+ * that has no export product at all needs it to refuse the job. Re-exported
+ * from `shiprocket/client` so existing imports keep working.
+ */
+
+/** True when a shipment's destination country is outside India. */
+export function isInternationalDestination(country?: string): boolean {
+  const raw = (country || "").trim()
+  if (!raw) return false
+  return !/^(in|india)$/i.test(raw)
+}

--- a/apps/backend/src/modules/shipping-providers/provider-interface.ts
+++ b/apps/backend/src/modules/shipping-providers/provider-interface.ts
@@ -146,6 +146,12 @@ export type ShipmentResult = {
 export type RateQuery = {
   origin_pincode: string
   destination_pincode: string
+  /**
+   * Destination country. Optional because domestic callers never set it, but a
+   * carrier with no export product needs it to refuse the quote rather than
+   * pass a foreign postcode to an India-only rate API.
+   */
+  destination_country?: string
   weight_grams: number
   cod?: boolean
   dimensions_cm?: Dimensions

--- a/apps/backend/src/modules/shipping-providers/shiprocket/client.ts
+++ b/apps/backend/src/modules/shipping-providers/shiprocket/client.ts
@@ -9,6 +9,7 @@
  *
  * Docs: https://apidocs.shiprocket.in/  ·  base: https://apiv2.shiprocket.in/v1/external
  */
+import { isInternationalDestination } from "../destination"
 import {
   CreateShipmentInput,
   LabelResult,
@@ -341,12 +342,13 @@ export function toShiprocketCountryName(country?: string): string {
   }
 }
 
-/** True when a shipment's destination country is outside India. */
-export function isInternationalDestination(country?: string): boolean {
-  const raw = (country || "").trim()
-  if (!raw) return false
-  return !/^(in|india)$/i.test(raw)
-}
+// Destination classification is carrier-neutral — it now lives in
+// `../destination` so an adapter with no export product (Delhivery) can refuse
+// the job without importing the Shiprocket client. Re-exported here so the
+// existing import sites keep working.
+// (A re-export alone wouldn't put the name in this module's scope, and it is
+// used below to branch the create flow — so import, then re-export.)
+export { isInternationalDestination }
 
 /** Shiprocket international customs fields, with retail-sale defaults applied. */
 export type ResolvedCustoms = {

--- a/apps/backend/src/workflows/customs/__tests__/apply-hs-codes.unit.spec.ts
+++ b/apps/backend/src/workflows/customs/__tests__/apply-hs-codes.unit.spec.ts
@@ -8,7 +8,11 @@ jest.mock("@medusajs/medusa/core-flows", () => ({
   updateProductsWorkflow: () => ({ run: updateProductsRun }),
 }))
 
-import { applyHsCodes, partitionAssignmentsByStore } from "../hs-codes"
+import {
+  applyHsCodes,
+  partitionAssignmentsByStore,
+  scanMissingHsCodes,
+} from "../hs-codes"
 
 /**
  * The bulk HS-code apply is deliberately NOT transactional: one bad id in a
@@ -129,22 +133,83 @@ describe("applyHsCodes", () => {
   })
 })
 
+/**
+ * Store scoping goes through the sales_channel → products_link pivot, NOT a
+ * `sales_channels` filter on product. The filter shape reads fine and passes a
+ * mocked query, but mikro-orm rejects it at runtime ("Trying to query by not
+ * existing property Product.sales_channels") and every partner-scoped call
+ * 500s. Since a mock can't reject it for us, these tests assert the query SHAPE
+ * — that's the only place the regression is visible from a unit test.
+ */
+const makeChannelQuery = (
+  products: any[],
+  linkedIds = products.map((p) => p.id)
+) => {
+  const graph = jest.fn(async ({ entity }: any) => {
+    if (entity === "sales_channel") {
+      return {
+        data: [
+          {
+            id: "sc_1",
+            products_link: linkedIds.map((id: string) => ({ product_id: id })),
+          },
+        ],
+      }
+    }
+    return { data: products }
+  })
+  return { graph }
+}
+
+const productCall = (query: any) =>
+  query.graph.mock.calls.map(([a]: any[]) => a).find((a: any) => a.entity === "product")
+
 describe("partitionAssignmentsByStore", () => {
-  const query = {
-    graph: jest.fn().mockResolvedValue({
-      data: [
+  const storeProducts = [
+    {
+      id: "prod_mine",
+      variants: [
         {
-          id: "prod_mine",
-          variants: [
-            {
-              id: "var_mine",
-              inventory_items: [{ inventory: { id: "iitem_mine" } }],
-            },
-          ],
+          id: "var_mine",
+          inventory_items: [{ inventory: { id: "iitem_mine" } }],
         },
       ],
-    }),
-  }
+    },
+  ]
+  let query = makeChannelQuery(storeProducts)
+
+  beforeEach(() => {
+    query = makeChannelQuery(storeProducts)
+  })
+
+  it("scopes by the channel pivot, never by a sales_channels filter on product", async () => {
+    await partitionAssignmentsByStore(makeContainer({ query }), "sc_1", [
+      { level: "product", id: "prod_mine", hs_code: "1" },
+    ])
+
+    expect(query.graph).toHaveBeenCalledWith(
+      expect.objectContaining({
+        entity: "sales_channel",
+        filters: { id: "sc_1" },
+      })
+    )
+    expect(productCall(query).filters).toEqual({ id: ["prod_mine"] })
+  })
+
+  it("rejects everything when the channel links no products", async () => {
+    // An empty `id` filter matches the whole catalogue, so this must short out
+    // before the product query rather than fall through to one.
+    const empty = makeChannelQuery([], [])
+    const { owned, foreign } = await partitionAssignmentsByStore(
+      makeContainer({ query: empty }),
+      "sc_1",
+      [{ level: "product", id: "prod_anything", hs_code: "1" }]
+    )
+
+    expect(owned).toHaveLength(0)
+    expect(foreign).toHaveLength(1)
+    expect(productCall(empty)).toBeUndefined()
+  })
 
   it("keeps ids in the store's catalogue and rejects everything else", async () => {
     const { owned, foreign } = await partitionAssignmentsByStore(
@@ -187,5 +252,61 @@ describe("partitionAssignmentsByStore", () => {
     )
     expect(owned).toHaveLength(0)
     expect(foreign).toHaveLength(1)
+  })
+})
+
+describe("scanMissingHsCodes", () => {
+  const gapProduct = {
+    id: "prod_mine",
+    title: "Kala Cotton Shirt",
+    hs_code: null,
+    variants: [
+      { id: "var_mine", manage_inventory: false, hs_code: null, inventory_items: [] },
+    ],
+  }
+
+  it("scopes a store scan through the channel pivot and pages over its ids", async () => {
+    const query = makeChannelQuery([gapProduct], ["prod_b", "prod_mine", "prod_a"])
+
+    const out = await scanMissingHsCodes(makeContainer({ query }), {
+      salesChannelId: "sc_1",
+      limit: 2,
+    })
+
+    expect(query.graph).toHaveBeenCalledWith(
+      expect.objectContaining({ entity: "sales_channel", filters: { id: "sc_1" } })
+    )
+    const call = productCall(query)
+    // Sorted so the page boundary is stable across calls, and paged here rather
+    // than in the DB — the ids came from the pivot, not from a product filter.
+    expect(call.filters).toEqual({ id: ["prod_a", "prod_b"] })
+    expect(call.pagination).toBeUndefined()
+    expect(out.has_more).toBe(true)
+  })
+
+  it("returns an empty page without querying products when the channel is empty", async () => {
+    const query = makeChannelQuery([], [])
+
+    const out = await scanMissingHsCodes(makeContainer({ query }), {
+      salesChannelId: "sc_1",
+    })
+
+    expect(out).toMatchObject({ gaps: [], scanned: 0, covered: 0, has_more: false })
+    expect(productCall(query)).toBeUndefined()
+  })
+
+  it("keeps DB-side pagination for the unscoped admin scan", async () => {
+    const query = makeChannelQuery([gapProduct])
+
+    const out = await scanMissingHsCodes(makeContainer({ query }), {
+      limit: 10,
+      offset: 20,
+    })
+
+    const call = productCall(query)
+    expect(call.filters).toEqual({})
+    expect(call.pagination).toEqual({ skip: 20, take: 10 })
+    expect(out.gaps).toHaveLength(1)
+    expect(out.gaps[0].suggested_target).toEqual({ level: "product", id: "prod_mine" })
   })
 })

--- a/apps/backend/src/workflows/customs/hs-codes.ts
+++ b/apps/backend/src/workflows/customs/hs-codes.ts
@@ -39,6 +39,41 @@ import {
 const DEFAULT_LIMIT = 50
 const MAX_LIMIT = 200
 
+/**
+ * Ids of the products linked to a sales channel.
+ *
+ * Scoping a product query with `filters: { sales_channels: { id } }` READS
+ * correctly and is what both halves of this file originally shipped with, but
+ * mikro-orm rejects it at runtime — "Trying to query by not existing property
+ * Product.sales_channels" — because the relation lives on the link entity, not
+ * on Product. Every partner-scoped call 500'd; nothing caught it because the
+ * unit tests mock `query.graph` and so never see the filter rejected.
+ *
+ * The working shape is to pivot from the channel and walk `products_link`,
+ * which is what `listStoreProductsWorkflow` and the price-fanout script already
+ * do. Two hops (`product_variants` filtered by `"product.sales_channels.id"`)
+ * fails differently — postgres "missing FROM-clause entry" — so don't reach for
+ * that either.
+ */
+async function channelProductIds(
+  query: any,
+  salesChannelId: string
+): Promise<string[]> {
+  const { data } = await query.graph({
+    entity: "sales_channel",
+    fields: ["id", "products_link.product_id"],
+    filters: { id: salesChannelId },
+  })
+
+  const links = ((data?.[0] as any)?.products_link || []) as Array<{
+    product_id?: string
+  }>
+
+  return Array.from(
+    new Set(links.map((l) => l?.product_id).filter(Boolean) as string[])
+  )
+}
+
 export type HsCodeGap = {
   product_id: string
   product_title: string
@@ -98,6 +133,23 @@ export async function scanMissingHsCodes(
   const limit = Math.min(Math.max(Number(input.limit) || DEFAULT_LIMIT, 1), MAX_LIMIT)
   const offset = Math.max(Number(input.offset) || 0, 0)
 
+  // Channel-scoped scans page over the id list HERE rather than in the product
+  // query: the channel pivot is the only way to resolve the set (see
+  // `channelProductIds`), and once we hold it, `pagination` on the id-filtered
+  // query would page a page. Unscoped (admin) scans page in the DB as before.
+  let pagedIds: string[] | null = null
+  let totalScopedProducts = 0
+
+  if (input.salesChannelId) {
+    const ids = await channelProductIds(query, input.salesChannelId)
+    totalScopedProducts = ids.length
+    pagedIds = ids.slice().sort().slice(offset, offset + limit)
+
+    if (!pagedIds.length) {
+      return { gaps: [], scanned: 0, covered: 0, limit, offset, has_more: false }
+    }
+  }
+
   const { data: products } = await query.graph({
     entity: "product",
     fields: [
@@ -122,11 +174,9 @@ export async function scanMissingHsCodes(
       "variants.inventory_items.inventory.hs_code",
     ],
     filters: {
-      ...(input.salesChannelId
-        ? { sales_channels: { id: input.salesChannelId } }
-        : {}),
+      ...(pagedIds ? { id: pagedIds } : {}),
     },
-    pagination: { skip: offset, take: limit },
+    ...(pagedIds ? {} : { pagination: { skip: offset, take: limit } }),
   })
 
   const gaps: HsCodeGap[] = []
@@ -184,7 +234,9 @@ export async function scanMissingHsCodes(
     covered,
     limit,
     offset,
-    has_more: (products || []).length === limit,
+    has_more: pagedIds
+      ? offset + pagedIds.length < totalScopedProducts
+      : (products || []).length === limit,
   }
 }
 
@@ -210,6 +262,14 @@ export async function partitionAssignmentsByStore(
   }
 
   const query: any = container.resolve(ContainerRegistrationKeys.QUERY)
+
+  const productIds = await channelProductIds(query, salesChannelId)
+  if (!productIds.length) {
+    // An empty `id` filter is not a no-op — it would match the whole catalogue
+    // and hand this partner every product on the platform.
+    return { owned: [], foreign: [...(assignments || [])] }
+  }
+
   const { data: products } = await query.graph({
     entity: "product",
     fields: [
@@ -218,7 +278,7 @@ export async function partitionAssignmentsByStore(
       "variants.inventory_items.inventory_item_id",
       "variants.inventory_items.inventory.id",
     ],
-    filters: { sales_channels: { id: salesChannelId } },
+    filters: { id: productIds },
   })
 
   const ownedIds: Record<HsCodeLevel, Set<string>> = {

--- a/apps/docs/notes/DELHIVERY_INTERNATIONAL_PARITY.md
+++ b/apps/docs/notes/DELHIVERY_INTERNATIONAL_PARITY.md
@@ -1,0 +1,81 @@
+# Delhivery international — parity audit (2026-08-06)
+
+Companion to `SHIPROCKET_INTERNATIONAL_API.md`. Question asked: does our Delhivery
+integration have parity with Shiprocket's international support?
+
+**Answer: there is nothing to have parity with. Delhivery's exports are a
+different product that we are not integrated with, and until this audit the
+domestic integration was reachable for international orders.**
+
+## What Delhivery's international shape actually is
+
+The public [Express API doc set](https://delhivery-express-api-doc.readme.io/llms.txt)
+has 43 pages and **no international/cross-border endpoint**. Order creation is a
+single endpoint, `POST /api/cmu/create.json` — the domestic manifest API. It
+takes a `country` field (their example uses `"BD"`), but that is the
+Indian-subcontinent last-mile product, not exports.
+
+Exports run on **Cross Border**, a separate Delhivery One service
+([help.delhivery.com/docs/cross-border](https://help.delhivery.com/docs/cross-border))
+that must be activated on the account. Per
+[International Order Creation](https://help.delhivery.com/docs/create-international-order)
+its order object is different:
+
+| Group | Fields |
+|---|---|
+| Shipment type | Document · Sample · Gifts · Commercial Cargo · Commercial (CSB-V) |
+| Invoice | INCO Terms, Invoice Number, Invoice Date, IGST Payment Status |
+| Per item | Category, HSN Code, Quantity, Price, IGST rate |
+| Parcel | Box Dimensions (LBH cm), Dead Weight (kg), mode: Document / Deferred Express / Express |
+| Onboarding | Seller KYC **mandatory before order creation** — PAN, GST, bank account + IFSC, AD code, IEC |
+
+None of this is documented publicly; the spec has to come from Delhivery's team
+(same contact as the #649 status push).
+
+## Measured against the live account, 2026-08-06
+
+| Probe | Result |
+|---|---|
+| `GET /c/api/pin-codes/json/?filter_codes=110001` | `200`, full `delivery_codes` entry |
+| same, US ZIP `10001` | `200 {"delivery_codes": []}` |
+| same, UK `SW1A1AA` | `200 {"delivery_codes": []}` |
+| `GET /api/kinko/v1/invoice/charges/` IN→IN | `200`, `total_amount: 56.79` |
+| same, IN→US ZIP | **`400 {"error": "Unable to process request, Please contact: lastmile-integration@delhivery.com"}`** |
+| staging (`staging-express`) with the live token | `401 Login or API Key Required` |
+
+Two things to keep: the failure mode is **opaque** — nothing in it says "this
+carrier has no export product on this account" — and **there is no sandbox**.
+Delhivery issues separate staging credentials; the production token does not
+cross over, with or without a `Content-Type` header. Any create test is against
+the live account and mints a real waybill.
+
+## What was wrong on our side
+
+1. **Delhivery was selectable for an international order.** `SHIPMENT_CARRIERS`
+   offered it unconditionally and `shiprocket-shipment.ts` is carrier-agnostic
+   (`input.carrier || "shiprocket"` → resolver). Every international behaviour —
+   FX conversion, the HSN-required check, `describeIntlPrereqError` — lives
+   *inside the Shiprocket client*, so Delhivery just posted a foreign postcode in
+   `pin` to the domestic endpoint.
+2. **`hsn_code` never reached Delhivery, even domestically.** The client
+   supported it; the adapter never set it. Delhivery lists it as mandatory on
+   order creation alongside `seller_gst_tin` (which we do send, #348). Note it is
+   **one code per shipment**, not per line.
+3. `customs` and `currency` on `CreateShipmentInput` are consumed by Shiprocket
+   only.
+4. Rates and serviceability are India-only by construction (`o_pin`/`d_pin`,
+   hardcoded `inr`).
+
+## What was fixed
+
+`assertDomestic` in `delhivery/adapter.ts` refuses `createShipment` / `getRates`
+for a non-India destination with an actionable message; `isInternationalDestination`
+moved to the carrier-neutral `shipping-providers/destination.ts` (re-exported
+from `shiprocket/client` so imports still work); the adapter now forwards
+`hsn_code`; the partner picker filters `domesticOnly` carriers out for
+international orders.
+
+## What is NOT fixed
+
+Real Delhivery cross-border. It needs the service activated, full seller
+KYC/IEC/AD-code onboarding, and a spec from Delhivery. That belongs under #649.

--- a/apps/partner-ui/src/routes/orders/order-create-shipment/components/order-create-shipment-form/carrier-tab.tsx
+++ b/apps/partner-ui/src/routes/orders/order-create-shipment/components/order-create-shipment-form/carrier-tab.tsx
@@ -17,7 +17,12 @@ import {
   useAttachShiprocketAwb,
   useGenerateShiprocketLabel,
 } from "../../../../../hooks/api/shiprocket"
-import { CreateShipmentSchema, SHIPMENT_CARRIERS } from "./constants"
+import {
+  CreateShipmentSchema,
+  SHIPMENT_CARRIERS,
+  carriersForDestination,
+  isInternationalDestination,
+} from "./constants"
 
 /**
  * Step 1 of "Mark as shipped" — the carrier step (#639 follow-up).
@@ -43,6 +48,8 @@ type CarrierTabProps = {
   form: UseFormReturn<zod.infer<typeof CreateShipmentSchema>>
   /** Called with the AWB once a label is generated or an existing one attached. */
   onCarrierResolved: (outcome: CarrierOutcome) => void
+  /** Destination country of the order — decides which carriers can serve it. */
+  destinationCountry?: string | null
 }
 
 export const CarrierTab = ({
@@ -50,10 +57,23 @@ export const CarrierTab = ({
   fulfillment,
   form,
   onCarrierResolved,
+  destinationCountry,
 }: CarrierTabProps) => {
   const [awbInput, setAwbInput] = useState("")
 
-  const carrier = form.watch("carrier") || "shiprocket"
+  // Only offer carriers that can actually reach this destination. Delhivery is
+  // domestic-only here (its exports are a separate Cross Border service), and
+  // picking it for a foreign address just returns an opaque carrier error.
+  const availableCarriers = carriersForDestination(destinationCountry)
+  const isIntl = isInternationalDestination(destinationCountry)
+
+  const selected = form.watch("carrier") || "shiprocket"
+  // A carrier that can't serve this destination must not stay selected — the
+  // default is `shiprocket` and the form may have been pre-filled from a
+  // previous, domestic order.
+  const carrier = availableCarriers.some((c) => c.value === selected)
+    ? selected
+    : availableCarriers[0]?.value || "shiprocket"
   const carrierLabel =
     SHIPMENT_CARRIERS.find((c) => c.value === carrier)?.label ?? carrier
 
@@ -153,13 +173,20 @@ export const CarrierTab = ({
               <Select.Value />
             </Select.Trigger>
             <Select.Content>
-              {SHIPMENT_CARRIERS.map((c) => (
+              {availableCarriers.map((c) => (
                 <Select.Item key={c.value} value={c.value}>
                   {c.label}
                 </Select.Item>
               ))}
             </Select.Content>
           </Select>
+          {isIntl ? (
+            <Text size="small" className="text-ui-fg-subtle">
+              This order ships outside India, so only carriers with an export
+              service are listed. Delhivery is domestic-only on this account —
+              its exports run on Cross Border, a separate service.
+            </Text>
+          ) : null}
           <div>
             <Button
               type="button"

--- a/apps/partner-ui/src/routes/orders/order-create-shipment/components/order-create-shipment-form/constants.ts
+++ b/apps/partner-ui/src/routes/orders/order-create-shipment/components/order-create-shipment-form/constants.ts
@@ -1,10 +1,32 @@
 import { z } from "@medusajs/framework/zod"
 
-/** Carriers the partner shipping routes can drive. */
+/**
+ * Carriers the partner shipping routes can drive.
+ *
+ * `domesticOnly` means the integration talks to that carrier's India-only
+ * product. Delhivery is the case: we drive its Express last-mile API, while its
+ * exports run on Cross Border — a separate Delhivery One service we are not
+ * onboarded to. Offering it for a foreign address only produces an opaque
+ * carrier error, so it is filtered out of the picker (and refused by the
+ * backend adapter, which is the real guard).
+ */
 export const SHIPMENT_CARRIERS = [
   { value: "shiprocket", label: "Shiprocket" },
-  { value: "delhivery", label: "Delhivery" },
+  { value: "delhivery", label: "Delhivery", domesticOnly: true },
 ] as const
+
+/** True when a destination country is outside India (mirrors the backend). */
+export const isInternationalDestination = (country?: string | null): boolean => {
+  const raw = (country || "").trim()
+  if (!raw) return false
+  return !/^(in|india)$/i.test(raw)
+}
+
+/** The carriers that can actually ship to a given destination. */
+export const carriersForDestination = (country?: string | null) =>
+  SHIPMENT_CARRIERS.filter(
+    (c) => !("domesticOnly" in c && c.domesticOnly) || !isInternationalDestination(country)
+  )
 
 export const CreateShipmentSchema = z.object({
   // Which carrier account a label is generated on. NOT sent to the shipment

--- a/apps/partner-ui/src/routes/orders/order-create-shipment/components/order-create-shipment-form/order-create-shipment-form.tsx
+++ b/apps/partner-ui/src/routes/orders/order-create-shipment/components/order-create-shipment-form/order-create-shipment-form.tsx
@@ -186,6 +186,7 @@ export function OrderCreateShipmentForm({
                 fulfillment={fulfillment}
                 form={form}
                 onCarrierResolved={handleCarrierResolved}
+                destinationCountry={order?.shipping_address?.country_code}
               />
             </ProgressTabs.Content>
             <ProgressTabs.Content


### PR DESCRIPTION
Piece one of the Delhivery international parity audit. Full findings and probe results in `apps/docs/notes/DELHIVERY_INTERNATIONAL_PARITY.md`.

## The problem

Delhivery was selectable for an order shipping outside India. Our integration drives Delhivery's **Express last-mile API** — the domestic product. Delhivery's exports run on **Cross Border**, a separate Delhivery One service with its own activation, seller KYC (PAN, GST, bank + IFSC, AD code, IEC) and a different order object. Their [public Express doc set](https://delhivery-express-api-doc.readme.io/llms.txt) has 43 pages and no cross-border endpoint.

Nothing stopped the combination. `SHIPMENT_CARRIERS` offered Delhivery unconditionally, `shiprocket-shipment.ts` is carrier-agnostic (`input.carrier || "shiprocket"` → resolver), and every international behaviour — FX conversion, HSN-required check, `describeIntlPrereqError` — lives *inside the Shiprocket client*. A foreign postcode went straight into `pin` on the domestic endpoint.

## Measured against the live account (2026-08-06)

| Probe | Result |
|---|---|
| serviceability, IN `110001` | `200`, full entry |
| serviceability, US `10001` / UK `SW1A1AA` | `200 {"delivery_codes": []}` |
| rate IN→IN | `200`, `total_amount: 56.79` |
| rate IN→US | **`400 {"error": "Unable to process request, Please contact: lastmile-integration@delhivery.com"}`** |
| staging with the live token | `401 Login or API Key Required` |

The failure mode is opaque — nothing says "this carrier has no export product on this account". And **there is no sandbox**: Delhivery issues separate staging credentials and the production token doesn't cross over, so any create test mints a real waybill on the live account. That's why creation is covered by unit tests over a mocked client rather than a live probe.

## Changes

- `assertDomestic` refuses `createShipment` / `getRates` for a non-India destination, with a message that names Cross Border and points at Shiprocket.
- `isInternationalDestination` moves to a carrier-neutral `shipping-providers/destination.ts`, re-exported from `shiprocket/client` (which still uses it internally) so every import site is unchanged. An adapter with no export product shouldn't have to import a competitor's client to know it can't ship.
- `RateQuery.destination_country` added, optional — domestic callers never set it.
- The partner carrier picker filters `domesticOnly` carriers for international orders, deselects one that's already chosen, and explains why.
- **`hsn_code` is now forwarded.** Delhivery lists it as mandatory on order creation next to `seller_gst_tin` (which we do send, #348). The client already supported the field and #1206 resolves a per-line HSN — only the adapter was dropping it. It's one code per *shipment*, so the first line that resolves one wins.

## Not in scope

Real Delhivery cross-border support. Needs the service activated, full KYC/IEC/AD-code onboarding, and a spec from Delhivery's team (same contact as the #649 status push). Belongs under #649.

The admin-side pickers (design orders, inventory order shipment modal) still list Delhivery unconditionally — the backend gate covers them correctly, but their UI isn't filtered.

## Verify

```bash
TEST_TYPE=unit npx jest --testPathPattern="shipping-providers|shiprocket"   # 110 pass
pnpm test:integration:http:shared ./integration-tests/http/retail-order-international-shiprocket.spec.ts ./integration-tests/http/partner-order-shiprocket-label.spec.ts
```

Both integration suites pass (7 tests) — per the last handoff these had been exercised by neither CI gate, so this is their first actual run. Backend `tsc --noEmit` at the 79 baseline; partner-ui at its 4 (all pre-existing, in claim/exchange forms).

🤖 Generated with [Claude Code](https://claude.com/claude-code)