### PR TITLE
feat(admin): manage partner storefront custom domain via drawer + action menu

### DIFF
--- a/apps/backend/src/admin/components/partners/partner-storefront-section.tsx
+++ b/apps/backend/src/admin/components/partners/partner-storefront-section.tsx
@@ -1,11 +1,16 @@
-import { Badge, Button, Container, Heading, Text, toast, usePrompt } from "@medusajs/ui"
-import { ArrowUpRightOnBox, ArrowPath } from "@medusajs/icons"
+import { Badge, Button, Container, Drawer, Heading, InlineTip, Input, Text, toast, usePrompt } from "@medusajs/ui"
+import { ArrowUpRightOnBox, Globe, XMark } from "@medusajs/icons"
 import { useState } from "react"
 import {
   useStorefrontStatus,
   useProvisionStorefront,
-  useRedeployStorefront,
+  useStorefrontDomain,
+  useAddStorefrontDomain,
+  useVerifyStorefrontDomain,
+  useRemoveStorefrontDomain,
+  type DomainStatus,
 } from "../../hooks/api/storefront"
+import { ActionMenu } from "../common/action-menu"
 
 function formatDate(dateStr: string | number | null | undefined): string {
   if (!dateStr) return "—"
@@ -35,12 +40,303 @@ function statusColor(status: string | undefined): "green" | "orange" | "grey" | 
   }
 }
 
