### PR TITLE
fix(designs): make produce_designs actually dispatch, per design (#1263)

### DIFF
--- a/apps/backend/integration-tests/http/designs-produce-no-customer.spec.ts
+++ b/apps/backend/integration-tests/http/designs-produce-no-customer.spec.ts
@@ -149,5 +149,165 @@ setupSharedTestSuite(() => {
         expect(assignedDesignIds).toContain(designId)
       }
     })
+
+    /**
+     * #1263 — this path used to stop at creation. Runs were born
+     * `sent_to_partner` and no task template was ever instantiated, so the
+     * partner was handed work with nothing to accept while the record claimed
+     * it had been sent — the same "the record says one thing and the work says
+     * another" class as #1261.
+     */
+    describe("dispatching the batch (#1263)", () => {
+      const createTemplate = async (suffix: string, category: string) => {
+        const res = await api.post(
+          "/admin/task-templates",
+          {
+            name: `produce-batch-${suffix}-${Date.now()}`,
+            description: "produce batch step",
+            priority: "medium",
+            estimated_duration: 30,
+            eventable: false,
+            notifiable: false,
+            metadata: { workflow_type: "production_run" },
+            category,
+          },
+          adminHeaders
+        )
+        expect(res.status).toBe(201)
+        return res.data.task_template.id as string
+      }
+
+      const createDesign = async (label: string) => {
+        const res = await api.post(
+          "/admin/designs",
+          {
+            name: `Produce Batch ${label} ${Date.now()}`,
+            description: "produce batch test",
+            design_type: "Original",
+            status: "Approved",
+            priority: "Medium",
+          },
+          adminHeaders
+        )
+        expect(res.status).toBe(201)
+        return res.data.design.id as string
+      }
+
+      it("dispatches each design with ITS OWN templates", async () => {
+        const container = getContainer()
+        const templateA = await createTemplate("cut", "Pre Production")
+        const templateB = await createTemplate("stitch", "Production")
+        const batchDesignIds = [
+          await createDesign("A"),
+          await createDesign("B"),
+        ]
+
+        const result = await produceDesignsAsWorkOrder(
+          container,
+          batchDesignIds,
+          partnerId,
+          {
+            // Per design, not pooled: the #1261 recovery found 7 runs using 4
+            // different sets, so one batch-wide selection would be wrong for
+            // most of them.
+            selections: [
+              { design_id: batchDesignIds[0], template_ids: [templateA] },
+              { design_id: batchDesignIds[1], template_ids: [templateB] },
+            ],
+          }
+        )
+
+        expect(result.created).toBe(2)
+        expect(result.not_dispatched).toEqual([])
+        expect([...result.dispatched].sort()).toEqual(
+          [...batchDesignIds].sort()
+        )
+
+        const expected = new Map([
+          [batchDesignIds[0], templateA],
+          [batchDesignIds[1], templateB],
+        ])
+
+        const runService: any = container.resolve(PRODUCTION_RUNS_MODULE)
+        const runs = await runService.listProductionRuns(
+          { id: result.run_ids },
+          { select: ["id", "design_id", "status", "dispatched_template_ids"] }
+        )
+        expect(runs).toHaveLength(2)
+        for (const run of runs) {
+          expect(run.status).toBe("sent_to_partner")
+          // The whole point: the run now records what it was dispatched with.
+          expect(run.dispatched_template_ids).toEqual([
+            expected.get(run.design_id),
+          ])
+        }
+
+        // And the partner has something to accept — the old path created none.
+        const query = container.resolve(ContainerRegistrationKeys.QUERY) as any
+        for (const runId of result.run_ids) {
+          const { data } = await query.graph({
+            entity: "production_runs",
+            fields: ["id", "tasks.id"],
+            filters: { id: runId },
+          })
+          expect((data?.[0]?.tasks || []).length).toBeGreaterThan(0)
+        }
+      })
+
+      it("previews the design → templates plan without creating anything", async () => {
+        const container = getContainer()
+        const templateA = await createTemplate("dry", "Production")
+        const designId = await createDesign("Dry")
+
+        const result = await produceDesignsAsWorkOrder(
+          container,
+          [designId],
+          partnerId,
+          { templateIds: [templateA], dryRun: true }
+        )
+
+        expect(result.dry_run).toBe(true)
+        expect(result.created).toBe(0)
+        expect(result.run_ids).toEqual([])
+        expect(result.work_order_id).toBeNull()
+        expect(result.designs).toEqual([
+          expect.objectContaining({
+            design_id: designId,
+            template_ids: [templateA],
+            dispatched: false,
+          }),
+        ])
+
+        const runService: any = container.resolve(PRODUCTION_RUNS_MODULE)
+        const runs = await runService.listProductionRuns(
+          { design_id: designId },
+          { select: ["id"] }
+        )
+        expect(runs).toHaveLength(0)
+      })
+
+      it("reports a design left with no templates instead of silently creating a taskless run", async () => {
+        const container = getContainer()
+        const designId = await createDesign("NoTemplates")
+
+        const result = await produceDesignsAsWorkOrder(
+          container,
+          [designId],
+          partnerId
+        )
+
+        // Backwards compatible — the run is still created, as before. What is
+        // new is that the caller is told it carries no tasks.
+        expect(result.created).toBe(1)
+        expect(result.dispatched).toEqual([])
+        expect(result.not_dispatched).toEqual([
+          expect.objectContaining({
+            design_id: designId,
+            dispatched: false,
+            reason: expect.stringContaining("no templates selected"),
+          }),
+        ])
+      })
+    })
   })
 })

