### PR TITLE
fix(flows): prevent duplicate cart-abandoned sends with distributed locks

### DIFF
--- a/apps/backend/src/jobs/run-scheduled-visual-flows.ts
+++ b/apps/backend/src/jobs/run-scheduled-visual-flows.ts
@@ -1,5 +1,5 @@
 import { MedusaContainer } from "@medusajs/framework/types"
-import { ContainerRegistrationKeys } from "@medusajs/framework/utils"
+import { ContainerRegistrationKeys, Modules } from "@medusajs/framework/utils"
 import { VISUAL_FLOWS_MODULE } from "../modules/visual_flows"
 import VisualFlowService from "../modules/visual_flows/service"
 import { executeVisualFlowWorkflow } from "../workflows/visual-flows"
@@ -140,6 +140,7 @@ async function patchScheduleMeta(
 export default async function runScheduledVisualFlows(container: MedusaContainer) {
   const logger = container.resolve(ContainerRegistrationKeys.LOGGER)
   const service: VisualFlowService = container.resolve(VISUAL_FLOWS_MODULE)
+  const locking = container.resolve(Modules.LOCKING) as any
 
   const now = new Date()
   const nowKey = minuteKey(now)
@@ -159,76 +160,115 @@ export default async function runScheduledVisualFlows(container: MedusaContainer
       continue
     }
 
+    // Cheap pre-filter: skip if the minute marker is already set. This avoids
+    // a lock acquire for flows that were claimed by a prior tick or a faster
+    // scanner. The authoritative guard is the lock below.
     const lastRunKey = flow?.metadata?.schedule?.last_run_minute_key
     if (lastRunKey === nowKey) {
       continue
     }
 
-    // Enqueue marker — written BEFORE the flow is fired so the every-minute
-    // scanner never double-enqueues a flow, even when the run is long-lived
-    // (durable waits) or a slow tick overlaps the next one. Dedup is keyed on
-    // this `last_run_minute_key`, so it must land synchronously.
-    try {
-      await patchScheduleMeta(service, flow.id, {
-        last_run_minute_key: nowKey,
-        last_run_at: now.toISOString(),
-        last_enqueued_at: now.toISOString(),
-        last_status: "enqueued",
-        last_error: null,
-      })
-    } catch (e: any) {
-      logger.error(
-        `[run-scheduled-visual-flows] flow=${flow.id} failed to mark enqueue: ${e?.message}`
-      )
-      continue
-    }
+    // ── Distributed lock per flow + minute (#1334) ──────────────────────────
+    //
+    // Two worker tasks briefly coexist during a rolling ECS deploy or a
+    // Fargate Spot replacement. The check-then-set on `last_run_minute_key`
+    // is a TOCTOU race — both scanners read a stale key before either writes,
+    // and both fire the workflow. The lock serializes the claim: only one
+    // scanner holds `scheduled-flow:{flowId}:{minuteKey}` at a time.
+    //
+    // `execute` with a 1-second timeout: if another scanner already holds
+    // the lock, this one gives up immediately instead of blocking the
+    // every-minute scanner. Inside the lock we re-check the minute key
+    // (double-check pattern) because the flow list was read at the top of
+    // the tick and the marker may have been written by the time we enter.
+    const lockKey = `scheduled-flow:${flow.id}:${nowKey}`
 
-    // Fire-and-forget: the durable workflow runs in the worker. We deliberately
-    // do NOT await it — one slow or long-running flow must not block the
-    // scanner or the other due flows in this tick (mirrors the webhook async
-    // path). Final status is recorded from the resolved/rejected callbacks.
-    void executeVisualFlowWorkflow(container)
-      .run({
-        input: {
-          flowId: flow.id,
-          triggerData: {
-            schedule: {
-              cron,
-              run_at: now.toISOString(),
-              minute_key: nowKey,
-            },
-          },
-          triggeredBy: "schedule",
-          metadata: {
-            schedule: {
-              cron,
-              run_at: now.toISOString(),
-              minute_key: nowKey,
-            },
-          },
+    try {
+      await locking.execute(
+        lockKey,
+        async () => {
+          // Re-check inside the lock — another scanner may have claimed this
+          // minute while we were acquiring.
+          const fresh = await service.retrieveVisualFlow(flow.id)
+          if ((fresh as any)?.metadata?.schedule?.last_run_minute_key === nowKey) {
+            return
+          }
+
+          // Enqueue marker — written BEFORE the flow is fired so the every-minute
+          // scanner never double-enqueues a flow, even when the run is long-lived
+          // (durable waits) or a slow tick overlaps the next one. Dedup is keyed on
+          // this `last_run_minute_key`, so it must land synchronously.
+          try {
+            await patchScheduleMeta(service, flow.id, {
+              last_run_minute_key: nowKey,
+              last_run_at: now.toISOString(),
+              last_enqueued_at: now.toISOString(),
+              last_status: "enqueued",
+              last_error: null,
+            })
+          } catch (e: any) {
+            logger.error(
+              `[run-scheduled-visual-flows] flow=${flow.id} failed to mark enqueue: ${e?.message}`
+            )
+            return
+          }
+
+          // Fire-and-forget: the durable workflow runs in the worker. We deliberately
+          // do NOT await it — one slow or long-running flow must not block the
+          // scanner or the other due flows in this tick (mirrors the webhook async
+          // path). Final status is recorded from the resolved/rejected callbacks.
+          void executeVisualFlowWorkflow(container)
+            .run({
+              input: {
+                flowId: flow.id,
+                triggerData: {
+                  schedule: {
+                    cron,
+                    run_at: now.toISOString(),
+                    minute_key: nowKey,
+                  },
+                },
+                triggeredBy: "schedule",
+                metadata: {
+                  schedule: {
+                    cron,
+                    run_at: now.toISOString(),
+                    minute_key: nowKey,
+                  },
+                },
+              },
+            })
+            .then(({ result, errors }) => {
+              if (errors?.length) {
+                return patchScheduleMeta(service, flow.id, {
+                  last_status: "failed",
+                  last_error: "Workflow execution returned errors",
+                })
+              }
+              return patchScheduleMeta(service, flow.id, {
+                last_execution_id: result?.executionId,
+                last_status: "completed",
+              })
+            })
+            .catch((e: any) => {
+              logger.error(`[run-scheduled-visual-flows] flow=${flow.id} error=${e?.message}`)
+              return patchScheduleMeta(service, flow.id, {
+                last_status: "failed",
+                last_error: e?.message,
+              }).catch(() => {
+                /* best-effort status write */
+              })
+            })
         },
-      })
-      .then(({ result, errors }) => {
-        if (errors?.length) {
-          return patchScheduleMeta(service, flow.id, {
-            last_status: "failed",
-            last_error: "Workflow execution returned errors",
-          })
-        }
-        return patchScheduleMeta(service, flow.id, {
-          last_execution_id: result?.executionId,
-          last_status: "completed",
-        })
-      })
-      .catch((e: any) => {
-        logger.error(`[run-scheduled-visual-flows] flow=${flow.id} error=${e?.message}`)
-        return patchScheduleMeta(service, flow.id, {
-          last_status: "failed",
-          last_error: e?.message,
-        }).catch(() => {
-          /* best-effort status write */
-        })
-      })
+        { timeout: 1 }
+      )
+    } catch (e: any) {
+      // Lock contention (another scanner holds it) or Redis hiccup — skip
+      // this flow this tick. The next tick retries.
+      logger.warn(
+        `[run-scheduled-visual-flows] flow=${flow.id} skipped (lock: ${e?.message})`
+      )
+    }
   }
 }
 

--- a/apps/backend/src/jobs/run-scheduled-visual-flows.ts
+++ b/apps/backend/src/jobs/run-scheduled-visual-flows.ts
@@ -4,6 +4,17 @@ import { VISUAL_FLOWS_MODULE } from "../modules/visual_flows"
 import VisualFlowService from "../modules/visual_flows/service"
 import { executeVisualFlowWorkflow } from "../workflows/visual-flows"
 
+/**
+ * TTL (seconds) on a scanner's per-flow+minute claim.
+ *
+ * A crash-safety net, not a hold time: the claim is released in a `finally`
+ * as soon as the enqueue marker is written. It only has to outlast the three DB
+ * round-trips inside the claim under prod load — comfortably, since a claim
+ * that expires early lets a second scanner in and re-opens the race the claim
+ * exists to close.
+ */
+const SCHEDULE_LOCK_TTL_SECONDS = 120
+
 function parseCronParts(cron: string): string[] | null {
   const parts = cron.trim().split(/\s+/)
   if (parts.length !== 5) {
@@ -176,17 +187,36 @@ export default async function runScheduledVisualFlows(container: MedusaContainer
     // and both fire the workflow. The lock serializes the claim: only one
     // scanner holds `scheduled-flow:{flowId}:{minuteKey}` at a time.
     //
-    // `execute` with a 1-second timeout: if another scanner already holds
-    // the lock, this one gives up immediately instead of blocking the
-    // every-minute scanner. Inside the lock we re-check the minute key
-    // (double-check pattern) because the flow list was read at the top of
-    // the tick and the marker may have been written by the time we enter.
+    // `acquire` is NON-BLOCKING: if another scanner already holds the key it
+    // throws at once and this scanner moves on, rather than blocking the
+    // every-minute tick. Inside the claim we re-check the minute key
+    // (double-check pattern) because the flow list was read at the top of the
+    // tick and the marker may have been written by the time we enter.
+    //
+    // Deliberately NOT `locking.execute(..., { timeout: 1 })`, which reads like
+    // "give up after a second" and is neither: the Redis provider maps
+    // `timeout` to the key's TTL (`expire: args?.timeout ? timeoutSeconds : 60`)
+    // and passes `awaitQueue: true`. That set a ONE-SECOND expiry over a body
+    // doing three DB round-trips — so under load the key expired while the
+    // first scanner was still inside it — and made the second scanner retry for
+    // that whole second rather than skip. Both scanners could then fire.
     const lockKey = `scheduled-flow:${flow.id}:${nowKey}`
 
     try {
-      await locking.execute(
-        lockKey,
-        async () => {
+      // TTL is a crash-safety net only: the claim is released in `finally`
+      // below. It has to comfortably exceed the enclosed DB writes, not the
+      // fire-and-forget workflow, which is deliberately not awaited.
+      await locking.acquire(lockKey, { expire: SCHEDULE_LOCK_TTL_SECONDS })
+    } catch (e: any) {
+      // Another scanner holds this flow+minute. The next tick retries.
+      logger.warn(
+        `[run-scheduled-visual-flows] flow=${flow.id} skipped (claim held: ${e?.message})`
+      )
+      continue
+    }
+
+    try {
+      await (async () => {
           // Re-check inside the lock — another scanner may have claimed this
           // minute while we were acquiring.
           const fresh = await service.retrieveVisualFlow(flow.id)
@@ -259,15 +289,15 @@ export default async function runScheduledVisualFlows(container: MedusaContainer
                 /* best-effort status write */
               })
             })
-        },
-        { timeout: 1 }
-      )
+      })()
     } catch (e: any) {
-      // Lock contention (another scanner holds it) or Redis hiccup — skip
-      // this flow this tick. The next tick retries.
-      logger.warn(
-        `[run-scheduled-visual-flows] flow=${flow.id} skipped (lock: ${e?.message})`
+      logger.error(
+        `[run-scheduled-visual-flows] flow=${flow.id} failed inside claim: ${e?.message}`
       )
+    } finally {
+      await locking.release(lockKey).catch(() => {
+        // Best-effort — the TTL clears it if this fails.
+      })
     }
   }
 }

