### PR TITLE
feat(mcp): per-ask tool slicing for the partner assistant

### DIFF
--- a/apps/backend/src/api/partners/assistant/chat/route.ts
+++ b/apps/backend/src/api/partners/assistant/chat/route.ts
@@ -12,6 +12,12 @@
  *     running; the frontend surfaces an approval card and, on confirm, calls
  *     POST /partners/mcp directly with `confirm: true`.
  *
+ * The full registry stays bound (every tool stays callable), but only a
+ * per-ask slice is serialised to the provider via `activeTools` + prepareStep
+ * (see ../../mcp/lib/tool-slice) — so the ~178-tool registry does not become a
+ * per-turn token cost. A `load_partner_tools` escape hatch widens the slice
+ * mid-run when the model asks for a domain it wasn't given.
+ *
  * Pipeline mirrors the theme-editor chat (#339): resolve the chat model for the
  * `ai_partner_assistant` role (DB-configured platform → OpenRouter free
  * fallback), bind tools, `streamText(...)`, and pipe the UI message stream into
@@ -30,6 +36,12 @@ import { resolveRoleTextModel, logAiUsage } from "../../../../mastra/services/ai
 import { dynamicFreeToolTextModel } from "../../../../mastra/providers/dynamic-text-model"
 import { foldSystemForProvider } from "../../../store/ai/chat/system-fold-lib"
 import { PARTNER_MCP_TOOLS, renderToolGuidance } from "../../mcp/lib/registry"
+import {
+  selectPartnerToolSlice,
+  toolsInDomains,
+  toolDomain,
+  SELECTABLE_DOMAINS,
+} from "../../mcp/lib/tool-slice"
 import {
   dispatchPartnerTool,
   buildToolInputSchema,
@@ -53,6 +65,9 @@ const SYSTEM_PROMPT = `You are the JYT partner-portal assistant. You help partne
 - For ONBOARDING: guide the partner conversationally. The essential gate is a business name + a persona (workspace_type: 'seller' | 'manufacturer' | 'individual' | 'designer'). Set those with \`update_partner_profile\`, and when both are set, merge \`metadata.onboarding_essentials_done = true\` into their existing metadata (read it from get_partner_profile first — metadata is REPLACED, not patched, so always spread the existing values). Record deeper answers (what they sell, team size, selling mode, etc.) with \`update_onboarding_profile\`.
 - For LAYOUT personalization: use the layout tools to reorder or hide sidebar/home widgets for zones 'sidebar.main' and 'home'.
 - To answer questions about their business, use the read tools (list_orders, list_products, list_stores, list_designs, list_inventory_items, list_notifications).
+
+## Your tools are loaded on demand
+You are given the tools for the domains this conversation appears to be about, not the full partner surface. If the tool you need is not in your list, DO NOT tell the user it is impossible or improvise with a different tool — call \`load_partner_tools\` with the relevant domains (orders, catalog, storefront, designs, production, inventory, customers, money) and the tools become callable on your next step. Loading a domain you turn out not to need is harmless.
 
 ## Safety rails (important)
 - Every tool accepts \`dry_run: true\`. Use it to PREVIEW a change and inspect the current object before you actually write — especially before any update. Show the user what will change, then run the tool for real.
@@ -95,8 +110,10 @@ export const POST = async (
 
   // Bind the registry as AI-SDK tools. One source of truth (JSON Schema) feeds
   // both this binding and the MCP endpoint's tools/list.
-  const tools = Object.fromEntries(
-    PARTNER_MCP_TOOLS.filter((def) => writeEnabled || !def.write).map((def) => [
+  const enabled = PARTNER_MCP_TOOLS.filter((def) => writeEnabled || !def.write)
+
+  const tools: Record<string, any> = Object.fromEntries(
+    enabled.map((def) => [
       def.name,
       tool({
         description:
@@ -127,6 +144,69 @@ export const POST = async (
     }
   })
 
+  // ---- Per-ask registry slicing -------------------------------------------
+  // All ~178 tools stay BOUND (so any of them can still execute), but only the
+  // slice this ask needs is serialised to the provider via `activeTools`.
+  // Without this every turn re-sends the whole registry, which is both the
+  // dominant token cost of a conversation and — because the free rotator ranks
+  // by context length — a lever on which model answers.
+  //
+  // `activated` is the live slice. It starts from keyword matching on the recent
+  // conversation and can only ever GROW, via load_partner_tools below, so a bad
+  // initial guess costs one round trip rather than a capability.
+  const recentText = messages
+    .slice(-6)
+    .map((m: any) => m.parts.map((p: any) => p.text).join(" "))
+    .join("\n")
+
+  const initialSlice = selectPartnerToolSlice(recentText, enabled)
+  const activated = new Set<string>(initialSlice.names)
+
+  logger.debug?.(
+    `[${FEATURE}] tool slice: ${activated.size}/${enabled.length} tools` +
+      ` (domains: ${initialSlice.domains.join(", ") || "none matched"})`
+  )
+
+  // The escape hatch. Always active, so the model is never boxed in by a slice
+  // that guessed wrong — it names the domains it needs and they light up on the
+  // next step. This is also why the slice can be aggressive.
+  tools.load_partner_tools = tool({
+    description:
+      "Load the tools for one or more partner domains when the tool you need is not currently available to you. " +
+      `Valid domains: ${SELECTABLE_DOMAINS.join(", ")}. ` +
+      "Returns the names and descriptions of the tools that just became callable — call them on your next step. " +
+      "Use this instead of telling the user something is impossible.",
+    inputSchema: jsonSchema({
+      type: "object",
+      properties: {
+        domains: {
+          type: "array",
+          items: { type: "string", enum: SELECTABLE_DOMAINS },
+          description: "The partner domains to load tools for.",
+        },
+      },
+      required: ["domains"],
+      additionalProperties: false,
+    }),
+    execute: async ({ domains }: { domains: string[] }) => {
+      const names = toolsInDomains(domains ?? [], enabled)
+      names.forEach((n) => activated.add(n))
+      return {
+        ok: true,
+        loaded: names.length,
+        domains: domains ?? [],
+        tools: enabled
+          .filter((d) => names.includes(d.name))
+          .map((d) => ({
+            name: d.name,
+            domain: toolDomain(d),
+            description: d.description,
+          })),
+      }
+    },
+  })
+  activated.add("load_partner_tools")
+
   // This assistant REQUIRES tool calling. The free rotator ranks by context
   // length and can land on a text-only model ("No endpoints found that support
   // tool use"), so on the free path use the tool-capable variant (openrouter/
@@ -155,6 +235,9 @@ export const POST = async (
         ...(folded.system ? { system: folded.system } : {}),
         messages: convertToModelMessages(folded.messages as any),
         tools,
+        // Re-read `activated` before every step so tools loaded via
+        // load_partner_tools become callable on the very next one.
+        prepareStep: () => ({ activeTools: [...activated] }),
         stopWhen: stepCountIs(8),
         temperature: 0.3,
         // Let the AI SDK retry transient network/5xx failures at the model

--- a/apps/backend/src/api/partners/assistant/chat/route.ts
+++ b/apps/backend/src/api/partners/assistant/chat/route.ts
@@ -39,6 +39,7 @@ import { PARTNER_MCP_TOOLS, renderToolGuidance } from "../../mcp/lib/registry"
 import {
   selectPartnerToolSlice,
   toolsInDomains,
+  widenedDomainsFromHistory,
   toolDomain,
   SELECTABLE_DOMAINS,
 } from "../../mcp/lib/tool-slice"
@@ -162,9 +163,19 @@ export const POST = async (
   const initialSlice = selectPartnerToolSlice(recentText, enabled)
   const activated = new Set<string>(initialSlice.names)
 
+  // Carry forward whatever the model widened into earlier in this conversation.
+  // Keyword matching runs fresh every request and history arrives text-only, so
+  // without this a domain bought with a round trip on the previous turn is gone
+  // on this one — and "now do the same for the other one" pays for it twice.
+  const carried = widenedDomainsFromHistory(body.messages)
+  if (carried.length) {
+    toolsInDomains(carried, enabled).forEach((n) => activated.add(n))
+  }
+
   logger.debug?.(
     `[${FEATURE}] tool slice: ${activated.size}/${enabled.length} tools` +
-      ` (domains: ${initialSlice.domains.join(", ") || "none matched"})`
+      ` (domains: ${initialSlice.domains.join(", ") || "none matched"}` +
+      `${carried.length ? `; carried: ${carried.join(", ")}` : ""})`
   )
 
   // The escape hatch. Always active, so the model is never boxed in by a slice

--- a/apps/backend/src/api/partners/mcp/lib/__tests__/tool-slice.unit.spec.ts
+++ b/apps/backend/src/api/partners/mcp/lib/__tests__/tool-slice.unit.spec.ts
@@ -1,0 +1,224 @@
+import {
+  selectPartnerToolSlice,
+  matchDomains,
+  toolDomain,
+  toolsInDomains,
+  ALWAYS_ON_TOOLS,
+  SELECTABLE_DOMAINS,
+} from "../tool-slice"
+import { PARTNER_MCP_TOOLS } from "../registry"
+import { buildToolInputSchema } from "../dispatch"
+
+/** Rough token proxy — what actually gets serialised per tool definition. */
+const weigh = (names: string[]) => {
+  const byName = new Map(PARTNER_MCP_TOOLS.map((t) => [t.name, t]))
+  const defs = names
+    .map((n) => byName.get(n))
+    .filter(Boolean)
+    .map((d: any) => ({
+      name: d.name,
+      description: d.description,
+      schema: buildToolInputSchema(d),
+    }))
+  return Math.round(JSON.stringify(defs).length / 4)
+}
+
+describe("partner-mcp per-ask tool slicing", () => {
+  describe("domain classification", () => {
+    it("classifies EVERY registry tool — an unclassified tool would be unreachable", () => {
+      const orphans = PARTNER_MCP_TOOLS.filter((t) => !toolDomain(t)).map(
+        (t) => `${t.name} (${t.path})`
+      )
+      expect(orphans).toEqual([])
+    })
+
+    it("classifies store-product tools as storefront, NOT catalog", () => {
+      // bulk_update_products lives under /partners/stores/:id/products/bulk-update,
+      // so it classifies as storefront — even though a partner thinks "products".
+      const byName = new Map(PARTNER_MCP_TOOLS.map((t) => [t.name, t]))
+      expect(toolDomain(byName.get("bulk_update_products")!)).toBe("storefront")
+      expect(toolDomain(byName.get("update_store_product")!)).toBe("storefront")
+      // ...while the partner's own product record + taxonomy stay in catalog.
+      expect(toolDomain(byName.get("create_product")!)).toBe("catalog")
+      expect(toolDomain(byName.get("list_product_categories")!)).toBe("catalog")
+    })
+
+    it("groups sibling route families under one domain", () => {
+      const domainOf = (name: string) =>
+        toolDomain(PARTNER_MCP_TOOLS.find((t) => t.name === name)!)
+      expect(domainOf("create_order_fulfillment")).toBe("orders")
+      expect(domainOf("list_returns")).toBe("orders")
+      expect(domainOf("add_design_media")).toBe("designs")
+      expect(domainOf("accept_production_run")).toBe("production")
+      expect(domainOf("list_raw_materials")).toBe("inventory")
+      expect(domainOf("create_customer")).toBe("customers")
+      expect(domainOf("get_payment")).toBe("money")
+      // The cross-cutting surface (identity, onboarding, layout, media, ai,
+      // notifications, currencies) is the always-present core.
+      expect(domainOf("get_partner_profile")).toBe("core")
+      expect(domainOf("describe_image")).toBe("core")
+      expect(domainOf("list_currencies")).toBe("core")
+    })
+
+    it("every selectable domain actually owns tools", () => {
+      for (const domain of SELECTABLE_DOMAINS) {
+        expect({
+          domain,
+          count: toolsInDomains([domain], PARTNER_MCP_TOOLS).length,
+        }).toEqual({ domain, count: expect.any(Number) })
+        expect(toolsInDomains([domain], PARTNER_MCP_TOOLS).length).toBeGreaterThan(0)
+      }
+    })
+  })
+
+  describe("keyword matching", () => {
+    it("matches the domain a partner is obviously asking about", () => {
+      expect(matchDomains("ship order 123 and mark it delivered")).toContain("orders")
+      expect(matchDomains("which production runs are still open?")).toContain(
+        "production"
+      )
+      expect(matchDomains("set the size sets on this design")).toContain("designs")
+      expect(matchDomains("how much raw material fabric is in stock")).toContain(
+        "inventory"
+      )
+      expect(matchDomains("update my storefront website and domain")).toContain(
+        "storefront"
+      )
+      expect(matchDomains("list my customers and their groups")).toContain(
+        "customers"
+      )
+      expect(matchDomains("what payments have come in")).toContain("money")
+      expect(matchDomains("create a new product category")).toContain("catalog")
+    })
+
+    it("matches on word boundaries, not substrings", () => {
+      // "reordering" must not light up orders via a bare "order" substring...
+      expect(matchDomains("reordering the dashboard widgets")).not.toContain("orders")
+      // ...but the real word still matches.
+      expect(matchDomains("cancel this order")).toContain("orders")
+    })
+
+    it("returns nothing for an ask with no operational vocabulary", () => {
+      expect(matchDomains("hi, what can you do?")).toEqual([])
+    })
+  })
+
+  describe("slice selection", () => {
+    it("always includes grounding + the top-level list reads, whatever the ask", () => {
+      const slice = selectPartnerToolSlice("hi", PARTNER_MCP_TOOLS)
+      for (const name of ALWAYS_ON_TOOLS) {
+        expect(slice.names).toContain(name)
+      }
+      expect(slice.domains).toEqual([])
+    })
+
+    it("a focused ask yields a small slice, not the whole registry", () => {
+      const slice = selectPartnerToolSlice(
+        "ship order_123 today and mark it delivered",
+        PARTNER_MCP_TOOLS
+      )
+      expect(slice.domains).toContain("orders")
+      expect(slice.names).toContain("create_order_fulfillment")
+      expect(slice.names).toContain("mark_fulfillment_delivered")
+      // Unrelated domains stay out.
+      expect(slice.names).not.toContain("accept_production_run")
+      expect(slice.names).not.toContain("create_store")
+      expect(slice.names).not.toContain("get_payment")
+      expect(slice.names.length).toBeLessThan(PARTNER_MCP_TOOLS.length / 2)
+    })
+
+    it("a multi-domain ask pulls in every domain it mentions", () => {
+      const slice = selectPartnerToolSlice(
+        "accept the production run for this design and update its media",
+        PARTNER_MCP_TOOLS
+      )
+      expect(slice.domains).toEqual(
+        expect.arrayContaining(["production", "designs"])
+      )
+      expect(slice.names).toContain("accept_production_run")
+      expect(slice.names).toContain("update_design")
+      expect(slice.names).toContain("add_design_media")
+    })
+
+    it("never re-admits a tool the write gate removed", () => {
+      const readsOnly = PARTNER_MCP_TOOLS.filter((t) => !t.write)
+      const slice = selectPartnerToolSlice(
+        "delete the customer and create a return",
+        readsOnly
+      )
+      expect(slice.names).not.toContain("delete_customer")
+      expect(slice.names).not.toContain("create_return")
+      // Everything it did pick is genuinely available.
+      const available = new Set(readsOnly.map((t) => t.name))
+      for (const n of slice.names) expect(available.has(n)).toBe(true)
+    })
+
+    it("cuts the serialised tool payload substantially for a focused ask", () => {
+      const full = weigh(PARTNER_MCP_TOOLS.map((t) => t.name))
+      const sliced = weigh(
+        selectPartnerToolSlice("ship order_123 today", PARTNER_MCP_TOOLS).names
+      )
+      expect(sliced).toBeLessThan(full / 2)
+    })
+  })
+
+  describe("widening (the escape hatch)", () => {
+    it("toolsInDomains returns exactly that domain's tools", () => {
+      const names = toolsInDomains(["money"], PARTNER_MCP_TOOLS)
+      expect(names).toContain("list_payment_providers")
+      expect(names).not.toContain("list_orders")
+    })
+
+    it("widening a slice can reach any tool the write gate left enabled", () => {
+      const slice = selectPartnerToolSlice("hi", PARTNER_MCP_TOOLS)
+      const activated = new Set(slice.names)
+      for (const domain of SELECTABLE_DOMAINS) {
+        toolsInDomains([domain], PARTNER_MCP_TOOLS).forEach((n) =>
+          activated.add(n)
+        )
+      }
+      // Core is always on, and every other domain is reachable on request, so
+      // the union must cover the whole registry — nothing is orphaned.
+      for (const def of PARTNER_MCP_TOOLS) {
+        expect(`${def.name}:${activated.has(def.name)}`).toBe(`${def.name}:true`)
+      }
+    })
+
+    it("ignores unknown domain names rather than throwing", () => {
+      expect(toolsInDomains(["not_a_domain"], PARTNER_MCP_TOOLS)).toEqual([])
+    })
+  })
+
+  describe("bulk store-product edits reach the storefront slice", () => {
+    // bulk_update_products classifies as storefront (it lives under
+    // /partners/stores), and the asks that need it are phrased in bulk/product
+    // words. Without these keywords the one tool that can serve them never
+    // loads — the partner would be told "impossible".
+    it("classifies bulk_update_products as storefront", () => {
+      const byName = new Map(PARTNER_MCP_TOOLS.map((t) => [t.name, t]))
+      expect(toolDomain(byName.get("bulk_update_products")!)).toBe("storefront")
+    })
+
+    it.each([
+      "bulk update the prices on all my products",
+      "update all products in this store in bulk",
+      "set stock to zero for every product",
+    ])("activates it for: %s", (ask) => {
+      const slice = selectPartnerToolSlice(ask, PARTNER_MCP_TOOLS)
+      expect(slice.names).toContain("bulk_update_products")
+    })
+  })
+
+  describe("storefront management reaches the storefront slice", () => {
+    it.each([
+      "publish my storefront website",
+      "set up a custom domain for my storefront",
+      "redeploy the storefront after an edit",
+      "provision my storefront",
+      "add a page to my storefront",
+    ])("activates storefront for: %s", (ask) => {
+      const slice = selectPartnerToolSlice(ask, PARTNER_MCP_TOOLS)
+      expect(slice.domains).toContain("storefront")
+    })
+  })
+})

--- a/apps/backend/src/api/partners/mcp/lib/__tests__/tool-slice.unit.spec.ts
+++ b/apps/backend/src/api/partners/mcp/lib/__tests__/tool-slice.unit.spec.ts
@@ -2,7 +2,9 @@ import {
   selectPartnerToolSlice,
   matchDomains,
   toolDomain,
+  toolRouteFamily,
   toolsInDomains,
+  widenedDomainsFromHistory,
   ALWAYS_ON_TOOLS,
   SELECTABLE_DOMAINS,
 } from "../tool-slice"
@@ -32,15 +34,29 @@ describe("partner-mcp per-ask tool slicing", () => {
       expect(orphans).toEqual([])
     })
 
-    it("classifies store-product tools as storefront, NOT catalog", () => {
-      // bulk_update_products lives under /partners/stores/:id/products/bulk-update,
-      // so it classifies as storefront — even though a partner thinks "products".
+    it("classifies store PRODUCTS as catalog, and store CONFIG as storefront", () => {
+      // Store products live under /partners/stores/:id/products, but a partner
+      // asks for them in product words ("update the price of my product"), never
+      // store words — so they classify with the rest of the catalog. Route shape
+      // and vocabulary part company here; vocabulary wins, because a domain is
+      // only useful if the words for a tool select the domain that OWNS it.
       const byName = new Map(PARTNER_MCP_TOOLS.map((t) => [t.name, t]))
-      expect(toolDomain(byName.get("bulk_update_products")!)).toBe("storefront")
-      expect(toolDomain(byName.get("update_store_product")!)).toBe("storefront")
-      // ...while the partner's own product record + taxonomy stay in catalog.
+      expect(toolDomain(byName.get("bulk_update_products")!)).toBe("catalog")
+      expect(toolDomain(byName.get("update_store_product")!)).toBe("catalog")
+      expect(toolDomain(byName.get("list_store_product_variants")!)).toBe("catalog")
+      expect(toolDomain(byName.get("list_missing_hs_codes")!)).toBe("catalog")
       expect(toolDomain(byName.get("create_product")!)).toBe("catalog")
       expect(toolDomain(byName.get("list_product_categories")!)).toBe("catalog")
+
+      // The same reasoning routes two more store sub-trees by meaning: a store
+      // "location" is a stock location, and payment providers are money.
+      expect(toolDomain(byName.get("add_store_location")!)).toBe("inventory")
+      expect(toolDomain(byName.get("list_store_payment_providers")!)).toBe("money")
+
+      // What remains under /partners/stores is genuine store CONFIGURATION.
+      expect(toolDomain(byName.get("add_store_sales_channel")!)).toBe("storefront")
+      expect(toolDomain(byName.get("add_store_shipping_option")!)).toBe("storefront")
+      expect(toolDomain(byName.get("add_store_tax_region")!)).toBe("storefront")
     })
 
     it("groups sibling route families under one domain", () => {
@@ -187,18 +203,87 @@ describe("partner-mcp per-ask tool slicing", () => {
     it("ignores unknown domain names rather than throwing", () => {
       expect(toolsInDomains(["not_a_domain"], PARTNER_MCP_TOOLS)).toEqual([])
     })
+
+    describe("carrying a widened slice across turns", () => {
+      const loadPart = (domains: any, key: "input" | "output" = "input") => ({
+        role: "assistant",
+        parts: [{ type: "tool-load_partner_tools", [key]: { domains } }],
+      })
+
+      it("recovers the domains loaded on an earlier turn", () => {
+        expect(widenedDomainsFromHistory([loadPart(["money"])])).toEqual(["money"])
+        expect(
+          widenedDomainsFromHistory([loadPart(["designs"], "output")])
+        ).toEqual(["designs"])
+      })
+
+      it("reads dynamic-tool parts too", () => {
+        expect(
+          widenedDomainsFromHistory([
+            {
+              role: "assistant",
+              parts: [
+                {
+                  type: "dynamic-tool",
+                  toolName: "load_partner_tools",
+                  input: { domains: ["inventory"] },
+                },
+              ],
+            },
+          ])
+        ).toEqual(["inventory"])
+      })
+
+      it("accepts only known domains, whatever the history claims", () => {
+        expect(
+          widenedDomainsFromHistory([
+            loadPart(["money", "not_a_domain", "core", 42, null]),
+          ])
+        ).toEqual(["money"])
+      })
+
+      it("survives malformed or absent history without throwing", () => {
+        expect(widenedDomainsFromHistory(undefined)).toEqual([])
+        expect(widenedDomainsFromHistory([])).toEqual([])
+        expect(widenedDomainsFromHistory([{ role: "user" }])).toEqual([])
+        expect(
+          widenedDomainsFromHistory([
+            { role: "assistant", parts: [{ type: "text", text: "hi" }] },
+          ])
+        ).toEqual([])
+        expect(
+          widenedDomainsFromHistory([loadPart("money" as any)])
+        ).toEqual([])
+      })
+
+      it("ignores other tools' parts", () => {
+        expect(
+          widenedDomainsFromHistory([
+            {
+              role: "assistant",
+              parts: [
+                { type: "tool-list_orders", input: { domains: ["money"] } },
+              ],
+            },
+          ])
+        ).toEqual([])
+      })
+
+      it("what it recovers is exactly what the escape hatch would load", () => {
+        // The carry-forward must be equivalent to re-calling load_partner_tools
+        // — otherwise turn N+1 gets a subtly different surface from turn N.
+        const carried = widenedDomainsFromHistory([loadPart(["money"])])
+        expect(toolsInDomains(carried, PARTNER_MCP_TOOLS)).toEqual(
+          toolsInDomains(["money"], PARTNER_MCP_TOOLS)
+        )
+      })
+    })
   })
 
-  describe("bulk store-product edits reach the storefront slice", () => {
-    // bulk_update_products classifies as storefront (it lives under
-    // /partners/stores), and the asks that need it are phrased in bulk/product
-    // words. Without these keywords the one tool that can serve them never
+  describe("bulk store-product edits reach the slice", () => {
+    // The asks that need bulk_update_products are phrased in bulk/product
+    // words. Without matching keywords the one tool that can serve them never
     // loads — the partner would be told "impossible".
-    it("classifies bulk_update_products as storefront", () => {
-      const byName = new Map(PARTNER_MCP_TOOLS.map((t) => [t.name, t]))
-      expect(toolDomain(byName.get("bulk_update_products")!)).toBe("storefront")
-    })
-
     it.each([
       "bulk update the prices on all my products",
       "update all products in this store in bulk",
@@ -219,6 +304,122 @@ describe("partner-mcp per-ask tool slicing", () => {
     ])("activates storefront for: %s", (ask) => {
       const slice = selectPartnerToolSlice(ask, PARTNER_MCP_TOOLS)
       expect(slice.domains).toContain("storefront")
+    })
+  })
+
+  /**
+   * Vocabulary coverage — the invariant the orphan test does NOT give you.
+   *
+   * Classifying a tool only proves it BELONGS somewhere; it says nothing about
+   * whether any phrasing a partner would use selects that somewhere. Every bug
+   * found in review was of that shape: `variant`/`sku` pointed at a domain with
+   * no variant tools, and the customs / shipping-option / sales-channel tools
+   * had no activating words at all — all while the orphan test stayed green.
+   *
+   * So: one realistic ask per ROUTE FAMILY, asserting the family's tools are
+   * actually in the resulting slice. A new route family fails here until it has
+   * both a prefix and words a partner would type.
+   */
+  describe("vocabulary coverage", () => {
+    /** Realistic ask -> the route family it must reach. Core is always on. */
+    const FAMILY_ASKS: Record<string, string> = {
+      "/partners/orders": "show me my open orders",
+      "/partners/order-edits": "request an order edit for this one",
+      "/partners/returns": "create a return for this order",
+      "/partners/claims": "is there a claim open on this order",
+      "/partners/exchanges": "any exchanges open on this order",
+      "/partners/refund-reasons": "what refund reasons can I pick from",
+      "/partners/return-reasons": "what return reasons can I pick from",
+      "/partners/products": "create a product",
+      "/partners/product-categories": "create a product category",
+      "/partners/product-collections": "add this to a product collection",
+      "/partners/product-tags": "list my product tags",
+      "/partners/product-types": "create a product type",
+      "/partners/price-preferences": "set a price preference",
+      "/partners/discover": "discover products I can copy into my catalogue",
+      "/partners/stores/:id/products": "update the price of my product to 2400",
+      "/partners/stores/:id/product-variants": "list my product variants",
+      "/partners/stores/:id/customs":
+        "which of my products are missing HS codes?",
+      "/partners/stores": "add a sales channel and a tax region to my store",
+      "/partners/storefront": "redeploy my storefront website",
+      "/partners/designs": "update the tech pack on this design",
+      "/partners/production-runs": "accept the production run",
+      "/partners/tasks": "finish the task I was assigned",
+      "/partners/assigned-tasks": "what tasks am I assigned",
+      "/partners/inventory-items": "how much stock is on this inventory item",
+      "/partners/inventory-orders": "raise an inventory order for more fabric",
+      "/partners/reservations": "list the stock reservations",
+      "/partners/stores/:id/locations": "add a warehouse location",
+      "/partners/customers": "show me my customers",
+      "/partners/customer-groups": "list my customer groups",
+      "/partners/payments": "refund this payment",
+      "/partners/payment-providers": "which payment providers are available",
+      "/partners/payment-submissions": "list my payment submissions",
+      "/partners/payment-collections": "mark this payment collection as paid",
+      "/partners/stores/:id/payment-providers":
+        "which payment providers are enabled for my store",
+    }
+
+    const familiesInRegistry = [
+      ...new Set(
+        PARTNER_MCP_TOOLS.map((t) => toolRouteFamily(t)).filter(
+          // Native (pathless) tools ride the always-on core.
+          (f) => f !== "native"
+        )
+      ),
+    ]
+      // Core families are in every slice by construction, so they need no ask.
+      .filter(
+        (f) =>
+          !PARTNER_MCP_TOOLS.some(
+            (t) => toolRouteFamily(t) === f && toolDomain(t) === "core"
+          )
+      )
+      .sort()
+
+    it("every route family has an ask that reaches it", () => {
+      const missing = familiesInRegistry.filter((f) => !FAMILY_ASKS[f])
+      expect(missing).toEqual([])
+    })
+
+    it.each(familiesInRegistry)(
+      "an ordinary ask loads every tool in %s",
+      (family) => {
+        const ask = FAMILY_ASKS[family]
+        const slice = selectPartnerToolSlice(ask, PARTNER_MCP_TOOLS)
+        const unreachable = PARTNER_MCP_TOOLS.filter(
+          (t) => toolRouteFamily(t) === family && !slice.names.includes(t.name)
+        ).map((t) => t.name)
+        expect({ family, ask, unreachable }).toEqual({
+          family,
+          ask,
+          unreachable: [],
+        })
+      }
+    )
+
+    // The four activation bugs found in review, by their exact phrasings.
+    it.each([
+      ["list my product variants", "list_store_product_variants"],
+      ["update the price of my product to 2400", "update_store_product"],
+      ["which of my products are missing HS codes?", "list_missing_hs_codes"],
+      ["set the hsn code for my sarees", "bulk_set_hs_codes"],
+      ["what shipping options do I offer", "list_store_shipping_options"],
+      ["add a sales channel", "add_store_sales_channel"],
+      ["add a warehouse location", "add_store_location"],
+      ["add a tax region for karnataka", "add_store_tax_region"],
+    ])("%s -> offers %s", (ask, toolName) => {
+      const slice = selectPartnerToolSlice(ask, PARTNER_MCP_TOOLS)
+      expect(slice.names).toContain(toolName)
+    })
+
+    it("keeps slices focused — no ask drags in the whole registry", () => {
+      for (const ask of Object.values(FAMILY_ASKS)) {
+        const slice = selectPartnerToolSlice(ask, PARTNER_MCP_TOOLS)
+        expect({ ask, tooBig: slice.names.length > PARTNER_MCP_TOOLS.length / 2 })
+          .toEqual({ ask, tooBig: false })
+      }
     })
   })
 })

--- a/apps/backend/src/api/partners/mcp/lib/tool-slice.ts
+++ b/apps/backend/src/api/partners/mcp/lib/tool-slice.ts
@@ -1,0 +1,285 @@
+/**
+ * Per-ask registry slicing for the partner assistant.
+ *
+ * Mirrors the admin tool-slice (see ../../admin/mcp/lib/tool-slice) for the
+ * Partner surface. The partner registry is ~178 tools — larger than admin's —
+ * and the in-app assistant re-sends every bound tool definition on EVERY turn,
+ * so registry size is both the dominant per-request token cost and (because the
+ * free-model rotator ranks by context length) a lever on which model answers.
+ *
+ * This module maps each partner tool to a domain and picks the domains an ask
+ * actually needs. The chat route binds the full registry (so every tool stays
+ * callable) but passes only the slice as `activeTools`, so only those
+ * definitions are serialised to the provider.
+ *
+ * Nothing here can make a tool permanently unreachable: the always-on core
+ * includes the onboarding/breadth reads, and the chat route widens the slice
+ * mid-run when the model asks for a domain it wasn't given. Getting the slice
+ * wrong costs a round trip, not a capability.
+ */
+import type { McpToolDef } from "../../../../lib/mcp-core"
+
+export type PartnerToolDomain =
+  | "core"
+  | "orders"
+  | "catalog"
+  | "storefront"
+  | "designs"
+  | "production"
+  | "inventory"
+  | "customers"
+  | "money"
+
+/**
+ * Route prefix -> domain. Longest prefix wins, so a more specific entry is
+ * never shadowed by a broader one. The `/` guard in `toolDomain` means a
+ * prefix only matches itself or a path segment under it — `/partners/me` does
+ * NOT swallow `/partners/medias`. A new registry row under an existing prefix
+ * is classified automatically; a genuinely new route family needs one line
+ * here (and the invariant test below fails loudly until it gets one).
+ */
+const PREFIX_DOMAINS: ReadonlyArray<readonly [string, PartnerToolDomain]> = [
+  // ---- core: identity, onboarding, UI, reference data, cross-cutting ----
+  ["/partners/me", "core"],
+  ["/partners/update", "core"],
+  ["/partners/onboarding-profile", "core"],
+  ["/partners/details", "core"],
+  ["/partners/layouts", "core"],
+  ["/partners/currencies", "core"],
+  // Media uploads are cross-cutting (design references, product photos,
+  // storefront assets) so they must be reachable from any conversation.
+  ["/partners/medias", "core"],
+  // AI vision + usage are cross-cutting — describe an image for a design OR a
+  // product, check own usage from anywhere.
+  ["/partners/ai", "core"],
+  ["/partners/notifications", "core"],
+
+  // ---- orders: fulfilment + the whole post-purchase lifecycle ----
+  ["/partners/orders", "orders"],
+  ["/partners/order-edits", "orders"],
+  ["/partners/returns", "orders"],
+  ["/partners/claims", "orders"],
+  ["/partners/exchanges", "orders"],
+  // Refund / return reasons are reference data FOR the orders slice — an
+  // operator creating a return needs the reason slug, so they ride together.
+  ["/partners/refund-reasons", "orders"],
+  ["/partners/return-reasons", "orders"],
+
+  // ---- catalog: the partner's own product record + taxonomy ----
+  ["/partners/products", "catalog"],
+  ["/partners/product-categories", "catalog"],
+  ["/partners/product-collections", "catalog"],
+  ["/partners/product-tags", "catalog"],
+  ["/partners/product-types", "catalog"],
+  ["/partners/price-preferences", "catalog"],
+  // discover = "copy a product from another store into mine" — it operates on
+  // the partner's catalog, so it belongs here next to create_product.
+  ["/partners/discover", "catalog"],
+
+  // ---- storefront: store channels + the public site + store product listings ----
+  // Note: store product listings (incl. bulk_update_products) live under
+  // /partners/stores/:id/products, so they classify as storefront, not catalog.
+  // A partner "updating a product's price" almost always means a store product
+  // (update_store_product), so the storefront keywords below include the
+  // product vocabulary to light this slice up for that ask.
+  ["/partners/stores", "storefront"],
+  ["/partners/storefront", "storefront"],
+
+  // ---- designs: the design record + cost / consumption / media ----
+  ["/partners/designs", "designs"],
+
+  // ---- production: run lifecycle + run-level cost & consumption + run tasks ----
+  // /partners/tasks and /partners/assigned-tasks are the per-task view onto a
+  // production run (accept/finish a dispatched task), so they ride the
+  // production slice — an ask about a task is an ask about a run.
+  ["/partners/production-runs", "production"],
+  ["/partners/tasks", "production"],
+  ["/partners/assigned-tasks", "production"],
+
+  // ---- inventory: items, levels, raw materials, inventory orders, reservations ----
+  ["/partners/inventory-items", "inventory"],
+  ["/partners/inventory-orders", "inventory"],
+  ["/partners/reservations", "inventory"],
+
+  // ---- customers: the partner's buyers + groups ----
+  ["/partners/customers", "customers"],
+  ["/partners/customer-groups", "customers"],
+
+  // ---- money: payments, providers, submissions, payment collections ----
+  ["/partners/payments", "money"],
+  ["/partners/payment-providers", "money"],
+  ["/partners/payment-submissions", "money"],
+  ["/partners/payment-collections", "money"],
+]
+
+/** Classify one tool by the route it wraps. */
+export function toolDomain(def: McpToolDef): PartnerToolDomain | undefined {
+  const path = def.path
+  if (!path) return "core" // native tools are grounding/discovery
+  let best: { len: number; domain: PartnerToolDomain } | undefined
+  for (const [prefix, domain] of PREFIX_DOMAINS) {
+    if (
+      (path === prefix || path.startsWith(`${prefix}/`)) &&
+      (!best || prefix.length > best.len)
+    ) {
+      best = { len: prefix.length, domain }
+    }
+  }
+  return best?.domain
+}
+
+/**
+ * Trigger words per domain, matched case-insensitively on word boundaries
+ * against the recent conversation text. Deliberately generous — a false
+ * positive costs a few hundred tokens, a false negative costs a round trip.
+ */
+const DOMAIN_KEYWORDS: Record<Exclude<PartnerToolDomain, "core">, string[]> = {
+  orders: [
+    "order", "orders", "fulfil", "fulfill", "fulfilment", "fulfillment",
+    "ship", "shipped", "shipping", "shipment", "deliver", "delivered",
+    "delivery", "courier", "awb", "waybill", "label", "tracking", "cancel",
+    "refund", "return", "returns", "claim", "claims", "exchange", "exchanges",
+    "line item", "line items", "mark as delivered", "fulfillment", "mark delivered",
+    "order edit", "order edits", "edit order", "request edit", "confirm edit",
+  ],
+  catalog: [
+    "product", "products", "variant", "variants", "sku", "catalog",
+    "catalogue", "category", "categories", "collection", "collections",
+    "tag", "tags", "product type", "product types", "price preference",
+    "price preferences", "price list", "discover", "copy product",
+    "artisan", "artisan detail", "resubmit",
+  ],
+  storefront: [
+    "store", "stores", "storefront", "website", "web site", "page", "pages",
+    "block", "blocks", "domain", "provision", "provisioning", "deploy",
+    "redeploy", "seed", "region", "regions", "listing", "listings",
+    "homepage", "home page", "landing", "hero", "store product",
+    "product listing", "product listings", "store product variant",
+    // Bulk store-product edits are the partner's "update all my products"
+    // path; without these the one tool that can serve it never loads.
+    "bulk", "in bulk", "all products", "every product", "all my products",
+    "bulk update",
+  ],
+  designs: [
+    "design", "designs", "designer", "moodboard", "tech pack", "techpack",
+    "size set", "size sets", "sizing", "measurement", "measurements",
+    "colourway", "colorway", "revision", "revisions", "bom",
+    "bill of materials", "consumption", "consumption log", "consumption logs",
+    "cost", "recalculate", "design media", "reference", "reference image",
+  ],
+  production: [
+    "production", "production run", "production runs", "run", "runs",
+    "accept", "accept run", "start", "start run", "finish", "finish run",
+    "complete", "complete run", "decline", "decline run", "cost summary",
+    "manufacture", "manufacturing", "in progress", "wip",
+    "task", "tasks", "assigned task", "assigned tasks", "accept task",
+    "finish task",
+  ],
+  inventory: [
+    "inventory", "stock", "stocks", "raw material", "raw materials",
+    "material", "materials", "fabric", "yarn", "warehouse", "location",
+    "restock", "purchase order", "reservation", "reservations",
+    "material group", "material groups", "swatch", "swatches", "trim", "trims",
+    "bolt", "bolts", "roll", "rolls", "composition", "gsm", "yardage",
+    "meterage", "delivery note", "packing list", "unit cost", "moq",
+    "inventory order", "inventory orders", "inventory level", "stock level",
+  ],
+  customers: [
+    "customer", "customers", "buyer", "buyers", "shopper", "shoppers",
+    "group", "groups", "customer group", "customer groups", "address",
+  ],
+  money: [
+    "payment", "payments", "payout", "payouts", "invoice", "invoices",
+    "revenue", "settle", "settlement", "money", "paid", "unpaid", "balance",
+    "submission", "payment submission", "payment provider", "payment providers",
+    "payment collection", "payment collections", "mark as paid", "collect payment",
+  ],
+}
+
+/**
+ * Always sent, regardless of the ask: the onboarding grounding, the partner's
+ * own detail record, and the cheap top-level list read for each domain. Those
+ * list_* tools are what let an unclassifiable ask ("what's going on with my
+ * shop?") still get somewhere, and they give the model the vocabulary to
+ * widen the slice deliberately.
+ */
+export const ALWAYS_ON_TOOLS: readonly string[] = [
+  "get_partner_profile",
+  "get_onboarding_profile",
+  "get_partner_details",
+  "list_orders",
+  "list_products",
+  "list_stores",
+  "list_designs",
+  "list_inventory_items",
+  "list_notifications",
+]
+
+export type ToolSlice = {
+  /** Tool names to expose on this turn. */
+  names: string[]
+  /** Domains the ask matched (excludes the always-on core). */
+  domains: PartnerToolDomain[]
+}
+
+const escapeRe = (s: string) => s.replace(/[.*+?^${}()|[\]\\]/g, "\\$&")
+
+/** Domains whose trigger words appear in the given text. */
+export function matchDomains(text: string): PartnerToolDomain[] {
+  const haystack = text.toLowerCase()
+  const hits: PartnerToolDomain[] = []
+  for (const [domain, keywords] of Object.entries(DOMAIN_KEYWORDS)) {
+    const hit = keywords.some((kw) =>
+      new RegExp(`\\b${escapeRe(kw)}\\b`).test(haystack)
+    )
+    if (hit) hits.push(domain as PartnerToolDomain)
+  }
+  return hits
+}
+
+/**
+ * Pick the tools to expose for one ask.
+ *
+ * `tools` should already be filtered by the write gate — this only narrows
+ * further, it never re-admits a tool the surface disabled.
+ */
+export function selectPartnerToolSlice(
+  text: string,
+  tools: McpToolDef[]
+): ToolSlice {
+  const available = new Set(tools.map((t) => t.name))
+  const domains = matchDomains(text)
+  const wanted = new Set<PartnerToolDomain>([...domains, "core"])
+
+  const names = new Set<string>()
+  for (const name of ALWAYS_ON_TOOLS) {
+    if (available.has(name)) names.add(name)
+  }
+  for (const def of tools) {
+    const domain = toolDomain(def)
+    if (domain && wanted.has(domain)) names.add(def.name)
+  }
+
+  return { names: [...names], domains }
+}
+
+/** Every tool in a domain (used to widen the slice on request). */
+export function toolsInDomains(
+  domains: string[],
+  tools: McpToolDef[]
+): string[] {
+  const wanted = new Set(domains)
+  return tools.filter((t) => wanted.has(toolDomain(t) ?? "")).map((t) => t.name)
+}
+
+/** The domains a partner can ask to be widened into. */
+export const SELECTABLE_DOMAINS: PartnerToolDomain[] = [
+  "orders",
+  "catalog",
+  "storefront",
+  "designs",
+  "production",
+  "inventory",
+  "customers",
+  "money",
+]

--- a/apps/backend/src/api/partners/mcp/lib/tool-slice.ts
+++ b/apps/backend/src/api/partners/mcp/lib/tool-slice.ts
@@ -76,14 +76,32 @@ const PREFIX_DOMAINS: ReadonlyArray<readonly [string, PartnerToolDomain]> = [
   // the partner's catalog, so it belongs here next to create_product.
   ["/partners/discover", "catalog"],
 
-  // ---- storefront: store channels + the public site + store product listings ----
-  // Note: store product listings (incl. bulk_update_products) live under
-  // /partners/stores/:id/products, so they classify as storefront, not catalog.
-  // A partner "updating a product's price" almost always means a store product
-  // (update_store_product), so the storefront keywords below include the
-  // product vocabulary to light this slice up for that ask.
+  // ---- storefront: store channels + the public site + store configuration ----
   ["/partners/stores", "storefront"],
   ["/partners/storefront", "storefront"],
+
+  // Sub-trees of /partners/stores that belong to ANOTHER domain by meaning.
+  //
+  // Longest-prefix wins, so these override the "/partners/stores" line above.
+  // They exist because a domain is only useful if the words a partner would use
+  // for a tool select the domain that OWNS it, and the store sub-tree is where
+  // route shape and vocabulary part company hardest:
+  //
+  //   - store products/variants ARE the partner's products. "update the price
+  //     of my product", "list my variants" and "bulk update" all say product,
+  //     never "store", so they must land in `catalog` alongside create_product.
+  //   - HS/HSN codes are a customs question about those same products.
+  //   - a store "location" is a stock location — the tool's own description
+  //     says "Location / warehouse name", which is the inventory vocabulary.
+  //   - payment providers are a money question.
+  //
+  // What stays `storefront` is the genuine store CONFIGURATION surface: the
+  // public site, regions, shipping options, tax regions and sales channels.
+  ["/partners/stores/:id/products", "catalog"],
+  ["/partners/stores/:id/product-variants", "catalog"],
+  ["/partners/stores/:id/customs", "catalog"],
+  ["/partners/stores/:id/locations", "inventory"],
+  ["/partners/stores/:id/payment-providers", "money"],
 
   // ---- designs: the design record + cost / consumption / media ----
   ["/partners/designs", "designs"],
@@ -112,20 +130,43 @@ const PREFIX_DOMAINS: ReadonlyArray<readonly [string, PartnerToolDomain]> = [
   ["/partners/payment-collections", "money"],
 ]
 
+/** The route family (PREFIX_DOMAINS entry) a tool matched — longest wins. */
+const matchPrefix = (
+  path: string
+): readonly [string, PartnerToolDomain] | undefined => {
+  let best: readonly [string, PartnerToolDomain] | undefined
+  for (const entry of PREFIX_DOMAINS) {
+    const [prefix] = entry
+    if (
+      (path === prefix || path.startsWith(`${prefix}/`)) &&
+      (!best || prefix.length > best[0].length)
+    ) {
+      best = entry
+    }
+  }
+  return best
+}
+
 /** Classify one tool by the route it wraps. */
 export function toolDomain(def: McpToolDef): PartnerToolDomain | undefined {
   const path = def.path
   if (!path) return "core" // native tools are grounding/discovery
-  let best: { len: number; domain: PartnerToolDomain } | undefined
-  for (const [prefix, domain] of PREFIX_DOMAINS) {
-    if (
-      (path === prefix || path.startsWith(`${prefix}/`)) &&
-      (!best || prefix.length > best.len)
-    ) {
-      best = { len: prefix.length, domain }
-    }
-  }
-  return best?.domain
+  return matchPrefix(path)?.[1]
+}
+
+/**
+ * The route family a tool belongs to — its matched prefix, or "native" for the
+ * pathless grounding tools.
+ *
+ * Exported for the vocabulary-coverage invariant: classification alone does not
+ * make a tool reachable, so the suite asserts every FAMILY has a phrasing that
+ * selects it. A new route family therefore fails the suite twice over until it
+ * has both a prefix and words a partner would actually type.
+ */
+export function toolRouteFamily(def: McpToolDef): string {
+  const path = def.path
+  if (!path) return "native"
+  return matchPrefix(path)?.[0] ?? "unclassified"
 }
 
 /**
@@ -139,26 +180,40 @@ const DOMAIN_KEYWORDS: Record<Exclude<PartnerToolDomain, "core">, string[]> = {
     "ship", "shipped", "shipping", "shipment", "deliver", "delivered",
     "delivery", "courier", "awb", "waybill", "label", "tracking", "cancel",
     "refund", "return", "returns", "claim", "claims", "exchange", "exchanges",
-    "line item", "line items", "mark as delivered", "fulfillment", "mark delivered",
+    "line item", "line items", "mark as delivered", "mark delivered",
     "order edit", "order edits", "edit order", "request edit", "confirm edit",
   ],
   catalog: [
     "product", "products", "variant", "variants", "sku", "catalog",
     "catalogue", "category", "categories", "collection", "collections",
-    "tag", "tags", "product type", "product types", "price preference",
-    "price preferences", "price list", "discover", "copy product",
-    "artisan", "artisan detail", "resubmit",
-  ],
-  storefront: [
-    "store", "stores", "storefront", "website", "web site", "page", "pages",
-    "block", "blocks", "domain", "provision", "provisioning", "deploy",
-    "redeploy", "seed", "region", "regions", "listing", "listings",
-    "homepage", "home page", "landing", "hero", "store product",
-    "product listing", "product listings", "store product variant",
+    "tag", "tags", "product type", "product types", "price", "prices",
+    "pricing", "price preference", "price preferences", "price list",
+    "discover", "copy product", "artisan", "artisan detail", "resubmit",
+    // Store product listings classify here (see PREFIX_DOMAINS), so the
+    // listing vocabulary belongs with them.
+    "store product", "product listing", "product listings",
+    "store product variant", "listing", "listings",
     // Bulk store-product edits are the partner's "update all my products"
     // path; without these the one tool that can serve it never loads.
     "bulk", "in bulk", "all products", "every product", "all my products",
     "bulk update",
+    // Customs codes are set ON products (/partners/stores/:id/customs), and a
+    // partner asks about them in customs words, never product ones. Mirrors
+    // the admin slicer, which carries the same list for /admin/customs.
+    "hsn", "hs code", "hs codes", "hs_code", "customs", "harmonized",
+    "harmonised", "tariff", "duty", "commodity code",
+  ],
+  storefront: [
+    "store", "stores", "storefront", "website", "web site", "page", "pages",
+    "block", "blocks", "domain", "provision", "provisioning", "deploy",
+    "redeploy", "seed", "region", "regions",
+    "homepage", "home page", "landing", "hero",
+    // Store CONFIGURATION. Without these the shipping-option / tax-region /
+    // sales-channel tools have no phrasing that reaches them: "shipping" alone
+    // selects `orders`, whose tools are order fulfilment, not store setup.
+    "shipping option", "shipping options", "delivery option",
+    "delivery options", "tax", "taxes", "tax region", "tax regions",
+    "sales channel", "sales channels", "channel", "channels",
   ],
   designs: [
     "design", "designs", "designer", "moodboard", "tech pack", "techpack",
@@ -270,6 +325,50 @@ export function toolsInDomains(
 ): string[] {
   const wanted = new Set(domains)
   return tools.filter((t) => wanted.has(toolDomain(t) ?? "")).map((t) => t.name)
+}
+
+/** The escape-hatch tool the model calls to widen its own slice. */
+export const LOAD_TOOLS_TOOL_NAME = "load_partner_tools"
+
+/**
+ * Domains the model already widened into earlier in THIS conversation.
+ *
+ * The slice is recomputed per HTTP request from keywords, and the chat route
+ * strips tool parts from history — so without this a domain bought with a
+ * round trip on turn N is silently gone on turn N+1, and the model has no
+ * transcript evidence it ever had it. A follow-up like "now do the same for the
+ * other one" would re-pay the widening AND burn one of the step budget.
+ *
+ * Reads the RAW inbound messages (before the route's text-only normalisation),
+ * and only ever returns known selectable domains, so a malformed or
+ * adversarial history part can widen nothing it could not widen by asking.
+ */
+export function widenedDomainsFromHistory(
+  rawMessages: unknown
+): PartnerToolDomain[] {
+  const selectable = new Set<string>(SELECTABLE_DOMAINS)
+  const found = new Set<PartnerToolDomain>()
+
+  for (const m of Array.isArray(rawMessages) ? rawMessages : []) {
+    const parts = Array.isArray((m as any)?.parts) ? (m as any).parts : []
+    for (const p of parts) {
+      const isLoadCall =
+        p?.type === `tool-${LOAD_TOOLS_TOOL_NAME}` ||
+        (p?.type === "dynamic-tool" && p?.toolName === LOAD_TOOLS_TOOL_NAME)
+      if (!isLoadCall) continue
+      // The call's own args are the reliable half; the result echoes them back,
+      // so read both and let the allow-list below discard anything odd.
+      for (const d of [
+        ...(Array.isArray(p?.input?.domains) ? p.input.domains : []),
+        ...(Array.isArray(p?.output?.domains) ? p.output.domains : []),
+      ]) {
+        if (typeof d === "string" && selectable.has(d)) {
+          found.add(d as PartnerToolDomain)
+        }
+      }
+    }
+  }
+  return [...found]
 }
 
 /** The domains a partner can ask to be widened into. */


### PR DESCRIPTION
## What

The partner assistant bound all **178 tools** and serialized every definition to the provider on **each turn** — the dominant per-request token cost of a conversation, and (because the free-model rotator ranks by context length) a lever on which model answers.

The admin surface already had a thin-loading layer (); partner had nothing equivalent despite being the **larger** registry. This mirrors admin's approach for the partner surface.

## How

**New: `partners/mcp/lib/tool-slice.ts`**
- 9 domains: `core` + `orders / catalog / storefront / designs / production / inventory / customers / money`
- Longest-prefix route → domain classification (a new row under an existing prefix classifies automatically; a new route family needs one line + a failing invariant test)
- Per-domain keyword matching on the last 6 messages (generous — a false positive costs a few hundred tokens, a false negative costs a round trip)
- 9 always-on grounding/breadth reads (`get_partner_profile`, `get_onboarding_profile`, `get_partner_details`, `list_orders/products/stores/designs/inventory_items/notifications`)
- `selectPartnerToolSlice` + `toolsInDomains` + `SELECTABLE_DOMAINS`

**Wired into `partners/assistant/chat/route.ts`**
- Binds the full registry (every tool stays **callable**) but serializes only the per-ask slice via `prepareStep: () => ({ activeTools: [...activated] })`.
- `load_partner_tools` escape hatch (always active) lets the model widen the slice mid-run — the slice **only grows**, so a wrong initial guess costs one round trip, not a lost capability.
- System prompt now teaches the model about on-demand loading.

**External MCP JSON-RPC endpoints unchanged** — they enumerate the full list once (no per-turn cost there), so this is strictly an in-app-assistant optimization.

## Tests

24 unit tests mirroring the admin suite (`partners/mcp/lib/__tests__/tool-slice.unit.spec.ts`):
- Orphan invariant (every registry tool classifies)
- Longest-prefix wins; store-product tools → `storefront` (not `catalog`)
- Sibling route families group; every selectable domain owns tools
- Keyword matching + word-boundary semantics
- Always-on inclusion; focused-ask small slice; multi-domain pull-in
- Write-gate never re-admits; payload cut < 50%
- Widening covers the whole registry; unknown domains ignored
- bulk_update_products + storefront-management activation suites

```
TEST_TYPE=unit jest --testPathPattern partners/mcp/lib/__tests__/tool-slice.unit.spec
# 24/24 pass; admin suite still 32/32 pass
```

## Out of scope
- The admin surface (already thin — no change).
- The store surface (consumed via JSON-RPC by external clients that enumerate once; no per-turn cost).
- Route-level rollout tiers (the separate `feat/mcp-tool-tiers` work).