### PR TITLE
feat(ops): order fulfillment-data cleanup + courier-changed email jobs (#1285)

### DIFF
--- a/apps/backend/src/api/admin/ops/maintenance-jobs/__tests__/clean-order-fulfillment-data.unit.spec.ts
+++ b/apps/backend/src/api/admin/ops/maintenance-jobs/__tests__/clean-order-fulfillment-data.unit.spec.ts
@@ -1,0 +1,111 @@
+import {
+  buildDataPatch,
+  refusedKeys,
+  targetProviderId,
+  PROTECTED_DATA_KEYS,
+} from "../clean-order-fulfillment-data-job"
+
+/**
+ * The whole point of this job is that it never relies on omission or `delete`.
+ * `updateFulfillment` MERGES `data`, so a key can only be cleared by WRITING
+ * null over it — #1293 lost a session to exactly that, with a passing unit test
+ * and stale prod data. These tests pin the null behaviour so the trap cannot
+ * quietly return.
+ */
+
+// Order 83's real shape: Blue Dart values merged on top of a Delhivery response.
+const ORDER_83_DATA = {
+  id: "delhivery-express",
+  mode: "Express",
+  name: "Delhivery Express",
+  carrier: "bluedart",
+  waybill: "21091376574",
+  upload_wbn: "UPL2285344091227112226",
+  packages: [{ client: "8e2306-JaalYantraTextilesPr-do", waybill: "41712510000092" }],
+  tracking_number: "21091376574",
+  pickup_location_name: "warehouse-AYV7GRDR",
+  cancelled_shipments: [{ awb: "41712510000092" }],
+}
+
+describe("buildDataPatch", () => {
+  it("writes NULL for cleared keys rather than omitting them", () => {
+    const patch = buildDataPatch(ORDER_83_DATA, ["id", "name", "mode"], {})
+    expect(patch).toEqual({ id: null, name: null, mode: null })
+    // The distinction that matters: the keys are PRESENT with a null value.
+    expect(Object.keys(patch)).toContain("name")
+    expect("name" in patch).toBe(true)
+  })
+
+  it("skips keys that are absent or already null, so the report is honest", () => {
+    const patch = buildDataPatch(
+      { a: 1, b: null },
+      ["a", "b", "never_existed"],
+      {}
+    )
+    expect(patch).toEqual({ a: null })
+  })
+
+  it("applies `set` values and skips ones already equal", () => {
+    const patch = buildDataPatch(
+      { name: "Delhivery Express", carrier: "bluedart" },
+      [],
+      { name: "Blue Dart Domestic Priority", carrier: "bluedart" }
+    )
+    expect(patch).toEqual({ name: "Blue Dart Domestic Priority" })
+  })
+
+  it("is idempotent — a second run over the patched result yields nothing", () => {
+    const keys = ["id", "name", "mode"]
+    const first = buildDataPatch(ORDER_83_DATA, keys, {})
+    const after = { ...ORDER_83_DATA, ...first }
+    expect(buildDataPatch(after, keys, {})).toEqual({})
+  })
+
+  it("tolerates a null/undefined data column", () => {
+    expect(buildDataPatch(null, ["a"], {})).toEqual({})
+    expect(buildDataPatch(undefined, [], { a: 1 })).toEqual({ a: 1 })
+  })
+})
+
+describe("refusedKeys", () => {
+  it("refuses keys carrying live shipment identity", () => {
+    expect(refusedKeys(["id", "waybill", "name"], false)).toEqual(["waybill"])
+  })
+
+  it("keeps cancelled_shipments protected — it is the audit trail", () => {
+    // It still holds the dead Delhivery AWB, which is correct as history.
+    expect(PROTECTED_DATA_KEYS).toContain("cancelled_shipments")
+    expect(refusedKeys(["cancelled_shipments"], false)).toEqual([
+      "cancelled_shipments",
+    ])
+  })
+
+  it("allows anything once force is set", () => {
+    expect(refusedKeys(["waybill", "carrier"], true)).toEqual([])
+  })
+})
+
+describe("targetProviderId", () => {
+  it("derives the provider id from data.carrier", () => {
+    expect(
+      targetProviderId({ provider_id: "delhivery_delhivery", data: { carrier: "bluedart" } })
+    ).toBe("bluedart_bluedart")
+  })
+
+  it("returns null when the attribution already matches", () => {
+    expect(
+      targetProviderId({ provider_id: "bluedart_bluedart", data: { carrier: "bluedart" } })
+    ).toBeNull()
+  })
+
+  it("returns null when no carrier is recorded — never guesses", () => {
+    expect(targetProviderId({ provider_id: "manual_manual", data: {} })).toBeNull()
+    expect(targetProviderId({ provider_id: "manual_manual" })).toBeNull()
+  })
+
+  it("normalises case and whitespace", () => {
+    expect(
+      targetProviderId({ provider_id: "x", data: { carrier: " BlueDart " } })
+    ).toBe("bluedart_bluedart")
+  })
+})

--- a/apps/backend/src/api/admin/ops/maintenance-jobs/clean-order-fulfillment-data-job.ts
+++ b/apps/backend/src/api/admin/ops/maintenance-jobs/clean-order-fulfillment-data-job.ts
@@ -1,0 +1,298 @@
+import {
+  ContainerRegistrationKeys,
+  MedusaError,
+  Modules,
+} from "@medusajs/framework/utils"
+import { z } from "@medusajs/framework/zod"
+
+import type {
+  MaintenanceChange,
+  MaintenanceJob,
+  MaintenanceJobResult,
+} from "./registry"
+
+/**
+ * #1285 — general-purpose repair for `fulfillment.data` (and provider attribution).
+ *
+ * WHY THIS EXISTS
+ * ---------------
+ * `fulfillment.data` is a free-form JSON column that every carrier adapter
+ * writes its own response into. When an order moves carrier mid-flight, the new
+ * carrier's values land ON TOP of the old carrier's — they do not replace them.
+ * Order 83 is the worked example: it carries a Blue Dart AWB, tracking URL and
+ * `provider_refs` sitting on a Delhivery manifest response, so `data.name` still
+ * reads "Delhivery Express" and `data.packages[0].client` is still a Delhivery
+ * account string.
+ *
+ * ⚠️ THE TRAP THIS TOOL EXISTS TO AVOID
+ * -------------------------------------
+ * `updateFulfillment` MERGES `data`. `delete`-ing a key is a SILENT NO-OP, and
+ * passing a "full replacement object" that simply omits a key leaves the old key
+ * in place — a green write that changed nothing. This cost a session in #1293,
+ * where a pure-function unit test passed for months while prod kept the stale
+ * refs. Medusa's own docs describe `data` as replaced wholesale; prod disagrees.
+ *
+ * **To clear a key you must WRITE `null` to it.** That is correct under BOTH
+ * semantics, so this job always does that and never relies on omission.
+ *
+ * WHAT IT DOES
+ * ------------
+ * Three independent operations, any combination, on one order or one fulfillment:
+ *
+ *   clear_keys      → write null over the named top-level `data` keys
+ *   set             → write explicit key/value pairs onto `data`
+ *   align_provider  → repoint `fulfillment.provider_id` at the provider that
+ *                     matches `data.carrier`
+ *
+ * `align_provider` is the one that is NOT cosmetic. Core routes cancellation on
+ * `provider_id`, so a fulfillment holding a Blue Dart AWB while attributed to
+ * `delhivery_delhivery` would ask the WRONG carrier to cancel it. The column is
+ * absent from `UpdateFulfillmentDTO` and is an FK to `fulfillment_provider`, so
+ * this verifies the target provider row EXISTS before writing and refuses
+ * otherwise — an FK violation mid-run is a worse outcome than a clear refusal.
+ *
+ * Dry-run (the default) previews every before→after without writing. Apply is
+ * idempotent: a second run finds the keys already null and reports no changes.
+ */
+
+/** Keys that carry live shipment identity — refused unless `force` is set. */
+export const PROTECTED_DATA_KEYS = [
+  "carrier",
+  "waybill",
+  "tracking_number",
+  "tracking_url",
+  "provider_refs",
+  "cancelled_shipments",
+]
+
+/** Hard cap on fulfillments touched in one call. */
+export const MAX_FULFILLMENTS = 200
+
+const paramsSchema = z
+  .object({
+    order_id: z.string().min(1).optional(),
+    fulfillment_id: z.string().min(1).optional(),
+    clear_keys: z.array(z.string().min(1)).optional().default([]),
+    set: z.record(z.string(), z.unknown()).optional().default({}),
+    align_provider: z.boolean().optional().default(false),
+    /** Permit clearing a PROTECTED_DATA_KEY. Deliberately explicit. */
+    force: z.boolean().optional().default(false),
+    limit: z.number().int().positive().max(MAX_FULFILLMENTS).optional().default(50),
+  })
+  .refine((v) => v.order_id || v.fulfillment_id, {
+    message: "Pass order_id or fulfillment_id",
+  })
+  .refine(
+    (v) => v.clear_keys.length > 0 || Object.keys(v.set).length > 0 || v.align_provider,
+    { message: "Nothing to do: pass clear_keys, set, or align_provider" }
+  )
+
+/**
+ * PURE: the `data` patch that clears `keys` and applies `set`.
+ *
+ * Only keys actually PRESENT and not already null are cleared, so the result is
+ * a faithful "what changed" record rather than a wall of no-op nulls. Exported
+ * for unit testing.
+ */
+export function buildDataPatch(
+  data: Record<string, unknown> | null | undefined,
+  keys: string[],
+  set: Record<string, unknown>
+): Record<string, unknown> {
+  const current = data ?? {}
+  const patch: Record<string, unknown> = {}
+  for (const k of keys) {
+    if (k in current && current[k] !== null) {
+      // NULL, not delete, and not omission — see the docblock.
+      patch[k] = null
+    }
+  }
+  for (const [k, v] of Object.entries(set)) {
+    if (current[k] !== v) patch[k] = v
+  }
+  return patch
+}
+
+/**
+ * PURE: which requested keys are protected and were not force-approved.
+ * Exported for unit testing.
+ */
+export function refusedKeys(keys: string[], force: boolean): string[] {
+  if (force) return []
+  return keys.filter((k) => PROTECTED_DATA_KEYS.includes(k))
+}
+
+/**
+ * PURE: the provider id a fulfillment SHOULD carry, given `data.carrier`.
+ * Medusa ids are `<provider>_<id>`, which for our carriers is the carrier
+ * doubled (`bluedart_bluedart`). Returns null when there is nothing to align —
+ * no carrier recorded, or it already matches. Exported for unit testing.
+ */
+export function targetProviderId(fulfillment: any): string | null {
+  const carrier = String(fulfillment?.data?.carrier ?? "").trim().toLowerCase()
+  if (!carrier) return null
+  const target = `${carrier}_${carrier}`
+  return fulfillment?.provider_id === target ? null : target
+}
+
+export const cleanOrderFulfillmentDataJob: MaintenanceJob = {
+  id: "clean-order-fulfillment-data",
+  label: "Clean stale carrier residue off order fulfillments (#1285)",
+  description:
+    "Repair fulfillment.data after a carrier switch. `updateFulfillment` MERGES data, so deleting a key is a silent no-op and omitting it from a 'full replacement' leaves it in place — this job always WRITES NULL, which works under both semantics. clear_keys nulls the named top-level keys; set writes explicit values; align_provider repoints provider_id at the provider matching data.carrier (not cosmetic — core routes cancellation on provider_id, so a mismatch asks the wrong carrier to cancel). Keys carrying live shipment identity (carrier, waybill, tracking_number, tracking_url, provider_refs, cancelled_shipments) are refused unless force=true. Dry-run previews every before→after; apply is idempotent.",
+  params: [
+    { name: "order_id", type: "string", required: false, description: "Repair every fulfillment on this order" },
+    { name: "fulfillment_id", type: "string", required: false, description: "Repair a single fulfillment (wins over order_id)" },
+    { name: "clear_keys", type: "string", required: false, description: "JSON array of top-level data keys to null out, e.g. [\"id\",\"name\",\"mode\"]" },
+    { name: "set", type: "string", required: false, description: "JSON object of data key/values to write, e.g. {\"name\":\"Blue Dart Domestic Priority\"}" },
+    { name: "align_provider", type: "boolean", required: false, description: "Repoint provider_id at the provider matching data.carrier (verifies the provider row exists first)" },
+    { name: "force", type: "boolean", required: false, description: "Permit clearing a protected key" },
+    { name: "limit", type: "number", required: false, description: `Max fulfillments in one call (default 50, max ${MAX_FULFILLMENTS})` },
+  ],
+  run: async (container, { dry_run, params }): Promise<MaintenanceJobResult> => {
+    const parsed = paramsSchema.safeParse(params)
+    if (!parsed.success) {
+      throw new MedusaError(
+        MedusaError.Types.INVALID_DATA,
+        parsed.error.issues.map((i) => i.message).join("; ")
+      )
+    }
+    const { order_id, fulfillment_id, clear_keys, set, align_provider, force, limit } =
+      parsed.data
+
+    const refused = refusedKeys(clear_keys, force)
+    if (refused.length) {
+      throw new MedusaError(
+        MedusaError.Types.NOT_ALLOWED,
+        `Refusing to clear protected key(s): ${refused.join(", ")}. These carry live shipment identity — pass force=true only if you are certain.`
+      )
+    }
+
+    const query: any = container.resolve(ContainerRegistrationKeys.QUERY)
+    const fulfillmentModule: any = container.resolve(Modules.FULFILLMENT)
+    const logger: any = container.resolve(ContainerRegistrationKeys.LOGGER)
+
+    // --- load the target fulfillments ---------------------------------------
+    let fulfillments: any[] = []
+    if (fulfillment_id) {
+      const { data } = await query.graph({
+        entity: "fulfillment",
+        filters: { id: fulfillment_id },
+        fields: ["id", "provider_id", "data", "canceled_at"],
+      })
+      fulfillments = data ?? []
+    } else {
+      const { data } = await query.graph({
+        entity: "order",
+        filters: { id: order_id },
+        fields: [
+          "id",
+          "display_id",
+          "fulfillments.id",
+          "fulfillments.provider_id",
+          "fulfillments.data",
+          "fulfillments.canceled_at",
+        ],
+      })
+      fulfillments = (data?.[0]?.fulfillments ?? []).slice(0, limit)
+    }
+
+    if (!fulfillments.length) {
+      throw new MedusaError(
+        MedusaError.Types.NOT_FOUND,
+        `No fulfillments found for ${fulfillment_id ?? order_id}`
+      )
+    }
+
+    // --- provider existence check (FK safety) --------------------------------
+    let knownProviderIds: Set<string> | null = null
+    if (align_provider) {
+      const providers = await fulfillmentModule.listFulfillmentProviders(
+        {},
+        { take: 200 }
+      )
+      knownProviderIds = new Set((providers ?? []).map((p: any) => p.id))
+    }
+
+    const changes: MaintenanceChange[] = []
+    const errors: Array<{ id: string; message: string }> = []
+
+    for (const f of fulfillments) {
+      const patch = buildDataPatch(f.data, clear_keys, set)
+      let nextProviderId: string | null = null
+
+      if (align_provider) {
+        const target = targetProviderId(f)
+        if (target && !knownProviderIds!.has(target)) {
+          // Do NOT attempt the write — an FK violation would abort the run and
+          // is far less useful than naming the missing provider.
+          errors.push({
+            id: f.id,
+            message: `Cannot align provider: '${target}' is not a registered fulfillment provider. Register it (and deploy) before aligning.`,
+          })
+        } else if (target) {
+          nextProviderId = target
+        }
+      }
+
+      if (!Object.keys(patch).length && !nextProviderId) continue
+
+      for (const [k, v] of Object.entries(patch)) {
+        changes.push({
+          entity: "fulfillment.data",
+          id: f.id,
+          field: k,
+          before: (f.data ?? {})[k],
+          after: v,
+        })
+      }
+      if (nextProviderId) {
+        changes.push({
+          entity: "fulfillment",
+          id: f.id,
+          field: "provider_id",
+          before: f.provider_id,
+          after: nextProviderId,
+        })
+      }
+
+      if (dry_run) continue
+
+      try {
+        if (Object.keys(patch).length) {
+          // Merge semantics: this patch is applied ON TOP of existing data, and
+          // the nulls in it are what actually clear the stale keys.
+          await fulfillmentModule.updateFulfillment(f.id, { data: patch })
+        }
+        if (nextProviderId) {
+          // `provider_id` is absent from UpdateFulfillmentDTO, but updateFulfillment_
+          // spreads `data` straight into the underlying update — the same
+          // deliberate, load-bearing cast used by backfill-open-order-requires-shipping.
+          await fulfillmentModule.updateFulfillment(f.id, {
+            provider_id: nextProviderId,
+          } as any)
+        }
+        logger?.info?.(
+          `[clean-order-fulfillment-data] repaired ${f.id} (${Object.keys(patch).join(", ") || "provider only"}${nextProviderId ? ` → ${nextProviderId}` : ""})`
+        )
+      } catch (e: any) {
+        errors.push({ id: f.id, message: e?.message ?? String(e) })
+      }
+    }
+
+    const dataChanges = changes.filter((c) => c.entity === "fulfillment.data").length
+    const providerChanges = changes.filter((c) => c.field === "provider_id").length
+    const applied = !dry_run && changes.length > 0 && errors.length === 0
+
+    return {
+      job_id: "clean-order-fulfillment-data",
+      dry_run,
+      applied,
+      summary: changes.length
+        ? `${dry_run ? "Would repair" : "Repaired"} ${dataChanges} data key(s) and ${providerChanges} provider attribution(s) across ${fulfillments.length} fulfillment(s)${errors.length ? `; ${errors.length} error(s)` : ""}`
+        : `Nothing to repair across ${fulfillments.length} fulfillment(s)`,
+      changes,
+      ...(errors.length ? { errors } : {}),
+    }
+  },
+}

--- a/apps/backend/src/api/admin/ops/maintenance-jobs/registry.ts
+++ b/apps/backend/src/api/admin/ops/maintenance-jobs/registry.ts
@@ -105,6 +105,8 @@ import { backfillDesignSizeSetsJob } from "./backfill-design-size-sets-job"
 import { backfillPartnerShippingOptionsJob } from "./backfill-partner-shipping-options-job"
 import { repairShippingOptionStoreVisibilityJob } from "./repair-shipping-option-store-visibility-job"
 import { backfillOpenOrderRequiresShippingJob } from "./backfill-open-order-requires-shipping-job"
+import { cleanOrderFulfillmentDataJob } from "./clean-order-fulfillment-data-job"
+import { sendCourierChangedEmailJob } from "./send-courier-changed-email-job"
 import { backfillProductShippingProfilesJob } from "./backfill-product-shipping-profiles-job"
 import { normalizeArtisanProductsJob } from "./normalize-artisan-products-job"
 import { linkArtisanDetailRowsJob } from "./link-artisan-detail-rows-job"
@@ -5723,6 +5725,8 @@ export const seedGoodsTransferTaskTemplateJob: MaintenanceJob = {
 }
 
 export const MAINTENANCE_JOBS: MaintenanceJob[] = [
+  cleanOrderFulfillmentDataJob,
+  sendCourierChangedEmailJob,
   recalculateDesignCostJob,
   recalculateDesignCostBulkJob,
   correctProductionRunCostJob,

--- a/apps/backend/src/api/admin/ops/maintenance-jobs/send-courier-changed-email-job.ts
+++ b/apps/backend/src/api/admin/ops/maintenance-jobs/send-courier-changed-email-job.ts
@@ -1,0 +1,158 @@
+import {
+  ContainerRegistrationKeys,
+  MedusaError,
+} from "@medusajs/framework/utils"
+import { z } from "@medusajs/framework/zod"
+
+import { notifyCustomerOfCarrierChange } from "../../../../workflows/orders/cancel-shipment"
+
+import type {
+  MaintenanceChange,
+  MaintenanceJob,
+  MaintenanceJobResult,
+} from "./registry"
+
+/**
+ * #1285 — (re)send the "your courier changed" email for an order.
+ *
+ * WHY A JOB
+ * ---------
+ * The email is sent by `cancel-shipment`, and it is BEST-EFFORT by design: the
+ * waybill is already cancelled at the carrier by the time it runs, so failing
+ * the whole operation because the template row is missing would report "cancel
+ * failed" for a cancel that definitively succeeded. The consequence is that a
+ * cancel can succeed while the customer is never told — which is exactly what
+ * happened to order 83, whose courier changed from Delhivery to Blue Dart on
+ * 2026-08-14 with no email sent. There was no way to send it afterwards short
+ * of cancelling something else.
+ *
+ * This job is that missing path. It reuses `notifyCustomerOfCarrierChange`
+ * rather than re-rendering the template, so it inherits the deliberate decision
+ * NOT to leak the operator's free-text reason — that text is an internal audit
+ * trail and can name partners, costs or blame. The customer gets the fact and
+ * the promise.
+ *
+ * ⚠️ SENDING IS NOT REVERSIBLE. Dry-run (the default) resolves the order and
+ * reports exactly who would be emailed, without sending. Nothing is written to
+ * the order either way — this job only sends.
+ */
+
+const paramsSchema = z.object({
+  order_id: z.string().min(1),
+  /**
+   * The carrier being moved AWAY from, named in the email. Optional: the
+   * template copes with an empty value, and guessing it wrong is worse than
+   * omitting it.
+   */
+  previous_carrier: z.string().min(1).optional(),
+})
+
+export const sendCourierChangedEmailJob: MaintenanceJob = {
+  id: "send-courier-changed-email",
+  label: "Send the courier-changed email for an order (#1285)",
+  description:
+    "(Re)send the 'your courier changed' email to an order's customer. cancel-shipment sends this best-effort — it deliberately never fails a cancel over a missing template — so a courier switch can complete with the customer never told, and until now there was no way to send it afterwards. Reuses the same renderer as cancel-shipment, so the operator's internal reason is never leaked to the customer. Dry-run reports the recipient without sending; SENDING IS NOT REVERSIBLE.",
+  params: [
+    {
+      name: "order_id",
+      type: "string",
+      required: true,
+      description: "Order whose customer should be emailed",
+    },
+    {
+      name: "previous_carrier",
+      type: "string",
+      required: false,
+      description:
+        "Carrier being moved away from, named in the email (e.g. 'delhivery'). Omitted rather than guessed if unknown.",
+    },
+  ],
+  run: async (container, { dry_run, params }): Promise<MaintenanceJobResult> => {
+    const parsed = paramsSchema.safeParse(params)
+    if (!parsed.success) {
+      throw new MedusaError(
+        MedusaError.Types.INVALID_DATA,
+        parsed.error.issues.map((i) => i.message).join("; ")
+      )
+    }
+    const { order_id, previous_carrier } = parsed.data
+
+    const query: any = container.resolve(ContainerRegistrationKeys.QUERY)
+    const { data } = await query.graph({
+      entity: "order",
+      filters: { id: order_id },
+      fields: [
+        "id",
+        "display_id",
+        "email",
+        "customer.email",
+        "customer.first_name",
+        "customer.last_name",
+        "shipping_address.first_name",
+        "shipping_address.last_name",
+      ],
+    })
+
+    const order = data?.[0]
+    if (!order) {
+      throw new MedusaError(MedusaError.Types.NOT_FOUND, `Order ${order_id} not found`)
+    }
+
+    const to = order.email || order.customer?.email
+    if (!to) {
+      throw new MedusaError(
+        MedusaError.Types.INVALID_DATA,
+        `Order ${order_id} has no email address — nobody to notify`
+      )
+    }
+
+    const changes: MaintenanceChange[] = [
+      {
+        entity: "email",
+        id: order.id,
+        field: "order-courier-changed",
+        before: "not sent",
+        after: `would send to ${to}`,
+      },
+    ]
+
+    if (dry_run) {
+      return {
+        job_id: "send-courier-changed-email",
+        dry_run,
+        applied: false,
+        summary: `Would email the courier change for order #${order.display_id ?? order.id} to ${to}${previous_carrier ? ` (previous carrier: ${previous_carrier})` : ""}`,
+        changes,
+      }
+    }
+
+    const sent = await notifyCustomerOfCarrierChange(container, {
+      order,
+      carrier: previous_carrier,
+    })
+
+    if (!sent) {
+      // notifyCustomerOfCarrierChange swallows its own failure by design and
+      // logs the reason. Surface it as an error rather than reporting a send
+      // that did not happen.
+      return {
+        job_id: "send-courier-changed-email",
+        dry_run,
+        applied: false,
+        summary: `Could not send the courier-changed email for order #${order.display_id ?? order.id} — see the [cancel-shipment] warning in the logs for the reason`,
+        changes: [],
+        errors: [{ id: order.id, message: "notifyCustomerOfCarrierChange returned false" }],
+      }
+    }
+
+    return {
+      job_id: "send-courier-changed-email",
+      dry_run,
+      applied: true,
+      summary: `Emailed the courier change for order #${order.display_id ?? order.id} to ${to}`,
+      changes: [
+        { ...changes[0], after: `sent to ${to}` },
+      ],
+    }
+  },
+}

--- a/apps/backend/src/workflows/orders/cancel-shipment.ts
+++ b/apps/backend/src/workflows/orders/cancel-shipment.ts
@@ -361,7 +361,7 @@ export const CARRIER_CHANGED_TEMPLATE_KEY = "order-courier-changed"
  * definitively succeeded — the worst possible lie to tell an operator who now
  * has to decide whether to retry.
  */
-async function notifyCustomerOfCarrierChange(
+export async function notifyCustomerOfCarrierChange(
   container: MedusaContainer,
   args: { order: any; carrier?: string; reason?: string }
 ): Promise<boolean> {


### PR DESCRIPTION
Two maintenance jobs. Both generic; order 83 is just the first caller.

## `clean-order-fulfillment-data`

`fulfillment.data` is a free-form JSON column every carrier adapter writes its own response into. When an order changes carrier mid-flight, the new carrier's values land **on top of** the old one's. Order 83 is the worked example — a Blue Dart AWB, tracking URL and `provider_refs` sitting on a Delhivery manifest response, so `data.name` still reads `"Delhivery Express"` and `data.packages[0].client` is still a Delhivery account string.

> ⚠️ **The trap this exists to avoid.** `updateFulfillment` **merges** `data`. `delete` on a key is a **silent no-op**, and passing a "full replacement object" that omits a key leaves the old key in place — a green write that changed nothing. That cost a session in #1293, where a pure-function unit test passed for months while prod kept the stale refs. Medusa's docs describe `data` as replaced wholesale; **prod disagrees, and order 83 is the evidence.**

So the job **always writes `null`**, which is correct under either semantics. Three independent operations, any combination:

| Param | Effect |
|---|---|
| `clear_keys` | write `null` over the named top-level keys |
| `set` | write explicit key/values |
| `align_provider` | repoint `provider_id` at the provider matching `data.carrier` |

**`align_provider` is not cosmetic.** Core routes cancellation on `provider_id`, so a fulfillment holding a Blue Dart AWB while attributed to `delhivery_delhivery` would ask the **wrong carrier** to cancel it. `provider_id` is an FK, so the job verifies the target provider row exists and **refuses by name** otherwise — an FK violation mid-run is worse than a clear refusal.

Keys carrying live shipment identity (`carrier`, `waybill`, `tracking_number`, `tracking_url`, `provider_refs`, `cancelled_shipments`) are refused unless `force=true`. `cancelled_shipments` is protected deliberately — it's the audit trail and still holds the dead Delhivery AWB, which is correct as history.

## `send-courier-changed-email`

The `order-courier-changed` email is sent by `cancel-shipment` and is **best-effort by design**: the waybill is already cancelled by the time it runs, so failing the operation over a missing template would report "cancel failed" for a cancel that definitively succeeded. The consequence is that a cancel can succeed while the customer is never told — which is what happened to order 83 on 2026-08-14, with no way to send it afterwards short of cancelling something else. This job is that missing path.

It reuses `notifyCustomerOfCarrierChange` (now exported) rather than re-rendering, so it inherits the deliberate choice **not** to leak the operator's free-text reason — that text is an internal audit trail and can name partners, costs or blame.

⚠️ **Sending is not reversible.** Dry-run reports the recipient without sending.

Checked live: **`order-courier-changed` IS seeded in prod**, so the template was never the blocker.

## Verify

```
pnpm check:prod-build                                        -> ✓ passed
npx jest --testPathPattern="clean-order-fulfillment-data"    -> 12 tests
pnpm test:integration:http:shared ops-maintenance-jobs.spec  -> 42 tests
npx tsc --noEmit                                             -> 75 (baseline)
```

## Planned use on order 83 (after Monday's collection)

```
clean-order-fulfillment-data  order_id=order_01KYPCSTQ783ZT1FKM72VHQABS
  clear_keys=["id","name","mode","upload_wbn","packages","package_count",
              "cod_count","cod_amount","cash_pickups","cash_pickups_count",
              "pickups_count","prepaid_count","replacement_count",
              "pickup_location_name"]
  align_provider=true
send-courier-changed-email    order_id=...  previous_carrier=delhivery
```

`align_provider` will refuse until `bluedart_bluedart` is registered — #1302 is merged, so it lands with that deploy.

🤖 Generated with [Claude Code](https://claude.com/claude-code)