### PR TITLE
fix(delhivery): declare the shipment's value and book the pickup from admin

### DIFF
--- a/apps/backend/src/admin/widgets/order-carrier-shipment.tsx
+++ b/apps/backend/src/admin/widgets/order-carrier-shipment.tsx
@@ -73,15 +73,25 @@ const FIELDS = [
 ].join(",")
 
 /** The AWB already on the order, if any — the state where actions are done. */
+/** Tomorrow, as YYYY-MM-DD — the earliest slot a packer can realistically make. */
+function defaultPickupDate(): string {
+  const d = new Date()
+  d.setDate(d.getDate() + 1)
+  return d.toISOString().slice(0, 10)
+}
+
 function existingAwbOf(fulfillments: Fulfillment[]): {
   awb?: string
   carrier?: string
+  fulfillmentId?: string
 } {
   for (const f of fulfillments) {
     const d = f.data || {}
     const awb =
       d.waybill || d.tracking_number || f.labels?.[0]?.tracking_number || undefined
-    if (awb) return { awb: String(awb), carrier: d.carrier || undefined }
+    if (awb) {
+      return { awb: String(awb), carrier: d.carrier || undefined, fulfillmentId: f.id }
+    }
   }
   return {}
 }
@@ -126,6 +136,48 @@ const OrderCarrierShipmentWidget = ({
   const [carrierChoice, setCarrierChoice] = useState<string | undefined>(undefined)
   const carrier = resolveSelectableCarrier(carrierChoice, destinationCountry)
   const isShiprocket = carrier === "shiprocket"
+
+  // Pickup booking. Separate from label creation on purpose: a waybill can be
+  // made the night before, but a pickup slot is a real-world commitment for a
+  // date, a package count and a warehouse.
+  const [pickupDate, setPickupDate] = useState(defaultPickupDate())
+  const [pickupTime, setPickupTime] = useState("14:00")
+  const [packageCount, setPackageCount] = useState("1")
+  const [schedulingPickup, setSchedulingPickup] = useState(false)
+  const [pickup, setPickup] = useState<
+    { pickup_id?: string; pickup_date: string; pickup_time: string } | null
+  >(null)
+
+  const schedulePickup = async (fulfillmentId: string) => {
+    if (!pickupDate || !pickupTime) {
+      toast.error("Pick a date and a time first")
+      return
+    }
+    setSchedulingPickup(true)
+    try {
+      const res = await sdk.client.fetch<{ pickup_id?: string }>(
+        `/admin/orders/${order.id}/fulfillments/${fulfillmentId}/pickup`,
+        {
+          method: "POST",
+          body: {
+            pickup_date: pickupDate,
+            pickup_time: pickupTime,
+            expected_package_count: Number(packageCount) || 1,
+          },
+        }
+      )
+      setPickup({
+        pickup_id: res?.pickup_id,
+        pickup_date: pickupDate,
+        pickup_time: pickupTime,
+      })
+      toast.success("Pickup scheduled")
+    } catch (e: any) {
+      toast.error(e?.message || "Could not schedule the pickup")
+    } finally {
+      setSchedulingPickup(false)
+    }
+  }
 
   // Parcel. Blank means "let the backend default it", which is how retail labels
   // used to ship at 500 g regardless of the box.
@@ -211,9 +263,11 @@ const OrderCarrierShipmentWidget = ({
     )
   }
 
-  // Already labelled — the tracking widget below owns that state in full.
-  // Render a one-line acknowledgement rather than a second set of controls that
-  // would only re-ship an order that is already moving.
+  // Already labelled — the tracking widget below owns that state in full, so
+  // this stays an acknowledgement rather than a second set of shipping controls.
+  // The one thing that DOES still need doing is booking the pickup: a waybill
+  // only tells the carrier a parcel exists, not to come and collect it. Order #83
+  // sat two days waiting for a pickup booked by hand on Delhivery's dashboard.
   if (existing.awb) {
     return (
       <Container className="divide-y p-0">
@@ -226,6 +280,72 @@ const OrderCarrierShipmentWidget = ({
             {carrierLabel(existing.carrier)} · {existing.awb}
           </Badge>
         </div>
+
+        {existing.fulfillmentId ? (
+          <div className="flex flex-col gap-y-3 px-6 py-4">
+            <Text size="small" className="text-ui-fg-subtle">
+              {pickup
+                ? `Pickup booked for ${pickup.pickup_date} at ${pickup.pickup_time}${
+                    pickup.pickup_id ? ` (#${pickup.pickup_id})` : ""
+                  }.`
+                : "The label exists, but the carrier won't collect until a pickup is booked."}
+            </Text>
+            {!pickup ? (
+              <>
+                <div className="grid grid-cols-3 gap-3">
+                  <div className="flex flex-col gap-y-1">
+                    <Label size="small" htmlFor="pickup_date">
+                      Pickup date
+                    </Label>
+                    <Input
+                      id="pickup_date"
+                      type="date"
+                      value={pickupDate}
+                      onChange={(e) => setPickupDate(e.target.value)}
+                    />
+                  </div>
+                  <div className="flex flex-col gap-y-1">
+                    <Label size="small" htmlFor="pickup_time">
+                      Time
+                    </Label>
+                    <Input
+                      id="pickup_time"
+                      type="time"
+                      value={pickupTime}
+                      onChange={(e) => setPickupTime(e.target.value)}
+                    />
+                  </div>
+                  <div className="flex flex-col gap-y-1">
+                    <Label size="small" htmlFor="package_count">
+                      Packages
+                    </Label>
+                    <Input
+                      id="package_count"
+                      type="number"
+                      min={1}
+                      value={packageCount}
+                      onChange={(e) => setPackageCount(e.target.value)}
+                    />
+                  </div>
+                </div>
+                <div>
+                  <Button
+                    variant="secondary"
+                    size="small"
+                    isLoading={schedulingPickup}
+                    onClick={() => schedulePickup(existing.fulfillmentId!)}
+                  >
+                    Schedule pickup
+                  </Button>
+                  <Text size="xsmall" className="text-ui-fg-subtle mt-1">
+                    Books a real collection slot with {carrierLabel(existing.carrier)}.
+                    Only book it once the parcel is actually packed.
+                  </Text>
+                </div>
+              </>
+            ) : null}
+          </div>
+        ) : null}
       </Container>
     )
   }

--- a/apps/backend/src/api/admin/orders/[id]/fulfillments/[fulfillmentId]/pickup/route.ts
+++ b/apps/backend/src/api/admin/orders/[id]/fulfillments/[fulfillmentId]/pickup/route.ts
@@ -1,0 +1,114 @@
+/**
+ * POST /admin/orders/:id/fulfillments/:fulfillmentId/pickup
+ *
+ * Schedule the carrier pickup for a fulfillment. The admin twin of
+ * `/partners/orders/:id/fulfillments/:fulfillmentId/pickup`, which existed while
+ * the admin side had nothing — so an admin-created shipment sat waiting until
+ * someone booked the pickup by hand on the carrier's dashboard. Order #83's
+ * first real shipment was collected two days late for exactly this reason.
+ *
+ * Creating the waybill and scheduling the pickup are deliberately separate
+ * calls: a manifest can be created the evening before, while the pickup slot is
+ * a real-world commitment for a particular date, count and warehouse. Booking
+ * one automatically on every fulfillment would send couriers to locations that
+ * are not packed yet.
+ */
+import { MedusaRequest, MedusaResponse } from "@medusajs/framework/http"
+import { ContainerRegistrationKeys, MedusaError } from "@medusajs/framework/utils"
+
+import {
+  isSupportedCarrier,
+  resolveShippingProvider,
+  shipmentRefFromFulfillment,
+} from "../../../../../../../modules/shipping-providers/resolver"
+
+export const POST = async (req: MedusaRequest, res: MedusaResponse) => {
+  const query = req.scope.resolve(ContainerRegistrationKeys.QUERY)
+
+  const { data: orders } = await query.graph({
+    entity: "orders",
+    fields: ["id", "fulfillments.*", "fulfillments.labels.*"],
+    filters: { id: req.params.id },
+  })
+
+  const order = (orders as any)?.[0]
+  const fulfillment = order?.fulfillments?.find(
+    (f: any) => f.id === req.params.fulfillmentId
+  )
+
+  if (!fulfillment) {
+    throw new MedusaError(MedusaError.Types.NOT_FOUND, "Fulfillment not found")
+  }
+
+  const carrier = fulfillment.data?.carrier
+  if (!isSupportedCarrier(carrier)) {
+    throw new MedusaError(
+      MedusaError.Types.INVALID_DATA,
+      "Pickup scheduling is not available for this shipment's carrier"
+    )
+  }
+
+  const locationId = fulfillment.location_id
+  if (!locationId) {
+    throw new MedusaError(
+      MedusaError.Types.NOT_FOUND,
+      "No stock location associated with this fulfillment"
+    )
+  }
+
+  const { data: locations } = await query.graph({
+    entity: "stock_location",
+    fields: ["id", "metadata"],
+    filters: { id: locationId },
+  })
+
+  const location = (locations as any)?.[0]
+  const warehouseName =
+    location?.metadata?.delhivery_warehouse_name ||
+    fulfillment.data?.pickup_location_name
+
+  // Delhivery schedules per registered warehouse; aggregators (Shiprocket)
+  // schedule per shipment via the ref, so only Delhivery hard-requires a name.
+  if (carrier === "delhivery" && !warehouseName) {
+    throw new MedusaError(
+      MedusaError.Types.NOT_FOUND,
+      "No Delhivery warehouse registered for this location"
+    )
+  }
+
+  const body = (req.body || {}) as any
+  const pickupDate = body.pickup_date
+  const pickupTime = body.pickup_time
+
+  if (!pickupDate || !pickupTime) {
+    throw new MedusaError(
+      MedusaError.Types.INVALID_DATA,
+      "pickup_date and pickup_time are required"
+    )
+  }
+
+  const provider = await resolveShippingProvider(req.scope, carrier)
+  if (!provider.schedulePickup) {
+    throw new MedusaError(
+      MedusaError.Types.NOT_ALLOWED,
+      `Pickup scheduling is not supported by ${carrier}`
+    )
+  }
+
+  const result = await provider.schedulePickup({
+    pickup_location_name: warehouseName,
+    pickup_date: pickupDate,
+    pickup_time: pickupTime,
+    expected_package_count: body.expected_package_count || 1,
+    ref: shipmentRefFromFulfillment(fulfillment.data),
+  })
+
+  const raw = (result.raw as Record<string, any>) || {}
+  res.json({
+    pickup_id: raw.pickup_id,
+    pickup_date: pickupDate,
+    pickup_time: pickupTime,
+    incoming_center_name: raw.incoming_center_name,
+    ...raw,
+  })
+}

--- a/apps/backend/src/modules/shipping-providers/delhivery/__tests__/declared-value.unit.spec.ts
+++ b/apps/backend/src/modules/shipping-providers/delhivery/__tests__/declared-value.unit.spec.ts
@@ -1,0 +1,80 @@
+import { declaredValueForShipment } from "../declared-value"
+
+/**
+ * Order #83 shipped prepaid and showed as a ₹0 order on the Delhivery dashboard
+ * because no declared value was ever sent. 0 is the one value that is certainly
+ * wrong, so the fallbacks below matter as much as the happy path.
+ */
+describe("declaredValueForShipment", () => {
+  const orderItems = (rows: any[]) =>
+    new Map(rows.map((r) => [r.id, r]))
+
+  it("sums the line totals of the items actually in the box", () => {
+    const value = declaredValueForShipment({
+      items: [
+        { line_item_id: "li_1", quantity: 1 },
+        { line_item_id: "li_2", quantity: 2 },
+      ],
+      orderItemById: orderItems([
+        { id: "li_1", quantity: 1, total: 1200 },
+        { id: "li_2", quantity: 2, total: 900 },
+      ]),
+    })
+    expect(value).toBe(2100)
+  })
+
+  it("declares only this shipment's share of a partially fulfilled line", () => {
+    // 4 ordered at 2000 total; only 1 is shipping.
+    const value = declaredValueForShipment({
+      items: [{ line_item_id: "li_1", quantity: 1 }],
+      orderItemById: orderItems([{ id: "li_1", quantity: 4, total: 2000 }]),
+    })
+    expect(value).toBe(500)
+  })
+
+  it("falls back to unit_price when the line carries no total", () => {
+    const value = declaredValueForShipment({
+      items: [{ line_item_id: "li_1", quantity: 3 }],
+      orderItemById: orderItems([{ id: "li_1", quantity: 3, unit_price: 250 }]),
+    })
+    expect(value).toBe(750)
+  })
+
+  it("reads BigNumber-ish money objects", () => {
+    const value = declaredValueForShipment({
+      items: [{ line_item_id: "li_1", quantity: 1 }],
+      orderItemById: orderItems([
+        { id: "li_1", quantity: 1, total: { value: "1499.5" } },
+      ]),
+    })
+    expect(value).toBe(1499.5)
+  })
+
+  it("falls back to the order total when no line price resolves", () => {
+    const value = declaredValueForShipment({
+      items: [{ line_item_id: "li_missing", quantity: 1 }],
+      orderItemById: orderItems([]),
+      order: { item_total: 3300 },
+    })
+    expect(value).toBe(3300)
+  })
+
+  it("returns 0 rather than guessing when nothing is known", () => {
+    expect(
+      declaredValueForShipment({
+        items: [{ line_item_id: "li_1", quantity: 1 }],
+        orderItemById: orderItems([{ id: "li_1", quantity: 1 }]),
+        order: null,
+      })
+    ).toBe(0)
+  })
+
+  it("is unaffected by cod_amount concerns — a prepaid box still has value", () => {
+    // Regression guard for the actual defect: prepaid (cod 0) must not imply 0 value.
+    const value = declaredValueForShipment({
+      items: [{ line_item_id: "li_1", quantity: 1 }],
+      orderItemById: orderItems([{ id: "li_1", quantity: 1, total: 4999 }]),
+    })
+    expect(value).toBeGreaterThan(0)
+  })
+})

--- a/apps/backend/src/modules/shipping-providers/delhivery/client.ts
+++ b/apps/backend/src/modules/shipping-providers/delhivery/client.ts
@@ -404,6 +404,12 @@ export class DelhiveryClient {
     width?: number
     height?: number
     cod_amount?: number
+    /**
+     * Declared value of the goods. Distinct from `cod_amount` — a prepaid
+     * shipment collects nothing on delivery but still carries value, and
+     * omitting this is what made every manifest show as a ₹0 order.
+     */
+    total_amount?: number
     quantity?: number
     fragile_shipment?: boolean
     seller_gst_tin?: string
@@ -428,6 +434,7 @@ export class DelhiveryClient {
       products_desc: shipment.product_desc || "",
       weight: shipment.weight,
       cod_amount: shipment.cod_amount || 0,
+      total_amount: shipment.total_amount || 0,
       quantity: shipment.quantity || 1,
       seller_name: shipment.seller_name || "",
       seller_add: shipment.seller_address ? sanitizeAddress(shipment.seller_address) : "",

--- a/apps/backend/src/modules/shipping-providers/delhivery/declared-value.ts
+++ b/apps/backend/src/modules/shipping-providers/delhivery/declared-value.ts
@@ -1,0 +1,86 @@
+/**
+ * The declared value (`total_amount`) to send Delhivery for a shipment.
+ *
+ * We never sent one, so every manifest was created with a value of 0 — visible
+ * on the Delhivery dashboard as a ₹0 order (found on the first real prepaid
+ * shipment, order #83). That is not cosmetic: the declared value is what a
+ * damage/loss claim pays out against, and it is what appears on the shipping
+ * label and in reconciliation.
+ *
+ * Deliberately computed from the FULFILLMENT's items rather than the order
+ * total: a partial fulfillment must declare only what is actually in this box.
+ * `cod_amount` stays a separate concern — for a prepaid shipment it is 0 while
+ * the declared value is the goods' worth, and conflating the two is what makes
+ * a prepaid order look free.
+ *
+ * Kept dependency-free so it can be unit-tested without the fulfillment module.
+ */
+
+/** Medusa money fields can arrive as numbers, numeric strings, or BigNumber-ish objects. */
+function toAmount(value: unknown): number {
+  if (typeof value === "number") return Number.isFinite(value) ? value : 0
+  if (typeof value === "string") {
+    const n = Number(value)
+    return Number.isFinite(n) ? n : 0
+  }
+  if (value && typeof value === "object") {
+    const raw = (value as any).value ?? (value as any).numeric
+    if (raw !== undefined) return toAmount(raw)
+  }
+  return 0
+}
+
+export type DeclaredValueInput = {
+  /** The fulfillment's items (line_item_id + quantity). */
+  items: Array<{ line_item_id?: string; quantity?: number }>
+  /** Order line items keyed by id, carrying unit_price / totals. */
+  orderItemById: Map<string, any>
+  /** The order, used only as a last-resort fallback. */
+  order?: { total?: unknown; item_total?: unknown } | null
+}
+
+/**
+ * Value of the goods in this shipment, in major currency units.
+ *
+ * Falls back to the order total only when no line price can be resolved at all —
+ * an over-declaration on a partial shipment is still far better than declaring
+ * nothing, because 0 is the one value that is certainly wrong.
+ */
+export function declaredValueForShipment({
+  items,
+  orderItemById,
+  order,
+}: DeclaredValueInput): number {
+  let total = 0
+  let resolvedAny = false
+
+  for (const item of items || []) {
+    const qty = Number(item?.quantity) || 1
+    const orderItem = item?.line_item_id ? orderItemById.get(item.line_item_id) : undefined
+    if (!orderItem) continue
+
+    // Prefer the line's own total (it already accounts for quantity and
+    // discounts); fall back to unit price × the quantity actually shipped.
+    const lineTotal = toAmount(orderItem.total ?? orderItem.subtotal)
+    if (lineTotal > 0) {
+      const orderedQty = Number(orderItem.quantity) || qty
+      // A partial shipment carries its share of the line total.
+      total += orderedQty > 0 ? (lineTotal / orderedQty) * qty : lineTotal
+      resolvedAny = true
+      continue
+    }
+
+    const unitPrice = toAmount(orderItem.unit_price)
+    if (unitPrice > 0) {
+      total += unitPrice * qty
+      resolvedAny = true
+    }
+  }
+
+  if (!resolvedAny) {
+    const fallback = toAmount(order?.item_total) || toAmount(order?.total)
+    if (fallback > 0) return Math.round(fallback * 100) / 100
+  }
+
+  return Math.round(total * 100) / 100
+}

--- a/apps/backend/src/modules/shipping-providers/delhivery/service.ts
+++ b/apps/backend/src/modules/shipping-providers/delhivery/service.ts
@@ -10,6 +10,7 @@ import {
 } from "@medusajs/framework/types"
 import { DelhiveryClient, DelhiveryOptions } from "./client"
 import { delhiveryWarehouseNameForLocation } from "./warehouse-name"
+import { declaredValueForShipment } from "./declared-value"
 import { Logger } from "@medusajs/framework/types"
 
 type InjectedDeps = { logger: Logger }
@@ -281,6 +282,22 @@ class DelhiveryFulfillmentService extends AbstractFulfillmentProviderService {
         fromLocation.name ||
         "Default"
 
+      // Declared value of the goods. Never sent before, so every manifest showed
+      // as a ₹0 order on the Delhivery dashboard — including prepaid ones, where
+      // cod_amount is legitimately 0. This is what a loss/damage claim pays out
+      // against, so it has to reflect what is actually in the box.
+      const declaredValue = declaredValueForShipment({
+        items: items as any[],
+        orderItemById,
+        order: order as any,
+      })
+      if (!declaredValue) {
+        this.logger.warn(
+          `Delhivery: could not resolve a declared value for fulfillment ${fulfillment?.id} — ` +
+            `the manifest will show 0`
+        )
+      }
+
       // Detect payment mode from order payment status
       const paymentStatus = (order as any)?.payment_status
       const paymentMode: "Pre-paid" | "COD" =
@@ -304,6 +321,7 @@ class DelhiveryFulfillmentService extends AbstractFulfillmentProviderService {
         product_desc: productDesc,
         weight: totalWeight || 500,
         quantity: totalQuantity,
+        total_amount: declaredValue,
         length: maxLength || undefined,
         width: maxWidth || undefined,
         height: maxHeight || undefined,


### PR DESCRIPTION
Two defects surfaced by order #83's first real Delhivery shipment — the one the warehouse fix (#1234) finally let through.

## 1. Every manifest was created with a value of ₹0

We never sent `total_amount` at all. Only `cod_amount` was set, and on a prepaid order that is legitimately 0 — so the shipment showed up on the Delhivery dashboard as a ₹0 order.

Not cosmetic: the declared value is what a **loss or damage claim pays out against**, and it's what appears on the label and in reconciliation.

`declaredValueForShipment` computes it from the **fulfillment's** items rather than the order total, because a partial fulfillment must declare only what's in that box:

- prefers each line's own `total` (already net of discounts),
- prorates it when only part of the line ships,
- falls back to `unit_price × shipped quantity`,
- and finally to the order total.

An over-declaration on a partial shipment still beats 0 — 0 is the one value that is certainly wrong. Extracted as a dependency-free helper with 7 unit tests, including a regression guard that prepaid (`cod_amount: 0`) must not imply zero value.

## 2. Nothing booked the pickup

A waybill tells the carrier a parcel exists, not to come and collect it. Pickup scheduling existed **only in the partner portal** — the client method (`schedulePickup` → `/fm/request/new/`) and adapter were already there, with no admin path. So an admin-created shipment waited until someone booked it by hand on Delhivery's dashboard. **Order #83 was collected two days late for exactly this reason.**

- New `POST /admin/orders/:id/fulfillments/:fulfillmentId/pickup`, mirroring the partner route.
- A pickup scheduler (date / time / package count) in the **Carrier Shipment** widget, on the already-labelled branch — where the operator actually is once an AWB exists.

Booking stays deliberately **separate from label creation**: a manifest can be made the night before, but a pickup slot commits a real courier to a date, a count and a warehouse. Auto-booking on every fulfillment would send couriers to locations that aren't packed yet. The button says so.

## Verify

```
TEST_TYPE=unit npx jest --testPathPattern="shipping-providers"   # 167/167
```
`tsc` at the 79-error baseline. Delhivery has no usable sandbox, so the value change is covered by unit tests over the payload builder rather than a live probe — the next real shipment is the proof.

🤖 Generated with [Claude Code](https://claude.com/claude-code)