### PR TITLE
fix(mcp): strip .env.test residue + add include_partner_owned to list_designs

### DIFF
--- a/apps/backend/.env.test
+++ b/apps/backend/.env.test
@@ -1,12 +1,3 @@
-DATABASE_TYPE=postgres
-DATABASE_URL=postgresql://postgres@localhost:5432/postgres
-REDIS_URL=redis://localhost:6379
-JWT_SECRET=secret
-COOKIE_SECRET=secret
-ADMIN_CORS=http://localhost:7001
-STORE_CORS=http://localhost:8000
-NODE_ENV=test
-ENCRYPTION_KEY=bPH59JuZDRQULLeDD62+NiwqwcChpOLN/j7aqu3A+Hw=
 MEDUSA_FF_INDEX_ENGINE=true
 
 # Short timeout for lifecycle workflow async steps in tests

--- a/apps/backend/src/api/admin/mcp/lib/registry.ts
+++ b/apps/backend/src/api/admin/mcp/lib/registry.ts
@@ -195,7 +195,7 @@ export const ADMIN_MCP_TOOLS: AdminMcpToolDef[] = [
       "List designs (paginated). Supports free-text search via q. Filter by status, design type, priority, partner or tags.",
     method: "GET",
     path: "/admin/designs",
-    queryParams: ["limit", "offset", "q", "status", "design_type", "priority", "partner_id", "tags", "name"],
+    queryParams: ["limit", "offset", "q", "status", "design_type", "priority", "partner_id", "tags", "name", "include_partner_owned"],
     inputSchema: obj({
       ...PAGINATION,
       name: STR("Partial or full name match."),
@@ -212,6 +212,7 @@ export const ADMIN_MCP_TOOLS: AdminMcpToolDef[] = [
         description: "'Low' | 'Medium' | 'High' | 'Urgent'.",
       },
       partner_id: STR("Filter by owning partner id."),
+      include_partner_owned: BOOL("Set to true to include partner-owned (self-serve) designs — these are hidden by default. Pass this when filtering by partner_id, or the result may be empty."),
       tags: {
         type: "array",
         description: "Tag strings to filter by.",


### PR DESCRIPTION
Follow-up to #1299.

## Changes

**1. Strip undocumented .env.test changes** — the merged PR inadvertently added `DATABASE_URL`, `REDIS_URL`, `JWT_SECRET`, `COOKIE_SECRET` and an `ENCRYPTION_KEY` to `.env.test`. These are inert in CI (dotenv doesn't override already-set env vars) but leave a key-shaped value in a tracked file and a `DATABASE_URL` default that points a dev with no env set at the local postgres. Reverted to the pre-PR state.

**2. Add `include_partner_owned` to admin `list_designs`** — the designs route hides partner-owned (self-serve) designs from the admin list unless `?include_partner_owned=true` (route.ts:292-295). The merged PR added `partner_id` as a filter but not this flag, so an assistant asking "show me partner X's designs" could get an empty result. Now declared alongside `partner_id` with a description that tells the model to pass it when filtering by partner.