### PR TITLE
test(e2e): pin the product page's three-column layout against a live storefront

### DIFF
--- a/e2e/playwright.storefront.config.ts
+++ b/e2e/playwright.storefront.config.ts
@@ -1,0 +1,25 @@
+import { defineConfig, devices } from "@playwright/test"
+import * as path from "path"
+
+/**
+ * Storefront layout checks against a LIVE site.
+ *
+ * Separate from playwright.config.ts because that one boots `medusa develop`
+ * on :9000 for the admin specs — pointless here, and a five-minute wait to
+ * test a page that is already deployed. No webServer, no local dependencies.
+ */
+export default defineConfig({
+  testDir: path.resolve(__dirname, "specs"),
+  grep: /@storefront/,
+  fullyParallel: true,
+  forbidOnly: !!process.env.CI,
+  retries: process.env.CI ? 2 : 0,
+  reporter: process.env.CI ? "github" : "list",
+  timeout: 60_000,
+  expect: { timeout: 15_000 },
+  use: {
+    ...devices["Desktop Chrome"],
+    trace: "retain-on-failure",
+    screenshot: "only-on-failure",
+  },
+})

--- a/e2e/specs/storefront-product-layout.spec.ts
+++ b/e2e/specs/storefront-product-layout.spec.ts
@@ -1,0 +1,117 @@
+import { test, expect } from "@playwright/test"
+
+/**
+ * Product page layout on a LIVE partner storefront.
+ *
+ * The product page is three columns — description | gallery | buy box — and the
+ * `product_page.gallery_position` theme setting moves the gallery with
+ * `order-first` / `order-last`. That does not merely move the images: pushing
+ * the gallery to an edge pulls the two narrow (max-w-[300px]) columns together,
+ * so the description ends up directly beside Add to cart and the variant
+ * picker. Reported from a real storefront stuck on `gallery_position: "left"`.
+ *
+ * The assertion is GEOMETRIC on purpose. Checking for the `order-first` class
+ * would pass the moment someone renamed a utility class while the page still
+ * rendered wrongly — and the complaint was about what the page looks like, not
+ * what its markup says. Comparing rendered x-positions tests the thing the
+ * partner actually sees.
+ *
+ * @storefront — hits a live external site, so it is excluded from the CI admin
+ * e2e run (see playwright.config.ts). Run it locally, or point it elsewhere:
+ *
+ *   STOREFRONT_PRODUCT_URL=https://…/products/handle \
+ *     pnpm exec playwright test -c e2e/playwright.storefront.config.ts
+ */
+
+const PRODUCT_URL =
+  process.env.STOREFRONT_PRODUCT_URL ??
+  "https://www.uniquepashmina.com/in/products/ikat-grid-patterns-blue-yellow"
+
+test.describe("Storefront product page layout @storefront", () => {
+  test.beforeEach(async ({ page }) => {
+    // The three-column layout only applies at Medusa's `small` breakpoint and
+    // up; below it everything stacks and the bug cannot manifest.
+    await page.setViewportSize({ width: 1440, height: 900 })
+    await page.goto(PRODUCT_URL, { waitUntil: "domcontentloaded" })
+  })
+
+  test("gallery sits between the description and the buy box", async ({
+    page,
+  }) => {
+    const container = page.getByTestId("product-container")
+    await expect(container).toBeVisible()
+
+    const title = container.getByRole("heading").first()
+    const gallery = container.locator("[data-image-layout]").first()
+    // Scoped to the container: the page also renders a MOBILE sticky
+    // add-to-cart bar with the same testid, so an unscoped locator matches two
+    // elements. It resolved intermittently depending on whether hydration had
+    // mounted the sticky bar yet — a locator that passes by winning a race is
+    // worse than one that fails.
+    const addToCart = container.getByTestId("add-product-button")
+
+    await expect(title).toBeVisible()
+    await expect(gallery).toBeVisible()
+    await expect(addToCart).toBeVisible()
+
+    const [titleBox, galleryBox, cartBox] = await Promise.all([
+      title.boundingBox(),
+      gallery.boundingBox(),
+      addToCart.boundingBox(),
+    ])
+
+    if (!titleBox || !galleryBox || !cartBox) {
+      throw new Error("Could not measure the product page columns")
+    }
+
+    // The description column must start left of the gallery, and the gallery
+    // left of the buy box. Any other order means two text columns have been
+    // pushed together.
+    expect(
+      titleBox.x,
+      `description column (x=${titleBox.x}) should be left of the gallery (x=${galleryBox.x}) — ` +
+        `if the gallery is leftmost, gallery_position is "left" and the description ` +
+        `is rendering beside Add to cart`
+    ).toBeLessThan(galleryBox.x)
+
+    expect(
+      galleryBox.x,
+      `gallery (x=${galleryBox.x}) should be left of the buy box (x=${cartBox.x}) — ` +
+        `if the gallery is rightmost, gallery_position is "right" and the same ` +
+        `collapse happens on the other side`
+    ).toBeLessThan(cartBox.x)
+  })
+
+  test("description is not rendered adjacent to the add-to-cart column", async ({
+    page,
+  }) => {
+    // The symptom as a partner describes it: two narrow text columns side by
+    // side. Stated separately from the ordering check so a failure report says
+    // which of the two things went wrong.
+    const container = page.getByTestId("product-container")
+    const title = container.getByRole("heading").first()
+    const addToCart = container.getByTestId("add-product-button")
+
+    const [titleBox, cartBox] = await Promise.all([
+      title.boundingBox(),
+      addToCart.boundingBox(),
+    ])
+    if (!titleBox || !cartBox) {
+      throw new Error("Could not measure the product page columns")
+    }
+
+    // Same row vertically, and nothing of substance between them horizontally,
+    // is the shape of the bug. The gallery is wide, so a healthy page leaves a
+    // large gap; the collapsed layout leaves roughly one column width.
+    const sameRow = Math.abs(titleBox.y - cartBox.y) < 400
+    const gap = cartBox.x - (titleBox.x + titleBox.width)
+
+    if (sameRow) {
+      expect(
+        gap,
+        `description and Add to cart are only ${Math.round(gap)}px apart on the ` +
+          `same row — the gallery should be between them`
+      ).toBeGreaterThan(400)
+    }
+  })
+})


