### PR TITLE
feat(crm): make the CRM usable — leads, pipeline stages, activity timeline, MCP tools, capture extension

### DIFF
--- a/apps/backend/src/admin/components/crm/activity-timeline.tsx
+++ b/apps/backend/src/admin/components/crm/activity-timeline.tsx
@@ -1,0 +1,251 @@
+import {
+  Badge,
+  Button,
+  Heading,
+  Select,
+  Text,
+  Textarea,
+  toast,
+} from "@medusajs/ui";
+import { useMutation, useQuery, useQueryClient } from "@tanstack/react-query";
+import { useState } from "react";
+
+import {
+  CRM_ACTIVITY_CHANNELS,
+  CRM_ENGAGEMENT_HINTS,
+  CRM_ENGAGEMENT_LABELS,
+  type CrmActivityChannel,
+  type CrmActivityDirection,
+  type CrmEngagementState,
+} from "../../../modules/crm/activity";
+import { sdk } from "../../lib/config";
+
+/**
+ * The interaction timeline for one CRM record, plus the one-box logger.
+ *
+ * Logging is deliberately three fields — direction, channel, what happened —
+ * because an activity form that asks for ten is a form nobody fills in, and an
+ * unlogged conversation is worse than a roughly-logged one. Everything else
+ * (summary, occurred_at, engagement recompute) is derived server-side.
+ */
+
+type CrmActivity = {
+  id: string;
+  related_type: string;
+  related_id: string;
+  activity_type: string;
+  kind?: string | null;
+  direction: CrmActivityDirection;
+  channel?: CrmActivityChannel | null;
+  subject?: string | null;
+  body?: string | null;
+  summary?: string | null;
+  occurred_at: string;
+  outcome?: string | null;
+};
+
+const DIRECTION_LABELS: Record<CrmActivityDirection, string> = {
+  inbound: "They contacted us",
+  outbound: "We contacted them",
+  internal: "Internal note",
+};
+
+const directionColor = (d: string) =>
+  d === "inbound" ? "green" : d === "outbound" ? "blue" : "grey";
+
+const formatWhen = (iso: string) => {
+  const d = new Date(iso);
+  if (Number.isNaN(d.getTime())) return "—";
+  return d.toLocaleString(undefined, {
+    year: "numeric",
+    month: "short",
+    day: "numeric",
+    hour: "2-digit",
+    minute: "2-digit",
+  });
+};
+
+export const EngagementBadge = ({
+  state,
+  nextFollowUpAt,
+}: {
+  state?: string | null;
+  nextFollowUpAt?: string | null;
+}) => {
+  const s = (state ?? "not_contacted") as CrmEngagementState;
+  const label = CRM_ENGAGEMENT_LABELS[s] ?? s;
+  const color =
+    s === "in_conversation"
+      ? "green"
+      : s === "follow_up_due"
+        ? "orange"
+        : s === "stalled" || s === "do_not_contact"
+          ? "red"
+          : "grey";
+  return (
+    <div className="flex flex-col items-end gap-1 md:items-start">
+      <Badge size="2xsmall" color={color as any}>
+        {label}
+      </Badge>
+      <Text size="xsmall" className="text-ui-fg-muted">
+        {CRM_ENGAGEMENT_HINTS[s] ?? ""}
+        {nextFollowUpAt ? ` · due ${formatWhen(nextFollowUpAt)}` : ""}
+      </Text>
+    </div>
+  );
+};
+
+export const ActivityTimeline = ({
+  relatedType,
+  relatedId,
+}: {
+  relatedType: "person" | "company" | "opportunity";
+  relatedId: string;
+}) => {
+  const queryClient = useQueryClient();
+  const [direction, setDirection] = useState<CrmActivityDirection>("outbound");
+  const [channel, setChannel] = useState<CrmActivityChannel>("whatsapp");
+  const [body, setBody] = useState("");
+
+  const { data, isLoading } = useQuery({
+    queryKey: ["crm-activities", relatedType, relatedId],
+    queryFn: () =>
+      sdk.client.fetch<{ crm_activities: CrmActivity[] }>(
+        "/admin/crm/activities",
+        {
+          query: { related_type: relatedType, related_id: relatedId, limit: 100 },
+        }
+      ),
+    enabled: !!relatedId,
+  });
+
+  const log = useMutation({
+    mutationFn: () =>
+      sdk.client.fetch("/admin/crm/activities", {
+        method: "POST",
+        body: {
+          related_type: relatedType,
+          related_id: relatedId,
+          // An internal entry is a note; anything that reached them is a message
+          // unless the user says otherwise. Keeping this mapping here rather
+          // than asking is what keeps the form to three fields.
+          activity_type: direction === "internal" ? "note" : "message",
+          direction,
+          ...(direction === "internal" ? {} : { channel }),
+          body: body.trim(),
+        },
+      }),
+    onSuccess: () => {
+      setBody("");
+      toast.success("Logged");
+      queryClient.invalidateQueries({ queryKey: ["crm-activities"] });
+      // The engagement state is recomputed server-side on every log, so the
+      // contact header is stale the moment this succeeds.
+      queryClient.invalidateQueries({ queryKey: ["crm-person"] });
+    },
+    onError: (e: any) => toast.error(e?.message ?? "Could not log that"),
+  });
+
+  const activities = data?.crm_activities ?? [];
+
+  return (
+    <div className="divide-y">
+      <div className="flex flex-col gap-2 px-6 py-4">
+        <Heading level="h3">Activity</Heading>
+
+        <div className="flex flex-col gap-2 md:flex-row">
+          <Select
+            size="small"
+            value={direction}
+            onValueChange={(v) => setDirection(v as CrmActivityDirection)}
+          >
+            <Select.Trigger className="md:w-56">
+              <Select.Value />
+            </Select.Trigger>
+            <Select.Content>
+              {(
+                ["outbound", "inbound", "internal"] as CrmActivityDirection[]
+              ).map((d) => (
+                <Select.Item key={d} value={d}>
+                  {DIRECTION_LABELS[d]}
+                </Select.Item>
+              ))}
+            </Select.Content>
+          </Select>
+
+          {direction !== "internal" && (
+            <Select
+              size="small"
+              value={channel}
+              onValueChange={(v) => setChannel(v as CrmActivityChannel)}
+            >
+              <Select.Trigger className="md:w-40">
+                <Select.Value />
+              </Select.Trigger>
+              <Select.Content>
+                {CRM_ACTIVITY_CHANNELS.map((c) => (
+                  <Select.Item key={c} value={c}>
+                    {c.replace(/_/g, " ")}
+                  </Select.Item>
+                ))}
+              </Select.Content>
+            </Select>
+          )}
+        </div>
+
+        <Textarea
+          placeholder="What happened?"
+          value={body}
+          onChange={(e) => setBody(e.target.value)}
+          rows={2}
+        />
+        <div>
+          <Button
+            size="small"
+            disabled={!body.trim() || log.isPending}
+            onClick={() => log.mutate()}
+          >
+            Log activity
+          </Button>
+        </div>
+      </div>
+
+      {isLoading && (
+        <div className="px-6 py-6">
+          <Text size="small" className="text-ui-fg-muted">
+            Loading timeline…
+          </Text>
+        </div>
+      )}
+
+      {!isLoading && activities.length === 0 && (
+        <div className="px-6 py-6">
+          <Text size="small" className="text-ui-fg-muted">
+            Nothing logged yet. Every call, message and reply recorded here is
+            what moves the conversation state.
+          </Text>
+        </div>
+      )}
+
+      {activities.map((a) => (
+        <div key={a.id} className="flex flex-col gap-1 px-6 py-3">
+          <div className="flex flex-wrap items-center gap-2">
+            <Badge size="2xsmall" color={directionColor(a.direction) as any}>
+              {a.direction}
+            </Badge>
+            {a.channel && <Badge size="2xsmall">{a.channel}</Badge>}
+            <Text size="xsmall" className="text-ui-fg-muted">
+              {formatWhen(a.occurred_at)}
+            </Text>
+          </div>
+          <Text size="small">{a.summary || a.subject || a.kind || "—"}</Text>
+          {a.body && (
+            <Text size="xsmall" className="text-ui-fg-subtle whitespace-pre-wrap">
+              {a.body}
+            </Text>
+          )}
+        </div>
+      ))}
+    </div>
+  );
+};

--- a/apps/backend/src/admin/routes/crm/[id]/page.tsx
+++ b/apps/backend/src/admin/routes/crm/[id]/page.tsx
@@ -4,6 +4,10 @@ import { useQuery } from "@tanstack/react-query";
 import type { ReactNode } from "react";
 import { Link, useParams } from "react-router-dom";
 
+import {
+  ActivityTimeline,
+  EngagementBadge,
+} from "../../../components/crm/activity-timeline";
 import { sdk } from "../../../lib/config";
 
 type CrmPerson = {
@@ -14,6 +18,10 @@ type CrmPerson = {
   phone?: string | null;
   title?: string | null;
   company_id?: string | null;
+  engagement_state?: string | null;
+  last_inbound_at?: string | null;
+  last_outbound_at?: string | null;
+  next_follow_up_at?: string | null;
   created_at?: string;
   updated_at?: string;
 };
@@ -62,12 +70,20 @@ const CrmPersonDetailPage = () => {
             </Text>
           )}
         </div>
