### PR TITLE
fix(ops): make align_provider actually write, and give admins carrier tracking

### DIFF
--- a/apps/backend/src/admin/widgets/order-carrier-shipment.tsx
+++ b/apps/backend/src/admin/widgets/order-carrier-shipment.tsx
@@ -84,6 +84,20 @@ type BookedPickup = {
   incoming_center_name?: string
 }
 
+/**
+ * What the carrier calls the pickup's handle.
+ *
+ * Blue Dart returns it as `TokenNumber` and its phone agents ask for the "token
+ * number"; a label reading "Reference" sends the operator hunting for a field
+ * that does not exist on the carrier's side. It is also the ONLY thing that can
+ * cancel a collection — cancelling the waybill does not.
+ */
+function pickupCodeLabel(carrier?: string): string {
+  return String(carrier || "").toLowerCase() === "bluedart"
+    ? "Pickup token"
+    : "Reference"
+}
+
 function bookedPickupOf(fulfillment: any): BookedPickup | null {
   const m = fulfillment?.metadata
   // `pickup_date` is the load-bearing field: Blue Dart hands back a
@@ -413,8 +427,10 @@ const OrderCarrierShipmentWidget = ({
                     ? // Shown, not hidden behind a tooltip: for Blue Dart this
                       // token is the only handle that can call the collection
                       // off, and an operator on the phone to the carrier needs
-                      // to be able to read it out.
-                      `Reference #${pickup.pickup_id}`
+                      // to be able to read it out. Named by what the carrier
+                      // calls it, because that is the word the agent on the
+                      // phone will ask for — Blue Dart says "token number".
+                      `${pickupCodeLabel(existing.carrier)} #${pickup.pickup_id}`
                     : "No reference returned by the carrier — cancelling may need a phone call."}
                   {pickup.incoming_center_name
                     ? ` · ${pickup.incoming_center_name}`

--- a/apps/backend/src/api/admin/ops/maintenance-jobs/__tests__/clean-order-fulfillment-data.unit.spec.ts
+++ b/apps/backend/src/api/admin/ops/maintenance-jobs/__tests__/clean-order-fulfillment-data.unit.spec.ts
@@ -2,6 +2,7 @@ import {
   buildDataPatch,
   refusedKeys,
   targetProviderId,
+  unlandedWrites,
   PROTECTED_DATA_KEYS,
 } from "../clean-order-fulfillment-data-job"
 
@@ -107,5 +108,90 @@ describe("targetProviderId", () => {
     expect(
       targetProviderId({ provider_id: "x", data: { carrier: " BlueDart " } })
     ).toBe("bluedart_bluedart")
+  })
+})
+
+/**
+ * The read-back check. This job reported `applied: true` on order 83 while
+ * `provider_id` never moved — the ORM discards a loose FK scalar without
+ * raising, so "no exception" was mistaken for "it landed". These tests pin the
+ * only thing that can tell the difference: reading the row back.
+ */
+describe("unlandedWrites", () => {
+  const write = {
+    id: "ful_83",
+    patch: { name: null, packages: null },
+    providerId: "bluedart_bluedart",
+  }
+
+  it("reports nothing when every intended write is visible in the row", () => {
+    expect(
+      unlandedWrites(
+        [write],
+        [
+          {
+            id: "ful_83",
+            provider_id: "bluedart_bluedart",
+            data: { name: null, packages: null, carrier: "bluedart" },
+          },
+        ]
+      )
+    ).toEqual([])
+  })
+
+  it("catches the order 83 failure: data cleared, provider_id unmoved", () => {
+    const errors = unlandedWrites(
+      [write],
+      [
+        {
+          id: "ful_83",
+          // The write that DID land.
+          data: { name: null, packages: null },
+          // The write that silently did not.
+          provider_id: "delhivery_delhivery",
+        },
+      ]
+    )
+    expect(errors).toHaveLength(1)
+    expect(errors[0].message).toContain("provider_id did not persist")
+    expect(errors[0].message).toContain("delhivery_delhivery")
+  })
+
+  it("catches a data key that did not persist — the merge no-op", () => {
+    const errors = unlandedWrites(
+      [{ id: "ful_83", patch: { name: null }, providerId: null }],
+      [{ id: "ful_83", provider_id: "x", data: { name: "Delhivery Express" } }]
+    )
+    expect(errors).toHaveLength(1)
+    expect(errors[0].message).toContain("did not persist: name")
+  })
+
+  it("treats a row that cannot be read back as unverified, not as success", () => {
+    const errors = unlandedWrites([write], [])
+    expect(errors).toHaveLength(1)
+    expect(errors[0].message).toContain("could not read it back")
+  })
+
+  it("compares structurally, so a jsonb round-trip is not a false alarm", () => {
+    const errors = unlandedWrites(
+      [
+        {
+          id: "ful_83",
+          patch: { refs: { waybill: "21091376574" } },
+          providerId: null,
+        },
+      ],
+      [{ id: "ful_83", data: { refs: { waybill: "21091376574" } } }]
+    )
+    expect(errors).toEqual([])
+  })
+
+  it("ignores provider verification when no alignment was requested", () => {
+    expect(
+      unlandedWrites(
+        [{ id: "ful_83", patch: {}, providerId: null }],
+        [{ id: "ful_83", provider_id: "delhivery_delhivery", data: {} }]
+      )
+    ).toEqual([])
   })
 })

--- a/apps/backend/src/api/admin/ops/maintenance-jobs/clean-order-fulfillment-data-job.ts
+++ b/apps/backend/src/api/admin/ops/maintenance-jobs/clean-order-fulfillment-data-job.ts
@@ -51,6 +51,23 @@ import type {
  * this verifies the target provider row EXISTS before writing and refuses
  * otherwise — an FK violation mid-run is a worse outcome than a clear refusal.
  *
+ * ⚠️ THE SECOND TRAP: `provider_id` CANNOT BE WRITTEN THROUGH THE MODULE
+ * ---------------------------------------------------------------------
+ * This job used to align the provider with
+ * `updateFulfillment(id, { provider_id } as any)`, reasoning that
+ * `updateFulfillment_` spreads its argument straight into
+ * `fulfillmentService_.update([{ id, ...data }])`. The spread is real, but the
+ * key never lands: `Fulfillment` declares `provider: model.hasOne(..., {
+ * foreignKey: true })`, so the column belongs to a RELATION, and the loose
+ * scalar is dropped by the ORM **without raising**. On order 83 that produced
+ * the worst possible outcome — `applied: true`, a change record reading
+ * `delhivery_delhivery → bluedart_bluedart`, and a row that never moved.
+ *
+ * So the provider write goes through SQL, where a no-op cannot masquerade as a
+ * success, and EVERY write is verified by re-reading the row (see
+ * `unlandedWrites`). A repair tool that reports a repair it did not make is
+ * worse than one that fails loudly: it retires the ticket.
+ *
  * Dry-run (the default) previews every before→after without writing. Apply is
  * idempotent: a second run finds the keys already null and reports no changes.
  */
@@ -135,6 +152,77 @@ export function targetProviderId(fulfillment: any): string | null {
   return fulfillment?.provider_id === target ? null : target
 }
 
+/** One fulfillment's intended writes, kept so they can be checked afterwards. */
+export type IntendedWrite = {
+  id: string
+  /** `data` keys and their intended values (nulls included). */
+  patch: Record<string, unknown>
+  /** Intended `provider_id`, or null when no alignment was requested. */
+  providerId: string | null
+}
+
+/** Structural equality that survives a jsonb round-trip. */
+const sameValue = (a: unknown, b: unknown): boolean =>
+  a === b ||
+  (a !== null &&
+    b !== null &&
+    typeof a === "object" &&
+    typeof b === "object" &&
+    JSON.stringify(a) === JSON.stringify(b))
+
+/**
+ * PURE: which intended writes are NOT visible in the rows read back after the
+ * write. Exported for unit testing.
+ *
+ * This exists because both of this job's write paths can no-op silently — the
+ * `data` merge (a `delete` or an omission changes nothing) and the `provider_id`
+ * relation FK (a loose scalar is discarded by the ORM). Neither raises, so
+ * without a read-back the job's own success report is just a restatement of its
+ * intent. Order 83 was repaired, reported `applied: true`, and kept pointing at
+ * Delhivery.
+ */
+export function unlandedWrites(
+  intended: IntendedWrite[],
+  actual: Array<{
+    id: string
+    provider_id?: string | null
+    data?: Record<string, any> | null
+  }>
+): Array<{ id: string; message: string }> {
+  const byId = new Map(actual.map((f) => [f.id, f]))
+  const errors: Array<{ id: string; message: string }> = []
+
+  for (const write of intended) {
+    const row = byId.get(write.id)
+    if (!row) {
+      errors.push({
+        id: write.id,
+        message: `Wrote ${write.id} but could not read it back to verify — treat this run as NOT applied.`,
+      })
+      continue
+    }
+
+    const staleKeys = Object.entries(write.patch)
+      .filter(([key, value]) => !sameValue((row.data ?? {})[key], value))
+      .map(([key]) => key)
+    if (staleKeys.length) {
+      errors.push({
+        id: write.id,
+        message: `data key(s) did not persist: ${staleKeys.join(", ")}. The write returned without error but the row is unchanged.`,
+      })
+    }
+
+    if (write.providerId && row.provider_id !== write.providerId) {
+      errors.push({
+        id: write.id,
+        message: `provider_id did not persist: still '${row.provider_id}', expected '${write.providerId}'. The column is a relation FK, so a module-level write is silently dropped.`,
+      })
+    }
+  }
+
+  return errors
+}
+
 export const cleanOrderFulfillmentDataJob: MaintenanceJob = {
   id: "clean-order-fulfillment-data",
   label: "Clean stale carrier residue off order fulfillments (#1285)",
@@ -171,6 +259,9 @@ export const cleanOrderFulfillmentDataJob: MaintenanceJob = {
     const query: any = container.resolve(ContainerRegistrationKeys.QUERY)
     const fulfillmentModule: any = container.resolve(Modules.FULFILLMENT)
     const logger: any = container.resolve(ContainerRegistrationKeys.LOGGER)
+    const pgConnection: any = container.resolve(
+      ContainerRegistrationKeys.PG_CONNECTION
+    )
 
     // --- load the target fulfillments ---------------------------------------
     let fulfillments: any[] = []
@@ -216,6 +307,8 @@ export const cleanOrderFulfillmentDataJob: MaintenanceJob = {
 
     const changes: MaintenanceChange[] = []
     const errors: Array<{ id: string; message: string }> = []
+    /** What we actually asked the database for, to be verified after the run. */
+    const intended: IntendedWrite[] = []
 
     for (const f of fulfillments) {
       const patch = buildDataPatch(f.data, clear_keys, set)
@@ -265,19 +358,35 @@ export const cleanOrderFulfillmentDataJob: MaintenanceJob = {
           await fulfillmentModule.updateFulfillment(f.id, { data: patch })
         }
         if (nextProviderId) {
-          // `provider_id` is absent from UpdateFulfillmentDTO, but updateFulfillment_
-          // spreads `data` straight into the underlying update — the same
-          // deliberate, load-bearing cast used by backfill-open-order-requires-shipping.
-          await fulfillmentModule.updateFulfillment(f.id, {
-            provider_id: nextProviderId,
-          } as any)
+          // SQL, not the module — see the docblock. `provider_id` is the FK of a
+          // `hasOne` relation, so passing it to `updateFulfillment` is discarded
+          // silently. The target's existence was checked above, so the FK is
+          // safe; `updated_at` is bumped by hand because we bypass the ORM.
+          await pgConnection.raw(
+            'update "fulfillment" set "provider_id" = ?, "updated_at" = now() where "id" = ?',
+            [nextProviderId, f.id]
+          )
         }
+        intended.push({ id: f.id, patch, providerId: nextProviderId })
         logger?.info?.(
           `[clean-order-fulfillment-data] repaired ${f.id} (${Object.keys(patch).join(", ") || "provider only"}${nextProviderId ? ` → ${nextProviderId}` : ""})`
         )
       } catch (e: any) {
         errors.push({ id: f.id, message: e?.message ?? String(e) })
       }
+    }
+
+    // --- read back and prove the writes landed --------------------------------
+    // Both write paths can no-op without raising, so "no exception" is not
+    // evidence. Anything that did not persist becomes an error, which drops
+    // `applied` to false — the report then describes the ROW, not the intent.
+    if (!dry_run && intended.length) {
+      const { data: readBack } = await query.graph({
+        entity: "fulfillment",
+        filters: { id: intended.map((w) => w.id) },
+        fields: ["id", "provider_id", "data"],
+      })
+      errors.push(...unlandedWrites(intended, readBack ?? []))
     }
 
     const dataChanges = changes.filter((c) => c.entity === "fulfillment.data").length
@@ -289,7 +398,10 @@ export const cleanOrderFulfillmentDataJob: MaintenanceJob = {
       dry_run,
       applied,
       summary: changes.length
-        ? `${dry_run ? "Would repair" : "Repaired"} ${dataChanges} data key(s) and ${providerChanges} provider attribution(s) across ${fulfillments.length} fulfillment(s)${errors.length ? `; ${errors.length} error(s)` : ""}`
+        ? // "Repaired" is claimed only after the read-back agreed. Otherwise the
+          // verb is ATTEMPTED — the whole point of the check is that this job
+          // once reported a repair it had not made.
+          `${dry_run ? "Would repair" : applied ? "Repaired" : "ATTEMPTED"} ${dataChanges} data key(s) and ${providerChanges} provider attribution(s) across ${fulfillments.length} fulfillment(s)${errors.length ? `; ${errors.length} error(s) — NOT applied, see errors` : ""}`
         : `Nothing to repair across ${fulfillments.length} fulfillment(s)`,
       changes,
       ...(errors.length ? { errors } : {}),

--- a/apps/backend/src/api/admin/orders/[id]/fulfillments/[fulfillmentId]/tracking/route.ts
+++ b/apps/backend/src/api/admin/orders/[id]/fulfillments/[fulfillmentId]/tracking/route.ts
@@ -1,0 +1,31 @@
+import { MedusaRequest, MedusaResponse } from "@medusajs/framework/http"
+
+import { getFulfillmentTracking } from "../../../../../../../workflows/orders/fulfillment-tracking"
+
+/**
+ * GET /admin/orders/:id/fulfillments/:fulfillmentId/tracking
+ *
+ * Ask the carrier where the parcel actually is.
+ *
+ * This existed for PARTNERS and nowhere else, which meant an in-house order had
+ * no way to answer it at all. Order 83 sat uncollected for days with `shipped_at`
+ * null and a Blue Dart waybill; the only question that mattered — "has it been
+ * picked up?" — could not be asked from inside the system, so it was answered by
+ * waiting for someone to say so.
+ *
+ * Read-only: no carrier state is changed, nothing is booked or cancelled. It
+ * does spend a carrier API call (and, per `resolveShippingProvider`, mints a
+ * fresh token to do it), so it is a request, not a poll.
+ *
+ * `source` says whether the answer came from the carrier or was synthesised from
+ * our own timestamps — the two look alike and mean very different things.
+ */
+export const GET = async (req: MedusaRequest, res: MedusaResponse) => {
+  const tracking = await getFulfillmentTracking(
+    req.scope,
+    req.params.id,
+    req.params.fulfillmentId
+  )
+
+  res.json(tracking)
+}

--- a/apps/backend/src/api/partners/orders/[id]/fulfillments/[fulfillmentId]/tracking/route.ts
+++ b/apps/backend/src/api/partners/orders/[id]/fulfillments/[fulfillmentId]/tracking/route.ts
@@ -1,122 +1,27 @@
 import { AuthenticatedMedusaRequest, MedusaResponse } from "@medusajs/framework/http"
-import { ContainerRegistrationKeys, MedusaError } from "@medusajs/framework/utils"
-import { validatePartnerOrderOwnership } from "../../../../../helpers"
-import {
-  isSupportedCarrier,
-  resolveShippingProvider,
-  shipmentRefFromFulfillment,
-} from "../../../../../../../modules/shipping-providers/resolver"
 
+import { validatePartnerOrderOwnership } from "../../../../../helpers"
+import { getFulfillmentTracking } from "../../../../../../../workflows/orders/fulfillment-tracking"
+
+/**
+ * GET /partners/orders/:id/fulfillments/:fulfillmentId/tracking
+ *
+ * Same answer as the admin route, behind an ownership check. The body lives in
+ * `getFulfillmentTracking` because the fallback timeline is the kind of code
+ * that drifts silently when copied — both copies keep returning something
+ * plausible.
+ */
 export const GET = async (
   req: AuthenticatedMedusaRequest,
   res: MedusaResponse
 ) => {
   await validatePartnerOrderOwnership(req.auth_context, req.params.id, req.scope)
 
-  const query = req.scope.resolve(ContainerRegistrationKeys.QUERY)
-  const { data: orders } = await query.graph({
-    entity: "orders",
-    fields: ["id", "fulfillments.*", "fulfillments.labels.*"],
-    filters: { id: req.params.id },
-  })
-
-  const order = (orders as any)?.[0]
-  const fulfillment = order?.fulfillments?.find(
-    (f: any) => f.id === req.params.fulfillmentId
+  const tracking = await getFulfillmentTracking(
+    req.scope,
+    req.params.id,
+    req.params.fulfillmentId
   )
 
-  if (!fulfillment) {
-    throw new MedusaError(MedusaError.Types.NOT_FOUND, "Fulfillment not found")
-  }
-
-  const waybill = fulfillment.data?.waybill || fulfillment.data?.tracking_number
-  if (!waybill) {
-    throw new MedusaError(
-      MedusaError.Types.NOT_FOUND,
-      "No waybill found for this fulfillment"
-    )
-  }
-
-  const carrier = fulfillment.data?.carrier
-
-  if (isSupportedCarrier(carrier)) {
-    const provider = await resolveShippingProvider(req.scope, carrier)
-    const result = await provider.track(shipmentRefFromFulfillment(fulfillment.data))
-
-    res.json({
-      waybill: result.awb || waybill,
-      carrier: result.carrier,
-      current_status: result.current_status,
-      current_status_type: result.current_status_code ?? "",
-      estimated_delivery: result.estimated_delivery,
-      origin: result.origin || "",
-      destination: result.destination || "",
-      events: result.events,
-    })
-    return
-  }
-
-  // No carrier client — return a basic timeline from fulfillment timestamps.
-  const events: Array<{
-    timestamp: string
-    status: string
-    location: string
-    scan_type: string
-  }> = []
-
-  if (fulfillment.created_at) {
-    events.push({
-      timestamp: fulfillment.created_at,
-      status: "Fulfillment created",
-      location: "",
-      scan_type: "created",
-    })
-  }
-  if (fulfillment.shipped_at) {
-    events.push({
-      timestamp: fulfillment.shipped_at,
-      status: "Shipped",
-      location: "",
-      scan_type: "shipped",
-    })
-  }
-  if (fulfillment.delivered_at) {
-    events.push({
-      timestamp: fulfillment.delivered_at,
-      status: "Delivered",
-      location: "",
-      scan_type: "delivered",
-    })
-  }
-  if (fulfillment.canceled_at) {
-    events.push({
-      timestamp: fulfillment.canceled_at,
-      status: "Canceled",
-      location: "",
-      scan_type: "canceled",
-    })
-  }
-
-  events.sort((a, b) =>
-    new Date(b.timestamp).getTime() - new Date(a.timestamp).getTime()
-  )
-
-  const currentStatus = fulfillment.canceled_at
-    ? "Canceled"
-    : fulfillment.delivered_at
-    ? "Delivered"
-    : fulfillment.shipped_at
-    ? "Shipped"
-    : "Awaiting Shipping"
-
-  res.json({
-    waybill,
-    carrier: carrier || "unknown",
-    current_status: currentStatus,
-    current_status_type: "",
-    estimated_delivery: null,
-    origin: "",
-    destination: "",
-    events,
-  })
+  res.json(tracking)
 }

--- a/apps/backend/src/workflows/orders/__tests__/fulfillment-tracking.unit.spec.ts
+++ b/apps/backend/src/workflows/orders/__tests__/fulfillment-tracking.unit.spec.ts
@@ -1,4 +1,5 @@
 import {
+  pickupFromMetadata,
   statusFromFulfillment,
   timelineFromFulfillment,
 } from "../fulfillment-tracking"
@@ -76,5 +77,66 @@ describe("timelineFromFulfillment", () => {
 
   it("returns an empty timeline rather than inventing one", () => {
     expect(timelineFromFulfillment({})).toEqual([])
+  })
+})
+
+/**
+ * The pickup code. For Blue Dart this is `TokenNumber`, and it is the ONLY
+ * handle that can call a collection off — cancelling the waybill does not. It
+ * lived in the shipment widget alone, so whoever asked the tracking question
+ * ("has it been collected?") could not see the field they need the moment the
+ * answer is "no, and it isn't coming".
+ */
+describe("pickupFromMetadata", () => {
+  it("reads order 83's Blue Dart token", () => {
+    expect(
+      pickupFromMetadata({
+        pickup_id: "4175751",
+        pickup_date: "2026-08-17",
+        pickup_time: "14:00",
+        carrier: "bluedart",
+        booked_at: "2026-08-17T05:00:00.000Z",
+        pickup_bookings: [{ pickup_id: "4175751" }],
+      })
+    ).toEqual({
+      code: "4175751",
+      date: "2026-08-17",
+      time: "14:00",
+      carrier: "bluedart",
+      incoming_center_name: null,
+      booked_at: "2026-08-17T05:00:00.000Z",
+      bookings_count: 1,
+    })
+  })
+
+  it("gates on pickup_date, not on the code — a booking with no token is still a courier coming", () => {
+    const pickup = pickupFromMetadata({
+      pickup_date: "2026-08-17",
+      pickup_time: "14:00",
+    })
+    expect(pickup).not.toBeNull()
+    // Null rather than "" so the UI can warn that cancelling needs a phone call.
+    expect(pickup!.code).toBeNull()
+  })
+
+  it("returns null when no pickup has been recorded", () => {
+    expect(pickupFromMetadata(null)).toBeNull()
+    expect(pickupFromMetadata({})).toBeNull()
+    expect(pickupFromMetadata({ pickup_id: "4175751" })).toBeNull()
+  })
+
+  it("counts every booking — a re-book can leave an earlier collection live", () => {
+    expect(
+      pickupFromMetadata({
+        pickup_date: "2026-08-17",
+        pickup_bookings: [{ pickup_id: "4175751" }, { pickup_id: "4175752" }],
+      })!.bookings_count
+    ).toBe(2)
+  })
+
+  it("stringifies a numeric token — Blue Dart sends TokenNumber as a number", () => {
+    expect(
+      pickupFromMetadata({ pickup_id: 4175751, pickup_date: "2026-08-17" })!.code
+    ).toBe("4175751")
   })
 })

--- a/apps/backend/src/workflows/orders/__tests__/fulfillment-tracking.unit.spec.ts
+++ b/apps/backend/src/workflows/orders/__tests__/fulfillment-tracking.unit.spec.ts
@@ -1,0 +1,80 @@
+import {
+  statusFromFulfillment,
+  timelineFromFulfillment,
+} from "../fulfillment-tracking"
+
+/**
+ * The local fallback, which is the half that misleads. When no carrier can be
+ * called, these two functions ARE the tracking answer — and on order 83 they
+ * would have said "Awaiting Shipping" for a parcel that had a Blue Dart waybill
+ * printed days earlier. That is a true statement about our records and a
+ * potentially false one about the parcel, which is why the route labels the
+ * source rather than letting the two blur.
+ */
+
+// Order 83's real shape at the time of writing: label created, never shipped.
+const ORDER_83 = {
+  created_at: "2026-08-14T10:47:18.251Z",
+  shipped_at: null,
+  delivered_at: null,
+  canceled_at: null,
+}
+
+describe("statusFromFulfillment", () => {
+  it("reports Awaiting Shipping when nothing has been marked", () => {
+    expect(statusFromFulfillment(ORDER_83)).toBe("Awaiting Shipping")
+  })
+
+  it("prefers Canceled over every other timestamp", () => {
+    expect(
+      statusFromFulfillment({
+        shipped_at: "2026-08-08T13:10:05.725Z",
+        delivered_at: "2026-08-12T00:00:00.000Z",
+        canceled_at: "2026-08-14T07:04:21.440Z",
+      })
+    ).toBe("Canceled")
+  })
+
+  it("prefers Delivered over Shipped", () => {
+    expect(
+      statusFromFulfillment({
+        shipped_at: "2026-08-08T13:10:05.725Z",
+        delivered_at: "2026-08-12T00:00:00.000Z",
+      })
+    ).toBe("Delivered")
+  })
+
+  it("reports Shipped once shipped_at is set", () => {
+    expect(
+      statusFromFulfillment({ shipped_at: "2026-08-08T13:10:05.725Z" })
+    ).toBe("Shipped")
+  })
+})
+
+describe("timelineFromFulfillment", () => {
+  it("emits only the timestamps that exist", () => {
+    const events = timelineFromFulfillment(ORDER_83)
+    expect(events).toHaveLength(1)
+    expect(events[0]).toMatchObject({
+      status: "Fulfillment created",
+      scan_type: "created",
+    })
+  })
+
+  it("sorts newest first", () => {
+    const events = timelineFromFulfillment({
+      created_at: "2026-08-01T00:00:00.000Z",
+      shipped_at: "2026-08-08T00:00:00.000Z",
+      delivered_at: "2026-08-12T00:00:00.000Z",
+    })
+    expect(events.map((e) => e.scan_type)).toEqual([
+      "delivered",
+      "shipped",
+      "created",
+    ])
+  })
+
+  it("returns an empty timeline rather than inventing one", () => {
+    expect(timelineFromFulfillment({})).toEqual([])
+  })
+})

--- a/apps/backend/src/workflows/orders/fulfillment-tracking.ts
+++ b/apps/backend/src/workflows/orders/fulfillment-tracking.ts
@@ -34,6 +34,27 @@ export type TrackingEvent = {
   scan_type: string
 }
 
+/**
+ * The booked collection, as the operator needs to read it out loud.
+ *
+ * For Blue Dart the code is `TokenNumber`, and it is **the only handle that can
+ * call the collection off** — a waybill cancellation does not cancel the pickup.
+ * It was previously visible only in the shipment widget, so anyone asking the
+ * tracking question ("has it been collected?") could not see the one field they
+ * would need the moment the answer was "no, and it's not coming".
+ */
+export type PickupSummary = {
+  /** Carrier's handle: Blue Dart `TokenNumber`, Shiprocket `pickup_token_number`. */
+  code: string | null
+  date: string
+  time: string
+  carrier: string | null
+  incoming_center_name: string | null
+  booked_at: string | null
+  /** Bookings recorded on this fulfillment; >1 means a pickup was re-booked. */
+  bookings_count: number
+}
+
 export type FulfillmentTracking = {
   waybill: string
   carrier: string
@@ -43,6 +64,8 @@ export type FulfillmentTracking = {
   origin: string
   destination: string
   events: TrackingEvent[]
+  /** The booked collection, or null when none has been recorded. */
+  pickup: PickupSummary | null
   /**
    * Whether these events came from the carrier or were synthesised locally.
    *
@@ -82,6 +105,42 @@ export function timelineFromFulfillment(fulfillment: {
     .sort(
       (a, b) => new Date(b.timestamp).getTime() - new Date(a.timestamp).getTime()
     )
+}
+
+/**
+ * PURE: the booked pickup recorded on a fulfillment. Exported for testing.
+ *
+ * Reads `metadata`, not `data` — `data` is the carrier's opaque blob and is
+ * cleared wholesale by cancel-shipment, which must not erase the record of a
+ * collection the carrier is still coming for (see `persist-pickup-booking`).
+ *
+ * `pickup_date` is the load-bearing field, matching the shipment widget: Blue
+ * Dart can hand back a booking with no token at all, and a record with a date
+ * but no code still has to render — as a WARNING, because cancelling it then
+ * means a phone call.
+ */
+export function pickupFromMetadata(
+  metadata: Record<string, any> | null | undefined
+): PickupSummary | null {
+  const m = metadata ?? {}
+  if (!m.pickup_date) return null
+
+  const bookings = Array.isArray(m.pickup_bookings) ? m.pickup_bookings : []
+
+  return {
+    code: m.pickup_id ? String(m.pickup_id) : null,
+    date: String(m.pickup_date),
+    time: String(m.pickup_time ?? ""),
+    carrier: m.carrier ? String(m.carrier) : null,
+    incoming_center_name: m.incoming_center_name
+      ? String(m.incoming_center_name)
+      : null,
+    booked_at: m.booked_at ? String(m.booked_at) : null,
+    // Kept because a re-booked pickup can leave an EARLIER collection live at
+    // the carrier under a different token — the orphan class cancel-shipment
+    // exists to prevent, one level up.
+    bookings_count: bookings.length,
+  }
 }
 
 /**
@@ -145,6 +204,7 @@ export async function getFulfillmentTracking(
   }
 
   const carrier = fulfillment.data?.carrier
+  const pickup = pickupFromMetadata(fulfillment.metadata)
 
   if (isSupportedCarrier(carrier)) {
     try {
@@ -168,6 +228,7 @@ export async function getFulfillmentTracking(
         origin: result.origin || "",
         destination: result.destination || "",
         events: result.events,
+        pickup,
         source: "carrier",
       }
     } catch (e: any) {
@@ -189,6 +250,7 @@ export async function getFulfillmentTracking(
     origin: "",
     destination: "",
     events: timelineFromFulfillment(fulfillment),
+    pickup,
     source: "fulfillment",
   }
 }

--- a/apps/backend/src/workflows/orders/fulfillment-tracking.ts
+++ b/apps/backend/src/workflows/orders/fulfillment-tracking.ts
@@ -1,0 +1,194 @@
+import { ContainerRegistrationKeys, MedusaError } from "@medusajs/framework/utils"
+import type { MedusaContainer } from "@medusajs/framework/types"
+
+import {
+  isSupportedCarrier,
+  resolveShippingProvider,
+  shipmentRefFromFulfillment,
+} from "../../modules/shipping-providers/resolver"
+
+/**
+ * Live carrier tracking for one fulfillment — the shared body behind both the
+ * partner and the admin tracking routes.
+ *
+ * WHY THIS IS SHARED RATHER THAN COPIED
+ * -------------------------------------
+ * The capability has existed in the adapters for a while (Blue Dart's `track()`
+ * even prefers DHL Unified Shipment Tracking, because Blue Dart's own TnT drops
+ * cancelled waybills and answers `"Incorrect waybill number or No information"`
+ * — indistinguishable from a typo). But the ONLY route that called it was the
+ * partner one, so for an in-house order like #83 nobody could ask "has the
+ * carrier collected it?" from inside this system at all. That question then got
+ * answered by waiting.
+ *
+ * The half worth not duplicating is the FALLBACK: when there is no carrier
+ * client, the answer is still a timeline, synthesised from the fulfillment's own
+ * timestamps. Two copies of that would drift, and the drift would be invisible
+ * — both would keep returning a plausible-looking timeline.
+ */
+
+export type TrackingEvent = {
+  timestamp: string
+  status: string
+  location: string
+  scan_type: string
+}
+
+export type FulfillmentTracking = {
+  waybill: string
+  carrier: string
+  current_status: string
+  current_status_type: string
+  estimated_delivery: string | null
+  origin: string
+  destination: string
+  events: TrackingEvent[]
+  /**
+   * Whether these events came from the carrier or were synthesised locally.
+   *
+   * Returned because the two answer different questions and look identical: a
+   * local timeline can say "Awaiting Shipping" for a parcel the carrier picked
+   * up an hour ago. An operator deciding whether to chase a pickup needs to know
+   * which one they are reading.
+   */
+  source: "carrier" | "fulfillment"
+}
+
+/**
+ * PURE: the timeline a fulfillment's own timestamps imply, for carriers we
+ * cannot call. Exported for unit testing.
+ */
+export function timelineFromFulfillment(fulfillment: {
+  created_at?: string | null
+  shipped_at?: string | null
+  delivered_at?: string | null
+  canceled_at?: string | null
+}): TrackingEvent[] {
+  const stamps: Array<[string | null | undefined, string, string]> = [
+    [fulfillment.created_at, "Fulfillment created", "created"],
+    [fulfillment.shipped_at, "Shipped", "shipped"],
+    [fulfillment.delivered_at, "Delivered", "delivered"],
+    [fulfillment.canceled_at, "Canceled", "canceled"],
+  ]
+
+  return stamps
+    .filter(([at]) => !!at)
+    .map(([at, status, scan_type]) => ({
+      timestamp: String(at),
+      status,
+      location: "",
+      scan_type,
+    }))
+    .sort(
+      (a, b) => new Date(b.timestamp).getTime() - new Date(a.timestamp).getTime()
+    )
+}
+
+/**
+ * PURE: the status a fulfillment's own timestamps imply. Exported for testing.
+ *
+ * ⚠️ This is what we know, NOT what the parcel is doing. "Awaiting Shipping"
+ * here means nobody has marked it shipped in this system — it is not a claim
+ * that the carrier has not collected it.
+ */
+export function statusFromFulfillment(fulfillment: {
+  shipped_at?: string | null
+  delivered_at?: string | null
+  canceled_at?: string | null
+}): string {
+  if (fulfillment.canceled_at) return "Canceled"
+  if (fulfillment.delivered_at) return "Delivered"
+  if (fulfillment.shipped_at) return "Shipped"
+  return "Awaiting Shipping"
+}
+
+/**
+ * Track a fulfillment, preferring the carrier and falling back to local state.
+ *
+ * Throws NOT_FOUND when the fulfillment or its waybill is missing — without a
+ * waybill there is nothing to ask about, and an empty timeline would read as
+ * "no movement" rather than "never booked".
+ */
+export async function getFulfillmentTracking(
+  container: MedusaContainer,
+  orderId: string,
+  fulfillmentId: string
+): Promise<FulfillmentTracking> {
+  const query: any = container.resolve(ContainerRegistrationKeys.QUERY)
+  const logger: any = container.resolve(ContainerRegistrationKeys.LOGGER)
+
+  const { data: orders } = await query.graph({
+    entity: "orders",
+    fields: ["id", "fulfillments.*", "fulfillments.labels.*"],
+    filters: { id: orderId },
+  })
+
+  const order = (orders as any)?.[0]
+  const fulfillment = order?.fulfillments?.find(
+    (f: any) => f.id === fulfillmentId
+  )
+
+  if (!fulfillment) {
+    throw new MedusaError(MedusaError.Types.NOT_FOUND, "Fulfillment not found")
+  }
+
+  const waybill =
+    fulfillment.data?.waybill ||
+    fulfillment.data?.tracking_number ||
+    fulfillment.labels?.[0]?.tracking_number
+
+  if (!waybill) {
+    throw new MedusaError(
+      MedusaError.Types.NOT_FOUND,
+      "No waybill found for this fulfillment"
+    )
+  }
+
+  const carrier = fulfillment.data?.carrier
+
+  if (isSupportedCarrier(carrier)) {
+    try {
+      const provider = await resolveShippingProvider(container, carrier)
+      const result = await provider.track(
+        shipmentRefFromFulfillment(fulfillment.data)
+      )
+
+      return {
+        waybill: result.awb || waybill,
+        carrier: result.carrier,
+        current_status: result.current_status,
+        // Carriers disagree on the shape of a status code — Blue Dart answers
+        // with a string, Delhivery with a number — so it is normalised here
+        // rather than leaking the union to every caller.
+        current_status_type:
+          result.current_status_code == null
+            ? ""
+            : String(result.current_status_code),
+        estimated_delivery: result.estimated_delivery ?? null,
+        origin: result.origin || "",
+        destination: result.destination || "",
+        events: result.events,
+        source: "carrier",
+      }
+    } catch (e: any) {
+      // A carrier that cannot answer must not take the whole route down: the
+      // local timeline is still worth having, and a 500 here would read to the
+      // operator as "tracking is broken" rather than "the carrier said no".
+      logger?.warn?.(
+        `[fulfillment-tracking] ${carrier} tracking failed for ${waybill}: ${e?.message}. Falling back to local state.`
+      )
+    }
+  }
+
+  return {
+    waybill,
+    carrier: carrier || "unknown",
+    current_status: statusFromFulfillment(fulfillment),
+    current_status_type: "",
+    estimated_delivery: null,
+    origin: "",
+    destination: "",
+    events: timelineFromFulfillment(fulfillment),
+    source: "fulfillment",
+  }
+}

--- a/apps/partner-ui/src/routes/orders/order-detail/components/order-fulfillment-section/order-fulfillment-section.tsx
+++ b/apps/partner-ui/src/routes/orders/order-detail/components/order-fulfillment-section/order-fulfillment-section.tsx
@@ -487,6 +487,11 @@ const Fulfillment = ({
                 ),
                 bookedPickup.pickup_time ? "dd MMM, HH:mm" : "dd MMM"
               )}`}
+              {/* The carrier's handle for the collection — Blue Dart's token
+                  number. Shown because it is what the carrier's phone agent
+                  asks for, and (for Blue Dart) the only thing that can call the
+                  collection off; cancelling the waybill does not. */}
+              {bookedPickup.pickup_id ? ` · #${bookedPickup.pickup_id}` : ""}
             </StatusBadge>
           )}
           <Tooltip


### PR DESCRIPTION
Both defects surfaced while repairing **order 83** on prod. Neither produced a wrong answer — each let a question go *unanswered* while looking answered.

## 1. `align_provider` reported a repair it never made

Running `clean-order-fulfillment-data` against order 83 returned:

```
summary: "Repaired 15 data key(s) and 1 provider attribution(s) across 1 fulfillment(s)"
applied: true,  errors: null
changes: [... { field: "provider_id", before: "delhivery_delhivery", after: "bluedart_bluedart" }]
```

`provider_id` is still `delhivery_delhivery`. Not replica lag — the 15 `data` keys from the *same* write, on the *same* row, in the *same* read, came back updated. That is exactly what made it convincing.

**Cause.** The job wrote `updateFulfillment(id, { provider_id } as any)`, reasoning (in a comment) that `updateFulfillment_` spreads its argument into `fulfillmentService_.update([{ id, ...data }])`. The spread is real, but the key never lands: `Fulfillment` declares `provider: model.hasOne(FulfillmentProvider, { foreignKey: true })`, so the column belongs to a **relation**, and the loose scalar is discarded by the ORM **without raising**.

**Why it is not cosmetic.** Core routes cancellation on `provider_id`. A fulfillment carrying a Blue Dart AWB while attributed to Delhivery asks the wrong carrier to cancel it — the #1225 orphan class, and order 83 is sitting uncollected in exactly that state.

**Fix.** The provider write goes through SQL, where a no-op cannot masquerade as success. More importantly, **every write is now read back and compared** (`unlandedWrites`) — both of this job's paths can no-op silently (the `data` merge, the relation FK), so "no exception" was never evidence. Anything that did not persist becomes an error, which drops `applied` to false and changes the summary verb from `Repaired` to `ATTEMPTED`.

> A repair tool that reports a repair it did not make is worse than one that fails loudly: it retires the ticket.

## 2. Only partners could ask a carrier where a parcel was

The adapters have had `track()` for a while — Blue Dart's even prefers **DHL Unified Shipment Tracking**, because Blue Dart's own TnT drops cancelled waybills and answers `"Incorrect waybill number or No information"`, indistinguishable from a typo. But the only route calling it was `/partners/orders/:id/fulfillments/:fid/tracking`.

So for an in-house order like #83, the one question that mattered — *has the carrier collected it?* — could not be asked from inside the system at all. It was answered by waiting for someone to say so.

Adds `GET /admin/orders/:id/fulfillments/:fulfillmentId/tracking` over a shared `getFulfillmentTracking`, and collapses the partner route onto it. The half worth not duplicating is the **fallback timeline** synthesised from our own timestamps — two copies of that drift silently, because both keep returning something plausible.

The response carries `source: "carrier" | "fulfillment"`. A local timeline can read `"Awaiting Shipping"` for a parcel picked up an hour ago; an operator deciding whether to chase a pickup needs to know which one they are reading. A carrier error falls back rather than 500ing, for the same reason — "the carrier said no" and "tracking is broken" are different facts.

## Verification

- `cd apps/backend && npx jest --testPathPattern="(clean-order-fulfillment-data|fulfillment-tracking)"` → **25 green**.
- `pnpm check:prod-build` → **green**. It earned its keep here: the typed contract exposed two mismatches the untyped partner route had been silently carrying (`current_status_code` is a string on Blue Dart and a number on Delhivery; `estimated_delivery` can be `undefined`).

## After merge

Order 83's `provider_id` is still wrong on prod — the repair has to be re-run once this deploys. Verify by **probing**: re-run with `align_provider`, then re-read the fulfillment and confirm `bluedart_bluedart`. A second run should then report *nothing to repair*.

Refs #1285.

🤖 Generated with [Claude Code](https://claude.com/claude-code)