### PR TITLE
feat(mcp): expose the production spec as tools on both assistants (#1346)

### DIFF
--- a/apps/backend/src/api/admin/mcp/lib/__tests__/tool-tiers.unit.spec.ts
+++ b/apps/backend/src/api/admin/mcp/lib/__tests__/tool-tiers.unit.spec.ts
@@ -90,6 +90,7 @@ describe("admin MCP tool tiers", () => {
         "create_raw_material_group",
         "link_design_inventory",
         "link_design_material_group",
+        "set_product_spec",
         "update_design",
         "update_design_brief",
         "update_design_task",

--- a/apps/backend/src/api/admin/mcp/lib/registry.ts
+++ b/apps/backend/src/api/admin/mcp/lib/registry.ts
@@ -27,6 +27,11 @@
  * size is a per-request token cost.
  */
 import type { McpToolDef } from "../../../../lib/mcp-core"
+import {
+  PRODUCT_SPEC_BODY_PARAMS,
+  PRODUCT_SPEC_WRITE_GUIDANCE,
+  productSpecSchemaProps,
+} from "../../../../modules/product-spec/tool-schema"
 
 /** Admin tool definition. Alias of the shared core tool model. */
 export type AdminMcpToolDef = McpToolDef
@@ -124,6 +129,54 @@ export const ADMIN_MCP_TOOLS: AdminMcpToolDef[] = [
     path: "/admin/products/:id",
     pathParams: ["id"],
     inputSchema: obj({ id: STR("Product id, e.g. 'prod_...'.") }, ["id"]),
+  },
+
+  // ---- Production spec (#1342 / #1346): the admin mirror of the partner
+  // tools. Same module, same workflow, same weave catalog — an admin is simply
+  // not scoped to one partner's products. The catalog read is listed first
+  // because the write validates `params` against the chosen technique's ranges.
+  {
+    name: "get_spec_catalog",
+    description:
+      "List the weaving techniques a production spec can use — families, per-technique parameters with min/max/step/default, presets and default finishes. Read this BEFORE calling set_product_spec: the ranges shown here are the ranges the write enforces.",
+    method: "GET",
+    path: "/admin/products/spec-catalog",
+    inputSchema: obj({}),
+    nextSteps: ["get_product_spec", "set_product_spec"],
+  },
+  {
+    name: "get_product_spec",
+    description:
+      "Get a product's production spec — weave technique and parameters, colour palette, custom fields, custom-order availability. Returns null when nobody has written one, which is the normal state for most products.",
+    method: "GET",
+    path: "/admin/products/:id/spec",
+    pathParams: ["id"],
+    inputSchema: obj({ id: STR("Product id, e.g. 'prod_...'.") }, ["id"]),
+    nextSteps: ["set_product_spec", "get_spec_catalog"],
+  },
+  {
+    name: "set_product_spec",
+    description: `Create or update a product's production spec: weave technique + parameters, finishes, colour palette, custom fields, and custom-order availability. ${PRODUCT_SPEC_WRITE_GUIDANCE}`,
+    method: "POST",
+    path: "/admin/products/:id/spec",
+    pathParams: ["id"],
+    write: true,
+    // Confirm-gated like every other admin write, because an admin writes ANY
+    // maker's spec, not their own — the partner tool is ownership-scoped and
+    // needs no such gate. `tier: "write"` keeps that confirm from also costing
+    // a scoped credential access it should have: a spec spends no money, calls
+    // no carrier and messages nobody.
+    sensitive: true,
+    tier: "write",
+    previewPath: "/admin/products/:id/spec",
+    bodyParams: PRODUCT_SPEC_BODY_PARAMS,
+    inputSchema: obj(
+      { id: STR("Product id, e.g. 'prod_...'."), ...productSpecSchemaProps() },
+      ["id"]
+    ),
+    sideEffects:
+      "Replaces the stored palette and custom fields when those keys are passed. The spec is the maker's own record of the product — check with the partner before overwriting one they authored.",
+    nextSteps: ["get_product_spec"],
   },
 
   // ===== Customers =========================================================

--- a/apps/backend/src/api/admin/mcp/lib/tool-slice.ts
+++ b/apps/backend/src/api/admin/mcp/lib/tool-slice.ts
@@ -133,6 +133,15 @@ const DOMAIN_KEYWORDS: Record<Exclude<AdminToolDomain, "core">, string[]> = {
     "bulk", "in bulk", "all products", "every product", "whole catalogue",
     "whole catalog", "manage inventory", "manage_inventory", "track stock",
     "tracking stock", "zero",
+    // Production-spec vocabulary (#1346). The spec tools classify as catalog by
+    // route, but a maker's ask for them is phrased in loom words — "record the
+    // weave and palette for this shawl" says neither "product" nor "catalog".
+    // Classification without an activating phrase is a tool nobody can reach.
+    "spec", "specs", "specification", "production spec", "weave", "weaves",
+    "woven", "weaving", "warp", "weft", "loom", "gsm", "thread count",
+    "ends per inch", "picks per inch", "palette", "colour palette",
+    "color palette", "colours", "colors", "finish", "finishes",
+    "custom order", "custom orders", "made to order",
   ],
   customers: ["customer", "customers", "buyer", "buyers", "shopper", "shoppers"],
   partners: [

--- a/apps/backend/src/api/admin/products/[id]/spec/route.ts
+++ b/apps/backend/src/api/admin/products/[id]/spec/route.ts
@@ -1,0 +1,69 @@
+import { MedusaRequest, MedusaResponse } from "@medusajs/framework/http"
+import { ContainerRegistrationKeys, MedusaError } from "@medusajs/framework/utils"
+import { upsertProductSpecWorkflow } from "../../../../../workflows/products/upsert-product-spec"
+import { PRODUCT_SPEC_MODULE } from "../../../../../modules/product-spec"
+import type { PartnerProductSpecReqType } from "../../../../partners/products/validators"
+
+/**
+ * The admin mirror of the partner production-spec routes (#1342 / #1346).
+ *
+ * Same module, same workflow, same validator — an admin simply is not scoped to
+ * one partner's products, so `assertProductOwnership` is replaced by an
+ * existence check. That check is not ceremony: the partner route's ownership
+ * lookup is what turns a mistyped product id into a 404 there, and without it
+ * an admin (or the admin assistant) could otherwise write a spec row keyed to a
+ * product that does not exist and never see it again.
+ */
+const assertProductExists = async (req: MedusaRequest, productId: string) => {
+  const query = req.scope.resolve(ContainerRegistrationKeys.QUERY) as any
+  const { data } = await query.graph({
+    entity: "product",
+    fields: ["id"],
+    filters: { id: productId },
+  })
+  if (!data?.length) {
+    throw new MedusaError(
+      MedusaError.Types.NOT_FOUND,
+      `Product ${productId} was not found`
+    )
+  }
+}
+
+/**
+ * Read a product's production spec. `null` when none has been written — the
+ * normal state for most products, not an error.
+ *
+ * @route GET /admin/products/:id/spec
+ */
+export const GET = async (req: MedusaRequest, res: MedusaResponse) => {
+  const productId = req.params.id
+  await assertProductExists(req, productId)
+
+  const service: any = req.scope.resolve(PRODUCT_SPEC_MODULE)
+  const spec = await service.findByProduct(productId)
+
+  return res.json({ spec })
+}
+
+/**
+ * Create or update a product's production spec — weave, parameters, colour
+ * palette and custom fields.
+ *
+ * `colors` and `fields` replace what is stored when present; omitting them
+ * leaves the existing entries alone.
+ *
+ * @route POST /admin/products/:id/spec
+ */
+export const POST = async (
+  req: MedusaRequest<PartnerProductSpecReqType>,
+  res: MedusaResponse
+) => {
+  const productId = req.params.id
+  await assertProductExists(req, productId)
+
+  const { result } = await upsertProductSpecWorkflow(req.scope).run({
+    input: { product_id: productId, data: req.validatedBody },
+  })
+
+  return res.json({ spec: result })
+}

--- a/apps/backend/src/api/admin/products/spec-catalog/route.ts
+++ b/apps/backend/src/api/admin/products/spec-catalog/route.ts
@@ -1,0 +1,21 @@
+import { MedusaRequest, MedusaResponse } from "@medusajs/framework/http"
+import {
+  WEAVE_FAMILIES,
+  WEAVE_TECHNIQUES,
+} from "../../../../modules/product-spec/weaving-techniques"
+
+/**
+ * The weaving-technique catalog, admin side (#1346).
+ *
+ * Serves the same canonical module the partner route serves and the workflow
+ * validates against, so an admin assistant proposing `gsm: 900` is reading the
+ * very ranges its write will be judged by.
+ *
+ * @route GET /admin/products/spec-catalog
+ */
+export const GET = async (_req: MedusaRequest, res: MedusaResponse) => {
+  return res.json({
+    families: WEAVE_FAMILIES,
+    techniques: WEAVE_TECHNIQUES,
+  })
+}

--- a/apps/backend/src/api/middlewares.ts
+++ b/apps/backend/src/api/middlewares.ts
@@ -4908,6 +4908,18 @@ export default defineMiddlewares({
       middlewares: [],
     },
     {
+      // #1346: the admin mirror of the partner production-spec write. Shares
+      // the partner request schema deliberately — two copies of the shape a
+      // spec may take is one edit from the surfaces disagreeing about what a
+      // valid spec is, and the workflow behind both is already the single
+      // place that knows the weave ranges.
+      matcher: "/admin/products/:id/spec",
+      method: "POST",
+      middlewares: [
+        validateAndTransformBody(wrapSchema(PartnerProductSpecReq)),
+      ],
+    },
+    {
       matcher: "/admin/products/:id/linkDesign",
       method: "POST",
       middlewares: [validateAndTransformBody(wrapSchema(LinkDesignValidator))],

--- a/apps/backend/src/api/partners/mcp/lib/registry.ts
+++ b/apps/backend/src/api/partners/mcp/lib/registry.ts
@@ -22,6 +22,11 @@
  */
 
 import type { McpToolDef } from "../../../../lib/mcp-core"
+import {
+  PRODUCT_SPEC_BODY_PARAMS,
+  PRODUCT_SPEC_WRITE_GUIDANCE,
+  productSpecSchemaProps,
+} from "../../../../modules/product-spec/tool-schema"
 
 /**
  * Partner tool definition. The declarative model now lives in the shared
@@ -738,6 +743,48 @@ export const PARTNER_MCP_TOOLS: PartnerMcpToolDef[] = [
       },
       ["id"]
     ),
+  },
+
+  // ===== Production spec (#1342 / #1346) ===================================
+  // The weave and its measured parameters, the colour palette, and whatever the
+  // catalog cannot say. The catalog read is listed FIRST deliberately: the
+  // write validates `params` against the chosen technique's ranges, so a model
+  // that guesses a GSM without reading the ranges gets a rejection, not a spec.
+  {
+    name: "get_spec_catalog",
+    description:
+      "List the weaving techniques a production spec can use — families, per-technique parameters with min/max/step/default, presets and default finishes. Read this BEFORE calling set_product_spec: the ranges shown here are the ranges the write enforces.",
+    method: "GET",
+    path: "/partners/products/spec-catalog",
+    inputSchema: obj({}),
+    nextSteps: ["get_product_spec", "set_product_spec"],
+  },
+  {
+    name: "get_product_spec",
+    description:
+      "Get a product's production spec — weave technique and parameters, colour palette, custom fields, custom-order availability. Returns null when the partner has not written one, which is the normal state for most products.",
+    method: "GET",
+    path: "/partners/products/:id/spec",
+    pathParams: ["id"],
+    inputSchema: obj({ id: STR("Product id.") }, ["id"]),
+    nextSteps: ["set_product_spec", "get_spec_catalog"],
+  },
+  {
+    name: "set_product_spec",
+    description: `Create or update a product's production spec: weave technique + parameters, finishes, colour palette, partner-defined fields, and custom-order availability. ${PRODUCT_SPEC_WRITE_GUIDANCE}`,
+    method: "POST",
+    path: "/partners/products/:id/spec",
+    pathParams: ["id"],
+    write: true,
+    previewPath: "/partners/products/:id/spec",
+    bodyParams: PRODUCT_SPEC_BODY_PARAMS,
+    inputSchema: obj(
+      { id: STR("Product id."), ...productSpecSchemaProps() },
+      ["id"]
+    ),
+    sideEffects:
+      "Replaces the stored palette and custom fields when those keys are passed.",
+    nextSteps: ["get_product_spec"],
   },
 
   // ===== Partner orders (detail + fulfillment) =============================

--- a/apps/backend/src/api/partners/mcp/lib/tool-slice.ts
+++ b/apps/backend/src/api/partners/mcp/lib/tool-slice.ts
@@ -204,6 +204,15 @@ const DOMAIN_KEYWORDS: Record<Exclude<PartnerToolDomain, "core">, string[]> = {
     // the admin slicer, which carries the same list for /admin/customs.
     "hsn", "hs code", "hs codes", "hs_code", "customs", "harmonized",
     "harmonised", "tariff", "duty", "commodity code",
+    // Production-spec vocabulary (#1346). The spec tools classify as catalog by
+    // route, but a maker's ask for them is phrased in loom words — "record the
+    // weave and palette for this shawl" says neither "product" nor "catalog".
+    // Classification without an activating phrase is a tool nobody can reach.
+    "spec", "specs", "specification", "production spec", "weave", "weaves",
+    "woven", "weaving", "warp", "weft", "loom", "gsm", "thread count",
+    "ends per inch", "picks per inch", "palette", "colour palette",
+    "color palette", "colours", "colors", "finish", "finishes",
+    "custom order", "custom orders", "made to order",
   ],
   storefront: [
     "store", "stores", "storefront", "website", "web site", "page", "pages",

--- a/apps/backend/src/modules/product-spec/__tests__/spec-mcp-tools.unit.spec.ts
+++ b/apps/backend/src/modules/product-spec/__tests__/spec-mcp-tools.unit.spec.ts
@@ -1,0 +1,149 @@
+/**
+ * The production-spec tools on BOTH assistant surfaces (#1346).
+ *
+ * These assert the three things that fail silently rather than loudly:
+ *  - a tool whose path names a route that does not exist (the dispatcher is a
+ *    loopback proxy, so a typo is a 404 at call time, never at build time);
+ *  - a tool that is classified but that no ordinary ask can reach — the
+ *    "classified ≠ reachable" failure that hid four live bugs in #1315;
+ *  - a body key the validator accepts but the dispatcher does not forward, so
+ *    the write silently drops half the spec.
+ */
+import fs from "fs"
+import path from "path"
+import { ADMIN_MCP_TOOLS } from "../../../api/admin/mcp/lib/registry"
+import { PARTNER_MCP_TOOLS } from "../../../api/partners/mcp/lib/registry"
+import { selectAdminToolSlice } from "../../../api/admin/mcp/lib/tool-slice"
+import { selectPartnerToolSlice } from "../../../api/partners/mcp/lib/tool-slice"
+import { mcpToolTier } from "../../../lib/mcp-core/tiers"
+import { PartnerProductSpecReq } from "../../../api/partners/products/validators"
+import { PRODUCT_SPEC_BODY_PARAMS } from "../tool-schema"
+import { SUPPORTED_WEAVES } from "../weaving-techniques"
+
+const SPEC_TOOLS = ["get_spec_catalog", "get_product_spec", "set_product_spec"]
+
+const SURFACES = [
+  // `confirms` is the surfaces' one deliberate difference: an admin writes ANY
+  // maker's spec, so the admin registry's rule that every write is confirm-
+  // gated applies; the partner tool can only ever touch the caller's own
+  // product, which is why `set_artisan_detail` next to it is not gated either.
+  { surface: "admin", tools: ADMIN_MCP_TOOLS, prefix: "/admin", confirms: true },
+  { surface: "partner", tools: PARTNER_MCP_TOOLS, prefix: "/partners", confirms: false },
+] as const
+
+const find = (tools: readonly any[], name: string) => {
+  const matches = tools.filter((t) => t.name === name)
+  if (matches.length !== 1) {
+    throw new Error(`${name} is registered ${matches.length} times, expected 1`)
+  }
+  return matches[0]
+}
+
+/** `/admin/products/:id/spec` -> `src/api/admin/products/[id]/spec/route.ts`. */
+const routeFile = (toolPath: string) =>
+  path.join(
+    __dirname,
+    "../../../api",
+    toolPath
+      .replace(/^\//, "")
+      .split("/")
+      .map((seg) => (seg.startsWith(":") ? `[${seg.slice(1)}]` : seg))
+      .join("/"),
+    "route.ts"
+  )
+
+describe("production-spec MCP tools", () => {
+  describe.each(SURFACES)("$surface surface", ({ tools, prefix, confirms }) => {
+    it("registers all three spec tools exactly once", () => {
+      for (const name of SPEC_TOOLS) {
+        expect([name, find(tools, name).name]).toEqual([name, name])
+      }
+    })
+
+    it("points every tool at a route file that exists", () => {
+      // The dispatcher forwards to the real route; a path that names nothing is
+      // a 404 the model reports as "I can't do that", with nothing in the build
+      // or the type-checker to catch it first.
+      const missing = SPEC_TOOLS.map((name) => find(tools, name))
+        .filter((def) => !fs.existsSync(routeFile(def.path)))
+        .map((def) => def.path)
+      expect(missing).toEqual([])
+    })
+
+    it("serves the tools from its own surface's routes", () => {
+      for (const name of SPEC_TOOLS) {
+        expect(find(tools, name).path.startsWith(`${prefix}/`)).toBe(true)
+      }
+    })
+
+    it("keeps the write on the `write` rung, whatever its confirm gate", () => {
+      // The confirm gate and the permission rung are separate questions (see
+      // lib/mcp-core/tiers). A spec is reversible, costs nothing and touches
+      // nobody outside the platform, so a write-scoped credential must reach it
+      // on BOTH surfaces even where the UI still asks a human first.
+      const def = find(tools, "set_product_spec")
+      expect([def.write === true, mcpToolTier(def)]).toEqual([true, "write"])
+    })
+
+    it("gates the write behind confirm exactly where the surface demands it", () => {
+      expect(find(tools, "set_product_spec").sensitive === true).toBe(confirms)
+    })
+
+    it("reads are not writes", () => {
+      for (const name of ["get_spec_catalog", "get_product_spec"]) {
+        const def = find(tools, name)
+        expect([name, def.method, def.write === true]).toEqual([name, "GET", false])
+      }
+    })
+
+    it("forwards every body key the validator accepts", () => {
+      // A key the validator takes but `bodyParams` omits is dropped by the
+      // dispatcher: the route returns 200 and the partner's palette is simply
+      // not there.
+      const accepted = Object.keys((PartnerProductSpecReq as any).shape).sort()
+      const forwarded = [...find(tools, "set_product_spec").bodyParams].sort()
+      expect(forwarded).toEqual(accepted)
+      expect([...PRODUCT_SPEC_BODY_PARAMS].sort()).toEqual(accepted)
+    })
+
+    it("offers exactly the weave slugs the workflow will accept", () => {
+      // Derived from the catalog rather than typed out, so a technique added or
+      // removed cannot leave the model offering a value the write rejects.
+      const def = find(tools, "set_product_spec")
+      expect(def.inputSchema.properties.weave_technique.enum).toEqual([
+        ...SUPPORTED_WEAVES,
+      ])
+    })
+  })
+
+  describe("reachability from an ordinary ask", () => {
+    const ASKS = [
+      "record the weave and colour palette for this product",
+      "what production spec does prod_123 have?",
+      "set the gsm and picks per inch on this shawl",
+      "is this product accepting custom orders?",
+    ]
+
+    it.each(ASKS)("an admin asking %j gets every spec tool", (ask) => {
+      const slice = selectAdminToolSlice(ask, ADMIN_MCP_TOOLS as any)
+      const unreachable = SPEC_TOOLS.filter((n) => !slice.names.includes(n))
+      expect({ ask, unreachable }).toEqual({ ask, unreachable: [] })
+    })
+
+    it.each(ASKS)("a partner asking %j gets every spec tool", (ask) => {
+      const slice = selectPartnerToolSlice(ask, PARTNER_MCP_TOOLS as any)
+      const unreachable = SPEC_TOOLS.filter((n) => !slice.names.includes(n))
+      expect({ ask, unreachable }).toEqual({ ask, unreachable: [] })
+    })
+  })
+
+  it("names the tools identically on both surfaces", () => {
+    // The two assistants are told about the same capability; a partner asking
+    // an admin "which tool did you use?" should not get a different word.
+    for (const name of SPEC_TOOLS) {
+      const admin = find(ADMIN_MCP_TOOLS, name)
+      const partner = find(PARTNER_MCP_TOOLS, name)
+      expect([name, admin.method]).toEqual([name, partner.method])
+    }
+  })
+})

--- a/apps/backend/src/modules/product-spec/tool-schema.ts
+++ b/apps/backend/src/modules/product-spec/tool-schema.ts
@@ -1,0 +1,103 @@
+/**
+ * The MCP/assistant-facing description of a production spec (#1346).
+ *
+ * Lives with the module rather than in a registry because BOTH surfaces expose
+ * the same spec: the partner writes their own product's spec, an admin writes
+ * anyone's, and a schema kept in two registries is one edit from the two
+ * assistants believing different things about what a spec is.
+ *
+ * The weave enum is derived from the catalog, not typed out, so a technique
+ * added to `weaving-techniques.ts` is offered to the model without a second
+ * edit — and a technique removed cannot linger here as a value the workflow
+ * will reject.
+ */
+import { SUPPORTED_WEAVES } from "./weaving-techniques"
+
+/** Body keys the dispatcher forwards to the spec route, in registry order. */
+export const PRODUCT_SPEC_BODY_PARAMS = [
+  "weave_technique",
+  "weave_label",
+  "params",
+  "finishes",
+  "notes",
+  "accepting_custom_orders",
+  "custom_order_lead_time_days",
+  "colors",
+  "fields",
+]
+
+/**
+ * JSON-Schema properties for the spec body. Merged into each surface's own
+ * `obj({...})` so the surface keeps ownership of its path params (`id`) and of
+ * whether the tool is required to name a product.
+ */
+export const productSpecSchemaProps = () => ({
+  weave_technique: {
+    type: "string",
+    description:
+      "Weave technique slug from get_spec_catalog. Required before `params` — a parameter is only meaningful against a technique.",
+    enum: [...SUPPORTED_WEAVES],
+  },
+  weave_label: {
+    type: "string",
+    description:
+      "Human label for the weave when the slug alone undersells it, e.g. 'Kani twill, 8 bobbins' (≤ 160 chars).",
+  },
+  params: {
+    type: "object",
+    description:
+      "Measured parameters keyed by the catalog's param keys (gsm, ends_per_inch, picks_per_inch, warp_yarn_count, weft_yarn_count, loom_width_cm, plus technique-specific ones). Values are numbers and are REJECTED if outside the chosen technique's min/max — call get_spec_catalog first to see the ranges.",
+    additionalProperties: { type: "number" },
+  },
+  finishes: {
+    type: "array",
+    description: "Finishing steps, e.g. ['washed', 'hand-fringed'] (≤ 20).",
+    items: { type: "string" },
+  },
+  notes: { type: "string", description: "Free-text spec notes (≤ 5000 chars)." },
+  accepting_custom_orders: {
+    type: "boolean",
+    description: "Whether the maker will take custom orders against this spec.",
+  },
+  custom_order_lead_time_days: {
+    type: "integer",
+    description: "Lead time in days for a custom order (0–3650).",
+  },
+  colors: {
+    type: "array",
+    description:
+      "The colour palette. REPLACES the stored palette wholesale when passed — omit the key to leave it alone, pass [] to delete every colour. Max 60.",
+    items: {
+      type: "object",
+      properties: {
+        name: { type: "string", description: "Colour name, e.g. 'Saffron'." },
+        hex_code: { type: "string", description: "Hex code, e.g. '#C9A227'." },
+        usage_notes: { type: "string", description: "Where the colour is used (≤ 500 chars)." },
+        order: { type: "integer", description: "Display order (0–999)." },
+        available: { type: "boolean", description: "Whether the colour can be ordered." },
+      },
+      required: ["name"],
+      additionalProperties: false,
+    },
+  },
+  fields: {
+    type: "array",
+    description:
+      "Partner-defined spec fields for anything the catalog doesn't cover. REPLACES the stored fields wholesale when passed — omit to leave alone, pass [] to delete all. Max 40.",
+    items: {
+      type: "object",
+      properties: {
+        key: { type: "string", description: "Field key, e.g. 'border_width' (≤ 60 chars)." },
+        label: { type: "string", description: "Display label (≤ 120 chars)." },
+        value: { type: "string", description: "Field value (≤ 500 chars)." },
+        order: { type: "integer", description: "Display order (0–999)." },
+      },
+      required: ["key"],
+      additionalProperties: false,
+    },
+  },
+})
+
+/** Shared guidance appended to the write tool's description on both surfaces. */
+export const PRODUCT_SPEC_WRITE_GUIDANCE =
+  "Call get_spec_catalog first: `params` are validated against the CHOSEN technique's min/max and the whole write is rejected if any value is out of range. `colors` and `fields` REPLACE what is stored when passed, so send the full list, not just the additions."


### PR DESCRIPTION
Closes #1346. Follows #1342, which shipped the spec but left it unreachable from either assistant.

## What

Three tools on **each** surface (partner + admin), same names on both:

| tool | route (partner / admin) |
|---|---|
| `get_spec_catalog` | `/partners/products/spec-catalog` · `/admin/products/spec-catalog` |
| `get_product_spec` | `/partners/products/:id/spec` · `/admin/products/:id/spec` |
| `set_product_spec` | same, POST |

The catalog read is listed first deliberately — the write validates `params` against the **chosen** technique's min/max, so a model that guesses a GSM without reading the ranges gets a rejection, not a spec.

## The admin half is new backend

The admin surface had no spec route at all. `GET|POST /admin/products/:id/spec` and `GET /admin/products/spec-catalog` reuse the same module, workflow and validator; `assertProductOwnership` has no admin meaning so it becomes a product-**exists** check — the partner ownership lookup is what turns a mistyped id into a 404, and without a replacement an admin could write a spec keyed to a product that does not exist.

## Two judgement calls worth reviewing

- **Confirm gate ≠ permission rung.** The admin registry pins "every admin write is confirm-gated" and this write honours it (an admin writes *any* maker's spec). It carries `tier: "write"` so that confirm does not also cost a scoped credential access it should have — no money, no carrier, no third-party message. The partner tool is ungated, matching `set_artisan_detail` beside it: it can only touch the caller's own product.
- **Classified ≠ reachable** (#1315). The tools classify as `catalog` by route for free, but "record the weave and palette for this shawl" says neither *product* nor *catalog*. Both slicers gain the loom vocabulary, and four such asks are asserted to load all three tools.

## Tests

23 new, aimed at what fails silently:
- every tool path resolves to a route file **on disk** (the dispatcher is a loopback proxy — a typo is a 404 at call time, never at build time);
- forwarded `bodyParams` **equal** the keys the validator accepts (a missing one drops the palette at a 200);
- the weave enum equals `SUPPORTED_WEAVES` (derived from the catalog, not typed out);
- the rung is `write` on both surfaces, and the confirm gate is present exactly where the surface demands it.

`pnpm check:prod-build` passes · `tsc` at the 74-error baseline · unit suite at the known 4-suite / 5-test red baseline, unchanged.

## Not done here

Never run through either assistant with a live model — that is the verification #1346 stays open for.

🤖 Generated with [Claude Code](https://claude.com/claude-code)