### PR TITLE
feat(inventory-orders): show raw_material thumbnails in order-lines grid and item details modal

### DIFF
--- a/apps/backend/src/admin/components/creates/inventory-order-lines-grid.tsx
+++ b/apps/backend/src/admin/components/creates/inventory-order-lines-grid.tsx
@@ -9,6 +9,8 @@ import { Eye, Trash } from "@medusajs/icons";
 import { Combobox } from "../inputs/combobox/combobox";
 import { InventoryItem, RawMaterial } from "../../hooks/api/raw-materials";
 import { MaterialItemModal } from "../inventory-orders/material-item-modal";
+import { ThumbnailPreview } from "../common/thumbnail-preview";
+import { firstMediaUrl } from "../../lib/utils/first-media-url";
 
 type PickerOption = { label: string; value: string; keywords?: string; disabled?: boolean };
 
@@ -268,6 +270,31 @@ export const InventoryOrderLinesGrid = <T extends { id: string; title?: string; 
 
   const columns: ColumnDef<InventoryOrderLine>[] = [
     columnHelper.column({
+      id: "image",
+      name: "Image",
+      header: "Image",
+      cell: (context: any) => {
+        const inventoryItemId =
+          lineAt(context.row.index)?.inventory_item_id || ""
+        const inventoryItem = inventoryItemId
+          ? inventoryItemMap.get(inventoryItemId) || null
+          : null
+        const photo =
+          firstMediaUrl(inventoryItem?.raw_materials?.media) ||
+          inventoryItem?.thumbnail ||
+          undefined
+        return (
+          <div className="flex h-full items-center justify-center px-2">
+            <ThumbnailPreview
+              src={photo}
+              alt={inventoryItem?.title || "Item"}
+              size="small"
+            />
+          </div>
+        )
+      },
+    }),
+    columnHelper.column({
       id: "item",
       name: "Item",
       header: "Item",
@@ -438,6 +465,9 @@ export const InventoryOrderLinesGrid = <T extends { id: string; title?: string; 
   // Increase widths for a more comfortable layout
   const sizedColumns: ColumnDef<InventoryOrderLine>[] = useMemo(() => {
     return columns.map((col) => {
+      if (col.id === "image") {
+        return { ...col, size: 72, maxSize: 96 }
+      }
       if (col.id === "item") {
         return { ...col, size: 480, maxSize: 720 }
       }

--- a/apps/backend/src/admin/components/inventory-orders/material-item-modal.tsx
+++ b/apps/backend/src/admin/components/inventory-orders/material-item-modal.tsx
@@ -3,6 +3,8 @@ import { Badge, Button, FocusModal, Text } from "@medusajs/ui"
 import { InventoryItem, RawMaterial } from "../../hooks/api/raw-materials"
 import { StackedFocusModal } from "../modal/stacked-modal/stacked-focused-modal"
 import { StackedModalContext } from "../modal/stacked-modal/stacked-modal-context"
+import { ThumbnailPreview } from "../common/thumbnail-preview"
+import { firstMediaUrl } from "../../lib/utils/first-media-url"
 
 type MaterialItem = (InventoryItem & { raw_materials?: RawMaterial | null }) | null
 
@@ -26,32 +28,56 @@ const InfoRow = ({
 const Divider = () => <div className="border-t border-ui-border-base" />
 
 /** Shared header + body content, reused by the stacked modal and the fallback. */
-const MaterialItemHeaderContent = ({ item }: { item: MaterialItem }) => (
-  <div className="flex flex-col gap-1">
-    <Text size="small" className="text-ui-fg-subtle uppercase">
-      Inventory Item
-    </Text>
-    <div className="flex flex-wrap items-center gap-2">
-      <FocusModal.Title asChild>
-        <Text weight="plus" size="large">
-          {item?.title || "Untitled item"}
-        </Text>
-      </FocusModal.Title>
-      {item?.sku && (
-        <Badge size="small" color="grey">
-          SKU: {item.sku}
-        </Badge>
-      )}
+const MaterialItemHeaderContent = ({ item }: { item: MaterialItem }) => {
+  const photo =
+    firstMediaUrl(item?.raw_materials?.media) || item?.thumbnail || undefined
+  return (
+    <div className="flex flex-col gap-1">
+      <Text size="small" className="text-ui-fg-subtle uppercase">
+        Inventory Item
+      </Text>
+      <div className="flex flex-wrap items-center gap-3">
+        {photo && (
+          <ThumbnailPreview
+            src={photo}
+            alt={item?.title || "Item"}
+            size="small"
+          />
+        )}
+        <div className="flex flex-wrap items-center gap-2">
+          <FocusModal.Title asChild>
+            <Text weight="plus" size="large">
+              {item?.title || "Untitled item"}
+            </Text>
+          </FocusModal.Title>
+          {item?.sku && (
+            <Badge size="small" color="grey">
+              SKU: {item.sku}
+            </Badge>
+          )}
+        </div>
+      </div>
     </div>
-  </div>
-)
+  )
+}
 
 const MaterialItemBodyContent = ({ item }: { item: MaterialItem }) => {
   if (!item) {
     return null
   }
+  const heroPhoto =
+    firstMediaUrl(item.raw_materials?.media) || item.thumbnail || undefined
   return (
     <div className="flex flex-col gap-6">
+      {heroPhoto && (
+        <div className="flex justify-center">
+          <ThumbnailPreview
+            src={heroPhoto}
+            alt={item.title || "Item"}
+            size="large"
+          />
+        </div>
+      )}
       <div className="flex flex-col gap-3">
         <Text size="small" className="text-ui-fg-subtle">
           {item.description || "No description provided."}
@@ -76,6 +102,44 @@ const MaterialItemBodyContent = ({ item }: { item: MaterialItem }) => {
         <div className="flex flex-col gap-3">
           <Divider />
           <Text weight="plus">Raw Material</Text>
+          {(() => {
+            const media = item.raw_materials?.media
+            const files: string[] = []
+            if (media && Array.isArray((media as { files?: unknown }).files)) {
+              for (const entry of (media as { files: unknown[] }).files) {
+                const url =
+                  typeof entry === "string" ? entry : firstMediaUrl(entry)
+                if (url) {
+                  files.push(url)
+                }
+              }
+            } else {
+              const url = firstMediaUrl(media)
+              if (url) {
+                files.push(url)
+              }
+            }
+            if (files.length > 0) {
+              return (
+                <div className="flex flex-col gap-2">
+                  <Text size="small" className="text-ui-fg-subtle">
+                    Media
+                  </Text>
+                  <div className="flex flex-wrap gap-2">
+                    {files.map((url, index) => (
+                      <ThumbnailPreview
+                        key={index}
+                        src={url}
+                        alt={`${item.raw_materials?.name ?? "Raw material"} media ${index + 1}`}
+                        size="large"
+                      />
+                    ))}
+                  </div>
+                </div>
+              )
+            }
+            return null
+          })()}
           <div className="grid gap-4 sm:grid-cols-2 lg:grid-cols-3">
             <InfoRow label="Name" value={item.raw_materials.name} />
             <InfoRow label="Color" value={item.raw_materials.color} />


### PR DESCRIPTION
## What

The `orders/inventory/create` order-lines grid and the **View item details** modal previously showed no images. This PR adds raw-material thumbnails using the existing `ThumbnailPreview` / `firstMediaUrl` patterns already used in the design inventory picker and the inventory-raw-material widget.

## Changes

### Data grid — `inventory-order-lines-grid.tsx`
- New **Image** column at the start of the grid renders a `ThumbnailPreview` per row.
- Source: `firstMediaUrl(raw_materials?.media)` with fallback to `inventoryItem.thumbnail`.
- Clicking the thumbnail expands the full-size image (uses `StackedFocusModal` automatically inside the `RouteFocusModal`).
- Column sized at 72px.

### View item details modal — `material-item-modal.tsx`
- **Header**: small thumbnail next to the item title.
- **Body hero**: large centered thumbnail at the top of the modal body.
- **Media gallery**: Raw Material section now iterates `raw_materials.media.files` and renders each as a large clickable `ThumbnailPreview`.

## Testing
- Frontend build completed successfully.
- No TypeScript errors in the changed files (`tsc --noEmit --project apps/backend/tsconfig.json` clean for both files).
- Pre-existing backend build errors in `src/mastra/` are unrelated.