### PR TITLE
feat(shipping): parcel weight + dimensions in partner Mark-as-Shipped

### DIFF
--- a/apps/backend/integration-tests/http/partner-order-shiprocket-label.spec.ts
+++ b/apps/backend/integration-tests/http/partner-order-shiprocket-label.spec.ts
@@ -302,6 +302,68 @@ setupSharedTestSuite(() => {
       expect(res.data.shiprocket_label.awb).toBe("STUBAWB123")
     })
 
+    it("forwards parcel weight + dimensions to the carrier body", async () => {
+      await api.post(
+        `/admin/stock-locations/${locationId}`,
+        {
+          address: {
+            address_1: "1 Loom St",
+            city: "Surendranagar",
+            province: "GJ",
+            postal_code: "363035",
+            country_code: "IN",
+            phone: "9990001112",
+          },
+        },
+        adminHeaders
+      )
+
+      const res = await api.post(
+        `/partners/orders/${orderId}/shiprocket-label`,
+        {
+          carrier: "shiprocket",
+          weight_grams: 1500,
+          dimensions_cm: { length: 30, width: 20, height: 10 },
+        },
+        { headers: partnerHeaders }
+      )
+      expect(res.status).toBe(200)
+      // Shiprocket takes kg; the parcel must reach the create body, not the
+      // 500 g / 10cm default the label used to always ship at.
+      expect(shiprocketStubState.lastAdhocBody.weight).toBe(1.5)
+      expect(shiprocketStubState.lastAdhocBody.length).toBe(30)
+      expect(shiprocketStubState.lastAdhocBody.breadth).toBe(20)
+      expect(shiprocketStubState.lastAdhocBody.height).toBe(10)
+    })
+
+    it("ignores a partial box and blank weight (falls back to defaults)", async () => {
+      await api.post(
+        `/admin/stock-locations/${locationId}`,
+        {
+          address: {
+            address_1: "1 Loom St",
+            city: "Surendranagar",
+            province: "GJ",
+            postal_code: "363035",
+            country_code: "IN",
+            phone: "9990001112",
+          },
+        },
+        adminHeaders
+      )
+
+      const res = await api.post(
+        `/partners/orders/${orderId}/shiprocket-label`,
+        // Only two of three dims → the box is meaningless and must be dropped;
+        // no weight → default. Neither should error.
+        { carrier: "shiprocket", dimensions_cm: { length: 30, width: 20 } },
+        { headers: partnerHeaders }
+      )
+      expect(res.status).toBe(200)
+      expect(shiprocketStubState.lastAdhocBody.weight).toBe(0.5) // 500 g default
+      expect(shiprocketStubState.lastAdhocBody.length).toBe(10) // default box
+    })
+
     it("400s when the partner's location cannot be registered — never ships from another party's warehouse", async () => {
       // Fixture location has NO phone → registration must fail loudly instead
       // of falling back to the shared account's first registered pickup.

--- a/apps/backend/src/api/partners/orders/[id]/shiprocket-label/route.ts
+++ b/apps/backend/src/api/partners/orders/[id]/shiprocket-label/route.ts
@@ -22,8 +22,17 @@ import { createShiprocketShipmentForFulfillment } from "../../../../../workflows
  * there is deliberately NO registered-pickup fallback — all parties share one
  * Shiprocket account, so the #638 fallback would print a label originating at
  * another party's warehouse. Accepts an optional `preferred_courier_id`
- * (#641 parity).
+ * (#641 parity) and optional parcel `weight_grams` / `dimensions_cm` — when
+ * omitted the shipment falls back to the default weight, which is why every
+ * label used to ship at 500 g regardless of the parcel.
  */
+
+/** Coerce a body value to a positive number, or undefined (never 0/NaN). */
+const positiveNumber = (v: unknown): number | undefined => {
+  const n = Number(v)
+  return Number.isFinite(n) && n > 0 ? n : undefined
+}
+
 export const POST = async (
   req: AuthenticatedMedusaRequest,
   res: MedusaResponse
@@ -34,11 +43,23 @@ export const POST = async (
   const body = (req.body || {}) as {
     carrier?: string
     preferred_courier_id?: string | number
+    weight_grams?: number
+    dimensions_cm?: { length?: number; width?: number; height?: number }
   }
   const preferredCourierId =
     body.preferred_courier_id != null && body.preferred_courier_id !== ""
       ? body.preferred_courier_id
       : undefined
+
+  const weightGrams = positiveNumber(body.weight_grams)
+  // Dimensions are all-or-nothing at the carrier (a partial box is meaningless),
+  // so only forward them when all three are present and positive.
+  const dims = body.dimensions_cm || {}
+  const length = positiveNumber(dims.length)
+  const width = positiveNumber(dims.width)
+  const height = positiveNumber(dims.height)
+  const dimensionsCm =
+    length && width && height ? { length, width, height } : undefined
 
   const { partner, locationId } = await resolvePartnerShipFromLocation(
     req.auth_context,
@@ -61,6 +82,8 @@ export const POST = async (
     pickupStockLocationId: locationId,
     actingEmail: partner?.admins?.[0]?.email,
     preferredCourierId,
+    weightGrams,
+    dimensionsCm,
   })
 
   res.status(200).json({ shiprocket_label: shipment })

--- a/apps/partner-ui/src/hooks/api/shiprocket.tsx
+++ b/apps/partner-ui/src/hooks/api/shiprocket.tsx
@@ -27,6 +27,10 @@ export type GenerateShiprocketLabelResponse = {
 export type GenerateShiprocketLabelVariables = {
   preferred_courier_id?: string | number
   carrier?: string
+  /** Chargeable parcel weight in grams. Omitted → backend default weight. */
+  weight_grams?: number
+  /** Parcel box in cm. All three or none — a partial box is ignored server-side. */
+  dimensions_cm?: { length?: number; width?: number; height?: number }
 }
 
 /**
@@ -47,6 +51,8 @@ export const useGenerateShiprocketLabel = (
       const body: Record<string, any> = {}
       if (variables?.preferred_courier_id) body.preferred_courier_id = variables.preferred_courier_id
       if (variables?.carrier) body.carrier = variables.carrier
+      if (variables?.weight_grams) body.weight_grams = variables.weight_grams
+      if (variables?.dimensions_cm) body.dimensions_cm = variables.dimensions_cm
       return sdk.client.fetch<GenerateShiprocketLabelResponse>(
         `/partners/orders/${orderId}/shiprocket-label`,
         { method: "POST", body }

--- a/apps/partner-ui/src/routes/orders/order-create-shipment/components/order-create-shipment-form/carrier-tab.tsx
+++ b/apps/partner-ui/src/routes/orders/order-create-shipment/components/order-create-shipment-form/carrier-tab.tsx
@@ -92,7 +92,24 @@ export const CarrierTab = ({
 
   const handleGenerate = async () => {
     try {
-      const res = await generateLabel({ carrier })
+      // Parcel details drive the carrier's weight/dimension pricing and the
+      // label. Form inputs are strings, so coerce; omitted/blank fields aren't
+      // sent — the backend keeps its default weight rather than shipping a
+      // zero-gram parcel. Dimensions are all-or-nothing (a partial box is
+      // meaningless), matching the server-side rule.
+      const pos = (v: unknown) => {
+        const n = Number(v)
+        return Number.isFinite(n) && n > 0 ? n : undefined
+      }
+      const values = form.getValues()
+      const weight_grams = pos(values.weight_grams)
+      const length = pos(values.length_cm)
+      const width = pos(values.width_cm)
+      const height = pos(values.height_cm)
+      const dimensions_cm =
+        length && width && height ? { length, width, height } : undefined
+
+      const res = await generateLabel({ carrier, weight_grams, dimensions_cm })
       const label = res?.shiprocket_label
       const awb = label?.awb || label?.tracking_number
       if (!awb) {
@@ -187,6 +204,49 @@ export const CarrierTab = ({
               its exports run on Cross Border, a separate service.
             </Text>
           ) : null}
+
+          {/* Parcel details — drive the carrier's weight/dimension pricing and
+              the printed label. Optional: left blank, the shipment uses the
+              backend default weight (which is why labels used to ship at 500 g
+              regardless of the parcel). */}
+          {!existingAwb ? (
+            <div className="flex flex-col gap-y-2 border-t pt-4">
+              <Label size="xsmall">Parcel</Label>
+              <Text size="small" className="text-ui-fg-subtle">
+                Weight and box size price the shipment and print on the label.
+                Leave blank to use the default weight.
+              </Text>
+              <div className="grid max-w-xs grid-cols-2 gap-2">
+                <Input
+                  type="number"
+                  min={0}
+                  placeholder="Weight (g)"
+                  {...form.register("weight_grams")}
+                />
+              </div>
+              <div className="grid max-w-xs grid-cols-3 gap-2">
+                <Input
+                  type="number"
+                  min={0}
+                  placeholder="L (cm)"
+                  {...form.register("length_cm")}
+                />
+                <Input
+                  type="number"
+                  min={0}
+                  placeholder="W (cm)"
+                  {...form.register("width_cm")}
+                />
+                <Input
+                  type="number"
+                  min={0}
+                  placeholder="H (cm)"
+                  {...form.register("height_cm")}
+                />
+              </div>
+            </div>
+          ) : null}
+
           <div>
             <Button
               type="button"

--- a/apps/partner-ui/src/routes/orders/order-create-shipment/components/order-create-shipment-form/constants.ts
+++ b/apps/partner-ui/src/routes/orders/order-create-shipment/components/order-create-shipment-form/constants.ts
@@ -28,10 +28,23 @@ export const carriersForDestination = (country?: string | null) =>
     (c) => !("domesticOnly" in c && c.domesticOnly) || !isInternationalDestination(country)
   )
 
+// Empty string → undefined, else a positive number. Parcel fields are optional;
+// a blank must not coerce to 0 (which would be a real, wrong, zero-gram parcel).
+const optionalPositive = z.preprocess(
+  (v) => (v === "" || v === null || v === undefined ? undefined : Number(v)),
+  z.number().positive().optional()
+)
+
 export const CreateShipmentSchema = z.object({
   // Which carrier account a label is generated on. NOT sent to the shipment
   // endpoint — it only drives the label/AWB calls on the carrier step.
   carrier: z.string().optional(),
+  // Parcel details for label generation (carrier step only). Omitted → the
+  // backend default weight, which is why every label used to ship at 500 g.
+  weight_grams: optionalPositive,
+  length_cm: optionalPositive,
+  width_cm: optionalPositive,
+  height_cm: optionalPositive,
   labels: z.array(
     z.object({
       tracking_number: z.string(),


### PR DESCRIPTION
First addition to the Mark-as-Shipped flow. Every partner label was shipping at the **hardcoded 500 g / 10×10×10 default** — the Carrier step had no parcel inputs and `POST /partners/orders/:id/shiprocket-label` didn't accept them, even though `createShiprocketShipmentForFulfillment` already supported `weightGrams` / `dimensionsCm`. Wrong weight → wrong carrier rate → wrong label.

## Change

- **Carrier tab** (step 1) gains an optional **Parcel** block: weight (g) + L×B×H (cm). Hidden once an AWB is attached (the label already exists).
- All-or-nothing dimensions on both client and route — a partial box is meaningless and is dropped. Values coerced to positive numbers; blank fields aren't sent, so the backend keeps its default weight rather than shipping a zero-gram parcel.
- Route forwards `weight_grams` / `dimensions_cm` to the shipment builder; hook + `CreateShipmentSchema` carry the fields.

## Placement

| Where | File |
|---|---|
| Parcel inputs | `carrier-tab.tsx` (between Provider select and Generate button) |
| Coercion + submit | `carrier-tab.tsx` `handleGenerate` |
| Schema | `order-create-shipment-form/constants.ts` |
| Hook | `hooks/api/shiprocket.tsx` |
| Route passthrough | `api/partners/orders/[id]/shiprocket-label/route.ts` |

## Verify

```bash
pnpm test:integration:http:shared ./integration-tests/http/partner-order-shiprocket-label.spec.ts   # 6/6
```

Two new tests: `1500 g → weight 1.5, box 30/20/10` reaches the carrier body; a partial box (`{length, width}` only) + blank weight falls back to `0.5` kg / `10` cm defaults. Backend tsc 79, partner-ui tsc 4 (pre-existing claim/exchange errors).

Scope: partner Mark-as-Shipped only. Admin design-orders label generation is a separate surface, untouched — a candidate for the same block next.

🤖 Generated with [Claude Code](https://claude.com/claude-code)