### PR TITLE
fix(inventory): schedule the divergence check, and stop swallowing a failed stock rollback (#1259)

### DIFF
--- a/apps/backend/src/jobs/__tests__/check-inventory-level-divergence.unit.spec.ts
+++ b/apps/backend/src/jobs/__tests__/check-inventory-level-divergence.unit.spec.ts
@@ -1,0 +1,166 @@
+import checkInventoryLevelDivergence, {
+  config,
+} from "../check-inventory-level-divergence"
+
+/**
+ * #1259 — the divergence detector was correct and unrun.
+ *
+ * The live case: `FAB-TWO-BLU-001` sat at numeric 0 / raw -2.5 from some write
+ * before 2026-08-11 and was found only when a human happened to look. By then
+ * the workflow-execution history had aged out and the level's pre-correction
+ * `updated_at` had been overwritten by the fix, so the writer is now
+ * unrecoverable. These tests pin the two properties that decide whether the
+ * NEXT one is recoverable: it must fire on its own, and it must never resolve
+ * anything by itself.
+ */
+
+const logger = () => ({
+  info: jest.fn(),
+  warn: jest.fn(),
+  error: jest.fn(),
+})
+
+const level = (over: Record<string, any> = {}) => ({
+  id: "ilev_1",
+  inventory_item_id: "iitem_1",
+  location_id: "sloc_1",
+  stocked_quantity: 5,
+  raw_stocked_quantity: { value: "5", precision: 20 },
+  ...over,
+})
+
+const containerWith = (
+  levels: any[],
+  over: { notification?: any; log?: any } = {}
+) => {
+  const log = over.log ?? logger()
+  const notification = over.notification ?? { createNotifications: jest.fn() }
+  const graph = jest.fn().mockResolvedValue({ data: levels })
+
+  return {
+    container: {
+      resolve: (key: string) => {
+        if (key === "logger") return log
+        if (key === "query") return { graph }
+        if (key === "notification") return notification
+        throw new Error(`unexpected resolve(${key})`)
+      },
+    } as any,
+    log,
+    notification,
+    graph,
+  }
+}
+
+describe("check-inventory-level-divergence", () => {
+  it("is scheduled — the detector's problem was never accuracy, it was that nothing ran it", () => {
+    expect(config.name).toBe("check-inventory-level-divergence")
+    expect(config.schedule).toBe("0 5 * * *")
+  })
+
+  it("says nothing to the bell when both halves agree and nothing is negative", async () => {
+    const { container, log, notification } = containerWith([level(), level({ id: "ilev_2" })])
+
+    await checkInventoryLevelDivergence(container)
+
+    expect(notification.createNotifications).not.toHaveBeenCalled()
+    expect(log.info).toHaveBeenCalledWith(
+      expect.stringContaining("compared 2/2")
+    )
+  })
+
+  it("reports a level whose two stored values disagree, and changes nothing", async () => {
+    const { container, log, notification, graph } = containerWith([
+      level({
+        stocked_quantity: 0,
+        raw_stocked_quantity: { value: "-2.5", precision: 20 },
+        inventory_item_id: "iitem_blu",
+      }),
+    ])
+
+    await checkInventoryLevelDivergence(container)
+
+    // query.graph is the ONLY call it makes. No write path exists.
+    expect(graph).toHaveBeenCalledTimes(1)
+
+    const [{ data }] = notification.createNotifications.mock.calls[0]
+    expect(data.title).toContain("disagree")
+    expect(data.description).toContain("numeric=0 raw=-2.5")
+    expect(data.description).toContain("Nothing was changed")
+    expect(log.warn).toHaveBeenCalled()
+  })
+
+  it("reports a negative level without zeroing it — it can be an un-recorded receipt", async () => {
+    const { container, notification } = containerWith([
+      level({
+        stocked_quantity: -4,
+        raw_stocked_quantity: { value: "-4", precision: 20 },
+      }),
+    ])
+
+    await checkInventoryLevelDivergence(container)
+
+    const [{ data }] = notification.createNotifications.mock.calls[0]
+    expect(data.title).toContain("Negative inventory level")
+    expect(data.description).toContain("record the receipt instead of zeroing it")
+  })
+
+  it("warns when it could not compare every row — a partial denominator IS the finding", async () => {
+    const { container, log } = containerWith([
+      level(),
+      level({ id: "ilev_2", raw_stocked_quantity: undefined }),
+    ])
+
+    await checkInventoryLevelDivergence(container)
+
+    expect(log.warn).toHaveBeenCalledWith(
+      expect.stringContaining("compared only 1/2")
+    )
+  })
+
+  it("calls a 0/N reading INERT rather than clean — a dead check and a healthy one look identical", async () => {
+    const { container, log, notification } = containerWith([
+      level({ raw_stocked_quantity: undefined }),
+      level({ id: "ilev_2", raw_stocked_quantity: undefined }),
+    ])
+
+    await checkInventoryLevelDivergence(container)
+
+    expect(log.warn).toHaveBeenCalledWith(expect.stringContaining("INERT"))
+    // Still no bell: nothing is provably wrong. The warn line is the signal.
+    expect(notification.createNotifications).not.toHaveBeenCalled()
+  })
+
+  it("survives a notification outage — losing the bell must not also lose the log line", async () => {
+    const { container, log } = containerWith(
+      [
+        level({
+          stocked_quantity: 0,
+          raw_stocked_quantity: { value: "-2.5", precision: 20 },
+        }),
+      ],
+      {
+        notification: {
+          createNotifications: jest.fn().mockRejectedValue(new Error("provider down")),
+        },
+      }
+    )
+
+    await expect(checkInventoryLevelDivergence(container)).resolves.toBeUndefined()
+    expect(log.warn).toHaveBeenCalledWith(expect.stringContaining("disagree"))
+    expect(log.warn).toHaveBeenCalledWith(expect.stringContaining("provider down"))
+  })
+
+  it("never throws out of the scheduler", async () => {
+    const log = logger()
+    const container = {
+      resolve: (key: string) => {
+        if (key === "logger") return log
+        throw new Error("query is gone")
+      },
+    } as any
+
+    await expect(checkInventoryLevelDivergence(container)).resolves.toBeUndefined()
+    expect(log.error).toHaveBeenCalledWith(expect.stringContaining("query is gone"))
+  })
+})

--- a/apps/backend/src/jobs/check-inventory-level-divergence.ts
+++ b/apps/backend/src/jobs/check-inventory-level-divergence.ts
@@ -1,0 +1,163 @@
+import type { MedusaContainer } from "@medusajs/framework/types"
+import { ContainerRegistrationKeys, Modules } from "@medusajs/framework/utils"
+
+import {
+  countComparableLevels,
+  findLevelValueDivergence,
+  planNegativeLevelResets,
+} from "../api/admin/ops/maintenance-jobs/reset-negative-inventory-levels-job"
+
+/**
+ * Inventory level divergence watcher (#1259).
+ *
+ * `model.bigNumber()` persists a value TWICE — `<field> numeric` and
+ * `raw_<field> jsonb`. On 2026-08-11 a level was found where the two halves had
+ * drifted apart: `FAB-TWO-BLU-001` read 0 through one API and -2.5 through
+ * another, and the negative sweep reported "no negative levels across 194"
+ * while an operator was looking at -2.5 on screen.
+ *
+ * The detector for that already exists, in the `reset-negative-inventory-levels`
+ * maintenance job. Its problem is not accuracy — it is that **nothing runs it**.
+ * It fires only when a human types the job name, which is why a level created
+ * 2026-03-26 was not noticed until 2026-08-11, and why the forensic trail
+ * (workflow-execution history, the level's pre-correction `updated_at`) had
+ * already aged out by the time anyone looked. The cause of that first
+ * divergence is now unrecoverable. The cost of the NEXT one is a scheduling
+ * decision, and this is it.
+ *
+ * This job is READ-ONLY, deliberately. It resolves nothing:
+ *
+ * - **Divergence is never auto-resolved.** Neither column is inherently
+ *   authoritative — the numeric side is what most queries filter on, the raw
+ *   side is what the admin UI renders — so picking a winner is a judgement
+ *   about what really happened to the stock, and that belongs to a human. Same
+ *   reasoning as refusing to guess a null `quantity_basis` (#1248).
+ * - **Negatives are not zeroed either.** A negative can be the residue of a
+ *   movement recorded with no counterpart, or it can be an un-recorded receipt
+ *   — and zeroing the second erases the evidence. `reset-negative-inventory-levels`
+ *   exists for that, behind a dry-run, on purpose.
+ *
+ * So this only ever says "look at this", and it says it the day it happens
+ * instead of four months later.
+ *
+ * ⚠️ The denominator is logged on EVERY run, healthy or not. The detector skips
+ * any row that did not return a readable `raw_stocked_quantity`, so a detector
+ * reading zero rows and a detector finding nothing wrong print IDENTICAL
+ * output. `compared 194/194` is evidence; `compared 0/194` is visibly useless.
+ * That distinction is the whole point of #1260 and it must survive here too.
+ */
+
+export default async function checkInventoryLevelDivergence(
+  container: MedusaContainer
+) {
+  const logger: any = container.resolve(ContainerRegistrationKeys.LOGGER)
+
+  try {
+    const query: any = container.resolve(ContainerRegistrationKeys.QUERY)
+
+    const { data: levels } = await query.graph({
+      entity: "inventory_level",
+      fields: [
+        "id",
+        "inventory_item_id",
+        "location_id",
+        "stocked_quantity",
+        // The other half of the bigNumber pair. Without it this watcher reads
+        // one side of the row and is confidently wrong when they disagree —
+        // which is the exact failure it exists to catch.
+        "raw_stocked_quantity",
+      ],
+    })
+
+    const rows = (levels || []) as any[]
+    const divergent = findLevelValueDivergence(rows)
+    const negatives = planNegativeLevelResets(rows)
+    const coverage = countComparableLevels(rows)
+
+    const coverageLine =
+      coverage.compared === coverage.total
+        ? `compared ${coverage.compared}/${coverage.total} level(s)`
+        : `⚠️ compared only ${coverage.compared}/${coverage.total} level(s) — the rest returned no readable raw_stocked_quantity${
+            coverage.compared === 0
+              ? ", so this check is INERT and a clean result here means nothing"
+              : ""
+          }`
+
+    // A partial denominator is itself a finding: it means the check silently
+    // stopped looking. Say so loudly even when nothing else is wrong.
+    if (coverage.compared !== coverage.total) {
+      logger.warn(`[inventory-divergence] ${coverageLine}`)
+    }
+
+    if (!divergent.length && !negatives.length) {
+      logger.info(
+        `[inventory-divergence] Clean — no divergence, no negative levels (${coverageLine}).`
+      )
+      return
+    }
+
+    const parts: string[] = []
+
+    if (divergent.length) {
+      parts.push(
+        `${divergent.length} level(s) whose two stored values DISAGREE: ${divergent
+          .map(
+            (d) =>
+              `${d.sku || d.inventory_item_id}@${d.location_id} numeric=${
+                d.numeric
+              } raw=${d.raw}`
+          )
+          .join(", ")}`
+      )
+    }
+
+    if (negatives.length) {
+      parts.push(
+        `${negatives.length} negative level(s): ${negatives
+          .map(
+            (n) => `${n.sku || n.inventory_item_id}@${n.location_id} at ${n.before}`
+          )
+          .join(", ")}`
+      )
+    }
+
+    const title = divergent.length
+      ? `Inventory levels disagree with themselves (${divergent.length})`
+      : `Negative inventory level${negatives.length === 1 ? "" : "s"} (${
+          negatives.length
+        })`
+
+    const description =
+      `${parts.join(". ")}. ${coverageLine}. ` +
+      `Nothing was changed — decide what really happened to the stock first. ` +
+      `Divergence: write the true value with POST /admin/inventory-items/:id/location-levels/:location_id, which rewrites both halves. ` +
+      `Negatives: run the reset-negative-inventory-levels maintenance job dry-run, and if the negative is an un-recorded receipt, record the receipt instead of zeroing it.`
+
+    logger.warn(`[inventory-divergence] ${title} — ${description}`)
+
+    // Best-effort: a notification-provider outage must not fail the job, or a
+    // transient problem would also cost us the log line above.
+    try {
+      const notificationService: any = container.resolve(Modules.NOTIFICATION)
+      await notificationService.createNotifications({
+        to: "",
+        channel: "feed",
+        template: "admin-ui",
+        data: { title, description },
+      })
+    } catch (e: any) {
+      logger.warn(
+        `[inventory-divergence] Could not post the admin notification: ${e?.message}`
+      )
+    }
+  } catch (e: any) {
+    logger.error(`[inventory-divergence] Error: ${e?.message}`)
+  }
+}
+
+export const config = {
+  name: "check-inventory-level-divergence",
+  // Daily, 05:00 UTC — early enough that a divergence found overnight is on the
+  // bell before the working day, and cheap: one query.graph over every level.
+  schedule: "0 5 * * *",
+}

--- a/apps/backend/src/workflows/production-runs/partner-run-steps.ts
+++ b/apps/backend/src/workflows/production-runs/partner-run-steps.ts
@@ -378,9 +378,22 @@ export const stockFinishedGoodsStep = createStep(
       location_id: rollbackData.location_id,
     })
     if (level) {
-      await inventoryService.updateInventoryLevels(level.id, {
-        stocked_quantity: Math.max(0, (level.stocked_quantity || 0) - rollbackData.quantity),
-      }).catch(() => {})
+      try {
+        await inventoryService.updateInventoryLevels(level.id, {
+          stocked_quantity: Math.max(0, (level.stocked_quantity || 0) - rollbackData.quantity),
+        })
+      } catch (e: any) {
+        // A compensation must not throw — it would mask the original failure and
+        // leave the rest of the rollback undone. But it must not vanish either:
+        // this swallowed a failed stock rollback silently, which leaves the
+        // level carrying goods that were never produced and no trace of why
+        // (#1259). Failing quietly is what made the last inventory drift take
+        // four months to notice. Say it, then let the rollback continue.
+        const logger: any = container.resolve(ContainerRegistrationKeys.LOGGER)
+        logger?.error(
+          `[stock-finished-goods] Rollback FAILED for ${rollbackData.inventory_item_id}@${rollbackData.location_id}: could not remove ${rollbackData.quantity}. The level is now overstated by that amount. ${e?.message}`
+        )
+      }
     }
   }
 )