+type DnsRow = { type: string; host: string; value: string }
+
+const DnsTable = ({ rows }: { rows: DnsRow[] }) => (
+  <div className="rounded-lg border border-ui-border-base overflow-hidden">
+    <table className="w-full text-sm">
+      <thead>
+        <tr className="bg-ui-bg-subtle border-b border-ui-border-base">
+          <th className="px-3 py-2 text-left text-ui-fg-subtle font-normal">Type</th>
+          <th className="px-3 py-2 text-left text-ui-fg-subtle font-normal">Host</th>
+          <th className="px-3 py-2 text-left text-ui-fg-subtle font-normal">Value</th>
+        </tr>
+      </thead>
+      <tbody>
+        {rows.map((rec, i) => (
+          <tr key={i}>
+            <td className="px-3 py-2 font-mono text-xs">{rec.type}</td>
+            <td className="px-3 py-2 font-mono text-xs">{rec.host}</td>
+            <td className="px-3 py-2 font-mono text-xs break-all">{rec.value}</td>
+          </tr>
+        ))}
+      </tbody>
+    </table>
+  </div>
+)
+
+/**
+ * Drawer for managing the partner's storefront custom domain. Mirrors the
+ * partner-portal's `CustomDomainSection` flow (add → verify → DNS instructions
+ * → remove) but driven from the admin side through the admin proxy routes.
+ *
+ * The backend supports a single custom domain per partner, so the drawer
+ * switches between an "add" form (no domain yet) and a "manage" view
+ * (existing domain + DNS instructions + verify/remove).
+ */
+const DomainDrawer = ({
+  partnerId,
+  open,
+  onOpenChange,
+  domainStatus,
+}: {
+  partnerId: string
+  open: boolean
+  onOpenChange: (open: boolean) => void
+  domainStatus: DomainStatus | undefined
+}) => {
+  const { mutateAsync: addDomain, isPending: isAdding } =
+    useAddStorefrontDomain(partnerId)
+  const { mutateAsync: verifyDomain, isPending: isVerifying } =
+    useVerifyStorefrontDomain(partnerId)
+  const { mutateAsync: removeDomain, isPending: isRemoving } =
+    useRemoveStorefrontDomain(partnerId)
+  const prompt = usePrompt()
+
+  const [domainInput, setDomainInput] = useState("")
+  const [addResult, setAddResult] = useState<{
+    domain: string
+    verified: boolean
+    verification?: Array<{ type: string; domain: string; value: string }> | null
+    misconfigured: boolean
+    configured_by: string | null
+    dns_records?: Array<{ type: string; host: string; value: string }>
+    error?: string | null
+  } | null>(null)
+
+  const handleAdd = async () => {
+    const value = domainInput.trim()
+    if (!value) return
+
+    try {
+      const result = await addDomain({ domain: value })
+      setAddResult(result)
+      setDomainInput("")
+      if (result.error) {
+        toast.error("Domain saved, but attach failed", {
+          description: result.error,
+        })
+      } else {
+        toast.success("Domain added", {
+          description: result.verified
+            ? "Domain verified. Configure DNS to point it at the storefront."
+            : "Domain added. Follow the verification steps below.",
+        })
+      }
+    } catch (e: any) {
+      toast.error("Could not add domain", {
+        description: e?.message || "Something went wrong",
+      })
+    }
+  }
+
+  const handleVerify = async () => {
+    try {
+      const result = await verifyDomain()
+      setAddResult(result)
+      if (result.verified) {
+        toast.success("Domain verified")
+      } else if (result.error) {
+        toast.error("Couldn't attach domain", { description: result.error })
+      } else {
+        const hasTxt = (result.verification?.length ?? 0) > 0
+        const hasDns = (result.dns_records?.length ?? 0) > 0
+        toast.warning("Domain not yet verified", {
+          description: hasTxt
+            ? "Add the TXT record(s) shown below to verify ownership, then check again."
+            : hasDns
+            ? "Add the DNS record(s) shown below at the domain provider, then check again in a few minutes."
+            : "Still attaching the domain — give it a minute, then check again.",
+        })
+      }
+    } catch (e: any) {
+      toast.error("Verification failed", {
+        description: e?.message || "Something went wrong",
+      })
+    }
+  }
+
+  const handleRemove = async () => {
+    const confirmed = await prompt({
+      title: "Remove Custom Domain",
+      description:
+        "This will remove the custom domain from the partner's storefront. The storefront will still be accessible via the default subdomain.",
+      confirmText: "Remove",
+      cancelText: "Cancel",
+    })
+    if (!confirmed) return
+
+    try {
+      const result = await removeDomain()
+      setAddResult(null)
+      if (result?.warnings?.length) {
+        toast.warning("Custom domain removed", {
+          description:
+            "Some records may still be clearing at the host: " +
+            result.warnings.join("; "),
+        })
+      } else {
+        toast.success("Custom domain removed")
+      }
+    } catch (e: any) {
+      toast.error("Could not remove domain", {
+        description: e?.message || "Something went wrong",
+      })
+    }
+  }
+
+  const hasDomain = domainStatus?.configured && !!domainStatus.domain
+  const currentDomain = domainStatus?.domain || addResult?.domain
+  const isVerified = domainStatus?.verified ?? addResult?.verified ?? false
+  const isMisconfigured =
+    domainStatus?.misconfigured ?? addResult?.misconfigured ?? true
+  const isActive = isVerified && !isMisconfigured
+  const verification = addResult?.verification || domainStatus?.verification || []
+  const dnsRecords = domainStatus?.dns_records || addResult?.dns_records || []
+
+  return (
+    <Drawer open={open} onOpenChange={onOpenChange}>
+      <Drawer.Content>
+        <Drawer.Header>
+          <Drawer.Title>Storefront domain</Drawer.Title>
+          <Drawer.Description>
+            {hasDomain
+              ? "Manage the custom domain attached to this partner's storefront."
+              : "Connect a custom domain to this partner's storefront."}
+          </Drawer.Description>
+        </Drawer.Header>
+        <Drawer.Body className="flex flex-col gap-y-4 overflow-y-auto">
+          {!hasDomain && !addResult ? (
+            <div className="space-y-3">
+              <Text size="small" className="text-ui-fg-subtle">
+                Enter the domain the partner wants to use (e.g.
+                shop.example.com). DNS configuration instructions will be shown
+                after the domain is attached.
+              </Text>
+              <div className="flex items-center gap-x-2">
+                <Input
+                  placeholder="shop.example.com"
+                  value={domainInput}
+                  onChange={(e) => setDomainInput(e.target.value)}
+                  onKeyDown={(e) => {
+                    if (e.key === "Enter") {
+                      e.preventDefault()
+                      handleAdd()
+                    }
+                  }}
+                  className="flex-1"
+                />
+                <Button
+                  size="small"
+                  onClick={handleAdd}
+                  disabled={isAdding || !domainInput.trim()}
+                >
+                  {isAdding ? "Adding..." : "Add Domain"}
+                </Button>
+              </div>
+            </div>
+          ) : (
+            <div className="space-y-4">
+              <div className="flex items-center justify-between">
+                <div className="flex items-center gap-x-2">
+                  <Text size="small" weight="plus">
+                    {currentDomain}
+                  </Text>
+                  {isVerified && !isMisconfigured ? (
+                    <Badge color="green" size="2xsmall">Active</Badge>
+                  ) : isVerified && isMisconfigured ? (
+                    <Badge color="orange" size="2xsmall">DNS Pending</Badge>
+                  ) : (
+                    <Badge color="red" size="2xsmall">Unverified</Badge>
+                  )}
+                </div>
+                <Button
+                  variant="secondary"
+                  size="small"
+                  onClick={handleRemove}
+                  disabled={isRemoving}
+                >
+                  <XMark className="mr-1" />
+                  {isRemoving ? "Removing..." : "Remove"}
+                </Button>
+              </div>
+
+              {isActive ? (
+                <InlineTip variant="success" label="Domain Active">
+                  The custom domain is configured and serving the storefront.
+                </InlineTip>
+              ) : (
+                <div className="space-y-3">
+                  {verification.length > 0 && (
+                    <>
+                      <InlineTip variant="warning" label="Verify Domain Ownership">
+                        Add the following TXT record at the partner's DNS
+                        provider to verify ownership of this domain.
+                      </InlineTip>
+                      <DnsTable
+                        rows={verification.map((v) => ({
+                          type: v.type,
+                          host: v.domain,
+                          value: v.value,
+                        }))}
+                      />
+                    </>
+                  )}
+
+                  {dnsRecords.length > 0 && (
+                    <>
+                      <InlineTip variant="info" label="Point the Domain">
+                        Add the DNS record{dnsRecords.length > 1 ? "s" : ""} below
+                        at the domain provider so it resolves to the storefront.
+                        DNS changes can take up to 48 hours to propagate.
+                      </InlineTip>
+                      <DnsTable rows={dnsRecords} />
+                    </>
+                  )}
+
+                  {verification.length === 0 && dnsRecords.length === 0 && (
+                    <InlineTip variant="info" label="Setting Up Domain">
+                      Still attaching the domain to the storefront. This can take
+                      a few minutes — click Check Status to refresh.
+                    </InlineTip>
+                  )}
+
+                  <Button
+                    size="small"
+                    variant="secondary"
+                    onClick={handleVerify}
+                    disabled={isVerifying}
+                  >
+                    {isVerifying ? "Checking..." : "Check Status"}
+                  </Button>
+                </div>
+              )}
+            </div>
+          )}
+        </Drawer.Body>
+        <Drawer.Footer>
+          <Button
+            size="small"
+            variant="secondary"
+            onClick={() => onOpenChange(false)}
+          >
+            Close
+          </Button>
+        </Drawer.Footer>
+      </Drawer.Content>
+    </Drawer>
+  )
+}
+
 export const PartnerStorefrontSection = ({ partnerId }: { partnerId: string }) => {
   const { data: status, isPending, isError } = useStorefrontStatus(partnerId)
   const { mutateAsync: provision, isPending: isProvisioning } = useProvisionStorefront(partnerId)
-  const { mutateAsync: redeploy, isPending: isRedeploying } = useRedeployStorefront(partnerId)
+  const { data: domainStatus } = useStorefrontDomain(partnerId, {
+    enabled: !!status?.provisioned,
+  })
   const prompt = usePrompt()
   const [showDetails, setShowDetails] = useState(false)
+  const [domainDrawerOpen, setDomainDrawerOpen] = useState(false)
 
   const handleProvision = async () => {
     const confirmed = await prompt({
@@ -61,19 +357,6 @@ export const PartnerStorefrontSection = ({ partnerId }: { partnerId: string }) =
     } catch (e: any) {
       toast.error("Provisioning failed", {
         description: e?.message || "Could not provision storefront",
-      })
-    }
-  }
-
-  const handleRedeploy = async () => {
-    try {
-      const result = await redeploy({ update_env: true })
-      toast.success("Redeployment triggered", {
-        description: `Deployment ${result.deployment.id} is ${result.deployment.status}`,
-      })
-    } catch (e: any) {
-      toast.error("Redeploy failed", {
-        description: e?.message || "Could not trigger redeployment",
       })
     }
   }
@@ -133,6 +416,16 @@ export const PartnerStorefrontSection = ({ partnerId }: { partnerId: string }) =
 
   // Provisioned
   const deployStatus = status.latest_deployment?.status
+  const hasCustomDomain =
+    domainStatus?.configured && !!domainStatus.domain
+  const domainActive =
+    hasCustomDomain &&
+    domainStatus!.verified &&
+    !domainStatus!.misconfigured
+  const visitUrl = domainActive
+    ? `https://${domainStatus!.domain}`
+    : status.storefront_url
+
   return (
     <Container className="divide-y p-0">
       <div className="flex items-center justify-between px-6 py-4">
@@ -141,9 +434,9 @@ export const PartnerStorefrontSection = ({ partnerId }: { partnerId: string }) =
           <Badge color="green" size="2xsmall">Live</Badge>
         </div>
         <div className="flex items-center gap-x-2">
-          {status.storefront_url && (
+          {visitUrl && (
             <a
-              href={status.storefront_url}
+              href={visitUrl}
               target="_blank"
               rel="noopener noreferrer"
             >
@@ -153,15 +446,21 @@ export const PartnerStorefrontSection = ({ partnerId }: { partnerId: string }) =
               </Button>
             </a>
           )}
-          <Button
-            variant="secondary"
-            size="small"
-            onClick={handleRedeploy}
-            disabled={isRedeploying}
-          >
-            <ArrowPath className="mr-1" />
-            {isRedeploying ? "Deploying..." : "Redeploy"}
-          </Button>
+          <ActionMenu
+            groups={[
+              {
+                actions: [
+                  {
+                    icon: <Globe />,
+                    label: hasCustomDomain
+                      ? "Manage domain"
+                      : "Add domain",
+                    onClick: () => setDomainDrawerOpen(true),
+                  },
+                ],
+              },
+            ]}
+          />
         </div>
       </div>
 
@@ -171,6 +470,22 @@ export const PartnerStorefrontSection = ({ partnerId }: { partnerId: string }) =
           <Text size="small">
             {status.domain || "—"}
           </Text>
+
+          {hasCustomDomain && (
+            <>
+              <Text size="small" className="text-ui-fg-subtle">Custom Domain</Text>
+              <div className="flex items-center gap-x-2">
+                <Text size="small">{domainStatus!.domain}</Text>
+                {domainStatus!.verified && !domainStatus!.misconfigured ? (
+                  <Badge color="green" size="2xsmall">Active</Badge>
+                ) : domainStatus!.verified ? (
+                  <Badge color="orange" size="2xsmall">DNS Pending</Badge>
+                ) : (
+                  <Badge color="red" size="2xsmall">Unverified</Badge>
+                )}
+              </div>
+            </>
+          )}
 
           <Text size="small" className="text-ui-fg-subtle">Vercel Project</Text>
           <Text size="small">{status.project?.name || "—"}</Text>
@@ -223,6 +538,13 @@ export const PartnerStorefrontSection = ({ partnerId }: { partnerId: string }) =
           {showDetails ? "Hide details" : "Show details"}
         </button>
       </div>
+
+      <DomainDrawer
+        partnerId={partnerId}
+        open={domainDrawerOpen}
+        onOpenChange={setDomainDrawerOpen}
+        domainStatus={domainStatus}
+      />
     </Container>
   )
 }

--- a/apps/backend/src/admin/hooks/api/storefront.ts
+++ b/apps/backend/src/admin/hooks/api/storefront.ts
@@ -87,3 +87,108 @@ export const useRedeployStorefront = (partnerId: string) => {
     },
   })
 }
