### PR TITLE
fix(deployment): read Cloudflare credentials from a platform row, not env

### DIFF
--- a/apps/backend/src/api/admin/partners/[id]/storefront/domain/verify/route.ts
+++ b/apps/backend/src/api/admin/partners/[id]/storefront/domain/verify/route.ts
@@ -54,7 +54,7 @@ export const POST = async (
     // Vercel-only: apply Vercel's recommended DNS via Cloudflare. No-op for
     // domains outside our zone.
     const deployment: DeploymentService = req.scope.resolve(DEPLOYMENT_MODULE)
-    applied = await deployment.applyRecommendedDns(customDomain)
+    applied = await deployment.applyRecommendedDns(customDomain, req.scope)
   } else {
     // Self-heal: idempotently (re)attach each host.
     const hosts = [pair.primary, pair.counterpart].filter(

--- a/apps/backend/src/api/admin/social-platforms/validators.ts
+++ b/apps/backend/src/api/admin/social-platforms/validators.ts
@@ -14,6 +14,7 @@ export const ApiCategorySchema = z.enum([
   "authentication",
   "google",
   "ai", // AI/LLM providers (OpenRouter, DashScope, Cloudflare AI, Vercel AI, custom)
+  "hosting", // Hosting/DNS providers (Cloudflare zone + API token, Vercel, ...)
   "other",
 ]);
 

--- a/apps/backend/src/api/partners/storefront/dns/route.ts
+++ b/apps/backend/src/api/partners/storefront/dns/route.ts
@@ -52,7 +52,7 @@ export const POST = async (
   const deployment: DeploymentService = req.scope.resolve(DEPLOYMENT_MODULE)
 
   if (providerName === "vercel") {
-    const applied = await deployment.applyRecommendedDns(domain)
+    const applied = await deployment.applyRecommendedDns(domain, req.scope)
 
     let recommendation: Awaited<
       ReturnType<DeploymentService["getDomainConfig"]>
@@ -83,7 +83,7 @@ export const POST = async (
     id: projectRef || domain,
     name: projectRef || domain,
   })
-  const applied = await deployment.ensureCname(domain, target)
+  const applied = await deployment.ensureCname(domain, target, req.scope)
 
   return res.json({
     domain,

--- a/apps/backend/src/api/partners/storefront/domain/verify/route.ts
+++ b/apps/backend/src/api/partners/storefront/domain/verify/route.ts
@@ -60,7 +60,7 @@ export const POST = async (
     // Vercel-only: apply Vercel's recommended DNS via Cloudflare. No-op for
     // domains outside our zone.
     const deployment: DeploymentService = req.scope.resolve(DEPLOYMENT_MODULE)
-    applied = await deployment.applyRecommendedDns(customDomain)
+    applied = await deployment.applyRecommendedDns(customDomain, req.scope)
   } else {
     // Self-heal: idempotently (re)attach each host. `addDomain` reuses an
     // existing provider hostname or creates a missing one — so a domain that

--- a/apps/backend/src/modules/deployment/__tests__/cloudflare-credentials.unit.spec.ts
+++ b/apps/backend/src/modules/deployment/__tests__/cloudflare-credentials.unit.spec.ts
@@ -1,0 +1,95 @@
+import {
+  envCloudflareCreds,
+  pickCloudflareCreds,
+} from "../providers/cloudflare-credentials"
+
+describe("pickCloudflareCreds", () => {
+  const decrypt = (blob: string) => blob.replace(/^enc:/, "")
+
+  it("prefers the encrypted token over plaintext", () => {
+    const out = pickCloudflareCreds(
+      { api_token: "plain-one", api_token_encrypted: "enc:real-one" },
+      decrypt
+    )
+    expect(out?.token).toBe("real-one")
+  })
+
+  it("falls back to plaintext when decryption throws", () => {
+    // A half-migrated row must keep working: the encryption module can be
+    // absent or the blob unreadable, and refusing to fall back would take DNS
+    // down for a partner whose credentials are otherwise fine.
+    const boom = () => {
+      throw new Error("bad key")
+    }
+    const out = pickCloudflareCreds(
+      { api_token: "plain-one", api_token_encrypted: "enc:real-one" },
+      boom
+    )
+    expect(out?.token).toBe("plain-one")
+  })
+
+  it("falls back to plaintext when no decrypt function is available", () => {
+    const out = pickCloudflareCreds({
+      api_token_encrypted: "enc:real-one",
+      api_token: "plain-one",
+    })
+    expect(out?.token).toBe("plain-one")
+  })
+
+  it("accepts token/api_key as aliases so an operator can't fill in the wrong box", () => {
+    expect(pickCloudflareCreds({ token: "t1" })?.token).toBe("t1")
+    expect(pickCloudflareCreds({ api_key: "k1" })?.token).toBe("k1")
+  })
+
+  it("returns null when there is no token at all", () => {
+    expect(pickCloudflareCreds({ zone_id: "z" })).toBeNull()
+    expect(pickCloudflareCreds({})).toBeNull()
+    expect(pickCloudflareCreds(null)).toBeNull()
+    expect(pickCloudflareCreds({ api_token: "" })).toBeNull()
+  })
+
+  it("carries zone id, zone name and account id, trimming blanks to undefined", () => {
+    const out = pickCloudflareCreds({
+      api_token: "t",
+      zone_id: " bff30e4a ",
+      zone_name: "cicilabel.com",
+      account_id: "   ",
+    })
+    expect(out).toMatchObject({
+      token: "t",
+      zoneId: "bff30e4a",
+      zoneName: "cicilabel.com",
+    })
+    // A blank account id must not masquerade as a configured one.
+    expect(out?.accountId).toBeUndefined()
+  })
+
+  it("keeps zone_name usable when zone_id is missing", () => {
+    // The zone id is perishable — a domain removed and re-added to Cloudflare
+    // keeps its name and gets a NEW id. Storing only the name has to remain a
+    // valid configuration, or the recovery path can never run.
+    const out = pickCloudflareCreds({ api_token: "t", zone_name: "cicilabel.com" })
+    expect(out?.zoneId).toBeUndefined()
+    expect(out?.zoneName).toBe("cicilabel.com")
+  })
+})
+
+describe("envCloudflareCreds", () => {
+  it("reads the legacy env trio and tags the source", () => {
+    const out = envCloudflareCreds({
+      CLOUDFLARE_API_TOKEN: "t",
+      CLOUDFLARE_ZONE_ID: "z",
+      CLOUDFLARE_ACCOUNT_ID: "a",
+    } as any)
+    expect(out).toEqual({
+      token: "t",
+      zoneId: "z",
+      accountId: "a",
+      source: "env",
+    })
+  })
+
+  it("is null without a token, so callers skip rather than throw", () => {
+    expect(envCloudflareCreds({ CLOUDFLARE_ZONE_ID: "z" } as any)).toBeNull()
+  })
+})

--- a/apps/backend/src/modules/deployment/providers/cloudflare-credentials.ts
+++ b/apps/backend/src/modules/deployment/providers/cloudflare-credentials.ts
@@ -1,0 +1,187 @@
+/**
+ * Cloudflare credentials, sourced from the external-platform store.
+ *
+ * Mirrors `shipping-providers/resolver.ts`: an admin stores the credentials as
+ * a `SocialPlatform` row (`category: "hosting"`, `api_config.provider_type:
+ * "cloudflare"`), the secret is encrypted at rest, and env vars remain as a
+ * fallback so nothing breaks before a row exists.
+ *
+ * Why this moved off env: the env values silently rotted. The token was dead
+ * AND the stored zone id pointed at a zone that no longer existed — and neither
+ * is visible without making an API call, because `isCloudflareConfigured()`
+ * only ever checked that the strings were PRESENT. A platform row is editable
+ * by an operator without a redeploy, which is the actual point: env is read at
+ * boot, so fixing a bad token used to mean shipping a release.
+ *
+ * ⚠️ The zone id is as perishable as the token. A zone that is deleted and
+ * re-added to Cloudflare — or moved between accounts — keeps its NAME and gets
+ * a NEW id, and the failure surfaces as `auth.zone_not_found` (reads like the
+ * domain is gone) or `9109 Unauthorized` (reads like a permissions problem).
+ * Neither names the real cause, so `zone_name` is stored alongside and
+ * `resolveZoneIdByName` can recover the current id from the API.
+ */
+import { MedusaContainer } from "@medusajs/framework/types"
+import { ENCRYPTION_MODULE } from "../../encryption"
+import type EncryptionService from "../../encryption/service"
+import { SOCIALS_MODULE } from "../../socials"
+
+export const CLOUDFLARE_API_BASE = "https://api.cloudflare.com/client/v4"
+
+export type CloudflareCreds = {
+  token: string
+  zoneId?: string
+  accountId?: string
+  zoneName?: string
+  /** Where these came from — surfaced in status payloads and logs so an
+   *  operator can tell whether their platform row is actually being used. */
+  source: "platform" | "env"
+}
+
+/** The api_config field names an operator fills in on the platform row. */
+const TOKEN_FIELDS = ["api_token", "token", "api_key"] as const
+
+/**
+ * PURE: pick credentials out of an api_config.
+ *
+ * `decrypt` is injected so this is testable without the encryption module, and
+ * so a decryption failure falls through to plaintext exactly the way the
+ * shipping resolver does (a half-migrated row still works).
+ */
+export const pickCloudflareCreds = (
+  apiConfig: Record<string, any> | null | undefined,
+  decrypt?: (blob: string) => string
+): Omit<CloudflareCreds, "source"> | null => {
+  const cfg = apiConfig || {}
+
+  let token: string | undefined
+  for (const field of TOKEN_FIELDS) {
+    const enc = cfg[`${field}_encrypted`]
+    if (enc && decrypt) {
+      try {
+        const out = decrypt(enc)
+        if (out) {
+          token = out
+          break
+        }
+      } catch {
+        /* fall through to plaintext */
+      }
+    }
+    const plain = cfg[field]
+    if (typeof plain === "string" && plain.length) {
+      token = plain
+      break
+    }
+  }
+
+  if (!token) return null
+
+  const str = (v: any) =>
+    typeof v === "string" && v.trim().length ? v.trim() : undefined
+
+  return {
+    token,
+    zoneId: str(cfg.zone_id),
+    accountId: str(cfg.account_id),
+    zoneName: str(cfg.zone_name),
+  }
+}
+
+/** Legacy env credentials. Kept so a deployment with no platform row behaves
+ *  exactly as it did before. */
+export const envCloudflareCreds = (
+  env: NodeJS.ProcessEnv = process.env
+): CloudflareCreds | null => {
+  const token = env.CLOUDFLARE_API_TOKEN
+  if (!token) return null
+  return {
+    token,
+    zoneId: env.CLOUDFLARE_ZONE_ID,
+    accountId: env.CLOUDFLARE_ACCOUNT_ID,
+    source: "env",
+  }
+}
+
+/** Find the active Cloudflare platform row, if one exists. */
+const findCloudflarePlatform = async (
+  container: MedusaContainer
+): Promise<Record<string, any> | null> => {
+  try {
+    const socials = container.resolve(SOCIALS_MODULE) as any
+    const platforms = await socials.listSocialPlatforms({
+      category: "hosting",
+      status: "active",
+    })
+    const match = (platforms || []).find((p: any) => {
+      const cfg = (p.api_config as Record<string, any>) || {}
+      const type = String(
+        cfg.provider_type || cfg.provider || p.name || ""
+      ).toLowerCase()
+      return type === "cloudflare" || type.includes("cloudflare")
+    })
+    return match || null
+  } catch {
+    // socials module unavailable — caller falls back to env
+    return null
+  }
+}
+
+/**
+ * Resolve Cloudflare credentials: platform row first, env second.
+ *
+ * Returns null when neither is configured, which callers treat as "skip DNS"
+ * rather than an error — the same contract `isCloudflareConfigured()` had.
+ */
+export const resolveCloudflareCredentials = async (
+  container?: MedusaContainer
+): Promise<CloudflareCreds | null> => {
+  if (container) {
+    const platform = await findCloudflarePlatform(container)
+    if (platform) {
+      let decrypt: ((blob: string) => string) | undefined
+      try {
+        const encryption = container.resolve(
+          ENCRYPTION_MODULE
+        ) as EncryptionService
+        decrypt = (blob: string) => (encryption as any).decrypt(blob)
+      } catch {
+        /* no encryption module — plaintext only */
+      }
+
+      const picked = pickCloudflareCreds(
+        platform.api_config as Record<string, any>,
+        decrypt
+      )
+      if (picked) return { ...picked, source: "platform" }
+    }
+  }
+  return envCloudflareCreds()
+}
+
+/**
+ * Look up a zone's CURRENT id by name.
+ *
+ * Exists because a stored zone id is a snapshot, not an identity: re-adding a
+ * domain to Cloudflare gives it a new id while the name stays put. When that
+ * happens every DNS call fails with an error that blames auth, so being able
+ * to re-derive the id from the name is the difference between a one-line fix
+ * and a day of chasing a permissions ghost.
+ */
+export const resolveZoneIdByName = async (
+  creds: CloudflareCreds,
+  zoneName: string
+): Promise<string | null> => {
+  const res = await fetch(
+    `${CLOUDFLARE_API_BASE}/zones?name=${encodeURIComponent(zoneName)}`,
+    {
+      headers: {
+        Authorization: `Bearer ${creds.token}`,
+        "Content-Type": "application/json",
+      },
+    }
+  )
+  const data: any = await res.json().catch(() => null)
+  if (!data?.success) return null
+  const zone = (data.result || [])[0]
+  return zone?.id ?? null
+}

--- a/apps/backend/src/modules/deployment/service.ts
+++ b/apps/backend/src/modules/deployment/service.ts
@@ -6,8 +6,14 @@
  */
 
 import { MedusaService } from "@medusajs/framework/utils";
+import type { MedusaContainer } from "@medusajs/framework/types";
 
 import DeploymentAccount from "./models/deployment-account";
+import {
+  resolveCloudflareCredentials,
+  resolveZoneIdByName,
+  type CloudflareCreds,
+} from "./providers/cloudflare-credentials";
 
 // ─── Types ───────────────────────────────────────────────────────────────────
 
@@ -100,14 +106,28 @@ class DeploymentService extends MedusaService({ DeploymentAccount }) {
     return Boolean(process.env.VERCEL_TOKEN)
   }
 
-  isCloudflareConfigured(): boolean {
-    const configured = Boolean(
-      process.env.CLOUDFLARE_API_TOKEN && process.env.CLOUDFLARE_ZONE_ID
-    )
+  /**
+   * Whether Cloudflare DNS can be driven at all.
+   *
+   * Pass the app container to consult the operator-managed platform row
+   * (`category: "hosting"`, `provider_type: "cloudflare"`); without it this
+   * falls back to env, which is what a caller with no container gets.
+   *
+   * ⚠️ This is a PRESENCE check, not a validity check. It answers "are there
+   * credentials to try", never "do they work" — a dead token and a stale zone
+   * id both pass here and fail at the API. That is exactly how the last
+   * breakage stayed invisible, so do not read a `true` as healthy.
+   */
+  async isCloudflareConfigured(
+    appContainer?: MedusaContainer
+  ): Promise<boolean> {
+    const creds = await resolveCloudflareCredentials(appContainer)
+    const configured = Boolean(creds?.token && (creds?.zoneId || creds?.zoneName))
     if (!configured) {
       this.log("warn", "Cloudflare not configured", {
-        hasToken: Boolean(process.env.CLOUDFLARE_API_TOKEN),
-        hasZoneId: Boolean(process.env.CLOUDFLARE_ZONE_ID),
+        hasToken: Boolean(creds?.token),
+        hasZoneId: Boolean(creds?.zoneId),
+        source: creds?.source ?? "none",
       })
     }
     return configured
@@ -401,16 +421,51 @@ class DeploymentService extends MedusaService({ DeploymentAccount }) {
 
   // ── Cloudflare ──────────────────────────────────────────────────────────
 
-  private cloudflareHeaders(): Record<string, string> {
-    const token = process.env.CLOUDFLARE_API_TOKEN
-    if (!token) throw new Error("CLOUDFLARE_API_TOKEN environment variable is not set")
-    return { Authorization: `Bearer ${token}`, "Content-Type": "application/json" }
+  /**
+   * Resolve credentials once per operation and hand them down, rather than
+   * re-reading them per HTTP call. Kept explicit (no instance cache) because
+   * the module service is long-lived: a cached token would outlive an
+   * operator's rotation and the fix would look like it hadn't worked.
+   */
+  private async cloudflareCreds(
+    appContainer?: MedusaContainer
+  ): Promise<CloudflareCreds> {
+    const creds = await resolveCloudflareCredentials(appContainer)
+    if (!creds?.token) {
+      throw new Error(
+        "Cloudflare is not configured: add an active platform (category 'hosting', provider_type 'cloudflare') with an api_token, or set CLOUDFLARE_API_TOKEN."
+      )
+    }
+    return creds
   }
 
-  private cloudflareZoneId(): string {
-    const zoneId = process.env.CLOUDFLARE_ZONE_ID
-    if (!zoneId) throw new Error("CLOUDFLARE_ZONE_ID environment variable is not set")
-    return zoneId
+  private cloudflareHeaders(creds: CloudflareCreds): Record<string, string> {
+    return {
+      Authorization: `Bearer ${creds.token}`,
+      "Content-Type": "application/json",
+    }
+  }
+
+  /**
+   * The zone to write into. Prefers the stored id, but falls back to looking it
+   * up by name — a zone removed and re-added to Cloudflare keeps its name and
+   * gets a NEW id, and every call then fails with an error that blames auth
+   * rather than the id.
+   */
+  private async cloudflareZoneId(creds: CloudflareCreds): Promise<string> {
+    if (creds.zoneId) return creds.zoneId
+    if (creds.zoneName) {
+      const found = await resolveZoneIdByName(creds, creds.zoneName)
+      if (found) {
+        this.log("info", "Cloudflare zone id resolved by name", {
+          zoneName: creds.zoneName,
+        })
+        return found
+      }
+    }
+    throw new Error(
+      "Cloudflare zone is not configured: set zone_id (or zone_name) on the platform row, or CLOUDFLARE_ZONE_ID."
+    )
   }
 
   async createDnsRecord(input: {
@@ -419,12 +474,13 @@ class DeploymentService extends MedusaService({ DeploymentAccount }) {
     type?: string
     proxied?: boolean
     ttl?: number
-  }): Promise<CloudflareDnsRecord> {
-    const zoneId = this.cloudflareZoneId()
+  }, creds?: CloudflareCreds): Promise<CloudflareDnsRecord> {
+    const c = creds ?? (await this.cloudflareCreds())
+    const zoneId = await this.cloudflareZoneId(c)
     this.log("info", `Cloudflare createDnsRecord`, { zoneId: zoneId.slice(0, 8) + "...", name: input.name, content: input.content })
     const res = await fetch(`${CLOUDFLARE_API_BASE}/zones/${zoneId}/dns_records`, {
       method: "POST",
-      headers: this.cloudflareHeaders(),
+      headers: this.cloudflareHeaders(c),
       body: JSON.stringify({
         type: input.type || "CNAME",
         name: input.name,
@@ -446,14 +502,15 @@ class DeploymentService extends MedusaService({ DeploymentAccount }) {
   async listDnsRecords(input: {
     name?: string
     type?: string
-  }): Promise<CloudflareDnsRecord[]> {
-    const zoneId = this.cloudflareZoneId()
+  }, creds?: CloudflareCreds): Promise<CloudflareDnsRecord[]> {
+    const c = creds ?? (await this.cloudflareCreds())
+    const zoneId = await this.cloudflareZoneId(c)
     const params = new URLSearchParams()
     if (input.name) params.set("name", input.name)
     if (input.type) params.set("type", input.type)
     const res = await fetch(
       `${CLOUDFLARE_API_BASE}/zones/${zoneId}/dns_records?${params.toString()}`,
-      { method: "GET", headers: this.cloudflareHeaders() }
+      { method: "GET", headers: this.cloudflareHeaders(c) }
     )
     const data: CloudflareResponse<CloudflareDnsRecord[]> = await res.json()
     if (!data.success) {
@@ -464,14 +521,16 @@ class DeploymentService extends MedusaService({ DeploymentAccount }) {
 
   async updateDnsRecord(
     recordId: string,
-    input: { name: string; content: string; type?: string; proxied?: boolean; ttl?: number }
+    input: { name: string; content: string; type?: string; proxied?: boolean; ttl?: number },
+    creds?: CloudflareCreds
   ): Promise<CloudflareDnsRecord> {
-    const zoneId = this.cloudflareZoneId()
+    const c = creds ?? (await this.cloudflareCreds())
+    const zoneId = await this.cloudflareZoneId(c)
     const res = await fetch(
       `${CLOUDFLARE_API_BASE}/zones/${zoneId}/dns_records/${recordId}`,
       {
         method: "PUT",
-        headers: this.cloudflareHeaders(),
+        headers: this.cloudflareHeaders(c),
         body: JSON.stringify({
           type: input.type || "CNAME",
           name: input.name,
@@ -488,11 +547,12 @@ class DeploymentService extends MedusaService({ DeploymentAccount }) {
     return data.result
   }
 
-  async deleteDnsRecord(recordId: string): Promise<void> {
-    const zoneId = this.cloudflareZoneId()
+  async deleteDnsRecord(recordId: string, creds?: CloudflareCreds): Promise<void> {
+    const c = creds ?? (await this.cloudflareCreds())
+    const zoneId = await this.cloudflareZoneId(c)
     const res = await fetch(
       `${CLOUDFLARE_API_BASE}/zones/${zoneId}/dns_records/${recordId}`,
-      { method: "DELETE", headers: this.cloudflareHeaders() }
+      { method: "DELETE", headers: this.cloudflareHeaders(c) }
     )
     const data: CloudflareResponse<{ id: string }> = await res.json()
     if (!data.success) {
@@ -508,20 +568,23 @@ class DeploymentService extends MedusaService({ DeploymentAccount }) {
    */
   async ensureVercelCname(
     subdomain: string,
-    rootDomain: string
+    rootDomain: string,
+    appContainer?: MedusaContainer
   ): Promise<EnsureCnameResult> {
     this.log("info", `ensureVercelCname called`, { subdomain, rootDomain })
 
-    if (!this.isCloudflareConfigured()) {
+    if (!(await this.isCloudflareConfigured(appContainer))) {
       this.log("warn", "ensureVercelCname skipped — Cloudflare not configured")
       return { action: "skipped", reason: "Cloudflare not configured" }
     }
+
+    const creds = await this.cloudflareCreds(appContainer)
 
     const fullDomain = `${subdomain}.${rootDomain}`
     const vercelCname = "cname.vercel-dns.com"
 
     this.log("info", `Looking up existing CNAME for ${fullDomain}`)
-    const existing = await this.listDnsRecords({ name: fullDomain, type: "CNAME" })
+    const existing = await this.listDnsRecords({ name: fullDomain, type: "CNAME" }, creds)
     this.log("info", `Found ${existing.length} existing records for ${fullDomain}`)
 
     if (existing.length > 0) {
@@ -535,7 +598,7 @@ class DeploymentService extends MedusaService({ DeploymentAccount }) {
         name: fullDomain,
         content: vercelCname,
         proxied: false,
-      })
+      }, creds)
       this.log("info", `CNAME updated successfully`, { id: updated.id })
       return { action: "updated", record: updated }
     }
@@ -545,7 +608,7 @@ class DeploymentService extends MedusaService({ DeploymentAccount }) {
       name: fullDomain,
       content: vercelCname,
       proxied: false,
-    })
+    }, creds)
     this.log("info", `CNAME created successfully`, { id: created.id, name: created.name })
     return { action: "created", record: created }
   }
@@ -564,11 +627,14 @@ class DeploymentService extends MedusaService({ DeploymentAccount }) {
    *     recommended records, leaving DNS apply to the operator)
    */
   async applyRecommendedDns(
-    domain: string
+    domain: string,
+    appContainer?: MedusaContainer
   ): Promise<ApplyRecommendedDnsResult> {
-    if (!this.isCloudflareConfigured()) {
+    if (!(await this.isCloudflareConfigured(appContainer))) {
       return { action: "skipped", reason: "Cloudflare not configured" }
     }
+
+    const creds = await this.cloudflareCreds(appContainer)
 
     let config: VercelDomainConfig | null = null
     try {
@@ -593,7 +659,7 @@ class DeploymentService extends MedusaService({ DeploymentAccount }) {
       : recommendedCNAME || "cname.vercel-dns.com"
 
     try {
-      const existing = await this.listDnsRecords({ name: domain, type })
+      const existing = await this.listDnsRecords({ name: domain, type }, creds)
 
       if (existing.length > 0) {
         const record = existing[0]
@@ -606,7 +672,7 @@ class DeploymentService extends MedusaService({ DeploymentAccount }) {
           content,
           type,
           proxied: false,
-        })
+        }, creds)
         this.log(
           "info",
           `applyRecommendedDns: updated ${type} for ${domain} → ${content}`
@@ -619,7 +685,7 @@ class DeploymentService extends MedusaService({ DeploymentAccount }) {
         content,
         type,
         proxied: false,
-      })
+      }, creds)
       this.log(
         "info",
         `applyRecommendedDns: created ${type} for ${domain} → ${content}`
@@ -642,13 +708,15 @@ class DeploymentService extends MedusaService({ DeploymentAccount }) {
    */
   async ensureCname(
     fullDomain: string,
-    target: string
+    target: string,
+    appContainer?: MedusaContainer
   ): Promise<ApplyRecommendedDnsResult> {
-    if (!this.isCloudflareConfigured()) {
+    if (!(await this.isCloudflareConfigured(appContainer))) {
       return { action: "skipped", reason: "Cloudflare not configured" }
     }
+    const creds = await this.cloudflareCreds(appContainer)
     try {
-      const existing = await this.listDnsRecords({ name: fullDomain, type: "CNAME" })
+      const existing = await this.listDnsRecords({ name: fullDomain, type: "CNAME" }, creds)
       if (existing.length > 0) {
         const record = existing[0]
         if (record.content === target) {
@@ -659,7 +727,7 @@ class DeploymentService extends MedusaService({ DeploymentAccount }) {
           content: target,
           type: "CNAME",
           proxied: false,
-        })
+        }, creds)
         return { action: "updated", type: "CNAME", name: fullDomain, content: target, record: updated }
       }
       const created = await this.createDnsRecord({
@@ -667,7 +735,7 @@ class DeploymentService extends MedusaService({ DeploymentAccount }) {
         content: target,
         type: "CNAME",
         proxied: false,
-      })
+      }, creds)
       return { action: "created", type: "CNAME", name: fullDomain, content: target, record: created }
     } catch (e: any) {
       this.log("error", `ensureCname failed for ${fullDomain}`, { error: e.message })
@@ -687,7 +755,7 @@ class DeploymentService extends MedusaService({ DeploymentAccount }) {
       return []
     }
 
-    if (!this.isCloudflareConfigured()) {
+    if (!(await this.isCloudflareConfigured())) {
       this.log("warn", "Cannot create verification records — Cloudflare not configured")
       return verification.map((v) => ({ domain: v.domain, action: "skipped" }))
     }
@@ -740,16 +808,19 @@ class DeploymentService extends MedusaService({ DeploymentAccount }) {
    * Remove DNS record for a storefront domain. Skips if Cloudflare is not configured.
    */
   async removeStorefrontDns(
-    domain: string
+    domain: string,
+    appContainer?: MedusaContainer
   ): Promise<{ action: string; error?: string }> {
-    if (!this.isCloudflareConfigured()) {
+    if (!(await this.isCloudflareConfigured(appContainer))) {
       return { action: "skipped" }
     }
 
+    const creds = await this.cloudflareCreds(appContainer)
+
     try {
-      const records = await this.listDnsRecords({ name: domain, type: "CNAME" })
+      const records = await this.listDnsRecords({ name: domain, type: "CNAME" }, creds)
       if (records.length > 0) {
-        await this.deleteDnsRecord(records[0].id)
+        await this.deleteDnsRecord(records[0].id, creds)
         return { action: "deleted" }
       }
       return { action: "not_found" }

--- a/apps/backend/src/workflows/partners/get-partner-storefront-status.ts
+++ b/apps/backend/src/workflows/partners/get-partner-storefront-status.ts
@@ -67,7 +67,7 @@ export const resolvePartnerStorefrontStatusStep = createStep(
         provider: refs.providerName,
         message: "Storefront has not been provisioned yet",
         vercel_configured: deployment.isVercelConfigured(),
-        cloudflare_configured: deployment.isCloudflareConfigured(),
+        cloudflare_configured: await deployment.isCloudflareConfigured(container),
       } as PartnerStorefrontStatus)
     }
 
@@ -135,7 +135,7 @@ export const resolvePartnerStorefrontStatusStep = createStep(
         project: { id: project.id, name: project.name },
         latest_deployment: deploymentInfo,
         vercel_configured: deployment.isVercelConfigured(),
-        cloudflare_configured: deployment.isCloudflareConfigured(),
+        cloudflare_configured: await deployment.isCloudflareConfigured(container),
       } as PartnerStorefrontStatus)
     } catch (e: any) {
       // Project no longer exists on the provider — the refs we hold are stale.

--- a/apps/backend/src/workflows/stores/provision-storefront.ts
+++ b/apps/backend/src/workflows/stores/provision-storefront.ts
@@ -346,7 +346,7 @@ const createCnameStep = createStep(
     try {
       if (input.providerName === "vercel") {
         // Vercel's per-project CNAME recommendation (e.g. <hash>.vercel-dns-017.com).
-        const result = await deployment.applyRecommendedDns(fullDomain)
+        const result = await deployment.applyRecommendedDns(fullDomain, container)
         console.log("[provision-storefront] DNS (vercel recommended):", JSON.stringify(result))
         return new StepResponse(result as any)
       }
@@ -375,7 +375,7 @@ const createCnameStep = createStep(
         name: input.projectName,
         originHost: input.originHost ?? undefined,
       })
-      const result = await deployment.ensureCname(fullDomain, target)
+      const result = await deployment.ensureCname(fullDomain, target, container)
       console.log(
         `[provision-storefront] DNS (${input.providerName} CNAME → ${target}):`,
         JSON.stringify(result)


### PR DESCRIPTION
Subdomain assignment on `cicilabel.com` was broken. The way it broke is the reason for this change.

## What was actually wrong

**Two stored values had rotted independently**, and fixing either alone would still have failed:

| | stored | actual |
|---|---|---|
| `CLOUDFLARE_API_TOKEN` | dead — `10000 Authentication error` even against the correct zone | needs rotation |
| `CLOUDFLARE_ZONE_ID` | `ac80552084461805e37b7cb1313863cd` | **`bff30e4ab635df5f3fbacd68630612f0`** |
| `CLOUDFLARE_ACCOUNT_ID` | `c9b8b538ae53cd197539e3d1228e6dbe` | **`9719d38e64dffe8fd6982afb3a7b25f6`** |

Neither is visible without making an API call, because **`isCloudflareConfigured()` only checked that the strings were PRESENT**. The platform reported itself configured while every DNS write failed.

**The errors blame the wrong thing.** A stale zone id surfaces as `auth.zone_not_found` — which reads as "the domain is gone" — or `9109 Unauthorized`, which reads as a permissions problem. Diagnosing it meant listing zones with a known-good token and comparing ids.

One more trap, found while testing a replacement key: `/user/tokens/verify` returns **`Invalid API Token`** for an account-owned (`cfat_`) token, because that endpoint only verifies *user-owned* ones. The account-scoped endpoint answers `"This API Token is valid and active"` for the same key. An error that names the credential when the fault is the endpoint — I nearly rejected a working token on it.

## The change

Credentials resolve from a `SocialPlatform` row, mirroring `shipping-providers/resolver.ts`:

- `category: "hosting"` *(new enum member)*, `api_config.provider_type: "cloudflare"`, `status: "active"`
- secret encrypted at rest (`api_token_encrypted`), plaintext fallback so a half-migrated row still works, `token`/`api_key` accepted as aliases
- **env remains the final fallback**, so nothing breaks before a row exists

The operational point: an operator can rotate a token **without a redeploy**. Env is read at boot, so fixing a dead key previously meant shipping a release.

## Two additions, both learned from this failure

**`zone_name` recovers a stale `zone_id`.** A domain removed and re-added to Cloudflare keeps its name and gets a new id — the id is a snapshot, not an identity. When `zone_id` is absent, the zone is looked up by name via the API.

**`isCloudflareConfigured()` no longer pretends to be a health check.** It's documented as presence-only and reports which source (`platform` vs `env`) is in play. Its previous `true` was actively misleading.

Credentials are resolved **once per operation and threaded down**, not cached on the service — the module service is long-lived, and a cached token would outlive an operator's rotation, making the fix look like it hadn't worked.

## Scope

**No secret is written by this commit.** The platform row is created by an operator; nothing changes until it exists.

The `deployment_account` row (CF-as-hosting-provider) carries the same stale ids and is `status: inactive` by design — `provision-storefront.ts` defers that tier because CF's SaaS path can't serve a bare apex without Enterprise. Deliberately left alone rather than widening this change.

## Verification

| | |
|---|---|
| 9 unit | encrypted-over-plaintext, fallback when decryption throws or is unavailable, field aliases, blank-vs-missing, `zone_name` surviving without `zone_id` |
| tsc | **75 errors with this change, 75 on a clean stash** — measured, not assumed |
| gate | `check:prod-build` passes |

The token that will go in the row was proven end-to-end out of band: a real CNAME created on `cicilabel.com` and deleted again, with the zone re-queried to confirm 0 remaining.

🤖 Generated with [Claude Code](https://claude.com/claude-code)