### PR TITLE
feat(storefront): surface revalidate failures, guard theme drift, and let the assistant build pages

### DIFF
--- a/.github/workflows/test-and-release.yml
+++ b/.github/workflows/test-and-release.yml
@@ -114,6 +114,12 @@ jobs:
     - uses: actions/checkout@v4
       with:
         fetch-depth: 0
+        # The theme drift test reads apps/storefront-starter's theme type to
+        # check that every setting the API accepts is actually rendered. Without
+        # this the file is simply absent on the runner and that half of the
+        # guard cannot run. The submodule is a PUBLIC repo over HTTPS, so the
+        # default job token is enough — no PAT.
+        submodules: true
 
     - name: Install pnpm
       uses: pnpm/action-setup@v4

--- a/.gitignore
+++ b/.gitignore
@@ -109,3 +109,9 @@ node_modules 2/
 .e2e-seed.json
 test-results/
 apps/backend/test-results/
+
+# Hyperbee/autobase stores the backend writes on startup. Created at runtime,
+# per-machine, never source — they showed up as untracked noise in every
+# `git status` and are one careless `git add -A` away from being committed.
+apps/backend/_crm_hb_e2e/
+apps/backend/_pp_hb_e2e/

--- a/apps/backend/src/api/partners/storefront/helpers.ts
+++ b/apps/backend/src/api/partners/storefront/helpers.ts
@@ -165,28 +165,51 @@ export const validatePartnerBlockOwnership = async (
  * are saved on the backend but invisible to visitors until the next
  * storefront-starter deploy.
  *
- * - Skips silently when STOREFRONT_REVALIDATE_SECRET isn't set (dev,
- *   tests, or instances that don't run a revalidate endpoint yet).
+ * - Skips when STOREFRONT_REVALIDATE_SECRET isn't set (dev, tests, or
+ *   instances that don't run a revalidate endpoint yet).
  * - Hard 5s timeout — never lets a slow / dead storefront block the
- *   partner's mutation response.
- * - Logs but doesn't throw. Theme PUT must not 500 because the
- *   webhook flaked.
+ *   partner's mutation response indefinitely.
+ * - Never throws. Theme PUT must not 500 because the webhook flaked.
+ *
+ * RETURNS the outcome rather than void. It used to return void and warn to
+ * the backend's own console, which meant a storefront answering 401 (secret
+ * mismatch) or 503 (secret unset on the storefront side) produced a perfectly
+ * green save and a live site that never changed — for the life of the
+ * deployment. Callers are expected to surface this so the partner learns that
+ * their edit is stored but not yet visible. A 200 on save proves the write,
+ * never the effect.
  *
  * Pass `paths: ['/']` for theme/layout edits (revalidates everything
  * via 'layout' scope). Pass specific `paths` like `['/products/foo']`
  * for narrow updates. Pass `tags` if you've wired specific cache tags.
  */
+export type RevalidateOutcome = {
+  /** false when we had no secret or no domain, so no request was made. */
+  attempted: boolean
+  /** true only when the storefront answered 2xx. */
+  ok: boolean
+  /** HTTP status when we got one — 401 = secret mismatch, 503 = unset there. */
+  status?: number
+  /** Short machine-readable why, for the caller to surface. */
+  reason?:
+    | "no_backend_secret"
+    | "no_domain"
+    | "rejected"
+    | "unreachable"
+    | "ok"
+}
+
 export const triggerStorefrontRevalidate = async (
   website: { domain?: string | null },
   opts: { paths?: string[]; tags?: string[] } = {}
-): Promise<void> => {
+): Promise<RevalidateOutcome> => {
   const secret = process.env.STOREFRONT_REVALIDATE_SECRET
   if (!secret) {
-    return
+    return { attempted: false, ok: false, reason: "no_backend_secret" }
   }
   const domain = website?.domain
   if (!domain) {
-    return
+    return { attempted: false, ok: false, reason: "no_domain" }
   }
 
   const url = domain.startsWith("http")
@@ -210,13 +233,26 @@ export const triggerStorefrontRevalidate = async (
     })
     if (!res.ok) {
       console.warn(
-        `[storefront-revalidate] ${url} returned ${res.status}`
+        `[storefront-revalidate] ${url} returned ${res.status}` +
+          (res.status === 401
+            ? " — the storefront's REVALIDATE_SECRET does not match this backend's STOREFRONT_REVALIDATE_SECRET"
+            : res.status === 503
+              ? " — the storefront has no REVALIDATE_SECRET set"
+              : "")
       )
+      return {
+        attempted: true,
+        ok: false,
+        status: res.status,
+        reason: "rejected",
+      }
     }
+    return { attempted: true, ok: true, status: res.status, reason: "ok" }
   } catch (err: any) {
     console.warn(
       `[storefront-revalidate] ${url} failed: ${err?.message || err}`
     )
+    return { attempted: true, ok: false, reason: "unreachable" }
   } finally {
     clearTimeout(timer)
   }

