### PR TITLE
feat(consumption): deduct from where the material is, gated on locations we own

### DIFF
--- a/apps/backend/medusa-config.prod.ts
+++ b/apps/backend/medusa-config.prod.ts
@@ -558,6 +558,9 @@ module.exports = defineConfig({
     resolve: "./src/modules/ops_audit",
   },
   {
+    resolve: "./src/modules/location_ownership",
+  },
+  {
     resolve: "./src/modules/marketing",
   },
   {

--- a/apps/backend/medusa-config.ts
+++ b/apps/backend/medusa-config.ts
@@ -531,6 +531,9 @@ module.exports = defineConfig({
     resolve: "./src/modules/ops_audit",
   },
   {
+    resolve: "./src/modules/location_ownership",
+  },
+  {
     resolve: "./src/modules/marketing",
   },
   {

--- a/apps/backend/src/admin/components/designs/design-inventory-table.tsx
+++ b/apps/backend/src/admin/components/designs/design-inventory-table.tsx
@@ -25,9 +25,45 @@ interface SelectedRowConfig {
   inventoryId: string
   title?: string
   sku?: string
+  /** Where this material is stocked, captured at link time. */
+  locationId?: string
+  locationName?: string
 }
 
 const getRowId = (row: InventoryItem) => String(row.inventory_item_id || row.id)
+
+/**
+ * Where this material is stocked, if that is unambiguous.
+ *
+ * Mirrors `resolveLocationsFromLevels` on the server: only levels holding stock
+ * count, and exactly one of them means the material lives there. Capturing it
+ * as the link is made is the point — the field exists and the API has always
+ * accepted it, but nothing ever asked, so every link on prod carries null and
+ * consumption had to fall back to a single inferred default.
+ *
+ * A default, not a decision: the drawer can change it, and the server still
+ * refuses to deduct from a location we do not own.
+ */
+const resolveDefaultLocation = (
+  item: InventoryItem
+): { locationId?: string; locationName?: string } => {
+  const levels = ((item as any).location_levels ?? []) as any[]
+  const stocked = levels.filter((l) => Number(l?.stocked_quantity ?? 0) > 0)
+
+  if (stocked.length !== 1) {
+    return {}
+  }
+
+  const level = stocked[0]
+  const location = Array.isArray(level.stock_locations)
+    ? level.stock_locations[0]
+    : level.stock_locations
+
+  return {
+    locationId: level.location_id,
+    locationName: location?.name,
+  }
+}
 
 const createSelectionConfig = (item: InventoryItem): SelectedRowConfig => {
   const rowId = getRowId(item)
@@ -35,6 +71,7 @@ const createSelectionConfig = (item: InventoryItem): SelectedRowConfig => {
     inventoryId: rowId,
     title: item.inventory_item?.title || item.title,
     sku: item.inventory_item?.sku || item.sku,
+    ...resolveDefaultLocation(item),
   }
 }
 
@@ -265,14 +302,23 @@ export function DesignInventoryTable({ designId }: DesignInventoryTableProps) {
     const inventoryItemsPayload = selectedRowEntries.map(([, cfg]) => ({
       inventoryId: cfg.inventoryId,
       plannedQuantity: 1,
+      // Null when the material is stocked nowhere, or in more than one place —
+      // better an empty field the drawer can fill than a guess that silently
+      // decides where consumption gets deducted from.
+      locationId: cfg.locationId ?? null,
     }))
+
+    const placed = selectedRowEntries.filter(([, cfg]) => cfg.locationId).length
 
     linkInventory.mutate(
       { inventoryItems: inventoryItemsPayload },
       {
         onSuccess: () => {
           toast.success("Inventory items linked", {
-            description: "Manage planned usage from the design inventory drawer.",
+            description:
+              placed === selectedCount
+                ? `Stock location captured for ${placed === 1 ? "it" : "all " + placed}. Change it from the design inventory drawer.`
+                : `Stock location captured for ${placed} of ${selectedCount} — set the rest from the design inventory drawer.`,
             action: {
               label: "Go to design",
               altText: "Navigate to design detail page",

--- a/apps/backend/src/admin/hooks/api/designs.ts
+++ b/apps/backend/src/admin/hooks/api/designs.ts
@@ -568,7 +568,12 @@ export const useApproveDesign = (
 export interface PlannedInventoryItemPayload {
   inventoryId: string;
   plannedQuantity?: number;
-  locationId?: string;
+  /**
+   * Nullable: the link UI sends an explicit null when a material is stocked
+   * nowhere, or in more than one place, rather than guessing which location
+   * consumption should later be deducted from.
+   */
+  locationId?: string | null;
   metadata?: Record<string, any>;
 }
 

--- a/apps/backend/src/admin/widgets/stock-location-ownership.tsx
+++ b/apps/backend/src/admin/widgets/stock-location-ownership.tsx
@@ -1,0 +1,126 @@
+import { defineWidgetConfig } from "@medusajs/admin-sdk"
+import { DetailWidgetProps } from "@medusajs/framework/types"
+import { Badge, Container, Heading, Skeleton, Switch, Text, toast } from "@medusajs/ui"
+import { useMutation, useQuery, useQueryClient } from "@tanstack/react-query"
+import { sdk } from "../lib/config"
+
+/**
+ * Is this location ours?
+ *
+ * Consumption is only ever deducted from a location we own, so this switch
+ * decides whether material burned against a design moves stock here at all.
+ * It used to be inferred — the brand store was whichever store no partner
+ * linked to, and its default location was the only one that counted — which
+ * could not express stocking at several of our own warehouses and broke
+ * outright on a store with no partner link.
+ *
+ * A location with nothing recorded reads as NOT ours. That is deliberate:
+ * treating an unknown location as ours would deduct partner-held stock, which
+ * is the one thing the boundary exists to prevent.
+ */
+
+type StockLocation = { id: string; name?: string }
+
+type OwnershipRow = {
+  id: string
+  stock_location_id: string
+  is_core: boolean
+  note?: string | null
+}
+
+const QUERY_KEY = ["location-ownership"]
+
+const LocationOwnershipWidget = ({
+  data,
+}: DetailWidgetProps<StockLocation>) => {
+  const locationId = data?.id
+  const queryClient = useQueryClient()
+
+  const { data: ownership, isLoading } = useQuery({
+    queryKey: QUERY_KEY,
+    queryFn: async () =>
+      (await sdk.client.fetch("/admin/location-ownership")) as {
+        location_ownership: OwnershipRow[]
+      },
+  })
+
+  const row = ownership?.location_ownership?.find(
+    (r) => r.stock_location_id === locationId
+  )
+  const isCore = Boolean(row?.is_core)
+
+  const { mutate, isPending } = useMutation({
+    mutationFn: async (next: boolean) =>
+      sdk.client.fetch("/admin/location-ownership", {
+        method: "POST",
+        // No JSON.stringify — the SDK client serialises the body itself.
+        body: {
+          stock_location_id: locationId,
+          is_core: next,
+          note: next ? "marked ours from the location page" : "marked not ours",
+        },
+      }),
+    onSuccess: (_res, next) => {
+      queryClient.invalidateQueries({ queryKey: QUERY_KEY })
+      toast.success(
+        next
+          ? "Marked as ours — consumption can be deducted here"
+          : "Marked as not ours — consumption will never deduct here"
+      )
+    },
+    onError: (error: any) => {
+      toast.error(error?.message || "Failed to update location ownership")
+    },
+  })
+
+  return (
+    <Container className="divide-y p-0">
+      <div className="flex items-center justify-between px-6 py-4">
+        <div>
+          <Heading level="h2">Stock ownership</Heading>
+          <Text size="small" className="text-ui-fg-subtle">
+            Whether we own the stock held here
+          </Text>
+        </div>
+        {isLoading ? (
+          <Skeleton className="h-6 w-16" />
+        ) : (
+          <Badge color={isCore ? "green" : "grey"}>
+            {isCore ? "Ours" : "Not ours"}
+          </Badge>
+        )}
+      </div>
+
+      <div className="flex items-center justify-between gap-x-4 px-6 py-4">
+        <Text size="small" className="text-ui-fg-subtle">
+          {isCore
+            ? "Material consumed against a design can be deducted from this location."
+            : "Consumption is never deducted from this location. Leave this off for partner warehouses — their stock is not on our books."}
+        </Text>
+        {isLoading ? (
+          <Skeleton className="h-6 w-10" />
+        ) : (
+          <Switch
+            checked={isCore}
+            disabled={isPending || !locationId}
+            onCheckedChange={(next) => mutate(next)}
+          />
+        )}
+      </div>
+
+      {!isLoading && !row && (
+        <div className="px-6 py-4">
+          <Text size="small" className="text-ui-fg-muted">
+            Nothing recorded for this location yet, so it counts as not ours.
+          </Text>
+        </div>
+      )}
+    </Container>
+  )
+}
+
+export const config = defineWidgetConfig({
+  zone: "location.details.after",
+})
+
+export default LocationOwnershipWidget

--- a/apps/backend/src/api/admin/designs/[id]/inventory/validators.ts
+++ b/apps/backend/src/api/admin/designs/[id]/inventory/validators.ts
@@ -3,7 +3,10 @@ import { z } from "@medusajs/framework/zod";
 const inventoryLinkItemSchema = z.object({
   inventoryId: z.string(),
   plannedQuantity: z.number().int().optional(),
-  locationId: z.string().optional(),
+  // Nullable, matching the PATCH schema: the link UI captures where a material
+  // is stocked and sends an explicit null when that is not unambiguous, which
+  // `.optional()` alone would reject.
+  locationId: z.string().nullable().optional(),
   metadata: z.record(z.string(), z.any()).optional(),
 })
 

--- a/apps/backend/src/api/admin/location-ownership/route.ts
+++ b/apps/backend/src/api/admin/location-ownership/route.ts
@@ -1,0 +1,49 @@
+import { MedusaRequest, MedusaResponse } from "@medusajs/framework/http"
+
+import { LOCATION_OWNERSHIP_MODULE } from "../../../modules/location_ownership"
+import { AdminPostLocationOwnershipReq } from "./validators"
+
+/**
+ * GET /admin/location-ownership
+ *
+ * Every recorded location ownership. Small by nature — one row per stock
+ * location — so it returns the lot rather than paginating.
+ */
+export const GET = async (req: MedusaRequest, res: MedusaResponse) => {
+  const service: any = req.scope.resolve(LOCATION_OWNERSHIP_MODULE)
+  const rows = await service.listLocationOwnerships({}, { take: null })
+
+  res.json({ location_ownership: rows ?? [] })
+}
+
+/**
+ * POST /admin/location-ownership
+ *
+ * Upsert one location's ownership. Whether a location is ours decides whether
+ * consumption may be deducted from it at all, so this writes an explicit row
+ * rather than toggling anything inferred.
+ */
+export const POST = async (req: MedusaRequest, res: MedusaResponse) => {
+  const { stock_location_id, is_core, note } =
+    req.validatedBody as AdminPostLocationOwnershipReq
+
+  const service: any = req.scope.resolve(LOCATION_OWNERSHIP_MODULE)
+  const [existing] = await service.listLocationOwnerships(
+    { stock_location_id },
+    { take: 1 }
+  )
+
+  const row = existing
+    ? await service.updateLocationOwnerships({
+        id: existing.id,
+        is_core,
+        ...(note !== undefined ? { note } : {}),
+      })
+    : await service.createLocationOwnerships({
+        stock_location_id,
+        is_core,
+        note: note ?? null,
+      })
+
+  res.json({ location_ownership: row })
+}

--- a/apps/backend/src/api/admin/location-ownership/validators.ts
+++ b/apps/backend/src/api/admin/location-ownership/validators.ts
@@ -1,0 +1,11 @@
+import { z } from "@medusajs/framework/zod"
+
+export const AdminPostLocationOwnershipReq = z.object({
+  stock_location_id: z.string().min(1),
+  is_core: z.boolean(),
+  note: z.string().nullable().optional(),
+})
+
+export type AdminPostLocationOwnershipReq = z.infer<
+  typeof AdminPostLocationOwnershipReq
+>

--- a/apps/backend/src/api/admin/ops/maintenance-jobs/apply-committed-consumption-job.ts
+++ b/apps/backend/src/api/admin/ops/maintenance-jobs/apply-committed-consumption-job.ts
@@ -20,6 +20,8 @@ import {
   levelKey,
   planConsumptionApplication,
   resolveBrandLocationId,
+  resolveCoreLocationIds,
+  resolveLocationsFromLevels,
   type ConsumptionApplyLog,
 } from "../../../../workflows/consumption-logs/lib/apply-to-inventory"
 import type { MaintenanceChange, MaintenanceJob, MaintenanceJobResult } from "./registry"
@@ -33,12 +35,16 @@ import type { MaintenanceChange, MaintenanceJob, MaintenanceJobResult } from "./
  * issued from our own warehouse. This job settles the backlog for the latter.
  *
  * Every deduction is gated on a location WE hold the material at, so
- * partner-held consumption is skipped rather than guessed at. Which location
- * that is comes from the design↔inventory link's `location_id` — the "Preferred
- * location" the admin drawer shows next to planned/consumed — falling back to
- * the brand store's default when the link sets none. Honouring it is what makes
- * that field mean what the UI has always implied; it used to be read by nothing
- * at all. Re-running is safe: an applied log is stamped with
+ * partner-held consumption is skipped rather than guessed at.
+ *
+ * Which location that is comes from the MATERIAL, not from the design: an
+ * inventory item stocked in exactly one place was drawn from that place. The
+ * design↔inventory link's `location_id` ("Preferred location") still wins when
+ * an operator has set one, and the brand default catches whatever neither can
+ * place. Deriving it from stock is also what carries the ownership boundary —
+ * material with no stock anywhere is material we do not hold.
+ *
+ * Re-running is safe: an applied log is stamped with
  * `metadata.inventory_applied_at` and skipped thereafter.
  *
  * Dry-run (default) previews every decision, including the skips and why.
@@ -64,7 +70,7 @@ export const applyCommittedConsumptionJob: MaintenanceJob = {
   id: "apply-committed-consumption-to-inventory",
   label: "Apply committed consumption to inventory (our own stock only)",
   description:
-    "Deduct committed material consumption from OUR stock — the movement that committing a consumption log has never performed. Each log draws from the design↔inventory link's Preferred location, falling back to the brand store's default; partner-held consumption is skipped, never guessed. Labour/energy logs (Hour, kWh — no inventory_item_id) are skipped. Also writes consumed_quantity/consumed_at on the design↔inventory link, which the admin UI renders but nothing has ever written. Idempotent via metadata.inventory_applied_at. Dry-run previews every decision including skips.",
+    "Deduct committed material consumption from OUR stock — the movement that committing a consumption log has never performed. Each log deducts from wherever that material is actually stocked (a design's Preferred location overrides it, the brand default catches the rest); material stocked nowhere is partner-held and skipped, never guessed. Labour/energy logs (Hour, kWh — no inventory_item_id) are skipped. Also writes consumed_quantity/consumed_at on the design↔inventory link, which the admin UI renders but nothing has ever written. Idempotent via metadata.inventory_applied_at. Dry-run previews every decision including skips.",
   params: [
     {
       name: "design_id",
@@ -121,8 +127,31 @@ export const applyCommittedConsumptionJob: MaintenanceJob = {
     const query: any = container.resolve(ContainerRegistrationKeys.QUERY)
     const consumptionService: any = container.resolve(CONSUMPTION_LOG_MODULE)
 
-    const brandLocationId =
-      location_id ?? (await resolveBrandLocationId(container))
+    // Which locations are ours. An explicit location_id param is the operator
+    // asserting one, so it stands in for the whole set.
+    //
+    // `brandLocationId` is only the LAST-RESORT fallback for a log nothing else
+    // could place. Once ownership is recorded it is no longer the point of the
+    // job, and `resolveBrandLocationId` throws whenever two stores look like
+    // the brand (prod, today) — so a failure to determine it must not take the
+    // whole run down. Empty string means "unresolved", which is never core, so
+    // such logs skip with a reason instead of landing somewhere arbitrary.
+    let coreLocationIds: Set<string>
+    let seeded: boolean
+    let brandLocationId: string
+
+    if (location_id) {
+      coreLocationIds = new Set([location_id])
+      seeded = true
+      brandLocationId = location_id
+    } else {
+      const resolved = await resolveCoreLocationIds(container)
+      coreLocationIds = resolved.coreLocationIds
+      seeded = resolved.seeded
+      brandLocationId = resolved.seeded
+        ? await resolveBrandLocationId(container).catch(() => "")
+        : (Array.from(resolved.coreLocationIds)[0] ?? "")
+    }
 
     const designFilter = design_ids?.length
       ? design_ids
@@ -158,36 +187,38 @@ export const applyCommittedConsumptionJob: MaintenanceJob = {
       new Set(considered.map((l) => l.inventory_item_id).filter(Boolean))
     ) as string[]
 
-    // Where each log draws from. The design↔inventory link's "Preferred
-    // location" wins over the brand default — an EXPLICIT location_id param
-    // still overrides both, since that is the operator's escape hatch.
+    // EVERY level for these items, at every location — not just the brand's.
+    // Where a material sits is what decides the deduction, so the levels have
+    // to be read before the location is known rather than after.
+    let allLevels: any[] = []
+    if (itemIds.length) {
+      const { data } = await query.graph({
+        entity: "inventory_level",
+        fields: ["id", "inventory_item_id", "location_id", "stocked_quantity"],
+        filters: { inventory_item_id: itemIds },
+      })
+      allLevels = (data || []) as any[]
+    }
+
+    // Where each log draws from, most specific first:
+    //   explicit param  >  design's Preferred location  >  where the material is
+    //   >  brand default
+    // The param is the operator's escape hatch and overrides everything.
     const locationByLog = location_id
       ? {}
-      : await resolveLocationByLog(query, considered)
+      : await resolveLocationByLog(query, considered, allLevels, coreLocationIds)
 
-    // Current stock at every location in play, keyed item@location. A key
-    // ABSENT means the item has no level there — the signal it was never ours.
-    const locationIds = Array.from(
-      new Set([brandLocationId, ...Object.values(locationByLog)])
-    )
     const brandLevels: Record<string, number> = {}
     const levelsAtLocation: Record<string, number> = {}
     const levelIdByKey: Record<string, string> = {}
-    if (itemIds.length) {
-      const { data: levels } = await query.graph({
-        entity: "inventory_level",
-        fields: ["id", "inventory_item_id", "location_id", "stocked_quantity"],
-        filters: { inventory_item_id: itemIds, location_id: locationIds },
-      })
-      for (const lv of (levels || []) as any[]) {
-        const key = levelKey(lv.inventory_item_id, lv.location_id)
-        const stocked = Number(lv.stocked_quantity ?? 0)
-        levelIdByKey[key] = lv.id
-        if (lv.location_id === brandLocationId) {
-          brandLevels[lv.inventory_item_id] = stocked
-        } else {
-          levelsAtLocation[key] = stocked
-        }
+    for (const lv of allLevels) {
+      const key = levelKey(lv.inventory_item_id, lv.location_id)
+      const stocked = Number(lv.stocked_quantity ?? 0)
+      levelIdByKey[key] = lv.id
+      if (lv.location_id === brandLocationId) {
+        brandLevels[lv.inventory_item_id] = stocked
+      } else {
+        levelsAtLocation[key] = stocked
       }
     }
 
@@ -235,6 +266,7 @@ export const applyCommittedConsumptionJob: MaintenanceJob = {
       brandLevels,
       locationByLog,
       levelsAtLocation,
+      coreLocationIds,
       maxShortfall: max_shortfall,
       piecesByLog,
       assumeBasisWhenUnknown: assumeBasis,
@@ -337,6 +369,9 @@ export const applyCommittedConsumptionJob: MaintenanceJob = {
             .map(([r, n]) => `${n}× ${r}`)
             .join("; ")}`
         : "",
+      seeded
+        ? ""
+        : "⚠️ no location ownership recorded yet — fell back to the inferred brand default. Mark your locations core to deduct from more than one warehouse.",
     ]
       .filter(Boolean)
       .join(". ")
@@ -352,20 +387,41 @@ export const applyCommittedConsumptionJob: MaintenanceJob = {
 }
 
 /**
- * Map each log to the location its design draws that material from.
+ * Map each log to the location that material is drawn from.
  *
- * The source is the design↔inventory link's `location_id` — the "Preferred
- * location" the admin drawer has always shown beside planned/consumed while
- * nothing read it. A pair with no location set is simply omitted, so the
- * planner falls back to the brand default.
+ * Two sources, in order:
+ *
+ * 1. The design↔inventory link's `location_id` — "Preferred location" in the
+ *    admin drawer. An explicit operator statement, so it wins.
+ * 2. Failing that, WHERE THE MATERIAL ACTUALLY IS: the item's own stock levels
+ *    (`resolveLocationsFromLevels`). This is the one that does the work —
+ *    every design carrying an unsettled material log on prod has the link's
+ *    location null, so relying on it alone would resolve nothing.
+ *
+ * A log neither source can place is omitted, and the planner falls back to the
+ * brand default — which is what skips partner-held material, since it has no
+ * level there.
  */
 async function resolveLocationByLog(
   query: any,
-  logs: ConsumptionApplyLog[]
+  logs: ConsumptionApplyLog[],
+  allLevels: Array<{
+    inventory_item_id: string
+    location_id: string
+    stocked_quantity: number | string | null
+  }>,
+  coreLocationIds: Set<string>
 ): Promise<Record<string, string>> {
+  const byMaterial = resolveLocationsFromLevels(allLevels, coreLocationIds)
+
   const pairs = logs.filter((l) => l.design_id && l.inventory_item_id)
   if (!pairs.length) {
-    return {}
+    // Still place logs by their material even with no design attached.
+    return Object.fromEntries(
+      logs
+        .filter((l) => l.inventory_item_id && byMaterial[l.inventory_item_id])
+        .map((l) => [l.id, byMaterial[l.inventory_item_id as string]])
+    )
   }
 
   const { data: links } = await query.graph({
@@ -389,8 +445,10 @@ async function resolveLocationByLog(
   }
 
   const out: Record<string, string> = {}
-  for (const l of pairs) {
-    const loc = byPair.get(`${l.design_id}::${l.inventory_item_id}`)
+  for (const l of logs) {
+    const loc =
+      byPair.get(`${l.design_id}::${l.inventory_item_id}`) ??
+      (l.inventory_item_id ? byMaterial[l.inventory_item_id] : undefined)
     if (loc) {
       out[l.id] = loc
     }

--- a/apps/backend/src/api/admin/ops/maintenance-jobs/registry.ts
+++ b/apps/backend/src/api/admin/ops/maintenance-jobs/registry.ts
@@ -92,6 +92,7 @@ import { repairInventoryOrderSourceJob } from "./repair-inventory-order-source-j
 import { repairInventoryOrderRouteJob } from "./repair-inventory-order-route-job"
 import { rewindProductionRunJob } from "./rewind-production-run-job"
 import { repairConsumptionLogJob } from "./repair-consumption-log-job"
+import { setLocationOwnershipJob } from "./set-location-ownership-job"
 import { applyCommittedConsumptionJob } from "./apply-committed-consumption-job"
 import { reconcileConsumptionVsProductionJob } from "./reconcile-consumption-vs-production-job"
 import { backfillGoogleAdsHistoryJob } from "./backfill-google-ads-history-job"
@@ -5655,6 +5656,7 @@ export const MAINTENANCE_JOBS: MaintenanceJob[] = [
   repairInventoryOrderRouteJob,
   rewindProductionRunJob,
   repairConsumptionLogJob,
+  setLocationOwnershipJob,
   applyCommittedConsumptionJob,
   reconcileConsumptionVsProductionJob,
   backfillGoogleAdsHistoryJob,

--- a/apps/backend/src/api/admin/ops/maintenance-jobs/set-location-ownership-job.ts
+++ b/apps/backend/src/api/admin/ops/maintenance-jobs/set-location-ownership-job.ts
@@ -1,0 +1,195 @@
+import { ContainerRegistrationKeys, MedusaError } from "@medusajs/framework/utils"
+import { z } from "@medusajs/framework/zod"
+
+import { LOCATION_OWNERSHIP_MODULE } from "../../../../modules/location_ownership"
+import type { MaintenanceChange, MaintenanceJob, MaintenanceJobResult } from "./registry"
+
+/**
+ * Data Plumbing — record which stock locations are OURS.
+ *
+ * Ownership decides whether consumption moves stock at all, and until now it
+ * was inferred: the brand store was whichever store no partner linked to, and
+ * its single `default_location_id` was the only place a deduction could land.
+ * That inference cannot express stocking at several of our own warehouses, and
+ * it breaks outright when a store exists with no partner link — prod carries
+ * `Sharhlo Store`, a mis-spelled orphan of the partner-linked `Sharlho Store`,
+ * which is why `resolveBrandLocationId` now throws `found 2`.
+ *
+ * Two modes:
+ *
+ * - `seed: true` proposes a row for every stock location, core when the
+ *   location is not a partner store's. This is the bootstrap, and it is only a
+ *   STARTING POINT: it reproduces the old inference, orphan and all, so the
+ *   dry-run output must be read before applying.
+ * - `location_id` + `is_core` sets one location, which is how the orphan gets
+ *   corrected and how a new warehouse is added later.
+ */
+
+const paramsSchema = z
+  .object({
+    /** Propose a row for every stock location, from partner linkage. */
+    seed: z.boolean().optional(),
+    /** Set a single location's ownership. */
+    location_id: z.string().min(1).optional(),
+    is_core: z.boolean().optional(),
+    note: z.string().optional(),
+  })
+  .refine((v) => v.seed || v.location_id, {
+    message: "pass seed:true to bootstrap, or location_id to set one location",
+  })
+  .refine((v) => !v.location_id || v.is_core !== undefined, {
+    message: "is_core is required when setting a single location",
+  })
+
+export const setLocationOwnershipJob: MaintenanceJob = {
+  id: "set-location-ownership",
+  label: "Record which stock locations are ours (core)",
+  description:
+    "Mark stock locations core (ours) or not. Consumption is only ever deducted from a core location, so this is what lets us stock at several of our own warehouses and what keeps partner-held material off our books. Use seed:true once to propose a row per location from partner linkage — a starting point that reproduces the old inference including any orphan store, so read the dry-run — then correct individual locations with location_id + is_core. Dry-run previews every row.",
+  params: [
+    {
+      name: "seed",
+      type: "boolean",
+      required: false,
+      description:
+        "Propose a row for every stock location, core when it is not a partner store's. Never overwrites a location already recorded.",
+    },
+    {
+      name: "location_id",
+      type: "string",
+      required: false,
+      description: "Set just this location, e.g. 'sloc_01JPAQVGYJR3CDP2Q2AYV7GRDR'",
+    },
+    {
+      name: "is_core",
+      type: "boolean",
+      required: false,
+      description: "true = ours, deductions allowed. Required with location_id.",
+    },
+    {
+      name: "note",
+      type: "string",
+      required: false,
+      description: "Why — free text kept alongside the row",
+    },
+  ],
+  run: async (container, { dry_run, params }): Promise<MaintenanceJobResult> => {
+    const parsed = paramsSchema.safeParse(params)
+    if (!parsed.success) {
+      throw new MedusaError(
+        MedusaError.Types.INVALID_DATA,
+        parsed.error.issues.map((i) => i.message).join("; ")
+      )
+    }
+
+    const query: any = container.resolve(ContainerRegistrationKeys.QUERY)
+    const service: any = container.resolve(LOCATION_OWNERSHIP_MODULE)
+
+    const existingRows = await service.listLocationOwnerships({}, { take: null })
+    const existing = new Map<string, any>(
+      ((existingRows || []) as any[]).map((r) => [r.stock_location_id, r])
+    )
+
+    const changes: MaintenanceChange[] = []
+    const creates: any[] = []
+    const updates: any[] = []
+
+    const plan = (
+      locationId: string,
+      isCore: boolean,
+      note: string | null,
+      label: string
+    ) => {
+      const row = existing.get(locationId)
+      if (!row) {
+        changes.push({
+          entity: "location_ownership",
+          id: locationId,
+          field: `is_core (${label})`,
+          before: null,
+          after: isCore,
+        })
+        creates.push({ stock_location_id: locationId, is_core: isCore, note })
+        return
+      }
+      if (row.is_core === isCore) {
+        return
+      }
+      changes.push({
+        entity: "location_ownership",
+        id: locationId,
+        field: `is_core (${label})`,
+        before: row.is_core,
+        after: isCore,
+      })
+      updates.push({ id: row.id, is_core: isCore, ...(note ? { note } : {}) })
+    }
+
+    if (parsed.data.seed) {
+      // Partner-owned locations are every partner store's default location.
+      const { data: partners } = await query.graph({
+        entity: "partners",
+        fields: ["id", "stores.id", "stores.default_location_id"],
+      })
+      const partnerLocationIds = new Set<string>()
+      for (const p of (partners || []) as any[]) {
+        for (const s of (p?.stores || []) as any[]) {
+          if (s?.default_location_id) {
+            partnerLocationIds.add(s.default_location_id)
+          }
+        }
+      }
+
+      const { data: locations } = await query.graph({
+        entity: "stock_location",
+        fields: ["id", "name"],
+      })
+
+      for (const loc of (locations || []) as any[]) {
+        // Seeding never overwrites a recorded decision — an operator who has
+        // already corrected the orphan must not have it undone by a re-run.
+        if (existing.has(loc.id)) {
+          continue
+        }
+        const isPartner = partnerLocationIds.has(loc.id)
+        plan(
+          loc.id,
+          !isPartner,
+          isPartner ? "seeded: partner store location" : "seeded: not a partner location",
+          loc.name ?? loc.id
+        )
+      }
+    }
+
+    if (parsed.data.location_id) {
+      plan(
+        parsed.data.location_id,
+        parsed.data.is_core as boolean,
+        parsed.data.note ?? null,
+        "explicit"
+      )
+    }
+
+    if (!dry_run && changes.length > 0) {
+      if (creates.length) {
+        await service.createLocationOwnerships(creates)
+      }
+      for (const u of updates) {
+        await service.updateLocationOwnerships(u)
+      }
+    }
+
+    const coreCount = changes.filter((c) => c.after === true).length
+    const summary = changes.length
+      ? `${dry_run ? "Would record" : "Recorded"} ${changes.length} location(s): ${coreCount} core, ${changes.length - coreCount} not ours`
+      : "Every location already holds the requested ownership — nothing to record"
+
+    return {
+      job_id: setLocationOwnershipJob.id,
+      dry_run,
+      applied: !dry_run && changes.length > 0,
+      summary,
+      changes,
+    }
+  },
+}

--- a/apps/backend/src/api/middlewares.ts
+++ b/apps/backend/src/api/middlewares.ts
@@ -19,6 +19,7 @@ import cors from "cors";
 import { z } from "@medusajs/framework/zod";
 import { personSchema, listPersonsQuerySchema, UpdatePersonSchema, ReadPersonQuerySchema } from "./admin/persons/validators";
 import { OpsMaintenanceRunSchema, OpsMaintenanceRunsQuerySchema, OpsMaintenanceBatchSchema, OpsMaintenanceBatchesQuerySchema } from "./admin/ops/maintenance-jobs/validators";
+import { AdminPostLocationOwnershipReq } from "./admin/location-ownership/validators";
 import { getPersonResourceDefinition } from "./admin/persons/resources/registry";
 import { AdminGetOrdersOrderParams } from "@medusajs/medusa/api/admin/orders/validators";
 import { retrieveTransformQueryConfig as retrieveOrderTransformQueryConfig } from "@medusajs/medusa/api/admin/orders/query-config";
@@ -3851,6 +3852,14 @@ export default defineMiddlewares({
       matcher: "/admin/designs",
       method: "POST",
       middlewares: [validateAndTransformBody(wrapSchema(designSchema))],
+    },
+    {
+      // Which stock locations are ours — gates every consumption deduction.
+      matcher: "/admin/location-ownership",
+      method: "POST",
+      middlewares: [
+        validateAndTransformBody(wrapSchema(AdminPostLocationOwnershipReq)),
+      ],
     },
     {
       // #457 admin data-plumbing / ops maintenance jobs

--- a/apps/backend/src/modules/location_ownership/index.ts
+++ b/apps/backend/src/modules/location_ownership/index.ts
@@ -1,0 +1,9 @@
+import { Module } from "@medusajs/framework/utils"
+
+import LocationOwnershipService from "./service"
+
+export const LOCATION_OWNERSHIP_MODULE = "location_ownership"
+
+export default Module(LOCATION_OWNERSHIP_MODULE, {
+  service: LocationOwnershipService,
+})

--- a/apps/backend/src/modules/location_ownership/migrations/.snapshot-location-ownership.json
+++ b/apps/backend/src/modules/location_ownership/migrations/.snapshot-location-ownership.json
@@ -1,0 +1,160 @@
+{
+  "namespaces": [
+    "public"
+  ],
+  "name": "public",
+  "tables": [
+    {
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "unsigned": false,
+          "autoincrement": false,
+          "primary": true,
+          "nullable": false,
+          "unique": false,
+          "length": null,
+          "precision": null,
+          "scale": null,
+          "default": null,
+          "comment": null,
+          "enumItems": [],
+          "mappedType": "text"
+        },
+        "stock_location_id": {
+          "name": "stock_location_id",
+          "type": "text",
+          "unsigned": false,
+          "autoincrement": false,
+          "primary": false,
+          "nullable": false,
+          "unique": false,
+          "length": null,
+          "precision": null,
+          "scale": null,
+          "default": null,
+          "comment": null,
+          "enumItems": [],
+          "mappedType": "text"
+        },
+        "is_core": {
+          "name": "is_core",
+          "type": "boolean",
+          "unsigned": false,
+          "autoincrement": false,
+          "primary": false,
+          "nullable": false,
+          "unique": false,
+          "length": null,
+          "precision": null,
+          "scale": null,
+          "default": "false",
+          "comment": null,
+          "enumItems": [],
+          "mappedType": "boolean"
+        },
+        "note": {
+          "name": "note",
+          "type": "text",
+          "unsigned": false,
+          "autoincrement": false,
+          "primary": false,
+          "nullable": true,
+          "unique": false,
+          "length": null,
+          "precision": null,
+          "scale": null,
+          "default": null,
+          "comment": null,
+          "enumItems": [],
+          "mappedType": "text"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamptz",
+          "unsigned": false,
+          "autoincrement": false,
+          "primary": false,
+          "nullable": false,
+          "unique": false,
+          "length": 6,
+          "precision": null,
+          "scale": null,
+          "default": "now()",
+          "comment": null,
+          "enumItems": [],
+          "mappedType": "datetime"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamptz",
+          "unsigned": false,
+          "autoincrement": false,
+          "primary": false,
+          "nullable": false,
+          "unique": false,
+          "length": 6,
+          "precision": null,
+          "scale": null,
+          "default": "now()",
+          "comment": null,
+          "enumItems": [],
+          "mappedType": "datetime"
+        },
+        "deleted_at": {
+          "name": "deleted_at",
+          "type": "timestamptz",
+          "unsigned": false,
+          "autoincrement": false,
+          "primary": false,
+          "nullable": true,
+          "unique": false,
+          "length": 6,
+          "precision": null,
+          "scale": null,
+          "default": null,
+          "comment": null,
+          "enumItems": [],
+          "mappedType": "datetime"
+        }
+      },
+      "name": "location_ownership",
+      "schema": "public",
+      "indexes": [
+        {
+          "keyName": "IDX_location_ownership_stock_location_id_unique",
+          "columnNames": [],
+          "composite": false,
+          "constraint": false,
+          "primary": false,
+          "unique": false,
+          "expression": "CREATE UNIQUE INDEX IF NOT EXISTS \"IDX_location_ownership_stock_location_id_unique\" ON \"location_ownership\" (\"stock_location_id\") WHERE deleted_at IS NULL"
+        },
+        {
+          "keyName": "IDX_location_ownership_deleted_at",
+          "columnNames": [],
+          "composite": false,
+          "constraint": false,
+          "primary": false,
+          "unique": false,
+          "expression": "CREATE INDEX IF NOT EXISTS \"IDX_location_ownership_deleted_at\" ON \"location_ownership\" (\"deleted_at\") WHERE deleted_at IS NULL"
+        },
+        {
+          "keyName": "location_ownership_pkey",
+          "columnNames": [
+            "id"
+          ],
+          "composite": false,
+          "constraint": true,
+          "primary": true,
+          "unique": true
+        }
+      ],
+      "checks": [],
+      "foreignKeys": {},
+      "nativeEnums": {}
+    }
+  ],
+  "nativeEnums": {}
+}

--- a/apps/backend/src/modules/location_ownership/migrations/Migration20260811152246.ts
+++ b/apps/backend/src/modules/location_ownership/migrations/Migration20260811152246.ts
@@ -1,0 +1,16 @@
+import { Migration } from "@medusajs/framework/mikro-orm/migrations";
+
+export class Migration20260811152246 extends Migration {
+
+  override async up(): Promise<void> {
+    this.addSql(`alter table if exists "location_ownership" drop constraint if exists "location_ownership_stock_location_id_unique";`);
+    this.addSql(`create table if not exists "location_ownership" ("id" text not null, "stock_location_id" text not null, "is_core" boolean not null default false, "note" text null, "created_at" timestamptz not null default now(), "updated_at" timestamptz not null default now(), "deleted_at" timestamptz null, constraint "location_ownership_pkey" primary key ("id"));`);
+    this.addSql(`CREATE UNIQUE INDEX IF NOT EXISTS "IDX_location_ownership_stock_location_id_unique" ON "location_ownership" ("stock_location_id") WHERE deleted_at IS NULL;`);
+    this.addSql(`CREATE INDEX IF NOT EXISTS "IDX_location_ownership_deleted_at" ON "location_ownership" ("deleted_at") WHERE deleted_at IS NULL;`);
+  }
+
+  override async down(): Promise<void> {
+    this.addSql(`drop table if exists "location_ownership" cascade;`);
+  }
+
+}

--- a/apps/backend/src/modules/location_ownership/models/location-ownership.ts
+++ b/apps/backend/src/modules/location_ownership/models/location-ownership.ts
@@ -1,0 +1,29 @@
+import { model } from "@medusajs/framework/utils"
+
+/**
+ * Whether a stock location is OURS.
+ *
+ * "Core" was never a thing the system knew. It was inferred: the brand store
+ * was whichever store no partner linked to, and its `default_location_id` was
+ * the one place stock could be deducted from. That inference is both too narrow
+ * and too fragile — it cannot express stocking at several of our own
+ * warehouses, and it breaks outright when a store exists without a partner
+ * link (prod carries `Sharhlo Store`, a mis-spelled orphan of the
+ * partner-linked `Sharlho Store`, and the resolver now throws `found 2`).
+ *
+ * Ownership decides whether material moves at all, so it is recorded, not
+ * derived. One row per stock location; a location with NO row is treated as
+ * non-core, because defaulting an unknown location to "ours" would deduct
+ * partner-held stock — the one outcome the whole boundary exists to prevent.
+ */
+const LocationOwnership = model.define("location_ownership", {
+  id: model.id().primaryKey(),
+  /** The stock location this describes. One row per location. */
+  stock_location_id: model.text().unique(),
+  /** True when we own the stock held here and may deduct consumption from it. */
+  is_core: model.boolean().default(false),
+  /** Why it was marked this way — free text for the operator who set it. */
+  note: model.text().nullable(),
+})
+
+export default LocationOwnership

--- a/apps/backend/src/modules/location_ownership/service.ts
+++ b/apps/backend/src/modules/location_ownership/service.ts
@@ -1,0 +1,16 @@
+import { MedusaService } from "@medusajs/framework/utils"
+
+import LocationOwnership from "./models/location-ownership"
+
+/**
+ * location_ownership module service — which stock locations are ours.
+ *
+ * The generated `listLocationOwnerships` / `createLocationOwnerships` /
+ * `updateLocationOwnerships` are all this needs; the interesting logic is the
+ * resolution in `workflows/consumption-logs/lib/apply-to-inventory.ts`.
+ */
+class LocationOwnershipService extends MedusaService({
+  LocationOwnership,
+}) {}
+
+export default LocationOwnershipService

--- a/apps/backend/src/workflows/consumption-logs/__tests__/apply-to-inventory.unit.spec.ts
+++ b/apps/backend/src/workflows/consumption-logs/__tests__/apply-to-inventory.unit.spec.ts
@@ -1,6 +1,7 @@
 import {
   APPLIED_AT_KEY,
   planConsumptionApplication,
+  resolveLocationsFromLevels,
   type ConsumptionApplyLog,
 } from "../lib/apply-to-inventory"
 
@@ -119,6 +120,106 @@ describe("planConsumptionApplication", () => {
 })
 
 /**
+ * Where a material sits is what decides the deduction. Cases are the real prod
+ * shapes from the nine unsettled material logs.
+ */
+describe("resolveLocationsFromLevels", () => {
+  const level = (item: string, loc: string, qty: number | string | null) => ({
+    inventory_item_id: item,
+    location_id: loc,
+    stocked_quantity: qty,
+  })
+
+  it("places a material stocked in exactly one location", () => {
+    // 5210-MUSLIN-100S: stocked only at Dharamshala.
+    expect(
+      resolveLocationsFromLevels([level("iitem_muslin", "sloc_dharamshala", 23)])
+    ).toEqual({ iitem_muslin: "sloc_dharamshala" })
+  })
+
+  it("ignores a zero level, so two levels still resolve to one place", () => {
+    // Denim Trouser's FAB-HAN-IND-001: Dharamshala 17.6, Shramdaan 0.
+    expect(
+      resolveLocationsFromLevels([
+        level("iitem_denim", "sloc_dharamshala", 17.6),
+        level("iitem_denim", "sloc_shramdaan", 0),
+      ])
+    ).toEqual({ iitem_denim: "sloc_dharamshala" })
+  })
+
+  it("leaves a material stocked nowhere unresolved (partner-held)", () => {
+    // Six prod logs look exactly like this — the ownership boundary, for free.
+    expect(
+      resolveLocationsFromLevels([level("iitem_partner", "sloc_partner", 0)])
+    ).toEqual({})
+  })
+
+  it("treats a negative level as no stock", () => {
+    // Dark Desires Dress sits at -2.5.
+    expect(
+      resolveLocationsFromLevels([level("iitem_neg", "sloc_partner", -2.5)])
+    ).toEqual({})
+  })
+
+  it("refuses to guess when two locations both hold stock", () => {
+    expect(
+      resolveLocationsFromLevels([
+        level("iitem_x", "sloc_a", 5),
+        level("iitem_x", "sloc_b", 5),
+      ])
+    ).toEqual({})
+  })
+
+  it("ignores stock sitting at a location we do not own", () => {
+    // The hazard core-gating exists to close: a partner warehouse holding real
+    // stock would otherwise resolve as the place to deduct from.
+    expect(
+      resolveLocationsFromLevels(
+        [level("iitem_x", "sloc_partner", 40)],
+        new Set(["sloc_dharamshala"])
+      )
+    ).toEqual({})
+  })
+
+  it("resolves against our locations only, ignoring a partner's stock", () => {
+    expect(
+      resolveLocationsFromLevels(
+        [
+          level("iitem_x", "sloc_dharamshala", 12),
+          level("iitem_x", "sloc_partner", 40),
+        ],
+        new Set(["sloc_dharamshala"])
+      )
+    ).toEqual({ iitem_x: "sloc_dharamshala" })
+  })
+
+  it("resolves each material independently", () => {
+    expect(
+      resolveLocationsFromLevels([
+        level("iitem_a", "sloc_dharamshala", 35.6),
+        level("iitem_b", "sloc_partner", 0),
+        level("iitem_c", "sloc_kashmir", 3),
+      ])
+    ).toEqual({ iitem_a: "sloc_dharamshala", iitem_c: "sloc_kashmir" })
+  })
+
+  it("handles string quantities without treating them as text", () => {
+    expect(
+      resolveLocationsFromLevels([level("iitem_s", "sloc_a", "17.6")])
+    ).toEqual({ iitem_s: "sloc_a" })
+  })
+
+  it("ignores malformed rows rather than throwing", () => {
+    expect(
+      resolveLocationsFromLevels([
+        { inventory_item_id: "", location_id: "sloc_a", stocked_quantity: 5 },
+        level("iitem_ok", "sloc_a", 5),
+      ] as any)
+    ).toEqual({ iitem_ok: "sloc_a" })
+  })
+})
+
+/**
  * The design↔inventory link's "Preferred location" is rendered next to
  * planned/consumed in the admin drawer, implying it decides where the material
  * comes from — while nothing read it and every deduction went to the single
@@ -205,6 +306,45 @@ describe("per-design Preferred location", () => {
     })
 
     expect(d.action).toBe("skip")
+  })
+
+  it("refuses a log resolved to a location we do not own", () => {
+    const [d] = planConsumptionApplication({
+      brandLocationId: BRAND,
+      logs: [log("l1")],
+      brandLevels: {},
+      locationByLog: { l1: "sloc_partner" },
+      levelsAtLocation: { "item_a@sloc_partner": 40 },
+      coreLocationIds: new Set([BRAND]),
+    })
+
+    expect(d.action).toBe("skip")
+    expect((d as any).reason).toMatch(/not one of our locations/)
+  })
+
+  it("allows any of several locations we own", () => {
+    const decisions = planConsumptionApplication({
+      brandLocationId: BRAND,
+      logs: [log("l1"), log("l2")],
+      brandLevels: { item_a: 10 },
+      locationByLog: { l2: OTHER },
+      levelsAtLocation: { [`item_a@${OTHER}`]: 5 },
+      coreLocationIds: new Set([BRAND, OTHER]),
+    })
+
+    expect(decisions[0]).toMatchObject({ action: "apply", location_id: BRAND })
+    expect(decisions[1]).toMatchObject({ action: "apply", location_id: OTHER })
+  })
+
+  it("skips when nothing could place the log at all", () => {
+    const [d] = planConsumptionApplication({
+      brandLocationId: "",
+      logs: [log("l1")],
+      brandLevels: {},
+    })
+
+    expect(d.action).toBe("skip")
+    expect((d as any).reason).toMatch(/no location could be resolved/)
   })
 
   it("keeps one item's balance separate across two locations", () => {

--- a/apps/backend/src/workflows/consumption-logs/lib/apply-to-inventory.ts
+++ b/apps/backend/src/workflows/consumption-logs/lib/apply-to-inventory.ts
@@ -1,6 +1,8 @@
 import { ContainerRegistrationKeys, MedusaError } from "@medusajs/framework/utils"
 import type { MedusaContainer } from "@medusajs/framework/types"
 
+import { LOCATION_OWNERSHIP_MODULE } from "../../../modules/location_ownership"
+
 /**
  * Turning committed consumption into an inventory movement — the shared rule.
  *
@@ -59,6 +61,13 @@ export type ConsumptionApplyPlanInput = {
    * location share it — and the same item at two locations does not.
    */
   levelsAtLocation?: Record<string, number>
+  /**
+   * The locations we own. A log resolving anywhere else is skipped outright —
+   * this is the ownership boundary stated as a rule instead of emerging from
+   * "the item happens to have no level at the one brand location". Omit to
+   * skip the check (callers that have already constrained the locations).
+   */
+  coreLocationIds?: Set<string>
   /**
    * Refuse any deduction whose shortfall would exceed this, skipping the log
    * instead of applying it.
@@ -132,6 +141,66 @@ export const levelKey = (inventoryItemId: string, locationId: string): string =>
 const round = (n: number): number => Number(n.toFixed(6))
 
 /**
+ * PURE: where each material actually sits, from its own stock levels.
+ *
+ * This is the honest source of truth for a deduction. The design↔inventory
+ * link's "Preferred location" is an override an operator has to remember to
+ * set, and in practice never is — all nine designs carrying an unsettled
+ * material log on prod have it null. The material itself always knows: a log
+ * against `5210-MUSLIN-100S` should come off Dharamshala because that is where
+ * the muslin is, not because anyone configured a design.
+ *
+ * Only levels holding stock count, and that single rule carries the ownership
+ * boundary that used to need the brand-store lookup:
+ *
+ *   - exactly one location holds stock → that is where it came from
+ *   - NO location holds stock → we do not have this material; partner-held, and
+ *     left unresolved so the caller's fallback skips it
+ *   - more than one → genuinely ambiguous, left unresolved rather than guessed
+ *
+ * Denim Trouser is the case that proves the first rule earns its keep: it has
+ * levels at two locations, and only Dharamshala holds any (Shramdaan is 0), so
+ * it resolves without a tiebreak.
+ */
+export function resolveLocationsFromLevels(
+  levels: Array<{
+    inventory_item_id: string
+    location_id: string
+    stocked_quantity: number | string | null
+  }>,
+  /**
+   * The locations we own. Levels anywhere else are ignored outright — a
+   * material sitting in a partner's warehouse must never resolve as the place
+   * to deduct from, however unambiguously it sits there. Omit to consider every
+   * location (callers that have already filtered).
+   */
+  coreLocationIds?: Set<string>
+): Record<string, string> {
+  const stockedByItem = new Map<string, string[]>()
+  for (const lv of levels) {
+    if (!lv?.inventory_item_id || !lv.location_id) {
+      continue
+    }
+    if (coreLocationIds && !coreLocationIds.has(lv.location_id)) {
+      continue
+    }
+    if (Number(lv.stocked_quantity ?? 0) > 0) {
+      const list = stockedByItem.get(lv.inventory_item_id) ?? []
+      list.push(lv.location_id)
+      stockedByItem.set(lv.inventory_item_id, list)
+    }
+  }
+
+  const out: Record<string, string> = {}
+  for (const [itemId, locations] of stockedByItem) {
+    if (locations.length === 1) {
+      out[itemId] = locations[0]
+    }
+  }
+  return out
+}
+
+/**
  * PURE: decide what each log does. Exported for unit tests.
  *
  * Logs are processed in id order and the level is carried forward between them,
@@ -177,10 +246,16 @@ export function planConsumptionApplication(
       skip("no inventory_item_id (labour/energy log)")
       continue
     }
-    // Where this log draws from: the design↔inventory link's location when it
-    // has one, else the brand default.
+    // Where this log draws from: whatever the caller resolved for it, else the
+    // brand default. Empty means nothing could place it at all.
     const locationId =
-      input.locationByLog?.[log.id] ?? input.brandLocationId
+      input.locationByLog?.[log.id] || input.brandLocationId
+    if (!locationId) {
+      skip(
+        "no location could be resolved — the material is stocked at none of our locations, and no brand default was determinable"
+      )
+      continue
+    }
 
     // A log carrying its own location is taken at its word, and a log recorded
     // somewhere other than where this design draws from is NOT ours to deduct.
@@ -190,6 +265,12 @@ export function planConsumptionApplication(
       skip(
         `logged at ${log.location_id}, which is not where this design draws stock from (${locationId})`
       )
+      continue
+    }
+    // The ownership rule, stated outright: material drawn from a location we
+    // do not own is not ours to move, whatever its stock says.
+    if (input.coreLocationIds && !input.coreLocationIds.has(locationId)) {
+      skip(`${locationId} is not one of our locations (partner-held)`)
       continue
     }
     const key = levelKey(log.inventory_item_id, locationId)
@@ -254,6 +335,41 @@ export function planConsumptionApplication(
   }
 
   return decisions
+}
+
+/**
+ * The locations we own, and may deduct consumption from.
+ *
+ * Read from `location_ownership` rather than inferred: ownership decides
+ * whether stock moves at all, and the old inference (the one store no partner
+ * links to, then its default location) cannot express several warehouses and
+ * breaks on an orphan store.
+ *
+ * PRE-SEED FALLBACK: with no rows recorded yet, an empty set would make every
+ * location non-core and quietly turn the job into a no-op that reports nothing
+ * wrong. So an empty table falls back to the previously-inferred brand default
+ * — exactly the old behaviour — and the caller says so in its summary. Once a
+ * single row exists the table is authoritative and no inference happens.
+ */
+export async function resolveCoreLocationIds(
+  container: MedusaContainer
+): Promise<{ coreLocationIds: Set<string>; seeded: boolean }> {
+  const service: any = container.resolve(LOCATION_OWNERSHIP_MODULE)
+  const rows = await service.listLocationOwnerships({}, { take: null })
+
+  if (!rows?.length) {
+    const brandLocationId = await resolveBrandLocationId(container)
+    return { coreLocationIds: new Set([brandLocationId]), seeded: false }
+  }
+
+  return {
+    coreLocationIds: new Set(
+      (rows as any[])
+        .filter((r) => r.is_core && r.stock_location_id)
+        .map((r) => r.stock_location_id as string)
+    ),
+    seeded: true,
+  }
 }
 
 /**

--- a/apps/backend/src/workflows/designs/inventory/link-inventory.ts
+++ b/apps/backend/src/workflows/designs/inventory/link-inventory.ts
@@ -23,7 +23,12 @@ import DesignInventoryLink from "../../../links/design-inventory-link"
 type InventoryLinkPayload = {
   inventory_id: string
   planned_quantity?: number
-  location_id?: string
+  /**
+   * Nullable: the link UI captures where a material is stocked and sends an
+   * explicit null when that is not unambiguous, rather than guessing which
+   * location consumption should later be deducted from.
+   */
+  location_id?: string | null
   metadata?: Record<string, any>
 }
 


### PR DESCRIPTION
Two related changes plus the surfaces to use them, because none is safe alone.

## 1. Ownership becomes recorded, not inferred

**"Core" was never a thing the system knew.** The brand store was whichever store no partner linked to, and its single `default_location_id` was the only place stock could be deducted from.

That inference can't express stocking at several of our own warehouses, and it breaks outright when a store exists with no partner link — prod carries `Sharhlo Store`, a mis-spelled orphan of the partner-linked `Sharlho Store`, so **`resolveBrandLocationId` throws `found 2` on prod today** and takes the whole job with it.

New `location_ownership` module records it per location:

| | |
|---|---|
| Switch on the stock location page | mark a location ours / not ours |
| `set-location-ownership` `{seed: true}` | proposes a row per location from partner linkage — a *starting point* reproducing the old inference, orphan included, so read the dry-run |
| `set-location-ownership` `{location_id, is_core}` | corrects one location |

A location with **no row is non-core**. Defaulting an unknown location to "ours" would deduct partner-held stock, which is the one outcome the boundary exists to prevent.

Not a flag day: with no rows recorded, the job falls back to the old inferred default and says so in its summary.

## 2. Location comes from the material

A log deducts from wherever that material is **actually stocked** — an item held in exactly one of our locations was drawn from there, with no configuration. A design's Preferred location still overrides it; an explicit `location_id` param overrides both.

This is what actually resolves things: **all nine designs** carrying an unsettled material log on prod have the link's location null, so reading the link alone resolves nothing.

Denim Trouser proves the "stocked" part earns its keep — levels at two locations, only Dharamshala holds any (Shramdaan is 0), so it resolves without a tiebreak.

### Core-gating is what makes this safe

Without it, a partner warehouse holding real stock would resolve as the place to deduct from. Today every partner-held material happens to sit at 0, so the bug wouldn't have surfaced until it did. Pinned by a test.

`resolveBrandLocationId` failing is also no longer fatal — it's the last-resort fallback now, and a log nothing can place skips with a reason rather than landing somewhere arbitrary.

## 3. Capture the location when linking

Linking a material to a design now records where it's stocked, using the same rule as the server. The API has always accepted `locationId` and nothing ever sent it — hence every link being null.

A default, not a decision: the drawer still edits it, stocked-nowhere or stocked-in-several sends an explicit null rather than a guess, and the toast reports how many were placed. `locationId` became nullable through the whole path (validator → workflow input → admin payload type), since `.optional()` alone rejects an explicit null.

## Tests

```
npx jest --testPathPattern="apply-to-inventory|apply-committed-consumption|list-design-inventory"   # 57 passed
npx tsc --noEmit                                                                                   # 79 — baseline, no new errors
```

## Deploy note

Adds `Migration20260811152246` (new `location_ownership` table). Registered in both `medusa-config.ts` and `medusa-config.prod.ts`. **Post-deploy: seed ownership before the next consumption apply** — see the runbook in the issue.

🤖 Generated with [Claude Code](https://claude.com/claude-code)