### PR TITLE
feat(production-runs): let admins re-assign a parked run to the same or a new partner (#1228)

### DIFF
--- a/apps/backend/integration-tests/http/production-run-manual-assign.spec.ts
+++ b/apps/backend/integration-tests/http/production-run-manual-assign.spec.ts
@@ -1,0 +1,277 @@
+import { createAdminUser, getAuthHeaders } from "../helpers/create-admin-user"
+import { setupSharedTestSuite, getSharedTestEnv } from "./shared-test-setup"
+
+jest.setTimeout(90 * 1000)
+
+/**
+ * #1228 — manual (re)assignment out of `awaiting_reassignment`.
+ *
+ * #1093 shipped the automatic half (reminder cap / decline → unassign + park)
+ * but nothing that moved a parked run back out: no route set `partner_id` on an
+ * existing run, and the policy excluded `awaiting_reassignment` from every
+ * dispatch transition. A parked run was a dead end, even for a retry with the
+ * SAME partner.
+ *
+ * These cases cover the whole recovery loop end to end: park it, send it back
+ * to the same partner, hand it to a different one, and the guards that stop an
+ * operator putting a run somewhere the API cannot honour.
+ */
+setupSharedTestSuite(() => {
+  describe("Admin manual production-run partner assignment", () => {
+    const { api, getContainer } = getSharedTestEnv()
+    let adminHeaders: { headers: Record<string, string> }
+
+    async function createPartner(slug: string, unique: number) {
+      const email = `${slug}-${unique}@jyt.test`
+      const password = "supersecret"
+      await api.post("/auth/partner/emailpass/register", { email, password })
+      let login = await api.post("/auth/partner/emailpass", { email, password })
+      const headers = { Authorization: `Bearer ${login.data.token}` }
+      const res = await api.post(
+        "/partners",
+        {
+          name: `Partner ${slug} ${unique}`,
+          handle: `${slug}-${unique}`,
+          admin: { email, first_name: "Test", last_name: "Partner" },
+        },
+        { headers }
+      )
+      expect(res.status).toBe(200)
+      // Re-login: the token gains the partner actor after creation.
+      login = await api.post("/auth/partner/emailpass", { email, password })
+      return {
+        partnerId: res.data.partner.id as string,
+        headers: { Authorization: `Bearer ${login.data.token}` },
+      }
+    }
+
+    /** A design + an approved child run assigned to `partnerId`. */
+    async function createAssignedRun(designId: string, partnerId: string) {
+      const parent = await api.post(
+        "/admin/production-runs",
+        { design_id: designId, quantity: 4 },
+        adminHeaders
+      )
+      expect(parent.status).toBe(201)
+
+      const approve = await api.post(
+        `/admin/production-runs/${parent.data.production_run.id}/approve`,
+        { assignments: [{ partner_id: partnerId, role: "stitching", quantity: 4 }] },
+        adminHeaders
+      )
+      expect(approve.status).toBe(200)
+
+      const child = (approve.data.result?.children || []).find(
+        (c: any) => (c?.partner_id ?? c?.partnerId) === partnerId
+      )
+      expect(child?.id).toBeTruthy()
+      return child.id as string
+    }
+
+    async function getRun(runId: string) {
+      const res = await api.get(`/admin/production-runs/${runId}`, adminHeaders)
+      expect(res.status).toBe(200)
+      return res.data.production_run
+    }
+
+    async function createDesign(unique: number, label: string) {
+      const res = await api.post(
+        "/admin/designs",
+        {
+          name: `Manual Assign ${label} ${unique}`,
+          description: "Design used by the #1228 manual assignment spec",
+          design_type: "Original",
+          status: "Commerce_Ready",
+          priority: "Medium",
+        },
+        adminHeaders
+      )
+      expect(res.status).toBe(201)
+      return res.data.design.id as string
+    }
+
+    beforeAll(async () => {
+      await createAdminUser(getContainer())
+      adminHeaders = await getAuthHeaders(api)
+    })
+
+    it("re-assigns a parked run to the SAME partner and makes it dispatchable again", async () => {
+      const unique = Date.now()
+      const a = await createPartner("assign-same", unique)
+      const designId = await createDesign(unique, "Same")
+      const runId = await createAssignedRun(designId, a.partnerId)
+
+      // Park it the way production does: the partner declines.
+      const declined = await api.post(
+        `/partners/production-runs/${runId}/decline`,
+        { reason: "capacity", notes: "Machine down" },
+        { headers: a.headers, validateStatus: () => true }
+      )
+      expect(declined.status).toBe(200)
+      expect(declined.data.production_run.status).toBe("awaiting_reassignment")
+      expect(declined.data.production_run.partner_id).toBeFalsy()
+      expect(declined.data.production_run.previous_partner_id).toBe(a.partnerId)
+
+      // The #1228 route: send it straight back to the same partner.
+      const assigned = await api.post(
+        `/admin/production-runs/${runId}/assign-partner`,
+        { partner_id: a.partnerId, note: "Called them, they'll take it" },
+        { ...adminHeaders, validateStatus: () => true }
+      )
+      expect(assigned.status).toBe(200)
+      expect(assigned.data.same_partner).toBe(true)
+      expect(assigned.data.previous_partner_id).toBe(a.partnerId)
+
+      const run = await getRun(runId)
+      expect(run.status).toBe("approved")
+      expect(run.partner_id).toBe(a.partnerId)
+      // The park reason described the previous failure — it must not linger as
+      // a live warning against the partner now holding the run.
+      expect(run.cancelled_reason).toBeFalsy()
+      // The reminder cycle and the retry budget both restart.
+      expect(run.reminder_count ?? 0).toBe(0)
+      expect(run.reminder_status ?? null).toBeFalsy()
+      expect(run.reassign_retry_count ?? 0).toBe(0)
+      // The dispatch cycle must be rewound, or the admin Dispatch action stays
+      // hidden (it requires dispatch_state "idle" AND no dispatch_completed_at)
+      // and the run would be assigned but unsendable.
+      expect(run.dispatch_state).toBe("idle")
+      expect(run.dispatch_completed_at).toBeFalsy()
+      expect(run.accepted_at).toBeFalsy()
+    })
+
+    it("hands a parked run to a DIFFERENT partner and records who dropped it", async () => {
+      const unique = Date.now() + 1
+      const a = await createPartner("assign-from", unique)
+      const b = await createPartner("assign-to", unique)
+      const designId = await createDesign(unique, "Different")
+      const runId = await createAssignedRun(designId, a.partnerId)
+
+      const declined = await api.post(
+        `/partners/production-runs/${runId}/decline`,
+        { reason: "capacity" },
+        { headers: a.headers, validateStatus: () => true }
+      )
+      expect(declined.status).toBe(200)
+
+      const assigned = await api.post(
+        `/admin/production-runs/${runId}/assign-partner`,
+        { partner_id: b.partnerId },
+        { ...adminHeaders, validateStatus: () => true }
+      )
+      expect(assigned.status).toBe(200)
+      expect(assigned.data.same_partner).toBe(false)
+      expect(assigned.data.previous_partner_id).toBe(a.partnerId)
+
+      const run = await getRun(runId)
+      expect(run.status).toBe("approved")
+      expect(run.partner_id).toBe(b.partnerId)
+      // Audit trail: partner A is still legible as the one who let it go.
+      expect(run.previous_partner_id).toBe(a.partnerId)
+
+      // And it really is dispatchable — not just cosmetically "approved".
+      const dispatch = await api.post(
+        `/admin/production-runs/${runId}/start-dispatch`,
+        {},
+        { ...adminHeaders, validateStatus: () => true }
+      )
+      expect(dispatch.status).toBe(202)
+      expect(dispatch.data.transaction_id).toBeTruthy()
+    })
+
+    it("rejects an unknown partner without touching the run", async () => {
+      const unique = Date.now() + 2
+      const a = await createPartner("assign-bogus", unique)
+      const designId = await createDesign(unique, "Bogus")
+      const runId = await createAssignedRun(designId, a.partnerId)
+
+      await api.post(
+        `/partners/production-runs/${runId}/decline`,
+        { reason: "capacity" },
+        { headers: a.headers, validateStatus: () => true }
+      )
+
+      const res = await api.post(
+        `/admin/production-runs/${runId}/assign-partner`,
+        { partner_id: "part_does_not_exist" },
+        { ...adminHeaders, validateStatus: () => true }
+      )
+      expect(res.status).toBe(404)
+
+      // The run must be untouched — a typo'd id assigning the run to nobody
+      // would be worse than the dead end #1228 set out to fix.
+      const run = await getRun(runId)
+      expect(run.status).toBe("awaiting_reassignment")
+      expect(run.partner_id).toBeFalsy()
+    })
+
+    it("requires partner_id", async () => {
+      const unique = Date.now() + 3
+      const a = await createPartner("assign-novalid", unique)
+      const designId = await createDesign(unique, "NoValid")
+      const runId = await createAssignedRun(designId, a.partnerId)
+
+      const res = await api.post(
+        `/admin/production-runs/${runId}/assign-partner`,
+        {},
+        { ...adminHeaders, validateStatus: () => true }
+      )
+      expect(res.status).toBe(400)
+    })
+
+    it("refuses to reassign a run the partner has already accepted", async () => {
+      const unique = Date.now() + 4
+      const a = await createPartner("assign-accepted", unique)
+      const b = await createPartner("assign-accepted-b", unique)
+      const designId = await createDesign(unique, "Accepted")
+      const runId = await createAssignedRun(designId, a.partnerId)
+
+      // Put the run in the accepted state directly through the module service.
+      // Driving it via dispatch → accept would depend on the async, template-
+      // driven dispatch chain landing first; when it doesn't, the run is never
+      // accepted and the guard under test silently isn't exercised.
+      const runService: any = getContainer().resolve("production_runs")
+      await runService.updateProductionRuns({
+        id: runId,
+        status: "in_progress",
+        accepted_at: new Date(),
+      })
+
+      const before = await getRun(runId)
+      expect(before.accepted_at).toBeTruthy()
+
+      const res = await api.post(
+        `/admin/production-runs/${runId}/assign-partner`,
+        { partner_id: b.partnerId },
+        { ...adminHeaders, validateStatus: () => true }
+      )
+      expect(res.status).toBe(400)
+
+      const run = await getRun(runId)
+      expect(run.partner_id).toBe(a.partnerId)
+    })
+
+    it("assigns a different partner before acceptance (plain correction, not a recovery)", async () => {
+      const unique = Date.now() + 5
+      const a = await createPartner("assign-correct-a", unique)
+      const b = await createPartner("assign-correct-b", unique)
+      const designId = await createDesign(unique, "Correction")
+      const runId = await createAssignedRun(designId, a.partnerId)
+
+      // No decline — the run is simply `approved` and pointed at the wrong
+      // partner. `assign_partner_from` covers this too.
+      const res = await api.post(
+        `/admin/production-runs/${runId}/assign-partner`,
+        { partner_id: b.partnerId },
+        { ...adminHeaders, validateStatus: () => true }
+      )
+      expect(res.status).toBe(200)
+      expect(res.data.same_partner).toBe(false)
+
+      const run = await getRun(runId)
+      expect(run.partner_id).toBe(b.partnerId)
+      expect(run.previous_partner_id).toBe(a.partnerId)
+      expect(run.status).toBe("approved")
+    })
+  })
+})

--- a/apps/backend/src/admin/components/designs/design-order-production-section.tsx
+++ b/apps/backend/src/admin/components/designs/design-order-production-section.tsx
@@ -6,7 +6,13 @@ import {
   Text,
   clx,
 } from "@medusajs/ui"
-import { ArrowRightMini, ArrowUpRightOnBox, PencilSquare } from "@medusajs/icons"
+import {
+  ArrowPath,
+  ArrowRightMini,
+  ArrowUpRightOnBox,
+  PencilSquare,
+  Users,
+} from "@medusajs/icons"
 import { Link } from "react-router-dom"
 
 import { ActionMenu } from "../../components/common/action-menu"
@@ -38,6 +44,9 @@ const runStatusColor = (
       return "blue"
     case "cancelled":
       return "red"
+    // #1228 — parked by the reminder cap or a decline: nobody is working on it.
+    case "awaiting_reassignment":
+      return "red"
     default:
       return "grey"
   }
@@ -55,12 +64,17 @@ const adminStatusHint = (run: any): string => {
     return "In progress"
   }
   if (s === "sent_to_partner") return "Sent — awaiting acceptance"
+  // #1228 — before this branch existed a parked run fell through to "Not sent
+  // to a partner yet", which reads as "nothing has happened" rather than "the
+  // partner dropped it and it is waiting on you".
+  if (s === "awaiting_reassignment") return "Unassigned — needs a new partner"
   return "Not sent to a partner yet"
 }
 
 /** The partner's NEXT step in the lifecycle ("up ahead"), or null when none. */
 const partnerNextStep = (run: any): string | null => {
   const s = String(run?.status || "")
+  if (s === "awaiting_reassignment") return null
   if (s === "sent_to_partner") return "Accept the run"
   if (s === "in_progress") {
     if (run.finished_at) return "Complete with output + cost"
@@ -136,6 +150,18 @@ export const RunCard = ({
   const status = String(run.status || "")
   const title = design?.name || run?.snapshot?.design?.name || `Design ${run.design_id}`
   const nextStep = partnerNextStep(run)
+  // #1228 — mirrors the server-side policy (`assign_partner_from` + the
+  // already-accepted guard) so we never offer an action the API will refuse.
+  const canAssignPartner =
+    !run?.accepted_at &&
+    [
+      "awaiting_reassignment",
+      "draft",
+      "pending_review",
+      "approved",
+      "sent_to_partner",
+    ].includes(status)
+  const lastPartnerId = run?.partner_id || run?.previous_partner_id || null
   const targetDate = fmtDate(design?.target_completion_date)
   const cost = fmtCost(
     run?.partner_cost_estimate ?? design?.estimated_cost,
@@ -184,9 +210,35 @@ export const RunCard = ({
           </Text>
         </div>
         {/* Lifecycle actions (approve / dispatch / cost / cancel / tasks) live on
-            the canonical run page — link there instead of duplicating them. */}
+            the canonical run page — link there instead of duplicating them.
+            #1228 is the exception: reassignment is the action an operator comes
+            to THIS page looking for, since this is where a stalled run is
+            noticed. Both entries deep-link into the run page's reassign drawer,
+            so there is still exactly one implementation. */}
         <ActionMenu
           groups={[
+            ...(canAssignPartner
+              ? [
+                  {
+                    actions: [
+                      ...(lastPartnerId
+                        ? [
+                            {
+                              label: "Send to the same partner again",
+                              icon: <ArrowPath />,
+                              to: `/production-runs/${run.id}/reassign?mode=same`,
+                            },
+                          ]
+                        : []),
+                      {
+                        label: "Assign a different partner",
+                        icon: <Users />,
+                        to: `/production-runs/${run.id}/reassign`,
+                      },
+                    ],
+                  },
+                ]
+              : []),
             {
               actions: [
                 {

--- a/apps/backend/src/admin/hooks/api/production-runs.ts
+++ b/apps/backend/src/admin/hooks/api/production-runs.ts
@@ -299,6 +299,48 @@ export const useApproveProductionRun = (
   })
 }
 
+export type AdminAssignProductionRunPartnerPayload = {
+  partner_id: string
+  note?: string | null
+}
+
+export type AdminAssignProductionRunPartnerResponse = {
+  production_run: AdminProductionRun
+  previous_partner_id: string | null
+  same_partner: boolean
+}
+
+/**
+ * #1228 — point a run at a partner by hand. The recovery path out of
+ * `awaiting_reassignment`, and the "send it to the same partner again" action.
+ * The run lands on `approved`; the operator's next step is Dispatch.
+ */
+export const useAssignProductionRunPartner = (
+  runId: string,
+  options?: UseMutationOptions<
+    AdminAssignProductionRunPartnerResponse,
+    FetchError,
+    AdminAssignProductionRunPartnerPayload
+  >
+) => {
+  const queryClient = useQueryClient()
+
+  return useMutation({
+    mutationFn: async (payload: AdminAssignProductionRunPartnerPayload) =>
+      sdk.client.fetch<AdminAssignProductionRunPartnerResponse>(
+        `/admin/production-runs/${runId}/assign-partner`,
+        { method: "POST", body: payload }
+      ),
+    onSuccess: (data, variables, _mutateResult, context) => {
+      queryClient.invalidateQueries({ queryKey: productionRunQueryKeys.detail(runId) })
+      queryClient.invalidateQueries({ queryKey: productionRunQueryKeys.lists() })
+      queryClient.invalidateQueries({ queryKey: designQueryKeys.lists() })
+      options?.onSuccess?.(data, variables, _mutateResult, context)
+    },
+    ...options,
+  })
+}
+
 export type AdminUpdateProductionRunPayload = {
   quantity?: number
   role?: string

--- a/apps/backend/src/admin/routes/production-runs/[id]/@reassign/page.tsx
+++ b/apps/backend/src/admin/routes/production-runs/[id]/@reassign/page.tsx
@@ -1,0 +1,239 @@
+import {
+  Button,
+  Container,
+  Heading,
+  Input,
+  Label,
+  Select,
+  StatusBadge,
+  Text,
+  Textarea,
+  toast,
+} from "@medusajs/ui"
+import { useMemo, useState } from "react"
+import { useParams, useSearchParams } from "react-router-dom"
+
+import { RouteDrawer } from "../../../../components/modal/route-drawer/route-drawer"
+import { useRouteModal } from "../../../../components/modal/use-route-modal"
+import {
+  useAssignProductionRunPartner,
+  useProductionRun,
+} from "../../../../hooks/api/production-runs"
+import { usePartners } from "../../../../hooks/api/partners"
+
+/**
+ * #1228 — assign or re-assign a production run to a partner.
+ *
+ * Reached from the run page and the design-order Production section. Two entry
+ * modes, both landing here:
+ *   ?mode=same      → pre-selects the partner who last held the run
+ *   (no mode)       → an empty picker, for handing it to someone else
+ *
+ * On success the run is `approved` with the partner attached — it is NOT yet
+ * sent. The drawer says so explicitly, because "assigned" reading as "sent" is
+ * the obvious way for an operator to lose a run here.
+ */
+const ReassignProductionRunDrawerForm = () => {
+  const { id: runId } = useParams()
+  const [searchParams] = useSearchParams()
+  const { handleSuccess } = useRouteModal()
+
+  const { production_run: run } = useProductionRun(runId || "", undefined, {
+    enabled: !!runId,
+  })
+
+  const { partners = [], isLoading: partnersLoading } = usePartners({ limit: 200 })
+
+  // Whoever last held the run: the live partner if it still has one, else the
+  // partner it was unassigned FROM when it was parked.
+  const lastPartnerId: string | null =
+    (run?.partner_id as string) || (run?.previous_partner_id as string) || null
+
+  const wantsSamePartner = searchParams.get("mode") === "same"
+
+  const [partnerId, setPartnerId] = useState<string>(
+    wantsSamePartner && lastPartnerId ? lastPartnerId : ""
+  )
+  const [note, setNote] = useState("")
+  const [search, setSearch] = useState("")
+
+  const assignPartner = useAssignProductionRunPartner(runId || "")
+
+  const sortedPartners = useMemo(() => {
+    const list = [...(partners as any[])].sort((a, b) =>
+      String(a?.name || "").localeCompare(String(b?.name || ""))
+    )
+    if (!search.trim()) return list
+    const q = search.trim().toLowerCase()
+    return list.filter((p) => String(p?.name || "").toLowerCase().includes(q))
+  }, [partners, search])
+
+  const lastPartnerName = useMemo(() => {
+    if (!lastPartnerId) return null
+    const match = (partners as any[]).find((p) => p.id === lastPartnerId)
+    return match?.name || lastPartnerId
+  }, [partners, lastPartnerId])
+
+  const isSamePartner = !!partnerId && partnerId === lastPartnerId
+
+  const handleAssign = async () => {
+    if (!runId || !partnerId) return
+    try {
+      await assignPartner.mutateAsync({
+        partner_id: partnerId,
+        note: note.trim() || null,
+      })
+      toast.success(
+        isSamePartner
+          ? "Re-assigned to the same partner — dispatch it to send it again"
+          : "Partner assigned — dispatch it to send it"
+      )
+      handleSuccess()
+    } catch (e: any) {
+      toast.error(e?.message || e?.body?.message || "Failed to assign partner")
+    }
+  }
+
+  // The run has already been accepted, so swapping the partner would strand
+  // their in-flight tasks. Mirrors the policy check server-side.
+  const alreadyAccepted = !!run?.accepted_at
+
+  return (
+    <div className="flex flex-1 flex-col overflow-hidden">
+      <RouteDrawer.Header>
+        <Heading>Assign partner</Heading>
+      </RouteDrawer.Header>
+
+      <RouteDrawer.Body className="flex flex-1 flex-col gap-y-6 overflow-y-auto py-6">
+        {alreadyAccepted ? (
+          <Container className="p-4">
+            <Text className="text-ui-fg-subtle">
+              This run has already been accepted by its partner. Cancel it instead
+              of reassigning — swapping partners now would strand their tasks.
+            </Text>
+          </Container>
+        ) : (
+          <>
+            <Container className="divide-y p-0">
+              <div className="px-6 py-4">
+                <Heading level="h2">Current state</Heading>
+              </div>
+              <div className="grid grid-cols-2 gap-3 px-6 py-3">
+                <div>
+                  <Text size="small" className="text-ui-fg-subtle">
+                    Status
+                  </Text>
+                  <StatusBadge
+                    color={run?.status === "awaiting_reassignment" ? "red" : "grey"}
+                  >
+                    {String(run?.status || "-").replace(/_/g, " ")}
+                  </StatusBadge>
+                </div>
+                <div>
+                  <Text size="small" className="text-ui-fg-subtle">
+                    Last partner
+                  </Text>
+                  <Text size="small">{lastPartnerName || "None"}</Text>
+                </div>
+              </div>
+              {run?.cancelled_reason && (
+                <div className="px-6 py-3">
+                  <Text size="small" className="text-ui-fg-subtle">
+                    Why it needs reassigning
+                  </Text>
+                  <Text size="small">{String(run.cancelled_reason)}</Text>
+                </div>
+              )}
+            </Container>
+
+            <div className="flex flex-col gap-y-2 px-1">
+              <Label size="small" weight="plus" htmlFor="partner-search">
+                Partner
+              </Label>
+              <Input
+                id="partner-search"
+                placeholder="Search partners…"
+                value={search}
+                onChange={(e) => setSearch(e.target.value)}
+              />
+              <Select value={partnerId} onValueChange={setPartnerId}>
+                <Select.Trigger>
+                  <Select.Value
+                    placeholder={
+                      partnersLoading ? "Loading partners…" : "Select a partner"
+                    }
+                  />
+                </Select.Trigger>
+                <Select.Content>
+                  {sortedPartners.map((p: any) => (
+                    <Select.Item key={p.id} value={p.id}>
+                      {p.name}
+                      {p.id === lastPartnerId ? " — same partner again" : ""}
+                    </Select.Item>
+                  ))}
+                </Select.Content>
+              </Select>
+              {isSamePartner && (
+                <Text size="xsmall" className="text-ui-fg-subtle">
+                  Sending this back to the partner who already let it lapse. Their
+                  reminder cycle and retry budget start over.
+                </Text>
+              )}
+            </div>
+
+            <div className="flex flex-col gap-y-2 px-1">
+              <Label size="small" weight="plus" htmlFor="assign-note">
+                Note <span className="text-ui-fg-muted">(optional)</span>
+              </Label>
+              <Textarea
+                id="assign-note"
+                placeholder="e.g. Called them, they'll take it this time"
+                value={note}
+                onChange={(e) => setNote(e.target.value)}
+                rows={3}
+              />
+            </div>
+
+            <Container className="p-4">
+              <Text size="small" className="text-ui-fg-subtle">
+                Assigning does not send the run. It moves back to{" "}
+                <span className="text-ui-fg-base">approved</span> with the partner
+                attached — use <span className="text-ui-fg-base">Dispatch</span> to
+                pick task templates and actually send it.
+              </Text>
+            </Container>
+          </>
+        )}
+      </RouteDrawer.Body>
+
+      <RouteDrawer.Footer>
+        <div className="flex items-center justify-end gap-x-2">
+          <RouteDrawer.Close asChild>
+            <Button size="small" variant="secondary">
+              Cancel
+            </Button>
+          </RouteDrawer.Close>
+          {!alreadyAccepted && (
+            <Button
+              size="small"
+              type="button"
+              onClick={handleAssign}
+              isLoading={assignPartner.isPending}
+              disabled={!partnerId}
+            >
+              {isSamePartner ? "Re-assign to same partner" : "Assign partner"}
+            </Button>
+          )}
+        </div>
+      </RouteDrawer.Footer>
+    </div>
+  )
+}
+
+export default function ReassignProductionRunDrawer() {
+  return (
+    <RouteDrawer>
+      <ReassignProductionRunDrawerForm />
+    </RouteDrawer>
+  )
+}

--- a/apps/backend/src/admin/routes/production-runs/[id]/page.tsx
+++ b/apps/backend/src/admin/routes/production-runs/[id]/page.tsx
@@ -10,7 +10,14 @@ import {
   toast,
   usePrompt,
 } from "@medusajs/ui"
-import { EllipsisHorizontal, PencilSquare, Trash, XMark } from "@medusajs/icons"
+import {
+  ArrowPath,
+  EllipsisHorizontal,
+  PencilSquare,
+  Trash,
+  Users,
+  XMark,
+} from "@medusajs/icons"
 import {
   Link,
   LoaderFunctionArgs,
@@ -68,6 +75,18 @@ const ProductionRunDetailPage = () => {
     run?.dispatch_state === "idle" &&
     !run?.dispatch_completed_at &&
     !!run?.partner_id
+
+  // #1228 — a run parked by the reminder cap (or a decline) has no partner and
+  // no other control on this page; this is its only way back into production.
+  const isParked = run?.status === "awaiting_reassignment"
+  // Reassignment is also a plain correction before the partner has accepted.
+  const canAssignPartner =
+    !isParent &&
+    !run?.accepted_at &&
+    ["awaiting_reassignment", "draft", "pending_review", "approved", "sent_to_partner"].includes(
+      String(run?.status)
+    )
+  const lastPartnerId = run?.partner_id || run?.previous_partner_id || null
 
   const handleCancel = async () => {
     const confirmed = await prompt({
@@ -154,6 +173,13 @@ const ProductionRunDetailPage = () => {
                   </Button>
                 </Link>
               )}
+              {/* A parked run is a dead end without this — promote it out of the
+                  overflow menu so the queue is actionable at a glance. */}
+              {isParked && canAssignPartner && (
+                <Link to={lastPartnerId ? "reassign?mode=same" : "reassign"}>
+                  <Button size="small">Reassign</Button>
+                </Link>
+              )}
               <DropdownMenu>
                 <DropdownMenu.Trigger asChild>
                   <IconButton size="small" variant="transparent" aria-label="Actions">
@@ -166,6 +192,23 @@ const ProductionRunDetailPage = () => {
                       <PencilSquare className="mr-2" />
                       {isOverride ? "Edit details (override)" : "Edit details"}
                     </DropdownMenu.Item>
+                  )}
+                  {canAssignPartner && (
+                    <>
+                      <DropdownMenu.Separator />
+                      {lastPartnerId && (
+                        <DropdownMenu.Item
+                          onClick={() => navigate("reassign?mode=same")}
+                        >
+                          <ArrowPath className="mr-2" />
+                          Send to the same partner again
+                        </DropdownMenu.Item>
+                      )}
+                      <DropdownMenu.Item onClick={() => navigate("reassign")}>
+                        <Users className="mr-2" />
+                        Assign a different partner
+                      </DropdownMenu.Item>
+                    </>
                   )}
                   {canEditCost && (
                     <>

--- a/apps/backend/src/api/admin/production-runs/[id]/assign-partner/route.ts
+++ b/apps/backend/src/api/admin/production-runs/[id]/assign-partner/route.ts
@@ -1,0 +1,62 @@
+/**
+ * @file Admin API route for manually assigning a partner to a production run
+ * @module API/Admin/ProductionRuns
+ */
+
+/**
+ * Assign (or re-assign) a production run to a partner.
+ *
+ * #1228 — the manual counterpart to #1093's automatic reassignment. When a run
+ * is parked in `awaiting_reassignment` (reminder cap reached, or the partner
+ * declined) this is the only way back out. `partner_id` may be the same partner
+ * who let it lapse — "send it to them again" — or a different one.
+ *
+ * The run lands on `approved`, NOT `sent_to_partner`: dispatch is what collects
+ * template names, and template names are what seed the partner's tasks. The
+ * operator's next step is the ordinary Dispatch action.
+ *
+ * @route POST /admin/production-runs/:id/assign-partner
+ * @param {string} id.path.required - The production run id
+ * @param {AdminAssignProductionRunPartnerReq} request.body.required - { partner_id, note? }
+ * @returns {Object} 200 - { production_run, previous_partner_id, same_partner }
+ * @throws {MedusaError} 404 - Production run or partner not found
+ * @throws {MedusaError} 400 - Run already accepted, terminal, or in a status the policy disallows
+ *
+ * @example request
+ * POST /admin/production-runs/prod_run_123/assign-partner
+ * { "partner_id": "part_456", "note": "Called them, they'll take it this time" }
+ */
+import { MedusaRequest, MedusaResponse } from "@medusajs/framework/http"
+
+import { PRODUCTION_RUNS_MODULE } from "../../../../../modules/production_runs"
+import type ProductionRunService from "../../../../../modules/production_runs/service"
+import { assignProductionRunPartnerWorkflow } from "../../../../../workflows/production-runs/assign-production-run-partner"
+import type { AdminAssignProductionRunPartnerReq } from "../../validators"
+
+export const POST = async (
+  req: MedusaRequest<AdminAssignProductionRunPartnerReq>,
+  res: MedusaResponse
+) => {
+  const id = req.params.id
+  const body = (req.validatedBody || req.body) as AdminAssignProductionRunPartnerReq
+
+  const { result } = await assignProductionRunPartnerWorkflow(req.scope).run({
+    input: {
+      production_run_id: id,
+      partner_id: body.partner_id,
+      note: body.note ?? null,
+      source: "manual",
+    },
+  })
+
+  const productionRunService: ProductionRunService = req.scope.resolve(
+    PRODUCTION_RUNS_MODULE
+  )
+  const production_run = await productionRunService.retrieveProductionRun(id)
+
+  return res.status(200).json({
+    production_run,
+    previous_partner_id: result.previous_partner_id,
+    same_partner: result.same_partner,
+  })
+}

--- a/apps/backend/src/api/admin/production-runs/validators.ts
+++ b/apps/backend/src/api/admin/production-runs/validators.ts
@@ -41,6 +41,16 @@ export const AdminCancelProductionRunReq = z.object({
   reason: z.string().optional(),
 })
 
+/**
+ * #1228 — manual (re)assignment. `partner_id` may be the partner who already
+ * let the run go stale (the "send to the same partner again" case) or a new
+ * one; the route treats both identically.
+ */
+export const AdminAssignProductionRunPartnerReq = z.object({
+  partner_id: z.string().min(1),
+  note: z.string().max(500).nullish(),
+})
+
 export const AdminResumeDispatchProductionRunReq = z.object({
   template_names: z.array(z.string()).min(1),
   transaction_id: z.string().min(1),
@@ -51,3 +61,4 @@ export type AdminApproveProductionRunReq = z.infer<typeof AdminApproveProduction
 export type AdminSendProductionRunToProductionReq = z.infer<typeof AdminSendProductionRunToProductionReq>
 export type AdminStartDispatchProductionRunReq = z.infer<typeof AdminStartDispatchProductionRunReq>
 export type AdminResumeDispatchProductionRunReq = z.infer<typeof AdminResumeDispatchProductionRunReq>
+export type AdminAssignProductionRunPartnerReq = z.infer<typeof AdminAssignProductionRunPartnerReq>

--- a/apps/backend/src/api/middlewares.ts
+++ b/apps/backend/src/api/middlewares.ts
@@ -133,6 +133,7 @@ import { AdminPostDesignTasksReq } from "./admin/designs/[id]/tasks/validators";
 import { AdminPutDesignTaskReq } from "./admin/designs/[id]/tasks/[taskId]/validators";
 import {
   AdminApproveProductionRunReq,
+  AdminAssignProductionRunPartnerReq,
   AdminCreateProductionRunReq,
   AdminCancelProductionRunReq,
   AdminResumeDispatchProductionRunReq,
@@ -4174,6 +4175,11 @@ export default defineMiddlewares({
       matcher: "/admin/production-runs/:id/resume-dispatch",
       method: "POST",
       middlewares: [validateAndTransformBody(wrapSchema(AdminResumeDispatchProductionRunReq))],
+    },
+    {
+      matcher: "/admin/production-runs/:id/assign-partner",
+      method: "POST",
+      middlewares: [validateAndTransformBody(wrapSchema(AdminAssignProductionRunPartnerReq))],
     },
 
     {

--- a/apps/backend/src/modules/partner/migrations/Migration20260809052749.ts
+++ b/apps/backend/src/modules/partner/migrations/Migration20260809052749.ts
@@ -1,0 +1,23 @@
+import { Migration } from "@medusajs/framework/mikro-orm/migrations";
+
+/**
+ * #1228 — partner-level opt-in for auto-accepting a production run that is
+ * re-sent to them after they let a dispatch go stale.
+ *
+ * HAND-WRITTEN, not the `db:generate` output. The partner module has no
+ * migration snapshot, so the generator emitted a full `create table if not
+ * exists "partner" (…)` — which is a silent no-op against the existing prod
+ * table, meaning the new column would never actually be added (and its `down`
+ * would have dropped the whole table). Only the ALTER below is wanted.
+ */
+export class Migration20260809052749 extends Migration {
+
+  override async up(): Promise<void> {
+    this.addSql(`alter table if exists "partner" add column if not exists "auto_accept_production_runs" boolean not null default false;`);
+  }
+
+  override async down(): Promise<void> {
+    this.addSql(`alter table if exists "partner" drop column if exists "auto_accept_production_runs";`);
+  }
+
+}

--- a/apps/backend/src/modules/partner/models/partner.ts
+++ b/apps/backend/src/modules/partner/models/partner.ts
@@ -70,6 +70,14 @@ const Partner = model.define("partner", {
     deployment_project_id: model.text().nullable(),
     deployment_project_name: model.text().nullable(),
 
+    // #1228 — the partner has pre-agreed that work re-sent to them after they
+    // let a dispatch go stale should be accepted on their behalf, skipping the
+    // accept step so production can actually move. Only ever consulted on a
+    // same-partner RETRY (never on a first dispatch), and only when the stored
+    // policy has `reassignment.auto_accept_on_retry` enabled. Typed column NOT
+    // metadata — it silently changes who owns the work.
+    auto_accept_production_runs: model.boolean().default(false),
+
     // Relationships
     admins: model.hasMany(() => PartnerAdmin),
 

--- a/apps/backend/src/modules/production_policy/service.ts
+++ b/apps/backend/src/modules/production_policy/service.ts
@@ -13,9 +13,31 @@ type ProductionRunLike = {
   role?: string | null
   depends_on_run_ids?: string[] | null
   dispatch_state?: string | null
+  accepted_at?: Date | string | null
   started_at?: Date | string | null
   finished_at?: Date | string | null
   metadata?: Record<string, any> | null
+}
+
+/** #1228 — what the reminder cap does before parking a run for reassignment. */
+export type ReassignmentPolicy = {
+  /**
+   * How many times the cap re-nudges the SAME partner (resetting the reminder
+   * cycle) before the run is parked in `awaiting_reassignment`. 0 restores the
+   * original #1093 behaviour: cap → park immediately.
+   */
+  same_partner_retries: number
+  /**
+   * On a same-partner retry ONLY, accept the run on the partner's behalf so
+   * production can move without another round-trip. Gated a second time by the
+   * partner's own `auto_accept_production_runs` opt-in — both must be true.
+   */
+  auto_accept_on_retry: boolean
+}
+
+export const DEFAULT_REASSIGNMENT_POLICY: ReassignmentPolicy = {
+  same_partner_retries: 1,
+  auto_accept_on_retry: false,
 }
 
 type StoredPolicy = {
@@ -55,7 +77,77 @@ class ProductionPolicyService extends MedusaService({
         finish_work_from: ["in_progress"],
         complete_work_from: ["in_progress"],
         decline_from: ["draft", "pending_review", "approved", "sent_to_partner", "in_progress"],
+        // #1228 — manual (re)assignment. Deliberately a SEPARATE key from
+        // dispatch_from: `allowedStatuses` falls back per-key, so adding this
+        // takes effect on already-stored policy configs without a backfill,
+        // whereas widening dispatch_from would need one.
+        assign_partner_from: [
+          "awaiting_reassignment",
+          "draft",
+          "pending_review",
+          "approved",
+          "sent_to_partner",
+        ],
       },
+      reassignment: DEFAULT_REASSIGNMENT_POLICY,
+    }
+  }
+
+  /**
+   * #1228 — what the reminder cap does before giving up on a partner.
+   * Missing/partial stored config falls back field-by-field, same contract as
+   * `allowedStatuses`, so existing policy rows need no backfill.
+   */
+  async getReassignmentPolicy(): Promise<ReassignmentPolicy> {
+    const config = await this.getPolicyConfig()
+    const stored = (config?.reassignment || {}) as Record<string, any>
+
+    const retries = Number(stored.same_partner_retries)
+    return {
+      same_partner_retries: Number.isFinite(retries) && retries >= 0
+        ? Math.floor(retries)
+        : DEFAULT_REASSIGNMENT_POLICY.same_partner_retries,
+      auto_accept_on_retry:
+        typeof stored.auto_accept_on_retry === "boolean"
+          ? stored.auto_accept_on_retry
+          : DEFAULT_REASSIGNMENT_POLICY.auto_accept_on_retry,
+    }
+  }
+
+  /**
+   * #1228 — an admin is pointing the run at a partner by hand: the recovery
+   * path out of `awaiting_reassignment`, and equally a correction before the
+   * partner has accepted. Refuses once work is under way (in_progress) or the
+   * run is terminal — swapping the partner mid-production would strand tasks.
+   */
+  async assertCanAssignPartner(run: ProductionRunLike) {
+    if (!run) {
+      throw new MedusaError(MedusaError.Types.NOT_FOUND, "ProductionRun not found")
+    }
+    this.assertNotTerminal(run, "reassigned")
+
+    const config = await this.getPolicyConfig()
+    const allowed = this.allowedStatuses(config, "assign_partner_from", [
+      "awaiting_reassignment",
+      "draft",
+      "pending_review",
+      "approved",
+      "sent_to_partner",
+    ])
+
+    const status = String(run.status)
+    if (!allowed.includes(status)) {
+      throw new MedusaError(
+        MedusaError.Types.NOT_ALLOWED,
+        `ProductionRun ${run.id} cannot be assigned a partner from status ${status}`
+      )
+    }
+
+    if (run.accepted_at) {
+      throw new MedusaError(
+        MedusaError.Types.NOT_ALLOWED,
+        `ProductionRun ${run.id} has already been accepted — cancel it instead of reassigning`
+      )
     }
   }
 

--- a/apps/backend/src/modules/production_runs/migrations/.snapshot-production-runs.json
+++ b/apps/backend/src/modules/production_runs/migrations/.snapshot-production-runs.json
@@ -1004,6 +1004,22 @@
           "enumItems": [],
           "mappedType": "text"
         },
+        "reassign_retry_count": {
+          "name": "reassign_retry_count",
+          "type": "integer",
+          "unsigned": false,
+          "autoincrement": false,
+          "primary": false,
+          "nullable": false,
+          "unique": false,
+          "length": null,
+          "precision": null,
+          "scale": null,
+          "default": "0",
+          "comment": null,
+          "enumItems": [],
+          "mappedType": "integer"
+        },
         "metadata": {
           "name": "metadata",
           "type": "jsonb",

--- a/apps/backend/src/modules/production_runs/migrations/Migration20260809052748.ts
+++ b/apps/backend/src/modules/production_runs/migrations/Migration20260809052748.ts
@@ -1,0 +1,13 @@
+import { Migration } from "@medusajs/framework/mikro-orm/migrations";
+
+export class Migration20260809052748 extends Migration {
+
+  override async up(): Promise<void> {
+    this.addSql(`alter table if exists "production_runs" add column if not exists "reassign_retry_count" integer not null default 0;`);
+  }
+
+  override async down(): Promise<void> {
+    this.addSql(`alter table if exists "production_runs" drop column if exists "reassign_retry_count";`);
+  }
+
+}

--- a/apps/backend/src/modules/production_runs/models/production-run.ts
+++ b/apps/backend/src/modules/production_runs/models/production-run.ts
@@ -106,6 +106,13 @@ const ProductionRun = model.define("production_runs", {
   // assigns a fresh partner_id.
   previous_partner_id: model.text().nullable(),
 
+  // #1228 — how many times the reminder cap has re-nudged the SAME partner
+  // instead of parking the run. Budget comes from the stored policy
+  // (`reassignment.same_partner_retries`, default 1). Once spent, the next cap
+  // parks the run in awaiting_reassignment as before. Reset to 0 whenever a
+  // partner is (re)assigned, so each partner gets its own budget.
+  reassign_retry_count: model.number().default(0),
+
   metadata: model.json().nullable(),
 })
 

--- a/apps/backend/src/subscribers/production-run-activity-recorder.ts
+++ b/apps/backend/src/subscribers/production-run-activity-recorder.ts
@@ -62,6 +62,11 @@ const LIFECYCLE_SUMMARY_BY_KIND: Record<string, string> = {
 const ESCALATION_SUMMARY_BY_EVENT: Record<string, string> = {
   "production_run.reassignment_needed": "Run queued for reassignment",
   "production_run.reminder_escalated": "Reminder cap reached — escalated to admin",
+  // #1228 — the cap spent a retry instead of parking the run, and the manual
+  // assignment that pulls a parked run back out.
+  "production_run.reminder_retried_same_partner":
+    "Reminder cap reached — re-sent to the same partner",
+  "production_run.partner_assigned": "Partner assigned by admin",
 }
 
 export default async function productionRunActivityRecorder({
@@ -184,5 +189,8 @@ export const config: SubscriberConfig = {
     // #1093 — reminder cap escalations.
     "production_run.reassignment_needed",
     "production_run.reminder_escalated",
+    // #1228 — same-partner retry + manual assignment.
+    "production_run.reminder_retried_same_partner",
+    "production_run.partner_assigned",
   ],
 }

--- a/apps/backend/src/workflows/production-runs/__tests__/decide-cap-outcome.unit.spec.ts
+++ b/apps/backend/src/workflows/production-runs/__tests__/decide-cap-outcome.unit.spec.ts
@@ -1,0 +1,54 @@
+import { decideCapOutcome } from "../emit-production-run-reminder"
+
+/**
+ * #1228 — the reminder cap no longer parks a run unconditionally. It may first
+ * spend a "same partner retry" from the stored policy budget. These cases pin
+ * the boundary, including the `same_partner_retries: 0` setting that restores
+ * the original #1093 behaviour.
+ */
+describe("decideCapOutcome", () => {
+  it("retries the same partner while budget remains", () => {
+    expect(
+      decideCapOutcome({ reassign_retry_count: 0 }, { same_partner_retries: 1 })
+    ).toEqual({ outcome: "retry_same_partner", nextRetryCount: 1 })
+  })
+
+  it("parks once the budget is spent", () => {
+    expect(
+      decideCapOutcome({ reassign_retry_count: 1 }, { same_partner_retries: 1 })
+    ).toEqual({ outcome: "park", nextRetryCount: 1 })
+  })
+
+  it("parks immediately when retries are disabled (pre-#1228 behaviour)", () => {
+    expect(
+      decideCapOutcome({ reassign_retry_count: 0 }, { same_partner_retries: 0 })
+    ).toEqual({ outcome: "park", nextRetryCount: 0 })
+  })
+
+  it("supports a larger budget across successive caps", () => {
+    const policy = { same_partner_retries: 2 }
+    expect(decideCapOutcome({ reassign_retry_count: 0 }, policy).outcome).toBe(
+      "retry_same_partner"
+    )
+    expect(decideCapOutcome({ reassign_retry_count: 1 }, policy).outcome).toBe(
+      "retry_same_partner"
+    )
+    expect(decideCapOutcome({ reassign_retry_count: 2 }, policy).outcome).toBe("park")
+  })
+
+  it("treats a null/absent counter as zero spent", () => {
+    expect(
+      decideCapOutcome({ reassign_retry_count: null }, { same_partner_retries: 1 })
+    ).toEqual({ outcome: "retry_same_partner", nextRetryCount: 1 })
+    expect(decideCapOutcome({}, { same_partner_retries: 1 })).toEqual({
+      outcome: "retry_same_partner",
+      nextRetryCount: 1,
+    })
+  })
+
+  it("never retries when the stored counter has somehow overshot the budget", () => {
+    expect(
+      decideCapOutcome({ reassign_retry_count: 9 }, { same_partner_retries: 1 })
+    ).toEqual({ outcome: "park", nextRetryCount: 9 })
+  })
+})

--- a/apps/backend/src/workflows/production-runs/assign-production-run-partner.ts
+++ b/apps/backend/src/workflows/production-runs/assign-production-run-partner.ts
@@ -1,0 +1,221 @@
+import { MedusaError, Modules } from "@medusajs/framework/utils"
+import {
+  createStep,
+  createWorkflow,
+  StepResponse,
+  WorkflowResponse,
+} from "@medusajs/framework/workflows-sdk"
+
+import { PRODUCTION_RUNS_MODULE } from "../../modules/production_runs"
+import type ProductionRunService from "../../modules/production_runs/service"
+import { PRODUCTION_POLICY_MODULE } from "../../modules/production_policy"
+import type ProductionPolicyService from "../../modules/production_policy/service"
+import { PARTNER_MODULE } from "../../modules/partner"
+
+/**
+ * #1228 — the manual half of #1093's reassignment story.
+ *
+ * #1093 built the automatic path (reminders → cap → park in
+ * `awaiting_reassignment`, partner unassigned, tasks cancelled) but nothing
+ * that moves a parked run back OUT. This workflow is that missing half: an
+ * admin points the run at a partner — the same one who let it go stale, or a
+ * different one — and it lands back on `approved`, ready for the ordinary
+ * dispatch flow.
+ *
+ * Deliberately stops at `approved` rather than dispatching itself. Dispatch is
+ * what collects template names, and template names are what seed the partner's
+ * tasks; short-circuiting it would hand a partner a run with no work items.
+ */
+
+export type AssignProductionRunPartnerSource = "manual" | "reminder_retry"
+
+export type AssignProductionRunPartnerInput = {
+  production_run_id: string
+  partner_id: string
+  /** Free-text admin note, recorded on the activity feed. */
+  note?: string | null
+  source?: AssignProductionRunPartnerSource
+}
+
+type AssignComp = {
+  id: string
+  prev_status: string
+  prev_partner_id: string | null
+  prev_previous_partner_id: string | null
+  prev_cancelled_reason: string | null
+  prev_reminder_count: number
+  prev_reminder_kind: string | null
+  prev_reminder_status: string | null
+  prev_reassign_retry_count: number
+  prev_dispatch_state: string | null
+  prev_dispatch_started_at: Date | null
+  prev_dispatch_completed_at: Date | null
+}
+
+/**
+ * Validate the partner exists before we point a run at it — a typo'd id would
+ * otherwise park the run against a partner that can never see it.
+ */
+const assertPartnerExistsStep = createStep(
+  "assign-partner-assert-exists",
+  async (input: { partner_id: string }, { container }) => {
+    const partnerService: any = container.resolve(PARTNER_MODULE)
+    const partner = await partnerService
+      .retrievePartner(input.partner_id)
+      .catch(() => null)
+
+    if (!partner) {
+      throw new MedusaError(
+        MedusaError.Types.NOT_FOUND,
+        `Partner ${input.partner_id} not found`
+      )
+    }
+
+    return new StepResponse({ id: partner.id, name: partner.name ?? null })
+  }
+)
+
+/**
+ * Point the run at the partner and reset it to a dispatchable state.
+ *
+ * `previous_partner_id` keeps whoever last held it (so a same-partner retry is
+ * still legible in the audit trail), the reminder cycle restarts from zero, and
+ * the retry budget resets — each partner earns their own.
+ */
+const assignPartnerStep = createStep(
+  "assign-production-run-partner",
+  async (input: AssignProductionRunPartnerInput, { container }) => {
+    const service: ProductionRunService = container.resolve(PRODUCTION_RUNS_MODULE)
+    const policy: ProductionPolicyService = container.resolve(PRODUCTION_POLICY_MODULE)
+
+    const run = (await service.retrieveProductionRun(input.production_run_id)) as any
+    await policy.assertCanAssignPartner(run)
+
+    const previousPartnerId = run.partner_id ?? run.previous_partner_id ?? null
+    const isSamePartner = previousPartnerId === input.partner_id
+
+    await service.updateProductionRuns({
+      id: input.production_run_id,
+      partner_id: input.partner_id,
+      previous_partner_id: previousPartnerId,
+      // Back to the one status the dispatch flow accepts, with the dispatch
+      // cycle rewound to untouched. All three matter: `dispatch_state` is a
+      // non-nullable enum, and the admin Dispatch button additionally hides
+      // itself unless `dispatch_completed_at` is clear — so a run that was
+      // already dispatched once would otherwise be assigned to a new partner
+      // and then offer no way to actually send it.
+      status: "approved",
+      dispatch_state: "idle",
+      dispatch_started_at: null,
+      dispatch_completed_at: null,
+      // The partner never accepted (the policy refuses to reassign once they
+      // have), so this is only ever clearing a stale value.
+      accepted_at: null,
+      // The park reason described the PREVIOUS partner's failure; it would read
+      // as a live warning against the new one.
+      cancelled_reason: null,
+      reminder_count: 0,
+      reminder_kind: null,
+      reminder_status: null,
+      last_reminded_at: null,
+      reassign_retry_count: 0,
+    })
+
+    return new StepResponse<
+      { ok: boolean; previous_partner_id: string | null; same_partner: boolean },
+      AssignComp
+    >(
+      {
+        ok: true,
+        previous_partner_id: previousPartnerId,
+        same_partner: isSamePartner,
+      },
+      {
+        id: input.production_run_id,
+        prev_status: run.status,
+        prev_partner_id: run.partner_id ?? null,
+        prev_previous_partner_id: run.previous_partner_id ?? null,
+        prev_cancelled_reason: run.cancelled_reason ?? null,
+        prev_reminder_count: run.reminder_count ?? 0,
+        prev_reminder_kind: run.reminder_kind ?? null,
+        prev_reminder_status: run.reminder_status ?? null,
+        prev_reassign_retry_count: run.reassign_retry_count ?? 0,
+        prev_dispatch_state: run.dispatch_state ?? null,
+        prev_dispatch_started_at: run.dispatch_started_at ?? null,
+        prev_dispatch_completed_at: run.dispatch_completed_at ?? null,
+      }
+    )
+  },
+  async (comp: AssignComp | undefined, { container }) => {
+    if (!comp) return
+    const service: ProductionRunService = container.resolve(PRODUCTION_RUNS_MODULE)
+    await service.updateProductionRuns({
+      id: comp.id,
+      status: comp.prev_status as any,
+      partner_id: comp.prev_partner_id,
+      previous_partner_id: comp.prev_previous_partner_id,
+      cancelled_reason: comp.prev_cancelled_reason,
+      reminder_count: comp.prev_reminder_count,
+      reminder_kind: comp.prev_reminder_kind,
+      reminder_status: comp.prev_reminder_status as any,
+      reassign_retry_count: comp.prev_reassign_retry_count,
+      dispatch_state: comp.prev_dispatch_state as any,
+      dispatch_started_at: comp.prev_dispatch_started_at,
+      dispatch_completed_at: comp.prev_dispatch_completed_at,
+    })
+  }
+)
+
+/**
+ * Drives the admin activity feed and any notification listeners. Non-fatal —
+ * the assignment itself has already committed.
+ */
+const emitAssignedEventStep = createStep(
+  "assign-partner-emit-event",
+  async (
+    input: AssignProductionRunPartnerInput & { previous_partner_id: string | null },
+    { container }
+  ) => {
+    try {
+      const eventService: any = container.resolve(Modules.EVENT_BUS)
+      await eventService.emit([
+        {
+          name: "production_run.partner_assigned",
+          data: {
+            id: input.production_run_id,
+            production_run_id: input.production_run_id,
+            partner_id: input.partner_id,
+            previous_partner_id: input.previous_partner_id,
+            same_partner: input.previous_partner_id === input.partner_id,
+            source: input.source ?? "manual",
+            note: input.note ?? null,
+          },
+        },
+      ])
+    } catch {
+      /* non-fatal */
+    }
+    return new StepResponse({ ok: true })
+  }
+)
+
+export const assignProductionRunPartnerWorkflow = createWorkflow(
+  "assign-production-run-partner",
+  (input: AssignProductionRunPartnerInput) => {
+    assertPartnerExistsStep({ partner_id: input.partner_id })
+
+    const assigned = assignPartnerStep(input)
+
+    emitAssignedEventStep({
+      production_run_id: input.production_run_id,
+      partner_id: input.partner_id,
+      note: input.note,
+      source: input.source,
+      previous_partner_id: assigned.previous_partner_id,
+    })
+
+    return new WorkflowResponse(assigned)
+  }
+)
+
+export default assignProductionRunPartnerWorkflow

--- a/apps/backend/src/workflows/production-runs/emit-production-run-reminder.ts
+++ b/apps/backend/src/workflows/production-runs/emit-production-run-reminder.ts
@@ -9,7 +9,12 @@ import type { IEventBusModuleService } from "@medusajs/types"
 
 import { PRODUCTION_RUNS_MODULE } from "../../modules/production_runs"
 import type ProductionRunService from "../../modules/production_runs/service"
+import { PRODUCTION_POLICY_MODULE } from "../../modules/production_policy"
+import type ProductionPolicyService from "../../modules/production_policy/service"
+import type { ReassignmentPolicy } from "../../modules/production_policy/service"
+import { PARTNER_MODULE } from "../../modules/partner"
 import { reassignProductionRunWorkflow } from "./reassign-production-run"
+import { acceptProductionRunWorkflow } from "./accept-production-run"
 
 export type ReminderKind = "assignment_pending" | "not_started" | "idle"
 
@@ -33,7 +38,13 @@ const REMINDER_EVENT_BY_KIND: Record<ReminderKind, string> = {
  */
 export const REMINDER_CAP = 2
 
-type EmitAction = "reminded" | "reassigned" | "escalated" | "skipped"
+type EmitAction =
+  | "reminded"
+  | "reassigned"
+  | "escalated"
+  | "skipped"
+  /** #1228 — cap hit, but the partner still has retry budget left. */
+  | "retried_same_partner"
 
 type EmitStepResult = {
   action: EmitAction
@@ -76,6 +87,27 @@ export function decideReminderAction(
   }
 
   return { action: "reminded", nextCount: effectiveCount + 1 }
+}
+
+/**
+ * #1228 — what a cap on an UNACCEPTED run does. Before #1228 this was always
+ * "park it"; now the stored policy may buy the partner one more full reminder
+ * cycle first, on the theory that a silent partner is usually a busy one rather
+ * than an absent one. `same_partner_retries: 0` restores the old behaviour.
+ *
+ * Pure — exported for unit testing.
+ */
+export function decideCapOutcome(
+  run: { reassign_retry_count?: number | null },
+  policy: Pick<ReassignmentPolicy, "same_partner_retries">
+): { outcome: "retry_same_partner" | "park"; nextRetryCount: number } {
+  const spent = run.reassign_retry_count ?? 0
+  const budget = policy.same_partner_retries ?? 0
+
+  if (spent < budget) {
+    return { outcome: "retry_same_partner", nextRetryCount: spent + 1 }
+  }
+  return { outcome: "park", nextRetryCount: spent }
 }
 
 const processReminderStep = createStep(
@@ -153,7 +185,75 @@ const processReminderStep = createStep(
     }
 
     if (action === "reassigned") {
-      // Cap hit on an unaccepted run → send it to the reassignment queue.
+      // Cap hit on an unaccepted run. #1228 — before giving the work to
+      // someone else, the policy may buy this partner one more reminder cycle.
+      const policyService: ProductionPolicyService = container.resolve(
+        PRODUCTION_POLICY_MODULE
+      )
+      const reassignmentPolicy = await policyService.getReassignmentPolicy()
+      const { outcome, nextRetryCount } = decideCapOutcome(run, reassignmentPolicy)
+
+      if (outcome === "retry_same_partner") {
+        // Keep the partner and the status; just restart the reminder cycle and
+        // spend a retry. The next cap on this run will park it.
+        await service.updateProductionRuns({
+          id: input.production_run_id,
+          reassign_retry_count: nextRetryCount,
+          reminder_count: 0,
+          reminder_kind: null,
+          reminder_status: null,
+        })
+
+        await eventService.emit([
+          {
+            name: "production_run.reminder_retried_same_partner",
+            data: {
+              production_run_id: input.production_run_id,
+              partner_id: input.partner_id,
+              design_id: input.design_id ?? null,
+              reminder_kind: input.reminder_kind,
+              retry_count: nextRetryCount,
+            },
+          },
+        ])
+
+        // Optional escape hatch: a partner who has pre-agreed to it gets the
+        // run accepted on their behalf, so production moves instead of waiting
+        // on a click that history says isn't coming. Both the policy AND the
+        // partner's own opt-in must be true, and only ever on a retry.
+        let autoAccepted = false
+        if (reassignmentPolicy.auto_accept_on_retry && run.status === "sent_to_partner") {
+          const partnerService: any = container.resolve(PARTNER_MODULE)
+          const partner = await partnerService
+            .retrievePartner(input.partner_id)
+            .catch(() => null)
+
+          if (partner?.auto_accept_production_runs) {
+            await acceptProductionRunWorkflow(container)
+              .run({
+                input: {
+                  production_run_id: input.production_run_id,
+                  partner_id: input.partner_id,
+                },
+              })
+              .then(() => {
+                autoAccepted = true
+              })
+              .catch(() => {
+                /* non-fatal — the retry itself already stands */
+              })
+          }
+        }
+
+        return new StepResponse<EmitStepResult>({
+          action: "retried_same_partner",
+          event: "production_run.reminder_retried_same_partner",
+          reminder_count: 0,
+          reason: autoAccepted ? "auto_accepted" : null,
+        })
+      }
+
+      // Retry budget spent → send it to the reassignment queue.
       await reassignProductionRunWorkflow(container).run({
         input: {
           production_run_id: input.production_run_id,

--- a/apps/backend/workflow-schemas.json
+++ b/apps/backend/workflow-schemas.json
@@ -5923,6 +5923,37 @@
     "source": "custom_ts",
     "sourceFile": "src/workflows/production-runs/approve-production-run.ts"
   },
+  "assign-production-run-partner": {
+    "fields": [
+      {
+        "name": "production_run_id",
+        "type": "id",
+        "required": true,
+        "placeholder": "{{ $last.production_run_id }}"
+      },
+      {
+        "name": "partner_id",
+        "type": "id",
+        "required": true,
+        "placeholder": "{{ $last.partner_id }}"
+      },
+      {
+        "name": "note",
+        "type": "string",
+        "required": false,
+        "placeholder": "{{ $last.note }}",
+        "description": "#1228 — the manual half of #1093's reassignment story. #1093 built the automatic path (reminders → cap → park in `awaiting_reassignment`, partner unassigned, tasks cancelled) but nothing that moves a parked run back OUT. This workflow is that missing half: an admin points the run at a partner — the same one who let it go stale, or a different one — and it lands back on `approved`, ready for the ordinary dispatch flow. Deliberately stops at `approved` rather than dispatching itself. Dispatch is what collects template names, and template names are what seed the partner's tasks; short-circuiting it would hand a partner a run with no work items. / export type AssignProductionRunPartnerSource = \"manual\" | \"reminder_retry\" export type AssignProductionRunPartnerInput = { production_run_id: string partner_id: string /** Free-text admin note, recorded on the activity feed."
+      },
+      {
+        "name": "source",
+        "type": "string",
+        "required": false,
+        "placeholder": "{{ $last.source }}"
+      }
+    ],
+    "source": "custom_ts",
+    "sourceFile": "src/workflows/production-runs/assign-production-run-partner.ts"
+  },
   "complete-production-run": {
     "fields": [
       {

--- a/e2e/helpers/e2e-seed.ts
+++ b/e2e/helpers/e2e-seed.ts
@@ -322,6 +322,83 @@ async function seedProvenanceProductRun(container: any): Promise<string> {
 }
 
 /**
+ * #1228 — a production run parked in `awaiting_reassignment`, plus the two
+ * partners the reassign drawer picks between: the one that let it lapse
+ * (`previous_partner_id`, the "same partner again" option) and a fresh one.
+ *
+ * Written straight through the module services rather than by driving a real
+ * decline: the fixture only needs the END state, and going through the partner
+ * decline route would drag the whole auth + dispatch chain into the seed.
+ *
+ * Mirrors exactly what `reassignProductionRunWorkflow` leaves behind — partner
+ * unassigned, previous partner retained, a park reason for the drawer to show —
+ * so the spec exercises the same shape production produces.
+ */
+async function seedParkedProductionRun(container: any): Promise<{
+  runId: string
+  designId: string
+  lapsedPartnerId: string
+  lapsedPartnerName: string
+  freshPartnerName: string
+}> {
+  const partnerModule: any = container.resolve("partner")
+  const designService: any = container.resolve("design")
+  const runService: any = container.resolve("production_runs")
+
+  const stamp = Date.now()
+
+  const mkPartner = async (label: string) => {
+    const created = await partnerModule.createPartners({
+      // Stamped: the name is what the reassign picker shows and what the spec
+      // selects on, so repeat seeds must not produce duplicates.
+      name: `E2E ${label} Partner ${stamp}`,
+      handle: `e2e-${label.toLowerCase()}-${stamp}`,
+      status: "active",
+      is_verified: true,
+    })
+    const row = Array.isArray(created) ? created[0] : created
+    return { id: row.id as string, name: row.name as string }
+  }
+
+  const lapsed = await mkPartner("Lapsed")
+  const fresh = await mkPartner("Fresh")
+
+  const design = await designService.createDesigns({
+    name: `Reassign Fixture (e2e ${stamp})`,
+    description: "e2e #1228 manual reassignment fixture",
+    design_type: "Original",
+    status: "Commerce_Ready",
+    priority: "Medium",
+  })
+  const designId = (Array.isArray(design) ? design[0] : design).id as string
+
+  const run = await runService.createProductionRuns({
+    design_id: designId,
+    quantity: 3,
+    run_type: "production",
+    // Both non-nullable on the model; the run page reads design.name off the
+    // snapshot.
+    snapshot: { design: { id: designId, name: `Reassign Fixture (e2e ${stamp})` } },
+    captured_at: new Date(),
+    status: "awaiting_reassignment",
+    partner_id: null,
+    previous_partner_id: lapsed.id,
+    cancelled_reason: "Declined by partner (capacity): Machine servicing",
+    reminder_count: 0,
+    reminder_status: "closed",
+  })
+  const runId = (Array.isArray(run) ? run[0] : run).id as string
+
+  return {
+    runId,
+    designId,
+    lapsedPartnerId: lapsed.id,
+    lapsedPartnerName: lapsed.name,
+    freshPartnerName: fresh.name,
+  }
+}
+
+/**
  * #1113 — seed a design carrying a full brief (concept + aesthetic anchor +
  * persona + competitors + price point + milestones + design budget), so the
  * designer-invite → brief-moodboard flow (S1 invite/accept + S2 generate) can be
@@ -694,6 +771,9 @@ export default async function e2eSeed({ container }: ExecArgs) {
   logger.info("E2E seed: creating the HSN-gap product (customs specs)...")
   const hsnGap = await seedHsCodeGapProduct(container)
 
+  logger.info("E2E seed: creating the #1228 parked production run + partners...")
+  const parkedRun = await seedParkedProductionRun(container)
+
   logger.info("E2E seed: creating the gate order's partner fee (payout spec)...")
   const gateFee = await seedPartnerFeeForGateOrder(
     container,
@@ -724,6 +804,13 @@ export default async function e2eSeed({ container }: ExecArgs) {
     // Expected payout arithmetic for partner-order-payout-summary.spec.ts.
     gateOrderCurrency: gate.currencyCode,
     gateFee,
+    // #1228 manual-reassignment fixture — consumed by
+    // production-run-reassign.spec.ts (admin, CI).
+    parkedRunId: parkedRun.runId,
+    parkedRunDesignId: parkedRun.designId,
+    parkedRunLapsedPartnerId: parkedRun.lapsedPartnerId,
+    parkedRunLapsedPartnerName: parkedRun.lapsedPartnerName,
+    parkedRunFreshPartnerName: parkedRun.freshPartnerName,
   }
 
   fs.writeFileSync(SEED_FILE, JSON.stringify(seedData, null, 2))

--- a/e2e/specs/production-run-reassign.spec.ts
+++ b/e2e/specs/production-run-reassign.spec.ts
@@ -1,0 +1,133 @@
+import { test, expect } from "@playwright/test"
+import * as fs from "fs"
+import * as path from "path"
+
+const SEED_FILE = path.resolve(__dirname, "../../apps/backend/.e2e-seed.json")
+
+/**
+ * #1228 — manual reassignment out of `awaiting_reassignment`, driven through
+ * the admin UI.
+ *
+ * #1093 could park a run (reminder cap / partner decline) but nothing moved it
+ * back out: the run page rendered a red badge and no actionable control, so a
+ * parked run was a dead end even for a retry with the SAME partner. These cases
+ * assert the UI half of the fix — the Reassign entry point exists on a parked
+ * run, the drawer pre-selects the partner who let it lapse, and completing it
+ * leaves the run genuinely dispatchable rather than merely re-labelled.
+ */
+test.describe("Production run manual reassignment (#1228)", () => {
+  let seed: {
+    email: string
+    password: string
+    parkedRunId: string
+    parkedRunLapsedPartnerName: string
+    parkedRunFreshPartnerName: string
+  }
+
+  test.beforeAll(() => {
+    if (!fs.existsSync(SEED_FILE)) {
+      throw new Error(
+        `E2E seed file not found at ${SEED_FILE}. Run "pnpm e2e:seed" first.`
+      )
+    }
+    seed = JSON.parse(fs.readFileSync(SEED_FILE, "utf-8"))
+    if (!seed.parkedRunId) {
+      throw new Error("E2E seed missing parkedRunId — re-run the seed.")
+    }
+  })
+
+  const login = async (page: any) => {
+    await page.goto("/app/login")
+    // `networkidle` never settles against `medusa develop` (the dev server holds
+    // long-lived connections open), so wait on the form itself.
+    await page.locator('input[name="email"]').waitFor({ timeout: 60000 })
+    await page.locator('input[name="email"]').fill(seed.email)
+    await page.locator('input[name="password"]').fill(seed.password)
+    await page.locator('button[type="submit"]').click()
+    await page.waitForURL(/\/app\/(?!login)/, { timeout: 15000 })
+  }
+
+  test("surfaces a Reassign action on a parked run and re-sends it to the same partner", async ({
+    page,
+  }) => {
+    await login(page)
+    await page.goto(`/app/production-runs/${seed.parkedRunId}`)
+
+    // The parked state is visible…
+    await expect(
+      page.getByText("awaiting reassignment", { exact: false }).first()
+    ).toBeVisible({ timeout: 15000 })
+
+    // …and, unlike before #1228, it is actionable.
+    const reassign = page.getByRole("button", { name: "Reassign" })
+    await expect(reassign).toBeVisible()
+    await reassign.click()
+
+    // The drawer explains WHY the run needs reassigning (the park reason).
+    await expect(
+      page.getByRole("heading", { name: "Assign partner" })
+    ).toBeVisible({ timeout: 10000 })
+    await expect(
+      page.getByText("Machine servicing", { exact: false })
+    ).toBeVisible()
+
+    // `?mode=same` pre-selects the partner who let it lapse, so the common case
+    // ("just send it to them again") is a single confirm.
+    await expect(
+      page.getByRole("button", { name: /Re-assign to same partner/i })
+    ).toBeEnabled()
+
+    await page
+      .getByRole("button", { name: /Re-assign to same partner/i })
+      .click()
+
+    // Back on the run page: it is approved, holds the partner again, and — the
+    // part that actually matters — Dispatch is offered. An "approved" run whose
+    // dispatch cycle wasn't rewound would show no Dispatch button at all.
+    await expect(page.getByText("approved", { exact: false }).first()).toBeVisible({
+      timeout: 15000,
+    })
+    await expect(
+      page.getByRole("button", { name: /Dispatch to Partner/i })
+    ).toBeVisible({ timeout: 15000 })
+    await expect(page.getByRole("button", { name: "Reassign" })).toHaveCount(0)
+  })
+
+  test("offers a different partner from the overflow menu and records the swap", async ({
+    page,
+  }) => {
+    await login(page)
+    // The previous case left the run `approved` and assigned — still a valid
+    // reassignment source (a plain correction before the partner accepts).
+    await page.goto(`/app/production-runs/${seed.parkedRunId}`)
+
+    await page.getByRole("button", { name: "Actions" }).click()
+    const differentPartner = page.getByText("Assign a different partner")
+    await expect(differentPartner).toBeVisible({ timeout: 10000 })
+    await differentPartner.click()
+
+    await expect(
+      page.getByRole("heading", { name: "Assign partner" })
+    ).toBeVisible({ timeout: 10000 })
+
+    // Narrow with the search box first, then pick — this also exercises the
+    // filter, which is the only way the picker stays usable at 200 partners.
+    await page.getByPlaceholder("Search partners…").fill(
+      seed.parkedRunFreshPartnerName
+    )
+    await page.getByRole("combobox").click()
+    await page
+      .getByRole("option", { name: seed.parkedRunFreshPartnerName })
+      .first()
+      .click()
+
+    const confirm = page.getByRole("button", { name: /^Assign partner$/ })
+    await expect(confirm).toBeEnabled()
+    await confirm.click()
+
+    // The run stays dispatchable under its new partner.
+    await expect(
+      page.getByRole("button", { name: /Dispatch to Partner/i })
+    ).toBeVisible({ timeout: 15000 })
+  })
+})


### PR DESCRIPTION
Closes #1228.

#1093 built the **automatic** half of reassignment — reminders → cap → park the run in `awaiting_reassignment`, partner unassigned, tasks cancelled — but nothing moved a run back **out**. No route set `partner_id` on an existing run, the stored policy excluded `awaiting_reassignment` from every dispatch transition, and the run page rendered a red badge with no actionable control. A parked run was a dead end, **even for a retry with the same partner**. The only workaround was `recreate-production-run`, which orphaned the parked run forever and inflated the admin "in progress" totals.

## What this adds

**Manual assignment**
- `assignProductionRunPartnerWorkflow` + `POST /admin/production-runs/:id/assign-partner` (`{ partner_id, note? }`)
- New `@reassign` admin drawer: shows the park reason, partner picker with search, `?mode=same` pre-selects `previous_partner_id`, and says explicitly that assigning does **not** send the run
- Entry points: a promoted **Reassign** button on a parked run, plus **"Send to the same partner again"** / **"Assign a different partner"** in the run page's overflow menu *and* on the design-order Production section's run cards (both deep-link to the same drawer — one implementation)
- The design-order section now shows `Unassigned — needs a new partner` for a parked run; it previously fell through to "Not sent to a partner yet", which reads as *nothing has happened*

**Policy-driven retry before giving up on a partner**
- `reassignment.same_partner_retries` (default `1`) — the cap re-nudges the same partner once, resetting the reminder cycle, before parking. `0` restores the pre-#1228 behaviour.
- `reassignment.auto_accept_on_retry` (default `false`) — on a retry *only*, accept on the partner's behalf. **Double-gated**: the policy flag *and* the partner's own new `auto_accept_production_runs` column must both be true. Nothing changes until someone opts in.
- Both settable through the existing `PUT /admin/production-run-policy` — its validator already accepts any config shape.

## Two things that would otherwise have broken silently

**1. `assign_partner_from` is a NEW policy key, not a widened `dispatch_from`.** `allowedStatuses` falls back per key, so already-stored policy configs pick the new transition up with **no backfill**. Widening an existing key would have needed a data-plumbing job to reach them — and would have looked like it worked locally.

**2. Assignment rewinds the whole dispatch cycle, not just `partner_id`.** `dispatch_state` is a non-nullable enum, and the admin Dispatch button additionally requires `dispatch_completed_at` to be clear. A previously-dispatched run would have come back assigned but with **no way to send it**. Pinned by an integration case that fires a real `start-dispatch` and asserts a 202.

## Deliberate choices

- **Lands on `approved`, not `sent_to_partner`.** Dispatch is what collects template names, and template names are what seed the partner's tasks. Short-circuiting it would hand a partner a run with no work items.
- **The partner migration is hand-written.** `db:generate` emitted a full `create table if not exists "partner"` (that module has no snapshot) — a silent no-op against the existing table, so the column would never have been added, and its `down` dropped the table outright. Only the `ALTER` is wanted.
- `previous_partner_id` is retained on assignment, so a same-partner retry is still legible in the audit trail.

## Schema

| Table | Column | Migration |
|---|---|---|
| `production_runs` | `reassign_retry_count` int not null default 0 | `Migration20260809052748` |
| `partner` | `auto_accept_production_runs` bool not null default false | `Migration20260809052749` (hand-written) |

⚠️ **Deploy needs both migrations.** If this goes out via a `workflow_dispatch` rather than a push, pass `force_migrate=true` — a dispatch has no push diff, so the migrate gate would otherwise skip.

## Tests — all green locally

- **Unit** `decide-cap-outcome.unit.spec.ts` — 6 cases incl. `same_partner_retries: 0` and an overshot counter
- **Integration** `production-run-manual-assign.spec.ts` — 6 cases: same-partner recovery, different-partner + `previous_partner_id` audit + a real `start-dispatch` 202, unknown partner 404 **leaving the run untouched**, missing `partner_id` 400, already-accepted 400, and a pre-acceptance correction
- **E2E (Playwright, admin, CI-eligible)** `production-run-reassign.spec.ts` — 2 cases driving the real UI, with a new `seedParkedProductionRun` fixture
- **Regression**: `partners-decline-run` (1) and `partner-cancel-reassign-desync` (3) still pass
- `tsc` **79** — unchanged baseline, zero errors in the new files
- `workflow-schemas.json` regenerated (the vflow node registry reads it at runtime)

## Not addressed here

- The reminders discoverer visual flow is still seeded `status: "draft"`, so the same-partner retry can't fire until it's activated. **Manual assignment works regardless.**
- `awaiting_reassignment` remains inside `IN_PROGRESS_STATUSES`, so admin totals still count parked runs.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