--- a/apps/backend/src/api/partners/storefront/website/theme/__tests__/theme-schema-drift.unit.spec.ts
+++ b/apps/backend/src/api/partners/storefront/website/theme/__tests__/theme-schema-drift.unit.spec.ts
@@ -49,7 +49,16 @@ const EXEMPT: Record<string, { from: Array<"storefront" | "editor">; why: string
 
 const read = (p: string): string => {
   if (!fs.existsSync(p)) {
-    throw new Error(`${p} not found — has the file moved?`)
+    // Failing loudly is the point. `apps/storefront-starter` is a SUBMODULE,
+    // so a runner that checks out without `submodules: true` has no such file
+    // — and the alternative (skip when absent) would let this guard quietly
+    // stop guarding in CI while still looking green locally, which is the
+    // exact failure mode it exists to prevent.
+    throw new Error(
+      `${p} not found. If this is CI, the storefront-starter submodule was ` +
+        `not checked out — add \`submodules: true\` to actions/checkout. ` +
+        `Locally, run \`git submodule update --init\`.`
+    )
   }
   return fs.readFileSync(p, "utf8")
 }

--- a/apps/backend/src/api/partners/storefront/website/theme/__tests__/theme-schema-drift.unit.spec.ts
+++ b/apps/backend/src/api/partners/storefront/website/theme/__tests__/theme-schema-drift.unit.spec.ts
@@ -1,0 +1,122 @@
+import * as fs from "fs"
+import * as path from "path"
+
+/**
+ * The theme vocabulary is written down three times:
+ *
+ *   1. `validators.ts`        — the Zod schema, what the API will accept
+ *   2. `storefront-starter`   — the TS type + the components that render it
+ *   3. `partner-ui`           — the editor form the partner actually touches
+ *
+ * Nothing has ever tied them together. Adding a setting means three hand edits
+ * in three apps, and forgetting one fails silently in a different way each
+ * time: miss the storefront and the value is stored but never rendered; miss
+ * the editor and the setting exists but no partner can reach it. `min_height`
+ * (schema-only) and `text_color` (schema + renderer, no editor control) both
+ * drifted exactly that way and nothing failed.
+ *
+ * This test makes the drift loud. It is deliberately a text scan rather than a
+ * type-level check: the three files live in three apps with three tsconfigs
+ * (the backend's excludes `apps/*` outright), so there is no compiler that
+ * sees all of them at once. A grep that fails CI beats a type relationship
+ * that cannot be expressed.
+ *
+ * It is a stopgap, not the destination — the destination is generating the
+ * editor and the storefront type FROM this schema so drift is impossible
+ * rather than merely detected. Until then, this is the guard.
+ */
+
+const REPO_ROOT = path.resolve(__dirname, "..", "..", "..", "..", "..", "..", "..", "..", "..")
+
+const SCHEMA = path.join(
+  REPO_ROOT,
+  "apps/backend/src/api/partners/storefront/website/theme/validators.ts"
+)
+const STOREFRONT_TYPE = path.join(
+  REPO_ROOT,
+  "apps/storefront-starter/src/lib/data/website.ts"
+)
+const EDITOR = path.join(
+  REPO_ROOT,
+  "apps/partner-ui/src/routes/settings/theme/theme.tsx"
+)
+
+/**
+ * Keys that are intentionally absent downstream. Every entry needs a reason —
+ * an allowlist without one is just a way to make a failing test pass.
+ */
+const EXEMPT: Record<string, { from: Array<"storefront" | "editor">; why: string }> = {}
+
+const read = (p: string): string => {
+  if (!fs.existsSync(p)) {
+    throw new Error(`${p} not found — has the file moved?`)
+  }
+  return fs.readFileSync(p, "utf8")
+}
+
+/**
+ * Jest's `expect` takes one argument, so the explanation cannot ride along as
+ * a second parameter. Fold it into the compared VALUE instead: on failure the
+ * diff prints the sentence and the offending keys, which is the whole point —
+ * a bare `[] !== ["min_height"]` tells the next person nothing about what to
+ * do about it.
+ */
+const complaint = (missing: string[], explain: string): string =>
+  missing.length === 0 ? "" : `${explain}: ${missing.join(", ")}`
+
+/** Leaf keys declared in the Zod schema (indented object properties). */
+const schemaKeys = (src: string): string[] => {
+  const keys = new Set<string>()
+  for (const m of src.matchAll(/^\s{4,}([a-z][a-z0-9_]*):/gm)) {
+    keys.add(m[1])
+  }
+  return [...keys].sort()
+}
+
+const mentions = (src: string, key: string): boolean =>
+  new RegExp(`\\b${key}\\b`).test(src)
+
+describe("theme schema stays in sync with its renderer and its editor", () => {
+  const schemaSrc = read(SCHEMA)
+  const keys = schemaKeys(schemaSrc)
+
+  it("parses a plausible number of settings out of the schema", () => {
+    // Guards the parser itself: if the regex stops matching, every assertion
+    // below passes vacuously and the drift guard silently stops guarding.
+    expect(keys.length).toBeGreaterThan(50)
+    expect(keys).toContain("gallery_position")
+    expect(keys).toContain("primary")
+  })
+
+  it("every theme setting is known to the storefront that renders it", () => {
+    const src = read(STOREFRONT_TYPE)
+    const missing = keys.filter(
+      (k) => !mentions(src, k) && !EXEMPT[k]?.from.includes("storefront")
+    )
+
+    expect(
+      complaint(
+        missing,
+        "accepted by the API but never read by the storefront, so a partner " +
+          "can save a value that does nothing — add them to WebsiteTheme and " +
+          "render them, or list them in EXEMPT with a reason"
+      )
+    ).toBe("")
+  })
+
+  it("every theme setting is reachable from the partner editor", () => {
+    const src = read(EDITOR)
+    const missing = keys.filter(
+      (k) => !mentions(src, k) && !EXEMPT[k]?.from.includes("editor")
+    )
+
+    expect(
+      complaint(
+        missing,
+        "in the schema but no control in the theme editor mentions them, so " +
+          "no partner can set them — add a control, or list them in EXEMPT " +
+          "with a reason"
+      )
+    ).toBe("")
+  })
+})

--- a/apps/backend/src/api/partners/storefront/website/theme/chat/__tests__/page-tools.unit.spec.ts
+++ b/apps/backend/src/api/partners/storefront/website/theme/chat/__tests__/page-tools.unit.spec.ts
@@ -1,0 +1,177 @@
+/**
+ * The page tools let a language model write to a partner's website. The
+ * safety properties below are the reason that is acceptable, so they are
+ * asserted rather than asserted-in-a-comment:
+ *
+ *   - a page the assistant creates is ALWAYS a draft (invisible to visitors)
+ *   - it never silently edits a page that is already published
+ *   - it never writes to a page belonging to another tenant
+ *   - it refuses to create a second page on an existing slug
+ *
+ * The workflows are mocked: this is about what the tools DECIDE, not whether
+ * MikroORM persists. A test that needed a database would not be run often
+ * enough to protect these.
+ */
+
+const createPageRun = jest.fn()
+const listPageRun = jest.fn()
+const createBatchRun = jest.fn()
+const listBlocksRun = jest.fn()
+
+jest.mock("../../../../../../../workflows/website/website-page/create-page", () => ({
+  createPageWorkflow: () => ({ run: createPageRun }),
+}))
+jest.mock("../../../../../../../workflows/website/website-page/list-page", () => ({
+  listPageWorkflow: () => ({ run: listPageRun }),
+}))
+jest.mock("../../../../../../../workflows/website/page-blocks/create-batch-blocks", () => ({
+  createBatchBlocksWorkflow: () => ({ run: createBatchRun }),
+}))
+jest.mock("../../../../../../../workflows/website/page-blocks/list-blocks", () => ({
+  listBlocksWorkflow: () => ({ run: listBlocksRun }),
+}))
+
+import { buildPageTools } from "../page-tools"
+
+const WEBSITE_ID = "web_01"
+
+const tools = () =>
+  buildPageTools({ scope: {} as any, websiteId: WEBSITE_ID }) as any
+
+/** The AI SDK wraps execute; call it the way the runtime does. */
+const run = (t: any, input: any) => t.execute(input, {} as any)
+
+const givenPages = (pages: any[]) =>
+  listPageRun.mockResolvedValue({ result: [pages, pages.length] })
+
+beforeEach(() => {
+  jest.clearAllMocks()
+  givenPages([])
+  createPageRun.mockResolvedValue({ result: { id: "page_new" } })
+  createBatchRun.mockResolvedValue({ result: { created: [{ id: "blk_1" }], errors: [] } })
+  listBlocksRun.mockResolvedValue({ result: { blocks: [] } })
+})
+
+describe("create_page", () => {
+  const blocks = [{ type: "Main", content: { body: "Hand-woven in Kashmir." } }]
+
+  it("always creates the page as a Draft", async () => {
+    await run(tools().create_page, {
+      title: "Care Instructions",
+      slug: "care-instructions",
+      page_type: "Custom",
+      blocks,
+    })
+
+    expect(createPageRun).toHaveBeenCalledTimes(1)
+    const input = createPageRun.mock.calls[0][0].input
+    expect(input.status).toBe("Draft")
+    expect(input.website_id).toBe(WEBSITE_ID)
+  })
+
+  it("cannot be talked into publishing — status is not an input at all", async () => {
+    // The model can only pass what the schema declares. If `status` ever
+    // becomes an accepted field, this fails and someone has to justify it.
+    const schema: any = tools().create_page.inputSchema
+    const shape = schema?.shape ?? schema?._def?.shape?.()
+    expect(Object.keys(shape ?? {})).not.toContain("status")
+    expect(Object.keys(shape ?? {})).not.toContain("published_at")
+  })
+
+  it("says the page is a draft in its own result, so the model cannot claim it is live", async () => {
+    const res: any = await run(tools().create_page, {
+      title: "About",
+      slug: "about",
+      page_type: "About",
+      blocks,
+    })
+    expect(res.status).toBe("Draft")
+    expect(res.note).toMatch(/not visible to visitors/i)
+  })
+
+  it("normalises a slug the model wrote as prose", async () => {
+    await run(tools().create_page, {
+      title: "Size Guide",
+      slug: "/Size Guide/",
+      page_type: "Custom",
+      blocks,
+    })
+    expect(createPageRun.mock.calls[0][0].input.slug).toBe("size-guide")
+  })
+
+  it("refuses to create a second page on an existing slug", async () => {
+    givenPages([
+      { id: "page_old", slug: "about", title: "About us", status: "Published" },
+    ])
+
+    const res: any = await run(tools().create_page, {
+      title: "About",
+      slug: "about",
+      page_type: "About",
+      blocks,
+    })
+
+    expect(res.created).toBe(false)
+    expect(res.existing_page_id).toBe("page_old")
+    expect(createPageRun).not.toHaveBeenCalled()
+  })
+})
+
+describe("add_page_blocks", () => {
+  const blocks = [{ type: "Main", content: { body: "More detail." } }]
+
+  it("refuses a published page unless the edit was confirmed", async () => {
+    givenPages([{ id: "page_1", title: "About", status: "Published" }])
+
+    const res: any = await run(tools().add_page_blocks, {
+      page_id: "page_1",
+      blocks,
+      confirm_live_edit: false,
+    })
+
+    expect(res.added).toBe(false)
+    expect(res.requires_confirmation).toBe(true)
+    expect(createBatchRun).not.toHaveBeenCalled()
+  })
+
+  it("proceeds on a published page once confirmed, and says the change is live", async () => {
+    givenPages([{ id: "page_1", title: "About", status: "Published" }])
+
+    const res: any = await run(tools().add_page_blocks, {
+      page_id: "page_1",
+      blocks,
+      confirm_live_edit: true,
+    })
+
+    expect(res.added).toBe(true)
+    expect(res.note).toMatch(/live/i)
+  })
+
+  it("appends after the existing blocks rather than overwriting their order", async () => {
+    givenPages([{ id: "page_1", title: "About", status: "Draft" }])
+    listBlocksRun.mockResolvedValue({
+      result: { blocks: [{ id: "b1" }, { id: "b2" }] },
+    })
+
+    await run(tools().add_page_blocks, { page_id: "page_1", blocks, confirm_live_edit: false })
+
+    expect(createBatchRun.mock.calls[0][0].input.blocks[0].order).toBe(2)
+  })
+
+  it("will not touch a page that is not on this partner's website", async () => {
+    // The page list is website-scoped, so another tenant's id simply is not in
+    // it. The refusal must not distinguish "someone else's" from "nonexistent"
+    // — confirming an id exists elsewhere is itself a leak.
+    givenPages([{ id: "page_mine", title: "Mine", status: "Draft" }])
+
+    const res: any = await run(tools().add_page_blocks, {
+      page_id: "page_someone_else",
+      blocks,
+      confirm_live_edit: true,
+    })
+
+    expect(res.added).toBe(false)
+    expect(res.error).toMatch(/No page with id/)
+    expect(createBatchRun).not.toHaveBeenCalled()
+  })
+})

--- a/apps/backend/src/api/partners/storefront/website/theme/chat/page-tools.ts
+++ b/apps/backend/src/api/partners/storefront/website/theme/chat/page-tools.ts
@@ -1,0 +1,305 @@
+/**
+ * Website-page tools for the theme editor's chat panel.
+ *
+ * The panel could already restyle a storefront but not add anything to it: a
+ * partner who wanted an About page, a size guide or a care-instructions page
+ * had to leave the assistant, open the pages editor, create the page, then
+ * write every block by hand. The page and block APIs already existed — nothing
+ * had connected them to the assistant that partners actually talk to.
+ *
+ * ── What these tools may and may not do ──────────────────────────────────────
+ *
+ * Pages are created as DRAFTS, always. A draft is invisible to visitors, so an
+ * assistant that misunderstands "add a page about our weavers" costs the
+ * partner a click to delete, never a wrong page on a live storefront. Nothing
+ * here publishes, unpublishes or deletes — publishing is the moment content
+ * becomes public and that stays a human decision, made in the pages editor
+ * where the partner can read the whole page first.
+ *
+ * Editing a page that is ALREADY published is different: those edits are
+ * immediately public. `add_page_blocks` therefore refuses a published page
+ * unless the caller passes `confirm_live_edit`, which the model is instructed
+ * to obtain from the user in words first.
+ *
+ * ── Block vocabulary ─────────────────────────────────────────────────────────
+ *
+ * The storefront renders two block types (see the `[slug]` page renderer):
+ *   - `Hero` — { title, subtitle?, align? }
+ *   - `Main` — { title?, body } where body is plain text (TipTap JSON also
+ *     renders, but prose is what a language model should be producing)
+ * Anything else falls through to a debug dump of the block's JSON, which is
+ * why the schema below is a closed enum rather than a free string: an invented
+ * block type renders as a wall of JSON on the partner's page.
+ */
+import { tool } from "ai"
+import { z } from "@medusajs/framework/zod"
+
+import { createPageWorkflow } from "../../../../../../workflows/website/website-page/create-page"
+import { listPageWorkflow } from "../../../../../../workflows/website/website-page/list-page"
+import { createBatchBlocksWorkflow } from "../../../../../../workflows/website/page-blocks/create-batch-blocks"
+import { listBlocksWorkflow } from "../../../../../../workflows/website/page-blocks/list-blocks"
+
+/** Prose the model needs in its system prompt to use these tools well. */
+export const PAGE_TOOL_DESCRIPTION = `## Website Pages
+
+You can also create and fill website pages (About, Size Guide, Care, Shipping, FAQ, …).
+
+- \`list_pages\` — see what pages already exist before creating anything. Never create a page whose slug already exists; offer to add blocks to it instead.
+- \`create_page\` — creates a page as a DRAFT with its blocks in one call. Write the actual copy; do not leave placeholders like "Lorem ipsum" or "[insert text]". Base the wording on what the partner sells and the words they use.
+- \`add_page_blocks\` — append blocks to an existing page.
+
+Block types:
+- \`Hero\` — a heading band. content: { title, subtitle?, align? }
+- \`Main\` — a prose section. content: { title?, body } where body is plain text; blank lines separate paragraphs.
+
+Rules:
+- Every page you create is a DRAFT. Tell the partner it is a draft and that they publish it from the Pages editor when they are happy with it. Never claim a page is live.
+- If \`add_page_blocks\` reports the page is published, STOP and ask the partner whether to edit a live page before retrying with confirm_live_edit.
+- Slugs are lowercase words joined by hyphens, no leading slash.`
+
+type Ctx = {
+  scope: any
+  websiteId: string
+}
+
+const blockSchema = z.object({
+  type: z
+    .enum(["Hero", "Main"])
+    .describe("Hero for a heading band, Main for a prose section"),
+  name: z
+    .string()
+    .optional()
+    .describe("Short internal label shown in the block list, e.g. 'Intro'"),
+  content: z
+    .object({
+      title: z.string().optional(),
+      subtitle: z.string().optional(),
+      align: z.enum(["left", "center"]).optional(),
+      body: z
+        .string()
+        .optional()
+        .describe("Plain-text prose for a Main block. Blank lines split paragraphs."),
+    })
+    .describe("Block content. Hero uses title/subtitle/align; Main uses title/body."),
+})
+
+const PAGE_TYPES = [
+  "Home",
+  "About",
+  "Contact",
+  "Blog",
+  "Product",
+  "Service",
+  "Portfolio",
+  "Landing",
+  "Custom",
+  "Newsletter",
+] as const
+
+/** Slug hygiene — the model writes prose, not URL segments. */
+const normalizeSlug = (raw: string): string =>
+  raw
+    .trim()
+    .toLowerCase()
+    .replace(/^\/+|\/+$/g, "")
+    .replace(/[^a-z0-9]+/g, "-")
+    .replace(/^-+|-+$/g, "")
+
+export const buildPageTools = ({ scope, websiteId }: Ctx) => ({
+  list_pages: tool({
+    description:
+      "List the website's existing pages (title, slug, status). Call this BEFORE creating a page so you never duplicate a slug that already exists.",
+    inputSchema: z.object({
+      limit: z.number().min(1).max(50).default(25),
+    }),
+    execute: async (input) => {
+      const { result } = await listPageWorkflow(scope).run({
+        input: {
+          website_id: websiteId,
+          filters: {},
+          config: { skip: 0, take: input.limit },
+        },
+      })
+      const [pages, count] = result as [any[], number]
+      return {
+        count,
+        pages: (pages || []).map((p: any) => ({
+          id: p.id,
+          title: p.title,
+          slug: p.slug,
+          status: p.status,
+          page_type: p.page_type,
+        })),
+      }
+    },
+  }),
+
+  create_page: tool({
+    description:
+      "Create a new website page as a DRAFT, with its content blocks. The page is NOT visible to visitors until the partner publishes it from the Pages editor. Write real copy, never placeholders.",
+    inputSchema: z.object({
+      title: z.string().min(1).describe("Page title, e.g. 'Care Instructions'"),
+      slug: z
+        .string()
+        .min(1)
+        .describe("URL segment, lowercase-with-hyphens, no leading slash"),
+      page_type: z.enum(PAGE_TYPES).default("Custom"),
+      meta_description: z
+        .string()
+        .optional()
+        .describe("One-sentence search snippet for this page"),
+      blocks: z
+        .array(blockSchema)
+        .min(1)
+        .max(12)
+        .describe("The page's content, in the order it should appear"),
+    }),
+    execute: async (input) => {
+      const slug = normalizeSlug(input.slug)
+      if (!slug) {
+        return { created: false, error: "The slug was empty after cleaning up." }
+      }
+
+      // Refuse duplicates rather than creating a second page on the same URL.
+      const { result: existingResult } = await listPageWorkflow(scope).run({
+        input: {
+          website_id: websiteId,
+          filters: {},
+          config: { skip: 0, take: 100 },
+        },
+      })
+      const [existingPages] = existingResult as [any[], number]
+      const clash = (existingPages || []).find((p: any) => p.slug === slug)
+      if (clash) {
+        return {
+          created: false,
+          error: `A page with slug "${slug}" already exists ("${clash.title}", ${clash.status}). Use add_page_blocks with page_id "${clash.id}" to extend it, or choose a different slug.`,
+          existing_page_id: clash.id,
+        }
+      }
+
+      const { result: page } = await createPageWorkflow(scope).run({
+        input: {
+          website_id: websiteId,
+          title: input.title,
+          slug,
+          // The page model carries a `content` string alongside its blocks;
+          // blocks are what the storefront renders, so this stays empty.
+          content: "",
+          page_type: input.page_type,
+          // Draft, always — see the module header.
+          status: "Draft",
+          meta_description: input.meta_description,
+          genMetaDataLLM: false,
+        },
+      })
+
+      const pageId = (page as any)?.id
+      const blockResult = await createBatchBlocksWorkflow(scope).run({
+        input: {
+          blocks: input.blocks.map((b, i) => ({
+            page_id: pageId,
+            name: b.name || b.type,
+            type: b.type,
+            content: b.content,
+            order: i,
+            status: "Active",
+          })),
+        },
+      })
+
+      const created = (blockResult.result as any)?.created || []
+      const errors = (blockResult.result as any)?.errors || []
+
+      return {
+        created: true,
+        page_id: pageId,
+        slug,
+        status: "Draft",
+        blocks_created: created.length,
+        blocks_failed: errors.length,
+        // Said explicitly so the model does not tell the partner it is live.
+        note: `Page created as a DRAFT at /${slug}. It is not visible to visitors until published from the Pages editor.`,
+        ...(errors.length ? { block_errors: errors } : {}),
+      }
+    },
+  }),
+
+  add_page_blocks: tool({
+    description:
+      "Append content blocks to an existing page. If the page is already published these edits are immediately public — ask the partner first, then pass confirm_live_edit.",
+    inputSchema: z.object({
+      page_id: z.string().min(1).describe("Page id from list_pages"),
+      blocks: z.array(blockSchema).min(1).max(12),
+      confirm_live_edit: z
+        .boolean()
+        .default(false)
+        .describe(
+          "Set true ONLY after the partner has agreed in conversation to edit a page that is already published."
+        ),
+    }),
+    execute: async (input) => {
+      const { result: pagesResult } = await listPageWorkflow(scope).run({
+        input: {
+          website_id: websiteId,
+          filters: {},
+          config: { skip: 0, take: 100 },
+        },
+      })
+      const [pages] = pagesResult as [any[], number]
+      const page = (pages || []).find((p: any) => p.id === input.page_id)
+
+      // Ownership: the list is scoped to this partner's website, so a page id
+      // that is not in it belongs to someone else's site or does not exist.
+      // Both answer the same way — never confirm another tenant's page id.
+      if (!page) {
+        return {
+          added: false,
+          error: `No page with id "${input.page_id}" on this website. Call list_pages for the ids.`,
+        }
+      }
+
+      if (page.status === "Published" && !input.confirm_live_edit) {
+        return {
+          added: false,
+          requires_confirmation: true,
+          error: `"${page.title}" is published — appending blocks changes the live site immediately. Ask the partner whether to proceed, then call again with confirm_live_edit: true.`,
+        }
+      }
+
+      const { result: existingBlocks } = await listBlocksWorkflow(scope).run({
+        input: { page_id: input.page_id },
+      })
+      const startOrder = ((existingBlocks as any)?.blocks || []).length
+
+      const blockResult = await createBatchBlocksWorkflow(scope).run({
+        input: {
+          blocks: input.blocks.map((b, i) => ({
+            page_id: input.page_id,
+            name: b.name || b.type,
+            type: b.type,
+            content: b.content,
+            order: startOrder + i,
+            status: "Active",
+          })),
+        },
+      })
+
+      const created = (blockResult.result as any)?.created || []
+      const errors = (blockResult.result as any)?.errors || []
+
+      return {
+        added: created.length > 0,
+        page_id: input.page_id,
+        page_status: page.status,
+        blocks_added: created.length,
+        blocks_failed: errors.length,
+        note:
+          page.status === "Published"
+            ? "These blocks are live on the storefront now."
+            : "The page is still a draft — publish it from the Pages editor when ready.",
+        ...(errors.length ? { block_errors: errors } : {}),
+      }
+    },
+  }),
+})

--- a/apps/backend/src/api/partners/storefront/website/theme/chat/route.ts
+++ b/apps/backend/src/api/partners/storefront/website/theme/chat/route.ts
@@ -12,6 +12,7 @@
  *      - `update_theme` — propose a scoped theme patch (no persist).
  *      - `list_media` — list uploaded images from the media library
  *        so the LLM can suggest images by URL.
+ *      - page tools — create/extend website pages as drafts (page-tools.ts).
  *   5. `streamText(...)` and pipe the AI-SDK UI message stream straight
  *      into the Express response.
  *
@@ -25,6 +26,8 @@ import { resolveRoleTextModel, logAiUsage } from "../../../../../../mastra/servi
 import { foldSystemForProvider } from "../../../../../store/ai/chat/system-fold-lib"
 import { safeThemePatchSchema, SAFE_TOKEN_DESCRIPTION } from "../safe-patch-schema"
 import { S3_LISTING_MODULE } from "../../../../../../modules/custom-s3-provider"
+import { buildPageTools, PAGE_TOOL_DESCRIPTION } from "./page-tools"
+import { getPartnerWebsite } from "../../../helpers"
 import type { ThemeChatReq } from "./validators"
 
 const SYSTEM_PROMPT = `You are a theme design assistant inside a storefront theme editor. The user describes changes in natural language and you propose structured theme edits.
@@ -42,7 +45,9 @@ Rules:
 - Never invent token names or values outside the allowed enums.
 - After calling the tool, briefly explain what you changed in one short sentence.
 - If the user asks for something outside the allowed tokens, explain politely that it's not available in this version and suggest the closest alternative within the allowed set.
-- Keep responses concise — this is a tool, not a chatbot.`
+- Keep responses concise — this is a tool, not a chatbot.
+
+${PAGE_TOOL_DESCRIPTION}`
 
 export const POST = async (
   req: AuthenticatedMedusaRequest,
@@ -68,7 +73,22 @@ export const POST = async (
     // Module not registered — media listing will be unavailable
   }
 
+  // Page tools need the partner's website id; the theme tools do not, so a
+  // failure to resolve it degrades to a theme-only assistant rather than a
+  // 500. A partner with no website row can still restyle the preview.
+  let pageTools: Record<string, any> = {}
+  try {
+    const { website } = await getPartnerWebsite(req.auth_context, req.scope)
+    pageTools = buildPageTools({ scope: req.scope, websiteId: website.id })
+  } catch (e: any) {
+    logger?.warn?.(
+      `[theme-chat] page tools unavailable: ${e?.message || e}`
+    )
+  }
+
   const tools = {
+    ...pageTools,
+
     update_theme: tool({
       description:
         "Propose a theme edit. Pass only the tokens you want to change. The patch will be deep-merged with the existing theme — omitted sections are preserved. The user must click Apply to confirm.",

--- a/apps/backend/src/api/partners/storefront/website/theme/route.ts
+++ b/apps/backend/src/api/partners/storefront/website/theme/route.ts
@@ -75,8 +75,16 @@ export const PUT = async (
   // Theme touches the root layout (branding, footer, navigation,
   // colours, every home section). Path-scoped revalidation isn't
   // enough — flush the whole app's data cache via paths:['/'].
-  // Fire-and-forget; logged but never blocks the response.
-  triggerStorefrontRevalidate(website, { paths: ["/"] }).catch(() => {})
+  //
+  // Awaited, not fire-and-forget: this hop is exactly where partner edits go
+  // to die (a mismatched secret answers 401 forever, and the save still looked
+  // green), so the partner is told whether their change is actually live. The
+  // helper caps itself at 5s and never throws, so the worst case is a slower
+  // save — not a failed one. The theme is already written at this point;
+  // `revalidation` describes visibility, not persistence.
+  const revalidation = await triggerStorefrontRevalidate(website, {
+    paths: ["/"],
+  })
 
-  res.json({ theme: merged })
+  res.json({ theme: merged, revalidation })
 }

--- a/apps/partner-ui/src/hooks/api/content.ts
+++ b/apps/partner-ui/src/hooks/api/content.ts
@@ -384,10 +384,23 @@ export const useWebsiteTheme = (
   return { theme: data?.theme || {}, ...rest }
 }
 
+/**
+ * What the backend reports about pushing the saved theme to the LIVE site.
+ * Persistence and visibility are different things: the theme is written before
+ * this is computed, so `ok: false` means "saved, not yet visible" — never
+ * "lost". See triggerStorefrontRevalidate in the backend.
+ */
+export type ThemeRevalidation = {
+  attempted: boolean
+  ok: boolean
+  status?: number
+  reason?: "no_backend_secret" | "no_domain" | "rejected" | "unreachable" | "ok"
+}
+
 export const useUpdateWebsiteTheme = () => {
   return useMutation({
     mutationFn: (payload: WebsiteTheme) =>
-      sdk.client.fetch<{ theme: WebsiteTheme }>(
+      sdk.client.fetch<{ theme: WebsiteTheme; revalidation?: ThemeRevalidation }>(
         "/partners/storefront/website/theme",
         { method: "PUT", body: payload }
       ),

--- a/apps/partner-ui/src/routes/settings/theme/theme.tsx
+++ b/apps/partner-ui/src/routes/settings/theme/theme.tsx
@@ -381,8 +381,30 @@ const ThemeEditorInner = () => {
   const handleSave = async () => {
     if (debounceRef.current) clearTimeout(debounceRef.current)
     try {
-      await updateThemeRef.current(formRef.current)
-      toast.success("Theme saved")
+      const res: any = await updateThemeRef.current(formRef.current)
+
+      // The save and the live site are two different outcomes. A theme can be
+      // stored perfectly while the storefront keeps serving its cached copy —
+      // that is what happened when the revalidate secret was misnamed, and the
+      // only signal was a green "Theme saved" toast. Say which one happened.
+      const revalidation = res?.revalidation
+      if (revalidation && !revalidation.ok) {
+        const why =
+          revalidation.reason === "rejected" && revalidation.status === 401
+            ? "the storefront rejected the refresh (secret mismatch)"
+            : revalidation.reason === "rejected" && revalidation.status === 503
+              ? "the storefront has no revalidate secret set"
+              : revalidation.reason === "unreachable"
+                ? "the storefront could not be reached"
+                : revalidation.reason === "no_backend_secret"
+                  ? "this environment has no storefront revalidate secret"
+                  : "the live site could not be refreshed"
+        toast.warning("Saved — but your live site may lag", {
+          description: `${why}. Your changes are stored and will appear within a few minutes.`,
+        })
+      } else {
+        toast.success("Theme saved")
+      }
     } catch (e: any) {
       toast.error("Could not save theme", {
         description: e?.message || "Something went wrong",
@@ -1153,6 +1175,45 @@ function HeroPanel({
           />
         </div>
 
+        {/*
+          Hero height. Presets cover the cases partners actually ask for — a
+          full-bleed photo, a shorter band, a compact text hero — while the
+          text field keeps any CSS length reachable. The setting existed in the
+          API for a while with nothing rendering it and no control here, so
+          every hero was 75vh whatever the content was.
+        */}
+        <div className="space-y-1">
+          <Label size="xsmall">Height</Label>
+          <div className="flex flex-wrap gap-1">
+            {[
+              ["Full", "100vh"],
+              ["Tall", "75vh"],
+              ["Medium", "60vh"],
+              ["Short", "45vh"],
+            ].map(([label, value]) => (
+              <button
+                key={value}
+                type="button"
+                className={`rounded border px-2 py-1 text-xs ${
+                  (form.hero?.min_height || "75vh") === value
+                    ? "border-ui-fg-base bg-ui-bg-base-pressed"
+                    : "border-ui-border-base"
+                }`}
+                onClick={() =>
+                  updateForm("hero", { ...form.hero, min_height: value })
+                }
+              >
+                {label}
+              </button>
+            ))}
+          </div>
+          <FieldInput
+            label="Custom height (any CSS length)"
+            value={form.hero?.min_height || ""}
+            onChange={(v) => updateForm("hero", { ...form.hero, min_height: v })}
+          />
+        </div>
+
         <div className="grid grid-cols-2 gap-2">
           <FieldInput
             label="CTA Text"
@@ -1808,6 +1869,39 @@ function TrustBannerEditor({ hs, writeSection }: SubEditorWithWriteProps) {
           />
         </div>
       </div>
+      {/*
+        Text colour is optional: leave it blank and the renderer flips the text
+        light or dark from the background's luminance. That auto-flip is right
+        most of the time and wrong on mid-tone backgrounds, which is why the
+        schema and the renderer both support an override — there was simply no
+        control for it here, so the automatic choice was the only choice.
+      */}
+      <div className="space-y-1">
+        <Label size="xsmall">Text Color (optional)</Label>
+        <div className="flex items-center gap-2">
+          <input
+            type="color"
+            className="h-7 w-7 cursor-pointer rounded border border-ui-border-base shrink-0"
+            value={tb.text_color || "#ffffff"}
+            onChange={(e) => writeTrustBanner({ text_color: e.target.value })}
+          />
+          <Input
+            size="small"
+            placeholder="auto from background"
+            value={tb.text_color || ""}
+            onChange={(e) => writeTrustBanner({ text_color: e.target.value })}
+          />
+          {tb.text_color ? (
+            <button
+              type="button"
+              className="text-xs text-ui-fg-interactive hover:underline shrink-0"
+              onClick={() => writeTrustBanner({ text_color: undefined })}
+            >
+              Auto
+            </button>
+          ) : null}
+        </div>
+      </div>
       <div className="flex items-center justify-between pt-1">
         <Label size="xsmall">Items</Label>
         <button
@@ -2044,6 +2138,33 @@ function BannerEditor({ hs, updateForm }: SubEditorProps) {
             value={b.background_color || ""}
             onChange={(e) => write({ background_color: e.target.value })}
           />
+        </div>
+      </div>
+      {/* Optional override; blank keeps the renderer's luminance auto-flip. */}
+      <div className="space-y-1">
+        <Label size="xsmall">Text Color (optional)</Label>
+        <div className="flex items-center gap-2">
+          <input
+            type="color"
+            className="h-7 w-7 cursor-pointer rounded border border-ui-border-base shrink-0"
+            value={b.text_color || "#ffffff"}
+            onChange={(e) => write({ text_color: e.target.value })}
+          />
+          <Input
+            size="small"
+            placeholder="auto from background"
+            value={b.text_color || ""}
+            onChange={(e) => write({ text_color: e.target.value })}
+          />
+          {b.text_color ? (
+            <button
+              type="button"
+              className="text-xs text-ui-fg-interactive hover:underline shrink-0"
+              onClick={() => write({ text_color: undefined })}
+            >
+              Auto
+            </button>
+          ) : null}
         </div>
       </div>
       <FieldInput

--- a/e2e/specs/storefront-home-metadata.spec.ts
+++ b/e2e/specs/storefront-home-metadata.spec.ts
@@ -1,0 +1,148 @@
+import { test, expect } from "@playwright/test"
+
+/**
+ * Homepage metadata on a LIVE partner storefront.
+ *
+ * The root layout already resolves the tenant's store name, tagline and
+ * favicon from the theme, but the homepage's own `generateMetadata` overrode
+ * that with `NEXT_PUBLIC_STORE_NAME || "Store"` and a hardcoded blurb. So a
+ * storefront whose theme said "Unique Pashmina" served:
+ *
+ *     <title>Store | Unique Pashmina</title>
+ *     <meta name="description" content="Shop handmade, locally sourced, …">
+ *     <meta property="og:title" content="Store">
+ *
+ * Every partner site shared the starter's boilerplate to social, and ranked on
+ * a page titled "Store". The bug was invisible from the theme editor — saving
+ * worked, the values were stored, nothing rendered them.
+ *
+ * The assertions compare the page against THAT TENANT'S theme fetched from the
+ * backend, never against literal strings. A test hardcoding "Unique Pashmina"
+ * would pass for one partner and lie for the rest, and would have to be edited
+ * every time a partner rewrites their copy — the point is that the page shows
+ * whatever the partner set.
+ *
+ * @storefront — hits a live external site, so it is excluded from the CI admin
+ * e2e run (see playwright.config.ts). Run it locally, or point it elsewhere:
+ *
+ *   STOREFRONT_HOME_URL=https://…/in \
+ *   STOREFRONT_BACKEND_URL=https://v3.jaalyantra.com \
+ *     pnpm exec playwright test -c e2e/playwright.storefront.config.ts
+ */
+
+const HOME_URL =
+  process.env.STOREFRONT_HOME_URL ?? "https://www.uniquepashmina.com/au"
+
+const BACKEND_URL =
+  process.env.STOREFRONT_BACKEND_URL ?? "https://v3.jaalyantra.com"
+
+type Theme = {
+  branding?: { store_name?: string; tagline?: string; favicon_url?: string }
+  hero?: { title?: string; description?: string; background_image_url?: string }
+}
+
+/** The domain the backend keys the website row by — the host, minus `www.`. */
+const domainOf = (url: string) => new URL(url).host.replace(/^www\./, "")
+
+test.describe("Storefront homepage metadata @storefront", () => {
+  let theme: Theme
+
+  test.beforeAll(async ({ request }) => {
+    const res = await request.get(
+      `${BACKEND_URL}/web/website/${domainOf(HOME_URL)}`
+    )
+    expect(
+      res.ok(),
+      `backend did not serve a website row for ${domainOf(HOME_URL)} — ` +
+        `without it there is nothing to compare the page against`
+    ).toBeTruthy()
+    const body = await res.json()
+    theme = (body.website ?? body).theme ?? {}
+  })
+
+  test.beforeEach(async ({ page }) => {
+    await page.goto(HOME_URL, { waitUntil: "domcontentloaded" })
+  })
+
+  test("the title carries the partner's store name, not the starter default", async ({
+    page,
+  }) => {
+    const storeName = theme.branding?.store_name
+    test.skip(!storeName, "tenant has not set branding.store_name")
+
+    const title = await page.title()
+
+    expect(
+      title,
+      `<title> is "${title}" — the homepage should be titled with the store ` +
+        `name from the theme ("${storeName}")`
+    ).toContain(storeName!)
+
+    // "Store" is the env fallback. Seeing it next to a real store name means
+    // the page-level metadata ignored the theme and the layout template then
+    // appended the brand — the exact "Store | Unique Pashmina" shape.
+    expect(
+      title,
+      `<title> is "${title}" — a leading "Store" means generateMetadata fell ` +
+        `back to NEXT_PUBLIC_STORE_NAME instead of reading the theme`
+    ).not.toMatch(/^Store\b/)
+  })
+
+  test("the description is the partner's copy, not the starter's boilerplate", async ({
+    page,
+  }) => {
+    const expected = theme.hero?.description || theme.branding?.tagline
+    test.skip(!expected, "tenant has set neither hero.description nor tagline")
+
+    const description = await page
+      .locator('meta[name="description"]')
+      .getAttribute("content")
+
+    expect(
+      description,
+      `meta description is "${description}" — it should be the partner's own ` +
+        `copy from the theme`
+    ).toBe(expected)
+  })
+
+  test("open graph shares the partner's brand and hero image", async ({
+    page,
+  }) => {
+    const ogTitle = await page
+      .locator('meta[property="og:title"]')
+      .getAttribute("content")
+
+    expect(
+      ogTitle,
+      `og:title is "${ogTitle}" — social cards were sharing the literal word ` +
+        `"Store" for every partner storefront`
+    ).not.toBe("Store")
+
+    const heroImage = theme.hero?.background_image_url
+    if (heroImage) {
+      const ogImage = await page
+        .locator('meta[property="og:image"]')
+        .getAttribute("content")
+      expect(
+        ogImage,
+        `og:image is "${ogImage}" — when the partner has chosen a hero image ` +
+          `that is what a shared link should preview`
+      ).toBe(heroImage)
+    }
+  })
+
+  test("a favicon is served when the tenant has set one", async ({ page }) => {
+    const faviconUrl = theme.branding?.favicon_url
+    test.skip(
+      !faviconUrl,
+      "tenant has not set branding.favicon_url — nothing to render"
+    )
+
+    const icon = page.locator('link[rel="icon"]')
+    await expect(
+      icon,
+      `no <link rel="icon"> in <head> though the theme sets favicon_url`
+    ).toHaveCount(1)
+    await expect(icon).toHaveAttribute("href", faviconUrl!)
+  })
+})


