### PR TITLE
feat(billing): record externally-booked freight with FX conversion (#1285)

### DIFF
--- a/apps/backend/src/api/admin/orders/[id]/external-awb/route.ts
+++ b/apps/backend/src/api/admin/orders/[id]/external-awb/route.ts
@@ -33,6 +33,20 @@ const Body = z.object({
   mark_shipped: z.boolean().optional(),
   /** Why this was booked outside the system. Kept in the audit trail. */
   notes: z.string().trim().max(500).optional(),
+  /**
+   * What the waybill cost. Omit when unknown — a blank must not read as free,
+   * so absence leaves the freight ledger untouched while 0 records free
+   * shipping. Negative is rejected: a refund is a reversal, not a charge.
+   */
+  shipping_amount: z.number().nonnegative().optional(),
+  /** Currency of `shipping_amount`; defaults to the order's currency. */
+  shipping_currency_code: z.string().trim().length(3).optional(),
+  /**
+   * The FX rate actually paid, when the charge is in another currency. Beats
+   * the cached market rate, which is the fallback — only the rate you were
+   * billed at reconciles against a bank statement.
+   */
+  shipping_fx_rate: z.number().positive().optional(),
 })
 
 /** The logged-in admin's email, recorded on the attachment. */
@@ -67,6 +81,9 @@ export const POST = async (req: MedusaRequest, res: MedusaResponse) => {
     markShipped: body.mark_shipped === true,
     notes: body.notes,
     actingEmail: await resolveActorEmail(req),
+    shippingAmount: body.shipping_amount,
+    shippingCurrencyCode: body.shipping_currency_code,
+    shippingFxRate: body.shipping_fx_rate,
   })
 
   res.status(200).json({ external_awb: result })

--- a/apps/backend/src/modules/partner_billing/__tests__/describe-fee.unit.spec.ts
+++ b/apps/backend/src/modules/partner_billing/__tests__/describe-fee.unit.spec.ts
@@ -285,6 +285,8 @@ describe("describeFee (#623)", () => {
         awb: "77712345678",
         reversed_at: "2026-08-14T06:00:00.000Z",
         reason: "pickup no-show",
+        // Pre-FX reversal: nothing was converted, so there is no rate to carry.
+        fx: null,
       })
       // 1000 − 100 commission, and nothing for the reversed freight.
       expect(d.net_payout).toBe(900)
@@ -344,6 +346,7 @@ describe("describeFee (#623)", () => {
         awb: null,
         reversed_at: null,
         reason: null,
+        fx: null,
       })
       expect(d.shipping_reversals[1].amount).toBe(0)
     })

--- a/apps/backend/src/modules/partner_billing/__tests__/shipping-ledger.unit.spec.ts
+++ b/apps/backend/src/modules/partner_billing/__tests__/shipping-ledger.unit.spec.ts
@@ -1,5 +1,6 @@
 import {
   planShippingChargeUpsert,
+  planShippingFxConversion,
   planShippingReversal,
   readShippingCharges,
   readShippingReversals,
@@ -53,6 +54,9 @@ describe("readShippingCharges — legacy rows", () => {
         carrier: "bluedart",
         awb: null,
         recorded_at: null,
+        // A pre-ledger row predates FX: the column holds whatever the carrier
+        // quoted, with no rate recorded anywhere to reconstruct.
+        fx: null,
       },
     ])
   })
@@ -87,6 +91,7 @@ describe("readShippingCharges — legacy rows", () => {
       carrier: null,
       awb: null,
       recorded_at: null,
+      fx: null,
     })
     expect(lines[1].amount).toBe(0)
   })
