### PR TITLE
feat(production-runs): let admins correct a partner's reported output

### DIFF
--- a/apps/backend/integration-tests/http/production-run-complete-yield.spec.ts
+++ b/apps/backend/integration-tests/http/production-run-complete-yield.spec.ts
@@ -408,5 +408,92 @@ setupSharedTestSuite(() => {
       // Stored verbatim: 450/unit (cost_type records per_unit). #456
       expect(adminDetail.data.production_run.partner_cost_estimate).toBe(450)
     })
+
+    // ── Test: admin corrects an over-reported yield ─────────────────
+
+    it("should let an admin correct the partner's reported output after completion", async () => {
+      const { adminHeaders, unique } = await setupTestData()
+      const { partnerId, partnerHeaders } = await createPartner(unique)
+      const { templateName } = await createTemplates(adminHeaders, unique)
+      const designId = await createDesign(adminHeaders, unique)
+
+      const createRes = await api.post(
+        `/admin/designs/${designId}/production-runs`,
+        {
+          quantity: 9,
+          assignments: [{ partner_id: partnerId, quantity: 9, template_names: [templateName] }],
+        },
+        adminHeaders
+      )
+      expect(createRes.status).toBe(201)
+      const runId = createRes.data.children[0].id
+
+      await advanceToFinished(runId, partnerHeaders)
+
+      // The partner over-reports: claims all 9 were made (prod_run_01KYPM4G…).
+      await api.post(
+        `/partners/production-runs/${runId}/complete`,
+        { produced_quantity: 9 },
+        { headers: partnerHeaders }
+      )
+
+      const correction = await api.post(
+        `/admin/production-runs/${runId}`,
+        {
+          produced_quantity: 3,
+          correction_reason: "Partner reported 9; physical count was 3",
+        },
+        adminHeaders
+      )
+      expect(correction.status).toBe(200)
+      expect(correction.data.production_run.produced_quantity).toBe(3)
+      // The ordered quantity is a different fact and must survive untouched.
+      expect(correction.data.production_run.quantity).toBe(9)
+      expect(correction.data.production_run.status).toBe("completed")
+
+      // The correction is auditable, not a silent overwrite.
+      const activities = await api.get(
+        `/admin/production-runs/${runId}/activities`,
+        adminHeaders
+      )
+      expect(activities.status).toBe(200)
+      const corrections = activities.data.activities.filter(
+        (a: any) => a.kind === "output_corrected"
+      )
+      expect(corrections).toHaveLength(1)
+      expect(corrections[0].actor_type).toBe("admin")
+      expect(corrections[0].payload.previous.produced_quantity).toBe(9)
+      expect(corrections[0].payload.corrected.produced_quantity).toBe(3)
+      expect(corrections[0].payload.reason).toBe(
+        "Partner reported 9; physical count was 3"
+      )
+    })
+
+    it("should reject a negative output correction", async () => {
+      const { adminHeaders, unique } = await setupTestData()
+      const { partnerId, partnerHeaders } = await createPartner(unique)
+      const { templateName } = await createTemplates(adminHeaders, unique)
+      const designId = await createDesign(adminHeaders, unique)
+
+      const createRes = await api.post(
+        `/admin/designs/${designId}/production-runs`,
+        {
+          quantity: 4,
+          assignments: [{ partner_id: partnerId, quantity: 4, template_names: [templateName] }],
+        },
+        adminHeaders
+      )
+      const runId = createRes.data.children[0].id
+      await advanceToFinished(runId, partnerHeaders)
+      await api.post(
+        `/partners/production-runs/${runId}/complete`,
+        { produced_quantity: 4 },
+        { headers: partnerHeaders }
+      )
+
+      await expect(
+        api.post(`/admin/production-runs/${runId}`, { produced_quantity: -1 }, adminHeaders)
+      ).rejects.toMatchObject({ response: { status: 400 } })
+    })
   })
 })

