### PR TITLE
fix(bluedart): send a real shipper address, and fit both addresses to the field caps (#1285)

### DIFF
--- a/apps/backend/src/modules/shipping-providers/__tests__/origin-address.unit.spec.ts
+++ b/apps/backend/src/modules/shipping-providers/__tests__/origin-address.unit.spec.ts
@@ -1,0 +1,101 @@
+import { originAddressFromLocation } from "../origin-address"
+
+/**
+ * The ship-from address Blue Dart puts on the waybill. `CreateShipmentInput.from`
+ * went unpopulated since the #31 spike, which cost nothing while Shiprocket and
+ * Delhivery derived their origin from a registered pickup — and produced a bare,
+ * empty-bodied 400 the first time a Blue Dart waybill was generated on prod.
+ */
+
+const LOCATION = {
+  id: "sloc_1",
+  name: "warehouse-AYV7GRDR",
+  address: {
+    address_1: "Ram Nagar Road Sharlho Factory , Ward 11",
+    address_2: "Near Nandini Villa",
+    company: "JYT",
+    city: "Dhramshala",
+    province: "Himachal Nagar",
+    postal_code: "176215",
+    country_code: "in",
+    phone: "7580067026",
+  },
+}
+
+describe("originAddressFromLocation", () => {
+  it("maps a complete stock location onto a shipment address", () => {
+    expect(originAddressFromLocation(LOCATION)).toEqual({
+      name: "JYT",
+      phone: "7580067026",
+      address_1: "Ram Nagar Road Sharlho Factory , Ward 11",
+      address_2: "Near Nandini Villa",
+      city: "Dhramshala",
+      state: "Himachal Nagar",
+      pincode: "176215",
+      country: "IN",
+    })
+  })
+
+  it("prefers the company over the location name", () => {
+    // The location name is routinely the derived `warehouse-<last8>` handle
+    // (#1234) — a routing key, not something a courier or customs officer reads.
+    expect(originAddressFromLocation(LOCATION)!.name).toBe("JYT")
+    expect(
+      originAddressFromLocation({
+        ...LOCATION,
+        address: { ...LOCATION.address, company: null },
+      })!.name
+    ).toBe("warehouse-AYV7GRDR")
+  })
+
+  it("returns undefined without a street line or a pincode", () => {
+    // A half-filled origin fails Blue Dart's block validation exactly as a blank
+    // one does, while an absent `from` keeps Shiprocket and Delhivery working.
+    expect(
+      originAddressFromLocation({
+        ...LOCATION,
+        address: { ...LOCATION.address, postal_code: "  " },
+      })
+    ).toBeUndefined()
+    expect(
+      originAddressFromLocation({
+        ...LOCATION,
+        address: { ...LOCATION.address, address_1: "" },
+      })
+    ).toBeUndefined()
+  })
+
+  it("returns undefined for a location with no address at all", () => {
+    expect(originAddressFromLocation({ id: "sloc_1", name: "x" })).toBeUndefined()
+    expect(originAddressFromLocation(null)).toBeUndefined()
+    expect(originAddressFromLocation(undefined)).toBeUndefined()
+  })
+
+  it("still maps a location missing its phone — 17 of 22 prod locations are (#1236)", () => {
+    const addr = originAddressFromLocation({
+      ...LOCATION,
+      address: { ...LOCATION.address, phone: null },
+    })!
+    expect(addr.phone).toBe("")
+    expect(addr.pincode).toBe("176215")
+  })
+
+  it("drops an empty address_2 rather than sending a blank line", () => {
+    expect(
+      originAddressFromLocation({
+        ...LOCATION,
+        address: { ...LOCATION.address, address_2: "   " },
+      })!.address_2
+    ).toBeUndefined()
+  })
+
+  it("defaults the country to IN and normalises its case", () => {
+    expect(originAddressFromLocation(LOCATION)!.country).toBe("IN")
+    expect(
+      originAddressFromLocation({
+        ...LOCATION,
+        address: { ...LOCATION.address, country_code: null },
+      })!.country
+    ).toBe("IN")
+  })
+})

--- a/apps/backend/src/modules/shipping-providers/bluedart/__tests__/address.unit.spec.ts
+++ b/apps/backend/src/modules/shipping-providers/bluedart/__tests__/address.unit.spec.ts
@@ -1,0 +1,133 @@
+import {
+  BLUEDART_TEXT_MAX,
+  blueDartDigits,
+  blueDartField,
+  packBlueDartAddress,
+  sanitiseBlueDartText,
+} from "../address"
+
+/**
+ * Blue Dart caps every name and address line at 30 characters and says nothing
+ * when you exceed it — the waybill call returns a bare 400 with an EMPTY body.
+ * Both real addresses on order 83 are over the cap, so these are the normal
+ * shape of an Indian address, not contrived edge cases.
+ */
+
+// The two addresses that actually failed on prod, 2026-08-14.
+const ORIGIN_83 = "Ram Nagar Road Sharlho Factory , Ward 11" // 40 chars
+const DEST_83 = "A502, Prathna Greens, Sargasan, Gandhinagar" // 43 chars
+
+describe("sanitiseBlueDartText", () => {
+  it("drops characters outside the accepted set and collapses the gap", () => {
+    // An em dash is the exact character that got `Remarks` rejected live.
+    expect(sanitiseBlueDartText("Ward 11 — Block A")).toBe("Ward 11 Block A")
+    expect(sanitiseBlueDartText("Café Résidence")).toBe("Caf R sidence")
+  })
+
+  it("drops the comma, which the guide leaves ambiguous", () => {
+    expect(sanitiseBlueDartText("A502, Prathna Greens")).toBe("A502 Prathna Greens")
+  })
+
+  it("keeps the punctuation the guide does list", () => {
+    expect(sanitiseBlueDartText("No.12/A (Rear) & Co-op #3")).toBe(
+      "No.12/A (Rear) & Co-op #3"
+    )
+  })
+
+  it("does not truncate — packing decides that", () => {
+    expect(sanitiseBlueDartText(ORIGIN_83).length).toBeGreaterThan(BLUEDART_TEXT_MAX)
+  })
+
+  it("survives nullish input", () => {
+    expect(sanitiseBlueDartText(null)).toBe("")
+    expect(sanitiseBlueDartText(undefined)).toBe("")
+  })
+})
+
+describe("blueDartField", () => {
+  it("truncates a name to the 30-character cap", () => {
+    const long = "Jaal Yantra Textiles Private Limited"
+    expect(blueDartField(long)).toBe("Jaal Yantra Textiles Private L")
+    expect(blueDartField(long).length).toBe(BLUEDART_TEXT_MAX)
+  })
+
+  it("leaves a short name alone", () => {
+    expect(blueDartField("JYT")).toBe("JYT")
+  })
+})
+
+describe("blueDartDigits", () => {
+  it("strips everything that is not a digit — Pincode and Mobile are numeric", () => {
+    expect(blueDartDigits("+91 75800-67026", 15)).toBe("917580067026")
+    expect(blueDartDigits("176 215", 6)).toBe("176215")
+  })
+
+  it("caps to the field width", () => {
+    expect(blueDartDigits("1762159999", 6)).toBe("176215")
+  })
+
+  it("returns empty for a missing value rather than 'undefined'", () => {
+    expect(blueDartDigits(undefined, 6)).toBe("")
+    expect(blueDartDigits(null)).toBe("")
+  })
+})
+
+describe("packBlueDartAddress", () => {
+  it("wraps order 83's origin on a word boundary instead of failing", () => {
+    const packed = packBlueDartAddress(ORIGIN_83, "Near Nandini Villa")
+    expect(packed.line1).toBe("Ram Nagar Road Sharlho Factory")
+    expect(packed.line2).toBe("Ward 11 Near Nandini Villa")
+    expect(packed.line3).toBe("")
+    for (const line of [packed.line1, packed.line2, packed.line3]) {
+      expect(line.length).toBeLessThanOrEqual(BLUEDART_TEXT_MAX)
+    }
+  })
+
+  it("wraps order 83's destination", () => {
+    const packed = packBlueDartAddress(DEST_83, "")
+    expect(packed.line1).toBe("A502 Prathna Greens Sargasan")
+    expect(packed.line2).toBe("Gandhinagar")
+    expect(packed.line1.length).toBeLessThanOrEqual(BLUEDART_TEXT_MAX)
+  })
+
+  it("never breaks mid-word", () => {
+    const packed = packBlueDartAddress(
+      "Twentyfour Something Roadway Junction Extension"
+    )
+    // Rejoining the lines must reproduce the words in order.
+    expect(`${packed.line1} ${packed.line2} ${packed.line3}`.trim()).toBe(
+      "Twentyfour Something Roadway Junction Extension"
+    )
+  })
+
+  it("hard-splits a single word longer than a line rather than dropping it", () => {
+    const packed = packBlueDartAddress("A".repeat(45))
+    expect(packed.line1).toBe("A".repeat(30))
+    expect(packed.line2).toBe("A".repeat(15))
+  })
+
+  it("discards overflow past the third line — the pincode still routes it", () => {
+    const packed = packBlueDartAddress("word ".repeat(60))
+    expect(packed.line1.length).toBeLessThanOrEqual(BLUEDART_TEXT_MAX)
+    expect(packed.line2.length).toBeLessThanOrEqual(BLUEDART_TEXT_MAX)
+    expect(packed.line3.length).toBeLessThanOrEqual(BLUEDART_TEXT_MAX)
+  })
+
+  it("returns three empty lines for no address — the blank Shipper case", () => {
+    // This is exactly what production sent before `from` was populated, and
+    // what Blue Dart answered with an empty-bodied 400.
+    expect(packBlueDartAddress(undefined, undefined)).toEqual({
+      line1: "",
+      line2: "",
+      line3: "",
+    })
+  })
+
+  it("keeps a short address on one line", () => {
+    expect(packBlueDartAddress("12 Mall Road", undefined)).toEqual({
+      line1: "12 Mall Road",
+      line2: "",
+      line3: "",
+    })
+  })
+})

--- a/apps/backend/src/modules/shipping-providers/bluedart/adapter.ts
+++ b/apps/backend/src/modules/shipping-providers/bluedart/adapter.ts
@@ -26,6 +26,11 @@ import {
   toBlueDartTime,
   toMsJsonDate,
 } from "./constants"
+import {
+  blueDartDigits,
+  blueDartField,
+  packBlueDartAddress,
+} from "./address"
 import type { BlueDartConfig } from "./types"
 
 /**
@@ -79,17 +84,34 @@ export class BlueDartProviderAdapter implements ShippingProviderClient {
   async createShipment(input: CreateShipmentInput): Promise<ShipmentResult> {
     const international = isInternationalDestination(input.to.country)
     const dims = input.dimensions_cm
+    // Every name and address line is capped at 30 characters and Blue Dart
+    // reports a breach as an empty-bodied 400, so pack both addresses before
+    // building the request rather than discovering it at the gateway.
+    const consignee = packBlueDartAddress(input.to.address_1, input.to.address_2)
+    const shipper = packBlueDartAddress(
+      input.from?.address_1,
+      input.from?.address_2
+    )
+    // `pickup_location_name` is the fallback the Shipper block has always used,
+    // but it is frequently the derived `warehouse-<last8>` handle (#1234) — a
+    // routing key rather than a sender a courier should read.
+    const shipperName = blueDartField(
+      input.from?.name || input.pickup_location_name
+    )
     const request: Record<string, any> = {
       Consignee: {
-        ConsigneeName: input.to.name,
-        ConsigneeAddress1: input.to.address_1,
-        ConsigneeAddress2: input.to.address_2 || "",
-        ConsigneeAddress3: "",
+        ConsigneeName: blueDartField(input.to.name),
+        // Packed, not truncated: a 43-character street line (order 83's
+        // Gandhinagar address) has to wrap onto the optional lines or Blue Dart
+        // 400s with an empty body naming nothing.
+        ConsigneeAddress1: consignee.line1,
+        ConsigneeAddress2: consignee.line2,
+        ConsigneeAddress3: consignee.line3,
         ConsigneeAddressType: "R",
-        ConsigneeAttention: input.to.name,
+        ConsigneeAttention: blueDartField(input.to.name),
         ConsigneeEmailID: input.to.email || "",
-        ConsigneeMobile: input.to.phone,
-        ConsigneePincode: input.to.pincode,
+        ConsigneeMobile: blueDartDigits(input.to.phone, 15),
+        ConsigneePincode: blueDartDigits(input.to.pincode, 6),
         ConsigneeTelephone: "",
         ...(international
           ? {
@@ -99,29 +121,29 @@ export class BlueDartProviderAdapter implements ShippingProviderClient {
           : {}),
       },
       Shipper: {
-        CustomerName: input.from?.name || input.pickup_location_name,
+        CustomerName: shipperName,
         CustomerCode: this.client.profile.Customercode,
-        CustomerAddress1: input.from?.address_1 || "",
-        CustomerAddress2: input.from?.address_2 || "",
-        CustomerAddress3: "",
+        CustomerAddress1: shipper.line1,
+        CustomerAddress2: shipper.line2,
+        CustomerAddress3: shipper.line3,
         CustomerEmailID: input.from?.email || "",
         CustomerGSTNumber: input.tax_id || "",
-        CustomerMobile: input.from?.phone || "",
-        CustomerPincode: input.from?.pincode || "",
+        CustomerMobile: blueDartDigits(input.from?.phone, 15),
+        CustomerPincode: blueDartDigits(input.from?.pincode, 6),
         CustomerTelephone: "",
         IsToPayCustomer: false,
         OriginArea: this.client.originArea,
-        Sender: input.from?.name || input.pickup_location_name,
+        Sender: shipperName,
         VendorCode: "",
       },
       Returnadds: {
-        ReturnAddress1: input.from?.address_1 || "",
-        ReturnAddress2: input.from?.address_2 || "",
-        ReturnAddress3: "",
-        ReturnContact: input.from?.name || input.pickup_location_name,
+        ReturnAddress1: shipper.line1,
+        ReturnAddress2: shipper.line2,
+        ReturnAddress3: shipper.line3,
+        ReturnContact: shipperName,
         ReturnEmailID: input.from?.email || "",
-        ReturnMobile: input.from?.phone || "",
-        ReturnPincode: input.from?.pincode || "",
+        ReturnMobile: blueDartDigits(input.from?.phone, 15),
+        ReturnPincode: blueDartDigits(input.from?.pincode, 6),
         ReturnTelephone: "",
         ManifestNumber: "",
       },

--- a/apps/backend/src/modules/shipping-providers/bluedart/address.ts
+++ b/apps/backend/src/modules/shipping-providers/bluedart/address.ts
@@ -1,0 +1,124 @@
+/**
+ * Fitting an address into Blue Dart's waybill fields.
+ *
+ * Blue Dart caps EVERY name and address line at 30 characters and restricts the
+ * character set, and it does not tell you when you break either rule: an
+ * over-long `ConsigneeAddress1` comes back as a bare 400 with an EMPTY body,
+ * which names no field and reads like an auth or routing fault. (This is the
+ * same class as `Remarks` rejecting an em dash — the gateway validates, then
+ * says nothing.)
+ *
+ * Both real addresses on order 83 exceed the cap: the Dharamshala origin is 40
+ * characters and the Gandhinagar destination 43. So this is not an edge case
+ * being defended against — it is the normal shape of an Indian street address,
+ * and no Blue Dart waybill for that order could ever have been generated
+ * without packing them.
+ *
+ * Per the Blue Dart developer guide, Shipper and Consignee share the limits:
+ *   *Name       30, mandatory
+ *   *Address1   30, mandatory
+ *   *Address2   30, optional
+ *   *Address3   30, optional
+ *   *Pincode     6, numeric, mandatory
+ *   *Mobile  10-15, numeric, optional
+ */
+
+/** Max length of a Blue Dart name / address line. */
+export const BLUEDART_TEXT_MAX = 30
+
+/**
+ * Characters Blue Dart accepts in a name or address line, per the developer
+ * guide: alphanumerics plus `./?;:'~!\@"#$%^&*()[]+=_-`, and space.
+ *
+ * The comma is deliberately EXCLUDED. The guide publishes the set as a
+ * comma-separated list, which leaves the comma itself ambiguous — and an
+ * ambiguous character is not worth a silent 400 on a billable waybill when
+ * dropping it costs an address nothing a courier needs.
+ */
+const ALLOWED = /[^a-zA-Z0-9 ./?;:'~!\\@"#$%^&*()[\]+=_-]/g
+
+/**
+ * Strip characters Blue Dart rejects and collapse the whitespace that leaves
+ * behind. Does NOT truncate — packing decides that, so a long line can be
+ * wrapped onto the next field rather than losing its tail.
+ */
+export function sanitiseBlueDartText(value: unknown): string {
+  return String(value ?? "")
+    .replace(ALLOWED, " ")
+    .replace(/\s+/g, " ")
+    .trim()
+}
+
+/** A name or single field: sanitised and hard-truncated to the cap. */
+export function blueDartField(
+  value: unknown,
+  max: number = BLUEDART_TEXT_MAX
+): string {
+  return sanitiseBlueDartText(value).slice(0, max)
+}
+
+/** Digits only — what Pincode and Mobile accept. */
+export function blueDartDigits(value: unknown, max?: number): string {
+  const digits = String(value ?? "").replace(/\D/g, "")
+  return max ? digits.slice(0, max) : digits
+}
+
+/**
+ * Pack address parts into Blue Dart's three 30-character lines.
+ *
+ * Wraps on WORD boundaries so a line breaks between words rather than mid-street
+ * — "Ram Nagar Road Sharlho Factory" / "Ward 11" instead of a hard cut. A single
+ * word longer than the cap (rare, but a run-on building code does it) is split
+ * hard, because refusing to split would drop it entirely.
+ *
+ * Overflow past the third line is discarded rather than crammed: Blue Dart
+ * prints these lines on the label, and the parts that fit are the ones a courier
+ * needs. The pincode, which is what actually routes the parcel, is a separate
+ * mandatory field and is never at risk from this.
+ */
+export function packBlueDartAddress(
+  ...parts: Array<string | null | undefined>
+): { line1: string; line2: string; line3: string } {
+  const words = parts
+    .map((p) => sanitiseBlueDartText(p))
+    .filter(Boolean)
+    .join(" ")
+    .split(" ")
+    .filter(Boolean)
+
+  const lines: string[] = []
+  let current = ""
+  const flush = () => {
+    if (current) {
+      lines.push(current)
+      current = ""
+    }
+  }
+
+  for (let word of words) {
+    // A single over-long word can never fit a line; break it up rather than
+    // silently dropping it.
+    while (word.length > BLUEDART_TEXT_MAX) {
+      flush()
+      if (lines.length >= 3) break
+      lines.push(word.slice(0, BLUEDART_TEXT_MAX))
+      word = word.slice(BLUEDART_TEXT_MAX)
+    }
+    if (lines.length >= 3) break
+    const candidate = current ? `${current} ${word}` : word
+    if (candidate.length <= BLUEDART_TEXT_MAX) {
+      current = candidate
+    } else {
+      flush()
+      if (lines.length >= 3) break
+      current = word
+    }
+  }
+  flush()
+
+  return {
+    line1: lines[0] || "",
+    line2: lines[1] || "",
+    line3: lines[2] || "",
+  }
+}

--- a/apps/backend/src/modules/shipping-providers/origin-address.ts
+++ b/apps/backend/src/modules/shipping-providers/origin-address.ts
@@ -1,0 +1,98 @@
+import { ContainerRegistrationKeys } from "@medusajs/framework/utils"
+import type { MedusaContainer } from "@medusajs/framework/types"
+import type { ShipmentAddress } from "./provider-interface"
+
+/**
+ * The seller / ship-from address for a shipment, read off the fulfillment's
+ * stock location.
+ *
+ * `CreateShipmentInput.from` has existed since the #31 provider spike and
+ * NOTHING ever populated it — `buildCreateShipmentInput` simply never set the
+ * field. That was invisible for the first two carriers, exactly as the interface
+ * comment says: Shiprocket derives the origin from the registered
+ * `pickup_location_name`, and Delhivery from the registered warehouse. Neither
+ * reads `from`, so an empty one cost nothing.
+ *
+ * Blue Dart does read it. Its waybill carries the origin inline — `Shipper`
+ * (address, pincode, mobile) and `Returnadds` — and with `from` undefined every
+ * one of those fields went out as `""`. Blue Dart answers that with a bare 400
+ * and an EMPTY body, which names nothing and reads like an auth or path fault.
+ * On an export it matters twice over: the shipper address is on the customs
+ * paperwork, not just the routing.
+ *
+ * Best-effort by design. A location we cannot read leaves `from` undefined,
+ * which is exactly the behaviour every existing Shiprocket and Delhivery label
+ * had — so this can only add information, never take a working label away.
+ */
+export async function resolveOriginAddress(
+  container: MedusaContainer,
+  locationId?: string | null
+): Promise<ShipmentAddress | undefined> {
+  if (!locationId) {
+    return undefined
+  }
+  const query: any = container.resolve(ContainerRegistrationKeys.QUERY)
+  const logger: any = container.resolve(ContainerRegistrationKeys.LOGGER)
+  try {
+    const { data: locs } = await query.graph({
+      entity: "stock_location",
+      fields: [
+        "id",
+        "name",
+        "address.address_1",
+        "address.address_2",
+        "address.city",
+        "address.province",
+        "address.postal_code",
+        "address.country_code",
+        "address.phone",
+        "address.company",
+      ],
+      filters: { id: locationId },
+    })
+    return originAddressFromLocation(locs?.[0])
+  } catch (e: any) {
+    logger?.warn?.(
+      `[origin-address] could not read the ship-from address for location ${locationId}: ${e?.message}`
+    )
+    return undefined
+  }
+}
+
+/**
+ * Pure: a stock location → `ShipmentAddress`, or undefined when there is not
+ * enough of one to be worth sending.
+ *
+ * The bar is a street line AND a pincode. A half-filled origin is worse than
+ * none: Blue Dart validates the block as a unit, so sending a name with a blank
+ * pincode fails the same 400 as sending nothing, while an absent `from` keeps
+ * the carriers that derive their origin from a registered pickup working
+ * exactly as before.
+ *
+ * `company` wins over the location's own name because the location name is
+ * frequently the derived `warehouse-<last8>` handle (#1234), which is a routing
+ * key rather than something a courier or a customs officer should read.
+ */
+export function originAddressFromLocation(
+  location: any
+): ShipmentAddress | undefined {
+  const addr = location?.address
+  if (!addr) {
+    return undefined
+  }
+  const address_1 = String(addr.address_1 || "").trim()
+  const pincode = String(addr.postal_code || "").trim()
+  if (!address_1 || !pincode) {
+    return undefined
+  }
+  return {
+    name: String(addr.company || location?.name || "").trim(),
+    phone: String(addr.phone || "").trim(),
+    address_1,
+    address_2: String(addr.address_2 || "").trim() || undefined,
+    city: String(addr.city || "").trim(),
+    state: String(addr.province || "").trim(),
+    pincode,
+    country: String(addr.country_code || "IN").toUpperCase(),
+  }
+}

--- a/apps/backend/src/workflows/orders/__tests__/plan-cancelled-fulfillment-data.unit.spec.ts
+++ b/apps/backend/src/workflows/orders/__tests__/plan-cancelled-fulfillment-data.unit.spec.ts
@@ -18,7 +18,7 @@ const RECORD: CancelledShipmentRecord = {
 }
 
 describe("planCancelledFulfillmentData", () => {
-  it("strips every carrier ref so the fulfillment reads as un-labelled", () => {
+  it("NULLS every carrier ref — deleting them does not survive the jsonb merge", () => {
     const next = planCancelledFulfillmentData(
       {
         carrier: "delhivery",
@@ -33,8 +33,12 @@ describe("planCancelledFulfillmentData", () => {
       RECORD
     )
 
-    // The "generate label" path keys off these being absent — a leftover would
-    // make the order look shipped and block the re-label it exists to enable.
+    // This assertion used to be `not.toHaveProperty` and passed for months while
+    // the refs sat untouched on prod: `updateFulfillment` MERGES `data`, so a key
+    // this function removes is re-supplied from the stored row. Order 83's
+    // cancellation (Delhivery AWB 41712510000092) is the proof — audit entry
+    // written, labels dropped, `waybill` still there. The key must be PRESENT and
+    // null, which is what actually overwrites the stored value.
     for (const key of [
       "carrier",
       "waybill",
@@ -45,8 +49,22 @@ describe("planCancelledFulfillmentData", () => {
       "sr_order_id",
       "provider_refs",
     ]) {
-      expect(next).not.toHaveProperty(key)
+      expect(next).toHaveProperty(key)
+      expect(next[key]).toBeNull()
     }
+  })
+
+  it("leaves the refs falsy, which is what every reader actually tests", () => {
+    const next = planCancelledFulfillmentData(
+      { carrier: "bluedart", waybill: "AWB1", provider_refs: { waybill: "AWB1" } },
+      RECORD
+    )
+    // `shipmentRefFromFulfillment`, the label widget and the re-label path all
+    // key off truthiness, so a null reads identically to an absent key to them —
+    // that equivalence is the whole reason nulling is safe.
+    expect(next.waybill).toBeFalsy()
+    expect(next.carrier).toBeFalsy()
+    expect(next.provider_refs).toBeFalsy()
   })
 
   it("keeps unrelated fulfillment data untouched", () => {
@@ -76,12 +94,21 @@ describe("planCancelledFulfillmentData", () => {
   })
 
   it("survives a fulfillment that has no data at all", () => {
-    expect(planCancelledFulfillmentData(null, RECORD)).toEqual({
+    // The nulls are written unconditionally: a row that never had the key is
+    // unaffected by being sent an explicit null for it.
+    const expected = {
+      carrier: null,
+      waybill: null,
+      tracking_number: null,
+      tracking_url: null,
+      label_url: null,
+      shipment_id: null,
+      sr_order_id: null,
+      provider_refs: null,
       cancelled_shipments: [RECORD],
-    })
-    expect(planCancelledFulfillmentData(undefined, RECORD)).toEqual({
-      cancelled_shipments: [RECORD],
-    })
+    }
+    expect(planCancelledFulfillmentData(null, RECORD)).toEqual(expected)
+    expect(planCancelledFulfillmentData(undefined, RECORD)).toEqual(expected)
   })
 
   it("does not mutate the fulfillment data it was handed", () => {

--- a/apps/backend/src/workflows/orders/cancel-shipment.ts
+++ b/apps/backend/src/workflows/orders/cancel-shipment.ts
@@ -77,6 +77,16 @@ const CARRIER_DATA_KEYS = [
  * anyone has for reconciling a carrier invoice against it later. Losing that on
  * the way out would make the cancellation itself untraceable.
  *
+ * ⚠️ The refs are NULLED, not deleted, and that is load-bearing.
+ * `updateFulfillment` MERGES the `data` jsonb (unlike `labels`, which it
+ * replaces wholesale), so a key removed from the object we hand it is simply
+ * re-supplied from the stored row. The first real cancellation on prod — order
+ * 83, Delhivery AWB 41712510000092 — proved it: the audit entry appeared, the
+ * label rows went, and `waybill` / `carrier` / `tracking_number` all survived a
+ * function whose unit tests correctly showed them deleted. Every reader treats
+ * these as truthy-or-absent, so an explicit null reads as "gone" while actually
+ * surviving the merge.
+ *
  * Exported for unit testing: this is the half that decides what survives.
  */
 export function planCancelledFulfillmentData(
@@ -85,7 +95,7 @@ export function planCancelledFulfillmentData(
 ): Record<string, any> {
   const next: Record<string, any> = { ...(data || {}) }
   for (const key of CARRIER_DATA_KEYS) {
-    delete next[key]
+    next[key] = null
   }
   const history = Array.isArray(next.cancelled_shipments)
     ? next.cancelled_shipments

--- a/apps/backend/src/workflows/orders/shiprocket-shipment.ts
+++ b/apps/backend/src/workflows/orders/shiprocket-shipment.ts
@@ -9,9 +9,11 @@ import type {
   CreateShipmentInput,
   CustomsDeclaration,
   Dimensions,
+  ShipmentAddress,
   ShipmentItem,
   ShipmentResult,
 } from "../../modules/shipping-providers/provider-interface"
+import { resolveOriginAddress } from "../../modules/shipping-providers/origin-address"
 import { resolveExportIgstForCountry } from "../../modules/shipping-providers/export-igst"
 import {
   SHIPROCKET_PICKUP_METADATA_KEY,
@@ -130,6 +132,13 @@ export type BuildShipmentOpts = {
   preferredCourierId?: string | number
   /** Seller tax/GST ID to stamp on the label (#348); resolved by the caller. */
   taxId?: string
+  /**
+   * The ship-from address, read off the fulfillment's stock location. Shiprocket
+   * and Delhivery ignore it (they derive the origin from a registered pickup);
+   * Blue Dart puts it on the waybill and rejects a blank one. Omitted when the
+   * location has no usable address, which is the pre-existing behaviour.
+   */
+  originAddress?: ShipmentAddress
   /**
    * The fulfillment's own lines. When given, ONLY these are declared, at these
    * quantities — a shipment must describe what's in the box, not the whole
@@ -284,6 +293,11 @@ export function buildCreateShipmentInput(
       pincode,
       country: addr.country_code ? String(addr.country_code).toUpperCase() : "IN",
     },
+    // Blue Dart stamps this onto the waybill (Shipper + Returnadds) and rejects
+    // a blank one with an empty-bodied 400. Shiprocket and Delhivery ignore it
+    // and derive the origin from the registered pickup, so leaving it undefined
+    // when the location has no usable address changes nothing for them.
+    from: opts.originAddress,
     items,
     weight_grams: opts.weightGrams || DEFAULT_WEIGHT_GRAMS,
     dimensions_cm: opts.dimensionsCm,
@@ -538,6 +552,11 @@ export async function createShiprocketShipmentForFulfillment(
     taxId,
     fulfillmentItems,
     customs,
+    // Read from the fulfillment's own location, not the resolved pickup NAME:
+    // the name is a carrier-side registry key (and often the derived
+    // `warehouse-<last8>` handle), while this is the postal address Blue Dart
+    // puts on the waybill and the customs paperwork.
+    originAddress: await resolveOriginAddress(container, fulfillment.location_id),
   })
 
   // International FX (#1111 S3). Shiprocket declares the customs value only in a


### PR DESCRIPTION
The first Blue Dart waybill ever generated through the app — order 83, moving off Delhivery on prod — failed with a bare **400 and an empty response body**. Three defects, none catchable by a test, because all three only exist on the path between a real order and the carrier.

## 1. `CreateShipmentInput.from` was never populated

The field has existed since the #31 spike; `buildCreateShipmentInput` simply never set it. Invisible for the first two carriers — Shiprocket derives its origin from the registered pickup name, Delhivery from the registered warehouse, exactly as the interface comment says. **Blue Dart reads it**, so every `Shipper` and `Returnadds` field went out as `""`.

Per the [Blue Dart developer guide](https://docsbay.net/doc/1132469/developers-guide-for-integrating-blue-dart-api), `CustomerAddress1` and `CustomerPincode` are **mandatory**. That's the 400.

## 2. Every name and address line is capped at 30 characters

Same silent failure mode. Order 83's origin is **40 chars** (`Ram Nagar Road Sharlho Factory , Ward 11`) and its destination **43** (`A502, Prathna Greens, Sargasan, Gandhinagar`) — so populating `from` alone would have failed again, and the `Consignee` block we've always sent unbounded was over the cap too. Addresses now pack across the three provided lines on word boundaries; pincode and mobile reduce to digits.

Caps are from the guide, not inferred: name/address 30, pincode 6 numeric, mobile 10–15 numeric. The comma is dropped from the accepted character set because the guide publishes that set *as a comma-separated list*, leaving the comma itself ambiguous — not worth a silent 400 on a billable waybill.

## 3. Cancelling a waybill did not clear the carrier refs

`updateFulfillment` **merges** the `data` jsonb (unlike `labels`, which it replaces), so the `delete` in `planCancelledFulfillmentData` was a no-op against the stored row. Order 83's cancellation is the proof — audit entry written, labels dropped, `waybill` / `carrier` / `tracking_number` all still present. The unit test asserted `not.toHaveProperty` on the *returned object* and passed throughout; it now pins the real contract.

Keys are **nulled**, which survives the merge. Every reader tests truthiness, so a null reads identically to absent.

## Safety

Origin resolution is best-effort: a location without both a street line and a pincode yields no `from` at all — precisely what every existing Shiprocket and Delhivery label already had. This can only add information, never take a working label away.

## Verify

```
npx jest --testPathPattern="bluedart|origin-address|plan-cancelled"   # 60 pass
npx tsc --noEmit                                                      # 79 = baseline
```

Order 83 is currently cancelled at Delhivery with no replacement label; it gets its Blue Dart waybill once this deploys.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