+
+// --- Admin custom domain hooks (mirror of /partners/storefront/domain) ---
+
+export type DnsRecord = {
+  type: string
+  host: string
+  value: string
+}
+
+export interface DomainStatus {
+  configured: boolean
+  domain?: string | null
+  verified?: boolean
+  misconfigured?: boolean
+  configured_by?: string | null
+  verification?: Array<{ type: string; domain: string; value: string }> | null
+  dns_records?: DnsRecord[]
+}
+
+export interface AddDomainResponse {
+  domain: string
+  verified: boolean
+  verification?: Array<{ type: string; domain: string; value: string }> | null
+  misconfigured: boolean
+  configured_by: string | null
+  dns_records?: DnsRecord[]
+  /** Provider attach/heal error (e.g. Cloudflare rejected the hostname). */
+  error?: string | null
+}
+
+export interface RemoveDomainResponse {
+  message: string
+  /** Provider hosts that couldn't be fully torn down (still resolving). */
+  warnings?: string[]
+}
+
+const DOMAIN_QUERY_KEY = "admin_partner_storefront_domain" as const
+export const domainQueryKeys = queryKeysFactory(DOMAIN_QUERY_KEY)
+
+export const useStorefrontDomain = (
+  partnerId: string,
+  options?: Omit<
+    UseQueryOptions<DomainStatus, FetchError, DomainStatus, QueryKey>,
+    "queryFn" | "queryKey"
+  >
+) => {
+  const { data, ...rest } = useQuery({
+    queryFn: () =>
+      sdk.client.fetch<DomainStatus>(
+        `/admin/partners/${partnerId}/storefront/domain`,
+        { method: "GET" }
+      ),
+    queryKey: domainQueryKeys.detail(partnerId),
+    enabled: !!partnerId,
+    ...options,
+  })
+  return { data, ...rest }
+}
+
+export const useAddStorefrontDomain = (partnerId: string) => {
+  const queryClient = useQueryClient()
+  return useMutation({
+    mutationFn: (input: { domain: string }) =>
+      sdk.client.fetch<AddDomainResponse>(
+        `/admin/partners/${partnerId}/storefront/domain`,
+        { method: "POST", body: input }
+      ),
+    onSuccess: () => {
+      queryClient.invalidateQueries({ queryKey: domainQueryKeys.detail(partnerId) })
+      queryClient.invalidateQueries({ queryKey: storefrontQueryKeys.detail(partnerId) })
+      queryClient.invalidateQueries({ queryKey: partnersQueryKeys.detail(partnerId) })
+    },
+  })
+}
+
+export const useVerifyStorefrontDomain = (partnerId: string) => {
+  const queryClient = useQueryClient()
+  return useMutation({
+    mutationFn: () =>
+      sdk.client.fetch<AddDomainResponse>(
+        `/admin/partners/${partnerId}/storefront/domain/verify`,
+        { method: "POST" }
+      ),
+    onSuccess: () => {
+      queryClient.invalidateQueries({ queryKey: domainQueryKeys.detail(partnerId) })
+      queryClient.invalidateQueries({ queryKey: storefrontQueryKeys.detail(partnerId) })
+    },
+  })
+}
+
+export const useRemoveStorefrontDomain = (partnerId: string) => {
+  const queryClient = useQueryClient()
+  return useMutation({
+    mutationFn: () =>
+      sdk.client.fetch<RemoveDomainResponse>(
+        `/admin/partners/${partnerId}/storefront/domain`,
+        { method: "DELETE" }
+      ),
+    onSuccess: () => {
+      queryClient.invalidateQueries({ queryKey: domainQueryKeys.detail(partnerId) })
+      queryClient.invalidateQueries({ queryKey: storefrontQueryKeys.detail(partnerId) })
+      queryClient.invalidateQueries({ queryKey: partnersQueryKeys.detail(partnerId) })
+    },
+  })
+}

