### PR TITLE
fix(ops): read both halves of a stock level, and report when they disagree

### DIFF
--- a/apps/backend/src/api/admin/ops/maintenance-jobs/__tests__/reset-negative-inventory-levels.unit.spec.ts
+++ b/apps/backend/src/api/admin/ops/maintenance-jobs/__tests__/reset-negative-inventory-levels.unit.spec.ts
@@ -1,4 +1,7 @@
-import { planNegativeLevelResets } from "../reset-negative-inventory-levels-job"
+import {
+  findLevelValueDivergence,
+  planNegativeLevelResets,
+} from "../reset-negative-inventory-levels-job"
 
 /**
  * A negative level is never a real position — you cannot hold minus two and a
@@ -71,6 +74,56 @@ describe("planNegativeLevelResets", () => {
     expect(planNegativeLevelResets([level("ilev_1", "not-a-number")])).toEqual([])
   })
 
+  it("catches a negative hiding in the raw column while numeric reads 0", () => {
+    // The live miss: FAB-TWO-BLU-001 read 0 through one route and -2.5 through
+    // the item relation, and the first version of this job reported it clean.
+    const resets = planNegativeLevelResets([
+      {
+        ...level("ilev_1", 0),
+        raw_stocked_quantity: { value: "-2.5", precision: 20 },
+      },
+    ])
+
+    expect(resets).toHaveLength(1)
+    expect(resets[0].before).toBe(-2.5)
+  })
+
+  it("takes the worse of the two sides", () => {
+    const [r] = planNegativeLevelResets([
+      {
+        ...level("ilev_1", -1),
+        raw_stocked_quantity: { value: "-9", precision: 20 },
+      },
+    ])
+
+    expect(r.before).toBe(-9)
+  })
+
+  it("leaves a level alone when both sides are sound", () => {
+    expect(
+      planNegativeLevelResets([
+        {
+          ...level("ilev_1", 19),
+          raw_stocked_quantity: { value: "19", precision: 20 },
+        },
+      ])
+    ).toEqual([])
+  })
+
+  it("applies max_magnitude to the worse side", () => {
+    expect(
+      planNegativeLevelResets(
+        [
+          {
+            ...level("ilev_1", 0),
+            raw_stocked_quantity: { value: "-400", precision: 20 },
+          },
+        ],
+        { maxMagnitude: 10 }
+      )
+    ).toEqual([])
+  })
+
   it("picks only the negatives out of a mixed set", () => {
     const resets = planNegativeLevelResets([
       level("ilev_1", 17.6, "iitem_a"),
@@ -80,5 +133,53 @@ describe("planNegativeLevelResets", () => {
     ])
 
     expect(resets.map((r) => r.level_id)).toEqual(["ilev_2", "ilev_4"])
+  })
+})
+
+/**
+ * A `bigNumber` lives in two columns and they can drift apart. That is worse
+ * than a wrong number, because it defeats the check that would catch a wrong
+ * number — whichever side a tool reads, it is confident and may be wrong.
+ */
+describe("findLevelValueDivergence", () => {
+  const lvl = (numeric: number | string | null, raw: unknown) => ({
+    id: "ilev_1",
+    inventory_item_id: "iitem_a",
+    location_id: "sloc_a",
+    stocked_quantity: numeric,
+    raw_stocked_quantity: raw,
+  })
+
+  it("reports the live case: numeric 0, raw -2.5", () => {
+    expect(
+      findLevelValueDivergence([lvl(0, { value: "-2.5", precision: 20 })])
+    ).toEqual([expect.objectContaining({ numeric: 0, raw: -2.5 })])
+  })
+
+  it("says nothing when the two agree", () => {
+    expect(
+      findLevelValueDivergence([lvl(19, { value: "19", precision: 20 })])
+    ).toEqual([])
+  })
+
+  it("treats a missing raw column as no evidence, not as disagreement", () => {
+    // Several read paths simply do not return raw_. Absence must not be noise.
+    expect(findLevelValueDivergence([lvl(19, null)])).toEqual([])
+  })
+
+  it("reads a bare raw value as well as the {value} wrapper", () => {
+    expect(findLevelValueDivergence([lvl(0, "-2.5")])).toHaveLength(1)
+  })
+
+  it("never picks a winner — it only reports both", () => {
+    const [d] = findLevelValueDivergence([lvl(5, { value: "7", precision: 20 })])
+
+    expect(d.numeric).toBe(5)
+    expect(d.raw).toBe(7)
+    expect(d).not.toHaveProperty("after")
+  })
+
+  it("ignores an unparseable raw rather than reporting a false divergence", () => {
+    expect(findLevelValueDivergence([lvl(19, { value: "abc" })])).toEqual([])
   })
 })

--- a/apps/backend/src/api/admin/ops/maintenance-jobs/reset-negative-inventory-levels-job.ts
+++ b/apps/backend/src/api/admin/ops/maintenance-jobs/reset-negative-inventory-levels-job.ts
@@ -39,6 +39,89 @@ const paramsSchema = z.object({
   max_magnitude: z.number().positive().optional(),
 })
 
