### PR TITLE
feat(mcp): make the `write` scope rung real, and enforce tiers per route (#1306)

### DIFF
--- a/apps/backend/src/api/admin/mcp/lib/__tests__/tool-tiers.unit.spec.ts
+++ b/apps/backend/src/api/admin/mcp/lib/__tests__/tool-tiers.unit.spec.ts
@@ -1,0 +1,148 @@
+/**
+ * Tier invariants for the admin MCP surface (#1306).
+ *
+ * The point of these is that a registry edit is the ONLY thing that can change
+ * what a scoped credential reaches, and a registry edit is one line. So the
+ * dangerous rails, the confirm gate and the shape of the ladder are asserted
+ * here rather than left to review.
+ */
+import { ADMIN_MCP_TOOLS } from "../registry"
+import { adminRouteTier, UNCLASSIFIED_ADMIN_ROUTE_TIER } from "../route-tier"
+import {
+  MCP_SCOPE_LEVELS,
+  mcpScopeAllows,
+  mcpToolTier,
+} from "../../../../../lib/mcp-core/tiers"
+import { isSensitive } from "../../../../../lib/mcp-core"
+import type { McpScopeLevel } from "../../../../../lib/mcp-core/tiers"
+
+const toolsAt = (level: McpScopeLevel) =>
+  ADMIN_MCP_TOOLS.filter((t) => mcpScopeAllows(level, mcpToolTier(t)))
+
+describe("admin MCP tool tiers", () => {
+  it("gives the `write` rung more than `read` — the whole reason it exists", () => {
+    const read = toolsAt("read").length
+    const write = toolsAt("write").length
+    // Before the tier axis these were equal (54 and 54), which made `write` a
+    // rung an operator could select and get nothing from.
+    expect(write).toBeGreaterThan(read)
+  })
+
+  it("keeps the ladder monotonic", () => {
+    const counts = MCP_SCOPE_LEVELS.map((l) => toolsAt(l).length)
+    for (let i = 1; i < counts.length; i++) {
+      expect(counts[i]).toBeGreaterThanOrEqual(counts[i - 1])
+    }
+    // Every tool is reachable at the top of the ladder.
+    expect(counts[counts.length - 1]).toBe(ADMIN_MCP_TOOLS.length)
+  })
+
+  it("never lets a read-scoped credential reach a mutation", () => {
+    const leaked = toolsAt("read").filter(
+      (t) => t.write || t.method === "DELETE"
+    )
+    expect(leaked.map((t) => t.name)).toEqual([])
+  })
+
+  it("never demotes a dangerous tool, whatever the registry says", () => {
+    for (const t of ADMIN_MCP_TOOLS.filter((t) => t.dangerous)) {
+      expect(mcpToolTier(t)).toBe("dangerous")
+    }
+    // Even an explicit attempt to demote one is ignored.
+    expect(
+      mcpToolTier({
+        name: "x",
+        description: "",
+        inputSchema: {},
+        method: "POST",
+        path: "/admin/x",
+        write: true,
+        dangerous: true,
+        tier: "write",
+      })
+    ).toBe("dangerous")
+  })
+
+  it("leaves the confirm gate alone — a write-tier tool is still sensitive", () => {
+    const writeTier = ADMIN_MCP_TOOLS.filter(
+      (t) => mcpToolTier(t) === "write" && t.write
+    )
+    expect(writeTier.length).toBeGreaterThan(0)
+    // Demoting for SCOPE must not have demoted for CONFIRM: these tools still
+    // require confirm:true, they are merely reachable by a write-scoped token.
+    for (const t of writeTier) {
+      expect(isSensitive(t)).toBe(true)
+    }
+  })
+
+  it("only demotes tools with no money, no carrier and no third-party message", () => {
+    // Locked deliberately. Adding a name here is a permission decision, so it
+    // should be a visible line in a diff rather than a quiet registry edit.
+    expect(
+      ADMIN_MCP_TOOLS.filter((t) => t.tier === "write")
+        .map((t) => t.name)
+        .sort()
+    ).toEqual(
+      [
+        "add_design_construction_detail",
+        "add_inventory_raw_material",
+        "create_design",
+        "create_raw_material_group",
+        "link_design_inventory",
+        "link_design_material_group",
+        "update_design",
+        "update_design_brief",
+        "update_design_task",
+      ].sort()
+    )
+  })
+})
+
+describe("adminRouteTier — the HTTP half of the same rule", () => {
+  it("agrees with the tool surface for every wrapped mutation", () => {
+    // The guard and `tools/list` must never disagree: a route reachable over
+    // HTTP but not through its own tool (or the reverse) is the drift this
+    // whole mechanism exists to prevent.
+    for (const t of ADMIN_MCP_TOOLS) {
+      if (t.native || !t.path || (t.method || "GET") === "GET") continue
+      if (t.path.includes("?")) continue
+      const concrete = t.path.replace(/:[A-Za-z0-9_]+/g, "sample-id")
+      const required = adminRouteTier(t.method!, concrete)
+      // The route may require MORE than this tool (another tool can wrap the
+      // same path more strictly) but never less.
+      expect(mcpScopeAllows(required, mcpToolTier(t))).toBe(true)
+    }
+  })
+
+  it("fails shut on a mutation no tool classifies", () => {
+    expect(adminRouteTier("POST", "/admin/some-route-nobody-wrapped")).toBe(
+      UNCLASSIFIED_ADMIN_ROUTE_TIER
+    )
+    // …and that default is strong enough to stop a write-scoped credential.
+    expect(
+      mcpScopeAllows("write", adminRouteTier("POST", "/admin/unwrapped"))
+    ).toBe(false)
+  })
+
+  it("keeps a write-scoped credential off the routes that spend money", () => {
+    // The concrete hole this closes: before per-route tiers, ANY write-scoped
+    // credential passed the HTTP guard for every admin mutation, including the
+    // ones its MCP tool surface refused.
+    const label = ADMIN_MCP_TOOLS.find(
+      (t) => t.name === "create_order_shipping_label"
+    )!
+    const path = label.path!.replace(/:[A-Za-z0-9_]+/g, "sample-id")
+    expect(mcpScopeAllows("write", adminRouteTier(label.method!, path))).toBe(
+      false
+    )
+    expect(
+      mcpScopeAllows("sensitive", adminRouteTier(label.method!, path))
+    ).toBe(true)
+  })
+
+  it("does not let a path param swallow a separator", () => {
+    // `/admin/designs/:id` must not match `/admin/designs/a/tasks/b`.
+    const deep = adminRouteTier("POST", "/admin/designs/a/b/c/d/e")
+    expect(deep).toBe(UNCLASSIFIED_ADMIN_ROUTE_TIER)
+  })
+})

--- a/apps/backend/src/api/admin/mcp/lib/handler.ts
+++ b/apps/backend/src/api/admin/mcp/lib/handler.ts
@@ -31,11 +31,12 @@ import {
   envFlagDefaultFalse,
 } from "../../../../lib/mcp-core"
 import { makeMcpLedgerSink } from "../../../../lib/mcp-ledger"
-import { isDangerous, isSensitive } from "../../../../lib/mcp-core"
 import {
   MCP_SCOPE_LEVELS,
   mcpCeilingLevel,
+  mcpScopeAllows,
   mcpScopeToContextFlags,
+  mcpToolTier,
   resolveMcpScope,
   type McpScopeLevel,
   type ResolvedMcpScope,
@@ -82,24 +83,19 @@ export function adminMcpCeiling(): McpScopeLevel {
 }
 
 /**
- * How many tools each level actually exposes, using the same filter the server
- * applies to `tools/list`.
+ * How many tools each level actually exposes, using the same tier comparison
+ * the server applies to `tools/list`.
  *
- * Surfaced by `/admin/mcp/scopes` because the ladder alone hides something an
- * operator needs to see: every admin write tool is currently `sensitive`, so
- * scoping a credential to `write` exposes exactly what `read` does. A number
- * next to the level makes that obvious at the moment of choosing it, instead of
- * after the third-party client starts refusing every call.
+ * Surfaced by `/admin/mcp/scopes` so an operator sees what a rung is worth at
+ * the moment of choosing it, rather than after the third-party client starts
+ * refusing calls. It existed because `write` used to expose exactly what `read`
+ * did; now that the rung is real the number is what proves it.
  */
 export function adminToolCountsByLevel(): Record<McpScopeLevel, number> {
   const counts = {} as Record<McpScopeLevel, number>
   for (const level of MCP_SCOPE_LEVELS) {
-    const f = mcpScopeToContextFlags(level)
-    counts[level] = ADMIN_MCP_TOOLS.filter(
-      (t) =>
-        (f.enableWrite || !t.write) &&
-        (f.enableDangerous || !isDangerous(t)) &&
-        (f.enableSensitive || !isSensitive(t))
+    counts[level] = ADMIN_MCP_TOOLS.filter((t) =>
+      mcpScopeAllows(level, mcpToolTier(t))
     ).length
   }
   return counts
@@ -123,7 +119,12 @@ export function buildAdminMcpServer(
       baseUrl: resolveAdminBaseUrl(req),
       bearer: req.get("authorization") || undefined,
       cookie: req.get("cookie") || undefined,
+      // Both, deliberately. `scopeLevel` is what the server and dispatcher act
+      // on (per-tool tiers); the three flags are kept in sync for anything that
+      // still reads them — notably the `writesRequireKey` guidance text — so the
+      // two can never describe different permissions.
       ...mcpScopeToContextFlags(level),
+      scopeLevel: level,
       surface: "admin",
       observe: makeMcpLedgerSink(req.scope, {
         id: actorId ?? null,

--- a/apps/backend/src/api/admin/mcp/lib/registry.ts
+++ b/apps/backend/src/api/admin/mcp/lib/registry.ts
@@ -2098,6 +2098,7 @@ export const ADMIN_MCP_TOOLS: AdminMcpToolDef[] = [
     path: "/admin/designs",
     write: true,
     sensitive: true,
+    tier: "write",
     bodyParams: [
       "name",
       "description",
@@ -2180,6 +2181,7 @@ export const ADMIN_MCP_TOOLS: AdminMcpToolDef[] = [
     previewPath: "/admin/designs/:id",
     write: true,
     sensitive: true,
+    tier: "write",
     bodyParams: [
       "name",
       "description",
@@ -2455,6 +2457,7 @@ export const ADMIN_MCP_TOOLS: AdminMcpToolDef[] = [
     previewPath: "/admin/designs/:id/tasks/:taskId",
     write: true,
     sensitive: true,
+    tier: "write",
     bodyParams: [
       "title",
       "description",
@@ -2599,6 +2602,7 @@ export const ADMIN_MCP_TOOLS: AdminMcpToolDef[] = [
     previewPath: "/admin/inventory-items/:id",
     write: true,
     sensitive: true,
+    tier: "write",
     bodyParams: ["rawMaterialData"],
     inputSchema: obj(
       {
@@ -2629,6 +2633,7 @@ export const ADMIN_MCP_TOOLS: AdminMcpToolDef[] = [
     path: "/admin/raw-material-groups",
     write: true,
     sensitive: true,
+    tier: "write",
     bodyParams: [
       "name",
       "description",
@@ -2682,6 +2687,7 @@ export const ADMIN_MCP_TOOLS: AdminMcpToolDef[] = [
     previewPath: "/admin/designs/:id/inventory",
     write: true,
     sensitive: true,
+    tier: "write",
     bodyParams: ["inventoryIds", "inventoryItems"],
     inputSchema: obj(
       {
@@ -2719,6 +2725,7 @@ export const ADMIN_MCP_TOOLS: AdminMcpToolDef[] = [
     pathParams: ["id"],
     write: true,
     sensitive: true,
+    tier: "write",
     bodyParams: [
       "raw_material_group_id",
       "resolved_raw_material_id",
@@ -2767,6 +2774,7 @@ export const ADMIN_MCP_TOOLS: AdminMcpToolDef[] = [
     previewPath: "/admin/designs/:id/construction-details",
     write: true,
     sensitive: true,
+    tier: "write",
     bodyParams: ["technique", "label", "params", "fabricRules", "note"],
     inputSchema: obj(
       {
@@ -2802,6 +2810,7 @@ export const ADMIN_MCP_TOOLS: AdminMcpToolDef[] = [
     previewPath: "/admin/designs/:id/brief",
     write: true,
     sensitive: true,
+    tier: "write",
     bodyParams: [
       "concept_theme",
       "aesthetic_keywords",

--- a/apps/backend/src/api/admin/mcp/lib/route-tier.ts
+++ b/apps/backend/src/api/admin/mcp/lib/route-tier.ts
@@ -1,0 +1,108 @@
+/**
+ * Map an `/admin/*` request to the scope rung it requires (#1306).
+ *
+ * ── Why this has to exist ─────────────────────────────────────────────────────
+ *
+ * The HTTP guard shipped in #1308 asked one question — "does this credential
+ * reach `write`?" — and let every mutation through once the answer was yes. That
+ * was harmless while `write` and `read` exposed the same 54 tools, because no
+ * row could sit at `write` and mean anything. The moment `write` becomes a real
+ * rung it stops being harmless: a `write`-scoped credential would see 63 tools
+ * over MCP and still be able to POST `/admin/orders/:id/shipping-label`
+ * directly, spending money at a carrier through the route the tool merely wraps.
+ *
+ * The MCP registry already states each route's rung, because every tool maps 1:1
+ * to a real route. So the guard reads its requirement from the same table the
+ * tool surface does, and the two cannot drift.
+ *
+ * ── The default for an unlisted route ─────────────────────────────────────────
+ *
+ * `sensitive`, which is to say: fail shut. Most `/admin/*` mutations are not
+ * wrapped by any tool, and a machine credential reaching one is a route nobody
+ * classified. Granting it on the strength of a `write` row would make `write`
+ * mean "everything we forgot to think about" — the exact failure this replaces.
+ * Credentials with no row at all are unaffected: they never reach here.
+ */
+import { mcpToolTier, type McpScopeLevel } from "../../../../lib/mcp-core/tiers"
+import { ADMIN_MCP_TOOLS } from "./registry"
+
+/** The rung required by a mutation no tool wraps. Fail shut. */
+export const UNCLASSIFIED_ADMIN_ROUTE_TIER: McpScopeLevel = "sensitive"
+
+type RouteMatcher = {
+  method: string
+  pattern: RegExp
+  tier: McpScopeLevel
+}
+
+const escapeRegex = (s: string): string => s.replace(/[.*+?^${}()|[\]\\]/g, "\\$&")
+
+/**
+ * `/admin/designs/:id/tasks/:taskId` → `^/admin/designs/[^/]+/tasks/[^/]+$`.
+ *
+ * `[^/]+` rather than `.+` so a param can never swallow a path separator and
+ * make one pattern match a deeper, differently-classified route.
+ */
+const pathToPattern = (path: string): RegExp =>
+  new RegExp(
+    "^" +
+      path
+        .split("/")
+        .map((seg) => (seg.startsWith(":") ? "[^/]+" : escapeRegex(seg)))
+        .join("/") +
+      "$"
+  )
+
+/**
+ * Built once from the static registry.
+ *
+ * Sorted so the STRONGEST requirement for a given (method, path) wins. Two tools
+ * can wrap the same route — a broad one and a narrower one — and if they
+ * disagree the guard must take the higher rung, never the first match.
+ */
+const buildMatchers = (): RouteMatcher[] =>
+  ADMIN_MCP_TOOLS.filter((t) => !t.native && t.path)
+    .map((t) => ({
+      method: (t.method || "GET").toUpperCase(),
+      pattern: pathToPattern(t.path!.split("?")[0].replace(/\/+$/, "")),
+      tier: mcpToolTier(t),
+    }))
+    .filter((m) => m.method !== "GET")
+
+let matchers: RouteMatcher[] | null = null
+
+/**
+ * The rung a machine credential needs to call `method path`.
+ *
+ * `path` must already be stripped of its query string and trailing slash.
+ * Returns the strongest tier among matching tools, or
+ * `UNCLASSIFIED_ADMIN_ROUTE_TIER` when nothing matches.
+ */
+export const adminRouteTier = (
+  method: string,
+  path: string
+): McpScopeLevel => {
+  matchers ??= buildMatchers()
+  const verb = method.toUpperCase()
+
+  let found: McpScopeLevel | null = null
+  for (const m of matchers) {
+    if (m.method !== verb || !m.pattern.test(path)) continue
+    // Strongest wins; "dangerous" is the top of the ladder so we can stop there.
+    if (!found || TIER_ORDER[m.tier] > TIER_ORDER[found]) found = m.tier
+    if (found === "dangerous") break
+  }
+  return found ?? UNCLASSIFIED_ADMIN_ROUTE_TIER
+}
+
+const TIER_ORDER: Record<McpScopeLevel, number> = {
+  read: 0,
+  write: 1,
+  sensitive: 2,
+  dangerous: 3,
+}
+
+/** Test seam: drop the memoised matchers so a registry stub is picked up. */
+export const __resetAdminRouteTierCache = (): void => {
+  matchers = null
+}

--- a/apps/backend/src/api/middlewares.ts
+++ b/apps/backend/src/api/middlewares.ts
@@ -38,6 +38,7 @@ import {
   mcpScopeAllows,
   MCP_SCOPE_EXEMPT_ADMIN_PATHS,
 } from "../lib/mcp-scope";
+import { adminRouteTier } from "./admin/mcp/lib/route-tier";
 
 // Helper function to wrap Zod schemas for compatibility with validateAndTransformBody.
 // Historically this wrapped with z.preprocess((obj) => obj, schema) — under Zod v3
@@ -707,14 +708,22 @@ const enforceMcpScopeOnAdminWrites = async (
 
   try {
     const granted = await loadMcpScopeLevel(req.scope, principal)
-    if (!granted || mcpScopeAllows(granted, "write")) {
+    if (!granted) {
+      return next()
+    }
+    // Per-ROUTE, not merely "is this a write" (#1306). Asking only the latter
+    // would let a `write`-scoped credential POST /admin/orders/:id/shipping-label
+    // — a route its MCP tool surface refuses — and spend money at a carrier
+    // through the route the tool just wraps.
+    const required = adminRouteTier(method, path)
+    if (mcpScopeAllows(granted, required)) {
       return next()
     }
     return res.status(403).json({
       message:
-        `This credential is scoped to '${granted}' and cannot perform write ` +
-        `operations. Scope is set per credential in mcp_access_scope; widen it ` +
-        `via POST /admin/mcp/scopes as an admin user.`,
+        `This credential is scoped to '${granted}' and this route requires ` +
+        `'${required}'. Scope is set per credential in mcp_access_scope; widen ` +
+        `it via POST /admin/mcp/scopes as an admin user.`,
     })
   } catch {
     // Fail CLOSED. `loadMcpScopeLevel` already returns null (→ pass through)

--- a/apps/backend/src/lib/mcp-core/dispatch.ts
+++ b/apps/backend/src/lib/mcp-core/dispatch.ts
@@ -25,6 +25,7 @@ import type {
   McpToolResult,
 } from "./types"
 import { isDangerous, isSensitive } from "./schema"
+import { mcpScopeAllows, mcpToolTier } from "./tiers"
 import { callMcpRoute, type McpProxyError } from "./proxy"
 
 const substitutePath = (
@@ -115,26 +116,44 @@ export async function dispatchMcpTool(
   const sensitive = railsOn && isSensitive(def)
   const dangerous = railsOn && isDangerous(def)
 
-  if (write && ctx.enableWrite === false) {
-    return fail(
-      ctx.writeDisabledMessage?.(name) ??
-        `Tool '${name}' is a write tool and writes are disabled on this server.`
-    )
-  }
-  // Dangerous tools are hidden + refused when the surface hasn't opted in.
-  if (dangerous && ctx.enableDangerous === false) {
-    return fail(
-      `Tool '${name}' is a platform-destructive action and dangerous tools are disabled on this server.`
-    )
-  }
-  // Sensitive tools refused when this credential's scope stops below them
-  // (#1306 Track C). Deliberately keyed off `isSensitive(def)` rather than the
-  // `sensitive` local: `disableSensitiveRails` turns off the confirm UX for the
-  // store surface, but it must never widen a permission.
-  if (isSensitive(def) && ctx.enableSensitive === false) {
-    return fail(
-      `Tool '${name}' is a sensitive action and this credential's scope does not include sensitive tools.`
-    )
+  // ── Permission ──────────────────────────────────────────────────────────────
+  //
+  // Two mutually exclusive modes, and they MUST NOT both run. A `write`-scoped
+  // credential calling a write-tier tool that is also confirm-gated (every
+  // interesting one) would clear the tier check and then be refused by the
+  // `enableSensitive` check, which is precisely the conflation this replaces.
+  if (ctx.scopeLevel) {
+    // One tier comparison, expressive per tool rather than per class (#1306).
+    const required = mcpToolTier(def)
+    if (!mcpScopeAllows(ctx.scopeLevel, required)) {
+      return fail(
+        `Tool '${name}' requires the '${required}' scope and this credential is ` +
+          `scoped to '${ctx.scopeLevel}'. Scope is set per credential in ` +
+          `mcp_access_scope; widen it via POST /admin/mcp/scopes as an admin user.`
+      )
+    }
+  } else {
+    if (write && ctx.enableWrite === false) {
+      return fail(
+        ctx.writeDisabledMessage?.(name) ??
+          `Tool '${name}' is a write tool and writes are disabled on this server.`
+      )
+    }
+    // Dangerous tools are hidden + refused when the surface hasn't opted in.
+    if (dangerous && ctx.enableDangerous === false) {
+      return fail(
+        `Tool '${name}' is a platform-destructive action and dangerous tools are disabled on this server.`
+      )
+    }
+    // Sensitive tools refused when this credential's scope stops below them
+    // (#1306 Track C). Deliberately keyed off `isSensitive(def)` rather than the
+    // `sensitive` local: `disableSensitiveRails` turns off the confirm UX for the
+    // store surface, but it must never widen a permission.
+    if (isSensitive(def) && ctx.enableSensitive === false) {
+      return fail(
+        `Tool '${name}' is a sensitive action and this credential's scope does not include sensitive tools.`
+      )
+    }
   }
 
   // Resolve the tenant publishable key for multi-tenant (store) surfaces. A

--- a/apps/backend/src/lib/mcp-core/index.ts
+++ b/apps/backend/src/lib/mcp-core/index.ts
@@ -19,6 +19,15 @@ export {
   renderToolGuidance,
   buildToolInputSchema,
 } from "./schema"
+export {
+  MCP_SCOPE_LEVELS,
+  isMcpScopeLevel,
+  mcpScopeRank,
+  minMcpScope,
+  mcpScopeAllows,
+  mcpToolTier,
+  type McpScopeLevel,
+} from "./tiers"
 export { dispatchMcpTool } from "./dispatch"
 export { callMcpRoute, type McpProxyArgs, type McpProxyError } from "./proxy"
 export { buildMcpServer, type BuildMcpServerOptions } from "./server"

--- a/apps/backend/src/lib/mcp-core/server.ts
+++ b/apps/backend/src/lib/mcp-core/server.ts
@@ -21,6 +21,7 @@ import {
   isSensitive,
   renderToolGuidance,
 } from "./schema"
+import { mcpScopeAllows, mcpToolTier } from "./tiers"
 
 export type BuildMcpServerOptions = {
   /** MCP server identity, e.g. { name: "jyt-admin", version: "0.1.0" }. */
@@ -53,12 +54,18 @@ export function buildMcpServer(
   const dangerousEnabled = ctx.enableDangerous === true
   // Undefined = allowed, so an unscoped surface keeps every sensitive tool.
   const sensitiveEnabled = ctx.enableSensitive !== false
-  const visibleTools = tools.filter(
-    (t) =>
-      (writeEnabled || !t.write) &&
-      (dangerousEnabled || !isDangerous(t)) &&
-      (sensitiveEnabled || !isSensitive(t))
-  )
+  // A ladder level, when the surface supplies one, decides visibility on its
+  // own: it is strictly more expressive than the three flags, which can only
+  // include or exclude a whole class (#1306). Surfaces that don't scope leave
+  // it undefined and keep the flag behaviour exactly.
+  const visibleTools = ctx.scopeLevel
+    ? tools.filter((t) => mcpScopeAllows(ctx.scopeLevel!, mcpToolTier(t)))
+    : tools.filter(
+        (t) =>
+          (writeEnabled || !t.write) &&
+          (dangerousEnabled || !isDangerous(t)) &&
+          (sensitiveEnabled || !isSensitive(t))
+      )
 
   server.setRequestHandler(ListToolsRequestSchema, async () => ({
     tools: visibleTools.map((t) => ({

--- a/apps/backend/src/lib/mcp-core/tiers.ts
+++ b/apps/backend/src/lib/mcp-core/tiers.ts
@@ -1,0 +1,95 @@
+/**
+ * The MCP scope ladder, and the rung each tool sits on (#1306).
+ *
+ * Pure and dependency-free on purpose: the ladder is imported by the request-
+ * bound resolver (`src/lib/mcp-scope.ts`), by the admin dashboard bundle, and by
+ * the surface-agnostic dispatcher, and none of those should drag the others in.
+ *
+ * ── Why a tier exists at all ──────────────────────────────────────────────────
+ *
+ * `sensitive` was doing two unrelated jobs. As a UX gate it means "ask the human
+ * before running this", which is why the dispatcher demands `confirm: true`. As
+ * a permission it was also being read as "no third-party credential may call
+ * this". Conflating them made the `write` rung grant nothing: all 59 admin write
+ * tools are confirm-gated, so scoping a credential to `write` exposed exactly
+ * what `read` did.
+ *
+ * They are separate questions. Creating a design is worth confirming in a UI and
+ * is also perfectly safe for a scoped machine client — it is reversible, costs
+ * nothing and touches no one outside the platform. Booking a shipping label is
+ * confirm-worthy for the same reason and NOT safe, because it spends money at a
+ * carrier. `sensitive` keeps its confirm meaning untouched; `tier` answers the
+ * permission question independently.
+ */
+import type { McpToolDef } from "./types"
+
+/**
+ * The scope ladder, weakest first. A level implies every level below it, so a
+ * "dangerous" token can also read. Index in this array IS the rank.
+ */
+export const MCP_SCOPE_LEVELS = [
+  "read",
+  "write",
+  "sensitive",
+  "dangerous",
+] as const
+
+export type McpScopeLevel = (typeof MCP_SCOPE_LEVELS)[number]
+
+export const isMcpScopeLevel = (value: unknown): value is McpScopeLevel =>
+  typeof value === "string" &&
+  (MCP_SCOPE_LEVELS as readonly string[]).includes(value)
+
+/** Rank on the ladder; unknown strings rank as the weakest level (fail shut). */
+export const mcpScopeRank = (level: string): number => {
+  const i = (MCP_SCOPE_LEVELS as readonly string[]).indexOf(level)
+  return i === -1 ? 0 : i
+}
+
+/** The weaker of two levels — how a row is intersected with the ceiling. */
+export const minMcpScope = (
+  a: McpScopeLevel,
+  b: McpScopeLevel
+): McpScopeLevel => (mcpScopeRank(a) <= mcpScopeRank(b) ? a : b)
+
+/** True when `level` reaches at least `required` on the ladder. */
+export const mcpScopeAllows = (
+  level: McpScopeLevel,
+  required: McpScopeLevel
+): boolean => mcpScopeRank(level) >= mcpScopeRank(required)
+
+/**
+ * The rung a tool sits on — the minimum scope a credential needs to call it.
+ *
+ * An explicit `tier` wins. Everything else is DERIVED to reproduce the previous
+ * behaviour exactly, so a registry with no `tier` anywhere grades identically to
+ * before this existed:
+ *
+ *   dangerous          → "dangerous"
+ *   sensitive / DELETE → "sensitive"
+ *   write              → "write"
+ *   otherwise          → "read"
+ *
+ * A `tier` that would WIDEN past the derived rung is ignored. `tier: "write"` on
+ * a dangerous tool would be a one-word way to hand a platform-destructive action
+ * to a low-privilege client, and no such demotion is worth that footgun — the
+ * dangerous rails are the one thing a registry edit must not be able to lower.
+ * Demoting a merely-`sensitive` tool to `write` IS allowed; that is the point.
+ */
+export const mcpToolTier = (def: McpToolDef): McpScopeLevel => {
+  const derived: McpScopeLevel = def.dangerous
+    ? "dangerous"
+    : def.sensitive || def.method === "DELETE"
+      ? "sensitive"
+      : def.write
+        ? "write"
+        : "read"
+
+  if (!def.tier || !isMcpScopeLevel(def.tier)) return derived
+  // Never below "write" for something that mutates: a read-scoped credential
+  // must not reach a write tool because someone typed `tier: "read"`.
+  const floor: McpScopeLevel =
+    def.write || def.method === "DELETE" ? "write" : "read"
+  if (def.dangerous) return "dangerous"
+  return mcpScopeRank(def.tier) < mcpScopeRank(floor) ? floor : def.tier
+}

--- a/apps/backend/src/lib/mcp-core/types.ts
+++ b/apps/backend/src/lib/mcp-core/types.ts
@@ -12,6 +12,9 @@
  * a new endpoint is a single registry row.
  */
 
+// Type-only, so no runtime cycle with `./tiers` (which imports McpToolDef).
+import type { McpScopeLevel } from "./tiers"
+
 /** HTTP verb of the wrapped route. GET = read (always exposed). */
 export type McpMethod = "GET" | "POST" | "PUT" | "PATCH" | "DELETE"
 
@@ -55,6 +58,19 @@ export type McpToolDef = {
    * dispatch when the surface's dangerous flag is off. Implies `sensitive`.
    */
   dangerous?: boolean
+  /**
+   * Rung on the scope ladder a credential must reach to call this tool (#1306).
+   *
+   * Independent of `sensitive`, which stays the confirm-gate. Set `tier:
+   * "write"` on a confirm-worthy but ordinary mutation — reversible, no money,
+   * no effect outside the platform — to make it reachable by a `write`-scoped
+   * third-party credential while the admin UI keeps asking to confirm it.
+   *
+   * Omit it and the rung is derived from the existing flags, which is the
+   * pre-#1306 behaviour. It can only ever NARROW relative to that derivation
+   * for a dangerous tool; see `mcpToolTier`.
+   */
+  tier?: McpScopeLevel
   /**
    * Companion GET path (same `:param` substitution) used during `dry_run` to
    * fetch the current object so the model can see what it is about to change.
@@ -133,6 +149,20 @@ export type McpContext = {
    * partner/admin keep the full rails.
    */
   disableSensitiveRails?: boolean
+  /**
+   * The credential's effective rung on the scope ladder (#1306).
+   *
+   * When set it SUPERSEDES the three `enable*` flags for visibility and
+   * dispatch: a tool is exposed and callable iff `scopeLevel` reaches its
+   * `mcpToolTier(def)`. That is what makes the `write` rung mean something —
+   * the flags cannot express "ordinary mutations but not the confirm-gated
+   * ones" per tool, only per class, and every admin write is in the sensitive
+   * class.
+   *
+   * Left undefined by surfaces that don't scope (store, partner), which keep
+   * the flag behaviour unchanged.
+   */
+  scopeLevel?: McpScopeLevel
   /** Which surface this context serves — labels observability + server name. */
   surface?: string
   /** Optional sink for per-call observability events (#844). */

--- a/apps/backend/src/lib/mcp-scope.ts
+++ b/apps/backend/src/lib/mcp-scope.ts
@@ -22,43 +22,30 @@
  * revoked scope keeps working for its TTL — the wrong trade for a permission.
  */
 import type { MedusaRequest } from "@medusajs/framework/http"
+import {
+  isMcpScopeLevel,
+  mcpScopeAllows,
+  minMcpScope,
+  type McpScopeLevel,
+} from "./mcp-core/tiers"
 import { MCP_ACCESS_MODULE } from "../modules/mcp_access"
 import type McpAccessService from "../modules/mcp_access/service"
 
 /**
- * The scope ladder, weakest first. A level implies every level below it, so a
- * "dangerous" token can also read. Index in this array IS the rank.
+ * The ladder itself lives in `mcp-core/tiers` — dependency-free, so the
+ * dispatcher and the admin dashboard bundle can share it without dragging in
+ * the module resolution below. Re-exported here because this is the import path
+ * every caller already uses.
  */
-export const MCP_SCOPE_LEVELS = [
-  "read",
-  "write",
-  "sensitive",
-  "dangerous",
-] as const
-
-export type McpScopeLevel = (typeof MCP_SCOPE_LEVELS)[number]
-
-export const isMcpScopeLevel = (value: unknown): value is McpScopeLevel =>
-  typeof value === "string" &&
-  (MCP_SCOPE_LEVELS as readonly string[]).includes(value)
-
-/** Rank on the ladder; unknown strings rank as the weakest level (fail shut). */
-export const mcpScopeRank = (level: string): number => {
-  const i = (MCP_SCOPE_LEVELS as readonly string[]).indexOf(level)
-  return i === -1 ? 0 : i
-}
-
-/** The weaker of two levels — how a row is intersected with the ceiling. */
-export const minMcpScope = (
-  a: McpScopeLevel,
-  b: McpScopeLevel
-): McpScopeLevel => (mcpScopeRank(a) <= mcpScopeRank(b) ? a : b)
-
-/** True when `level` reaches at least `required` on the ladder. */
-export const mcpScopeAllows = (
-  level: McpScopeLevel,
-  required: McpScopeLevel
-): boolean => mcpScopeRank(level) >= mcpScopeRank(required)
+export {
+  MCP_SCOPE_LEVELS,
+  isMcpScopeLevel,
+  mcpScopeRank,
+  minMcpScope,
+  mcpScopeAllows,
+  mcpToolTier,
+} from "./mcp-core/tiers"
+export type { McpScopeLevel } from "./mcp-core/tiers"
 
 /**
  * Translate a level into the three flags `McpContext` already understands.


### PR DESCRIPTION
Unblocks **#1306 Track B**. The `write` rung granted nothing — `read 54 · write 54 · sensitive 117` — so "let a third party make ordinary changes but not the scary ones" was not expressible, and an OAuth front door would have had only two settings: read-only, or fully trusted.

## The conflation

`sensitive` was doing two unrelated jobs:

| | question it answers | enforced by |
|---|---|---|
| confirm gate | "should a human approve this before it runs?" | dispatcher demands `confirm: true` |
| permission | "may this credential call it at all?" | scope ladder |

Those come apart in practice. Creating a design is worth confirming in a UI **and** safe for a scoped machine client — reversible, costs nothing, touches nobody outside the platform. Booking a shipping label is confirm-worthy and **not** safe, because it spends money at a carrier.

So `tier` becomes its own axis on `McpToolDef`. `sensitive` keeps its confirm meaning untouched: **all nine demoted tools still require `confirm: true`**. With no explicit `tier` the rung is derived from the existing flags, so a registry with no `tier` anywhere grades exactly as it did before.

## Result

`read 54 · write 63 · sensitive 117 · dangerous 123`

The nine at `write` are internal design/spec authoring only — no money, no carrier, no message to a third party, all reversible:

`create_design` · `update_design` · `update_design_brief` · `update_design_task` · `add_design_construction_detail` · `link_design_inventory` · `link_design_material_group` · `create_raw_material_group` · `add_inventory_raw_material`

Deliberately **not** demoted: everything touching orders, shipping, production, partner admins, subscriptions, WhatsApp, the live catalogue, or stock levels — plus `assign_design_task` and `create_partner_task`, which notify a partner.

The list is asserted in a test, so adding a name to it is a visible line in a diff rather than a quiet registry edit.

## 🔥 It also closes a hole

The HTTP guard from #1308 asked one question — *does this credential reach `write`?* — and let every mutation through on a yes. That was harmless while `write` and `read` were the same 54 tools, because no row could sit at `write` and mean anything.

It stops being harmless the moment `write` means something: a write-scoped credential would see 63 tools over MCP and still be able to `POST /admin/orders/:id/shipping-label` **directly**, through the very route the tool wraps — spending money at a carrier its tool surface refuses.

`adminRouteTier` now derives each route's required rung from the same registry the tool surface uses, so the two cannot drift, and **fails shut (`sensitive`) on any mutation no tool classifies** — otherwise `write` would come to mean "everything we forgot to think about".

## Blast radius

Nil until someone writes a row. No row ⇒ pass-through, unchanged. The only live scope row on prod is `read`, and `read` behaves identically before and after (it 403s every mutation either way).

## Verify

```
cd apps/backend && npx jest --testPathPattern="(tool-tiers|scope-invariants|mcp-scope|dispatch.unit|tool-slice)"
```

157 tests green. `check:prod-build` passes locally. tsc unchanged at the 75 baseline.

Note `apps/backend` is the right cwd — the repo-root jest config has a different transform and fails to parse TS specs.

🤖 Generated with [Claude Code](https://claude.com/claude-code)