--- a/apps/backend/src/api/admin/partners/[id]/storefront/domain/route.ts
+++ b/apps/backend/src/api/admin/partners/[id]/storefront/domain/route.ts
@@ -1,0 +1,253 @@
+/**
+ * @file Admin write-proxy: a partner's storefront custom domain (#843 mirror).
+ * @module API/Admin/Partners/Storefront/Domain
+ *
+ * Admin-side mirror of `src/api/partners/storefront/domain/route.ts`. The
+ * partner route resolves the partner from `req.auth_context` (the partner
+ * bearer); this one resolves the partner from the `:id` URL param via
+ * `getPartnerInspectionRecord`, which 404s on an unknown partner the same way
+ * the sibling admin storefront routes do.
+ *
+ * Unlike the read-only admin storefront status route, this one MUTATES the
+ * partner record (adds/removes a custom domain) — that is the whole point of
+ * an operator managing a partner's domain on their behalf. It reuses the
+ * exact same workflows and helpers the partner route uses, so the two cannot
+ * drift.
+ */
+import {
+  AuthenticatedMedusaRequest,
+  MedusaResponse,
+} from "@medusajs/framework/http"
+import { MedusaError } from "@medusajs/framework/utils"
+import { getPartnerInspectionRecord } from "../../lib/partner-inspection"
+import { resolveHostingProviderForPartner } from "../../../../../../modules/deployment/providers/resolve-partner-provider"
+import type { HostingDomainStatus } from "../../../../../../modules/deployment/providers/types"
+import { WEBSITE_MODULE } from "../../../../../../modules/website"
+import type WebsiteService from "../../../../../../modules/website/service"
+import updatePartnerWorkflow from "../../../../../../workflows/partners/update-partner"
+import {
+  attachStorefrontDomainWorkflow,
+  deriveDomainPair,
+  partnerCustomDomain,
+  partnerCustomDomainVerified,
+} from "../../../../../../workflows/partners/attach-storefront-domain"
+
+/**
+ * GET /admin/partners/:id/storefront/domain
+ * Returns the custom domain status and DNS configuration instructions,
+ * dispatched to whichever hosting provider the partner's storefront runs on.
+ */
+export const GET = async (
+  req: AuthenticatedMedusaRequest,
+  res: MedusaResponse
+) => {
+  const { id: partnerId } = req.params
+  const partner = await getPartnerInspectionRecord(partnerId, req.scope)
+
+  const { provider, projectRef } = await resolveHostingProviderForPartner(
+    partner,
+    req.scope
+  )
+  if (!projectRef) {
+    throw new MedusaError(
+      MedusaError.Types.NOT_FOUND,
+      "Storefront has not been provisioned"
+    )
+  }
+
+  const customDomain = partnerCustomDomain(partner)
+  if (!customDomain) {
+    return res.json({ configured: false })
+  }
+
+  const pair = deriveDomainPair(customDomain)
+  const verified = partnerCustomDomainVerified(partner)
+
+  try {
+    const primary = await provider.describeDomain(projectRef, pair.primary)
+    const records = [...primary.dnsRecords]
+    let verification = primary.verification ?? null
+    if (pair.counterpart) {
+      const twin = await provider.describeDomain(projectRef, pair.counterpart)
+      records.push(...twin.dnsRecords)
+      if ((!verification || !verification.length) && twin.verification?.length) {
+        verification = twin.verification
+      }
+    }
+    return res.json({
+      configured: true,
+      domain: customDomain,
+      redirect_from: pair.counterpart,
+      verified,
+      misconfigured: primary.misconfigured,
+      configured_by: primary.configuredBy ?? null,
+      verification,
+      dns_records: records,
+    })
+  } catch {
+    return res.json({
+      configured: true,
+      domain: customDomain,
+      redirect_from: pair.counterpart,
+      verified,
+      misconfigured: true,
+      configured_by: null,
+      dns_records: [],
+    })
+  }
+}
+
+/**
+ * POST /admin/partners/:id/storefront/domain
+ * Add a custom domain to the partner's storefront project (provider-agnostic:
+ * the attach workflow resolves the partner's provider internally).
+ */
+export const POST = async (
+  req: AuthenticatedMedusaRequest,
+  res: MedusaResponse
+) => {
+  const { id: partnerId } = req.params
+  const partner = await getPartnerInspectionRecord(partnerId, req.scope)
+
+  const { provider, projectRef } = await resolveHostingProviderForPartner(
+    partner,
+    req.scope
+  )
+  if (!projectRef) {
+    throw new MedusaError(
+      MedusaError.Types.NOT_FOUND,
+      "Storefront has not been provisioned"
+    )
+  }
+
+  const { domain } = req.body as { domain?: string }
+  if (!domain || typeof domain !== "string") {
+    throw new MedusaError(MedusaError.Types.INVALID_DATA, "domain is required")
+  }
+
+  const cleaned = domain.trim().toLowerCase().replace(/^https?:\/\//, "").replace(/\/+$/, "")
+  if (!cleaned || cleaned.length < 3 || !cleaned.includes(".")) {
+    throw new MedusaError(
+      MedusaError.Types.INVALID_DATA,
+      "Please enter a valid domain name (e.g. shop.example.com)"
+    )
+  }
+
+  const websiteId =
+    ((partner as any).website_id || partner.metadata?.website_id || null) as
+      | string
+      | null
+
+  const { result } = await attachStorefrontDomainWorkflow(req.scope).run({
+    input: {
+      partner_id: partner.id,
+      website_id: websiteId,
+      domain: cleaned,
+    },
+  })
+
+  // DNS instructions for both hosts (best-effort, provider-specific).
+  const dnsRecords: HostingDomainStatus["dnsRecords"] = []
+  let misconfigured = true
+  let configuredBy: string | null = null
+  try {
+    const primary = await provider.describeDomain(projectRef, result.primary)
+    dnsRecords.push(...primary.dnsRecords)
+    misconfigured = primary.misconfigured
+    configuredBy = primary.configuredBy ?? null
+    if (result.counterpart) {
+      const twin = await provider.describeDomain(projectRef, result.counterpart)
+      dnsRecords.push(...twin.dnsRecords)
+    }
+  } catch {
+    // non-critical — the operator can refresh via the verify endpoint
+  }
+
+  res.status(201).json({
+    domain: result.primary,
+    redirect_from: result.counterpart,
+    verified: result.verified,
+    verification: result.verification || null,
+    misconfigured,
+    configured_by: configuredBy,
+    dns_records: dnsRecords,
+    error: result.error || null,
+  })
+}
+
+/**
+ * DELETE /admin/partners/:id/storefront/domain
+ * Remove the custom domain from the partner's storefront project.
+ */
+export const DELETE = async (
+  req: AuthenticatedMedusaRequest,
+  res: MedusaResponse
+) => {
+  const { id: partnerId } = req.params
+  const partner = await getPartnerInspectionRecord(partnerId, req.scope)
+
+  const { provider, projectRef } = await resolveHostingProviderForPartner(
+    partner,
+    req.scope
+  )
+  const customDomain = partnerCustomDomain(partner)
+
+  if (!projectRef || !customDomain) {
+    throw new MedusaError(
+      MedusaError.Types.NOT_FOUND,
+      "No custom domain configured"
+    )
+  }
+
+  // Remove BOTH hosts (primary + its www/apex twin — see deriveDomainPair).
+  const pair = deriveDomainPair(customDomain)
+  const hosts = [pair.primary, pair.counterpart].filter(
+    (h): h is string => !!h
+  )
+  const warnings: string[] = []
+  for (const host of hosts) {
+    try {
+      await provider.removeDomain(projectRef, host)
+    } catch (e: any) {
+      warnings.push(`${host}: ${e?.message || e}`)
+    }
+  }
+
+  // Clear the typed columns (and strip any legacy metadata copy).
+  const meta = { ...(partner.metadata || {}) }
+  delete meta.custom_domain
+  delete meta.custom_domain_verified
+
+  await updatePartnerWorkflow(req.scope).run({
+    input: {
+      id: partner.id,
+      data: {
+        custom_domain: null,
+        custom_domain_verified: false,
+        metadata: meta,
+      },
+    },
+  })
+
+  // Soft-delete the alias rows so lookups stop resolving the custom domain
+  try {
+    const websiteService: WebsiteService = req.scope.resolve(WEBSITE_MODULE)
+    for (const host of hosts) {
+      const [rows] = await (websiteService as any).listAndCountWebsiteDomains(
+        { domain: host },
+        { take: 1 }
+      )
+      const row = rows?.[0]
+      if (row && !row.is_primary) {
+        await (websiteService as any).softDeleteWebsiteDomains(row.id)
+      }
+    }
+  } catch {
+    // best-effort
+  }
+
+  res.json({
+    message: "Custom domain removed",
+    ...(warnings.length ? { warnings } : {}),
+  })
+}

--- a/apps/backend/src/api/admin/partners/[id]/storefront/domain/verify/route.ts
+++ b/apps/backend/src/api/admin/partners/[id]/storefront/domain/verify/route.ts
@@ -1,0 +1,121 @@
+/**
+ * @file Admin write-proxy: verify a partner's storefront custom domain.
+ * @module API/Admin/Partners/Storefront/Domain/Verify
+ *
+ * Admin-side mirror of `src/api/partners/storefront/domain/verify/route.ts`.
+ * Resolves the partner from the `:id` URL param instead of `req.auth_context`.
+ */
+import {
+  AuthenticatedMedusaRequest,
+  MedusaResponse,
+} from "@medusajs/framework/http"
+import { MedusaError } from "@medusajs/framework/utils"
+import { getPartnerInspectionRecord } from "../../../lib/partner-inspection"
+import { DEPLOYMENT_MODULE } from "../../../../../../../modules/deployment"
+import type DeploymentService from "../../../../../../../modules/deployment/service"
+import { resolveHostingProviderForPartner } from "../../../../../../../modules/deployment/providers/resolve-partner-provider"
+import updatePartnerWorkflow from "../../../../../../../workflows/partners/update-partner"
+import {
+  deriveDomainPair,
+  partnerCustomDomain,
+} from "../../../../../../../workflows/partners/attach-storefront-domain"
+
+/**
+ * POST /admin/partners/:id/storefront/domain/verify
+ *
+ * Re-checks domain ownership with the partner's hosting provider AND — for
+ * Vercel partners whose domain lives inside the Cloudflare zone we control —
+ * pushes whatever DNS Vercel currently recommends so the domain self-heals
+ * without operator intervention. Mirrors the partner verify endpoint.
+ */
+export const POST = async (
+  req: AuthenticatedMedusaRequest,
+  res: MedusaResponse
+) => {
+  const { id: partnerId } = req.params
+  const partner = await getPartnerInspectionRecord(partnerId, req.scope)
+
+  const { providerName, provider, projectRef } =
+    await resolveHostingProviderForPartner(partner, req.scope)
+  const customDomain = partnerCustomDomain(partner)
+
+  if (!projectRef || !customDomain) {
+    throw new MedusaError(
+      MedusaError.Types.NOT_FOUND,
+      "No custom domain configured"
+    )
+  }
+
+  const pair = deriveDomainPair(customDomain)
+  const healErrors: string[] = []
+  let applied: any = null
+
+  if (providerName === "vercel") {
+    // Vercel-only: apply Vercel's recommended DNS via Cloudflare. No-op for
+    // domains outside our zone.
+    const deployment: DeploymentService = req.scope.resolve(DEPLOYMENT_MODULE)
+    applied = await deployment.applyRecommendedDns(customDomain)
+  } else {
+    // Self-heal: idempotently (re)attach each host.
+    const hosts = [pair.primary, pair.counterpart].filter(
+      (h): h is string => !!h
+    )
+    for (const host of hosts) {
+      try {
+        const r = await provider.addDomain(
+          projectRef,
+          host,
+          host === pair.primary
+            ? undefined
+            : { redirect: pair.primary, redirectStatusCode: 308 }
+        )
+        if (r?.error) healErrors.push(`${host}: ${r.error}`)
+      } catch (e: any) {
+        healErrors.push(`${host}: ${e?.message || e}`)
+      }
+    }
+  }
+
+  // Verify after (re)attaching so a freshly-created/validated hostname can flip
+  // verified=true in the same call (subject to the propagation window).
+  const result = await provider.verifyDomain(projectRef, pair.primary)
+
+  if (result.verified) {
+    await updatePartnerWorkflow(req.scope).run({
+      input: {
+        id: partner.id,
+        data: { custom_domain_verified: true },
+      },
+    })
+  }
+
+  // Aggregate status + DNS/verification records across the apex/www pair.
+  const primaryStatus = await provider
+    .describeDomain(projectRef, pair.primary)
+    .catch(() => null)
+  const records = [...(primaryStatus?.dnsRecords ?? [])]
+  let verification =
+    result.verification || primaryStatus?.verification || []
+  if (pair.counterpart) {
+    const twin = await provider
+      .describeDomain(projectRef, pair.counterpart)
+      .catch(() => null)
+    if (twin) {
+      records.push(...twin.dnsRecords)
+      if (!verification.length && twin.verification?.length) {
+        verification = twin.verification
+      }
+    }
+  }
+
+  res.json({
+    domain: customDomain,
+    verified: result.verified,
+    verification,
+    misconfigured: primaryStatus?.misconfigured ?? true,
+    configured_by: primaryStatus?.configuredBy ?? null,
+    applied,
+    dns_records: records,
+    ...(healErrors.length ? { error: healErrors.join("; ") } : {}),
+  })
+}

--- a/apps/backend/src/api/middlewares.ts
+++ b/apps/backend/src/api/middlewares.ts
@@ -3886,6 +3886,27 @@ export default defineMiddlewares({
       method: "POST",
       middlewares: [],
     },
+    // Admin Partner Storefront Domain (mirror of /partners/storefront/domain)
+    {
+      matcher: "/admin/partners/:id/storefront/domain",
+      method: "GET",
+      middlewares: [],
+    },
+    {
+      matcher: "/admin/partners/:id/storefront/domain",
+      method: "POST",
+      middlewares: [],
+    },
+    {
+      matcher: "/admin/partners/:id/storefront/domain",
+      method: "DELETE",
+      middlewares: [],
+    },
+    {
+      matcher: "/admin/partners/:id/storefront/domain/verify",
+      method: "POST",
+      middlewares: [],
+    },
     // Admin Partner Admins routes
     {
       matcher: "/admin/partners/:id/admins",


### PR DESCRIPTION
## What

Lets an operator manage a partner's storefront custom domain from the **admin** partner detail page — the same capability the partner already has in their own portal at `/partners/storefront/domain`, but driven by an admin through admin-auth-scoped routes.

## Why

The domain add/verify/remove API existed only on the partner-auth-scoped `/partners/storefront/domain/*` routes (resolved from `req.auth_context`), so an admin had no way to manage a partner's custom domain on their behalf. The admin storefront section also still surfaced a **Redeploy** button, but shared multi-tenant storefronts deploy centrally — the partner-ui already hides it (`REDEPLOY_ENABLED = false`); the admin UI had drifted.

## Changes

### Backend — admin proxy routes
Mirror of the partner routes, resolving the partner from the `:id` URL param via `getPartnerInspectionRecord` (404s on unknown partner like the sibling admin storefront routes):

- `GET    /admin/partners/:id/storefront/domain` — domain status + DNS instructions
- `POST   /admin/partners/:id/storefront/domain` — attach a custom domain (reuses `attachStorefrontDomainWorkflow`)
- `DELETE /admin/partners/:id/storefront/domain` — remove the custom domain
- `POST   /admin/partners/:id/storefront/domain/verify` — re-check ownership + self-heal DNS

Reuses the exact same workflows/helpers the partner route uses (`attachStorefrontDomainWorkflow`, `updatePartnerWorkflow`, `resolveHostingProviderForPartner`, `deriveDomainPair`, `partnerCustomDomain`), so the two surfaces cannot drift. Registered all 4 routes in `middlewares.ts`.

### Admin UI hooks (`hooks/api/storefront.ts`)
Added `DomainStatus`/`AddDomainResponse`/`RemoveDomainResponse` types, `domainQueryKeys`, and `useStorefrontDomain` / `useAddStorefrontDomain` / `useVerifyStorefrontDomain` / `useRemoveStorefrontDomain` pointed at the new admin routes. Mutations invalidate the storefront + partner detail queries so the section refreshes.

### Admin UI (`components/partners/partner-storefront-section.tsx`)
- **Removed** the Redeploy button (and its handler/hook usage).
- **Added** an `ActionMenu` dropdown in the header with a `Globe` action labelled "Add domain" (or "Manage domain" when one is configured) that opens a Medusa UI `Drawer`.
- The `DomainDrawer` mirrors the partner-portal `CustomDomainSection` flow: add form when no domain is configured; otherwise shows the domain with an Active/DNS Pending/Unverified badge, DNS + TXT verification tables, a "Check Status" (verify) button, and "Remove". The backend supports a single custom domain per partner, so the drawer switches to the manage view once one exists rather than queuing more.
- Added a "Custom Domain" row to the inline status grid; "Visit" now uses the verified custom domain when active.

## Notes
- The unrelated `apps/storefront-starter` submodule bump and untracked `docs/` / `opencode.json` in the worktree were intentionally left out of this PR.
- Scope kept to a single custom domain per partner (the backend's current capability). Supporting multiple domains would require a model/workflow change and is out of scope here.

## Verification
- `tsc --noEmit` reports no errors in any touched file (pre-existing errors in unrelated files remain).
- Pre-push config parity check passed.