### PR TITLE
feat(shipping): courier selection in partner Mark-as-Shipped

### DIFF
--- a/apps/backend/integration-tests/http/partner-order-shiprocket-label.spec.ts
+++ b/apps/backend/integration-tests/http/partner-order-shiprocket-label.spec.ts
@@ -364,6 +364,50 @@ setupSharedTestSuite(() => {
       expect(shiprocketStubState.lastAdhocBody.length).toBe(10) // default box
     })
 
+    it("lists courier rates for the partner's own order (#641 mirror)", async () => {
+      // Registerable location so a pickup (rate origin) exists.
+      await api.post(
+        `/admin/stock-locations/${locationId}`,
+        {
+          address: {
+            address_1: "1 Loom St",
+            city: "Surendranagar",
+            province: "GJ",
+            postal_code: "363035",
+            country_code: "IN",
+            phone: "9990001112",
+          },
+        },
+        adminHeaders
+      )
+      // Register the pickup so listPickupLocations has an origin pincode.
+      await api.post(
+        `/partners/orders/${orderId}/shiprocket-label`,
+        { carrier: "shiprocket" },
+        { headers: partnerHeaders }
+      )
+
+      const res = await api.get(
+        `/partners/orders/${orderId}/shiprocket-rates`,
+        { headers: partnerHeaders }
+      )
+      expect(res.status).toBe(200)
+      expect(res.data.destination_pincode).toBe("400001")
+      expect(Array.isArray(res.data.rates)).toBe(true)
+      // Same canned stub as the admin rates spec — a recommended courier is present.
+      expect(res.data.rates.find((r: any) => r.is_recommended)).toBeDefined()
+    })
+
+    it("rejects a rates request for an order the partner does not own", async () => {
+      const res = await api
+        .get(`/partners/orders/order_not_mine/shiprocket-rates`, {
+          headers: partnerHeaders,
+        })
+        .catch((e: any) => e.response)
+      // Ownership guard runs before any carrier work (404, not a rate list).
+      expect([401, 403, 404]).toContain(res.status)
+    })
+
     it("400s when the partner's location cannot be registered — never ships from another party's warehouse", async () => {
       // Fixture location has NO phone → registration must fail loudly instead
       // of falling back to the shared account's first registered pickup.

--- a/apps/backend/src/api/middlewares.ts
+++ b/apps/backend/src/api/middlewares.ts
@@ -5122,6 +5122,14 @@ export default defineMiddlewares({
       ],
     },
     {
+      matcher: "/partners/orders/:id/shiprocket-rates",
+      method: "GET",
+      middlewares: [
+        createCorsPartnerMiddleware(),
+        authenticate("partner", ["session", "bearer"]),
+      ],
+    },
+    {
       matcher: "/partners/orders/:id/shiprocket-attach-awb",
       method: "POST",
       middlewares: [

--- a/apps/backend/src/api/partners/orders/[id]/shiprocket-rates/route.ts
+++ b/apps/backend/src/api/partners/orders/[id]/shiprocket-rates/route.ts
@@ -1,0 +1,48 @@
+import { AuthenticatedMedusaRequest, MedusaResponse } from "@medusajs/framework/http"
+
+import { validatePartnerOrderOwnership } from "../../../helpers"
+import { getShiprocketRatesForOrder } from "../../../../../workflows/orders/shiprocket-rates"
+
+/**
+ * GET /partners/orders/:id/shiprocket-rates
+ *
+ * Partner mirror of `GET /admin/orders/:id/shiprocket-rates` (#641). Lists the
+ * carrier's courier options (rate / ETA / recommended) for one of the partner's
+ * own orders, so the Mark-as-Shipped carrier step can show a picker before
+ * Generate-Label. The chosen `courier_id` threads back into
+ * `POST /partners/orders/:id/shiprocket-label` as `preferred_courier_id`; when
+ * none is chosen the carrier auto-selects.
+ *
+ * Partner ownership is enforced INSIDE the handler (retail sales-channel OR the
+ * partner↔order work link) — a foreign order 404s before any carrier work runs,
+ * same guard as the label route.
+ *
+ * Read-only: this quotes, it never creates a shipment. `?carrier=` and
+ * `?weight_grams=` refine the quote (the carrier step's parcel weight feeds the
+ * latter so the estimate matches the parcel that will actually ship).
+ */
+export const GET = async (
+  req: AuthenticatedMedusaRequest,
+  res: MedusaResponse
+) => {
+  const orderId = req.params.id
+  await validatePartnerOrderOwnership(req.auth_context, orderId, req.scope)
+
+  const carrierRaw = req.query.carrier
+  const carrier =
+    typeof carrierRaw === "string" && carrierRaw ? carrierRaw : undefined
+
+  const weightRaw = req.query.weight_grams
+  const weightGrams = weightRaw != null ? Number(weightRaw) : undefined
+
+  const result = await getShiprocketRatesForOrder(req.scope, {
+    orderId,
+    carrier,
+    weightGrams:
+      weightGrams != null && Number.isFinite(weightGrams) && weightGrams > 0
+        ? weightGrams
+        : undefined,
+  })
+
+  res.status(200).json(result)
+}

--- a/apps/partner-ui/src/hooks/api/shiprocket.tsx
+++ b/apps/partner-ui/src/hooks/api/shiprocket.tsx
@@ -1,4 +1,9 @@
-import { useMutation, UseMutationOptions } from "@tanstack/react-query"
+import {
+  useMutation,
+  UseMutationOptions,
+  useQuery,
+  UseQueryOptions,
+} from "@tanstack/react-query"
 
 import { sdk } from "../../lib/client"
 import { queryClient } from "../../lib/query-client"
@@ -62,6 +67,57 @@ export const useGenerateShiprocketLabel = (
       queryClient.invalidateQueries({ queryKey: ordersQueryKeys.all })
       options?.onSuccess?.(data, variables, context)
     },
+    ...options,
+  })
+}
+
+// ── Courier rates (#641 partner mirror) ───────────────────────────────────────
+
+export type ShiprocketRateOption = {
+  courier_id?: string | number
+  courier_name?: string
+  amount: number
+  currency_code: string
+  estimated_days?: number
+  cod_charges?: number
+  is_recommended?: boolean
+}
+
+export type ShiprocketRatesResponse = {
+  origin_pincode: string
+  destination_pincode: string
+  weight_grams: number
+  cod: boolean
+  rates: ShiprocketRateOption[]
+}
+
+/**
+ * List the carrier's courier options (rate / ETA / recommended) for one of the
+ * partner's own orders, so the Mark-as-Shipped carrier step can show a picker
+ * before generating the label. On-demand: pass `enabled` to fetch only when the
+ * partner asks (the request hits the live carrier). `weightGrams` feeds the
+ * quote from the parcel weight entered in the same step.
+ */
+export const usePartnerShiprocketRates = (
+  orderId: string,
+  query?: { carrier?: string; weightGrams?: number },
+  options?: Omit<
+    UseQueryOptions<ShiprocketRatesResponse, FetchError>,
+    "queryFn" | "queryKey"
+  >
+) => {
+  const params = new URLSearchParams()
+  if (query?.carrier) params.set("carrier", query.carrier)
+  if (query?.weightGrams) params.set("weight_grams", String(query.weightGrams))
+  const qs = params.toString() ? `?${params.toString()}` : ""
+
+  return useQuery({
+    queryKey: [...ordersQueryKeys.detail(orderId), "shiprocket-rates", qs],
+    queryFn: () =>
+      sdk.client.fetch<ShiprocketRatesResponse>(
+        `/partners/orders/${orderId}/shiprocket-rates${qs}`,
+        { method: "GET" }
+      ),
     ...options,
   })
 }

--- a/apps/partner-ui/src/routes/orders/order-create-shipment/components/order-create-shipment-form/carrier-tab.tsx
+++ b/apps/partner-ui/src/routes/orders/order-create-shipment/components/order-create-shipment-form/carrier-tab.tsx
@@ -2,6 +2,7 @@ import { AdminFulfillment } from "@medusajs/types"
 import {
   Badge,
   Button,
+  clx,
   Heading,
   Input,
   Label,
@@ -16,6 +17,7 @@ import { z as zod } from "@medusajs/framework/zod"
 import {
   useAttachShiprocketAwb,
   useGenerateShiprocketLabel,
+  usePartnerShiprocketRates,
 } from "../../../../../hooks/api/shiprocket"
 import {
   CreateShipmentSchema,
@@ -90,6 +92,40 @@ export const CarrierTab = ({
   const { mutateAsync: attachAwb, isPending: isAttaching } =
     useAttachShiprocketAwb(orderId)
 
+  // Courier selection (#641). Shiprocket-only — Delhivery auto-assigns and has
+  // no courier picker. Fetched on demand (the request hits the live carrier),
+  // quoting against the parcel weight entered above. A chosen courier threads
+  // into generate as `preferred_courier_id`; none → the carrier auto-selects.
+  const isShiprocket = carrier === "shiprocket"
+  const [ratesRequested, setRatesRequested] = useState(false)
+  const [rateWeight, setRateWeight] = useState<number | undefined>(undefined)
+  const [selectedCourierId, setSelectedCourierId] = useState<
+    string | number | undefined
+  >(undefined)
+
+  const {
+    data: ratesData,
+    isFetching: ratesLoading,
+    error: ratesError,
+  } = usePartnerShiprocketRates(
+    orderId,
+    { weightGrams: rateWeight },
+    { enabled: ratesRequested && isShiprocket && !existingAwb }
+  )
+
+  const numeric = (v: unknown) => {
+    const n = Number(v)
+    return Number.isFinite(n) && n > 0 ? n : undefined
+  }
+
+  const handleGetRates = () => {
+    // Quote against the weight typed in the parcel block, so the estimate
+    // matches the parcel that will actually ship.
+    setRateWeight(numeric(form.getValues().weight_grams))
+    setSelectedCourierId(undefined)
+    setRatesRequested(true)
+  }
+
   const handleGenerate = async () => {
     try {
       // Parcel details drive the carrier's weight/dimension pricing and the
@@ -109,7 +145,13 @@ export const CarrierTab = ({
       const dimensions_cm =
         length && width && height ? { length, width, height } : undefined
 
-      const res = await generateLabel({ carrier, weight_grams, dimensions_cm })
+      const res = await generateLabel({
+        carrier,
+        weight_grams,
+        dimensions_cm,
+        // Only meaningful for Shiprocket; ignored by carriers that auto-assign.
+        preferred_courier_id: isShiprocket ? selectedCourierId : undefined,
+      })
       const label = res?.shiprocket_label
       const awb = label?.awb || label?.tracking_number
       if (!awb) {
@@ -247,6 +289,90 @@ export const CarrierTab = ({
             </div>
           ) : null}
 
+          {/* Courier selection — Shiprocket only. Quote couriers by rate/ETA and
+              pick one before generating; skipping this lets Shiprocket
+              auto-select. Delhivery has no courier picker (it auto-assigns). */}
+          {!existingAwb && isShiprocket ? (
+            <div className="flex flex-col gap-y-2 border-t pt-4">
+              <div className="flex items-center justify-between">
+                <Label size="xsmall">Courier</Label>
+                <Button
+                  type="button"
+                  variant="secondary"
+                  size="small"
+                  onClick={handleGetRates}
+                  isLoading={ratesLoading}
+                >
+                  {ratesRequested ? "Refresh rates" : "Get courier rates"}
+                </Button>
+              </div>
+              <Text size="small" className="text-ui-fg-subtle">
+                Compare couriers by price and delivery estimate. Optional —
+                leave it and Shiprocket picks the recommended courier.
+              </Text>
+
+              {ratesError ? (
+                <Text size="small" className="text-ui-fg-error">
+                  {(ratesError as any)?.message || "Couldn't load courier rates."}
+                </Text>
+              ) : null}
+
+              {ratesRequested && !ratesLoading && ratesData ? (
+                ratesData.rates?.length ? (
+                  <div className="flex flex-col gap-y-2">
+                    {ratesData.rates.map((r, i) => {
+                      const id = r.courier_id ?? `rate-${i}`
+                      const isSel = selectedCourierId === r.courier_id
+                      return (
+                        <button
+                          type="button"
+                          key={id}
+                          onClick={() => setSelectedCourierId(r.courier_id)}
+                          className={clx(
+                            "flex items-center justify-between rounded-lg border px-3 py-2 text-left",
+                            {
+                              "border-ui-border-interactive bg-ui-bg-highlight":
+                                isSel,
+                              "border-ui-border-base hover:bg-ui-bg-subtle-hover":
+                                !isSel,
+                            }
+                          )}
+                        >
+                          <div className="flex flex-col">
+                            <div className="flex items-center gap-x-2">
+                              <Text size="small" weight="plus">
+                                {r.courier_name || `Courier ${id}`}
+                              </Text>
+                              {r.is_recommended ? (
+                                <Badge size="2xsmall" color="green">
+                                  Recommended
+                                </Badge>
+                              ) : null}
+                            </div>
+                            {r.estimated_days != null ? (
+                              <Text size="xsmall" className="text-ui-fg-subtle">
+                                Est. {r.estimated_days} day
+                                {r.estimated_days === 1 ? "" : "s"}
+                              </Text>
+                            ) : null}
+                          </div>
+                          <Text size="small" weight="plus">
+                            {r.currency_code?.toUpperCase()} {r.amount}
+                          </Text>
+                        </button>
+                      )
+                    })}
+                  </div>
+                ) : (
+                  <Text size="small" className="text-ui-fg-subtle">
+                    No couriers serviced this route. You can still generate a
+                    label — Shiprocket will auto-assign.
+                  </Text>
+                )
+              ) : null}
+            </div>
+          ) : null}
+
           <div>
             <Button
               type="button"
@@ -255,6 +381,9 @@ export const CarrierTab = ({
               isLoading={isGenerating}
             >
               Generate {carrierLabel} label
+              {selectedCourierId != null && isShiprocket
+                ? " (selected courier)"
+                : ""}
             </Button>
           </div>
         </div>


### PR DESCRIPTION
Second addition to the Mark-as-Shipped flow. The partner label flow only ever let Shiprocket **auto-assign** a courier. The admin design-orders page has had a rate/ETA courier picker since #641; partners had no equivalent. This adds the same picker to the Carrier step.

## Change

- **New route** `GET /partners/orders/:id/shiprocket-rates` — partner mirror of `GET /admin/orders/:id/shiprocket-rates`. Guarded by `validatePartnerOrderOwnership` (a foreign order 404s before any carrier call). **Read-only** — wraps the existing `getShiprocketRatesForOrder`, no new carrier logic. `?carrier=` / `?weight_grams=` refine the quote.
- Middleware matcher (CORS + partner auth) next to the label route.
- **Hook** `usePartnerShiprocketRates` — on-demand (`enabled` gated), since the request hits the live carrier; fetches only when the partner clicks **Get courier rates**.
- **Carrier tab** gains a Courier section under Parcel: courier cards with price + ETA + a Recommended badge; the chosen `courier_id` threads into generate as `preferred_courier_id`. The quote uses the parcel weight entered in the same step.

Shiprocket-only — Delhivery auto-assigns and has no picker. Skipping selection keeps auto-assign (unchanged behaviour), so this is purely additive.

## Flow, now complete for the Carrier step

`Pick provider → enter parcel (weight/dims) → get courier rates → pick courier → generate label`

## Verify

```bash
pnpm test:integration:http:shared ./integration-tests/http/partner-order-shiprocket-label.spec.ts   # 8/8
```

Two new tests: rates listed for a partner-owned order (recommended courier present), and a rates request for an unowned order rejected before any carrier work. Backend tsc 79, partner-ui tsc 4 (pre-existing).

Scope: partner Mark-as-Shipped only. Admin already has this picker on design-orders.

🤖 Generated with [Claude Code](https://claude.com/claude-code)