### PR TITLE
fix(shipping): international Shiprocket delivery block, rates and declared value

### DIFF
--- a/apps/backend/src/modules/shipping-providers/shiprocket/__tests__/create-international-shipment.unit.spec.ts
+++ b/apps/backend/src/modules/shipping-providers/shiprocket/__tests__/create-international-shipment.unit.spec.ts
@@ -58,12 +58,17 @@ describe("toShiprocketCountryName", () => {
 })
 
 describe("resolveCustomsDefaults", () => {
-  it("defaults to a commercial FOB export", () => {
+  // "C" (export against IGST payment), not "A". A complete commercial export
+  // body classifies as CSB-5 at Shiprocket, and CSB-5 rejects "A" at create
+  // time: "IGST can not be Not Applicable in case of CSB5 shipments."
+  // (live-verified). "C" rather than "B" because the LUT has no ARN yet —
+  // claiming LUT/bond without one on file would be a false declaration.
+  it("defaults to a commercial FOB export declaring IGST paid", () => {
     expect(resolveCustomsDefaults()).toEqual({
       reasonOfExport: 3,
       purpose_of_shipment: 2,
       Terms_Of_Invoice: "FOB",
-      igstPaymentStatus: "A",
+      igstPaymentStatus: "C",
       commodity: true,
     })
   })
@@ -71,6 +76,25 @@ describe("resolveCustomsDefaults", () => {
     expect(
       resolveCustomsDefaults({ reason_of_export: 2, terms_of_invoice: "CIF" })
     ).toMatchObject({ reasonOfExport: 2, Terms_Of_Invoice: "CIF" })
+  })
+  it("switches to LUT/bond once the exporter has one on file", () => {
+    expect(
+      resolveCustomsDefaults({ igst_payment_status: "B" })
+    ).toMatchObject({ igstPaymentStatus: "B" })
+  })
+  it("takes the account-wide default from the environment", () => {
+    const prev = process.env.SHIPROCKET_IGST_PAYMENT_STATUS
+    process.env.SHIPROCKET_IGST_PAYMENT_STATUS = "B"
+    try {
+      expect(resolveCustomsDefaults()).toMatchObject({ igstPaymentStatus: "B" })
+      // An explicit per-shipment value still wins over the env.
+      expect(
+        resolveCustomsDefaults({ igst_payment_status: "C" })
+      ).toMatchObject({ igstPaymentStatus: "C" })
+    } finally {
+      if (prev === undefined) delete process.env.SHIPROCKET_IGST_PAYMENT_STATUS
+      else process.env.SHIPROCKET_IGST_PAYMENT_STATUS = prev
+    }
   })
 })
 
@@ -86,12 +110,47 @@ describe("buildInternationalCreateBody", () => {
       reasonOfExport: 3,
       purpose_of_shipment: 2,
       Terms_Of_Invoice: "FOB",
-      igstPaymentStatus: "A",
+      igstPaymentStatus: "C",
       commodity: true,
       sub_total: 80,
     })
     expect(body.order_items[0]).toMatchObject({ sku: "SCARF-1", hsn: "6214", units: 2 })
   })