### PR DESCRIPTION
Adds the check that caught the reported *"description and add to cart and variant are showing next to each other"* on `uniquepashmina.com` — and that would have caught it the moment the theme setting was saved.

## Before / after

```
✕ description is not rendered adjacent to the add-to-cart column
    Expected: > 400
    Received:   0        ← the two columns were touching
```

After setting `gallery_position: "center"` (#1325) and busting the cache:

```
✓ gallery sits between the description and the buy box
✓ description is not rendered adjacent to the add-to-cart column
```

## Why geometric assertions

Checking for the `order-first` class would pass the moment someone renamed a utility class while the page still rendered wrongly — and the complaint was about **what the page looks like**, not what its markup says. The test compares rendered x-positions: the gallery must sit between the description column and the buy box.

## Mechanics

- Its own config, **no `webServer`**: `playwright.config.ts` boots `medusa develop` for the admin specs, which is a five-minute wait to test a page that is already deployed.
- Tagged `@storefront`, pointed at a live URL, overridable via `STOREFRONT_PRODUCT_URL`.

```
pnpm exec playwright test -c e2e/playwright.storefront.config.ts
```

- Both add-to-cart lookups are **scoped to the product container**. The page also renders a mobile sticky bar with the same testid, and an unscoped locator resolved intermittently depending on whether hydration had mounted it. The first run passed only by winning that race — a test that passes by racing is worse than one that fails.

## Related

Depends on #1325 (adds the `center` gallery position). Two production issues surfaced while verifying this and are described in the session notes: the storefront's revalidate secret was set under the **wrong variable name** on Vercel, so theme edits never busted the cache; and the backend swallows that failure silently.

🤖 Generated with [Claude Code](https://claude.com/claude-code)