### PR TITLE
fix(pinterest): wire the prod token, and stop dropping half the pins (#1238)

### DIFF
--- a/apps/backend/src/api/admin/mcp/lib/registry.ts
+++ b/apps/backend/src/api/admin/mcp/lib/registry.ts
@@ -2524,7 +2524,7 @@ export const ADMIN_MCP_TOOLS: AdminMcpToolDef[] = [
   {
     name: "search_pinterest",
     description:
-      "Search Pinterest for reference images by keyword. Returns pins with image urls that can be read with read_image or recorded on a design as inspiration. Requires PINTEREST_ACCESS_TOKEN to be configured.",
+      "Find reference images on Pinterest by keyword. Returns pins with image urls that can be read with read_image or recorded on a design as inspiration. Check the `source` field before reporting results: 'partner_search' is all of Pinterest, while 'own_pins' means only OUR OWN saved pins were searched — never say 'nothing exists on Pinterest' when the source was own_pins.",
     method: "GET",
     path: "/admin/pinterest",
     queryParams: ["q", "bookmark"],

--- a/apps/backend/src/api/admin/pinterest/route.ts
+++ b/apps/backend/src/api/admin/pinterest/route.ts
@@ -24,50 +24,135 @@ export const GET = async (req: MedusaRequest, res: MedusaResponse) => {
     throw new MedusaError(MedusaError.Types.INVALID_DATA, "Search query (q) is required")
   }
 
-  // Try partner search first (broader results), fall back to user pins
+  // Three tiers, widest first. Both search tiers are gated behind things a token
+  // alone cannot grant, so the third exists to keep this endpoint useful rather
+  // than returning an error for the common setup:
+  //
+  //   1. partner search — all of Pinterest. Needs the RESTRICTED `pin_search`
+  //      feature, which Pinterest grants per-app on request. Scopes don't help.
+  //   2. user pin search — the account's own pins, server-side query. Needs the
+  //      `boards:read_secret` + `pins:read_secret` scopes on the token, so a
+  //      token authorized without them fails here even though it works elsewhere.
+  //   3. own pins, filtered locally — needs only `pins:read`, which every token
+  //      has. For "design from a reference" this is often the BETTER source
+  //      anyway: the team's own saved board is curated, global search is not.
   let pins: any[] = []
   let nextBookmark: string | null = null
+  let source: "partner_search" | "user_search" | "own_pins" = "partner_search"
+  const unavailable: string[] = []
 
   try {
     const result = await searchPartnerPins(accessToken, query, bookmark)
     pins = result.pins
     nextBookmark = result.bookmark
-  } catch {
-    // Partner search not available — fall back to user's own pins
+  } catch (e: any) {
+    unavailable.push(`partner search (${e.message})`)
     try {
       const result = await searchUserPins(accessToken, query, bookmark)
       pins = result.pins
       nextBookmark = result.bookmark
-    } catch (e: any) {
-      throw new MedusaError(
-        MedusaError.Types.UNEXPECTED_STATE,
-        `Pinterest API error: ${e.message}`
-      )
+      source = "user_search"
+    } catch (e2: any) {
+      unavailable.push(`pin search (${e2.message})`)
+      try {
+        const result = await listOwnPins(accessToken, query, bookmark)
+        pins = result.pins
+        nextBookmark = result.bookmark
+        source = "own_pins"
+      } catch (e3: any) {
+        // Every tier failed — this is a real outage or a dead token, so say
+        // which rungs were tried instead of one opaque message.
+        throw new MedusaError(
+          MedusaError.Types.UNEXPECTED_STATE,
+          `Pinterest API error: ${e3.message}. Also unavailable: ${unavailable.join("; ")}`
+        )
+      }
     }
   }
 
   // Normalize to a clean response
-  const results = pins.map((pin: any) => ({
-    id: pin.id,
-    title: pin.title || "",
-    description: pin.description || "",
-    alt_text: pin.alt_text || "",
-    dominant_color: pin.dominant_color || null,
-    images: {
-      small: pin.media?.images?.["150x150"]?.url || null,
-      medium: pin.media?.images?.["400x300"]?.url || null,
-      large: pin.media?.images?.["600x"]?.url || null,
-      original: pin.media?.images?.["1200x"]?.url || pin.media?.images?.["600x"]?.url || null,
-    },
-    link: pin.link || null,
-    source: "pinterest",
-  }))
+  const results = pins.map((pin: any) => {
+    // Carousel pins (media_type "multiple_images") carry NO `media.images` —
+    // their sizes live on each entry of `media.items`. Reading only
+    // `media.images` returns null urls for every carousel, which on this account
+    // is 25 of 49 pins: over half the references, silently imageless. Fall back
+    // to the first slide, which is the one that represents the pin.
+    const images = pin.media?.images ?? pin.media?.items?.[0]?.images ?? {}
+    return {
+      id: pin.id,
+      title: pin.title || "",
+      description: pin.description || "",
+      alt_text: pin.alt_text || "",
+      dominant_color: pin.dominant_color || null,
+      images: {
+        small: images?.["150x150"]?.url || null,
+        medium: images?.["400x300"]?.url || null,
+        large: images?.["600x"]?.url || null,
+        original: images?.["1200x"]?.url || images?.["600x"]?.url || null,
+      },
+      // How many slides, so the assistant can say "this is a 4-image carousel"
+      // rather than pretending a single frame is the whole reference.
+      image_count: pin.media?.items?.length ?? (pin.media?.images ? 1 : 0),
+      link: pin.link || null,
+      source: "pinterest",
+    }
+  })
 
   res.json({
     pins: results,
     bookmark: nextBookmark,
     query,
+    // Which tier answered. The assistant surfaces this so an operator is never
+    // told "no results on Pinterest" when we actually only looked at our own 49
+    // saved pins.
+    source,
+    ...(unavailable.length ? { unavailable } : {}),
   })
+}
+
+/**
+ * Tier 3: the account's own pins, filtered client-side on title/description/
+ * alt_text. Needs only `pins:read`.
+ *
+ * Pinterest has no query parameter on GET /v5/pins, so the filtering happens
+ * here. That is fine at this scale (the account holds tens of pins, not
+ * thousands) and an empty query just returns the most recent pins — which is
+ * what "show me our references" should do.
+ */
+async function listOwnPins(
+  token: string,
+  query: string,
+  bookmark?: string
+): Promise<{ pins: any[]; bookmark: string | null }> {
+  const params = new URLSearchParams({ page_size: "50" })
+  if (bookmark) params.set("bookmark", bookmark)
+
+  const response = await fetch(`https://api.pinterest.com/v5/pins?${params}`, {
+    headers: { Authorization: `Bearer ${token}` },
+  })
+
+  if (!response.ok) {
+    throw new Error(`Listing own pins failed: ${response.status}`)
+  }
+
+  const data = await response.json()
+  const items: any[] = data.items || []
+
+  const needle = query.trim().toLowerCase()
+  const terms = needle ? needle.split(/\s+/) : []
+  const matches = terms.length
+    ? items.filter((pin) => {
+        const haystack = [pin.title, pin.description, pin.alt_text]
+          .filter(Boolean)
+          .join(" ")
+          .toLowerCase()
+        // Every term must appear — an OR match on "indigo block print" returns
+        // every pin mentioning "print", which is not a search.
+        return terms.every((t) => haystack.includes(t))
+      })
+    : items
+
+  return { pins: matches, bookmark: data.bookmark || null }
 }
 
 async function searchPartnerPins(

--- a/deploy/aws/copilot/medusa-server/manifest.yml
+++ b/deploy/aws/copilot/medusa-server/manifest.yml
@@ -254,6 +254,13 @@ secrets:
   X_CLIENT_SECRET: /jyt/prod/X_CLIENT_SECRET
   X_REDIRECT_URI: /jyt/prod/X_REDIRECT_URI
   X_SCOPE: /jyt/prod/X_SCOPE
+  # #1238 — reference images for the assistant's idea->design flow. Server only:
+  # /admin/pinterest is an admin API route, not a worker job.
+  #
+  # ⚠️ Pinterest v5 access tokens EXPIRE AFTER 30 DAYS, so this parameter needs
+  # rotating (put-parameter + a task roll) roughly monthly, or the route starts
+  # 401ing. Verify a replacement with GET /v5/user_account BEFORE writing it.
+  PINTEREST_ACCESS_TOKEN: /jyt/prod/PINTEREST_ACCESS_TOKEN
 
 # Logging — 14-day retention to keep CW costs down.
 logging:


### PR DESCRIPTION
Follow-up to #1242, which shipped `search_pinterest` against a route that had never run with a real token. Now it has.

## Token is set in prod

`/jyt/prod/PINTEREST_ACCESS_TOKEN` — SecureString, and **tagged**
`copilot-application=jyt` + `copilot-environment=prod` in the same sitting, so it
can't circuit-break the rollout the way an untagged param did in #315, #1083 and
#1163. Referenced from `medusa-server` only (`/admin/pinterest` is an admin API
route, not a worker job).

Verified **before** writing it: `GET /v5/user_account` → 200 (Jaal Yantra
Textiles, 49 pins, 2 boards).

## What the working token exposed

**1. Neither search endpoint is reachable — for two different reasons**, and the
route treated both as fatal:

| endpoint | result | fixable by? |
|---|---|---|
| `/v5/search/partner/pins` | `pin_search` is a **restricted feature** this app lacks | Pinterest granting it per-app |
| `/v5/search/pins` | missing scopes `boards:read_secret`, `pins:read_secret` | re-authorizing the token |

So added a third tier: list the account's own pins and filter locally, which
needs only `pins:read` — the scope every token has. For "design from a
reference", our own curated board is arguably the *better* source; global search
isn't curated. The response now reports which tier answered (`source`), and the
tool description tells the assistant never to report "nothing exists on
Pinterest" when it only searched our own pins.

**2. Carousel pins were silently imageless.** Pins with
`media_type: "multiple_images"` carry no `media.images` at all — the sizes live
on `media.items[].images` — so the normalizer returned `null` for every url. On
this account that's **25 of 49 pins**: over half the references came back with
nothing `read_image` could open. Falling back to the first slide:

```
usable image url BEFORE fix: 24/49
usable image url AFTER  fix: 49/49
```

`image_count` is also returned now, so the assistant can say "this is a 4-image
carousel" instead of passing off one frame as the whole reference.

## Verification

- Every tier exercised against the **live** API with the real token
- `tsc` at the 79 baseline; 44 unit tests pass
- Tag presence confirmed with `list-tags-for-resource` before the manifest entry

## Watch-out

⚠️ **Pinterest v5 access tokens expire after 30 days**, so this parameter needs
rotating roughly monthly or the route starts 401ing. The manifest says so at the
point of use. Storing Pinterest as a **social platform** row (like X/FBINSTA/
Facebook) instead would let rotation happen without a deploy — worth considering
separately.

🤖 Generated with [Claude Code](https://claude.com/claude-code)