### PR TITLE
feat(mcp): expose route-level filters on admin + partner tool registries

### DIFF
--- a/apps/backend/.env.test
+++ b/apps/backend/.env.test
@@ -1,3 +1,12 @@
+DATABASE_TYPE=postgres
+DATABASE_URL=postgresql://postgres@localhost:5432/postgres
+REDIS_URL=redis://localhost:6379
+JWT_SECRET=secret
+COOKIE_SECRET=secret
+ADMIN_CORS=http://localhost:7001
+STORE_CORS=http://localhost:8000
+NODE_ENV=test
+ENCRYPTION_KEY=bPH59JuZDRQULLeDD62+NiwqwcChpOLN/j7aqu3A+Hw=
 MEDUSA_FF_INDEX_ENGINE=true
 
 # Short timeout for lifecycle workflow async steps in tests

--- a/apps/backend/src/api/admin/mcp/lib/registry.ts
+++ b/apps/backend/src/api/admin/mcp/lib/registry.ts
@@ -74,13 +74,16 @@ export const ADMIN_MCP_TOOLS: AdminMcpToolDef[] = [
       "List orders (paginated). Supports free-text search via q. Defaults to RETAIL orders only — pass kind to see design/inventory orders or all of them. Use to answer 'what orders came in', revenue/volume, and to find an order id.",
     method: "GET",
     path: "/admin/orders",
-    queryParams: ["limit", "offset", "q", "status", "kind"],
+    queryParams: ["limit", "offset", "q", "status", "kind", "sales_channel_id", "region_id", "customer_id"],
     inputSchema: obj({
       ...PAGINATION,
       status: STR("Optional order status filter."),
       kind: STR(
         "Which order family to list: 'retail' (default) | 'design' | 'inventory' | 'all'."
       ),
+      sales_channel_id: STR("Filter to orders in a specific sales channel id."),
+      region_id: STR("Filter to orders in a specific region id."),
+      customer_id: STR("Filter to orders for a specific customer id."),
     }),
   },
   {
@@ -95,11 +98,24 @@ export const ADMIN_MCP_TOOLS: AdminMcpToolDef[] = [
   // ===== Catalog ===========================================================
   {
     name: "list_products",
-    description: "List products (paginated). Supports free-text search via q.",
+    description:
+      "List products (paginated). Supports free-text search via q. Filter by status, sales channel, collection, category, type, tag or handle to scope results — e.g. pass sales_channel_id to see products in a partner's storefront, or status=published to see only live products.",
     method: "GET",
     path: "/admin/products",
-    queryParams: ["limit", "offset", "q"],
-    inputSchema: obj({ ...PAGINATION }),
+    queryParams: ["limit", "offset", "q", "status", "sales_channel_id", "collection_id", "category_id", "type_id", "tag_id", "handle"],
+    inputSchema: obj({
+      ...PAGINATION,
+      status: {
+        type: "string",
+        description: "Product status: 'draft' | 'proposed' | 'published' | 'rejected'.",
+      },
+      sales_channel_id: STR("Filter to products in a specific sales channel id (e.g. a partner store's default_sales_channel_id from list_stores)."),
+      collection_id: STR("Filter to products in a specific collection."),
+      category_id: STR("Filter to products in a specific category."),
+      type_id: STR("Filter to products of a specific type."),
+      tag_id: STR("Filter to products with a specific tag."),
+      handle: STR("Filter to a product by its URL handle."),
+    }),
   },
   {
     name: "get_product",
@@ -113,11 +129,19 @@ export const ADMIN_MCP_TOOLS: AdminMcpToolDef[] = [
   // ===== Customers =========================================================
   {
     name: "list_customers",
-    description: "List customers (paginated). Supports free-text search via q.",
+    description:
+      "List customers (paginated). Supports free-text search via q. Filter by email, name, company or account type.",
     method: "GET",
     path: "/admin/customers",
-    queryParams: ["limit", "offset", "q"],
-    inputSchema: obj({ ...PAGINATION }),
+    queryParams: ["limit", "offset", "q", "email", "has_account", "company_name", "first_name", "last_name"],
+    inputSchema: obj({
+      ...PAGINATION,
+      email: STR("Filter to customers with a specific email."),
+      has_account: BOOL("Filter to registered (true) or guest (false) customers."),
+      company_name: STR("Filter by company name."),
+      first_name: STR("Filter by first name."),
+      last_name: STR("Filter by last name."),
+    }),
   },
 
   // ===== Partners & stores =================================================
@@ -139,6 +163,23 @@ export const ADMIN_MCP_TOOLS: AdminMcpToolDef[] = [
     inputSchema: obj({ id: STR("Partner id, e.g. 'partner_...'.") }, ["id"]),
   },
   {
+    name: "list_partner_products",
+    description:
+      "List a specific partner's products — the sales-channel-scoped catalog that partner sees on their own portal. Use list_stores or get_partner to find the partner's stores first, then pass store_id to scope to a specific storefront. Without store_id, the partner's first store is used.",
+    method: "GET",
+    path: "/admin/partners/:id/products",
+    pathParams: ["id"],
+    queryParams: ["store_id", "q", "limit", "offset"],
+    inputSchema: obj(
+      {
+        id: STR("Partner id, e.g. 'partner_...'."),
+        store_id: STR("Optional store id to scope to a specific storefront. Defaults to the partner's first store."),
+        ...PAGINATION,
+      },
+      ["id"]
+    ),
+  },
+  {
     name: "list_stores",
     description: "List storefronts / stores configured on the platform.",
     method: "GET",
@@ -150,11 +191,33 @@ export const ADMIN_MCP_TOOLS: AdminMcpToolDef[] = [
   // ===== Designs & production ==============================================
   {
     name: "list_designs",
-    description: "List designs (paginated). Supports free-text search via q.",
+    description:
+      "List designs (paginated). Supports free-text search via q. Filter by status, design type, priority, partner or tags.",
     method: "GET",
     path: "/admin/designs",
-    queryParams: ["limit", "offset", "q"],
-    inputSchema: obj({ ...PAGINATION }),
+    queryParams: ["limit", "offset", "q", "status", "design_type", "priority", "partner_id", "tags", "name"],
+    inputSchema: obj({
+      ...PAGINATION,
+      name: STR("Partial or full name match."),
+      status: {
+        type: "string",
+        description: "Design status: 'Conceptual' | 'In_Development' | 'Technical_Review' | 'Sample_Production' | 'Revision' | 'Approved' | 'Rejected' | 'On_Hold' | 'Commerce_Ready' | 'Superseded'.",
+      },
+      design_type: {
+        type: "string",
+        description: "'Original' | 'Derivative' | 'Custom' | 'Collaboration'.",
+      },
+      priority: {
+        type: "string",
+        description: "'Low' | 'Medium' | 'High' | 'Urgent'.",
+      },
+      partner_id: STR("Filter by owning partner id."),
+      tags: {
+        type: "array",
+        description: "Tag strings to filter by.",
+        items: { type: "string" },
+      },
+    }),
   },
   {
     name: "get_design",

--- a/apps/backend/src/api/partners/mcp/lib/registry.ts
+++ b/apps/backend/src/api/partners/mcp/lib/registry.ts
@@ -283,18 +283,28 @@ export const PARTNER_MCP_TOOLS: PartnerMcpToolDef[] = [
   // ===== Read-only breadth across partner resources ========================
   {
     name: "list_orders",
-    description: "List the partner's orders (paginated). Supports free-text search via q.",
+    description:
+      "List the partner's orders (paginated). Supports free-text search via q. Pass kind to switch between retail, design or inventory work-orders. Filter by status, date range, region or sales channel.",
     method: "GET",
     path: "/partners/orders",
-    queryParams: ["limit", "offset", "q", "status"],
+    queryParams: ["limit", "offset", "q", "status", "kind", "created_at", "updated_at", "region_id", "sales_channel_id", "order"],
     inputSchema: obj({
       ...PAGINATION,
       status: STR("Optional order status filter."),
+      kind: STR(
+        "Which order family to list: 'retail' (default) | 'design' | 'inventory' | 'all'."
+      ),
+      created_at: STR("Date filter (ISO string, optionally with $gt/$lt/$gte/$lte operators)."),
+      updated_at: STR("Date filter (ISO string, optionally with $gt/$lt/$gte/$lte operators)."),
+      region_id: STR("Filter to orders in a specific region (retail only)."),
+      sales_channel_id: STR("Filter to orders in a specific sales channel (retail only)."),
+      order: STR("Sort field with optional leading '-' for DESC, e.g. '-created_at' (default) or 'display_id'."),
     }),
   },
   {
     name: "list_products",
-    description: "List the partner's products (paginated). Supports free-text search via q.",
+    description:
+      "List the partner's products (paginated). Supports free-text search via q. Prefer list_store_products with a store_id for store-scoped / sales-channel-filtered results.",
     method: "GET",
     path: "/partners/products",
     queryParams: ["limit", "offset", "q"],
@@ -396,11 +406,19 @@ export const PARTNER_MCP_TOOLS: PartnerMcpToolDef[] = [
   },
   {
     name: "list_designs",
-    description: "List the partner's designs / design briefs (paginated).",
+    description:
+      "List the partner's designs / design briefs (paginated). Filter by status or bucket (incoming / in_progress / completed / yours).",
     method: "GET",
     path: "/partners/designs",
-    queryParams: ["limit", "offset", "q"],
-    inputSchema: obj({ ...PAGINATION }),
+    queryParams: ["limit", "offset", "q", "status", "bucket"],
+    inputSchema: obj({
+      ...PAGINATION,
+      status: STR("Filter designs by status (e.g. 'In_Development', 'Approved')."),
+      bucket: {
+        type: "string",
+        description: "Action-oriented bucket: 'all' (default) | 'incoming' | 'in_progress' | 'completed' | 'yours'.",
+      },
+    }),
   },
   {
     name: "list_inventory_items",


### PR DESCRIPTION
## What

The Admin and Partner MCP tool registries declared only a fraction of the filters their underlying routes actually accept — the model had no way to pass , , , etc. This PR exposes all supported filter parameters on both surfaces so the assistant can scope product, order, customer and design queries.

## Admin MCP changes

| Tool | Filters added |
|------|--------------|
| `list_products` | `status`, `sales_channel_id`, `collection_id`, `category_id`, `type_id`, `tag_id`, `handle` |
| `list_orders` | `sales_channel_id`, `region_id`, `customer_id` |
| `list_customers` | `email`, `has_account`, `company_name`, `first_name`, `last_name` |
| `list_designs` | `status`, `design_type`, `priority`, `partner_id`, `tags`, `name` |
| **new** `list_partner_products` | `GET /admin/partners/:id/products?store_id=` — admin inspection mirror of a partner's sales-channel-scoped catalog |

## Partner MCP changes

| Tool | Filters added |
|------|--------------|
| `list_orders` | `kind`, `created_at`, `updated_at`, `region_id`, `sales_channel_id`, `order` (sort) |
| `list_designs` | `status`, `bucket` |
| `list_products` | Description updated to steer model toward `list_store_products` for store/sales-channel-scoped results |

## How it works

Every filter added to the `queryParams` array and `inputSchema` was verified against the underlying route's validator or middleware — these are params the routes already accept, just not declared in the MCP tool schema. The shared `dispatchMcpTool` in `mcp-core/dispatch.ts` forwards all query params from the tool input to the proxied route, so no dispatcher changes are needed.

## Verification

- `tsc --noEmit` — zero new errors (156 pre-existing, 156 after)
- Pre-push hooks passed (lockfile sync + prod config parity)

## Not included

- The partner `list_products` (`GET /partners/products`) still has no GET handler on the route — that's a pre-existing bug, not addressed here. The `list_store_products` tool (`GET /partners/stores/:id/products`) already covers store-scoped product listing.
- The `bulk_update_products` tool added by #1288 is unchanged.