### PR TITLE
fix(partner-ui): give a genuine shortfall a control instead of a 400 (#1271)

### DIFF
--- a/apps/partner-ui/src/components/work-orders/production-run-card.tsx
+++ b/apps/partner-ui/src/components/work-orders/production-run-card.tsx
@@ -21,6 +21,7 @@ import { InformationCircleSolid, ExclamationCircle } from "@medusajs/icons"
 import { useState } from "react"
 import { Link } from "react-router-dom"
 
+import { planCompletionOutput } from "../../lib/completion-output"
 import { PartnerDesign } from "../../hooks/api/partner-designs"
 import {
   useAcceptPartnerProductionRun,
@@ -941,6 +942,14 @@ const CompleteRunForm = ({
   const [rejectedQty, setRejectedQty] = useState("")
   const [rejectionReason, setRejectionReason] = useState("")
   const [rejectionNotes, setRejectionNotes] = useState("")
+  /**
+   * #1271 — what happened to units that were neither made nor rejected.
+   * The backend allows a genuine shortfall, but only with `allow_shortfall`
+   * AND a written explanation; without a control for it the only way past the
+   * gate was to inflate `produced_quantity`, which is what the gate exists to
+   * prevent.
+   */
+  const [shortfallReason, setShortfallReason] = useState("")
 
   // ── Step 2: Cost ──
   const [costType, setCostType] = useState<"per_unit" | "total">("total")
@@ -977,6 +986,15 @@ const CompleteRunForm = ({
   const produced = parseFloat(producedQty) || 0
   const rejected = parseFloat(rejectedQty) || 0
   const yieldPct = runQuantity > 0 ? Math.round((produced / runQuantity) * 100) : 0
+  // Rejects are output too — output that failed. Anything left over is
+  // unaccounted for, and the completion gate refuses it unless it is declared.
+  const outputPlan = planCompletionOutput({
+    ordered: runQuantity,
+    produced,
+    rejected,
+    shortfallReason,
+  })
+  const unaccounted = outputPlan.unaccounted
   const costValue = parseFloat(partnerEstimate) || 0
   const totalCost = costType === "per_unit" ? Math.round(costValue * produced * 100) / 100 : costValue
   const perUnitCost = costType === "total" && produced > 0 ? Math.round(costValue / produced * 100) / 100 : costValue
@@ -1011,11 +1029,34 @@ const CompleteRunForm = ({
       body.cost_type = costType
     }
     if (validConsumptions.length > 0) body.consumptions = validConsumptions
-    if (completionNotes.trim()) body.notes = completionNotes.trim()
+
+    // The shortfall explanation rides in `notes` — that is the field the gate
+    // reads, and it keeps the reason with the completion rather than in a
+    // side channel nobody looks at.
+    const noteParts = [outputPlan.noteLine || "", completionNotes.trim()].filter(
+      Boolean
+    )
+
+    if (noteParts.length) body.notes = noteParts.join("\n")
+    if (outputPlan.allowShortfall) body.allow_shortfall = true
+
     return body
   }
 
   const handleSubmit = async () => {
+    // Mirror the backend gate so the partner gets a control, not a 400 telling
+    // them to do something the form could not express (#1271).
+    if (outputPlan.needsReason) {
+      toast.error(
+        `${unaccounted} piece${unaccounted !== 1 ? "s" : ""} unaccounted for`,
+        {
+          description:
+            "Say what happened to them — record them as rejected, or write the reason in the shortfall box. Don't raise the produced count to cover them.",
+        }
+      )
+      return
+    }
+
     const body = buildBody()
 
     // Warn if no cost data
@@ -1084,14 +1125,7 @@ const CompleteRunForm = ({
               max={runQuantity}
               step="1"
               value={producedQty}
-              onChange={(e) => {
-                setProducedQty(e.target.value)
-                // Auto-calculate rejected
-                const p = parseFloat(e.target.value) || 0
-                const r = runQuantity - p
-                if (r > 0) setRejectedQty(String(r))
-                else setRejectedQty("")
-              }}
+              onChange={(e) => setProducedQty(e.target.value)}
             />
           </div>
           <div>
@@ -1117,7 +1151,46 @@ const CompleteRunForm = ({
             <Text size="xsmall" className="text-ui-fg-muted">
               {produced} of {runQuantity} pieces
               {rejected > 0 ? ` · ${rejected} rejected` : ""}
+              {unaccounted > 0 ? ` · ${unaccounted} unaccounted for` : ""}
             </Text>
+          </div>
+        )}
+
+        {/*
+          #1271 — the missing units. The form used to fill the rejected field
+          with the remainder automatically, which recorded units that were
+          never made as units that FAILED, and left a partner whose shortfall
+          was something else (fabric ran out, order cut short) with no way
+          through the completion gate except inflating the produced count.
+        */}
+        {unaccounted > 0 && (
+          <div className="mt-3 pt-3 border-t border-ui-border-base">
+            <div className="flex items-center justify-between gap-3 mb-2">
+              <Text size="xsmall" weight="plus" className="text-ui-tag-orange-text">
+                {unaccounted} piece{unaccounted !== 1 ? "s" : ""} not accounted for
+              </Text>
+              <Button
+                type="button"
+                size="small"
+                variant="secondary"
+                onClick={() => {
+                  setRejectedQty(String(rejected + unaccounted))
+                  setShortfallReason("")
+                }}
+              >
+                They were rejected
+              </Button>
+            </div>
+            <Text size="xsmall" className="text-ui-fg-subtle mb-1">
+              If they failed quality, record them as rejected. Otherwise say what
+              happened — a recorded shortfall is fine, a wrong produced count is not.
+            </Text>
+            <Textarea
+              rows={2}
+              placeholder="e.g. fabric ran out after 8 pieces — remaining 2 not cut"
+              value={shortfallReason}
+              onChange={(e) => setShortfallReason(e.target.value)}
+            />
           </div>
         )}
 

--- a/apps/partner-ui/src/lib/__tests__/completion-output.spec.ts
+++ b/apps/partner-ui/src/lib/__tests__/completion-output.spec.ts
@@ -1,0 +1,92 @@
+import { describe, expect, it } from "vitest"
+
+import { planCompletionOutput } from "../completion-output"
+
+describe("planCompletionOutput (#1271)", () => {
+  it("passes a completion that accounts for everything ordered", () => {
+    const plan = planCompletionOutput({ ordered: 10, produced: 10, rejected: 0 })
+
+    expect(plan.unaccounted).toBe(0)
+    expect(plan.allowShortfall).toBe(false)
+    expect(plan.needsReason).toBe(false)
+    expect(plan.noteLine).toBeNull()
+  })
+
+  it("counts rejects as accounted output, not as a shortfall", () => {
+    // 9 good + 1 rejected against an order of 10 is a complete, honest
+    // completion — the gate asks what happened to the units, not that they
+    // all succeeded.
+    const plan = planCompletionOutput({ ordered: 10, produced: 9, rejected: 1 })
+
+    expect(plan.unaccounted).toBe(0)
+    expect(plan.allowShortfall).toBe(false)
+  })
+
+  it("asks for a reason when units are unaccounted for", () => {
+    const plan = planCompletionOutput({ ordered: 10, produced: 8, rejected: 0 })
+
+    expect(plan.unaccounted).toBe(2)
+    expect(plan.needsReason).toBe(true)
+    // Nothing is sent until the partner says what happened — the alternative
+    // the old form pushed them towards was inflating produced to 10.
+    expect(plan.noteLine).toBeNull()
+  })
+
+  it("declares the shortfall once a reason is given", () => {
+    const plan = planCompletionOutput({
+      ordered: 10,
+      produced: 8,
+      rejected: 0,
+      shortfallReason: "  fabric ran out after 8  ",
+    })
+
+    expect(plan.unaccounted).toBe(2)
+    expect(plan.allowShortfall).toBe(true)
+    expect(plan.needsReason).toBe(false)
+    expect(plan.noteLine).toBe(
+      "Shortfall: 2 of 10 not produced — fabric ran out after 8"
+    )
+  })
+
+  it("treats whitespace as no reason at all", () => {
+    const plan = planCompletionOutput({
+      ordered: 10,
+      produced: 8,
+      rejected: 0,
+      shortfallReason: "   ",
+    })
+
+    expect(plan.needsReason).toBe(true)
+    expect(plan.noteLine).toBeNull()
+  })
+
+  it("splits the remainder between rejects and shortfall", () => {
+    const plan = planCompletionOutput({
+      ordered: 10,
+      produced: 6,
+      rejected: 2,
+      shortfallReason: "two were never cut",
+    })
+
+    expect(plan.unaccounted).toBe(2)
+    expect(plan.noteLine).toBe(
+      "Shortfall: 2 of 10 not produced — two were never cut"
+    )
+  })
+
+  it("never reports a negative shortfall when output exceeds the order", () => {
+    const plan = planCompletionOutput({ ordered: 10, produced: 12, rejected: 0 })
+
+    expect(plan.unaccounted).toBe(0)
+    expect(plan.allowShortfall).toBe(false)
+  })
+
+  it("enforces nothing when there is no ordered quantity", () => {
+    // Runs created without one predate the field being meaningful; the
+    // backend gate skips them too.
+    const plan = planCompletionOutput({ ordered: 0, produced: 0, rejected: 0 })
+
+    expect(plan.unaccounted).toBe(0)
+    expect(plan.needsReason).toBe(false)
+  })
+})

--- a/apps/partner-ui/src/lib/completion-output.ts
+++ b/apps/partner-ui/src/lib/completion-output.ts
@@ -1,0 +1,68 @@
+/**
+ * #1271 — the partner side of the completion output gate.
+ *
+ * The backend (`checkCompletionOutput`) refuses a completion that does not
+ * account for everything ordered. Rejects count as output — output that
+ * failed — so 9 good + 1 rejected against an order of 10 is complete. What it
+ * refuses is units nobody said anything about, unless the completion carries
+ * `allow_shortfall: true` AND a written reason.
+ *
+ * Neither UI had a control for that, so a partner who genuinely made 8 of 10
+ * hit a 400 asking for something the form could not send, and the only way
+ * through was to raise the produced count — exactly what the gate exists to
+ * prevent. This mirrors the gate locally so the form can ask the right
+ * question instead of failing the request.
+ */
+export type CompletionOutputPlan = {
+  /** Ordered minus (produced + rejected), never negative. */
+  unaccounted: number
+  /** Whether the request must declare a shortfall. */
+  allowShortfall: boolean
+  /** Set when the partner must still say what happened to the missing units. */
+  needsReason: boolean
+  /** The shortfall line to prepend to `notes`, or null when there is none. */
+  noteLine: string | null
+}
+
+export const planCompletionOutput = (input: {
+  ordered: number
+  produced: number
+  rejected: number
+  shortfallReason?: string
+}): CompletionOutputPlan => {
+  const ordered = Number(input.ordered)
+  const produced = Number(input.produced) || 0
+  const rejected = Number(input.rejected) || 0
+
+  // No ordered quantity to measure against — the backend enforces nothing
+  // here either, so neither should the form.
+  if (!Number.isFinite(ordered) || ordered <= 0) {
+    return {
+      unaccounted: 0,
+      allowShortfall: false,
+      needsReason: false,
+      noteLine: null,
+    }
+  }
+
+  const unaccounted = Math.max(0, ordered - (produced + rejected))
+  const reason = (input.shortfallReason || "").trim()
+
+  if (unaccounted <= 0) {
+    return {
+      unaccounted: 0,
+      allowShortfall: false,
+      needsReason: false,
+      noteLine: null,
+    }
+  }
+
+  return {
+    unaccounted,
+    allowShortfall: true,
+    needsReason: !reason,
+    noteLine: reason
+      ? `Shortfall: ${unaccounted} of ${ordered} not produced — ${reason}`
+      : null,
+  }
+}


### PR DESCRIPTION
Closes #1271.

## The problem

`checkCompletionOutput` (#1262) refuses a completion that doesn't account for the ordered quantity. A genuine shortfall is allowed — but only with `allow_shortfall: true` **plus** a written reason. The route accepts it; **`allow_shortfall` appeared nowhere in `apps/partner-ui`**. A partner who made 8 of 10 got a 400 telling them to do something the form had no control for.

Auditing the form turned up a second half the issue didn't have:

> the produced input **auto-filled the rejected field with the remainder**

So lowering "good pieces produced" silently recorded the missing units as units that **failed quality**. A partner whose shortfall was something else — fabric ran out, run cut short — had exactly one way through the gate: raise the produced count back to 10. That is the outcome the gate's own comment says it exists to prevent:

> *"Without that escape the gate would be unworkable and someone would route around it by inflating the number, which is worse than a recorded shortfall."*

## The fix

The Output step now names the gap instead of guessing at it. The auto-fill is gone; when `produced + rejected < ordered` the form shows how many are unaccounted for, with:

- a one-click **"They were rejected"** for the case the auto-fill assumed, and
- a **shortfall box** for everything else.

With a reason, the completion sends `allow_shortfall: true` and prepends the explanation to `notes` — the field the gate reads, which also keeps the reason attached to the completion rather than in a side channel. With no reason, the form says so itself rather than letting the request 400.

The decision is extracted to `planCompletionOutput` (`src/lib/completion-output.ts`) and unit-tested against the same cases as the backend gate, since it decides what output — and therefore what production history and payout basis — gets recorded.

**Admin needs no mirror**: the output-correction flow (#1239) writes the columns directly via `updateProductionRuns` and never reaches this gate.

## Verification

```
✓ src/lib/__tests__/completion-output.spec.ts (8 tests)
```
covering: full accounting passes · rejects count as accounted, not shortfall · unaccounted asks for a reason and sends nothing until it has one · a reason produces the `allow_shortfall` note line · whitespace is not a reason · a remainder split between rejects and shortfall · overproduction never goes negative · no ordered quantity enforces nothing (as the backend gate also skips).

`tsc` clean for the touched files (4 pre-existing errors in untouched `order-create-claim`/`order-create-exchange` files remain).

## Still open from the issue

Whether any partner has **already** worked around this by inflating `produced_quantity` is a prod read (see the #1248 thread for why that number matters downstream) and has not been run.

🤖 Generated with [Claude Code](https://claude.com/claude-code)