### PR TITLE
feat(production-runs): give parked runs an admin escalation, and the escalation a delivery (#1279)

### DIFF
--- a/apps/backend/src/api/admin/ops/maintenance-jobs/registry.ts
+++ b/apps/backend/src/api/admin/ops/maintenance-jobs/registry.ts
@@ -70,6 +70,7 @@ import { FLOW_DEF as INVENTORY_ORDER_STATUS_FLOW_DEF } from "../../../../scripts
 import { FLOW_DEF as INVENTORY_SHIPMENT_PICKUP_FLOW_DEF } from "../../../../scripts/seed-inventory-shipment-pickup-flow"
 import { FLOW_DEF as ARTISAN_PRODUCT_APPROVAL_FLOW_DEF } from "../../../../scripts/seed-artisan-product-approval-flow"
 import { FLOW_DEF as PARTNER_RUN_WHATSAPP_FLOW_DEF } from "../../../../scripts/seed-partner-run-whatsapp-flow"
+import { FLOW_DEF as RUN_REMINDERS_FLOW_DEF } from "../../../../scripts/seed-production-run-reminders-flow"
 import { ALL_WHATSAPP_TEMPLATES } from "../../../../scripts/whatsapp-templates/all-templates"
 import {
   syncWhatsAppTemplates,
@@ -4675,6 +4676,116 @@ export const syncPartnerRunWhatsAppFlowJob: MaintenanceJob = {
 }
 
 // ---------------------------------------------------------------------------
+// sync-production-run-reminders-flow (#1279) — install OR REPLACE the daily
+// "Production Run Reminders — Daily Discoverer" flow in place.
+//
+// Why this job has to exist: the CLI seeder REFUSES to touch an existing flow,
+// so editing the FLOW_DEF changes nothing on prod. The live row keeps the graph
+// it was created with. That is how `awaiting_reassignment` stayed out of the
+// read filter long after anyone would have called it fixed — a change that
+// looks shipped and is inert. Replacing in place is the only way the parked
+// bucket actually reaches production. Id and active/draft status are preserved.
+// ---------------------------------------------------------------------------
+
+export const syncProductionRunRemindersFlowJob: MaintenanceJob = {
+  id: "sync-production-run-reminders-flow",
+  label: "Install / replace the daily production-run reminders flow",
+  description:
+    "Install or REPLACE the 'Production Run Reminders — Daily Discoverer' visual flow in place, preserving its id and active/draft status (#1279). Needed because the CLI seeder refuses to overwrite an existing flow, so code changes to the flow graph do NOT reach prod on deploy — they need this. The current definition adds the awaiting_reassignment (parked) bucket to the read filter and classifier: parked runs have no partner and escalate weekly to an ADMIN instead of nagging one. ⚠️ Read the dry-run: it reports whether the live flow is already current, and replacing DISCARDS any hand edits made in the flow editor.",
+  params: [],
+  run: async (container, { dry_run }) => {
+    const service: any = container.resolve(VISUAL_FLOWS_MODULE)
+    const def = RUN_REMINDERS_FLOW_DEF
+    const flowName = def.name
+    const nodeCount = def.canvas_state?.nodes?.length ?? 0
+    const connCount = def.connections?.length ?? 0
+
+    const [existing] = await service.listVisualFlows({ name: flowName })
+    const mode = existing ? "replace" : "create"
+
+    // Is the live flow already carrying the parked bucket? Reported so a
+    // re-run reads as a no-op rather than looking like it did something. The
+    // read filter is the load-bearing half — without it the classifier never
+    // sees a parked run at all.
+    let alreadyCurrent = false
+    if (existing) {
+      try {
+        const ops = await service.listVisualFlowOperations({ flow_id: existing.id })
+        const read = (ops || []).find((o: any) => o.operation_key === "read_active_runs")
+        const statuses = read?.options?.filters?.status?.$in ?? []
+        alreadyCurrent = statuses.includes("awaiting_reassignment")
+      } catch {
+        // Non-fatal: the sync still works, we just cannot say whether it is a
+        // no-op. Better to under-claim than to assert a state we did not read.
+        alreadyCurrent = false
+      }
+    }
+
+    if (!dry_run) {
+      if (existing) {
+        await service.updateCompleteFlow(existing.id, {
+          description: def.description,
+          trigger_type: def.trigger_type,
+          trigger_config: def.trigger_config,
+          canvas_state: def.canvas_state,
+          operations: def.operations,
+          connections: def.connections,
+        })
+      } else {
+        await service.createCompleteFlow({
+          flow: {
+            name: def.name,
+            description: def.description,
+            status: def.status,
+            trigger_type: def.trigger_type,
+            trigger_config: def.trigger_config,
+            canvas_state: def.canvas_state,
+          },
+          operations: def.operations,
+          connections: def.connections,
+        })
+      }
+    }
+
+    const targetId = existing?.id ?? "(new)"
+    const changes: MaintenanceChange[] = [
+      {
+        entity: "visual_flow",
+        id: targetId,
+        field: mode === "replace" ? "replaced" : "created",
+        after: {
+          name: flowName,
+          nodes: nodeCount,
+          connections: connCount,
+          parked_bucket_present_before: alreadyCurrent,
+          status_preserved: existing ? (existing as any).status : def.status,
+        },
+      },
+    ]
+
+    const currency = alreadyCurrent
+      ? " The live flow ALREADY reads awaiting_reassignment, so this is a no-op re-sync."
+      : " The live flow does NOT currently read awaiting_reassignment — parked runs are invisible to it until this is applied."
+
+    const summary = dry_run
+      ? mode === "replace"
+        ? `Would REPLACE visual flow "${flowName}" (${targetId}) in place — ${nodeCount} nodes, ${connCount} connections; id and status preserved.${currency} Nothing written. ⚠️ Replacing discards hand edits made in the flow editor.`
+        : `Would create visual flow "${flowName}" (${nodeCount} nodes) as DRAFT. Nothing written.`
+      : mode === "replace"
+        ? `Replaced visual flow "${flowName}" (${targetId}) in place — ${nodeCount} nodes, ${connCount} connections; id and status preserved. Parked runs now escalate weekly to an admin.`
+        : `Created visual flow "${flowName}" as DRAFT — flip draft→active to go live.`
+
+    return {
+      job_id: syncProductionRunRemindersFlowJob.id,
+      dry_run,
+      applied: !dry_run,
+      summary,
+      changes,
+    }
+  },
+}
+
+// ---------------------------------------------------------------------------
 // generate-winback-targets (#659, report §12.5) — read ad_planning churn-risk
 // (+ optional CLV) scores, resolve each scored Person's email, and select
 // winback targets with a PURE, unit-tested selector (threshold + optional CLV
@@ -5638,6 +5749,7 @@ export const MAINTENANCE_JOBS: MaintenanceJob[] = [
   installArtisanProductApprovalFlowJob,
   syncWhatsAppTemplatesJob,
   syncPartnerRunWhatsAppFlowJob,
+  syncProductionRunRemindersFlowJob,
   generateWinbackTargetsJob,
   sendMarketingDailySummaryJob,
   auditAiPlatformsJob,

--- a/apps/backend/src/scripts/seed-production-run-reminders-flow.ts
+++ b/apps/backend/src/scripts/seed-production-run-reminders-flow.ts
@@ -2,7 +2,7 @@
  * Seed: Production Run Reminders — Scheduled Discoverer
  *
  * Daily-weekday scheduled visual flow that finds production runs which
- * are stuck in one of three buckets and emits a per-run reminder event.
+ * are stuck in one of four buckets and emits a per-run reminder event.
  * The actual WhatsApp send is handled by the existing wildcard seed
  * (src/scripts/seed-partner-run-whatsapp-flow.ts) which already listens
  * to `production_run.*` and is "attuned to production subscription".
@@ -13,6 +13,11 @@
  *   not_started         accepted_at set AND no started_at
  *                       AND accepted_at < now − 24h
  *   idle                status='in_progress' AND started_at < now − 72h
+ *   awaiting_reassignment  status='awaiting_reassignment' — PARKED, no partner.
+ *                       Not a nag: escalates to an ADMIN, weekly, until the run
+ *                       is re-dispatched. Added in #1279, where its absence
+ *                       from the read filter made parking terminal in practice
+ *                       and left six runs invisible for up to 4.5 months.
  *
  * Cadence:
  *   Cron `30 4 * * 1-5` = 10:00 IST Mon–Fri when the container runs UTC.
@@ -58,10 +63,26 @@ function ageMs(iso) {
 }
 
 const items = []
-const counts = { assignment_pending: 0, not_started: 0, idle: 0, skipped_no_partner: 0, skipped_not_overdue: 0 }
+const counts = { assignment_pending: 0, not_started: 0, idle: 0, awaiting_reassignment: 0, skipped_no_partner: 0, skipped_not_overdue: 0 }
 
 for (const run of records) {
   if (!run || !run.id) continue
+
+  // A parked run has NO partner — parking nulls partner_id and keeps
+  // previous_partner_id. It must be classified BEFORE the no-partner skip,
+  // which is exactly what hid it from this flow (#1279). Its escalation goes
+  // to an admin, not a partner, and the cadence lives in the emit workflow.
+  if (run.status === "awaiting_reassignment") {
+    counts.awaiting_reassignment++
+    items.push({
+      production_run_id: run.id,
+      partner_id: null,
+      design_id: run.design_id || null,
+      reminder_kind: "awaiting_reassignment",
+    })
+    continue
+  }
+
   if (!run.partner_id) {
     counts.skipped_no_partner++
     continue
@@ -100,14 +121,23 @@ return { items, counts, total_inspected: records.length }
 
 // ─── Flow definition ─────────────────────────────────────────────────────────
 
-const FLOW_DEF = {
+/**
+ * Exported so the `sync-production-run-reminders-flow` maintenance job can
+ * install OR REPLACE this flow from the Data-Plumbing console — single source
+ * of truth with the CLI seed. Without that, editing this file changes nothing
+ * on prod: the seeder below refuses to touch an existing flow, so the live row
+ * keeps whatever graph it was created with (#1279).
+ */
+export const FLOW_DEF = {
   name: FLOW_NAME,
   description:
     "Scheduled daily discoverer for stuck production runs. Reads active runs, " +
-    "classifies them into reminder buckets (assignment_pending / not_started / idle) " +
-    "and emits a per-run reminder event via the emit-production-run-reminder workflow. " +
-    "The existing wildcard partner-WhatsApp flow picks up the events and sends the " +
-    "appropriate Meta-approved template to the partner.",
+    "classifies them into reminder buckets (assignment_pending / not_started / idle / " +
+    "awaiting_reassignment) and emits a per-run reminder event via the " +
+    "emit-production-run-reminder workflow. The existing wildcard partner-WhatsApp flow " +
+    "picks up the partner-facing events and sends the appropriate Meta-approved template. " +
+    "awaiting_reassignment is the odd one out: a parked run has no partner, so it escalates " +
+    "weekly to an admin via the production-run-escalation-notifier subscriber instead.",
   status: "draft" as const,
   trigger_type: "schedule" as const,
   trigger_config: {
@@ -156,7 +186,14 @@ const FLOW_DEF = {
           "quantity",
         ],
         filters: {
-          status: { $in: ["sent_to_partner", "in_progress"] },
+          // #1279 — `awaiting_reassignment` was missing here, which made
+          // parking terminal in practice: the cap parked a run and the
+          // machinery that parked it could no longer see it. Six runs sat that
+          // way, the oldest for 4.5 months. It has NO partner, so the
+          // classifier below must not skip it for that.
+          status: {
+            $in: ["sent_to_partner", "in_progress", "awaiting_reassignment"],
+          },
         },
         limit: 500,
       },
@@ -215,6 +252,7 @@ const FLOW_DEF = {
           "assignment_pending={{ classify.counts.assignment_pending }} " +
           "not_started={{ classify.counts.not_started }} " +
           "idle={{ classify.counts.idle }} " +
+          "parked={{ classify.counts.awaiting_reassignment }} " +
           "dispatched={{ dispatch.triggered }} failed={{ dispatch.failed }}",
         level: "info",
       },

--- a/apps/backend/src/subscribers/__tests__/production-run-escalation-notifier.unit.spec.ts
+++ b/apps/backend/src/subscribers/__tests__/production-run-escalation-notifier.unit.spec.ts
@@ -1,0 +1,133 @@
+import productionRunEscalationNotifier, {
+  config,
+} from "../production-run-escalation-notifier"
+
+/**
+ * #1279 — this subscriber is the audience `production_run.reminder_escalated`
+ * has been naming since #1093 and never had. Before it, the event's only
+ * consumer wrote a timeline row labelled "escalated to admin" that nobody read.
+ *
+ * So the properties worth pinning are about REACHING someone, and about the two
+ * escalations staying distinguishable — a parked run needs re-dispatching, a
+ * stalled one needs chasing, and telling an admin the wrong one wastes the only
+ * message they get.
+ */
+
+const RUN = "prod_run_01KMYY7XVR6XVHW39YXMY6CKX0"
+
+const harness = (
+  run: Record<string, any> | null = { name: "Dark Desires Dress", quantity: 4 },
+  over: { notification?: any } = {}
+) => {
+  const logger = { info: jest.fn(), warn: jest.fn(), error: jest.fn() }
+  const notification = over.notification ?? { createNotifications: jest.fn() }
+  const runService = {
+    retrieveProductionRun: jest.fn().mockResolvedValue(run),
+  }
+
+  return {
+    logger,
+    notification,
+    runService,
+    container: {
+      resolve: (key: string) => {
+        if (key === "logger") return logger
+        if (key === "notification") return notification
+        if (key === "production_runs") return runService
+        throw new Error(`unexpected resolve(${key})`)
+      },
+    } as any,
+  }
+}
+
+const fire = (h: any, name: string, data: Record<string, any>) =>
+  productionRunEscalationNotifier({ event: { name, data }, container: h.container } as any)
+
+describe("production-run-escalation-notifier", () => {
+  it("subscribes to BOTH silent rungs, not just the new one", () => {
+    expect(config.event).toEqual([
+      "production_run.reminder_escalated",
+      "production_run.reminder_awaiting_reassignment",
+    ])
+  })
+
+  it("tells an admin a parked run needs a partner, and how to give it one", async () => {
+    const h = harness()
+    await fire(h, "production_run.reminder_awaiting_reassignment", {
+      production_run_id: RUN,
+      parked_days: 135,
+      previous_partner_id: "partner_abc",
+    })
+
+    const [{ data }] = h.notification.createNotifications.mock.calls[0]
+    expect(data.title).toContain("parked")
+    expect(data.title).toContain("135d")
+    expect(data.description).toContain("Dark Desires Dress")
+    expect(data.description).toContain("no partner assigned")
+    expect(data.description).toContain("redispatch-parked")
+    expect(data.description).toContain("partner_abc")
+    // It must say it will come back — an escalation that looks one-shot gets
+    // triaged as "I'll deal with it later" and then never resurfaces.
+    expect(data.description).toContain("weekly")
+  })
+
+  it("does NOT tell an admin to re-dispatch a run whose partner still holds it", async () => {
+    const h = harness()
+    await fire(h, "production_run.reminder_escalated", { production_run_id: RUN })
+
+    const [{ data }] = h.notification.createNotifications.mock.calls[0]
+    expect(data.title).toContain("gone quiet")
+    expect(data.description).toContain("still holds the work")
+    expect(data.description).not.toContain("redispatch-parked")
+  })
+
+  it("falls back to the run id when the run has no name", async () => {
+    const h = harness(null)
+    await fire(h, "production_run.reminder_awaiting_reassignment", {
+      production_run_id: RUN,
+    })
+
+    const [{ data }] = h.notification.createNotifications.mock.calls[0]
+    expect(data.description).toContain(RUN)
+  })
+
+  it("still logs the escalation when the notification provider is down", async () => {
+    const h = harness(undefined as any, {
+      notification: {
+        createNotifications: jest.fn().mockRejectedValue(new Error("provider down")),
+      },
+    })
+
+    await expect(
+      fire(h, "production_run.reminder_awaiting_reassignment", { production_run_id: RUN })
+    ).resolves.toBeUndefined()
+
+    // The log line is the fallback record that an escalation happened at all.
+    expect(h.logger.warn).toHaveBeenCalledWith(expect.stringContaining("parked"))
+    expect(h.logger.warn).toHaveBeenCalledWith(expect.stringContaining("provider down"))
+  })
+
+  it("ignores an event with no run id instead of throwing", async () => {
+    const h = harness()
+    await expect(fire(h, "production_run.reminder_escalated", {})).resolves.toBeUndefined()
+    expect(h.notification.createNotifications).not.toHaveBeenCalled()
+  })
+
+  it("never throws out of the subscriber — a retry would re-escalate", async () => {
+    const logger = { info: jest.fn(), warn: jest.fn(), error: jest.fn() }
+    const container = {
+      resolve: (key: string) => {
+        if (key === "logger") return logger
+        throw new Error("module gone")
+      },
+    } as any
+
+    await expect(
+      productionRunEscalationNotifier({
+        event: { name: "production_run.reminder_escalated", data: { production_run_id: RUN } },
+        container,
+      } as any)
+    ).resolves.toBeUndefined()
+    expect(logger.error).toHaveBeenCalledWith(expect.stringContaining("module gone"))
+  })
+})

--- a/apps/backend/src/subscribers/production-run-escalation-notifier.ts
+++ b/apps/backend/src/subscribers/production-run-escalation-notifier.ts
@@ -1,0 +1,115 @@
+import { SubscriberArgs, type SubscriberConfig } from "@medusajs/framework"
+import { ContainerRegistrationKeys, Modules } from "@medusajs/framework/utils"
+
+import { PRODUCTION_RUNS_MODULE } from "../modules/production_runs"
+import type ProductionRunService from "../modules/production_runs/service"
+
+/**
+ * Delivers production-run escalations to a human (#1279).
+ *
+ * Both top rungs of the reminder ladder used to end in silence:
+ *
+ *   sent_to_partner → reminders → cap → awaiting_reassignment → nothing
+ *   accepted        → reminders → cap → "escalated to admin"  → an activity row
+ *
+ * The second one is the subtle failure. `production_run.reminder_escalated`
+ * has existed since #1093 and its only consumer was
+ * `production-run-activity-recorder.ts`, which writes a timeline row labelled
+ * "Reminder cap reached — escalated to admin". Nobody reads a timeline row.
+ * The event named an audience it never reached.
+ *
+ * This subscriber is that audience. It is the ONLY thing standing between an
+ * escalation and nobody hearing it, so it is deliberately dumb: read the run,
+ * compose a sentence a human can act on, post it to the admin feed. No
+ * decisions, no writes to the run.
+ *
+ * ⚠️ The two escalations are NOT the same message and must not be merged:
+ *   - `reminder_escalated`: the partner accepted and then went quiet. The
+ *     partner still holds the work; the ask is "chase them".
+ *   - `reminder_awaiting_reassignment`: the run is parked and has NO partner.
+ *     Nothing will move it without a human choosing one; the ask is
+ *     "re-dispatch it". This is the one that let six runs sit for months.
+ */
+
+type EscalationEvent =
+  | "production_run.reminder_escalated"
+  | "production_run.reminder_awaiting_reassignment"
+
+export default async function productionRunEscalationNotifier({
+  event,
+  container,
+}: SubscriberArgs<Record<string, any>>) {
+  const logger: any = container.resolve(ContainerRegistrationKeys.LOGGER)
+  const name = event.name as EscalationEvent
+  const runId = event.data?.production_run_id
+
+  if (!runId) {
+    return
+  }
+
+  try {
+    const service: ProductionRunService = container.resolve(PRODUCTION_RUNS_MODULE)
+    const run = (await service.retrieveProductionRun(runId).catch(() => null)) as any
+
+    const label = run?.name || runId
+    const qty = run?.quantity != null ? ` (${run.quantity} pcs)` : ""
+
+    let title: string
+    let description: string
+
+    if (name === "production_run.reminder_awaiting_reassignment") {
+      const days = event.data?.parked_days
+      const parkedFor =
+        typeof days === "number" && days > 0
+          ? ` It has been parked for ${days} day${days === 1 ? "" : "s"}.`
+          : ""
+      const from = event.data?.previous_partner_id
+        ? ` It was previously with partner ${event.data.previous_partner_id}.`
+        : ""
+
+      title = `Production run parked — needs a partner${
+        typeof days === "number" && days > 0 ? ` (${days}d)` : ""
+      }`
+      description =
+        `${label}${qty} is in awaiting_reassignment and has no partner assigned.${parkedFor}${from} ` +
+        `Nothing will move it automatically — re-dispatch it from the run page, ` +
+        `or via POST /admin/production-runs/redispatch-parked. ` +
+        `This repeats weekly until the run leaves the parked state.`
+    } else {
+      title = `Production run stalled — partner has gone quiet`
+      description =
+        `${label}${qty} was accepted by its partner and then stopped progressing. ` +
+        `The reminder cap has been reached, so no further reminders will be sent. ` +
+        `The partner still holds the work — chase them, or reassign the run if they have dropped it.`
+    }
+
+    logger.warn(`[run-escalation] ${title} — ${description}`)
+
+    // Best-effort: a notification-provider outage must not lose the log line
+    // above, which is the fallback record that an escalation happened at all.
+    try {
+      const notificationService: any = container.resolve(Modules.NOTIFICATION)
+      await notificationService.createNotifications({
+        to: "",
+        channel: "feed",
+        template: "admin-ui",
+        data: { title, description },
+      })
+    } catch (e: any) {
+      logger.warn(
+        `[run-escalation] Could not post the admin notification for ${runId}: ${e?.message}`
+      )
+    }
+  } catch (e: any) {
+    // Never throw out of a subscriber — a failed notification must not retry
+    // the event and re-escalate.
+    logger.error(`[run-escalation] Error handling ${name} for ${runId}: ${e?.message}`)
+  }
+}
+
+export const config: SubscriberConfig = {
+  event: [
+    "production_run.reminder_escalated",
+    "production_run.reminder_awaiting_reassignment",
+  ],
+}

--- a/apps/backend/src/workflows/production-runs/__tests__/decide-parked-escalation.unit.spec.ts
+++ b/apps/backend/src/workflows/production-runs/__tests__/decide-parked-escalation.unit.spec.ts
@@ -1,0 +1,115 @@
+import {
+  decideParkedEscalation,
+  PARKED_ESCALATION_INTERVAL_DAYS,
+} from "../emit-production-run-reminder"
+
+/**
+ * #1279 — `awaiting_reassignment` was terminal in practice. The reminder flow
+ * read only `sent_to_partner`/`in_progress`, so the moment the cap parked a
+ * run, the machinery that parked it could no longer see it. Six runs sat that
+ * way until a human noticed, the oldest for 4.5 months.
+ *
+ * The two failure modes this must avoid are opposites, which is why the rule
+ * is a cadence rather than a cap:
+ *   - escalate once and go quiet  → recreates the original bug
+ *   - escalate every single day    → the channel gets muted, same outcome
+ */
+
+const NOW = new Date("2026-08-12T05:00:00.000Z")
+const daysAgo = (n: number) =>
+  new Date(NOW.getTime() - n * 86_400_000).toISOString()
+
+describe("decideParkedEscalation", () => {
+  it("uses a weekly cadence", () => {
+    expect(PARKED_ESCALATION_INTERVAL_DAYS).toBe(7)
+  })
+
+  it("escalates a run that has never been escalated", () => {
+    const out = decideParkedEscalation(
+      { reminder_kind: null, reminder_status: "closed", last_reminded_at: null },
+      NOW
+    )
+    expect(out.action).toBe("escalated")
+    expect(out.reason).toBeNull()
+  })
+
+  it("stays quiet inside the interval", () => {
+    const out = decideParkedEscalation(
+      {
+        reminder_kind: "awaiting_reassignment",
+        reminder_status: "escalated",
+        last_reminded_at: daysAgo(3),
+      },
+      NOW
+    )
+    expect(out).toMatchObject({ action: "skipped", reason: "escalated_recently" })
+  })
+
+  it("escalates again once the interval has passed — told once is how runs get lost", () => {
+    const out = decideParkedEscalation(
+      {
+        reminder_kind: "awaiting_reassignment",
+        reminder_status: "escalated",
+        last_reminded_at: daysAgo(8),
+      },
+      NOW
+    )
+    expect(out.action).toBe("escalated")
+  })
+
+  it("is not silenced by `escalated` status the way the partner buckets are", () => {
+    // decideReminderAction returns `skipped` forever on reminder_status
+    // "escalated". Reusing it here would have reproduced the bug being fixed.
+    const out = decideParkedEscalation(
+      {
+        reminder_kind: "awaiting_reassignment",
+        reminder_status: "escalated",
+        last_reminded_at: daysAgo(30),
+      },
+      NOW
+    )
+    expect(out.action).toBe("escalated")
+  })
+
+  it("ignores a stale last_reminded_at left over from the partner cycle", () => {
+    // Parking sets reminder_kind to null but does NOT clear last_reminded_at,
+    // so a run parked yesterday can carry a timestamp from the partner nags.
+    // Reading it as ours would silence the first admin escalation for a week.
+    const out = decideParkedEscalation(
+      {
+        reminder_kind: null,
+        reminder_status: "closed",
+        last_reminded_at: daysAgo(1),
+      },
+      NOW
+    )
+    expect(out.action).toBe("escalated")
+  })
+
+  it("reports how long the run has been parked, for a message that sharpens over time", () => {
+    const out = decideParkedEscalation(
+      { reminder_kind: null, last_reminded_at: null, updated_at: daysAgo(135) },
+      NOW
+    )
+    expect(out.parked_days).toBe(135)
+  })
+
+  it("reports 0 parked days rather than guessing when the timestamp is unusable", () => {
+    expect(
+      decideParkedEscalation({ updated_at: null, last_reminded_at: null }, NOW).parked_days
+    ).toBe(0)
+    expect(
+      decideParkedEscalation({ updated_at: "not-a-date", last_reminded_at: null }, NOW)
+        .parked_days
+    ).toBe(0)
+  })
+
+  it("honours a custom interval", () => {
+    const run = {
+      reminder_kind: "awaiting_reassignment",
+      last_reminded_at: daysAgo(2),
+    }
+    expect(decideParkedEscalation(run, NOW, 7).action).toBe("skipped")
+    expect(decideParkedEscalation(run, NOW, 1).action).toBe("escalated")
+  })
+})

--- a/apps/backend/src/workflows/production-runs/emit-production-run-reminder.ts
+++ b/apps/backend/src/workflows/production-runs/emit-production-run-reminder.ts
@@ -16,11 +16,25 @@ import { PARTNER_MODULE } from "../../modules/partner"
 import { reassignProductionRunWorkflow } from "./reassign-production-run"
 import { acceptProductionRunWorkflow } from "./accept-production-run"
 
-export type ReminderKind = "assignment_pending" | "not_started" | "idle"
+export type ReminderKind =
+  | "assignment_pending"
+  | "not_started"
+  | "idle"
+  /**
+   * #1279 — a run parked in `awaiting_reassignment`. Unlike every other kind
+   * this one has NO partner (parking nulls `partner_id` and keeps
+   * `previous_partner_id` for audit), so it is not a nag — it is an admin
+   * escalation. It exists because parking used to be terminal in practice:
+   * the reminder flow read only `sent_to_partner`/`in_progress`, so the moment
+   * the cap parked a run, the machinery that parked it could no longer see it.
+   * Six runs sat that way until a human noticed, the oldest for 4.5 months.
+   */
+  | "awaiting_reassignment"
 
 export type EmitProductionRunReminderInput = {
   production_run_id: string
-  partner_id: string
+  /** Null only for `awaiting_reassignment` — a parked run has no partner. */
+  partner_id: string | null
   design_id?: string | null
   reminder_kind: ReminderKind
 }
@@ -29,7 +43,20 @@ const REMINDER_EVENT_BY_KIND: Record<ReminderKind, string> = {
   assignment_pending: "production_run.reminder_assignment_pending",
   not_started: "production_run.reminder_not_started",
   idle: "production_run.reminder_idle",
+  awaiting_reassignment: "production_run.reminder_awaiting_reassignment",
 }
+
+/**
+ * #1279 — how long a parked run waits between admin escalations.
+ *
+ * Not daily: a parked run is waiting on a human decision that takes days, and
+ * a daily nag about the same six runs is how a channel gets muted. Not once
+ * either — "tell someone a single time and never again" is precisely the bug
+ * being fixed. Weekly is the compromise, and the escalation states how long
+ * the run has been parked so the message gets more pointed rather than more
+ * frequent.
+ */
+export const PARKED_ESCALATION_INTERVAL_DAYS = 7
 
 /**
  * #1093 — after this many reminders in a single bucket the run stops being
@@ -87,6 +114,66 @@ export function decideReminderAction(
   }
 
   return { action: "reminded", nextCount: effectiveCount + 1 }
+}
+
+/**
+ * PURE: should a parked run escalate to an admin right now? Exported for tests.
+ *
+ * Deliberately NOT folded into `decideReminderAction`. That function's contract
+ * — count up to a cap, then hand off — is about nagging a partner, and a parked
+ * run has no partner to nag. Reusing it would have meant `reminder_status ===
+ * "escalated" → skipped forever`, which recreates the original bug in a new
+ * place: told once, then silent while the run sits.
+ *
+ * So the rule is a cadence, not a cap:
+ *   - never escalated for this bucket → escalate now
+ *   - escalated less than the interval ago → stay quiet
+ *   - escalated longer ago than the interval → escalate again
+ *
+ * `parked_days` rides along so the message can sharpen over time instead of
+ * repeating itself.
+ */
+export function decideParkedEscalation(
+  run: {
+    reminder_kind?: string | null
+    reminder_status?: string | null
+    last_reminded_at?: string | Date | null
+    updated_at?: string | Date | null
+  },
+  now: Date = new Date(),
+  intervalDays: number = PARKED_ESCALATION_INTERVAL_DAYS
+): { action: "escalated" | "skipped"; parked_days: number; reason: string | null } {
+  const nowMs = now.getTime()
+  const asMs = (v: string | Date | null | undefined): number | null => {
+    if (!v) return null
+    const t = v instanceof Date ? v.getTime() : new Date(v).getTime()
+    return Number.isFinite(t) ? t : null
+  }
+
+  // How long it has been parked. `updated_at` is when parking last wrote the
+  // row; it is an approximation, and it is the only one available without a
+  // new column. Reported, never used to decide.
+  const parkedSince = asMs(run.updated_at)
+  const parked_days =
+    parkedSince == null ? 0 : Math.max(0, Math.floor((nowMs - parkedSince) / 86_400_000))
+
+  const alreadyInBucket = run.reminder_kind === "awaiting_reassignment"
+  const lastAt = alreadyInBucket ? asMs(run.last_reminded_at) : null
+
+  if (lastAt == null) {
+    return { action: "escalated", parked_days, reason: null }
+  }
+
+  const sinceDays = (nowMs - lastAt) / 86_400_000
+  if (sinceDays < intervalDays) {
+    return {
+      action: "skipped",
+      parked_days,
+      reason: "escalated_recently",
+    }
+  }
+
+  return { action: "escalated", parked_days, reason: null }
 }
 
 /**
@@ -168,7 +255,10 @@ const processReminderStep = createStep(
         reason: "unknown_reminder_kind",
       })
     }
-    if (!input.production_run_id || !input.partner_id) {
+    // A parked run legitimately has no partner — that is the whole point of the
+    // bucket. Every other kind still requires one.
+    const isParked = input.reminder_kind === "awaiting_reassignment"
+    if (!input.production_run_id || (!input.partner_id && !isParked)) {
       return new StepResponse<EmitStepResult>({
         action: "skipped",
         event: eventName,
@@ -190,8 +280,59 @@ const processReminderStep = createStep(
       })
     }
 
-    const { action, nextCount } = decideReminderAction(run, input.reminder_kind)
     const eventService = container.resolve(Modules.EVENT_BUS) as IEventBusModuleService
+
+    // ── #1279: parked runs escalate to an admin on a cadence ─────────────────
+    // Handled before the partner buckets because none of that logic applies:
+    // there is nobody to nag, and the cap must not silence this.
+    if (isParked) {
+      const parked = decideParkedEscalation(run)
+
+      if (parked.action === "skipped") {
+        return new StepResponse<EmitStepResult>({
+          action: "skipped",
+          event: eventName,
+          reminder_count: run.reminder_count ?? 0,
+          reason: parked.reason,
+        })
+      }
+
+      await eventService.emit([
+        {
+          name: eventName,
+          data: {
+            production_run_id: input.production_run_id,
+            // Who it came FROM. A parked run has no current partner, and an
+            // admin's first question is always "who dropped it".
+            previous_partner_id: run.previous_partner_id ?? null,
+            design_id: input.design_id ?? run.design_id ?? null,
+            reminder_kind: input.reminder_kind,
+            parked_days: parked.parked_days,
+          },
+        },
+      ])
+
+      await service.updateProductionRuns({
+        id: input.production_run_id,
+        reminder_kind: input.reminder_kind,
+        reminder_status: "escalated",
+        // Doubles as "when we last told an admin" — the cadence reads it back.
+        last_reminded_at: new Date(),
+      })
+
+      return new StepResponse<EmitStepResult>({
+        action: "escalated",
+        event: eventName,
+        reminder_count: run.reminder_count ?? 0,
+        reason: null,
+      })
+    }
+
+    // Past the parked branch every kind is partner-facing, and the guard above
+    // already returned when a partner was missing. Narrow for the type system.
+    const partnerId = input.partner_id as string
+
+    const { action, nextCount } = decideReminderAction(run, input.reminder_kind)
 
     if (action === "skipped") {
       return new StepResponse<EmitStepResult>({
@@ -208,7 +349,7 @@ const processReminderStep = createStep(
           name: eventName,
           data: {
             production_run_id: input.production_run_id,
-            partner_id: input.partner_id,
+            partner_id: partnerId,
             design_id: input.design_id ?? null,
             reminder_kind: input.reminder_kind,
             reminder_count: nextCount,
@@ -255,7 +396,7 @@ const processReminderStep = createStep(
             name: "production_run.reminder_retried_same_partner",
             data: {
               production_run_id: input.production_run_id,
-              partner_id: input.partner_id,
+              partner_id: partnerId,
               design_id: input.design_id ?? null,
               reminder_kind: input.reminder_kind,
               retry_count: nextRetryCount,
@@ -271,7 +412,7 @@ const processReminderStep = createStep(
         if (reassignmentPolicy.auto_accept_on_retry && run.status === "sent_to_partner") {
           const partnerService: any = container.resolve(PARTNER_MODULE)
           const partner = await partnerService
-            .retrievePartner(input.partner_id)
+            .retrievePartner(partnerId)
             .catch(() => null)
 
           if (partner?.auto_accept_production_runs) {
@@ -279,7 +420,7 @@ const processReminderStep = createStep(
               .run({
                 input: {
                   production_run_id: input.production_run_id,
-                  partner_id: input.partner_id,
+                  partner_id: partnerId,
                 },
               })
               .then(() => {
@@ -303,7 +444,7 @@ const processReminderStep = createStep(
       await reassignProductionRunWorkflow(container).run({
         input: {
           production_run_id: input.production_run_id,
-          partner_id: input.partner_id,
+          partner_id: partnerId,
           source: "reminder_cap",
           reason: "reminder_cap_reached",
           composed_reason: `Auto-reassigned: no response after ${REMINDER_CAP} reminders`,
@@ -324,7 +465,7 @@ const processReminderStep = createStep(
         name: "production_run.reminder_escalated",
         data: {
           production_run_id: input.production_run_id,
-          partner_id: input.partner_id,
+          partner_id: partnerId,
           design_id: input.design_id ?? null,
           reminder_kind: input.reminder_kind,
           reminder_count: nextCount,


### PR DESCRIPTION
Closes the remaining half of #1279. (#1282 fixed the first rung — reminders that never reached the partner at all.)

## Both top rungs ended in silence

```
sent_to_partner --reminders--> cap --> awaiting_reassignment --> nothing
accepted        --reminders--> cap --> "escalated to admin"   --> an activity row
```

The second one is the subtle failure and it was not in the original issue. `production_run.reminder_escalated` has existed since #1093, and its only consumer in the repo is `production-run-activity-recorder.ts`, which writes a timeline row labelled *"Reminder cap reached — escalated to admin"*. Nobody reads a timeline row. **The event named an audience it never had.**

## What ships

**A parked bucket that is not a nag.** New reminder kind `awaiting_reassignment`. Unlike every other kind it has no partner — parking nulls `partner_id` and preserves `previous_partner_id` — so it escalates to an admin. The flow's read filter now includes the status, and the classifier handles it **before** the no-partner skip, which is exactly what made parked runs invisible.

**A cadence, not a cap.** `decideParkedEscalation()` is deliberately kept out of `decideReminderAction`. Reusing that function would have meant `reminder_status === "escalated" → skipped forever` — telling someone once and then going quiet, which is the original bug wearing a new hat. Weekly is the compromise: escalate-and-forget loses runs, a daily nag about the same six runs gets the channel muted. `parked_days` rides along so the message sharpens over time rather than repeating. No new columns — `reminder_kind` and `last_reminded_at` carry it.

One subtlety pinned by a test: parking sets `reminder_kind` to null but does **not** clear `last_reminded_at`, so a freshly parked run carries a timestamp from the partner nags. Reading that as ours would silence the first admin escalation for a week.

**The missing audience.** New subscriber `production-run-escalation-notifier` handles both events and posts to the admin feed. The two messages stay distinct on purpose — a parked run needs *re-dispatching*, a stalled one needs *chasing*, and telling an admin the wrong one wastes the only message they get.

**A way to actually reach prod.** New maintenance job `sync-production-run-reminders-flow`. Without it this ships **inert**: the CLI seeder refuses to touch an existing flow, so editing `FLOW_DEF` changes nothing and the live row keeps the graph it was created with. That is how `awaiting_reassignment` could have stayed out of the filter long after this looked merged. The job installs or replaces in place, preserving id and active/draft status, and the dry-run reports whether the live flow **already** reads `awaiting_reassignment` so a re-run is visibly a no-op.

## Deploy tail — this is not done at merge

1. Deploy.
2. `sync-production-run-reminders-flow` **dry-run** → expect *"does NOT currently read awaiting_reassignment"*.
3. Apply. ⚠️ Replacing discards hand edits made in the flow editor — read the dry-run first.
4. Confirm at the next 04:30 UTC run: the log line now carries `parked=N`.

There are **zero** parked runs on prod right now (all six were re-dispatched 2026-08-12), so the first live exercise will be the next run that parks. The escalation path is covered by unit tests, not by a production observation.

## Verify

```
pnpm test:unit --testPathPattern="decide-parked-escalation|production-run-escalation-notifier"   # 16 pass
pnpm test:unit --testPathPattern="production-run|reminder"                                        # 204 pass
```

tsc 79 — the main baseline. No migrations.

⚠️ `audit-ai-platforms.unit.spec.ts` fails on clean `main` too (expects 7 AI roles, finds 10). Pre-existing, verified by stashing; not from this branch.

🤖 Generated with [Claude Code](https://claude.com/claude-code)