### PR TITLE
feat(consumption): apply committed consumption to our own stock

### DIFF
--- a/apps/backend/src/api/admin/ops/maintenance-jobs/apply-committed-consumption-job.ts
+++ b/apps/backend/src/api/admin/ops/maintenance-jobs/apply-committed-consumption-job.ts
@@ -1,0 +1,304 @@
+import {
+  ContainerRegistrationKeys,
+  MedusaError,
+  Modules,
+} from "@medusajs/framework/utils"
+import { z } from "@medusajs/framework/zod"
+import type { MedusaContainer } from "@medusajs/framework/types"
+import { updateInventoryLevelsWorkflow } from "@medusajs/medusa/core-flows"
+
+import { CONSUMPTION_LOG_MODULE } from "../../../../modules/consumption_log"
+import { DESIGN_MODULE } from "../../../../modules/designs"
+import {
+  APPLIED_AT_KEY,
+  APPLIED_LOCATION_KEY,
+  planConsumptionApplication,
+  resolveBrandLocationId,
+  type ConsumptionApplyLog,
+} from "../../../../workflows/consumption-logs/lib/apply-to-inventory"
+import type { MaintenanceChange, MaintenanceJob, MaintenanceJobResult } from "./registry"
+
+/**
+ * Data Plumbing — apply committed material consumption to our own inventory.
+ *
+ * 63 committed consumption logs on prod moved zero stock, because committing is
+ * accounting-only by design (partners report burn on fabric we never owned).
+ * That boundary is right for partner-held material and wrong for material
+ * issued from our own warehouse. This job settles the backlog for the latter.
+ *
+ * Every deduction is gated on the brand store's own location, so partner-held
+ * consumption is skipped rather than guessed at. Re-running is safe: an applied
+ * log is stamped with `metadata.inventory_applied_at` and skipped thereafter.
+ *
+ * Dry-run (default) previews every decision, including the skips and why.
+ */
+
+const paramsSchema = z.object({
+  design_id: z.string().min(1).optional(),
+  design_ids: z.array(z.string().min(1)).optional(),
+  /** Override the resolved brand location (escape hatch for a second warehouse). */
+  location_id: z.string().min(1).optional(),
+  limit: z.number().int().positive().optional(),
+})
+
+export const applyCommittedConsumptionJob: MaintenanceJob = {
+  id: "apply-committed-consumption-to-inventory",
+  label: "Apply committed consumption to inventory (our own stock only)",
+  description:
+    "Deduct committed material consumption from OUR stock — the movement that committing a consumption log has never performed. Gated on the brand store's own location: partner-held consumption is skipped, never guessed. Labour/energy logs (Hour, kWh — no inventory_item_id) are skipped. Also writes consumed_quantity/consumed_at on the design↔inventory link, which the admin UI renders but nothing has ever written. Idempotent via metadata.inventory_applied_at. Dry-run previews every decision including skips.",
+  params: [
+    {
+      name: "design_id",
+      type: "string",
+      required: false,
+      description: "Only this design's logs (start here — verify one before sweeping)",
+    },
+    {
+      name: "design_ids",
+      type: "string",
+      required: false,
+      description: "Only these designs' logs (array of design ids)",
+    },
+    {
+      name: "location_id",
+      type: "string",
+      required: false,
+      description:
+        "Deduct from this location instead of the auto-resolved brand default location",
+    },
+    {
+      name: "limit",
+      type: "number",
+      required: false,
+      description: "Cap the number of logs considered (applied after ordering)",
+    },
+  ],
+  run: async (container, { dry_run, params }): Promise<MaintenanceJobResult> => {
+    const parsed = paramsSchema.safeParse(params)
+    if (!parsed.success) {
+      throw new MedusaError(
+        MedusaError.Types.INVALID_DATA,
+        parsed.error.issues.map((i) => i.message).join("; ")
+      )
+    }
+    const { design_id, design_ids, location_id, limit } = parsed.data
+
+    const query: any = container.resolve(ContainerRegistrationKeys.QUERY)
+    const consumptionService: any = container.resolve(CONSUMPTION_LOG_MODULE)
+
+    const brandLocationId =
+      location_id ?? (await resolveBrandLocationId(container))
+
+    const designFilter = design_ids?.length
+      ? design_ids
+      : design_id
+        ? [design_id]
+        : null
+
+    const filters: Record<string, any> = { is_committed: true }
+    if (designFilter) {
+      filters.design_id = designFilter
+    }
+    const [rawLogs] = await consumptionService.listAndCountConsumptionLogs(
+      filters,
+      { take: null }
+    )
+
+    const logs: ConsumptionApplyLog[] = ((rawLogs || []) as any[]).map((l) => ({
+      id: l.id,
+      design_id: l.design_id ?? null,
+      inventory_item_id: l.inventory_item_id ?? null,
+      quantity: l.quantity ?? null,
+      is_committed: Boolean(l.is_committed),
+      location_id: l.location_id ?? null,
+      metadata: l.metadata ?? null,
+    }))
+    const considered = [...logs]
+      .sort((a, b) => (a.id < b.id ? -1 : a.id > b.id ? 1 : 0))
+      .slice(0, limit ?? logs.length)
+
+    // Current stock at the brand location, per item. An item ABSENT from this
+    // map has no level there — the signal that it was never ours.
+    const itemIds = Array.from(
+      new Set(considered.map((l) => l.inventory_item_id).filter(Boolean))
+    ) as string[]
+    const brandLevels: Record<string, number> = {}
+    const levelIdByItem: Record<string, string> = {}
+    if (itemIds.length) {
+      const { data: levels } = await query.graph({
+        entity: "inventory_level",
+        fields: ["id", "inventory_item_id", "location_id", "stocked_quantity"],
+        filters: { inventory_item_id: itemIds, location_id: brandLocationId },
+      })
+      for (const lv of (levels || []) as any[]) {
+        brandLevels[lv.inventory_item_id] = Number(lv.stocked_quantity ?? 0)
+        levelIdByItem[lv.inventory_item_id] = lv.id
+      }
+    }
+
+    const decisions = planConsumptionApplication({
+      brandLocationId,
+      logs: considered,
+      brandLevels,
+    })
+    const applies = decisions.filter((d) => d.action === "apply") as Extract<
+      (typeof decisions)[number],
+      { action: "apply" }
+    >[]
+
+    const changes: MaintenanceChange[] = applies.map((d) => ({
+      entity: "inventory_level",
+      id: `${d.inventory_item_id}@${brandLocationId}`,
+      field: `stocked_quantity (log ${d.log_id})`,
+      before: d.before,
+      after: d.after,
+    }))
+
+    if (!dry_run && applies.length > 0) {
+      const logById = new Map(considered.map((l) => [l.id, l]))
+      const appliedAt = new Date().toISOString()
+
+      // Final level per item — several logs may draw down one item, and the
+      // planner already carried the balance forward across them, so only the
+      // last decision's `after` is written.
+      //
+      // Deliberately the ABSOLUTE setter rather than the module's relative
+      // `adjustInventory(item, location, -qty)`: the planner has already
+      // floored at 0 and reported any shortfall, and a relative delta would
+      // drive the level negative instead. This also matches how every other
+      // level change in the repo is made (cancel-inventory-order,
+      // partner-complete-inventory-order), so it inherits the workflow's
+      // compensation rather than being a bare service write.
+      const finalByItem = new Map<string, number>()
+      for (const d of applies) {
+        finalByItem.set(d.inventory_item_id, d.after)
+      }
+      const updates = Array.from(finalByItem, ([itemId, stocked]) => ({
+        id: levelIdByItem[itemId],
+        stocked_quantity: stocked,
+      }))
+      await updateInventoryLevelsWorkflow(container as any).run({
+        input: { updates: updates as any },
+      })
+
+      for (const d of applies) {
+        const existing = logById.get(d.log_id)
+        await consumptionService.updateConsumptionLogs({
+          id: d.log_id,
+          metadata: {
+            ...(existing?.metadata || {}),
+            [APPLIED_AT_KEY]: appliedAt,
+            [APPLIED_LOCATION_KEY]: brandLocationId,
+          },
+        })
+      }
+
+      await writeConsumedOnDesignLinks(container, query, applies, logById, appliedAt)
+    }
+
+    const skipReasons = decisions
+      .filter((d) => d.action === "skip")
+      .reduce<Record<string, number>>((acc, d) => {
+        const reason = (d as any).reason.replace(/\(.*\)/, "(…)")
+        acc[reason] = (acc[reason] ?? 0) + 1
+        return acc
+      }, {})
+    const shortfalls = applies.filter((d) => d.shortfall)
+
+    const summary = [
+      `${dry_run ? "Would apply" : "Applied"} ${applies.length} of ${considered.length} committed log(s) at ${brandLocationId}`,
+      shortfalls.length
+        ? `⚠️ ${shortfalls.length} log(s) wanted more than the level held (floored at 0): ${shortfalls
+            .map((d) => `${d.inventory_item_id} short ${d.shortfall}`)
+            .join(", ")}`
+        : "",
+      Object.keys(skipReasons).length
+        ? `Skipped: ${Object.entries(skipReasons)
+            .map(([r, n]) => `${n}× ${r}`)
+            .join("; ")}`
+        : "",
+    ]
+      .filter(Boolean)
+      .join(". ")
+
+    return {
+      job_id: applyCommittedConsumptionJob.id,
+      dry_run,
+      applied: !dry_run && applies.length > 0,
+      summary,
+      changes,
+    }
+  },
+}
+
+/**
+ * Give `consumed_quantity` / `consumed_at` on the design↔inventory link their
+ * first writer. The admin design UI renders both, so they have displayed 0
+ * forever. Mirrors `updateDesignInventoryLinkStep`'s dismiss+create, preserving
+ * every other column.
+ */
+async function writeConsumedOnDesignLinks(
+  container: MedusaContainer,
+  query: any,
+  applies: Array<{ log_id: string; inventory_item_id: string; quantity: number }>,
+  logById: Map<string, ConsumptionApplyLog>,
+  appliedAt: string
+): Promise<void> {
+  const remoteLink: any = container.resolve(ContainerRegistrationKeys.LINK)
+
+  // Sum this run's consumption per (design, item) pair.
+  const added = new Map<string, number>()
+  for (const d of applies) {
+    const designId = logById.get(d.log_id)?.design_id
+    if (!designId) {
+      continue
+    }
+    const key = `${designId}::${d.inventory_item_id}`
+    added.set(key, (added.get(key) ?? 0) + d.quantity)
+  }
+
+  for (const [key, quantity] of added) {
+    const [designId, inventoryItemId] = key.split("::")
+    try {
+      const { data: rows } = await query.graph({
+        entity: "design_inventory_item",
+        fields: [
+          "design_id",
+          "inventory_item_id",
+          "planned_quantity",
+          "consumed_quantity",
+          "consumed_at",
+          "location_id",
+          "metadata",
+        ],
+        filters: { design_id: designId, inventory_item_id: inventoryItemId },
+      })
+      const existing = (rows || [])[0]
+      if (!existing) {
+        continue
+      }
+
+      const linkDefinition = {
+        [DESIGN_MODULE]: { design_id: designId },
+        [Modules.INVENTORY]: { inventory_item_id: inventoryItemId },
+      }
+      await remoteLink.dismiss([linkDefinition])
+      await remoteLink.create([
+        {
+          ...linkDefinition,
+          data: {
+            planned_quantity: existing.planned_quantity ?? null,
+            consumed_quantity:
+              Number(existing.consumed_quantity ?? 0) + quantity,
+            consumed_at: appliedAt,
+            location_id: existing.location_id ?? null,
+            metadata: existing.metadata ?? null,
+          },
+        },
+      ])
+    } catch {
+      // A missing/!unlinkable pair must not fail the stock correction that
+      // already succeeded — the link column is a display mirror.
+    }
+  }
+}

