### PR TITLE
fix(shipping): try the next intl courier, opt out of insurance, name credits to partners

### DIFF
--- a/apps/backend/src/api/partners/orders/[id]/shiprocket-label/route.ts
+++ b/apps/backend/src/api/partners/orders/[id]/shiprocket-label/route.ts
@@ -84,6 +84,10 @@ export const POST = async (
     preferredCourierId,
     weightGrams,
     dimensionsCm,
+    // Carrier-account failures must read as something a PARTNER can act on —
+    // "load courier credits or contact support", not "open the Shiprocket
+    // dashboard" (they have no login for the shared platform account).
+    audience: "partner",
   })
 
   res.status(200).json({ shiprocket_label: shipment })

--- a/apps/backend/src/modules/shipping-providers/shiprocket/__tests__/create-international-shipment.unit.spec.ts
+++ b/apps/backend/src/modules/shipping-providers/shiprocket/__tests__/create-international-shipment.unit.spec.ts
@@ -118,6 +118,11 @@ describe("buildInternationalCreateBody", () => {
       sub_total: 80,
     })
     expect(body.order_items[0]).toMatchObject({ sku: "SCARF-1", hsn: "62141010", units: 2 })
+    // Insurance opted OUT explicitly. `is_insurance_opt` is the only field that
+    // moves it (live-verified 2026-08-08: 1 ⇒ opted, 0/absent ⇒ not) — sending 0
+    // keeps us opted out even if the account's auto-insurance toggle is flipped,
+    // instead of silently paying a premium (a live IL quote wanted 362.39).
+    expect(body.is_insurance_opt).toBe(0)
   })
 
   // The bug behind `assign/awb` 400 ["Delivery pincode is empty","Customer phone
