### PR TITLE
fix(designs): key the create-run drawer's template selection by id (#1272)

### DIFF
--- a/apps/backend/integration-tests/http/design-production-runs-multi-partner.spec.ts
+++ b/apps/backend/integration-tests/http/design-production-runs-multi-partner.spec.ts
@@ -298,5 +298,181 @@ setupSharedTestSuite(() => {
       expect(runRes.data.production_run.dispatch_template_ids).toEqual([templateId])
       expect(runRes.data.production_run.dispatched_template_ids).toEqual([templateId])
     })
+
+    /**
+     * #1272 — the design page's "Create Production Run" drawer was the last
+     * name-keyed dispatch caller. It has two branches, and both now send ids:
+     *
+     *  a) per-assignment templates — the route auto-dispatches each child with
+     *     that assignment's OWN selection;
+     *  b) no per-assignment templates — the drawer creates, then calls
+     *     /send-to-production per partner-assigned run with the top-level
+     *     selection.
+     *
+     * Ids matter because two templates can share a name (#1261) and dispatch
+     * refuses an ambiguous one (#1262), so a name-keyed drawer could record an
+     * intent that can never be carried out.
+     */
+    describe("dispatching the design drawer's branches by template id", () => {
+      const setup = async (unique: number, partnerCount: number) => {
+        const { api } = getSharedTestEnv()
+
+        const partnerIds: string[] = []
+        for (let i = 0; i < partnerCount; i++) {
+          const res = await api.post(
+            "/admin/partners",
+            {
+              partner: {
+                name: `MP Ids Partner ${i} ${unique}`,
+                handle: `mp-ids-partner-${i}-${unique}`,
+              },
+              admin: {
+                email: `mp-ids-partner-${i}-admin-${unique}@jyt.test`,
+                first_name: "MP",
+                last_name: `Ids${i}`,
+              },
+            },
+            adminHeaders
+          )
+          expect(res.status).toBe(201)
+          partnerIds.push(res.data.partner.id)
+        }
+
+        const designRes = await api.post(
+          "/admin/designs",
+          {
+            name: `MP Ids Design ${unique}`,
+            description: "Design drawer dispatching by template id",
+            design_type: "Original",
+            status: "Commerce_Ready",
+            priority: "Medium",
+          },
+          adminHeaders
+        )
+        expect(designRes.status).toBe(201)
+
+        return { partnerIds, designId: designRes.data.design.id }
+      }
+
+      const createTemplate = async (name: string, category: string) => {
+        const { api } = getSharedTestEnv()
+        const res = await api.post(
+          "/admin/task-templates",
+          {
+            name,
+            description: "Drawer dispatch step",
+            priority: "medium",
+            estimated_duration: 30,
+            eventable: false,
+            notifiable: false,
+            metadata: { workflow_type: "production_run" },
+            category,
+          },
+          adminHeaders
+        )
+        expect(res.status).toBe(201)
+        return res.data.task_template.id as string
+      }
+
+      it("dispatches each assignment with its own template_ids", async () => {
+        const { api } = getSharedTestEnv()
+        const unique = Date.now()
+
+        const { partnerIds, designId } = await setup(unique, 2)
+        const cutId = await createTemplate(`mp-ids-cut-${unique}`, "Pre Production")
+        const stitchId = await createTemplate(`mp-ids-stitch-${unique}`, "Production")
+
+        const createRes = await api.post(
+          `/admin/designs/${designId}/production-runs`,
+          {
+            assignments: [
+              {
+                partner_id: partnerIds[0],
+                quantity: 3,
+                role: "cutting",
+                template_ids: [cutId],
+              },
+              {
+                partner_id: partnerIds[1],
+                quantity: 2,
+                role: "stitching",
+                template_ids: [stitchId],
+              },
+            ],
+          },
+          adminHeaders
+        )
+
+        expect(createRes.status).toBe(201)
+        const children = createRes.data.children || []
+        expect(children.length).toBe(2)
+        expect(createRes.data.dispatch?.failed).toEqual([])
+        expect((createRes.data.dispatch?.dispatched || []).sort()).toEqual(
+          children.map((c: any) => String(c.id)).sort()
+        )
+
+        // Each child carries ITS OWN selection — a batch-wide set would be
+        // wrong for most runs (#1263 makes the same point about bulk produce).
+        const expected = new Map<string, string>([
+          [String(partnerIds[0]), cutId],
+          [String(partnerIds[1]), stitchId],
+        ])
+
+        for (const child of children) {
+          const runRes = await api.get(
+            `/admin/production-runs/${child.id}`,
+            adminHeaders
+          )
+          const run = runRes.data.production_run
+          const templateId = expected.get(String(run.partner_id))
+          expect(templateId).toBeDefined()
+          expect(String(run.status)).toBe("sent_to_partner")
+          expect(run.dispatch_template_ids).toEqual([templateId])
+          expect(run.dispatched_template_ids).toEqual([templateId])
+        }
+      })
+
+      it("dispatches a created run through /send-to-production by id", async () => {
+        const { api } = getSharedTestEnv()
+        const unique = Date.now() + 1
+
+        const { partnerIds, designId } = await setup(unique, 1)
+        const templateId = await createTemplate(
+          `mp-ids-global-${unique}`,
+          "Production"
+        )
+
+        // The drawer's other branch: assignments carry no templates, so the
+        // run is created approved and dispatched in a second call.
+        const createRes = await api.post(
+          `/admin/designs/${designId}/production-runs`,
+          {
+            assignments: [{ partner_id: partnerIds[0], quantity: 4 }],
+          },
+          adminHeaders
+        )
+        expect(createRes.status).toBe(201)
+        const children = createRes.data.children || []
+        expect(children.length).toBe(1)
+        const childRunId = String(children[0].id)
+        expect(createRes.data.dispatch?.dispatched).toEqual([])
+
+        const sendRes = await api.post(
+          `/admin/production-runs/${childRunId}/send-to-production`,
+          { template_ids: [templateId] },
+          adminHeaders
+        )
+        expect([200, 201]).toContain(sendRes.status)
+
+        const runRes = await api.get(
+          `/admin/production-runs/${childRunId}`,
+          adminHeaders
+        )
+        expect(String(runRes.data.production_run.status)).toBe("sent_to_partner")
+        expect(runRes.data.production_run.dispatched_template_ids).toEqual([
+          templateId,
+        ])
+      })
+    })
   })
 })

