### PR TITLE
fix(partner-ui): stop the auto-accept switch promising what the platform won't do

### DIFF
--- a/apps/backend/src/api/partners/details/route.ts
+++ b/apps/backend/src/api/partners/details/route.ts
@@ -57,6 +57,8 @@ import { AuthenticatedMedusaRequest, MedusaResponse } from "@medusajs/framework"
 import { Modules } from "@medusajs/framework/utils"
 import { getPartnerFromAuthContext } from "../helpers"
 import type { IAuthModuleService } from "@medusajs/types"
+import { PRODUCTION_POLICY_MODULE } from "../../../modules/production_policy"
+import type ProductionPolicyService from "../../../modules/production_policy/service"
 
 export const GET = async (
     req: AuthenticatedMedusaRequest,
@@ -101,8 +103,30 @@ export const GET = async (
         }
     }
 
+    // #1228 — the partner's `auto_accept_production_runs` opt-in is gated a
+    // SECOND time by the platform's reassignment policy, and on prod that gate
+    // is off. Without shipping the gate's state the settings switch promises
+    // something the platform will not do: a partner turns it on, is told
+    // re-sent runs will be accepted for them, and they never are. Read-only,
+    // and deliberately just the one flag the partner UI can act on.
+    let productionRunPolicy: { auto_accept_on_retry: boolean } | null = null
+    try {
+        const policyService: ProductionPolicyService = req.scope.resolve(
+            PRODUCTION_POLICY_MODULE
+        )
+        const reassignment = await policyService.getReassignmentPolicy()
+        productionRunPolicy = {
+            auto_accept_on_retry: reassignment.auto_accept_on_retry,
+        }
+    } catch {
+        // The partner's own details must not fail because the platform policy
+        // is unreadable. `null` means "unknown", which the UI states as such
+        // rather than claiming the switch works.
+    }
+
     res.json({
         partner,
         current_admin_id: currentAdminId,
+        production_run_policy: productionRunPolicy,
     })
 }

--- a/apps/partner-ui/src/hooks/api/partner-settings.tsx
+++ b/apps/partner-ui/src/hooks/api/partner-settings.tsx
@@ -37,9 +37,20 @@ export type PartnerSettings = Record<string, any> & {
   auto_accept_production_runs?: boolean
 }
 
+/**
+ * The PLATFORM half of the auto-accept decision (#1228). The partner's opt-in
+ * only does anything when this is on too, so the settings surface has to be
+ * able to say whether it is. `null` means the platform policy could not be
+ * read — unknown, not "off".
+ */
+export type ProductionRunPolicy = {
+  auto_accept_on_retry: boolean
+}
+
 type PartnerDetailsResponse = {
   partner?: PartnerSettings | null
   current_admin_id?: string | null
+  production_run_policy?: ProductionRunPolicy | null
 }
 
 export const usePartnerSettings = (
@@ -62,7 +73,11 @@ export const usePartnerSettings = (
     ...options,
   })
 
