### PR TITLE
feat(shipping): cancel a carrier waybill end-to-end + Blue Dart provider (#1285)

### DIFF
--- a/apps/backend/.env.template
+++ b/apps/backend/.env.template
@@ -56,6 +56,40 @@ SHIPROCKET_EMAIL=shipping@example.com
 SHIPROCKET_API_PASSWORD=your_shiprocket_password
 # SHIPROCKET_PICKUP_LOCATION=Primary
 
+# Blue Dart carrier. TWO layers of credentials, and both are required:
+#   1. the developer.dhl.com API gateway pair, which mints a 24h JWT
+#   2. the Blue Dart shipping account, which travels in the request BODY
+# A valid JWT tells you nothing about whether the shipping account is right.
+# Unlike Delhivery this is NOT domestic-only — product "H" (IPC) is a real
+# export product on the same account.
+BLUE_DART_CLIENT_ID=your_gateway_client_id
+BLUE_DART_CLIENT_SECRET=your_gateway_client_secret
+BLUE_DART_LOGIN_ID=your_shipping_login_id
+BLUE_DART_LICENCE_KEY=your_shipping_licence_key
+# NOT the LoginID, and not "DHM000001" — a short numeric code like 000001.
+BLUE_DART_CUSTOMER_CODE=000001
+# BLUE_DART_API_TYPE=S
+# BLUE_DART_VERSION=1.3
+# Origin area code. Product availability is per-area: "A" is NOT available
+# outbound from DHM (Dharamshala) while "D" is.
+# BLUE_DART_ORIGIN_AREA=DHM
+# ⚠️ Blue Dart's sandbox issues SEPARATE shipping credentials — production ones
+# return RequestAuthenticationFailed against it.
+# BLUE_DART_SANDBOX=false
+#
+# Blue Dart's own Shipment Tracking (TnT) endpoint works with the SHIPPING
+# licence key above — there is no separate tracking credential.
+# ⚠️ It must be called WITHOUT a `verno` parameter: TnT folds verno into its
+# licence check, so any value returns "License Mismatch" and blames the
+# credential for what is a parameter fault. See bluedart/client.ts.
+# Optional override, only if Blue Dart ever splits the licences:
+# BLUE_DART_TRACKING_LICENCE_KEY=
+#
+# DHL's Unified Shipment Tracking API also resolves Blue Dart AWBs
+# (service: "bluedart") and keeps history for CANCELLED waybills, which TnT
+# drops. Defaults to BLUE_DART_CLIENT_ID, already a valid DHL-API-Key.
+# DHL_UNIFIED_TRACKING_API_KEY=your_dhl_api_key
+
 # Workflow / step execution timeouts (#742). Both are millisecond windows that
 # were previously hardcoded at 10s — too short for real LLM/external-API work.
 # MASTRA_STEP_TIMEOUT_MS  — per-step executor timeout (default 60000).

--- a/apps/backend/src/admin/hooks/api/design-orders.ts
+++ b/apps/backend/src/admin/hooks/api/design-orders.ts
@@ -90,6 +90,8 @@ export type DesignOrderDetail = {
     created_at: string;
     canceled_at: string | null;
     tracking: {
+      /** The fulfillment carrying this AWB — the address for cancelling it. */
+      fulfillment_id: string | null;
       carrier: string | null;
       awb: string | null;
       tracking_url: string | null;
@@ -501,6 +503,58 @@ export const useAttachShiprocketAwb = (
       sdk.client.fetch<AttachShiprocketAwbResponse>(
         `/admin/orders/${orderId}/shiprocket-attach-awb`,
         { method: "POST", body: { awb } }
+      ),
+    onSuccess: (...args) => {
+      queryClient.invalidateQueries({
+        queryKey: designOrdersQueryKeys.lists(),
+      });
+      options?.onSuccess?.(...args);
+    },
+    ...options,
+  });
+};
+
+export type CancelShipmentResponse = {
+  cancelled_shipment: {
+    fulfillment_id: string;
+    carrier?: string;
+    awb?: string;
+    cancelled_at: string;
+    /** False when the customer email could not be sent (see the seed script). */
+    customer_notified: boolean;
+  };
+};
+
+export type CancelShipmentVariables = {
+  fulfillmentId: string;
+  reason?: string;
+  /** Cancel even though the fulfillment is already marked shipped. */
+  force?: boolean;
+  /** Defaults to true on the backend. */
+  notify_customer?: boolean;
+};
+
+/**
+ * Void the carrier waybill on a fulfillment — the "the courier fell through /
+ * we're changing partner" path. Cancels at the carrier FIRST, then clears the
+ * refs, so a refusal leaves the live waybill attached rather than orphaned.
+ *
+ * Admin-only by design; there is no partner equivalent.
+ */
+export const useCancelShipment = (
+  orderId: string,
+  options?: UseMutationOptions<
+    CancelShipmentResponse,
+    FetchError,
+    CancelShipmentVariables
+  >
+) => {
+  const queryClient = useQueryClient();
+  return useMutation({
+    mutationFn: async ({ fulfillmentId, ...body }: CancelShipmentVariables) =>
+      sdk.client.fetch<CancelShipmentResponse>(
+        `/admin/orders/${orderId}/fulfillments/${fulfillmentId}/cancel-shipment`,
+        { method: "POST", body }
       ),
     onSuccess: (...args) => {
       queryClient.invalidateQueries({

--- a/apps/backend/src/admin/lib/shipment-carriers.ts
+++ b/apps/backend/src/admin/lib/shipment-carriers.ts
@@ -19,6 +19,11 @@
 export const SHIPMENT_CARRIERS = [
   { value: "shiprocket", label: "Shiprocket" },
   { value: "delhivery", label: "Delhivery", domesticOnly: true },
+  // Blue Dart is NOT domestic-only: product "H" (IPC) is a real export product
+  // on the same account, so it is offered for foreign destinations too. It is
+  // also the fallback for origins where the other carriers' pickups don't
+  // materialise, which is why it was integrated at all.
+  { value: "bluedart", label: "Blue Dart" },
 ] as const
 
 export type ShipmentCarrier = (typeof SHIPMENT_CARRIERS)[number]["value"]

--- a/apps/backend/src/admin/routes/design-orders/[id]/page.tsx
+++ b/apps/backend/src/admin/routes/design-orders/[id]/page.tsx
@@ -34,6 +34,7 @@ import {
   useProduceDesignOrder,
   useGenerateShiprocketLabel,
   useAttachShiprocketAwb,
+  useCancelShipment,
   useShiprocketRates,
 } from "../../../hooks/api/design-orders"
 import { usePartners } from "../../../hooks/api/partners"
@@ -288,6 +289,8 @@ const OrderSection = ({
     useGenerateShiprocketLabel(order?.id ?? "")
   const { mutateAsync: attachAwb, isPending: isAttaching } =
     useAttachShiprocketAwb(order?.id ?? "")
+  const { mutateAsync: cancelShipment, isPending: isCancellingShipment } =
+    useCancelShipment(order?.id ?? "")
   const [labelUrl, setLabelUrl] = useState<string | null>(null)
   const [attachOpen, setAttachOpen] = useState(false)
   const [awbValue, setAwbValue] = useState("")
@@ -713,6 +716,45 @@ const OrderSection = ({
                   <HandTruck className="w-4 h-4 mr-1" />
                   Track shipment
                 </a>
+              </Button>
+            )}
+            {order.tracking.fulfillment_id && (
+              <Button
+                variant="transparent"
+                size="small"
+                isLoading={isCancellingShipment}
+                onClick={async () => {
+                  const ok = await prompt({
+                    title: "Cancel this waybill?",
+                    description: `AWB ${order.tracking.awb} will be cancelled with ${
+                      order.tracking.carrier || "the carrier"
+                    }. This cannot be undone, and the customer is emailed that their courier has changed. The order can then be re-labelled with another carrier.`,
+                    confirmText: "Cancel waybill",
+                    cancelText: "Keep it",
+                  })
+                  if (!ok) return
+                  try {
+                    const res = await cancelShipment({
+                      fulfillmentId: order.tracking.fulfillment_id!,
+                    })
+                    toast.success(
+                      `AWB ${res.cancelled_shipment.awb} cancelled${
+                        res.cancelled_shipment.customer_notified
+                          ? " — customer emailed"
+                          : ""
+                      }`
+                    )
+                    if (!res.cancelled_shipment.customer_notified) {
+                      toast.warning(
+                        "The customer was NOT emailed about the courier change — send them a note by hand."
+                      )
+                    }
+                  } catch (e: any) {
+                    toast.error(e?.message || "Could not cancel the waybill")
+                  }
+                }}
+              >
+                Cancel waybill
               </Button>
             )}
           </div>

--- a/apps/backend/src/admin/widgets/order-carrier-shipment.tsx
+++ b/apps/backend/src/admin/widgets/order-carrier-shipment.tsx
@@ -24,6 +24,7 @@ import {
 } from "../lib/shipment-carriers"
 import {
   useAttachShiprocketAwb,
+  useCancelShipment,
   useGenerateShiprocketLabel,
   useShiprocketRates,
 } from "../hooks/api/design-orders"
@@ -70,7 +71,32 @@ const FIELDS = [
   "fulfillments.id",
   "fulfillments.data",
   "fulfillments.labels.tracking_number",
+  // The booked pickup lives here. Without it the widget could only know about a
+  // pickup it had booked itself, in this tab, since the last refresh.
+  "fulfillments.metadata",
 ].join(",")
+
+/** A pickup already booked with the carrier, as persisted by the pickup route. */
+type BookedPickup = {
+  pickup_id?: string
+  pickup_date: string
+  pickup_time: string
+  incoming_center_name?: string
+}
+
+function bookedPickupOf(fulfillment: any): BookedPickup | null {
+  const m = fulfillment?.metadata
+  // `pickup_date` is the load-bearing field: Blue Dart hands back a
+  // `TokenNumber` and some carriers hand back nothing identifying at all, so a
+  // booking with no id is still a booking — a courier is still coming.
+  if (!m?.pickup_date) return null
+  return {
+    pickup_id: m.pickup_id,
+    pickup_date: m.pickup_date,
+    pickup_time: m.pickup_time,
+    incoming_center_name: m.incoming_center_name,
+  }
+}
 
 /** The AWB already on the order, if any — the state where actions are done. */
 /** Tomorrow, as YYYY-MM-DD — the earliest slot a packer can realistically make. */
@@ -87,13 +113,30 @@ function existingAwbOf(fulfillments: Fulfillment[]): {
 } {
   for (const f of fulfillments) {
     const d = f.data || {}
+    const live = d.waybill || d.tracking_number || undefined
+    // A cancelled shipment clears the carrier refs from `data` but the label row
+    // is a separate table. Trusting the label alone would keep showing a voided
+    // AWB and lock the widget in its "already labelled" branch — exactly the
+    // re-label this feature exists to allow. Once anything has been cancelled
+    // here, `data` is the only authority.
+    const cancelledBefore = Array.isArray(d.cancelled_shipments)
+      ? d.cancelled_shipments.length > 0
+      : false
     const awb =
-      d.waybill || d.tracking_number || f.labels?.[0]?.tracking_number || undefined
+      live || (cancelledBefore ? undefined : f.labels?.[0]?.tracking_number)
     if (awb) {
       return { awb: String(awb), carrier: d.carrier || undefined, fulfillmentId: f.id }
     }
   }
   return {}
+}
+
+/** "2026-08-14" + "14:00" → "14 Aug, 14:00". Falls back to the raw values. */
+function formatPickupWhen(date: string, time?: string): string {
+  const d = new Date(`${date}T00:00:00`)
+  if (Number.isNaN(d.getTime())) return [date, time].filter(Boolean).join(" ")
+  const day = d.toLocaleDateString("en-IN", { day: "numeric", month: "short" })
+  return time ? `${day}, ${time}` : day
 }
 
 /** Empty string → undefined, else a positive number (a blank is not 0 grams). */
@@ -144,9 +187,15 @@ const OrderCarrierShipmentWidget = ({
   const [pickupTime, setPickupTime] = useState("14:00")
   const [packageCount, setPackageCount] = useState("1")
   const [schedulingPickup, setSchedulingPickup] = useState(false)
-  const [pickup, setPickup] = useState<
-    { pickup_id?: string; pickup_date: string; pickup_time: string } | null
-  >(null)
+
+  // Server state, not local state. This used to be a `useState` set only by our
+  // own booking call, so a refresh — or an admin opening the order in a second
+  // tab, or a pickup a partner booked — showed an empty form for a collection
+  // that was already scheduled, inviting a duplicate booking.
+  const pickupFulfillment = fulfillments.find(
+    (f: any) => f.id === existing.fulfillmentId
+  )
+  const pickup = bookedPickupOf(pickupFulfillment)
 
   const schedulePickup = async (fulfillmentId: string) => {
     if (!pickupDate || !pickupTime) {
@@ -155,7 +204,10 @@ const OrderCarrierShipmentWidget = ({
     }
     setSchedulingPickup(true)
     try {
-      const res = await sdk.client.fetch<{ pickup_id?: string }>(
+      const res = await sdk.client.fetch<{
+        pickup_id?: string
+        pickup_persisted?: boolean
+      }>(
         `/admin/orders/${order.id}/fulfillments/${fulfillmentId}/pickup`,
         {
           method: "POST",
@@ -166,12 +218,21 @@ const OrderCarrierShipmentWidget = ({
           },
         }
       )
-      setPickup({
-        pickup_id: res?.pickup_id,
-        pickup_date: pickupDate,
-        pickup_time: pickupTime,
-      })
-      toast.success("Pickup scheduled")
+      // Refetch rather than set local state: the route is the thing that knows
+      // whether the booking was actually persisted.
+      await refetch()
+      if (res?.pickup_persisted === false) {
+        // Booked at the carrier but not saved. Saying "scheduled" here would be
+        // a lie by omission — the collection is live and its cancellation token
+        // is now only in the server log.
+        toast.warning(
+          `Pickup booked with the carrier${
+            res?.pickup_id ? ` (#${res.pickup_id})` : ""
+          }, but it could not be saved to this order. Note the reference — cancelling it later may need a phone call.`
+        )
+      } else {
+        toast.success("Pickup scheduled")
+      }
     } catch (e: any) {
       toast.error(e?.message || "Could not schedule the pickup")
     } finally {
@@ -210,6 +271,52 @@ const OrderCarrierShipmentWidget = ({
 
   const [labelUrl, setLabelUrl] = useState<string | null>(null)
   const [awbInput, setAwbInput] = useState("")
+
+  // Cancelling a waybill. Two-step on purpose: it costs money at the carrier and
+  // cannot be undone, so the reason field doubles as the confirmation gesture.
+  const [cancelOpen, setCancelOpen] = useState(false)
+  const [cancelReason, setCancelReason] = useState("")
+  const { mutateAsync: cancelShipment, isPending: isCancelling } =
+    useCancelShipment(order.id)
+
+  const handleCancel = async (fulfillmentId: string) => {
+    await cancelShipment(
+      { fulfillmentId, reason: cancelReason.trim() || undefined },
+      {
+        onSuccess: (res) => {
+          const c = res.cancelled_shipment
+          toast.success(
+            `AWB ${c.awb} cancelled${
+              c.customer_notified ? " — customer emailed" : ""
+            }`
+          )
+          if (!c.customer_notified) {
+            // Never silent: the whole point of the email is that the customer
+            // finds out from us rather than from a dead tracking link.
+            toast.warning(
+              "The customer was NOT emailed about the courier change — send them a note by hand."
+            )
+          }
+          setCancelOpen(false)
+          setCancelReason("")
+          setLabelUrl(null)
+          // The pickup is NOT cancelled by cancelling the waybill — they are
+          // separate bookings at the carrier, exactly as creating them is. A
+          // voided AWB with a live collection means a courier arrives for a
+          // parcel that no longer has a manifest.
+          if (pickup) {
+            toast.warning(
+              `The ${pickup.pickup_date} pickup is still booked${
+                pickup.pickup_id ? ` (#${pickup.pickup_id})` : ""
+              } — cancel it with the carrier, or a courier will still arrive.`
+            )
+          }
+          refetch()
+        },
+        onError: (e) => toast.error(e.message),
+      }
+    )
+  }
 
   const { mutateAsync: generateLabel, isPending: isGenerating } =
     useGenerateShiprocketLabel(order.id)
@@ -283,13 +390,35 @@ const OrderCarrierShipmentWidget = ({
 
         {existing.fulfillmentId ? (
           <div className="flex flex-col gap-y-3 px-6 py-4">
-            <Text size="small" className="text-ui-fg-subtle">
-              {pickup
-                ? `Pickup booked for ${pickup.pickup_date} at ${pickup.pickup_time}${
-                    pickup.pickup_id ? ` (#${pickup.pickup_id})` : ""
-                  }.`
-                : "The label exists, but the carrier won't collect until a pickup is booked."}
-            </Text>
+            {pickup ? (
+              <div className="flex flex-col gap-y-1">
+                <div className="flex items-center gap-x-2">
+                  <Badge size="2xsmall" color="green">
+                    Pickup booked
+                  </Badge>
+                  <Text size="small">
+                    {formatPickupWhen(pickup.pickup_date, pickup.pickup_time)}
+                  </Text>
+                </div>
+                <Text size="small" className="text-ui-fg-subtle">
+                  {pickup.pickup_id
+                    ? // Shown, not hidden behind a tooltip: for Blue Dart this
+                      // token is the only handle that can call the collection
+                      // off, and an operator on the phone to the carrier needs
+                      // to be able to read it out.
+                      `Reference #${pickup.pickup_id}`
+                    : "No reference returned by the carrier — cancelling may need a phone call."}
+                  {pickup.incoming_center_name
+                    ? ` · ${pickup.incoming_center_name}`
+                    : ""}
+                </Text>
+              </div>
+            ) : (
+              <Text size="small" className="text-ui-fg-subtle">
+                The label exists, but the carrier won't collect until a pickup is
+                booked.
+              </Text>
+            )}
             {!pickup ? (
               <>
                 <div className="grid grid-cols-3 gap-3">
@@ -344,6 +473,64 @@ const OrderCarrierShipmentWidget = ({
                 </div>
               </>
             ) : null}
+
+            {/* Something went wrong with this booking — void it and start over. */}
+            <div className="flex flex-col gap-y-2 border-t pt-4">
+              {!cancelOpen ? (
+                <div>
+                  <Button
+                    variant="danger"
+                    size="small"
+                    onClick={() => setCancelOpen(true)}
+                  >
+                    Cancel waybill
+                  </Button>
+                  <Text size="xsmall" className="text-ui-fg-subtle mt-1">
+                    For a pickup that never happened, a partner change, or an
+                    address caught late. Frees the order to be re-labelled with
+                    another carrier.
+                  </Text>
+                </div>
+              ) : (
+                <>
+                  <Label size="small" htmlFor="cancel_reason">
+                    Why is this being cancelled?
+                  </Label>
+                  <Input
+                    id="cancel_reason"
+                    placeholder="e.g. pickup no-show three days running"
+                    value={cancelReason}
+                    onChange={(e) => setCancelReason(e.target.value)}
+                  />
+                  <Text size="xsmall" className="text-ui-fg-subtle">
+                    Kept on the fulfillment for reconciling the carrier invoice.
+                    The customer is emailed that we've moved them to another
+                    courier — they are not shown this reason.
+                  </Text>
+                  <div className="flex items-center gap-x-2">
+                    <Button
+                      variant="danger"
+                      size="small"
+                      isLoading={isCancelling}
+                      onClick={() => handleCancel(existing.fulfillmentId!)}
+                    >
+                      Cancel AWB {existing.awb}
+                    </Button>
+                    <Button
+                      variant="secondary"
+                      size="small"
+                      disabled={isCancelling}
+                      onClick={() => {
+                        setCancelOpen(false)
+                        setCancelReason("")
+                      }}
+                    >
+                      Keep it
+                    </Button>
+                  </div>
+                </>
+              )}
+            </div>
           </div>
         ) : null}
       </Container>
@@ -477,8 +664,9 @@ const OrderCarrierShipmentWidget = ({
           </div>
         ) : (
           <Text size="xsmall" className="text-ui-fg-subtle">
-            Delhivery assigns the courier itself — there is no courier picker,
-            and it serves domestic destinations only.
+            {carrier === "bluedart"
+              ? "Blue Dart carries the parcel itself — there is no courier picker. It serves international destinations too, on its IPC export product."
+              : "Delhivery assigns the courier itself — there is no courier picker, and it serves domestic destinations only."}
           </Text>
         )}
 

--- a/apps/backend/src/api/admin/designs/orders/[lineItemId]/route.ts
+++ b/apps/backend/src/api/admin/designs/orders/[lineItemId]/route.ts
@@ -102,6 +102,10 @@ export async function GET(
       activeFulfillment.find((f: any) => f.data?.carrier) ?? activeFulfillment[0]
     const tracking = tracked
       ? {
+          // The fulfillment this AWB is stamped on. Needed to cancel the
+          // waybill from here — cancel is addressed per-fulfillment, and this
+          // page otherwise never learns which one carries the shipment.
+          fulfillment_id: tracked.id ?? null,
           carrier: tracked.data?.carrier ?? null,
           awb: tracked.data?.waybill ?? tracked.data?.tracking_number ?? null,
           tracking_url: tracked.data?.tracking_url ?? null,

--- a/apps/backend/src/api/admin/orders/[id]/fulfillments/[fulfillmentId]/cancel-shipment/route.ts
+++ b/apps/backend/src/api/admin/orders/[id]/fulfillments/[fulfillmentId]/cancel-shipment/route.ts
@@ -1,0 +1,51 @@
+import { MedusaRequest, MedusaResponse } from "@medusajs/framework/http"
+import { Modules } from "@medusajs/framework/utils"
+import { cancelShipmentForFulfillment } from "../../../../../../../workflows/orders/cancel-shipment"
+
+/** The logged-in admin's email, recorded on the cancellation's audit entry. */
+const resolveActorEmail = async (
+  req: MedusaRequest
+): Promise<string | undefined> => {
+  try {
+    const actorId = (req as any).auth_context?.actor_id
+    if (!actorId) return undefined
+    const userService: any = req.scope.resolve(Modules.USER)
+    const user = await userService.retrieveUser(actorId)
+    return user?.email
+  } catch {
+    return undefined
+  }
+}
+
+/**
+ * POST /admin/orders/:id/fulfillments/:fulfillmentId/cancel-shipment
+ *
+ * Void a carrier waybill when a shipment can't go out as booked — a pickup that
+ * never happens, a partner change, an address caught late. Cancels at the
+ * carrier, clears the carrier refs off the fulfillment so a fresh label can be
+ * generated (possibly on a different carrier), and emails the customer.
+ *
+ * ADMIN ONLY, deliberately. A cancel costs real money at the carrier and the
+ * partner-change decision that usually motivates it is an admin's to make; the
+ * partner portal shows the AWB and points at support instead.
+ */
+export const POST = async (req: MedusaRequest, res: MedusaResponse) => {
+  const orderId = req.params.id
+  const fulfillmentId = req.params.fulfillmentId
+  const body = (req.validatedBody || req.body || {}) as {
+    reason?: string
+    force?: boolean
+    notify_customer?: boolean
+  }
+
+  const result = await cancelShipmentForFulfillment(req.scope, {
+    orderId,
+    fulfillmentId,
+    reason: body.reason,
+    force: body.force === true,
+    notifyCustomer: body.notify_customer !== false,
+    actingEmail: await resolveActorEmail(req),
+  })
+
+  res.status(200).json({ cancelled_shipment: result })
+}

--- a/apps/backend/src/api/admin/orders/[id]/fulfillments/[fulfillmentId]/pickup/route.ts
+++ b/apps/backend/src/api/admin/orders/[id]/fulfillments/[fulfillmentId]/pickup/route.ts
@@ -16,6 +16,7 @@
 import { MedusaRequest, MedusaResponse } from "@medusajs/framework/http"
 import { ContainerRegistrationKeys, MedusaError } from "@medusajs/framework/utils"
 
+import { persistPickupBookingSafely } from "../../../../../../../lib/persist-pickup-booking"
 import {
   isSupportedCarrier,
   resolveShippingProvider,
@@ -27,7 +28,12 @@ export const POST = async (req: MedusaRequest, res: MedusaResponse) => {
 
   const { data: orders } = await query.graph({
     entity: "orders",
-    fields: ["id", "fulfillments.*", "fulfillments.labels.*"],
+    fields: [
+      "id",
+      "fulfillments.*",
+      "fulfillments.labels.*",
+      "fulfillments.metadata",
+    ],
     filters: { id: req.params.id },
   })
 
@@ -104,11 +110,37 @@ export const POST = async (req: MedusaRequest, res: MedusaResponse) => {
   })
 
   const raw = (result.raw as Record<string, any>) || {}
+  // `result.token` is the normalized fallback: Blue Dart returns its handle as
+  // `TokenNumber`, not `pickup_id`, and that token is the only thing that can
+  // call the collection off later. Dropping it means a pickup can be booked
+  // and then only cancelled by phone.
+  const pickupId = raw.pickup_id || result.token
+
+  // Best-effort: the carrier has already committed to the collection, so a
+  // failed write must not surface as "pickup failed" and send the operator to
+  // book a second one.
+  const { persisted, record } = await persistPickupBookingSafely(
+    req.scope,
+    fulfillment.id,
+    {
+      pickup_id: pickupId,
+      pickup_date: pickupDate,
+      pickup_time: pickupTime,
+      incoming_center_name: raw.incoming_center_name,
+      carrier,
+    },
+    fulfillment.metadata
+  )
+
   res.json({
-    pickup_id: raw.pickup_id,
+    pickup_id: pickupId,
     pickup_date: pickupDate,
     pickup_time: pickupTime,
     incoming_center_name: raw.incoming_center_name,
+    // `false` means the booking is live at the carrier but this order no longer
+    // knows its token — the UI must say so rather than render a clean success.
+    pickup_persisted: persisted,
+    booked_at: record.booked_at,
     ...raw,
   })
 }

--- a/apps/backend/src/api/partners/orders/[id]/fulfillments/[fulfillmentId]/pickup/route.ts
+++ b/apps/backend/src/api/partners/orders/[id]/fulfillments/[fulfillmentId]/pickup/route.ts
@@ -1,6 +1,7 @@
 import { AuthenticatedMedusaRequest, MedusaResponse } from "@medusajs/framework/http"
 import { ContainerRegistrationKeys, MedusaError } from "@medusajs/framework/utils"
 import { validatePartnerOrderOwnership } from "../../../../../helpers"
+import { persistPickupBookingSafely } from "../../../../../../../lib/persist-pickup-booking"
 import {
   isSupportedCarrier,
   resolveShippingProvider,
@@ -20,6 +21,7 @@ export const POST = async (
       "id",
       "fulfillments.*",
       "fulfillments.labels.*",
+      "fulfillments.metadata",
     ],
     filters: { id: req.params.id },
   })
@@ -98,11 +100,32 @@ export const POST = async (
   })
 
   const raw = (result.raw as Record<string, any>) || {}
+  // `|| result.token` is not cosmetic: Blue Dart returns its handle as
+  // `TokenNumber`, so without the fallback this route answered
+  // `pickup_id: undefined` for every Blue Dart collection — and the partner UI
+  // keys its "pickup booked" block on exactly that field.
+  const pickupId = raw.pickup_id || result.token
+
+  const { persisted, record } = await persistPickupBookingSafely(
+    req.scope,
+    fulfillment.id,
+    {
+      pickup_id: pickupId,
+      pickup_date: pickupDate,
+      pickup_time: pickupTime,
+      incoming_center_name: raw.incoming_center_name,
+      carrier,
+    },
+    fulfillment.metadata
+  )
+
   res.json({
-    pickup_id: raw.pickup_id,
+    pickup_id: pickupId,
     pickup_date: pickupDate,
     pickup_time: pickupTime,
     incoming_center_name: raw.incoming_center_name,
+    pickup_persisted: persisted,
+    booked_at: record.booked_at,
     ...raw,
   })
 }

--- a/apps/backend/src/lib/__tests__/persist-pickup-booking.unit.spec.ts
+++ b/apps/backend/src/lib/__tests__/persist-pickup-booking.unit.spec.ts
@@ -1,0 +1,108 @@
+import {
+  persistPickupBooking,
+  persistPickupBookingSafely,
+} from "../persist-pickup-booking"
+
+const BOOKING = {
+  pickup_id: "TOKEN123",
+  pickup_date: "2026-08-14",
+  pickup_time: "14:00",
+  carrier: "bluedart",
+}
+
+function buildScope(updateImpl?: () => Promise<any>) {
+  const calls: any[] = []
+  const logs: string[] = []
+  const scope: any = {
+    resolve: (key: string) => {
+      if (key === "logger") return { error: (m: string) => logs.push(m) }
+      return {
+        updateFulfillment: async (id: string, payload: any) => {
+          calls.push({ id, payload })
+          if (updateImpl) return updateImpl()
+          return {}
+        },
+      }
+    },
+  }
+  return { scope, calls, logs }
+}
+
+describe("persistPickupBooking", () => {
+  it("writes the booking onto fulfillment metadata", async () => {
+    const { scope, calls } = buildScope()
+    await persistPickupBooking(scope, "ful_1", BOOKING)
+
+    expect(calls[0].id).toBe("ful_1")
+    expect(calls[0].payload.metadata).toMatchObject({
+      pickup_id: "TOKEN123",
+      pickup_date: "2026-08-14",
+      pickup_time: "14:00",
+      carrier: "bluedart",
+    })
+    expect(calls[0].payload.metadata.booked_at).toEqual(expect.any(String))
+  })
+
+  it("preserves unrelated metadata already on the fulfillment", async () => {
+    const { scope, calls } = buildScope()
+    await persistPickupBooking(scope, "ful_1", BOOKING, {
+      partner_note: "handle with care",
+    })
+    // Blowing away sibling keys here would silently destroy data owned by
+    // completely unrelated features.
+    expect(calls[0].payload.metadata.partner_note).toBe("handle with care")
+  })
+
+  it("appends to the booking history rather than overwriting it", async () => {
+    const { scope, calls } = buildScope()
+    await persistPickupBooking(scope, "ful_1", BOOKING, {
+      pickup_bookings: [
+        {
+          pickup_id: "OLD",
+          pickup_date: "2026-08-10",
+          pickup_time: "11:00",
+          booked_at: "2026-08-10T05:00:00.000Z",
+        },
+      ],
+    })
+
+    const history = calls[0].payload.metadata.pickup_bookings
+    // A rebooked pickup must not erase the token of the previous collection —
+    // that one may still be live at the carrier.
+    expect(history).toHaveLength(2)
+    expect(history[0].pickup_id).toBe("OLD")
+    expect(history[1].pickup_id).toBe("TOKEN123")
+  })
+})
+
+describe("persistPickupBookingSafely", () => {
+  it("reports persisted:false instead of throwing when the write fails", async () => {
+    const { scope, logs } = buildScope(async () => {
+      throw new Error("db down")
+    })
+
+    // The carrier has ALREADY committed to the collection. Throwing here would
+    // surface as "pickup failed" and send the operator to book a second one.
+    const { persisted, record } = await persistPickupBookingSafely(
+      scope,
+      "ful_1",
+      BOOKING
+    )
+
+    expect(persisted).toBe(false)
+    expect(record.pickup_id).toBe("TOKEN123")
+    // The token is the only way to call the collection off, so it must survive
+    // somewhere an operator can find it.
+    expect(logs.join(" ")).toContain("TOKEN123")
+  })
+
+  it("reports persisted:true on success", async () => {
+    const { scope } = buildScope()
+    const { persisted } = await persistPickupBookingSafely(
+      scope,
+      "ful_1",
+      BOOKING
+    )
+    expect(persisted).toBe(true)
+  })
+})

--- a/apps/backend/src/lib/persist-pickup-booking.ts
+++ b/apps/backend/src/lib/persist-pickup-booking.ts
@@ -1,0 +1,102 @@
+/**
+ * Persist a booked carrier pickup onto the fulfillment.
+ *
+ * Both pickup routes (admin and partner) used to book the collection with the
+ * carrier and then return the result to the browser and nothing else. Three
+ * things broke as a result, and all three look like separate bugs until you find
+ * this one:
+ *
+ *  1. The partner UI gates its "pickup booked" block on
+ *     `fulfillment.metadata.pickup_id`, which nothing ever wrote — so the
+ *     booking form never collapsed and a partner who had already booked a pickup
+ *     saw an empty form inviting them to book a second one.
+ *  2. The admin widget held the booking in React state, so a refresh erased it.
+ *  3. **The cancellation token was thrown away.** Blue Dart returns its handle as
+ *     `TokenNumber` and it is the only thing that can call a collection off; once
+ *     the response left the browser tab, the pickup could only be cancelled by
+ *     phone.
+ *
+ * Metadata rather than `fulfillment.data`: `data` is the carrier's own opaque
+ * blob (and is cleared wholesale by cancel-shipment, which must NOT erase the
+ * record of a collection the carrier is still coming for), while `metadata` is
+ * the queryable, ours-to-own field both UIs already read.
+ */
+import { ContainerRegistrationKeys, Modules } from "@medusajs/framework/utils"
+import type { MedusaContainer } from "@medusajs/framework/types"
+
+export type PickupBookingRecord = {
+  pickup_id?: string
+  pickup_date: string
+  pickup_time: string
+  incoming_center_name?: string
+  carrier?: string
+  booked_at: string
+}
+
+export async function persistPickupBooking(
+  scope: MedusaContainer,
+  fulfillmentId: string,
+  booking: Omit<PickupBookingRecord, "booked_at">,
+  existingMetadata?: Record<string, any> | null
+): Promise<PickupBookingRecord> {
+  const record: PickupBookingRecord = {
+    ...booking,
+    booked_at: new Date().toISOString(),
+  }
+
+  const fulfillmentModule = scope.resolve(Modules.FULFILLMENT)
+
+  await fulfillmentModule.updateFulfillment(fulfillmentId, {
+    metadata: {
+      ...(existingMetadata || {}),
+      ...record,
+      // Keep every booking, not just the latest. A rebooked pickup (carrier
+      // no-show, date moved) otherwise silently overwrites the token of a
+      // collection that may still be live, which is the same class of orphan
+      // cancel-shipment exists to prevent.
+      pickup_bookings: [
+        ...((existingMetadata?.pickup_bookings as PickupBookingRecord[]) || []),
+        record,
+      ],
+    },
+  })
+
+  return record
+}
+
+/**
+ * Best-effort variant. The pickup is ALREADY booked with the carrier by the time
+ * this runs, so a write failure must not be reported to the operator as "pickup
+ * failed" — that would send them to book a second collection for the same
+ * parcel. Same reasoning as the courier-changed email in cancel-shipment.
+ */
+export async function persistPickupBookingSafely(
+  scope: MedusaContainer,
+  fulfillmentId: string,
+  booking: Omit<PickupBookingRecord, "booked_at">,
+  existingMetadata?: Record<string, any> | null
+): Promise<{ persisted: boolean; record: PickupBookingRecord }> {
+  const record: PickupBookingRecord = {
+    ...booking,
+    booked_at: new Date().toISOString(),
+  }
+  try {
+    const saved = await persistPickupBooking(
+      scope,
+      fulfillmentId,
+      booking,
+      existingMetadata
+    )
+    return { persisted: true, record: saved }
+  } catch (e) {
+    const logger = scope.resolve(ContainerRegistrationKeys.LOGGER)
+    logger.error(
+      `Pickup ${booking.pickup_id ?? "(no id)"} was booked with ${
+        booking.carrier ?? "the carrier"
+      } for fulfillment ${fulfillmentId} but could NOT be saved: ${
+        (e as Error)?.message
+      }. The collection is live and its cancellation token is now only in this log line.`
+    )
+    return { persisted: false, record }
+  }
+}

--- a/apps/backend/src/modules/shipping-providers/__tests__/dhl-unified-tracking.unit.spec.ts
+++ b/apps/backend/src/modules/shipping-providers/__tests__/dhl-unified-tracking.unit.spec.ts
@@ -1,0 +1,158 @@
+import {
+  DhlUnifiedTrackingClient,
+  classifyDhlStatus,
+  normalizeDhlUnifiedTracking,
+} from "../dhl-unified-tracking"
+
+/**
+ * Pinned against a REAL payload captured live on 2026-08-13 from
+ * `GET https://api-eu.dhl.com/track/shipments?trackingNumber=21089967146`
+ * with the approved DHL API key — the Blue Dart test waybill from the
+ * integration report. Written from the wire, not from the docs.
+ */
+const LIVE_PAYLOAD = {
+  shipments: [
+    {
+      id: "21089967146",
+      service: "bluedart",
+      origin: { address: { addressLocality: "DHARAMSHALA", countryCode: "IN" } },
+      destination: { address: { addressLocality: "DHARAMSHALA", countryCode: "IN" } },
+      status: {
+        timestamp: "2026-08-13T10:02:00",
+        location: {
+          address: {
+            addressLocality: "DHARAMSHALA, DHARAMSHALA, HIMACHAL PRADESH",
+            countryCode: "IN",
+          },
+        },
+        statusCode: "pre-transit",
+        status: "PU",
+        description: "PICKUP HAS BEEN REGISTERED",
+      },
+      returnFlag: false,
+      details: { product: { productCode: "D", productName: "Documents" } },
+      events: [
+        {
+          timestamp: "2026-08-13T10:02:00",
+          location: {
+            address: { addressLocality: "DHARAMSHALA, DHARAMSHALA, HIMACHAL PRADESH" },
+          },
+          statusCode: "pre-transit",
+          status: "PU",
+          description: "PICKUP HAS BEEN REGISTERED ",
+        },
+        {
+          timestamp: "2026-08-13T09:48:00",
+          location: { address: { addressLocality: "BLUE DART CENTRE, MUMBAI, MAHARASHTRA" } },
+          statusCode: "transit",
+          status: "PU",
+          description: "SHIPPER INSTRUCTED TO RTO THE SHIPMENT ",
+        },
+        {
+          timestamp: "2026-08-13T09:47:00",
+          location: {
+            address: { addressLocality: "DHARAMSHALA, DHARAMSHALA, HIMACHAL PRADESH" },
+          },
+          statusCode: "pre-transit",
+          status: "PU",
+          description: "Online shipment booked ",
+        },
+      ],
+    },
+  ],
+}
+
+describe("normalizeDhlUnifiedTracking", () => {
+  it("maps the live Blue Dart payload onto the uniform tracking shape", () => {
+    const result = normalizeDhlUnifiedTracking(LIVE_PAYLOAD, "21089967146", "bluedart")
+    expect(result).toMatchObject({
+      carrier: "bluedart",
+      awb: "21089967146",
+      current_status: "PICKUP HAS BEEN REGISTERED",
+      current_status_code: "pre-transit",
+    })
+    expect(result.events).toHaveLength(3)
+  })
+
+  it("shows the human scan text, not the two-letter carrier code", () => {
+    const result = normalizeDhlUnifiedTracking(LIVE_PAYLOAD, "21089967146", "bluedart")
+    // "PU" means nothing to an operator reading a timeline.
+    expect(result.events[0].status).toBe("PICKUP HAS BEEN REGISTERED")
+    expect(result.events[0].location).toBe("DHARAMSHALA, DHARAMSHALA, HIMACHAL PRADESH")
+  })
+
+  it("falls back to the given AWB when the payload has no shipment", () => {
+    const result = normalizeDhlUnifiedTracking({ shipments: [] }, "FALLBACK", "bluedart")
+    expect(result.awb).toBe("FALLBACK")
+    expect(result.events).toEqual([])
+  })
+})
+
+describe("classifyDhlStatus", () => {
+  it("classifies an RTO as returned even though DHL codes it as plain transit", () => {
+    // The live payload proves this case is real: statusCode "transit" with
+    // "SHIPPER INSTRUCTED TO RTO THE SHIPMENT". Treating it as ordinary transit
+    // makes a parcel coming BACK look like one still going out.
+    expect(classifyDhlStatus("transit", "SHIPPER INSTRUCTED TO RTO THE SHIPMENT ")).toBe(
+      "returned"
+    )
+  })
+
+  it("classifies the coarse codes", () => {
+    expect(classifyDhlStatus("pre-transit", "Online shipment booked")).toBe("created")
+    expect(classifyDhlStatus("transit", "In transit")).toBe("in_transit")
+    expect(classifyDhlStatus("delivered", "Delivered")).toBe("delivered")
+    expect(classifyDhlStatus("failure", "Delivery exception")).toBe("exception")
+  })
+
+  it("reads a pickup scan as picked_up", () => {
+    expect(classifyDhlStatus("pre-transit", "PICKUP HAS BEEN REGISTERED")).toBe("picked_up")
+  })
+
+  it("never guesses delivered for an unrecognised scan", () => {
+    // #1206's rule: guessing delivery closes an order whose parcel is still
+    // moving, and nobody finds out until the customer complains.
+    expect(classifyDhlStatus(undefined, "SOME NOVEL SCAN NOBODY MAPPED")).toBe("in_transit")
+    expect(classifyDhlStatus("unknown", "")).toBe("in_transit")
+  })
+
+  it("does not read 'undelivered' as delivered", () => {
+    expect(classifyDhlStatus("failure", "UNDELIVERED - CONSIGNEE UNAVAILABLE")).toBe(
+      "exception"
+    )
+  })
+})
+
+describe("DhlUnifiedTrackingClient", () => {
+  const clientWith = (status: number, body: any) => {
+    const calls: string[] = []
+    const fetchImpl = (async (url: string) => {
+      calls.push(String(url))
+      return {
+        ok: status >= 200 && status < 300,
+        status,
+        text: async () => (typeof body === "string" ? body : JSON.stringify(body)),
+      }
+    }) as unknown as typeof fetch
+    return { client: new DhlUnifiedTrackingClient({ api_key: "k", fetchImpl }), calls }
+  }
+
+  it("sends the tracking number and the carrier service", async () => {
+    const { client, calls } = clientWith(200, LIVE_PAYLOAD)
+    await client.track("21089967146", "bluedart")
+    expect(calls[0]).toContain("trackingNumber=21089967146")
+    expect(calls[0]).toContain("service=bluedart")
+  })
+
+  it("names a 404 as 'not scanned yet' rather than a failure", async () => {
+    // A freshly generated waybill is legitimately absent for a while; reporting
+    // that as an error sends operators chasing a shipment that is fine.
+    const { client } = clientWith(404, { detail: "no data" })
+    await expect(client.track("NEW")).rejects.toThrow(/no tracking data .* yet/i)
+  })
+
+  it("surfaces other failures with their status", async () => {
+    const { client } = clientWith(401, { detail: "invalid key" })
+    await expect(client.track("X")).rejects.toThrow(/401/)
+  })
+})

--- a/apps/backend/src/modules/shipping-providers/bluedart/__tests__/bluedart-adapter.unit.spec.ts
+++ b/apps/backend/src/modules/shipping-providers/bluedart/__tests__/bluedart-adapter.unit.spec.ts
@@ -1,0 +1,422 @@
+import { BlueDartProviderAdapter } from "../adapter"
+import { BlueDartClient, describeBlueDartFailure } from "../client"
+import { gramsToKgString, toBlueDartTime, toMsJsonDate } from "../constants"
+import type { CreateShipmentInput } from "../../provider-interface"
+
+/**
+ * Blue Dart's contract is a minefield of shapes that fail silently or with
+ * unhelpful errors when got wrong (see the integration report's "gotchas").
+ * These pin the ones that cost real money or produce a rejected waybill.
+ */
+
+const CFG = {
+  client_id: "cid",
+  client_secret: "csecret",
+  login_id: "DY3585329",
+  licence_key: "lickey",
+  customer_code: "000001",
+  origin_area: "DHM",
+}
+
+const BASE_INPUT: CreateShipmentInput = {
+  reference_id: "order_1",
+  payment_mode: "prepaid",
+  pickup_location_name: "Dharamshala Studio",
+  to: {
+    name: "Delhi Recipient",
+    phone: "9995554441",
+    address_1: "Connaught Place",
+    city: "New Delhi",
+    state: "Delhi",
+    pincode: "110001",
+    country: "IN",
+  },
+  from: {
+    name: "JYT Textiles",
+    phone: "9996665554",
+    address_1: "Dharamshala",
+    city: "Dharamshala",
+    state: "HP",
+    pincode: "176215",
+    country: "IN",
+  },
+  items: [
+    { name: "Handloom Scarf", sku: "SCF-1", quantity: 2, unit_price: 500, hsn: "61091000" },
+  ],
+  weight_grams: 500,
+  sub_total: 1000,
+}
+
+/** Capture what the adapter actually sends, and reply with a success envelope. */
+function buildAdapter(reply?: any) {
+  const calls: Array<{ url: string; body: any; headers: any }> = []
+  const fetchImpl = (async (url: string, init: any = {}) => {
+    if (String(url).includes("/token/v1/login")) {
+      return {
+        ok: true,
+        status: 200,
+        json: async () => ({ JWTToken: "jwt-123" }),
+        text: async () => JSON.stringify({ JWTToken: "jwt-123" }),
+      }
+    }
+    const body = init.body ? JSON.parse(init.body) : undefined
+    calls.push({ url: String(url), body, headers: init.headers })
+    const payload =
+      reply ??
+      {
+        GenerateWayBillResult: {
+          AWBNo: "21089967146",
+          IsError: false,
+          Status: [{ StatusCode: "Valid", StatusInformation: "Waybill Generation Successful" }],
+          AvailableBalance: 2698.99,
+          TransactionAmount: 400.01,
+          DestinationArea: "DEL",
+          MPSDetails: [{ MPSNumber: "21089967146-0001" }],
+        },
+        CancelWaybillResult: {
+          AWBNo: "21089967146",
+          IsError: false,
+          Status: [{ StatusCode: "Valid", StatusInformation: "cancelled successfully" }],
+        },
+        RegisterPickupResult: {
+          IsError: false,
+          TokenNumber: "4047896",
+          Status: [{ StatusCode: "InsertSuccess" }],
+        },
+        GetServicesforPincodeResult: {
+          AreaCode: "DEL",
+          IsError: false,
+          DomesticPriorityInbound: "Yes",
+          ApexInbound: "No",
+          GroundInbound: "No",
+        },
+      }
+    return { ok: true, status: 200, text: async () => JSON.stringify(payload) }
+  }) as unknown as typeof fetch
+
+  return {
+    adapter: new BlueDartProviderAdapter(new BlueDartClient({ ...CFG, fetchImpl })),
+    calls,
+  }
+}
+
+describe("BlueDart formatting helpers", () => {
+  it("renders Microsoft-JSON dates, which is the only form Blue Dart accepts", () => {
+    expect(toMsJsonDate(new Date(1786657200000))).toBe("/Date(1786657200000)/")
+  })
+
+  it("strips the colon out of a pickup time", () => {
+    expect(toBlueDartTime("16:00")).toBe("1600")
+    expect(toBlueDartTime("09:30")).toBe("0930")
+  })
+
+  it("converts grams to a two-decimal KG string and never sends a zero weight", () => {
+    expect(gramsToKgString(500)).toBe("0.50")
+    expect(gramsToKgString(1250)).toBe("1.25")
+    // Blue Dart treats 0 as a missing weight and rejects the waybill outright.
+    expect(Number(gramsToKgString(0))).toBeGreaterThan(0)
+    expect(Number(gramsToKgString(undefined))).toBeGreaterThan(0)
+  })
+})
+
+describe("describeBlueDartFailure", () => {
+  it("treats a 200 with IsError as a failure", () => {
+    expect(describeBlueDartFailure({ IsError: true, Status: [{ StatusInformation: "no balance" }] }))
+      .toBe("no balance")
+  })
+
+  it("treats a non-Valid status code as a failure even when IsError is absent", () => {
+    expect(
+      describeBlueDartFailure({ Status: [{ StatusCode: "Error", StatusInformation: "bad pincode" }] })
+    ).toBe("bad pincode")
+  })
+
+  it("reports the bare Error string form used by the tracking endpoint", () => {
+    expect(describeBlueDartFailure({ Error: "License Mismatch" })).toBe("License Mismatch")
+  })
+
+  it("passes a genuinely successful result", () => {
+    expect(describeBlueDartFailure({ IsError: false, Status: [{ StatusCode: "Valid" }] })).toBeNull()
+    expect(describeBlueDartFailure({ IsError: false, Status: [{ StatusCode: "InsertSuccess" }] })).toBeNull()
+  })
+})
+
+describe("BlueDartProviderAdapter.createShipment", () => {
+  it("sends the mandatory shapes a waybill is rejected without", async () => {
+    const { adapter, calls } = buildAdapter()
+    await adapter.createShipment(BASE_INPUT)
+
+    const services = calls[0].body.Request.Services
+    // Dimensions array — absent, the waybill is refused.
+    expect(services.Dimensions).toHaveLength(1)
+    expect(services.Dimensions[0].Count).toBe(1)
+    // OTP must be the STRING "0"; the numeric 2 demands an OTPCode.
+    expect(services.OTPBasedDelivery).toBe("0")
+    // Commodity object is required even domestically.
+    expect(services.Commodity.CommodityDetail1).toBe("61091000")
+    // Profile needs BOTH Customercode and Version or auth fails obscurely.
+    expect(calls[0].body.Profile).toMatchObject({
+      Customercode: "000001",
+      Version: "1.3",
+      LoginID: "DY3585329",
+    })
+  })
+
+  it("authenticates with a JWTToken header, not Authorization: Bearer", async () => {
+    const { adapter, calls } = buildAdapter()
+    await adapter.createShipment(BASE_INPUT)
+    expect(calls[0].headers.JWTToken).toBe("jwt-123")
+    expect(calls[0].headers.Authorization).toBeUndefined()
+  })
+
+  it("books no pickup at label time — a waybill and a collection slot are separate acts", async () => {
+    const { adapter, calls } = buildAdapter()
+    await adapter.createShipment(BASE_INPUT)
+    expect(calls[0].body.Request.Services.RegisterPickup).toBe(false)
+  })
+
+  it("sends product D domestically and product H with an IPC sub-product abroad", async () => {
+    const { adapter: dom, calls: domCalls } = buildAdapter()
+    await dom.createShipment(BASE_INPUT)
+    expect(domCalls[0].body.Request.Services.ProductCode).toBe("D")
+    expect(domCalls[0].body.Request.Services.itemdtl).toEqual([])
+
+    const { adapter: intl, calls: intlCalls } = buildAdapter()
+    await intl.createShipment({
+      ...BASE_INPUT,
+      currency: "USD",
+      to: { ...BASE_INPUT.to, country: "IL", pincode: "9100000", city: "Jerusalem" },
+    })
+    const svc = intlCalls[0].body.Request.Services
+    expect(svc.ProductCode).toBe("H")
+    expect(svc.SubProductCode).toBe("IPC-Expedited")
+    expect(svc.CurrencyCode).toBe("USD")
+    // Per-item customs lines are mandatory on the international product.
+    expect(svc.itemdtl).toHaveLength(1)
+    expect(svc.itemdtl[0]).toMatchObject({ HSCode: "61091000", Itemquantity: 2, TotalValue: 1000 })
+    expect(intlCalls[0].body.Request.Consignee.ConsigneeCountryCode).toBe("IL")
+  })
+
+  it("collects nothing at the door on a prepaid order", async () => {
+    const { adapter, calls } = buildAdapter()
+    await adapter.createShipment(BASE_INPUT)
+    // Sending the order value here would ask a customer who has already paid to
+    // pay again at delivery.
+    expect(calls[0].body.Request.Services.CollectableAmount).toBe(0)
+  })
+
+  it("collects the COD amount on a COD order", async () => {
+    const { adapter, calls } = buildAdapter()
+    await adapter.createShipment({ ...BASE_INPUT, payment_mode: "cod", cod_amount: 1180 })
+    expect(calls[0].body.Request.Services.CollectableAmount).toBe(1180)
+  })
+
+  it("returns the AWB, the balance and the charge as provider refs", async () => {
+    const { adapter } = buildAdapter()
+    const result = await adapter.createShipment(BASE_INPUT)
+    expect(result).toMatchObject({ carrier: "bluedart", awb: "21089967146", tracking_number: "21089967146" })
+    // The prepaid balance is the only early warning that the account is about to
+    // stop shipping.
+    expect(result.provider_refs?.available_balance).toBe(2698.99)
+    expect(result.provider_refs?.courier_rate).toBe(400.01)
+  })
+
+  it("throws rather than returning an AWB-less success", async () => {
+    const { adapter } = buildAdapter({
+      GenerateWayBillResult: { IsError: false, Status: [{ StatusCode: "Valid" }] },
+    })
+    await expect(adapter.createShipment(BASE_INPUT)).rejects.toThrow(/no AWB/i)
+  })
+
+  it("surfaces a carrier rejection as a thrown error, not a silent success", async () => {
+    const { adapter } = buildAdapter({
+      GenerateWayBillResult: {
+        IsError: true,
+        Status: [{ StatusCode: "Error", StatusInformation: "Insufficient balance" }],
+      },
+    })
+    await expect(adapter.createShipment(BASE_INPUT)).rejects.toThrow(/Insufficient balance/)
+  })
+})
+
+describe("BlueDartProviderAdapter.cancelShipment", () => {
+  it("cancels by waybill and reports success", async () => {
+    const { adapter, calls } = buildAdapter()
+    const res = await adapter.cancelShipment({ awb: "21089967146" })
+    expect(calls[0].body.Request.AWBNo).toBe("21089967146")
+    expect(res.success).toBe(true)
+  })
+
+  it("reads the waybill out of provider_refs when awb is absent", async () => {
+    const { adapter, calls } = buildAdapter()
+    await adapter.cancelShipment({ provider_refs: { waybill: "999" } })
+    expect(calls[0].body.Request.AWBNo).toBe("999")
+  })
+
+  it("refuses without a waybill rather than posting an empty cancel", async () => {
+    const { adapter } = buildAdapter()
+    await expect(adapter.cancelShipment({})).rejects.toThrow(/requires a waybill/i)
+  })
+
+  it("does NOT report success when Blue Dart refuses the cancellation", async () => {
+    // The dangerous failure: a false success clears our carrier refs while the
+    // waybill stays live and billable — the #1225 orphan, in reverse.
+    const { adapter } = buildAdapter({
+      CancelWaybillResult: {
+        IsError: true,
+        Status: [{ StatusCode: "Error", StatusInformation: "Shipment already in transit" }],
+      },
+    })
+    await expect(adapter.cancelShipment({ awb: "21089967146" })).rejects.toThrow(
+      /already in transit/
+    )
+  })
+})
+
+describe("BlueDartProviderAdapter.schedulePickup", () => {
+  it("books against the AWB and returns the token needed to cancel it later", async () => {
+    const { adapter, calls } = buildAdapter()
+    const res = await adapter.schedulePickup({
+      pickup_location_name: "Dharamshala Studio",
+      pickup_date: "2026-08-20",
+      expected_package_count: 2,
+      ref: { awb: "21089967146" },
+    })
+    const req = calls[0].body.request
+    expect(req.AWBNo).toEqual(["21089967146"])
+    expect(req.AreaCode).toBe("DHM")
+    expect(req.NumberofPieces).toBe(2)
+    // Empty SubProducts is rejected by the pickup API.
+    expect(req.SubProducts.length).toBeGreaterThan(0)
+    expect(req.ShipmentPickupDate).toMatch(/^\/Date\(\d+\)\/$/)
+    expect(res.token).toBe("4047896")
+  })
+
+  it("sends pickup times as HHMM, not HH:MM", async () => {
+    const { adapter, calls } = buildAdapter()
+    await adapter.schedulePickup({
+      pickup_location_name: "Dharamshala Studio",
+      pickup_date: "2026-08-20",
+      // What both UIs actually send — an <input type="time"> value.
+      pickup_time: "14:00",
+      ref: { awb: "21089967146" },
+    })
+    const req = calls[0].body.request
+    // `createShipment` normalised this and `schedulePickup` did not, so the
+    // colon went straight to Blue Dart on the one call that books a courier.
+    expect(req.ShipmentPickupTime).toBe("1400")
+    expect(req.OfficeCloseTime).toBe("1800")
+  })
+
+  it("refuses to book a pickup before there is a waybill to collect", async () => {
+    const { adapter } = buildAdapter()
+    await expect(
+      adapter.schedulePickup({ pickup_location_name: "X", pickup_date: "2026-08-20" })
+    ).rejects.toThrow(/requires the shipment's waybill/i)
+  })
+})
+
+describe("BlueDartProviderAdapter.checkServiceability", () => {
+  it("reads the INBOUND flags — outbound describes that pincode's own senders", async () => {
+    const { adapter } = buildAdapter()
+    await expect(adapter.checkServiceability("110001")).resolves.toBe(true)
+  })
+
+  it("is false when no inbound product serves the destination", async () => {
+    const { adapter } = buildAdapter({
+      GetServicesforPincodeResult: {
+        IsError: false,
+        DomesticPriorityInbound: "No",
+        ApexInbound: "No",
+        GroundInbound: "No",
+        // Outbound being available must not be mistaken for deliverability.
+        DomesticPriorityOutbound: "Yes",
+      },
+    })
+    await expect(adapter.checkServiceability("999999")).resolves.toBe(false)
+  })
+})
+
+describe("BlueDartClient.trackShipment", () => {
+  /**
+   * Pins the tracking query, and above all pins the ABSENCE of `verno`.
+   *
+   * TnT folds `verno` into its licence check, so sending it returns
+   * `{"Error":"License Mismatch"}` — an error that blames the credential for a
+   * parameter fault. That misreading cost a session and nearly had us chasing a
+   * second licence key from Blue Dart that does not exist. Re-adding `verno`
+   * must fail here, loudly, rather than at 2am against a live shipment.
+   */
+  it("sends the documented tracking query", async () => {
+    const calls: string[] = []
+    const fetchImpl = (async (url: string) => {
+      calls.push(String(url))
+      if (String(url).includes("/token/v1/login")) {
+        return { ok: true, status: 200, json: async () => ({ JWTToken: "jwt-123" }) }
+      }
+      return {
+        ok: true,
+        status: 200,
+        text: async () => JSON.stringify({ ShipmentData: { Shipment: [{ WaybillNo: "21089967146" }] } }),
+      }
+    }) as any
+
+    const client = new BlueDartClient({ ...CFG, tracking_licence_key: "trackkey", fetchImpl })
+    await client.trackShipment("21089967146")
+
+    const url = new URL(calls[calls.length - 1])
+    expect(url.pathname).toBe("/in/transportation/tracking/v1")
+    expect(Object.fromEntries(url.searchParams)).toMatchObject({
+      handler: "tnt",
+      action: "custawbquery",
+      loginid: "DY3585329",
+      // A mode selector, not the number — the number rides in `numbers`.
+      awb: "awb",
+      numbers: "21089967146",
+      // Omitting this 400s at the gateway before the tracking app sees it.
+      scan: "1",
+      lickey: "trackkey",
+    })
+    // The whole point. Any value here returns "License Mismatch".
+    expect(url.searchParams.has("verno")).toBe(false)
+  })
+
+  it("uses the shipping licence key when no tracking override is set", async () => {
+    // Verified live 2026-08-13: the shipping licence key authenticates against
+    // TnT once `verno` is dropped. There is no second licence to obtain.
+    const calls: string[] = []
+    const fetchImpl = (async (url: string) => {
+      calls.push(String(url))
+      if (String(url).includes("/token/v1/login")) {
+        return { ok: true, status: 200, json: async () => ({ JWTToken: "jwt-123" }) }
+      }
+      return { ok: true, status: 200, text: async () => JSON.stringify({ ShipmentData: { Shipment: [{}] } }) }
+    }) as any
+
+    const client = new BlueDartClient({ ...CFG, fetchImpl })
+    await client.trackShipment("21089967146")
+    expect(new URL(calls[calls.length - 1]).searchParams.get("lickey")).toBe("lickey")
+  })
+
+  it("surfaces a cancelled or unknown waybill as a plain failure", async () => {
+    // A CANCELLED waybill drops out of TnT and answers exactly like a typo'd
+    // one — observed live on AWB 21089967146 after its cancellation. The two
+    // are indistinguishable at this layer, so we must not claim either.
+    const fetchImpl = (async (url: string) => {
+      if (String(url).includes("/token/v1/login")) {
+        return { ok: true, status: 200, json: async () => ({ JWTToken: "jwt-123" }) }
+      }
+      return {
+        ok: true,
+        status: 200,
+        text: async () =>
+          JSON.stringify({ ShipmentData: { Error: "Incorrect waybill number or No information" } }),
+      }
+    }) as any
+
+    const client = new BlueDartClient({ ...CFG, fetchImpl })
+    await expect(client.trackShipment("21089967146")).rejects.toThrow(
+      /Incorrect waybill number or No information/
+    )
+  })
+})

--- a/apps/backend/src/modules/shipping-providers/bluedart/adapter.ts
+++ b/apps/backend/src/modules/shipping-providers/bluedart/adapter.ts
@@ -1,0 +1,439 @@
+import { isInternationalDestination } from "../destination"
+import type {
+  CreateShipmentInput,
+  LabelResult,
+  PickupLocation,
+  RegisterPickupLocationInput,
+  SchedulePickupInput,
+  SchedulePickupResult,
+  ShipmentRef,
+  ShipmentResult,
+  ShippingProviderClient,
+  TrackingResult,
+} from "../provider-interface"
+import {
+  DhlUnifiedTrackingClient,
+  normalizeDhlUnifiedTracking,
+} from "../dhl-unified-tracking"
+import { BlueDartApiError, BlueDartClient } from "./client"
+import {
+  BLUEDART_CARRIER_ID,
+  BLUEDART_DEFAULT_DIMENSIONS,
+  BLUEDART_INTL_SUBPRODUCT,
+  BLUEDART_PICKUP_SUBPRODUCTS,
+  BLUEDART_PRODUCT,
+  gramsToKgString,
+  toBlueDartTime,
+  toMsJsonDate,
+} from "./constants"
+import type { BlueDartConfig } from "./types"
+
+/**
+ * Blue Dart as a `ShippingProviderClient`.
+ *
+ * Why it exists (#1236 / order #83's lineage): some of our pickup locations
+ * simply do not work with the incumbent carriers — the pickup never materialises
+ * — and Blue Dart serves those lanes. Unlike our Delhivery integration it is
+ * NOT domestic-only: product `H` (IPC) is a real export product on the same
+ * account, so there is no `assertDomestic` guard here.
+ *
+ * Two shapes worth knowing before reading on:
+ *
+ *  - **Waybill and pickup are separate acts.** `createShipment` sends
+ *    `RegisterPickup: false` and `schedulePickup` books the collection. A
+ *    waybill can be made the night before; a pickup slot is a commitment for a
+ *    date and a warehouse. Same split we settled on for Delhivery in #1241.
+ *  - **Weights are KG, ours are grams**; dates are Microsoft-JSON, not ISO.
+ */
+export class BlueDartProviderAdapter implements ShippingProviderClient {
+  readonly carrier = BLUEDART_CARRIER_ID
+  private readonly client: BlueDartClient
+  /** DHL unified tracking, when a key is configured — see `track()`. */
+  private readonly tracking?: DhlUnifiedTrackingClient
+
+  constructor(
+    cfg: BlueDartConfig | BlueDartClient,
+    tracking?: DhlUnifiedTrackingClient
+  ) {
+    this.client = cfg instanceof BlueDartClient ? cfg : new BlueDartClient(cfg)
+    this.tracking = tracking
+  }
+
+  /**
+   * True when the destination pincode can receive the product we would ship it.
+   *
+   * Reads the INBOUND flag, not the outbound one: outbound describes what can
+   * leave that pincode, which is a fact about the destination's own senders and
+   * says nothing about whether our parcel can be delivered there.
+   */
+  async checkServiceability(destinationPincode: string): Promise<boolean> {
+    const result = await this.client.checkServiceability(destinationPincode)
+    const yes = (v: any) => String(v || "").trim().toLowerCase() === "yes"
+    return (
+      yes(result?.DomesticPriorityInbound) ||
+      yes(result?.ApexInbound) ||
+      yes(result?.GroundInbound)
+    )
+  }
+
+  async createShipment(input: CreateShipmentInput): Promise<ShipmentResult> {
+    const international = isInternationalDestination(input.to.country)
+    const dims = input.dimensions_cm
+    const request: Record<string, any> = {
+      Consignee: {
+        ConsigneeName: input.to.name,
+        ConsigneeAddress1: input.to.address_1,
+        ConsigneeAddress2: input.to.address_2 || "",
+        ConsigneeAddress3: "",
+        ConsigneeAddressType: "R",
+        ConsigneeAttention: input.to.name,
+        ConsigneeEmailID: input.to.email || "",
+        ConsigneeMobile: input.to.phone,
+        ConsigneePincode: input.to.pincode,
+        ConsigneeTelephone: "",
+        ...(international
+          ? {
+              ConsigneeCountryCode: String(input.to.country || "").toUpperCase(),
+              ConsigneeCityName: input.to.city,
+            }
+          : {}),
+      },
+      Shipper: {
+        CustomerName: input.from?.name || input.pickup_location_name,
+        CustomerCode: this.client.profile.Customercode,
+        CustomerAddress1: input.from?.address_1 || "",
+        CustomerAddress2: input.from?.address_2 || "",
+        CustomerAddress3: "",
+        CustomerEmailID: input.from?.email || "",
+        CustomerGSTNumber: input.tax_id || "",
+        CustomerMobile: input.from?.phone || "",
+        CustomerPincode: input.from?.pincode || "",
+        CustomerTelephone: "",
+        IsToPayCustomer: false,
+        OriginArea: this.client.originArea,
+        Sender: input.from?.name || input.pickup_location_name,
+        VendorCode: "",
+      },
+      Returnadds: {
+        ReturnAddress1: input.from?.address_1 || "",
+        ReturnAddress2: input.from?.address_2 || "",
+        ReturnAddress3: "",
+        ReturnContact: input.from?.name || input.pickup_location_name,
+        ReturnEmailID: input.from?.email || "",
+        ReturnMobile: input.from?.phone || "",
+        ReturnPincode: input.from?.pincode || "",
+        ReturnTelephone: "",
+        ManifestNumber: "",
+      },
+      Services: {
+        AWBNo: "",
+        ActualWeight: gramsToKgString(input.weight_grams),
+        // COD is collected at the door; a prepaid shipment must send 0, never
+        // the order value, or Blue Dart asks the customer to pay twice.
+        CollectableAmount:
+          input.payment_mode === "cod" ? Number(input.cod_amount) || 0 : 0,
+        Commodity: this.commodityOf(input),
+        CreditReferenceNo: input.reference_id,
+        CreditReferenceNo2: "",
+        CreditReferenceNo3: "",
+        DeclaredValue: this.declaredValueOf(input),
+        // Mandatory. A waybill with no Dimensions array is rejected outright,
+        // so an unmeasured parcel falls back to a nominal box rather than
+        // failing the shipment.
+        Dimensions: [
+          {
+            Length: dims?.length ?? BLUEDART_DEFAULT_DIMENSIONS.length,
+            Breadth: dims?.width ?? BLUEDART_DEFAULT_DIMENSIONS.breadth,
+            Height: dims?.height ?? BLUEDART_DEFAULT_DIMENSIONS.height,
+            Count: 1,
+          },
+        ],
+        ECCN: "",
+        PDFOutputNotRequired: true,
+        PackType: "",
+        PickupDate: toMsJsonDate(new Date()),
+        PickupTime: toBlueDartTime("16:00"),
+        PieceCount: "1",
+        ProductCode: international
+          ? BLUEDART_PRODUCT.international
+          : BLUEDART_PRODUCT.domestic,
+        ProductType: 0,
+        // Booked separately by `schedulePickup` — see the class docblock.
+        RegisterPickup: false,
+        SpecialInstruction: input.product_description || "",
+        SubProductCode: international ? BLUEDART_INTL_SUBPRODUCT : "",
+        // "0" (a STRING) disables OTP delivery. The numeric 2 demands an OTPCode
+        // and fails with "OTP Number cannot be blank" when one isn't supplied.
+        OTPBasedDelivery: "0",
+        OTPCode: "",
+        itemdtl: international ? this.itemDetailsOf(input) : [],
+        noOfDCGiven: 0,
+        ...(international ? this.internationalServicesOf(input) : {}),
+      },
+    }
+
+    const result = await this.client.generateWaybill(request)
+    const awb = result?.AWBNo ? String(result.AWBNo) : ""
+    if (!awb) {
+      throw new BlueDartApiError(
+        "Blue Dart accepted the waybill request but returned no AWB",
+        [],
+        result
+      )
+    }
+
+    return {
+      carrier: this.carrier,
+      awb,
+      tracking_number: awb,
+      tracking_url: `https://www.bluedart.com/tracking?trackFor=0&trackNo=${awb}`,
+      provider_refs: {
+        waybill: awb,
+        mps_numbers: (result.MPSDetails || [])
+          .map((m) => m?.MPSNumber)
+          .filter(Boolean),
+        destination_area: result.DestinationArea,
+        // Surfaced because a Blue Dart account ships until the prepaid balance
+        // runs out and then simply stops — knowing it is falling is the only
+        // early warning there is.
+        available_balance: result.AvailableBalance,
+        transaction_amount: result.TransactionAmount,
+        courier_rate: result.TransactionAmount,
+        courier_rate_currency: "INR",
+      },
+      raw: result,
+    }
+  }
+
+  /** Customs commodity block. Blue Dart requires the object even domestically. */
+  private commodityOf(input: CreateShipmentInput) {
+    const codes = input.items
+      .map((i) => i.hsn)
+      .filter((c): c is string => Boolean(c && String(c).trim()))
+    return {
+      CommodityDetail1: codes[0] || input.items[0]?.name || "Merchandise",
+      CommodityDetail2: codes[1] || "",
+      CommodityDetail3: codes[2] || "",
+    }
+  }
+
+  private declaredValueOf(input: CreateShipmentInput): number {
+    if (input.sub_total != null && Number(input.sub_total) > 0) {
+      return Number(input.sub_total)
+    }
+    return input.items.reduce(
+      (sum, i) => sum + (Number(i.unit_price) || 0) * (Number(i.quantity) || 1),
+      0
+    )
+  }
+
+  /** Per-item customs lines — mandatory for the international product. */
+  private itemDetailsOf(input: CreateShipmentInput) {
+    return input.items.map((item, idx) => {
+      const qty = Number(item.quantity) || 1
+      const unit = Number(item.unit_price) || 0
+      return {
+        ItemID: item.sku || `ITEM${String(idx + 1).padStart(3, "0")}`,
+        ItemName: item.name,
+        HSCode: item.hsn || "",
+        countryOfOrigin: "IN",
+        Itemquantity: qty,
+        Unit: "PCS",
+        ItemValue: unit,
+        TotalValue: unit * qty,
+      }
+    })
+  }
+
+  private internationalServicesOf(input: CreateShipmentInput) {
+    return {
+      CurrencyCode: (input.currency || "INR").toUpperCase(),
+      IsCommercialShipment: input.customs?.commodity !== false,
+      IncotermCode: "DAP",
+      TermsOfTrade: input.customs?.terms_of_invoice === "CIF" ? "CIF" : "FOB",
+      ExportReason:
+        input.customs?.reason_of_export === 2 ? "Gift" : "Sale of Goods",
+    }
+  }
+
+  /**
+   * Blue Dart returns the label inline with the waybill only when
+   * `PDFOutputNotRequired` is false, and we set it true (the PDF is large and
+   * the label is fetched on demand). There is no separate label-fetch endpoint
+   * on the documented surface, so this reports that honestly rather than
+   * returning an empty result the UI would render as a broken link.
+   */
+  async getLabel(_ref: ShipmentRef): Promise<LabelResult> {
+    throw new BlueDartApiError(
+      "Blue Dart does not expose a standalone label fetch — the label PDF is returned with the waybill at creation time. Download it from the Blue Dart portal, or re-generate with PDF output enabled."
+    )
+  }
+
+  /**
+   * Track via DHL's **Unified Shipment Tracking**, not Blue Dart's own endpoint.
+   *
+   * Both work. Blue Dart's own TnT endpoint authenticates with the SHIPPING
+   * licence key (see `client.trackShipment` — the blocker was only ever the
+   * `verno` parameter). DHL Unified is preferred for one reason that is not
+   * about credentials: **TnT drops cancelled waybills**, answering
+   * `"Incorrect waybill number or No information"` — indistinguishable from a
+   * typo — while DHL Unified retains their full history, including the
+   * shipper-instructed-RTO scan that a cancellation produces.
+   *
+   * Falls back to Blue Dart's native endpoint when no unified key is configured.
+   */
+  async track(ref: ShipmentRef): Promise<TrackingResult> {
+    const awb = ref.awb || ref.provider_refs?.waybill
+    if (!awb) throw new BlueDartApiError("Blue Dart track requires a waybill")
+
+    if (this.tracking) {
+      const raw = await this.tracking.track(String(awb), BLUEDART_CARRIER_ID)
+      return normalizeDhlUnifiedTracking(raw, String(awb), this.carrier)
+    }
+
+    const raw = await this.client.trackShipment(String(awb))
+    return normalizeBlueDartTracking(raw, String(awb))
+  }
+
+  async cancelShipment(
+    ref: ShipmentRef
+  ): Promise<{ success: boolean; raw?: any }> {
+    const awb = ref.awb || ref.provider_refs?.waybill
+    if (!awb) {
+      throw new BlueDartApiError("Blue Dart cancelShipment requires a waybill")
+    }
+    // The client throws on any of Blue Dart's failure shapes, so reaching here
+    // means it really was cancelled — `IsError: false` plus a Valid status.
+    const raw = await this.client.cancelWaybill(String(awb))
+    return { success: true, raw }
+  }
+
+  async schedulePickup(input: SchedulePickupInput): Promise<SchedulePickupResult> {
+    const awb = input.ref?.awb || input.ref?.provider_refs?.waybill
+    if (!awb) {
+      throw new BlueDartApiError(
+        "Blue Dart schedulePickup requires the shipment's waybill — book the pickup after generating the label."
+      )
+    }
+    const date = input.pickup_date ? new Date(input.pickup_date) : new Date()
+    const result = await this.client.registerPickup({
+      AWBNo: [String(awb)],
+      AreaCode: this.client.originArea,
+      CustomerCode: this.client.profile.Customercode,
+      CustomerName: input.pickup_location_name,
+      CustomerAddress1: input.pickup_location_name,
+      CustomerPincode: "",
+      CustomerTelephone: "",
+      ContactPersonName: input.pickup_location_name,
+      ProductCode: BLUEDART_PRODUCT.domestic,
+      NumberofPieces: input.expected_package_count || 1,
+      WeightofShipment: 0.5,
+      VolumeWeight: 0.5,
+      ShipmentPickupDate: toMsJsonDate(date),
+      // HHMM, not HH:MM. `createShipment` runs its pickup time through
+      // `toBlueDartTime` and this path did not, so a UI that sends "14:00" —
+      // which both the admin widget and the partner form do — handed Blue Dart
+      // a colon it does not parse. Same helper, same format, both paths.
+      ShipmentPickupTime: toBlueDartTime(input.pickup_time),
+      OfficeCloseTime: toBlueDartTime("18:00"),
+      DoxNDox: "1",
+      // Must be non-empty — an empty SubProducts array is rejected.
+      SubProducts: BLUEDART_PICKUP_SUBPRODUCTS,
+      IsForcePickup: false,
+      IsReversePickup: false,
+      isToPayShipper: false,
+      CISDDN: false,
+      EmailID: "",
+      PackType: "",
+      ReferenceNo: String(awb),
+      Remarks: "",
+      RouteCode: "",
+    })
+    return {
+      scheduled_date: input.pickup_date,
+      // The token is what CancelPickup needs later — losing it means the
+      // collection can only be called off by phone.
+      token: result?.TokenNumber ? String(result.TokenNumber) : undefined,
+      raw: result,
+    }
+  }
+
+  /**
+   * Blue Dart has no pickup-location registry: collections are booked per-AWB
+   * against the account's origin area, so there is nothing to register or list.
+   * Deliberately NOT implemented (rather than faked) — `registerPickupLocation`
+   * and `listPickupLocations` are optional on the interface precisely for this,
+   * and a stub returning `[]` would make the carrier-pickups UI claim a
+   * location is unregistered when registration is not a concept here.
+   */
+  registerPickupLocation?: (
+    input: RegisterPickupLocationInput
+  ) => Promise<{ name: string; raw?: any }>
+  listPickupLocations?: () => Promise<PickupLocation[]>
+}
+
+/**
+ * Map Blue Dart's scan list onto our uniform tracking shape.
+ *
+ * Exported and pure so it can be tested against captured payloads without a
+ * live account — which matters more than usual here, since tracking needs a
+ * licence key we do not yet hold.
+ */
+export function normalizeBlueDartTracking(
+  raw: any,
+  awb: string
+): TrackingResult {
+  const shipmentData = raw?.ShipmentData ?? raw
+  const shipment = Array.isArray(shipmentData?.Shipment)
+    ? shipmentData.Shipment[0]
+    : shipmentData?.Shipment || shipmentData
+
+  const scans: any[] = Array.isArray(shipment?.Scans)
+    ? shipment.Scans
+    : Array.isArray(shipment?.Scans?.ScanDetail)
+      ? shipment.Scans.ScanDetail
+      : []
+
+  const events = scans.map((s: any) => {
+    const detail = s?.ScanDetail || s
+    const status = detail?.Scan || detail?.ScanType || ""
+    return {
+      timestamp: [detail?.ScanDate, detail?.ScanTime].filter(Boolean).join(" "),
+      status: String(status),
+      location: String(detail?.ScannedLocation || detail?.ScannedLocationCode || ""),
+      scan_type: classifyBlueDartScan(String(status)),
+    }
+  })
+
+  const current = shipment?.Status || events[events.length - 1]?.status || ""
+  return {
+    carrier: BLUEDART_CARRIER_ID,
+    awb,
+    current_status: String(current),
+    current_status_code: shipment?.StatusCode || undefined,
+    estimated_delivery: shipment?.ExpectedDeliveryDate || null,
+    origin: shipment?.Origin || undefined,
+    destination: shipment?.Destination || undefined,
+    events,
+    raw,
+  }
+}
+
+/**
+ * Coarse classification consumers switch on.
+ *
+ * An unrecognised live scan maps to `in_transit`, never `delivered` — the same
+ * rule the Delhivery normalizer follows (#1206). Guessing "delivered" closes an
+ * order whose parcel is still in the network, and that error is not visible
+ * until a customer complains.
+ */
+export function classifyBlueDartScan(status: string): string {
+  const s = status.toLowerCase()
+  if (/deliver/.test(s) && !/undeliver|out for deliver/.test(s)) return "delivered"
+  if (/out for delivery/.test(s)) return "out_for_delivery"
+  if (/pick|collect|shipment picked/.test(s)) return "picked_up"
+  if (/rto|return/.test(s)) return "returned"
+  if (/cancel/.test(s)) return "cancelled"
+  if (/undeliver|exception|hold|delay/.test(s)) return "exception"
+  return "in_transit"
+}

--- a/apps/backend/src/modules/shipping-providers/bluedart/client.ts
+++ b/apps/backend/src/modules/shipping-providers/bluedart/client.ts
@@ -1,0 +1,308 @@
+import {
+  BLUEDART_BASE_URL,
+  BLUEDART_PATHS,
+  BLUEDART_SANDBOX_URL,
+} from "./constants"
+import type {
+  BlueDartCancelResult,
+  BlueDartConfig,
+  BlueDartPickupResult,
+  BlueDartProfile,
+  BlueDartServiceabilityResult,
+  BlueDartStatus,
+  BlueDartWaybillResult,
+} from "./types"
+
+/**
+ * Raw Blue Dart HTTP client — token lifecycle, envelope unwrapping, and turning
+ * their several ways of saying "no" into one thrown error.
+ *
+ * The adapter above this maps our carrier-agnostic shapes onto it; this file
+ * knows only Blue Dart.
+ */
+
+export class BlueDartApiError extends Error {
+  readonly statusCodes: string[]
+  readonly raw: any
+  constructor(message: string, statusCodes: string[] = [], raw?: any) {
+    super(message)
+    this.name = "BlueDartApiError"
+    this.statusCodes = statusCodes
+    this.raw = raw
+  }
+}
+
+/**
+ * Blue Dart reports failure three different ways and a caller must treat all
+ * three as failure: an `IsError: true` flag, a `Status[]` whose codes are not
+ * `Valid`/`InsertSuccess`, or an `Error` string on the payload. A 200 means the
+ * request was well-formed, nothing more.
+ */
+export function describeBlueDartFailure(result: any): string | null {
+  if (!result || typeof result !== "object") return null
+  if (typeof result.Error === "string" && result.Error.trim()) {
+    return result.Error.trim()
+  }
+  const statuses: BlueDartStatus[] = Array.isArray(result.Status)
+    ? result.Status
+    : []
+  const informative = statuses
+    .map((s) => s?.StatusInformation || s?.StatusCode)
+    .filter(Boolean)
+    .join("; ")
+  const OK = new Set(["valid", "insertsuccess", "success"])
+  const anyBadStatus =
+    statuses.length > 0 &&
+    !statuses.some((s) => OK.has(String(s?.StatusCode || "").toLowerCase()))
+
+  if (result.IsError === true || anyBadStatus) {
+    return informative || "Blue Dart rejected the request"
+  }
+  return null
+}
+
+export class BlueDartClient {
+  readonly carrier = "bluedart"
+  private readonly baseUrl: string
+  private readonly cfg: BlueDartConfig
+  private readonly fetchImpl: typeof fetch
+  private cachedToken: string | null = null
+  private tokenExpiry = 0
+
+  constructor(cfg: BlueDartConfig) {
+    this.cfg = cfg
+    this.baseUrl = cfg.sandbox ? BLUEDART_SANDBOX_URL : BLUEDART_BASE_URL
+    this.fetchImpl = cfg.fetchImpl || fetch
+  }
+
+  /** Layer-2 credentials. `Customercode` AND `Version` are both mandatory — omitting
+   *  either yields "UnauthorizedUser" or a null-reference error, not a clear message. */
+  get profile(): BlueDartProfile {
+    return {
+      Api_type: this.cfg.api_type || "S",
+      Customercode: this.cfg.customer_code,
+      LicenceKey: this.cfg.licence_key,
+      LoginID: this.cfg.login_id,
+      Version: this.cfg.version || "1.3",
+    }
+  }
+
+  get originArea(): string {
+    return this.cfg.origin_area || "DHM"
+  }
+
+  /**
+   * Mint (and cache) the gateway JWT. Valid 24 h; refreshed 5 min early.
+   *
+   * Cached in memory only, and never logged — it is a bearer credential for an
+   * account with a real balance behind it.
+   */
+  async getToken(now: number = Date.now()): Promise<string> {
+    if (this.cachedToken && now < this.tokenExpiry) return this.cachedToken
+
+    const res = await this.fetchImpl(`${this.baseUrl}${BLUEDART_PATHS.token}`, {
+      method: "GET",
+      headers: {
+        Accept: "application/json",
+        clientID: this.cfg.client_id,
+        clientSecret: this.cfg.client_secret,
+      },
+    })
+    if (!res.ok) {
+      const body = await res.text().catch(() => "")
+      throw new BlueDartApiError(
+        `Blue Dart token request failed (${res.status}): ${body.slice(0, 300)}`
+      )
+    }
+    const json: any = await res.json()
+    const token = json?.JWTToken
+    if (!token) {
+      throw new BlueDartApiError(
+        "Blue Dart token response carried no JWTToken",
+        [],
+        json
+      )
+    }
+    this.cachedToken = token
+    this.tokenExpiry = now + 24 * 60 * 60 * 1000 - 5 * 60 * 1000
+    return token
+  }
+
+  /** POST a JSON body with the JWT header. NOT `Authorization: Bearer` — Blue Dart
+   *  reads a bare `JWTToken` header and ignores anything else. */
+  private async post<T>(path: string, body: any): Promise<T> {
+    const token = await this.getToken()
+    const res = await this.fetchImpl(`${this.baseUrl}${path}`, {
+      method: "POST",
+      headers: {
+        "Content-Type": "application/json",
+        JWTToken: token,
+      },
+      body: JSON.stringify(body),
+    })
+    const text = await res.text().catch(() => "")
+    if (!res.ok) {
+      throw new BlueDartApiError(
+        `Blue Dart ${path} failed (${res.status}): ${text.slice(0, 300)}`
+      )
+    }
+    try {
+      return JSON.parse(text) as T
+    } catch {
+      throw new BlueDartApiError(
+        `Blue Dart ${path} returned a non-JSON body: ${text.slice(0, 200)}`
+      )
+    }
+  }
+
+  /** Unwrap a `<Name>Result` envelope and throw on any of the failure shapes. */
+  private unwrap<T>(json: any, key: string): T {
+    const result = json?.[key] ?? json
+    const failure = describeBlueDartFailure(result)
+    if (failure) {
+      const codes = (Array.isArray(result?.Status) ? result.Status : [])
+        .map((s: BlueDartStatus) => s?.StatusCode)
+        .filter(Boolean)
+      throw new BlueDartApiError(`Blue Dart: ${failure}`, codes, result)
+    }
+    return result as T
+  }
+
+  async checkServiceability(
+    pincode: string
+  ): Promise<BlueDartServiceabilityResult> {
+    // This call takes a REDUCED profile — no Customercode, no Version. Sending
+    // the full one is accepted, but the documented shape is this.
+    const json = await this.post<any>(BLUEDART_PATHS.servicesForPincode, {
+      pinCode: String(pincode),
+      profile: {
+        Api_type: this.profile.Api_type,
+        LicenceKey: this.profile.LicenceKey,
+        LoginID: this.profile.LoginID,
+      },
+    })
+    return this.unwrap<BlueDartServiceabilityResult>(
+      json,
+      "GetServicesforPincodeResult"
+    )
+  }
+
+  async generateWaybill(request: any): Promise<BlueDartWaybillResult> {
+    const json = await this.post<any>(BLUEDART_PATHS.generateWaybill, {
+      Request: request,
+      Profile: this.profile,
+    })
+    return this.unwrap<BlueDartWaybillResult>(json, "GenerateWayBillResult")
+  }
+
+  async cancelWaybill(awbNo: string): Promise<BlueDartCancelResult> {
+    const json = await this.post<any>(BLUEDART_PATHS.cancelWaybill, {
+      Request: { AWBNo: String(awbNo) },
+      Profile: this.profile,
+    })
+    return this.unwrap<BlueDartCancelResult>(json, "CancelWaybillResult")
+  }
+
+  async registerPickup(request: any): Promise<BlueDartPickupResult> {
+    // Note the lowercase `request` / `profile` keys here — the pickup API differs
+    // from the waybill API's capitalised `Request` / `Profile`, and swapping them
+    // yields an unhelpful null-reference error rather than a validation message.
+    const json = await this.post<any>(BLUEDART_PATHS.registerPickup, {
+      request,
+      profile: this.profile,
+    })
+    return this.unwrap<BlueDartPickupResult>(json, "RegisterPickupResult")
+  }
+
+  /**
+   * Verified live 2026-08-13 against two real pickup tokens — both cancelled
+   * with `{"StatusCode":"CancelSuccess"}`, and a repeat call correctly returns
+   * `PickupAlreadyCancelled`.
+   *
+   *  - `TokenNumber` is a NUMBER in the spec, not a string.
+   *  - `Remarks` rejects non-alphanumerics: an em dash returns "Invalid value in
+   *    Remarks parameter". Keep it plain ASCII.
+   *  - `PickupRegistrationDate` must be the date the pickup was booked FOR, in
+   *    Microsoft-JSON form. It is part of the lookup key, not decoration.
+   */
+  async cancelPickup(tokenNumber: string, pickupDate: string): Promise<any> {
+    const numeric = Number(tokenNumber)
+    const json = await this.post<any>(BLUEDART_PATHS.cancelPickup, {
+      request: {
+        TokenNumber: Number.isFinite(numeric) ? numeric : String(tokenNumber),
+        PickupRegistrationDate: pickupDate,
+        Remarks: "Cancelled from Jaal Yantra admin",
+      },
+      profile: this.profile,
+    })
+    return this.unwrap<any>(json, "CancelPickupResult")
+  }
+
+  /**
+   * Track one or more AWBs.
+   *
+   * ⚠️⚠️ **NEVER send `verno` here.** The shipping licence key IS the tracking
+   * licence key — but TnT folds `verno` into its licence check, so *any* value
+   * (`1`, `1.3`, anything) comes back
+   * `{"ShipmentData":{"Error":"License Mismatch"}}`. That error names the wrong
+   * culprit and cost a full session: it was read as "tracking needs a second
+   * credential Blue Dart never issued us", and a 30-combination probe matrix
+   * "confirmed" it — every cell carried `verno`, so every cell failed for the
+   * one reason baked into all of them. Drop `verno` and the same key
+   * authenticates. `verno` is a SHIPPING-API parameter; it has no business on
+   * this endpoint, which is why the published spec's example is the only place
+   * it appears.
+   *
+   * `awb=awb` is a mode selector, not the number — the number rides in
+   * `numbers`. `scan` is required (`1` = full scan detail, `0` = status only);
+   * dropping it makes the gateway reject with a 400 "Request validation error"
+   * before the tracking app ever sees it.
+   *
+   * `tracking_licence_key` (env `BLUE_DART_TRACKING_LICENCE_KEY`) remains an
+   * optional override for the day Blue Dart splits the licences for real. It is
+   * NOT required, and leaving it unset is the normal case.
+   */
+  async trackShipment(awbNumbers: string | string[]): Promise<any> {
+    const numbers = (Array.isArray(awbNumbers) ? awbNumbers : [awbNumbers]).join(
+      ","
+    )
+    const params = new URLSearchParams({
+      handler: "tnt",
+      action: "custawbquery",
+      loginid: this.cfg.login_id,
+      awb: "awb",
+      numbers,
+      format: "json",
+      lickey: this.cfg.tracking_licence_key || this.cfg.licence_key,
+      scan: "1",
+    })
+    const token = await this.getToken()
+    const res = await this.fetchImpl(
+      `${this.baseUrl}${BLUEDART_PATHS.tracking}?${params.toString()}`,
+      { method: "GET", headers: { JWTToken: token } }
+    )
+    const text = await res.text().catch(() => "")
+    if (!res.ok) {
+      throw new BlueDartApiError(
+        `Blue Dart tracking failed (${res.status}): ${text.slice(0, 300)}`
+      )
+    }
+    let json: any
+    try {
+      json = JSON.parse(text)
+    } catch {
+      throw new BlueDartApiError(
+        `Blue Dart tracking returned a non-JSON body: ${text.slice(0, 200)}`
+      )
+    }
+    const shipmentData = json?.ShipmentData ?? json
+    const failure = describeBlueDartFailure(shipmentData)
+    if (failure) {
+      const hint = /licen[cs]e mismatch/i.test(failure)
+        ? " — tracking uses a different licence key from shipping; set BLUE_DART_TRACKING_LICENCE_KEY."
+        : ""
+      throw new BlueDartApiError(`Blue Dart tracking: ${failure}${hint}`, [], json)
+    }
+    return json
+  }
+}

--- a/apps/backend/src/modules/shipping-providers/bluedart/constants.ts
+++ b/apps/backend/src/modules/shipping-providers/bluedart/constants.ts
@@ -1,0 +1,100 @@
+/**
+ * Blue Dart (DHL India) API surface constants.
+ *
+ * Two-layer auth, which is the thing that trips everyone up:
+ *   Layer 1 — the API gateway (`clientID` / `clientSecret` headers) mints a JWT.
+ *   Layer 2 — the shipping account (`LoginID` / `LicenceKey` / `Customercode`)
+ *             travels in the request BODY, inside a `Profile` object.
+ * Having a valid JWT tells you nothing about whether the shipping account is
+ * right, and vice versa.
+ */
+
+export const BLUEDART_CARRIER_ID = "bluedart"
+
+export const BLUEDART_BASE_URL = "https://apigateway.bluedart.com"
+export const BLUEDART_SANDBOX_URL = "https://apigateway-sandbox.bluedart.com"
+
+export const BLUEDART_PATHS = {
+  token: "/in/transportation/token/v1/login",
+  generateWaybill: "/in/transportation/waybill/v1/GenerateWayBill",
+  cancelWaybill: "/in/transportation/waybill/v1/CancelWaybill",
+  registerPickup: "/in/transportation/pickup/v1/RegisterPickup",
+  /**
+   * ⚠️ Two traps in one line, both cost real time on 2026-08-13.
+   *
+   *  1. It is NOT "/pickup/v1/CancelPickup" by symmetry with RegisterPickup —
+   *     cancellation has its own top-level `cancel-pickup` segment.
+   *  2. The published curl stops at `/cancel-pickup/v1`, and that path 415s.
+   *     The operation name must still be appended.
+   *
+   * ⚠️ A wrong path here answers **415 "Access to the method is not allowed"**,
+   * which reads exactly like an unsubscribed-API error and sent us looking for
+   * a subscription problem that did not exist. On this gateway, treat 415 as
+   * "wrong path", not "no access". Verified: this path returns
+   * `{"CancelPickupResult":{"IsError":false,"Status":[{"StatusCode":"CancelSuccess"}]}}`.
+   */
+  cancelPickup: "/in/transportation/cancel-pickup/v1/CancelPickup",
+  servicesForPincode: "/in/transportation/finder/v1/GetServicesforPincode",
+  tracking: "/in/transportation/tracking/v1",
+} as const
+
+/**
+ * Product codes. `H` is the international one (IPC) — the reason Blue Dart can
+ * do what Delhivery's Express integration cannot, and why this adapter has no
+ * `assertDomestic` guard.
+ *
+ * ⚠️ Availability is per-origin-area, not global: product `A` is NOT available
+ * outbound from DHM (Dharamshala, 176215) while `D` is. Never hardcode a
+ * product for a lane without checking `GetServicesforPincode` first.
+ */
+export const BLUEDART_PRODUCT = {
+  /** Domestic priority (DART PLUS / TDD). Available outbound from DHM. */
+  domestic: "D",
+  /** Apex — NOT available outbound from DHM. */
+  apex: "A",
+  /** International IPC (Expedited / Standard). */
+  international: "H",
+  /** International import. */
+  internationalImport: "I",
+} as const
+
+/** Sub-product for the international product. */
+export const BLUEDART_INTL_SUBPRODUCT = "IPC-Expedited"
+
+/** Pickup registration requires a non-empty SubProducts array. */
+export const BLUEDART_PICKUP_SUBPRODUCTS = ["TDD"]
+
+/** Default parcel dimensions (cm). Blue Dart REJECTS a waybill with no Dimensions. */
+export const BLUEDART_DEFAULT_DIMENSIONS = {
+  length: 10,
+  breadth: 10,
+  height: 10,
+}
+
+/**
+ * Microsoft-JSON date, which is what every Blue Dart date field expects:
+ * `/Date(1786657200000)/`. A plain ISO string is silently rejected.
+ */
+export function toMsJsonDate(date: Date | string | number): string {
+  const ms =
+    date instanceof Date
+      ? date.getTime()
+      : typeof date === "number"
+        ? date
+        : new Date(date).getTime()
+  return `/Date(${ms})/`
+}
+
+/** `HH:mm` → `HHmm`, the form the waybill's `PickupTime` wants. */
+export function toBlueDartTime(time?: string): string {
+  const raw = String(time || "16:00").replace(/[^0-9]/g, "")
+  return raw.slice(0, 4).padStart(4, "0")
+}
+
+/** Grams → the two-decimal KG string Blue Dart bills on. */
+export function gramsToKgString(grams?: number): string {
+  const kg = Math.max(Number(grams) || 0, 1) / 1000
+  // Blue Dart treats 0 as a missing weight and rejects the waybill, so the
+  // floor is a token 0.01 kg rather than 0.
+  return Math.max(kg, 0.01).toFixed(2)
+}

--- a/apps/backend/src/modules/shipping-providers/bluedart/index.ts
+++ b/apps/backend/src/modules/shipping-providers/bluedart/index.ts
@@ -1,0 +1,4 @@
+export { BlueDartProviderAdapter, normalizeBlueDartTracking, classifyBlueDartScan } from "./adapter"
+export { BlueDartClient, BlueDartApiError, describeBlueDartFailure } from "./client"
+export * from "./constants"
+export type * from "./types"

--- a/apps/backend/src/modules/shipping-providers/bluedart/types.ts
+++ b/apps/backend/src/modules/shipping-providers/bluedart/types.ts
@@ -1,0 +1,71 @@
+/** Layer-2 credentials — travel in the request BODY, not the headers. */
+export type BlueDartProfile = {
+  Api_type: string
+  Customercode: string
+  LicenceKey: string
+  LoginID: string
+  Version: string
+}
+
+export type BlueDartConfig = {
+  /** Layer-1 gateway credentials, used only to mint the JWT. */
+  client_id: string
+  client_secret: string
+  /** Layer-2 shipping account. */
+  login_id: string
+  licence_key: string
+  customer_code: string
+  api_type?: string
+  version?: string
+  /** Origin area code, e.g. "DHM" for Dharamshala. */
+  origin_area?: string
+  /**
+   * Tracking uses a DIFFERENT licence key from shipping. Probed live on
+   * 2026-08-13: the shipping key returns `{"ShipmentData":{"Error":"License
+   * Mismatch"}}` against the tracking endpoint. Defaults to the shipping key so
+   * the call is at least attempted and fails with a nameable reason.
+   */
+  tracking_licence_key?: string
+  sandbox?: boolean
+  /** Injected transport for tests — the live API mints billable waybills. */
+  fetchImpl?: typeof fetch
+}
+
+/** Status entries Blue Dart returns on nearly every result envelope. */
+export type BlueDartStatus = {
+  StatusCode?: string
+  StatusInformation?: string
+}
+
+export type BlueDartWaybillResult = {
+  AWBNo?: string
+  Status?: BlueDartStatus[]
+  AvailableBalance?: number
+  TransactionAmount?: number
+  DestinationArea?: string
+  IsError?: boolean
+  MPSDetails?: Array<{ MPSNumber?: string }>
+}
+
+export type BlueDartCancelResult = {
+  AWBNo?: string
+  IsError?: boolean
+  Status?: BlueDartStatus[]
+}
+
+export type BlueDartPickupResult = {
+  IsError?: boolean
+  TokenNumber?: string
+  Status?: BlueDartStatus[]
+  ShipmentPickupDate?: string
+}
+
+export type BlueDartServiceabilityResult = {
+  AreaCode?: string
+  CityDescription?: string
+  Region?: string
+  IsError?: boolean
+  Status?: BlueDartStatus[]
+  /** Product availability flags, e.g. `DomesticPriorityOutbound: "Yes"`. */
+  [flag: string]: any
+}

--- a/apps/backend/src/modules/shipping-providers/dhl-unified-tracking.ts
+++ b/apps/backend/src/modules/shipping-providers/dhl-unified-tracking.ts
@@ -1,0 +1,166 @@
+import type { TrackingResult } from "./provider-interface"
+
+/**
+ * DHL **Unified Shipment Tracking** — one API, many carriers.
+ *
+ * Distinct from `dhl/client.ts`, which drives DHL Express's own MyDHL tracking
+ * for shipments WE booked with DHL Express. This one is the developer.dhl.com
+ * unified endpoint: it resolves a tracking number across the DHL group,
+ * **including Blue Dart** (`service: "bluedart"`), from a single API key.
+ *
+ * Why Blue Dart tracking routes through here rather than Blue Dart's own
+ * tracking endpoint: that endpoint authenticates with a licence key SEPARATE
+ * from the shipping licence key, which we do not hold — probed live on
+ * 2026-08-13, it returns `{"ShipmentData":{"Error":"License Mismatch"}}`. The
+ * unified API returns the same scans for the same AWB using the API-gateway key
+ * we already have. One approved key instead of a credential we would have to
+ * chase.
+ *
+ * Verified live 2026-08-13 against AWB 21089967146:
+ * `{"shipments":[{"id":"21089967146","service":"bluedart",…}]}`.
+ */
+
+export const DHL_UNIFIED_TRACKING_URL = "https://api-eu.dhl.com/track/shipments"
+
+export type DhlUnifiedTrackingConfig = {
+  api_key: string
+  /** Injected transport for tests. */
+  fetchImpl?: typeof fetch
+}
+
+export class DhlTrackingError extends Error {
+  readonly status?: number
+  constructor(message: string, status?: number) {
+    super(message)
+    this.name = "DhlTrackingError"
+    this.status = status
+  }
+}
+
+export class DhlUnifiedTrackingClient {
+  private readonly apiKey: string
+  private readonly fetchImpl: typeof fetch
+
+  constructor(cfg: DhlUnifiedTrackingConfig) {
+    this.apiKey = cfg.api_key
+    this.fetchImpl = cfg.fetchImpl || fetch
+  }
+
+  /**
+   * Raw tracking payload for one number.
+   *
+   * `service` narrows the lookup when the number is ambiguous across carriers
+   * (e.g. "bluedart", "express", "parcel-de"). Omitting it lets DHL resolve it,
+   * which is what we want for an AWB whose carrier we already recorded.
+   */
+  async track(trackingNumber: string, service?: string): Promise<any> {
+    const params = new URLSearchParams({ trackingNumber })
+    if (service) params.set("service", service)
+
+    const res = await this.fetchImpl(
+      `${DHL_UNIFIED_TRACKING_URL}?${params.toString()}`,
+      { method: "GET", headers: { Accept: "application/json", "DHL-API-Key": this.apiKey } }
+    )
+    const text = await res.text().catch(() => "")
+    if (res.status === 404) {
+      // A number DHL has never seen. Distinguished from a real failure because
+      // "not found yet" is the NORMAL state for the minutes between generating
+      // a waybill and the carrier's first scan.
+      throw new DhlTrackingError(
+        `DHL has no tracking data for ${trackingNumber} yet — a freshly generated waybill takes a while to appear.`,
+        404
+      )
+    }
+    if (!res.ok) {
+      throw new DhlTrackingError(
+        `DHL unified tracking failed (${res.status}): ${text.slice(0, 300)}`,
+        res.status
+      )
+    }
+    try {
+      return JSON.parse(text)
+    } catch {
+      throw new DhlTrackingError(
+        `DHL unified tracking returned a non-JSON body: ${text.slice(0, 200)}`
+      )
+    }
+  }
+}
+
+/** DHL's own coarse status vocabulary, mapped onto ours. */
+const STATUS_CODE_MAP: Record<string, string> = {
+  "pre-transit": "created",
+  transit: "in_transit",
+  delivered: "delivered",
+  failure: "exception",
+  unknown: "in_transit",
+}
+
+/**
+ * Normalize a unified-tracking payload onto the shape every carrier returns.
+ *
+ * Pure and exported: this is the half worth testing, and it can be pinned
+ * against captured payloads without touching a live account.
+ */
+export function normalizeDhlUnifiedTracking(
+  raw: any,
+  fallbackAwb: string,
+  carrier: string
+): TrackingResult {
+  const shipment = Array.isArray(raw?.shipments) ? raw.shipments[0] : raw?.shipments
+  const locality = (node: any) =>
+    String(node?.location?.address?.addressLocality || node?.address?.addressLocality || "")
+
+  const events = (Array.isArray(shipment?.events) ? shipment.events : []).map(
+    (e: any) => ({
+      timestamp: String(e?.timestamp || ""),
+      // `description` is the human scan text ("PICKUP HAS BEEN REGISTERED");
+      // `status` is a two-letter carrier code ("PU") that means nothing to an
+      // operator reading a timeline.
+      status: String(e?.description || e?.status || e?.statusCode || "").trim(),
+      location: locality(e),
+      scan_type: classifyDhlStatus(e?.statusCode, e?.description),
+    })
+  )
+
+  return {
+    carrier,
+    awb: String(shipment?.id || fallbackAwb),
+    current_status: String(
+      shipment?.status?.description || shipment?.status?.statusCode || ""
+    ).trim(),
+    current_status_code: shipment?.status?.statusCode || undefined,
+    estimated_delivery: shipment?.estimatedTimeOfDelivery || null,
+    origin: locality({ location: shipment?.origin }) || undefined,
+    destination: locality({ location: shipment?.destination }) || undefined,
+    events,
+    raw,
+  }
+}
+
+/**
+ * Classify one scan.
+ *
+ * The description is consulted BEFORE the coarse code, because DHL's
+ * `statusCode` collapses several outcomes we must keep apart: an RTO and a
+ * normal leg both report `transit`, and treating a return as ordinary transit
+ * is how a parcel coming back to us looks like a parcel still going out.
+ *
+ * An unrecognised scan maps to `in_transit`, never `delivered` — same rule as
+ * the Delhivery normalizer (#1206). Guessing delivery closes an order whose
+ * parcel is still moving, and nobody notices until the customer complains.
+ */
+export function classifyDhlStatus(
+  statusCode?: string,
+  description?: string
+): string {
+  const d = String(description || "").toLowerCase()
+  if (/\brto\b|return to origin|returned to shipper/.test(d)) return "returned"
+  if (/out for delivery/.test(d)) return "out_for_delivery"
+  if (/undeliver|delivery attempt failed|refused/.test(d)) return "exception"
+  if (/cancel/.test(d)) return "cancelled"
+  if (/picked up|pickup has been|shipment collected/.test(d)) return "picked_up"
+  if (/delivered/.test(d) && !/undelivered/.test(d)) return "delivered"
+
+  return STATUS_CODE_MAP[String(statusCode || "").toLowerCase()] || "in_transit"
+}

--- a/apps/backend/src/modules/shipping-providers/provider-interface.ts
+++ b/apps/backend/src/modules/shipping-providers/provider-interface.ts
@@ -291,4 +291,4 @@ export interface ShippingProviderClient {
 }
 
 /** Known carrier identifiers persisted on `fulfillment.data.carrier`. */
-export type CarrierId = "delhivery" | "shiprocket"
+export type CarrierId = "delhivery" | "shiprocket" | "bluedart"

--- a/apps/backend/src/modules/shipping-providers/resolver.ts
+++ b/apps/backend/src/modules/shipping-providers/resolver.ts
@@ -24,9 +24,15 @@ import { SOCIALS_MODULE } from "../socials"
 import { CarrierId, ShipmentRef, ShippingProviderClient } from "./provider-interface"
 import { DelhiveryProviderAdapter } from "./delhivery/adapter"
 import { ShiprocketClient } from "./shiprocket/client"
+import { BlueDartProviderAdapter } from "./bluedart/adapter"
+import { DhlUnifiedTrackingClient } from "./dhl-unified-tracking"
 
 /** Carriers `resolveShippingProvider` can return a live client for. */
-export const SUPPORTED_CARRIERS: CarrierId[] = ["delhivery", "shiprocket"]
+export const SUPPORTED_CARRIERS: CarrierId[] = [
+  "delhivery",
+  "shiprocket",
+  "bluedart",
+]
 
 /**
  * True when a carrier has a registered ShippingProviderClient. Consumer routes
@@ -178,6 +184,69 @@ export async function resolveShippingProvider(
         cfg.pickup_location || process.env.SHIPROCKET_PICKUP_LOCATION,
       fetchImpl,
     })
+  }
+
+  if (id === "bluedart") {
+    // Two-layer credentials: the gateway pair mints the JWT, the shipping
+    // account travels in the request body. BOTH are required — a valid JWT with
+    // a wrong LicenceKey fails deep inside the call with "UnauthorizedUser".
+    const clientId =
+      readSecret(cfg, "client_id", encryption) || process.env.BLUE_DART_CLIENT_ID
+    const clientSecret =
+      readSecret(cfg, "client_secret", encryption) ||
+      process.env.BLUE_DART_CLIENT_SECRET
+    const loginId =
+      readSecret(cfg, "login_id", encryption) || process.env.BLUE_DART_LOGIN_ID
+    const licenceKey =
+      readSecret(cfg, "licence_key", encryption) ||
+      process.env.BLUE_DART_LICENCE_KEY
+    const customerCode =
+      cfg.customer_code || process.env.BLUE_DART_CUSTOMER_CODE
+
+    const missing = [
+      !clientId && "BLUE_DART_CLIENT_ID",
+      !clientSecret && "BLUE_DART_CLIENT_SECRET",
+      !loginId && "BLUE_DART_LOGIN_ID",
+      !licenceKey && "BLUE_DART_LICENCE_KEY",
+      !customerCode && "BLUE_DART_CUSTOMER_CODE",
+    ].filter(Boolean)
+    if (missing.length) {
+      throw new MedusaError(
+        MedusaError.Types.UNEXPECTED_STATE,
+        `Blue Dart credentials not configured (missing ${missing.join(", ")})`
+      )
+    }
+
+    // Tracking goes through DHL's unified API when a key is available — Blue
+    // Dart's own tracking endpoint needs a licence key we don't hold. The
+    // gateway client id doubles as the DHL-API-Key.
+    const trackingKey =
+      readSecret(cfg, "dhl_tracking_api_key", encryption) ||
+      process.env.DHL_UNIFIED_TRACKING_API_KEY ||
+      clientId
+
+    return new BlueDartProviderAdapter(
+      {
+        client_id: clientId!,
+        client_secret: clientSecret!,
+        login_id: loginId!,
+        licence_key: licenceKey!,
+        customer_code: customerCode!,
+        api_type: cfg.api_type || process.env.BLUE_DART_API_TYPE,
+        version: cfg.version || process.env.BLUE_DART_VERSION,
+        origin_area: cfg.origin_area || process.env.BLUE_DART_ORIGIN_AREA,
+        tracking_licence_key: process.env.BLUE_DART_TRACKING_LICENCE_KEY,
+        // ⚠️ Blue Dart's sandbox issues SEPARATE shipping credentials — the
+        // production LoginID does NOT work against it ("RequestAuthenticationFailed").
+        // So sandbox mode is only meaningful with sandbox creds configured too.
+        sandbox:
+          (cfg.mode ? cfg.mode === "test" : undefined) ??
+          process.env.BLUE_DART_SANDBOX === "true",
+      },
+      trackingKey
+        ? new DhlUnifiedTrackingClient({ api_key: trackingKey })
+        : undefined
+    )
   }
 
   throw new MedusaError(

--- a/apps/backend/src/scripts/seed-courier-changed-email.ts
+++ b/apps/backend/src/scripts/seed-courier-changed-email.ts
@@ -1,0 +1,79 @@
+/**
+ * Seed: the customer-facing "we changed your courier" email.
+ *
+ * Sent by `cancelShipmentForFulfillment` when an admin voids a waybill — the
+ * customer is the one person guaranteed to notice a tracking link going dead,
+ * and finding that out by clicking it is the worst way to learn.
+ *
+ * Idempotent — creates the row only if `template_key` isn't already present
+ * (active). Mirrors `seed-additional-email-templates.ts` exactly (data inlined
+ * as a const, not a JSON import, so it survives the prod `medusa build` with no
+ * asset-copy dependency).
+ *
+ * ⚠️ Until this has run, the cancel still works: the email send is best-effort
+ * and a missing template is logged, not thrown. `customer_notified: false` in
+ * the response is the signal that this seed is outstanding.
+ *
+ * Run:
+ *   npx medusa exec ./src/scripts/seed-courier-changed-email.ts
+ *   # prod: ./deploy/aws/scripts/run-backfill.sh seed-courier-changed-email
+ */
+import { EMAIL_TEMPLATES_MODULE } from "../modules/email_templates"
+
+export const courierChangedEmailTemplates = [
+  {
+    template_key: "order-courier-changed",
+    name: "Customer — Courier Changed / Shipment Rebooked",
+    template_type: "customer",
+    from: "orders@jaalyantra.com",
+    is_active: true,
+    locale: "en",
+    subject: "A quick update on your order {{order_display_id}}",
+    variables: {
+      customer_name: "Customer's display name",
+      order_display_id: "Human-readable order number, e.g. #1042",
+      order_id: "Internal order id",
+      previous_carrier: "Carrier the cancelled waybill was booked with",
+      current_year: "Year",
+    },
+    // No tracking link and no new AWB on purpose: at send time the replacement
+    // shipment does not exist yet. Promising a link we cannot include is how a
+    // reassuring email becomes a second complaint.
+    html_content: `<div style="font-family:-apple-system,Segoe UI,Roboto,Helvetica,Arial,sans-serif;max-width:560px;margin:0 auto;color:#18181b"><h1 style="font-size:18px;margin:0 0 12px">A quick update on {{order_display_id}}</h1><p style="font-size:14px;line-height:1.6;color:#3f3f46">Hi {{customer_name}}, we hit a problem with the courier booked for your order, so we've cancelled that booking and are arranging your delivery with a different courier partner.</p><div style="background:#f4f4f5;padding:16px 18px;border-radius:10px;margin:16px 0"><p style="font-size:13px;line-height:1.7;color:#3f3f46;margin:0"><strong>Nothing is needed from you.</strong> Your order is safe with us and still on its way. Any tracking link we sent earlier will stop updating — we'll send you a fresh one as soon as the new courier has collected your parcel.</p></div><p style="font-size:14px;line-height:1.6;color:#3f3f46">We're sorry for the delay this may cause. If you'd like an update in the meantime, just reply to this email and we'll check where things stand.</p><p style="font-size:12px;color:#a1a1aa;margin-top:24px">Jaal Yantra Textiles · {{current_year}}</p></div>`,
+  },
+]
+
+export default async function seedCourierChangedEmail({
+  container,
+}: {
+  container: any
+}) {
+  const logger = container.resolve("logger")
+  const svc: any = container.resolve(EMAIL_TEMPLATES_MODULE)
+
+  let created = 0
+  let skipped = 0
+  for (const t of courierChangedEmailTemplates) {
+    const locale = (t as any).locale ?? "en"
+    const [existing] = await svc.listAndCountEmailTemplates({
+      template_key: t.template_key,
+      locale: locale as any,
+      is_active: true,
+    })
+    if (existing && existing.length > 0) {
+      skipped++
+      logger.info(
+        `[seed-courier-changed-email] ⏭ ${t.template_key} (${locale}) exists — skip`
+      )
+      continue
+    }
+    await svc.createEmailTemplates([t])
+    created++
+    logger.info(
+      `[seed-courier-changed-email] ✅ created ${t.template_key} (${locale})`
+    )
+  }
+  logger.info(
+    `[seed-courier-changed-email] done — created=${created} skipped=${skipped}`
+  )
+}

--- a/apps/backend/src/workflows/orders/__tests__/plan-cancelled-fulfillment-data.unit.spec.ts
+++ b/apps/backend/src/workflows/orders/__tests__/plan-cancelled-fulfillment-data.unit.spec.ts
@@ -1,0 +1,102 @@
+import {
+  planCancelledFulfillmentData,
+  type CancelledShipmentRecord,
+} from "../cancel-shipment"
+
+/**
+ * The half of a waybill cancellation that decides what survives on
+ * `fulfillment.data`. Everything else in the flow is a carrier call; this is
+ * the state machine, so it is where the rules get pinned.
+ */
+
+const RECORD: CancelledShipmentRecord = {
+  carrier: "delhivery",
+  awb: "21089967146",
+  cancelled_at: "2026-08-13T04:00:00.000Z",
+  cancelled_by: "ops@jaalyantra.com",
+  reason: "pickup never happened, moving to Blue Dart",
+}
+
+describe("planCancelledFulfillmentData", () => {
+  it("strips every carrier ref so the fulfillment reads as un-labelled", () => {
+    const next = planCancelledFulfillmentData(
+      {
+        carrier: "delhivery",
+        waybill: "21089967146",
+        tracking_number: "21089967146",
+        tracking_url: "https://track/21089967146",
+        label_url: "https://label.pdf",
+        shipment_id: "ship_1",
+        sr_order_id: "sr_1",
+        provider_refs: { waybill: "21089967146" },
+      },
+      RECORD
+    )
+
+    // The "generate label" path keys off these being absent — a leftover would
+    // make the order look shipped and block the re-label it exists to enable.
+    for (const key of [
+      "carrier",
+      "waybill",
+      "tracking_number",
+      "tracking_url",
+      "label_url",
+      "shipment_id",
+      "sr_order_id",
+      "provider_refs",
+    ]) {
+      expect(next).not.toHaveProperty(key)
+    }
+  })
+
+  it("keeps unrelated fulfillment data untouched", () => {
+    const next = planCancelledFulfillmentData(
+      { carrier: "shiprocket", waybill: "AWB1", pickup_location_name: "DHM-Main" },
+      RECORD
+    )
+    expect(next.pickup_location_name).toBe("DHM-Main")
+  })
+
+  it("records the voided AWB, because it is the only handle for reconciling a carrier invoice later", () => {
+    const next = planCancelledFulfillmentData({ waybill: "AWB1" }, RECORD)
+    expect(next.cancelled_shipments).toEqual([RECORD])
+  })
+
+  it("appends rather than overwrites, so a second cancellation keeps the first", () => {
+    const first: CancelledShipmentRecord = { ...RECORD, awb: "FIRST" }
+    const afterOne = planCancelledFulfillmentData({ waybill: "FIRST" }, first)
+
+    const second: CancelledShipmentRecord = { ...RECORD, awb: "SECOND" }
+    const afterTwo = planCancelledFulfillmentData(
+      { ...afterOne, waybill: "SECOND", carrier: "bluedart" },
+      second
+    )
+
+    expect(afterTwo.cancelled_shipments).toEqual([first, second])
+  })
+
+  it("survives a fulfillment that has no data at all", () => {
+    expect(planCancelledFulfillmentData(null, RECORD)).toEqual({
+      cancelled_shipments: [RECORD],
+    })
+    expect(planCancelledFulfillmentData(undefined, RECORD)).toEqual({
+      cancelled_shipments: [RECORD],
+    })
+  })
+
+  it("does not mutate the fulfillment data it was handed", () => {
+    const original = { carrier: "delhivery", waybill: "AWB1" }
+    planCancelledFulfillmentData(original, RECORD)
+    expect(original).toEqual({ carrier: "delhivery", waybill: "AWB1" })
+  })
+
+  it("tolerates a non-array cancelled_shipments rather than throwing on it", () => {
+    // Hand-edited JSONB is a real possibility; a bad shape must not take out a
+    // cancellation the carrier has ALREADY accepted.
+    const next = planCancelledFulfillmentData(
+      { waybill: "AWB1", cancelled_shipments: "corrupted" as any },
+      RECORD
+    )
+    expect(next.cancelled_shipments).toEqual([RECORD])
+  })
+})

--- a/apps/backend/src/workflows/orders/cancel-shipment.ts
+++ b/apps/backend/src/workflows/orders/cancel-shipment.ts
@@ -1,0 +1,336 @@
+import {
+  ContainerRegistrationKeys,
+  MedusaError,
+  Modules,
+} from "@medusajs/framework/utils"
+import type { MedusaContainer } from "@medusajs/framework/types"
+import type { INotificationModuleService } from "@medusajs/types"
+import * as Handlebars from "handlebars"
+import {
+  isSupportedCarrier,
+  resolveShippingProvider,
+  shipmentRefFromFulfillment,
+} from "../../modules/shipping-providers/resolver"
+import { EMAIL_TEMPLATES_MODULE } from "../../modules/email_templates"
+
+/**
+ * Cancel a carrier waybill for a fulfillment, end to end.
+ *
+ * Every carrier client has implemented `cancelShipment` since the #31 provider
+ * spike, and until now NOTHING reached it — no route, no workflow, no UI. The
+ * only callers were a dev script and #1233's internal "a failed AWB assign must
+ * cancel the order it just created". So an operator whose parcel hit a problem
+ * (a pickup that never happens, a partner change, a wrong address caught late)
+ * had a live waybill they could only kill on the carrier's own dashboard, while
+ * our fulfillment went on claiming it.
+ *
+ * The ordering here is the whole design:
+ *
+ *   1. cancel at the CARRIER first,
+ *   2. only then clear the refs from `fulfillment.data`.
+ *
+ * Never the reverse. Clearing first and failing at the carrier would leave a
+ * live, billable waybill that nothing in our system points at any more — which
+ * is precisely the orphan class #1225 was filed for. If the carrier refuses,
+ * this throws and the fulfillment is left exactly as it was.
+ */
+
+/** What a cancellation records about the shipment it retired. */
+export type CancelledShipmentRecord = {
+  carrier?: string
+  awb?: string
+  /** ISO timestamp of the cancellation. */
+  cancelled_at: string
+  /** Admin email that performed it, when known. */
+  cancelled_by?: string
+  reason?: string
+  /** Carrier-side ids, kept so the cancellation can be reconciled later. */
+  provider_refs?: Record<string, any>
+}
+
+/** The carrier keys `createShiprocketShipmentForFulfillment` writes and this clears. */
+const CARRIER_DATA_KEYS = [
+  "carrier",
+  "waybill",
+  "tracking_number",
+  "tracking_url",
+  "label_url",
+  "shipment_id",
+  "sr_order_id",
+  "provider_refs",
+] as const
+
+/**
+ * Pure: the `fulfillment.data` a cancelled shipment leaves behind.
+ *
+ * Strips every carrier ref so the fulfillment reads as un-labelled and the
+ * existing "generate label" path can run again against a different carrier —
+ * and appends an audit entry, because the AWB we just voided is the only handle
+ * anyone has for reconciling a carrier invoice against it later. Losing that on
+ * the way out would make the cancellation itself untraceable.
+ *
+ * Exported for unit testing: this is the half that decides what survives.
+ */
+export function planCancelledFulfillmentData(
+  data: Record<string, any> | null | undefined,
+  record: CancelledShipmentRecord
+): Record<string, any> {
+  const next: Record<string, any> = { ...(data || {}) }
+  for (const key of CARRIER_DATA_KEYS) {
+    delete next[key]
+  }
+  const history = Array.isArray(next.cancelled_shipments)
+    ? next.cancelled_shipments
+    : []
+  next.cancelled_shipments = [...history, record]
+  return next
+}
+
+export type CancelShipmentInput = {
+  orderId: string
+  fulfillmentId: string
+  /** Free-text operator reason; surfaced in the audit entry and the email. */
+  reason?: string
+  /** Acting admin's email, recorded on the audit entry. */
+  actingEmail?: string
+  /**
+   * Cancel even though the fulfillment is already marked shipped. Off by
+   * default: a shipped parcel is physically in the carrier's network, and
+   * voiding its waybill strands a box nobody can route.
+   */
+  force?: boolean
+  /**
+   * Email the customer that we hit a problem and are moving them to another
+   * courier. Defaults to true — the customer is the one person guaranteed to
+   * notice the tracking link going dead.
+   */
+  notifyCustomer?: boolean
+}
+
+export type CancelShipmentResult = {
+  fulfillment_id: string
+  carrier?: string
+  awb?: string
+  cancelled_at: string
+  /** True when a customer email actually went out. */
+  customer_notified: boolean
+  raw?: any
+}
+
+export async function cancelShipmentForFulfillment(
+  container: MedusaContainer,
+  input: CancelShipmentInput
+): Promise<CancelShipmentResult> {
+  const query: any = container.resolve(ContainerRegistrationKeys.QUERY)
+  const fulfillmentModule: any = container.resolve(Modules.FULFILLMENT)
+  const logger: any = container.resolve(ContainerRegistrationKeys.LOGGER)
+
+  const { data: orders } = await query.graph({
+    entity: "order",
+    fields: [
+      "id",
+      "display_id",
+      "email",
+      "currency_code",
+      "shipping_address.first_name",
+      "shipping_address.last_name",
+      "customer.first_name",
+      "customer.last_name",
+      "customer.email",
+      "fulfillments.id",
+      "fulfillments.data",
+      "fulfillments.shipped_at",
+      "fulfillments.canceled_at",
+    ],
+    filters: { id: input.orderId },
+  })
+  const order = orders?.[0]
+  if (!order) {
+    throw new MedusaError(
+      MedusaError.Types.NOT_FOUND,
+      `Order ${input.orderId} not found`
+    )
+  }
+  const fulfillment = (order.fulfillments || []).find(
+    (f: any) => f.id === input.fulfillmentId
+  )
+  if (!fulfillment) {
+    throw new MedusaError(
+      MedusaError.Types.NOT_FOUND,
+      `Fulfillment ${input.fulfillmentId} not found on order ${input.orderId}`
+    )
+  }
+
+  const data = (fulfillment.data || {}) as Record<string, any>
+  const ref = shipmentRefFromFulfillment(data)
+  const carrier = data.carrier as string | undefined
+  const awb = ref.awb
+
+  if (!awb && !ref.provider_refs?.sr_order_id) {
+    throw new MedusaError(
+      MedusaError.Types.INVALID_DATA,
+      `Fulfillment ${input.fulfillmentId} carries no carrier shipment to cancel.`
+    )
+  }
+  if (!isSupportedCarrier(carrier)) {
+    // An AWB attached by hand (#1267's attach flow) or a manual fulfillment has
+    // no carrier API behind it. Say so rather than throwing a resolver error
+    // the operator can do nothing about.
+    throw new MedusaError(
+      MedusaError.Types.NOT_ALLOWED,
+      `Fulfillment ${input.fulfillmentId} has no cancellable carrier${
+        carrier ? ` (carrier "${carrier}")` : ""
+      }. Cancel it directly with the carrier, then detach the AWB here.`
+    )
+  }
+  if (fulfillment.shipped_at && !input.force) {
+    throw new MedusaError(
+      MedusaError.Types.NOT_ALLOWED,
+      `Fulfillment ${input.fulfillmentId} is already marked shipped — the parcel is in ${carrier}'s network. Cancelling its waybill strands the box. Re-send with force if the handover never actually happened.`
+    )
+  }
+
+  const provider = await resolveShippingProvider(container, carrier)
+  if (!provider.cancelShipment) {
+    throw new MedusaError(
+      MedusaError.Types.NOT_ALLOWED,
+      `${carrier} provider does not support cancelling a shipment`
+    )
+  }
+
+  // Carrier FIRST. A throw here leaves the fulfillment untouched, which is the
+  // correct end state: the waybill is still live and still ours.
+  const outcome = await provider.cancelShipment(ref)
+  if (!outcome?.success) {
+    throw new MedusaError(
+      MedusaError.Types.UNEXPECTED_STATE,
+      `${carrier} refused to cancel ${awb || "the shipment"}. The waybill is still live; nothing was changed here.`
+    )
+  }
+
+  const cancelledAt = new Date().toISOString()
+  const record: CancelledShipmentRecord = {
+    carrier,
+    awb,
+    cancelled_at: cancelledAt,
+    cancelled_by: input.actingEmail,
+    reason: input.reason,
+    provider_refs: ref.provider_refs,
+  }
+
+  await fulfillmentModule.updateFulfillment(input.fulfillmentId, {
+    data: planCancelledFulfillmentData(data, record),
+    // Drop the label row too. It isn't cosmetic: the AWB is stamped as a
+    // `fulfillment_label` tracking number precisely because that is the
+    // queryable key the tracking webhook matches carrier pushes on (`data` is
+    // JSONB and can't be filtered). Leaving a dead label behind lets a late
+    // scan for a voided waybill land back on this order.
+    labels: [],
+  })
+
+  logger.info(
+    `[cancel-shipment] cancelled ${carrier} ${awb} on fulfillment ${input.fulfillmentId} (order ${input.orderId})${
+      input.reason ? `: ${input.reason}` : ""
+    }`
+  )
+
+  const customerNotified =
+    input.notifyCustomer === false
+      ? false
+      : await notifyCustomerOfCarrierChange(container, {
+          order,
+          carrier,
+          reason: input.reason,
+        })
+
+  return {
+    fulfillment_id: input.fulfillmentId,
+    carrier,
+    awb,
+    cancelled_at: cancelledAt,
+    customer_notified: customerNotified,
+    raw: outcome.raw,
+  }
+}
+
+/** Template key seeded by `seed-shipment-cancelled-email.ts`. */
+export const CARRIER_CHANGED_TEMPLATE_KEY = "order-courier-changed"
+
+/**
+ * Tell the customer their courier changed. Best-effort by design.
+ *
+ * The waybill is already cancelled at the carrier by the time this runs, and
+ * that is not undoable. Failing the whole operation because a template row is
+ * missing (this key is seeded separately, so it will not exist on an
+ * un-seeded environment) would report "cancel failed" for a cancel that
+ * definitively succeeded — the worst possible lie to tell an operator who now
+ * has to decide whether to retry.
+ */
+async function notifyCustomerOfCarrierChange(
+  container: MedusaContainer,
+  args: { order: any; carrier?: string; reason?: string }
+): Promise<boolean> {
+  const logger: any = container.resolve(ContainerRegistrationKeys.LOGGER)
+  const { order } = args
+  const to = order?.email || order?.customer?.email
+  if (!to) {
+    logger?.warn?.(
+      `[cancel-shipment] order ${order?.id} has no email — customer not notified of the courier change`
+    )
+    return false
+  }
+
+  try {
+    const templates: any = container.resolve(EMAIL_TEMPLATES_MODULE)
+    const template = await templates.getTemplateByKey(
+      CARRIER_CHANGED_TEMPLATE_KEY
+    )
+
+    const name =
+      [order?.shipping_address?.first_name, order?.shipping_address?.last_name]
+        .filter(Boolean)
+        .join(" ")
+        .trim() ||
+      [order?.customer?.first_name, order?.customer?.last_name]
+        .filter(Boolean)
+        .join(" ")
+        .trim() ||
+      "there"
+
+    const templateData = {
+      customer_name: name,
+      order_display_id: order?.display_id ? `#${order.display_id}` : order?.id,
+      order_id: order?.id || "",
+      // Deliberately NOT the operator's free-text reason: it is written for an
+      // internal audit trail ("partner swap", "pickup no-show") and can name
+      // partners, costs or blame. The customer gets the fact and the promise.
+      previous_carrier: args.carrier || "",
+      current_year: String(new Date().getFullYear()),
+    }
+
+    const html = Handlebars.compile(template.html_content)(templateData)
+    const subject = Handlebars.compile(template.subject)(templateData)
+
+    const notifications = container.resolve(
+      Modules.NOTIFICATION
+    ) as INotificationModuleService
+    await notifications.createNotifications({
+      to,
+      channel: "email",
+      template: CARRIER_CHANGED_TEMPLATE_KEY,
+      data: {
+        ...templateData,
+        _template_subject: subject,
+        _template_html_content: html,
+        _template_from: template.from,
+        _template_processed: true,
+      },
+    })
+    return true
+  } catch (e: any) {
+    logger?.warn?.(
+      `[cancel-shipment] could not email the courier change to ${to} for order ${order?.id}: ${e?.message}. The waybill IS cancelled.`
+    )
+    return false
+  }
+}

--- a/apps/docs/notes/BLUEDART_INTEGRATION.md
+++ b/apps/docs/notes/BLUEDART_INTEGRATION.md
@@ -1,0 +1,264 @@
+# Blue Dart integration + carrier waybill cancellation
+
+Status: implemented, **not yet exercised against the live account** beyond
+read-only probes. 2026-08-13.
+
+## Why
+
+Two separate problems, done in one pass because they share the carrier
+abstraction.
+
+1. **Nothing could cancel a waybill.** Every carrier client has implemented
+   `cancelShipment` since the #31 provider spike, and nothing ever reached it —
+   no route, no workflow, no UI. The only callers were a dev script and #1233's
+   internal "a failed AWB assign must cancel the order it just created". An
+   operator whose shipment hit a problem (pickup no-show, partner change, wrong
+   address caught late) had a live waybill they could only kill on the carrier's
+   own dashboard, while our fulfillment went on claiming it.
+2. **Some origins don't work with the incumbent carriers** — the pickup never
+   materialises. Blue Dart serves those lanes, and unlike our Delhivery
+   integration it also has a real export product.
+
+## Part 1 — cancelling a waybill
+
+`cancelShipmentForFulfillment` (`src/workflows/orders/cancel-shipment.ts`), via
+`POST /admin/orders/:id/fulfillments/:fulfillmentId/cancel-shipment`.
+
+**The ordering is the whole design:**
+
+1. cancel at the **carrier** first,
+2. only then clear the refs from `fulfillment.data`.
+
+Never the reverse. Clearing first and then failing at the carrier leaves a live,
+billable waybill that nothing in our system points at — precisely the orphan
+class #1225 was filed for. A carrier refusal throws and leaves the fulfillment
+exactly as it was.
+
+What a successful cancel does:
+
+- strips `carrier`, `waybill`, `tracking_number`, `tracking_url`, `label_url`,
+  `shipment_id`, `sr_order_id`, `provider_refs` from `fulfillment.data`, so the
+  order drops back to un-labelled and the existing Generate-label path can run
+  again on a different carrier;
+- appends `data.cancelled_shipments[]` — `{carrier, awb, cancelled_at,
+  cancelled_by, reason, provider_refs}`. The voided AWB is the only handle for
+  reconciling a carrier invoice later, so losing it would make the cancellation
+  itself untraceable;
+- clears the fulfillment's **labels**. Not cosmetic: the AWB is stamped as a
+  `fulfillment_label` tracking number because that is the queryable key the
+  tracking webhook matches carrier pushes on (`data` is JSONB and can't be
+  filtered). A dead label row lets a late scan for a voided waybill land back
+  on the order;
+- emails the customer (below).
+
+Guards:
+
+- **no AWB** → 400, nothing to cancel;
+- **carrier not API-backed** (a hand-attached AWB, a manual fulfillment) → 400
+  telling the operator to cancel with the carrier directly;
+- **already marked shipped** → refused unless `force: true`. The parcel is
+  physically in the carrier's network and voiding its waybill strands a box
+  nobody can route.
+
+**Admin only, deliberately.** A cancel costs real money at the carrier and the
+partner-change decision that usually motivates it is an admin's to make. There
+is no partner route.
+
+### The customer email
+
+Template key `order-courier-changed`, seeded by
+`src/scripts/seed-courier-changed-email.ts`.
+
+⚠️ **The send is best-effort and must stay that way.** By the time it runs the
+waybill is already cancelled and that is not undoable; failing the operation
+because a template row is missing would report "cancel failed" for a cancel that
+definitively succeeded — the worst possible lie to tell an operator deciding
+whether to retry. `customer_notified: false` in the response is the signal that
+the seed hasn't been run, and both UIs raise a warning toast on it.
+
+The operator's free-text reason is **not** shown to the customer: it is written
+for an internal audit trail ("partner swap", "pickup no-show") and can name
+partners, costs or blame. The email carries the fact and the promise, and no
+tracking link — at send time the replacement shipment does not exist yet.
+
+### UI
+
+- **Retail orders** — `admin/widgets/order-carrier-shipment.tsx`, in the
+  already-labelled branch. Two-step: the reason field doubles as the
+  confirmation gesture.
+- **Design orders** — `admin/routes/design-orders/[id]/page.tsx`, next to the
+  tracking row, behind a `usePrompt` confirm. The design-order payload gained
+  `tracking.fulfillment_id` (additive) because cancel is addressed per
+  fulfillment and that page never knew which one carried the shipment.
+- **Partner UI** — unchanged; partners see the AWB and are pointed at support.
+
+⚠️ `existingAwbOf` in the widget now treats `data` as authoritative once
+anything has been cancelled on that fulfillment, rather than trusting the label
+row. Otherwise a label that didn't clear would keep the widget in its
+"already labelled" branch and block the re-label the feature exists to enable.
+
+## Part 2 — Blue Dart as a provider
+
+`src/modules/shipping-providers/bluedart/` — `client.ts` (transport, token
+cache, envelope unwrapping), `adapter.ts` (`ShippingProviderClient`),
+`constants.ts`, `types.ts`. Registered in `resolver.ts`'s `SUPPORTED_CARRIERS`,
+so it appears in every existing admin surface automatically.
+
+**Not domestic-only.** Product `H` (IPC, sub-product `IPC-Expedited`) is a real
+export product on the same account, so there is no `assertDomestic` guard —
+unlike Delhivery, whose exports run on the separate Cross Border service.
+
+**Waybill and pickup stay separate acts.** `createShipment` sends
+`RegisterPickup: false`; `schedulePickup` books the collection. A waybill can be
+made the night before, but a pickup slot is a commitment for a date and a
+warehouse. Same split settled for Delhivery in #1241.
+
+### Gotchas that are load-bearing
+
+Each of these is pinned by a unit test:
+
+| Trap | What happens if you get it wrong |
+|---|---|
+| `JWTToken` header, **not** `Authorization: Bearer` | 401 |
+| `Profile` must carry `Customercode` **and** `Version` | "UnauthorizedUser" or a null-reference error |
+| `Customercode` is `000001` — not the LoginID, not `DHM000001` | auth fails obscurely |
+| `Dimensions` array mandatory | waybill rejected; we fall back to a nominal 10×10×10 box |
+| `OTPBasedDelivery` must be the **string** `"0"` | numeric `2` demands an OTPCode: "OTP Number cannot be blank" |
+| `Commodity` object required even domestically | rejected |
+| Dates are Microsoft-JSON `/Date(ms)/` | ISO strings are silently rejected |
+| Weights are **KG**, ours are grams; 0 is treated as missing | rejected |
+| Pickup API uses lowercase `request`/`profile`, waybill API uses `Request`/`Profile` | null-reference error, no validation message |
+| `SubProducts` must be non-empty on pickup registration | rejected |
+| Product availability is **per origin area** | `A` is not available outbound from DHM (176215); `D` is |
+| A 200 can still be a failure | check `IsError`, non-`Valid`/`InsertSuccess` `Status[]`, **and** a bare `Error` string |
+| Sandbox has **separate** shipping credentials | production creds return `RequestAuthenticationFailed` |
+
+`checkServiceability` reads the **inbound** flags. Outbound describes what can
+leave that pincode — a fact about the destination's own senders, saying nothing
+about whether our parcel can be delivered there.
+
+### Tracking goes through DHL Unified, not Blue Dart
+
+`src/modules/shipping-providers/dhl-unified-tracking.ts`.
+
+Blue Dart's own *Shipment Tracking (DHL eCommerce India, Blue Dart)* endpoint
+**works with the shipping licence key.** There is no separate tracking
+credential.
+
+```
+GET /in/transportation/tracking/v1
+    ?handler=tnt&action=custawbquery&loginid=DY3585329&awb=awb
+    &numbers=<AWB>&format=json&lickey=<shipping licence key>&scan=1
+    JWTToken: <token>          scan: 1 = full detail, 0 = status only
+```
+
+### ⚠️⚠️ NEVER send `verno` to this endpoint
+
+TnT folds `verno` into its licence check. **Any** value — `1`, `1.3`, anything —
+returns:
+
+```
+→ 200 {"ShipmentData":{"Error":"License Mismatch"}}
+```
+
+Drop `verno` and the *same* key authenticates:
+
+```
+→ 200 {"ShipmentData":{"Error":"Incorrect waybill number or No information"}}
+```
+
+That second error is the service answering about the AWB, not the credential.
+
+This error message blames the wrong thing and it cost a full session. It was
+read as "tracking needs a second licence key Blue Dart never issued us", and a
+**30-combination probe matrix appeared to confirm it** — both paths × `lickey`
+as licence key / consumer key / consumer secret × `loginid` as LoginID /
+customer code / client id × `awb` on/off × `format` json/xml. Every cell carried
+`verno`, so every cell failed for the one reason baked into all of them. A wide
+matrix with a constant defect is not evidence; it is the same experiment run 30
+times. The absence of `verno` is now pinned by a unit test.
+
+`verno` is a *shipping*-API parameter. It appears in the portal's tracking curl
+example, which is where we got it — the example is wrong.
+
+### A cancelled waybill is indistinguishable from a typo
+
+TnT drops cancelled waybills and answers `"Incorrect waybill number or No
+information"` for them — identical to a number that never existed. Observed on
+AWB 21089967146 after its cancellation. **Never report "not found" as "invalid
+AWB"** at this layer; the two cannot be told apart.
+
+DHL Unified *does* retain cancelled-shipment history, which is the one thing it
+gives us that TnT does not:
+
+```
+09:47  pre-transit/PU  Online shipment booked
+09:48  transit/PU      SHIPPER INSTRUCTED TO RTO THE SHIPMENT   ← the cancellation
+10:02  pre-transit/PU  PICKUP HAS BEEN REGISTERED
+```
+
+Note a cancellation surfaces as **shipper-instructed RTO**, not as a "cancelled"
+status — `classifyDhlStatus` reading the description before the coarse
+`statusCode` is what keeps that from looking like ordinary transit.
+
+DHL's Unified Shipment Tracking API returns the same scans for the same AWB
+using the API-gateway key we already have and that is already approved:
+
+```
+GET https://api-eu.dhl.com/track/shipments?trackingNumber=21089967146
+    DHL-API-Key: <gateway client id>
+→ 200 {"shipments":[{"id":"21089967146","service":"bluedart",…}]}
+```
+
+One approved credential beats chasing a second one. The adapter falls back to
+Blue Dart's native endpoint if `BLUE_DART_TRACKING_LICENCE_KEY` is ever set, so
+that path stays open without a code change.
+
+⚠️ `classifyDhlStatus` consults the **description before** the coarse
+`statusCode`, because DHL collapses outcomes we must keep apart: the live probe
+returned `statusCode: "transit"` for `"SHIPPER INSTRUCTED TO RTO THE SHIPMENT"`.
+Treating an RTO as ordinary transit makes a parcel coming *back* look like one
+still going out. An unrecognised scan maps to `in_transit`, never `delivered`
+(#1206's rule).
+
+### Known gaps
+
+- **`getLabel` throws by design.** Blue Dart returns the label PDF inline with
+  the waybill only when `PDFOutputNotRequired` is false, and there is no
+  standalone label-fetch endpoint on the documented surface. Throwing a named
+  error beats returning an empty result the UI renders as a broken link.
+- **No pickup-location registry.** Collections are booked per-AWB against the
+  account's origin area, so `registerPickupLocation` / `listPickupLocations` are
+  deliberately not implemented — a stub returning `[]` would make the
+  carrier-pickups UI claim a location is unregistered when registration isn't a
+  concept here. `carrier-pickups` keeps its own `["shiprocket","delhivery"]`
+  list and is unaffected.
+- **Not registered as a native Medusa fulfillment provider.** This is the
+  `resolveShippingProvider` path only (what every admin route uses), not the
+  `ENABLE_CARRIER_FULFILLMENT` block in `medusa-config.ts`.
+- **A live waybill HAS been generated** — AWB 21089967146, booked 2026-08-13
+  09:47 and cancelled 09:48, with a pickup registered at 10:02. It billed the
+  prepaid account. Earlier drafts of this note and the #1285 handoff claimed no
+  live waybill had ever been generated; that was wrong, and the DHL Unified
+  event history is the receipt. The end-to-end path (book → cancel → pickup) is
+  therefore carrier-proven, not just unit-proven.
+- **No tracking call has returned shipment DATA.** Every live probe hit a
+  cancelled AWB, which TnT will not serve. The credential and query shape are
+  confirmed; a positive-data read needs a live, uncancelled waybill, which costs
+  money to create.
+
+## Env
+
+See `.env.template`. Two layers: the developer.dhl.com gateway pair
+(`BLUE_DART_CLIENT_ID` / `_SECRET`) that mints a 24 h JWT, and the shipping
+account (`BLUE_DART_LOGIN_ID`, `_LICENCE_KEY`, `_CUSTOMER_CODE`) that travels in
+the request body. Both required. The resolver prefers an encrypted
+`shipping_platform.api_config` record and falls back to env, same as the other
+carriers.
+
+## Verify
+
+```bash
+pnpm test:unit --testPathPattern="bluedart-adapter|dhl-unified-tracking|plan-cancelled-fulfillment-data"
+npx medusa exec ./src/scripts/seed-courier-changed-email.ts
+```

--- a/apps/docs/notes/SHIPPING_CARRIER_AUTH.md
+++ b/apps/docs/notes/SHIPPING_CARRIER_AUTH.md
@@ -1,0 +1,151 @@
+# Carrier authentication — Delhivery, Shiprocket, Blue Dart
+
+How each carrier authenticates, where the credentials come from, and what the
+token lifecycle actually is at runtime (which is not what the client code alone
+suggests).
+
+## The short answer on tokens
+
+**Every carrier call mints a fresh token.** Both token-based clients cache
+internally, and both caches are defeated by the same thing: `resolveShippingProvider`
+constructs a **brand-new adapter and client on every call**
+(`resolver.ts` — `return new DelhiveryProviderAdapter(...)` /
+`new ShiprocketClient(...)` / `new BlueDartProviderAdapter(...)`). There is no
+instance cache, no container registration, no module singleton. The client lives
+for one API call and is then garbage.
+
+So the in-client caches only ever help when a *single* client instance makes
+several calls in a row — which today only happens inside a single
+`createShipment` or `schedulePickup`.
+
+| Carrier | Credential | Round trip before the real call? | In-client cache | Effective lifetime |
+|---|---|---|---|---|
+| **Delhivery** | Static API token | **No** — sent directly | n/a | n/a |
+| **Shiprocket** | email + password → JWT | **Yes**, one login | `this.token`, TTL ~10 days | One resolve |
+| **Blue Dart** | clientID + clientSecret → JWT | **Yes**, one login | `cachedToken`, 24 h − 5 min | One resolve |
+
+**This is a real cost, not a theoretical one.** Every Blue Dart label, pickup and
+tracking call pays an extra HTTPS round trip to `/token/v1/login`, and every
+Shiprocket call re-authenticates with email+password. Blue Dart's own token is
+valid for 24 hours; we discard it after one use.
+
+### Why it hasn't been fixed yet
+
+Caching across requests needs somewhere to put the token that outlives the
+request — a module-scoped `Map`, or the container. That is a small change, but it
+is a **correctness** change, not just a speed one: a cached token has to be
+invalidated on 401, on credential rotation via
+`shipping_platform.api_config`, and per-carrier-per-account (the resolver can
+return different credentials for different platform rows). Worth doing
+deliberately rather than as a drive-by.
+
+`ShiprocketClient` already has the hook: `options.token` is documented as
+"inject a token to skip the login round-trip (e.g. cached)" — the resolver simply
+never passes one.
+
+## Where credentials come from
+
+All three resolve **DB-first, env-fallback** (`resolver.ts`):
+
+1. A `shipping_platform` row whose `api_config.provider` / `provider_type` /
+   `name` matches the carrier, case-insensitively.
+2. Each secret prefers the encrypted `<field>_encrypted` blob and falls back to
+   plaintext (`readSecret`), mirroring the google-ads workflow steps.
+3. If no row matches, the `process.env` values are used — the local-dev path.
+
+## Delhivery — static token
+
+```http
+Authorization: Token <api_key>
+```
+
+No login endpoint, nothing to expire, nothing to cache. The simplest of the
+three, and the reason Delhivery calls have no auth failure mode beyond "wrong
+key".
+
+## Shiprocket — email/password → JWT
+
+```
+POST /v1/external/auth/login   { email, password }  →  { token }
+Authorization: Bearer <token>
+```
+
+- Token TTL is ~10 days.
+- `request()` retries **once** transparently on a 401, re-logging in — so an
+  expired injected token self-heals rather than failing the call.
+- ⚠️ Shiprocket's WAF 403s some networks (the office laptop); a VPN clears it.
+  A 403 here is not an auth problem.
+
+## Blue Dart — two layers, and both must be right
+
+This is the one that trips people up. Blue Dart has **two independent
+credentials**, and a valid one of each is required:
+
+```
+GET /in/transportation/token/v1/login
+    clientID: <gateway client id>
+    clientSecret: <gateway client secret>
+ →  { "JWTToken": "..." }
+
+then, on every call:
+    JWTToken: <token>          ← NOT "Authorization: Bearer"
+```
+
+**Layer 1 — the API gateway pair** (`BLUE_DART_CLIENT_ID` / `_CLIENT_SECRET`)
+mints a 24-hour JWT. This says the *application* may call the API.
+
+**Layer 2 — the shipping account** (`BLUE_DART_LOGIN_ID`, `_LICENCE_KEY`,
+`_CUSTOMER_CODE`) travels in the request **body**, inside a `Profile` object.
+This says *which Blue Dart customer* is shipping.
+
+> A valid JWT tells you nothing about whether the shipping account is right, and
+> vice versa. A correct gateway pair with a wrong LicenceKey fails deep inside
+> the call with `UnauthorizedUser`, long after the token succeeded.
+
+### Casing is not consistent across Blue Dart endpoints
+
+| API | Wrapper keys |
+|---|---|
+| Waybill (generate/cancel) | `Request` / `Profile` — **capitalised** |
+| Pickup (register/cancel) | `request` / `profile` — **lowercase** |
+
+Getting this backwards yields a null-reference error or a 500, never a
+validation message. Both were hit live on 2026-08-13.
+
+### Tracking is a third credential story
+
+Blue Dart's TnT endpoint authenticates with the **same shipping licence key** —
+there is no separate tracking credential. But it must be called **without a
+`verno` parameter**: TnT folds `verno` into its licence check, so any value
+returns `{"Error":"License Mismatch"}` — an error that blames the credential for
+a parameter fault. See `BLUEDART_INTEGRATION.md`.
+
+### Sandbox has its own shipping credentials
+
+The sandbox gateway (`apigateway-sandbox.bluedart.com`) accepts the **production
+gateway pair** and mints a JWT happily — then the shipping account returns
+`UserDoesNotExists`. Sandbox issues separate LoginID/LicenceKey values which we
+do not hold, so there is currently **no sandbox path**; everything is exercised
+against production.
+
+## Failure-message decoder
+
+Carrier auth errors are frequently misleading. Observed live:
+
+| Message | What it actually means |
+|---|---|
+| `415 "Access to the method is not allowed"` (Blue Dart) | **Wrong path.** Not a subscription or permission problem — this gateway returns 415 for paths the app can't route to. |
+| `401 "Access to the method is not allowed"` (Blue Dart) | Missing/invalid JWT. |
+| `{"Error":"License Mismatch"}` (Blue Dart TnT) | Usually a stray `verno` parameter, not a bad key. |
+| `UserDoesNotExists` (Blue Dart sandbox) | Production shipping creds against sandbox. |
+| `UnauthorizedUser` (Blue Dart) | Good JWT, wrong LoginID/LicenceKey in the body. |
+| `403` (Shiprocket) | WAF blocking the network, not bad credentials. |
+
+## If you change any of this
+
+- `resolver.ts` is the only place that reads credentials. Adding a carrier means
+  adding a branch there and to `SUPPORTED_CARRIERS`; every admin surface picks it
+  up automatically.
+- Never log a token or a licence key. The Blue Dart licence key is a
+  bearer-equivalent secret: it authorises shipping *and* tracking on a live,
+  billed account.

--- a/apps/docs/notes/starfleet-openapi.json
+++ b/apps/docs/notes/starfleet-openapi.json
@@ -1,0 +1,1748 @@
+{
+  "openapi": "3.0.2",
+  "info": {
+    "title": "Starfleet REST Api",
+    "description": "Exhaustive list of APIs for Starfleet<br><b>Following characters are not allowed in manifest request i.e '&' '&bsol;' '%' '#' ';'</b><br><b>'*'(against field name) denotes Mandatory for Imports</b><br><b>'^'(against field name) denotes Mandatory for Exports</b><br>Our APIs require Authentication.</br>Parameters:<br>1. API Endpoint - <b>https://api-stage-starfleet.delhivery.com/auth/token</b><br>2. Content-Type - application/x-www-form-urlencoded<br>3. grant_type - 'password'<br>4. audience - 'StarFleet'<br>5. scope - \"starfleet openid profile email ^&bsol;/package&bsol;/batchGeneratePackages&bsol;:POST$ ^&bsol;/package&bsol;/batchGeneratePackages&bsol;/.+&bsol;:GET$ ^&bsol;/package&bsol;/auth-track&bsol;/.+&bsol;:GET$ ^&bsol;/package&bsol;/.+&bsol;/invoice&bsol;:GET$ ^&bsol;/package&bsol;/.+&bsol;/shipping-label&bsol;:GET$ ^&bsol;/package&bsol;/.+&bsol;/upload-kyc-doc&bsol;:POST$\". If this Oauth API is executed via code then you have to URL-Encode the \"scope\" parameter  <br>6. client_id (that is shared with you)<br>7. client_secret (that is shared with you)<br>8. username (Your login Username)<br>9. password (Your Login Password)",
+    "version": "1.0.2"
+  },
+  "servers": [
+    {
+      "url": "https://api-stage-starfleet.delhivery.com/package"
+    }
+  ],
+  "tags": [
+    {
+      "name": "Package",
+      "description": "Metadata for shipments."
+    }
+  ],
+  "paths": {
+    "/batchGeneratePackages": {
+      "post": {
+        "tags": [
+          "Package"
+        ],
+        "parameters": [
+          {
+            "name": "id_token",
+            "in": "header",
+            "description": "user identification token",
+            "required": true,
+            "schema": {
+              "type": "string"
+            }
+          }
+        ],
+        "summary": "Batch Job for Package Creation.",
+        "description": "Create packages in bulk.\n",
+        "operationId": "addBulkPackage",
+        "security": [
+          {
+            "bearerAuth": []
+          }
+        ],
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/CreatePackageBatchRequest"
+              },
+              "example": {
+                "packages": [
+                  {
+                    "weight": 50,
+                    "dims": {
+                      "length": 10,
+                      "width": 15,
+                      "height": 20
+                    },
+                    "package_amount": 500,
+                    "total_commodity_value": 500,
+                    "shipment_type": "sample",
+                    "currency": "INR",
+                    "order_no": "UNIQUE_ID_123456",
+                    "client_name": "xxxxx-InternationalAccount-in",
+                    "transaction_type": "B2B",
+                    "payment_mode": "Prepaid",
+                    "cod_amount": 0,
+                    "service_type": "EXPORTS_DLV_SAVER",
+                    "billing_mode": "E",
+                    "battery": false,
+                    "eor": {
+                      "name": "[name]",
+                      "postal": "[address]",
+                      "phone": "+911234567890"
+                    },
+                    "ior": {
+                      "name": "[name]",
+                      "postal": "[address]",
+                      "phone": "+911234567890"
+                    },
+                    "invoice": {
+                      "number": "INV000000001",
+                      "date": "2024-01-20",
+                      "terms": "FOB",
+                      "igst_payment_status": "Paid",
+                      "lut_bond_ref": "LUT0000"
+                    },
+                    "pickup_location": {
+                      "country": "IN",
+                      "name": "[warehouse_name]",
+                      "zip": "400001",
+                      "state": "Maharashtra",
+                      "city": "Mumbai"
+                    },
+                    "delivery_location": {
+                      "postal": "Shipping",
+                      "city": "PARIS",
+                      "state": "PARIS",
+                      "country": "FR",
+                      "zip": "75002",
+                      "address": "[delivery_address]"
+                    },
+                    "bill_to": {
+                      "as_shipto": false,
+                      "name": "[name]",
+                      "address": "[billing_address]",
+                      "city": "PARIS",
+                      "state": "PARIS",
+                      "zip": "75002",
+                      "country": "FR",
+                      "phone": "+911234567890",
+                      "email": "test.user@example.com"
+                    },
+                    "clearance_mode": "courier",
+                    "products": [
+                      {
+                        "desc": "Men's knit jacket",
+                        "quantity": 1,
+                        "item_commodity_value": 100,
+                        "total_amount": 200,
+                        "hsn_code": "84713010",
+                        "euec": false,
+                        "product_amount": 2000,
+                        "meis": false,
+                        "unit_price": 1000,
+                        "igst_rate": 18,
+                        "igst_amount": 18,
+                        "type": "abc",
+                        "contains_artificial_jewellery": false
+                      }
+                    ],
+                    "add_on_services": {
+                      "free_domicile": false,
+                      "signature_pod": false
+                    },
+                    "consignor": {
+                      "name": "[company_name]",
+                      "phone": "+911234567890",
+                      "email": "test.user@example.com",
+                      "type": "Office",
+                      "address": "[address]",
+                      "city": "Gurugram",
+                      "state": "Haryana",
+                      "country": "IN",
+                      "zip": "122003",
+                      "document_id": "[document_id]",
+                      "document_type": "PAN",
+                      "iec": "[iec_code]",
+                      "pan": "[pan_number]",
+                      "gstin": "[gstin_number]",
+                      "bank_ad_code": "[bank_ad_code]",
+                      "bank_ifsc": "[bank_ifsc]",
+                      "bank_ac": "[bank_account]",
+                      "seller_id": "[seller_id]"
+                    },
+                    "consignee": {
+                      "name": "[name]",
+                      "email": "test.user@example.com",
+                      "phone": "+911234567890",
+                      "vat_no": ""
+                    },
+                    "e_waybill": ""
+                  }
+                ]
+              }
+            }
+          },
+          "required": true
+        },
+        "responses": {
+          "200": {
+            "description": "OK",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/CreateTaskApiResponse"
+                }
+              }
+            },
+            "links": {
+              "GetPackageById": {
+                "operationId": "GetBatchPackageJob",
+                "parameters": {
+                  "id": "$response.body.payload.id"
+                },
+                "description": "The Job ID returned can be used to query the status of the job as `id` parameter in `GET /batchCreatePackages/{id}`"
+              }
+            }
+          },
+          "400": {
+            "description": "Bad request",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ApiErrorResponse"
+                }
+              }
+            }
+          },
+          "500": {
+            "description": "Error",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ApiErrorResponse"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/batchGeneratePackages/{id}": {
+      "get": {
+        "tags": [
+          "Package"
+        ],
+        "summary": "Get Status of Batch Package Creation Job.",
+        "description": "Fetches status of an asynchronous task\n",
+        "operationId": "GetBatchPackageJob",
+        "security": [
+          {
+            "bearerAuth": []
+          }
+        ],
+        "parameters": [
+          {
+            "name": "id",
+            "in": "path",
+            "required": true,
+            "style": "simple",
+            "explode": false,
+            "schema": {
+              "$ref": "#/components/schemas/UUID4"
+            }
+          },
+          {
+            "name": "id_token",
+            "in": "header",
+            "description": "user identification token",
+            "required": true,
+            "schema": {
+              "type": "string"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "ok",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/CreatePackageBatchResponse"
+                }
+              }
+            }
+          },
+          "400": {
+            "description": "Bad request",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ApiErrorResponse"
+                }
+              }
+            }
+          },
+          "500": {
+            "description": "Error",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ApiErrorResponse"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/{id}/invoice": {
+      "get": {
+        "tags": [
+          "Package"
+        ],
+        "summary": "Get Invoice of a package with waybill `id`.",
+        "description": "Fetches Invoice of a package\n",
+        "operationId": "GetPackageInvoice",
+        "security": [
+          {
+            "bearerAuth": []
+          }
+        ],
+        "parameters": [
+          {
+            "name": "id",
+            "in": "path",
+            "required": true,
+            "style": "simple",
+            "explode": false,
+            "schema": {
+              "type": "string",
+              "example": "DL00000525CN"
+            }
+          },
+          {
+            "name": "id_token",
+            "in": "header",
+            "description": "user identification token",
+            "required": true,
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "name": "accept",
+            "in": "header",
+            "description": "The content-type of the expected response of the api",
+            "required": true,
+            "schema": {
+              "type": "string",
+              "description": "The response is of type pdf file, hence set this value as 'application/pdf'",
+              "example": "application/pdf"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "ok",
+            "content": {
+              "application/pdf": {
+                "schema": {
+                  "type": "string",
+                  "format": "binary"
+                }
+              }
+            }
+          },
+          "400": {
+            "description": "Bad request",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ApiErrorResponse"
+                }
+              }
+            }
+          },
+          "404": {
+            "description": "Not Found",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ApiErrorResponse"
+                }
+              }
+            }
+          },
+          "500": {
+            "description": "Error",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ApiErrorResponse"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/{id}/shipping-label": {
+      "get": {
+        "tags": [
+          "Package"
+        ],
+        "summary": "Get Shipping Label of a package with waybill `id`.",
+        "description": "Fetches Shipping Label of a package\n",
+        "operationId": "GetPackageShippingLabel",
+        "security": [
+          {
+            "bearerAuth": []
+          }
+        ],
+        "parameters": [
+          {
+            "name": "id",
+            "in": "path",
+            "required": true,
+            "style": "simple",
+            "explode": false,
+            "schema": {
+              "type": "string",
+              "example": "DL00000525CN"
+            }
+          },
+          {
+            "name": "id_token",
+            "in": "header",
+            "description": "user identification token",
+            "required": true,
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "name": "accept",
+            "in": "header",
+            "description": "The content-type of the expected response of the api",
+            "required": true,
+            "schema": {
+              "type": "string",
+              "description": "The response is of type pdf file, hence set this value as 'application/pdf'",
+              "example": "application/pdf"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "ok",
+            "content": {
+              "application/pdf": {
+                "schema": {
+                  "type": "string",
+                  "format": "binary"
+                }
+              }
+            }
+          },
+          "400": {
+            "description": "Bad request",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ApiErrorResponse"
+                }
+              }
+            }
+          },
+          "404": {
+            "description": "Not Found",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ApiErrorResponse"
+                }
+              }
+            }
+          },
+          "500": {
+            "description": "Error",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ApiErrorResponse"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/auth-track/{id}": {
+      "get": {
+        "tags": [
+          "Package"
+        ],
+        "summary": "Fetches list of scan events for one or more waybill(s) (maximum 15 waybills)",
+        "operationId": "PackageTrackAPI",
+        "security": [
+          {
+            "bearerAuth": []
+          }
+        ],
+        "parameters": [
+          {
+            "name": "id",
+            "in": "path",
+            "required": true,
+            "style": "simple",
+            "explode": false,
+            "schema": {
+              "type": "string",
+              "example": "DL00000525CN,DL00000535CN"
+            }
+          },
+          {
+            "name": "id_token",
+            "in": "header",
+            "description": "user identification token",
+            "required": false,
+            "schema": {
+              "type": "string"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Success",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/trackApiResponse"
+                }
+              }
+            }
+          },
+          "400": {
+            "description": "Bad Request",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ApiErrorResponse"
+                }
+              }
+            }
+          },
+          "500": {
+            "description": "Error",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ApiErrorResponse"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/{id}/upload-kyc-doc": {
+      "post": {
+        "tags": [
+          "Package"
+        ],
+        "parameters": [
+          {
+            "name": "dlv-image-type",
+            "in": "header",
+            "required": true,
+            "style": "simple",
+            "explode": false,
+            "schema": {
+              "type": "string",
+              "example": "Front"
+            }
+          },
+          {
+            "name": "Content-Type",
+            "in": "header",
+            "required": true,
+            "style": "simple",
+            "explode": false,
+            "schema": {
+              "type": "string",
+              "example": "image/jpeg"
+            }
+          },
+          {
+            "name": "id",
+            "in": "path",
+            "required": true,
+            "style": "simple",
+            "explode": false,
+            "schema": {
+              "type": "string",
+              "example": "DL00000525CN"
+            }
+          }
+        ],
+        "summary": "Upload KYC documents for a waybill",
+        "description": "Upload KYC document\n",
+        "operationId": "UploadKycDoc",
+        "security": [
+          {
+            "bearerAuth": []
+          }
+        ],
+        "requestBody": {
+          "content": {
+            "image/jpeg": {
+              "schema": {
+                "type": "string",
+                "format": "binary"
+              },
+              "examples": {
+                "sampleFile": {
+                  "summary": "A sample file",
+                  "externalValue": "home/example/example.jpeg"
+                }
+              }
+            },
+            "image/jpg": {
+              "schema": {
+                "type": "string",
+                "format": "binary"
+              },
+              "examples": {
+                "sampleFile": {
+                  "summary": "A sample file",
+                  "externalValue": "home/example/example.jpg"
+                }
+              }
+            },
+            "image/png": {
+              "schema": {
+                "type": "string",
+                "format": "binary"
+              },
+              "examples": {
+                "sampleFile": {
+                  "summary": "A sample file",
+                  "externalValue": "home/example/example.png"
+                }
+              }
+            },
+            "application/pdf": {
+              "schema": {
+                "type": "string",
+                "format": "binary"
+              },
+              "examples": {
+                "sampleFile": {
+                  "summary": "A sample file",
+                  "externalValue": "home/example/example.pdf"
+                }
+              }
+            }
+          },
+          "required": true
+        },
+        "responses": {
+          "200": {
+            "description": "OK",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/KycUploadApiResponse"
+                }
+              }
+            }
+          },
+          "400": {
+            "description": "Bad request",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/KycUploadApiErrorResponse"
+                }
+              }
+            }
+          },
+          "404": {
+            "description": "Bad request",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/KycUploadApiErrorResponse"
+                }
+              }
+            }
+          },
+          "500": {
+            "description": "Error",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/KycUploadApiErrorResponse"
+                }
+              }
+            }
+          }
+        }
+      }
+    }
+  },
+  "components": {
+    "securitySchemes": {
+      "bearerAuth": {
+        "type": "http",
+        "scheme": "bearer",
+        "bearerFormat": "JWT"
+      }
+    },
+    "schemas": {
+      "UPUS10": {
+        "type": "string",
+        "description": "A unique identifier as defined by UPU S10 standard",
+        "example": "DL000000000CN"
+      },
+      "UUID4": {
+        "type": "string",
+        "description": "A unique identifier of the form UUID4",
+        "example": "e99f54a7-d726-42ef-bb02-9c6ebf4003f1"
+      },
+      "Product": {
+        "required": [
+          "desc",
+          "quantity",
+          "item_commodity_value",
+          "total_amount",
+          "hsn_code",
+          "product_amount",
+          "unit_price",
+          "igst_rate",
+          "igst_amount"
+        ],
+        "properties": {
+          "desc*^": {
+            "type": "string",
+            "description": "Description of the item being shipped",
+            "example": "50W Laser Pointer"
+          },
+          "quantity*^": {
+            "type": "integer",
+            "description": "quantity of item",
+            "example": 2
+          },
+          "item_commodity_value*^": {
+            "type": "number",
+            "description": "Item level Commodity/Taxable amount of the product, should be equal to 'product amount'",
+            "example": 200
+          },
+          "total_amount*^": {
+            "type": "number",
+            "description": "Total amount of the item (including tax)",
+            "example": 300
+          },
+          "hsn_code*^": {
+            "type": "string",
+            "description": "8 Digit HSN Code for the product; mandatory for all exports from India; mandatory for B2B,B2B2C imports into India; non-mandatory for B2C, C2C imports into India",
+            "example": "67909019"
+          },
+          "euec": {
+            "type": "boolean",
+            "description": "Flag for Export using E-Commerce. Only valid in case of 'commercial' type of shipment",
+            "example": true
+          },
+          "cu3c": {
+            "type": "string",
+            "description": "Commodity under 3C (only required in case MEIS benefit is marked 'Yes' under 'commercial' type of shipment)",
+            "example": "Leather Footwear",
+            "enum": [
+              "Handicrafts Items/Products",
+              "Handloom Products",
+              "Toys",
+              "Books/Periodicals",
+              "Leather Footwear",
+              "Customised Fashion Garments"
+            ]
+          },
+          "product_amount*^": {
+            "type": "number",
+            "description": "'unit price' multiplied by 'product quantity'",
+            "example": 5000
+          },
+          "meis": {
+            "type": "boolean",
+            "description": "Flag for MEIS benefit. Only valid in case of 'commercial' type of shipment",
+            "example": false
+          },
+          "unit_price*^": {
+            "type": "number",
+            "description": "Price of each unit of product",
+            "example": 400
+          },
+          "igst_rate": {
+            "type": "number",
+            "description": "Integrated GST rate(percent) for product(without percentage symbol) Only valid in case of 'commercial' type of shipment and IGST payment status as 'Paid'",
+            "example": 8,
+            "enum": [
+              0,
+              5,
+              8,
+              12,
+              18,
+              28
+            ]
+          },
+          "igst_amount": {
+            "type": "number",
+            "description": "Integrated GST amount for product or item. Only valid in case of 'commercial' type of shipment and IGST payment status as 'Paid'",
+            "example": 45
+          },
+          "size": {
+            "type": "string",
+            "description": "Size of product",
+            "example": "XL (46)"
+          },
+          "type": {
+            "type": "string",
+            "description": "Type of made of product",
+            "example": "Knitted or Woven"
+          },
+          "composition": {
+            "type": "string",
+            "description": "Composition of the product",
+            "example": "80% Cotton, 20% Polyester"
+          },
+          "sell_weblink": {
+            "type": "string",
+            "description": "Marketplace product weblink for price reference",
+            "example": "https://www.amazon.in/Red-Rose-Stylish-Sports-Shoes/dp/B083CS4LWC/ref=asc_df_B083CS4LWC/?tag=googleshopdes-21&linkCode=df0&hvadid=399395476524&hvpos=&hvnetw=g&hvrand=4411002271417656661&hvpone=&hvptwo=&hvqmt=&hvdev=c&hvdvcmdl=&hvlocint=&hvlocphy=9040175&hvtargid=pla-864285823436&psc=1&language=en_IN&ext_vrnc=hi"
+          },
+          "contains_artificial_jewellery": {
+            "type": "boolean",
+            "description": "Flag to indicate if the product contains artificial jewellery. Optional.",
+            "example": false
+          }
+        },
+        "description": "Metadata associated with a product"
+      },
+      "Contact": {
+        "required": [
+          "name"
+        ],
+        "properties": {
+          "name*^": {
+            "type": "string",
+            "description": "Name for the contact",
+            "example": "[name]"
+          },
+          "email^": {
+            "type": "string",
+            "description": "Email for the contact",
+            "example": "test.user@example.com"
+          },
+          "phone^": {
+            "type": "string",
+            "description": "Phone for the contact",
+            "example": "+911234567890"
+          }
+        },
+        "description": "Metadata for a person acting as the contact for the consignor/consignee/eor/ior"
+      },
+      "RegisteredAddress": {
+        "required": [
+          "pickup_warehouse_id",
+          "country"
+        ],
+        "properties": {
+          "pickup_warehouse_id*^": {
+            "type": "string",
+            "description": "Pickup address ID as provided by Delhivery",
+            "example": "VS_FC_01"
+          },
+          "country*^": {
+            "type": "string",
+            "description": "Country of the postal address in universal 2 letter code format",
+            "example": "IN"
+          }
+        },
+        "description": "Payload for requests against a Starfleet registered address"
+      },
+      "UnregisteredAddress": {
+        "required": [
+          "city",
+          "country",
+          "address",
+          "state",
+          "zip"
+        ],
+        "properties": {
+          "type": {
+            "type": "string",
+            "description": "Type of address",
+            "example": "Office",
+            "enum": [
+              "Office",
+              "Residential"
+            ]
+          },
+          "address*^": {
+            "type": "string",
+            "description": "Complete postal address",
+            "example": "Plot-5, Sector-44"
+          },
+          "city*^": {
+            "type": "string",
+            "description": "City of the postal address",
+            "example": "Gurugram"
+          },
+          "state*^": {
+            "type": "string",
+            "description": "2 or 3 letter State/Region/Province of the postal address. Mandatory only in case of Exports to United States (US) and Canada (CA)",
+            "example": "HR"
+          },
+          "country*^": {
+            "type": "string",
+            "description": "Country of the postal address in universal 2 letter code format",
+            "example": "IN"
+          },
+          "zip*^": {
+            "type": "string",
+            "description": "Pin/Zip code of the postal address",
+            "example": "122003"
+          }
+        },
+        "description": "Payload for requests against unregistered or temporary address"
+      },
+      "PackageMetadata": {
+        "required": [
+          "client_name",
+          "order_no",
+          "consignee",
+          "consignor",
+          "delivery_location",
+          "pickup_location",
+          "products"
+        ],
+        "properties": {
+          "waybill": {
+            "$ref": "#/components/schemas/UPUS10"
+          },
+          "weight^": {
+            "type": "number",
+            "description": "Dead weight of the shipment in grams",
+            "example": 100
+          },
+          "dims^": {
+            "$ref": "#/components/schemas/Product_dim"
+          },
+          "package_amount*^": {
+            "type": "number",
+            "description": "Total package amount after taxes (or selling price). This will be the sum of all amounts calculated at item level and will be the final amount printed on shipping label.",
+            "example": 699.99
+          },
+          "total_commodity_value*^": {
+            "type": "number",
+            "description": "Total value (before tax) of all the commodities inside the shipment. This becomes the customs declared value of the product.",
+            "example": 34.44
+          },
+          "shipment_type*^": {
+            "type": "string",
+            "description": "Type of the shipment.",
+            "example": "sample",
+            "enum": [
+              "document",
+              "gift",
+              "sample",
+              "commercial",
+              "commercial_cargo"
+            ]
+          },
+          "currency*^": {
+            "type": "string",
+            "description": "Currency code of all the amounts",
+            "example": "INR"
+          },
+          "order_no*^": {
+            "type": "string",
+            "description": "Order id of the shipment",
+            "example": "12op90"
+          },
+          "client_name*^": {
+            "type": "string",
+            "description": "Account Name as provided by Delhivery",
+            "example": "GP HANDICRAFTS XB"
+          },
+          "transaction_type": {
+            "type": "string",
+            "description": "Type or nature of transaction for the shipment",
+            "example": "B2C",
+            "enum": [
+              "B2C",
+              "B2B",
+              "C2C",
+              "B2B2C"
+            ]
+          },
+          "payment_mode*^": {
+            "type": "string",
+            "description": "Payment mode for the shipment",
+            "example": "Prepaid",
+            "enum": [
+              "Prepaid",
+              "COD"
+            ]
+          },
+          "cod_amount": {
+            "type": "number",
+            "description": "Amount to be collected by consignee at the time of delivery. Only applicable in case of 'COD'",
+            "example": 100
+          },
+          "service_type*^": {
+            "type": "string",
+            "description": "Type of service for the shipment. Note: EXPORTS_DLV_SAVER is not applicable for document shipments.",
+            "example": "EXPORTS_EXPRESS",
+            "enum": [
+              "EXPORTS_EXPRESS",
+              "EXPORTS_DOCUMENT",
+              "EXPORTS_DEFERRED_EXPRESS",
+              "IMPORTS_EXPRESS",
+              "EXPORTS_DLV_SAVER"
+            ]
+          },
+          "billing_mode": {
+            "type": "string",
+            "description": "Mode of billing for the shipment",
+            "example": "E",
+            "enum": [
+              "E",
+              "S"
+            ]
+          },
+          "battery^": {
+            "type": "boolean",
+            "description": "Boolean indicative if the product is a battery requiring MSDS documentation or otherwise.",
+            "example": true
+          },
+          "eor": {
+            "type": "object",
+            "description": "Details of exporter on record",
+            "properties": {
+              "name": {
+                "type": "string",
+                "description": "Name of Exporter On Record. Mandatory in case of 'transaction type' is 'B2B2C'",
+                "example": "abc"
+              },
+              "postal": {
+                "type": "string",
+                "description": "Complete postal address of Exporter On Record. Mandatory in case of 'transaction type' is 'B2B2C'",
+                "example": "Tsuen Wen, Hongkong"
+              },
+              "phone": {
+                "type": "string",
+                "description": "Contact number of Exporter On Record. andatory in case of 'transaction type' is 'B2B2C'",
+                "example": "+911234567890"
+              }
+            }
+          },
+          "ior": {
+            "type": "object",
+            "description": "Details of importer on record",
+            "properties": {
+              "name": {
+                "type": "string",
+                "description": "Name of Importer On Record. Mandatory in case of 'transaction type' is 'B2B2C'",
+                "example": "abc"
+              },
+              "postal": {
+                "type": "string",
+                "description": "Complete postal address of Importer On Record. Mandatory in case of 'transaction type' is 'B2B2C'",
+                "example": "SEEPS, Andheri East, Mumbai"
+              },
+              "phone": {
+                "type": "string",
+                "description": "Contact number of Importer On Record. andatory in case of 'transaction type' is 'B2B2C'",
+                "example": "+911234567890"
+              }
+            }
+          },
+          "invoice": {
+            "type": "object",
+            "properties": {
+              "number*^": {
+                "type": "string",
+                "description": "Invoice number",
+                "example": "AMP/TI/19-20/1258"
+              },
+              "date*^": {
+                "type": "string",
+                "description": "Invoice date (Format: YYYY-MM-DD)",
+                "example": "2019-09-20"
+              },
+              "terms*^": {
+                "type": "string",
+                "description": "INCOterms for customs invoice",
+                "example": "CIF"
+              },
+              "igst_payment_status": {
+                "type": "string",
+                "description": "IGST payment status. Mandatory only in case of 'commercial' type of shipment",
+                "example": "Paid",
+                "enum": [
+                  "Paid",
+                  "LUT",
+                  "Bond"
+                ]
+              },
+              "lut_bond_ref": {
+                "type": "string",
+                "description": "LUT/Bond reference number. Only required in case IGST Payment Status is 'LUT' or 'Bond'",
+                "example": "07AAHCA12721C7A"
+              }
+            }
+          },
+          "return_location": {
+            "type": "object",
+            "properties": {
+              "address": {
+                "type": "string",
+                "description": "Complete postal address for return",
+                "example": "Plot no 5. Sector-44"
+              },
+              "zip": {
+                "type": "string",
+                "description": "Pin/Zip code of the postal address for return",
+                "example": "122002"
+              }
+            }
+          },
+          "pickup_location": {
+            "type": "object",
+            "oneOf": [
+              {
+                "$ref": "#/components/schemas/RegisteredAddress"
+              },
+              {
+                "$ref": "#/components/schemas/UnregisteredAddress"
+              }
+            ]
+          },
+          "delivery_location*^": {
+            "$ref": "#/components/schemas/UnregisteredAddress"
+          },
+          "bill_to": {
+            "type": "object",
+            "description": "Billing address details. Used when the billing address differs from the shipping address.",
+            "properties": {
+              "as_shipto": {
+                "type": "boolean",
+                "description": "If true, bill_to address is same as ship_to address",
+                "example": false
+              },
+              "name": {
+                "type": "string",
+                "description": "Name of the billing contact",
+                "example": "[name]"
+              },
+              "address": {
+                "type": "string",
+                "description": "Complete billing address",
+                "example": "123 Main Street, Suite 4B"
+              },
+              "city": {
+                "type": "string",
+                "description": "City of the billing address",
+                "example": "PARIS"
+              },
+              "state": {
+                "type": "string",
+                "description": "State/Region/Province of the billing address",
+                "example": "PARIS"
+              },
+              "zip": {
+                "type": "string",
+                "description": "Pin/Zip code of the billing address",
+                "example": "75002"
+              },
+              "country": {
+                "type": "string",
+                "description": "Country code of the billing address (2 letter ISO code)",
+                "example": "FR"
+              },
+              "phone": {
+                "type": "string",
+                "description": "Phone number of the billing contact",
+                "example": "+911234567890"
+              },
+              "email": {
+                "type": "string",
+                "description": "Email of the billing contact",
+                "example": "test.user@example.com"
+              }
+            }
+          },
+          "clearance_mode": {
+            "type": "string",
+            "description": "Type of clearance mode opted for",
+            "example": "courier",
+            "enum": [
+              "courier",
+              "cargo"
+            ]
+          },
+          "products*^": {
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/Product"
+            }
+          },
+          "add_on_services": {
+            "type": "object",
+            "properties": {
+              "free_domicile": {
+                "type": "boolean",
+                "description": "Bill duties and/or taxes to shipper and no amount to be billed to consignee. This is an add on service (with additional charges) provided for exports out of India.",
+                "example": true
+              },
+              "signature_pod": {
+                "type": "boolean",
+                "description": "Mandatory signature POD required at the time of delivery. This is an add on service (with additional charges) provided for exports out of India.",
+                "example": true
+              }
+            }
+          },
+          "consignor*^": {
+            "type": "object",
+            "properties": {
+              "seller_id": {
+                "type": "string",
+                "description": "Actual Seller address ID as provided by Delhivery. All other fields inside this consignor object are not mandatory if this field is filled.",
+                "example": "PO_Handicrafts_1"
+              },
+              "name": {
+                "type": "string",
+                "description": "Name for the shipper/seller",
+                "example": "[company_name]"
+              },
+              "phone": {
+                "type": "string",
+                "description": "Contact number of shipper/seller with country code",
+                "example": "+911234567890"
+              },
+              "email": {
+                "type": "string",
+                "description": "Email for the shipper/seller",
+                "example": "test.user@example.com"
+              },
+              "type": {
+                "type": "string",
+                "description": "Type of address: Office or Residential",
+                "example": "Office",
+                "enum": [
+                  "Office",
+                  "Residential"
+                ]
+              },
+              "address": {
+                "type": "string",
+                "description": "Complete postal address of the shipper/seller as per KYC or customs invoice",
+                "example": "Plot-5, Sector-44"
+              },
+              "city": {
+                "type": "string",
+                "description": "City of the postal address of shipper/seller as per KYC or customs invoice",
+                "example": "Gurugram"
+              },
+              "state": {
+                "type": "string",
+                "description": "State/Region/Province of the postal address of shipper/seller as per KYC or customs invoice",
+                "example": "Haryana"
+              },
+              "country": {
+                "type": "string",
+                "description": "Two letter Country Code of the postal address of shipper/seller",
+                "example": "IN"
+              },
+              "zip": {
+                "type": "string",
+                "description": "Pin/Zip code of the postal address of shipper/seller",
+                "example": "122003"
+              },
+              "document_id": {
+                "type": "string",
+                "description": "ID number of the KYC document of the shipper that is provided to Delhivery",
+                "example": "AMBHGDNKFBG"
+              },
+              "document_type": {
+                "type": "string",
+                "description": "Name of the KYC document of the shipper that is provided to Delhivery",
+                "example": "PAN",
+                "enum": [
+                  "Aadhar",
+                  "Passport",
+                  "Voter ID",
+                  "PAN",
+                  "GST"
+                ]
+              },
+              "iec": {
+                "type": "string",
+                "description": "Importer Exporter Code of the shipper. This is mandatory in case of 'commercial' type of shipment under 'EXPORT' services",
+                "example": "795003556"
+              },
+              "pan": {
+                "type": "string",
+                "description": "PAN number of shipper. This is mandatory in case of 'commercial' type of shipment under 'EXPORT' services.",
+                "example": "AAACT5410T"
+              },
+              "gstin": {
+                "type": "string",
+                "description": "Registered GSTIN number of the shipper. This is mandatory in case of 'commercial' type of shipment under 'EXPORT' services.",
+                "example": "29AAACT5410T2RJ"
+              },
+              "bank_ad_code": {
+                "type": "string",
+                "description": "Authorized Dealer Code of the shipper. Should be 14 digits. This is mandatory in case of 'commercial' type of shipment under 'EXPORT' services.",
+                "example": "01234567891234"
+              },
+              "bank_ifsc": {
+                "type": "string",
+                "description": "Bank IFSC code of the shipper. This is mandatory in case of 'commercial' type of shipment under 'EXPORT' services.",
+                "example": "HDFC0000003"
+              },
+              "bank_ac": {
+                "type": "string",
+                "description": "Bank account no. of the shipper. This is mandatory in case of 'commercial' type of shipment under 'EXPORT' services.",
+                "example": "5010003456792"
+              }
+            }
+          },
+          "consignee*^": {
+            "$ref": "#/components/schemas/Contact"
+          },
+          "e_waybill": {
+            "type": "string",
+            "description": "E-Waybill number, mandatory for movement within India in case total shipment value is greater than 50,000 INR",
+            "example": "1810 0000 1387"
+          }
+        },
+        "description": "Metadata against a package. A package represents a physical shipment being routed via Starfleet"
+      },
+      "CreatePackageBatchRequest": {
+        "description": "Payload to trigger a job to create/manifest shipments in bulk.",
+        "required": [
+          "packages"
+        ],
+        "properties": {
+          "packages": {
+            "maxLength": 500,
+            "minLength": 2,
+            "type": "array",
+            "description": "List/Array of packages to be manifested",
+            "items": {
+              "$ref": "#/components/schemas/PackageMetadata"
+            }
+          },
+          "mps_amount": {
+            "type": "number",
+            "description": "Only valid in case of MPS shipment. Amount that needs to be collected from consignee. Enter 0 in case it is a prepaid shipment"
+          },
+          "no_of_pieces": {
+            "type": "number",
+            "description": "Only mandatory in case of MPS shipment. Enter total number of boxes associated with the shipment. The number entered will generate as many number of airwaybills associated with 1 master airwaybill. Leave blank in case of only 1 box."
+          },
+          "master_waybill": {
+            "type": "string",
+            "description": "Master Waybill for MPS Shipment. Only valid in case of MPS shipment."
+          }
+        }
+      },
+      "ApiResponse": {
+        "required": [
+          "payload"
+        ],
+        "type": "object",
+        "properties": {
+          "payload": {
+            "type": "object",
+            "description": "Actual payload containing results of actions implemented by API"
+          },
+          "message": {
+            "type": "string",
+            "description": "Any metadata to explain status of the job such as error codes on a FAILED job",
+            "example": "ok"
+          }
+        },
+        "description": "Common structure for any Api response"
+      },
+      "ApiErrorResponse": {
+        "allOf": [
+          {
+            "$ref": "#/components/schemas/ApiResponse"
+          },
+          {
+            "required": [
+              "message"
+            ],
+            "properties": {
+              "message": {
+                "type": "string",
+                "example": "error message"
+              }
+            }
+          }
+        ]
+      },
+      "CreateTaskApiResponse": {
+        "description": "Common structure for any asynchronous Api response.",
+        "allOf": [
+          {
+            "$ref": "#/components/schemas/ApiResponse"
+          },
+          {
+            "type": "object",
+            "properties": {
+              "payload": {
+                "$ref": "#/components/schemas/CreateTaskApiResponse_payload"
+              }
+            }
+          }
+        ]
+      },
+      "TaskStatusResponse": {
+        "description": "Common structure for any API that indicate the status of a previously triggered task",
+        "allOf": [
+          {
+            "$ref": "#/components/schemas/CreateTaskApiResponse"
+          },
+          {
+            "type": "object",
+            "properties": {
+              "payload": {
+                "$ref": "#/components/schemas/TaskStatusResponse_payload"
+              }
+            }
+          }
+        ]
+      },
+      "CreatePackageBatchResponse": {
+        "allOf": [
+          {
+            "$ref": "#/components/schemas/TaskStatusResponse"
+          },
+          {
+            "type": "object",
+            "properties": {
+              "payload": {
+                "$ref": "#/components/schemas/CreatePackageBatchResponse_payload"
+              }
+            }
+          }
+        ]
+      },
+      "trackApiResponse": {
+        "description": "Response for track waybill",
+        "allOf": [
+          {
+            "$ref": "#/components/schemas/ApiResponse"
+          },
+          {
+            "type": "object",
+            "properties": {
+              "payload": {
+                "$ref": "#/components/schemas/trackApiResponse_payload"
+              }
+            }
+          }
+        ]
+      },
+      "Product_dim": {
+        "required": [
+          "height",
+          "length",
+          "width"
+        ],
+        "type": "object",
+        "properties": {
+          "length^": {
+            "type": "number",
+            "description": "Length in centimeters",
+            "example": 10
+          },
+          "width^": {
+            "type": "number",
+            "description": "Width in centimeters",
+            "example": 4
+          },
+          "height^": {
+            "type": "number",
+            "description": "Height in centimeters",
+            "example": 2
+          }
+        },
+        "description": "Dimentions of the shipment"
+      },
+      "CreateTaskApiResponse_payload": {
+        "required": [
+          "id"
+        ],
+        "type": "object",
+        "properties": {
+          "id": {
+            "type": "string",
+            "description": "Unique identifier/reference for the job/task created",
+            "example": "534530f6-7d5a-4011-adfe-e73a2a43f700"
+          }
+        }
+      },
+      "TaskStatusResponse_payload": {
+        "required": [
+          "data",
+          "status"
+        ],
+        "type": "object",
+        "properties": {
+          "status": {
+            "type": "string",
+            "description": "Status of a job/task",
+            "example": "COMPLETED",
+            "enum": [
+              "IN_PROCESS",
+              "COMPLETED",
+              "FAILED"
+            ]
+          },
+          "data": {
+            "type": "object",
+            "description": "Paginated results of task action"
+          }
+        }
+      },
+      "CreatePackageBatchResponse_payload": {
+        "type": "object",
+        "properties": {
+          "data": {
+            "type": "object",
+            "properties": {
+              "total_count": {
+                "type": "string",
+                "description": "Total count of packages that are being processed for manifestation",
+                "example": 10
+              },
+              "error_count": {
+                "type": "string",
+                "description": "count of packages that failed to be manifested",
+                "example": 5
+              },
+              "success_count": {
+                "type": "string",
+                "description": "count of packages that successfully manifested",
+                "example": 5
+              },
+              "error_waybills": {
+                "type": "array",
+                "items": {
+                  "type": "object",
+                  "properties": {
+                    "result": {
+                      "type": "boolean",
+                      "description": "denotes fail status of package",
+                      "example": false
+                    },
+                    "waybill": {
+                      "type": "string",
+                      "description": "AWB No",
+                      "example": "DL00000000CN"
+                    },
+                    "order_id": {
+                      "type": "string",
+                      "description": "Order ID",
+                      "example": "111"
+                    },
+                    "reason": {
+                      "type": "string",
+                      "description": "denotes reason for why package could not be manifested",
+                      "example": "Client Name mismatch"
+                    }
+                  }
+                }
+              },
+              "success_waybills": {
+                "type": "array",
+                "items": {
+                  "type": "object",
+                  "properties": {
+                    "result": {
+                      "type": "boolean",
+                      "description": "denotes fail status of package",
+                      "example": false
+                    },
+                    "waybill": {
+                      "type": "string",
+                      "description": "AWB No",
+                      "example": "DL00000000CN"
+                    },
+                    "order_id": {
+                      "type": "string",
+                      "description": "Order ID",
+                      "example": "111"
+                    }
+                  }
+                }
+              }
+            }
+          }
+        }
+      },
+      "trackApiResponse_payload_scans": {
+        "type": "object",
+        "properties": {
+          "city": {
+            "type": "string",
+            "example": "CN_Shenzen_P"
+          },
+          "state": {
+            "type": "string",
+            "example": "Shenzen"
+          },
+          "country": {
+            "type": "string",
+            "example": "CHN"
+          },
+          "time": {
+            "type": "string",
+            "example": "1566209100"
+          },
+          "action": {
+            "type": "string",
+            "example": "INT-PKG-MANF"
+          },
+          "remarks": {
+            "type": "string",
+            "example": "Package Manifestation Done"
+          }
+        }
+      },
+      "trackApiResponse_waybillFound_payload": {
+        "type": "object",
+        "properties": {
+          "waybill": {
+            "$ref": "#/components/schemas/UPUS10"
+          },
+          "scans": {
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/trackApiResponse_payload_scans"
+            }
+          },
+          "shipment_type": {
+            "type": "string",
+            "example": "sample_or_gift"
+          },
+          "is_master": {
+            "type": "boolean",
+            "example": "true",
+            "description": "True if it is an mps master shipment. Note- this key will only be present when shipment_type is MPS"
+          },
+          "related_wbns": {
+            "type": "array",
+            "description": "List of Related AWB's of a MPS shipment. Note- this key will only be present when shipment_type is MPS",
+            "items": {
+              "type": "string",
+              "example": "DL00000000CN"
+            }
+          },
+          "master_wbn": {
+            "type": "string",
+            "description": "Master AWB of a MPS shipment. Note- this key will only be present when shipment_type is MPS",
+            "example": "DL00000000CN"
+          },
+          "origin": {
+            "type": "string",
+            "example": "testwarehouse"
+          },
+          "destination": {
+            "type": "object",
+            "properties": {
+              "address*^": {
+                "type": "string",
+                "description": "Complete postal address",
+                "example": "Plot-5, Sector-44"
+              },
+              "city*^": {
+                "type": "string",
+                "description": "City of the postal address",
+                "example": "Gurugram"
+              },
+              "state*^": {
+                "type": "string",
+                "description": "State/Region/Province of the postal address",
+                "example": "Haryana"
+              },
+              "country*^": {
+                "type": "string",
+                "description": "Country of the postal address",
+                "example": "IN"
+              },
+              "zip*^": {
+                "type": "string",
+                "description": "Pin code of the postal address",
+                "example": "122003"
+              }
+            }
+          }
+        }
+      },
+      "trackApiResponse_waybillNotFound_payload": {
+        "type": "object",
+        "properties": {
+          "waybill": {
+            "$ref": "#/components/schemas/UPUS10"
+          },
+          "status": {
+            "type": "string",
+            "example": "DL00000000CN Details not found"
+          }
+        }
+      },
+      "trackApiResponse_payload": {
+        "type": "object",
+        "properties": {
+          "waybills_found": {
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/trackApiResponse_waybillFound_payload"
+            }
+          },
+          "waybills_not_found": {
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/trackApiResponse_waybillNotFound_payload"
+            }
+          }
+        }
+      },
+      "KycUploadApiResponse": {
+        "required": [
+          "payload"
+        ],
+        "type": "object",
+        "properties": {
+          "success": {
+            "type": "boolean",
+            "description": "Boolean value if image upload was succesful or not",
+            "example": true
+          },
+          "message": {
+            "type": "string",
+            "description": "Data to indicate reason of failure or indicate success",
+            "example": "ok"
+          }
+        },
+        "description": "Common structure for any Api response"
+      },
+      "KycUploadApiErrorResponse": {
+        "required": [
+          "payload"
+        ],
+        "type": "object",
+        "properties": {
+          "success": {
+            "type": "boolean",
+            "description": "Boolean value if image upload was succesful or not",
+            "example": false
+          },
+          "message": {
+            "type": "string",
+            "description": "Data to indicate reason of failure or indicate success"
+          }
+        },
+        "description": "Common structure for any Api response"
+      }
+    }
+  }
+}