@@ -323,5 +328,187 @@ describe("planShippingReversal", () => {
     )!
     expect(planned.reversal.awb).toBe("LEDGER1")
     expect(planned.reversal.reason).toBeNull()
+  })
+})
+
+describe("planShippingFxConversion (#1305)", () => {
+  const AT_FX = "2026-08-15T07:00:00.000Z"
+  const convert = (over: Record<string, any> = {}) =>
+    planShippingFxConversion({
+      amount: 11767,
+      currency_code: "INR",
+      orderCurrency: "usd",
+      rate: 0.01048,
+      source: "fx_rates",
+      convertedAt: AT_FX,
+      ...over,
+    })
+
+  it("converts into the order currency and keeps the original for the invoice", () => {
+    // Order 79: a DTDC counter booking billed in INR against a USD order.
+    expect(convert()).toEqual({
+      amount: 123.32,
+      currency_code: "USD",
+      fx: {
+        original_amount: 11767,
+        original_currency_code: "INR",
+        fx_rate: 0.01048,
+        fx_source: "fx_rates",
+        converted_at: AT_FX,
+      },
+    })
+  })
+
+  it("rounds to the minor unit — a payout must match an invoice", () => {
+    // Left at full precision this is 123.31816, and no statement ever agrees.
+    expect(convert()!.amount).toBe(123.32)
+  })
+
+  it("returns null for a same-currency charge rather than stamping rate 1", () => {
+    // There is nothing to convert; an fx record would claim a conversion that
+    // never happened and invite someone to 'correct' the rate later.
+    expect(convert({ currency_code: "USD", orderCurrency: "usd" })).toBeNull()
+  })
+
+  it("REFUSES a rate that is missing, zero, negative or not finite", () => {
+    // Each returns null = "record it unconverted", which is the pre-FX
+    // behaviour: shown in its own currency, never deducted. A bad rate must
+    // never produce a wrong deduction.
+    for (const rate of [null, undefined, 0, -1, NaN, Infinity]) {
+      expect(convert({ rate })).toBeNull()
+    }
+  })
+
+  it("returns null when either currency is missing", () => {
+    expect(convert({ orderCurrency: null })).toBeNull()
+    expect(convert({ currency_code: "" })).toBeNull()
+  })
+
+  it("marks an operator-supplied rate as such — only it matches a statement", () => {
+    const r = convert({ rate: 0.0112, source: "operator" })!
+    expect(r.fx.fx_source).toBe("operator")
+    expect(r.amount).toBe(131.79)
+  })
+})
+
+describe("the FX ledger round trip (#1305)", () => {
+  const AT_FX = "2026-08-15T07:00:00.000Z"
+  const converted = planShippingFxConversion({
+    amount: 11767,
+    currency_code: "INR",
+    orderCurrency: "usd",
+    rate: 0.01048,
+    source: "fx_rates",
+    convertedAt: AT_FX,
+  })!
+
+  // Order 79 exactly: a legacy scalar-only row holding the ABANDONED
+  // Shiprocket charge, on a USD order.
+  const legacyRow = {
+    id: "pfee_79",
+    currency_code: "usd",
+    shipping_amount: 6944,
+    shipping_currency_code: "INR",
+    shipping_carrier: "shiprocket",
+    metadata: { kind: "retail" },
+  }
+
+  it("a converted charge becomes DEDUCTIBLE — the whole point of #1305", () => {
+    const update = planShippingChargeUpsert(legacyRow, {
+      fulfillment_id: "ful_79",
+      amount: converted.amount,
+      currency_code: converted.currency_code,
+      carrier: "dtdc",
+      awb: "N40878729",
+      recorded_at: AT_FX,
+      fx: converted.fx,
+    })!
+    // Before: an INR charge on a USD order rolled up to null and never reached
+    // the payout. After: it is USD, so it does.
+    expect(update.shipping_amount).toBe(123.32)
+    expect(update.shipping_currency_code).toBe("USD")
+    expect(update.shipping_carrier).toBe("dtdc")
+  })
+
+  it("REPLACES the abandoned carrier's charge instead of stacking on it", () => {
+    // The legacy line is claimed, not appended to — otherwise order 79 would be
+    // billed for both the cancelled Shiprocket booking and the DTDC one.
+    const update = planShippingChargeUpsert(legacyRow, {
+      fulfillment_id: "ful_79",
+      amount: converted.amount,
+      currency_code: converted.currency_code,
+      carrier: "dtdc",
+      awb: "N40878729",
+      recorded_at: AT_FX,
+      fx: converted.fx,
+    })!
+    expect(update.metadata.shipping_charges).toHaveLength(1)
+    expect(update.metadata.shipping_charges[0].carrier).toBe("dtdc")
+    expect(update.metadata.shipping_charges[0].fx.original_amount).toBe(11767)
+  })
+
+  it("survives the read back — the rate is not lost in the jsonb", () => {
+    const update = planShippingChargeUpsert(legacyRow, {
+      fulfillment_id: "ful_79",
+      amount: converted.amount,
+      currency_code: converted.currency_code,
+      carrier: "dtdc",
+      awb: "N40878729",
+      recorded_at: AT_FX,
+      fx: converted.fx,
+    })!
+    const [line] = readShippingCharges({ ...legacyRow, ...update } as any)
+    expect(line.fx).toEqual(converted.fx)
+  })
+
+  it("drops a PARTIAL fx record rather than patching it with defaults", () => {
+    // A rate of 0 or a missing original would misstate what a partner was
+    // charged. Absent fx is already a correct state; a wrong rate is not.
+    const [line] = readShippingCharges({
+      id: "pfee_1",
+      currency_code: "usd",
+      metadata: {
+        shipping_charges: [
+          {
+            fulfillment_id: "ful_1",
+            amount: 100,
+            currency_code: "USD",
+            fx: { original_amount: 9000, fx_rate: 0 },
+          },
+        ],
+      },
+    })
+    expect(line.fx).toBeNull()
+    expect(line.amount).toBe(100)
+  })
+
+  it("carries the rate onto the reversal so a credit note can be matched", () => {
+    const row = {
+      id: "pfee_79",
+      currency_code: "usd",
+      metadata: {
+        shipping_charges: [
+          {
+            fulfillment_id: "ful_79",
+            amount: converted.amount,
+            currency_code: "USD",
+            carrier: "dtdc",
+            awb: "N40878729",
+            recorded_at: AT_FX,
+            fx: converted.fx,
+          },
+        ],
+      },
+    }
+    const planned = planShippingReversal(row, {
+      fulfillment_id: "ful_79",
+      awb: "N40878729",
+      reason: "returned to origin",
+      reversed_at: AT_FX,
+    })!
+    // The payout gave back USD 123.32, but DTDC will credit INR 11,767.
+    expect(planned.reversal.amount).toBe(123.32)
+    expect(planned.reversal.fx!.original_amount).toBe(11767)
+    expect(planned.update.shipping_amount).toBeNull()
   })
 })

