### PR TITLE
feat(customs): export-LUT admin settings page + expiry warning job (#1216)

### DIFF
--- a/apps/backend/src/admin/hooks/api/export-luts.ts
+++ b/apps/backend/src/admin/hooks/api/export-luts.ts
@@ -1,0 +1,232 @@
+import { FetchError } from "@medusajs/js-sdk"
+import {
+  QueryKey,
+  UseMutationOptions,
+  UseQueryOptions,
+  useMutation,
+  useQuery,
+  useQueryClient,
+} from "@tanstack/react-query"
+
+import { sdk } from "../../lib/config"
+import { queryKeysFactory } from "../../lib/query-key-factory"
+
+/**
+ * Export LUTs + the resolved export IGST status (#1216).
+ *
+ * An LUT (GST form RFD-11) covers ONE financial year and must be re-furnished
+ * each April. `useExportIgstStatus` is deliberately a SEPARATE query from the LUT
+ * list: the list says what rows exist, the status says what a label would declare
+ * *today*. They diverge the moment an LUT lapses — which is the whole failure this
+ * feature prevents — so the UI must never infer the status from the rows itself.
+ */
+
+const EXPORT_LUTS_QUERY_KEY = "export-luts" as const
+export const exportLutQueryKeys = queryKeysFactory(EXPORT_LUTS_QUERY_KEY)
+
+const EXPORT_IGST_QUERY_KEY = "export-igst-status" as const
+export const exportIgstQueryKeys = queryKeysFactory(EXPORT_IGST_QUERY_KEY)
+
+export type AdminExportLut = {
+  id: string
+  arn: string
+  financial_year: string
+  valid_from: string
+  valid_to: string
+  filed_on: string | null
+  notes: string | null
+  is_active: boolean
+  created_at?: string
+}
+
+export type AdminPlatformTaxIdentity = {
+  id: string
+  brand_code: string
+  legal_name: string
+  tax_id: string
+  tax_id_type: string
+  country_codes: string[] | null
+  is_active: boolean
+  export_luts?: AdminExportLut[] | null
+}
+
+export type AdminPlatformTaxIdentitiesResponse = {
+  platform_tax_identities: AdminPlatformTaxIdentity[]
+}
+
+export type AdminExportLutsResponse = { export_luts: AdminExportLut[] }
+export type AdminExportLutResponse = { export_lut: AdminExportLut }
+
+/** "B" = LUT/bond on file, no IGST paid. "C" = IGST paid and reclaimed. */
+export type AdminExportIgstStatus = {
+  status: "B" | "C"
+  declares_under_lut: boolean
+  lut_arn?: string
+  financial_year?: string
+  days_until_expiry?: number
+}
+
+export type AdminExportIgstResponse = { export_igst: AdminExportIgstStatus }
+
+export type AdminCreateExportLutPayload = {
+  arn: string
+  financial_year: string
+  valid_from: string
+  valid_to: string
+  filed_on?: string
+  notes?: string
+  is_active?: boolean
+}
+
+export type AdminUpdateExportLutPayload = Partial<AdminCreateExportLutPayload>
+
+// --- Queries ---
+
+export const usePlatformTaxIdentities = (
+  options?: Omit<
+    UseQueryOptions<
+      AdminPlatformTaxIdentitiesResponse,
+      FetchError,
+      AdminPlatformTaxIdentitiesResponse,
+      QueryKey
+    >,
+    "queryFn" | "queryKey"
+  >
+) => {
+  const { data, ...rest } = useQuery({
+    queryKey: ["platform-tax-identities"],
+    queryFn: async () =>
+      sdk.client.fetch<AdminPlatformTaxIdentitiesResponse>(
+        `/admin/platform-tax-identities`,
+        { method: "GET" }
+      ),
+    ...options,
+  })
+
+  return { ...data, ...rest }
+}
+
+export const useExportLuts = (
+  identityId: string,
+  options?: Omit<
+    UseQueryOptions<AdminExportLutsResponse, FetchError, AdminExportLutsResponse, QueryKey>,
+    "queryFn" | "queryKey"
+  >
+) => {
+  const { data, ...rest } = useQuery({
+    queryKey: exportLutQueryKeys.list({ identityId }),
+    queryFn: async () =>
+      sdk.client.fetch<AdminExportLutsResponse>(
+        `/admin/platform-tax-identities/${identityId}/export-luts`,
+        { method: "GET" }
+      ),
+    ...options,
+  })
+
+  return { ...data, ...rest }
+}
+
+/** What an export label would declare RIGHT NOW, and which LUT justifies it. */
+export const useExportIgstStatus = (
+  options?: Omit<
+    UseQueryOptions<AdminExportIgstResponse, FetchError, AdminExportIgstResponse, QueryKey>,
+    "queryFn" | "queryKey"
+  >
+) => {
+  const { data, ...rest } = useQuery({
+    queryKey: exportIgstQueryKeys.details(),
+    queryFn: async () =>
+      sdk.client.fetch<AdminExportIgstResponse>(
+        `/admin/customs/export-igst-status`,
+        { method: "GET" }
+      ),
+    ...options,
+  })
+
+  return { ...data, ...rest }
+}
+
+// --- Mutations ---
+
+/**
+ * Every mutation invalidates the STATUS as well as the list. Recording, editing
+ * or withdrawing an LUT changes what the next label declares, and a stale banner
+ * claiming "declaring under LUT" after a withdrawal is exactly the wrong thing to
+ * show for a compliance surface.
+ */
+const invalidateLutQueries = (queryClient: any, identityId: string) => {
+  queryClient.invalidateQueries({ queryKey: exportLutQueryKeys.list({ identityId }) })
+  queryClient.invalidateQueries({ queryKey: exportLutQueryKeys.lists() })
+  queryClient.invalidateQueries({ queryKey: exportIgstQueryKeys.details() })
+  queryClient.invalidateQueries({ queryKey: ["platform-tax-identities"] })
+}
+
+export const useCreateExportLut = (
+  identityId: string,
+  options?: UseMutationOptions<
+    AdminExportLutResponse,
+    FetchError,
+    AdminCreateExportLutPayload
+  >
+) => {
+  const queryClient = useQueryClient()
+
+  return useMutation({
+    mutationFn: async (payload: AdminCreateExportLutPayload) =>
+      sdk.client.fetch<AdminExportLutResponse>(
+        `/admin/platform-tax-identities/${identityId}/export-luts`,
+        { method: "POST", body: payload }
+      ),
+    onSuccess: (data, variables, _mr, context) => {
+      invalidateLutQueries(queryClient, identityId)
+      options?.onSuccess?.(data, variables, _mr, context)
+    },
+    ...options,
+  })
+}
+
+export const useUpdateExportLut = (
+  identityId: string,
+  lutId: string,
+  options?: UseMutationOptions<
+    AdminExportLutResponse,
+    FetchError,
+    AdminUpdateExportLutPayload
+  >
+) => {
+  const queryClient = useQueryClient()
+
+  return useMutation({
+    mutationFn: async (payload: AdminUpdateExportLutPayload) =>
+      sdk.client.fetch<AdminExportLutResponse>(
+        `/admin/platform-tax-identities/${identityId}/export-luts/${lutId}`,
+        { method: "POST", body: payload }
+      ),
+    onSuccess: (data, variables, _mr, context) => {
+      invalidateLutQueries(queryClient, identityId)
+      options?.onSuccess?.(data, variables, _mr, context)
+    },
+    ...options,
+  })
+}
+
+export const useDeleteExportLut = (
+  identityId: string,
+  lutId: string,
+  options?: UseMutationOptions<{ id: string; deleted: boolean }, FetchError, void>
+) => {
+  const queryClient = useQueryClient()
+
+  return useMutation({
+    mutationFn: async () =>
+      sdk.client.fetch<{ id: string; deleted: boolean }>(
+        `/admin/platform-tax-identities/${identityId}/export-luts/${lutId}`,
+        { method: "DELETE" }
+      ),
+    onSuccess: (data, variables, _mr, context) => {
+      invalidateLutQueries(queryClient, identityId)
+      options?.onSuccess?.(data, variables, _mr, context)
+    },
+    ...options,
+  })
+}

--- a/apps/backend/src/admin/lib/__tests__/financial-year.unit.spec.ts
+++ b/apps/backend/src/admin/lib/__tests__/financial-year.unit.spec.ts
@@ -1,0 +1,45 @@
+import { financialYearWindow } from "../financial-year"
+
+/**
+ * #1216 — the LUT form prefills its validity window from the FY label. That
+ * window is what makes an expired LUT stop justifying a zero-IGST declaration, so
+ * a wrong end date is a compliance bug rather than a cosmetic one.
+ */
+describe("financialYearWindow", () => {
+  it("maps an Indian FY onto 1 April → 31 March", () => {
+    expect(financialYearWindow("2026-27")).toEqual({
+      from: "2026-04-01",
+      to: "2027-03-31",
+    })
+  })
+
+  it("tolerates surrounding whitespace", () => {
+    expect(financialYearWindow("  2026-27 ")).toEqual({
+      from: "2026-04-01",
+      to: "2027-03-31",
+    })
+  })
+
+  it("handles the century rollover", () => {
+    // "2099-00" means 2100, not 2000 — naive century-prefixing would go backwards.
+    expect(financialYearWindow("2099-00")).toEqual({
+      from: "2099-04-01",
+      to: "2100-03-31",
+    })
+  })
+
+  it.each([
+    ["empty", ""],
+    ["a single year", "2026"],
+    ["a full end year", "2026-2027"],
+    ["prose", "FY 2026-27"],
+    ["nonsense", "abcd-ef"],
+  ])("returns null for %s so nothing is prefilled from junk", (_label, input) => {
+    expect(financialYearWindow(input)).toBeNull()
+  })
+
+  it("returns null rather than throwing on a missing value", () => {
+    expect(financialYearWindow(undefined as any)).toBeNull()
+    expect(financialYearWindow(null as any)).toBeNull()
+  })
+})

--- a/apps/backend/src/admin/lib/financial-year.ts
+++ b/apps/backend/src/admin/lib/financial-year.ts
@@ -1,0 +1,26 @@
+/**
+ * Indian financial-year helpers for the export-LUT form (#1216).
+ *
+ * Kept dependency-free (no UI imports) so the date maths is unit-testable — the
+ * validity window is what makes an expired LUT stop justifying a zero-IGST
+ * declaration, so getting it wrong is a compliance bug, not a cosmetic one.
+ */
+
+/**
+ * "2026-27" → 1 Apr 2026 … 31 Mar 2027, as `yyyy-mm-dd` for date inputs.
+ * Returns null for anything that isn't a well-formed FY label.
+ */
+export function financialYearWindow(
+  fy: string
+): { from: string; to: string } | null {
+  const m = /^(\d{4})-(\d{2})$/.exec((fy ?? "").trim())
+  if (!m) {
+    return null
+  }
+  const startYear = Number(m[1])
+  // Expand the 2-digit end against the START year's century, then guard the
+  // rollover: "2099-00" means 2100, not 2000.
+  const sameCentury = Math.floor(startYear / 100) * 100 + Number(m[2])
+  const endYear = sameCentury > startYear ? sameCentury : startYear + 1
+  return { from: `${startYear}-04-01`, to: `${endYear}-03-31` }
+}

--- a/apps/backend/src/admin/routes/settings/export-lut/page.tsx
+++ b/apps/backend/src/admin/routes/settings/export-lut/page.tsx
@@ -1,0 +1,587 @@
+import { defineRouteConfig } from "@medusajs/admin-sdk"
+import { DocumentText } from "@medusajs/icons"
+import {
+  Badge,
+  Button,
+  Container,
+  Drawer,
+  FocusModal,
+  Heading,
+  Input,
+  Label,
+  StatusBadge,
+  Switch,
+  Text,
+  Textarea,
+  toast,
+  usePrompt,
+} from "@medusajs/ui"
+import { useEffect, useMemo, useState } from "react"
+
+import { financialYearWindow } from "../../../lib/financial-year"
+import {
+  AdminExportLut,
+  AdminPlatformTaxIdentity,
+  useCreateExportLut,
+  useDeleteExportLut,
+  useExportIgstStatus,
+  usePlatformTaxIdentities,
+  useUpdateExportLut,
+} from "../../../hooks/api/export-luts"
+
+/**
+ * Export LUT settings (#1216).
+ *
+ * An LUT (GST form RFD-11) lets an exporter ship without paying IGST. It covers
+ * ONE financial year and must be re-furnished each April — which is the entire
+ * reason this screen exists rather than an env var. The banner therefore leads
+ * with what a label declares TODAY (read from the resolver, not inferred from the
+ * rows on screen) and how long that has left to run, because "a row exists" and
+ * "it is still valid" are different facts and the gap between them is a false
+ * declaration.
+ */
+
+/** Warn this far ahead of expiry — enough time to re-furnish before the FY rolls. */
+const EXPIRY_WARNING_DAYS = 45
+
+const fmtDate = (value?: string | null) =>
+  value ? new Date(value).toLocaleDateString(undefined, { dateStyle: "medium" }) : "—"
+
+type LutFormState = {
+  arn: string
+  financial_year: string
+  valid_from: string
+  valid_to: string
+  filed_on: string
+  notes: string
+  is_active: boolean
+}
+
+const emptyForm: LutFormState = {
+  arn: "",
+  financial_year: "",
+  valid_from: "",
+  valid_to: "",
+  filed_on: "",
+  notes: "",
+  is_active: true,
+}
+
+const toFormState = (lut: AdminExportLut): LutFormState => ({
+  arn: lut.arn ?? "",
+  financial_year: lut.financial_year ?? "",
+  valid_from: lut.valid_from ? lut.valid_from.slice(0, 10) : "",
+  valid_to: lut.valid_to ? lut.valid_to.slice(0, 10) : "",
+  filed_on: lut.filed_on ? lut.filed_on.slice(0, 10) : "",
+  notes: lut.notes ?? "",
+  is_active: lut.is_active ?? true,
+})
+
+const LutFields = ({
+  value,
+  onChange,
+  showActive,
+}: {
+  value: LutFormState
+  onChange: (next: LutFormState) => void
+  showActive?: boolean
+}) => {
+  const set = (patch: Partial<LutFormState>) => onChange({ ...value, ...patch })
+
+  return (
+    <div className="flex flex-col gap-4">
+      <div className="flex flex-col gap-2">
+        <Label size="small" weight="plus">
+          ARN
+        </Label>
+        <Input
+          placeholder="AD070426000123A"
+          value={value.arn}
+          onChange={(e) => set({ arn: e.target.value })}
+        />
+        <Text size="small" leading="compact" className="text-ui-fg-subtle">
+          The acknowledgement number the GST portal returns on furnishing RFD-11.
+        </Text>
+      </div>
+
+      <div className="flex flex-col gap-2">
+        <Label size="small" weight="plus">
+          Financial year
+        </Label>
+        <Input
+          placeholder="2026-27"
+          value={value.financial_year}
+          onChange={(e) => {
+            const financial_year = e.target.value
+            // Prefill the window from the FY, but never overwrite dates already
+            // typed — a mid-year LUT starts on its filing date, not 1 April.
+            const window = financialYearWindow(financial_year)
+            set({
+              financial_year,
+              ...(window && !value.valid_from && !value.valid_to
+                ? { valid_from: window.from, valid_to: window.to }
+                : {}),
+            })
+          }}
+        />
+      </div>
+
+      <div className="grid grid-cols-2 gap-3">
+        <div className="flex flex-col gap-2">
+          <Label size="small" weight="plus">
+            Valid from
+          </Label>
+          <Input
+            type="date"
+            value={value.valid_from}
+            onChange={(e) => set({ valid_from: e.target.value })}
+          />
+        </div>
+        <div className="flex flex-col gap-2">
+          <Label size="small" weight="plus">
+            Valid to
+          </Label>
+          <Input
+            type="date"
+            value={value.valid_to}
+            onChange={(e) => set({ valid_to: e.target.value })}
+          />
+        </div>
+      </div>
+      <Text size="small" leading="compact" className="text-ui-fg-subtle">
+        After <strong>valid to</strong>, exports automatically go back to declaring
+        IGST as paid and reclaimed. Nothing needs switching off.
+      </Text>
+
+      <div className="flex flex-col gap-2">
+        <Label size="small" weight="plus">
+          Filed on <span className="text-ui-fg-muted">(optional)</span>
+        </Label>
+        <Input
+          type="date"
+          value={value.filed_on}
+          onChange={(e) => set({ filed_on: e.target.value })}
+        />
+      </div>
+
+      <div className="flex flex-col gap-2">
+        <Label size="small" weight="plus">
+          Notes <span className="text-ui-fg-muted">(optional)</span>
+        </Label>
+        <Textarea
+          placeholder="Who furnished it, witnesses, portal reference…"
+          value={value.notes}
+          onChange={(e) => set({ notes: e.target.value })}
+        />
+      </div>
+
+      {showActive ? (
+        <div className="flex items-center justify-between">
+          <div className="flex flex-col">
+            <Text size="small" leading="compact" weight="plus">
+              Active
+            </Text>
+            <Text size="small" leading="compact" className="text-ui-fg-subtle">
+              Turning this off stops exports relying on it immediately, while
+              keeping it readable for shipments already declared under it.
+            </Text>
+          </div>
+          <Switch
+            checked={value.is_active}
+            onCheckedChange={(is_active) => set({ is_active })}
+          />
+        </div>
+      ) : null}
+    </div>
+  )
+}
+
+/** Shared payload builder — omits the optional fields rather than sending "". */
+const toPayload = (form: LutFormState, includeActive: boolean) => ({
+  arn: form.arn.trim(),
+  financial_year: form.financial_year.trim(),
+  valid_from: form.valid_from,
+  valid_to: form.valid_to,
+  ...(form.filed_on ? { filed_on: form.filed_on } : {}),
+  ...(form.notes.trim() ? { notes: form.notes.trim() } : {}),
+  ...(includeActive ? { is_active: form.is_active } : {}),
+})
+
+const isComplete = (form: LutFormState) =>
+  Boolean(form.arn.trim() && form.financial_year.trim() && form.valid_from && form.valid_to)
+
+const CreateLutModal = ({
+  identity,
+  open,
+  onOpenChange,
+}: {
+  identity: AdminPlatformTaxIdentity
+  open: boolean
+  onOpenChange: (open: boolean) => void
+}) => {
+  const [form, setForm] = useState<LutFormState>(emptyForm)
+  const create = useCreateExportLut(identity.id)
+
+  useEffect(() => {
+    if (open) setForm(emptyForm)
+  }, [open])
+
+  const submit = () => {
+    create.mutate(toPayload(form, true), {
+      onSuccess: () => {
+        toast.success("LUT recorded — exports will declare under it while it is valid")
+        onOpenChange(false)
+      },
+      onError: (e: any) => toast.error(e?.message || "Could not record the LUT"),
+    })
+  }
+
+  return (
+    <FocusModal open={open} onOpenChange={onOpenChange}>
+      <FocusModal.Content>
+        <FocusModal.Header>
+          <Heading level="h2">Record an export LUT</Heading>
+        </FocusModal.Header>
+        <FocusModal.Body className="flex flex-col items-center overflow-y-auto py-8">
+          <div className="flex w-full max-w-lg flex-col gap-4">
+            <Text size="small" leading="compact" className="text-ui-fg-subtle">
+              Furnished by <strong>{identity.legal_name}</strong> ({identity.tax_id}).
+              Record one per financial year — renewing adds a new entry rather than
+              editing last year's, so past declarations stay auditable.
+            </Text>
+            <LutFields value={form} onChange={setForm} showActive />
+          </div>
+        </FocusModal.Body>
+        <FocusModal.Footer>
+          <div className="flex items-center justify-end gap-2">
+            <Button
+              size="small"
+              variant="secondary"
+              onClick={() => onOpenChange(false)}
+              disabled={create.isPending}
+            >
+              Cancel
+            </Button>
+            <Button
+              size="small"
+              onClick={submit}
+              isLoading={create.isPending}
+              disabled={create.isPending || !isComplete(form)}
+            >
+              Record LUT
+            </Button>
+          </div>
+        </FocusModal.Footer>
+      </FocusModal.Content>
+    </FocusModal>
+  )
+}
+
+const EditLutDrawer = ({
+  identityId,
+  lut,
+  onClose,
+}: {
+  identityId: string
+  lut: AdminExportLut
+  onClose: () => void
+}) => {
+  const [form, setForm] = useState<LutFormState>(() => toFormState(lut))
+  const update = useUpdateExportLut(identityId, lut.id)
+
+  useEffect(() => setForm(toFormState(lut)), [lut])
+
+  const submit = () => {
+    update.mutate(toPayload(form, true), {
+      onSuccess: () => {
+        toast.success("LUT updated")
+        onClose()
+      },
+      onError: (e: any) => toast.error(e?.message || "Could not update the LUT"),
+    })
+  }
+
+  return (
+    <Drawer open onOpenChange={(open) => !open && onClose()}>
+      <Drawer.Content>
+        <Drawer.Header>
+          <Heading level="h2">Edit LUT</Heading>
+        </Drawer.Header>
+        <Drawer.Body className="overflow-y-auto">
+          <LutFields value={form} onChange={setForm} showActive />
+        </Drawer.Body>
+        <Drawer.Footer>
+          <div className="flex items-center justify-end gap-2">
+            <Button
+              size="small"
+              variant="secondary"
+              onClick={onClose}
+              disabled={update.isPending}
+            >
+              Cancel
+            </Button>
+            <Button
+              size="small"
+              onClick={submit}
+              isLoading={update.isPending}
+              disabled={update.isPending || !isComplete(form)}
+            >
+              Save
+            </Button>
+          </div>
+        </Drawer.Footer>
+      </Drawer.Content>
+    </Drawer>
+  )
+}
+
+const LutRow = ({
+  identityId,
+  lut,
+  onEdit,
+}: {
+  identityId: string
+  lut: AdminExportLut
+  onEdit: () => void
+}) => {
+  const prompt = usePrompt()
+  const remove = useDeleteExportLut(identityId, lut.id)
+
+  const now = Date.now()
+  const from = new Date(lut.valid_from).getTime()
+  const to = new Date(lut.valid_to).getTime()
+  const inForce = lut.is_active && now >= from && now <= to
+
+  const state = !lut.is_active
+    ? { color: "grey" as const, label: "Withdrawn" }
+    : now > to
+      ? { color: "red" as const, label: "Expired" }
+      : now < from
+        ? { color: "orange" as const, label: "Not yet in force" }
+        : { color: "green" as const, label: "In force" }
+
+  const confirmDelete = async () => {
+    const ok = await prompt({
+      title: "Delete this LUT?",
+      description:
+        "Prefer switching it to inactive instead — shipments already declared under it should stay auditable. Delete only a row created in error.",
+    })
+    if (!ok) return
+    remove.mutate(undefined, {
+      onSuccess: () => toast.success("LUT deleted"),
+      onError: (e: any) => toast.error(e?.message || "Could not delete the LUT"),
+    })
+  }
+
+  return (
+    <div className="flex items-center justify-between gap-3 border-t border-ui-border-base px-6 py-4">
+      <div className="flex flex-col gap-1">
+        <div className="flex items-center gap-2">
+          <Text size="small" leading="compact" weight="plus">
+            {lut.arn}
+          </Text>
+          <Badge size="2xsmall">FY {lut.financial_year}</Badge>
+          <StatusBadge color={state.color}>{state.label}</StatusBadge>
+          {inForce ? <Badge size="2xsmall" color="green">Declaring B</Badge> : null}
+        </div>
+        <Text size="small" leading="compact" className="text-ui-fg-subtle">
+          {fmtDate(lut.valid_from)} → {fmtDate(lut.valid_to)}
+          {lut.filed_on ? ` · filed ${fmtDate(lut.filed_on)}` : ""}
+        </Text>
+        {lut.notes ? (
+          <Text size="small" leading="compact" className="text-ui-fg-muted">
+            {lut.notes}
+          </Text>
+        ) : null}
+      </div>
+      <div className="flex items-center gap-2">
+        <Button size="small" variant="secondary" onClick={onEdit}>
+          Edit
+        </Button>
+        <Button
+          size="small"
+          variant="danger"
+          onClick={confirmDelete}
+          isLoading={remove.isPending}
+          disabled={remove.isPending}
+        >
+          Delete
+        </Button>
+      </div>
+    </div>
+  )
+}
+
+const IdentitySection = ({ identity }: { identity: AdminPlatformTaxIdentity }) => {
+  const [createOpen, setCreateOpen] = useState(false)
+  const [editing, setEditing] = useState<AdminExportLut | null>(null)
+
+  // The identity payload already carries its LUTs, so no second fetch per section.
+  const luts = useMemo(
+    () =>
+      [...(identity.export_luts ?? [])].sort(
+        (a, b) => new Date(b.valid_from).getTime() - new Date(a.valid_from).getTime()
+      ),
+    [identity.export_luts]
+  )
+
+  return (
+    <Container className="divide-y p-0">
+      <div className="flex items-center justify-between px-6 py-4">
+        <div className="flex flex-col">
+          <Text size="small" leading="compact" weight="plus">
+            {identity.legal_name}
+          </Text>
+          <Text size="small" leading="compact" className="text-ui-fg-subtle">
+            {identity.tax_id_type?.toUpperCase()} {identity.tax_id}
+          </Text>
+        </div>
+        <Button size="small" onClick={() => setCreateOpen(true)}>
+          Record LUT
+        </Button>
+      </div>
+
+      {luts.length ? (
+        luts.map((lut) => (
+          <LutRow
+            key={lut.id}
+            identityId={identity.id}
+            lut={lut}
+            onEdit={() => setEditing(lut)}
+          />
+        ))
+      ) : (
+        <div className="px-6 py-4">
+          <Text size="small" leading="compact" className="text-ui-fg-subtle">
+            No LUT recorded. Exports declare IGST as paid and reclaimed until one is
+            furnished and entered here.
+          </Text>
+        </div>
+      )}
+
+      <CreateLutModal
+        identity={identity}
+        open={createOpen}
+        onOpenChange={setCreateOpen}
+      />
+      {editing ? (
+        <EditLutDrawer
+          identityId={identity.id}
+          lut={editing}
+          onClose={() => setEditing(null)}
+        />
+      ) : null}
+    </Container>
+  )
+}
+
+const StatusBanner = () => {
+  const { export_igst, isLoading } = useExportIgstStatus()
+
+  if (isLoading) {
+    return (
+      <Container>
+        <Text size="small" leading="compact" className="text-ui-fg-subtle">
+          Checking what exports declare today…
+        </Text>
+      </Container>
+    )
+  }
+
+  const underLut = export_igst?.declares_under_lut
+  const days = export_igst?.days_until_expiry
+  const expiringSoon = underLut && typeof days === "number" && days <= EXPIRY_WARNING_DAYS
+
+  return (
+    <Container className="flex flex-col gap-2">
+      <div className="flex items-center gap-2">
+        <Text size="small" leading="compact" weight="plus">
+          Exports currently declare
+        </Text>
+        <StatusBadge color={underLut ? "green" : "orange"}>
+          {underLut ? "B — under LUT, no IGST paid" : "C — IGST paid and reclaimed"}
+        </StatusBadge>
+      </div>
+
+      {underLut ? (
+        <Text size="small" leading="compact" className="text-ui-fg-subtle">
+          Relying on ARN <strong>{export_igst?.lut_arn}</strong> (FY{" "}
+          {export_igst?.financial_year}) — {days} day{days === 1 ? "" : "s"} of cover
+          left.
+        </Text>
+      ) : (
+        <Text size="small" leading="compact" className="text-ui-fg-subtle">
+          No LUT is in force, so exports pay IGST and reclaim it. This is the correct
+          declaration without one on file — record an LUT below to switch.
+        </Text>
+      )}
+
+      {expiringSoon ? (
+        <Text size="small" leading="compact" className="text-ui-fg-error">
+          This LUT lapses in {days} day{days === 1 ? "" : "s"}. Re-furnish RFD-11 for
+          the next financial year and record it here; exports revert to “C” on their
+          own the moment it expires.
+        </Text>
+      ) : null}
+    </Container>
+  )
+}
+
+const ExportLutPage = () => {
+  const { platform_tax_identities, isLoading } = usePlatformTaxIdentities()
+
+  // Mirror the resolver: it only considers LUTs on an ACTIVE identity registered
+  // for India. Showing rows the resolver would ignore (the Latvian VAT entity —
+  // an LUT is a GST instrument) would imply cover that doesn't exist.
+  const indianIdentities = useMemo(
+    () =>
+      (platform_tax_identities ?? []).filter(
+        (i) =>
+          i.is_active !== false &&
+          (i.country_codes ?? []).some((c) => String(c).toUpperCase() === "IN")
+      ),
+    [platform_tax_identities]
+  )
+
+  return (
+    <div className="flex flex-col gap-3">
+      <Container className="flex flex-col gap-1">
+        <Heading level="h1">Export LUT</Heading>
+        <Text size="small" leading="compact" className="text-ui-fg-subtle">
+          A Letter of Undertaking (GST form RFD-11) lets exports ship without paying
+          IGST. It covers one financial year and must be re-furnished each April —
+          recorded here so the declaration expires by itself instead of silently
+          claiming cover that has lapsed.
+        </Text>
+      </Container>
+
+      <StatusBanner />
+
+      {isLoading ? (
+        <Container>
+          <Text size="small" leading="compact" className="text-ui-fg-subtle">
+            Loading tax identities…
+          </Text>
+        </Container>
+      ) : indianIdentities.length ? (
+        indianIdentities.map((identity) => (
+          <IdentitySection key={identity.id} identity={identity} />
+        ))
+      ) : (
+        <Container>
+          <Text size="small" leading="compact" className="text-ui-fg-subtle">
+            No active India-registered tax identity found, so there is nothing an LUT
+            could attach to.
+          </Text>
+        </Container>
+      )}
+    </div>
+  )
+}
+
+export const config = defineRouteConfig({
+  label: "Export LUT",
+  icon: DocumentText,
+})
+
+export default ExportLutPage

--- a/apps/backend/src/jobs/check-export-lut-expiry.ts
+++ b/apps/backend/src/jobs/check-export-lut-expiry.ts
@@ -1,0 +1,94 @@
+import type { MedusaContainer } from "@medusajs/framework/types"
+import { ContainerRegistrationKeys, Modules } from "@medusajs/framework/utils"
+
+import { resolveExportIgstForCountry } from "../modules/shipping-providers/export-igst"
+
+/**
+ * Export LUT expiry check (#1216).
+ *
+ * An LUT (GST form RFD-11) covers ONE financial year and must be re-furnished each
+ * April. Nothing breaks loudly when it lapses — the resolver quietly reverts to
+ * declaring IGST as paid and reclaimed ("C"), which is the SAFE outcome but also a
+ * silent one: exports start costing working capital again and nobody is told.
+ *
+ * So this job exists to make the rollover visible in advance. It does NOT change
+ * any declaration — expiry is already handled by the validity window, by design.
+ * It only warns, at escalating urgency, so RFD-11 gets re-furnished before the FY
+ * turns rather than after someone notices the cash impact.
+ *
+ * Notifies on the `feed` channel (the admin bell) via the generic `admin-ui`
+ * template — no new email template to seed, and no recipient list to keep current.
+ */
+
+/** Warn from here in. Roughly the last 6 weeks of the financial year. */
+const WARNING_DAYS = 45
+/** Below this, say it more urgently. */
+const URGENT_DAYS = 14
+
+export default async function checkExportLutExpiry(container: MedusaContainer) {
+  const logger: any = container.resolve(ContainerRegistrationKeys.LOGGER)
+
+  try {
+    const resolution = await resolveExportIgstForCountry(container)
+
+    // Nothing in force → already declaring the safe "C". There is no expiry to
+    // warn about, and nagging about a LUT that was never filed would be noise.
+    if (resolution.status !== "B") {
+      logger.info(
+        "[export-lut-check] No LUT in force; exports declare IGST paid and reclaimed (C). Nothing to warn about."
+      )
+      return
+    }
+
+    const days = resolution.days_until_expiry
+    if (typeof days !== "number") {
+      logger.warn(
+        `[export-lut-check] LUT ${resolution.lut_arn} is in force but its expiry could not be read — check the recorded validity window.`
+      )
+      return
+    }
+
+    if (days > WARNING_DAYS) {
+      logger.info(
+        `[export-lut-check] LUT ${resolution.lut_arn} (FY ${resolution.financial_year}) valid for ${days} more days.`
+      )
+      return
+    }
+
+    const urgent = days <= URGENT_DAYS
+    const title = urgent
+      ? `Export LUT expires in ${days} day${days === 1 ? "" : "s"}`
+      : `Export LUT expires in ${days} days`
+    const description =
+      `LUT ${resolution.lut_arn} (FY ${resolution.financial_year}) lapses in ${days} day${days === 1 ? "" : "s"}. ` +
+      `Re-furnish RFD-11 on the GST portal for the next financial year and record it under Settings → Export LUT. ` +
+      `When it expires, exports revert to paying IGST and reclaiming it — correct, but it ties up working capital on every shipment.`
+
+    logger.warn(`[export-lut-check] ${title} — ${description}`)
+
+    // Best-effort: a notification-provider problem must not fail the job, or a
+    // transient outage would also cost us the log line above.
+    try {
+      const notificationService: any = container.resolve(Modules.NOTIFICATION)
+      await notificationService.createNotifications({
+        to: "",
+        channel: "feed",
+        template: "admin-ui",
+        data: { title, description },
+      })
+    } catch (e: any) {
+      logger.warn(
+        `[export-lut-check] Could not post the admin notification: ${e?.message}`
+      )
+    }
+  } catch (e: any) {
+    logger.error(`[export-lut-check] Error: ${e?.message}`)
+  }
+}
+
+export const config = {
+  name: "check-export-lut-expiry",
+  // Weekly (Mondays, 07:00). An LUT lapses on a known date months ahead — a daily
+  // check would just repeat the same warning 45 times.
+  schedule: "0 7 * * 1",
+}


### PR DESCRIPTION
UI half of #1216, on top of the backend merged in #1217. Closes the loop: you can enter the LUT the day the ARN arrives, and the FY rollover can't be silently forgotten.

## Settings → Export LUT

**The banner is a separate query from the LUT list, deliberately.** The list says *what rows exist*; the banner says *what a label would declare today*. Those two diverge the moment an LUT lapses — and inferring the banner from the rows on screen would recreate the exact bug this feature exists to prevent. So it reads `GET /admin/customs/export-igst-status`, i.e. the same resolver the label path uses.

- **Status banner** — `B` (under LUT, no IGST paid) vs `C` (IGST paid and reclaimed), the ARN being relied on, and days of cover left. Inside 45 days it becomes an error-toned warning telling you to re-furnish.
- **Per-identity sections**, filtered to **active India-registered** identities — mirroring what the resolver actually reads. The Latvian VAT entity is deliberately not shown: an LUT is a GST instrument, and listing it would imply cover that cannot exist.
- **Create in a `FocusModal`, edit in a `Drawer`** (Medusa's create-vs-edit convention), with actions disabled and spinner-ed while pending.
- **FY prefill** — typing `2026-27` fills `2026-04-01 → 2027-03-31`, but **never overwrites dates already entered**, because a mid-year LUT starts on its filing date rather than 1 April.
- **Row state computed from the window**, not from `is_active` alone: *In force* / *Not yet in force* / *Expired* / *Withdrawn*. An expired row reads as expired without anyone touching it.
- **Delete prompts and steers toward withdrawing instead**, so shipments already declared under an LUT stay auditable.

## Expiry job

`check-export-lut-expiry`, Mondays 07:00. Warns at 45 days, more urgently inside 14, via the admin feed using the existing generic `admin-ui` template — **no new email template to seed and no recipient list to keep current.**

It changes **no declaration**. Expiry is already handled by the validity window in #1217 — reverting to `"C"` is automatic *and safe*. The job exists because that safety is **silent**: exports quietly start tying up working capital again, and without this the cash impact gets discovered rather than anticipated. Weekly rather than daily, or the same warning fires 45 times.

## Verification

- `medusa build` → **"Frontend build completed successfully"** — the page and hook compile and bundle. (Backend build errors are the pre-existing ai-sdk version-mismatch noise, unrelated.)
- `tsc --noEmit` → **78** (was 79; the build regenerated `.medusa/types`). No errors in these files.
- **+9 unit tests** on `financialYearWindow`, extracted to `src/admin/lib` so the date maths is testable without pulling in UI imports — including the `2099-00` century rollover, which naive century-prefixing gets backwards.
- ⚠️ **No browser verification.** No visual or interaction check was run — the build passing is not the same as the page rendering correctly. Worth a click-through on the create/edit/withdraw paths before relying on it.

## Note on the earlier design discussion

This deviates from `settings/energy-rates`, which uses route-based `create/page.tsx` and `[id]/page.tsx`. With one or two rows per entity a modal-and-drawer page is lighter and matches the Admin SDK's own create/edit convention — flagging it since it's an intentional divergence from the neighbouring settings page rather than an oversight.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