+
+  // The bug behind `assign/awb` 400 ["Delivery pincode is empty","Customer phone
+  // is empty"]: the international pipeline does NOT honour shipping_is_billing,
+  // so the delivery block has to be sent field-by-field.
+  it("sends an explicit shipping_* delivery block rather than relying on shipping_is_billing", () => {
+    const body = buildInternationalCreateBody(usInput(), "warehouse-abc")
+    expect(body.shipping_is_billing).toBe(false)
+    expect(body).toMatchObject({
+      shipping_pincode: body.billing_pincode,
+      shipping_phone: body.billing_phone,
+      shipping_address: body.billing_address,
+      shipping_city: body.billing_city,
+      shipping_state: body.billing_state,
+      shipping_country: "United States",
+    })
+    for (const f of ["shipping_pincode", "shipping_phone"] as const) {
+      expect(String(body[f] ?? "")).not.toBe("")
+    }
+  })
+
+  it.each([
+    ["phone", { phone: "" }],
+    ["pincode", { pincode: "" }],
+    ["address", { address_1: "" }],
+    ["city", { city: "" }],
+  ])(
+    "refuses to build a body missing the delivery %s (carrier 400s two calls later)",
+    (field, patch) => {
+      const input = usInput()
+      Object.assign(input.to, patch)
+      expect(() => buildInternationalCreateBody(input, "warehouse-abc")).toThrow(
+        new RegExp(field)
+      )
+    }
+  )
 
   it("throws when any line is missing an HSN code (mandatory internationally)", () => {
     const input = usInput({

--- a/apps/backend/src/modules/shipping-providers/shiprocket/__tests__/describe-intl-prereq-error.unit.spec.ts
+++ b/apps/backend/src/modules/shipping-providers/shiprocket/__tests__/describe-intl-prereq-error.unit.spec.ts
@@ -48,6 +48,16 @@ describe("describeIntlPrereqError (#1118)", () => {
     expect(g?.reason).toBe("kyc")
   })
 
+  it("names a wallet shortfall so it isn't mistaken for bad order data", () => {
+    // Arrives as awb_assign_error on an HTTP 200 (see assertAwbAssigned).
+    const g = describeIntlPrereqError({
+      message:
+        "Shiprocket AWB assignment failed — Insufficient amount to label this shipment",
+    })
+    expect(g?.reason).toBe("insufficient_balance")
+    expect(g?.message).toMatch(/wallet/i)
+  })
+
   it("returns null for an unrelated error (caller rethrows untouched)", () => {
     expect(
       describeIntlPrereqError({ message: "HSN code is required for international shipments" })

--- a/apps/backend/src/modules/shipping-providers/shiprocket/__tests__/international-rates.unit.spec.ts
+++ b/apps/backend/src/modules/shipping-providers/shiprocket/__tests__/international-rates.unit.spec.ts
@@ -1,0 +1,236 @@
+import {
+  assertAwbAssigned,
+  normalizeInternationalRate,
+  ShiprocketClient,
+} from "../client"
+
+/**
+ * Two silent-failure shapes in Shiprocket's international responses, both
+ * live-verified against the account on 2026-08-06. Each one used to produce a
+ * plausible-looking result instead of an error, which is why they survived: a
+ * courier picker full of ₹0 options, and a "successful" label with no AWB.
+ */
+
+describe("normalizeInternationalRate", () => {
+  // Verbatim shape from GET /international/courier/serviceability. Note `rate`
+  // is an OBJECT and `estimated_delivery_days` is a STRING RANGE — the domestic
+  // response has a numeric `rate` and numeric days, and reusing that mapper
+  // turned every international quote into amount 0 / ETA NaN.
+  const live = {
+    courier_company_id: 381,
+    courier_name: "SRX Premium",
+    is_international: 1,
+    etd: "Aug 16, 2026 - Aug 18, 2026",
+    estimated_delivery_days: "10 - 12",
+    rate: {
+      courier_id: 381,
+      rate: 1125,
+      zone: "default",
+      extra_info: { edd: { to: 12, from: 10 } },
+      charge_exclusion: 0,
+    },
+  }
+
+  it("reads the amount out of the nested rate object, not Number(rate)", () => {
+    // The regression guard: Number({...}) is NaN, which `|| 0` quietly turned
+    // into a free-looking shipment.
+    expect(Number(live.rate)).toBeNaN()
+    expect(normalizeInternationalRate(live).amount).toBe(1125)
+  })
+
+  it("still accepts a flat numeric rate", () => {
+    expect(normalizeInternationalRate({ ...live, rate: 990 }).amount).toBe(990)
+  })
+
+  it("takes the ETA from the structured edd upper bound", () => {
+    expect(normalizeInternationalRate(live).estimated_days).toBe(12)
+  })
+
+  it("parses the high end of the '10 - 12' string when edd is absent", () => {
+    const { rate, ...noRateObj } = live
+    expect(
+      normalizeInternationalRate({ ...noRateObj, rate: 990 }).estimated_days
+    ).toBe(12)
+  })
+
+  it("leaves the ETA undefined rather than NaN when unparseable", () => {
+    expect(
+      normalizeInternationalRate({ ...live, rate: 990, estimated_delivery_days: "" })
+        .estimated_days
+    ).toBeUndefined()
+  })
+
+  it("defaults currency to INR (the intl payload carries none) but honours one if sent", () => {
+    expect(normalizeInternationalRate(live).currency_code).toBe("inr")
+    expect(
+      normalizeInternationalRate({ ...live, currency: "USD" }).currency_code
+    ).toBe("usd")
+  })
+
+  it("flags the recommended courier, comparing ids as strings", () => {
+    expect(normalizeInternationalRate(live, 381).is_recommended).toBe(true)
+    expect(normalizeInternationalRate(live, "381").is_recommended).toBe(true)
+    expect(normalizeInternationalRate(live, 384).is_recommended).toBe(false)
+    // No recommendation in the payload must not mark everything recommended.
+    expect(normalizeInternationalRate(live).is_recommended).toBe(false)
+  })
+
+  it("survives a courier object with nothing useful in it", () => {
+    expect(normalizeInternationalRate({})).toMatchObject({
+      amount: 0,
+      currency_code: "inr",
+      is_recommended: false,
+    })
+  })
+})
+
+describe("ShiprocketClient.getRates — endpoint routing by destination", () => {
+  let fetchSpy: jest.SpyInstance
+  afterEach(() => fetchSpy?.mockRestore())
+
+  const client = () =>
+    new ShiprocketClient({
+      email: "x@y.com",
+      password: "p",
+      token: "injected-token",
+      pickup_location: "warehouse-abc",
+    })
+
+  const spy = (payload: any) => {
+    const hits: string[] = []
+    const real = global.fetch?.bind(globalThis)
+    fetchSpy = jest
+      .spyOn(global, "fetch" as any)
+      .mockImplementation(async (input: any, init: any = {}) => {
+        const url = String(input)
+        if (!url.includes("shiprocket.in")) return real?.(input, init)
+        hits.push(url.replace("https://apiv2.shiprocket.in/v1/external", ""))
+        return {
+          ok: true,
+          status: 200,
+          json: async () => payload,
+          text: async () => JSON.stringify(payload),
+        } as any
+      })
+    return hits
+  }
+
+  const intlPayload = {
+    data: {
+      recommended_courier_company_id: 381,
+      available_courier_companies: [
+        {
+          courier_company_id: 381,
+          courier_name: "SRX Premium",
+          estimated_delivery_days: "10 - 12",
+          rate: { rate: 1125, extra_info: { edd: { to: 12, from: 10 } } },
+        },
+      ],
+    },
+  }
+
+  // The zero-rates bug: a foreign destination went to the India-only pincode
+  // endpoint, which answers 200 with an empty courier list — an empty picker
+  // rather than an error.
+  it("sends a foreign destination to /international/courier/serviceability", async () => {
+    const hits = spy(intlPayload)
+    const rates = await client().getRates({
+      origin_pincode: "176215",
+      destination_pincode: "10001",
+      destination_country: "US",
+      weight_grams: 500,
+    })
+    expect(hits.some((h) => h.startsWith("/international/courier/serviceability"))).toBe(true)
+    expect(hits.some((h) => h.startsWith("/courier/serviceability"))).toBe(false)
+    expect(rates[0]).toMatchObject({ courier_id: 381, amount: 1125, estimated_days: 12 })
+  })
+
+  // Live-verified: the country mode 400s without pickup_postcode, so the origin
+  // must be on the query string.
+  it("passes the origin as pickup_postcode plus the ISO-2 delivery country", async () => {
+    const hits = spy(intlPayload)
+    await client().getRates({
+      origin_pincode: "176215",
+      destination_pincode: "",
+      destination_country: "il",
+      weight_grams: 750,
+    })
+    const url = hits.find((h) => h.startsWith("/international/"))!
+    expect(url).toContain("pickup_postcode=176215")
+    expect(url).toContain("delivery_country=IL")
+    expect(url).toContain("weight=0.75")
+    expect(url).toContain("cod=0")
+  })
+
+  it("refuses a cross-border quote with no origin instead of sending a known-400", async () => {
+    spy(intlPayload)
+    await expect(
+      client().getRates({
+        origin_pincode: "",
+        destination_pincode: "",
+        destination_country: "US",
+        weight_grams: 500,
+      })
+    ).rejects.toThrow(/pickup pincode/i)
+  })
+
+  it("keeps India (and an unset country) on the domestic endpoint", async () => {
+    for (const destination_country of ["IN", "India", undefined]) {
+      const hits = spy({
+        data: {
+          recommended_courier_company_id: 5,
+          available_courier_companies: [
+            { courier_company_id: 5, courier_name: "Delhivery Surface", rate: 60 },
+          ],
+        },
+      })
+      const rates = await client().getRates({
+        origin_pincode: "176215",
+        destination_pincode: "560001",
+        destination_country,
+        weight_grams: 500,
+      })
+      expect(hits.some((h) => h.startsWith("/courier/serviceability"))).toBe(true)
+      expect(hits.some((h) => h.includes("/international/"))).toBe(false)
+      expect(rates[0]).toMatchObject({ amount: 60, currency_code: "inr" })
+      fetchSpy.mockRestore()
+    }
+  })
+})
+
+describe("assertAwbAssigned", () => {
+  it("passes through a real assignment", () => {
+    expect(() =>
+      assertAwbAssigned({ response: { data: { awb_code: "SR123456789" } } })
+    ).not.toThrow()
+  })
+
+  // The live failure: HTTP 200, awb_assign_status 0, no awb_code. The old code
+  // read `awb_code || ""` and reported success with a blank tracking number.
+  it("throws on the 200-with-awb_assign_error shape, quoting the carrier reason", () => {
+    expect(() =>
+      assertAwbAssigned({
+        awb_assign_status: 0,
+        response: {
+          data: {
+            courier_id: 384,
+            awb_assign_error: "Insufficient amount to label this shipment",
+          },
+        },
+      })
+    ).toThrow(/Insufficient amount to label this shipment/)
+  })
+
+  it("throws when there is no AWB and no stated reason", () => {
+    expect(() => assertAwbAssigned({ response: { data: {} } })).toThrow(
+      /assigned no AWB/
+    )
+    expect(() => assertAwbAssigned({})).toThrow(/assigned no AWB/)
+  })
+
+  it("falls back to a top-level message when present", () => {
+    expect(() =>
+      assertAwbAssigned({ message: "Courier not serviceable for this pincode" })
+    ).toThrow(/Courier not serviceable/)
+  })
+})

--- a/apps/backend/src/modules/shipping-providers/shiprocket/client.ts
+++ b/apps/backend/src/modules/shipping-providers/shiprocket/client.ts
@@ -141,7 +141,11 @@ export function parseShiprocketError(raw: string): {
  * it's deliberately conservative: returns `null` for anything unrecognised, and
  * the caller rethrows the original error untouched. Pure + unit-tested.
  */
-export type IntlPrereqReason = "kyc" | "bank_details" | "pickup_not_intl"
+export type IntlPrereqReason =
+  | "kyc"
+  | "bank_details"
+  | "pickup_not_intl"
+  | "insufficient_balance"
 
 export type IntlPrereqGate = { reason: IntlPrereqReason; message: string }
 
@@ -170,6 +174,25 @@ export function describeIntlPrereqError(err: {
       reason: "pickup_not_intl",
       message:
         "This pickup location isn't enabled for international shipping in Shiprocket. Enable international shipping for the pickup address in your Shiprocket dashboard (Settings → Pickup Addresses), or choose an international-capable pickup, then retry generating the label.",
+    }
+  }
+
+  // Wallet balance. Live-verified 2026-08-06: this arrives as
+  // `awb_assign_error: "Insufficient amount to label this shipment"` on an HTTP
+  // 200 (see assertAwbAssigned) — the address was fine, the account just can't
+  // pay for the waybill. Worth naming because it's indistinguishable from a data
+  // problem otherwise.
+  if (
+    (text.includes("insufficient") || text.includes("low balance")) &&
+    (text.includes("amount") ||
+      text.includes("balance") ||
+      text.includes("wallet") ||
+      text.includes("label"))
+  ) {
+    return {
+      reason: "insufficient_balance",
+      message:
+        "Your Shiprocket wallet doesn't have enough balance to book this waybill. Top up the wallet in your Shiprocket dashboard (Billing → Recharge), then retry generating the label. The shipment details were accepted — only payment is missing.",
     }
   }
 
@@ -366,12 +389,25 @@ export function resolveCustomsDefaults(
   customs?: import("../provider-interface").CustomsDeclaration
 ): ResolvedCustoms {
   return {
-    // A retail order is a commercial sale, shipped FOB, IGST not-applicable
-    // (LUT/bond is an account-level export scheme, not per-shipment here).
+    // A retail order is a commercial sale, shipped FOB.
     reasonOfExport: customs?.reason_of_export ?? 3, // COMMERCIAL
     purpose_of_shipment: customs?.purpose_of_shipment ?? 2, // commercial
     Terms_Of_Invoice: customs?.terms_of_invoice ?? "FOB",
-    igstPaymentStatus: customs?.igst_payment_status ?? "A",
+    // IGST: was "A" (not applicable). Live-verified 2026-08-06 that a complete
+    // commercial export body classifies as CSB-5, and CSB-5 REJECTS "A" at
+    // create time: "IGST can not be Not Applicable in case of CSB5 shipments."
+    // An export of goods is zero-rated either way — this field only says HOW the
+    // Indian exporter discharges that: "B" = LUT/bond on file (no IGST paid),
+    // "C" = IGST paid and reclaimed.
+    //
+    // Default "C": as of 2026-08-06 the LUT is applied for but has NO ARN yet,
+    // and declaring "B" without an LUT on file is a false declaration. Flip to
+    // "B" once the ARN is issued — via SHIPROCKET_IGST_PAYMENT_STATUS (no code
+    // change), or per-shipment through the customs declaration.
+    igstPaymentStatus:
+      customs?.igst_payment_status ??
+      (process.env.SHIPROCKET_IGST_PAYMENT_STATUS as "A" | "B" | "C") ??
+      "C",
     commodity: customs?.commodity ?? true,
   }
 }
@@ -401,6 +437,27 @@ export function buildInternationalCreateBody(
       `HSN code is required for international shipments; missing on: ${missingHsn.join(", ")}`
     )
   }
+  // Pre-flight the delivery fields Shiprocket rejects downstream. Without this
+  // an empty phone or pincode only surfaces at assign/awb as
+  // `["Delivery pincode is empty","Customer phone is empty"]` — a 400 two calls
+  // deep, after an order has already been created carrier-side. Name them all at
+  // once so one round of data-fixing clears them (rather than one per attempt).
+  const missingTo = (
+    [
+      ["phone", input.to.phone],
+      ["pincode", input.to.pincode],
+      ["address", input.to.address_1],
+      ["city", input.to.city],
+    ] as const
+  )
+    .filter(([, v]) => !String(v ?? "").trim())
+    .map(([k]) => k)
+  if (missingTo.length) {
+    throw new MedusaError(
+      MedusaError.Types.INVALID_DATA,
+      `Shipping address is missing ${missingTo.join(", ")} — Shiprocket rejects an international shipment without ${missingTo.length > 1 ? "these" : "this"}. Add ${missingTo.length > 1 ? "them" : "it"} to the order's shipping address (or billing address / customer record) and retry.`
+    )
+  }
   const [firstName, ...rest] = (input.to.name || "Customer").split(" ")
   const lastName = rest.join(" ")
   const subTotal =
@@ -408,6 +465,9 @@ export function buildInternationalCreateBody(
     input.items.reduce((s, i) => s + i.unit_price * i.quantity, 0)
   const iso2 = (input.to.country || "").trim().toUpperCase()
   const customs = resolveCustomsDefaults(input.customs)
+
+  const state = nonEmptyCode(input.to.state) || input.to.city
+  const countryName = toShiprocketCountryName(input.to.country)
 
   return {
     order_id: input.reference_id,
@@ -425,12 +485,30 @@ export function buildInternationalCreateBody(
     // buyer left it blank) — it 422s with "The billing state field is required".
     // Fall back to the city, which is what Shiprocket's own support advises for
     // stateless addresses, so a valid order isn't blocked on an empty field.
-    billing_state: nonEmptyCode(input.to.state) || input.to.city,
-    billing_country: toShiprocketCountryName(input.to.country),
+    billing_state: state,
+    billing_country: countryName,
     billing_email: input.to.email || "",
     billing_phone: input.to.phone,
     ...(ISD_BY_ISO2[iso2] ? { isd_code: ISD_BY_ISO2[iso2] } : {}),
-    shipping_is_billing: true,
+    // The DELIVERY block must be sent explicitly. `shipping_is_billing: true` is
+    // NOT honored by the international pipeline: create/adhoc returns 200 and
+    // `/orders/show` even echoes the copied address back, but
+    // `/international/courier/assign/awb` then 400s with
+    // `["Delivery pincode is empty","Customer phone is empty"]` — the intl
+    // shipment record never got a delivery address. Live-verified 2026-08-06:
+    // billing-only + the flag → assign 400; the same order with an explicit
+    // shipping_* block → assign 200. Domestic is unaffected (it honors the flag).
+    shipping_is_billing: false,
+    shipping_customer_name: firstName,
+    shipping_last_name: lastName,
+    shipping_address: input.to.address_1,
+    shipping_address_2: input.to.address_2 || "",
+    shipping_city: input.to.city,
+    shipping_pincode: input.to.pincode,
+    shipping_state: state,
+    shipping_country: countryName,
+    shipping_email: input.to.email || "",
+    shipping_phone: input.to.phone,
     order_items: items,
     payment_method: "Prepaid",
     sub_total: subTotal,
@@ -446,6 +524,81 @@ export function buildInternationalCreateBody(
     igstPaymentStatus: customs.igstPaymentStatus,
     commodity: customs.commodity,
   }
+}
+
+/**
+ * Normalize one courier from `/international/courier/serviceability` into a
+ * `RateOption`. Pure & exported because the international response shape differs
+ * from the domestic one in two ways that both silently produced garbage
+ * (live-verified 2026-08-06):
+ *
+ *  · `rate` is an OBJECT (`{ rate: 1125, zone, extra_info: { edd } }`), not a
+ *    number. `Number(c.rate)` is NaN, so every international quote came out as
+ *    amount 0 — an empty-looking courier picker and a `courier_rate: 0` stamped
+ *    on the shipment by the auto-select path.
+ *  · `estimated_delivery_days` is a STRING RANGE ("10 - 12"), not a number, so
+ *    `Number(...)` was NaN. The structured `rate.extra_info.edd.{from,to}` is
+ *    the reliable source; the string is the fallback.
+ *
+ * The international payload carries no `currency` field, and these accounts are
+ * billed in INR, so INR is the fallback — but an explicit currency still wins if
+ * Shiprocket ever starts sending one.
+ */
+export function normalizeInternationalRate(
+  c: any,
+  recommendedId?: number | string
+): RateOption {
+  const rateObj = c?.rate && typeof c.rate === "object" ? c.rate : undefined
+  const amount = Number(rateObj ? rateObj.rate : c?.rate) || 0
+  // Prefer the structured upper bound (the promise we'd show a customer), then
+  // the high end of the "10 - 12" string, then a bare number.
+  const eddTo = Number(rateObj?.extra_info?.edd?.to)
+  // `Number("")` is 0, not NaN — so an absent ETA has to be rejected on the
+  // string being empty, or it reports as a 0-day delivery promise.
+  const eddText = String(c?.estimated_delivery_days ?? "")
+    .split(/[-–]/)
+    .pop()
+    ?.trim()
+  const parsedDays = Number.isFinite(eddTo)
+    ? eddTo
+    : eddText
+      ? Number(eddText)
+      : NaN
+  return {
+    courier_id: c?.courier_company_id,
+    courier_name: c?.courier_name,
+    amount,
+    currency_code: (c?.currency || rateObj?.currency || "inr")
+      .toString()
+      .toLowerCase(),
+    estimated_days: Number.isFinite(parsedDays) ? parsedDays : undefined,
+    is_recommended:
+      recommendedId != null &&
+      String(c?.courier_company_id) === String(recommendedId),
+  }
+}
+
+/**
+ * AWB assignment can FAIL WITH HTTP 200. Shiprocket answers
+ * `/courier/assign/awb` (domestic and international) with
+ * `{ awb_assign_status: 0, response: { data: { awb_assign_error: "..." } } }`
+ * and no `awb_code` — e.g. "Insufficient amount to label this shipment" (wallet
+ * balance) or a courier-side rejection. The old code read `awb_code || ""` and
+ * returned a shipment carrying a BLANK AWB and no error, so an operator saw a
+ * label step that appeared to succeed while nothing was ever booked. Throw
+ * instead, with the carrier's own reason. Pure & exported for unit testing.
+ */
+export function assertAwbAssigned(assigned: any): void {
+  const data = assigned?.response?.data || {}
+  if (data.awb_code) return
+  const reason =
+    data.awb_assign_error ||
+    assigned?.message ||
+    "Shiprocket assigned no AWB and gave no reason"
+  throw new ShiprocketApiError(
+    `Shiprocket AWB assignment failed — ${reason}`,
+    { status: 200, raw: JSON.stringify(assigned) }
+  )
 }
 
 /** Shiprocket numeric shipment_status_id → coarse scan_type. */
@@ -576,6 +729,19 @@ export class ShiprocketClient implements ShippingProviderClient {
   }
 
   async getRates(query: RateQuery): Promise<RateOption[]> {
+    // An international destination has to go through the `/international/*`
+    // serviceability endpoint — the domestic one takes a delivery PINCODE and
+    // simply returns no couriers for a foreign postcode, which surfaced as an
+    // empty courier picker rather than an error. Branch here (not at the call
+    // sites) so every rate caller — admin, partner, inventory-order — gets the
+    // right endpoint from the destination country alone.
+    if (isInternationalDestination(query.destination_country)) {
+      return this.getInternationalRates({
+        destination_country: query.destination_country,
+        weight_grams: query.weight_grams,
+        origin_pincode: query.origin_pincode,
+      })
+    }
     const qs = new URLSearchParams({
       pickup_postcode: query.origin_pincode,
       delivery_postcode: query.destination_pincode,
@@ -712,6 +878,7 @@ export class ShiprocketClient implements ShippingProviderClient {
 
     const srOrderId = created?.order_id
     const shipmentId = created?.shipment_id
+    assertAwbAssigned(assigned)
     const awbData = assigned?.response?.data || {}
     const awb = awbData.awb_code || ""
 
@@ -766,16 +933,27 @@ export class ShiprocketClient implements ShippingProviderClient {
     order_id?: string | number
     origin_pincode?: string
   }): Promise<RateOption[]> {
-    // Live-verified (#1111): the `order_id` mode is the ONLY one this account
-    // answers — passing an existing Shiprocket order id returns the available
-    // international couriers (+ the recommended one) priced in the order
-    // currency. The documented country+weight mode (below) 400s on the live
-    // account, so `order_id` takes precedence and we omit weight/country when
-    // it's present (they're ignored anyway per the docs).
+    // Two modes, BOTH live-verified 2026-08-06:
+    //  · `order_id` — prices an existing Shiprocket order in its own currency.
+    //    Used after create/adhoc to auto-select a courier.
+    //  · `delivery_country` + `weight` — quotes BEFORE any order exists, which
+    //    is what a pre-label courier picker needs.
+    // An earlier note here claimed the country mode "400s on the live account"
+    // and that `order_id` was the only one that answers. That was wrong: the
+    // country mode 400s ("Please fix request using below fields") only when
+    // `pickup_postcode` is omitted. With an origin it returns 200 + couriers.
+    // So the origin is REQUIRED in country mode — fail loudly rather than send
+    // a request we know comes back 400.
     const qs = new URLSearchParams({ cod: "0" })
     if (query.order_id != null) {
       qs.set("order_id", String(query.order_id))
     } else {
+      if (!query.origin_pincode) {
+        throw new MedusaError(
+          MedusaError.Types.INVALID_DATA,
+          "International courier rates need a pickup pincode (origin). Register a Shiprocket pickup location before requesting rates."
+        )
+      }
       qs.set("weight", String(Math.max(0.01, (query.weight_grams || 500) / 1000)))
       qs.set("delivery_country", (query.destination_country || "").toUpperCase())
     }
@@ -786,16 +964,7 @@ export class ShiprocketClient implements ShippingProviderClient {
     )
     const couriers = json?.data?.available_courier_companies || []
     const recommended = json?.data?.recommended_courier_company_id
-    return couriers.map((c: any) => ({
-      courier_id: c.courier_company_id,
-      courier_name: c.courier_name,
-      amount: Number(c.rate) || 0,
-      currency_code: (c.currency || "inr").toString().toLowerCase(),
-      estimated_days: c.estimated_delivery_days
-        ? Number(c.estimated_delivery_days)
-        : undefined,
-      is_recommended: c.courier_company_id === recommended,
-    }))
+    return couriers.map((c: any) => normalizeInternationalRate(c, recommended))
   }
 
   /**
@@ -879,6 +1048,7 @@ export class ShiprocketClient implements ShippingProviderClient {
 
     const srOrderId = created?.order_id
     const shipmentId = created?.shipment_id
+    assertAwbAssigned(assigned)
     const awbData = assigned?.response?.data || {}
     const awb = awbData.awb_code || ""
 

--- a/apps/backend/src/workflows/orders/__tests__/build-create-shipment-input.unit.spec.ts
+++ b/apps/backend/src/workflows/orders/__tests__/build-create-shipment-input.unit.spec.ts
@@ -1,5 +1,6 @@
 import {
   buildCreateShipmentInput,
+  selectFulfilledLines,
   type OrderForShipment,
 } from "../shiprocket-shipment"
 
@@ -115,7 +116,10 @@ describe("buildCreateShipmentInput (#404 PR-B)", () => {
     expect(input.items).toEqual([
       { name: "Custom Saree", sku: "SAR-1", quantity: 2, unit_price: 100 },
     ])
-    expect(input.sub_total).toBe(250)
+    // 200, not the fixture's `subtotal: 250` — that 250 carries shipping, and
+    // the declared value is goods only (2 × 100). See "declared value excludes
+    // shipping" below.
+    expect(input.sub_total).toBe(200)
     expect(input.weight_grams).toBe(500) // default
   })
 
@@ -136,6 +140,51 @@ describe("buildCreateShipmentInput (#404 PR-B)", () => {
     expect(input.pickup_location_name).toBe("")
     expect(input.sub_total).toBe(200) // 2 * 100
     expect(input.weight_grams).toBe(1200)
+  })
+
+  describe("declared value excludes shipping", () => {
+    // Live order order_01KXWHFP132AM0H940WFD2P0XW: item_total 241.85 +
+    // shipping_total 39 = subtotal 280.85. Declaring `subtotal` put the freight
+    // into the customs invoice — an inflated total that also contradicted the
+    // FOB terms we state, and inflated the duty the buyer pays on arrival.
+    const withShipping: OrderForShipment = {
+      ...baseOrder,
+      subtotal: 239, // 200 goods + 39 shipping
+      item_total: 200,
+      item_subtotal: 200,
+    }
+
+    it("declares the goods total, not the shipping-inclusive subtotal", () => {
+      const input = buildCreateShipmentInput(withShipping, { pickupLocationName: "wh" })
+      expect(input.sub_total).toBe(200)
+    })
+
+    it("keeps the declared total equal to the sum of the declared lines", () => {
+      const input = buildCreateShipmentInput(withShipping, { pickupLocationName: "wh" })
+      const lineSum = input.items.reduce((s, i) => s + i.unit_price * i.quantity, 0)
+      expect(input.sub_total).toBe(lineSum)
+    })
+
+    it("prefers the post-discount goods total over the pre-discount one", () => {
+      const input = buildCreateShipmentInput(
+        { ...withShipping, item_total: 180, item_subtotal: 200 },
+        { pickupLocationName: "wh" }
+      )
+      expect(input.sub_total).toBe(180)
+    })
+
+    it("falls back to the line sum when the goods totals are absent or zero", () => {
+      for (const patch of [
+        { item_total: null, item_subtotal: null },
+        { item_total: 0, item_subtotal: null },
+      ]) {
+        const input = buildCreateShipmentInput(
+          { ...withShipping, ...patch } as OrderForShipment,
+          { pickupLocationName: "wh" }
+        )
+        expect(input.sub_total).toBe(200)
+      }
+    })
   })
 
   describe("international customs fields (#1111)", () => {
@@ -340,5 +389,168 @@ describe("buildCreateShipmentInput (#404 PR-B)", () => {
       )
       expect(input.items[0].hsn).toBeUndefined()
     })
+  })
+})
+
+/**
+ * A shipment declares what's in the BOX. Declaring every order line on a partial
+ * fulfillment overstated the customs value and listed goods that weren't being
+ * shipped — a misdeclaration, and (for COD) a double charge at the door.
+ *
+ * Shapes here mirror live prod data (order_01KXWHFP132AM0H940WFD2P0XW): fulfillment
+ * items carry `line_item_id` + `quantity`, and their `title` is the VARIANT name
+ * ("Chrome Yellow", "S") while the order line carries the product name — so the
+ * join must be on the id.
+ */
+describe("selectFulfilledLines", () => {
+  const lines = [
+    { id: "ordli_1", title: "Shirt", quantity: 3, unit_price: 50 },
+    { id: "ordli_2", title: "Apron", quantity: 2, unit_price: 20 },
+    { id: "ordli_3", title: "Fanny", quantity: 1, unit_price: 15 },
+  ]
+
+  it("returns every line untouched when there are no fulfillment items", () => {
+    for (const fi of [undefined, null, []]) {
+      const r = selectFulfilledLines(lines, fi)
+      expect(r.items).toEqual(lines)
+      expect(r.partial).toBe(false)
+    }
+  })
+
+  it("keeps only the fulfilled lines", () => {
+    const r = selectFulfilledLines(lines, [
+      { line_item_id: "ordli_2", quantity: 2 },
+    ])
+    expect(r.items.map((i) => i.title)).toEqual(["Apron"])
+    expect(r.partial).toBe(true)
+  })
+
+  it("uses the fulfilled quantity, not the ordered quantity", () => {
+    // One line shipped across two boxes: this box has 1 of the 3 ordered.
+    const r = selectFulfilledLines(lines, [
+      { line_item_id: "ordli_1", quantity: 1 },
+    ])
+    expect(r.items[0]).toMatchObject({ title: "Shirt", quantity: 1 })
+    expect(r.partial).toBe(true)
+  })
+
+  it("is not partial when the fulfillment covers every line at full quantity", () => {
+    const r = selectFulfilledLines(lines, [
+      { line_item_id: "ordli_1", quantity: 3 },
+      { line_item_id: "ordli_2", quantity: 2 },
+      { line_item_id: "ordli_3", quantity: 1 },
+    ])
+    expect(r.items).toHaveLength(3)
+    expect(r.partial).toBe(false)
+  })
+
+  it("ignores fulfillment items that match no order line", () => {
+    const r = selectFulfilledLines(lines, [
+      { line_item_id: "ordli_2", quantity: 2 },
+      { line_item_id: "ordli_gone", quantity: 9 },
+    ])
+    expect(r.items.map((i) => i.title)).toEqual(["Apron"])
+  })
+
+  it("falls back to all lines when NOTHING resolves, never an empty declaration", () => {
+    // A missing field selection must degrade to the old behaviour, not ship a
+    // box declaring zero goods.
+    const r = selectFulfilledLines(lines, [{ line_item_id: null, quantity: 1 }])
+    expect(r.items).toEqual(lines)
+    expect(r.partial).toBe(false)
+  })
+
+  it("keeps the ordered quantity when the fulfilled one is missing or junk", () => {
+    for (const quantity of [null, 0, undefined] as any[]) {
+      const r = selectFulfilledLines(lines, [
+        { line_item_id: "ordli_1", quantity },
+      ])
+      expect(r.items[0].quantity).toBe(3)
+    }
+  })
+})
+
+describe("buildCreateShipmentInput — partial fulfillment", () => {
+  const order: OrderForShipment = {
+    id: "order_1",
+    email: "buyer@example.com",
+    total: 300,
+    subtotal: 300,
+    item_total: 261,
+    item_subtotal: 261,
+    metadata: {},
+    shipping_address: {
+      first_name: "Asha",
+      phone: "+919800000000",
+      address_1: "12 MG Road",
+      city: "Bengaluru",
+      province: "KA",
+      postal_code: "560001",
+      country_code: "in",
+    },
+    items: [
+      { id: "ordli_1", title: "Shirt", quantity: 3, unit_price: 50, sku: "SH-1" },
+      { id: "ordli_2", title: "Apron", quantity: 2, unit_price: 20, sku: "AP-1" },
+    ],
+  }
+
+  it("declares only the shipped line, at the shipped quantity and value", () => {
+    const input = buildCreateShipmentInput(order, {
+      pickupLocationName: "wh",
+      fulfillmentItems: [{ line_item_id: "ordli_2", quantity: 1 }],
+    })
+    expect(input.items).toEqual([
+      { name: "Apron", sku: "AP-1", quantity: 1, unit_price: 20, hsn: undefined },
+    ])
+    // 20, NOT the order's item_total of 261.
+    expect(input.sub_total).toBe(20)
+  })
+
+  it("ignores the order-level goods total on a partial shipment", () => {
+    const input = buildCreateShipmentInput(order, {
+      pickupLocationName: "wh",
+      fulfillmentItems: [{ line_item_id: "ordli_1", quantity: 2 }],
+    })
+    expect(input.sub_total).toBe(100) // 2 × 50
+    expect(input.sub_total).not.toBe(261)
+  })
+
+  it("still prefers the order goods total when the whole order ships", () => {
+    const input = buildCreateShipmentInput(order, {
+      pickupLocationName: "wh",
+      fulfillmentItems: [
+        { line_item_id: "ordli_1", quantity: 3 },
+        { line_item_id: "ordli_2", quantity: 2 },
+      ],
+    })
+    // 261 (post-discount goods) rather than the 190 the raw lines sum to.
+    expect(input.sub_total).toBe(261)
+  })
+
+  it("collects COD for this box only, never the whole order twice", () => {
+    const input = buildCreateShipmentInput(
+      { ...order, metadata: { payment_mode: "cod" } },
+      {
+        pickupLocationName: "wh",
+        fulfillmentItems: [{ line_item_id: "ordli_2", quantity: 1 }],
+      }
+    )
+    expect(input.payment_mode).toBe("cod")
+    expect(input.cod_amount).toBe(20)
+    expect(input.cod_amount).not.toBe(300)
+  })
+
+  it("still collects the full order total when everything ships together", () => {
+    const input = buildCreateShipmentInput(
+      { ...order, metadata: { payment_mode: "cod" } },
+      {
+        pickupLocationName: "wh",
+        fulfillmentItems: [
+          { line_item_id: "ordli_1", quantity: 3 },
+          { line_item_id: "ordli_2", quantity: 2 },
+        ],
+      }
+    )
+    expect(input.cod_amount).toBe(300)
   })
 })

--- a/apps/backend/src/workflows/orders/shiprocket-rates.ts
+++ b/apps/backend/src/workflows/orders/shiprocket-rates.ts
@@ -4,6 +4,7 @@ import {
 } from "@medusajs/framework/utils"
 import type { MedusaContainer } from "@medusajs/framework/types"
 import { resolveShippingProvider } from "../../modules/shipping-providers/resolver"
+import { isInternationalDestination } from "../../modules/shipping-providers/destination"
 import { SHIPROCKET_PICKUP_METADATA_KEY } from "../../modules/shipping-providers/pickup-locations"
 import type {
   PickupLocation,
@@ -52,6 +53,10 @@ export type ShiprocketRatesResult = {
   weight_grams: number
   cod: boolean
   rates: RateOption[]
+  /** Destination country (ISO-2). Present so the UI can label the quote. */
+  destination_country?: string
+  /** True when quoted through the carrier's cross-border product. */
+  international?: boolean
 }
 
 export async function getShiprocketRatesForOrder(
@@ -66,6 +71,12 @@ export async function getShiprocketRatesForOrder(
       "id",
       "metadata",
       "shipping_address.postal_code",
+      "shipping_address.country_code",
+      // Same fallback source the label flow walks (#1212): the postal code can
+      // land on the billing address instead, and quoting must not fail on a
+      // field the label call would have found.
+      "billing_address.postal_code",
+      "billing_address.country_code",
       "fulfillments.location_id",
     ],
     filters: { id: input.orderId },
@@ -79,9 +90,24 @@ export async function getShiprocketRatesForOrder(
   }
 
   const destinationPincode = String(
-    order.shipping_address?.postal_code || ""
+    order.shipping_address?.postal_code ||
+      order.billing_address?.postal_code ||
+      ""
   ).trim()
-  if (!destinationPincode) {
+  const destinationCountry = String(
+    order.shipping_address?.country_code ||
+      order.billing_address?.country_code ||
+      ""
+  )
+    .trim()
+    .toUpperCase()
+  const international = isInternationalDestination(destinationCountry)
+
+  // A cross-border quote is priced on destination COUNTRY + weight, not on a
+  // postcode, so a missing pincode must not block it — international couriers
+  // quote fine without one (and the label flow validates it separately, where it
+  // actually matters). Domestic serviceability genuinely needs the pincode.
+  if (!destinationPincode && !international) {
     throw new MedusaError(
       MedusaError.Types.INVALID_DATA,
       "Order has no shipping-address pincode to quote a delivery rate against."
@@ -127,9 +153,14 @@ export async function getShiprocketRatesForOrder(
   const cod = order.metadata?.payment_mode === "cod"
   const weightGrams = input.weightGrams || DEFAULT_WEIGHT_GRAMS
 
+  // `destination_country` is what makes the adapter reach for its cross-border
+  // product. Omitting it was why international orders came back with an empty
+  // courier list: the quote went to the India-only pincode endpoint, which has
+  // no couriers to offer for a foreign postcode and reports that as success.
   const rates = await provider.getRates({
     origin_pincode: originPincode,
     destination_pincode: destinationPincode,
+    destination_country: destinationCountry || undefined,
     weight_grams: weightGrams,
     cod,
   })
@@ -137,6 +168,8 @@ export async function getShiprocketRatesForOrder(
   return {
     origin_pincode: originPincode,
     destination_pincode: destinationPincode,
+    destination_country: destinationCountry || undefined,
+    international,
     weight_grams: weightGrams,
     cod,
     rates,

--- a/apps/backend/src/workflows/orders/shiprocket-shipment.ts
+++ b/apps/backend/src/workflows/orders/shiprocket-shipment.ts
@@ -53,6 +53,14 @@ export type OrderForShipment = {
   email?: string | null
   total?: number | null
   subtotal?: number | null
+  /**
+   * Goods-only value. `subtotal` is NOT it — in Medusa v2 `order.subtotal`
+   * INCLUDES shipping (verified on a live order: item_total 241.85 + shipping 39
+   * = subtotal 280.85), so it over-declares a customs invoice by the freight.
+   * `item_total` is post-discount, `item_subtotal` pre-discount.
+   */
+  item_total?: number | null
+  item_subtotal?: number | null
   /** ISO-4217 currency the order was placed in — declared value for intl customs (#1111). */
   currency_code?: string | null
   metadata?: Record<string, any> | null
@@ -62,6 +70,8 @@ export type OrderForShipment = {
   /** Fallback source for the buyer phone when neither address carries one. */
   customer?: { phone?: string | null; email?: string | null } | null
   items?: Array<{
+    /** Line id — the key `fulfillment.items[].line_item_id` points at. */
+    id?: string | null
     title?: string | null
     quantity?: number | null
     unit_price?: number | null
@@ -100,6 +110,12 @@ export function resolveLineHsn(
   )
 }
 
+/** One line of the fulfillment being shipped — what is actually in the box. */
+export type FulfillmentLine = {
+  line_item_id?: string | null
+  quantity?: number | null
+}
+
 export type BuildShipmentOpts = {
   pickupLocationName?: string
   weightGrams?: number
@@ -107,6 +123,58 @@ export type BuildShipmentOpts = {
   preferredCourierId?: string | number
   /** Seller tax/GST ID to stamp on the label (#348); resolved by the caller. */
   taxId?: string
+  /**
+   * The fulfillment's own lines. When given, ONLY these are declared, at these
+   * quantities — a shipment must describe what's in the box, not the whole
+   * order. Omitted (or unresolvable) falls back to every order line, which is
+   * correct for the single-fulfillment case and is what every caller did before.
+   */
+  fulfillmentItems?: FulfillmentLine[] | null
+}
+
+/**
+ * Restrict an order's lines to the ones this fulfillment actually ships, at the
+ * fulfilled quantity. Pure & exported: a partial fulfillment that declared the
+ * whole order overstated both the customs value AND the goods themselves —
+ * declaring items that aren't in the box is a misdeclaration, not a rounding
+ * error.
+ *
+ * Matching is by `line_item_id` only. Fulfillment items carry the VARIANT title
+ * ("Chrome Yellow", "S") while order lines carry the product title, so titles
+ * can't be joined on — and two lines of the same product would collide anyway.
+ *
+ * Returns the full list unchanged when there's nothing usable to filter by, so a
+ * missing field selection degrades to today's behaviour rather than shipping an
+ * empty declaration.
+ */
+export function selectFulfilledLines(
+  lines: NonNullable<OrderForShipment["items"]>,
+  fulfillmentItems?: FulfillmentLine[] | null
+): { items: NonNullable<OrderForShipment["items"]>; partial: boolean } {
+  if (!fulfillmentItems?.length) return { items: lines, partial: false }
+
+  const byId = new Map(
+    lines.filter((l) => l.id).map((l) => [String(l.id), l] as const)
+  )
+  const selected: NonNullable<OrderForShipment["items"]> = []
+  for (const fi of fulfillmentItems) {
+    const line = fi.line_item_id ? byId.get(String(fi.line_item_id)) : undefined
+    if (!line) continue
+    // The fulfilled quantity wins — one order line can be shipped across
+    // several fulfillments, and each may carry only part of it.
+    const qty = Number(fi.quantity)
+    selected.push({
+      ...line,
+      quantity: Number.isFinite(qty) && qty > 0 ? qty : line.quantity,
+    })
+  }
+  if (!selected.length) return { items: lines, partial: false }
+
+  const sameCount = selected.length === lines.length
+  const sameQty = selected.every(
+    (s) => Number(s.quantity) === Number(byId.get(String(s.id))?.quantity)
+  )
+  return { items: selected, partial: !(sameCount && sameQty) }
 }
 
 /**
@@ -135,7 +203,12 @@ export function buildCreateShipmentInput(
   const paymentMode: "prepaid" | "cod" =
     order.metadata?.payment_mode === "cod" ? "cod" : "prepaid"
 
-  const items: ShipmentItem[] = (order.items || []).map((li) => ({
+  // Declare what's in THIS box, not the whole order.
+  const { items: fulfilledLines, partial } = selectFulfilledLines(
+    order.items || [],
+    opts.fulfillmentItems
+  )
+  const items: ShipmentItem[] = fulfilledLines.map((li) => ({
     name: li.title || "Item",
     sku: li.sku || undefined,
     quantity: Number(li.quantity) || 1,
@@ -145,10 +218,24 @@ export function buildCreateShipmentInput(
     // requires it only when the destination is international.
     hsn: resolveLineHsn(li),
   }))
-  const subTotal =
-    order.subtotal != null
-      ? Number(order.subtotal)
-      : items.reduce((s, i) => s + i.unit_price * i.quantity, 0)
+  // Declared value = GOODS ONLY, and it must agree with the line items we send
+  // (the carrier shows the invoice total, and customs duty abroad is charged on
+  // it). `order.subtotal` includes shipping, so using it declared freight as
+  // merchandise — inflating the total by the shipping charge and contradicting
+  // the FOB terms we state, where freight is the buyer's cost, not part of the
+  // invoice value. Prefer the goods figures; fall back to the line sum, which is
+  // by construction consistent with what we declare.
+  const lineSum = items.reduce((s, i) => s + i.unit_price * i.quantity, 0)
+  // On a PARTIAL shipment the order-level goods totals describe the whole order,
+  // so only the line sum can describe this box.
+  const goodsTotal = partial
+    ? lineSum
+    : order.item_total != null
+      ? Number(order.item_total)
+      : order.item_subtotal != null
+        ? Number(order.item_subtotal)
+        : lineSum
+  const subTotal = Number.isFinite(goodsTotal) && goodsTotal > 0 ? goodsTotal : lineSum
 
   const name =
     [addr.first_name, addr.last_name].filter(Boolean).join(" ") || "Customer"
@@ -156,8 +243,16 @@ export function buildCreateShipmentInput(
   return {
     reference_id: order.id,
     payment_mode: paymentMode,
+    // A partial shipment must not collect the WHOLE order at the door — two
+    // boxes would each ask the customer for the full order total. Collect only
+    // what this box is worth; the full order total stays correct for the normal
+    // ship-everything case.
     cod_amount:
-      paymentMode === "cod" ? Number(order.total) || subTotal : undefined,
+      paymentMode === "cod"
+        ? partial
+          ? subTotal
+          : Number(order.total) || subTotal
+        : undefined,
     // "" lets the client fall back to its configured default pickup location.
     pickup_location_name: opts.pickupLocationName || "",
     to: {
@@ -210,6 +305,7 @@ export async function createShiprocketShipmentForFulfillment(
 ): Promise<ShipmentResult & { fulfillment_id: string }> {
   const query: any = container.resolve(ContainerRegistrationKeys.QUERY)
   const fulfillmentModule: any = container.resolve(Modules.FULFILLMENT)
+  const logger: any = container.resolve(ContainerRegistrationKeys.LOGGER)
 
   const { data: orders } = await query.graph({
     entity: "order",
@@ -218,6 +314,10 @@ export async function createShiprocketShipmentForFulfillment(
       "email",
       "total",
       "subtotal",
+      // Goods-only totals — `subtotal` includes shipping and must not be used as
+      // the declared customs value.
+      "item_total",
+      "item_subtotal",
       "currency_code",
       "metadata",
       "shipping_address.*",
@@ -225,6 +325,8 @@ export async function createShiprocketShipmentForFulfillment(
       "billing_address.*",
       "customer.phone",
       "customer.email",
+      // Line id — the join key for `fulfillment.items[].line_item_id`.
+      "items.id",
       "items.title",
       "items.quantity",
       "items.unit_price",
@@ -237,6 +339,11 @@ export async function createShiprocketShipmentForFulfillment(
       "fulfillments.id",
       "fulfillments.location_id",
       "fulfillments.data",
+      // What is actually in the box. Must be named explicitly — the default order
+      // payload returns `fulfillments.items` EMPTY, so the shipment silently
+      // declared every line of the order instead.
+      "fulfillments.items.line_item_id",
+      "fulfillments.items.quantity",
     ],
     filters: { id: input.orderId },
   })
@@ -351,12 +458,25 @@ export async function createShiprocketShipmentForFulfillment(
     (order as any)?.shipping_address?.country_code
   )
 
+  // Declare the fulfillment's own lines, not the order's. `fulfillment.items`
+  // has to be requested explicitly — the default order payload returns it empty,
+  // which is exactly how declaring every order line went unnoticed.
+  const fulfillmentItems = (fulfillment as any)?.items as
+    | FulfillmentLine[]
+    | undefined
+  if (!fulfillmentItems?.length) {
+    logger.warn(
+      `Fulfillment ${input.fulfillmentId} exposed no items; declaring all lines of order ${input.orderId} to ${carrier}. Correct for a single full fulfillment, over-declares a partial one.`
+    )
+  }
+
   let shipmentInput = buildCreateShipmentInput(order as OrderForShipment, {
     pickupLocationName,
     weightGrams: input.weightGrams,
     dimensionsCm: input.dimensionsCm,
     preferredCourierId: input.preferredCourierId,
     taxId,
+    fulfillmentItems,
   })
 
   // International FX (#1111 S3). Shiprocket declares the customs value only in a


### PR DESCRIPTION
Fixes the two symptoms hit on `order_01KXWHFP132AM0H940WFD2P0XW` — courier rates returning nothing, and label generation failing with `Shiprocket /international/courier/assign/awb failed (400) — ["Delivery pincode is empty","Customer phone is empty"]` — plus four more defects found while probing them.

All findings are **live-verified against the Shiprocket account** (5 test orders, all cancelled afterwards; `awb_assign_status: 0` throughout, so no AWB was ever assigned and nothing was billed).

## The label 400

`shipping_is_billing: true` is **not honoured by the international pipeline.** `create/adhoc` returns 200 and `/orders/show` even echoes the copied address back (`customer_pincode: "10001"`), so the order looks correct — but the international shipment record never receives a delivery address, and `assign/awb` rejects it two calls later.

| body | assign/awb |
|---|---|
| `billing_*` + `shipping_is_billing: true` (before) | **400** `["Delivery pincode is empty","Customer phone is empty"]` |
| explicit `shipping_*` block (after) | **200** |

## The zero rates — two independent causes

1. `getShiprocketRatesForOrder` always called the **domestic** endpoint, which cannot price a foreign pincode and reports that as success: an empty courier list, no error. Now branches on destination country inside `getRates`, so admin, partner and inventory-order callers all get the right endpoint.
2. The comment claiming intl serviceability "only answers in `order_id` mode" was **wrong** — it 400s only when `pickup_postcode` is omitted. With an origin it returns couriers, so a pre-label picker was possible all along.

And even once routed correctly, **every rate would have been ₹0**: in the international response `rate` is an *object* (`{rate: 1125}`) and `estimated_delivery_days` a *string range* (`"10 - 12"`), so `Number(c.rate)` was `NaN → || 0`. The auto-select path had been stamping `courier_rate: 0` on shipments.

Live result after the fix:
```
SRX Economy ₹848 (recommended, 15d) · SRX Premium Plus Pro ₹1560
SRX Economy Pro ₹1723 · SRX Express ₹3059 (9d) · Aramex ₹5613
```

## Silent failures closed

- **AWB assignment can fail with HTTP 200** — `{awb_assign_status: 0, awb_assign_error: "…"}` and no `awb_code`. The old code read `awb_code || ""` and returned a shipment with a **blank AWB and no error**: a label step that appeared to succeed while nothing was booked. Same shape as the 422 chain from the previous session.
- **Wrong declared total.** `order.subtotal` **includes shipping** — on the live order, `item_total` 241.85 + `shipping_total` 39 = `subtotal` 280.85. We declared 280.85 against lines summing to 241.85, so freight was declared as merchandise: an inflated total that also contradicted our own `Terms_Of_Invoice: "FOB"` and inflated the buyer's duty on arrival. Now goods-only, and equal by construction to the lines we send.
- **A shipment now declares the fulfillment's lines, not the whole order.** `fulfillment.items` comes back **empty** unless named in the field selection, which is exactly how this went unnoticed. Joined on `line_item_id` — fulfillment items carry the *variant* title (`"Chrome Yellow"`, `"S"`) while order lines carry the product title, and this order has two identical `Lamyig Canvas Carryall` lines that would have collided on title. Knock-ons: fulfilled quantity rather than ordered quantity; order-level goods totals ignored on a partial box; and **COD no longer collects the full order total per box** (two partial shipments would each have asked the customer for the entire order at the door). Degrades safely — if nothing resolves it falls back to all lines and logs, never an empty declaration.

## CSB-5 / IGST

Sending a complete commercial export body makes Shiprocket classify the order as **CSB-5**, which rejects our old `igstPaymentStatus: "A"` at create time (`"IGST can not be Not Applicable in case of CSB5 shipments."`). An export of goods is zero-rated regardless; this field only states *how* the Indian exporter discharges that — `"B"` LUT/bond on file, `"C"` IGST paid and reclaimed.

Defaults to **`"C"`**: the LUT is applied for but has **no ARN yet**, and declaring `"B"` without one on file would be a false declaration. Flip with `SHIPROCKET_IGST_PAYMENT_STATUS=B` once the ARN issues — no code change. Tracked as a follow-up.

## Also

- Pre-flight guard naming **all** missing delivery fields at once, so one round of data-fixing clears them instead of one 400 per attempt.
- `insufficient_balance` in the friendly-error map, so a wallet shortfall reads as a wallet shortfall.

## Verification

- Shipping unit tests **126 → 161**; each new test pins a live-verified finding.
- `tsc` unchanged at the documented **79** baseline.
- Full unit suite: 2592 pass, 5 fail — all 5 (`seed-additional-email-templates`, `brief-shaper`, `build-email-data`, `audit-ai-platforms`) **verified failing identically with these changes stashed**, so pre-existing and unrelated.
- Integration specs for these surfaces were not run: local Postgres is still missing the `saranshsharma` role from the 2026-08-05 rebuild.

**Remaining blocker on the original order is the Shiprocket wallet balance**, not code — the live run now reaches `"Insufficient amount to label this shipment"`, surfaced as actionable guidance.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
