### PR TITLE
fix(partner-assistant): hand an approved tool's real result back to the model

### DIFF
--- a/apps/backend/src/api/partners/assistant/chat/route.ts
+++ b/apps/backend/src/api/partners/assistant/chat/route.ts
@@ -78,7 +78,9 @@ You are given the tools for the domains this conversation appears to be about, n
 
 ## Safety rails (important)
 - Every tool accepts \`dry_run: true\`. Use it to PREVIEW a change and inspect the current object before you actually write — especially before any update. Show the user what will change, then run the tool for real.
-- Sensitive/destructive tools (deletes, resets) will refuse to run unless the user confirms. Never set \`confirm: true\` yourself. If a tool returns \`requires_confirmation\`, tell the user plainly what it will do and ask them to confirm — the UI gives them an approve button.
+- Sensitive/destructive tools (deletes, resets, product creation) will refuse to run unless the user confirms. Never set \`confirm: true\` yourself.
+- When a tool returns \`requires_confirmation\`, the UI has ALREADY rendered an approval card carrying the full plan, with Approve and Cancel buttons. Reply with ONE short line and stop — e.g. "Approve below and I'll create it." Do NOT re-list the spec, do NOT restate the warning, and never ask them to reply "yes": there is nothing for them to type. Then WAIT. The action has not run.
+- A turn beginning with \`[approved-tool-result]\` means the user pressed Approve and the tool has ALREADY RUN — its real result is in that message. Never call that tool again and never ask for confirmation again; just tell them what actually happened, reading the result (ids, status, counts) rather than repeating what you had planned.
 
 ## Photos the partner shares
 Photos are uploaded into the partner's own media folder and listed for you as \`[photo N]\` lines with a url — but you CANNOT see them. Nothing about their content is available to you unless you go and look.

--- a/apps/partner-ui/src/lib/__tests__/assistant-approval.spec.ts
+++ b/apps/partner-ui/src/lib/__tests__/assistant-approval.spec.ts
@@ -1,0 +1,119 @@
+import { describe, expect, it } from "vitest"
+
+import {
+  APPROVAL_NOTE_PREFIX,
+  approvalNote,
+  approvalNoteTool,
+  resolveToolPart,
+} from "../assistant-approval"
+
+/** The shape a `requires_confirmation` turn actually has: the model explains,
+ *  the tool call comes back unrun, and the model then asks for a confirmation
+ *  the UI is already offering as a button. */
+const confirmTurn = () => [
+  { type: "text", text: "Here is what I'll create." },
+  {
+    type: "tool-create_product",
+    toolCallId: "call_1",
+    state: "output-available",
+    input: { title: "Ikat grid" },
+    output: { ok: false, tool: "create_product", requires_confirmation: true },
+  },
+  { type: "text", text: "Please confirm that you want me to proceed." },
+]
+
+describe("resolveToolPart", () => {
+  it("writes the real result into the approved call", () => {
+    const parts = resolveToolPart(
+      confirmTurn(),
+      "call_1",
+      { ok: true, tool: "create_product", data: { id: "prod_1" } },
+      "approved"
+    )
+    const call = parts.find((p) => p.toolCallId === "call_1") as any
+    expect(call.output).toEqual({
+      ok: true,
+      tool: "create_product",
+      data: { id: "prod_1" },
+    })
+    expect(call.output.requires_confirmation).toBeUndefined()
+    expect(call.state).toBe("output-available")
+  })
+
+  it("drops the stale ask written after the card, keeping the lead-in", () => {
+    const parts = resolveToolPart(confirmTurn(), "call_1", { ok: true }, "approved")
+    const texts = parts.filter((p) => p.type === "text").map((p: any) => p.text)
+    expect(texts).toEqual(["Here is what I'll create."])
+  })
+
+  it("keeps everything from a later tool call onwards", () => {
+    const parts = resolveToolPart(
+      [
+        ...confirmTurn(),
+        { type: "tool-list_products", toolCallId: "call_2", output: { ok: true } },
+        { type: "text", text: "…and these are your products." },
+      ],
+      "call_1",
+      { ok: true },
+      "approved"
+    )
+    expect(parts.map((p) => p.type)).toEqual([
+      "text",
+      "tool-create_product",
+      "tool-list_products",
+      "text",
+    ])
+  })
+
+  it("keeps the prose on cancel — nothing ran, so nothing it said is stale", () => {
+    const parts = resolveToolPart(
+      confirmTurn(),
+      "call_1",
+      { ok: false, cancelled: true, error: "Cancelled — nothing ran." },
+      "rejected"
+    )
+    expect(parts).toHaveLength(3)
+    expect((parts[2] as any).text).toBe(
+      "Please confirm that you want me to proceed."
+    )
+    expect((parts[1] as any).output.cancelled).toBe(true)
+  })
+
+  it("leaves a message that doesn't hold the call untouched", () => {
+    const parts = confirmTurn()
+    expect(resolveToolPart(parts, "call_other", { ok: true }, "approved")).toBe(
+      parts
+    )
+  })
+})
+
+describe("approvalNote", () => {
+  it("names the tool and carries the result", () => {
+    const note = approvalNote("create_product", { ok: true, data: { id: "p_1" } })
+    expect(note.startsWith(APPROVAL_NOTE_PREFIX)).toBe(true)
+    expect(note).toContain("`create_product`")
+    expect(note).toContain('"id":"p_1"')
+    expect(note).toContain("ALREADY RUN")
+  })
+
+  it("truncates a large result rather than blowing the context window", () => {
+    const note = approvalNote("create_product", {
+      data: { variants: Array.from({ length: 500 }, (_, i) => ({ id: `v_${i}` })) },
+    })
+    expect(note).toContain("(truncated)")
+    expect(note.length).toBeLessThan(2400)
+  })
+})
+
+describe("approvalNoteTool", () => {
+  it("recognises an approval turn and reads back its tool", () => {
+    expect(approvalNoteTool(approvalNote("delete_design", { ok: true }))).toBe(
+      "delete_design"
+    )
+  })
+
+  it("returns null for anything the partner actually typed", () => {
+    expect(approvalNoteTool("please create the product")).toBeNull()
+    expect(approvalNoteTool("")).toBeNull()
+  })
+})

--- a/apps/partner-ui/src/lib/assistant-approval.ts
+++ b/apps/partner-ui/src/lib/assistant-approval.ts
@@ -1,0 +1,87 @@
+/**
+ * Approval hand-back for the partner assistant's sensitive-tool cards.
+ *
+ * A sensitive tool comes back as `requires_confirmation` and is then run
+ * CLIENT-SIDE, straight against POST /partners/mcp (see ./assistant-mcp) — the
+ * model is not involved in that call and never learns it happened. The chat
+ * route also strips tool parts from history and sends the model text only, so
+ * patching the tool part's output is not enough on its own: without a text
+ * hand-back the model's last words ("…please confirm you want me to proceed")
+ * stand as its answer to an approval that already went through.
+ *
+ * So resolving a card does two things:
+ *   1. `resolveToolPart` writes the real result into the message (which is what
+ *      gets persisted — a reopened chat must never re-offer an action that has
+ *      already run) and drops the prose the model wrote after the card, which
+ *      was written on the assumption that nothing had run yet;
+ *   2. `approvalNote` gives the model the outcome as an ordinary user turn, so
+ *      its next words describe what happened rather than what it planned.
+ */
+
+/** Marks the turn that carries an approved tool's result back to the model. */
+export const APPROVAL_NOTE_PREFIX = "[approved-tool-result]"
+
+/** Result payloads can be large (a product with nine variants); the model only
+ *  needs enough of one to describe what happened. */
+const APPROVAL_NOTE_MAX_CHARS = 2000
+
+export function approvalNote(name: string, result: unknown): string {
+  let json: string
+  try {
+    json = JSON.stringify(result) ?? "null"
+  } catch {
+    json = "{}"
+  }
+  if (json.length > APPROVAL_NOTE_MAX_CHARS) {
+    json = `${json.slice(0, APPROVAL_NOTE_MAX_CHARS)}… (truncated)`
+  }
+  return (
+    `${APPROVAL_NOTE_PREFIX} I approved \`${name}\` in the UI and it has ALREADY RUN. ` +
+    `Its result:\n${json}\n` +
+    `Do not ask for confirmation again and do not call it again — tell me what actually happened, based on this result.`
+  )
+}
+
+/** The tool name carried by an approval-note turn, or null if it isn't one. */
+export function approvalNoteTool(text: string): string | null {
+  if (!text.startsWith(APPROVAL_NOTE_PREFIX)) return null
+  return text.match(/`([^`]+)`/)?.[1] ?? "the action"
+}
+
+type Part = { type?: string; toolCallId?: string; [k: string]: unknown }
+
+/**
+ * Replace a tool call's output with the outcome of the user's decision.
+ *
+ * On approval the prose that follows the card is dropped — it asked for a
+ * confirmation that has since been given, so leaving it reads as the assistant
+ * ignoring the button the user just pressed. Prose BEFORE the card stays (it
+ * explains the action), and anything from a later tool call onwards stays too:
+ * that belongs to a different action.
+ *
+ * Returns the original array when the call isn't in it, so callers can map over
+ * a message list without special-casing.
+ */
+export function resolveToolPart(
+  parts: Part[],
+  toolCallId: string,
+  result: unknown,
+  action: "approved" | "rejected"
+): Part[] {
+  if (!Array.isArray(parts)) return parts
+  const idx = parts.findIndex((p) => p?.toolCallId === toolCallId)
+  if (idx === -1) return parts
+
+  const next: Part[] = parts.slice(0, idx)
+  next.push({ ...parts[idx], output: result, state: "output-available" })
+
+  for (let i = idx + 1; i < parts.length; i++) {
+    const p = parts[i]
+    const isProse = p?.type === "text" || p?.type === "reasoning"
+    if (action === "approved" && isProse) continue
+    // A later tool call ends the stale region — keep it and everything after.
+    next.push(...parts.slice(i))
+    break
+  }
+  return next
+}

--- a/apps/partner-ui/src/routes/assistant/components/chat-thread.tsx
+++ b/apps/partner-ui/src/routes/assistant/components/chat-thread.tsx
@@ -8,7 +8,10 @@
  *     conversation after each completed turn (create-on-first-turn, then patch);
  *   - generic tool rendering: any registry tool result is summarised;
  *   - a sensitive-tool confirmation card that executes via POST /partners/mcp
- *     on the user's explicit approval (the model never self-confirms).
+ *     on the user's explicit approval (the model never self-confirms), and then
+ *     hands the REAL result back to the model so its next words describe what
+ *     happened rather than re-asking for the approval it just got (see
+ *     ../../../lib/assistant-approval).
  *
  * UX additions:
  *   - Stop: a stop button replaces the send button while the model is working
@@ -39,6 +42,11 @@ import {
   type StoredMessage,
 } from "../../../hooks/api/assistant-conversations"
 import { runPartnerMcpTool } from "../../../lib/assistant-mcp"
+import {
+  approvalNote,
+  approvalNoteTool,
+  resolveToolPart,
+} from "../../../lib/assistant-approval"
 import { Markdown } from "./markdown"
 import { ToolData } from "./tool-data"
 
@@ -326,6 +334,37 @@ export const ChatThread = ({
     void run()
   }, [status, messages, onCreated])
 
+  /**
+   * A sensitive tool was approved (and ran) or cancelled in a ToolCard.
+   *
+   * Writes the outcome back into the thread so it is what gets persisted — a
+   * reloaded conversation must not offer to run an action that already ran —
+   * and, on approval, drops the model's now-stale "please confirm…" prose and
+   * asks it to continue from the real result.
+   */
+  const handleToolResolved = useCallback(
+    (
+      messageId: string,
+      toolCallId: string,
+      name: string,
+      result: any,
+      action: "approved" | "rejected"
+    ) => {
+      setMessages?.((prev: any[]) =>
+        prev.map((m: any) =>
+          m.id === messageId
+            ? { ...m, parts: resolveToolPart(m.parts, toolCallId, result, action) }
+            : m
+        )
+      )
+
+      if (action === "approved") {
+        void sendMessage({ text: approvalNote(name, result) })
+      }
+    },
+    [setMessages, sendMessage]
+  )
+
   const handleSubmit = (e: React.FormEvent) => {
     e.preventDefault()
     // A message carrying only photos is legitimate — "here are three more" is a
@@ -513,7 +552,7 @@ export const ChatThread = ({
         )}
 
         {messages.map((m: any) => (
-          <MessageRow key={m.id} message={m} />
+          <MessageRow key={m.id} message={m} onToolResolved={handleToolResolved} />
         ))}
 
         {streaming && (
@@ -683,8 +722,35 @@ export const ChatThread = ({
   )
 }
 
-function MessageRow({ message: m }: { message: any }) {
+type ToolResolvedHandler = (
+  messageId: string,
+  toolCallId: string,
+  name: string,
+  result: any,
+  action: "approved" | "rejected"
+) => void
+
+function MessageRow({
+  message: m,
+  onToolResolved,
+}: {
+  message: any
+  onToolResolved: ToolResolvedHandler
+}) {
   if (m.role === "user") {
+    // An approval hand-back is addressed to the model, not something the
+    // partner typed — show it as what it is: a record that they approved.
+    const approvedTool = approvalNoteTool(getText(m.parts).trim())
+    if (approvedTool) {
+      return (
+        <div className="flex items-center gap-x-1.5 px-2">
+          <Check className="text-ui-tag-green-icon" />
+          <Text size="xsmall" className="text-ui-fg-muted capitalize">
+            Approved · {approvedTool.replace(/_/g, " ")}
+          </Text>
+        </div>
+      )
+    }
     return (
       <div className="flex justify-end">
         <div className="bg-ui-bg-highlight rounded-lg rounded-br-sm px-3 py-2 max-w-[85%]">
@@ -725,6 +791,9 @@ function MessageRow({ message: m }: { message: any }) {
               input={part.input}
               output={part.output}
               state={part.state}
+              onResolved={(result, action) =>
+                onToolResolved(m.id, part.toolCallId, name, result, action)
+              }
             />
           )
         }
@@ -779,11 +848,15 @@ function ToolCard({
   input,
   output,
   state,
+  onResolved,
 }: {
   name: string
   input: any
   output: any
   state?: string
+  /** Reports the outcome to the thread, which persists it and (on approval)
+   *  asks the model to continue from the real result. */
+  onResolved: (result: any, action: "approved" | "rejected") => void
 }) {
   const [confirming, setConfirming] = useState(false)
   const [resolved, setResolved] = useState<null | "approved" | "rejected">(null)
@@ -797,6 +870,9 @@ function ToolCard({
       const r = await runPartnerMcpTool(name, (input as any) || {})
       setResult(r)
       setResolved("approved")
+      // Hand the outcome to the thread BEFORE toasting: the model has to answer
+      // from what actually happened, not from the ask it wrote before the run.
+      onResolved(r, "approved")
       if (r.ok) {
         toast.success(`Done: ${label}`)
       } else {
@@ -807,7 +883,21 @@ function ToolCard({
     } finally {
       setConfirming(false)
     }
-  }, [name, input, label])
+  }, [name, input, label, onResolved])
+
+  const onCancel = useCallback(() => {
+    setResolved("rejected")
+    // Persisted too — a reopened chat must not re-offer an action the partner
+    // already declined as though it were still pending.
+    const cancelled = {
+      ok: false,
+      cancelled: true,
+      tool: name,
+      error: "Cancelled — nothing ran.",
+    }
+    setResult(cancelled)
+    onResolved(cancelled, "rejected")
+  }, [name, onResolved])
 
   // Still streaming the tool input / awaiting execution.
   if (state && state !== "output-available" && state !== "output-error") {
@@ -839,25 +929,31 @@ function ToolCard({
           </Text>
         )}
         <PlanSummary plan={out.plan} />
-        {resolved === "rejected" ? (
-          <Text size="xsmall" className="text-ui-fg-muted">
-            Cancelled.
-          </Text>
-        ) : (
-          <div className="flex justify-end gap-x-2 pt-1">
-            <Button
-              size="small"
-              variant="secondary"
-              onClick={() => setResolved("rejected")}
-              disabled={confirming}
-            >
-              Cancel
-            </Button>
-            <Button size="small" onClick={onApprove} isLoading={confirming}>
-              Approve &amp; run
-            </Button>
-          </div>
-        )}
+        <div className="flex justify-end gap-x-2 pt-1">
+          <Button
+            size="small"
+            variant="secondary"
+            onClick={onCancel}
+            disabled={confirming}
+          >
+            Cancel
+          </Button>
+          <Button size="small" onClick={onApprove} isLoading={confirming}>
+            Approve &amp; run
+          </Button>
+        </div>
+      </div>
+    )
+  }
+
+  // Declined by the partner — not a failure, and nothing ran.
+  if (out?.cancelled) {
+    return (
+      <div className="border border-ui-border-base rounded-lg px-3 py-2 bg-ui-bg-base flex items-center gap-x-1.5">
+        <XMarkMini className="text-ui-fg-muted" />
+        <Text size="xsmall" className="text-ui-fg-muted capitalize">
+          Cancelled: {label} — nothing ran.
+        </Text>
       </div>
     )
   }


### PR DESCRIPTION
## The bug

Reported from the partner assistant: the approval card appears, the partner presses **Approve & run**, the product **is created** — and the assistant's reply on screen is still *"I'm ready to create the Ikat grid patterns pashmina product… Please confirm that you want me to proceed."*

It reads as the assistant jumping ahead. It is the opposite: the assistant never learned the approval happened.

## Root cause (structural, not a prompt problem)

`ToolCard` runs the approved tool **client-side** against `POST /partners/mcp` (`lib/assistant-mcp.ts`) and stored the result in **local component state only**. The chat route deliberately **strips tool parts from history** and sends the model text only (`partners/assistant/chat/route.ts:157`), so patching the tool part alone would not have reached it either. The model's last streamed words — written *before* the run, asking for the confirmation — stayed as its answer.

A second defect fell out of the same gap: the outcome was never written into the message array, so it was never persisted. **Reopening that conversation re-rendered the card as still pending** — one more click from creating the product a second time.

## The fix

New pure module `apps/partner-ui/src/lib/assistant-approval.ts`:

- **`resolveToolPart()`** — writes the executed result into the tool part (so it persists and the card cannot be re-offered) and drops the prose the model wrote *after* the card, which asked for a confirmation that has since been given. Prose *before* the card stays; anything from a later tool call onward stays.
- **`approvalNote()`** — hands the real result back as a short turn (`[approved-tool-result] …`, JSON truncated at 2k chars), the only channel that survives the text-only history. Rendered as a muted `✓ Approved · create product` status line, not a chat bubble the partner never typed.

`chat-thread.tsx`: approve/cancel lift out of `ToolCard` into the thread via `onResolved`. Cancel now persists as *"Cancelled — nothing ran"* (muted, not a red failure) instead of vanishing on reload.

System prompt (`partners/assistant/chat/route.ts`): over an approval card, reply with **one** line and stop — the card already shows the plan and the buttons, so no re-listing the spec and no *"reply yes"* (there is nothing to type). And an `[approved-tool-result]` turn means the tool **has already run**: never re-call it, never re-confirm, report the real ids/status.

## Test plan

- [x] 9 new unit tests — `apps/partner-ui/src/lib/__tests__/assistant-approval.spec.ts` (result written in, stale ask dropped, later tool calls preserved, cancel keeps prose, truncation, note round-trip)
- [x] `tsc --noEmit` clean for both apps (backend at its 74-error baseline, none in touched files)
- [x] partner-ui suite green apart from `validate-translations`, which fails identically on clean `main`
- [ ] **Not exercised through the UI** — verified by tests and reading, not by a live approval

## Watch-out

The **admin** assistant (`apps/backend/src/admin/routes/assistant/page.tsx:262`) has the identical shape — `approved` held in local `ToolPart` state, never handed back — so it carries the same bug. Deliberately left out of this PR's scope.

🤖 Generated with [Claude Code](https://claude.com/claude-code)