### PR TITLE
feat(admin-assistant): image attachments, materials from photos, idea-to-design tools (#1238)

### DIFF
--- a/apps/backend/src/admin/routes/assistant/page.tsx
+++ b/apps/backend/src/admin/routes/assistant/page.tsx
@@ -13,7 +13,7 @@
  */
 import { useCallback, useEffect, useMemo, useRef, useState } from "react"
 import { defineRouteConfig } from "@medusajs/admin-sdk"
-import { ChatBubbleLeftRight, Sparkles, ArrowUpMini, Spinner, Check, ExclamationCircle, ArrowPathMini, SquareTwoStack, Plus, Trash } from "@medusajs/icons"
+import { ChatBubbleLeftRight, Sparkles, ArrowUpMini, Spinner, Check, ExclamationCircle, ArrowPathMini, SquareTwoStack, Plus, Trash, Photo } from "@medusajs/icons"
 import { Container, Heading, Text, Button, Textarea, IconButton, Badge, Table, toast } from "@medusajs/ui"
 import { useChat } from "@ai-sdk/react"
 import { DefaultChatTransport } from "ai"
@@ -27,6 +27,53 @@ const SUGGESTIONS = [
   "List the most recent partners",
   "What production runs are open?",
 ]
+
+/** An uploaded image the operator attached to the next message. */
+type Attachment = {
+  url: string
+  name: string
+  mime_type: string
+}
+
+/** Images only, and small enough that a vision model can actually read it. */
+const MAX_ATTACHMENT_BYTES = 10 * 1024 * 1024
+const MAX_ATTACHMENTS = 4
+
+/**
+ * Upload one image and return the reference the chat route stores.
+ *
+ * Goes through /admin/medias (multipart), which base64-encodes the content —
+ * the path that must never regress to latin1, or every image ≥ 0x80 arrives
+ * corrupted and unreadable by any vision model (#769/#789).
+ */
+async function uploadAttachment(file: File): Promise<Attachment> {
+  const form = new FormData()
+  form.append("files", file)
+
+  const res = await fetch(`${API_BASE_URL.replace(/\/$/, "")}/admin/medias`, {
+    method: "POST",
+    credentials: "include",
+    body: form,
+  })
+
+  const payload = await res.json().catch(() => null)
+  if (!res.ok) {
+    throw new Error(payload?.message || `Upload failed (${res.status})`)
+  }
+
+  // The media workflow returns { result: { mediaFiles: [...] } }; be defensive
+  // about the exact nesting rather than assuming one shape.
+  const files: any[] =
+    payload?.result?.mediaFiles ??
+    payload?.result?.media_files ??
+    (Array.isArray(payload?.result) ? payload.result : [])
+  const url = files?.[0]?.url ?? files?.[0]?.file_path
+  if (!url) {
+    throw new Error("Upload succeeded but returned no url")
+  }
+
+  return { url, name: file.name, mime_type: file.type || "image/*" }
+}
 
 const isRecord = (v: unknown): v is Record<string, unknown> =>
   !!v && typeof v === "object" && !Array.isArray(v)
@@ -447,11 +494,27 @@ const AssistantChat = ({
     JSON.stringify(initialMessages.map((m) => [m.id, m.parts?.length]))
   )
 
+  // Attachments for the turn currently being sent. A ref, not state, because
+  // the transport closure is built once and must read the value at send time —
+  // and because clearing it must not race the re-render that follows send.
+  const pendingAttachmentsRef = useRef<Attachment[]>([])
+
   const transport = useMemo(
     () =>
       new DefaultChatTransport({
         api: `${API_BASE_URL.replace(/\/$/, "")}/admin/assistant/chat`,
         credentials: "include",
+        prepareSendMessagesRequest: ({ body, ...rest }: any) => {
+          const attachments = pendingAttachmentsRef.current
+          pendingAttachmentsRef.current = []
+          return {
+            ...rest,
+            body: {
+              ...body,
+              ...(attachments.length ? { attachments } : {}),
+            },
+          }
+        },
       }),
     []
   )
@@ -462,6 +525,9 @@ const AssistantChat = ({
 
   const [autoScroll, setAutoScroll] = useState(true)
   const [queued, setQueued] = useState<string[]>([])
+  const [attachments, setAttachments] = useState<Attachment[]>([])
+  const [uploading, setUploading] = useState(false)
+  const fileInputRef = useRef<HTMLInputElement>(null)
   const [compacting, setCompacting] = useState(false)
   const tokenEstimate = useMemo(() => estimateTokens(messages as any[]), [messages])
   const overBudget = tokenEstimate >= CONTEXT_WARN_TOKENS
@@ -539,14 +605,78 @@ const AssistantChat = ({
    */
   const submit = (text: string) => {
     const t = text.trim()
-    if (!t) return
+    // An image on its own IS a message — "here, file this" with no words is a
+    // normal thing to do, so don't require text when something is attached.
+    if (!t && attachments.length === 0) return
     setInput("")
+
     if (streaming) {
+      // Queued turns carry text only. Sending the attachment now would attach it
+      // to whichever turn happens to flush next, which is not the one the
+      // operator was looking at when they picked the file.
+      if (attachments.length) {
+        toast.warning("Wait for the current answer before sending an attachment")
+        return
+      }
       setQueued((q) => [...q, t])
       return
     }
-    sendMessage({ text: t })
+
+    if (attachments.length) {
+      pendingAttachmentsRef.current = attachments
+      setAttachments([])
+    }
+    sendMessage({ text: t || "(see attached)" })
   }
+
+  /** Validate, upload, and hold images for the next send. */
+  const attachFiles = useCallback(
+    async (files: FileList | null) => {
+      if (!files?.length) return
+      const picked = Array.from(files)
+
+      const room = MAX_ATTACHMENTS - attachments.length
+      if (room <= 0) {
+        toast.error(`You can attach at most ${MAX_ATTACHMENTS} images per message`)
+        return
+      }
+
+      const accepted: File[] = []
+      for (const f of picked.slice(0, room)) {
+        if (!f.type.startsWith("image/")) {
+          toast.error(`${f.name} is not an image — only images can be attached`)
+          continue
+        }
+        if (f.size > MAX_ATTACHMENT_BYTES) {
+          toast.error(
+            `${f.name} is ${(f.size / 1024 / 1024).toFixed(1)} MB — the limit is ${
+              MAX_ATTACHMENT_BYTES / 1024 / 1024
+            } MB`
+          )
+          continue
+        }
+        accepted.push(f)
+      }
+      if (!accepted.length) return
+
+      setUploading(true)
+      try {
+        const settled = await Promise.allSettled(accepted.map(uploadAttachment))
+        const ok = settled
+          .filter((s): s is PromiseFulfilledResult<Attachment> => s.status === "fulfilled")
+          .map((s) => s.value)
+        settled
+          .filter((s): s is PromiseRejectedResult => s.status === "rejected")
+          .forEach((s) =>
+            toast.error(`Could not attach: ${s.reason?.message ?? "upload failed"}`)
+          )
+        if (ok.length) setAttachments((a) => [...a, ...ok])
+      } finally {
+        setUploading(false)
+      }
+    },
+    [attachments.length]
+  )
 
   useEffect(() => {
     if (status !== "ready" || queued.length === 0 || error) return
@@ -713,7 +843,58 @@ const AssistantChat = ({
             </Button>
           </div>
         ) : null}
+        {attachments.length ? (
+          <div className="mb-2 flex flex-wrap items-center gap-2">
+            {attachments.map((a, i) => (
+              <div
+                key={`${a.url}-${i}`}
+                className="border-ui-border-base bg-ui-bg-subtle flex items-center gap-2 rounded-md border px-2 py-1"
+              >
+                <img
+                  src={a.url}
+                  alt={a.name}
+                  className="h-8 w-8 rounded object-cover"
+                />
+                <Text size="xsmall" className="max-w-[160px] truncate">
+                  {a.name}
+                </Text>
+                <IconButton
+                  size="2xsmall"
+                  variant="transparent"
+                  onClick={() =>
+                    setAttachments((list) => list.filter((_, idx) => idx !== i))
+                  }
+                >
+                  <Trash />
+                </IconButton>
+              </div>
+            ))}
+            <Text size="xsmall" className="text-ui-fg-muted">
+              Attached, not read — ask me to read one if you need what's in it.
+            </Text>
+          </div>
+        ) : null}
         <div className="flex items-end gap-2">
+          <input
+            ref={fileInputRef}
+            type="file"
+            accept="image/*"
+            multiple
+            hidden
+            onChange={(e) => {
+              void attachFiles(e.target.files)
+              // Reset so picking the same file twice still fires onChange.
+              e.target.value = ""
+            }}
+          />
+          <IconButton
+            variant="transparent"
+            isLoading={uploading}
+            disabled={uploading || attachments.length >= MAX_ATTACHMENTS}
+            onClick={() => fileInputRef.current?.click()}
+          >
+            <Photo />
+          </IconButton>
           <Textarea
             placeholder={
               streaming ? "Type to queue the next message…" : "Ask the admin assistant…"
@@ -736,7 +917,7 @@ const AssistantChat = ({
           ) : null}
           <IconButton
             variant="primary"
-            disabled={!input.trim()}
+            disabled={!input.trim() && attachments.length === 0}
             onClick={() => submit(input)}
           >
             <ArrowUpMini />

--- a/apps/backend/src/api/admin/assistant/chat/route.ts
+++ b/apps/backend/src/api/admin/assistant/chat/route.ts
@@ -70,9 +70,48 @@ You are given the tools for the domains this conversation appears to be about, n
 - Sensitive/destructive tools refuse to run unless the user confirms. Never set \`confirm: true\` yourself. If a tool returns \`requires_confirmation\`, tell the user plainly what it will do and ask them to approve — the UI gives them a button.
 - Platform-destructive ("dangerous") tools additionally require a \`reason\`. If a tool returns \`requires_reason\`, ask the operator WHY they want to do it and pass their answer as the reason. Never invent a reason.
 
+## Images the operator attaches
+Attached images are uploaded and listed for you as \`[attachment N]\` lines with a url — but you CANNOT see them. Nothing about their content is available to you unless you go and read them.
+- Do NOT read an image just because it was attached. Most attachments are there to be filed against a record (a design's reference, an inventory item's photo), not interpreted, and reading costs real time and money.
+- Read one ONLY when the operator asks you to, or when they ask for something that is impossible without it ("add the raw materials from this photo", "what does this note say"). Then call \`read_image\` with the attachment's url and a specific question.
+- \`extract_inventory_from_image\` is the purpose-built path for "create raw materials / inventory from this photo" — prefer it over \`read_image\` + manual creation, and keep \`persist: false\` until the operator has seen and approved the extraction.
+- If a read fails, relay the reason verbatim — they are all actionable (no vision provider configured, a text-only model, a licence-gated model). Never retry silently and never guess at what the image showed.
+
+## Turning an idea into a design
+When an operator describes an idea — with or without a reference image or Pinterest link — build it out properly instead of creating a bare named record:
+1. \`create_design\` with the name, description and \`inspiration_sources\` (put the reference link there; a link they gave you and you dropped is a link they have to find again). Set \`thumbnail_url\` to the reference image when there is one.
+2. \`update_design_brief\` for the attributes that describe the IDEA — concept theme, aesthetic keywords, persona, price point. Take these from what the operator said; ask rather than invent a persona.
+3. \`list_construction_techniques\` then \`add_design_construction_detail\` for how the garment is actually made. The technique must be a slug from that list — the catalog IS the vocabulary, so map "gathered waist" onto the real slug rather than writing prose.
+4. Materials: \`link_design_material_group\` to pin a material group, and/or \`link_design_inventory\` for the specific items and planned quantities.
+5. \`link_design_partners\`, then \`create_design_production_run\` to actually put it into production.
+Each of those is sensitive, so the operator approves each one — narrate what you're about to do, don't dump five approval cards without explanation.
+
 ## Style
 - Be concise and operator-focused. After a successful change, confirm what you did in one short sentence.
 - Never invent ids, values, or fields outside the tool schemas.`
+
+/**
+ * Tell the model an attachment EXISTS without sending a single pixel.
+ *
+ * The url is what makes it actionable: `read_image` and
+ * `extract_inventory_from_image` both take one, so the model can act on an image
+ * it cannot see, but only deliberately.
+ */
+const renderAttachments = (
+  attachments: NonNullable<AdminAssistantChatReq["attachments"]>
+): string =>
+  [
+    "",
+    "---",
+    `The operator attached ${attachments.length} file(s) to this message. You cannot see them.`,
+    "Read one only if this request actually requires it (see: Images the operator attaches).",
+    ...attachments.map(
+      (a, i) =>
+        `[attachment ${i + 1}] name=${a.name ?? "untitled"} type=${
+          a.mime_type ?? "unknown"
+        } url=${a.url}`
+    ),
+  ].join("\n")
 
 export const POST = async (
   req: AuthenticatedMedusaRequest,
@@ -151,6 +190,20 @@ export const POST = async (
       parts: textParts.length ? textParts : [{ type: "text", text: "" }],
     }
   })
+
+  // Attachments ride on the LAST user message — the turn they were sent with.
+  // Appended as text so every provider handles it identically; a provider that
+  // can't do multimodal parts is not a special case here, because we never send
+  // parts it would have to understand.
+  const attachments = body.attachments ?? []
+  if (attachments.length) {
+    for (let i = messages.length - 1; i >= 0; i--) {
+      if (messages[i].role === "user") {
+        messages[i].parts.push({ type: "text", text: renderAttachments(attachments) })
+        break
+      }
+    }
+  }
 
   // ---- Per-ask registry slicing -------------------------------------------
   // All ~100 tools stay BOUND (so any of them can still execute), but only the

--- a/apps/backend/src/api/admin/assistant/chat/validators.ts
+++ b/apps/backend/src/api/admin/assistant/chat/validators.ts
@@ -23,10 +23,28 @@ const UiMessageSchema = z
   })
   .passthrough()
 
+/**
+ * An image the operator attached to this turn. Already uploaded — this is a
+ * reference, not the bytes.
+ *
+ * The model is TOLD an attachment exists (name, type, url) but is never sent the
+ * pixels: the assistant's own model may well be text-only, and the ones that are
+ * accept an image part and silently ignore it. Reading an image is an explicit,
+ * separate act — the `read_image` tool.
+ */
+const AttachmentSchema = z.object({
+  url: z.string().trim().min(1),
+  name: z.string().trim().min(1).max(300).optional(),
+  mime_type: z.string().trim().min(1).max(100).optional(),
+})
+
 export const AdminAssistantChatSchema = z.object({
   messages: z.array(UiMessageSchema).min(1).max(60),
   id: z.string().optional(),
   trigger: z.string().optional(),
+  attachments: z.array(AttachmentSchema).max(8).optional(),
 })
+
+export type AdminAssistantAttachment = z.infer<typeof AttachmentSchema>
 
 export type AdminAssistantChatReq = z.infer<typeof AdminAssistantChatSchema>

--- a/apps/backend/src/api/admin/assistant/vision/__tests__/guards.unit.spec.ts
+++ b/apps/backend/src/api/admin/assistant/vision/__tests__/guards.unit.spec.ts
@@ -1,0 +1,102 @@
+/**
+ * Vision guards (#1238).
+ *
+ * Each case here is a failure observed against Cloudflare Workers AI on
+ * 2026-08-10, not a hypothetical. The point of the guards is that none of these
+ * failures announce themselves: the dangerous ones return HTTP 200.
+ */
+import {
+  explainEmptyAnswer,
+  explainFailure,
+  isKnownTextOnly,
+} from "../guards"
+
+describe("isKnownTextOnly", () => {
+  it("refuses the model the admin assistant actually runs on", () => {
+    // Measured: this returns 200 with the image silently dropped, so the model
+    // answers blind. There is no error to catch — refusing is the only guard.
+    expect(isKnownTextOnly("@cf/zai-org/glm-5.2")).toBe(true)
+  })
+
+  it("matches the same weights however a provider addresses them", () => {
+    for (const id of ["z-ai/glm-5.2", "glm-5.2:free", "@cf/zai-org/GLM-5.2"]) {
+      expect([id, isKnownTextOnly(id)]).toEqual([id, true])
+    }
+  })
+
+  it("allows the models that genuinely read images", () => {
+    for (const id of [
+      "@cf/google/gemma-4-26b-a4b-it",
+      "@cf/meta/llama-4-scout-17b-16e-instruct",
+      "@cf/meta/llama-3.2-11b-vision-instruct",
+    ]) {
+      expect([id, isKnownTextOnly(id)]).toEqual([id, false])
+    }
+  })
+
+  it("does not block an unknown model — an allowlist would freeze the catalog", () => {
+    expect(isKnownTextOnly("@cf/some/model-shipped-next-week")).toBe(false)
+    expect(isKnownTextOnly(undefined)).toBe(false)
+  })
+})
+
+describe("explainFailure", () => {
+  it("names the licence wall for a gated model", () => {
+    // Verbatim shape of Cloudflare's refusal for llama-3.2-11b-vision-instruct.
+    const e = {
+      statusCode: 403,
+      message:
+        "AiError: Model Agreement: Prior to using this model, you must submit the prompt 'agree'.",
+    }
+    const out = explainFailure(e, "@cf/meta/llama-3.2-11b-vision-instruct")
+    expect(out.status).toBe(424)
+    expect(out.error).toMatch(/licence-gated/i)
+  })
+
+  it("detects the licence wall from the message even without a status", () => {
+    const out = explainFailure({ message: "community license not accepted" })
+    expect(out.status).toBe(424)
+  })
+
+  it("separates bad credentials from a bad model", () => {
+    const out = explainFailure({ statusCode: 401, message: "Unauthorized" })
+    expect(out.status).toBe(424)
+    expect(out.error).toMatch(/API key/i)
+  })
+
+  it("marks rate limiting as retryable", () => {
+    expect(explainFailure({ statusCode: 429 }).status).toBe(429)
+  })
+
+  it("explains a timeout in terms of how slow these models really are", () => {
+    const out = explainFailure({ message: "ETIMEDOUT" })
+    expect(out.status).toBe(504)
+    expect(out.error).toMatch(/30s/)
+  })
+
+  it("falls back to 502 with the provider's own words", () => {
+    const out = explainFailure({ message: "socket hang up" })
+    expect(out.status).toBe(502)
+    expect(out.error).toMatch(/socket hang up/)
+  })
+
+  it("never produces an empty explanation", () => {
+    expect(explainFailure(undefined).error).toMatch(/unknown provider error/)
+  })
+})
+
+describe("explainEmptyAnswer", () => {
+  it("explains the reasoning-model token trap", () => {
+    // gemma-4 at max_tokens 700: 16s, finish_reason "length", content "" —
+    // the whole answer went to reasoning_content. Reads as a dead provider.
+    const msg = explainEmptyAnswer("@cf/google/gemma-4-26b-a4b-it", "length")
+    expect(msg).toMatch(/token budget reasoning/i)
+    expect(msg).toMatch(/narrower question/i)
+  })
+
+  it("says something different when the model simply had nothing to say", () => {
+    const msg = explainEmptyAnswer("@cf/google/gemma-4-26b-a4b-it", "stop")
+    expect(msg).toMatch(/empty response/i)
+    expect(msg).not.toMatch(/token budget/i)
+  })
+})

--- a/apps/backend/src/api/admin/assistant/vision/guards.ts
+++ b/apps/backend/src/api/admin/assistant/vision/guards.ts
@@ -1,0 +1,107 @@
+/**
+ * Pure guards for on-demand image reading.
+ *
+ * Split out of route.ts so the failure modes can be asserted directly — every
+ * rule here was written against a live probe, not a spec sheet, and each one
+ * corresponds to a way a vision call fails WITHOUT throwing anything obvious.
+ */
+
+/**
+ * Models that accept an `image_url` part and ignore it.
+ *
+ * This is the dangerous class. Cloudflare returns HTTP 200 for
+ * `@cf/zai-org/glm-5.2` with an image attached, having silently dropped the
+ * image — the model then answers from the text alone, confidently and wrongly.
+ * Refusing up front is the only safe handling: there is no error to catch.
+ *
+ * Substring-matched because the same weights are addressed many ways across
+ * providers (`@cf/zai-org/glm-5.2`, `z-ai/glm-5.2`, `glm-5.2:free`).
+ */
+export const TEXT_ONLY_MODEL_HINTS = [
+  "glm-5.2",
+  "glm-4.6",
+  "llama-3.3-70b",
+  "qwen-turbo",
+  "gpt-oss",
+]
+
+export const isKnownTextOnly = (modelId?: string): boolean => {
+  if (!modelId) {
+    return false
+  }
+  const id = modelId.toLowerCase()
+  return TEXT_ONLY_MODEL_HINTS.some((hint) => id.includes(hint))
+}
+
+export type VisionFailure = { status: number; error: string }
+
+/**
+ * Turn a provider failure into something an operator can act on.
+ *
+ * Every branch is a real observed failure: a licence-gated model (Meta's
+ * community licence must be accepted per-account before
+ * `@cf/meta/llama-3.2-11b-vision-instruct` will answer), bad credentials, rate
+ * limits, and the 30s+ timeouts reasoning vision models genuinely take.
+ */
+export const explainFailure = (e: any, modelId?: string): VisionFailure => {
+  const raw = String(e?.message ?? e ?? "")
+  const status = e?.statusCode ?? e?.status
+
+  if (
+    status === 403 ||
+    /model agreement|community license|must submit the prompt/i.test(raw)
+  ) {
+    return {
+      status: 424,
+      error:
+        `The vision model ${modelId ?? ""} is licence-gated and has not been accepted for this ` +
+        `account. Accept its licence in the provider dashboard, or point the ` +
+        `ai_image_extraction platform at a different model.`,
+    }
+  }
+  if (status === 401 || /unauthor|forbidden|invalid api key/i.test(raw)) {
+    return {
+      status: 424,
+      error:
+        "The vision provider rejected our credentials. Check the API key on the " +
+        "ai_image_extraction platform in Settings → External Platforms.",
+    }
+  }
+  if (status === 429 || /rate limit|too many requests/i.test(raw)) {
+    return {
+      status: 429,
+      error: "The vision provider is rate-limiting us. Try again in a moment.",
+    }
+  }
+  if (/timeout|etimedout|aborted/i.test(raw)) {
+    return {
+      status: 504,
+      error:
+        "The vision model timed out. Reasoning models can take 30s+ on a dense " +
+        "image — retry, or pass a faster model explicitly.",
+    }
+  }
+  return {
+    status: 502,
+    error: `The vision model could not read the image: ${raw || "unknown provider error"}`,
+  }
+}
+
+/**
+ * Why an empty answer happened.
+ *
+ * Reasoning vision models emit their working into `reasoning_content` and leave
+ * `content` empty until they reach an answer — so a token cap produces a
+ * perfectly successful-looking response containing nothing. Measured: gemma-4 at
+ * a 700-token cap returned "" after 16s. Without this message that reads as a
+ * dead provider and gets debugged as one.
+ */
+export const explainEmptyAnswer = (
+  modelId: string | undefined,
+  finishReason?: string
+): string =>
+  finishReason === "length"
+    ? `${modelId} used its entire token budget reasoning and never emitted an ` +
+      `answer. Ask a narrower question about the image, or switch the ` +
+      `ai_image_extraction platform to a faster non-reasoning vision model.`
+    : `${modelId} returned an empty response for this image.`

--- a/apps/backend/src/api/admin/assistant/vision/route.ts
+++ b/apps/backend/src/api/admin/assistant/vision/route.ts
@@ -1,0 +1,157 @@
+/**
+ * POST /admin/assistant/vision
+ *
+ * Read an attached image on demand. Attaching a photo to the assistant does not
+ * send its pixels to any model — the image is stored and the assistant is merely
+ * told one exists. This route is what actually looks at it, and it only runs when
+ * the operator asks ("read this", "what materials are in this photo").
+ *
+ * That split is a cost decision AND a correctness one. The admin assistant's own
+ * model is whatever the operator configured for `ai_admin_assistant`, and the
+ * model configured in prod today (`@cf/zai-org/glm-5.2`) is text-only: Cloudflare
+ * accepts an `image_url` part, **silently drops it, and still returns HTTP 200**.
+ * A blind model answering confidently is worse than an error, so vision is
+ * resolved separately through the `ai_image_extraction` role — the same resolver
+ * inventory import-from-image (#769) uses — and the known text-only models are
+ * refused up front rather than trusted to complain.
+ *
+ * Live probe (2026-08-10, prod CF account) that set these rules:
+ *   @cf/zai-org/glm-5.2                    → 200, image dropped, "no image"
+ *   @cf/google/gemma-4-26b-a4b-it          → correct, but 22-33s AND it emits its
+ *                                            answer into `reasoning_content`,
+ *                                            leaving `content` EMPTY if the token
+ *                                            budget runs out first
+ *   @cf/meta/llama-4-scout-17b-16e-instruct→ correct, ~5s
+ *   @cf/meta/llama-3.2-11b-vision-instruct → 403, Meta licence not accepted
+ */
+import { AuthenticatedMedusaRequest, MedusaResponse } from "@medusajs/framework/http"
+import { ContainerRegistrationKeys } from "@medusajs/framework/utils"
+import { generateText } from "ai"
+
+import {
+  resolveRoleVisionModel,
+  logAiUsage,
+} from "../../../../mastra/services/ai-platforms"
+import type { AdminAssistantVisionReq } from "./validators"
+import { explainEmptyAnswer, explainFailure, isKnownTextOnly } from "./guards"
+
+const FEATURE = "admin/assistant/vision"
+const ROLE = "ai_image_extraction"
+
+const DEFAULT_PROMPT =
+  "Describe this image for a textile operations team. If it contains handwriting, " +
+  "printed text, tables or numbers, transcribe them exactly, preserving line order. " +
+  "Do not guess at anything you cannot actually see."
+
+/**
+ * Reasoning-style vision models spend tokens thinking before they answer, and on
+ * Cloudflare's OpenAI-compatible endpoint that thinking goes to `reasoning_content`
+ * while `content` stays empty until the answer is reached. Capping this low is how
+ * you get a convincing "the model returned nothing".
+ */
+const MAX_OUTPUT_TOKENS = 4000
+
+export const POST = async (
+  req: AuthenticatedMedusaRequest,
+  res: MedusaResponse
+) => {
+  const logger: any = req.scope.resolve(ContainerRegistrationKeys.LOGGER)
+  const body = (req as any).validatedBody as AdminAssistantVisionReq
+
+  const resolved = await resolveRoleVisionModel(
+    req.scope as any,
+    ROLE,
+    body.model
+  )
+
+  // The free fallback is an OpenRouter vision model — usable, but only if a key
+  // exists. Without one there is nothing to call, so say so precisely instead of
+  // failing inside the provider.
+  if (resolved.source === "free" && !process.env.OPENROUTER_API_KEY) {
+    res.status(503).json({
+      error:
+        "No vision provider is configured. Add a platform with role " +
+        "ai_image_extraction in Settings → External Platforms (Cloudflare Workers " +
+        "AI works — e.g. @cf/google/gemma-4-26b-a4b-it), or set OPENROUTER_API_KEY.",
+    })
+    return
+  }
+
+  if (isKnownTextOnly(resolved.modelId)) {
+    res.status(422).json({
+      error:
+        `The model configured for image reading (${resolved.modelId}) is text-only — ` +
+        `it accepts an image and silently ignores it, so any answer would be invented. ` +
+        `Point the ai_image_extraction platform at a vision model ` +
+        `(e.g. @cf/google/gemma-4-26b-a4b-it for accuracy, ` +
+        `@cf/meta/llama-4-scout-17b-16e-instruct for speed).`,
+      model: resolved.modelId,
+    })
+    return
+  }
+
+  const startedAt = Date.now()
+  const usageBase = {
+    feature: FEATURE,
+    role: ROLE,
+    provider: resolved.providerType,
+    source: resolved.source,
+    platformId: resolved.platformId,
+    model: resolved.modelId,
+  } as const
+
+  let text: string
+  let finishReason: string | undefined
+  try {
+    const result = await generateText({
+      model: resolved.model,
+      maxOutputTokens: MAX_OUTPUT_TOKENS,
+      messages: [
+        {
+          role: "user",
+          content: [
+            { type: "text", text: body.prompt || DEFAULT_PROMPT },
+            { type: "image", image: new URL(body.image_url) },
+          ],
+        },
+      ],
+    })
+    text = (result.text ?? "").trim()
+    finishReason = result.finishReason
+    logAiUsage(logger, {
+      ...usageBase,
+      ok: true,
+      ms: Date.now() - startedAt,
+      tokens: result.usage?.totalTokens,
+    })
+  } catch (e: any) {
+    logAiUsage(logger, {
+      ...usageBase,
+      ok: false,
+      ms: Date.now() - startedAt,
+      error: e,
+    })
+    const { status, error } = explainFailure(e, resolved.modelId)
+    res.status(status).json({ error, model: resolved.modelId })
+    return
+  }
+
+  // Empty answer from a reasoning model that spent its whole budget thinking.
+  // Distinguish it from "the model had nothing to say" so nobody re-debugs this.
+  if (!text) {
+    res.status(502).json({
+      error: explainEmptyAnswer(resolved.modelId, finishReason),
+      model: resolved.modelId,
+      finish_reason: finishReason,
+    })
+    return
+  }
+
+  res.json({
+    text,
+    model: resolved.modelId,
+    provider: resolved.providerType,
+    source: resolved.source,
+    ms: Date.now() - startedAt,
+  })
+}

--- a/apps/backend/src/api/admin/assistant/vision/validators.ts
+++ b/apps/backend/src/api/admin/assistant/vision/validators.ts
@@ -1,0 +1,22 @@
+import { z } from "@medusajs/framework/zod"
+
+/**
+ * On-demand image reading for the admin assistant.
+ *
+ * Deliberately explicit: attaching an image to the chat does NOT send its pixels
+ * anywhere. The operator (or the model, on the operator's instruction) has to ask
+ * for the image to be read, and that lands here.
+ */
+export const AdminAssistantVisionSchema = z.object({
+  image_url: z.string().trim().min(1),
+  /** What to look for. Defaults to a generic describe-and-transcribe prompt. */
+  prompt: z.string().trim().min(1).max(2000).optional(),
+  /**
+   * Override the model resolved for the `ai_image_extraction` role. Lets an
+   * operator trade accuracy for latency per call without reconfiguring the
+   * platform (gemma-4 reads handwriting better; llama-4-scout answers ~5x faster).
+   */
+  model: z.string().trim().min(1).optional(),
+})
+
+export type AdminAssistantVisionReq = z.infer<typeof AdminAssistantVisionSchema>

--- a/apps/backend/src/api/admin/mcp/lib/__tests__/image-and-design-tools.unit.spec.ts
+++ b/apps/backend/src/api/admin/mcp/lib/__tests__/image-and-design-tools.unit.spec.ts
@@ -1,0 +1,164 @@
+/**
+ * The image / materials / idea-to-design tools (#1238).
+ *
+ * These assert the two things that actually break in production: a tool that
+ * exists but can never be reached (wrong domain, no keyword), and a write tool
+ * that isn't gated. Both fail silently — the model just says it can't do it.
+ */
+import { ADMIN_MCP_TOOLS } from "../registry"
+import {
+  selectAdminToolSlice,
+  toolDomain,
+  matchDomains,
+} from "../tool-slice"
+
+const byName = (name: string) => {
+  const def = ADMIN_MCP_TOOLS.find((t) => t.name === name)
+  if (!def) {
+    throw new Error(`tool ${name} is not registered`)
+  }
+  return def
+}
+
+const NEW_TOOLS = [
+  "read_image",
+  "extract_inventory_from_image",
+  "list_raw_materials",
+  "add_inventory_raw_material",
+  "list_raw_material_groups",
+  "create_raw_material_group",
+  "link_design_inventory",
+  "list_design_material_groups",
+  "link_design_material_group",
+  "list_construction_techniques",
+  "list_design_construction_details",
+  "add_design_construction_detail",
+  "update_design_brief",
+  "search_pinterest",
+]
+
+describe("registry — image, materials and design tools", () => {
+  it("registers every new tool exactly once", () => {
+    for (const name of NEW_TOOLS) {
+      const matches = ADMIN_MCP_TOOLS.filter((t) => t.name === name)
+      expect([name, matches.length]).toEqual([name, 1])
+    }
+  })
+
+  it("gates everything that creates records behind write + confirm", () => {
+    const mutating = [
+      "extract_inventory_from_image",
+      "add_inventory_raw_material",
+      "create_raw_material_group",
+      "link_design_inventory",
+      "link_design_material_group",
+      "add_design_construction_detail",
+      "update_design_brief",
+    ]
+    for (const name of mutating) {
+      const def = byName(name)
+      expect([name, def.write === true, def.sensitive === true]).toEqual([
+        name,
+        true,
+        true,
+      ])
+    }
+  })
+
+  it("does NOT gate reads — including read_image, which writes nothing", () => {
+    for (const name of [
+      "read_image",
+      "list_raw_materials",
+      "list_raw_material_groups",
+      "list_design_material_groups",
+      "list_construction_techniques",
+      "list_design_construction_details",
+      "search_pinterest",
+    ]) {
+      expect([name, !!byName(name).write]).toEqual([name, false])
+    }
+  })
+
+  it("declares every :param in the path as a pathParam", () => {
+    for (const name of NEW_TOOLS) {
+      const def = byName(name)
+      const placeholders = (def.path?.match(/:(\w+)/g) ?? []).map((p) => p.slice(1))
+      expect([name, def.pathParams ?? []]).toEqual([name, placeholders])
+    }
+  })
+
+  it("only forwards body params the tool's own schema declares", () => {
+    for (const name of NEW_TOOLS) {
+      const def = byName(name)
+      const props = Object.keys(def.inputSchema?.properties ?? {})
+      for (const key of def.bodyParams ?? []) {
+        expect([name, key, props.includes(key)]).toEqual([name, key, true])
+      }
+    }
+  })
+})
+
+describe("tool-slice — reachability", () => {
+  it("puts read_image in core so it survives any conversation", () => {
+    // An image can be attached to a conversation about anything. If read_image
+    // were domain-scoped, "what does this say?" in an orders thread would find
+    // no tool and the model would claim it cannot see images at all.
+    expect(toolDomain(byName("read_image"))).toBe("core")
+
+    const slice = selectAdminToolSlice(
+      "how many orders shipped yesterday?",
+      ADMIN_MCP_TOOLS as any
+    )
+    expect(slice.names).toContain("read_image")
+  })
+
+  it("classifies photo-to-inventory as inventory, not as an image feature", () => {
+    expect(toolDomain(byName("extract_inventory_from_image"))).toBe("inventory")
+    expect(toolDomain(byName("create_raw_material_group"))).toBe("inventory")
+  })
+
+  it("classifies Pinterest reference search with designs", () => {
+    expect(toolDomain(byName("search_pinterest"))).toBe("designs")
+  })
+
+  it("lights up inventory for how an operator describes a delivery", () => {
+    for (const ask of [
+      "here's a photo of the swatches that arrived",
+      "log these fabric rolls",
+      "add the trims from this delivery note",
+      "what's the composition and unit cost?",
+    ]) {
+      expect([ask, matchDomains(ask)]).toEqual([ask, expect.arrayContaining(["inventory"])])
+    }
+  })
+
+  it("lights up designs for construction vocabulary, not just the word 'design'", () => {
+    // An operator says "add a waist dart", never "add a construction detail".
+    for (const ask of [
+      "add a waist dart to it",
+      "put a knife pleat on the skirt",
+      "topstitch the hem",
+      "give me a brief with the persona and price point",
+    ]) {
+      expect([ask, matchDomains(ask)]).toEqual([ask, expect.arrayContaining(["designs"])])
+    }
+  })
+
+  it("exposes the whole idea-to-production chain for one design ask", () => {
+    const slice = selectAdminToolSlice(
+      "create a design from this pinterest reference, link the fabric and a partner, then start a production run",
+      ADMIN_MCP_TOOLS as any
+    )
+    for (const name of [
+      "create_design",
+      "update_design_brief",
+      "add_design_construction_detail",
+      "link_design_inventory",
+      "link_design_partners",
+      "create_design_production_run",
+      "search_pinterest",
+    ]) {
+      expect([name, slice.names.includes(name)]).toEqual([name, true])
+    }
+  })
+})

--- a/apps/backend/src/api/admin/mcp/lib/registry.ts
+++ b/apps/backend/src/api/admin/mcp/lib/registry.ts
@@ -1828,6 +1828,8 @@ export const ADMIN_MCP_TOOLS: AdminMcpToolDef[] = [
       "cost_currency",
       "colors",
       "size_sets",
+      "inspiration_sources",
+      "thumbnail_url",
       "metadata",
     ],
     inputSchema: obj(
@@ -1845,6 +1847,15 @@ export const ADMIN_MCP_TOOLS: AdminMcpToolDef[] = [
         target_completion_date: STR("Target completion date (ISO string)."),
         tags: { type: "array", items: { type: "string" }, description: "Free-form tags." },
         designer_notes: STR("Notes for the designer."),
+        inspiration_sources: {
+          type: "array",
+          items: { type: "string" },
+          description:
+            "Reference urls the design came from — a Pinterest pin, a lookbook, a supplier page. Record the link the operator gave you here rather than dropping it.",
+        },
+        thumbnail_url: STR(
+          "Url of the reference/hero image for this design (e.g. an attached photo or a pin's image url)."
+        ),
         estimated_cost: { type: "number", description: "Estimated cost." },
         cost_currency: STR("Currency code for estimated_cost."),
         colors: {
@@ -1899,6 +1910,8 @@ export const ADMIN_MCP_TOOLS: AdminMcpToolDef[] = [
       "cost_currency",
       "colors",
       "size_sets",
+      "inspiration_sources",
+      "thumbnail_url",
       "metadata",
     ],
     inputSchema: obj(
@@ -1914,6 +1927,13 @@ export const ADMIN_MCP_TOOLS: AdminMcpToolDef[] = [
         target_completion_date: STR("New target completion date (ISO string)."),
         tags: { type: "array", items: { type: "string" }, description: "Replacement tag list." },
         designer_notes: STR("New designer notes."),
+        inspiration_sources: {
+          type: "array",
+          items: { type: "string" },
+          description:
+            "Reference urls the design came from — a Pinterest pin, a lookbook, a supplier page. Replaces the existing list.",
+        },
+        thumbnail_url: STR("Url of the reference/hero image for this design."),
         estimated_cost: { type: "number", description: "New estimated cost." },
         cost_currency: STR("Currency code for estimated_cost."),
         colors: {
@@ -2159,6 +2179,363 @@ export const ADMIN_MCP_TOOLS: AdminMcpToolDef[] = [
       ["id", "taskId", "partnerId"]
     ),
     sideEffects: "Links the task to the partner and notifies them.",
+  },
+
+  // ===== Images, materials and the idea -> design pipeline ================
+  // Everything here already existed as an admin route; what was missing was the
+  // assistant's ability to reach it. Two operator journeys drive the selection:
+  //   1. "here's a photo of what arrived" -> raw materials + inventory
+  //   2. "here's an idea and a reference"  -> design + attributes + construction
+  //      details + materials + partner + production run
+  {
+    name: "read_image",
+    description:
+      "Look at an image and answer a question about it (transcribe handwriting, describe a garment, read a label). Costs a real vision call and can take 30s — only use it when the operator asks, or when their request is impossible without seeing the image. Attaching an image is NOT a reason to read it.",
+    method: "POST",
+    path: "/admin/assistant/vision",
+    bodyParams: ["image_url", "prompt", "model"],
+    inputSchema: obj(
+      {
+        image_url: STR("Url of the image to read — take it from an [attachment] line."),
+        prompt: STR(
+          "The specific question to ask about the image. Be narrow: broad prompts on reasoning models can exhaust the token budget before they answer."
+        ),
+        model: STR(
+          "Optional model override, e.g. '@cf/meta/llama-4-scout-17b-16e-instruct' for a fast read or '@cf/google/gemma-4-26b-a4b-it' for an accurate one. Omit to use the configured ai_image_extraction platform."
+        ),
+      },
+      ["image_url"]
+    ),
+    sideEffects:
+      "Reads the image with a separately-configured vision model and returns text. Stores nothing and changes no records. Failures are configuration problems, not transient ones — relay the message rather than retrying.",
+  },
+  {
+    name: "extract_inventory_from_image",
+    description:
+      "Read a photo of fabric/trims/a delivery note and turn it into raw materials + inventory items. Run it with persist:false first to show the operator what was found; only persist:true creates records. Sensitive: requires confirm:true.",
+    method: "POST",
+    path: "/admin/ai/image-extraction",
+    write: true,
+    sensitive: true,
+    bodyParams: [
+      "image_url",
+      "entity_type",
+      "notes",
+      "hints",
+      "verify",
+      "persist",
+      "defaults",
+    ],
+    inputSchema: obj(
+      {
+        image_url: STR("Url of the image to extract from."),
+        entity_type: STR(
+          "What to extract, e.g. 'raw_material' for fabric/trims or 'product'."
+        ),
+        notes: STR("Extra context for the extraction, in the operator's words."),
+        hints: {
+          type: "array",
+          items: { type: "string" },
+          description: "Hints that steer the extraction, e.g. 'metres not yards'.",
+        },
+        verify: {
+          type: "boolean",
+          description: "Ask the model to double-check its own extraction.",
+        },
+        persist: {
+          type: "boolean",
+          description:
+            "Create the raw materials and inventory items. Default false — preview first, always.",
+        },
+        defaults: {
+          type: "object",
+          description:
+            "Fallbacks for fields the image doesn't state: { notes, raw_materials: { width_inch, material_type }, inventory: { stock_location_id, default_stocked_quantity, default_incoming_quantity, incoming_from_extraction } }.",
+        },
+      },
+      ["image_url", "entity_type"]
+    ),
+    sideEffects:
+      "With persist:true, creates raw material records, inventory items and stock levels.",
+    nextSteps: ["list_raw_materials", "link_design_inventory"],
+  },
+  {
+    name: "list_raw_materials",
+    description:
+      "List raw materials (the inventory items that carry raw-material data: composition, unit of measure, unit cost).",
+    method: "GET",
+    path: "/admin/inventory-items/raw-materials",
+    queryParams: ["limit", "offset", "q"],
+    inputSchema: obj({ ...PAGINATION }),
+  },
+  {
+    name: "add_inventory_raw_material",
+    description:
+      "Attach raw-material data (composition, unit of measure, cost, material type) to an existing inventory item. Sensitive: requires confirm:true.",
+    method: "POST",
+    path: "/admin/inventory-items/:id/rawmaterials",
+    pathParams: ["id"],
+    previewPath: "/admin/inventory-items/:id",
+    write: true,
+    sensitive: true,
+    bodyParams: ["rawMaterialData"],
+    inputSchema: obj(
+      {
+        id: STR("Inventory item id, e.g. 'iitem_...'."),
+        rawMaterialData: {
+          type: "object",
+          description:
+            "{ name, composition, unit_of_measure?, unit_cost?, material_type? (a category NAME, find-or-create) or material_type_id?, specifications?, media? }.",
+        },
+      },
+      ["id", "rawMaterialData"]
+    ),
+  },
+  {
+    name: "list_raw_material_groups",
+    description:
+      "List raw material groups — the colourway/spec families that designs pin their materials to.",
+    method: "GET",
+    path: "/admin/raw-material-groups",
+    queryParams: ["limit", "offset", "q"],
+    inputSchema: obj({ ...PAGINATION }),
+  },
+  {
+    name: "create_raw_material_group",
+    description:
+      "Create a raw material group holding the specs its colours inherit (composition, unit of measure, material type, cost). Sensitive: requires confirm:true.",
+    method: "POST",
+    path: "/admin/raw-material-groups",
+    write: true,
+    sensitive: true,
+    bodyParams: [
+      "name",
+      "description",
+      "status",
+      "composition",
+      "specifications",
+      "dimensions",
+      "unit_of_measure",
+      "material_type",
+      "material_type_id",
+      "unit_cost",
+      "cost_currency",
+      "lead_time_days",
+      "minimum_order_quantity",
+      "stock_location_id",
+      "metadata",
+    ],
+    inputSchema: obj(
+      {
+        name: STR("Group name (required)."),
+        description: STR("What this group covers."),
+        status: STR("Group status."),
+        composition: STR("e.g. '100% organic cotton'."),
+        specifications: { type: "object", description: "Arbitrary spec key/values." },
+        dimensions: {
+          type: "array",
+          items: { type: "object" },
+          description: "[{ key, label, values? }] — the group's variant axes.",
+        },
+        unit_of_measure: STR("Meter, Kilogram, Gram, Yard, Roll, Piece, ..."),
+        material_type: STR("Category NAME — resolved/created server-side."),
+        material_type_id: STR("Existing material type id, if known."),
+        unit_cost: { type: "number", description: "Cost per unit." },
+        cost_currency: STR("e.g. 'inr'."),
+        lead_time_days: { type: "integer", description: "Supplier lead time." },
+        minimum_order_quantity: { type: "integer", description: "MOQ." },
+        stock_location_id: STR("Default stock location."),
+        metadata: { type: "object", description: "Free-form metadata." },
+      },
+      ["name"]
+    ),
+    nextSteps: ["link_design_material_group"],
+  },
+  {
+    name: "link_design_inventory",
+    description:
+      "Link inventory items to a design as its bill of materials, with planned quantities. Sensitive: requires confirm:true.",
+    method: "POST",
+    path: "/admin/designs/:id/inventory",
+    pathParams: ["id"],
+    previewPath: "/admin/designs/:id/inventory",
+    write: true,
+    sensitive: true,
+    bodyParams: ["inventoryIds", "inventoryItems"],
+    inputSchema: obj(
+      {
+        id: STR("Design id, e.g. 'design_...'."),
+        inventoryIds: {
+          type: "array",
+          items: { type: "string" },
+          description: "Inventory item ids to link.",
+        },
+        inventoryItems: {
+          type: "array",
+          items: { type: "object" },
+          description:
+            "Detailed links instead of bare ids: [{ inventoryId, plannedQuantity?, locationId?, metadata? }].",
+        },
+      },
+      ["id"]
+    ),
+    nextSteps: ["list_design_inventory", "create_design_production_run"],
+  },
+  {
+    name: "list_design_material_groups",
+    description: "List the raw material groups pinned to a design.",
+    method: "GET",
+    path: "/admin/designs/:id/material-groups",
+    pathParams: ["id"],
+    inputSchema: obj({ id: STR("Design id, e.g. 'design_...'.") }, ["id"]),
+  },
+  {
+    name: "link_design_material_group",
+    description:
+      "Pin a raw material group to a design — the Materials frame of its tech pack. Sensitive: requires confirm:true.",
+    method: "POST",
+    path: "/admin/designs/:id/material-groups",
+    pathParams: ["id"],
+    write: true,
+    sensitive: true,
+    bodyParams: [
+      "raw_material_group_id",
+      "resolved_raw_material_id",
+      "note",
+      "metadata",
+    ],
+    inputSchema: obj(
+      {
+        id: STR("Design id, e.g. 'design_...'."),
+        raw_material_group_id: STR("Raw material group id to pin (required)."),
+        resolved_raw_material_id: STR(
+          "The specific colour/material chosen from the group, if decided."
+        ),
+        note: STR("Why this material, in the designer's words."),
+        metadata: { type: "object", description: "Free-form metadata." },
+      },
+      ["id", "raw_material_group_id"]
+    ),
+  },
+  {
+    name: "list_construction_techniques",
+    description:
+      "List the canonical construction techniques a design can use — slug, label, family, garment areas, tunable params and ready-made presets. Call this BEFORE add_design_construction_detail: only these slugs are accepted.",
+    method: "GET",
+    path: "/admin/designs/:id/construction-techniques",
+    pathParams: ["id"],
+    inputSchema: obj({ id: STR("Design id, e.g. 'design_...'.") }, ["id"]),
+    nextSteps: ["add_design_construction_detail"],
+  },
+  {
+    name: "list_design_construction_details",
+    description:
+      "List a design's construction details (its Construction specifications — the tech-pack construction frame).",
+    method: "GET",
+    path: "/admin/designs/:id/construction-details",
+    pathParams: ["id"],
+    inputSchema: obj({ id: STR("Design id, e.g. 'design_...'.") }, ["id"]),
+  },
+  {
+    name: "add_design_construction_detail",
+    description:
+      "Add a construction detail to a design (dart, pleat, gather, topstitch, yoke, embroidery...). `technique` MUST be a slug from list_construction_techniques — free text is rejected. Sensitive: requires confirm:true.",
+    method: "POST",
+    path: "/admin/designs/:id/construction-details",
+    pathParams: ["id"],
+    previewPath: "/admin/designs/:id/construction-details",
+    write: true,
+    sensitive: true,
+    bodyParams: ["technique", "label", "params", "fabricRules", "note"],
+    inputSchema: obj(
+      {
+        id: STR("Design id, e.g. 'design_...'."),
+        technique: STR(
+          "Technique slug from list_construction_techniques, e.g. 'dart', 'knife-pleat'."
+        ),
+        label: STR("Display label. Defaults to the technique's own label."),
+        params: {
+          type: "object",
+          description:
+            "Numeric params for the technique, e.g. { intake: 0.6 }. Omit to take the technique's defaults.",
+        },
+        fabricRules: {
+          type: "array",
+          items: { type: "string" },
+          description: "Sewing/fabric rules, e.g. 'press toward centre front'.",
+        },
+        note: STR("Anything the maker needs to know."),
+      },
+      ["id", "technique"]
+    ),
+    sideEffects:
+      "Creates a Construction specification on the design. Its params are the numbers the tech-pack renderer draws, so prefer a preset's values over invented ones.",
+  },
+  {
+    name: "update_design_brief",
+    description:
+      "Set a design's brief — the attributes that describe the idea rather than the garment: concept theme, aesthetic keywords, target persona, competitors, price point, budget and milestones. Partial: only the keys you pass change. Sensitive: requires confirm:true.",
+    method: "PUT",
+    path: "/admin/designs/:id/brief",
+    pathParams: ["id"],
+    previewPath: "/admin/designs/:id/brief",
+    write: true,
+    sensitive: true,
+    bodyParams: [
+      "concept_theme",
+      "aesthetic_keywords",
+      "persona",
+      "competitors",
+      "price_point",
+      "design_budget",
+      "cost_currency",
+      "milestones",
+    ],
+    inputSchema: obj(
+      {
+        id: STR("Design id, e.g. 'design_...'."),
+        concept_theme: STR("Short story/title for the concept, e.g. '90s Tokyo streetwear'."),
+        aesthetic_keywords: {
+          type: "array",
+          items: { type: "string" },
+          description: "3-5 keywords defining the look, e.g. ['utilitarian','nostalgic'].",
+        },
+        persona: {
+          type: "object",
+          description: "{ age_range, lifestyle, values[], pain_points[] }.",
+        },
+        competitors: {
+          type: "array",
+          items: { type: "object" },
+          description: "[{ name, url?, differentiator }].",
+        },
+        price_point: STR("'luxury' | 'mid_market' | 'budget'."),
+        design_budget: { type: "number", description: "Design-phase budget." },
+        cost_currency: STR("e.g. 'inr'."),
+        milestones: {
+          type: "array",
+          items: { type: "object" },
+          description: "[{ label, date? }] in order.",
+        },
+      },
+      ["id"]
+    ),
+  },
+  {
+    name: "search_pinterest",
+    description:
+      "Search Pinterest for reference images by keyword. Returns pins with image urls that can be read with read_image or recorded on a design as inspiration. Requires PINTEREST_ACCESS_TOKEN to be configured.",
+    method: "GET",
+    path: "/admin/pinterest",
+    queryParams: ["q", "bookmark"],
+    inputSchema: obj(
+      {
+        q: STR("Search query, e.g. 'indigo block print kurta'."),
+        bookmark: STR("Cursor from a previous response, for the next page."),
+      },
+      ["q"]
+    ),
+    nextSteps: ["read_image", "create_design"],
   },
 
   // ===== Tier 2: the first dangerous action ==============================

--- a/apps/backend/src/api/admin/mcp/lib/tool-slice.ts
+++ b/apps/backend/src/api/admin/mcp/lib/tool-slice.ts
@@ -58,6 +58,15 @@ const PREFIX_DOMAINS: ReadonlyArray<readonly [string, AdminToolDomain]> = [
   ["/admin/production-runs", "production"],
   ["/admin/inventory-items", "inventory"],
   ["/admin/inventory-orders", "inventory"],
+  ["/admin/raw-material-groups", "inventory"],
+  // Photo -> raw materials + inventory. Classified as inventory because that is
+  // what it CREATES; the image is just the input format.
+  ["/admin/ai/image-extraction", "inventory"],
+  // Reference-image search feeds design creation, so it lights up with designs.
+  ["/admin/pinterest", "designs"],
+  // Reading an attached image is domain-agnostic — it must be reachable from
+  // any conversation, so it lives in the always-present core slice.
+  ["/admin/assistant/vision", "core"],
   ["/admin/payments", "money"],
   ["/admin/publishing-campaigns", "marketing"],
   ["/admin/notifications", "marketing"],
@@ -113,6 +122,14 @@ const DOMAIN_KEYWORDS: Record<Exclude<AdminToolDomain, "core">, string[]> = {
     "size set", "size sets", "sizing", "measurement", "measurements",
     "colourway", "colorway", "revision", "revisions", "bom",
     "bill of materials", "work order", "work orders", "sample", "collection",
+    // The brief — attributes that describe the idea rather than the garment.
+    "brief", "concept", "aesthetic", "persona", "price point", "inspiration",
+    "reference", "pinterest", "mood board", "idea",
+    // Construction details. The technique nouns matter: an operator says
+    // "add a waist dart", never "add a construction detail".
+    "construction", "dart", "darts", "pleat", "pleats", "gather", "gathers",
+    "tuck", "tucks", "topstitch", "topstitching", "seam", "seams", "yoke",
+    "yokes", "embroidery", "silhouette", "garment",
   ],
   production: [
     "production", "production run", "production runs", "run", "runs",
@@ -124,6 +141,11 @@ const DOMAIN_KEYWORDS: Record<Exclude<AdminToolDomain, "core">, string[]> = {
     "inventory", "stock", "stocks", "raw material", "raw materials",
     "material", "materials", "fabric", "yarn", "warehouse", "location",
     "restock", "reorder", "purchase order",
+    // Material groups + the vocabulary of a physical delivery, which is what an
+    // operator photographs and asks us to file.
+    "material group", "material groups", "swatch", "swatches", "trim", "trims",
+    "bolt", "bolts", "roll", "rolls", "composition", "gsm", "yardage",
+    "meterage", "delivery note", "packing list", "unit cost", "moq",
   ],
   money: [
     "payment", "payments", "payout", "payouts", "invoice", "invoices",

--- a/apps/backend/src/api/middlewares.ts
+++ b/apps/backend/src/api/middlewares.ts
@@ -243,6 +243,7 @@ import { ListConversationsQuerySchema, ListMessagesQuerySchema, SendMessageSchem
 import { AdminAiChatReq } from "./admin/ai/chat/chat/validators";
 import { AdminAssistantChatSchema } from "./admin/assistant/chat/validators";
 import { AdminAssistantSummarizeSchema } from "./admin/assistant/summarize/validators";
+import { AdminAssistantVisionSchema } from "./admin/assistant/vision/validators";
 import { AdminPostDesignTaskAssignReq } from "./admin/designs/[id]/tasks/[taskId]/assign/validators";
 import { AdminPostPartnerTaskAssignReq } from "./admin/partners/[id]/tasks/[taskId]/assign/validators";
 import { AdminCreatePartnerTaskReq, AdminUpdatePartnerTaskReq } from "./admin/partners/[id]/tasks/validators";
@@ -3480,6 +3481,15 @@ export default defineMiddlewares({
       method: "POST",
       middlewares: [
         validateAndTransformBody(wrapSchema(AdminAssistantSummarizeSchema)),
+      ],
+    },
+    // Admin assistant on-demand image reading. Attaching a photo never sends
+    // pixels anywhere; this is the explicit "actually look at it" call.
+    {
+      matcher: "/admin/assistant/vision",
+      method: "POST",
+      middlewares: [
+        validateAndTransformBody(wrapSchema(AdminAssistantVisionSchema)),
       ],
     },
 


### PR DESCRIPTION
Closes part of #1238.

Two operator journeys drove this, and both turned out to be mostly **unreachable
plumbing rather than missing engines** — the routes existed, the assistant just
couldn't get to them:

1. *"here's a photo of what arrived"* → raw materials + inventory
2. *"here's an idea and a reference"* → design + attributes + construction
   details + materials + partner + production run

## Attachments are store-and-mention, not store-and-read

You can now attach images in the assistant. The model is told an attachment
**exists** — name, type, url — and never receives the pixels.

That isn't only a cost decision. The model configured for `ai_admin_assistant`
in prod is `@cf/zai-org/glm-5.2`, which is **text-only**, and Cloudflare's
failure mode for it is the dangerous one: hand it an `image_url` part and it
**silently drops the image and still returns HTTP 200**, so the model answers
blind and confidently. "Attach an image and let the assistant handle it" would
have shipped a feature that looks like it works.

Probed live against the prod CF account with a real handwritten weaver note
(`integration-tests/assets/sample-image.jpg`, true total **88885**):

| model | result |
|---|---|
| `@cf/zai-org/glm-5.2` (today's assistant model) | **image dropped, 200 OK** |
| `@cf/google/gemma-4-26b-a4b-it` (today's `ai_image_extraction`) | correct, 22–33s |
| `@cf/meta/llama-4-scout-17b-16e-instruct` | correct, ~5s, one digit misread |
| `@cf/meta/llama-3.2-11b-vision-instruct` | 403 — Meta licence not accepted |

## Reading is a separate, explicit act

`POST /admin/assistant/vision` resolves the `ai_image_extraction` role — the
same resolver inventory import-from-image (#769) already uses — and only runs
when the operator asks. It refuses the known text-only models **up front**
rather than trusting them to complain, and turns each observed failure into
something actionable: licence-gated model, rejected credentials, rate limit,
timeout, and the empty-content trap where a reasoning model spends its entire
budget in `reasoning_content` and returns `""` with `finish_reason: "length"`
(gemma-4 at a 700-token cap: 16s, empty string — reads exactly like a dead
provider).

## New tools — one registry row each, over routes that already existed

- **Materials from a photo:** `extract_inventory_from_image` (persist defaults
  false — preview first), `list_raw_materials`, `add_inventory_raw_material`,
  `list_raw_material_groups`, `create_raw_material_group`
- **Design ↔ materials:** `link_design_inventory` (the BOM — the workflow
  existed, only `list_` was exposed), `list/link_design_material_group`
- **Attributes + construction:** `update_design_brief`,
  `list_construction_techniques`, `list_design_construction_details`,
  `add_design_construction_detail` — `technique` must be a slug from the
  canonical `construction-techniques` catalog, so the model maps "gathered
  waist" onto a real slug instead of inventing prose the renderer can't draw
- **References:** `search_pinterest`, plus `inspiration_sources` and
  `thumbnail_url` forwarded on create/update design — the design route already
  accepted them, the tools just dropped the link the operator gave us

`read_image` lives in the **core** slice so an attachment works in any
conversation; everything else is reachable through the vocabulary operators
actually use (`swatches`, `waist dart`, `delivery note`), not just the domain
noun.

## Verification

- `126` unit tests pass, including 24 new ones covering the vision guards
  (every case is a measured failure, not a hypothetical) and tool
  reachability/gating
- `24` admin-mcp + `11` admin-assistant integration tests pass on the shared runner
- `tsc` at the **79** baseline — no new errors
- Every record-creating tool asserted `write: true` + `sensitive: true`, so each
  one surfaces an approval card and the model never self-confirms

## Not in this PR

- The partner assistant — this is admin-only for now; the plumbing is
  surface-agnostic and can be mirrored.
- Model choice is a real trade-off (gemma-4 accurate/slow vs llama-4-scout
  fast/slightly less accurate) so it resolves from the platform role and can be
  overridden per call, rather than being hardcoded.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
