### PR TITLE
fix(shipping): fall back Shiprocket phone/pincode to billing + customer

### DIFF
--- a/apps/backend/src/workflows/orders/__tests__/build-create-shipment-input.unit.spec.ts
+++ b/apps/backend/src/workflows/orders/__tests__/build-create-shipment-input.unit.spec.ts
@@ -22,6 +22,77 @@ const baseOrder: OrderForShipment = {
   items: [{ title: "Custom Saree", quantity: 2, unit_price: 100, sku: "SAR-1" }],
 }
 
+describe("buildCreateShipmentInput — phone / pincode fallbacks", () => {
+  // Shiprocket 422s on empty billing_phone / billing_pincode. The buyer's phone
+  // and postal code are often captured on the order/customer or billing address,
+  // not the shipping address — walk shipping → billing → customer.
+  const noContactShipping = {
+    first_name: "Asha",
+    last_name: "Rao",
+    address_1: "12 MG Road",
+    city: "Bengaluru",
+    province: "KA",
+    country_code: "in",
+    // no phone, no postal_code
+  }
+
+  it("falls back phone to billing, then to the customer", () => {
+    const fromBilling = buildCreateShipmentInput(
+      {
+        ...baseOrder,
+        shipping_address: noContactShipping,
+        billing_address: { phone: "+919811111111", postal_code: "560001" },
+      },
+      { pickupLocationName: "wh" }
+    )
+    expect(fromBilling.to.phone).toBe("+919811111111")
+
+    const fromCustomer = buildCreateShipmentInput(
+      {
+        ...baseOrder,
+        shipping_address: noContactShipping,
+        billing_address: {},
+        customer: { phone: "+919822222222" },
+      },
+      { pickupLocationName: "wh" }
+    )
+    expect(fromCustomer.to.phone).toBe("+919822222222")
+  })
+
+  it("falls back pincode to the billing address", () => {
+    const input = buildCreateShipmentInput(
+      {
+        ...baseOrder,
+        shipping_address: noContactShipping,
+        billing_address: { postal_code: "110001" },
+      },
+      { pickupLocationName: "wh" }
+    )
+    expect(input.to.pincode).toBe("110001")
+  })
+
+  it("prefers the shipping address when it has its own phone/pincode", () => {
+    const input = buildCreateShipmentInput(
+      {
+        ...baseOrder,
+        billing_address: { phone: "+910000000000", postal_code: "000000" },
+      },
+      { pickupLocationName: "wh" }
+    )
+    expect(input.to.phone).toBe("+919800000000")
+    expect(input.to.pincode).toBe("560001")
+  })
+
+  it("leaves phone/pincode empty when no source has them (guarded upstream)", () => {
+    const input = buildCreateShipmentInput(
+      { ...baseOrder, shipping_address: noContactShipping, billing_address: {}, customer: {} },
+      { pickupLocationName: "wh" }
+    )
+    expect(input.to.phone).toBe("")
+    expect(input.to.pincode).toBe("")
+  })
+})
+
 describe("buildCreateShipmentInput (#404 PR-B)", () => {
   it("maps a prepaid order (no cod_amount)", () => {
     const input = buildCreateShipmentInput(baseOrder, {

--- a/apps/backend/src/workflows/orders/shiprocket-shipment.ts
+++ b/apps/backend/src/workflows/orders/shiprocket-shipment.ts
@@ -57,6 +57,10 @@ export type OrderForShipment = {
   currency_code?: string | null
   metadata?: Record<string, any> | null
   shipping_address?: Record<string, any> | null
+  /** Fallback source for phone / postal code the shipping address may lack. */
+  billing_address?: Record<string, any> | null
+  /** Fallback source for the buyer phone when neither address carries one. */
+  customer?: { phone?: string | null; email?: string | null } | null
   items?: Array<{
     title?: string | null
     quantity?: number | null
@@ -115,6 +119,19 @@ export function buildCreateShipmentInput(
   opts: BuildShipmentOpts
 ): CreateShipmentInput {
   const addr = order.shipping_address || {}
+  const billing = order.billing_address || {}
+  // Shiprocket makes billing_phone and billing_pincode mandatory. The buyer's
+  // phone is often captured on the order/customer or the billing address rather
+  // than the shipping address, and the postal code can likewise live on billing
+  // — sending "" 422s ("The billing phone field is required" / pincode). Walk
+  // shipping → billing → customer so a complete order isn't blocked because one
+  // field landed on a sibling record.
+  const phone =
+    nonEmptyCode(addr.phone) ||
+    nonEmptyCode(billing.phone) ||
+    nonEmptyCode(order.customer?.phone) ||
+    ""
+  const pincode = nonEmptyCode(addr.postal_code) || nonEmptyCode(billing.postal_code) || ""
   const paymentMode: "prepaid" | "cod" =
     order.metadata?.payment_mode === "cod" ? "cod" : "prepaid"
 
@@ -145,13 +162,13 @@ export function buildCreateShipmentInput(
     pickup_location_name: opts.pickupLocationName || "",
     to: {
       name,
-      phone: addr.phone || "",
-      email: order.email || addr.email || undefined,
+      phone,
+      email: order.email || addr.email || billing.email || order.customer?.email || undefined,
       address_1: addr.address_1 || "",
       address_2: addr.address_2 || undefined,
       city: addr.city || "",
       state: addr.province || "",
-      pincode: addr.postal_code || "",
+      pincode,
       country: addr.country_code ? String(addr.country_code).toUpperCase() : "IN",
     },
     items,
@@ -204,6 +221,10 @@ export async function createShiprocketShipmentForFulfillment(
       "currency_code",
       "metadata",
       "shipping_address.*",
+      // Fallback source for phone / postal code the shipping address may lack.
+      "billing_address.*",
+      "customer.phone",
+      "customer.email",
       "items.title",
       "items.quantity",
       "items.unit_price",


### PR DESCRIPTION
Next 422 layer after #1211, regenerating an international label:

```
billing_pincode required
billing_phone required
```

## Cause

`buildCreateShipmentInput` mapped `to.phone` / `to.pincode` from `shipping_address` **only**, with an empty-string fallback, and the order-fetch graph query pulled only `shipping_address.*`. The buyer's phone is frequently captured on the order/customer or the **billing** address, and the postal code can live on billing too. So a perfectly complete order sent `""` for both and Shiprocket rejected it.

## Fix

- Phone: `shipping_address → billing_address → customer.phone`
- Pincode: `shipping_address → billing_address` (postal_code)
- Email gains the same billing/customer fallback
- Graph query now fetches `billing_address.*`, `customer.phone`, `customer.email`

A real shipping-address value still wins. If every source is empty it still yields `""` — Shiprocket's own required-field error is the guard of last resort (we can't invent a phone number).

## Relatedly — answering "how is domestic vs international decided?"

There is **no boolean**, in the UI or anywhere. The order is international iff `shipping_address.country_code` is outside India:

`buildCreateShipmentInput` → `to.country` → `isInternationalDestination()` → the Shiprocket client branches to `/international/*` vs the domestic endpoints. It's data-driven — which is exactly why these address-completeness bugs surface as carrier 422s rather than a validation error up front. Same address fields feed both the routing decision and the carrier body.

## Verify

```bash
TEST_TYPE=unit npx jest --testPathPattern="build-create-shipment-input"   # 18 pass
```

4 new tests: phone→billing→customer, pincode→billing, shipping wins when present, all-empty stays empty. `tsc --noEmit` at 79.

Note: the inventory-order shipment builder is a separate path with its own minimal-address handling and is untouched.

🤖 Generated with [Claude Code](https://claude.com/claude-code)