### PR TITLE
fix(shipping): normalize HSN to digits + fall back billing_state for Shiprocket intl

### DIFF
--- a/apps/backend/src/modules/shipping-providers/__tests__/hs-code-resolution.unit.spec.ts
+++ b/apps/backend/src/modules/shipping-providers/__tests__/hs-code-resolution.unit.spec.ts
@@ -1,5 +1,6 @@
 import {
   nonEmptyCode,
+  normalizeHsCode,
   resolveVariantHsCode,
   suggestHsCodeTarget,
 } from "../hs-code-resolution"
@@ -23,6 +24,32 @@ describe("nonEmptyCode", () => {
     expect(nonEmptyCode("   ")).toBeUndefined()
     expect(nonEmptyCode(null)).toBeUndefined()
     expect(nonEmptyCode(undefined)).toBeUndefined()
+  })
+})
+
+describe("normalizeHsCode", () => {
+  it("strips the formatting customs schedules print", () => {
+    // Same code, three ways a merchant might type it — carriers want bare digits.
+    expect(normalizeHsCode("6205.20.00")).toBe("62052000")
+    expect(normalizeHsCode("6205 20 00")).toBe("62052000")
+    expect(normalizeHsCode("6205-20-00")).toBe("62052000")
+    expect(normalizeHsCode(" 6205200000 ")).toBe("6205200000")
+    expect(normalizeHsCode(62052000)).toBe("62052000")
+  })
+
+  it("returns undefined when nothing numeric survives", () => {
+    // A pure-text code must not reach the carrier as "" and slip past — it
+    // returns undefined so the missing-HSN guard fires with a clear message.
+    expect(normalizeHsCode("N/A")).toBeUndefined()
+    expect(normalizeHsCode("")).toBeUndefined()
+    expect(normalizeHsCode(null)).toBeUndefined()
+    expect(normalizeHsCode(undefined)).toBeUndefined()
+  })
+
+  it("rejects an over-long string rather than truncating a code", () => {
+    // >15 digits is a data error, not a code to silently cut to 15.
+    expect(normalizeHsCode("1234567890123456")).toBeUndefined()
+    expect(normalizeHsCode("123456789012345")).toBe("123456789012345")
   })
 })
 

--- a/apps/backend/src/modules/shipping-providers/delhivery/adapter.ts
+++ b/apps/backend/src/modules/shipping-providers/delhivery/adapter.ts
@@ -8,6 +8,7 @@ import { MedusaError } from "@medusajs/framework/utils"
 
 import { DelhiveryClient, DelhiveryOptions } from "./client"
 import { isInternationalDestination } from "../destination"
