### PR TITLE
fix(mcp): make create_storefront_page satisfy its own route

### DIFF
--- a/apps/backend/src/api/admin/websites/[id]/pages/validators.ts
+++ b/apps/backend/src/api/admin/websites/[id]/pages/validators.ts
@@ -1,26 +1,36 @@
 import { z } from "@medusajs/framework/zod";
 
+/**
+ * The page vocabulary, exported so the surfaces that OFFER these values read
+ * the same list the validator enforces.
+ *
+ * Capitalised, and that matters: the MCP tool row advertised `page_type: 'home'`
+ * and `status: 'published'` in its description while this enum only ever
+ * accepted "Home"/"Published", and the theme-chat tools kept a third copy of
+ * the list. A value a caller is invited to send and the route then rejects is
+ * indistinguishable, from the caller's side, from the feature being broken.
+ */
+export const PAGE_TYPES = [
+  "Home",
+  "About",
+  "Contact",
+  "Blog",
+  "Product",
+  "Service",
+  "Portfolio",
+  "Landing",
+  "Custom",
+  "Newsletter",
+] as const
+
+export const PAGE_STATUSES = ["Draft", "Published", "Archived"] as const
+
 const pageBaseSchema = z.object({
   title: z.string().min(1, "Title is required"),
   slug: z.string().min(1, "Slug is required"),
   content: z.string().min(1, "Content is required"),
-  page_type: z.enum([
-    "Home",
-    "About",
-    "Contact",
-    "Blog",
-    "Product",
-    "Service",
-    "Portfolio",
-    "Landing",
-    "Custom",
-    "Newsletter"
-  ]).optional(),
-  status: z.enum([
-    "Draft",
-    "Published",
-    "Archived"
-  ]).optional(),
+  page_type: z.enum(PAGE_TYPES).optional(),
+  status: z.enum(PAGE_STATUSES).optional(),
   meta_title: z.string().optional(),
   meta_description: z.string().optional(),
   meta_keywords: z.string().optional(),

--- a/apps/backend/src/api/partners/mcp/lib/registry.ts
+++ b/apps/backend/src/api/partners/mcp/lib/registry.ts
@@ -27,6 +27,11 @@ import {
   PRODUCT_SPEC_WRITE_GUIDANCE,
   productSpecSchemaProps,
 } from "../../../../modules/product-spec/tool-schema"
+// The page vocabulary comes from the validator that enforces it, never a copy.
+import {
+  PAGE_STATUSES,
+  PAGE_TYPES,
+} from "../../../admin/websites/[id]/pages/validators"
 
 /**
  * Partner tool definition. The declarative model now lives in the shared
@@ -64,6 +69,23 @@ const obj = (
   ...(required.length ? { required } : {}),
   additionalProperties: false,
 })
+
+/**
+ * Page vocabulary, taken from the route's validator rather than restated, so
+ * the values offered are exactly the values accepted.
+ */
+const PAGE_TYPE_ENUM = {
+  type: "string",
+  description: "Page type. Capitalised — these are the only accepted values.",
+  enum: [...PAGE_TYPES],
+} as const
+
+const PAGE_STATUS_ENUM = {
+  type: "string",
+  description:
+    "Page status. Capitalised. 'Published' is LIVE on the storefront; new pages should be 'Draft' unless the partner asked to publish.",
+  enum: [...PAGE_STATUSES],
+} as const
 
 /** Unit-of-measure enum shared by consumption-log tools. */
 const UOM = {
@@ -1226,46 +1248,72 @@ export const PARTNER_MCP_TOOLS: PartnerMcpToolDef[] = [
     pathParams: ["pageId"],
     inputSchema: obj({ pageId: STR("Page id.") }, ["pageId"]),
   },
+  // The two page writes below mirror `postPagesSchema` / `updatePageSchema`
+  // field for field. They did not, and the gap was invisible from here: the row
+  // never mentioned `content` (which the route REQUIRES), never required
+  // `slug`, offered lowercase 'home'/'published' against a capitalised enum,
+  // and advertised a `blocks` array that zod strips on the way through. Every
+  // create attempt came back "Field 'content' is required" — a tool that could
+  // not satisfy its own route no matter what the model sent.
   {
     name: "create_storefront_page",
-    description: "Create a storefront page (title, slug, page_type, status). The route validator is the source of truth.",
+    description:
+      "Create a storefront page. `content` is REQUIRED — it is the page's body text, and the route rejects the call without it. Blocks are NOT part of this call: create the page, then use the page-block tools to lay it out. Call list_storefront_pages first so you do not reuse an existing slug.",
     method: "POST",
     path: "/partners/storefront/pages",
     write: true,
-    bodyParams: ["title", "slug", "page_type", "status", "blocks", "metadata"],
+    bodyParams: [
+      "title", "slug", "content", "page_type", "status",
+      "meta_title", "meta_description", "meta_keywords", "metadata",
+    ],
     inputSchema: obj(
       {
         title: STR("Page title."),
-        slug: STR("URL slug."),
-        page_type: STR("Page type, e.g. 'home'."),
-        status: STR("Optional status, e.g. 'published'."),
-        blocks: { type: "array", items: { type: "object", additionalProperties: true } },
+        slug: STR("URL slug: lowercase-with-hyphens, no leading slash."),
+        content: STR("The page's body text. Required, and must not be empty — write real copy, not a placeholder."),
+        page_type: PAGE_TYPE_ENUM,
+        status: PAGE_STATUS_ENUM,
+        meta_title: STR("Optional SEO title."),
+        meta_description: STR("Optional one-sentence search snippet."),
+        meta_keywords: STR("Optional comma-separated keywords."),
         metadata: { type: "object", additionalProperties: true },
       },
-      ["title"]
+      ["title", "slug", "content"]
     ),
+    sideEffects:
+      "A page created with status 'Published' is immediately visible on the live storefront. Omit status (or send 'Draft') unless the partner asked to publish.",
+    nextSteps: ["get_storefront_page", "list_storefront_page_blocks"],
   },
   {
     name: "update_storefront_page",
-    description: "Update a storefront page (title, slug, status, blocks). Pass only the fields to change.",
+    description:
+      "Update a storefront page. Every field is optional here — pass only what changes. Blocks are NOT part of this call; use the page-block tools.",
     method: "PUT",
     path: "/partners/storefront/pages/:pageId",
     pathParams: ["pageId"],
     write: true,
     previewPath: "/partners/storefront/pages/:pageId",
-    bodyParams: ["title", "slug", "page_type", "status", "blocks", "metadata"],
+    bodyParams: [
+      "title", "slug", "content", "page_type", "status",
+      "meta_title", "meta_description", "meta_keywords", "metadata",
+    ],
     inputSchema: obj(
       {
         pageId: STR("Page id to update."),
         title: STR("Page title."),
-        slug: STR("URL slug."),
-        page_type: STR("Page type."),
-        status: STR("Status."),
-        blocks: { type: "array", items: { type: "object", additionalProperties: true } },
+        slug: STR("URL slug: lowercase-with-hyphens, no leading slash."),
+        content: STR("The page's body text. Must not be empty if sent."),
+        page_type: PAGE_TYPE_ENUM,
+        status: PAGE_STATUS_ENUM,
+        meta_title: STR("Optional SEO title."),
+        meta_description: STR("Optional one-sentence search snippet."),
+        meta_keywords: STR("Optional comma-separated keywords."),
         metadata: { type: "object", additionalProperties: true },
       },
       ["pageId"]
     ),
+    sideEffects:
+      "Setting status to 'Published' makes the page live immediately; setting it to 'Draft' or 'Archived' takes a live page down.",
   },
   {
     name: "get_storefront_domain",

--- a/apps/backend/src/api/partners/storefront/__tests__/page-tool-contract.unit.spec.ts
+++ b/apps/backend/src/api/partners/storefront/__tests__/page-tool-contract.unit.spec.ts
@@ -1,0 +1,130 @@
+/**
+ * The storefront page tools against the validator they actually post to.
+ *
+ * `create_storefront_page` failed EVERY call with
+ * `Field 'content' is required`: the registry row never mentioned `content`,
+ * so the tool could not satisfy its own route no matter what the model sent —
+ * `content` was absent from `bodyParams` too, so even a model that guessed
+ * right had the field stripped by the dispatcher on the way out.
+ *
+ * That is not a typo, it is a missing contract. These tests assert the tool
+ * rows and the zod schema agree on three things a caller cannot discover for
+ * itself: which fields are required, which fields survive the dispatcher, and
+ * which literal values the enums accept.
+ */
+import { PARTNER_MCP_TOOLS } from "../../mcp/lib/registry"
+import {
+  PAGE_TYPES,
+  PAGE_STATUSES,
+  postPagesSchema,
+  updatePageSchema,
+} from "../../../admin/websites/[id]/pages/validators"
+
+const tool = (name: string) => {
+  const def = PARTNER_MCP_TOOLS.find((t) => t.name === name)
+  if (!def) throw new Error(`${name} is not registered`)
+  return def as any
+}
+
+/** The keys a zod object schema requires (no default, not optional). */
+const requiredKeys = (shape: Record<string, any>) =>
+  Object.entries(shape)
+    .filter(([, v]) => !v.isOptional?.())
+    .map(([k]) => k)
+    .sort()
+
+// postPagesSchema is a union of "one page" and "{ pages: [...] }"; the tool
+// posts a single page, so that is the member its contract must match.
+const pageShape = (postPagesSchema as any).options[0].shape
+
+describe("create_storefront_page ↔ postPagesSchema", () => {
+  const def = tool("create_storefront_page")
+
+  it("requires every field the route requires", () => {
+    // The bug, stated as a test: `content` is required by the route and was
+    // absent here, so the tool 400'd on every call.
+    const missing = requiredKeys(pageShape).filter(
+      (k) => !(def.inputSchema.required ?? []).includes(k)
+    )
+    expect(missing).toEqual([])
+  })
+
+  it("forwards every field it asks for", () => {
+    // A field in inputSchema but not bodyParams is silently dropped by the
+    // dispatcher — the model does everything right and the route still 400s.
+    const declared = Object.keys(def.inputSchema.properties).filter(
+      (k) => !(def.pathParams ?? []).includes(k)
+    )
+    const dropped = declared.filter((k) => !def.bodyParams.includes(k))
+    expect(dropped).toEqual([])
+  })
+
+  it("only forwards fields the validator accepts", () => {
+    // `blocks` was advertised here and stripped by zod on arrival: the model
+    // sends a laid-out page, the route stores a blank one, nothing errors.
+    const unknown = def.bodyParams.filter((k: string) => !(k in pageShape))
+    expect(unknown).toEqual([])
+  })
+
+  it("offers exactly the enum values the route accepts", () => {
+    expect(def.inputSchema.properties.page_type.enum).toEqual([...PAGE_TYPES])
+    expect(def.inputSchema.properties.status.enum).toEqual([...PAGE_STATUSES])
+  })
+
+  it("does not describe the values in the wrong case", () => {
+    // The row used to say "e.g. 'home'" / "e.g. 'published'" against a
+    // capitalised enum — an invitation to a 400.
+    expect(def.description).not.toMatch(/'home'|'published'/)
+  })
+
+  it("passes a realistic model payload through the real validator", () => {
+    const payload = {
+      title: "About us",
+      slug: "about-us",
+      content: "We are a weaving collective in Kashmir.",
+      page_type: "About",
+      status: "Draft",
+    }
+    expect(() => postPagesSchema.parse(payload)).not.toThrow()
+  })
+
+  it("still rejects the payload the tool used to send", () => {
+    // Exactly what the old row could produce: no content, no slug, lowercase
+    // page_type. If this ever passes, the validator moved and the tool's
+    // required list should move with it.
+    expect(() =>
+      postPagesSchema.parse({ title: "About us", page_type: "about" })
+    ).toThrow()
+  })
+})
+
+describe("update_storefront_page ↔ updatePageSchema", () => {
+  const def = tool("update_storefront_page")
+
+  it("forwards every field it asks for, and nothing the validator drops", () => {
+    const shape = (updatePageSchema as any).shape
+    const declared = Object.keys(def.inputSchema.properties).filter(
+      (k) => !(def.pathParams ?? []).includes(k)
+    )
+    expect(declared.filter((k) => !def.bodyParams.includes(k))).toEqual([])
+    expect(def.bodyParams.filter((k: string) => !(k in shape))).toEqual([])
+  })
+
+  it("offers exactly the enum values the route accepts", () => {
+    expect(def.inputSchema.properties.page_type.enum).toEqual([...PAGE_TYPES])
+    expect(def.inputSchema.properties.status.enum).toEqual([...PAGE_STATUSES])
+  })
+})
+
+describe("one page vocabulary", () => {
+  it("is defined once and imported, never restated", () => {
+    // The theme-chat tools kept a third copy of PAGE_TYPES; the registry kept
+    // a fourth in prose. Both now read this list.
+    const pageTools = require("fs").readFileSync(
+      require("path").join(__dirname, "../website/theme/chat/page-tools.ts"),
+      "utf8"
+    )
+    expect(pageTools).toContain("import { PAGE_TYPES }")
+    expect(pageTools).not.toMatch(/const PAGE_TYPES = \[/)
+  })
+})

--- a/apps/backend/src/api/partners/storefront/website/theme/chat/page-tools.ts
+++ b/apps/backend/src/api/partners/storefront/website/theme/chat/page-tools.ts
@@ -38,6 +38,7 @@ import { createPageWorkflow } from "../../../../../../workflows/website/website-
 import { listPageWorkflow } from "../../../../../../workflows/website/website-page/list-page"
 import { createBatchBlocksWorkflow } from "../../../../../../workflows/website/page-blocks/create-batch-blocks"
 import { listBlocksWorkflow } from "../../../../../../workflows/website/page-blocks/list-blocks"
+import { PAGE_TYPES } from "../../../../../admin/websites/[id]/pages/validators"
 
 /** Prose the model needs in its system prompt to use these tools well. */
 export const PAGE_TOOL_DESCRIPTION = `## Website Pages
@@ -83,18 +84,8 @@ const blockSchema = z.object({
     .describe("Block content. Hero uses title/subtitle/align; Main uses title/body."),
 })
 
-const PAGE_TYPES = [
-  "Home",
-  "About",
-  "Contact",
-  "Blog",
-  "Product",
-  "Service",
-  "Portfolio",
-  "Landing",
-  "Custom",
-  "Newsletter",
-] as const
+// One list, owned by the validator that enforces it — this file used to keep
+// its own copy, which is how the MCP row ended up advertising a third.
 
 /** Slug hygiene — the model writes prose, not URL segments. */
 const normalizeSlug = (raw: string): string =>


### PR DESCRIPTION
Fixes the error partners were hitting on every page creation:

```
Failed: Create Storefront Page
Error calling create_storefront_page (/partners/storefront/pages):
Route /partners/storefront/pages responded 400: Invalid request: Field 'content' is required
```

## Root cause

The registry row and `postPagesSchema` had drifted in four ways, none of them visible from the tool side:

| | row said | route wants |
|---|---|---|
| `content` | **absent entirely** — not in `inputSchema`, not in `bodyParams` | **required**, min length 1 |
| `slug` | optional | **required** |
| `page_type` | free string, *"e.g. `'home'`"* | capitalised enum — `'Home'` |
| `status` | free string, *"e.g. `'published'`"* | capitalised enum — `'Published'` |
| `blocks` | advertised as an array | **silently stripped by zod** |

`content` being missing from `bodyParams` is the part that made this unfixable from the model's side: `bodyParams` is the dispatcher's forward list, so even a model that guessed the field had it dropped on the way out. The tool could not satisfy its own route no matter what it sent.

`blocks` is the quiet one — the model sends a laid-out page, the route stores a blank one, and nothing errors.

## The fix

`PAGE_TYPES` / `PAGE_STATUSES` are now exported from the validator that enforces them and imported by both the registry and the theme-chat page tools, which kept a **third** copy of the list. A value a caller is invited to send and the route then rejects is indistinguishable, from the caller's side, from the feature being broken.

`update_storefront_page` had the same enum and `blocks` problems and is fixed alongside. Both rows gained the `meta_*` fields the validator already accepts, and a `sideEffects` line — `status: "Published"` puts a page on the live storefront immediately.

## Tests

10, asserting the **contract** rather than this instance, so the next field added to the validator fails loudly here:

- every field the zod schema requires appears in the tool's required list (this is the bug, as a test);
- every field the tool declares is actually forwarded by `bodyParams`;
- nothing is forwarded that the validator would strip;
- the tool enums **equal** the zod enums;
- a realistic model payload parses, and the payload the old row could produce still throws.

## Not touched

The theme-chat `create_page` writes `content: ""` directly through the workflow, bypassing the validator — so the two paths disagree about whether content may be empty. `postPagesSchema` is shared with `/admin/websites/:id/pages`, so relaxing it is a separate decision.

`check:prod-build` passes · tsc at the 74 baseline · unit suite at the known red baseline.

🤖 Generated with [Claude Code](https://claude.com/claude-code)