--- a/apps/backend/src/api/admin/ops/maintenance-jobs/registry.ts
+++ b/apps/backend/src/api/admin/ops/maintenance-jobs/registry.ts
@@ -90,6 +90,7 @@ import { recomputeEmailEngagementStatusJob } from "./recompute-email-engagement-
 import { generateNewsletterWinbackTargetsJob } from "./generate-newsletter-winback-targets-job"
 import { repairInventoryOrderSourceJob } from "./repair-inventory-order-source-job"
 import { repairInventoryOrderRouteJob } from "./repair-inventory-order-route-job"
+import { applyCommittedConsumptionJob } from "./apply-committed-consumption-job"
 import { backfillGoogleAdsHistoryJob } from "./backfill-google-ads-history-job"
 import { backfillDesignSizeSetsJob } from "./backfill-design-size-sets-job"
 import { backfillPartnerShippingOptionsJob } from "./backfill-partner-shipping-options-job"
@@ -5649,6 +5650,7 @@ export const MAINTENANCE_JOBS: MaintenanceJob[] = [
   generateNewsletterWinbackTargetsJob,
   repairInventoryOrderSourceJob,
   repairInventoryOrderRouteJob,
+  applyCommittedConsumptionJob,
   backfillGoogleAdsHistoryJob,
   backfillDesignSizeSetsJob,
   backfillPartnerShippingOptionsJob,

--- a/apps/backend/src/workflows/consumption-logs/__tests__/apply-to-inventory.unit.spec.ts
+++ b/apps/backend/src/workflows/consumption-logs/__tests__/apply-to-inventory.unit.spec.ts
@@ -1,0 +1,117 @@
+import {
+  APPLIED_AT_KEY,
+  planConsumptionApplication,
+  type ConsumptionApplyLog,
+} from "../lib/apply-to-inventory"
+
+/**
+ * planConsumptionApplication. Pure: no container/DB.
+ *
+ * The scenario: 63 committed consumption logs on prod moved zero stock.
+ * Committing is accounting-only by design — partners burn fabric we never
+ * owned — so the fix must deduct ONLY material issued from our own warehouse
+ * (the brand store's location), and must not touch the 1300 units of
+ * `Hour`/`kWh` labour and energy logs that carry no inventory_item_id.
+ */
+describe("planConsumptionApplication", () => {
+  const BRAND = "sloc_dharamshala"
+
+  const log = (over: Partial<ConsumptionApplyLog> = {}): ConsumptionApplyLog => ({
+    id: "log_1",
+    design_id: "design_1",
+    inventory_item_id: "iitem_denim",
+    quantity: 2.15,
+    is_committed: true,
+    location_id: null,
+    metadata: null,
+    ...over,
+  })
+
+  const plan = (logs: ConsumptionApplyLog[], brandLevels = { iitem_denim: 17.6 }) =>
+    planConsumptionApplication({ brandLocationId: BRAND, logs, brandLevels })
+
+  it("deducts a committed log from the brand location", () => {
+    expect(plan([log()])).toEqual([
+      {
+        action: "apply",
+        log_id: "log_1",
+        inventory_item_id: "iitem_denim",
+        quantity: 2.15,
+        before: 17.6,
+        after: 15.45,
+      },
+    ])
+  })
+
+  it("skips labour/energy logs, which carry no inventory_item_id", () => {
+    const [d] = plan([log({ inventory_item_id: null, quantity: 30 })])
+    expect(d.action).toBe("skip")
+    expect((d as any).reason).toMatch(/labour\/energy/)
+  })
+
+  it("skips an item with no level at the brand location (partner-held)", () => {
+    const [d] = plan([log({ inventory_item_id: "iitem_partner_only" })])
+    expect(d.action).toBe("skip")
+    expect((d as any).reason).toMatch(/partner-held/)
+  })
+
+  it("skips a log explicitly located somewhere other than the brand location", () => {
+    const [d] = plan([log({ location_id: "sloc_weaver" })])
+    expect(d.action).toBe("skip")
+    expect((d as any).reason).toMatch(/non-brand location/)
+  })
+
+  it("applies a log explicitly located AT the brand location", () => {
+    const [d] = plan([log({ location_id: BRAND })])
+    expect(d.action).toBe("apply")
+  })
+
+  it("skips an already-applied log so re-runs never double-deduct", () => {
+    const [d] = plan([
+      log({ metadata: { [APPLIED_AT_KEY]: "2026-08-11T00:00:00.000Z" } }),
+    ])
+    expect(d.action).toBe("skip")
+    expect((d as any).reason).toMatch(/already applied/)
+  })
+
+  it("skips uncommitted logs", () => {
+    const [d] = plan([log({ is_committed: false })])
+    expect(d.action).toBe("skip")
+    expect((d as any).reason).toBe("not committed")
+  })
+
+  it("carries the balance forward across several logs on one item", () => {
+    const decisions = plan([
+      log({ id: "log_a", quantity: 10 }),
+      log({ id: "log_b", quantity: 5 }),
+    ])
+    expect(decisions).toEqual([
+      expect.objectContaining({ log_id: "log_a", before: 17.6, after: 7.6 }),
+      expect.objectContaining({ log_id: "log_b", before: 7.6, after: 2.6 }),
+    ])
+  })
+
+  it("floors at zero and reports the shortfall instead of going negative", () => {
+    const [d] = plan([log({ quantity: 20 })])
+    expect(d).toEqual(
+      expect.objectContaining({ action: "apply", before: 17.6, after: 0, shortfall: 2.4 })
+    )
+  })
+
+  it("lands exactly on zero without reporting a shortfall", () => {
+    const [d] = plan([log({ quantity: 3 })], { iitem_denim: 3 })
+    expect(d).toEqual(expect.objectContaining({ after: 0 }))
+    expect((d as any).shortfall).toBeUndefined()
+  })
+
+  it("skips non-positive quantities", () => {
+    expect(plan([log({ quantity: 0 })])[0].action).toBe("skip")
+    expect(plan([log({ quantity: null })])[0].action).toBe("skip")
+  })
+
+  it("is deterministic regardless of input order", () => {
+    const a = plan([log({ id: "log_b", quantity: 5 }), log({ id: "log_a", quantity: 10 })])
+    const b = plan([log({ id: "log_a", quantity: 10 }), log({ id: "log_b", quantity: 5 })])
+    expect(a).toEqual(b)
+  })
+})

--- a/apps/backend/src/workflows/consumption-logs/lib/apply-to-inventory.ts
+++ b/apps/backend/src/workflows/consumption-logs/lib/apply-to-inventory.ts
@@ -1,0 +1,188 @@
+import { ContainerRegistrationKeys, MedusaError } from "@medusajs/framework/utils"
+import type { MedusaContainer } from "@medusajs/framework/types"
+
+/**
+ * Turning committed consumption into an inventory movement — the shared rule.
+ *
+ * Committing a consumption log deliberately does NOT move stock (see the
+ * docblock on `propagateCostsStep` in ../commit-consumption.ts): partners burn
+ * fabric we never owned, and their reported consumption should move cost, not
+ * inventory. That is a boundary, not an oversight.
+ *
+ * The bug is that the boundary was drawn as "never", when it should be "not
+ * theirs". Material issued from OUR OWN warehouse is a real stock movement and
+ * has never been recorded — 63 committed logs on prod moved zero stock.
+ *
+ * So every deduction is gated on the brand store's own location. Partner-held
+ * consumption keeps behaving exactly as it does today, by construction.
+ */
+
+/** A `Hour`/`kWh` labour or energy log carries raw_material_id, not an item. */
+export type ConsumptionApplyLog = {
+  id: string
+  design_id: string | null
+  inventory_item_id: string | null
+  quantity: number | string | null
+  is_committed: boolean
+  location_id: string | null
+  metadata: Record<string, any> | null
+}
+
+export type ConsumptionApplyPlanInput = {
+  /** The only location stock may be deducted from. */
+  brandLocationId: string
+  logs: ConsumptionApplyLog[]
+  /**
+   * Stocked quantity at the brand location, keyed by inventory_item_id. A key
+   * being ABSENT means the item has no level there at all — which is the signal
+   * that the material was never ours.
+   */
+  brandLevels: Record<string, number>
+}
+
+export type ConsumptionApplyDecision =
+  | {
+      action: "apply"
+      log_id: string
+      inventory_item_id: string
+      quantity: number
+      before: number
+      after: number
+      /** Set when the log wanted more than the level held. */
+      shortfall?: number
+    }
+  | { action: "skip"; log_id: string; reason: string }
+
+export const APPLIED_AT_KEY = "inventory_applied_at"
+export const APPLIED_LOCATION_KEY = "inventory_applied_location_id"
+
+/**
+ * Quantities here are decimal metres, so binary float noise is guaranteed:
+ * `17.6 - 2.15` is `15.450000000000001`. That would be written straight to
+ * `stocked_quantity` and then compound on the next deduction. Six places is far
+ * beyond any real fabric measurement and well inside float precision.
+ */
+const round = (n: number): number => Number(n.toFixed(6))
+
+/**
+ * PURE: decide what each log does. Exported for unit tests.
+ *
+ * Logs are processed in id order and the level is carried forward between them,
+ * so several logs against one item draw down a shared running balance rather
+ * than each measuring against the original stock.
+ *
+ * Never goes negative: a log wanting more than is held floors the level at 0 and
+ * reports the `shortfall`. A negative level is not more honest here — the stock
+ * genuinely left the building, and the discrepancy is in the paperwork, which
+ * the shortfall is what surfaces.
+ */
+export function planConsumptionApplication(
+  input: ConsumptionApplyPlanInput
+): ConsumptionApplyDecision[] {
+  const running: Record<string, number> = { ...input.brandLevels }
+  const decisions: ConsumptionApplyDecision[] = []
+
+  const ordered = [...input.logs].sort((a, b) => (a.id < b.id ? -1 : a.id > b.id ? 1 : 0))
+
+  for (const log of ordered) {
+    const skip = (reason: string) =>
+      decisions.push({ action: "skip", log_id: log.id, reason })
+
+    if (!log.is_committed) {
+      skip("not committed")
+      continue
+    }
+    if (log.metadata?.[APPLIED_AT_KEY]) {
+      skip(`already applied at ${log.metadata[APPLIED_AT_KEY]}`)
+      continue
+    }
+    // Labour (`Hour`) and energy (`kWh`) logs carry a raw_material_id instead —
+    // 1300 units of them on prod. Deducting those would be nonsense.
+    if (!log.inventory_item_id) {
+      skip("no inventory_item_id (labour/energy log)")
+      continue
+    }
+    // An explicitly-located log is taken at its word.
+    if (log.location_id && log.location_id !== input.brandLocationId) {
+      skip(`logged at a non-brand location (${log.location_id})`)
+      continue
+    }
+    if (!(log.inventory_item_id in running)) {
+      skip("item has no stock level at the brand location (partner-held)")
+      continue
+    }
+
+    const quantity = Number(log.quantity ?? 0)
+    if (!Number.isFinite(quantity) || quantity <= 0) {
+      skip(`non-positive quantity (${log.quantity})`)
+      continue
+    }
+
+    const before = running[log.inventory_item_id]
+    const after = round(Math.max(0, before - quantity))
+    const shortfall = round(quantity - (before - after))
+
+    running[log.inventory_item_id] = after
+    decisions.push({
+      action: "apply",
+      log_id: log.id,
+      inventory_item_id: log.inventory_item_id,
+      quantity,
+      before,
+      after,
+      ...(shortfall > 0 ? { shortfall } : {}),
+    })
+  }
+
+  return decisions
+}
+
+/**
+ * The brand store is the one store NOT reachable from any partner.
+ *
+ * There is no ownership flag on a store or a location, and matching on name is
+ * a trap: prod carries legacy duplicates named after partners (`Shramdaan` vs
+ * the partner's `Shramdaan India Warehouse`). Partner stores are reachable
+ * through the partner↔store link, so the brand store is what's left over.
+ */
+export async function resolveBrandLocationId(
+  container: MedusaContainer
+): Promise<string> {
+  const query: any = container.resolve(ContainerRegistrationKeys.QUERY)
+
+  const { data: partners } = await query.graph({
+    entity: "partners",
+    fields: ["id", "stores.id"],
+  })
+  const partnerStoreIds = new Set<string>()
+  for (const p of (partners || []) as any[]) {
+    for (const s of (p?.stores || []) as any[]) {
+      if (s?.id) {
+        partnerStoreIds.add(s.id)
+      }
+    }
+  }
+
+  const { data: stores } = await query.graph({
+    entity: "stores",
+    fields: ["id", "name", "default_location_id"],
+  })
+  const brandStores = ((stores || []) as any[]).filter(
+    (s) => s?.id && !partnerStoreIds.has(s.id)
+  )
+
+  if (brandStores.length !== 1) {
+    throw new MedusaError(
+      MedusaError.Types.UNEXPECTED_STATE,
+      `Expected exactly one non-partner (brand) store, found ${brandStores.length} — pass location_id explicitly`
+    )
+  }
+  const locationId = brandStores[0].default_location_id
+  if (!locationId) {
+    throw new MedusaError(
+      MedusaError.Types.UNEXPECTED_STATE,
+      `Brand store ${brandStores[0].id} has no default_location_id — pass location_id explicitly`
+    )
+  }
+  return locationId as string
+}


### PR DESCRIPTION
Closes the backfill half of #1248.

## What was wrong

Committing a consumption log has never moved inventory. **63 committed logs on
prod, zero stock movement** — which is why a completed run against "Denim
Trouser" showed 2.15 m consumed against a level that never budged.

The docblock on `commit-consumption.ts` calls this deliberate, and **for
partner-held material it is right**: partners burn fabric we never owned, so
their reported consumption should move cost, not stock. But the boundary was
drawn as *"never"* when it should have been *"not theirs"*. Material issued from
our own warehouse is a real movement that was simply going unrecorded.

## The gate

Every deduction is gated on the **brand store's own location**, which makes the
partner case safe by construction rather than by care.

The brand store is found **by elimination** — the one store not reachable from
any partner via the partner↔store link. There is no ownership flag on a store or
a location, and matching on name is a trap: prod carries legacy duplicates named
after partners (`Shramdaan` `sloc_01K4JH3E…` vs the partner's real
`Shramdaan India Warehouse` `sloc_01KM55Y4…`; `GOF` vs `GOF Warehouse`).

Skips, all previewed with their reason:

| Case | Why |
|---|---|
| item has no level at the brand location | never ours — skipped, not guessed |
| no `inventory_item_id` | the **1300 units of `Hour`/`kWh`** labour and energy; nonsense to deduct from stock |
| `location_id` set to a non-brand location | the log is taken at its word |
| `metadata.inventory_applied_at` present | already applied — re-runs never double-deduct |
| uncommitted / non-positive quantity | nothing to do |

## Decisions worth reviewing

**Floors at 0 and reports a shortfall** rather than going negative. The stock
really did leave the building; the discrepancy is in the paperwork, and the
shortfall is what surfaces it.

**Writes the absolute level, not `adjustInventory(item, location, -qty)`.** The
module does offer a relative adjustment, but a delta would drive the level
negative and bypass the floor above. `updateInventoryLevelsWorkflow` also
matches how every other level change in the repo is made
(`cancel-inventory-order`, `partner-complete-inventory-order`) and inherits its
compensation, rather than being a bare service write.

**Rounds to six places.** These are decimal metres, so `17.6 - 2.15` is
`15.450000000000001`; left alone, that noise compounds on every subsequent
deduction. Caught by a unit test, not by eye.

**Balance carries forward** across several logs on one item, so they draw down a
shared running total instead of each measuring against the original stock.

## Also

Gives `consumed_quantity` / `consumed_at` on the design↔inventory link their
**first writer**. The admin design UI has rendered both since they were added and
has always shown 0. Failure there is swallowed — it is a display mirror and must
not fail a stock correction that already succeeded.

**No new MCP rows.** `run_maintenance_job` (shipped in #1249) is generic, so the
assistant discovers this job through `list_maintenance_jobs` automatically —
including `design_id` / `design_ids`, so "apply the consumption for these three
designs" works as one ask.

## Suggested rollout

```
POST /admin/ops/maintenance-jobs/apply-committed-consumption-to-inventory/run
{ "params": { "design_id": "01KWWJ0S3ZWWNK6YTDSC2AFARQ" } }     # dry-run by default
```

Verify Denim Trouser (17.6 → 15.45) before sweeping the rest.

⚠️ **Hold the full sweep** until `inv_order_01KVCT5Z…` is flipped and the seven
partner-side items are re-checked. If other orders are reversed too, some of
those items are actually ours, and a sweep run first would bake in the wrong
scope.

## Not in this PR

The **forward fix** — the same deduction inside `commitConsumptionWorkflow` so
future commits stay correct without a sweep. Deliberately held back so the
backfill numbers can be verified against real stock first; it is a live
behaviour change on every future commit.

## Test

`npx jest --testPathPattern="apply-to-inventory|tool-slice|repair-inventory-order"`
→ **53 passed** (12 new, covering the gate, the labour/energy skip, idempotency,
the running balance, the zero floor and the rounding). `tsc` baseline unchanged
at **79**, zero errors in the new files.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