### PR DESCRIPTION
Pairs with Jaal-Yantra-Textiles/nextjs-starter-medusa#7 (the storefront half).

⚠️ **Merge order matters.** The drift test asserts that every theme setting is known to the storefront that renders it. `hero.min_height` is added to the storefront type in starter#7, so **that must merge first and the submodule pointer be bumped here** — until then the drift test fails in CI. That failure is the guard working, not a flake.

## 1. Revalidation failed silently

`triggerStorefrontRevalidate` returned `void` and warned to the backend's own console. A storefront answering **401** (secret mismatch) or **503** (secret unset there) produced a perfectly green `Theme saved` and a live site that never changed — for the life of the deployment, because the storefront's cache entry had no expiry either. This is the mechanism behind "theme edits have never reached live storefronts".

Now it returns a typed outcome distinguishing `no_backend_secret` / `no_domain` / `rejected` (with status) / `unreachable`, the theme PUT awaits it and returns it, and the editor shows **"Saved — but your live site may lag"** with the specific reason instead of a success toast.

The call is now awaited rather than fire-and-forget. The helper caps itself at 5s and never throws, so the worst case is a slower save — not a failed one. The theme is already written before this runs: `revalidation` describes **visibility**, not persistence, and the UI says so.

## 2. Theme drift had no guard

