### PR TITLE
feat(shipping): attach and detach an externally-booked AWB (#1285)

### DIFF
--- a/apps/backend/integration-tests/http/shiprocket-attach-awb.spec.ts
+++ b/apps/backend/integration-tests/http/shiprocket-attach-awb.spec.ts
@@ -282,5 +282,59 @@ setupSharedTestSuite(() => {
       await fulfillmentModule.updateFulfillment(fulfillmentId, { labels: [] })
       expect(await labelsOf()).toHaveLength(0)
     })
+
+    it("updateFulfillment MERGES data — delete is a no-op, null is what clears", async () => {
+      // The sibling of the labels rule above, and the OPPOSITE of it. Missing
+      // this cost us order 83 on prod: the cancel flow removed the carrier keys
+      // from the object it passed, the pure unit test asserted they were gone
+      // and passed, and the stored row went on advertising a Delhivery AWB that
+      // was already dead at the carrier. A pure-function test structurally
+      // cannot see this — only a round trip through the ORM can.
+      const container = getContainer()
+      const query: any = container.resolve(ContainerRegistrationKeys.QUERY)
+      const fulfillmentModule: any = container.resolve(Modules.FULFILLMENT)
+
+      const lineItemId = await buildDesignOrder()
+      const convertRes = await api.post(
+        `/admin/designs/orders/${lineItemId}/convert`,
+        { payment_mode: "prepaid" },
+        adminHeaders
+      )
+      const orderId = convertRes.data.design_order_conversion.order_id
+      const fulfillmentId = await ensureOrderFulfillment(container, orderId)
+
+      const dataOf = async () => {
+        const { data } = await query.graph({
+          entity: "fulfillment",
+          fields: ["id", "data"],
+          filters: { id: fulfillmentId },
+        })
+        return data?.[0]?.data || {}
+      }
+
+      await fulfillmentModule.updateFulfillment(fulfillmentId, {
+        data: { carrier: "delhivery", waybill: "AWB-MERGE-1", keep_me: "yes" },
+      })
+      expect((await dataOf()).waybill).toBe("AWB-MERGE-1")
+
+      // Omitting a key does NOT remove it — this is the trap.
+      await fulfillmentModule.updateFulfillment(fulfillmentId, {
+        data: { keep_me: "yes", cancelled_shipments: [{ awb: "AWB-MERGE-1" }] },
+      })
+      const afterOmit = await dataOf()
+      expect(afterOmit.cancelled_shipments).toHaveLength(1)
+      expect(afterOmit.waybill).toBe("AWB-MERGE-1")
+      expect(afterOmit.carrier).toBe("delhivery")
+
+      // An explicit null does, which is why the cancel and detach planners
+      // write nulls instead of deleting.
+      await fulfillmentModule.updateFulfillment(fulfillmentId, {
+        data: { ...afterOmit, carrier: null, waybill: null },
+      })
+      const afterNull = await dataOf()
+      expect(afterNull.waybill).toBeFalsy()
+      expect(afterNull.carrier).toBeFalsy()
+      expect(afterNull.keep_me).toBe("yes")
+    })
   })
 })

