### PR TITLE
fix(email): suppress known-bot recipients at every provider (#1333)

### DIFF
--- a/apps/backend/src/jobs/process-email-queue.ts
+++ b/apps/backend/src/jobs/process-email-queue.ts
@@ -6,6 +6,12 @@ import EmailProviderManagerService from "../modules/email-provider-manager/servi
 import { EMAIL_TEMPLATES_MODULE } from "../modules/email_templates"
 import EmailTemplatesService from "../modules/email_templates/service"
 import { sendMailjetBulk, BulkEmailEntry } from "../modules/mailjet/bulk"
+import {
+  isBotRecipient,
+  classifyRecipient,
+  botSuppressionLog,
+  BOT_SUPPRESSED_SEND_ID,
+} from "../lib/bot-recipients"
 import * as Handlebars from "handlebars"
 
 const MAX_ATTEMPTS = 3
@@ -41,7 +47,7 @@ export default async function processEmailQueue(container: MedusaContainer) {
   const today = new Date().toISOString().split("T")[0]
 
   // Fetch pending entries scheduled for today or earlier
-  const pendingEntries = await providerManager.listEmailQueues(
+  let pendingEntries = await providerManager.listEmailQueues(
     { status: "pending", scheduled_for: { $lte: today } } as any,
     { take: 500, order: { scheduled_for: "ASC" } }
   ) as any[]
@@ -52,6 +58,44 @@ export default async function processEmailQueue(container: MedusaContainer) {
   }
 
   logger.info(`[Email Queue] Found ${pendingEntries.length} pending emails`)
+
+  /**
+   * Retire known-bot rows before anything else (#1333).
+   *
+   * The provider guard already refuses to mail these, but a suppressed address
+   * comes back in neither `successful` nor `failed`, so a row left in the run
+   * is never updated: it stays pending, is re-picked every day forever, and
+   * consumes a provider allocation slot each time (capacity is allocated
+   * BEFORE the send). Retiring here is terminal and costs no allocation.
+   *
+   * Marked `failed` rather than a new `suppressed` status on purpose: the
+   * status is a DB enum and widening it needs a check-constraint migration
+   * (see #1208). `last_error` carries the reason and is greppable by the same
+   * prefix as the provider log line. What matters is that it never reads
+   * `sent` — nothing was sent.
+   */
+  const botEntries = pendingEntries.filter((e) => isBotRecipient(e.to_email))
+  let suppressedCount = 0
+  for (const entry of botEntries) {
+    const verdict = classifyRecipient(entry.to_email)
+    logger.warn(botSuppressionLog("email-queue", entry.to_email, entry.template, verdict))
+    await providerManager.updateEmailQueues({
+      id: entry.id,
+      status: "failed",
+      last_error: `[bot-recipient-suppressed] rule=${verdict.rule} — ${verdict.note}`,
+    })
+    suppressedCount++
+  }
+  if (suppressedCount > 0) {
+    logger.warn(
+      `[Email Queue] Retired ${suppressedCount} known-bot recipient(s) without sending`
+    )
+    pendingEntries = pendingEntries.filter((e) => !isBotRecipient(e.to_email))
+    if (pendingEntries.length === 0) {
+      logger.info("[Email Queue] Nothing left to process after bot suppression")
+      return
+    }
+  }
 
   // Mark as processing to prevent concurrent runs from picking them up
   for (const entry of pendingEntries) {
@@ -198,6 +242,20 @@ export default async function processEmailQueue(container: MedusaContainer) {
       }
     }
 
+    // Defensive: the provider is the enforcement point, so it can suppress an
+    // address this job did not pre-filter (policy widened between the filter
+    // above and the send). Retire those rows too — never leave them pending.
+    for (const dropped of bulkResult.suppressed || []) {
+      const entry = emailToEntry.get(dropped.email)
+      if (!entry) continue
+      await providerManager.updateEmailQueues({
+        id: entry.id,
+        status: "failed",
+        last_error: `[bot-recipient-suppressed] rule=${dropped.rule} — ${dropped.note}`,
+      })
+      suppressedCount++
+    }
+
     try {
       await providerManager.recordUsage("mailjet", bulkResult.successful.length)
     } catch (err) {
@@ -227,12 +285,29 @@ export default async function processEmailQueue(container: MedusaContainer) {
       }
 
       try {
-        await notificationService.createNotifications({
+        const created: any = await notificationService.createNotifications({
           to: email,
           channel: "email",
           template: entry.template,
           data: notificationData,
         })
+
+        // A suppressed send resolves normally — the provider returns the
+        // synthetic id instead of a message id. Without this check the row
+        // would read `sent` for mail that never left (#1333).
+        const externalId = Array.isArray(created)
+          ? created[0]?.external_id
+          : created?.external_id
+        if (externalId === BOT_SUPPRESSED_SEND_ID) {
+          const verdict = classifyRecipient(email)
+          await providerManager.updateEmailQueues({
+            id: entry.id,
+            status: "failed",
+            last_error: `[bot-recipient-suppressed] rule=${verdict.rule} — ${verdict.note}`,
+          })
+          suppressedCount++
+          continue
+        }
 
         await providerManager.updateEmailQueues({ id: entry.id, status: "sent" })
         sentCount++
@@ -289,7 +364,8 @@ export default async function processEmailQueue(container: MedusaContainer) {
   }
 
   logger.info(
-    `[Email Queue] Complete: ${sentCount} sent, ${failedCount} failed permanently`
+    `[Email Queue] Complete: ${sentCount} sent, ${failedCount} failed permanently` +
+    (suppressedCount > 0 ? `, ${suppressedCount} suppressed (bot recipients)` : "")
   )
 }
 

--- a/apps/backend/src/lib/__tests__/bot-recipients.unit.spec.ts
+++ b/apps/backend/src/lib/__tests__/bot-recipients.unit.spec.ts
@@ -1,0 +1,145 @@
+import {
+  classifyRecipient,
+  isBotRecipient,
+  normalizeRecipient,
+  partitionBotRecipients,
+  botSuppressionLog,
+  SUPPRESSED_RECIPIENT_DOMAINS,
+} from "../bot-recipients"
+
+describe("bot recipient policy (#1333)", () => {
+  describe("the address that actually got mailed on prod", () => {
+    // The ONLY cart-abandoned recipient in the last 200 prod notifications.
+    const REAL = "johnsmith004@storebotmail.joonix.net"
+
+    it("is classified as a bot", () => {
+      expect(isBotRecipient(REAL)).toBe(true)
+      expect(classifyRecipient(REAL)).toEqual({
+        bot: true,
+        rule: "joonix.net",
+        note: "Google shopping crawler (storebot) infrastructure",
+      })
+    })
+
+    it("is still a bot with different casing or padding", () => {
+      expect(isBotRecipient("  JohnSmith004@StoreBotMail.Joonix.NET ")).toBe(true)
+    })
+
+    it("is still a bot inside a display-name form", () => {
+      expect(isBotRecipient("John Smith <johnsmith004@storebotmail.joonix.net>")).toBe(true)
+    })
+  })
+
+  describe("matching is on a dot boundary, never a substring", () => {
+    it("catches the apex and any subdomain", () => {
+      expect(isBotRecipient("a@joonix.net")).toBe(true)
+      expect(isBotRecipient("a@deep.nested.joonix.net")).toBe(true)
+    })
+
+    it("does NOT catch a lookalike domain", () => {
+      // The failure that matters: suppressing a real customer silently.
+      expect(isBotRecipient("a@notjoonix.net")).toBe(false)
+      expect(isBotRecipient("a@joonix.net.example.com")).toBe(false)
+      expect(isBotRecipient("a@myjoonix.net")).toBe(false)
+    })
+  })
+
+  describe("real customers are never suppressed", () => {
+    const HUMANS = [
+      "customer@gmail.com",
+      "someone@jaalyantra.com",
+      "robot.fan@yahoo.co.in",       // 'robot' in the local part is not a rule
+      "storebot@gmail.com",          // 'storebot' at a human domain is not a rule
+      "a@joonix.com",                // different TLD
+    ]
+    for (const email of HUMANS) {
+      it(email, () => expect(isBotRecipient(email)).toBe(false))
+    }
+  })
+
+  describe("garbage in", () => {
+    for (const bad of [null, undefined, "", "   ", "not-an-email", "@", "no-domain@"]) {
+      it(`${JSON.stringify(bad)} is not a bot (and does not throw)`, () => {
+        expect(isBotRecipient(bad as any)).toBe(false)
+      })
+    }
+  })
+
+  describe("normalizeRecipient", () => {
+    it("unwraps a display name", () => {
+      expect(normalizeRecipient("Jane Doe <JANE@Example.com>")).toBe("jane@example.com")
+    })
+    it("passes a bare address through lowercased", () => {
+      expect(normalizeRecipient(" Bare@Example.COM ")).toBe("bare@example.com")
+    })
+  })
+
+  describe("partitionBotRecipients (bulk paths get the same policy)", () => {
+    it("splits a batch and keeps order", () => {
+      const entries = [
+        { to: "a@gmail.com" },
+        { to: "bot@storebotmail.joonix.net" },
+        { to: "b@gmail.com" },
+      ]
+      const { send, suppressed } = partitionBotRecipients(entries, (e) => e.to)
+      expect(send.map((e) => e.to)).toEqual(["a@gmail.com", "b@gmail.com"])
+      expect(suppressed).toHaveLength(1)
+      expect(suppressed[0].entry.to).toBe("bot@storebotmail.joonix.net")
+      expect(suppressed[0].verdict.rule).toBe("joonix.net")
+    })
+
+    it("an all-human batch is untouched", () => {
+      const entries = [{ to: "a@gmail.com" }, { to: "b@gmail.com" }]
+      const { send, suppressed } = partitionBotRecipients(entries, (e) => e.to)
+      expect(send).toHaveLength(2)
+      expect(suppressed).toHaveLength(0)
+    })
+
+    it("an all-bot batch sends nothing", () => {
+      const entries = [{ to: "x@joonix.net" }, { to: "y@storebotmail.joonix.net" }]
+      const { send, suppressed } = partitionBotRecipients(entries, (e) => e.to)
+      expect(send).toHaveLength(0)
+      expect(suppressed).toHaveLength(2)
+    })
+  })
+
+  describe("suppression is visible", () => {
+    it("the log line names the address, template, rule and reason", () => {
+      const line = botSuppressionLog(
+        "resend",
+        "JohnSmith004@storebotmail.joonix.net",
+        "cart-abandoned",
+        classifyRecipient("johnsmith004@storebotmail.joonix.net")
+      )
+      expect(line).toContain("[bot-recipient-suppressed]")
+      expect(line).toContain("provider=resend")
+      expect(line).toContain("to=johnsmith004@storebotmail.joonix.net")
+      expect(line).toContain("template=cart-abandoned")
+      expect(line).toContain("rule=joonix.net")
+      expect(line).toContain("Google shopping crawler")
+    })
+
+    it("tolerates a missing template", () => {
+      expect(
+        botSuppressionLog("mailjet", "a@joonix.net", undefined, classifyRecipient("a@joonix.net"))
+      ).toContain("template=-")
+    })
+  })
+
+  describe("the rule list itself", () => {
+    it("is explicit — every rule carries a reason someone can audit", () => {
+      expect(SUPPRESSED_RECIPIENT_DOMAINS.length).toBeGreaterThan(0)
+      for (const r of SUPPRESSED_RECIPIENT_DOMAINS) {
+        expect(r.suffix).toMatch(/^[a-z0-9.-]+\.[a-z]{2,}$/)
+        expect(r.note.length).toBeGreaterThan(10)
+      }
+    })
+
+    it("contains no bare TLD or wildcard that could swallow real mail", () => {
+      for (const r of SUPPRESSED_RECIPIENT_DOMAINS) {
+        expect(r.suffix).not.toMatch(/[*]/)
+        expect(r.suffix.split(".").length).toBeGreaterThanOrEqual(2)
+      }
+    })
+  })
+})

--- a/apps/backend/src/lib/bot-recipients.ts
+++ b/apps/backend/src/lib/bot-recipients.ts
@@ -1,0 +1,142 @@
+/**
+ * Known-bot recipient policy — the ONE place we decide that an address belongs
+ * to a crawler rather than a person (#1333, part of #1327).
+ *
+ * ── Why this exists ───────────────────────────────────────────────────────────
+ *
+ * Google's shopping crawler adds items to a cart to verify price and
+ * availability. Our cart-recovery flow cannot tell that visit from a customer's,
+ * so it emails the crawler. On prod, `johnsmith004@storebotmail.joonix.net` was
+ * the ONLY `cart-abandoned` recipient in the last 200 notifications — six sends
+ * across four days, every one recorded `success`. Nothing surfaced the waste
+ * because a send to a black hole looks exactly like a send to a customer.
+ *
+ * ── Suppress, do NOT block ────────────────────────────────────────────────────
+ *
+ * The crawler's visits are legitimate and we want them: blocking Google risks
+ * Merchant Center and Shopping listings. Four carts in four months is not an
+ * attack. The defect is that we treat a crawler's visit as a customer's, so the
+ * fix is to stop *mailing* it — never to stop it browsing, and never to delete
+ * the customer record (those visits are evidence for #1328).
+ *
+ * ── Why the guard lives at the provider, not at the caller ────────────────────
+ *
+ * Lifecycle mail reaches the wire through several paths: the visual-flow
+ * `send_email` op, the `send-notification-email` workflows, and direct
+ * `createNotifications` calls scattered across workflows. A guard on any one of
+ * those is not a guard — it just moves the leak. Every email that actually
+ * leaves the platform goes through one of the three provider services we own
+ * (Resend / Mailjet / Maileroo), so that is where this is enforced.
+ *
+ * This module is PURE and has no Medusa imports, so the policy is testable
+ * without a container and cannot drift between the five call sites.
+ */
+
+/**
+ * Domain suffixes whose mail we suppress, with the reason recorded in the log
+ * line. Kept EXPLICIT and short — a wildcard heuristic ("anything with 'bot' in
+ * it") would eventually eat a real customer, and the failure would be silent in
+ * the exact way this fix exists to end.
+ *
+ * `joonix.net` is Google infrastructure; `storebotmail` is its shopping crawler.
+ */
+export const SUPPRESSED_RECIPIENT_DOMAINS: ReadonlyArray<{
+  readonly suffix: string
+  readonly note: string
+}> = [
+  { suffix: "joonix.net", note: "Google shopping crawler (storebot) infrastructure" },
+]
+
+export type RecipientVerdict = {
+  /** true when this address is a known bot and must not be mailed. */
+  bot: boolean
+  /** The matched domain suffix, for the log line. Empty when not a bot. */
+  rule: string
+  /** Human-readable why, for the log line. Empty when not a bot. */
+  note: string
+}
+
+const NOT_A_BOT: RecipientVerdict = { bot: false, rule: "", note: "" }
+
+/**
+ * PURE: normalize an address for matching. Lowercases and trims; tolerates a
+ * `Display Name <addr@example.com>` form because provider callers do not all
+ * hand us a bare address.
+ */
+export function normalizeRecipient(raw: unknown): string {
+  const s = String(raw ?? "").trim().toLowerCase()
+  const angled = s.match(/<([^>]+)>\s*$/)
+  return (angled ? angled[1] : s).trim()
+}
+
+/**
+ * PURE: is this recipient a known bot?
+ *
+ * Matches on the domain part only, and requires either an exact domain match or
+ * a dot-boundary subdomain match — so `joonix.net` catches
+ * `storebotmail.joonix.net` but never `notjoonix.net`.
+ */
+export function classifyRecipient(raw: unknown): RecipientVerdict {
+  const email = normalizeRecipient(raw)
+  const at = email.lastIndexOf("@")
+  if (at < 0) return NOT_A_BOT
+  const domain = email.slice(at + 1)
+  if (!domain) return NOT_A_BOT
+
+  for (const rule of SUPPRESSED_RECIPIENT_DOMAINS) {
+    if (domain === rule.suffix || domain.endsWith(`.${rule.suffix}`)) {
+      return { bot: true, rule: rule.suffix, note: rule.note }
+    }
+  }
+  return NOT_A_BOT
+}
+
+/** Convenience predicate for the single-send paths. */
+export function isBotRecipient(raw: unknown): boolean {
+  return classifyRecipient(raw).bot
+}
+
+/**
+ * PURE: split a bulk recipient list into the addresses we will mail and the
+ * bot addresses we drop. Bulk paths need the same policy as single sends —
+ * a crawler address inside a 50-address batch is the same waste.
+ */
+export function partitionBotRecipients<T>(
+  entries: readonly T[],
+  getEmail: (entry: T) => string
+): { send: T[]; suppressed: Array<{ entry: T; verdict: RecipientVerdict }> } {
+  const send: T[] = []
+  const suppressed: Array<{ entry: T; verdict: RecipientVerdict }> = []
+  for (const entry of entries) {
+    const verdict = classifyRecipient(getEmail(entry))
+    if (verdict.bot) suppressed.push({ entry, verdict })
+    else send.push(entry)
+  }
+  return { send, suppressed }
+}
+
+/**
+ * The log line every suppression emits. Suppression MUST be visible: a silent
+ * drop is indistinguishable from "the mail was never triggered", which is the
+ * ambiguity that let six wasted sends sit unnoticed. One shared formatter so
+ * all five call sites are greppable by the same prefix.
+ */
+export function botSuppressionLog(
+  provider: string,
+  email: string,
+  template: string | undefined,
+  verdict: RecipientVerdict
+): string {
+  return (
+    `[bot-recipient-suppressed] provider=${provider} ` +
+    `to=${normalizeRecipient(email)} template=${template || "-"} ` +
+    `rule=${verdict.rule} reason="${verdict.note}"`
+  )
+}
+
+/**
+ * The synthetic provider id returned in place of a real message id. Prefixed so
+ * a notification row that was suppressed is distinguishable from one that was
+ * actually delivered — "suppressed" must never read as "sent".
+ */
+export const BOT_SUPPRESSED_SEND_ID = "suppressed-bot-recipient"

--- a/apps/backend/src/modules/__tests__/bot-recipient-guard.unit.spec.ts
+++ b/apps/backend/src/modules/__tests__/bot-recipient-guard.unit.spec.ts
@@ -1,0 +1,205 @@
+/**
+ * The guard has to hold at EVERY provider, not just the one we happened to
+ * debug. #1319's lesson: a guard on one path is not a guard. So this exercises
+ * each provider's real send() and asserts the upstream API is never touched.
+ */
+import { BOT_SUPPRESSED_SEND_ID } from "../../lib/bot-recipients"
+
+const BOT = "johnsmith004@storebotmail.joonix.net"
+const HUMAN = "real.customer@gmail.com"
+
+const makeLogger = () => ({
+  info: jest.fn(),
+  warn: jest.fn(),
+  error: jest.fn(),
+  debug: jest.fn(),
+  log: jest.fn(),
+})
+
+const resendSend = jest.fn().mockResolvedValue({ data: { id: "re_real" }, error: null })
+jest.mock("resend", () => ({
+  Resend: jest.fn().mockImplementation(() => ({ emails: { send: resendSend } })),
+}))
+
+const mailjetRequest = jest.fn().mockResolvedValue({ body: { Messages: [] } })
+jest.mock("node-mailjet", () => ({
+  __esModule: true,
+  default: {
+    apiConnect: jest.fn().mockImplementation(() => ({
+      post: jest.fn().mockReturnValue({ request: mailjetRequest }),
+    })),
+  },
+}))
+
+describe("bot-recipient guard is enforced at every provider (#1333)", () => {
+  beforeEach(() => jest.clearAllMocks())
+
+  describe("resend (channel: email — the cart-abandoned path)", () => {
+    const load = () => require("../resend/service").default
+
+    it("suppresses the bot address without calling Resend", async () => {
+      const svc = new (load())({ logger: makeLogger() }, { api_key: "re_test", from: "a@b.com" })
+      const res = await svc.send({ to: BOT, template: "cart-abandoned", data: {} })
+
+      expect(resendSend).not.toHaveBeenCalled()
+      expect(res.id).toBe(BOT_SUPPRESSED_SEND_ID)
+    })
+
+    it("logs the suppression — it must never be silent", async () => {
+      const logger = makeLogger()
+      const svc = new (load())({ logger }, { api_key: "re_test", from: "a@b.com" })
+      await svc.send({ to: BOT, template: "cart-abandoned", data: {} })
+
+      const line = logger.warn.mock.calls.map((c: any[]) => String(c[0])).join("\n")
+      expect(line).toContain("[bot-recipient-suppressed]")
+      expect(line).toContain("cart-abandoned")
+      expect(line).toContain("joonix.net")
+    })
+
+    it("still sends to a real customer", async () => {
+      const svc = new (load())({ logger: makeLogger() }, { api_key: "re_test", from: "a@b.com" })
+      const res = await svc.send({
+        to: HUMAN,
+        template: "cart-abandoned",
+        data: { _template_processed: true, _template_html_content: "<p>hi</p>", _template_subject: "s" },
+      })
+
+      expect(resendSend).toHaveBeenCalledTimes(1)
+      expect(res.id).not.toBe(BOT_SUPPRESSED_SEND_ID)
+    })
+  })
+
+  describe("mailjet (channel: email_bulk)", () => {
+    const load = () => require("../mailjet/service").default
+    const opts = { api_key: "k", secret_key: "s", from_email: "a@b.com" }
+
+    it("suppresses the bot address without calling Mailjet", async () => {
+      const svc = new (load())({ logger: makeLogger() }, opts)
+      const res = await svc.send({ to: BOT, template: "cart-abandoned", data: {} })
+
+      expect(mailjetRequest).not.toHaveBeenCalled()
+      expect(res.id).toBe(BOT_SUPPRESSED_SEND_ID)
+    })
+
+    it("drops bot addresses out of a BULK batch and keeps the humans", async () => {
+      const svc = new (load())({ logger: makeLogger() }, opts)
+      ;(svc as any).client = { post: jest.fn().mockReturnValue({ request: mailjetRequest }) }
+
+      await svc.sendBulk([
+        { to: HUMAN, subject: "s", htmlContent: "<p>1</p>" },
+        { to: BOT, subject: "s", htmlContent: "<p>2</p>" },
+        { to: "second.human@gmail.com", subject: "s", htmlContent: "<p>3</p>" },
+      ])
+
+      expect(mailjetRequest).toHaveBeenCalledTimes(1)
+      const payload = mailjetRequest.mock.calls[0][0]
+      const recipients = payload.Messages.map((m: any) => m.To[0].Email)
+      expect(recipients).toEqual([HUMAN, "second.human@gmail.com"])
+      expect(recipients).not.toContain(BOT)
+    })
+
+    /**
+     * The caller contract: a suppressed address is in NEITHER `successful` nor
+     * `failed`, so callers that walk only those two lists leave their queue row
+     * untouched — pending forever, re-picked every run. `suppressed` is what
+     * lets them retire the row. Pinned here because it is invisible from
+     * inside the provider.
+     */
+    it("reports suppressed addresses so callers can retire the row", async () => {
+      const svc = new (load())({ logger: makeLogger() }, opts)
+      ;(svc as any).client = { post: jest.fn().mockReturnValue({ request: mailjetRequest }) }
+
+      const res = await svc.sendBulk([
+        { to: HUMAN, subject: "s", htmlContent: "<p>1</p>" },
+        { to: BOT, subject: "s", htmlContent: "<p>2</p>" },
+      ])
+
+      expect(res.suppressed).toEqual([
+        { email: BOT, rule: "joonix.net", note: expect.stringContaining("Google") },
+      ])
+      expect(res.successful.map((r: any) => r.email)).not.toContain(BOT)
+      expect(res.failed.map((r: any) => r.email)).not.toContain(BOT)
+    })
+
+    it("an all-bot bulk batch makes no API call at all", async () => {
+      const svc = new (load())({ logger: makeLogger() }, opts)
+      ;(svc as any).client = { post: jest.fn().mockReturnValue({ request: mailjetRequest }) }
+
+      const res = await svc.sendBulk([{ to: BOT, subject: "s", htmlContent: "<p>1</p>" }])
+
+      expect(mailjetRequest).not.toHaveBeenCalled()
+      expect(res.successful).toHaveLength(0)
+    })
+  })
+
+  /**
+   * Maileroo's SDK is ESM-only and cannot be instantiated under this jest
+   * transform, so it gets a structural check instead of an exercised one. This
+   * block is also the invariant that matters longest: it fails when someone
+   * adds a fourth email provider — or a new bulk path — without the guard.
+   */
+  describe("every email provider wires the guard (structural invariant)", () => {
+    const fs = require("fs")
+    const path = require("path")
+    const dir = path.join(__dirname, "..")
+
+    const EMAIL_PROVIDERS = ["resend", "mailjet", "maileroo"]
+
+    for (const provider of EMAIL_PROVIDERS) {
+      it(`${provider}: send() consults classifyRecipient`, () => {
+        const src = fs.readFileSync(path.join(dir, provider, "service.ts"), "utf8")
+        expect(src).toContain("classifyRecipient")
+        expect(src).toContain("BOT_SUPPRESSED_SEND_ID")
+        expect(src).toContain("bot-recipients")
+      })
+
+      it(`${provider}: any sendBulk() consults partitionBotRecipients`, () => {
+        const src = fs.readFileSync(path.join(dir, provider, "service.ts"), "utf8")
+        if (!src.includes("async sendBulk(")) return // provider has no bulk path
+        expect(src).toContain("partitionBotRecipients")
+      })
+    }
+
+    /**
+     * The direction that matters is EVERY-WIRED-PROVIDER ⊆ COVERED, not the
+     * reverse. Asserting only that our three are present passes happily when a
+     * fourth email provider is added with no guard — which is the exact failure
+     * this block exists to catch. So parse the provider blocks out of the prod
+     * config and assert every one bound to an `email*` channel is covered here.
+     */
+    const wiredEmailProviders = (): string[] => {
+      const cfg = fs.readFileSync(
+        path.join(__dirname, "..", "..", "..", "medusa-config.prod.ts"),
+        "utf8"
+      )
+      // One entry per `resolve: "./src/modules/<x>"`, paired with the channels
+      // block that follows it before the next `resolve:`.
+      const blocks = cfg.split(/resolve:\s*/).slice(1)
+      const found: string[] = []
+      for (const block of blocks) {
+        const mod = block.match(/^"\.\/src\/modules\/([a-z0-9_-]+)"/)
+        if (!mod) continue
+        const channels = block.match(/channels:\s*\[([^\]]*)\]/)
+        if (!channels) continue
+        const isEmail = channels[1]
+          .split(",")
+          .map((c: string) => c.trim().replace(/['"]/g, ""))
+          .some((c: string) => c.startsWith("email"))
+        if (isEmail) found.push(mod[1])
+      }
+      return found
+    }
+
+    it("finds the email providers actually wired in prod (parser sanity)", () => {
+      // If this fails the parser has drifted from the config format, and the
+      // coverage assertion below would pass vacuously.
+      expect(wiredEmailProviders().sort()).toEqual([...EMAIL_PROVIDERS].sort())
+    })
+
+    it("every email provider wired in prod is covered by this spec", () => {
+      for (const wired of wiredEmailProviders()) {
+        expect(EMAIL_PROVIDERS).toContain(wired)
+      }
+    })
+  })
+})

--- a/apps/backend/src/modules/maileroo/service.ts
+++ b/apps/backend/src/modules/maileroo/service.ts
@@ -12,6 +12,12 @@ const mailerooImport = import("maileroo-sdk")
 type MailerooClientType = InstanceType<
   Awaited<typeof mailerooImport>["MailerooClient"]
 >
+import {
+  classifyRecipient,
+  partitionBotRecipients,
+  botSuppressionLog,
+  BOT_SUPPRESSED_SEND_ID,
+} from "../../lib/bot-recipients"
 
 type InjectedDependencies = {
   logger: Logger
@@ -43,6 +49,14 @@ export type BulkSendSuccess = {
 export type BulkSendResult = {
   successful: BulkSendSuccess[]
   failed: { email: string; error: string }[]
+  /**
+   * Addresses dropped by the bot-recipient guard (#1333). These are NOT in
+   * `successful` and NOT in `failed`, so a caller that only walks those two
+   * lists leaves its queue row untouched — pending forever, re-picked every
+   * run. Callers MUST retire these rows: suppression is terminal, not a
+   * failure to retry.
+   */
+  suppressed: { email: string; rule: string; note: string }[]
 }
 
 // ---------------------------------------------------------------------------
@@ -99,6 +113,17 @@ class MailerooNotificationProviderService extends AbstractNotificationProviderSe
   async send(
     notification: ProviderSendNotificationDTO
   ): Promise<ProviderSendNotificationResultsDTO> {
+    // Bot-recipient guard (#1333). Every email that leaves the platform passes
+    // through a provider, so this is the one place the policy cannot be bypassed
+    // by a new caller. Suppress, don't block — see src/lib/bot-recipients.ts.
+    const botVerdict = classifyRecipient(notification.to)
+    if (botVerdict.bot) {
+      this.logger.warn(
+        botSuppressionLog("maileroo", notification.to, notification.template, botVerdict)
+      )
+      return { id: BOT_SUPPRESSED_SEND_ID }
+    }
+
     const templateData = notification.data as any
 
     // If already sent via bulk API, skip
@@ -168,6 +193,18 @@ class MailerooNotificationProviderService extends AbstractNotificationProviderSe
   // -------------------------------------------------------------------------
 
   async sendBulk(entries: BulkEmailEntry[]): Promise<BulkSendResult> {
+    // Bot-recipient guard (#1333). Bulk bypasses the notification module and
+    // therefore send() — a crawler address inside a 50-address batch is the same
+    // waste as a single send, so the same policy is applied here.
+    const partitioned = partitionBotRecipients(entries, (e) => e.to)
+    const suppressed = partitioned.suppressed.map(({ entry, verdict }) => {
+      this.logger?.warn(
+        botSuppressionLog("maileroo-bulk", entry.to, undefined, verdict)
+      )
+      return { email: entry.to, rule: verdict.rule, note: verdict.note }
+    })
+    entries = partitioned.send
+
     const defaultFrom = this.options.from_email
     const defaultName = this.options.from_name || "Jaal Yantra Textiles"
 
@@ -250,7 +287,7 @@ class MailerooNotificationProviderService extends AbstractNotificationProviderSe
       `Maileroo bulk: ${successful.length} sent, ${failed.length} failed (${entries.length} total)`
     )
 
-    return { successful, failed }
+    return { successful, failed, suppressed }
   }
 }
 

--- a/apps/backend/src/modules/mailjet/service.ts
+++ b/apps/backend/src/modules/mailjet/service.ts
@@ -5,6 +5,12 @@ import {
   ProviderSendNotificationResultsDTO,
 } from "@medusajs/framework/types"
 import Mailjet from "node-mailjet"
+import {
+  classifyRecipient,
+  partitionBotRecipients,
+  botSuppressionLog,
+  BOT_SUPPRESSED_SEND_ID,
+} from "../../lib/bot-recipients"
 
 type InjectedDependencies = {
   logger: Logger
@@ -37,6 +43,14 @@ export type BulkSendSuccess = {
 export type BulkSendResult = {
   successful: BulkSendSuccess[]
   failed: { email: string; error: string }[]
+  /**
+   * Addresses dropped by the bot-recipient guard (#1333). These are NOT in
+   * `successful` and NOT in `failed`, so a caller that only walks those two
+   * lists leaves its queue row untouched — pending forever, re-picked every
+   * run. Callers MUST retire these rows: suppression is terminal, not a
+   * failure to retry.
+   */
+  suppressed: { email: string; rule: string; note: string }[]
 }
 
 // ---------------------------------------------------------------------------
@@ -89,6 +103,17 @@ class MailjetNotificationProviderService extends AbstractNotificationProviderSer
   async send(
     notification: ProviderSendNotificationDTO
   ): Promise<ProviderSendNotificationResultsDTO> {
+    // Bot-recipient guard (#1333). Every email that leaves the platform passes
+    // through a provider, so this is the one place the policy cannot be bypassed
+    // by a new caller. Suppress, don't block — see src/lib/bot-recipients.ts.
+    const botVerdict = classifyRecipient(notification.to)
+    if (botVerdict.bot) {
+      this.logger.warn(
+        botSuppressionLog("mailjet", notification.to, notification.template, botVerdict)
+      )
+      return { id: BOT_SUPPRESSED_SEND_ID }
+    }
+
     const templateData = notification.data as any
 
     // If the email was already sent via bulk API, skip sending and just return
@@ -170,6 +195,18 @@ class MailjetNotificationProviderService extends AbstractNotificationProviderSer
    * Uses the same client instance and from address configured for this provider.
    */
   async sendBulk(entries: BulkEmailEntry[]): Promise<BulkSendResult> {
+    // Bot-recipient guard (#1333). Bulk bypasses the notification module and
+    // therefore send() — a crawler address inside a 50-address batch is the same
+    // waste as a single send, so the same policy is applied here.
+    const partitioned = partitionBotRecipients(entries, (e) => e.to)
+    const suppressed = partitioned.suppressed.map(({ entry, verdict }) => {
+      this.logger?.warn(
+        botSuppressionLog("mailjet-bulk", entry.to, undefined, verdict)
+      )
+      return { email: entry.to, rule: verdict.rule, note: verdict.note }
+    })
+    entries = partitioned.send
+
     const fromEmail = this.options.from_email
     const fromName = this.options.from_name || "Jaal Yantra Textiles"
 
@@ -230,7 +267,7 @@ class MailjetNotificationProviderService extends AbstractNotificationProviderSer
       `Mailjet bulk: ${successful.length} sent, ${failed.length} failed (${entries.length} total)`
     )
 
-    return { successful, failed }
+    return { successful, failed, suppressed }
   }
 }
 

--- a/apps/backend/src/modules/resend/service.ts
+++ b/apps/backend/src/modules/resend/service.ts
@@ -7,6 +7,11 @@ import {
 import { Resend } from "resend"
 import React from "react"
 import DefaultEmail from "./templates/default-email"
+import {
+  classifyRecipient,
+  botSuppressionLog,
+  BOT_SUPPRESSED_SEND_ID,
+} from "../../lib/bot-recipients"
 
 type InjectedDependencies = {
   logger: Logger
@@ -51,6 +56,17 @@ class ResendNotificationProviderService extends AbstractNotificationProviderServ
   async send(
     notification: ProviderSendNotificationDTO
   ): Promise<ProviderSendNotificationResultsDTO> {
+    // Bot-recipient guard (#1333). Every email that leaves the platform passes
+    // through a provider, so this is the one place the policy cannot be bypassed
+    // by a new caller. Suppress, don't block — see src/lib/bot-recipients.ts.
+    const botVerdict = classifyRecipient(notification.to)
+    if (botVerdict.bot) {
+      this.logger.warn(
+        botSuppressionLog("resend", notification.to, notification.template, botVerdict)
+      )
+      return { id: BOT_SUPPRESSED_SEND_ID }
+    }
+
     let template: string | null = null
     let subject = "We have a message for you"
     let fromAddress = this.options.from // Default to environment variable

--- a/apps/backend/src/workflows/blogs/send-blog-subscribers/steps/process-all-batches.ts
+++ b/apps/backend/src/workflows/blogs/send-blog-subscribers/steps/process-all-batches.ts
@@ -2,6 +2,10 @@ import { StepResponse, createStep } from "@medusajs/framework/workflows-sdk"
 import { SubscriberBatch, EmailSendingResult, SendingSummary } from "../types"
 import { Modules } from "@medusajs/framework/utils"
 import { sendMailjetBulk, BulkEmailEntry } from "../../../../modules/mailjet/bulk"
+import {
+  classifyRecipient,
+  BOT_SUPPRESSED_SEND_ID,
+} from "../../../../lib/bot-recipients"
 import { INotificationModuleService } from "@medusajs/types"
 import { EMAIL_PROVIDER_MANAGER_MODULE } from "../../../../modules/email-provider-manager"
 import EmailProviderManagerService from "../../../../modules/email-provider-manager/service"
@@ -285,6 +289,19 @@ export const processAllBatchesStep = createStep(
           const entry = emailToSubscriber.get(fail.email)
           allResults.push({ success: false, subscriber_id: entry?.subscriber.id || "", email: fail.email, error: fail.error })
         }
+
+        // Known-bot recipients (#1333) are in neither list. Record them as a
+        // non-retryable result so the totals still add up and the retry pass
+        // below never re-queues them — they are not a delivery failure.
+        for (const dropped of bulkResult.suppressed || []) {
+          const entry = emailToSubscriber.get(dropped.email)
+          allResults.push({
+            success: false,
+            subscriber_id: entry?.subscriber.id || "",
+            email: dropped.email,
+            error: `[bot-recipient-suppressed] rule=${dropped.rule} — ${dropped.note}`,
+          })
+        }
       }
 
       // --- Resend one-at-a-time sending (passes _template_* flags) ---
@@ -391,14 +408,28 @@ export const processAllBatchesStep = createStep(
             notificationData._template_processed = true
           }
 
-          await notificationModuleService.createNotifications({
+          const created: any = await notificationModuleService.createNotifications({
             to: subscriber.email,
             channel: "email",
             template: BLOG_TEMPLATE_KEY,
             data: notificationData,
           })
 
-          allResults.push({ success: true, subscriber_id: subscriber.id, email: subscriber.email })
+          // A suppressed send resolves normally; the provider returns the
+          // synthetic id in place of a message id. Recording success here
+          // would make suppressed mail read as delivered (#1333).
+          const externalId = Array.isArray(created)
+            ? created[0]?.external_id
+            : created?.external_id
+          if (externalId === BOT_SUPPRESSED_SEND_ID) {
+            const verdict = classifyRecipient(subscriber.email)
+            allResults.push({
+              success: false, subscriber_id: subscriber.id, email: subscriber.email,
+              error: `[bot-recipient-suppressed] rule=${verdict.rule} — ${verdict.note}`,
+            })
+          } else {
+            allResults.push({ success: true, subscriber_id: subscriber.id, email: subscriber.email })
+          }
         } catch (error) {
           allResults.push({
             success: false, subscriber_id: subscriber.id, email: subscriber.email,
@@ -413,6 +444,9 @@ export const processAllBatchesStep = createStep(
     // Retry failed sends that are not validation errors (queue for next day)
     const PERMANENT_ERROR_PATTERNS = [
       "invalid `to` field", "validation_error", "invalid email", "email address",
+      // A known-bot recipient (#1333) is a decision, not a transient failure —
+      // re-queueing it would reintroduce the daily waste this fix removes.
+      "[bot-recipient-suppressed]",
     ]
 
     if (providerManager) {


### PR DESCRIPTION
Closes #1333. Part of #1327.

## The defect

`johnsmith004@storebotmail.joonix.net` was the **only** `cart-abandoned` recipient in the last 200 prod notifications — six sends across four days, every one recorded `success`. `joonix.net` is Google infrastructure; `storebot` is its shopping crawler. Not an attacker: it adds items to a cart to verify price and availability, our cart-recovery flow can't tell that from a customer, so it emails the crawler.

Nothing surfaced it because **a send to a black hole looks exactly like a send to a customer**.

## Suppress, don't block

The crawler's visits are legitimate and we want them — blocking Google risks Merchant Center and Shopping listings. Four carts in four months is not an attack. So this stops *mailing* it, never stops it browsing, and never deletes the customer record (those visits are evidence for #1328).

## Why the guard lives at the provider

Lifecycle mail reaches the wire through several paths: the visual-flow `send_email` op, the `send-notification-email` workflows, and direct `createNotifications` calls scattered across workflows. A guard on any one of those is not a guard — it moves the leak.

Verified rather than assumed:
- `medusa-config.prod.ts` wires exactly `resend`→`email`, `mailjet`→`email_bulk`, `maileroo`→`email_partner`. `local` is `feed`-only; whatsapp-audit is audit-only.
- Nothing imports `resend` / `node-mailjet` / `maileroo-sdk` / `nodemailer` anywhere in `src` outside those three modules.
- Traced the live path end to end: `visual_flows/operations/send-email.ts` → `createNotifications({channel:"email"})` → resend `send()` → guard.

## Three defects fixed on review

**1. Bulk-suppressed queue rows were immortal.** A suppressed address is in neither `successful` nor `failed`, so callers walking those two lists never called `updateEmailQueues`: the row stayed `pending`, was re-picked every run **forever**, and consumed a provider allocation slot each time (capacity is allocated *before* the send). `sendBulk` now returns `suppressed[]`, and the queue job retires bot rows up front.

**2. Suppressed mail read as `sent`.** A suppressed send resolves normally, so the row was marked `sent` and `sentCount++`. Both single-send callers now check the returned external id. The blog retry pass also treats suppression as permanent — otherwise it re-queued the bot address daily, reintroducing the waste.

**3. The invariant test didn't hold its invariant.** It asserted our three providers are present in the prod config — never the reverse — so adding a fourth unguarded email provider passed it happily. It now parses providers bound to an `email*` channel and asserts each is covered. Proven by temporarily adding a fake `sendgrid` provider to `medusa-config.prod.ts`: 2 tests failed, config restored.

## Note on the status enum

Suppressed rows are marked `failed` with a greppable `[bot-recipient-suppressed]` reason rather than a new `suppressed` status: the status is a DB enum and widening it needs a check-constraint migration (#1208). What matters is that it never reads `sent`.

## Not fixed here

#1334 (duplicate sends, one second apart) is deliberately untouched — the scheduler dedupe is a check-then-set and the likely window is deploy/Spot overlap. That needs correlating against deploys first; a guessed fix to a race is worse than none.

## Verification

- 53 unit tests pass, including the negative proof above.
- `check:prod-build` green (the real gate).
- Behavioural effect on prod is **unverified** until deployed — probe by checking that a bot-addressed notification records the synthetic provider id rather than a message id.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
