### PR TITLE
feat(mcp): settings screen for OAuth authorizations (#1309)

### DIFF
--- a/apps/backend/src/admin/hooks/api/mcp-oauth-tokens.ts
+++ b/apps/backend/src/admin/hooks/api/mcp-oauth-tokens.ts
@@ -1,0 +1,91 @@
+import { useMutation, useQuery, useQueryClient } from "@tanstack/react-query"
+
+import { sdk } from "../../lib/config"
+import { queryKeysFactory } from "../../lib/query-key-factory"
+import type {
+  AdminMcpOauthToken,
+  AdminUserSummary,
+} from "../../lib/mcp-oauth-token-state"
+
+/**
+ * OAuth authorizations issued by the Admin MCP front door (#1306 Track B).
+ *
+ * The counterpart to `/admin/mcp/scopes`: that says what a credential MAY do,
+ * this says which credentials EXIST and who let them in.
+ *
+ * ⚠️ Every one of these is a Medusa **user JWT** carrying an `mcp_oauth` claim —
+ * the framework 401s any other actor type on `/admin/*`, so no other shape was
+ * available. The consequence is worth showing an admin plainly: an
+ * authorization acts AS a person, and everything it does is attributed to them.
+ *
+ * The pure read-model lives in lib/mcp-oauth-token-state; this file is only the
+ * transport.
+ */
+
+export type {
+  AdminMcpOauthToken,
+  AdminUserSummary,
+  TokenState,
+} from "../../lib/mcp-oauth-token-state"
+export { describeUser, tokenState } from "../../lib/mcp-oauth-token-state"
+
+const MCP_OAUTH_TOKENS_QUERY_KEY = "mcp_oauth_tokens" as const
+export const mcpOauthTokenQueryKeys = queryKeysFactory(
+  MCP_OAUTH_TOKENS_QUERY_KEY
+)
+
+export const useMcpOauthTokens = () => {
+  const { data, ...rest } = useQuery({
+    queryKey: mcpOauthTokenQueryKeys.list(),
+    queryFn: async () =>
+      sdk.client.fetch<{ tokens: AdminMcpOauthToken[] }>(
+        "/admin/mcp/oauth-tokens",
+        { method: "GET" }
+      ),
+  })
+
+  return { ...rest, tokens: data?.tokens }
+}
+
+/**
+ * Revoke one authorization.
+ *
+ * Takes effect on the NEXT request, reads included — the access token is a
+ * self-verifying JWT, and what makes revocation immediate is the `/admin/*`
+ * global that reads this row on every request carrying an `mcp_oauth` claim.
+ */
+export const useRevokeMcpOauthToken = () => {
+  const queryClient = useQueryClient()
+
+  return useMutation({
+    mutationFn: async (id: string) =>
+      sdk.client.fetch<{ id: string; revoked: boolean }>(
+        `/admin/mcp/oauth-tokens/${id}`,
+        { method: "DELETE" }
+      ),
+    onSuccess: () => {
+      // `lists()` is the PREFIX ([key, "list"]); `list()` appends a `{query}`
+      // object, so invalidating with it would miss the query above.
+      queryClient.invalidateQueries({ queryKey: mcpOauthTokenQueryKeys.lists() })
+    },
+  })
+}
+
+/**
+ * Admin users, so an authorization can name the person it acts as rather than
+ * showing a bare `usr_…`.
+ */
+export const useAdminUserLookup = () => {
+  const { data, ...rest } = useQuery({
+    queryKey: [MCP_OAUTH_TOKENS_QUERY_KEY, "users"],
+    queryFn: async () =>
+      sdk.client.fetch<{ users: AdminUserSummary[] }>("/admin/users?limit=200", {
+        method: "GET",
+      }),
+  })
+
+  const byId: Record<string, AdminUserSummary> = {}
+  for (const u of data?.users || []) byId[u.id] = u
+
+  return { ...rest, usersById: byId }
+}

--- a/apps/backend/src/admin/lib/__tests__/mcp-oauth-token-state.unit.spec.ts
+++ b/apps/backend/src/admin/lib/__tests__/mcp-oauth-token-state.unit.spec.ts
@@ -1,0 +1,99 @@
+import {
+  describeUser,
+  tokenState,
+  type AdminMcpOauthToken,
+} from "../mcp-oauth-token-state"
+
+const NOW = new Date("2026-08-17T12:00:00Z").getTime()
+const past = "2026-08-17T11:00:00Z"
+const future = "2026-08-17T13:00:00Z"
+
+const token = (over: Partial<AdminMcpOauthToken> = {}): AdminMcpOauthToken => ({
+  id: "mcpt_1",
+  client_id: "mcpc_1",
+  client_name: "Claude",
+  user_id: "usr_1",
+  level: "read",
+  revoked_at: null,
+  last_used_at: null,
+  access_expires_at: future,
+  refresh_expires_at: future,
+  created_at: past,
+  ...over,
+})
+
+describe("tokenState", () => {
+  it("is active while both tokens are in date", () => {
+    expect(tokenState(token(), NOW)).toBe("active")
+  })
+
+  /**
+   * The distinction the whole screen hangs on: a lapsed ACCESS token is not a
+   * lapsed authorization. The client still holds a refresh token and will mint
+   * a new access token without anyone approving it again — so reporting this as
+   * "expired" would invite an admin to leave a live authorization in place.
+   */
+  it("reports a lapsed access token as refreshable, not expired", () => {
+    expect(
+      tokenState(
+        token({ access_expires_at: past, refresh_expires_at: future }),
+        NOW
+      )
+    ).toBe("refreshable")
+  })
+
+  it("is expired only once the refresh token has lapsed too", () => {
+    expect(
+      tokenState(
+        token({ access_expires_at: past, refresh_expires_at: past }),
+        NOW
+      )
+    ).toBe("expired")
+  })
+
+  it("reports revoked ahead of every expiry state", () => {
+    expect(
+      tokenState(
+        token({
+          revoked_at: past,
+          access_expires_at: past,
+          refresh_expires_at: past,
+        }),
+        NOW
+      )
+    ).toBe("revoked")
+  })
+
+  it("treats a missing expiry as not expired rather than as expired", () => {
+    expect(
+      tokenState(
+        token({ access_expires_at: null, refresh_expires_at: null }),
+        NOW
+      )
+    ).toBe("active")
+  })
+})
+
+describe("describeUser", () => {
+  it("falls back to the raw id when the user cannot be resolved", () => {
+    expect(describeUser(undefined, "usr_9")).toBe("usr_9")
+  })
+
+  it("prefers a name, and keeps the email alongside it", () => {
+    expect(
+      describeUser(
+        { id: "usr_1", email: "a@b.com", first_name: "Ada", last_name: "L" },
+        "usr_1"
+      )
+    ).toBe("Ada L (a@b.com)")
+  })
+
+  it("uses the email alone when there is no name", () => {
+    expect(
+      describeUser(
+        { id: "usr_1", email: "a@b.com", first_name: null, last_name: null },
+        "usr_1"
+      )
+    ).toBe("a@b.com")
+  })
+})

--- a/apps/backend/src/admin/lib/mcp-oauth-token-state.ts
+++ b/apps/backend/src/admin/lib/mcp-oauth-token-state.ts
@@ -1,0 +1,74 @@
+/**
+ * Pure read-model for OAuth authorizations (#1306 Track B).
+ *
+ * Split from the query hooks deliberately: those import the Medusa JS SDK,
+ * which is built for Vite and uses `import.meta`, so anything importing them is
+ * unloadable under Jest. Keeping the judgement calls here means the parts that
+ * can actually be wrong are the parts that can be tested.
+ */
+
+export type McpOauthLevel = "read" | "write" | "sensitive" | "dangerous"
+
+export type AdminMcpOauthToken = {
+  id: string
+  client_id: string
+  client_name: string | null
+  /** The admin this authorization acts as. */
+  user_id: string
+  level: McpOauthLevel
+  revoked_at: string | null
+  last_used_at: string | null
+  access_expires_at: string | null
+  refresh_expires_at: string | null
+  created_at: string
+}
+
+export type AdminUserSummary = {
+  id: string
+  email: string
+  first_name?: string | null
+  last_name?: string | null
+}
+
+export type TokenState = "revoked" | "expired" | "refreshable" | "active"
+
+/**
+ * An authorization is not simply on or off.
+ *
+ * A client whose ACCESS token has expired is not locked out — it still holds a
+ * refresh token and will mint a new one without asking anyone. Reporting that
+ * as "expired" would invite an admin to leave a live authorization in place
+ * believing it had lapsed on its own, which is the one misreading here that
+ * actually costs something.
+ *
+ * A missing expiry means "does not expire", never "expired" — failing the safe
+ * way round would hide a live authorization behind a dead-looking label.
+ */
+export const tokenState = (
+  t: AdminMcpOauthToken,
+  now: number = Date.now()
+): TokenState => {
+  if (t.revoked_at) return "revoked"
+
+  const refreshExpired =
+    !!t.refresh_expires_at && new Date(t.refresh_expires_at).getTime() <= now
+  if (refreshExpired) return "expired"
+
+  const accessExpired =
+    !!t.access_expires_at && new Date(t.access_expires_at).getTime() <= now
+  return accessExpired ? "refreshable" : "active"
+}
+
+/**
+ * Name the person an authorization acts as. "Acts as whom" is the whole
+ * security question, and a bare `usr_…` does not answer it — but falling back
+ * to the id beats rendering nothing when the lookup has not loaded.
+ */
+export const describeUser = (
+  user: AdminUserSummary | undefined,
+  userId: string
+): string => {
+  if (!user) return userId
+  const name = [user.first_name, user.last_name].filter(Boolean).join(" ").trim()
+  return name ? `${name} (${user.email})` : user.email
+}

--- a/apps/backend/src/admin/routes/settings/mcp-oauth-tokens/page.tsx
+++ b/apps/backend/src/admin/routes/settings/mcp-oauth-tokens/page.tsx
@@ -1,0 +1,269 @@
+import { defineRouteConfig } from "@medusajs/admin-sdk"
+import {
+  Badge,
+  Button,
+  Container,
+  Copy,
+  Heading,
+  Skeleton,
+  Text,
+  toast,
+  usePrompt,
+} from "@medusajs/ui"
+import { ShieldCheck } from "@medusajs/icons"
+
+import {
+  useAdminUserLookup,
+  useMcpOauthTokens,
+  useRevokeMcpOauthToken,
+} from "../../../hooks/api/mcp-oauth-tokens"
+import {
+  describeUser,
+  tokenState,
+  type AdminMcpOauthToken,
+  type TokenState,
+} from "../../../lib/mcp-oauth-token-state"
+
+/**
+ * Settings → MCP OAuth Authorizations (#1306 Track B).
+ *
+ * The API to list and revoke these landed with the front door; this is the
+ * screen for it. Without one, revoking a client meant knowing an `mcpt_…` id
+ * nobody had ever been shown.
+ *
+ * Two facts drive the whole layout, because both are easy to get wrong and
+ * expensive to get wrong:
+ *
+ * 1. An authorization is a **user JWT** — it acts AS an admin, and everything
+ *    it does is attributed to that person. So the person is displayed as
+ *    prominently as the client, by name rather than by `usr_…`.
+ * 2. An expired ACCESS token is not a lapsed authorization — the client still
+ *    holds a refresh token and will quietly mint a new one. That state is
+ *    labelled "access expired · will refresh" rather than "expired", so nobody
+ *    leaves a live authorization in place believing it died of old age.
+ */
+
+const STATE_LABEL: Record<TokenState, string> = {
+  active: "Active",
+  refreshable: "Access expired · will refresh",
+  expired: "Expired",
+  revoked: "Revoked",
+}
+
+const STATE_COLOR: Record<TokenState, "green" | "orange" | "grey" | "red"> = {
+  active: "green",
+  refreshable: "orange",
+  expired: "grey",
+  revoked: "red",
+}
+
+const levelColor = (level: string) =>
+  level === "read"
+    ? "grey"
+    : level === "write"
+      ? "blue"
+      : level === "sensitive"
+        ? "orange"
+        : "red"
+
+const formatWhen = (value: string | null): string => {
+  if (!value) return "never"
+  const d = new Date(value)
+  return Number.isNaN(d.getTime()) ? "unknown" : d.toLocaleString()
+}
+
+const McpOauthTokensPage = () => {
+  const prompt = usePrompt()
+  const { tokens, isLoading } = useMcpOauthTokens()
+  const { usersById } = useAdminUserLookup()
+  const revoke = useRevokeMcpOauthToken()
+
+  // The dashboard is served by the backend, so its origin IS the resource
+  // server an MCP client should be pointed at.
+  const mountUrl =
+    typeof window !== "undefined" ? `${window.location.origin}/mcp/admin` : "/mcp/admin"
+
+  // "Live" means still able to reach the API — so a `refreshable` one counts
+  // (it mints a new access token on its own) but an `expired` one does not.
+  const live = (tokens || []).filter((t) => {
+    const s = tokenState(t)
+    return s === "active" || s === "refreshable"
+  })
+
+  const onRevoke = async (t: AdminMcpOauthToken) => {
+    const who = describeUser(usersById[t.user_id], t.user_id)
+    const ok = await prompt({
+      title: `Revoke ${t.client_name || t.client_id}?`,
+      description:
+        `This takes effect on the client's very next request, reads included. ` +
+        `${who} will have to authorize it again from scratch to restore access. ` +
+        `The client is not told — it will simply start receiving 401s. Continue?`,
+      confirmText: "Revoke",
+      cancelText: "Cancel",
+    })
+    if (!ok) return
+
+    try {
+      await revoke.mutateAsync(t.id)
+      toast.success(`Revoked ${t.client_name || t.client_id}`)
+    } catch (e: any) {
+      toast.error(e?.message || "Failed to revoke")
+    }
+  }
+
+  return (
+    <Container className="divide-y p-0">
+      <div className="flex items-start justify-between gap-4 px-6 py-4">
+        <div>
+          <Heading>MCP OAuth Authorizations</Heading>
+          <Text className="text-ui-fg-subtle" size="small">
+            External clients — Claude, ChatGPT, Cursor — that an admin has
+            authorized to act on their behalf over MCP. Each one is revocable
+            here, and takes effect immediately.
+          </Text>
+        </div>
+        {!isLoading && (
+          <Badge size="2xsmall" color={live.length ? "green" : "grey"}>
+            {live.length} live
+          </Badge>
+        )}
+      </div>
+
+      <div className="flex flex-col gap-2 px-6 py-4">
+        <Text size="small" weight="plus">
+          Connect a client
+        </Text>
+        <div className="flex items-center gap-2">
+          <Text size="small" className="font-mono text-ui-fg-subtle">
+            {mountUrl}
+          </Text>
+          <Copy content={mountUrl} />
+        </div>
+        <Text size="small" className="text-ui-fg-subtle">
+          Give a client this URL — it discovers the authorization server on its
+          own and sends the admin here to sign in and consent. Nothing needs to
+          be created in advance; the authorization appears below once granted.
+        </Text>
+      </div>
+
+      <div className="px-6 py-4">
+        <Text size="small" className="text-ui-fg-subtle">
+          <span className="text-ui-fg-base">How much can these do?</span> An
+          authorization is a signed-in admin session scoped to a level, not a
+          lesser kind of credential — on any route the per-tier guard does not
+          cover it is as capable as the dashboard. Narrow one further under{" "}
+          <span className="text-ui-fg-base">MCP Access Scopes</span>, which keys
+          on the authorization id shown below.
+        </Text>
+      </div>
+
+      <div className="px-6 py-4">
+        {isLoading ? (
+          <div className="flex flex-col gap-2">
+            <Skeleton className="h-16 w-full" />
+            <Skeleton className="h-16 w-full" />
+          </div>
+        ) : !tokens?.length ? (
+          <Text size="small" className="text-ui-fg-subtle">
+            No client has been authorized yet. Point one at the URL above to
+            create the first authorization.
+          </Text>
+        ) : (
+          <div className="flex flex-col gap-2">
+            {tokens.map((t) => {
+              const state = tokenState(t)
+              const who = describeUser(usersById[t.user_id], t.user_id)
+
+              return (
+                <div
+                  key={t.id}
+                  data-testid={`mcp-oauth-token-row-${t.id}`}
+                  className="flex items-start justify-between gap-4 rounded-lg border border-ui-border-base px-4 py-3"
+                >
+                  <div className="flex min-w-0 flex-col gap-1">
+                    <div className="flex flex-wrap items-center gap-2">
+                      <Text size="small" weight="plus">
+                        {t.client_name || t.client_id}
+                      </Text>
+                      <Badge size="2xsmall" color={STATE_COLOR[state]}>
+                        {STATE_LABEL[state]}
+                      </Badge>
+                      <Badge size="2xsmall" color={levelColor(t.level)}>
+                        {t.level}
+                      </Badge>
+                    </div>
+
+                    {/* An OAuth token IS this person's session. Say so. */}
+                    <Text size="small" className="text-ui-fg-subtle" leading="compact">
+                      Acts as <span className="text-ui-fg-base">{who}</span>
+                    </Text>
+
+                    <Text
+                      size="small"
+                      className="truncate font-mono text-ui-fg-subtle"
+                      leading="compact"
+                    >
+                      {t.id} · {t.client_id}
+                    </Text>
+
+                    <Text size="small" className="text-ui-fg-subtle" leading="compact">
+                      Authorized {formatWhen(t.created_at)} · last used{" "}
+                      {formatWhen(t.last_used_at)}
+                      {t.revoked_at && ` · revoked ${formatWhen(t.revoked_at)}`}
+                    </Text>
+
+                    {/* Stated outright rather than hidden behind a hover: this
+                        is the one state an admin is likely to misread as
+                        "it has lapsed on its own, leave it". */}
+                    {state === "refreshable" && (
+                      <Text
+                        size="small"
+                        className="text-ui-fg-subtle"
+                        leading="compact"
+                      >
+                        Its access token has lapsed, but its refresh token has
+                        not — this client can mint a new one without anyone
+                        approving it again.{" "}
+                        <span className="text-ui-fg-base">
+                          Revoke to actually stop it.
+                        </span>
+                      </Text>
+                    )}
+                  </div>
+
+                  <div className="flex shrink-0 items-center gap-2">
+                    {state === "revoked" ? (
+                      <Text size="small" className="text-ui-fg-muted">
+                        Revoked
+                      </Text>
+                    ) : (
+                      <Button
+                        size="small"
+                        variant="danger"
+                        disabled={revoke.isPending}
+                        onClick={() => onRevoke(t)}
+                      >
+                        Revoke
+                      </Button>
+                    )}
+                  </div>
+                </div>
+              )
+            })}
+          </div>
+        )}
+      </div>
+    </Container>
+  )
+}
+
+export default McpOauthTokensPage
+
+export const config = defineRouteConfig({
+  label: "MCP OAuth Authorizations",
+  icon: ShieldCheck,
+})
+
+export const handle = {
+  breadcrumb: () => "MCP OAuth Authorizations",
+}


### PR DESCRIPTION
#1318 shipped the OAuth front door and the API to list and revoke what it issues, but no screen for it — so revoking a client meant knowing an `mcpt_…` id nobody had ever been shown. This is that screen, sitting alongside the existing **MCP Access Scopes** page.

## What it shows

Every authorization the front door has issued: client name, the admin it acts as, its level, when it was authorized, when it was last used, and one **Revoke** button that takes effect on the client's next request.

## Two facts drive the layout

Both are easy to misread, and expensive to misread.

**1. An authorization acts AS a person.** The access token is a Medusa `user` JWT carrying an `mcp_oauth` claim — the framework 401s every other actor type on `/admin/*`, so nothing else was available. Every action it takes is attributed to that admin. So the page names them —

> Acts as **Ada L (ada@example.com)**

— rather than printing a bare `usr_…`, and the revoke confirmation says whose access is being taken away and that the client is not told, it simply starts receiving 401s.

**2. An expired access token is not a lapsed authorization.** The client still holds a refresh token and will mint a new access token without anyone approving it again. Reporting that as "expired" would invite an admin to leave a live authorization in place believing it had died of old age. So it reads:

> **Access expired · will refresh** — its access token has lapsed, but its refresh token has not. This client can mint a new one without anyone approving it again. **Revoke to actually stop it.**

Stated in the row rather than hidden behind a tooltip, precisely because it is the state most likely to be misread. The "live" count follows the same rule: a `refreshable` authorization counts, an `expired` one does not.

## Also

- The mount URL (`…/mcp/admin`) with a copy button. It is not guessable and lives nowhere a human would look — a client is pointed at it and discovers the authorization server on its own, so nothing has to be created in advance.
- A note that an authorization is a signed-in admin session scoped to a level, not a lesser kind of credential, pointing at MCP Access Scopes to narrow one further.

## Structure

The pure read-model is split into `admin/lib/mcp-oauth-token-state` so it can be tested at all — the query hooks import the Medusa JS SDK, which is built for Vite and uses `import.meta`, making anything that imports them unloadable under Jest. The hook file re-exports it, so callers see one module.

## Verification

- **8 unit tests** over the state machine (`active` / `refreshable` / `expired` / `revoked`, revoked outranking every expiry, a missing expiry meaning "does not expire" rather than "expired") and the user-naming fallback
- `check:prod-build` green — it compiles the admin frontend, which is the real gate for a new page

⚠️ Compile- and test-verified, **not yet viewed in a browser**; it has no live authorization to render against until a real client connects.

Refs #1306, #1309

🤖 Generated with [Claude Code](https://claude.com/claude-code)