### PR TITLE
fix(customs): reject a short HSN before the carrier does (intl needs 8 digits)

### DIFF
--- a/apps/backend/integration-tests/http/retail-order-international-shiprocket.spec.ts
+++ b/apps/backend/integration-tests/http/retail-order-international-shiprocket.spec.ts
@@ -193,7 +193,7 @@ setupSharedTestSuite(() => {
               title: "Tangaliya Stole",
               quantity: 1,
               unit_price: 1500,
-              metadata: { hsn: "621410" },
+              metadata: { hsn: "62141010" },
             },
           ],
         },
@@ -250,7 +250,7 @@ setupSharedTestSuite(() => {
       expect(String(body.shipping_phone ?? "")).not.toBe("")
 
       // HSN reached the line item.
-      expect(body.order_items[0].hsn).toBe("621410")
+      expect(body.order_items[0].hsn).toBe("62141010")
       // Ships from the partner's registered India pickup.
       const nickname = `warehouse-${locationId.slice(-8)}`
       expect(body.pickup_location).toBe(nickname)
@@ -269,7 +269,7 @@ setupSharedTestSuite(() => {
             {
               title: "OS",
               sku: `STOLE-${Date.now()}`,
-              hs_code: "621410",
+              hs_code: "62141010",
               manage_inventory: false, // no stock-location association needed
               options: { Size: "OS" },
               prices: [{ currency_code: "usd", amount: 1500 }],
@@ -317,7 +317,7 @@ setupSharedTestSuite(() => {
       )
       expect(res.status).toBe(200)
       // HSN reached the customs body from the variant's hs_code.
-      expect(shiprocketStubState.lastIntlAdhocBody.order_items[0].hsn).toBe("621410")
+      expect(shiprocketStubState.lastIntlAdhocBody.order_items[0].hsn).toBe("62141010")
     })
 
     it("rejects the international shipment when a line has no HSN code", async () => {
@@ -359,6 +359,68 @@ setupSharedTestSuite(() => {
         .catch((e: any) => e.response)
       expect(res.status).toBe(400)
       expect(res.data.message).toMatch(/HSN code is required/i)
+    })
+
+    /**
+     * A code can be PRESENT and still rejected. `/international/*` requires at
+     * least 8 digits; the domestic endpoint documents 1–15, which is what
+     * `normalizeHsCode` enforces. So a 6-digit WCO heading passed every check we
+     * had and died at the carrier — the live 422 on order 79 (2026-08-07) named
+     * all six lines at once:
+     *   "order_items.0.hsn: The order_items.0.hsn must be at least 8 characters"
+     *
+     * This asserts the rejection happens HERE, before the carrier call, naming
+     * the offending line and its current code.
+     */
+    it("rejects a 6-digit HSN before the carrier sees it (422: 'at least 8 characters')", async () => {
+      const draft = await api.post(
+        "/admin/draft-orders",
+        {
+          email: "buyer3@t.com",
+          region_id: regionId,
+          sales_channel_id: salesChannelId,
+          currency_code: "usd",
+          shipping_address: {
+            first_name: "Short",
+            last_name: "Hsn",
+            address_1: "9 Buyer Rd",
+            city: "Dallas",
+            province: "TX",
+            postal_code: "75201",
+            country_code: "us",
+            phone: "8887776665",
+          },
+          items: [
+            {
+              title: "Six Digit Shirt",
+              quantity: 1,
+              unit_price: 1500,
+              // The exact shape that shipped to prod: a valid WCO heading that
+              // the international endpoint refuses.
+              metadata: { hsn: "620520" },
+            },
+          ],
+        },
+        adminHeaders
+      )
+      const converted = await api.post(
+        `/admin/draft-orders/${draft.data.draft_order.id}/convert-to-order`,
+        {},
+        adminHeaders
+      )
+
+      const res = await api
+        .post(
+          `/partners/orders/${converted.data.order?.id}/shiprocket-label`,
+          {},
+          { headers: partnerHeaders }
+        )
+        .catch((e: any) => e.response)
+
+      expect(res.status).toBe(400)
+      expect(res.data.message).toMatch(/8-digit|at least/i)
+      // Names the line AND its current code, so the fix is obvious.
+      expect(res.data.message).toMatch(/620520/)
     })
   })
 })

--- a/apps/backend/src/modules/shipping-providers/shiprocket/__tests__/create-international-shipment.unit.spec.ts
+++ b/apps/backend/src/modules/shipping-providers/shiprocket/__tests__/create-international-shipment.unit.spec.ts
@@ -26,7 +26,10 @@ const usInput = (over: Partial<CreateShipmentInput> = {}): CreateShipmentInput =
     pincode: "75201",
     country: "US",
   },
-  items: [{ name: "Silk Scarf", sku: "SCARF-1", quantity: 2, unit_price: 40, hsn: "6214" }],
+  // 8-digit ITC-HS (6214.10.10, silk scarves). The fixture used to carry the
+  // 4-digit "6214", which `/international/*` rejects outright — so every test
+  // built on it was asserting against a body the carrier would never accept.
+  items: [{ name: "Silk Scarf", sku: "SCARF-1", quantity: 2, unit_price: 40, hsn: "62141010" }],
   weight_grams: 600,
   sub_total: 80,
   currency: "USD",
@@ -114,7 +117,7 @@ describe("buildInternationalCreateBody", () => {
       commodity: true,
       sub_total: 80,
     })
-    expect(body.order_items[0]).toMatchObject({ sku: "SCARF-1", hsn: "6214", units: 2 })
+    expect(body.order_items[0]).toMatchObject({ sku: "SCARF-1", hsn: "62141010", units: 2 })
   })
 
   // The bug behind `assign/awb` 400 ["Delivery pincode is empty","Customer phone
