### PR TITLE
fix(product-spec): host the spec editors inside their modal provider

### DIFF
--- a/apps/backend/src/admin/components/forms/product-spec/product-spec-edit-form.tsx
+++ b/apps/backend/src/admin/components/forms/product-spec/product-spec-edit-form.tsx
@@ -2,35 +2,34 @@ import { Button, Heading, Text, toast } from "@medusajs/ui"
 import { useEffect, useState } from "react"
 import { useParams } from "react-router-dom"
 
-import { ProductSpecForm } from "../../../components/forms/product-spec-form"
-import { RouteFocusModal, useRouteModal } from "../../../components/modals"
+import { ProductSpecForm } from "../../product-spec-form"
+import { RouteFocusModal } from "../../modal/route-focus-modal"
+import { useRouteModal } from "../../modal/use-route-modal"
 import {
   useProductSpec,
   useUpsertProductSpec,
   useWeaveCatalog,
   type ProductSpecPayload,
-} from "../../../hooks/api/products"
-import { extractErrorMessage } from "../../../lib/extract-error-message"
+} from "../../../hooks/api/product-spec"
 
 /**
- * #1349 — the production spec editor, lifted out of the detail page.
+ * #1349 — the ADMIN production spec editor.
  *
- * The section on product detail now READS; writing happens here, in a focus
- * modal at `products/:id/spec/edit`. The editor is a five-part form (weave,
- * parameters, finishes, palette, custom fields) and inlining it made the
- * detail page's main column mostly spec — while the sections above it, which a
- * partner edits far more often, were pushed off screen.
+ * Lives on its own route (`/products/:id/spec`) rather than inside the widget,
+ * so the edit is a `RouteFocusModal` like every other admin edit of this size —
+ * closing returns to the product page, the URL is shareable, and back works.
  *
- * Same `ProductSpecForm` the create wizard hosts. There is still exactly one
- * editor; only its host changed.
+ * The widget it replaced held the modal itself with local `open` state. A
+ * routed modal cannot be driven that way: `RouteFocusModal` opens on mount and
+ * navigates to `prev` on close, so hosting one inside an always-mounted widget
+ * would pop the editor open on every product page load and, on close, navigate
+ * off the product entirely.
  *
- * Split into a host and an inner component on purpose: `RouteFocusModal`
- * creates the `RouteModalProvider` around its OWN children, so a
- * `useRouteModal()` call in the component that renders the modal sits outside
- * the context and throws "useRouteModal must be used within a
- * RouteModalProvider" the moment the route is opened. Every other route modal
- * in this app is shaped the same way — host renders the shell, a child holds
- * the hook.
+ * NOTE the host/child split below. `RouteFocusModal` creates the
+ * `RouteModalProvider` around its OWN children, so the component that renders
+ * the modal must not call `useRouteModal()` — that is what threw
+ * "useRouteModal must be used within a RouteModalProvider" on the partner side
+ * of this same feature.
  */
 
 const EMPTY: ProductSpecPayload = {
@@ -45,20 +44,21 @@ const EMPTY: ProductSpecPayload = {
   fields: [],
 }
 
-/** Everything that needs the modal context. Only ever rendered as a child of
- *  `RouteFocusModal`, which is what makes `useRouteModal` legal here. */
-const ProductSpecEditor = ({ id }: { id: string }) => {
+export const ProductSpecEditForm = () => {
+  const { id } = useParams()
+  const productId = id!
+
   const { handleSuccess } = useRouteModal()
 
-  const { spec, isLoading, isError, error } = useProductSpec(id)
-  const { families, techniques, isLoading: catalogLoading } = useWeaveCatalog()
-  const { mutateAsync, isPending } = useUpsertProductSpec(id)
+  const { spec, isLoading } = useProductSpec(productId)
+  const { techniques, families, isLoading: catalogLoading } = useWeaveCatalog()
+  const { mutateAsync, isPending } = useUpsertProductSpec(productId)
 
   const [value, setValue] = useState<ProductSpecPayload>(EMPTY)
   const [dirty, setDirty] = useState(false)
 
   // Hydrate once the saved spec loads. Guarded on `dirty` so a slow refetch
-  // cannot overwrite edits the partner has already started making.
+  // cannot overwrite edits the admin has already started making.
   useEffect(() => {
     if (!spec || dirty) {
       return
@@ -80,19 +80,10 @@ const ProductSpecEditor = ({ id }: { id: string }) => {
     })
   }, [spec, dirty])
 
-  if (isError) {
-    throw error
-  }
-
-  const handleChange = (next: ProductSpecPayload) => {
-    setDirty(true)
-    setValue(next)
-  }
-
   const handleSave = async () => {
     // Drop half-written rows rather than sending them: the route rejects a
-    // colour with no name, and losing the whole save over an empty row the
-    // partner forgot about is a worse outcome than silently ignoring it.
+    // colour with no name, and losing the whole save over a row the admin
+    // forgot about is worse than silently ignoring it.
     const payload: ProductSpecPayload = {
       ...value,
       weave_label: value.weave_label?.trim() ? value.weave_label.trim() : null,
@@ -104,10 +95,10 @@ const ProductSpecEditor = ({ id }: { id: string }) => {
     try {
       await mutateAsync(payload)
       setDirty(false)
-      toast.success("Spec saved")
+      toast.success("Production spec saved")
       handleSuccess()
-    } catch (e) {
-      toast.error(extractErrorMessage(e, "Could not save the spec"))
+    } catch (e: any) {
+      toast.error(e?.message || "Could not save the production spec")
     }
   }
 
@@ -140,22 +131,23 @@ const ProductSpecEditor = ({ id }: { id: string }) => {
         </span>
       </RouteFocusModal.Description>
 
-      {/* FocusModal.Body does not scroll on its own in this app — without
-       *  overflow-y-auto a spec with a long palette is unreachable below the
-       *  fold. Same trap the partner-ui modal audit records. */}
+      {/* FocusModal.Body does not scroll on its own — without overflow-y-auto a
+       *  spec with a long palette is unreachable below the fold. */}
       <RouteFocusModal.Body className="flex flex-1 flex-col overflow-y-auto">
         <div className="mx-auto flex w-full max-w-[720px] flex-col gap-y-6 px-6 py-16">
           <div className="flex flex-col gap-y-1">
             <Heading level="h2">Production spec</Heading>
             <Text size="small" className="text-ui-fg-subtle">
-              The weave, colours and specs you&apos;ll make this to — agreed
-              before you take a custom order.
+              What this product is made to.
             </Text>
           </div>
 
           <ProductSpecForm
             value={value}
-            onChange={handleChange}
+            onChange={(next) => {
+              setDirty(true)
+              setValue(next)
+            }}
             techniques={techniques}
             families={families}
             isLoading={isLoading || catalogLoading}
@@ -163,15 +155,5 @@ const ProductSpecEditor = ({ id }: { id: string }) => {
         </div>
       </RouteFocusModal.Body>
     </>
-  )
-}
-
-export const ProductSpec = () => {
-  const { id } = useParams()
-
-  return (
-    <RouteFocusModal>
-      <ProductSpecEditor id={id!} />
-    </RouteFocusModal>
   )
 }

--- a/apps/backend/src/admin/routes/products/[id]/spec/page.tsx
+++ b/apps/backend/src/admin/routes/products/[id]/spec/page.tsx
@@ -1,0 +1,16 @@
+import { RouteFocusModal } from "../../../../components/modal/route-focus-modal"
+import { ProductSpecEditForm } from "../../../../components/forms/product-spec/product-spec-edit-form"
+
+/**
+ * #1349 — `/products/:id/spec`. Same shape as `link-design`: the page is the
+ * modal shell, the form is its child (and the only thing allowed to call
+ * `useRouteModal`). Closing returns to the product page via the modal's
+ * default `prev` of "..".
+ */
+export default function ProductSpecPage() {
+  return (
+    <RouteFocusModal>
+      <ProductSpecEditForm />
+    </RouteFocusModal>
+  )
+}

--- a/apps/backend/src/admin/widgets/product-production-spec.tsx
+++ b/apps/backend/src/admin/widgets/product-production-spec.tsx
@@ -1,55 +1,38 @@
 import { defineWidgetConfig } from "@medusajs/admin-sdk"
 import { DetailWidgetProps } from "@medusajs/framework/types"
 import { PencilSquare } from "@medusajs/icons"
-import {
-  Badge,
-  Button,
-  Container,
-  FocusModal,
-  Heading,
-  Text,
-  toast,
-} from "@medusajs/ui"
-import { useEffect, useState } from "react"
+import { Badge, Button, Container, Heading, Text } from "@medusajs/ui"
+import { useNavigate } from "react-router-dom"
 
-import { ProductSpecForm } from "../components/product-spec-form"
 import {
   useProductSpec,
-  useUpsertProductSpec,
   useWeaveCatalog,
   type ProductSpecColor,
   type ProductSpecField,
-  type ProductSpecPayload,
   type WeaveTechnique,
 } from "../hooks/api/product-spec"
 
 /**
  * #1349 — the production spec on the ADMIN product page.
  *
- * Same shape as the partner surface: the widget READS, and a modal writes.
- * Admins were the one audience with no way to see a spec at all — the data was
- * reachable only through the partner portal or an MCP call, so a support
- * question about what a piece is made to could not be answered from the admin.
+ * Same shape as the partner surface: the widget READS, and a separate route
+ * writes. Admins were the one audience with no way to see a spec at all — the
+ * data was reachable only through the partner portal or an MCP call, so a
+ * support question about what a piece is made to could not be answered from
+ * the admin.
  *
- * A `FocusModal` rather than the `Drawer` the admin guidance prefers for edits:
- * the editor is a five-part form with a parameter grid and a repeatable colour
- * palette, and a drawer's width forces every row to wrap. The rule exists so
- * edits stay in place and lightweight; this edit is neither.
+ * The editor is a `RouteFocusModal` at `/products/:id/spec`, not a `FocusModal`
+ * held open by this widget's own state. A widget is mounted with the product
+ * page, and `RouteFocusModal` opens on mount and navigates away on close, so
+ * the two cannot be combined — hence the navigate below, which is how
+ * `product-designs` opens `link-design` too. A `FocusModal` rather than the
+ * `Drawer` the admin guidance prefers for edits: the editor is a five-part form
+ * with a parameter grid and a repeatable colour palette, and a drawer's width
+ * forces every row to wrap. The rule exists so edits stay in place and
+ * lightweight; this edit is neither.
  */
 
 type AdminProduct = { id: string; title?: string }
-
-const EMPTY: ProductSpecPayload = {
-  weave_technique: null,
-  weave_label: null,
-  params: null,
-  finishes: [],
-  notes: null,
-  accepting_custom_orders: false,
-  custom_order_lead_time_days: null,
-  colors: [],
-  fields: [],
-}
 
 /** A stored param rendered with the label + unit its technique defines. Falls
  *  back to the raw key so a param whose technique was renamed still shows. */
@@ -78,36 +61,10 @@ const Row = ({ label, children }: { label: string; children: React.ReactNode }) 
 const ProductProductionSpecWidget = ({
   data: product,
 }: DetailWidgetProps<AdminProduct>) => {
-  const [open, setOpen] = useState(false)
-  const [value, setValue] = useState<ProductSpecPayload>(EMPTY)
-  const [dirty, setDirty] = useState(false)
+  const navigate = useNavigate()
 
-  // Display query — no `enabled` gate on modal state, or the widget renders
-  // empty every time the page is refreshed with the modal closed.
   const { spec, isLoading } = useProductSpec(product.id)
-  const { techniques, families, isLoading: catalogLoading } = useWeaveCatalog()
-  const { mutateAsync, isPending } = useUpsertProductSpec(product.id)
-
-  useEffect(() => {
-    if (!spec || dirty) {
-      return
-    }
-    setValue({
-      weave_technique: spec.weave_technique ?? null,
-      weave_label: spec.weave_label ?? null,
-      params: spec.params ?? null,
-      finishes: spec.finishes ?? [],
-      notes: spec.notes ?? null,
-      accepting_custom_orders: !!spec.accepting_custom_orders,
-      custom_order_lead_time_days: spec.custom_order_lead_time_days ?? null,
-      colors: (spec.colors ?? [])
-        .slice()
-        .sort((a, b) => (a.order ?? 0) - (b.order ?? 0)),
-      fields: (spec.fields ?? [])
-        .slice()
-        .sort((a, b) => (a.order ?? 0) - (b.order ?? 0)),
-    })
-  }, [spec, dirty])
+  const { techniques, isLoading: catalogLoading } = useWeaveCatalog()
 
   const technique = techniques.find((t) => t.slug === spec?.weave_technique)
   const colors: ProductSpecColor[] = (spec?.colors ?? [])
@@ -130,28 +87,6 @@ const ProductProductionSpecWidget = ({
     !!colors.length ||
     !!fields.length
 
-  const handleSave = async () => {
-    // Drop half-written rows rather than sending them: the route rejects a
-    // colour with no name, and losing the whole save over a row the admin
-    // forgot about is worse than silently ignoring it.
-    const payload: ProductSpecPayload = {
-      ...value,
-      weave_label: value.weave_label?.trim() ? value.weave_label.trim() : null,
-      notes: value.notes?.trim() ? value.notes.trim() : null,
-      colors: (value.colors ?? []).filter((c) => c.name.trim()),
-      fields: (value.fields ?? []).filter((f) => (f.label ?? f.key).trim()),
-    }
-
-    try {
-      await mutateAsync(payload)
-      setDirty(false)
-      setOpen(false)
-      toast.success("Production spec saved")
-    } catch (e: any) {
-      toast.error(e?.message || "Could not save the production spec")
-    }
-  }
-
   return (
     <Container className="divide-y p-0">
       <div className="flex items-center justify-between px-6 py-4">
@@ -172,7 +107,7 @@ const ProductProductionSpecWidget = ({
           <Button
             size="small"
             variant="secondary"
-            onClick={() => setOpen(true)}
+            onClick={() => navigate(`/products/${product.id}/spec`)}
             disabled={isLoading || catalogLoading}
           >
             <PencilSquare />
@@ -270,45 +205,6 @@ const ProductProductionSpecWidget = ({
           ))}
         </>
       )}
-
-      <FocusModal open={open} onOpenChange={setOpen}>
-        <FocusModal.Content>
-          <FocusModal.Header>
-            <div className="flex items-center justify-end gap-x-2">
-              <Button
-                size="small"
-                onClick={handleSave}
-                isLoading={isPending}
-                disabled={isPending}
-              >
-                Save
-              </Button>
-            </div>
-          </FocusModal.Header>
-          <FocusModal.Body className="flex flex-1 flex-col overflow-y-auto">
-            <div className="mx-auto flex w-full max-w-[720px] flex-col gap-y-6 px-6 py-16">
-              <div className="flex flex-col gap-y-1">
-                <Heading level="h2">Production spec</Heading>
-                <Text size="small" className="text-ui-fg-subtle">
-                  {product.title
-                    ? `What ${product.title} is made to.`
-                    : "What this product is made to."}
-                </Text>
-              </div>
-              <ProductSpecForm
-                value={value}
-                onChange={(next) => {
-                  setDirty(true)
-                  setValue(next)
-                }}
-                techniques={techniques}
-                families={families}
-                isLoading={isLoading || catalogLoading}
-              />
-            </div>
-          </FocusModal.Body>
-        </FocusModal.Content>
-      </FocusModal>
     </Container>
   )
 }

--- a/apps/partner-ui/src/components/modals/__tests__/route-modal-context-usage.spec.ts
+++ b/apps/partner-ui/src/components/modals/__tests__/route-modal-context-usage.spec.ts
@@ -1,0 +1,85 @@
+import { readFileSync, readdirSync, statSync } from "node:fs"
+import { join } from "node:path"
+
+import { describe, expect, it } from "vitest"
+
+/**
+ * `RouteFocusModal`/`RouteDrawer` create the `RouteModalProvider` around their
+ * OWN children. So the component that RENDERS one cannot also call
+ * `useRouteModal()` — at the time its body runs, the context it is asking for
+ * does not exist yet, and the route throws
+ * "useRouteModal must be used within a RouteModalProvider" the moment it opens.
+ *
+ * The shape is always: a host renders the shell, a CHILD holds the hook.
+ *
+ * This is a runtime context error, so `tsc` cannot see it and neither can a
+ * build — the only signal is opening the route. It has now been introduced
+ * three separate times, twice leaving behind a comment warning the next person
+ * (see `product-create-choice.tsx` and `product-quick-create.tsx`) and once
+ * shipping to partners as the spec editor (#1349). Comments did not hold the
+ * line, so this does.
+ */
+
+const SRC = join(__dirname, "..", "..", "..")
+
+const tsxFiles = (dir: string): string[] => {
+  const out: string[] = []
+  for (const entry of readdirSync(dir)) {
+    if (entry === "node_modules" || entry === "dist") {
+      continue
+    }
+    const full = join(dir, entry)
+    if (statSync(full).isDirectory()) {
+      out.push(...tsxFiles(full))
+    } else if (entry.endsWith(".tsx")) {
+      out.push(full)
+    }
+  }
+  return out
+}
+
+/** Comments describe this trap in several files; only real code counts. */
+const stripComments = (source: string): string =>
+  source.replace(/\/\*[\s\S]*?\*\//g, "").replace(/\/\/[^\n]*/g, "")
+
+/**
+ * Split a module into its top-level declarations, so "the hook and the modal
+ * are in the SAME component" can be asked without a real parser. A host and its
+ * child living in one file is the correct shape and must not trip this.
+ */
+const topLevelBlocks = (source: string): string[] =>
+  source.split(/\n(?=(?:export\s+)?(?:const|function|class)\s)/)
+
+/** The Root elements — `<RouteFocusModal.Header>` and friends are fine. */
+const RENDERS_ROOT = /<(RouteFocusModal|RouteDrawer)(?![.\w])/
+const CALLS_HOOK = /\buseRouteModal\s*\(/
+
+describe("useRouteModal is never called by the component that renders the modal", () => {
+  const files = tsxFiles(SRC)
+
+  it("finds source to check", () => {
+    expect(files.length).toBeGreaterThan(0)
+  })
+
+  it("has no component that both renders a route modal and calls useRouteModal", () => {
+    const offenders: string[] = []
+
+    for (const file of files) {
+      const source = stripComments(readFileSync(file, "utf8"))
+      if (!CALLS_HOOK.test(source)) {
+        continue
+      }
+
+      for (const block of topLevelBlocks(source)) {
+        if (RENDERS_ROOT.test(block) && CALLS_HOOK.test(block)) {
+          const name = block.match(
+            /(?:export\s+)?(?:const|function)\s+([A-Za-z0-9_]+)/
+          )?.[1]
+          offenders.push(`${file.replace(SRC, "src")} → ${name ?? "?"}`)
+        }
+      }
+    }
+
+    expect(offenders).toEqual([])
+  })
+})


### PR DESCRIPTION
## The bug

Opening the partner spec editor threw **`useRouteModal must be used within a RouteModalProvider`** on every attempt — the editor #1349 shipped was unopenable.

`RouteFocusModal` creates the `RouteModalProvider` around its *own* children (`route-focus-modal.tsx:46`). `ProductSpec` called `useRouteModal()` at the top of the same function that rendered `<RouteFocusModal>`, so the hook ran before the context existed. Split into a host and a child; the editor logic is unchanged.

`tsc` cannot see this — it is a runtime context error — which is why a green build and a green suite shipped it.

## Not a one-off

Two other files already carried comments warning about this exact trap (`product-create-choice.tsx:12`, `product-quick-create.tsx:38`), and it was introduced a third time anyway. Comments did not hold the line, so this adds a static guard that scans for the shape.

**The guard was verified against the pre-fix source**, where it fails naming `src/routes/products/product-spec/product-spec.tsx → ProductSpec` — not merely confirmed green on the fixed code. It screens the whole app and finds no other instance.

## The admin half

The admin editor used a plain `FocusModal` held open by the widget's own `useState`. It is now a `RouteFocusModal` at `/products/:id/spec`, following the existing `link-design` pattern.

A drop-in swap would not work: a widget is mounted with the product page, and `RouteFocusModal` opens on mount and navigates to `prev` on close — so hosting one in the widget would pop the editor open on every product load and, on close, navigate off the product. The widget now reads only and navigates to the route. This also gives admin the same read/edit split as the partner surface, plus a shareable URL and a working back button.

One deliberate copy change: the modal subtitle loses the product title (`What ${product.title} is made to.` → `What this product is made to.`), since the route has no product object.

## Verify

- `pnpm check:prod-build` — passed, frontend build included, so the new admin route compiles and registers
- Backend `tsc`: zero errors in touched files (74 total = existing baseline)
- partner-ui `tsc`: zero in touched files (the 4 `TS1005` errors are pre-existing, in unrelated order-claim files)
- partner-ui suite: 51 tests, +2 from this PR. The one failure is the i18n translation validator, **confirmed pre-existing** by re-running on a clean tree

## Not verified

Neither modal has been opened in a browser. The partner fix is high-confidence — the guard reproduces the exact failure — but the admin route is new code on a path nobody has clicked. That is #1351 step 3, still outstanding.

Refs #1349 #1351

🤖 Generated with [Claude Code](https://claude.com/claude-code)