### PR TITLE
feat(bluedart): register Blue Dart as a fulfillment provider (#1285)

### DIFF
--- a/apps/backend/medusa-config.prod.ts
+++ b/apps/backend/medusa-config.prod.ts
@@ -369,6 +369,36 @@ module.exports = defineConfig({
                 },
               ]
             : []),
+          // Blue Dart (#1285). Same split as Shiprocket above: this registration
+          // serves the checkout/createFulfillment flow, while the label/tracking/
+          // pickup routes go through `resolveShippingProvider` and the
+          // external-platform credential store.
+          //
+          // Gated on the LICENCE KEY, not the gateway client id: Blue Dart's two
+          // auth layers are independent, and the gateway mints a valid JWT for
+          // EMPTY credentials (401 only for *wrong* ones), so a client-id check
+          // would register a provider that cannot actually ship.
+          ...(process.env.BLUE_DART_LICENCE_KEY
+            ? [
+                {
+                  resolve: "./src/modules/shipping-providers/bluedart",
+                  id: "bluedart",
+                  options: {
+                    client_id: process.env.BLUE_DART_CLIENT_ID,
+                    client_secret: process.env.BLUE_DART_CLIENT_SECRET,
+                    login_id: process.env.BLUE_DART_LOGIN_ID,
+                    licence_key: process.env.BLUE_DART_LICENCE_KEY,
+                    customer_code: process.env.BLUE_DART_CUSTOMER_CODE,
+                    api_type: process.env.BLUE_DART_API_TYPE,
+                    version: process.env.BLUE_DART_VERSION,
+                    origin_area: process.env.BLUE_DART_ORIGIN_AREA,
+                    tracking_licence_key:
+                      process.env.BLUE_DART_TRACKING_LICENCE_KEY,
+                    sandbox: process.env.BLUE_DART_SANDBOX === "true",
+                  },
+                },
+              ]
+            : []),
           ...(process.env.DHL_API_KEY
             ? [
                 {

--- a/apps/backend/medusa-config.ts
+++ b/apps/backend/medusa-config.ts
@@ -432,6 +432,31 @@ module.exports = defineConfig({
                       },
                     ]
                   : []),
+                // Gated on the LICENCE KEY, not the gateway client id: Blue Dart's
+                // two auth layers are independent, and the gateway happily mints a
+                // valid JWT for EMPTY credentials (401 only for *wrong* ones), so
+                // a client-id check would register a provider that cannot ship.
+                ...(process.env.BLUE_DART_LICENCE_KEY
+                  ? [
+                      {
+                        resolve: "./src/modules/shipping-providers/bluedart",
+                        id: "bluedart",
+                        options: {
+                          client_id: process.env.BLUE_DART_CLIENT_ID,
+                          client_secret: process.env.BLUE_DART_CLIENT_SECRET,
+                          login_id: process.env.BLUE_DART_LOGIN_ID,
+                          licence_key: process.env.BLUE_DART_LICENCE_KEY,
+                          customer_code: process.env.BLUE_DART_CUSTOMER_CODE,
+                          api_type: process.env.BLUE_DART_API_TYPE,
+                          version: process.env.BLUE_DART_VERSION,
+                          origin_area: process.env.BLUE_DART_ORIGIN_AREA,
+                          tracking_licence_key:
+                            process.env.BLUE_DART_TRACKING_LICENCE_KEY,
+                          sandbox: process.env.BLUE_DART_SANDBOX === "true",
+                        },
+                      },
+                    ]
+                  : []),
                 ...(process.env.DHL_API_KEY
                   ? [
                       {

--- a/apps/backend/src/modules/shipping-providers/bluedart/__tests__/fulfillment-service.unit.spec.ts
+++ b/apps/backend/src/modules/shipping-providers/bluedart/__tests__/fulfillment-service.unit.spec.ts
@@ -83,7 +83,10 @@ describe("BlueDartFulfillmentService", () => {
     ])
     expect(opts.filter((o) => o.is_return)).toHaveLength(1)
     // International (product H) stays out until #1223's HS codes land.
-    expect(opts.some((o) => /international|ipc/i.test(o.name))).toBe(false)
+    // `String(...)` because FulfillmentOption types every field but `id` as
+    // `unknown` — the prod-config build (which mirrors the ECS Dockerfile) is
+    // stricter than `tsc --noEmit` here and rejects the bare value.
+    expect(opts.some((o) => /international|ipc/i.test(String(o.name)))).toBe(false)
   })
 
   it("declines to calculate rather than quoting zero", async () => {

--- a/apps/backend/src/modules/shipping-providers/bluedart/__tests__/fulfillment-service.unit.spec.ts
+++ b/apps/backend/src/modules/shipping-providers/bluedart/__tests__/fulfillment-service.unit.spec.ts
@@ -1,0 +1,176 @@
+import BlueDartFulfillmentService from "../service"
+import { BLUEDART_CARRIER_ID } from "../constants"
+
+/**
+ * The registration contract, not the carrier logic.
+ *
+ * `BlueDartProviderAdapter` is already covered by bluedart-adapter.unit.spec;
+ * what was missing until #1285 is everything Medusa needs to SEE the provider at
+ * all — a stable identifier, a fulfillment-option list, and a createFulfillment
+ * that maps Medusa's DTOs onto `CreateShipmentInput`. That mapping is the part
+ * with no other test, because it is the part the fulfillment module drives.
+ *
+ * A live Blue Dart create mints a real, billable waybill, so the adapter is
+ * stubbed here rather than the transport.
+ */
+
+const logger: any = {
+  info: jest.fn(),
+  warn: jest.fn(),
+  error: jest.fn(),
+  debug: jest.fn(),
+}
+
+const CONFIG: any = {
+  client_id: "cid",
+  client_secret: "csec",
+  login_id: "login",
+  licence_key: "lic",
+  customer_code: "cust",
+  fetchImpl: jest.fn(),
+}
+
+const buildService = (createShipment: jest.Mock) => {
+  const svc = new BlueDartFulfillmentService({ logger }, CONFIG)
+  ;(svc as any).adapter = {
+    createShipment,
+    checkServiceability: jest.fn().mockResolvedValue(true),
+    cancelShipment: jest.fn().mockResolvedValue({ success: true }),
+  }
+  return svc
+}
+
+const ORDER: any = {
+  id: "order_01KYPCSTQ783ZT1FKM72VHQABS",
+  payment_status: "captured",
+  email: "buyer@example.com",
+  shipping_address: {
+    first_name: "Test",
+    last_name: "Buyer",
+    address_1: "12 MG Road",
+    city: "Gandhinagar",
+    province: "Gujarat",
+    postal_code: "382421",
+    country_code: "IN",
+    phone: "9999999999",
+  },
+  items: [
+    {
+      id: "item_1",
+      title: "Handloom Dupatta",
+      unit_price: 2500,
+      variant_sku: "DUP-001",
+      variant: { weight: 325, length: 10, width: 10, height: 3 },
+    },
+  ],
+}
+
+const ITEMS: any = [{ line_item_id: "item_1", title: "Handloom Dupatta", quantity: 2 }]
+
+describe("BlueDartFulfillmentService", () => {
+  it("registers under the carrier id the rest of the platform already uses", () => {
+    // fulfillment.data.carrier, SUPPORTED_CARRIERS and the provider id must all
+    // be the same string, or a fulfillment created here cannot be resolved back.
+    expect(BlueDartFulfillmentService.identifier).toBe(BLUEDART_CARRIER_ID)
+    expect(BlueDartFulfillmentService.identifier).toBe("bluedart")
+  })
+
+  it("offers a domestic option and a return, and no international one", async () => {
+    const opts = await buildService(jest.fn()).getFulfillmentOptions()
+    expect(opts.map((o) => o.id)).toEqual([
+      "bluedart-domestic-priority",
+      "bluedart-domestic-priority-return",
+    ])
+    expect(opts.filter((o) => o.is_return)).toHaveLength(1)
+    // International (product H) stays out until #1223's HS codes land.
+    expect(opts.some((o) => /international|ipc/i.test(o.name))).toBe(false)
+  })
+
+  it("declines to calculate rather than quoting zero", async () => {
+    // Blue Dart has no rate API wired. Answering `true` here and then returning
+    // 0 — the other carriers' error-path behaviour — would price shipping at
+    // zero on a live cart, which is worse than refusing.
+    const svc = buildService(jest.fn())
+    await expect(svc.canCalculate({} as any)).resolves.toBe(false)
+    await expect(svc.calculatePrice({}, {}, {})).rejects.toThrow(/flat-rate/i)
+  })
+
+  it("maps order line-item variants onto the shipment, multiplying by quantity", async () => {
+    const createShipment = jest.fn().mockResolvedValue({
+      awb: "21091376574",
+      tracking_number: "21091376574",
+      tracking_url: "https://bluedart.com/track/21091376574",
+      provider_refs: { waybill: "21091376574" },
+    })
+    const svc = buildService(createShipment)
+
+    const result = await svc.createFulfillment(
+      { from_location: { name: "Dharamshala Studio" } },
+      ITEMS,
+      ORDER,
+      { id: "ful_1" } as any
+    )
+
+    const input = createShipment.mock.calls[0][0]
+    // 325 g x 2 — the weight has to come off the ORDER item's variant, since the
+    // FulfillmentItemDTO carries none.
+    expect(input.weight_grams).toBe(650)
+    expect(input.dimensions_cm).toEqual({ length: 10, width: 10, height: 6 })
+    expect(input.payment_mode).toBe("prepaid")
+    expect(input.cod_amount).toBeUndefined()
+    expect(input.sub_total).toBe(5000)
+    expect(input.to.pincode).toBe("382421")
+    expect(input.items[0]).toMatchObject({ sku: "DUP-001", quantity: 2 })
+
+    expect(result.data).toMatchObject({
+      carrier: "bluedart",
+      waybill: "21091376574",
+    })
+    expect(result.labels).toHaveLength(1)
+  })
+
+  it("falls back to an estimated weight and NO dimensions when variants carry neither", async () => {
+    const createShipment = jest.fn().mockResolvedValue({ awb: "1" })
+    const svc = buildService(createShipment)
+    const bare = { ...ORDER, items: [{ id: "item_1", title: "X", unit_price: 100 }] }
+
+    await svc.createFulfillment({}, ITEMS, bare, { id: "ful_1" } as any)
+
+    const input = createShipment.mock.calls[0][0]
+    expect(input.weight_grams).toBe(800)
+    // Left undefined on purpose so the adapter applies BLUEDART_DEFAULT_DIMENSIONS
+    // — Blue Dart REJECTS a waybill with no Dimensions, and inventing a size here
+    // would silently override the one place that default is documented.
+    expect(input.dimensions_cm).toBeUndefined()
+  })
+
+  it("treats an uncaptured order as COD", async () => {
+    const createShipment = jest.fn().mockResolvedValue({ awb: "1" })
+    const svc = buildService(createShipment)
+
+    await svc.createFulfillment(
+      {},
+      ITEMS,
+      { ...ORDER, payment_status: "awaiting" },
+      { id: "ful_1" } as any
+    )
+
+    const input = createShipment.mock.calls[0][0]
+    expect(input.payment_mode).toBe("cod")
+    expect(input.cod_amount).toBe(5000)
+  })
+
+  it("cancels by waybill, and no-ops when there is none to cancel", async () => {
+    const svc = buildService(jest.fn())
+    const adapter = (svc as any).adapter
+
+    await svc.cancelFulfillment({ data: { waybill: "21091376574" } })
+    expect(adapter.cancelShipment).toHaveBeenCalledWith(
+      expect.objectContaining({ awb: "21091376574" })
+    )
+
+    adapter.cancelShipment.mockClear()
+    await svc.cancelFulfillment({ data: {} })
+    expect(adapter.cancelShipment).not.toHaveBeenCalled()
+  })
+})

--- a/apps/backend/src/modules/shipping-providers/bluedart/constants.ts
+++ b/apps/backend/src/modules/shipping-providers/bluedart/constants.ts
@@ -35,6 +35,20 @@ export const BLUEDART_PATHS = {
    */
   cancelPickup: "/in/transportation/cancel-pickup/v1/CancelPickup",
   servicesForPincode: "/in/transportation/finder/v1/GetServicesforPincode",
+  /**
+   * The product/sub-product registry — the authoritative answer to "what codes
+   * exist", and free to call.
+   *
+   * ⚠️ POST, unlike the token endpoint which is GET. Body is
+   * `{"profile":{"Api_type","LicenceKey","LoginID"}}`.
+   *
+   * 🔑 Its scope is the PICKUP vocabulary (DHL documents it as feeding Pickup
+   * Registration's input params), so it confirms `SubProducts` full names —
+   * NOT the waybill's single-character `SubProductCode`. Verified live
+   * 2026-08-15; it is what settled `H` above.
+   */
+  allProductsAndSubProducts:
+    "/in/transportation/allproduct/v1/GetAllProductsAndSubProducts",
   tracking: "/in/transportation/tracking/v1",
 } as const
 
@@ -53,40 +67,55 @@ export const BLUEDART_PRODUCT = {
   /** Apex — NOT available outbound from DHM. */
   apex: "A",
   /**
-   * International IPC (Expedited / Standard).
+   * International IPC. ✅ **SETTLED 2026-08-15 — `H` is correct.**
    *
-   * ⚠️ **DISPUTED.** A 2026-08-14 note claims `I` is the outbound IPC product
-   * and `H` is not mentioned. This file has said `H` since #1286. NOT changed:
-   * flipping the product code on an unverified claim risks breaking exports in
-   * a new way. `GetServicesforProduct` would settle it — it answers
-   * serviceability for a given product/sub-product — but the Finder is
-   * currently UNRELIABLE: on 2026-08-14 it returned real data once
-   * (`Area: "DHM"`, `IsError: false`, ordinary shipping profile) and then
-   * `UserDoesNotExists` on six consecutive identical calls, across four
-   * pincodes and both gateway keys.
+   * The carrier's own registry (`GetAllProductsAndSubProducts`, see below)
+   * returns product `H` with exactly two sub-products: `IPC-Expedited` and
+   * `IPC-Standard`. That is the international product, and this value has been
+   * right since #1286.
    *
-   * ⚠️ Do NOT read `UserDoesNotExists` as "not enrolled" — a success disproves
-   * that. Blue Dart errors routinely name the wrong culprit (see the `verno`
-   * "License Mismatch" trap). Cause unknown; retry before concluding anything.
-   *
-   * International is blocked on #1223's HS codes regardless.
+   * ⚠️ This RETRACTS the 2026-08-14 conclusion that "`A`, `D`, `E` are the only
+   * valid product codes" and that `H`/`I` return `InvalidProductCode`. That came
+   * from `GetServicesforPincode`, a *pincode serviceability* call — which this
+   * file already suspected of covering domestic products only. The suspicion was
+   * correct. Do not "fix" this to `I` or `A`: it would break exports.
    */
   international: "H",
-  /** International import. ⚠️ See the dispute above — may in fact be outbound IPC. */
+  /**
+   * ⚠️ NOT "international import" — that label is wrong and is kept only because
+   * nothing sends this value. `GetAllProductsAndSubProducts` lists `I` with
+   * sub-products E-Tailing, SII, DTP, Express Easy 6, Express Easy 8, Express
+   * Pallete and Imp/EXP — a mixed import/export product, not the IPC one.
+   */
   internationalImport: "I",
+  /**
+   * Surface / ground. Identified 2026-08-15 from its sub-product list (SFC
+   * Laptop Box 10, FOD, FOV/DC, DOD, EDL, Express Pallete, Smart Box) — SFC is
+   * Surface Freight Cargo. Previously an unidentified valid code.
+   */
+  surface: "E",
 } as const
 
 /**
  * Sub-product for the international product. Max 1 char, A-Z — see the guard in
  * `createShipment`.
  *
- * ⚠️ **UNVERIFIED against the carrier.** Supplied 2026-08-14 as "P = Prepaid,
- * the single-letter sub-product for IPC Expedited". It is not published on
- * developer.dhl.com, and Blue Dart support has not confirmed it. The previous
- * value ("IPC-Expedited") was definitively wrong — that is the PICKUP API's
- * vocabulary — so this can only be an improvement, but it is a candidate, not a
- * fact. International is separately blocked on #1223's HS codes, so nothing
- * ships on this until both are resolved.
+ * ⚠️ **STILL UNVERIFIED, and now looking weaker.** Supplied 2026-08-14 as
+ * "P = Prepaid, the single-letter sub-product for IPC Expedited". It is not
+ * published on developer.dhl.com and Blue Dart support has not confirmed it.
+ *
+ * `GetAllProductsAndSubProducts` (2026-08-15) names the two real sub-products of
+ * product `H` — `IPC-Expedited` and `IPC-Standard` — and "Prepaid" appears
+ * nowhere in the carrier's registry. But that registry is the PICKUP
+ * vocabulary, which takes full names in a `SubProducts` ARRAY, whereas this
+ * field is the waybill's, capped at 1 char A-Z by the documented field limits
+ * (#1295). So the registry does NOT settle this value; it only removes the
+ * story behind it. `E` (Expedited) and `S` (Standard) are the obvious
+ * candidates — inference, not evidence. Left alone deliberately; it is one of
+ * the two open questions for Blue Dart support.
+ *
+ * International is separately blocked on #1223's HS codes, so nothing ships on
+ * this until both are resolved.
  */
 export const BLUEDART_INTL_SUBPRODUCT = "P"
 

--- a/apps/backend/src/modules/shipping-providers/bluedart/index.ts
+++ b/apps/backend/src/modules/shipping-providers/bluedart/index.ts
@@ -1,4 +1,25 @@
-export { BlueDartProviderAdapter, normalizeBlueDartTracking, classifyBlueDartScan } from "./adapter"
+import { ModuleProvider, Modules } from "@medusajs/framework/utils"
+import BlueDartFulfillmentService from "./service"
+
+/**
+ * The DEFAULT export is what makes Blue Dart visible in Settings → Locations &
+ * Shipping. Until #1285 this file was a plain barrel, so the fulfillment module
+ * had nothing to register and the carrier — though fully drivable through
+ * `resolveShippingProvider` — could not be attached to a stock location.
+ *
+ * The named re-exports below are kept for callers that reach for the barrel.
+ * Nothing does today (`resolver.ts` deep-imports `./bluedart/adapter`), but they
+ * cost nothing and removing them would be a gratuitous break.
+ */
+export default ModuleProvider(Modules.FULFILLMENT, {
+  services: [BlueDartFulfillmentService],
+})
+
+export {
+  BlueDartProviderAdapter,
+  normalizeBlueDartTracking,
+  classifyBlueDartScan,
+} from "./adapter"
 export { BlueDartClient, BlueDartApiError, describeBlueDartFailure } from "./client"
 export * from "./constants"
 export type * from "./types"

--- a/apps/backend/src/modules/shipping-providers/bluedart/service.ts
+++ b/apps/backend/src/modules/shipping-providers/bluedart/service.ts
@@ -1,0 +1,261 @@
+import { AbstractFulfillmentProviderService } from "@medusajs/framework/utils"
+import {
+  CreateFulfillmentResult,
+  FulfillmentOption,
+  FulfillmentItemDTO,
+  FulfillmentOrderDTO,
+  FulfillmentDTO,
+  CalculatedShippingOptionPrice,
+  CreateShippingOptionDTO,
+  Logger,
+} from "@medusajs/framework/types"
+import { BlueDartClient } from "./client"
+import { BlueDartProviderAdapter } from "./adapter"
+import { BLUEDART_CARRIER_ID } from "./constants"
+import type { BlueDartConfig } from "./types"
+import { CreateShipmentInput, ShipmentItem } from "../provider-interface"
+
+type InjectedDeps = { logger: Logger }
+
+/**
+ * Blue Dart fulfillment provider (#1285).
+ *
+ * Blue Dart has been drivable from admin/partner routes since #1286 — it is in
+ * `SUPPORTED_CARRIERS` and `resolveShippingProvider` returns a live client for
+ * it. What it was NOT is a *Medusa fulfillment provider*: `bluedart/index.ts`
+ * was a plain barrel, so the fulfillment module never saw it, and it therefore
+ * never appeared in Settings → Locations & Shipping. It could not be attached
+ * to a stock location or a shipping option the way Delhivery and Shiprocket can.
+ * This file closes that gap; the carrier logic itself is unchanged and still
+ * lives in `BlueDartProviderAdapter`.
+ *
+ * ⚠️ A live `createShipment` mints a REAL, BILLABLE waybill — Blue Dart's
+ * sandbox host is a separate base URL, not a dry-run flag on production. The
+ * registration in `medusa-config.ts` sits behind `ENABLE_CARRIER_FULFILLMENT`
+ * for exactly this reason.
+ */
+class BlueDartFulfillmentService extends AbstractFulfillmentProviderService {
+  static identifier = BLUEDART_CARRIER_ID
+
+  protected adapter: BlueDartProviderAdapter
+  protected logger: Logger
+
+  constructor({ logger }: InjectedDeps, options: BlueDartConfig) {
+    super()
+    this.logger = logger
+    this.adapter = new BlueDartProviderAdapter(new BlueDartClient(options))
+  }
+
+  /**
+   * One domestic option, deliberately.
+   *
+   * `createShipment` picks the product code from the destination
+   * (`BLUEDART_PRODUCT.domestic` vs `.international`), not from the chosen
+   * option — so advertising Apex/Surface here would offer service levels that
+   * all ship as `D` regardless. Per-option product selection needs the adapter
+   * to accept a product code first; until then one honest option beats four
+   * misleading ones.
+   *
+   * International (product `H`, sub-products IPC-Expedited / IPC-Standard —
+   * confirmed against `GetAllProductsAndSubProducts`) is intentionally NOT
+   * offered: it is still blocked on #1223's HS codes and on the unverified
+   * single-letter waybill `SubProductCode`.
+   */
+  async getFulfillmentOptions(): Promise<FulfillmentOption[]> {
+    return [
+      {
+        id: "bluedart-domestic-priority",
+        name: "Blue Dart Domestic Priority",
+        is_return: false,
+      },
+      {
+        id: "bluedart-domestic-priority-return",
+        name: "Blue Dart Domestic Priority - Return",
+        is_return: true,
+      },
+    ]
+  }
+
+  /**
+   * Serviceability is advisory here, never a hard block.
+   *
+   * The Finder has a demonstrated flap (real data once, then `UserDoesNotExists`
+   * on six consecutive identical calls on 2026-08-14). Refusing an option on a
+   * transient carrier error would take checkout down for lanes that are in fact
+   * serviceable, so a failed check warns and passes.
+   */
+  async validateFulfillmentData(
+    optionData: Record<string, unknown>,
+    data: Record<string, unknown>,
+    _context: any
+  ): Promise<Record<string, unknown>> {
+    const pin =
+      (data.shipping_address as any)?.postal_code || (data as any).postal_code
+    if (pin) {
+      try {
+        const ok = await this.adapter.checkServiceability(String(pin))
+        if (!ok) {
+          this.logger.warn(
+            `Blue Dart reports pincode ${pin} is not serviceable inbound`
+          )
+        }
+      } catch (e: any) {
+        this.logger.warn(`Blue Dart serviceability check failed: ${e.message}`)
+      }
+    }
+    return { ...data, ...optionData }
+  }
+
+  async validateOption(_data: Record<string, any>): Promise<boolean> {
+    return true
+  }
+
+  /**
+   * False — and that is the accurate answer, not a stub.
+   *
+   * Blue Dart exposes no rate API through this integration (the adapter has no
+   * `getRates`), so there is nothing to calculate. Returning true and then
+   * answering 0 — as the other two carriers do on their error paths — would
+   * silently price shipping at zero. Shipping options on this provider must be
+   * flat-rate.
+   */
+  async canCalculate(_data: CreateShippingOptionDTO): Promise<boolean> {
+    return false
+  }
+
+  async calculatePrice(
+    _optionData: Record<string, unknown>,
+    _data: Record<string, unknown>,
+    _context: any
+  ): Promise<CalculatedShippingOptionPrice> {
+    throw new Error(
+      "Blue Dart has no rate API wired — use a flat-rate shipping option"
+    )
+  }
+
+  async createFulfillment(
+    data: Record<string, unknown>,
+    items: Partial<Omit<FulfillmentItemDTO, "fulfillment">>[],
+    order: Partial<FulfillmentOrderDTO> | undefined,
+    fulfillment: Partial<Omit<FulfillmentDTO, "provider_id" | "data" | "items">>
+  ): Promise<CreateFulfillmentResult> {
+    const shippingAddress = (order as any)?.shipping_address || {}
+    const fromLocation = (data as any).from_location || {}
+
+    // Weight/dims come off the ORDER's line-item variants: the FulfillmentItemDTO
+    // passed here carries no variant. Same approach as Delhivery and Shiprocket.
+    const orderItems = ((order as any)?.items || []) as any[]
+    const orderItemById = new Map<string, any>()
+    for (const oi of orderItems) if (oi.id) orderItemById.set(oi.id, oi)
+
+    let totalWeight = 0
+    let maxLength = 0
+    let maxWidth = 0
+    let maxHeight = 0
+    let hasWeight = false
+    const shipItems: ShipmentItem[] = []
+
+    for (const fItem of items) {
+      const qty = (fItem as any).quantity || 1
+      const oi = orderItemById.get((fItem as any).line_item_id)
+      const variant = oi?.variant
+      if (variant?.weight) {
+        hasWeight = true
+        totalWeight += variant.weight * qty
+      }
+      if (variant?.length && variant.length > maxLength) maxLength = variant.length
+      if (variant?.width && variant.width > maxWidth) maxWidth = variant.width
+      if (variant?.height) maxHeight += variant.height * qty
+
+      shipItems.push({
+        name: (fItem as any).title || oi?.title || "Item",
+        sku: oi?.variant_sku || undefined,
+        quantity: qty,
+        unit_price: oi?.unit_price || 0,
+      })
+    }
+
+    // No variant carried a weight — estimate. Order 83 hit exactly this path;
+    // the real fix is per-variant weights alongside #1223.
+    if (!hasWeight) {
+      const totalQty = shipItems.reduce((s, i) => s + i.quantity, 0)
+      totalWeight = Math.max(400, totalQty * 400)
+    }
+
+    const paymentStatus = (order as any)?.payment_status
+    const isPrepaid = paymentStatus === "captured" || paymentStatus === "paid"
+    const subTotal = shipItems.reduce((s, i) => s + i.unit_price * i.quantity, 0)
+
+    const input: CreateShipmentInput = {
+      reference_id: (order as any)?.id || fulfillment.id || "",
+      payment_mode: isPrepaid ? "prepaid" : "cod",
+      cod_amount: isPrepaid ? undefined : subTotal,
+      // Blue Dart keeps NO pickup-location registry (#1296) — the collection
+      // address travels inline on every call, built by the adapter from the
+      // stock location. This name is a label, never a carrier-side handle.
+      pickup_location_name: fromLocation.name || undefined,
+      to: {
+        name:
+          `${shippingAddress.first_name || ""} ${shippingAddress.last_name || ""}`.trim() ||
+          "Customer",
+        phone: shippingAddress.phone || "",
+        email: (order as any)?.email || undefined,
+        address_1: shippingAddress.address_1 || "",
+        address_2: shippingAddress.address_2 || undefined,
+        city: shippingAddress.city || "",
+        state: shippingAddress.province || "",
+        pincode: shippingAddress.postal_code || "",
+        country: shippingAddress.country_code || "India",
+      },
+      items: shipItems,
+      weight_grams: totalWeight,
+      dimensions_cm:
+        maxLength && maxWidth && maxHeight
+          ? { length: maxLength, width: maxWidth, height: maxHeight }
+          : undefined,
+      sub_total: subTotal,
+    }
+
+    try {
+      const result = await this.adapter.createShipment(input)
+      this.logger.info(`Blue Dart shipment created: awb=${result.awb}`)
+      return {
+        data: {
+          carrier: BLUEDART_CARRIER_ID,
+          waybill: result.awb,
+          tracking_number: result.tracking_number,
+          ...result.provider_refs,
+        },
+        labels: result.awb
+          ? [
+              {
+                tracking_number: result.tracking_number || result.awb,
+                tracking_url: result.tracking_url || "",
+                label_url: result.label_url || "",
+              },
+            ]
+          : [],
+      }
+    } catch (e: any) {
+      // #1296 made these messages carry the carrier's own `error-response[]`.
+      this.logger.error(`Blue Dart createFulfillment error: ${e.message}`)
+      throw e
+    }
+  }
+
+  async cancelFulfillment(fulfillment: Record<string, any>): Promise<any> {
+    const waybill = fulfillment?.data?.waybill || fulfillment?.data?.tracking_number
+    if (!waybill) return {}
+    try {
+      return await this.adapter.cancelShipment({
+        awb: String(waybill),
+        provider_refs: { waybill: String(waybill) },
+      })
+    } catch (e: any) {
+      this.logger.error(`Blue Dart cancelFulfillment error: ${e.message}`)
+      throw e
+    }
+  }
+}
+
+export default BlueDartFulfillmentService


### PR DESCRIPTION
Makes Blue Dart selectable in **Settings → Locations & Shipping**, alongside Delhivery and Shiprocket.

## The gap

Blue Dart has been drivable since #1286 — it is in `SUPPORTED_CARRIERS` and `resolveShippingProvider` returns a live client for it, which is how order 83 got its waybill. What it never was is a **Medusa fulfillment provider**: `bluedart/index.ts` was a plain barrel rather than a `ModuleProvider(Modules.FULFILLMENT, …)`, and there was no `service.ts` at all. Delhivery, Shiprocket, DHL, UPS, FedEx and AusPost all have both. So the fulfillment module never saw Blue Dart, and it could not be attached to a stock location or a shipping option.

Confirmed against prod rather than assumed — `GET /admin/fulfillment-providers` returns exactly three rows: `manual_manual`, `delhivery_delhivery`, `shiprocket_shiprocket`. Blue Dart becomes a fourth on deploy, with **no env change needed**.

Carrier logic is untouched; the service delegates to the existing `BlueDartProviderAdapter`.

## Three judgment calls

- **One domestic option, not four.** `createShipment` picks the product code from the destination, not from the chosen option, so advertising Apex/Surface would offer service levels that all ship as `D`. Per-option product selection needs the adapter to accept a product code first.
- **International (product `H`) is deliberately not offered** — still blocked on #1223's HS codes and the unverified single-letter waybill `SubProductCode`.
- **`canCalculate` returns `false`.** Blue Dart has no rate API wired here. The other two carriers return `true` and then answer `0` on their error paths, which prices shipping at zero on a live cart. That is not copied — **Blue Dart shipping options must be flat-rate.**

## Also in here: the product codes are settled

Called `GetAllProductsAndSubProducts` live (free, read-only). It returns the authoritative registry:

| Product | Sub-products |
|---|---|
| A | DART PLUS, Apex Laptop Box 10, BHARAT DART, Critical Express, TDD, Smart Box 10/25/Mult, FOV, FOD, Express Pallete 50/75/100, EDL, Economy, E-Tailing, DOD, DC |
| D | Rakhi Express Env, Diwali Express, DP Critical Express, TDD, Rakhi Express Box |
| E | FOD, Smart Box Mult, SFC Laptop Box 10, FOV/DC, DOD, EDL, Express Pallete 50/75/100, Smart Box 10/25, E-Tailing |
| **H** | **IPC-Expedited, IPC-Standard** |
| I | E-Tailing, SII, DTP, Express Easy 6, Express Easy 8, Express Pallete, Imp/EXP |

⚠️ **This retracts the 2026-08-14 conclusion** that "`A`, `D`, `E` are the only valid product codes" and that `H`/`I` return `InvalidProductCode`. That came from `GetServicesforPincode` — a pincode *serviceability* call, which `constants.ts` already suspected of covering domestic products only. The suspicion was right.

- `international: "H"` is **correct**, not known-invalid. The standing action item to "fix" it is dropped — changing it would have broken exports.
- `E` is identified: the surface/ground product (SFC = Surface Freight Cargo).
- `I` is **not** "international import"; it is a mixed import/export product.
- `BLUEDART_INTL_SUBPRODUCT = "P"` stays unverified and now looks weaker, but the registry is the *pickup* vocabulary (full names, array) while that field is the *waybill's* (1 char, A-Z) — so it is not settled. Left alone deliberately.

## Watch-outs

- The pre-push parity check caught that prod boots from a **separate** `medusa-config.prod.ts`; registering only in `medusa-config.ts` would have shipped a provider that never appeared in prod. Both are updated.
- The Blue Dart token endpoint is **GET**; a POST to it answers `200` with an **empty body**.
- Not boot-verified — local Postgres was down, so `check-fulfillment-providers.ts` could not run. After deploy it should list `bluedart_bluedart`.

## Verify

```
npx tsc --noEmit                                 → 79 (baseline; none in these files)
npx jest --testPathPattern="shipping-providers"  → 21 suites / 246 tests
npx jest --testPathPattern="bluedart"            → 68 tests
node ./scripts/check-prod-config-parity.mjs      → ✓
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)