### PR TITLE
fix(shipping): the LIVE tracking path also called a registered pickup a collection

### DIFF
--- a/apps/backend/src/modules/shipping-providers/__tests__/dhl-unified-tracking.unit.spec.ts
+++ b/apps/backend/src/modules/shipping-providers/__tests__/dhl-unified-tracking.unit.spec.ts
@@ -105,8 +105,38 @@ describe("classifyDhlStatus", () => {
     expect(classifyDhlStatus("failure", "Delivery exception")).toBe("exception")
   })
 
-  it("reads a pickup scan as picked_up", () => {
-    expect(classifyDhlStatus("pre-transit", "PICKUP HAS BEEN REGISTERED")).toBe("picked_up")
+  /**
+   * This test used to assert the opposite, and that is why the defect survived:
+   * "PICKUP HAS BEEN REGISTERED" is what Blue Dart emits when a pickup is
+   * BOOKED, and it keeps emitting it until someone physically collects. Order
+   * 83 sat on this exact scan from 14 to 17 Aug 2026 — uncollected — while the
+   * timeline told operators it had been picked up. Note the statusCode in the
+   * same payload: `pre-transit`. The carrier was contradicting us in the very
+   * response we were misreading.
+   */
+  it("does not read a REGISTERED pickup as a collection", () => {
+    expect(classifyDhlStatus("pre-transit", "PICKUP HAS BEEN REGISTERED")).toBe(
+      "pickup_scheduled"
+    )
+    expect(classifyDhlStatus("pre-transit", "Pickup Scheduled")).toBe(
+      "pickup_scheduled"
+    )
+    expect(classifyDhlStatus("pre-transit", "AWAITING PICKUP")).toBe(
+      "pickup_scheduled"
+    )
+  })
+
+  it("still reads a real collection as picked_up", () => {
+    expect(classifyDhlStatus("transit", "SHIPMENT PICKED UP")).toBe("picked_up")
+    expect(classifyDhlStatus("transit", "Shipment collected from shipper")).toBe(
+      "picked_up"
+    )
+  })
+
+  it("keeps reading a cancelled pickup as cancelled, not scheduled", () => {
+    expect(classifyDhlStatus("pre-transit", "PICKUP HAS BEEN CANCELLED")).toBe(
+      "cancelled"
+    )
   })
 
   it("never guesses delivered for an unrecognised scan", () => {

--- a/apps/backend/src/modules/shipping-providers/dhl-unified-tracking.ts
+++ b/apps/backend/src/modules/shipping-providers/dhl-unified-tracking.ts
@@ -159,6 +159,20 @@ export function classifyDhlStatus(
   if (/out for delivery/.test(d)) return "out_for_delivery"
   if (/undeliver|delivery attempt failed|refused/.test(d)) return "exception"
   if (/cancel/.test(d)) return "cancelled"
+  // Registering a pickup is a REQUEST for a courier, not a collection. Blue
+  // Dart emits "PICKUP HAS BEEN REGISTERED" the moment the booking lands and
+  // keeps emitting it until someone physically collects — order 83 sat on that
+  // scan for three days while the SAME payload's statusCode read `pre-transit`.
+  // The old `/pickup has been/` branch was written for this exact string and
+  // called it `picked_up`, so the timeline an operator reads to answer "has the
+  // courier taken it?" said yes for a parcel still on the shelf.
+  if (
+    /pickup (has been )?(registered|scheduled|booked|arranged)|awaiting pickup|pickup requested/.test(
+      d
+    )
+  ) {
+    return "pickup_scheduled"
+  }
   if (/picked up|pickup has been|shipment collected/.test(d)) return "picked_up"
   if (/delivered/.test(d) && !/undelivered/.test(d)) return "delivered"
 


### PR DESCRIPTION
#1319 fixed `classifyBlueDartScan`, merged green, deployed green — and **prod kept answering `picked_up`**. Caught by probing the deployed behaviour rather than reading the deploy badge.

## Why the first fix did nothing

`BlueDartProviderAdapter.track()` (`adapter.ts:340`) returns `normalizeDhlUnifiedTracking` whenever a DHL Unified client is configured, and only falls back to `normalizeBlueDartTracking` when it is not. **On prod it is configured** — so `classifyBlueDartScan`, the function #1319 fixed, is the fallback path. The live classifier is `classifyDhlStatus`, which carried its own copy of the same mistake.

## The mistake was deliberate, and pinned by a test

```ts
if (/picked up|pickup has been|shipment collected/.test(d)) return "picked_up"
```

```ts
it("reads a pickup scan as picked_up", () =>
  expect(classifyDhlStatus("pre-transit", "PICKUP HAS BEEN REGISTERED")).toBe("picked_up"))
```

`/pickup has been/` was written **for that exact string**. So the suite was green, #1319's own new tests were green, and the defect was load-bearing in a test asserting it.

Order 83 sat on that scan — **uncollected** — from 14 to 17 Aug 2026, while the timeline told operators the courier had taken it. The `statusCode` in the same payload read `pre-transit` the whole time: the carrier was contradicting us inside the very response we were misreading.

## The fix

Registration, scheduling and "awaiting pickup" classify as `pickup_scheduled`. A real collection still reads `picked_up`. A cancelled pickup still reads `cancelled` — that branch runs first, and there is now a test holding it there.

The test that asserted the defect now asserts against it, and carries the reason it existed.

## Verification

- `dhl-unified-tracking` — **13 pass**, including the corrected assertion and two new guards
- `check:prod-build` green
- ⏳ The real check is re-probing order 83's tracking route after deploy and seeing `pickup_scheduled`. That is the only thing that proves this one, given how the last attempt went.

Refs #1285

🤖 Generated with [Claude Code](https://claude.com/claude-code)