--- a/apps/backend/src/admin/routes/designs/[id]/@production-run/page.tsx
+++ b/apps/backend/src/admin/routes/designs/[id]/@production-run/page.tsx
@@ -35,6 +35,7 @@ const assignmentSchema = z.object({
   quantity: z.coerce.number().positive("Quantity must be > 0"),
   order: z.coerce.number().int().positive().optional(),
   template_names: z.array(z.string()).optional(),
+  template_ids: z.array(z.string()).optional(),
 })
 
 const createSchema = z.object({
@@ -43,6 +44,7 @@ const createSchema = z.object({
   assignments: z.array(assignmentSchema).optional(),
   send_to_production: z.boolean().optional(),
   template_names: z.array(z.string()).optional(),
+  template_ids: z.array(z.string()).optional(),
 })
 
 type FormValues = z.infer<typeof createSchema>
@@ -53,6 +55,43 @@ type Assignment = {
   quantity: number
   order?: number
   template_names?: string[]
+  template_ids?: string[]
+}
+
+/**
+ * Two templates can share a name — different process steps wearing one label
+ * (#1261) — and dispatch REFUSES an ambiguous name since #1262. Selection is
+ * therefore keyed by id everywhere below; the grouping by category already
+ * separates the common collision visually, so a name is only qualified further
+ * when it repeats INSIDE one category, where the header cannot tell them apart.
+ */
+const labelForTemplate = (tpl: any, siblingNameCount: number) => {
+  const name = String(tpl?.name || "")
+  return siblingNameCount > 1 ? `${name} · ${String(tpl?.id || "").slice(-6)}` : name
+}
+
+/** Group templates by category name, preserving the existing display order. */
+const groupByCategory = (templates: any[]): [string, any[]][] =>
+  Object.entries(
+    templates.reduce((acc: Record<string, any[]>, tpl: any) => {
+      const cat =
+        typeof tpl.category === "object"
+          ? tpl.category?.name || "Uncategorized"
+          : String(tpl.category || "Uncategorized")
+      if (!acc[cat]) acc[cat] = []
+      acc[cat].push(tpl)
+      return acc
+    }, {} as Record<string, any[]>)
+  )
+
+/** How many templates in `group` answer to each name — drives the label above. */
+const nameCounts = (group: any[]) => {
+  const counts = new Map<string, number>()
+  for (const t of group) {
+    const name = String(t?.name || "")
+    counts.set(name, (counts.get(name) ?? 0) + 1)
+  }
+  return counts
 }
 
 const MODAL_ID = "manage-assignments"
@@ -85,7 +124,7 @@ const AssignmentsModal = ({
   const addAssignment = () => {
     setLocal((prev) => [
       ...prev,
-      { partner_id: "", role: "", quantity: 1, order: undefined, template_names: [] },
+      { partner_id: "", role: "", quantity: 1, order: undefined, template_ids: [] },
     ])
   }
 
@@ -99,15 +138,16 @@ const AssignmentsModal = ({
     )
   }
 
-  const toggleTemplate = (idx: number, name: string) => {
+  /** Keyed by id, not name — see `labelForTemplate` (#1272). */
+  const toggleTemplate = (idx: number, id: string) => {
     setLocal((prev) =>
       prev.map((a, i) => {
         if (i !== idx) return a
-        const current = a.template_names || []
-        const next = current.includes(name)
-          ? current.filter((n) => n !== name)
-          : [...current, name]
-        return { ...a, template_names: next }
+        const current = a.template_ids || []
+        const next = current.includes(id)
+          ? current.filter((t) => t !== id)
+          : [...current, id]
+        return { ...a, template_ids: next }
       })
     )
   }
@@ -227,19 +267,12 @@ const AssignmentsModal = ({
                   <Text size="small" weight="plus" className="mb-2">
                     Task Templates
                   </Text>
-                  {Object.entries(
-                    templatesToShow.reduce((acc: Record<string, any[]>, tpl: any) => {
-                      const cat = typeof tpl.category === "object"
-                        ? tpl.category?.name || "Uncategorized"
-                        : String(tpl.category || "Uncategorized")
-                      if (!acc[cat]) acc[cat] = []
-                      acc[cat].push(tpl)
-                      return acc
-                    }, {} as Record<string, any[]>)
-                  ).map(([categoryName, categoryTemplates]: [string, any[]]) => {
-                    const categoryNames = categoryTemplates.map((t: any) => String(t.name))
-                    const selectedNames = assignment.template_names || []
-                    const allSelected = categoryNames.every((n: string) => selectedNames.includes(n))
+                  {groupByCategory(templatesToShow).map(
+                    ([categoryName, categoryTemplates]) => {
+                    const categoryIds = categoryTemplates.map((t: any) => String(t.id))
+                    const selectedIds = assignment.template_ids || []
+                    const allSelected = categoryIds.every((id: string) => selectedIds.includes(id))
+                    const counts = nameCounts(categoryTemplates)
 
                     return (
                       <div key={categoryName} className="mb-3">
@@ -253,12 +286,12 @@ const AssignmentsModal = ({
                             onClick={() => {
                               if (allSelected) {
                                 // Deselect all in this category
-                                const next = selectedNames.filter((n: string) => !categoryNames.includes(n))
-                                updateField(idx, "template_names", next)
+                                const next = selectedIds.filter((id: string) => !categoryIds.includes(id))
+                                updateField(idx, "template_ids", next)
                               } else {
                                 // Select all in this category
-                                const next = [...new Set([...selectedNames, ...categoryNames])]
-                                updateField(idx, "template_names", next)
+                                const next = [...new Set([...selectedIds, ...categoryIds])]
+                                updateField(idx, "template_ids", next)
                               }
                             }}
                           >
@@ -267,16 +300,18 @@ const AssignmentsModal = ({
                         </div>
                         <div className="flex flex-wrap gap-2">
                           {categoryTemplates.map((tpl: any) => {
-                            const name = String(tpl.name)
-                            const selected = selectedNames.includes(name)
+                            const id = String(tpl.id)
+                            const selected = selectedIds.includes(id)
                             return (
                               <button
-                                key={name}
+                                key={id}
                                 type="button"
                                 className="rounded-md border px-3 py-1.5 text-sm"
-                                onClick={() => toggleTemplate(idx, name)}
+                                onClick={() => toggleTemplate(idx, id)}
                               >
-                                <Badge color={selected ? "green" : "grey"}>{name}</Badge>
+                                <Badge color={selected ? "green" : "grey"}>
+                                  {labelForTemplate(tpl, counts.get(String(tpl.name)) ?? 1)}
+                                </Badge>
                               </button>
                             )
                           })}
@@ -326,12 +361,12 @@ const CreateProductionRunDrawerForm = () => {
       run_type: "production",
       assignments: [],
       send_to_production: false,
-      template_names: [],
+      template_ids: [],
     },
   })
 
   const sendToProduction = form.watch("send_to_production")
-  const selectedTemplateNames = form.watch("template_names") || []
+  const selectedTemplateIds = form.watch("template_ids") || []
   const assignments = form.watch("assignments") || []
 
   const { partners = [] } = usePartners({ limit: 100, offset: 0 })
@@ -361,13 +396,13 @@ const CreateProductionRunDrawerForm = () => {
     }
 
     const hasPerAssignmentTemplates = values.assignments?.some(
-      (a) => a.template_names && a.template_names.length > 0
+      (a) => a.template_ids && a.template_ids.length > 0
     )
 
     if (
       values.send_to_production &&
       !hasPerAssignmentTemplates &&
-      (!values.template_names || !values.template_names.length)
+      (!values.template_ids || !values.template_ids.length)
     ) {
       toast.error("Select at least one task template")
       return
@@ -387,12 +422,12 @@ const CreateProductionRunDrawerForm = () => {
         return
       }
 
-      // When per-assignment template_names are set, the backend route
+      // When per-assignment template_ids are set, the backend route
       // already auto-dispatches each child (see
       // apps/backend/src/api/admin/designs/[id]/production-runs/route.ts
-      // — the for-loop over children with dispatch_template_names).
+      // — `autoDispatchApprovedChildren` over the approved children).
       // Calling sendMutation here would be a redundant second dispatch,
-      // and with `values.template_names = []` (global empty because the
+      // and with `values.template_ids = []` (global empty because the
       // user picked per-assignment templates) the strict `min(1)`
       // validator on /send-to-production would 400.
       if (hasPerAssignmentTemplates) {
@@ -416,7 +451,8 @@ const CreateProductionRunDrawerForm = () => {
       for (const run of runsToSend) {
         await sendMutation.mutateAsync({
           run_id: String(run.id),
-          template_names: values.template_names || [],
+          // By id — dispatch refuses an ambiguous name (#1262/#1272).
+          template_ids: values.template_ids || [],
         })
       }
 
@@ -552,18 +588,11 @@ const CreateProductionRunDrawerForm = () => {
                     </Text>
 
                     <div className="mt-2">
-                      {Object.entries(
-                        templatesToShow.reduce((acc: Record<string, any[]>, tpl: any) => {
-                          const cat = typeof tpl.category === "object"
-                            ? tpl.category?.name || "Uncategorized"
-                            : String(tpl.category || "Uncategorized")
-                          if (!acc[cat]) acc[cat] = []
-                          acc[cat].push(tpl)
-                          return acc
-                        }, {} as Record<string, any[]>)
-                      ).map(([categoryName, categoryTemplates]) => {
-                        const categoryNames = categoryTemplates.map((t: any) => String(t.name))
-                        const allSelected = categoryNames.every((n: string) => selectedTemplateNames.includes(n))
+                      {groupByCategory(templatesToShow).map(
+                        ([categoryName, categoryTemplates]) => {
+                        const categoryIds = categoryTemplates.map((t: any) => String(t.id))
+                        const allSelected = categoryIds.every((id: string) => selectedTemplateIds.includes(id))
+                        const counts = nameCounts(categoryTemplates)
 
                         return (
                           <div key={categoryName} className="mb-3">
@@ -575,17 +604,17 @@ const CreateProductionRunDrawerForm = () => {
                                 type="button"
                                 className="text-xs text-ui-fg-interactive hover:text-ui-fg-interactive-hover"
                                 onClick={() => {
-                                  const current = form.getValues("template_names") || []
+                                  const current = form.getValues("template_ids") || []
                                   if (allSelected) {
                                     form.setValue(
-                                      "template_names",
-                                      current.filter((n) => !categoryNames.includes(n)),
+                                      "template_ids",
+                                      current.filter((id) => !categoryIds.includes(id)),
                                       { shouldDirty: true }
                                     )
                                   } else {
                                     form.setValue(
-                                      "template_names",
-                                      [...new Set([...current, ...categoryNames])],
+                                      "template_ids",
+                                      [...new Set([...current, ...categoryIds])],
                                       { shouldDirty: true }
                                     )
                                   }
@@ -596,24 +625,26 @@ const CreateProductionRunDrawerForm = () => {
                             </div>
                             <div className="flex flex-wrap gap-2">
                               {categoryTemplates.map((tpl: any) => {
-                                const name = String(tpl.name)
-                                const selected = selectedTemplateNames.includes(name)
+                                const id = String(tpl.id)
+                                const selected = selectedTemplateIds.includes(id)
                                 return (
                                   <button
-                                    key={name}
+                                    key={id}
                                     type="button"
                                     className="rounded-md border px-2 py-1 text-xs"
                                     onClick={() => {
-                                      const current = form.getValues("template_names") || []
+                                      const current = form.getValues("template_ids") || []
                                       const next = selected
-                                        ? current.filter((n) => n !== name)
-                                        : [...current, name]
-                                      form.setValue("template_names", next, {
+                                        ? current.filter((t) => t !== id)
+                                        : [...current, id]
+                                      form.setValue("template_ids", next, {
                                         shouldDirty: true,
                                       })
                                     }}
                                   >
-                                    <Badge color={selected ? "green" : "grey"}>{name}</Badge>
+                                    <Badge color={selected ? "green" : "grey"}>
+                                      {labelForTemplate(tpl, counts.get(String(tpl.name)) ?? 1)}
+                                    </Badge>
                                   </button>
                                 )
                               })}


### PR DESCRIPTION
Closes #1272.

The design page's "Create Production Run" drawer was the **last name-keyed dispatch caller** from the #1261 thread — #1267 converted the dispatch drawer and WhatsApp `send run`, #1269 the approve modal.

## The bug

Two templates can share a name — different process steps wearing one label (#1261). The drawer keyed per-assignment selection by name and rendered `key={name}`, so a collision collapsed them into **one toggle with a duplicate React key**, and whichever the admin picked went out as a name that dispatch has **refused since #1262**. The admin had no way to say which one they meant.

Latent rather than firing today, because #1262 auto-qualifies colliding names on create/rename and the dedup job cleared the one prod collision. It re-arms the moment a collision is reintroduced — e.g. templates seeded outside the API.

## The fix

Both of the drawer's branches now select and send `template_ids`:

- **per-assignment** — the route auto-dispatches each child with its own set;
- **top-level selection** — passed to `/send-to-production` per partner-assigned run.

Selection, `key=`, and select-all are all id-keyed. Grouping by category already separates the common collision visually, so a name is only qualified further (with a short id suffix) when it repeats **inside one category**, where the header cannot tell them apart.

**No backend change** — the route, validators and `AdminSendProductionRunToProductionPayload` have accepted `template_ids` since #1267/#1268. `template_names` stays declared in the form schema (as in #1269) but the UI no longer writes it.

## Verification

`integration-tests/http/design-production-runs-multi-partner.spec.ts` — two new cases, one per branch, asserting `dispatched_template_ids` on the resulting runs. The per-assignment case gives the two assignments **different** template sets and checks each child got its own, not a pooled batch-wide set.

```
✓ should create parent run + child runs from assignments
✓ dispatches auto-populated assignments with the top-level template selection
✓ dispatches each assignment with its own template_ids            (new)
✓ dispatches a created run through /send-to-production by id      (new)
```

`tsc` unchanged at the 79 baseline (the resolver error in this file is pre-existing on clean `main`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)