### PR TITLE
fix(tests): repair two CI-failing integration specs (shard 6 + shard 8)

### DIFF
--- a/apps/backend/integration-tests/http/design-cost-propagation.spec.ts
+++ b/apps/backend/integration-tests/http/design-cost-propagation.spec.ts
@@ -7,6 +7,8 @@ import type { IRegionModuleService } from "@medusajs/types"
 
 jest.setTimeout(90000)
 
+const originalFetch = global.fetch
+
 setupSharedTestSuite(() => {
   describe("E2E: Consumption cost propagation → Design estimate → Draft order", () => {
     const { api, getContainer } = getSharedTestEnv()
@@ -26,6 +28,26 @@ setupSharedTestSuite(() => {
         console.log(`[COST-PROP TEST] ${label}:`, payload)
       }
     }
+
+    beforeAll(() => {
+      global.fetch = (async (input: any, init?: RequestInit) => {
+        const url = typeof input === "string" ? input : input instanceof URL ? input.href : input?.url
+        if (url && url.includes("api.frankfurter.app")) {
+          const u = new URL(url)
+          const to = (u.searchParams.get("to") || "inr").toUpperCase()
+          const from = (u.searchParams.get("from") || "eur").toUpperCase()
+          return new Response(
+            JSON.stringify({ base: from, date: "2026-08-12", rates: { [to]: 90 } }),
+            { status: 200, headers: { "content-type": "application/json" } }
+          )
+        }
+        return originalFetch(input, init)
+      }) as any
+    })
+
+    afterAll(() => {
+      global.fetch = originalFetch
+    })
 
     beforeEach(async () => {
       const container = getContainer()

--- a/apps/backend/integration-tests/http/retail-order-tracking-webhook.spec.ts
+++ b/apps/backend/integration-tests/http/retail-order-tracking-webhook.spec.ts
@@ -139,7 +139,7 @@ setupSharedTestSuite(() => {
             first_name: "Elena", last_name: "Doe", address_1: "9 Buyer Rd",
             city: "Dallas", province: "TX", postal_code: "75201", country_code: "us", phone: "8887776665",
           },
-          items: [{ title: "Tangaliya Stole", quantity: 1, unit_price: 1500, metadata: { hsn: "621410" } }],
+          items: [{ title: "Tangaliya Stole", quantity: 1, unit_price: 1500, metadata: { hsn: "62141010" } }],
         },
         adminHeaders
       )


### PR DESCRIPTION
## Root causes

### Shard 8 — `retail-order-tracking-webhook.spec.ts` (real test regression)
The spec used a 6-digit HSN code (`621410`) on an international order (`country_code: "us"`). Commit `82e6be16` (#1206 "international HSN sourcing") added 8-digit HSN validation for Shiprocket international shipments; the spec was never updated.

```
POST /partners/orders/:id/shiprocket-label → 400
"Shiprocket requires an 8-digit HSN code … Tangaliya Stole (621410)"
```

**Fix:** `621410` → `62141010` (8-digit ITC-HS). One-line change.

### Shard 6 — `design-cost-propagation.spec.ts` (CI-only, no egress)
Only the draft-order test hits `convertEstimateCurrencyStep` → `fetchExchangeRate("eur"→"inr")` against `api.frankfurter.app` — a live external API. Passes locally (internet available) but fails in CI (no egress) with a 500.

**Fix:** Stub `global.fetch` to intercept `api.frankfurter.app` URLs and return a deterministic rate (90), restored in `afterAll`. No production code changed.

## Verification
```
TEST_TYPE=integration:http jest --config=./integration-tests/jest-shared.config.js   integration-tests/http/design-cost-propagation.spec.ts   integration-tests/http/retail-order-tracking-webhook.spec.ts

Test Suites: 2 passed, 2 total
Tests:       6 passed, 6 total
Time:        28.9s
```

## CI runs fixed
- Run 31593101700 — shard 8 failed (same spec, same 400)
- Run 31604467953 — shard 8 failed again + shard 6 failed (500)