### PR TITLE
fix(designs): stop the inventory sanitiser rebuilding every Date as {}

### DIFF
--- a/apps/backend/src/admin/routes/designs/[id]/@inventory/[inventoryId]/page.tsx
+++ b/apps/backend/src/admin/routes/designs/[id]/@inventory/[inventoryId]/page.tsx
@@ -17,14 +17,25 @@ import { Thumbnail } from "../../../../../components/common/thumbnail"
 import { firstMediaUrl } from "../../../../../lib/utils/first-media-url"
 
 
-const formatConsumedAt = (consumedAt?: string) => {
+/**
+ * Takes `unknown` on purpose: this renders straight into JSX, so returning a
+ * value that isn't a string crashes the whole drawer with "Objects are not
+ * valid as a React child". That is exactly what happened once `consumed_at`
+ * got its first real value and reached the UI as `{}` — never hand a raw
+ * API value back to the caller.
+ */
+const formatConsumedAt = (consumedAt?: unknown) => {
   if (!consumedAt) {
     return "Not recorded"
   }
 
-  const date = new Date(consumedAt)
+  if (typeof consumedAt !== "string" && !(consumedAt instanceof Date)) {
+    return "Not recorded"
+  }
+
+  const date = new Date(consumedAt as string | Date)
   if (Number.isNaN(date.getTime())) {
-    return consumedAt
+    return "Not recorded"
   }
 
   return date.toLocaleString()

--- a/apps/backend/src/workflows/designs/inventory/__tests__/list-design-inventory.unit.spec.ts
+++ b/apps/backend/src/workflows/designs/inventory/__tests__/list-design-inventory.unit.spec.ts
@@ -1,0 +1,75 @@
+/**
+ * Unit tests for `sanitizeBigInt` — the payload sanitiser behind
+ * GET /admin/designs/:id/inventory.
+ *
+ * It recurses into every object to convert bigints, and a Date has no own
+ * enumerable properties: the generic branch rebuilt one as `{}`, wiping every
+ * timestamp on the wire. Harmless for as long as `consumed_at` was always null
+ * (it had no writer at all — #1248), then the apply-consumption job gave it a
+ * real value and the admin drawer threw "Objects are not valid as a React
+ * child". These pin the passthrough so a refactor cannot reintroduce it.
+ */
+
+// Mock the SDK so the module-level createStep/createWorkflow calls don't throw
+// at import time.
+jest.mock("@medusajs/framework/workflows-sdk", () => ({
+  createStep: (_name: string, fn: Function) => fn,
+  createWorkflow: (_name: string, fn: Function) => fn,
+  StepResponse: class { constructor(public data: any) {} },
+  WorkflowResponse: class { constructor(public data: any) {} },
+}))
+
+jest.mock("@medusajs/framework/utils", () => ({
+  ContainerRegistrationKeys: { QUERY: "query" },
+  MedusaError: class extends Error {
+    static Types = { NOT_FOUND: "not_found" }
+    constructor(_type: string, message: string) {
+      super(message)
+    }
+  },
+}))
+
+jest.mock("../../../../links/design-inventory-link", () => ({
+  __esModule: true,
+  default: { entryPoint: "design_inventory_item" },
+}))
+
+import { sanitizeBigInt } from "../list-design-inventory"
+
+describe("sanitizeBigInt", () => {
+  it("returns a Date untouched rather than rebuilding it as {}", () => {
+    const date = new Date("2026-08-11T11:34:26.597Z")
+
+    expect(sanitizeBigInt(date)).toBe(date)
+  })
+
+  it("keeps a nested consumed_at serialisable as an ISO string", () => {
+    const row = {
+      consumed_quantity: 4,
+      consumed_at: new Date("2026-08-11T11:34:26.597Z"),
+    }
+
+    const sanitized = sanitizeBigInt(row)
+
+    // The crash was that this round-tripped to `{}` and reached JSX as an object.
+    expect(JSON.parse(JSON.stringify(sanitized)).consumed_at).toBe(
+      "2026-08-11T11:34:26.597Z"
+    )
+  })
+
+  it("still converts bigints, including inside arrays and nested objects", () => {
+    const sanitized = sanitizeBigInt({
+      quantity: BigInt(23),
+      levels: [{ stocked: BigInt(19) }],
+    })
+
+    expect(sanitized.quantity).toBe(23)
+    expect(sanitized.levels[0].stocked).toBe(19)
+  })
+
+  it("leaves null and primitives alone", () => {
+    expect(sanitizeBigInt(null)).toBeNull()
+    expect(sanitizeBigInt(undefined)).toBeUndefined()
+    expect(sanitizeBigInt("2026-08-11")).toBe("2026-08-11")
+  })
+})

--- a/apps/backend/src/workflows/designs/inventory/list-design-inventory.ts
+++ b/apps/backend/src/workflows/designs/inventory/list-design-inventory.ts
@@ -2,13 +2,23 @@ import { ContainerRegistrationKeys, MedusaError } from "@medusajs/framework/util
 import { createStep, createWorkflow, StepResponse, WorkflowResponse } from "@medusajs/framework/workflows-sdk"
 import DesignInventoryLink from "../../../links/design-inventory-link"
 
-const sanitizeBigInt = (value: any): any => {
+export const sanitizeBigInt = (value: any): any => {
   if (typeof value === "bigint") {
     return Number(value)
   }
 
   if (Array.isArray(value)) {
     return value.map((item) => sanitizeBigInt(item))
+  }
+
+  // A Date has no own enumerable properties, so the generic object branch below
+  // would rebuild it as `{}` — destroying every timestamp on the wire
+  // (`consumed_at`, `created_at`, `updated_at`). That went unnoticed for as long
+  // as `consumed_at` was always null; the moment the apply-consumption job gave
+  // it a real value, the admin drawer tried to render `{}` as a React child and
+  // threw. Hand it back untouched so it serializes as an ISO string.
+  if (value instanceof Date) {
+    return value
   }
 
   if (value && typeof value === "object") {


### PR DESCRIPTION
The design inventory drawer crashed with **"Objects are not valid as a React child (found: object with keys {})"** the first time a link carried a real `consumed_at` — which happened today, on prod.

## Cause

`sanitizeBigInt` (`workflows/designs/inventory/list-design-inventory.ts`) recurses into every object to convert bigints. A `Date` has no own enumerable properties, so `Object.entries(new Date())` is `[]` and the generic object branch rebuilt it as `{}`.

That wiped **every** timestamp the route returns — `consumed_at`, `created_at`, `updated_at` — not just the one that crashed.

It stayed invisible for as long as `consumed_at` was always null: it had no writer anywhere (#1248). Running `apply-committed-consumption-to-inventory` on prod gave it its first value, and the drawer immediately tried to render `{}`.

## Fix

- Dates pass through `sanitizeBigInt` untouched, so they serialise as ISO strings again.
- `formatConsumedAt` took `string` while being handed API data, and returned the **raw value** when parsing failed — feeding an object straight into JSX. It now takes `unknown` and can only ever return a string, so any future serialiser regression degrades to "Not recorded" instead of blanking the whole drawer.

## Tests

Four unit tests pin the passthrough, the ISO round-trip, the bigint conversion that the function exists for, and the primitive cases.

## Verify

```
cd apps/backend && npx jest --testPathPattern="list-design-inventory"
```

Then open a design → inventory item → info drawer on a link with a non-null `consumed_at` (e.g. design `01KWVA4SB9HRWYE9Z7D5P1MAFP`, which now reads `consumed: 4`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)