### PR TITLE
fix(designs): stop stripping the template selection for auto-populated assignments

### DIFF
--- a/apps/backend/integration-tests/http/design-production-runs-multi-partner.spec.ts
+++ b/apps/backend/integration-tests/http/design-production-runs-multi-partner.spec.ts
@@ -199,5 +199,104 @@ setupSharedTestSuite(() => {
       expect(Number(c2.quantity)).toBe(2)
       expect(c2.role).toBe("stitching")
     })
+
+    /**
+     * The route builds assignments itself from the design's linked partners
+     * when the caller sends none, and has always read a top-level template
+     * selection for them — but the schema never declared the field, so zod
+     * stripped it and the auto-populated assignments got `[]` every time.
+     * Those runs were created approved and then silently never dispatched.
+     *
+     * Ids, not names: a name may match two templates and be refused at
+     * dispatch (#1261).
+     */
+    it("dispatches auto-populated assignments with the top-level template selection", async () => {
+      const { api } = getSharedTestEnv()
+
+      const unique = Date.now()
+
+      const partnerRes = await api.post(
+        "/admin/partners",
+        {
+          partner: {
+            name: `MP Auto Partner ${unique}`,
+            handle: `mp-auto-partner-${unique}`,
+          },
+          admin: {
+            email: `mp-auto-partner-admin-${unique}@jyt.test`,
+            first_name: "MP",
+            last_name: "Auto",
+          },
+        },
+        adminHeaders
+      )
+      expect(partnerRes.status).toBe(201)
+      const partnerId = partnerRes.data.partner.id
+
+      const templateRes = await api.post(
+        "/admin/task-templates",
+        {
+          name: `mp-auto-step-${unique}`,
+          description: "Auto-populate step",
+          priority: "medium",
+          estimated_duration: 30,
+          eventable: false,
+          notifiable: false,
+          metadata: { workflow_type: "production_run" },
+          category: "Production",
+        },
+        adminHeaders
+      )
+      expect(templateRes.status).toBe(201)
+      const templateId = templateRes.data.task_template.id
+
+      const designRes = await api.post(
+        "/admin/designs",
+        {
+          name: `MP Auto Design ${unique}`,
+          description: "Design with a linked partner and no explicit assignments",
+          design_type: "Original",
+          status: "Commerce_Ready",
+          priority: "Medium",
+        },
+        adminHeaders
+      )
+      expect(designRes.status).toBe(201)
+      const designId = designRes.data.design.id
+
+      // Link the partner to the design so the route can auto-populate from it.
+      const linkRes = await api.post(
+        `/admin/designs/${designId}/partner`,
+        { partnerIds: [partnerId] },
+        adminHeaders
+      )
+      expect([200, 201]).toContain(linkRes.status)
+
+      // No `assignments` — the route builds them from the linked partner, and
+      // the top-level selection is what those assignments must carry.
+      const createRes = await api.post(
+        `/admin/designs/${designId}/production-runs`,
+        { quantity: 5, template_ids: [templateId] },
+        adminHeaders
+      )
+
+      expect(createRes.status).toBe(201)
+      const children = createRes.data.children || []
+      expect(children.length).toBe(1)
+      const childRunId = children[0].id
+
+      // Before this fix the selection was stripped, so this reported nothing
+      // dispatched and the run sat approved forever.
+      expect(createRes.data.dispatch?.dispatched).toEqual([childRunId])
+      expect(createRes.data.dispatch?.failed).toEqual([])
+
+      const runRes = await api.get(
+        `/admin/production-runs/${childRunId}`,
+        adminHeaders
+      )
+      expect(String(runRes.data.production_run.status)).toBe("sent_to_partner")
+      expect(runRes.data.production_run.dispatch_template_ids).toEqual([templateId])
+      expect(runRes.data.production_run.dispatched_template_ids).toEqual([templateId])
+    })
   })
 })

