### PR TITLE
fix(production): let an approval say which templates it means, and stop a failed dispatch from erasing it (#1268)

### DIFF
--- a/apps/backend/integration-tests/http/production-runs.spec.ts
+++ b/apps/backend/integration-tests/http/production-runs.spec.ts
@@ -508,5 +508,138 @@ setupSharedTestSuite(() => {
       // The intent field stays null: it is not, and never was, this record.
       expect(run?.dispatch_template_names ?? null).toBeNull()
     })
+
+    /**
+     * #1268 — approval and auto-dispatch are two workflows in one request with
+     * no transaction across them, and approval commits first.
+     *
+     * An approval carrying template IDS dispatches straight through. An
+     * approval whose dispatch fails must still BE an approval: the old code let
+     * the throw escape, so the admin was told approval failed when it had
+     * committed, the run sat approved with no tasks, and `assertCanApprove`
+     * then refused a retry because it was no longer pending_review.
+     */
+    it("approves with template ids and auto-dispatches the children", async () => {
+      const { api } = getSharedTestEnv()
+
+      const unique = `${Date.now()}-appr`
+      const t1 = await api.post(
+        "/admin/task-templates",
+        {
+          name: `prod-approve-a-${unique}`,
+          description: "Approve step A",
+          priority: "medium",
+          estimated_duration: 30,
+          eventable: false,
+          notifiable: false,
+          metadata: { workflow_type: "production_run", step: "a" },
+          category: "Production",
+        },
+        adminHeaders
+      )
+      expect(t1.status).toBe(201)
+      const templateId = t1.data.task_template.id
+      const templateName = t1.data.task_template.name
+
+      const createRunRes = await api.post(
+        "/admin/production-runs",
+        { design_id: designId, quantity: 2 },
+        adminHeaders
+      )
+      expect(createRunRes.status).toBe(201)
+      const parentRunId = createRunRes.data.production_run.id
+
+      const approveRes = await api.post(
+        `/admin/production-runs/${parentRunId}/approve`,
+        {
+          assignments: [
+            {
+              partner_id: partnerId,
+              role: "production",
+              quantity: 2,
+              template_ids: [templateId],
+            },
+          ],
+        },
+        adminHeaders
+      )
+
+      expect(approveRes.status).toBe(200)
+      const childRunId = (approveRes.data.result?.children || [])[0]?.id
+      expect(childRunId).toBeTruthy()
+
+      // The approval carried the ids through, and the route reports what went out.
+      expect(approveRes.data.dispatch?.dispatched).toEqual([childRunId])
+      expect(approveRes.data.dispatch?.failed).toEqual([])
+
+      const runRes = await api.get(
+        `/admin/production-runs/${childRunId}`,
+        adminHeaders
+      )
+      expect(String(runRes.data.production_run.status)).toBe("sent_to_partner")
+      expect(runRes.data.production_run.dispatch_template_ids).toEqual([templateId])
+      // And what it was dispatched with was recorded (#1265).
+      expect(runRes.data.production_run.dispatched_template_ids).toEqual([templateId])
+      const titles = (runRes.data.tasks || []).map((t: any) => t.title)
+      expect(titles).toContain(templateName)
+    })
+
+    it("keeps the approval when the auto-dispatch fails, and says which run failed", async () => {
+      const { api } = getSharedTestEnv()
+
+      const createRunRes = await api.post(
+        "/admin/production-runs",
+        { design_id: designId, quantity: 2 },
+        adminHeaders
+      )
+      expect(createRunRes.status).toBe(201)
+      const parentRunId = createRunRes.data.production_run.id
+
+      // A template id that does not exist — dispatch refuses it outright, which
+      // is precisely the class of failure that used to 500 the approval.
+      const approveRes = await api.post(
+        `/admin/production-runs/${parentRunId}/approve`,
+        {
+          assignments: [
+            {
+              partner_id: partnerId,
+              role: "production",
+              quantity: 2,
+              template_ids: ["tpl_does_not_exist_01K"],
+            },
+          ],
+        },
+        adminHeaders
+      )
+
+      // The approval succeeded, and says so.
+      expect(approveRes.status).toBe(200)
+      const childRunId = (approveRes.data.result?.children || [])[0]?.id
+      expect(childRunId).toBeTruthy()
+
+      expect(approveRes.data.dispatch?.dispatched).toEqual([])
+      expect(approveRes.data.dispatch?.failed).toHaveLength(1)
+      expect(approveRes.data.dispatch?.failed[0].production_run_id).toBe(childRunId)
+      expect(String(approveRes.data.dispatch?.failed[0].message)).toContain(
+        "tpl_does_not_exist_01K"
+      )
+
+      // The run is approved and undispatched — recoverable through the normal
+      // dispatch drawer, rather than a run nobody can act on.
+      const parentRes = await api.get(
+        `/admin/production-runs/${parentRunId}`,
+        adminHeaders
+      )
+      expect(String(parentRes.data.production_run.status)).toBe("approved")
+
+      const childRes = await api.get(
+        `/admin/production-runs/${childRunId}`,
+        adminHeaders
+      )
+      expect(String(childRes.data.production_run.status)).toBe("approved")
+      expect(
+        childRes.data.production_run.dispatched_template_ids ?? null
+      ).toBeNull()
+    })
   })
 })

