### PR TITLE
feat(partner-assistant): build products from photos shared in chat

### DIFF
--- a/apps/backend/integration-tests/http/partner-assistant-attachments.spec.ts
+++ b/apps/backend/integration-tests/http/partner-assistant-attachments.spec.ts
@@ -1,0 +1,250 @@
+/**
+ * POST /partners/assistant/attachments — photos shared with the partner
+ * assistant.
+ *
+ * The pre-existing `/partners/medias/uploads/*` pair puts objects at the bucket
+ * ROOT and writes no media record at all, so an uploaded photo becomes
+ * unattributable the moment the chat ends. These tests pin the properties that
+ * fix is made of: a real media row, in a folder owned by the uploading partner,
+ * reused across uploads, with the bytes intact.
+ */
+import fs from "fs"
+import path from "path"
+import FormData from "form-data"
+import { getSharedTestEnv, setupSharedTestSuite } from "./shared-test-setup"
+import { MEDIA_MODULE } from "../../src/modules/media"
+import { assistantFolderSlug } from "../../src/api/partners/assistant/attachments/folder-naming"
+
+const TEST_PARTNER_PASSWORD = "supersecret"
+
+jest.setTimeout(60 * 1000)
+
+setupSharedTestSuite(() => {
+  const { api, getContainer } = getSharedTestEnv()
+
+  describe("Partner assistant attachments", () => {
+    let partnerHeaders: Record<string, string>
+    let partnerId: string
+    let partnerName: string
+
+    /** A real JPEG whose body walks every byte 0x00-0xFF, so any latin1/UTF-8
+     *  round trip (#769) changes its length and magic bytes. */
+    const buildBinaryImage = (): Buffer => {
+      const body: number[] = []
+      for (let rep = 0; rep < 4; rep++) {
+        for (let b = 0; b <= 255; b++) body.push(b)
+      }
+      return Buffer.concat([
+        Buffer.from([0xff, 0xd8, 0xff, 0xe0]),
+        Buffer.from(body),
+        Buffer.from([0xff, 0xd9]),
+      ])
+    }
+
+    const readStoredFile = (filePath: string): Buffer | null => {
+      const marker = "/static/"
+      const idx = filePath.indexOf(marker)
+      if (idx === -1) return null
+      const key = decodeURIComponent(filePath.slice(idx + marker.length))
+      const onDisk = path.join(process.cwd(), "static", key)
+      return fs.existsSync(onDisk) ? fs.readFileSync(onDisk) : null
+    }
+
+    const upload = async (
+      files: Array<{ buf: Buffer; filename: string; contentType: string }>,
+      conversationId?: string
+    ) => {
+      const form = new FormData()
+      for (const f of files) {
+        form.append("files", f.buf, {
+          filename: f.filename,
+          contentType: f.contentType,
+        })
+      }
+      if (conversationId) form.append("conversation_id", conversationId)
+      return api.post("/partners/assistant/attachments", form, {
+        headers: { ...partnerHeaders, ...form.getHeaders() },
+      })
+    }
+
+    /** axios rejects on 4xx, so error responses have to be unwrapped rather
+     *  than returned — without this a correct 400 reads as a test failure. */
+    const expectFailure = async (fn: () => Promise<any>) => {
+      try {
+        const res = await fn()
+        throw new Error(
+          `Expected the request to fail, but it returned ${res.status}`
+        )
+      } catch (e: any) {
+        if (!e?.response) throw e
+        return e.response
+      }
+    }
+
+    beforeEach(async () => {
+      const unique = Date.now()
+      const partnerEmail = `partner-att-${unique}@medusa-test.com`
+      partnerName = `Pashmina Att ${unique}`
+
+      await api.post("/auth/partner/emailpass/register", {
+        email: partnerEmail,
+        password: TEST_PARTNER_PASSWORD,
+      })
+      const login1 = await api.post("/auth/partner/emailpass", {
+        email: partnerEmail,
+        password: TEST_PARTNER_PASSWORD,
+      })
+      partnerHeaders = { Authorization: `Bearer ${login1.data.token}` }
+
+      const partnerRes = await api.post(
+        "/partners",
+        {
+          name: partnerName,
+          handle: `pashmina-att-${unique}`,
+          admin: {
+            email: partnerEmail,
+            first_name: "Admin",
+            last_name: "Att",
+          },
+        },
+        { headers: partnerHeaders }
+      )
+      partnerId = partnerRes.data.partner.id
+
+      const login2 = await api.post("/auth/partner/emailpass", {
+        email: partnerEmail,
+        password: TEST_PARTNER_PASSWORD,
+      })
+      partnerHeaders = { Authorization: `Bearer ${login2.data.token}` }
+    })
+
+    it("stores each photo as a media record inside a folder owned by the partner", async () => {
+      const res = await upload(
+        [
+          { buf: buildBinaryImage(), filename: "shawl-1.jpg", contentType: "image/jpeg" },
+          { buf: buildBinaryImage(), filename: "shawl-2.jpg", contentType: "image/jpeg" },
+        ],
+        "chat_abc"
+      )
+
+      expect(res.status).toBe(201)
+      expect(res.data.attachments).toHaveLength(2)
+      for (const a of res.data.attachments) {
+        expect(a.url).toBeTruthy()
+        expect(a.media_id).toBeTruthy()
+        expect(a.type).toBe("image/jpeg")
+      }
+
+      const mediaService: any = getContainer().resolve(MEDIA_MODULE)
+      const folders = await mediaService.listFolders({
+        slug: assistantFolderSlug(partnerId),
+      })
+      expect(folders).toHaveLength(1)
+      expect(folders[0].id).toBe(res.data.folder_id)
+      expect(folders[0].name).toContain(partnerName)
+      expect(folders[0].metadata?.partner_id).toBe(partnerId)
+
+      // The media rows live IN that folder — this is the whole difference from
+      // the bucket-root path, so assert the link rather than just the row.
+      const files = await mediaService.listMediaFiles({
+        folder_id: folders[0].id,
+      })
+      expect(files).toHaveLength(2)
+      for (const f of files) {
+        expect(f.metadata?.uploaded_by_partner_id).toBe(partnerId)
+        expect(f.metadata?.conversation_id).toBe("chat_abc")
+        expect(f.metadata?.source).toBe("partner_assistant")
+      }
+    })
+
+    it("keeps the image bytes intact", async () => {
+      // #769: content passed as latin1 rather than base64 is UTF-8 re-encoded,
+      // inflating the file ~1.5x and rewriting the magic bytes — the image
+      // uploads "successfully" and no vision model can read it.
+      const original = buildBinaryImage()
+      const res = await upload(
+        [{ buf: original, filename: "integrity.jpg", contentType: "image/jpeg" }],
+        "chat_bytes"
+      )
+      expect(res.status).toBe(201)
+
+      const stored = readStoredFile(res.data.attachments[0].url)
+      expect(stored).not.toBeNull()
+      expect(stored!.length).toBe(original.length)
+      expect(stored!.equals(original)).toBe(true)
+    })
+
+    it("reuses the same folder across separate uploads", async () => {
+      // Photos arrive a few at a time across several messages. Each batch must
+      // land in the SAME folder — a per-upload folder would scatter one
+      // conversation's photos across many.
+      const first = await upload(
+        [{ buf: buildBinaryImage(), filename: "a.jpg", contentType: "image/jpeg" }],
+        "chat_same"
+      )
+      const second = await upload(
+        [{ buf: buildBinaryImage(), filename: "b.jpg", contentType: "image/jpeg" }],
+        "chat_same"
+      )
+
+      expect(first.status).toBe(201)
+      expect(second.status).toBe(201)
+      expect(second.data.folder_id).toBe(first.data.folder_id)
+
+      const mediaService: any = getContainer().resolve(MEDIA_MODULE)
+      const folders = await mediaService.listFolders({
+        slug: assistantFolderSlug(partnerId),
+      })
+      expect(folders).toHaveLength(1)
+
+      const files = await mediaService.listMediaFiles({
+        folder_id: first.data.folder_id,
+      })
+      expect(files).toHaveLength(2)
+    })
+
+    it("refuses non-image uploads instead of attaching something unreadable", async () => {
+      const res = await expectFailure(() =>
+        upload(
+          [
+            {
+              buf: Buffer.from("not an image"),
+              filename: "notes.txt",
+              contentType: "text/plain",
+            },
+          ],
+          "chat_bad"
+        )
+      )
+      expect(res.status).toBe(400)
+      expect(String(res.data.message)).toMatch(/only image uploads/i)
+
+      // Nothing was stored — a rejected batch must not leave a half-written
+      // folder or an orphan media row behind.
+      const mediaService: any = getContainer().resolve(MEDIA_MODULE)
+      const folders = await mediaService.listFolders({
+        slug: assistantFolderSlug(partnerId),
+      })
+      if (folders.length) {
+        const files = await mediaService.listMediaFiles({
+          folder_id: folders[0].id,
+        })
+        expect(files).toHaveLength(0)
+      }
+    })
+
+    it("rejects an unauthenticated upload", async () => {
+      const form = new FormData()
+      form.append("files", buildBinaryImage(), {
+        filename: "x.jpg",
+        contentType: "image/jpeg",
+      })
+      const res = await expectFailure(() =>
+        api.post("/partners/assistant/attachments", form, {
+          headers: form.getHeaders(),
+        })
+      )
+      expect([401, 403]).toContain(res.status)
+    })
+  })
+})

--- a/apps/backend/integration-tests/http/partner-assistant-attachments.spec.ts
+++ b/apps/backend/integration-tests/http/partner-assistant-attachments.spec.ts
@@ -14,6 +14,7 @@ import FormData from "form-data"
 import { getSharedTestEnv, setupSharedTestSuite } from "./shared-test-setup"
 import { MEDIA_MODULE } from "../../src/modules/media"
 import { assistantFolderSlug } from "../../src/api/partners/assistant/attachments/folder-naming"
+import { loadConversationAttachments } from "../../src/api/partners/assistant/chat/attachments"
 
 const TEST_PARTNER_PASSWORD = "supersecret"
 
@@ -201,6 +202,49 @@ setupSharedTestSuite(() => {
         folder_id: first.data.folder_id,
       })
       expect(files).toHaveLength(2)