--- a/apps/backend/src/modules/partner_billing/describe-fee.ts
+++ b/apps/backend/src/modules/partner_billing/describe-fee.ts
@@ -13,7 +13,11 @@
 
 // `shipping-ledger` is itself pure and dependency-free, so importing it here
 // keeps this file's "trivially unit-testable" contract intact.
-import { readShippingCharges, readShippingReversals } from "./shipping-ledger"
+import {
+  readShippingCharges,
+  readShippingReversals,
+  type ShippingFxRecord,
+} from "./shipping-ledger"
 
 export type PartnerFeeBasis = "percentage" | "flat"
 
@@ -103,8 +107,17 @@ export type ShippingChargeLine = {
   currency_code: string
   carrier: string | null
   awb: string | null
-  /** True when quoted outside the order currency — shown, never deducted. */
+  /**
+   * True when quoted outside the order currency — shown, never deducted.
+   *
+   * A CONVERTED line is false here: it was quoted in the carrier's currency but
+   * is stored in the order's, and is deducted like any other. `fx` is what says
+   * a conversion happened, so a UI can render "₹11,767 @ 0.01048 = $123.32"
+   * rather than a bare converted number nobody can tie to an invoice.
+   */
   is_foreign_currency: boolean
+  /** The conversion, when this line was converted. Null when it was not. */
+  fx: ShippingFxRecord | null
 }
 
 /** A retired platform-shipping charge, shown for continuity, never deducted. */
@@ -116,6 +129,8 @@ export type ReversedShippingCharge = {
   awb: string | null
   reversed_at: string | null
   reason: string | null
+  /** The conversion behind `amount`, so a credit note can still be matched. */
+  fx: ShippingFxRecord | null
 }
 
 /** Platform-shipping deduction, when the partner used our carrier account. */
@@ -210,6 +225,7 @@ export function describeFee(
     carrier: c.carrier,
     awb: c.awb,
     is_foreign_currency: c.currency_code !== reference,
+    fx: c.fx,
   }))
   const deductibleLines = shipping_charges.filter((c) => !c.is_foreign_currency)
 
@@ -253,6 +269,7 @@ export function describeFee(
     awb: r?.awb || null,
     reversed_at: r?.reversed_at || null,
     reason: r?.reason || null,
+    fx: (r?.fx as ShippingFxRecord) || null,
   }))
 
   // Only deduct what is actually collected. A foreign-currency carrier charge

--- a/apps/backend/src/modules/partner_billing/shipping-ledger.ts
+++ b/apps/backend/src/modules/partner_billing/shipping-ledger.ts
@@ -21,6 +21,32 @@
  * Pure and dependency-free so the whole ledger is unit-testable without a DB.
  */
 
