### PR TITLE
feat(mcp): OAuth 2.1 + PKCE front door for the Admin MCP (#1306 Track B)

### DIFF
--- a/apps/backend/medusa-config.prod.ts
+++ b/apps/backend/medusa-config.prod.ts
@@ -597,6 +597,9 @@ module.exports = defineConfig({
     resolve: "./src/modules/mcp_access",
   },
   {
+    resolve: "./src/modules/mcp_oauth",
+  },
+  {
     resolve: "./src/modules/fx_rates",
   },
   {

--- a/apps/backend/medusa-config.ts
+++ b/apps/backend/medusa-config.ts
@@ -211,6 +211,9 @@ module.exports = defineConfig({
       resolve: "./src/modules/mcp_access",
     },
     {
+      resolve: "./src/modules/mcp_oauth",
+    },
+    {
       resolve: "./src/modules/unified_order_status",
     },
     {

--- a/apps/backend/src/api/admin/mcp/oauth-tokens/[id]/route.ts
+++ b/apps/backend/src/api/admin/mcp/oauth-tokens/[id]/route.ts
@@ -1,0 +1,49 @@
+/**
+ * DELETE /admin/mcp/oauth-tokens/:id — revoke one OAuth authorization
+ * (#1306 Track B).
+ *
+ * Takes effect on the very next request: the access token is a self-verifying
+ * JWT, so what makes this immediate is the `/admin/*` revocation global in
+ * `src/api/middlewares.ts`, which reads this row on every request that carries
+ * an `mcp_oauth` claim — reads included.
+ *
+ * The scope row is narrowed to `read` rather than deleted. A deleted row means
+ * "no restriction", i.e. the process ceiling — so removing it while some other
+ * path still accepted the token would WIDEN the credential at the exact moment
+ * it was meant to lose access. Failing safe here costs one stale row.
+ */
+import { MedusaRequest, MedusaResponse } from "@medusajs/framework/http"
+import { MCP_ACCESS_MODULE } from "../../../../../modules/mcp_access"
+import type McpAccessService from "../../../../../modules/mcp_access/service"
+import { MCP_OAUTH_MODULE } from "../../../../../modules/mcp_oauth"
+import type McpOauthService from "../../../../../modules/mcp_oauth/service"
+import { refuseNonHumanAdmin } from "../route"
+
+export const DELETE = async (req: MedusaRequest, res: MedusaResponse) => {
+  if (refuseNonHumanAdmin(req, res)) return
+
+  const id = String((req.params as any).id || "")
+  const service = req.scope.resolve(MCP_OAUTH_MODULE) as McpOauthService
+  const row = await service.getToken(id)
+  if (!row) {
+    return res.status(404).json({ message: `No OAuth authorization ${id}.` })
+  }
+
+  await service.revokeToken(id)
+
+  try {
+    const access = req.scope.resolve(MCP_ACCESS_MODULE) as McpAccessService
+    await access.setScope({
+      principal_type: "oauth",
+      principal_id: id,
+      level: "read",
+      note: `Revoked ${new Date().toISOString()} — retained at 'read' because a missing scope row means the process ceiling, not zero.`,
+    })
+  } catch {
+    // The revocation itself has already landed and is what is enforced; a
+    // failure to also narrow the (now unreachable) scope row must not turn a
+    // successful revoke into an error the admin retries.
+  }
+
+  res.json({ id, revoked: true })
+}

--- a/apps/backend/src/api/admin/mcp/oauth-tokens/route.ts
+++ b/apps/backend/src/api/admin/mcp/oauth-tokens/route.ts
@@ -1,0 +1,60 @@
+/**
+ * GET /admin/mcp/oauth-tokens — every authorization the OAuth front door has
+ * issued (#1306 Track B).
+ *
+ * The counterpart to `/admin/mcp/scopes`: that lists what a credential MAY do,
+ * this lists which credentials EXIST and who let them in. Without it, revoking
+ * an OAuth client would mean knowing a `mcpt_…` id you were never shown.
+ *
+ * ⚠️ HUMAN ADMINS ONLY, for the same reason as the scopes route — a machine
+ * credential must not be able to enumerate or revoke its siblings, and
+ * emphatically must not be able to see whether it is itself about to be
+ * revoked. Deliberately NOT exposed as an MCP tool.
+ */
+import { MedusaRequest, MedusaResponse } from "@medusajs/framework/http"
+import { mcpPrincipalFromRequest } from "../../../../lib/mcp-scope"
+import { MCP_OAUTH_MODULE } from "../../../../modules/mcp_oauth"
+import type McpOauthService from "../../../../modules/mcp_oauth/service"
+
+export const refuseNonHumanAdmin = (
+  req: MedusaRequest,
+  res: MedusaResponse
+): boolean => {
+  const principal = mcpPrincipalFromRequest(req)
+  if (principal && principal.type === "user") {
+    return false
+  }
+  res.status(403).json({
+    message:
+      "OAuth authorizations can only be managed by a signed-in admin user. A " +
+      "machine credential cannot list or revoke them.",
+  })
+  return true
+}
+
+export const GET = async (req: MedusaRequest, res: MedusaResponse) => {
+  if (refuseNonHumanAdmin(req, res)) return
+
+  const service = req.scope.resolve(MCP_OAUTH_MODULE) as McpOauthService
+  const rows = (await service.listMcpOauthTokens(
+    {},
+    { order: { created_at: "DESC" } }
+  )) as any[]
+
+  res.json({
+    tokens: rows.map((t) => ({
+      id: t.id,
+      client_id: t.client_id,
+      client_name: (t.metadata as any)?.client_name ?? null,
+      // The admin this authorization acts AS — an OAuth token is a user JWT,
+      // so every action it takes is attributed to this person.
+      user_id: t.user_id,
+      level: t.level,
+      revoked_at: t.revoked_at,
+      last_used_at: t.last_used_at,
+      access_expires_at: t.access_expires_at,
+      refresh_expires_at: t.refresh_expires_at,
+      created_at: t.created_at,
+    })),
+  })
+}

--- a/apps/backend/src/api/admin/mcp/scopes/route.ts
+++ b/apps/backend/src/api/admin/mcp/scopes/route.ts
@@ -65,9 +65,9 @@ export const GET = async (req: MedusaRequest, res: MedusaResponse) => {
     // The ceiling is the process-wide cap; a row can only ever restrict below
     // it, so a level above `ceiling` is stored but has no effect.
     ceiling: adminMcpCeiling(),
-    // Tools each level exposes. ⚠️ `write` currently equals `read` — every
-    // admin write tool is flagged sensitive — so a credential that needs to
-    // change anything needs `sensitive`.
+    // Tools each level exposes. The rungs are genuinely distinct since #1310
+    // split the tier axis out of the `sensitive` flag — `write` no longer
+    // equals `read`, so picking it is a real choice.
     levels: MCP_SCOPE_LEVELS.map((level) => ({
       level,
       tools: counts[level],
@@ -130,8 +130,8 @@ export const POST = async (req: MedusaRequest, res: MedusaResponse) => {
           warning: `Stored as '${level}', but the process ceiling is '${ceiling}', so this credential operates at '${effective}'. Raising it requires ADMIN_MCP_ENABLE_WRITE / ADMIN_MCP_ENABLE_DANGEROUS.`,
         }
       : {}),
-    // ⚠️ `write` exposes exactly what `read` does today — every admin write tool
-    // is flagged sensitive. Surfaced so picking `write` doesn't look useful.
+    // The whole ladder, so the operator can see what the neighbouring rungs
+    // would have bought at the moment of choosing this one.
     tools_by_level: counts,
   })
 }

--- a/apps/backend/src/api/mcp/admin/route.ts
+++ b/apps/backend/src/api/mcp/admin/route.ts
@@ -1,0 +1,156 @@
+/**
+ * POST /mcp/admin — the Admin MCP endpoint for OAuth clients (#1306 Track B).
+ *
+ * ## Why this exists next to `/admin/mcp` rather than replacing it
+ *
+ * An RFC 9728 client discovers where to authenticate from a
+ * `WWW-Authenticate: Bearer resource_metadata=…` header on a 401. Medusa's auth
+ * middleware is applied in the loader BEFORE user middlewares, so on any
+ * `/admin/*` path it answers `{"message":"Unauthorized"}` first and nothing we
+ * register can attach that header. The mount therefore has to live outside
+ * `/admin/*` and verify the bearer itself — which is all this file does before
+ * delegating to the same handler `/admin/mcp` uses.
+ *
+ * `/admin/mcp` is unchanged and remains the endpoint for secret-API-key
+ * clients, which need no discovery because they are configured by hand.
+ *
+ * Authorization is unaffected by the split: the token is a real admin user JWT,
+ * so the dispatcher's loopback calls re-enter `/admin/*` and hit the per-route
+ * scope guard exactly as they always have. This route adds one check the guard
+ * cannot make — revocation — and applies it to reads as well as writes.
+ */
+import type { MedusaRequest, MedusaResponse } from "@medusajs/framework/http"
+import { getAuthContextFromJwtToken } from "@medusajs/framework/http"
+import { ContainerRegistrationKeys } from "@medusajs/framework/utils"
+import {
+  bearerChallenge,
+  resolveOauthIssuer,
+} from "../../../lib/mcp-oauth"
+import {
+  handleAdminMcpRequest,
+  adminMcpMethodNotAllowed,
+} from "../../admin/mcp/lib/handler"
+import { MCP_OAUTH_MODULE } from "../../../modules/mcp_oauth"
+import type McpOauthService from "../../../modules/mcp_oauth/service"
+
+const unauthorized = (
+  req: MedusaRequest,
+  res: MedusaResponse,
+  code: string,
+  description: string
+) => {
+  const issuer = resolveOauthIssuer(req)
+  res.setHeader(
+    "www-authenticate",
+    bearerChallenge(issuer, { code, description })
+  )
+  res.status(401).json({ error: code, error_description: description })
+}
+
+/**
+ * Authenticate the request, or answer 401 with the discovery challenge.
+ *
+ * Returns true when the request may proceed. Deliberately uses the framework's
+ * own JWT verification rather than a second implementation, so a token accepted
+ * here is accepted identically on the `/admin/*` routes the dispatcher will
+ * then call.
+ */
+const authenticateOrChallenge = async (
+  req: MedusaRequest,
+  res: MedusaResponse
+): Promise<boolean> => {
+  if (!req.get("authorization")) {
+    return (
+      unauthorized(
+        req,
+        res,
+        "invalid_token",
+        "Authorization required. Authorize at this server's OAuth endpoints."
+      ),
+      false
+    )
+  }
+
+  const { projectConfig } = req.scope.resolve(
+    ContainerRegistrationKeys.CONFIG_MODULE
+  ) as any
+  const http = projectConfig?.http ?? {}
+
+  const authContext = getAuthContextFromJwtToken(
+    req.get("authorization"),
+    http.jwtSecret,
+    ["bearer"],
+    ["user"],
+    http.jwtPublicKey,
+    http.jwtVerifyOptions ?? http.jwtOptions
+  ) as any
+
+  if (!authContext?.actor_id) {
+    return (
+      unauthorized(
+        req,
+        res,
+        "invalid_token",
+        "The access token is missing, malformed, or expired."
+      ),
+      false
+    )
+  }
+
+  // Revocation. A JWT verifies on its signature alone, so this is the only
+  // thing standing between a revoked authorization and a full hour of further
+  // access — and it covers reads, because a revoked token must not read either.
+  const tokenId = authContext?.mcp_oauth?.token_id
+  if (typeof tokenId === "string" && tokenId) {
+    let row: any
+    try {
+      const oauth = req.scope.resolve(MCP_OAUTH_MODULE) as McpOauthService
+      row = await oauth.getToken(tokenId)
+    } catch {
+      // Fail CLOSED: a permission check that cannot read the permission must
+      // not grant it.
+      res.status(503).json({
+        error: "temporarily_unavailable",
+        error_description:
+          "Could not verify this token's status; refusing the request rather than assuming it is valid.",
+      })
+      return false
+    }
+    if (!row || row.revoked_at) {
+      return (
+        unauthorized(
+          req,
+          res,
+          "invalid_token",
+          "This authorization has been revoked."
+        ),
+        false
+      )
+    }
+    // Best-effort usage stamp; never block the request on it.
+    void (req.scope.resolve(MCP_OAUTH_MODULE) as McpOauthService)
+      .updateMcpOauthTokens([{ id: tokenId, last_used_at: new Date() }])
+      .catch(() => {})
+  }
+
+  ;(req as any).auth_context = authContext
+  return true
+}
+
+export const POST = async (req: MedusaRequest, res: MedusaResponse) => {
+  if (!(await authenticateOrChallenge(req, res))) return
+  await handleAdminMcpRequest(req, res)
+}
+
+/**
+ * 405 for GET/DELETE is spec-compliant for a stateless Streamable-HTTP server
+ * that offers no SSE stream — but only once the caller is authenticated. An
+ * unauthenticated GET still gets the 401 challenge, because some clients probe
+ * with GET first and that probe is a discovery opportunity.
+ */
+export const GET = async (req: MedusaRequest, res: MedusaResponse) => {
+  if (!(await authenticateOrChallenge(req, res))) return
+  adminMcpMethodNotAllowed(req, res)
+}
+
+export const DELETE = GET

--- a/apps/backend/src/api/middlewares.ts
+++ b/apps/backend/src/api/middlewares.ts
@@ -39,6 +39,11 @@ import {
   MCP_SCOPE_EXEMPT_ADMIN_PATHS,
 } from "../lib/mcp-scope";
 import { adminRouteTier } from "./admin/mcp/lib/route-tier";
+import { mcpOauthTokenIdFromRequest } from "../lib/mcp-oauth";
+import { MCP_OAUTH_MODULE } from "../modules/mcp_oauth";
+import type McpOauthService from "../modules/mcp_oauth/service";
+import { GET as oauthProtectedResourceDoc } from "./well-known/oauth-protected-resource/route";
+import { GET as oauthAuthorizationServerDoc } from "./well-known/oauth-authorization-server/route";
 
 // Helper function to wrap Zod schemas for compatibility with validateAndTransformBody.
 // Historically this wrapped with z.preprocess((obj) => obj, schema) — under Zod v3
@@ -738,8 +743,68 @@ const enforceMcpScopeOnAdminWrites = async (
   }
 }
 
+/**
+ * Refuse a revoked OAuth authorization on every `/admin/*` request (#1306
+ * Track B).
+ *
+ * An access token minted by the OAuth front door is a real Medusa user JWT, so
+ * it verifies on its signature alone and would otherwise keep working for the
+ * remainder of its hour no matter what the admin did in the settings UI. This
+ * is the only thing standing between "revoked" and "revoked in an hour".
+ *
+ * Ordered before `enforceMcpScopeOnAdminWrites` and — unlike that guard —
+ * applied to READS too. A revoked credential must not read either; scoping is
+ * about what a live credential may do, revocation is about whether it is live
+ * at all.
+ *
+ * Costs nothing for ordinary traffic: without the `mcp_oauth` claim it returns
+ * on the first line. Dashboard sessions and API keys never reach the lookup.
+ */
+const enforceMcpOauthRevocation = async (
+  req: MedusaRequest,
+  res: MedusaResponse,
+  next: MedusaNextFunction
+) => {
+  const tokenId = mcpOauthTokenIdFromRequest(req);
+  if (!tokenId) {
+    return next();
+  }
+  try {
+    const oauth = req.scope.resolve(MCP_OAUTH_MODULE) as McpOauthService;
+    const row = await oauth.getToken(tokenId);
+    if (!row || row.revoked_at) {
+      // A claim pointing at a row that no longer exists authorizes nothing —
+      // treat a missing row exactly like a revoked one.
+      return res.status(401).json({
+        message:
+          "This OAuth authorization has been revoked. Re-authorize the client to obtain a new token.",
+      });
+    }
+    return next();
+  } catch {
+    // Fail CLOSED, same reasoning as the scope guard below: a check that
+    // cannot read the permission must not grant it. Only affects requests that
+    // actually carry the claim.
+    return res.status(503).json({
+      message:
+        "Could not verify this token's revocation status; refusing the request rather than assuming it is valid. Retry shortly.",
+    });
+  }
+};
+
+/** Public, credential-free endpoints — safe to allow any origin. */
+const publicCors = cors({ origin: "*", credentials: false });
+
 export default defineMiddlewares({
   routes: [
+    // OAuth revocation check (#1306 Track B). Method-less on purpose, exactly
+    // like the scope guard below — a "global" entry is concatenated ahead of
+    // every /admin/* handler — and registered FIRST so a revoked credential is
+    // rejected before anything asks what it is allowed to do.
+    {
+      matcher: "/admin/*",
+      middlewares: [enforceMcpOauthRevocation],
+    },
     // Per-credential scope guard (#1306 Track C).
     //
     // No `method`/`methods` key on purpose: Medusa's routes sorter buckets a
@@ -751,6 +816,82 @@ export default defineMiddlewares({
     {
       matcher: "/admin/*",
       middlewares: [enforceMcpScopeOnAdminWrites],
+    },
+
+    // =====================================================
+    // OAuth 2.1 front door for the Admin MCP (#1306 Track B)
+    // =====================================================
+
+    // Discovery documents. Medusa's file-based router ignores directories
+    // starting with ".", so the handlers in src/api/well-known/* are registered
+    // here — the /.well-known/ucp precedent further down. The wildcard variants
+    // exist because MCP clients probe the path-suffixed form
+    // (/.well-known/oauth-protected-resource/mcp/admin); this server protects
+    // exactly one resource, so both forms answer identically.
+    {
+      matcher: "/.well-known/oauth-protected-resource",
+      method: "GET",
+      middlewares: [publicCors, oauthProtectedResourceDoc as any],
+    },
+    {
+      matcher: "/.well-known/oauth-protected-resource/*",
+      method: "GET",
+      middlewares: [publicCors, oauthProtectedResourceDoc as any],
+    },
+    {
+      matcher: "/.well-known/oauth-authorization-server",
+      method: "GET",
+      middlewares: [publicCors, oauthAuthorizationServerDoc as any],
+    },
+    {
+      matcher: "/.well-known/oauth-authorization-server/*",
+      method: "GET",
+      middlewares: [publicCors, oauthAuthorizationServerDoc as any],
+    },
+
+    // Open CORS on the machine-facing endpoints. None of them read cookies, and
+    // all three are reached from clients whose origin we cannot know ahead of
+    // time.
+    //
+    // No body parser here: Medusa's own stack already applies
+    // `express.urlencoded({ extended: true })` to every route
+    // (`framework/dist/http/middlewares/bodyparser.js`), so the form encoding
+    // RFC 6749 specifies for the token endpoint is parsed before any of this
+    // runs. Adding a second parser does not merely duplicate work — it HANGS
+    // the request, because the stream is already consumed and the `end` event
+    // it waits for has long since fired.
+    {
+      matcher: "/oauth/token",
+      method: "POST",
+      middlewares: [publicCors],
+    },
+    {
+      matcher: "/oauth/revoke",
+      method: "POST",
+      middlewares: [publicCors],
+    },
+    {
+      matcher: "/oauth/register",
+      method: "POST",
+      middlewares: [publicCors],
+    },
+
+    // The consent step. `/oauth/*` is otherwise unauthenticated — this is the
+    // one endpoint that must know which admin is approving, and it gets that
+    // from the bearer the consent page just obtained via
+    // POST /auth/user/emailpass.
+    {
+      matcher: "/oauth/authorize/consent",
+      method: "POST",
+      middlewares: [authenticate("user", ["bearer", "session"])],
+    },
+
+    // The OAuth-facing MCP mount authenticates itself (it has to, in order to
+    // emit the RFC 9728 challenge on 401), so no `authenticate` here — only
+    // CORS, for browser-based clients.
+    {
+      matcher: "/mcp/admin",
+      middlewares: [publicCors],
     },
     // ─── Store collection & category validation (replicate framework middleware) ───
     {

--- a/apps/backend/src/api/oauth/authorize/consent/route.ts
+++ b/apps/backend/src/api/oauth/authorize/consent/route.ts
@@ -1,0 +1,123 @@
+/**
+ * POST /oauth/authorize/consent — turn an admin's approval into an
+ * authorization code (#1306 Track B).
+ *
+ * Authenticated as an admin `user` (registered in `src/api/middlewares.ts`;
+ * `/oauth/*` is otherwise unauthenticated). The consent page obtains that
+ * bearer from Medusa's own `POST /auth/user/emailpass` moments earlier, so the
+ * approval is bound to a password the human just typed and carries no ambient
+ * authority.
+ *
+ * Everything the consent page sent is re-validated here. That page is HTML we
+ * emitted, but nothing stops a client from posting to this endpoint directly —
+ * the parameters are a request, not a trust boundary.
+ *
+ * ⚠️ An admin cannot grant more than the process ceiling. `min(ceiling,
+ * chosen)` is applied before the row is written, so `ADMIN_MCP_ENABLE_DANGEROUS
+ * = false` still means no OAuth client anywhere can reach a dangerous tool.
+ */
+import type { MedusaRequest, MedusaResponse } from "@medusajs/framework/http"
+import { minMcpScope } from "../../../../lib/mcp-core/tiers"
+import {
+  MCP_OAUTH_CODE_TTL_SEC,
+  asScopeLevel,
+  randomSecret,
+  redirectUriRegistered,
+  sha256,
+} from "../../../../lib/mcp-oauth"
+import { adminMcpCeiling } from "../../../admin/mcp/lib/handler"
+import { MCP_OAUTH_MODULE } from "../../../../modules/mcp_oauth"
+import type McpOauthService from "../../../../modules/mcp_oauth/service"
+
+const fail = (res: MedusaResponse, status: number, error: string, description: string) => {
+  res.status(status).json({ error, error_description: description })
+}
+
+export const POST = async (req: MedusaRequest, res: MedusaResponse) => {
+  const auth = (req as any).auth_context
+  const userId: string | undefined = auth?.actor_id
+  if (!userId || auth?.actor_type !== "user") {
+    return fail(
+      res,
+      401,
+      "access_denied",
+      "Sign in as an admin user before approving."
+    )
+  }
+  // A token minted by this very flow must not be able to mint another. Without
+  // this, a `read`-scoped OAuth client could bootstrap itself a `dangerous`
+  // one — the consent step is where a HUMAN is the point.
+  if (auth?.mcp_oauth) {
+    return fail(
+      res,
+      403,
+      "access_denied",
+      "An OAuth-issued token cannot authorize another client. Sign in with your password."
+    )
+  }
+
+  const body = (req.body ?? {}) as Record<string, any>
+  const clientId = String(body.client_id || "")
+  const redirectUri = String(body.redirect_uri || "")
+  const codeChallenge = String(body.code_challenge || "")
+  const codeChallengeMethod = String(
+    body.code_challenge_method || "S256"
+  ).toUpperCase()
+
+  if (!clientId || !redirectUri || !codeChallenge) {
+    return fail(
+      res,
+      400,
+      "invalid_request",
+      "client_id, redirect_uri and code_challenge are all required."
+    )
+  }
+  if (codeChallengeMethod !== "S256") {
+    return fail(
+      res,
+      400,
+      "invalid_request",
+      "code_challenge_method must be S256."
+    )
+  }
+
+  const service = req.scope.resolve(MCP_OAUTH_MODULE) as McpOauthService
+  const client = await service.getClient(clientId)
+  if (!client) {
+    return fail(res, 400, "invalid_client", "Unknown client_id.")
+  }
+  if (!redirectUriRegistered(client.redirect_uris, redirectUri)) {
+    return fail(
+      res,
+      400,
+      "invalid_request",
+      "redirect_uri does not match a registered value."
+    )
+  }
+
+  const level = minMcpScope(adminMcpCeiling(), asScopeLevel(body.level))
+
+  const code = randomSecret(32)
+  await service.createMcpOauthGrants({
+    code_hash: sha256(code),
+    client_id: clientId,
+    redirect_uri: redirectUri,
+    code_challenge: codeChallenge,
+    code_challenge_method: "S256",
+    user_id: userId,
+    auth_identity_id: auth?.auth_identity_id || null,
+    level,
+    state: typeof body.state === "string" && body.state ? body.state : null,
+    expires_at: new Date(Date.now() + MCP_OAUTH_CODE_TTL_SEC * 1000),
+  })
+
+  const url = new URL(redirectUri)
+  url.searchParams.set("code", code)
+  if (body.state) url.searchParams.set("state", String(body.state))
+
+  // Returned as JSON rather than a 302: the caller is a fetch() inside the
+  // consent page, and a redirect there would be followed by the browser
+  // instead of navigating the top-level document to the client.
+  res.setHeader("cache-control", "no-store")
+  return res.json({ redirect_to: url.toString(), level })
+}

--- a/apps/backend/src/api/oauth/authorize/route.ts
+++ b/apps/backend/src/api/oauth/authorize/route.ts
@@ -1,0 +1,274 @@
+/**
+ * GET /oauth/authorize — the consent screen (#1306 Track B).
+ *
+ * This is the only place a third party can acquire authority, and the whole
+ * design leans on it: dynamic registration hands out nothing, and every token
+ * is traceable to an admin who typed their password here and chose a rung on
+ * the scope ladder.
+ *
+ * The page is self-contained HTML with no build step and no framework. It does
+ * three fetches in order:
+ *
+ *   1. `POST /auth/user/emailpass`  — reuse Medusa's own password check rather
+ *      than reimplementing one. We never see a password server-side here.
+ *   2. `POST /oauth/authorize/consent` with that bearer — mints the code.
+ *   3. redirect to the client's `redirect_uri`.
+ *
+ * Because step 2 needs a bearer the admin just obtained, the flow carries no
+ * ambient authority and therefore no CSRF surface.
+ *
+ * ⚠️ Every parameter below is attacker-controlled, including `client_name`
+ * chosen at registration. Everything interpolated into the page goes through
+ * `esc`, and the request parameters are re-validated at the consent endpoint —
+ * this page's copy of them is a convenience, not a trust boundary.
+ */
+import type { MedusaRequest, MedusaResponse } from "@medusajs/framework/http"
+import { MCP_SCOPE_LEVELS, mcpScopeAllows } from "../../../lib/mcp-core/tiers"
+import type { McpScopeLevel } from "../../../lib/mcp-core/tiers"
+import { levelFromScopeString } from "../../../lib/mcp-oauth"
+import {
+  adminMcpCeiling,
+  adminToolCountsByLevel,
+} from "../../admin/mcp/lib/handler"
+import { MCP_OAUTH_MODULE } from "../../../modules/mcp_oauth"
+import type McpOauthService from "../../../modules/mcp_oauth/service"
+import { redirectUriRegistered } from "../../../lib/mcp-oauth"
+
+const esc = (value: unknown): string =>
+  String(value ?? "")
+    .replace(/&/g, "&amp;")
+    .replace(/</g, "&lt;")
+    .replace(/>/g, "&gt;")
+    .replace(/"/g, "&quot;")
+    .replace(/'/g, "&#39;")
+
+/** What each rung actually lets the client do, in the admin's language. */
+const LEVEL_BLURB: Record<McpScopeLevel, string> = {
+  read: "Read only. No mutation of any kind.",
+  write: "Read, plus ordinary edits — catalog, tasks, partner records.",
+  sensitive:
+    "Adds the confirm-gated actions, including deletes and anything that spends money at a carrier.",
+  dangerous:
+    "Adds platform-destructive actions. Grant this only to something you would trust with the dashboard.",
+}
+
+/**
+ * A hard stop with no redirect.
+ *
+ * When the client id or redirect URI is wrong we must NOT bounce the browser
+ * anywhere — an unvalidated redirect target is exactly what an attacker
+ * registering a lookalike client is fishing for. Errors that occur AFTER the
+ * redirect URI is proven registered do go back to the client, per RFC 6749.
+ */
+const errorPage = (
+  res: MedusaResponse,
+  status: number,
+  title: string,
+  detail: string
+) => {
+  res.status(status)
+  res.setHeader("content-type", "text/html; charset=utf-8")
+  res.send(
+    `<!doctype html><meta charset="utf-8"><meta name="viewport" content="width=device-width,initial-scale=1">` +
+      `<title>${esc(title)}</title>` +
+      `<style>body{font:16px/1.5 system-ui,sans-serif;max-width:34rem;margin:15vh auto;padding:0 1.5rem;color:#111}` +
+      `h1{font-size:1.25rem}code{background:#f4f4f5;padding:.1em .35em;border-radius:.25rem}</style>` +
+      `<h1>${esc(title)}</h1><p>${esc(detail)}</p>`
+  )
+}
+
+export const GET = async (req: MedusaRequest, res: MedusaResponse) => {
+  const q = req.query as Record<string, string | undefined>
+
+  const clientId = q.client_id || ""
+  const redirectUri = q.redirect_uri || ""
+
+  if (!clientId || !redirectUri) {
+    return errorPage(
+      res,
+      400,
+      "Missing parameters",
+      "Both client_id and redirect_uri are required."
+    )
+  }
+
+  const service = req.scope.resolve(MCP_OAUTH_MODULE) as McpOauthService
+  const client = await service.getClient(clientId)
+  if (!client) {
+    return errorPage(
+      res,
+      400,
+      "Unknown client",
+      "That client_id is not registered with this server. Reconnect from your MCP client so it can register again."
+    )
+  }
+  if (!redirectUriRegistered(client.redirect_uris, redirectUri)) {
+    return errorPage(
+      res,
+      400,
+      "Redirect URI mismatch",
+      "That redirect_uri was not registered by this client. It must match one of the registered values exactly."
+    )
+  }
+
+  // Past this point the redirect target is proven, so protocol errors are
+  // reported to the client rather than to the human.
+  const bounce = (error: string, description: string) => {
+    const url = new URL(redirectUri)
+    url.searchParams.set("error", error)
+    url.searchParams.set("error_description", description)
+    if (q.state) url.searchParams.set("state", q.state)
+    return res.redirect(302, url.toString())
+  }
+
+  if ((q.response_type || "") !== "code") {
+    return bounce(
+      "unsupported_response_type",
+      "Only the authorization code flow is supported."
+    )
+  }
+  if (!q.code_challenge) {
+    return bounce(
+      "invalid_request",
+      "PKCE is required: send code_challenge with code_challenge_method=S256."
+    )
+  }
+  if ((q.code_challenge_method || "").toUpperCase() !== "S256") {
+    return bounce(
+      "invalid_request",
+      "code_challenge_method must be S256; 'plain' is not accepted."
+    )
+  }
+
+  const ceiling = adminMcpCeiling()
+  const requested = levelFromScopeString(q.scope)
+  const offerable = MCP_SCOPE_LEVELS.filter((l) => mcpScopeAllows(ceiling, l))
+  // Default the selection to the narrowest of {what was asked for, the
+  // ceiling}, and fall back to `read` when the client asked for nothing. The
+  // default a tired admin accepts should be the least powerful one that works.
+  const preselected: McpScopeLevel =
+    requested && mcpScopeAllows(ceiling, requested) ? requested : "read"
+  const counts = adminToolCountsByLevel()
+
+  const options = offerable
+    .map(
+      (level) =>
+        `<label class="opt${level === preselected ? " sel" : ""}">` +
+        `<input type="radio" name="level" value="${esc(level)}"${
+          level === preselected ? " checked" : ""
+        }>` +
+        `<span><strong>${esc(level)}</strong> — ${esc(counts[level])} tools` +
+        `<br><small>${esc(LEVEL_BLURB[level])}</small></span></label>`
+    )
+    .join("")
+
+  const params = {
+    client_id: clientId,
+    redirect_uri: redirectUri,
+    code_challenge: q.code_challenge,
+    code_challenge_method: "S256",
+    state: q.state ?? "",
+    resource: q.resource ?? "",
+  }
+
+  res.setHeader("content-type", "text/html; charset=utf-8")
+  // No framing, no referrer: the page carries a password field and, briefly, a
+  // bearer token in memory.
+  res.setHeader("x-frame-options", "DENY")
+  res.setHeader("referrer-policy", "no-referrer")
+  res.setHeader("cache-control", "no-store")
+  return res.send(`<!doctype html>
+<meta charset="utf-8">
+<meta name="viewport" content="width=device-width,initial-scale=1">
+<title>Connect ${esc(client.client_name)} — JYT Admin MCP</title>
+<style>
+  :root{color-scheme:light dark}
+  body{font:16px/1.5 system-ui,-apple-system,sans-serif;max-width:32rem;margin:8vh auto;padding:0 1.5rem;color:#111;background:#fff}
+  @media(prefers-color-scheme:dark){body{color:#eee;background:#111}}
+  h1{font-size:1.35rem;margin-bottom:.25rem}
+  .sub{color:#666;margin-top:0}
+  .app{border:1px solid #d4d4d8;border-radius:.6rem;padding:.9rem 1rem;margin:1.25rem 0}
+  .app b{display:block}
+  label.opt{display:flex;gap:.6rem;align-items:flex-start;border:1px solid #d4d4d8;border-radius:.5rem;padding:.6rem .75rem;margin:.4rem 0;cursor:pointer}
+  label.opt.sel{border-color:#111}
+  label.opt small{color:#666}
+  input[type=email],input[type=password]{width:100%;box-sizing:border-box;padding:.55rem .6rem;border:1px solid #d4d4d8;border-radius:.4rem;font-size:1rem;background:transparent;color:inherit}
+  .field{margin:.6rem 0}
+  button{width:100%;padding:.7rem;border:0;border-radius:.45rem;background:#111;color:#fff;font-size:1rem;cursor:pointer;margin-top:1rem}
+  @media(prefers-color-scheme:dark){button{background:#eee;color:#111}}
+  button[disabled]{opacity:.55;cursor:default}
+  .err{color:#b91c1c;margin-top:.75rem;min-height:1.25rem}
+  .cancel{display:block;text-align:center;margin-top:.75rem;color:#666;font-size:.9rem}
+  .warn{font-size:.85rem;color:#666;margin-top:1rem}
+</style>
+<h1>Authorize an MCP client</h1>
+<p class="sub">It will act on the JYT platform as you.</p>
+
+<div class="app">
+  <b>${esc(client.client_name)}</b>
+  <small>redirects to <code>${esc(redirectUri)}</code></small>
+</div>
+
+<form id="f">
+  <div class="field"><input type="email" id="email" placeholder="Admin email" autocomplete="username" required></div>
+  <div class="field"><input type="password" id="password" placeholder="Password" autocomplete="current-password" required></div>
+
+  <p style="margin:1.25rem 0 .25rem"><strong>Access level</strong></p>
+  ${options}
+
+  <button type="submit" id="go">Approve</button>
+  <div class="err" id="err"></div>
+  <a class="cancel" href="#" id="deny">Cancel</a>
+  <p class="warn">You can revoke this at any time from Settings &rsaquo; MCP access. The level you pick is enforced per request, on the tool surface and on the underlying admin routes alike.</p>
+</form>
+
+<script>
+  var P = ${JSON.stringify(params)};
+  var f = document.getElementById('f'), err = document.getElementById('err'), go = document.getElementById('go');
+  document.addEventListener('change', function (e) {
+    if (e.target.name !== 'level') return;
+    Array.prototype.forEach.call(document.querySelectorAll('label.opt'), function (l) {
+      l.classList.toggle('sel', l.contains(e.target));
+    });
+  });
+  document.getElementById('deny').addEventListener('click', function (e) {
+    e.preventDefault();
+    var u = new URL(P.redirect_uri);
+    u.searchParams.set('error', 'access_denied');
+    if (P.state) u.searchParams.set('state', P.state);
+    location.href = u.toString();
+  });
+  f.addEventListener('submit', async function (e) {
+    e.preventDefault();
+    err.textContent = ''; go.disabled = true; go.textContent = 'Authorizing…';
+    try {
+      var login = await fetch('/auth/user/emailpass', {
+        method: 'POST', headers: { 'content-type': 'application/json' },
+        body: JSON.stringify({
+          email: document.getElementById('email').value,
+          password: document.getElementById('password').value
+        })
+      });
+      var loginBody = await login.json().catch(function () { return {}; });
+      if (!login.ok || !loginBody.token) throw new Error(loginBody.message || 'Sign-in failed.');
+
+      var level = (document.querySelector('input[name=level]:checked') || {}).value || 'read';
+      var consent = await fetch('/oauth/authorize/consent', {
+        method: 'POST',
+        headers: { 'content-type': 'application/json', authorization: 'Bearer ' + loginBody.token },
+        body: JSON.stringify({
+          client_id: P.client_id, redirect_uri: P.redirect_uri,
+          code_challenge: P.code_challenge, code_challenge_method: P.code_challenge_method,
+          state: P.state, resource: P.resource, level: level
+        })
+      });
+      var out = await consent.json().catch(function () { return {}; });
+      if (!consent.ok || !out.redirect_to) throw new Error(out.error_description || out.message || 'Could not authorize.');
+      location.href = out.redirect_to;
+    } catch (e2) {
+      err.textContent = e2.message || String(e2);
+      go.disabled = false; go.textContent = 'Approve';
+    }
+  });
+</script>`)
+}

--- a/apps/backend/src/api/oauth/register/route.ts
+++ b/apps/backend/src/api/oauth/register/route.ts
@@ -1,0 +1,150 @@
+/**
+ * POST /oauth/register — dynamic client registration (RFC 7591), #1306 Track B.
+ *
+ * Unauthenticated by design. Claude web, ChatGPT and Cursor have no way to
+ * pre-arrange a client id with us, so the spec has them register themselves
+ * when a user first pastes the server URL.
+ *
+ * That is safe because **a client row grants nothing**. It is a display name
+ * and a set of redirect URIs. Every capability comes from a token, and no token
+ * exists until an admin has logged in on the consent screen and picked a rung
+ * on the scope ladder. The registration endpoint cannot mint, widen, or imply
+ * a grant.
+ *
+ * What it CAN do is create rows, so the input is bounded: a capped number of
+ * redirect URIs, each one https / loopback / private-use-scheme, and no
+ * `client_credentials` grant — this front door exists to act as a human admin,
+ * so there is deliberately no grant type that skips the human.
+ */
+import type { MedusaRequest, MedusaResponse } from "@medusajs/framework/http"
+import {
+  isAcceptableRedirectUri,
+  randomSecret,
+  sha256,
+} from "../../../lib/mcp-oauth"
+import { MCP_OAUTH_MODULE } from "../../../modules/mcp_oauth"
+import type McpOauthService from "../../../modules/mcp_oauth/service"
+
+/** More than this and the client is not describing a real application. */
+const MAX_REDIRECT_URIS = 10
+
+const MAX_CLIENT_NAME_LEN = 120
+
+const SUPPORTED_GRANT_TYPES = new Set(["authorization_code", "refresh_token"])
+
+const badRequest = (
+  res: MedusaResponse,
+  error: string,
+  description: string
+) => {
+  res.status(400).json({ error, error_description: description })
+}
+
+export const POST = async (req: MedusaRequest, res: MedusaResponse) => {
+  const body = (req.body ?? {}) as Record<string, any>
+
+  const redirectUris: unknown = body.redirect_uris
+  if (!Array.isArray(redirectUris) || redirectUris.length === 0) {
+    return badRequest(
+      res,
+      "invalid_redirect_uri",
+      "redirect_uris is required and must be a non-empty array."
+    )
+  }
+  if (redirectUris.length > MAX_REDIRECT_URIS) {
+    return badRequest(
+      res,
+      "invalid_redirect_uri",
+      `At most ${MAX_REDIRECT_URIS} redirect_uris may be registered.`
+    )
+  }
+  for (const uri of redirectUris) {
+    if (typeof uri !== "string" || !isAcceptableRedirectUri(uri)) {
+      return badRequest(
+        res,
+        "invalid_redirect_uri",
+        `Unacceptable redirect_uri: ${String(uri).slice(0, 200)}. Use https, ` +
+          `http on loopback, or a private-use scheme, with no fragment.`
+      )
+    }
+  }
+
+  const grantTypes: string[] = Array.isArray(body.grant_types)
+    ? body.grant_types.map(String)
+    : ["authorization_code", "refresh_token"]
+  const unsupported = grantTypes.filter((g) => !SUPPORTED_GRANT_TYPES.has(g))
+  if (unsupported.length) {
+    return badRequest(
+      res,
+      "invalid_client_metadata",
+      `Unsupported grant_types: ${unsupported.join(", ")}. This server issues ` +
+        `tokens only through an admin's explicit consent, so authorization_code ` +
+        `(+ refresh_token) are the only grants.`
+    )
+  }
+
+  const responseTypes: string[] = Array.isArray(body.response_types)
+    ? body.response_types.map(String)
+    : ["code"]
+  if (responseTypes.some((t) => t !== "code")) {
+    return badRequest(
+      res,
+      "invalid_client_metadata",
+      "Only the 'code' response_type is supported."
+    )
+  }
+
+  const authMethod = String(body.token_endpoint_auth_method || "none")
+  if (
+    !["none", "client_secret_post", "client_secret_basic"].includes(authMethod)
+  ) {
+    return badRequest(
+      res,
+      "invalid_client_metadata",
+      `Unsupported token_endpoint_auth_method: ${authMethod}.`
+    )
+  }
+
+  const clientName = String(
+    body.client_name || body.client_id || "Unnamed MCP client"
+  ).slice(0, MAX_CLIENT_NAME_LEN)
+
+  const service = req.scope.resolve(MCP_OAUTH_MODULE) as McpOauthService
+
+  const clientId = `mcpc_${randomSecret(18)}`
+  // Public clients (the ones this endpoint exists for) get no secret: PKCE is
+  // what binds the authorization code to the client. A confidential client
+  // sees its secret exactly once, in this response.
+  const clientSecret = authMethod === "none" ? null : randomSecret(32)
+
+  // Cast: DML types `model.json()` as Record<string, unknown>, so a string[]
+  // of redirect URIs does not fit the generated input type even though it is
+  // exactly what the column holds.
+  const created = await service.createMcpOauthClients({
+    client_id: clientId,
+    client_secret_hash: clientSecret ? sha256(clientSecret) : null,
+    client_name: clientName,
+    redirect_uris: redirectUris,
+    grant_types: grantTypes,
+    token_endpoint_auth_method: authMethod,
+    scope: typeof body.scope === "string" ? body.scope : null,
+  } as any)
+
+  const row = Array.isArray(created) ? created[0] : created
+
+  return res.status(201).json({
+    client_id: clientId,
+    ...(clientSecret ? { client_secret: clientSecret } : {}),
+    client_id_issued_at: Math.floor(
+      new Date(row?.created_at ?? Date.now()).getTime() / 1000
+    ),
+    // 0 = never expires (RFC 7591 §3.2.1). Revocation is per-token, not per
+    // client, so there is nothing for a client secret expiry to protect.
+    ...(clientSecret ? { client_secret_expires_at: 0 } : {}),
+    client_name: clientName,
+    redirect_uris: redirectUris,
+    grant_types: grantTypes,
+    response_types: ["code"],
+    token_endpoint_auth_method: authMethod,
+  })
+}

--- a/apps/backend/src/api/oauth/revoke/route.ts
+++ b/apps/backend/src/api/oauth/revoke/route.ts
@@ -1,0 +1,69 @@
+/**
+ * POST /oauth/revoke — RFC 7009 token revocation (#1306 Track B).
+ *
+ * Accepts either a refresh token or an access token as `token`, and always
+ * answers 200. RFC 7009 §2.2 is explicit about that: an unknown token is
+ * already in the desired state, and distinguishing "revoked" from "never
+ * existed" would turn this endpoint into a token oracle.
+ *
+ * Revoking kills the whole authorization, not just the presented token —
+ * `mcp_oauth_token` is one row per grant, and a client asking us to forget one
+ * half of a pair it holds both of is not a case worth modelling.
+ */
+import type { MedusaRequest, MedusaResponse } from "@medusajs/framework/http"
+import jwt from "jsonwebtoken"
+import {
+  resolveJwtSecret,
+  secretsMatch,
+  sha256,
+} from "../../../lib/mcp-oauth"
+import { MCP_OAUTH_MODULE } from "../../../modules/mcp_oauth"
+import type McpOauthService from "../../../modules/mcp_oauth/service"
+
+/** The `token_id` inside an access token, verified. */
+const tokenIdFromAccessToken = (
+  value: string,
+  secret: string | null
+): string | null => {
+  if (!secret) return null
+  try {
+    const payload = jwt.verify(value, secret) as any
+    const id = payload?.mcp_oauth?.token_id
+    return typeof id === "string" && id ? id : null
+  } catch {
+    return null
+  }
+}
+
+export const POST = async (req: MedusaRequest, res: MedusaResponse) => {
+  const body = (req.body ?? {}) as Record<string, any>
+  const presented = String(body.token || "")
+  res.setHeader("cache-control", "no-store")
+  if (!presented) {
+    return res.status(200).json({})
+  }
+
+  const oauth = req.scope.resolve(MCP_OAUTH_MODULE) as McpOauthService
+
+  // A refresh token first — it is the opaque one, so a hash lookup either
+  // matches or does not, with nothing to verify.
+  const byRefresh = await oauth.getTokenByRefreshHash(sha256(presented))
+  let tokenId: string | null = byRefresh?.id ?? null
+
+  if (!tokenId) {
+    tokenId = tokenIdFromAccessToken(presented, resolveJwtSecret(req))
+  }
+
+  if (tokenId) {
+    const row = await oauth.getToken(tokenId)
+    // A client may only revoke its own authorization. Without this check any
+    // registered client could revoke another's by guessing an id — and ids are
+    // not secrets, they appear in scope rows and audit output.
+    const clientId = String(body.client_id || "")
+    if (row && (!clientId || secretsMatch(clientId, row.client_id))) {
+      await oauth.revokeToken(tokenId)
+    }
+  }
+
+  return res.status(200).json({})
+}

--- a/apps/backend/src/api/oauth/token/route.ts
+++ b/apps/backend/src/api/oauth/token/route.ts
@@ -1,0 +1,271 @@
+/**
+ * POST /oauth/token — PKCE code exchange and refresh (#1306 Track B).
+ *
+ * Accepts both `application/x-www-form-urlencoded` (what RFC 6749 specifies and
+ * most clients send) and JSON. No parser of our own is needed: Medusa's body
+ * parser stack already applies `express.urlencoded` to every route. ⚠️ Adding a
+ * second one does not just duplicate work, it hangs the request — the stream is
+ * already consumed, so the `end` event a hand-rolled parser waits on never
+ * fires.
+ *
+ * What comes back is a Medusa **user** JWT carrying an `mcp_oauth.token_id`
+ * claim — see `src/lib/mcp-oauth.ts` for why it cannot be anything else. Two
+ * rows are written alongside it:
+ *
+ *   - `mcp_oauth_token`   — the authorization, so it can be revoked; and
+ *   - `mcp_access_scope`  — the Track C row keyed on `("oauth", token_id)`,
+ *     which is what is actually ENFORCED, on the MCP tool surface and on plain
+ *     `/admin/*` writes alike.
+ *
+ * 🔑 Refreshing keeps the same `token_id`. The scope row is attached to it, so
+ * rotating the refresh token must not mint a new identity — otherwise the
+ * credential would quietly climb back to the process ceiling on first refresh.
+ */
+import type { MedusaRequest, MedusaResponse } from "@medusajs/framework/http"
+import {
+  MCP_OAUTH_ACCESS_TTL_SEC,
+  MCP_OAUTH_REFRESH_TTL_SEC,
+  asScopeLevel,
+  levelToScopeString,
+  mintAccessToken,
+  randomSecret,
+  resolveJwtSecret,
+  secretsMatch,
+  sha256,
+  verifyPkce,
+} from "../../../lib/mcp-oauth"
+import { MCP_ACCESS_MODULE } from "../../../modules/mcp_access"
+import type McpAccessService from "../../../modules/mcp_access/service"
+import { MCP_OAUTH_MODULE } from "../../../modules/mcp_oauth"
+import type McpOauthService from "../../../modules/mcp_oauth/service"
+
+const fail = (
+  res: MedusaResponse,
+  status: number,
+  error: string,
+  description: string
+) => {
+  res.setHeader("cache-control", "no-store")
+  res.status(status).json({ error, error_description: description })
+}
+
+/** `client_secret_basic` credentials, if the client used that method. */
+const basicCredentials = (
+  header: string | undefined
+): { id: string; secret: string } | null => {
+  if (!header?.toLowerCase().startsWith("basic ")) return null
+  try {
+    const decoded = Buffer.from(header.slice(6).trim(), "base64").toString(
+      "utf-8"
+    )
+    const idx = decoded.indexOf(":")
+    if (idx < 0) return null
+    return {
+      id: decodeURIComponent(decoded.slice(0, idx)),
+      secret: decodeURIComponent(decoded.slice(idx + 1)),
+    }
+  } catch {
+    return null
+  }
+}
+
+/**
+ * Confirm the caller is the registered client.
+ *
+ * A public client proves nothing here — PKCE is what binds the code to it, and
+ * demanding a secret it does not have would just lock out the clients this
+ * whole track exists for.
+ */
+const clientAuthenticated = (
+  client: any,
+  providedSecret: string | undefined
+): boolean => {
+  if (!client.client_secret_hash) return true
+  if (!providedSecret) return false
+  return secretsMatch(sha256(providedSecret), client.client_secret_hash)
+}
+
+export const POST = async (req: MedusaRequest, res: MedusaResponse) => {
+  const body = (req.body ?? {}) as Record<string, any>
+  const basic = basicCredentials(req.get("authorization"))
+
+  const grantType = String(body.grant_type || "")
+  const clientId = String(body.client_id || basic?.id || "")
+  const clientSecret = (body.client_secret as string) || basic?.secret
+
+  if (!clientId) {
+    return fail(res, 400, "invalid_client", "client_id is required.")
+  }
+
+  const oauth = req.scope.resolve(MCP_OAUTH_MODULE) as McpOauthService
+  const client = await oauth.getClient(clientId)
+  if (!client) {
+    return fail(res, 401, "invalid_client", "Unknown client_id.")
+  }
+  if (!clientAuthenticated(client, clientSecret)) {
+    return fail(res, 401, "invalid_client", "Client authentication failed.")
+  }
+
+  const secret = resolveJwtSecret(req)
+  if (!secret) {
+    return fail(
+      res,
+      500,
+      "server_error",
+      "JWT secret not configured (projectConfig.http.jwtSecret)."
+    )
+  }
+
+  /** Mint an access token for an existing authorization row. */
+  const issue = async (token: any, refreshToken: string) => {
+    const level = asScopeLevel(token.level)
+    const accessToken = mintAccessToken({
+      secret,
+      userId: token.user_id,
+      authIdentityId: token.auth_identity_id,
+      tokenId: token.id,
+    })
+    res.setHeader("cache-control", "no-store")
+    return res.json({
+      access_token: accessToken,
+      token_type: "Bearer",
+      expires_in: MCP_OAUTH_ACCESS_TTL_SEC,
+      refresh_token: refreshToken,
+      scope: levelToScopeString(level),
+    })
+  }
+
+  if (grantType === "authorization_code") {
+    const code = String(body.code || "")
+    const codeVerifier = String(body.code_verifier || "")
+    const redirectUri = String(body.redirect_uri || "")
+    if (!code || !codeVerifier) {
+      return fail(
+        res,
+        400,
+        "invalid_request",
+        "code and code_verifier are required."
+      )
+    }
+
+    const grant = await oauth.getGrantByCodeHash(sha256(code))
+    if (!grant || grant.client_id !== clientId) {
+      return fail(res, 400, "invalid_grant", "Unknown or foreign code.")
+    }
+
+    if (grant.consumed_at) {
+      // A second redemption means the code leaked. Kill what it produced —
+      // whoever holds it now, we cannot tell which redemption was the honest
+      // one, so neither party keeps access.
+      const issuedTokenId = (grant.metadata as any)?.token_id
+      if (typeof issuedTokenId === "string" && issuedTokenId) {
+        await oauth.revokeToken(issuedTokenId)
+      }
+      return fail(
+        res,
+        400,
+        "invalid_grant",
+        "This authorization code was already used. Any token it issued has been revoked; start a new authorization."
+      )
+    }
+    if (new Date(grant.expires_at).getTime() <= Date.now()) {
+      return fail(res, 400, "invalid_grant", "Authorization code expired.")
+    }
+    if (redirectUri && redirectUri !== grant.redirect_uri) {
+      return fail(
+        res,
+        400,
+        "invalid_grant",
+        "redirect_uri does not match the one used at authorization."
+      )
+    }
+    if (
+      !verifyPkce(grant.code_challenge, grant.code_challenge_method, codeVerifier)
+    ) {
+      return fail(res, 400, "invalid_grant", "PKCE verification failed.")
+    }
+
+    const level = asScopeLevel(grant.level)
+    const refreshToken = randomSecret(32)
+    const now = Date.now()
+
+    const created = await oauth.createMcpOauthTokens({
+      client_id: clientId,
+      user_id: grant.user_id,
+      auth_identity_id: grant.auth_identity_id || null,
+      level,
+      refresh_token_hash: sha256(refreshToken),
+      access_expires_at: new Date(now + MCP_OAUTH_ACCESS_TTL_SEC * 1000),
+      refresh_expires_at: new Date(now + MCP_OAUTH_REFRESH_TTL_SEC * 1000),
+      metadata: { grant_id: grant.id, client_name: client.client_name },
+    })
+    const token = Array.isArray(created) ? created[0] : created
+
+    // The scope row is the enforcement point — write it BEFORE handing the
+    // access token out. Absent a row a principal gets the process ceiling, so
+    // the wrong order would leave a `read` client briefly unrestricted.
+    const access = req.scope.resolve(MCP_ACCESS_MODULE) as McpAccessService
+    await access.setScope({
+      principal_type: "oauth",
+      principal_id: token.id,
+      level,
+      label: client.client_name,
+      note: `OAuth client ${clientId}, authorized by user ${grant.user_id}`,
+    })
+
+    await oauth.updateMcpOauthGrants([
+      {
+        id: grant.id,
+        consumed_at: new Date(),
+        metadata: { ...(grant.metadata || {}), token_id: token.id },
+      },
+    ])
+
+    return issue(token, refreshToken)
+  }
+
+  if (grantType === "refresh_token") {
+    const refreshToken = String(body.refresh_token || "")
+    if (!refreshToken) {
+      return fail(res, 400, "invalid_request", "refresh_token is required.")
+    }
+    const token = await oauth.getTokenByRefreshHash(sha256(refreshToken))
+    if (!token || token.client_id !== clientId) {
+      return fail(res, 400, "invalid_grant", "Unknown refresh token.")
+    }
+    if (token.revoked_at) {
+      return fail(res, 400, "invalid_grant", "This authorization was revoked.")
+    }
+    if (
+      token.refresh_expires_at &&
+      new Date(token.refresh_expires_at).getTime() <= Date.now()
+    ) {
+      return fail(res, 400, "invalid_grant", "Refresh token expired.")
+    }
+
+    // Rotate the refresh token, keep the authorization id. The scope row hangs
+    // off that id, so reusing it is what keeps the credential's level pinned
+    // across the whole lifetime of the grant.
+    const next = randomSecret(32)
+    const now = Date.now()
+    await oauth.updateMcpOauthTokens([
+      {
+        id: token.id,
+        refresh_token_hash: sha256(next),
+        access_expires_at: new Date(now + MCP_OAUTH_ACCESS_TTL_SEC * 1000),
+        refresh_expires_at: new Date(now + MCP_OAUTH_REFRESH_TTL_SEC * 1000),
+        last_used_at: new Date(),
+      },
+    ])
+
+    return issue(token, next)
+  }
+
+  return fail(
+    res,
+    400,
+    "unsupported_grant_type",
+    `Unsupported grant_type: ${grantType || "(none)"}. This server supports ` +
+      `authorization_code and refresh_token.`
+  )
+}

--- a/apps/backend/src/api/well-known/oauth-authorization-server/route.ts
+++ b/apps/backend/src/api/well-known/oauth-authorization-server/route.ts
@@ -1,0 +1,22 @@
+/**
+ * GET /.well-known/oauth-authorization-server — RFC 8414 (#1306 Track B).
+ *
+ * Tells a client where to register, where to send the user for consent, and
+ * where to exchange the code. Advertises S256 as the only PKCE method: `plain`
+ * offers no protection against a code intercepted on the redirect leg, which is
+ * the single thing PKCE exists to stop.
+ *
+ * NOTE: registered as a middleware entry in `src/api/middlewares.ts` — Medusa's
+ * file router ignores dot-directories. See the sibling
+ * `oauth-protected-resource` route.
+ */
+import type { MedusaRequest, MedusaResponse } from "@medusajs/framework/http"
+import {
+  authorizationServerMetadata,
+  resolveOauthIssuer,
+} from "../../../lib/mcp-oauth"
+
+export async function GET(req: MedusaRequest, res: MedusaResponse) {
+  res.setHeader("cache-control", "public, max-age=300")
+  res.json(authorizationServerMetadata(resolveOauthIssuer(req)))
+}

--- a/apps/backend/src/api/well-known/oauth-protected-resource/route.ts
+++ b/apps/backend/src/api/well-known/oauth-protected-resource/route.ts
@@ -1,0 +1,27 @@
+/**
+ * GET /.well-known/oauth-protected-resource — RFC 9728 (#1306 Track B).
+ *
+ * The first document an MCP client fetches after a 401 from `/mcp/admin`. It
+ * names the resource and points at the authorization server, which is this
+ * same origin.
+ *
+ * NOTE: Medusa's file-based router ignores directories starting with ".", so
+ * the actual route is registered from this handler as a middleware entry in
+ * `src/api/middlewares.ts` — the `/.well-known/ucp` precedent. Exported rather
+ * than inlined there so the two cannot drift.
+ *
+ * Clients also probe the path-suffixed form
+ * (`/.well-known/oauth-protected-resource/mcp/admin`); both matchers point
+ * here, and the body is identical because this server protects exactly one
+ * resource.
+ */
+import type { MedusaRequest, MedusaResponse } from "@medusajs/framework/http"
+import {
+  protectedResourceMetadata,
+  resolveOauthIssuer,
+} from "../../../lib/mcp-oauth"
+
+export async function GET(req: MedusaRequest, res: MedusaResponse) {
+  res.setHeader("cache-control", "public, max-age=300")
+  res.json(protectedResourceMetadata(resolveOauthIssuer(req)))
+}

--- a/apps/backend/src/lib/__tests__/mcp-oauth.unit.spec.ts
+++ b/apps/backend/src/lib/__tests__/mcp-oauth.unit.spec.ts
@@ -1,0 +1,213 @@
+/**
+ * The OAuth front door's pure half (#1306 Track B).
+ *
+ * These assert the properties that make the flow safe rather than the ones that
+ * make it work — a working flow is what the integration path proves. Here:
+ * PKCE actually binds the code, redirect matching is exact, an OAuth token is
+ * distinguishable from the admin JWT it is shaped like, and the discovery
+ * documents point somewhere a client can reach.
+ */
+import crypto from "crypto"
+import jwt from "jsonwebtoken"
+import {
+  MCP_OAUTH_RESOURCE_PATH,
+  authorizationServerMetadata,
+  bearerChallenge,
+  isAcceptableRedirectUri,
+  levelFromScopeString,
+  mcpOauthTokenIdFromRequest,
+  mintAccessToken,
+  protectedResourceMetadata,
+  redirectUriRegistered,
+  verifyPkce,
+} from "../mcp-oauth"
+import { mcpPrincipalFromRequest } from "../mcp-scope"
+
+const challengeFor = (verifier: string) =>
+  crypto.createHash("sha256").update(verifier).digest("base64url")
+
+// 43 chars is the RFC 7636 minimum; anything shorter is not a verifier.
+const VERIFIER = "a".repeat(43)
+
+describe("PKCE", () => {
+  it("accepts the verifier that produced the challenge", () => {
+    expect(verifyPkce(challengeFor(VERIFIER), "S256", VERIFIER)).toBe(true)
+  })
+
+  it("rejects any other verifier", () => {
+    expect(verifyPkce(challengeFor(VERIFIER), "S256", "b".repeat(43))).toBe(
+      false
+    )
+  })
+
+  it("rejects a verifier outside the RFC length bounds", () => {
+    // Short verifiers are brute-forceable, which defeats the entire point of
+    // binding the code to the client.
+    expect(verifyPkce(challengeFor("short"), "S256", "short")).toBe(false)
+    expect(verifyPkce(challengeFor("x".repeat(129)), "S256", "x".repeat(129))).toBe(
+      false
+    )
+  })
+
+  it("does not treat the challenge itself as a valid verifier", () => {
+    const challenge = challengeFor(VERIFIER)
+    expect(verifyPkce(challenge, "S256", challenge)).toBe(false)
+  })
+})
+
+describe("redirect URI handling", () => {
+  const registered = ["https://claude.ai/api/mcp/auth_callback"]
+
+  it("matches only verbatim", () => {
+    expect(redirectUriRegistered(registered, registered[0])).toBe(true)
+  })
+
+  it("rejects a prefix, a suffix, and an added query", () => {
+    // Loose matching here is the classic open-redirect hole: it turns an
+    // authorization server into a token-exfiltration service.
+    expect(redirectUriRegistered(registered, "https://claude.ai")).toBe(false)
+    expect(
+      redirectUriRegistered(registered, registered[0] + ".evil.com")
+    ).toBe(false)
+    expect(redirectUriRegistered(registered, registered[0] + "?x=1")).toBe(
+      false
+    )
+  })
+
+  it("rejects an empty candidate against an empty registration", () => {
+    expect(redirectUriRegistered([], "")).toBe(false)
+    expect(redirectUriRegistered(undefined, "https://claude.ai")).toBe(false)
+  })
+
+  it("accepts https, loopback http, and private-use schemes at registration", () => {
+    expect(isAcceptableRedirectUri("https://claude.ai/cb")).toBe(true)
+    expect(isAcceptableRedirectUri("http://127.0.0.1:51763/cb")).toBe(true)
+    expect(isAcceptableRedirectUri("http://localhost:8080/cb")).toBe(true)
+    expect(isAcceptableRedirectUri("com.example.app:/oauth")).toBe(true)
+  })
+
+  it("rejects plaintext http off-loopback, fragments, and nonsense", () => {
+    expect(isAcceptableRedirectUri("http://evil.com/cb")).toBe(false)
+    expect(isAcceptableRedirectUri("https://claude.ai/cb#frag")).toBe(false)
+    expect(isAcceptableRedirectUri("not a url")).toBe(false)
+  })
+})
+
+describe("scope strings", () => {
+  it("takes the widest recognized rung", () => {
+    expect(levelFromScopeString("mcp:read mcp:write")).toBe("write")
+    expect(levelFromScopeString("mcp:dangerous")).toBe("dangerous")
+  })
+
+  it("ignores unknown entries rather than failing the request", () => {
+    // Clients routinely send openid/offline_access; refusing the whole request
+    // over one would break a connection we can serve. The admin picks the
+    // actual rung at consent, so a generous parse grants nothing.
+    expect(levelFromScopeString("openid offline_access mcp:read")).toBe("read")
+    expect(levelFromScopeString("openid")).toBeNull()
+    expect(levelFromScopeString(undefined)).toBeNull()
+  })
+})
+
+describe("the access token", () => {
+  const SECRET = "test-secret"
+
+  it("is a Medusa user JWT — the framework rejects any other actor type", () => {
+    const token = mintAccessToken({
+      secret: SECRET,
+      userId: "usr_123",
+      authIdentityId: "authid_1",
+      tokenId: "mcpt_abc",
+    })
+    const payload = jwt.verify(token, SECRET) as any
+    expect(payload.actor_type).toBe("user")
+    expect(payload.actor_id).toBe("usr_123")
+    expect(payload.auth_identity_id).toBe("authid_1")
+    expect(payload.mcp_oauth).toEqual({ token_id: "mcpt_abc" })
+  })
+
+  it("honours its own expiry rather than the global jwtExpiresIn", () => {
+    const token = mintAccessToken({
+      secret: SECRET,
+      userId: "usr_123",
+      tokenId: "mcpt_abc",
+      expiresInSec: 60,
+    })
+    const payload = jwt.verify(token, SECRET) as any
+    expect(payload.exp - payload.iat).toBe(60)
+  })
+
+  it("resolves to an `oauth` principal keyed on the TOKEN, not the user", () => {
+    // This is the whole Track B integration: scope binds to the token, so two
+    // clients authorized by the same admin can hold different levels.
+    const req = {
+      auth_context: {
+        actor_id: "usr_123",
+        actor_type: "user",
+        mcp_oauth: { token_id: "mcpt_abc" },
+      },
+    } as any
+    expect(mcpOauthTokenIdFromRequest(req)).toBe("mcpt_abc")
+    expect(mcpPrincipalFromRequest(req)).toEqual({
+      type: "oauth",
+      id: "mcpt_abc",
+    })
+  })
+
+  it("leaves an ordinary admin JWT resolving as a user", () => {
+    const req = {
+      auth_context: { actor_id: "usr_123", actor_type: "user" },
+    } as any
+    expect(mcpPrincipalFromRequest(req)).toEqual({
+      type: "user",
+      id: "usr_123",
+    })
+  })
+
+  it("ignores a malformed mcp_oauth claim instead of trusting it", () => {
+    const req = {
+      auth_context: {
+        actor_id: "usr_123",
+        actor_type: "user",
+        mcp_oauth: { token_id: 42 },
+      },
+    } as any
+    expect(mcpOauthTokenIdFromRequest(req)).toBeNull()
+    expect(mcpPrincipalFromRequest(req)).toEqual({
+      type: "user",
+      id: "usr_123",
+    })
+  })
+})
+
+describe("discovery", () => {
+  const ISSUER = "https://api.example.com"
+
+  it("points the client at the mount that can actually challenge it", () => {
+    // Not /admin/mcp: the framework's 401 there cannot carry a
+    // WWW-Authenticate header, which is what makes discovery work at all.
+    const doc = protectedResourceMetadata(ISSUER)
+    expect(doc.resource).toBe(`${ISSUER}${MCP_OAUTH_RESOURCE_PATH}`)
+    expect(doc.resource).not.toContain("/admin/")
+    expect(doc.authorization_servers).toEqual([ISSUER])
+  })
+
+  it("advertises S256 only", () => {
+    // `plain` offers no protection against a code intercepted on the redirect
+    // leg — the single thing PKCE exists to stop.
+    const doc = authorizationServerMetadata(ISSUER)
+    expect(doc.code_challenge_methods_supported).toEqual(["S256"])
+    expect(doc.grant_types_supported).not.toContain("client_credentials")
+  })
+
+  it("names the protected-resource document in the challenge", () => {
+    const header = bearerChallenge(ISSUER, {
+      code: "invalid_token",
+      description: "nope",
+    })
+    expect(header).toContain(
+      `resource_metadata="${ISSUER}/.well-known/oauth-protected-resource"`
+    )
+    expect(header).toContain(`error="invalid_token"`)
+  })
+})

--- a/apps/backend/src/lib/mcp-oauth.ts
+++ b/apps/backend/src/lib/mcp-oauth.ts
@@ -1,0 +1,336 @@
+/**
+ * OAuth 2.1 + PKCE front door for the Admin MCP surface — the pure half
+ * (#1306 Track B).
+ *
+ * ## Why the token is a Medusa *user* JWT
+ *
+ * The obvious design — an access token carrying `actor_type: "oauth"` — cannot
+ * work. Medusa authenticates `/admin/*` with `actorType: "user"` and
+ * `isActorTypePermitted` 401s every other actor type
+ * (`@medusajs/framework/dist/http/middlewares/authenticate-middleware.js`), so
+ * such a token is rejected at the door and never reaches our scope guard. API
+ * keys are the one hard-coded exception, and only over HTTP Basic.
+ *
+ * So the access token IS a normal admin user JWT — `actor_type: "user"`,
+ * `actor_id` = the admin who approved the consent — with one extra claim:
+ *
+ *     mcp_oauth: { token_id: "mcpt_…" }
+ *
+ * The framework verifies it like any other bearer and, because it assigns the
+ * whole verified payload to `req.auth_context`, the claim arrives intact
+ * without any parsing of our own. `mcpPrincipalFromRequest` reads it and
+ * returns `{ type: "oauth", id: token_id }` while leaving `auth_context`
+ * untouched, so:
+ *
+ *   - the #1310 per-route tier guard and the Track C `mcp_access_scope` row
+ *     apply for free, bound to the TOKEN rather than to the user; and
+ *   - every admin route that reads `actor_id` as a user id (audit trails,
+ *     `created_by`) still sees a real user.
+ *
+ * ⚠️ Do NOT rewrite `auth_context.actor_type` to `"oauth"` to achieve the same
+ * thing. It breaks the second point above, silently.
+ *
+ * ⚠️ `projectConfig.http.jwtExpiresIn` is GLOBAL — shortening it would shorten
+ * every dashboard session. OAuth access tokens are signed with their own
+ * `expiresIn` instead.
+ *
+ * Everything in this file is pure or reads env/config only; storage lives in
+ * the `mcp_oauth` module and the flow decisions live in `src/api/oauth/*`.
+ */
+import crypto from "crypto"
+import jwt from "jsonwebtoken"
+import type { MedusaRequest } from "@medusajs/framework/http"
+import { ContainerRegistrationKeys } from "@medusajs/framework/utils"
+import { MCP_SCOPE_LEVELS, isMcpScopeLevel } from "./mcp-core/tiers"
+import type { McpScopeLevel } from "./mcp-core/tiers"
+
+/**
+ * The MCP endpoint this authorization server protects.
+ *
+ * Deliberately NOT `/admin/mcp`. An RFC 9728 client discovers the
+ * authorization server from a `WWW-Authenticate: Bearer resource_metadata=…`
+ * header on a 401 — and nothing we register can put that header on a
+ * `/admin/*` 401, because the framework's auth middleware is applied in the
+ * loader BEFORE user middlewares and answers first. A mount outside `/admin/*`
+ * verifies the bearer itself and can therefore emit the challenge.
+ *
+ * `/admin/mcp` stays exactly as it is for secret-API-key clients.
+ */
+export const MCP_OAUTH_RESOURCE_PATH = "/mcp/admin"
+
+/** Access-token lifetime. Short: revocation is a DB read on every request, but
+ *  a short window limits the damage if that check is ever bypassed. */
+export const MCP_OAUTH_ACCESS_TTL_SEC = 60 * 60
+
+/** Refresh-token lifetime, rotated on every use. */
+export const MCP_OAUTH_REFRESH_TTL_SEC = 60 * 60 * 24 * 30
+
+/** Authorization codes live only long enough to be redeemed once. */
+export const MCP_OAUTH_CODE_TTL_SEC = 300
+
+/** Consent screens older than this are stale; the client must restart. */
+export const MCP_OAUTH_REQUEST_TTL_SEC = 600
+
+/** The scope string prefix. `mcp:read` … `mcp:dangerous` mirror the ladder. */
+export const MCP_OAUTH_SCOPE_PREFIX = "mcp:"
+
+/** Every scope string this server understands, widest last. */
+export const MCP_OAUTH_SCOPES: readonly string[] = MCP_SCOPE_LEVELS.map(
+  (l) => `${MCP_OAUTH_SCOPE_PREFIX}${l}`
+)
+
+export const levelToScopeString = (level: McpScopeLevel): string =>
+  `${MCP_OAUTH_SCOPE_PREFIX}${level}`
+
+/**
+ * The widest rung named in a space-separated `scope` parameter, or null when
+ * the client asked for nothing recognizable.
+ *
+ * Unknown entries are ignored rather than rejected: clients routinely send
+ * extra scopes (`openid`, `offline_access`) and failing the whole request over
+ * one would break a connection that we can serve perfectly well. The admin
+ * picks the actual rung at consent, so a generous parse grants nothing.
+ */
+export const levelFromScopeString = (
+  scope: string | undefined | null
+): McpScopeLevel | null => {
+  if (!scope) return null
+  const asked = new Set(
+    String(scope)
+      .split(/\s+/)
+      .filter(Boolean)
+      .map((s) => s.replace(MCP_OAUTH_SCOPE_PREFIX, ""))
+  )
+  let widest: McpScopeLevel | null = null
+  for (const level of MCP_SCOPE_LEVELS) {
+    if (asked.has(level)) widest = level
+  }
+  return widest
+}
+
+/** sha256, hex. Used for every stored secret in this flow. */
+export const sha256 = (value: string): string =>
+  crypto.createHash("sha256").update(value).digest("hex")
+
+/** A URL-safe random secret. 32 bytes → 43 base64url chars. */
+export const randomSecret = (bytes = 32): string =>
+  crypto.randomBytes(bytes).toString("base64url")
+
+/**
+ * Constant-time string comparison, for client secrets and code hashes.
+ *
+ * `crypto.timingSafeEqual` throws on length mismatch, which would itself leak
+ * length — so compare digests, which are always the same size.
+ */
+export const secretsMatch = (a: string, b: string): boolean => {
+  const ha = crypto.createHash("sha256").update(a).digest()
+  const hb = crypto.createHash("sha256").update(b).digest()
+  return crypto.timingSafeEqual(ha, hb)
+}
+
+/**
+ * PKCE verification (RFC 7636).
+ *
+ * `plain` is rejected at the authorize endpoint, so in practice this only ever
+ * sees S256 — it still handles both, because a stored grant should be
+ * self-describing rather than depending on today's validation staying put.
+ */
+export const verifyPkce = (
+  codeChallenge: string,
+  method: string,
+  codeVerifier: string
+): boolean => {
+  if (!codeChallenge || !codeVerifier) return false
+  // RFC 7636 §4.1: 43–128 characters from the unreserved set.
+  if (codeVerifier.length < 43 || codeVerifier.length > 128) return false
+  if ((method || "S256").toUpperCase() === "PLAIN") {
+    return secretsMatch(codeChallenge, codeVerifier)
+  }
+  const derived = crypto
+    .createHash("sha256")
+    .update(codeVerifier)
+    .digest("base64url")
+  return secretsMatch(codeChallenge, derived)
+}
+
+/**
+ * The public origin this server is reached at — the OAuth `issuer`.
+ *
+ * Honours `x-forwarded-proto` because behind the ALB `req.protocol` is `http`,
+ * and an `http://` issuer is rejected outright by conforming clients. Override
+ * with `MCP_OAUTH_ISSUER` when the public hostname differs from the Host header.
+ */
+export const resolveOauthIssuer = (req: MedusaRequest): string => {
+  const override = process.env.MCP_OAUTH_ISSUER
+  if (override) return override.replace(/\/+$/, "")
+  const forwarded = (req.get("x-forwarded-proto") || "").split(",")[0].trim()
+  const proto = forwarded || (req.protocol || "http").split(",")[0].trim()
+  const host = req.get("host") || `localhost:${process.env.PORT || "9000"}`
+  return `${proto}://${host}`
+}
+
+/**
+ * A redirect URI is acceptable only if the client registered it VERBATIM.
+ *
+ * No prefix matching, no wildcards, no ignoring the query string — loose
+ * matching here is the classic open-redirect hole that turns an authorization
+ * server into a token-exfiltration service.
+ */
+export const redirectUriRegistered = (
+  registered: unknown,
+  candidate: string
+): boolean => {
+  if (!candidate) return false
+  const list = Array.isArray(registered) ? registered : []
+  return list.some((u) => typeof u === "string" && u === candidate)
+}
+
+/**
+ * Redirect targets we accept at registration.
+ *
+ * Loopback (any port — RFC 8252 §7.3 requires the port to be ignored, and
+ * desktop clients pick a random one) and https elsewhere. Custom app schemes
+ * (`cursor://`, `claude://`) are allowed because native clients depend on them
+ * and they are not interceptable over the network.
+ */
+export const isAcceptableRedirectUri = (value: string): boolean => {
+  let url: URL
+  try {
+    url = new URL(value)
+  } catch {
+    return false
+  }
+  if (url.hash) return false // RFC 6749 §3.1.2 — no fragment component
+  if (url.protocol === "https:") return true
+  if (
+    url.protocol === "http:" &&
+    (url.hostname === "127.0.0.1" ||
+      url.hostname === "::1" ||
+      url.hostname === "localhost")
+  ) {
+    return true
+  }
+  // A private-use scheme: must contain a dot, per RFC 8252 §7.1.
+  return /^[a-z][a-z0-9+.-]*:$/.test(url.protocol) && url.protocol.includes(".")
+}
+
+/** The configured JWT secret, or null when the deployment has none. */
+export const resolveJwtSecret = (req: MedusaRequest): string | null => {
+  try {
+    const configModule = req.scope.resolve(
+      ContainerRegistrationKeys.CONFIG_MODULE
+    ) as any
+    const secret = configModule?.projectConfig?.http?.jwtSecret
+    return typeof secret === "string" && secret ? secret : null
+  } catch {
+    return null
+  }
+}
+
+export type MintAccessTokenInput = {
+  secret: string
+  userId: string
+  authIdentityId?: string | null
+  tokenId: string
+  expiresInSec?: number
+}
+
+/**
+ * Sign an access token.
+ *
+ * The payload shape is exactly what Medusa's `generateJwtTokenForAuthIdentity`
+ * produces — the framework reads `actor_id` / `actor_type` /
+ * `auth_identity_id` off it — plus the `mcp_oauth` claim. Signed with its own
+ * `expiresIn`, never the global `jwtExpiresIn`.
+ */
+export const mintAccessToken = ({
+  secret,
+  userId,
+  authIdentityId,
+  tokenId,
+  expiresInSec = MCP_OAUTH_ACCESS_TTL_SEC,
+}: MintAccessTokenInput): string =>
+  jwt.sign(
+    {
+      actor_id: userId,
+      actor_type: "user",
+      auth_identity_id: authIdentityId ?? "",
+      app_metadata: { user_id: userId },
+      mcp_oauth: { token_id: tokenId },
+    },
+    secret,
+    { expiresIn: expiresInSec }
+  )
+
+/**
+ * The `mcp_oauth.token_id` claim on an authenticated request, or null.
+ *
+ * Reads `req.auth_context`, which the framework sets to the *entire* verified
+ * JWT payload — so an unverified token can never reach this, and no separate
+ * parse of the Authorization header is needed.
+ */
+export const mcpOauthTokenIdFromRequest = (
+  req: MedusaRequest
+): string | null => {
+  const claim = (req as any).auth_context?.mcp_oauth
+  const id = claim?.token_id
+  return typeof id === "string" && id ? id : null
+}
+
+/**
+ * RFC 9728 protected-resource metadata. Points a client at this same origin as
+ * its own authorization server — we are both, which keeps the discovery chain
+ * one hop long.
+ */
+export const protectedResourceMetadata = (issuer: string) => ({
+  resource: `${issuer}${MCP_OAUTH_RESOURCE_PATH}`,
+  authorization_servers: [issuer],
+  scopes_supported: MCP_OAUTH_SCOPES,
+  bearer_methods_supported: ["header"],
+  resource_documentation: `${issuer}/oauth/authorize`,
+})
+
+/** RFC 8414 authorization-server metadata. */
+export const authorizationServerMetadata = (issuer: string) => ({
+  issuer,
+  authorization_endpoint: `${issuer}/oauth/authorize`,
+  token_endpoint: `${issuer}/oauth/token`,
+  registration_endpoint: `${issuer}/oauth/register`,
+  revocation_endpoint: `${issuer}/oauth/revoke`,
+  scopes_supported: MCP_OAUTH_SCOPES,
+  response_types_supported: ["code"],
+  grant_types_supported: ["authorization_code", "refresh_token"],
+  // S256 only. `plain` offers no protection against a code intercepted on the
+  // redirect leg, which is the single thing PKCE exists to stop.
+  code_challenge_methods_supported: ["S256"],
+  token_endpoint_auth_methods_supported: [
+    "none",
+    "client_secret_post",
+    "client_secret_basic",
+  ],
+  revocation_endpoint_auth_methods_supported: ["none", "client_secret_post"],
+})
+
+/**
+ * The `WWW-Authenticate` challenge an MCP client follows to find all of the
+ * above. This header is the entire reason the OAuth mount lives outside
+ * `/admin/*`.
+ */
+export const bearerChallenge = (
+  issuer: string,
+  error?: { code: string; description: string }
+): string => {
+  const parts = [
+    `Bearer realm="jyt-admin-mcp"`,
+    `resource_metadata="${issuer}/.well-known/oauth-protected-resource"`,
+  ]
+  if (error) {
+    parts.push(`error="${error.code}"`)
+    parts.push(`error_description="${error.description.replace(/"/g, "'")}"`)
+  }
+  return parts.join(", ")
+}
+
+/** Narrow an arbitrary stored string back onto the ladder, failing safe. */
+export const asScopeLevel = (value: unknown): McpScopeLevel =>
+  typeof value === "string" && isMcpScopeLevel(value) ? value : "read"

--- a/apps/backend/src/lib/mcp-scope.ts
+++ b/apps/backend/src/lib/mcp-scope.ts
@@ -28,6 +28,7 @@ import {
   minMcpScope,
   type McpScopeLevel,
 } from "./mcp-core/tiers"
+import { mcpOauthTokenIdFromRequest } from "./mcp-oauth"
 import { MCP_ACCESS_MODULE } from "../modules/mcp_access"
 import type McpAccessService from "../modules/mcp_access/service"
 
@@ -93,6 +94,17 @@ export type McpPrincipal = {
  * "api-key" }` (see the framework's authenticate middleware — API keys are the
  * one hard-coded actor type). For a dashboard session or admin JWT it is the
  * user id with `actor_type: "user"`.
+ *
+ * ⚠️ An OAuth access token (#1306 Track B) is deliberately ALSO a `user` JWT —
+ * Medusa 401s every other actor type on `/admin/*`, so it has no choice. What
+ * distinguishes it is the `mcp_oauth` claim, and this is the one place that
+ * matters: a request carrying it resolves to `{ type: "oauth", id: token_id }`,
+ * so scope binds to the TOKEN rather than to the admin who authorized it, and
+ * the credential counts as a machine principal for the HTTP write guard.
+ *
+ * `req.auth_context` is left untouched on purpose. Many admin routes read
+ * `actor_id` as a user id (audit trails, `created_by`); rewriting the actor
+ * type there instead of reading the claim here would break them silently.
  */
 export const mcpPrincipalFromRequest = (
   req: MedusaRequest
@@ -102,6 +114,10 @@ export const mcpPrincipalFromRequest = (
   const type = ctx?.actor_type
   if (typeof id !== "string" || !id || typeof type !== "string" || !type) {
     return null
+  }
+  const oauthTokenId = mcpOauthTokenIdFromRequest(req)
+  if (oauthTokenId) {
+    return { type: "oauth", id: oauthTokenId }
   }
   return { type, id }
 }

--- a/apps/backend/src/modules/mcp_oauth/index.ts
+++ b/apps/backend/src/modules/mcp_oauth/index.ts
@@ -1,0 +1,8 @@
+import { Module } from "@medusajs/framework/utils"
+import McpOauthService from "./service"
+
+export const MCP_OAUTH_MODULE = "mcp_oauth"
+
+export default Module(MCP_OAUTH_MODULE, {
+  service: McpOauthService,
+})

--- a/apps/backend/src/modules/mcp_oauth/migrations/Migration20260817030000.ts
+++ b/apps/backend/src/modules/mcp_oauth/migrations/Migration20260817030000.ts
@@ -1,0 +1,41 @@
+import { Migration } from "@medusajs/framework/mikro-orm/migrations";
+
+/**
+ * Creates the three mcp_oauth tables (#1306 Track B — the OAuth front door).
+ *
+ * Hand-written to mirror what DML would generate, following the mcp_access
+ * precedent: partial unique indexes (WHERE deleted_at IS NULL) so a soft-deleted
+ * row never blocks re-registering the same client, plus the standard deleted_at
+ * indexes.
+ *
+ * Idempotent (`if not exists` throughout) — a re-run is a no-op rather than a
+ * failure the migrate job would then report as success (#1208).
+ *
+ * ⚠️ Without these tables the OAuth routes 500 and `/mcp/admin` fails closed,
+ * exactly as `/admin/mcp` did when mcp_access_scope was missing. Check the
+ * migrate log for `MODULE: mcp_oauth` after deploying.
+ */
+export class Migration20260817030000 extends Migration {
+
+  override async up(): Promise<void> {
+    this.addSql(`create table if not exists "mcp_oauth_client" ("id" text not null, "client_id" text not null, "client_secret_hash" text null, "client_name" text not null, "redirect_uris" jsonb not null, "grant_types" jsonb null, "token_endpoint_auth_method" text not null default 'none', "scope" text null, "metadata" jsonb null, "created_at" timestamptz not null default now(), "updated_at" timestamptz not null default now(), "deleted_at" timestamptz null, constraint "mcp_oauth_client_pkey" primary key ("id"));`);
+    this.addSql(`CREATE UNIQUE INDEX IF NOT EXISTS "IDX_mcp_oauth_client_client_id_unique" ON "mcp_oauth_client" ("client_id") WHERE deleted_at IS NULL;`);
+    this.addSql(`CREATE INDEX IF NOT EXISTS "IDX_mcp_oauth_client_deleted_at" ON "mcp_oauth_client" ("deleted_at") WHERE deleted_at IS NULL;`);
+
+    this.addSql(`create table if not exists "mcp_oauth_grant" ("id" text not null, "code_hash" text not null, "client_id" text not null, "redirect_uri" text not null, "code_challenge" text not null, "code_challenge_method" text not null default 'S256', "user_id" text not null, "auth_identity_id" text null, "level" text not null default 'read', "state" text null, "expires_at" timestamptz not null, "consumed_at" timestamptz null, "metadata" jsonb null, "created_at" timestamptz not null default now(), "updated_at" timestamptz not null default now(), "deleted_at" timestamptz null, constraint "mcp_oauth_grant_pkey" primary key ("id"));`);
+    this.addSql(`CREATE UNIQUE INDEX IF NOT EXISTS "IDX_mcp_oauth_grant_code_hash_unique" ON "mcp_oauth_grant" ("code_hash") WHERE deleted_at IS NULL;`);
+    this.addSql(`CREATE INDEX IF NOT EXISTS "IDX_mcp_oauth_grant_deleted_at" ON "mcp_oauth_grant" ("deleted_at") WHERE deleted_at IS NULL;`);
+
+    this.addSql(`create table if not exists "mcp_oauth_token" ("id" text not null, "client_id" text not null, "user_id" text not null, "auth_identity_id" text null, "level" text not null default 'read', "refresh_token_hash" text null, "access_expires_at" timestamptz null, "refresh_expires_at" timestamptz null, "revoked_at" timestamptz null, "last_used_at" timestamptz null, "metadata" jsonb null, "created_at" timestamptz not null default now(), "updated_at" timestamptz not null default now(), "deleted_at" timestamptz null, constraint "mcp_oauth_token_pkey" primary key ("id"));`);
+    this.addSql(`CREATE UNIQUE INDEX IF NOT EXISTS "IDX_mcp_oauth_token_refresh_hash_unique" ON "mcp_oauth_token" ("refresh_token_hash") WHERE refresh_token_hash IS NOT NULL AND deleted_at IS NULL;`);
+    this.addSql(`CREATE INDEX IF NOT EXISTS "IDX_mcp_oauth_token_user_id" ON "mcp_oauth_token" ("user_id") WHERE deleted_at IS NULL;`);
+    this.addSql(`CREATE INDEX IF NOT EXISTS "IDX_mcp_oauth_token_deleted_at" ON "mcp_oauth_token" ("deleted_at") WHERE deleted_at IS NULL;`);
+  }
+
+  override async down(): Promise<void> {
+    this.addSql(`drop table if exists "mcp_oauth_token" cascade;`);
+    this.addSql(`drop table if exists "mcp_oauth_grant" cascade;`);
+    this.addSql(`drop table if exists "mcp_oauth_client" cascade;`);
+  }
+
+}

--- a/apps/backend/src/modules/mcp_oauth/models/mcp-oauth-client.ts
+++ b/apps/backend/src/modules/mcp_oauth/models/mcp-oauth-client.ts
@@ -1,0 +1,59 @@
+import { model } from "@medusajs/framework/utils"
+
+/**
+ * A dynamically-registered OAuth client (#1306 Track B, RFC 7591).
+ *
+ * Claude web/desktop, ChatGPT and Cursor cannot hold a static secret, so they
+ * register themselves at connect time and then run authorization-code + PKCE.
+ * Registration by itself grants NOTHING: a row here is only a name and a set of
+ * redirect URIs. Every capability comes from a token, and no token exists until
+ * a human admin has logged in and approved one.
+ *
+ * `client_secret_hash` is nullable because public clients (the ones this exists
+ * for) have no secret — PKCE is what binds the code to the client. When a
+ * confidential client does register, only the hash is stored; the secret is
+ * shown once at registration and never again, matching how Medusa treats its
+ * own secret API keys.
+ */
+const McpOauthClient = model
+  .define("mcp_oauth_client", {
+    id: model.id({ prefix: "mcpcl" }).primaryKey(),
+
+    // The public `client_id` handed to the client. Distinct from `id` so the
+    // value a third party holds is never a database primary key.
+    client_id: model.text().searchable(),
+
+    // sha256 of the client secret, or null for a public (PKCE-only) client.
+    client_secret_hash: model.text().nullable(),
+
+    // RFC 7591 `client_name` — shown to the admin on the consent screen. This
+    // is attacker-controlled text; render it escaped.
+    client_name: model.text(),
+
+    // Exact-match redirect URIs. An authorization request must name one of
+    // these verbatim — no prefix or wildcard matching, which is the classic
+    // open-redirect hole in OAuth implementations.
+    redirect_uris: model.json(),
+
+    // `client_credentials` is deliberately absent: this front door exists to
+    // act as a human admin, so there is no grant that skips the human.
+    grant_types: model.json().nullable(),
+
+    // "none" for public clients, "client_secret_post"/"client_secret_basic"
+    // otherwise.
+    token_endpoint_auth_method: model.text().default("none"),
+
+    // The scope string the client asked for at registration, kept for display.
+    // It is NOT authority — the admin chooses the level at consent time.
+    scope: model.text().nullable(),
+
+    metadata: model.json().nullable(),
+  })
+  .indexes([
+    {
+      on: ["client_id"],
+      unique: true,
+    },
+  ])
+
+export default McpOauthClient

--- a/apps/backend/src/modules/mcp_oauth/models/mcp-oauth-grant.ts
+++ b/apps/backend/src/modules/mcp_oauth/models/mcp-oauth-grant.ts
@@ -1,0 +1,62 @@
+import { model } from "@medusajs/framework/utils"
+
+/**
+ * A pending authorization code (#1306 Track B).
+ *
+ * Written when an admin approves a consent screen, consumed once at
+ * `POST /oauth/token`. Short-lived by design — the code travels through a
+ * browser redirect, which is the least trustworthy leg of the flow.
+ *
+ * Only `code_hash` is stored. A leaked database row must not be redeemable, so
+ * the code itself exists solely in the redirect and in the client's memory —
+ * the same reasoning as `mcp_oauth_token.refresh_token_hash`.
+ *
+ * `consumed_at` rather than a delete: a second redemption of the same code is
+ * evidence the code leaked, and the row has to survive for us to notice. The
+ * token endpoint revokes every token already issued from a replayed code.
+ */
+const McpOauthGrant = model
+  .define("mcp_oauth_grant", {
+    id: model.id({ prefix: "mcpg" }).primaryKey(),
+
+    // sha256 of the authorization code.
+    code_hash: model.text().searchable(),
+
+    client_id: model.text().searchable(),
+
+    // Must match the `redirect_uri` presented at the token endpoint verbatim.
+    redirect_uri: model.text(),
+
+    // PKCE (RFC 7636). `plain` is rejected at the authorize endpoint, so this
+    // is always S256 in practice — stored anyway so a stored row is
+    // self-describing rather than depending on today's validation.
+    code_challenge: model.text(),
+    code_challenge_method: model.text().default("S256"),
+
+    // The admin who approved. Becomes `actor_id` on the minted token, so every
+    // action taken through this grant attributes to a real user.
+    user_id: model.text(),
+
+    // Their auth identity — the framework's authenticate middleware expects it
+    // on the JWT payload.
+    auth_identity_id: model.text().nullable(),
+
+    // The MCP scope ladder rung the admin approved: read|write|sensitive|dangerous.
+    level: model.text().default("read"),
+
+    // Echoed back on the redirect for the client's CSRF check.
+    state: model.text().nullable(),
+
+    expires_at: model.dateTime(),
+    consumed_at: model.dateTime().nullable(),
+
+    metadata: model.json().nullable(),
+  })
+  .indexes([
+    {
+      on: ["code_hash"],
+      unique: true,
+    },
+  ])
+
+export default McpOauthGrant

--- a/apps/backend/src/modules/mcp_oauth/models/mcp-oauth-token.ts
+++ b/apps/backend/src/modules/mcp_oauth/models/mcp-oauth-token.ts
@@ -1,0 +1,70 @@
+import { model } from "@medusajs/framework/utils"
+
+/**
+ * One issued authorization — the identity a third-party client acts under
+ * (#1306 Track B).
+ *
+ * The access token itself is NOT stored: it is a Medusa user JWT carrying an
+ * `mcp_oauth: { token_id }` claim, verified statelessly by the framework. This
+ * row is what that claim points at, and it exists for the two things a JWT
+ * cannot do on its own — be revoked, and carry a scope.
+ *
+ * 🔑 **The row survives refresh.** Rotating the refresh token updates
+ * `refresh_token_hash` in place and keeps `id`, so the `mcp_access_scope` row
+ * written against `("oauth", <id>)` at issuance stays attached for the life of
+ * the authorization. Scope binds to the AUTHORIZATION, not to one access token
+ * — otherwise every refresh would silently restore the process ceiling.
+ *
+ * ⚠️ An access token minted here is a real admin user JWT. On any route the
+ * per-route scope guard does not cover it is as powerful as a dashboard
+ * session — the same posture as a Medusa secret API key. That is a deliberate
+ * consequence of the framework rejecting every non-`user` actor type on
+ * `/admin/*`; do not widen it further.
+ */
+const McpOauthToken = model
+  .define("mcp_oauth_token", {
+    // `mcpt_…`. This is the value carried in the JWT's `mcp_oauth.token_id`
+    // claim and the `principal_id` of the credential's scope row.
+    id: model.id({ prefix: "mcpt" }).primaryKey(),
+
+    client_id: model.text().searchable(),
+
+    // The admin this authorization acts as.
+    user_id: model.text().searchable(),
+    auth_identity_id: model.text().nullable(),
+
+    // The approved rung, duplicated from the scope row purely for display and
+    // audit. The row in `mcp_access_scope` is what is ENFORCED — one source of
+    // truth for permissions, and it is the one Track C already reads.
+    level: model.text().default("read"),
+
+    // sha256 of the current refresh token. Null once refresh is exhausted or
+    // the client never received one.
+    refresh_token_hash: model.text().nullable(),
+
+    // When the most recently minted access token stops verifying. Informational
+    // — expiry is enforced by the JWT's own `exp`, not by this column.
+    access_expires_at: model.dateTime().nullable(),
+
+    refresh_expires_at: model.dateTime().nullable(),
+
+    // Set by the revocation endpoint or an admin. Checked on EVERY request,
+    // reads included: a revoked token must not read either.
+    revoked_at: model.dateTime().nullable(),
+
+    last_used_at: model.dateTime().nullable(),
+
+    metadata: model.json().nullable(),
+  })
+  .indexes([
+    {
+      on: ["refresh_token_hash"],
+      unique: true,
+      where: "refresh_token_hash IS NOT NULL AND deleted_at IS NULL",
+    },
+    {
+      on: ["user_id"],
+    },
+  ])
+
+export default McpOauthToken

--- a/apps/backend/src/modules/mcp_oauth/service.ts
+++ b/apps/backend/src/modules/mcp_oauth/service.ts
@@ -1,0 +1,94 @@
+import { MedusaService } from "@medusajs/framework/utils"
+import McpOauthClient from "./models/mcp-oauth-client"
+import McpOauthGrant from "./models/mcp-oauth-grant"
+import McpOauthToken from "./models/mcp-oauth-token"
+
+/**
+ * The OAuth 2.1 front door's data access (#1306 Track B).
+ *
+ * Deliberately thin: it hashes nothing and decides nothing about the protocol.
+ * All the crypto (code/secret generation, sha256, PKCE verification) lives in
+ * `src/lib/mcp-oauth.ts` so it can be unit-tested without a container, and the
+ * flow decisions live in the routes. This class only stores and looks up.
+ */
+class McpOauthService extends MedusaService({
+  McpOauthClient,
+  McpOauthGrant,
+  McpOauthToken,
+}) {
+  /** A registered client by its public `client_id`, or null. */
+  async getClient(clientId: string): Promise<any | null> {
+    if (!clientId) return null
+    const rows = await this.listMcpOauthClients({ client_id: clientId })
+    return rows?.[0] ?? null
+  }
+
+  /**
+   * A pending grant by the hash of its code, or null.
+   *
+   * Returns consumed and expired rows too — the caller must distinguish them,
+   * because "this code was already used" is a security event worth acting on
+   * while "no such code" is merely a bad request.
+   */
+  async getGrantByCodeHash(codeHash: string): Promise<any | null> {
+    if (!codeHash) return null
+    const rows = await this.listMcpOauthGrants({ code_hash: codeHash })
+    return rows?.[0] ?? null
+  }
+
+  async getTokenByRefreshHash(refreshHash: string): Promise<any | null> {
+    if (!refreshHash) return null
+    const rows = await this.listMcpOauthTokens({
+      refresh_token_hash: refreshHash,
+    })
+    return rows?.[0] ?? null
+  }
+
+  /**
+   * One token row by id — the revocation check, run on every `/admin/*`
+   * request made with an OAuth-minted JWT.
+   *
+   * Returns null when the row is missing. The caller treats that as revoked:
+   * a claim pointing at a row that no longer exists must not authorize
+   * anything.
+   */
+  async getToken(tokenId: string): Promise<any | null> {
+    if (!tokenId) return null
+    const rows = await this.listMcpOauthTokens({ id: tokenId })
+    return rows?.[0] ?? null
+  }
+
+  /** Every authorization for one admin — powers the settings listing. */
+  async listTokensForUser(userId: string): Promise<any[]> {
+    if (!userId) return []
+    return (
+      (await this.listMcpOauthTokens(
+        { user_id: userId },
+        { order: { created_at: "DESC" } }
+      )) ?? []
+    )
+  }
+
+  /**
+   * Mark a token revoked. Idempotent — revoking twice is a no-op rather than
+   * an error, because a client that retries `POST /oauth/revoke` after a
+   * timeout is doing the right thing (RFC 7009 requires a 200 either way).
+   */
+  async revokeToken(tokenId: string): Promise<void> {
+    const existing = await this.getToken(tokenId)
+    if (!existing || existing.revoked_at) return
+    await this.updateMcpOauthTokens([
+      {
+        id: tokenId,
+        revoked_at: new Date(),
+        // Drop the refresh secret at the same moment. Leaving it would let a
+        // holder keep exchanging it and only discover the revocation on the
+        // access-token check — one avoidable round trip through a valid-looking
+        // credential.
+        refresh_token_hash: null,
+      },
+    ])
+  }
+}
+
+export default McpOauthService


### PR DESCRIPTION
Closes part of #1306 (Track B). Lets a client that **cannot hold a secret** — Claude web/desktop, ChatGPT, Cursor — connect to the Admin MCP and act as the admin who authorized it, with a scope that binds to the token and can be revoked.

## The constraint that shaped this

The obvious design does not work. Medusa authenticates `/admin/*` with `actorType: "user"` and `isActorTypePermitted` 401s every other actor type, so an access token **cannot** carry `actor_type: "oauth"` — `MCP_MACHINE_PRINCIPAL_TYPES` already listing `"oauth"` was true and useless on its own. And because that auth middleware is applied in the loader *ahead of* user middlewares, nothing we register can attach the `WWW-Authenticate` challenge RFC 9728 clients use to discover the authorization server.

So the access token **is** a Medusa user JWT, with one extra claim:

```
mcp_oauth: { token_id: "mcpt_…" }
```

The framework assigns the whole verified payload to `req.auth_context`, so `mcpPrincipalFromRequest` reads that claim and returns `{ type: "oauth", id: token_id }` **while leaving `auth_context` untouched** — every admin route still sees a real user id for audit and `created_by`, and the #1310 per-route tier guard plus the Track C scope row apply for free, bound to the **token** rather than to the person.

## The mount decision, measured rather than argued

`POST /mcp/admin`, outside `/admin/*`, verifying the bearer itself:

```
/mcp/admin  → 401  www-authenticate: Bearer realm="jyt-admin-mcp", resource_metadata="…/.well-known/oauth-protected-resource", error="invalid_token"
/admin/mcp  → 401  {"message":"Unauthorized"}          ← no header, and none can be added
```

`/admin/mcp` is unchanged and stays the endpoint for secret-API-key clients, which need no discovery because they are configured by hand.

## What's here

- **`mcp_oauth` module** — clients (RFC 7591 dynamic registration), grants, tokens. Only **hashes** are stored for codes, refresh tokens and client secrets.
- **`/.well-known/oauth-protected-resource`** + **`/.well-known/oauth-authorization-server`** (RFC 9728 / 8414), incl. the path-suffixed forms clients probe. Registered as middleware entries — Medusa's file router ignores dot-directories (the `/.well-known/ucp` precedent), but pointing at the exported handlers so the two cannot drift.
- **`POST /oauth/register`** — open, and safe because a client row grants nothing. Redirect URIs are https / loopback / private-use scheme, exact-match only at authorize time. No `client_credentials` grant: this door exists to act as a human admin.
- **`GET /oauth/authorize`** — a self-contained consent page. Reuses `POST /auth/user/emailpass` for the password check, so no ambient authority and no CSRF surface. Offers only rungs at or below the process ceiling and **defaults to the narrowest** one that works.
- **`POST /oauth/token`** — PKCE (S256 only) + refresh. **Refresh rotates the refresh token but keeps `token_id`**, because the scope row hangs off it; a new id per refresh would quietly restore the process ceiling on first use.
- **`POST /oauth/revoke`** (RFC 7009) and **`GET`/`DELETE /admin/mcp/oauth-tokens[/:id]`** — human admins only, deliberately not MCP tools.
- **Revocation global on `/admin/*`**, ordered before the scope guard and applied to **reads too**, failing closed. Scoping is what a live credential may do; revocation is whether it is live at all.
- Replaying an authorization code **revokes what that code issued** — we cannot tell which redemption was honest, so neither party keeps access.
- An OAuth-issued token **cannot authorize another client**; otherwise a `read` client could bootstrap itself a `dangerous` one.

## Verified end to end against a running server

| | |
|---|---|
| register → consent → PKCE exchange → `tools/list` | ✅ |
| wrong `code_verifier` | `invalid_grant` |
| `read` token | **54 tools**, 403 on an `/admin/*` write, 200 on a read |
| `write` token | **63 tools**, still 403 on `POST /admin/orders/:id/shipping-label` |
| `sensitive` token | **117 tools**, reaches it |
| after revoke | 401 on both surfaces, **reads included**, with the challenge |
| replayed code | the token it issued is dead |

Those are #1310's numbers, reproduced through the new front door — so this also independently exercises that rung split locally.

## Found while proving it

A hand-rolled urlencoded parser on the token endpoint **hung every exchange**: it waited on an `end` event that had already fired, because Medusa's own stack already applies `express.urlencoded` to every route. Deleted. Caught only because the probe was a real HTTP round trip rather than a unit test.

## Watch-outs

- ⚠️ An OAuth access token is as powerful as a dashboard session on any route the per-route guard does not cover — the same posture as a Medusa secret API key. Deliberate: the framework leaves no other shape available.
- ⚠️ **Check the migrate log for `MODULE: mcp_oauth`.** Without the tables the OAuth routes 500 and `/mcp/admin` fails closed — the shape `mcp_access` hit. It did appear locally.
- ⚠️ `medusa-config.prod.ts` is a separate file; a pre-push hook caught the missing entry. Both are registered.
- Not in scope: partner-side OAuth, and the #1309 Settings UI for these tokens (the API is here; the screen is not).

🤖 Generated with [Claude Code](https://claude.com/claude-code)