--- a/apps/backend/src/api/admin/mcp/lib/registry.ts
+++ b/apps/backend/src/api/admin/mcp/lib/registry.ts
@@ -1520,20 +1520,45 @@ export const ADMIN_MCP_TOOLS: AdminMcpToolDef[] = [
   {
     name: "update_production_run",
     description:
-      "Update a production run's quantity, role, run type or partner cost estimate. Sensitive: requires confirm:true. Structural edits (quantity/role/run_type) are REJECTED once the run has been accepted or started, and any edit is rejected on a cancelled run. Use dry_run to see the current run first.",
+      "Update a production run's quantity, role, run type, partner cost estimate, or correct the output the partner reported (produced_quantity / rejected_quantity). Sensitive: requires confirm:true. Structural edits (quantity/role/run_type) are REJECTED once the run has been accepted or started, and any edit is rejected on a cancelled run — but output corrections are allowed precisely BECAUSE the run is completed. Use dry_run to see the current run first.",
     method: "POST",
     path: "/admin/production-runs/:id",
     pathParams: ["id"],
     previewPath: "/admin/production-runs/:id",
     write: true,
     sensitive: true,
-    bodyParams: ["quantity", "role", "run_type", "partner_cost_estimate", "cost_type"],
+    bodyParams: [
+      "quantity",
+      "role",
+      "run_type",
+      "partner_cost_estimate",
+      "cost_type",
+      "produced_quantity",
+      "rejected_quantity",
+      "correction_reason",
+    ],
     inputSchema: obj(
       {
         id: STR("Production run id."),
-        quantity: { type: "number", description: "New quantity (pre-acceptance only)." },
+        quantity: {
+          type: "number",
+          description:
+            "New ORDERED quantity (pre-acceptance only). This is what was asked for — to correct what was actually MADE, use produced_quantity instead.",
+        },
         role: STR("New role for the run (pre-acceptance only)."),
         run_type: STR("'production' | 'sample' (pre-acceptance only)."),
+        produced_quantity: {
+          type: "number",
+          description:
+            "Correct the number of good pieces the partner reported making. Partners self-report this at completion and do over-report. Editable after completion. Feeds cost-per-unit, the design cost engine, goods-transfer quantities and the public production story, so pass correction_reason too.",
+        },
+        rejected_quantity: {
+          type: "number",
+          description: "Correct the number of rejected pieces the partner reported.",
+        },
+        correction_reason: STR(
+          "Why the reported output is being corrected (e.g. 'physical count was 3'). Recorded on the run's activity timeline alongside the before/after values."
+        ),
         partner_cost_estimate: {
           type: "number",
           description:

--- a/apps/backend/src/api/admin/production-runs/[id]/route.ts
+++ b/apps/backend/src/api/admin/production-runs/[id]/route.ts
@@ -126,6 +126,16 @@ export const GET = async (req: MedusaRequest, res: MedusaResponse) => {
  * run is accepted/started. Cost fields (partner_cost_estimate, cost_type) are
  * editable by admins any time except cancelled, since admins may need to
  * record/correct cost after the partner has already begun work.
+ *
+ * produced_quantity/rejected_quantity are corrections of what the PARTNER
+ * reported at completion, so — unlike the structural fields — they are editable
+ * precisely BECAUSE the run is completed. Partners self-report these
+ * (`POST /partners/production-runs/:id/complete`) and do over-report:
+ * `prod_run_01KYPM4G…` was reported as 9 produced when 3 were made, and there
+ * was no way to correct it short of a direct DB write. Every correction writes
+ * an append-only activity row recording who changed what from what, since the
+ * number feeds cost-per-unit, the design cost engine, goods-transfer quantities
+ * and the public production story.
  */
 export const POST = async (req: MedusaRequest, res: MedusaResponse) => {
   const id = req.params.id
@@ -180,12 +190,91 @@ export const POST = async (req: MedusaRequest, res: MedusaResponse) => {
     update.cost_type = body.cost_type
   }
 
+  // Corrections to the partner's self-reported output. `null` clears the field
+  // back to "not reported"; a number must be a non-negative, finite quantity.
+  const readQuantityCorrection = (field: string): number | null | undefined => {
+    const raw = body[field]
+    if (raw === undefined) return undefined
+    if (raw === null) return null
+    const value = Number(raw)
+    if (!Number.isFinite(value) || value < 0) {
+      throw new MedusaError(
+        MedusaError.Types.INVALID_DATA,
+        `${field} must be a non-negative number, or null to clear it`
+      )
+    }
+    return value
+  }
+
+  const producedCorrection = readQuantityCorrection("produced_quantity")
+  const rejectedCorrection = readQuantityCorrection("rejected_quantity")
+
+  if (producedCorrection !== undefined) update.produced_quantity = producedCorrection
+  if (rejectedCorrection !== undefined) update.rejected_quantity = rejectedCorrection
+
   if (Object.keys(update).length === 0) {
     return res.json({ production_run: run, message: "No changes" })
   }
 
   await productionRunService.updateProductionRuns({ id, ...update })
   const updated = await productionRunService.retrieveProductionRun(id)
+
+  // Audit the output correction. Best-effort: the correction itself is already
+  // persisted and must not be rolled back because the timeline write failed.
+  if (producedCorrection !== undefined || rejectedCorrection !== undefined) {
+    const changes: string[] = []
+    if (producedCorrection !== undefined) {
+      changes.push(`produced ${run.produced_quantity ?? "—"} → ${producedCorrection ?? "—"}`)
+    }
+    if (rejectedCorrection !== undefined) {
+      changes.push(`rejected ${run.rejected_quantity ?? "—"} → ${rejectedCorrection ?? "—"}`)
+    }
+    const reason =
+      typeof body.correction_reason === "string" && body.correction_reason.trim()
+        ? body.correction_reason.trim()
+        : null
+
+    try {
+      await productionRunService.createProductionRunActivities({
+        production_run_id: id,
+        activity_type: "note",
+        kind: "output_corrected",
+        actor_type: "admin",
+        actor_id: (req as any).auth_context?.actor_id ?? null,
+        partner_id: run.partner_id ?? null,
+        channel: null,
+        message_id: null,
+        template_name: null,
+        recipient: null,
+        summary: `Admin corrected reported output: ${changes.join(", ")}`,
+        payload: {
+          reason,
+          quantity: run.quantity ?? null,
+          previous: {
+            produced_quantity: run.produced_quantity ?? null,
+            rejected_quantity: run.rejected_quantity ?? null,
+          },
+          corrected: {
+            produced_quantity:
+              producedCorrection !== undefined
+                ? producedCorrection
+                : run.produced_quantity ?? null,
+            rejected_quantity:
+              rejectedCorrection !== undefined
+                ? rejectedCorrection
+                : run.rejected_quantity ?? null,
+          },
+        },
+        occurred_at: new Date(),
+      } as any)
+    } catch (e: any) {
+      req.scope
+        .resolve(ContainerRegistrationKeys.LOGGER)
+        .error(
+          `[admin.production-runs] output correction saved but activity write failed for run=${id}: ${e?.message}`
+        )
+    }
+  }
 
   res.json({ production_run: updated })
 }


### PR DESCRIPTION
Partners self-report `produced_quantity` / `rejected_quantity` when completing a run (`POST /partners/production-runs/:id/complete`), and they do over-report. **`prod_run_01KYPM4G…` was recorded as 9 produced when only 3 were made**, and there was no way to correct it: the admin update route accepted `quantity`/`role`/`run_type` and the cost fields only.

That number is not cosmetic — it feeds cost-per-unit (`cost-summary`), the design cost engine, goods-transfer quantities (`transferQuantity`), and the public production story.

## What changed

`POST /admin/production-runs/:id` now accepts `produced_quantity`, `rejected_quantity`, and an optional `correction_reason`.

- Unlike the structural fields, these are editable **precisely because the run is completed** — correcting after the fact is the point.
- Values must be finite and non-negative; `null` clears a field back to "not reported".
- The ordered `quantity` is a separate fact and is left untouched.
- Each correction writes an append-only **`output_corrected`** activity with the actor, the reason, and before/after values, so the timeline shows what changed instead of the number silently diverging from what the partner sent. The activity write is best-effort — the correction is already persisted and must not be rolled back because the timeline write failed.

The `update_production_run` MCP tool carries the same fields, so the admin assistant can do this from chat behind its `confirm:true` approval card (#1238).

## Heads-up: this does not fix the payout

`cost-summary` computes the partner total as `partner_cost_estimate × quantity` — the **ordered** quantity, not what was produced. So for this run it still bills 9 × ₹1200, even after the correction to 3. That may well be deliberate (a partner may be owed for the order, not the output), which is why it is **not** changed here — but it should be an explicit decision rather than an accident. Say the word and I'll open an issue.

## Verify

```
pnpm test:integration:http:shared ./integration-tests/http/production-run-complete-yield.spec.ts
# 9/9 — includes the new correction case (9 → 3, quantity survives, activity written)
# and rejection of a negative value

TEST_TYPE=unit npx jest --testPathPattern="mcp"    # 116/116
```
`tsc` sits at the 79-error baseline.

## Follow-up

Once deployed, `prod_run_01KYPM4G2S85PX61HT25T8BFDT` gets corrected to 3 produced with a reason recorded.

🤖 Generated with [Claude Code](https://claude.com/claude-code)