+/**
+ * What a converted freight charge remembers about the conversion.
+ *
+ * A charge quoted in the carrier's currency is stored CONVERTED — `amount` and
+ * `currency_code` are the ORDER's — because that is what makes it deductible
+ * without every reader having to know about FX. That would be lossy on its own:
+ * the carrier's invoice is in the original currency, and reconciling it against
+ * a converted number is impossible unless the rate is kept. So the original is
+ * kept alongside, and a payout can always be reconstructed from the row.
+ *
+ * `source` distinguishes a rate an operator actually paid from a market rate we
+ * looked up — they differ, sometimes by several percent, and only the first
+ * matches a bank statement.
+ */
+export type ShippingFxRecord = {
+  /** Amount as the carrier billed it, before conversion. */
+  original_amount: number
+  /** Currency the carrier billed in. */
+  original_currency_code: string
+  /** Multiplier applied: `amount = original_amount * fx_rate`. */
+  fx_rate: number
+  /** `operator` = supplied by a human; `fx_rates` = the cached market rate. */
+  fx_source: "operator" | "fx_rates"
+  converted_at: string
+}
+
 /** One live freight charge, for one fulfillment. */
 export type ShippingChargeLine = {
   /** The fulfillment whose label booked it. Null on a pre-ledger legacy row. */
@@ -31,6 +57,12 @@ export type ShippingChargeLine = {
   /** The waybill, so a carrier invoice line can be matched to it. */
   awb: string | null
   recorded_at: string | null
+  /**
+   * Present only when this line was converted. Absent means `amount` is exactly
+   * what the carrier charged — which is every line written before FX existed,
+   * and every line whose carrier already quoted in the order's currency.
+   */
+  fx: ShippingFxRecord | null
 }
 
 /** A charge that was deducted and has since been given back. */
@@ -43,6 +75,12 @@ export type ShippingReversal = {
   reversed_at: string
   reason: string | null
   reversed_by: string | null
+  /**
+   * Carried over from the charge being reversed, so a credit note in the
+   * carrier's own currency can still be matched after the line is gone. `amount`
+   * above is the converted figure that actually came off the payout.
+   */
+  fx?: ShippingFxRecord | null
 }
 
 /**
@@ -68,6 +106,35 @@ const toNum = (v: unknown): number => {
 }
 
 const upper = (v: unknown): string => String(v || "").toUpperCase()
+
+/**
+ * Read an FX record off a stored line, defensively — `metadata` is free-form
+ * jsonb written by past and future versions of this code.
+ *
+ * A partial record is treated as ABSENT rather than patched with defaults. An
+ * `fx_rate` of 0 or a missing original amount would silently misstate what a
+ * partner was charged, and a line with no FX record is already a correct,
+ * meaningful state ("this was never converted"). Failing back to it loses only
+ * the audit trail; inventing a rate loses the money.
+ */
+function readFx(raw: any): ShippingFxRecord | null {
+  if (!raw || typeof raw !== "object") {
+    return null
+  }
+  const rate = Number(raw.fx_rate)
+  const originalAmount = Number(raw.original_amount)
+  const originalCurrency = upper(raw.original_currency_code)
+  if (!Number.isFinite(rate) || rate <= 0) return null
+  if (!Number.isFinite(originalAmount)) return null
+  if (!originalCurrency) return null
+  return {
+    original_amount: originalAmount,
+    original_currency_code: originalCurrency,
+    fx_rate: rate,
+    fx_source: raw.fx_source === "operator" ? "operator" : "fx_rates",
+    converted_at: String(raw.converted_at || ""),
+  }
+}
 
 /** Existing reversals, defensively — `metadata` is free-form jsonb. */
 export function readShippingReversals(
@@ -103,6 +170,7 @@ export function readShippingCharges(
       carrier: c?.carrier || null,
       awb: c?.awb || null,
       recorded_at: c?.recorded_at || null,
+      fx: readFx(c?.fx),
     }))
   }
   if (fee.shipping_amount === null || fee.shipping_amount === undefined) {
@@ -116,6 +184,9 @@ export function readShippingCharges(
       carrier: fee.shipping_carrier || null,
       awb: null,
       recorded_at: null,
+      // A legacy scalar row predates FX entirely: the column holds whatever the
+      // carrier quoted, in whatever currency, with no rate recorded anywhere.
+      fx: null,
     },
   ]
 }
