### PR TITLE
fix(ops): stop rewind-production-run claiming it re-mirrors the unified order (#1228)

### DIFF
--- a/apps/backend/src/api/admin/ops/maintenance-jobs/__tests__/rewind-production-run.unit.spec.ts
+++ b/apps/backend/src/api/admin/ops/maintenance-jobs/__tests__/rewind-production-run.unit.spec.ts
@@ -351,3 +351,21 @@ describe("rewind-production-run — registry wiring", () => {
     expect(required).toEqual(["production_run_id"])
   })
 })
+
+describe("rewind-production-run — honest about what it does not do", () => {
+  it("says the unified order is not re-mirrored", async () => {
+    const { container } = makeContainer({ run: completedRun() })
+
+    const result = await rewindProductionRunJob.run(container, {
+      dry_run: true,
+      params: { production_run_id: "prod_run_1" },
+    } as any)
+
+    expect(result.summary).toMatch(/unified order.*NOT re-mirrored/)
+  })
+
+  it("does not claim in its description to do either of them", () => {
+    expect(rewindProductionRunJob.description).toMatch(/NOT reverse finished goods/)
+    expect(rewindProductionRunJob.description).toMatch(/NOT re-mirror the unified order/)
+  })
+})

--- a/apps/backend/src/api/admin/ops/maintenance-jobs/rewind-production-run-job.ts
+++ b/apps/backend/src/api/admin/ops/maintenance-jobs/rewind-production-run-job.ts
@@ -131,7 +131,7 @@ export const rewindProductionRunJob: MaintenanceJob = {
   id: "rewind-production-run",
   label: "Rewind a prematurely completed production run",
   description:
-    "Put a run that was marked complete without its data back where the partner can finish it properly — clears the completion stamps and output, reopens the tasks completion force-closed, and re-mirrors the unified order. Refuses when completion left consumption logs a re-completion would duplicate, unless forced. Does NOT reverse finished goods already stocked; those are reported so you can decide. Dry-run previews every field.",
+    "Put a run that was marked complete without its data back where the partner can finish it properly — clears the completion stamps and output, reopens the tasks completion force-closed, and optionally rewinds the parent that completed by cascade. Refuses when completion left consumption logs a re-completion would duplicate, unless forced. Does NOT reverse finished goods already stocked, and does NOT re-mirror the unified order — both are reported so you can decide. Dry-run previews every field.",
   params: [
     {
       name: "production_run_id",
@@ -337,6 +337,13 @@ export const rewindProductionRunJob: MaintenanceJob = {
     // rather than let a silent double-count arrive at the next completion.
     notes.push(
       "finished goods stocked at completion are NOT reversed — check the partner location's levels before the run is completed again"
+    )
+    // The unified-order mirror is driven by the completion workflow's own step,
+    // which this job deliberately does not re-enter (it would re-fire the
+    // completion event). Prod already shows the two drifting apart, so say it
+    // rather than let the operator assume the order followed.
+    notes.push(
+      "the unified order's partner_status is NOT re-mirrored — verify it separately"
     )
 
     const summary = [


### PR DESCRIPTION
The job's description said it "re-mirrors the unified order". It does not — the mirror is driven by the completion workflow's own step, which this job deliberately does not re-enter.

The description is what the admin console and the assistant read to decide what a job is for, so an overclaim there is worse than a silent gap: prod already shows `prod_run_01KWPVZ4R2PWK6DW1X8X5DKNZE` completed while its order still reads `partner_status: accepted`, and an operator trusting that sentence would not go and look.

Description corrected; the run summary now says it outright next to the existing finished-goods warning. Two tests pin both so claim and behaviour can't drift apart again. 22 tests pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)