+/** Read the value out of a `raw_<field>` jsonb, whatever shape it arrives in. */
+const rawValue = (raw: unknown): number | null => {
+  if (raw == null) {
+    return null
+  }
+  const v =
+    typeof raw === "object" && raw !== null && "value" in (raw as any)
+      ? (raw as any).value
+      : raw
+  const n = Number(v)
+  return Number.isFinite(n) ? n : null
+}
+
+/**
+ * PURE: levels whose two storage columns disagree. Exported for unit tests.
+ *
+ * `model.bigNumber()` persists a field TWICE — `<field> numeric` and
+ * `raw_<field> jsonb` — and on 2026-08-11 a single row was found where they had
+ * drifted apart: `FAB-TWO-BLU-001` read `0` through
+ * `/admin/inventory-items/:id/location-levels` and `-2.5` through the item's
+ * `location_levels` relation, which is what the admin UI renders.
+ *
+ * That divergence is worse than a wrong number, because it defeats the check
+ * that would catch a wrong number: the negative-level sweep reported "no
+ * negative levels across 194" while an operator was looking at -2.5 on screen.
+ * Whichever side a tool happens to read, it is confident and it is not
+ * necessarily right.
+ *
+ * ⚠️ This REPORTS ONLY and never picks a winner. Neither column is inherently
+ * authoritative — the numeric side is what most queries filter on, the raw side
+ * is what the UI shows — so choosing between them is a judgement about what
+ * really happened to the stock, which belongs to a human. Same reasoning as
+ * refusing to guess a null `quantity_basis` (#1248).
+ */
+export function findLevelValueDivergence(
+  levels: Array<{
+    id: string
+    inventory_item_id: string
+    location_id: string
+    stocked_quantity: number | string | null
+    raw_stocked_quantity?: unknown
+    sku?: string | null
+  }>
+): Array<{
+  level_id: string
+  inventory_item_id: string
+  location_id: string
+  sku?: string | null
+  numeric: number
+  raw: number
+}> {
+  const out: Array<{
+    level_id: string
+    inventory_item_id: string
+    location_id: string
+    sku?: string | null
+    numeric: number
+    raw: number
+  }> = []
+
+  for (const lv of levels ?? []) {
+    const raw = rawValue(lv?.raw_stocked_quantity)
+    if (raw == null) {
+      // Not every read path returns the raw column; absence is not disagreement.
+      continue
+    }
+    const numeric = Number(lv?.stocked_quantity ?? 0)
+    if (!Number.isFinite(numeric) || numeric === raw) {
+      continue
+    }
+    out.push({
+      level_id: lv.id,
+      inventory_item_id: lv.inventory_item_id,
+      location_id: lv.location_id,
+      sku: lv.sku ?? null,
+      numeric,
+      raw,
+    })
+  }
+
+  return out
+}
+
 /**
  * PURE: which levels to reset, and to what. Exported for unit tests.
  *
@@ -51,6 +134,7 @@ export function planNegativeLevelResets(
     inventory_item_id: string
     location_id: string
     stocked_quantity: number | string | null
+    raw_stocked_quantity?: unknown
     sku?: string | null
   }>,
   options: { maxMagnitude?: number } = {}
@@ -72,8 +156,20 @@ export function planNegativeLevelResets(
   }> = []
 
   for (const lv of levels ?? []) {
-    const before = Number(lv?.stocked_quantity ?? 0)
-    if (!Number.isFinite(before) || before >= 0) {
+    // BOTH columns, and the WORST of them. Reading one side is exactly how the
+    // first version of this job missed the live case: it saw `stocked_quantity`
+    // 0 and reported "no negative levels across 194" while the admin UI, which
+    // renders the raw side, showed -2.5. A level is bad if EITHER side is.
+    const numeric = Number(lv?.stocked_quantity ?? 0)
+    const raw = rawValue(lv?.raw_stocked_quantity)
+    const candidates = [numeric, raw].filter(
+      (n): n is number => n != null && Number.isFinite(n)
+    )
+    if (!candidates.length) {
+      continue
+    }
+    const before = Math.min(...candidates)
+    if (before >= 0) {
       continue
     }
     if (options.maxMagnitude != null && Math.abs(before) > options.maxMagnitude) {
@@ -96,7 +192,7 @@ export const resetNegativeInventoryLevelsJob: MaintenanceJob = {
   id: "reset-negative-inventory-levels",
   label: "Bring negative stock levels back to zero",
   description:
-    "Find inventory levels with a negative stocked quantity and reset them to 0. A negative level is never a real position — it is the residue of a movement recorded with no counterpart, and available_quantity inherits the sign, so allocation downstream reasons about a balance that cannot exist. Reports every level it would touch with its current value. ⚠️ If a negative is really an un-recorded receipt, record the receipt instead of zeroing it — read the dry-run first. Safe to re-run as a periodic check: with nothing negative it reports no changes.",
+    "Find inventory levels with a negative stocked quantity and reset them to 0, and report levels whose two stored values disagree. A negative level is never a real position — it is the residue of a movement recorded with no counterpart, and available_quantity inherits the sign, so allocation downstream reasons about a balance that cannot exist. Reads BOTH halves of the bigNumber pair (numeric and raw_), because reading one side is how a level showing -2.5 in the admin was reported clean. Divergence is reported, never auto-resolved — neither side is inherently authoritative. ⚠️ If a negative is really an un-recorded receipt, record the receipt instead of zeroing it — read the dry-run first. Safe to re-run as a periodic check.",
   params: [
     {
       name: "inventory_item_id",
@@ -139,13 +235,22 @@ export const resetNegativeInventoryLevelsJob: MaintenanceJob = {
 
     const { data: levels } = await query.graph({
       entity: "inventory_level",
-      fields: ["id", "inventory_item_id", "location_id", "stocked_quantity"],
+      fields: [
+        "id",
+        "inventory_item_id",
+        "location_id",
+        "stocked_quantity",
+        // The other half of the bigNumber pair. Without it this job reads one
+        // side of the row and is confidently wrong when they disagree.
+        "raw_stocked_quantity",
+      ],
       ...(Object.keys(filters).length ? { filters } : {}),
     })
 
     const resets = planNegativeLevelResets((levels || []) as any[], {
       maxMagnitude: parsed.data.max_magnitude,
     })
+    const divergent = findLevelValueDivergence((levels || []) as any[])
 
     const changes: MaintenanceChange[] = resets.map((r) => ({
       entity: "inventory_level",
@@ -172,11 +277,26 @@ export const resetNegativeInventoryLevelsJob: MaintenanceJob = {
       })
     }
 
-    const summary = resets.length
-      ? `${dry_run ? "Would reset" : "Reset"} ${resets.length} negative level(s) to 0: ${resets
-          .map((r) => `${r.inventory_item_id}@${r.location_id} was ${r.before}`)
-          .join(", ")}`
-      : `No negative stock levels found across ${(levels || []).length} level(s)`
+    const summary = [
+      resets.length
+        ? `${dry_run ? "Would reset" : "Reset"} ${resets.length} negative level(s) to 0: ${resets
+            .map((r) => `${r.inventory_item_id}@${r.location_id} was ${r.before}`)
+            .join(", ")}`
+        : `No negative stock levels found across ${(levels || []).length} level(s)`,
+      // Reported, never auto-resolved — see findLevelValueDivergence.
+      divergent.length
+        ? `⚠️ ${divergent.length} level(s) whose two stored values DISAGREE (the UI shows the raw one): ${divergent
+            .map(
+              (d) =>
+                `${d.inventory_item_id}@${d.location_id} numeric=${d.numeric} raw=${d.raw}`
+            )
+            .join(
+              ", "
+            )}. Not resolved automatically — decide which is true, then write it with POST /admin/inventory-items/:id/location-levels/:location_id, which rewrites both.`
+        : "",
+    ]
+      .filter(Boolean)
+      .join(". ")
 
     return {
       job_id: resetNegativeInventoryLevelsJob.id,


### PR DESCRIPTION
## The miss

The negative-level sweep from #1257 reported:

```
No negative stock levels found across 194 level(s)
```

…while the admin UI showed **−2.5** on one of those very rows.

It wasn't wrong about what it saw. **It was reading one half of the value.**

`model.bigNumber()` persists a field **twice** — `<field> numeric` and `raw_<field> jsonb` — and on `FAB-TWO-BLU-001` at Shramdaan the two had drifted apart:

| surface | reported |
|---|---|
| `/admin/inventory-items/:id/location-levels` | `0` |
| item's `location_levels` relation (what the UI renders) | `-2.5` |

A healthy row agrees on both — the muslin read 19/19. **That comparison is the cheap discriminator**, and it's what proved this was a row-level fault rather than a serialization quirk.

## Two changes

**1. The sweep reads both columns and takes the worse.** A level is bad if *either* side is negative. A test pins the exact live shape — `numeric: 0`, `raw: -2.5` — so this specific miss can't recur.

**2. Divergence is reported in its own right.** It's worse than a wrong number, because it defeats the check that would catch a wrong number: whichever side a tool happens to read, it is confident and it may be wrong.

**Reported, never auto-resolved.** Neither column is inherently authoritative — the numeric side is what most queries filter on, the raw side is what the UI renders — so choosing between them is a judgement about what really happened to the stock. That belongs to a human. Same reasoning as refusing to guess a null `quantity_basis` (#1248).

## Prod state

The live row was already corrected by hand via `POST /admin/inventory-items/:id/location-levels/:location_id`, which rewrites both columns. Both surfaces now read `0`, and a full re-sweep is clean: **0 negatives across 194 levels / 219 items**.

⚠️ That manual write **bypassed the ops audit log** — no `ops_maintenance_run` row exists for it. Which is the other reason this class of fix belongs in a job.

## Tests

```
npx jest --testPathPattern="reset-negative-inventory-levels"   # 19 passed
npx tsc --noEmit                                               # 79 — baseline
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)