### PR TITLE
feat(order-design): add View Design dropdown action to order design widget

### DIFF
--- a/apps/backend/src/admin/widgets/order-design.tsx
+++ b/apps/backend/src/admin/widgets/order-design.tsx
@@ -1,8 +1,10 @@
 import { defineWidgetConfig } from "@medusajs/admin-sdk"
 import { Container, Text, Badge, Heading, Button, Skeleton, toast } from "@medusajs/ui"
+import { PencilSquare } from "@medusajs/icons"
 import { DetailWidgetProps } from "@medusajs/framework/types"
 import { useQuery, useMutation, useQueryClient } from "@tanstack/react-query"
 import { sdk } from "../lib/config"
+import { ActionMenu } from "../components/common/action-menu"
 
 type DesignType = {
   id: string
@@ -78,13 +80,28 @@ const DesignCard = ({
       {design.estimated_cost != null && (
         <Text>Est. cost: ${design.estimated_cost}</Text>
       )}
-      <Button
-        size="small"
-        disabled={design.status === "Approved" || isPending}
-        onClick={() => approve(design.id)}
-      >
-        {design.status === "Approved" ? "Approved ✓" : "Approve Design"}
-      </Button>
+      <div className="flex items-center gap-x-2">
+        <Button
+          size="small"
+          disabled={design.status === "Approved" || isPending}
+          onClick={() => approve(design.id)}
+        >
+          {design.status === "Approved" ? "Approved ✓" : "Approve Design"}
+        </Button>
+        <ActionMenu
+          groups={[
+            {
+              actions: [
+                {
+                  label: "View Design",
+                  icon: <PencilSquare />,
+                  to: `/designs/${design.id}`,
+                },
+              ],
+            },
+          ]}
+        />
+      </div>
     </div>
   )
 }


### PR DESCRIPTION
## What & Why

The **Custom Designs** widget on the order detail page currently only shows an inline "Approve Design" button with no way to jump to the design itself. This adds an `ActionMenu` (the ⋯ dropdown) to each design card containing a **View Design** action that navigates to the admin design detail page (`/designs/:id`).

This matches the dropdown pattern already established in the `customer-designs` and `product-designs` widgets.

## Changes

- `apps/backend/src/admin/widgets/order-design.tsx`
  - Import `PencilSquare` icon and the reusable `ActionMenu` component.
  - Place an `ActionMenu` next to the existing "Approve Design" button; the menu contains a single "View Design" item linking to `/designs/${design.id}`.

## Screenshots

N/A — UI widget change. Each design card now shows: `[Approve Design]  ⋯ → View Design`.

## Testing

- `tsc --noEmit` — no new errors introduced (only pre-existing errors in unrelated `ad-planning`/`mastra` files remain).
- Manual: open an order with linked designs → "Custom Designs" widget → click ⋯ → "View Design" → lands on `/admin/designs/:id`.

## Checklist

- [x] Conventional commit message
- [x] No unrelated files included (excluded storefront-starter, docs/, opencode.json)
- [x] Builds on latest `main`
