### PR TITLE
fix(shipping): never email empty tracking, and stop calling a registered pickup a collection

### DIFF
--- a/apps/backend/src/api/admin/mcp/lib/tool-slice.ts
+++ b/apps/backend/src/api/admin/mcp/lib/tool-slice.ts
@@ -18,6 +18,10 @@
  * round trip, not a capability.
  */
 import type { McpToolDef } from "../../../../lib/mcp-core"
+// Imported from the submodule, not the barrel: this module is otherwise a
+// type-only consumer of mcp-core, and pulling the barrel in for one function
+// would drag dispatch/proxy/server into every context that slices a registry.
+import { widenedDomainsFromHistory as sharedWidenedDomainsFromHistory } from "../../../../lib/mcp-core/tool-slice"
 
 export type AdminToolDomain =
   | "core"
@@ -281,34 +285,16 @@ export const LOAD_TOOLS_TOOL_NAME = "load_admin_tools"
  * adversarial history part can widen nothing it could not widen by asking.
  *
  * Mirrored for the partner surface in partners/mcp/lib/tool-slice — the two
- * slicers are deliberately parallel modules over different domain unions.
+ * slicers are deliberately parallel modules over different domain unions, but
+ * the history parse itself is one implementation in lib/mcp-core.
  */
 export function widenedDomainsFromHistory(
   rawMessages: unknown
 ): AdminToolDomain[] {
-  const selectable = new Set<string>(SELECTABLE_DOMAINS)
-  const found = new Set<AdminToolDomain>()
-
-  for (const m of Array.isArray(rawMessages) ? rawMessages : []) {
-    const parts = Array.isArray((m as any)?.parts) ? (m as any).parts : []
-    for (const p of parts) {
-      const isLoadCall =
-        p?.type === `tool-${LOAD_TOOLS_TOOL_NAME}` ||
-        (p?.type === "dynamic-tool" && p?.toolName === LOAD_TOOLS_TOOL_NAME)
-      if (!isLoadCall) continue
-      // The call's own args are the reliable half; the result echoes them back,
-      // so read both and let the allow-list below discard anything odd.
-      for (const d of [
-        ...(Array.isArray(p?.input?.domains) ? p.input.domains : []),
-        ...(Array.isArray(p?.output?.domains) ? p.output.domains : []),
-      ]) {
-        if (typeof d === "string" && selectable.has(d)) {
-          found.add(d as AdminToolDomain)
-        }
-      }
-    }
-  }
-  return [...found]
+  return sharedWidenedDomainsFromHistory(rawMessages, {
+    loadToolName: LOAD_TOOLS_TOOL_NAME,
+    selectable: SELECTABLE_DOMAINS,
+  })
 }
 
 /** The domains an operator can ask to be widened into. */

--- a/apps/backend/src/api/partners/mcp/lib/tool-slice.ts
+++ b/apps/backend/src/api/partners/mcp/lib/tool-slice.ts
@@ -18,6 +18,8 @@
  * wrong costs a round trip, not a capability.
  */
 import type { McpToolDef } from "../../../../lib/mcp-core"
+// Submodule, not the barrel — see the admin slicer for why.
+import { widenedDomainsFromHistory as sharedWidenedDomainsFromHistory } from "../../../../lib/mcp-core/tool-slice"
 
 export type PartnerToolDomain =
   | "core"