--- a/apps/partner-ui/src/routes/orders/order-create-shipment/components/order-create-shipment-form/constants.ts
+++ b/apps/partner-ui/src/routes/orders/order-create-shipment/components/order-create-shipment-form/constants.ts
@@ -13,6 +13,11 @@ import { z } from "@medusajs/framework/zod"
 export const SHIPMENT_CARRIERS = [
   { value: "shiprocket", label: "Shiprocket" },
   { value: "delhivery", label: "Delhivery", domesticOnly: true },
+  // Blue Dart is NOT domestic-only: product "H" (IPC) is a real export product
+  // on the same account. Must stay in step with the admin twin at
+  // `apps/backend/src/admin/lib/shipment-carriers.ts` — both pickers drive the
+  // same backend, whose `SUPPORTED_CARRIERS` is the real authority.
+  { value: "bluedart", label: "Blue Dart" },
 ] as const
 
 /** True when a destination country is outside India (mirrors the backend). */

--- a/apps/partner-ui/src/routes/orders/order-detail/components/order-fulfillment-section/order-fulfillment-section.tsx
+++ b/apps/partner-ui/src/routes/orders/order-detail/components/order-fulfillment-section/order-fulfillment-section.tsx
@@ -291,7 +291,29 @@ const Fulfillment = ({
   const { mutateAsync: schedulePickup, isPending: isPickupPending } =
     useSchedulePickup(order.id, fulfillment.id)
 
-  const isDelhivery = (fulfillment as any).data?.carrier === "delhivery"
+  // Carriers whose pickup can be booked from here. Blue Dart books collections
+  // through the same route as Delhivery, so gating on `delhivery` alone left a
+  // Blue Dart shipment with a waybill and no way to summon a courier.
+  const CARRIERS_WITH_PICKUP = ["delhivery", "bluedart"]
+  const supportsPickup = CARRIERS_WITH_PICKUP.includes(
+    (fulfillment as any).data?.carrier
+  )
+
+  // A booking with no carrier reference is still a booking — Blue Dart returns
+  // its handle as a token and some carriers return nothing identifying at all.
+  // Gating on `pickup_id` alone would re-offer the form for a collection that is
+  // already scheduled, and a second courier would be dispatched.
+  const bookedPickup = (fulfillment as any).metadata?.pickup_date
+    ? {
+        pickup_id: (fulfillment as any).metadata?.pickup_id as
+          | string
+          | undefined,
+        pickup_date: (fulfillment as any).metadata.pickup_date as string,
+        pickup_time: (fulfillment as any).metadata?.pickup_time as
+          | string
+          | undefined,
+      }
+    : null
   const hasWaybill = !!(fulfillment as any).data?.waybill
 
   // #1195: `requires_shipping` is NOT a reliable gate. It is derived from
@@ -318,11 +340,11 @@ const Fulfillment = ({
     !fulfillment.canceled_at && !fulfillment.delivered_at
 
   const showPickupButton =
-    isDelhivery &&
+    supportsPickup &&
     hasWaybill &&
     !fulfillment.canceled_at &&
     !fulfillment.delivered_at &&
-    !(fulfillment as any).metadata?.pickup_id
+    !bookedPickup
 
   const handleFetchLabel = async () => {
     try {
@@ -450,14 +472,21 @@ const Fulfillment = ({
           })}
         </Heading>
         <div className="flex items-center gap-x-4">
-          {(fulfillment as any).metadata?.pickup_id && (
+          {bookedPickup && (
             <StatusBadge color="blue" className="text-nowrap">
               Pickup Scheduled
-              {(fulfillment as any).metadata?.pickup_date &&
-                ` — ${format(
-                  new Date((fulfillment as any).metadata.pickup_date),
-                  "dd MMM, HH:mm"
-                )}`}
+              {` — ${format(
+                // `pickup_date` is date-ONLY ("2026-08-14"); the slot is in
+                // `pickup_time`. Parsing the date alone rendered every booked
+                // pickup as "14 Aug, 00:00" — a midnight collection nobody
+                // scheduled.
+                new Date(
+                  `${bookedPickup.pickup_date}T${
+                    bookedPickup.pickup_time || "00:00"
+                  }:00`
+                ),
+                bookedPickup.pickup_time ? "dd MMM, HH:mm" : "dd MMM"
+              )}`}
             </StatusBadge>
           )}
           <Tooltip


### PR DESCRIPTION
Closes #1285.

A booked waybill could not be called off from the platform. When a courier fell
through or an order changed partner, the AWB stayed live at the carrier and kept
billing. This adds the cancel path, adds Blue Dart as a third carrier, and fixes
the reason none of the pickup state ever survived a page refresh.

## Cancel a waybill

**The order of operations is the design: cancel at the CARRIER first, then clear
our refs.** The reverse leaves a live billable waybill that nothing in the
platform points at any more — an orphan we cannot even find in order to cancel
it. A carrier refusal therefore leaves the waybill attached, which is the
recoverable state.

Deliberate scope calls:

- **Admin-only.** Partners create shipments but do not void them.
- **The fulfillment is KEPT.** Cancelling a waybill is not cancelling a
  fulfillment — the goods still need to go out, usually via another carrier.
- **The customer email is best-effort**, reported as `customer_notified`, so a
  mail failure never blocks the carrier cancel.

## Blue Dart

Waybill generate/cancel, pickup register/cancel and tracking, all verified live
against the production gateway (founder-authorised; ₹400.01 spent, nothing left
live).

Tracking works with **the shipping licence key we already hold** — the
long-standing "we need a second licence key" belief was wrong. The blocker was
the **`verno`** parameter: TnT folds it into its licence check, so any value
returns `"License Mismatch"`, an error that blames the credential for a
parameter fault. Its absence is now pinned by a unit test.

Two published-doc shapes that are simply wrong:

| | Reality |
|---|---|
| Cancel waybill | Needs **capitalised** `Request`/`Profile`; pickup uses lowercase. Lowercase → 500. |
| Cancel pickup | `/cancel-pickup/v1/**CancelPickup**`. Our constant and the published curl both omit the operation segment. |

⚠️ On this gateway a **wrong path answers 415 "Access to the method is not
allowed"** — indistinguishable from an unsubscribed API. Treat 415 as wrong
path, not no access.

## The pickup persistence bug

Both pickup routes booked the collection and **persisted nothing**. One omission,
three bugs that looked separate: the partner UI gated on a
`fulfillment.metadata.pickup_id` nothing ever wrote; the admin widget held the
booking in `useState` and lost it on refresh; and **the cancellation token was
discarded** — the only handle that can call a booked collection off.

Bookings now write to `fulfillment.metadata` with a `pickup_bookings[]` history,
so a rebooking cannot erase a still-live token. Best-effort, surfacing
`pickup_persisted: false` rather than pretending it stuck.

Three more fell out of the same path:

- Partner pickup was gated `carrier === "delhivery"` ⇒ a Blue Dart shipment could
  get a waybill and then have **no way to summon a courier**.
- `pickup_date` is date-only ⇒ every booked pickup rendered as `00:00`.
- `schedulePickup` sent `"14:00"` where Blue Dart wants `1400`. `createShipment`
  normalised this; the one call that actually dispatches a courier did not.

## Verify

```
pnpm test:unit --testPathPattern="bluedart|dhl-unified|plan-cancelled|persist-pickup"   # 51 pass
npx tsc --noEmit -p apps/backend/tsconfig.json                                          # 79 (baseline)
```

## Post-deploy

1. Seed the courier-changed email template (`seed-courier-changed-email`).
2. Provision Blue Dart credentials (env, or an encrypted
   `shipping_platform.api_config` row).

## Watch-outs

- ⚠️ **Verify the undo before running the do** on any billable carrier call.
- ⚠️ International waybills still send `HSCode: ""` when a product has no HS code
  — **#1223**, 65/75 products. International is not really shippable until that
  lands.
- ⚠️ Blue Dart's **sandbox is unusable**: production creds mint a JWT, then the
  shipping account returns `UserDoesNotExists`. Sandbox issues its own shipping
  credentials, which we do not hold.
- ⚠️ `Remarks` on the pickup API rejects non-alphanumerics (an em dash →
  "Invalid value in Remarks parameter"). Repeat bookings dedupe to one token.
- ⚠️ `getLabel` throws by design for Blue Dart — there is no standalone label
  endpoint.
- 🔑 `AWBNo: [""]` is accepted on RegisterPickup, so the pickup legs can be
  exercised for free. Our adapter is stricter than Blue Dart here.

`apps/docs/notes/starfleet-openapi.json` is Delhivery cross-border research
(#649) parked so it survives; unrelated to this code.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
