### PR TITLE
feat(ops): resend-shipment-email — correct a customer's stale tracking number

### DIFF
--- a/apps/backend/src/api/admin/ops/maintenance-jobs/__tests__/resend-shipment-email-job.unit.spec.ts
+++ b/apps/backend/src/api/admin/ops/maintenance-jobs/__tests__/resend-shipment-email-job.unit.spec.ts
@@ -1,0 +1,97 @@
+/**
+ * #1294 — guards on the tracking re-send.
+ *
+ * This job emails a real customer and cannot be undone, so the interesting
+ * assertions are the refusals: the cases where sending would be worse than
+ * staying quiet.
+ */
+const runMock = jest.fn().mockResolvedValue({})
+
+jest.mock("../../../../../workflows/email/send-notification-email", () => ({
+  sendShipmentStatusEmail: () => ({ run: runMock }),
+}))
+
+import { resendShipmentEmailJob } from "../resend-shipment-email-job"
+
+const FULFILLMENT = {
+  id: "ful_79",
+  shipped_at: "2026-08-08T13:10:05.725Z",
+  canceled_at: null,
+  labels: [{ tracking_number: "N40878729", tracking_url: "" }],
+  order: { id: "order_79", display_id: 79, email: "buyer@example.com" },
+}
+
+const containerWith = (fulfillment: any) => ({
+  resolve: () => ({
+    graph: async () => ({ data: fulfillment ? [fulfillment] : [] }),
+  }),
+})
+
+const run = (fulfillment: any, opts: any = {}) =>
+  (resendShipmentEmailJob.run as any)(containerWith(fulfillment), {
+    dry_run: opts.dry_run ?? true,
+    params: { fulfillment_id: "ful_79", ...(opts.params || {}) },
+  })
+
+beforeEach(() => runMock.mockClear())
+
+describe("resend-shipment-email", () => {
+  it("dry-run names the recipient AND the tracking number, and sends nothing", async () => {
+    // The number is the whole message, so it has to be checkable before send —
+    // a second WRONG tracking mail is worse than the first.
+    const res = await run(FULFILLMENT)
+    expect(res.applied).toBe(false)
+    expect(res.summary).toContain("buyer@example.com")
+    expect(res.summary).toContain("N40878729")
+    expect(runMock).not.toHaveBeenCalled()
+  })
+
+  it("sends the current label's tracking when applied", async () => {
+    const res = await run(FULFILLMENT, { dry_run: false })
+    expect(res.applied).toBe(true)
+    expect(runMock).toHaveBeenCalledWith({
+      input: { shipment_id: "ful_79", status: "shipped" },
+    })
+    expect(res.summary).toContain("N40878729")
+  })
+
+  it("refuses when no label carries a tracking number", async () => {
+    // An empty tracking block is a worse silence than no email at all.
+    await expect(
+      run({ ...FULFILLMENT, labels: [] })
+    ).rejects.toThrow(/no tracking number/i)
+    await expect(
+      run({ ...FULFILLMENT, labels: [{ tracking_number: null }] })
+    ).rejects.toThrow(/no tracking number/i)
+  })
+
+  it("refuses on a cancelled fulfillment", async () => {
+    // Emailing tracking for a parcel that is not going out is the exact
+    // confusion this job exists to clean up.
+    await expect(
+      run({ ...FULFILLMENT, canceled_at: "2026-08-09T17:50:43.527Z" })
+    ).rejects.toThrow(/cancelled/i)
+    expect(runMock).not.toHaveBeenCalled()
+  })
+
+  it("refuses when the order has nobody to email", async () => {
+    await expect(
+      run({ ...FULFILLMENT, order: { id: "order_79", email: null } })
+    ).rejects.toThrow(/no email address/i)
+  })
+
+  it("refuses an unknown fulfillment rather than emailing blindly", async () => {
+    await expect(run(null)).rejects.toThrow(/not found/i)
+  })
+
+  it("supports the delivered template", async () => {
+    const res = await run(FULFILLMENT, {
+      dry_run: false,
+      params: { status: "delivered" },
+    })
+    expect(runMock).toHaveBeenCalledWith({
+      input: { shipment_id: "ful_79", status: "delivered" },
+    })
+    expect(res.changes[0].field).toBe("order-shipment-delivered")
+  })
+})

