### PR TITLE
fix(assistant): carry a widened tool slice across turns on the admin chat

### DIFF
--- a/apps/backend/src/api/admin/assistant/chat/route.ts
+++ b/apps/backend/src/api/admin/assistant/chat/route.ts
@@ -34,6 +34,7 @@ import { ADMIN_MCP_TOOLS, renderToolGuidance } from "../../mcp/lib/registry"
 import {
   selectAdminToolSlice,
   toolsInDomains,
+  widenedDomainsFromHistory,
   toolDomain,
   SELECTABLE_DOMAINS,
 } from "../../mcp/lib/tool-slice"
@@ -320,9 +321,19 @@ export const POST = async (
   const initialSlice = selectAdminToolSlice(recentText, enabled)
   const activated = new Set<string>(initialSlice.names)
 
+  // Carry forward whatever the model widened into earlier in this conversation.
+  // Keyword matching runs fresh every request and history arrives text-only, so
+  // without this a domain bought with a round trip on the previous turn is gone
+  // on this one — and "now do the same for the other one" pays for it twice.
+  const carried = widenedDomainsFromHistory(body.messages)
+  if (carried.length) {
+    toolsInDomains(carried, enabled).forEach((n) => activated.add(n))
+  }
+
   logger.debug?.(
     `[${FEATURE}] tool slice: ${activated.size}/${enabled.length} tools` +
-      ` (domains: ${initialSlice.domains.join(", ") || "none matched"})`
+      ` (domains: ${initialSlice.domains.join(", ") || "none matched"}` +
+      `${carried.length ? `; carried: ${carried.join(", ")}` : ""})`
   )
 
   // The escape hatch. Always active, so the model is never boxed in by a slice

--- a/apps/backend/src/api/admin/mcp/lib/__tests__/tool-slice.unit.spec.ts
+++ b/apps/backend/src/api/admin/mcp/lib/__tests__/tool-slice.unit.spec.ts
@@ -3,6 +3,7 @@ import {
   matchDomains,
   toolDomain,
   toolsInDomains,
+  widenedDomainsFromHistory,
   ALWAYS_ON_TOOLS,
   SELECTABLE_DOMAINS,
 } from "../tool-slice"
@@ -250,6 +251,87 @@ describe("admin-mcp per-ask tool slicing", () => {
     ])("activates it for: %s", (ask) => {
       const slice = selectAdminToolSlice(ask, ADMIN_MCP_TOOLS)
       expect(slice.names).toContain("bulk_update_products")
+    })
+  })
+
+  describe("carrying a widened slice across turns", () => {
+    // The slice is recomputed from keywords on every request and history
+    // arrives text-only, so a domain the model bought with a load_admin_tools
+    // round trip on turn N was gone on turn N+1 — the follow-up ask paid for
+    // it again and burned one of the 8 steps.
+    const loadPart = (domains: any, key: "input" | "output" = "input") => ({
+      role: "assistant",
+      parts: [{ type: "tool-load_admin_tools", [key]: { domains } }],
+    })
+
+    it("recovers the domains loaded on an earlier turn", () => {
+      expect(widenedDomainsFromHistory([loadPart(["money"])])).toEqual(["money"])
+      expect(
+        widenedDomainsFromHistory([loadPart(["marketing"], "output")])
+      ).toEqual(["marketing"])
+    })
+
+    it("reads dynamic-tool parts too", () => {
+      expect(
+        widenedDomainsFromHistory([
+          {
+            role: "assistant",
+            parts: [
+              {
+                type: "dynamic-tool",
+                toolName: "load_admin_tools",
+                input: { domains: ["inventory"] },
+              },
+            ],
+          },
+        ])
+      ).toEqual(["inventory"])
+    })
+
+    it("accepts only known domains, whatever the history claims", () => {
+      expect(
+        widenedDomainsFromHistory([
+          loadPart(["money", "not_a_domain", "core", 42, null]),
+        ])
+      ).toEqual(["money"])
+    })
+
+    it("survives malformed or absent history without throwing", () => {
+      expect(widenedDomainsFromHistory(undefined)).toEqual([])
+      expect(widenedDomainsFromHistory([])).toEqual([])
+      expect(widenedDomainsFromHistory([{ role: "user" }])).toEqual([])
+      expect(
+        widenedDomainsFromHistory([
+          { role: "assistant", parts: [{ type: "text", text: "hi" }] },
+        ])
+      ).toEqual([])
+      expect(widenedDomainsFromHistory([loadPart("money" as any)])).toEqual([])
+    })
+
+    it("ignores other tools' parts", () => {
+      expect(
+        widenedDomainsFromHistory([
+          {
+            role: "assistant",
+            parts: [{ type: "tool-list_orders", input: { domains: ["money"] } }],
+          },
+        ])
+      ).toEqual([])
+    })
+
+    it("what it recovers is exactly what the escape hatch would load", () => {
+      // The carry-forward must be equivalent to re-calling load_admin_tools —
+      // otherwise turn N+1 gets a subtly different surface from turn N.
+      const carried = widenedDomainsFromHistory([loadPart(["money"])])
+      expect(toolsInDomains(carried, ADMIN_MCP_TOOLS)).toEqual(
+        toolsInDomains(["money"], ADMIN_MCP_TOOLS)
+      )
+    })
+
+    it("every selectable domain survives a round trip through history", () => {
+      for (const domain of SELECTABLE_DOMAINS) {
+        expect(widenedDomainsFromHistory([loadPart([domain])])).toEqual([domain])
+      }
     })
   })
 })