--- a/apps/backend/src/modules/visual_flows/operations/__tests__/bulk-trigger-workflow.unit.spec.ts
+++ b/apps/backend/src/modules/visual_flows/operations/__tests__/bulk-trigger-workflow.unit.spec.ts
@@ -154,7 +154,7 @@ describe("bulk_trigger_workflow — idempotency_key_template (#1334)", () => {
     expect(result.data.results[0].error).toBe("idempotency-skip")
   })
 
-  it("acquires and releases the lock for each non-skipped item", async () => {
+  it("claims a key per item and HOLDS it after a successful trigger", async () => {
     const { engine } = makeWorkflowEngine()
     const { locking, acquired, released } = makeLocking()
     const ctx = makeContext(
@@ -180,10 +180,15 @@ describe("bulk_trigger_workflow — idempotency_key_template (#1334)", () => {
 
     expect(acquired.has("cart-abandoned:cart_a")).toBe(true)
     expect(acquired.has("cart-abandoned:cart_b")).toBe(true)
-    expect(released.has("cart-abandoned:cart_a")).toBe(true)
-    expect(released.has("cart-abandoned:cart_b")).toBe(true)
     expect(locking.acquire).toHaveBeenCalledTimes(2)
-    expect(locking.release).toHaveBeenCalledTimes(2)
+
+    // The key is the dedup WINDOW, not a mutex hold. This assertion used to
+    // read `release` twice — which is what let a later execution re-send a cart
+    // the moment the first one had finished with it. Releasing on success is
+    // the defect, not the contract.
+    expect(released.has("cart-abandoned:cart_a")).toBe(false)
+    expect(released.has("cart-abandoned:cart_b")).toBe(false)
+    expect(locking.release).not.toHaveBeenCalled()
   })
 
   it("releases the lock even when the workflow trigger throws", async () => {
@@ -231,5 +236,139 @@ describe("bulk_trigger_workflow — idempotency_key_template (#1334)", () => {
     )
 
     expect(result.data.skipped).toBe(0)
+  })
+})
+
+/**
+ * The failure mode the option exists to prevent, as it actually occurs (#1334).
+ *
+ * The tests above hand each execution a FRESH locking fake, which models two
+ * scanners that overlap on the same instant. Production is not like that: the
+ * two executions share one Redis, and they walk the same `send_items` list
+ * SERIALLY. Whether the key still exists when the second execution reaches an
+ * item is the whole question — so these tests share one locking service across
+ * two sequential runs, which is the only arrangement that can answer it.
+ */
+describe("bulk_trigger_workflow — idempotency across sequential executions (#1334)", () => {
+  const OPTIONS = {
+    workflow_name: "send-notification-email",
+    items: "{{ classify.send_items }}",
+    input_template: {
+      to: "{{ item.to }}",
+      template: "{{ item.template }}",
+      data: "{{ item.data }}",
+    },
+    idempotency_key_template: "cart-abandoned:{{ item.cart_id }}",
+    continue_on_error: true,
+    max_items: 100,
+  }
+
+  it("does not re-send a cart a previous execution already sent", async () => {
+    // One Redis, two executions — exactly the rolling-deploy scenario. The
+    // second scanner reads the same carts (its `classify` ran before the
+    // first's `mark_sent` landed) and must send nothing.
+    const { engine } = makeWorkflowEngine()
+    const { locking } = makeLocking()
+    const container = makeContainer(engine, locking)
+
+    const first = await bulkTriggerWorkflowOperation.execute(
+      OPTIONS,
+      makeContext({ classify: { send_items: SEND_ITEMS } }, container)
+    )
+    const second = await bulkTriggerWorkflowOperation.execute(
+      OPTIONS,
+      makeContext({ classify: { send_items: SEND_ITEMS } }, container)
+    )
+
+    expect(first.data.triggered).toBe(2)
+    expect(second.data.triggered).toBe(0)
+    expect(second.data.skipped).toBe(2)
+    // Two carts, two emails. Anything more is the duplicate this option exists
+    // to stop.
+    expect(engine.run).toHaveBeenCalledTimes(2)
+  })
+
+  it("lets a cart whose send FAILED be retried by the next execution", async () => {
+    // The mirror image: an idempotency key must not permanently blacklist a
+    // cart whose mail never went out. Release on failure, hold on success.
+    const runs: any[] = []
+    const flakyEngine = {
+      run: jest.fn(async (_name: string, opts: any) => {
+        runs.push(opts)
+        if (runs.length === 1) throw new Error("SMTP down")
+        return { result: { id: "wf-ok" }, errors: null }
+      }),
+    }
+    const { locking } = makeLocking()
+    const container = makeContainer(flakyEngine, locking)
+    const items = { classify: { send_items: [SEND_ITEMS[0]] } }
+
+    const first = await bulkTriggerWorkflowOperation.execute(
+      OPTIONS,
+      makeContext(items, container)
+    )
+    const second = await bulkTriggerWorkflowOperation.execute(
+      OPTIONS,
+      makeContext(items, container)
+    )
+
+    expect(first.data.failed).toBe(1)
+    expect(second.data.triggered).toBe(1)
+    expect(second.data.skipped).toBe(0)
+  })
+
+  it("fails an item loudly when the locking backend is unreachable", async () => {
+    // A Redis outage throws from `acquire` just like contention does. Reading
+    // one as the other turns a total send outage into `success: true` with
+    // every cart reported as an idempotency skip — and, because `mark_sent`
+    // marks on classification, those carts are recorded as reminded anyway.
+    const { engine } = makeWorkflowEngine()
+    const brokenLocking = {
+      acquire: jest.fn(async () => {
+        throw new Error("connect ECONNREFUSED 10.0.0.4:6379")
+      }),
+      release: jest.fn(async () => {}),
+    }
+    const ctx = makeContext(
+      { classify: { send_items: SEND_ITEMS } },
+      makeContainer(engine, brokenLocking)
+    )
+
+    const result = await bulkTriggerWorkflowOperation.execute(OPTIONS, ctx)
+
+    // Reported as failures, NOT as tidy idempotency skips. (`success` still
+    // follows `continue_on_error`, which is the operation-wide contract and not
+    // this option's to redefine — but `failed: 2` with an explicit message is
+    // now visible in the execution log, where `skipped: 2` looked like healthy
+    // dedup.)
+    expect(result.data.skipped).toBe(0)
+    expect(result.data.failed).toBe(2)
+    expect(result.data.results[0].error).toMatch(/Locking backend unavailable/)
+    expect(engine.run).not.toHaveBeenCalled()
+  })
+
+  it("does not count skipped items as failures when continue_on_error is false", async () => {
+    // The two return paths compute `failed` differently: the early return
+    // counts every not-ok result, which includes skips.
+    const failOnSecond = {
+      run: jest.fn(async (_name: string, opts: any) => {
+        if (opts.input.to === "b@test.com") throw new Error("SMTP down")
+        return { result: { id: "wf-1" }, errors: null }
+      }),
+    }
+    const { locking } = makeLocking(new Set(["cart-abandoned:cart_a"]))
+    const ctx = makeContext(
+      { classify: { send_items: SEND_ITEMS } },
+      makeContainer(failOnSecond, locking)
+    )
+
+    const result = await bulkTriggerWorkflowOperation.execute(
+      { ...OPTIONS, continue_on_error: false },
+      ctx
+    )
+
+    expect(result.success).toBe(false)
+    expect(result.data.skipped).toBe(1) // cart_a — lock held elsewhere
+    expect(result.data.failed).toBe(1)  // cart_b — the actual failure
   })
 })

--- a/apps/backend/src/modules/visual_flows/operations/__tests__/bulk-trigger-workflow.unit.spec.ts
+++ b/apps/backend/src/modules/visual_flows/operations/__tests__/bulk-trigger-workflow.unit.spec.ts
@@ -1,0 +1,235 @@
+/**
+ * Unit tests for the visual-flows `bulk_trigger_workflow` operation —
+ * specifically the `idempotency_key_template` per-item lock (#1334).
+ *
+ * The regression this guards: two concurrent flow executions (e.g. during a
+ * rolling ECS deploy) both read the same abandoned carts, both build
+ * `send_items`, and both trigger `send-notification-email` for the same cart.
+ * The `idempotency_key_template` option wraps each item's trigger in a
+ * distributed lock (Modules.LOCKING). `acquire` is non-blocking — it throws
+ * immediately when the lock is already held — so the second execution skips
+ * the item instead of producing a duplicate send.
+ *
+ * The operation only reads `context.container` + `context.dataChain`, so we
+ * can invoke it directly without booting Medusa.
+ */
+
+import { bulkTriggerWorkflowOperation } from "../bulk-trigger-workflow"
+
+/** A minimal fake locking service that records calls and can be pre-locked. */
+function makeLocking(preLockedKeys: Set<string> = new Set()) {
+  const held = new Set<string>()       // currently held
+  const everAcquired = new Set<string>() // all keys ever acquired (for assertions)
+  const released = new Set<string>()
+  return {
+    acquired: everAcquired,
+    released,
+    locking: {
+      acquire: jest.fn(async (key: string) => {
+        if (preLockedKeys.has(key) || held.has(key)) {
+          throw new Error("Failed to acquire lock")
+        }
+        held.add(key)
+        everAcquired.add(key)
+      }),
+      release: jest.fn(async (key: string) => {
+        held.delete(key)
+        released.add(key)
+      }),
+    },
+  }
+}
+
+/** A minimal fake workflow engine that records runs. */
+function makeWorkflowEngine() {
+  const runs: any[] = []
+  return {
+    runs,
+    engine: {
+      run: jest.fn(async (_name: string, opts: any) => {
+        runs.push(opts)
+        return { result: { id: `wf-${runs.length}` }, errors: null }
+      }),
+    },
+  }
+}
+
+function makeContext(
+  dataChain: Record<string, any>,
+  container: any
+): any {
+  return {
+    container,
+    dataChain: {
+      $trigger: { payload: {}, timestamp: "2026-08-18T00:00:00.000Z" },
+      $accountability: {},
+      $env: {},
+      $last: null,
+      ...dataChain,
+    },
+    flowId: "flow_test",
+    executionId: "exec_test",
+    operationId: "op_test",
+    operationKey: "dispatch",
+  }
+}
+
+/** Build a fake container that resolves `workflows` → engine and `locking` → locking service. */
+function makeContainer(engine: any, locking: any) {
+  return {
+    resolve: (name: string) => {
+      if (name === "workflows") return engine
+      if (name === "locking") return locking
+      return undefined
+    },
+  }
+}
+
+const SEND_ITEMS = [
+  { cart_id: "cart_a", to: "a@test.com", template: "cart-abandoned", data: {} },
+  { cart_id: "cart_b", to: "b@test.com", template: "cart-abandoned", data: {} },
+]
+
+describe("bulk_trigger_workflow — idempotency_key_template (#1334)", () => {
+  it("triggers the workflow for every item when no idempotency key is set", async () => {
+    const { engine } = makeWorkflowEngine()
+    const ctx = makeContext(
+      { classify: { send_items: SEND_ITEMS } },
+      makeContainer(engine, null)
+    )
+
+    const result = await bulkTriggerWorkflowOperation.execute(
+      {
+        workflow_name: "send-notification-email",
+        items: "{{ classify.send_items }}",
+        input_template: {
+          to: "{{ item.to }}",
+          template: "{{ item.template }}",
+          data: "{{ item.data }}",
+        },
+        continue_on_error: true,
+        max_items: 100,
+      },
+      ctx
+    )
+
+    expect(result.success).toBe(true)
+    expect(result.data.triggered).toBe(2)
+    expect(result.data.skipped).toBe(0)
+    expect(result.data.failed).toBe(0)
+    expect(engine.run).toHaveBeenCalledTimes(2)
+  })
+
+  it("skips items whose idempotency lock is already held", async () => {
+    const { engine } = makeWorkflowEngine()
+    const { locking, acquired } = makeLocking(new Set(["cart-abandoned:cart_a"]))
+    const ctx = makeContext(
+      { classify: { send_items: SEND_ITEMS } },
+      makeContainer(engine, locking)
+    )
+
+    const result = await bulkTriggerWorkflowOperation.execute(
+      {
+        workflow_name: "send-notification-email",
+        items: "{{ classify.send_items }}",
+        input_template: {
+          to: "{{ item.to }}",
+          template: "{{ item.template }}",
+          data: "{{ item.data }}",
+        },
+        idempotency_key_template: "cart-abandoned:{{ item.cart_id }}",
+        continue_on_error: true,
+        max_items: 100,
+      },
+      ctx
+    )
+
+    expect(result.success).toBe(true)
+    expect(result.data.triggered).toBe(1)  // only cart_b
+    expect(result.data.skipped).toBe(1)   // cart_a skipped
+    expect(result.data.failed).toBe(0)
+    expect(engine.run).toHaveBeenCalledTimes(1)
+    // The skip is visible in the per-item results
+    expect(result.data.results[0].skipped).toBe(true)
+    expect(result.data.results[0].error).toBe("idempotency-skip")
+  })
+
+  it("acquires and releases the lock for each non-skipped item", async () => {
+    const { engine } = makeWorkflowEngine()
+    const { locking, acquired, released } = makeLocking()
+    const ctx = makeContext(
+      { classify: { send_items: SEND_ITEMS } },
+      makeContainer(engine, locking)
+    )
+
+    await bulkTriggerWorkflowOperation.execute(
+      {
+        workflow_name: "send-notification-email",
+        items: "{{ classify.send_items }}",
+        input_template: {
+          to: "{{ item.to }}",
+          template: "{{ item.template }}",
+          data: "{{ item.data }}",
+        },
+        idempotency_key_template: "cart-abandoned:{{ item.cart_id }}",
+        continue_on_error: true,
+        max_items: 100,
+      },
+      ctx
+    )
+
+    expect(acquired.has("cart-abandoned:cart_a")).toBe(true)
+    expect(acquired.has("cart-abandoned:cart_b")).toBe(true)
+    expect(released.has("cart-abandoned:cart_a")).toBe(true)
+    expect(released.has("cart-abandoned:cart_b")).toBe(true)
+    expect(locking.acquire).toHaveBeenCalledTimes(2)
+    expect(locking.release).toHaveBeenCalledTimes(2)
+  })
+
+  it("releases the lock even when the workflow trigger throws", async () => {
+    const failingEngine = {
+      run: jest.fn().mockRejectedValue(new Error("SMTP down")),
+    }
+    const { locking, released } = makeLocking()
+    const ctx = makeContext(
+      { classify: { send_items: [SEND_ITEMS[0]] } },
+      makeContainer(failingEngine, locking)
+    )
+
+    const result = await bulkTriggerWorkflowOperation.execute(
+      {
+        workflow_name: "send-notification-email",
+        items: "{{ classify.send_items }}",
+        input_template: { to: "{{ item.to }}" },
+        idempotency_key_template: "cart-abandoned:{{ item.cart_id }}",
+        continue_on_error: true,
+        max_items: 100,
+      },
+      ctx
+    )
+
+    expect(result.data.failed).toBe(1)
+    expect(released.has("cart-abandoned:cart_a")).toBe(true)
+  })
+
+  it("returns skipped=0 when idempotency_key_template is omitted", async () => {
+    const { engine } = makeWorkflowEngine()
+    const ctx = makeContext(
+      { classify: { send_items: SEND_ITEMS } },
+      makeContainer(engine, null)
+    )
+
+    const result = await bulkTriggerWorkflowOperation.execute(
+      {
+        workflow_name: "send-notification-email",
+        items: "{{ classify.send_items }}",
+        input_template: { to: "{{ item.to }}" },
+        continue_on_error: true,
+        max_items: 100,
+      },
+      ctx
+    )
+
+    expect(result.data.skipped).toBe(0)
+  })
+})

--- a/apps/backend/src/modules/visual_flows/operations/bulk-trigger-workflow.ts
+++ b/apps/backend/src/modules/visual_flows/operations/bulk-trigger-workflow.ts
@@ -5,13 +5,23 @@ import { OperationDefinition, OperationContext, OperationResult } from "./types"
 import { interpolateVariables, interpolateString } from "./utils"
 
 /**
- * Default TTL (seconds) for a per-item idempotency lock. Long enough to cover
- * the workflow trigger + a crash-recovery margin, short enough that a
- * genuinely failed item is retried on the next scheduled tick. The lock is
- * always released explicitly after the trigger resolves, so this is only the
- * crash-safety net.
+ * TTL (seconds) for a per-item idempotency key.
+ *
+ * This is the DEDUP WINDOW, not a mutex hold — which is why the key is not
+ * released after a successful trigger. Two racing executions walk the same item
+ * list serially, so the second one reaches a given item seconds or minutes
+ * after the first finished it; a key released on success is simply gone by
+ * then, and the item sends twice. The key has to outlive the window in which a
+ * duplicate could still arrive.
+ *
+ * An hour comfortably covers a rolling ECS deploy (the window in which two
+ * scanners coexist) while staying far shorter than the hourly cart-recovery
+ * cadence's own per-cart guard (`recovery_email_count` / `recovery_email_sent_at`),
+ * which remains the durable record. A key is released early only when the
+ * trigger FAILED, so a cart whose mail never went out is retried at once
+ * rather than being blacklisted for the window.
  */
-const IDEMPOTENCY_LOCK_TTL_SECONDS = 300
+const IDEMPOTENCY_LOCK_TTL_SECONDS = 3600
 
 /**
  * Substitute $index placeholder in a serialised template.
@@ -56,14 +66,24 @@ export const bulkTriggerWorkflowOperation: OperationDefinition = {
     /**
      * Per-item idempotency lock key template (#1334).
      *
-     * When set, each item's workflow trigger is guarded by a distributed
-     * lock (Modules.LOCKING) keyed on the interpolated template. If the lock
-     * is already held — meaning another concurrent execution is processing
-     * the same item — the item is skipped immediately (not queued).
+     * When set, each item's trigger claims a distributed key (Modules.LOCKING)
+     * built from the interpolated template. A key that is already claimed means
+     * another execution has ALREADY TRIGGERED this item — within the last
+     * IDEMPOTENCY_LOCK_TTL_SECONDS — so the item is skipped, not queued.
      *
-     * The template supports the same {{ item.field }} and $index
-     * interpolation as `input_template`. Example:
+     * The key is held for the whole dedup window rather than released after the
+     * trigger: the racing execution arrives late, not simultaneously (see the
+     * TTL note above). It IS released early when the trigger fails, so a failed
+     * item is retried immediately.
+     *
+     * Supports {{ item.field }} interpolation (NOT $index, which is applied to
+     * `input_template` only — a key containing it would stay literal and
+     * collapse every item onto one key). Example:
      *   "cart-abandoned:{{ item.cart_id }}"
+     *
+     * The interpolated key must be non-empty and fully resolved; an
+     * unresolvable path would otherwise silently collapse every item onto the
+     * same key and drop all but the first.
      *
      * Omit for workflows that don't need per-item idempotency (the original
      * behaviour — every item triggers its workflow unconditionally).
@@ -140,18 +160,32 @@ export const bulkTriggerWorkflowOperation: OperationDefinition = {
             input = interpolateVariables(templateWithIndex, chainWithItem)
           }
 
-          // ── Per-item idempotency lock (#1334) ───────────────────────────────
+          // ── Per-item idempotency key (#1334) ────────────────────────────
           //
-          // When `idempotency_key_template` is set, acquire a distributed lock
-          // BEFORE triggering the workflow. `acquire` is non-blocking — it
-          // succeeds immediately or throws if another execution holds the
-          // lock. A skipped item means another concurrent execution is already
-          // processing it, so we move on. The lock is released in a `finally`
-          // after the trigger resolves, and carries an TTL as a crash-safety
-          // net so a dead worker can't pin an item forever.
+          // Claim the key BEFORE triggering. A claimed key means this item was
+          // already triggered inside the dedup window, so we skip it.
+          //
+          // The claim is NOT released on success: the racing execution reaches
+          // this item late (both walk the list serially), so a key released the
+          // moment the trigger resolved would already be gone when the
+          // duplicate arrives. It IS released when the trigger fails, so a send
+          // that never happened can be retried at once.
           let idempotencyKey: string | null = null
           if (idempotencyTemplate) {
             idempotencyKey = interpolateString(idempotencyTemplate, chainWithItem)
+
+            // `interpolateString` substitutes "" for a path it cannot resolve.
+            // Left alone, a typo'd template collapses every item onto one key —
+            // one item sends and the rest are reported as idempotency skips —
+            // and a fully unresolved template yields "", which is falsy and so
+            // disables the guard entirely. Both fail silently, in the direction
+            // of sending nothing while claiming success.
+            if (!idempotencyKey || idempotencyKey === idempotencyTemplate) {
+              throw new Error(
+                `idempotency_key_template "${idempotencyTemplate}" did not resolve for item ${i} — ` +
+                  `check the field names on the items feeding this operation`
+              )
+            }
           }
 
           if (idempotencyKey && locking) {
@@ -159,11 +193,27 @@ export const bulkTriggerWorkflowOperation: OperationDefinition = {
               await locking.acquire(idempotencyKey, {
                 expire: IDEMPOTENCY_LOCK_TTL_SECONDS,
               })
-            } catch {
-              // Lock already held — another execution is handling this item.
+            } catch (lockError: any) {
+              // CONFLICT is contention — the item is genuinely already handled.
+              // Anything else (Redis unreachable, timeout) is infrastructure
+              // failing, and reading it as "already sent" would turn a total
+              // send outage into `success: true` with every item reported as a
+              // tidy skip.
+              const isContention =
+                lockError?.type === "conflict" ||
+                lockError?.type === "not_allowed" ||
+                /failed to acquire lock/i.test(lockError?.message ?? "")
+
+              if (!isContention) {
+                throw new Error(
+                  `Locking backend unavailable while claiming "${idempotencyKey}": ` +
+                    `${lockError?.message || lockError}`
+                )
+              }
+
               skipped++
               results.push({ index: i, ok: false, error: "idempotency-skip", skipped: true })
-              console.log(`[bulk_trigger_workflow] [${i}] skipped (idempotency lock held: ${idempotencyKey})`)
+              console.log(`[bulk_trigger_workflow] [${i}] skipped (already triggered: ${idempotencyKey})`)
               continue
             }
           }
@@ -183,14 +233,17 @@ export const bulkTriggerWorkflowOperation: OperationDefinition = {
             }
 
             results.push({ index: i, ok: true, record: result })
-          } finally {
+          } catch (triggerError) {
+            // Failed send → drop the claim so the next execution can retry.
+            // A successful send keeps it until the TTL expires.
             if (idempotencyKey && locking) {
               try {
                 await locking.release(idempotencyKey)
               } catch {
-                // Best-effort release — the TTL will clean up if this fails.
+                // Best-effort — the TTL will clean up if this fails.
               }
             }
+            throw triggerError
           }
         } catch (e: any) {
           const error = e?.message || "Unknown error"
@@ -203,7 +256,9 @@ export const bulkTriggerWorkflowOperation: OperationDefinition = {
               error,
               data: {
                 triggered: results.filter((r) => r.ok).length,
-                failed: results.filter((r) => !r.ok).length,
+                // Excludes skips, matching the normal return below — counting
+                // them here reported failures that never happened.
+                failed: results.filter((r) => !r.ok && !r.skipped).length,
                 skipped,
                 records: results.filter((r) => r.ok).map((r) => r.record),
                 results,

--- a/apps/backend/src/modules/visual_flows/operations/bulk-trigger-workflow.ts
+++ b/apps/backend/src/modules/visual_flows/operations/bulk-trigger-workflow.ts
@@ -5,6 +5,15 @@ import { OperationDefinition, OperationContext, OperationResult } from "./types"
 import { interpolateVariables, interpolateString } from "./utils"
 
 /**
+ * Default TTL (seconds) for a per-item idempotency lock. Long enough to cover
+ * the workflow trigger + a crash-recovery margin, short enough that a
+ * genuinely failed item is retried on the next scheduled tick. The lock is
+ * always released explicitly after the trigger resolves, so this is only the
+ * crash-safety net.
+ */
+const IDEMPOTENCY_LOCK_TTL_SECONDS = 300
+
+/**
  * Substitute $index placeholder in a serialised template.
  * Mirrors the approach used in bulk-create-data.ts and bulk-http-request.ts.
  */
@@ -44,6 +53,22 @@ export const bulkTriggerWorkflowOperation: OperationDefinition = {
       ),
     continue_on_error: z.boolean().optional().default(true),
     max_items: z.number().int().min(1).max(500).optional().default(100),
+    /**
+     * Per-item idempotency lock key template (#1334).
+     *
+     * When set, each item's workflow trigger is guarded by a distributed
+     * lock (Modules.LOCKING) keyed on the interpolated template. If the lock
+     * is already held — meaning another concurrent execution is processing
+     * the same item — the item is skipped immediately (not queued).
+     *
+     * The template supports the same {{ item.field }} and $index
+     * interpolation as `input_template`. Example:
+     *   "cart-abandoned:{{ item.cart_id }}"
+     *
+     * Omit for workflows that don't need per-item idempotency (the original
+     * behaviour — every item triggers its workflow unconditionally).
+     */
+    idempotency_key_template: z.string().optional(),
   }),
 
   defaultOptions: {
@@ -52,6 +77,7 @@ export const bulkTriggerWorkflowOperation: OperationDefinition = {
     input_template: {},
     continue_on_error: true,
     max_items: 100,
+    idempotency_key_template: "",
   },
 
   execute: async (options, context: OperationContext): Promise<OperationResult> => {
@@ -60,6 +86,7 @@ export const bulkTriggerWorkflowOperation: OperationDefinition = {
       const maxItems = Number(options.max_items ?? 100)
       const rawName = options.workflow_name ?? options.workflow_id ?? ""
       const workflowName = interpolateString(String(rawName), context.dataChain)
+      const idempotencyTemplate = options.idempotency_key_template || null
 
       if (!workflowName) {
         return { success: false, error: "workflow_name is required — select a workflow in the node properties panel" }
@@ -75,7 +102,7 @@ export const bulkTriggerWorkflowOperation: OperationDefinition = {
       }
 
       if (resolvedItems.length === 0) {
-        return { success: true, data: { triggered: 0, failed: 0, records: [], results: [] } }
+        return { success: true, data: { triggered: 0, failed: 0, skipped: 0, records: [], results: [] } }
       }
 
       if (resolvedItems.length > maxItems) {
@@ -89,7 +116,16 @@ export const bulkTriggerWorkflowOperation: OperationDefinition = {
         Modules.WORKFLOW_ENGINE
       )
 
-      const results: Array<{ index: number; ok: boolean; record?: any; error?: string }> = []
+      // Resolve the locking service once if idempotency keys are in use.
+      // `acquire` throws immediately when the lock is already held — the
+      // caller skips the item instead of waiting, so two concurrent flow
+      // executions can't both send for the same cart / entity. #1334.
+      const locking = idempotencyTemplate
+        ? (context.container.resolve(Modules.LOCKING) as any)
+        : null
+
+      const results: Array<{ index: number; ok: boolean; record?: any; error?: string; skipped?: boolean }> = []
+      let skipped = 0
 
       for (let i = 0; i < resolvedItems.length; i++) {
         const item = resolvedItems[i]
@@ -104,20 +140,58 @@ export const bulkTriggerWorkflowOperation: OperationDefinition = {
             input = interpolateVariables(templateWithIndex, chainWithItem)
           }
 
-          console.log(`[bulk_trigger_workflow] [${i}/${resolvedItems.length}] ${workflowName}`, { input })
-
-          const { result, errors } = await workflowEngine.run(workflowName, {
-            input,
-            transactionId: `vflow-${context.executionId}-${workflowName}-${i}-${Date.now()}`,
-            context: { requestId: context.executionId },
-          })
-
-          if (errors?.length) {
-            const msg = errors.map((e: any) => e.error?.message || e.message || String(e)).join("; ")
-            throw new Error(`Workflow error: ${msg}`)
+          // ── Per-item idempotency lock (#1334) ───────────────────────────────
+          //
+          // When `idempotency_key_template` is set, acquire a distributed lock
+          // BEFORE triggering the workflow. `acquire` is non-blocking — it
+          // succeeds immediately or throws if another execution holds the
+          // lock. A skipped item means another concurrent execution is already
+          // processing it, so we move on. The lock is released in a `finally`
+          // after the trigger resolves, and carries an TTL as a crash-safety
+          // net so a dead worker can't pin an item forever.
+          let idempotencyKey: string | null = null
+          if (idempotencyTemplate) {
+            idempotencyKey = interpolateString(idempotencyTemplate, chainWithItem)
           }
 
-          results.push({ index: i, ok: true, record: result })
+          if (idempotencyKey && locking) {
+            try {
+              await locking.acquire(idempotencyKey, {
+                expire: IDEMPOTENCY_LOCK_TTL_SECONDS,
+              })
+            } catch {
+              // Lock already held — another execution is handling this item.
+              skipped++
+              results.push({ index: i, ok: false, error: "idempotency-skip", skipped: true })
+              console.log(`[bulk_trigger_workflow] [${i}] skipped (idempotency lock held: ${idempotencyKey})`)
+              continue
+            }
+          }
+
+          try {
+            console.log(`[bulk_trigger_workflow] [${i}/${resolvedItems.length}] ${workflowName}`, { input })
+
+            const { result, errors } = await workflowEngine.run(workflowName, {
+              input,
+              transactionId: `vflow-${context.executionId}-${workflowName}-${i}-${Date.now()}`,
+              context: { requestId: context.executionId },
+            })
+
+            if (errors?.length) {
+              const msg = errors.map((e: any) => e.error?.message || e.message || String(e)).join("; ")
+              throw new Error(`Workflow error: ${msg}`)
+            }
+
+            results.push({ index: i, ok: true, record: result })
+          } finally {
+            if (idempotencyKey && locking) {
+              try {
+                await locking.release(idempotencyKey)
+              } catch {
+                // Best-effort release — the TTL will clean up if this fails.
+              }
+            }
+          }
         } catch (e: any) {
           const error = e?.message || "Unknown error"
           console.error(`[bulk_trigger_workflow] [${i}] failed:`, error)
@@ -130,6 +204,7 @@ export const bulkTriggerWorkflowOperation: OperationDefinition = {
               data: {
                 triggered: results.filter((r) => r.ok).length,
                 failed: results.filter((r) => !r.ok).length,
+                skipped,
                 records: results.filter((r) => r.ok).map((r) => r.record),
                 results,
               },
@@ -139,13 +214,14 @@ export const bulkTriggerWorkflowOperation: OperationDefinition = {
       }
 
       const triggered = results.filter((r) => r.ok).length
-      const failed = results.filter((r) => !r.ok).length
+      const failed = results.filter((r) => !r.ok && !r.skipped).length
 
       return {
         success: failed === 0 || continueOnError,
         data: {
           triggered,
           failed,
+          skipped,
           records: results.filter((r) => r.ok).map((r) => r.record),
           results,
         },

--- a/apps/backend/src/scripts/seed-cart-recovery-flow.ts
+++ b/apps/backend/src/scripts/seed-cart-recovery-flow.ts
@@ -204,7 +204,9 @@ const FLOW_DEF = {
     " reminders, spaced >= " +
     RESEND_GAP_HOURS +
     "h apart (metadata.recovery_email_count + recovery_email_sent_at); " +
-    "converted carts (metadata.converted_order_id) are skipped.",
+    "converted carts (metadata.converted_order_id) are skipped. " +
+    "Per-cart idempotency lock (cart-abandoned:{cart_id}) prevents " +
+    "duplicate sends during concurrent executions (#1334).",
   status: "draft" as const,
   trigger_type: "schedule" as const,
   trigger_config: {
@@ -293,6 +295,13 @@ const FLOW_DEF = {
     },
 
     // ── 3. Bulk-trigger send-notification-email per cart ──────────────────
+    //
+    // `idempotency_key_template` (#1334): each cart's send is guarded by a
+    // distributed lock keyed on `cart-abandoned:{cart_id}`. If two flow
+    // executions race (e.g. a rolling deploy overlaps two worker tasks),
+    // only the first to acquire the lock sends — the second skips the item
+    // immediately instead of producing a duplicate email. The `mark_sent`
+    // step still runs after dispatch as the durable per-cart record.
     {
       operation_key: "dispatch",
       operation_type: "bulk_trigger_workflow",
@@ -308,6 +317,7 @@ const FLOW_DEF = {
           template: "{{ item.template }}",
           data: "{{ item.data }}",
         },
+        idempotency_key_template: "cart-abandoned:{{ item.cart_id }}",
         continue_on_error: true,
         max_items: 500,
       },
@@ -350,7 +360,7 @@ const FLOW_DEF = {
           "converted={{ classify.counts.converted }} " +
           "gap_wait={{ classify.counts.gap_wait }} " +
           "sent={{ dispatch.triggered }} failed={{ dispatch.failed }} " +
-          "marked={{ mark_sent.updated }}",
+          "skipped={{ dispatch.skipped }} marked={{ mark_sent.updated }}",
         level: "info",
       },
     },

--- a/apps/backend/src/scripts/seed-cart-recovery-flow.ts
+++ b/apps/backend/src/scripts/seed-cart-recovery-flow.ts
@@ -386,8 +386,54 @@ export default async function seedCartRecoveryFlow({
 
   const [existing] = await service.listVisualFlows({ name: FLOW_NAME } as any)
   if (existing) {
-    console.log(`Flow "${FLOW_NAME}" already exists (${existing.id}) — skipping.`)
-    console.log(`Delete it in the admin UI (or by id) to re-seed.`)
+    console.log(`Flow "${FLOW_NAME}" already exists (${existing.id}).`)
+
+    // The flow that is sending duplicates is by definition one that ALREADY
+    // EXISTS, so a plain early-return here means the #1334 fix ships to
+    // everything except the installation that needs it. Re-seeding is not the
+    // answer either: `createCompleteFlow` writes `status: "draft"`, so deleting
+    // and re-creating would silently stop recovery mail until someone noticed
+    // and re-activated it.
+    //
+    // So backfill just the one option, onto the live row, leaving the flow's
+    // status, schedule and every other operation untouched. Idempotent: a flow
+    // that already carries the key is left alone.
+    // Read the wanted value from the seed definition itself, so the backfill
+    // cannot drift from what a fresh seed would write.
+    const dispatchOp = FLOW_DEF.operations.find(
+      (o) => o.operation_key === "dispatch"
+    )
+    if (!dispatchOp) {
+      console.log(`  ⚠️  Seed definition has no "dispatch" operation.`)
+      return
+    }
+    const [liveDispatch] = await service.listVisualFlowOperations({
+      flow_id: existing.id,
+      operation_key: "dispatch",
+    } as any)
+
+    if (!liveDispatch) {
+      console.log(`  ⚠️  No "dispatch" operation on this flow — nothing to backfill.`)
+      return
+    }
+
+    const liveOptions = (liveDispatch as any).options ?? {}
+    const wanted = (dispatchOp.options as any).idempotency_key_template
+
+    if (liveOptions.idempotency_key_template === wanted) {
+      console.log(`  ✓ Per-cart idempotency key already set — nothing to do.`)
+      return
+    }
+
+    await service.updateVisualFlowOperations({
+      id: (liveDispatch as any).id,
+      options: { ...liveOptions, idempotency_key_template: wanted },
+    } as any)
+
+    console.log(
+      `  ✓ Backfilled idempotency_key_template="${wanted}" onto the live dispatch operation (#1334).`
+    )
+    console.log(`  (Delete the flow in the admin UI to re-seed it from scratch.)`)
     return
   }
 


### PR DESCRIPTION
## Summary

Fixes #1334 — `cart-abandoned` emails sent twice, ~1 second apart.

Two independent defects produced duplicate abandoned-cart emails. Both are fixed using Medusa's built-in Locking Module (`Modules.LOCKING`), which is already configured with the Redis provider in prod (`medusa-config.prod.ts:191-205`) and already used in four places across the codebase.

### Defect A — Scheduler race (duplicate within ~1s)

The scheduler's dedup is a **check-then-set** on `metadata.schedule.last_run_minute_key` — a classic TOCTOU race. During a rolling ECS deploy or Fargate Spot replacement, two worker tasks briefly coexist; both read a stale key, both write, both fire `executeVisualFlowWorkflow`. Intermittent (2 of 4 days in the evidence) — the signature of a race, not a logic error.

**Fix:** Wrap the per-flow claim in `locking.execute("scheduled-flow:{flowId}:{minuteKey}", ..., { timeout: 1 })`. Two scanners serialize on the lock; the second either times out (skips) or enters and finds the marker already set (double-check pattern). The existing `last_run_minute_key` pre-filter stays as a cheap read to avoid unnecessary lock acquires.

### Defect B — No per-cart idempotency (same cart re-emailed across days)

Two concurrent flow executions both `read_carts` and `classify` the same carts **before** either one's `mark_sent` runs. The `classify` code already checks `recovery_email_count` and `recovery_email_sent_at`, but it's a stale read — both executions see the same pre-mark metadata.

**Fix:** Add `idempotency_key_template` option to the `bulk_trigger_workflow` operation. When set, each item's workflow trigger is guarded by `locking.acquire(key, { expire: 300 })`. `acquire` is non-blocking — it throws immediately if another execution holds the lock, and the item is skipped (counted as `skipped`, not `failed`). The lock is released in a `finally` after the trigger resolves, with a 5-minute TTL as a crash-safety net.

The seed is updated to set `idempotency_key_template: "cart-abandoned:{{ item.cart_id }}"` on the dispatch node. `mark_sent` stays as the durable per-cart record.

## Files changed

| File | Change |
|------|--------|
| `run-scheduled-visual-flows.ts` | Scheduler lock per flow+minute with double-check |
| `bulk-trigger-workflow.ts` | New `idempotency_key_template` option with per-item `acquire`/`release` |
| `seed-cart-recovery-flow.ts` | Set `idempotency_key_template` on dispatch; add `skipped` to log |
| `bulk-trigger-workflow.unit.spec.ts` | 5 new unit tests (new file) |

## Test plan

- [x] Unit tests pass (`bulk-trigger-workflow.unit.spec.ts` — 5 tests)
- [x] Existing related tests pass (`executor-dedup`, `bulk-update-data`)
- [x] No TypeScript errors in changed files
- [ ] Integration test: create a scheduled flow, invoke `runScheduledVisualFlows` twice concurrently, assert only one execution is created (extends `scheduled-enqueue.spec.ts`)
- [ ] End-to-end: create a cart, run the cart-recovery flow twice concurrently, assert only one notification row

## Done when

The same template cannot be sent to the same recipient for the same cart twice, and the duplicate-suppression is proven by a test rather than by not having seen it lately.