--- a/apps/backend/src/api/admin/orders/[id]/external-awb/route.ts
+++ b/apps/backend/src/api/admin/orders/[id]/external-awb/route.ts
@@ -1,0 +1,73 @@
+import { MedusaRequest, MedusaResponse } from "@medusajs/framework/http"
+import { Modules } from "@medusajs/framework/utils"
+import { z } from "zod"
+import { ensureOrderFulfillment } from "../../../../../workflows/orders/fulfillment-context"
+import { attachExternalAwb } from "../../../../../workflows/orders/external-awb"
+
+/**
+ * POST /admin/orders/:id/external-awb
+ *
+ * The manual override: attach a waybill we did NOT book. For a carrier we do
+ * not integrate (DTDC, India Post, a local courier), a counter booking, or a
+ * waybill generated on a carrier's own portal because ours would not — which is
+ * exactly where order 83 sat while Blue Dart answered with an empty 400.
+ *
+ * NO carrier API is called, for creation OR validation. That is the whole
+ * point: `POST /admin/orders/:id/shiprocket-attach-awb` validates by looking
+ * the AWB up, which hard-wires it to Shiprocket and would reject a freshly
+ * created waybill anyway (Blue Dart's TnT cannot distinguish a scanless AWB
+ * from a typo). The operator holding the physical waybill is the authority.
+ *
+ * ADMIN ONLY, matching the cancel flow: asserting that a parcel is out on a
+ * carrier we cannot verify is a claim only staff should be able to make.
+ */
+const Body = z.object({
+  awb: z.string().trim().min(1, "An AWB is required"),
+  carrier: z.string().trim().min(1, "A carrier name is required"),
+  /** Where a human can follow the parcel; free-form, carrier-specific. */
+  tracking_url: z.string().trim().url().optional(),
+  label_url: z.string().trim().url().optional(),
+  /** Existing fulfillment to attach to; one is created when omitted. */
+  fulfillment_id: z.string().trim().optional(),
+  /** Defaults to false — attaching and handing over are different events. */
+  mark_shipped: z.boolean().optional(),
+  /** Why this was booked outside the system. Kept in the audit trail. */
+  notes: z.string().trim().max(500).optional(),
+})
+
+/** The logged-in admin's email, recorded on the attachment. */
+const resolveActorEmail = async (
+  req: MedusaRequest
+): Promise<string | undefined> => {
+  try {
+    const actorId = (req as any).auth_context?.actor_id
+    if (!actorId) return undefined
+    const userService: any = req.scope.resolve(Modules.USER)
+    const user = await userService.retrieveUser(actorId)
+    return user?.email
+  } catch {
+    return undefined
+  }
+}
+
+export const POST = async (req: MedusaRequest, res: MedusaResponse) => {
+  const orderId = req.params.id
+  const body = Body.parse((req.body as Record<string, unknown>) ?? {})
+
+  const fulfillmentId =
+    body.fulfillment_id || (await ensureOrderFulfillment(req.scope, orderId))
+
+  const result = await attachExternalAwb(req.scope, {
+    orderId,
+    fulfillmentId,
+    awb: body.awb,
+    carrier: body.carrier,
+    trackingUrl: body.tracking_url,
+    labelUrl: body.label_url,
+    markShipped: body.mark_shipped === true,
+    notes: body.notes,
+    actingEmail: await resolveActorEmail(req),
+  })
+
+  res.status(200).json({ external_awb: result })
+}

--- a/apps/backend/src/api/admin/orders/[id]/fulfillments/[fulfillmentId]/external-awb/route.ts
+++ b/apps/backend/src/api/admin/orders/[id]/fulfillments/[fulfillmentId]/external-awb/route.ts
@@ -1,0 +1,52 @@
+import { MedusaRequest, MedusaResponse } from "@medusajs/framework/http"
+import { Modules } from "@medusajs/framework/utils"
+import { z } from "zod"
+import { detachAwbFromFulfillment } from "../../../../../../../workflows/orders/external-awb"
+
+/**
+ * DELETE /admin/orders/:id/fulfillments/:fulfillmentId/external-awb
+ *
+ * Detach a waybill from a fulfillment WITHOUT touching the carrier.
+ *
+ * The counterpart `cancel-shipment` has been telling operators about since
+ * #1286 — "Cancel it directly with the carrier, then detach the AWB here" —
+ * while no detach existed anywhere to do it with. It is the correct exit for a
+ * waybill no API can void for us: an unintegrated carrier, or one booked on an
+ * account that isn't ours.
+ *
+ * Deliberately does NOT cancel at the carrier. Whether the waybill is dead is
+ * the operator's assertion; conflating the two would let a detach quietly leave
+ * a live billable waybill behind, or claim to have voided one it never touched.
+ * When the carrier IS integrated and the waybill IS ours, use `cancel-shipment`
+ * instead — that voids it for real and reverses the freight.
+ */
+const Body = z.object({
+  reason: z.string().trim().max(500).optional(),
+})
+
+const resolveActorEmail = async (
+  req: MedusaRequest
+): Promise<string | undefined> => {
+  try {
+    const actorId = (req as any).auth_context?.actor_id
+    if (!actorId) return undefined
+    const userService: any = req.scope.resolve(Modules.USER)
+    const user = await userService.retrieveUser(actorId)
+    return user?.email
+  } catch {
+    return undefined
+  }
+}
+
+export const DELETE = async (req: MedusaRequest, res: MedusaResponse) => {
+  const body = Body.parse((req.body as Record<string, unknown>) ?? {})
+
+  const result = await detachAwbFromFulfillment(req.scope, {
+    orderId: req.params.id,
+    fulfillmentId: req.params.fulfillmentId,
+    reason: body.reason,
+    actingEmail: await resolveActorEmail(req),
+  })
+
+  res.status(200).json({ detached_awb: result })
+}

