### PR TITLE
feat(production-runs): render the run activity timeline, and put goods movement on it

### DIFF
--- a/apps/backend/src/admin/components/production-runs/production-run-activity-timeline.tsx
+++ b/apps/backend/src/admin/components/production-runs/production-run-activity-timeline.tsx
@@ -1,0 +1,214 @@
+import { Badge, Button, Container, Heading, Text } from "@medusajs/ui"
+import { useState } from "react"
+
+import {
+  AdminProductionRunActivity,
+  useProductionRunActivities,
+} from "../../hooks/api/production-runs"
+
+/**
+ * The run's activity stream (#1093 / #1228 / #1239).
+ *
+ * `GET /admin/production-runs/:id/activities` has been populated for a while —
+ * lifecycle transitions, reminder dispatches, reassignment escalations, admin
+ * output corrections, and goods transfers — but nothing rendered it, so an
+ * admin correcting a partner's reported output had no way to see that the
+ * correction had been recorded at all. This is that view.
+ *
+ * Ordered newest first, which is how the API returns it.
+ */
+
+const PAGE_SIZE = 20
+
+/** Dot colour by activity type — the coarsest signal, readable at a glance. */
+const DOT_CLASS: Record<string, string> = {
+  lifecycle_event: "bg-ui-tag-blue-icon",
+  reminder_sent: "bg-ui-tag-orange-icon",
+  note: "bg-ui-tag-purple-icon",
+  system: "bg-ui-fg-muted",
+}
+
+/** Kinds that deserve to stand out from ordinary lifecycle progress. */
+const NOTABLE_KINDS = new Set([
+  "output_corrected",
+  "cancelled",
+  "reassignment_needed",
+  "reminder_escalated",
+  "reminder_retried_same_partner",
+])
+
+const formatWhen = (value?: string | null) => {
+  if (!value) return "-"
+  const d = new Date(value)
+  if (Number.isNaN(d.getTime())) return "-"
+  return d.toLocaleString("en-US", {
+    month: "short",
+    day: "numeric",
+    year: "numeric",
+    hour: "2-digit",
+    minute: "2-digit",
+  })
+}
+
+const formatKind = (kind?: string | null) =>
+  String(kind || "").replace(/_/g, " ") || "-"
+
+/**
+ * The few payload fields worth surfacing inline. Everything else stays in the
+ * payload — this is a timeline, not a debugger.
+ */
+const detailLines = (activity: AdminProductionRunActivity): string[] => {
+  const payload = activity.payload || {}
+  const lines: string[] = []
+
+  if (payload.reason) {
+    lines.push(`Reason: ${payload.reason}`)
+  }
+  if (payload.notes) {
+    lines.push(String(payload.notes))
+  }
+  if (payload.rejection_reason) {
+    lines.push(`Rejected: ${payload.rejection_reason}`)
+  }
+  if (payload.cancelled_reason) {
+    lines.push(`Cancelled: ${payload.cancelled_reason}`)
+  }
+  if (activity.kind === "output_corrected" && payload.quantity != null) {
+    lines.push(`Ordered quantity: ${payload.quantity}`)
+  }
+  if (activity.template_name) {
+    lines.push(`Template: ${activity.template_name}`)
+  }
+  return lines
+}
+
+export const ProductionRunActivityTimeline = ({ runId }: { runId: string }) => {
+  const [limit, setLimit] = useState(PAGE_SIZE)
+
+  const {
+    activities = [],
+    count = 0,
+    isLoading,
+    isError,
+  } = useProductionRunActivities(
+    runId,
+    { limit },
+    { enabled: !!runId }
+  )
+
+  return (
+    <Container className="divide-y p-0">
+      <div className="flex items-center justify-between px-6 py-4">
+        <Heading level="h2">Activity</Heading>
+        {count > 0 && (
+          <Text size="small" className="text-ui-fg-muted">
+            {count} {count === 1 ? "entry" : "entries"}
+          </Text>
+        )}
+      </div>
+
+      <div className="px-6 py-4">
+        {isLoading && (
+          <div className="flex flex-col gap-3">
+            {[0, 1, 2].map((i) => (
+              <div key={i} className="flex gap-3">
+                <div className="mt-1 h-2 w-2 shrink-0 animate-pulse rounded-full bg-ui-bg-component" />
+                <div className="flex-1 space-y-2">
+                  <div className="h-3 w-1/2 animate-pulse rounded bg-ui-bg-component" />
+                  <div className="h-3 w-1/4 animate-pulse rounded bg-ui-bg-component" />
+                </div>
+              </div>
+            ))}
+          </div>
+        )}
+
+        {!isLoading && isError && (
+          <Text size="small" className="text-ui-fg-error">
+            Could not load this run's activity.
+          </Text>
+        )}
+
+        {!isLoading && !isError && activities.length === 0 && (
+          <Text size="small" className="text-ui-fg-subtle">
+            No activity recorded for this run yet.
+          </Text>
+        )}
+
+        {!isLoading && !isError && activities.length > 0 && (
+          <div className="relative flex flex-col gap-4">
+            {/* The rail. Stops short of the last dot so it doesn't dangle. */}
+            <div
+              className="absolute left-[3px] top-2 w-px bg-ui-border-base"
+              style={{ height: "calc(100% - 1.5rem)" }}
+              aria-hidden
+            />
+
+            {activities.map((activity) => {
+              const lines = detailLines(activity)
+              const notable = NOTABLE_KINDS.has(activity.kind)
+
+              return (
+                <div key={activity.id} className="relative flex gap-3">
+                  <div
+                    className={`mt-[6px] h-[7px] w-[7px] shrink-0 rounded-full ring-2 ring-ui-bg-base ${
+                      DOT_CLASS[activity.activity_type] || DOT_CLASS.system
+                    }`}
+                  />
+                  <div className="flex-1">
+                    <div className="flex flex-wrap items-center gap-x-2 gap-y-1">
+                      <Text
+                        size="small"
+                        weight={notable ? "plus" : "regular"}
+                        className={notable ? "text-ui-fg-base" : "text-ui-fg-subtle"}
+                      >
+                        {activity.summary || formatKind(activity.kind)}
+                      </Text>
+                      {activity.channel && (
+                        <Badge size="2xsmall" color="grey">
+                          {activity.channel}
+                        </Badge>
+                      )}
+                      {activity.actor_type === "admin" && (
+                        <Badge size="2xsmall" color="purple">
+                          admin
+                        </Badge>
+                      )}
+                    </div>
+
+                    {lines.map((line, i) => (
+                      <Text
+                        key={i}
+                        size="xsmall"
+                        className="text-ui-fg-muted mt-0.5"
+                      >
+                        {line}
+                      </Text>
+                    ))}
+
+                    <Text size="xsmall" className="text-ui-fg-muted mt-0.5">
+                      {formatWhen(activity.occurred_at)}
+                    </Text>
+                  </div>
+                </div>
+              )
+            })}
+          </div>
+        )}
+
+        {!isLoading && !isError && count > activities.length && (
+          <div className="pt-4">
+            <Button
+              size="small"
+              variant="secondary"
+              onClick={() => setLimit((l) => l + PAGE_SIZE)}
+            >
+              Show older activity
+            </Button>
+          </div>
+        )}
+      </div>
+    </Container>
+  )
+}
+
+export default ProductionRunActivityTimeline