--- a/apps/backend/src/api/admin/mcp/lib/tool-slice.ts
+++ b/apps/backend/src/api/admin/mcp/lib/tool-slice.ts
@@ -264,6 +264,53 @@ export function toolsInDomains(
   return tools.filter((t) => wanted.has(toolDomain(t) ?? "")).map((t) => t.name)
 }
 
+/** The escape-hatch tool the model calls to widen its own slice. */
+export const LOAD_TOOLS_TOOL_NAME = "load_admin_tools"
+
+/**
+ * Domains the model already widened into earlier in THIS conversation.
+ *
+ * The slice is recomputed per HTTP request from keywords, and the chat route
+ * strips tool parts from history — so without this a domain bought with a
+ * `load_admin_tools` round trip on turn N is silently gone on turn N+1, and the
+ * model has no transcript evidence it ever had it. A follow-up like "now do the
+ * same for the other one" re-pays the widening AND burns one of the 8 steps.
+ *
+ * Reads the RAW inbound messages (before the route's text-only normalisation),
+ * and only ever returns known selectable domains, so a malformed or
+ * adversarial history part can widen nothing it could not widen by asking.
+ *
+ * Mirrored for the partner surface in partners/mcp/lib/tool-slice — the two
+ * slicers are deliberately parallel modules over different domain unions.
+ */
+export function widenedDomainsFromHistory(
+  rawMessages: unknown
+): AdminToolDomain[] {
+  const selectable = new Set<string>(SELECTABLE_DOMAINS)
+  const found = new Set<AdminToolDomain>()
+
+  for (const m of Array.isArray(rawMessages) ? rawMessages : []) {
+    const parts = Array.isArray((m as any)?.parts) ? (m as any).parts : []
+    for (const p of parts) {
+      const isLoadCall =
+        p?.type === `tool-${LOAD_TOOLS_TOOL_NAME}` ||
+        (p?.type === "dynamic-tool" && p?.toolName === LOAD_TOOLS_TOOL_NAME)
+      if (!isLoadCall) continue
+      // The call's own args are the reliable half; the result echoes them back,
+      // so read both and let the allow-list below discard anything odd.
+      for (const d of [
+        ...(Array.isArray(p?.input?.domains) ? p.input.domains : []),
+        ...(Array.isArray(p?.output?.domains) ? p.output.domains : []),
+      ]) {
+        if (typeof d === "string" && selectable.has(d)) {
+          found.add(d as AdminToolDomain)
+        }
+      }
+    }
+  }
+  return [...found]
+}
+
 /** The domains an operator can ask to be widened into. */
 export const SELECTABLE_DOMAINS: AdminToolDomain[] = [
   "orders",


### PR DESCRIPTION
## What

Follow-up to a defect found while reviewing #1315. That PR mirrors this surface's design for the partner assistant, and inherited this bug along with it — so it is fixed on both, separately.

The per-ask slice is recomputed from keyword matching on **every** HTTP request, and the route strips tool parts from history before sending it to the model. So a domain the model bought with a `load_admin_tools` round trip on turn N is silently gone on turn N+1 — and because the tool parts were stripped, the model has no transcript evidence it ever had it.

A follow-up like *"now do the same for the other one"* re-pays the widening and burns one of the 8 `stepCountIs` steps. Every turn, for the rest of the conversation.

## How

`widenedDomainsFromHistory` reads the **raw** inbound messages (before the route's text-only normalisation) for prior `load_admin_tools` parts, and seeds `activated` from them. Handles both AI SDK v5 shapes: `tool-load_admin_tools` parts and `dynamic-tool` parts, reading the call's `input` and the echoed `output`.

It is allow-listed to `SELECTABLE_DOMAINS`, so a malformed — or adversarial — history part can widen nothing that simply asking would not.

The slice still only ever GROWS, so this cannot make a tool unreachable; it only stops one from becoming unreachable *again*.

## Deliberately duplicated

The partner copy in `partners/mcp/lib/tool-slice.ts` (on #1315) is the same function over a different domain union. The two slicers are already parallel modules by design, and sharing now would stack this branch on top of that one. **Worth folding into `lib/mcp-core` once both have landed** — noted in the commit.

## Tests

7 new (39 total in the suite):
- recovery from `input` and from `output` parts
- `dynamic-tool` parts
- the allow-list (unknown domains, `core`, non-strings all rejected)
- malformed / absent history does not throw
- other tools' parts ignored
- **equivalence**: what is carried is exactly what re-calling the escape hatch would load — otherwise turn N+1 gets a subtly different surface from turn N
- every selectable domain survives a round trip through history

```
cd apps/backend && TEST_TYPE=unit npx jest --testPathPattern "admin/mcp/lib/__tests__/tool-slice"
# 39/39 pass
```

`check:prod-build` exit 0; tsc at the 75 baseline.

🤖 Generated with [Claude Code](https://claude.com/claude-code)