--- a/apps/backend/src/workflows/orders/__tests__/external-awb.unit.spec.ts
+++ b/apps/backend/src/workflows/orders/__tests__/external-awb.unit.spec.ts
@@ -1,0 +1,168 @@
+import {
+  planDetachedFulfillmentData,
+  planExternalAttachData,
+  type ExternalAttachment,
+} from "../external-awb"
+
+/**
+ * The manual override: a waybill we did not book. No carrier API is involved in
+ * either direction, so these two planners ARE the feature — everything else is
+ * persistence.
+ */
+
+const ATTACHMENT: ExternalAttachment = {
+  carrier: "dtdc",
+  awb: "D1234567890",
+  attached_at: "2026-08-14T08:00:00.000Z",
+  attached_by: "ops@jaalyantra.com",
+  notes: "booked at the DTDC counter, our portal was down",
+}
+
+describe("planExternalAttachData", () => {
+  it("stamps the refs the label and tracking routes read", () => {
+    const next = planExternalAttachData(null, {
+      carrier: "dtdc",
+      awb: "D1234567890",
+      trackingUrl: "https://dtdc.in/track/D1234567890",
+      attachment: ATTACHMENT,
+    })
+    expect(next.carrier).toBe("dtdc")
+    expect(next.waybill).toBe("D1234567890")
+    expect(next.tracking_number).toBe("D1234567890")
+    expect(next.tracking_url).toBe("https://dtdc.in/track/D1234567890")
+    expect(next.provider_refs).toEqual({ waybill: "D1234567890" })
+  })
+
+  it("marks the parcel external so the UI stops offering what we cannot do", () => {
+    const next = planExternalAttachData(null, {
+      carrier: "dtdc",
+      awb: "D1234567890",
+      attachment: ATTACHMENT,
+    })
+    // No label to regenerate and no rate to quote for a parcel we did not book.
+    expect(next.external_attachment).toEqual(ATTACHMENT)
+  })
+
+  it("keeps unrelated fulfillment data", () => {
+    const next = planExternalAttachData(
+      { pickup_location_name: "DHM-Main", weight_grams: 500 },
+      { carrier: "dtdc", awb: "D1", attachment: ATTACHMENT }
+    )
+    expect(next.pickup_location_name).toBe("DHM-Main")
+    expect(next.weight_grams).toBe(500)
+  })
+
+  it("appends to the attachment history rather than replacing it", () => {
+    const first = planExternalAttachData(null, {
+      carrier: "dtdc",
+      awb: "D1",
+      attachment: { ...ATTACHMENT, awb: "D1" },
+    })
+    const second = planExternalAttachData(first, {
+      carrier: "india post",
+      awb: "IP2",
+      attachment: { ...ATTACHMENT, carrier: "india post", awb: "IP2" },
+    })
+    expect(second.external_attachments).toHaveLength(2)
+    expect(second.external_attachments[1].awb).toBe("IP2")
+  })
+
+  it("defaults the optional urls to empty rather than undefined", () => {
+    const next = planExternalAttachData(null, {
+      carrier: "dtdc",
+      awb: "D1",
+      attachment: ATTACHMENT,
+    })
+    expect(next.tracking_url).toBe("")
+    expect(next.label_url).toBe("")
+  })
+
+  it("tolerates a corrupt history rather than throwing on it", () => {
+    const next = planExternalAttachData(
+      { external_attachments: "corrupted" as any },
+      { carrier: "dtdc", awb: "D1", attachment: ATTACHMENT }
+    )
+    expect(next.external_attachments).toEqual([ATTACHMENT])
+  })
+})
+
+describe("planDetachedFulfillmentData", () => {
+  const RECORD = {
+    awb: "D1234567890",
+    carrier: "dtdc",
+    detached_at: "2026-08-14T09:00:00.000Z",
+    detached_by: "ops@jaalyantra.com",
+    reason: "cancelled at the DTDC counter",
+  }
+
+  it("NULLS every ref — deleting does not survive the jsonb merge", () => {
+    // The order 83 lesson: `updateFulfillment` merges `data`, so a removed key
+    // is re-supplied from the stored row and the fulfillment goes on
+    // advertising a waybill nobody claims.
+    const next = planDetachedFulfillmentData(
+      {
+        carrier: "dtdc",
+        waybill: "D1234567890",
+        tracking_number: "D1234567890",
+        tracking_url: "https://dtdc.in/track",
+        label_url: "https://label.pdf",
+        shipment_id: "s1",
+        sr_order_id: "sr1",
+        provider_refs: { waybill: "D1234567890" },
+        external_attachment: ATTACHMENT,
+      },
+      RECORD
+    )
+    for (const key of [
+      "carrier",
+      "waybill",
+      "tracking_number",
+      "tracking_url",
+      "label_url",
+      "shipment_id",
+      "sr_order_id",
+      "provider_refs",
+      "external_attachment",
+    ]) {
+      expect(next).toHaveProperty(key)
+      expect(next[key]).toBeNull()
+    }
+  })
+
+  it("keeps the attachment history — the AWB is the handle for a courier invoice", () => {
+    const attached = planExternalAttachData(null, {
+      carrier: "dtdc",
+      awb: "D1234567890",
+      attachment: ATTACHMENT,
+    })
+    const next = planDetachedFulfillmentData(attached, RECORD)
+    // A detach means "no longer ours to show", not "never happened".
+    expect(next.external_attachments).toHaveLength(1)
+    expect(next.detached_shipments).toEqual([RECORD])
+  })
+
+  it("appends so a second detach keeps the first", () => {
+    const once = planDetachedFulfillmentData({ waybill: "A" }, RECORD)
+    const twice = planDetachedFulfillmentData(
+      { ...once, waybill: "B" },
+      { ...RECORD, awb: "B" }
+    )
+    expect(twice.detached_shipments).toHaveLength(2)
+  })
+
+  it("keeps unrelated data and survives an empty fulfillment", () => {
+    expect(
+      planDetachedFulfillmentData({ pickup_location_name: "DHM" }, RECORD)
+        .pickup_location_name
+    ).toBe("DHM")
+    expect(planDetachedFulfillmentData(null, RECORD).detached_shipments).toEqual([
+      RECORD,
+    ])
+  })
+
+  it("leaves the refs falsy, which is what every reader actually tests", () => {
+    const next = planDetachedFulfillmentData({ waybill: "A", carrier: "dtdc" }, RECORD)
+    expect(next.waybill).toBeFalsy()
+    expect(next.carrier).toBeFalsy()
+  })
+})

