### PR TITLE
feat(mcp): per-credential scopes for the admin MCP surface (#1306)

### DIFF
--- a/apps/backend/medusa-config.prod.ts
+++ b/apps/backend/medusa-config.prod.ts
@@ -594,6 +594,9 @@ module.exports = defineConfig({
     resolve: "./src/modules/ai_usage",
   },
   {
+    resolve: "./src/modules/mcp_access",
+  },
+  {
     resolve: "./src/modules/fx_rates",
   },
   {

--- a/apps/backend/medusa-config.ts
+++ b/apps/backend/medusa-config.ts
@@ -208,6 +208,9 @@ module.exports = defineConfig({
       resolve: "./src/modules/ai_usage",
     },
     {
+      resolve: "./src/modules/mcp_access",
+    },
+    {
       resolve: "./src/modules/unified_order_status",
     },
     {

--- a/apps/backend/src/api/admin/assistant/chat/route.ts
+++ b/apps/backend/src/api/admin/assistant/chat/route.ts
@@ -45,10 +45,10 @@ import {
   type AdminMcpContext,
 } from "../../mcp/lib/dispatch"
 import {
-  isAdminWriteEnabled,
-  isAdminDangerousEnabled,
   resolveAdminBaseUrl,
+  resolveAdminMcpScope,
 } from "../../mcp/lib/handler"
+import { mcpScopeToContextFlags } from "../../../../lib/mcp-scope"
 import { makeMcpLedgerSink } from "../../../../lib/mcp-ledger"
 import type { AdminAssistantChatReq } from "./validators"
 
@@ -217,13 +217,20 @@ export const POST = async (
 
   // Loopback context — forward the admin's auth so wrapped routes authenticate
   // as the admin user. Writes/dangerous still require confirmation (+ reason)
-  // via the shared dispatcher; the write/dangerous flags gate visibility.
+  // via the shared dispatcher; the scope flags gate visibility.
+  //
+  // The level is min(process ceiling, this principal's mcp_access_scope row),
+  // resolved exactly as the JSON-RPC endpoint does (#1306 Track C) — the two
+  // tool surfaces must not disagree about what a credential may reach. In
+  // practice this is the process ceiling, since the assistant is driven by a
+  // human admin and scope rows are written for machine credentials.
+  const { level: scopeLevel } = await resolveAdminMcpScope(req)
+  const scopeFlags = mcpScopeToContextFlags(scopeLevel)
   const ctx: AdminMcpContext = {
     baseUrl: resolveAdminBaseUrl(req),
     bearer: req.get("authorization") || undefined,
     cookie: req.get("cookie") || undefined,
-    enableWrite: isAdminWriteEnabled(),
-    enableDangerous: isAdminDangerousEnabled(),
+    ...scopeFlags,
     surface: "admin",
     observe: makeMcpLedgerSink(req.scope, {
       id: (req as any).auth_context?.actor_id ?? null,
@@ -232,13 +239,16 @@ export const POST = async (
   }
   const writeEnabled = ctx.enableWrite !== false
   const dangerousEnabled = ctx.enableDangerous === true
+  const sensitiveEnabled = ctx.enableSensitive !== false
 
   // Bind the registry as AI-SDK tools. One source of truth (JSON Schema) feeds
   // both this binding and the MCP endpoint's tools/list. Disabled tiers are
   // hidden from the model entirely (and refused at dispatch as a backstop).
   const enabled = ADMIN_MCP_TOOLS.filter(
     (def) =>
-      (writeEnabled || !def.write) && (dangerousEnabled || !isDangerous(def))
+      (writeEnabled || !def.write) &&
+      (dangerousEnabled || !isDangerous(def)) &&
+      (sensitiveEnabled || !isSensitive(def))
   )
 
   const tools: Record<string, any> = Object.fromEntries(

--- a/apps/backend/src/api/admin/mcp/lib/__tests__/scope-invariants.unit.spec.ts
+++ b/apps/backend/src/api/admin/mcp/lib/__tests__/scope-invariants.unit.spec.ts
@@ -1,0 +1,70 @@
+/**
+ * Invariants tying the registry to the HTTP scope guard (#1306 Track C).
+ *
+ * The guard in `src/api/middlewares.ts` classifies a request by HTTP VERB; the
+ * registry classifies a tool by its `write` flag. Where the two disagree — a
+ * POST route that only reads — a read-only credential would see the tool in
+ * `tools/list` and then get a 403 when calling it. That drift is invisible until
+ * someone actually holds a read-only token, so it is asserted here instead.
+ */
+import { ADMIN_MCP_TOOLS } from "../registry"
+import { MCP_SCOPE_EXEMPT_ADMIN_PATHS } from "../../../../../lib/mcp-scope"
+import { isSensitive } from "../../../../../lib/mcp-core"
+
+describe("registry vs the admin write guard", () => {
+  it("every non-GET tool is either flagged `write` or exempted by path", () => {
+    const offenders = ADMIN_MCP_TOOLS.filter((t) => {
+      if (t.native) return false // natives never touch HTTP
+      const method = t.method ?? "GET"
+      if (method === "GET") return false
+      if (t.write) return false
+      return !MCP_SCOPE_EXEMPT_ADMIN_PATHS.includes(t.path ?? "")
+    }).map((t) => `${t.name} (${t.method} ${t.path})`)
+
+    expect(offenders).toEqual([])
+  })
+
+  it("keeps the transport itself exempt", () => {
+    // Every MCP tool call is a POST /admin/mcp, reads included. If this entry
+    // ever goes away, a read-only token cannot call the MCP endpoint at all.
+    expect(MCP_SCOPE_EXEMPT_ADMIN_PATHS).toContain("/admin/mcp")
+  })
+
+  it("exempts no path that a write tool actually uses", () => {
+    // The exemption is a hole in the guard, so nothing that mutates may sit
+    // behind it.
+    const writePaths = new Set(
+      ADMIN_MCP_TOOLS.filter((t) => t.write).map((t) => t.path)
+    )
+    for (const path of MCP_SCOPE_EXEMPT_ADMIN_PATHS) {
+      expect(writePaths.has(path)).toBe(false)
+    }
+  })
+})
+
+describe("what a `write`-scoped credential can reach", () => {
+  it("excludes every DELETE, because DELETE is implicitly sensitive", () => {
+    const deletes = ADMIN_MCP_TOOLS.filter((t) => t.method === "DELETE")
+    expect(deletes.length).toBeGreaterThan(0)
+    for (const t of deletes) {
+      expect(isSensitive(t)).toBe(true)
+    }
+  })
+
+  it("reaches NOTHING a read-scoped one cannot — every admin write is sensitive", () => {
+    // A characterization test, not a requirement. Of 69 write tools, 59 are
+    // explicitly `sensitive: true` and the other 10 are DELETEs (implicitly
+    // sensitive), so the `write` rung of the ladder is currently EMPTY on this
+    // surface: scoping a third-party token to `write` grants it exactly what
+    // `read` grants, and every real mutation needs `sensitive`.
+    //
+    // That is invisible from the ladder itself and it decides what a
+    // third-party token is worth, so it is pinned here. When a genuinely
+    // non-sensitive write tool lands, this test fails — delete it then, and
+    // the `write` rung starts meaning something.
+    const plainWrites = ADMIN_MCP_TOOLS.filter(
+      (t) => t.write && !isSensitive(t)
+    ).map((t) => t.name)
+    expect(plainWrites).toEqual([])
+  })
+})

--- a/apps/backend/src/api/admin/mcp/lib/handler.ts
+++ b/apps/backend/src/api/admin/mcp/lib/handler.ts
@@ -6,11 +6,19 @@
  * admin-scoped server (auth captured from the request) and hand Medusa's
  * already-parsed JSON-RPC body to the stateless Streamable-HTTP transport.
  *
- * Two env flags gate the write surface:
+ * Two env flags set the process-wide CEILING for the write surface:
  *   - ADMIN_MCP_ENABLE_WRITE      (default true)  — write tools (non-GET).
  *   - ADMIN_MCP_ENABLE_DANGEROUS  (default false) — platform-destructive tools.
- * Tier 1 is read-only, so neither flag affects it yet; they are wired now so
- * later tiers land safe-by-default.
+ *
+ * The ceiling is then narrowed per credential by an `mcp_access_scope` row
+ * (#1306 Track C), which is what makes a read-only token possible. No row means
+ * the ceiling, i.e. the behaviour that existed before scopes. The intersection
+ * only ever restricts — see `src/lib/mcp-scope.ts`.
+ *
+ * ⚠️ Scope enforced HERE governs the tool surface only. A secret API key also
+ * authenticates plain `/admin/*` routes, so the same scope is enforced again by
+ * the admin write guard in `src/api/middlewares.ts` — without that, a read-only
+ * scope would be bypassable by calling the wrapped route directly.
  */
 import { MedusaRequest, MedusaResponse } from "@medusajs/framework/http"
 import { Server } from "@modelcontextprotocol/sdk/server/index.js"
@@ -23,6 +31,15 @@ import {
   envFlagDefaultFalse,
 } from "../../../../lib/mcp-core"
 import { makeMcpLedgerSink } from "../../../../lib/mcp-ledger"
+import { isDangerous, isSensitive } from "../../../../lib/mcp-core"
+import {
+  MCP_SCOPE_LEVELS,
+  mcpCeilingLevel,
+  mcpScopeToContextFlags,
+  resolveMcpScope,
+  type McpScopeLevel,
+  type ResolvedMcpScope,
+} from "../../../../lib/mcp-scope"
 import { ADMIN_MCP_TOOLS } from "./registry"
 
 const SERVER_INFO = { name: "jyt-admin", version: "0.1.0" } as const
@@ -56,15 +73,57 @@ export function resolveAdminBaseUrl(req: MedusaRequest): string {
   return resolveLoopbackBaseUrl(req, "ADMIN_MCP_LOOPBACK_URL")
 }
 
-export function buildAdminMcpServer(req: MedusaRequest): Server {
+/** The process-wide ceiling on the scope ladder, from the two env flags. */
+export function adminMcpCeiling(): McpScopeLevel {
+  return mcpCeilingLevel({
+    write: isAdminWriteEnabled(),
+    dangerous: isAdminDangerousEnabled(),
+  })
+}
+
+/**
+ * How many tools each level actually exposes, using the same filter the server
+ * applies to `tools/list`.
+ *
+ * Surfaced by `/admin/mcp/scopes` because the ladder alone hides something an
+ * operator needs to see: every admin write tool is currently `sensitive`, so
+ * scoping a credential to `write` exposes exactly what `read` does. A number
+ * next to the level makes that obvious at the moment of choosing it, instead of
+ * after the third-party client starts refusing every call.
+ */
+export function adminToolCountsByLevel(): Record<McpScopeLevel, number> {
+  const counts = {} as Record<McpScopeLevel, number>
+  for (const level of MCP_SCOPE_LEVELS) {
+    const f = mcpScopeToContextFlags(level)
+    counts[level] = ADMIN_MCP_TOOLS.filter(
+      (t) =>
+        (f.enableWrite || !t.write) &&
+        (f.enableDangerous || !isDangerous(t)) &&
+        (f.enableSensitive || !isSensitive(t))
+    ).length
+  }
+  return counts
+}
+
+/** Effective scope for this request: min(process ceiling, credential's row). */
+export async function resolveAdminMcpScope(
+  req: MedusaRequest
+): Promise<ResolvedMcpScope> {
+  return resolveMcpScope(req, adminMcpCeiling())
+}
+
+export function buildAdminMcpServer(
+  req: MedusaRequest,
+  /** Defaults to the process ceiling so existing callers keep their behaviour. */
+  level: McpScopeLevel = adminMcpCeiling()
+): Server {
   const actorId = (req as any).auth_context?.actor_id as string | undefined
   return buildMcpServer(
     {
       baseUrl: resolveAdminBaseUrl(req),
       bearer: req.get("authorization") || undefined,
       cookie: req.get("cookie") || undefined,
-      enableWrite: isAdminWriteEnabled(),
-      enableDangerous: isAdminDangerousEnabled(),
+      ...mcpScopeToContextFlags(level),
       surface: "admin",
       observe: makeMcpLedgerSink(req.scope, {
         id: actorId ?? null,
@@ -80,7 +139,8 @@ export async function handleAdminMcpRequest(
   req: MedusaRequest,
   res: MedusaResponse
 ): Promise<void> {
-  await handleMcpJsonRpc(req, res, buildAdminMcpServer(req))
+  const { level } = await resolveAdminMcpScope(req)
+  await handleMcpJsonRpc(req, res, buildAdminMcpServer(req, level))
 }
 
 export function adminMcpMethodNotAllowed(

--- a/apps/backend/src/api/admin/mcp/scopes/[id]/route.ts
+++ b/apps/backend/src/api/admin/mcp/scopes/[id]/route.ts
@@ -1,0 +1,37 @@
+/**
+ * DELETE /admin/mcp/scopes/:id — remove a credential's scope row (#1306 Track C).
+ *
+ * Deleting a row WIDENS the credential back to the process ceiling; it does not
+ * revoke it. To take access away, revoke the API key in Medusa (or set the row's
+ * level to `read`) — this endpoint is "stop restricting", not "block".
+ *
+ * Human admins only, for the same reason as the collection route: a machine
+ * credential deleting its own row would be a one-call escalation to the ceiling.
+ */
+import { MedusaRequest, MedusaResponse } from "@medusajs/framework/http"
+import { MCP_ACCESS_MODULE } from "../../../../../modules/mcp_access"
+import type McpAccessService from "../../../../../modules/mcp_access/service"
+import { mcpPrincipalFromRequest } from "../../../../../lib/mcp-scope"
+
+export const DELETE = async (req: MedusaRequest, res: MedusaResponse) => {
+  const principal = mcpPrincipalFromRequest(req)
+  if (!principal || principal.type !== "user") {
+    return res.status(403).json({
+      message:
+        "MCP scopes can only be managed by a signed-in admin user. A machine " +
+        "credential cannot remove its own scope.",
+    })
+  }
+
+  const { id } = req.params
+  const service = req.scope.resolve(MCP_ACCESS_MODULE) as McpAccessService
+
+  const existing = await service.listMcpAccessScopes({ id })
+  if (!existing?.[0]) {
+    return res.status(404).json({ message: `MCP scope '${id}' not found.` })
+  }
+
+  await service.deleteMcpAccessScopes(id)
+
+  res.json({ id, object: "mcp_access_scope", deleted: true })
+}

--- a/apps/backend/src/api/admin/mcp/scopes/route.ts
+++ b/apps/backend/src/api/admin/mcp/scopes/route.ts
@@ -113,13 +113,25 @@ export const POST = async (req: MedusaRequest, res: MedusaResponse) => {
 
   const counts = adminToolCountsByLevel()
   const ceiling = adminMcpCeiling()
+  const effective = minMcpScope(ceiling, level as McpScopeLevel)
 
   res.json({
     scope,
-    effective_level: minMcpScope(ceiling, level as McpScopeLevel),
+    effective_level: effective,
     ceiling,
-    // Echo what this level actually buys, so an operator who picks `write`
-    // sees immediately that it exposes no more tools than `read` does.
-    tools_visible: counts[level as McpScopeLevel],
+    // Counted at the EFFECTIVE level, not the requested one — a row granting
+    // more than the ceiling is stored but clamped, and reporting the granted
+    // level's count here would overstate what the credential can actually see.
+    tools_visible: counts[effective],
+    // Stated explicitly rather than left for the reader to infer from two
+    // fields that happen to differ.
+    ...(effective !== level
+      ? {
+          warning: `Stored as '${level}', but the process ceiling is '${ceiling}', so this credential operates at '${effective}'. Raising it requires ADMIN_MCP_ENABLE_WRITE / ADMIN_MCP_ENABLE_DANGEROUS.`,
+        }
+      : {}),
+    // ⚠️ `write` exposes exactly what `read` does today — every admin write tool
+    // is flagged sensitive. Surfaced so picking `write` doesn't look useful.
+    tools_by_level: counts,
   })
 }

--- a/apps/backend/src/api/admin/mcp/scopes/route.ts
+++ b/apps/backend/src/api/admin/mcp/scopes/route.ts
@@ -1,0 +1,125 @@
+/**
+ * GET/POST /admin/mcp/scopes — manage per-credential MCP scopes (#1306 Track C).
+ *
+ * A scope row narrows ONE credential below the process ceiling
+ * (`ADMIN_MCP_ENABLE_WRITE` / `ADMIN_MCP_ENABLE_DANGEROUS`). Absent a row the
+ * credential gets the ceiling, which is the behaviour that existed before.
+ *
+ * ⚠️ HUMAN ADMINS ONLY. Both handlers refuse any principal that is not
+ * `actor_type: "user"`. A machine credential must never be able to widen its own
+ * scope — without this check a token scoped to `write` could POST itself up to
+ * `dangerous`, and the whole mechanism would be decorative.
+ *
+ * Deliberately NOT wrapped as MCP tools for the same reason: the tool surface is
+ * driven by a model, and scope escalation is not a thing a model should be able
+ * to attempt on its own.
+ */
+import { MedusaRequest, MedusaResponse } from "@medusajs/framework/http"
+import { MCP_ACCESS_MODULE } from "../../../../modules/mcp_access"
+import type McpAccessService from "../../../../modules/mcp_access/service"
+import {
+  MCP_SCOPE_LEVELS,
+  isMcpScopeLevel,
+  mcpPrincipalFromRequest,
+  minMcpScope,
+  type McpScopeLevel,
+} from "../../../../lib/mcp-scope"
+import { adminMcpCeiling, adminToolCountsByLevel } from "../lib/handler"
+
+/** Refuse anything that is not a logged-in human admin. Returns true if handled. */
+const refuseNonHumanAdmin = (
+  req: MedusaRequest,
+  res: MedusaResponse
+): boolean => {
+  const principal = mcpPrincipalFromRequest(req)
+  if (principal && principal.type === "user") {
+    return false
+  }
+  res.status(403).json({
+    message:
+      "MCP scopes can only be managed by a signed-in admin user. A machine " +
+      "credential cannot read or change its own scope.",
+  })
+  return true
+}
+
+export const GET = async (req: MedusaRequest, res: MedusaResponse) => {
+  if (refuseNonHumanAdmin(req, res)) return
+
+  const service = req.scope.resolve(MCP_ACCESS_MODULE) as McpAccessService
+  const scopes = await service.listMcpAccessScopes({})
+
+  const counts = adminToolCountsByLevel()
+
+  res.json({
+    scopes: (scopes as any[]).map((s) => ({
+      id: s.id,
+      principal_type: s.principal_type,
+      principal_id: s.principal_id,
+      level: s.level,
+      label: s.label,
+      note: s.note,
+      created_at: s.created_at,
+      updated_at: s.updated_at,
+    })),
+    // The ceiling is the process-wide cap; a row can only ever restrict below
+    // it, so a level above `ceiling` is stored but has no effect.
+    ceiling: adminMcpCeiling(),
+    // Tools each level exposes. ⚠️ `write` currently equals `read` — every
+    // admin write tool is flagged sensitive — so a credential that needs to
+    // change anything needs `sensitive`.
+    levels: MCP_SCOPE_LEVELS.map((level) => ({
+      level,
+      tools: counts[level],
+    })),
+  })
+}
+
+export const POST = async (req: MedusaRequest, res: MedusaResponse) => {
+  if (refuseNonHumanAdmin(req, res)) return
+
+  const body = ((req as any).validatedBody || req.body || {}) as {
+    principal_type?: string
+    principal_id?: string
+    level?: string
+    label?: string | null
+    note?: string | null
+  }
+
+  const principalType = String(body.principal_type || "").trim()
+  const principalId = String(body.principal_id || "").trim()
+  const level = String(body.level || "").trim()
+
+  if (!principalType || !principalId) {
+    return res.status(400).json({
+      message:
+        "principal_type and principal_id are required. For a Medusa secret API key, principal_type is 'api-key' and principal_id is the key id (apk_…).",
+    })
+  }
+  if (!isMcpScopeLevel(level)) {
+    return res.status(400).json({
+      message: `level must be one of: ${MCP_SCOPE_LEVELS.join(", ")}`,
+    })
+  }
+
+  const service = req.scope.resolve(MCP_ACCESS_MODULE) as McpAccessService
+  const scope = await service.setScope({
+    principal_type: principalType,
+    principal_id: principalId,
+    level: level as McpScopeLevel,
+    label: body.label ?? null,
+    note: body.note ?? null,
+  })
+
+  const counts = adminToolCountsByLevel()
+  const ceiling = adminMcpCeiling()
+
+  res.json({
+    scope,
+    effective_level: minMcpScope(ceiling, level as McpScopeLevel),
+    ceiling,
+    // Echo what this level actually buys, so an operator who picks `write`
+    // sees immediately that it exposes no more tools than `read` does.
+    tools_visible: counts[level as McpScopeLevel],
+  })
+}

--- a/apps/backend/src/api/middlewares.ts
+++ b/apps/backend/src/api/middlewares.ts
@@ -31,6 +31,13 @@ import {
   CatalogLookupSchema,
 } from "./ucp/validators";
 import { resolveStorefrontUrl } from "./ucp/lib/context";
+import {
+  isMcpMachinePrincipal,
+  loadMcpScopeLevel,
+  mcpPrincipalFromRequest,
+  mcpScopeAllows,
+  MCP_SCOPE_EXEMPT_ADMIN_PATHS,
+} from "../lib/mcp-scope";
 
 // Helper function to wrap Zod schemas for compatibility with validateAndTransformBody.
 // Historically this wrapped with z.preprocess((obj) => obj, schema) — under Zod v3
@@ -659,8 +666,83 @@ const applyCategoryFilters = (req: MedusaRequest, _res: MedusaResponse, next: Me
   next()
 }
 
+/**
+ * Enforce a machine credential's MCP scope on ordinary `/admin/*` mutations
+ * (#1306 Track C).
+ *
+ * Without this the scope would be theatre: a Medusa secret API key authenticates
+ * every admin route, so a token scoped to `read` on the MCP surface could simply
+ * POST the wrapped route directly. Enforcing at the HTTP layer makes the scope
+ * real and, because the MCP dispatcher reaches routes over the same loopback
+ * HTTP path, gives one unbypassable choke point rather than two that can drift.
+ *
+ * Applies to MACHINE principals only (api-key / OAuth). A human admin holds a
+ * dashboard session and can do anything through the UI, so restricting their raw
+ * HTTP writes would restrict nothing while risking locking a real person out;
+ * their scope row still narrows the MCP tool surface.
+ *
+ * Absent a scope row this is a pass-through, so the behaviour of every existing
+ * key is unchanged until someone writes one.
+ */
+const enforceMcpScopeOnAdminWrites = async (
+  req: MedusaRequest,
+  res: MedusaResponse,
+  next: MedusaNextFunction
+) => {
+  const method = (req.method || "GET").toUpperCase()
+  if (method === "GET" || method === "HEAD" || method === "OPTIONS") {
+    return next()
+  }
+
+  // `req.path` is relative to the matched mount, so read the full path.
+  const path = (req.originalUrl || "").split("?")[0].replace(/\/+$/, "")
+  if (MCP_SCOPE_EXEMPT_ADMIN_PATHS.includes(path)) {
+    return next()
+  }
+
+  const principal = mcpPrincipalFromRequest(req)
+  if (!principal || !isMcpMachinePrincipal(principal)) {
+    return next()
+  }
+
+  try {
+    const granted = await loadMcpScopeLevel(req.scope, principal)
+    if (!granted || mcpScopeAllows(granted, "write")) {
+      return next()
+    }
+    return res.status(403).json({
+      message:
+        `This credential is scoped to '${granted}' and cannot perform write ` +
+        `operations. Scope is set per credential in mcp_access_scope; widen it ` +
+        `via POST /admin/mcp/scopes as an admin user.`,
+    })
+  } catch {
+    // Fail CLOSED. `loadMcpScopeLevel` already returns null (→ pass through)
+    // when the module simply isn't registered, so reaching here means the
+    // module is present and the read failed — and a permission check that
+    // cannot read the permission must not grant it. Affects machine
+    // credentials only; human admin traffic never reaches this branch.
+    return res.status(503).json({
+      message:
+        "Could not read this credential's MCP scope; refusing the write rather than assuming it is permitted. Retry shortly.",
+    })
+  }
+}
+
 export default defineMiddlewares({
   routes: [
+    // Per-credential scope guard (#1306 Track C).
+    //
+    // No `method`/`methods` key on purpose: Medusa's routes sorter buckets a
+    // method-less entry as "global", and globals are concatenated ahead of
+    // wildcard/regex/static/params, so this registers as `app.use()` before
+    // every `/admin/*` route handler. It also runs after the framework's own
+    // admin auth middleware (applied in the loader before user middlewares),
+    // which is what makes `req.auth_context` available here.
+    {
+      matcher: "/admin/*",
+      middlewares: [enforceMcpScopeOnAdminWrites],
+    },
     // ─── Store collection & category validation (replicate framework middleware) ───
     {
       matcher: "/store/collections",

--- a/apps/backend/src/lib/__tests__/mcp-scope.unit.spec.ts
+++ b/apps/backend/src/lib/__tests__/mcp-scope.unit.spec.ts
@@ -1,0 +1,170 @@
+/**
+ * Per-token MCP scope arithmetic (#1306 Track C).
+ *
+ * The properties that matter here are not "does the ladder sort" but the two
+ * that make the mechanism safe: a scope row can only ever RESTRICT, and an
+ * absent row leaves behaviour exactly as it was before scopes existed.
+ */
+import {
+  MCP_SCOPE_LEVELS,
+  isMcpScopeLevel,
+  mcpScopeRank,
+  minMcpScope,
+  mcpScopeAllows,
+  mcpScopeToContextFlags,
+  mcpCeilingLevel,
+  mcpPrincipalFromRequest,
+  isMcpMachinePrincipal,
+  resolveMcpScope,
+  type McpScopeLevel,
+} from "../mcp-scope"
+
+const asReq = (authContext: any, service?: any) =>
+  ({
+    auth_context: authContext,
+    scope: {
+      resolve: () => {
+        if (!service) throw new Error("module not registered")
+        return service
+      },
+    },
+  } as any)
+
+describe("mcp scope ladder", () => {
+  it("orders the levels weakest-first", () => {
+    expect([...MCP_SCOPE_LEVELS]).toEqual([
+      "read",
+      "write",
+      "sensitive",
+      "dangerous",
+    ])
+  })
+
+  it("ranks an unknown level as the weakest, not the strongest", () => {
+    // Fail shut: a typo'd or future level stored in the DB must not grant more
+    // than `read` on an older deployment that doesn't know the word.
+    expect(mcpScopeRank("wildcard")).toBe(mcpScopeRank("read"))
+    expect(isMcpScopeLevel("wildcard")).toBe(false)
+  })
+
+  it("implies every level below it", () => {
+    expect(mcpScopeAllows("dangerous", "read")).toBe(true)
+    expect(mcpScopeAllows("dangerous", "write")).toBe(true)
+    expect(mcpScopeAllows("write", "sensitive")).toBe(false)
+    expect(mcpScopeAllows("read", "write")).toBe(false)
+  })
+
+  it("maps each level onto the three context flags", () => {
+    expect(mcpScopeToContextFlags("read")).toEqual({
+      enableWrite: false,
+      enableSensitive: false,
+      enableDangerous: false,
+    })
+    // The rung that did not exist before: ordinary mutations, no confirm-gated
+    // tools — which is what a third-party client should get by default, since
+    // there the MODEL supplies confirm:true rather than a human.
+    expect(mcpScopeToContextFlags("write")).toEqual({
+      enableWrite: true,
+      enableSensitive: false,
+      enableDangerous: false,
+    })
+    expect(mcpScopeToContextFlags("sensitive")).toEqual({
+      enableWrite: true,
+      enableSensitive: true,
+      enableDangerous: false,
+    })
+    expect(mcpScopeToContextFlags("dangerous")).toEqual({
+      enableWrite: true,
+      enableSensitive: true,
+      enableDangerous: true,
+    })
+  })
+})
+
+describe("process ceiling", () => {
+  it("is 'sensitive' in the default deployment — writes on, dangerous off", () => {
+    // This is the compatibility assertion. Confirm-gated tools have always been
+    // callable when ADMIN_MCP_ENABLE_WRITE is on, so the default ceiling must
+    // sit at `sensitive`, not `write`, or scopes would silently take something
+    // away from every existing credential.
+    expect(mcpCeilingLevel({ write: true, dangerous: false })).toBe("sensitive")
+  })
+
+  it("collapses to read when writes are off, regardless of the dangerous flag", () => {
+    expect(mcpCeilingLevel({ write: false, dangerous: false })).toBe("read")
+    expect(mcpCeilingLevel({ write: false, dangerous: true })).toBe("read")
+  })
+
+  it("reaches dangerous only when both flags are on", () => {
+    expect(mcpCeilingLevel({ write: true, dangerous: true })).toBe("dangerous")
+  })
+})
+
+describe("intersection with the ceiling", () => {
+  it("takes the weaker of the two", () => {
+    expect(minMcpScope("dangerous", "read")).toBe("read")
+    expect(minMcpScope("write", "sensitive")).toBe("write")
+  })
+
+  it("never lets a row widen past the ceiling", async () => {
+    const service = {
+      getScope: async () => ({ level: "dangerous" }),
+    }
+    const req = asReq({ actor_id: "apk_1", actor_type: "api-key" }, service)
+    // Deployment allows writes but not dangerous ⇒ ceiling 'sensitive'.
+    const resolved = await resolveMcpScope(req, "sensitive")
+    expect(resolved.level).toBe("sensitive")
+    expect(resolved.granted).toBe("dangerous")
+    expect(resolved.source).toBe("scope_row")
+  })
+
+  it("falls back to the ceiling when the principal has no row", async () => {
+    const service = { getScope: async () => null }
+    const req = asReq({ actor_id: "apk_1", actor_type: "api-key" }, service)
+    const resolved = await resolveMcpScope(req, "sensitive")
+    expect(resolved).toEqual({ level: "sensitive", source: "ceiling" })
+  })
+
+  it("falls back to the ceiling when the module is unavailable", async () => {
+    // A missing module must degrade to prior behaviour, not lock every
+    // credential out of the platform.
+    const req = asReq({ actor_id: "apk_1", actor_type: "api-key" })
+    const resolved = await resolveMcpScope(req, "sensitive")
+    expect(resolved).toEqual({ level: "sensitive", source: "ceiling" })
+  })
+
+  it("restricts when the row is weaker than the ceiling", async () => {
+    const service = { getScope: async () => ({ level: "read" }) }
+    const req = asReq({ actor_id: "apk_1", actor_type: "api-key" }, service)
+    expect((await resolveMcpScope(req, "dangerous")).level).toBe("read")
+  })
+
+  it("treats an unrecognised stored level as read", async () => {
+    const service = { getScope: async () => ({ level: "admin" }) }
+    const req = asReq({ actor_id: "apk_1", actor_type: "api-key" }, service)
+    expect((await resolveMcpScope(req, "dangerous")).level).toBe("read")
+  })
+})
+
+describe("principals", () => {
+  it("reads the api-key actor Medusa sets for a secret key", () => {
+    const req = asReq({ actor_id: "apk_01M0", actor_type: "api-key" })
+    expect(mcpPrincipalFromRequest(req)).toEqual({
+      type: "api-key",
+      id: "apk_01M0",
+    })
+  })
+
+  it("is null when unauthenticated", () => {
+    expect(mcpPrincipalFromRequest(asReq(undefined))).toBeNull()
+    expect(mcpPrincipalFromRequest(asReq({ actor_type: "user" }))).toBeNull()
+  })
+
+  it("counts only machine credentials as HTTP-enforceable", () => {
+    // A human admin can do anything through the dashboard, so refusing their
+    // raw HTTP writes would restrict nothing and could lock a person out.
+    expect(isMcpMachinePrincipal({ type: "api-key", id: "apk_1" })).toBe(true)
+    expect(isMcpMachinePrincipal({ type: "oauth", id: "tok_1" })).toBe(true)
+    expect(isMcpMachinePrincipal({ type: "user", id: "usr_1" })).toBe(false)
+  })
+})

--- a/apps/backend/src/lib/mcp-core/__tests__/proxy.unit.spec.ts
+++ b/apps/backend/src/lib/mcp-core/__tests__/proxy.unit.spec.ts
@@ -1,0 +1,60 @@
+/**
+ * Loopback proxy auth forwarding.
+ *
+ * The bug this pins: `callMcpRoute` used to prefix any header that didn't
+ * already start with "bearer " — so a Medusa secret API key, which authenticates
+ * over HTTP Basic and only over Basic, was forwarded as `Bearer Basic <b64>` and
+ * every tool CALL 401'd on the loopback. `initialize` and `tools/list` never
+ * touch a route, so they kept working and the surface looked functional for a
+ * key holder (#1306).
+ */
+import { callMcpRoute } from "../proxy"
+
+describe("callMcpRoute — authorization forwarding", () => {
+  const originalFetch = global.fetch
+  let seen: Record<string, string>
+
+  beforeEach(() => {
+    seen = {}
+    global.fetch = jest.fn(async (_url: any, init: any) => {
+      seen = init.headers
+      return {
+        ok: true,
+        status: 200,
+        text: async () => JSON.stringify({ ok: true }),
+      } as any
+    }) as any
+  })
+
+  afterEach(() => {
+    global.fetch = originalFetch
+  })
+
+  const call = (bearer?: string) =>
+    callMcpRoute({ baseUrl: "http://localhost:9000", path: "/admin/products", bearer })
+
+  it("forwards a Basic header verbatim — an API key must stay Basic", async () => {
+    await call("Basic c2tfZm9vOg==")
+    expect(seen["authorization"]).toBe("Basic c2tfZm9vOg==")
+  })
+
+  it("is case-insensitive about the scheme", async () => {
+    await call("basic c2tfZm9vOg==")
+    expect(seen["authorization"]).toBe("basic c2tfZm9vOg==")
+  })
+
+  it("forwards a Bearer header verbatim", async () => {
+    await call("Bearer jwt.token.here")
+    expect(seen["authorization"]).toBe("Bearer jwt.token.here")
+  })
+
+  it("still prefixes a bare token", async () => {
+    await call("jwt.token.here")
+    expect(seen["authorization"]).toBe("Bearer jwt.token.here")
+  })
+
+  it("sends no authorization header when there is nothing to forward", async () => {
+    await call(undefined)
+    expect(seen["authorization"]).toBeUndefined()
+  })
+})

--- a/apps/backend/src/lib/mcp-core/dispatch.ts
+++ b/apps/backend/src/lib/mcp-core/dispatch.ts
@@ -127,6 +127,15 @@ export async function dispatchMcpTool(
       `Tool '${name}' is a platform-destructive action and dangerous tools are disabled on this server.`
     )
   }
+  // Sensitive tools refused when this credential's scope stops below them
+  // (#1306 Track C). Deliberately keyed off `isSensitive(def)` rather than the
+  // `sensitive` local: `disableSensitiveRails` turns off the confirm UX for the
+  // store surface, but it must never widen a permission.
+  if (isSensitive(def) && ctx.enableSensitive === false) {
+    return fail(
+      `Tool '${name}' is a sensitive action and this credential's scope does not include sensitive tools.`
+    )
+  }
 
   // Resolve the tenant publishable key for multi-tenant (store) surfaces. A
   // `store` argument (handle/domain) wins and is resolved per-call; otherwise

--- a/apps/backend/src/lib/mcp-core/proxy.ts
+++ b/apps/backend/src/lib/mcp-core/proxy.ts
@@ -72,9 +72,19 @@ export async function callMcpRoute({
 
   const headers: Record<string, string> = { accept: "application/json" }
   if (bearer) {
-    headers["authorization"] = bearer.toLowerCase().startsWith("bearer ")
-      ? bearer
-      : `Bearer ${bearer}`
+    // Forward an already-schemed header VERBATIM; only a bare token gets the
+    // Bearer prefix.
+    //
+    // `Basic` matters as much as `Bearer`: a Medusa secret API key authenticates
+    // over HTTP Basic and ONLY over Basic (the framework returns a pointed 401
+    // when one arrives as a Bearer token). Prefixing unconditionally turned
+    // `Basic <b64>` into `Bearer Basic <b64>`, so every tool CALL from an
+    // API-key-authenticated MCP client 401'd on the loopback — while
+    // `initialize` and `tools/list`, which never touch a route, kept working.
+    // That combination is why the surface looked functional for a key holder.
+    const scheme = bearer.trim().split(" ")[0].toLowerCase()
+    headers["authorization"] =
+      scheme === "bearer" || scheme === "basic" ? bearer : `Bearer ${bearer}`
   }
   if (cookie) {
     headers["cookie"] = cookie

--- a/apps/backend/src/lib/mcp-core/server.ts
+++ b/apps/backend/src/lib/mcp-core/server.ts
@@ -51,9 +51,13 @@ export function buildMcpServer(
 
   const writeEnabled = ctx.enableWrite !== false
   const dangerousEnabled = ctx.enableDangerous === true
+  // Undefined = allowed, so an unscoped surface keeps every sensitive tool.
+  const sensitiveEnabled = ctx.enableSensitive !== false
   const visibleTools = tools.filter(
     (t) =>
-      (writeEnabled || !t.write) && (dangerousEnabled || !isDangerous(t))
+      (writeEnabled || !t.write) &&
+      (dangerousEnabled || !isDangerous(t)) &&
+      (sensitiveEnabled || !isSensitive(t))
   )
 
   server.setRequestHandler(ListToolsRequestSchema, async () => ({

--- a/apps/backend/src/lib/mcp-core/types.ts
+++ b/apps/backend/src/lib/mcp-core/types.ts
@@ -114,6 +114,17 @@ export type McpContext = {
    */
   enableDangerous?: boolean
   /**
+   * When false, `sensitive` tools (explicitly flagged ones, every DELETE, and
+   * every dangerous tool) are hidden from `tools/list` and refused at dispatch.
+   *
+   * This is a PERMISSION, distinct from the confirm rail: the rail asks a human
+   * to approve, whereas from a third-party MCP client the model supplies
+   * `confirm: true` itself, so the rail is not a boundary there (#1306 Track C).
+   * A token scoped to `write` gets ordinary mutations without the confirm-gated
+   * ones. Undefined means allowed, so surfaces that don't scope are unaffected.
+   */
+  enableSensitive?: boolean
+  /**
    * When true, the confirm/reason safety rails are skipped entirely and every
    * tool is either a read or a plain write (write-gated only). The store
    * surface sets this: there a DELETE (`remove_line_item`) is an ordinary cart

--- a/apps/backend/src/lib/mcp-scope.ts
+++ b/apps/backend/src/lib/mcp-scope.ts
@@ -1,0 +1,213 @@
+/**
+ * MCP scope vocabulary — the ladder, the process ceiling, and the resolver
+ * (#1306 Track C).
+ *
+ * Two independent things decide what a caller may do through MCP:
+ *
+ *   1. the PROCESS CEILING — `ADMIN_MCP_ENABLE_WRITE` (default true) and
+ *      `ADMIN_MCP_ENABLE_DANGEROUS` (default false), env flags that apply to
+ *      the whole deployment; and
+ *   2. the PRINCIPAL'S SCOPE — an `mcp_access_scope` row for this specific
+ *      credential.
+ *
+ * The effective level is `min(ceiling, row)`. A row can only ever restrict:
+ * widening still needs the env flag, so a bad scope row cannot turn a
+ * read-only deployment into a write one. No row at all means "whatever the
+ * process allows", which is exactly the behaviour that existed before this
+ * module — so nothing changes until a row is written.
+ *
+ * Everything here is pure except `loadMcpScopeLevel`, which does one indexed
+ * lookup. There is deliberately NO cache: the lookup runs on admin writes and
+ * MCP tool calls only (never on dashboard reads), and a cache would mean a
+ * revoked scope keeps working for its TTL — the wrong trade for a permission.
+ */
+import type { MedusaRequest } from "@medusajs/framework/http"
+import { MCP_ACCESS_MODULE } from "../modules/mcp_access"
+import type McpAccessService from "../modules/mcp_access/service"
+
+/**
+ * The scope ladder, weakest first. A level implies every level below it, so a
+ * "dangerous" token can also read. Index in this array IS the rank.
+ */
+export const MCP_SCOPE_LEVELS = [
+  "read",
+  "write",
+  "sensitive",
+  "dangerous",
+] as const
+
+export type McpScopeLevel = (typeof MCP_SCOPE_LEVELS)[number]
+
+export const isMcpScopeLevel = (value: unknown): value is McpScopeLevel =>
+  typeof value === "string" &&
+  (MCP_SCOPE_LEVELS as readonly string[]).includes(value)
+
+/** Rank on the ladder; unknown strings rank as the weakest level (fail shut). */
+export const mcpScopeRank = (level: string): number => {
+  const i = (MCP_SCOPE_LEVELS as readonly string[]).indexOf(level)
+  return i === -1 ? 0 : i
+}
+
+/** The weaker of two levels — how a row is intersected with the ceiling. */
+export const minMcpScope = (
+  a: McpScopeLevel,
+  b: McpScopeLevel
+): McpScopeLevel => (mcpScopeRank(a) <= mcpScopeRank(b) ? a : b)
+
+/** True when `level` reaches at least `required` on the ladder. */
+export const mcpScopeAllows = (
+  level: McpScopeLevel,
+  required: McpScopeLevel
+): boolean => mcpScopeRank(level) >= mcpScopeRank(required)
+
+/**
+ * Translate a level into the three flags `McpContext` already understands.
+ * `sensitive` covers the confirm-gated tools (every DELETE is implicitly one);
+ * `dangerous` covers the ones that additionally demand a human reason.
+ */
+export const mcpScopeToContextFlags = (
+  level: McpScopeLevel
+): {
+  enableWrite: boolean
+  enableSensitive: boolean
+  enableDangerous: boolean
+} => ({
+  enableWrite: mcpScopeAllows(level, "write"),
+  enableSensitive: mcpScopeAllows(level, "sensitive"),
+  enableDangerous: mcpScopeAllows(level, "dangerous"),
+})
+
+/**
+ * The process ceiling expressed on the ladder.
+ *
+ * Note the middle rung: with writes on but dangerous off — the default
+ * deployment — the ceiling is "sensitive", because confirm-gated tools have
+ * always been callable in that configuration. Only `dangerous` was ever gated
+ * separately, and this preserves that exactly.
+ */
+export const mcpCeilingLevel = (flags: {
+  write: boolean
+  dangerous: boolean
+}): McpScopeLevel =>
+  !flags.write ? "read" : flags.dangerous ? "dangerous" : "sensitive"
+
+/** The authenticated principal a scope row can be attached to. */
+export type McpPrincipal = {
+  /** Medusa `auth_context.actor_type`: "api-key" | "user" | … */
+  type: string
+  /** Medusa `auth_context.actor_id`: `apk_…` for a secret API key. */
+  id: string
+}
+
+/**
+ * Principal for a request, or null when unauthenticated.
+ *
+ * For a secret API key Medusa sets `{ actor_id: <api_key.id>, actor_type:
+ * "api-key" }` (see the framework's authenticate middleware — API keys are the
+ * one hard-coded actor type). For a dashboard session or admin JWT it is the
+ * user id with `actor_type: "user"`.
+ */
+export const mcpPrincipalFromRequest = (
+  req: MedusaRequest
+): McpPrincipal | null => {
+  const ctx = (req as any).auth_context
+  const id = ctx?.actor_id
+  const type = ctx?.actor_type
+  if (typeof id !== "string" || !id || typeof type !== "string" || !type) {
+    return null
+  }
+  return { type, id }
+}
+
+/**
+ * Machine principals — the ones an HTTP-level restriction is meaningful for.
+ *
+ * A human admin holds a dashboard session and can perform any mutation through
+ * the UI, so refusing their raw HTTP writes would restrict nothing while
+ * risking locking a real person out. Their scope row (if any) still narrows the
+ * MCP tool surface; it just isn't enforced on ordinary `/admin/*` routes.
+ */
+export const MCP_MACHINE_PRINCIPAL_TYPES: readonly string[] = [
+  "api-key",
+  "oauth",
+]
+
+export const isMcpMachinePrincipal = (principal: McpPrincipal): boolean =>
+  MCP_MACHINE_PRINCIPAL_TYPES.includes(principal.type)
+
+/**
+ * Non-GET `/admin/*` paths a read-scoped machine credential may still call.
+ *
+ * The HTTP guard (`src/api/middlewares.ts`) classifies by verb, but the registry
+ * classifies by its `write` flag, and the two disagree for POSTs that only read:
+ *
+ *   - `/admin/mcp` is the JSON-RPC transport — EVERY tool call is a POST,
+ *     including reads. Scope is enforced per-tool inside the dispatcher instead,
+ *     and the loopback call it then makes re-enters the guard for the real
+ *     route, so a read-only token still cannot reach a mutation through it.
+ *   - `/admin/mcp/resolve-query` is a POST that only plans (`resolve_admin_query`,
+ *     correctly not flagged `write`).
+ *   - `/admin/assistant/vision` is a POST that only looks at an already-stored
+ *     image (`read_image`). It is POST because the image reference goes in the
+ *     body, not because anything changes.
+ *
+ * An invariant test asserts every non-GET tool that is not flagged `write` has
+ * its path listed here — so a future read-only POST tool fails the suite instead
+ * of silently 403ing for read-only credentials.
+ */
+export const MCP_SCOPE_EXEMPT_ADMIN_PATHS: readonly string[] = [
+  "/admin/mcp",
+  "/admin/mcp/resolve-query",
+  "/admin/assistant/vision",
+]
+
+export type ResolvedMcpScope = {
+  /** The effective level after intersecting the row with the ceiling. */
+  level: McpScopeLevel
+  /** Where it came from — "ceiling" means no row existed for this principal. */
+  source: "ceiling" | "scope_row"
+  /** The row's own level, before intersection (for diagnostics/audit). */
+  granted?: McpScopeLevel
+}
+
+/**
+ * Read this principal's stored level, if any. Returns null both when no row
+ * exists and when the module is unavailable — the caller falls back to the
+ * ceiling, so a missing module degrades to today's behaviour rather than
+ * locking every credential out.
+ */
+export const loadMcpScopeLevel = async (
+  container: MedusaRequest["scope"],
+  principal: McpPrincipal
+): Promise<McpScopeLevel | null> => {
+  let service: McpAccessService
+  try {
+    service = container.resolve(MCP_ACCESS_MODULE) as McpAccessService
+  } catch {
+    return null
+  }
+  const row = await service.getScope(principal.type, principal.id)
+  if (!row) return null
+  return isMcpScopeLevel(row.level) ? row.level : "read"
+}
+
+/**
+ * Effective scope for a request: `min(ceiling, stored row)`.
+ *
+ * `ceiling` is supplied by the caller (each surface owns its own env flags),
+ * keeping this module free of surface-specific configuration.
+ */
+export const resolveMcpScope = async (
+  req: MedusaRequest,
+  ceiling: McpScopeLevel
+): Promise<ResolvedMcpScope> => {
+  const principal = mcpPrincipalFromRequest(req)
+  if (!principal) {
+    return { level: ceiling, source: "ceiling" }
+  }
+  const granted = await loadMcpScopeLevel(req.scope, principal)
+  if (!granted) {
+    return { level: ceiling, source: "ceiling" }
+  }
+  return { level: minMcpScope(ceiling, granted), source: "scope_row", granted }
+}

--- a/apps/backend/src/modules/mcp_access/index.ts
+++ b/apps/backend/src/modules/mcp_access/index.ts
@@ -1,0 +1,8 @@
+import { Module } from "@medusajs/framework/utils"
+import McpAccessService from "./service"
+
+export const MCP_ACCESS_MODULE = "mcp_access"
+
+export default Module(MCP_ACCESS_MODULE, {
+  service: McpAccessService,
+})

--- a/apps/backend/src/modules/mcp_access/migrations/Migration20260815140000.ts
+++ b/apps/backend/src/modules/mcp_access/migrations/Migration20260815140000.ts
@@ -1,0 +1,26 @@
+import { Migration } from "@medusajs/framework/mikro-orm/migrations";
+
+/**
+ * Creates the mcp_access_scope table (#1306 Track C — per-token MCP scopes).
+ *
+ * Hand-written create migration, mirroring what DML would generate for the
+ * model: the compound unique index over (principal_type, principal_id) as a
+ * partial index (WHERE deleted_at IS NULL) so a soft-deleted scope doesn't
+ * block re-scoping the same credential, plus the standard deleted_at index.
+ *
+ * Idempotent (`if not exists` throughout) — a re-run is a no-op rather than a
+ * failure that the migrate job would report as success (#1208).
+ */
+export class Migration20260815140000 extends Migration {
+
+  override async up(): Promise<void> {
+    this.addSql(`create table if not exists "mcp_access_scope" ("id" text not null, "principal_type" text not null, "principal_id" text not null, "level" text not null default 'read', "label" text null, "note" text null, "metadata" jsonb null, "created_at" timestamptz not null default now(), "updated_at" timestamptz not null default now(), "deleted_at" timestamptz null, constraint "mcp_access_scope_pkey" primary key ("id"));`);
+    this.addSql(`CREATE UNIQUE INDEX IF NOT EXISTS "IDX_mcp_access_scope_principal_unique" ON "mcp_access_scope" ("principal_type", "principal_id") WHERE deleted_at IS NULL;`);
+    this.addSql(`CREATE INDEX IF NOT EXISTS "IDX_mcp_access_scope_deleted_at" ON "mcp_access_scope" ("deleted_at") WHERE deleted_at IS NULL;`);
+  }
+
+  override async down(): Promise<void> {
+    this.addSql(`drop table if exists "mcp_access_scope" cascade;`);
+  }
+
+}

--- a/apps/backend/src/modules/mcp_access/models/mcp-access-scope.ts
+++ b/apps/backend/src/modules/mcp_access/models/mcp-access-scope.ts
@@ -1,0 +1,66 @@
+import { model } from "@medusajs/framework/utils"
+
+/**
+ * Per-token MCP access scope (#1306 Track C).
+ *
+ * `ADMIN_MCP_ENABLE_WRITE` / `ADMIN_MCP_ENABLE_DANGEROUS` are process-wide env
+ * flags, so before this model every credential that could reach `/admin/mcp`
+ * inherited whatever the process allowed — there was no read-only token. This
+ * table narrows a SINGLE principal below that ceiling.
+ *
+ * One row per (principal_type, principal_id). Absent a row the principal gets
+ * the process ceiling, i.e. today's behaviour — adding this model changes
+ * nothing until someone writes a row.
+ *
+ * `principal_type` mirrors Medusa's `auth_context.actor_type`:
+ *   - "api-key" — a Medusa secret API key (`apk_…` is the `principal_id`).
+ *     This is what a machine/MCP client authenticates with today.
+ *   - "user"    — a human admin. Rows are accepted but NOT enforced on plain
+ *     HTTP routes (see the guard in `src/api/middlewares.ts`): a human can
+ *     always use the dashboard, so an HTTP-level restriction there would be
+ *     theatre. They still apply to the MCP tool surface.
+ *   - "oauth"   — reserved for Track B's minted tokens.
+ *
+ * `level` is a LADDER, not a set of independent switches, so no nonsensical
+ * combination (dangerous-but-not-write) can be stored:
+ *
+ *   read      → GET tools only. The read-only token that did not exist before.
+ *   write     → ordinary mutations; `sensitive`/`dangerous` tools stay hidden.
+ *   sensitive → adds the confirm-gated tools (every DELETE is implicitly one).
+ *   dangerous → adds the platform-destructive tools (confirm + human reason).
+ *
+ * The effective level is always `min(process ceiling, this row)` — a row can
+ * only ever restrict. Widening still requires the env flag, so a compromised
+ * scope row cannot turn a read-only deployment into a write one.
+ */
+const McpAccessScope = model
+  .define("mcp_access_scope", {
+    id: model.id().primaryKey(),
+
+    // Medusa auth_context.actor_type — see the doc-comment.
+    principal_type: model.text().searchable(),
+
+    // The API key id (`apk_…`), admin user id, or OAuth token id.
+    principal_id: model.text().searchable(),
+
+    // read | write | sensitive | dangerous. Stored as text rather than an enum
+    // so Track B can add a level without a column migration.
+    level: model.text().default("read"),
+
+    // Human label for the credential this scopes, e.g. "claude-code-mcp".
+    // Free-text: the api_key title lives in another module and can drift.
+    label: model.text().nullable(),
+
+    // Why this principal is restricted — shown in the scope listing.
+    note: model.text().nullable(),
+
+    metadata: model.json().nullable(),
+  })
+  .indexes([
+    {
+      on: ["principal_type", "principal_id"],
+      unique: true,
+    },
+  ])
+
+export default McpAccessScope

--- a/apps/backend/src/modules/mcp_access/service.ts
+++ b/apps/backend/src/modules/mcp_access/service.ts
@@ -1,0 +1,69 @@
+import { MedusaService } from "@medusajs/framework/utils"
+import McpAccessScope from "./models/mcp-access-scope"
+
+/**
+ * Per-token MCP scopes (#1306 Track C). See the model for the ladder and why a
+ * row can only ever restrict.
+ */
+class McpAccessService extends MedusaService({
+  McpAccessScope,
+}) {
+  /**
+   * The scope row for one principal, or null. Called on every admin write by a
+   * machine principal and on every MCP request, so it stays a single indexed
+   * lookup on the unique (principal_type, principal_id) pair.
+   */
+  async getScope(
+    principalType: string,
+    principalId: string
+  ): Promise<any | null> {
+    const rows = await this.listMcpAccessScopes({
+      principal_type: principalType,
+      principal_id: principalId,
+    })
+    return rows?.[0] ?? null
+  }
+
+  /**
+   * Create or replace the single row for a principal. Idempotent per principal
+   * — re-scoping a credential is one call, not delete-then-create, so there is
+   * no window in which it briefly has the process ceiling instead.
+   */
+  async setScope(input: {
+    principal_type: string
+    principal_id: string
+    level: string
+    label?: string | null
+    note?: string | null
+  }): Promise<any> {
+    const existing = await this.getScope(
+      input.principal_type,
+      input.principal_id
+    )
+
+    if (existing) {
+      const [updated] = await this.updateMcpAccessScopes([
+        {
+          id: existing.id,
+          level: input.level,
+          ...(input.label !== undefined ? { label: input.label } : {}),
+          ...(input.note !== undefined ? { note: input.note } : {}),
+        },
+      ])
+      return updated
+    }
+
+    const [created] = await this.createMcpAccessScopes([
+      {
+        principal_type: input.principal_type,
+        principal_id: input.principal_id,
+        level: input.level,
+        label: input.label ?? null,
+        note: input.note ?? null,
+      },
+    ])
+    return created
+  }
+}
+
+export default McpAccessService

--- a/apps/docs/notes/ADMIN_MCP_SCOPES.md
+++ b/apps/docs/notes/ADMIN_MCP_SCOPES.md
@@ -1,0 +1,107 @@
+# Admin MCP — per-credential scopes (#1306 Track C)
+
+## What this replaces
+
+`ADMIN_MCP_ENABLE_WRITE` (default **true**) and `ADMIN_MCP_ENABLE_DANGEROUS`
+(default false) are **process-wide** env flags. Every credential that could
+reach `POST /admin/mcp` inherited whatever the process allowed, so **there was
+no read-only token** — which is what blocked opening the MCP endpoint to a
+third-party client.
+
+Those flags now set a **ceiling**. A row in `mcp_access_scope` narrows a single
+credential below it. The effective level is always `min(ceiling, row)`, so a row
+can only ever restrict; widening still requires the env flag.
+
+**Absent a row, a credential gets the ceiling** — i.e. exactly the behaviour
+that existed before. Nothing changes until someone writes a row.
+
+## The ladder
+
+| Level | Grants |
+|---|---|
+| `read` | GET tools only |
+| `write` | + ordinary mutations |
+| `sensitive` | + confirm-gated tools (every DELETE is implicitly one) |
+| `dangerous` | + platform-destructive tools (confirm **and** a human reason) |
+
+The default deployment (writes on, dangerous off) has a ceiling of
+**`sensitive`**, not `write` — confirm-gated tools have always been callable
+when writes are on, and the ceiling has to preserve that.
+
+> ⚠️ **`write` currently grants nothing beyond `read`.** Of the 69 write tools in
+> the admin registry, 59 are flagged `sensitive: true` and the other 10 are
+> DELETEs (implicitly sensitive). So a credential that needs to change anything
+> needs **`sensitive`**. `GET /admin/mcp/scopes` reports the tool count per level
+> so this is visible at the moment of choosing one, and
+> `scope-invariants.unit.spec.ts` pins it — when a genuinely non-sensitive write
+> tool lands, that test fails and the `write` rung starts meaning something.
+
+## Two enforcement points, and why both are needed
+
+1. **The MCP tool surface** (`api/admin/mcp/lib/handler.ts` → `mcp-core`) filters
+   `tools/list` and refuses at dispatch.
+2. **The HTTP layer** (`enforceMcpScopeOnAdminWrites` in `src/api/middlewares.ts`)
+   refuses non-GET `/admin/*` requests from a `read`-scoped machine credential.
+
+Without (2) the scope would be **theatre**: a Medusa secret API key
+authenticates every admin route, so a read-only token could simply POST the
+wrapped route directly. And because the MCP dispatcher reaches routes over the
+same loopback HTTP path, (2) also backstops (1).
+
+**Machine principals only.** The HTTP guard applies to `actor_type` `api-key`
+(and, later, `oauth`). A human admin holds a dashboard session and can do
+anything through the UI, so refusing their raw HTTP writes would restrict
+nothing while risking locking a real person out. A `user` row still narrows the
+MCP tool surface and the in-app assistant.
+
+### Exempt paths
+
+`MCP_SCOPE_EXEMPT_ADMIN_PATHS` (`src/lib/mcp-scope.ts`) — non-GET paths a
+read-scoped credential may still call, because they are POSTs that only read:
+
+- `/admin/mcp` — the JSON-RPC transport. **Every** tool call is a POST, reads
+  included; scope is enforced per-tool inside the dispatcher instead.
+- `/admin/mcp/resolve-query` — `resolve_admin_query`, a planner.
+- `/admin/assistant/vision` — `read_image`, POST only because the reference goes
+  in the body.
+
+An invariant test asserts every non-GET tool that isn't flagged `write` is
+listed here, so a future read-only POST tool fails the suite instead of silently
+403ing for read-only credentials.
+
+## Managing scopes
+
+```
+GET    /admin/mcp/scopes        # list + ceiling + tool count per level
+POST   /admin/mcp/scopes        # upsert { principal_type, principal_id, level, label?, note? }
+DELETE /admin/mcp/scopes/:id    # stop restricting (widens back to the ceiling)
+```
+
+**Human admins only** — all three refuse any principal that is not
+`actor_type: "user"`. A machine credential must never be able to widen its own
+scope; without that check a `write` token could POST itself up to `dangerous`.
+
+For the same reason these are **deliberately not wrapped as MCP tools**: the tool
+surface is driven by a model, and scope escalation is not something a model
+should be able to attempt.
+
+Scoping the key minted for `claude-code-mcp`:
+
+```jsonc
+POST /admin/mcp/scopes
+{ "principal_type": "api-key", "principal_id": "apk_…", "level": "read",
+  "label": "claude-code-mcp", "note": "read-only until Track B lands" }
+```
+
+`principal_id` for a Medusa secret key is the **key id** (`apk_…`), not the
+token — Medusa sets `auth_context.actor_id` to the key id.
+
+Deleting a row **widens**; it does not revoke. To take access away, revoke the
+API key in Medusa (or set the row to `read`).
+
+## Notes for Track B (OAuth)
+
+Minted tokens should carry `principal_type: "oauth"` and get an explicit row at
+issue time rather than relying on the ceiling default. `"oauth"` is already in
+`MCP_MACHINE_PRINCIPAL_TYPES`, so the HTTP guard covers it the moment
+`auth_context.actor_type` says so.


### PR DESCRIPTION
Closes the Track C checklist on #1306.

## The problem

`ADMIN_MCP_ENABLE_WRITE` (default **true**) and `ADMIN_MCP_ENABLE_DANGEROUS` are process-wide env flags, so every credential that could reach `POST /admin/mcp` inherited whatever the process allowed. **There was no read-only token** — which is what gates opening the endpoint to a third-party client.

## The shape

Those flags now set a **ceiling**. An `mcp_access_scope` row narrows one credential below it, on a ladder:

| Level | Grants |
|---|---|
| `read` | GET tools only |
| `write` | + ordinary mutations |
| `sensitive` | + confirm-gated tools (every DELETE is implicitly one) |
| `dangerous` | + platform-destructive tools (confirm **and** a human reason) |

Effective level is `min(ceiling, row)` — a row can only ever restrict, so a bad row can't turn a read-only deployment into a write one. **Absent a row, a credential gets the ceiling**, i.e. exactly today's behaviour; nothing changes until someone writes a row.

## Why two enforcement points

Scoping only the MCP tool surface would be **theatre**: a Medusa secret key authenticates every `/admin/*` route, so a read-only token could simply POST the wrapped route directly. So there is also an HTTP guard on `/admin/*`. Because the dispatcher reaches routes over the same loopback HTTP path, the guard *backstops* the tool layer rather than being a second thing that can drift.

The guard covers **machine principals only** (`api-key`, and later `oauth`). A human admin holds a dashboard session and can do anything through the UI, so refusing their raw HTTP writes would restrict nothing while risking locking a real person out; their row still narrows the MCP tool surface.

Also adds `enableSensitive` to `mcp-core` — the missing dimension. The confirm rail is not a boundary for a third party, because there **the model** supplies `confirm: true`, not a human.

## Two findings, both pinned by tests

🔥 **The `write` rung is currently empty.** Of 69 write tools, 59 are flagged `sensitive: true` and the other 10 are DELETEs (implicitly sensitive) — so a credential scoped to `write` reaches **exactly what `read` reaches**, and any real mutation needs `sensitive`. That's invisible from the ladder and it decides what a third-party token is worth, so `GET /admin/mcp/scopes` reports the tool count per level and a characterization test fails the day a genuinely non-sensitive write tool lands.

`read_image` (`POST /admin/assistant/vision`) is a read-only POST the guard would have 403'd — now exempt, with an invariant test asserting every non-GET tool is either flagged `write` or listed as exempt.

## Managing scopes

```
GET    /admin/mcp/scopes        # list + ceiling + tool count per level
POST   /admin/mcp/scopes        # upsert { principal_type, principal_id, level, label?, note? }
DELETE /admin/mcp/scopes/:id    # stop restricting (widens back to the ceiling)
```

**Human admins only**, and deliberately **not** wrapped as MCP tools: a machine credential must never be able to widen its own scope, and scope escalation is not something a model should be able to attempt.

`principal_id` for a secret key is the **key id** (`apk_…`), not the token — Medusa sets `auth_context.actor_id` to the key id.

## Verification

- Unit suite at the documented baseline: **4 suites / 5 tests failing, unchanged** (`audit-ai-platforms`, `brief-shaper`, `seed-additional-email-templates`, `build-email-data` — all reproduce on clean `main`).
- `tsc --noEmit`: **87 errors, and 87 on clean `main`** (measured by stashing). Zero added. ⚠️ The memory/handoff baseline of 75 is stale.
- ⚠️ **`check:prod-build` is already RED on `main`** — 10 errors in `payu-payment` + `stripe-connect-payment` from duplicate `@medusajs/types` versions. Identical with and without this branch.
- ❌ **Not yet verified at runtime** — no local Postgres when this was written, so the migration has not been applied and the server has not been booted. Middleware registration was verified statically instead: a method-less entry buckets as `global` in Medusa's routes sorter and globals concatenate ahead of all route handlers, so it registers as `app.use()` before them and after the framework's admin auth (which is what makes `req.auth_context` available).

Doc: `apps/docs/notes/ADMIN_MCP_SCOPES.md`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)