-  return { partner: data?.partner ?? null, ...rest }
+  return {
+    partner: data?.partner ?? null,
+    productionRunPolicy: data?.production_run_policy ?? null,
+    ...rest,
+  }
 }
 
 export type UpdatePartnerSettingsInput = {

--- a/apps/partner-ui/src/routes/settings/production-runs/production-runs.tsx
+++ b/apps/partner-ui/src/routes/settings/production-runs/production-runs.tsx
@@ -25,18 +25,29 @@ import {
  * the auto-accept path was dead code.
  */
 const AutoAcceptSection = () => {
-  const { partner, isPending, isError } = usePartnerSettings()
+  const { partner, productionRunPolicy, isPending, isError } =
+    usePartnerSettings()
   const { mutateAsync: updateSettings, isPending: isSaving } =
     useUpdatePartnerSettings()
 
   const enabled = !!partner?.auto_accept_production_runs
+
+  // Both halves must be on (#1228). The platform's is off on production, so a
+  // switch that only reported the partner's half was telling partners their
+  // re-sent runs would be accepted when nothing would accept them. `null` is
+  // "couldn't read it", which is not the same as "off" and mustn't be shown as
+  // a definite answer either way.
+  const platformAllows = productionRunPolicy?.auto_accept_on_retry ?? null
+  const inEffect = enabled && platformAllows === true
 
   const handleToggle = async (next: boolean) => {
     try {
       await updateSettings({ auto_accept_production_runs: next })
       toast.success(
         next
-          ? "Re-sent production runs will be accepted for you"
+          ? platformAllows === true
+            ? "Re-sent production runs will be accepted for you"
+            : "Saved — this will apply once the platform allows auto accept"
           : "Re-sent production runs will wait for you to accept"
       )
     } catch (e: any) {
@@ -93,7 +104,28 @@ const AutoAcceptSection = () => {
         />
       </div>
 
-      {enabled && (
+      {enabled && platformAllows === false && (
+        <div className="px-6 py-4">
+          <InlineTip variant="info" label="Not in effect yet">
+            Your preference is saved, but auto accept is currently switched off
+            for everyone on the platform, so every re-sent run still waits for
+            you to accept it by hand. This setting will start working the moment
+            that changes — you don't need to come back and turn it on again.
+          </InlineTip>
+        </div>
+      )}
+
+      {enabled && platformAllows === null && (
+        <div className="px-6 py-4">
+          <InlineTip variant="info" label="Saved">
+            We couldn't check whether the platform currently allows auto accept,
+            so we can't confirm this is taking effect. Your preference is saved
+            either way.
+          </InlineTip>
+        </div>
+      )}
+
+      {inEffect && (
         <div className="px-6 py-4">
           <InlineTip variant="warning" label="You own the work">
             An auto-accepted run is yours — the same deadlines, reminders and


### PR DESCRIPTION
## The problem

`partner.auto_accept_production_runs` is gated a **second** time by the platform's `reassignment.auto_accept_on_retry` (#1228) — both must be true for a re-sent run to be auto-accepted.

Read against prod today, the stored policy is:

```json
{ "transitions": { "accept_from": ["sent_to_partner"], "dispatch_from": ["approved"], … } }
```

There is **no `reassignment` key at all**, so `getReassignmentPolicy()` falls back to its `DEFAULT_REASSIGNMENT_POLICY.auto_accept_on_retry = false`. The switch shipped in #1274 is inert on production, exactly as that PR's handoff suspected but couldn't verify.

The switch reported only the partner's half of the decision. A partner turning it on got the toast *"Re-sent production runs will be accepted for you"* and the "you own the work" warning — and then nothing ever accepted anything. The UI was making a promise the platform silently declines to keep.

## The change

- **`GET /partners/details`** now returns `production_run_policy.auto_accept_on_retry`. Read-only, additive, and deliberately just the one flag the partner UI can act on. If the policy can't be read the field is `null`, not `false` — "unknown" and "off" are different answers and the UI states them differently rather than guessing.
- **Settings › Production Runs** keeps the switch settable (the preference is genuine and applies the moment the platform flips), but now says plainly when it is not in effect. The "you own the work" warning only renders when the run really would be auto-accepted.

## Deliberately not done

**The platform policy is not changed here.** Turning auto-accept on decides who owns work on a stale re-dispatch — an operator's call, not a side effect of making copy honest. Offered as an option and declined in favour of this.

## Verification

- Read against prod with the admin API: policy has no `reassignment` key ⇒ gate is `false`.
- `pnpm test:integration:http:shared ./apps/backend/integration-tests/http/partner-scoping-api.spec.ts` → **4/4 pass**, including `partner details are scoped`.
- Backend `tsc --noEmit`: **79 errors, unchanged from the `main` baseline**.
- partner-ui `tsc --noEmit`: 4 errors, all pre-existing parse errors in untouched `order-create-claim` / `order-create-exchange` files.

**No migration.**

## Related

#1274 (shipped the switch) · #1228 (the two-sided gate) · #1279 (filed this session: parked runs are watched by nothing)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