--- a/apps/backend/src/workflows/orders/cancel-shipment.ts
+++ b/apps/backend/src/workflows/orders/cancel-shipment.ts
@@ -200,7 +200,7 @@ export async function cancelShipmentForFulfillment(
       MedusaError.Types.NOT_ALLOWED,
       `Fulfillment ${input.fulfillmentId} has no cancellable carrier${
         carrier ? ` (carrier "${carrier}")` : ""
-      }. Cancel it directly with the carrier, then detach the AWB here.`
+      }. Cancel it directly with the carrier, then detach it here: DELETE /admin/orders/${input.orderId}/fulfillments/${input.fulfillmentId}/external-awb`
     )
   }
   if (fulfillment.shipped_at && !input.force) {

--- a/apps/backend/src/workflows/orders/external-awb.ts
+++ b/apps/backend/src/workflows/orders/external-awb.ts
@@ -1,0 +1,376 @@
+import {
+  ContainerRegistrationKeys,
+  MedusaError,
+  Modules,
+} from "@medusajs/framework/utils"
+import type { MedusaContainer } from "@medusajs/framework/types"
+import { createOrderShipmentWorkflow } from "@medusajs/medusa/core-flows"
+import { buildAttachAwbLabels } from "./shiprocket-attach-awb"
+
+/**
+ * Attach (and detach) a waybill we did NOT book — the manual override.
+ *
+ * Every other path in this system assumes we created the shipment: the label
+ * routes call a carrier API, `attachExistingShiprocketAwb` validates the AWB by
+ * looking it up on Shiprocket, and `cancelShipmentForFulfillment` voids it at
+ * the carrier. All of that breaks the moment a parcel is booked outside those
+ * integrations, which happens more often than the code assumed:
+ *
+ *  - a carrier we do not integrate at all (DTDC, India Post, a local courier);
+ *  - a waybill generated on a carrier's own portal because ours was down — the
+ *    exact situation order 83 sat in while Blue Dart returned an empty 400;
+ *  - a counter booking, or a partner who shipped on their own account.
+ *
+ * Two things make this different from `attachExistingShiprocketAwb`, and both
+ * are deliberate:
+ *
+ * **No carrier call. At all.** Not to create, not to validate. Validation by
+ * lookup is precisely what makes the existing attach unusable here: it is
+ * hard-wired to Shiprocket, and even pointed at the right carrier it would
+ * reject a freshly-created waybill, because Blue Dart's TnT answers a scanless
+ * AWB with "Incorrect waybill number or No information" — indistinguishable
+ * from a typo. An operator who is holding the physical waybill is a better
+ * authority than an API that cannot see it yet.
+ *
+ * **It is recorded as external.** `data.external_attachment` marks the parcel as
+ * something we track but do not control, so the UI can stop offering label
+ * downloads and rate lookups that were never going to work.
+ */
+
+/** What an external attachment records about its provenance. */
+export type ExternalAttachment = {
+  /** Carrier as the operator named it — free text; may be unintegrated. */
+  carrier: string
+  awb: string
+  attached_at: string
+  attached_by?: string
+  /** Why this was booked outside the system; shown in the audit trail. */
+  notes?: string
+}
+
+/** Carrier ref keys an attach writes and a detach clears. */
+const CARRIER_DATA_KEYS = [
+  "carrier",
+  "waybill",
+  "tracking_number",
+  "tracking_url",
+  "label_url",
+  "shipment_id",
+  "sr_order_id",
+  "provider_refs",
+] as const
+
+/**
+ * Pure: the `fulfillment.data` an external attachment leaves behind.
+ *
+ * Exported for unit testing — this decides what the rest of the system will
+ * believe about a parcel nobody here booked.
+ */
+export function planExternalAttachData(
+  data: Record<string, any> | null | undefined,
+  input: {
+    carrier: string
+    awb: string
+    trackingUrl?: string
+    labelUrl?: string
+    attachment: ExternalAttachment
+  }
+): Record<string, any> {
+  const history = Array.isArray(data?.external_attachments)
+    ? data!.external_attachments
+    : []
+  return {
+    ...(data || {}),
+    carrier: input.carrier,
+    waybill: input.awb,
+    tracking_number: input.awb,
+    tracking_url: input.trackingUrl || "",
+    label_url: input.labelUrl || "",
+    // The flag the UI keys off to stop offering what we cannot do for a parcel
+    // we did not book: no label to regenerate, no rate to quote.
+    external_attachment: input.attachment,
+    external_attachments: [...history, input.attachment],
+    provider_refs: { waybill: input.awb },
+  }
+}
+
+/**
+ * Pure: the `fulfillment.data` a detach leaves behind.
+ *
+ * ⚠️ NULLS the refs rather than deleting them. `updateFulfillment` MERGES the
+ * `data` jsonb, so a removed key is re-supplied from the stored row — the bug
+ * that left order 83 advertising a cancelled Delhivery AWB. Same rule here:
+ * every reader tests truthiness, so an explicit null reads as gone AND survives
+ * the merge.
+ *
+ * The attachment history is kept. A detach means "this waybill is no longer
+ * ours to show", not "this never happened" — and the AWB is the only handle for
+ * reconciling a courier's invoice against the order later.
+ */
+export function planDetachedFulfillmentData(
+  data: Record<string, any> | null | undefined,
+  record: { awb?: string; carrier?: string; detached_at: string; detached_by?: string; reason?: string }
+): Record<string, any> {
+  const next: Record<string, any> = { ...(data || {}) }
+  for (const key of CARRIER_DATA_KEYS) {
+    next[key] = null
+  }
+  next.external_attachment = null
+  const history = Array.isArray(next.detached_shipments)
+    ? next.detached_shipments
+    : []
+  next.detached_shipments = [...history, record]
+  return next
+}
+
+export type AttachExternalAwbInput = {
+  orderId: string
+  fulfillmentId: string
+  awb: string
+  /** Carrier name as the operator knows it. Not required to be integrated. */
+  carrier: string
+  trackingUrl?: string
+  labelUrl?: string
+  /**
+   * Mark the fulfillment shipped. Off by default: attaching a waybill and
+   * handing the parcel over are different events, and a waybill is routinely
+   * generated the night before. The operator says when it actually left.
+   */
+  markShipped?: boolean
+  notes?: string
+  actingEmail?: string
+}
+
+export type AttachExternalAwbResult = {
+  fulfillment_id: string
+  carrier: string
+  awb: string
+  attached_at: string
+  marked_shipped: boolean
+}
+
+export async function attachExternalAwb(
+  container: MedusaContainer,
+  input: AttachExternalAwbInput
+): Promise<AttachExternalAwbResult> {
+  const query: any = container.resolve(ContainerRegistrationKeys.QUERY)
+  const fulfillmentModule: any = container.resolve(Modules.FULFILLMENT)
+  const logger: any = container.resolve(ContainerRegistrationKeys.LOGGER)
+
+  const awb = String(input.awb || "").trim()
+  const carrier = String(input.carrier || "").trim().toLowerCase()
+  if (!awb) {
+    throw new MedusaError(MedusaError.Types.INVALID_DATA, "An AWB is required")
+  }
+  if (!carrier) {
+    throw new MedusaError(
+      MedusaError.Types.INVALID_DATA,
+      "A carrier name is required — it is what tells an operator who is actually carrying the parcel."
+    )
+  }
+
+  const { data: orders } = await query.graph({
+    entity: "order",
+    fields: [
+      "id",
+      "items.id",
+      "items.detail.quantity",
+      "fulfillments.id",
+      "fulfillments.data",
+      // `updateFulfillment` REPLACES the labels collection, so existing rows
+      // must be carried through by id or the ORM deletes them.
+      "fulfillments.labels.id",
+      "fulfillments.labels.tracking_number",
+    ],
+    filters: { id: input.orderId },
+  })
+  const order = orders?.[0]
+  if (!order) {
+    throw new MedusaError(
+      MedusaError.Types.NOT_FOUND,
+      `Order ${input.orderId} not found`
+    )
+  }
+  const fulfillment = (order.fulfillments || []).find(
+    (f: any) => f.id === input.fulfillmentId
+  )
+  if (!fulfillment) {
+    throw new MedusaError(
+      MedusaError.Types.NOT_FOUND,
+      `Fulfillment ${input.fulfillmentId} not found on order ${input.orderId}`
+    )
+  }
+
+  // Refuse to paper over a live waybill. Overwriting the refs would orphan it —
+  // still billable, still moving, and no longer pointed at by anything here.
+  // That is the #1225 orphan class, which is exactly what the cancel flow was
+  // built to prevent; make the operator go through it.
+  const existingAwb = fulfillment.data?.waybill || fulfillment.data?.tracking_number
+  if (existingAwb && String(existingAwb) !== awb) {
+    throw new MedusaError(
+      MedusaError.Types.NOT_ALLOWED,
+      `Fulfillment ${input.fulfillmentId} already carries AWB ${existingAwb}. Cancel or detach it first — attaching over a live waybill leaves it billable with nothing pointing at it.`
+    )
+  }
+
+  const attachedAt = new Date().toISOString()
+  const attachment: ExternalAttachment = {
+    carrier,
+    awb,
+    attached_at: attachedAt,
+    attached_by: input.actingEmail,
+    notes: input.notes,
+  }
+
+  // #1195: the label row is the ONLY way a fulfillment can be found from an AWB
+  // (`data` is jsonb and cannot be filtered), so it is what makes this parcel
+  // discoverable to any later status push or manual lookup.
+  const labels = buildAttachAwbLabels(fulfillment.labels, {
+    tracking_number: awb,
+    tracking_url: input.trackingUrl || "",
+    label_url: input.labelUrl || "",
+  })
+
+  await fulfillmentModule.updateFulfillment(input.fulfillmentId, {
+    data: planExternalAttachData(fulfillment.data, {
+      carrier,
+      awb,
+      trackingUrl: input.trackingUrl,
+      labelUrl: input.labelUrl,
+      attachment,
+    }),
+    labels: labels as any,
+  })
+
+  let markedShipped = false
+  if (input.markShipped) {
+    const items = (order.items || []).map((i: any) => ({
+      id: i.id,
+      quantity: Number(i.detail?.quantity ?? i.quantity) || 1,
+    }))
+    try {
+      await createOrderShipmentWorkflow(container).run({
+        input: {
+          order_id: input.orderId,
+          fulfillment_id: input.fulfillmentId,
+          items,
+          // NOT `[]` — that is a full replace and would drop the AWB label we
+          // just wrote, taking the parcel's only discoverable handle with it.
+          labels: labels as any,
+          no_notification: true,
+        },
+      })
+      markedShipped = true
+    } catch (e: any) {
+      // Best-effort: the AWB is attached either way, and reporting a failed
+      // attach for one that succeeded would send an operator to re-attach it.
+      logger?.warn?.(
+        `[external-awb] could not mark fulfillment ${input.fulfillmentId} shipped: ${e?.message}. The AWB IS attached.`
+      )
+    }
+  }
+
+  logger?.info?.(
+    `[external-awb] attached ${carrier} ${awb} to fulfillment ${input.fulfillmentId} (order ${input.orderId})${
+      input.notes ? `: ${input.notes}` : ""
+    }`
+  )
+
+  return {
+    fulfillment_id: input.fulfillmentId,
+    carrier,
+    awb,
+    attached_at: attachedAt,
+    marked_shipped: markedShipped,
+  }
+}
+
+export type DetachAwbInput = {
+  orderId: string
+  fulfillmentId: string
+  reason?: string
+  actingEmail?: string
+}
+
+export type DetachAwbResult = {
+  fulfillment_id: string
+  carrier?: string
+  awb?: string
+  detached_at: string
+}
+
+/**
+ * Remove a waybill's refs from a fulfillment WITHOUT touching the carrier.
+ *
+ * The counterpart the cancel flow has been telling operators about since #1286
+ * — "Cancel it directly with the carrier, then detach the AWB here" — while no
+ * detach existed anywhere. It is the correct exit for a waybill we cannot void
+ * through an API: an unintegrated carrier, or one booked on someone else's
+ * account.
+ *
+ * Deliberately does NOT call `cancelShipment`. A detach says "this is no longer
+ * ours to display"; whether the waybill is dead at the carrier is the operator's
+ * assertion, not something this can verify. Conflating the two would let a
+ * detach quietly leave a live billable waybill behind — or claim to have voided
+ * one it never touched.
+ */
+export async function detachAwbFromFulfillment(
+  container: MedusaContainer,
+  input: DetachAwbInput
+): Promise<DetachAwbResult> {
+  const query: any = container.resolve(ContainerRegistrationKeys.QUERY)
+  const fulfillmentModule: any = container.resolve(Modules.FULFILLMENT)
+  const logger: any = container.resolve(ContainerRegistrationKeys.LOGGER)
+
+  const { data: orders } = await query.graph({
+    entity: "order",
+    fields: ["id", "fulfillments.id", "fulfillments.data"],
+    filters: { id: input.orderId },
+  })
+  const fulfillment = (orders?.[0]?.fulfillments || []).find(
+    (f: any) => f.id === input.fulfillmentId
+  )
+  if (!fulfillment) {
+    throw new MedusaError(
+      MedusaError.Types.NOT_FOUND,
+      `Fulfillment ${input.fulfillmentId} not found on order ${input.orderId}`
+    )
+  }
+
+  const data = (fulfillment.data || {}) as Record<string, any>
+  const awb = data.waybill || data.tracking_number
+  if (!awb) {
+    throw new MedusaError(
+      MedusaError.Types.INVALID_DATA,
+      `Fulfillment ${input.fulfillmentId} carries no AWB to detach.`
+    )
+  }
+
+  const detachedAt = new Date().toISOString()
+  await fulfillmentModule.updateFulfillment(input.fulfillmentId, {
+    data: planDetachedFulfillmentData(data, {
+      awb: String(awb),
+      carrier: data.carrier,
+      detached_at: detachedAt,
+      detached_by: input.actingEmail,
+      reason: input.reason,
+    }),
+    // Drop the label row with it: it is the key the tracking webhook matches
+    // pushes on, and leaving it would let a scan for a waybill we no longer
+    // claim land back on this order.
+    labels: [],
+  })
+
+  logger?.info?.(
+    `[external-awb] detached ${data.carrier || "unknown"} ${awb} from fulfillment ${input.fulfillmentId}${
+      input.reason ? `: ${input.reason}` : ""
+    }`
+  )
+
+  return {
+    fulfillment_id: input.fulfillmentId,
+    carrier: data.carrier,
+    awb: String(awb),
+    detached_at: detachedAt,
+  }
+}


### PR DESCRIPTION
Every path in this system assumed we created the shipment. The label routes call a carrier API, `attachExistingShiprocketAwb` validates an AWB by looking it up on Shiprocket, and `cancelShipmentForFulfillment` voids it at the carrier. All of that breaks when a parcel is booked **outside** those integrations — which happens more than the code assumed:

- a carrier we don't integrate (DTDC, India Post, a local courier)
- a counter booking, or a partner who shipped on their own account
- a waybill generated on a carrier's own portal because ours wouldn't — exactly where order 83 sat while Blue Dart answered with an empty 400

## Attach — `POST /admin/orders/:id/external-awb`

```jsonc
{ "awb": "D1234567890", "carrier": "dtdc",
  "tracking_url": "https://…", "mark_shipped": false,
  "notes": "booked at the counter, our portal was down" }
