### PR TITLE
fix(partners): add the missing auth matcher for the fulfillment-label alias (#1204)

### DIFF
--- a/apps/backend/integration-tests/http/partner-shiprocket-routes.spec.ts
+++ b/apps/backend/integration-tests/http/partner-shiprocket-routes.spec.ts
@@ -135,21 +135,34 @@ setupSharedTestSuite(() => {
       const order = await createOrder(unique)
       await linkPartnerOrder(owner.partnerId, order.id)
 
+      // 404, not 401 — and the difference IS the test (#1204).
+      //
+      // This route re-exports `shiprocket-label`'s handler verbatim, so the only
+      // thing unique to the alias is its matcher. Until #1204 it had none:
+      // `authenticate` never ran, `auth_context` was always undefined, and the
+      // handler refused EVERY caller with UNAUTHORIZED — the legitimate owner
+      // included. The old assertion expected that 401 and so passed while the
+      // route was completely broken.
+      //
+      // 404 can only be reached by authenticating successfully and THEN failing
+      // the ownership lookup, which is precisely what a working matcher buys.
+      // Regress the matcher and this flips back to 401.
       await expect(
         api.post(
           `/partners/orders/${order.id}/fulfillment-label`,
           {},
           { headers: intruder.headers }
         )
-        // 401 since #1202 (was 400 via the collapsed error handler).
-        //
-        // ⚠️ This assertion passes for the WRONG REASON. `/partners/orders/:id/
-        // fulfillment-label` has NO matcher in src/api/middlewares.ts, so
-        // `authenticate` never runs, `auth_context` is always undefined, and the
-        // route refuses EVERY caller — the legitimate owner included. It has
-        // therefore never tested ownership. Tracked in #1204; once the matcher
-        // exists a genuine intruder should get 404, like the two routes above.
-      ).rejects.toMatchObject({ response: { status: 401 } })
+      ).rejects.toMatchObject({ response: { status: 404 } })
+
+      // NOTE: no owner-passes-through assertion here, deliberately. The sibling
+      // test proves that with `attach-awb`, whose body validation trips before
+      // any carrier work. This handler has no such gate: after the ownership
+      // check it resolves a ship-from location, and `pickPartnerShipFromLocation`
+      // falls back to the first linked location — so the fixture's warehouse
+      // qualifies and an owner's request would proceed into a LIVE Shiprocket
+      // label call. The 404-vs-401 discriminator above already proves the
+      // matcher authenticates; buying the owner half is not worth a live call.
     })
   })
 })

--- a/apps/backend/src/api/middlewares.ts
+++ b/apps/backend/src/api/middlewares.ts
@@ -5159,6 +5159,20 @@ export default defineMiddlewares({
       ],
     },
     {
+      // #1204 — the `fulfillment-label` alias (#835) re-exports the handler
+      // above, but a route file is not a route: with no matcher here
+      // `authenticate` never ran, so `auth_context` was always undefined and
+      // `validatePartnerOrderOwnership` refused EVERY caller, the owner
+      // included. Must stay identical to the canonical matcher above — an alias
+      // that authenticates differently from its target is worse than no alias.
+      matcher: "/partners/orders/:id/fulfillment-label",
+      method: "POST",
+      middlewares: [
+        createCorsPartnerMiddleware(),
+        authenticate("partner", ["session", "bearer"]),
+      ],
+    },
+    {
       matcher: "/partners/orders/:id/shiprocket-rates",
       method: "GET",
       middlewares: [


### PR DESCRIPTION
Closes #1204.

## The bug

`/partners/orders/:id/fulfillment-label` re-exports the `shiprocket-label`
handler, but had **no entry in `src/api/middlewares.ts`** — a route file is not
a route. With no matcher `authenticate` never ran, so `req.auth_context` was
always undefined, `getPartnerFromAuthContext` returned null, and
`validatePartnerOrderOwnership` threw `UNAUTHORIZED` for **every** caller, the
legitimate owner included. Partner label generation on this endpoint has never
worked for anyone.

The new matcher is a byte-for-byte copy of the canonical `shiprocket-label` one:
an alias that authenticates differently from its target is worse than no alias.

## The test that hid it

The spec asserted an intruder got **401** — which passed while the route was
completely broken, because *everyone* got 401. It now asserts **404**, only
reachable by authenticating successfully and *then* failing the ownership
lookup, which is exactly what a working matcher buys.

Verified as a genuine tripwire rather than assumed:

| middlewares.ts | spec |
|---|---|
| matcher removed | ✕ fails — expected 404, received 401 |
| matcher present | ✓ passes |

## One deliberate omission

The issue also asked for an owner-passes-through assertion. I did not add one.
Unlike the `attach-awb` sibling (whose body validation trips first), this handler
has no gate between the ownership check and the carrier call, and
`pickPartnerShipFromLocation` falls back to the *first* linked location — so the
fixture's warehouse qualifies and an owner's request would proceed into a **live
Shiprocket label call**. The 404-vs-401 discriminator already proves the matcher
authenticates; the owner half is not worth a billable call in CI. Reasoning is
recorded in the spec.

## Verify

```
pnpm test:integration:http:shared ./integration-tests/http/partner-shiprocket-routes.spec.ts
```

## Note on callers

The alias has no real callers today — the partner-ui `useFulfillmentLabel` hook
only uses the string as a react-query key and fetches
`/fulfillments/:fulfillmentId/label`. Restored rather than deleted because the
partner API is an external surface.

🤖 Generated with [Claude Code](https://claude.com/claude-code)