### PR TITLE
feat(mcp): admin settings UI for per-credential MCP scopes (#1306)

### DIFF
--- a/apps/backend/src/admin/hooks/api/mcp-scopes.ts
+++ b/apps/backend/src/admin/hooks/api/mcp-scopes.ts
@@ -1,0 +1,153 @@
+import { useMutation, useQuery, useQueryClient } from "@tanstack/react-query"
+
+import { sdk } from "../../lib/config"
+import { queryKeysFactory } from "../../lib/query-key-factory"
+
+/**
+ * Admin MCP per-credential scopes (#1306 Track C).
+ *
+ * The two env flags are a process-wide CEILING; a row here narrows ONE
+ * credential below it. Effective level is `min(ceiling, row)`, and no row means
+ * the ceiling — so deleting a row WIDENS rather than revokes.
+ */
+
+export const MCP_SCOPE_LEVELS = [
+  "read",
+  "write",
+  "sensitive",
+  "dangerous",
+] as const
+
+export type McpScopeLevel = (typeof MCP_SCOPE_LEVELS)[number]
+
+export type AdminMcpScope = {
+  id: string
+  principal_type: string
+  principal_id: string
+  level: McpScopeLevel
+  label?: string | null
+  note?: string | null
+  created_at: Date
+  updated_at: Date
+}
+
+export type AdminMcpScopeLevelCount = {
+  level: McpScopeLevel
+  tools: number
+}
+
+export type AdminMcpScopesResponse = {
+  scopes: AdminMcpScope[]
+  ceiling: McpScopeLevel
+  levels: AdminMcpScopeLevelCount[]
+}
+
+export type AdminSetMcpScopePayload = {
+  principal_type: string
+  principal_id: string
+  level: McpScopeLevel
+  label?: string | null
+  note?: string | null
+}
+
+export type AdminSetMcpScopeResponse = {
+  scope: AdminMcpScope
+  effective_level: McpScopeLevel
+  ceiling: McpScopeLevel
+  tools_visible: number
+  /** Present only when the row asks for more than the ceiling allows. */
+  warning?: string
+  tools_by_level: Record<McpScopeLevel, number>
+}
+
+const MCP_SCOPES_QUERY_KEY = "mcp_access_scopes" as const
+export const mcpScopesQueryKeys = queryKeysFactory(MCP_SCOPES_QUERY_KEY)
+
+export const useMcpScopes = () => {
+  const { data, ...rest } = useQuery({
+    queryKey: mcpScopesQueryKeys.list(),
+    queryFn: async () =>
+      sdk.client.fetch<AdminMcpScopesResponse>("/admin/mcp/scopes", {
+        method: "GET",
+      }),
+  })
+
+  return {
+    ...rest,
+    scopes: data?.scopes,
+    ceiling: data?.ceiling,
+    levels: data?.levels,
+  }
+}
+
+/**
+ * Upsert — the backend keys on (principal_type, principal_id), so re-scoping a
+ * credential is one call rather than delete-then-create. There is therefore no
+ * window in which it briefly holds the ceiling instead.
+ */
+export const useSetMcpScope = () => {
+  const queryClient = useQueryClient()
+
+  return useMutation({
+    mutationFn: async (payload: AdminSetMcpScopePayload) =>
+      sdk.client.fetch<AdminSetMcpScopeResponse>("/admin/mcp/scopes", {
+        method: "POST",
+        body: payload,
+      }),
+    onSuccess: () => {
+      // `lists()` is the PREFIX ([key, "list"]); `list()` appends a `{query}`
+      // object, so invalidating with it would miss the query above.
+      queryClient.invalidateQueries({ queryKey: mcpScopesQueryKeys.lists() })
+    },
+  })
+}
+
+export const useDeleteMcpScope = () => {
+  const queryClient = useQueryClient()
+
+  return useMutation({
+    mutationFn: async (id: string) =>
+      sdk.client.fetch<{ id: string; deleted: boolean }>(
+        `/admin/mcp/scopes/${id}`,
+        { method: "DELETE" }
+      ),
+    onSuccess: () => {
+      // `lists()` is the PREFIX ([key, "list"]); `list()` appends a `{query}`
+      // object, so invalidating with it would miss the query above.
+      queryClient.invalidateQueries({ queryKey: mcpScopesQueryKeys.lists() })
+    },
+  })
+}
+
+export type AdminSecretApiKey = {
+  id: string
+  title: string
+  type: string
+  revoked_at?: string | null
+}
+
+/**
+ * Secret API keys, for the credential picker.
+ *
+ * ⚠️ `principal_id` is the key ID (`apk_…`), never the token — a row keyed on a
+ * token silently never matches. Picking from a list removes that whole class of
+ * mistake, so the free-text field is only a fallback for `oauth`/`user`.
+ */
+export const useSecretApiKeys = (enabled: boolean) => {
+  const { data, ...rest } = useQuery({
+    queryKey: [MCP_SCOPES_QUERY_KEY, "api-keys"],
+    queryFn: async () =>
+      sdk.client.fetch<{ api_keys: AdminSecretApiKey[] }>(
+        "/admin/api-keys?limit=100",
+        { method: "GET" }
+      ),
+    enabled,
+  })
+
+  return {
+    ...rest,
+    apiKeys: (data?.api_keys || []).filter(
+      (k) => k.type === "secret" && !k.revoked_at
+    ),
+  }
+}

--- a/apps/backend/src/admin/routes/settings/mcp-scopes/page.tsx
+++ b/apps/backend/src/admin/routes/settings/mcp-scopes/page.tsx
@@ -1,0 +1,510 @@
+import { defineRouteConfig } from "@medusajs/admin-sdk"
+import {
+  Badge,
+  Button,
+  Container,
+  Drawer,
+  FocusModal,
+  Heading,
+  Input,
+  Label,
+  Select,
+  Skeleton,
+  Text,
+  Textarea,
+  toast,
+  usePrompt,
+} from "@medusajs/ui"
+import { Key } from "@medusajs/icons"
+import { useState } from "react"
+
+import {
+  MCP_SCOPE_LEVELS,
+  useDeleteMcpScope,
+  useMcpScopes,
+  useSecretApiKeys,
+  useSetMcpScope,
+  type AdminMcpScope,
+  type McpScopeLevel,
+} from "../../../hooks/api/mcp-scopes"
+
+/**
+ * Settings → MCP Access Scopes (#1306 Track C).
+ *
+ * Narrows ONE machine credential below the process-wide ceiling set by
+ * ADMIN_MCP_ENABLE_WRITE / ADMIN_MCP_ENABLE_DANGEROUS. A row can only ever
+ * restrict: the effective level is `min(ceiling, row)`, and no row means the
+ * ceiling — so removing a row WIDENS a credential rather than revoking it.
+ *
+ * The page leans on one non-obvious fact throughout: `write` currently exposes
+ * exactly what `read` does, because every admin write tool is flagged
+ * sensitive. The tool count sits next to every level so that is visible at the
+ * moment of choosing, rather than after a client starts refusing calls.
+ */
+
+const LEVEL_HINTS: Record<McpScopeLevel, string> = {
+  read: "Reads only. Every write is refused over MCP and over /admin/* HTTP.",
+  write:
+    "No different from read today — every admin write tool is flagged sensitive.",
+  sensitive: "Reads plus writes. This is the lowest level that can change data.",
+  dangerous: "Everything, including platform-destructive tools.",
+}
+
+const levelColor = (level: McpScopeLevel) =>
+  level === "read"
+    ? "grey"
+    : level === "write"
+      ? "blue"
+      : level === "sensitive"
+        ? "orange"
+        : "red"
+
+type FormState = {
+  principal_type: string
+  principal_id: string
+  level: McpScopeLevel
+  label: string
+  note: string
+}
+
+const EMPTY_FORM: FormState = {
+  principal_type: "api-key",
+  principal_id: "",
+  level: "read",
+  label: "",
+  note: "",
+}
+
+/** Shared field set — used by both the create modal and the edit drawer. */
+const ScopeFields = ({
+  form,
+  setForm,
+  toolsByLevel,
+  ceiling,
+  lockPrincipal,
+}: {
+  form: FormState
+  setForm: (next: FormState) => void
+  toolsByLevel: Record<string, number>
+  ceiling?: McpScopeLevel
+  lockPrincipal: boolean
+}) => {
+  // Only fetched for the picker, and only while the form is open.
+  const { apiKeys, isLoading: keysLoading } = useSecretApiKeys(
+    !lockPrincipal && form.principal_type === "api-key"
+  )
+
+  return (
+    <div className="flex flex-col gap-4">
+      <div className="flex flex-col gap-2">
+        <Label size="small" weight="plus">
+          Credential type
+        </Label>
+        <Select
+          value={form.principal_type}
+          onValueChange={(v) =>
+            setForm({ ...form, principal_type: v, principal_id: "" })
+          }
+          disabled={lockPrincipal}
+        >
+          <Select.Trigger>
+            <Select.Value />
+          </Select.Trigger>
+          <Select.Content>
+            <Select.Item value="api-key">Secret API key</Select.Item>
+            <Select.Item value="oauth">OAuth client</Select.Item>
+            <Select.Item value="user">Admin user</Select.Item>
+          </Select.Content>
+        </Select>
+      </div>
+
+      <div className="flex flex-col gap-2">
+        <Label size="small" weight="plus">
+          Credential
+        </Label>
+        {lockPrincipal ? (
+          <Text size="small" className="font-mono text-ui-fg-subtle">
+            {form.principal_id}
+          </Text>
+        ) : form.principal_type === "api-key" ? (
+          <>
+            {keysLoading ? (
+              <Skeleton className="h-8 w-full" />
+            ) : (
+              <Select
+                value={form.principal_id}
+                onValueChange={(v) => setForm({ ...form, principal_id: v })}
+              >
+                <Select.Trigger>
+                  <Select.Value placeholder="Select a secret API key" />
+                </Select.Trigger>
+                <Select.Content>
+                  {apiKeys.map((k) => (
+                    <Select.Item key={k.id} value={k.id}>
+                      {k.title} — {k.id}
+                    </Select.Item>
+                  ))}
+                </Select.Content>
+              </Select>
+            )}
+            <Text size="small" className="text-ui-fg-subtle">
+              Scopes key on the key ID (apk_…), never the token. Revoked keys are
+              hidden.
+            </Text>
+          </>
+        ) : (
+          <Input
+            value={form.principal_id}
+            placeholder={
+              form.principal_type === "user" ? "usr_…" : "OAuth client ID"
+            }
+            onChange={(e) => setForm({ ...form, principal_id: e.target.value })}
+          />
+        )}
+      </div>
+
+      <div className="flex flex-col gap-2">
+        <Label size="small" weight="plus">
+          Level
+        </Label>
+        <Select
+          value={form.level}
+          onValueChange={(v) => setForm({ ...form, level: v as McpScopeLevel })}
+        >
+          <Select.Trigger>
+            <Select.Value />
+          </Select.Trigger>
+          <Select.Content>
+            {MCP_SCOPE_LEVELS.map((l) => (
+              <Select.Item key={l} value={l}>
+                {l} — {toolsByLevel[l] ?? "?"} tools
+              </Select.Item>
+            ))}
+          </Select.Content>
+        </Select>
+        <Text size="small" className="text-ui-fg-subtle">
+          {LEVEL_HINTS[form.level]}
+        </Text>
+        {ceiling && MCP_SCOPE_LEVELS.indexOf(form.level) >
+          MCP_SCOPE_LEVELS.indexOf(ceiling) && (
+          <Text size="small" className="text-ui-fg-error">
+            Above the current ceiling ({ceiling}). It will be stored but clamped
+            to {ceiling} until the env flags are raised.
+          </Text>
+        )}
+      </div>
+
+      <div className="flex flex-col gap-2">
+        <Label size="small" weight="plus">
+          Label
+        </Label>
+        <Input
+          value={form.label}
+          placeholder="What this credential is for"
+          onChange={(e) => setForm({ ...form, label: e.target.value })}
+        />
+      </div>
+
+      <div className="flex flex-col gap-2">
+        <Label size="small" weight="plus">
+          Note
+        </Label>
+        <Textarea
+          rows={3}
+          value={form.note}
+          placeholder="Why it is scoped this way"
+          onChange={(e) => setForm({ ...form, note: e.target.value })}
+        />
+      </div>
+    </div>
+  )
+}
+
+const McpScopesPage = () => {
+  const prompt = usePrompt()
+  const { scopes, ceiling, levels, isLoading } = useMcpScopes()
+  const setScope = useSetMcpScope()
+  const deleteScope = useDeleteMcpScope()
+
+  const [createOpen, setCreateOpen] = useState(false)
+  const [editing, setEditing] = useState<AdminMcpScope | null>(null)
+  const [form, setForm] = useState<FormState>(EMPTY_FORM)
+
+  const toolsByLevel: Record<string, number> = {}
+  for (const l of levels || []) toolsByLevel[l.level] = l.tools
+
+  const openCreate = () => {
+    setForm(EMPTY_FORM)
+    setCreateOpen(true)
+  }
+
+  const openEdit = (scope: AdminMcpScope) => {
+    setForm({
+      principal_type: scope.principal_type,
+      principal_id: scope.principal_id,
+      level: scope.level,
+      label: scope.label || "",
+      note: scope.note || "",
+    })
+    setEditing(scope)
+  }
+
+  const save = async () => {
+    if (!form.principal_id) {
+      toast.error("Pick a credential first")
+      return
+    }
+
+    try {
+      const res = await setScope.mutateAsync({
+        principal_type: form.principal_type,
+        principal_id: form.principal_id,
+        level: form.level,
+        label: form.label || null,
+        note: form.note || null,
+      })
+
+      // The backend clamps a row above the ceiling and says so; surfacing it as
+      // a success toast would hide that the credential is not at the level just
+      // chosen.
+      if (res.warning) {
+        toast.warning(res.warning)
+      } else {
+        toast.success(
+          `Scoped to ${res.effective_level} — ${res.tools_visible} tools visible`
+        )
+      }
+
+      setCreateOpen(false)
+      setEditing(null)
+    } catch (e: any) {
+      toast.error(e?.message || "Failed to save scope")
+    }
+  }
+
+  const remove = async (scope: AdminMcpScope) => {
+    const ok = await prompt({
+      title: "Remove this scope?",
+      description:
+        `This does NOT revoke the credential — it WIDENS it back to the ` +
+        `process ceiling (${ceiling}). To take access away, revoke the API key ` +
+        `or set this row to 'read'. Continue?`,
+      confirmText: "Remove",
+      cancelText: "Cancel",
+    })
+    if (!ok) return
+
+    try {
+      await deleteScope.mutateAsync(scope.id)
+      toast.success("Scope removed — credential is back at the ceiling")
+    } catch (e: any) {
+      toast.error(e?.message || "Failed to remove scope")
+    }
+  }
+
+  return (
+    <Container className="divide-y p-0">
+      <div className="flex items-start justify-between px-6 py-4">
+        <div>
+          <Heading>MCP Access Scopes</Heading>
+          <Text className="text-ui-fg-subtle" size="small">
+            Restrict what a single machine credential can reach over MCP and the
+            Admin API. A scope can only narrow — never widen — what the
+            environment already allows.
+          </Text>
+        </div>
+        <Button size="small" onClick={openCreate}>
+          Scope a credential
+        </Button>
+      </div>
+
+      <div className="flex flex-wrap items-center gap-x-6 gap-y-2 px-6 py-4">
+        <div className="flex items-center gap-2">
+          <Text size="small" weight="plus">
+            Ceiling
+          </Text>
+          {isLoading || !ceiling ? (
+            <Skeleton className="h-5 w-20" />
+          ) : (
+            <Badge size="2xsmall" color={levelColor(ceiling)}>
+              {ceiling}
+            </Badge>
+          )}
+        </div>
+        {(levels || []).map((l) => (
+          <div key={l.level} className="flex items-center gap-2">
+            <Text size="small" className="text-ui-fg-subtle">
+              {l.level}
+            </Text>
+            <Text size="small" weight="plus">
+              {l.tools} tools
+            </Text>
+          </div>
+        ))}
+      </div>
+
+      {toolsByLevel.write === toolsByLevel.read && (
+        <div className="px-6 py-4">
+          <Text size="small" className="text-ui-fg-subtle">
+            <span className="text-ui-fg-base">Note:</span> `write` exposes
+            exactly what `read` does, because every admin write tool is flagged
+            sensitive. A credential that must change anything needs{" "}
+            <span className="text-ui-fg-base">sensitive</span>.
+          </Text>
+        </div>
+      )}
+
+      <div className="px-6 py-4">
+        {isLoading ? (
+          <div className="flex flex-col gap-2">
+            <Skeleton className="h-12 w-full" />
+            <Skeleton className="h-12 w-full" />
+          </div>
+        ) : !scopes?.length ? (
+          <Text size="small" className="text-ui-fg-subtle">
+            No scoped credentials. Every credential runs at the ceiling (
+            {ceiling}).
+          </Text>
+        ) : (
+          <div className="flex flex-col gap-2">
+            {scopes.map((s) => (
+              <div
+                key={s.id}
+                data-testid={`mcp-scope-row-${s.principal_id}`}
+                className="flex items-center justify-between rounded-lg border border-ui-border-base px-4 py-3"
+              >
+                <div className="flex flex-col gap-1">
+                  <div className="flex items-center gap-2">
+                    <Text size="small" weight="plus">
+                      {s.label || s.principal_id}
+                    </Text>
+                    <Badge size="2xsmall" color={levelColor(s.level)}>
+                      {s.level}
+                    </Badge>
+                    <Text size="small" className="text-ui-fg-subtle">
+                      {toolsByLevel[s.level] ?? "?"} tools
+                    </Text>
+                  </div>
+                  <Text
+                    size="small"
+                    className="font-mono text-ui-fg-subtle"
+                    leading="compact"
+                  >
+                    {s.principal_type} · {s.principal_id}
+                  </Text>
+                  {s.note && (
+                    <Text
+                      size="small"
+                      className="text-ui-fg-subtle"
+                      leading="compact"
+                    >
+                      {s.note}
+                    </Text>
+                  )}
+                </div>
+                <div className="flex items-center gap-2">
+                  <Button
+                    size="small"
+                    variant="secondary"
+                    onClick={() => openEdit(s)}
+                  >
+                    Edit
+                  </Button>
+                  <Button
+                    size="small"
+                    variant="danger"
+                    disabled={deleteScope.isPending}
+                    onClick={() => remove(s)}
+                  >
+                    Remove
+                  </Button>
+                </div>
+              </div>
+            ))}
+          </div>
+        )}
+      </div>
+
+      {/* Create → FocusModal */}
+      <FocusModal open={createOpen} onOpenChange={setCreateOpen}>
+        <FocusModal.Content>
+          <FocusModal.Header>
+            <Heading>Scope a credential</Heading>
+          </FocusModal.Header>
+          <FocusModal.Body className="flex flex-col overflow-y-auto p-6">
+            <ScopeFields
+              form={form}
+              setForm={setForm}
+              toolsByLevel={toolsByLevel}
+              ceiling={ceiling}
+              lockPrincipal={false}
+            />
+          </FocusModal.Body>
+          <FocusModal.Footer>
+            <Button
+              size="small"
+              variant="secondary"
+              onClick={() => setCreateOpen(false)}
+            >
+              Cancel
+            </Button>
+            <Button
+              size="small"
+              onClick={save}
+              disabled={setScope.isPending}
+              isLoading={setScope.isPending}
+            >
+              Save
+            </Button>
+          </FocusModal.Footer>
+        </FocusModal.Content>
+      </FocusModal>
+
+      {/* Edit → Drawer */}
+      <Drawer open={!!editing} onOpenChange={(o) => !o && setEditing(null)}>
+        <Drawer.Content>
+          <Drawer.Header>
+            <Heading>Edit scope</Heading>
+          </Drawer.Header>
+          <Drawer.Body className="flex flex-col overflow-y-auto p-4">
+            <ScopeFields
+              form={form}
+              setForm={setForm}
+              toolsByLevel={toolsByLevel}
+              ceiling={ceiling}
+              lockPrincipal
+            />
+          </Drawer.Body>
+          <Drawer.Footer>
+            <Button
+              size="small"
+              variant="secondary"
+              onClick={() => setEditing(null)}
+            >
+              Cancel
+            </Button>
+            <Button
+              size="small"
+              onClick={save}
+              disabled={setScope.isPending}
+              isLoading={setScope.isPending}
+            >
+              Save
+            </Button>
+          </Drawer.Footer>
+        </Drawer.Content>
+      </Drawer>
+    </Container>
+  )
+}
+
+export default McpScopesPage
+
+export const config = defineRouteConfig({
+  label: "MCP Access Scopes",
+  icon: Key,
+})
+
+export const handle = {
+  breadcrumb: () => "MCP Access Scopes",
+}

--- a/apps/docs/notes/ADMIN_MCP_SCOPES.md
+++ b/apps/docs/notes/ADMIN_MCP_SCOPES.md
@@ -71,6 +71,11 @@ listed here, so a future read-only POST tool fails the suite instead of silently
 
 ## Managing scopes
 
+**Settings → MCP Access Scopes** in the admin dashboard is the normal way in.
+For the step-by-step — including how to authenticate as a human admin, and the
+403-vs-400 probe that proves a scope is actually enforced — see
+[`ADMIN_MCP_SCOPES_OPERATOR_GUIDE.md`](./ADMIN_MCP_SCOPES_OPERATOR_GUIDE.md).
+
 ```
 GET    /admin/mcp/scopes        # list + ceiling + tool count per level
 POST   /admin/mcp/scopes        # upsert { principal_type, principal_id, level, label?, note? }

--- a/apps/docs/notes/ADMIN_MCP_SCOPES_OPERATOR_GUIDE.md
+++ b/apps/docs/notes/ADMIN_MCP_SCOPES_OPERATOR_GUIDE.md
@@ -1,0 +1,161 @@
+# Admin MCP scopes — operator guide
+
+How to hand someone a restricted credential, and how to prove the restriction is
+real. The design rationale lives in [`ADMIN_MCP_SCOPES.md`](./ADMIN_MCP_SCOPES.md);
+this is the doing.
+
+Everything below was measured against **prod** on 2026-08-15, on `main` @
+`583bc44c7` (deploy run `31881352146`).
+
+---
+
+## 1. The one-paragraph model
+
+Two env flags (`ADMIN_MCP_ENABLE_WRITE`, `ADMIN_MCP_ENABLE_DANGEROUS`) set a
+process-wide **ceiling**. A row in `mcp_access_scope` narrows **one** credential
+below that ceiling. Effective level is `min(ceiling, row)`, and **no row means
+the ceiling** — so scopes are opt-in, and *removing* a row widens a credential
+rather than revoking it.
+
+Ladder: `read → write → sensitive → dangerous`.
+
+---
+
+## 2. Do it in the UI
+
+**Settings → MCP Access Scopes.**
+
+- The header shows the current **ceiling** and how many tools each level exposes.
+- **Scope a credential** → pick a secret API key from the list, choose a level,
+  save.
+- **Edit** changes the level of an existing row; **Remove** widens it back to the
+  ceiling (the confirm dialog says so, because "remove" reads like "revoke" and
+  it is not).
+
+The credential picker lists secret API keys by ID on purpose — see the
+`principal_id` trap in §5.
+
+## 3. Or do it over HTTP
+
+```
+GET    /admin/mcp/scopes        # rows + ceiling + tool count per level
+POST   /admin/mcp/scopes        # upsert { principal_type, principal_id, level, label?, note? }
+DELETE /admin/mcp/scopes/:id    # stop restricting (widens to the ceiling)
+```
+
+```jsonc
+POST /admin/mcp/scopes
+{ "principal_type": "api-key", "principal_id": "apk_…", "level": "read",
+  "label": "claude-code-mcp", "note": "read-only until Track B lands" }
+```
+
+---
+
+## 4. ⚠️ Only a signed-in admin USER can manage scopes
+
+All three routes refuse anything that is not `actor_type: "user"`. **A secret API
+key can never write a scope row**, no matter which mount or header you use — a
+machine credential widening its own scope would defeat the whole mechanism.
+
+This costs people real time, so here is the proof it is the credential *class*
+and not a misconfiguration. The same `sk_…` token:
+
+| Sent as | Route | Result |
+|---|---|---|
+| `Basic` (`-u "$TOKEN:"`) | `/admin/mcp` | 200 |
+| `Basic` | `/admin/mcp/scopes` (GET **and** POST) | **403** |
+| `Bearer` | `/admin/mcp/scopes` | **401** |
+
+401-as-Bearer plus 200-as-Basic means it is a secret key, not a JWT, so Medusa
+stamps `actor_type: "api-key"` and the guard rejects it. Get a real session
+instead:
+
+```bash
+# 1. log in as a human admin → {"token": "<jwt>"}
+curl -s -X POST https://v3.jaalyantra.com/auth/user/emailpass \
+  -H "Content-Type: application/json" -d @login.json > ptok.json
+
+# 2. turn it into a curl config (avoids inline secret substitution)
+sed -e 's/{"token":"/header = "Authorization: Bearer /' -e 's/"}[[:space:]]*$/"/' \
+  ptok.json > pjwtrc
+
+# 3. use it
+curl -s -K pjwtrc https://v3.jaalyantra.com/admin/mcp/scopes
+```
+
+`GET /admin/mcp/scopes` as a human admin is also the **cheapest check that the
+migration landed** — it reads `mcp_access_scope` directly, so a 200 settles it.
+
+---
+
+## 5. ⚠️ `principal_id` is the key ID, not the token
+
+For a Medusa secret key it is the `apk_…` **key ID**, because that is what
+Medusa puts in `auth_context.actor_id`. A row keyed on the token is not an
+error — it simply never matches, and the credential silently keeps running at
+the ceiling. The UI picker exists to remove this failure mode.
+
+---
+
+## 6. Verify it actually bites
+
+Do not stop at "the row saved". Two probes, and **run them against a second,
+unscoped credential at the same time** — that control is what shows the row is
+per-credential rather than a global flag flip:
+
+```bash
+# A. tool surface
+curl -s -K <cred>rc -X POST https://v3.jaalyantra.com/admin/mcp \
+  -H "Content-Type: application/json" \
+  -H "Accept: application/json, text/event-stream" \
+  -d '{"jsonrpc":"2.0","id":1,"method":"tools/list"}' | jq '.result.tools|length'
+
+# B. HTTP guard — empty body, writes nothing either way
+curl -s -o /dev/null -w "%{http_code}\n" -K <cred>rc \
+  -X POST https://v3.jaalyantra.com/admin/products \
+  -H "Content-Type: application/json" -d '{}'
+```
+
+Measured on prod, with `ceiling = dangerous`:
+
+| | scoped to `read` | unscoped |
+|---|---|---|
+| `tools/list` | **54** | 123 |
+| `POST /admin/products {}` | **403** | **400** |
+
+🔑 **The 403-vs-400 pair is the whole proof.** `400` means the guard did *not*
+fire and the empty body was merely rejected by validation; `403` means it did.
+Neither writes anything, which is what makes this safe to run against prod.
+
+---
+
+## 7. Gotchas learned the hard way
+
+- **`write` grants nothing today.** Measured: `read 54 · write 54 ·
+  sensitive 117 · dangerous 123`. Every admin write tool is flagged sensitive,
+  so a credential scoped to `write` reaches **exactly** what `read` reaches, and
+  anything that mutates needs `sensitive`. This is why the UI prints a tool count
+  next to every level: the ladder alone makes `write` look useful.
+- **Removing a row widens.** It is "stop restricting", not "block". To take
+  access away, revoke the API key in Medusa, or set the row to `read`.
+- **A row above the ceiling is stored but clamped.** The API returns a `warning`
+  and the UI surfaces it as a warning toast rather than a success — otherwise the
+  credential looks like it is at a level it is not.
+- **Scoping a credential restricts it everywhere, not just MCP.** The HTTP guard
+  covers all of `/admin/*` for machine principals, because a secret key
+  authenticates every admin route — scoping only the tool list would be theatre.
+  So check what else uses a key before scoping it.
+- **A missing `mcp_access_scope` table 500s the whole MCP surface**, and only for
+  requests where a principal resolves. `loadMcpScopeLevel` catches a missing
+  *module* but not a failing *query*.
+
+---
+
+## 8. What is NOT covered
+
+**Partner MCP has no scopes.** `/partners/mcp` is gated only by the process-wide
+`PARTNER_MCP_ENABLE_WRITE` flag — there is no per-credential ladder, no
+`mcp_access_scope` equivalent, and no partner secret-key model at all
+(`/partners/api-keys` is publishable-only). Partners authenticate with session or
+bearer partner JWTs. Giving partners their own scoped MCP credentials is
+unstarted work, not a configuration step.

--- a/e2e/specs/mcp-access-scopes.spec.ts
+++ b/e2e/specs/mcp-access-scopes.spec.ts
@@ -1,0 +1,229 @@
+import { test, expect } from "@playwright/test"
+import * as fs from "fs"
+import * as path from "path"
+
+/**
+ * Settings → MCP Access Scopes (#1306 Track C).
+ *
+ * Drives the scope UI against the live server so three things are proven that
+ * unit tests can't:
+ *
+ *  1. The page is actually MOUNTED at /app/settings/mcp-scopes and renders the
+ *     ceiling + per-level tool counts it reads from the backend.
+ *  2. A row written through the UI actually NARROWS the credential — asserted
+ *     against the key's own token, not by re-reading the row we just wrote.
+ *     A row that saves but doesn't bite is the failure mode worth catching.
+ *  3. Removing the row WIDENS it back to the ceiling. "Remove" reads like
+ *     "revoke" and is not, so the behaviour is pinned here deliberately.
+ *
+ * The enforcement assertions use the `request` fixture rather than
+ * `page.request`: the latter shares the browser's admin session cookie, which
+ * would authenticate as the human admin and bypass the machine-principal guard
+ * entirely — the test would pass while proving nothing.
+ *
+ * 🔑 The write probe sends an EMPTY body to /admin/products. 403 means the
+ * scope guard fired; 400 means it did not and validation merely rejected the
+ * body. Neither writes anything, so this is safe to run repeatedly.
+ *
+ * Runs on CI: admin-only, no partner-UI server and no live LLM.
+ */
+
+const SEED_FILE = path.resolve(__dirname, "../../apps/backend/.e2e-seed.json")
+
+type Seed = {
+  email: string
+  password: string
+}
+
+let seed: Seed
+
+/** Basic base64("<token>:") — how Medusa authenticates a secret API key. */
+const basicAuth = (token: string) =>
+  `Basic ${Buffer.from(`${token}:`).toString("base64")}`
+
+test.describe("Settings → MCP Access Scopes", () => {
+  test.beforeAll(() => {
+    if (!fs.existsSync(SEED_FILE)) {
+      throw new Error(
+        `E2E seed file not found at ${SEED_FILE}. Run "pnpm e2e:seed" first.`
+      )
+    }
+    seed = JSON.parse(fs.readFileSync(SEED_FILE, "utf-8"))
+  })
+
+  test.beforeEach(async ({ page }) => {
+    await page.goto("/app/login")
+    await page.waitForLoadState("networkidle")
+    await page.locator('input[name="email"]').fill(seed.email)
+    await page.locator('input[name="password"]').fill(seed.password)
+    await page.locator('button[type="submit"]').click()
+    await page.waitForURL(/\/app\/(?!login)/, { timeout: 15_000 })
+  })
+
+  test("scopes a credential to read, enforces it, then widens it back", async ({
+    page,
+    request,
+  }) => {
+    // --- 1. A throwaway secret key to scope --------------------------------
+    const title = `e2e-mcp-scope-${Date.now()}`
+    const createKey = await page.request.post("/admin/api-keys", {
+      data: { title, type: "secret" },
+    })
+    expect(createKey.status(), "api-keys route must be mounted").toBe(200)
+    const { api_key: apiKey } = await createKey.json()
+    const keyId: string = apiKey.id
+    const keyToken: string = apiKey.token
+    expect(keyId).toMatch(/^apk_/)
+
+    // --- 2. Baseline: ceiling + per-level counts ---------------------------
+    const scopesRes = await page.request.get("/admin/mcp/scopes")
+    expect(scopesRes.status(), "scopes route must be mounted").toBe(200)
+    const scopesBody = await scopesRes.json()
+    const ceiling: string = scopesBody.ceiling
+    const counts: Record<string, number> = {}
+    for (const l of scopesBody.levels) counts[l.level] = l.tools
+
+    expect(counts.read).toBeGreaterThan(0)
+    expect(
+      counts[ceiling],
+      "the ceiling must expose at least as many tools as read"
+    ).toBeGreaterThanOrEqual(counts.read)
+
+    try {
+      // --- 3. The page renders what it read --------------------------------
+      await page.goto("/app/settings/mcp-scopes")
+      await expect(
+        page.getByRole("heading", { name: "MCP Access Scopes" })
+      ).toBeVisible()
+      // The ceiling badge and the per-level tool counts both come from the
+      // backend, so seeing them proves the page is wired, not just mounted.
+      await expect(page.getByText(ceiling, { exact: true }).first()).toBeVisible()
+      await expect(
+        page.getByText(`${counts.read} tools`).first()
+      ).toBeVisible()
+
+      // --- 4. Scope it to `read` through the UI ----------------------------
+      await page.getByRole("button", { name: "Scope a credential" }).click()
+
+      // Credential picker — Medusa's Select renders options in a portal.
+      await page.getByText("Select a secret API key").click()
+      await page.getByRole("option", { name: new RegExp(keyId) }).click()
+
+      // Level defaults to `read`; assert rather than assume, since the default
+      // is what most operators will accept.
+      await expect(
+        page.getByRole("option", { name: /^read/ }).or(page.getByText(/^read —/))
+      ).toBeTruthy()
+
+      await page.getByRole("button", { name: "Save" }).click()
+
+      // The row is listed, keyed on the key ID (never the token). Scope every
+      // later assertion to THIS row — other scope rows may exist, and a
+      // `.first()` would act on someone else's.
+      const row = page.getByTestId(`mcp-scope-row-${keyId}`)
+      await expect(row).toBeVisible({ timeout: 15_000 })
+
+      // --- 5. It actually bites, judged by the credential itself -----------
+      const auth = { Authorization: basicAuth(keyToken) }
+
+      const listRes = await request.post("/admin/mcp", {
+        headers: {
+          ...auth,
+          "Content-Type": "application/json",
+          Accept: "application/json, text/event-stream",
+        },
+        data: { jsonrpc: "2.0", id: 1, method: "tools/list" },
+      })
+      expect(listRes.status()).toBe(200)
+      const listBody = await listRes.json()
+      expect(
+        listBody.result.tools.length,
+        "a read-scoped key must see exactly the read tool count"
+      ).toBe(counts.read)
+
+      // Empty-body write probe: 403 = guard fired, 400 = it didn't.
+      const writeRes = await request.post("/admin/products", {
+        headers: { ...auth, "Content-Type": "application/json" },
+        data: {},
+      })
+      expect(
+        writeRes.status(),
+        "read-scoped key must be refused by the HTTP guard (403), not merely fail validation (400)"
+      ).toBe(403)
+
+      // --- 6. Removing the row WIDENS, it does not revoke ------------------
+      await row.getByRole("button", { name: "Remove" }).click()
+      // usePrompt renders a Radix alert dialog. Scope the confirm to it — a
+      // bare `.last()` also matches the row's own Remove button, and clicking
+      // it while the dialog animates in fails the stability check.
+      const confirmDialog = page.getByRole("alertdialog")
+      await expect(confirmDialog).toBeVisible()
+      await confirmDialog.getByRole("button", { name: "Remove" }).click()
+      await expect(row).toHaveCount(0, { timeout: 15_000 })
+
+      const afterRes = await request.post("/admin/mcp", {
+        headers: {
+          ...auth,
+          "Content-Type": "application/json",
+          Accept: "application/json, text/event-stream",
+        },
+        data: { jsonrpc: "2.0", id: 2, method: "tools/list" },
+      })
+      const afterBody = await afterRes.json()
+      expect(
+        afterBody.result.tools.length,
+        "removing a scope must widen the credential back to the ceiling"
+      ).toBe(counts[ceiling])
+    } finally {
+      // Drop the scope row too. A failed run that leaves one behind makes the
+      // NEXT run act on a stale row instead of its own — which is exactly how
+      // this spec first went wrong.
+      try {
+        const res = await page.request.get("/admin/mcp/scopes")
+        const body = await res.json()
+        const mine = (body.scopes || []).find(
+          (s: any) => s.principal_id === keyId
+        )
+        if (mine) {
+          await page.request.delete(`/admin/mcp/scopes/${mine.id}`)
+        }
+      } catch {
+        // best-effort
+      }
+
+      // Always revoke — a live unrestricted secret key left behind by a test
+      // run is worse than a failing test.
+      await page.request.post(`/admin/api-keys/${keyId}/revoke`).catch(() => {})
+      await page.request.delete(`/admin/api-keys/${keyId}`).catch(() => {})
+    }
+  })
+
+  test("refuses to manage scopes with a machine credential", async ({
+    page,
+    request,
+  }) => {
+    const title = `e2e-mcp-guard-${Date.now()}`
+    const createKey = await page.request.post("/admin/api-keys", {
+      data: { title, type: "secret" },
+    })
+    const { api_key: apiKey } = await createKey.json()
+
+    try {
+      // The scope routes are human-admin-only: a secret key authenticates every
+      // other /admin/* route, so without this check a machine credential could
+      // POST itself up to the ceiling.
+      const res = await request.get("/admin/mcp/scopes", {
+        headers: { Authorization: basicAuth(apiKey.token) },
+      })
+      expect(
+        res.status(),
+        "a secret API key must never be able to read or change scopes"
+      ).toBe(403)
+    } finally {
+      await page.request
+        .post(`/admin/api-keys/${apiKey.id}/revoke`)
+        .catch(() => {})
+      await page.request.delete(`/admin/api-keys/${apiKey.id}`).catch(() => {})
+    }
+  })
+})


### PR DESCRIPTION
Follow-up to #1308 (Track C), which shipped the scope ladder as API-only.

## Why

The only way to restrict a credential was curl — and `/admin/mcp/scopes`
refuses every machine credential by design, which reads as "broken" rather
than "guarded" until you know that only an `actor_type: "user"` may manage
scopes. This puts it in the dashboard and writes down the rest.

## What

**Settings → MCP Access Scopes** (`src/admin/routes/settings/mcp-scopes/` +
`hooks/api/mcp-scopes.ts`), following the existing settings-page convention.

Three details are deliberate, each from a trap hit while verifying Track C on
prod:

- **Tool count next to every level.** `write` exposes exactly what `read` does
  (`read 54 · write 54 · sensitive 117 · dangerous 123`) because every admin
  write tool is flagged sensitive. The ladder alone makes `write` look useful
  when it grants nothing.
- **Credential picker lists secret keys by ID.** `principal_id` must be the
  `apk_…` key ID; a row keyed on the token is not an error — it never matches,
  and the credential silently keeps running at the ceiling.
- **Remove is worded as "widens back to the ceiling", not "revokes"**, with the
  ceiling named in the confirm dialog.

A row above the ceiling surfaces the backend's `warning` as a warning toast
rather than a success, so a clamped row cannot read as applied.

Plus `apps/docs/notes/ADMIN_MCP_SCOPES_OPERATOR_GUIDE.md` (cross-linked from
the existing design doc) covering the human-admin auth requirement, the
`principal_id` trap, the verification probes, and §8 noting partner MCP has no
scope equivalent.

## Verification

Prod (`583bc44c7`), first scope row ever written, with a same-moment control:

| | scoped to `read` | unscoped control |
|---|---|---|
| `tools/list` | **54** | 123 |
| `POST /admin/products {}` | **403** | **400** |

🔑 The 403-vs-400 pair is the proof: 400 means the guard did *not* fire and
validation merely rejected the empty body. Neither writes anything.

New e2e spec (`e2e/specs/mcp-access-scopes.spec.ts`) encodes exactly that, and
judges enforcement by the scoped key's **own token** rather than by re-reading
the row it just wrote — it uses the `request` fixture, not `page.request`,
because the latter carries the admin session cookie and would bypass the
machine-principal guard entirely while still passing.

- `pnpm exec playwright test mcp-access-scopes` — **2 passed**, run twice, zero
  rows left behind.
- `tsc --noEmit` — no errors in the new files (`include: ["**/*"]` covers
  `src/admin`).
- All 14 `@medusajs/ui` imports and the `Key` icon verified to exist.

⚠️ E2E runs on this PR (it touches `apps/backend/src/admin/**`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
