### PR TITLE
feat(admin-assistant): context compaction, message queueing, scroll control (#1238)

### DIFF
--- a/apps/backend/integration-tests/http/admin-assistant-summarize-api.spec.ts
+++ b/apps/backend/integration-tests/http/admin-assistant-summarize-api.spec.ts
@@ -1,0 +1,54 @@
+import { getSharedTestEnv, setupSharedTestSuite } from "./shared-test-setup"
+import { createAdminUser, getAuthHeaders } from "../helpers/create-admin-user"
+
+jest.setTimeout(90 * 1000)
+
+/**
+ * Contract tests for POST /admin/assistant/summarize (#1238) — the admin twin of
+ * the partner assistant's context compaction.
+ *
+ * Deliberately covers only auth and validation: a body that passes validation
+ * calls a live model, which would make this suite slow, flaky and billable. The
+ * summary text itself is not something an assertion can meaningfully pin.
+ */
+setupSharedTestSuite(() => {
+  describe("Admin assistant — summarize (context compaction)", () => {
+    const { api, getContainer } = getSharedTestEnv()
+
+    beforeEach(async () => {
+      await createAdminUser(getContainer())
+    })
+
+    it("requires admin authentication", async () => {
+      const res = await api
+        .post("/admin/assistant/summarize", {
+          messages: [
+            { role: "user", parts: [{ type: "text", text: "hello" }] },
+            { role: "assistant", parts: [{ type: "text", text: "hi" }] },
+          ],
+        })
+        .catch((e: any) => e.response)
+      expect([401, 403]).toContain(res.status)
+    })
+
+    it("rejects a thread too short to be worth compacting", async () => {
+      const headers = await getAuthHeaders(api)
+      const res = await api
+        .post(
+          "/admin/assistant/summarize",
+          { messages: [{ role: "user", parts: [{ type: "text", text: "only one" }] }] },
+          headers
+        )
+        .catch((e: any) => e.response)
+      expect(res.status).toBe(400)
+    })
+
+    it("rejects a body with no messages at all", async () => {
+      const headers = await getAuthHeaders(api)
+      const res = await api
+        .post("/admin/assistant/summarize", {}, headers)
+        .catch((e: any) => e.response)
+      expect(res.status).toBe(400)
+    })
+  })
+})

--- a/apps/backend/src/admin/routes/assistant/page.tsx
+++ b/apps/backend/src/admin/routes/assistant/page.tsx
@@ -335,6 +335,101 @@ function toStored(messages: any[]): StoredMessage[] {
   return messages.map((m) => ({ id: m.id, role: m.role, parts: m.parts }))
 }
 
+/**
+ * Rough context budget the thread tries to stay under (#1238). Admin threads
+ * carry every tool call's input AND its JSON result, so they reach the ceiling
+ * markedly faster than the same number of partner turns — we warn at 20k
+ * estimated tokens to leave headroom for the next tool's output.
+ *
+ * Deliberately an estimate, not a count: the provider's real usage figure only
+ * arrives after a request, and the point is to warn BEFORE sending one.
+ */
+const CONTEXT_WARN_TOKENS = 20000
+
+/** Rough token estimate (~4 chars/token) across a thread, tool payloads included. */
+function estimateTokens(messages: any[]): number {
+  let chars = 0
+  for (const m of messages) {
+    for (const p of m.parts ?? []) {
+      if (p?.type === "text" && typeof p.text === "string") chars += p.text.length
+      else if (p?.type === "reasoning" && typeof p.text === "string") chars += p.text.length
+      else if (p?.toolName) {
+        try {
+          if (p.input) chars += JSON.stringify(p.input).length
+          if (p.output) chars += JSON.stringify(p.output).length
+        } catch {
+          /* a non-serialisable payload just doesn't count toward the estimate */
+        }
+      }
+    }
+  }
+  return Math.ceil(chars / 4)
+}
+
+/**
+ * Turn whatever `useChat` surfaced into something an operator can act on.
+ *
+ * A single "the assistant hit an error" line is useless when the real cause is
+ * an expired admin session or one failing tool — the operator retries forever
+ * against a problem retrying cannot fix. Transport/auth faults are separated
+ * from model faults so the message can say what to actually do.
+ */
+function describeChatError(error: unknown): { title: string; detail?: string; retryable: boolean } {
+  const raw = (error as any)?.message ? String((error as any).message) : ""
+
+  if (/\b401\b|unauthor/i.test(raw)) {
+    return {
+      title: "Your admin session expired.",
+      detail: "Reload the page to sign in again — retrying won't help until you do.",
+      retryable: false,
+    }
+  }
+  if (/\b503\b|not configured/i.test(raw)) {
+    return {
+      title: "The admin assistant isn't configured.",
+      detail:
+        "Add a platform with role ai_admin_assistant under Settings → External Platforms, or set OPENROUTER_API_KEY.",
+      retryable: false,
+    }
+  }
+  if (/\b429\b|rate limit/i.test(raw)) {
+    return {
+      title: "The model is rate-limited.",
+      detail: "Wait a moment before retrying.",
+      retryable: true,
+    }
+  }
+  if (/failed to fetch|network|ECONN/i.test(raw)) {
+    return {
+      title: "Couldn't reach the server.",
+      detail: "Check your connection, then retry.",
+      retryable: true,
+    }
+  }
+  return {
+    title: "The assistant hit an error.",
+    detail: raw || undefined,
+    retryable: true,
+  }
+}
+
+/** Tool calls that came back as errors, so the UI can name them. */
+function failedToolNames(messages: any[]): string[] {
+  const names = new Set<string>()
+  for (const m of messages) {
+    for (const p of m.parts ?? []) {
+      if (!p?.toolName) continue
+      const out: any = p.output
+      const errored =
+        p.state === "output-error" ||
+        p.errorText ||
+        (out && typeof out === "object" && (out.error || out.ok === false))
+      if (errored) names.add(String(p.toolName))
+    }
+  }
+  return [...names]
+}
+
 const AssistantChat = ({
   conversationId,
   initialMessages,
@@ -361,9 +456,15 @@ const AssistantChat = ({
     []
   )
 
-  const { messages, sendMessage, status, error, stop, regenerate, clearError } =
+  const { messages, setMessages, sendMessage, status, error, stop, regenerate, clearError } =
     useChat({ transport, messages: initialMessages as any })
   const streaming = status === "submitted" || status === "streaming"
+
+  const [autoScroll, setAutoScroll] = useState(true)
+  const [queued, setQueued] = useState<string[]>([])
+  const [compacting, setCompacting] = useState(false)
+  const tokenEstimate = useMemo(() => estimateTokens(messages as any[]), [messages])
+  const overBudget = tokenEstimate >= CONTEXT_WARN_TOKENS
 
   const retry = () => {
     clearError?.()
@@ -374,9 +475,25 @@ const AssistantChat = ({
     }
   }
 
+  /**
+   * Follow the stream only while the operator is actually at the bottom.
+   *
+   * Auto-scroll used to be unconditional, so reading back through a long tool
+   * result mid-answer yanked you to the end on every token. Scrolling away now
+   * releases the thread; returning to the bottom re-attaches it, and the toggle
+   * turns the whole behaviour off.
+   */
+  const handleScroll = useCallback(() => {
+    const el = scrollRef.current
+    if (!el) return
+    const atBottom = el.scrollHeight - el.scrollTop - el.clientHeight < 48
+    setAutoScroll(atBottom)
+  }, [])
+
   useEffect(() => {
-    if (scrollRef.current) scrollRef.current.scrollTop = scrollRef.current.scrollHeight
-  }, [messages, status])
+    if (!autoScroll || !scrollRef.current) return
+    scrollRef.current.scrollTop = scrollRef.current.scrollHeight
+  }, [messages, status, autoScroll])
 
   // Persist the thread after each completed turn: create-on-first-turn, then
   // patch. A ref-guarded snapshot avoids redundant writes and re-entrancy.
@@ -415,16 +532,68 @@ const AssistantChat = ({
     void run()
   }, [status, messages, onCreated])
 
+  /**
+   * Queue instead of dropping. Typing a follow-up while the model is working
+   * used to be silently discarded (`if (streaming) return`), which reads as the
+   * UI ignoring you. Queued messages send in order as each turn finishes.
+   */
   const submit = (text: string) => {
     const t = text.trim()
-    if (!t || streaming) return
+    if (!t) return
     setInput("")
+    if (streaming) {
+      setQueued((q) => [...q, t])
+      return
+    }
     sendMessage({ text: t })
   }
 
+  useEffect(() => {
+    if (status !== "ready" || queued.length === 0 || error) return
+    const [next, ...rest] = queued
+    setQueued(rest)
+    sendMessage({ text: next })
+  }, [status, queued, error, sendMessage])
+
+  /**
+   * Context compaction: roll the older turns into a summary so a long thread can
+   * continue instead of silently losing its head. Mirrors the partner assistant,
+   * against POST /admin/assistant/summarize.
+   */
+  const compact = useCallback(async () => {
+    if (compacting || messages.length < 2) return
+    setCompacting(true)
+    try {
+      const { summary } = await apiFetch<{ summary: string }>(
+        `${API_BASE_URL.replace(/\/$/, "")}/admin/assistant/summarize`,
+        { method: "POST", body: JSON.stringify({ messages: toStored(messages as any[]) }) }
+      )
+      // Keep the last exchange verbatim — the operator is usually mid-thought in
+      // it — and replace everything older with the summary.
+      const tail = (messages as any[]).slice(-2)
+      setMessages([
+        {
+          id: `summary-${Date.now()}`,
+          role: "assistant",
+          parts: [{ type: "text", text: `**Summary so far**\n\n${summary}` }],
+        } as any,
+        ...tail,
+      ])
+      toast.success("Chat compacted — older messages were summarized.")
+    } catch (e: any) {
+      toast.error(e?.message || "Could not compact the chat. Try starting a new chat instead.")
+    } finally {
+      setCompacting(false)
+    }
+  }, [compacting, messages, setMessages])
+
   return (
     <div className="flex h-full min-h-0 flex-1 flex-col overflow-hidden">
-      <div ref={scrollRef} className="flex-1 space-y-4 overflow-y-auto px-6 py-4">
+      <div
+        ref={scrollRef}
+        onScroll={handleScroll}
+        className="flex-1 space-y-4 overflow-y-auto px-6 py-4"
+      >
         {messages.length === 0 ? (
           <div className="flex flex-col gap-2">
             <Text size="small" className="text-ui-fg-muted">
@@ -487,20 +656,68 @@ const AssistantChat = ({
         ) : null}
 
         {error ? (
-          <div className="text-ui-fg-error flex items-center gap-2">
-            <ExclamationCircle />
-            <Text size="small">The assistant hit an error.</Text>
-            <Button size="small" variant="secondary" onClick={retry}>
-              <ArrowPathMini /> Retry
-            </Button>
-          </div>
+          (() => {
+            const described = describeChatError(error)
+            const failed = failedToolNames(messages as any[])
+            return (
+              <div className="text-ui-fg-error flex flex-col gap-1">
+                <div className="flex items-center gap-2">
+                  <ExclamationCircle />
+                  <Text size="small">{described.title}</Text>
+                  {described.retryable ? (
+                    <Button size="small" variant="secondary" onClick={retry}>
+                      <ArrowPathMini /> Retry
+                    </Button>
+                  ) : null}
+                </div>
+                {described.detail ? (
+                  <Text size="xsmall" className="text-ui-fg-subtle pl-6">
+                    {described.detail}
+                  </Text>
+                ) : null}
+                {failed.length ? (
+                  <Text size="xsmall" className="text-ui-fg-subtle pl-6">
+                    Failed {failed.length === 1 ? "tool" : "tools"}: {failed.join(", ")}
+                  </Text>
+                ) : null}
+              </div>
+            )
+          })()
         ) : null}
       </div>
 
       <div className="border-ui-border-base border-t px-6 py-4">
+        {overBudget ? (
+          <div className="border-ui-border-base bg-ui-bg-subtle mb-3 flex items-center gap-2 rounded-md border px-3 py-2">
+            <Text size="xsmall" className="text-ui-fg-subtle flex-1">
+              This chat is getting long (~{tokenEstimate.toLocaleString()} tokens) and the
+              assistant may start losing earlier context.
+            </Text>
+            <Button size="small" variant="secondary" isLoading={compacting} onClick={compact}>
+              Compact summary
+            </Button>
+          </div>
+        ) : null}
+        {queued.length ? (
+          <div className="mb-2 flex flex-wrap items-center gap-1">
+            <Text size="xsmall" className="text-ui-fg-muted">
+              Queued:
+            </Text>
+            {queued.map((q, i) => (
+              <Badge key={`${q}-${i}`} size="2xsmall" className="max-w-[240px] truncate">
+                {q}
+              </Badge>
+            ))}
+            <Button size="small" variant="transparent" onClick={() => setQueued([])}>
+              Clear
+            </Button>
+          </div>
+        ) : null}
         <div className="flex items-end gap-2">
           <Textarea
-            placeholder="Ask the admin assistant…"
+            placeholder={
+              streaming ? "Type to queue the next message…" : "Ask the admin assistant…"
+            }
             value={input}
             onChange={(e) => setInput(e.target.value)}
             onKeyDown={(e) => {
@@ -516,15 +733,32 @@ const AssistantChat = ({
             <Button variant="secondary" onClick={() => stop()}>
               Stop
             </Button>
-          ) : (
-            <IconButton
-              variant="primary"
-              disabled={!input.trim()}
-              onClick={() => submit(input)}
-            >
-              <ArrowUpMini />
-            </IconButton>
-          )}
+          ) : null}
+          <IconButton
+            variant="primary"
+            disabled={!input.trim()}
+            onClick={() => submit(input)}
+          >
+            <ArrowUpMini />
+          </IconButton>
+        </div>
+        <div className="mt-2 flex items-center justify-between">
+          <Text size="xsmall" className="text-ui-fg-muted">
+            ~{tokenEstimate.toLocaleString()} tokens
+          </Text>
+          <Button
+            size="small"
+            variant="transparent"
+            onClick={() => {
+              const next = !autoScroll
+              setAutoScroll(next)
+              if (next && scrollRef.current) {
+                scrollRef.current.scrollTop = scrollRef.current.scrollHeight
+              }
+            }}
+          >
+            {autoScroll ? "Following" : "Not following"}
+          </Button>
         </div>
       </div>
     </div>

--- a/apps/backend/src/api/admin/assistant/summarize/route.ts
+++ b/apps/backend/src/api/admin/assistant/summarize/route.ts
@@ -1,0 +1,114 @@
+/**
+ * POST /admin/assistant/summarize
+ *
+ * Context-compaction for the admin assistant (#1238), mirroring
+ * `/partners/assistant/summarize`. As a thread grows it approaches the model's
+ * context window; rather than silently truncating — which the operator
+ * experiences as the assistant "forgetting" what it just did — the client asks
+ * this endpoint to roll the older turns into a short summary, stores the
+ * trimmed thread, and the next /chat request stays within budget.
+ *
+ * Admin threads hit the ceiling sooner than partner ones because every tool
+ * call carries its request and its JSON result, so the summary prompt is
+ * explicitly told to preserve what was *done* (and to which ids) rather than
+ * what was said.
+ *
+ * Non-streaming `generateText` is right here: the result is short and the call
+ * is infrequent. Retries once so a transient model error does not block
+ * compaction.
+ */
+import { AuthenticatedMedusaRequest, MedusaResponse } from "@medusajs/framework/http"
+import { ContainerRegistrationKeys } from "@medusajs/framework/utils"
+import { convertToModelMessages, generateText } from "ai"
+
+import { resolveRoleTextModel, logAiUsage } from "../../../../mastra/services/ai-platforms"
+import { foldSystemForProvider } from "../../../store/ai/chat/system-fold-lib"
+import type { AdminAssistantSummarizeReq } from "./validators"
+
+const FEATURE = "admin/assistant/summarize"
+const ROLE = "ai_admin_assistant"
+
+const SUMMARIZE_SYSTEM = `You are condensing an admin-console assistant conversation so it can continue within a limited context window. Write a tight "Summary so far" the assistant can read instead of the earlier messages.
+
+Rules:
+- Preserve what was DONE over what was said: tool calls made, the ids they touched (order/run/location/partner ids), and their outcome. An id the operator is mid-way through working on must survive compaction verbatim.
+- Capture decisions taken, facts established about the platform's state, any action the operator approved or declined, and open follow-ups.
+- Do NOT restate the whole conversation. Aim for 4-8 short bullet lines.
+- Do NOT invent details. If something is uncertain, say "unclear".
+- Write in the second person to the assistant ("The operator ...", "You already ..."). End with a one-line "Continue by:" hint.`
+
+export const POST = async (
+  req: AuthenticatedMedusaRequest,
+  res: MedusaResponse
+) => {
+  const logger: any = req.scope.resolve(ContainerRegistrationKeys.LOGGER)
+  const body = (req as any).validatedBody as AdminAssistantSummarizeReq
+
+  const resolved = await resolveRoleTextModel(req.scope as any, ROLE)
+  if (resolved.source === "free" && !process.env.OPENROUTER_API_KEY) {
+    res.status(503).json({
+      error:
+        "The admin assistant is not configured. Add a platform with role ai_admin_assistant in Settings → External Platforms, or set OPENROUTER_API_KEY.",
+    })
+    return
+  }
+
+  // Keep only text parts — tool and reasoning parts would inflate the input
+  // tokens for nothing, and what those calls achieved is already narrated in
+  // the assistant's own text.
+  const messages = body.messages.map((m: any) => {
+    const parts = Array.isArray(m.parts) ? m.parts : null
+    const textParts = parts
+      ? parts
+          .filter(
+            (p: any) =>
+              p?.type === "text" && typeof p.text === "string" && p.text.length > 0
+          )
+          .map((p: any) => ({ type: "text", text: p.text }))
+      : [{ type: "text", text: String(m.content ?? "") }]
+    return { role: m.role, parts: textParts.length ? textParts : [{ type: "text", text: "" }] }
+  })
+
+  const folded = foldSystemForProvider(resolved.providerType, SUMMARIZE_SYSTEM, messages)
+  const startedAt = Date.now()
+  const usageBase = {
+    feature: FEATURE,
+    role: ROLE,
+    provider: resolved.providerType,
+    source: resolved.source,
+    platformId: resolved.platformId,
+    model: resolved.modelId,
+  } as const
+
+  const MAX_ATTEMPTS = 2
+  for (let attempt = 1; attempt <= MAX_ATTEMPTS; attempt++) {
+    try {
+      const { text } = await generateText({
+        model: resolved.model,
+        ...(folded.system ? { system: folded.system } : {}),
+        messages: convertToModelMessages(folded.messages as any),
+        temperature: 0.2,
+        maxRetries: 3,
+      })
+      logAiUsage(logger, { ...usageBase, ok: true, ms: Date.now() - startedAt })
+      res.status(200).json({ summary: text.trim() })
+      return
+    } catch (e: any) {
+      logAiUsage(logger, {
+        ...usageBase,
+        ok: false,
+        ms: Date.now() - startedAt,
+        error: e,
+      })
+      if (attempt < MAX_ATTEMPTS) {
+        await new Promise((r) => setTimeout(r, 400 * attempt))
+        continue
+      }
+      res.status(502).json({
+        error:
+          "Could not summarize the conversation. Please try again or start a new chat.",
+      })
+      return
+    }
+  }
+}

--- a/apps/backend/src/api/admin/assistant/summarize/validators.ts
+++ b/apps/backend/src/api/admin/assistant/summarize/validators.ts
@@ -1,0 +1,27 @@
+/**
+ * POST /admin/assistant/summarize
+ *
+ * Validator for the admin assistant's context-compaction endpoint. The twin of
+ * `partners/assistant/summarize/validators` — the client sends the current
+ * message history once its token estimate crosses the warn threshold, and gets
+ * back a short summary it stores in place of the older turns.
+ */
+import { z } from "zod"
+
+const UiMessageSchema = z
+  .object({
+    role: z.enum(["system", "user", "assistant"]),
+    content: z.string().optional(),
+    parts: z
+      .array(z.object({ type: z.string(), text: z.string().optional() }).passthrough())
+      .optional(),
+  })
+  .passthrough()
+
+export const AdminAssistantSummarizeSchema = z.object({
+  messages: z.array(UiMessageSchema).min(2).max(200),
+})
+
+export type AdminAssistantSummarizeReq = z.infer<
+  typeof AdminAssistantSummarizeSchema
+>

--- a/apps/backend/src/api/middlewares.ts
+++ b/apps/backend/src/api/middlewares.ts
@@ -242,6 +242,7 @@ import { AdminAiChatResolveReq, AdminAiChatResolveQuery } from "./admin/ai/chat/
 import { ListConversationsQuerySchema, ListMessagesQuerySchema, SendMessageSchema, CreateConversationSchema } from "./admin/messaging/validators";
 import { AdminAiChatReq } from "./admin/ai/chat/chat/validators";
 import { AdminAssistantChatSchema } from "./admin/assistant/chat/validators";
+import { AdminAssistantSummarizeSchema } from "./admin/assistant/summarize/validators";
 import { AdminPostDesignTaskAssignReq } from "./admin/designs/[id]/tasks/[taskId]/assign/validators";
 import { AdminPostPartnerTaskAssignReq } from "./admin/partners/[id]/tasks/[taskId]/assign/validators";
 import { AdminCreatePartnerTaskReq, AdminUpdatePartnerTaskReq } from "./admin/partners/[id]/tasks/validators";
@@ -3470,6 +3471,16 @@ export default defineMiddlewares({
       matcher: "/admin/assistant/chat",
       method: "POST",
       middlewares: [validateAndTransformBody(wrapSchema(AdminAssistantChatSchema))],
+    },
+    // Admin assistant context compaction — the client calls this when the thread
+    // approaches the model's context window; the route returns a short summary
+    // the client stores in place of the older turns.
+    {
+      matcher: "/admin/assistant/summarize",
+      method: "POST",
+      middlewares: [
+        validateAndTransformBody(wrapSchema(AdminAssistantSummarizeSchema)),
+      ],
     },
 
     {


### PR DESCRIPTION
Part B of #1238 — brings the admin assistant's chat surface up to the partner Assistant, and past it where admin threads genuinely differ.

**Already present and untouched:** stop button, `error`/`clearError`/`regenerate`, conversation create/delete, MCP approval cards. Nothing was rebuilt.

## Context / token accounting

Admin threads carry every tool call's input *and* its JSON result, so they reach the model's context ceiling markedly faster than the same number of partner turns — and did so silently, which the operator experiences as the assistant forgetting what it just did.

- Running token estimate in the composer footer.
- Past 20k, a banner offers **Compact summary**, backed by a new `POST /admin/assistant/summarize` (twin of `/partners/assistant/summarize`).
- The summary prompt is explicitly told to preserve **what was done and the ids it touched** — an id the operator is mid-way through working on has to survive compaction verbatim. The last exchange is kept as-is.

## Message queueing

Typing a follow-up while the model worked was silently discarded (`if (streaming) return`), which reads as the UI ignoring you. Messages now queue, show as chips with a Clear action, and send in order as each turn finishes.

## Scroll control

Auto-scroll was unconditional (`scrollTop = scrollHeight` on every message change), so scrolling up to read a long tool result mid-answer yanked you back on every token. Now: scrolling away releases the thread, returning to the bottom re-attaches it, and a **Following** toggle turns it off outright.

## Error handling

One generic "the assistant hit an error" becomes a diagnosis — expired session and missing configuration (both unfixable by retrying, so the Retry button is hidden) separated from rate limits and network faults, plus any tool that came back with an error is named.

## Not included

**File upload.** It reads as a parity item but isn't: the partner UI *deliberately* refuses it with a disabled attachment button, while `initiate_media_upload` / `complete_media_upload` already exist in the registry for the model to call. So the backend half largely exists, the composer half doesn't, and the scope (images only vs any file, size caps, whether the file reaches the model or just storage) is a product decision. Tracked in #1238.

## Verify

```
pnpm test:integration:http:shared ./integration-tests/http/admin-assistant-summarize-api.spec.ts     # 3/3
pnpm test:integration:http:shared ./integration-tests/http/admin-assistant-conversations-api.spec.ts # 8/8
```
`tsc` at the 79-error baseline. The new spec covers auth and validation only — a valid body calls a live model, which would make the suite slow, flaky and billable.

🤖 Generated with [Claude Code](https://claude.com/claude-code)