```

Two deliberate differences from the Shiprocket attach:

**No carrier call, for creation *or* validation.** Validation-by-lookup is precisely what makes the existing attach unusable here — it's hard-wired to Shiprocket, and even pointed at the right carrier it would reject a *freshly created* waybill, because Blue Dart's TnT answers a scanless AWB with `"Incorrect waybill number or No information"`, indistinguishable from a typo. An operator holding the physical waybill is a better authority than an API that can't see it yet.

**Recorded as external** (`data.external_attachment`), so the UI can stop offering label downloads and rate lookups that were never going to work for a parcel we didn't book.

Attaching *over* a live waybill is refused rather than silently overwriting it — that's the #1225 orphan class, and `cancel-shipment` exists to handle it properly. `mark_shipped` defaults to **false**: attaching a waybill and handing the parcel over are different events, and a waybill is routinely made the night before.

## Detach — `DELETE /admin/orders/:id/fulfillments/:fulfillmentId/external-awb`

The counterpart `cancel-shipment` has been telling operators about since #1286 — *"Cancel it directly with the carrier, then detach the AWB here"* — while **no detach existed anywhere** to do it with. That error message now names this route.

It deliberately does **not** cancel at the carrier. A detach says "no longer ours to display"; whether the waybill is dead is the operator's assertion, not something this can verify. Conflating the two would let a detach quietly leave a live billable waybill behind, or claim to have voided one it never touched. When the carrier *is* integrated and the waybill *is* ours, `cancel-shipment` remains correct — it voids for real and reverses the freight.

## The test that would have caught order 83

Adds an integration test pinning that `updateFulfillment` **MERGES `data`** while **REPLACING `labels`** — so omitting a key does not remove it, and only an explicit null clears it. The `labels` half was already pinned; the `data` half wasn't, which is why a passing unit test sat alongside a prod row still advertising a cancelled AWB. Now proven against a real database rather than inferred.

## Verify

```
pnpm test:integration:http:shared ./integration-tests/http/shiprocket-attach-awb.spec.ts   # 3 pass
npx jest --testPathPattern="external-awb"                                                  # 13 pass
npx tsc --noEmit                                                                           # 79 = baseline
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)
