### PR TITLE
fix(shipping): recreate the carrier order when Shiprocket returns a CANCELED one

### DIFF
--- a/apps/backend/src/modules/shipping-providers/shiprocket/__tests__/create-international-shipment.unit.spec.ts
+++ b/apps/backend/src/modules/shipping-providers/shiprocket/__tests__/create-international-shipment.unit.spec.ts
@@ -534,6 +534,78 @@ describe("ShiprocketClient.createShipment — international routing", () => {
     )
   })
 
+  /**
+   * THE order-79 bug. `create/adhoc` dedupes on the channel `order_id`, so a
+   * reference whose carrier order was cancelled resolves back to that dead
+   * record — HTTP 200, `status: "CANCELED"`, the OLD shipment_id — and assign
+   * then blames the delivery pincode. Live-verified: creating with order 79's id
+   * returned sr_order 1499133560 / shipment 1495356234, cancelled on 6 Aug.
+   */
+  it("recreates under a fresh channel id when the carrier returns a CANCELED order", async () => {
+    const creates: string[] = []
+    const assigned: any[] = []
+    const real = global.fetch?.bind(globalThis)
+    fetchSpy = jest
+      .spyOn(global, "fetch" as any)
+      .mockImplementation(async (input: any, init: any = {}) => {
+        const url = String(input)
+        if (!url.includes("shiprocket.in")) return real?.(input, init)
+        const path = url.replace("https://apiv2.shiprocket.in/v1/external", "")
+        if (path.includes("/international/orders/create/adhoc")) {
+          const body = JSON.parse(init.body)
+          creates.push(body.order_id)
+          // First create resolves to the CANCELLED existing carrier order.
+          return creates.length === 1
+            ? make({
+                order_id: 1499133560,
+                shipment_id: 1495356234,
+                status: "CANCELED",
+                status_code: 5,
+              })
+            : make({ order_id: 1503999, shipment_id: 1499999, status: "NEW", status_code: 1 })
+        }
+        if (path.includes("/international/courier/serviceability"))
+          return make({
+            data: {
+              recommended_courier_company_id: 262,
+              available_courier_companies: [
+                { courier_company_id: 262, courier_name: "SRX Premium Plus Pro", rate: { rate: 1300 } },
+              ],
+            },
+          })
+        if (path.includes("/international/courier/assign/awb")) {
+          const body = JSON.parse(init.body)
+          assigned.push(body.shipment_id[0])
+          // The dead shipment refuses exactly as the live account does.
+          if (body.shipment_id[0] === 1495356234)
+            return make(
+              { message: '["Delivery pincode is empty","Customer phone is empty"]' },
+              400
+            )
+          return make({ response: { data: { awb_code: "INTLAWB79", courier_company_id: 262 } } })
+        }
+        if (path.endsWith("/courier/generate/label")) return make({ label_url: "x.pdf" })
+        return make({}, 404)
+      })
+
+    const client = new ShiprocketClient({
+      email: "x@y.com",
+      password: "p",
+      token: "injected-token",
+      pickup_location: "warehouse-abc",
+    })
+
+    const result = await client.createShipment(usInput({ reference_id: "order_79" } as any))
+
+    expect(result.awb).toBe("INTLAWB79")
+    // Recreated under a suffixed channel id, and the dead shipment was NEVER assigned.
+    expect(creates[0]).toBe("order_79")
+    expect(creates[1]).toMatch(/^order_79-R[a-z0-9]+$/)
+    expect(assigned).toEqual([1499999])
+    // The refs describe the FRESH carrier order, not the cancelled one.
+    expect(result.provider_refs).toMatchObject({ sr_order_id: 1503999, shipment_id: 1499999 })
+  })
+
   it("keeps a domestic (India) destination on the domestic endpoints", async () => {
     const hits: string[] = []
     const real = global.fetch?.bind(globalThis)

--- a/apps/backend/src/modules/shipping-providers/shiprocket/client.ts
+++ b/apps/backend/src/modules/shipping-providers/shiprocket/client.ts
@@ -52,6 +52,36 @@ const BASE_URL = "https://apiv2.shiprocket.in/v1/external"
 const INSURANCE_OPT_OUT = 0
 
 /**
+ * `create/adhoc` is NOT create-only: a repeated `order_id` resolves to the
+ * EXISTING carrier order and returns it with HTTP 200 — no error, no new
+ * shipment. If that order was cancelled, every retry then assigns against a
+ * cancelled shipment.
+ *
+ * Live-verified 2026-08-08 (order 79 → IL): creating with the real order id
+ * returned `{order_id: 1499133560, shipment_id: 1495356234, status: "CANCELED",
+ * status_code: 5}` — a carrier order cancelled on 6 Aug — and
+ * `/international/courier/assign/awb` refused it with
+ * `["Delivery pincode is empty","Customer phone is empty"]`. THAT is what made
+ * the error immune to every address fix: the create was a no-op handing back a
+ * dead shipment, so nothing we changed about the order ever reached the carrier.
+ *
+ * The existing suffixed retry only fired on an assign error matching
+ * /cancell?ed state/i, which the international pipeline never says. Checking the
+ * create RESPONSE instead is deterministic and catches it one call earlier, for
+ * domestic and international alike. Pure + exported for unit testing.
+ */
+export function isCanceledCarrierOrder(res: any): boolean {
+  return (
+    Number(res?.status_code) === 5 || /cancell?ed/i.test(String(res?.status ?? ""))
+  )
+}
+
+/** Fresh channel order id for a retry — the carrier keys dedup on this. */
+export function suffixedChannelOrderId(referenceId: string): string {
+  return `${referenceId}-R${Date.now().toString(36)}`
+}
+
+/**
  * Minimum HSN length accepted by `/international/*` — live-verified against a
  * 422 that named every line at once. India's ITC-HS export schedule is 8-digit;
  * the 6-digit WCO heading that satisfies the DOMESTIC endpoint is rejected here.
@@ -975,13 +1005,18 @@ export class ShiprocketClient implements ShippingProviderClient {
     }
 
     let created = await createAdhoc(String(createBody.order_id))
+    // Shiprocket dedupes adhoc orders on the channel `order_id`, so a reference
+    // whose earlier attempt was cancelled carrier-side resolves BACK to that
+    // cancelled record — returned with HTTP 200. Detect it here rather than
+    // waiting for the assign to complain (international never says "cancelled
+    // state"; it blames the delivery pincode instead).
+    if (isCanceledCarrierOrder(created)) {
+      created = await createAdhoc(suffixedChannelOrderId(input.reference_id))
+    }
 
-    // 2) Assign an AWB (force a courier if the caller picked one). Shiprocket
-    // dedupes adhoc orders on the channel `order_id`: a reference whose earlier
-    // shipment attempt was CANCELLED carrier-side maps back to that cancelled
-    // record, and the assign fails with "order is in cancelled state". Retry
-    // ONCE under a fresh suffixed channel id so a legitimate re-ship of the
-    // same platform order gets a new carrier order instead of a dead end.
+    // 2) Assign an AWB (force a courier if the caller picked one). The
+    // "cancelled state" catch stays as a belt-and-braces fallback for a record
+    // that only reveals itself at assign time.
     let assigned: any
     try {
       assigned = await assignAwb(created.shipment_id)
@@ -989,9 +1024,7 @@ export class ShiprocketClient implements ShippingProviderClient {
       const cancelled =
         e instanceof ShiprocketApiError && /cancell?ed state/i.test(e.message)
       if (!cancelled) throw e
-      created = await createAdhoc(
-        `${input.reference_id}-R${Date.now().toString(36)}`
-      )
+      created = await createAdhoc(suffixedChannelOrderId(input.reference_id))
       assigned = await assignAwb(created.shipment_id)
     }
 
@@ -1238,6 +1271,12 @@ export class ShiprocketClient implements ShippingProviderClient {
     }
 
     let created = await createAdhoc(String(createBody.order_id))
+    // The carrier handed back a CANCELLED order for this reference — assigning
+    // against it can only fail (and fails misleadingly). Take a fresh channel
+    // order id before touching couriers.
+    if (isCanceledCarrierOrder(created)) {
+      created = await createAdhoc(suffixedChannelOrderId(input.reference_id))
+    }
     let assigned: any
     let courier: { id?: string | number; rate?: RateOption }
     try {


### PR DESCRIPTION
## The cause of order 79's unbreakable 400

`create/adhoc` is **not create-only**. It dedupes on the channel `order_id`, so a reference whose carrier order was cancelled resolves back to that dead record and returns it with HTTP 200. Live-verified — creating with order 79's real id returns:

```json
{"order_id":1499133560,"shipment_id":1495356234,"status":"CANCELED","status_code":5,"awb_code":""}
```

a carrier order cancelled on **6 Aug**. Every prod retry then assigned an AWB against that cancelled shipment, and the international pipeline refuses it by blaming the delivery pincode and phone:

```
["Delivery pincode is empty","Customer phone is empty"]
```

That is why the error was immune to everything we tried: **the create was a no-op handing back a dead shipment**, so no change to the order ever reached the carrier. Each disproof cost a round of live testing — `isd_code` (#1224), recipient name, phone format, courier choice — and all returned a byte-identical 400. My probes escaped it only because they used unique channel order ids, which is exactly why they succeeded where prod could not.

## Fix

The codebase already had a suffixed retry for this case, but it keyed on an *assign* error matching `/cancell?ed state/i` — wording the international pipeline never uses. Check the **create response** instead:

- `isCanceledCarrierOrder(res)` — `status_code === 5` or `status` matching `/cancell?ed/i`. Deterministic, no keyword guessing.
- On a hit, recreate immediately under `suffixedChannelOrderId(reference_id)` before touching couriers.
- Applied to both the domestic and international paths; the old assign-time catch stays as belt and braces for a record that only reveals itself later.

## Test

`pnpm jest src/modules/shipping-providers src/workflows/orders` → **204 passing**, including a new spec that reproduces the live shape: first create returns `status: "CANCELED"` with shipment `1495356234`, that shipment 400s with the exact pincode/phone message, and the client is asserted to recreate under a suffixed id, **never assign the dead shipment**, and report refs for the fresh carrier order.

## Follow-up

Stacked on #1226 (courier fallback + insurance opt-out + partner credit copy). Order 79 should label on the first retry once this is live — wallet is now funded (₹8,555.61).

🤖 Generated with [Claude Code](https://claude.com/claude-code)