### PR TITLE
feat(catalog): bulk product + variant + inventory updates on both MCP surfaces (#1287)

### DIFF
--- a/apps/backend/src/api/admin/mcp/lib/__tests__/tool-slice.unit.spec.ts
+++ b/apps/backend/src/api/admin/mcp/lib/__tests__/tool-slice.unit.spec.ts
@@ -230,4 +230,26 @@ describe("admin-mcp per-ask tool slicing", () => {
       expect(slice.names).toContain("bulk_set_hs_codes")
     })
   })
+
+  describe("bulk product editing reaches the catalog slice", () => {
+    it("classifies bulk_update_products as catalog", () => {
+      const byName = new Map(ADMIN_MCP_TOOLS.map((t) => [t.name, t]))
+      expect(toolDomain(byName.get("bulk_update_products")!)).toBe("catalog")
+    })
+
+    // The tool lives under /admin/products and so classifies as catalog, but
+    // the asks that need it are usually phrased in INVENTORY words. Each of
+    // these would match only the inventory slice on its nouns alone, and the
+    // one tool that can serve them would never load.
+    it.each([
+      "zero the stock on everything",
+      "set stock to zero for all products",
+      "start tracking stock on the whole range",
+      "turn on manage inventory for every product",
+      "bulk update these products and their variants",
+    ])("activates it for: %s", (ask) => {
+      const slice = selectAdminToolSlice(ask, ADMIN_MCP_TOOLS)
+      expect(slice.names).toContain("bulk_update_products")
+    })
+  })
 })

--- a/apps/backend/src/api/admin/mcp/lib/registry.ts
+++ b/apps/backend/src/api/admin/mcp/lib/registry.ts
@@ -36,6 +36,8 @@ export { renderToolGuidance } from "../../../../lib/mcp-core"
 // ---- Reusable JSON-Schema fragments ---------------------------------------
 
 const STR = (description: string) => ({ type: "string", description })
+const BOOL = (description: string) => ({ type: "boolean", description })
+const INT = (description: string) => ({ type: "integer", description })
 
 const obj = (
   properties: Record<string, any>,
@@ -333,6 +335,124 @@ export const ADMIN_MCP_TOOLS: AdminMcpToolDef[] = [
       ["id"]
     ),
     sideEffects: "Publishing a product makes it live on the storefront.",
+  },
+  {
+    name: "bulk_update_products",
+    description: [
+      "Update MANY products, their variants and their stock levels in one call. Sensitive: requires confirm:true. ALWAYS dry_run first — the plan names every product and variant it would touch, with the before/after quantity at each location, and there is no undo once it fires.",
+      "Returns a PER-ROW outcome: one bad id never discards the rest of the batch, so read `variants`, `products` and `warnings` rather than just the status.",
+      "",
+      "TARGETING — combine freely:",
+      "- `products: [{ product_id, update, variants }]` for named products. Omit a product's `variants` key to mean EVERY variant of it.",
+      "- `selector` for filter-based batches: `{ all: true }`, `collection_id`, `category_id`, `status`, `product_ids`. This is how 'zero the whole catalogue' is one call. `all: true` must be passed explicitly — the selector will not default to everything.",
+      "- `product_update` / `variant_update` apply to everything selected; a per-row `update` wins over them.",
+      "",
+      "INVENTORY — `set_inventory: { quantity, ensure_managed, location_ids }`:",
+      "- `quantity` is ABSOLUTE, not a delta. 0 zeroes the stock.",
+      "- 🔑 `ensure_managed: true` is what makes this work on untracked variants. Medusa CANNOT turn inventory tracking on for a variant that already exists — core only ever turns it off — so a variant with `manage_inventory: false` has no inventory item and nothing to stock. With this flag the tool creates the inventory item, links it to the variant, seeds the levels, then writes the quantity. Without it, untracked variants come back `skipped` and their stock is untouched.",
+      "- `location_ids` defaults to every location on the scoping sales channel.",
+      "",
+      "⚠️ `manage_inventory: false` is REFUSED here. Core dismisses the variant's inventory item and its levels with it, with no undo, so it is not something to do to a whole selector. Use `update_product_variant` one variant at a time.",
+      "Capped at 200 products per call.",
+    ].join("\n"),
+    method: "POST",
+    path: "/admin/products/bulk-update",
+    write: true,
+    sensitive: true,
+    bodyParams: [
+      "products",
+      "selector",
+      "product_update",
+      "variant_update",
+      "set_inventory",
+      "dry_run",
+    ],
+    inputSchema: obj({
+      products: {
+        type: "array",
+        description:
+          "Named products. Omit a row's `variants` to target every variant of it.",
+        items: {
+          type: "object",
+          properties: {
+            product_id: STR("Product id, e.g. 'prod_...'."),
+            update: {
+              type: "object",
+              description:
+                "Product fields to change (title, subtitle, description, handle, status, material, hs_code, weight, metadata, …).",
+              additionalProperties: true,
+            },
+            variants: {
+              type: "array",
+              description:
+                "Specific variants only. Omit the key entirely to mean all of them.",
+              items: {
+                type: "object",
+                properties: {
+                  variant_id: STR("Variant id, e.g. 'variant_...'."),
+                  update: {
+                    type: "object",
+                    description:
+                      "Variant fields to change (title, sku, hs_code, origin_country, material, allow_backorder, weight, metadata, …).",
+                    additionalProperties: true,
+                  },
+                },
+                required: ["variant_id"],
+                additionalProperties: false,
+              },
+            },
+          },
+          required: ["product_id"],
+          additionalProperties: false,
+        },
+      },
+      selector: {
+        type: "object",
+        description:
+          "Filter-based targeting. Must narrow something; pass all: true to mean the whole catalogue.",
+        properties: {
+          all: BOOL("Every product in scope. Say this explicitly."),
+          product_ids: { type: "array", items: { type: "string" }, description: "Specific product ids." },
+          collection_id: { type: "array", items: { type: "string" }, description: "Restrict to these collections." },
+          category_id: { type: "array", items: { type: "string" }, description: "Restrict to these categories." },
+          status: { type: "array", items: { type: "string" }, description: "Restrict to these product statuses." },
+        },
+        additionalProperties: false,
+      },
+      product_update: {
+        type: "object",
+        description: "Product fields applied to every selected product.",
+        additionalProperties: true,
+      },
+      variant_update: {
+        type: "object",
+        description:
+          "Variant fields applied to every selected variant. manage_inventory: false is refused.",
+        additionalProperties: true,
+      },
+      set_inventory: {
+        type: "object",
+        description: "Stock to write on every selected variant.",
+        properties: {
+          quantity: INT("Absolute on-hand quantity. NOT a delta; 0 zeroes it."),
+          ensure_managed: BOOL(
+            "Turn inventory tracking on where it is off, creating the inventory item, link and levels core never makes for an existing variant. Untracked variants are skipped without this."
+          ),
+          location_ids: {
+            type: "array",
+            items: { type: "string" },
+            description:
+              "Stock locations to write. Defaults to every location on the sales channel.",
+          },
+        },
+        required: ["quantity"],
+        additionalProperties: false,
+      },
+      dry_run: BOOL("Return the plan without writing. Do this first."),
+    }),
+    sideEffects:
+      "Overwrites live catalogue fields and on-hand stock across many products at once. Enabling tracking creates inventory items and levels. Setting a quantity below a variant's reserved stock oversells open orders — the response warns, it does not block.",
+    nextSteps: ["list_products", "get_product"],
   },
   // ===== Customs / HS codes ===============================================
   // Shiprocket rejects EVERY international shipment whose lines lack an HSN,