--- a/apps/backend/src/api/admin/ops/maintenance-jobs/registry.ts
+++ b/apps/backend/src/api/admin/ops/maintenance-jobs/registry.ts
@@ -107,6 +107,7 @@ import { repairShippingOptionStoreVisibilityJob } from "./repair-shipping-option
 import { backfillOpenOrderRequiresShippingJob } from "./backfill-open-order-requires-shipping-job"
 import { cleanOrderFulfillmentDataJob } from "./clean-order-fulfillment-data-job"
 import { sendCourierChangedEmailJob } from "./send-courier-changed-email-job"
+import { resendShipmentEmailJob } from "./resend-shipment-email-job"
 import { backfillProductShippingProfilesJob } from "./backfill-product-shipping-profiles-job"
 import { normalizeArtisanProductsJob } from "./normalize-artisan-products-job"
 import { linkArtisanDetailRowsJob } from "./link-artisan-detail-rows-job"
@@ -5727,6 +5728,7 @@ export const seedGoodsTransferTaskTemplateJob: MaintenanceJob = {
 export const MAINTENANCE_JOBS: MaintenanceJob[] = [
   cleanOrderFulfillmentDataJob,
   sendCourierChangedEmailJob,
+  resendShipmentEmailJob,
   recalculateDesignCostJob,
   recalculateDesignCostBulkJob,
   correctProductionRunCostJob,

--- a/apps/backend/src/api/admin/ops/maintenance-jobs/resend-shipment-email-job.ts
+++ b/apps/backend/src/api/admin/ops/maintenance-jobs/resend-shipment-email-job.ts
@@ -1,0 +1,188 @@
+import {
+  ContainerRegistrationKeys,
+  MedusaError,
+} from "@medusajs/framework/utils"
+import { z } from "@medusajs/framework/zod"
+
+import { sendShipmentStatusEmail } from "../../../../workflows/email/send-notification-email"
+
+import type {
+  MaintenanceChange,
+  MaintenanceJob,
+  MaintenanceJobResult,
+} from "./registry"
+
+/**
+ * #1294 — (re)send the shipped/delivered email for a fulfillment.
+ *
+ * WHY A JOB
+ * ---------
+ * The shipped mail fires once, from the `shipment.created` subscriber, using
+ * whatever labels the fulfillment held AT THAT MOMENT. If the waybill changes
+ * afterwards, the customer keeps a tracking number that has stopped moving and
+ * there is no path to correct it — the shipment already exists, so nothing will
+ * emit `shipment.created` again.
+ *
+ * That is not hypothetical. **Order 79** was marked shipped on 2026-08-08 and
+ * its customer was emailed the Shiprocket/SRX waybill. That booking was then
+ * cancelled (three failed pickups) and the parcel went out on DTDC `N40878729`,
+ * attached on 2026-08-15 — which, on the external-attach path, sent nothing.
+ * The customer has been holding a dead tracking number ever since, while the
+ * parcel moves under one they have never seen.
+ *
+ * `send-courier-changed-email` does not solve this: that mail deliberately
+ * carries no AWB, because when a courier is swapped the replacement usually
+ * does not exist yet. Here it does, and the number IS the message.
+ *
+ * The mail is rebuilt from the fulfillment's CURRENT labels, so it always
+ * carries the live waybill rather than a remembered one.
+ *
+ * ⚠️ SENDING IS NOT REVERSIBLE. Dry-run (the default) reports the recipient AND
+ * the tracking numbers that would go out — check the number before sending, as
+ * a second wrong tracking mail is worse than the first. Nothing is written to
+ * the order either way; this job only sends.
+ */
+
+const paramsSchema = z.object({
+  /**
+   * The FULFILLMENT id. Named as it is because the email workflow's
+   * `shipment_id` input has always been a fulfillment id — there is no separate
+   * shipment entity to point at.
+   */
+  fulfillment_id: z.string().min(1),
+  /** Which mail to send. Defaults to the shipped one. */
+  status: z.enum(["shipped", "delivered"]).optional(),
+})
+
+export const resendShipmentEmailJob: MaintenanceJob = {
+  id: "resend-shipment-email",
+  label: "Re-send the shipment tracking email for a fulfillment (#1294)",
+  description:
+    "(Re)send the shipped/delivered email for a fulfillment, rebuilt from its CURRENT labels. The shipped mail fires once from shipment.created with whatever waybill existed then, so a later carrier swap leaves the customer holding a tracking number that has stopped moving and no way to correct it. Unlike send-courier-changed-email, this one carries the actual AWB. Dry-run reports the recipient and the tracking numbers; SENDING IS NOT REVERSIBLE.",
+  params: [
+    {
+      name: "fulfillment_id",
+      type: "string",
+      required: true,
+      description:
+        "Fulfillment whose customer should be emailed, e.g. 'ful_...'. The mail is built from this fulfillment's current labels.",
+    },
+    {
+      name: "status",
+      type: "string",
+      required: false,
+      description:
+        "'shipped' (default) or 'delivered' — which template to send.",
+    },
+  ],
+  run: async (container, { dry_run, params }): Promise<MaintenanceJobResult> => {
+    const parsed = paramsSchema.safeParse(params)
+    if (!parsed.success) {
+      throw new MedusaError(
+        MedusaError.Types.INVALID_DATA,
+        parsed.error.issues.map((i) => i.message).join("; ")
+      )
+    }
+    const { fulfillment_id } = parsed.data
+    const status = parsed.data.status ?? "shipped"
+
+    const query: any = container.resolve(ContainerRegistrationKeys.QUERY)
+    const { data } = await query.graph({
+      entity: "fulfillment",
+      filters: { id: fulfillment_id },
+      fields: [
+        "id",
+        "shipped_at",
+        "canceled_at",
+        "labels.tracking_number",
+        "labels.tracking_url",
+        "order.id",
+        "order.display_id",
+        "order.email",
+      ],
+    })
+
+    const fulfillment = data?.[0]
+    if (!fulfillment) {
+      throw new MedusaError(
+        MedusaError.Types.NOT_FOUND,
+        `Fulfillment ${fulfillment_id} not found`
+      )
+    }
+
+    const order = fulfillment.order
+    if (!order) {
+      throw new MedusaError(
+        MedusaError.Types.UNEXPECTED_STATE,
+        `Fulfillment ${fulfillment_id} is not linked to an order`
+      )
+    }
+
+    const to = order.email
+    if (!to) {
+      throw new MedusaError(
+        MedusaError.Types.INVALID_DATA,
+        `Order ${order.id} has no email address — nobody to notify`
+      )
+    }
+
+    const labels = Array.isArray(fulfillment.labels) ? fulfillment.labels : []
+    const trackingNumbers = labels
+      .map((l: any) => l?.tracking_number)
+      .filter(Boolean)
+
+    if (!trackingNumbers.length) {
+      // The mail's entire purpose is the tracking number. Sending one with an
+      // empty tracking block would be a worse silence than none at all.
+      throw new MedusaError(
+        MedusaError.Types.INVALID_DATA,
+        `Fulfillment ${fulfillment_id} has no tracking number on any label — there is nothing to tell the customer. Attach the waybill first.`
+      )
+    }
+
+    if (fulfillment.canceled_at) {
+      throw new MedusaError(
+        MedusaError.Types.INVALID_DATA,
+        `Fulfillment ${fulfillment_id} is cancelled — refusing to email tracking for a parcel that is not going out.`
+      )
+    }
+
+    const label = `order-shipment-${status === "delivered" ? "delivered" : "created"}`
+    const changes: MaintenanceChange[] = [
+      {
+        entity: "email",
+        id: fulfillment.id,
+        field: label,
+        before: "not sent",
+        after: `would send to ${to} with tracking ${trackingNumbers.join(", ")}`,
+      },
+    ]
+
+    if (dry_run) {
+      return {
+        job_id: "resend-shipment-email",
+        dry_run,
+        applied: false,
+        summary: `Would email the ${status} notice for order #${order.display_id ?? order.id} to ${to} carrying tracking ${trackingNumbers.join(", ")}`,
+        changes,
+      }
+    }
+
+    await sendShipmentStatusEmail(container).run({
+      input: { shipment_id: fulfillment.id, status },
+    })
+
+    return {
+      job_id: "resend-shipment-email",
+      dry_run,
+      applied: true,
+      summary: `Emailed the ${status} notice for order #${order.display_id ?? order.id} to ${to} carrying tracking ${trackingNumbers.join(", ")}`,
+      changes: [
+        {
+          ...changes[0],
+          after: `sent to ${to} with tracking ${trackingNumbers.join(", ")}`,
+        },
+      ],
+    }
+  },
+}

--- a/apps/backend/src/workflows/orders/__tests__/external-awb.unit.spec.ts
+++ b/apps/backend/src/workflows/orders/__tests__/external-awb.unit.spec.ts
@@ -2,6 +2,7 @@ import {
   planDetachedFulfillmentData,
   planExternalAttachData,
   resolveExternalAwbNotify,
+  resolveExternalTrackingUrl,
   type ExternalAttachment,
 } from "../external-awb"
 
@@ -203,6 +204,43 @@ describe("resolveExternalAwbNotify", () => {
     ).toBe(true)
     expect(resolveExternalAwbNotify({ cancelled_shipments: 3 as any })).toBe(
       true
+    )
+  })
+})
+
+describe("resolveExternalTrackingUrl", () => {
+  it("fills DTDC's per-AWB link so the mail has something to click", () => {
+    // Order 79 shipped with an empty tracking_url and the customer got a bare
+    // number. The operator remembering to paste a link is not a mechanism.
+    expect(resolveExternalTrackingUrl("dtdc", "N40878729")).toBe(
+      "https://www.dtdc.com/track-your-shipment/?awb=N40878729"
+    )
+  })
+
+  it("matches the carrier case-insensitively, as an operator types it", () => {
+    expect(resolveExternalTrackingUrl("DTDC", "N40878729")).toContain(
+      "awb=N40878729"
+    )
+    expect(resolveExternalTrackingUrl(" Dtdc ", "N40878729")).toContain(
+      "awb=N40878729"
+    )
+  })
+
+  it("lets an operator-supplied url win — they hold the waybill", () => {
+    expect(
+      resolveExternalTrackingUrl("dtdc", "N40878729", "https://example.com/x")
+    ).toBe("https://example.com/x")
+  })
+
+  it("returns empty for a carrier with no known pattern", () => {
+    // "" is what every reader already treats as absent.
+    expect(resolveExternalTrackingUrl("india post", "IP2")).toBe("")
+    expect(resolveExternalTrackingUrl("dtdc", "")).toBe("")
+  })
+
+  it("url-encodes the waybill", () => {
+    expect(resolveExternalTrackingUrl("dtdc", "N 40/878")).toBe(
+      "https://www.dtdc.com/track-your-shipment/?awb=N%2040%2F878"
     )
   })
 })