+import { normalizeHsCode } from "../hs-code-resolution"
 import {
   CreateShipmentInput,
   LabelResult,
@@ -106,7 +107,9 @@ export class DelhiveryProviderAdapter implements ShippingProviderClient {
       // the shared variant → inventory item → product → line-metadata chain
       // (#1206); this adapter was dropping it, which is why Delhivery labels
       // carried a GSTIN but never an HSN.
-      hsn_code: input.items.map((i) => i.hsn).find((h) => !!h && String(h).trim()),
+      hsn_code: input.items
+        .map((i) => normalizeHsCode(i.hsn))
+        .find((h) => !!h),
       waybill: "",
       name: input.to.name,
       phone: input.to.phone,

--- a/apps/backend/src/modules/shipping-providers/hs-code-resolution.ts
+++ b/apps/backend/src/modules/shipping-providers/hs-code-resolution.ts
@@ -23,6 +23,33 @@ export const nonEmptyCode = (v: unknown): string | undefined => {
   return s.length ? s : undefined
 }
 
+/**
+ * Normalize an HS/HSN code for a carrier that wants digits only.
+ *
+ * Merchants enter codes the way customs schedules print them — `6205.20.00`,
+ * `6205 20 00`, `6205-20-00` — but Shiprocket rejects anything non-numeric
+ * (`HSN should be numeric; Can have length between 1 to 15`) and Delhivery
+ * expects a bare code too. Dots / spaces / hyphens are pure formatting of the
+ * SAME code, so stripping them is safe and does not change the declaration.
+ *
+ * Returns undefined when nothing numeric survives (e.g. a code typed as pure
+ * text), so the caller's existing "missing HSN" guard fires with an actionable
+ * message rather than posting an invalid code. Capped at 15 digits — Shiprocket's
+ * documented max; a longer string is a data error, not a truncatable code, so it
+ * is rejected (undefined) rather than silently cut.
+ */
+export const normalizeHsCode = (v: unknown): string | undefined => {
+  const raw = nonEmptyCode(v)
+  if (!raw) {
+    return undefined
+  }
+  const digits = raw.replace(/[^0-9]/g, "")
+  if (!digits.length || digits.length > 15) {
+    return undefined
+  }
+  return digits
+}
+
 /** The shape `resolveVariantHsCode` needs; a superset of it is fine. */
 export type VariantLike = {
   id?: string | null

--- a/apps/backend/src/modules/shipping-providers/shiprocket/__tests__/create-international-shipment.unit.spec.ts
+++ b/apps/backend/src/modules/shipping-providers/shiprocket/__tests__/create-international-shipment.unit.spec.ts
@@ -110,6 +110,36 @@ describe("buildInternationalCreateBody", () => {
     const body = buildInternationalCreateBody(usInput({ currency: undefined }), "wh")
     expect(body.currency).toBe("INR")
   })
+
+  it("normalizes a formatted HSN to digits (Shiprocket 422: 'HSN should be numeric')", () => {
+    const body = buildInternationalCreateBody(
+      usInput({
+        items: [{ name: "Shirt", sku: "S-1", quantity: 1, unit_price: 20, hsn: "6205.20.00" }],
+      }),
+      "wh"
+    )
+    expect(body.order_items[0].hsn).toBe("62052000")
+  })
+
+  it("treats a non-numeric HSN as missing rather than posting it invalid", () => {
+    const input = usInput({
+      items: [{ name: "Shirt", sku: "S-1", quantity: 1, unit_price: 20, hsn: "N/A" }],
+    })
+    expect(() => buildInternationalCreateBody(input, "wh")).toThrow(/HSN code is required/i)
+  })
+
+  it("falls back billing_state to the city when the address has none (422: 'billing state field is required')", () => {
+    const body = buildInternationalCreateBody(
+      usInput({ to: { ...usInput().to, state: "" } as any }),
+      "wh"
+    )
+    expect(body.billing_state).toBe("Dallas")
+  })
+
+  it("keeps a real billing_state untouched", () => {
+    const body = buildInternationalCreateBody(usInput(), "wh")
+    expect(body.billing_state).toBe("Texas")
+  })
 })
 
 describe("ShiprocketClient.createShipment — international routing", () => {

--- a/apps/backend/src/modules/shipping-providers/shiprocket/client.ts
+++ b/apps/backend/src/modules/shipping-providers/shiprocket/client.ts
@@ -10,6 +10,7 @@
  * Docs: https://apidocs.shiprocket.in/  ·  base: https://apiv2.shiprocket.in/v1/external
  */
 import { isInternationalDestination } from "../destination"
+import { nonEmptyCode, normalizeHsCode } from "../hs-code-resolution"
 import {
   CreateShipmentInput,
   LabelResult,
@@ -276,7 +277,10 @@ export function buildShiprocketOrderItems(
         sku,
         units,
         selling_price: i.unit_price,
-        hsn: i.hsn || "",
+        // Digits only — Shiprocket rejects `6205.20.00` / `6205 20 00` with
+        // "HSN should be numeric". An unrecoverable code normalizes to "" and is
+        // then caught by the missing-HSN guard rather than posted invalid.
+        hsn: normalizeHsCode(i.hsn) || "",
         tax: i.tax ?? "",
       })
     }
@@ -416,7 +420,12 @@ export function buildInternationalCreateBody(
     billing_address_2: input.to.address_2 || "",
     billing_city: input.to.city,
     billing_pincode: input.to.pincode,
-    billing_state: input.to.state,
+    // Shiprocket makes billing_state mandatory even for destinations that have
+    // no province in their address (city-states, or foreign addresses where the
+    // buyer left it blank) — it 422s with "The billing state field is required".
+    // Fall back to the city, which is what Shiprocket's own support advises for
+    // stateless addresses, so a valid order isn't blocked on an empty field.
+    billing_state: nonEmptyCode(input.to.state) || input.to.city,
     billing_country: toShiprocketCountryName(input.to.country),
     billing_email: input.to.email || "",
     billing_phone: input.to.phone,
@@ -636,7 +645,9 @@ export class ShiprocketClient implements ShippingProviderClient {
       billing_address_2: input.to.address_2 || "",
       billing_city: input.to.city,
       billing_pincode: input.to.pincode,
-      billing_state: input.to.state,
+      // Mandatory at Shiprocket even when the address carries no state — fall
+      // back to the city (same as the international body above).
+      billing_state: nonEmptyCode(input.to.state) || input.to.city,
       billing_country: input.to.country || "India",
       billing_email: input.to.email || "",
       billing_phone: input.to.phone,


### PR DESCRIPTION
Regenerating an international label from the partner UI 422'd on two fields:

```
billing_state: The billing state field is required
order_items.4.hsn: HSN should be numeric; Can have length between 1 to 15
```

Both are real defects in the `/international/orders/create/adhoc` body builder.

## 1. HSN — accept the formats merchants actually enter

Codes get typed the way customs schedules print them — `6205.20.00`, `6205 20 00`, `6205-20-00` — but Shiprocket (and Delhivery) want bare digits, 1–15 chars. We sent the value verbatim, so `order_items.4` had a dotted code and Shiprocket rejected it.

New shared `normalizeHsCode` (in `hs-code-resolution.ts`) strips formatting. Dots/spaces/hyphens are pure formatting of the **same** code, so this doesn't change the declaration. Edge cases handled deliberately:
- A code that normalizes to nothing (pure text like `N/A`) → `undefined`, so the existing missing-HSN guard fires with an actionable message rather than posting `""`.
- `>15` digits → rejected as a data error, not silently truncated to 15.

Applied at both carrier boundaries: `buildShiprocketOrderItems` (runs **before** the missing-HSN filter, so the two compose — a bad code reads as missing) and the Delhivery adapter's `hsn_code` pick.

## 2. billing_state — fall back to city when the address has none

Shiprocket makes `billing_state` mandatory even for destinations with no province, or when the buyer left it blank. Falling back to the **city** is Shiprocket support's own advice for stateless addresses. Applied to both the international and domestic create bodies; a real state is passed through untouched.

## Verify

Unit tests reproduce **both** 422 inputs and assert the corrected body:
- `6205.20.00` → `order_items[].hsn === "62052000"`
- `N/A` → throws `HSN code is required`
- `state: ""` → `billing_state === "Dallas"` (the city)
- real state → untouched

```bash
TEST_TYPE=unit npx jest --testPathPattern="shipping-providers|shiprocket|delhivery|hs-code"   # 117 pass
```

`tsc --noEmit` at the 79 baseline.

## Retry

Once merged + deployed, regenerate the same international label from the partner UI — the two 422 fields are the ones this fixes. If the order's HSN codes were set with dot-formatting via the assistant, no re-entry is needed; the normalizer handles them at label time (labels read live, per #1206).

🤖 Generated with [Claude Code](https://claude.com/claude-code)