### PR TITLE
feat(ops): bring negative stock levels back to zero

### DIFF
--- a/apps/backend/src/api/admin/ops/maintenance-jobs/__tests__/reset-negative-inventory-levels.unit.spec.ts
+++ b/apps/backend/src/api/admin/ops/maintenance-jobs/__tests__/reset-negative-inventory-levels.unit.spec.ts
@@ -1,0 +1,84 @@
+import { planNegativeLevelResets } from "../reset-negative-inventory-levels-job"
+
+/**
+ * A negative level is never a real position — you cannot hold minus two and a
+ * half metres of cloth. These pin what qualifies, and just as importantly what
+ * does not: zero is already correct, and a large negative is evidence worth
+ * keeping rather than erasing.
+ */
+describe("planNegativeLevelResets", () => {
+  const level = (
+    id: string,
+    stocked: number | string | null,
+    item = "iitem_a",
+    loc = "sloc_a"
+  ) => ({
+    id,
+    inventory_item_id: item,
+    location_id: loc,
+    stocked_quantity: stocked,
+  })
+
+  it("resets a negative level to zero", () => {
+    // The live case: FAB-TWO-BLU-001 at Shramdaan.
+    expect(planNegativeLevelResets([level("ilev_1", -2.5)])).toEqual([
+      expect.objectContaining({
+        level_id: "ilev_1",
+        inventory_item_id: "iitem_a",
+        location_id: "sloc_a",
+        before: -2.5,
+        after: 0,
+      }),
+    ])
+  })
+
+  it("leaves zero alone rather than writing a no-op", () => {
+    expect(planNegativeLevelResets([level("ilev_1", 0)])).toEqual([])
+  })
+
+  it("leaves positive levels alone", () => {
+    expect(planNegativeLevelResets([level("ilev_1", 17.6)])).toEqual([])
+  })
+
+  it("carries the item and location, since the workflow ignores the level id", () => {
+    // #1251: updateInventoryLevels_ re-resolves from the pair, so dropping
+    // these gives "Item undefined is not stocked at location undefined".
+    const [r] = planNegativeLevelResets([
+      level("ilev_1", -1, "iitem_muslin", "sloc_dharamshala"),
+    ])
+
+    expect(r.inventory_item_id).toBe("iitem_muslin")
+    expect(r.location_id).toBe("sloc_dharamshala")
+  })
+
+  it("refuses a negative larger than max_magnitude, keeping the evidence", () => {
+    expect(
+      planNegativeLevelResets([level("ilev_1", -400)], { maxMagnitude: 10 })
+    ).toEqual([])
+  })
+
+  it("still resets a small negative inside the guard", () => {
+    expect(
+      planNegativeLevelResets([level("ilev_1", -2.5)], { maxMagnitude: 10 })
+    ).toHaveLength(1)
+  })
+
+  it("handles string quantities", () => {
+    expect(planNegativeLevelResets([level("ilev_1", "-2.5")])).toHaveLength(1)
+  })
+
+  it("ignores a non-numeric quantity rather than writing NaN", () => {
+    expect(planNegativeLevelResets([level("ilev_1", "not-a-number")])).toEqual([])
+  })
+
+  it("picks only the negatives out of a mixed set", () => {
+    const resets = planNegativeLevelResets([
+      level("ilev_1", 17.6, "iitem_a"),
+      level("ilev_2", -2.5, "iitem_b"),
+      level("ilev_3", 0, "iitem_c"),
+      level("ilev_4", -0.5, "iitem_d"),
+    ])
+
+    expect(resets.map((r) => r.level_id)).toEqual(["ilev_2", "ilev_4"])
+  })
+})

--- a/apps/backend/src/api/admin/ops/maintenance-jobs/registry.ts
+++ b/apps/backend/src/api/admin/ops/maintenance-jobs/registry.ts
@@ -93,6 +93,7 @@ import { repairInventoryOrderRouteJob } from "./repair-inventory-order-route-job
 import { rewindProductionRunJob } from "./rewind-production-run-job"
 import { repairConsumptionLogJob } from "./repair-consumption-log-job"
 import { setLocationOwnershipJob } from "./set-location-ownership-job"
+import { resetNegativeInventoryLevelsJob } from "./reset-negative-inventory-levels-job"
 import { applyCommittedConsumptionJob } from "./apply-committed-consumption-job"
 import { reconcileConsumptionVsProductionJob } from "./reconcile-consumption-vs-production-job"
 import { backfillGoogleAdsHistoryJob } from "./backfill-google-ads-history-job"
