### PR TITLE
fix(billing): reverse the platform shipping charge when a waybill is cancelled (#1285)

### DIFF
--- a/apps/backend/src/admin/hooks/api/design-orders.ts
+++ b/apps/backend/src/admin/hooks/api/design-orders.ts
@@ -522,6 +522,17 @@ export type CancelShipmentResponse = {
     cancelled_at: string;
     /** False when the customer email could not be sent (see the seed script). */
     customer_notified: boolean;
+    /**
+     * The platform-shipping deduction handed back to the partner, when the
+     * cancelled label had booked one. Null for a retail order, a partner on
+     * their own carrier account, or a carrier that quoted no rate.
+     */
+    shipping_reversed?: {
+      amount: number;
+      currency_code: string;
+      carrier: string | null;
+      awb: string | null;
+    } | null;
   };
 };
 

--- a/apps/backend/src/admin/widgets/order-carrier-shipment.tsx
+++ b/apps/backend/src/admin/widgets/order-carrier-shipment.tsx
@@ -290,6 +290,14 @@ const OrderCarrierShipmentWidget = ({
               c.customer_notified ? " — customer emailed" : ""
             }`
           )
+          // Say what it was worth. The freight deduction is invisible on this
+          // widget (it lives on the payout panel), so without this the operator
+          // has no signal that the partner's payout just moved.
+          if (c.shipping_reversed) {
+            toast.info(
+              `Reversed ${c.shipping_reversed.amount} ${c.shipping_reversed.currency_code} of platform shipping on the partner's payout.`
+            )
+          }
           if (!c.customer_notified) {
             // Never silent: the whole point of the email is that the customer
             // finds out from us rather than from a dead tracking link.

--- a/apps/backend/src/admin/widgets/order-partner-fee.tsx
+++ b/apps/backend/src/admin/widgets/order-partner-fee.tsx
@@ -19,6 +19,16 @@ type ShippingCharge = {
   is_foreign_currency: boolean
 }
 
+/** A freight charge given back because its waybill was cancelled (#1285). */
+type ReversedShippingCharge = {
+  amount: number
+  currency_code: string
+  carrier: string | null
+  awb: string | null
+  reversed_at: string | null
+  reason: string | null
+}
+
 type DescribedFee = {
   order_id: string
   status: string
@@ -30,6 +40,8 @@ type DescribedFee = {
   is_collectible: boolean
   /** Null when the partner shipped on their own carrier account. */
   shipping: ShippingCharge | null
+  /** Retired freight charges — shown for continuity, never deducted. */
+  shipping_reversals: ReversedShippingCharge[]
   /** order_total − commission − platform shipping. */
   net_payout: number
 }
@@ -116,6 +128,32 @@ const OrderPartnerFeeWidget = ({ data: order }: DetailWidgetProps<AdminOrder>) =
               {formatMoney(fee.fee_amount, fee.currency_code)}
             </Text>
           </div>
+          {/* Freight from a cancelled waybill, listed before the live charge so
+              the column reads in the order it happened: charged, given back,
+              charged again on the replacement carrier. Struck through and
+              signed "+" because it is money returned, not money taken. */}
+          {(fee.shipping_reversals || []).map((r, i) => (
+            <div
+              key={`${r.awb || "reversal"}-${i}`}
+              className="flex items-start justify-between"
+            >
+              <div className="flex flex-col">
+                <Text size="small" className="text-ui-fg-muted">
+                  Shipping reversed
+                  {r.carrier ? ` (${r.carrier})` : ""}
+                </Text>
+                {r.awb && (
+                  <Text size="xsmall" className="text-ui-fg-muted">
+                    AWB {r.awb} cancelled
+                    {r.reason ? ` — ${r.reason}` : ""}
+                  </Text>
+                )}
+              </div>
+              <Text size="small" className="text-ui-fg-muted line-through">
+                {formatMoney(r.amount, r.currency_code)}
+              </Text>
+            </div>
+          ))}
           {/* Platform shipping — present only when the partner generated the
               label on OUR carrier account rather than shipping themselves. A
               foreign-currency carrier charge is shown but never folded into

--- a/apps/backend/src/modules/partner_billing/__tests__/describe-fee.unit.spec.ts
+++ b/apps/backend/src/modules/partner_billing/__tests__/describe-fee.unit.spec.ts
@@ -51,6 +51,7 @@ describe("describeFee (#623)", () => {
       is_collectible: true,
       breakdown: null,
       shipping: null,
+      shipping_reversals: [],
       net_payout: 9799.51,
     })
   })
@@ -131,6 +132,112 @@ describe("describeFee (#623)", () => {
       expect(d.shipping!.currency_code).toBe("INR")
       expect(d.shipping!.is_foreign_currency).toBe(false)
       expect(d.net_payout).toBe(860)
+    })
+  })
+
+  describe("reversed platform shipping (#1285 follow-up)", () => {
+    const base = {
+      order_id: "o",
+      currency_code: "inr",
+      fee_rate: 200,
+      fee_amount: 100,
+      order_total: 1000,
+      status: "accrued",
+    }
+
+    it("is empty for a row that never carried a reversal", () => {
+      expect(describeFee(base)!.shipping_reversals).toEqual([])
+      expect(describeFee({ ...base, metadata: {} })!.shipping_reversals).toEqual([])
+    })
+
+    it("surfaces a reversal WITHOUT deducting it — that is the point", () => {
+      const d = describeFee({
+        ...base,
+        // Cleared by the reversal; the freight is no longer charged.
+        shipping_amount: null,
+        metadata: {
+          shipping_reversals: [
+            {
+              amount: 400.01,
+              currency_code: "INR",
+              carrier: "bluedart",
+              awb: "77712345678",
+              reversed_at: "2026-08-14T06:00:00.000Z",
+              reason: "pickup no-show",
+            },
+          ],
+        },
+      })!
+      expect(d.shipping).toBeNull()
+      expect(d.shipping_reversals).toHaveLength(1)
+      expect(d.shipping_reversals[0]).toEqual({
+        amount: 400.01,
+        currency_code: "INR",
+        carrier: "bluedart",
+        awb: "77712345678",
+        reversed_at: "2026-08-14T06:00:00.000Z",
+        reason: "pickup no-show",
+      })
+      // 1000 − 100 commission, and nothing for the reversed freight.
+      expect(d.net_payout).toBe(900)
+    })
+
+    it("shows the replacement carrier's charge beside the reversed one", () => {
+      const d = describeFee({
+        ...base,
+        shipping_amount: 250,
+        shipping_currency_code: "INR",
+        shipping_carrier: "delhivery",
+        metadata: {
+          shipping_reversals: [
+            { amount: 400, currency_code: "INR", carrier: "bluedart" },
+          ],
+        },
+      })!
+      expect(d.shipping!.amount).toBe(250)
+      expect(d.shipping!.carrier).toBe("delhivery")
+      expect(d.shipping_reversals[0].amount).toBe(400)
+      // Only the LIVE charge is deducted: 1000 − 100 − 250.
+      expect(d.net_payout).toBe(650)
+    })
+
+    it("keeps every reversal when a waybill is cancelled more than once", () => {
+      const d = describeFee({
+        ...base,
+        metadata: {
+          shipping_reversals: [
+            { amount: 400, currency_code: "INR", carrier: "bluedart" },
+            { amount: 250, currency_code: "INR", carrier: "delhivery" },
+          ],
+        },
+      })!
+      expect(d.shipping_reversals.map((r) => r.carrier)).toEqual([
+        "bluedart",
+        "delhivery",
+      ])
+      expect(d.net_payout).toBe(900)
+    })
+
+    it("never throws on malformed metadata — this is a reporting payload", () => {
+      expect(
+        describeFee({ ...base, metadata: { shipping_reversals: "nope" } as any })!
+          .shipping_reversals
+      ).toEqual([])
+      const d = describeFee({
+        ...base,
+        metadata: { shipping_reversals: [{}, { amount: "oops" }] },
+      })!
+      expect(d.shipping_reversals).toHaveLength(2)
+      expect(d.shipping_reversals[0]).toEqual({
+        amount: 0,
+        // Falls back to the order currency rather than an empty label.
+        currency_code: "INR",
+        carrier: null,
+        awb: null,
+        reversed_at: null,
+        reason: null,
+      })
+      expect(d.shipping_reversals[1].amount).toBe(0)
     })
   })
 

--- a/apps/backend/src/modules/partner_billing/__tests__/reverse-shipping.unit.spec.ts
+++ b/apps/backend/src/modules/partner_billing/__tests__/reverse-shipping.unit.spec.ts
@@ -1,0 +1,131 @@
+import {
+  planShippingReversal,
+  readShippingReversals,
+} from "../reverse-shipping"
+
+const EVENT = {
+  awb: "77712345678",
+  fulfillment_id: "ful_1",
+  reason: "pickup no-show",
+  reversed_by: "ops@jyt.in",
+  reversed_at: "2026-08-14T06:00:00.000Z",
+}
+
+describe("readShippingReversals (#1285 follow-up)", () => {
+  it("returns [] for anything that isn't an array — metadata is free-form jsonb", () => {
+    expect(readShippingReversals(null)).toEqual([])
+    expect(readShippingReversals(undefined)).toEqual([])
+    expect(readShippingReversals({})).toEqual([])
+    expect(readShippingReversals({ shipping_reversals: "nope" } as any)).toEqual([])
+    expect(readShippingReversals({ shipping_reversals: {} } as any)).toEqual([])
+  })
+})
+
+describe("planShippingReversal (#1285 follow-up)", () => {
+  const fee = {
+    id: "pfee_1",
+    shipping_amount: 400.01,
+    shipping_currency_code: "inr",
+    shipping_carrier: "bluedart",
+    metadata: null,
+  }
+
+  it("clears the live charge and records what was given back", () => {
+    const planned = planShippingReversal(fee, EVENT)!
+    expect(planned.id).toBe("pfee_1")
+    expect(planned.update).toEqual({
+      id: "pfee_1",
+      shipping_amount: null,
+      shipping_currency_code: null,
+      shipping_carrier: null,
+      metadata: {
+        shipping_reversals: [
+          {
+            amount: 400.01,
+            currency_code: "INR",
+            carrier: "bluedart",
+            awb: "77712345678",
+            fulfillment_id: "ful_1",
+            reversed_at: "2026-08-14T06:00:00.000Z",
+            reason: "pickup no-show",
+            reversed_by: "ops@jyt.in",
+          },
+        ],
+      },
+    })
+  })
+
+  it("appends rather than replaces, and preserves unrelated metadata", () => {
+    const planned = planShippingReversal(
+      {
+        ...fee,
+        shipping_amount: 250,
+        shipping_carrier: "delhivery",
+        metadata: {
+          reversed_reason: "keep me",
+          shipping_reversals: [{ amount: 400, carrier: "bluedart" }],
+        },
+      },
+      EVENT
+    )!
+    expect(planned.update.metadata.reversed_reason).toBe("keep me")
+    expect(planned.update.metadata.shipping_reversals).toHaveLength(2)
+    expect(planned.update.metadata.shipping_reversals[1].amount).toBe(250)
+  })
+
+  it("is idempotent — a second cancel can't stack a phantom reversal", () => {
+    // What the row looks like after the first reversal ran.
+    expect(
+      planShippingReversal(
+        {
+          id: "pfee_1",
+          shipping_amount: null,
+          shipping_currency_code: null,
+          shipping_carrier: null,
+          metadata: { shipping_reversals: [{ amount: 400 }] },
+        },
+        EVENT
+      )
+    ).toBeNull()
+  })
+
+  it("reverses a recorded 0 — free shipping is a real quoted rate", () => {
+    const planned = planShippingReversal({ ...fee, shipping_amount: 0 }, EVENT)!
+    expect(planned.reversal.amount).toBe(0)
+    expect(planned.update.shipping_amount).toBeNull()
+  })
+
+  it("no-ops when there is nothing to reverse", () => {
+    // Partner shipped on their own account / carrier quoted no rate.
+    expect(planShippingReversal({ id: "pfee_1" }, EVENT)).toBeNull()
+    expect(
+      planShippingReversal({ id: "pfee_1", shipping_amount: undefined }, EVENT)
+    ).toBeNull()
+    // Retail order — no fee row at all.
+    expect(planShippingReversal(null, EVENT)).toBeNull()
+    expect(planShippingReversal({ id: "" }, EVENT)).toBeNull()
+    // A corrupt amount must not be "reversed" into a NaN line.
+    expect(
+      planShippingReversal({ id: "pfee_1", shipping_amount: "oops" }, EVENT)
+    ).toBeNull()
+  })
+
+  it("coerces a bigNumber string amount and normalises the currency", () => {
+    const planned = planShippingReversal(
+      { ...fee, shipping_amount: "84.50", shipping_currency_code: "usd" },
+      EVENT
+    )!
+    expect(planned.reversal.amount).toBe(84.5)
+    expect(planned.reversal.currency_code).toBe("USD")
+  })
+
+  it("tolerates an unattributed cancellation", () => {
+    const planned = planShippingReversal(fee, {
+      reversed_at: "2026-08-14T06:00:00.000Z",
+    })!
+    expect(planned.reversal.awb).toBeNull()
+    expect(planned.reversal.reason).toBeNull()
+    expect(planned.reversal.reversed_by).toBeNull()
+    expect(planned.reversal.fulfillment_id).toBeNull()
+  })
+})

--- a/apps/backend/src/modules/partner_billing/describe-fee.ts
+++ b/apps/backend/src/modules/partner_billing/describe-fee.ts
@@ -11,6 +11,10 @@
  * coerced with `Number(...)` and non-finite values count as 0.
  */
 
+// `reverse-shipping` is itself pure and dependency-free, so importing it here
+// keeps this file's "trivially unit-testable" contract intact.
+import { readShippingReversals } from "./reverse-shipping"
+
 export type PartnerFeeBasis = "percentage" | "flat"
 
 export type PartnerFeeRowLike = {
@@ -29,6 +33,7 @@ export type PartnerFeeRowLike = {
   shipping_amount?: number | string | null
   shipping_currency_code?: string | null
   shipping_carrier?: string | null
+  metadata?: Record<string, any> | null
 }
 
 /** Itemised components of a `retail_split` fee (gateway + commission). */
@@ -61,12 +66,35 @@ export type DescribedFee = {
    */
   shipping: ShippingCharge | null
   /**
+   * Platform-shipping charges that WERE deducted and have since been given back
+   * because their waybill was cancelled. Empty for the overwhelming majority of
+   * orders.
+   *
+   * These deduct nothing — they are already out of `net_payout`. They are
+   * carried into the display precisely so the payout doesn't appear to change
+   * value on its own between two views: the partner sees the charge arrive, sees
+   * it reversed, and sees the replacement carrier's charge as its own line.
+   */
+  shipping_reversals: ReversedShippingCharge[]
+  /**
    * What the partner actually receives: `order_total − fee_amount − shipping`.
    *
    * A non-collectible fee (waived / reversed) deducts nothing, so it drops out
-   * of the arithmetic rather than being subtracted anyway.
+   * of the arithmetic rather than being subtracted anyway. Reversed shipping is
+   * likewise absent — reversing is what removed it.
    */
   net_payout: number
+}
+
+/** A retired platform-shipping charge, shown for continuity, never deducted. */
+export type ReversedShippingCharge = {
+  amount: number
+  currency_code: string
+  carrier: string | null
+  /** The cancelled waybill — the handle for the carrier's credit note. */
+  awb: string | null
+  reversed_at: string | null
+  reason: string | null
 }
 
 /** Platform-shipping deduction, when the partner used our carrier account. */
@@ -158,6 +186,20 @@ export function describeFee(
             fee.shipping_currency_code.toUpperCase() !== currency_code,
         }
 
+  // Reversed charges are display-only — they were removed from the row when the
+  // waybill was cancelled, so they must never re-enter the arithmetic below.
+  // Coerced defensively: `metadata` is free-form jsonb and this must not throw.
+  const shipping_reversals: ReversedShippingCharge[] = readShippingReversals(
+    fee.metadata
+  ).map((r: any) => ({
+    amount: toNum(r?.amount),
+    currency_code: String(r?.currency_code || currency_code).toUpperCase(),
+    carrier: r?.carrier || null,
+    awb: r?.awb || null,
+    reversed_at: r?.reversed_at || null,
+    reason: r?.reason || null,
+  }))
+
   // Only deduct what is actually collected. A foreign-currency carrier charge
   // is deliberately NOT subtracted — converting it here would invent an FX rate
   // this pure function has no business choosing; the UI shows it as its own
@@ -178,6 +220,7 @@ export function describeFee(
     is_collectible,
     breakdown,
     shipping,
+    shipping_reversals,
     net_payout: order_total - deductions,
   }
 }

--- a/apps/backend/src/modules/partner_billing/reverse-shipping.ts
+++ b/apps/backend/src/modules/partner_billing/reverse-shipping.ts
@@ -1,0 +1,125 @@
+/**
+ * Reversing the platform-shipping deduction when a waybill is cancelled.
+ *
+ * `recordPlatformShippingCost` stamps what a label cost us onto the order's
+ * `partner_fee` row at label generation, and `describeFee` subtracts it from the
+ * payout. Cancelling the waybill at the carrier used to leave that stamp exactly
+ * where it was — so a partner kept paying freight for an AWB that no longer
+ * existed, and the next label (on a carrier that may not quote a rate at all,
+ * e.g. Delhivery) silently inherited the dead carrier's figure.
+ *
+ * A reversal therefore does two things, and the second is what makes it safe:
+ *
+ *   1. clears the active charge (`shipping_amount` → null), which stops the
+ *      deduction and restores the payout, and
+ *   2. appends the cleared figure to `metadata.shipping_reversals`, because a
+ *      payout line that silently changes value between two views is the thing
+ *      partners escalate. The reversal stays visible, and it carries the AWB —
+ *      the only handle anyone has for matching a carrier credit note to it.
+ *
+ * Kept pure and dependency-free so the decision ("is there anything to reverse,
+ * and what does the row look like afterwards") is unit-testable without a DB.
+ */
+
+/** One retired platform-shipping charge, as stored on `partner_fee.metadata`. */
+export type ShippingReversal = {
+  /** The amount that WAS being deducted and no longer is. */
+  amount: number
+  currency_code: string
+  /** Carrier the reversed charge was booked on ("bluedart", "shiprocket", …). */
+  carrier: string | null
+  /** The cancelled waybill, for reconciling the carrier's credit note. */
+  awb: string | null
+  /** Fulfillment whose waybill was cancelled. */
+  fulfillment_id: string | null
+  reversed_at: string
+  /** Operator's free-text cancellation reason, when given. */
+  reason: string | null
+  /** Admin email that performed the cancellation, when known. */
+  reversed_by: string | null
+}
+
+/** The parts of a `partner_fee` row a reversal reads. */
+export type ReversibleFeeRow = {
+  id: string
+  shipping_amount?: number | string | null
+  shipping_currency_code?: string | null
+  shipping_carrier?: string | null
+  metadata?: Record<string, any> | null
+}
+
+export type ShippingReversalEvent = {
+  awb?: string | null
+  fulfillment_id?: string | null
+  reason?: string | null
+  reversed_by?: string | null
+  /** ISO timestamp; injected so the caller controls the clock. */
+  reversed_at: string
+}
+
+/** Existing reversals on a row, defensively — `metadata` is free-form jsonb. */
+export function readShippingReversals(
+  metadata: Record<string, any> | null | undefined
+): ShippingReversal[] {
+  const raw = metadata?.shipping_reversals
+  return Array.isArray(raw) ? (raw as ShippingReversal[]) : []
+}
+
+/**
+ * The `updatePartnerFees` payload that reverses the active shipping charge, or
+ * `null` when there is nothing to reverse.
+ *
+ * Returns null — rather than writing an empty reversal — when the row carries no
+ * active charge. That covers the partner who shipped on their own account, a
+ * carrier that never quoted a rate, and (importantly) a second cancel on the
+ * same fulfillment: the operation is idempotent, so a retry after a partial
+ * failure can't stack phantom reversals.
+ *
+ * Note a recorded `0` IS reversed. Free shipping is a real quoted outcome and
+ * the row's presence is what says "the partner used our carrier account", so
+ * absence is the only thing that means nothing was charged.
+ */
+export function planShippingReversal(
+  fee: ReversibleFeeRow | null | undefined,
+  event: ShippingReversalEvent
+): { id: string; reversal: ShippingReversal; update: Record<string, any> } | null {
+  if (!fee?.id) {
+    return null
+  }
+  const current = fee.shipping_amount
+  if (current === null || current === undefined) {
+    return null
+  }
+  const amount = Number(current)
+  if (!Number.isFinite(amount)) {
+    return null
+  }
+
+  const reversal: ShippingReversal = {
+    amount,
+    currency_code: (fee.shipping_currency_code || "").toUpperCase(),
+    carrier: fee.shipping_carrier || null,
+    awb: event.awb || null,
+    fulfillment_id: event.fulfillment_id || null,
+    reversed_at: event.reversed_at,
+    reason: event.reason || null,
+    reversed_by: event.reversed_by || null,
+  }
+
+  return {
+    id: fee.id,
+    reversal,
+    update: {
+      id: fee.id,
+      // Back to "the partner did not use our shipping" — which is exactly what
+      // is true again, and what the next label will overwrite from scratch.
+      shipping_amount: null,
+      shipping_currency_code: null,
+      shipping_carrier: null,
+      metadata: {
+        ...(fee.metadata || {}),
+        shipping_reversals: [...readShippingReversals(fee.metadata), reversal],
+      },
+    },
+  }
+}

--- a/apps/backend/src/modules/partner_billing/service.ts
+++ b/apps/backend/src/modules/partner_billing/service.ts
@@ -1,5 +1,10 @@
 import { MedusaService } from "@medusajs/framework/utils"
 import PartnerFee from "./models/partner-fee"
+import {
+  planShippingReversal,
+  type ShippingReversal,
+  type ShippingReversalEvent,
+} from "./reverse-shipping"
 
 /**
  * partner_billing — accrues platform commission fees per partner per order (#336).
@@ -50,6 +55,34 @@ class PartnerBillingService extends MedusaService({
       },
     ])
     return updated
+  }
+
+  /**
+   * Reverse the platform-shipping deduction on an order, when its waybill is
+   * cancelled (#1285 follow-up).
+   *
+   * Distinct from `reverseFeeForOrder`, which retires the whole COMMISSION on
+   * `order.canceled`. This retires only the freight line: the order is still
+   * live and will be re-labelled, most likely on a different carrier.
+   *
+   * Idempotent — a row with no active shipping charge returns null and is left
+   * untouched, so a retried cancel cannot stack reversals. Returns the reversal
+   * that was recorded so the caller can surface the amount it just gave back.
+   */
+  async reverseShippingForOrder(
+    orderId: string,
+    event: Omit<ShippingReversalEvent, "reversed_at"> & { reversed_at?: string }
+  ): Promise<ShippingReversal | null> {
+    const fee = await this.findFeeForOrder(orderId)
+    const planned = planShippingReversal(fee as any, {
+      ...event,
+      reversed_at: event.reversed_at || new Date().toISOString(),
+    })
+    if (!planned) {
+      return null
+    }
+    await this.updatePartnerFees([planned.update])
+    return planned.reversal
   }
 }
 

--- a/apps/backend/src/workflows/orders/cancel-shipment.ts
+++ b/apps/backend/src/workflows/orders/cancel-shipment.ts
@@ -12,6 +12,8 @@ import {
   shipmentRefFromFulfillment,
 } from "../../modules/shipping-providers/resolver"
 import { EMAIL_TEMPLATES_MODULE } from "../../modules/email_templates"
+import { PARTNER_BILLING_MODULE } from "../../modules/partner_billing"
+import type { ShippingReversal } from "../../modules/partner_billing/reverse-shipping"
 
 /**
  * Cancel a carrier waybill for a fulfillment, end to end.
@@ -46,6 +48,12 @@ export type CancelledShipmentRecord = {
   reason?: string
   /** Carrier-side ids, kept so the cancellation can be reconciled later. */
   provider_refs?: Record<string, any>
+  /**
+   * The platform-shipping deduction this cancellation gave back to the partner,
+   * when there was one. Absent for a retail order, a partner on their own
+   * carrier account, or a carrier that never quoted a rate.
+   */
+  shipping_reversed?: { amount: number; currency_code: string } | null
 }
 
 /** The carrier keys `createShiprocketShipmentForFulfillment` writes and this clears. */
@@ -114,6 +122,8 @@ export type CancelShipmentResult = {
   cancelled_at: string
   /** True when a customer email actually went out. */
   customer_notified: boolean
+  /** The freight deduction handed back to the partner, when there was one. */
+  shipping_reversed?: ShippingReversal | null
   raw?: any
 }
 
@@ -209,6 +219,19 @@ export async function cancelShipmentForFulfillment(
   }
 
   const cancelledAt = new Date().toISOString()
+
+  // Give the freight back BEFORE the fulfillment write, so the audit entry we
+  // are about to persist records what the cancellation was actually worth. The
+  // waybill is already dead at this point either way.
+  const shippingReversed = await reversePlatformShippingCost(container, {
+    orderId: input.orderId,
+    fulfillmentId: input.fulfillmentId,
+    awb,
+    reason: input.reason,
+    actingEmail: input.actingEmail,
+    reversedAt: cancelledAt,
+  })
+
   const record: CancelledShipmentRecord = {
     carrier,
     awb,
@@ -216,6 +239,12 @@ export async function cancelShipmentForFulfillment(
     cancelled_by: input.actingEmail,
     reason: input.reason,
     provider_refs: ref.provider_refs,
+    shipping_reversed: shippingReversed
+      ? {
+          amount: shippingReversed.amount,
+          currency_code: shippingReversed.currency_code,
+        }
+      : null,
   }
 
   await fulfillmentModule.updateFulfillment(input.fulfillmentId, {
@@ -249,7 +278,59 @@ export async function cancelShipmentForFulfillment(
     awb,
     cancelled_at: cancelledAt,
     customer_notified: customerNotified,
+    shipping_reversed: shippingReversed,
     raw: outcome.raw,
+  }
+}
+
+/**
+ * Hand back the platform-shipping deduction the cancelled label booked.
+ *
+ * `recordPlatformShippingCost` stamps the carrier's quoted rate onto the order's
+ * `partner_fee` at label generation, and the payout view subtracts it. Without
+ * this, cancelling the waybill left that deduction standing — the partner went
+ * on paying freight for an AWB that no longer existed — and the replacement
+ * label silently inherited it whenever the new carrier quoted no rate of its own
+ * (Delhivery never does), so the charge would even keep the dead carrier's name.
+ *
+ * Best-effort, for the same reason the customer email is: the waybill is already
+ * cancelled at the carrier and that cannot be undone. Failing the operation over
+ * a bookkeeping write would report "cancel failed" for a cancel that succeeded.
+ * A miss leaves a stale deduction, which is visible and correctable; a false
+ * failure sends an operator to re-cancel a waybill that is already dead.
+ */
+async function reversePlatformShippingCost(
+  container: MedusaContainer,
+  args: {
+    orderId: string
+    fulfillmentId: string
+    awb?: string
+    reason?: string
+    actingEmail?: string
+    reversedAt: string
+  }
+): Promise<ShippingReversal | null> {
+  const logger: any = container.resolve(ContainerRegistrationKeys.LOGGER)
+  try {
+    const billing: any = container.resolve(PARTNER_BILLING_MODULE)
+    const reversal = await billing.reverseShippingForOrder(args.orderId, {
+      awb: args.awb,
+      fulfillment_id: args.fulfillmentId,
+      reason: args.reason,
+      reversed_by: args.actingEmail,
+      reversed_at: args.reversedAt,
+    })
+    if (reversal) {
+      logger?.info?.(
+        `[cancel-shipment] reversed platform shipping ${reversal.amount} ${reversal.currency_code} (${reversal.carrier}) on order ${args.orderId}`
+      )
+    }
+    return reversal
+  } catch (e: any) {
+    logger?.warn?.(
+      `[cancel-shipment] could not reverse the platform shipping cost on order ${args.orderId}: ${e?.message}. The waybill IS cancelled; the payout still shows the old freight deduction.`
+    )
+    return null
   }
 }
 

--- a/apps/partner-ui/src/hooks/api/partner-order-fee.tsx
+++ b/apps/partner-ui/src/hooks/api/partner-order-fee.tsx
@@ -16,6 +16,21 @@ export type PartnerOrderShippingCharge = {
   is_foreign_currency: boolean
 }
 
+/**
+ * A platform-shipping charge that was deducted and has since been given back,
+ * because its waybill was cancelled (#1285 follow-up). Deducts nothing — it is
+ * already out of `net_payout`, and is shown so the payout never appears to
+ * change value on its own between two views.
+ */
+export type PartnerOrderShippingReversal = {
+  amount: number
+  currency_code: string
+  carrier: string | null
+  awb: string | null
+  reversed_at: string | null
+  reason: string | null
+}
+
 export type PartnerOrderFeeDisplay = {
   order_id: string
   status: string
@@ -27,6 +42,8 @@ export type PartnerOrderFeeDisplay = {
   is_collectible: boolean
   /** Null when the partner shipped on their own account. */
   shipping: PartnerOrderShippingCharge | null
+  /** Freight from cancelled waybills, given back. Usually empty. */
+  shipping_reversals: PartnerOrderShippingReversal[]
   /** order_total − commission − platform shipping. */
   net_payout: number
 }

--- a/apps/partner-ui/src/routes/orders/order-detail/components/order-summary-section/order-summary-section.tsx
+++ b/apps/partner-ui/src/routes/orders/order-detail/components/order-summary-section/order-summary-section.tsx
@@ -1344,6 +1344,37 @@ const PartnerPayout = ({ order }: { order: AdminOrder }) => {
         </Text>
       </div>
 
+      {/* Freight we charged and then gave back because the waybill was
+          cancelled. Listed above the live charge so the panel reads in the order
+          it happened — charged, refunded, re-charged on the new courier — which
+          is the only way a partner who saw the earlier number can reconcile it
+          with the one below. */}
+      {(fee.shipping_reversals || []).map((reversal, i) => (
+        <div
+          key={`${reversal.awb || "reversal"}-${i}`}
+          className="text-ui-fg-muted flex items-start justify-between"
+        >
+          <div className="flex flex-col">
+            <Text size="small" leading="compact">
+              Shipping reversed
+              {reversal.carrier ? ` (${reversal.carrier})` : ""}
+            </Text>
+            <Text size="xsmall" leading="compact" className="text-ui-fg-muted">
+              {reversal.awb
+                ? `AWB ${reversal.awb} was cancelled — this charge was returned.`
+                : "That waybill was cancelled — this charge was returned."}
+            </Text>
+          </div>
+          <Text
+            size="small"
+            leading="compact"
+            className="whitespace-nowrap line-through"
+          >
+            {getStylizedAmount(reversal.amount, reversal.currency_code)}
+          </Text>
+        </div>
+      ))}
+
       {shipping && (
         <div className="text-ui-fg-subtle flex items-start justify-between">
           <div className="flex flex-col">


### PR DESCRIPTION
Follow-up to #1285/#1286. Cancelling a carrier waybill reversed nothing on the money side.

## The bug

`recordPlatformShippingCost` stamps the carrier's quoted rate onto the order's `partner_fee` at label generation, and `describeFee` subtracts it from the payout. `cancelShipmentForFulfillment` cancelled at the carrier, cleared the refs, dropped the label, emailed the customer — and never opened `partner_billing`. The partner kept paying freight for an AWB that no longer existed.

Re-labelling only *appeared* to fix it. `updatePartnerFees` sets `shipping_amount` absolutely, so a new label overwrote the stale figure — but only when the new carrier quoted a rate. It early-returns when it didn't, and **Delhivery never quotes one**. Cancel a Blue Dart AWB at ₹400, re-label on Delhivery, and the partner was still charged ₹400 tagged `shipping_carrier: "bluedart"`. Blue Dart went billable this week, so this was live.

## The fix

`planShippingReversal` (pure, `partner_billing/reverse-shipping.ts`) clears the live charge and appends the cleared figure to `partner_fee.metadata.shipping_reversals`, carrying the cancelled AWB — the handle for matching a carrier credit note later. Clearing alone would stop the deduction, but a payout line that silently changes value between two views is what partners escalate, so the reversal stays visible and the replacement carrier's charge renders as its own line beside it.

- Runs **after** the carrier confirms and **before** the fulfillment write, so the `cancelled_shipments` audit entry records what the cancellation was worth.
- **Best-effort**, for the same reason the customer email is — the waybill is already dead and un-undoable, and reporting "cancel failed" for a cancel that succeeded sends an operator to re-cancel a waybill that isn't live. A miss leaves a stale deduction, which is visible and correctable.
- **Idempotent** — no live charge → returns null, untouched. A retried cancel can't stack phantom reversals.
- A recorded **0 is reversed**: free shipping is a real quoted rate; absence is the only thing meaning "shipped on their own account".
- `net_payout` arithmetic is unchanged — reversals deduct nothing, which is the point.

## Surfaces

Both payout views (admin `order-partner-fee` widget, partner-ui order summary) list reversed lines struck through above the live charge, so the column reads in the order it happened: charged → returned → re-charged on the new courier. The cancel widget also toasts what was handed back, since the deduction lives on a different panel.

## Not fixed here

`findFeeForOrder` is per-ORDER, so a multi-fulfillment order still overwrites rather than sums its freight. Pre-existing and already flagged in the `Migration20260806120000` comment.

## Verify

```
npx jest --testPathPattern="partner_billing"   # 73 pass (18 new)
npx tsc --noEmit                               # 79 = baseline, none in touched files
```

No migration — `partner_fee.metadata` is existing jsonb.

🤖 Generated with [Claude Code](https://claude.com/claude-code)