### PR TITLE
feat(assistant): re-send a partner's parked production runs back to them

### DIFF
--- a/apps/backend/src/api/admin/mcp/lib/registry.ts
+++ b/apps/backend/src/api/admin/mcp/lib/registry.ts
@@ -1633,6 +1633,37 @@ export const ADMIN_MCP_TOOLS: AdminMcpToolDef[] = [
     sideEffects: "Creates partner tasks from the templates and notifies the assigned partner.",
   },
   {
+    name: "redispatch_parked_production_runs",
+    description:
+      "Re-send production runs parked in 'awaiting_reassignment' back to the PARTNER THEY CAME FROM, and dispatch them again — the batch answer to 'this partner says they'll take their lapsed runs now'. Each run goes to its own previous_partner_id; partner_id only FILTERS which parked runs are considered, so this can never hand one partner's work to another. Pass template_names to dispatch end-to-end; omit it and each run is assigned and started but left awaiting a template selection. Dry-run by default. Sensitive: requires confirm:true.",
+    method: "POST",
+    path: "/admin/production-runs/redispatch-parked",
+    write: true,
+    sensitive: true,
+    bodyParams: ["partner_id", "template_names", "limit", "note", "dry_run", "confirm"],
+    inputSchema: obj({
+      partner_id: STR(
+        "Only consider runs parked FROM this partner. Omit for every parked run."
+      ),
+      template_names: {
+        type: "array",
+        items: { type: "string" },
+        description:
+          "Task templates to dispatch with. Omit and runs stop at 'awaiting_templates'.",
+      },
+      limit: { type: "integer", description: "Cap how many runs are re-sent." },
+      note: STR("Admin note recorded on each run's activity feed."),
+      dry_run: {
+        type: "boolean",
+        description: "Default true — preview which runs would be re-sent.",
+      },
+      confirm: { type: "boolean", description: "Required to actually re-send." },
+    }),
+    sideEffects:
+      "Assigns each run to its previous partner and starts dispatch, which notifies the partner. Runs dispatched without template_names stay in 'awaiting_templates' until resume_production_run_dispatch is called with the returned transaction_id.",
+    nextSteps: ["resume_production_run_dispatch", "list_production_runs"],
+  },
+  {
     name: "start_production_run_dispatch",
     description:
       "Begin the interactive dispatch of a production run. Returns a transaction_id and PARKS the workflow with the run in 'awaiting_templates' — you MUST follow up with resume_production_run_dispatch or the run stays stuck. Sensitive: requires confirm:true.",

--- a/apps/backend/src/api/admin/mcp/lib/tool-slice.ts
+++ b/apps/backend/src/api/admin/mcp/lib/tool-slice.ts
@@ -139,6 +139,11 @@ const DOMAIN_KEYWORDS: Record<Exclude<AdminToolDomain, "core">, string[]> = {
     "dispatch", "dispatched", "approve", "approval", "stage", "task", "tasks",
     "template", "templates", "manufacture", "manufacturing", "factory",
     "capacity", "wip", "in progress",
+    // The vocabulary of a lapsed run. "Send this partner's parked runs back to
+    // them" has to reach the production slice — without these it reads as a
+    // purely partner-domain question and the run tools never load.
+    "reassign", "reassignment", "re-assign", "re-assignment", "reassigned",
+    "parked", "lapsed", "declined", "redispatch", "re-dispatch",
   ],
   inventory: [
     "inventory", "stock", "stocks", "raw material", "raw materials",

--- a/apps/backend/src/api/admin/production-runs/redispatch-parked/__tests__/plan.unit.spec.ts
+++ b/apps/backend/src/api/admin/production-runs/redispatch-parked/__tests__/plan.unit.spec.ts
@@ -1,0 +1,64 @@
+import { planRedispatch, type ParkedRun } from "../plan"
+
+/**
+ * The safety property this exists for: a parked run goes back to the partner it
+ * came from, never to the partner named in the request. Dispatch notifies the
+ * partner, so mis-routing is not fixable by editing a row afterwards.
+ */
+describe("planRedispatch", () => {
+  const run = (id: string, previous: string | null): ParkedRun => ({
+    id,
+    previous_partner_id: previous,
+  })
+
+  it("sends each run back to its own previous partner", () => {
+    const plan = planRedispatch([run("r1", "part_a"), run("r2", "part_b")])
+
+    expect(plan.selected).toEqual([
+      { run: expect.objectContaining({ id: "r1" }), partner_id: "part_a" },
+      { run: expect.objectContaining({ id: "r2" }), partner_id: "part_b" },
+    ])
+  })
+
+  it("treats partner_id as a FILTER, never as the assignee", () => {
+    const plan = planRedispatch([run("r1", "part_a"), run("r2", "part_b")], {
+      partnerId: "part_a",
+    })
+
+    expect(plan.selected).toHaveLength(1)
+    expect(plan.selected[0].run.id).toBe("r1")
+    // The whole point: r1 goes to part_a because that is where it came from.
+    expect(plan.selected[0].partner_id).toBe("part_a")
+  })
+
+  it("never routes another partner's run to the filtered partner", () => {
+    const plan = planRedispatch([run("r2", "part_b")], { partnerId: "part_a" })
+
+    expect(plan.selected).toEqual([])
+  })
+
+  it("sets aside runs with no previous partner rather than inventing one", () => {
+    const plan = planRedispatch([run("r1", "part_a"), run("r2", null)])
+
+    expect(plan.selected.map((s) => s.run.id)).toEqual(["r1"])
+    expect(plan.orphaned.map((r) => r.id)).toEqual(["r2"])
+  })
+
+  it("reports what a limit cut instead of dropping it silently", () => {
+    const plan = planRedispatch(
+      [run("r1", "part_a"), run("r2", "part_a"), run("r3", "part_a")],
+      { limit: 2 }
+    )
+
+    expect(plan.selected.map((s) => s.run.id)).toEqual(["r1", "r2"])
+    expect(plan.deferred.map((r) => r.id)).toEqual(["r3"])
+  })
+
+  it("handles an empty queue", () => {
+    expect(planRedispatch([])).toEqual({
+      selected: [],
+      orphaned: [],
+      deferred: [],
+    })
+  })
+})

--- a/apps/backend/src/api/admin/production-runs/redispatch-parked/plan.ts
+++ b/apps/backend/src/api/admin/production-runs/redispatch-parked/plan.ts
@@ -1,0 +1,52 @@
+/**
+ * Deciding which parked runs go back out, and to whom.
+ *
+ * Pure so the safety property is checkable without a container: a run is always
+ * re-assigned to ITS OWN `previous_partner_id`, never to the `partner_id` in
+ * the request. That field only filters. Routing by the requested partner would
+ * mean one mistyped id hands a batch of one partner's work to another, and
+ * dispatch notifies them, so it is not recoverable by editing a row afterwards.
+ */
+
+export type ParkedRun = {
+  id: string
+  previous_partner_id?: string | null
+  design_id?: string | null
+  quantity?: number | null
+  cancelled_reason?: string | null
+}
+
+export type RedispatchPlan = {
+  /** Runs that will go back out, each paired with the partner it came from. */
+  selected: Array<{ run: ParkedRun; partner_id: string }>
+  /** Parked runs with no previous partner — nowhere to send them back to. */
+  orphaned: ParkedRun[]
+  /** Eligible but cut by `limit`. */
+  deferred: ParkedRun[]
+}
+
+export function planRedispatch(
+  runs: ParkedRun[],
+  options: { partnerId?: string | null; limit?: number } = {}
+): RedispatchPlan {
+  const matchesPartner = (r: ParkedRun) =>
+    !options.partnerId || r.previous_partner_id === options.partnerId
+
+  const considered = (runs ?? []).filter(matchesPartner)
+
+  // No previous partner means the run was parked before the field existed, or
+  // by a path that never set it. There is no "same partner" to send it back to,
+  // and picking one would be inventing an assignment.
+  const orphaned = considered.filter((r) => !r.previous_partner_id)
+  const eligible = considered.filter((r) => Boolean(r.previous_partner_id))
+
+  const cut = options.limit ?? eligible.length
+  return {
+    selected: eligible.slice(0, cut).map((run) => ({
+      run,
+      partner_id: run.previous_partner_id as string,
+    })),
+    orphaned,
+    deferred: eligible.slice(cut),
+  }
+}

--- a/apps/backend/src/api/admin/production-runs/redispatch-parked/route.ts
+++ b/apps/backend/src/api/admin/production-runs/redispatch-parked/route.ts
@@ -1,0 +1,163 @@
+/**
+ * @file Re-send parked production runs back to the partner who let them lapse.
+ * @module API/Admin/ProductionRuns
+ */
+import { MedusaRequest, MedusaResponse } from "@medusajs/framework/http"
+import { IWorkflowEngineService } from "@medusajs/framework/types"
+import {
+  MedusaError,
+  Modules,
+  TransactionHandlerType,
+} from "@medusajs/framework/utils"
+import { StepResponse } from "@medusajs/framework/workflows-sdk"
+
+import { PRODUCTION_RUNS_MODULE } from "../../../../modules/production_runs"
+import type ProductionRunService from "../../../../modules/production_runs/service"
+import { assignProductionRunPartnerWorkflow } from "../../../../workflows/production-runs/assign-production-run-partner"
+import {
+  dispatchProductionRunWorkflow,
+  dispatchProductionRunWorkflowId,
+  waitDispatchTemplateSelectionStepId,
+} from "../../../../workflows/production-runs/dispatch-production-run"
+import type { AdminRedispatchParkedRunsReq } from "../validators"
+import { planRedispatch } from "./plan"
+
+/**
+ * "Send these back to the same partner."
+ *
+ * A run whose partner never accepted (reminder cap) or who declined is parked
+ * in `awaiting_reassignment` with `partner_id` cleared and the old partner kept
+ * on `previous_partner_id`. Getting one moving again is three separate calls —
+ * assign, start dispatch, resume dispatch with template names — and the common
+ * case is a batch of them for one partner who has since said yes. Doing that by
+ * hand, per run, is where they get left parked.
+ *
+ * Re-assignment goes to `previous_partner_id`, per run. Not to a partner_id
+ * passed in: this endpoint only ever sends work back where it came from, so a
+ * typo cannot hand one partner's runs to another. `partner_id` FILTERS.
+ *
+ * `template_names` is what makes it end-to-end. Dispatch parks at
+ * `awaiting_templates` until a selection arrives, and nothing records which
+ * templates a run used last time — tasks do not carry their template. Omit it
+ * and each run is assigned and started but left awaiting a selection, which is
+ * reported rather than guessed at.
+ */
+export const POST = async (req: MedusaRequest, res: MedusaResponse) => {
+  const body = (req.validatedBody || req.body) as AdminRedispatchParkedRunsReq
+  const dryRun = body.dry_run !== false
+
+  const service: ProductionRunService = req.scope.resolve(PRODUCTION_RUNS_MODULE)
+
+  const [parked] = await (service as any).listAndCountProductionRuns(
+    {
+      status: "awaiting_reassignment",
+      ...(body.partner_id ? { previous_partner_id: body.partner_id } : {}),
+    },
+    { take: null }
+  )
+
+  const { selected, orphaned, deferred } = planRedispatch(
+    (parked || []) as any[],
+    { partnerId: body.partner_id, limit: body.limit ?? undefined }
+  )
+
+  if (dryRun) {
+    return res.json({
+      dry_run: true,
+      would_redispatch: selected.map(({ run, partner_id }) => ({
+        production_run_id: run.id,
+        partner_id,
+        design_id: run.design_id ?? null,
+        quantity: run.quantity ?? null,
+        parked_reason: run.cancelled_reason ?? null,
+      })),
+      skipped_without_previous_partner: orphaned.map((r) => r.id),
+      deferred_by_limit: deferred.map((r) => r.id),
+      will_await_template_selection: !body.template_names?.length,
+      summary: `Would re-send ${selected.length} parked run(s) to the partner they came from${
+        body.template_names?.length
+          ? ` and dispatch with ${body.template_names.join(", ")}`
+          : ", each left awaiting a template selection"
+      }${orphaned.length ? `. ${orphaned.length} skipped with no previous partner` : ""}${
+        deferred.length ? `. ${deferred.length} held back by limit` : ""
+      }`,
+    })
+  }
+
+  if (!body.confirm) {
+    throw new MedusaError(
+      MedusaError.Types.INVALID_DATA,
+      "This re-assigns and dispatches real work to partners. Re-send with confirm:true once the dry-run looks right."
+    )
+  }
+
+  const engine = req.scope.resolve(Modules.WORKFLOW_ENGINE) as IWorkflowEngineService
+  const results: any[] = []
+
+  for (const { run, partner_id: partnerId } of selected) {
+    try {
+      await assignProductionRunPartnerWorkflow(req.scope).run({
+        input: {
+          production_run_id: run.id,
+          partner_id: partnerId,
+          note: body.note ?? "Re-sent to the same partner",
+          source: "manual",
+        },
+      })
+
+      const { transaction } = await dispatchProductionRunWorkflow(req.scope).run({
+        input: { production_run_id: run.id },
+      })
+      const transactionId = (transaction as any)?.transactionId
+
+      let dispatched = false
+      if (body.template_names?.length && transactionId) {
+        await engine.setStepSuccess({
+          idempotencyKey: {
+            action: TransactionHandlerType.INVOKE,
+            transactionId,
+            stepId: waitDispatchTemplateSelectionStepId,
+            workflowId: dispatchProductionRunWorkflowId,
+          },
+          stepResponse: new StepResponse({
+            template_names: body.template_names,
+          }),
+        })
+        dispatched = true
+      }
+
+      results.push({
+        production_run_id: run.id,
+        partner_id: partnerId,
+        assigned: true,
+        dispatched,
+        transaction_id: transactionId ?? null,
+        awaiting_templates: !dispatched,
+      })
+    } catch (e: any) {
+      // One partner's run failing must not strand the rest of the batch —
+      // each run is an independent assign + dispatch.
+      results.push({
+        production_run_id: run.id,
+        partner_id: partnerId,
+        assigned: false,
+        dispatched: false,
+        error: e?.message ?? String(e),
+      })
+    }
+  }
+
+  const ok = results.filter((r) => r.assigned)
+  const dispatched = results.filter((r) => r.dispatched)
+  const failed = results.filter((r) => !r.assigned)
+
+  res.json({
+    dry_run: false,
+    results,
+    summary: `Re-sent ${ok.length} of ${selected.length} parked run(s) to the partner they came from; ${dispatched.length} fully dispatched${
+      ok.length - dispatched.length > 0
+        ? `, ${ok.length - dispatched.length} awaiting a template selection`
+        : ""
+    }${failed.length ? `; ${failed.length} failed` : ""}`,
+  })
+}

--- a/apps/backend/src/api/admin/production-runs/validators.ts
+++ b/apps/backend/src/api/admin/production-runs/validators.ts
@@ -56,9 +56,28 @@ export const AdminResumeDispatchProductionRunReq = z.object({
   transaction_id: z.string().min(1),
 })
 
+/**
+ * Re-send parked runs to the partner they came from.
+ *
+ * `partner_id` FILTERS which parked runs are considered — it is never the
+ * partner assigned. Each run goes back to its own `previous_partner_id`, so
+ * this endpoint cannot hand one partner's work to another.
+ */
+export const AdminRedispatchParkedRunsReq = z.object({
+  partner_id: z.string().min(1).nullish(),
+  /** Templates to dispatch with. Omit and each run stops at awaiting_templates. */
+  template_names: z.array(z.string()).optional(),
+  limit: z.number().int().positive().optional(),
+  note: z.string().max(500).nullish(),
+  /** Defaults true — previewing costs nothing, dispatching messages partners. */
+  dry_run: z.boolean().optional(),
+  confirm: z.boolean().optional(),
+})
+
 export type AdminCreateProductionRunReq = z.infer<typeof AdminCreateProductionRunReq>
 export type AdminApproveProductionRunReq = z.infer<typeof AdminApproveProductionRunReq>
 export type AdminSendProductionRunToProductionReq = z.infer<typeof AdminSendProductionRunToProductionReq>
 export type AdminStartDispatchProductionRunReq = z.infer<typeof AdminStartDispatchProductionRunReq>
 export type AdminResumeDispatchProductionRunReq = z.infer<typeof AdminResumeDispatchProductionRunReq>
 export type AdminAssignProductionRunPartnerReq = z.infer<typeof AdminAssignProductionRunPartnerReq>
+export type AdminRedispatchParkedRunsReq = z.infer<typeof AdminRedispatchParkedRunsReq>

--- a/apps/backend/src/api/middlewares.ts
+++ b/apps/backend/src/api/middlewares.ts
@@ -135,6 +135,7 @@ import { AdminPutDesignTaskReq } from "./admin/designs/[id]/tasks/[taskId]/valid
 import {
   AdminApproveProductionRunReq,
   AdminAssignProductionRunPartnerReq,
+  AdminRedispatchParkedRunsReq,
   AdminCreateProductionRunReq,
   AdminCancelProductionRunReq,
   AdminResumeDispatchProductionRunReq,
@@ -4246,6 +4247,12 @@ export default defineMiddlewares({
       matcher: "/admin/production-runs/:id/assign-partner",
       method: "POST",
       middlewares: [validateAndTransformBody(wrapSchema(AdminAssignProductionRunPartnerReq))],
+    },
+    {
+      // Re-send parked runs to the partner they came from (batch).
+      matcher: "/admin/production-runs/redispatch-parked",
+      method: "POST",
+      middlewares: [validateAndTransformBody(wrapSchema(AdminRedispatchParkedRunsReq))],
     },
 
     {


### PR DESCRIPTION
> Requested: *"ask for any production runs per partner that are in re-assignment state to be re-assigned for the same partner and dispatched to them again."*

## Why

A run whose partner never accepted (reminder cap) or who declined is parked in `awaiting_reassignment` with `partner_id` cleared and the old partner kept on `previous_partner_id`.

Getting one moving again is **three calls**: assign → start dispatch → resume dispatch with template names. Done by hand, per run. Which is how 11 of them ended up parked.

## What

`POST /admin/production-runs/redispatch-parked`, reachable from the assistant as **`redispatch_parked_production_runs`**.

```
"send Shramdaan's parked runs back to them"
  -> dry-run: 4 runs, each to the partner it came from
  -> confirm: assigned + dispatched
```

### `partner_id` filters — it never assigns

Each run goes back to **its own `previous_partner_id`**. A mistyped id cannot hand one partner's work to another, which matters because dispatch *notifies the partner* — that's not recoverable by editing a row afterwards.

A pure `planRedispatch` holds that rule; a test pins it explicitly:

```ts
planRedispatch([run("r2", "part_b")], { partnerId: "part_a" })  // -> selected: []
```

### `template_names` is what makes it end-to-end

Dispatch parks at `awaiting_templates` until a selection arrives, and **nothing records which templates a run used last time** — tasks carry no template reference. So:

- **with** `template_names` → assigned, dispatched, done
- **without** → assigned and started, left awaiting a selection, **reported per run** rather than guessed at

### Other guards

- Dry-run by default; `confirm: true` to actually send
- One run failing doesn't strand the rest of the batch
- Runs with no `previous_partner_id` are set aside, not invented for
- A `limit` reports what it held back rather than truncating silently

### Slice keywords

Added the vocabulary of a lapsed run — `reassign`, `parked`, `lapsed`, `declined`, `redispatch`. Without these, *"send this partner's parked runs back to them"* classifies as a purely partner-domain question and the production tools never load.

## Tests

```
npx jest --testPathPattern="redispatch-parked"   # 6 passed
npx jest --testPathPattern="tool-slice"          # passed
npx tsc --noEmit                                 # 79 — baseline, no new errors
```

Pre-existing integration MCP suites fail locally without `--experimental-vm-modules` + a DB; unaffected by this change.

## Note

This dispatches real work and messages partners. I have **not** run it against the 11 parked runs on prod — dry-run first.

🤖 Generated with [Claude Code](https://claude.com/claude-code)