### PR TITLE
feat(partner-ui): design pictures + stable loading in orders, run-policy settings, auto-drafted payouts (#1273)

### DIFF
--- a/apps/backend/src/api/partners/validators.ts
+++ b/apps/backend/src/api/partners/validators.ts
@@ -37,4 +37,9 @@ export const partnerUpdateSchema = z.object({
         .nullable()
         .optional(),
     metadata: z.record(z.string(), z.any()).nullable().optional(),
+    // #1228 — the partner pre-agreeing that work re-sent to them after a
+    // dispatch went stale is accepted on their behalf. A typed column, not
+    // metadata: it changes who owns the work, so it must be settable (and
+    // auditable) as a first-class field rather than a loose metadata key.
+    auto_accept_production_runs: z.boolean().optional(),
 })

--- a/apps/backend/src/lib/__tests__/design-thumbnail.unit.spec.ts
+++ b/apps/backend/src/lib/__tests__/design-thumbnail.unit.spec.ts
@@ -1,0 +1,93 @@
+import {
+  resolveDesignThumbnail,
+  resolveMoodboardFirstImage,
+} from "../design-thumbnail"
+
+describe("resolveDesignThumbnail", () => {
+  it("prefers the media file flagged as the thumbnail", () => {
+    expect(
+      resolveDesignThumbnail({
+        media_files: [
+          { url: "https://cdn/first.png" },
+          { url: "https://cdn/flagged.png", isThumbnail: true },
+        ],
+        metadata: { thumbnail: "https://cdn/meta.png" },
+      })
+    ).toBe("https://cdn/flagged.png")
+  })
+
+  it("falls back to metadata.thumbnail when no media file is flagged", () => {
+    expect(
+      resolveDesignThumbnail({
+        media_files: [{ url: "https://cdn/first.png" }],
+        metadata: { thumbnail: "https://cdn/meta.png" },
+      })
+    ).toBe("https://cdn/meta.png")
+  })
+
+  it("falls back to the first usable media file", () => {
+    expect(
+      resolveDesignThumbnail({
+        media_files: [{ url: "  " }, { url: "https://cdn/first.png" }],
+      })
+    ).toBe("https://cdn/first.png")
+  })
+
+  it("falls back to the moodboard's first reference image", () => {
+    expect(
+      resolveDesignThumbnail({
+        media_files: [],
+        moodboard: {
+          elements: [
+            { type: "text", id: "t1" },
+            { type: "image", id: "i1", fileId: "f1" },
+            { type: "image", id: "i2", fileId: "f2" },
+          ],
+          files: {
+            f1: { dataURL: "https://cdn/moodboard-1.png" },
+            f2: { dataURL: "https://cdn/moodboard-2.png" },
+          },
+        },
+      })
+    ).toBe("https://cdn/moodboard-1.png")
+  })
+
+  it("returns null for a design with no pictures anywhere", () => {
+    expect(resolveDesignThumbnail({})).toBeNull()
+    expect(resolveDesignThumbnail(null)).toBeNull()
+  })
+
+  it("skips base64 data URLs unless the caller opts in", () => {
+    const design = {
+      media_files: [{ url: "data:image/png;base64,AAAA" }],
+    }
+    expect(resolveDesignThumbnail(design)).toBeNull()
+    expect(resolveDesignThumbnail(design, { allowDataUrl: true })).toBe(
+      "data:image/png;base64,AAAA"
+    )
+  })
+})
+
+describe("resolveMoodboardFirstImage", () => {
+  it("skips deleted elements and images whose file is missing", () => {
+    expect(
+      resolveMoodboardFirstImage({
+        elements: [
+          { type: "image", fileId: "gone" },
+          { type: "image", fileId: "f1", isDeleted: true },
+          { type: "image", fileId: "f2" },
+        ],
+        files: {
+          f1: { dataURL: "https://cdn/deleted.png" },
+          f2: { dataURL: "https://cdn/kept.png" },
+        },
+      })
+    ).toBe("https://cdn/kept.png")
+  })
+
+  it("returns null for a scene with no files or no elements", () => {
+    expect(resolveMoodboardFirstImage({ elements: [] })).toBeNull()
+    expect(resolveMoodboardFirstImage({ files: {} })).toBeNull()
+    expect(resolveMoodboardFirstImage(null)).toBeNull()
+  })
+})

--- a/apps/backend/src/lib/design-thumbnail.ts
+++ b/apps/backend/src/lib/design-thumbnail.ts
@@ -1,0 +1,108 @@
+// Shared derivation of "the one image that stands for this design".
+//
+// A design carries pictures in three places and no single column names the
+// canonical one:
+//   • `media_files` — the uploaded gallery; an entry may be flagged
+//     `isThumbnail` by the media editor.
+//   • `metadata.thumbnail` — the denormalised copy the media form writes when a
+//     thumbnail is picked (kept in sync by the admin edit-media form).
+//   • `moodboard` — an Excalidraw scene whose image elements reference
+//     `files[fileId].dataURL`; for generated tech-pack scenes that dataURL is a
+//     plain URL (see build-moodboard-scene), not base64.
+//
+// Order of preference: an explicitly flagged media file → the denormalised
+// metadata thumbnail → the first media file → the moodboard's first reference
+// image. Callers that render a LIST (order tables, design tables) pass
+// `allowDataUrl: false` so a base64-inlined moodboard image can never bloat a
+// list payload; a detail surface that already loaded the scene can allow it.
+
+export type DesignMediaFile = {
+  id?: string
+  url?: string | null
+  isThumbnail?: boolean
+}
+
+export type DesignThumbnailSource = {
+  media_files?: DesignMediaFile[] | null
+  moodboard?: Record<string, any> | null
+  metadata?: Record<string, any> | null
+}
+
+const isUsableUrl = (
+  value: unknown,
+  allowDataUrl: boolean
+): value is string => {
+  if (typeof value !== "string") {
+    return false
+  }
+  const url = value.trim()
+  if (!url) {
+    return false
+  }
+  if (url.startsWith("data:")) {
+    return allowDataUrl
+  }
+  return true
+}
+
+/**
+ * The first reference image of an Excalidraw moodboard scene: the earliest
+ * image element (scene order) whose `fileId` resolves to a usable file URL.
+ * Elements deleted on the canvas keep an `isDeleted` marker — skip those.
+ */
+export const resolveMoodboardFirstImage = (
+  moodboard: Record<string, any> | null | undefined,
+  { allowDataUrl = false }: { allowDataUrl?: boolean } = {}
+): string | null => {
+  const elements = moodboard?.elements
+  const files = moodboard?.files
+  if (!Array.isArray(elements) || !files || typeof files !== "object") {
+    return null
+  }
+
+  for (const element of elements) {
+    if (!element || element.type !== "image" || element.isDeleted) {
+      continue
+    }
+    const file = (files as Record<string, any>)[element.fileId]
+    if (isUsableUrl(file?.dataURL, allowDataUrl)) {
+      return String(file.dataURL).trim()
+    }
+  }
+
+  return null
+}
+
+/**
+ * The single image that represents a design, or null when it has none.
+ * Pure — callers supply an already-loaded design row.
+ */
+export const resolveDesignThumbnail = (
+  design: DesignThumbnailSource | null | undefined,
+  { allowDataUrl = false }: { allowDataUrl?: boolean } = {}
+): string | null => {
+  if (!design) {
+    return null
+  }
+
+  const mediaFiles = Array.isArray(design.media_files) ? design.media_files : []
+
+  const flagged = mediaFiles.find(
+    (m) => m?.isThumbnail && isUsableUrl(m?.url, allowDataUrl)
+  )
+  if (flagged) {
+    return String(flagged.url).trim()
+  }
+
+  const fromMetadata = design.metadata?.thumbnail
+  if (isUsableUrl(fromMetadata, allowDataUrl)) {
+    return String(fromMetadata).trim()
+  }
+
+  const firstMedia = mediaFiles.find((m) => isUsableUrl(m?.url, allowDataUrl))
+  if (firstMedia) {
+    return String(firstMedia.url).trim()
+  }
+
+  return resolveMoodboardFirstImage(design.moodboard, { allowDataUrl })
+}

--- a/apps/backend/src/subscribers/auto-draft-payment-submission.ts
+++ b/apps/backend/src/subscribers/auto-draft-payment-submission.ts
@@ -1,0 +1,97 @@
+import { ContainerRegistrationKeys } from "@medusajs/framework/utils"
+import type { SubscriberArgs, SubscriberConfig } from "@medusajs/framework"
+
+import { createPaymentSubmissionWorkflow } from "../workflows/payment_submissions/create-payment-submission"
+import { assessRunPayout } from "../workflows/production-runs/lib/run-payable"
+
+/**
+ * When a production run completes, pre-fill the partner's payment submission.
+ *
+ * Completion is the moment every fact needed to bill for the work exists: the
+ * design, the partner, the ordered quantity, and the cost the partner just
+ * typed into the completion form. Until now the partner had to then go to
+ * Payment Submissions, find that design in a list of everything they've ever
+ * been assigned, re-enter the same amount, and submit — so the money step
+ * lagged the work step by however long that took, or never happened.
+ *
+ * This drafts it for them: one design-sourced item, amount = the run's payable
+ * total, landing as **Draft** — visible, editable, and NOT yet a claim on
+ * anyone. The partner still reviews and submits, so nothing is billed on their
+ * behalf without their say-so. See the `status` / `require_design_status`
+ * options on createPaymentSubmissionWorkflow for why a draft is allowed to skip
+ * the design-status gate that a hand-made submission must pass.
+ *
+ * Deliberately best-effort: a failure here must never look like the completion
+ * failed (completion has already committed by the time this event fires), so
+ * every path logs and returns.
+ */
+export default async function autoDraftPaymentSubmissionHandler({
+  event,
+  container,
+}: SubscriberArgs<{ id?: string; production_run_id?: string }>) {
+  const runId = event.data?.production_run_id || event.data?.id
+  if (!runId) {
+    return
+  }
+
+  const logger = container.resolve(ContainerRegistrationKeys.LOGGER)
+  const productionRunService = container.resolve("production_runs") as any
+
+  let run: any = null
+  try {
+    run = await productionRunService.retrieveProductionRun(runId)
+  } catch {
+    return
+  }
+
+  const payout = assessRunPayout(run)
+  if (!payout.eligible) {
+    logger.info(
+      `[auto-draft-payment-submission] run ${runId}: skipped (${payout.reason})`
+    )
+    return
+  }
+
+  try {
+    const { result } = await createPaymentSubmissionWorkflow(container).run({
+      input: {
+        partner_id: payout.partner_id,
+        design_ids: [payout.design_id],
+        status: "Draft",
+        // The completed run IS the proof of finished work — completion moves
+        // the design to Technical_Review, which the hand-submission gate would
+        // reject.
+        require_design_status: false,
+        notes: `Drafted automatically when production run ${runId} completed. Review the amount and submit when you're ready.`,
+        metadata: {
+          auto_drafted: true,
+          source: "production_run.completed",
+          production_run_id: runId,
+          cost_type: run?.cost_type ?? null,
+          ordered_quantity: run?.quantity ?? null,
+          partner_cost_estimate: run?.partner_cost_estimate ?? null,
+          // Reuse the existing override channel so the amount the partner
+          // entered at completion is what the draft bills, regardless of what
+          // the design's own cost columns say.
+          design_cost_overrides: { [payout.design_id]: payout.amount },
+        },
+      },
+    })
+
+    logger.info(
+      `[auto-draft-payment-submission] run ${runId}: drafted submission ${
+        (result as any)?.submission?.id
+      } for design ${payout.design_id} (${payout.amount})`
+    )
+  } catch (e: any) {
+    // The commonest "failure" is the design already sitting in an open
+    // submission — that's the guard doing its job, not an error worth paging on.
+    logger.info(
+      `[auto-draft-payment-submission] run ${runId}: no draft created — ${e?.message}`
+    )
+  }
+}
+
+export const config: SubscriberConfig = {
+  event: "production_run.completed",
+}

--- a/apps/backend/src/workflows/orders/list-partner-orders.ts
+++ b/apps/backend/src/workflows/orders/list-partner-orders.ts
@@ -9,6 +9,7 @@ import {
 import { ContainerRegistrationKeys } from "@medusajs/framework/utils"
 import { getOrdersListWorkflow } from "@medusajs/medusa/core-flows"
 import partnerOrderLink from "../../links/partner-order"
+import { resolveDesignThumbnail } from "../../lib/design-thumbnail"
 
 // Chunk 5 (T3.4, #342): the kind-aware partner orders listing, lifted out of the
 // route handler into a workflow so the scoping/discrimination logic is reusable
@@ -97,6 +98,116 @@ export const resolvePartnerWorkOrderIdsStep = createStep(
   }
 )
 
+// A design work-order row in the partner's table is otherwise all numbers and
+// badges — nothing on it says WHICH garment it is. This attaches, per order, a
+// small `designs` summary (id, name, thumbnail) so the table can show the
+// picture the partner recognises the job by.
+//
+// Two shapes have to be covered: a legacy single-design order links exactly one
+// production run, while a COLLATED order (#826) carries one design per line item
+// on `items.metadata.design_id`. We union both sources rather than pick one.
+//
+// Additive: it only ever ADDS `designs` to rows that resolve to a design, so
+// retail/inventory rows and the admin read-proxy (#843) are untouched.
+export const attachOrderDesignSummariesStep = createStep(
+  "attach-order-design-summaries",
+  async (input: { orders: any[] }, { container }) => {
+    const orders = Array.isArray(input.orders) ? input.orders : []
+    if (!orders.length) {
+      return new StepResponse(orders)
+    }
+
+    const query: any = container.resolve(ContainerRegistrationKeys.QUERY)
+    const orderIds = orders.map((o) => o?.id).filter(Boolean)
+    if (!orderIds.length) {
+      return new StepResponse(orders)
+    }
+
+    // The reverse execution accessor resolves to an object for a 1:1 link and
+    // an array when several runs hang off one order — tolerate both.
+    const asArray = (rel: any): any[] =>
+      Array.isArray(rel) ? rel : rel ? [rel] : []
+
+    let rows: any[] = []
+    try {
+      const { data } = await query.graph({
+        entity: "orders",
+        fields: [
+          "id",
+          "production_runs.design_id",
+          "items.metadata",
+        ],
+        filters: { id: orderIds },
+      })
+      rows = data || []
+    } catch {
+      // Non-fatal: the table renders without pictures rather than 500-ing.
+      return new StepResponse(orders)
+    }
+
+    const designIdsByOrder = new Map<string, string[]>()
+    const allDesignIds = new Set<string>()
+    for (const row of rows) {
+      const ids = new Set<string>()
+      for (const run of asArray(row?.production_runs)) {
+        if (run?.design_id) {
+          ids.add(String(run.design_id))
+        }
+      }
+      for (const item of asArray(row?.items)) {
+        const designId = item?.metadata?.design_id
+        if (designId) {
+          ids.add(String(designId))
+        }
+      }
+      if (ids.size) {
+        designIdsByOrder.set(String(row.id), [...ids])
+        ids.forEach((id) => allDesignIds.add(id))
+      }
+    }
+
+    if (!allDesignIds.size) {
+      return new StepResponse(orders)
+    }
+
+    let designs: any[] = []
+    try {
+      const { data } = await query.graph({
+        entity: "design",
+        fields: ["id", "name", "media_files", "moodboard", "metadata"],
+        filters: { id: [...allDesignIds] },
+      })
+      designs = data || []
+    } catch {
+      return new StepResponse(orders)
+    }
+
+    const byId = new Map<string, any>(
+      designs.filter((d) => d?.id).map((d) => [String(d.id), d])
+    )
+
+    const enriched = orders.map((order) => {
+      const ids = designIdsByOrder.get(String(order?.id))
+      if (!ids?.length) {
+        return order
+      }
+      const summaries = ids
+        .map((id) => byId.get(id))
+        .filter(Boolean)
+        .map((design) => ({
+          id: String(design.id),
+          name: design.name ?? null,
+          // `allowDataUrl` stays off: a base64-inlined moodboard image would
+          // be megabytes of JSON per row on a list endpoint.
+          thumbnail: resolveDesignThumbnail(design),
+        }))
+      return summaries.length ? { ...order, designs: summaries } : order
+    })
+
+    return new StepResponse(enriched)
+  }
+)
+
 export const listPartnerOrdersWorkflow = createWorkflow(
   "list-partner-orders",
   (input: ListPartnerOrdersWorkflowInput) => {
@@ -171,21 +282,28 @@ export const listPartnerOrdersWorkflow = createWorkflow(
       (p) => !p.shortCircuit
     ).then(() => getOrdersListWorkflow.runAsStep({ input: listInput }))
 
-    const output = transform({ listed, input }, ({ listed, input }) => {
+    const page = transform({ listed }, ({ listed }) => {
       const result = listed as any
-      const orders = Array.isArray(result)
-        ? result
-        : result?.rows ?? []
+      const orders = Array.isArray(result) ? result : result?.rows ?? []
       const count = Array.isArray(result)
         ? result.length
         : result?.metadata?.count ?? orders.length
-      return {
-        orders,
-        count,
+      return { orders, count }
+    })
+
+    // Design pictures for the rows that have one. Runs over the page only
+    // (≤ `take` orders), and no-ops for retail/inventory pages.
+    const withDesigns = attachOrderDesignSummariesStep({ orders: page.orders })
+
+    const output = transform(
+      { page, withDesigns, input },
+      ({ page, withDesigns, input }) => ({
+        orders: withDesigns,
+        count: page.count,
         offset: input.skip,
         limit: input.take,
-      }
-    })
+      })
+    )
 
     return new WorkflowResponse(output)
   }

--- a/apps/backend/src/workflows/partners/update-partner.ts
+++ b/apps/backend/src/workflows/partners/update-partner.ts
@@ -33,6 +33,8 @@ export type UpdatePartnerInput = {
     deployment_account_id: string | null
     deployment_project_id: string | null
     deployment_project_name: string | null
+    /** #1228 — accept a re-sent run on this partner's behalf (opt-in). */
+    auto_accept_production_runs: boolean
   }>
 }
 
@@ -76,6 +78,7 @@ export const updatePartnerStep = createStep(
       status: previous.status,
       is_verified: previous.is_verified,
       metadata: previous.metadata ?? null,
+      auto_accept_production_runs: previous.auto_accept_production_runs ?? false,
     } as any)
   }
 )

