### PR TITLE
fix(shipping): forward parcel dimensions to international rate quotes

### DIFF
--- a/apps/backend/integration-tests/http/retail-order-international-shiprocket.spec.ts
+++ b/apps/backend/integration-tests/http/retail-order-international-shiprocket.spec.ts
@@ -229,8 +229,26 @@ setupSharedTestSuite(() => {
       expect(body.reasonOfExport).toBe(3)
       expect(body.purpose_of_shipment).toBe(2)
       expect(body.Terms_Of_Invoice).toBe("FOB")
-      expect(body.igstPaymentStatus).toBe("A")
+      // "C", not "A". A complete commercial export body classifies as CSB-5 at
+      // Shiprocket, which REJECTS "A" ("IGST can not be Not Applicable in case of
+      // CSB5 shipments") — so "A" was never shippable. "C" = IGST paid and
+      // reclaimed, correct until an LUT is on file (#1216).
+      expect(body.igstPaymentStatus).toBe("C")
       expect(body.commodity).toBe(true)
+
+      // The DELIVERY block must be sent explicitly. `shipping_is_billing` is not
+      // honoured by the international pipeline: create/adhoc accepts the body
+      // either way, and only `assign/awb` fails — with
+      // `["Delivery pincode is empty","Customer phone is empty"]` two calls
+      // later. This assertion is what would have caught #1215 at the create
+      // step instead of in production.
+      expect(body.shipping_is_billing).toBe(false)
+      expect(body.shipping_pincode).toBe(body.billing_pincode)
+      expect(body.shipping_phone).toBe(body.billing_phone)
+      expect(body.shipping_country).toBe("United States")
+      expect(String(body.shipping_pincode ?? "")).not.toBe("")
+      expect(String(body.shipping_phone ?? "")).not.toBe("")
+
       // HSN reached the line item.
       expect(body.order_items[0].hsn).toBe("621410")
       // Ships from the partner's registered India pickup.

--- a/apps/backend/integration-tests/http/shiprocket-rates.spec.ts
+++ b/apps/backend/integration-tests/http/shiprocket-rates.spec.ts
@@ -174,14 +174,22 @@ setupSharedTestSuite(() => {
       expect(res.data.destination_pincode).toBe("10001")
       expect(res.data.cod).toBe(false)
 
+      // This fixture ships to the US, so the quote MUST come from the
+      // international courier product. It previously asserted the 2-courier
+      // DOMESTIC stub response — i.e. it pinned the bug fixed in #1215, where a
+      // foreign destination was quoted against the India-only pincode endpoint
+      // (which in production returns an EMPTY courier list, not a wrong one).
+      expect(res.data.destination_country).toBe("US")
+      expect(res.data.international).toBe(true)
+
       const rates = res.data.rates
       expect(Array.isArray(rates)).toBe(true)
-      expect(rates.length).toBe(2)
+      expect(rates.length).toBe(1)
       const recommended = rates.find((r: any) => r.is_recommended)
-      expect(recommended?.courier_id).toBe(51)
-      expect(recommended?.courier_name).toBe("Xpressbees Surface")
-      expect(recommended?.amount).toBe(78)
-      expect(recommended?.estimated_days).toBe(4)
+      expect(recommended?.courier_id).toBe(301)
+      expect(recommended?.courier_name).toBe("DHL Express Intl")
+      expect(recommended?.amount).toBe(1450)
+      expect(recommended?.estimated_days).toBe(6)
 
       // ── weight_grams override ─────────────────────────────────────────
       const res2 = await api.get(
@@ -199,7 +207,32 @@ setupSharedTestSuite(() => {
       )
       expect(res.status).toBe(200)
       expect(Array.isArray(res.data.rates)).toBe(true)
-      expect(res.data.rates.length).toBe(2)
+      // 1, not 2 — the US destination is quoted internationally (see above).
+      expect(res.data.rates.length).toBe(1)
+    })
+
+    it("threads parcel dimensions into the quote (volumetric pricing)", async () => {
+      // Dimensions decide the CHARGED weight on a cross-border quote, and which
+      // couriers will take the parcel at all — live-verified 176215→IL, where
+      // 60x50x40 dropped the list from 5 couriers to 2 and took one from
+      // INR 8,477 to INR 57,937. Echoing them back proves the query params
+      // parsed and reached the carrier call rather than being dropped.
+      const res = await api.get(
+        `/admin/orders/${orderId}/shiprocket-rates?weight_grams=1200&length_cm=30&width_cm=25&height_cm=10`,
+        adminHeaders
+      )
+      expect(res.status).toBe(200)
+      expect(res.data.weight_grams).toBe(1200)
+      expect(res.data.dimensions_cm).toEqual({ length: 30, width: 25, height: 10 })
+    })
+
+    it("ignores a partial dimension set rather than guessing a side", async () => {
+      const res = await api.get(
+        `/admin/orders/${orderId}/shiprocket-rates?length_cm=30&height_cm=10`,
+        adminHeaders
+      )
+      expect(res.status).toBe(200)
+      expect(res.data.dimensions_cm).toBeUndefined()
     })
 
     it("rejects carrier=delhivery (no courier picker for Delhivery)", async () => {
@@ -222,7 +255,9 @@ setupSharedTestSuite(() => {
       expect(res.status).toBe(200)
       expect(res.data.origin_pincode).toBe("302001")
       expect(Array.isArray(res.data.rates)).toBe(true)
-      expect(res.data.rates.length).toBe(2)
+      // The alias resolves the same workflow, so it too quotes internationally.
+      expect(res.data.rates.length).toBe(1)
+      expect(res.data.international).toBe(true)
     })
 
     it("carrier-neutral fulfillment-rates alias honours ?carrier=shiprocket", async () => {

--- a/apps/backend/src/api/admin/orders/[id]/shiprocket-rates/route.ts
+++ b/apps/backend/src/api/admin/orders/[id]/shiprocket-rates/route.ts
@@ -1,5 +1,8 @@
 import { MedusaRequest, MedusaResponse } from "@medusajs/framework/http"
-import { getShiprocketRatesForOrder } from "../../../../../workflows/orders/shiprocket-rates"
+import {
+  getShiprocketRatesForOrder,
+  parseRateQuery,
+} from "../../../../../workflows/orders/shiprocket-rates"
 
 /**
  * GET /admin/orders/:id/shiprocket-rates
@@ -13,20 +16,12 @@ import { getShiprocketRatesForOrder } from "../../../../../workflows/orders/ship
  * cleanly to the UI toast.
  */
 export const GET = async (req: MedusaRequest, res: MedusaResponse) => {
-  const orderId = req.params.id
-  const carrierRaw = req.query.carrier
-  const carrier =
-    typeof carrierRaw === "string" && carrierRaw ? carrierRaw : undefined
-  const weightRaw = req.query.weight_grams
-  const weightGrams = weightRaw != null ? Number(weightRaw) : undefined
-
+  // Dimensions matter on a cross-border quote (volumetric weight + which
+  // couriers accept the size), so the parsing is shared with every other rate
+  // route rather than hand-rolled per route.
   const result = await getShiprocketRatesForOrder(req.scope, {
-    orderId,
-    carrier,
-    weightGrams:
-      weightGrams != null && Number.isFinite(weightGrams) && weightGrams > 0
-        ? weightGrams
-        : undefined,
+    orderId: req.params.id,
+    ...parseRateQuery(req.query as Record<string, any>),
   })
 
   res.status(200).json(result)

--- a/apps/backend/src/api/partners/orders/[id]/shiprocket-rates/route.ts
+++ b/apps/backend/src/api/partners/orders/[id]/shiprocket-rates/route.ts
@@ -1,7 +1,10 @@
 import { AuthenticatedMedusaRequest, MedusaResponse } from "@medusajs/framework/http"
 
 import { validatePartnerOrderOwnership } from "../../../helpers"
-import { getShiprocketRatesForOrder } from "../../../../../workflows/orders/shiprocket-rates"
+import {
+  getShiprocketRatesForOrder,
+  parseRateQuery,
+} from "../../../../../workflows/orders/shiprocket-rates"
 
 /**
  * GET /partners/orders/:id/shiprocket-rates
@@ -28,20 +31,9 @@ export const GET = async (
   const orderId = req.params.id
   await validatePartnerOrderOwnership(req.auth_context, orderId, req.scope)
 
-  const carrierRaw = req.query.carrier
-  const carrier =
-    typeof carrierRaw === "string" && carrierRaw ? carrierRaw : undefined
-
-  const weightRaw = req.query.weight_grams
-  const weightGrams = weightRaw != null ? Number(weightRaw) : undefined
-
   const result = await getShiprocketRatesForOrder(req.scope, {
     orderId,
-    carrier,
-    weightGrams:
-      weightGrams != null && Number.isFinite(weightGrams) && weightGrams > 0
-        ? weightGrams
-        : undefined,
+    ...parseRateQuery(req.query as Record<string, any>),
   })
 
   res.status(200).json(result)

--- a/apps/backend/src/modules/shipping-providers/shiprocket/client.ts
+++ b/apps/backend/src/modules/shipping-providers/shiprocket/client.ts
@@ -13,6 +13,7 @@ import { isInternationalDestination } from "../destination"
 import { nonEmptyCode, normalizeHsCode } from "../hs-code-resolution"
 import {
   CreateShipmentInput,
+  Dimensions,
   LabelResult,
   PickupLocation,
   RateOption,
@@ -740,6 +741,7 @@ export class ShiprocketClient implements ShippingProviderClient {
         destination_country: query.destination_country,
         weight_grams: query.weight_grams,
         origin_pincode: query.origin_pincode,
+        dimensions_cm: query.dimensions_cm,
       })
     }
     const qs = new URLSearchParams({
@@ -932,6 +934,7 @@ export class ShiprocketClient implements ShippingProviderClient {
     weight_grams?: number
     order_id?: string | number
     origin_pincode?: string
+    dimensions_cm?: Dimensions
   }): Promise<RateOption[]> {
     // Two modes, BOTH live-verified 2026-08-06:
     //  · `order_id` — prices an existing Shiprocket order in its own currency.
@@ -956,6 +959,19 @@ export class ShiprocketClient implements ShippingProviderClient {
       }
       qs.set("weight", String(Math.max(0.01, (query.weight_grams || 500) / 1000)))
       qs.set("delivery_country", (query.destination_country || "").toUpperCase())
+      // Dimensions are NOT cosmetic on a cross-border quote — international
+      // couriers price on VOLUMETRIC weight, and the size also decides who will
+      // carry it. Live-verified (176215→IL, 1.2 kg actual):
+      //   no dims        → 5 couriers, charge weight 1.2, SRX Economy Pro ₹3119
+      //   30×25×10       → charge weight 1.5, SRX Economy Pro ₹3700
+      //   60×50×40       → only 2 couriers left, Aramex ₹8477 → ₹57,937 (24 kg)
+      // Quoting without them understates the price and offers couriers that
+      // cannot take the parcel.
+      if (query.dimensions_cm) {
+        qs.set("length", String(query.dimensions_cm.length))
+        qs.set("breadth", String(query.dimensions_cm.width))
+        qs.set("height", String(query.dimensions_cm.height))
+      }
     }
     if (query.origin_pincode) qs.set("pickup_postcode", query.origin_pincode)
     const json = await this.request<any>(

--- a/apps/backend/src/workflows/orders/__tests__/shiprocket-rates.unit.spec.ts
+++ b/apps/backend/src/workflows/orders/__tests__/shiprocket-rates.unit.spec.ts
@@ -1,4 +1,4 @@
-import { pickRatesPickup } from "../shiprocket-rates"
+import { parseRateQuery, pickRatesPickup } from "../shiprocket-rates"
 import type { PickupLocation } from "../../../modules/shipping-providers/provider-interface"
 
 /**
@@ -50,5 +50,66 @@ describe("pickRatesPickup (#641)", () => {
       undefined
     )
     expect(chosen?.name).toBe("warehouse-a")
+  })
+})
+
+/**
+ * `parseRateQuery` — shared by every rate route so they accept the SAME
+ * parameters. The per-route hand-parsing it replaces is how dimensions ended up
+ * supported on the label call but not on the quote, which then priced a different
+ * parcel than the one that shipped.
+ */
+describe("parseRateQuery", () => {
+  it("reads weight, carrier and a full dimension set", () => {
+    expect(
+      parseRateQuery({
+        carrier: "shiprocket",
+        weight_grams: "1200",
+        length_cm: "30",
+        width_cm: "25",
+        height_cm: "10",
+      })
+    ).toEqual({
+      carrier: "shiprocket",
+      weightGrams: 1200,
+      dimensionsCm: { length: 30, width: 25, height: 10 },
+    })
+  })
+
+  it("accepts the un-suffixed and `breadth` spellings the carrier uses", () => {
+    expect(
+      parseRateQuery({ length: "30", breadth: "25", height: "10" }).dimensionsCm
+    ).toEqual({ length: 30, width: 25, height: 10 })
+  })
+
+  it.each([
+    ["length missing", { width_cm: "25", height_cm: "10" }],
+    ["width missing", { length_cm: "30", height_cm: "10" }],
+    ["height missing", { length_cm: "30", width_cm: "25" }],
+    ["one side blank", { length_cm: "30", width_cm: "", height_cm: "10" }],
+    ["one side zero", { length_cm: "30", width_cm: "0", height_cm: "10" }],
+    ["one side junk", { length_cm: "30", width_cm: "abc", height_cm: "10" }],
+  ])("drops a partial box (%s) rather than guessing a side", (_l, query) => {
+    // Inventing the missing side would silently change the quoted price.
+    expect(parseRateQuery(query).dimensionsCm).toBeUndefined()
+  })
+
+  it("ignores non-positive or unparseable weights", () => {
+    for (const weight_grams of ["0", "-5", "abc", "", null, undefined]) {
+      expect(parseRateQuery({ weight_grams }).weightGrams).toBeUndefined()
+    }
+  })
+
+  it("omits an empty carrier so the workflow default applies", () => {
+    expect(parseRateQuery({ carrier: "" }).carrier).toBeUndefined()
+    expect(parseRateQuery({}).carrier).toBeUndefined()
+  })
+
+  it("returns an all-undefined shape for an empty query", () => {
+    expect(parseRateQuery({})).toEqual({
+      carrier: undefined,
+      weightGrams: undefined,
+      dimensionsCm: undefined,
+    })
   })
 })

--- a/apps/backend/src/workflows/orders/shiprocket-rates.ts
+++ b/apps/backend/src/workflows/orders/shiprocket-rates.ts
@@ -7,6 +7,7 @@ import { resolveShippingProvider } from "../../modules/shipping-providers/resolv
 import { isInternationalDestination } from "../../modules/shipping-providers/destination"
 import { SHIPROCKET_PICKUP_METADATA_KEY } from "../../modules/shipping-providers/pickup-locations"
 import type {
+  Dimensions,
   PickupLocation,
   RateOption,
 } from "../../modules/shipping-providers/provider-interface"
@@ -45,12 +46,22 @@ export type ShiprocketRatesInput = {
   /** Defaults to "shiprocket". */
   carrier?: string
   weightGrams?: number
+  /**
+   * Parcel dimensions. Forwarded to the carrier because a cross-border quote is
+   * priced on VOLUMETRIC weight, and the size also filters which couriers will
+   * accept the parcel — so a quote without them can be both too cheap and list
+   * couriers that would refuse the job. The Carrier step already collects these
+   * (#1213), so the estimate can match the parcel that actually ships.
+   */
+  dimensionsCm?: Dimensions
 }
 
 export type ShiprocketRatesResult = {
   origin_pincode: string
   destination_pincode: string
   weight_grams: number
+  /** Echoed back so the UI can show what the quote was actually priced on. */
+  dimensions_cm?: Dimensions
   cod: boolean
   rates: RateOption[]
   /** Destination country (ISO-2). Present so the UI can label the quote. */
@@ -162,6 +173,7 @@ export async function getShiprocketRatesForOrder(
     destination_pincode: destinationPincode,
     destination_country: destinationCountry || undefined,
     weight_grams: weightGrams,
+    dimensions_cm: input.dimensionsCm,
     cod,
   })
 
@@ -171,7 +183,47 @@ export async function getShiprocketRatesForOrder(
     destination_country: destinationCountry || undefined,
     international,
     weight_grams: weightGrams,
+    dimensions_cm: input.dimensionsCm,
     cod,
     rates,
+  }
+}
+
+/**
+ * Parse the shared `?weight_grams=&length_cm=&width_cm=&height_cm=` rate-quote
+ * query into workflow input. Exported so all four rate routes (admin/partner ×
+ * order/inventory-order) accept the SAME parameters — the previous per-route
+ * hand-parsing is how dimensions ended up supported on the label call but not on
+ * the quote, which then priced a different parcel than the one that shipped.
+ *
+ * Dimensions are all-or-nothing: a partial box (length but no height) can't be
+ * turned into a volume, and guessing the missing side would silently change the
+ * price. Pure — unit-tested.
+ */
+export function parseRateQuery(query: Record<string, any>): {
+  carrier?: string
+  weightGrams?: number
+  dimensionsCm?: Dimensions
+} {
+  const num = (v: any): number | undefined => {
+    if (v == null || v === "") return undefined
+    const n = Number(v)
+    return Number.isFinite(n) && n > 0 ? n : undefined
+  }
+
+  const carrier =
+    typeof query.carrier === "string" && query.carrier ? query.carrier : undefined
+
+  const length = num(query.length_cm ?? query.length)
+  const width = num(query.width_cm ?? query.width ?? query.breadth)
+  const height = num(query.height_cm ?? query.height)
+
+  return {
+    carrier,
+    weightGrams: num(query.weight_grams),
+    dimensionsCm:
+      length != null && width != null && height != null
+        ? { length, width, height }
+        : undefined,
   }
 }

--- a/apps/partner-ui/src/hooks/api/shiprocket.tsx
+++ b/apps/partner-ui/src/hooks/api/shiprocket.tsx
@@ -87,20 +87,39 @@ export type ShiprocketRatesResponse = {
   origin_pincode: string
   destination_pincode: string
   weight_grams: number
+  dimensions_cm?: { length: number; width: number; height: number }
   cod: boolean
   rates: ShiprocketRateOption[]
+  /** Destination country (ISO-2) — set when quoted cross-border. */
+  destination_country?: string
+  /** True when quoted through the carrier's international product. */
+  international?: boolean
 }
 
 /**
  * List the carrier's courier options (rate / ETA / recommended) for one of the
  * partner's own orders, so the Mark-as-Shipped carrier step can show a picker
  * before generating the label. On-demand: pass `enabled` to fetch only when the
- * partner asks (the request hits the live carrier). `weightGrams` feeds the
- * quote from the parcel weight entered in the same step.
+ * partner asks (the request hits the live carrier). `weightGrams` and the parcel
+ * dimensions both feed the quote from the same step, so the estimate is priced on
+ * the parcel that will actually ship.
+ *
+ * Dimensions are NOT optional detail on a cross-border quote: international
+ * couriers price on VOLUMETRIC weight, and the size also decides which of them
+ * will carry the parcel at all. Live-verified 176215→IL at 1.2 kg — adding
+ * 60×50×40 dropped the courier list from 5 to 2 and took Aramex from ₹8,477 to
+ * ₹57,937 (charged as 24 kg). Sent all-or-nothing; a partial box can't be turned
+ * into a volume.
  */
 export const usePartnerShiprocketRates = (
   orderId: string,
-  query?: { carrier?: string; weightGrams?: number },
+  query?: {
+    carrier?: string
+    weightGrams?: number
+    lengthCm?: number
+    widthCm?: number
+    heightCm?: number
+  },
   options?: Omit<
     UseQueryOptions<ShiprocketRatesResponse, FetchError>,
     "queryFn" | "queryKey"
@@ -109,6 +128,11 @@ export const usePartnerShiprocketRates = (
   const params = new URLSearchParams()
   if (query?.carrier) params.set("carrier", query.carrier)
   if (query?.weightGrams) params.set("weight_grams", String(query.weightGrams))
+  if (query?.lengthCm && query?.widthCm && query?.heightCm) {
+    params.set("length_cm", String(query.lengthCm))
+    params.set("width_cm", String(query.widthCm))
+    params.set("height_cm", String(query.heightCm))
+  }
   const qs = params.toString() ? `?${params.toString()}` : ""
 
   return useQuery({

--- a/apps/partner-ui/src/routes/orders/order-create-shipment/components/order-create-shipment-form/carrier-tab.tsx
+++ b/apps/partner-ui/src/routes/orders/order-create-shipment/components/order-create-shipment-form/carrier-tab.tsx
@@ -99,6 +99,11 @@ export const CarrierTab = ({
   const isShiprocket = carrier === "shiprocket"
   const [ratesRequested, setRatesRequested] = useState(false)
   const [rateWeight, setRateWeight] = useState<number | undefined>(undefined)
+  const [rateDims, setRateDims] = useState<{
+    lengthCm?: number
+    widthCm?: number
+    heightCm?: number
+  }>({})
   const [selectedCourierId, setSelectedCourierId] = useState<
     string | number | undefined
   >(undefined)
@@ -109,7 +114,7 @@ export const CarrierTab = ({
     error: ratesError,
   } = usePartnerShiprocketRates(
     orderId,
-    { weightGrams: rateWeight },
+    { weightGrams: rateWeight, ...rateDims },
     { enabled: ratesRequested && isShiprocket && !existingAwb }
   )
 
@@ -119,9 +124,19 @@ export const CarrierTab = ({
   }
 
   const handleGetRates = () => {
-    // Quote against the weight typed in the parcel block, so the estimate
-    // matches the parcel that will actually ship.
-    setRateWeight(numeric(form.getValues().weight_grams))
+    // Quote against the weight AND dimensions typed in the parcel block, so the
+    // estimate matches the parcel that will actually ship. Dimensions are not a
+    // refinement on a cross-border quote — international couriers price on
+    // volumetric weight and the size filters who will carry it at all, so a
+    // quote without them can be far too cheap and list couriers that would
+    // refuse the parcel.
+    const values = form.getValues()
+    setRateWeight(numeric(values.weight_grams))
+    setRateDims({
+      lengthCm: numeric(values.length_cm),
+      widthCm: numeric(values.width_cm),
+      heightCm: numeric(values.height_cm),
+    })
     setSelectedCourierId(undefined)
     setRatesRequested(true)
   }


### PR DESCRIPTION
Answers "the intl rate calculator still comes back empty" — and fixes a regression I shipped in #1215.

## Why it looked empty in prod

**The deploy had not run.** Every workflow run was still `queued`, so prod was serving pre-#1215 code. Confirmed from the response *shape* rather than guessed — `GET /admin/orders/<id>/shiprocket-rates` came back with neither `destination_country` nor `international`, the two fields #1215 adds:

```json
{ "origin_pincode": "176215", "destination_pincode": "9339904",
  "weight_grams": 1200, "cod": false, "rates": [] }
```

Nothing to fix there; it works when the deploy lands. Verified the logic directly against the live carrier for that exact case — origin `176215` → Israel, 1.2 kg → **5 couriers**, SRX Economy ₹1459 recommended.

## The real bug: dimensions were never sent on a quote

Only the label call sent them. That isn't a refinement — international couriers price on **volumetric weight**, and size also decides who will carry the parcel. Live-verified, 176215 → IL, 1.2 kg actual:

| dimensions | couriers | effect |
|---|---|---|
| none | 5 | charge wt 1.2 · SRX Economy Pro ₹3119 |
| 30×25×10 | 5 | charge wt **1.5** · SRX Economy Pro **₹3700** |
| 60×50×40 | **2** | Aramex ₹8477 → **₹57,937** (charged as **24 kg**) |

So a quote could be far too cheap *and* list couriers that would refuse the job. The Carrier step already collects dimensions for the label (#1213); now the quote uses the same numbers and echoes them back so the UI can show what was priced.

Adds `parseRateQuery`, shared across the rate routes so they accept identical params — the per-route hand-parsing is precisely how dimensions ended up wired into the label but not the quote. All-or-nothing: a partial box can't become a volume, and guessing the missing side would silently change the price.

## A regression I shipped in #1215

**#1215 broke 4 integration tests and I merged it.** Verified they all pass at `4218fa150` (pre-#1215) and fail on `main` — so this is mine, not pre-existing.

Both specs were **pinning the old, wrong behaviour**:
- `shiprocket-rates.spec` — the fixture ships to the **US** but asserted the 2-courier **domestic** stub response. In production that path returns an *empty* list, which is the bug the user hit.
- `retail-order-international-shiprocket.spec` — asserted `igstPaymentStatus: "A"`, which CSB-5 rejects outright, so it was never shippable.

Updated to the correct expectations, and added the assertions that would have caught #1215 at the create step: the explicit `shipping_*` delivery block, and `international: true` on the quote.

**Why neither gate caught it:** PR CI runs only *changed specs*, and I changed the workflow without touching its spec. Exactly the hole I flagged in #1215's own PR body — I noted the specs "were not run" without checking whether they would still pass. Local Postgres does work (it's Docker over TCP, not broken as the handoffs claimed), so these now run locally.

## Verification

- **54 shipping integration tests green** across all 8 shiprocket/customs specs — rates 8, partner-label 8, intl 3, inventory 20, hs-codes 5, partner-routes 2, attach-awb 2, pickup 6.
- **177 unit tests** pass.
- Backend `tsc` **79 = baseline** (an unimported `Dimensions` briefly made it 80 — caught by diffing which *files* the errors sit in, not the count). partner-ui `tsc` **4 = baseline**.

🤖 Generated with [Claude Code](https://claude.com/claude-code)