### PR TITLE
feat(product-spec): read/edit split on both surfaces, and made-to-order on the storefront (#1349)

### DIFF
--- a/apps/backend/src/admin/components/product-spec-form.tsx
+++ b/apps/backend/src/admin/components/product-spec-form.tsx
@@ -1,0 +1,514 @@
+import {
+  Button,
+  Checkbox,
+  Heading,
+  IconButton,
+  Input,
+  Label,
+  Select,
+  Switch,
+  Text,
+  Textarea,
+} from "@medusajs/ui"
+import { Plus, Trash, XMarkMini } from "@medusajs/icons"
+import { useMemo } from "react"
+
+import type {
+  ProductSpecColor,
+  ProductSpecField,
+  ProductSpecPayload,
+  WeaveTechnique,
+} from "../hooks/api/product-spec"
+
+/**
+ * The product-spec editor (#1342 / #1349), ADMIN copy.
+ *
+ * This is a deliberate port of `apps/partner-ui/src/components/forms/
+ * product-spec-form`, not an import: partner-ui and the admin extension are
+ * separate builds with separate tsconfigs, and the backend's `tsconfig`
+ * excludes `apps/*` outright, so there is no module either side can share.
+ *
+ * What keeps the two from drifting is NOT this file — it is that both generate
+ * every weave, preset, parameter and range from `/…/products/spec-catalog`,
+ * served by the same `weaving-techniques.ts` the upsert workflow validates
+ * against. A range shown here is the range enforced on write, on both surfaces.
+ * Only the chrome is duplicated; the vocabulary has one owner.
+ *
+ * Fully CONTROLLED, so the host decides where the value lives and when it saves.
+ */
+
+export type ProductSpecFormProps = {
+  value: ProductSpecPayload
+  onChange: (next: ProductSpecPayload) => void
+  techniques?: WeaveTechnique[]
+  families?: string[]
+  isLoading?: boolean
+  /** Hidden in the create wizard: a product with no orders yet cannot sensibly
+   *  be "accepting custom orders" until it has been saved. */
+  showCustomOrderSection?: boolean
+}
+
+const emptyColor = (order: number): ProductSpecColor => ({
+  name: "",
+  hex_code: "#C9A227",
+  usage_notes: "",
+  order,
+  available: true,
+})
+
+const emptyField = (order: number): ProductSpecField => ({
+  key: "",
+  label: "",
+  value: "",
+  order,
+})
+
+export const ProductSpecForm = ({
+  value,
+  onChange,
+  techniques = [],
+  families = [],
+  isLoading,
+  showCustomOrderSection = true,
+}: ProductSpecFormProps) => {
+  const technique = useMemo(
+    () => techniques.find((t) => t.slug === value.weave_technique),
+    [techniques, value.weave_technique]
+  )
+
+  const grouped = useMemo(() => {
+    const order = families.length
+      ? families
+      : Array.from(new Set(techniques.map((t) => t.family)))
+    return order
+      .map((family) => ({
+        family,
+        items: techniques.filter((t) => t.family === family),
+      }))
+      .filter((g) => g.items.length)
+  }, [families, techniques])
+
+  const patch = (next: Partial<ProductSpecPayload>) =>
+    onChange({ ...value, ...next })
+
+  /**
+   * Changing technique clears the params. Keeping them would silently carry a
+   * value the new technique does not define, which the backend then rejects on
+   * save with a message about a field the partner can no longer see.
+   */
+  const selectTechnique = (slug: string) => {
+    const next = techniques.find((t) => t.slug === slug)
+    patch({
+      weave_technique: slug || null,
+      params: next
+        ? Object.fromEntries(next.params.map((p) => [p.key, p.default]))
+        : null,
+      finishes: value.finishes?.length ? value.finishes : next?.defaultFinishes ?? [],
+    })
+  }
+
+  const applyPreset = (presetValue: string) => {
+    const preset = technique?.presets.find((p) => p.value === presetValue)
+    if (!preset) return
+    patch({
+      weave_label: preset.detailLabel,
+      params: { ...(value.params ?? {}), ...(preset.params ?? {}) },
+      ...(preset.finishes ? { finishes: preset.finishes } : {}),
+    })
+  }
+
+  const setParam = (key: string, raw: string) => {
+    const params = { ...(value.params ?? {}) }
+    if (raw.trim() === "") {
+      // Blank clears the parameter rather than storing 0 — an unmeasured GSM
+      // and a GSM of zero are very different claims to make to a customer.
+      delete params[key]
+    } else {
+      params[key] = Number(raw)
+    }
+    patch({ params })
+  }
+
+  const colors = value.colors ?? []
+  const fields = value.fields ?? []
+
+  const setColor = (i: number, next: Partial<ProductSpecColor>) =>
+    patch({ colors: colors.map((c, j) => (i === j ? { ...c, ...next } : c)) })
+
+  const setField = (i: number, next: Partial<ProductSpecField>) =>
+    patch({ fields: fields.map((f, j) => (i === j ? { ...f, ...next } : f)) })
+
+  return (
+    <div className="flex flex-col gap-y-8">
+      {/* ── Weave ──────────────────────────────────────────────────────── */}
+      <section className="flex flex-col gap-y-4">
+        <div>
+          <Heading level="h2">Weave</Heading>
+          <Text size="small" className="text-ui-fg-subtle">
+            How the cloth is made. Everything here is optional — fill in what you
+            know, and add anything the list is missing further down.
+          </Text>
+        </div>
+
+        <div className="grid gap-4 md:grid-cols-2">
+          <div className="flex flex-col gap-y-2">
+            <Label size="small" weight="plus">
+              Technique
+            </Label>
+            <Select
+              value={value.weave_technique ?? ""}
+              onValueChange={selectTechnique}
+              disabled={isLoading || !techniques.length}
+            >
+              <Select.Trigger>
+                <Select.Value placeholder="Choose a weave" />
+              </Select.Trigger>
+              <Select.Content>
+                {grouped.map((group) => (
+                  <Select.Group key={group.family}>
+                    <Select.Label>{group.family}</Select.Label>
+                    {group.items.map((t) => (
+                      <Select.Item key={t.slug} value={t.slug}>
+                        {t.label}
+                      </Select.Item>
+                    ))}
+                  </Select.Group>
+                ))}
+              </Select.Content>
+            </Select>
+            {technique && (
+              <Text size="xsmall" className="text-ui-fg-muted">
+                {technique.description}
+              </Text>
+            )}
+          </div>
+
+          <div className="flex flex-col gap-y-2">
+            <Label size="small" weight="plus">
+              Your name for it
+            </Label>
+            <Input
+              placeholder="Kani, 3-colour, Srinagar loom"
+              value={value.weave_label ?? ""}
+              onChange={(e) => patch({ weave_label: e.target.value })}
+            />
+            <Text size="xsmall" className="text-ui-fg-muted">
+              Shown instead of the catalog name when set.
+            </Text>
+          </div>
+        </div>
+
+        {!!technique?.presets.length && (
+          <div className="flex flex-wrap items-center gap-2">
+            <Text size="xsmall" className="text-ui-fg-muted">
+              Start from:
+            </Text>
+            {technique.presets.map((p) => (
+              <Button
+                key={p.value}
+                type="button"
+                size="small"
+                variant="secondary"
+                onClick={() => applyPreset(p.value)}
+              >
+                {p.label}
+              </Button>
+            ))}
+          </div>
+        )}
+
+        {!!technique?.params.length && (
+          <div className="grid gap-4 md:grid-cols-3">
+            {technique.params.map((p) => (
+              <div key={p.key} className="flex flex-col gap-y-2">
+                <Label size="small" weight="plus">
+                  {p.label}
+                </Label>
+                <div className="flex items-center gap-x-2">
+                  <Input
+                    type="number"
+                    min={p.min}
+                    max={p.max}
+                    step={p.step}
+                    placeholder={String(p.default)}
+                    value={value.params?.[p.key] ?? ""}
+                    onChange={(e) => setParam(p.key, e.target.value)}
+                  />
+                  <Text size="xsmall" className="text-ui-fg-muted shrink-0">
+                    {p.unit}
+                  </Text>
+                </div>
+                <Text size="xsmall" className="text-ui-fg-muted">
+                  {p.min}–{p.max}
+                </Text>
+              </div>
+            ))}
+          </div>
+        )}
+
+        {!!value.finishes?.length && (
+          <div className="flex flex-col gap-y-2">
+            <Label size="small" weight="plus">
+              Finishing &amp; care
+            </Label>
+            <div className="flex flex-wrap gap-2">
+              {value.finishes.map((f, i) => (
+                <span
+                  key={`${f}-${i}`}
+                  className="flex items-center gap-x-1 rounded-full border border-ui-border-base bg-ui-bg-subtle px-2.5 py-1"
+                >
+                  <Text size="xsmall">{f}</Text>
+                  <IconButton
+                    type="button"
+                    size="2xsmall"
+                    variant="transparent"
+                    aria-label={`Remove ${f}`}
+                    onClick={() =>
+                      patch({
+                        finishes: (value.finishes ?? []).filter(
+                          (_, j) => j !== i
+                        ),
+                      })
+                    }
+                  >
+                    <XMarkMini />
+                  </IconButton>
+                </span>
+              ))}
+            </div>
+          </div>
+        )}
+        <FinishInput
+          onAdd={(f) => patch({ finishes: [...(value.finishes ?? []), f] })}
+        />
+      </section>
+
+      {/* ── Colour palette ─────────────────────────────────────────────── */}
+      <section className="flex flex-col gap-y-4">
+        <div>
+          <Heading level="h2">Colour palette</Heading>
+          <Text size="small" className="text-ui-fg-subtle">
+            The colours this can be made in. A customer ordering a custom piece
+            chooses from these.
+          </Text>
+        </div>
+
+        {colors.map((c, i) => (
+          <div
+            key={i}
+            className="grid items-end gap-3 rounded-lg border border-ui-border-base p-3 md:grid-cols-[auto_1fr_1fr_auto_auto]"
+          >
+            <div className="flex flex-col gap-y-2">
+              <Label size="small" weight="plus">
+                Colour
+              </Label>
+              {/* A native colour input: the swatch IS the control, which is
+                  faster than typing a hex and is what a weaver expects. */}
+              <input
+                type="color"
+                aria-label={`Colour for ${c.name || `entry ${i + 1}`}`}
+                value={c.hex_code || "#CCCCCC"}
+                onChange={(e) => setColor(i, { hex_code: e.target.value })}
+                className="h-8 w-12 cursor-pointer rounded border border-ui-border-base bg-ui-bg-field"
+              />
+            </div>
+            <div className="flex flex-col gap-y-2">
+              <Label size="small" weight="plus">
+                Name
+              </Label>
+              <Input
+                placeholder="Kashmiri walnut"
+                value={c.name}
+                onChange={(e) => setColor(i, { name: e.target.value })}
+              />
+            </div>
+            <div className="flex flex-col gap-y-2">
+              <Label size="small" weight="plus">
+                Used for
+              </Label>
+              <Input
+                placeholder="Border only"
+                value={c.usage_notes ?? ""}
+                onChange={(e) => setColor(i, { usage_notes: e.target.value })}
+              />
+            </div>
+            <div className="flex items-center gap-x-2 pb-2">
+              <Checkbox
+                id={`color-available-${i}`}
+                checked={c.available !== false}
+                onCheckedChange={(v) => setColor(i, { available: !!v })}
+              />
+              <Label size="small" htmlFor={`color-available-${i}`}>
+                Available
+              </Label>
+            </div>
+            <IconButton
+              type="button"
+              size="small"
+              variant="transparent"
+              aria-label={`Remove ${c.name || "colour"}`}
+              onClick={() => patch({ colors: colors.filter((_, j) => j !== i) })}
+            >
+              <Trash />
+            </IconButton>
+          </div>
+        ))}
+
+        <div>
+          <Button
+            type="button"
+            size="small"
+            variant="secondary"
+            onClick={() => patch({ colors: [...colors, emptyColor(colors.length)] })}
+          >
+            <Plus />
+            Add colour
+          </Button>
+        </div>
+      </section>
+
+      {/* ── Partner-defined fields ─────────────────────────────────────── */}
+      <section className="flex flex-col gap-y-4">
+        <div>
+          <Heading level="h2">Anything else</Heading>
+          <Text size="small" className="text-ui-fg-subtle">
+            Specs the list above doesn't cover — write them in your own words.
+          </Text>
+        </div>
+
+        {fields.map((f, i) => (
+          <div
+            key={i}
+            className="grid items-end gap-3 rounded-lg border border-ui-border-base p-3 md:grid-cols-[1fr_1fr_auto]"
+          >
+            <div className="flex flex-col gap-y-2">
+              <Label size="small" weight="plus">
+                Spec
+              </Label>
+              <Input
+                placeholder="Pallu type"
+                value={f.label ?? ""}
+                onChange={(e) =>
+                  // The label is what the partner wrote; the key is derived from
+                  // it (and normalised again server-side) so the same spec on two
+                  // products can be compared.
+                  setField(i, { label: e.target.value, key: e.target.value })
+                }
+              />
+            </div>
+            <div className="flex flex-col gap-y-2">
+              <Label size="small" weight="plus">
+                Value
+              </Label>
+              <Input
+                placeholder="Woven, 18 inches"
+                value={f.value ?? ""}
+                onChange={(e) => setField(i, { value: e.target.value })}
+              />
+            </div>
+            <IconButton
+              type="button"
+              size="small"
+              variant="transparent"
+              aria-label={`Remove ${f.label || "field"}`}
+              onClick={() => patch({ fields: fields.filter((_, j) => j !== i) })}
+            >
+              <Trash />
+            </IconButton>
+          </div>
+        ))}
+
+        <div>
+          <Button
+            type="button"
+            size="small"
+            variant="secondary"
+            onClick={() => patch({ fields: [...fields, emptyField(fields.length)] })}
+          >
+            <Plus />
+            Add spec
+          </Button>
+        </div>
+      </section>
+
+      {/* ── Custom orders ──────────────────────────────────────────────── */}
+      {showCustomOrderSection && (
+        <section className="flex flex-col gap-y-4">
+          <div>
+            <Heading level="h2">Custom orders</Heading>
+            <Text size="small" className="text-ui-fg-subtle">
+              Whether you'll take an order made to this spec in a colour of the
+              customer's choosing.
+            </Text>
+          </div>
+
+          <div className="flex items-center gap-x-3">
+            <Switch
+              id="accepting-custom-orders"
+              checked={!!value.accepting_custom_orders}
+              onCheckedChange={(v) => patch({ accepting_custom_orders: v })}
+            />
+            <Label size="small" htmlFor="accepting-custom-orders">
+              Accepting custom orders against this spec
+            </Label>
+          </div>
+
+          <div className="max-w-xs flex flex-col gap-y-2">
+            <Label size="small" weight="plus">
+              Lead time for a custom order (days)
+            </Label>
+            <Input
+              type="number"
+              min={0}
+              placeholder="30"
+              value={value.custom_order_lead_time_days ?? ""}
+              onChange={(e) =>
+                patch({
+                  custom_order_lead_time_days:
+                    e.target.value.trim() === "" ? null : Number(e.target.value),
+                })
+              }
+            />
+            <Text size="xsmall" className="text-ui-fg-muted">
+              A bespoke colourway usually takes longer than the ready-made piece.
+            </Text>
+          </div>
+        </section>
+      )}
+
+      <section className="flex flex-col gap-y-2">
+        <Label size="small" weight="plus">
+          Notes for the workshop
+        </Label>
+        <Textarea
+          rows={3}
+          placeholder="Warp tension eases in monsoon — allow an extra day."
+          value={value.notes ?? ""}
+          onChange={(e) => patch({ notes: e.target.value })}
+        />
+      </section>
+    </div>
+  )
+}
+
+/** Add-a-finish input. Kept local so Enter adds a chip without submitting the
+ *  host form — inside the create wizard, Enter means "next tab". */
+const FinishInput = ({ onAdd }: { onAdd: (finish: string) => void }) => {
+  return (
+    <div className="max-w-sm">
+      <Input
+        placeholder="Add a finishing or care step, then press Enter"
+        onKeyDown={(e) => {
+          if (e.key !== "Enter") return
+          e.preventDefault()
+          e.stopPropagation()
+          const el = e.currentTarget
+          const text = el.value.trim()
+          if (!text) return
+          onAdd(text)
+          el.value = ""
+        }}
+      />
+    </div>
+  )
+}

--- a/apps/backend/src/admin/hooks/api/product-spec.ts
+++ b/apps/backend/src/admin/hooks/api/product-spec.ts
@@ -1,0 +1,145 @@
+import { useMutation, useQuery, useQueryClient } from "@tanstack/react-query"
+
+import { sdk } from "../../lib/config"
+
+/**
+ * #1349 — admin-side production spec (the mirror of the partner hooks).
+ *
+ * Same module, same workflow, same weave catalog: these call the admin routes
+ * added in #1346, which differ from the partner ones only in that an admin is
+ * not scoped to one partner's products.
+ */
+
+/** Mirrors `WeaveParamDef` in the backend catalog — min/max/step drive the input. */
+export type WeaveParamDef = {
+  key: string
+  label: string
+  unit: string
+  min: number
+  max: number
+  step: number
+  default: number
+}
+
+export type WeavePreset = {
+  value: string
+  label: string
+  detailLabel: string
+  params?: Record<string, number>
+  finishes?: string[]
+  note?: string
+}
+
+export type WeaveTechnique = {
+  slug: string
+  label: string
+  family: string
+  description: string
+  params: WeaveParamDef[]
+  defaultFinishes: string[]
+  presets: WeavePreset[]
+}
+
+export type ProductSpecColor = {
+  id?: string
+  name: string
+  hex_code?: string | null
+  usage_notes?: string | null
+  order?: number
+  available?: boolean
+}
+
+export type ProductSpecField = {
+  id?: string
+  key: string
+  label?: string | null
+  value?: string | null
+  order?: number
+}
+
+export type ProductSpec = {
+  id?: string
+  product_id?: string
+  weave_technique?: string | null
+  weave_label?: string | null
+  params?: Record<string, number> | null
+  finishes?: string[] | null
+  notes?: string | null
+  accepting_custom_orders?: boolean | null
+  custom_order_lead_time_days?: number | null
+  colors?: ProductSpecColor[]
+  fields?: ProductSpecField[]
+} | null
+
+/** The payload the upsert route accepts. `colors`/`fields` REPLACE when sent. */
+export type ProductSpecPayload = Omit<
+  NonNullable<ProductSpec>,
+  "id" | "product_id"
+>
+
+export const productSpecKeys = {
+  all: ["admin-product-spec"] as const,
+  detail: (productId: string) =>
+    [...productSpecKeys.all, "detail", productId] as const,
+  catalog: () => [...productSpecKeys.all, "weave-catalog"] as const,
+}
+
+/**
+ * The weaving-technique catalog behind the picker.
+ *
+ * Static for the life of a deploy — the ranges, defaults and presets come from
+ * the same module the backend validates against — so it is cached hard rather
+ * than refetched per product.
+ */
+export const useWeaveCatalog = () => {
+  const { data, ...rest } = useQuery({
+    queryKey: productSpecKeys.catalog(),
+    queryFn: async () =>
+      (await sdk.client.fetch("/admin/products/spec-catalog", {
+        method: "GET",
+      })) as { techniques: WeaveTechnique[]; families: string[] },
+    staleTime: Infinity,
+  })
+
+  return {
+    techniques: data?.techniques ?? [],
+    families: data?.families ?? [],
+    ...rest,
+  }
+}
+
+/**
+ * A product's saved spec. Loaded on mount, unconditionally — a display query
+ * gated on modal state renders empty on every page refresh.
+ */
+export const useProductSpec = (productId: string) => {
+  const { data, ...rest } = useQuery({
+    queryKey: productSpecKeys.detail(productId),
+    queryFn: async () =>
+      (await sdk.client.fetch(`/admin/products/${productId}/spec`, {
+        method: "GET",
+      })) as { spec: ProductSpec },
+    enabled: !!productId,
+  })
+
+  return { spec: data?.spec ?? null, ...rest }
+}
+
+export const useUpsertProductSpec = (productId: string) => {
+  const queryClient = useQueryClient()
+
+  return useMutation({
+    mutationFn: async (payload: ProductSpecPayload) =>
+      (await sdk.client.fetch(`/admin/products/${productId}/spec`, {
+        method: "POST",
+        body: payload,
+      })) as { spec: ProductSpec },
+    onSuccess: () => {
+      // The DISPLAY query, not just whatever the modal read — otherwise the
+      // widget keeps rendering the pre-save spec until the page is reloaded.
+      queryClient.invalidateQueries({
+        queryKey: productSpecKeys.detail(productId),
+      })
+    },
+  })
+}

--- a/apps/backend/src/admin/widgets/product-production-spec.tsx
+++ b/apps/backend/src/admin/widgets/product-production-spec.tsx
@@ -1,0 +1,320 @@
+import { defineWidgetConfig } from "@medusajs/admin-sdk"
+import { DetailWidgetProps } from "@medusajs/framework/types"
+import { PencilSquare } from "@medusajs/icons"
+import {
+  Badge,
+  Button,
+  Container,
+  FocusModal,
+  Heading,
+  Text,
+  toast,
+} from "@medusajs/ui"
+import { useEffect, useState } from "react"
+
+import { ProductSpecForm } from "../components/product-spec-form"
+import {
+  useProductSpec,
+  useUpsertProductSpec,
+  useWeaveCatalog,
+  type ProductSpecColor,
+  type ProductSpecField,
+  type ProductSpecPayload,
+  type WeaveTechnique,
+} from "../hooks/api/product-spec"
+
+/**
+ * #1349 — the production spec on the ADMIN product page.
+ *
+ * Same shape as the partner surface: the widget READS, and a modal writes.
+ * Admins were the one audience with no way to see a spec at all — the data was
+ * reachable only through the partner portal or an MCP call, so a support
+ * question about what a piece is made to could not be answered from the admin.
+ *
+ * A `FocusModal` rather than the `Drawer` the admin guidance prefers for edits:
+ * the editor is a five-part form with a parameter grid and a repeatable colour
+ * palette, and a drawer's width forces every row to wrap. The rule exists so
+ * edits stay in place and lightweight; this edit is neither.
+ */
+
+type AdminProduct = { id: string; title?: string }
+
+const EMPTY: ProductSpecPayload = {
+  weave_technique: null,
+  weave_label: null,
+  params: null,
+  finishes: [],
+  notes: null,
+  accepting_custom_orders: false,
+  custom_order_lead_time_days: null,
+  colors: [],
+  fields: [],
+}
+
+/** A stored param rendered with the label + unit its technique defines. Falls
+ *  back to the raw key so a param whose technique was renamed still shows. */
+const paramRows = (
+  params: Record<string, number> | null | undefined,
+  technique?: WeaveTechnique
+) =>
+  Object.entries(params ?? {}).map(([key, value]) => {
+    const def = technique?.params.find((p) => p.key === key)
+    return {
+      key,
+      label: def?.label ?? key,
+      value: def?.unit ? `${value} ${def.unit}` : `${value}`,
+    }
+  })
+
+const Row = ({ label, children }: { label: string; children: React.ReactNode }) => (
+  <div className="text-ui-fg-subtle grid w-full grid-cols-1 items-start gap-1 px-6 py-4 sm:grid-cols-2 sm:items-center sm:gap-4">
+    <Text size="small" weight="plus" leading="compact">
+      {label}
+    </Text>
+    <div className="flex flex-wrap items-center gap-1">{children}</div>
+  </div>
+)
+
+const ProductProductionSpecWidget = ({
+  data: product,
+}: DetailWidgetProps<AdminProduct>) => {
+  const [open, setOpen] = useState(false)
+  const [value, setValue] = useState<ProductSpecPayload>(EMPTY)
+  const [dirty, setDirty] = useState(false)
+
+  // Display query — no `enabled` gate on modal state, or the widget renders
+  // empty every time the page is refreshed with the modal closed.
+  const { spec, isLoading } = useProductSpec(product.id)
+  const { techniques, families, isLoading: catalogLoading } = useWeaveCatalog()
+  const { mutateAsync, isPending } = useUpsertProductSpec(product.id)
+
+  useEffect(() => {
+    if (!spec || dirty) {
+      return
+    }
+    setValue({
+      weave_technique: spec.weave_technique ?? null,
+      weave_label: spec.weave_label ?? null,
+      params: spec.params ?? null,
+      finishes: spec.finishes ?? [],
+      notes: spec.notes ?? null,
+      accepting_custom_orders: !!spec.accepting_custom_orders,
+      custom_order_lead_time_days: spec.custom_order_lead_time_days ?? null,
+      colors: (spec.colors ?? [])
+        .slice()
+        .sort((a, b) => (a.order ?? 0) - (b.order ?? 0)),
+      fields: (spec.fields ?? [])
+        .slice()
+        .sort((a, b) => (a.order ?? 0) - (b.order ?? 0)),
+    })
+  }, [spec, dirty])
+
+  const technique = techniques.find((t) => t.slug === spec?.weave_technique)
+  const colors: ProductSpecColor[] = (spec?.colors ?? [])
+    .slice()
+    .sort((a, b) => (a.order ?? 0) - (b.order ?? 0))
+  const fields: ProductSpecField[] = (spec?.fields ?? [])
+    .slice()
+    .sort((a, b) => (a.order ?? 0) - (b.order ?? 0))
+  const params = paramRows(spec?.params, technique)
+  const finishes = spec?.finishes ?? []
+
+  // A spec row can exist carrying nothing but defaults, so "has a spec" is
+  // decided by whether anything was written — not by the row existing.
+  const hasContent =
+    !!spec?.weave_technique ||
+    !!spec?.weave_label ||
+    !!spec?.notes ||
+    !!params.length ||
+    !!finishes.length ||
+    !!colors.length ||
+    !!fields.length
+
+  const handleSave = async () => {
+    // Drop half-written rows rather than sending them: the route rejects a
+    // colour with no name, and losing the whole save over a row the admin
+    // forgot about is worse than silently ignoring it.
+    const payload: ProductSpecPayload = {
+      ...value,
+      weave_label: value.weave_label?.trim() ? value.weave_label.trim() : null,
+      notes: value.notes?.trim() ? value.notes.trim() : null,
+      colors: (value.colors ?? []).filter((c) => c.name.trim()),
+      fields: (value.fields ?? []).filter((f) => (f.label ?? f.key).trim()),
+    }
+
+    try {
+      await mutateAsync(payload)
+      setDirty(false)
+      setOpen(false)
+      toast.success("Production spec saved")
+    } catch (e: any) {
+      toast.error(e?.message || "Could not save the production spec")
+    }
+  }
+
+  return (
+    <Container className="divide-y p-0">
+      <div className="flex items-center justify-between px-6 py-4">
+        <div>
+          <Heading level="h2">Production spec</Heading>
+          <Text size="small" className="text-ui-fg-subtle">
+            The weave, colours and specs this product is made to.
+          </Text>
+        </div>
+        <div className="flex items-center gap-x-2">
+          {spec?.accepting_custom_orders && (
+            <Badge size="2xsmall" color="green">
+              {spec.custom_order_lead_time_days
+                ? `Custom orders · ${spec.custom_order_lead_time_days} days`
+                : "Custom orders"}
+            </Badge>
+          )}
+          <Button
+            size="small"
+            variant="secondary"
+            onClick={() => setOpen(true)}
+            disabled={isLoading || catalogLoading}
+          >
+            <PencilSquare />
+            {hasContent ? "Edit" : "Add spec"}
+          </Button>
+        </div>
+      </div>
+
+      {isLoading || catalogLoading ? (
+        <div className="px-6 py-4">
+          <Text size="small" className="text-ui-fg-subtle">
+            Loading spec…
+          </Text>
+        </div>
+      ) : !hasContent ? (
+        <div className="px-6 py-4">
+          <Text size="small" className="text-ui-fg-subtle">
+            No production spec has been written for this product.
+          </Text>
+        </div>
+      ) : (
+        <>
+          <Row label="Weave">
+            <Text size="small" leading="compact">
+              {technique?.label ?? spec?.weave_technique ?? "-"}
+            </Text>
+          </Row>
+          {spec?.weave_label && (
+            <Row label="Weave name">
+              <Text size="small" leading="compact">
+                {spec.weave_label}
+              </Text>
+            </Row>
+          )}
+          {params.map((param) => (
+            <Row key={param.key} label={param.label}>
+              <Text size="small" leading="compact">
+                {param.value}
+              </Text>
+            </Row>
+          ))}
+          {!!finishes.length && (
+            <Row label="Finishes">
+              {finishes.map((finish) => (
+                <Badge key={finish} size="2xsmall">
+                  {finish}
+                </Badge>
+              ))}
+            </Row>
+          )}
+          {!!colors.length && (
+            <Row label="Palette">
+              {colors.map((color) => (
+                <div
+                  key={color.id ?? color.name}
+                  className="border-ui-border-base bg-ui-bg-subtle flex items-center gap-x-2 rounded-full border py-1 pl-1 pr-3"
+                >
+                  <span
+                    className="border-ui-border-base size-5 rounded-full border"
+                    style={{ backgroundColor: color.hex_code ?? "transparent" }}
+                    aria-hidden
+                  />
+                  <Text size="small" leading="compact">
+                    {color.name}
+                  </Text>
+                  {color.available === false && (
+                    <Badge size="2xsmall" color="grey">
+                      Unavailable
+                    </Badge>
+                  )}
+                </div>
+              ))}
+            </Row>
+          )}
+          {spec?.notes && (
+            <Row label="Notes">
+              <Text
+                size="small"
+                leading="compact"
+                className="whitespace-pre-line"
+              >
+                {spec.notes}
+              </Text>
+            </Row>
+          )}
+          {fields.map((field) => (
+            <Row
+              key={field.id ?? field.key}
+              label={field.label?.trim() || field.key}
+            >
+              <Text size="small" leading="compact">
+                {field.value ?? "-"}
+              </Text>
+            </Row>
+          ))}
+        </>
+      )}
+
+      <FocusModal open={open} onOpenChange={setOpen}>
+        <FocusModal.Content>
+          <FocusModal.Header>
+            <div className="flex items-center justify-end gap-x-2">
+              <Button
+                size="small"
+                onClick={handleSave}
+                isLoading={isPending}
+                disabled={isPending}
+              >
+                Save
+              </Button>
+            </div>
+          </FocusModal.Header>
+          <FocusModal.Body className="flex flex-1 flex-col overflow-y-auto">
+            <div className="mx-auto flex w-full max-w-[720px] flex-col gap-y-6 px-6 py-16">
+              <div className="flex flex-col gap-y-1">
+                <Heading level="h2">Production spec</Heading>
+                <Text size="small" className="text-ui-fg-subtle">
+                  {product.title
+                    ? `What ${product.title} is made to.`
+                    : "What this product is made to."}
+                </Text>
+              </div>
+              <ProductSpecForm
+                value={value}
+                onChange={(next) => {
+                  setDirty(true)
+                  setValue(next)
+                }}
+                techniques={techniques}
+                families={families}
+                isLoading={isLoading || catalogLoading}
+              />
+            </div>
+          </FocusModal.Body>
+        </FocusModal.Content>
+      </FocusModal>
+    </Container>
+  )
+}
+
+export const config = defineWidgetConfig({
+  zone: "product.details.after",
+})
+
+export default ProductProductionSpecWidget

--- a/apps/backend/src/api/middlewares.ts
+++ b/apps/backend/src/api/middlewares.ts
@@ -290,6 +290,7 @@ import { ListInventoryItemRawMaterialsQuerySchema } from "./admin/inventory-item
 import { BulkImportSchema } from "./admin/inventory-items/bulk-import/validators";
 import { PartnerCreateStoreReq } from "./partners/stores/validators";
 import { PartnerCreateProductReq, PartnerArtisanProductDetailReq, PartnerProductSpecReq } from "./partners/products/validators";
+import { StoreMadeToSpecReq } from "./store/carts/[id]/made-to-spec/validators";
 import {
   PartnerCreateRegionReq,
   PartnerUpdateRegionReq,
@@ -4511,6 +4512,15 @@ export default defineMiddlewares({
       middlewares: [
         authenticate("customer", ["session", "bearer"]),
       ],
+    },
+    {
+      // #1349: add a made-to-order line item, validated against the partner's
+      // published production spec. Deliberately NOT customer-authenticated —
+      // a guest cart is a cart, and requiring a login to configure a piece
+      // would put the sign-up wall before the thing that motivates it.
+      matcher: "/store/carts/:id/made-to-spec",
+      method: "POST",
+      middlewares: [validateAndTransformBody(wrapSchema(StoreMadeToSpecReq))],
     },
     // Task-Templates
     {

--- a/apps/backend/src/api/store/carts/[id]/made-to-spec/lib.ts
+++ b/apps/backend/src/api/store/carts/[id]/made-to-spec/lib.ts
@@ -1,0 +1,156 @@
+import { MedusaError } from "@medusajs/framework/utils"
+
+/**
+ * #1349 — validating a customer's made-to-spec choice against the spec the
+ * partner actually published, and SNAPSHOTTING it onto the line item.
+ *
+ * Two rules carry the weight here:
+ *
+ * 1. The palette is a closed set. A colour is orderable only if the partner
+ *    listed it AND left it available. Without this check the storefront is the
+ *    only thing standing between a customer and an order for a colourway
+ *    nobody can weave — and the storefront is the half an attacker controls.
+ *
+ * 2. The selection is COPIED onto the line item, never referenced. A spec is a
+ *    living document the partner edits; an order is a record of what was
+ *    agreed. If the line item held only `color_id`, a partner renaming a colour
+ *    or turning off custom orders next week would silently rewrite what a
+ *    customer bought last week — and the dispute would be unanswerable. The
+ *    lead time is snapshotted for the same reason: it is a promise made at a
+ *    point in time.
+ */
+
+/** Namespaced so it cannot collide with metadata another feature writes. */
+export const MADE_TO_SPEC_METADATA_KEY = "made_to_spec"
+
+export type SpecColor = {
+  id?: string
+  name: string
+  hex_code?: string | null
+  usage_notes?: string | null
+  available?: boolean
+}
+
+export type SpecField = {
+  key: string
+  label?: string | null
+  value?: string | null
+}
+
+export type ProductSpecRecord = {
+  id?: string
+  weave_technique?: string | null
+  weave_label?: string | null
+  params?: Record<string, number> | null
+  finishes?: string[] | null
+  accepting_custom_orders?: boolean | null
+  custom_order_lead_time_days?: number | null
+  colors?: SpecColor[]
+  fields?: SpecField[]
+} | null
+
+export type MadeToSpecSelection = {
+  /** Colour name as published in the palette. Matched case-insensitively. */
+  color?: string | null
+  /** Free text from the customer — a monogram, a length, an occasion date. */
+  note?: string | null
+}
+
+/** What ends up on the line item, and later on the order. */
+export type MadeToSpecSnapshot = {
+  spec_id?: string
+  weave?: string | null
+  color_name?: string
+  color_hex?: string | null
+  /** Copied so the order still reads correctly after the spec changes. */
+  lead_time_days?: number | null
+  note?: string | null
+  /** The spec's own fields at time of order — what the piece is made to. */
+  spec_fields?: { label: string; value: string }[]
+  captured_at: string
+}
+
+const normalize = (value: string) => value.trim().toLowerCase()
+
+/**
+ * Build the snapshot, or throw a MedusaError the store route surfaces as a 4xx.
+ *
+ * `now` is injected rather than read from the clock so the snapshot is
+ * assertable in a test.
+ */
+export const buildMadeToSpecSnapshot = ({
+  spec,
+  selection,
+  now,
+}: {
+  spec: ProductSpecRecord
+  selection: MadeToSpecSelection
+  now: Date
+}): MadeToSpecSnapshot => {
+  if (!spec) {
+    throw new MedusaError(
+      MedusaError.Types.NOT_FOUND,
+      "This product has no production spec, so it cannot be made to order."
+    )
+  }
+
+  if (!spec.accepting_custom_orders) {
+    throw new MedusaError(
+      MedusaError.Types.NOT_ALLOWED,
+      "This product is not currently accepting made-to-order requests."
+    )
+  }
+
+  const palette = (spec.colors ?? []).filter((c) => c.available !== false)
+  const requested = selection.color?.trim()
+
+  let color: SpecColor | undefined
+  if (requested) {
+    color = palette.find((c) => normalize(c.name) === normalize(requested))
+    if (!color) {
+      // Name what IS orderable. A bare rejection sends the customer back to a
+      // page that still shows the colour they picked.
+      const available = palette.map((c) => c.name).join(", ")
+      throw new MedusaError(
+        MedusaError.Types.INVALID_DATA,
+        available
+          ? `"${requested}" is not available for this product. Available colours: ${available}.`
+          : `"${requested}" is not available for this product, and no colours are currently listed.`
+      )
+    }
+  } else if (palette.length) {
+    throw new MedusaError(
+      MedusaError.Types.INVALID_DATA,
+      `Choose a colour. Available colours: ${palette
+        .map((c) => c.name)
+        .join(", ")}.`
+    )
+  }
+
+  const note = selection.note?.trim()
+  if (note && note.length > 500) {
+    throw new MedusaError(
+      MedusaError.Types.INVALID_DATA,
+      "Keep the note under 500 characters."
+    )
+  }
+
+  const specFields = (spec.fields ?? [])
+    .filter((f) => (f.value ?? "").trim())
+    .map((f) => ({
+      label: (f.label ?? f.key).trim(),
+      value: (f.value ?? "").trim(),
+    }))
+
+  return {
+    ...(spec.id ? { spec_id: spec.id } : {}),
+    weave: spec.weave_label?.trim() || spec.weave_technique || null,
+    ...(color
+      ? { color_name: color.name, color_hex: color.hex_code ?? null }
+      : {}),
+    lead_time_days: spec.custom_order_lead_time_days ?? null,
+    note: note || null,
+    ...(specFields.length ? { spec_fields: specFields } : {}),
+    captured_at: now.toISOString(),
+  }
+}

--- a/apps/backend/src/api/store/carts/[id]/made-to-spec/route.ts
+++ b/apps/backend/src/api/store/carts/[id]/made-to-spec/route.ts
@@ -1,0 +1,124 @@
+/**
+ * POST /store/carts/:id/made-to-spec
+ *
+ * Add a made-to-order line item: the customer's chosen colourway plus a note,
+ * validated against the partner's published production spec (#1342) and
+ * snapshotted onto the line item.
+ *
+ * A dedicated route rather than the core `/line-items` call with metadata,
+ * because the palette is a business rule the core route cannot know: whether a
+ * colour is orderable lives in the spec, and a client posting metadata directly
+ * would be trusted. This route is the only path that can write
+ * `made_to_spec` metadata that means anything.
+ */
+import { MedusaRequest, MedusaResponse } from "@medusajs/framework/http"
+import {
+  ContainerRegistrationKeys,
+  MedusaError,
+  Modules,
+} from "@medusajs/framework/utils"
+import { addToCartWorkflowId } from "@medusajs/core-flows"
+
+import { PRODUCT_SPEC_MODULE } from "../../../../../modules/product-spec"
+import {
+  buildMadeToSpecSnapshot,
+  MADE_TO_SPEC_METADATA_KEY,
+  type MadeToSpecSelection,
+} from "./lib"
+
+type Body = MadeToSpecSelection & {
+  variant_id: string
+  quantity?: number
+}
+
+export const POST = async (req: MedusaRequest<Body>, res: MedusaResponse) => {
+  const logger: any = req.scope.resolve(ContainerRegistrationKeys.LOGGER)
+  const query: any = req.scope.resolve(ContainerRegistrationKeys.QUERY)
+  const cartId = req.params.id
+  const body = (req.validatedBody || req.body || {}) as Body
+
+  if (!body.variant_id) {
+    return res.status(400).json({
+      type: "invalid_data",
+      error: "variant_id is required.",
+    })
+  }
+
+  // The spec is keyed by PRODUCT, and the customer picks a VARIANT — so resolve
+  // one to the other rather than trusting a product_id from the client.
+  const { data: variants } = await query.graph({
+    entity: "variant",
+    fields: ["id", "product_id"],
+    filters: { id: body.variant_id },
+  })
+
+  const productId = variants?.[0]?.product_id
+  if (!productId) {
+    return res.status(404).json({
+      type: "not_found",
+      error: `Variant ${body.variant_id} was not found.`,
+    })
+  }
+
+  const service: any = req.scope.resolve(PRODUCT_SPEC_MODULE)
+  const spec = await service.findByProduct(productId)
+
+  let snapshot
+  try {
+    snapshot = buildMadeToSpecSnapshot({
+      spec,
+      selection: { color: body.color, note: body.note },
+      now: new Date(),
+    })
+  } catch (e: any) {
+    const status =
+      e?.type === MedusaError.Types.NOT_FOUND
+        ? 404
+        : e?.type === MedusaError.Types.NOT_ALLOWED
+          ? 409
+          : 400
+    return res.status(status).json({
+      type: e?.type || "invalid_data",
+      error: e?.message || "That made-to-order choice is not available.",
+    })
+  }
+
+  try {
+    const we: any = req.scope.resolve(Modules.WORKFLOW_ENGINE)
+    await we.run(addToCartWorkflowId, {
+      input: {
+        cart_id: cartId,
+        items: [
+          {
+            variant_id: body.variant_id,
+            quantity: body.quantity ?? 1,
+            metadata: { [MADE_TO_SPEC_METADATA_KEY]: snapshot },
+          },
+        ],
+      },
+    })
+  } catch (e: any) {
+    logger.error(
+      `[Made to spec] add to cart failed for cart ${cartId}: ${e?.message}`
+    )
+    return res.status(e?.status === 404 ? 404 : 400).json({
+      type: "cart",
+      error: e?.message || "Could not add this made-to-order piece to the cart.",
+    })
+  }
+
+  const { data: carts } = await query.graph({
+    entity: "cart",
+    fields: [
+      "id",
+      "items.id",
+      "items.title",
+      "items.quantity",
+      "items.variant_id",
+      "items.metadata",
+    ],
+    filters: { id: cartId },
+  })
+
+  return res.json({ cart: carts?.[0] ?? null, made_to_spec: snapshot })
+}

--- a/apps/backend/src/api/store/carts/[id]/made-to-spec/validators.ts
+++ b/apps/backend/src/api/store/carts/[id]/made-to-spec/validators.ts
@@ -1,0 +1,18 @@
+import { z } from "zod"
+
+/**
+ * #1349 — the made-to-spec add-to-cart body.
+ *
+ * Shape only. WHICH colour is orderable is decided in `lib.ts` against the
+ * partner's published palette — zod cannot know a palette that lives in the
+ * database, and a schema that pretended to would be a second, weaker copy of
+ * the rule.
+ */
+export const StoreMadeToSpecReq = z.object({
+  variant_id: z.string().min(1),
+  quantity: z.number().int().positive().max(100).optional(),
+  color: z.string().min(1).max(200).nullish(),
+  note: z.string().max(500).nullish(),
+})
+
+export type StoreMadeToSpecReqType = z.infer<typeof StoreMadeToSpecReq>

--- a/apps/backend/src/api/store/carts/__tests__/made-to-spec.unit.spec.ts
+++ b/apps/backend/src/api/store/carts/__tests__/made-to-spec.unit.spec.ts
@@ -1,0 +1,186 @@
+import {
+  buildMadeToSpecSnapshot,
+  MADE_TO_SPEC_METADATA_KEY,
+  type ProductSpecRecord,
+} from "../[id]/made-to-spec/lib"
+
+/**
+ * #1349 — what a customer is allowed to order, and what the order remembers.
+ *
+ * These assert the two rules the storefront cannot be trusted with: the palette
+ * is closed, and the selection is copied rather than referenced.
+ */
+
+const NOW = new Date("2026-08-18T12:00:00.000Z")
+
+const spec = (over: Partial<NonNullable<ProductSpecRecord>> = {}) =>
+  ({
+    id: "pspec_1",
+    weave_technique: "pashmina",
+    weave_label: "Kani, 3-colour",
+    accepting_custom_orders: true,
+    custom_order_lead_time_days: 45,
+    colors: [
+      { id: "c1", name: "Kashmiri walnut", hex_code: "#5B4636" },
+      { id: "c2", name: "Saffron", hex_code: "#F4C430" },
+      { id: "c3", name: "Retired indigo", hex_code: "#33468C", available: false },
+    ],
+    fields: [{ key: "pallu_type", label: "Pallu type", value: "Woven, 18in" }],
+    ...over,
+  }) as NonNullable<ProductSpecRecord>
+
+describe("made-to-spec selection", () => {
+  it("accepts a colour the partner published", () => {
+    const snapshot = buildMadeToSpecSnapshot({
+      spec: spec(),
+      selection: { color: "Saffron" },
+      now: NOW,
+    })
+
+    expect(snapshot.color_name).toBe("Saffron")
+    expect(snapshot.color_hex).toBe("#F4C430")
+  })
+
+  it("matches the colour case- and whitespace-insensitively", () => {
+    const snapshot = buildMadeToSpecSnapshot({
+      spec: spec(),
+      selection: { color: "  saffron " },
+      now: NOW,
+    })
+
+    // The stored name is the PARTNER's spelling, not the customer's — the
+    // order should read the way the partner wrote it.
+    expect(snapshot.color_name).toBe("Saffron")
+  })
+
+  it("rejects a colour that is not in the palette, and says what is", () => {
+    expect(() =>
+      buildMadeToSpecSnapshot({
+        spec: spec(),
+        selection: { color: "Neon pink" },
+        now: NOW,
+      })
+    ).toThrow(/Kashmiri walnut, Saffron/)
+  })
+
+  it("rejects a colour the partner marked unavailable", () => {
+    // The colour exists in the palette — it is simply not orderable. A check
+    // that only asked "is this name known?" would let this through.
+    expect(() =>
+      buildMadeToSpecSnapshot({
+        spec: spec(),
+        selection: { color: "Retired indigo" },
+        now: NOW,
+      })
+    ).toThrow(/not available/)
+  })
+
+  it("refuses when the partner is not taking custom orders", () => {
+    expect(() =>
+      buildMadeToSpecSnapshot({
+        spec: spec({ accepting_custom_orders: false }),
+        selection: { color: "Saffron" },
+        now: NOW,
+      })
+    ).toThrow(/not currently accepting/)
+  })
+
+  it("refuses when the product has no spec at all", () => {
+    expect(() =>
+      buildMadeToSpecSnapshot({
+        spec: null,
+        selection: { color: "Saffron" },
+        now: NOW,
+      })
+    ).toThrow(/no production spec/)
+  })
+
+  it("requires a colour when the palette offers any", () => {
+    expect(() =>
+      buildMadeToSpecSnapshot({ spec: spec(), selection: {}, now: NOW })
+    ).toThrow(/Choose a colour/)
+  })
+
+  it("allows an order with no colour when the palette is empty", () => {
+    // A partner may take made-to-order work without publishing a palette —
+    // the weave itself is the spec. Demanding a colour would block them.
+    const snapshot = buildMadeToSpecSnapshot({
+      spec: spec({ colors: [] }),
+      selection: { note: "For a September wedding" },
+      now: NOW,
+    })
+
+    expect(snapshot.color_name).toBeUndefined()
+    expect(snapshot.note).toBe("For a September wedding")
+  })
+
+  it("treats a palette of only-unavailable colours as offering nothing", () => {
+    expect(() =>
+      buildMadeToSpecSnapshot({
+        spec: spec({
+          colors: [{ id: "c1", name: "Sold out", available: false }],
+        }),
+        selection: { color: "Sold out" },
+        now: NOW,
+      })
+    ).toThrow(/no colours are currently listed/)
+  })
+
+  it("snapshots the lead time and weave rather than referencing the spec", () => {
+    // A spec is edited; an order is a record. If the line item held only an id,
+    // a partner changing the lead time next week would rewrite what a customer
+    // was promised last week.
+    const snapshot = buildMadeToSpecSnapshot({
+      spec: spec(),
+      selection: { color: "Saffron" },
+      now: NOW,
+    })
+
+    expect(snapshot).toMatchObject({
+      spec_id: "pspec_1",
+      weave: "Kani, 3-colour",
+      lead_time_days: 45,
+      captured_at: "2026-08-18T12:00:00.000Z",
+      spec_fields: [{ label: "Pallu type", value: "Woven, 18in" }],
+    })
+  })
+
+  it("falls back to the technique slug when the partner named nothing", () => {
+    const snapshot = buildMadeToSpecSnapshot({
+      spec: spec({ weave_label: "   " }),
+      selection: { color: "Saffron" },
+      now: NOW,
+    })
+
+    expect(snapshot.weave).toBe("pashmina")
+  })
+
+  it("drops spec fields that carry no value", () => {
+    const snapshot = buildMadeToSpecSnapshot({
+      spec: spec({
+        fields: [
+          { key: "pallu_type", label: "Pallu type", value: "  " },
+          { key: "border", label: "Border", value: "Zari" },
+        ],
+      }),
+      selection: { color: "Saffron" },
+      now: NOW,
+    })
+
+    expect(snapshot.spec_fields).toEqual([{ label: "Border", value: "Zari" }])
+  })
+
+  it("rejects an oversized note", () => {
+    expect(() =>
+      buildMadeToSpecSnapshot({
+        spec: spec(),
+        selection: { color: "Saffron", note: "x".repeat(501) },
+        now: NOW,
+      })
+    ).toThrow(/under 500 characters/)
+  })
+
+  it("namespaces the metadata key so it cannot collide", () => {
+    expect(MADE_TO_SPEC_METADATA_KEY).toBe("made_to_spec")
+  })
+})

--- a/apps/backend/src/api/store/products/[id]/spec/route.ts
+++ b/apps/backend/src/api/store/products/[id]/spec/route.ts
@@ -1,0 +1,102 @@
+/**
+ * GET /store/products/:id/spec
+ *
+ * The public read of a product's production spec (#1342): what the piece is
+ * made to, and — when the partner is taking made-to-order work — the palette a
+ * customer may choose from.
+ *
+ * `:id` accepts a product id or a handle, because a storefront product page is
+ * routed by handle and should not have to make a second call to learn the id.
+ *
+ * The stored spec carries param KEYS (`gsm`, `ends_per_inch`); a customer needs
+ * labels and units. Rather than making every storefront ship a copy of the
+ * catalog, the resolved technique is returned alongside — same reason the
+ * editors read it from the API instead of hardcoding it.
+ */
+import { MedusaRequest, MedusaResponse } from "@medusajs/framework/http"
+import { ContainerRegistrationKeys } from "@medusajs/framework/utils"
+
+import { PRODUCT_SPEC_MODULE } from "../../../../../modules/product-spec"
+import { WEAVE_TECHNIQUES } from "../../../../../modules/product-spec/weaving-techniques"
+
+export const GET = async (req: MedusaRequest, res: MedusaResponse) => {
+  const query: any = req.scope.resolve(ContainerRegistrationKeys.QUERY)
+  const idOrHandle = req.params.id
+
+  const { data: byId } = await query.graph({
+    entity: "product",
+    fields: ["id", "handle", "status"],
+    filters: { id: idOrHandle },
+  })
+
+  let product = byId?.[0]
+  if (!product) {
+    const { data: byHandle } = await query.graph({
+      entity: "product",
+      fields: ["id", "handle", "status"],
+      filters: { handle: idOrHandle },
+    })
+    product = byHandle?.[0]
+  }
+
+  if (!product) {
+    return res.status(404).json({
+      type: "not_found",
+      error: `Product ${idOrHandle} was not found.`,
+    })
+  }
+
+  const service: any = req.scope.resolve(PRODUCT_SPEC_MODULE)
+  const spec = await service.findByProduct(product.id)
+
+  // No spec is the normal state for most products, not an error — the
+  // storefront simply renders nothing.
+  if (!spec) {
+    return res.json({ spec: null, technique: null })
+  }
+
+  const technique =
+    WEAVE_TECHNIQUES.find((t) => t.slug === spec.weave_technique) ?? null
+
+  // Colours the partner has switched off are not offered. They are dropped
+  // here rather than in the storefront so every storefront — ours, the
+  // starter, and anything built later — agrees on what is orderable.
+  const colors = (spec.colors ?? [])
+    .filter((c: any) => c.available !== false)
+    .slice()
+    .sort((a: any, b: any) => (a.order ?? 0) - (b.order ?? 0))
+
+  const fields = (spec.fields ?? [])
+    .slice()
+    .sort((a: any, b: any) => (a.order ?? 0) - (b.order ?? 0))
+
+  return res.json({
+    spec: {
+      id: spec.id,
+      weave_technique: spec.weave_technique ?? null,
+      weave_label: spec.weave_label ?? null,
+      params: spec.params ?? null,
+      finishes: spec.finishes ?? [],
+      accepting_custom_orders: !!spec.accepting_custom_orders,
+      custom_order_lead_time_days: spec.custom_order_lead_time_days ?? null,
+      colors,
+      fields,
+      // `notes` is deliberately NOT returned: it is written as "notes for the
+      // workshop" in the partner editor, and workshop notes are not customer
+      // copy. Publishing them would change what partners feel able to write.
+    },
+    technique: technique
+      ? {
+          slug: technique.slug,
+          label: technique.label,
+          family: technique.family,
+          description: technique.description,
+          params: technique.params.map((p) => ({
+            key: p.key,
+            label: p.label,
+            unit: p.unit,
+          })),
+        }
+      : null,
+  })
+}

--- a/apps/partner-ui/src/dashboard-app/routes/get-partner-route.map.tsx
+++ b/apps/partner-ui/src/dashboard-app/routes/get-partner-route.map.tsx
@@ -487,6 +487,13 @@ export function getPartnerRouteMap(): RouteObject[] {
                             import("../../routes/products/product-metadata"),
                         },
                         {
+                          // #1349 — the production spec is written here, in a
+                          // focus modal, and only READ on the detail page.
+                          path: "spec/edit",
+                          lazy: () =>
+                            import("../../routes/products/product-spec"),
+                        },
+                        {
                           path: "options/create",
                           lazy: () =>
                             import(

--- a/apps/partner-ui/src/routes/products/product-detail/components/product-spec-section/product-spec-section.tsx
+++ b/apps/partner-ui/src/routes/products/product-detail/components/product-spec-section/product-spec-section.tsx
@@ -1,94 +1,117 @@
 import { HttpTypes } from "@medusajs/types"
-import { Button, Container, Heading, Text, toast } from "@medusajs/ui"
-import { useEffect, useState } from "react"
+import { PencilSquare } from "@medusajs/icons"
+import { Badge, Container, Heading, Text } from "@medusajs/ui"
 
-import { ProductSpecForm } from "../../../../../components/forms/product-spec-form"
+import { ActionMenu } from "../../../../../components/common/action-menu"
+import { SectionRow } from "../../../../../components/common/section"
+import { Skeleton } from "../../../../../components/common/skeleton"
 import {
   useProductSpec,
-  useUpsertProductSpec,
   useWeaveCatalog,
-  type ProductSpecPayload,
+  type ProductSpecColor,
+  type ProductSpecField,
+  type WeaveTechnique,
 } from "../../../../../hooks/api/products"
-import { extractErrorMessage } from "../../../../../lib/extract-error-message"
 
 type Props = {
   product: HttpTypes.AdminProduct
 }
 
-const EMPTY: ProductSpecPayload = {
-  weave_technique: null,
-  weave_label: null,
-  params: null,
-  finishes: [],
-  notes: null,
-  accepting_custom_orders: false,
-  custom_order_lead_time_days: null,
-  colors: [],
-  fields: [],
+/**
+ * #1342 / #1349 — the partner-authored production spec, as READ-ONLY content.
+ *
+ * This section used to host the editor inline. It now shows what was written
+ * and sends the partner to `spec/edit` (a focus modal) to change it, matching
+ * every other section on this page: detail pages read, modals write. The
+ * previous arrangement put a five-part form in the middle of the main column,
+ * so the sections a partner touches daily sat below a form most products never
+ * use.
+ */
+
+/** A stored param key rendered with the label + unit the catalog defines for
+ *  it. Falls back to the raw key so a param whose technique was later renamed
+ *  still shows its value rather than vanishing. */
+const paramRows = (
+  params: Record<string, number> | null | undefined,
+  technique?: WeaveTechnique
+) => {
+  const entries = Object.entries(params ?? {})
+  if (!entries.length) {
+    return []
+  }
+
+  return entries.map(([key, value]) => {
+    const def = technique?.params.find((p) => p.key === key)
+    return {
+      key,
+      label: def?.label ?? key,
+      value: def?.unit ? `${value} ${def.unit}` : `${value}`,
+    }
+  })
 }
 
-/**
- * #1342 — the partner-authored production spec panel on product detail.
- *
- * The same editor the create wizard uses, loaded from and saved to the linked
- * `product_spec` module. Colours and fields are sent every save (they replace
- * what is stored), which is why an empty palette here means "no palette" rather
- * than "leave it alone".
- */
+const ColorSwatches = ({ colors }: { colors: ProductSpecColor[] }) => (
+  <div className="flex flex-wrap items-center gap-2">
+    {colors.map((color) => (
+      <div
+        key={color.id ?? color.name}
+        className="border-ui-border-base bg-ui-bg-subtle flex items-center gap-x-2 rounded-full border py-1 pl-1 pr-3"
+      >
+        <span
+          className="border-ui-border-base size-5 rounded-full border"
+          style={{ backgroundColor: color.hex_code ?? "transparent" }}
+          // The swatch is decorative; the name beside it carries the meaning.
+          aria-hidden
+        />
+        <Text size="small" leading="compact">
+          {color.name}
+        </Text>
+        {color.available === false && (
+          <Badge size="2xsmall" color="grey">
+            Unavailable
+          </Badge>
+        )}
+      </div>
+    ))}
+  </div>
+)
+
+const CustomFields = ({ fields }: { fields: ProductSpecField[] }) => (
+  <div className="flex flex-col">
+    {fields.map((field) => (
+      <SectionRow
+        key={field.id ?? field.key}
+        title={field.label?.trim() || field.key}
+        value={field.value ?? "-"}
+      />
+    ))}
+  </div>
+)
+
 export const ProductSpecSection = ({ product }: Props) => {
   const { spec, isLoading } = useProductSpec(product.id)
-  const { families, techniques, isLoading: catalogLoading } = useWeaveCatalog()
-  const { mutateAsync, isPending } = useUpsertProductSpec(product.id)
+  const { techniques, isLoading: catalogLoading } = useWeaveCatalog()
 
-  const [value, setValue] = useState<ProductSpecPayload>(EMPTY)
-  const [dirty, setDirty] = useState(false)
+  const technique = techniques?.find((t) => t.slug === spec?.weave_technique)
+  const colors = (spec?.colors ?? [])
+    .slice()
+    .sort((a, b) => (a.order ?? 0) - (b.order ?? 0))
+  const fields = (spec?.fields ?? [])
+    .slice()
+    .sort((a, b) => (a.order ?? 0) - (b.order ?? 0))
+  const params = paramRows(spec?.params, technique)
+  const finishes = spec?.finishes ?? []
 
-  // Hydrate once the saved spec loads. Guarded on `dirty` so a slow refetch
-  // cannot overwrite edits the partner has already started making.
-  useEffect(() => {
-    if (!spec || dirty) return
-    setValue({
-      weave_technique: spec.weave_technique ?? null,
-      weave_label: spec.weave_label ?? null,
-      params: spec.params ?? null,
-      finishes: spec.finishes ?? [],
-      notes: spec.notes ?? null,
-      accepting_custom_orders: !!spec.accepting_custom_orders,
-      custom_order_lead_time_days: spec.custom_order_lead_time_days ?? null,
-      colors: (spec.colors ?? [])
-        .slice()
-        .sort((a, b) => (a.order ?? 0) - (b.order ?? 0)),
-      fields: (spec.fields ?? [])
-        .slice()
-        .sort((a, b) => (a.order ?? 0) - (b.order ?? 0)),
-    })
-  }, [spec, dirty])
-
-  const handleChange = (next: ProductSpecPayload) => {
-    setDirty(true)
-    setValue(next)
-  }
-
-  const handleSave = async () => {
-    // Drop half-written rows rather than sending them: the route rejects a
-    // colour with no name, and losing the whole save over an empty row the
-    // partner forgot about is a worse outcome than silently ignoring it.
-    const payload: ProductSpecPayload = {
-      ...value,
-      weave_label: value.weave_label?.trim() ? value.weave_label.trim() : null,
-      notes: value.notes?.trim() ? value.notes.trim() : null,
-      colors: (value.colors ?? []).filter((c) => c.name.trim()),
-      fields: (value.fields ?? []).filter((f) => (f.label ?? f.key).trim()),
-    }
-
-    try {
-      await mutateAsync(payload)
-      setDirty(false)
-      toast.success("Spec saved")
-    } catch (e) {
-      toast.error(extractErrorMessage(e, "Could not save the spec"))
-    }
-  }
+  // A spec row can exist with nothing but defaults on it, so "has a spec" is
+  // decided by whether anything was actually written — not by the row.
+  const hasContent =
+    !!spec?.weave_technique ||
+    !!spec?.weave_label ||
+    !!spec?.notes ||
+    !!params.length ||
+    !!finishes.length ||
+    !!colors.length ||
+    !!fields.length
 
   return (
     <Container className="divide-y p-0">
@@ -96,29 +119,82 @@ export const ProductSpecSection = ({ product }: Props) => {
         <div>
           <Heading level="h2">Production spec</Heading>
           <Text size="small" className="text-ui-fg-subtle">
-            The weave, colours and specs you'll make this to — agreed before you
-            take a custom order.
+            The weave, colours and specs you&apos;ll make this to — agreed
+            before you take a custom order.
           </Text>
         </div>
-        <Button
-          size="small"
-          onClick={handleSave}
-          isLoading={isPending}
-          disabled={isLoading || !dirty}
-        >
-          Save
-        </Button>
+        <div className="flex items-center gap-x-2">
+          {spec?.accepting_custom_orders && (
+            <Badge size="2xsmall" color="green">
+              {spec.custom_order_lead_time_days
+                ? `Custom orders · ${spec.custom_order_lead_time_days} days`
+                : "Custom orders"}
+            </Badge>
+          )}
+          <ActionMenu
+            groups={[
+              {
+                actions: [
+                  {
+                    label: hasContent ? "Edit" : "Add spec",
+                    to: "spec/edit",
+                    icon: <PencilSquare />,
+                  },
+                ],
+              },
+            ]}
+          />
+        </div>
       </div>
 
-      <div className="px-6 py-6">
-        <ProductSpecForm
-          value={value}
-          onChange={handleChange}
-          techniques={techniques}
-          families={families}
-          isLoading={isLoading || catalogLoading}
-        />
-      </div>
+      {isLoading || catalogLoading ? (
+        <div className="flex flex-col gap-y-2 px-6 py-4">
+          <Skeleton className="h-4 w-1/3" />
+          <Skeleton className="h-4 w-1/2" />
+        </div>
+      ) : !hasContent ? (
+        <div className="px-6 py-4">
+          <Text size="small" className="text-ui-fg-subtle">
+            No production spec yet. Add one so buyers — and anyone quoting a
+            custom order — can see what this is made to.
+          </Text>
+        </div>
+      ) : (
+        <>
+          <SectionRow
+            title="Weave"
+            value={technique?.label ?? spec?.weave_technique ?? "-"}
+          />
+          {spec?.weave_label && (
+            <SectionRow title="Weave name" value={spec.weave_label} />
+          )}
+          {params.map((param) => (
+            <SectionRow
+              key={param.key}
+              title={param.label}
+              value={param.value}
+            />
+          ))}
+          {!!finishes.length && (
+            <SectionRow
+              title="Finishes"
+              value={finishes.map((finish) => (
+                <Badge key={finish} size="2xsmall">
+                  {finish}
+                </Badge>
+              ))}
+            />
+          )}
+          {!!colors.length && (
+            <SectionRow
+              title="Palette"
+              value={<ColorSwatches colors={colors} />}
+            />
+          )}
+          {spec?.notes && <SectionRow title="Notes" value={spec.notes} />}
+          {!!fields.length && <CustomFields fields={fields} />}
+        </>
+      )}
     </Container>
   )
 }

--- a/apps/partner-ui/src/routes/products/product-spec/index.ts
+++ b/apps/partner-ui/src/routes/products/product-spec/index.ts
@@ -1,0 +1,1 @@
+export { ProductSpec as Component } from "./product-spec"

--- a/apps/partner-ui/src/routes/products/product-spec/product-spec.tsx
+++ b/apps/partner-ui/src/routes/products/product-spec/product-spec.tsx
@@ -1,0 +1,158 @@
+import { Button, Heading, Text, toast } from "@medusajs/ui"
+import { useEffect, useState } from "react"
+import { useParams } from "react-router-dom"
+
+import { ProductSpecForm } from "../../../components/forms/product-spec-form"
+import { RouteFocusModal, useRouteModal } from "../../../components/modals"
+import {
+  useProductSpec,
+  useUpsertProductSpec,
+  useWeaveCatalog,
+  type ProductSpecPayload,
+} from "../../../hooks/api/products"
+import { extractErrorMessage } from "../../../lib/extract-error-message"
+
+/**
+ * #1349 — the production spec editor, lifted out of the detail page.
+ *
+ * The section on product detail now READS; writing happens here, in a focus
+ * modal at `products/:id/spec/edit`. The editor is a five-part form (weave,
+ * parameters, finishes, palette, custom fields) and inlining it made the
+ * detail page's main column mostly spec — while the sections above it, which a
+ * partner edits far more often, were pushed off screen.
+ *
+ * Same `ProductSpecForm` the create wizard hosts. There is still exactly one
+ * editor; only its host changed.
+ */
+
+const EMPTY: ProductSpecPayload = {
+  weave_technique: null,
+  weave_label: null,
+  params: null,
+  finishes: [],
+  notes: null,
+  accepting_custom_orders: false,
+  custom_order_lead_time_days: null,
+  colors: [],
+  fields: [],
+}
+
+export const ProductSpec = () => {
+  const { id } = useParams()
+  const { handleSuccess } = useRouteModal()
+
+  const { spec, isLoading, isError, error } = useProductSpec(id!)
+  const { families, techniques, isLoading: catalogLoading } = useWeaveCatalog()
+  const { mutateAsync, isPending } = useUpsertProductSpec(id!)
+
+  const [value, setValue] = useState<ProductSpecPayload>(EMPTY)
+  const [dirty, setDirty] = useState(false)
+
+  // Hydrate once the saved spec loads. Guarded on `dirty` so a slow refetch
+  // cannot overwrite edits the partner has already started making.
+  useEffect(() => {
+    if (!spec || dirty) {
+      return
+    }
+    setValue({
+      weave_technique: spec.weave_technique ?? null,
+      weave_label: spec.weave_label ?? null,
+      params: spec.params ?? null,
+      finishes: spec.finishes ?? [],
+      notes: spec.notes ?? null,
+      accepting_custom_orders: !!spec.accepting_custom_orders,
+      custom_order_lead_time_days: spec.custom_order_lead_time_days ?? null,
+      colors: (spec.colors ?? [])
+        .slice()
+        .sort((a, b) => (a.order ?? 0) - (b.order ?? 0)),
+      fields: (spec.fields ?? [])
+        .slice()
+        .sort((a, b) => (a.order ?? 0) - (b.order ?? 0)),
+    })
+  }, [spec, dirty])
+
+  if (isError) {
+    throw error
+  }
+
+  const handleChange = (next: ProductSpecPayload) => {
+    setDirty(true)
+    setValue(next)
+  }
+
+  const handleSave = async () => {
+    // Drop half-written rows rather than sending them: the route rejects a
+    // colour with no name, and losing the whole save over an empty row the
+    // partner forgot about is a worse outcome than silently ignoring it.
+    const payload: ProductSpecPayload = {
+      ...value,
+      weave_label: value.weave_label?.trim() ? value.weave_label.trim() : null,
+      notes: value.notes?.trim() ? value.notes.trim() : null,
+      colors: (value.colors ?? []).filter((c) => c.name.trim()),
+      fields: (value.fields ?? []).filter((f) => (f.label ?? f.key).trim()),
+    }
+
+    try {
+      await mutateAsync(payload)
+      setDirty(false)
+      toast.success("Spec saved")
+      handleSuccess()
+    } catch (e) {
+      toast.error(extractErrorMessage(e, "Could not save the spec"))
+    }
+  }
+
+  return (
+    <RouteFocusModal>
+      <RouteFocusModal.Header>
+        <div className="flex items-center justify-end gap-x-2">
+          <RouteFocusModal.Close asChild>
+            <Button size="small" variant="secondary">
+              Cancel
+            </Button>
+          </RouteFocusModal.Close>
+          <Button
+            size="small"
+            onClick={handleSave}
+            isLoading={isPending}
+            disabled={isLoading || catalogLoading}
+          >
+            Save
+          </Button>
+        </div>
+      </RouteFocusModal.Header>
+
+      <RouteFocusModal.Title asChild>
+        <span className="sr-only">Edit production spec</span>
+      </RouteFocusModal.Title>
+      <RouteFocusModal.Description asChild>
+        <span className="sr-only">
+          The weave, colours and specs this product is made to.
+        </span>
+      </RouteFocusModal.Description>
+
+      {/* FocusModal.Body does not scroll on its own in this app — without
+       *  overflow-y-auto a spec with a long palette is unreachable below the
+       *  fold. Same trap the partner-ui modal audit records. */}
+      <RouteFocusModal.Body className="flex flex-1 flex-col overflow-y-auto">
+        <div className="mx-auto flex w-full max-w-[720px] flex-col gap-y-6 px-6 py-16">
+          <div className="flex flex-col gap-y-1">
+            <Heading level="h2">Production spec</Heading>
+            <Text size="small" className="text-ui-fg-subtle">
+              The weave, colours and specs you&apos;ll make this to — agreed
+              before you take a custom order.
+            </Text>
+          </div>
+
+          <ProductSpecForm
+            value={value}
+            onChange={handleChange}
+            techniques={techniques}
+            families={families}
+            isLoading={isLoading || catalogLoading}
+          />
+        </div>
+      </RouteFocusModal.Body>
+    </RouteFocusModal>
+  )
+}

--- a/apps/storefront/src/lib/data/product-spec.ts
+++ b/apps/storefront/src/lib/data/product-spec.ts
@@ -1,0 +1,133 @@
+"use server"
+
+import { revalidateTag } from "next/cache"
+
+import { sdk } from "@lib/config"
+import medusaError from "@lib/util/medusa-error"
+
+import { getAuthHeaders, getCacheOptions, getCacheTag } from "./cookies"
+import { getOrSetCart } from "./cart"
+
+/**
+ * #1349 — the production spec on the storefront.
+ *
+ * Reading it is public and cacheable; ordering against it is not. The colour a
+ * customer may choose is decided by the BACKEND against the partner's published
+ * palette (`/store/carts/:id/made-to-spec`), never here — this file builds the
+ * request, it does not get to decide what is orderable.
+ */
+
+export type StoreSpecColor = {
+  id?: string
+  name: string
+  hex_code?: string | null
+  usage_notes?: string | null
+}
+
+export type StoreSpecField = {
+  key: string
+  label?: string | null
+  value?: string | null
+}
+
+export type StoreProductSpec = {
+  id?: string
+  weave_technique?: string | null
+  weave_label?: string | null
+  params?: Record<string, number> | null
+  finishes?: string[]
+  accepting_custom_orders?: boolean
+  custom_order_lead_time_days?: number | null
+  colors: StoreSpecColor[]
+  fields: StoreSpecField[]
+}
+
+export type StoreSpecTechnique = {
+  slug: string
+  label: string
+  family: string
+  description: string
+  params: { key: string; label: string; unit: string }[]
+}
+
+export type StoreProductSpecResponse = {
+  spec: StoreProductSpec | null
+  technique: StoreSpecTechnique | null
+}
+
+/**
+ * A product's spec, by id or handle.
+ *
+ * Most products have none, and that is not an error — an absent spec resolves
+ * to `{ spec: null }` so a product page never fails over a block it was only
+ * going to render conditionally.
+ */
+export const getProductSpec = async (
+  idOrHandle: string
+): Promise<StoreProductSpecResponse> => {
+  const next = {
+    ...(await getCacheOptions(`product-spec-${idOrHandle}`)),
+  }
+
+  return sdk.client
+    .fetch<StoreProductSpecResponse>(
+      `/store/products/${encodeURIComponent(idOrHandle)}/spec`,
+      { next, cache: "force-cache" }
+    )
+    .catch(() => ({ spec: null, technique: null }))
+}
+
+/**
+ * Add a made-to-order piece to the cart.
+ *
+ * Posts the customer's colourway and note to the validating route, which
+ * refuses anything the partner has not published and snapshots what it accepts
+ * onto the line item. A rejection is surfaced verbatim — the backend's message
+ * names the colours that ARE available, which is what the shopper needs.
+ */
+export async function addMadeToSpecToCart({
+  variantId,
+  quantity,
+  color,
+  note,
+  countryCode,
+}: {
+  variantId: string
+  quantity: number
+  color?: string | null
+  note?: string | null
+  countryCode: string
+}) {
+  if (!variantId) {
+    throw new Error("Missing variant ID when ordering a made-to-order piece")
+  }
+
+  const cart = await getOrSetCart(countryCode)
+
+  if (!cart) {
+    throw new Error("Error retrieving or creating cart")
+  }
+
+  const headers = {
+    ...(await getAuthHeaders()),
+  }
+
+  await sdk.client
+    .fetch(`/store/carts/${cart.id}/made-to-spec`, {
+      method: "POST",
+      body: {
+        variant_id: variantId,
+        quantity,
+        color: color || undefined,
+        note: note || undefined,
+      },
+      headers,
+    })
+    .catch(medusaError)
+
+  const cartCacheTag = await getCacheTag("carts")
+  revalidateTag(cartCacheTag)
+
+  const fulfillmentCacheTag = await getCacheTag("fulfillment")
+  revalidateTag(fulfillmentCacheTag)
+}

--- a/apps/storefront/src/modules/cart/components/item/index.tsx
+++ b/apps/storefront/src/modules/cart/components/item/index.tsx
@@ -69,7 +69,13 @@ const Item = ({ item, type = "full", currencyCode }: ItemProps) => {
         >
           {item.product_title || item.title}
         </Text>
-        {item.variant && <LineItemOptions variant={item.variant} data-testid="product-variant" />}
+        {item.variant && (
+          <LineItemOptions
+            variant={item.variant}
+            metadata={item.metadata}
+            data-testid="product-variant"
+          />
+        )}
       </Table.Cell>
 
       {type === "full" && (

--- a/apps/storefront/src/modules/common/components/line-item-options/index.tsx
+++ b/apps/storefront/src/modules/common/components/line-item-options/index.tsx
@@ -1,25 +1,93 @@
 import { HttpTypes } from "@medusajs/types"
 import { Text } from "@medusajs/ui"
 
+/**
+ * #1349 — the made-to-order snapshot written onto the line item by
+ * `/store/carts/:id/made-to-spec`. Read defensively: it is metadata, so an
+ * older line item, or one added by any other path, simply has none.
+ */
+type MadeToSpec = {
+  weave?: string | null
+  color_name?: string
+  color_hex?: string | null
+  lead_time_days?: number | null
+  note?: string | null
+}
+
+const readMadeToSpec = (
+  metadata: Record<string, unknown> | null | undefined
+): MadeToSpec | null => {
+  const value = metadata?.made_to_spec
+  if (!value || typeof value !== "object") {
+    return null
+  }
+  return value as MadeToSpec
+}
+
 type LineItemOptionsProps = {
   variant: HttpTypes.StoreProductVariant | undefined
+  /** Line-item metadata, when the caller has it. */
+  metadata?: Record<string, unknown> | null
   "data-testid"?: string
   "data-value"?: HttpTypes.StoreProductVariant
 }
 
 const LineItemOptions = ({
   variant,
+  metadata,
   "data-testid": dataTestid,
   "data-value": dataValue,
 }: LineItemOptionsProps) => {
+  const madeToSpec = readMadeToSpec(metadata)
+
   return (
-    <Text
-      data-testid={dataTestid}
-      data-value={dataValue}
-      className="inline-block txt-medium text-ui-fg-subtle w-full overflow-hidden text-ellipsis"
-    >
-      Variant: {variant?.title}
-    </Text>
+    <div className="flex flex-col gap-y-1">
+      <Text
+        data-testid={dataTestid}
+        data-value={dataValue}
+        className="inline-block txt-medium text-ui-fg-subtle w-full overflow-hidden text-ellipsis"
+      >
+        Variant: {variant?.title}
+      </Text>
+
+      {/* Shown wherever a line item is shown — cart, cart dropdown and the
+       *  order confirmation all render through this component. A customer who
+       *  chose a colourway needs to see it on the order, not only at the
+       *  moment they picked it. */}
+      {madeToSpec && (
+        <div
+          className="flex flex-col gap-y-0.5"
+          data-testid="line-item-made-to-spec"
+        >
+          <div className="flex items-center gap-x-2">
+            {madeToSpec.color_hex && (
+              <span
+                className="border-ui-border-base size-3 shrink-0 rounded-full border"
+                style={{ backgroundColor: madeToSpec.color_hex }}
+                aria-hidden
+              />
+            )}
+            <Text className="txt-small text-ui-fg-subtle">
+              Made to order
+              {madeToSpec.color_name ? ` — ${madeToSpec.color_name}` : ""}
+              {madeToSpec.lead_time_days
+                ? ` · about ${madeToSpec.lead_time_days} days`
+                : ""}
+            </Text>
+          </div>
+          {madeToSpec.weave && (
+            <Text className="txt-small text-ui-fg-muted">
+              {madeToSpec.weave}
+            </Text>
+          )}
+          {madeToSpec.note && (
+            <Text className="txt-small text-ui-fg-muted italic">
+              “{madeToSpec.note}”
+            </Text>
+          )}
+        </div>
+      )}
+    </div>
   )
 }
 

--- a/apps/storefront/src/modules/layout/components/cart-dropdown/index.tsx
+++ b/apps/storefront/src/modules/layout/components/cart-dropdown/index.tsx
@@ -145,6 +145,7 @@ const CartDropdown = ({
                                 </h3>
                                 <LineItemOptions
                                   variant={item.variant}
+                                  metadata={item.metadata}
                                   data-testid="cart-item-variant"
                                   data-value={item.variant}
                                 />

--- a/apps/storefront/src/modules/order/components/item/index.tsx
+++ b/apps/storefront/src/modules/order/components/item/index.tsx
@@ -27,7 +27,13 @@ const Item = ({ item, currencyCode }: ItemProps) => {
         >
           {item.product_title || item.title}
         </Text>
-        {item.variant && <LineItemOptions variant={item.variant} data-testid="product-variant" />}
+        {item.variant && (
+          <LineItemOptions
+            variant={item.variant}
+            metadata={item.metadata}
+            data-testid="product-variant"
+          />
+        )}
       </Table.Cell>
 
       <Table.Cell className="!pr-0">

--- a/apps/storefront/src/modules/products/components/production-spec/index.tsx
+++ b/apps/storefront/src/modules/products/components/production-spec/index.tsx
@@ -1,0 +1,109 @@
+import { HttpTypes } from "@medusajs/types"
+import { Text } from "@medusajs/ui"
+
+import { getProductSpec } from "@lib/data/product-spec"
+
+import MadeToOrderForm from "./made-to-order-form"
+
+/**
+ * #1349 — the production spec on the product page.
+ *
+ * Two things, in this order: what the piece IS made to (weave, measured
+ * parameters, finishes, the partner's own specs), and — only when the partner
+ * is taking the work — the form to have one made in a colour of the customer's
+ * choosing.
+ *
+ * A server component, so the spec is fetched and cached with the page rather
+ * than after it paints. It renders nothing at all when a product has no spec,
+ * which is the normal case.
+ */
+
+type Props = {
+  product: HttpTypes.StoreProduct
+}
+
+const ProductionSpec = async ({ product }: Props) => {
+  const { spec, technique } = await getProductSpec(product.id)
+
+  if (!spec) {
+    return null
+  }
+
+  const params = Object.entries(spec.params ?? {}).map(([key, value]) => {
+    const def = technique?.params.find((p) => p.key === key)
+    return {
+      key,
+      label: def?.label ?? key,
+      value: def?.unit ? `${value} ${def.unit}` : `${value}`,
+    }
+  })
+
+  const rows = [
+    ...(technique?.label || spec.weave_label
+      ? [
+          {
+            key: "weave",
+            label: "Weave",
+            value: spec.weave_label || technique?.label || "",
+          },
+        ]
+      : []),
+    ...params,
+    ...(spec.finishes?.length
+      ? [
+          {
+            key: "finishes",
+            label: "Finishing & care",
+            value: spec.finishes.join(", "),
+          },
+        ]
+      : []),
+    ...spec.fields
+      .filter((field) => (field.value ?? "").trim())
+      .map((field) => ({
+        key: field.key,
+        label: (field.label ?? field.key).trim(),
+        value: (field.value ?? "").trim(),
+      })),
+  ]
+
+  // A spec row can exist with nothing written on it. Rendering a heading over
+  // an empty table would advertise detail the partner never provided.
+  if (!rows.length && !spec.accepting_custom_orders) {
+    return null
+  }
+
+  return (
+    <div className="flex flex-col gap-y-6 py-8">
+      {!!rows.length && (
+        <div className="flex flex-col gap-y-3">
+          <Text className="text-ui-fg-base font-medium">Made to</Text>
+          <dl className="grid grid-cols-1 gap-x-8 gap-y-2 small:grid-cols-2">
+            {rows.map((row) => (
+              <div
+                key={row.key}
+                className="flex items-baseline justify-between gap-x-4 border-b border-ui-border-base py-2"
+              >
+                <dt className="text-ui-fg-subtle text-sm">{row.label}</dt>
+                <dd className="text-ui-fg-base text-sm text-right">
+                  {row.value}
+                </dd>
+              </div>
+            ))}
+          </dl>
+          {technique?.description && (
+            <Text size="small" className="text-ui-fg-muted">
+              {technique.description}
+            </Text>
+          )}
+        </div>
+      )}
+
+      {spec.accepting_custom_orders && (
+        <MadeToOrderForm spec={spec} variants={product.variants ?? []} />
+      )}
+    </div>
+  )
+}
+
+export default ProductionSpec

--- a/apps/storefront/src/modules/products/components/production-spec/made-to-order-form.tsx
+++ b/apps/storefront/src/modules/products/components/production-spec/made-to-order-form.tsx
@@ -1,0 +1,172 @@
+"use client"
+
+import { Button, Text, clx } from "@medusajs/ui"
+import { HttpTypes } from "@medusajs/types"
+import { useParams } from "next/navigation"
+import { useState } from "react"
+
+import { addMadeToSpecToCart, type StoreProductSpec } from "@lib/data/product-spec"
+
+/**
+ * #1349 — ordering a piece made to the partner's spec, in a colour the customer
+ * chooses from the partner's palette.
+ *
+ * Deliberately SEPARATE from the ordinary add-to-cart control rather than a
+ * mode inside it. "Buy this piece" and "have this woven for me in walnut, in
+ * about six weeks" are different purchases with different lead times, and
+ * folding them into one button hides the wait until checkout.
+ *
+ * The palette rendered here is only what the storefront was told is available;
+ * the backend re-checks the choice on submit, so a stale page cannot place an
+ * order for a colour the partner has since withdrawn.
+ */
+
+type Props = {
+  spec: StoreProductSpec
+  variants: HttpTypes.StoreProductVariant[]
+}
+
+const MadeToOrderForm = ({ spec, variants }: Props) => {
+  const countryCode = useParams().countryCode as string
+
+  const [variantId, setVariantId] = useState(variants[0]?.id ?? "")
+  const [color, setColor] = useState<string | null>(
+    spec.colors[0]?.name ?? null
+  )
+  const [note, setNote] = useState("")
+  const [isAdding, setIsAdding] = useState(false)
+  const [error, setError] = useState<string | null>(null)
+  const [added, setAdded] = useState(false)
+
+  const handleSubmit = async () => {
+    setIsAdding(true)
+    setError(null)
+    try {
+      await addMadeToSpecToCart({
+        variantId,
+        quantity: 1,
+        color,
+        note,
+        countryCode,
+      })
+      setAdded(true)
+    } catch (e: any) {
+      // The backend's rejection names the colours that ARE available. Showing
+      // our own generic message instead would throw that away.
+      setError(e?.message || "We couldn't add this made-to-order piece.")
+    } finally {
+      setIsAdding(false)
+    }
+  }
+
+  return (
+    <div className="flex flex-col gap-y-4 border-t border-ui-border-base pt-6">
+      <div className="flex flex-col gap-y-1">
+        <Text className="text-ui-fg-base font-medium">Have it made for you</Text>
+        <Text size="small" className="text-ui-fg-subtle">
+          {spec.custom_order_lead_time_days
+            ? `Woven to order in your colour — about ${spec.custom_order_lead_time_days} days.`
+            : "Woven to order in the colour you choose."}
+        </Text>
+      </div>
+
+      {variants.length > 1 && (
+        <div className="flex flex-col gap-y-2">
+          <Text size="small" className="text-ui-fg-subtle">
+            Size
+          </Text>
+          <select
+            className="border-ui-border-base bg-ui-bg-field h-10 rounded-md border px-3 text-sm"
+            value={variantId}
+            onChange={(e) => setVariantId(e.target.value)}
+          >
+            {variants.map((variant) => (
+              <option key={variant.id} value={variant.id}>
+                {variant.title}
+              </option>
+            ))}
+          </select>
+        </div>
+      )}
+
+      {!!spec.colors.length && (
+        <div className="flex flex-col gap-y-2">
+          <Text size="small" className="text-ui-fg-subtle">
+            Colour{color ? ` — ${color}` : ""}
+          </Text>
+          <div className="flex flex-wrap gap-2">
+            {spec.colors.map((option) => {
+              const selected = option.name === color
+              return (
+                <button
+                  key={option.id ?? option.name}
+                  type="button"
+                  onClick={() => setColor(option.name)}
+                  aria-pressed={selected}
+                  // The name is in the label, not only the swatch — a palette
+                  // told apart by colour alone is unusable to anyone who
+                  // cannot distinguish the swatches.
+                  aria-label={
+                    option.usage_notes
+                      ? `${option.name} — ${option.usage_notes}`
+                      : option.name
+                  }
+                  title={option.usage_notes ?? option.name}
+                  className={clx(
+                    "flex items-center gap-x-2 rounded-full border py-1 pl-1 pr-3 transition-colors",
+                    selected
+                      ? "border-ui-fg-base bg-ui-bg-base"
+                      : "border-ui-border-base bg-ui-bg-subtle hover:border-ui-fg-muted"
+                  )}
+                >
+                  <span
+                    className="border-ui-border-base size-6 rounded-full border"
+                    style={{ backgroundColor: option.hex_code ?? "transparent" }}
+                    aria-hidden
+                  />
+                  <Text size="small">{option.name}</Text>
+                </button>
+              )
+            })}
+          </div>
+        </div>
+      )}
+
+      <div className="flex flex-col gap-y-2">
+        <Text size="small" className="text-ui-fg-subtle">
+          Anything we should know? (optional)
+        </Text>
+        <textarea
+          rows={2}
+          maxLength={500}
+          value={note}
+          onChange={(e) => setNote(e.target.value)}
+          placeholder="For a September wedding — a wider border if possible."
+          className="border-ui-border-base bg-ui-bg-field rounded-md border px-3 py-2 text-sm"
+        />
+      </div>
+
+      {error && (
+        <Text size="small" className="text-ui-fg-error">
+          {error}
+        </Text>
+      )}
+
+      <Button
+        onClick={handleSubmit}
+        isLoading={isAdding}
+        disabled={isAdding || !variantId}
+        variant="secondary"
+        className="w-full"
+      >
+        {added ? "Added — add another" : "Add made-to-order piece"}
+      </Button>
+
+      <Text size="xsmall" className="text-ui-fg-muted">
+        Made-to-order pieces are woven for you after the order is placed.
+      </Text>
+    </div>
+  )
+}
+
+export default MadeToOrderForm

--- a/apps/storefront/src/modules/products/templates/index.tsx
+++ b/apps/storefront/src/modules/products/templates/index.tsx
@@ -13,6 +13,7 @@ import { notFound } from "next/navigation"
 import ProductActionsWrapper from "./product-actions-wrapper"
 import SizeGuide from "@modules/products/components/size-guide"
 import MakerStory from "@modules/products/components/artisan-detail/maker-story"
+import ProductionSpec from "@modules/products/components/production-spec"
 import MadeToOrderNotice from "@modules/products/components/artisan-detail/made-to-order-notice"
 import { getArtisanDetail } from "@modules/products/components/artisan-detail"
 import { HttpTypes } from "@medusajs/types"
@@ -139,6 +140,10 @@ const ProductTemplate = async ({
 
             <ProductActionsWrapper id={product.id} region={region} />
             <MadeToOrderNotice detail={getArtisanDetail(product)} className="mt-4" />
+            {/* #1349 — what the piece is made to, and (when the partner takes
+                the work) the form to have one woven in a chosen colour. Renders
+                nothing when the product has no spec, which is most of them. */}
+            <ProductionSpec product={product} />
             <MakerStory product={product} className="mt-4" />
             <div className="mt-4 flex items-center gap-x-2">
               <Text className="txt-medium">Size Guide</Text>


### PR DESCRIPTION
Three surfaces for the production spec (#1342), plus the storefront half of the product-builder guide.

## Partner UI — the section reads, a `RouteFocusModal` writes
`ProductSpecSection` now shows weave + measured params (with the labels and units the catalog defines), finish badges, colour swatches, custom fields and a custom-orders badge carrying the lead time. Editing moved to `products/:id/spec/edit`, hosting the same `ProductSpecForm` the create wizard hosts — detail pages read, modals write, like every other section on that page.

A five-part form inlined in the main column pushed the sections a partner edits daily below a form most products never use.

`FocusModal.Body` gets `overflow-y-auto`; without it a long palette is unreachable below the fold.

## Admin — a `product.details.after` widget with the same split
Admins were the one audience with **no way to see a spec at all** — it was reachable only through the partner portal or an MCP call, so "what is this piece made to?" could not be answered from the admin.

`FocusModal` rather than the `Drawer` the admin guidance prefers for edits: a parameter grid plus a repeatable palette wraps at drawer width. The rule exists to keep edits light; this edit is not.

The editor is a deliberate **port**, not an import — partner-ui and the admin extension are separate builds and the backend tsconfig excludes `apps/*`. What stops them drifting is that both generate every weave, preset, parameter and range from `/…/products/spec-catalog`, served by the same `weaving-techniques.ts` the upsert workflow validates against. Only the chrome is duplicated; the vocabulary keeps one owner.

## Storefront — made to order
The tutorial's storefront mechanism (the configuration rides on the line item, the order replays it), adapted to a spec that is *authored by the partner* rather than assembled by the shopper.

- `GET /store/products/:id/spec` — public, by id **or handle** so a page routed by handle needs no second call. Returns the resolved technique alongside, because stored params are keys (`gsm`) and a customer needs labels and units. Unavailable colours are filtered **here**, so every storefront agrees on what is orderable. `notes` is withheld — the partner editor calls it "notes for the workshop", and publishing them would change what partners feel able to write.
- `POST /store/carts/:id/made-to-spec` — validates, then delegates to `addToCartWorkflow`. A dedicated route rather than the core `/line-items` call with metadata, because whether a colour is orderable is a rule that lives in the spec; a client posting metadata straight through would be trusted.

Two rules carry the weight, both in a pure tested lib:

1. **The palette is closed.** A colour must be listed *and* left available. A check that only asked "is this name known?" would sell the colourway a partner just withdrew.
2. **The selection is copied, not referenced.** Weave, colour, lead time and the spec's own fields are snapshotted onto the line item. Holding a `spec_id` would let a partner editing their lead time next week silently rewrite what a customer was promised last week.

14 unit tests. **Verified they bite: removing the availability filter fails 2 of them; restoring it passes all 14.**

`LineItemOptions` grew an optional `metadata` prop, so the chosen colourway shows in the cart, the cart dropdown and the order confirmation from one change.

## Also
- MCP: nothing new needed — #1346/#1347 already put `get_spec_catalog`, `get_product_spec` and `set_product_spec` on **both** assistants.
- `apps/storefront-starter` is a submodule on its own Vercel project: Jaal-Yantra-Textiles/nextjs-starter-medusa#8, and the pointer bump here. Merging that PR is what puts the block on partner storefronts.

## Not verified
No UI pass on any of the three surfaces, and no order has been placed through the made-to-order path. `check:prod-build` passes; backend spec suites are green (69 tests).

🤖 Generated with [Claude Code](https://claude.com/claude-code)