--- a/apps/backend/src/workflows/payment_submissions/create-payment-submission.ts
+++ b/apps/backend/src/workflows/payment_submissions/create-payment-submission.ts
@@ -30,6 +30,25 @@ export type CreatePaymentSubmissionInput = {
   notes?: string
   documents?: Array<{ id?: string; url: string; filename?: string; mimeType?: string }>
   metadata?: Record<string, any>
+  /**
+   * The status the submission lands in. "Pending" (the default) is a partner
+   * saying "pay me for this". "Draft" is the system pre-filling one FOR the
+   * partner — see `require_design_status` — which they then review and submit.
+   */
+  status?: "Draft" | "Pending"
+  /**
+   * Whether the design's own status must be Approved / Commerce_Ready.
+   *
+   * Default true: a partner submitting by hand is asserting the design work is
+   * finished, and the design status is the check on that assertion.
+   *
+   * The run-completion auto-draft passes false, because there the proof of
+   * finished work is the COMPLETED PRODUCTION RUN itself — and completion sets
+   * the design to Technical_Review, so a status check would reject every single
+   * auto-draft. Only the auto path may set this; the partner-facing route never
+   * does.
+   */
+  require_design_status?: boolean
 }
 
 type ValidatedDesign = {
@@ -108,6 +127,9 @@ const validateDesignsForSubmissionStep = createStep(
       partner_id: string
       design_ids: string[]
       cost_overrides?: Record<string, number>
+      require_design_status?: boolean
+      /** Draft submissions also block a second Draft — see below. */
+      status?: "Draft" | "Pending"
     },
     { container }
   ) => {
@@ -135,16 +157,20 @@ const validateDesignsForSubmissionStep = createStep(
       )
     }
 