--- a/apps/backend/src/admin/components/designs/send-to-production-drawer.tsx
+++ b/apps/backend/src/admin/components/designs/send-to-production-drawer.tsx
@@ -11,11 +11,20 @@ import {
 import { useNavigate } from "react-router-dom"
 import { AdminDesign } from "../../hooks/api/designs"
 import { usePartners, AdminPartner } from "../../hooks/api/partners"
+import { useTaskTemplates } from "../../hooks/api/task-templates"
 import { sdk } from "../../lib/config"
 import { useQueryClient } from "@tanstack/react-query"
 import { queryKeysFactory } from "../../lib/query-key-factory"
 
 const designQueryKeys = queryKeysFactory("designs" as const)
+
+interface ProduceDesignReport {
+  design_id: string
+  run_id: string | null
+  template_ids: string[]
+  dispatched: boolean
+  reason?: string
+}
 
 interface ProduceDesignsResponse {
   design_production: {
@@ -23,6 +32,9 @@ interface ProduceDesignsResponse {
     run_ids: string[]
     design_ids: string[]
     work_order_id: string | null
+    designs?: ProduceDesignReport[]
+    dispatched?: string[]
+    not_dispatched?: ProduceDesignReport[]
   }
 }
 
@@ -52,6 +64,38 @@ export const SendToProductionDrawer = ({
   const [search, setSearch] = useState("")
   const [selectedPartnerId, setSelectedPartnerId] = useState("")
   const [isSending, setIsSending] = useState(false)
+  /**
+   * #1263 — the process the partner is being asked to run. Without it the
+   * batch used to be created `sent_to_partner` with NO tasks: nothing for the
+   * partner to accept, while the record claimed it had been sent.
+   *
+   * By id, never name — two templates can share a name and dispatch refuses
+   * an ambiguous one (#1262). One selection applies to every design in the
+   * batch; per-design sets go through the API's `designs[]` form.
+   */
+  const [selectedTemplateIds, setSelectedTemplateIds] = useState<string[]>([])
+  const { task_templates: taskTemplates = [] } = useTaskTemplates({
+    limit: 100,
+    offset: 0,
+  })
+
+  const templatesByCategory = useMemo(() => {
+    const groups = new Map<string, any[]>()
+    for (const tpl of taskTemplates as any[]) {
+      const category =
+        typeof tpl?.category === "object"
+          ? tpl.category?.name || "Uncategorized"
+          : String(tpl?.category || "Uncategorized")
+      groups.set(category, [...(groups.get(category) || []), tpl])
+    }
+    return [...groups.entries()]
+  }, [taskTemplates])
+
+  const toggleTemplate = (id: string) => {
+    setSelectedTemplateIds((prev) =>
+      prev.includes(id) ? prev.filter((t) => t !== id) : [...prev, id]
+    )
+  }
 
   const filteredPartners = useMemo(() => {
     if (!search) return partners
@@ -73,6 +117,14 @@ export const SendToProductionDrawer = ({
       return
     }
 
+    if (!selectedTemplateIds.length) {
+      toast.error("Select at least one task template", {
+        description:
+          "Without one the partner is sent work with no tasks to accept.",
+      })
+      return
+    }
+
     setIsSending(true)
     try {
       const { design_production } =
@@ -83,11 +135,29 @@ export const SendToProductionDrawer = ({
             body: {
               design_ids: selectedDesigns.map((d) => d.id),
               partner_id: selectedPartnerId,
+              template_ids: selectedTemplateIds,
             },
           }
         )
 
       queryClient.invalidateQueries({ queryKey: designQueryKeys.lists() })
+
+      // Per-design failure isolation means a partial batch is a real outcome,
+      // not an error — say so rather than reporting a clean success (#1263).
+      const undispatched = design_production.not_dispatched || []
+      if (undispatched.length) {
+        toast.warning(
+          `${undispatched.length} of ${design_production.created} design${
+            design_production.created > 1 ? "s" : ""
+          } were not dispatched`,
+          {
+            description:
+              undispatched[0]?.reason ||
+              "Their runs exist but carry no tasks — dispatch them from the run page.",
+          }
+        )
+      }
+
       toast.success(
         `Sent ${design_production.created} design${
           design_production.created > 1 ? "s" : ""
@@ -120,6 +190,7 @@ export const SendToProductionDrawer = ({
   const handleClose = () => {
     if (isSending) return
     setSelectedPartnerId("")
+    setSelectedTemplateIds([])
     setSearch("")
     onOpenChange(false)
   }
@@ -145,6 +216,49 @@ export const SendToProductionDrawer = ({
                 <Badge key={d.id} size="2xsmall" color="blue">
                   {d.name || d.id}
                 </Badge>
+              ))}
+            </div>
+          </div>
+
+          <div>
+            <Label className="mb-1.5">Task Templates</Label>
+            <Text size="xsmall" className="text-ui-fg-subtle mb-2">
+              The process these designs go through. Applied to every design in
+              this batch — for different processes per design, send them
+              separately.
+            </Text>
+            <div className="max-h-[220px] overflow-y-auto">
+              {templatesByCategory.map(([categoryName, templates]) => (
+                <div key={categoryName} className="mb-3">
+                  <Text
+                    size="xsmall"
+                    weight="plus"
+                    className="text-ui-fg-subtle mb-1"
+                  >
+                    {categoryName}
+                  </Text>
+                  <div className="flex flex-wrap gap-1.5">
+                    {templates.map((tpl: any) => {
+                      const id = String(tpl.id)
+                      const selected = selectedTemplateIds.includes(id)
+                      return (
+                        <button
+                          key={id}
+                          type="button"
+                          onClick={() => toggleTemplate(id)}
+                          className="rounded-md border px-2 py-1 text-xs"
+                        >
+                          <Badge
+                            size="2xsmall"
+                            color={selected ? "green" : "grey"}
+                          >
+                            {String(tpl.name)}
+                          </Badge>
+                        </button>
+                      )
+                    })}
+                  </div>
+                </div>
               ))}
             </div>
           </div>
@@ -218,7 +332,12 @@ export const SendToProductionDrawer = ({
           <Button variant="secondary" onClick={handleClose} disabled={isSending}>
             Cancel
           </Button>
-          <Button onClick={handleSubmit} disabled={!selectedPartnerId || isSending}>
+          <Button
+            onClick={handleSubmit}
+            disabled={
+              !selectedPartnerId || !selectedTemplateIds.length || isSending
+            }
+          >
             {isSending
               ? "Sending..."
               : `Send ${selectedDesigns.length} Design${

--- a/apps/backend/src/api/admin/designs/produce/route.ts
+++ b/apps/backend/src/api/admin/designs/produce/route.ts
@@ -15,24 +15,62 @@ import { produceDesignsAsWorkOrder } from "../../../../workflows/designs/produce
  * Contrast with POST /admin/orders/:id/design/produce, which fans runs out of a
  * commissioning order's line items (there IS a customer/sale). This path is the
  * no-customer analog for when the operator just wants a partner to make things.
+ *
+ * #1263 — it now dispatches each design with its own `template_ids` rather than
+ * creating runs that claim to have been sent and carry no tasks. The response
+ * reports per design what was dispatched and what was not.
  */
-const ProduceBody = z.object({
-  design_ids: z.array(z.string()).min(1),
-  partner_id: z.string().min(1),
-})
+/**
+ * #1263 — templates are per DESIGN. A batch-wide set would be wrong for most
+ * runs (the #1261 recovery: 7 runs, 4 different sets), and ids rather than
+ * names because dispatch refuses an ambiguous name (#1262).
+ *
+ * `template_ids` at the top level is the fallback for designs without their
+ * own selection — convenient when a batch genuinely does share one process.
+ */
+const ProduceBody = z
+  .object({
+    design_ids: z.array(z.string()).min(1).optional(),
+    designs: z
+      .array(
+        z.object({
+          design_id: z.string().min(1),
+          template_ids: z.array(z.string().min(1)).optional(),
+          quantity: z.number().int().positive().optional(),
+        })
+      )
+      .min(1)
+      .optional(),
+    partner_id: z.string().min(1),
+    template_ids: z.array(z.string().min(1)).optional(),
+    /** Preview which design would get which templates; creates nothing. */
+    dry_run: z.boolean().optional(),
+  })
+  .refine((b) => Boolean(b.design_ids?.length || b.designs?.length), {
+    message: "Pass designs (preferred, per-design templates) or design_ids.",
+    path: ["designs"],
+  })
 
 export const POST = async (
   req: AuthenticatedMedusaRequest,
   res: MedusaResponse
 ): Promise<void> => {
-  const { design_ids, partner_id } = ProduceBody.parse(
-    (req.body as Record<string, unknown>) ?? {}
-  )
+  const body = ProduceBody.parse((req.body as Record<string, unknown>) ?? {})
+
+  const designIds =
+    body.design_ids?.length
+      ? body.design_ids
+      : (body.designs || []).map((d) => d.design_id)
 
   const result = await produceDesignsAsWorkOrder(
     req.scope,
-    design_ids,
-    partner_id
+    designIds,
+    body.partner_id,
+    {
+      selections: body.designs,
+      templateIds: body.template_ids,
+      dryRun: body.dry_run,
+    }
   )
 
   res.status(200).json({ design_production: result })

--- a/apps/backend/src/api/admin/mcp/lib/registry.ts
+++ b/apps/backend/src/api/admin/mcp/lib/registry.ts
@@ -2149,23 +2149,61 @@ export const ADMIN_MCP_TOOLS: AdminMcpToolDef[] = [
   {
     name: "produce_designs",
     description:
-      "Send a batch of designs to one partner for production (no customer order involved): creates one run per design, collated into a single work-order. Sensitive: requires confirm:true.",
+      "Send a batch of designs to one partner for production (no customer order involved): one run per design, each DISPATCHED with its own task templates, collated into a single work-order. Pass dry_run:true first to see which design gets which templates. Sensitive: requires confirm:true.",
     method: "POST",
     path: "/admin/designs/produce",
     write: true,
     sensitive: true,
-    bodyParams: ["design_ids", "partner_id"],
+    bodyParams: [
+      "design_ids",
+      "designs",
+      "partner_id",
+      "template_ids",
+      "dry_run",
+    ],
     inputSchema: obj(
       {
+        designs: {
+          type: "array",
+          description:
+            "Preferred. Per design: { design_id, template_ids?, quantity? }. Templates are per design — a batch rarely shares one process.",
+          items: obj(
+            {
+              design_id: STR("Design to produce."),
+              template_ids: {
+                type: "array",
+                items: { type: "string" },
+                description:
+                  "Task template IDS (not names — an ambiguous name is refused at dispatch).",
+              },
+              quantity: { type: "number", description: "Defaults to 1." },
+            },
+            ["design_id"]
+          ),
+        },
         design_ids: {
           type: "array",
           items: { type: "string" },
-          description: "Design ids to produce (required, non-empty).",
+          description:
+            "Design ids to produce. Use with template_ids when the whole batch shares one process; otherwise prefer `designs`.",
         },
         partner_id: STR("Partner to assign every created run to (required)."),
+        template_ids: {
+          type: "array",
+          items: { type: "string" },
+          description:
+            "Fallback template ids for designs without their own selection. A design left with none is created but NOT dispatched, and is reported in not_dispatched.",
+        },
+        dry_run: {
+          type: "boolean",
+          description:
+            "Preview the design → templates plan and create nothing.",
+        },
       },
-      ["design_ids", "partner_id"]
+      ["partner_id"]
     ),
+    sideEffects:
+      "Dispatches each design to the partner (creates tasks and notifies). Designs with no template selection are created without tasks and listed under not_dispatched.",
     nextSteps: ["list_design_work_orders"],
   },
   {

--- a/apps/backend/src/workflows/designs/produce-designs-as-work-order.ts
+++ b/apps/backend/src/workflows/designs/produce-designs-as-work-order.ts
@@ -2,9 +2,35 @@ import { ContainerRegistrationKeys } from "@medusajs/framework/utils"
 import type { MedusaContainer } from "@medusajs/framework/types"
 
 import { createProductionRunWorkflow } from "../production-runs/create-production-run"
+import { sendProductionRunToProductionWorkflow } from "../production-runs/send-production-run-to-production"
 import { collateRunsIntoWorkOrder } from "../production-runs/dual-write-unified-run-order"
 import { PRODUCTION_RUNS_MODULE } from "../../modules/production_runs"
 import type ProductionRunService from "../../modules/production_runs/service"
+
+/**
+ * #1263 — the template selection for ONE design.
+ *
+ * Per design, never pooled across the batch: the parked-run recovery (#1261)
+ * proved on prod that 7 runs used 4 different template sets, so a batch-wide
+ * selection would have been wrong for most of them. `template_ids` only —
+ * a name may match two templates and dispatch refuses an ambiguous one
+ * (#1262), so a bulk tool built on names fails on any design whose process
+ * includes `Stitching`.
+ */
+export type ProduceDesignSelection = {
+  design_id: string
+  template_ids?: string[]
+  quantity?: number
+}
+
+export type ProduceDesignReport = {
+  design_id: string
+  run_id: string | null
+  template_ids: string[]
+  dispatched: boolean
+  /** Why this design was not dispatched, when it was not. */
+  reason?: string
+}
 
 /**
  * #826 — "send to production" straight from the designs list, WITHOUT a
@@ -19,16 +45,36 @@ import type ProductionRunService from "../../modules/production_runs/service"
  *
  * There is no group key to be idempotent against (no order), so every call
  * creates a fresh batch — the caller (a one-shot admin action) owns that.
+ *
+ * #1263 — this used to stop at creation: runs were born `sent_to_partner` and
+ * no task template was ever instantiated, so the partner was handed work with
+ * nothing to accept while the record claimed it had been sent. Each design is
+ * now dispatched with ITS OWN templates right after its run is created, and a
+ * design that cannot be dispatched is reported rather than left looking sent.
+ * Selections are per design; a design with no selection is created and
+ * reported as undispatched, which is the old behaviour made visible.
  */
 export async function produceDesignsAsWorkOrder(
   container: MedusaContainer,
   designIds: string[],
-  partnerId: string
+  partnerId: string,
+  options?: {
+    /** Per-design template selections. Wins over `templateIds` for a design. */
+    selections?: ProduceDesignSelection[]
+    /** Fallback selection for designs without one of their own. */
+    templateIds?: string[]
+    /** Plan only: resolve what would happen and create nothing. */
+    dryRun?: boolean
+  }
 ): Promise<{
   created: number
   run_ids: string[]
   design_ids: string[]
   work_order_id: string | null
+  dry_run?: boolean
+  designs: ProduceDesignReport[]
+  dispatched: string[]
+  not_dispatched: ProduceDesignReport[]
 }> {
   const logger: any = container.resolve(ContainerRegistrationKeys.LOGGER)
   const runService = container.resolve(
@@ -37,20 +83,81 @@ export async function produceDesignsAsWorkOrder(
 
   const runIds: string[] = []
   const producedDesignIds: string[] = []
+  const reports: ProduceDesignReport[] = []
 
-  for (const designId of designIds) {
-    if (!designId) {
-      continue
+  // One plan row per design, in the order given, with its own templates.
+  const selectionsById = new Map<string, ProduceDesignSelection>(
+    (options?.selections || [])
+      .filter((s) => s?.design_id)
+      .map((s) => [String(s.design_id), s])
+  )
+  const fallbackTemplateIds = (options?.templateIds || []).filter(Boolean)
+
+  const orderedDesignIds = designIds?.length
+    ? designIds
+    : [...selectionsById.keys()]
+
+  const plan = orderedDesignIds
+    .filter(Boolean)
+    .map((designId) => {
+      const selection = selectionsById.get(String(designId))
+      const templateIds = (
+        selection?.template_ids?.length
+          ? selection.template_ids
+          : fallbackTemplateIds
+      ).filter(Boolean)
+      return {
+        design_id: String(designId),
+        template_ids: [...new Set(templateIds)],
+        quantity: selection?.quantity ?? 1,
+      }
+    })
+
+  // A dry run answers "which design gets which templates" — the question the
+  // operator actually needs answered before messaging a partner.
+  if (options?.dryRun) {
+    const preview = plan.map((row) => ({
+      design_id: row.design_id,
+      run_id: null,
+      template_ids: row.template_ids,
+      dispatched: false,
+      reason: row.template_ids.length
+        ? "dry run — nothing was created"
+        : "no templates selected for this design",
+    }))
+    return {
+      created: 0,
+      run_ids: [],
+      design_ids: [],
+      work_order_id: null,
+      dry_run: true,
+      designs: preview,
+      dispatched: [],
+      not_dispatched: preview,
     }
+  }
+
+  for (const row of plan) {
+    const designId = row.design_id
     try {
       const { result } = await createProductionRunWorkflow(container).run({
         input: {
           design_id: designId,
-          quantity: 1,
+          quantity: row.quantity,
           partner_id: partnerId,
-          // Committed to a partner up front → born partner-facing so the
-          // collated work-order gets its partner↔order link (else invisible).
-          status: "sent_to_partner" as const,
+          // #1263 — a run being dispatched is born `approved`, because
+          // dispatch REFUSES anything else ("must be approved before
+          // sending"), and it is dispatch that moves it to `sent_to_partner`,
+          // creates the tasks and writes the partner↔order link. Being born
+          // partner-facing was precisely what made the old path unable to
+          // dispatch, and so what left partners holding taskless runs.
+          //
+          // With no templates there is nothing to dispatch, so the run keeps
+          // the original born-`sent_to_partner` shape — same behaviour as
+          // before for callers that pass no selection.
+          status: row.template_ids.length
+            ? ("approved" as const)
+            : ("sent_to_partner" as const),
           // Collated into ONE work-order below — don't mint a per-run order.
           skip_unified_projection: true,
           metadata: {
@@ -59,19 +166,86 @@ export async function produceDesignsAsWorkOrder(
         },
       })
       const run = (result as any)?.production_run ?? (result as any)?.run ?? result
-      if (run?.id) {
-        runIds.push(run.id)
-        producedDesignIds.push(designId)
+      if (!run?.id) {
+        reports.push({
+          design_id: designId,
+          run_id: null,
+          template_ids: row.template_ids,
+          dispatched: false,
+          reason: "run creation returned no run",
+        })
+        continue
+      }
+
+      runIds.push(run.id)
+      producedDesignIds.push(designId)
+
+      // No selection → create the run but say plainly that nothing was
+      // dispatched, instead of leaving it looking sent with no tasks.
+      if (!row.template_ids.length) {
+        reports.push({
+          design_id: designId,
+          run_id: run.id,
+          template_ids: [],
+          dispatched: false,
+          reason:
+            "no templates selected for this design — the run has no tasks and the partner has nothing to accept",
+        })
+        continue
+      }
+
+      // Per design, so one design's dispatch failure never strands the batch.
+      try {
+        await sendProductionRunToProductionWorkflow(container).run({
+          input: {
+            production_run_id: run.id,
+            template_ids: row.template_ids,
+          } as any,
+        })
+        reports.push({
+          design_id: designId,
+          run_id: run.id,
+          template_ids: row.template_ids,
+          dispatched: true,
+        })
+      } catch (e: any) {
+        logger.warn(
+          `[produce-designs-as-work-order] dispatch failed for design ${designId}: ${e?.message}`
+        )
+        reports.push({
+          design_id: designId,
+          run_id: run.id,
+          template_ids: row.template_ids,
+          dispatched: false,
+          reason: e?.message || "dispatch failed",
+        })
       }
     } catch (e: any) {
       logger.warn(
         `[produce-designs-as-work-order] run creation failed for design ${designId}: ${e?.message}`
       )
+      reports.push({
+        design_id: designId,
+        run_id: null,
+        template_ids: row.template_ids,
+        dispatched: false,
+        reason: e?.message || "run creation failed",
+      })
     }
   }
 
+  const notDispatched = reports.filter((r) => !r.dispatched)
+
   if (!runIds.length) {
-    return { created: 0, run_ids: [], design_ids: [], work_order_id: null }
+    return {
+      created: 0,
+      run_ids: [],
+      design_ids: [],
+      work_order_id: null,
+      designs: reports,
+      dispatched: [],
+      not_dispatched: notDispatched,
+    }
   }
 
   // Re-read the created runs with their snapshot (design name, cost) so the
@@ -90,5 +264,8 @@ export async function produceDesignsAsWorkOrder(
     run_ids: runIds,
     design_ids: producedDesignIds,
     work_order_id: projection.unified_order_id ?? null,
+    designs: reports,
+    dispatched: reports.filter((r) => r.dispatched).map((r) => r.design_id),
+    not_dispatched: notDispatched,
   }
 }


### PR DESCRIPTION
Closes #1263. Takes the "fix the existing endpoint" option from the issue's *Decide first*.

## What was wrong

`produceDesignsAsWorkOrder` created one run per design **born `sent_to_partner`** and never instantiated a task template. The partner was handed runs with nothing to accept while the record claimed they had been sent — the same class as #1261.

The born status turned out to be the **cause, not a detail**: `sendProductionRunToProductionWorkflow` refuses anything but `approved` (*"must be approved before sending"*), so a run born partner-facing could never be dispatched at all. Runs being dispatched are now born `approved`, and dispatch moves them to `sent_to_partner`, creates the tasks and writes the partner↔order link.

## What it does now

- **Templates per DESIGN** (`designs[].template_ids`), never pooled — the #1261 recovery found 7 parked runs using **4 different sets**, so one batch-wide selection would have been wrong for most of them. A top-level `template_ids` stays as the fallback for a batch that genuinely shares one process.
- **Ids, not names** — post-#1262 an ambiguous name is refused outright, so a bulk tool built on names fails on any design whose process includes `Stitching`.
- **`dry_run`** returns the design → templates plan and creates nothing.
- **Per-design failure isolation** — one design failing never strands the batch; the response reports `dispatched` / `not_dispatched` with a reason each.
- A design left with **no** selection is still created exactly as before (born `sent_to_partner`, no tasks) — it is now *reported* as undispatched rather than silently looking sent. That keeps every existing caller working.

The admin "Send to Production" drawer gains the id-keyed template picker this needs, refuses to send without one, and warns on a partial batch. The MCP `produce_designs` row documents the new shape and its side effects.

## Verification

`integration-tests/http/designs-produce-no-customer.spec.ts` — 4 passing, including the pre-existing #826 case unchanged:

```
✓ creates one partner-facing run per design and collates them into ONE work-order
✓ dispatches each design with ITS OWN templates                            (new)
✓ previews the design → templates plan without creating anything           (new)
✓ reports a design left with no templates instead of a silently taskless run (new)
```

The dispatch case gives the two designs **different** template sets and asserts each run's `dispatched_template_ids` matches its own — plus that each run now actually has tasks, which the old path never created.

`tsc` unchanged at the 79 baseline.

🤖 Generated with [Claude Code](https://claude.com/claude-code)