@@ -342,33 +344,17 @@ export const LOAD_TOOLS_TOOL_NAME = "load_partner_tools"
  * Reads the RAW inbound messages (before the route's text-only normalisation),
  * and only ever returns known selectable domains, so a malformed or
  * adversarial history part can widen nothing it could not widen by asking.
+ *
+ * The parse is shared with the admin surface via lib/mcp-core; only the domain
+ * union and the load-tool name differ.
  */
 export function widenedDomainsFromHistory(
   rawMessages: unknown
 ): PartnerToolDomain[] {
-  const selectable = new Set<string>(SELECTABLE_DOMAINS)
-  const found = new Set<PartnerToolDomain>()
-
-  for (const m of Array.isArray(rawMessages) ? rawMessages : []) {
-    const parts = Array.isArray((m as any)?.parts) ? (m as any).parts : []
-    for (const p of parts) {
-      const isLoadCall =
-        p?.type === `tool-${LOAD_TOOLS_TOOL_NAME}` ||
-        (p?.type === "dynamic-tool" && p?.toolName === LOAD_TOOLS_TOOL_NAME)
-      if (!isLoadCall) continue
-      // The call's own args are the reliable half; the result echoes them back,
-      // so read both and let the allow-list below discard anything odd.
-      for (const d of [
-        ...(Array.isArray(p?.input?.domains) ? p.input.domains : []),
-        ...(Array.isArray(p?.output?.domains) ? p.output.domains : []),
-      ]) {
-        if (typeof d === "string" && selectable.has(d)) {
-          found.add(d as PartnerToolDomain)
-        }
-      }
-    }
-  }
-  return [...found]
+  return sharedWidenedDomainsFromHistory(rawMessages, {
+    loadToolName: LOAD_TOOLS_TOOL_NAME,
+    selectable: SELECTABLE_DOMAINS,
+  })
 }
 
 /** The domains a partner can ask to be widened into. */

--- a/apps/backend/src/lib/mcp-core/index.ts
+++ b/apps/backend/src/lib/mcp-core/index.ts
@@ -39,3 +39,4 @@ export {
   envFlagDefaultFalse,
 } from "./handler"
 export { makeMcpLogSink } from "./observability"
+export { widenedDomainsFromHistory } from "./tool-slice"

--- a/apps/backend/src/lib/mcp-core/tool-slice.ts
+++ b/apps/backend/src/lib/mcp-core/tool-slice.ts
@@ -1,0 +1,53 @@
+/**
+ * Slice bookkeeping shared by every MCP chat surface.
+ *
+ * The per-surface slicers (admin, partners) are deliberately parallel modules
+ * over different domain unions — that part is not duplication, it is two
+ * registries. But the rule for reading a widening back out of history is not
+ * surface-specific: it is a fact about the message shape the AI SDK emits, and
+ * it was copied byte-for-byte into both. Two copies of a parser is two places to
+ * fix when the transport changes its part shape.
+ */
+
+/**
+ * Domains the model already widened into earlier in THIS conversation.
+ *
+ * The slice is recomputed per HTTP request from keywords, and the chat routes
+ * strip tool parts from history — so without this a domain bought with a
+ * `load_*_tools` round trip on turn N is silently gone on turn N+1, and the
+ * model has no transcript evidence it ever had it. A follow-up like "now do the
+ * same for the other one" re-pays the widening AND burns one of the steps.
+ *
+ * Reads the RAW inbound messages (before a route's text-only normalisation),
+ * and only ever returns domains on `selectable`, so a malformed or adversarial
+ * history part can widen nothing it could not widen by asking.
+ */
+export function widenedDomainsFromHistory<D extends string>(
+  rawMessages: unknown,
+  opts: { loadToolName: string; selectable: readonly D[] }
+): D[] {
+  const selectable = new Set<string>(opts.selectable)
+  const found = new Set<D>()
+
+  for (const m of Array.isArray(rawMessages) ? rawMessages : []) {
+    const parts = Array.isArray((m as any)?.parts) ? (m as any).parts : []
+    for (const p of parts) {
+      const isLoadCall =
+        p?.type === `tool-${opts.loadToolName}` ||
+        (p?.type === "dynamic-tool" && p?.toolName === opts.loadToolName)
+      if (!isLoadCall) continue
+      // The call's own args are the reliable half; the result echoes them back,
+      // so read both and let the allow-list below discard anything odd.
+      for (const d of [
+        ...(Array.isArray(p?.input?.domains) ? p.input.domains : []),
+        ...(Array.isArray(p?.output?.domains) ? p.output.domains : []),
+      ]) {
+        if (typeof d === "string" && selectable.has(d)) {
+          found.add(d as D)
+        }
+      }
+    }
+  }
+
+  return [...found]
+}

--- a/apps/backend/src/modules/shipping-providers/bluedart/__tests__/bluedart-adapter.unit.spec.ts
+++ b/apps/backend/src/modules/shipping-providers/bluedart/__tests__/bluedart-adapter.unit.spec.ts
@@ -1,4 +1,4 @@
-import { BlueDartProviderAdapter } from "../adapter"
+import { BlueDartProviderAdapter, classifyBlueDartScan } from "../adapter"
 import {
   BlueDartClient,
   describeBlueDartFailure,
@@ -540,5 +540,33 @@ describe("BlueDartClient.trackShipment", () => {
     await expect(client.trackShipment("21089967146")).rejects.toThrow(
       /Incorrect waybill number or No information/
     )
+  })
+})
+
+describe("classifyBlueDartScan", () => {
+  // Order 83 sat on this exact scan for three days — booked 2026-08-14, still
+  // uncollected on 2026-08-17 — while Blue Dart's own StatusCode read
+  // `pre-transit`. Calling it "picked_up" made the timeline an operator reads to
+  // answer "has it been collected?" answer yes for a parcel on the shelf.
+  it("does not treat a registered pickup as a collection", () => {
+    expect(classifyBlueDartScan("PICKUP HAS BEEN REGISTERED")).toBe(
+      "pickup_scheduled"
+    )
+    expect(classifyBlueDartScan("Pickup Scheduled")).toBe("pickup_scheduled")
+    expect(classifyBlueDartScan("Awaiting Pickup")).toBe("pickup_scheduled")
+  })
+
+  it("still recognises a real collection", () => {
+    expect(classifyBlueDartScan("SHIPMENT PICKED UP")).toBe("picked_up")
+    expect(classifyBlueDartScan("Picked up from shipper")).toBe("picked_up")
+  })
+
+  it("keeps the rest of the mapping intact", () => {
+    expect(classifyBlueDartScan("SHIPMENT DELIVERED")).toBe("delivered")
+    expect(classifyBlueDartScan("OUT FOR DELIVERY")).toBe("out_for_delivery")
+    expect(classifyBlueDartScan("UNDELIVERED")).toBe("exception")
+    expect(classifyBlueDartScan("RTO INITIATED")).toBe("returned")
+    // An unrecognised live scan is in_transit, never delivered (#1206).
+    expect(classifyBlueDartScan("REACHED HUB")).toBe("in_transit")
   })
 })

