### PR TITLE
fix(whatsapp): resize outbound images, and stop the cap counting reminders Meta refused (#1279)

### DIFF
--- a/apps/backend/src/api/webhooks/social/whatsapp/route.ts
+++ b/apps/backend/src/api/webhooks/social/whatsapp/route.ts
@@ -8,6 +8,8 @@ import { handleIncomingMessage, resolvePartnerByPhone } from "../../../../workfl
 import { resolveAdminByPhone, handleAdminMessage } from "../../../../workflows/whatsapp/whatsapp-admin-handler"
 import { logger } from "@medusajs/framework"
 import  { MESSAGING_MODULE } from "../../../../modules/messaging"
+import { PRODUCTION_RUNS_MODULE } from "../../../../modules/production_runs"
+import { planReminderRollback } from "../../../../workflows/production-runs/emit-production-run-reminder"
 
 /**
  * GET /webhooks/social/whatsapp
@@ -270,6 +272,11 @@ async function processWhatsAppWebhook(
               const currentRank = STATUS_RANK[msg.status] ?? 0
               const newRank = STATUS_RANK[status.status] ?? 0
 
+              // A reminder Meta REFUSED was never a reminder. Decide before the
+              // status write, because the rollback is gated on the message not
+              // already being `failed` (#1279).
+              const rollback = planReminderRollback(msg, status.status)
+
               // Only progress forward (sent → delivered → read), never downgrade
               // Exception: "failed" always applies
               if (newRank > currentRank || status.status === "failed") {
@@ -278,6 +285,38 @@ async function processWhatsAppWebhook(
                   status: status.status as any,
                   ...(failReason ? { fail_reason: failReason } : {}),
                 })
+              }
+
+              if (rollback) {
+                // Un-count it. Otherwise the cap counts an attempt nobody
+                // received, and the run is eventually parked into
+                // `awaiting_reassignment` — the one state nothing watches —
+                // without its partner ever having been asked.
+                try {
+                  const runService = scope.resolve(PRODUCTION_RUNS_MODULE) as any
+                  const run = await runService
+                    .retrieveProductionRun(rollback.production_run_id)
+                    .catch(() => null)
+                  const current = run?.reminder_count ?? 0
+                  if (run && current > 0) {
+                    await runService.updateProductionRuns({
+                      id: rollback.production_run_id,
+                      reminder_count: current - 1,
+                    })
+                    logger.warn(
+                      `[whatsapp-webhook] Reminder to ${status.recipient_id} was REJECTED by Meta ` +
+                        `(${failReason ?? "no reason given"}) — un-counting it on ` +
+                        `${rollback.production_run_id}: reminder_count ${current} → ${current - 1}. ` +
+                        `The partner was never asked, so this must not count toward the cap.`
+                    )
+                  }
+                } catch (e: any) {
+                  // Never fail the webhook over a bookkeeping correction — Meta
+                  // retries the whole delivery, which would re-apply the status.
+                  logger.warn(
+                    `[whatsapp-webhook] Could not un-count the failed reminder on ${rollback.production_run_id}: ${e.message}`
+                  )
+                }
               }
             }
           } catch (e: any) {

--- a/apps/backend/src/modules/social-provider/__tests__/transform-for-whatsapp.unit.spec.ts
+++ b/apps/backend/src/modules/social-provider/__tests__/transform-for-whatsapp.unit.spec.ts
@@ -1,0 +1,54 @@
+import {
+  transformForWhatsApp,
+  WHATSAPP_MAX_IMAGE_BYTES,
+} from "../image-transformer"
+
+/**
+ * #1279 — 132 partner reminders between 2026-04 and 2026-08 were rejected by
+ * Meta with `131053 · Image file has size 6533833 bytes but must be atmost
+ * 5242880 bytes`. Meta drops the WHOLE message, so the partner saw nothing,
+ * stayed silent, hit the reminder cap, and the run was parked unasked.
+ *
+ * Measured against the real asset host: 1,665,812 B PNG → 180,996 B JPEG.
+ */
+
+const CF = "https://automatic.jaalyantra.com/automatica/design-01KTDQ.png"
+
+describe("transformForWhatsApp", () => {
+  it("states Meta's ceiling as the real one", () => {
+    expect(WHATSAPP_MAX_IMAGE_BYTES).toBe(5242880)
+  })
+
+  it("rewrites a Cloudflare-backed asset through the resizing path", () => {
+    const out = transformForWhatsApp(CF)
+    expect(out).toContain("/cdn-cgi/image/")
+    expect(out).toContain("/automatica/design-01KTDQ.png")
+  })
+
+  it("forces jpeg rather than auto — Meta's fetcher does not take webp/avif", () => {
+    const out = transformForWhatsApp(CF)
+    expect(out).toContain("format=jpeg")
+    expect(out).not.toContain("format=auto")
+  })
+
+  it("scales down only, and never crops a design photo to a square", () => {
+    const out = transformForWhatsApp(CF)
+    expect(out).toContain("fit=scale-down")
+    expect(out).toContain("width=1600")
+    expect(out).not.toContain("height=")
+  })
+
+  it("leaves a non-Cloudflare URL untouched — silently sending a different image is worse", () => {
+    const foreign = "https://example.com/some/photo.png"
+    expect(transformForWhatsApp(foreign)).toBe(foreign)
+  })
+
+  it("does not rewrite a rewrite — nesting the path yields a 404", () => {
+    const once = transformForWhatsApp(CF)
+    expect(transformForWhatsApp(once)).toBe(once)
+  })
+
+  it("passes empty input straight through", () => {
+    expect(transformForWhatsApp("")).toBe("")
+  })
+})

--- a/apps/backend/src/modules/social-provider/image-transformer.ts
+++ b/apps/backend/src/modules/social-provider/image-transformer.ts
@@ -10,7 +10,7 @@ export interface ImageTransformOptions {
   height?: number
   fit?: "scale-down" | "contain" | "cover" | "crop" | "pad"
   quality?: number
-  format?: "auto" | "webp" | "avif" | "json"
+  format?: "auto" | "webp" | "avif" | "json" | "jpeg" | "png"
 }
 
 /**
@@ -105,8 +105,66 @@ export function transformForInstagram(
 }
 
 /**
+ * Meta's hard ceiling for an image sent over the WhatsApp Cloud API.
+ * Exceed it and Meta rejects the ENTIRE message with error 131053 — not the
+ * image, the message. The recipient sees nothing at all.
+ */
+export const WHATSAPP_MAX_IMAGE_BYTES = 5 * 1024 * 1024
+
+/**
+ * Longest edge for an outbound WhatsApp image. WhatsApp itself downscales for
+ * display, so anything larger is bytes spent to be thrown away — and bytes are
+ * exactly what breaks the send.
+ */
+const WHATSAPP_MAX_EDGE = 1600
+
+/**
+ * Transform an image for the WhatsApp Cloud API (#1279).
+ *
+ * Between 2026-04 and 2026-08, 132 daily production-run reminders to partners
+ * FAILED with `131053 · Media upload error — Image file has size 6533833 bytes
+ * but must be atmost 5242880 bytes`. The reminder template carries the design
+ * image, the design image is the full-size upload, and Meta drops the whole
+ * message. Partners were never nagging-blind — they were never messaged. Runs
+ * then hit the reminder cap and were parked, unasked.
+ *
+ * Two decisions worth keeping:
+ *
+ * - **`format: "jpeg"`, not `"auto"`.** Cloudflare's `auto` serves WebP/AVIF to
+ *   clients that advertise them, and Meta's fetcher does not — an unsupported
+ *   format is the same rejected message by another route. Designs are also
+ *   uploaded as PNG, which is how a render reaches 6.5 MB in the first place;
+ *   forcing JPEG is most of the saving. Measured on a real design asset:
+ *   1,665,812 B PNG → 180,996 B JPEG.
+ * - **`fit: "scale-down"`.** Never enlarge, never crop. A design photo cropped
+ *   to a square is a worse message than a slightly large one.
+ *
+ * Non-Cloudflare URLs are returned untouched — there is nothing to rewrite, and
+ * silently sending a different image would be worse than sending the original.
+ * Callers must treat the result as best-effort, not as a guarantee of size.
+ */
+export function transformForWhatsApp(imageUrl: string): string {
+  if (!imageUrl || !isCloudflareUrl(imageUrl)) {
+    return imageUrl
+  }
+
+  // Already rewritten (a caller transformed it, or it is a resize URL from the
+  // media library). Rewriting a rewrite yields a 404 path, so leave it alone.
+  if (imageUrl.includes("/cdn-cgi/image/")) {
+    return imageUrl
+  }
+
+  return transformImageUrl(imageUrl, {
+    width: WHATSAPP_MAX_EDGE,
+    fit: "scale-down",
+    quality: 80,
+    format: "jpeg",
+  })
+}
+
+/**
  * Transform image for Facebook with optimal settings
- * 
+ *
  * @param imageUrl - Original image URL
  * @returns Transformed URL optimized for Facebook
  */

--- a/apps/backend/src/modules/social-provider/whatsapp-service.ts
+++ b/apps/backend/src/modules/social-provider/whatsapp-service.ts
@@ -1,6 +1,7 @@
 import { MedusaError, ContainerRegistrationKeys } from "@medusajs/utils"
 import type { MedusaContainer } from "@medusajs/framework/types"
 import { describeFetchError } from "../../utils/describe-fetch-error"
+import { transformForWhatsApp } from "./image-transformer"
 import { SOCIALS_MODULE } from "../socials"
 import { ENCRYPTION_MODULE } from "../encryption"
 import type EncryptionService from "../encryption/service"
@@ -310,11 +311,28 @@ export default class WhatsAppService {
       // string ("0"). Callers pass it as a number (typed) — coerce here so
       // the wire format matches Meta's spec for dynamic URL/quick-reply
       // button parameters.
-      payload.template.components = components.map((c) =>
-        c.type === "button" && c.index !== undefined
-          ? { ...c, index: String(c.index) }
-          : c
-      )
+      payload.template.components = components.map((c) => {
+        const coerced =
+          c.type === "button" && c.index !== undefined
+            ? { ...c, index: String(c.index) }
+            : c
+
+        // Header images ride along in template parameters, and an oversized one
+        // fails the WHOLE message (131053). Rewrite at the boundary rather than
+        // trusting every caller to remember — that is what cost 132 reminders
+        // between 2026-04 and 2026-08 (#1279).
+        if (!coerced.parameters?.length) {
+          return coerced
+        }
+        return {
+          ...coerced,
+          parameters: coerced.parameters.map((p) =>
+            p?.image?.link
+              ? { ...p, image: { ...p.image, link: transformForWhatsApp(p.image.link) } }
+              : p
+          ),
+        }
+      })
     }
 
     return this.sendRequest(payload, to, {
@@ -544,7 +562,9 @@ export default class WhatsAppService {
         messaging_product: "whatsapp",
         to,
         type: "image",
-        image: { link: imageUrl, ...(caption ? { caption } : {}) },
+        // Resized at the boundary — see transformForWhatsApp. Meta rejects the
+        // whole message over 5 MB, so this is not an optimisation (#1279).
+        image: { link: transformForWhatsApp(imageUrl), ...(caption ? { caption } : {}) },
       },
       to,
       audit

--- a/apps/backend/src/workflows/production-runs/__tests__/plan-reminder-rollback.unit.spec.ts
+++ b/apps/backend/src/workflows/production-runs/__tests__/plan-reminder-rollback.unit.spec.ts
@@ -1,0 +1,73 @@
+import { planReminderRollback } from "../emit-production-run-reminder"
+
+/**
+ * #1279 — the cap counted attempts Meta refused.
+ *
+ * 132 reminders failed with `131053` (oversized design image) between 2026-04
+ * and 2026-08, and every one still incremented `reminder_count`. Runs reached
+ * the cap and were parked into `awaiting_reassignment` — the state nothing
+ * watches — without the partner ever having been asked. A reminder Meta
+ * refused was never a reminder.
+ */
+
+const RUN = "prod_run_01KMYY7XVR6XVHW39YXMY6CKX0"
+
+const reminderMsg = (over: Record<string, any> = {}) => ({
+  status: "sent",
+  context_type: "production_run",
+  context_id: `${RUN}:reminder:2026-04-25`,
+  ...over,
+})
+
+describe("planReminderRollback", () => {
+  it("un-counts a reminder Meta refused", () => {
+    expect(planReminderRollback(reminderMsg(), "failed")).toEqual({
+      production_run_id: RUN,
+    })
+  })
+
+  it("leaves delivered and read alone", () => {
+    expect(planReminderRollback(reminderMsg(), "delivered")).toBeNull()
+    expect(planReminderRollback(reminderMsg(), "read")).toBeNull()
+    expect(planReminderRollback(reminderMsg(), "sent")).toBeNull()
+  })
+
+  it("does not decrement twice for one message — Meta repeats statuses", () => {
+    // The webhook re-applies `failed` by design. Counting it again would
+    // under-count and nag the partner forever.
+    expect(planReminderRollback(reminderMsg({ status: "failed" }), "failed")).toBeNull()
+  })
+
+  it("ignores a failed DISPATCH — only reminders touch the cap", () => {
+    expect(
+      planReminderRollback(
+        reminderMsg({ context_id: `${RUN}:sent_to_partner:2026-04-25` }),
+        "failed"
+      )
+    ).toBeNull()
+  })
+
+  it("ignores a message about something other than a production run", () => {
+    expect(
+      planReminderRollback(
+        reminderMsg({ context_type: "inventory_order" }),
+        "failed"
+      )
+    ).toBeNull()
+  })
+
+  it("ignores a message with no context at all — the old rows carry none", () => {
+    expect(
+      planReminderRollback({ status: "sent", context_type: null, context_id: null }, "failed")
+    ).toBeNull()
+    expect(planReminderRollback({}, "failed")).toBeNull()
+  })
+
+  it("reads the run id off the real prod context shape", () => {
+    // Verbatim from a failed prod row: "<run_id>:reminder:<date>".
+    const actual = "prod_run_01KMYY7XVR6XVHW39YXMY6CKX0:reminder:2026-04-25"
+    expect(
+      planReminderRollback({ status: "sent", context_type: "production_run", context_id: actual }, "failed")
+    ).toEqual({ production_run_id: "prod_run_01KMYY7XVR6XVHW39YXMY6CKX0" })
+  })
+})

--- a/apps/backend/src/workflows/production-runs/emit-production-run-reminder.ts
+++ b/apps/backend/src/workflows/production-runs/emit-production-run-reminder.ts
@@ -90,6 +90,52 @@ export function decideReminderAction(
 }
 
 /**
+ * PURE: should a failed WhatsApp delivery un-count the reminder it carried?
+ * Exported for unit testing.
+ *
+ * The cap counts reminders SENT, and until #1279 "sent" meant "handed to Meta",
+ * not "reached anyone". Between 2026-04 and 2026-08, 132 reminders were
+ * rejected outright (`131053`, an oversized design image) and every one of them
+ * still incremented the count. Runs reached the cap and were parked having
+ * never been asked — which is the worst possible outcome, because parking is
+ * the state nothing watches.
+ *
+ * The send is asynchronous — the emitter increments long before Meta answers —
+ * so the correction has to happen when the delivery-status webhook lands. This
+ * decides whether it should.
+ *
+ * Conditions, all required:
+ *   - the new status is `failed` (delivered/read obviously stand)
+ *   - the message is NOT already `failed` — Meta can repeat a status, and the
+ *     webhook re-applies `failed` by design; decrementing twice for one message
+ *     would under-count and nag a partner forever
+ *   - the message is a production-run REMINDER, identified by the
+ *     `("production_run", "<run_id>:reminder:<date>")` context pair the reminder
+ *     path writes. A failed dispatch or ad-hoc message must not touch the cap.
+ */
+export function planReminderRollback(
+  message: {
+    status?: string | null
+    context_type?: string | null
+    context_id?: string | null
+  },
+  newStatus: string
+): { production_run_id: string } | null {
+  if (newStatus !== "failed" || message?.status === "failed") {
+    return null
+  }
+  if (message?.context_type !== "production_run" || !message?.context_id) {
+    return null
+  }
+  if (!message.context_id.includes(":reminder:")) {
+    return null
+  }
+
+  const runId = message.context_id.split(":")[0]
+  return runId ? { production_run_id: runId } : null
+}
+
+/**
  * #1228 — what a cap on an UNACCEPTED run does. Before #1228 this was always
  * "park it"; now the stored policy may buy the partner one more full reminder
  * cycle first, on the theory that a silent partner is usually a busy one rather


### PR DESCRIPTION
Fixes the first rung of #1279 — the one that made all the others matter.

## Partners were not ignoring the reminders. They were never sent one.

We persist `sent → delivered → read` and `fail_reason` per message, so this is measured, not inferred. Outbound to the four partners holding the parked runs:

| partner | read | failed | of those, at **04:30** |
|---|---|---|---|
| Prince Tailors | 43 | 12 | 9 |
| Raja Shawls | 27 | 6 | 5 |
| Shramdaan | 180 | 78 | **75** |
| Sharlho | 244 | 44 | **43** |
| **total** | **494** | **140** | **132** |

04:30 UTC is the daily reminder flow's schedule. **132 of the 140 failures are reminders**, against 494 messages read — these partners are on WhatsApp constantly. Where a reason was captured it is the same one twice:

```
131053 · Media upload error — Image file has size 6533833 bytes
                              but must be atmost 5242880 bytes
```

The reminder template carries the design image, the design image is the raw full-size upload, and Meta rejects **the whole message**. The partner sees nothing, says nothing, hits the reminder cap, and the run is parked into `awaiting_reassignment` — the one state nothing watches — having never been asked.

## 1. Resize at the send boundary

`transformForWhatsApp()` rewrites Cloudflare-backed image URLs through Cloudflare Image Resizing before they reach Meta. A **URL rewrite** — no download, no `sharp`, no re-upload. Verified against the live asset host and against the exact URL the code emits:

```
1,665,812 B  image/png   →   180,996 B  image/jpeg      (9x)
```

Applied in `sendImageMessage` and in template header parameters, so no caller has to remember. Two choices worth keeping:

- **`format=jpeg`, not `auto`.** Cloudflare's `auto` serves WebP/AVIF to clients that advertise them and Meta's fetcher does not — that is the same rejected message by another route. Designs are uploaded as PNG, which is how a render reaches 6.5 MB; forcing JPEG is most of the saving.
- **`fit=scale-down`.** Never enlarge, never crop. A design photo cropped square is a worse message than a slightly large one.

Non-Cloudflare URLs pass through untouched, and an already-rewritten URL is not rewritten again (nesting the path 404s).

## 2. A reminder Meta refused was never a reminder

The cap counts reminders *sent*, and "sent" meant "handed to Meta". Every one of those 132 rejections still incremented `reminder_count`. That is what actually parked the runs.

The send is asynchronous, so the correction lands with the delivery-status webhook: `planReminderRollback()` decrements `reminder_count` on a `failed` status for a `("production_run", "<run>:reminder:<date>")` message and logs the rejection. Gated on the message not *already* being `failed` — Meta repeats statuses and the webhook re-applies `failed` by design, so decrementing twice would under-count and nag a partner forever. Failed dispatches and non-run messages never touch the cap.

## No resend

All six re-dispatches from 2026-08-12 07:41 came back **`read`**, and hrhandloom is 9/9 read. Nothing is currently undelivered, and replaying months-old reminders would nag partners about work they were asked about yesterday. Caveat: I verified 5 of 17 conversations — the four holding parked runs plus one control — so this is "no live run is waiting on an undelivered message", not "no historical failure exists elsewhere".

## Also settled

WhatsApp **groups are out** for this escalation. `/admin/social-platforms/whatsapp/config` (#1246 is deployed) returns `is_official_business_account: false`; `name_status: APPROVED` is display-name approval, not OBA. The Groups API needs OBA, which is Meta's official-business tier granted on review — not a setting. Don't wait on #1245.

## Verify

```
pnpm test:unit --testPathPattern="transform-for-whatsapp|plan-reminder-rollback|decide-reminder-action"   # 24 pass
```

⚠️ Use `pnpm test:unit`, not bare `npx jest` — the latter picks the wrong transform and dies with a bogus `SyntaxError`.

tsc 79 — the main baseline, unchanged. No migrations.

## Still open on #1279

The admin escalation bucket for `awaiting_reassignment`, and a delivery path for `production_run.reminder_escalated`, whose only consumer today is `production-run-activity-recorder.ts` — an activity row nobody reads.

🤖 Generated with [Claude Code](https://claude.com/claude-code)