--- a/apps/backend/src/admin/hooks/api/production-runs.ts
+++ b/apps/backend/src/admin/hooks/api/production-runs.ts
@@ -23,6 +23,8 @@ export type AdminCreateDesignProductionRunPayload = {
     role?: string
     quantity: number
     order?: number
+    /** #1268 — preferred; a name may match two templates and become undispatchable. */
+    template_ids?: string[]
     template_names?: string[]
   }>
 }
@@ -245,6 +247,8 @@ export type AdminApproveProductionRunPayload = {
     role?: string
     quantity?: number
     order?: number
+    /** #1268 — preferred; a name may match two templates and become undispatchable. */
+    template_ids?: string[]
     template_names?: string[]
   }>
 }

--- a/apps/backend/src/admin/routes/production-runs/[id]/@approve/page.tsx
+++ b/apps/backend/src/admin/routes/production-runs/[id]/@approve/page.tsx
@@ -29,6 +29,7 @@ const assignmentSchema = z.object({
   quantity: z.coerce.number().positive("Quantity must be > 0"),
   order: z.coerce.number().int().positive().optional(),
   template_names: z.array(z.string()).optional(),
+  template_ids: z.array(z.string()).optional(),
 })
 
 const approveSchema = z.object({
@@ -43,6 +44,7 @@ type Assignment = {
   quantity: number
   order?: number
   template_names?: string[]
+  template_ids?: string[]
 }
 
 const MODAL_ID = "approve-assignments"
@@ -58,6 +60,18 @@ const AssignmentsModal = ({
 }) => {
   const { setIsOpen } = useStackedModal()
   const [local, setLocal] = useState<Assignment[]>([])
+
+  /** Names more than one template answers to — these must show their category. */
+  const ambiguousNames = useMemo(() => {
+    const counts = new Map<string, number>()
+    for (const t of templatesToShow || []) {
+      const name = String((t as any)?.name || "")
+      counts.set(name, (counts.get(name) ?? 0) + 1)
+    }
+    return new Set(
+      [...counts.entries()].filter(([, n]) => n > 1).map(([name]) => name)
+    )
+  }, [templatesToShow])
 
   const currentAssignments: Assignment[] = form.watch("assignments") || []
 
@@ -75,7 +89,7 @@ const AssignmentsModal = ({
   const addAssignment = () => {
     setLocal((prev) => [
       ...prev,
-      { partner_id: "", role: "", quantity: 1, order: undefined, template_names: [] },
+      { partner_id: "", role: "", quantity: 1, order: undefined, template_ids: [] },
     ])
   }
 
@@ -89,15 +103,21 @@ const AssignmentsModal = ({
     )
   }
 
-  const toggleTemplate = (idx: number, name: string) => {
+  /**
+   * Keyed by id, not name (#1268). Two templates can share a name — different
+   * process steps wearing one label (#1261) — so a name-keyed toggle merged
+   * them into one control and then recorded an intent dispatch REFUSES, leaving
+   * the run approved and undispatchable.
+   */
+  const toggleTemplate = (idx: number, id: string) => {
     setLocal((prev) =>
       prev.map((a, i) => {
         if (i !== idx) return a
-        const current = a.template_names || []
-        const next = current.includes(name)
-          ? current.filter((n) => n !== name)
-          : [...current, name]
-        return { ...a, template_names: next }
+        const current = a.template_ids || []
+        const next = current.includes(id)
+          ? current.filter((t) => t !== id)
+          : [...current, id]
+        return { ...a, template_ids: next }
       })
     )
   }
@@ -201,16 +221,22 @@ const AssignmentsModal = ({
                   </Text>
                   <div className="flex flex-wrap gap-2">
                     {templatesToShow.map((tpl: any) => {
+                      const id = String(tpl.id)
                       const name = String(tpl.name)
-                      const selected = (assignment.template_names || []).includes(name)
+                      const selected = (assignment.template_ids || []).includes(id)
+                      // Without the category these are indistinguishable, and
+                      // they are different process steps (#1261).
+                      const label = ambiguousNames.has(name)
+                        ? `${name} — ${tpl.category?.name || "uncategorised"}`
+                        : name
                       return (
                         <button
-                          key={name}
+                          key={id}
                           type="button"
                           className="rounded-md border px-3 py-1.5 text-sm"
-                          onClick={() => toggleTemplate(idx, name)}
+                          onClick={() => toggleTemplate(idx, id)}
                         >
-                          <Badge color={selected ? "green" : "grey"}>{name}</Badge>
+                          <Badge color={selected ? "green" : "grey"}>{label}</Badge>
                         </button>
                       )
                     })}

--- a/apps/backend/src/api/admin/designs/[id]/production-runs/route.ts
+++ b/apps/backend/src/api/admin/designs/[id]/production-runs/route.ts
@@ -99,7 +99,7 @@ import { ContainerRegistrationKeys, MedusaError } from "@medusajs/framework/util
 
 import { createProductionRunWorkflow } from "../../../../../workflows/production-runs/create-production-run"
 import { approveProductionRunWorkflow } from "../../../../../workflows/production-runs/approve-production-run"
-import { sendProductionRunToProductionWorkflow } from "../../../../../workflows/production-runs/send-production-run-to-production"
+import { autoDispatchApprovedChildren } from "../../../production-runs/auto-dispatch-approved-children"
 
 import type { AdminCreateDesignProductionRunReq } from "./validators"
 
@@ -210,30 +210,16 @@ export const POST = async (
     },
   })
 
-  // For each approved child that has dispatch_template_names,
-  // trigger sendProductionRunToProductionWorkflow to actually create tasks.
-  // If any child has cross-run ordering (depends_on_run_ids), skip auto-dispatch
-  // entirely — the admin controls dispatch sequencing via start-dispatch/resume-dispatch,
-  // and the task subscriber handles cascading dispatch when dependencies complete.
-  const children = approved?.children || []
-  const hasOrdering = children.some((c: any) => c.depends_on_run_ids?.length)
-
-  if (!hasOrdering) {
-    for (const child of children) {
-      const templateNames = (child as any)?.dispatch_template_names as string[] | undefined
-      if (!templateNames?.length) continue
-
-      await sendProductionRunToProductionWorkflow(req.scope).run({
-        input: {
-          production_run_id: (child as any).id,
-          template_names: templateNames,
-        },
-      })
-    }
-  }
+  // See `autoDispatchApprovedChildren` — a dispatch failure is reported, not
+  // thrown, because the approval above has already committed (#1268).
+  const dispatch = await autoDispatchApprovedChildren(
+    req.scope,
+    (approved?.children || []) as any
+  )
 
   return res.status(201).json({
     production_run: approved?.parent || createdRun,
     children: approved?.children || [],
+    dispatch,
   })
 }

--- a/apps/backend/src/api/admin/designs/[id]/production-runs/validators.ts
+++ b/apps/backend/src/api/admin/designs/[id]/production-runs/validators.ts
@@ -10,6 +10,8 @@ const ProductionAssignmentSchema = z.object({
   // templates are picked — `.optional()` alone rejected that with
   // "Field is required" and never let the request reach the workflow.
   template_names: z.array(z.string()).nullish(),
+  /** #1268 — the preferred, unambiguous form. See production-runs/validators.ts. */
+  template_ids: z.array(z.string()).nullish(),
 })
 
 export const AdminCreateDesignProductionRunSchema = z.object({

--- a/apps/backend/src/api/admin/production-runs/[id]/approve/route.ts
+++ b/apps/backend/src/api/admin/production-runs/[id]/approve/route.ts
@@ -63,7 +63,7 @@
 import { MedusaRequest, MedusaResponse } from "@medusajs/framework/http"
 
 import { approveProductionRunWorkflow } from "../../../../../workflows/production-runs/approve-production-run"
-import { sendProductionRunToProductionWorkflow } from "../../../../../workflows/production-runs/send-production-run-to-production"
+import { autoDispatchApprovedChildren } from "../../auto-dispatch-approved-children"
 import type { AdminApproveProductionRunReq } from "../../validators"
 
 export const POST = async (
@@ -80,27 +80,14 @@ export const POST = async (
     },
   })
 
-  // For each approved child that has dispatch_template_names,
-  // trigger sendProductionRunToProductionWorkflow to actually create tasks.
-  // If any child has cross-run ordering (depends_on_run_ids), skip auto-dispatch
-  // entirely — the admin controls dispatch sequencing via start-dispatch/resume-dispatch,
-  // and the task subscriber handles cascading dispatch when dependencies complete.
-  const children = result?.children || []
-  const hasOrdering = children.some((c: any) => c.depends_on_run_ids?.length)
+  // Dispatch each approved child that recorded a template selection, by id
+  // where the approval gave one. A dispatch failure here does NOT fail the
+  // approval — it already committed, and reporting it as a failure left runs
+  // approved, undispatched and un-retryable (#1268).
+  const dispatch = await autoDispatchApprovedChildren(
+    req.scope,
+    (result?.children || []) as any
+  )
 
-  if (!hasOrdering) {
-    for (const child of children) {
-      const templateNames = (child as any)?.dispatch_template_names as string[] | undefined
-      if (!templateNames?.length) continue
-
-      await sendProductionRunToProductionWorkflow(req.scope).run({
-        input: {
-          production_run_id: (child as any).id,
-          template_names: templateNames,
-        },
-      })
-    }
-  }
-
-  return res.status(200).json({ result })
+  return res.status(200).json({ result, dispatch })
 }

--- a/apps/backend/src/api/admin/production-runs/__tests__/auto-dispatch-approved-children.unit.spec.ts
+++ b/apps/backend/src/api/admin/production-runs/__tests__/auto-dispatch-approved-children.unit.spec.ts
@@ -1,0 +1,144 @@
+/**
+ * #1268. Approval and dispatch are two workflows in one request with no
+ * transaction across them, and approval commits first. These cover the two
+ * things that must hold once it has: dispatch acts on identity rather than a
+ * label, and a dispatch failure never retroactively claims the approval failed.
+ */
+const runMock = jest.fn()
+
+jest.mock(
+  "../../../../workflows/production-runs/send-production-run-to-production",
+  () => ({
+    sendProductionRunToProductionWorkflow: () => ({ run: runMock }),
+  })
+)
+
+import {
+  autoDispatchApprovedChildren,
+  hasCrossRunOrdering,
+  selectDispatchInput,
+} from "../auto-dispatch-approved-children"
+
+describe("selectDispatchInput", () => {
+  it("prefers ids over names — a name is not an identity (#1261)", () => {
+    expect(
+      selectDispatchInput({
+        id: "run_1",
+        dispatch_template_ids: ["tpl_prod"],
+        dispatch_template_names: ["Stitching"],
+      })
+    ).toEqual({ template_ids: ["tpl_prod"] })
+  })
+
+  it("falls back to names so approvals recorded before ids still dispatch", () => {
+    expect(
+      selectDispatchInput({
+        id: "run_1",
+        dispatch_template_names: ["Cutting"],
+      })
+    ).toEqual({ template_names: ["Cutting"] })
+  })
+
+  it("treats an empty or junk selection as no selection, not as an empty dispatch", () => {
+    expect(
+      selectDispatchInput({
+        id: "run_1",
+        dispatch_template_ids: [],
+        dispatch_template_names: null,
+      })
+    ).toBeNull()
+
+    expect(
+      selectDispatchInput({
+        id: "run_1",
+        dispatch_template_ids: ["", null, undefined] as any,
+        dispatch_template_names: ["  "].slice(0, 0),
+      })
+    ).toBeNull()
+  })
+})
+
+describe("hasCrossRunOrdering", () => {
+  it("is true when any child depends on another run", () => {
+    expect(
+      hasCrossRunOrdering([
+        { id: "a" },
+        { id: "b", depends_on_run_ids: ["a"] },
+      ])
+    ).toBe(true)
+  })
+
+  it("is false for an empty dependency list", () => {
+    expect(hasCrossRunOrdering([{ id: "a", depends_on_run_ids: [] }])).toBe(false)
+  })
+})
+
+describe("autoDispatchApprovedChildren", () => {
+  beforeEach(() => {
+    runMock.mockReset()
+    runMock.mockResolvedValue({ result: {} })
+  })
+
+  it("dispatches by id and reports each run that went out", async () => {
+    const report = await autoDispatchApprovedChildren({} as any, [
+      { id: "run_1", dispatch_template_ids: ["tpl_a", "tpl_b"] },
+    ])
+
+    expect(runMock).toHaveBeenCalledWith({
+      input: { production_run_id: "run_1", template_ids: ["tpl_a", "tpl_b"] },
+    })
+    expect(report.dispatched).toEqual(["run_1"])
+    expect(report.failed).toEqual([])
+  })
+
+  /**
+   * The whole point. Before this, the throw escaped the route: the admin was
+   * told the approval failed when it had committed, the run was left approved
+   * with no tasks, and `assertCanApprove` then refused a retry because the run
+   * was no longer pending_review — stuck.
+   */
+  it("does not throw when a dispatch fails, and names the run and the reason", async () => {
+    runMock
+      .mockRejectedValueOnce(
+        new Error(
+          'Ambiguous task template name(s): "Stitching" matches 2 templates'
+        )
+      )
+      .mockResolvedValueOnce({ result: {} })
+
+    const report = await autoDispatchApprovedChildren({} as any, [
+      { id: "run_bad", dispatch_template_names: ["Stitching"] },
+      { id: "run_good", dispatch_template_ids: ["tpl_a"] },
+    ])
+
+    expect(report.failed).toEqual([
+      {
+        production_run_id: "run_bad",
+        message: expect.stringContaining("Ambiguous task template name(s)"),
+      },
+    ])
+    // A failure must not stop the children after it from going out.
+    expect(report.dispatched).toEqual(["run_good"])
+  })
+
+  it("skips a child that recorded no selection rather than dispatching nothing", async () => {
+    const report = await autoDispatchApprovedChildren({} as any, [
+      { id: "run_1" },
+    ])
+
+    expect(runMock).not.toHaveBeenCalled()
+    expect(report.skipped).toEqual(["run_1"])
+    expect(report.failed).toEqual([])
+  })
+
+  it("dispatches nothing when the batch is ordered — the admin sequences those", async () => {
+    const report = await autoDispatchApprovedChildren({} as any, [
+      { id: "run_1", dispatch_template_ids: ["tpl_a"] },
+      { id: "run_2", dispatch_template_ids: ["tpl_b"], depends_on_run_ids: ["run_1"] },
+    ])
+
+    expect(runMock).not.toHaveBeenCalled()
+    expect(report.deferred_for_ordering).toBe(true)
+    expect(report.dispatched).toEqual([])
+  })
+})

--- a/apps/backend/src/api/admin/production-runs/auto-dispatch-approved-children.ts
+++ b/apps/backend/src/api/admin/production-runs/auto-dispatch-approved-children.ts
@@ -1,0 +1,129 @@
+import { sendProductionRunToProductionWorkflow } from "../../../workflows/production-runs/send-production-run-to-production"
+
+/**
+ * Auto-dispatch of the children an approval just created (#1268).
+ *
+ * Approval and dispatch are two workflows in one request and there is no
+ * transaction across them. Approval commits first: parent approved, children
+ * created. The dispatch that follows can fail — an ambiguous template name is a
+ * hard failure since #1262, and task creation or partner linking can fail on
+ * their own — and when it did, the throw escaped the route.
+ *
+ * That produced the worst available outcome. The admin saw a 500 saying the
+ * approval failed; it had not. The run was approved, its children existed, and
+ * NOTHING had been dispatched — no tasks, no partner notification. Worse, the
+ * approval could not be retried: `assertCanApprove` only permits draft and
+ * pending_review, and the parent was now approved. The run was stuck in exactly
+ * the parked shape that had to be re-dispatched by hand on prod.
+ *
+ * So dispatch failures are collected, not thrown. The approval is real and the
+ * response says so, alongside exactly which children went out and which did not
+ * and why. Recovery is then the ordinary dispatch drawer, per child.
+ */
+
+export type AutoDispatchChild = {
+  id: string
+  dispatch_template_ids?: string[] | null
+  dispatch_template_names?: string[] | null
+  depends_on_run_ids?: string[] | null
+}
+
+export type DispatchSelection =
+  | { template_ids: string[] }
+  | { template_names: string[] }
+  | null
+
+export type AutoDispatchReport = {
+  /** Runs that dispatched cleanly. */
+  dispatched: string[]
+  /** Runs with no template selection recorded — nothing to dispatch, not a failure. */
+  skipped: string[]
+  /** Runs whose dispatch threw. The approval still stands. */
+  failed: Array<{ production_run_id: string; message: string }>
+  /**
+   * True when auto-dispatch was not attempted at all because the batch has
+   * cross-run ordering — the admin sequences those by hand.
+   */
+  deferred_for_ordering: boolean
+}
+
+const clean = (values: unknown): string[] =>
+  (Array.isArray(values) ? values : []).filter(
+    (v): v is string => typeof v === "string" && v.length > 0
+  )
+
+/**
+ * What to dispatch a child with, preferring identity over label.
+ *
+ * Ids win outright: a name may match two templates that are different process
+ * steps sharing one label (#1261), and dispatch refuses such a name rather than
+ * guessing. Returns null when the approval named nothing — that run is meant to
+ * be dispatched later, by hand.
+ */
+export const selectDispatchInput = (
+  child: AutoDispatchChild
+): DispatchSelection => {
+  const ids = clean(child?.dispatch_template_ids)
+  if (ids.length) {
+    return { template_ids: ids }
+  }
+
+  const names = clean(child?.dispatch_template_names)
+  if (names.length) {
+    return { template_names: names }
+  }
+
+  return null
+}
+
+/**
+ * Cross-run ordering means the admin drives dispatch sequencing themselves via
+ * start-dispatch/resume-dispatch, and the task subscriber cascades the rest as
+ * dependencies complete. Auto-dispatching here would start work out of order.
+ */
+export const hasCrossRunOrdering = (children: AutoDispatchChild[]): boolean =>
+  (children || []).some((c) => clean(c?.depends_on_run_ids).length > 0)
+
+export const autoDispatchApprovedChildren = async (
+  scope: any,
+  children: AutoDispatchChild[]
+): Promise<AutoDispatchReport> => {
+  const report: AutoDispatchReport = {
+    dispatched: [],
+    skipped: [],
+    failed: [],
+    deferred_for_ordering: false,
+  }
+
+  const list = children || []
+
+  if (hasCrossRunOrdering(list)) {
+    report.deferred_for_ordering = true
+    return report
+  }
+
+  for (const child of list) {
+    const selection = selectDispatchInput(child)
+
+    if (!selection) {
+      report.skipped.push(child.id)
+      continue
+    }
+
+    try {
+      await sendProductionRunToProductionWorkflow(scope).run({
+        input: { production_run_id: child.id, ...selection },
+      })
+      report.dispatched.push(child.id)
+    } catch (e: any) {
+      // The approval stands. Carry the reason back so the admin knows what to
+      // fix — an ambiguous name error names the colliding ids to retry with.
+      report.failed.push({
+        production_run_id: child.id,
+        message: String(e?.message || e || "Dispatch failed"),
+      })
+    }
+  }
+
+  return report
+}

--- a/apps/backend/src/api/admin/production-runs/validators.ts
+++ b/apps/backend/src/api/admin/production-runs/validators.ts
@@ -13,6 +13,13 @@ const AssignmentSchema = z.object({
   // fired. With null/empty the auto-dispatch loop in the route handler
   // skips dispatch — the run lands in `approved`/idle.
   template_names: z.array(z.string()).nullish(),
+  /**
+   * #1268 — the same selection by id, and the preferred form. A name may match
+   * two templates, and dispatch refuses such a name, so an approval that
+   * recorded only names can become impossible to carry out. Same `.nullish()`
+   * tolerance as the names, for the same reason.
+   */
+  template_ids: z.array(z.string()).nullish(),
 })
 
 export const AdminCreateProductionRunReq = z.object({

--- a/apps/backend/src/modules/production_runs/migrations/Migration20260812140000.ts
+++ b/apps/backend/src/modules/production_runs/migrations/Migration20260812140000.ts
@@ -1,0 +1,25 @@
+import { Migration } from "@medusajs/framework/mikro-orm/migrations";
+
+/**
+ * #1268 — let an approval say WHICH templates it meant, by id.
+ *
+ * `dispatch_template_names` records the approver's intent as labels. Since #1261
+ * a label may not identify anything — prod carried two "Stitching" rows differing
+ * only by category — and dispatch now refuses an ambiguous name outright, which
+ * means an approval recorded that way can no longer be carried out at all.
+ *
+ * Nullable, no default, no backfill. An existing approval genuinely recorded
+ * names and nothing else; inventing ids for it would mean guessing exactly the
+ * thing #1261 established we must not guess.
+ */
+export class Migration20260812140000 extends Migration {
+
+  override async up(): Promise<void> {
+    this.addSql(`alter table if exists "production_runs" add column if not exists "dispatch_template_ids" jsonb null;`);
+  }
+
+  override async down(): Promise<void> {
+    this.addSql(`alter table if exists "production_runs" drop column if exists "dispatch_template_ids";`);
+  }
+
+}

--- a/apps/backend/src/modules/production_runs/models/production-run.ts
+++ b/apps/backend/src/modules/production_runs/models/production-run.ts
@@ -80,6 +80,18 @@ const ProductionRun = model.define("production_runs", {
    */
   dispatch_template_names: model.json().nullable(),
   /**
+   * The same INTENT, said properly (#1268). `dispatch_template_names` records a
+   * label, and a label is not an identity: two templates can share one (#1261),
+   * in which case dispatch refuses the name outright and the approval it came
+   * from can no longer be carried out. Ids survive the
+   * `deduplicate-task-template-names` job renaming a row, too.
+   *
+   * Preferred over the names wherever both are present. Still INTENT — what an
+   * approver asked for, not what happened; `dispatched_template_ids` is the
+   * record of what actually went out.
+   */
+  dispatch_template_ids: model.json().nullable(),
+  /**
    * RECORD, written when the run is actually dispatched — the ids of the task
    * templates that were resolved and instantiated. Written by
    * `send-production-run-to-production`, which every dispatch path goes through.

--- a/apps/backend/src/workflows/production-runs/approve-production-run.ts
+++ b/apps/backend/src/workflows/production-runs/approve-production-run.ts
@@ -24,7 +24,14 @@ export type ProductionRunAssignment = {
   role?: string | null
   quantity?: number
   order?: number
+  /**
+   * Templates BY NAME. Kept because existing callers use it, but since #1261 a
+   * name may identify nothing — dispatch REFUSES one that matches more than one
+   * template, so an approval recorded this way can become uncarryable.
+   */
   template_names?: string[]
+  /** Templates BY ID — preferred. Wins over `template_names` when both are sent. */
+  template_ids?: string[]
 }
 
 export type ApproveProductionRunInput = {
@@ -120,7 +127,10 @@ const approveProductionRunStep = createStep(
         captured_at: (original as any).captured_at,
         status: "approved" as any,
         run_type: (original as any).run_type ?? "production",
+        // Both are recorded as sent. The ids are what dispatch should act on;
+        // the names stay so an older reader still sees what was asked for.
         dispatch_template_names: a.template_names?.length ? a.template_names : null,
+        dispatch_template_ids: a.template_ids?.length ? a.template_ids : null,
         metadata: Object.keys(inheritedMetadata).length ? inheritedMetadata : null,
       }
     })


### PR DESCRIPTION
Closes #1268. Follow-up to #1266 / #1267 — the last of the #1261/#1262/#1265 thread.

## The bug

Approval and auto-dispatch are two workflows in one request with **no transaction across them**, and approval commits first. When the dispatch that follows threw, the throw escaped the route, producing the worst outcome available:

- the admin was told the approval **failed** — it had committed;
- the run sat `approved`, children created, **no tasks, no partner notification**;
- and it could not be retried, because `assertCanApprove` only permits `draft`/`pending_review` and the parent was now `approved`.

A run stuck in exactly the parked shape that had to be re-dispatched by hand on prod.

#1262 made this reachable by design — an ambiguous template name became a hard failure — but the exposure isn't really about ambiguity. **Any** dispatch failure produced the same stuck run and the same misleading 500.

## Two halves

**Say it by id.** `dispatch_template_ids` records approval intent the way #1265 records dispatch: as identity, not label. A name may match two templates that are different process steps sharing a label (#1261), and dispatch refuses such a name — so an approval recorded as names could become impossible to carry out. Names are still written and still honoured as a fallback. The approve modal's picker was keyed by **name**, merging those two templates into one control; it's now keyed by id and shows the category on any colliding name — the same fix #1267 applied to the dispatch drawer.

**Report the failure, don't throw it.** Both approve paths now share `autoDispatchApprovedChildren`, returning a per-child `dispatch` report:

```jsonc
{ "dispatched": ["run_a"],
  "skipped":    ["run_b"],                  // nothing selected — not a failure
  "failed":     [{ "production_run_id": "run_c", "message": "…" }],
  "deferred_for_ordering": false }           // ordered batches stay admin-sequenced
```

The approval is real and the response says so, alongside which children went out and which didn't and why. A failed child no longer stops the ones behind it; recovery is the ordinary dispatch drawer.

Migration is additive, nullable, no backfill — an existing approval genuinely recorded names and nothing else, and inventing ids would mean guessing precisely what #1261 established we must not guess.

## Verification

- **24** production-run/dispatch integration suites green across two batches. The first runner OOM'd after 14 suites passed — the known many-files-per-process limit, not a test failure — so the remainder ran as a second batch.
- New integration coverage both ways: approve-with-ids auto-dispatches and records `dispatched_template_ids`; **and a failing dispatch leaves a real approval**, a named `failed` entry, and a recoverable `approved` run.
- Unit **23/23 suites, 322 tests**, including 9 new for the helper.
- `tsc --noEmit` → **79**, identical to `main`, same pre-existing `@approve` resolver error.
- One red unit suite (`seed-additional-email-templates`) fails **identically on clean main** — pre-existing, unrelated.

🤖 Generated with [Claude Code](https://claude.com/claude-code)