-    // 2. Validate status — must be Commerce_Ready or Approved
+    // 2. Validate status — must be Commerce_Ready or Approved.
+    // Skipped for the run-completion auto-draft, whose proof of finished work
+    // is the completed run rather than the design's status.
     const ELIGIBLE_STATUSES = ["Commerce_Ready", "Approved"]
-    const ineligible = typedDesigns.filter(
-      (d) => !ELIGIBLE_STATUSES.includes(d.status)
-    )
-    if (ineligible.length) {
-      throw new MedusaError(
-        MedusaError.Types.INVALID_DATA,
-        `Designs not eligible for payment (status must be Approved or Commerce_Ready): ${ineligible.map((d) => `${d.name || d.id} (${d.status})`).join(", ")}`
+    if (input.require_design_status !== false) {
+      const ineligible = typedDesigns.filter(
+        (d) => !ELIGIBLE_STATUSES.includes(d.status)
       )
+      if (ineligible.length) {
+        throw new MedusaError(
+          MedusaError.Types.INVALID_DATA,
+          `Designs not eligible for payment (status must be Approved or Commerce_Ready): ${ineligible.map((d) => `${d.name || d.id} (${d.status})`).join(", ")}`
+        )
+      }
     }
 
     // 3. Validate all designs have a cost (estimated_cost, production_cost,
@@ -192,10 +218,19 @@ const validateDesignsForSubmissionStep = createStep(
       filters: { design_id: input.design_ids },
     })
 
+    // A Draft counts as blocking when we're about to create ANOTHER Draft:
+    // the run-completion auto-draft fires per completion, and without this a
+    // design completed twice (a redo, a re-dispatch) would accumulate duplicate
+    // drafts. A partner submitting by hand is NOT blocked by their own draft —
+    // that's them turning the draft into a real submission.
     const typedExistingLinks = existingLinks as unknown as SubmissionDesignLinkResult[]
+    const blockingStatuses = new Set(["Pending", "Under_Review"])
+    if (input.status === "Draft") {
+      blockingStatuses.add("Draft")
+    }
     const activeSubmissionDesigns = (typedExistingLinks || []).filter((link) => {
       const status = link.payment_submission?.status
-      return status === "Pending" || status === "Under_Review"
+      return !!status && blockingStatuses.has(status)
     })
 
     if (activeSubmissionDesigns.length) {
@@ -363,6 +398,7 @@ const createSubmissionRecordStep = createStep(
       notes?: string
       documents?: Array<{ id?: string; url: string; filename?: string; mimeType?: string }>
       metadata?: Record<string, any>
+      status?: "Draft" | "Pending"
     },
     { container }
   ) => {
@@ -386,12 +422,16 @@ const createSubmissionRecordStep = createStep(
 
     // documents is typed as json() (Record<string, unknown>) in the model
     // but we store an array of document objects — cast at the service boundary
+    // A Draft has not been submitted, so it carries no `submitted_at` — the
+    // partner stamps that when they submit it.
+    const status = input.status === "Draft" ? "Draft" : "Pending"
+
     const submission = await service.createPaymentSubmissions({
       partner_id: input.partner_id,
-      status: "Pending",
+      status,
       total_amount,
       currency: "inr",
-      submitted_at: new Date(),
+      submitted_at: status === "Draft" ? null : new Date(),
       notes: input.notes || null,
       documents: (input.documents || null) as Record<string, unknown> | null,
       metadata: input.metadata || null,
@@ -547,20 +587,34 @@ const emitSubmissionCreatedStep = createStep(
       partner_id: string
       total_amount: number | null
       currency: string | null
+      status?: "Draft" | "Pending"
     },
     { container },
   ) => {
     const eventService = container.resolve(
       Modules.EVENT_BUS,
     ) as IEventBusModuleService
+
+    // A Draft is not a submission the partner has made — telling them "we
+    // received your payment request" would be a lie, and the run-completion
+    // auto-draft fires on every completed run. It gets its own name, still
+    // under the `payment_submission.*` wildcard the visual flow listens on;
+    // that flow maps event names to templates explicitly and skips ones it
+    // doesn't know, so a draft sends no WhatsApp until someone maps it.
+    const name =
+      input.status === "Draft"
+        ? "payment_submission.drafted"
+        : "payment_submission.created"
+
     await eventService.emit([
       {
-        name: "payment_submission.created",
+        name,
         data: {
           payment_submission_id: input.submission_id,
           partner_id: input.partner_id,
           total_amount: input.total_amount,
           currency: input.currency,
+          status: input.status ?? "Pending",
         },
       },
     ])
@@ -583,6 +637,8 @@ export const createPaymentSubmissionWorkflow = createWorkflow(
       partner_id: input.partner_id,
       design_ids: input.design_ids || [],
       cost_overrides: costOverrides.designs,
+      require_design_status: input.require_design_status,
+      status: input.status,
     })
 
     const validatedTasks = validateTasksForSubmissionStep({
@@ -598,6 +654,7 @@ export const createPaymentSubmissionWorkflow = createWorkflow(
       notes: input.notes,
       documents: input.documents,
       metadata: input.metadata,
+      status: input.status,
     })
 
     linkSubmissionToPartnerStep({
@@ -620,6 +677,7 @@ export const createPaymentSubmissionWorkflow = createWorkflow(
       partner_id: input.partner_id,
       total_amount: submission.total_amount,
       currency: submission.currency,
+      status: input.status,
     })
 
     return new WorkflowResponse({ submission })

--- a/apps/backend/src/workflows/production-runs/__tests__/run-payable.unit.spec.ts
+++ b/apps/backend/src/workflows/production-runs/__tests__/run-payable.unit.spec.ts
@@ -1,0 +1,105 @@
+import { assessRunPayout, runPayableAmount } from "../lib/run-payable"
+
+describe("runPayableAmount", () => {
+  it("multiplies a per-unit cost by the ORDERED quantity", () => {
+    expect(
+      runPayableAmount({
+        quantity: 9,
+        produced_quantity: 7,
+        partner_cost_estimate: 850,
+        cost_type: "per_unit",
+      } as any)
+    ).toBe(7650)
+  })
+
+  it("takes a total cost verbatim", () => {
+    expect(
+      runPayableAmount({
+        quantity: 9,
+        partner_cost_estimate: 7650,
+        cost_type: "total",
+      })
+    ).toBe(7650)
+  })
+
+  it("treats a missing cost_type as a total", () => {
+    expect(
+      runPayableAmount({ quantity: 9, partner_cost_estimate: 500 })
+    ).toBe(500)
+  })
+
+  it("falls back to one unit when a per-unit run has no quantity", () => {
+    expect(
+      runPayableAmount({ partner_cost_estimate: 500, cost_type: "per_unit" })
+    ).toBe(500)
+  })
+
+  it("rounds to two decimals", () => {
+    expect(
+      runPayableAmount({
+        quantity: 3,
+        partner_cost_estimate: 10.005,
+        cost_type: "per_unit",
+      })
+    ).toBe(30.02)
+  })
+
+  it("is zero for a run with no usable cost", () => {
+    expect(runPayableAmount({ quantity: 5 })).toBe(0)
+    expect(runPayableAmount({ partner_cost_estimate: 0 })).toBe(0)
+    expect(runPayableAmount({ partner_cost_estimate: -5 })).toBe(0)
+    expect(runPayableAmount(null)).toBe(0)
+  })
+})
+
+describe("assessRunPayout", () => {
+  const completed = {
+    id: "run_1",
+    status: "completed",
+    design_id: "des_1",
+    partner_id: "part_1",
+    quantity: 4,
+    partner_cost_estimate: 100,
+    cost_type: "per_unit" as const,
+  }
+
+  it("accepts a completed run with a design, a partner and a cost", () => {
+    expect(assessRunPayout(completed)).toEqual({
+      eligible: true,
+      design_id: "des_1",
+      partner_id: "part_1",
+      amount: 400,
+    })
+  })
+
+  it("refuses a run that has not completed", () => {
+    expect(assessRunPayout({ ...completed, status: "in_progress" })).toEqual({
+      eligible: false,
+      reason: "run_not_completed",
+    })
+  })
+
+  it("refuses a run with no design or no partner", () => {
+    expect(assessRunPayout({ ...completed, design_id: null })).toEqual({
+      eligible: false,
+      reason: "no_design",
+    })
+    expect(assessRunPayout({ ...completed, partner_id: null })).toEqual({
+      eligible: false,
+      reason: "no_partner",
+    })
+  })
+
+  it("refuses a run with no agreed cost rather than drafting a zero", () => {
+    expect(
+      assessRunPayout({ ...completed, partner_cost_estimate: null })
+    ).toEqual({ eligible: false, reason: "no_cost" })
+  })
+
+  it("refuses a missing run", () => {
+    expect(assessRunPayout(null)).toEqual({
+      eligible: false,
+      reason: "run_not_found",
+    })
+  })
+})

--- a/apps/backend/src/workflows/production-runs/lib/run-payable.ts
+++ b/apps/backend/src/workflows/production-runs/lib/run-payable.ts
@@ -1,0 +1,82 @@
+// What we owe a partner for a completed run, and whether that run should turn
+// into a payment submission at all.
+//
+// `partner_cost_estimate` is stored VERBATIM as the partner typed it, paired
+// with `cost_type` — a "per_unit" value is per-unit and a "total" value is a
+// total (#456). Every reader multiplies for itself; this is that multiplication,
+// in one place, for the payout path.
+//
+// The multiplier is the ORDERED quantity, not the produced one: partner payout
+// bills what was ordered (see the partner cost summary + the unified-order
+// dual-write, which both derive the unit price from `run.quantity`). Correcting
+// a partner's output figure therefore does NOT move the money — deliberately.
+
+export type RunForPayout = {
+  id?: string
+  design_id?: string | null
+  partner_id?: string | null
+  status?: string | null
+  quantity?: number | null
+  partner_cost_estimate?: number | null
+  cost_type?: "per_unit" | "total" | null
+}
+
+/**
+ * The payable total for a run, or 0 when it has no usable cost.
+ */
+export const runPayableAmount = (run: RunForPayout | null | undefined): number => {
+  const cost = Number(run?.partner_cost_estimate)
+  if (!Number.isFinite(cost) || cost <= 0) {
+    return 0
+  }
+
+  if (run?.cost_type !== "per_unit") {
+    return cost
+  }
+
+  const ordered = Number(run?.quantity)
+  const units = Number.isFinite(ordered) && ordered > 0 ? ordered : 1
+  // Money — keep it to two decimals rather than trailing float dust.
+  return Math.round(cost * units * 100) / 100
+}
+
+export type PayoutEligibility =
+  | { eligible: true; design_id: string; partner_id: string; amount: number }
+  | { eligible: false; reason: string }
+
+/**
+ * Whether a completed run can be turned into a draft payment submission.
+ *
+ * Deliberately strict and silent: this runs off an event for every completion,
+ * so anything it can't bill confidently is skipped with a reason rather than
+ * guessed at. In particular a run with no cost entered is NOT a zero-value
+ * submission — it's a run whose price hasn't been agreed yet.
+ */
+export const assessRunPayout = (
+  run: RunForPayout | null | undefined
+): PayoutEligibility => {
+  if (!run) {
+    return { eligible: false, reason: "run_not_found" }
+  }
+  if (String(run.status || "") !== "completed") {
+    return { eligible: false, reason: "run_not_completed" }
+  }
+  if (!run.design_id) {
+    return { eligible: false, reason: "no_design" }
+  }
+  if (!run.partner_id) {
+    return { eligible: false, reason: "no_partner" }
+  }
+
+  const amount = runPayableAmount(run)
+  if (amount <= 0) {
+    return { eligible: false, reason: "no_cost" }
+  }
+
+  return {
+    eligible: true,
+    design_id: String(run.design_id),
+    partner_id: String(run.partner_id),
+    amount,
+  }
+}

--- a/apps/backend/src/workflows/production-runs/list-partner-production-runs.ts
+++ b/apps/backend/src/workflows/production-runs/list-partner-production-runs.ts
@@ -59,6 +59,15 @@ export const PARTNER_PRODUCTION_RUN_LIST_FIELDS = [
   "rejection_reason",
   "rejection_notes",
   "depends_on_run_ids",
+  // #1228 — how the run got here. `previous_partner_id` is set when a run was
+  // taken off a partner who didn't accept it, and survives the re-dispatch to
+  // whoever holds it now; `reassign_retry_count` counts the times THIS partner
+  // has already been re-nudged on it. The partner UI needs both to say "this
+  // was re-assigned to you" vs "you've already missed one dispatch of this" —
+  // without them a re-sent run is indistinguishable from a fresh one, which is
+  // exactly the confusion this surfaces.
+  "previous_partner_id",
+  "reassign_retry_count",
   "metadata",
   "created_at",
   "updated_at",

--- a/apps/partner-ui/src/components/layout/settings-layout/settings-layout.tsx
+++ b/apps/partner-ui/src/components/layout/settings-layout/settings-layout.tsx
@@ -24,6 +24,10 @@ const useSettingRoutes = (): INavItem[] => {
   return useMemo(
     () => [
       { label: t("partner.settingsSidebar.store"), to: "/settings/store" },
+      {
+        label: t("partner.settingsSidebar.productionRuns"),
+        to: "/settings/production-runs",
+      },
       { label: t("partner.settingsSidebar.regions"), to: "/settings/regions" },
       { label: t("partner.settingsSidebar.locationsShipping"), to: "/settings/locations" },
       { label: t("partner.settingsSidebar.salesChannels"), to: "/settings/sales-channels" },

--- a/apps/partner-ui/src/components/table/table-cells/order/design-cell/design-cell.tsx
+++ b/apps/partner-ui/src/components/table/table-cells/order/design-cell/design-cell.tsx
@@ -1,0 +1,58 @@
+import { Thumbnail } from "../../../../common/thumbnail"
+import { PlaceholderCell } from "../../common/placeholder-cell"
+
+/** One design of a work-order, as summarised by `GET /partners/orders`. */
+export type OrderDesignSummary = {
+  id: string
+  name?: string | null
+  thumbnail?: string | null
+}
+
+/**
+ * The design column of the Design Orders table.
+ *
+ * Every other column on that table is a number, a date, or a badge — nothing
+ * says WHICH garment the row is. This shows the design's picture (its flagged
+ * media thumbnail, else its first media file, else the moodboard's first
+ * reference image — resolved server-side) next to its name, which is what a
+ * partner actually recognises a job by.
+ *
+ * A COLLATED order (#826) holds many designs: the first design's picture leads
+ * and the rest are counted, rather than growing the row.
+ */
+export const DesignCell = ({
+  designs,
+}: {
+  designs?: OrderDesignSummary[] | null
+}) => {
+  if (!designs?.length) {
+    return <PlaceholderCell />
+  }
+
+  const [first, ...rest] = designs
+  const label = first.name || "Untitled design"
+
+  return (
+    <div className="flex h-full w-full max-w-[250px] items-center gap-x-3 overflow-hidden">
+      <div className="w-fit flex-shrink-0">
+        <Thumbnail src={first.thumbnail} alt={label} />
+      </div>
+      <span title={label} className="truncate">
+        {label}
+      </span>
+      {rest.length > 0 && (
+        <span className="text-ui-fg-muted txt-compact-small flex-shrink-0">
+          +{rest.length}
+        </span>
+      )}
+    </div>
+  )
+}
+
+export const DesignHeader = () => {
+  return (
+    <div className="flex h-full w-full items-center">
+      <span className="truncate">Design</span>
+    </div>
+  )
+}

--- a/apps/partner-ui/src/components/table/table-cells/order/design-cell/index.ts
+++ b/apps/partner-ui/src/components/table/table-cells/order/design-cell/index.ts
@@ -1,0 +1,1 @@
+export * from "./design-cell"

--- a/apps/partner-ui/src/components/work-orders/collated-design-detail.tsx
+++ b/apps/partner-ui/src/components/work-orders/collated-design-detail.tsx
@@ -1,5 +1,5 @@
 import { ArrowUpRightOnBox } from "@medusajs/icons"
-import { Badge, Button, Container, Heading, Skeleton, StatusBadge, Text } from "@medusajs/ui"
+import { Badge, Button, Container, Heading, StatusBadge, Text } from "@medusajs/ui"
 import { Link } from "react-router-dom"
 import { useTranslation } from "react-i18next"
 
@@ -11,7 +11,9 @@ import { usePartnerDesign } from "../../hooks/api/partner-designs"
 import { usePartnerProductionRun } from "../../hooks/api/partner-production-runs"
 import { DesignCostSection } from "../../routes/designs/design-detail/components/design-cost-section"
 import { DesignInventoryBomSection } from "../../routes/designs/design-detail/components/design-inventory-bom-section"
+import { DesignMediaSection } from "../../routes/designs/design-detail/components/design-media-section"
 import { DesignSizeSetsSection } from "../../routes/designs/design-detail/components/design-size-sets-section"
+import { DesignSectionsSkeleton } from "./design-sections-skeleton"
 import { ProductionRunCard } from "./production-run-card"
 
 /**
@@ -158,6 +160,15 @@ export const DesignSpecs = ({ design }: { design: any }) => {
         )}
       </Container>
 
+      {/* The design's pictures, in the order. A partner working a collated
+          order sees what they're making without opening the design manager;
+          the links point at the design's own media routes, nested under this
+          order, so "Manage" stays in the Orders context. */}
+      <DesignMediaSection
+        design={design}
+        linkBase={`design-details/${design.id}`}
+      />
+
       {/* Sizes (size_sets or legacy custom_sizes) + full BOM. The design
           "specs" the operator asked to keep under the order form. */}
       <DesignSizeSetsSection design={design} />
@@ -247,12 +258,7 @@ export const DesignLineDetail = ({
   }
 
   if (!production_run || !design) {
-    return (
-      <Container className="p-6">
-        <Skeleton className="h-6 w-40" />
-        <Skeleton className="mt-3 h-24 w-full" />
-      </Container>
-    )
+    return <DesignSectionsSkeleton />
   }
 
   return (

--- a/apps/partner-ui/src/components/work-orders/design-sections-skeleton.tsx
+++ b/apps/partner-ui/src/components/work-orders/design-sections-skeleton.tsx
@@ -1,0 +1,48 @@
+import { Container } from "@medusajs/ui"
+
+import {
+  GeneralSectionSkeleton,
+  HeadingSkeleton,
+  Skeleton,
+} from "../common/skeleton"
+
+/**
+ * Loading state for the design half of a work-order.
+ *
+ * The order detail resolves its design in two hops (order → production run →
+ * design), so between the order rendering and the design arriving the design
+ * sections simply were not in the tree: the page painted the status card and
+ * then, a beat later, four sections popped in below it and shoved everything
+ * down. This stands in for that stack — summary, media grid, sizes, BOM — so
+ * the layout is stable from the first paint and the wait reads as loading
+ * rather than as an order with no design on it.
+ *
+ * Mirrors the real stack's shape (`DesignSpecs` + `DesignMediaSection`), not
+ * its exact row count — a skeleton that tracked the content byte-for-byte
+ * would have to know the design before it could describe it.
+ */
+export const DesignSectionsSkeleton = () => {
+  return (
+    <div className="flex flex-col gap-y-3" aria-hidden>
+      {/* Summary — type / status / priority / target date / cost / materials */}
+      <GeneralSectionSkeleton rowCount={5} />
+
+      {/* Media — the thumbnail grid */}
+      <Container className="divide-y p-0">
+        <div className="flex flex-col gap-y-3 px-6 py-4 sm:flex-row sm:items-center sm:justify-between">
+          <HeadingSkeleton level="h2" characters={5} />
+          <Skeleton className="h-7 w-20 rounded-md" />
+        </div>
+        <div className="grid grid-cols-[repeat(auto-fill,minmax(96px,1fr))] gap-4 px-6 py-4">
+          {Array.from({ length: 4 }, (_, i) => (
+            <Skeleton key={i} className="aspect-square size-full rounded-[8px]" />
+          ))}
+        </div>
+      </Container>
+
+      {/* Sizes + BOM */}
+      <GeneralSectionSkeleton rowCount={3} />
+      <GeneralSectionSkeleton rowCount={4} />
+    </div>
+  )
+}

--- a/apps/partner-ui/src/components/work-orders/production-run-card.tsx
+++ b/apps/partner-ui/src/components/work-orders/production-run-card.tsx
@@ -33,7 +33,9 @@ import {
   useFinishPartnerAssignedTask,
   useCompletePartnerAssignedTaskSubtask,
 } from "../../hooks/api/partner-assigned-tasks"
+import { useMe } from "../../hooks/api/users"
 import { getStatusBadgeColor } from "../../lib/status-badge"
+import { getReassignmentNotice } from "../../lib/reassignment-notice"
 import { extractErrorMessage } from "../../lib/extract-error-message"
 import { GoodsTransferSection } from "./goods-transfer-section"
 
@@ -319,6 +321,12 @@ export const ProductionRunCard = ({
   const tasks = run.tasks || []
   const isSample = run.run_type === "sample"
   const prompt = usePrompt()
+
+  // #1228 — how this run got here. Needs the viewer's own partner id to tell
+  // "re-assigned to you from someone else" apart from a run handed back to you.
+  const { user } = useMe()
+  const reassignmentNotice = getReassignmentNotice(run, user?.partner_id)
+
   const [showFinishForm, setShowFinishForm] = useState(false)
   const [showCompleteForm, setShowCompleteForm] = useState(false)
   const [finishNotes, setFinishNotes] = useState("")
@@ -516,6 +524,18 @@ export const ProductionRunCard = ({
           )}
         </div>
       </div>
+
+      {/* #1228 — how this run reached the partner. Sits ABOVE the stepper: a
+          re-sent run and a fresh one are otherwise identical on screen, and
+          "you're on your last chance to accept this" has to be read before the
+          Accept button, not after it. */}
+      {reassignmentNotice && (
+        <InfoBanner
+          title={reassignmentNotice.title}
+          description={reassignmentNotice.description}
+          variant={reassignmentNotice.variant}
+        />
+      )}
 
       {/* Progress stepper */}
       <ProgressStepper run={run} />

--- a/apps/partner-ui/src/dashboard-app/routes/get-partner-route.map.tsx
+++ b/apps/partner-ui/src/dashboard-app/routes/get-partner-route.map.tsx
@@ -1020,6 +1020,14 @@ export function getPartnerRouteMap(): RouteObject[] {
                   ],
                 },
                 {
+                  // #1228 — the partner's own policy for work sent to them.
+                  // Home of the auto-accept opt-in, which had a column and a
+                  // reader but no way to switch on until now.
+                  path: "production-runs",
+                  lazy: () => import("../../routes/settings/production-runs"),
+                  handle: { breadcrumb: () => "Production Runs" },
+                },
+                {
                   path: "onboarding",
                   lazy: () => import("../../routes/settings/onboarding"),
                 },

--- a/apps/partner-ui/src/hooks/api/partner-settings.tsx
+++ b/apps/partner-ui/src/hooks/api/partner-settings.tsx
@@ -1,0 +1,98 @@
+import { FetchError } from "@medusajs/js-sdk"
+import {
+  QueryKey,
+  UseMutationOptions,
+  UseQueryOptions,
+  useMutation,
+  useQuery,
+} from "@tanstack/react-query"
+
+import { sdk } from "../../lib/client"
+import { queryClient } from "../../lib/query-client"
+import { queryKeysFactory } from "../../lib/query-key-factory"
+
+const PARTNER_SETTINGS_QUERY_KEY = "partner-settings" as const
+export const partnerSettingsQueryKeys = queryKeysFactory(
+  PARTNER_SETTINGS_QUERY_KEY
+)
+
+/**
+ * The partner ORGANISATION (not the signed-in admin — that's `useMe`). Only the
+ * fields the settings surfaces write are typed here; the route returns the
+ * whole record.
+ */
+export type PartnerSettings = Record<string, any> & {
+  id: string
+  name?: string | null
+  /**
+   * #1228 — when a dispatch to this partner goes stale and the same run is
+   * re-sent to them, accept it on their behalf instead of waiting for another
+   * manual accept. A typed column, not metadata: it changes who owns the work.
+   *
+   * Consulted ONLY on a same-partner retry, and only when the platform's
+   * reassignment policy has `auto_accept_on_retry` on — so switching this on
+   * cannot make a partner auto-accept a FIRST dispatch, and cannot override the
+   * platform being configured against it.
+   */
+  auto_accept_production_runs?: boolean
+}
+
+type PartnerDetailsResponse = {
+  partner?: PartnerSettings | null
+  current_admin_id?: string | null
+}
+
+export const usePartnerSettings = (
+  options?: Omit<
+    UseQueryOptions<
+      PartnerDetailsResponse,
+      FetchError,
+      PartnerDetailsResponse,
+      QueryKey
+    >,
+    "queryFn" | "queryKey"
+  >
+) => {
+  const { data, ...rest } = useQuery({
+    queryKey: partnerSettingsQueryKeys.details(),
+    queryFn: async () =>
+      await sdk.client.fetch<PartnerDetailsResponse>("/partners/details", {
+        method: "GET",
+      }),
+    ...options,
+  })
+
+  return { partner: data?.partner ?? null, ...rest }
+}
+
+export type UpdatePartnerSettingsInput = {
+  auto_accept_production_runs?: boolean
+}
+
+export const useUpdatePartnerSettings = (
+  options?: UseMutationOptions<
+    { partner: PartnerSettings },
+    FetchError,
+    UpdatePartnerSettingsInput
+  >
+) => {
+  return useMutation({
+    mutationFn: async (payload) =>
+      await sdk.client.fetch<{ partner: PartnerSettings }>(
+        "/partners/update",
+        {
+          method: "PUT",
+          body: payload,
+        }
+      ),
+    onSuccess: async (data, variables, context) => {
+      await queryClient.invalidateQueries({
+        queryKey: partnerSettingsQueryKeys.all,
+      })
+      // The signed-in user carries an embedded copy of the partner record.
+      await queryClient.invalidateQueries({ queryKey: ["users", "me"] })
+      options?.onSuccess?.(data, variables, context)
+    },
+    ...options,
+  })
+}

--- a/apps/partner-ui/src/i18n/translations/en.json
+++ b/apps/partner-ui/src/i18n/translations/en.json
@@ -3281,6 +3281,7 @@
   "partner": {
     "settingsSidebar": {
       "store": "Store",
+      "productionRuns": "Production Runs",
       "regions": "Regions",
       "locationsShipping": "Locations & Shipping",
       "salesChannels": "Sales Channels",
@@ -3483,7 +3484,6 @@
       "stockLocation": "Stock location",
       "designDetails": "Design details",
       "openDesignManager": "Open design manager",
-      "backToOrder": "Back to order",
       "noDesign": "No design linked to this order.",
       "activity": {
         "title": "Activity",

--- a/apps/partner-ui/src/lib/__tests__/reassignment-notice.spec.ts
+++ b/apps/partner-ui/src/lib/__tests__/reassignment-notice.spec.ts
@@ -1,0 +1,86 @@
+import { describe, expect, it } from "vitest"
+
+import { getReassignmentNotice } from "../reassignment-notice"
+
+describe("getReassignmentNotice", () => {
+  it("says nothing about a run that arrived normally", () => {
+    expect(
+      getReassignmentNotice({ status: "sent_to_partner" }, "part_me")
+    ).toBeNull()
+  })
+
+  it("warns a partner who is on a re-sent dispatch they haven't accepted", () => {
+    const notice = getReassignmentNotice(
+      { status: "sent_to_partner", reassign_retry_count: 1 },
+      "part_me"
+    )
+    expect(notice?.variant).toBe("warning")
+    expect(notice?.title).toBe("This run was sent to you again")
+  })
+
+  it("drops the re-send warning once the partner has accepted", () => {
+    expect(
+      getReassignmentNotice(
+        {
+          status: "in_progress",
+          reassign_retry_count: 1,
+          accepted_at: "2026-08-12T00:00:00.000Z",
+        },
+        "part_me"
+      )
+    ).toBeNull()
+  })
+
+  it("tells a partner when a run was re-assigned to them from someone else", () => {
+    const notice = getReassignmentNotice(
+      { status: "sent_to_partner", previous_partner_id: "part_other" },
+      "part_me"
+    )
+    expect(notice?.variant).toBe("info")
+    expect(notice?.title).toBe("Re-assigned to you")
+  })
+
+  it("does not call it a re-assignment when the run came back to the same partner", () => {
+    expect(
+      getReassignmentNotice(
+        { status: "sent_to_partner", previous_partner_id: "part_me" },
+        "part_me"
+      )
+    ).toBeNull()
+  })
+
+  it("prefers the last-chance warning over the inherited-work note", () => {
+    const notice = getReassignmentNotice(
+      {
+        status: "sent_to_partner",
+        previous_partner_id: "part_other",
+        reassign_retry_count: 2,
+      },
+      "part_me"
+    )
+    expect(notice?.title).toBe("This run was sent to you again")
+  })
+
+  it("flags a parked run as no longer theirs", () => {
+    const notice = getReassignmentNotice(
+      { status: "awaiting_reassignment", previous_partner_id: "part_me" },
+      "part_me"
+    )
+    expect(notice?.title).toBe("No longer assigned to you")
+  })
+
+  it("stays quiet on finished or cancelled work", () => {
+    for (const status of ["completed", "cancelled"]) {
+      expect(
+        getReassignmentNotice(
+          { status, previous_partner_id: "part_other", reassign_retry_count: 3 },
+          "part_me"
+        )
+      ).toBeNull()
+    }
+  })
+
+  it("handles a missing run", () => {
+    expect(getReassignmentNotice(null, "part_me")).toBeNull()
+  })
+})

--- a/apps/partner-ui/src/lib/reassignment-notice.ts
+++ b/apps/partner-ui/src/lib/reassignment-notice.ts
@@ -1,0 +1,86 @@
+/**
+ * #1228 — what a partner is told about how a run reached them.
+ *
+ * A re-sent run is byte-identical to a fresh one on screen: same status, same
+ * buttons, no trace of the dispatch that went unanswered. So a partner who
+ * missed the first dispatch has no idea they're on a second chance, and a
+ * partner picking up someone else's abandoned work has no idea it was abandoned
+ * — they just see a run that appeared with a date that's already tight.
+ *
+ * Two distinct situations, told apart by which field the backend wrote:
+ *
+ *   • `reassign_retry_count > 0` — the reminder cap fired on THIS partner and
+ *     the platform chose to re-nudge them rather than take the run away. They
+ *     are on their last chance; the next cap parks the run for reassignment.
+ *     Reset to 0 whenever a partner is (re)assigned, so a positive count always
+ *     means "you, again".
+ *
+ *   • `previous_partner_id` set to someone else — the run was taken off another
+ *     partner and re-dispatched here. Explains an inherited deadline.
+ *
+ * Pure so the wording is testable without mounting the card.
+ */
+
+export type ReassignmentNotice = {
+  title: string
+  description: string
+  variant: "info" | "warning"
+}
+
+export type RunForReassignmentNotice = {
+  status?: string | null
+  accepted_at?: string | Date | null
+  previous_partner_id?: string | null
+  reassign_retry_count?: number | null
+}
+
+export const getReassignmentNotice = (
+  run: RunForReassignmentNotice | null | undefined,
+  myPartnerId?: string | null
+): ReassignmentNotice | null => {
+  if (!run) {
+    return null
+  }
+
+  const status = String(run.status || "")
+
+  // Terminal runs are history — a warning about accepting in time would be
+  // noise on work that's already finished or called off.
+  if (status === "completed" || status === "cancelled") {
+    return null
+  }
+
+  // Defensive: reassignment nulls `partner_id`, so a partner shouldn't be able
+  // to load a parked run at all. If one ever surfaces, say so plainly rather
+  // than showing action buttons for work that isn't theirs.
+  if (status === "awaiting_reassignment") {
+    return {
+      title: "No longer assigned to you",
+      description:
+        "This run went unanswered and has been sent back for reassignment. You don't need to do anything.",
+      variant: "warning",
+    }
+  }
+
+  const retries = Number(run.reassign_retry_count) || 0
+  if (retries > 0 && !run.accepted_at) {
+    return {
+      title: "This run was sent to you again",
+      description:
+        "The first dispatch went unanswered, so it was re-sent rather than reassigned. Accept it to keep it — if it goes unanswered again it will be handed to another partner.",
+      variant: "warning",
+    }
+  }
+
+  const previous = run.previous_partner_id
+  if (previous && (!myPartnerId || previous !== myPartnerId)) {
+    return {
+      title: "Re-assigned to you",
+      description:
+        "Another partner didn't accept this run, so it was handed to you. Its target date may already be close — check it before you start.",
+      variant: "info",
+    }
+  }
+
+  return null
+}

--- a/apps/partner-ui/src/routes/designs/design-detail/components/design-media-section.tsx
+++ b/apps/partner-ui/src/routes/designs/design-detail/components/design-media-section.tsx
@@ -5,19 +5,37 @@ import { PartnerDesign } from "../../../../hooks/api/partner-designs"
 
 type DesignMediaSectionProps = {
   design: PartnerDesign
+  /**
+   * Where the "Manage" / preview links point, relative to the CURRENT route.
+   *
+   * On the design manager (`/designs/:id`, and its in-order twin
+   * `/orders/:id/design-details/:designId`) the upload + preview routes are
+   * direct children, so the default empty base resolves to `media` /
+   * `media-preview` and is correct.
+   *
+   * The order detail (`/orders/:id`) renders this section for a design it shows
+   * INLINE — there is no `media` child of the order itself, so it passes
+   * `design-details/<designId>` and the links land on the design's own routes.
+   */
+  linkBase?: string
 }
 
-export const DesignMediaSection = ({ design }: DesignMediaSectionProps) => {
+export const DesignMediaSection = ({
+  design,
+  linkBase,
+}: DesignMediaSectionProps) => {
   const mediaFiles = (design as any)?.media_files as
     | Array<{ id?: string; url: string; isThumbnail?: boolean }>
     | undefined
+
+  const base = linkBase ? `${linkBase.replace(/\/$/, "")}/` : ""
 
   return (
     <Container className="divide-y p-0">
       <div className="flex flex-col gap-y-3 px-6 py-4 sm:flex-row sm:items-center sm:justify-between">
         <Heading level="h2">Media</Heading>
         <Button size="small" variant="secondary" asChild>
-          <Link to="media">Manage</Link>
+          <Link to={`${base}media`}>Manage</Link>
         </Button>
       </div>
       {mediaFiles?.length ? (
@@ -26,7 +44,7 @@ export const DesignMediaSection = ({ design }: DesignMediaSectionProps) => {
             return (
               <Link
                 key={media.id || String(index)}
-                to="media-preview"
+                to={`${base}media-preview`}
                 state={{ curr: index }}
                 className="shadow-elevation-card-rest hover:shadow-elevation-card-hover transition-fg group relative aspect-square size-full cursor-pointer overflow-hidden rounded-[8px]"
               >
@@ -55,7 +73,7 @@ export const DesignMediaSection = ({ design }: DesignMediaSectionProps) => {
             </Text>
           </div>
           <Button size="small" variant="secondary" asChild>
-            <Link to="media">Add Media</Link>
+            <Link to={`${base}media`}>Add Media</Link>
           </Button>
         </div>
       )}

--- a/apps/partner-ui/src/routes/designs/design-detail/design-detail.tsx
+++ b/apps/partner-ui/src/routes/designs/design-detail/design-detail.tsx
@@ -1,8 +1,7 @@
 import React from "react"
-import { ArrowLeft } from "@medusajs/icons"
-import { Badge, Button, Container, Heading, Text } from "@medusajs/ui"
+import { Badge, Container, Heading, Text } from "@medusajs/ui"
 import { useMemo } from "react"
-import { Link, useParams } from "react-router-dom"
+import { useParams } from "react-router-dom"
 
 import { SectionRow } from "../../../components/common/section"
 import { TwoColumnPageSkeleton } from "../../../components/common/skeleton"
@@ -208,19 +207,17 @@ function getTipTapBlocks(input: unknown): BlockNode[] {
 /**
  * The full design manager. Standalone it reads the design id from the route
  * param (`/designs/:id`). Nested under an order (`/orders/:id/design-details`)
- * the resolver passes the design id + a `backTo` link explicitly, so the SAME
- * manager renders inside the order instead of jumping the partner to a new
- * top-level route. `backTo` swaps the standalone breadcrumb for a "Back to
- * order" affordance.
+ * the resolver passes the design id explicitly, so the SAME manager renders
+ * inside the order instead of jumping the partner to a new top-level route.
+ * Returning to the order is the breadcrumb's job either way — there is no
+ * separate back-link affordance.
  */
 export type DesignDetailProps = {
   /** Explicit design id (nested/in-order use). Falls back to the route param. */
   designId?: string
-  /** When set, renders a back link at the top (in-order use). */
-  backTo?: { to: string; label: string }
 }
 
-export const DesignDetail = ({ designId, backTo }: DesignDetailProps = {}) => {
+export const DesignDetail = ({ designId }: DesignDetailProps = {}) => {
   const { id: idParam } = useParams()
   const id = designId ?? idParam
 
@@ -318,16 +315,6 @@ export const DesignDetail = ({ designId, backTo }: DesignDetailProps = {}) => {
   return (
     <TwoColumnPage widgets={{ before: [], after: [], sideBefore: [], sideAfter: [] }} hasOutlet>
       <TwoColumnPage.Main>
-        {backTo && (
-          <div>
-            <Button size="small" variant="transparent" asChild>
-              <Link to={backTo.to}>
-                <ArrowLeft />
-                {backTo.label}
-              </Link>
-            </Button>
-          </div>
-        )}
         {design && <DesignOwnerActionsSection design={design} />}
         <Container className="divide-y p-0">
           <div className="px-6 py-4">

--- a/apps/partner-ui/src/routes/orders/order-design-details/order-design-details.tsx
+++ b/apps/partner-ui/src/routes/orders/order-design-details/order-design-details.tsx
@@ -13,8 +13,10 @@ import { DesignDetail } from "../../designs/design-detail/design-detail"
  * (`/orders/:id/design-details[/:designId]`). Instead of a reduced read-only
  * view with an "Open design manager" button that jumped to `/designs/:id`
  * (leaving the Orders context), this resolves the design id and renders the
- * FULL design manager INLINE, with a "Back to order" link — so the partner
- * drives the whole design from within the order and can return with one click.
+ * FULL design manager INLINE — so the partner drives the whole design from
+ * within the order. Getting back is the breadcrumb's job (Orders › id › Design
+ * details); the extra "Back to order" button above the first card duplicated it
+ * and pushed the design's own content down, so it's gone.
  *
  * Resolution: a collated order's per-design route names the design directly via
  * `:designId`; a legacy single-design order resolves it from the order's
@@ -54,13 +56,5 @@ export const OrderDesignDetails = () => {
     )
   }
 
-  return (
-    <DesignDetail
-      designId={designId}
-      backTo={{
-        to: `/orders/${id}`,
-        label: t("partner.workOrders.backToOrder", "Back to order"),
-      }}
-    />
-  )
+  return <DesignDetail designId={designId} />
 }

--- a/apps/partner-ui/src/routes/orders/order-detail/order-detail.tsx
+++ b/apps/partner-ui/src/routes/orders/order-detail/order-detail.tsx
@@ -6,6 +6,7 @@ import { TwoColumnPage } from "../../../components/layout/pages"
 import { InventoryOrderLines } from "../../../components/work-orders/inventory-order-lines"
 import { DesignOrderLines } from "../../../components/work-orders/design-order-lines"
 import { CollatedDesignRuns } from "../../../components/work-orders/collated-design-runs"
+import { DesignSectionsSkeleton } from "../../../components/work-orders/design-sections-skeleton"
 import {
   InventoryFulfillmentsSection,
   InventoryPaymentsSection,
@@ -16,6 +17,7 @@ import { ProductionRunCard } from "../../../components/work-orders/production-ru
 import { WorkOrderActivitySection } from "../../../components/work-orders/work-order-activity-section"
 import { WorkOrderSummarySection } from "../../../components/work-orders/work-order-summary-section"
 import { DesignInventoryBomSection } from "../../designs/design-detail/components/design-inventory-bom-section"
+import { DesignMediaSection } from "../../designs/design-detail/components/design-media-section"
 import { DesignSizeSetsSection } from "../../designs/design-detail/components/design-size-sets-section"
 import { DesignCostSection } from "../../designs/design-detail/components/design-cost-section"
 import { ordersQueryKeys, useOrder, useOrderPreview } from "../../../hooks/api/orders"
@@ -91,7 +93,21 @@ export const OrderDetail = () => {
     enabled: kind === "design" && !!legacyId,
   })
   const designId = (production_run as any)?.design_id as string | undefined
-  const { design } = usePartnerDesign(designId ?? "", { enabled: !!designId })
+  const { design, isError: isDesignError } = usePartnerDesign(designId ?? "", {
+    enabled: !!designId,
+  })
+
+  // Resolving a design work-order's design takes two hops (order → run →
+  // design), so the design sections used to be absent from the tree for a beat
+  // and then pop in, shoving the page down. Skeleton that window instead. A
+  // design that genuinely 404s for this partner (no design↔partner link) sets
+  // isError and falls through — that must not skeleton forever.
+  const isDesignResolving =
+    kind === "design" &&
+    !!legacyId &&
+    !(order as any)?.metadata?.collated_design_order &&
+    !design &&
+    !isDesignError
   const { logs: consumptionLogs = [], count: consumptionCount = 0 } =
     usePartnerConsumptionLogs(designId ?? "", undefined, { enabled: !!designId })
 
@@ -184,11 +200,19 @@ export const OrderDetail = () => {
                   />
                 </>
               )}
+            {isDesignResolving && <DesignSectionsSkeleton />}
             {kind === "design" &&
               !(order as any)?.metadata?.collated_design_order &&
               design && (
                 <>
                   <WorkOrderSummarySection kind="design" design={design} designId={designId} />
+                  {/* The design's pictures, in the order — the partner sees
+                      what they're making without leaving Orders. Links point at
+                      the design's media routes nested under this order. */}
+                  <DesignMediaSection
+                    design={design}
+                    linkBase={`design-details/${design.id}`}
+                  />
                   {/* Sizes (size_sets or legacy custom_sizes) + BOM inventory
                       with thumbnails — parity with the collated design view (#1, #3). */}
                   <DesignSizeSetsSection design={design} />

--- a/apps/partner-ui/src/routes/orders/order-list/components/order-list-table/order-list-table.tsx
+++ b/apps/partner-ui/src/routes/orders/order-list/components/order-list-table/order-list-table.tsx
@@ -6,6 +6,10 @@ import { useTranslation } from "react-i18next"
 import { useLocation } from "react-router-dom"
 
 import { _DataTable } from "../../../../../components/table/data-table/data-table"
+import {
+  DesignCell,
+  DesignHeader,
+} from "../../../../../components/table/table-cells/order/design-cell"
 import { useOrders } from "../../../../../hooks/api/orders"
 import { usePartnerStores } from "../../../../../hooks/api/partner-stores"
 import { useOrderTableColumns } from "../../../../../hooks/table/columns/use-order-table-columns"
@@ -28,6 +32,24 @@ const PAGE_SIZE = 20
 // Work-order-only column: the partner-facing lifecycle status. Shown on the
 // design/inventory/all tabs; retail rows have no partner_status and render "—".
 const workColumnHelper = createColumnHelper<any>()
+
+// Design-order-only column: the design's picture + name, from the `designs`
+// summary the partner orders list attaches to design-kind rows. Leads the table
+// because it's what identifies the job at a glance.
+const designColumn = workColumnHelper.display({
+  id: "design",
+  header: () => (
+    <div className="flex h-full w-full items-center px-4 py-2.5">
+      <DesignHeader />
+    </div>
+  ),
+  cell: ({ row }) => (
+    <div className="flex items-center px-4">
+      <DesignCell designs={(row.original as any)?.designs} />
+    </div>
+  ),
+})
+
 const partnerStatusColumn = workColumnHelper.display({
   id: "partner_status",
   header: () => (
@@ -85,11 +107,16 @@ export const OrderListTable = () => {
       ? ["customer", "sales_channel", "payment_status", "fulfillment_status", "country"]
       : [],
   })
-  const columns = useMemo(
-    () =>
-      kind === "retail" ? baseColumns : [...baseColumns, partnerStatusColumn],
-    [baseColumns, kind]
-  )
+  const columns = useMemo(() => {
+    if (kind === "retail") {
+      return baseColumns
+    }
+    // The design picture only means anything where every row IS a design;
+    // `all` and `inventory` mix in rows that have none.
+    return kind === "design"
+      ? [designColumn, ...baseColumns, partnerStatusColumn]
+      : [...baseColumns, partnerStatusColumn]
+  }, [baseColumns, kind])
 
   const { table } = useDataTable({
     data: orders ?? [],

--- a/apps/partner-ui/src/routes/orders/order-list/components/order-list-table/order-table-adapter.tsx
+++ b/apps/partner-ui/src/routes/orders/order-list/components/order-list-table/order-table-adapter.tsx
@@ -1,6 +1,10 @@
 import { HttpTypes } from "@medusajs/types"
 import { StatusBadge, createDataTableColumnHelper } from "@medusajs/ui"
 import { createTableAdapter, TableAdapter } from "../../../../../lib/table/table-adapters"
+import {
+  DesignCell,
+  DesignHeader,
+} from "../../../../../components/table/table-cells/order/design-cell"
 import { useOrders } from "../../../../../hooks/api/orders"
 import { useOrderTableFilters } from "./use-order-table-filters"
 import { orderColumnAdapter } from "../../../../../lib/table/entity-adapters"
@@ -40,6 +44,17 @@ const workStatusColumn = workColumnHelper.display({
   },
 }) as any
 
+// Derived "Design" column for the design kind — the picture + name that say
+// WHICH garment the row is. Fed by the `designs` summary the partner orders
+// list attaches server-side, so it needs no extra requested fields.
+const designColumn = workColumnHelper.display({
+  id: "design",
+  header: () => <DesignHeader />,
+  cell: ({ row }: { row: any }) => (
+    <DesignCell designs={(row.original as any)?.designs} />
+  ),
+}) as any
+
 /**
  * Create the order table adapter with all order-specific logic. The `kind`
  * (#342) makes the configurable table filter natively by which unified link is
@@ -57,7 +72,11 @@ export function createOrderTableAdapter(
     columnAdapter: orderColumnAdapter,
     // Work-order kinds carry a partner work-status badge the backend column
     // registry doesn't know about — append it as a derived column.
-    extraColumns: isWorkOrderKind ? [workStatusColumn] : undefined,
+    extraColumns: isWorkOrderKind
+      ? kind === "design"
+        ? [designColumn, workStatusColumn]
+        : [workStatusColumn]
+      : undefined,
 
     useData: (fields, params) => {
       const resolvedFields = isWorkOrderKind ? withWorkStatusField(fields) : fields

--- a/apps/partner-ui/src/routes/payment-submissions/payment-submission-create/payment-submission-create.tsx
+++ b/apps/partner-ui/src/routes/payment-submissions/payment-submission-create/payment-submission-create.tsx
@@ -253,7 +253,15 @@ export const PaymentSubmissionCreate = () => {
         </div>
       </RouteFocusModal.Header>
 
-      <RouteFocusModal.Body className="flex flex-col gap-y-6 p-6 md:p-16">
+      {/* FocusModal.Content is `overflow-hidden` and FocusModal.Body is only
+          `flex-1` — the body does NOT scroll unless it asks to. Without
+          `overflow-y-auto` a partner with more than a handful of eligible
+          designs or tasks had the rest of the list clipped off the bottom of
+          the modal with no way to reach it (the Submit button lives in the
+          header, so the form still "worked" — you just couldn't see or pick
+          anything past the fold). `min-h-0` lets the flex child actually shrink
+          below its content height, which is what makes the scroll take effect. */}
+      <RouteFocusModal.Body className="flex min-h-0 flex-1 flex-col gap-y-6 overflow-y-auto p-6 md:p-16">
         <div className="mx-auto w-full max-w-[720px]">
           {/* Notes */}
           <div className="mb-6">

--- a/apps/partner-ui/src/routes/settings/production-runs/index.ts
+++ b/apps/partner-ui/src/routes/settings/production-runs/index.ts
@@ -1,0 +1,1 @@
+export { SettingsProductionRuns as Component } from "./production-runs.tsx"

--- a/apps/partner-ui/src/routes/settings/production-runs/production-runs.tsx
+++ b/apps/partner-ui/src/routes/settings/production-runs/production-runs.tsx
@@ -1,0 +1,127 @@
+import {
+  Container,
+  Heading,
+  InlineTip,
+  Switch,
+  Text,
+  toast,
+} from "@medusajs/ui"
+
+import { SingleColumnPage } from "../../../components/layout/pages"
+import { GeneralSectionSkeleton } from "../../../components/common/skeleton"
+import {
+  usePartnerSettings,
+  useUpdatePartnerSettings,
+} from "../../../hooks/api/partner-settings"
+
+/**
+ * Settings › Production Runs — the partner's own policy for the work sent to
+ * them.
+ *
+ * Today that's one switch, and it exists because the platform side of it
+ * already shipped with no way to opt in: `partner.auto_accept_production_runs`
+ * is a real column (#1228) that `emit-production-run-reminder` reads, but
+ * nothing in either UI could ever set it, so it was false for every partner and
+ * the auto-accept path was dead code.
+ */
+const AutoAcceptSection = () => {
+  const { partner, isPending, isError } = usePartnerSettings()
+  const { mutateAsync: updateSettings, isPending: isSaving } =
+    useUpdatePartnerSettings()
+
+  const enabled = !!partner?.auto_accept_production_runs
+
+  const handleToggle = async (next: boolean) => {
+    try {
+      await updateSettings({ auto_accept_production_runs: next })
+      toast.success(
+        next
+          ? "Re-sent production runs will be accepted for you"
+          : "Re-sent production runs will wait for you to accept"
+      )
+    } catch (e: any) {
+      toast.error("Could not save", {
+        description: e?.message || "Something went wrong",
+      })
+    }
+  }
+
+  if (isPending) {
+    return <GeneralSectionSkeleton rowCount={2} />
+  }
+
+  if (isError || !partner) {
+    return (
+      <Container className="divide-y p-0">
+        <div className="px-6 py-4">
+          <Heading level="h2">Auto accept</Heading>
+          <Text size="small" className="text-ui-fg-subtle mt-1">
+            Could not load your production settings.
+          </Text>
+        </div>
+      </Container>
+    )
+  }
+
+  return (
+    <Container className="divide-y p-0">
+      <div className="px-6 py-4">
+        <Heading level="h2">Auto accept</Heading>
+        <Text size="small" className="text-ui-fg-subtle">
+          What happens when work you didn't accept is sent to you again
+        </Text>
+      </div>
+
+      <div className="flex items-start justify-between gap-x-6 px-6 py-4">
+        <div className="flex flex-col gap-y-1">
+          <Text size="small" weight="plus">
+            Accept re-sent runs for me
+          </Text>
+          <Text size="small" className="text-ui-fg-subtle">
+            If a design run is dispatched to you and you don't accept it in
+            time, it gets re-sent. With this on, that second dispatch is
+            accepted on your behalf so production can start without another
+            round trip. Your FIRST dispatch is never auto-accepted — you always
+            get the chance to look at new work before taking it on.
+          </Text>
+        </div>
+        <Switch
+          checked={enabled}
+          disabled={isSaving}
+          onCheckedChange={handleToggle}
+          aria-label="Accept re-sent production runs automatically"
+        />
+      </div>
+
+      {enabled && (
+        <div className="px-6 py-4">
+          <InlineTip variant="warning" label="You own the work">
+            An auto-accepted run is yours — the same deadlines, reminders and
+            completion steps apply as if you had accepted it by hand. Turn this
+            off if you'd rather see every run before it becomes your
+            responsibility.
+          </InlineTip>
+        </div>
+      )}
+    </Container>
+  )
+}
+
+export const SettingsProductionRuns = () => {
+  return (
+    <SingleColumnPage widgets={{ before: [], after: [] }} hasOutlet>
+      <Container className="divide-y p-0">
+        <div className="px-6 py-4">
+          <Heading>Production Runs</Heading>
+          <Text className="text-ui-fg-subtle" size="small">
+            How design orders are handed to you
+          </Text>
+        </div>
+      </Container>
+
+      <AutoAcceptSection />
+    </SingleColumnPage>
+  )
+}
+
+export const Component = SettingsProductionRuns


### PR DESCRIPTION
Closes #1273.

Six partner-facing gaps across the order surfaces, the payment path and
production-run policy. Two of them were dead code paths — a column and a reader
with no UI to drive them.

## Orders → design

- **Drop the "Back to order" link.** The breadcrumb already does that job; the
  button duplicated it and pushed the design's content down. `backTo` is gone
  from `DesignDetail` along with its now-dead imports and the i18n string.
- **`DesignSectionsSkeleton`.** The single-design path rendered nothing while
  the design resolved over two hops (order → run → design) and then popped four
  sections in; the collated path had a two-bar placeholder. Both now skeleton
  the real stack, so the layout is stable from first paint.
- **Media in the order.** `DesignMediaSection` gained `linkBase`, so it renders
  under `/orders/:id` with Manage/preview pointing at
  `design-details/<id>/media` — routes that already exist.

## Design Orders table

Shows the design's picture + name, reusing the existing `Thumbnail` component
(`DesignCell`, modelled on `ProductCell`), in both the standard and the
flag-gated configurable table.

Backend side: `attachOrderDesignSummariesStep` attaches
`designs: [{id, name, thumbnail}]` per row, unioning the single-run link and
collated `items.metadata.design_id`. Resolution order is flagged media →
`metadata.thumbnail` → first media → the moodboard's first reference image.
Base64 data-URLs are deliberately skipped on the list path — an inlined
moodboard image would be megabytes per row. The step is additive and degrades
to no pictures rather than 500-ing, so retail/inventory rows and the admin
read-proxy (#843) are untouched.

## Payment submissions

- **Modal scroll.** `FocusModal.Content` is `overflow-hidden` and
  `FocusModal.Body` is only `flex-1`, so the body never scrolls unless a screen
  asks. Added `min-h-0 flex-1 overflow-y-auto`.
  ⚠️ ~98 of 172 `RouteFocusModal.Body` usages still lack it — out of scope here.
- **Auto-drafted submission on run completion.** A `production_run.completed`
  subscriber drafts a design-sourced submission with the amount the partner just
  entered. It lands as **Draft**, so nothing is billed on their behalf. Amount
  is per-unit × **ordered** quantity, so correcting output still does not move
  money.

  Two things this required, both deliberate:
  - `status` + `require_design_status` on `createPaymentSubmissionWorkflow`.
    Completion sets the design to `Technical_Review`, so the hand-submission
    gate ("must be Approved / Commerce_Ready") would have rejected every draft.
    Only the auto path passes `require_design_status: false`; the partner-facing
    route never does.
  - Drafts emit `payment_submission.drafted`, not `.created`. The seeded
    WhatsApp flow maps event names to templates explicitly and skips unknown
    ones, so an auto-draft sends no message — otherwise every completed run
    would tell the partner "we received your payment request".

## Production-run policy

- **Settings › Production Runs** with a `@medusajs/ui` Switch for auto-accept,
  saved via `PUT /partners/update`. `auto_accept_production_runs` was already a
  migrated column read by `emit-production-run-reminder`, but nothing could set
  it. Both gates still apply: the platform policy's `auto_accept_on_retry` AND
  the partner's opt-in, and only ever on a same-partner retry — never a first
  dispatch.
- **Re-assignment notice on the run card**, above the stepper so it's read
  before the Accept button: "sent to you again" (`reassign_retry_count > 0`,
  not yet accepted) vs "re-assigned to you" (`previous_partner_id` is someone
  else). Both fields are now returned by the partner run list.

## Verification

- 28 new unit tests, all passing (`design-thumbnail`, `run-payable`,
  `reassignment-notice`).
- Backend `tsc --noEmit`: **79 errors — exactly the clean-`main` baseline**
  (#1179), none in touched files.
- partner-ui `tsc`: adds nothing to its 4 pre-existing parse errors.
- Pre-existing failures confirmed by stashing, not caused here:
  `brief-shaper.unit.spec` and the i18n schema test (507 stale keys; net effect
  of this branch on it is zero).
- Integration suites not run.

**No migrations.** `auto_accept_production_runs` was already migrated.

🤖 Generated with [Claude Code](https://claude.com/claude-code)