### PR TITLE
fix(inventory-orders): repair reversed order routes, and give the assistant the ops surface

### DIFF
--- a/apps/backend/src/api/admin/mcp/lib/registry.ts
+++ b/apps/backend/src/api/admin/mcp/lib/registry.ts
@@ -2538,6 +2538,63 @@ export const ADMIN_MCP_TOOLS: AdminMcpToolDef[] = [
     nextSteps: ["read_image", "create_design"],
   },
 
+  // ===== Data Plumbing (audited operational corrections) ==================
+  // These wrap the #457 maintenance-job surface. Every run is persisted to
+  // `ops_maintenance_run` with the acting admin, so assistant-driven repairs
+  // carry the same audit trail as hand-run ones.
+  {
+    name: "list_maintenance_jobs",
+    description:
+      "List the available Data Plumbing maintenance jobs — audited, guarded data corrections (repair a reversed inventory-order route, backfill a field, reconcile a mirror). Returns each job's id, label, description and parameter schema. Start here when an operator reports data that looks wrong rather than code that looks wrong.",
+    method: "GET",
+    path: "/admin/ops/maintenance-jobs",
+    inputSchema: obj({}),
+    nextSteps: ["run_maintenance_job", "list_maintenance_job_runs"],
+  },
+  {
+    name: "list_maintenance_job_runs",
+    description:
+      "Read the maintenance-job audit log — who ran what, when, dry-run or applied, and the change set. Use it to check whether a repair has already been attempted before running another.",
+    method: "GET",
+    path: "/admin/ops/maintenance-jobs/runs",
+    queryParams: ["limit", "offset", "job_id"],
+    inputSchema: obj({
+      ...PAGINATION,
+      job_id: STR("Only runs of this job id, e.g. 'repair-inventory-order-route'."),
+    }),
+  },
+  {
+    name: "run_maintenance_job",
+    description:
+      "Run a Data Plumbing maintenance job. SAFE BY DEFAULT: dry_run defaults to true and previews the exact change set without writing — always preview and show the operator the changes before applying. Pass dry_run:false to apply, which requires confirm:true. Per-job params are validated by the job itself; call list_maintenance_jobs first for the schema.",
+    method: "POST",
+    path: "/admin/ops/maintenance-jobs/:id/run",
+    pathParams: ["id"],
+    bodyParams: ["dry_run", "params"],
+    write: true,
+    sensitive: true,
+    inputSchema: obj(
+      {
+        id: STR("Maintenance job id, e.g. 'repair-inventory-order-route'."),
+        dry_run: {
+          type: "boolean",
+          description:
+            "Preview only. Defaults to true — pass false to actually apply.",
+        },
+        params: {
+          type: "object",
+          description:
+            "Job-specific parameters. See the job's `params` from list_maintenance_jobs.",
+          additionalProperties: true,
+        },
+      },
+      ["id"]
+    ),
+    sideEffects:
+      "With dry_run:false, mutates production data as described by the job. Every run is written to the ops_maintenance_run audit log.",
+    nextSteps: ["list_maintenance_job_runs"],
+  },
+
   // ===== Tier 2: the first dangerous action ==============================
   // Platform-destructive: hidden + refused unless ADMIN_MCP_ENABLE_DANGEROUS is
   // on, and even then requires BOTH confirm:true AND a human-supplied reason.