### PR DESCRIPTION
Closes the actionable half of #1259.

## What this does not do

It does not name the writer. That question is now **unanswerable**, and the evidence for saying so is in the issue thread: the `workflow_execution` table holds 43 rows total with a gap from 2026-03-26 to 2026-04-08 and does not retain successful runs, and the level's pre-correction `updated_at` was overwritten by the 2026-08-11 fix. Nothing survives to read. Chasing it further is spending time on a trail that no longer exists.

## What it does

The detector was never the problem — **nothing ran it**. It fired only when a human typed the maintenance-job name, which is why `FAB-TWO-BLU-001` sat at `numeric 0 / raw -2.5` for months and was found by someone glancing at a screen. That is a scheduling gap, and it is the part still worth fixing.

- **New scheduled job `check-inventory-level-divergence`** — daily, 05:00 UTC. It imports `findLevelValueDivergence`, `planNegativeLevelResets` and `countComparableLevels` from `reset-negative-inventory-levels-job` unchanged, so the watcher and the repair tool cannot drift apart about what counts as wrong.
- **Read-only, deliberately.** Divergence is reported and never resolved: neither column is inherently authoritative — the numeric side is what queries filter on, the raw side is what the admin UI renders — so choosing between them is a judgement about what happened to the stock. Negatives are reported and never zeroed, because a negative can be an un-recorded receipt and zeroing it erases the evidence.
- **The denominator is logged every run.** A check that compared zero rows and a check that found nothing wrong print identical output. `compared 194/194` is evidence; `compared 0/194` is called INERT to its face. That is #1260's point and it had to survive into the scheduled path.
- **`stockFinishedGoodsStep`'s compensation no longer swallows a failed rollback.** `.catch(() => {})` meant a rollback that failed left the level carrying goods that were never produced, silently. It still cannot throw — that would mask the original failure — but it now logs what it left overstated.

## Verify

```
npx jest --testPathPattern="check-inventory-level-divergence"   # 8 pass
npx jest --testPathPattern="reset-negative"                     # 26 pass, unchanged
```

tsc 79 — the main baseline, unchanged. No migrations.

🤖 Generated with [Claude Code](https://claude.com/claude-code)