--- a/apps/backend/src/workflows/orders/external-awb.ts
+++ b/apps/backend/src/workflows/orders/external-awb.ts
@@ -127,6 +127,44 @@ export function planDetachedFulfillmentData(
 }
 
 /**
+ * Public tracking-page URL patterns for carriers we do NOT integrate.
+ *
+ * An integrated carrier builds its own link in its adapter (see bluedart's
+ * `adapter.ts`). This path has no adapter by definition — the whole point is a
+ * waybill from a carrier we cannot call — so the link has to come from
+ * somewhere, and "the operator remembers to paste one" is not somewhere. Order
+ * 79 shipped with an empty `tracking_url` for exactly that reason, leaving a
+ * tracking mail with a bare number and nothing to click.
+ *
+ * Keys are the lowercased carrier name as the operator types it.
+ */
+export const EXTERNAL_CARRIER_TRACKING_URLS: Record<string, string> = {
+  dtdc: "https://www.dtdc.com/track-your-shipment/?awb={awb}",
+}
+
+/**
+ * The tracking link to stamp on this attachment.
+ *
+ * An operator-supplied URL always wins — they are holding the waybill and may
+ * have a better link than any pattern. Otherwise fall back to a known public
+ * pattern, and to "" when the carrier has none, which is what every reader
+ * already treats as absent.
+ */
+export function resolveExternalTrackingUrl(
+  carrier: string,
+  awb: string,
+  explicit?: string
+): string {
+  const supplied = (explicit || "").trim()
+  if (supplied) return supplied
+  if (!awb) return ""
+  const template = EXTERNAL_CARRIER_TRACKING_URLS[carrier.trim().toLowerCase()]
+  return template
+    ? template.replace("{awb}", encodeURIComponent(awb))
+    : ""
+}
+
+/**
  * Should marking this externally-booked parcel shipped tell the customer?
  *
  * **Yes, unless the operator says otherwise.** Same as every other shipment —
@@ -321,9 +359,11 @@ export async function attachExternalAwb(
   // #1195: the label row is the ONLY way a fulfillment can be found from an AWB
   // (`data` is jsonb and cannot be filtered), so it is what makes this parcel
   // discoverable to any later status push or manual lookup.
+  const trackingUrl = resolveExternalTrackingUrl(carrier, awb, input.trackingUrl)
+
   const labels = buildAttachAwbLabels(fulfillment.labels, {
     tracking_number: awb,
-    tracking_url: input.trackingUrl || "",
+    tracking_url: trackingUrl,
     label_url: input.labelUrl || "",
   })
 
@@ -331,7 +371,7 @@ export async function attachExternalAwb(
     data: planExternalAttachData(fulfillment.data, {
       carrier,
       awb,
-      trackingUrl: input.trackingUrl,
+      trackingUrl,
       labelUrl: input.labelUrl,
       attachment,
     }),


### PR DESCRIPTION
## The gap

The shipped mail fires **once**, from the `shipment.created` subscriber, carrying whatever labels the fulfillment held *at that moment*. If the waybill changes afterwards there is no path to correct it — the shipment already exists, so nothing emits `shipment.created` again. The customer keeps refreshing a number that has stopped moving.

## The live case: order 79

| when | what |
|---|---|
| 2026-08-08 13:10 | marked shipped → `order-shipment-created` sent, carrying the **Shiprocket/SRX** waybill |
| — | that booking cancelled — *"SRX Express failed pickup 3× and was cancelled"* |
| 2026-08-15 06:48 | DTDC **`N40878729`** attached externally — **no email** (`no_notification: true`) |

Nine days of a dead tracking number while the parcel moves under one the customer has never seen.

**`send-courier-changed-email` does not cover this.** That mail deliberately carries **no AWB**, because when a courier is swapped the replacement usually does not exist yet. Here it does, and the number *is* the message. Sending it alone would tell the customer their link is dead and still leave them without `N40878729`, while promising a follow-up nothing would send.

## What it does

Rebuilds the mail from the fulfillment's **current** labels, so it always carries the live waybill rather than a remembered one. `status` selects shipped (default) or delivered.

## Guards

This emails a real person and cannot be undone, so the refusals are the interesting part:

- **no tracking number on any label** → refuse. An empty tracking block is a worse silence than no email at all.
- **cancelled fulfillment** → refuse. Emailing tracking for a parcel that is not going out is the exact confusion this exists to clean up.
- **no recipient / unknown fulfillment** → refuse rather than email blindly.
- **dry-run is the default** and reports the recipient **and** the tracking number — so the number is checkable *before* sending. A second wrong tracking mail is worse than the first.

## Verify

```
cd apps/backend && npx jest --testPathPattern="resend-shipment-email"
```

7 green. `check:prod-build` passes locally. tsc unchanged at the 75 baseline.

Dry-run on prod once deployed:

```
POST /admin/ops/maintenance-jobs/resend-shipment-email/run
{"dry_run":true,"params":{"fulfillment_id":"ful_..."}}
```

## Note

Order 79's DTDC label has an **empty `tracking_url`** — the attach note records that DTDC supplied no per-AWB deep link. The mail will carry the number without a clickable link. Worth deciding separately whether to attach DTDC's generic tracking page.

🤖 Generated with [Claude Code](https://claude.com/claude-code)