--- a/apps/backend/src/api/admin/mcp/lib/tool-slice.ts
+++ b/apps/backend/src/api/admin/mcp/lib/tool-slice.ts
@@ -117,6 +117,14 @@ const DOMAIN_KEYWORDS: Record<Exclude<AdminToolDomain, "core">, string[]> = {
     // above only classifies the tools; these are what ACTIVATE the slice.
     "hsn", "hs code", "hs codes", "hs_code", "customs", "harmonized",
     "harmonised", "tariff", "duty", "commodity code",
+    // Bulk catalogue vocabulary. `bulk_update_products` classifies as catalog
+    // (it lives under /admin/products) but the asks that need it are usually
+    // phrased in inventory words — "set stock to zero for everything", "start
+    // tracking stock on the whole range". Without these the ask matches only
+    // the inventory slice and the one tool that can do it never loads.
+    "bulk", "in bulk", "all products", "every product", "whole catalogue",
+    "whole catalog", "manage inventory", "manage_inventory", "track stock",
+    "tracking stock", "zero",
   ],
   customers: ["customer", "customers", "buyer", "buyers", "shopper", "shoppers"],
   partners: [

--- a/apps/backend/src/api/admin/products/bulk-update/route.ts
+++ b/apps/backend/src/api/admin/products/bulk-update/route.ts
@@ -1,0 +1,33 @@
+import { AuthenticatedMedusaRequest, MedusaResponse } from "@medusajs/framework/http"
+
+import { bulkUpdateProducts } from "../../../../workflows/products/bulk-update-products"
+import type { BulkUpdateProductsReq } from "./validators"
+
+/**
+ * POST /admin/products/bulk-update
+ *
+ * Update many products, their variants and their stock levels in one call —
+ * including turning inventory tracking ON, which core cannot do for an
+ * existing variant (see `bulk-update-products.ts` for why).
+ *
+ * Responds 200 with a PER-ROW outcome even when some rows failed: one bad id
+ * in a two-hundred-row batch must not discard the rest. Read `variants` /
+ * `products` / `warnings`, not the status code.
+ *
+ * `dry_run: true` returns the same plan without writing, including the
+ * before/after quantity and the reserved stock at each location.
+ *
+ * Unscoped by design — this is the admin surface and reaches the whole
+ * platform. Mirrored, store-scoped, by
+ * POST /partners/stores/:id/products/bulk-update.
+ */
+export const POST = async (
+  req: AuthenticatedMedusaRequest,
+  res: MedusaResponse
+) => {
+  const body = (req as any).validatedBody as BulkUpdateProductsReq
+
+  const result = await bulkUpdateProducts(req.scope, body)
+
+  res.status(200).json(result)
+}

--- a/apps/backend/src/api/admin/products/bulk-update/validators.ts
+++ b/apps/backend/src/api/admin/products/bulk-update/validators.ts
@@ -1,0 +1,73 @@
+import { z } from "@medusajs/framework/zod"
+
+/**
+ * Bulk product / variant / inventory update.
+ *
+ * Field objects are `passthrough()` on purpose: the shared engine picks the
+ * columns it accepts from an allow-list (`PRODUCT_FIELDS` / `VARIANT_FIELDS`)
+ * and drops the rest, so validating the exact column set twice would mean two
+ * lists to keep in step and a 400 the moment they drift.
+ */
+
+const VariantTargetSchema = z.object({
+  variant_id: z.string().min(1),
+  update: z.record(z.string(), z.any()).optional(),
+})
+
+const ProductTargetSchema = z.object({
+  product_id: z.string().min(1),
+  update: z.record(z.string(), z.any()).optional(),
+  /** Omit to mean every variant of this product. */
+  variants: z.array(VariantTargetSchema).optional(),
+})
+
+const SelectorSchema = z
+  .object({
+    product_ids: z.array(z.string().min(1)).optional(),
+    collection_id: z.array(z.string().min(1)).optional(),
+    category_id: z.array(z.string().min(1)).optional(),
+    status: z.array(z.string().min(1)).optional(),
+    all: z.boolean().optional(),
+  })
+  .refine(
+    (s) =>
+      s.all ||
+      s.product_ids?.length ||
+      s.collection_id?.length ||
+      s.category_id?.length ||
+      s.status?.length,
+    {
+      message:
+        "selector must narrow something — pass all: true explicitly to mean the whole catalogue.",
+    }
+  )
+
+const InventorySchema = z.object({
+  /** Absolute on-hand quantity. Not a delta; 0 means zero it. */
+  quantity: z.number().int().min(0),
+  ensure_managed: z.boolean().optional(),
+  location_ids: z.array(z.string().min(1)).optional(),
+})
+
+export const BulkUpdateProductsSchema = z
+  .object({
+    products: z.array(ProductTargetSchema).optional(),
+    selector: SelectorSchema.optional(),
+    product_update: z.record(z.string(), z.any()).optional(),
+    variant_update: z.record(z.string(), z.any()).optional(),
+    set_inventory: InventorySchema.optional(),
+    dry_run: z.boolean().optional(),
+  })
+  .refine((b) => b.products?.length || b.selector, {
+    message: "Pass products, a selector, or both — there is nothing to target.",
+  })
+  .refine(
+    (b) =>
+      b.product_update ||
+      b.variant_update ||
+      b.set_inventory ||
+      b.products?.some((p) => p.update || p.variants?.some((v) => v.update)),
+    { message: "Nothing to change — pass at least one update or set_inventory." }
+  )
+
+export type BulkUpdateProductsReq = z.infer<typeof BulkUpdateProductsSchema>

--- a/apps/backend/src/api/middlewares.ts
+++ b/apps/backend/src/api/middlewares.ts
@@ -175,6 +175,7 @@ import { PartnerAssistantSummarizeSchema } from "./partners/assistant/summarize/
 import { CreateConversationSchema as PartnerCreateConversationSchema, UpdateConversationSchema as PartnerUpdateConversationSchema } from "./partners/assistant/conversations/validators";
 import { CreateConversationSchema as AdminAssistantCreateConversationSchema, UpdateConversationSchema as AdminAssistantUpdateConversationSchema } from "./admin/assistant/conversations/validators";
 import { BulkHsCodesSchema } from "./admin/customs/hs-codes/validators";
+import { BulkUpdateProductsSchema } from "./admin/products/bulk-update/validators";
 import {
   CreateExportLutSchema,
   UpdateExportLutSchema,
@@ -2425,6 +2426,25 @@ export default defineMiddlewares({
       matcher: "/admin/customs/hs-codes",
       method: "POST",
       middlewares: [validateAndTransformBody(wrapSchema(BulkHsCodesSchema))],
+    },
+    // Bulk product / variant / inventory editing. The one path that can turn
+    // inventory tracking ON for an existing variant — core only ever turns it
+    // off. Partner mirror below is store- and location-scoped.
+    {
+      matcher: "/admin/products/bulk-update",
+      method: "POST",
+      middlewares: [
+        validateAndTransformBody(wrapSchema(BulkUpdateProductsSchema)),
+      ],
+    },
+    {
+      matcher: "/partners/stores/:id/products/bulk-update",
+      method: "POST",
+      middlewares: [
+        createCorsPartnerMiddleware(),
+        authenticate("partner", ["session", "bearer"]),
+        validateAndTransformBody(wrapSchema(BulkUpdateProductsSchema)),
+      ],
     },
     // Partner mirrors. These carry their own CORS + partner auth, and the POST
     // additionally re-checks every id against the store's catalogue inside the

--- a/apps/backend/src/api/partners/mcp/lib/registry.ts
+++ b/apps/backend/src/api/partners/mcp/lib/registry.ts
@@ -1459,6 +1459,130 @@ export const PARTNER_MCP_TOOLS: PartnerMcpToolDef[] = [
     ),
   },
   {
+    name: "bulk_update_products",
+    description: [
+      "Update MANY of your products, their variants and their stock levels in one call. Sensitive: requires confirm:true. ALWAYS dry_run first — the plan names every product and variant it would touch, with the before/after quantity at each location, and there is no undo once it fires.",
+      "Returns a PER-ROW outcome: one bad id never discards the rest of the batch, so read `variants`, `products` and `warnings` rather than just the status.",
+      "",
+      "TARGETING — combine freely:",
+      "- `products: [{ product_id, update, variants }]` for named products. Omit a product's `variants` key to mean EVERY variant of it.",
+      "- `selector` for filter-based batches: `{ all: true }`, `collection_id`, `category_id`, `status`, `product_ids`. This is how 'zero my whole catalogue' is one call. `all: true` must be passed explicitly — the selector will not default to everything.",
+      "- `product_update` / `variant_update` apply to everything selected; a per-row `update` wins over them.",
+      "",
+      "INVENTORY — `set_inventory: { quantity, ensure_managed }`:",
+      "- `quantity` is ABSOLUTE, not a delta. 0 zeroes the stock.",
+      "- 🔑 `ensure_managed: true` is what makes this work on untracked variants. Medusa CANNOT turn inventory tracking on for a variant that already exists — core only ever turns it off — so a variant with `manage_inventory: false` has no inventory item and nothing to stock. With this flag the tool creates the inventory item, links it to the variant, seeds the levels, then writes the quantity. Without it, untracked variants come back `skipped` and their stock is untouched.",
+      "- Stock always lands on YOUR store's own location; any other location you name is dropped with a warning.",
+      "",
+      "Everything is scoped to your own catalogue — a product that isn't yours comes back as an error row, never silently applied.",
+      "⚠️ `manage_inventory: false` is REFUSED here. Core dismisses the variant's inventory item and its levels with it, with no undo. Use `update_product_variant` one variant at a time.",
+      "Capped at 200 products per call.",
+    ].join("\n"),
+    method: "POST",
+    path: "/partners/stores/:id/products/bulk-update",
+    pathParams: ["id"],
+    write: true,
+    sensitive: true,
+    bodyParams: [
+      "products",
+      "selector",
+      "product_update",
+      "variant_update",
+      "set_inventory",
+      "dry_run",
+    ],
+    inputSchema: obj(
+      {
+        id: STR("Store id."),
+        products: {
+          type: "array",
+          description:
+            "Named products. Omit a row's `variants` to target every variant of it.",
+          items: {
+            type: "object",
+            properties: {
+              product_id: STR("Product id, e.g. 'prod_...'."),
+              update: {
+                type: "object",
+                description:
+                  "Product fields to change (title, subtitle, description, handle, status, material, hs_code, weight, metadata, …).",
+                additionalProperties: true,
+              },
+              variants: {
+                type: "array",
+                description:
+                  "Specific variants only. Omit the key entirely to mean all of them.",
+                items: {
+                  type: "object",
+                  properties: {
+                    variant_id: STR("Variant id, e.g. 'variant_...'."),
+                    update: {
+                      type: "object",
+                      description:
+                        "Variant fields to change (title, sku, hs_code, origin_country, material, allow_backorder, weight, metadata, …).",
+                      additionalProperties: true,
+                    },
+                  },
+                  required: ["variant_id"],
+                  additionalProperties: false,
+                },
+              },
+            },
+            required: ["product_id"],
+            additionalProperties: false,
+          },
+        },
+        selector: {
+          type: "object",
+          description:
+            "Filter-based targeting, always confined to your own catalogue. Must narrow something; pass all: true to mean your whole catalogue.",
+          properties: {
+            all: BOOL("Every product in your store. Say this explicitly."),
+            product_ids: { type: "array", items: { type: "string" }, description: "Specific product ids." },
+            collection_id: { type: "array", items: { type: "string" }, description: "Restrict to these collections." },
+            category_id: { type: "array", items: { type: "string" }, description: "Restrict to these categories." },
+            status: { type: "array", items: { type: "string" }, description: "Restrict to these product statuses." },
+          },
+          additionalProperties: false,
+        },
+        product_update: {
+          type: "object",
+          description: "Product fields applied to every selected product.",
+          additionalProperties: true,
+        },
+        variant_update: {
+          type: "object",
+          description:
+            "Variant fields applied to every selected variant. manage_inventory: false is refused.",
+          additionalProperties: true,
+        },
+        set_inventory: {
+          type: "object",
+          description: "Stock to write on every selected variant.",
+          properties: {
+            quantity: INT("Absolute on-hand quantity. NOT a delta; 0 zeroes it."),
+            ensure_managed: BOOL(
+              "Turn inventory tracking on where it is off, creating the inventory item, link and levels core never makes for an existing variant. Untracked variants are skipped without this."
+            ),
+            location_ids: {
+              type: "array",
+              items: { type: "string" },
+              description:
+                "Optional. Only your own store location is writable; anything else is dropped.",
+            },
+          },
+          required: ["quantity"],
+          additionalProperties: false,
+        },
+        dry_run: BOOL("Return the plan without writing. Do this first."),
+      },
+      ["id"]
+    ),
+    sideEffects:
+      "Overwrites live catalogue fields and on-hand stock across many of your products at once. Enabling tracking creates inventory items and levels. Setting a quantity below a variant's reserved stock oversells open orders — the response warns, it does not block.",
+    nextSteps: ["list_store_products", "get_store_product"],
+  },
+  {
     name: "delete_store_product",
     description: "Remove a product from a store's product set. Sensitive (DELETE).",
     method: "DELETE",

--- a/apps/backend/src/api/partners/stores/[id]/products/bulk-update/route.ts
+++ b/apps/backend/src/api/partners/stores/[id]/products/bulk-update/route.ts
@@ -1,0 +1,43 @@
+import { AuthenticatedMedusaRequest, MedusaResponse } from "@medusajs/framework/http"
+
+import { validatePartnerStoreAccess } from "../../../../helpers"
+import { bulkUpdateProducts } from "../../../../../../workflows/products/bulk-update-products"
+import type { BulkUpdateProductsReq } from "../../../../../admin/products/bulk-update/validators"
+
+/**
+ * POST /partners/stores/:id/products/bulk-update
+ *
+ * Partner mirror of `POST /admin/products/bulk-update`.
+ *
+ * Two scoping rails, and both are load-bearing. Passing the store check is not
+ * enough on its own — the ids and selectors in the body are arbitrary:
+ *
+ *  - `salesChannelId` confines every selector AND every explicit product id to
+ *    this store's own catalogue. Out-of-scope ids come back as per-row errors
+ *    rather than failing the batch, and a store with no channel resolves to
+ *    nothing rather than defaulting open.
+ *  - `allowedLocationIds` confines stock writes to the store's own location. A
+ *    partner naming someone else's location has it dropped with a warning,
+ *    never honoured.
+ */
+export const POST = async (
+  req: AuthenticatedMedusaRequest,
+  res: MedusaResponse
+) => {
+  const { store } = await validatePartnerStoreAccess(
+    req.auth_context,
+    req.params.id,
+    req.scope
+  )
+
+  const body = (req as any).validatedBody as BulkUpdateProductsReq
+
+  const result = await bulkUpdateProducts(req.scope, body, {
+    salesChannelId: store.default_sales_channel_id,
+    allowedLocationIds: store.default_location_id
+      ? [store.default_location_id]
+      : [],
+  })
+
+  res.status(200).json(result)
+}

--- a/apps/backend/src/workflows/products/__tests__/bulk-update-products.unit.spec.ts
+++ b/apps/backend/src/workflows/products/__tests__/bulk-update-products.unit.spec.ts
@@ -1,0 +1,500 @@
+import { bulkUpdateProducts } from "../bulk-update-products"
+
+/**
+ * The behaviours worth pinning here are the ones a reader would otherwise have
+ * to take on trust, and the two that are outright counter-intuitive:
+ *
+ *  - `manage_inventory: false` is refused rather than forwarded (core would
+ *    dismiss the inventory item and its levels).
+ *  - an untracked variant gets an inventory item CREATED and LINKED, because
+ *    core has no false → true path — the whole reason this file exists.
+ */
+
+const updateProductsWorkflow = jest.fn()
+const updateProductVariantsWorkflow = jest.fn()
+const createInventoryItemsWorkflow = jest.fn()
+const batchInventoryItemLevelsWorkflow = jest.fn()
+
+jest.mock("@medusajs/medusa/core-flows", () => ({
+  updateProductsWorkflow: (...a: any[]) => updateProductsWorkflow(...a),
+  updateProductVariantsWorkflow: (...a: any[]) =>
+    updateProductVariantsWorkflow(...a),
+  createInventoryItemsWorkflow: (...a: any[]) =>
+    createInventoryItemsWorkflow(...a),
+  batchInventoryItemLevelsWorkflow: (...a: any[]) =>
+    batchInventoryItemLevelsWorkflow(...a),
+}))
+
+type Level = {
+  inventory_item_id: string
+  location_id: string
+  stocked_quantity: number
+  reserved_quantity?: number
+}
+
+const TRACKED_VARIANT = {
+  id: "variant_tracked",
+  title: "Tracked",
+  sku: "SKU-T",
+  manage_inventory: true,
+  inventory_items: [{ inventory_item_id: "iitem_1", inventory: { id: "iitem_1" } }],
+}
+
+const UNTRACKED_VARIANT = {
+  id: "variant_untracked",
+  title: "Untracked",
+  sku: "SKU-U",
+  manage_inventory: false,
+  inventory_items: [],
+}
+
+const buildContainer = (opts: {
+  products?: any[]
+  channelProductIds?: string[]
+  locationIds?: string[]
+  levels?: Level[]
+}) => {
+  const products = opts.products ?? []
+  const levels = opts.levels ?? []
+  const linkCreate = jest.fn().mockResolvedValue(undefined)
+
+  const graph = jest.fn(async ({ entity, fields }: any) => {
+    if (entity === "sales_channel") {
+      return {
+        data: [
+          {
+            id: "sc_1",
+            products_link: (opts.channelProductIds ?? []).map((product_id) => ({
+              product_id,
+            })),
+          },
+        ],
+      }
+    }
+    if (entity === "sales_channels") {
+      return {
+        data: [
+          {
+            stock_locations: (opts.locationIds ?? []).map((id) => ({ id })),
+          },
+        ],
+      }
+    }
+    if (entity === "product") {
+      // The id-only shape is the selector resolution pass.
+      if (Array.isArray(fields) && fields.length === 1 && fields[0] === "id") {
+        return { data: products.map((p) => ({ id: p.id })) }
+      }
+      return { data: products }
+    }
+    return { data: [] }
+  })
+
+  const inventoryService = {
+    listInventoryLevels: jest.fn(
+      async ({ inventory_item_id, location_id }: any) =>
+        levels.filter(
+          (l) =>
+            l.inventory_item_id === inventory_item_id &&
+            l.location_id === location_id
+        )
+    ),
+  }
+
+  const container: any = {
+    resolve: (key: string) => {
+      if (key === "query") return { graph }
+      if (key === "link") return { create: linkCreate }
+      if (key === "inventory") return inventoryService
+      return {}
+    },
+  }
+
+  return { container, graph, linkCreate, inventoryService }
+}
+
+beforeEach(() => {
+  jest.clearAllMocks()
+  updateProductsWorkflow.mockReturnValue({
+    run: jest.fn().mockResolvedValue({ result: [] }),
+  })
+  updateProductVariantsWorkflow.mockReturnValue({
+    run: jest.fn().mockResolvedValue({ result: [] }),
+  })
+  createInventoryItemsWorkflow.mockReturnValue({
+    run: jest.fn().mockResolvedValue({ result: [{ id: "iitem_new" }] }),
+  })
+  batchInventoryItemLevelsWorkflow.mockReturnValue({
+    run: jest.fn().mockResolvedValue({ result: {} }),
+  })
+})
+
+describe("bulkUpdateProducts — refusals", () => {
+  it("refuses manage_inventory: false without touching anything", async () => {
+    const { container } = buildContainer({})
+
+    const result = await bulkUpdateProducts(container, {
+      selector: { all: true },
+      variant_update: { manage_inventory: false },
+    })
+
+    expect(result.errors).toBe(1)
+    expect(result.updated).toBe(0)
+    expect(result.warnings[0]).toMatch(/not accepted in bulk/i)
+    // The refusal must come before any resolution, let alone any write.
+    expect(updateProductVariantsWorkflow).not.toHaveBeenCalled()
+    expect(batchInventoryItemLevelsWorkflow).not.toHaveBeenCalled()
+  })
+
+  it("caps the batch and writes nothing when a selector matches too many", async () => {
+    const many = Array.from({ length: 201 }, (_, i) => ({
+      id: `prod_${i}`,
+      title: `P${i}`,
+      variants: [],
+    }))
+    const { container } = buildContainer({ products: many })
+
+    const result = await bulkUpdateProducts(container, {
+      selector: { all: true },
+      set_inventory: { quantity: 0 },
+    })
+
+    expect(result.matched_products).toBe(201)
+    expect(result.updated).toBe(0)
+    expect(result.warnings.join(" ")).toMatch(/capped at 200/i)
+    expect(batchInventoryItemLevelsWorkflow).not.toHaveBeenCalled()
+  })
+})
+
+describe("bulkUpdateProducts — the false → true path core lacks", () => {
+  const product = {
+    id: "prod_1",
+    title: "Shawl",
+    shipping_profile: { id: "sp_1" },
+    variants: [UNTRACKED_VARIANT],
+  }
+
+  it("creates an inventory item, links it, and seeds the level", async () => {
+    const { container, linkCreate } = buildContainer({
+      products: [product],
+      locationIds: ["sloc_1"],
+    })
+
+    const result = await bulkUpdateProducts(container, {
+      products: [{ product_id: "prod_1" }],
+      set_inventory: { quantity: 12, ensure_managed: true, location_ids: ["sloc_1"] },
+    })
+
+    const variant = result.variants[0]
+    expect(variant.status).toBe("ok")
+    expect(variant.actions).toEqual(
+      expect.arrayContaining([
+        "enable_manage_inventory",
+        "create_inventory_item",
+        "link_inventory_item",
+        "create_level",
+      ])
+    )
+
+    // The flag flip is a real variant update...
+    expect(updateProductVariantsWorkflow).toHaveBeenCalled()
+    // ...and the link carries required_quantity, matching what core writes at
+    // variant-create time. A link without it is not equivalent.
+    expect(linkCreate).toHaveBeenCalledWith([
+      expect.objectContaining({ data: { required_quantity: 1 } }),
+    ])
+
+    const levelInput =
+      batchInventoryItemLevelsWorkflow.mock.results[0].value.run.mock.calls[0][0]
+        .input
+    expect(levelInput.create).toEqual([
+      {
+        inventory_item_id: "iitem_new",
+        location_id: "sloc_1",
+        stocked_quantity: 12,
+      },
+    ])
+    expect(levelInput.update).toEqual([])
+  })
+
+  it("skips an untracked variant when ensure_managed is not asked for", async () => {
+    const { container, linkCreate } = buildContainer({
+      products: [product],
+      locationIds: ["sloc_1"],
+    })
+
+    const result = await bulkUpdateProducts(container, {
+      products: [{ product_id: "prod_1" }],
+      set_inventory: { quantity: 12, location_ids: ["sloc_1"] },
+    })
+
+    expect(result.variants[0].status).toBe("skipped")
+    expect(result.variants[0].reason).toMatch(/ensure_managed/)
+    expect(linkCreate).not.toHaveBeenCalled()
+    expect(createInventoryItemsWorkflow).not.toHaveBeenCalled()
+  })
+})
+
+describe("bulkUpdateProducts — zeroing an existing level", () => {
+  it("updates by (item, location) rather than by level id", async () => {
+    const { container } = buildContainer({
+      products: [
+        { id: "prod_1", title: "Shawl", variants: [TRACKED_VARIANT] },
+      ],
+      locationIds: ["sloc_1"],
+      levels: [
+        {
+          inventory_item_id: "iitem_1",
+          location_id: "sloc_1",
+          stocked_quantity: 40,
+          reserved_quantity: 0,
+        },
+      ],
+    })
+
+    const result = await bulkUpdateProducts(container, {
+      selector: { all: true },
+      set_inventory: { quantity: 0, location_ids: ["sloc_1"] },
+    })
+
+    const levelInput =
+      batchInventoryItemLevelsWorkflow.mock.results[0].value.run.mock.calls[0][0]
+        .input
+    // updateInventoryLevels keys on (inventory_item_id, location_id) and
+    // IGNORES `id` — an update addressed by level id silently no-ops.
+    expect(levelInput.update).toEqual([
+      {
+        inventory_item_id: "iitem_1",
+        location_id: "sloc_1",
+        stocked_quantity: 0,
+      },
+    ])
+    expect(levelInput.create).toEqual([])
+    expect(result.variants[0].inventory).toEqual([
+      { location_id: "sloc_1", before: 40, after: 0, reserved: 0 },
+    ])
+  })
+
+  it("warns when zeroing below stock already promised to orders", async () => {
+    const { container } = buildContainer({
+      products: [
+        { id: "prod_1", title: "Shawl", variants: [TRACKED_VARIANT] },
+      ],
+      locationIds: ["sloc_1"],
+      levels: [
+        {
+          inventory_item_id: "iitem_1",
+          location_id: "sloc_1",
+          stocked_quantity: 40,
+          reserved_quantity: 3,
+        },
+      ],
+    })
+
+    const result = await bulkUpdateProducts(container, {
+      selector: { all: true },
+      set_inventory: { quantity: 0, location_ids: ["sloc_1"] },
+    })
+
+    expect(result.warnings.join(" ")).toMatch(/below their reserved quantity/i)
+    // Warned, not blocked — the write still went out.
+    expect(result.variants[0].status).toBe("ok")
+    expect(batchInventoryItemLevelsWorkflow).toHaveBeenCalled()
+  })
+})
+
+describe("bulkUpdateProducts — dry run", () => {
+  it("reports the plan and writes nothing", async () => {
+    const { container, linkCreate } = buildContainer({
+      products: [
+        {
+          id: "prod_1",
+          title: "Shawl",
+          variants: [TRACKED_VARIANT, UNTRACKED_VARIANT],
+        },
+      ],
+      locationIds: ["sloc_1"],
+      levels: [
+        {
+          inventory_item_id: "iitem_1",
+          location_id: "sloc_1",
+          stocked_quantity: 40,
+        },
+      ],
+    })
+
+    const result = await bulkUpdateProducts(container, {
+      selector: { all: true },
+      set_inventory: { quantity: 0, ensure_managed: true, location_ids: ["sloc_1"] },
+      dry_run: true,
+    })
+
+    expect(result.dry_run).toBe(true)
+    expect(result.matched_variants).toBe(2)
+    expect(result.variants.every((v) => v.status === "planned")).toBe(true)
+
+    // The plan must show the tracked variant's real current quantity, and the
+    // untracked one as having no level yet — that difference is the whole
+    // point of reviewing a plan.
+    const tracked = result.variants.find((v) => v.variant_id === "variant_tracked")!
+    const untracked = result.variants.find(
+      (v) => v.variant_id === "variant_untracked"
+    )!
+    expect(tracked.inventory?.[0]).toMatchObject({ before: 40, after: 0 })
+    expect(untracked.inventory?.[0]).toMatchObject({ before: null, after: 0 })
+    expect(untracked.actions).toEqual(
+      expect.arrayContaining(["enable_manage_inventory", "create_inventory_item"])
+    )
+
+    expect(updateProductsWorkflow).not.toHaveBeenCalled()
+    expect(updateProductVariantsWorkflow).not.toHaveBeenCalled()
+    expect(createInventoryItemsWorkflow).not.toHaveBeenCalled()
+    expect(batchInventoryItemLevelsWorkflow).not.toHaveBeenCalled()
+    expect(linkCreate).not.toHaveBeenCalled()
+  })
+
+  it("flags products with no shipping profile when enabling tracking", async () => {
+    const { container } = buildContainer({
+      products: [
+        { id: "prod_1", title: "Shawl", variants: [UNTRACKED_VARIANT] },
+      ],
+      locationIds: ["sloc_1"],
+    })
+
+    const result = await bulkUpdateProducts(container, {
+      selector: { all: true },
+      set_inventory: { quantity: 5, ensure_managed: true, location_ids: ["sloc_1"] },
+      dry_run: true,
+    })
+
+    expect(result.warnings.join(" ")).toMatch(/no shipping profile/i)
+    expect(result.warnings.join(" ")).toMatch(/requires_shipping/)
+  })
+})
+
+describe("bulkUpdateProducts — partner scoping", () => {
+  const products = [
+    { id: "prod_mine", title: "Mine", variants: [TRACKED_VARIANT] },
+  ]
+
+  it("rejects a product outside the store's catalogue without failing the batch", async () => {
+    const { container } = buildContainer({
+      products,
+      channelProductIds: ["prod_mine"],
+      locationIds: ["sloc_mine"],
+      levels: [
+        {
+          inventory_item_id: "iitem_1",
+          location_id: "sloc_mine",
+          stocked_quantity: 10,
+        },
+      ],
+    })
+
+    const result = await bulkUpdateProducts(
+      container,
+      {
+        products: [{ product_id: "prod_mine" }, { product_id: "prod_theirs" }],
+        set_inventory: { quantity: 0 },
+      },
+      { salesChannelId: "sc_1", allowedLocationIds: ["sloc_mine"] }
+    )
+
+    const foreign = result.products.find((p) => p.product_id === "prod_theirs")!
+    expect(foreign.status).toBe("error")
+    expect(foreign.reason).toMatch(/not part of your store/i)
+    // The owned half still went through.
+    expect(result.variants.some((v) => v.status === "ok")).toBe(true)
+  })
+
+  it("treats a store with no sales channel as owning nothing, not everything", async () => {
+    const { container } = buildContainer({ products })
+
+    const result = await bulkUpdateProducts(
+      container,
+      { selector: { all: true }, set_inventory: { quantity: 0 } },
+      { salesChannelId: null }
+    )
+
+    expect(result.matched_products).toBe(0)
+    expect(batchInventoryItemLevelsWorkflow).not.toHaveBeenCalled()
+  })
+
+  it("drops a stock location the caller may not write", async () => {
+    const { container } = buildContainer({
+      products,
+      channelProductIds: ["prod_mine"],
+      locationIds: ["sloc_mine"],
+    })
+
+    const result = await bulkUpdateProducts(
+      container,
+      {
+        products: [{ product_id: "prod_mine" }],
+        set_inventory: { quantity: 0, location_ids: ["sloc_someone_else"] },
+      },
+      { salesChannelId: "sc_1", allowedLocationIds: ["sloc_mine"] }
+    )
+
+    expect(result.warnings.join(" ")).toMatch(/may not write/i)
+    // Falls back to the caller's own location rather than writing nothing.
+    expect(result.variants[0].inventory?.[0].location_id).toBe("sloc_mine")
+  })
+})
+
+describe("bulkUpdateProducts — field updates", () => {
+  it("drops unknown columns instead of forwarding them", async () => {
+    const { container } = buildContainer({
+      products: [{ id: "prod_1", title: "Shawl", variants: [TRACKED_VARIANT] }],
+    })
+
+    await bulkUpdateProducts(container, {
+      products: [{ product_id: "prod_1" }],
+      product_update: { title: "New", not_a_column: "boom" },
+    })
+
+    const input =
+      updateProductsWorkflow.mock.results[0].value.run.mock.calls[0][0].input
+    expect(input.products[0]).toEqual({ id: "prod_1", title: "New" })
+    expect(input.products[0]).not.toHaveProperty("not_a_column")
+  })
+
+  it("lets a per-product update override the blanket one", async () => {
+    const { container } = buildContainer({
+      products: [{ id: "prod_1", title: "Shawl", variants: [] }],
+    })
+
+    await bulkUpdateProducts(container, {
+      products: [{ product_id: "prod_1", update: { status: "published" } }],
+      product_update: { status: "draft" },
+    })
+
+    const input =
+      updateProductsWorkflow.mock.results[0].value.run.mock.calls[0][0].input
+    expect(input.products[0].status).toBe("published")
+  })
+
+  it("targets only the named variants when `variants` is given", async () => {
+    const { container } = buildContainer({
+      products: [
+        {
+          id: "prod_1",
+          title: "Shawl",
+          variants: [TRACKED_VARIANT, UNTRACKED_VARIANT],
+        },
+      ],
+    })
+
+    const result = await bulkUpdateProducts(container, {
+      products: [
+        {
+          product_id: "prod_1",
+          variants: [{ variant_id: "variant_tracked", update: { sku: "NEW" } }],
+        },
+      ],
+    })
+
+    expect(result.matched_variants).toBe(1)
+    expect(result.variants[0].variant_id).toBe("variant_tracked")
+  })
+})

--- a/apps/backend/src/workflows/products/bulk-update-products.ts
+++ b/apps/backend/src/workflows/products/bulk-update-products.ts
@@ -1,0 +1,862 @@
+import {
+  ContainerRegistrationKeys,
+  Modules,
+} from "@medusajs/framework/utils"
+import type { MedusaContainer } from "@medusajs/framework/types"
+import {
+  batchInventoryItemLevelsWorkflow,
+  createInventoryItemsWorkflow,
+  updateProductsWorkflow,
+  updateProductVariantsWorkflow,
+} from "@medusajs/medusa/core-flows"
+
+/**
+ * Bulk product + variant + inventory editing in one pass.
+ *
+ * Editing a catalogue one variant at a time doesn't scale: "zero everything",
+ * "put these 40 products live", "start tracking stock on the whole range" are
+ * each dozens-to-hundreds of calls today, and a model driving them one at a
+ * time will drift halfway through. This is the bulk half — plan it, review it,
+ * fire it once.
+ *
+ * Plain container functions rather than `createWorkflow`, and shared by the
+ * admin route and its partner mirror so the two surfaces can never drift apart
+ * (the #843 recipe, same as `workflows/customs/hs-codes.ts`).
+ *
+ * ---------------------------------------------------------------------------
+ * THE CORE REASON THIS FILE EXISTS
+ *
+ * `updateProductVariantsWorkflow` handles `manage_inventory: false` and ONLY
+ * that direction — it runs `dismissProductVariantsInventoryStep`, which unlinks
+ * the variant's inventory item. There is no `false → true` counterpart
+ * anywhere in core-flows 2.17.2.
+ *
+ * So flipping the flag ON through any ordinary update path produces a variant
+ * that claims to track stock and has no inventory item, no levels, and no way
+ * to be stocked. The partner-ui inventory page 404s on exactly that state,
+ * because its access check needs a level at the store's `default_location_id`.
+ *
+ * `enableInventoryTracking` below is the missing direction: set the flag,
+ * create the inventory item, link variant ↔ item, then seed a level at each
+ * location. Every step is skipped when it has already been done, so re-running
+ * a batch is safe.
+ *
+ * The reverse (`manage_inventory: false`) is deliberately REFUSED here. It
+ * destroys the inventory item and its levels with no undo, which is a
+ * per-variant decision made with eyes open — not something to do to 400
+ * variants because a selector matched them. `update_product_variant` still
+ * does it one at a time.
+ * ---------------------------------------------------------------------------
+ */
+
+/** Cap per call. Each product is its own workflow run; a runaway batch would
+ *  hold a connection open long past any sane request timeout. */
+const MAX_PRODUCTS = 200
+
+/** Product columns a caller may set. Anything else in `update` is dropped
+ *  rather than forwarded — an unknown key reaching the product module is a 500,
+ *  and a bulk call is the worst place to discover one. */
+const PRODUCT_FIELDS = [
+  "title",
+  "subtitle",
+  "description",
+  "handle",
+  "status",
+  "thumbnail",
+  "material",
+  "origin_country",
+  "hs_code",
+  "mid_code",
+  "weight",
+  "length",
+  "height",
+  "width",
+  "discountable",
+  "metadata",
+] as const
+
+/** Variant columns a caller may set. `manage_inventory` is handled separately
+ *  (see `enableInventoryTracking`) and is not a plain passthrough. */
+const VARIANT_FIELDS = [
+  "title",
+  "sku",
+  "barcode",
+  "ean",
+  "upc",
+  "allow_backorder",
+  "hs_code",
+  "origin_country",
+  "mid_code",
+  "material",
+  "weight",
+  "length",
+  "height",
+  "width",
+  "metadata",
+] as const
+
+export type BulkVariantTarget = {
+  variant_id: string
+  /** Field updates for this one variant. */
+  update?: Record<string, any>
+}
+
+export type BulkProductTarget = {
+  product_id: string
+  /** Product-level field updates. */
+  update?: Record<string, any>
+  /** Name specific variants. Omit to mean "every variant of this product". */
+  variants?: BulkVariantTarget[]
+}
+
+export type BulkInventoryIntent = {
+  /** Absolute on-hand quantity to write. NOT a delta — 0 means zero it. */
+  quantity: number
+  /**
+   * Turn tracking on where it is off, creating the inventory item, the
+   * variant ↔ item link and the levels that core never creates for an
+   * existing variant. Without this, untracked variants are reported as
+   * `skipped` rather than silently ignored.
+   */
+  ensure_managed?: boolean
+  /**
+   * Which stock locations to write. Defaults to every location linked to the
+   * scoping sales channel. The partner mirror always pins this to its own
+   * location — a partner may not write anyone else's stock.
+   */
+  location_ids?: string[]
+}
+
+export type BulkProductUpdateInput = {
+  /** Explicit targets. Combine freely with `selector`. */
+  products?: BulkProductTarget[]
+  /**
+   * Filter-based targeting — the "zero the whole catalogue" path. Resolved to
+   * ids up front so the plan can state exactly what it matched BEFORE
+   * anything is written.
+   */
+  selector?: {
+    product_ids?: string[]
+    collection_id?: string[]
+    category_id?: string[]
+    status?: string[]
+    /** Every product in the scoping sales channel. Partner-scoped by default. */
+    all?: boolean
+  }
+  /** Applied to every selected product. Per-product `update` wins on conflict. */
+  product_update?: Record<string, any>
+  /** Applied to every selected variant. Per-variant `update` wins on conflict. */
+  variant_update?: Record<string, any>
+  /** Applied to every selected variant. */
+  set_inventory?: BulkInventoryIntent
+  /** Compute and return the plan without writing anything. */
+  dry_run?: boolean
+}
+
+export type BulkScope = {
+  /**
+   * Restrict every selector AND every explicit id to this channel's catalogue.
+   * The partner mirror always passes it. Admin calls leave it undefined for
+   * the whole platform.
+   */
+  salesChannelId?: string | null
+  /** Locations the caller is allowed to write. Undefined = no restriction. */
+  allowedLocationIds?: string[]
+}
+
+/** What will happen / did happen to one variant. */
+export type VariantOutcome = {
+  product_id: string
+  variant_id: string
+  sku?: string | null
+  title?: string | null
+  /** Ordered list of the operations this variant needs. */
+  actions: string[]
+  status: "planned" | "ok" | "skipped" | "error"
+  reason?: string
+  /** On-hand before → after, per location, when inventory is in play. */
+  inventory?: {
+    location_id: string
+    before: number | null
+    after: number
+    /** Held by orders. Zeroing below this oversells — surfaced, never blocked. */
+    reserved: number
+  }[]
+}
+
+export type ProductOutcome = {
+  product_id: string
+  title?: string | null
+  actions: string[]
+  status: "planned" | "ok" | "skipped" | "error"
+  reason?: string
+}
+
+export type BulkProductUpdateResult = {
+  dry_run: boolean
+  /** Products matched by ids + selector, after scoping. */
+  matched_products: number
+  matched_variants: number
+  products: ProductOutcome[]
+  variants: VariantOutcome[]
+  /** Non-fatal things the caller should read before/after applying. */
+  warnings: string[]
+  updated: number
+  skipped: number
+  errors: number
+}
+
+const pick = (
+  source: Record<string, any> | undefined,
+  allowed: readonly string[]
+): Record<string, any> => {
+  const out: Record<string, any> = {}
+  if (!source) return out
+  for (const key of allowed) {
+    if (source[key] !== undefined) out[key] = source[key]
+  }
+  return out
+}
+
+/**
+ * Product ids linked to a sales channel.
+ *
+ * Filtering products by `sales_channels.id` reads correctly but mikro-orm
+ * rejects it at runtime — the relation lives on the link entity, not on
+ * Product. Pivot from the channel and walk `products_link` instead. Same
+ * trap and same fix as `workflows/customs/hs-codes.ts`.
+ */
+async function channelProductIds(
+  query: any,
+  salesChannelId: string
+): Promise<string[]> {
+  const { data } = await query.graph({
+    entity: "sales_channel",
+    fields: ["id", "products_link.product_id"],
+    filters: { id: salesChannelId },
+  })
+
+  const links = ((data?.[0] as any)?.products_link || []) as Array<{
+    product_id?: string
+  }>
+
+  return Array.from(
+    new Set(links.map((l) => l?.product_id).filter(Boolean) as string[])
+  )
+}
+
+/** Stock locations linked to a sales channel. */
+async function channelLocationIds(
+  query: any,
+  salesChannelId: string
+): Promise<string[]> {
+  const { data } = await query.graph({
+    entity: "sales_channels",
+    fields: ["stock_locations.id"],
+    filters: { id: salesChannelId },
+  })
+
+  const out: string[] = []
+  for (const loc of (data?.[0] as any)?.stock_locations || []) {
+    if (loc?.id) out.push(loc.id)
+  }
+  return out
+}
+
+/**
+ * Resolve the target product ids from explicit ids + selector, intersected
+ * with the caller's scope.
+ *
+ * An out-of-scope id is dropped here and reported as an error row rather than
+ * failing the batch — a partner naming someone else's product must not be able
+ * to tell the difference between "not yours" and "doesn't exist", and one bad
+ * id must not discard the ninety-nine good ones.
+ */
+async function resolveTargetIds(
+  container: MedusaContainer,
+  input: BulkProductUpdateInput,
+  scope: BulkScope
+): Promise<{ ids: string[]; rejected: string[] }> {
+  const query: any = container.resolve(ContainerRegistrationKeys.QUERY)
+
+  const explicit = (input.products || []).map((p) => p.product_id)
+  const selector = input.selector || {}
+
+  // PRESENCE of the key, not its truthiness, decides whether scoping applies.
+  // The partner mirror always passes it; a store with a null/absent channel
+  // must then own NOTHING. Branching on the value instead would turn a
+  // misconfigured store into a skeleton key over the whole platform — the
+  // caller looks unscoped and every product matches.
+  let scopeIds: Set<string> | null = null
+  if ("salesChannelId" in scope) {
+    scopeIds = scope.salesChannelId
+      ? new Set(await channelProductIds(query, scope.salesChannelId))
+      : new Set()
+  }
+
+  const selected = new Set<string>(selector.product_ids || [])
+
+  const needsQuery =
+    selector.all ||
+    selector.collection_id?.length ||
+    selector.category_id?.length ||
+    selector.status?.length
+
+  if (needsQuery) {
+    const filters: Record<string, any> = {}
+    if (selector.collection_id?.length) {
+      filters.collection_id = selector.collection_id
+    }
+    if (selector.category_id?.length) {
+      filters.categories = { id: selector.category_id }
+    }
+    if (selector.status?.length) {
+      filters.status = selector.status
+    }
+    if (scopeIds) {
+      // Scope by id list rather than by channel — see channelProductIds.
+      if (!scopeIds.size) {
+        return { ids: [], rejected: explicit }
+      }
+      filters.id = Array.from(scopeIds)
+    }
+
+    const { data } = await query.graph({
+      entity: "product",
+      fields: ["id"],
+      filters,
+    })
+    for (const p of (data as any[]) || []) {
+      if (p?.id) selected.add(p.id)
+    }
+  }
+
+  for (const id of explicit) selected.add(id)
+
+  const ids: string[] = []
+  const rejected: string[] = []
+  for (const id of selected) {
+    if (scopeIds && !scopeIds.has(id)) {
+      rejected.push(id)
+      continue
+    }
+    ids.push(id)
+  }
+
+  return { ids, rejected }
+}
+
+/**
+ * Give an existing variant the inventory record core never creates for it.
+ *
+ * Order matters and each step is conditional:
+ *  1. flip `manage_inventory` on (only if off)
+ *  2. create an inventory item (only if the variant has none)
+ *  3. link variant ↔ item (only for a freshly created item)
+ *
+ * Returns the inventory item id to stock, or null when one could not be
+ * established.
+ */
+async function enableInventoryTracking(
+  container: MedusaContainer,
+  variant: any,
+  actions: string[]
+): Promise<string | null> {
+  const link: any = container.resolve(ContainerRegistrationKeys.LINK)
+
+  const existingItemId = variant.inventory_items?.find(
+    (i: any) => i?.inventory?.id || i?.inventory_item_id
+  )
+  const alreadyLinked =
+    existingItemId?.inventory?.id || existingItemId?.inventory_item_id || null
+
+  if (!variant.manage_inventory) {
+    await updateProductVariantsWorkflow(container).run({
+      input: { product_variants: [{ id: variant.id, manage_inventory: true }] },
+    })
+    actions.push("enable_manage_inventory")
+  }
+
+  if (alreadyLinked) {
+    return String(alreadyLinked)
+  }
+
+  // Mirror the shape core uses when it creates a default item at variant-create
+  // time, so an item made here is indistinguishable from one made there.
+  const { result } = await createInventoryItemsWorkflow(container).run({
+    input: {
+      items: [
+        {
+          sku: variant.sku || undefined,
+          title: variant.title || undefined,
+          description: variant.title || undefined,
+          hs_code: variant.hs_code || undefined,
+          origin_country: variant.origin_country || undefined,
+          mid_code: variant.mid_code || undefined,
+          material: variant.material || undefined,
+          weight: variant.weight ?? undefined,
+          length: variant.length ?? undefined,
+          height: variant.height ?? undefined,
+          width: variant.width ?? undefined,
+          requires_shipping: true,
+        },
+      ],
+    } as any,
+  })
+
+  const created = (result as any)?.[0] ?? (result as any)?.items?.[0]
+  if (!created?.id) return null
+
+  actions.push("create_inventory_item")
+
+  await link.create([
+    {
+      [Modules.PRODUCT]: { variant_id: variant.id },
+      [Modules.INVENTORY]: { inventory_item_id: created.id },
+      data: { required_quantity: 1 },
+    },
+  ])
+  actions.push("link_inventory_item")
+
+  return String(created.id)
+}
+
+/**
+ * Plan, and optionally apply, a bulk product/variant/inventory update.
+ *
+ * Always computes the full plan first. `dry_run` returns it untouched; an
+ * apply walks the same plan, so what you review is what runs.
+ */
+export async function bulkUpdateProducts(
+  container: MedusaContainer,
+  input: BulkProductUpdateInput,
+  scope: BulkScope = {}
+): Promise<BulkProductUpdateResult> {
+  const query: any = container.resolve(ContainerRegistrationKeys.QUERY)
+  const inventoryService: any = container.resolve(Modules.INVENTORY)
+
+  const dryRun = !!input.dry_run
+  const warnings: string[] = []
+  const productOutcomes: ProductOutcome[] = []
+  const variantOutcomes: VariantOutcome[] = []
+
+  if (input.variant_update?.manage_inventory === false) {
+    // Refused rather than honoured: core would dismiss the inventory item and
+    // take its levels with it, across every variant the selector matched.
+    return {
+      dry_run: dryRun,
+      matched_products: 0,
+      matched_variants: 0,
+      products: [],
+      variants: [],
+      warnings: [
+        "manage_inventory: false is not accepted in bulk — core dismisses the variant's inventory item and its stock levels, with no undo. Use update_product_variant per variant.",
+      ],
+      updated: 0,
+      skipped: 0,
+      errors: 1,
+    }
+  }
+
+  const { ids: targetIds, rejected } = await resolveTargetIds(
+    container,
+    input,
+    scope
+  )
+
+  for (const id of rejected) {
+    productOutcomes.push({
+      product_id: id,
+      actions: [],
+      status: "error",
+      reason: "Not part of your store's catalogue.",
+    })
+  }
+
+  if (targetIds.length > MAX_PRODUCTS) {
+    warnings.push(
+      `Selector matched ${targetIds.length} products; this call is capped at ${MAX_PRODUCTS}. Narrow the selector or page through it — nothing was written.`
+    )
+    return {
+      dry_run: dryRun,
+      matched_products: targetIds.length,
+      matched_variants: 0,
+      products: productOutcomes,
+      variants: [],
+      warnings,
+      updated: 0,
+      skipped: 0,
+      errors: productOutcomes.length + 1,
+    }
+  }
+
+  if (!targetIds.length) {
+    return {
+      dry_run: dryRun,
+      matched_products: 0,
+      matched_variants: 0,
+      products: productOutcomes,
+      variants: [],
+      warnings: ["Nothing matched — no products were selected."],
+      updated: 0,
+      skipped: 0,
+      errors: productOutcomes.length,
+    }
+  }
+
+  const { data: products } = await query.graph({
+    entity: "product",
+    fields: [
+      "id",
+      "title",
+      "status",
+      "shipping_profile.id",
+      "variants.id",
+      "variants.title",
+      "variants.sku",
+      "variants.manage_inventory",
+      "variants.hs_code",
+      "variants.origin_country",
+      "variants.mid_code",
+      "variants.material",
+      "variants.weight",
+      "variants.length",
+      "variants.height",
+      "variants.width",
+      "variants.inventory_items.inventory_item_id",
+      "variants.inventory_items.inventory.id",
+    ],
+    filters: { id: targetIds },
+  })
+
+  const productsById = new Map<string, any>()
+  for (const p of (products as any[]) || []) productsById.set(p.id, p)
+
+  // Which locations inventory writes land on.
+  let locationIds: string[] = input.set_inventory?.location_ids || []
+  if (!locationIds.length && scope.salesChannelId) {
+    locationIds = await channelLocationIds(query, scope.salesChannelId)
+  }
+  if (scope.allowedLocationIds) {
+    const allowed = new Set(scope.allowedLocationIds)
+    const dropped = locationIds.filter((l) => !allowed.has(l))
+    if (dropped.length) {
+      warnings.push(
+        `Dropped ${dropped.length} location(s) you may not write: ${dropped.join(", ")}.`
+      )
+    }
+    locationIds = locationIds.filter((l) => allowed.has(l))
+    // A store whose own location isn't linked to its sales channel would
+    // otherwise resolve to nothing and silently write no stock. The caller is
+    // explicitly permitted to write these, so use them.
+    if (!locationIds.length && scope.allowedLocationIds.length) {
+      locationIds = [...scope.allowedLocationIds]
+    }
+  }
+  if (input.set_inventory && !locationIds.length) {
+    warnings.push(
+      "No writable stock location resolved — inventory quantities were not applied. Set location_ids, or configure the store's default location."
+    )
+  }
+
+  const explicitById = new Map<string, BulkProductTarget>()
+  for (const p of input.products || []) explicitById.set(p.product_id, p)
+
+  const levelsToCreate: any[] = []
+  const levelsToUpdate: any[] = []
+
+  let matchedVariants = 0
+
+  for (const productId of targetIds) {
+    const product = productsById.get(productId)
+    if (!product) {
+      productOutcomes.push({
+        product_id: productId,
+        actions: [],
+        status: "error",
+        reason: "Product not found.",
+      })
+      continue
+    }
+
+    const target = explicitById.get(productId)
+    const productUpdate = {
+      ...pick(input.product_update, PRODUCT_FIELDS),
+      ...pick(target?.update, PRODUCT_FIELDS),
+    }
+
+    const productActions: string[] = []
+    if (Object.keys(productUpdate).length) {
+      productActions.push(
+        ...Object.keys(productUpdate).map((k) => `product.${k}`)
+      )
+    }
+
+    // Selecting specific variants means only those; omitting the key means
+    // every variant, which is what makes "zero everything" a single call.
+    const namedVariantIds = target?.variants?.map((v) => v.variant_id)
+    const variantOverrides = new Map<string, BulkVariantTarget>()
+    for (const v of target?.variants || []) variantOverrides.set(v.variant_id, v)
+
+    const variants = (product.variants || []).filter((v: any) =>
+      namedVariantIds ? namedVariantIds.includes(v.id) : true
+    )
+
+    if (!dryRun && Object.keys(productUpdate).length) {
+      try {
+        await updateProductsWorkflow(container).run({
+          input: { products: [{ id: productId, ...productUpdate }] } as any,
+        })
+        productOutcomes.push({
+          product_id: productId,
+          title: product.title,
+          actions: productActions,
+          status: "ok",
+        })
+      } catch (e: any) {
+        productOutcomes.push({
+          product_id: productId,
+          title: product.title,
+          actions: productActions,
+          status: "error",
+          reason: e?.message || "Product update failed.",
+        })
+        // The product write failed; its variants are still independent writes
+        // and are attempted below rather than abandoned.
+      }
+    } else {
+      productOutcomes.push({
+        product_id: productId,
+        title: product.title,
+        actions: productActions,
+        status: Object.keys(productUpdate).length
+          ? dryRun
+            ? "planned"
+            : "ok"
+          : "skipped",
+        reason: Object.keys(productUpdate).length
+          ? undefined
+          : "No product-level fields to change.",
+      })
+    }
+
+    for (const variant of variants) {
+      matchedVariants += 1
+
+      const override = variantOverrides.get(variant.id)
+      const variantUpdate = {
+        ...pick(input.variant_update, VARIANT_FIELDS),
+        ...pick(override?.update, VARIANT_FIELDS),
+      }
+
+      const actions: string[] = []
+      const outcome: VariantOutcome = {
+        product_id: productId,
+        variant_id: variant.id,
+        sku: variant.sku,
+        title: variant.title,
+        actions,
+        status: dryRun ? "planned" : "ok",
+      }
+
+      if (Object.keys(variantUpdate).length) {
+        actions.push(...Object.keys(variantUpdate).map((k) => `variant.${k}`))
+      }
+
+      const wantsInventory = !!input.set_inventory && locationIds.length > 0
+      const managed = !!variant.manage_inventory
+      const ensureManaged = !!input.set_inventory?.ensure_managed
+
+      if (wantsInventory && !managed && !ensureManaged) {
+        outcome.status = "skipped"
+        outcome.reason =
+          "Variant does not track inventory. Pass set_inventory.ensure_managed: true to turn tracking on first."
+      }
+
+      let inventoryItemId: string | null =
+        variant.inventory_items?.find(
+          (i: any) => i?.inventory?.id || i?.inventory_item_id
+        )?.inventory?.id ??
+        variant.inventory_items?.find((i: any) => i?.inventory_item_id)
+          ?.inventory_item_id ??
+        null
+
+      if (wantsInventory && (managed || ensureManaged)) {
+        if (!managed) actions.push("enable_manage_inventory")
+        if (!inventoryItemId) {
+          actions.push("create_inventory_item", "link_inventory_item")
+        }
+      }
+
+      if (dryRun) {
+        if (wantsInventory && (managed || ensureManaged)) {
+          outcome.inventory = []
+          for (const locationId of locationIds) {
+            let before: number | null = null
+            let reserved = 0
+            if (inventoryItemId) {
+              const levels = await inventoryService.listInventoryLevels({
+                inventory_item_id: inventoryItemId,
+                location_id: locationId,
+              })
+              const level = (levels as any[])?.[0]
+              before = level ? Number(level.stocked_quantity) || 0 : null
+              reserved = level ? Number(level.reserved_quantity) || 0 : 0
+            }
+            outcome.inventory.push({
+              location_id: locationId,
+              before,
+              after: input.set_inventory!.quantity,
+              reserved,
+            })
+            actions.push(before === null ? "create_level" : "set_quantity")
+          }
+        }
+        if (!actions.length && outcome.status === "planned") {
+          outcome.status = "skipped"
+          outcome.reason = "Nothing to change."
+        }
+        variantOutcomes.push(outcome)
+        continue
+      }
+
+      try {
+        if (Object.keys(variantUpdate).length) {
+          await updateProductVariantsWorkflow(container).run({
+            input: {
+              product_variants: [{ id: variant.id, ...variantUpdate }],
+            } as any,
+          })
+        }
+
+        if (wantsInventory && (managed || ensureManaged)) {
+          // Re-derive rather than trusting the planned action list: another
+          // call may have created the item since the graph read above.
+          inventoryItemId = await enableInventoryTracking(
+            container,
+            variant,
+            actions
+          )
+
+          if (!inventoryItemId) {
+            outcome.status = "error"
+            outcome.reason =
+              "Could not establish an inventory item for this variant."
+            variantOutcomes.push(outcome)
+            continue
+          }
+
+          outcome.inventory = []
+          for (const locationId of locationIds) {
+            const levels = await inventoryService.listInventoryLevels({
+              inventory_item_id: inventoryItemId,
+              location_id: locationId,
+            })
+            const level = (levels as any[])?.[0]
+            const before = level ? Number(level.stocked_quantity) || 0 : null
+            const reserved = level ? Number(level.reserved_quantity) || 0 : 0
+
+            if (level) {
+              // Keyed on (inventory_item_id, location_id) — updateInventoryLevels
+              // ignores `id`, so passing the level id alone silently no-ops.
+              levelsToUpdate.push({
+                inventory_item_id: inventoryItemId,
+                location_id: locationId,
+                stocked_quantity: input.set_inventory!.quantity,
+              })
+              actions.push("set_quantity")
+            } else {
+              levelsToCreate.push({
+                inventory_item_id: inventoryItemId,
+                location_id: locationId,
+                stocked_quantity: input.set_inventory!.quantity,
+              })
+              actions.push("create_level")
+            }
+
+            outcome.inventory.push({
+              location_id: locationId,
+              before,
+              after: input.set_inventory!.quantity,
+              reserved,
+            })
+          }
+        }
+
+        // Don't overwrite a reason already set above — "needs ensure_managed"
+        // is the one the caller has to read to fix their call, and the generic
+        // line would bury it.
+        if (!actions.length && !outcome.reason) {
+          outcome.status = "skipped"
+          outcome.reason = "Nothing to change."
+        }
+      } catch (e: any) {
+        outcome.status = "error"
+        outcome.reason = e?.message || "Variant update failed."
+      }
+
+      variantOutcomes.push(outcome)
+    }
+  }
+
+  // One batched level write for the whole call rather than one per variant.
+  if (!dryRun && (levelsToCreate.length || levelsToUpdate.length)) {
+    try {
+      await batchInventoryItemLevelsWorkflow(container).run({
+        input: {
+          create: levelsToCreate,
+          update: levelsToUpdate,
+          delete: [],
+        } as any,
+      })
+    } catch (e: any) {
+      warnings.push(
+        `Inventory level write failed: ${e?.message || "unknown error"}. Field updates above still landed — re-run with the same input to retry the levels (it is idempotent).`
+      )
+      for (const v of variantOutcomes) {
+        if (v.inventory?.length && v.status === "ok") {
+          v.status = "error"
+          v.reason = "Inventory level write failed for the batch."
+        }
+      }
+    }
+  }
+
+  // Knock-on worth seeing BEFORE it surprises someone on an order screen:
+  // Medusa derives requires_shipping from (shipping profile + manage_inventory).
+  // A product with no profile whose variants start tracking stock changes how
+  // its future fulfillments are stamped. Reported, never auto-fixed.
+  if (input.set_inventory?.ensure_managed) {
+    const noProfile = targetIds.filter(
+      (id) => productsById.get(id) && !productsById.get(id)?.shipping_profile?.id
+    )
+    if (noProfile.length) {
+      warnings.push(
+        `${noProfile.length} product(s) have no shipping profile. Turning inventory tracking on changes how Medusa derives requires_shipping for their future fulfillments — run the backfill-product-shipping-profiles job if "Mark as shipped" goes missing.`
+      )
+    }
+  }
+
+  const oversold = variantOutcomes.filter((v) =>
+    v.inventory?.some((l) => l.reserved > l.after)
+  )
+  if (oversold.length) {
+    warnings.push(
+      `${oversold.length} variant(s) would be set below their reserved quantity — stock already promised to open orders. Not blocked, but check those orders.`
+    )
+  }
+
+  return {
+    dry_run: dryRun,
+    matched_products: targetIds.length,
+    matched_variants: matchedVariants,
+    products: productOutcomes,
+    variants: variantOutcomes,
+    warnings,
+    updated: variantOutcomes.filter((v) => v.status === "ok").length,
+    skipped: variantOutcomes.filter((v) => v.status === "skipped").length,
+    errors:
+      variantOutcomes.filter((v) => v.status === "error").length +
+      productOutcomes.filter((p) => p.status === "error").length,
+  }
+}


### PR DESCRIPTION
Closes #1287.

One tool on each MCP surface that updates many products, their variants and
their stock levels in a single call.

## Why this isn't just a loop over `update_product_variant`

**Medusa cannot turn inventory tracking on for a variant that already exists.**

`updateProductVariantsWorkflow` (core-flows 2.17.2) handles `manage_inventory:
false` and *only* that direction — it runs `dismissProductVariantsInventoryStep`,
which unlinks the variant's inventory item. There is no `false → true`
counterpart anywhere in core-flows.

So flipping the flag on through any ordinary path yields a variant that claims
to track stock and has **no inventory item, no levels, and nothing to stock**.
The partner-ui inventory page 404s on exactly that state, because its access
check needs a level at the store's default location.

`enableInventoryTracking` supplies the missing direction — set the flag, create
the item, link variant ↔ item, seed a level per location, write the quantity —
with every step skipped when already done, so a re-run is safe.

## What it does

| Case | How |
|---|---|
| Update fields on one or many products | `products: [{ product_id, update }]` |
| Update fields on specific variants | `products: [{ product_id, variants: [{ variant_id, update }] }]` |
| …on **every** variant of a product | omit the `variants` key |
| Stock a tracked variant | `set_inventory: { quantity }` |
| Stock an **untracked** variant | `set_inventory: { quantity, ensure_managed: true }` — creates item + link + levels |
| **Zero the whole catalogue** | `selector: { all: true }` + `set_inventory: { quantity: 0, ensure_managed: true }` |

`dry_run: true` returns the same plan without writing: every product and
variant, the before/after quantity at each location, and the reserved stock.
Per-row outcomes throughout — one bad id never discards the batch. Capped at
200 products per call.

## What it refuses

⚠️ **`manage_inventory: false` is rejected in bulk.** Core would dismiss the
variant's inventory item and take its levels with it, with no undo, across
every variant a selector matched. That stays a per-variant decision made with
eyes open, via `update_product_variant`.

## Two traps the tests pin — both found by writing them

- **Scoping keys on the PRESENCE of `salesChannelId`, not its truthiness.** A
  partner store with no channel must own *nothing*. Branching on the value
  would have made a misconfigured store a skeleton key over the whole platform:
  the caller looks unscoped and every product matches.
- **Levels are addressed by `(inventory_item_id, location_id)`.**
  `updateInventoryLevels` ignores `id`, so an update sent by level id silently
  no-ops.

## Reported, never auto-fixed

- Enabling tracking on a product with **no shipping profile** changes how Medusa
  derives `requires_shipping` for its future fulfillments (the same derivation
  behind `backfill-product-shipping-profiles`). Flagged in the plan.
- Setting a quantity **below reserved stock** oversells open orders. Warned, not
  blocked.

## Shape

A shared container function behind an admin route and a store-scoped partner
mirror, so the two surfaces cannot drift — the #843 recipe, same as
`workflows/customs/hs-codes.ts`. The partner mirror carries two rails, both
load-bearing: `salesChannelId` confines every selector *and* every explicit id
to the store's own catalogue, and `allowedLocationIds` confines stock writes to
its own location.

The admin tool classifies as `catalog` (it lives under `/admin/products`), but
the asks that need it are phrased in inventory words — "set stock to zero for
everything". Without the added catalog keywords those match only the inventory
slice and the one tool that can serve them never loads. Pinned by a test.

## Verify

```
pnpm test:unit --testPathPattern="bulk-update-products|tool-slice"   # 46 pass
npx tsc --noEmit -p apps/backend/tsconfig.json                       # 79 (baseline)
```

Full unit suite: 3115 pass, 5 fail across 4 suites — all four reproduce
identically on clean `main` with this branch stashed (`audit-ai-platforms`,
`seed-additional-email-templates`, `brief-shaper`, `build-email-data`). This
branch adds no failures. Note the red baseline is **4** suites, not the 2 in
older handoffs.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
