### PR TITLE
fix(assistant): render message parts in order, not text-then-tools

### DIFF
--- a/apps/backend/src/admin/routes/assistant/page.tsx
+++ b/apps/backend/src/admin/routes/assistant/page.tsx
@@ -905,38 +905,57 @@ const AssistantChat = ({
 
         {messages.map((m: any) => {
           const text = getText(m.parts)
-          const toolParts = (m.parts || []).filter(
-            (p: any) =>
-              p?.type === "dynamic-tool" || String(p?.type || "").startsWith("tool-")
-          )
           return (
             <div key={m.id} className={m.role === "user" ? "flex justify-end" : ""}>
               <div
                 className={
                   m.role === "user"
                     ? "bg-ui-bg-interactive text-ui-fg-on-color max-w-[80%] rounded-lg px-3 py-2"
-                    : "max-w-[92%]"
+                    : "max-w-[92%] space-y-2"
                 }
               >
-                {text ? (
-                  m.role === "user" ? (
+                {m.role === "user" ? (
+                  text ? (
                     <Text size="small" className="whitespace-pre-wrap">
                       {text}
                     </Text>
-                  ) : (
-                    <>
-                      <Markdown content={text} />
-                      {!streaming ? <CopyButton text={text} /> : null}
-                    </>
-                  )
-                ) : null}
-                {toolParts.map((p: any, i: number) => (
-                  <ToolPart
-                    key={p.toolCallId || i}
-                    part={p}
-                    collapsePreference={collapseTools}
-                  />
-                ))}
+                  ) : null
+                ) : (
+                  <>
+                    {/*
+                      In part ORDER. This used to concatenate every text part
+                      into one blob and render it above every tool card, so an
+                      answer written around its tool calls came out inverted:
+                      the summary the model wrote after a tool grew on top of
+                      the call it was describing, and each further step appended
+                      to that same block. Walking the parts puts narration
+                      before its tool and the closing summary last, which is the
+                      order the model actually wrote them in.
+                    */}
+                    {(m.parts || []).map((p: any, i: number) => {
+                      if (p?.type === "text" && typeof p.text === "string") {
+                        return p.text ? (
+                          <Markdown key={i} content={p.text} />
+                        ) : null
+                      }
+                      if (
+                        p?.type === "dynamic-tool" ||
+                        String(p?.type || "").startsWith("tool-")
+                      ) {
+                        return (
+                          <ToolPart
+                            key={p.toolCallId || i}
+                            part={p}
+                            collapsePreference={collapseTools}
+                          />
+                        )
+                      }
+                      return null
+                    })}
+                    {/* One copy affordance for the whole answer, not per block. */}
+                    {text && !streaming ? <CopyButton text={text} /> : null}
+                  </>
+                )}
               </div>
             </div>
           )


### PR DESCRIPTION
The admin assistant flattened **every** text part of a message into one string with `getText(m.parts)` and rendered that block **above** every tool card, then listed the tools underneath.

So an answer written around its tool calls came out inverted: the summary the model wrote *after* a tool appeared on top of the call it was describing, and each further step appended to that same growing block. The whole reply read as one section that kept accumulating, with the tool cards stranded below it.

Walk `m.parts` in order instead. Narration lands before the tool it introduces, and the closing summary lands last — the order the model actually wrote them in. The copy affordance stays one button for the whole answer rather than one per text block.

The partner assistant (`apps/partner-ui/src/routes/assistant/components/chat-thread.tsx`) already rendered parts in order; this brings the admin surface in line with it. Those are the only two chat renderers in the repo.

## Verify

Ask the admin assistant something that needs a tool, e.g. *"how many orders are unfulfilled?"* — the tool card should appear between the sentence that introduces it and the summary that follows, rather than below both.

`check:prod-build` passes locally (this compiles the admin frontend, so it is the gate that matters here). tsc unchanged at the 75 baseline.

🤖 Generated with [Claude Code](https://claude.com/claude-code)