--- a/apps/backend/src/modules/shipping-providers/bluedart/adapter.ts
+++ b/apps/backend/src/modules/shipping-providers/bluedart/adapter.ts
@@ -511,6 +511,14 @@ export function classifyBlueDartScan(status: string): string {
   const s = status.toLowerCase()
   if (/deliver/.test(s) && !/undeliver|out for deliver/.test(s)) return "delivered"
   if (/out for delivery/.test(s)) return "out_for_delivery"
+  // Registering a pickup is a REQUEST for a courier, not a collection. Blue Dart
+  // says "PICKUP HAS BEEN REGISTERED" the moment the booking lands and keeps
+  // saying it until someone physically collects — order 83 sat on that scan for
+  // three days while its own StatusCode read `pre-transit`. Matching /pick/
+  // first called that "picked_up", so the timeline an operator reads to answer
+  // "has it been collected?" answered yes for a parcel still on the shelf.
+  if (/pickup (has been )?(registered|scheduled|booked)|awaiting pickup/.test(s))
+    return "pickup_scheduled"
   if (/pick|collect|shipment picked/.test(s)) return "picked_up"
   if (/rto|return/.test(s)) return "returned"
   if (/cancel/.test(s)) return "cancelled"

--- a/apps/backend/src/subscribers/__tests__/shipment-created.unit.spec.ts
+++ b/apps/backend/src/subscribers/__tests__/shipment-created.unit.spec.ts
@@ -1,0 +1,76 @@
+import shipmentCreatedHandler from "../shipment-created"
+
+const mockRun = jest.fn()
+
+jest.mock("../../workflows/email/send-notification-email", () => ({
+  sendShipmentStatusEmail: jest.fn(() => ({ run: mockRun })),
+}))
+
+const buildContainer = (labels: any) => {
+  const logger = { error: jest.fn(), warn: jest.fn(), info: jest.fn() }
+  const query = {
+    graph: jest.fn(async () => ({ data: [{ id: "ful_1", labels }] })),
+  }
+
+  return {
+    logger,
+    query,
+    container: {
+      resolve: (key: string) => (key === "logger" ? logger : query),
+    } as any,
+  }
+}
+
+const run = async (labels: any, data: any = {}) => {
+  const ctx = buildContainer(labels)
+  await shipmentCreatedHandler({
+    event: { data: { id: "ful_1", ...data } },
+    container: ctx.container,
+  } as any)
+  return ctx
+}
+
+describe("shipment-created subscriber", () => {
+  beforeEach(() => {
+    mockRun.mockReset()
+  })
+
+  it("emails the customer when a label carries a tracking number", async () => {
+    await run([{ id: "fulla_1", tracking_number: "21091376574" }])
+
+    expect(mockRun).toHaveBeenCalledWith({
+      input: { shipment_id: "ful_1", status: "shipped" },
+    })
+  })
+
+  /**
+   * Order 83, 2026-08-17: core's create-shipment writes `labels: input.labels ??
+   * []` and the fulfillment write REPLACES rather than merges, so marking the
+   * order shipped without echoing the labels back deleted the Blue Dart label.
+   * The mail went out seconds later with an empty tracking block — "your items
+   * are on the way", nothing to click.
+   */
+  it("refuses to send a shipped notice with nothing to track", async () => {
+    const ctx = await run([])
+
+    expect(mockRun).not.toHaveBeenCalled()
+    expect(ctx.logger.error).toHaveBeenCalledWith(
+      expect.stringContaining("ful_1")
+    )
+  })
+
+  it("refuses when the labels exist but carry no number", async () => {
+    await run([{ id: "fulla_1", tracking_number: "" }])
+
+    expect(mockRun).not.toHaveBeenCalled()
+  })
+
+  it("still honours no_notification without querying at all", async () => {
+    const ctx = await run([{ id: "fulla_1", tracking_number: "X" }], {
+      no_notification: true,
+    })
+
+    expect(mockRun).not.toHaveBeenCalled()
+    expect(ctx.query.graph).not.toHaveBeenCalled()
+  })
+})

--- a/apps/backend/src/subscribers/shipment-created.ts
+++ b/apps/backend/src/subscribers/shipment-created.ts
@@ -1,6 +1,27 @@
 import { SubscriberArgs, type SubscriberConfig } from "@medusajs/framework"
+import { ContainerRegistrationKeys } from "@medusajs/framework/utils"
 import { sendShipmentStatusEmail } from "../workflows/email/send-notification-email"
 
+/**
+ * The shipped mail is built from the fulfillment's labels, and its whole point
+ * is the tracking number — the template says "Track the package below". With no
+ * labels it renders an empty tracking block: a "your items are on the way"
+ * notice the customer cannot act on.
+ *
+ * That is not hypothetical. Core's create-shipment writes `labels: input.labels
+ * ?? []`, and `updateFulfillment` REPLACES the labels collection rather than
+ * merging it — so marking an order shipped through the API without echoing the
+ * existing labels back DELETES them. Order 83 lost its Blue Dart label that way
+ * on 2026-08-17 and the customer was emailed a contentless shipped notice
+ * (`noti_01M075WC7Q7SQ6KM4C6B9CH6B2`) seconds later.
+ *
+ * `resend-shipment-email` (#1314) already refuses this exact case, on the
+ * grounds that a second wrong tracking mail is worse than the first. This is the
+ * same rule on the automatic path, which had no guard at all.
+ *
+ * ⚠️ Skipping is not silence: the fulfillment is named in the log, and the
+ * operator's recovery is to attach the waybill and run `resend-shipment-email`.
+ */
 export default async function shipmentCreatedHandler({
   event: { data },
   container,
@@ -9,6 +30,31 @@ export default async function shipmentCreatedHandler({
   no_notification?: boolean
 }>) {
   if (data.no_notification) {
+    return
+  }
+
+  const logger: any = container.resolve(ContainerRegistrationKeys.LOGGER)
+  const query: any = container.resolve(ContainerRegistrationKeys.QUERY)
+
+  // `labels.id` is selected alongside the scalars deliberately — the relation is
+  // what decides whether the mail has anything to say.
+  const { data: fulfillments } = await query.graph({
+    entity: "fulfillment",
+    filters: { id: data.id },
+    fields: ["id", "labels.id", "labels.tracking_number"],
+  })
+
+  const labels = fulfillments?.[0]?.labels
+  const hasTracking =
+    Array.isArray(labels) && labels.some((l: any) => l?.tracking_number)
+
+  if (!hasTracking) {
+    logger?.error?.(
+      `[shipment-created] Refusing to email the shipped notice for fulfillment ${data.id}: ` +
+        `it carries no tracking number on any label, so the mail would tell the customer ` +
+        `nothing they can follow. Attach the waybill, then run the ` +
+        `'resend-shipment-email' maintenance job.`
+    )
     return
   }
 


### PR DESCRIPTION
Found while discharging order 83's nine-day-old tracking promise on prod. Neither defect produced a wrong *value* — each answered a question someone was actually asking, wrongly.

## 1. The shipped mail had no guard

Core's `create-shipment` writes `labels: input.labels ?? []`, and the fulfillment write **REPLACES** the labels collection rather than merging it. So marking an order shipped through the API without echoing the existing labels back **deletes them**.

Order 83 lost its Blue Dart label exactly that way, and the `shipment.created` subscriber emailed the customer a contentless *"your items are on the way"* seconds later. The empty tracking block is in the prod notification log:

```
06:17:29  chiragtitiya6893@gmail.com  order-shipment-created  success
          tracking_numbers: []   tracking_links: []
```

`resend-shipment-email` (#1314) already refuses this exact case, on the grounds that a mail whose entire purpose is the tracking number is worse than silence when it carries none. The automatic path now applies the same rule, and names the fulfillment in the log so the recovery — attach the waybill, run `resend-shipment-email` — is discoverable rather than inferred.

⚠️ **Behaviour change:** a shipment genuinely booked without any waybill will now be silent where it previously sent an unusable mail. Deliberate, and logged loudly.

## 2. A registered pickup is not a collection

`classifyBlueDartScan` matched `/pick/` against `"PICKUP HAS BEEN REGISTERED"` and returned `picked_up` — while Blue Dart's own `StatusCode` in the same response read `pre-transit`. Order 83 sat on that scan for three days (booked 14 Aug, still uncollected 17 Aug), so the timeline an operator reads to answer *"has the courier taken it?"* answered **yes** for a parcel still on the shelf.

Registration scans now classify as `pickup_scheduled`; a real collection still reads `picked_up`. Both fall to the neutral default in the timeline UI, so nothing renders differently — this is a data-correctness fix.

## 3. Folded `widenedDomainsFromHistory` into `lib/mcp-core`

Carried across three handoffs. The two slicers are deliberately parallel modules over different domain unions, but the *history parse* is a fact about the AI SDK's message-part shape and had been copied byte-for-byte. Now one generic implementation parameterised by the load-tool name and the selectable list — the only two things that differed.

Imported from the submodule rather than the barrel on purpose: both slicers are otherwise type-only consumers of mcp-core, and pulling the barrel in for one function would drag dispatch/proxy/server into every context that slices a registry.

## Verification

- `bluedart-adapter` — 37 pass (3 new classifier cases)
- `shipment-created` — 4 new tests: sends with tracking, refuses without, refuses on a blank number, honours `no_notification` without querying
- `tool-slice` — **112 pass untouched** on both surfaces, which is what makes the fold provably behaviour-preserving rather than merely plausible
- `check:prod-build` green

Refs #1285

🤖 Generated with [Claude Code](https://claude.com/claude-code)