@@ -185,6 +188,69 @@ describe("buildInternationalCreateBody", () => {
       items: [{ name: "Shirt", sku: "S-1", quantity: 1, unit_price: 20, hsn: "N/A" }],
     })
     expect(() => buildInternationalCreateBody(input, "wh")).toThrow(/HSN code is required/i)
+  })
+
+  /**
+   * The live 422 this guard exists for, reproduced from order 79 (2026-08-07):
+   *   "order_items.0.hsn: The order_items.0.hsn must be at least 8 characters"
+   *   … repeated for every line.
+   *
+   * All six products carried a 6-digit WCO heading, which the DOMESTIC endpoint
+   * accepts (documented 1–15) and `normalizeHsCode` therefore allows. The failure
+   * was invisible until the carrier saw it.
+   */
+  it("rejects a 6-digit HSN before the call (422: 'must be at least 8 characters')", () => {
+    const input = usInput({
+      items: [
+        { name: "Garpön Kala Cotton Shirt", sku: "S-1", quantity: 1, unit_price: 20, hsn: "620520" },
+        { name: "Lamyig Canvas Carryall", sku: "S-2", quantity: 1, unit_price: 30, hsn: "420222" },
+      ],
+    })
+    expect(() => buildInternationalCreateBody(input, "wh")).toThrow(
+      /at least|8-digit/i
+    )
+  })
+
+  it("names every short line and its current code, so one fix clears them all", () => {
+    const input = usInput({
+      items: [
+        { name: "Shirt", sku: "S-1", quantity: 1, unit_price: 20, hsn: "620520" },
+        { name: "Carryall", sku: "S-2", quantity: 1, unit_price: 30, hsn: "420222" },
+        { name: "Apron", sku: "S-3", quantity: 1, unit_price: 15, hsn: "62114900" },
+      ],
+    })
+    try {
+      buildInternationalCreateBody(input, "wh")
+      throw new Error("expected a throw")
+    } catch (e: any) {
+      expect(e.message).toMatch(/Shirt \(620520\)/)
+      expect(e.message).toMatch(/Carryall \(420222\)/)
+      // The already-valid 8-digit line must NOT be blamed.
+      expect(e.message).not.toMatch(/Apron/)
+    }
+  })
+
+  /**
+   * Zero-padding 6→8 is deliberately NOT done. The last two digits are an Indian
+   * national subheading: 4202.22 splits into 42022210/20/30/40/90 and there is no
+   * 42022200, so padding would invent a tariff line and declare it to customs.
+   */
+  it("does not pad a short HSN to 8 digits", () => {
+    const input = usInput({
+      items: [{ name: "Carryall", sku: "S-2", quantity: 1, unit_price: 30, hsn: "420222" }],
+    })
+    expect(() => buildInternationalCreateBody(input, "wh")).toThrow()
+    // …rather than silently producing "42022200".
+  })
+
+  it("accepts a full 8-digit ITC-HS code", () => {
+    const body = buildInternationalCreateBody(
+      usInput({
+        items: [{ name: "Shirt", sku: "S-1", quantity: 1, unit_price: 20, hsn: "62052000" }],
+      }),
+      "wh"
+    )
+    expect(body.order_items[0].hsn).toBe("62052000")
   })
 
   it("falls back billing_state to the city when the address has none (422: 'billing state field is required')", () => {

--- a/apps/backend/src/modules/shipping-providers/shiprocket/client.ts
+++ b/apps/backend/src/modules/shipping-providers/shiprocket/client.ts
@@ -32,6 +32,13 @@ import { MedusaError } from "@medusajs/framework/utils"
 
 const BASE_URL = "https://apiv2.shiprocket.in/v1/external"
 
+/**
+ * Minimum HSN length accepted by `/international/*` — live-verified against a
+ * 422 that named every line at once. India's ITC-HS export schedule is 8-digit;
+ * the 6-digit WCO heading that satisfies the DOMESTIC endpoint is rejected here.
+ */
+export const INTERNATIONAL_HSN_MIN_DIGITS = 8
+
 /** The subset of `fetch` the client uses — injectable so tests/CI can supply a
  *  deterministic transport instead of patching the global (which doesn't reliably
  *  cross the test ↔ in-process-server boundary). See `stub-fetch.ts`. (#647) */
@@ -417,8 +424,9 @@ export function resolveCustomsDefaults(
  * Build the Shiprocket INTERNATIONAL `create/adhoc` body from a shipment input.
  * Pure & exported so the exact customs payload (country name, currency, HSN,
  * export reason) is unit-testable without a live API. Throws if HSN is missing
- * on any line (Shiprocket makes HSN mandatory for every international shipment)
- * or if the caller asked for COD (unavailable internationally).
+ * or shorter than 8 digits on any line (Shiprocket makes a full-length HSN
+ * mandatory for every international shipment) or if the caller asked for COD
+ * (unavailable internationally).
  */
 export function buildInternationalCreateBody(
   input: CreateShipmentInput,
@@ -436,6 +444,28 @@ export function buildInternationalCreateBody(
     throw new MedusaError(
       MedusaError.Types.INVALID_DATA,
       `HSN code is required for international shipments; missing on: ${missingHsn.join(", ")}`
+    )
+  }
+  // A code can be PRESENT and still rejected: `/international/*` requires at
+  // least 8 digits ("The order_items.0.hsn must be at least 8 characters"),
+  // while the domestic endpoint documents 1–15 — which is what `normalizeHsCode`
+  // enforces. So the common 6-digit WCO code (620520, 420222 …) passes every
+  // check we have and dies at the carrier, one 422 listing every line at once.
+  //
+  // Deliberately NOT auto-padded to 8. The first 6 digits are the internationally
+  // harmonised heading; the last 2 are a NATIONAL subheading, and India's ITC-HS
+  // does not simply zero-extend — 4202.22 splits into 42022210/20/30/40/90 with
+  // no 42022200 at all. Padding would invent a tariff line that doesn't exist and
+  // put it on a customs declaration; the same reason a non-numeric code is
+  // treated as missing rather than coerced. Only a human can pick the right
+  // subheading, so name the lines and their current codes and stop here.
+  const shortHsn = items.filter((i) => i.hsn.length < INTERNATIONAL_HSN_MIN_DIGITS)
+  if (shortHsn.length) {
+    throw new MedusaError(
+      MedusaError.Types.INVALID_DATA,
+      `Shiprocket requires an ${INTERNATIONAL_HSN_MIN_DIGITS}-digit HSN code for international shipments, but these lines carry a shorter one: ` +
+        `${shortHsn.map((i) => `${i.name} (${i.hsn})`).join(", ")}. ` +
+        `Set the full ${INTERNATIONAL_HSN_MIN_DIGITS}-digit ITC-HS code on the product, variant or inventory item — do not pad with zeros, as the last two digits are an Indian national subheading.`
     )
   }
   // Pre-flight the delivery fields Shiprocket rejects downstream. Without this


### PR DESCRIPTION
## The failure

Live 422 from `/international/orders/create/adhoc` on order 79:

```
order_items.0.hsn: The order_items.0.hsn must be at least 8 characters
… repeated for all six lines
```

`/international/*` requires **≥8 digits**. The domestic endpoint documents 1–15,
and that is what `normalizeHsCode` enforces — so a 6-digit WCO heading
(`620520`, `420222`, …) passes every check we have and only dies at the carrier,
after the order body is already built. Every line of that order carried one.

## The fix

Extends the existing international pre-flight with a length check, naming each
offending line **with its current code** so one round of data-fixing clears them
all — same shape as the missing phone/pincode guard from #1215.

## Why it does NOT auto-pad 6→8

Tempting, and wrong. The first six digits are the internationally harmonised
heading; the last two are an **Indian national subheading**, and ITC-HS does not
zero-extend. `4202.22` splits into `42022210 / 20 / 30 / 40 / 90` — there is no
`42022200`. Padding would invent a tariff line that doesn't exist and put it on a
customs declaration. Only a human can pick the right subheading, so the guard
stops and says which lines need one. Same reasoning as treating a non-numeric
code as missing rather than coercing it.

## The fixtures were pinning invalid data

Worth calling out, because it is the #1215 pattern again:

| fixture | was | reality |
|---|---|---|
| `create-international-shipment.unit.spec.ts` | `hsn: "6214"` (4-digit) | carrier rejects |
| `retail-order-international-shiprocket.spec.ts` | `hsn: "621410"` (6-digit) | carrier rejects |

Every assertion built on them described a body that could never succeed. Both now
use a real 8-digit ITC-HS code (`62141010`, silk scarves). Adding the guard made
11 existing unit tests fail — that failure was the fixtures being wrong, not the
guard.

## Tests

- Unit: rejects 6-digit; names every short line + code; does not pad; accepts a
  full 8-digit code.
- Integration: `rejects a 6-digit HSN before the carrier sees it`, asserting a 400
  that names `620520` — the exact code from the live failure.

## Verify

```
npx jest --testPathPattern="create-international-shipment.unit"      # 27 passed
pnpm test:integration:http:shared ./apps/backend/integration-tests/http/retail-order-international-shiprocket.spec.ts   # 4 passed
```

Also ran the whole surface rather than assuming: 149 shiprocket/customs unit
tests and all 8 shiprocket/customs integration specs (55 tests) pass.

## Follow-up (data, not code)

This unblocks the error message, not the shipment. A prod audit of all 75
products: **1** has an 8-digit code, **65** have none, **9** carry a 6-digit code
that this guard will now reject. Those need real ITC-HS codes before the
international order can label — and `620469` on a *cotton shirt* looks like a
misclassification worth a second look.

🤖 Generated with [Claude Code](https://claude.com/claude-code)