### PR TITLE
fix(security): encrypt and redact carrier shipping-account credentials (#1285)

### DIFF
--- a/apps/backend/src/api/admin/social-platforms/__tests__/secrets.unit.spec.ts
+++ b/apps/backend/src/api/admin/social-platforms/__tests__/secrets.unit.spec.ts
@@ -65,6 +65,30 @@ describe("redactApiConfig (#32A)", () => {
     expect(redactApiConfig(null)).toBeNull()
     expect(redactApiConfig(undefined)).toBeUndefined()
   })
+
+  // Carrier rows arrived after this list was written. Blue Dart's licence key
+  // is the credential that books a BILLABLE waybill, and it sits beside a
+  // `client_secret` that was already covered — so the row would have looked
+  // protected while echoing the expensive half in plaintext.
+  it("redacts carrier shipping-account credentials", () => {
+    const out = redactApiConfig({
+      provider: "bluedart",
+      login_id: "LOGIN",
+      licence_key: "LICENCE",
+      client_secret: "GATEWAY",
+      customer_code: "000001",
+    })!
+
+    expect(out.licence_key).toBeUndefined()
+    expect(out.login_id).toBeUndefined()
+    expect(out.client_secret).toBeUndefined()
+    expect(out.licence_key_present).toBe(true)
+    expect(out.login_id_present).toBe(true)
+    // Non-secret carrier config still comes back — the UI needs it to show
+    // which account is configured.
+    expect(out.provider).toBe("bluedart")
+    expect(out.customer_code).toBe("000001")
+  })
 })
 
 describe("preserveExistingSecrets (#32A)", () => {

--- a/apps/backend/src/api/admin/social-platforms/secrets.ts
+++ b/apps/backend/src/api/admin/social-platforms/secrets.ts
@@ -50,6 +50,14 @@ const PLAINTEXT_SECRET_FIELDS = [
   "app_secret",
   "webhook_verify_token",
   "password",
+  // Carrier credentials. Blue Dart splits its auth across two layers: the
+  // gateway pair mints the JWT (`client_secret`, already above) and the
+  // SHIPPING account travels in the request body. `licence_key` is the half
+  // that actually books a billable waybill, so leaving it off this list would
+  // have echoed it in plaintext from every GET /admin/social-platforms.
+  "licence_key",
+  "license_key",
+  "login_id",
 ] as const
 
 // Nested secret bags (OAuth1). Stripped wholesale by default.

--- a/apps/backend/src/subscribers/social-platform-credentials-encryption.ts
+++ b/apps/backend/src/subscribers/social-platform-credentials-encryption.ts
@@ -85,6 +85,14 @@ export async function encryptSocialPlatformCredentials(
     // Google Business Manager: per-row OAuth client secret and Ads developer token
     encryptBearer("client_secret")
     encryptBearer("developer_token")
+    // Carrier shipping-account credentials. Blue Dart authenticates in two
+    // layers — the gateway pair mints the JWT (`client_secret` above) and the
+    // shipping account travels in the request body. `licence_key` is the half
+    // that books a billable waybill; without these it would sit in plaintext
+    // on disk while the gateway secret beside it was encrypted.
+    encryptBearer("licence_key")
+    encryptBearer("license_key")
+    encryptBearer("login_id")
 
     // OAuth1 user credentials
     if (


### PR DESCRIPTION
Blocks the Blue Dart go-live on #1285. Found while provisioning; **nothing was
written to prod before this.**

## The hole

Carrier credentials are stored as a `shipping`-category platform row, and the
resolver reads them via `readSecret(cfg, field)` — encrypted blob first,
plaintext fallback. Two independent lists decide whether a field is protected:

| | covers |
|---|---|
| `social-platform-credentials-encryption.ts` | what gets encrypted **at rest** |
| `secrets.ts` `PLAINTEXT_SECRET_FIELDS` | what gets stripped **from API responses** |

Both were written before any carrier was configured this way, and neither knows
a carrier's field names.

Blue Dart authenticates in **two layers**: the gateway pair mints the JWT, and
the shipping account travels in the request body.

- `client_secret` — the gateway half — was already in both lists ✅
- **`licence_key` and `login_id` were in neither** ❌

So a Blue Dart row would have been written with the gateway secret encrypted and
the **licence key sitting in plaintext beside it**, and `GET
/admin/social-platforms` would have **echoed that licence key** to any admin
caller. `licence_key` is the half that actually books a billable waybill — the
row would have looked protected while leaking the expensive part.

## The fix

Add `licence_key`, `license_key` and `login_id` to both lists. `license_key` is
covered alongside the British spelling because the resolver's plaintext fallback
reads whatever the row happens to carry.

Pinned by a test that asserts a Blue Dart-shaped config comes back with the
credentials stripped and `*_present` set, while non-secret carrier config
(`provider`, `customer_code`) still comes through — the UI needs that to show
which account is configured.

## Note for whoever provisions next

This is a forward fix, not a backfill: it protects rows written from here on.
The only shipping row on prod today is Shiprocket, whose `password` was already
covered by both lists — so there is nothing exposed right now to clean up.

## Verify

```
pnpm test:unit --testPathPattern="social-platform"    # 36 pass
npx tsc --noEmit -p apps/backend/tsconfig.json        # 79 (baseline)
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)