The 87-key theme vocabulary is written down three times — Zod schema, storefront type + renderer, editor form — across three apps with three tsconfigs (the backend's excludes `apps/*` outright), so no compiler sees all three. Nothing tied them together, and two keys had already drifted:

- `min_height` — in the schema, read by nobody, no control
- `text_color` — in the schema and the renderer, no control

Both fixed here rather than exempted: hero height gets presets plus a custom CSS-length field, and the trust banner and banner get optional text colour with an "Auto" reset (blank keeps the renderer's luminance auto-flip).

The test is a text scan, deliberately: a grep that fails CI beats a type relationship that cannot be expressed. It is a **stopgap** — the destination is generating the editor and the storefront type from the schema so drift is impossible rather than merely detected.

## 3. The assistant can now build pages

The page and block APIs already existed; nothing had connected them to the assistant partners actually talk to. A partner wanting an About page, size guide or care instructions had to leave the chat and write every block by hand.

Adds `list_pages`, `create_page` (page + its blocks in one call) and `add_page_blocks`.

Safety properties, each asserted by tests rather than documented:

| Property | How it's enforced |
|---|---|
| Pages are always drafts | `status` is not an accepted input at all — a test asserts it never becomes one |
| No silent edits to live pages | a published page refuses `add_page_blocks` without explicit `confirm_live_edit` |
| No cross-tenant writes | the page list is website-scoped; another tenant's id is refused indistinguishably from a nonexistent one |
| No duplicate slugs | refused, with a pointer to the existing page |
| No publishing or deleting | those tools do not exist |

Block types are a closed enum (`Hero`, `Main`) because the renderer falls through to a JSON dump for anything else — an invented block type would render as a wall of JSON on the partner's page.

## Verification

- 53 unit tests pass (9 of them on the page tools' safety properties).
- `check:prod-build` green.
- `e2e/specs/storefront-home-metadata.spec.ts` compares a live storefront against its own theme from the backend. It **fails today** against `uniquepashmina.com`, which is what proves it detects the bug; it should pass once starter#7 is deployed.
- Everything behavioural here is deploy-gated and **unverified**: the editor toast has not been driven through the UI, and the page tools have never been run through the chat with a live model. Given #1319's history, treat as unverified until probed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
