### PR TITLE
fix(production-runs): stop counting stock sales as production, and ask what a consumption quantity measures (#1248)

### DIFF
--- a/apps/backend/src/admin/components/designs/design-consumption-logs-section.tsx
+++ b/apps/backend/src/admin/components/designs/design-consumption-logs-section.tsx
@@ -73,6 +73,7 @@ export const DesignConsumptionLogsSection = ({ design }: DesignConsumptionLogsSe
   // Form state
   const [formInventoryId, setFormInventoryId] = useState("")
   const [formQuantity, setFormQuantity] = useState("")
+  const [formBasis, setFormBasis] = useState("per_piece")
   const [formUnitCost, setFormUnitCost] = useState("")
   const [formUnit, setFormUnit] = useState("Meter")
   // Smart default: use "production" for designs in production stages, "sample" for earlier stages
@@ -86,6 +87,7 @@ export const DesignConsumptionLogsSection = ({ design }: DesignConsumptionLogsSe
   const resetForm = () => {
     setFormInventoryId("")
     setFormQuantity("")
+    setFormBasis("per_piece")
     setFormUnitCost("")
     setFormUnit("Meter")
     setFormType("sample")
@@ -102,6 +104,7 @@ export const DesignConsumptionLogsSection = ({ design }: DesignConsumptionLogsSe
       await logConsumption({
         inventoryItemId: formInventoryId,
         quantity: parseFloat(formQuantity),
+        quantityBasis: formBasis as "total" | "per_piece",
         unitCost: formUnitCost ? parseFloat(formUnitCost) : undefined,
         unitOfMeasure: formUnit,
         consumptionType: formType as "sample" | "production" | "wastage",
@@ -240,6 +243,27 @@ export const DesignConsumptionLogsSection = ({ design }: DesignConsumptionLogsSe
                   value={formQuantity}
                   onChange={(e) => setFormQuantity(e.target.value)}
                 />
+                {/*
+                  Which one this is CANNOT be inferred later: the same 2.15 m
+                  means 2.15 or 4.3 depending on the answer, and it scales both
+                  the costing and the stock deduction. Asked here, once.
+                */}
+                <div className="flex items-center gap-2 mt-1.5">
+                  <Select value={formBasis} onValueChange={setFormBasis}>
+                    <Select.Trigger>
+                      <Select.Value placeholder="Measured as" />
+                    </Select.Trigger>
+                    <Select.Content>
+                      <Select.Item value="per_piece">Per piece</Select.Item>
+                      <Select.Item value="total">Total for the run</Select.Item>
+                    </Select.Content>
+                  </Select>
+                </div>
+                <Text size="xsmall" className="text-ui-fg-muted mt-1">
+                  {formBasis === "per_piece"
+                    ? "Material for ONE finished piece — multiplied by the run's output."
+                    : "Material for the WHOLE run — deducted as entered."}
+                </Text>
               </div>
               <div>
                 <Text size="xsmall" weight="plus" className="text-ui-fg-subtle mb-1">

--- a/apps/backend/src/admin/hooks/api/designs.ts
+++ b/apps/backend/src/admin/hooks/api/designs.ts
@@ -1346,6 +1346,7 @@ export interface LogConsumptionPayload {
   inventoryItemId: string;
   rawMaterialId?: string;
   quantity: number;
+  quantityBasis?: "total" | "per_piece";
   unitCost?: number;
   unitOfMeasure?: string;
   consumptionType?: "sample" | "production" | "wastage";

--- a/apps/backend/src/admin/lib/__tests__/production-run-totals.unit.spec.ts
+++ b/apps/backend/src/admin/lib/__tests__/production-run-totals.unit.spec.ts
@@ -1,4 +1,5 @@
 import {
+  isFulfillmentProvenanceRun,
   leafProductionRuns,
   summarizeProductionRunTotals,
   type ProductionRunLike,
@@ -76,6 +77,7 @@ describe("summarizeProductionRunTotals (#498 double-count)", () => {
       inProgress: 0,
       leafCount: 0,
       total: 0,
+      shippedFromStock: 0,
     })
     // @ts-expect-error - guarding runtime misuse
     expect(summarizeProductionRunTotals(undefined).completed).toBe(0)
@@ -90,5 +92,85 @@ describe("summarizeProductionRunTotals (#498 double-count)", () => {
     const totals = summarizeProductionRunTotals(runs)
     expect(totals.total).toBe(3)
     expect(totals.leafCount).toBe(2)
+  })
+})
+
+describe("provenance runs are not production", () => {
+  const PROVENANCE = { source: "order.fulfillment_created" }
+
+  // The real prod shape: design 01KWWJ0S3Z… "Denim Trouser". Run A is shop-floor
+  // work (2 pieces, full lifecycle). Run B was minted when a retail line item
+  // shipped FROM STOCK — completed, quantity 1, no partner, no lifecycle, no
+  // activities. Both are leaves, so the pre-fix sum reported 3 produced.
+  const denimTrouser: ProductionRunLike[] = [
+    {
+      id: "prod_run_A",
+      parent_run_id: null,
+      status: "completed",
+      quantity: 2,
+      metadata: { source: "designs-produce-no-customer" },
+    },
+    {
+      id: "prod_run_B",
+      parent_run_id: null,
+      status: "completed",
+      quantity: 1,
+      metadata: { ...PROVENANCE, design_backed: true, is_custom_design: true },
+    },
+  ]
+
+  it("excludes fulfillment-provenance runs from produced quantity", () => {
+    const totals = summarizeProductionRunTotals(denimTrouser)
+    expect(totals.completed).toBe(2)
+    expect(totals.leafCount).toBe(1)
+  })
+
+  it("reports the shipped-from-stock quantity instead of dropping it", () => {
+    const totals = summarizeProductionRunTotals(denimTrouser)
+    expect(totals.shippedFromStock).toBe(1)
+    // Every record is still accounted for.
+    expect(totals.total).toBe(2)
+  })
+
+  it("catches DESIGN-BACKED provenance runs, which isOwnedProvenanceRun misses", () => {
+    // isOwnedProvenanceRun additionally requires design_id == null, so it
+    // returns false for run B. The create-side marker is the reliable signal.
+    expect(isFulfillmentProvenanceRun(denimTrouser[1])).toBe(true)
+    expect(isFulfillmentProvenanceRun(denimTrouser[0])).toBe(false)
+  })
+
+  it("does not treat a missing/!=marker metadata as provenance", () => {
+    expect(isFulfillmentProvenanceRun({ id: "x" })).toBe(false)
+    expect(isFulfillmentProvenanceRun({ id: "x", metadata: null })).toBe(false)
+    expect(
+      isFulfillmentProvenanceRun({ id: "x", metadata: { source: "order.placed" } })
+    ).toBe(false)
+  })
+
+  it("excludes provenance runs from in-progress too", () => {
+    const runs: ProductionRunLike[] = [
+      { id: "real", parent_run_id: null, status: "in_progress", quantity: 5 },
+      {
+        id: "prov",
+        parent_run_id: null,
+        status: "in_progress",
+        quantity: 3,
+        metadata: PROVENANCE,
+      },
+    ]
+    expect(summarizeProductionRunTotals(runs).inProgress).toBe(5)
+  })
+
+  it("still detects leaves using the full set when a parent is provenance", () => {
+    // A provenance parent must not promote its children out of existence, nor
+    // be counted itself.
+    const runs: ProductionRunLike[] = [
+      { id: "p", parent_run_id: null, status: "completed", quantity: 10, metadata: PROVENANCE },
+      { id: "c1", parent_run_id: "p", status: "completed", quantity: 4 },
+      { id: "c2", parent_run_id: "p", status: "completed", quantity: 6 },
+    ]
+    const totals = summarizeProductionRunTotals(runs)
+    expect(totals.completed).toBe(10)
+    expect(totals.shippedFromStock).toBe(0)
   })
 })

--- a/apps/backend/src/admin/lib/production-run-totals.ts
+++ b/apps/backend/src/admin/lib/production-run-totals.ts
@@ -19,6 +19,27 @@ export type ProductionRunLike = {
   parent_run_id?: string | null
   status?: string | null
   quantity?: number | null
+  metadata?: Record<string, any> | null
+}
+
+/**
+ * A run minted from retail fulfillment rather than shop-floor work.
+ *
+ * `plan-fulfillment-production-runs.ts` creates these "born terminal" when a
+ * fulfilled line item has no run behind it: the goods shipped from stock, so
+ * nothing was produced and no material was consumed. They carry a real
+ * `quantity` and `status: "completed"` purely as provenance, which makes them
+ * indistinguishable from production to any plain status+quantity sum.
+ *
+ * Deliberately NOT `isOwnedProvenanceRun` from
+ * ../../lib/resolve-line-item-production: that helper additionally requires
+ * `design_id == null`, and the create path mints DESIGN-BACKED provenance runs
+ * too (`metadata.design_backed`). Testing the create-side marker alone is what
+ * catches both — the design-backed ones are exactly the ones that land on a
+ * design's totals.
+ */
+export function isFulfillmentProvenanceRun(run: ProductionRunLike): boolean {
+  return run?.metadata?.source === "order.fulfillment_created"
 }
 
 export const COMPLETED_STATUSES = ["completed"] as const
@@ -36,10 +57,16 @@ export type ProductionRunTotals = {
   completed: number
   /** Sum of in-progress leaf-run quantities. */
   inProgress: number
-  /** Number of leaf runs (parents with children are excluded). */
+  /** Number of leaf runs (parents with children, and provenance runs, excluded). */
   leafCount: number
   /** Total number of run records returned (parents + children). */
   total: number
+  /**
+   * Quantity on leaf runs minted from retail fulfillment — goods that shipped
+   * from stock rather than being produced. Reported rather than silently
+   * dropped, so a caller can show where the difference went.
+   */
+  shippedFromStock: number
 }
 
 /**
@@ -66,7 +93,11 @@ export function summarizeProductionRunTotals(
   runs: ProductionRunLike[]
 ): ProductionRunTotals {
   const list = Array.isArray(runs) ? runs : []
-  const leaves = leafProductionRuns(list)
+  // Leaf detection runs over the FULL set, before provenance is filtered out, so
+  // dropping a run can never promote its parent to a leaf.
+  const allLeaves = leafProductionRuns(list)
+  const provenanceLeaves = allLeaves.filter(isFulfillmentProvenanceRun)
+  const leaves = allLeaves.filter((r) => !isFulfillmentProvenanceRun(r))
 
   const sumByStatus = (statuses: readonly string[]) =>
     leaves
@@ -78,5 +109,9 @@ export function summarizeProductionRunTotals(
     inProgress: sumByStatus(IN_PROGRESS_STATUSES),
     leafCount: leaves.length,
     total: list.length,
+    shippedFromStock: provenanceLeaves.reduce(
+      (acc, r) => acc + (Number(r?.quantity) || 0),
+      0
+    ),
   }
 }

--- a/apps/backend/src/admin/widgets/product-designs.tsx
+++ b/apps/backend/src/admin/widgets/product-designs.tsx
@@ -133,7 +133,15 @@ function DesignAdminProductionRunsSection({ designId }: { designId: string }) {
   // #498: a design's runs come back as a parent + one child per partner
   // assignment (all sharing design_id). The parent's quantity already equals
   // the sum of its children, so sum LEAF runs only to avoid double-counting.
-  const { completed: totalProduced, inProgress } = summarizeProductionRunTotals(runs)
+  //
+  // Runs minted from retail fulfillment are excluded from "completed": the goods
+  // shipped from stock, nothing was produced. They're reported separately rather
+  // than dropped, so the run list below still reconciles against the badges.
+  const {
+    completed: totalProduced,
+    inProgress,
+    shippedFromStock,
+  } = summarizeProductionRunTotals(runs)
 
   return (
     <div className="flex flex-col gap-y-3">
@@ -151,6 +159,14 @@ function DesignAdminProductionRunsSection({ designId }: { designId: string }) {
             <span className="h-1.5 w-1.5 rounded-full bg-ui-tag-blue-icon" />
             <Text size="xsmall" className="text-ui-tag-blue-text font-medium">
               {inProgress.toLocaleString()} in production
+            </Text>
+          </div>
+        )}
+        {shippedFromStock > 0 && (
+          <div className="flex items-center gap-x-1 rounded-full bg-ui-tag-neutral-bg px-2.5 py-0.5">
+            <span className="h-1.5 w-1.5 rounded-full bg-ui-tag-neutral-icon" />
+            <Text size="xsmall" className="text-ui-tag-neutral-text font-medium">
+              {shippedFromStock.toLocaleString()} shipped from stock
             </Text>
           </div>
         )}

--- a/apps/backend/src/api/admin/assistant/chat/__tests__/cap-tool-result.unit.spec.ts
+++ b/apps/backend/src/api/admin/assistant/chat/__tests__/cap-tool-result.unit.spec.ts
@@ -1,0 +1,107 @@
+import { capToolResult } from "../route"
+
+/**
+ * #1238 — bound a single tool result so one Data Plumbing sweep can't push the
+ * next chat request past the body limit ("Payload too large").
+ *
+ * The body-parser ceiling was the actual cause (Express's 100kb default applied
+ * because the route never set `sizeLimit`); this is the belt to that braces —
+ * results are re-sent on every subsequent turn, so an unbounded one is paid for
+ * over and over.
+ */
+
+const bytes = (v: unknown) => JSON.stringify(v)!.length
+const LIMIT = 64 * 1024
+
+const bigChanges = (n: number) =>
+  Array.from({ length: n }, (_, i) => ({
+    entity: "inventory_level",
+    id: `iitem_${String(i).padStart(26, "0")}@sloc_${String(i).padStart(26, "0")}`,
+    field: `stocked_quantity (log 01KXQNH53${String(i).padStart(17, "0")})`,
+    before: 100 + i,
+    after: 99 + i,
+  }))
+
+describe("capToolResult", () => {
+  it("passes a small result through untouched", () => {
+    const result = { summary: "Would apply 1 of 1", changes: bigChanges(1) }
+    expect(capToolResult(result)).toBe(result)
+  })
+
+  it("truncates the largest array when the result is oversized", () => {
+    const result = {
+      summary: "Would apply 4000 of 4000 committed log(s)",
+      dry_run: true,
+      changes: bigChanges(4000),
+    }
+    expect(bytes(result)).toBeGreaterThan(LIMIT)
+
+    const capped = capToolResult(result)
+    expect(bytes(capped)).toBeLessThanOrEqual(LIMIT)
+    expect(capped.changes.length).toBeLessThan(4000)
+    expect(capped.changes.length).toBeGreaterThan(0)
+  })
+
+  it("keeps the summary and scalars — the part a human actually reads", () => {
+    const capped = capToolResult({
+      summary: "Would apply 4000 of 4000 committed log(s) at sloc_brand",
+      dry_run: true,
+      applied: false,
+      job_id: "apply-committed-consumption-to-inventory",
+      changes: bigChanges(4000),
+    })
+
+    expect(capped.summary).toBe(
+      "Would apply 4000 of 4000 committed log(s) at sloc_brand"
+    )
+    expect(capped.dry_run).toBe(true)
+    expect(capped.applied).toBe(false)
+    expect(capped.job_id).toBe("apply-committed-consumption-to-inventory")
+  })
+
+  it("says it truncated, and by how much, rather than going quiet", () => {
+    const capped = capToolResult({
+      summary: "big",
+      changes: bigChanges(4000),
+    })
+
+    expect(capped.truncated.field).toBe("changes")
+    expect(capped.truncated.total).toBe(4000)
+    expect(capped.truncated.shown).toBe(capped.changes.length)
+    expect(capped.truncated.note).toMatch(/truncated/i)
+  })
+
+  it("picks the biggest array when several are present", () => {
+    const capped = capToolResult({
+      summary: "big",
+      errors: [{ message: "one" }, { message: "two" }],
+      changes: bigChanges(4000),
+    })
+
+    expect(capped.truncated.field).toBe("changes")
+    expect(capped.errors).toHaveLength(2)
+  })
+
+  it("reaches into `data` when the payload is wrapped", () => {
+    const capped = capToolResult({
+      ok: true,
+      data: { summary: "big", changes: bigChanges(4000) },
+    })
+
+    expect(bytes(capped)).toBeLessThanOrEqual(LIMIT)
+    expect(capped.data.truncated.total).toBe(4000)
+    expect(capped.ok).toBe(true)
+  })
+
+  it("leaves a large result with no array alone rather than mangling it", () => {
+    const result = { summary: "x".repeat(LIMIT + 10) }
+    const capped = capToolResult(result)
+    expect(capped.summary).toBe(result.summary)
+  })
+
+  it("is safe on non-objects", () => {
+    expect(capToolResult(null)).toBeNull()
+    expect(capToolResult("text")).toBe("text")
+    expect(capToolResult(42)).toBe(42)
+  })
+})

--- a/apps/backend/src/api/admin/assistant/chat/route.ts
+++ b/apps/backend/src/api/admin/assistant/chat/route.ts
@@ -55,6 +55,92 @@ import type { AdminAssistantChatReq } from "./validators"
 const FEATURE = "admin/assistant/chat"
 const ROLE = "ai_admin_assistant"
 
+/**
+ * Ceiling on a single tool result, in serialised bytes.
+ *
+ * A tool result is streamed to the client, stored in the thread, and sent back
+ * up on EVERY subsequent turn — so one large result is paid for repeatedly. A
+ * Data Plumbing sweep returns one `changes` row per affected record, which for
+ * a wide backfill runs to hundreds of kB and used to push the next request past
+ * the body limit ("Payload too large"). Raising that limit was the actual fix;
+ * this keeps a single job from silently eating the whole budget anyway.
+ *
+ * 64kB is far more than any result a human reads in a chat, and the model gets
+ * an explicit note that it was truncated rather than a silently short list.
+ */
+const MAX_TOOL_RESULT_BYTES = 64 * 1024
+
+/**
+ * Trim an oversized tool result to something a thread can carry.
+ *
+ * Arrays are the only thing that grows without bound here (`changes`, `runs`,
+ * result rows), so the biggest one is truncated and annotated. The summary,
+ * counts and every scalar field survive untouched — those are what the operator
+ * is reading, and dropping them to save bytes would defeat the point.
+ */
+export const capToolResult = (result: any): any => {
+  if (!result || typeof result !== "object") {
+    return result
+  }
+
+  const size = (v: unknown) => {
+    try {
+      return JSON.stringify(v)?.length ?? 0
+    } catch {
+      return 0
+    }
+  }
+
+  if (size(result) <= MAX_TOOL_RESULT_BYTES) {
+    return result
+  }
+
+  // Walk one level into the payload — tool results are `{ data: {...} }` or a
+  // flat object; either way the unbounded arrays sit at the top of one of them.
+  const trimContainer = (obj: any): any => {
+    if (!obj || typeof obj !== "object" || Array.isArray(obj)) {
+      return obj
+    }
+    const entries = Object.entries(obj)
+    const biggest = entries
+      .filter(([, v]) => Array.isArray(v) && v.length > 1)
+      .sort((a, b) => size(b[1]) - size(a[1]))[0]
+
+    if (!biggest) {
+      return obj
+    }
+
+    const [key, arr] = biggest as [string, unknown[]]
+    // Keep whatever prefix fits, always at least one row so the shape is legible.
+    let keep = arr.length
+    while (keep > 1 && size(arr.slice(0, keep)) > MAX_TOOL_RESULT_BYTES / 2) {
+      keep = Math.floor(keep / 2)
+    }
+
+    return {
+      ...obj,
+      [key]: arr.slice(0, keep),
+      truncated: {
+        field: key,
+        shown: keep,
+        total: arr.length,
+        note: `${key} was truncated to keep the conversation within its size budget. ${
+          arr.length - keep
+        } more row(s) exist — narrow the request, or read the full set via the audit log / admin UI.`,
+      },
+    }
+  }
+
+  const trimmed = trimContainer(result)
+  if (size(trimmed) <= MAX_TOOL_RESULT_BYTES) {
+    return trimmed
+  }
+  if (result.data && typeof result.data === "object") {
+    return { ...result, data: trimContainer(result.data) }
+  }
+  return trimmed
+}
+
 const SYSTEM_PROMPT = `You are the JYT admin assistant. You help platform operators run the business by calling Admin API tools on their behalf — reading orders, products, customers, partners, stores, designs, production runs, inventory, payments and campaigns, and (in later tiers) acting on them.
 
 ## How to work
@@ -168,7 +254,8 @@ export const POST = async (
             : "") +
           renderToolGuidance(def),
         inputSchema: jsonSchema(buildToolInputSchema(def)),
-        execute: async (input: any) => dispatchAdminTool(ctx, def.name, input),
+        execute: async (input: any) =>
+          capToolResult(await dispatchAdminTool(ctx, def.name, input)),
       }),
     ])
   )

--- a/apps/backend/src/api/admin/designs/[id]/consumption-logs/route.ts
+++ b/apps/backend/src/api/admin/designs/[id]/consumption-logs/route.ts
@@ -18,6 +18,7 @@ export const POST = async (
       inventory_item_id: req.validatedBody.inventoryItemId,
       raw_material_id: req.validatedBody.rawMaterialId,
       quantity: req.validatedBody.quantity,
+      quantity_basis: req.validatedBody.quantityBasis ?? null,
       unit_cost: req.validatedBody.unitCost,
       unit_of_measure: req.validatedBody.unitOfMeasure,
       consumption_type: req.validatedBody.consumptionType,

--- a/apps/backend/src/api/admin/designs/[id]/consumption-logs/validators.ts
+++ b/apps/backend/src/api/admin/designs/[id]/consumption-logs/validators.ts
@@ -5,6 +5,7 @@ export const AdminPostConsumptionLogReq = z.object({
   rawMaterialId: z.string().optional(),
   productionRunId: z.string().optional(),
   quantity: z.number().positive(),
+  quantityBasis: z.enum(["total", "per_piece"]).optional(),
   unitCost: z.number().positive().optional(),
   unitOfMeasure: z
     .enum([

--- a/apps/backend/src/api/admin/ops/maintenance-jobs/__tests__/apply-committed-consumption-job.unit.spec.ts
+++ b/apps/backend/src/api/admin/ops/maintenance-jobs/__tests__/apply-committed-consumption-job.unit.spec.ts
@@ -1,0 +1,202 @@
+const runInventoryLevels = jest.fn().mockResolvedValue({ result: [] })
+
+jest.mock("@medusajs/medusa/core-flows", () => ({
+  updateInventoryLevelsWorkflow: jest.fn(() => ({ run: runInventoryLevels })),
+}))
+
+import { applyCommittedConsumptionJob } from "../apply-committed-consumption-job"
+
+/**
+ * #1248 — the container-bound half of `apply-committed-consumption-to-inventory`.
+ *
+ * The planner is covered exhaustively in
+ * `workflows/consumption-logs/__tests__/apply-to-inventory.unit.spec.ts`, and
+ * only the planner was — which is how the first prod apply died with
+ * `Item undefined is not stocked at location undefined`. The job handed
+ * `updateInventoryLevelsWorkflow` just `{ id, stocked_quantity }`, but
+ * `updateInventoryLevels_` ignores `id` and re-resolves the level from
+ * `(inventory_item_id, location_id)`. A dry-run never reaches that call, so the
+ * defect was invisible until the apply.
+ *
+ * These tests drive `run()` against a fake container so the WRITE SHAPE itself
+ * is asserted, not just the arithmetic that decides it.
+ */
+
+const BRAND_LOC = "sloc_brand"
+const ITEM = "iitem_1"
+const LEVEL = "iilev_1"
+
+type Log = Record<string, any>
+
+const makeContainer = (opts: {
+  logs: Log[]
+  levels?: Array<Record<string, any>>
+  runs?: Array<Record<string, any>>
+}) => {
+  const updateConsumptionLogs = jest.fn().mockResolvedValue(undefined)
+  const linkCreate = jest.fn().mockResolvedValue(undefined)
+  const linkDismiss = jest.fn().mockResolvedValue(undefined)
+
+  const levels = opts.levels ?? [
+    {
+      id: LEVEL,
+      inventory_item_id: ITEM,
+      location_id: BRAND_LOC,
+      stocked_quantity: 10,
+    },
+  ]
+
+  const query = {
+    graph: jest.fn(async ({ entity }: { entity: string }) => {
+      if (entity === "inventory_level") {
+        return { data: levels }
+      }
+      // design↔inventory link mirror — absent here, so the job skips it.
+      return { data: [] }
+    }),
+  }
+
+  const container = {
+    resolve: (key: string) => {
+      if (key === "query") return query
+      if (key === "link" || key === "remoteLink") {
+        return { create: linkCreate, dismiss: linkDismiss }
+      }
+      if (key === "production_runs") {
+        return {
+          listAndCountProductionRuns: jest
+            .fn()
+            .mockResolvedValue([opts.runs ?? [], (opts.runs ?? []).length]),
+        }
+      }
+      // consumption_log
+      return {
+        listAndCountConsumptionLogs: jest
+          .fn()
+          .mockResolvedValue([opts.logs, opts.logs.length]),
+        updateConsumptionLogs,
+      }
+    },
+  } as any
+
+  return { container, updateConsumptionLogs, query }
+}
+
+const committedLog = (over: Log = {}): Log => ({
+  id: "log_1",
+  design_id: "design_1",
+  production_run_id: null,
+  quantity_basis: "total",
+  inventory_item_id: ITEM,
+  quantity: 2,
+  is_committed: true,
+  location_id: null,
+  metadata: null,
+  ...over,
+})
+
+beforeEach(() => {
+  runInventoryLevels.mockClear()
+})
+
+describe("apply-committed-consumption-to-inventory — level update shape", () => {
+  it("sends inventory_item_id and location_id, not just the level id", async () => {
+    const { container } = makeContainer({ logs: [committedLog()] })
+
+    const result = await applyCommittedConsumptionJob.run(container, {
+      dry_run: false,
+      params: { location_id: BRAND_LOC },
+    } as any)
+
+    expect(result.applied).toBe(true)
+    expect(runInventoryLevels).toHaveBeenCalledTimes(1)
+
+    const [{ input }] = runInventoryLevels.mock.calls[0]
+    expect(input.updates).toEqual([
+      {
+        id: LEVEL,
+        inventory_item_id: ITEM,
+        location_id: BRAND_LOC,
+        stocked_quantity: 8,
+      },
+    ])
+  })
+
+  it("never emits an update missing the item/location pair", async () => {
+    const { container } = makeContainer({
+      logs: [
+        committedLog({ id: "log_1", quantity: 2 }),
+        committedLog({ id: "log_2", quantity: 3 }),
+      ],
+    })
+
+    await applyCommittedConsumptionJob.run(container, {
+      dry_run: false,
+      params: { location_id: BRAND_LOC },
+    } as any)
+
+    const [{ input }] = runInventoryLevels.mock.calls[0]
+    for (const u of input.updates) {
+      expect(typeof u.inventory_item_id).toBe("string")
+      expect(typeof u.location_id).toBe("string")
+      expect(u.inventory_item_id).not.toBeUndefined()
+      expect(u.location_id).not.toBeUndefined()
+    }
+    // Two logs on one item collapse to a single carried-forward level write.
+    expect(input.updates).toHaveLength(1)
+    expect(input.updates[0].stocked_quantity).toBe(5)
+  })
+
+  it("writes nothing at all on a dry run", async () => {
+    const { container, updateConsumptionLogs } = makeContainer({
+      logs: [committedLog()],
+    })
+
+    const result = await applyCommittedConsumptionJob.run(container, {
+      dry_run: true,
+      params: { location_id: BRAND_LOC },
+    } as any)
+
+    expect(result.applied).toBe(false)
+    expect(result.changes).toHaveLength(1)
+    expect(runInventoryLevels).not.toHaveBeenCalled()
+    expect(updateConsumptionLogs).not.toHaveBeenCalled()
+  })
+
+  it("stamps every applied log so a re-run cannot double-deduct", async () => {
+    const { container, updateConsumptionLogs } = makeContainer({
+      logs: [committedLog({ metadata: { committed_at: "2026-07-17" } })],
+    })
+
+    await applyCommittedConsumptionJob.run(container, {
+      dry_run: false,
+      params: { location_id: BRAND_LOC },
+    } as any)
+
+    expect(updateConsumptionLogs).toHaveBeenCalledTimes(1)
+    const stamped = updateConsumptionLogs.mock.calls[0][0]
+    expect(stamped.id).toBe("log_1")
+    // the pre-existing metadata survives the stamp
+    expect(stamped.metadata.committed_at).toBe("2026-07-17")
+    expect(stamped.metadata.inventory_applied_at).toEqual(expect.any(String))
+    expect(stamped.metadata.inventory_applied_location_id).toBe(BRAND_LOC)
+  })
+
+  it("does not touch inventory when every log is skipped", async () => {
+    // No level at the brand location ⇒ partner-held ⇒ skip.
+    const { container, updateConsumptionLogs } = makeContainer({
+      logs: [committedLog()],
+      levels: [],
+    })
+
+    const result = await applyCommittedConsumptionJob.run(container, {
+      dry_run: false,
+      params: { location_id: BRAND_LOC },
+    } as any)
+
+    expect(result.applied).toBe(false)
+    expect(runInventoryLevels).not.toHaveBeenCalled()
+    expect(updateConsumptionLogs).not.toHaveBeenCalled()
+    expect(result.summary).toMatch(/Skipped/)
+  })
+})

--- a/apps/backend/src/api/admin/ops/maintenance-jobs/__tests__/repair-consumption-log.unit.spec.ts
+++ b/apps/backend/src/api/admin/ops/maintenance-jobs/__tests__/repair-consumption-log.unit.spec.ts
@@ -1,0 +1,193 @@
+import {
+  planConsumptionLogRepair,
+  repairConsumptionLogJob,
+} from "../repair-consumption-log-job"
+import { getMaintenanceJob, MAINTENANCE_JOBS } from "../registry"
+
+/**
+ * #1248 — correcting a consumption log, which nothing could do before.
+ *
+ * The live case: log 01KXQNH5301PBA9H2BF9ZWWAJJ on "Butterfly in muslin" carries
+ * location sloc_01KKTXV7…, but 5210-MUSLIN-100S is stocked only at Dharamshala
+ * (sloc_01JPAQVG…). The apply job reads a foreign location as partner-held and
+ * skips it, so 4 m never leaves the books.
+ */
+
+const DHARAMSHALA = "sloc_01JPAQVGYJR3CDP2Q2AYV7GRDR"
+const WRONG_LOC = "sloc_01KKTXV7B3EFCNSAK4WD1JQW7A"
+
+const log = (over: Record<string, any> = {}) => ({
+  id: "01KXQNH5301PBA9H2BF9ZWWAJJ",
+  design_id: "01KWVA4SB9HRWYE9Z7D5P1MAFP",
+  inventory_item_id: "iitem_01K76M7XBNH7K1ER46WAXT7BY6",
+  quantity: 4,
+  quantity_basis: null,
+  location_id: WRONG_LOC,
+  is_committed: true,
+  metadata: { committed_at: "2026-07-17T09:11:44.151Z" },
+  ...over,
+})
+
+describe("planConsumptionLogRepair", () => {
+  it("moves the log to the location the material is actually stocked at", () => {
+    const changes = planConsumptionLogRepair(log(), { location_id: DHARAMSHALA })
+    expect(changes).toEqual([
+      {
+        entity: "consumption_log",
+        id: "01KXQNH5301PBA9H2BF9ZWWAJJ",
+        field: "location_id",
+        before: WRONG_LOC,
+        after: DHARAMSHALA,
+      },
+    ])
+  })
+
+  it("corrects several fields at once", () => {
+    const changes = planConsumptionLogRepair(log(), {
+      location_id: DHARAMSHALA,
+      quantity: 2,
+      quantity_basis: "per_piece",
+    })
+    expect(changes.map((c) => c.field)).toEqual([
+      "location_id",
+      "quantity",
+      "quantity_basis",
+    ])
+  })
+
+  it("emits nothing for a field already at the requested value", () => {
+    const changes = planConsumptionLogRepair(log({ location_id: DHARAMSHALA }), {
+      location_id: DHARAMSHALA,
+    })
+    expect(changes).toEqual([])
+  })
+
+  it("sets a basis on a legacy log that has none", () => {
+    const changes = planConsumptionLogRepair(log(), { quantity_basis: "total" })
+    expect(changes[0]).toMatchObject({
+      field: "quantity_basis",
+      before: null,
+      after: "total",
+    })
+  })
+
+  it("touches only what was asked for", () => {
+    const changes = planConsumptionLogRepair(log(), { quantity: 2 })
+    expect(changes).toHaveLength(1)
+    expect(changes[0].field).toBe("quantity")
+  })
+})
+
+const makeContainer = (row: Record<string, any> | null) => {
+  const updateConsumptionLogs = jest.fn().mockResolvedValue(undefined)
+  const container = {
+    resolve: () => ({
+      retrieveConsumptionLog: jest.fn(async () => {
+        if (!row) throw new Error("not found")
+        return row
+      }),
+      updateConsumptionLogs,
+    }),
+  } as any
+  return { container, updateConsumptionLogs }
+}
+
+describe("repair-consumption-log — run()", () => {
+  it("previews without writing on a dry run", async () => {
+    const { container, updateConsumptionLogs } = makeContainer(log())
+
+    const res = await repairConsumptionLogJob.run(container, {
+      dry_run: true,
+      params: { log_id: log().id, set_location_id: DHARAMSHALA },
+    } as any)
+
+    expect(res.applied).toBe(false)
+    expect(res.changes).toHaveLength(1)
+    expect(updateConsumptionLogs).not.toHaveBeenCalled()
+    expect(res.summary).toMatch(/Would correct/)
+  })
+
+  it("writes only the corrected fields", async () => {
+    const { container, updateConsumptionLogs } = makeContainer(log())
+
+    const res = await repairConsumptionLogJob.run(container, {
+      dry_run: false,
+      params: { log_id: log().id, set_location_id: DHARAMSHALA, set_quantity: 2 },
+    } as any)
+
+    expect(res.applied).toBe(true)
+    expect(updateConsumptionLogs).toHaveBeenCalledWith({
+      id: log().id,
+      location_id: DHARAMSHALA,
+      quantity: 2,
+    })
+  })
+
+  it("refuses a log whose deduction already moved stock", async () => {
+    const { container } = makeContainer(
+      log({ metadata: { inventory_applied_at: "2026-08-11T09:56:00.000Z" } })
+    )
+
+    await expect(
+      repairConsumptionLogJob.run(container, {
+        dry_run: true,
+        params: { log_id: log().id, set_quantity: 2 },
+      } as any)
+    ).rejects.toThrow(/already applied to inventory/)
+  })
+
+  it("refuses a call that asks for no correction at all", async () => {
+    const { container } = makeContainer(log())
+
+    await expect(
+      repairConsumptionLogJob.run(container, {
+        dry_run: true,
+        params: { log_id: log().id },
+      } as any)
+    ).rejects.toThrow(/nothing to correct/)
+  })
+
+  it("rejects a non-positive quantity rather than storing it", async () => {
+    const { container } = makeContainer(log())
+
+    await expect(
+      repairConsumptionLogJob.run(container, {
+        dry_run: true,
+        params: { log_id: log().id, set_quantity: 0 },
+      } as any)
+    ).rejects.toThrow()
+  })
+
+  it("404s on an unknown log", async () => {
+    const { container } = makeContainer(null)
+
+    await expect(
+      repairConsumptionLogJob.run(container, {
+        dry_run: true,
+        params: { log_id: "nope", set_quantity: 2 },
+      } as any)
+    ).rejects.toThrow(/not found/)
+  })
+
+  it("reports a no-op plainly instead of claiming a change", async () => {
+    const { container, updateConsumptionLogs } = makeContainer(
+      log({ location_id: DHARAMSHALA })
+    )
+
+    const res = await repairConsumptionLogJob.run(container, {
+      dry_run: false,
+      params: { log_id: log().id, set_location_id: DHARAMSHALA },
+    } as any)
+
+    expect(res.applied).toBe(false)
+    expect(updateConsumptionLogs).not.toHaveBeenCalled()
+    expect(res.summary).toMatch(/already holds the requested values/)
+  })
+})
+
+describe("repair-consumption-log — registry wiring", () => {
+  it("is registered and resolvable by id", () => {
+    expect(getMaintenanceJob("repair-consumption-log")).toBe(repairConsumptionLogJob)
+    expect(MAINTENANCE_JOBS).toContain(repairConsumptionLogJob)
+  })
+})

--- a/apps/backend/src/api/admin/ops/maintenance-jobs/__tests__/rewind-production-run.unit.spec.ts
+++ b/apps/backend/src/api/admin/ops/maintenance-jobs/__tests__/rewind-production-run.unit.spec.ts
@@ -1,0 +1,353 @@
+import {
+  fieldsToClearForRewind,
+  planRunRewind,
+  rewindProductionRunJob,
+} from "../rewind-production-run-job"
+import { getMaintenanceJob, MAINTENANCE_JOBS } from "../registry"
+
+/**
+ * #1228/#1248 — rewinding a run that was completed without its data.
+ *
+ * The prod case: prod_run_01KWPVZ4R2PWK6DW1X8X5DKNZE ran accept → start →
+ * finish → complete in 36 seconds with `produced_quantity` null, no consumption
+ * logged, and its two dispatch tasks left at `accepted`. Nothing in the
+ * platform could put it back.
+ */
+
+const completedRun = (over: Record<string, any> = {}) => ({
+  id: "prod_run_1",
+  status: "completed",
+  parent_run_id: null,
+  partner_id: "partner_1",
+  accepted_at: "2026-08-11T09:06:42.621Z",
+  started_at: "2026-08-11T09:06:47.997Z",
+  finished_at: "2026-08-11T09:06:53.893Z",
+  completed_at: "2026-08-11T09:06:59.193Z",
+  produced_quantity: null,
+  rejected_quantity: null,
+  rejection_reason: null,
+  rejection_notes: null,
+  completion_notes: null,
+  finish_notes: null,
+  dispatch_state: "completed",
+  dispatch_started_at: "2026-08-11T09:06:23.074Z",
+  dispatch_completed_at: "2026-08-11T09:06:24.218Z",
+  cancelled_at: null,
+  deleted_at: null,
+  ...over,
+})
+
+describe("fieldsToClearForRewind", () => {
+  it("keeps accepted_at/started_at when rewinding to in_progress", () => {
+    const fields = fieldsToClearForRewind("in_progress")
+    expect(fields).toContain("completed_at")
+    expect(fields).toContain("finished_at")
+    expect(fields).toContain("produced_quantity")
+    expect(fields).not.toContain("accepted_at")
+    expect(fields).not.toContain("started_at")
+  })
+
+  it("clears the acceptance stamps when rewinding behind acceptance", () => {
+    const fields = fieldsToClearForRewind("sent_to_partner")
+    expect(fields).toContain("accepted_at")
+    expect(fields).toContain("started_at")
+    // Still sent — the dispatch itself stands.
+    expect(fields).not.toContain("dispatch_state")
+  })
+
+  it("rewinds the dispatch cycle only when going back to approved", () => {
+    const fields = fieldsToClearForRewind("approved")
+    expect(fields).toContain("dispatch_state")
+    expect(fields).toContain("dispatch_started_at")
+    expect(fields).toContain("dispatch_completed_at")
+  })
+})
+
+describe("planRunRewind", () => {
+  const byField = (changes: any[], field: string) =>
+    changes.find((c) => c.field === field)
+
+  it("moves the status and clears the completion stamps", () => {
+    const changes = planRunRewind(completedRun(), "in_progress")
+
+    expect(byField(changes, "status")).toMatchObject({
+      before: "completed",
+      after: "in_progress",
+    })
+    expect(byField(changes, "completed_at")).toMatchObject({
+      before: "2026-08-11T09:06:59.193Z",
+      after: null,
+    })
+    expect(byField(changes, "finished_at")?.after).toBeNull()
+  })
+
+  it("does not emit a change for a field already at its rewound value", () => {
+    // produced_quantity is ALREADY null on the prod run — the defect, not a diff.
+    const changes = planRunRewind(completedRun(), "in_progress")
+    expect(byField(changes, "produced_quantity")).toBeUndefined()
+  })
+
+  it("clears a produced_quantity that was recorded", () => {
+    const changes = planRunRewind(
+      completedRun({ produced_quantity: 3 }),
+      "in_progress"
+    )
+    expect(byField(changes, "produced_quantity")).toMatchObject({
+      before: 3,
+      after: null,
+    })
+  })
+
+  it("rewinds dispatch_state to 'idle', never null (non-nullable enum)", () => {
+    const changes = planRunRewind(completedRun(), "approved")
+    expect(byField(changes, "dispatch_state")).toMatchObject({
+      before: "completed",
+      after: "idle",
+    })
+  })
+
+  it("emits nothing when the run already sits at the target", () => {
+    const alreadyThere = completedRun({
+      status: "in_progress",
+      finished_at: null,
+      completed_at: null,
+      rejection_reason: null,
+      rejection_notes: null,
+      completion_notes: null,
+      finish_notes: null,
+    })
+    expect(planRunRewind(alreadyThere, "in_progress")).toEqual([])
+  })
+})
+
+// ---------------------------------------------------------------------------
+// run() — the container-bound half
+// ---------------------------------------------------------------------------
+
+const makeContainer = (opts: {
+  run: Record<string, any>
+  parent?: Record<string, any>
+  logs?: any[]
+  tasks?: any[]
+}) => {
+  const updateProductionRuns = jest.fn().mockResolvedValue(undefined)
+  const updateTasks = jest.fn().mockResolvedValue(undefined)
+  const createProductionRunActivities = jest.fn().mockResolvedValue(undefined)
+
+  const runs: Record<string, any> = { [opts.run.id]: opts.run }
+  if (opts.parent) {
+    runs[opts.parent.id] = opts.parent
+  }
+
+  const container = {
+    resolve: (key: string) => {
+      if (key === "query") {
+        return {
+          graph: jest.fn().mockResolvedValue({
+            data: [{ id: opts.run.id, tasks: opts.tasks ?? [] }],
+          }),
+        }
+      }
+      if (key === "production_runs") {
+        return {
+          retrieveProductionRun: jest.fn(async (id: string) => {
+            if (!runs[id]) throw new Error("not found")
+            return runs[id]
+          }),
+          updateProductionRuns,
+          createProductionRunActivities,
+        }
+      }
+      if (key === "consumption_log") {
+        const logs = opts.logs ?? []
+        return {
+          listAndCountConsumptionLogs: jest
+            .fn()
+            .mockResolvedValue([logs, logs.length]),
+        }
+      }
+      return { updateTasks }
+    },
+  } as any
+
+  return { container, updateProductionRuns, updateTasks, createProductionRunActivities }
+}
+
+describe("rewind-production-run — run()", () => {
+  it("previews without writing on a dry run", async () => {
+    const { container, updateProductionRuns, updateTasks } = makeContainer({
+      run: completedRun(),
+      tasks: [{ id: "task_1", status: "completed", title: "Sampling" }],
+    })
+
+    const result = await rewindProductionRunJob.run(container, {
+      dry_run: true,
+      params: { production_run_id: "prod_run_1" },
+    } as any)
+
+    expect(result.applied).toBe(false)
+    expect(result.changes.length).toBeGreaterThan(0)
+    expect(updateProductionRuns).not.toHaveBeenCalled()
+    expect(updateTasks).not.toHaveBeenCalled()
+    expect(result.summary).toMatch(/Would rewind/)
+  })
+
+  it("writes the run, reopens closed tasks and records the timeline entry", async () => {
+    const {
+      container,
+      updateProductionRuns,
+      updateTasks,
+      createProductionRunActivities,
+    } = makeContainer({
+      run: completedRun(),
+      tasks: [
+        { id: "task_1", status: "completed", title: "production-run-x" },
+        { id: "task_2", status: "cancelled", title: "Stitching" },
+        { id: "task_3", status: "accepted", title: "Sampling" },
+      ],
+    })
+
+    const result = await rewindProductionRunJob.run(container, {
+      dry_run: false,
+      params: { production_run_id: "prod_run_1" },
+    } as any)
+
+    expect(result.applied).toBe(true)
+    expect(updateProductionRuns).toHaveBeenCalledWith(
+      expect.objectContaining({
+        id: "prod_run_1",
+        status: "in_progress",
+        completed_at: null,
+        finished_at: null,
+      })
+    )
+    // Only the CLOSED ones reopen — an already-open task is left alone.
+    expect(updateTasks).toHaveBeenCalledTimes(2)
+    expect(updateTasks).toHaveBeenCalledWith({ id: "task_1", status: "in_progress" })
+    expect(updateTasks).toHaveBeenCalledWith({ id: "task_2", status: "in_progress" })
+    expect(createProductionRunActivities).toHaveBeenCalledWith(
+      expect.objectContaining({ kind: "rewound" })
+    )
+  })
+
+  it("refuses when consumption logs would be duplicated by re-completion", async () => {
+    const { container } = makeContainer({
+      run: completedRun(),
+      logs: [{ id: "log_1" }, { id: "log_2" }],
+    })
+
+    await expect(
+      rewindProductionRunJob.run(container, {
+        dry_run: true,
+        params: { production_run_id: "prod_run_1" },
+      } as any)
+    ).rejects.toThrow(/2 consumption log/)
+  })
+
+  it("proceeds on the same run when forced, and says so", async () => {
+    const { container } = makeContainer({
+      run: completedRun(),
+      logs: [{ id: "log_1" }],
+    })
+
+    const result = await rewindProductionRunJob.run(container, {
+      dry_run: true,
+      params: { production_run_id: "prod_run_1", force: true },
+    } as any)
+
+    expect(result.summary).toMatch(/1 consumption log\(s\) already attached/)
+  })
+
+  it("refuses to rewind a cancelled run — that would resurrect it", async () => {
+    const { container } = makeContainer({
+      run: completedRun({ status: "cancelled", cancelled_at: "2026-08-01" }),
+    })
+
+    await expect(
+      rewindProductionRunJob.run(container, {
+        dry_run: true,
+        params: { production_run_id: "prod_run_1" },
+      } as any)
+    ).rejects.toThrow(/cancelled/)
+  })
+
+  it("leaves the parent alone unless asked, and says the parent was skipped", async () => {
+    const { container, updateProductionRuns } = makeContainer({
+      run: completedRun({ parent_run_id: "prod_run_parent" }),
+      parent: completedRun({ id: "prod_run_parent" }),
+    })
+
+    const result = await rewindProductionRunJob.run(container, {
+      dry_run: false,
+      params: { production_run_id: "prod_run_1" },
+    } as any)
+
+    expect(result.summary).toMatch(/parent prod_run_parent left as-is/)
+    expect(updateProductionRuns).toHaveBeenCalledTimes(1)
+  })
+
+  it("rewinds the parent too when asked", async () => {
+    const { container, updateProductionRuns } = makeContainer({
+      run: completedRun({ parent_run_id: "prod_run_parent" }),
+      parent: completedRun({ id: "prod_run_parent" }),
+    })
+
+    const result = await rewindProductionRunJob.run(container, {
+      dry_run: false,
+      params: { production_run_id: "prod_run_1", rewind_parent: true },
+    } as any)
+
+    expect(updateProductionRuns).toHaveBeenCalledTimes(2)
+    expect(updateProductionRuns).toHaveBeenCalledWith(
+      expect.objectContaining({ id: "prod_run_parent", status: "in_progress" })
+    )
+    expect(result.summary).toMatch(/and parent prod_run_parent/)
+  })
+
+  it("always warns that stocked finished goods are not reversed", async () => {
+    const { container } = makeContainer({ run: completedRun() })
+
+    const result = await rewindProductionRunJob.run(container, {
+      dry_run: true,
+      params: { production_run_id: "prod_run_1" },
+    } as any)
+
+    expect(result.summary).toMatch(/finished goods .* NOT reversed/)
+  })
+
+  it("404s on an unknown run", async () => {
+    const { container } = makeContainer({ run: completedRun() })
+
+    await expect(
+      rewindProductionRunJob.run(container, {
+        dry_run: true,
+        params: { production_run_id: "prod_run_nope" },
+      } as any)
+    ).rejects.toThrow(/not found/)
+  })
+
+  it("rejects an unknown to_status rather than silently defaulting", async () => {
+    const { container } = makeContainer({ run: completedRun() })
+
+    await expect(
+      rewindProductionRunJob.run(container, {
+        dry_run: true,
+        params: { production_run_id: "prod_run_1", to_status: "banana" },
+      } as any)
+    ).rejects.toThrow(/to_status/)
+  })
+})
+
+describe("rewind-production-run — registry wiring", () => {
+  it("is registered and resolvable by id", () => {
+    expect(getMaintenanceJob("rewind-production-run")).toBe(rewindProductionRunJob)
+    expect(MAINTENANCE_JOBS).toContain(rewindProductionRunJob)
+  })
+
+  it("declares production_run_id as its only required param", () => {
+    const required = rewindProductionRunJob.params
+      .filter((p) => p.required)
+      .map((p) => p.name)
+    expect(required).toEqual(["production_run_id"])
+  })
+})

--- a/apps/backend/src/api/admin/ops/maintenance-jobs/apply-committed-consumption-job.ts
+++ b/apps/backend/src/api/admin/ops/maintenance-jobs/apply-committed-consumption-job.ts
@@ -39,6 +39,8 @@ const paramsSchema = z.object({
   /** Override the resolved brand location (escape hatch for a second warehouse). */
   location_id: z.string().min(1).optional(),
   limit: z.number().int().positive().optional(),
+  /** Skip (don't stamp) any log whose shortfall would exceed this. */
+  max_shortfall: z.number().nonnegative().optional(),
 })
 
 export const applyCommittedConsumptionJob: MaintenanceJob = {
@@ -72,6 +74,13 @@ export const applyCommittedConsumptionJob: MaintenanceJob = {
       required: false,
       description: "Cap the number of logs considered (applied after ordering)",
     },
+    {
+      name: "max_shortfall",
+      type: "number",
+      required: false,
+      description:
+        "Refuse any deduction short by more than this — the log is skipped, not stamped. Use 0 to apply only logs fully covered by stock on hand.",
+    },
   ],
   run: async (container, { dry_run, params }): Promise<MaintenanceJobResult> => {
     const parsed = paramsSchema.safeParse(params)
@@ -81,7 +90,8 @@ export const applyCommittedConsumptionJob: MaintenanceJob = {
         parsed.error.issues.map((i) => i.message).join("; ")
       )
     }
-    const { design_id, design_ids, location_id, limit } = parsed.data
+    const { design_id, design_ids, location_id, limit, max_shortfall } =
+      parsed.data
 
     const query: any = container.resolve(ContainerRegistrationKeys.QUERY)
     const consumptionService: any = container.resolve(CONSUMPTION_LOG_MODULE)
@@ -140,6 +150,7 @@ export const applyCommittedConsumptionJob: MaintenanceJob = {
       brandLocationId,
       logs: considered,
       brandLevels,
+      maxShortfall: max_shortfall,
     })
     const applies = decisions.filter((d) => d.action === "apply") as Extract<
       (typeof decisions)[number],

--- a/apps/backend/src/api/admin/ops/maintenance-jobs/apply-committed-consumption-job.ts
+++ b/apps/backend/src/api/admin/ops/maintenance-jobs/apply-committed-consumption-job.ts
@@ -247,8 +247,18 @@ export const applyCommittedConsumptionJob: MaintenanceJob = {
       for (const d of applies) {
         finalByItem.set(d.inventory_item_id, d.after)
       }
+      // `inventory_item_id` + `location_id` are REQUIRED, not decoration:
+      // `updateInventoryLevels_` ignores `id` entirely and re-resolves the level
+      // from the item/location pair. Passing the level id alone made it look up
+      // `(undefined, undefined)` and die with `Item undefined is not stocked at
+      // location undefined` — which is what the first prod apply hit. The step's
+      // compensation reads the same two fields, so omitting them also left the
+      // rollback with nothing to restore. Matches how cancel-inventory-order and
+      // partner-complete-inventory-order already shape their updates.
       const updates = Array.from(finalByItem, ([itemId, stocked]) => ({
         id: levelIdByItem[itemId],
+        inventory_item_id: itemId,
+        location_id: brandLocationId,
         stocked_quantity: stocked,
       }))
       await updateInventoryLevelsWorkflow(container as any).run({

--- a/apps/backend/src/api/admin/ops/maintenance-jobs/apply-committed-consumption-job.ts
+++ b/apps/backend/src/api/admin/ops/maintenance-jobs/apply-committed-consumption-job.ts
@@ -8,6 +8,11 @@ import type { MedusaContainer } from "@medusajs/framework/types"
 import { updateInventoryLevelsWorkflow } from "@medusajs/medusa/core-flows"
 
 import { CONSUMPTION_LOG_MODULE } from "../../../../modules/consumption_log"
+import { PRODUCTION_RUNS_MODULE } from "../../../../modules/production_runs"
+import {
+  isProvenanceRun,
+  leafRuns,
+} from "../../../../workflows/consumption-logs/lib/reconcile-production-consumption"
 import { DESIGN_MODULE } from "../../../../modules/designs"
 import {
   APPLIED_AT_KEY,
@@ -41,6 +46,11 @@ const paramsSchema = z.object({
   limit: z.number().int().positive().optional(),
   /** Skip (don't stamp) any log whose shortfall would exceed this. */
   max_shortfall: z.number().nonnegative().optional(),
+  /**
+   * Treat each log's quantity as a PER-PIECE rate and multiply by the finished
+   * pieces of the design's real production runs. Default true.
+   */
+  per_piece: z.boolean().optional(),
 })
 
 export const applyCommittedConsumptionJob: MaintenanceJob = {
@@ -81,6 +91,13 @@ export const applyCommittedConsumptionJob: MaintenanceJob = {
       description:
         "Refuse any deduction short by more than this — the log is skipped, not stamped. Use 0 to apply only logs fully covered by stock on hand.",
     },
+    {
+      name: "per_piece",
+      type: "boolean",
+      required: false,
+      description:
+        "Treat the logged quantity as PER PIECE and multiply by the design's completed production (default true). Set false to deduct the figure verbatim.",
+    },
   ],
   run: async (container, { dry_run, params }): Promise<MaintenanceJobResult> => {
     const parsed = paramsSchema.safeParse(params)
@@ -92,6 +109,7 @@ export const applyCommittedConsumptionJob: MaintenanceJob = {
     }
     const { design_id, design_ids, location_id, limit, max_shortfall } =
       parsed.data
+    const perPiece = parsed.data.per_piece !== false
 
     const query: any = container.resolve(ContainerRegistrationKeys.QUERY)
     const consumptionService: any = container.resolve(CONSUMPTION_LOG_MODULE)
@@ -117,6 +135,7 @@ export const applyCommittedConsumptionJob: MaintenanceJob = {
     const logs: ConsumptionApplyLog[] = ((rawLogs || []) as any[]).map((l) => ({
       id: l.id,
       design_id: l.design_id ?? null,
+      production_run_id: l.production_run_id ?? null,
       inventory_item_id: l.inventory_item_id ?? null,
       quantity: l.quantity ?? null,
       is_committed: Boolean(l.is_committed),
@@ -146,11 +165,50 @@ export const applyCommittedConsumptionJob: MaintenanceJob = {
       }
     }
 
+    // A logged quantity is a PER-PIECE rate, so it has to be multiplied by what
+    // the design actually finished. Pieces come from the log's own run when it
+    // has one, else from the design's completed leaf runs — with provenance runs
+    // excluded, since those shipped from stock and consumed nothing.
+    let piecesByLog: Record<string, number> | undefined
+    if (perPiece) {
+      const runService: any = container.resolve(PRODUCTION_RUNS_MODULE)
+      const designIds = Array.from(
+        new Set(considered.map((l) => l.design_id).filter(Boolean))
+      ) as string[]
+      const [rawRuns] = designIds.length
+        ? await runService.listAndCountProductionRuns(
+            { design_id: designIds },
+            { take: null }
+          )
+        : [[]]
+      const completed = leafRuns((rawRuns || []) as any[]).filter(
+        (r: any) => r.status === "completed" && !isProvenanceRun(r)
+      )
+      const byDesign: Record<string, number> = {}
+      const byRun: Record<string, number> = {}
+      for (const r of completed as any[]) {
+        const q = Number(r.produced_quantity ?? r.quantity ?? 0) || 0
+        byRun[r.id] = q
+        if (r.design_id) {
+          byDesign[r.design_id] = (byDesign[r.design_id] ?? 0) + q
+        }
+      }
+      piecesByLog = {}
+      for (const l of considered) {
+        const runPieces = l.production_run_id
+          ? byRun[l.production_run_id]
+          : undefined
+        piecesByLog[l.id] =
+          runPieces ?? (l.design_id ? byDesign[l.design_id] ?? 0 : 0)
+      }
+    }
+
     const decisions = planConsumptionApplication({
       brandLocationId,
       logs: considered,
       brandLevels,
       maxShortfall: max_shortfall,
+      piecesByLog,
     })
     const applies = decisions.filter((d) => d.action === "apply") as Extract<
       (typeof decisions)[number],
@@ -160,7 +218,9 @@ export const applyCommittedConsumptionJob: MaintenanceJob = {
     const changes: MaintenanceChange[] = applies.map((d) => ({
       entity: "inventory_level",
       id: `${d.inventory_item_id}@${brandLocationId}`,
-      field: `stocked_quantity (log ${d.log_id})`,
+      field: `stocked_quantity (log ${d.log_id}${
+        d.pieces != null ? `, ${d.per_piece}/pc × ${d.pieces} pcs` : ""
+      })`,
       before: d.before,
       after: d.after,
     }))

--- a/apps/backend/src/api/admin/ops/maintenance-jobs/apply-committed-consumption-job.ts
+++ b/apps/backend/src/api/admin/ops/maintenance-jobs/apply-committed-consumption-job.ts
@@ -50,7 +50,8 @@ const paramsSchema = z.object({
    * Treat each log's quantity as a PER-PIECE rate and multiply by the finished
    * pieces of the design's real production runs. Default true.
    */
-  per_piece: z.boolean().optional(),
+  /** Basis to assume for legacy logs whose quantity_basis is null. */
+  assume_basis: z.enum(["total", "per_piece"]).optional(),
 })
 
 export const applyCommittedConsumptionJob: MaintenanceJob = {
@@ -92,11 +93,11 @@ export const applyCommittedConsumptionJob: MaintenanceJob = {
         "Refuse any deduction short by more than this — the log is skipped, not stamped. Use 0 to apply only logs fully covered by stock on hand.",
     },
     {
-      name: "per_piece",
-      type: "boolean",
+      name: "assume_basis",
+      type: "string",
       required: false,
       description:
-        "Treat the logged quantity as PER PIECE and multiply by the design's completed production (default true). Set false to deduct the figure verbatim.",
+        "total | per_piece — how to read logs written before the form recorded a basis. Omit and those logs are skipped rather than guessed.",
     },
   ],
   run: async (container, { dry_run, params }): Promise<MaintenanceJobResult> => {
@@ -109,7 +110,7 @@ export const applyCommittedConsumptionJob: MaintenanceJob = {
     }
     const { design_id, design_ids, location_id, limit, max_shortfall } =
       parsed.data
-    const perPiece = parsed.data.per_piece !== false
+    const assumeBasis = parsed.data.assume_basis
 
     const query: any = container.resolve(ContainerRegistrationKeys.QUERY)
     const consumptionService: any = container.resolve(CONSUMPTION_LOG_MODULE)
@@ -136,6 +137,7 @@ export const applyCommittedConsumptionJob: MaintenanceJob = {
       id: l.id,
       design_id: l.design_id ?? null,
       production_run_id: l.production_run_id ?? null,
+      quantity_basis: l.quantity_basis ?? null,
       inventory_item_id: l.inventory_item_id ?? null,
       quantity: l.quantity ?? null,
       is_committed: Boolean(l.is_committed),
@@ -170,7 +172,7 @@ export const applyCommittedConsumptionJob: MaintenanceJob = {
     // has one, else from the design's completed leaf runs — with provenance runs
     // excluded, since those shipped from stock and consumed nothing.
     let piecesByLog: Record<string, number> | undefined
-    if (perPiece) {
+    {
       const runService: any = container.resolve(PRODUCTION_RUNS_MODULE)
       const designIds = Array.from(
         new Set(considered.map((l) => l.design_id).filter(Boolean))
@@ -209,6 +211,7 @@ export const applyCommittedConsumptionJob: MaintenanceJob = {
       brandLevels,
       maxShortfall: max_shortfall,
       piecesByLog,
+      assumeBasisWhenUnknown: assumeBasis,
     })
     const applies = decisions.filter((d) => d.action === "apply") as Extract<
       (typeof decisions)[number],

--- a/apps/backend/src/api/admin/ops/maintenance-jobs/reconcile-consumption-vs-production-job.ts
+++ b/apps/backend/src/api/admin/ops/maintenance-jobs/reconcile-consumption-vs-production-job.ts
@@ -1,0 +1,179 @@
+import { ContainerRegistrationKeys, MedusaError } from "@medusajs/framework/utils"
+import { z } from "@medusajs/framework/zod"
+
+import { CONSUMPTION_LOG_MODULE } from "../../../../modules/consumption_log"
+import { PRODUCTION_RUNS_MODULE } from "../../../../modules/production_runs"
+import {
+  reconcileDesigns,
+  type ReconcileLog,
+  type ReconcileRun,
+} from "../../../../workflows/consumption-logs/lib/reconcile-production-consumption"
+import type { MaintenanceChange, MaintenanceJob, MaintenanceJobResult } from "./registry"
+
+/**
+ * Data Plumbing — REPORT-ONLY: what each design produced vs what it reported
+ * consuming.
+ *
+ * Committed consumption is the only evidence that material left the shelf, and
+ * that evidence is thin: of nine designs with real production, five logged no
+ * material at all and one reported 1.75 m against nine finished pieces.
+ * Settling those figures against stock would move a rounding error while the
+ * real outflow stayed invisible, so this job measures the gap instead.
+ *
+ * It NEVER writes. `dry_run: false` produces the same report — there is nothing
+ * to apply, because an expected quantity is a model and the stock ledger must
+ * keep meaning "what is on the shelf". Where a variance is real, the fix is to
+ * correct the LOG (mirroring how an admin corrects a partner's reported output),
+ * after which `apply-committed-consumption-to-inventory` deducts the corrected
+ * figure.
+ */
+
+const paramsSchema = z.object({
+  design_id: z.string().min(1).optional(),
+  /**
+   * Expected metres per finished piece, keyed by design id. Accepts a JSON
+   * string too — the ops UI and the MCP tool both pass params as scalars.
+   */
+  rate_per_unit: z
+    .preprocess((v) => {
+      if (typeof v !== "string") {
+        return v
+      }
+      try {
+        return JSON.parse(v)
+      } catch {
+        return v // fall through to the record check, which reports a clear error
+      }
+    }, z.record(z.string(), z.number().positive()))
+    .optional(),
+  /** Flag any design whose implied metres/piece falls below this. */
+  implausible_rate_below: z.number().positive().optional(),
+  /** Only return designs carrying at least one flag. Default true. */
+  flagged_only: z.boolean().optional(),
+})
+
+export const reconcileConsumptionVsProductionJob: MaintenanceJob = {
+  id: "reconcile-consumption-vs-production",
+  label: "Reconcile consumption against production (report-only)",
+  description:
+    "Compare what each design PRODUCED against what it reported CONSUMING. Counts completed leaf runs only (#498) and excludes provenance runs minted from retail fulfillment — those shipped from stock and consumed nothing, so counting them invents material. Flags: production with zero material logged, consumption with no production, implausible metres/piece, and logs not attributed to a production run. Reports an expected/variance figure when a per-unit rate is supplied. NEVER writes — correct the log, then run the apply job.",
+  params: [
+    {
+      name: "design_id",
+      type: "string",
+      required: false,
+      description: "Only this design (omit to scan every design)",
+    },
+    {
+      name: "rate_per_unit",
+      type: "string",
+      required: false,
+      description:
+        'Expected material per finished piece, keyed by design id, e.g. {"01KWWJ0S3Z…": 2.5}',
+    },
+    {
+      name: "implausible_rate_below",
+      type: "number",
+      required: false,
+      description: "Flag designs whose implied metres/piece is under this (default 0.5)",
+    },
+    {
+      name: "flagged_only",
+      type: "boolean",
+      required: false,
+      description: "Return only designs with at least one flag (default true)",
+    },
+  ],
+  run: async (container, { dry_run, params }): Promise<MaintenanceJobResult> => {
+    const parsed = paramsSchema.safeParse(params)
+    if (!parsed.success) {
+      throw new MedusaError(
+        MedusaError.Types.INVALID_DATA,
+        parsed.error.issues.map((i) => i.message).join("; ")
+      )
+    }
+    const { design_id, rate_per_unit, implausible_rate_below, flagged_only } =
+      parsed.data
+
+    const runService: any = container.resolve(PRODUCTION_RUNS_MODULE)
+    const consumptionService: any = container.resolve(CONSUMPTION_LOG_MODULE)
+
+    const runFilters: Record<string, any> = {}
+    const logFilters: Record<string, any> = { is_committed: true }
+    if (design_id) {
+      runFilters.design_id = design_id
+      logFilters.design_id = design_id
+    }
+
+    const [rawRuns] = await runService.listAndCountProductionRuns(runFilters, {
+      take: null,
+    })
+    const [rawLogs] = await consumptionService.listAndCountConsumptionLogs(
+      logFilters,
+      { take: null }
+    )
+
+    const runs: ReconcileRun[] = ((rawRuns || []) as any[]).map((r) => ({
+      id: r.id,
+      design_id: r.design_id ?? null,
+      parent_run_id: r.parent_run_id ?? null,
+      status: r.status ?? null,
+      produced_quantity: r.produced_quantity ?? null,
+      quantity: r.quantity ?? null,
+      metadata: r.metadata ?? null,
+    }))
+    const logs: ReconcileLog[] = ((rawLogs || []) as any[]).map((l) => ({
+      id: l.id,
+      design_id: l.design_id ?? null,
+      inventory_item_id: l.inventory_item_id ?? null,
+      production_run_id: l.production_run_id ?? null,
+      quantity: l.quantity ?? null,
+      is_committed: Boolean(l.is_committed),
+    }))
+
+    const all = reconcileDesigns({
+      runs,
+      logs,
+      ratePerUnit: rate_per_unit,
+      implausibleRateBelow: implausible_rate_below,
+    })
+    const rows = flagged_only === false ? all : all.filter((r) => r.flags.length)
+
+    // Reported as `changes` purely so the ops UI renders the table; before/after
+    // are the observation, not a proposed write.
+    const changes: MaintenanceChange[] = rows.map((r) => ({
+      entity: "design",
+      id: r.design_id,
+      field: `produced ${r.produced} / shipped-from-stock ${r.shipped_from_stock} [${r.flags.join(", ")}]`,
+      before: r.expected ?? r.produced,
+      after: r.consumed,
+    }))
+
+    const counts = rows.reduce<Record<string, number>>((acc, r) => {
+      for (const f of r.flags) {
+        acc[f] = (acc[f] ?? 0) + 1
+      }
+      return acc
+    }, {})
+
+    const summary = [
+      `Reconciled ${all.length} design(s); ${rows.length} flagged`,
+      Object.keys(counts).length
+        ? Object.entries(counts)
+            .sort((a, b) => b[1] - a[1])
+            .map(([f, n]) => `${n}× ${f}`)
+            .join("; ")
+        : "no flags",
+      "report-only — no stock was moved",
+    ].join(". ")
+
+    return {
+      job_id: reconcileConsumptionVsProductionJob.id,
+      dry_run,
+      // Nothing is ever written, so this is false even for dry_run: false.
+      applied: false,
+      summary,
+      changes,
+    }
+  },
+}

--- a/apps/backend/src/api/admin/ops/maintenance-jobs/registry.ts
+++ b/apps/backend/src/api/admin/ops/maintenance-jobs/registry.ts
@@ -91,6 +91,7 @@ import { generateNewsletterWinbackTargetsJob } from "./generate-newsletter-winba
 import { repairInventoryOrderSourceJob } from "./repair-inventory-order-source-job"
 import { repairInventoryOrderRouteJob } from "./repair-inventory-order-route-job"
 import { applyCommittedConsumptionJob } from "./apply-committed-consumption-job"
+import { reconcileConsumptionVsProductionJob } from "./reconcile-consumption-vs-production-job"
 import { backfillGoogleAdsHistoryJob } from "./backfill-google-ads-history-job"
 import { backfillDesignSizeSetsJob } from "./backfill-design-size-sets-job"
 import { backfillPartnerShippingOptionsJob } from "./backfill-partner-shipping-options-job"
@@ -5651,6 +5652,7 @@ export const MAINTENANCE_JOBS: MaintenanceJob[] = [
   repairInventoryOrderSourceJob,
   repairInventoryOrderRouteJob,
   applyCommittedConsumptionJob,
+  reconcileConsumptionVsProductionJob,
   backfillGoogleAdsHistoryJob,
   backfillDesignSizeSetsJob,
   backfillPartnerShippingOptionsJob,

--- a/apps/backend/src/api/admin/ops/maintenance-jobs/registry.ts
+++ b/apps/backend/src/api/admin/ops/maintenance-jobs/registry.ts
@@ -91,6 +91,7 @@ import { generateNewsletterWinbackTargetsJob } from "./generate-newsletter-winba
 import { repairInventoryOrderSourceJob } from "./repair-inventory-order-source-job"
 import { repairInventoryOrderRouteJob } from "./repair-inventory-order-route-job"
 import { rewindProductionRunJob } from "./rewind-production-run-job"
+import { repairConsumptionLogJob } from "./repair-consumption-log-job"
 import { applyCommittedConsumptionJob } from "./apply-committed-consumption-job"
 import { reconcileConsumptionVsProductionJob } from "./reconcile-consumption-vs-production-job"
 import { backfillGoogleAdsHistoryJob } from "./backfill-google-ads-history-job"
@@ -5653,6 +5654,7 @@ export const MAINTENANCE_JOBS: MaintenanceJob[] = [
   repairInventoryOrderSourceJob,
   repairInventoryOrderRouteJob,
   rewindProductionRunJob,
+  repairConsumptionLogJob,
   applyCommittedConsumptionJob,
   reconcileConsumptionVsProductionJob,
   backfillGoogleAdsHistoryJob,

--- a/apps/backend/src/api/admin/ops/maintenance-jobs/registry.ts
+++ b/apps/backend/src/api/admin/ops/maintenance-jobs/registry.ts
@@ -90,6 +90,7 @@ import { recomputeEmailEngagementStatusJob } from "./recompute-email-engagement-
 import { generateNewsletterWinbackTargetsJob } from "./generate-newsletter-winback-targets-job"
 import { repairInventoryOrderSourceJob } from "./repair-inventory-order-source-job"
 import { repairInventoryOrderRouteJob } from "./repair-inventory-order-route-job"
+import { rewindProductionRunJob } from "./rewind-production-run-job"
 import { applyCommittedConsumptionJob } from "./apply-committed-consumption-job"
 import { reconcileConsumptionVsProductionJob } from "./reconcile-consumption-vs-production-job"
 import { backfillGoogleAdsHistoryJob } from "./backfill-google-ads-history-job"
@@ -5651,6 +5652,7 @@ export const MAINTENANCE_JOBS: MaintenanceJob[] = [
   generateNewsletterWinbackTargetsJob,
   repairInventoryOrderSourceJob,
   repairInventoryOrderRouteJob,
+  rewindProductionRunJob,
   applyCommittedConsumptionJob,
   reconcileConsumptionVsProductionJob,
   backfillGoogleAdsHistoryJob,

--- a/apps/backend/src/api/admin/ops/maintenance-jobs/repair-consumption-log-job.ts
+++ b/apps/backend/src/api/admin/ops/maintenance-jobs/repair-consumption-log-job.ts
@@ -1,0 +1,170 @@
+import { MedusaError } from "@medusajs/framework/utils"
+import { z } from "@medusajs/framework/zod"
+
+import { CONSUMPTION_LOG_MODULE } from "../../../../modules/consumption_log"
+import type { MaintenanceChange, MaintenanceJob, MaintenanceJobResult } from "./registry"
+
+/**
+ * Data Plumbing — correct a committed consumption log.
+ *
+ * A consumption log is write-once in practice: there is a POST to create one
+ * and a POST to commit it, and nothing anywhere that edits one. That was fine
+ * while committing was pure accounting, and stopped being fine the moment
+ * committed logs started moving stock — a log recorded against the wrong
+ * location is now a deduction that silently never happens, and there is no way
+ * to put it right.
+ *
+ * The live case: `5210-MUSLIN-100S` is stocked only at Dharamshala
+ * (`sloc_01JPAQVG…`), but its log on "Butterfly in muslin" carries
+ * `sloc_01KKTXV7…`. The apply job reads that as partner-held and skips it, so
+ * 4 m of muslin stays on the books forever.
+ *
+ * Corrections only — this never creates or deletes a log, and it refuses to
+ * touch one whose deduction has already been applied, since the stock movement
+ * was computed from the values being changed.
+ */
+
+const paramsSchema = z
+  .object({
+    log_id: z.string().min(1),
+    /** Move the log to this stock location. */
+    set_location_id: z.string().min(1).optional(),
+    /** Correct the recorded quantity. */
+    set_quantity: z.number().positive().optional(),
+    /** Record what the quantity measures (see #1248). */
+    set_quantity_basis: z.enum(["total", "per_piece"]).optional(),
+  })
+  .refine(
+    (v) =>
+      v.set_location_id !== undefined ||
+      v.set_quantity !== undefined ||
+      v.set_quantity_basis !== undefined,
+    { message: "nothing to correct — pass at least one set_* parameter" }
+  )
+
+/** Stamped by the apply job; its presence means stock already moved. */
+const APPLIED_AT_KEY = "inventory_applied_at"
+
+/**
+ * Diff the requested corrections against the log as it stands.
+ *
+ * Pure, so the decision is checkable without a container. A field already at
+ * the requested value produces no change rather than a no-op write — the same
+ * rule every other job here follows, and what keeps `applied` honest.
+ */
+export function planConsumptionLogRepair(
+  log: Record<string, any>,
+  set: {
+    location_id?: string
+    quantity?: number
+    quantity_basis?: "total" | "per_piece"
+  }
+): MaintenanceChange[] {
+  const changes: MaintenanceChange[] = []
+  const field = (name: string, after: unknown) => {
+    const before = log[name] ?? null
+    if (before === after) {
+      return
+    }
+    changes.push({ entity: "consumption_log", id: log.id, field: name, before, after })
+  }
+
+  if (set.location_id !== undefined) field("location_id", set.location_id)
+  if (set.quantity !== undefined) field("quantity", set.quantity)
+  if (set.quantity_basis !== undefined) field("quantity_basis", set.quantity_basis)
+
+  return changes
+}
+
+export const repairConsumptionLogJob: MaintenanceJob = {
+  id: "repair-consumption-log",
+  label: "Correct a consumption log's location, quantity or basis",
+  description:
+    "Fix a committed consumption log that was recorded wrong — most often at a location the material is not actually stocked at, which makes the apply job skip it as partner-held forever. Corrections only: never creates or deletes a log, and refuses one whose stock deduction has already been applied. Dry-run previews each field.",
+  params: [
+    {
+      name: "log_id",
+      type: "string",
+      required: true,
+      description: "The consumption log to correct, e.g. '01KXQNH5301PBA9H2BF9ZWWAJJ'",
+    },
+    {
+      name: "set_location_id",
+      type: "string",
+      required: false,
+      description:
+        "Move the log to this stock location — use the location the material is actually stocked at",
+    },
+    {
+      name: "set_quantity",
+      type: "number",
+      required: false,
+      description: "Correct the recorded quantity",
+    },
+    {
+      name: "set_quantity_basis",
+      type: "string",
+      required: false,
+      description:
+        "total | per_piece — what the quantity measures. Legacy logs carry neither and are skipped by the apply job until this is set.",
+    },
+  ],
+  run: async (container, { dry_run, params }): Promise<MaintenanceJobResult> => {
+    const parsed = paramsSchema.safeParse(params)
+    if (!parsed.success) {
+      throw new MedusaError(
+        MedusaError.Types.INVALID_DATA,
+        parsed.error.issues.map((i) => i.message).join("; ")
+      )
+    }
+    const { log_id: logId } = parsed.data
+
+    const service: any = container.resolve(CONSUMPTION_LOG_MODULE)
+    const log = await service.retrieveConsumptionLog(logId).catch(() => null)
+    if (!log) {
+      throw new MedusaError(
+        MedusaError.Types.NOT_FOUND,
+        `Consumption log ${logId} not found`
+      )
+    }
+
+    // The deduction was computed from these exact values. Editing them after
+    // the fact would leave the log describing a movement that never happened,
+    // and the idempotency stamp means it will never be re-applied to correct
+    // itself. Reverse the stock by hand first if this really needs changing.
+    const appliedAt = (log.metadata || {})[APPLIED_AT_KEY]
+    if (appliedAt) {
+      throw new MedusaError(
+        MedusaError.Types.NOT_ALLOWED,
+        `Consumption log ${logId} was already applied to inventory at ${appliedAt}. Correcting it now would not move the stock back — reverse the level by hand first, clear metadata.${APPLIED_AT_KEY}, then re-run.`
+      )
+    }
+
+    const changes = planConsumptionLogRepair(log, {
+      location_id: parsed.data.set_location_id,
+      quantity: parsed.data.set_quantity,
+      quantity_basis: parsed.data.set_quantity_basis,
+    })
+
+    if (!dry_run && changes.length > 0) {
+      await service.updateConsumptionLogs({
+        id: logId,
+        ...Object.fromEntries(changes.map((c) => [c.field as string, c.after])),
+      })
+    }
+
+    const summary = changes.length
+      ? `${dry_run ? "Would correct" : "Corrected"} ${changes.length} field(s) on consumption log ${logId}: ${changes
+          .map((c) => `${c.field} ${JSON.stringify(c.before)} → ${JSON.stringify(c.after)}`)
+          .join(", ")}`
+      : `Consumption log ${logId} already holds the requested values — nothing to correct`
+
+    return {
+      job_id: repairConsumptionLogJob.id,
+      dry_run,
+      applied: !dry_run && changes.length > 0,
+      summary,
+      changes,
+    }
+  },
+}

--- a/apps/backend/src/api/admin/ops/maintenance-jobs/rewind-production-run-job.ts
+++ b/apps/backend/src/api/admin/ops/maintenance-jobs/rewind-production-run-job.ts
@@ -1,0 +1,360 @@
+import {
+  ContainerRegistrationKeys,
+  MedusaError,
+} from "@medusajs/framework/utils"
+import { z } from "@medusajs/framework/zod"
+
+import { PRODUCTION_RUNS_MODULE } from "../../../../modules/production_runs"
+import { CONSUMPTION_LOG_MODULE } from "../../../../modules/consumption_log"
+import { TASKS_MODULE } from "../../../../modules/tasks"
+import type { MaintenanceChange, MaintenanceJob, MaintenanceJobResult } from "./registry"
+
+/**
+ * Data Plumbing — rewind a production run that was completed prematurely.
+ *
+ * A partner can drive a run accept → start → finish → complete in seconds
+ * without recording what they made: `produced_quantity` is optional at
+ * completion, and nothing gates completing on the run's own checklist. The run
+ * then reads "completed" while its output is null, its material unlogged and
+ * its subtasks unfinished — and there has never been a way back. Reassignment
+ * rewinds `dispatch_state`, but its policy refuses once the partner accepted,
+ * which is long past by then.
+ *
+ * This puts the run back where the partner can do it properly. It is a
+ * LIFECYCLE rewind, not an undo of everything completion caused — see the
+ * side-effect guard below, which is the whole reason this job is careful rather
+ * than a three-line update.
+ */
+
+/** Statuses a rewind may target, ordered earliest-first. */
+const REWIND_TARGETS = ["approved", "sent_to_partner", "in_progress"] as const
+type RewindTarget = (typeof REWIND_TARGETS)[number]
+
+/** Task statuses that count as "closed" and therefore reopenable by a rewind. */
+const CLOSED_TASK_STATUSES = new Set(["completed", "cancelled"])
+
+const paramsSchema = z.object({
+  production_run_id: z.string().min(1),
+  /** Where to rewind to. Default `in_progress` — the partner picks up mid-run. */
+  to_status: z.enum(REWIND_TARGETS).optional(),
+  /** Also rewind the parent run when the child's completion cascaded into it. */
+  rewind_parent: z.boolean().optional(),
+  /** Reopen tasks that completion force-closed. Default true. */
+  reopen_tasks: z.boolean().optional(),
+  /**
+   * Proceed even though completion left side effects a re-completion would
+   * duplicate (consumption logs). Off by default, deliberately.
+   */
+  force: z.boolean().optional(),
+})
+
+/**
+ * Which lifecycle stamps a rewind to `target` must clear.
+ *
+ * Pure so the decision is testable without a container. Ordering matters:
+ * rewinding to `in_progress` keeps `accepted_at`/`started_at` (the partner did
+ * accept and did start), while rewinding further back clears them too — a run
+ * sitting at `approved` with an `accepted_at` would be read as accepted by
+ * every policy check that looks at the stamp rather than the status.
+ */
+export function fieldsToClearForRewind(target: RewindTarget): string[] {
+  const always = [
+    "finished_at",
+    "completed_at",
+    "produced_quantity",
+    "rejected_quantity",
+    "rejection_reason",
+    "rejection_notes",
+    "completion_notes",
+    "finish_notes",
+  ]
+
+  if (target === "in_progress") {
+    return always
+  }
+  if (target === "sent_to_partner") {
+    return [...always, "accepted_at", "started_at"]
+  }
+  // approved — before dispatch, so the dispatch cycle rewinds too.
+  return [
+    ...always,
+    "accepted_at",
+    "started_at",
+    "dispatch_state",
+    "dispatch_started_at",
+    "dispatch_completed_at",
+  ]
+}
+
+/**
+ * The diff a rewind would make to one run.
+ *
+ * `dispatch_state` is a non-nullable enum, so it rewinds to "idle" rather than
+ * null — the same value `assignProductionRunPartner` uses when it puts a run
+ * back in the dispatchable state.
+ */
+export function planRunRewind(
+  run: Record<string, any>,
+  target: RewindTarget
+): MaintenanceChange[] {
+  const changes: MaintenanceChange[] = []
+
+  if (String(run.status) !== target) {
+    changes.push({
+      entity: "production_run",
+      id: run.id,
+      field: "status",
+      before: run.status ?? null,
+      after: target,
+    })
+  }
+
+  for (const field of fieldsToClearForRewind(target)) {
+    const before = run[field] ?? null
+    const after = field === "dispatch_state" ? "idle" : null
+    if (before === after) {
+      continue
+    }
+    changes.push({
+      entity: "production_run",
+      id: run.id,
+      field,
+      before,
+      after,
+    })
+  }
+
+  return changes
+}
+
+export const rewindProductionRunJob: MaintenanceJob = {
+  id: "rewind-production-run",
+  label: "Rewind a prematurely completed production run",
+  description:
+    "Put a run that was marked complete without its data back where the partner can finish it properly — clears the completion stamps and output, reopens the tasks completion force-closed, and re-mirrors the unified order. Refuses when completion left consumption logs a re-completion would duplicate, unless forced. Does NOT reverse finished goods already stocked; those are reported so you can decide. Dry-run previews every field.",
+  params: [
+    {
+      name: "production_run_id",
+      type: "string",
+      required: true,
+      description: "The run to rewind, e.g. 'prod_run_01KWPVZ4R2PWK6DW1X8X5DKNZE'",
+    },
+    {
+      name: "to_status",
+      type: "string",
+      required: false,
+      description:
+        "approved | sent_to_partner | in_progress (default). in_progress keeps accepted_at/started_at; earlier targets clear them too.",
+    },
+    {
+      name: "rewind_parent",
+      type: "boolean",
+      required: false,
+      description:
+        "Also rewind the parent run, whose completion was cascaded from this child. Default false.",
+    },
+    {
+      name: "reopen_tasks",
+      type: "boolean",
+      required: false,
+      description:
+        "Reopen tasks that completion force-closed, back to in_progress. Default true.",
+    },
+    {
+      name: "force",
+      type: "boolean",
+      required: false,
+      description:
+        "Proceed despite consumption logs that a re-completion would duplicate. Default false.",
+    },
+  ],
+  run: async (container, { dry_run, params }): Promise<MaintenanceJobResult> => {
+    const parsed = paramsSchema.safeParse(params)
+    if (!parsed.success) {
+      throw new MedusaError(
+        MedusaError.Types.INVALID_DATA,
+        parsed.error.issues.map((i) => `${i.path.join(".")}: ${i.message}`).join("; ")
+      )
+    }
+    const {
+      production_run_id: runId,
+      rewind_parent: rewindParent = false,
+      force = false,
+    } = parsed.data
+    const target: RewindTarget = parsed.data.to_status ?? "in_progress"
+    const reopenTasks = parsed.data.reopen_tasks ?? true
+
+    const query: any = container.resolve(ContainerRegistrationKeys.QUERY)
+    const runService: any = container.resolve(PRODUCTION_RUNS_MODULE)
+    const consumptionService: any = container.resolve(CONSUMPTION_LOG_MODULE)
+    const taskService: any = container.resolve(TASKS_MODULE)
+
+    const run = await runService.retrieveProductionRun(runId).catch(() => null)
+    if (!run) {
+      throw new MedusaError(
+        MedusaError.Types.NOT_FOUND,
+        `Production run ${runId} not found`
+      )
+    }
+    if (run.deleted_at) {
+      throw new MedusaError(
+        MedusaError.Types.INVALID_DATA,
+        `Production run ${runId} is deleted — restore it before rewinding`
+      )
+    }
+    if (run.cancelled_at) {
+      throw new MedusaError(
+        MedusaError.Types.INVALID_DATA,
+        `Production run ${runId} is cancelled, not completed — rewinding would resurrect it. Use reassignment instead.`
+      )
+    }
+
+    // A re-completion re-runs logConsumptionsStep, so logs already attached to
+    // this run would be written twice. Nothing here can tell an intended log
+    // from a duplicate, so this is the operator's call, not ours.
+    const [existingLogs] = await consumptionService.listAndCountConsumptionLogs(
+      { production_run_id: runId },
+      { take: null }
+    )
+    const logCount = (existingLogs || []).length
+    if (logCount > 0 && !force) {
+      throw new MedusaError(
+        MedusaError.Types.NOT_ALLOWED,
+        `Run ${runId} already has ${logCount} consumption log(s). Completing it again would log the material a second time. Delete or reconcile them first, or pass force:true if you have already accounted for that.`
+      )
+    }
+
+    const changes: MaintenanceChange[] = planRunRewind(run, target)
+
+    // Parent runs complete by cascade from the child, so a child rewind leaves
+    // a parent claiming goods that are no longer finished.
+    const parentId = run.parent_run_id ?? null
+    let parent: any = null
+    if (rewindParent && parentId) {
+      parent = await runService.retrieveProductionRun(parentId).catch(() => null)
+      if (parent && !parent.cancelled_at && !parent.deleted_at) {
+        changes.push(...planRunRewind(parent, target))
+      }
+    }
+
+    // Tasks the completion force-closed. Read through the run↔task link so a
+    // task that was never linked is left alone rather than guessed at by title.
+    let taskChanges: Array<{ id: string; before: string }> = []
+    if (reopenTasks) {
+      const { data: runData } = await query.graph({
+        entity: "production_runs",
+        fields: ["id", "tasks.id", "tasks.status", "tasks.title"],
+        filters: { id: runId },
+      })
+      const linked = ((runData?.[0] as any)?.tasks || []) as any[]
+      taskChanges = linked
+        .filter((t) => t?.id && CLOSED_TASK_STATUSES.has(String(t.status || "")))
+        .map((t) => ({ id: t.id, before: String(t.status) }))
+
+      for (const t of taskChanges) {
+        changes.push({
+          entity: "task",
+          id: t.id,
+          field: "status",
+          before: t.before,
+          after: "in_progress",
+        })
+      }
+    }
+
+    if (!dry_run && changes.length > 0) {
+      const clearFor = (r: Record<string, any>) =>
+        Object.fromEntries(
+          fieldsToClearForRewind(target).map((f) => [
+            f,
+            f === "dispatch_state" ? "idle" : null,
+          ])
+        )
+
+      await runService.updateProductionRuns({
+        id: run.id,
+        status: target,
+        ...clearFor(run),
+      })
+
+      if (parent) {
+        await runService.updateProductionRuns({
+          id: parent.id,
+          status: target,
+          ...clearFor(parent),
+        })
+      }
+
+      for (const t of taskChanges) {
+        await taskService
+          .updateTasks({ id: t.id, status: "in_progress" })
+          .catch(() => {
+            // A task that refuses to reopen must not strand the run rewind that
+            // already committed — the run state is what the partner acts on.
+          })
+      }
+
+      // Audit on the run's own timeline, not only in the ops log: the admin run
+      // page is where anyone asking "why is this open again" will look.
+      await runService
+        .createProductionRunActivities({
+          production_run_id: run.id,
+          activity_type: "lifecycle_event",
+          kind: "rewound",
+          actor_type: "system",
+          actor_id: null,
+          partner_id: run.partner_id ?? null,
+          channel: null,
+          message_id: null,
+          template_name: null,
+          recipient: null,
+          summary: `Run rewound to ${target} for re-completion`,
+          payload: {
+            from_status: run.status ?? null,
+            to_status: target,
+            tasks_reopened: taskChanges.length,
+            forced: force,
+          },
+          occurred_at: new Date(),
+        } as any)
+        .catch(() => {
+          // Timeline write is a record, not the act.
+        })
+    }
+
+    const notes: string[] = []
+    if (logCount > 0) {
+      notes.push(
+        `⚠️ ${logCount} consumption log(s) already attached — re-completing will log material again unless you clear them`
+      )
+    }
+    if (parentId && !rewindParent) {
+      notes.push(
+        `parent ${parentId} left as-is (pass rewind_parent:true if its completion cascaded from this run)`
+      )
+    }
+    // Completion stocks finished goods, and nothing here reverses that. Say so
+    // rather than let a silent double-count arrive at the next completion.
+    notes.push(
+      "finished goods stocked at completion are NOT reversed — check the partner location's levels before the run is completed again"
+    )
+
+    const summary = [
+      `${dry_run ? "Would rewind" : "Rewound"} run ${runId} from ${
+        run.status
+      } to ${target}${parent ? ` (and parent ${parent.id})` : ""}`,
+      taskChanges.length
+        ? `${dry_run ? "would reopen" : "reopened"} ${taskChanges.length} task(s)`
+        : "no closed tasks to reopen",
+      ...notes,
+    ].join(". ")
+
+    return {
+      job_id: rewindProductionRunJob.id,
+      dry_run,
+      applied: !dry_run && changes.length > 0,
+      summary,
+      changes,
+    }
+  },
+}

--- a/apps/backend/src/api/middlewares.ts
+++ b/apps/backend/src/api/middlewares.ts
@@ -2285,6 +2285,8 @@ export default defineMiddlewares({
     {
       matcher: "/partners/assistant/chat",
       method: "POST",
+      // Same 100kb Express default as the admin assistant — see the note there.
+      bodyParser: { sizeLimit: "5mb" },
       middlewares: [
         createCorsPartnerMiddleware(),
         authenticate("partner", ["session", "bearer"]),
@@ -2297,6 +2299,7 @@ export default defineMiddlewares({
     {
       matcher: "/partners/assistant/summarize",
       method: "POST",
+      bodyParser: { sizeLimit: "5mb" },
       middlewares: [
         createCorsPartnerMiddleware(),
         authenticate("partner", ["session", "bearer"]),
@@ -3468,9 +3471,18 @@ export default defineMiddlewares({
       middlewares: [],
     },
     // Admin agentic assistant — streaming tool-caller over the Admin MCP registry.
+    //
+    // The body carries up to 60 UI messages INCLUDING their tool parts, and a
+    // Data Plumbing job's `changes` array alone can be tens of kB. Medusa passes
+    // `sizeLimit` straight to express.json(), so leaving it unset means the
+    // Express default of 100kb — which a thread that has run a maintenance job
+    // blows through, and the operator sees an intermittent "Payload too large".
+    // The route discards tool parts before modelling anyway (see the normalise
+    // step in the handler); it just has to be able to RECEIVE them first.
     {
       matcher: "/admin/assistant/chat",
       method: "POST",
+      bodyParser: { sizeLimit: "5mb" },
       middlewares: [validateAndTransformBody(wrapSchema(AdminAssistantChatSchema))],
     },
     // Admin assistant context compaction — the client calls this when the thread
@@ -3479,6 +3491,9 @@ export default defineMiddlewares({
     {
       matcher: "/admin/assistant/summarize",
       method: "POST",
+      // Compaction is handed the very thread that grew too big to continue —
+      // the one request guaranteed to be large. Same 100kb default trap.
+      bodyParser: { sizeLimit: "5mb" },
       middlewares: [
         validateAndTransformBody(wrapSchema(AdminAssistantSummarizeSchema)),
       ],

--- a/apps/backend/src/api/partners/assigned-tasks/[taskId]/accept/route.ts
+++ b/apps/backend/src/api/partners/assigned-tasks/[taskId]/accept/route.ts
@@ -129,8 +129,22 @@ export async function POST(
                          task.partners.some((p: any) => p.id === partner.id);
         
         if (!isLinked) {
-            return res.status(403).json({ 
-                message: "Task not assigned to this partner" 
+            return res.status(403).json({
+                message: "Task not assigned to this partner"
+            });
+        }
+
+        // Accepting is a FORWARD move. Without this the route happily walked a
+        // finished task backwards: completing a production run force-closes its
+        // linked tasks, and a partner whose UI still showed the old "Accept"
+        // button then flipped them from `completed` back to `accepted` seconds
+        // later — leaving the run reading completed while its subtasks read
+        // open, with nothing in the data to say which was right.
+        // (prod: run prod_run_01KWPVZ4R2PWK6DW1X8X5DKNZE, 2026-08-11.)
+        const currentStatus = String(task.status || "");
+        if (["completed", "cancelled"].includes(currentStatus)) {
+            return res.status(409).json({
+                message: `Task is already ${currentStatus} and cannot be accepted again`,
             });
         }
 

--- a/apps/backend/src/api/partners/designs/[designId]/consumption-logs/route.ts
+++ b/apps/backend/src/api/partners/designs/[designId]/consumption-logs/route.ts
@@ -15,6 +15,7 @@ export const POST = async (
       inventory_item_id: req.validatedBody.inventoryItemId,
       raw_material_id: req.validatedBody.rawMaterialId,
       quantity: req.validatedBody.quantity,
+      quantity_basis: req.validatedBody.quantityBasis ?? null,
       unit_cost: req.validatedBody.unitCost,
       unit_of_measure: req.validatedBody.unitOfMeasure,
       consumption_type: req.validatedBody.consumptionType,

--- a/apps/backend/src/api/partners/designs/[designId]/consumption-logs/validators.ts
+++ b/apps/backend/src/api/partners/designs/[designId]/consumption-logs/validators.ts
@@ -5,6 +5,7 @@ export const PartnerPostConsumptionLogReq = z.object({
   rawMaterialId: z.string().optional(),
   productionRunId: z.string().optional(),
   quantity: z.number().positive(),
+  quantityBasis: z.enum(["total", "per_piece"]).optional(),
   unitCost: z.number().positive().optional(),
   unitOfMeasure: z
     .enum([

--- a/apps/backend/src/api/partners/production-runs/[id]/consumption-logs/route.ts
+++ b/apps/backend/src/api/partners/production-runs/[id]/consumption-logs/route.ts
@@ -54,6 +54,7 @@ export const POST = async (
       inventory_item_id: req.validatedBody.inventoryItemId,
       raw_material_id: req.validatedBody.rawMaterialId,
       quantity: req.validatedBody.quantity,
+      quantity_basis: req.validatedBody.quantityBasis ?? null,
       unit_cost: req.validatedBody.unitCost,
       unit_of_measure: req.validatedBody.unitOfMeasure,
       consumption_type: req.validatedBody.consumptionType,

--- a/apps/backend/src/api/partners/production-runs/[id]/consumption-logs/validators.ts
+++ b/apps/backend/src/api/partners/production-runs/[id]/consumption-logs/validators.ts
@@ -4,6 +4,7 @@ export const PartnerPostProductionRunConsumptionLogReq = z.object({
   inventoryItemId: z.string(),
   rawMaterialId: z.string().optional(),
   quantity: z.number().positive(),
+  quantityBasis: z.enum(["total", "per_piece"]).optional(),
   unitCost: z.number().positive().optional(),
   unitOfMeasure: z
     .enum([

--- a/apps/backend/src/api/partners/tasks/[taskId]/accept/route.ts
+++ b/apps/backend/src/api/partners/tasks/[taskId]/accept/route.ts
@@ -57,6 +57,7 @@
  * }
  */
 import { AuthenticatedMedusaRequest, MedusaResponse } from "@medusajs/framework";
+import { ContainerRegistrationKeys } from "@medusajs/framework/utils";
 import { updateTaskWorkflow } from "../../../../../workflows/tasks/update-task";
 import { setStepSuccessWorkflow } from "../../../../../workflows/tasks/task-engine/task-steps";
 import { Status } from "../../../../../workflows/tasks/create-task";
@@ -67,7 +68,24 @@ export async function POST(
 ) {
 
     const taskId = req.params.taskId
-    
+
+    // Accepting only ever moves a task forward — see the note on the
+    // assigned-tasks accept route. A completed task walked back to `accepted`
+    // is what left run prod_run_01KWPVZ4R2PWK6DW1X8X5DKNZE reading completed
+    // with open subtasks.
+    const query = req.scope.resolve(ContainerRegistrationKeys.QUERY)
+    const { data: existing } = await query.graph({
+        entity: "task",
+        fields: ["id", "status"],
+        filters: { id: taskId },
+    })
+    const currentStatus = String((existing?.[0] as any)?.status || "")
+    if (["completed", "cancelled"].includes(currentStatus)) {
+        return res.status(409).json({
+            message: `Task is already ${currentStatus} and cannot be accepted again`,
+        })
+    }
+
     const { result, errors } = await updateTaskWorkflow(req.scope).run({
         input: {
             id: taskId,

--- a/apps/backend/src/lib/__tests__/resolve-line-item-production.unit.spec.ts
+++ b/apps/backend/src/lib/__tests__/resolve-line-item-production.unit.spec.ts
@@ -1,0 +1,62 @@
+import { isOwnedProvenanceRun } from "../resolve-line-item-production"
+
+/**
+ * Guards the classifier that decides which runs the fulfillment / cancellation
+ * reconciler is allowed to adjust or soft-delete. Getting this wrong in either
+ * direction is expensive: too narrow leaves phantom completed runs behind after
+ * a cancellation, too broad lets the reconciler delete real shop-floor work.
+ */
+describe("isOwnedProvenanceRun", () => {
+  const MARKER = "order.fulfillment_created"
+
+  it("matches a product-only provenance run", () => {
+    expect(
+      isOwnedProvenanceRun({ design_id: null, metadata: { source: MARKER } } as any)
+    ).toBe(true)
+  })
+
+  it("matches a DESIGN-BACKED provenance run", () => {
+    // The regression: reconcile-provenance-runs mints these whenever the
+    // fulfilled line resolves to a design, stamping design_backed alongside the
+    // marker. The old `design_id == null` requirement excluded them, so they
+    // were never quantity-adjusted and never voided on cancellation.
+    // Real shape from prod: prod_run_01KZJJX9ZT… on design 01KWWJ0S3Z….
+    expect(
+      isOwnedProvenanceRun({
+        design_id: "01KWWJ0S3ZWWNK6YTDSC2AFARQ",
+        metadata: { source: MARKER, design_backed: true, is_custom_design: true },
+      } as any)
+    ).toBe(true)
+  })
+
+  it("does NOT match a real design work-order", () => {
+    expect(
+      isOwnedProvenanceRun({
+        design_id: "01KWWJ0S3ZWWNK6YTDSC2AFARQ",
+        metadata: { source: "designs-produce-no-customer" },
+      } as any)
+    ).toBe(false)
+  })
+
+  it("does NOT match a run created at order.placed", () => {
+    // These go through real production; fulfillment COMPLETES them, but the
+    // reconciler must never delete or requantify them.
+    expect(
+      isOwnedProvenanceRun({
+        design_id: null,
+        metadata: { source: "order.placed" },
+      } as any)
+    ).toBe(false)
+  })
+
+  it("does NOT match runs with absent or empty metadata", () => {
+    expect(isOwnedProvenanceRun({ design_id: null, metadata: null } as any)).toBe(false)
+    expect(isOwnedProvenanceRun({ design_id: null, metadata: {} } as any)).toBe(false)
+    expect(isOwnedProvenanceRun({ design_id: "d1" } as any)).toBe(false)
+  })
+
+  it("is null/undefined safe", () => {
+    expect(isOwnedProvenanceRun(null)).toBe(false)
+    expect(isOwnedProvenanceRun(undefined)).toBe(false)
+  })
+})

--- a/apps/backend/src/lib/resolve-line-item-production.ts
+++ b/apps/backend/src/lib/resolve-line-item-production.ts
@@ -100,19 +100,27 @@ export async function getProductionRunForLineItem(
 }
 
 /**
- * A provenance run this system minted from retail fulfillment (product-only,
- * born terminal). ONLY these are quantity-reconciled / soft-deleted by the
- * fulfillment + cancellation paths — a real production run (design work-order,
- * or a run that actually went through the shop) is never touched. Identified by
- * the create-side marker `metadata.source === "order.fulfillment_created"` and
- * the absence of a backing design.
+ * A provenance run this system minted from retail fulfillment (born terminal).
+ * ONLY these are quantity-reconciled / soft-deleted by the fulfillment +
+ * cancellation paths — a real production run (design work-order, or a run that
+ * actually went through the shop) is never touched.
+ *
+ * Identified SOLELY by the create-side marker
+ * `metadata.source === "order.fulfillment_created"`, which is written in exactly
+ * one place (`reconcile-provenance-runs.ts`) and never by any path that mints a
+ * real run. That marker alone is therefore sufficient.
+ *
+ * It previously ALSO required `design_id == null`, on the assumption that
+ * provenance runs are product-only. They are not: the same creator mints
+ * DESIGN-BACKED provenance runs whenever the fulfilled line resolves to a design
+ * (it stamps `design_backed: true` alongside the marker). Those runs matched the
+ * marker but failed the null check, so they were never adjusted when the
+ * fulfilled quantity changed and — worse — were never soft-deleted when the
+ * order was canceled, leaving a completed run claiming goods that never shipped.
  */
 export function isOwnedProvenanceRun(
   run: Pick<LineItemProductionRun, "design_id" | "metadata"> | null | undefined
 ): boolean {
   if (!run) return false
-  return (
-    run.design_id == null &&
-    run.metadata?.source === "order.fulfillment_created"
-  )
+  return run.metadata?.source === "order.fulfillment_created"
 }

--- a/apps/backend/src/modules/consumption_log/migrations/.snapshot-consumption-log.json
+++ b/apps/backend/src/modules/consumption_log/migrations/.snapshot-consumption-log.json
@@ -102,6 +102,25 @@
           "enumItems": [],
           "mappedType": "float"
         },
+        "quantity_basis": {
+          "name": "quantity_basis",
+          "type": "text",
+          "unsigned": false,
+          "autoincrement": false,
+          "primary": false,
+          "nullable": true,
+          "unique": false,
+          "length": null,
+          "precision": null,
+          "scale": null,
+          "default": null,
+          "comment": null,
+          "enumItems": [
+            "total",
+            "per_piece"
+          ],
+          "mappedType": "enum"
+        },
         "unit_cost": {
           "name": "unit_cost",
           "type": "real",

--- a/apps/backend/src/modules/consumption_log/migrations/Migration20260811085117.ts
+++ b/apps/backend/src/modules/consumption_log/migrations/Migration20260811085117.ts
@@ -1,0 +1,13 @@
+import { Migration } from "@medusajs/framework/mikro-orm/migrations";
+
+export class Migration20260811085117 extends Migration {
+
+  override async up(): Promise<void> {
+    this.addSql(`alter table if exists "consumption_log" add column if not exists "quantity_basis" text check ("quantity_basis" in ('total', 'per_piece')) null;`);
+  }
+
+  override async down(): Promise<void> {
+    this.addSql(`alter table if exists "consumption_log" drop column if exists "quantity_basis";`);
+  }
+
+}

--- a/apps/backend/src/modules/consumption_log/models/consumption-log.ts
+++ b/apps/backend/src/modules/consumption_log/models/consumption-log.ts
@@ -7,6 +7,13 @@ const ConsumptionLog = model.define("consumption_log", {
   inventory_item_id: model.text().nullable(),
   raw_material_id: model.text().nullable(),
   quantity: model.float(),
+  /**
+   * What `quantity` measures. NULLABLE on purpose: rows written before the
+   * capture forms asked the question have an unknowable basis, and guessing one
+   * would silently mis-scale both cost and stock. Consumers must resolve a null
+   * basis explicitly rather than defaulting it.
+   */
+  quantity_basis: model.enum(["total", "per_piece"]).nullable(),
   unit_cost: model.float().nullable(),
   unit_of_measure: model
     .enum([

--- a/apps/backend/src/workflows/consumption-logs/__tests__/apply-to-inventory.unit.spec.ts
+++ b/apps/backend/src/workflows/consumption-logs/__tests__/apply-to-inventory.unit.spec.ts
@@ -180,3 +180,91 @@ describe("maxShortfall guard", () => {
     expect(decisions[1]).toMatchObject({ action: "apply", before: 10, after: 8 })
   })
 })
+
+describe("per-piece resolution", () => {
+  const log = (id: string, item: string, quantity: number) => ({
+    id,
+    design_id: "d1",
+    inventory_item_id: item,
+    quantity,
+    is_committed: true,
+    location_id: null,
+    metadata: null,
+  })
+
+  it("multiplies the logged rate by finished pieces", () => {
+    // Denim Trouser: 2.15 m/piece against 2 finished pieces = 4.3 m, not 2.15.
+    const [d] = planConsumptionApplication({
+      brandLocationId: "sloc_brand",
+      logs: [log("l1", "item_a", 2.15)],
+      brandLevels: { item_a: 17.6 },
+      piecesByLog: { l1: 2 },
+    })
+    expect(d).toMatchObject({
+      action: "apply",
+      per_piece: 2.15,
+      pieces: 2,
+      quantity: 4.3,
+      before: 17.6,
+      after: 13.3,
+    })
+  })
+
+  it("skips when the piece count is unknown rather than deducting face value", () => {
+    // Partner-held designs have no completed runs; deducting 2.5 verbatim would
+    // be a guess, and stamping it would make the guess permanent.
+    const [d] = planConsumptionApplication({
+      brandLocationId: "sloc_brand",
+      logs: [log("l1", "item_a", 2.5)],
+      brandLevels: { item_a: 10 },
+      piecesByLog: { l1: 0 },
+    })
+    expect(d.action).toBe("skip")
+    expect((d as any).reason).toMatch(/piece count unknown/)
+  })
+
+  it("skips a log missing from the map entirely", () => {
+    const [d] = planConsumptionApplication({
+      brandLocationId: "sloc_brand",
+      logs: [log("l1", "item_a", 2.5)],
+      brandLevels: { item_a: 10 },
+      piecesByLog: {},
+    })
+    expect(d.action).toBe("skip")
+  })
+
+  it("keeps 1:1 behaviour when no map is supplied", () => {
+    const [d] = planConsumptionApplication({
+      brandLocationId: "sloc_brand",
+      logs: [log("l1", "item_a", 2.15)],
+      brandLevels: { item_a: 17.6 },
+    })
+    expect(d).toMatchObject({ action: "apply", quantity: 2.15, after: 15.45 })
+    expect((d as any).pieces).toBeUndefined()
+  })
+
+  it("draws the running balance down by the RESOLVED total", () => {
+    const decisions = planConsumptionApplication({
+      brandLocationId: "sloc_brand",
+      logs: [log("l1", "item_a", 2), log("l2", "item_a", 1)],
+      brandLevels: { item_a: 20 },
+      piecesByLog: { l1: 3, l2: 4 },
+    })
+    // 2×3 = 6 → 14, then 1×4 = 4 → 10
+    expect(decisions[0]).toMatchObject({ quantity: 6, after: 14 })
+    expect(decisions[1]).toMatchObject({ quantity: 4, before: 14, after: 10 })
+  })
+
+  it("applies max_shortfall against the RESOLVED total, not the logged rate", () => {
+    // 2.15 alone fits inside 3, but 2.15 × 2 does not — the guard must see 4.3.
+    const [d] = planConsumptionApplication({
+      brandLocationId: "sloc_brand",
+      logs: [log("l1", "item_a", 2.15)],
+      brandLevels: { item_a: 3 },
+      piecesByLog: { l1: 2 },
+      maxShortfall: 0,
+    })
+    expect(d.action).toBe("skip")
+    expect((d as any).reason).toMatch(/shortfall 1.3 exceeds/)
+  })
+})

--- a/apps/backend/src/workflows/consumption-logs/__tests__/apply-to-inventory.unit.spec.ts
+++ b/apps/backend/src/workflows/consumption-logs/__tests__/apply-to-inventory.unit.spec.ts
@@ -21,6 +21,7 @@ describe("planConsumptionApplication", () => {
     design_id: "design_1",
     inventory_item_id: "iitem_denim",
     quantity: 2.15,
+    quantity_basis: "total",
     is_committed: true,
     location_id: null,
     metadata: null,
@@ -122,6 +123,7 @@ describe("maxShortfall guard", () => {
     design_id: "d1",
     inventory_item_id: item,
     quantity,
+    quantity_basis: "total" as const,
     is_committed: true,
     location_id: null,
     metadata: null,
@@ -187,6 +189,7 @@ describe("per-piece resolution", () => {
     design_id: "d1",
     inventory_item_id: item,
     quantity,
+    quantity_basis: "per_piece" as const,
     is_committed: true,
     location_id: null,
     metadata: null,
@@ -233,10 +236,10 @@ describe("per-piece resolution", () => {
     expect(d.action).toBe("skip")
   })
 
-  it("keeps 1:1 behaviour when no map is supplied", () => {
+  it("a total-basis log ignores the piece map entirely", () => {
     const [d] = planConsumptionApplication({
       brandLocationId: "sloc_brand",
-      logs: [log("l1", "item_a", 2.15)],
+      logs: [{ ...log("l1", "item_a", 2.15), quantity_basis: "total" as const }],
       brandLevels: { item_a: 17.6 },
     })
     expect(d).toMatchObject({ action: "apply", quantity: 2.15, after: 15.45 })
@@ -266,5 +269,74 @@ describe("per-piece resolution", () => {
     })
     expect(d.action).toBe("skip")
     expect((d as any).reason).toMatch(/shortfall 1.3 exceeds/)
+  })
+})
+
+describe("quantity_basis", () => {
+  const log = (id: string, quantity: number, basis?: "total" | "per_piece" | null) => ({
+    id,
+    design_id: "d1",
+    inventory_item_id: "item_a",
+    quantity,
+    quantity_basis: basis ?? null,
+    is_committed: true,
+    location_id: null,
+    metadata: null,
+  })
+
+  it("multiplies a per_piece log by its pieces", () => {
+    const [d] = planConsumptionApplication({
+      brandLocationId: "sloc_brand",
+      logs: [log("l1", 2.15, "per_piece")],
+      brandLevels: { item_a: 17.6 },
+      piecesByLog: { l1: 2 },
+    })
+    expect(d).toMatchObject({ action: "apply", quantity: 4.3, after: 13.3, pieces: 2 })
+  })
+
+  it("deducts a total log verbatim, even with pieces available", () => {
+    const [d] = planConsumptionApplication({
+      brandLocationId: "sloc_brand",
+      logs: [log("l1", 2.15, "total")],
+      brandLevels: { item_a: 17.6 },
+      piecesByLog: { l1: 2 },
+    })
+    expect(d).toMatchObject({ action: "apply", quantity: 2.15, after: 15.45 })
+    expect((d as any).pieces).toBeUndefined()
+  })
+
+  it("refuses to guess a null basis", () => {
+    // The 63 legacy prod logs. Reading 2.15 as a total or per-piece differs by
+    // the piece count, so the job must be told rather than assume.
+    const [d] = planConsumptionApplication({
+      brandLocationId: "sloc_brand",
+      logs: [log("l1", 2.15)],
+      brandLevels: { item_a: 17.6 },
+      piecesByLog: { l1: 2 },
+    })
+    expect(d.action).toBe("skip")
+    expect((d as any).reason).toMatch(/quantity_basis unknown/)
+  })
+
+  it("resolves a null basis only against an explicit assumption", () => {
+    const [d] = planConsumptionApplication({
+      brandLocationId: "sloc_brand",
+      logs: [log("l1", 2.15)],
+      brandLevels: { item_a: 17.6 },
+      piecesByLog: { l1: 2 },
+      assumeBasisWhenUnknown: "per_piece",
+    })
+    expect(d).toMatchObject({ action: "apply", quantity: 4.3 })
+  })
+
+  it("lets a recorded basis win over the assumption", () => {
+    const [d] = planConsumptionApplication({
+      brandLocationId: "sloc_brand",
+      logs: [log("l1", 2.15, "total")],
+      brandLevels: { item_a: 17.6 },
+      piecesByLog: { l1: 2 },
+      assumeBasisWhenUnknown: "per_piece",
+    })
+    expect(d).toMatchObject({ action: "apply", quantity: 2.15 })
   })
 })

--- a/apps/backend/src/workflows/consumption-logs/__tests__/apply-to-inventory.unit.spec.ts
+++ b/apps/backend/src/workflows/consumption-logs/__tests__/apply-to-inventory.unit.spec.ts
@@ -115,3 +115,68 @@ describe("planConsumptionApplication", () => {
     expect(a).toEqual(b)
   })
 })
+
+describe("maxShortfall guard", () => {
+  const log = (id: string, item: string, quantity: number) => ({
+    id,
+    design_id: "d1",
+    inventory_item_id: item,
+    quantity,
+    is_committed: true,
+    location_id: null,
+    metadata: null,
+  })
+
+  it("skips rather than stamps a log the level cannot cover", () => {
+    // The one-way door: applying floors at 0, records the shortfall, and stamps
+    // inventory_applied_at — so a later route repair can never re-apply it.
+    const decisions = planConsumptionApplication({
+      brandLocationId: "sloc_brand",
+      logs: [log("l1", "item_a", 5)],
+      brandLevels: { item_a: 0 },
+      maxShortfall: 0,
+    })
+    expect(decisions[0].action).toBe("skip")
+    expect((decisions[0] as any).reason).toMatch(/shortfall 5 exceeds max_shortfall 0/)
+  })
+
+  it("still applies a deduction fully covered by stock", () => {
+    const decisions = planConsumptionApplication({
+      brandLocationId: "sloc_brand",
+      logs: [log("l1", "item_a", 2.15)],
+      brandLevels: { item_a: 17.6 },
+      maxShortfall: 0,
+    })
+    expect(decisions[0]).toMatchObject({ action: "apply", before: 17.6, after: 15.45 })
+  })
+
+  it("allows a shortfall within the tolerance", () => {
+    const decisions = planConsumptionApplication({
+      brandLocationId: "sloc_brand",
+      logs: [log("l1", "item_a", 5)],
+      brandLevels: { item_a: 4.5 },
+      maxShortfall: 1,
+    })
+    expect(decisions[0]).toMatchObject({ action: "apply", after: 0, shortfall: 0.5 })
+  })
+
+  it("keeps prior behaviour when the guard is not set", () => {
+    const decisions = planConsumptionApplication({
+      brandLocationId: "sloc_brand",
+      logs: [log("l1", "item_a", 5)],
+      brandLevels: { item_a: 0 },
+    })
+    expect(decisions[0]).toMatchObject({ action: "apply", shortfall: 5 })
+  })
+
+  it("does not let a skipped log draw down the running balance", () => {
+    const decisions = planConsumptionApplication({
+      brandLocationId: "sloc_brand",
+      logs: [log("l1", "item_a", 99), log("l2", "item_a", 2)],
+      brandLevels: { item_a: 10 },
+      maxShortfall: 0,
+    })
+    expect(decisions[0].action).toBe("skip")
+    expect(decisions[1]).toMatchObject({ action: "apply", before: 10, after: 8 })
+  })
+})

--- a/apps/backend/src/workflows/consumption-logs/__tests__/reconcile-production-consumption.unit.spec.ts
+++ b/apps/backend/src/workflows/consumption-logs/__tests__/reconcile-production-consumption.unit.spec.ts
@@ -1,0 +1,202 @@
+import {
+  isProvenanceRun,
+  leafRuns,
+  reconcileDesigns,
+  type ReconcileLog,
+  type ReconcileRun,
+} from "../lib/reconcile-production-consumption"
+
+const DENIM = "01KWWJ0S3ZWWNK6YTDSC2AFARQ"
+
+/** The real prod shape for design "Denim Trouser". */
+const denimRuns: ReconcileRun[] = [
+  {
+    id: "prod_run_A",
+    design_id: DENIM,
+    parent_run_id: null,
+    status: "completed",
+    produced_quantity: 2,
+    quantity: 2,
+    metadata: { source: "designs-produce-no-customer" },
+  },
+  {
+    id: "prod_run_B",
+    design_id: DENIM,
+    parent_run_id: null,
+    status: "completed",
+    produced_quantity: 1,
+    quantity: 1,
+    metadata: { source: "order.fulfillment_created", design_backed: true },
+  },
+]
+
+const denimLogs: ReconcileLog[] = [
+  {
+    id: "log_1",
+    design_id: DENIM,
+    inventory_item_id: "iitem_01KMEYT9C8JSK12TK7ZY0G3WXT",
+    production_run_id: null,
+    quantity: 2.15,
+    is_committed: true,
+  },
+]
+
+describe("reconcileDesigns", () => {
+  it("counts real production only — a provenance run consumed nothing", () => {
+    const [r] = reconcileDesigns({ runs: denimRuns, logs: denimLogs })
+    expect(r.produced).toBe(2)
+    expect(r.shipped_from_stock).toBe(1)
+    // The bug this guards: summing produced_quantity across both runs gives 3,
+    // which would invent a piece's worth of expected fabric out of a stock sale.
+    expect(r.implied_rate).toBe(1.075)
+  })
+
+  it("computes expected and variance against a known per-unit rate", () => {
+    const [r] = reconcileDesigns({
+      runs: denimRuns,
+      logs: denimLogs,
+      ratePerUnit: { [DENIM]: 2.5 },
+    })
+    expect(r.expected).toBe(5) // 2.5 x 2 real pieces, NOT x 3
+    expect(r.variance).toBe(2.85)
+    expect(r.flags).toContain("under_expected")
+  })
+
+  it("flags a log that is not attributed to any production run", () => {
+    const [r] = reconcileDesigns({ runs: denimRuns, logs: denimLogs })
+    expect(r.unattributed_logs).toBe(1)
+    expect(r.flags).toContain("unattributed_consumption")
+  })
+
+  it("flags production with no material logged at all", () => {
+    // Five prod designs look like this — the largest failure mode by count.
+    const [r] = reconcileDesigns({
+      runs: [
+        { id: "r1", design_id: "d_jacket", status: "completed", produced_quantity: 3 },
+      ],
+      logs: [],
+    })
+    expect(r.produced).toBe(3)
+    expect(r.consumed).toBe(0)
+    expect(r.implied_rate).toBeNull()
+    expect(r.flags).toContain("produced_without_consumption")
+  })
+
+  it("flags an implausible per-piece rate", () => {
+    // "Bakshi's Design" on prod: 9 pieces, 1.75 m logged = 0.19 m/piece.
+    const [r] = reconcileDesigns({
+      runs: [
+        { id: "r1", design_id: "d_bakshi", status: "completed", produced_quantity: 9 },
+      ],
+      logs: [
+        {
+          id: "l1",
+          design_id: "d_bakshi",
+          inventory_item_id: "iitem_x",
+          quantity: 1.75,
+          is_committed: true,
+        },
+      ],
+    })
+    expect(r.implied_rate).toBe(0.194444)
+    expect(r.flags).toContain("implausible_rate")
+  })
+
+  it("flags consumption recorded against no production run at all", () => {
+    const [r] = reconcileDesigns({
+      runs: [],
+      logs: [
+        {
+          id: "l1",
+          design_id: "d_partner",
+          inventory_item_id: "iitem_y",
+          quantity: 2.5,
+          is_committed: true,
+        },
+      ],
+    })
+    expect(r.produced).toBe(0)
+    expect(r.consumed).toBe(2.5)
+    expect(r.flags).toContain("consumption_without_production")
+  })
+
+  it("ignores uncommitted logs and labour/energy logs", () => {
+    const [r] = reconcileDesigns({
+      runs: [
+        { id: "r1", design_id: "d1", status: "completed", produced_quantity: 2 },
+      ],
+      logs: [
+        // labour: no inventory_item_id (1300 such rows on prod)
+        { id: "l1", design_id: "d1", quantity: 8, is_committed: true },
+        // not committed yet
+        {
+          id: "l2",
+          design_id: "d1",
+          inventory_item_id: "iitem_z",
+          quantity: 99,
+          is_committed: false,
+        },
+      ],
+    })
+    expect(r.consumed).toBe(0)
+    expect(r.flags).toContain("produced_without_consumption")
+  })
+
+  it("does not double-count a parent against its children (#498)", () => {
+    const runs: ReconcileRun[] = [
+      { id: "p", design_id: "d1", status: "completed", produced_quantity: 10 },
+      { id: "c1", design_id: "d1", parent_run_id: "p", status: "completed", produced_quantity: 4 },
+      { id: "c2", design_id: "d1", parent_run_id: "p", status: "completed", produced_quantity: 6 },
+    ]
+    const [r] = reconcileDesigns({ runs, logs: [] })
+    expect(r.produced).toBe(10)
+  })
+
+  it("ignores runs that are not completed", () => {
+    const [r] = reconcileDesigns({
+      runs: [
+        { id: "r1", design_id: "d1", status: "in_progress", produced_quantity: 5 },
+        { id: "r2", design_id: "d1", status: "completed", produced_quantity: 2 },
+      ],
+      logs: [],
+    })
+    expect(r.produced).toBe(2)
+  })
+
+  it("falls back to ordered quantity when yield was never recorded", () => {
+    const [r] = reconcileDesigns({
+      runs: [
+        { id: "r1", design_id: "d1", status: "completed", produced_quantity: null, quantity: 4 },
+      ],
+      logs: [],
+    })
+    expect(r.produced).toBe(4)
+  })
+
+  it("sorts worst-first by produced quantity", () => {
+    const out = reconcileDesigns({
+      runs: [
+        { id: "r1", design_id: "small", status: "completed", produced_quantity: 1 },
+        { id: "r2", design_id: "big", status: "completed", produced_quantity: 9 },
+      ],
+      logs: [],
+    })
+    expect(out.map((r) => r.design_id)).toEqual(["big", "small"])
+  })
+})
+
+describe("isProvenanceRun / leafRuns", () => {
+  it("matches design-backed provenance, not real work", () => {
+    expect(isProvenanceRun(denimRuns[1])).toBe(true)
+    expect(isProvenanceRun(denimRuns[0])).toBe(false)
+    expect(isProvenanceRun({ id: "x" })).toBe(false)
+  })
+
+  it("drops runs that are referenced as a parent", () => {
+    const runs: ReconcileRun[] = [
+      { id: "p" },
+      { id: "c", parent_run_id: "p" },
+    ]
+    expect(leafRuns(runs).map((r) => r.id)).toEqual(["c"])
+  })
+})

--- a/apps/backend/src/workflows/consumption-logs/lib/apply-to-inventory.ts
+++ b/apps/backend/src/workflows/consumption-logs/lib/apply-to-inventory.ts
@@ -38,6 +38,19 @@ export type ConsumptionApplyPlanInput = {
    * that the material was never ours.
    */
   brandLevels: Record<string, number>
+  /**
+   * Refuse any deduction whose shortfall would exceed this, skipping the log
+   * instead of applying it.
+   *
+   * A shortfall means the level held less than the log claimed, so the applied
+   * movement is smaller than the reported consumption — and the log is then
+   * STAMPED `inventory_applied_at` and skipped forever after. When the stock
+   * simply hasn't arrived yet (a mis-routed inventory order, an un-received
+   * delivery), that stamp burns the log against a balance it was never measured
+   * against, and no later repair can re-apply it. Undefined keeps the previous
+   * behaviour of applying regardless.
+   */
+  maxShortfall?: number
 }
 
 export type ConsumptionApplyDecision =
@@ -121,6 +134,13 @@ export function planConsumptionApplication(
     const before = running[log.inventory_item_id]
     const after = round(Math.max(0, before - quantity))
     const shortfall = round(quantity - (before - after))
+
+    if (input.maxShortfall != null && shortfall > input.maxShortfall) {
+      skip(
+        `shortfall ${shortfall} exceeds max_shortfall ${input.maxShortfall} (level ${before} < logged ${quantity}) — stock likely not received yet`
+      )
+      continue
+    }
 
     running[log.inventory_item_id] = after
     decisions.push({

--- a/apps/backend/src/workflows/consumption-logs/lib/apply-to-inventory.ts
+++ b/apps/backend/src/workflows/consumption-logs/lib/apply-to-inventory.ts
@@ -21,6 +21,7 @@ import type { MedusaContainer } from "@medusajs/framework/types"
 export type ConsumptionApplyLog = {
   id: string
   design_id: string | null
+  production_run_id?: string | null
   inventory_item_id: string | null
   quantity: number | string | null
   is_committed: boolean
@@ -51,6 +52,19 @@ export type ConsumptionApplyPlanInput = {
    * behaviour of applying regardless.
    */
   maxShortfall?: number
+  /**
+   * Finished pieces the log's quantity should be multiplied by, keyed by log id.
+   *
+   * A logged quantity is PER PIECE: a partner reporting 2.15 m against a run of
+   * 2 consumed 4.3 m. The column is read as a total everywhere else (cost is
+   * `quantity × unit_cost`), so the multiplication belongs here, at the point
+   * stock actually moves, and is reported explicitly on every decision.
+   *
+   * A log absent from this map, or mapped to 0, CANNOT be resolved — the piece
+   * count is unknown — and is skipped rather than deducted at face value.
+   * Omitting the map entirely keeps the old 1:1 behaviour.
+   */
+  piecesByLog?: Record<string, number>
 }
 
 export type ConsumptionApplyDecision =
@@ -58,9 +72,14 @@ export type ConsumptionApplyDecision =
       action: "apply"
       log_id: string
       inventory_item_id: string
+      /** The RESOLVED total actually deducted (per_piece × pieces when known). */
       quantity: number
       before: number
       after: number
+      /** The figure as logged, when it was resolved as a per-piece rate. */
+      per_piece?: number
+      /** Finished pieces the per-piece figure was multiplied by. */
+      pieces?: number
       /** Set when the log wanted more than the level held. */
       shortfall?: number
     }
@@ -125,10 +144,24 @@ export function planConsumptionApplication(
       continue
     }
 
-    const quantity = Number(log.quantity ?? 0)
-    if (!Number.isFinite(quantity) || quantity <= 0) {
+    const perPiece = Number(log.quantity ?? 0)
+    if (!Number.isFinite(perPiece) || perPiece <= 0) {
       skip(`non-positive quantity (${log.quantity})`)
       continue
+    }
+
+    // Resolve the per-piece figure to the run's actual material draw.
+    let quantity = perPiece
+    let pieces: number | undefined
+    if (input.piecesByLog) {
+      pieces = input.piecesByLog[log.id]
+      if (!pieces || pieces <= 0) {
+        skip(
+          "piece count unknown (no completed production run for this design) — cannot resolve a per-piece quantity"
+        )
+        continue
+      }
+      quantity = round(perPiece * pieces)
     }
 
     const before = running[log.inventory_item_id]
@@ -150,6 +183,7 @@ export function planConsumptionApplication(
       quantity,
       before,
       after,
+      ...(pieces != null ? { per_piece: perPiece, pieces } : {}),
       ...(shortfall > 0 ? { shortfall } : {}),
     })
   }

--- a/apps/backend/src/workflows/consumption-logs/lib/apply-to-inventory.ts
+++ b/apps/backend/src/workflows/consumption-logs/lib/apply-to-inventory.ts
@@ -22,6 +22,7 @@ export type ConsumptionApplyLog = {
   id: string
   design_id: string | null
   production_run_id?: string | null
+  quantity_basis?: "total" | "per_piece" | null
   inventory_item_id: string | null
   quantity: number | string | null
   is_committed: boolean
@@ -65,6 +66,11 @@ export type ConsumptionApplyPlanInput = {
    * Omitting the map entirely keeps the old 1:1 behaviour.
    */
   piecesByLog?: Record<string, number>
+  /**
+   * Basis to assume for logs written before the capture forms recorded one
+   * (`quantity_basis: null`). Undefined means refuse to guess: those logs skip.
+   */
+  assumeBasisWhenUnknown?: "total" | "per_piece"
 }
 
 export type ConsumptionApplyDecision =
@@ -150,11 +156,21 @@ export function planConsumptionApplication(
       continue
     }
 
-    // Resolve the per-piece figure to the run's actual material draw.
+    // What the figure measures decides whether it is multiplied at all. A null
+    // basis predates the forms asking, so it is resolved only against an
+    // explicit assumption — never defaulted.
+    const basis = log.quantity_basis ?? input.assumeBasisWhenUnknown
+    if (!basis) {
+      skip(
+        "quantity_basis unknown (logged before the form recorded it) — pass assume_basis to resolve"
+      )
+      continue
+    }
+
     let quantity = perPiece
     let pieces: number | undefined
-    if (input.piecesByLog) {
-      pieces = input.piecesByLog[log.id]
+    if (basis === "per_piece") {
+      pieces = input.piecesByLog?.[log.id]
       if (!pieces || pieces <= 0) {
         skip(
           "piece count unknown (no completed production run for this design) — cannot resolve a per-piece quantity"

--- a/apps/backend/src/workflows/consumption-logs/lib/reconcile-production-consumption.ts
+++ b/apps/backend/src/workflows/consumption-logs/lib/reconcile-production-consumption.ts
@@ -1,0 +1,218 @@
+/**
+ * Reconcile what a design PRODUCED against what it reported CONSUMING.
+ *
+ * Committing a consumption log is the only signal we have that material left the
+ * shelf, and on prod that signal is mostly missing: of nine designs with real
+ * production, five have logged no material at all, and one reports 1.75 m against
+ * nine finished pieces. Deducting those figures moves a rounding error while the
+ * real outflow stays invisible, so the gap has to be measurable before any of it
+ * is settled against stock.
+ *
+ * This module is deliberately REPORT-ONLY and computes no stock movement. An
+ * expected quantity is a model, not a measurement; writing one into
+ * `stocked_quantity` would make the ledger mean "what we think is on the shelf"
+ * and let every future variance compound invisibly. The variance is surfaced so
+ * a human can correct the LOG — which the existing apply job then deducts.
+ */
+
+/** Only what reconciliation needs; mirrors the production_run model subset. */
+export type ReconcileRun = {
+  id: string
+  design_id?: string | null
+  parent_run_id?: string | null
+  status?: string | null
+  produced_quantity?: number | null
+  quantity?: number | null
+  metadata?: Record<string, any> | null
+}
+
+export type ReconcileLog = {
+  id: string
+  design_id?: string | null
+  inventory_item_id?: string | null
+  production_run_id?: string | null
+  quantity?: number | string | null
+  is_committed?: boolean
+}
+
+export type DesignReconciliation = {
+  design_id: string
+  /** Completed leaf-run output, provenance excluded — pieces we actually made. */
+  produced: number
+  /** Completed provenance quantity — shipped from stock, consumed nothing. */
+  shipped_from_stock: number
+  /** Committed material consumption (labour/energy logs excluded). */
+  consumed: number
+  /** consumed / produced, or null when nothing was produced. */
+  implied_rate: number | null
+  /** Expected consumption when a per-unit rate is known, else null. */
+  expected: number | null
+  /** expected - consumed, when expected is known. */
+  variance: number | null
+  /** Committed material logs not attributed to any production run. */
+  unattributed_logs: number
+  flags: ReconcileFlag[]
+}
+
+/**
+ * `implausible_rate` usually means the operator entered a PER-PIECE figure into
+ * a field the system reads as a TOTAL.
+ *
+ * `quantity` is unambiguously a total everywhere it is used — `unit_cost` is
+ * priced per unit-of-measure and the design UI renders `quantity × unit_cost` as
+ * the line's total cost, so a per-piece entry silently understates cost as well
+ * as stock. But the capture form is labelled only "Quantity", with no piece
+ * count and no run attached, so nothing tells the operator which is meant.
+ *
+ * The gap is procedural: partners are ASKED for consumption PER PIECE, but the
+ * partner form is a mirror of the admin one — labelled only "Quantity", sending
+ * no production_run_id — and the value lands in a column every consumer reads as
+ * a total. So a per-piece answer is stored, costed and deducted as though it
+ * were the whole run's material, understating both by the piece count.
+ *
+ * Prod shows both readings side by side: "Denim Trouser" (admin) logs 2.15 m
+ * against 2 pieces — 1.07 m/piece, sensible as a total — while "Lets test this
+ * design" (partner) logs 5 m against 5 pieces, which under the per-piece rule is
+ * 25 m of real consumption against 5 m recorded.
+ *
+ * This module therefore does NOT multiply. Resolving it needs the basis recorded
+ * explicitly on the log (`total` vs `per_piece`) plus a run attribution to supply
+ * the piece count — most partner logs currently carry neither, and no
+ * multiplication is safe until they do.
+ */
+export type ReconcileFlag =
+  | "produced_without_consumption"
+  | "consumption_without_production"
+  | "implausible_rate"
+  | "unattributed_consumption"
+  | "under_expected"
+
+/**
+ * A run minted from retail fulfillment: born terminal, no shop-floor work, no
+ * material consumed. Identified by the create-side marker alone — the creator
+ * also mints DESIGN-BACKED provenance runs, so testing for a null design_id
+ * would let exactly the design-attached ones through, which are the only kind
+ * that can reach a design's reconciliation at all.
+ */
+export function isProvenanceRun(run: ReconcileRun): boolean {
+  return run?.metadata?.source === "order.fulfillment_created"
+}
+
+/**
+ * #498: a design's runs come back as a parent plus one child per partner
+ * assignment, the parent's quantity already being the sum of its children.
+ * Counting both double-counts, so only leaves are summed.
+ */
+export function leafRuns(runs: ReconcileRun[]): ReconcileRun[] {
+  const parentIds = new Set(
+    runs.map((r) => r?.parent_run_id).filter(Boolean).map(String)
+  )
+  return runs.filter((r) => !parentIds.has(String(r.id)))
+}
+
+const num = (v: unknown): number => {
+  const n = Number(v ?? 0)
+  return Number.isFinite(n) ? n : 0
+}
+
+/** Decimal metres — see the rounding note in ./apply-to-inventory. */
+const round = (n: number): number => Number(n.toFixed(6))
+
+/**
+ * PURE. Exported for unit tests.
+ *
+ * `ratePerUnit` is the expected material per finished piece, keyed by design.
+ * It is optional: with no rate we still report the IMPLIED rate, which is what
+ * makes a 0.19 m/piece design visible without anyone having specified a spec.
+ */
+export function reconcileDesigns(input: {
+  runs: ReconcileRun[]
+  logs: ReconcileLog[]
+  ratePerUnit?: Record<string, number>
+  /** Below this implied rate, flag the design. Default 0.5 (metres/piece). */
+  implausibleRateBelow?: number
+}): DesignReconciliation[] {
+  const implausibleBelow = input.implausibleRateBelow ?? 0.5
+  const rates = input.ratePerUnit ?? {}
+
+  const leaves = leafRuns(
+    (input.runs || []).filter((r) => r?.design_id)
+  ).filter((r) => r.status === "completed")
+
+  const produced: Record<string, number> = {}
+  const provenance: Record<string, number> = {}
+  for (const r of leaves) {
+    const d = String(r.design_id)
+    // produced_quantity is the reported yield; fall back to the ordered
+    // quantity only when the yield was never recorded.
+    const q = num(r.produced_quantity ?? r.quantity)
+    if (isProvenanceRun(r)) {
+      provenance[d] = round((provenance[d] ?? 0) + q)
+    } else {
+      produced[d] = round((produced[d] ?? 0) + q)
+    }
+  }
+
+  const consumed: Record<string, number> = {}
+  const unattributed: Record<string, number> = {}
+  for (const l of input.logs || []) {
+    // Labour (`Hour`) and energy (`kWh`) logs carry a raw_material_id instead of
+    // an inventory item; they are not material and must not enter a metres-per-
+    // piece rate.
+    if (!l?.is_committed || !l.inventory_item_id || !l.design_id) {
+      continue
+    }
+    const d = String(l.design_id)
+    consumed[d] = round((consumed[d] ?? 0) + num(l.quantity))
+    if (!l.production_run_id) {
+      unattributed[d] = (unattributed[d] ?? 0) + 1
+    }
+  }
+
+  const designIds = new Set([
+    ...Object.keys(produced),
+    ...Object.keys(provenance),
+    ...Object.keys(consumed),
+  ])
+
+  const out: DesignReconciliation[] = []
+  for (const design_id of designIds) {
+    const p = produced[design_id] ?? 0
+    const c = consumed[design_id] ?? 0
+    const rate = rates[design_id]
+    const expected = rate != null && p > 0 ? round(rate * p) : null
+    const flags: ReconcileFlag[] = []
+
+    if (p > 0 && c === 0) {
+      flags.push("produced_without_consumption")
+    }
+    if (p === 0 && c > 0) {
+      flags.push("consumption_without_production")
+    }
+    const implied = p > 0 && c > 0 ? round(c / p) : null
+    if (implied != null && implied < implausibleBelow) {
+      flags.push("implausible_rate")
+    }
+    if ((unattributed[design_id] ?? 0) > 0) {
+      flags.push("unattributed_consumption")
+    }
+    if (expected != null && c < expected) {
+      flags.push("under_expected")
+    }
+
+    out.push({
+      design_id,
+      produced: p,
+      shipped_from_stock: provenance[design_id] ?? 0,
+      consumed: c,
+      implied_rate: implied,
+      expected,
+      variance: expected != null ? round(expected - c) : null,
+      unattributed_logs: unattributed[design_id] ?? 0,
+      flags,
+    })
+  }
+
+  // Worst first: most produced with least accounted for.
+  return out.sort((a, b) => b.produced - a.produced || b.consumed - a.consumed)
+}

--- a/apps/backend/src/workflows/consumption-logs/log-consumption.ts
+++ b/apps/backend/src/workflows/consumption-logs/log-consumption.ts
@@ -24,6 +24,8 @@ export type LogConsumptionInput = {
   inventory_item_id?: string
   raw_material_id?: string
   quantity: number
+  /** What `quantity` measures — see the model. */
+  quantity_basis?: "total" | "per_piece" | null
   unit_cost?: number
   unit_of_measure?:
     | "Meter"
@@ -96,6 +98,7 @@ const createConsumptionLogStep = createStep(
       inventory_item_id: input.inventory_item_id,
       raw_material_id: input.raw_material_id || null,
       quantity: input.quantity,
+      quantity_basis: input.quantity_basis ?? null,
       unit_cost: input.unit_cost ?? null,
       unit_of_measure: input.unit_of_measure || "Other",
       consumption_type: input.consumption_type || "sample",

--- a/apps/partner-ui/src/components/work-orders/goods-transfer-section.tsx
+++ b/apps/partner-ui/src/components/work-orders/goods-transfer-section.tsx
@@ -42,14 +42,26 @@ const REASONS = [
   { value: "other", label: "Other" },
 ] as const
 
-// Mirrors the backend's supported carriers. "" is a real choice, not an empty
-// state: a van run between two of our own locations is a movement worth
-// recording even though no carrier is involved.
+// Mirrors the backend's supported carriers. "No carrier" is a real choice, not
+// an empty state: a van run between two of our own locations is a movement
+// worth recording even though no carrier is involved.
+//
+// It carries the sentinel `NO_CARRIER` rather than "" because Radix reserves
+// the empty string to mean "cleared, show the placeholder" and THROWS on a
+// `<Select.Item value="">` — which took the whole "Move to next location"
+// drawer down with a render error the moment it opened. The sentinel never
+// leaves this component: `carrierValue()` maps it back to undefined on submit.
+const NO_CARRIER = "none"
+
 const CARRIERS = [
-  { value: "", label: "No carrier (self-driven)" },
+  { value: NO_CARRIER, label: "No carrier (self-driven)" },
   { value: "shiprocket", label: "Shiprocket" },
   { value: "delhivery", label: "Delhivery" },
 ] as const
+
+/** Sentinel/blank → undefined, so the backend still sees "no carrier". */
+const carrierValue = (v: string): string | undefined =>
+  !v || v === NO_CARRIER ? undefined : v
 
 const STATUS_COLOR: Record<
   GoodsTransfer["status"],
@@ -78,7 +90,7 @@ export const GoodsTransferSection = ({ runId, isCompleted }: Props) => {
   const [open, setOpen] = useState(false)
   const [toLocationId, setToLocationId] = useState("")
   const [reason, setReason] = useState<GoodsTransfer["reason"]>("stock")
-  const [carrier, setCarrier] = useState("")
+  const [carrier, setCarrier] = useState<string>(NO_CARRIER)
   const [quantity, setQuantity] = useState("")
   const [weight, setWeight] = useState("")
   const [notes, setNotes] = useState("")
@@ -107,7 +119,7 @@ export const GoodsTransferSection = ({ runId, isCompleted }: Props) => {
       const res = await createTransfer({
         to_location_id: toLocationId,
         reason,
-        carrier: carrier || undefined,
+        carrier: carrierValue(carrier),
         quantity: positive(quantity),
         weight_grams: positive(weight),
         notes: notes.trim() || undefined,
@@ -120,6 +132,7 @@ export const GoodsTransferSection = ({ runId, isCompleted }: Props) => {
       )
       setOpen(false)
       setToLocationId("")
+      setCarrier(NO_CARRIER)
       setNotes("")
       setQuantity("")
       setWeight("")
@@ -218,7 +231,7 @@ export const GoodsTransferSection = ({ runId, isCompleted }: Props) => {
                 </Select.Trigger>
                 <Select.Content>
                   {CARRIERS.map((c) => (
-                    <Select.Item key={c.value || "none"} value={c.value}>
+                    <Select.Item key={c.value} value={c.value}>
                       {c.label}
                     </Select.Item>
                   ))}

--- a/apps/partner-ui/src/hooks/api/partner-consumption-logs.tsx
+++ b/apps/partner-ui/src/hooks/api/partner-consumption-logs.tsx
@@ -22,6 +22,7 @@ export type ConsumptionLog = {
   inventory_item_id: string
   raw_material_id?: string | null
   quantity: number
+  quantity_basis?: "total" | "per_piece" | null
   unit_of_measure: string
   consumption_type: "sample" | "production" | "wastage"
   is_committed: boolean
@@ -43,6 +44,7 @@ export type LogConsumptionPayload = {
   inventoryItemId: string
   rawMaterialId?: string
   quantity: number
+  quantityBasis?: "total" | "per_piece"
   unitCost?: number
   unitOfMeasure?: string
   consumptionType?: "sample" | "production" | "wastage"

--- a/apps/partner-ui/src/routes/designs/design-detail/components/design-consumption-logs-section.tsx
+++ b/apps/partner-ui/src/routes/designs/design-detail/components/design-consumption-logs-section.tsx
@@ -73,6 +73,7 @@ export const DesignConsumptionLogsSection = ({ design }: DesignConsumptionLogsSe
   // Form state
   const [formInventoryId, setFormInventoryId] = useState("")
   const [formQuantity, setFormQuantity] = useState("")
+  const [formBasis, setFormBasis] = useState("per_piece")
   const [formUnitCost, setFormUnitCost] = useState("")
   const [formUnit, setFormUnit] = useState("Meter")
   const [formType, setFormType] = useState("production")
@@ -81,6 +82,7 @@ export const DesignConsumptionLogsSection = ({ design }: DesignConsumptionLogsSe
   const resetForm = () => {
     setFormInventoryId("")
     setFormQuantity("")
+    setFormBasis("per_piece")
     setFormUnitCost("")
     setFormUnit("Meter")
     setFormType("production")
@@ -97,6 +99,7 @@ export const DesignConsumptionLogsSection = ({ design }: DesignConsumptionLogsSe
       await logConsumption({
         inventoryItemId: formInventoryId,
         quantity: parseFloat(formQuantity),
+        quantityBasis: formBasis as "total" | "per_piece",
         unitCost: formUnitCost ? parseFloat(formUnitCost) : undefined,
         unitOfMeasure: formUnit,
         consumptionType: formType as "sample" | "production" | "wastage",
@@ -216,6 +219,27 @@ export const DesignConsumptionLogsSection = ({ design }: DesignConsumptionLogsSe
                       value={formQuantity}
                       onChange={(e) => setFormQuantity(e.target.value)}
                     />
+                    {/*
+                      Which one this is CANNOT be inferred later: the same 2.15 m
+                      means 2.15 or 4.3 depending on the answer, and it scales
+                      both the costing and the stock deduction. Asked here, once.
+                    */}
+                    <div className="mt-1.5">
+                      <Select value={formBasis} onValueChange={setFormBasis}>
+                        <Select.Trigger>
+                          <Select.Value placeholder="Measured as" />
+                        </Select.Trigger>
+                        <Select.Content>
+                          <Select.Item value="per_piece">Per piece</Select.Item>
+                          <Select.Item value="total">Total for the run</Select.Item>
+                        </Select.Content>
+                      </Select>
+                    </div>
+                    <Text size="xsmall" className="text-ui-fg-muted mt-1">
+                      {formBasis === "per_piece"
+                        ? "Material for ONE finished piece — we multiply by how many you make."
+                        : "Material for the WHOLE run — recorded as entered."}
+                    </Text>
                   </div>
                   <div>
                     <Text size="xsmall" weight="plus" className="text-ui-fg-subtle mb-1">


### PR DESCRIPTION
Three defects found while trying to settle the 63 committed consumption logs against stock. They share one root cause: **a run minted from retail fulfillment is indistinguishable from shop-floor work to anything reading only status + quantity.**

## 1. Design totals counted stock sales as production

`summarizeProductionRunTotals` summed every leaf run, so design `01KWWJ0S3Z…` ("Denim Trouser") reported **3 produced** when the shop made 2 and the third shipped from stock. That number is rendered as `totalProduced` in `product-designs.tsx`, so it was wrong in the UI for every design whose product has ever been fulfilled from stock.

Provenance runs are now excluded, and the excluded quantity is reported as `shippedFromStock` rather than silently dropped.

## 2. `isOwnedProvenanceRun` missed design-backed provenance runs

It required `design_id == null`, but the same creator mints **design-backed** provenance runs (stamping `design_backed: true` beside the marker). Those runs therefore were:

- never quantity-adjusted as fulfilled quantity changed, and
- **never soft-deleted when an order was cancelled** — leaving a completed run claiming goods that never shipped.

The marker `metadata.source === "order.fulfillment_created"` has exactly one writer and no path that mints a real run sets it, so it suffices alone.

## 3. A logged quantity's meaning was never captured

`quantity` is read as a **total** by every consumer (cost is `quantity × unit_cost`), while partners are asked for material **per piece** — and neither capture form said which it wanted; both were labelled just "Quantity". A per-piece answer was stored, costed and deducted as though it covered the whole run.

The basis cannot be recovered after the fact — 2.15 m against 2 pieces is either 2.15 or 4.3 — and prod carries entries that only make sense under each reading. So it is now **asked at capture**, on both forms, with the effect shown under the selector.

| basis | behaviour |
|---|---|
| `per_piece` | × finished pieces (provenance excluded from the count) |
| `total` | deducted verbatim |
| `null` (legacy) | **skipped, with a reason** |

`quantity_basis` is nullable **by design**: the 63 existing rows predate the question. `assume_basis` resolves them deliberately per sweep instead of baking a guess into a default.

## Also

- **`reconcile-consumption-vs-production`** — new REPORT-ONLY job. Of nine designs with real production, **five logged no material at all** and one reports 1.75 m against nine finished pieces. It flags production-without-consumption, consumption-without-production, implausible rate, and unattributed logs. It never writes: an expected quantity is a model, not a measurement, and must not reach `stocked_quantity`.
- **`max_shortfall`** on the apply job — a shortfall applies a smaller movement than logged and still stamps `inventory_applied_at`, so a log burned against stock that hadn't arrived could never be re-applied. The guard skips instead. Evaluated against the *resolved* total.

## Migration

`Migration20260811085117` adds a nullable `quantity_basis` column — additive, `add column if not exists`, safe to re-run and to roll back. Generated via `db:generate`; name-collision checked.

## Verification

- **101 unit tests pass**; `tsc` clean on backend and partner-ui.
- New specs cover the real prod shapes (Denim Trouser's two runs, Bakshi's 9-piece design).
- **Nothing has been applied to prod stock.** The dry-run now prints `2.15/pc × 2 pcs` per decision so the arithmetic is checkable before anything moves.

🤖 Generated with [Claude Code](https://claude.com/claude-code)