### PR TITLE
fix(production-policy): show the rules that are in force, not just the stored ones

### DIFF
--- a/apps/backend/src/admin/hooks/api/production-run-policy.ts
+++ b/apps/backend/src/admin/hooks/api/production-run-policy.ts
@@ -13,8 +13,18 @@ export type AdminProductionRunPolicy = {
   deleted_at?: Date | null
 }
 
+/** Which parts of the policy are in force but absent from the stored row. */
+export type AdminProductionRunPolicyMissing = {
+  transitions: string[]
+  sections: string[]
+}
+
 export type AdminProductionRunPolicyResponse = {
   policy: AdminProductionRunPolicy
+  /** Defaults with the stored row layered on top — what actually governs
+   *  transitions. The stored `policy.config` can be a strict subset. */
+  effective_config: Record<string, any>
+  missing: AdminProductionRunPolicyMissing
 }
 
 export type AdminUpdateProductionRunPolicyPayload = {
@@ -41,6 +51,8 @@ export const useProductionRunPolicy = () => {
   return {
     ...rest,
     policy: data?.policy,
+    effectiveConfig: data?.effective_config,
+    missing: data?.missing,
   }
 }
 

--- a/apps/backend/src/admin/routes/settings/production-run-policy/page.tsx
+++ b/apps/backend/src/admin/routes/settings/production-run-policy/page.tsx
@@ -9,8 +9,17 @@ import {
 } from "../../../hooks/api/production-run-policy"
 
 const ProductionRunPolicyPage = () => {
-  const { policy, isLoading } = useProductionRunPolicy()
+  const { policy, effectiveConfig, missing, isLoading } =
+    useProductionRunPolicy()
   const updatePolicy = useUpdateProductionRunPolicy()
+
+  // Rules that govern the system but aren't in the stored row. The row is
+  // seeded with defaults once, at creation, and never backfilled — so a policy
+  // created before a key existed runs on that key's default forever while the
+  // editor below shows no sign of it.
+  const missingTransitions = missing?.transitions ?? []
+  const missingSections = missing?.sections ?? []
+  const hasGap = missingTransitions.length > 0 || missingSections.length > 0
 
   const initialText = useMemo(() => {
     return JSON.stringify(policy?.config || {}, null, 2)
@@ -53,6 +62,31 @@ const ProductionRunPolicyPage = () => {
         </Text>
       </div>
 
+      {hasGap && (
+        <div className="px-6 py-4 bg-ui-tag-orange-bg space-y-2">
+          <Text size="small" weight="plus">
+            Some rules are in force but not saved
+          </Text>
+          <Text className="text-ui-fg-subtle" size="small">
+            The editor below shows only what is stored. These are running on
+            their built-in defaults, and editing the box will not change them —
+            add them explicitly to take control of them.
+          </Text>
+          {missingSections.length > 0 && (
+            <Text className="text-ui-fg-subtle" size="small">
+              Missing sections:{" "}
+              <span className="font-mono">{missingSections.join(", ")}</span>
+            </Text>
+          )}
+          {missingTransitions.length > 0 && (
+            <Text className="text-ui-fg-subtle" size="small">
+              Missing transitions:{" "}
+              <span className="font-mono">{missingTransitions.join(", ")}</span>
+            </Text>
+          )}
+        </div>
+      )}
+
       <div className="px-6 py-4 space-y-3">
         <Textarea
           value={raw}
@@ -77,7 +111,23 @@ const ProductionRunPolicyPage = () => {
           </Text>
         )}
 
-        <div className="flex justify-end">
+        <div className="flex justify-end gap-x-2">
+          {hasGap && (
+            <Button
+              variant="secondary"
+              disabled={isLoading || updatePolicy.isPending}
+              onClick={() => {
+                // Load what is actually in force into the editor. This does not
+                // save — the operator still reviews and presses Save, so
+                // adopting the defaults stays a deliberate act rather than
+                // something that happens to a live gating policy by itself.
+                setRaw(JSON.stringify(effectiveConfig ?? {}, null, 2))
+                setJsonError(null)
+              }}
+            >
+              Load effective policy
+            </Button>
+          )}
           <Button
             onClick={onSave}
             disabled={Boolean(jsonError) || isLoading || updatePolicy.isPending}
@@ -85,6 +135,19 @@ const ProductionRunPolicyPage = () => {
             Save
           </Button>
         </div>
+      </div>
+
+      <div className="px-6 py-4 space-y-2">
+        <Text size="small" weight="plus">
+          Effective policy (read-only)
+        </Text>
+        <Text className="text-ui-fg-subtle" size="small">
+          What actually governs transitions right now: the defaults with the
+          stored config above layered on top.
+        </Text>
+        <pre className="bg-ui-bg-subtle rounded-lg p-3 font-mono text-xs overflow-x-auto">
+          {JSON.stringify(effectiveConfig ?? {}, null, 2)}
+        </pre>
       </div>
     </Container>
   )

--- a/apps/backend/src/api/admin/production-run-policy/route.ts
+++ b/apps/backend/src/api/admin/production-run-policy/route.ts
@@ -100,9 +100,17 @@ export const GET = async (req: MedusaRequest, res: MedusaResponse) => {
     PRODUCTION_POLICY_MODULE
   )
 
-  const policy = await productionPolicyService.getOrCreatePolicy()
+  // `policy` is the row exactly as stored — unchanged, so existing consumers
+  // are unaffected. `effective_config` is what actually governs transitions
+  // (defaults with the stored row layered on top), and `missing` names the keys
+  // that are in force but absent from the row.
+  //
+  // Reading the two separately is deliberate: the stored row predates several
+  // transition keys and the whole reassignment block, and showing only the
+  // stored config is what made those rules invisible. Nothing here writes.
+  const view = await productionPolicyService.getPolicyView()
 
-  return res.status(200).json({ policy })
+  return res.status(200).json(view)
 }
 
 export const PUT = async (

--- a/apps/backend/src/modules/production_policy/__tests__/policy-config.unit.spec.ts
+++ b/apps/backend/src/modules/production_policy/__tests__/policy-config.unit.spec.ts
@@ -1,0 +1,133 @@
+import {
+  DEFAULT_TRANSITIONS,
+  defaultPolicyConfig,
+  mergePolicyConfig,
+  missingPolicyKeys,
+} from "../policy-config"
+
+/** The shape prod actually stores: 4 of the 9 transition keys, no reassignment. */
+const PROD_SHAPED_CONFIG = {
+  transitions: {
+    accept_from: ["sent_to_partner"],
+    approve_from: ["draft", "pending_review"],
+    dispatch_from: ["approved"],
+    send_to_production_from: ["approved"],
+  },
+}
+
+describe("mergePolicyConfig", () => {
+  it("fills in transition keys the stored row has never heard of", () => {
+    const merged = mergePolicyConfig(PROD_SHAPED_CONFIG)
+
+    expect(Object.keys(merged.transitions).sort()).toEqual(
+      Object.keys(DEFAULT_TRANSITIONS).sort()
+    )
+    // The five that prod is missing today.
+    expect(merged.transitions.start_work_from).toEqual(["in_progress"])
+    expect(merged.transitions.finish_work_from).toEqual(["in_progress"])
+    expect(merged.transitions.complete_work_from).toEqual(["in_progress"])
+    expect(merged.transitions.decline_from).toContain("sent_to_partner")
+    expect(merged.transitions.assign_partner_from).toContain(
+      "awaiting_reassignment"
+    )
+  })
+
+  it("supplies the whole reassignment block when it is absent", () => {
+    // This is the mechanism behind the inert auto-accept switch: the key isn't
+    // stored, so the switch always read the default no matter what was shown.
+    const merged = mergePolicyConfig(PROD_SHAPED_CONFIG)
+    expect(merged.reassignment).toEqual({
+      same_partner_retries: 1,
+      auto_accept_on_retry: false,
+    })
+  })
+
+  it("lets a stored value win over the default", () => {
+    const merged = mergePolicyConfig({
+      transitions: { approve_from: ["draft"] },
+      reassignment: { same_partner_retries: 3, auto_accept_on_retry: true },
+    })
+    expect(merged.transitions.approve_from).toEqual(["draft"])
+    expect(merged.reassignment).toEqual({
+      same_partner_retries: 3,
+      auto_accept_on_retry: true,
+    })
+  })
+
+  it("honours an empty array — 'nothing may do this' is a real policy", () => {
+    // The trap: treating [] as falsy would silently re-open a transition an
+    // operator deliberately closed, which is the most dangerous possible
+    // direction for a merge to be wrong in.
+    const merged = mergePolicyConfig({ transitions: { approve_from: [] } })
+    expect(merged.transitions.approve_from).toEqual([])
+  })
+
+  it("ignores malformed stored values rather than propagating them", () => {
+    const merged = mergePolicyConfig({
+      transitions: { approve_from: "draft" as any },
+    })
+    expect(merged.transitions.approve_from).toEqual(
+      DEFAULT_TRANSITIONS.approve_from
+    )
+  })
+
+  it("keeps unknown keys instead of silently discarding an operator's edit", () => {
+    const merged = mergePolicyConfig({
+      transitions: { future_from: ["draft"] },
+      something_else: { enabled: true },
+    })
+    expect(merged.transitions.future_from).toEqual(["draft"])
+    expect(merged.something_else).toEqual({ enabled: true })
+  })
+
+  it("returns the full defaults for an empty or missing config", () => {
+    expect(mergePolicyConfig(null)).toEqual(defaultPolicyConfig())
+    expect(mergePolicyConfig({})).toEqual(defaultPolicyConfig())
+  })
+
+  it("coerces a nonsense retry count back to the default", () => {
+    expect(
+      mergePolicyConfig({ reassignment: { same_partner_retries: -2 } })
+        .reassignment.same_partner_retries
+    ).toBe(1)
+    expect(
+      mergePolicyConfig({ reassignment: { same_partner_retries: "many" } })
+        .reassignment.same_partner_retries
+    ).toBe(1)
+    // 0 is meaningful — cap then park immediately — and must survive.
+    expect(
+      mergePolicyConfig({ reassignment: { same_partner_retries: 0 } })
+        .reassignment.same_partner_retries
+    ).toBe(0)
+  })
+})
+
+describe("missingPolicyKeys", () => {
+  it("names exactly what prod is running on defaults", () => {
+    const missing = missingPolicyKeys(PROD_SHAPED_CONFIG)
+    expect(missing.transitions.sort()).toEqual(
+      [
+        "assign_partner_from",
+        "complete_work_from",
+        "decline_from",
+        "finish_work_from",
+        "start_work_from",
+      ].sort()
+    )
+    expect(missing.sections).toEqual(["reassignment"])
+  })
+
+  it("reports nothing missing for a fully-populated config", () => {
+    const missing = missingPolicyKeys(defaultPolicyConfig())
+    expect(missing.transitions).toEqual([])
+    expect(missing.sections).toEqual([])
+  })
+
+  it("reports both sections missing for an empty config", () => {
+    const missing = missingPolicyKeys({})
+    expect(missing.sections).toEqual(["transitions", "reassignment"])
+    expect(missing.transitions).toHaveLength(
+      Object.keys(DEFAULT_TRANSITIONS).length
+    )
+  })
+})

--- a/apps/backend/src/modules/production_policy/policy-config.ts
+++ b/apps/backend/src/modules/production_policy/policy-config.ts
@@ -1,0 +1,137 @@
+/**
+ * The production-run policy's shape, its defaults, and how a stored config is
+ * reconciled with them.
+ *
+ * Why this exists: the stored policy row is seeded with defaults exactly once,
+ * at creation, and every key added to the policy since then has never reached
+ * it. Prod's row (created long before `start_work_from`, `decline_from`,
+ * `assign_partner_from` or `reassignment` existed) carries 4 of the 9
+ * transition keys and no reassignment block at all.
+ *
+ * Nothing broke, because every read falls back per key — which is precisely why
+ * it went unnoticed for so long. What DID break is the operator's view: the
+ * settings screen renders the stored config, so it presents "the rules that
+ * gate approve, dispatch and accept" while showing fewer than half of them, and
+ * the reassignment switch reads a key that isn't there.
+ *
+ * These helpers are pure so the reconciliation can be tested without a DB.
+ */
+
+/** #1228 — what the reminder cap does before parking a run for reassignment. */
+export type ReassignmentPolicy = {
+  same_partner_retries: number
+  auto_accept_on_retry: boolean
+}
+
+export const DEFAULT_REASSIGNMENT_POLICY: ReassignmentPolicy = {
+  same_partner_retries: 1,
+  auto_accept_on_retry: false,
+}
+
+/** Every transition key the policy understands, and the statuses each allows. */
+export const DEFAULT_TRANSITIONS: Record<string, string[]> = {
+  approve_from: ["draft", "pending_review"],
+  dispatch_from: ["approved"],
+  send_to_production_from: ["approved"],
+  accept_from: ["sent_to_partner"],
+  // Partner work lifecycle. Accepting moves the run to in_progress; start/
+  // finish/complete then stage within it via the lifecycle timestamps.
+  start_work_from: ["in_progress"],
+  finish_work_from: ["in_progress"],
+  complete_work_from: ["in_progress"],
+  decline_from: [
+    "draft",
+    "pending_review",
+    "approved",
+    "sent_to_partner",
+    "in_progress",
+  ],
+  // #1228 — manual (re)assignment, deliberately separate from dispatch_from.
+  assign_partner_from: [
+    "awaiting_reassignment",
+    "draft",
+    "pending_review",
+    "approved",
+    "sent_to_partner",
+  ],
+}
+
+export const defaultPolicyConfig = (): Record<string, any> => ({
+  transitions: { ...DEFAULT_TRANSITIONS },
+  reassignment: { ...DEFAULT_REASSIGNMENT_POLICY },
+})
+
+/**
+ * PURE: the config that actually governs the system — defaults with the stored
+ * config layered on top, key by key.
+ *
+ * Merged rather than replaced so that a row missing newer keys still reports
+ * the rules those keys enforce. A stored key always wins, including one whose
+ * value is an empty array: "no status may do this" is a legitimate policy and
+ * must not silently revert to the default.
+ */
+export const mergePolicyConfig = (
+  stored: Record<string, any> | null | undefined
+): Record<string, any> => {
+  const defaults = defaultPolicyConfig()
+  const cfg = stored || {}
+
+  const storedTransitions = (cfg.transitions || {}) as Record<string, any>
+  const transitions: Record<string, any> = { ...defaults.transitions }
+  for (const [key, value] of Object.entries(storedTransitions)) {
+    // Keep unknown keys: an operator may be staging a rename, and dropping
+    // their edit silently would be worse than carrying a key nothing reads.
+    if (Array.isArray(value) && value.every((v) => typeof v === "string")) {
+      transitions[key] = value
+    } else if (!(key in transitions)) {
+      transitions[key] = value
+    }
+  }
+
+  const storedReassignment = (cfg.reassignment || {}) as Record<string, any>
+  const retries = Number(storedReassignment.same_partner_retries)
+  const reassignment: ReassignmentPolicy = {
+    same_partner_retries:
+      Number.isFinite(retries) && retries >= 0
+        ? Math.floor(retries)
+        : DEFAULT_REASSIGNMENT_POLICY.same_partner_retries,
+    auto_accept_on_retry:
+      typeof storedReassignment.auto_accept_on_retry === "boolean"
+        ? storedReassignment.auto_accept_on_retry
+        : DEFAULT_REASSIGNMENT_POLICY.auto_accept_on_retry,
+  }
+
+  // Carry any other top-level keys the stored config has, so this never
+  // silently discards something an operator put there.
+  const rest: Record<string, any> = {}
+  for (const [key, value] of Object.entries(cfg)) {
+    if (key !== "transitions" && key !== "reassignment") rest[key] = value
+  }
+
+  return { ...rest, transitions, reassignment }
+}
+
+/**
+ * PURE: which parts of the policy are running on defaults because the stored
+ * row has never heard of them.
+ *
+ * Surfaced to the operator so the settings screen can say "these 6 rules are in
+ * force but not saved" instead of quietly omitting them — the omission is what
+ * made the inert reassignment switch look like a UI bug rather than a missing
+ * key.
+ */
+export const missingPolicyKeys = (
+  stored: Record<string, any> | null | undefined
+): { transitions: string[]; sections: string[] } => {
+  const cfg = stored || {}
+  const storedTransitions = (cfg.transitions || {}) as Record<string, any>
+
+  const transitions = Object.keys(DEFAULT_TRANSITIONS).filter(
+    (k) => !(k in storedTransitions)
+  )
+  const sections: string[] = []
+  if (!cfg.transitions) sections.push("transitions")
+  if (!cfg.reassignment) sections.push("reassignment")
+
+  return { transitions, sections }
+}

--- a/apps/backend/src/modules/production_policy/service.ts
+++ b/apps/backend/src/modules/production_policy/service.ts
@@ -1,6 +1,13 @@
 import { MedusaError, MedusaService } from "@medusajs/framework/utils"
 
 import ProductionRunPolicy from "./models/production-run-policy"
+import {
+  DEFAULT_REASSIGNMENT_POLICY,
+  defaultPolicyConfig,
+  mergePolicyConfig,
+  missingPolicyKeys,
+  type ReassignmentPolicy,
+} from "./policy-config"
 
 import { InferTypeOf } from "@medusajs/framework/types"
 import  ProductionRun from "../../modules/production_runs/models/production-run"
@@ -19,26 +26,11 @@ type ProductionRunLike = {
   metadata?: Record<string, any> | null
 }
 
-/** #1228 — what the reminder cap does before parking a run for reassignment. */
-export type ReassignmentPolicy = {
-  /**
-   * How many times the cap re-nudges the SAME partner (resetting the reminder
-   * cycle) before the run is parked in `awaiting_reassignment`. 0 restores the
-   * original #1093 behaviour: cap → park immediately.
-   */
-  same_partner_retries: number
-  /**
-   * On a same-partner retry ONLY, accept the run on the partner's behalf so
-   * production can move without another round-trip. Gated a second time by the
-   * partner's own `auto_accept_production_runs` opt-in — both must be true.
-   */
-  auto_accept_on_retry: boolean
-}
-
-export const DEFAULT_REASSIGNMENT_POLICY: ReassignmentPolicy = {
-  same_partner_retries: 1,
-  auto_accept_on_retry: false,
-}
+// The policy's shape, defaults and reconciliation live in ./policy-config so
+// they can be unit-tested without a container. Re-exported here because
+// existing callers import them from the service.
+export { DEFAULT_REASSIGNMENT_POLICY, defaultPolicyConfig, mergePolicyConfig }
+export type { ReassignmentPolicy }
 
 type StoredPolicy = {
   id: string
@@ -64,33 +56,7 @@ class ProductionPolicyService extends MedusaService({
   }
 
   private defaultPolicyConfig(): Record<string, any> {
-    return {
-      transitions: {
-        approve_from: ["draft", "pending_review"],
-        dispatch_from: ["approved"],
-        send_to_production_from: ["approved"],
-        accept_from: ["sent_to_partner"],
-        // Partner work lifecycle. Accepting moves the run to in_progress;
-        // start/finish/complete then stage within it via the lifecycle
-        // timestamps (started_at / finished_at).
-        start_work_from: ["in_progress"],
-        finish_work_from: ["in_progress"],
-        complete_work_from: ["in_progress"],
-        decline_from: ["draft", "pending_review", "approved", "sent_to_partner", "in_progress"],
-        // #1228 — manual (re)assignment. Deliberately a SEPARATE key from
-        // dispatch_from: `allowedStatuses` falls back per-key, so adding this
-        // takes effect on already-stored policy configs without a backfill,
-        // whereas widening dispatch_from would need one.
-        assign_partner_from: [
-          "awaiting_reassignment",
-          "draft",
-          "pending_review",
-          "approved",
-          "sent_to_partner",
-        ],
-      },
-      reassignment: DEFAULT_REASSIGNMENT_POLICY,
-    }
+    return defaultPolicyConfig()
   }
 
   /**
@@ -208,9 +174,40 @@ class ProductionPolicyService extends MedusaService({
     return updated as any
   }
 
+  /**
+   * The config that actually governs transitions: defaults with the stored row
+   * layered on top.
+   *
+   * Reads were already falling back per key, so this changes no behaviour — it
+   * makes the fallback explicit and gives one place to ask "what is in force?".
+   * The stored row is NOT written to; see getPolicyView for what an operator is
+   * shown.
+   */
   async getPolicyConfig(): Promise<Record<string, any>> {
     const policy = await this.getOrCreatePolicy()
-    return (policy?.config || this.defaultPolicyConfig()) as Record<string, any>
+    return mergePolicyConfig(policy?.config)
+  }
+
+  /**
+   * What the settings screen needs: the row as stored, the config actually in
+   * force, and which keys differ between them.
+   *
+   * The gap is the point. Prod's row predates five transition keys and the
+   * whole reassignment block, so the screen was rendering fewer than half the
+   * rules it claimed to show — which is why the reassignment switch looked
+   * broken rather than unsaved.
+   */
+  async getPolicyView(): Promise<{
+    policy: StoredPolicy
+    effective_config: Record<string, any>
+    missing: { transitions: string[]; sections: string[] }
+  }> {
+    const policy = await this.getOrCreatePolicy()
+    return {
+      policy,
+      effective_config: mergePolicyConfig(policy?.config),
+      missing: missingPolicyKeys(policy?.config),
+    }
   }
 
   async assertCanAccept(run: ProductionRun) {


### PR DESCRIPTION
Prod's policy row (`prod_pol_01KE3P…`) stores **4 of the 9 transition keys and no `reassignment` block at all**:

```
stored:  accept_from, approve_from, dispatch_from, send_to_production_from
missing: start_work_from, finish_work_from, complete_work_from,
         decline_from, assign_partner_from, + the whole reassignment section
```

## Why it can never self-heal

Three things line up:

1. `getOrCreatePolicy` seeds defaults **only at creation** — the row predates every key added since.
2. `updatePolicy` **replaces** the config wholesale.
3. The settings page is a raw JSON box **seeded from the stored value**.

So the operator sees the truncated config, saves back exactly that, and the missing keys stay missing forever.

## This is the mechanism behind #1280's inert switch

`reassignment` isn't stored, so `auto_accept_on_retry` always read the default no matter what the screen showed. It presented as a UI bug and was a missing key.

**Behaviour was never wrong** — every read falls back per key, which is precisely why this went unnoticed. What was wrong is that a screen claiming to show *"the rules that gate approve, dispatch, accept"* was showing fewer than half of them.

## The change — read-only by design

Nothing writes to the row.

- **`mergePolicyConfig`** — defaults with the stored config layered on top, extracted to a pure module so reconciliation is testable without a container.
- **GET returns three things**: `policy` (raw and unchanged, so existing consumers are unaffected), `effective_config`, and `missing`.
- **The settings page names the gap** — a banner listing the exact missing keys, stating plainly that editing the box will not change them, plus a read-only panel showing what is actually in force.
- **"Load effective policy"** fills the editor *without saving*, so adopting the defaults into a live gating policy stays a deliberate act.

### The one subtle rule

An **empty array is honoured**, not treated as absent. `approve_from: []` means "nothing may approve", and a merge that reverted it to the default would **re-open a transition an operator deliberately closed** — the most dangerous direction for this to be wrong in. Pinned by a test.

## Deliberately still unfixed

Both are write-path and each deserves its own change:

- `updatePolicy` **replaces rather than merges**, so pasting a partial config still wipes siblings — the same bug class as the conversation-metadata fix in #1322.
- The validator is `z.record(z.string(), z.any())`, so a **typo'd key writes silently and does nothing**, with no feedback that the edit was inert.

Backfilling the prod row is also left out on purpose, pending a look at the merged config.

## Verification

| | |
|---|---|
| 11 unit | merge + missing-key report: empty-array, malformed values, unknown-key preservation, `retries: 0` surviving |
| 7 integ | `production-run-transition-guards` — no regression |
| tsc | 75 with this change, 75 on a clean tree |
| gate | `check:prod-build` passes |

The missing-key list in the tests is the shape prod actually stores, read from `/admin/production-run-policy` — not an assumed one.

🤖 Generated with [Claude Code](https://claude.com/claude-code)