+    })
+
+    it("recovers a conversation's photos later, oldest first, and only that conversation's", async () => {
+      // This is what makes "upload a few now, build the product later" work.
+      // Message history arrives text-only, so the photos have to be recovered
+      // from the folder — and scoped, or one chat's photos would leak into
+      // another's context.
+      await upload(
+        [{ buf: buildBinaryImage(), filename: "first.jpg", contentType: "image/jpeg" }],
+        "chat_one"
+      )
+      await upload(
+        [{ buf: buildBinaryImage(), filename: "second.jpg", contentType: "image/jpeg" }],
+        "chat_one"
+      )
+      await upload(
+        [{ buf: buildBinaryImage(), filename: "other.jpg", contentType: "image/jpeg" }],
+        "chat_two"
+      )
+
+      const recovered = await loadConversationAttachments(
+        getContainer(),
+        partnerId,
+        "chat_one"
+      )
+      expect(recovered.map((a) => a.name)).toEqual(["first.jpg", "second.jpg"])
+      for (const a of recovered) expect(a.url).toBeTruthy()
+
+      const otherChat = await loadConversationAttachments(
+        getContainer(),
+        partnerId,
+        "chat_two"
+      )
+      expect(otherChat.map((a) => a.name)).toEqual(["other.jpg"])
+
+      // An unknown conversation, and a missing one, both yield nothing rather
+      // than falling back to "all this partner's photos".
+      expect(
+        await loadConversationAttachments(getContainer(), partnerId, "chat_nope")
+      ).toEqual([])
+      expect(
+        await loadConversationAttachments(getContainer(), partnerId, undefined)
+      ).toEqual([])
     })
 
     it("refuses non-image uploads instead of attaching something unreadable", async () => {

--- a/apps/backend/integration-tests/http/partner-assistant-conversations-api.spec.ts
+++ b/apps/backend/integration-tests/http/partner-assistant-conversations-api.spec.ts
@@ -132,6 +132,55 @@ setupSharedTestSuite(() => {
       expect(res.data.conversation.messages).toHaveLength(2)
     })
 
+    it("persists thread_key and KEEPS it through later message-only PATCHes", async () => {
+      // thread_key ties a conversation to the photos uploaded during it. It is
+      // written once, on the first save, and every later PATCH sends only
+      // title/messages — so a metadata write that REPLACED rather than merged
+      // would silently drop it on the very next turn and orphan the photos.
+      // The reopened conversation would then look fine and simply have no
+      // photos, which is exactly the kind of failure nobody reports as a bug.
+      const post = await api.post(
+        "/partners/assistant/conversations",
+        {
+          title: "Pashmina photos",
+          messages: SAMPLE_MESSAGES,
+          metadata: { thread_key: "chat_abc123" },
+        },
+        { headers: partner.headers }
+      )
+      expect(post.status).toBe(201)
+      expect(post.data.conversation.metadata?.thread_key).toBe("chat_abc123")
+      const id = post.data.conversation.id
+
+      // A normal follow-up turn: messages only, no metadata.
+      const patched = await api.patch(
+        `/partners/assistant/conversations/${id}`,
+        {
+          messages: [
+            ...SAMPLE_MESSAGES,
+            { id: "m3", role: "user", parts: [{ type: "text", text: "More" }] },
+          ],
+        },
+        { headers: partner.headers }
+      )
+      expect(patched.status).toBe(200)
+      expect(patched.data.conversation.messages).toHaveLength(3)
+      expect(patched.data.conversation.metadata?.thread_key).toBe("chat_abc123")
+
+      // And a metadata PATCH must not wipe sibling keys either.
+      await api.patch(
+        `/partners/assistant/conversations/${id}`,
+        { metadata: { something_else: true } },
+        { headers: partner.headers }
+      )
+      const get = await api.get(
+        `/partners/assistant/conversations/${id}`,
+        { headers: partner.headers }
+      )
+      expect(get.data.conversation.metadata?.thread_key).toBe("chat_abc123")
+      expect(get.data.conversation.metadata?.something_else).toBe(true)
+    })
+
     it("DELETE removes the conversation", async () => {
       const post = await api.post(
         "/partners/assistant/conversations",

--- a/apps/backend/integration-tests/http/partners-products-multi-variant.spec.ts
+++ b/apps/backend/integration-tests/http/partners-products-multi-variant.spec.ts
@@ -1,0 +1,514 @@
+/**
+ * Multi-variant product creation through POST /partners/products — the exact
+ * path the partner assistant's `create_product` tool dispatches to.
+ *
+ * The existing partners-products spec only ever creates ONE option with ONE
+ * value and ONE variant, so nothing pinned what happens when a partner says
+ * "create Mill Spun and Hand Spun Pashmina". These tests pin three things that
+ * the assistant feature depends on and that a single-variant test cannot see:
+ *
+ *   1. EVERY named variant is created, with its option value mapped correctly
+ *      — not just the first, and not a cartesian product nobody asked for.
+ *   2. EVERY managed variant gets its OWN inventory item AND a location level
+ *      at the store's stock location. `ensureInventoryLevelsForVariants` loops,
+ *      so a per-variant assertion is the only thing that proves the loop ran to
+ *      the end rather than seeding variant #1 and stopping.
+ *   3. Status defaults to DRAFT when the caller omits it, and only becomes
+ *      published when explicitly asked. "draft unless asked" is the assistant's
+ *      contract with the partner, so it belongs in a test rather than a prompt.
+ *
+ * NOTE: this partner has no onboarding profile, so `selling_mode` is undefined
+ * and the `core_channel_listing` override (products/route.ts) does not apply.
+ * A core-channel artisan is forced to `proposed` regardless of what is asked
+ * for — that is a separate case and is asserted in its own test below.
+ */
+import { getSharedTestEnv, setupSharedTestSuite } from "./shared-test-setup"
+import { createAdminUser, getAuthHeaders } from "../helpers/create-admin-user"
+import { ProductStatus } from "@medusajs/framework/utils"
+
+const TEST_PARTNER_PASSWORD = "supersecret"
+
+jest.setTimeout(60 * 1000)
+
+setupSharedTestSuite(() => {
+  const { api, getContainer } = getSharedTestEnv()
+
+  describe("Partner API - multi-variant product creation", () => {
+    let adminHeaders: Record<string, any>
+    let partnerHeaders: Record<string, string>
+    let partnerId: string
+    let storeId: string
+    let currencyCode: string
+
+    beforeEach(async () => {
+      const container = getContainer()
+      await createAdminUser(container)
+      adminHeaders = await getAuthHeaders(api)
+
+      const unique = Date.now()
+      const partnerEmail = `partner-mv-${unique}@medusa-test.com`
+
+      await api.post("/auth/partner/emailpass/register", {
+        email: partnerEmail,
+        password: TEST_PARTNER_PASSWORD,
+      })
+
+      const login1 = await api.post("/auth/partner/emailpass", {
+        email: partnerEmail,
+        password: TEST_PARTNER_PASSWORD,
+      })
+      partnerHeaders = { Authorization: `Bearer ${login1.data.token}` }
+
+      const partnerRes = await api.post(
+        "/partners",
+        {
+          name: `Pashmina Co ${unique}`,
+          handle: `pashmina-${unique}`,
+          admin: {
+            email: partnerEmail,
+            first_name: "Admin",
+            last_name: "Pashmina",
+          },
+        },
+        { headers: partnerHeaders }
+      )
+      partnerId = partnerRes.data.partner.id
+
+      const login2 = await api.post("/auth/partner/emailpass", {
+        email: partnerEmail,
+        password: TEST_PARTNER_PASSWORD,
+      })
+      partnerHeaders = { Authorization: `Bearer ${login2.data.token}` }
+
+      const currenciesRes = await api.get("/admin/currencies", adminHeaders)
+      const currencies = currenciesRes.data.currencies || []
+      const usd = currencies.find((c: any) => c.code?.toLowerCase() === "usd")
+      const selected = usd || currencies[0]
+      currencyCode = String(selected.code).toLowerCase()
+
+      const storeRes = await api.post(
+        "/partners/stores",
+        {
+          store: {
+            name: `Pashmina Store ${unique}`,
+            supported_currencies: [
+              { currency_code: currencyCode, is_default: true },
+            ],
+            metadata: { test_run: unique },
+          },
+          sales_channel: {
+            name: `Pashmina ${unique} - Default`,
+            description: "Default sales channel",
+          },
+          region: {
+            name: "Default Region",
+            currency_code: currencyCode,
+            countries: ["us"],
+          },
+          location: {
+            name: "Main Warehouse",
+            address: {
+              address_1: "123 Main St",
+              city: "New York",
+              postal_code: "10001",
+              country_code: "US",
+            },
+          },
+        },
+        { headers: partnerHeaders }
+      )
+      expect(storeRes.status).toBe(201)
+      storeId = storeRes.data.store.id
+    })
+
+    /** Fetch a product with everything needed to assert per-variant inventory. */
+    const getProductWithInventory = async (productId: string) => {
+      const res = await api.get(
+        `/admin/products/${productId}?fields=status,variants.id,variants.title,variants.sku,variants.manage_inventory,` +
+          `variants.options.value,variants.options.option.title,` +
+          `variants.inventory_items.inventory_item_id,` +
+          `variants.inventory_items.inventory.location_levels.location_id,` +
+          `variants.inventory_items.inventory.location_levels.stocked_quantity`,
+        adminHeaders
+      )
+      expect(res.status).toBe(200)
+      return res.data.product
+    }
+
+    const levelsOf = (variant: any) =>
+      (variant.inventory_items || []).flatMap(
+        (ii: any) => ii?.inventory?.location_levels || []
+      )
+
+    it("creates one variant per named value — Mill Spun and Hand Spun — each with its own inventory item and level", async () => {
+      const stamp = Date.now()
+      const payload = {
+        store_id: storeId,
+        product: {
+          title: "Pashmina Shawl",
+          handle: `pashmina-shawl-${stamp}`,
+          description: "Handwoven Kashmiri pashmina.",
+          options: [
+            {
+              title: "Spinning",
+              values: ["Mill Spun", "Hand Spun"],
+            },
+          ],
+          variants: [
+            {
+              title: "Mill Spun",
+              sku: `PASH-MILL-${stamp}`,
+              options: { Spinning: "Mill Spun" },
+              prices: [{ amount: 12000, currency_code: currencyCode }],
+            },
+            {
+              title: "Hand Spun",
+              sku: `PASH-HAND-${stamp}`,
+              options: { Spinning: "Hand Spun" },
+              prices: [{ amount: 24000, currency_code: currencyCode }],
+            },
+          ],
+        },
+      }
+
+      const createRes = await api.post("/partners/products", payload, {
+        headers: partnerHeaders,
+      })
+      expect(createRes.status).toBe(201)
+      expect(createRes.data.partner_id).toBe(partnerId)
+
+      const product = await getProductWithInventory(createRes.data.product.id)
+
+      // 1. Both variants exist — and ONLY those two.
+      expect(product.variants).toHaveLength(2)
+      const byTitle = Object.fromEntries(
+        product.variants.map((v: any) => [v.title, v])
+      )
+      expect(Object.keys(byTitle).sort()).toEqual(["Hand Spun", "Mill Spun"])
+
+      // 2. Each variant carries the option value it was asked for. A variant
+      //    created with the wrong option value still "exists", so asserting the
+      //    count alone would pass on a product nobody could actually buy from.
+      for (const title of ["Mill Spun", "Hand Spun"]) {
+        const opts = byTitle[title].options || []
+        expect(opts.map((o: any) => o.value)).toContain(title)
+        expect(opts.map((o: any) => o?.option?.title)).toContain("Spinning")
+      }
+
+      // 3. Distinct SKUs and distinct inventory items — the failure mode where
+      //    both variants share one inventory item would make stock on one show
+      //    up on the other.
+      const skus = product.variants.map((v: any) => v.sku)
+      expect(new Set(skus).size).toBe(2)
+
+      const itemIds = product.variants.flatMap((v: any) =>
+        (v.inventory_items || []).map((ii: any) => ii.inventory_item_id)
+      )
+      expect(itemIds.length).toBe(2)
+      expect(new Set(itemIds).size).toBe(2)
+
+      // 4. EVERY variant got a location level, not just the first one.
+      for (const v of product.variants) {
+        expect(levelsOf(v).length).toBeGreaterThanOrEqual(1)
+      }
+    })
+
+    it("creates a variant for every combination when two options are named", async () => {
+      const stamp = Date.now()
+      const combos = [
+        ["Mill Spun", "S"],
+        ["Mill Spun", "M"],
+        ["Hand Spun", "S"],
+        ["Hand Spun", "M"],
+      ]
+
+      const payload = {
+        store_id: storeId,
+        product: {
+          title: "Pashmina Stole",
+          handle: `pashmina-stole-${stamp}`,
+          options: [
+            { title: "Spinning", values: ["Mill Spun", "Hand Spun"] },
+            { title: "Size", values: ["S", "M"] },
+          ],
+          variants: combos.map(([spin, size], i) => ({
+            title: `${spin} / ${size}`,
+            sku: `STOLE-${i}-${stamp}`,
+            options: { Spinning: spin, Size: size },
+            prices: [{ amount: 15000, currency_code: currencyCode }],
+          })),
+        },
+      }
+
+      const createRes = await api.post("/partners/products", payload, {
+        headers: partnerHeaders,
+      })
+      expect(createRes.status).toBe(201)
+
+      const product = await getProductWithInventory(createRes.data.product.id)
+      expect(product.variants).toHaveLength(4)
+
+      const seen = product.variants
+        .map((v: any) => {
+          const o = Object.fromEntries(
+            (v.options || []).map((x: any) => [x?.option?.title, x.value])
+          )
+          return `${o.Spinning}|${o.Size}`
+        })
+        .sort()
+      expect(seen).toEqual(
+        combos.map(([a, b]) => `${a}|${b}`).sort()
+      )
+
+      // Per-variant inventory holds at 4 variants too — this is the assertion
+      // that would catch a loop that silently stops early under load.
+      for (const v of product.variants) {
+        expect(levelsOf(v).length).toBeGreaterThanOrEqual(1)
+      }
+    })
+
+    it("creates untracked variants with no inventory item and no level at all", async () => {
+      // Made-to-order pashmina is not stocked. `manage_inventory: false` must
+      // produce a variant with NO inventory item and NO location level — not a
+      // tracked variant with an empty item, which is the shape that 404s the
+      // partner-ui inventory page and cannot be repaired afterwards (Medusa
+      // cannot turn manage_inventory ON for an existing variant).
+      const stamp = Date.now()
+      const payload = {
+        store_id: storeId,
+        product: {
+          title: "Pashmina Made To Order",
+          handle: `pashmina-mto-${stamp}`,
+          options: [{ title: "Spinning", values: ["Mill Spun", "Hand Spun"] }],
+          variants: [
+            {
+              title: "Mill Spun",
+              sku: `MTO-MILL-${stamp}`,
+              options: { Spinning: "Mill Spun" },
+              prices: [{ amount: 12000, currency_code: currencyCode }],
+              manage_inventory: false,
+            },
+            {
+              title: "Hand Spun",
+              sku: `MTO-HAND-${stamp}`,
+              options: { Spinning: "Hand Spun" },
+              prices: [{ amount: 24000, currency_code: currencyCode }],
+              manage_inventory: false,
+            },
+          ],
+        },
+      }
+
+      const createRes = await api.post("/partners/products", payload, {
+        headers: partnerHeaders,
+      })
+      expect(createRes.status).toBe(201)
+
+      const product = await getProductWithInventory(createRes.data.product.id)
+      expect(product.variants).toHaveLength(2)
+
+      for (const v of product.variants) {
+        expect(v.manage_inventory).toBe(false)
+        expect(v.inventory_items || []).toHaveLength(0)
+        expect(levelsOf(v)).toHaveLength(0)
+      }
+    })
+
+    it("seeds inventory only for the tracked variant when tracking is mixed", async () => {
+      // The realistic artisan case: a stocked mill-spun line alongside a
+      // made-to-order hand-spun one. This is the assertion that proves the
+      // seeding loop FILTERS rather than just iterating — an all-tracked or
+      // all-untracked fixture passes under either behaviour.
+      const stamp = Date.now()
+      const payload = {
+        store_id: storeId,
+        product: {
+          title: "Pashmina Mixed",
+          handle: `pashmina-mixed-${stamp}`,
+          options: [{ title: "Spinning", values: ["Mill Spun", "Hand Spun"] }],
+          variants: [
+            {
+              title: "Mill Spun",
+              sku: `MIX-MILL-${stamp}`,
+              options: { Spinning: "Mill Spun" },
+              prices: [{ amount: 12000, currency_code: currencyCode }],
+              manage_inventory: true,
+            },
+            {
+              title: "Hand Spun",
+              sku: `MIX-HAND-${stamp}`,
+              options: { Spinning: "Hand Spun" },
+              prices: [{ amount: 24000, currency_code: currencyCode }],
+              manage_inventory: false,
+            },
+          ],
+        },
+      }
+
+      const createRes = await api.post("/partners/products", payload, {
+        headers: partnerHeaders,
+      })
+      expect(createRes.status).toBe(201)
+
+      const product = await getProductWithInventory(createRes.data.product.id)
+      const byTitle = Object.fromEntries(
+        product.variants.map((v: any) => [v.title, v])
+      )
+
+      const tracked = byTitle["Mill Spun"]
+      expect(tracked.manage_inventory).toBe(true)
+      expect((tracked.inventory_items || []).length).toBeGreaterThanOrEqual(1)
+      expect(levelsOf(tracked).length).toBeGreaterThanOrEqual(1)
+
+      const untracked = byTitle["Hand Spun"]
+      expect(untracked.manage_inventory).toBe(false)
+      expect(untracked.inventory_items || []).toHaveLength(0)
+      expect(levelsOf(untracked)).toHaveLength(0)
+    })
+
+    it("persists weight, dimensions and customs fields — per product AND per variant", async () => {
+      // These are not cosmetic. Blue Dart rejects a waybill without Dimensions
+      // and reads weight in KG (0 = missing), and international labels need an
+      // hs_code — so a product created from the assistant without them is a
+      // product that cannot be shipped abroad. Pin that they survive the
+      // free-form `product` record → createProductsWorkflow hand-off, because
+      // nothing in the route validator (`z.record(z.string(), z.any())`) would
+      // complain if they were silently dropped.
+      const stamp = Date.now()
+      const payload = {
+        store_id: storeId,
+        product: {
+          title: "Pashmina Wrap",
+          handle: `pashmina-wrap-${stamp}`,
+          // Product-level defaults — inherited conceptually, but Medusa stores
+          // them on the product row and carriers read the VARIANT, so both are
+          // asserted separately below.
+          weight: 250,
+          length: 200,
+          width: 70,
+          height: 3,
+          material: "100% Cashmere",
+          origin_country: "in",
+          hs_code: "62141010",
+          options: [{ title: "Spinning", values: ["Mill Spun", "Hand Spun"] }],
+          variants: [
+            {
+              title: "Mill Spun",
+              sku: `WRAP-MILL-${stamp}`,
+              options: { Spinning: "Mill Spun" },
+              prices: [{ amount: 12000, currency_code: currencyCode }],
+              weight: 240,
+              length: 200,
+              width: 70,
+              height: 3,
+              material: "100% Cashmere",
+              origin_country: "in",
+              hs_code: "62141010",
+            },
+            {
+              // Deliberately DIFFERENT weight from its sibling. If the workflow
+              // collapsed variants onto one row, or copied variant #1's
+              // measurements across, an equal-weight fixture would pass anyway.
+              title: "Hand Spun",
+              sku: `WRAP-HAND-${stamp}`,
+              options: { Spinning: "Hand Spun" },
+              prices: [{ amount: 24000, currency_code: currencyCode }],
+              weight: 310,
+              length: 210,
+              width: 75,
+              height: 4,
+              material: "100% Pashmina",
+              origin_country: "in",
+              hs_code: "62141010",
+            },
+          ],
+        },
+      }
+
+      const createRes = await api.post("/partners/products", payload, {
+        headers: partnerHeaders,
+      })
+      expect(createRes.status).toBe(201)
+
+      const res = await api.get(
+        `/admin/products/${createRes.data.product.id}?fields=weight,length,width,height,material,origin_country,hs_code,` +
+          `variants.title,variants.weight,variants.length,variants.width,variants.height,` +
+          `variants.material,variants.origin_country,variants.hs_code`,
+        adminHeaders
+      )
+      expect(res.status).toBe(200)
+      const product = res.data.product
+
+      expect(product).toMatchObject({
+        weight: 250,
+        length: 200,
+        width: 70,
+        height: 3,
+        material: "100% Cashmere",
+        origin_country: "in",
+        hs_code: "62141010",
+      })
+
+      const byTitle = Object.fromEntries(
+        product.variants.map((v: any) => [v.title, v])
+      )
+      expect(byTitle["Mill Spun"]).toMatchObject({
+        weight: 240,
+        length: 200,
+        width: 70,
+        height: 3,
+        material: "100% Cashmere",
+        origin_country: "in",
+        hs_code: "62141010",
+      })
+      expect(byTitle["Hand Spun"]).toMatchObject({
+        weight: 310,
+        length: 210,
+        width: 75,
+        height: 4,
+        material: "100% Pashmina",
+        origin_country: "in",
+        hs_code: "62141010",
+      })
+    })
+
+    it("defaults to draft when status is omitted, and publishes only when asked", async () => {
+      const stamp = Date.now()
+      const base = (suffix: string) => ({
+        store_id: storeId,
+        product: {
+          title: `Pashmina ${suffix}`,
+          handle: `pashmina-${suffix}-${stamp}`,
+          options: [{ title: "Spinning", values: ["Hand Spun"] }],
+          variants: [
+            {
+              title: "Hand Spun",
+              sku: `PASH-${suffix}-${stamp}`,
+              options: { Spinning: "Hand Spun" },
+              prices: [{ amount: 20000, currency_code: currencyCode }],
+            },
+          ],
+        },
+      })
+
+      // No status asked for → draft.
+      const draftPayload = base("draft")
+      const draftRes = await api.post("/partners/products", draftPayload, {
+        headers: partnerHeaders,
+      })
+      expect(draftRes.status).toBe(201)
+      const draft = await getProductWithInventory(draftRes.data.product.id)
+      expect(draft.status).toBe(ProductStatus.DRAFT)
+
+      // Explicitly asked to publish → published.
+      const pubPayload: any = base("live")
+      pubPayload.product.status = ProductStatus.PUBLISHED
+      const pubRes = await api.post("/partners/products", pubPayload, {
+        headers: partnerHeaders,
+      })
+      expect(pubRes.status).toBe(201)
+      const published = await getProductWithInventory(pubRes.data.product.id)
+      expect(published.status).toBe(ProductStatus.PUBLISHED)
+    })
+  })
+})

--- a/apps/backend/src/api/middlewares.ts
+++ b/apps/backend/src/api/middlewares.ts
@@ -2528,6 +2528,21 @@ export default defineMiddlewares({
         validateAndTransformBody(wrapSchema(PartnerAssistantChatSchema)),
       ],
     },
+    // Partner assistant photo attachments. Multipart, so bodyParser is OFF and
+    // multer owns the body — Medusa already parses urlencoded on every route
+    // and a second parser on a stream whose `end` has fired hangs the request.
+    // Disk-backed (mediaUpload) rather than memory: a partner attaching several
+    // phone photos at once is tens of MB and memory storage OOMs the worker.
+    {
+      matcher: "/partners/assistant/attachments",
+      method: "POST",
+      bodyParser: false,
+      middlewares: [
+        createCorsPartnerMiddleware(),
+        authenticate("partner", ["session", "bearer"]),
+        adaptMulter(mediaUpload.array("files")),
+      ],
+    },
     // Partner assistant context compaction — the client calls this when the
     // chat approaches the model's context window; the route returns a short
     // summary the client stores in place of the older turns.

--- a/apps/backend/src/api/partners/assistant/__tests__/attachments.unit.spec.ts
+++ b/apps/backend/src/api/partners/assistant/__tests__/attachments.unit.spec.ts
@@ -1,0 +1,111 @@
+import {
+  MAX_CONVERSATION_ATTACHMENTS,
+  mergeAttachments,
+  renderAttachments,
+} from "../chat/attachments"
+import {
+  assistantFolderName,
+  assistantFolderPath,
+  assistantFolderSlug,
+} from "../attachments/folder-naming"
+
+describe("partner assistant — folder naming", () => {
+  it("derives the slug from the partner id, not the name", () => {
+    // Two partners can share a display name, and folder.slug is UNIQUE — an
+    // name-derived slug would make the second partner's first upload fail.
+    expect(assistantFolderSlug("part_123")).toBe("partner-assistant-part_123")
+    expect(assistantFolderSlug("part_123")).toBe(assistantFolderSlug("part_123"))
+    expect(assistantFolderSlug("part_456")).not.toBe(
+      assistantFolderSlug("part_123")
+    )
+  })
+
+  it("is stable when the partner renames itself", () => {
+    const before = assistantFolderSlug("part_123")
+    const after = assistantFolderSlug("part_123")
+    expect(before).toBe(after)
+    expect(assistantFolderName("Old Name")).not.toBe(
+      assistantFolderName("New Name")
+    )
+  })
+
+  it("falls back to a generic name when the partner has none", () => {
+    expect(assistantFolderName("Pashmina Co")).toBe(
+      "Assistant uploads — Pashmina Co"
+    )
+    expect(assistantFolderName("")).toBe("Assistant uploads")
+    expect(assistantFolderName(null)).toBe("Assistant uploads")
+    expect(assistantFolderName(undefined)).toBe("Assistant uploads")
+  })
+
+  it("puts the folder at the root, matching createFolderStep's convention", () => {
+    expect(assistantFolderPath("part_123")).toBe("/partner-assistant-part_123")
+  })
+})
+
+describe("partner assistant — mergeAttachments", () => {
+  const a = { url: "https://cdn/1.jpg", name: "one.jpg" }
+  const b = { url: "https://cdn/2.jpg", name: "two.jpg" }
+
+  it("de-duplicates by url when both sources carry the same photo", () => {
+    // The normal case: the upload completes before the message is sent, so the
+    // folder and the request body describe the SAME rows. Rendering both would
+    // show the model every photo twice.
+    expect(mergeAttachments([a, b], [b])).toEqual([a, b])
+  })
+
+  it("survives either source being empty", () => {
+    expect(mergeAttachments([a], [])).toEqual([a])
+    expect(mergeAttachments([], [a])).toEqual([a])
+    expect(mergeAttachments([], [])).toEqual([])
+  })
+
+  it("keeps conversation order, oldest first", () => {
+    expect(mergeAttachments([a, b], []).map((x) => x.url)).toEqual([
+      a.url,
+      b.url,
+    ])
+  })
+
+  it("drops entries with no usable url", () => {
+    // A media row with no file_path would otherwise be handed to the model as
+    // `url=undefined`, which it would then try to read.
+    expect(
+      mergeAttachments([{ url: "" } as any, { url: "   " } as any, a], [])
+    ).toEqual([a])
+  })
+
+  it("caps the list so a long catalogue session cannot dominate the turn", () => {
+    const many = Array.from({ length: MAX_CONVERSATION_ATTACHMENTS + 10 }, (_, i) => ({
+      url: `https://cdn/${i}.jpg`,
+    }))
+    const merged = mergeAttachments(many, [])
+    expect(merged).toHaveLength(MAX_CONVERSATION_ATTACHMENTS)
+    // Keeps the MOST RECENT ones — the older photos are the ones a partner has
+    // usually already turned into products.
+    expect(merged[merged.length - 1].url).toBe(many[many.length - 1].url)
+  })
+})
+
+describe("partner assistant — renderAttachments", () => {
+  it("states the photos exist, that they cannot be seen, and how to look", () => {
+    const out = renderAttachments([
+      { url: "https://cdn/1.jpg", name: "shawl.jpg", mime_type: "image/jpeg" },
+    ])
+    expect(out).toContain("CANNOT see them")
+    expect(out).toContain("describe_image")
+    expect(out).toContain("url=https://cdn/1.jpg")
+    expect(out).toContain("name=shawl.jpg")
+    expect(out).toContain("type=image/jpeg")
+  })
+
+  it("numbers photos from 1 in conversation order", () => {
+    const out = renderAttachments([
+      { url: "https://cdn/1.jpg" },
+      { url: "https://cdn/2.jpg" },
+    ])
+    expect(out).toContain("[photo 1] name=untitled type=unknown url=https://cdn/1.jpg")
+    expect(out).toContain("[photo 2] name=untitled type=unknown url=https://cdn/2.jpg")
+    expect(out).toContain("2 photo(s) have been shared")
+  })
+})

--- a/apps/backend/src/api/partners/assistant/attachments/folder-naming.ts
+++ b/apps/backend/src/api/partners/assistant/attachments/folder-naming.ts
@@ -1,0 +1,32 @@
+/**
+ * Naming for the per-partner assistant upload folder.
+ *
+ * Kept pure and dependency-free so it can be unit-tested without a container,
+ * and so the slug rule lives in exactly one place — the slug is the lookup key
+ * for "does this partner already have a folder?", so if it were derived
+ * differently in two places a partner would silently accumulate folders.
+ */
+
+/** Marker written to folder.metadata so ownership survives independently of
+ *  the person→folder link the shared-folders UI reads. */
+export const PARTNER_ASSISTANT_FOLDER_PURPOSE = "partner_assistant_uploads"
+
+/**
+ * Deterministic, unique slug for a partner's assistant folder.
+ *
+ * Derived from the partner ID rather than the name: `folder.slug` is UNIQUE,
+ * and two partners can share a display name ("Pashmina Co") while a partner may
+ * also rename itself later. An id-derived slug is stable across both.
+ */
+export const assistantFolderSlug = (partnerId: string): string =>
+  `partner-assistant-${String(partnerId).trim()}`
+
+/** Human-facing folder name. Falls back when a partner has no name set. */
+export const assistantFolderName = (partnerName?: string | null): string => {
+  const trimmed = String(partnerName ?? "").trim()
+  return trimmed ? `Assistant uploads — ${trimmed}` : "Assistant uploads"
+}
+
+/** Root-level path for the folder, matching createFolderStep's convention. */
+export const assistantFolderPath = (partnerId: string): string =>
+  `/${assistantFolderSlug(partnerId)}`

--- a/apps/backend/src/api/partners/assistant/attachments/folder.ts
+++ b/apps/backend/src/api/partners/assistant/attachments/folder.ts
@@ -1,0 +1,117 @@
+/**
+ * Resolve (and create on first use) the folder that assistant attachments land
+ * in for a given partner.
+ *
+ * Why a folder at all: the pre-existing `/partners/medias/uploads/*` flow puts
+ * objects at the BUCKET ROOT and writes no media record — the file exists, but
+ * nothing in the platform knows whose it is or what it was for. Everything
+ * uploaded through the assistant goes into a partner-owned folder instead, so
+ * a photo can be found again from the media UI after the chat is gone.
+ *
+ * Ownership is recorded TWICE, deliberately:
+ *   - `folder.metadata.partner_id` — the authoritative marker. Works even for a
+ *     partner with no linked people, which is the common case for a fresh
+ *     partner and would otherwise leave them unable to upload at all.
+ *   - a person→folder link for each of the partner's people — this is what
+ *     `verifyFolderAccess` and the shared-folders listing read, so the folder
+ *     shows up in the UI the partner already has.
+ */
+import { ContainerRegistrationKeys } from "@medusajs/framework/utils"
+import type { MedusaContainer } from "@medusajs/framework/types"
+import { MEDIA_MODULE } from "../../../../modules/media"
+import { PERSON_MODULE } from "../../../../modules/person"
+import {
+  PARTNER_ASSISTANT_FOLDER_PURPOSE,
+  assistantFolderName,
+  assistantFolderPath,
+  assistantFolderSlug,
+} from "./folder-naming"
+
+export type PartnerLike = { id: string; name?: string | null }
+
+/**
+ * Returns the folder id for this partner's assistant uploads, creating the
+ * folder the first time it is needed. Idempotent: the slug is unique and
+ * derived from the partner id, so concurrent first-uploads converge on one
+ * folder rather than racing to create two.
+ */
+export const ensurePartnerAssistantFolder = async (
+  container: MedusaContainer,
+  partner: PartnerLike
+): Promise<string> => {
+  const mediaService: any = container.resolve(MEDIA_MODULE)
+  const slug = assistantFolderSlug(partner.id)
+
+  const existing = await mediaService.listFolders({ slug })
+  if (existing?.length) {
+    return existing[0].id
+  }
+
+  let folder: any
+  try {
+    folder = await mediaService.createFolders({
+      name: assistantFolderName(partner.name),
+      slug,
+      description: "Photos shared with the partner assistant.",
+      path: assistantFolderPath(partner.id),
+      level: 0,
+      is_public: false,
+      metadata: {
+        partner_id: partner.id,
+        purpose: PARTNER_ASSISTANT_FOLDER_PURPOSE,
+      },
+    })
+  } catch (e: any) {
+    // Unique-slug collision: another request created it between our read and
+    // our write. Re-read rather than failing the upload.
+    const retry = await mediaService.listFolders({ slug })
+    if (retry?.length) return retry[0].id
+    throw e
+  }
+
+  await linkFolderToPartnerPeople(container, partner.id, folder.id)
+  return folder.id
+}
+
+/**
+ * Best-effort: make the folder visible in the partner's existing shared-folders
+ * screen, which resolves access through partner → people → folders.
+ *
+ * Never throws. A partner with no linked people still gets a working folder —
+ * it just isn't listed by that particular screen — and failing the photo upload
+ * over a listing concern would be the wrong trade.
+ */
+export const linkFolderToPartnerPeople = async (
+  container: MedusaContainer,
+  partnerId: string,
+  folderId: string
+): Promise<void> => {
+  try {
+    const query: any = container.resolve(ContainerRegistrationKeys.QUERY)
+    const { data } = await query.graph({
+      entity: "partners",
+      fields: ["people.id"],
+      filters: { id: partnerId },
+    })
+
+    const peopleIds: string[] = ((data?.[0] as any)?.people || [])
+      .map((p: any) => p?.id)
+      .filter(Boolean)
+    if (!peopleIds.length) return
+
+    const remoteLink: any = container.resolve(ContainerRegistrationKeys.LINK)
+    for (const personId of peopleIds) {
+      await remoteLink.create({
+        [PERSON_MODULE]: { person_id: personId },
+        [MEDIA_MODULE]: { folder_id: folderId },
+      })
+    }
+  } catch (e: any) {
+    const logger: any = container.resolve(ContainerRegistrationKeys.LOGGER)
+    logger?.warn?.(
+      `[partner-assistant/attachments] could not link folder ${folderId} to partner ${partnerId} people: ${
+        e?.message ?? e
+      }`
+    )
+  }
+}

--- a/apps/backend/src/api/partners/assistant/attachments/route.ts
+++ b/apps/backend/src/api/partners/assistant/attachments/route.ts
@@ -1,0 +1,144 @@
+/**
+ * POST /partners/assistant/attachments
+ *
+ * Upload one or more photos from the partner-assistant composer. Returns the
+ * public URLs the model will be told about — the assistant never receives
+ * pixels, only `[attachment N] name=… type=… url=…` lines (see ../chat/route).
+ *
+ * Why this route exists rather than the model driving the upload:
+ *   - The browser is the only place the bytes are. Having the model orchestrate
+ *     initiate → PUT parts → complete costs 3-4 round trips per photo and makes
+ *     it hold upload ids it has no use for.
+ *   - The pre-existing `/partners/medias/uploads/*` pair puts objects at the
+ *     BUCKET ROOT and writes NO media record, so an uploaded photo is
+ *     unattributable the moment the chat ends. Everything here lands in the
+ *     partner's own folder with a real `media_file` row.
+ *
+ * Files arrive as multipart `files` (see middlewares.ts). Content is passed to
+ * the workflow as BASE64 — not "binary"/latin1 — because the file provider
+ * round-trips it through `Buffer.from(content, "base64")` and silently
+ * UTF-8-corrupts every byte >= 0x80 otherwise (#769).
+ */
+import { AuthenticatedMedusaRequest, MedusaResponse } from "@medusajs/framework/http"
+import { ContainerRegistrationKeys, MedusaError } from "@medusajs/framework/utils"
+import fs from "fs"
+import { uploadAndOrganizeMediaWorkflow } from "../../../../workflows/media/upload-and-organize-media"
+import { getPartnerFromAuthContext } from "../../helpers"
+import { ensurePartnerAssistantFolder } from "./folder"
+
+/** Only images — the assistant's vision path cannot do anything with the rest,
+ *  and an unreadable attachment is worse than a refused one because the model
+ *  will happily describe a file it never saw. */
+const ALLOWED_MIME = /^image\/(jpeg|jpg|png|webp|gif|heic|heif)$/i
+
+/** Per-request cap. The composer enforces its own limit; this is the backstop. */
+const MAX_FILES = 10
+
+export const POST = async (
+  req: AuthenticatedMedusaRequest & { files?: Express.Multer.File[] },
+  res: MedusaResponse
+) => {
+  const logger: any = req.scope.resolve(ContainerRegistrationKeys.LOGGER)
+
+  const partner = await getPartnerFromAuthContext(req.auth_context, req.scope)
+  if (!partner) {
+    return res.status(401).json({ message: "Partner authentication required" })
+  }
+
+  const uploaded: Express.Multer.File[] = Array.isArray(req.files)
+    ? (req.files as Express.Multer.File[])
+    : (req as any).file
+    ? [(req as any).file as Express.Multer.File]
+    : []
+
+  if (!uploaded.length) {
+    throw new MedusaError(MedusaError.Types.INVALID_DATA, "No files were uploaded")
+  }
+  if (uploaded.length > MAX_FILES) {
+    throw new MedusaError(
+      MedusaError.Types.INVALID_DATA,
+      `Too many files in one request (max ${MAX_FILES}).`
+    )
+  }
+
+  const rejected = uploaded.filter((f) => !ALLOWED_MIME.test(f.mimetype || ""))
+  if (rejected.length) {
+    throw new MedusaError(
+      MedusaError.Types.INVALID_DATA,
+      `Only image uploads are supported. Rejected: ${rejected
+        .map((f) => `${f.originalname} (${f.mimetype || "unknown type"})`)
+        .join(", ")}`
+    )
+  }
+
+  const folderId = await ensurePartnerAssistantFolder(req.scope, {
+    id: partner.id,
+    name: (partner as any).name,
+  })
+
+  const conversationId =
+    (req.body as any)?.conversation_id ?? (req as any).validatedBody?.conversation_id
+
+  const files = uploaded.map((file) => {
+    const buf = (file as any).buffer
+    const path = (file as any).path
+    const content = Buffer.isBuffer(buf)
+      ? buf.toString("base64")
+      : typeof path === "string"
+      ? fs.readFileSync(path).toString("base64")
+      : ""
+    return {
+      filename: file.originalname,
+      mimeType: file.mimetype,
+      content,
+      ...(typeof path === "string" ? { _tempPath: path } : {}),
+    } as any
+  })
+
+  try {
+    const { result } = await uploadAndOrganizeMediaWorkflow(req.scope).run({
+      input: {
+        files,
+        existingFolderId: folderId,
+        metadata: {
+          source: "partner_assistant",
+          uploaded_by_partner_id: partner.id,
+          uploaded_by_partner_name: (partner as any).name ?? null,
+          ...(conversationId ? { conversation_id: String(conversationId) } : {}),
+        },
+      },
+    })
+
+    const mediaFiles = (result as any)?.mediaFiles ?? []
+    const attachments = mediaFiles.map((m: any) => ({
+      media_id: m.id,
+      name: m.original_name || m.file_name,
+      type: m.mime_type,
+      url: m.file_path,
+    }))
+
+    // A media row with no usable URL would be handed to the model as
+    // `url=undefined`, which it would then "read" — fail loudly instead.
+    const urlless = attachments.filter((a: any) => !a.url)
+    if (urlless.length) {
+      throw new MedusaError(
+        MedusaError.Types.UNEXPECTED_STATE,
+        "Upload stored but no URL was returned for it; not attaching."
+      )
+    }
+
+    return res.status(201).json({ folder_id: folderId, attachments })
+  } finally {
+    // Disk-backed multer writes to tmp; clean up regardless of outcome.
+    for (const file of uploaded) {
+      const p = (file as any).path
+      if (typeof p === "string") {
+        fs.promises.unlink(p).catch((e) =>
+          logger?.debug?.(
+            `[partner-assistant/attachments] temp cleanup failed for ${p}: ${e?.message}`
+          )
+        )
+      }
+    }
+  }
+}

--- a/apps/backend/src/api/partners/assistant/chat/attachments.ts
+++ b/apps/backend/src/api/partners/assistant/chat/attachments.ts
@@ -1,0 +1,128 @@
+/**
+ * Photo context for the partner assistant.
+ *
+ * The partner uploads photos a few at a time across several messages and only
+ * later says "now make the product from these". That is the whole point of the
+ * feature, and it is exactly what the transport makes hard: the client resends
+ * its message history as TEXT, and anything the server appended to a previous
+ * turn is gone by the next one. Rendering only `body.attachments` would mean
+ * the model can see the photos from the current message and nothing before it.
+ *
+ * So the conversation's photos are reconstructed from the DB instead. Every
+ * upload is stamped with `metadata.conversation_id` and lands in the partner's
+ * own assistant folder, which makes the folder — not the message history — the
+ * source of truth for "what has been shared in this chat".
+ *
+ * The pure functions are separated from the container-touching one so the merge
+ * and render rules can be unit-tested without a DB.
+ */
+import { ContainerRegistrationKeys } from "@medusajs/framework/utils"
+import type { MedusaContainer } from "@medusajs/framework/types"
+import { MEDIA_MODULE } from "../../../../modules/media"
+import { assistantFolderSlug } from "../attachments/folder-naming"
+
+export type ChatAttachment = {
+  url: string
+  name?: string
+  mime_type?: string
+  media_id?: string
+}
+
+/** How many of a conversation's photos to consider. A partner working through a
+ *  catalogue can accumulate a lot; the model only needs the recent ones, and an
+ *  unbounded list would quietly become the dominant token cost of every turn. */
+export const MAX_CONVERSATION_ATTACHMENTS = 24
+
+/**
+ * Merge photos recovered from the folder with the ones on this request,
+ * de-duplicated by URL and keeping the earliest position of each.
+ *
+ * Both sources normally contain the same rows — the upload completes before the
+ * message is sent — so the merge exists to make either source being empty
+ * survivable rather than to combine two distinct sets.
+ */
+export const mergeAttachments = (
+  fromConversation: ChatAttachment[],
+  fromBody: ChatAttachment[]
+): ChatAttachment[] => {
+  const out: ChatAttachment[] = []
+  const seen = new Set<string>()
+  for (const a of [...fromConversation, ...fromBody]) {
+    const url = String(a?.url ?? "").trim()
+    if (!url || seen.has(url)) continue
+    seen.add(url)
+    out.push({ ...a, url })
+  }
+  return out.slice(-MAX_CONVERSATION_ATTACHMENTS)
+}
+
+/**
+ * Tell the model the photos EXIST without sending a single pixel.
+ *
+ * `describe_image` takes a url, so the model can act on a photo it cannot see —
+ * but only deliberately, and only when the request actually needs it.
+ */
+export const renderAttachments = (attachments: ChatAttachment[]): string =>
+  [
+    "",
+    "---",
+    `${attachments.length} photo(s) have been shared in this conversation. You CANNOT see them.`,
+    "They are listed oldest first. Look at one with `describe_image` only when the request needs it.",
+    ...attachments.map(
+      (a, i) =>
+        `[photo ${i + 1}] name=${a.name ?? "untitled"} type=${
+          a.mime_type ?? "unknown"
+        } url=${a.url}`
+    ),
+  ].join("\n")
+
+/**
+ * Recover every photo uploaded into this conversation, oldest first.
+ *
+ * Never throws: losing photo context degrades the answer, but failing the whole
+ * chat turn over it would be worse. Returns [] when the partner has never
+ * uploaded anything (no folder yet), which is the common case.
+ */
+export const loadConversationAttachments = async (
+  container: MedusaContainer,
+  partnerId: string,
+  conversationId?: string | null
+): Promise<ChatAttachment[]> => {
+  if (!conversationId) return []
+
+  try {
+    const mediaService: any = container.resolve(MEDIA_MODULE)
+    const folders = await mediaService.listFolders({
+      slug: assistantFolderSlug(partnerId),
+    })
+    const folder = folders?.[0]
+    if (!folder) return []
+
+    const files = await mediaService.listMediaFiles(
+      { folder_id: folder.id },
+      { take: 200, order: { created_at: "DESC" } }
+    )
+
+    return (files || [])
+      .filter(
+        (f: any) =>
+          String(f?.metadata?.conversation_id ?? "") === String(conversationId)
+      )
+      .reverse() // listed DESC for the `take` window; the model reads oldest first
+      .map((f: any) => ({
+        media_id: f.id,
+        name: f.original_name || f.file_name,
+        mime_type: f.mime_type,
+        url: f.file_path,
+      }))
+      .filter((a: ChatAttachment) => Boolean(a.url))
+  } catch (e: any) {
+    const logger: any = container.resolve(ContainerRegistrationKeys.LOGGER)
+    logger?.warn?.(
+      `[partners/assistant/chat] could not load conversation attachments: ${
+        e?.message ?? e
+      }`
+    )
+    return []
+  }
+}

--- a/apps/backend/src/api/partners/assistant/chat/route.ts
+++ b/apps/backend/src/api/partners/assistant/chat/route.ts
@@ -54,6 +54,12 @@ import {
   resolvePartnerBaseUrl,
 } from "../../mcp/lib/handler"
 import { makeMcpLedgerSink } from "../../../../lib/mcp-ledger"
+import { getPartnerFromAuthContext } from "../../helpers"
+import {
+  loadConversationAttachments,
+  mergeAttachments,
+  renderAttachments,
+} from "./attachments"
 import type { PartnerAssistantChatReq } from "./validators"
 
 const FEATURE = "partners/assistant/chat"
@@ -73,6 +79,29 @@ You are given the tools for the domains this conversation appears to be about, n
 ## Safety rails (important)
 - Every tool accepts \`dry_run: true\`. Use it to PREVIEW a change and inspect the current object before you actually write — especially before any update. Show the user what will change, then run the tool for real.
 - Sensitive/destructive tools (deletes, resets) will refuse to run unless the user confirms. Never set \`confirm: true\` yourself. If a tool returns \`requires_confirmation\`, tell the user plainly what it will do and ask them to confirm — the UI gives them an approve button.
+
+## Photos the partner shares
+Photos are uploaded into the partner's own media folder and listed for you as \`[photo N]\` lines with a url — but you CANNOT see them. Nothing about their content is available to you unless you go and look.
+- Do NOT look at a photo just because it was shared. Reading costs real time and money.
+- Look at one ONLY when the request needs it ("make a product from these", "what colour is this") — then call \`describe_image\` with that photo's url and a specific question.
+- If a read fails, relay the reason verbatim. Never retry silently and never guess at what the photo showed.
+
+## Creating a product from photos
+Photos may arrive a few at a time across several messages. They accumulate — the list you are given covers the whole conversation, not just the last message.
+
+**Never call \`create_product\` on your first reply to "make a product from these".** A product is cheap to create and expensive to correct: variants cannot be renamed into existence later, and inventory tracking CANNOT be switched on for a variant that was created without it. So gather the spec first, in ONE message containing every question you still need answered:
+
+1. **Variants** — exactly which ones, in the partner's own words ("Mill Spun and Hand Spun"). Do not invent variants, sizes or colours they did not ask for. If they named a set, use exactly that set.
+2. **Price per variant** — required. Different variants often differ in price (hand spun usually costs more than mill spun); ask per variant rather than assuming one price covers all.
+3. **Stocked or made to order** — this sets \`manage_inventory\` and CANNOT be changed afterwards. Made-to-order → \`manage_inventory: false\` (no stock is tracked). Stocked → \`manage_inventory: true\`, and quantities are set separately afterwards.
+4. **Weight and dimensions** — needed for shipping labels; a product without them cannot ship internationally. Ask for weight in grams and length/width/height in cm.
+5. **Which store**, if the partner has more than one.
+
+Then show the full spec back as a short list and create it only after they say yes. Set \`status: 'draft'\` unless they explicitly asked for it to be live. Put the photo urls in \`images\`.
+
+Two things to tell them truthfully afterwards:
+- If the result comes back as \`proposed\` rather than what you asked for, say so — some partners' products go to JYT for review instead of publishing directly. Do not describe a proposed product as published.
+- A draft is not visible on the storefront until published.
 
 ## Style
 - Be concise and action-oriented. Prefer doing (calling a tool) over describing.
@@ -144,6 +173,33 @@ export const POST = async (
       parts: textParts.length ? textParts : [{ type: "text", text: "" }],
     }
   })
+
+  // ---- Photo context ------------------------------------------------------
+  // Recovered from the partner's assistant folder rather than the message
+  // history, because history arrives text-only: anything appended to a previous
+  // turn is gone by this one, and "upload a few, then build the product" is the
+  // whole feature. See ./attachments.
+  const partner = await getPartnerFromAuthContext(req.auth_context, req.scope)
+  const conversationAttachments = partner
+    ? await loadConversationAttachments(req.scope, partner.id, body.id)
+    : []
+  const attachments = mergeAttachments(
+    conversationAttachments,
+    (body.attachments ?? []) as any
+  )
+  if (attachments.length) {
+    // Attach to the last USER message — that is the turn the model is answering,
+    // and appending to an assistant turn would read as something it once said.
+    for (let i = messages.length - 1; i >= 0; i--) {
+      if (messages[i].role === "user") {
+        messages[i].parts.push({
+          type: "text",
+          text: renderAttachments(attachments),
+        })
+        break
+      }
+    }
+  }
 
   // ---- Per-ask registry slicing -------------------------------------------
   // All ~178 tools stay BOUND (so any of them can still execute), but only the

--- a/apps/backend/src/api/partners/assistant/chat/validators.ts
+++ b/apps/backend/src/api/partners/assistant/chat/validators.ts
@@ -22,10 +22,32 @@ const UiMessageSchema = z
   })
   .passthrough()
 
+/**
+ * A photo the partner attached to this message, already uploaded via
+ * POST /partners/assistant/attachments.
+ *
+ * The model is TOLD an attachment exists (name, type, url) and is never sent
+ * the pixels — the partner assistant's model may be text-only, and the ones
+ * that aren't accept an image part and then silently drop it at 200 OK.
+ * Looking at an image is a separate, deliberate act: `describe_image`.
+ */
+const AttachmentSchema = z.object({
+  url: z.string().trim().min(1),
+  name: z.string().trim().min(1).max(300).optional(),
+  mime_type: z.string().trim().min(1).max(100).optional(),
+  media_id: z.string().trim().min(1).max(100).optional(),
+})
+
 export const PartnerAssistantChatSchema = z.object({
   messages: z.array(UiMessageSchema).min(1).max(60),
   id: z.string().optional(),
   trigger: z.string().optional(),
+  // Sent by the transport on `regenerate`. Unused server-side, but declared so
+  // a strict wrapper can never reject a regenerate turn.
+  messageId: z.string().optional(),
+  attachments: z.array(AttachmentSchema).max(10).optional(),
 })
+
+export type PartnerAssistantAttachment = z.infer<typeof AttachmentSchema>
 
 export type PartnerAssistantChatReq = z.infer<typeof PartnerAssistantChatSchema>

--- a/apps/backend/src/api/partners/assistant/conversations/validators.ts
+++ b/apps/backend/src/api/partners/assistant/conversations/validators.ts
@@ -14,19 +14,40 @@ const StoredMessageSchema = z
   })
   .passthrough()
 
+/**
+ * Conversation-level metadata.
+ *
+ * `thread_key` is the stable id tying this conversation's turns to the photos
+ * uploaded during it — the assistant recovers a conversation's photos by
+ * matching it against the `conversation_id` stamped on each upload. It is
+ * written on the first save and never changes, which is what lets a reopened
+ * conversation still see the photos shared in it.
+ */
+const ConversationMetadataSchema = z
+  .object({
+    thread_key: z.string().trim().min(1).max(100).optional(),
+  })
+  .passthrough()
+
 export const CreateConversationSchema = z.object({
   title: z.string().trim().min(1).max(200).optional(),
   messages: z.array(StoredMessageSchema).max(200).optional(),
+  metadata: ConversationMetadataSchema.optional(),
 })
 
 export const UpdateConversationSchema = z
   .object({
     title: z.string().trim().min(1).max(200).optional(),
     messages: z.array(StoredMessageSchema).max(200).optional(),
+    metadata: ConversationMetadataSchema.optional(),
   })
-  .refine((v) => v.title !== undefined || v.messages !== undefined, {
-    message: "Provide at least one of title or messages",
-  })
+  .refine(
+    (v) =>
+      v.title !== undefined ||
+      v.messages !== undefined ||
+      v.metadata !== undefined,
+    { message: "Provide at least one of title, messages or metadata" }
+  )
 
 export type CreateConversationInput = z.infer<typeof CreateConversationSchema>
 export type UpdateConversationInput = z.infer<typeof UpdateConversationSchema>

--- a/apps/backend/src/api/partners/mcp/lib/__tests__/dispatch.unit.spec.ts
+++ b/apps/backend/src/api/partners/mcp/lib/__tests__/dispatch.unit.spec.ts
@@ -86,11 +86,22 @@ describe("partner-mcp registry + dispatch", () => {
         "log_production_run_consumption", "accept_production_run",
         "complete_production_run", "get_production_run_cost_summary",
         "create_product", "set_artisan_detail",
-        "initiate_media_upload", "complete_media_upload",
         "get_order", "create_order_fulfillment", "mark_fulfillment_delivered",
       ]) {
         expect(names.has(n)).toBe(true)
       }
+    })
+
+    it("does not advertise the media-upload tools, which never worked", () => {
+      // This assertion used to run the other way, which is what kept two dead
+      // tools on the surface: they sent file_name/mime_type/upload_id where the
+      // routes read name/type/uploadId, so every call 400'd, and the middle step
+      // was a binary PUT no model can perform. A test asserting a tool EXISTS
+      // says nothing about whether it works — and here it actively preserved
+      // the breakage. Photos go through POST /partners/assistant/attachments.
+      const names = new Set(PARTNER_MCP_TOOLS.map((t) => t.name))
+      expect(names.has("initiate_media_upload")).toBe(false)
+      expect(names.has("complete_media_upload")).toBe(false)
     })
 
     it("covers the broader dashboard reads (customers, payments, returns/claims/exchanges, inventory)", () => {

--- a/apps/backend/src/api/partners/mcp/lib/registry.ts
+++ b/apps/backend/src/api/partners/mcp/lib/registry.ts
@@ -616,49 +616,24 @@ export const PARTNER_MCP_TOOLS: PartnerMcpToolDef[] = [
     inputSchema: obj({ id: STR("Production-run id.") }, ["id"]),
   },
 
-  // ===== Media upload (presigned multipart) =================================
-  {
-    name: "initiate_media_upload",
-    description:
-      "Start a multipart media upload; returns an upload id + presigned part URLs. The raw bytes are PUT to those URLs out-of-band, then complete_media_upload is called.",
-    method: "POST",
-    path: "/partners/medias/uploads/initiate",
-    write: true,
-    bodyParams: ["file_name", "mime_type", "size", "parts", "folder_id", "metadata"],
-    inputSchema: obj(
-      {
-        file_name: STR("Original file name."),
-        mime_type: STR("MIME type, e.g. 'image/jpeg'."),
-        size: INT("File size in bytes."),
-        parts: INT("Number of parts to split into."),
-        folder_id: STR("Optional target folder id."),
-        metadata: { type: "object", additionalProperties: true },
-      },
-      ["file_name", "mime_type"]
-    ),
-  },
-  {
-    name: "complete_media_upload",
-    description:
-      "Finalize a multipart media upload once all parts are uploaded. Returns the stored media record.",
-    method: "POST",
-    path: "/partners/medias/uploads/complete",
-    write: true,
-    bodyParams: ["upload_id", "parts", "key", "metadata"],
-    inputSchema: obj(
-      {
-        upload_id: STR("Upload id from initiate."),
-        key: STR("Object key from initiate."),
-        parts: {
-          type: "array",
-          description: "Uploaded parts: [{ part_number, etag }].",
-          items: { type: "object", additionalProperties: true },
-        },
-        metadata: { type: "object", additionalProperties: true },
-      },
-      ["upload_id"]
-    ),
-  },
+  // ===== Media upload =======================================================
+  // `initiate_media_upload` / `complete_media_upload` used to live here and are
+  // deliberately GONE. They could never have worked:
+  //
+  //   - dispatch does a bare `pick(def.bodyParams, args)` with no renaming, and
+  //     the tools sent file_name/mime_type/upload_id where the routes read
+  //     name/type/uploadId — every call 400'd on "Missing required fields";
+  //   - `complete` writes NO media record at all and `initiate` deliberately
+  //     builds a flat key at the BUCKET ROOT, so even a fixed-up call left an
+  //     object nothing could attribute — while the tool description claimed it
+  //     "returns the stored media record";
+  //   - and the middle step is a raw binary PUT to a presigned URL, which a
+  //     language model cannot perform. No amount of field-name repair makes
+  //     these callable by the thing they were exposed to.
+  //
+  // Photos now reach the assistant through POST /partners/assistant/attachments,
+  // driven by the browser (which is where the bytes are), landing in the
+  // partner's own media folder. The routes themselves are untouched.
 
   // ===== Products (write) ===================================================
   {

--- a/apps/backend/src/modules/partner-assistant/service.ts
+++ b/apps/backend/src/modules/partner-assistant/service.ts
@@ -45,7 +45,11 @@ class PartnerAssistantService extends MedusaService({
 
   createConversationForPartner(
     partnerId: string,
-    input: { title?: string; messages?: unknown[] }
+    input: {
+      title?: string
+      messages?: unknown[]
+      metadata?: Record<string, unknown>
+    }
   ) {
     // `messages` is an array stored in a json column, which the generated
     // create typing narrows to an object — cast at the boundary.
@@ -53,6 +57,9 @@ class PartnerAssistantService extends MedusaService({
       partner_id: partnerId,
       ...(input.title !== undefined ? { title: input.title } : {}),
       messages: (input.messages ?? []) as any,
+      ...(input.metadata !== undefined
+        ? { metadata: input.metadata as any }
+        : {}),
     })
   }
 
@@ -60,9 +67,13 @@ class PartnerAssistantService extends MedusaService({
   async updateConversationForPartner(
     partnerId: string,
     id: string,
-    input: { title?: string; messages?: unknown[] }
+    input: {
+      title?: string
+      messages?: unknown[]
+      metadata?: Record<string, unknown>
+    }
   ) {
-    await this.getConversationForPartner(partnerId, id)
+    const existing = await this.getConversationForPartner(partnerId, id)
     const [updated] = await this.updatePartnerAssistantConversations([
       {
         id,
@@ -70,6 +81,17 @@ class PartnerAssistantService extends MedusaService({
         // json column holds an array; cast past the object-narrowed typing.
         ...(input.messages !== undefined
           ? { messages: input.messages as any }
+          : {}),
+        // MERGE rather than replace. `thread_key` is written once, on the first
+        // save, and every later PATCH sends only title/messages — a replacing
+        // write would drop it and orphan the conversation's photos.
+        ...(input.metadata !== undefined
+          ? {
+              metadata: {
+                ...((existing as any)?.metadata ?? {}),
+                ...input.metadata,
+              } as any,
+            }
           : {}),
       },
     ])

--- a/apps/partner-ui/src/routes/assistant/assistant.tsx
+++ b/apps/partner-ui/src/routes/assistant/assistant.tsx
@@ -30,6 +30,9 @@ export const Assistant = () => {
   const [activeId, setActiveId] = useState<string | null>(null)
   const [threadKey, setThreadKey] = useState(0)
   const [initialMessages, setInitialMessages] = useState<StoredMessage[]>([])
+  // The reopened conversation's stable upload key, so photos shared in it are
+  // still in context after a reload. Null for a fresh chat (one is generated).
+  const [storedThreadKey, setStoredThreadKey] = useState<string | null>(null)
   const [opening, setOpening] = useState(false)
   // Desktop: history sidebar visible by default, collapsible to give the chat
   // thread the full width (e.g. when starting a fresh "New chat").
@@ -40,6 +43,7 @@ export const Assistant = () => {
   const startNew = useCallback(() => {
     setActiveId(null)
     setInitialMessages([])
+    setStoredThreadKey(null)
     setThreadKey((k) => k + 1)
     setMobileOpen(false)
   }, [])
@@ -53,10 +57,15 @@ export const Assistant = () => {
       setOpening(true)
       try {
         const { conversation } = await sdk.client.fetch<{
-          conversation: { id: string; messages: StoredMessage[] }
+          conversation: {
+            id: string
+            messages: StoredMessage[]
+            metadata?: { thread_key?: string } | null
+          }
         }>(`/partners/assistant/conversations/${id}`, { method: "GET" })
         setActiveId(id)
         setInitialMessages(conversation.messages || [])
+        setStoredThreadKey(conversation.metadata?.thread_key ?? null)
         setThreadKey((k) => k + 1)
         setMobileOpen(false)
       } catch {
@@ -191,6 +200,7 @@ export const Assistant = () => {
             key={threadKey}
             conversationId={activeId}
             initialMessages={initialMessages}
+            storedThreadKey={storedThreadKey}
             onCreated={onCreated}
             onCompacted={onCompacted}
           />

--- a/apps/partner-ui/src/routes/assistant/components/chat-thread.tsx
+++ b/apps/partner-ui/src/routes/assistant/components/chat-thread.tsx
@@ -15,8 +15,12 @@
  *     (streaming or reasoning) so the partner can interrupt a long turn.
  *   - Retry: an inline "Retry" button appears when a turn errors, calling
  *     `regenerate()`. The backend also retries construction once.
- *   - Media upload: not supported in chat — a disabled attachment button with a
- *     tooltip tells the partner so, instead of silently failing.
+ *   - Photo attachments: the partner can attach images, a few at a time across
+ *     several messages, and later ask for a product to be built from them. Each
+ *     upload goes into the partner's own assistant media folder (so it stays
+ *     findable after the chat), and the model is told the photo EXISTS — name,
+ *     type, url — but never receives pixels; looking is a deliberate act
+ *     (`describe_image`).
  *   - Context window: a rough token estimate is tracked across the thread;
  *     near the limit a banner offers "Compact summary" (POST .../summarize),
  *     which replaces the older turns with a short summary so the chat keeps
@@ -49,6 +53,66 @@ type ChatThreadProps = {
   onCreated: (id: string, title: string) => void
   /** Fired after a context compaction replaces the stored history. */
   onCompacted?: () => void
+}
+
+/** A photo the partner attached, already uploaded to their assistant folder. */
+type Attachment = {
+  url: string
+  name: string
+  mime_type: string
+  media_id?: string
+}
+
+/** Images only — the assistant's vision path can do nothing with anything else,
+ *  and a file it cannot read is worse than one it refuses, because it will
+ *  cheerfully describe a photo it never saw. */
+const ATTACHMENT_ACCEPT = "image/jpeg,image/png,image/webp,image/gif,image/heic,image/heif"
+const MAX_ATTACHMENT_BYTES = 15 * 1024 * 1024
+/** Per message. The backend enforces its own cap independently. */
+const MAX_ATTACHMENTS = 8
+
+/**
+ * Upload photos into the partner's own assistant folder and return the
+ * references the chat route stores.
+ *
+ * Goes to /partners/assistant/attachments rather than the older
+ * /partners/medias/uploads/* pair, which writes objects to the bucket ROOT with
+ * no media record — an upload nothing can attribute once the chat is gone.
+ */
+async function uploadAttachments(
+  files: File[],
+  conversationKey: string,
+  token: string | null
+): Promise<Attachment[]> {
+  const form = new FormData()
+  for (const f of files) form.append("files", f)
+  form.append("conversation_id", conversationKey)
+
+  const res = await fetch(
+    `${backendUrl.replace(/\/$/, "")}/partners/assistant/attachments`,
+    {
+      method: "POST",
+      credentials: "include",
+      headers: token ? { Authorization: `Bearer ${token}` } : undefined,
+      body: form,
+    }
+  )
+
+  const payload = await res.json().catch(() => null)
+  if (!res.ok) {
+    throw new Error(payload?.message || `Upload failed (${res.status})`)
+  }
+
+  const attachments: Attachment[] = (payload?.attachments ?? []).map((a: any) => ({
+    url: a.url,
+    name: a.name ?? "untitled",
+    mime_type: a.type ?? "image/jpeg",
+    media_id: a.media_id,
+  }))
+  if (!attachments.length) {
+    throw new Error("Upload succeeded but returned no file")
+  }
+  return attachments
 }
 
 const SUGGESTIONS = [
@@ -128,20 +192,62 @@ export const ChatThread = ({
   )
   const persistingRef = useRef(false)
 
+  // Photos held for the NEXT send, and the ones already sent this session.
+  const [attachments, setAttachments] = useState<Attachment[]>([])
+  const [uploading, setUploading] = useState(false)
+  const fileInputRef = useRef<HTMLInputElement>(null)
+  const pendingAttachmentsRef = useRef<Attachment[]>([])
+
+  // Stable key tying this thread's uploads to its chat turns. The server
+  // recovers a conversation's photos by matching this against the
+  // `conversation_id` stamped on each upload, so the SAME value must reach both
+  // the upload route and `body.id` on the chat request — hence an explicit id
+  // rather than the one useChat would generate internally.
+  const threadKeyRef = useRef<string>(
+    conversationId ??
+      `chat_${Date.now().toString(36)}${Math.random().toString(36).slice(2, 8)}`
+  )
+
+  const authToken = () =>
+    (sdk as any).client?.token ||
+    (typeof window !== "undefined"
+      ? localStorage.getItem(jwtTokenStorageKey)
+      : null)
+
   const transport = new DefaultChatTransport({
     api: `${backendUrl.replace(/\/$/, "")}/partners/assistant/chat`,
     credentials: "include",
     headers: () => {
-      const token =
-        (sdk as any).client?.token ||
-        (typeof window !== "undefined"
-          ? localStorage.getItem(jwtTokenStorageKey)
-          : null)
+      const token = authToken()
       return token ? { Authorization: `Bearer ${token}` } : {}
+    },
+    // Returning a `body` REPLACES the SDK's default wholesale, so `id`,
+    // `trigger` and `messageId` have to be spread back in by hand — only
+    // api/headers/credentials/body are read from here.
+    prepareSendMessagesRequest: ({
+      body,
+      messages,
+      id,
+      trigger,
+      messageId,
+    }: any) => {
+      const pending = pendingAttachmentsRef.current
+      pendingAttachmentsRef.current = []
+      return {
+        body: {
+          ...body,
+          id,
+          messages,
+          trigger,
+          messageId,
+          ...(pending.length ? { attachments: pending } : {}),
+        },
+      }
     },
   })
 
   const { messages, sendMessage, setMessages, status, error, stop, regenerate, clearError } = useChat({
+    id: threadKeyRef.current,
     transport,
     messages: initialMessages as any,
   })
@@ -202,11 +308,74 @@ export const ChatThread = ({
 
   const handleSubmit = (e: React.FormEvent) => {
     e.preventDefault()
-    if (!input.trim() || status !== "ready") return
+    // A message carrying only photos is legitimate — "here are three more" is a
+    // complete turn when the partner is uploading a batch at a time.
+    if ((!input.trim() && attachments.length === 0) || status !== "ready") return
     clearError?.()
-    sendMessage({ text: input.trim() })
+    if (attachments.length) {
+      pendingAttachmentsRef.current = attachments
+      setAttachments([])
+    }
+    sendMessage({
+      text: input.trim() || "I've shared some photos.",
+    })
     setInput("")
   }
+
+  /** Validate, upload, and hold photos for the next send. */
+  const handleFiles = useCallback(
+    async (fileList: FileList | null) => {
+      const picked = Array.from(fileList ?? [])
+      if (!picked.length) return
+
+      const room = MAX_ATTACHMENTS - attachments.length
+      if (room <= 0) {
+        toast.error(`You can attach up to ${MAX_ATTACHMENTS} photos per message.`)
+        return
+      }
+
+      const accepted: File[] = []
+      for (const file of picked.slice(0, room)) {
+        if (!file.type.startsWith("image/")) {
+          toast.error(`${file.name} isn't an image.`)
+          continue
+        }
+        if (file.size > MAX_ATTACHMENT_BYTES) {
+          toast.error(
+            `${file.name} is too large (max ${Math.round(
+              MAX_ATTACHMENT_BYTES / (1024 * 1024)
+            )}MB).`
+          )
+          continue
+        }
+        accepted.push(file)
+      }
+      if (picked.length > room) {
+        toast.error(
+          `Only the first ${room} photo(s) were attached — the limit is ${MAX_ATTACHMENTS} per message.`
+        )
+      }
+      if (!accepted.length) return
+
+      setUploading(true)
+      try {
+        const uploaded = await uploadAttachments(
+          accepted,
+          threadKeyRef.current,
+          authToken()
+        )
+        setAttachments((prev) => [...prev, ...uploaded])
+      } catch (err: any) {
+        toast.error(`Could not attach: ${err?.message ?? "upload failed"}`)
+      } finally {
+        setUploading(false)
+      }
+    },
+    [attachments.length]
+  )
+
+  const removeAttachment = (url: string) =>
+    setAttachments((prev) => prev.filter((a) => a.url !== url))
 
   const handleStop = () => {
     try {
@@ -378,9 +547,40 @@ export const ChatThread = ({
         )}
       </div>
 
+      {attachments.length > 0 && (
+        <div className="border-t border-ui-border-base px-3 pt-3 flex flex-wrap gap-2">
+          {attachments.map((a) => (
+            <div
+              key={a.url}
+              className="flex items-center gap-x-2 rounded-lg border border-ui-border-base bg-ui-bg-subtle px-2 py-1"
+            >
+              <img
+                src={a.url}
+                alt={a.name}
+                className="h-8 w-8 rounded object-cover"
+              />
+              <Text size="xsmall" className="max-w-[10rem] truncate">
+                {a.name}
+              </Text>
+              <IconButton
+                type="button"
+                size="small"
+                variant="transparent"
+                aria-label={`Remove ${a.name}`}
+                onClick={() => removeAttachment(a.url)}
+              >
+                <XMarkMini />
+              </IconButton>
+            </div>
+          ))}
+        </div>
+      )}
+
       <form
         onSubmit={handleSubmit}
-        className="border-t border-ui-border-base p-3 flex items-end gap-x-2"
+        className={`border-ui-border-base p-3 flex items-end gap-x-2 ${
+          attachments.length > 0 ? "" : "border-t"
+        }`}
       >
         <textarea
           value={input}
@@ -395,11 +595,36 @@ export const ChatThread = ({
           placeholder="Ask the assistant…"
           className="flex-1 resize-none rounded-lg border border-ui-border-base bg-ui-bg-field px-3 py-2 text-sm focus:outline-none focus:border-ui-border-interactive max-h-32"
         />
-        {/* Media upload is intentionally not supported in chat. The attachment
-            tool exists in the registry (initiate/complete_media_upload) for the
-            model to call, but a partner cannot attach a file in the composer. */}
-        <Tooltip content="Media upload isn't supported in chat — start a new chat if you need to share a file." side="top">
-          <IconButton type="button" size="large" disabled aria-label="Attach media">
+        {/* Photos go into the partner's own assistant media folder, so they are
+            still findable after the chat ends. */}
+        <input
+          ref={fileInputRef}
+          type="file"
+          accept={ATTACHMENT_ACCEPT}
+          multiple
+          className="hidden"
+          onChange={(e) => {
+            void handleFiles(e.target.files)
+            // Reset so picking the SAME file twice still fires onChange.
+            e.target.value = ""
+          }}
+        />
+        <Tooltip
+          content={
+            attachments.length >= MAX_ATTACHMENTS
+              ? `Up to ${MAX_ATTACHMENTS} photos per message`
+              : "Attach photos"
+          }
+          side="top"
+        >
+          <IconButton
+            type="button"
+            size="large"
+            aria-label="Attach photos"
+            isLoading={uploading}
+            disabled={uploading || attachments.length >= MAX_ATTACHMENTS}
+            onClick={() => fileInputRef.current?.click()}
+          >
             <PaperClip />
           </IconButton>
         </Tooltip>
@@ -417,7 +642,9 @@ export const ChatThread = ({
           <IconButton
             type="submit"
             size="large"
-            disabled={!input.trim() || status !== "ready"}
+            disabled={
+              (!input.trim() && attachments.length === 0) || status !== "ready"
+            }
             aria-label="Send message"
           >
             <ArrowUpMini />

--- a/apps/partner-ui/src/routes/assistant/components/chat-thread.tsx
+++ b/apps/partner-ui/src/routes/assistant/components/chat-thread.tsx
@@ -49,6 +49,13 @@ type ChatThreadProps = {
   conversationId: string | null
   /** Messages to seed the thread with (empty for a new chat). */
   initialMessages: StoredMessage[]
+  /**
+   * The saved conversation's upload key, if it has one. Photos are found by
+   * matching this against the `conversation_id` stamped on each upload, so
+   * reopening a conversation must reuse the SAME key or its photos drop out of
+   * context. Null for a fresh chat — one is generated and persisted on save.
+   */
+  storedThreadKey?: string | null
   /** Fired once, when a fresh chat is first persisted (gets its server id). */
   onCreated: (id: string, title: string) => void
   /** Fired after a context compaction replaces the stored history. */
@@ -176,6 +183,7 @@ function estimateTokens(messages: any[]): number {
 
 export const ChatThread = ({
   conversationId,
+  storedThreadKey,
   initialMessages,
   onCreated,
   onCompacted,
@@ -203,8 +211,12 @@ export const ChatThread = ({
   // `conversation_id` stamped on each upload, so the SAME value must reach both
   // the upload route and `body.id` on the chat request — hence an explicit id
   // rather than the one useChat would generate internally.
+  //
+  // Reopening a saved conversation restores its key from the server, which is
+  // what keeps photos shared days ago in context. A fresh chat generates one
+  // and persists it on the first save (see the persist effect below).
   const threadKeyRef = useRef<string>(
-    conversationId ??
+    storedThreadKey ??
       `chat_${Date.now().toString(36)}${Math.random().toString(36).slice(2, 8)}`
   )
 
@@ -288,7 +300,15 @@ export const ChatThread = ({
             conversation: { id: string; title: string }
           }>("/partners/assistant/conversations", {
             method: "POST",
-            body: { title, messages: stored },
+            body: {
+              title,
+              messages: stored,
+              // Written once, on the first save. Without it a reopened
+              // conversation would generate a fresh key and lose every photo
+              // shared in it — the server merges metadata on PATCH so later
+              // title/message writes cannot drop it.
+              metadata: { thread_key: threadKeyRef.current },
+            },
           })
           idRef.current = conversation.id
           onCreated(conversation.id, conversation.title)


### PR DESCRIPTION
Partners can now attach photos to the assistant — a few at a time, across several messages — and then ask for a product to be built from them, with the variants they name.

## What was actually missing

The product side needed **no new code**. `create_product` already accepted `title, handle, status, options, variants, prices, images` and passed them to `createProductsWorkflow`. What was missing was any way to get a photo in:

- the composer had a **deliberately disabled** attachment button, and
- the chat route **stripped every non-text message part**.

Everything else here follows from fixing that.

## How photos get in

New `POST /partners/assistant/attachments` — multipart, images only, disk-backed multer (a batch of phone photos is tens of MB; memory storage OOMs the worker), base64 content so bytes survive (#769).

Each photo becomes a real `media_file` in a folder owned by the partner. The pre-existing `/partners/medias/uploads/*` pair writes objects to the **bucket root with no media record at all**, so an upload became unattributable the moment the chat ended.

The folder's slug derives from the **partner id, not the name**: `folder.slug` is unique, two partners can share a display name, and a partner can rename itself. Ownership is recorded twice on purpose — `metadata.partner_id` is authoritative and works for a partner with **no linked people** (who would otherwise be unable to upload at all), and a person→folder link makes it appear in the shared-folders screen that already exists.

## Accumulating across messages

This is the part that doesn't work the obvious way. History arrives **text-only**, so anything the server appends to one turn is gone by the next; rendering only `body.attachments` would give the model the current message's photos and nothing before them — defeating the point of uploading a few at a time.

Photos are recovered from the folder instead, scoped by a stable thread key that is **persisted on the conversation** and restored on reopen. The service **merges** metadata rather than replacing it: the key is written once on the first save, and every later turn PATCHes title/messages only, so a replacing write would drop it on the very next turn. The conversation would then reopen looking healthy and simply have no photos.

The model is told a photo **exists** (name, type, url) and never receives pixels. Looking is a deliberate act via `describe_image` — forced by the same constraint as the admin assistant: the chat model drops image parts silently at 200 OK.

## Ask before creating

The prompt no longer calls `create_product` on the first reply. It gathers, in one message: variants in the partner's own words, **price per variant**, **stocked vs made-to-order**, weight and dimensions, and which store — then shows the spec back and waits.

A product is cheap to create and expensive to correct: `manage_inventory` **cannot be switched on** for an existing variant, so guessing it wrong is unrepairable. The assistant is also told to report honestly when a product comes back `proposed` rather than published, instead of claiming it published.

## Two dead tools removed

`initiate_media_upload` / `complete_media_upload` never worked and aren't repairable in any useful sense:

- dispatch does a bare `pick(bodyParams)` with no renaming, and they sent `file_name`/`mime_type`/`upload_id` where the routes read `name`/`type`/`uploadId` — every call 400'd;
- `complete` writes no record and `initiate` builds a bucket-root key, so even a field-name fix leaves an unattributable object, while the description claimed it *"returns the stored media record"*;
- the middle step is a **binary PUT to a presigned URL, which a model cannot perform**.

A test asserted these two tools *exist*, which is what carried them through every previous pass. It now asserts the opposite, with the reason. Same shape as the Blue Dart classifier whose defect was pinned by the test written for it. The routes are untouched; only the advertised MCP surface changed.

## Tests

Six of these pin the product side, which already worked but had never been covered — the existing spec only ever created one option with one value and one variant.

| | |
|---|---|
| 103 unit | partner MCP, incl. the turned-around assertion |
| 11 unit | folder naming, merge/dedupe, render |
| 6 integ | attachments: media row in the partner's folder, byte integrity (#769), folder reuse across uploads, cross-conversation scoping, non-image refused with nothing written, unauthenticated rejected |
| 9 integ | conversations, incl. metadata surviving a message-only PATCH |
| 6 integ | products: one variant per named value each with its own inventory item and level; every combination for two options; untracked variants creating no inventory item at all; mixed tracking seeding only the tracked variant; weight/dimensions/hs_code per product **and** per variant; draft-unless-asked |
| 2 integ | existing partners-products — no regression |

`check:prod-build` passes (side effects reverted).

The two variants in the dimensions test carry **deliberately different weights** — with equal fixtures, a workflow that copied variant #1's measurements across would have passed anyway. The mixed-tracking test is the one that proves the seeding loop *filters* rather than merely iterating; an all-tracked or all-untracked fixture passes under either behaviour.

## Not yet done

**Nobody has driven this through the UI with a real model** — attach photos, ask for Mill Spun and Hand Spun, answer the questions, see the product. Every layer is proven at the API and DB level; the end-to-end pass is not.

🤖 Generated with [Claude Code](https://claude.com/claude-code)