--- a/apps/backend/src/api/admin/designs/[id]/production-runs/route.ts
+++ b/apps/backend/src/api/admin/designs/[id]/production-runs/route.ts
@@ -21,8 +21,15 @@
  *                    assignments?: Array<{
  *                      partner_id?: string | null,
  *                      quantity: number,
+ *                      template_ids?: string[],
+ *                      template_names?: string[],
  *                      metadata?: Record<string, any>
  *                    }>,
+ *                    // Used ONLY for assignments this route builds itself from
+ *                    // the design's linked partners; ignored when `assignments`
+ *                    // are supplied.
+ *                    template_ids?: string[],
+ *                    template_names?: string[],
  *                    metadata?: Record<string, any>
  *                  }
  * @param res - MedusaResponse used to send the 201 JSON response.
@@ -145,6 +152,10 @@ export const POST = async (
         quantity: idx === linkedPartners.length - 1
           ? Number(body.quantity) - perPartner * (linkedPartners.length - 1)
           : perPartner,
+        // Ids where given — a name may match two templates and be refused at
+        // dispatch (#1261). Both are passed through; the approval records
+        // whichever it was told, and dispatch prefers the ids.
+        template_ids: body.template_ids || [],
         template_names: body.template_names || [],
       }))
     }

--- a/apps/backend/src/api/admin/designs/[id]/production-runs/validators.ts
+++ b/apps/backend/src/api/admin/designs/[id]/production-runs/validators.ts
@@ -18,6 +18,21 @@ export const AdminCreateDesignProductionRunSchema = z.object({
   quantity: z.number().positive().optional(),
   run_type: z.enum(["production", "sample"]).optional(),
   assignments: z.array(ProductionAssignmentSchema).min(1).optional(),
+  /**
+   * The template selection to give assignments this route builds ITSELF, when
+   * the caller sent none and the design's linked partners are used instead.
+   *
+   * The route has always read `body.template_names` for that branch, but the
+   * schema never declared it, so zod stripped it before the handler ever saw
+   * it — the auto-populated assignments got `[]` every time and those runs were
+   * created approved and then never dispatched. Declaring the fields is the
+   * whole fix; the branch already does the right thing with them.
+   *
+   * Ignored when `assignments` are given — those carry their own selection.
+   * Ids preferred, for the reasons in production-runs/validators.ts.
+   */
+  template_ids: z.array(z.string()).nullish(),
+  template_names: z.array(z.string()).nullish(),
 })
 
 export type AdminCreateDesignProductionRunReq = z.infer<


### PR DESCRIPTION
The last loose end from the #1261/#1262/#1265/#1268 thread, flagged in #1269's handoff and deliberately left out of that PR.

## The bug

`/admin/designs/:id/production-runs` builds assignments itself from the design's linked partners when the caller sends none, and has always read a top-level `body.template_names` for them:

```ts
assignments = linkedPartners.map(...( { template_names: body.template_names || [] } ))
```

But `AdminCreateDesignProductionRunSchema` never declared `template_names`, and zod strips unknown keys. So `body.template_names` was **always `undefined`**, the auto-populated assignments got `[]` every time, and the runs they created were approved and then **silently never dispatched**. The branch has never worked.

## The fix

Declaring the fields is the whole fix — the branch already does the right thing with them. `template_ids` is added alongside and preferred, since a name may match two templates and be refused at dispatch (#1261). Both pass through; the approval records whichever it was told. Ignored when explicit `assignments` are supplied, as those carry their own selection.

## Verification

- New integration coverage on the path that never worked: link a partner to a design, POST with **no assignments** and a top-level `template_ids`, and assert the route reports the child as `dispatched`, the run reaches `sent_to_partner`, and both `dispatch_template_ids` and `dispatched_template_ids` are set. This test fails on `main`.
- 7 integration suites green, 16 tests.
- `tsc --noEmit` → **79**, identical to `main`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)