--- a/apps/backend/src/api/admin/mcp/lib/tool-slice.ts
+++ b/apps/backend/src/api/admin/mcp/lib/tool-slice.ts
@@ -42,6 +42,9 @@ export type AdminToolDomain =
 const PREFIX_DOMAINS: ReadonlyArray<readonly [string, AdminToolDomain]> = [
   ["/admin/mcp/usage", "observability"],
   ["/admin/mcp", "core"],
+  // Data Plumbing / maintenance jobs are audited operational corrections, so
+  // they ride the observability slice alongside the usage ledger.
+  ["/admin/ops", "observability"],
   ["/admin/orders", "orders"],
   ["/admin/order-edits", "orders"],
   ["/admin/products", "catalog"],
@@ -159,6 +162,12 @@ const DOMAIN_KEYWORDS: Record<Exclude<AdminToolDomain, "core">, string[]> = {
   observability: [
     "mcp", "tool usage", "telemetry", "observability", "ledger", "audit",
     "failing", "failures", "error rate",
+    // Data Plumbing vocabulary. An operator describing a data problem rarely
+    // says "maintenance job" — they say "the stock is wrong" or "reversed", so
+    // the repair words matter more than the product name.
+    "maintenance job", "maintenance jobs", "data plumbing", "backfill",
+    "backfills", "repair", "reconcile", "reconciliation", "dry run", "dry-run",
+    "reversed", "mis-assigned", "wrong location", "wrong warehouse",
   ],
 }
 

--- a/apps/backend/src/api/admin/ops/maintenance-jobs/__tests__/repair-inventory-order-route.unit.spec.ts
+++ b/apps/backend/src/api/admin/ops/maintenance-jobs/__tests__/repair-inventory-order-route.unit.spec.ts
@@ -1,0 +1,107 @@
+import { planRouteRepair } from "../repair-inventory-order-route-job"
+
+/**
+ * repair-inventory-order-route planner. Pure: no container/DB.
+ *
+ * The scenario behind it: `inv_order_01KVCT5Z…` stored its ends reversed —
+ * from=Dharamshala (ours) / to=Shramdaan (the weaver) for 17.6 m of fabric that
+ * was woven at Shramdaan and delivered to Dharamshala. Delivery posted the
+ * stock at the reversed destination, so the material never showed up in our own
+ * warehouse. `repair-inventory-order-source` cannot fix this: a reversal is
+ * precisely the case where the correct source IS the current destination, which
+ * that job blocks on.
+ */
+describe("planRouteRepair", () => {
+  const base = {
+    orderId: "inv_order_1",
+    current: { fromId: "sloc_ours", toId: "sloc_weaver" },
+    target: { fromId: "sloc_weaver", toId: "sloc_ours" },
+  }
+
+  it("plans both ends for a reversed order", () => {
+    const { changes, blocker } = planRouteRepair(base)
+    expect(blocker).toBeUndefined()
+    expect(changes).toEqual([
+      {
+        entity: "inventory_order",
+        id: "inv_order_1",
+        field: "from_stock_location (link)",
+        before: "sloc_ours",
+        after: "sloc_weaver",
+      },
+      {
+        entity: "inventory_order",
+        id: "inv_order_1",
+        field: "to_stock_location (link)",
+        before: "sloc_weaver",
+        after: "sloc_ours",
+      },
+    ])
+  })
+
+  it("is a no-op when the route already points the right way", () => {
+    const { changes, blocker } = planRouteRepair({
+      ...base,
+      current: { fromId: "sloc_weaver", toId: "sloc_ours" },
+    })
+    expect(blocker).toBeUndefined()
+    expect(changes).toEqual([])
+  })
+
+  it("plans only the end that moved", () => {
+    const { changes } = planRouteRepair({
+      ...base,
+      current: { fromId: "sloc_weaver", toId: "sloc_wrong" },
+    })
+    expect(changes).toHaveLength(1)
+    expect(changes[0].field).toBe("to_stock_location (link)")
+  })
+
+  it("blocks when source and destination are the same location", () => {
+    const { changes, blocker } = planRouteRepair({
+      ...base,
+      target: { fromId: "sloc_ours", toId: "sloc_ours" },
+    })
+    expect(changes).toEqual([])
+    expect(blocker).toMatch(/originate at its own destination/)
+  })
+
+  it("blocks when the order is missing an end and none was supplied", () => {
+    const { changes, blocker } = planRouteRepair({
+      ...base,
+      current: { fromId: "sloc_ours", toId: null },
+      target: { fromId: "sloc_ours", toId: null },
+    })
+    expect(changes).toEqual([])
+    expect(blocker).toMatch(/missing one end/)
+  })
+
+  it("syncs the unified-order display mirror to the target source", () => {
+    const { changes } = planRouteRepair({
+      ...base,
+      unified: { id: "order_1", fromInMetadata: "sloc_ours" },
+    })
+    const mirror = changes.find(
+      (c) => c.field === "metadata.from_stock_location_id"
+    )
+    expect(mirror).toEqual({
+      entity: "order",
+      id: "order_1",
+      field: "metadata.from_stock_location_id",
+      before: "sloc_ours",
+      after: "sloc_weaver",
+    })
+  })
+
+  it("converges the mirror on a re-run after a partial apply", () => {
+    // Links already fixed, mirror still stale — the mirror is compared against
+    // the TARGET, not the current link, so the re-run still plans it.
+    const { changes } = planRouteRepair({
+      ...base,
+      current: { fromId: "sloc_weaver", toId: "sloc_ours" },
+      unified: { id: "order_1", fromInMetadata: "sloc_ours" },
+    })
+    expect(changes).toHaveLength(1)
+    expect(changes[0].field).toBe("metadata.from_stock_location_id")
+  })
+})

--- a/apps/backend/src/api/admin/ops/maintenance-jobs/registry.ts
+++ b/apps/backend/src/api/admin/ops/maintenance-jobs/registry.ts
@@ -89,6 +89,7 @@ import { backfillRetailPartnerFeesJob } from "./backfill-retail-partner-fees-job
 import { recomputeEmailEngagementStatusJob } from "./recompute-email-engagement-status-job"
 import { generateNewsletterWinbackTargetsJob } from "./generate-newsletter-winback-targets-job"
 import { repairInventoryOrderSourceJob } from "./repair-inventory-order-source-job"
+import { repairInventoryOrderRouteJob } from "./repair-inventory-order-route-job"
 import { backfillGoogleAdsHistoryJob } from "./backfill-google-ads-history-job"
 import { backfillDesignSizeSetsJob } from "./backfill-design-size-sets-job"
 import { backfillPartnerShippingOptionsJob } from "./backfill-partner-shipping-options-job"
@@ -5647,6 +5648,7 @@ export const MAINTENANCE_JOBS: MaintenanceJob[] = [
   recomputeEmailEngagementStatusJob,
   generateNewsletterWinbackTargetsJob,
   repairInventoryOrderSourceJob,
+  repairInventoryOrderRouteJob,
   backfillGoogleAdsHistoryJob,
   backfillDesignSizeSetsJob,
   backfillPartnerShippingOptionsJob,

--- a/apps/backend/src/api/admin/ops/maintenance-jobs/repair-inventory-order-route-job.ts
+++ b/apps/backend/src/api/admin/ops/maintenance-jobs/repair-inventory-order-route-job.ts
@@ -1,0 +1,302 @@
+import {
+  ContainerRegistrationKeys,
+  MedusaError,
+  Modules,
+} from "@medusajs/framework/utils"
+import { z } from "@medusajs/framework/zod"
+
+import {
+  getInventoryOrderRoute,
+  setInventoryOrderRoute,
+} from "../../../../workflows/inventory_orders/lib/repoint-route"
+import type { MaintenanceChange, MaintenanceJob, MaintenanceJobResult } from "./registry"
+
+/**
+ * Data Plumbing — repair an inventory order's ROUTE (both ends: ship-from and
+ * deliver-to), including the reversed-order case.
+ *
+ * `repair-inventory-order-source` moves only the FROM end, and refuses when the
+ * requested source is the order's current destination. That refusal is correct
+ * for its own job — but it makes a *reversed* order unrepairable, because a
+ * reversal is exactly the case where the correct source is the current
+ * destination. Nothing else writes the to-link: the PUT route silently drops
+ * `to_stock_location_id` (it isn't in the update workflow's acted-on set) and is
+ * gated to Pending/Processing besides, so a Shipped/Delivered order has no
+ * repair path at all today.
+ *
+ * Found via `inv_order_01KVCT5Z…` (17.6 m FAB-HAN-IND-001): stored
+ * from=Dharamshala / to=Shramdaan when the fabric was woven at Shramdaan and
+ * delivered to Dharamshala. Delivery posted the stock at the reversed
+ * destination, so the material sat at the partner's location and never appeared
+ * in our own warehouse.
+ *
+ * ⚠️ This job repairs LINKS ONLY. It deliberately does not move inventory:
+ * `metadata.partner_delivered_lines` records `{order_line_id, quantity}` with no
+ * location, so a re-delivery after the fix computes `remaining = 0` and posts
+ * nothing. Stock already sitting at the wrong location must be corrected
+ * separately via the location-levels endpoints. The summary says so on every
+ * applied run.
+ *
+ * Dry-run (default) previews the change set without writing.
+ */
+
+const paramsSchema = z
+  .object({
+    order_id: z.string().min(1, "order_id is required"),
+    from_stock_location_id: z.string().min(1).optional(),
+    to_stock_location_id: z.string().min(1).optional(),
+    swap: z.boolean().optional().default(false),
+  })
+  .refine(
+    (v) => v.swap || v.from_stock_location_id || v.to_stock_location_id,
+    "provide swap:true, or at least one of from_stock_location_id / to_stock_location_id"
+  )
+  .refine(
+    (v) => !(v.swap && (v.from_stock_location_id || v.to_stock_location_id)),
+    "swap:true reverses the order's existing ends — do not also pass explicit locations"
+  )
+
+export type RouteRepairPlanInput = {
+  orderId: string
+  current: { fromId: string | null; toId: string | null }
+  target: { fromId: string | null; toId: string | null }
+  /**
+   * The unified core-order mirror (#342). Its `metadata.from_stock_location_id`
+   * is a display copy the partner UI reads, and goes stale when the from-link
+   * moves.
+   */
+  unified?: { id: string; fromInMetadata: string | null } | null
+}
+
+/**
+ * PURE: plan the repair, or explain why it must not run. Exported for tests.
+ */
+export function planRouteRepair(
+  input: RouteRepairPlanInput
+): { changes: MaintenanceChange[]; blocker?: string } {
+  const { fromId, toId } = input.target
+
+  if (!fromId || !toId) {
+    return {
+      changes: [],
+      blocker:
+        "the order is missing one end of its route — pass both from_stock_location_id and to_stock_location_id explicitly",
+    }
+  }
+  if (fromId === toId) {
+    return {
+      changes: [],
+      blocker:
+        "source and destination are the same stock location — a shipment cannot originate at its own destination",
+    }
+  }
+
+  const changes: MaintenanceChange[] = []
+
+  if (input.current.fromId !== fromId) {
+    changes.push({
+      entity: "inventory_order",
+      id: input.orderId,
+      field: "from_stock_location (link)",
+      before: input.current.fromId,
+      after: fromId,
+    })
+  }
+  if (input.current.toId !== toId) {
+    changes.push({
+      entity: "inventory_order",
+      id: input.orderId,
+      field: "to_stock_location (link)",
+      before: input.current.toId,
+      after: toId,
+    })
+  }
+
+  // Compared against the TARGET so a re-run after a partial apply still
+  // converges the mirror.
+  if (input.unified && input.unified.fromInMetadata !== fromId) {
+    changes.push({
+      entity: "order",
+      id: input.unified.id,
+      field: "metadata.from_stock_location_id",
+      before: input.unified.fromInMetadata,
+      after: fromId,
+    })
+  }
+
+  return { changes }
+}
+
+export const repairInventoryOrderRouteJob: MaintenanceJob = {
+  id: "repair-inventory-order-route",
+  label: "Repair inventory-order route (ship-from / deliver-to, incl. reversed)",
+  description:
+    "Rewrite both ends of an inventory order's stock-location route. Handles the reversed-order case that repair-inventory-order-source cannot (it refuses when the correct source is the current destination) and the to-link that no route writes at all. Pass swap:true to reverse the existing ends, or set from/to explicitly. Ungated by order status. Repairs LINKS ONLY — stock already posted at the wrong location must be corrected via the location-levels endpoints. Dry-run previews the change set.",
+  params: [
+    {
+      name: "order_id",
+      type: "string",
+      required: true,
+      description: "ID of the inventory order to repair",
+    },
+    {
+      name: "swap",
+      type: "boolean",
+      required: false,
+      description:
+        "Reverse the order's existing ends (the reversed-order fix). Cannot be combined with explicit locations.",
+    },
+    {
+      name: "from_stock_location_id",
+      type: "string",
+      required: false,
+      description: "The CORRECT source stock location the order ships from",
+    },
+    {
+      name: "to_stock_location_id",
+      type: "string",
+      required: false,
+      description: "The CORRECT destination stock location the order delivers to",
+    },
+  ],
+  run: async (container, { dry_run, params }): Promise<MaintenanceJobResult> => {
+    const parsed = paramsSchema.safeParse(params)
+    if (!parsed.success) {
+      throw new MedusaError(
+        MedusaError.Types.INVALID_DATA,
+        parsed.error.issues.map((i) => i.message).join("; ")
+      )
+    }
+    const { order_id, from_stock_location_id, to_stock_location_id, swap } =
+      parsed.data
+
+    const query: any = container.resolve(ContainerRegistrationKeys.QUERY)
+
+    const { data: orders } = await query.graph({
+      entity: "inventory_orders",
+      fields: ["id", "status"],
+      filters: { id: order_id },
+    })
+    const order = orders?.[0]
+    if (!order) {
+      throw new MedusaError(
+        MedusaError.Types.NOT_FOUND,
+        `Inventory order not found: ${order_id}`
+      )
+    }
+
+    const current = await getInventoryOrderRoute(container, order_id)
+
+    const target = swap
+      ? { fromId: current.toId, toId: current.fromId }
+      : {
+          fromId: from_stock_location_id ?? current.fromId,
+          toId: to_stock_location_id ?? current.toId,
+        }
+
+    // Both ends must be live (non-deleted) stock locations.
+    for (const [label, id] of [
+      ["from_stock_location_id", target.fromId],
+      ["to_stock_location_id", target.toId],
+    ] as const) {
+      if (!id) {
+        continue
+      }
+      const { data: locs } = await query.graph({
+        entity: "stock_location",
+        fields: ["id", "name"],
+        filters: { id },
+      })
+      if (!locs?.[0]) {
+        throw new MedusaError(
+          MedusaError.Types.NOT_FOUND,
+          `Stock location not found (or deleted) for ${label}: ${id}`
+        )
+      }
+    }
+
+    // The unified core-order mirror carries a display copy of
+    // from_stock_location_id that the partner UI reads.
+    let unifiedOrder: { id: string; metadata: Record<string, any> | null } | null =
+      null
+    try {
+      const { data: withOrder } = await query.graph({
+        entity: "inventory_orders",
+        fields: ["order.id", "order.metadata"],
+        filters: { id: order_id },
+      })
+      const raw = withOrder?.[0]?.order
+      const unified = Array.isArray(raw) ? raw[0] : raw
+      if (unified?.id) {
+        unifiedOrder = { id: unified.id, metadata: unified.metadata ?? null }
+      }
+    } catch {
+      // No unified mirror (pre-#342 order) — nothing to sync.
+    }
+
+    const plan = planRouteRepair({
+      orderId: order_id,
+      current,
+      target,
+      unified: unifiedOrder
+        ? {
+            id: unifiedOrder.id,
+            fromInMetadata:
+              (unifiedOrder.metadata as any)?.from_stock_location_id ?? null,
+          }
+        : null,
+    })
+    if (plan.blocker) {
+      throw new MedusaError(MedusaError.Types.NOT_ALLOWED, plan.blocker)
+    }
+
+    const linkChanged = plan.changes.some((c) =>
+      String(c.field).endsWith("(link)")
+    )
+
+    if (!dry_run && plan.changes.length > 0) {
+      if (linkChanged) {
+        await setInventoryOrderRoute(
+          container,
+          order_id,
+          target.fromId as string,
+          target.toId as string
+        )
+      }
+      if (
+        unifiedOrder &&
+        plan.changes.some((c) => c.field === "metadata.from_stock_location_id")
+      ) {
+        // The ORDER module's updateOrders REPLACES metadata wholesale —
+        // read-then-merge so the unification keys survive.
+        const orderService: any = container.resolve(Modules.ORDER)
+        await orderService.updateOrders([
+          {
+            id: unifiedOrder.id,
+            metadata: {
+              ...(unifiedOrder.metadata || {}),
+              from_stock_location_id: target.fromId,
+            },
+          },
+        ])
+      }
+    }
+
+    const summary =
+      plan.changes.length === 0
+        ? `No changes — order ${order_id} already routes ${target.fromId} → ${target.toId}`
+        : `${dry_run ? "Would apply" : "Applied"} ${plan.changes.length} change(s) on order ${order_id}: ${current.fromId} → ${current.toId} becomes ${target.fromId} → ${target.toId}.${
+            linkChanged
+              ? " Links only — stock already posted at the previous destination is NOT moved; correct it via the location-levels endpoints."
+              : ""
+          }`
+
+    return {
+      job_id: repairInventoryOrderRouteJob.id,
+      dry_run,
+      applied: !dry_run && plan.changes.length > 0,
+      summary,
+      changes: plan.changes,
+    }
+  },
+}

--- a/apps/backend/src/workflows/inventory_orders/lib/repoint-route.ts
+++ b/apps/backend/src/workflows/inventory_orders/lib/repoint-route.ts
@@ -1,0 +1,95 @@
+import { ContainerRegistrationKeys, Modules } from "@medusajs/framework/utils"
+import type { MedusaContainer } from "@medusajs/framework/types"
+import type { Link } from "@medusajs/modules-sdk"
+import { ORDER_INVENTORY_MODULE } from "../../../modules/inventory_orders"
+import inventoryOrdersStockLocations from "../../../links/inventory-orders-stock-locations"
+
+export type InventoryOrderRoute = {
+  fromId: string | null
+  toId: string | null
+}
+
+/**
+ * Read BOTH ends of the order↔stock-location link in one pass.
+ *
+ * `repoint-from-location.ts` reads only the from-link because the PUT path can
+ * only ever move that end. Repairing a *reversed* order needs both, and needs
+ * them from a single read so the two ends can't be observed at different times.
+ */
+export async function getInventoryOrderRoute(
+  container: MedusaContainer,
+  orderId: string
+): Promise<InventoryOrderRoute> {
+  const query: any = container.resolve(ContainerRegistrationKeys.QUERY)
+  const { data: links } = await query.graph({
+    entity: (inventoryOrdersStockLocations as any).entryPoint,
+    fields: ["stock_location_id", "from_location", "to_location"],
+    filters: { inventory_orders_id: orderId },
+  })
+  const rows = (links || []) as any[]
+  return {
+    fromId: rows.find((l) => l?.from_location)?.stock_location_id ?? null,
+    toId: rows.find((l) => l?.to_location)?.stock_location_id ?? null,
+  }
+}
+
+/**
+ * Rewrite both ends of an inventory order's route to (`fromId`, `toId`).
+ *
+ * Why this exists alongside `repointInventoryOrderFromLink`: that helper moves
+ * one end at a time, which cannot express a **swap**. Dismissal is keyed on
+ * `(order, stock_location)` — not on the direction flag — so moving one end of
+ * a reversed pair first either dismisses the row the other end still needs, or
+ * leaves two rows for the same location carrying contradictory flags. Both ends
+ * are therefore torn down before either is rebuilt.
+ *
+ * Idempotent: a route already pointing the right way is a no-op.
+ */
+export async function setInventoryOrderRoute(
+  container: MedusaContainer,
+  orderId: string,
+  fromId: string,
+  toId: string
+): Promise<{ changed: boolean; previous: InventoryOrderRoute }> {
+  const remoteLink = container.resolve(ContainerRegistrationKeys.LINK) as Link
+  const previous = await getInventoryOrderRoute(container, orderId)
+
+  if (previous.fromId === fromId && previous.toId === toId) {
+    return { changed: false, previous }
+  }
+
+  // Tear down every existing end first. Dismissing a location that is about to
+  // be re-created is deliberate — see the docblock above.
+  const stale = [previous.fromId, previous.toId].filter(
+    (id, i, all): id is string => Boolean(id) && all.indexOf(id) === i
+  )
+  for (const locationId of stale) {
+    await remoteLink.dismiss({
+      [ORDER_INVENTORY_MODULE]: { inventory_orders_id: orderId },
+      [Modules.STOCK_LOCATION]: { stock_location_id: locationId },
+    })
+  }
+
+  await remoteLink.create({
+    [ORDER_INVENTORY_MODULE]: { inventory_orders_id: orderId },
+    [Modules.STOCK_LOCATION]: { stock_location_id: fromId },
+    data: {
+      order_id: orderId,
+      stock_location_id: fromId,
+      from_location: true,
+      to_location: false,
+    },
+  })
+  await remoteLink.create({
+    [ORDER_INVENTORY_MODULE]: { inventory_orders_id: orderId },
+    [Modules.STOCK_LOCATION]: { stock_location_id: toId },
+    data: {
+      order_id: orderId,
+      stock_location_id: toId,
+      from_location: false,
+      to_location: true,
+    },
+  })
+
+  return { changed: true, previous }
+}


### PR DESCRIPTION
## The bug

`inv_order_01KVCT5Z00E39M511Z7MTEFFMN` — 17.6 m of `FAB-HAN-IND-001`, woven at
**Shramdaan** and delivered to **Dharamshala** — stored its ends reversed:

```
from_stock_location = Dharamshala   (should be Shramdaan)
to_stock_location   = Shramdaan     (should be Dharamshala)
```

Delivery posts stock at whatever the to-link says, so the 17.6 m landed at the
weaver's location and never appeared in our own warehouse. Downstream, the
design that consumed it ("Denim Trouser", `01KWWJ0S3ZWWNK6YTDSC2AFARQ`) looked
like a phantom — completed run, a **committed** 2.15 m consumption log, and an
inventory level that never moved.

Corroborating signal: of all 15 inventory orders on prod, this is the only one
whose links list the supplier location before Dharamshala.

## Why nothing could fix it

- `PUT /admin/inventory-orders/:id` **silently drops `to_stock_location_id`** —
  only `from_stock_location_id` is in the update workflow's acted-on set
  (`update-inventory-orders.ts`, `LINK_ONLY_UPDATE_FIELDS`). It is also gated to
  `Pending`/`Processing`, so a `Shipped` order never reaches it.
- `repair-inventory-order-source` moves only the from-end and **blocks when the
  requested source is the current destination** (`planSourceRepair`) — which is
  precisely what a reversal looks like.

So the to-link had no writer anywhere in the codebase.

## What this adds

**`repair-inventory-order-route`** — rewrites both ends at once, ungated by
order status, dry-run by default.

It has to be both-at-once. `remoteLink.dismiss` is keyed on
`(order, stock_location)`, **not** on the direction flag, so moving one end of a
reversed pair first either dismisses the row the other end still needs, or
leaves two rows for one location carrying contradictory flags.
`setInventoryOrderRoute` tears both ends down before rebuilding either.
`swap: true` expresses the reversal without retyping ids that are easy to get
backwards.

Guards: both ends must be live locations; source ≠ destination; blocks when the
order is missing an end and none was supplied. Syncs the #342 unified-order
`metadata.from_stock_location_id` mirror, compared against the target so a
re-run after a partial apply still converges.

**Links only, and it says so on every applied run.**
`metadata.partner_delivered_lines` records `{order_line_id, quantity}` with no
location, so re-delivery after the fix computes `remaining = 0` and posts
nothing. Stock already at the wrong location stays there until someone moves it.

**MCP/ops tools.** There were **no** `/admin/ops` tools in the registry, so the
assistant could not reach any maintenance job. Adds `list_maintenance_jobs`,
`list_maintenance_job_runs`, `run_maintenance_job` (write + sensitive; inherits
the route's `dry_run`-defaults-true so a preview is the natural first call), and
maps `/admin/ops` → `observability`. The keywords lean on how an operator
actually describes this ("reversed", "wrong warehouse") rather than the product
name.

## Already done by hand on prod

The stock move for the order above, since the repair job isn't deployed yet:

| Location | Before | After |
|---|---|---|
| Shramdaan `sloc_01K4JH3E…` | 17.6 | **0** |
| Dharamshala `sloc_01JPAQVG…` | 0 | **17.6** |

The link flip still needs this PR deployed. Run after deploy:

```
POST /admin/ops/maintenance-jobs/repair-inventory-order-route/run
{ "params": { "order_id": "inv_order_01KVCT5Z00E39M511Z7MTEFFMN", "swap": true } }
```

(preview first — `dry_run` defaults to true), then re-run with `"dry_run": false`.

## Test

`npx jest --testPathPattern="tool-slice|repair-inventory-order"` → **41 passed**,
including the tool-slice orphan invariant. `tsc` baseline unchanged at **79**,
zero errors in the new files.

## Context

Found while investigating #1248 (committed consumption never decrements
inventory). This is the *upstream* half: #1248 is about consumption not being
deducted; this is about the material never arriving at the right place to begin
with. With the route fixed, Denim Trouser's fabric sits at Dharamshala — ours —
so its 2.15 m becomes a legitimate deduction under #1248's brand-owned-location
gate, rather than partner-held stock that must be left alone.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