--- a/apps/backend/src/admin/hooks/api/production-runs.ts
+++ b/apps/backend/src/admin/hooks/api/production-runs.ts
@@ -419,6 +419,59 @@ export const useProductionRunTask = (
   return { ...data, ...rest }
 }
 
+/**
+ * A row of the run's activity stream — lifecycle transitions, reminder
+ * dispatches, admin corrections, and goods movement. Written by
+ * `production-run-activity-recorder` and by the routes that act on a run.
+ */
+export type AdminProductionRunActivity = Record<string, any> & {
+  id: string
+  production_run_id: string
+  activity_type: "lifecycle_event" | "reminder_sent" | "note" | "system"
+  kind: string
+  actor_type?: string | null
+  actor_id?: string | null
+  partner_id?: string | null
+  channel?: string | null
+  template_name?: string | null
+  summary: string
+  payload?: Record<string, any> | null
+  occurred_at: string
+}
+
+export type AdminProductionRunActivitiesResponse = {
+  activities: AdminProductionRunActivity[]
+  count: number
+  limit: number
+  offset: number
+}
+
+export const useProductionRunActivities = (
+  runId: string,
+  query?: Record<string, any>,
+  options?: Omit<
+    UseQueryOptions<
+      AdminProductionRunActivitiesResponse,
+      FetchError,
+      AdminProductionRunActivitiesResponse,
+      QueryKey
+    >,
+    "queryFn" | "queryKey"
+  >
+) => {
+  const { data, ...rest } = useQuery({
+    queryKey: [...productionRunQueryKeys.detail(runId), "activities", query],
+    queryFn: async () =>
+      sdk.client.fetch<AdminProductionRunActivitiesResponse>(
+        `/admin/production-runs/${runId}/activities`,
+        { method: "GET", query }
+      ),
+    ...options,
+  })
+
+  return { ...data, ...rest }
+}
+
 export type AdminUpdateProductionRunTaskPayload = {
   title?: string
   description?: string

--- a/apps/backend/src/admin/routes/production-runs/[id]/page.tsx
+++ b/apps/backend/src/admin/routes/production-runs/[id]/page.tsx
@@ -30,6 +30,7 @@ import {
 import { TwoColumnPage } from "../../../components/pages/two-column-pages"
 import { TwoColumnPageSkeleton } from "../../../components/table/skeleton"
 import { ProductionRunChildrenSection } from "../../../components/production-runs/production-run-children-section"
+import { ProductionRunActivityTimeline } from "../../../components/production-runs/production-run-activity-timeline"
 import { productionRunLoader } from "./loader"
 import {
   useCancelProductionRun,
@@ -509,6 +510,8 @@ const ProductionRunDetailPage = () => {
             </div>
           </Container>
         )}
+
+        {id && <ProductionRunActivityTimeline runId={id} />}
       </TwoColumnPage.Main>
 
       <TwoColumnPage.Sidebar>

--- a/apps/backend/src/api/admin/production-runs/[id]/transfers/[transferId]/route.ts
+++ b/apps/backend/src/api/admin/production-runs/[id]/transfers/[transferId]/route.ts
@@ -1,0 +1,90 @@
+import { MedusaRequest, MedusaResponse } from "@medusajs/framework/http"
+import { ContainerRegistrationKeys, MedusaError } from "@medusajs/framework/utils"
+
+import { FULLFILLED_ORDERS_MODULE } from "../../../../../../modules/fullfilled_orders"
+import { PRODUCTION_RUNS_MODULE } from "../../../../../../modules/production_runs"
+
+/**
+ * DELETE /admin/production-runs/:id/transfers/:transferId
+ *
+ * Cancel a planned hop (#891). A transfer row is created BEFORE any carrier
+ * call so a failed booking leaves something visible to retry — which means a
+ * booking that is never retried leaves a `draft` behind forever, and the run's
+ * transfer list slowly fills with movements that never happened.
+ *
+ * Only a `draft` can be cancelled here. Once a carrier has been booked the
+ * movement is real and the AWB has been paid for: cancelling that is a carrier
+ * operation, not a row edit, and pretending otherwise would leave a live
+ * shipment tracking against a transfer we claim is cancelled.
+ *
+ * `cancelled` is terminal, and nothing is deleted — the row stays as the record
+ * that a hop was planned and abandoned.
+ */
+export const DELETE = async (
+  req: MedusaRequest & { params: { id: string; transferId: string } },
+  res: MedusaResponse
+) => {
+  const { id: runId, transferId } = req.params
+  const service: any = req.scope.resolve(FULLFILLED_ORDERS_MODULE)
+
+  const transfer = await service
+    .retrieveGoodsTransfer(transferId)
+    .catch(() => null)
+
+  if (!transfer || transfer.production_run_id !== runId) {
+    throw new MedusaError(
+      MedusaError.Types.NOT_FOUND,
+      `Goods transfer ${transferId} not found on production run ${runId}`
+    )
+  }
+
+  if (transfer.status === "cancelled") {
+    return res.status(200).json({ goods_transfer: transfer, message: "Already cancelled" })
+  }
+
+  if (transfer.status !== "draft") {
+    throw new MedusaError(
+      MedusaError.Types.NOT_ALLOWED,
+      `Only a draft transfer can be cancelled — this one is "${transfer.status}". Cancel the carrier shipment first.`
+    )
+  }
+
+  await service.updateGoodsTransfers({ id: transferId, status: "cancelled" })
+  const updated = await service.retrieveGoodsTransfer(transferId)
+
+  // Timeline row, best-effort — the cancellation is already persisted.
+  try {
+    const runService: any = req.scope.resolve(PRODUCTION_RUNS_MODULE)
+    await runService.createProductionRunActivities({
+      production_run_id: runId,
+      activity_type: "lifecycle_event",
+      kind: "goods_transfer_cancelled",
+      actor_type: "admin",
+      actor_id: (req as any).auth_context?.actor_id ?? null,
+      partner_id: null,
+      channel: null,
+      message_id: null,
+      template_name: null,
+      recipient: null,
+      summary: `Planned transfer of ${transfer.quantity} unit${
+        Number(transfer.quantity) === 1 ? "" : "s"
+      } cancelled before booking`,
+      payload: {
+        goods_transfer_id: transferId,
+        from_location_id: transfer.from_location_id,
+        to_location_id: transfer.to_location_id,
+        quantity: transfer.quantity,
+        reason: transfer.reason ?? null,
+      },
+      occurred_at: new Date(),
+    })
+  } catch (e: any) {
+    req.scope
+      .resolve(ContainerRegistrationKeys.LOGGER)
+      .error(
+        `[admin.production-runs] transfer ${transferId} cancelled but timeline write failed: ${e?.message}`
+      )
+  }
+
+  res.status(200).json({ goods_transfer: updated })
+}

--- a/apps/backend/src/api/admin/social-platforms/whatsapp/config/route.ts
+++ b/apps/backend/src/api/admin/social-platforms/whatsapp/config/route.ts
@@ -16,8 +16,11 @@ export const GET = async (req: MedusaRequest, res: MedusaResponse) => {
   let phoneInfo: any = null
   if (config.accessToken && config.phoneNumberId) {
     try {
+      // `name_status` and `is_official_business_account` are what gate the
+      // Groups API (#1245) — it is OBA-only — so they belong next to the rest
+      // of the number's standing rather than in a one-off script.
       phoneInfo = await graphApiRequest(
-        `${config.phoneNumberId}?fields=id,display_phone_number,verified_name,quality_rating,platform_type,account_mode`,
+        `${config.phoneNumberId}?fields=id,display_phone_number,verified_name,quality_rating,platform_type,account_mode,name_status,is_official_business_account`,
         config.accessToken
       )
     } catch { /* non-fatal */ }

--- a/apps/backend/src/workflows/production-runs/create-production-run-transfer.ts
+++ b/apps/backend/src/workflows/production-runs/create-production-run-transfer.ts
@@ -149,6 +149,70 @@ export async function resolveRunGoodsLocation(
   }
 }
 
+/**
+ * Put the hop on the run's timeline.
+ *
+ * A goods movement is exactly the kind of thing someone opening a run wants to
+ * see next to "partner marked the run finished" — but transfers used to write
+ * only a `goods_transfer` row, so the timeline showed the run being made and
+ * then nothing about the goods leaving. Best-effort throughout: the transfer
+ * (and any carrier booking it paid for) is already real, and must never be
+ * undone because an audit row failed to write.
+ */
+async function recordTransferActivity(
+  container: MedusaContainer,
+  run: { id: string; partner_id?: string | null },
+  transfer: ProductionRunTransferResult,
+  extra: { reason?: string; notes?: string | null }
+): Promise<void> {
+  const logger: any = container.resolve(ContainerRegistrationKeys.LOGGER)
+  try {
+    const runService: any = container.resolve(PRODUCTION_RUNS_MODULE)
+
+    const [from, to] = await Promise.all([
+      getStockLocation(container, transfer.from_location_id),
+      getStockLocation(container, transfer.to_location_id),
+    ])
+    const fromName = from?.name || transfer.from_location_id
+    const toName = to?.name || transfer.to_location_id
+
+    const summary = transfer.carrier
+      ? `${transfer.quantity} unit${transfer.quantity === 1 ? "" : "s"} shipped ${fromName} → ${toName} via ${transfer.carrier}${transfer.awb ? ` (AWB ${transfer.awb})` : ""}`
+      : `${transfer.quantity} unit${transfer.quantity === 1 ? "" : "s"} recorded moving ${fromName} → ${toName} (no carrier)`
+
+    await runService.createProductionRunActivities({
+      production_run_id: run.id,
+      activity_type: "lifecycle_event",
+      kind: transfer.carrier ? "goods_transfer_shipped" : "goods_transfer_recorded",
+      actor_type: "system",
+      actor_id: null,
+      partner_id: run.partner_id ?? null,
+      channel: null,
+      message_id: null,
+      template_name: null,
+      recipient: null,
+      summary,
+      payload: {
+        goods_transfer_id: transfer.transfer_id,
+        from_location_id: transfer.from_location_id,
+        to_location_id: transfer.to_location_id,
+        quantity: transfer.quantity,
+        reason: extra.reason ?? null,
+        notes: extra.notes ?? null,
+        carrier: transfer.carrier ?? null,
+        awb: transfer.awb ?? null,
+        tracking_url: transfer.tracking_url ?? null,
+        shipment_id: transfer.shipment_id ?? null,
+      },
+      occurred_at: new Date(),
+    })
+  } catch (e: any) {
+    logger.error(
+      `[goods-transfer] transfer ${transfer.transfer_id} saved but timeline write failed: ${e?.message}`
+    )
+  }
+}
+
 export async function createProductionRunTransfer(
   container: MedusaContainer,
   input: CreateProductionRunTransferInput
@@ -217,7 +281,13 @@ export async function createProductionRunTransfer(
   }
 
   // No carrier asked for → a self-driven hop. The transfer stands on its own.
-  if (!input.carrier) return base
+  if (!input.carrier) {
+    await recordTransferActivity(container, run, base, {
+      reason: input.reason,
+      notes: input.notes ?? null,
+    })
+    return base
+  }
 
   const carrier = input.carrier
   const provider = await resolveShippingProvider(container, carrier)
@@ -341,7 +411,7 @@ export async function createProductionRunTransfer(
     shipment_id: shipmentRecordId ?? null,
   })
 
-  return {
+  const shipped: ProductionRunTransferResult = {
     ...base,
     status: "in_transit",
     carrier,
@@ -350,6 +420,13 @@ export async function createProductionRunTransfer(
     label_url: result.label_url,
     shipment_id: shipmentRecordId,
   }
+
+  await recordTransferActivity(container, run, shipped, {
+    reason: input.reason,
+    notes: input.notes ?? null,
+  })
+
+  return shipped
 }
 
 const createProductionRunTransferStep = createStep(


### PR DESCRIPTION
## Why

`GET /admin/production-runs/:id/activities` has been populated since #1093 and
gained an `output_corrected` row in #1239 — and nothing has ever rendered it. An
admin correcting a partner's over-reported output got no confirmation the
correction landed, which is how `prod_run_01KYPM4G…` sat mis-reported for four
sessions. The data was always there.

## What

- **Run activity timeline.** `useProductionRunActivities` + a
  `ProductionRunActivityTimeline` section on the run detail page. Newest first,
  dot-coded by activity type, corrections/cancellations/escalations emphasised,
  `payload.reason` and reminder template surfaced, paged at 20.

- **Goods transfers now write to the timeline.** They wrote nothing before, so a
  run showed the goods being made and then silence about them leaving.
  `createProductionRunTransfer` records `goods_transfer_shipped` (or
  `goods_transfer_recorded` for a carrier-less hop) with location names, AWB and
  tracking url. Best-effort, matching the #1239 write — a booking that has been
  paid for is never rolled back because an audit row failed.

- **`DELETE /admin/production-runs/:id/transfers/:transferId`.** The transfer row
  is created *before* the carrier call by design, so a booking that is never
  retried leaves a `draft` behind with no way to clear it — prod already has one
  (`gtrf_01KZKM8CJZ0ZE35YWR5ZFESK41`). Drafts only: once an AWB exists the
  movement is real, and cancelling the row would leave a live shipment tracking
  against a transfer we claim is cancelled. Nothing is deleted; `cancelled` is
  terminal.

- **OBA fields on the WhatsApp config route.** `name_status` and
  `is_official_business_account`. The Groups API (#1245) is OBA-only, so this is
  the single fact that decides whether in-group partner commands are buildable —
  it belongs next to the number's other standing, not in a one-off script.

## Verification

Against prod (`v3.jaalyantra.com`):

- Run `prod_run_01KYPM4G2S85PX61HT25T8BFDT` returns **11 activities**, newest
  `note / output_corrected — "Admin corrected reported output: produced 9 → 3"`.
- A **live Delhivery goods transfer** booked end to end:
  `gtrf_01KZP7C2SJ21R81GCFZNSY66RC`, AWB **41712510000103**, Shramdaan India
  Warehouse → Dharamshala, 3 units / 1200 g, `in_transit`, with the
  `inventory_shipment` row the tracking webhook matches on.

`tsc` clean on all six files (backlog unchanged); the 31 production-run workflow
unit tests pass.

## Follow-ups, not in this PR

- The prod draft transfer can only be cancelled once this deploys — the route
  doesn't exist in prod yet.
- **#891 S3 is still open**: inventory does not follow the goods. This transfer
  moved 3 units on paper and via a carrier; no inventory level changed at either
  location.
- The `/jyt/prod/WHATSAPP_ACCESS_TOKEN` SSM parameter **expired 2026-06-09**.
  Harmless today — prod reads the encrypted `social_platform` row — but it is a
  dead fallback that would fail silently if the row ever went missing.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
