### PR TITLE
fix(production): move the dispatch callers onto template ids, and close the test gap (#1265)

### DIFF
--- a/apps/backend/integration-tests/http/production-run-complete-yield.spec.ts
+++ b/apps/backend/integration-tests/http/production-run-complete-yield.spec.ts
@@ -221,7 +221,19 @@ setupSharedTestSuite(() => {
 
     // ── Test: Complete without yield data (backward compat) ─────────
 
-    it("should still work without yield fields (backward compatibility)", async () => {
+    /**
+     * This asserted the OPPOSITE until #1262: completing with no output fields
+     * used to be a 200, and this test was named for that backward
+     * compatibility. #1262 closed the gap deliberately — a run could be closed
+     * with nothing said about what came out of it, which is the cause behind
+     * the #1248 thread — so an unaccounted completion is now REFUSED. The
+     * spec was never updated with the code, so it has been failing since.
+     *
+     * Compatibility is preserved only where it was always meaningful: a run
+     * with no ordered quantity has nothing to measure against and still
+     * completes without output fields (covered below).
+     */
+    it("should refuse a completion that says nothing about output", async () => {
       const { adminHeaders, unique } = await setupTestData()
       const { partnerId, partnerHeaders } = await createPartner(unique)
       const { templateName } = await createTemplates(adminHeaders, unique)
@@ -240,20 +252,38 @@ setupSharedTestSuite(() => {
 
       await advanceToFinished(runId, partnerHeaders)
 
-      // Complete with no yield fields — just like the old API
-      const completeRes = await api.post(
-        `/partners/production-runs/${runId}/complete`,
-        {
-          partner_cost_estimate: 1500,
-          notes: "Done",
-        },
-        { headers: partnerHeaders }
+      // Complete with no yield fields — just like the old API. 3 were ordered
+      // and this says nothing about how many were made.
+      const completeErr = await api
+        .post(
+          `/partners/production-runs/${runId}/complete`,
+          {
+            partner_cost_estimate: 1500,
+            notes: "Done",
+          },
+          { headers: partnerHeaders }
+        )
+        .then(
+          (res: any) => {
+            throw new Error(
+              `Expected the completion to be refused, got ${res.status}`
+            )
+          },
+          (err: any) => err
+        )
+
+      expect(completeErr.response?.status).toBe(400)
+      expect(String(completeErr.response?.data?.message)).toContain(
+        "produced_quantity is required"
       )
-      expect(completeRes.status).toBe(200)
-      expect(completeRes.data.production_run.status).toBe("completed")
-      expect(completeRes.data.production_run.partner_cost_estimate).toBe(1500)
-      // produced_quantity should be null (not sent)
-      expect(completeRes.data.production_run.produced_quantity).toBeNull()
+
+      // The run is untouched — a refused completion must not half-close it.
+      const afterRes = await api.get(
+        `/admin/production-runs/${runId}`,
+        adminHeaders
+      )
+      expect(afterRes.data.production_run.status).not.toBe("completed")
+      expect(afterRes.data.production_run.produced_quantity ?? null).toBeNull()
     })
 
     // ── Test: Complete with consumptions + yield ────────────────────

--- a/apps/backend/integration-tests/http/production-runs.spec.ts
+++ b/apps/backend/integration-tests/http/production-runs.spec.ts
@@ -406,5 +406,107 @@ setupSharedTestSuite(() => {
       expect(runTaskTitles).toContain(templateA.name)
       expect(runTaskTitles).toContain(templateB.name)
     })
+
+    /**
+     * #1265 — a dispatched run must record WHICH templates it went out with.
+     *
+     * `dispatch_template_names` looks like it answers this and does not: it is
+     * approval-time intent, written only when an approver named templates, so a
+     * run whose templates are chosen at dispatch keeps it null forever. This
+     * asserts the field that dispatch itself writes, over the real HTTP path,
+     * and dispatches BY ID — a name is not an identity (#1261).
+     */
+    it("records dispatched_template_ids on the run when dispatched by id", async () => {
+      const { api } = getSharedTestEnv()
+
+      const unique = `${Date.now()}-rec`
+      const mkTemplate = (step: string) => ({
+        name: `prod-record-${step}-${unique}`,
+        description: `Record step ${step}`,
+        priority: "medium",
+        estimated_duration: 30,
+        eventable: false,
+        notifiable: false,
+        metadata: { workflow_type: "production_run", step },
+        category: "Production",
+      })
+
+      const templateA = mkTemplate("a")
+      const t1 = await api.post("/admin/task-templates", templateA, adminHeaders)
+      expect(t1.status).toBe(201)
+      const templateAId = t1.data.task_template.id
+      const categoryId = t1.data.task_template.category_id
+
+      const { category: _c, ...templateB } = {
+        ...mkTemplate("b"),
+        category_id: categoryId,
+      } as any
+      const t2 = await api.post("/admin/task-templates", templateB, adminHeaders)
+      expect(t2.status).toBe(201)
+      const templateBId = t2.data.task_template.id
+
+      const createRunRes = await api.post(
+        "/admin/production-runs",
+        { design_id: designId, quantity: 4 },
+        adminHeaders
+      )
+      expect(createRunRes.status).toBe(201)
+      const parentRunId = createRunRes.data.production_run.id
+
+      // Nothing is named at approval — exactly the case that leaves
+      // `dispatch_template_names` null forever.
+      const approveRes = await api.post(
+        `/admin/production-runs/${parentRunId}/approve`,
+        {
+          assignments: [
+            { partner_id: partnerId, role: "production", quantity: 4 },
+          ],
+        },
+        adminHeaders
+      )
+      expect(approveRes.status).toBe(200)
+      const childRunId = (approveRes.data.result?.children || [])[0]?.id
+      expect(childRunId).toBeTruthy()
+
+      const startRes = await api.post(
+        `/admin/production-runs/${childRunId}/start-dispatch`,
+        {},
+        adminHeaders
+      )
+      expect(startRes.status).toBe(202)
+
+      const resumeRes = await api.post(
+        `/admin/production-runs/${childRunId}/resume-dispatch`,
+        {
+          transaction_id: startRes.data.transaction_id,
+          template_ids: [templateAId, templateBId],
+        },
+        adminHeaders
+      )
+      expect(resumeRes.status).toBe(200)
+
+      const deadline = Date.now() + 15_000
+      let run: any = null
+      while (Date.now() < deadline) {
+        const res = await api.get(
+          `/admin/production-runs/${childRunId}`,
+          adminHeaders
+        )
+        run = res.data.production_run
+        if (
+          String(run?.status) === "sent_to_partner" &&
+          (run?.dispatched_template_ids || []).length
+        ) {
+          break
+        }
+        await new Promise((r) => setTimeout(r, 500))
+      }
+
+      expect(String(run?.status)).toBe("sent_to_partner")
+      // Caller order is the order the partner works in — preserved, not sorted.
+      expect(run?.dispatched_template_ids).toEqual([templateAId, templateBId])
+      // The intent field stays null: it is not, and never was, this record.
+      expect(run?.dispatch_template_names ?? null).toBeNull()
+    })
   })
 })

--- a/apps/backend/src/admin/hooks/api/production-runs.ts
+++ b/apps/backend/src/admin/hooks/api/production-runs.ts
@@ -140,7 +140,9 @@ export const useProductionRun = (
 
 export type AdminSendProductionRunToProductionPayload = {
   run_id: string
-  template_names: string[]
+  /** Preferred — see `AdminResumeDispatchPayload`. */
+  template_ids?: string[]
+  template_names?: string[]
 }
 
 export type AdminSendProductionRunToProductionResponse = {
@@ -163,6 +165,7 @@ export const useSendProductionRunToProduction = (
         {
           method: "POST",
           body: {
+            template_ids: payload.template_ids,
             template_names: payload.template_names,
           },
         }
@@ -197,7 +200,13 @@ export const useStartDispatch = (
 
 export type AdminResumeDispatchPayload = {
   transaction_id: string
-  template_names: string[]
+  /**
+   * #1261 — a name is not an identity: prod carries two "Stitching" templates
+   * differing only by category, and dispatch REFUSES an ambiguous name rather
+   * than picking one. Send ids; names remain accepted for older callers.
+   */
+  template_ids?: string[]
+  template_names?: string[]
 }
 
 export type AdminResumeDispatchResponse = {

--- a/apps/backend/src/admin/routes/production-runs/[id]/@dispatch/page.tsx
+++ b/apps/backend/src/admin/routes/production-runs/[id]/@dispatch/page.tsx
@@ -7,7 +7,7 @@ import {
   Text,
   toast,
 } from "@medusajs/ui"
-import { useMemo, useState } from "react"
+import { useEffect, useMemo, useState } from "react"
 import { useParams } from "react-router-dom"
 
 import { RouteDrawer } from "../../../../components/modal/route-drawer/route-drawer"
@@ -40,19 +40,89 @@ const DispatchProductionRunDrawerForm = () => {
     )
   }, [taskTemplates])
 
-  const [selectedTemplates, setSelectedTemplates] = useState<string[]>(
-    () => (run?.dispatch_template_names as string[]) || []
-  )
+  /**
+   * Names that more than one template answers to. Prod carries two "Stitching"
+   * rows differing only by category — different process steps wearing one label
+   * (#1261). Dispatch refuses such a name, so the picker has to show the
+   * category or the choice cannot be made here at all.
+   */
+  const ambiguousNames = useMemo(() => {
+    const counts = new Map<string, number>()
+    for (const t of templatesToShow) {
+      const name = String((t as any)?.name || "")
+      counts.set(name, (counts.get(name) ?? 0) + 1)
+    }
+    return new Set(
+      [...counts.entries()].filter(([, n]) => n > 1).map(([name]) => name)
+    )
+  }, [templatesToShow])
+
+  /**
+   * Selection is by ID, not name. Keying it by name merged the two "Stitching"
+   * rows into one toggle and then sent a name dispatch rejects.
+   */
+  const [selectedTemplates, setSelectedTemplates] = useState<string[]>([])
+  const [seededFrom, setSeededFrom] = useState<string | null>(null)
   const [step, setStep] = useState<DispatchStep>("select-templates")
+
+  /**
+   * Preselect what this run was last dispatched with (#1265) — the record
+   * written BY dispatch. `dispatch_template_names` is only approval-time intent
+   * and is null on most runs, so it is the fallback, and only for names that
+   * identify exactly one template.
+   */
+  useEffect(() => {
+    if (!run?.id || seededFrom === run.id || !templatesToShow.length) {
+      return
+    }
+
+    const knownIds = new Set(templatesToShow.map((t: any) => String(t.id)))
+    const dispatched = ((run as any)?.dispatched_template_ids as string[] | null) || []
+    const seed = dispatched.filter((id) => knownIds.has(String(id)))
+
+    if (!seed.length) {
+      const intent = ((run as any)?.dispatch_template_names as string[] | null) || []
+      for (const name of intent) {
+        if (ambiguousNames.has(String(name))) {
+          continue
+        }
+        const match = templatesToShow.find(
+          (t: any) => String(t.name) === String(name)
+        )
+        if (match) {
+          seed.push(String((match as any).id))
+        }
+      }
+    }
+
+    setSeededFrom(run.id)
+    if (seed.length) {
+      setSelectedTemplates(seed)
+    }
+  }, [run?.id, templatesToShow, ambiguousNames, seededFrom])
 
   const startDispatch = useStartDispatch(runId || "")
   const resumeDispatch = useResumeDispatch(runId || "")
 
   const isPending = startDispatch.isPending || resumeDispatch.isPending
 
-  const toggleTemplate = (name: string) => {
+  /** The summary line reads names, not the ids the selection is keyed on. */
+  const selectedLabels = useMemo(() => {
+    return selectedTemplates.map((id) => {
+      const tpl: any = templatesToShow.find((t: any) => String(t.id) === id)
+      if (!tpl) {
+        return id
+      }
+      const name = String(tpl.name)
+      return ambiguousNames.has(name)
+        ? `${name} (${tpl.category?.name || "uncategorised"})`
+        : name
+    })
+  }, [selectedTemplates, templatesToShow, ambiguousNames])
+
+  const toggleTemplate = (id: string) => {
     setSelectedTemplates((prev) =>
-      prev.includes(name) ? prev.filter((n) => n !== name) : [...prev, name]
+      prev.includes(id) ? prev.filter((t) => t !== id) : [...prev, id]
     )
   }
 
@@ -71,9 +141,10 @@ const DispatchProductionRunDrawerForm = () => {
       const { transaction_id } = await startDispatch.mutateAsync()
 
       // Step 2: Resume with selected templates
+      // Ids, not names — the selection already knows exactly which rows.
       await resumeDispatch.mutateAsync({
         transaction_id,
-        template_names: selectedTemplates,
+        template_ids: selectedTemplates,
       })
 
       setStep("done")
@@ -176,21 +247,23 @@ const DispatchProductionRunDrawerForm = () => {
                   ) : (
                     <div className="flex flex-col gap-2">
                       {templatesToShow.map((tpl: any) => {
+                        const id = String(tpl.id)
                         const name = String(tpl.name)
-                        const selected = selectedTemplates.includes(name)
+                        const selected = selectedTemplates.includes(id)
+                        const category = tpl.category?.name || null
                         const estCost = tpl.estimated_cost
                           ? ` (est. ${tpl.estimated_cost}${tpl.cost_currency ? ` ${tpl.cost_currency}` : ""})`
                           : ""
                         return (
                           <button
-                            key={name}
+                            key={id}
                             type="button"
                             className={`flex items-center justify-between rounded-lg border px-4 py-3 text-left transition-colors ${
                               selected
                                 ? "border-ui-border-interactive bg-ui-bg-interactive"
                                 : "border-ui-border-base hover:bg-ui-bg-base-hover"
                             }`}
-                            onClick={() => toggleTemplate(name)}
+                            onClick={() => toggleTemplate(id)}
                           >
                             <div className="flex flex-col">
                               <Text
@@ -199,6 +272,15 @@ const DispatchProductionRunDrawerForm = () => {
                                 className={selected ? "text-ui-fg-on-color" : ""}
                               >
                                 {name}
+                                {/* Without the category these two rows are
+                                    indistinguishable, and they are different
+                                    process steps (#1261). */}
+                                {ambiguousNames.has(name) && (
+                                  <span className="opacity-70">
+                                    {" "}
+                                    — {category || "uncategorised"}
+                                  </span>
+                                )}
                               </Text>
                               {tpl.description && (
                                 <Text
@@ -230,7 +312,7 @@ const DispatchProductionRunDrawerForm = () => {
                   <div className="px-6 py-3">
                     <Text size="small" className="text-ui-fg-subtle">
                       {selectedTemplates.length} template{selectedTemplates.length > 1 ? "s" : ""} selected:{" "}
-                      {selectedTemplates.join(", ")}
+                      {selectedLabels.join(", ")}
                     </Text>
                   </div>
                 )}

--- a/apps/backend/src/workflows/whatsapp/whatsapp-admin-handler.ts
+++ b/apps/backend/src/workflows/whatsapp/whatsapp-admin-handler.ts
@@ -692,10 +692,34 @@ async function handleSendRun(
     return { handled: true, action: "send_run", error: "not_found" }
   }
 
-  const templateNames = ((run as any).dispatch_template_names as string[]) || []
+  /**
+   * What this run was last dispatched with (#1265) beats what an approver
+   * intended (#1265 again: `dispatch_template_names` is written only at
+   * approval and is null on most runs — this command used to send an empty
+   * list and get "No task templates selected" back).
+   *
+   * Ids first: the dedup job renames template rows, and dispatch REFUSES a name
+   * that matches more than one row (#1261), so a name-only re-send of a run
+   * whose template shares its label would fail here with nothing to do about it
+   * over WhatsApp.
+   */
+  const dispatchedIds = (((run as any).dispatched_template_ids as string[]) || [])
+    .filter((id) => typeof id === "string" && id.length > 0)
+  const templateNames = (((run as any).dispatch_template_names as string[]) || [])
+    .filter((n) => typeof n === "string" && n.length > 0)
+
+  if (!dispatchedIds.length && !templateNames.length) {
+    await whatsapp.sendTextMessage(
+      phone,
+      `Run \`${runId}\` has no task templates on record — it was never dispatched, and no templates were chosen at approval.\n\nDispatch it from the admin (Production Run → Dispatch) once, and \`send run\` will be able to repeat that selection.`
+    )
+    return { handled: true, action: "send_run", error: "no_templates" }
+  }
 
   await sendProductionRunToProductionWorkflow(scope).run({
-    input: { production_run_id: runId, template_names: templateNames },
+    input: dispatchedIds.length
+      ? { production_run_id: runId, template_ids: dispatchedIds }
+      : { production_run_id: runId, template_names: templateNames },
   })
 
   const designName = await getDesignName(scope, run.design_id)
@@ -708,7 +732,9 @@ async function handleSendRun(
       admin_name: admin.name,
       design_name: designName,
       partner_id: run.partner_id ?? null,
-      template_names: templateNames,
+      // Record what was actually sent, not the field that happened to be read.
+      template_ids: dispatchedIds.length ? dispatchedIds : null,
+      template_names: dispatchedIds.length ? null : templateNames,
     },
   }
   await whatsapp.sendTextMessage(


### PR DESCRIPTION
Follow-up to #1266. #1262 taught dispatch to resolve templates **by id** and to REFUSE a name matching more than one row; #1265 added `dispatched_template_ids` as the record of what a run actually went out with. Both landed on the workflow and the routes — the two human-facing callers were never moved across, so they still speak the language the workflow now rejects.

### Admin dispatch drawer
- Selection was keyed by template **name**. The two prod "Stitching" rows (Pre Production vs Production) shared one toggle and one React key, and whichever the admin picked went out as an ambiguous name that dispatch rejects — with no way to say which was meant. Selection is now keyed by id and sent as `template_ids`; a name more than one template answers to is labelled with its category, so the choice is visible.
- Preselection read `dispatch_template_names` — approval-time **intent**, null on most runs (that is the whole of #1265). It now seeds from `dispatched_template_ids`, and falls back to intent only for names identifying exactly one template.

### WhatsApp `send run <id>`
Read the same intent field and passed it straight through, so for any run without approval-time intent it dispatched an empty list and got back *"No task templates selected"*. Now prefers `dispatched_template_ids`, falls back to unambiguous intent names, and when a run has neither, says so and points at the admin drawer instead of failing with a validation error over WhatsApp.

The backend already accepted ids everywhere — this is the client half that #1262 left behind.

### Test gap
The suites had never been run against the #1265 work. Running them:

- **New:** `dispatched_template_ids` is now asserted end-to-end — dispatch by id with nothing named at approval, assert the run carries the ids in caller order and the intent field stays null. Nothing covered the new field before.
- **Fixed:** `production-run-complete-yield` → *"should still work without yield fields (backward compatibility)"* asserted a **200** for a completion saying nothing about output. #1262 deliberately refuses that; the spec was never moved with the code, so **it has been red since #1262 merged**. It now asserts the contract that exists: a 400 naming `produced_quantity`, and a run left untouched rather than half-closed. Genuine compatibility (a run with no ordered quantity) is unaffected and still covered.

### Verification
- 20 production-run integration suites, **73 tests green**, both changed tests confirmed by name
- unit **8/8 (78 tests)**
- `tsc --noEmit` → **79**, identical to the `main` baseline

### Still open (not in this PR)
`/approve` and `/designs/:id/production-runs` auto-dispatch children by `dispatch_template_names`. Post-#1262 an ambiguous name throws *after* approval has committed, leaving the run approved but undispatched and 500ing the call. The real fix is recording ids as approval intent — worth its own issue rather than widening this.

🤖 Generated with [Claude Code](https://claude.com/claude-code)