@@ -420,6 +425,113 @@ describe("ShiprocketClient.createShipment — international routing", () => {
     const createIdx = hits.findIndex((h) => h.url.includes("/international/orders/create/adhoc"))
     const svcIdx = hits.findIndex((h) => h.url.includes("/international/courier/serviceability"))
     expect(svcIdx).toBeGreaterThan(createIdx)
+  })
+
+  /**
+   * Live-verified 2026-08-08, order 79 → IL: the RECOMMENDED courier
+   * `SRX Economy (384)` refuses the shipment while `SRX Premium Plus Pro (262)`
+   * assigns the identical body/pickup/address instantly. 384's refusal arrives
+   * as `["Delivery pincode is empty","Customer phone is empty"]` — on an address
+   * Shiprocket has recorded — so the whole label used to die on a message that
+   * named fields which were not the problem.
+   */
+  it("falls through to the next courier when the recommended one refuses", async () => {
+    const assigns: any[] = []
+    const real = global.fetch?.bind(globalThis)
+    fetchSpy = jest
+      .spyOn(global, "fetch" as any)
+      .mockImplementation(async (input: any, init: any = {}) => {
+        const url = String(input)
+        if (!url.includes("shiprocket.in")) return real?.(input, init)
+        const path = url.replace("https://apiv2.shiprocket.in/v1/external", "")
+        if (path.includes("/international/orders/create/adhoc"))
+          return make({ shipment_id: 700, order_id: 800 })
+        if (path.includes("/international/courier/serviceability"))
+          return make({
+            data: {
+              recommended_courier_company_id: 384,
+              available_courier_companies: [
+                { courier_company_id: 384, courier_name: "SRX Economy", rate: { rate: 1100 } },
+                { courier_company_id: 262, courier_name: "SRX Premium Plus Pro", rate: { rate: 1300 } },
+              ],
+            },
+          })
+        if (path.includes("/international/courier/assign/awb")) {
+          const body = JSON.parse(init.body)
+          assigns.push(body.courier_id)
+          // 384 refuses the way the live account does: a 400 naming the wrong fields.
+          if (body.courier_id === 384)
+            return make(
+              { message: '["Delivery pincode is empty","Customer phone is empty"]' },
+              400
+            )
+          return make({
+            response: { data: { awb_code: "INTLAWB262", courier_company_id: 262 } },
+          })
+        }
+        if (path.endsWith("/courier/generate/label")) return make({ label_url: "x.pdf" })
+        return make({}, 404)
+      })
+
+    const client = new ShiprocketClient({
+      email: "x@y.com",
+      password: "p",
+      token: "injected-token",
+      pickup_location: "warehouse-abc",
+    })
+
+    const result = await client.createShipment(usInput())
+
+    expect(result.awb).toBe("INTLAWB262")
+    // Recommended first, then the fallback — and the refusal did not fail the label.
+    expect(assigns).toEqual([384, 262])
+    // The refs describe the courier that actually took it, not the recommended one.
+    expect(result.provider_refs).toMatchObject({ courier_company_id: 262 })
+  })
+
+  it("fails naming every courier and its own reason once all refuse", async () => {
+    const real = global.fetch?.bind(globalThis)
+    fetchSpy = jest
+      .spyOn(global, "fetch" as any)
+      .mockImplementation(async (input: any, init: any = {}) => {
+        const url = String(input)
+        if (!url.includes("shiprocket.in")) return real?.(input, init)
+        const path = url.replace("https://apiv2.shiprocket.in/v1/external", "")
+        if (path.includes("/international/orders/create/adhoc"))
+          return make({ shipment_id: 700, order_id: 800 })
+        if (path.includes("/international/courier/serviceability"))
+          return make({
+            data: {
+              recommended_courier_company_id: 384,
+              available_courier_companies: [
+                { courier_company_id: 384, courier_name: "SRX Economy", rate: { rate: 1100 } },
+                { courier_company_id: 262, courier_name: "SRX Premium Plus Pro", rate: { rate: 1300 } },
+              ],
+            },
+          })
+        if (path.includes("/international/courier/assign/awb")) {
+          const body = JSON.parse(init.body)
+          // The other live shape: HTTP 200 with awb_assign_status 0 and no AWB.
+          if (body.courier_id === 262)
+            return make({
+              awb_assign_status: 0,
+              response: { data: "Courier is facing some issues, Please try after sometime." },
+            })
+          return make({ message: '["Delivery pincode is empty"]' }, 400)
+        }
+        return make({}, 404)
+      })
+
+    const client = new ShiprocketClient({
+      email: "x@y.com",
+      password: "p",
+      token: "injected-token",
+      pickup_location: "warehouse-abc",
+    })
+
+    await expect(client.createShipment(usInput())).rejects.toThrow(
+      /No international courier would accept this shipment.*SRX Economy \(384\).*SRX Premium Plus Pro \(262\).*facing some issues/s
+    )
   })
 
   it("keeps a domestic (India) destination on the domestic endpoints", async () => {

--- a/apps/backend/src/modules/shipping-providers/shiprocket/__tests__/create-shipment.unit.spec.ts
+++ b/apps/backend/src/modules/shipping-providers/shiprocket/__tests__/create-shipment.unit.spec.ts
@@ -154,6 +154,9 @@ describe("ShiprocketClient.createShipment (#404 PR-B)", () => {
       sub_total: 250,
     })
 
+    // Domestic opts out of shipment insurance explicitly too — same field, same
+    // reason as the international body (don't inherit the account toggle).
+    expect(createBodies[0].is_insurance_opt).toBe(0)
     // Two creates: the original reference, then the suffixed retry.
     expect(createBodies).toHaveLength(2)
     expect(createBodies[0].order_id).toBe("inv_order_CANCELLED1")

--- a/apps/backend/src/modules/shipping-providers/shiprocket/__tests__/describe-intl-prereq-error.unit.spec.ts
+++ b/apps/backend/src/modules/shipping-providers/shiprocket/__tests__/describe-intl-prereq-error.unit.spec.ts
@@ -58,6 +58,29 @@ describe("describeIntlPrereqError (#1118)", () => {
     expect(g?.message).toMatch(/wallet/i)
   })
 
+  /**
+   * A partner has no Shiprocket login — the shared carrier account is the
+   * platform's. Pointing them at "Billing → Recharge" is advice they cannot act
+   * on, so every gate carries partner-facing copy that names what they CAN do.
+   */
+  it("gives every gate partner-facing copy that never mentions the dashboard", () => {
+    const gates = [
+      describeIntlPrereqError({ message: "Insufficient amount to label this shipment" }),
+      describeIntlPrereqError({ message: "KYC is not verified" }),
+      describeIntlPrereqError({ message: "settlement bank details missing" }),
+      describeIntlPrereqError({ message: "pickup location is not enabled for international" }),
+    ]
+    for (const g of gates) {
+      expect(g?.partnerMessage).toBeTruthy()
+      expect(g!.partnerMessage).not.toMatch(/shiprocket|dashboard/i)
+      expect(g!.partnerMessage).toMatch(/support|credits/i)
+    }
+    // The wallet case is the one a partner hits in practice — it must name
+    // credits and support, per the wording asked for in the field.
+    expect(gates[0]!.partnerMessage).toMatch(/courier credits/i)
+    expect(gates[0]!.partnerMessage).toMatch(/support/i)
+  })
+
   it("returns null for an unrelated error (caller rethrows untouched)", () => {
     expect(
       describeIntlPrereqError({ message: "HSN code is required for international shipments" })

--- a/apps/backend/src/modules/shipping-providers/shiprocket/client.ts
+++ b/apps/backend/src/modules/shipping-providers/shiprocket/client.ts
@@ -33,6 +33,25 @@ import { MedusaError } from "@medusajs/framework/utils"
 const BASE_URL = "https://apiv2.shiprocket.in/v1/external"
 
 /**
+ * Shipment insurance: OFF, explicitly.
+ *
+ * `is_insurance_opt` is the ONLY field that moves it — live-verified 2026-08-08
+ * against the account: `1` ⇒ serviceability reports
+ * `insurace_opted_at_order_creation: true` (their typo), `0` or omitted ⇒ false.
+ * `insurance`, `is_insurance` and `shipment_insurance` are silently ignored.
+ *
+ * Omitting it already means opted-out today, but only because the account has
+ * `company_auto_shipment_insurance_setting: false`. Sending 0 explicitly keeps us
+ * opted out even if someone flips that dashboard toggle — the premium is real
+ * money (a live IL quote wanted `coverage_charges: 362.39` on top of 848 freight).
+ * Per-courier `insurance_applicable: 1` only means the courier OFFERS it.
+ *
+ * ⚠️ If Shiprocket ever sets `user_insurance_manadatory: true` on the account,
+ * revisit — an explicit 0 may then be rejected rather than ignored.
+ */
+const INSURANCE_OPT_OUT = 0
+
+/**
  * Minimum HSN length accepted by `/international/*` — live-verified against a
  * 422 that named every line at once. India's ITC-HS export schedule is 8-digit;
  * the 6-digit WCO heading that satisfies the DOMESTIC endpoint is rejected here.
@@ -155,7 +174,18 @@ export type IntlPrereqReason =
   | "pickup_not_intl"
   | "insufficient_balance"
 
-export type IntlPrereqGate = { reason: IntlPrereqReason; message: string }
+/**
+ * `message` is admin-facing — it names the Shiprocket dashboard, which only the
+ * platform account holder can reach. `partnerMessage` is what a partner sees:
+ * none of these are theirs to fix (one shared carrier account), so it tells them
+ * the one thing they CAN do instead of pointing them at a dashboard they have no
+ * login for. Pick with `audience` on the shipment call.
+ */
+export type IntlPrereqGate = {
+  reason: IntlPrereqReason
+  message: string
+  partnerMessage: string
+}
 
 export function describeIntlPrereqError(err: {
   message?: string
@@ -182,6 +212,8 @@ export function describeIntlPrereqError(err: {
       reason: "pickup_not_intl",
       message:
         "This pickup location isn't enabled for international shipping in Shiprocket. Enable international shipping for the pickup address in your Shiprocket dashboard (Settings → Pickup Addresses), or choose an international-capable pickup, then retry generating the label.",
+      partnerMessage:
+        "Your pickup address isn't approved for international shipping yet. Please contact support to get it enabled, then retry generating the label.",
     }
   }
 
@@ -201,6 +233,8 @@ export function describeIntlPrereqError(err: {
       reason: "insufficient_balance",
       message:
         "Your Shiprocket wallet doesn't have enough balance to book this waybill. Top up the wallet in your Shiprocket dashboard (Billing → Recharge), then retry generating the label. The shipment details were accepted — only payment is missing.",
+      partnerMessage:
+        "You don't have enough courier credits to book this label. Please load courier credits or contact support, then retry — the shipment details were accepted, only the payment is missing.",
     }
   }
 
@@ -209,6 +243,8 @@ export function describeIntlPrereqError(err: {
       reason: "kyc",
       message:
         "International shipping requires your Shiprocket KYC to be verified. Complete KYC in your Shiprocket dashboard (Settings → KYC), then retry generating the label.",
+      partnerMessage:
+        "International shipping isn't activated on the courier account yet (KYC pending). Please contact support, then retry generating the label.",
     }
   }
 
@@ -222,6 +258,8 @@ export function describeIntlPrereqError(err: {
       reason: "bank_details",
       message:
         "International shipping requires your settlement bank details on file with Shiprocket. Add them in your Shiprocket dashboard (Settings → Company → Bank Details), then retry generating the label.",
+      partnerMessage:
+        "International shipping isn't fully set up on the courier account (settlement bank details missing). Please contact support, then retry generating the label.",
     }
   }
 
@@ -601,6 +639,7 @@ export function buildInternationalCreateBody(
     Terms_Of_Invoice: customs.Terms_Of_Invoice,
     igstPaymentStatus: customs.igstPaymentStatus,
     commodity: customs.commodity,
+    is_insurance_opt: INSURANCE_OPT_OUT,
   }
 }
 
@@ -907,6 +946,7 @@ export class ShiprocketClient implements ShippingProviderClient {
       breadth: input.dimensions_cm?.width || 10,
       height: input.dimensions_cm?.height || 10,
       weight: Math.max(0.01, input.weight_grams / 1000),
+      is_insurance_opt: INSURANCE_OPT_OUT,
     }
 
     const createAdhoc = async (channelOrderId: string) => {
@@ -1095,23 +1135,46 @@ export class ShiprocketClient implements ShippingProviderClient {
     // return the chosen RateOption too so the caller can surface which courier
     // (and rate/currency) was auto-selected — S3 chose auto-select-only, so this
     // read-only visibility replaces a picker.
-    const resolveCourier = async (
+    /**
+     * ORDERED candidates, not one pick. An explicit caller choice is the only
+     * candidate (their call, don't silently ship with someone else). Otherwise:
+     * recommended first, then every other serviceable courier as a fallback.
+     *
+     * Live-verified 2026-08-08 on order 79 → IL: the SAME order body, pickup and
+     * address assigns fine on `SRX Premium Plus Pro (262)` while the RECOMMENDED
+     * `SRX Economy (384)` refuses it — and 384's refusal arrives as
+     * `["Delivery pincode is empty","Customer phone is empty"]` on an address
+     * Shiprocket has demonstrably recorded (`/orders/show` echoes the pincode,
+     * state and country back), or as "Courier is facing some issues". So a
+     * recommended courier that won't take the parcel used to fail the whole
+     * label with an error naming fields that are not the problem.
+     */
+    const resolveCandidates = async (
       srOrderIdForRates: any
-    ): Promise<{ id?: string | number; rate?: RateOption }> => {
-      let rate: RateOption | undefined
+    ): Promise<{ id?: string | number; rate?: RateOption }[]> => {
+      let rates: RateOption[] = []
       try {
-        const rates = await this.getInternationalRates({
-          order_id: srOrderIdForRates,
-        })
-        rate = input.preferred_courier_id
-          ? rates.find(
-              (r) => String(r.courier_id) === String(input.preferred_courier_id)
-            )
-          : rates.find((r) => r.is_recommended) || rates[0]
+        rates = await this.getInternationalRates({ order_id: srOrderIdForRates })
       } catch {
         // best-effort — assign can still auto-select carrier-side.
       }
-      return { id: input.preferred_courier_id ?? rate?.courier_id, rate }
+      if (input.preferred_courier_id != null) {
+        return [
+          {
+            id: input.preferred_courier_id,
+            rate: rates.find(
+              (r) => String(r.courier_id) === String(input.preferred_courier_id)
+            ),
+          },
+        ]
+      }
+      const ordered = [
+        ...rates.filter((r) => r.is_recommended),
+        ...rates.filter((r) => !r.is_recommended),
+      ]
+      // No serviceability at all — one attempt, letting Shiprocket default.
+      if (!ordered.length) return [{}]
+      return ordered.map((rate) => ({ id: rate.courier_id, rate }))
     }
 
     const assignAwb = async (shipmentIdToAssign: any, courierId?: string | number) => {
@@ -1123,11 +1186,65 @@ export class ShiprocketClient implements ShippingProviderClient {
       })
     }
 
+    /**
+     * Walk the candidates until one actually returns an AWB. A refusal is either
+     * a 4xx (throws) or a 200 carrying `awb_assign_status: 0` — both mean "this
+     * courier didn't take it", so both fall through to the next one. Only when
+     * every candidate has refused do we fail, naming each courier and its own
+     * reason; that beats reporting the first courier's misleading message as if
+     * it described the order.
+     */
+    const assignWithFallback = async (
+      shipmentIdToAssign: any,
+      candidates: { id?: string | number; rate?: RateOption }[]
+    ): Promise<{ assigned: any; courier: { id?: string | number; rate?: RateOption } }> => {
+      const refusals: string[] = []
+      for (const candidate of candidates) {
+        const label = candidate.rate?.courier_name
+          ? `${candidate.rate.courier_name} (${candidate.id})`
+          : `courier ${candidate.id ?? "auto"}`
+        let assigned: any
+        try {
+          assigned = await assignAwb(shipmentIdToAssign, candidate.id)
+        } catch (e: any) {
+          // A cancelled-order state is about the ORDER, not this courier —
+          // the caller recreates and retries, so it must not be swallowed.
+          if (e instanceof ShiprocketApiError && /cancell?ed state/i.test(e.message)) {
+            throw e
+          }
+          refusals.push(`${label}: ${e?.message ?? e}`)
+          continue
+        }
+        if (assigned?.response?.data?.awb_code) return { assigned, courier: candidate }
+        const data = assigned?.response?.data
+        const reason =
+          data?.awb_assign_error ||
+          (typeof data === "string" ? data : "") ||
+          assigned?.message ||
+          "no AWB and no reason"
+        refusals.push(`${label}: ${reason}`)
+        // An empty wallet is not a courier's opinion — every remaining candidate
+        // will refuse for the same reason. Stop so the operator gets the balance
+        // error promptly instead of after N round-trips (each one is a request the
+        // browser is waiting on, and the label call is already slow).
+        if (describeIntlPrereqError({ message: reason })?.reason === "insufficient_balance") {
+          break
+        }
+      }
+      throw new ShiprocketApiError(
+        `No international courier would accept this shipment. ${refusals.join(" · ")}`,
+        { status: 400, raw: JSON.stringify(refusals) }
+      )
+    }
+
     let created = await createAdhoc(String(createBody.order_id))
-    let courier = await resolveCourier(created.order_id)
     let assigned: any
+    let courier: { id?: string | number; rate?: RateOption }
     try {
-      assigned = await assignAwb(created.shipment_id, courier.id)
+      ;({ assigned, courier } = await assignWithFallback(
+        created.shipment_id,
+        await resolveCandidates(created.order_id)
+      ))
     } catch (e: any) {
       const cancelled =
         e instanceof ShiprocketApiError && /cancell?ed state/i.test(e.message)
@@ -1135,8 +1252,10 @@ export class ShiprocketClient implements ShippingProviderClient {
       created = await createAdhoc(
         `${input.reference_id}-R${Date.now().toString(36)}`
       )
-      courier = await resolveCourier(created.order_id)
-      assigned = await assignAwb(created.shipment_id, courier.id)
+      ;({ assigned, courier } = await assignWithFallback(
+        created.shipment_id,
+        await resolveCandidates(created.order_id)
+      ))
     }
 
     const srOrderId = created?.order_id

--- a/apps/backend/src/workflows/orders/__tests__/build-create-shipment-input.unit.spec.ts
+++ b/apps/backend/src/workflows/orders/__tests__/build-create-shipment-input.unit.spec.ts
@@ -37,6 +37,47 @@ describe("buildCreateShipmentInput — phone / pincode fallbacks", () => {
     // no phone, no postal_code
   }
 
+  /**
+   * Order 79's shipping address was replaced on 2026-08-07 with one carrying no
+   * first/last name, while billing still held "Yosef Pivk" — so the recipient
+   * went out as the placeholder "Customer" on a commercial-invoice-bearing
+   * international shipment. The name walks the same chain as phone/pincode.
+   */
+  it("falls back the recipient name to billing, then to the customer", () => {
+    const nameless = { ...noContactShipping, first_name: null, last_name: null }
+
+    expect(
+      buildCreateShipmentInput(
+        {
+          ...baseOrder,
+          shipping_address: nameless,
+          billing_address: { first_name: "Yosef", last_name: "Pivk" },
+        },
+        { pickupLocationName: "wh" }
+      ).to.name
+    ).toBe("Yosef Pivk")
+
+    expect(
+      buildCreateShipmentInput(
+        {
+          ...baseOrder,
+          shipping_address: nameless,
+          billing_address: {},
+          customer: { first_name: "Yosef", last_name: "Pivk" },
+        },
+        { pickupLocationName: "wh" }
+      ).to.name
+    ).toBe("Yosef Pivk")
+
+    // Genuinely nameless everywhere — the placeholder is the last resort only.
+    expect(
+      buildCreateShipmentInput(
+        { ...baseOrder, shipping_address: nameless, billing_address: {} },
+        { pickupLocationName: "wh" }
+      ).to.name
+    ).toBe("Customer")
+  })
+
   it("falls back phone to billing, then to the customer", () => {
     const fromBilling = buildCreateShipmentInput(
       {

--- a/apps/backend/src/workflows/orders/shiprocket-shipment.ts
+++ b/apps/backend/src/workflows/orders/shiprocket-shipment.ts
@@ -69,8 +69,13 @@ export type OrderForShipment = {
   shipping_address?: Record<string, any> | null
   /** Fallback source for phone / postal code the shipping address may lack. */
   billing_address?: Record<string, any> | null
-  /** Fallback source for the buyer phone when neither address carries one. */
-  customer?: { phone?: string | null; email?: string | null } | null
+  /** Fallback source for the buyer phone/name when neither address carries one. */
+  customer?: {
+    phone?: string | null
+    email?: string | null
+    first_name?: string | null
+    last_name?: string | null
+  } | null
   items?: Array<{
     /** Line id — the key `fulfillment.items[].line_item_id` points at. */
     id?: string | null
@@ -241,8 +246,17 @@ export function buildCreateShipmentInput(
         : lineSum
   const subTotal = Number.isFinite(goodsTotal) && goodsTotal > 0 ? goodsTotal : lineSum
 
+  // Recipient name: walk shipping → billing → customer, the same fallback the
+  // phone and pincode already do above. Order 79's shipping address was replaced
+  // with one carrying NO first/last name while billing still held "Yosef Pivk",
+  // so we sent `shipping_customer_name: "Customer"` with an empty
+  // `shipping_last_name` — and an international shipment must name its
+  // recipient (it prints on the commercial invoice). "Customer" stays only as
+  // the last resort for a genuinely nameless order.
+  const nameFrom = (src: Record<string, any> | null | undefined) =>
+    [src?.first_name, src?.last_name].filter(Boolean).join(" ").trim()
   const name =
-    [addr.first_name, addr.last_name].filter(Boolean).join(" ") || "Customer"
+    nameFrom(addr) || nameFrom(billing) || nameFrom(order.customer) || "Customer"
 
   return {
     reference_id: order.id,
@@ -302,6 +316,14 @@ export type CreateShiprocketShipmentInput = {
   weightGrams?: number
   dimensionsCm?: Dimensions
   preferredCourierId?: string | number
+  /**
+   * Who is reading the error. Carrier-account failures (empty wallet, KYC,
+   * settlement bank, pickup not international-enabled) are none of a partner's
+   * doing and none of them are fixable from a dashboard they can't log into —
+   * so a partner gets "load courier credits or contact support" where an admin
+   * gets the Shiprocket dashboard path. Defaults to admin wording.
+   */
+  audience?: "admin" | "partner"
 }
 
 export async function createShiprocketShipmentForFulfillment(
@@ -330,6 +352,9 @@ export async function createShiprocketShipmentForFulfillment(
       "billing_address.*",
       "customer.phone",
       "customer.email",
+      // Last-resort recipient name when neither address carries one.
+      "customer.first_name",
+      "customer.last_name",
       // Line id — the join key for `fulfillment.items[].line_item_id`.
       "items.id",
       "items.title",
@@ -556,14 +581,24 @@ export async function createShiprocketShipmentForFulfillment(
   try {
     result = await provider.createShipment(shipmentInput)
   } catch (e: any) {
-    if (isInternationalDestination(shipmentInput.to.country)) {
-      const gate = describeIntlPrereqError({
-        message: e?.message,
-        fieldErrors: e?.fieldErrors,
-      })
-      if (gate) {
-        throw new MedusaError(MedusaError.Types.NOT_ALLOWED, gate.message)
-      }
+    const gate = describeIntlPrereqError({
+      message: e?.message,
+      fieldErrors: e?.fieldErrors,
+    })
+    // KYC / bank / pickup-not-international are international-only signatures.
+    // An empty WALLET is not: a domestic label fails on it identically, and it
+    // used to surface as a raw carrier string ("Insufficient amount to label this
+    // shipment") on the domestic path. Keyword matching is fuzzy, so only the
+    // balance gate is trusted for a domestic destination.
+    const applies =
+      gate &&
+      (isInternationalDestination(shipmentInput.to.country) ||
+        gate.reason === "insufficient_balance")
+    if (gate && applies) {
+      throw new MedusaError(
+        MedusaError.Types.NOT_ALLOWED,
+        input.audience === "partner" ? gate.partnerMessage : gate.message
+      )
     }
     throw e
   }


### PR DESCRIPTION
## Why

Order 79 → IL could not be labelled: `/international/courier/assign/awb` 400'd with `["Delivery pincode is empty","Customer phone is empty"]` on an address carrying both.

A live A/B on the account (one create, then assign per courier) found the cause — **it is a per-courier refusal, not a payload problem**:

```
recommended_courier_company_id = 384
SRX Economy(384)*         → refuses ("Delivery pincode is empty…", other times
                            "Courier is facing some issues")
SRX Premium Plus Pro(262) → assigns an AWB instantly
```

Same body, same pickup, same address. `/orders/show` confirms the delivery row exists (`customer_country: "Israel"`, `customer_state: "Jerusalem"`, `customer_pincode: "9339904"`), so the error names fields that are not the problem. We auto-assigned the **recommended** courier and therefore failed every time.

Ruled out first, each by direct test on the live order — `isd_code` (#1224, prod verified on `sha-46430305e`), the recipient name, and the phone format. All three returned a **byte-identical** 400. When the message doesn't move as you change the field it names, it isn't reporting on that field.

## What changed

- **`assign/awb` walks ordered candidates** — recommended, then every other serviceable courier. Both refusal shapes fall through: a 4xx, and a 200 carrying `awb_assign_status: 0`. Only when all refuse does it throw, naming each courier and its own reason rather than presenting the first one's misleading message as the order's problem. An explicit `preferred_courier_id` remains the only candidate; the cancelled-order-state retry still propagates.
- **Insurance opted out explicitly** (domestic + international). `is_insurance_opt` is the only field that moves it — live-verified: `1` ⇒ serviceability reports `insurace_opted_at_order_creation: true`, `0`/absent ⇒ false; `insurance`, `is_insurance`, `shipment_insurance` are silently ignored (create still 200s). We already sent none, but only because the account has `company_auto_shipment_insurance_setting: false`. The premium is real money: a live IL quote wanted `coverage_charges: 362.39` on top of `848` freight.
- **Carrier-account failures read as partner-actionable.** Every gate carries `partnerMessage` beside the admin copy, and the partner route passes `audience: "partner"` — an empty wallet now says "load courier credits or contact support" instead of naming a Shiprocket dashboard partners have no login for. The **balance gate now applies to domestic labels too**; it was wrapped in `isInternationalDestination`, so a domestic label on an empty wallet surfaced the raw carrier string. Only the balance reason is trusted for domestic (KYC/bank/pickup signatures are international-only and the matcher is keyword-based).
- **Early break on insufficient balance** — an empty wallet isn't a courier's opinion, and each extra round-trip is one the browser waits on (a slow label call is what surfaced as "Load failed" in the partner UI).
- **Recipient name walks shipping → billing → customer**, the chain phone and pincode already use. Order 79's shipping address was replaced with one holding no first/last name while billing kept "Yosef Pivk", so the commercial invoice was addressed to the placeholder `"Customer"`. Not the bug, but a real defect on an export document.

## Test

`pnpm jest src/modules/shipping-providers src/workflows/orders` → **203 passing**, including new specs that pin:
- 384 refusing with the exact live 400 while 262 takes it — asserting assign order `[384, 262]` and that `provider_refs` describe the courier that actually took the parcel
- all couriers refusing → error names each courier and its own reason
- `is_insurance_opt: 0` in both the domestic and international create bodies
- every gate's partner copy naming support/credits and never a dashboard

## Watch-outs

- Order 79 is still blocked on **courier credits** (wallet low, previous amount pending) — courier 262 won't book until that clears. This PR does not fix that.
- If Shiprocket ever sets `user_insurance_manadatory: true` on the account, an explicit `is_insurance_opt: 0` may be rejected rather than ignored.
- Shiprocket's WAF 403s non-VPN laptop IPs on `/auth/login`; prod is unaffected (egresses `us-east-1`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)