### PR TITLE
fix(theme): add a Center gallery position, the only one that keeps the product page readable

### DIFF
--- a/apps/backend/src/api/partners/storefront/website/theme/validators.ts
+++ b/apps/backend/src/api/partners/storefront/website/theme/validators.ts
@@ -221,7 +221,13 @@ export const websiteThemeSchema = z.object({
       show_sku: z.boolean().optional(),
       show_stock_status: z.boolean().optional(),
       image_layout: z.enum(["gallery", "single", "grid"]).optional(),
-      gallery_position: z.enum(["left", "right"]).optional(),
+      // "center" keeps the gallery between the description and the buy box.
+      // Left/right push it to an edge, which pulls those two narrow columns
+      // together so the description renders beside Add to cart. Center was
+      // previously only reachable by omitting the key entirely, which the
+      // editor could not do — so every partner who touched this setting got
+      // the collapsed layout.
+      gallery_position: z.enum(["left", "center", "right"]).optional(),
       description_layout: z.enum(["tabs", "accordion", "stacked"]).optional(),
       cta_text: z.string().optional(),
       sample_product_name: z.string().optional(),

--- a/apps/partner-ui/src/hooks/api/content.ts
+++ b/apps/partner-ui/src/hooks/api/content.ts
@@ -340,7 +340,7 @@ export type WebsiteTheme = {
     show_sku?: boolean
     show_stock_status?: boolean
     image_layout?: "gallery" | "single" | "grid"
-    gallery_position?: "left" | "right"
+    gallery_position?: "left" | "center" | "right"
     description_layout?: "tabs" | "accordion" | "stacked"
     cta_text?: string
     sample_product_name?: string

--- a/apps/partner-ui/src/routes/settings/theme/theme.tsx
+++ b/apps/partner-ui/src/routes/settings/theme/theme.tsx
@@ -2213,12 +2213,17 @@ function ProductPagePanel({ form, updateForm }: PanelProps) {
 
         <div className="space-y-1">
           <Label size="xsmall">Gallery Position</Label>
-          <div className="grid grid-cols-2 gap-1">
-            {(["left", "right"] as const).map((v) => (
+          {/* "Center" keeps the images between the description and the buy box.
+              Left/right push the gallery to an edge, which pulls those two
+              narrow columns together — the description then sits directly
+              beside Add to cart, which reads as a broken page. Center is the
+              default for that reason. */}
+          <div className="grid grid-cols-3 gap-1">
+            {(["left", "center", "right"] as const).map((v) => (
               <button
                 key={v}
                 className={`px-2 py-1 text-xs rounded border ${
-                  (pp.gallery_position || "left") === v
+                  (pp.gallery_position || "center") === v
                     ? "border-ui-fg-interactive bg-ui-bg-interactive text-ui-fg-on-color"
                     : "border-ui-border-base text-ui-fg-subtle"
                 }`}
@@ -2228,6 +2233,11 @@ function ProductPagePanel({ form, updateForm }: PanelProps) {
               </button>
             ))}
           </div>
+          {(pp.gallery_position === "left" || pp.gallery_position === "right") && (
+            <Text size="xsmall" className="text-ui-fg-subtle">
+              Description and Add to cart sit side by side in this layout.
+            </Text>
+          )}
         </div>
 
         <div className="space-y-1">


### PR DESCRIPTION
Reported as "the description and add to cart and variant are showing next to each other" on a live partner storefront (`uniquepashmina.cicilabel.com`).

## The cause

The product page is **three columns** — description (`max-w-[300px]`) │ gallery │ buy box (`max-w-[300px]`) — and `gallery_position` moves the gallery with `order-first` / `order-last`.

So the setting doesn't merely move the images. Pushing the gallery to either edge **pulls the two narrow columns together**, and the description ends up directly beside Add to cart and the variant picker:

| value | resulting order |
|---|---|
| `left` *(this partner)* | gallery │ description │ variants+cart |
| `right` | description │ variants+cart │ gallery |
| *absent* | description │ gallery │ variants+cart ✅ |

**The readable layout was only reachable by omitting the key** — which the editor could not do. It rendered the default as `"left"` (`pp.gallery_position || "left"`) and always wrote one of the two values. Any partner who opened this control got the collapsed layout and no way back.

The storefront was never broken. The setting simply had no safe value.

## The fix

- Adds `"center"` to the validator enum and the editor, and makes it the editor's default.
- Warns under the control when left/right are selected, naming the consequence.
- **The storefront needs no change** — it keys off `"left"` and `"right"` only, so `"center"` already falls through to the natural order that an absent value has always produced. (`apps/storefront-starter` is a submodule and is untouched.)

## Note on resetting an affected partner

A partner already stuck on `left` cannot be fixed by data alone before this ships:

- the theme `PUT` **deep-merges**, so omitting `gallery_position` preserves the old value;
- the merge's null-replace escape hatch fails validation, because `product_page` is `.optional()` but not `.nullable()`.

So shipping `center` is the prerequisite for resetting them.

## Verification

tsc unchanged on both apps — 75 backend, 4 partner-ui, both matching their pre-existing baselines.

🤖 Generated with [Claude Code](https://claude.com/claude-code)