@@ -5657,6 +5658,7 @@ export const MAINTENANCE_JOBS: MaintenanceJob[] = [
   rewindProductionRunJob,
   repairConsumptionLogJob,
   setLocationOwnershipJob,
+  resetNegativeInventoryLevelsJob,
   applyCommittedConsumptionJob,
   reconcileConsumptionVsProductionJob,
   backfillGoogleAdsHistoryJob,

--- a/apps/backend/src/api/admin/ops/maintenance-jobs/reset-negative-inventory-levels-job.ts
+++ b/apps/backend/src/api/admin/ops/maintenance-jobs/reset-negative-inventory-levels-job.ts
@@ -1,0 +1,189 @@
+import { ContainerRegistrationKeys, MedusaError } from "@medusajs/framework/utils"
+import { z } from "@medusajs/framework/zod"
+import { updateInventoryLevelsWorkflow } from "@medusajs/medusa/core-flows"
+
+import type { MaintenanceChange, MaintenanceJob, MaintenanceJobResult } from "./registry"
+
+/**
+ * Data Plumbing — bring negative stocked quantities back to zero.
+ *
+ * A negative level says more material left than ever arrived. It is never a
+ * real position: you cannot hold minus two and a half metres of cloth. It is
+ * the residue of a movement recorded with no counterpart — and it is quietly
+ * corrosive, because `available_quantity` inherits the sign and every
+ * allocation decision downstream then reasons about a balance that cannot
+ * exist.
+ *
+ * The live case (2026-08-11): `FAB-TWO-BLU-001` sat at **-2.5** at Shramdaan
+ * India Warehouse, the only level that material has anywhere. No inventory
+ * order ever moved it there — all 15 orders, 64 lines, none reference it — so
+ * there is no receipt to reconcile against and nothing to net it off. One
+ * negative out of 194 levels across 219 items.
+ *
+ * ⚠️ This job does NOT explain the movement, and deliberately records the
+ * before value on every change so the write is auditable. If a negative turns
+ * out to be a genuine un-recorded receipt, the fix is to record the receipt,
+ * NOT to zero it — read the dry-run before applying.
+ */
+
+const paramsSchema = z.object({
+  /** Only this item, e.g. a single known bad level. */
+  inventory_item_id: z.string().min(1).optional(),
+  /** Only levels at this location. */
+  location_id: z.string().min(1).optional(),
+  /**
+   * Refuse to touch anything more negative than this. A level at -0.5 is
+   * rounding residue; one at -400 is a broken integration, and zeroing it would
+   * erase the only evidence.
+   */
+  max_magnitude: z.number().positive().optional(),
+})
+
+/**
+ * PURE: which levels to reset, and to what. Exported for unit tests.
+ *
+ * Only strictly-negative levels qualify — zero is already correct and must not
+ * produce a no-op write, which is what keeps `applied` honest.
+ */
+export function planNegativeLevelResets(
+  levels: Array<{
+    id: string
+    inventory_item_id: string
+    location_id: string
+    stocked_quantity: number | string | null
+    sku?: string | null
+  }>,
+  options: { maxMagnitude?: number } = {}
+): Array<{
+  level_id: string
+  inventory_item_id: string
+  location_id: string
+  sku?: string | null
+  before: number
+  after: number
+}> {
+  const out: Array<{
+    level_id: string
+    inventory_item_id: string
+    location_id: string
+    sku?: string | null
+    before: number
+    after: number
+  }> = []
+
+  for (const lv of levels ?? []) {
+    const before = Number(lv?.stocked_quantity ?? 0)
+    if (!Number.isFinite(before) || before >= 0) {
+      continue
+    }
+    if (options.maxMagnitude != null && Math.abs(before) > options.maxMagnitude) {
+      continue
+    }
+    out.push({
+      level_id: lv.id,
+      inventory_item_id: lv.inventory_item_id,
+      location_id: lv.location_id,
+      sku: lv.sku ?? null,
+      before,
+      after: 0,
+    })
+  }
+
+  return out
+}
+
+export const resetNegativeInventoryLevelsJob: MaintenanceJob = {
+  id: "reset-negative-inventory-levels",
+  label: "Bring negative stock levels back to zero",
+  description:
+    "Find inventory levels with a negative stocked quantity and reset them to 0. A negative level is never a real position — it is the residue of a movement recorded with no counterpart, and available_quantity inherits the sign, so allocation downstream reasons about a balance that cannot exist. Reports every level it would touch with its current value. ⚠️ If a negative is really an un-recorded receipt, record the receipt instead of zeroing it — read the dry-run first. Safe to re-run as a periodic check: with nothing negative it reports no changes.",
+  params: [
+    {
+      name: "inventory_item_id",
+      type: "string",
+      required: false,
+      description: "Only this inventory item",
+    },
+    {
+      name: "location_id",
+      type: "string",
+      required: false,
+      description: "Only levels at this stock location",
+    },
+    {
+      name: "max_magnitude",
+      type: "number",
+      required: false,
+      description:
+        "Refuse anything more negative than this. A level at -0.5 is residue; one at -400 is a broken integration whose evidence should not be erased.",
+    },
+  ],
+  run: async (container, { dry_run, params }): Promise<MaintenanceJobResult> => {
+    const parsed = paramsSchema.safeParse(params)
+    if (!parsed.success) {
+      throw new MedusaError(
+        MedusaError.Types.INVALID_DATA,
+        parsed.error.issues.map((i) => i.message).join("; ")
+      )
+    }
+
+    const query: any = container.resolve(ContainerRegistrationKeys.QUERY)
+
+    const filters: Record<string, any> = {}
+    if (parsed.data.inventory_item_id) {
+      filters.inventory_item_id = parsed.data.inventory_item_id
+    }
+    if (parsed.data.location_id) {
+      filters.location_id = parsed.data.location_id
+    }
+
+    const { data: levels } = await query.graph({
+      entity: "inventory_level",
+      fields: ["id", "inventory_item_id", "location_id", "stocked_quantity"],
+      ...(Object.keys(filters).length ? { filters } : {}),
+    })
+
+    const resets = planNegativeLevelResets((levels || []) as any[], {
+      maxMagnitude: parsed.data.max_magnitude,
+    })
+
+    const changes: MaintenanceChange[] = resets.map((r) => ({
+      entity: "inventory_level",
+      id: `${r.inventory_item_id}@${r.location_id}`,
+      field: "stocked_quantity",
+      before: r.before,
+      after: r.after,
+    }))
+
+    if (!dry_run && resets.length > 0) {
+      // `inventory_item_id` + `location_id` are REQUIRED, not decoration:
+      // `updateInventoryLevels_` ignores `id` and re-resolves the level from
+      // the pair. Passing the level id alone dies with "Item undefined is not
+      // stocked at location undefined" (#1251).
+      await updateInventoryLevelsWorkflow(container as any).run({
+        input: {
+          updates: resets.map((r) => ({
+            id: r.level_id,
+            inventory_item_id: r.inventory_item_id,
+            location_id: r.location_id,
+            stocked_quantity: r.after,
+          })) as any,
+        },
+      })
+    }
+
+    const summary = resets.length
+      ? `${dry_run ? "Would reset" : "Reset"} ${resets.length} negative level(s) to 0: ${resets
+          .map((r) => `${r.inventory_item_id}@${r.location_id} was ${r.before}`)
+          .join(", ")}`
+      : `No negative stock levels found across ${(levels || []).length} level(s)`
+
+    return {
+      job_id: resetNegativeInventoryLevelsJob.id,
+      dry_run,
+      applied: !dry_run && resets.length > 0,
+      summary,
+      changes,
+    }
+  },
+}


### PR DESCRIPTION
## Why

A negative level says more material left than ever arrived. It is **never a real position** — you cannot hold minus two and a half metres of cloth — and it's quietly corrosive: `available_quantity` inherits the sign, so every allocation decision downstream reasons about a balance that cannot exist.

Found while tracing Dark Desires Dress:

```
FAB-TWO-BLU-001  "Two Forty Twenty S Blue"
  Shramdaan India Warehouse   stocked = -2.5   available = -2.5
```

That's the **only** level this material has anywhere, and **no inventory order ever moved it there** — all 15 orders, 64 lines, none reference it. So there's no receipt to reconcile against and nothing to net it off.

## Scope

A full sweep found **exactly one**: 1 negative across **194 levels on 219 items**.

So this is a **guard, not a cleanup**. Safe to re-run periodically; with nothing negative it reports no changes.

## Guards

- **Dry-run by default**, and records the `before` value on every change so the write is auditable
- ⚠️ **It does not explain the movement.** If a negative turns out to be an un-recorded receipt, the fix is to *record the receipt*, not zero it — hence `max_magnitude`, which refuses anything large enough that erasing it would destroy the evidence (`-0.5` is residue; `-400` is a broken integration)
- Zero and positive levels produce no write at all, which keeps `applied` honest

## Correctness detail

Passes `inventory_item_id` + `location_id` on the update, not just the level id — `updateInventoryLevels_` **ignores `id`** and re-resolves from the pair. Passing the level id alone dies with `Item undefined is not stocked at location undefined` (the #1251 bug). A test pins it.

## Tests

```
npx jest --testPathPattern="reset-negative-inventory-levels"   # 9 passed
npx tsc --noEmit                                               # 79 — baseline
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)