### PR TITLE
fix(deploy): wire Blue Dart credentials into prod so the provider registers (#1285)

### DIFF
--- a/deploy/aws/copilot/medusa-server/manifest.yml
+++ b/deploy/aws/copilot/medusa-server/manifest.yml
@@ -120,6 +120,25 @@ secrets:
   ANALYTICS_INGEST_SECRET: /jyt/prod/ANALYTICS_INGEST_SECRET
   AUTH_CORS: /jyt/prod/AUTH_CORS
   AUTH_MFA_ENCRYPTION_KEY: /jyt/prod/AUTH_MFA_ENCRYPTION_KEY
+  # Blue Dart fulfillment provider (#1285). The env-gated block in
+  # medusa-config.prod.ts registers the provider whenever BLUE_DART_LICENCE_KEY is
+  # set — without it the provider does not appear in Fulfillment Providers at all,
+  # which is exactly what happened after #1297 shipped: the code was live and the
+  # provider still never showed, because none of these existed.
+  #
+  # Unlike Shiprocket (below), the FULL credential set is wired here, because
+  # BlueDartFulfillmentService builds its own BlueDartClient from these options —
+  # the licence key alone would register a provider that cannot call the carrier.
+  # Label/tracking/pickup via resolveShippingProvider still read the
+  # `category:shipping` SocialPlatform record; these are the boot-time source.
+  #
+  # api_type / version / origin_area are deliberately NOT wired: the client
+  # already defaults them to "S" / "1.3" / "DHM", matching the values in use.
+  BLUE_DART_CLIENT_ID: /jyt/prod/BLUE_DART_CLIENT_ID
+  BLUE_DART_CLIENT_SECRET: /jyt/prod/BLUE_DART_CLIENT_SECRET
+  BLUE_DART_CUSTOMER_CODE: /jyt/prod/BLUE_DART_CUSTOMER_CODE
+  BLUE_DART_LICENCE_KEY: /jyt/prod/BLUE_DART_LICENCE_KEY
+  BLUE_DART_LOGIN_ID: /jyt/prod/BLUE_DART_LOGIN_ID
   CLOUDFLARE_API_TOKEN: /jyt/prod/CLOUDFLARE_API_TOKEN
   CLOUDFLARE_ZONE_ID: /jyt/prod/CLOUDFLARE_ZONE_ID
   COOKIE_SECRET: /jyt/prod/COOKIE_SECRET

--- a/deploy/aws/copilot/medusa-worker/manifest.yml
+++ b/deploy/aws/copilot/medusa-worker/manifest.yml
@@ -42,6 +42,16 @@ secrets:
   # medusa-server (server mode skips scheduled jobs). The flag MUST be set on the
   # worker too or the drain early-returns and the Redis buffer never persists.
   ANALYTICS_BATCH_INGEST: /jyt/prod/ANALYTICS_BATCH_INGEST
+  # Blue Dart fulfillment provider (#1285) — see the fuller note in
+  # medusa-server/manifest.yml. Mirrored onto the worker because prod runs SPLIT
+  # server + worker and the worker boots the same medusa-config.prod.ts; a module
+  # registered on only one of the two is a source of "works on the server, missing
+  # on the worker" bugs.
+  BLUE_DART_CLIENT_ID: /jyt/prod/BLUE_DART_CLIENT_ID
+  BLUE_DART_CLIENT_SECRET: /jyt/prod/BLUE_DART_CLIENT_SECRET
+  BLUE_DART_CUSTOMER_CODE: /jyt/prod/BLUE_DART_CUSTOMER_CODE
+  BLUE_DART_LICENCE_KEY: /jyt/prod/BLUE_DART_LICENCE_KEY
+  BLUE_DART_LOGIN_ID: /jyt/prod/BLUE_DART_LOGIN_ID
   CLOUDFLARE_API_TOKEN: /jyt/prod/CLOUDFLARE_API_TOKEN
   CLOUDFLARE_ZONE_ID: /jyt/prod/CLOUDFLARE_ZONE_ID
   DATABASE_URL: /jyt/prod/DATABASE_URL


### PR DESCRIPTION
Completes #1297, which shipped clean and **changed nothing in prod**.

## The gap

After a successful deploy of `09b9696e9`, `GET /admin/fulfillment-providers` still returned exactly three rows — `manual_manual`, `delhivery_delhivery`, `shiprocket_shiprocket`. No Blue Dart.

Registration is gated on `process.env.BLUE_DART_LICENCE_KEY`, and **none of the `BLUE_DART_*` variables existed in prod**: no entries in either copilot manifest, and no `/jyt/prod/BLUE_DART_*` SSM parameters at all. The gate could never fire. My claim in #1297 that it would "register with no env change" was wrong.

## Why this was easy to miss

Blue Dart already **works** in prod — order 83's waybill proves it. But that path is `resolveShippingProvider`, which reads credentials from the encrypted `category:shipping` `SocialPlatform` record in the database. Fulfillment-provider registration is a *different* path that can only read env at boot. Having credentials in one says nothing about the other.

## What changed

Five SecureString parameters created in `us-east-1` (Version 1 each — no overwrite, so an existing value would have failed loudly):

```
/jyt/prod/BLUE_DART_CLIENT_ID
/jyt/prod/BLUE_DART_CLIENT_SECRET
/jyt/prod/BLUE_DART_CUSTOMER_CODE
/jyt/prod/BLUE_DART_LICENCE_KEY
/jyt/prod/BLUE_DART_LOGIN_ID
```

This PR references them from **both** manifests. Server *and* worker, because prod runs split server + worker off the same `medusa-config.prod.ts` — a module registered on only one of the two is a classic "works on the server, missing on the worker" bug.

## Two deliberate choices

- **Full credential set, unlike Shiprocket.** Shiprocket wires only its gate variable (`SHIPROCKET_EMAIL`) and notes that real API calls go through the resolver. Blue Dart can't follow that: `BlueDartFulfillmentService` builds its own `BlueDartClient` from these options, so the licence key alone would register a provider that appears in the UI and then cannot call the carrier.
- **`api_type` / `version` / `origin_area` NOT wired.** `client.ts` already defaults them to `"S"` / `"1.3"` / `"DHM"`, which is exactly what's in use — wiring them would add three secrets that can only drift.

## Verify after deploy

```
GET /admin/fulfillment-providers  → expect a 4th row: bluedart_bluedart
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)