-        <Link to="/crm">
-          <Button variant="secondary" size="small">
-            <ArrowLeft />
-            Back
-          </Button>
-        </Link>
+        <div className="flex items-center gap-4">
+          {person && (
+            <EngagementBadge
+              state={person.engagement_state}
+              nextFollowUpAt={person.next_follow_up_at}
+            />
+          )}
+          <Link to="/crm">
+            <Button variant="secondary" size="small">
+              <ArrowLeft />
+              Back
+            </Button>
+          </Link>
+        </div>
       </div>
 
       {isLoading && (
@@ -103,6 +119,20 @@ const CrmPersonDetailPage = () => {
               {person.id}
             </Text>
           </Row>
+          <Row label="Last reply from them">
+            {val(
+              person.last_inbound_at
+                ? new Date(person.last_inbound_at).toLocaleString()
+                : null
+            )}
+          </Row>
+          <Row label="Last time we reached out">
+            {val(
+              person.last_outbound_at
+                ? new Date(person.last_outbound_at).toLocaleString()
+                : null
+            )}
+          </Row>
           <Row label="Created">
             {val(
               person.created_at
@@ -111,6 +141,10 @@ const CrmPersonDetailPage = () => {
             )}
           </Row>
         </div>
+      )}
+
+      {person && (
+        <ActivityTimeline relatedType="person" relatedId={person.id} />
       )}
     </Container>
   );

--- a/apps/backend/src/admin/routes/crm/leads/page.tsx
+++ b/apps/backend/src/admin/routes/crm/leads/page.tsx
@@ -1,0 +1,218 @@
+import { defineRouteConfig } from "@medusajs/admin-sdk";
+import { Envelope } from "@medusajs/icons";
+import {
+  Badge,
+  Button,
+  Container,
+  Heading,
+  Select,
+  Text,
+  toast,
+} from "@medusajs/ui";
+import { useMutation, useQuery, useQueryClient } from "@tanstack/react-query";
+import { useMemo, useState } from "react";
+
+import { sdk } from "../../../lib/config";
+
+/**
+ * The intake queue: ad-leads that have not yet become CRM contacts.
+ *
+ * This is the screen the whole lead->CRM bridge exists for. 230 leads had sat
+ * at status `new` since November with no surface that made "work this one" a
+ * single action.
+ *
+ * Deliberately NOT a full lead browser — `/admin/meta-ads/leads` already lists
+ * and filters every lead in detail. This shows the unworked ones and the one
+ * button that moves them forward.
+ */
+
+type Lead = {
+  id: string;
+  email?: string | null;
+  phone?: string | null;
+  full_name?: string | null;
+  first_name?: string | null;
+  last_name?: string | null;
+  status?: string | null;
+  source_platform?: string | null;
+  campaign_name?: string | null;
+  created_time?: string | null;
+  external_id?: string | null;
+  external_system?: string | null;
+};
+
+type LeadsResponse = { leads: Lead[]; total: number };
+
+/**
+ * Prod stores three spellings for two platforms (`fb`, `facebook`, `ig`).
+ * Mirrors `normalizeLeadSource` in modules/crm/lead-to-crm — kept in sync by
+ * eye rather than by import, because that module pulls server-only types.
+ */
+const SOURCE_LABELS: Record<string, string> = {
+  fb: "Facebook",
+  facebook: "Facebook",
+  ig: "Instagram",
+  instagram: "Instagram",
+  email: "Email",
+  extension: "Web capture",
+};
+
+const sourceLabel = (raw?: string | null) =>
+  SOURCE_LABELS[(raw ?? "").toLowerCase()] ?? raw ?? "Unknown";
+
+const displayName = (l: Lead) =>
+  [l.first_name, l.last_name].filter(Boolean).join(" ") ||
+  l.full_name ||
+  l.email ||
+  l.id;
+
+const formatDate = (iso?: string | null) => {
+  if (!iso) return "—";
+  const d = new Date(iso);
+  return Number.isNaN(d.getTime())
+    ? "—"
+    : d.toLocaleDateString(undefined, {
+        year: "numeric",
+        month: "short",
+        day: "numeric",
+      });
+};
+
+const CrmLeadsPage = () => {
+  const queryClient = useQueryClient();
+  const [status, setStatus] = useState("new");
+
+  const { data, isLoading } = useQuery({
+    queryKey: ["crm-intake", status],
+    queryFn: () =>
+      sdk.client.fetch<LeadsResponse>("/admin/meta-ads/leads", {
+        query: { limit: 100, ...(status === "all" ? {} : { status }) },
+      }),
+    staleTime: 15_000,
+  });
+
+  const importLead = useMutation({
+    mutationFn: (leadId: string) =>
+      sdk.client.fetch<{ action: string; crm_person_id: string }>(
+        `/admin/crm/leads/${leadId}/import`,
+        { method: "POST" }
+      ),
+    onSuccess: (res) => {
+      toast.success(
+        res.action === "linked"
+          ? "Linked to the contact already in the CRM"
+          : res.action === "already_imported"
+            ? "Already in the CRM"
+            : "Added to the CRM"
+      );
+      queryClient.invalidateQueries({ queryKey: ["crm-intake"] });
+      queryClient.invalidateQueries({ queryKey: ["crm-people"] });
+    },
+    onError: (e: any) => {
+      // A lead with no email genuinely cannot be imported — the CRM keys
+      // contacts on it. The route says which, so show that rather than a
+      // generic failure the user cannot act on.
+      toast.error(e?.message ?? "Could not import this lead");
+    },
+  });
+
+  const leads = data?.leads ?? [];
+
+  const unimported = useMemo(
+    () => leads.filter((l) => !(l.external_system === "crm" && l.external_id)),
+    [leads]
+  );
+
+  return (
+    <Container className="divide-y p-0">
+      <div className="flex flex-col items-start justify-between gap-2 px-6 py-4 md:flex-row md:items-center">
+        <div>
+          <Heading>CRM · Intake</Heading>
+          <Text size="small" className="text-ui-fg-subtle">
+            {isLoading
+              ? "Loading leads…"
+              : `${unimported.length} lead${unimported.length === 1 ? "" : "s"} not yet in the CRM${
+                  data?.total ? ` · ${data.total} total` : ""
+                }`}
+          </Text>
+        </div>
+        <Select size="small" value={status} onValueChange={setStatus}>
+          <Select.Trigger className="w-48">
+            <Select.Value />
+          </Select.Trigger>
+          <Select.Content>
+            <Select.Item value="new">New (unworked)</Select.Item>
+            <Select.Item value="contacted">Contacted</Select.Item>
+            <Select.Item value="qualified">Qualified</Select.Item>
+            <Select.Item value="all">All statuses</Select.Item>
+          </Select.Content>
+        </Select>
+      </div>
+
+      {!isLoading && leads.length === 0 && (
+        <div className="px-6 py-10 text-center">
+          <Text size="small" className="text-ui-fg-muted">
+            No leads with this status.
+          </Text>
+        </div>
+      )}
+
+      <div className="divide-y">
+        {leads.map((lead) => {
+          const imported = lead.external_system === "crm" && !!lead.external_id;
+          return (
+            <div
+              key={lead.id}
+              className="flex flex-col gap-3 px-6 py-4 md:flex-row md:items-center md:justify-between"
+            >
+              <div className="min-w-0">
+                <div className="flex flex-wrap items-center gap-2">
+                  <Text size="small" weight="plus">
+                    {displayName(lead)}
+                  </Text>
+                  <Badge size="2xsmall">{sourceLabel(lead.source_platform)}</Badge>
+                  {lead.status && (
+                    <Badge
+                      size="2xsmall"
+                      color={lead.status === "new" ? "orange" : "grey"}
+                    >
+                      {lead.status}
+                    </Badge>
+                  )}
+                  {imported && (
+                    <Badge size="2xsmall" color="green">
+                      in CRM
+                    </Badge>
+                  )}
+                </div>
+                <Text size="xsmall" className="text-ui-fg-subtle">
+                  {[lead.email, lead.phone].filter(Boolean).join(" · ") || "—"}
+                </Text>
+                <Text size="xsmall" className="text-ui-fg-muted truncate">
+                  {formatDate(lead.created_time)}
+                  {lead.campaign_name ? ` · ${lead.campaign_name}` : ""}
+                </Text>
+              </div>
+
+              <Button
+                size="small"
+                variant={imported ? "secondary" : "primary"}
+                disabled={imported || importLead.isPending}
+                onClick={() => importLead.mutate(lead.id)}
+              >
+                {imported ? "In CRM" : "Add to CRM"}
+              </Button>
+            </div>
+          );
+        })}
+      </div>
+    </Container>
+  );
+};
+
+export const config = defineRouteConfig({
+  label: "CRM Intake",
+  icon: Envelope,
+});
+
+export default CrmLeadsPage;

--- a/apps/backend/src/admin/routes/crm/pipeline/page.tsx
+++ b/apps/backend/src/admin/routes/crm/pipeline/page.tsx
@@ -1,0 +1,258 @@
+import { defineRouteConfig } from "@medusajs/admin-sdk";
+import { CurrencyDollar } from "@medusajs/icons";
+import {
+  Badge,
+  Container,
+  Heading,
+  Select,
+  Text,
+  toast,
+} from "@medusajs/ui";
+import { useMutation, useQuery, useQueryClient } from "@tanstack/react-query";
+import { useMemo } from "react";
+
+import {
+  CRM_OPPORTUNITY_STAGES,
+  CRM_STAGE_HINTS,
+  CRM_STAGE_LABELS,
+  isClosedStage,
+  type CrmOpportunityStage,
+} from "../../../../modules/crm/stages";
+import { sdk } from "../../../lib/config";
+
+/**
+ * The deal board. Columns come from the shared stage vocabulary in
+ * `modules/crm/stages` — NOT a local copy — so a stage added to the pipeline
+ * shows up here without a second edit, and one removed cannot linger as a dead
+ * column.
+ *
+ * The CRM lives on the Autobase node, not Postgres, so there is no query.graph
+ * and no join: an opportunity carries `owner_person_id` / `company_id` as ids.
+ * Contacts and companies are fetched alongside and resolved client-side, which
+ * is one extra request rather than N.
+ */
+
+type CrmOpportunity = {
+  id: string;
+  title: string;
+  stage: CrmOpportunityStage;
+  amount?: number | null;
+  currency?: string | null;
+  expected_close_date?: string | null;
+  company_id?: string | null;
+  owner_person_id?: string | null;
+  updated_at?: string;
+};
+
+type CrmPerson = { id: string; first_name: string; last_name?: string | null };
+type CrmCompany = { id: string; name: string };
+
+const formatAmount = (amount?: number | null, currency?: string | null) => {
+  if (amount == null) return null;
+  const code = (currency || "INR").toUpperCase();
+  try {
+    return new Intl.NumberFormat("en-IN", {
+      style: "currency",
+      currency: code,
+      maximumFractionDigits: 0,
+    }).format(amount);
+  } catch {
+    // An unrecognised currency code must not blank the card.
+    return `${code} ${amount.toLocaleString("en-IN")}`;
+  }
+};
+
+const CrmPipelinePage = () => {
+  const queryClient = useQueryClient();
+
+  const { data, isLoading } = useQuery({
+    queryKey: ["crm-pipeline"],
+    queryFn: async () => {
+      const [opps, people, companies] = await Promise.all([
+        sdk.client.fetch<{ crm_opportunities: CrmOpportunity[] }>(
+          "/admin/crm/opportunities",
+          { query: { limit: 200 } }
+        ),
+        sdk.client.fetch<{ crm_people: CrmPerson[] }>("/admin/crm/people", {
+          query: { limit: 500 },
+        }),
+        sdk.client.fetch<{ crm_companies: CrmCompany[] }>(
+          "/admin/crm/companies",
+          { query: { limit: 200 } }
+        ),
+      ]);
+      return {
+        opportunities: opps.crm_opportunities ?? [],
+        people: people.crm_people ?? [],
+        companies: companies.crm_companies ?? [],
+      };
+    },
+    staleTime: 15_000,
+  });
+
+  const moveStage = useMutation({
+    mutationFn: ({ id, stage }: { id: string; stage: CrmOpportunityStage }) =>
+      sdk.client.fetch(`/admin/crm/opportunities/${id}`, {
+        method: "POST",
+        body: { stage },
+      }),
+    onSuccess: (_res, vars) => {
+      toast.success(`Moved to ${CRM_STAGE_LABELS[vars.stage]}`);
+      queryClient.invalidateQueries({ queryKey: ["crm-pipeline"] });
+    },
+    onError: (e: any) => {
+      // The node enforces the stage enum from its own bundled copy of the
+      // contract. If it has not been redeployed since the vocabulary changed,
+      // the rejection surfaces here and nowhere else — so show what it said
+      // rather than a generic failure.
+      toast.error(e?.message ?? "Could not move the deal");
+    },
+  });
+
+  const nameById = useMemo(() => {
+    const m = new Map<string, string>();
+    for (const p of data?.people ?? []) {
+      m.set(p.id, [p.first_name, p.last_name].filter(Boolean).join(" "));
+    }
+    return m;
+  }, [data?.people]);
+
+  const companyById = useMemo(() => {
+    const m = new Map<string, string>();
+    for (const c of data?.companies ?? []) m.set(c.id, c.name);
+    return m;
+  }, [data?.companies]);
+
+  const byStage = useMemo(() => {
+    const m = new Map<CrmOpportunityStage, CrmOpportunity[]>();
+    for (const stage of CRM_OPPORTUNITY_STAGES) m.set(stage, []);
+    for (const o of data?.opportunities ?? []) {
+      // An opportunity at a stage this build does not know about (e.g. written
+      // before the vocabulary changed) would otherwise vanish from the board
+      // entirely. Surface it rather than silently dropping it.
+      const bucket = m.get(o.stage) ?? m.get("prospecting")!;
+      bucket.push(o);
+    }
+    return m;
+  }, [data?.opportunities]);
+
+  const openTotal = useMemo(() => {
+    let sum = 0;
+    for (const o of data?.opportunities ?? []) {
+      if (!isClosedStage(o.stage) && typeof o.amount === "number") sum += o.amount;
+    }
+    return sum;
+  }, [data?.opportunities]);
+
+  const total = data?.opportunities.length ?? 0;
+
+  return (
+    <Container className="divide-y p-0">
+      <div className="flex flex-col items-start justify-between gap-2 px-6 py-4 md:flex-row md:items-center">
+        <div>
+          <Heading>CRM · Pipeline</Heading>
+          <Text size="small" className="text-ui-fg-subtle">
+            {isLoading
+              ? "Loading deals…"
+              : total === 0
+                ? "No deals yet. A deal is opened when a lead is genuinely qualified."
+                : `${total} deal${total === 1 ? "" : "s"} · ${formatAmount(openTotal, "INR")} open`}
+          </Text>
+        </div>
+      </div>
+
+      <div className="flex gap-4 overflow-x-auto px-6 py-4">
+        {CRM_OPPORTUNITY_STAGES.map((stage) => {
+          const deals = byStage.get(stage) ?? [];
+          return (
+            <div
+              key={stage}
+              className="flex w-72 shrink-0 flex-col gap-2 rounded-lg bg-ui-bg-subtle p-3"
+            >
+              <div className="flex items-center justify-between">
+                <Text size="small" weight="plus">
+                  {CRM_STAGE_LABELS[stage]}
+                </Text>
+                <Badge size="2xsmall" color={isClosedStage(stage) ? "grey" : "blue"}>
+                  {deals.length}
+                </Badge>
+              </div>
+              <Text size="xsmall" className="text-ui-fg-muted">
+                {CRM_STAGE_HINTS[stage]}
+              </Text>
+
+              {deals.length === 0 ? (
+                <div className="rounded-md border border-dashed border-ui-border-base px-3 py-6 text-center">
+                  <Text size="xsmall" className="text-ui-fg-muted">
+                    Empty
+                  </Text>
+                </div>
+              ) : (
+                deals.map((o) => {
+                  const owner = o.owner_person_id
+                    ? nameById.get(o.owner_person_id)
+                    : null;
+                  const company = o.company_id
+                    ? companyById.get(o.company_id)
+                    : null;
+                  const amount = formatAmount(o.amount, o.currency);
+                  return (
+                    <div
+                      key={o.id}
+                      className="flex flex-col gap-2 rounded-md border border-ui-border-base bg-ui-bg-base p-3"
+                    >
+                      {/* Deliberately not a link: there is no opportunity
+                          detail route yet, and a card that navigates to a 404
+                          is worse than one that does not navigate. */}
+                      <Text size="small" weight="plus">
+                        {o.title}
+                      </Text>
+                      {(owner || company) && (
+                        <Text size="xsmall" className="text-ui-fg-subtle">
+                          {[company, owner].filter(Boolean).join(" · ")}
+                        </Text>
+                      )}
+                      {amount && (
+                        <Text size="xsmall" className="text-ui-fg-muted">
+                          {amount}
+                        </Text>
+                      )}
+                      <Select
+                        size="small"
+                        value={o.stage}
+                        onValueChange={(next) =>
+                          moveStage.mutate({
+                            id: o.id,
+                            stage: next as CrmOpportunityStage,
+                          })
+                        }
+                      >
+                        <Select.Trigger>
+                          <Select.Value />
+                        </Select.Trigger>
+                        <Select.Content>
+                          {CRM_OPPORTUNITY_STAGES.map((s) => (
+                            <Select.Item key={s} value={s}>
+                              {CRM_STAGE_LABELS[s]}
+                            </Select.Item>
+                          ))}
+                        </Select.Content>
+                      </Select>
+                    </div>
+                  );
+                })
+              )}
+            </div>
+          );
+        })}
+      </div>
+    </Container>
+  );
+};
+
+export const config = defineRouteConfig({
+  label: "CRM Pipeline",
+  icon: CurrencyDollar,
+});
+
+export default CrmPipelinePage;

--- a/apps/backend/src/api/admin/crm/activities/[id]/route.ts
+++ b/apps/backend/src/api/admin/crm/activities/[id]/route.ts
@@ -1,0 +1,33 @@
+import { MedusaRequest, MedusaResponse } from "@medusajs/framework/http";
+
+import { CRM_MODULE } from "../../../../../modules/crm";
+
+export const GET = async (req: MedusaRequest, res: MedusaResponse) => {
+  const service: any = req.scope.resolve(CRM_MODULE);
+  const crm_activity = await service.retrieveCrmActivity(req.params.id);
+  res.json({ crm_activity });
+};
+
+export const POST = async (req: MedusaRequest, res: MedusaResponse) => {
+  const service: any = req.scope.resolve(CRM_MODULE);
+  const crm_activity = await service.updateCrmActivities({
+    id: req.params.id,
+    ...(req.validatedBody as Record<string, unknown>),
+  });
+  // Correcting an activity's direction or time changes what the engagement
+  // state should be, so the cache is refreshed here too.
+  if (crm_activity?.related_type === "person" && crm_activity?.related_id) {
+    await service.refreshCrmEngagement(crm_activity.related_id).catch(() => {});
+  }
+  res.json({ crm_activity });
+};
+
+export const DELETE = async (req: MedusaRequest, res: MedusaResponse) => {
+  const service: any = req.scope.resolve(CRM_MODULE);
+  const existing = await service.retrieveCrmActivity(req.params.id).catch(() => null);
+  await service.deleteCrmActivities(req.params.id);
+  if (existing?.related_type === "person" && existing?.related_id) {
+    await service.refreshCrmEngagement(existing.related_id).catch(() => {});
+  }
+  res.json({ id: req.params.id, object: "crm_activity", deleted: true });
+};

--- a/apps/backend/src/api/admin/crm/activities/route.ts
+++ b/apps/backend/src/api/admin/crm/activities/route.ts
@@ -1,0 +1,37 @@
+import { MedusaRequest, MedusaResponse } from "@medusajs/framework/http";
+
+import { CRM_MODULE } from "../../../../modules/crm";
+import { ACTIVITY_LIST_FILTER_FIELDS } from "./validators";
+
+export const POST = async (req: MedusaRequest, res: MedusaResponse) => {
+  const service: any = req.scope.resolve(CRM_MODULE);
+  // `recordCrmActivity`, not `createCrmActivities`: writing the row without
+  // refreshing the contact's engagement cache would leave `engagement_state`
+  // describing a conversation that has moved on — and flows select on it.
+  const created = await service.recordCrmActivity(req.validatedBody);
+  res.status(201).json({ crm_activity: created });
+};
+
+export const GET = async (req: MedusaRequest, res: MedusaResponse) => {
+  const service: any = req.scope.resolve(CRM_MODULE);
+  const q = req.query as Record<string, string | undefined>;
+  const filters: Record<string, string> = {};
+  for (const f of ACTIVITY_LIST_FILTER_FIELDS) {
+    if (q[f] !== undefined && q[f] !== "") filters[f] = q[f] as string;
+  }
+  const limit = Math.min(Math.max(Number(q.limit) || 20, 1), 100);
+  const offset = Math.max(Number(q.offset) || 0, 0);
+  const [rows, count] = await service.listAndCountCrmActivities(filters, {
+    take: limit,
+    skip: offset,
+  });
+
+  // Newest first. The store has no ordering guarantee and a timeline read in
+  // arbitrary order is not a timeline.
+  const crm_activities = [...rows].sort(
+    (a: any, b: any) =>
+      Date.parse(b?.occurred_at ?? 0) - Date.parse(a?.occurred_at ?? 0)
+  );
+
+  res.json({ crm_activities, count, limit, offset });
+};

--- a/apps/backend/src/api/admin/crm/activities/validators.ts
+++ b/apps/backend/src/api/admin/crm/activities/validators.ts
@@ -1,0 +1,49 @@
+import { z } from "zod";
+
+// The vocabulary is owned by `modules/crm/activity` — the leaf the Hyperbee
+// contract itself imports. Restating it here would be a second copy free to
+// drift from the store that actually rejects the write.
+import {
+  CRM_ACTIVITY_CHANNELS,
+  CRM_ACTIVITY_DIRECTIONS,
+  CRM_ACTIVITY_OUTCOMES,
+  CRM_ACTIVITY_RELATED_TYPES,
+  CRM_ACTIVITY_TYPES,
+} from "../../../../modules/crm/activity";
+
+export const CreateCrmActivitySchema = z.object({
+  related_type: z.enum(CRM_ACTIVITY_RELATED_TYPES),
+  related_id: z.string().min(1),
+  activity_type: z.enum(CRM_ACTIVITY_TYPES),
+  kind: z.string().nullish(),
+  direction: z.enum(CRM_ACTIVITY_DIRECTIONS).optional().default("internal"),
+  channel: z.enum(CRM_ACTIVITY_CHANNELS).nullish(),
+  subject: z.string().nullish(),
+  body: z.string().nullish(),
+  summary: z.string().nullish(),
+  actor_type: z.enum(["system", "admin", "contact", "flow"]).optional().default("admin"),
+  actor_id: z.string().nullish(),
+  message_id: z.string().nullish(),
+  template_name: z.string().nullish(),
+  recipient: z.string().nullish(),
+  outcome: z.enum(CRM_ACTIVITY_OUTCOMES).nullish(),
+  // Optional so the common case ("this just happened") needs no clock handling
+  // in the caller; the service stamps now when it is absent. Present means a
+  // deliberate back-date, which is the normal shape for an inbound message
+  // recorded after the fact.
+  occurred_at: z.string().datetime().nullish(),
+  payload: z.record(z.string(), z.unknown()).nullish(),
+});
+
+export const UpdateCrmActivitySchema = CreateCrmActivitySchema.partial();
+
+export type CreateCrmActivityInput = z.infer<typeof CreateCrmActivitySchema>;
+export type UpdateCrmActivityInput = z.infer<typeof UpdateCrmActivitySchema>;
+
+export const ACTIVITY_LIST_FILTER_FIELDS = [
+  "related_type",
+  "related_id",
+  "direction",
+  "channel",
+  "activity_type",
+] as const;

--- a/apps/backend/src/api/admin/crm/leads/[id]/import/route.ts
+++ b/apps/backend/src/api/admin/crm/leads/[id]/import/route.ts
@@ -1,0 +1,98 @@
+import type { MedusaRequest, MedusaResponse } from "@medusajs/framework/http";
+import { MedusaError } from "@medusajs/framework/utils";
+
+import { CRM_MODULE } from "../../../../../../modules/crm";
+import {
+  CRM_EXTERNAL_SYSTEM,
+  planLeadImport,
+  type LeadSource,
+} from "../../../../../../modules/crm/lead-to-crm";
+import { SOCIALS_MODULE } from "../../../../../../modules/socials";
+
+/**
+ * POST /admin/crm/leads/:id/import — promote ONE ad-lead into a CRM contact.
+ *
+ * The per-lead counterpart to the `import-leads-to-crm` maintenance job, and it
+ * shares the job's planner rather than restating the rules: same idempotency
+ * (the lead's `external_id` stamp, and the `crm_person` email index), same
+ * name derivation, same "contacts only, never opportunities" policy.
+ *
+ * Answers 200 in every non-error case, with `action` saying what happened —
+ * `created`, `linked` (an existing contact already held that email) or
+ * `already_imported`. A second click is a no-op, not a duplicate and not a 409:
+ * the caller's intent ("this lead should be in the CRM") is satisfied either
+ * way, and the button that fires this is exactly the kind a user double-clicks.
+ */
+export const POST = async (req: MedusaRequest, res: MedusaResponse) => {
+  const { id } = req.params;
+  const socialsService: any = req.scope.resolve(SOCIALS_MODULE);
+  const crmService: any = req.scope.resolve(CRM_MODULE);
+
+  const leads: LeadSource[] = await socialsService.listLeads(
+    { id },
+    { take: 1 }
+  );
+  const lead = leads?.[0];
+  if (!lead) {
+    throw new MedusaError(MedusaError.Types.NOT_FOUND, `Lead ${id} not found`);
+  }
+
+  // Only the contacts that could collide — one narrow read instead of the whole
+  // book, since a single promotion needs exactly one email checked.
+  const email = (lead.email ?? "").trim().toLowerCase();
+  const existingByEmail: Record<string, string> = {};
+  if (email) {
+    const matches: any[] = await crmService
+      .listCrmPeople({ email }, { take: 1 })
+      .catch(() => []);
+    if (matches?.[0]) existingByEmail[email] = matches[0].id;
+  }
+
+  const plan = planLeadImport([lead], existingByEmail);
+  const action = plan.actions[0];
+
+  if (action.kind === "skip") {
+    if (action.reason === "already_imported") {
+      return res.json({
+        action: "already_imported",
+        lead_id: lead.id,
+        crm_person_id: lead.external_id,
+      });
+    }
+    // A lead with no usable email or name cannot become a contact — that is a
+    // property of the data, so say which, rather than failing opaquely.
+    throw new MedusaError(
+      MedusaError.Types.INVALID_DATA,
+      action.reason === "no_usable_email"
+        ? `Lead ${id} has no usable email address, so it cannot be imported (the CRM keys contacts on email).`
+        : `Lead ${id} has no usable name, so it cannot be imported.`
+    );
+  }
+
+  let crmPersonId: string;
+  if (action.kind === "create") {
+    const created = await crmService.createCrmPeople(action.draft);
+    crmPersonId = Array.isArray(created) ? created[0].id : created.id;
+  } else {
+    crmPersonId = action.crm_person_id;
+  }
+
+  await socialsService.updateLeads([
+    {
+      id: lead.id,
+      external_id: crmPersonId,
+      external_system: CRM_EXTERNAL_SYSTEM,
+      synced_to_external_at: new Date(),
+      // Promoting a lead is the act of working it, so it stops being `new`.
+      // Deliberately NOT `qualified`: importing a contact is not a judgement
+      // that the deal is real — that is what opening an opportunity means.
+      ...(lead.status === "new" ? { status: "contacted", contacted_at: new Date() } : {}),
+    },
+  ]);
+
+  res.json({
+    action: action.kind === "create" ? "created" : "linked",
+    lead_id: lead.id,
+    crm_person_id: crmPersonId,
+  });
+};

--- a/apps/backend/src/api/admin/crm/opportunities/validators.ts
+++ b/apps/backend/src/api/admin/crm/opportunities/validators.ts
@@ -1,17 +1,18 @@
 import { z } from "zod";
 
-const STAGES = [
-  "prospecting",
-  "qualification",
-  "proposal",
-  "negotiation",
-  "won",
-  "lost",
-] as const;
+// The stage vocabulary is owned by the CRM contract, not restated here — the
+// contract is what the standalone node enforces, so a local copy could only
+// ever drift out of agreement with the store that actually rejects the write.
+import {
+  CRM_OPPORTUNITY_DEFAULT_STAGE,
+  CRM_OPPORTUNITY_STAGES,
+} from "../../../../modules/crm/dal/crm-contracts";
+
+const STAGES = CRM_OPPORTUNITY_STAGES;
 
 export const CreateCrmOpportunitySchema = z.object({
   title: z.string().min(1),
-  stage: z.enum(STAGES).optional().default("prospecting"),
+  stage: z.enum(STAGES).optional().default(CRM_OPPORTUNITY_DEFAULT_STAGE),
   amount: z.number().nonnegative().nullish(),
   currency: z.string().optional().default("INR"),
   expected_close_date: z.string().datetime().nullish(),

--- a/apps/backend/src/api/admin/crm/opportunities/validators.ts
+++ b/apps/backend/src/api/admin/crm/opportunities/validators.ts
@@ -6,7 +6,7 @@ import { z } from "zod";
 import {
   CRM_OPPORTUNITY_DEFAULT_STAGE,
   CRM_OPPORTUNITY_STAGES,
-} from "../../../../modules/crm/dal/crm-contracts";
+} from "../../../../modules/crm/stages";
 
 const STAGES = CRM_OPPORTUNITY_STAGES;
 

--- a/apps/backend/src/api/admin/crm/people/[id]/route.ts
+++ b/apps/backend/src/api/admin/crm/people/[id]/route.ts
@@ -10,10 +10,18 @@ export const GET = async (req: MedusaRequest, res: MedusaResponse) => {
 
 export const POST = async (req: MedusaRequest, res: MedusaResponse) => {
   const service: any = req.scope.resolve(CRM_MODULE);
-  const crm_person = await service.updateCrmPeople({
-    id: req.params.id,
-    ...(req.validatedBody as Record<string, unknown>),
-  });
+  const body = req.validatedBody as Record<string, unknown>;
+  let crm_person = await service.updateCrmPeople({ id: req.params.id, ...body });
+
+  // Scheduling (or clearing) a follow-up changes what the engagement state
+  // should be right now — a date set in the past means the contact is due
+  // immediately. Recomputing here keeps the cached state honest without waiting
+  // for the nightly sweep to notice.
+  if ("next_follow_up_at" in body) {
+    await service.refreshCrmEngagement(req.params.id).catch(() => {});
+    crm_person = await service.retrieveCrmPerson(req.params.id);
+  }
+
   res.json({ crm_person });
 };
 

--- a/apps/backend/src/api/admin/crm/people/validators.ts
+++ b/apps/backend/src/api/admin/crm/people/validators.ts
@@ -10,6 +10,12 @@ export const CreateCrmPersonSchema = z.object({
   phone: z.string().nullish(),
   title: z.string().nullish(),
   company_id: z.string().nullish(),
+  // Scheduling a follow-up is a legitimate manual action ("chase them Tuesday").
+  // The DERIVED fields (engagement_state, last_*_at) are deliberately absent:
+  // they are a cache of the activity log, and letting a caller set them by hand
+  // is what produces a record claiming `awaiting_reply` about somebody who
+  // replied last week. Only the service writes those.
+  next_follow_up_at: z.string().datetime().nullish(),
   metadata: z.record(z.string(), z.unknown()).nullish(),
 });
 
@@ -22,4 +28,9 @@ export const PERSON_LIST_FILTER_FIELDS = [
   "email",
   "last_name",
   "company_id",
+  // The conversation axis. This is the filter flows and the intake board select
+  // on ("everyone at follow_up_due"), and a field absent from THIS list is
+  // dropped by the route before it ever reaches the store — so the query would
+  // silently return every contact rather than erroring.
+  "engagement_state",
 ] as const;

--- a/apps/backend/src/api/admin/crm/people/validators.ts
+++ b/apps/backend/src/api/admin/crm/people/validators.ts
@@ -2,7 +2,10 @@ import { z } from "zod";
 
 export const CreateCrmPersonSchema = z.object({
   first_name: z.string().min(1),
-  last_name: z.string().min(1),
+  // Optional, matching crmPersonContract: real lead data routinely carries a
+  // single-token name with no surname. Kept `.min(1)` when present so the
+  // caller cannot smuggle in an empty string as a stand-in for "unknown".
+  last_name: z.string().min(1).nullish(),
   email: z.string().email().nullish(),
   phone: z.string().nullish(),
   title: z.string().nullish(),

--- a/apps/backend/src/api/admin/mcp/lib/__tests__/tool-slice.unit.spec.ts
+++ b/apps/backend/src/api/admin/mcp/lib/__tests__/tool-slice.unit.spec.ts
@@ -179,6 +179,57 @@ describe("admin-mcp per-ask tool slicing", () => {
     })
   })
 
+  describe("the CRM reaches the vocabulary people actually use", () => {
+    // #1315's lesson: a tool that CLASSIFIES into a domain is not the same as a
+    // tool that is REACHABLE. These asks are how a founder actually phrases CRM
+    // work, and most of them never contain the word "crm".
+    const byName = new Map(ADMIN_MCP_TOOLS.map((t) => [t.name, t]))
+
+    it("classifies the CRM tools and the lead intake into one domain", () => {
+      expect(toolDomain(byName.get("list_crm_contacts")!)).toBe("crm")
+      expect(toolDomain(byName.get("update_crm_opportunity")!)).toBe("crm")
+      // The ad-lead list is the CRM's intake queue, not a marketing report.
+      expect(toolDomain(byName.get("list_ad_leads")!)).toBe("crm")
+    })
+
+    it.each([
+      "who came in from the ads and hasn't been contacted?",
+      "show me the leads from last month",
+      "what's in the pipeline right now?",
+      "move this deal to sampling",
+      "which deals are at quoted?",
+      "log a note against this contact",
+      "who do I need to follow up with this week?",
+      "list the enquiries that came through the form",
+      "add this boutique as a prospect",
+      "which buyers are qualified?",
+    ])("lights the CRM slice for: %s", (ask) => {
+      const slice = selectAdminToolSlice(ask, ADMIN_MCP_TOOLS)
+      expect(slice.domains).toContain("crm")
+    })
+
+    it("puts the lead list and the contact-create tool in the same slice", () => {
+      // The whole point of the intake: read the leads, then promote one. If
+      // these load separately every promotion costs an extra round trip.
+      const slice = selectAdminToolSlice(
+        "who came in from the ads and hasn't been contacted?",
+        ADMIN_MCP_TOOLS
+      )
+      expect(slice.names).toContain("list_ad_leads")
+      expect(slice.names).toContain("create_crm_contact")
+      expect(slice.names).toContain("list_crm_contacts")
+    })
+
+    it("does not light the CRM for unrelated operational asks", () => {
+      // A generous keyword list is fine; one that fires on everything is not.
+      for (const ask of ["ship order_123 today", "how much yarn is left?"]) {
+        expect(selectAdminToolSlice(ask, ADMIN_MCP_TOOLS).domains).not.toContain(
+          "crm"
+        )
+      }
+    })
+  })
+
   describe("task templates reach the production slice", () => {
     // The dispatch vocabulary. Every run tool taking `template_names` needs a
     // name from here, and an invented one fails the dispatch with "Missing task

--- a/apps/backend/src/api/admin/mcp/lib/__tests__/tool-slice.unit.spec.ts
+++ b/apps/backend/src/api/admin/mcp/lib/__tests__/tool-slice.unit.spec.ts
@@ -220,6 +220,28 @@ describe("admin-mcp per-ask tool slicing", () => {
       expect(slice.names).toContain("list_crm_contacts")
     })
 
+    it.each([
+      "did they ever reply?",
+      "chase the ones who have gone quiet",
+      "what have we said to this contact so far?",
+      "log that I called them",
+      "who should I follow up with on Tuesday?",
+      "they asked to be taken off the list",
+    ])("lights the CRM for conversation-axis asks: %s", (ask) => {
+      // None of these name a CRM noun. Before the conversation keywords they
+      // all fell through to the always-on slice, where no CRM tool exists.
+      expect(selectAdminToolSlice(ask, ADMIN_MCP_TOOLS).domains).toContain("crm")
+    })
+
+    it("loads the timeline reader next to the activity writer", () => {
+      const slice = selectAdminToolSlice(
+        "what have we said to this contact so far?",
+        ADMIN_MCP_TOOLS
+      )
+      expect(slice.names).toContain("list_crm_activities")
+      expect(slice.names).toContain("log_crm_activity")
+    })
+
     it("does not light the CRM for unrelated operational asks", () => {
       // A generous keyword list is fine; one that fires on everything is not.
       for (const ask of ["ship order_123 today", "how much yarn is left?"]) {

--- a/apps/backend/src/api/admin/mcp/lib/__tests__/tool-tiers.unit.spec.ts
+++ b/apps/backend/src/api/admin/mcp/lib/__tests__/tool-tiers.unit.spec.ts
@@ -98,6 +98,7 @@ describe("admin MCP tool tiers", () => {
         "create_crm_task",
         "create_design",
         "create_raw_material_group",
+        "log_crm_activity",
         "log_crm_note",
         "link_design_inventory",
         "link_design_material_group",

--- a/apps/backend/src/api/admin/mcp/lib/__tests__/tool-tiers.unit.spec.ts
+++ b/apps/backend/src/api/admin/mcp/lib/__tests__/tool-tiers.unit.spec.ts
@@ -78,6 +78,12 @@ describe("admin MCP tool tiers", () => {
   it("only demotes tools with no money, no carrier and no third-party message", () => {
     // Locked deliberately. Adding a name here is a permission decision, so it
     // should be a visible line in a diff rather than a quiet registry edit.
+    //
+    // The CRM rows qualify on the stated rule: creating a contact or moving a
+    // deal along the pipeline spends no money, books nothing with a carrier and
+    // sends nothing to a third party. They remain `sensitive` for the confirm
+    // gate — a write-scoped credential may reach them, a model still cannot fire
+    // one without confirm:true.
     expect(
       ADMIN_MCP_TOOLS.filter((t) => t.tier === "write")
         .map((t) => t.name)
@@ -86,11 +92,18 @@ describe("admin MCP tool tiers", () => {
       [
         "add_design_construction_detail",
         "add_inventory_raw_material",
+        "create_crm_company",
+        "create_crm_contact",
+        "create_crm_opportunity",
+        "create_crm_task",
         "create_design",
         "create_raw_material_group",
+        "log_crm_note",
         "link_design_inventory",
         "link_design_material_group",
         "set_product_spec",
+        "update_crm_contact",
+        "update_crm_opportunity",
         "update_design",
         "update_design_brief",
         "update_design_task",

--- a/apps/backend/src/api/admin/mcp/lib/registry.ts
+++ b/apps/backend/src/api/admin/mcp/lib/registry.ts
@@ -3108,4 +3108,353 @@ export const ADMIN_MCP_TOOLS: AdminMcpToolDef[] = [
     inputSchema: obj({ id: STR("Product id to delete, e.g. 'prod_...'.") }, ["id"]),
     sideEffects: "Irreversibly removes the product and its variants from the catalog.",
   },
+
+  // ===== CRM (contacts, companies, deals, follow-ups) =======================
+  // The CRM is NOT Postgres: these routes proxy to the Autobase node over a
+  // Cloudflare tunnel (modules/crm/loaders/hyperbee-dal.ts). Behaviourally that
+  // matters in one place — there is no query.graph and no cross-module join, so
+  // a contact's company arrives as a `company_id` to look up, never as an
+  // embedded object.
+  {
+    name: "list_crm_contacts",
+    description:
+      "List CRM contacts (people in the sales pipeline). Filter by email, last_name or company_id. NOTE: a CRM contact is a prospect — somebody who has not necessarily bought. For people who HAVE placed orders use list_customers; for the weaver directory use the persons tools.",
+    method: "GET",
+    path: "/admin/crm/people",
+    queryParams: ["email", "last_name", "company_id", "limit", "offset"],
+    inputSchema: obj({
+      email: STR("Exact email match."),
+      last_name: STR("Exact surname match."),
+      company_id: STR("Only contacts at this company, e.g. 'crmco_...'."),
+      ...PAGINATION,
+    }),
+  },
+  {
+    name: "get_crm_contact",
+    description:
+      "Get one CRM contact by id, including the provenance metadata recording which ad campaign or capture produced them.",
+    method: "GET",
+    path: "/admin/crm/people/:id",
+    pathParams: ["id"],
+    inputSchema: obj({ id: STR("Contact id, e.g. 'crmp_...'.") }, ["id"]),
+  },
+  {
+    name: "list_crm_companies",
+    description:
+      "List CRM companies (the organizations contacts belong to — boutiques, stockists, wholesale buyers).",
+    method: "GET",
+    path: "/admin/crm/companies",
+    queryParams: ["name", "industry", "region", "limit", "offset"],
+    inputSchema: obj({
+      name: STR("Exact company name match."),
+      industry: STR("Exact industry match."),
+      region: STR("Exact region match."),
+      ...PAGINATION,
+    }),
+  },
+  {
+    name: "list_crm_opportunities",
+    description:
+      "List CRM opportunities (open and closed deals). Filter by stage to read the pipeline: prospecting, sampling, quoted, negotiation, won, lost. 'sampling' means a swatch or sample has physically gone out.",
+    method: "GET",
+    path: "/admin/crm/opportunities",
+    queryParams: ["stage", "company_id", "owner_person_id", "limit", "offset"],
+    inputSchema: obj({
+      stage: STR(
+        "Pipeline stage: 'prospecting' | 'sampling' | 'quoted' | 'negotiation' | 'won' | 'lost'."
+      ),
+      company_id: STR("Only deals for this company."),
+      owner_person_id: STR("Only deals whose contact is this person."),
+      ...PAGINATION,
+    }),
+  },
+  {
+    name: "list_crm_tasks",
+    description:
+      "List CRM follow-up tasks. Filter by status or assignee to answer 'what do I owe somebody this week'.",
+    method: "GET",
+    path: "/admin/crm/tasks",
+    queryParams: [
+      "status",
+      "assignee_person_id",
+      "related_type",
+      "related_id",
+      "limit",
+      "offset",
+    ],
+    inputSchema: obj({
+      status: STR("'pending' | 'in_progress' | 'completed' | 'cancelled'."),
+      assignee_person_id: STR("Only tasks assigned to this contact."),
+      related_type: STR("'person' | 'company' | 'opportunity'."),
+      related_id: STR("Id of the related record."),
+      ...PAGINATION,
+    }),
+  },
+  {
+    name: "list_crm_notes",
+    description:
+      "List notes logged against a CRM record — the conversation history for a contact, company or deal. Pass related_type + related_id to scope it.",
+    method: "GET",
+    path: "/admin/crm/notes",
+    queryParams: ["related_type", "related_id", "limit", "offset"],
+    inputSchema: obj({
+      related_type: STR("'person' | 'company' | 'opportunity' | 'task'."),
+      related_id: STR("Id of the related record."),
+      ...PAGINATION,
+    }),
+  },
+  {
+    name: "list_ad_leads",
+    description:
+      "List raw ad-leads — the intake queue feeding the CRM (Meta/Instagram/Facebook lead-ad form fills and email enquiries). These are NOT yet CRM contacts. Use this to see what has come in and what is still unworked; status 'new' means nobody has touched it.",
+    method: "GET",
+    path: "/admin/meta-ads/leads",
+    queryParams: [
+      "status",
+      "campaign_id",
+      "form_id",
+      "platform_id",
+      "since",
+      "until",
+      "q",
+      "limit",
+      "offset",
+    ],
+    inputSchema: obj({
+      status: STR(
+        "'new' | 'contacted' | 'qualified' | 'unqualified' | 'converted' | 'lost' | 'archived'."
+      ),
+      campaign_id: STR("Only leads from this campaign."),
+      form_id: STR("Only leads from this lead form."),
+      platform_id: STR("Only leads from this social platform record."),
+      since: STR("ISO date — leads created after this."),
+      until: STR("ISO date — leads created before this."),
+      ...PAGINATION,
+    }),
+    sideEffects:
+      "Source platform is stored unnormalized: 'fb' and 'facebook' are the same channel, and 'ig' is Instagram.",
+    nextSteps: ["create_crm_contact", "list_crm_contacts"],
+  },
+  {
+    name: "create_crm_contact",
+    description:
+      "Create a CRM contact. Email must be unique across the CRM — creating a contact whose email already exists is rejected, so check with list_crm_contacts first. last_name is optional: many real contacts have a single-token name. Sensitive: requires confirm:true.",
+    method: "POST",
+    path: "/admin/crm/people",
+    write: true,
+    sensitive: true,
+    tier: "write",
+    bodyParams: [
+      "first_name",
+      "last_name",
+      "email",
+      "phone",
+      "title",
+      "company_id",
+      "metadata",
+    ],
+    inputSchema: obj(
+      {
+        first_name: STR("Given name. Required."),
+        last_name: STR("Surname. Omit when the contact has none."),
+        email: STR("Email — the uniqueness key for the whole CRM."),
+        phone: STR("Phone number."),
+        title: STR("Job title."),
+        company_id: STR("Company id, e.g. 'crmco_...'."),
+        metadata: {
+          type: "object",
+          description:
+            "Provenance and free-form detail (source, campaign, captured_at, page URL).",
+        },
+      },
+      ["first_name"]
+    ),
+  },
+  {
+    name: "update_crm_contact",
+    description:
+      "Update a CRM contact's details. Sensitive: requires confirm:true. Use dry_run to see the current record first.",
+    method: "POST",
+    path: "/admin/crm/people/:id",
+    pathParams: ["id"],
+    previewPath: "/admin/crm/people/:id",
+    write: true,
+    sensitive: true,
+    tier: "write",
+    bodyParams: [
+      "first_name",
+      "last_name",
+      "email",
+      "phone",
+      "title",
+      "company_id",
+      "metadata",
+    ],
+    inputSchema: obj(
+      {
+        id: STR("Contact id, e.g. 'crmp_...'."),
+        first_name: STR("New given name."),
+        last_name: STR("New surname."),
+        email: STR("New email (must stay unique)."),
+        phone: STR("New phone."),
+        title: STR("New job title."),
+        company_id: STR("Attach to this company."),
+        metadata: { type: "object", description: "Metadata to merge." },
+      },
+      ["id"]
+    ),
+  },
+  {
+    name: "create_crm_company",
+    description:
+      "Create a CRM company. The name must be unique. Sensitive: requires confirm:true.",
+    method: "POST",
+    path: "/admin/crm/companies",
+    write: true,
+    sensitive: true,
+    tier: "write",
+    bodyParams: ["name", "website", "industry", "size", "region", "metadata"],
+    inputSchema: obj(
+      {
+        name: STR("Company name — unique across the CRM."),
+        website: STR("Website URL."),
+        industry: STR("Industry, e.g. 'boutique retail'."),
+        size: STR("Rough size, e.g. '1-10'."),
+        region: STR("Region or city."),
+        metadata: { type: "object", description: "Free-form detail." },
+      },
+      ["name"]
+    ),
+  },
+  {
+    name: "create_crm_opportunity",
+    description:
+      "Open a deal in the pipeline. Create this when a lead is genuinely qualified, not on first contact — an opportunity per enquiry makes the pipeline meaningless. Sensitive: requires confirm:true.",
+    method: "POST",
+    path: "/admin/crm/opportunities",
+    write: true,
+    sensitive: true,
+    tier: "write",
+    bodyParams: [
+      "title",
+      "stage",
+      "amount",
+      "currency",
+      "expected_close_date",
+      "company_id",
+      "owner_person_id",
+      "metadata",
+    ],
+    inputSchema: obj(
+      {
+        title: STR("What the deal is for, e.g. '40 pashmina stoles - Sharlho'."),
+        stage: STR(
+          "'prospecting' (default) | 'sampling' | 'quoted' | 'negotiation' | 'won' | 'lost'."
+        ),
+        amount: { type: "number", description: "Expected value, >= 0." },
+        currency: STR("ISO currency, defaults to INR."),
+        expected_close_date: STR("ISO datetime."),
+        company_id: STR("Buying company, e.g. 'crmco_...'."),
+        owner_person_id: STR("The contact this deal belongs to, 'crmp_...'."),
+        metadata: { type: "object", description: "Free-form detail." },
+      },
+      ["title"]
+    ),
+  },
+  {
+    name: "update_crm_opportunity",
+    description:
+      "Update a deal — most often to move its stage along the pipeline. Sensitive: requires confirm:true. Use dry_run to see the deal's current stage before moving it.",
+    method: "POST",
+    path: "/admin/crm/opportunities/:id",
+    pathParams: ["id"],
+    previewPath: "/admin/crm/opportunities/:id",
+    write: true,
+    sensitive: true,
+    tier: "write",
+    bodyParams: [
+      "title",
+      "stage",
+      "amount",
+      "currency",
+      "expected_close_date",
+      "company_id",
+      "owner_person_id",
+      "metadata",
+    ],
+    inputSchema: obj(
+      {
+        id: STR("Opportunity id, e.g. 'crmo_...'."),
+        title: STR("New title."),
+        stage: STR(
+          "'prospecting' | 'sampling' | 'quoted' | 'negotiation' | 'won' | 'lost'."
+        ),
+        amount: { type: "number", description: "Revised value." },
+        currency: STR("ISO currency."),
+        expected_close_date: STR("ISO datetime."),
+        company_id: STR("Reassign to this company."),
+        owner_person_id: STR("Reassign to this contact."),
+        metadata: { type: "object", description: "Metadata to merge." },
+      },
+      ["id"]
+    ),
+    sideEffects:
+      "Moving a deal to 'won' or 'lost' closes it and takes it off the working board.",
+  },
+  {
+    name: "log_crm_note",
+    description:
+      "Log a note against a CRM contact, company or deal — what was said on the call, what the buyer asked for. Sensitive: requires confirm:true.",
+    method: "POST",
+    path: "/admin/crm/notes",
+    write: true,
+    sensitive: true,
+    tier: "write",
+    bodyParams: ["body", "author", "related_type", "related_id", "metadata"],
+    inputSchema: obj(
+      {
+        body: STR("The note text."),
+        author: STR("Who wrote it."),
+        related_type: STR("'person' | 'company' | 'opportunity' | 'task'."),
+        related_id: STR("Id of the record the note is about."),
+        metadata: { type: "object", description: "Free-form detail." },
+      },
+      ["body"]
+    ),
+  },
+  {
+    name: "create_crm_task",
+    description:
+      "Create a follow-up task against a contact, company or deal. Sensitive: requires confirm:true.",
+    method: "POST",
+    path: "/admin/crm/tasks",
+    write: true,
+    sensitive: true,
+    tier: "write",
+    bodyParams: [
+      "title",
+      "description",
+      "due_date",
+      "status",
+      "priority",
+      "assignee_person_id",
+      "related_type",
+      "related_id",
+      "metadata",
+    ],
+    inputSchema: obj(
+      {
+        title: STR("What needs doing, e.g. 'Send swatch pack'."),
+        description: STR("Detail."),
+        due_date: STR("ISO datetime."),
+        status: STR("'pending' (default) | 'in_progress' | 'completed' | 'cancelled'."),
+        priority: STR("'low' | 'medium' (default) | 'high'."),
+        assignee_person_id: STR("CRM contact responsible, 'crmp_...'."),
+        related_type: STR("'person' | 'company' | 'opportunity'."),
+        related_id: STR("Id of the related record."),
+        metadata: { type: "object", description: "Free-form detail." },
+      },
+      ["title"]
+    ),
+  },
 ]

--- a/apps/backend/src/api/admin/mcp/lib/registry.ts
+++ b/apps/backend/src/api/admin/mcp/lib/registry.ts
@@ -3121,13 +3121,25 @@ export const ADMIN_MCP_TOOLS: AdminMcpToolDef[] = [
       "List CRM contacts (people in the sales pipeline). Filter by email, last_name or company_id. NOTE: a CRM contact is a prospect — somebody who has not necessarily bought. For people who HAVE placed orders use list_customers; for the weaver directory use the persons tools.",
     method: "GET",
     path: "/admin/crm/people",
-    queryParams: ["email", "last_name", "company_id", "limit", "offset"],
+    queryParams: [
+      "email",
+      "last_name",
+      "company_id",
+      "engagement_state",
+      "limit",
+      "offset",
+    ],
     inputSchema: obj({
       email: STR("Exact email match."),
       last_name: STR("Exact surname match."),
       company_id: STR("Only contacts at this company, e.g. 'crmco_...'."),
+      engagement_state: STR(
+        "Where the CONVERSATION is (not the deal): 'not_contacted' | 'awaiting_reply' | 'in_conversation' | 'follow_up_due' | 'stalled' | 'do_not_contact' | 'closed'. Use 'follow_up_due' and 'not_contacted' to answer 'who needs chasing'."
+      ),
       ...PAGINATION,
     }),
+    sideEffects:
+      "engagement_state is derived from the activity log — never set it by hand; log an activity instead.",
   },
   {
     name: "get_crm_contact",
@@ -3288,11 +3300,15 @@ export const ADMIN_MCP_TOOLS: AdminMcpToolDef[] = [
       "phone",
       "title",
       "company_id",
+      "next_follow_up_at",
       "metadata",
     ],
     inputSchema: obj(
       {
         id: STR("Contact id, e.g. 'crmp_...'."),
+        next_follow_up_at: STR(
+          "ISO datetime to chase this contact. When it passes, the contact moves to 'follow_up_due' and a crm.follow_up_due event fires for any visual flow listening."
+        ),
         first_name: STR("New given name."),
         last_name: STR("New surname."),
         email: STR("New email (must stay unique)."),
@@ -3456,5 +3472,94 @@ export const ADMIN_MCP_TOOLS: AdminMcpToolDef[] = [
       },
       ["title"]
     ),
+  },
+
+  {
+    name: "list_crm_activities",
+    description:
+      "Read the interaction timeline for a CRM contact, company or deal — every call, message and note, with its direction. Pass related_type + related_id to scope it. Answers 'what have we actually said to them' and 'when did they last reply'. Returned newest-first.",
+    method: "GET",
+    path: "/admin/crm/activities",
+    queryParams: [
+      "related_type",
+      "related_id",
+      "direction",
+      "channel",
+      "activity_type",
+      "limit",
+      "offset",
+    ],
+    inputSchema: obj({
+      related_type: STR("'person' | 'company' | 'opportunity'."),
+      related_id: STR("Id of the record, e.g. 'crmp_...'."),
+      direction: STR(
+        "'inbound' (they contacted us) | 'outbound' (we contacted them) | 'internal' (logged on our side, nobody was reached)."
+      ),
+      channel: STR("'whatsapp' | 'email' | 'phone' | 'instagram' | 'facebook' | 'in_person' | 'other'."),
+      activity_type: STR("'message' | 'call' | 'meeting' | 'note' | 'lifecycle' | 'system'."),
+      ...PAGINATION,
+    }),
+    nextSteps: ["log_crm_activity", "get_crm_contact"],
+  },
+  {
+    name: "log_crm_activity",
+    description:
+      "Record an interaction with a CRM contact — an inbound reply, an outbound message, a call, a meeting. This is how the conversation state moves: logging an inbound activity marks the contact as replying, an outbound one as awaiting reply. Use direction 'internal' for something that did not actually reach them. Sensitive: requires confirm:true.",
+    method: "POST",
+    path: "/admin/crm/activities",
+    write: true,
+    sensitive: true,
+    tier: "write",
+    bodyParams: [
+      "related_type",
+      "related_id",
+      "activity_type",
+      "kind",
+      "direction",
+      "channel",
+      "subject",
+      "body",
+      "summary",
+      "actor_type",
+      "actor_id",
+      "message_id",
+      "template_name",
+      "recipient",
+      "outcome",
+      "occurred_at",
+      "payload",
+    ],
+    inputSchema: obj(
+      {
+        related_type: STR("'person' | 'company' | 'opportunity'. Required."),
+        related_id: STR("Id of the record this happened with. Required."),
+        activity_type: STR(
+          "'message' | 'call' | 'meeting' | 'note' | 'lifecycle' | 'system'. Required."
+        ),
+        kind: STR(
+          "Finer type within the bucket, e.g. 'reply', 'quote_sent', 'no_answer'. Use 'opt_out' to mark somebody as do-not-contact."
+        ),
+        direction: STR(
+          "'inbound' | 'outbound' | 'internal' (default). Getting this right is what makes the engagement state correct."
+        ),
+        channel: STR("'whatsapp' | 'email' | 'phone' | 'instagram' | 'facebook' | 'in_person' | 'other'."),
+        subject: STR("Short subject line."),
+        body: STR("What was said."),
+        summary: STR("One-line timeline text. Computed automatically if omitted."),
+        actor_type: STR("'system' | 'admin' | 'contact' | 'flow'."),
+        actor_id: STR("Who did it."),
+        message_id: STR("Correlating messaging_message id, when this was a real send."),
+        template_name: STR("WhatsApp/email template used."),
+        recipient: STR("Address or number it went to."),
+        outcome: STR("'pending' | 'delivered' | 'replied' | 'no_answer' | 'bounced' | 'failed'."),
+        occurred_at: STR(
+          "ISO datetime the interaction happened. Defaults to now — pass it explicitly when recording something after the fact, which is normal for inbound messages."
+        ),
+        payload: { type: "object", description: "Type-specific structured extras." },
+      },
+      ["related_type", "related_id", "activity_type"]
+    ),
+    sideEffects:
+      "Also recomputes the contact's engagement_state, which is what visual flows select on. Logging an activity with kind 'opt_out' makes the contact permanently do_not_contact.",
   },
 ]

--- a/apps/backend/src/api/admin/mcp/lib/tool-slice.ts
+++ b/apps/backend/src/api/admin/mcp/lib/tool-slice.ts
@@ -227,6 +227,20 @@ const DOMAIN_KEYWORDS: Record<Exclude<AdminToolDomain, "core">, string[]> = {
     // from the ads" — none of these say "lead" either.
     "enquiry", "enquiries", "inquiry", "inquiries", "form fill", "sign up",
     "signups", "buyer", "buyers", "wholesale", "stockist", "boutique",
+    // The CONVERSATION axis. "did they reply?", "chase them Tuesday", "who has
+    // gone quiet" are all CRM asks that name no CRM noun at all.
+    "reply", "replied", "replies", "reach out", "reached out", "chase",
+    "chasing", "conversation", "conversations", "timeline", "activity",
+    "activities", "engagement", "engaged", "stalled", "gone quiet",
+    "unresponsive", "opt out", "opted out", "opt-out", "unsubscribe",
+    "do not contact", "touchpoint", "interaction", "interactions",
+    // Logging a real-world touch. Bare "call" is deliberately absent — it fires
+    // on "call the workflow" / "call the API"; the past tenses do not.
+    "called", "phoned", "rang", "spoke to", "call with", "voicemail",
+    // How an opt-out is actually reported. "taken off the list" names nothing
+    // in the vocabulary, and it is the one ask where a miss is a compliance
+    // problem rather than an extra round trip.
+    "taken off", "take me off", "remove from list", "stop messaging",
   ],
   observability: [
     "mcp", "tool usage", "telemetry", "observability", "ledger", "audit",

--- a/apps/backend/src/api/admin/mcp/lib/tool-slice.ts
+++ b/apps/backend/src/api/admin/mcp/lib/tool-slice.ts
@@ -34,6 +34,7 @@ export type AdminToolDomain =
   | "inventory"
   | "money"
   | "marketing"
+  | "crm"
   | "observability"
 
 /**
@@ -86,6 +87,15 @@ const PREFIX_DOMAINS: ReadonlyArray<readonly [string, AdminToolDomain]> = [
   // organic publishing surface alongside the automated campaigns.
   ["/admin/social-posts", "marketing"],
   ["/admin/social-platforms", "marketing"],
+  // The sales CRM (contacts, companies, deals, follow-up tasks). Distinct from
+  // `customers`, which is the Medusa storefront customer — a CRM contact is
+  // somebody who has NOT bought yet. Distinct again from /admin/persons, which
+  // is the weaver directory.
+  ["/admin/crm", "crm"],
+  // Ad-leads are the CRM's intake, so they light up with it rather than with
+  // marketing: the question "who came in from the ads" is answered by working
+  // the lead list, not by reading campaign spend.
+  ["/admin/meta-ads/leads", "crm"],
 ]
 
 /** Classify one tool by the route it wraps. */
@@ -199,6 +209,24 @@ const DOMAIN_KEYWORDS: Record<Exclude<AdminToolDomain, "core">, string[]> = {
     "social", "social post", "social posts", "social media", "instagram",
     "facebook", "twitter", "tweet", "linkedin", "post to", "publish post",
     "reel", "caption", "hashtag", "hashtags", "fbinsta",
+  ],
+  crm: [
+    "crm", "lead", "leads", "contact", "contacts", "prospect", "prospects",
+    // Word boundaries are exact: "contact" does NOT match "contacted", and
+    // "who came in from the ads and hasn't been contacted?" is the single most
+    // natural way to ask for the unworked intake queue.
+    "contacted", "uncontacted", "unworked", "ad lead", "ad leads",
+    "pipeline", "deal", "deals", "opportunity", "opportunities",
+    "follow up", "follow-up", "followup", "outreach",
+    // The pipeline stage names ARE the vocabulary: "move it to sampling" or
+    // "who is at quoted" must reach the CRM slice, and neither sentence
+    // contains the word "crm".
+    "prospecting", "sampling", "quoted", "negotiation", "qualified",
+    "unqualified", "converted",
+    // What a lead physically is here. "who filled the form", "the enquiries
+    // from the ads" — none of these say "lead" either.
+    "enquiry", "enquiries", "inquiry", "inquiries", "form fill", "sign up",
+    "signups", "buyer", "buyers", "wholesale", "stockist", "boutique",
   ],
   observability: [
     "mcp", "tool usage", "telemetry", "observability", "ledger", "audit",
@@ -327,5 +355,6 @@ export const SELECTABLE_DOMAINS: AdminToolDomain[] = [
   "inventory",
   "money",
   "marketing",
+  "crm",
   "observability",
 ]

--- a/apps/backend/src/api/admin/ops/maintenance-jobs/crm-engagement-sweep-job.ts
+++ b/apps/backend/src/api/admin/ops/maintenance-jobs/crm-engagement-sweep-job.ts
@@ -1,0 +1,171 @@
+import { Modules } from "@medusajs/framework/utils"
+
+import { CRM_MODULE } from "../../../../modules/crm"
+import {
+  CRM_ENGAGEMENT_NEEDS_ACTION,
+  deriveEngagement,
+  type CrmEngagementState,
+} from "../../../../modules/crm/activity"
+import type { MaintenanceChange, MaintenanceJob, MaintenanceJobResult } from "./registry"
+
+/**
+ * Recompute every contact's engagement state, and emit an event when one
+ * CHANGES.
+ *
+ * This is the clock the conversation axis needs. Most engagement transitions
+ * are driven by an activity arriving, and `recordCrmActivity` handles those
+ * synchronously. But two transitions are driven by time passing and nothing
+ * else — a follow-up coming due, and a contact going quiet long enough to count
+ * as stalled. Without a sweep those states are only ever discovered by someone
+ * opening the record.
+ *
+ * ## The events are the point
+ *
+ * `visual-flow-event-trigger` already routes any emitted event to flows whose
+ * trigger_config matches — including by wildcard (`crm.*`). So emitting here is
+ * what lets a flow say "when a follow-up comes due, send the WhatsApp template
+ * and log the send", with no new subscriber and no new plumbing.
+ *
+ * ⚠️ Events fire ONLY on transition, never on every sweep. A contact that sits
+ * at `follow_up_due` because nobody has acted must not re-trigger the flow each
+ * run — that is how an automation turns into a person receiving the same
+ * message every morning. Re-notification is a flow's decision (it can schedule
+ * its own repeat), not something this job imposes.
+ */
+
+/** Transitions worth telling the rest of the system about. */
+const EVENT_BY_STATE: Partial<Record<CrmEngagementState, string>> = {
+  follow_up_due: "crm.follow_up_due",
+  stalled: "crm.contact_stalled",
+  in_conversation: "crm.contact_replied",
+  do_not_contact: "crm.contact_opted_out",
+}
+
+export const crmEngagementSweepJob: MaintenanceJob = {
+  id: "crm-engagement-sweep",
+  label: "Sweep CRM engagement states",
+  description:
+    "Recompute every CRM contact's engagement state from its activity log, and emit an event for each contact whose state CHANGED (crm.follow_up_due, crm.contact_stalled, crm.contact_replied, crm.contact_opted_out) so visual flows can act on it. Time-driven transitions — a follow-up coming due, a contact going quiet — are only discovered here. Dry-run reports the transitions without writing or emitting.",
+  params: [
+    {
+      name: "person_id",
+      type: "string",
+      required: false,
+      description: "Sweep only this contact. Omit to sweep all of them.",
+    },
+  ],
+  run: async (container, { dry_run, params }): Promise<MaintenanceJobResult> => {
+    const crmService: any = container.resolve(CRM_MODULE)
+    const eventBus: any = container.resolve(Modules.EVENT_BUS)
+
+    const personId = (params.person_id as string | undefined)?.trim()
+    const people: any[] = personId
+      ? [await crmService.retrieveCrmPerson(personId)]
+      : await crmService.listCrmPeople({}, { take: null })
+
+    const changes: MaintenanceChange[] = []
+    const errors: Array<{ id: string; message: string }> = []
+    const events: Array<{ name: string; data: Record<string, unknown> }> = []
+    const now = new Date()
+    let applied = false
+    let needsAction = 0
+
+    for (const person of people) {
+      if (!person?.id) continue
+      try {
+        if (dry_run) {
+          // Derive without persisting, so a dry run reports exactly the
+          // transitions an apply would make.
+          const activities = await crmService.listCrmActivities(
+            { related_type: "person", related_id: person.id },
+            { take: null }
+          )
+          const snapshot = deriveEngagement(activities, {
+            now,
+            scheduledFollowUpAt: person.next_follow_up_at ?? null,
+          })
+          if (snapshot.engagement_state !== person.engagement_state) {
+            changes.push({
+              entity: "crm_person",
+              id: person.id,
+              field: "engagement_state",
+              before: person.engagement_state ?? null,
+              after: snapshot.engagement_state,
+            })
+          }
+          if (
+            (CRM_ENGAGEMENT_NEEDS_ACTION as readonly string[]).includes(
+              snapshot.engagement_state
+            )
+          ) {
+            needsAction++
+          }
+          continue
+        }
+
+        const result = await crmService.refreshCrmEngagement(person.id, now)
+
+        if (
+          (CRM_ENGAGEMENT_NEEDS_ACTION as readonly string[]).includes(
+            result.engagement_state
+          )
+        ) {
+          needsAction++
+        }
+
+        const transitioned = result.previous_state !== result.engagement_state
+        if (!transitioned) continue
+
+        applied = true
+        changes.push({
+          entity: "crm_person",
+          id: person.id,
+          field: "engagement_state",
+          before: result.previous_state,
+          after: result.engagement_state,
+        })
+
+        const eventName = EVENT_BY_STATE[result.engagement_state as CrmEngagementState]
+        if (eventName) {
+          events.push({
+            name: eventName,
+            data: {
+              crm_person_id: person.id,
+              email: person.email ?? null,
+              phone: person.phone ?? null,
+              engagement_state: result.engagement_state,
+              previous_state: result.previous_state,
+              last_inbound_at: result.last_inbound_at,
+              last_outbound_at: result.last_outbound_at,
+              outbound_attempts: result.outbound_attempts,
+              next_follow_up_at: result.next_follow_up_at,
+            },
+          })
+        }
+      } catch (e: any) {
+        // One unreadable contact must not abort the sweep; the rest still need
+        // their states refreshed.
+        errors.push({ id: person.id, message: e?.message ?? String(e) })
+      }
+    }
+
+    // Emitted after the loop so a contact's state is already persisted before a
+    // flow can read it back. A flow triggered mid-loop could otherwise fetch the
+    // contact and see the state the sweep is in the middle of replacing.
+    for (const evt of events) {
+      await eventBus.emit(evt).catch(() => {})
+    }
+
+    const verb = dry_run ? "Would transition" : "Transitioned"
+    return {
+      job_id: crmEngagementSweepJob.id,
+      dry_run,
+      applied,
+      summary: `${verb} ${changes.length} of ${people.length} contact(s); ${needsAction} now need action${
+        dry_run ? "" : `; emitted ${events.length} event(s)`
+      }.${errors.length ? ` ${errors.length} failed.` : ""}`,
+      changes,
+      ...(errors.length ? { errors } : {}),
+    }
+  },
+}

--- a/apps/backend/src/api/admin/ops/maintenance-jobs/import-leads-to-crm-job.ts
+++ b/apps/backend/src/api/admin/ops/maintenance-jobs/import-leads-to-crm-job.ts
@@ -1,0 +1,182 @@
+import { SOCIALS_MODULE } from "../../../../modules/socials"
+import { CRM_MODULE } from "../../../../modules/crm"
+import {
+  CRM_EXTERNAL_SYSTEM,
+  planLeadImport,
+  summarizeLeadImport,
+  type LeadImportAction,
+  type LeadSource,
+} from "../../../../modules/crm/lead-to-crm"
+import type { MaintenanceChange, MaintenanceJob, MaintenanceJobResult } from "./registry"
+
+/**
+ * Import ad-leads into the CRM as contacts.
+ *
+ * `socials.Lead` is where every ad channel already lands (Meta leadgen webhook,
+ * Facebook webhook, the manual sync pull, the email-ingest job). This job is the
+ * missing way OUT: it materializes each lead as a `crm_person` and stamps the
+ * lead's long-unused `external_id` / `external_system` / `synced_to_external_at`
+ * fields with the contact it produced.
+ *
+ * It creates CONTACTS ONLY — never opportunities. A nine-month-old form fill is
+ * not a deal, and seeding the pipeline board with 230 of them would make the
+ * board lie on the day it ships. An opportunity is created when somebody
+ * actually qualifies the lead.
+ *
+ * Idempotent and convergent on two independent keys (the lead's stamp and the
+ * `crm_person` email uniqueness index) — see `planLeadImport`. A settled import
+ * re-runs as a pure no-op.
+ *
+ * ⚠️ The CRM is NOT Postgres. Writes go Medusa -> proxy -> Cloudflare tunnel ->
+ * the Autobase node on the OCI VM, one HTTP call per contact. There is no
+ * transaction spanning the CRM write and the Postgres stamp, so the stamp is
+ * written immediately after each contact rather than batched at the end: a
+ * crash mid-run then leaves contacts that are correctly stamped, and the
+ * remainder simply unimported. The reverse order would orphan contacts the next
+ * run would duplicate.
+ */
+export const importLeadsToCrmJob: MaintenanceJob = {
+  id: "import-leads-to-crm",
+  label: "Import ad-leads into the CRM",
+  description:
+    "Materialize socials leads (Meta/Instagram/Facebook ads, email intake) as CRM contacts, and stamp each lead with the crm_person it produced. Creates contacts only — never opportunities. Idempotent: a lead already stamped, or an email the CRM already holds, is skipped or linked rather than duplicated. Dry-run reports the plan without writing.",
+  params: [
+    {
+      name: "source_platform",
+      type: "string",
+      required: false,
+      description:
+        "Only import leads from one source (fb, ig, facebook, email). Omit for all sources.",
+    },
+    {
+      name: "limit",
+      type: "number",
+      required: false,
+      description: "Cap how many leads to consider in one run (default 500).",
+    },
+  ],
+  run: async (container, { dry_run, params }): Promise<MaintenanceJobResult> => {
+    const socialsService: any = container.resolve(SOCIALS_MODULE)
+    const crmService: any = container.resolve(CRM_MODULE)
+
+    const limit = Math.max(1, Number(params.limit ?? 500) || 500)
+    const sourceFilter = (params.source_platform as string | undefined)?.trim()
+
+    const filters: Record<string, unknown> = {}
+    if (sourceFilter) filters.source_platform = sourceFilter
+
+    const leads: LeadSource[] = await socialsService.listLeads(filters, {
+      select: [
+        "id",
+        "email",
+        "phone",
+        "full_name",
+        "first_name",
+        "last_name",
+        "company_name",
+        "job_title",
+        "city",
+        "state",
+        "country",
+        "source_platform",
+        "campaign_name",
+        "campaign_id",
+        "ad_name",
+        "form_name",
+        "created_time",
+        "status",
+        "external_id",
+        "external_system",
+      ],
+      take: limit,
+    })
+
+    // Existing contacts, keyed by email — the second idempotency key. Read once
+    // up front rather than probing per lead: that is one call to the CRM node
+    // instead of N over a Cloudflare tunnel.
+    const existingByEmail: Record<string, string> = {}
+    const existing: any[] = await crmService
+      .listCrmPeople({}, { take: null })
+      .catch(() => [])
+    for (const p of existing) {
+      if (p?.email) existingByEmail[String(p.email).toLowerCase()] = p.id
+    }
+
+    const plan = planLeadImport(leads, existingByEmail)
+    const changes: MaintenanceChange[] = []
+    const errors: Array<{ id: string; message: string }> = []
+
+    if (dry_run) {
+      for (const action of plan.actions) {
+        if (action.kind === "skip") continue
+        changes.push(describe(action, null))
+      }
+      return {
+        job_id: importLeadsToCrmJob.id,
+        dry_run: true,
+        applied: false,
+        summary: `${summarizeLeadImport(plan, true)} Scanned ${leads.length} lead(s); CRM currently holds ${existing.length} contact(s).`,
+        changes,
+      }
+    }
+
+    let applied = false
+    for (const action of plan.actions) {
+      if (action.kind === "skip") continue
+      try {
+        let crmPersonId: string
+        if (action.kind === "create") {
+          const created = await crmService.createCrmPeople(action.draft)
+          crmPersonId = Array.isArray(created) ? created[0].id : created.id
+        } else {
+          crmPersonId = action.crm_person_id
+        }
+
+        // Stamp immediately — see the ordering note in the doc comment.
+        await socialsService.updateLeads([
+          {
+            id: action.lead.id,
+            external_id: crmPersonId,
+            external_system: CRM_EXTERNAL_SYSTEM,
+            synced_to_external_at: new Date(),
+          },
+        ])
+
+        applied = true
+        changes.push(describe(action, crmPersonId))
+      } catch (e: any) {
+        // One bad lead must not abort the batch — the remaining contacts are
+        // still worth importing, and the failure is reported per-id.
+        errors.push({ id: action.lead.id, message: e?.message ?? String(e) })
+      }
+    }
+
+    return {
+      job_id: importLeadsToCrmJob.id,
+      dry_run: false,
+      applied,
+      summary: `${summarizeLeadImport(plan, false)} Scanned ${leads.length} lead(s).${
+        errors.length ? ` ${errors.length} failed.` : ""
+      }`,
+      changes,
+      ...(errors.length ? { errors } : {}),
+    }
+  },
+}
+
+function describe(
+  action: Extract<LeadImportAction, { kind: "create" | "link" }>,
+  crmPersonId: string | null
+): MaintenanceChange {
+  return {
+    entity: "lead",
+    id: action.lead.id,
+    field: "external_id",
+    before: action.lead.external_id ?? null,
+    after:
+      crmPersonId ??
+      (action.kind === "link"
+        ? action.crm_person_id
+        : `(new crm_person for ${action.draft.email})`),
+  }
+}

--- a/apps/backend/src/api/admin/ops/maintenance-jobs/registry.ts
+++ b/apps/backend/src/api/admin/ops/maintenance-jobs/registry.ts
@@ -86,6 +86,7 @@ import { repointPartnerStorefrontSharedJob } from "./repoint-partner-storefront-
 import { enableStripeConnectEurRegionsJob } from "./enable-stripe-connect-eur-regions-job"
 import { suppressBouncedSubscribersJob } from "./suppress-bounced-subscribers-job"
 import { backfillAudienceEntriesJob } from "./backfill-audience-entries-job"
+import { importLeadsToCrmJob } from "./import-leads-to-crm-job"
 import { backfillRetailPartnerFeesJob } from "./backfill-retail-partner-fees-job"
 import { recomputeEmailEngagementStatusJob } from "./recompute-email-engagement-status-job"
 import { generateNewsletterWinbackTargetsJob } from "./generate-newsletter-winback-targets-job"
@@ -5772,6 +5773,7 @@ export const MAINTENANCE_JOBS: MaintenanceJob[] = [
   enableStripeConnectEurRegionsJob,
   suppressBouncedSubscribersJob,
   backfillAudienceEntriesJob,
+  importLeadsToCrmJob,
   recomputeEmailEngagementStatusJob,
   generateNewsletterWinbackTargetsJob,
   repairInventoryOrderSourceJob,

--- a/apps/backend/src/api/admin/ops/maintenance-jobs/registry.ts
+++ b/apps/backend/src/api/admin/ops/maintenance-jobs/registry.ts
@@ -87,6 +87,7 @@ import { enableStripeConnectEurRegionsJob } from "./enable-stripe-connect-eur-re
 import { suppressBouncedSubscribersJob } from "./suppress-bounced-subscribers-job"
 import { backfillAudienceEntriesJob } from "./backfill-audience-entries-job"
 import { importLeadsToCrmJob } from "./import-leads-to-crm-job"
+import { crmEngagementSweepJob } from "./crm-engagement-sweep-job"
 import { backfillRetailPartnerFeesJob } from "./backfill-retail-partner-fees-job"
 import { recomputeEmailEngagementStatusJob } from "./recompute-email-engagement-status-job"
 import { generateNewsletterWinbackTargetsJob } from "./generate-newsletter-winback-targets-job"
@@ -5774,6 +5775,7 @@ export const MAINTENANCE_JOBS: MaintenanceJob[] = [
   suppressBouncedSubscribersJob,
   backfillAudienceEntriesJob,
   importLeadsToCrmJob,
+  crmEngagementSweepJob,
   recomputeEmailEngagementStatusJob,
   generateNewsletterWinbackTargetsJob,
   repairInventoryOrderSourceJob,

--- a/apps/backend/src/api/middlewares.ts
+++ b/apps/backend/src/api/middlewares.ts
@@ -383,6 +383,10 @@ import {
   CreateCrmTaskSchema,
   UpdateCrmTaskSchema,
 } from "./admin/crm/tasks/validators";
+import {
+  CreateCrmActivitySchema,
+  UpdateCrmActivitySchema,
+} from "./admin/crm/activities/validators";
 import { VerifyWeaverSchema } from "./web/census/verify/validators";
 
 /**
@@ -3639,6 +3643,16 @@ export default defineMiddlewares({
       matcher: "/admin/crm/people/:id",
       method: "POST",
       middlewares: [validateAndTransformBody(wrapSchema(UpdateCrmPersonSchema))],
+    },
+    {
+      matcher: "/admin/crm/activities",
+      method: "POST",
+      middlewares: [validateAndTransformBody(wrapSchema(CreateCrmActivitySchema))],
+    },
+    {
+      matcher: "/admin/crm/activities/:id",
+      method: "POST",
+      middlewares: [validateAndTransformBody(wrapSchema(UpdateCrmActivitySchema))],
     },
     {
       matcher: "/admin/crm/opportunities",

--- a/apps/backend/src/modules/crm/__tests__/activity.unit.spec.ts
+++ b/apps/backend/src/modules/crm/__tests__/activity.unit.spec.ts
@@ -1,0 +1,221 @@
+import {
+  DEFAULT_ENGAGEMENT_POLICY,
+  deriveEngagement,
+  followUpDate,
+  isContactable,
+  summarizeActivity,
+  type EngagementActivity,
+} from "../activity"
+
+const NOW = "2026-08-19T12:00:00.000Z"
+const daysAgo = (n: number) =>
+  new Date(Date.parse(NOW) - n * 24 * 60 * 60 * 1000).toISOString()
+
+const act = (
+  direction: string,
+  occurred_at: string,
+  over: Partial<EngagementActivity> = {}
+): EngagementActivity => ({
+  direction,
+  occurred_at,
+  activity_type: "message",
+  channel: "whatsapp",
+  ...over,
+})
+
+const derive = (
+  activities: EngagementActivity[],
+  scheduledFollowUpAt?: string | null
+) => deriveEngagement(activities, { now: NOW, scheduledFollowUpAt })
+
+describe("deriveEngagement", () => {
+  it("is not_contacted with no activity at all", () => {
+    const s = derive([])
+    expect(s.engagement_state).toBe("not_contacted")
+    expect(s.last_activity_at).toBeNull()
+    expect(s.outbound_attempts).toBe(0)
+  })
+
+  it("treats an internal note as no contact — nobody has been reached", () => {
+    // The whole reason `internal` exists as a third direction. If notes counted
+    // as outreach, writing a note would make a contact look worked.
+    const s = derive([act("internal", daysAgo(1), { activity_type: "note" })])
+    expect(s.engagement_state).toBe("not_contacted")
+    expect(s.outbound_attempts).toBe(0)
+  })
+
+  it("is awaiting_reply after we reach out", () => {
+    const s = derive([act("outbound", daysAgo(2))])
+    expect(s.engagement_state).toBe("awaiting_reply")
+    expect(s.outbound_attempts).toBe(1)
+  })
+
+  it("is in_conversation once they reply", () => {
+    const s = derive([act("outbound", daysAgo(3)), act("inbound", daysAgo(1))])
+    expect(s.engagement_state).toBe("in_conversation")
+  })
+
+  it("is in_conversation for an unsolicited inbound enquiry", () => {
+    // An enquiry with no prior outreach: the ball is with us from the start.
+    const s = derive([act("inbound", daysAgo(1))])
+    expect(s.engagement_state).toBe("in_conversation")
+  })
+
+  it("resets the attempt count when they reply", () => {
+    // Otherwise a contact who replies after two chases is permanently two
+    // attempts closer to being written off as stalled.
+    const s = derive([
+      act("outbound", daysAgo(30)),
+      act("outbound", daysAgo(25)),
+      act("inbound", daysAgo(20)),
+      act("outbound", daysAgo(2)),
+    ])
+    expect(s.outbound_attempts).toBe(1)
+    expect(s.engagement_state).toBe("awaiting_reply")
+  })
+
+  it("sorts activities itself rather than trusting the caller's order", () => {
+    // The CRM list endpoint gives no ordering guarantee, and a mis-ordered log
+    // would invert "who spoke last" — the fact everything else turns on.
+    const shuffled = [act("inbound", daysAgo(1)), act("outbound", daysAgo(5))]
+    expect(derive(shuffled).engagement_state).toBe("in_conversation")
+    expect(derive([...shuffled].reverse()).engagement_state).toBe("in_conversation")
+  })
+
+  it("ignores activities with an unparseable occurred_at", () => {
+    const s = derive([act("outbound", "not-a-date"), act("outbound", daysAgo(1))])
+    expect(s.outbound_attempts).toBe(1)
+  })
+
+  describe("stalling", () => {
+    it("needs BOTH enough attempts and enough silence", () => {
+      const { maxAttempts, stallAfterDays } = DEFAULT_ENGAGEMENT_POLICY
+
+      // Enough attempts, but the last one was recent.
+      const recent = derive(
+        Array.from({ length: maxAttempts }, (_, i) => act("outbound", daysAgo(i + 1)))
+      )
+      expect(recent.engagement_state).toBe("awaiting_reply")
+
+      // Long silence, but only one attempt — not yet a pattern.
+      const oneOld = derive([act("outbound", daysAgo(stallAfterDays + 5))])
+      expect(oneOld.engagement_state).toBe("awaiting_reply")
+
+      // Both.
+      const stalled = derive(
+        Array.from({ length: maxAttempts }, (_, i) =>
+          act("outbound", daysAgo(stallAfterDays + 5 + i))
+        )
+      )
+      expect(stalled.engagement_state).toBe("stalled")
+    })
+  })
+
+  describe("follow-ups", () => {
+    it("is follow_up_due once the scheduled time passes", () => {
+      const s = derive([act("outbound", daysAgo(5))], daysAgo(1))
+      expect(s.engagement_state).toBe("follow_up_due")
+    })
+
+    it("stays awaiting_reply while the follow-up is still in the future", () => {
+      const future = new Date(Date.parse(NOW) + 86_400_000).toISOString()
+      const s = derive([act("outbound", daysAgo(5))], future)
+      expect(s.engagement_state).toBe("awaiting_reply")
+    })
+
+    it("outranks stalling — an instruction beats a heuristic", () => {
+      const { maxAttempts, stallAfterDays } = DEFAULT_ENGAGEMENT_POLICY
+      const s = derive(
+        Array.from({ length: maxAttempts }, (_, i) =>
+          act("outbound", daysAgo(stallAfterDays + 5 + i))
+        ),
+        daysAgo(1)
+      )
+      expect(s.engagement_state).toBe("follow_up_due")
+    })
+
+    it("does not fire a follow-up while they are mid-conversation", () => {
+      // They replied; chasing them on a stale timer is the classic
+      // automation embarrassment.
+      const s = derive(
+        [act("outbound", daysAgo(5)), act("inbound", daysAgo(1))],
+        daysAgo(2)
+      )
+      expect(s.engagement_state).toBe("in_conversation")
+    })
+  })
+
+  describe("terminal states", () => {
+    it("do_not_contact outranks everything", () => {
+      const s = derive(
+        [
+          act("outbound", daysAgo(10)),
+          act("inbound", daysAgo(5), { kind: "opt_out" }),
+        ],
+        daysAgo(1)
+      )
+      expect(s.engagement_state).toBe("do_not_contact")
+      // A pending follow-up must not survive an opt-out, or the sweep would
+      // keep re-raising somebody who asked to be left alone.
+      expect(s.next_follow_up_at).toBeNull()
+    })
+
+    it("never lets a later message revive an opt-out", () => {
+      // Consent has to be given again explicitly, not inferred from traffic.
+      const s = derive([
+        act("inbound", daysAgo(10), { kind: "unsubscribed" }),
+        act("inbound", daysAgo(1)),
+      ])
+      expect(s.engagement_state).toBe("do_not_contact")
+    })
+
+    it("lets a later inbound reopen a merely-closed conversation", () => {
+      // Unlike an opt-out, `closed` is our own decision and they can undo it
+      // by getting back in touch.
+      const s = derive([
+        act("internal", daysAgo(10), { kind: "closed" }),
+        act("inbound", daysAgo(1)),
+      ])
+      expect(s.engagement_state).toBe("in_conversation")
+    })
+  })
+})
+
+describe("isContactable", () => {
+  it("blocks the two terminal states and allows the rest", () => {
+    expect(isContactable("do_not_contact")).toBe(false)
+    expect(isContactable("closed")).toBe(false)
+    expect(isContactable("awaiting_reply")).toBe(true)
+    expect(isContactable("stalled")).toBe(true)
+  })
+
+  it("treats an unset state as contactable, not as a block", () => {
+    // A contact created before this field existed must not become permanently
+    // unreachable by automation.
+    expect(isContactable(null)).toBe(true)
+    expect(isContactable(undefined)).toBe(true)
+  })
+})
+
+describe("followUpDate", () => {
+  it("adds whole days in UTC", () => {
+    expect(followUpDate(NOW, 3)).toBe("2026-08-22T12:00:00.000Z")
+  })
+})
+
+describe("summarizeActivity", () => {
+  it("reads as a timeline line, with direction and channel", () => {
+    expect(
+      summarizeActivity({ direction: "inbound", channel: "whatsapp", kind: "reply" })
+    ).toBe("Received whatsapp: reply")
+    expect(
+      summarizeActivity({ direction: "outbound", channel: "email", subject: "Quote" })
+    ).toBe("Sent email: Quote")
+  })
+
+  it("does not invent a channel for an internal entry", () => {
+    expect(
+      summarizeActivity({ direction: "internal", activity_type: "note" })
+    ).toBe("Logged: note")
+  })
+})

--- a/apps/backend/src/modules/crm/__tests__/crm-proxy.unit.spec.ts
+++ b/apps/backend/src/modules/crm/__tests__/crm-proxy.unit.spec.ts
@@ -1,0 +1,80 @@
+import {
+  createCrmProxyRepositories,
+  PROXY_LIST_ALL_LIMIT,
+} from "../dal/crm-proxy"
+
+/**
+ * The proxy is the ONLY CRM data path in prod, and it speaks to the node purely
+ * through a query string. Anything it fails to put on that query string is not
+ * an error — it is a default the node picks instead, silently.
+ */
+describe("CrmProxyRepository query building", () => {
+  const calls: string[] = []
+  const original = globalThis.fetch
+
+  beforeEach(() => {
+    calls.length = 0
+    globalThis.fetch = (async (url: any) => {
+      calls.push(String(url))
+      return {
+        ok: true,
+        json: async () => ({ rows: [], count: 0, record: {} }),
+      }
+    }) as any
+  })
+
+  afterAll(() => {
+    globalThis.fetch = original
+  })
+
+  const repos = () => createCrmProxyRepositories("https://crm.example.com", "tok")
+
+  const lastQuery = () => new URL(calls[calls.length - 1]).searchParams
+
+  it("sends an explicit large limit for take: null", async () => {
+    // THE REGRESSION. `take: null` means "every row" in the embedded
+    // repository. It used to be dropped here, and the node then defaulted to
+    // its page size of 15 — so a full-collection read returned everything in
+    // dev and the oldest fifteen rows in prod, with no error either way.
+    await repos().crmActivityService.list({}, { take: null })
+    expect(lastQuery().get("limit")).toBe(String(PROXY_LIST_ALL_LIMIT))
+  })
+
+  it("never sends limit=0, which the node reads as an empty page", async () => {
+    await repos().crmPersonService.list({}, { take: null })
+    expect(lastQuery().get("limit")).not.toBe("0")
+  })
+
+  it("forwards an explicit finite take unchanged", async () => {
+    await repos().crmActivityService.list({}, { take: 20, skip: 40 })
+    expect(lastQuery().get("limit")).toBe("20")
+    expect(lastQuery().get("offset")).toBe("40")
+  })
+
+  it("omits limit entirely when the caller expresses no preference", async () => {
+    // undefined must stay undefined: that is the node's own default page, and
+    // forcing a value here would override every caller that wants paging.
+    await repos().crmActivityService.list({})
+    expect(lastQuery().has("limit")).toBe(false)
+  })
+
+  it("forwards scalar equality filters and drops operator objects", async () => {
+    // The node only understands equality. An operator object silently becoming
+    // `[object Object]` in the query string would filter on a literal string
+    // and return nothing, which reads as "no results" rather than "unsupported".
+    await repos().crmActivityService.list({
+      related_type: "person",
+      related_id: "crmp_1",
+      occurred_at: { $gte: "2026-01-01" },
+    })
+    const q = lastQuery()
+    expect(q.get("related_type")).toBe("person")
+    expect(q.get("related_id")).toBe("crmp_1")
+    expect(q.has("occurred_at")).toBe(false)
+  })
+
+  it("hits the activities segment for the activity repository", async () => {
+    await repos().crmActivityService.list({})
+    expect(calls[0]).toContain("/crm/activities")
+  })
+})

--- a/apps/backend/src/modules/crm/__tests__/lead-to-crm.unit.spec.ts
+++ b/apps/backend/src/modules/crm/__tests__/lead-to-crm.unit.spec.ts
@@ -1,0 +1,196 @@
+import {
+  buildCrmPersonDraft,
+  CRM_EXTERNAL_SYSTEM,
+  deriveLeadName,
+  normalizeLeadSource,
+  planLeadImport,
+  summarizeLeadImport,
+  type LeadSource,
+} from "../lead-to-crm"
+
+/**
+ * A lead in the shape prod actually produces: `full_name` only, both split
+ * fields null. Every one of the 230 live ad-leads looks like this, so it is the
+ * default the tests build on rather than an edge case they bolt on at the end.
+ */
+const lead = (over: Partial<LeadSource> = {}): LeadSource => ({
+  id: "lead_1",
+  email: "raju@example.com",
+  phone: "+919000000000",
+  full_name: "Raju Jadhav",
+  first_name: null,
+  last_name: null,
+  source_platform: "ig",
+  campaign_name: "[07/11/2025] Promoting Cici Label's form",
+  created_time: "2025-11-14T15:34:40.000Z",
+  status: "new",
+  external_id: null,
+  external_system: null,
+  ...over,
+})
+
+describe("normalizeLeadSource", () => {
+  // Prod carries three spellings for two platforms; grouping by source is
+  // wrong until they collapse.
+  it("collapses the fb/ig/facebook spellings prod actually stores", () => {
+    expect(normalizeLeadSource("fb")).toBe("facebook")
+    expect(normalizeLeadSource("facebook")).toBe("facebook")
+    expect(normalizeLeadSource("FB")).toBe("facebook")
+    expect(normalizeLeadSource("ig")).toBe("instagram")
+  })
+
+  it("passes through unknown sources rather than discarding them", () => {
+    expect(normalizeLeadSource("linkedin")).toBe("linkedin")
+    expect(normalizeLeadSource(null)).toBe("unknown")
+    expect(normalizeLeadSource("  ")).toBe("unknown")
+  })
+})
+
+describe("deriveLeadName", () => {
+  it("splits full_name when the split fields are null (the prod shape)", () => {
+    expect(deriveLeadName(lead())).toEqual({
+      first_name: "Raju",
+      last_name: "Jadhav",
+    })
+  })
+
+  it("returns null — not an empty string — for a single-token name", () => {
+    // "SukhdevDhiman" is a real prod row. An empty-string surname would pass
+    // the contract's `required` check silently, which is exactly the failure
+    // mode this asserts against.
+    const { first_name, last_name } = deriveLeadName(
+      lead({ full_name: "SukhdevDhiman" })
+    )
+    expect(first_name).toBe("SukhdevDhiman")
+    expect(last_name).toBeNull()
+  })
+
+  it("keeps every trailing token as the surname", () => {
+    expect(deriveLeadName(lead({ full_name: "Suresh Kumar Matlam Ji" }))).toEqual({
+      first_name: "Suresh",
+      last_name: "Kumar Matlam Ji",
+    })
+  })
+
+  it("prefers explicit split fields over full_name", () => {
+    expect(
+      deriveLeadName(lead({ first_name: "Given", last_name: "Family" }))
+    ).toEqual({ first_name: "Given", last_name: "Family" })
+  })
+
+  it("falls back to the email local-part when there is no name at all", () => {
+    expect(
+      deriveLeadName(lead({ full_name: null, email: "jane.doe@example.com" }))
+    ).toEqual({ first_name: "Jane", last_name: "Doe" })
+  })
+})
+
+describe("buildCrmPersonDraft", () => {
+  it("lowercases the email, since it is the uniqueness key", () => {
+    const draft = buildCrmPersonDraft(lead({ email: "Raju@Example.COM" }))
+    expect(draft?.email).toBe("raju@example.com")
+  })
+
+  it("carries provenance so a contact is traceable to its campaign", () => {
+    const draft = buildCrmPersonDraft(lead())
+    expect(draft?.metadata).toMatchObject({
+      lead_id: "lead_1",
+      source: "instagram",
+      source_raw: "ig",
+      captured_at: "2025-11-14T15:34:40.000Z",
+    })
+  })
+
+  it("refuses a lead with no usable email", () => {
+    // Without an email there is no key to recognise the contact on a re-run,
+    // so importing it would duplicate on every subsequent pass.
+    expect(buildCrmPersonDraft(lead({ email: null }))).toBeNull()
+    expect(buildCrmPersonDraft(lead({ email: "not-an-email" }))).toBeNull()
+  })
+
+  it("normalizes blank optional fields to null rather than empty strings", () => {
+    const draft = buildCrmPersonDraft(lead({ phone: "   ", job_title: "" }))
+    expect(draft?.phone).toBeNull()
+    expect(draft?.title).toBeNull()
+  })
+})
+
+describe("planLeadImport", () => {
+  it("creates a contact for a fresh lead", () => {
+    const plan = planLeadImport([lead()])
+    expect(plan.actions[0].kind).toBe("create")
+    expect(plan.counts).toMatchObject({ create: 1 })
+  })
+
+  it("never re-imports a lead already stamped with its CRM id", () => {
+    const plan = planLeadImport([
+      lead({ external_system: CRM_EXTERNAL_SYSTEM, external_id: "crmp_abc" }),
+    ])
+    expect(plan.actions[0]).toMatchObject({
+      kind: "skip",
+      reason: "already_imported",
+    })
+  })
+
+  it("still imports a lead stamped into a DIFFERENT external system", () => {
+    // `external_system` is not ours to assume; a lead synced to some other CRM
+    // has no bearing on whether this one holds it.
+    const plan = planLeadImport([
+      lead({ external_system: "hubspot", external_id: "123" }),
+    ])
+    expect(plan.actions[0].kind).toBe("create")
+  })
+
+  it("links rather than duplicates when the CRM already holds the email", () => {
+    // The contact could have arrived via the browser extension or a manual
+    // create; `crm_person.email` is unique, so a second create would be
+    // rejected by the contract anyway.
+    const plan = planLeadImport([lead()], { "RAJU@example.com": "crmp_existing" })
+    expect(plan.actions[0]).toMatchObject({
+      kind: "link",
+      crm_person_id: "crmp_existing",
+    })
+    expect(plan.counts).toMatchObject({ link: 1 })
+  })
+
+  it("lets the first lead win when one batch holds the same email twice", () => {
+    const plan = planLeadImport([
+      lead({ id: "lead_1" }),
+      lead({ id: "lead_2", full_name: "Raju J" }),
+    ])
+    expect(plan.actions.map((a) => a.kind)).toEqual(["create", "skip"])
+    expect(plan.counts).toMatchObject({ create: 1, skip_duplicate_in_batch: 1 })
+  })
+
+  it("separates the two reasons a lead is unusable", () => {
+    const plan = planLeadImport([
+      lead({ id: "a", email: null }),
+      lead({ id: "b", full_name: null, email: "@example.com" }),
+    ])
+    expect(plan.counts).toMatchObject({ skip_no_usable_email: 2 })
+  })
+
+  it("is convergent: replanning after an import is a complete no-op", () => {
+    // The property that matters operationally — running the backfill twice
+    // must not touch anything the first run created.
+    const leads = [lead({ id: "a" }), lead({ id: "b", email: "b@example.com" })]
+    const first = planLeadImport(leads)
+    expect(first.counts.create).toBe(2)
+
+    const afterStamp = leads.map((l) => ({
+      ...l,
+      external_system: CRM_EXTERNAL_SYSTEM,
+      external_id: `crmp_${l.id}`,
+    }))
+    const second = planLeadImport(afterStamp)
+    expect(second.counts).toEqual({ skip_already_imported: 2 })
+  })
+})
+
+describe("summarizeLeadImport", () => {
+  it("distinguishes a dry run from an applied one", () => {
+    const plan = planLeadImport([lead()])
+    expect(summarizeLeadImport(plan, true)).toMatch(/^Would import 1 lead/)
+    expect(summarizeLeadImport(plan, false)).toMatch(/^Imported 1 lead/)
+  })
+})

--- a/apps/backend/src/modules/crm/activity.ts
+++ b/apps/backend/src/modules/crm/activity.ts
@@ -1,0 +1,340 @@
+/**
+ * CRM activity + engagement vocabulary, and the PURE derivation that turns a
+ * contact's activity history into "where is this conversation right now".
+ *
+ * Like `./stages`, this file has NO imports — the admin timeline needs these
+ * constants in the browser, and reaching them through the contract would pull
+ * the hypercore stack into a Vite bundle.
+ *
+ * ## Two axes that are deliberately NOT the same thing
+ *
+ *   - `crm_opportunity.stage`   — where the DEAL is (see ./stages)
+ *   - `crm_person.engagement_state` — where the CONVERSATION is
+ *
+ * They move independently and conflating them is the usual CRM modelling
+ * mistake. A deal can sit at `quoted` while the contact has gone quiet; a
+ * chatty contact may have no deal at all. Flows care about the conversation
+ * axis, reporting cares about the deal axis.
+ *
+ * ## Why the state is derived rather than hand-set
+ *
+ * Every value below is a function of the activity log plus the clock, so it
+ * cannot drift from what actually happened. A stored-and-hand-edited state is
+ * exactly the field that ends up saying `awaiting_reply` about somebody who
+ * replied three weeks ago. It IS persisted on the contact — but only ever
+ * written by `deriveEngagement`, so the stored value is a cache of the
+ * derivation, never an independent source of truth.
+ */
+
+// ---------------------------------------------------------------------------
+// Vocabulary
+// ---------------------------------------------------------------------------
+
+/** Coarse classifier. Add values as new sources start writing activities. */
+export const CRM_ACTIVITY_TYPES = [
+  "message",
+  "call",
+  "meeting",
+  "note",
+  "lifecycle",
+  "system",
+] as const;
+export type CrmActivityType = (typeof CRM_ACTIVITY_TYPES)[number];
+
+/**
+ * Who moved. `internal` is for things that happened on our side without
+ * reaching the contact (a note, a stage change) — keeping those out of
+ * inbound/outbound is what makes "have they replied?" answerable.
+ */
+export const CRM_ACTIVITY_DIRECTIONS = [
+  "inbound",
+  "outbound",
+  "internal",
+] as const;
+export type CrmActivityDirection = (typeof CRM_ACTIVITY_DIRECTIONS)[number];
+
+export const CRM_ACTIVITY_CHANNELS = [
+  "whatsapp",
+  "email",
+  "phone",
+  "instagram",
+  "facebook",
+  "in_person",
+  "other",
+] as const;
+export type CrmActivityChannel = (typeof CRM_ACTIVITY_CHANNELS)[number];
+
+/**
+ * Delivery/response outcome. Distinct from the messaging module's own status:
+ * this records what the activity MEANT for the relationship, while
+ * `messaging_message.status` records what the transport did. Correlate the two
+ * through `message_id` rather than copying one into the other.
+ */
+export const CRM_ACTIVITY_OUTCOMES = [
+  "pending",
+  "delivered",
+  "replied",
+  "no_answer",
+  "bounced",
+  "failed",
+] as const;
+export type CrmActivityOutcome = (typeof CRM_ACTIVITY_OUTCOMES)[number];
+
+/** What a CRM activity can be attached to. */
+export const CRM_ACTIVITY_RELATED_TYPES = [
+  "person",
+  "company",
+  "opportunity",
+] as const;
+export type CrmActivityRelatedType =
+  (typeof CRM_ACTIVITY_RELATED_TYPES)[number];
+
+/** Where the CONVERSATION is. Not where the deal is. */
+export const CRM_ENGAGEMENT_STATES = [
+  "not_contacted",
+  "awaiting_reply",
+  "in_conversation",
+  "follow_up_due",
+  "stalled",
+  "do_not_contact",
+  "closed",
+] as const;
+export type CrmEngagementState = (typeof CRM_ENGAGEMENT_STATES)[number];
+
+export const CRM_ENGAGEMENT_DEFAULT_STATE: CrmEngagementState = "not_contacted";
+
+export const CRM_ENGAGEMENT_LABELS: Record<CrmEngagementState, string> = {
+  not_contacted: "Not contacted",
+  awaiting_reply: "Awaiting reply",
+  in_conversation: "In conversation",
+  follow_up_due: "Follow-up due",
+  stalled: "Stalled",
+  do_not_contact: "Do not contact",
+  closed: "Closed",
+};
+
+export const CRM_ENGAGEMENT_HINTS: Record<CrmEngagementState, string> = {
+  not_contacted: "Nobody has reached out yet",
+  awaiting_reply: "We reached out — the ball is in their court",
+  in_conversation: "They replied; the conversation is live",
+  follow_up_due: "A scheduled follow-up has come due",
+  stalled: "Repeated outreach, no answer",
+  do_not_contact: "Opted out — do not contact",
+  closed: "Conversation deliberately ended",
+};
+
+/**
+ * States a flow should never message into.
+ *
+ * `do_not_contact` is a compliance boundary, not a preference: it is checked by
+ * `isContactable` and every send path must consult it. `closed` is our own
+ * decision to stop. Both are terminal for automation but a human can still act
+ * deliberately.
+ */
+export const CRM_ENGAGEMENT_UNCONTACTABLE: readonly CrmEngagementState[] = [
+  "do_not_contact",
+  "closed",
+];
+
+export const isContactable = (state?: string | null): boolean =>
+  !(CRM_ENGAGEMENT_UNCONTACTABLE as readonly string[]).includes(
+    String(state ?? CRM_ENGAGEMENT_DEFAULT_STATE)
+  );
+
+/** States that mean somebody owes this contact an action right now. */
+export const CRM_ENGAGEMENT_NEEDS_ACTION: readonly CrmEngagementState[] = [
+  "not_contacted",
+  "follow_up_due",
+];
+
+// ---------------------------------------------------------------------------
+// Derivation
+// ---------------------------------------------------------------------------
+
+/** The fields of a `crm_activity` the derivation actually reads. */
+export type EngagementActivity = {
+  direction?: string | null;
+  activity_type?: string | null;
+  kind?: string | null;
+  occurred_at?: string | null;
+  channel?: string | null;
+};
+
+export type EngagementPolicy = {
+  /** Outbound attempts with no inbound before a contact counts as stalled. */
+  maxAttempts: number;
+  /** …and this long since the last one. Both must hold. */
+  stallAfterDays: number;
+  /** Default gap used when scheduling a follow-up with no explicit date. */
+  defaultFollowUpDays: number;
+};
+
+export const DEFAULT_ENGAGEMENT_POLICY: EngagementPolicy = {
+  maxAttempts: 3,
+  stallAfterDays: 14,
+  defaultFollowUpDays: 3,
+};
+
+export type EngagementSnapshot = {
+  engagement_state: CrmEngagementState;
+  last_activity_at: string | null;
+  last_inbound_at: string | null;
+  last_outbound_at: string | null;
+  /** Outbound attempts since the most recent inbound. Resets when they reply. */
+  outbound_attempts: number;
+  next_follow_up_at: string | null;
+};
+
+const MS_PER_DAY = 24 * 60 * 60 * 1000;
+
+const toTime = (iso?: string | null): number | null => {
+  if (!iso) return null;
+  const t = new Date(iso).getTime();
+  return Number.isNaN(t) ? null : t;
+};
+
+/** `kind` values that force a terminal state regardless of anything else. */
+const OPT_OUT_KINDS = new Set(["opt_out", "unsubscribed", "do_not_contact"]);
+const CLOSE_KINDS = new Set(["closed", "conversation_closed"]);
+
+/**
+ * Derive the whole engagement snapshot for one contact.
+ *
+ * `activities` may arrive in any order — they are sorted here rather than
+ * trusting the caller, because the CRM's list endpoint has no ordering
+ * guarantee and a mis-ordered log would silently invert "who spoke last",
+ * which is the single fact everything below turns on.
+ *
+ * `now` is injected rather than read from the clock so this stays pure and the
+ * time-dependent transitions are testable without waiting fourteen days.
+ */
+export function deriveEngagement(
+  activities: EngagementActivity[],
+  opts: {
+    now: Date | string | number;
+    /** An explicitly scheduled follow-up, if one is set on the contact. */
+    scheduledFollowUpAt?: string | null;
+    policy?: EngagementPolicy;
+  }
+): EngagementSnapshot {
+  const policy = opts.policy ?? DEFAULT_ENGAGEMENT_POLICY;
+  const now =
+    opts.now instanceof Date
+      ? opts.now.getTime()
+      : typeof opts.now === "number"
+        ? opts.now
+        : new Date(opts.now).getTime();
+
+  const sorted = [...activities]
+    .filter((a) => toTime(a.occurred_at) !== null)
+    .sort((a, b) => (toTime(a.occurred_at) ?? 0) - (toTime(b.occurred_at) ?? 0));
+
+  let lastInbound: number | null = null;
+  let lastOutbound: number | null = null;
+  let lastAny: number | null = null;
+  let optedOut = false;
+  let closed = false;
+
+  for (const a of sorted) {
+    const t = toTime(a.occurred_at)!;
+    lastAny = t;
+    const kind = String(a.kind ?? "").toLowerCase();
+    if (OPT_OUT_KINDS.has(kind)) optedOut = true;
+    if (CLOSE_KINDS.has(kind)) closed = true;
+    // A later re-engagement reopens a closed conversation, but NEVER an
+    // opt-out: consent has to be given again explicitly, not inferred from
+    // somebody sending another message.
+    if (a.direction === "inbound") {
+      lastInbound = t;
+      closed = false;
+    }
+    if (a.direction === "outbound") lastOutbound = t;
+  }
+
+  // Outbound attempts since the last reply — the count that decides "stalled".
+  let attempts = 0;
+  for (const a of sorted) {
+    const t = toTime(a.occurred_at)!;
+    if (a.direction !== "outbound") continue;
+    if (lastInbound !== null && t <= lastInbound) continue;
+    attempts++;
+  }
+
+  const iso = (t: number | null) => (t === null ? null : new Date(t).toISOString());
+  const scheduled = toTime(opts.scheduledFollowUpAt);
+
+  const base = {
+    last_activity_at: iso(lastAny),
+    last_inbound_at: iso(lastInbound),
+    last_outbound_at: iso(lastOutbound),
+    outbound_attempts: attempts,
+    next_follow_up_at: opts.scheduledFollowUpAt ?? null,
+  };
+
+  // Terminal states first — they outrank every time-based transition.
+  if (optedOut) {
+    return { ...base, engagement_state: "do_not_contact", next_follow_up_at: null };
+  }
+  if (closed) {
+    return { ...base, engagement_state: "closed", next_follow_up_at: null };
+  }
+
+  if (lastOutbound === null && lastInbound === null) {
+    return { ...base, engagement_state: "not_contacted" };
+  }
+
+  // They spoke last (or an inbound arrived with no outreach at all — an
+  // enquiry). Either way the conversation is live and the ball is with us.
+  if (lastInbound !== null && (lastOutbound === null || lastInbound >= lastOutbound)) {
+    return { ...base, engagement_state: "in_conversation" };
+  }
+
+  // We spoke last. A due follow-up outranks stalling: it is an instruction
+  // somebody left, and acting on it is what clears it.
+  if (scheduled !== null && scheduled <= now) {
+    return { ...base, engagement_state: "follow_up_due" };
+  }
+
+  const quietFor = lastOutbound === null ? 0 : now - lastOutbound;
+  if (
+    attempts >= policy.maxAttempts &&
+    quietFor >= policy.stallAfterDays * MS_PER_DAY
+  ) {
+    return { ...base, engagement_state: "stalled" };
+  }
+
+  return { ...base, engagement_state: "awaiting_reply" };
+}
+
+/** ISO timestamp `days` from `from`. Used when scheduling a default follow-up. */
+export function followUpDate(
+  from: Date | string | number,
+  days: number
+): string {
+  const base =
+    from instanceof Date
+      ? from.getTime()
+      : typeof from === "number"
+        ? from
+        : new Date(from).getTime();
+  return new Date(base + days * MS_PER_DAY).toISOString();
+}
+
+/**
+ * One-line timeline summary for an activity that did not supply its own.
+ * Kept here so the API, the flows and the UI all render a row the same way.
+ */
+export function summarizeActivity(a: EngagementActivity & {
+  subject?: string | null
+  recipient?: string | null
+}): string {
+  const channel = a.channel ? String(a.channel).replace(/_/g, " ") : null;
+  const verb =
+    a.direction === "inbound"
+      ? "Received"
+      : a.direction === "outbound"
+        ? "Sent"
+        : "Logged";
+  const what = a.subject || a.kind || a.activity_type || "activity";
+  return channel ? `${verb} ${channel}: ${what}` : `${verb}: ${what}`;
+}

--- a/apps/backend/src/modules/crm/dal/crm-contracts.ts
+++ b/apps/backend/src/modules/crm/dal/crm-contracts.ts
@@ -10,6 +10,15 @@ import {
   CRM_OPPORTUNITY_DEFAULT_STAGE,
   CRM_OPPORTUNITY_STAGES,
 } from "../stages";
+import {
+  CRM_ACTIVITY_CHANNELS,
+  CRM_ACTIVITY_DIRECTIONS,
+  CRM_ACTIVITY_OUTCOMES,
+  CRM_ACTIVITY_RELATED_TYPES,
+  CRM_ACTIVITY_TYPES,
+  CRM_ENGAGEMENT_DEFAULT_STATE,
+  CRM_ENGAGEMENT_STATES,
+} from "../activity";
 
 // The stage vocabulary lives in a dependency-free leaf so the admin dashboard
 // can import it without pulling the hypercore stack into a browser bundle.
@@ -20,6 +29,15 @@ export {
   CRM_OPPORTUNITY_CLOSED_STAGES,
   type CrmOpportunityStage,
 } from "../stages";
+export {
+  CRM_ACTIVITY_TYPES,
+  CRM_ACTIVITY_DIRECTIONS,
+  CRM_ACTIVITY_CHANNELS,
+  CRM_ACTIVITY_OUTCOMES,
+  CRM_ENGAGEMENT_STATES,
+  type CrmActivityType,
+  type CrmEngagementState,
+} from "../activity";
 
 export const crmCompanyContract = defineContract("crm_company", {
   id: { prefix: "crmco" },
@@ -51,8 +69,41 @@ export const crmPersonContract = defineContract("crm_person", {
     phone: { type: "string", nullable: true },
     title: { type: "string", nullable: true },
     company_id: { type: "string", nullable: true },
+
+    // ── Engagement (the CONVERSATION axis) ──────────────────────────────────
+    // A CACHE of `deriveEngagement`, never an independent source of truth:
+    // only the recorder and the sweep write these, always from the activity
+    // log. A hand-edited engagement state is precisely the field that ends up
+    // claiming `awaiting_reply` about somebody who replied three weeks ago.
+    // Indexed because the flows select on it ("everyone at follow_up_due").
+    engagement_state: {
+      type: "string",
+      default: CRM_ENGAGEMENT_DEFAULT_STATE,
+      enum: [...CRM_ENGAGEMENT_STATES],
+    },
+    last_activity_at: { type: "string", nullable: true },
+    last_inbound_at: { type: "string", nullable: true },
+    last_outbound_at: { type: "string", nullable: true },
+    // Explicitly scheduled, by a human or a flow. Distinct from the derived
+    // state: this is the instruction, `follow_up_due` is it having come round.
+    next_follow_up_at: { type: "string", nullable: true },
+
     metadata: { type: "json", nullable: true },
   },
+  // NOTE: `engagement_state` is deliberately NOT indexed.
+  //
+  // Indexes here are written at put-time (`idx.put(field/value/key)`), and the
+  // package has no reindex. A field added to this list is therefore absent from
+  // the index for every row written BEFORE the change — and `candidateKeys`
+  // prefers the index whenever a filter names an indexed field, so
+  // `{engagement_state: "not_contacted"}` would silently MISS every pre-existing
+  // contact instead of scanning for them.
+  //
+  // Leaving it unindexed makes that query fall through to a full scan + in-memory
+  // `matches()`, which is correct for old and new rows alike. At CRM volume
+  // (hundreds of contacts) the scan is free; a wrong answer about who still
+  // needs contacting is not. Index it only alongside a backfill that rewrites
+  // every row.
   indexes: ["email", "last_name", "company_id"],
   unique: ["email"],
   relations: {
@@ -123,12 +174,88 @@ export const crmTaskContract = defineContract("crm_task", {
   },
 });
 
+/**
+ * The interaction log — every touch with a contact, company or deal.
+ *
+ * A Hyperbee contract like the other five: NO Postgres table, no migration, no
+ * DML model. It lives in the same Autobase store on the CRM node, so a
+ * contact and its timeline are one store and one replication unit.
+ *
+ * Shape mirrors `production_run_activity` (already proven for run timelines)
+ * rather than inventing a second idiom: coarse `activity_type`, fine `kind`,
+ * an actor, an optional message correlation, a computed `summary` and a
+ * `payload` for type-specific extras.
+ *
+ * Two things it deliberately does NOT do:
+ *
+ *  - It does not duplicate `messaging_message`. Transport truth (queued/sent/
+ *    delivered/read/failed) stays there; `message_id` is a plain correlation
+ *    id — no foreign key, nothing joined. Copying the status here would create
+ *    two records of one fact, free to disagree.
+ *  - It does not replace `crm_note`. A note is human commentary; an activity is
+ *    something that happened, with a direction and a time. Notes stay notes.
+ *
+ * `occurred_at` is when the interaction happened, which is NOT `created_at` —
+ * an inbound message is usually recorded after the fact, and back-dating it is
+ * the whole point of having both.
+ */
+export const crmActivityContract = defineContract("crm_activity", {
+  id: { prefix: "crma" },
+  mode: "strict",
+  fields: {
+    related_type: {
+      type: "string",
+      required: true,
+      enum: [...CRM_ACTIVITY_RELATED_TYPES],
+    },
+    related_id: { type: "string", required: true },
+
+    activity_type: {
+      type: "string",
+      required: true,
+      enum: [...CRM_ACTIVITY_TYPES],
+    },
+    /** Fine-grained type within the bucket, e.g. "reply", "quote_sent". */
+    kind: { type: "string", nullable: true },
+
+    direction: {
+      type: "string",
+      default: "internal",
+      enum: [...CRM_ACTIVITY_DIRECTIONS],
+    },
+    channel: { type: "string", nullable: true, enum: [...CRM_ACTIVITY_CHANNELS] },
+
+    subject: { type: "string", nullable: true },
+    body: { type: "string", nullable: true },
+    /** One-line timeline text, computed at write time. */
+    summary: { type: "string", nullable: true },
+
+    actor_type: {
+      type: "string",
+      default: "system",
+      enum: ["system", "admin", "contact", "flow"],
+    },
+    actor_id: { type: "string", nullable: true },
+
+    // Correlation with the messaging module — an id, not a relation.
+    message_id: { type: "string", nullable: true },
+    template_name: { type: "string", nullable: true },
+    recipient: { type: "string", nullable: true },
+    outcome: { type: "string", nullable: true, enum: [...CRM_ACTIVITY_OUTCOMES] },
+
+    occurred_at: { type: "string", required: true },
+    payload: { type: "json", nullable: true },
+  },
+  indexes: ["related_type", "related_id", "direction", "channel", "activity_type"],
+});
+
 export const crmContracts: Record<string, Contract> = {
   crm_company: crmCompanyContract,
   crm_person: crmPersonContract,
   crm_opportunity: crmOpportunityContract,
   crm_note: crmNoteContract,
   crm_task: crmTaskContract,
+  crm_activity: crmActivityContract,
 };
 
 /** URL path segment ↔ model name, for the node's REST surface + the proxy. */
@@ -138,4 +265,5 @@ export const CRM_MODEL_BY_SEGMENT: Record<string, string> = {
   opportunities: "crm_opportunity",
   notes: "crm_note",
   tasks: "crm_task",
+  activities: "crm_activity",
 };

--- a/apps/backend/src/modules/crm/dal/crm-contracts.ts
+++ b/apps/backend/src/modules/crm/dal/crm-contracts.ts
@@ -6,6 +6,43 @@
  */
 import { defineContract, type Contract } from "@jytextiles/mikrohyperbee";
 
+/**
+ * The deal pipeline, in order. THE single source of truth for the stage
+ * vocabulary — the API validator (api/admin/crm/opportunities/validators.ts)
+ * and the admin pipeline board both import from here rather than restating it.
+ * They used to each carry their own copy, which is the same shape of defect as
+ * #1348: one vocabulary, two artifacts, free to drift.
+ *
+ * Shaped for textiles rather than generic SaaS. `sampling` is the decisive
+ * stage in this business — a swatch or sample has physically gone out — and it
+ * was invisible in the previous list. `quoted` replaces `proposal` for the same
+ * reason: what gets sent is a price for a quantity, not a document.
+ *
+ * ⚠️ This enum is enforced in BOTH processes: Medusa validates on the way in,
+ * and the standalone CRM node re-validates against its own bundled copy of this
+ * file. Changing it therefore requires REBUILDING AND REDEPLOYING the node
+ * bundle (see modules/crm/node/deploy/README.md) — until that happens the node
+ * rejects any new value and the write fails at the proxy, not at the validator.
+ */
+export const CRM_OPPORTUNITY_STAGES = [
+  "prospecting",
+  "sampling",
+  "quoted",
+  "negotiation",
+  "won",
+  "lost",
+] as const;
+
+export type CrmOpportunityStage = (typeof CRM_OPPORTUNITY_STAGES)[number];
+
+export const CRM_OPPORTUNITY_DEFAULT_STAGE: CrmOpportunityStage = "prospecting";
+
+/** Stages that end the deal. Used to keep won/lost off the working board. */
+export const CRM_OPPORTUNITY_CLOSED_STAGES: readonly CrmOpportunityStage[] = [
+  "won",
+  "lost",
+];
+
 export const crmCompanyContract = defineContract("crm_company", {
   id: { prefix: "crmco" },
   mode: "strict",
@@ -26,7 +63,12 @@ export const crmPersonContract = defineContract("crm_person", {
   mode: "strict",
   fields: {
     first_name: { type: "string", required: true },
-    last_name: { type: "string", required: true },
+    // NOT required. Every one of the 230 production ad-leads arrives with only
+    // a `full_name`, and many are a single token with no surname at all
+    // ("SukhdevDhiman"). Requiring it would have meant writing `""` into all of
+    // them — which the contract's `required` check permits, since it only
+    // rejects `undefined`. Absent stays absent.
+    last_name: { type: "string", nullable: true },
     email: { type: "string", nullable: true },
     phone: { type: "string", nullable: true },
     title: { type: "string", nullable: true },
@@ -52,8 +94,8 @@ export const crmOpportunityContract = defineContract("crm_opportunity", {
     title: { type: "string", required: true },
     stage: {
       type: "string",
-      default: "prospecting",
-      enum: ["prospecting", "qualification", "proposal", "negotiation", "won", "lost"],
+      default: CRM_OPPORTUNITY_DEFAULT_STAGE,
+      enum: [...CRM_OPPORTUNITY_STAGES],
     },
     amount: { type: "number", nullable: true },
     currency: { type: "string", default: "INR" },

--- a/apps/backend/src/modules/crm/dal/crm-contracts.ts
+++ b/apps/backend/src/modules/crm/dal/crm-contracts.ts
@@ -6,42 +6,20 @@
  */
 import { defineContract, type Contract } from "@jytextiles/mikrohyperbee";
 
-/**
- * The deal pipeline, in order. THE single source of truth for the stage
- * vocabulary — the API validator (api/admin/crm/opportunities/validators.ts)
- * and the admin pipeline board both import from here rather than restating it.
- * They used to each carry their own copy, which is the same shape of defect as
- * #1348: one vocabulary, two artifacts, free to drift.
- *
- * Shaped for textiles rather than generic SaaS. `sampling` is the decisive
- * stage in this business — a swatch or sample has physically gone out — and it
- * was invisible in the previous list. `quoted` replaces `proposal` for the same
- * reason: what gets sent is a price for a quantity, not a document.
- *
- * ⚠️ This enum is enforced in BOTH processes: Medusa validates on the way in,
- * and the standalone CRM node re-validates against its own bundled copy of this
- * file. Changing it therefore requires REBUILDING AND REDEPLOYING the node
- * bundle (see modules/crm/node/deploy/README.md) — until that happens the node
- * rejects any new value and the write fails at the proxy, not at the validator.
- */
-export const CRM_OPPORTUNITY_STAGES = [
-  "prospecting",
-  "sampling",
-  "quoted",
-  "negotiation",
-  "won",
-  "lost",
-] as const;
+import {
+  CRM_OPPORTUNITY_DEFAULT_STAGE,
+  CRM_OPPORTUNITY_STAGES,
+} from "../stages";
 
-export type CrmOpportunityStage = (typeof CRM_OPPORTUNITY_STAGES)[number];
-
-export const CRM_OPPORTUNITY_DEFAULT_STAGE: CrmOpportunityStage = "prospecting";
-
-/** Stages that end the deal. Used to keep won/lost off the working board. */
-export const CRM_OPPORTUNITY_CLOSED_STAGES: readonly CrmOpportunityStage[] = [
-  "won",
-  "lost",
-];
+// The stage vocabulary lives in a dependency-free leaf so the admin dashboard
+// can import it without pulling the hypercore stack into a browser bundle.
+// Re-exported here because this file is what the CRM node bundles.
+export {
+  CRM_OPPORTUNITY_STAGES,
+  CRM_OPPORTUNITY_DEFAULT_STAGE,
+  CRM_OPPORTUNITY_CLOSED_STAGES,
+  type CrmOpportunityStage,
+} from "../stages";
 
 export const crmCompanyContract = defineContract("crm_company", {
   id: { prefix: "crmco" },

--- a/apps/backend/src/modules/crm/dal/crm-proxy.ts
+++ b/apps/backend/src/modules/crm/dal/crm-proxy.ts
@@ -14,13 +14,31 @@ import { MedusaError } from "@medusajs/framework/utils";
 
 import type { ModelRepository } from "@jytextiles/mikrohyperbee";
 
-const SEGMENT_BY_MODEL: Record<string, string> = {
-  crm_company: "companies",
-  crm_person: "people",
-  crm_opportunity: "opportunities",
-  crm_note: "notes",
-  crm_task: "tasks",
-};
+import { CRM_MODEL_BY_SEGMENT } from "./crm-contracts";
+
+/**
+ * The `limit` sent when a caller asks for every row (`take: null`).
+ *
+ * Deliberately finite: an unbounded read of a collection that has grown past
+ * this is a bug worth noticing, not one to paper over. Well above any expected
+ * CRM collection size (230 contacts today).
+ */
+export const PROXY_LIST_ALL_LIMIT = 100_000;
+
+
+/**
+ * model -> URL segment, INVERTED from the contract's `CRM_MODEL_BY_SEGMENT`
+ * rather than restated.
+ *
+ * This was a hand-maintained duplicate, and adding `crm_activity` to the
+ * contract left it stale — the proxy quietly built `/crm/undefined`, which the
+ * node answers with a 404 that reads like a missing route rather than a missing
+ * map entry. Inverting the one map makes a new collection work everywhere the
+ * moment the contract declares it.
+ */
+const SEGMENT_BY_MODEL: Record<string, string> = Object.fromEntries(
+  Object.entries(CRM_MODEL_BY_SEGMENT).map(([segment, model]) => [model, segment])
+);
 
 const ERROR_TYPE: Record<string, string> = {
   not_found: MedusaError.Types.NOT_FOUND,
@@ -62,7 +80,23 @@ class CrmProxyRepository implements ModelRepository {
       if (v === undefined || v === null || typeof v === "object") continue; // node handles equality filters
       p.set(k, String(v));
     }
-    if (config?.take != null) p.set("limit", String(config.take));
+    if (config?.take === null) {
+      // `take: null` means "every row" in the embedded repository. It used to be
+      // dropped here, and the node then saw no `limit` at all -> `take:
+      // undefined` -> the repository's DEFAULT PAGE OF 15. So the same call
+      // returned everything in dev and the oldest fifteen rows in prod, with no
+      // error either way. That silently truncates any full-collection read —
+      // deriving a contact's engagement from its first 15 activities, or
+      // building a dedupe map from 15 of 230 contacts.
+      //
+      // Sent as a large explicit number rather than a new sentinel so it
+      // behaves identically on a node that has NOT been redeployed. (`limit=0`
+      // would be worse than the bug: the old node reads it as take:0 and
+      // returns an empty array.)
+      p.set("limit", String(PROXY_LIST_ALL_LIMIT));
+    } else if (config?.take != null) {
+      p.set("limit", String(config.take));
+    }
     if (config?.skip) p.set("offset", String(config.skip));
     const s = p.toString();
     return s ? `?${s}` : "";
@@ -129,6 +163,7 @@ export interface CrmRepositories {
   crmOpportunityService: ModelRepository;
   crmNoteService: ModelRepository;
   crmTaskService: ModelRepository;
+  crmActivityService: ModelRepository;
 }
 
 /** Build proxy repositories that forward to the CRM node at `baseUrl`. */
@@ -141,5 +176,6 @@ export function createCrmProxyRepositories(baseUrl: string, token?: string): Crm
     crmOpportunityService: repo("crm_opportunity"),
     crmNoteService: repo("crm_note"),
     crmTaskService: repo("crm_task"),
+    crmActivityService: repo("crm_activity"),
   };
 }

--- a/apps/backend/src/modules/crm/dal/hyperbee-crm-service.ts
+++ b/apps/backend/src/modules/crm/dal/hyperbee-crm-service.ts
@@ -69,6 +69,7 @@ export interface CrmRepositories {
   crmOpportunityService: ModelRepository;
   crmNoteService: ModelRepository;
   crmTaskService: ModelRepository;
+  crmActivityService: ModelRepository;
 }
 
 export function createCrmRepositories(bee: BeeLike): CrmRepositories {
@@ -111,5 +112,6 @@ export function createCrmRepositories(bee: BeeLike): CrmRepositories {
     crmOpportunityService: wrapped.crm_opportunity,
     crmNoteService: wrapped.crm_note,
     crmTaskService: wrapped.crm_task,
+    crmActivityService: wrapped.crm_activity,
   };
 }

--- a/apps/backend/src/modules/crm/lead-to-crm.ts
+++ b/apps/backend/src/modules/crm/lead-to-crm.ts
@@ -1,0 +1,287 @@
+/**
+ * PURE lead -> CRM mapping. No container, no IO — so the whole "which of these
+ * 230 leads can become a contact, and what does it look like" question is
+ * unit-testable without booting Medusa or reaching the CRM node.
+ *
+ * ## Why this exists
+ *
+ * `socials.Lead` (Postgres) is already the merged ad-intake table: the Meta
+ * leadgen webhook, the Facebook webhook, the manual `/admin/meta-ads/leads/sync`
+ * pull and the email-ingest job all write to it. What it has never had is a way
+ * OUT — into the CRM where somebody actually works the contact. `Lead` has
+ * carried `external_id` / `external_system` / `synced_to_external_at` since it
+ * was written, unused. Those three fields are the link, and the idempotency key.
+ *
+ * ## The shape of the real data (checked against prod, not assumed)
+ *
+ * All 230 production leads have `full_name` and NEITHER `first_name` NOR
+ * `last_name`. Many are a single token with no surname at all
+ * ("SukhdevDhiman"). `crm_person.last_name` is therefore modelled nullable —
+ * see the note on the contract. A mapper that assumed the split fields were
+ * populated would have produced 230 contacts named "" "".
+ *
+ * Note the contract's `required` check only rejects `undefined`, so an empty
+ * string would have passed validation silently. Absent data is represented as
+ * `null` here, deliberately, so a missing surname stays visibly missing.
+ */
+import {
+  isUsableEmail,
+  splitFullName,
+} from "../../workflows/ad-planning/conversions/person-identity-lib"
+
+/** The `Lead` fields this mapping reads. Structural, so tests need no ORM row. */
+export type LeadSource = {
+  id: string
+  email?: string | null
+  phone?: string | null
+  full_name?: string | null
+  first_name?: string | null
+  last_name?: string | null
+  company_name?: string | null
+  job_title?: string | null
+  city?: string | null
+  state?: string | null
+  country?: string | null
+  source_platform?: string | null
+  campaign_name?: string | null
+  campaign_id?: string | null
+  ad_name?: string | null
+  form_name?: string | null
+  created_time?: string | Date | null
+  status?: string | null
+  external_id?: string | null
+  external_system?: string | null
+  metadata?: Record<string, any> | null
+}
+
+/** A `crm_person` create payload. Mirrors crmPersonContract. */
+export type CrmPersonDraft = {
+  first_name: string
+  last_name: string | null
+  email: string
+  phone: string | null
+  title: string | null
+  metadata: Record<string, any>
+}
+
+/** `external_system` value stamped back onto an imported Lead. */
+export const CRM_EXTERNAL_SYSTEM = "crm"
+
+/**
+ * Canonical source names. Prod carries THREE spellings for two platforms —
+ * `fb` (113), `ig` (116) and `facebook` (1) — because the leadgen webhook, the
+ * Facebook webhook and the sync route each stamp their own. Grouping "leads by
+ * source" is wrong until they agree, so collapse on read rather than migrating
+ * rows that other screens still display.
+ */
+const SOURCE_ALIASES: Record<string, string> = {
+  fb: "facebook",
+  facebook: "facebook",
+  ig: "instagram",
+  instagram: "instagram",
+  email: "email",
+  extension: "extension",
+}
+
+export function normalizeLeadSource(raw?: string | null): string {
+  const key = (raw ?? "").trim().toLowerCase()
+  if (!key) return "unknown"
+  return SOURCE_ALIASES[key] ?? key
+}
+
+/**
+ * Best-effort {first,last} for a lead. Precedence: the split fields when the
+ * source actually populated them, then `full_name`, then the email local-part
+ * (reusing the same derivation the order->Person backfill uses, so a contact
+ * imported from a lead and one derived from an order read alike).
+ *
+ * Returns `last_name: null` — not `""` — when there is no surname.
+ */
+export function deriveLeadName(lead: LeadSource): {
+  first_name: string
+  last_name: string | null
+} {
+  const first = (lead.first_name ?? "").trim()
+  const last = (lead.last_name ?? "").trim()
+  if (first || last) {
+    return { first_name: first, last_name: last || null }
+  }
+
+  const full = (lead.full_name ?? "").trim()
+  if (full) {
+    const split = splitFullName(full)
+    return { first_name: split.first_name, last_name: split.last_name || null }
+  }
+
+  const email = (lead.email ?? "").trim()
+  if (isUsableEmail(email)) {
+    const local = email.split("@")[0].replace(/[._+-]+/g, " ")
+    const split = splitFullName(local)
+    return {
+      first_name: titleCase(split.first_name),
+      last_name: titleCase(split.last_name) || null,
+    }
+  }
+
+  return { first_name: "", last_name: null }
+}
+
+function titleCase(s: string): string {
+  return s
+    .split(/\s+/)
+    .filter(Boolean)
+    .map((w) => w.charAt(0).toUpperCase() + w.slice(1))
+    .join(" ")
+}
+
+/**
+ * Build the `crm_person` payload for a lead, or `null` when the lead cannot
+ * become a contact.
+ *
+ * A usable email is REQUIRED, and not merely for politeness: `crm_person`
+ * declares `unique: ["email"]`, so it is the only key by which a re-run can
+ * recognise a contact it already created. Importing an email-less lead would
+ * create a row that every subsequent run duplicates.
+ */
+export function buildCrmPersonDraft(lead: LeadSource): CrmPersonDraft | null {
+  const email = (lead.email ?? "").trim().toLowerCase()
+  if (!isUsableEmail(email)) return null
+
+  const { first_name, last_name } = deriveLeadName(lead)
+  if (!first_name) return null
+
+  return {
+    first_name,
+    last_name,
+    email,
+    phone: (lead.phone ?? "").trim() || null,
+    title: (lead.job_title ?? "").trim() || null,
+    // Provenance travels with the contact. Without it a CRM person is an
+    // orphan: you cannot tell which campaign bought them or go back to the
+    // original form submission.
+    metadata: {
+      lead_id: lead.id,
+      source: normalizeLeadSource(lead.source_platform),
+      source_raw: lead.source_platform ?? null,
+      campaign_name: lead.campaign_name ?? null,
+      campaign_id: lead.campaign_id ?? null,
+      ad_name: lead.ad_name ?? null,
+      form_name: lead.form_name ?? null,
+      captured_at: toIso(lead.created_time),
+      city: (lead.city ?? "").trim() || null,
+      state: (lead.state ?? "").trim() || null,
+      country: (lead.country ?? "").trim() || null,
+    },
+  }
+}
+
+function toIso(v?: string | Date | null): string | null {
+  if (!v) return null
+  const d = v instanceof Date ? v : new Date(v)
+  return Number.isNaN(d.getTime()) ? null : d.toISOString()
+}
+
+// ---------------------------------------------------------------------------
+
+export type LeadImportAction =
+  /** Create a new crm_person, then stamp the lead. */
+  | { kind: "create"; lead: LeadSource; draft: CrmPersonDraft }
+  /** A crm_person already holds this email — stamp the lead at it, create nothing. */
+  | { kind: "link"; lead: LeadSource; crm_person_id: string }
+  /** Nothing to do. */
+  | { kind: "skip"; lead: LeadSource; reason: LeadSkipReason }
+
+export type LeadSkipReason =
+  | "already_imported"
+  | "no_usable_email"
+  | "no_usable_name"
+  | "duplicate_in_batch"
+
+export type LeadImportPlan = {
+  actions: LeadImportAction[]
+  counts: Record<string, number>
+}
+
+/**
+ * Decide what to do with every lead, given the contacts the CRM already holds.
+ *
+ * Idempotent on TWO independent keys, because either alone leaks:
+ *  - the lead's own `external_id`/`external_system` stamp (a lead imported
+ *    before is never re-imported), and
+ *  - the crm_person email index (a contact that arrived by another route — the
+ *    browser extension, a manual create — is linked, not duplicated).
+ *
+ * `existingPersonIdByEmail` keys are matched case-insensitively; callers pass
+ * whatever the CRM returned and this lowercases both sides.
+ *
+ * Within a single batch the first lead for an email wins and later ones are
+ * `duplicate_in_batch`, so one run cannot race itself into a uniqueness error
+ * that the contract would reject anyway.
+ */
+export function planLeadImport(
+  leads: LeadSource[],
+  existingPersonIdByEmail: Record<string, string> = {}
+): LeadImportPlan {
+  const existing = new Map<string, string>()
+  for (const [email, id] of Object.entries(existingPersonIdByEmail)) {
+    if (email) existing.set(email.trim().toLowerCase(), id)
+  }
+
+  const seenInBatch = new Set<string>()
+  const actions: LeadImportAction[] = []
+
+  for (const lead of leads) {
+    if (lead.external_system === CRM_EXTERNAL_SYSTEM && lead.external_id) {
+      actions.push({ kind: "skip", lead, reason: "already_imported" })
+      continue
+    }
+
+    const draft = buildCrmPersonDraft(lead)
+    if (!draft) {
+      const reason: LeadSkipReason = isUsableEmail((lead.email ?? "").trim())
+        ? "no_usable_name"
+        : "no_usable_email"
+      actions.push({ kind: "skip", lead, reason })
+      continue
+    }
+
+    const hit = existing.get(draft.email)
+    if (hit) {
+      actions.push({ kind: "link", lead, crm_person_id: hit })
+      continue
+    }
+
+    if (seenInBatch.has(draft.email)) {
+      actions.push({ kind: "skip", lead, reason: "duplicate_in_batch" })
+      continue
+    }
+
+    seenInBatch.add(draft.email)
+    actions.push({ kind: "create", lead, draft })
+  }
+
+  const counts: Record<string, number> = {}
+  for (const a of actions) {
+    const key = a.kind === "skip" ? `skip_${a.reason}` : a.kind
+    counts[key] = (counts[key] ?? 0) + 1
+  }
+
+  return { actions, counts }
+}
+
+/** One-line human summary of a plan, for the maintenance-job result. */
+export function summarizeLeadImport(plan: LeadImportPlan, dryRun: boolean): string {
+  const c = plan.counts
+  const verb = dryRun ? "Would import" : "Imported"
+  const parts = [
+    `${verb} ${c.create ?? 0} lead(s) as CRM contacts`,
+    `${c.link ?? 0} linked to existing contacts`,
+    `${c.skip_already_imported ?? 0} already imported`,
+  ]
+  const unusable = (c.skip_no_usable_email ?? 0) + (c.skip_no_usable_name ?? 0)
+  if (unusable) parts.push(`${unusable} unusable (no email/name)`)
+  if (c.skip_duplicate_in_batch) {
+    parts.push(`${c.skip_duplicate_in_batch} duplicate email(s) within the batch`)
+  }
+  return `${parts.join(", ")}.`
+}

--- a/apps/backend/src/modules/crm/loaders/hyperbee-dal.ts
+++ b/apps/backend/src/modules/crm/loaders/hyperbee-dal.ts
@@ -40,6 +40,7 @@ function registerCrm(container: LoaderOptions["container"], repos: CrmRepositori
     crmOpportunityService: asValue(repos.crmOpportunityService),
     crmNoteService: asValue(repos.crmNoteService),
     crmTaskService: asValue(repos.crmTaskService),
+    crmActivityService: asValue(repos.crmActivityService),
     baseRepository: asValue(baseRepository),
   });
 }

--- a/apps/backend/src/modules/crm/node/deploy/README.md
+++ b/apps/backend/src/modules/crm/node/deploy/README.md
@@ -28,6 +28,12 @@ POST /crm/opportunities {"stage": "sampling"}   → 422   "must be one of
                                                   lost], got 'sampling'"
 ```
 
+A **new collection** is the strongest case of all: the node builds its repo map
+from `crmContracts` and its URL segments from `CRM_MODEL_BY_SEGMENT`, both at
+bundle time. Until it is redeployed, `/crm/activities` is simply not a route it
+serves — every activity write fails with the node's own 404, which reads exactly
+like a missing Medusa route.
+
 So: **widening** a field (required → nullable) needs no redeploy, because the
 old contract already accepted the wider value. **Changing an enum** does. After
 any edit to `stages.ts` or `crm-contracts.ts`, rebuild the bundle (step 1),

--- a/apps/backend/src/modules/crm/node/deploy/README.md
+++ b/apps/backend/src/modules/crm/node/deploy/README.md
@@ -9,6 +9,31 @@ the API tasks).
 No secrets live in this directory. The bearer token and the cloudflared connector
 token are generated at deploy time and kept only in SSM / on the box.
 
+## ⚠️ When a contract change REQUIRES a redeploy
+
+The node validates every write against **its own bundled copy** of
+`../dal/crm-contracts.ts` (and, through it, `../../stages.ts`). Medusa validates
+too, but the node has the last word — so a vocabulary change that ships only in
+the backend is rejected here, at the proxy, with a 422 naming the *old* enum.
+`tsc`, the unit tests and `check:prod-build` are all blind to it: they only ever
+see the new copy.
+
+Verified by probe on 2026-08-19 against the live node:
+
+```
+POST /crm/people       {"last_name": null}      → 201   (widening a field: safe)
+POST /crm/opportunities {"stage": "sampling"}   → 422   "must be one of
+                                                  [prospecting, qualification,
+                                                  proposal, negotiation, won,
+                                                  lost], got 'sampling'"
+```
+
+So: **widening** a field (required → nullable) needs no redeploy, because the
+old contract already accepted the wider value. **Changing an enum** does. After
+any edit to `stages.ts` or `crm-contracts.ts`, rebuild the bundle (step 1),
+re-ship it (step 2) and `sudo systemctl restart crm-node`, then re-probe the new
+value before believing the pipeline works.
+
 ## 1. Build the bundle (from repo root)
 
 A single self-contained CJS file — `server.ts` + `../dal/crm-contracts.ts` +

--- a/apps/backend/src/modules/crm/service.ts
+++ b/apps/backend/src/modules/crm/service.ts
@@ -1,5 +1,11 @@
 import type { ModelRepository } from "@jytextiles/mikrohyperbee";
 
+import {
+  deriveEngagement,
+  summarizeActivity,
+  type EngagementActivity,
+} from "./activity";
+
 /**
  * CrmService — the module service for the Hyperbee-only CRM module.
  *
@@ -127,6 +133,96 @@ class CrmService {
   }
   async deleteCrmTasks(selector: any) {
     return this.repo("crmTaskService").delete(selector);
+  }
+
+  // ── activities ────────────────────────────────────────────────────────────
+  async createCrmActivities(data: any) {
+    return this.repo("crmActivityService").create(data);
+  }
+  async retrieveCrmActivity(id: string) {
+    return this.repo("crmActivityService").retrieve(id);
+  }
+  async listCrmActivities(filters?: any, config?: any) {
+    return this.repo("crmActivityService").list(filters, config);
+  }
+  async listAndCountCrmActivities(filters?: any, config?: any) {
+    return this.repo("crmActivityService").listAndCount(filters, config);
+  }
+  async updateCrmActivities(data: any) {
+    return this.repo("crmActivityService").update(data);
+  }
+  async deleteCrmActivities(selector: any) {
+    return this.repo("crmActivityService").delete(selector);
+  }
+
+  // ── the two composed operations ───────────────────────────────────────────
+
+  /**
+   * Record an interaction AND refresh the contact's engagement cache.
+   *
+   * These are one operation on purpose. An activity written without the
+   * recompute leaves `engagement_state` describing a conversation that has
+   * since moved on — and since flows select on that field, a stale value does
+   * not merely look wrong, it decides who gets messaged. Every write path
+   * (route, subscriber, flow, MCP tool) goes through here.
+   *
+   * The recompute is best-effort: the interaction genuinely happened, so
+   * failing to update a derived cache must not lose the record of it. A failed
+   * recompute is repaired by the next activity or by the sweep job.
+   */
+  async recordCrmActivity(input: any) {
+    const occurred_at = input.occurred_at ?? new Date().toISOString();
+    const activity = await this.createCrmActivities({
+      ...input,
+      occurred_at,
+      summary: input.summary ?? summarizeActivity({ ...input, occurred_at }),
+    });
+
+    if (input.related_type === "person" && input.related_id) {
+      await this.refreshCrmEngagement(input.related_id).catch(() => {});
+    }
+    return activity;
+  }
+
+  /**
+   * Recompute one contact's engagement snapshot from its activity log.
+   *
+   * Returns the snapshot, and writes it only when something actually changed —
+   * so a settled contact costs a read and no write. That matters more here
+   * than in Postgres: every write is an HTTP round trip to the CRM node and an
+   * Autobase append that replicates.
+   */
+  async refreshCrmEngagement(personId: string, now: Date = new Date()) {
+    const person: any = await this.retrieveCrmPerson(personId);
+    const activities: EngagementActivity[] = await this.listCrmActivities(
+      { related_type: "person", related_id: personId },
+      { take: null }
+    );
+
+    const snapshot = deriveEngagement(activities, {
+      now,
+      scheduledFollowUpAt: person?.next_follow_up_at ?? null,
+    });
+
+    const changed =
+      person?.engagement_state !== snapshot.engagement_state ||
+      person?.last_activity_at !== snapshot.last_activity_at ||
+      person?.last_inbound_at !== snapshot.last_inbound_at ||
+      person?.last_outbound_at !== snapshot.last_outbound_at ||
+      (person?.next_follow_up_at ?? null) !== snapshot.next_follow_up_at;
+
+    if (changed) {
+      await this.updateCrmPeople({
+        id: personId,
+        engagement_state: snapshot.engagement_state,
+        last_activity_at: snapshot.last_activity_at,
+        last_inbound_at: snapshot.last_inbound_at,
+        last_outbound_at: snapshot.last_outbound_at,
+        next_follow_up_at: snapshot.next_follow_up_at,
+      });
+    }
+
+    return { ...snapshot, changed, previous_state: person?.engagement_state ?? null };
   }
 }
 

--- a/apps/backend/src/modules/crm/stages.ts
+++ b/apps/backend/src/modules/crm/stages.ts
@@ -1,0 +1,70 @@
+/**
+ * The CRM deal pipeline vocabulary. THE single source of truth.
+ *
+ * This file deliberately has NO imports. It is consumed by four things that
+ * cannot all share a heavier dependency:
+ *
+ *   1. `dal/crm-contracts.ts`      — the Hyperbee contract (Medusa-free)
+ *   2. `node/server.ts`            — via the contract, bundled into the
+ *                                    standalone CRM node with esbuild
+ *   3. the admin API validators    — zod, server-side
+ *   4. the admin dashboard         — Vite-bundled for the BROWSER
+ *
+ * (4) is why the constants live here rather than in the contract: importing the
+ * contract would pull `@jytextiles/mikrohyperbee` — corestore, hyperbee and the
+ * native hypercore stack behind it — into a browser bundle.
+ *
+ * Shaped for textiles rather than generic SaaS. `sampling` is the decisive
+ * stage in this business (a swatch or sample has physically gone out) and was
+ * invisible in the previous list; `quoted` replaces `proposal` because what
+ * gets sent is a price for a quantity, not a document.
+ *
+ * ⚠️ This enum is enforced in TWO processes. Medusa validates on the way in,
+ * and the standalone CRM node re-validates against its own bundled copy.
+ * Changing it therefore requires REBUILDING AND REDEPLOYING the node bundle
+ * (modules/crm/node/deploy/README.md) — until that happens the node rejects any
+ * new value with a 422 naming the old enum, and the write fails at the proxy
+ * rather than at the validator. Verified by probe, not assumed.
+ */
+
+export const CRM_OPPORTUNITY_STAGES = [
+  "prospecting",
+  "sampling",
+  "quoted",
+  "negotiation",
+  "won",
+  "lost",
+] as const;
+
+export type CrmOpportunityStage = (typeof CRM_OPPORTUNITY_STAGES)[number];
+
+export const CRM_OPPORTUNITY_DEFAULT_STAGE: CrmOpportunityStage = "prospecting";
+
+/** Stages that end the deal. Used to keep won/lost out of open-pipeline value. */
+export const CRM_OPPORTUNITY_CLOSED_STAGES: readonly CrmOpportunityStage[] = [
+  "won",
+  "lost",
+];
+
+/** Display label per stage. */
+export const CRM_STAGE_LABELS: Record<CrmOpportunityStage, string> = {
+  prospecting: "Prospecting",
+  sampling: "Sampling",
+  quoted: "Quoted",
+  negotiation: "Negotiation",
+  won: "Won",
+  lost: "Lost",
+};
+
+/** What each stage actually means, so the board is self-explaining. */
+export const CRM_STAGE_HINTS: Record<CrmOpportunityStage, string> = {
+  prospecting: "Qualified, not yet sent anything",
+  sampling: "Swatch or sample has gone out",
+  quoted: "Price and quantity sent",
+  negotiation: "Terms being agreed",
+  won: "Closed — order placed",
+  lost: "Closed — no deal",
+};
+
+export const isClosedStage = (s: string): boolean =>
+  (CRM_OPPORTUNITY_CLOSED_STAGES as readonly string[]).includes(s);

--- a/apps/crm-extension/README.md
+++ b/apps/crm-extension/README.md
@@ -1,0 +1,99 @@
+# JYT CRM Capture — Chrome extension
+
+Capture a contact from any web page into the JYT CRM in two clicks.
+
+No build step, no dependencies, no bundler. It is plain ES modules that Chrome
+loads directly, so what you read here is exactly what runs.
+
+## Install (unpacked)
+
+1. Open `chrome://extensions`
+2. Turn on **Developer mode** (top right)
+3. **Load unpacked** → select this folder (`apps/crm-extension`)
+4. Click the extension → **Open settings**, and set:
+   - **Backend URL** — `https://v3.jaalyantra.com` (the prod backend)
+   - **Admin API key** — a Medusa admin secret key
+
+Works in Chrome, Edge, Brave and Arc.
+
+## Use
+
+On any page with contact details, click the toolbar button. The popup shows
+what it found, pre-filled and **editable**. Correct anything, then **Save to
+CRM**.
+
+Selecting text before you click seeds the note with your selection — the
+fastest way to capture "they asked about 40 stoles in undyed pashmina".
+
+## What it reads
+
+In rough order of trust:
+
+| Source | Used for |
+|---|---|
+| JSON-LD `Person` / `Organization` | name, company, job title, email, phone |
+| `mailto:` / `tel:` links | email, phone |
+| Open Graph / meta tags | name, company, description |
+| First `<h1>` | name |
+| Visible page text | emails (regex, filtered) |
+| Your text selection | the note |
+
+Everything is a **suggestion**. Nothing is sent until you press Save, because a
+scraper is guessing and a CRM full of confidently-wrong contacts is worse than
+an empty one.
+
+Email candidates are filtered for the usual false positives — asset filenames
+that look like addresses, `no-reply@`, `example@`. When a page yields more than
+one, you get a picker rather than a silent "first one wins", since the first is
+so often a generic `info@`.
+
+## Privacy
+
+`activeTab` + `scripting`, so the extension can read **no page at all** until
+you click its button, and then only that tab. There is no content script
+running in the background and no host permission for arbitrary sites.
+
+## ⚠️ About the API key
+
+A Medusa admin secret key is **not scoped to the CRM** — it reaches the whole
+admin API, and it sits in this browser profile's local storage.
+
+- Create a key **specifically for this extension** so it can be revoked alone.
+- Treat it like a password.
+
+The per-token scopes built for MCP (#1306 Track C) do not help here: a scope row
+is only written for a `user` actor, and an `sk_` key is not one. Narrowing this
+properly means either giving the extension an OAuth flow against the MCP front
+door (#1306 Track B, already live and proven) or adding a dedicated
+capture-only credential. Both are follow-ups, not v0.1.
+
+## Endpoints used
+
+- `POST /admin/crm/people` — creates the contact
+- `POST /admin/crm/notes` — attaches the note (best-effort; a failed note never
+  reads as a failed capture)
+
+Contacts are stamped `metadata.source = "extension"` with the page URL and
+title, so a captured contact is traceable to where it came from — the same way
+an imported ad-lead carries its campaign.
+
+## Safari
+
+This is Chrome MV3. Safari can run it via Apple's converter:
+
+```
+xcrun safari-web-extension-converter apps/crm-extension
+```
+
+That produces an Xcode project. Running it outside a development machine needs
+a paid Apple Developer account, which is why Chrome ships first.
+
+## Known limits (v0.1)
+
+- Company is captured into the contact's metadata as text, not linked to a
+  `crm_company` record — linking happens in the admin.
+- No duplicate check before saving. The backend rejects a duplicate email and
+  the popup shows that message, so nothing is silently double-written, but the
+  extension does not warn you in advance.
+- Chrome refuses script injection on `chrome://` pages, the Web Store and PDFs.
+  The popup says so rather than failing silently.

--- a/apps/crm-extension/manifest.json
+++ b/apps/crm-extension/manifest.json
@@ -1,0 +1,20 @@
+{
+  "manifest_version": 3,
+  "name": "JYT CRM Capture",
+  "version": "0.1.0",
+  "description": "Capture a contact from any web page into the JYT CRM.",
+  "permissions": [
+    "activeTab",
+    "scripting",
+    "storage"
+  ],
+  "host_permissions": [
+    "https://v3.jaalyantra.com/*",
+    "http://localhost/*"
+  ],
+  "action": {
+    "default_title": "Capture to JYT CRM",
+    "default_popup": "src/popup.html"
+  },
+  "options_page": "src/options.html"
+}

--- a/apps/crm-extension/src/api.js
+++ b/apps/crm-extension/src/api.js
@@ -1,0 +1,102 @@
+/**
+ * The extension's whole backend surface: two admin routes, plus settings.
+ *
+ * ## Authentication
+ *
+ * A Medusa admin secret API key, sent as HTTP Basic with the key as the
+ * username and an empty password — the same scheme the admin API already
+ * accepts everywhere else.
+ *
+ * ⚠️ An admin secret key is NOT scoped to the CRM. Anything holding it can
+ * reach the whole admin API, and it lives in extension storage on this machine.
+ * Use a key created FOR this extension so it can be revoked on its own, and
+ * treat it like a password. The per-token scopes built for MCP (#1306 Track C)
+ * do not apply here: scope rows are only written for a `user` actor, and an
+ * `sk_` key is not one.
+ */
+
+const DEFAULT_BASE_URL = "https://v3.jaalyantra.com";
+
+export async function getSettings() {
+  const { baseUrl, token } = await chrome.storage.local.get([
+    "baseUrl",
+    "token",
+  ]);
+  return { baseUrl: baseUrl || DEFAULT_BASE_URL, token: token || "" };
+}
+
+export async function saveSettings(baseUrl, token) {
+  await chrome.storage.local.set({
+    baseUrl: (baseUrl || DEFAULT_BASE_URL).replace(/\/+$/, ""),
+    token: token || "",
+  });
+}
+
+/**
+ * Split a scraped display name into {first,last}.
+ *
+ * Mirrors the backend's `splitFullName`: the first token is the given name and
+ * everything after it is the surname. A single-token name yields an EMPTY
+ * surname, not a duplicated one — the CRM models a missing surname as absent,
+ * and inventing one here would put a guess into the record permanently.
+ */
+export function splitName(full) {
+  const parts = String(full || "")
+    .trim()
+    .split(/\s+/)
+    .filter(Boolean);
+  if (parts.length === 0) return { first: "", last: "" };
+  if (parts.length === 1) return { first: parts[0], last: "" };
+  return { first: parts[0], last: parts.slice(1).join(" ") };
+}
+
+async function request(settings, path, body) {
+  let res;
+  try {
+    res = await fetch(`${settings.baseUrl}${path}`, {
+      method: "POST",
+      headers: {
+        "content-type": "application/json",
+        // btoa is fine here: an API key is ASCII by construction.
+        authorization: `Basic ${btoa(`${settings.token}:`)}`,
+      },
+      body: JSON.stringify(body),
+    });
+  } catch {
+    throw new Error(
+      `Could not reach ${settings.baseUrl}. Check the URL in settings and that the host is allowed in the manifest.`
+    );
+  }
+
+  if (res.status === 401 || res.status === 403) {
+    throw new Error("Rejected: the API key is wrong, revoked, or lacks access.");
+  }
+
+  const text = await res.text();
+  let data;
+  try {
+    data = text ? JSON.parse(text) : {};
+  } catch {
+    // A non-JSON body on an error status is usually a proxy or WAF page; the
+    // status is the only trustworthy part of it.
+    throw new Error(`Unexpected response (HTTP ${res.status}).`);
+  }
+
+  if (!res.ok) {
+    // Surface what the server said. A duplicate email is the common case and
+    // the message names it, which is far more useful than "save failed".
+    throw new Error(data.message || `Save failed (HTTP ${res.status}).`);
+  }
+  return data;
+}
+
+export async function createContact(settings, contact) {
+  const data = await request(settings, "/admin/crm/people", contact);
+  const person = data.crm_person || data.person || data;
+  if (!person || !person.id) throw new Error("Saved, but no contact id came back.");
+  return person;
+}
+
+export async function logNote(settings, note) {
+  return request(settings, "/admin/crm/notes", note);
+}

--- a/apps/crm-extension/src/extract.js
+++ b/apps/crm-extension/src/extract.js
@@ -1,0 +1,123 @@
+/**
+ * The page scraper, injected on demand.
+ *
+ * This function is stringified and run in the page by `chrome.scripting`, so it
+ * must be entirely self-contained — no imports, no closure over anything in the
+ * extension. It returns plain data; every judgement about what to keep is made
+ * back in the popup, where the user can see and correct it.
+ *
+ * Runs only when the user clicks the toolbar button (activeTab), so the
+ * extension can read no page until it is explicitly invoked on that page.
+ */
+export function extractFromPage() {
+  const text = document.body ? document.body.innerText || "" : "";
+
+  const meta = (name) => {
+    const el =
+      document.querySelector(`meta[property="${name}"]`) ||
+      document.querySelector(`meta[name="${name}"]`);
+    return el ? (el.getAttribute("content") || "").trim() : "";
+  };
+
+  // ---- JSON-LD -----------------------------------------------------------
+  // The richest source when present: many company and profile pages publish a
+  // fully-formed Person or Organization here.
+  const jsonLd = [];
+  for (const node of document.querySelectorAll(
+    'script[type="application/ld+json"]'
+  )) {
+    try {
+      const parsed = JSON.parse(node.textContent || "");
+      // A page may publish a single object, an array, or an @graph wrapper.
+      const items = Array.isArray(parsed)
+        ? parsed
+        : parsed && Array.isArray(parsed["@graph"])
+          ? parsed["@graph"]
+          : [parsed];
+      for (const item of items) if (item && typeof item === "object") jsonLd.push(item);
+    } catch {
+      // A malformed block on somebody else's page must not stop the capture.
+    }
+  }
+
+  const ldOfType = (type) =>
+    jsonLd.find((i) => {
+      const t = i["@type"];
+      return Array.isArray(t) ? t.includes(type) : t === type;
+    });
+
+  const person = ldOfType("Person");
+  const org = ldOfType("Organization") || ldOfType("LocalBusiness");
+
+  // ---- Emails ------------------------------------------------------------
+  // mailto: links first — they are declared, not guessed.
+  const emails = [];
+  const pushEmail = (raw) => {
+    const e = (raw || "").trim().toLowerCase();
+    if (!e || !/^[^@\s]+@[^@\s]+\.[a-z]{2,}$/i.test(e)) return;
+    // Tracking pixels and asset filenames produce convincing false positives.
+    if (/\.(png|jpe?g|gif|svg|webp|css|js)$/i.test(e)) return;
+    if (/^(example|test|no-?reply|donotreply)@/i.test(e)) return;
+    if (!emails.includes(e)) emails.push(e);
+  };
+
+  for (const a of document.querySelectorAll('a[href^="mailto:"]')) {
+    pushEmail((a.getAttribute("href") || "").slice(7).split("?")[0]);
+  }
+  for (const m of text.match(/[^\s<>()[\]{}]+@[^\s<>()[\]{}]+\.[a-z]{2,}/gi) || []) {
+    pushEmail(m.replace(/[.,;:]+$/, ""));
+  }
+  if (person && person.email) pushEmail(String(person.email).replace(/^mailto:/, ""));
+  if (org && org.email) pushEmail(String(org.email).replace(/^mailto:/, ""));
+
+  // ---- Phones ------------------------------------------------------------
+  const phones = [];
+  const pushPhone = (raw) => {
+    const p = (raw || "").trim();
+    if (!p) return;
+    const digits = p.replace(/[^\d]/g, "");
+    // Below 8 digits it is far more likely a price, a year or an order number.
+    if (digits.length < 8 || digits.length > 15) return;
+    if (!phones.includes(p)) phones.push(p);
+  };
+  for (const a of document.querySelectorAll('a[href^="tel:"]')) {
+    pushPhone(decodeURIComponent((a.getAttribute("href") || "").slice(4)));
+  }
+  if (person && person.telephone) pushPhone(String(person.telephone));
+  if (org && org.telephone) pushPhone(String(org.telephone));
+
+  // ---- Name / company / title -------------------------------------------
+  const h1 = document.querySelector("h1");
+  const name =
+    (person && person.name) ||
+    meta("profile:first_name") ||
+    (h1 ? (h1.innerText || "").trim() : "") ||
+    meta("og:title") ||
+    "";
+
+  const company =
+    (org && org.name) ||
+    (person && person.worksFor && person.worksFor.name) ||
+    meta("og:site_name") ||
+    "";
+
+  const jobTitle = (person && person.jobTitle) || meta("profile:title") || "";
+
+  // A deliberate selection is the strongest signal of intent on the page, so
+  // it seeds the note rather than the generic description.
+  const selection = String(window.getSelection ? window.getSelection() : "").trim();
+
+  return {
+    url: location.href,
+    origin: location.origin,
+    hostname: location.hostname,
+    page_title: document.title || "",
+    name: String(name).trim().slice(0, 200),
+    company: String(company).trim().slice(0, 200),
+    job_title: String(jobTitle).trim().slice(0, 200),
+    emails: emails.slice(0, 10),
+    phones: phones.slice(0, 10),
+    description: meta("og:description") || meta("description") || "",
+    selection: selection.slice(0, 2000),
+  };
+}

--- a/apps/crm-extension/src/options.html
+++ b/apps/crm-extension/src/options.html
@@ -1,0 +1,54 @@
+<!doctype html>
+<html lang="en">
+  <head>
+    <meta charset="utf-8" />
+    <title>JYT CRM Capture — Settings</title>
+    <style>
+      :root { color-scheme: light dark; }
+      body {
+        max-width: 520px;
+        margin: 40px auto;
+        padding: 0 20px;
+        font: 14px/1.55 -apple-system, BlinkMacSystemFont, "Segoe UI", sans-serif;
+      }
+      h1 { font-size: 17px; }
+      label { display: block; margin: 16px 0 4px; font-weight: 600; font-size: 12px; }
+      input { width: 100%; padding: 7px 9px; font: inherit; border: 1px solid #d4d4d8; border-radius: 6px; }
+      button { margin-top: 18px; padding: 8px 16px; font: inherit; font-weight: 600; border-radius: 6px; border: 0; background: #18181b; color: #fff; cursor: pointer; }
+      .warn { margin-top: 22px; padding: 11px 13px; border-left: 3px solid #d97706; background: #fffbeb; color: #78350f; font-size: 12.5px; border-radius: 4px; }
+      .hint { font-size: 12px; color: #71717a; margin-top: 3px; }
+      #saved { margin-left: 10px; color: #15803d; font-size: 12px; }
+      @media (prefers-color-scheme: dark) {
+        body { background: #18181b; color: #fafafa; }
+        input { background: #27272a; color: #fafafa; border-color: #3f3f46; }
+        button { background: #fafafa; color: #18181b; }
+        .warn { background: #292524; color: #fde68a; }
+      }
+    </style>
+  </head>
+  <body>
+    <h1>JYT CRM Capture — Settings</h1>
+
+    <label for="baseUrl">Backend URL</label>
+    <input id="baseUrl" placeholder="https://v3.jaalyantra.com" />
+    <div class="hint">
+      The prod backend is <code>v3.jaalyantra.com</code>. A host not listed in
+      the extension manifest will be blocked by Chrome even if the URL is right.
+    </div>
+
+    <label for="token">Admin API key</label>
+    <input id="token" type="password" placeholder="sk_..." autocomplete="off" />
+    <div class="hint">Stored locally in this browser profile. Never synced.</div>
+
+    <button id="save">Save</button><span id="saved"></span>
+
+    <div class="warn">
+      <strong>This key is not scoped to the CRM.</strong> A Medusa admin secret
+      key reaches the entire admin API. Create one specifically for this
+      extension so it can be revoked on its own without disturbing anything
+      else, and treat it like a password.
+    </div>
+
+    <script type="module" src="options.js"></script>
+  </body>
+</html>

--- a/apps/crm-extension/src/options.js
+++ b/apps/crm-extension/src/options.js
@@ -1,0 +1,13 @@
+import { getSettings, saveSettings } from "./api.js";
+
+const $ = (id) => document.getElementById(id);
+
+const settings = await getSettings();
+$("baseUrl").value = settings.baseUrl;
+$("token").value = settings.token;
+
+$("save").addEventListener("click", async () => {
+  await saveSettings($("baseUrl").value.trim(), $("token").value.trim());
+  $("saved").textContent = "Saved";
+  setTimeout(() => ($("saved").textContent = ""), 2000);
+});

--- a/apps/crm-extension/src/popup.html
+++ b/apps/crm-extension/src/popup.html
@@ -1,0 +1,120 @@
+<!doctype html>
+<html lang="en">
+  <head>
+    <meta charset="utf-8" />
+    <title>Capture to JYT CRM</title>
+    <style>
+      :root {
+        color-scheme: light dark;
+        --bg: #ffffff;
+        --fg: #18181b;
+        --muted: #71717a;
+        --border: #e4e4e7;
+        --accent: #18181b;
+        --accent-fg: #ffffff;
+        --ok: #15803d;
+        --err: #b91c1c;
+      }
+      @media (prefers-color-scheme: dark) {
+        :root {
+          --bg: #18181b;
+          --fg: #fafafa;
+          --muted: #a1a1aa;
+          --border: #3f3f46;
+          --accent: #fafafa;
+          --accent-fg: #18181b;
+          --ok: #4ade80;
+          --err: #f87171;
+        }
+      }
+      * { box-sizing: border-box; }
+      body {
+        width: 360px;
+        margin: 0;
+        padding: 14px;
+        font: 13px/1.45 -apple-system, BlinkMacSystemFont, "Segoe UI", sans-serif;
+        background: var(--bg);
+        color: var(--fg);
+      }
+      h1 { font-size: 13px; margin: 0 0 2px; }
+      .sub { color: var(--muted); font-size: 11px; margin-bottom: 12px; word-break: break-all; }
+      label { display: block; font-size: 11px; color: var(--muted); margin: 9px 0 3px; }
+      input, textarea, select {
+        width: 100%;
+        padding: 6px 8px;
+        font: inherit;
+        color: var(--fg);
+        background: var(--bg);
+        border: 1px solid var(--border);
+        border-radius: 6px;
+      }
+      textarea { resize: vertical; min-height: 52px; }
+      .row { display: flex; gap: 8px; }
+      .row > div { flex: 1; min-width: 0; }
+      button {
+        width: 100%;
+        margin-top: 14px;
+        padding: 8px;
+        font: inherit;
+        font-weight: 600;
+        color: var(--accent-fg);
+        background: var(--accent);
+        border: 0;
+        border-radius: 6px;
+        cursor: pointer;
+      }
+      button:disabled { opacity: 0.5; cursor: default; }
+      #status { margin-top: 10px; font-size: 11px; min-height: 15px; }
+      #status.ok { color: var(--ok); }
+      #status.err { color: var(--err); }
+      .hint { font-size: 11px; color: var(--muted); margin-top: 4px; }
+      a { color: inherit; }
+    </style>
+  </head>
+  <body>
+    <h1>Capture to JYT CRM</h1>
+    <div class="sub" id="page-url">Reading page…</div>
+
+    <div id="form" hidden>
+      <div class="row">
+        <div>
+          <label for="first_name">First name *</label>
+          <input id="first_name" autocomplete="off" />
+        </div>
+        <div>
+          <label for="last_name">Last name</label>
+          <input id="last_name" autocomplete="off" />
+        </div>
+      </div>
+
+      <label for="email">Email *</label>
+      <select id="email-pick" hidden></select>
+      <input id="email" type="email" autocomplete="off" />
+      <div class="hint">The CRM keys contacts on email — it must be unique.</div>
+
+      <label for="phone">Phone</label>
+      <input id="phone" autocomplete="off" />
+
+      <label for="title">Job title</label>
+      <input id="title" autocomplete="off" />
+
+      <label for="company">Company</label>
+      <input id="company" autocomplete="off" />
+      <div class="hint">Saved as a note — companies are linked in the admin.</div>
+
+      <label for="note">Note</label>
+      <textarea id="note"></textarea>
+
+      <button id="save">Save to CRM</button>
+    </div>
+
+    <div id="setup" hidden>
+      <p>No backend credentials set yet.</p>
+      <button id="open-options">Open settings</button>
+    </div>
+
+    <div id="status"></div>
+
+    <script type="module" src="popup.js"></script>
+  </body>
+</html>

--- a/apps/crm-extension/src/popup.js
+++ b/apps/crm-extension/src/popup.js
@@ -1,0 +1,138 @@
+import { extractFromPage } from "./extract.js";
+import { getSettings, splitName, createContact, logNote } from "./api.js";
+
+const $ = (id) => document.getElementById(id);
+
+const setStatus = (msg, kind) => {
+  const el = $("status");
+  el.textContent = msg;
+  el.className = kind || "";
+};
+
+/**
+ * Populate the form from what the page yielded. Everything is a SUGGESTION —
+ * the user sees each field before anything is sent, because a scraper is
+ * guessing and a CRM full of confidently-wrong contacts is worse than an empty
+ * one.
+ */
+function fill(extracted) {
+  $("page-url").textContent = extracted.url;
+
+  const { first, last } = splitName(extracted.name);
+  $("first_name").value = first;
+  $("last_name").value = last;
+  $("title").value = extracted.job_title || "";
+  $("company").value = extracted.company || extracted.hostname || "";
+  $("phone").value = extracted.phones[0] || "";
+  $("email").value = extracted.emails[0] || "";
+
+  // More than one candidate email: let the user pick rather than silently
+  // taking the first, which is often a generic info@ address.
+  if (extracted.emails.length > 1) {
+    const pick = $("email-pick");
+    pick.hidden = false;
+    pick.innerHTML = extracted.emails
+      .map((e) => `<option value="${e}">${e}</option>`)
+      .join("");
+    pick.addEventListener("change", () => {
+      $("email").value = pick.value;
+    });
+  }
+
+  const noteParts = [`Captured from ${extracted.url}`];
+  if (extracted.selection) noteParts.push(`"${extracted.selection}"`);
+  else if (extracted.description) noteParts.push(extracted.description);
+  $("note").value = noteParts.join("\n\n");
+
+  $("form").hidden = false;
+}
+
+async function main() {
+  const settings = await getSettings();
+  if (!settings.baseUrl || !settings.token) {
+    $("page-url").textContent = "";
+    $("setup").hidden = false;
+    $("open-options").addEventListener("click", () =>
+      chrome.runtime.openOptionsPage()
+    );
+    return;
+  }
+
+  const [tab] = await chrome.tabs.query({ active: true, currentWindow: true });
+  if (!tab || !tab.id) {
+    setStatus("No active tab to read.", "err");
+    return;
+  }
+
+  let extracted;
+  try {
+    const [result] = await chrome.scripting.executeScript({
+      target: { tabId: tab.id },
+      func: extractFromPage,
+    });
+    extracted = result && result.result;
+  } catch (e) {
+    // Chrome refuses injection on its own pages, the Web Store, and PDFs.
+    setStatus(
+      `Cannot read this page (${e.message}). Try a normal web page.`,
+      "err"
+    );
+    $("page-url").textContent = tab.url || "";
+    return;
+  }
+
+  if (!extracted) {
+    setStatus("Nothing could be read from this page.", "err");
+    return;
+  }
+
+  fill(extracted);
+
+  $("save").addEventListener("click", async () => {
+    const first_name = $("first_name").value.trim();
+    const email = $("email").value.trim().toLowerCase();
+
+    if (!first_name) return setStatus("A first name is required.", "err");
+    if (!email) return setStatus("An email is required.", "err");
+
+    $("save").disabled = true;
+    setStatus("Saving…");
+
+    try {
+      const contact = await createContact(settings, {
+        first_name,
+        // Absent, not empty — matching how the backend models a missing surname.
+        last_name: $("last_name").value.trim() || null,
+        email,
+        phone: $("phone").value.trim() || null,
+        title: $("title").value.trim() || null,
+        metadata: {
+          source: "extension",
+          captured_at: new Date().toISOString(),
+          page_url: extracted.url,
+          page_title: extracted.page_title,
+          company_name: $("company").value.trim() || null,
+        },
+      });
+
+      const note = $("note").value.trim();
+      if (note) {
+        // Best-effort: the contact is the thing that matters, and a failed note
+        // must not read as a failed capture.
+        await logNote(settings, {
+          body: note,
+          related_type: "person",
+          related_id: contact.id,
+        }).catch(() => {});
+      }
+
+      setStatus(`Saved as ${contact.id}`, "ok");
+      $("save").textContent = "Saved";
+    } catch (e) {
+      $("save").disabled = false;
+      setStatus(e.message, "err");
+    }
+  });
+}
+
+main().catch((e) => setStatus(e.message, "err"));


### PR DESCRIPTION
The CRM has been live on prod since July holding **one smoke-test record**, while **230 ad-leads** sat in `socials.Lead` at `status: "new"` since November — nobody has ever worked one. This connects the two and adds the surfaces that make it something you can open.

## What was found (probed on prod, not assumed)

- All five CRM entities answer 200 end-to-end (Medusa → proxy → CF tunnel → Autobase node). Contents: 1 person, 0 companies/opportunities/tasks/notes.
- 230 leads, all with email **and** phone, 230 distinct emails, 229 from one campaign, `person_id` null on all.
- `socials.Lead` was already the merged intake table — Meta leadgen webhook, FB webhook, the sync pull and the email job all write to it. It never had a way *out*. Its `external_id` / `external_system` / `synced_to_external_at` fields have sat unused since it was written; those are now the link.

### 🔥 The landmine

`first_name` and `last_name` are **null on all 230** leads — only `full_name`, and many are a single token with no surname ("SukhdevDhiman"). `crm_person` required both. A naive backfill would have written 230 contacts named `"" ""` **and passed**, because the contract's `required` check only rejects `undefined`, never `""`. `last_name` is now nullable and the mapper emits `null`.

Prod also stores three spellings for two platforms (`fb` 113, `ig` 116, `facebook` 1) — "leads by source" was wrong before anyone asked it.

## What this adds

**Lead → CRM bridge.** Pure mapper + a bulk maintenance job + a per-lead route, all sharing one planner. Idempotent on *two* independent keys (the lead's stamp and the `crm_person` email index) because either alone leaks. Contacts only, never opportunities — a nine-month-old form fill is not a deal, and seeding the board with 230 of them would make it lie on day one.

**Pipeline stages** — `prospecting → sampling → quoted → negotiation → won/lost`. `sampling` (a swatch physically went out) is the decisive stage in textiles and was invisible.

**Activity timeline + engagement state.** `crm_activity` is a Hyperbee contract like the other five — no Postgres, no migration, no DML model. Two axes kept deliberately separate: `stage` is where the *deal* is, `engagement_state` is where the *conversation* is (`not_contacted → awaiting_reply → in_conversation → follow_up_due → stalled`, plus `do_not_contact` and `closed`). The state is derived by a pure function and only ever written by the service — flows select on it, so a hand-settable value would decide who gets messaged.

**Flow integration.** `visual-flow-event-trigger` already routes events to flows by name or wildcard, so `crm-engagement-sweep` emits `crm.follow_up_due` / `crm.contact_stalled` / `crm.contact_replied` / `crm.contact_opted_out`. No new subscriber. Events fire **only on transition** — otherwise a contact sitting at `follow_up_due` re-triggers every morning.

**Admin** — `/crm/pipeline` (deal board), `/crm/intake` (unworked leads, one button each), and a timeline + three-field logger on the contact page.

**MCP** — 16 rows behind a new `crm` domain. The 8 writes are `tier: "write"` and stay `sensitive`; added to the locked allowlist deliberately.

**Chrome extension** (`apps/crm-extension`) — MV3, vanilla ES modules, no build step. `activeTab` + `scripting` only, so it can read no page until you click its button. Nothing is sent until you press Save.

## Bugs found while building this

1. 🔥 **`take: null` was silently truncating to 15 rows in prod.** It means "every row" to the embedded repository, but the proxy dropped it, the node then saw no `limit`, and the repository applied its default page. Same call: everything in dev, the oldest fifteen rows in prod, no error either way. Already live in the lead-import dedupe map. Now an explicit large limit — not `limit=0`, which an un-redeployed node reads as an empty page. Pinned by a regression test.
2. A **third** hand-maintained copy of the model→segment map left the proxy building `/crm/undefined`. Now inverted from the contract's one map.
3. `engagement_state` is **deliberately not indexed** — indexes are written at put-time and the package has no reindex, so indexing a field leaves every pre-existing row invisible to queries naming it, and `candidateKeys` prefers the index whenever a filter matches one.

Two registry invariants also caught real defects: a `queryParams` entry missing from its input schema (the #1348 shape), and the declared-domain-with-no-tools guard.

## ⚠️ Deploying this needs a CRM node redeploy

The node validates against its **own bundled copy** of the contract, and builds its repo map and URL segments from it at bundle time. `tsc`, the unit tests and `check:prod-build` are all blind to that. Probed against the live node:

| change | deployed node |
|---|---|
| `last_name: null` | **201** — widening needs no redeploy |
| `stage: "sampling"` | **422**, naming the old enum |
| a new collection | not a route it serves until rebuilt |

Recorded in `modules/crm/node/deploy/README.md`. Probe records were created and deleted; the store is back to its original single row.

## Verification

- 705 unit tests green across the affected suites (the 1 failure is the documented red `audit-ai-platforms` baseline, unrelated)
- 21 engagement-derivation units covering time-driven transitions and opt-out precedence; 19 mapper units; 6 proxy regression units; 21 new slice/vocabulary assertions
- `check:prod-build` passes; `tsc` unchanged against baseline
- Nothing has been run against prod data yet — the import job runs after deploy

🤖 Generated with [Claude Code](https://claude.com/claude-code)