@@ -178,6 +249,61 @@ export type ShippingChargeInput = {
   carrier: string | null
   awb?: string | null
   recorded_at: string
+  /**
+   * Set by the caller when `amount`/`currency_code` are already the CONVERTED,
+   * order-currency figures. Resolving a rate needs the fx_rates module, which
+   * this pure planner (and the module service that calls it) cannot reach under
+   * module isolation — so conversion happens at the container edge and arrives
+   * here as a finished fact. See `resolveShippingFx`.
+   */
+  fx?: ShippingFxRecord | null
+}
+
+/**
+ * Convert a carrier's quote into the order's currency.
+ *
+ * Pure, and deliberately refuses more often than it succeeds: a rate that is
+ * absent, zero, negative or not finite yields `null`, which the callers treat as
+ * "leave the charge in its own currency" — the pre-FX behaviour, where the line
+ * is displayed but never deducted. That is the safe direction. A bad rate does
+ * not produce a wrong deduction; it produces no deduction, which is visible in
+ * the UI as a foreign-currency line and gets asked about.
+ *
+ * Same-currency input returns `null` too: there is nothing to convert and
+ * stamping an `fx_rate: 1` record would imply a conversion that never happened.
+ */
+export function planShippingFxConversion(input: {
+  amount: number
+  currency_code: string
+  orderCurrency: string | null | undefined
+  rate: number | null | undefined
+  source: "operator" | "fx_rates"
+  convertedAt: string
+}): { amount: number; currency_code: string; fx: ShippingFxRecord } | null {
+  const from = upper(input.currency_code)
+  const to = upper(input.orderCurrency)
+  if (!from || !to || from === to) {
+    return null
+  }
+  const rate = Number(input.rate)
+  if (!Number.isFinite(rate) || rate <= 0) {
+    return null
+  }
+  const original = toNum(input.amount)
+  // Money, so round to the minor unit. Left at full precision the payout picks
+  // up a fraction of a cent that no invoice will ever agree with.
+  const converted = Math.round(original * rate * 100) / 100
+  return {
+    amount: converted,
+    currency_code: to,
+    fx: {
+      original_amount: original,
+      original_currency_code: from,
+      fx_rate: rate,
+      fx_source: input.source,
+      converted_at: input.convertedAt,
+    },
+  }
 }
 
 /**
@@ -207,6 +333,7 @@ export function planShippingChargeUpsert(
     carrier: charge.carrier || null,
     awb: charge.awb || null,
     recorded_at: charge.recorded_at,
+    fx: readFx(charge.fx),
   }
 
   const claimsLegacyLine =
@@ -295,6 +422,7 @@ export function planShippingReversal(
     reversed_at: event.reversed_at,
     reason: event.reason || null,
     reversed_by: event.reversed_by || null,
+    fx: removed.fx,
   }
 
   return {

--- a/apps/backend/src/workflows/orders/__tests__/build-attach-awb-labels.unit.spec.ts
+++ b/apps/backend/src/workflows/orders/__tests__/build-attach-awb-labels.unit.spec.ts
@@ -21,11 +21,34 @@ describe("buildAttachAwbLabels (#1195)", () => {
     ).toEqual([{ id: "fulab_1" }, label])
   })
 
-  it("is idempotent — re-attaching the same AWB adds nothing", () => {
+  it("re-attaching the same AWB adds no ROW — it corrects the one there", () => {
+    // #1305: re-supplying an AWB is how a tracking or label URL that arrived
+    // late gets recorded. Returning a bare `{id}` kept the old (usually empty)
+    // URLs while the caller saw a 200 and `data.tracking_url` updated — so the
+    // label row and `data` disagreed permanently. Order 79 is the proof.
     expect(
       buildAttachAwbLabels(
         [{ id: "fulab_1", tracking_number: "AWB123" }],
         label
+      )
+    ).toEqual([
+      { id: "fulab_1", tracking_url: "https://shiprocket.co/tracking/AWB123" },
+    ])
+  })
+
+  it("never blanks a URL it already has with one the caller doesn't", () => {
+    // An operator attaching an AWB they have no label PDF for must not destroy
+    // the PDF link someone else recorded.
+    expect(
+      buildAttachAwbLabels(
+        [
+          {
+            id: "fulab_1",
+            tracking_number: "AWB123",
+            label_url: "https://cdn/label.pdf",
+          },
+        ],
+        { ...label, tracking_url: "", label_url: "" }
       )
     ).toEqual([{ id: "fulab_1" }])
   })

--- a/apps/backend/src/workflows/orders/external-awb.ts
+++ b/apps/backend/src/workflows/orders/external-awb.ts
@@ -6,6 +6,9 @@ import {
 import type { MedusaContainer } from "@medusajs/framework/types"
 import { createOrderShipmentWorkflow } from "@medusajs/medusa/core-flows"
 import { buildAttachAwbLabels } from "./shiprocket-attach-awb"
+import { resolveShippingFx } from "./shipping-fx"
+import { PARTNER_BILLING_MODULE } from "../../modules/partner_billing"
+import type { ShippingFxRecord } from "../../modules/partner_billing/shipping-ledger"
 
 /**
  * Attach (and detach) a waybill we did NOT book — the manual override.
@@ -139,6 +142,26 @@ export type AttachExternalAwbInput = {
   markShipped?: boolean
   notes?: string
   actingEmail?: string
+  /**
+   * What this waybill cost, when the operator knows it.
+   *
+   * Unique to this path: every integrated carrier returns a rate with the label
+   * (`provider_refs.courier_rate`), so freight records itself. A counter booking
+   * has a receipt and no API, and until #1305 there was nowhere to put it — the
+   * order kept whatever the ABANDONED booking had cost, which is how order 79
+   * came to carry a ₹6,944 Shiprocket charge for a parcel that went DTDC.
+   *
+   * Omitted leaves the ledger untouched. Attaching a waybill and knowing its
+   * price are separate facts, and a blank field must not read as "free".
+   */
+  shippingAmount?: number | null
+  /** Currency of `shippingAmount`. Defaults to the order's when omitted. */
+  shippingCurrencyCode?: string | null
+  /**
+   * The FX rate actually paid, when it differs from the market rate. Only used
+   * if the charge currency differs from the order's. See `resolveShippingFx`.
+   */
+  shippingFxRate?: number | null
 }
 
 export type AttachExternalAwbResult = {
@@ -147,6 +170,18 @@ export type AttachExternalAwbResult = {
   awb: string
   attached_at: string
   marked_shipped: boolean
+  /**
+   * What was written to the freight ledger, or null when no cost was supplied
+   * or there was no partner fee row to hang it off. Returned rather than
+   * swallowed so an operator can see the CONVERTED figure that will actually
+   * come off the payout — which is the number they will be asked about, and is
+   * not the one they typed.
+   */
+  shipping_charge: {
+    amount: number
+    currency_code: string
+    fx: ShippingFxRecord | null
+  } | null
 }
 
 export async function attachExternalAwb(
@@ -270,6 +305,17 @@ export async function attachExternalAwb(
     }
   }
 
+  const shippingCharge = await recordExternalFreight(container, {
+    orderId: input.orderId,
+    fulfillmentId: input.fulfillmentId,
+    carrier,
+    awb,
+    amount: input.shippingAmount,
+    currencyCode: input.shippingCurrencyCode,
+    operatorRate: input.shippingFxRate,
+    recordedAt: attachedAt,
+  })
+
   logger?.info?.(
     `[external-awb] attached ${carrier} ${awb} to fulfillment ${input.fulfillmentId} (order ${input.orderId})${
       input.notes ? `: ${input.notes}` : ""
@@ -282,6 +328,93 @@ export async function attachExternalAwb(
     awb,
     attached_at: attachedAt,
     marked_shipped: markedShipped,
+    shipping_charge: shippingCharge,
+  }
+}
+
+/**
+ * Write an externally-booked parcel's freight onto the partner fee ledger.
+ *
+ * Best-effort by design, mirroring the integrated carriers' own recording step:
+ * the waybill IS attached by the time this runs, and failing the whole attach
+ * because a billing row could not be updated would send an operator back to
+ * re-attach a parcel that is already correct.
+ *
+ * Returns what was recorded — CONVERTED, if the carrier billed in a currency
+ * other than the order's — or null when there was no cost to record or no fee
+ * row to record it against.
+ */
+async function recordExternalFreight(
+  container: MedusaContainer,
+  args: {
+    orderId: string
+    fulfillmentId: string
+    carrier: string
+    awb: string
+    amount?: number | null
+    currencyCode?: string | null
+    operatorRate?: number | null
+    recordedAt: string
+  }
+): Promise<AttachExternalAwbResult["shipping_charge"]> {
+  const logger: any = container.resolve(ContainerRegistrationKeys.LOGGER)
+  const amount = Number(args.amount)
+  // Absent means "cost unknown", which is not the same as free. A recorded 0 IS
+  // a real charge and passes here, matching the rule the ledger already applies.
+  if (args.amount === null || args.amount === undefined || !Number.isFinite(amount)) {
+    return null
+  }
+
+  try {
+    const billing: any = container.resolve(PARTNER_BILLING_MODULE)
+    const fee = await billing.findFeeForOrder(args.orderId)
+    if (!fee) {
+      // Retail order with no partner, or accrual hasn't run. Nothing to hang the
+      // cost off, and inventing a fee row is not this path's business.
+      logger?.info?.(
+        `[external-awb] no partner fee row for order ${args.orderId}; freight of ${amount} not recorded.`
+      )
+      return null
+    }
+
+    const orderCurrency = String(fee.currency_code || "").toUpperCase()
+    const charged = String(args.currencyCode || orderCurrency).toUpperCase()
+
+    const converted = await resolveShippingFx(container, {
+      amount,
+      currency_code: charged,
+      orderCurrency,
+      operatorRate: args.operatorRate,
+      now: args.recordedAt,
+    })
+
+    await billing.recordShippingChargeForOrder(args.orderId, {
+      fulfillment_id: args.fulfillmentId,
+      amount: converted ? converted.amount : amount,
+      currency_code: converted ? converted.currency_code : charged,
+      carrier: args.carrier,
+      awb: args.awb,
+      recorded_at: args.recordedAt,
+      fx: converted?.fx ?? null,
+    })
+
+    logger?.info?.(
+      `[external-awb] recorded freight for order ${args.orderId}: ${amount} ${charged}` +
+        (converted
+          ? ` -> ${converted.amount} ${converted.currency_code} @ ${converted.fx.fx_rate} (${converted.fx.fx_source})`
+          : "")
+    )
+
+    return {
+      amount: converted ? converted.amount : amount,
+      currency_code: converted ? converted.currency_code : charged,
+      fx: converted?.fx ?? null,
+    }
+  } catch (e: any) {
+    logger?.warn?.(
+      `[external-awb] could not record freight for order ${args.orderId}: ${e?.message}. The AWB IS attached.`
+    )
+    return null
   }
 }
 

--- a/apps/backend/src/workflows/orders/shipping-fx.ts
+++ b/apps/backend/src/workflows/orders/shipping-fx.ts
@@ -1,0 +1,106 @@
+import { ContainerRegistrationKeys } from "@medusajs/framework/utils"
+import type { MedusaContainer } from "@medusajs/framework/types"
+import {
+  planShippingFxConversion,
+  type ShippingFxRecord,
+} from "../../modules/partner_billing/shipping-ledger"
+import { FX_RATES_MODULE } from "../../modules/fx_rates"
+import type FxRatesService from "../../modules/fx_rates/service"
+
+/**
+ * Convert a carrier's freight quote into the order's currency, at the container
+ * edge.
+ *
+ * This lives in `workflows/`, not in `partner_billing`, for a reason that is
+ * structural rather than stylistic: under module isolation a module's service
+ * gets the MODULE container and cannot resolve another module, so
+ * `PartnerBillingService` can never reach `fx_rates`. (Same constraint that
+ * forces Blue Dart's credentials to exist in two places — see #1285.) Anything
+ * needing both must be composed one level up, where the full container is in
+ * hand. So the rate is resolved here and handed to the ledger as a finished
+ * fact, and `planShippingFxConversion` stays pure and unit-testable.
+ *
+ * ## Why a foreign charge was excluded before this
+ *
+ * `rollUpShippingScalars` and `describeFee` both drop charges quoted outside the
+ * order currency, with the same comment: converting there would mean inventing
+ * an FX rate a pure function has no business choosing. That was right. This does
+ * not change the rule — it supplies the rate from outside, records it, and lets
+ * the existing rule find the line already in the right currency.
+ *
+ * ## Failure is not an error
+ *
+ * Every failure path returns `null`, meaning "record the charge unconverted".
+ * That is exactly today's behaviour: the line shows in the UI in its own
+ * currency and is not deducted. A missing rate must never block attaching a
+ * waybill — the parcel has shipped either way, and an operator who cannot record
+ * a shipment because an FX cache is cold will record it somewhere we cannot see.
+ */
+export type ResolveShippingFxInput = {
+  amount: number
+  currency_code: string
+  /** The order's currency — the target. */
+  orderCurrency: string | null | undefined
+  /**
+   * A rate the operator supplied, e.g. what their bank actually billed. Always
+   * preferred over the cached market rate: only this one reconciles against a
+   * statement. `fx_rates` is the fallback, not the authority.
+   */
+  operatorRate?: number | null
+  /** Injected so callers control the clock (and tests don't need to freeze it). */
+  now?: string
+}
+
+export type ResolvedShippingFx = {
+  amount: number
+  currency_code: string
+  fx: ShippingFxRecord
+} | null
+
+export async function resolveShippingFx(
+  container: MedusaContainer,
+  input: ResolveShippingFxInput
+): Promise<ResolvedShippingFx> {
+  const logger: any = container.resolve(ContainerRegistrationKeys.LOGGER)
+  const from = String(input.currency_code || "").toUpperCase()
+  const to = String(input.orderCurrency || "").toUpperCase()
+  const convertedAt = input.now || new Date().toISOString()
+
+  if (!from || !to || from === to) {
+    return null
+  }
+
+  // An operator-supplied rate short-circuits the lookup entirely. It is the
+  // rate that was actually paid; a market rate fetched a day later is not.
+  const operatorRate = Number(input.operatorRate)
+  if (Number.isFinite(operatorRate) && operatorRate > 0) {
+    return planShippingFxConversion({
+      amount: input.amount,
+      currency_code: from,
+      orderCurrency: to,
+      rate: operatorRate,
+      source: "operator",
+      convertedAt,
+    })
+  }
+
+  try {
+    const fx = container.resolve(FX_RATES_MODULE) as FxRatesService
+    const rate = await fx.getRate(from, to)
+    return planShippingFxConversion({
+      amount: input.amount,
+      currency_code: from,
+      orderCurrency: to,
+      rate,
+      source: "fx_rates",
+      convertedAt,
+    })
+  } catch (e: any) {
+    // `getRate` throws NOT_FOUND when the cache has no path between the two
+    // currencies — a cold cache, or a currency the provider doesn't quote.
+    logger?.warn?.(
+      `[shipping-fx] no ${from}->${to} rate (${e?.message}); recording the charge unconverted, so it will show in ${from} and not be deducted.`
+    )
+    return null
+  }
+}

--- a/apps/backend/src/workflows/orders/shiprocket-attach-awb.ts
+++ b/apps/backend/src/workflows/orders/shiprocket-attach-awb.ts
@@ -76,12 +76,33 @@ export function deriveFulfillmentState(
 export function buildAttachAwbLabels(
   existingLabels: any[] | undefined,
   label: { tracking_number: string; tracking_url: string; label_url: string }
-): Array<{ id: string } | typeof label> {
+): Array<
+  { id: string; tracking_url?: string; label_url?: string } | typeof label
+> {
   const existing = existingLabels ?? []
+  const match = existing.find(
+    (l: any) => l?.tracking_number === label.tracking_number
+  )
   const carried = existing
     .filter((l: any) => !!l?.id)
-    .map((l: any) => ({ id: l.id as string }))
-  if (existing.some((l: any) => l?.tracking_number === label.tracking_number)) {
+    .map((l: any) =>
+      // Re-supplying the SAME AWB is a correction, not a duplicate: the tracking
+      // or label URL arrived later, or was wrong. Merging them onto the existing
+      // row is what makes that possible — returning a bare `{id}` (as this did
+      // until #1305) silently kept the old, usually empty, URLs while the caller
+      // saw a 200 and `data.tracking_url` updated, so the two disagreed forever.
+      //
+      // Only non-empty values overwrite. A caller attaching an AWB it has no
+      // label URL for must not blank one that is already there.
+      l.id === (match as any)?.id
+        ? {
+            id: l.id as string,
+            ...(label.tracking_url ? { tracking_url: label.tracking_url } : {}),
+            ...(label.label_url ? { label_url: label.label_url } : {}),
+          }
+        : { id: l.id as string }
+    )
+  if (match) {
     return carried
   }
   return [...carried, label]


### PR DESCRIPTION
Closes the gap order 79 exposed: an externally-attached waybill had nowhere to record what it cost, and even once recorded it would never have reached the payout.

## Why

Every integrated carrier returns a rate with the label, so freight records itself (`provider_refs.courier_rate`). A counter booking has a receipt and no API. Order 79's Shiprocket booking was cancelled after three failed pickups and rebooked with DTDC — and the fee row kept the **₹6,944 charge for a parcel that never moved on that carrier**.

Recording it alone would not have been enough. `rollUpShippingScalars` and `describeFee` both **drop** a charge quoted outside the order currency, with the same reasoning: converting there would mean inventing an FX rate a pure function has no business choosing. That reasoning is correct and is unchanged here. But order 79 is a **USD order with INR freight**, so the DTDC charge would have been stored, displayed, and silently never deducted.

## What

The rate is supplied from **outside** the pure layer, and recorded.

| | |
|---|---|
| `planShippingFxConversion` | Pure. Converts into the order currency, keeps `original_amount` / `original_currency_code` / `fx_rate` / `fx_source` / `converted_at` on the line. |
| `resolveShippingFx` | Resolves the rate at the **container edge**, in `workflows/`. |
| `POST /admin/orders/:id/external-awb` | New optional `shipping_amount`, `shipping_currency_code`, `shipping_fx_rate`. |

**Storing the converted figure** is what lets every existing reader stay unchanged — the line simply arrives already in the reference currency, so `describeFee`'s existing rule finds it deductible. **Storing the original** is what lets a carrier invoice still be reconciled against it.

`resolveShippingFx` lives in `workflows/`, not in `partner_billing`, for a structural reason: under module isolation a module service gets the *module* container and cannot resolve another module, so `PartnerBillingService` can never reach `fx_rates`. Same constraint that forces Blue Dart's credentials to exist in two places (#1285).

An **operator-supplied rate beats the cached market rate**. Only the rate you were actually billed at reconciles against a bank statement; `fx_rates` is the fallback, not the authority. `fx_source` records which was used.

## Failure is not an error

Every FX failure path — no rate cached, zero, negative, non-finite, same-currency — returns `null`, meaning *record it unconverted*: shown in its own currency, not deducted. That is exactly the pre-change behaviour, so:

- a bad rate produces **no** deduction rather than a **wrong** one, and it shows in the UI as a foreign-currency line that gets asked about;
- a cold FX cache can never block attaching a waybill. The parcel has shipped either way, and an operator who cannot record a shipment will record it somewhere we cannot see.

A **partial** stored `fx` record is dropped rather than patched with defaults, for the same reason.

## Also fixed

`buildAttachAwbLabels` returned a bare `{id}` for an AWB it had already written. Re-supplying the same AWB is how a late-arriving tracking or label URL gets recorded — so the label row kept its old (usually empty) URLs while the caller saw a 200 and `data.tracking_url` updated. **The two disagreed permanently.** Order 79 reproduced it exactly today. Non-empty values now merge onto the existing row; a caller with no URL cannot blank one already there.

## Scope

Deliberately **new writes only**. No retroactive re-rating of historical foreign-currency lines — those keep today's behaviour until asked for, so no already-paid payout moves silently. Order 79 will be corrected explicitly after deploy.

## Verify

```
npx tsc --noEmit        -> 75 (baseline; none in changed files)
pnpm test:unit          -> 4 suites / 5 tests red (baseline, unchanged); ledger+label suites 111 passed
pnpm check:prod-build   -> passed
```

⚠️ Adds no new env vars or SSM parameters, so the tagging trap does not apply.

🤖 Generated with [Claude Code](https://claude.com/claude-code)