### PR TITLE
feat(mcp): expose social post tools and filter create-post UI to social platforms

### DIFF
--- a/apps/backend/src/admin/components/social-posts/create-social-post-component.tsx
+++ b/apps/backend/src/admin/components/social-posts/create-social-post-component.tsx
@@ -190,7 +190,7 @@ export const CreateSocialPostComponent = () => {
   const {
     socialPlatforms = [],
     isLoading: isPlatformsLoading,
-  } = useSocialPlatforms()
+  } = useSocialPlatforms({ category: "social" })
 
   // Watch selected platform and post_type to conditionally render fields
   const platformId = useWatch({ control: form.control, name: "platform_id" })

--- a/apps/backend/src/api/admin/mcp/lib/registry.ts
+++ b/apps/backend/src/api/admin/mcp/lib/registry.ts
@@ -327,13 +327,13 @@ export const ADMIN_MCP_TOOLS: AdminMcpToolDef[] = [
   {
     name: "list_social_platforms",
     description:
-      "List the configured social-media platform integrations (Facebook, Instagram, Twitter/X, LinkedIn, FBINSTA). Each row carries the platform id, name, auth type and status. Use to find a platform_id for create_social_post. Secrets are stripped from the response.",
+      "List the configured platform integrations. ALWAYS pass category:'social' for social-media work (Facebook, Instagram, Twitter/X, LinkedIn, FBINSTA) — the route applies NO default, so omitting it returns every integration, including payment, shipping, email, SMS, analytics, CRM and storage rows. Each row carries the platform id, name, auth type and status. Use to find a platform_id for create_social_post. Secrets are stripped from the response.",
     method: "GET",
     path: "/admin/social-platforms",
     queryParams: ["limit", "offset", "q", "category", "status"],
     inputSchema: obj({
       ...PAGINATION,
-      category: STR("Filter by category. Pass 'social' (default) to list only social-media platforms."),
+      category: STR("Filter by category. Pass 'social' to list only social-media platforms; omitted means NO filter, not 'social'."),
       status: STR("Filter by platform status: 'active' | 'inactive' | 'error' | 'pending'."),
     }),
   },

--- a/apps/backend/src/api/admin/mcp/lib/registry.ts
+++ b/apps/backend/src/api/admin/mcp/lib/registry.ts
@@ -319,6 +319,120 @@ export const ADMIN_MCP_TOOLS: AdminMcpToolDef[] = [
     inputSchema: obj({ ...PAGINATION }),
   },
 
+  // ===== Social posts & platforms =========================================
+  // Social-platform integrations (Facebook, Instagram, Twitter/X, LinkedIn)
+  // are stored as SocialPlatform rows with category "social". These tools let
+  // the assistant list the configured social platforms, create draft posts,
+  // and publish them — the same surface the admin UI exposes.
+  {
+    name: "list_social_platforms",
+    description:
+      "List the configured social-media platform integrations (Facebook, Instagram, Twitter/X, LinkedIn, FBINSTA). Each row carries the platform id, name, auth type and status. Use to find a platform_id for create_social_post. Secrets are stripped from the response.",
+    method: "GET",
+    path: "/admin/social-platforms",
+    queryParams: ["limit", "offset", "q", "category", "status"],
+    inputSchema: obj({
+      ...PAGINATION,
+      category: STR("Filter by category. Pass 'social' (default) to list only social-media platforms."),
+      status: STR("Filter by platform status: 'active' | 'inactive' | 'error' | 'pending'."),
+    }),
+  },
+  {
+    name: "list_social_posts",
+    description:
+      "List social posts (paginated). Filter by status (draft/scheduled/posted/failed/archived) or free-text search by name. Use to see what's queued, published or failed.",
+    method: "GET",
+    path: "/admin/social-posts",
+    queryParams: ["limit", "offset", "q", "status", "posted_at", "error_message"],
+    inputSchema: obj({
+      ...PAGINATION,
+      status: STR("Post status: 'draft' | 'scheduled' | 'posted' | 'failed' | 'archived'."),
+      posted_at: STR("Filter by posted date (ISO string or partial match)."),
+      error_message: STR("Filter by error message."),
+    }),
+  },
+  {
+    name: "get_social_post",
+    description:
+      "Get a single social post by id (status, caption, media attachments, platform, publish results). Use before publish_social_post to review the post.",
+    method: "GET",
+    path: "/admin/social-posts/:id",
+    pathParams: ["id"],
+    inputSchema: obj({ id: STR("Social post id, e.g. 'spost_...'.") }, ["id"]),
+  },
+  {
+    name: "create_social_post",
+    description:
+      "Create a new social post (draft by default). Sensitive: requires confirm:true. Pass platform_id (from list_social_platforms), a name, and a message/caption. For Facebook/FBINSTA, pass page_id and/or ig_user_id in metadata, and set post_type (photo/feed/reel). Pass media_urls for image/video posts. Set metadata.auto_publish to publish immediately after creation. Use dry_run first to review the payload.",
+    method: "POST",
+    path: "/admin/social-posts",
+    write: true,
+    sensitive: true,
+    bodyParams: [
+      "name",
+      "platform_id",
+      "caption",
+      "message",
+      "link",
+      "media_urls",
+      "post_type",
+      "status",
+      "scheduled_at",
+      "platform_name",
+      "metadata",
+    ],
+    inputSchema: obj(
+      {
+        name: STR("Post name (required)."),
+        platform_id: STR("Social platform id from list_social_platforms (required)."),
+        caption: STR("Post caption text."),
+        message: STR("Post message text (alias for caption; preferred by the UI)."),
+        link: STR("Optional URL for link/feed posts."),
+        media_urls: {
+          type: "array",
+          items: { type: "string" },
+          description: "Media URLs for photo/reel posts (1-10 images or 1 video).",
+        },
+        post_type: STR("'photo' | 'feed' | 'reel'. Required for Facebook/Instagram."),
+        status: STR("'draft' (default) | 'scheduled' | 'posted' | 'failed' | 'archived'."),
+        scheduled_at: STR("ISO datetime for scheduled publishing."),
+        platform_name: STR("Platform name (e.g. 'facebook', 'instagram', 'FBINSTA'). Set for the workflow's platform detection."),
+        metadata: {
+          type: "object",
+          description:
+            "Platform-specific fields: { page_id, ig_user_id, publish_target ('facebook'|'instagram'|'both'), auto_publish (boolean) }. The workflow reads these to route the post.",
+        },
+      },
+      ["name", "platform_id"]
+    ),
+    sideEffects:
+      "Creates a draft social post linked to the configured platform. With metadata.auto_publish, also triggers the publish workflow immediately.",
+    nextSteps: ["get_social_post", "publish_social_post"],
+  },
+  {
+    name: "publish_social_post",
+    description:
+      "Publish a social post to its configured platform(s) — goes LIVE publicly. PLATFORM-DESTRUCTIVE: requires confirm:true AND a human reason, and is only available when ADMIN_MCP_ENABLE_DANGEROUS is enabled. This calls the real Facebook/Instagram/Twitter/LinkedIn API and creates a public post. Always dry_run first to review the post content and target. Pass override_page_id or override_ig_user_id to redirect to a different account than the one stored on the post.",
+    method: "POST",
+    path: "/admin/social-posts/:id/publish",
+    pathParams: ["id"],
+    previewPath: "/admin/social-posts/:id",
+    write: true,
+    dangerous: true,
+    bodyParams: ["override_page_id", "override_ig_user_id"],
+    inputSchema: obj(
+      {
+        id: STR("Social post id to publish, e.g. 'spost_...'."),
+        override_page_id: STR("Override the Facebook Page ID to publish to."),
+        override_ig_user_id: STR("Override the Instagram Business account ID to publish to."),
+      },
+      ["id"]
+    ),
+    sideEffects:
+      "Calls the live social platform API and creates a public post. Failed publishes are recorded on the post for retry; partial successes (e.g. Facebook ok, Instagram failed) are reported per-platform.",
+    nextSteps: ["get_social_post", "list_social_posts"],
+  },
+
   // ===== Observability (#844) =============================================
   {
     name: "get_mcp_usage",

--- a/apps/backend/src/api/admin/mcp/lib/tool-slice.ts
+++ b/apps/backend/src/api/admin/mcp/lib/tool-slice.ts
@@ -82,6 +82,10 @@ const PREFIX_DOMAINS: ReadonlyArray<readonly [string, AdminToolDomain]> = [
   ["/admin/payments", "money"],
   ["/admin/publishing-campaigns", "marketing"],
   ["/admin/notifications", "marketing"],
+  // Social posts and platform integrations belong to marketing — they are the
+  // organic publishing surface alongside the automated campaigns.
+  ["/admin/social-posts", "marketing"],
+  ["/admin/social-platforms", "marketing"],
 ]
 
 /** Classify one tool by the route it wraps. */
@@ -180,6 +184,12 @@ const DOMAIN_KEYWORDS: Record<Exclude<AdminToolDomain, "core">, string[]> = {
     "campaign", "campaigns", "newsletter", "email", "emails", "notification",
     "notifications", "marketing", "publish campaign", "blog", "subscriber",
     "subscribers",
+    // Social post vocabulary — the organic publishing surface. Without these
+    // a "post to Instagram" or "create a Facebook post" ask never lights the
+    // marketing slice, so the social tools never load.
+    "social", "social post", "social posts", "social media", "instagram",
+    "facebook", "twitter", "tweet", "linkedin", "post to", "publish post",
+    "reel", "caption", "hashtag", "hashtags", "fbinsta",
   ],
   observability: [
     "mcp", "tool usage", "telemetry", "observability", "ledger", "audit",


### PR DESCRIPTION
## Summary

Exposes the existing social-post and social-platform admin routes as MCP tools so the assistant can list platforms, create draft posts, and publish them — the same surface the admin UI exposes. Also fixes the create-social-post UI to only show social-media platforms in the dropdown.

## MCP Tools Added

| Tool | Method | Path | Safety |
|------|--------|------|--------|
| `list_social_platforms` | GET | `/admin/social-platforms` | read |
| `list_social_posts` | GET | `/admin/social-posts` | read |
| `get_social_post` | GET | `/admin/social-posts/:id` | read |
| `create_social_post` | POST | `/admin/social-posts` | sensitive (confirm) |
| `publish_social_post` | POST | `/admin/social-posts/:id/publish` | **dangerous** (confirm + reason) |

`publish_social_post` is classified `dangerous` because it goes live publicly — it calls the real Facebook/Instagram/Twitter/LinkedIn API and creates a public post. Like other dangerous tools, it's hidden unless `ADMIN_MCP_ENABLE_DANGEROUS` is on, and requires both `confirm: true` and a human-supplied `reason`.

## Tool-Slice Changes

- Added `/admin/social-posts` and `/admin/social-platforms` route prefixes to the **marketing** domain
- Added social-media vocabulary to the marketing domain keywords: `social`, `instagram`, `facebook`, `twitter`, `reel`, `caption`, `hashtag`, `fbinsta`, etc.

This ensures a "post to Instagram" or "create a Facebook post" ask lights the marketing slice so the social tools load.

## UI Fix

The create-social-post component (`create-social-post-component.tsx`) was calling `useSocialPlatforms()` with no filter, which returned **every** external platform (payment, shipping, email, SMS, analytics, CRM, storage, etc.) in the platform dropdown. Now it passes `{ category: "social" }` to only show social-media integrations.

## Test Plan

- [x] `tool-slice.unit.spec.ts` — 112 tests pass (prefix coverage + vocabulary invariants)
- [x] `tool-tiers.unit.spec.ts` — 10 tests pass (tier monotonicity, dangerous gate)
- [x] `tsc --noEmit` — no new errors in changed files
- [ ] Manual: verify the create-post dropdown only shows social platforms
- [ ] Manual: verify `list_social_platforms` MCP tool returns only category=social by default
- [ ] Manual: verify `create_social_post` + `publish_social_post` flow via the assistant