### PR TITLE
feat(bluedart): gate the provider on BLUE_DART_PROVIDER_ENABLED (#1285)

### DIFF
--- a/apps/backend/medusa-config.prod.ts
+++ b/apps/backend/medusa-config.prod.ts
@@ -369,11 +369,13 @@ module.exports = defineConfig({
           // pickup routes go through `resolveShippingProvider` and the
           // external-platform credential store.
           //
-          // Gated on the LICENCE KEY, not the gateway client id: Blue Dart's two
-          // auth layers are independent, and the gateway mints a valid JWT for
-          // EMPTY credentials (401 only for *wrong* ones), so a client-id check
-          // would register a provider that cannot actually ship.
-          ...(process.env.BLUE_DART_LICENCE_KEY
+          // Gated on an explicit ON/OFF SWITCH, not on a credential — same shape
+          // as STRIPE_CONNECT_ENABLED. Gating on a secret is what let #1297 ship
+          // a registered provider that never appeared in prod, because neither
+          // the secret nor the manifest entry existed. Credentials live in the
+          // encrypted category:shipping SocialPlatform record; the env values
+          // below are the documented fallback (see bluedart/service.ts).
+          ...(process.env.BLUE_DART_PROVIDER_ENABLED === "true"
             ? [
                 {
                   resolve: "./src/modules/shipping-providers/bluedart",

--- a/apps/backend/medusa-config.ts
+++ b/apps/backend/medusa-config.ts
@@ -429,11 +429,19 @@ module.exports = defineConfig({
                       },
                     ]
                   : []),
-                // Gated on the LICENCE KEY, not the gateway client id: Blue Dart's
-                // two auth layers are independent, and the gateway happily mints a
-                // valid JWT for EMPTY credentials (401 only for *wrong* ones), so
-                // a client-id check would register a provider that cannot ship.
-                ...(process.env.BLUE_DART_LICENCE_KEY
+                // Gated on an explicit ON/OFF SWITCH, not on a credential.
+                //
+                // Gating on BLUE_DART_LICENCE_KEY (as this did until #1285's
+                // follow-up) coupled "is this provider offered?" to "is this
+                // secret wired?" — and prod had neither, so #1297 shipped a
+                // registered provider that never appeared. A boolean is the same
+                // shape as STRIPE_CONNECT_ENABLED and is checkable at a glance.
+                //
+                // Credentials are NOT the gate: they live in the encrypted
+                // category:shipping SocialPlatform record. The env values below
+                // are a documented FALLBACK for when the module container cannot
+                // reach that store — see resolveAdapter() in bluedart/service.ts.
+                ...(process.env.BLUE_DART_PROVIDER_ENABLED === "true"
                   ? [
                       {
                         resolve: "./src/modules/shipping-providers/bluedart",

--- a/apps/backend/src/modules/shipping-providers/bluedart/__tests__/fulfillment-service.unit.spec.ts
+++ b/apps/backend/src/modules/shipping-providers/bluedart/__tests__/fulfillment-service.unit.spec.ts
@@ -32,11 +32,15 @@ const CONFIG: any = {
 
 const buildService = (createShipment: jest.Mock) => {
   const svc = new BlueDartFulfillmentService({ logger }, CONFIG)
-  ;(svc as any).adapter = {
+  // Credentials are resolved per call now (platform store first, env fallback),
+  // so the stub replaces the resolver rather than a constructor-built adapter.
+  const adapter = {
     createShipment,
     checkServiceability: jest.fn().mockResolvedValue(true),
     cancelShipment: jest.fn().mockResolvedValue({ success: true }),
   }
+  ;(svc as any).adapter = adapter
+  ;(svc as any).resolveAdapter = jest.fn().mockResolvedValue(adapter)
   return svc
 }
 

--- a/apps/backend/src/modules/shipping-providers/bluedart/service.ts
+++ b/apps/backend/src/modules/shipping-providers/bluedart/service.ts
@@ -14,8 +14,12 @@ import { BlueDartProviderAdapter } from "./adapter"
 import { BLUEDART_CARRIER_ID } from "./constants"
 import type { BlueDartConfig } from "./types"
 import { CreateShipmentInput, ShipmentItem } from "../provider-interface"
+// Static, not dynamic: `await import("../resolver")` trips TS2835 under
+// node16 module resolution. No cycle — resolver.ts imports ./bluedart/adapter
+// directly, never this file or the barrel.
+import { resolveShippingProvider } from "../resolver"
 
-type InjectedDeps = { logger: Logger }
+type InjectedDeps = { logger: Logger } & Record<string, unknown>
 
 /**
  * Blue Dart fulfillment provider (#1285).
@@ -33,17 +37,71 @@ type InjectedDeps = { logger: Logger }
  * sandbox host is a separate base URL, not a dry-run flag on production. The
  * registration in `medusa-config.ts` sits behind `ENABLE_CARRIER_FULFILLMENT`
  * for exactly this reason.
+ *
+ * ## Credentials: platform store first, env second
+ *
+ * Registration is gated on `BLUE_DART_PROVIDER_ENABLED` — a plain on/off switch,
+ * mirroring `STRIPE_CONNECT_ENABLED` — rather than on the presence of a
+ * credential. Credentials live in the encrypted `category:shipping`
+ * SocialPlatform record, which is where `resolveShippingProvider` already reads
+ * them and how every real Blue Dart call is made today.
+ *
+ * ⚠️ Whether the store can be reached from HERE is not guaranteed: a module
+ * provider is constructed with the FULFILLMENT MODULE's container, and
+ * "the module's own __container__ cannot resolve other modules under module
+ * isolation" (see google_merchant/service.ts). `createFulfillment` is handed
+ * DTOs, not an app container, so there is no second chance to pass one in.
+ * Hence `resolveAdapter()`: try the store, fall back to the env-built client,
+ * and LOG which path was taken so the answer is observable in prod instead of
+ * assumed. Env credentials are therefore a fallback, not the design.
  */
 class BlueDartFulfillmentService extends AbstractFulfillmentProviderService {
   static identifier = BLUEDART_CARRIER_ID
 
-  protected adapter: BlueDartProviderAdapter
   protected logger: Logger
+  private readonly container: unknown
+  private readonly options: BlueDartConfig
 
-  constructor({ logger }: InjectedDeps, options: BlueDartConfig) {
+  constructor(deps: InjectedDeps, options: BlueDartConfig) {
     super()
-    this.logger = logger
-    this.adapter = new BlueDartProviderAdapter(new BlueDartClient(options))
+    this.logger = deps.logger
+    this.container = deps
+    this.options = options ?? ({} as BlueDartConfig)
+  }
+
+  /**
+   * Build an adapter for one call. Never cached: `resolveShippingProvider`
+   * re-reads (and re-decrypts) the platform record each time, so a credential
+   * rotated in the admin UI takes effect on the next call rather than on the
+   * next deploy.
+   */
+  protected async resolveAdapter(): Promise<BlueDartProviderAdapter> {
+    try {
+      const client = await resolveShippingProvider(
+        this.container as any,
+        BLUEDART_CARRIER_ID
+      )
+      if (client) {
+        this.logger.debug?.(
+          "[bluedart] credentials resolved from the SocialPlatform store"
+        )
+        return client as unknown as BlueDartProviderAdapter
+      }
+    } catch (e: any) {
+      this.logger.warn(
+        `[bluedart] platform-store credentials unavailable from the module ` +
+          `container (${e?.message}); falling back to env credentials`
+      )
+    }
+
+    if (!this.options.licence_key || !this.options.client_id) {
+      throw new Error(
+        "Blue Dart credentials are not available: the category:shipping " +
+          "SocialPlatform record could not be read from this container, and no " +
+          "BLUE_DART_* env fallback is configured."
+      )
+    }
+    return new BlueDartProviderAdapter(new BlueDartClient(this.options))
   }
 
   /**
@@ -93,7 +151,8 @@ class BlueDartFulfillmentService extends AbstractFulfillmentProviderService {
       (data.shipping_address as any)?.postal_code || (data as any).postal_code
     if (pin) {
       try {
-        const ok = await this.adapter.checkServiceability(String(pin))
+        const adapter = await this.resolveAdapter()
+        const ok = await adapter.checkServiceability(String(pin))
         if (!ok) {
           this.logger.warn(
             `Blue Dart reports pincode ${pin} is not serviceable inbound`
@@ -217,7 +276,8 @@ class BlueDartFulfillmentService extends AbstractFulfillmentProviderService {
     }
 
     try {
-      const result = await this.adapter.createShipment(input)
+      const adapter = await this.resolveAdapter()
+      const result = await adapter.createShipment(input)
       this.logger.info(`Blue Dart shipment created: awb=${result.awb}`)
       return {
         data: {
@@ -247,7 +307,8 @@ class BlueDartFulfillmentService extends AbstractFulfillmentProviderService {
     const waybill = fulfillment?.data?.waybill || fulfillment?.data?.tracking_number
     if (!waybill) return {}
     try {
-      return await this.adapter.cancelShipment({
+      const adapter = await this.resolveAdapter()
+      return await adapter.cancelShipment({
         awb: String(waybill),
         provider_refs: { waybill: String(waybill) },
       })

--- a/deploy/aws/copilot/medusa-server/manifest.yml
+++ b/deploy/aws/copilot/medusa-server/manifest.yml
@@ -120,6 +120,31 @@ secrets:
   ANALYTICS_INGEST_SECRET: /jyt/prod/ANALYTICS_INGEST_SECRET
   AUTH_CORS: /jyt/prod/AUTH_CORS
   AUTH_MFA_ENCRYPTION_KEY: /jyt/prod/AUTH_MFA_ENCRYPTION_KEY
+  # Blue Dart fulfillment provider (#1285).
+  #
+  # BLUE_DART_PROVIDER_ENABLED is the ON/OFF SWITCH — "true" registers the
+  # provider, anything else withdraws it. Same shape as STRIPE_CONNECT_ENABLED.
+  # Without it the provider does not appear in Fulfillment Providers at all,
+  # which is exactly what happened after #1297: the code was live and the
+  # provider still never showed, because nothing here was set.
+  # ⚠️ Medusa does NOT delete a withdrawn provider's row — it flips
+  # is_enabled=false and leaves it (verified locally both ways).
+  #
+  # The credentials below are a FALLBACK, not the design. They are needed
+  # because a fulfillment provider is built with the fulfillment MODULE's
+  # container, which cannot resolve other modules under module isolation — so it
+  # cannot read the encrypted category:shipping SocialPlatform record that
+  # resolveShippingProvider uses for every other Blue Dart call. See
+  # resolveAdapter() in bluedart/service.ts, which logs which path it took.
+  #
+  # api_type / version / origin_area are deliberately NOT wired: the client
+  # defaults them to "S" / "1.3" / "DHM", matching the values in use.
+  BLUE_DART_PROVIDER_ENABLED: /jyt/prod/BLUE_DART_PROVIDER_ENABLED
+  BLUE_DART_CLIENT_ID: /jyt/prod/BLUE_DART_CLIENT_ID
+  BLUE_DART_CLIENT_SECRET: /jyt/prod/BLUE_DART_CLIENT_SECRET
+  BLUE_DART_CUSTOMER_CODE: /jyt/prod/BLUE_DART_CUSTOMER_CODE
+  BLUE_DART_LICENCE_KEY: /jyt/prod/BLUE_DART_LICENCE_KEY
+  BLUE_DART_LOGIN_ID: /jyt/prod/BLUE_DART_LOGIN_ID
   CLOUDFLARE_API_TOKEN: /jyt/prod/CLOUDFLARE_API_TOKEN
   CLOUDFLARE_ZONE_ID: /jyt/prod/CLOUDFLARE_ZONE_ID
   COOKIE_SECRET: /jyt/prod/COOKIE_SECRET

--- a/deploy/aws/copilot/medusa-worker/manifest.yml
+++ b/deploy/aws/copilot/medusa-worker/manifest.yml
@@ -42,6 +42,16 @@ secrets:
   # medusa-server (server mode skips scheduled jobs). The flag MUST be set on the
   # worker too or the drain early-returns and the Redis buffer never persists.
   ANALYTICS_BATCH_INGEST: /jyt/prod/ANALYTICS_BATCH_INGEST
+  # Blue Dart fulfillment provider (#1285) — see the fuller note in
+  # medusa-server/manifest.yml. Mirrored onto the worker because prod runs SPLIT
+  # server + worker off the same medusa-config.prod.ts; a provider registered on
+  # only one of the two is a "works on the server, missing on the worker" bug.
+  BLUE_DART_PROVIDER_ENABLED: /jyt/prod/BLUE_DART_PROVIDER_ENABLED
+  BLUE_DART_CLIENT_ID: /jyt/prod/BLUE_DART_CLIENT_ID
+  BLUE_DART_CLIENT_SECRET: /jyt/prod/BLUE_DART_CLIENT_SECRET
+  BLUE_DART_CUSTOMER_CODE: /jyt/prod/BLUE_DART_CUSTOMER_CODE
+  BLUE_DART_LICENCE_KEY: /jyt/prod/BLUE_DART_LICENCE_KEY
+  BLUE_DART_LOGIN_ID: /jyt/prod/BLUE_DART_LOGIN_ID
   CLOUDFLARE_API_TOKEN: /jyt/prod/CLOUDFLARE_API_TOKEN
   CLOUDFLARE_ZONE_ID: /jyt/prod/CLOUDFLARE_ZONE_ID
   DATABASE_URL: /jyt/prod/DATABASE_URL


### PR DESCRIPTION
Supersedes #1301, which should be closed.

Registration was gated on `BLUE_DART_LICENCE_KEY` — coupling *"is this provider offered?"* to *"is this secret wired?"*. Prod had neither, so #1297 shipped a registered provider that never appeared. The gate is now a plain on/off switch, same shape as `STRIPE_CONNECT_ENABLED`.

## Verified locally, both directions

Local Postgres + `check-fulfillment-providers.ts`:

```
BLUE_DART_PROVIDER_ENABLED unset  ->  bluedart_bluedart  enabled=false
BLUE_DART_PROVIDER_ENABLED=true   ->  bluedart_bluedart  enabled=true
```

⚠️ **Medusa does not delete a withdrawn provider's row** — it flips `is_enabled=false` and leaves it. Useful corollary: prod showing only three rows was real proof Blue Dart had *never* registered there, not merely that it was disabled.

## The store-only idea does not work here — and that is now explicit

The aim was to keep credentials solely in the encrypted `category:shipping` SocialPlatform record and delete the env copies. **That is not reachable from a fulfillment provider.** It is constructed with the *fulfillment module's* container, and per `google_merchant/service.ts`:

> the module's own `__container__` cannot resolve other modules under module isolation

`createFulfillment` is handed DTOs, not an app container, so there is no second chance to pass one in. Confirmed while probing: the provider cannot even be resolved *from* the app container, because it lives inside the module's own container.

So `resolveAdapter()` tries the platform store, falls back to the env-built client, and **logs which path it took** — making the answer observable in prod rather than assumed. The `BLUE_DART_*` secrets stay wired as that fallback, documented as a fallback rather than the design. They can be deleted the day the store path is confirmed working.

Side benefit: credentials are no longer read in the constructor, so a credential rotated in the admin UI takes effect on the next call instead of the next deploy.

## SSM

`/jyt/prod/BLUE_DART_PROVIDER_ENABLED` created as a plain `String` (`"true"`) — it is not a secret. The five SecureString credentials from #1301 are referenced from both manifests here.

## Verify

```
pnpm check:prod-build                            -> ✓ passed
npx jest --testPathPattern="shipping-providers"  -> 22 suites / 253 tests
npx tsc --noEmit                                 -> 75 (baseline)
```

## After deploy

`GET /admin/fulfillment-providers` should show a 4th row, `bluedart_bluedart`, `enabled=true`. Then check the logs for `[bluedart] platform-store credentials unavailable` on the first real call — its presence tells us the env fallback is load-bearing; its absence means we can delete the five secrets.

🤖 Generated with [Claude Code](https://claude.com/claude-code)