### PR TITLE
feat(product-spec): partner-defined option groups, and a CRM contact screen you can read

### DIFF
--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -54,6 +54,11 @@ jobs:
       DATABASE_URL: postgresql://runner@localhost:5432/postgres
       POSTGRES_USER: runner
       POSTGRES_PASSWORD: runner
+      # The CRM is a Hyperbee node, not Postgres. Without this the module is
+      # not registered at all and the CRM screens render an empty state — which
+      # a spec would pass against. The embedded store is single-writer and
+      # dev-only, which is exactly what a single-worker e2e is.
+      CRM_HYPERBEE: "true"
 
     steps:
       - uses: actions/checkout@v4

--- a/apps/backend/src/admin/components/crm/activity-timeline.tsx
+++ b/apps/backend/src/admin/components/crm/activity-timeline.tsx
@@ -1,6 +1,8 @@
 import {
   Badge,
   Button,
+  Container,
+  Drawer,
   Heading,
   Select,
   Text,
@@ -21,12 +23,19 @@ import {
 import { sdk } from "../../lib/config";
 
 /**
- * The interaction timeline for one CRM record, plus the one-box logger.
+ * The interaction history for one CRM record.
  *
- * Logging is deliberately three fields — direction, channel, what happened —
- * because an activity form that asks for ten is a form nobody fills in, and an
- * unlogged conversation is worse than a roughly-logged one. Everything else
- * (summary, occurred_at, engagement recompute) is derived server-side.
+ * Split in two on purpose, which is how every CRM that people actually use is
+ * built: the timeline is a SECTION of the record — always visible, scannable,
+ * the thing you came to read — and logging happens in a DRAWER on top of it.
+ * The earlier shape put a three-field form above the history, so the first
+ * thing the page said was "type something" rather than "here is where this
+ * conversation got to", and the form ate the fold on every visit.
+ *
+ * Logging stays three fields — direction, channel, what happened — because an
+ * activity form that asks for ten is a form nobody fills in, and an unlogged
+ * conversation is worse than a roughly-logged one. Everything else (summary,
+ * occurred_at, engagement recompute) is derived server-side.
  */
 
 type CrmActivity = {
@@ -43,6 +52,8 @@ type CrmActivity = {
   occurred_at: string;
   outcome?: string | null;
 };
+
+export type CrmRelatedType = "person" | "company" | "opportunity";
 
 const DIRECTION_LABELS: Record<CrmActivityDirection, string> = {
   inbound: "They contacted us",
@@ -95,29 +106,27 @@ export const EngagementBadge = ({
   );
 };
 
-export const ActivityTimeline = ({
+/**
+ * The logger. A controlled drawer rather than a routed modal: this is a widget
+ * inside a page, and a routed modal opens on mount and navigates away on close
+ * — see `route-modal-context-usage` (#1352) for why that shape does not belong
+ * to a component the page renders itself.
+ */
+export const ActivityLogDrawer = ({
   relatedType,
   relatedId,
+  open,
+  onOpenChange,
 }: {
-  relatedType: "person" | "company" | "opportunity";
+  relatedType: CrmRelatedType;
   relatedId: string;
+  open: boolean;
+  onOpenChange: (open: boolean) => void;
 }) => {
   const queryClient = useQueryClient();
   const [direction, setDirection] = useState<CrmActivityDirection>("outbound");
   const [channel, setChannel] = useState<CrmActivityChannel>("whatsapp");
   const [body, setBody] = useState("");
-
-  const { data, isLoading } = useQuery({
-    queryKey: ["crm-activities", relatedType, relatedId],
-    queryFn: () =>
-      sdk.client.fetch<{ crm_activities: CrmActivity[] }>(
-        "/admin/crm/activities",
-        {
-          query: { related_type: relatedType, related_id: relatedId, limit: 100 },
-        }
-      ),
-    enabled: !!relatedId,
-  });
 
   const log = useMutation({
     mutationFn: () =>
@@ -142,72 +151,147 @@ export const ActivityTimeline = ({
       // The engagement state is recomputed server-side on every log, so the
       // contact header is stale the moment this succeeds.
       queryClient.invalidateQueries({ queryKey: ["crm-person"] });
+      onOpenChange(false);
     },
     onError: (e: any) => toast.error(e?.message ?? "Could not log that"),
+  });
+
+  return (
+    <Drawer open={open} onOpenChange={onOpenChange}>
+      <Drawer.Content>
+        <Drawer.Header>
+          <Drawer.Title>Log activity</Drawer.Title>
+          <Drawer.Description>
+            Every call, message and reply recorded here is what moves the
+            conversation state.
+          </Drawer.Description>
+        </Drawer.Header>
+        <Drawer.Body className="flex flex-col gap-y-4 overflow-y-auto">
+          <div className="flex flex-col gap-2">
+            <Text size="small" weight="plus">
+              What kind of contact was it?
+            </Text>
+            <Select
+              size="small"
+              value={direction}
+              onValueChange={(v) => setDirection(v as CrmActivityDirection)}
+            >
+              <Select.Trigger>
+                <Select.Value />
+              </Select.Trigger>
+              <Select.Content>
+                {(
+                  ["outbound", "inbound", "internal"] as CrmActivityDirection[]
+                ).map((d) => (
+                  <Select.Item key={d} value={d}>
+                    {DIRECTION_LABELS[d]}
+                  </Select.Item>
+                ))}
+              </Select.Content>
+            </Select>
+          </div>
+
+          {direction !== "internal" && (
+            <div className="flex flex-col gap-2">
+              <Text size="small" weight="plus">
+                Channel
+              </Text>
+              <Select
+                size="small"
+                value={channel}
+                onValueChange={(v) => setChannel(v as CrmActivityChannel)}
+              >
+                <Select.Trigger>
+                  <Select.Value />
+                </Select.Trigger>
+                <Select.Content>
+                  {CRM_ACTIVITY_CHANNELS.map((c) => (
+                    <Select.Item key={c} value={c}>
+                      {c.replace(/_/g, " ")}
+                    </Select.Item>
+                  ))}
+                </Select.Content>
+              </Select>
+            </div>
+          )}
+
+          <div className="flex flex-col gap-2">
+            <Text size="small" weight="plus">
+              What happened?
+            </Text>
+            <Textarea
+              placeholder="Called about the sampling order — asked for a photo of the border."
+              value={body}
+              onChange={(e) => setBody(e.target.value)}
+              rows={5}
+            />
+          </div>
+        </Drawer.Body>
+        <Drawer.Footer>
+          <Button
+            variant="secondary"
+            size="small"
+            onClick={() => onOpenChange(false)}
+          >
+            Cancel
+          </Button>
+          <Button
+            size="small"
+            disabled={!body.trim() || log.isPending}
+            isLoading={log.isPending}
+            onClick={() => log.mutate()}
+          >
+            Log activity
+          </Button>
+        </Drawer.Footer>
+      </Drawer.Content>
+    </Drawer>
+  );
+};
+
+/**
+ * The timeline as a section of the record — its own container, the way a CRM
+ * lays out a contact: details above, the conversation below.
+ */
+export const ActivitySection = ({
+  relatedType,
+  relatedId,
+}: {
+  relatedType: CrmRelatedType;
+  relatedId: string;
+}) => {
+  const [logging, setLogging] = useState(false);
+
+  const { data, isLoading } = useQuery({
+    queryKey: ["crm-activities", relatedType, relatedId],
+    queryFn: () =>
+      sdk.client.fetch<{ crm_activities: CrmActivity[] }>(
+        "/admin/crm/activities",
+        {
+          query: { related_type: relatedType, related_id: relatedId, limit: 100 },
+        }
+      ),
+    enabled: !!relatedId,
   });
 
   const activities = data?.crm_activities ?? [];
 
   return (
-    <div className="divide-y">
-      <div className="flex flex-col gap-2 px-6 py-4">
-        <Heading level="h3">Activity</Heading>
-
-        <div className="flex flex-col gap-2 md:flex-row">
-          <Select
-            size="small"
-            value={direction}
-            onValueChange={(v) => setDirection(v as CrmActivityDirection)}
-          >
-            <Select.Trigger className="md:w-56">
-              <Select.Value />
-            </Select.Trigger>
-            <Select.Content>
-              {(
-                ["outbound", "inbound", "internal"] as CrmActivityDirection[]
-              ).map((d) => (
-                <Select.Item key={d} value={d}>
-                  {DIRECTION_LABELS[d]}
-                </Select.Item>
-              ))}
-            </Select.Content>
-          </Select>
-
-          {direction !== "internal" && (
-            <Select
-              size="small"
-              value={channel}
-              onValueChange={(v) => setChannel(v as CrmActivityChannel)}
-            >
-              <Select.Trigger className="md:w-40">
-                <Select.Value />
-              </Select.Trigger>
-              <Select.Content>
-                {CRM_ACTIVITY_CHANNELS.map((c) => (
-                  <Select.Item key={c} value={c}>
-                    {c.replace(/_/g, " ")}
-                  </Select.Item>
-                ))}
-              </Select.Content>
-            </Select>
-          )}
+    <Container className="divide-y p-0">
+      <div className="flex items-center justify-between px-6 py-4">
+        <div className="flex flex-col">
+          <Heading level="h2">Activity</Heading>
+          <Text size="small" className="text-ui-fg-subtle">
+            {activities.length
+              ? `${activities.length} logged interaction${
+                  activities.length === 1 ? "" : "s"
+                }`
+              : "Nothing logged yet"}
+          </Text>
         </div>
-
-        <Textarea
-          placeholder="What happened?"
-          value={body}
-          onChange={(e) => setBody(e.target.value)}
-          rows={2}
-        />
-        <div>
-          <Button
-            size="small"
-            disabled={!body.trim() || log.isPending}
-            onClick={() => log.mutate()}
-          >
-            Log activity
-          </Button>
-        </div>
+        <Button size="small" variant="secondary" onClick={() => setLogging(true)}>
+          Log activity
+        </Button>
       </div>
 
       {isLoading && (
@@ -221,8 +305,8 @@ export const ActivityTimeline = ({
       {!isLoading && activities.length === 0 && (
         <div className="px-6 py-6">
           <Text size="small" className="text-ui-fg-muted">
-            Nothing logged yet. Every call, message and reply recorded here is
-            what moves the conversation state.
+            Every call, message and reply recorded here is what moves the
+            conversation state.
           </Text>
         </div>
       )}
@@ -246,6 +330,13 @@ export const ActivityTimeline = ({
           )}
         </div>
       ))}
-    </div>
+
+      <ActivityLogDrawer
+        relatedType={relatedType}
+        relatedId={relatedId}
+        open={logging}
+        onOpenChange={setLogging}
+      />
+    </Container>
   );
 };

--- a/apps/backend/src/admin/components/product-spec-form.tsx
+++ b/apps/backend/src/admin/components/product-spec-form.tsx
@@ -16,6 +16,8 @@ import { useMemo } from "react"
 import type {
   ProductSpecColor,
   ProductSpecField,
+  ProductSpecOption,
+  ProductSpecOptionValue,
   ProductSpecPayload,
   WeaveTechnique,
 } from "../hooks/api/product-spec"
@@ -54,6 +56,25 @@ const emptyColor = (order: number): ProductSpecColor => ({
   usage_notes: "",
   order,
   available: true,
+})
+
+const emptyOptionValue = (order: number): ProductSpecOptionValue => ({
+  label: "",
+  note: "",
+  order,
+  available: true,
+})
+
+const emptyOption = (order: number): ProductSpecOption => ({
+  key: "",
+  label: "",
+  help_text: "",
+  required: false,
+  order,
+  // A group is born with one empty value: the backend rejects a group with
+  // none, and starting at zero makes "add a choice" a step a partner can miss
+  // and then be told about only on save.
+  values: [emptyOptionValue(0)],
 })
 
 const emptyField = (order: number): ProductSpecField => ({
@@ -137,6 +158,22 @@ export const ProductSpecForm = ({
 
   const setField = (i: number, next: Partial<ProductSpecField>) =>
     patch({ fields: fields.map((f, j) => (i === j ? { ...f, ...next } : f)) })
+
+  const options = value.options ?? []
+
+  const setOption = (i: number, next: Partial<ProductSpecOption>) =>
+    patch({ options: options.map((o, j) => (i === j ? { ...o, ...next } : o)) })
+
+  const setOptionValue = (
+    i: number,
+    vi: number,
+    next: Partial<ProductSpecOptionValue>
+  ) =>
+    setOption(i, {
+      values: (options[i]?.values ?? []).map((v, j) =>
+        vi === j ? { ...v, ...next } : v
+      ),
+    })
 
   return (
     <div className="flex flex-col gap-y-8">
@@ -363,6 +400,167 @@ export const ProductSpecForm = ({
           >
             <Plus />
             Add colour
+          </Button>
+        </div>
+      </section>
+
+      {/* ── Options the customer chooses ───────────────────────────────── */}
+      <section className="flex flex-col gap-y-4">
+        <div>
+          <Heading level="h2">Choices you offer</Heading>
+          <Text size="small" className="text-ui-fg-subtle">
+            Things the customer picks when ordering this made to order —
+            embroidery, a border, a colour pattern. Use these instead of product
+            variants when the choice doesn't change what you keep in stock.
+          </Text>
+        </div>
+
+        {options.map((o, i) => (
+          <div
+            key={i}
+            className="flex flex-col gap-y-3 rounded-lg border border-ui-border-base p-3"
+          >
+            <div className="grid items-end gap-3 md:grid-cols-[1fr_auto]">
+              <div className="flex flex-col gap-y-2">
+                <Label size="small" weight="plus">
+                  What are they choosing?
+                </Label>
+                <Input
+                  placeholder="Embroidery"
+                  value={o.label ?? ""}
+                  onChange={(e) =>
+                    // Key derived from the label and normalised again
+                    // server-side, exactly as the custom fields do it.
+                    setOption(i, { label: e.target.value, key: e.target.value })
+                  }
+                />
+              </div>
+              <IconButton
+                type="button"
+                size="small"
+                variant="transparent"
+                aria-label={`Remove ${o.label || "choice"}`}
+                onClick={() =>
+                  patch({ options: options.filter((_, j) => j !== i) })
+                }
+              >
+                <Trash />
+              </IconButton>
+            </div>
+
+            <div className="flex flex-col gap-y-2">
+              <Label size="small" weight="plus">
+                Hint (optional)
+              </Label>
+              <Input
+                placeholder="Hand-worked — adds about two weeks"
+                value={o.help_text ?? ""}
+                onChange={(e) => setOption(i, { help_text: e.target.value })}
+              />
+            </div>
+
+            <div className="flex items-center gap-x-2">
+              <Checkbox
+                id={`spec-option-required-${i}`}
+                checked={!!o.required}
+                onCheckedChange={(checked) =>
+                  setOption(i, { required: !!checked })
+                }
+              />
+              <Label size="small" htmlFor={`spec-option-required-${i}`}>
+                They must choose one
+              </Label>
+            </div>
+
+            <div className="flex flex-col gap-y-2">
+              <Label size="small" weight="plus">
+                Choices
+              </Label>
+              {(o.values ?? []).map((v, vi) => (
+                <div
+                  key={vi}
+                  className="grid items-center gap-2 md:grid-cols-[1fr_1fr_auto_auto]"
+                >
+                  <Input
+                    placeholder="Kashida — cuff and pallu"
+                    value={v.label}
+                    onChange={(e) =>
+                      setOptionValue(i, vi, { label: e.target.value })
+                    }
+                  />
+                  <Input
+                    placeholder="Note (optional)"
+                    value={v.note ?? ""}
+                    onChange={(e) =>
+                      setOptionValue(i, vi, { note: e.target.value })
+                    }
+                  />
+                  <div className="flex items-center gap-x-2">
+                    {/* Off rather than deleted: a choice your embroiderer is
+                      *  booked out of comes back, and every order that already
+                      *  named it must keep resolving. */}
+                    <Switch
+                      id={`spec-option-value-available-${i}-${vi}`}
+                      checked={v.available !== false}
+                      onCheckedChange={(checked) =>
+                        setOptionValue(i, vi, { available: !!checked })
+                      }
+                    />
+                    <Label
+                      size="xsmall"
+                      htmlFor={`spec-option-value-available-${i}-${vi}`}
+                    >
+                      Available
+                    </Label>
+                  </div>
+                  <IconButton
+                    type="button"
+                    size="small"
+                    variant="transparent"
+                    aria-label={`Remove ${v.label || "choice"}`}
+                    onClick={() =>
+                      setOption(i, {
+                        values: (o.values ?? []).filter((_, j) => j !== vi),
+                      })
+                    }
+                  >
+                    <XMarkMini />
+                  </IconButton>
+                </div>
+              ))}
+              <div>
+                <Button
+                  type="button"
+                  size="small"
+                  variant="transparent"
+                  onClick={() =>
+                    setOption(i, {
+                      values: [
+                        ...(o.values ?? []),
+                        emptyOptionValue((o.values ?? []).length),
+                      ],
+                    })
+                  }
+                >
+                  <Plus />
+                  Add choice
+                </Button>
+              </div>
+            </div>
+          </div>
+        ))}
+
+        <div>
+          <Button
+            type="button"
+            size="small"
+            variant="secondary"
+            onClick={() =>
+              patch({ options: [...options, emptyOption(options.length)] })
+            }
+          >
+            <Plus />
+            Add something to choose
           </Button>
         </div>
       </section>

--- a/apps/backend/src/admin/hooks/api/product-spec.ts
+++ b/apps/backend/src/admin/hooks/api/product-spec.ts
@@ -57,6 +57,29 @@ export type ProductSpecField = {
   order?: number
 }
 
+export type ProductSpecOptionValue = {
+  id?: string
+  label: string
+  note?: string | null
+  order?: number
+  available?: boolean
+}
+
+/**
+ * A choice the CUSTOMER makes, as against `ProductSpecField` which is a fact the
+ * partner states. The partner names the axis, so "Embroidery", "Border" and
+ * "Color Pattern" are all this one shape.
+ */
+export type ProductSpecOption = {
+  id?: string
+  key: string
+  label?: string | null
+  help_text?: string | null
+  required?: boolean
+  order?: number
+  values: ProductSpecOptionValue[]
+}
+
 export type ProductSpec = {
   id?: string
   product_id?: string
@@ -69,9 +92,13 @@ export type ProductSpec = {
   custom_order_lead_time_days?: number | null
   colors?: ProductSpecColor[]
   fields?: ProductSpecField[]
+  options?: ProductSpecOption[]
 } | null
 
-/** The payload the upsert route accepts. `colors`/`fields` REPLACE when sent. */
+/**
+ * The payload the upsert route accepts. `colors`/`fields`/`options` REPLACE
+ * what is stored when sent, so omitting a key and sending `[]` differ.
+ */
 export type ProductSpecPayload = Omit<
   NonNullable<ProductSpec>,
   "id" | "product_id"

--- a/apps/backend/src/admin/routes/crm/[id]/loader.ts
+++ b/apps/backend/src/admin/routes/crm/[id]/loader.ts
@@ -1,0 +1,24 @@
+import { sdk } from "../../../lib/config";
+import { queryClient } from "../../../lib/query-client";
+
+/**
+ * Loaded before the route renders so the breadcrumb can say the contact's NAME
+ * rather than `per_01J…`. The breadcrumb reads `match.data`, which only exists
+ * if the route has a loader — an id-only crumb is what you get otherwise, and
+ * an id in a trail is not navigation, it is a receipt.
+ *
+ * Shares the `crm-person` query key with the page, so this is one request, not
+ * two: the component's `useQuery` reads the cache this warmed.
+ */
+const crmPersonDetailQuery = (id: string) => ({
+  queryKey: ["crm-person", id],
+  queryFn: async () =>
+    sdk.client.fetch<{ crm_person: any }>(`/admin/crm/people/${id}`, {
+      method: "GET",
+    }),
+});
+
+export const crmPersonLoader = async ({ params }: any) => {
+  const id = params.id;
+  return queryClient.ensureQueryData(crmPersonDetailQuery(id!));
+};

--- a/apps/backend/src/admin/routes/crm/[id]/page.tsx
+++ b/apps/backend/src/admin/routes/crm/[id]/page.tsx
@@ -1,14 +1,15 @@
-import { ArrowLeft, Spinner } from "@medusajs/icons";
-import { Container, Heading, Text, Badge, Button } from "@medusajs/ui";
+import { Spinner } from "@medusajs/icons";
+import { Container, Heading, Text, Badge } from "@medusajs/ui";
 import { useQuery } from "@tanstack/react-query";
 import type { ReactNode } from "react";
-import { Link, useParams } from "react-router-dom";
+import { UIMatch, useLoaderData, useParams } from "react-router-dom";
 
 import {
-  ActivityTimeline,
+  ActivitySection,
   EngagementBadge,
 } from "../../../components/crm/activity-timeline";
 import { sdk } from "../../../lib/config";
+import { crmPersonLoader } from "./loader";
 
 type CrmPerson = {
   id: string;
@@ -44,110 +45,127 @@ const val = (v?: string | null) =>
     </Text>
   );
 
+const displayName = (p?: Partial<CrmPerson> | null) =>
+  [p?.first_name, p?.last_name].filter(Boolean).join(" ").trim();
+
 const CrmPersonDetailPage = () => {
   const { id } = useParams();
+
+  const initialData = useLoaderData() as
+    | Awaited<ReturnType<typeof crmPersonLoader>>
+    | undefined;
 
   const { data, isLoading, isError } = useQuery({
     queryKey: ["crm-person", id],
     queryFn: () =>
       sdk.client.fetch<{ crm_person: CrmPerson }>(`/admin/crm/people/${id}`),
     enabled: !!id,
+    initialData,
   });
 
   const person = data?.crm_person;
-  const fullName = person
-    ? [person.first_name, person.last_name].filter(Boolean).join(" ")
-    : "";
 
   return (
-    <Container className="divide-y p-0">
-      <div className="flex items-center justify-between px-6 py-4">
-        <div className="flex flex-col">
-          <Heading>{isLoading ? "Loading…" : fullName || "Person"}</Heading>
-          {person?.title && (
-            <Text size="small" className="text-ui-fg-subtle">
-              {person.title}
-            </Text>
-          )}
-        </div>
-        <div className="flex items-center gap-4">
+    // Details and conversation as two stacked records, the way a CRM contact
+    // reads: who they are, then what has passed between us.
+    <div className="flex flex-col gap-y-2">
+      <Container className="divide-y p-0">
+        <div className="flex items-center justify-between px-6 py-4">
+          <div className="flex flex-col">
+            {/* No back button: the breadcrumb below the header is the way out,
+                and two competing ways back is how a trail stops being trusted. */}
+            <Heading>
+              {isLoading ? "Loading…" : displayName(person) || "Person"}
+            </Heading>
+            {person?.title && (
+              <Text size="small" className="text-ui-fg-subtle">
+                {person.title}
+              </Text>
+            )}
+          </div>
           {person && (
             <EngagementBadge
               state={person.engagement_state}
               nextFollowUpAt={person.next_follow_up_at}
             />
           )}
-          <Link to="/crm">
-            <Button variant="secondary" size="small">
-              <ArrowLeft />
-              Back
-            </Button>
-          </Link>
         </div>
-      </div>
 
-      {isLoading && (
-        <div className="flex items-center justify-center px-6 py-16">
-          <Spinner className="text-ui-fg-subtle animate-spin" />
-        </div>
-      )}
+        {isLoading && (
+          <div className="flex items-center justify-center px-6 py-16">
+            <Spinner className="text-ui-fg-subtle animate-spin" />
+          </div>
+        )}
 
-      {isError && (
-        <div className="px-6 py-16">
-          <Text size="small" className="text-ui-fg-error">
-            Could not load this person.
-          </Text>
-        </div>
-      )}
-
-      {person && (
-        <div className="divide-y">
-          <Row label="First name">{val(person.first_name)}</Row>
-          <Row label="Last name">{val(person.last_name)}</Row>
-          <Row label="Email">{val(person.email)}</Row>
-          <Row label="Phone">{val(person.phone)}</Row>
-          <Row label="Title">{val(person.title)}</Row>
-          <Row label="Company">
-            {person.company_id ? (
-              <Badge size="2xsmall">{person.company_id}</Badge>
-            ) : (
-              val(null)
-            )}
-          </Row>
-          <Row label="ID">
-            <Text size="small" className="font-mono text-ui-fg-subtle">
-              {person.id}
+        {isError && (
+          <div className="px-6 py-16">
+            <Text size="small" className="text-ui-fg-error">
+              Could not load this person.
             </Text>
-          </Row>
-          <Row label="Last reply from them">
-            {val(
-              person.last_inbound_at
-                ? new Date(person.last_inbound_at).toLocaleString()
-                : null
-            )}
-          </Row>
-          <Row label="Last time we reached out">
-            {val(
-              person.last_outbound_at
-                ? new Date(person.last_outbound_at).toLocaleString()
-                : null
-            )}
-          </Row>
-          <Row label="Created">
-            {val(
-              person.created_at
-                ? new Date(person.created_at).toLocaleString()
-                : null
-            )}
-          </Row>
-        </div>
-      )}
+          </div>
+        )}
 
-      {person && (
-        <ActivityTimeline relatedType="person" relatedId={person.id} />
-      )}
-    </Container>
+        {person && (
+          <div className="divide-y">
+            <Row label="First name">{val(person.first_name)}</Row>
+            <Row label="Last name">{val(person.last_name)}</Row>
+            <Row label="Email">{val(person.email)}</Row>
+            <Row label="Phone">{val(person.phone)}</Row>
+            <Row label="Title">{val(person.title)}</Row>
+            <Row label="Company">
+              {person.company_id ? (
+                <Badge size="2xsmall">{person.company_id}</Badge>
+              ) : (
+                val(null)
+              )}
+            </Row>
+            <Row label="ID">
+              <Text size="small" className="font-mono text-ui-fg-subtle">
+                {person.id}
+              </Text>
+            </Row>
+            <Row label="Last reply from them">
+              {val(
+                person.last_inbound_at
+                  ? new Date(person.last_inbound_at).toLocaleString()
+                  : null
+              )}
+            </Row>
+            <Row label="Last time we reached out">
+              {val(
+                person.last_outbound_at
+                  ? new Date(person.last_outbound_at).toLocaleString()
+                  : null
+              )}
+            </Row>
+            <Row label="Created">
+              {val(
+                person.created_at
+                  ? new Date(person.created_at).toLocaleString()
+                  : null
+              )}
+            </Row>
+          </div>
+        )}
+      </Container>
+
+      {person && <ActivitySection relatedType="person" relatedId={person.id} />}
+    </div>
   );
 };
 
 export default CrmPersonDetailPage;
+
+export async function loader({ params }: any) {
+  return crmPersonLoader({ params });
+}
+
+export const handle = {
+  // `match.data` is the loader's payload. Falling back to the id keeps the
+  // crumb honest when the load failed rather than printing "Contact" over a
+  // record that is not there.
+  breadcrumb: (match: UIMatch<{ id: string }>) => {
+    const data = match.data as { crm_person?: Partial<CrmPerson> } | undefined;
+    return displayName(data?.crm_person) || match.params.id;
+  },
+};

--- a/apps/backend/src/admin/routes/crm/leads/page.tsx
+++ b/apps/backend/src/admin/routes/crm/leads/page.tsx
@@ -216,3 +216,7 @@ export const config = defineRouteConfig({
 });
 
 export default CrmLeadsPage;
+
+export const handle = {
+  breadcrumb: () => "Intake",
+};

--- a/apps/backend/src/admin/routes/crm/pipeline/page.tsx
+++ b/apps/backend/src/admin/routes/crm/pipeline/page.tsx
@@ -256,3 +256,8 @@ export const config = defineRouteConfig({
 });
 
 export default CrmPipelinePage;
+
+export const handle = {
+  // Without this the crumb reads the raw path segment ("pipeline").
+  breadcrumb: () => "Pipeline",
+};

--- a/apps/backend/src/api/partners/products/validators.ts
+++ b/apps/backend/src/api/partners/products/validators.ts
@@ -66,6 +66,38 @@ export const PartnerProductSpecFieldReq = z
   })
   .strict()
 
+/**
+ * A partner-defined selectable option group and its values.
+ *
+ * The partner names the axis, so this schema deliberately constrains nothing
+ * about WHAT the choice is — "Embroidery", "Border", "Pallu finish" are all the
+ * same shape. What it does constrain is size: an option group with 200 values
+ * is not a choice, it is a search box, and a made-to-order page that renders
+ * one has stopped being usable.
+ */
+export const PartnerProductSpecOptionValueReq = z
+  .object({
+    label: z.string().trim().min(1).max(160),
+    note: z.string().trim().max(500).nullable().optional(),
+    order: z.number().int().min(0).max(999).optional(),
+    available: z.boolean().optional(),
+  })
+  .strict()
+
+export const PartnerProductSpecOptionReq = z
+  .object({
+    key: z.string().trim().min(1).max(60),
+    label: z.string().trim().max(120).nullable().optional(),
+    help_text: z.string().trim().max(500).nullable().optional(),
+    required: z.boolean().optional(),
+    order: z.number().int().min(0).max(999).optional(),
+    // A group with no values is not "no choice offered", it is a broken choice
+    // the customer cannot satisfy — and if it is `required` too, the product
+    // becomes unorderable. Rejected at the door rather than at add-to-cart.
+    values: z.array(PartnerProductSpecOptionValueReq).min(1).max(40),
+  })
+  .strict()
+
 export const PartnerProductSpecReq = z
   .object({
     weave_technique: z.string().trim().max(60).nullable().optional(),
@@ -85,6 +117,8 @@ export const PartnerProductSpecReq = z
       .optional(),
     colors: z.array(PartnerProductSpecColorReq).max(60).optional(),
     fields: z.array(PartnerProductSpecFieldReq).max(40).optional(),
+    // Replaces wholesale when present, exactly like colors/fields.
+    options: z.array(PartnerProductSpecOptionReq).max(12).optional(),
   })
   .strict()
 

--- a/apps/backend/src/api/store/carts/[id]/made-to-spec/lib.ts
+++ b/apps/backend/src/api/store/carts/[id]/made-to-spec/lib.ts
@@ -37,6 +37,24 @@ export type SpecField = {
   value?: string | null
 }
 
+export type SpecOptionValue = {
+  id?: string
+  label: string
+  note?: string | null
+  available?: boolean
+  order?: number
+}
+
+export type SpecOption = {
+  id?: string
+  key: string
+  label?: string | null
+  help_text?: string | null
+  required?: boolean
+  order?: number
+  values?: SpecOptionValue[]
+}
+
 export type ProductSpecRecord = {
   id?: string
   weave_technique?: string | null
@@ -47,6 +65,7 @@ export type ProductSpecRecord = {
   custom_order_lead_time_days?: number | null
   colors?: SpecColor[]
   fields?: SpecField[]
+  options?: SpecOption[]
 } | null
 
 export type MadeToSpecSelection = {
@@ -54,6 +73,14 @@ export type MadeToSpecSelection = {
   color?: string | null
   /** Free text from the customer — a monogram, a length, an occasion date. */
   note?: string | null
+  /**
+   * The partner-defined choices, keyed by the option's `key` and valued by the
+   * chosen value's LABEL — which is what the customer saw and what the read
+   * route published. Keyed by id instead would be tidier to validate and worse
+   * to debug: an order line reading `psov_01J…` tells a support conversation
+   * nothing.
+   */
+  options?: Record<string, string> | null
 }
 
 /** What ends up on the line item, and later on the order. */
@@ -67,10 +94,116 @@ export type MadeToSpecSnapshot = {
   note?: string | null
   /** The spec's own fields at time of order — what the piece is made to. */
   spec_fields?: { label: string; value: string }[]
+  /**
+   * What the customer CHOSE, as against `spec_fields` which is what the partner
+   * stated. Copied label-and-all for the same reason the colour is: the partner
+   * may rename "Kashida — cuff only" next month, and the order must still read
+   * the way it was agreed.
+   */
+  options?: { key: string; label: string; value: string; note?: string | null }[]
   captured_at: string
 }
 
 const normalize = (value: string) => value.trim().toLowerCase()
+
+/**
+ * Resolve the partner-defined option groups against what the customer picked.
+ *
+ * The rule is the palette's rule, applied to an axis the partner named: a value
+ * counts only if the partner listed it AND left it available. Two cases are
+ * worth stating because they are the ones a storefront gets wrong:
+ *
+ * - A group whose values are ALL unavailable is not silently skipped when it is
+ *   `required`. Skipping would let the piece be ordered without an axis it
+ *   cannot be made without, and the partner would find out at the loom. It is
+ *   rejected loudly instead; an optional group in that state is simply not
+ *   offered.
+ * - An unknown key is rejected rather than ignored. A storefront sending
+ *   `embroidery` at a spec that has since dropped the group is stale, and
+ *   dropping the value quietly would record an order the customer did not place.
+ */
+const resolveOptionSelections = (
+  specOptions: SpecOption[],
+  selected: Record<string, string> | null | undefined
+): MadeToSpecSnapshot["options"] => {
+  const groups = (specOptions ?? [])
+    .slice()
+    .sort((a, b) => (a.order ?? 0) - (b.order ?? 0))
+
+  const byKey = new Map(groups.map((o) => [normalize(o.key), o]))
+
+  for (const key of Object.keys(selected ?? {})) {
+    if (!byKey.has(normalize(key))) {
+      throw new MedusaError(
+        MedusaError.Types.INVALID_DATA,
+        groups.length
+          ? `"${key}" is not an option on this product. Options: ${groups
+              .map((o) => o.key)
+              .join(", ")}.`
+          : `"${key}" is not an option on this product.`
+      )
+    }
+  }
+
+  const chosen: NonNullable<MadeToSpecSnapshot["options"]> = []
+
+  for (const group of groups) {
+    const label = (group.label ?? group.key).trim()
+    const available = (group.values ?? [])
+      .filter((v) => v.available !== false)
+      .slice()
+      .sort((a, b) => (a.order ?? 0) - (b.order ?? 0))
+
+    const raw = (selected ?? {})[group.key] ?? (selected ?? {})[normalize(group.key)]
+    const requested = typeof raw === "string" ? raw.trim() : ""
+
+    if (!available.length) {
+      if (group.required) {
+        throw new MedusaError(
+          MedusaError.Types.NOT_ALLOWED,
+          `${label} is required for this piece, but none of its choices are available right now.`
+        )
+      }
+      // Optional and nothing to offer — not a choice at all this week.
+      if (requested) {
+        throw new MedusaError(
+          MedusaError.Types.INVALID_DATA,
+          `${label} has no choices available right now.`
+        )
+      }
+      continue
+    }
+
+    if (!requested) {
+      if (group.required) {
+        throw new MedusaError(
+          MedusaError.Types.INVALID_DATA,
+          `Choose ${label}. Available: ${available.map((v) => v.label).join(", ")}.`
+        )
+      }
+      continue
+    }
+
+    const match = available.find((v) => normalize(v.label) === normalize(requested))
+    if (!match) {
+      throw new MedusaError(
+        MedusaError.Types.INVALID_DATA,
+        `"${requested}" is not available for ${label}. Available: ${available
+          .map((v) => v.label)
+          .join(", ")}.`
+      )
+    }
+
+    chosen.push({
+      key: group.key,
+      label,
+      value: match.label,
+      ...(match.note ? { note: match.note } : {}),
+    })
+  }
+
+  return chosen
+}
 
 /**
  * Build the snapshot, or throw a MedusaError the store route surfaces as a 4xx.
@@ -135,6 +268,8 @@ export const buildMadeToSpecSnapshot = ({
     )
   }
 
+  const chosenOptions = resolveOptionSelections(spec.options ?? [], selection.options)
+
   const specFields = (spec.fields ?? [])
     .filter((f) => (f.value ?? "").trim())
     .map((f) => ({
@@ -151,6 +286,7 @@ export const buildMadeToSpecSnapshot = ({
     lead_time_days: spec.custom_order_lead_time_days ?? null,
     note: note || null,
     ...(specFields.length ? { spec_fields: specFields } : {}),
+    ...(chosenOptions?.length ? { options: chosenOptions } : {}),
     captured_at: now.toISOString(),
   }
 }

--- a/apps/backend/src/api/store/carts/[id]/made-to-spec/route.ts
+++ b/apps/backend/src/api/store/carts/[id]/made-to-spec/route.ts
@@ -67,7 +67,7 @@ export const POST = async (req: MedusaRequest<Body>, res: MedusaResponse) => {
   try {
     snapshot = buildMadeToSpecSnapshot({
       spec,
-      selection: { color: body.color, note: body.note },
+      selection: { color: body.color, note: body.note, options: body.options },
       now: new Date(),
     })
   } catch (e: any) {

--- a/apps/backend/src/api/store/carts/[id]/made-to-spec/validators.ts
+++ b/apps/backend/src/api/store/carts/[id]/made-to-spec/validators.ts
@@ -13,6 +13,11 @@ export const StoreMadeToSpecReq = z.object({
   quantity: z.number().int().positive().max(100).optional(),
   color: z.string().min(1).max(200).nullish(),
   note: z.string().max(500).nullish(),
+  // Keyed by the option's `key`, valued by the chosen value's label — both as
+  // published by GET /store/products/:id/spec. WHICH values are orderable is
+  // decided in `lib.ts` against the stored option groups, for the same reason
+  // the palette is: zod cannot see the database.
+  options: z.record(z.string().min(1).max(60), z.string().min(1).max(160)).nullish(),
 })
 
 export type StoreMadeToSpecReqType = z.infer<typeof StoreMadeToSpecReq>

--- a/apps/backend/src/api/store/carts/__tests__/made-to-spec.unit.spec.ts
+++ b/apps/backend/src/api/store/carts/__tests__/made-to-spec.unit.spec.ts
@@ -184,3 +184,176 @@ describe("made-to-spec selection", () => {
     expect(MADE_TO_SPEC_METADATA_KEY).toBe("made_to_spec")
   })
 })
+
+/**
+ * Partner-defined option groups — the axis a spec grew when "Color Pattern"
+ * came off the variant matrix and "Embroidery" had nowhere to live.
+ *
+ * Same two rules as the palette, one level more general: the set is closed, and
+ * what the customer picked is COPIED onto the line item. The cases below are
+ * the ones a storefront gets wrong on its own.
+ */
+const withOptions = (over: Partial<NonNullable<ProductSpecRecord>> = {}) =>
+  spec({
+    colors: [],
+    options: [
+      {
+        key: "color_pattern",
+        label: "Color Pattern",
+        required: true,
+        order: 0,
+        values: [
+          { label: "Pattern 1 - Blue/Mustard/Cream/Grey", order: 0 },
+          { label: "Pattern 2 - Mustard/Dusty Blue/Grey", order: 1 },
+          { label: "Pattern 3 - Blue/Yellow/Grey/Cream", order: 2, available: false },
+        ],
+      },
+      {
+        key: "embroidery",
+        label: "Embroidery",
+        required: false,
+        order: 1,
+        values: [
+          { label: "None", order: 0 },
+          { label: "Kashida — cuff and pallu", note: "adds about two weeks", order: 1 },
+        ],
+      },
+    ],
+    ...over,
+  })
+
+describe("made-to-spec option groups", () => {
+  it("records the chosen value, its group label and its note", () => {
+    const snapshot = buildMadeToSpecSnapshot({
+      spec: withOptions(),
+      selection: {
+        options: {
+          color_pattern: "Pattern 1 - Blue/Mustard/Cream/Grey",
+          embroidery: "Kashida — cuff and pallu",
+        },
+      },
+      now: NOW,
+    })
+
+    expect(snapshot.options).toEqual([
+      {
+        key: "color_pattern",
+        label: "Color Pattern",
+        value: "Pattern 1 - Blue/Mustard/Cream/Grey",
+      },
+      {
+        key: "embroidery",
+        label: "Embroidery",
+        value: "Kashida — cuff and pallu",
+        note: "adds about two weeks",
+      },
+    ])
+  })
+
+  it("rejects a value the partner switched off, naming what IS available", () => {
+    expect(() =>
+      buildMadeToSpecSnapshot({
+        spec: withOptions(),
+        selection: {
+          options: { color_pattern: "Pattern 3 - Blue/Yellow/Grey/Cream" },
+        },
+        now: NOW,
+      })
+    ).toThrow(/not available for Color Pattern.*Pattern 1.*Pattern 2/s)
+  })
+
+  it("rejects an unknown option key rather than ignoring it", () => {
+    // A stale storefront sending a group the partner has dropped must not have
+    // its choice silently discarded — that records an order nobody placed.
+    expect(() =>
+      buildMadeToSpecSnapshot({
+        spec: withOptions(),
+        selection: {
+          options: {
+            color_pattern: "Pattern 1 - Blue/Mustard/Cream/Grey",
+            tassel: "Knotted",
+          },
+        },
+        now: NOW,
+      })
+    ).toThrow(/"tassel" is not an option/)
+  })
+
+  it("requires a required group and names the choices", () => {
+    expect(() =>
+      buildMadeToSpecSnapshot({
+        spec: withOptions(),
+        selection: { options: { embroidery: "None" } },
+        now: NOW,
+      })
+    ).toThrow(/Choose Color Pattern.*Pattern 1.*Pattern 2/s)
+  })
+
+  it("leaves an optional group out when it was not chosen", () => {
+    const snapshot = buildMadeToSpecSnapshot({
+      spec: withOptions(),
+      selection: {
+        options: { color_pattern: "Pattern 2 - Mustard/Dusty Blue/Grey" },
+      },
+      now: NOW,
+    })
+
+    expect(snapshot.options).toHaveLength(1)
+    expect(snapshot.options?.[0].key).toBe("color_pattern")
+  })
+
+  it("refuses the order when a REQUIRED group has nothing available", () => {
+    // The dangerous alternative is skipping it: the piece would be ordered
+    // without an axis it cannot be woven without, and the partner would find
+    // out at the loom.
+    const dead = withOptions({
+      options: [
+        {
+          key: "color_pattern",
+          label: "Color Pattern",
+          required: true,
+          values: [{ label: "Pattern 1", available: false }],
+        },
+      ],
+    })
+
+    expect(() =>
+      buildMadeToSpecSnapshot({ spec: dead, selection: {}, now: NOW })
+    ).toThrow(/Color Pattern is required.*none of its choices are available/s)
+  })
+
+  it("skips an OPTIONAL group that has nothing available", () => {
+    const quiet = withOptions({
+      options: [
+        {
+          key: "embroidery",
+          label: "Embroidery",
+          required: false,
+          values: [{ label: "Kashida", available: false }],
+        },
+      ],
+    })
+
+    const snapshot = buildMadeToSpecSnapshot({
+      spec: quiet,
+      selection: {},
+      now: NOW,
+    })
+
+    expect(snapshot.options).toBeUndefined()
+  })
+
+  it("matches the value case-insensitively but stores the partner's casing", () => {
+    const snapshot = buildMadeToSpecSnapshot({
+      spec: withOptions(),
+      selection: {
+        options: { color_pattern: "pattern 1 - blue/mustard/cream/grey" },
+      },
+      now: NOW,
+    })
+
+    expect(snapshot.options?.[0].value).toBe(
+      "Pattern 1 - Blue/Mustard/Cream/Grey"
+    )
+  })
+})

--- a/apps/backend/src/api/store/products/[id]/spec/route.ts
+++ b/apps/backend/src/api/store/products/[id]/spec/route.ts
@@ -70,6 +70,32 @@ export const GET = async (req: MedusaRequest, res: MedusaResponse) => {
     .slice()
     .sort((a: any, b: any) => (a.order ?? 0) - (b.order ?? 0))
 
+  // Partner-defined choices. Unavailable VALUES are dropped for the same reason
+  // unavailable colours are — every storefront should agree on what is
+  // orderable — but a group is published even when `required` and empty, rather
+  // than hidden. Hiding it would render a page that looks orderable and a cart
+  // route that refuses, and the customer would never learn which is right.
+  const options = (spec.options ?? [])
+    .slice()
+    .sort((a: any, b: any) => (a.order ?? 0) - (b.order ?? 0))
+    .map((o: any) => ({
+      id: o.id,
+      key: o.key,
+      label: o.label ?? o.key,
+      help_text: o.help_text ?? null,
+      required: !!o.required,
+      values: (o.values ?? [])
+        .filter((v: any) => v.available !== false)
+        .slice()
+        .sort((a: any, b: any) => (a.order ?? 0) - (b.order ?? 0))
+        .map((v: any) => ({
+          id: v.id,
+          label: v.label,
+          note: v.note ?? null,
+        })),
+    }))
+    .filter((o: any) => o.required || o.values.length)
+
   return res.json({
     spec: {
       id: spec.id,
@@ -81,6 +107,7 @@ export const GET = async (req: MedusaRequest, res: MedusaResponse) => {
       custom_order_lead_time_days: spec.custom_order_lead_time_days ?? null,
       colors,
       fields,
+      options,
       // `notes` is deliberately NOT returned: it is written as "notes for the
       // workshop" in the partner editor, and workshop notes are not customer
       // copy. Publishing them would change what partners feel able to write.

--- a/apps/backend/src/modules/product-spec/migrations/.snapshot-product-spec.json
+++ b/apps/backend/src/modules/product-spec/migrations/.snapshot-product-spec.json
@@ -642,6 +642,414 @@
         }
       },
       "nativeEnums": {}
+    },
+    {
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "unsigned": false,
+          "autoincrement": false,
+          "primary": true,
+          "nullable": false,
+          "unique": false,
+          "length": null,
+          "precision": null,
+          "scale": null,
+          "default": null,
+          "comment": null,
+          "enumItems": [],
+          "mappedType": "text"
+        },
+        "key": {
+          "name": "key",
+          "type": "text",
+          "unsigned": false,
+          "autoincrement": false,
+          "primary": false,
+          "nullable": false,
+          "unique": false,
+          "length": null,
+          "precision": null,
+          "scale": null,
+          "default": null,
+          "comment": null,
+          "enumItems": [],
+          "mappedType": "text"
+        },
+        "label": {
+          "name": "label",
+          "type": "text",
+          "unsigned": false,
+          "autoincrement": false,
+          "primary": false,
+          "nullable": true,
+          "unique": false,
+          "length": null,
+          "precision": null,
+          "scale": null,
+          "default": null,
+          "comment": null,
+          "enumItems": [],
+          "mappedType": "text"
+        },
+        "help_text": {
+          "name": "help_text",
+          "type": "text",
+          "unsigned": false,
+          "autoincrement": false,
+          "primary": false,
+          "nullable": true,
+          "unique": false,
+          "length": null,
+          "precision": null,
+          "scale": null,
+          "default": null,
+          "comment": null,
+          "enumItems": [],
+          "mappedType": "text"
+        },
+        "required": {
+          "name": "required",
+          "type": "boolean",
+          "unsigned": false,
+          "autoincrement": false,
+          "primary": false,
+          "nullable": false,
+          "unique": false,
+          "length": null,
+          "precision": null,
+          "scale": null,
+          "default": "false",
+          "comment": null,
+          "enumItems": [],
+          "mappedType": "boolean"
+        },
+        "order": {
+          "name": "order",
+          "type": "integer",
+          "unsigned": false,
+          "autoincrement": false,
+          "primary": false,
+          "nullable": false,
+          "unique": false,
+          "length": null,
+          "precision": null,
+          "scale": null,
+          "default": "0",
+          "comment": null,
+          "enumItems": [],
+          "mappedType": "integer"
+        },
+        "spec_id": {
+          "name": "spec_id",
+          "type": "text",
+          "unsigned": false,
+          "autoincrement": false,
+          "primary": false,
+          "nullable": false,
+          "unique": false,
+          "length": null,
+          "precision": null,
+          "scale": null,
+          "default": null,
+          "comment": null,
+          "enumItems": [],
+          "mappedType": "text"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamptz",
+          "unsigned": false,
+          "autoincrement": false,
+          "primary": false,
+          "nullable": false,
+          "unique": false,
+          "length": 6,
+          "precision": null,
+          "scale": null,
+          "default": "now()",
+          "comment": null,
+          "enumItems": [],
+          "mappedType": "datetime"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamptz",
+          "unsigned": false,
+          "autoincrement": false,
+          "primary": false,
+          "nullable": false,
+          "unique": false,
+          "length": 6,
+          "precision": null,
+          "scale": null,
+          "default": "now()",
+          "comment": null,
+          "enumItems": [],
+          "mappedType": "datetime"
+        },
+        "deleted_at": {
+          "name": "deleted_at",
+          "type": "timestamptz",
+          "unsigned": false,
+          "autoincrement": false,
+          "primary": false,
+          "nullable": true,
+          "unique": false,
+          "length": 6,
+          "precision": null,
+          "scale": null,
+          "default": null,
+          "comment": null,
+          "enumItems": [],
+          "mappedType": "datetime"
+        }
+      },
+      "name": "product_spec_option",
+      "schema": "public",
+      "indexes": [
+        {
+          "keyName": "IDX_product_spec_option_spec_id",
+          "columnNames": [],
+          "composite": false,
+          "constraint": false,
+          "primary": false,
+          "unique": false,
+          "expression": "CREATE INDEX IF NOT EXISTS \"IDX_product_spec_option_spec_id\" ON \"product_spec_option\" (\"spec_id\") WHERE deleted_at IS NULL"
+        },
+        {
+          "keyName": "IDX_product_spec_option_deleted_at",
+          "columnNames": [],
+          "composite": false,
+          "constraint": false,
+          "primary": false,
+          "unique": false,
+          "expression": "CREATE INDEX IF NOT EXISTS \"IDX_product_spec_option_deleted_at\" ON \"product_spec_option\" (\"deleted_at\") WHERE deleted_at IS NULL"
+        },
+        {
+          "keyName": "product_spec_option_pkey",
+          "columnNames": [
+            "id"
+          ],
+          "composite": false,
+          "constraint": true,
+          "primary": true,
+          "unique": true
+        }
+      ],
+      "checks": [],
+      "foreignKeys": {
+        "product_spec_option_spec_id_foreign": {
+          "constraintName": "product_spec_option_spec_id_foreign",
+          "columnNames": [
+            "spec_id"
+          ],
+          "localTableName": "public.product_spec_option",
+          "referencedColumnNames": [
+            "id"
+          ],
+          "referencedTableName": "public.product_spec",
+          "updateRule": "cascade"
+        }
+      },
+      "nativeEnums": {}
+    },
+    {
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "unsigned": false,
+          "autoincrement": false,
+          "primary": true,
+          "nullable": false,
+          "unique": false,
+          "length": null,
+          "precision": null,
+          "scale": null,
+          "default": null,
+          "comment": null,
+          "enumItems": [],
+          "mappedType": "text"
+        },
+        "label": {
+          "name": "label",
+          "type": "text",
+          "unsigned": false,
+          "autoincrement": false,
+          "primary": false,
+          "nullable": false,
+          "unique": false,
+          "length": null,
+          "precision": null,
+          "scale": null,
+          "default": null,
+          "comment": null,
+          "enumItems": [],
+          "mappedType": "text"
+        },
+        "note": {
+          "name": "note",
+          "type": "text",
+          "unsigned": false,
+          "autoincrement": false,
+          "primary": false,
+          "nullable": true,
+          "unique": false,
+          "length": null,
+          "precision": null,
+          "scale": null,
+          "default": null,
+          "comment": null,
+          "enumItems": [],
+          "mappedType": "text"
+        },
+        "order": {
+          "name": "order",
+          "type": "integer",
+          "unsigned": false,
+          "autoincrement": false,
+          "primary": false,
+          "nullable": false,
+          "unique": false,
+          "length": null,
+          "precision": null,
+          "scale": null,
+          "default": "0",
+          "comment": null,
+          "enumItems": [],
+          "mappedType": "integer"
+        },
+        "available": {
+          "name": "available",
+          "type": "boolean",
+          "unsigned": false,
+          "autoincrement": false,
+          "primary": false,
+          "nullable": false,
+          "unique": false,
+          "length": null,
+          "precision": null,
+          "scale": null,
+          "default": "true",
+          "comment": null,
+          "enumItems": [],
+          "mappedType": "boolean"
+        },
+        "option_id": {
+          "name": "option_id",
+          "type": "text",
+          "unsigned": false,
+          "autoincrement": false,
+          "primary": false,
+          "nullable": false,
+          "unique": false,
+          "length": null,
+          "precision": null,
+          "scale": null,
+          "default": null,
+          "comment": null,
+          "enumItems": [],
+          "mappedType": "text"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamptz",
+          "unsigned": false,
+          "autoincrement": false,
+          "primary": false,
+          "nullable": false,
+          "unique": false,
+          "length": 6,
+          "precision": null,
+          "scale": null,
+          "default": "now()",
+          "comment": null,
+          "enumItems": [],
+          "mappedType": "datetime"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamptz",
+          "unsigned": false,
+          "autoincrement": false,
+          "primary": false,
+          "nullable": false,
+          "unique": false,
+          "length": 6,
+          "precision": null,
+          "scale": null,
+          "default": "now()",
+          "comment": null,
+          "enumItems": [],
+          "mappedType": "datetime"
+        },
+        "deleted_at": {
+          "name": "deleted_at",
+          "type": "timestamptz",
+          "unsigned": false,
+          "autoincrement": false,
+          "primary": false,
+          "nullable": true,
+          "unique": false,
+          "length": 6,
+          "precision": null,
+          "scale": null,
+          "default": null,
+          "comment": null,
+          "enumItems": [],
+          "mappedType": "datetime"
+        }
+      },
+      "name": "product_spec_option_value",
+      "schema": "public",
+      "indexes": [
+        {
+          "keyName": "IDX_product_spec_option_value_option_id",
+          "columnNames": [],
+          "composite": false,
+          "constraint": false,
+          "primary": false,
+          "unique": false,
+          "expression": "CREATE INDEX IF NOT EXISTS \"IDX_product_spec_option_value_option_id\" ON \"product_spec_option_value\" (\"option_id\") WHERE deleted_at IS NULL"
+        },
+        {
+          "keyName": "IDX_product_spec_option_value_deleted_at",
+          "columnNames": [],
+          "composite": false,
+          "constraint": false,
+          "primary": false,
+          "unique": false,
+          "expression": "CREATE INDEX IF NOT EXISTS \"IDX_product_spec_option_value_deleted_at\" ON \"product_spec_option_value\" (\"deleted_at\") WHERE deleted_at IS NULL"
+        },
+        {
+          "keyName": "product_spec_option_value_pkey",
+          "columnNames": [
+            "id"
+          ],
+          "composite": false,
+          "constraint": true,
+          "primary": true,
+          "unique": true
+        }
+      ],
+      "checks": [],
+      "foreignKeys": {
+        "product_spec_option_value_option_id_foreign": {
+          "constraintName": "product_spec_option_value_option_id_foreign",
+          "columnNames": [
+            "option_id"
+          ],
+          "localTableName": "public.product_spec_option_value",
+          "referencedColumnNames": [
+            "id"
+          ],
+          "referencedTableName": "public.product_spec_option",
+          "updateRule": "cascade"
+        }
+      },
+      "nativeEnums": {}
     }
   ],
   "nativeEnums": {}

--- a/apps/backend/src/modules/product-spec/migrations/Migration20260819044713.ts
+++ b/apps/backend/src/modules/product-spec/migrations/Migration20260819044713.ts
@@ -1,0 +1,27 @@
+import { Migration } from "@medusajs/framework/mikro-orm/migrations";
+
+export class Migration20260819044713 extends Migration {
+
+  override async up(): Promise<void> {
+    this.addSql(`create table if not exists "product_spec_option" ("id" text not null, "key" text not null, "label" text null, "help_text" text null, "required" boolean not null default false, "order" integer not null default 0, "spec_id" text not null, "created_at" timestamptz not null default now(), "updated_at" timestamptz not null default now(), "deleted_at" timestamptz null, constraint "product_spec_option_pkey" primary key ("id"));`);
+    this.addSql(`CREATE INDEX IF NOT EXISTS "IDX_product_spec_option_spec_id" ON "product_spec_option" ("spec_id") WHERE deleted_at IS NULL;`);
+    this.addSql(`CREATE INDEX IF NOT EXISTS "IDX_product_spec_option_deleted_at" ON "product_spec_option" ("deleted_at") WHERE deleted_at IS NULL;`);
+
+    this.addSql(`create table if not exists "product_spec_option_value" ("id" text not null, "label" text not null, "note" text null, "order" integer not null default 0, "available" boolean not null default true, "option_id" text not null, "created_at" timestamptz not null default now(), "updated_at" timestamptz not null default now(), "deleted_at" timestamptz null, constraint "product_spec_option_value_pkey" primary key ("id"));`);
+    this.addSql(`CREATE INDEX IF NOT EXISTS "IDX_product_spec_option_value_option_id" ON "product_spec_option_value" ("option_id") WHERE deleted_at IS NULL;`);
+    this.addSql(`CREATE INDEX IF NOT EXISTS "IDX_product_spec_option_value_deleted_at" ON "product_spec_option_value" ("deleted_at") WHERE deleted_at IS NULL;`);
+
+    this.addSql(`alter table if exists "product_spec_option" add constraint "product_spec_option_spec_id_foreign" foreign key ("spec_id") references "product_spec" ("id") on update cascade;`);
+
+    this.addSql(`alter table if exists "product_spec_option_value" add constraint "product_spec_option_value_option_id_foreign" foreign key ("option_id") references "product_spec_option" ("id") on update cascade;`);
+  }
+
+  override async down(): Promise<void> {
+    this.addSql(`alter table if exists "product_spec_option_value" drop constraint if exists "product_spec_option_value_option_id_foreign";`);
+
+    this.addSql(`drop table if exists "product_spec_option" cascade;`);
+
+    this.addSql(`drop table if exists "product_spec_option_value" cascade;`);
+  }
+
+}

--- a/apps/backend/src/modules/product-spec/models/product-spec-option-value.ts
+++ b/apps/backend/src/modules/product-spec/models/product-spec-option-value.ts
@@ -1,0 +1,32 @@
+import { model } from "@medusajs/framework/utils"
+import ProductSpecOption from "./product-spec-option"
+
+/**
+ * One selectable value on a partner-defined spec option ("Kashida — cuff and
+ * pallu", "None").
+ *
+ * Rows rather than a string array on the option, for the reason
+ * `ProductSpecColor` is rows: a value needs to be switchable OFF without being
+ * deleted. A partner whose embroiderer is booked for a month turns the value
+ * unavailable; deleting it would break every order that already named it and
+ * would lose the row's identity when it comes back.
+ */
+const ProductSpecOptionValue = model.define("product_spec_option_value", {
+  id: model.id().primaryKey(),
+
+  // What the customer picks by, and what is snapshotted onto the line item.
+  label: model.text(),
+
+  // Detail shown beside the value — a lead-time hint, a caveat.
+  note: model.text().nullable(),
+
+  order: model.number().default(0),
+
+  // Orderable right now. Filtered out of the public read and rejected by the
+  // cart route, the same closed-set rule the palette already enforces.
+  available: model.boolean().default(true),
+
+  option: model.belongsTo(() => ProductSpecOption, { mappedBy: "values" }),
+})
+
+export default ProductSpecOptionValue

--- a/apps/backend/src/modules/product-spec/models/product-spec-option.ts
+++ b/apps/backend/src/modules/product-spec/models/product-spec-option.ts
@@ -1,0 +1,50 @@
+import { model } from "@medusajs/framework/utils"
+import ProductSpec from "./product-spec"
+import ProductSpecOptionValue from "./product-spec-option-value"
+
+/**
+ * A partner-defined CHOICE on a made-to-order spec — "Embroidery", "Border",
+ * "Pallu finish" — with the values a customer may pick from.
+ *
+ * The third kind of thing a spec holds, and the one the first cut was missing.
+ * `ProductSpecColor` is a palette (one axis, always colours) and
+ * `ProductSpecField` is a fixed FACT the partner states about the cloth. Neither
+ * can express "the customer picks one of these", which is what a made-to-order
+ * piece is mostly made of. Adding an `embroidery` column instead would have
+ * bought one word and left the next one — border, tassel, monogram — to another
+ * migration; the partner names the axis here.
+ *
+ * Why it is not a product option/variant: a variant is a stocked, priced thing.
+ * These are choices on a piece that does not exist yet, so multiplying them into
+ * the variant matrix invents SKUs nobody will ever hold. Moving "Color Pattern"
+ * off the variant axis of `ikat-grid-patterns-blue-yellow` is exactly this — 3
+ * patterns × 2 spins = 6 phantom variants where 2 real ones will do.
+ */
+const ProductSpecOption = model.define("product_spec_option", {
+  id: model.id().primaryKey(),
+
+  // Machine key, normalised on write ("embroidery", "border_finish"). Same
+  // reason `ProductSpecField.key` is normalised: these are meant to be compared
+  // across products, and no two partners capitalise the same way.
+  key: model.text(),
+
+  // What the customer sees on the product page ("Embroidery").
+  label: model.text().nullable(),
+
+  // One line under the label, when the choice needs explaining ("Kashida is
+  // worked by hand and adds about two weeks").
+  help_text: model.text().nullable(),
+
+  // Whether a customer MUST choose before adding to cart. False lets a group be
+  // a genuine add-on that can be left off; true is for an axis that has no
+  // sensible default, which is what "Color Pattern" becomes once it stops
+  // being a variant.
+  required: model.boolean().default(false),
+
+  order: model.number().default(0),
+
+  values: model.hasMany(() => ProductSpecOptionValue, { mappedBy: "option" }),
+  spec: model.belongsTo(() => ProductSpec, { mappedBy: "options" }),
+})
+
+export default ProductSpecOption

--- a/apps/backend/src/modules/product-spec/models/product-spec.ts
+++ b/apps/backend/src/modules/product-spec/models/product-spec.ts
@@ -1,6 +1,7 @@
 import { model } from "@medusajs/framework/utils"
 import ProductSpecColor from "./product-spec-color"
 import ProductSpecField from "./product-spec-field"
+import ProductSpecOption from "./product-spec-option"
 
 /**
  * Partner-authored production spec for a product (#1342).
@@ -57,6 +58,7 @@ const ProductSpec = model.define("product_spec", {
   custom_order_lead_time_days: model.number().nullable(),
 
   colors: model.hasMany(() => ProductSpecColor, { mappedBy: "spec" }),
+  options: model.hasMany(() => ProductSpecOption, { mappedBy: "spec" }),
   fields: model.hasMany(() => ProductSpecField, { mappedBy: "spec" }),
 })
 

--- a/apps/backend/src/modules/product-spec/service.ts
+++ b/apps/backend/src/modules/product-spec/service.ts
@@ -2,23 +2,31 @@ import { MedusaService } from "@medusajs/framework/utils"
 import ProductSpec from "./models/product-spec"
 import ProductSpecColor from "./models/product-spec-color"
 import ProductSpecField from "./models/product-spec-field"
+import ProductSpecOption from "./models/product-spec-option"
+import ProductSpecOptionValue from "./models/product-spec-option-value"
 
 class ProductSpecService extends MedusaService({
   ProductSpec,
   ProductSpecColor,
   ProductSpecField,
+  ProductSpecOption,
+  ProductSpecOptionValue,
 }) {
   /**
-   * Fetch a product's spec with its palette and custom fields, or null.
+   * Fetch a product's spec with its palette, its custom fields and its
+   * selectable option groups, or null.
    *
    * Relations are requested explicitly — without them the caller gets a spec
    * whose `colors` and `fields` are simply absent, which reads identically to a
-   * spec that has none.
+   * spec that has none. `options.values` is the same trap one level deeper:
+   * asking for `options` alone yields groups with no values, i.e. a choice with
+   * nothing to choose, and the cart route would then reject every selection as
+   * "not in the list".
    */
   async findByProduct(productId: string) {
     const specs = await this.listProductSpecs(
       { product_id: productId },
-      { relations: ["colors", "fields"] }
+      { relations: ["colors", "fields", "options", "options.values"] }
     )
     return specs?.[0] || null
   }

--- a/apps/backend/src/modules/product-spec/tool-schema.ts
+++ b/apps/backend/src/modules/product-spec/tool-schema.ts
@@ -24,6 +24,7 @@ export const PRODUCT_SPEC_BODY_PARAMS = [
   "custom_order_lead_time_days",
   "colors",
   "fields",
+  "options",
 ]
 
 /**
@@ -96,8 +97,64 @@ export const productSpecSchemaProps = () => ({
       additionalProperties: false,
     },
   },
+  options: {
+    type: "array",
+    description:
+      "Choices the CUSTOMER makes when ordering this made to order — embroidery, a border, a colour pattern. Distinct from `fields`, which are facts the partner states and the customer cannot change. Use these instead of product variants when the choice doesn't change what is kept in stock. REPLACES the stored options wholesale when passed — omit to leave alone, pass [] to delete all. Max 12.",
+    items: {
+      type: "object",
+      properties: {
+        key: {
+          type: "string",
+          description: "Option key, e.g. 'embroidery' (≤ 60 chars).",
+        },
+        label: {
+          type: "string",
+          description: "What the customer sees, e.g. 'Embroidery' (≤ 120 chars).",
+        },
+        help_text: {
+          type: "string",
+          description: "One line under the label (≤ 500 chars).",
+        },
+        required: {
+          type: "boolean",
+          description:
+            "Whether the customer must choose before adding to cart. If true and no value is available, the piece cannot be ordered at all.",
+        },
+        order: { type: "integer", description: "Display order (0–999)." },
+        values: {
+          type: "array",
+          description:
+            "The selectable values. At least 1, max 40 — a group with none is rejected.",
+          items: {
+            type: "object",
+            properties: {
+              label: {
+                type: "string",
+                description: "What the customer picks by (≤ 160 chars).",
+              },
+              note: {
+                type: "string",
+                description: "Detail shown beside the value (≤ 500 chars).",
+              },
+              order: { type: "integer", description: "Display order (0–999)." },
+              available: {
+                type: "boolean",
+                description:
+                  "Orderable right now. Switch off rather than deleting, so orders that already named it still resolve.",
+              },
+            },
+            required: ["label"],
+            additionalProperties: false,
+          },
+        },
+      },
+      required: ["key", "values"],
+      additionalProperties: false,
+    },
+  },
 })
 
 /** Shared guidance appended to the write tool's description on both surfaces. */
 export const PRODUCT_SPEC_WRITE_GUIDANCE =
-  "Call get_spec_catalog first: `params` are validated against the CHOSEN technique's min/max and the whole write is rejected if any value is out of range. `colors` and `fields` REPLACE what is stored when passed, so send the full list, not just the additions."
+  "Call get_spec_catalog first: `params` are validated against the CHOSEN technique's min/max and the whole write is rejected if any value is out of range. `colors`, `fields` and `options` REPLACE what is stored when passed, so send the full list, not just the additions."

--- a/apps/backend/src/scripts/seed-ikat-spec-local.ts
+++ b/apps/backend/src/scripts/seed-ikat-spec-local.ts
@@ -1,0 +1,151 @@
+import { ExecArgs } from "@medusajs/framework/types"
+import { ContainerRegistrationKeys } from "@medusajs/framework/utils"
+import { createProductsWorkflow } from "@medusajs/medusa/core-flows"
+
+import { upsertProductSpecWorkflow } from "../workflows/products/upsert-product-spec"
+
+/**
+ * LOCAL seed for the made-to-order option groups.
+ *
+ * Reproduces prod's `ikat-grid-patterns-blue-yellow` with one change: the
+ * "Color Pattern" axis is NOT a product option any more. On prod it is, giving
+ * 3 patterns × 2 spins = 6 variants — six SKUs for a piece that is woven to
+ * order and never stocked. Here the product keeps only the axis that is a real
+ * stocked difference (Spin Type, 2 variants), and the pattern becomes a spec
+ * choice validated and snapshotted at add-to-cart.
+ *
+ * Embroidery is the second group, and the reason the spec grew option groups at
+ * all: it is a choice, so it fits neither the palette nor the fixed fields.
+ *
+ * Idempotent — re-running updates the spec rather than duplicating the product.
+ *
+ * Usage:
+ *   npx medusa exec src/scripts/seed-ikat-spec-local.ts
+ */
+const HANDLE = "ikat-grid-patterns-blue-yellow"
+
+export default async function seedIkatSpecLocal({ container }: ExecArgs) {
+  const logger = container.resolve(ContainerRegistrationKeys.LOGGER)
+  const query = container.resolve(ContainerRegistrationKeys.QUERY)
+
+  const { data: existing } = await query.graph({
+    entity: "product",
+    fields: ["id", "handle", "status"],
+    filters: { handle: HANDLE },
+  })
+
+  let productId = existing?.[0]?.id
+
+  if (!productId) {
+    const { data: salesChannels } = await query.graph({
+      entity: "sales_channel",
+      fields: ["id", "name"],
+    })
+    const { data: shippingProfiles } = await query.graph({
+      entity: "shipping_profile",
+      fields: ["id"],
+    })
+
+    const created = await createProductsWorkflow(container).run({
+      input: {
+        products: [
+          {
+            title: "Ikat grid patterns of blue and yellow color",
+            handle: HANDLE,
+            status: "published" as any,
+            description:
+              "Handwoven ikat, gridded in blue and yellow. Woven to order in the pattern you choose.",
+            shipping_profile_id: shippingProfiles?.[0]?.id,
+            sales_channels: salesChannels?.[0]
+              ? [{ id: salesChannels[0].id }]
+              : undefined,
+            // Only the axis that is a real stocked difference. The pattern is
+            // deliberately absent — that is the whole point of the seed.
+            options: [{ title: "Spin Type", values: ["HandSpun", "MilSpun"] }],
+            variants: [
+              {
+                title: "HandSpun",
+                sku: "IKAT-GRID-HANDSPUN",
+                manage_inventory: false,
+                options: { "Spin Type": "HandSpun" },
+                prices: [{ amount: 4500, currency_code: "inr" }],
+              },
+              {
+                title: "MilSpun",
+                sku: "IKAT-GRID-MILSPUN",
+                manage_inventory: false,
+                options: { "Spin Type": "MilSpun" },
+                prices: [{ amount: 3200, currency_code: "inr" }],
+              },
+            ],
+          },
+        ],
+      },
+    })
+    productId = created.result[0].id
+    logger.info(`[seed] created product ${productId} (${HANDLE}) with 2 variants`)
+  } else {
+    logger.info(`[seed] product ${productId} already exists — updating its spec`)
+  }
+
+  const { result: spec } = await upsertProductSpecWorkflow(container).run({
+    input: {
+      product_id: productId,
+      data: {
+        weave_technique: "ikat",
+        weave_label: "Ikat, grid, blue and yellow",
+        accepting_custom_orders: true,
+        custom_order_lead_time_days: 30,
+        notes: "Grid registration drifts in damp weather — allow an extra day.",
+        // The palette stays EMPTY: the colour question is asked by the
+        // "Color Pattern" group below, and asking it twice would let a customer
+        // answer it two ways.
+        colors: [],
+        fields: [
+          { key: "warp", label: "Warp", value: "Cotton, 2/60s" },
+          { key: "finished_size", label: "Finished size", value: '44" x 90"' },
+        ],
+        options: [
+          {
+            key: "color_pattern",
+            label: "Color Pattern",
+            help_text: "The gridded colourway this piece is woven in.",
+            required: true,
+            order: 0,
+            values: [
+              { label: "Pattern 1 - Blue/Mustard/Cream/Grey", order: 0 },
+              { label: "Pattern 2 - Mustard/Dusty Blue/Grey", order: 1 },
+              { label: "Pattern 3 - Blue/Yellow/Grey/Cream", order: 2 },
+            ],
+          },
+          {
+            key: "embroidery",
+            label: "Embroidery",
+            help_text: "Hand-worked after the weaving is finished.",
+            required: false,
+            order: 1,
+            values: [
+              { label: "Kashida — border only", note: "adds about 10 days", order: 0 },
+              { label: "Kashida — border and pallu", note: "adds about 3 weeks", order: 1 },
+              {
+                label: "Sozni — fine, all over",
+                note: "currently booked out",
+                order: 2,
+                available: false,
+              },
+            ],
+          },
+        ],
+      },
+    },
+  })
+
+  logger.info(
+    `[seed] spec ${spec.id}: ${spec.options?.length ?? 0} option groups, ` +
+      `${(spec.options ?? []).reduce(
+        (n: number, o: any) => n + (o.values?.length ?? 0),
+        0
+      )} values`
+  )
+  logger.info(`[seed] product handle: ${HANDLE}`)
+}

--- a/apps/backend/src/workflows/products/upsert-product-spec.ts
+++ b/apps/backend/src/workflows/products/upsert-product-spec.ts
@@ -28,6 +28,22 @@ export type ProductSpecFieldInput = {
   order?: number
 }
 
+export type ProductSpecOptionValueInput = {
+  label: string
+  note?: string | null
+  order?: number
+  available?: boolean
+}
+
+export type ProductSpecOptionInput = {
+  key: string
+  label?: string | null
+  help_text?: string | null
+  required?: boolean
+  order?: number
+  values: ProductSpecOptionValueInput[]
+}
+
 export type ProductSpecInput = {
   weave_technique?: string | null
   weave_label?: string | null
@@ -40,6 +56,8 @@ export type ProductSpecInput = {
   colors?: ProductSpecColorInput[]
   /** Full replacement of the custom fields when present; omit to leave alone. */
   fields?: ProductSpecFieldInput[]
+  /** Full replacement of the selectable option groups; omit to leave alone. */
+  options?: ProductSpecOptionInput[]
 }
 
 export type UpsertProductSpecInput = {
@@ -54,8 +72,10 @@ type UpsertCompensation = {
   prev?: Record<string, unknown>
   prevColors?: any[]
   prevFields?: any[]
+  prevOptions?: any[]
   replacedColors: boolean
   replacedFields: boolean
+  replacedOptions: boolean
 }
 
 /**
@@ -66,7 +86,7 @@ type UpsertCompensation = {
  * not a request-shape rule: whether 900 GSM is a typo depends on the technique
  * that was chosen, which only this layer knows.
  *
- * Palette and fields are REPLACED wholesale when supplied. Diffing them by id
+ * Palette, fields and option groups are REPLACED wholesale when supplied. Diffing them by id
  * would be kinder to concurrent editors, but a partner spec has exactly one
  * editor, and a replace cannot leave a colour the partner deleted alive because
  * its row failed to match.
@@ -77,7 +97,7 @@ const upsertProductSpecStep = createStep(
     const service: any = container.resolve(PRODUCT_SPEC_MODULE)
     const link: any = container.resolve(ContainerRegistrationKeys.LINK)
 
-    const { colors, fields, ...specData } = input.data
+    const { colors, fields, options, ...specData } = input.data
 
     // Parameters are only meaningful against a technique. Validating here means
     // a spec can never be stored claiming 8000 GSM because a UI let it through.
@@ -119,8 +139,10 @@ const upsertProductSpecStep = createStep(
         },
         prevColors: existing.colors ?? [],
         prevFields: existing.fields ?? [],
+        prevOptions: existing.options ?? [],
         replacedColors: !!colors,
         replacedFields: !!fields,
+        replacedOptions: !!options,
       }
     } else {
       spec = await service.createProductSpecs({
@@ -133,6 +155,7 @@ const upsertProductSpecStep = createStep(
         product_id: input.product_id,
         replacedColors: !!colors,
         replacedFields: !!fields,
+        replacedOptions: !!options,
       }
     }
 
@@ -169,6 +192,45 @@ const upsertProductSpecStep = createStep(
       }
     }
 
+    if (options) {
+      // Values first, then their groups: a value row whose option is already
+      // gone is unreachable garbage, and the FK points that way. Deleting the
+      // parent first would strand every value it owned.
+      const staleOptions = existing?.options ?? []
+      const staleValueIds = staleOptions.flatMap((o: any) =>
+        (o.values ?? []).map((v: any) => v.id)
+      )
+      if (staleValueIds.length)
+        await service.deleteProductSpecOptionValues(staleValueIds)
+      const staleOptionIds = staleOptions.map((o: any) => o.id)
+      if (staleOptionIds.length)
+        await service.deleteProductSpecOptions(staleOptionIds)
+
+      for (const [i, o] of options.entries()) {
+        const created = await service.createProductSpecOptions({
+          key: normalizeKey(o.key),
+          label: o.label ?? o.key.trim(),
+          help_text: o.help_text ?? null,
+          required: o.required ?? false,
+          order: o.order ?? i,
+          spec_id: spec.id,
+        })
+        // `createX` returns one row for an object input and an array for an
+        // array input — normalise rather than assume, because guessing wrong
+        // yields `undefined.id` as the FK and every value lands orphaned.
+        const optionRow = Array.isArray(created) ? created[0] : created
+        await service.createProductSpecOptionValues(
+          o.values.map((v, vi) => ({
+            label: v.label.trim(),
+            note: v.note ?? null,
+            order: v.order ?? vi,
+            available: v.available ?? true,
+            option_id: optionRow.id,
+          }))
+        )
+      }
+    }
+
     // Ensure the link on BOTH paths (idempotent). Creating it only on first
     // write is what left artisan-detail rows readable by their own module but
     // invisible to query.graph, so the storefront silently dropped them (#859).
@@ -195,12 +257,20 @@ const upsertProductSpecStep = createStep(
       // Children go with the parent — deleting the spec alone would leave
       // orphan colour/field rows pointing at an id that no longer exists.
       const spec = await service
-        .retrieveProductSpec(compensation.id, { relations: ["colors", "fields"] })
+        .retrieveProductSpec(compensation.id, {
+          relations: ["colors", "fields", "options", "options.values"],
+        })
         .catch(() => null)
       const colorIds = (spec?.colors ?? []).map((c: any) => c.id)
       const fieldIds = (spec?.fields ?? []).map((f: any) => f.id)
+      const optionIds = (spec?.options ?? []).map((o: any) => o.id)
+      const valueIds = (spec?.options ?? []).flatMap((o: any) =>
+        (o.values ?? []).map((v: any) => v.id)
+      )
       if (colorIds.length) await service.deleteProductSpecColors(colorIds)
       if (fieldIds.length) await service.deleteProductSpecFields(fieldIds)
+      if (valueIds.length) await service.deleteProductSpecOptionValues(valueIds)
+      if (optionIds.length) await service.deleteProductSpecOptions(optionIds)
       await service.deleteProductSpecs(compensation.id)
       return
     }
@@ -247,6 +317,42 @@ const upsertProductSpecStep = createStep(
             spec_id: compensation.id,
           }))
         )
+      }
+    }
+
+    if (compensation.replacedOptions) {
+      const current = await service.listProductSpecOptions(
+        { spec_id: compensation.id },
+        { relations: ["values"] }
+      )
+      const valueIds = (current ?? []).flatMap((o: any) =>
+        (o.values ?? []).map((v: any) => v.id)
+      )
+      const optionIds = (current ?? []).map((o: any) => o.id)
+      if (valueIds.length) await service.deleteProductSpecOptionValues(valueIds)
+      if (optionIds.length) await service.deleteProductSpecOptions(optionIds)
+
+      for (const o of compensation.prevOptions ?? []) {
+        const restored = await service.createProductSpecOptions({
+          key: o.key,
+          label: o.label,
+          help_text: o.help_text,
+          required: o.required,
+          order: o.order,
+          spec_id: compensation.id,
+        })
+        const optionRow = Array.isArray(restored) ? restored[0] : restored
+        if (o.values?.length) {
+          await service.createProductSpecOptionValues(
+            o.values.map((v: any) => ({
+              label: v.label,
+              note: v.note,
+              order: v.order,
+              available: v.available,
+              option_id: optionRow.id,
+            }))
+          )
+        }
       }
     }
   }

--- a/apps/partner-ui/src/components/forms/product-spec-form/product-spec-form.tsx
+++ b/apps/partner-ui/src/components/forms/product-spec-form/product-spec-form.tsx
@@ -16,6 +16,8 @@ import { useMemo } from "react"
 import type {
   ProductSpecColor,
   ProductSpecField,
+  ProductSpecOption,
+  ProductSpecOptionValue,
   ProductSpecPayload,
   WeaveTechnique,
 } from "../../../hooks/api/products"
@@ -53,6 +55,25 @@ const emptyColor = (order: number): ProductSpecColor => ({
   usage_notes: "",
   order,
   available: true,
+})
+
+const emptyOptionValue = (order: number): ProductSpecOptionValue => ({
+  label: "",
+  note: "",
+  order,
+  available: true,
+})
+
+const emptyOption = (order: number): ProductSpecOption => ({
+  key: "",
+  label: "",
+  help_text: "",
+  required: false,
+  order,
+  // A group is born with one empty value: the backend rejects a group with
+  // none, and starting at zero makes "add a choice" a step a partner can miss
+  // and then be told about only on save.
+  values: [emptyOptionValue(0)],
 })
 
 const emptyField = (order: number): ProductSpecField => ({
@@ -136,6 +157,22 @@ export const ProductSpecForm = ({
 
   const setField = (i: number, next: Partial<ProductSpecField>) =>
     patch({ fields: fields.map((f, j) => (i === j ? { ...f, ...next } : f)) })
+
+  const options = value.options ?? []
+
+  const setOption = (i: number, next: Partial<ProductSpecOption>) =>
+    patch({ options: options.map((o, j) => (i === j ? { ...o, ...next } : o)) })
+
+  const setOptionValue = (
+    i: number,
+    vi: number,
+    next: Partial<ProductSpecOptionValue>
+  ) =>
+    setOption(i, {
+      values: (options[i]?.values ?? []).map((v, j) =>
+        vi === j ? { ...v, ...next } : v
+      ),
+    })
 
   return (
     <div className="flex flex-col gap-y-8">
@@ -362,6 +399,167 @@ export const ProductSpecForm = ({
           >
             <Plus />
             Add colour
+          </Button>
+        </div>
+      </section>
+
+      {/* ── Options the customer chooses ───────────────────────────────── */}
+      <section className="flex flex-col gap-y-4">
+        <div>
+          <Heading level="h2">Choices you offer</Heading>
+          <Text size="small" className="text-ui-fg-subtle">
+            Things the customer picks when ordering this made to order —
+            embroidery, a border, a colour pattern. Use these instead of product
+            variants when the choice doesn't change what you keep in stock.
+          </Text>
+        </div>
+
+        {options.map((o, i) => (
+          <div
+            key={i}
+            className="flex flex-col gap-y-3 rounded-lg border border-ui-border-base p-3"
+          >
+            <div className="grid items-end gap-3 md:grid-cols-[1fr_auto]">
+              <div className="flex flex-col gap-y-2">
+                <Label size="small" weight="plus">
+                  What are they choosing?
+                </Label>
+                <Input
+                  placeholder="Embroidery"
+                  value={o.label ?? ""}
+                  onChange={(e) =>
+                    // Key derived from the label and normalised again
+                    // server-side, exactly as the custom fields do it.
+                    setOption(i, { label: e.target.value, key: e.target.value })
+                  }
+                />
+              </div>
+              <IconButton
+                type="button"
+                size="small"
+                variant="transparent"
+                aria-label={`Remove ${o.label || "choice"}`}
+                onClick={() =>
+                  patch({ options: options.filter((_, j) => j !== i) })
+                }
+              >
+                <Trash />
+              </IconButton>
+            </div>
+
+            <div className="flex flex-col gap-y-2">
+              <Label size="small" weight="plus">
+                Hint (optional)
+              </Label>
+              <Input
+                placeholder="Hand-worked — adds about two weeks"
+                value={o.help_text ?? ""}
+                onChange={(e) => setOption(i, { help_text: e.target.value })}
+              />
+            </div>
+
+            <div className="flex items-center gap-x-2">
+              <Checkbox
+                id={`spec-option-required-${i}`}
+                checked={!!o.required}
+                onCheckedChange={(checked) =>
+                  setOption(i, { required: !!checked })
+                }
+              />
+              <Label size="small" htmlFor={`spec-option-required-${i}`}>
+                They must choose one
+              </Label>
+            </div>
+
+            <div className="flex flex-col gap-y-2">
+              <Label size="small" weight="plus">
+                Choices
+              </Label>
+              {(o.values ?? []).map((v, vi) => (
+                <div
+                  key={vi}
+                  className="grid items-center gap-2 md:grid-cols-[1fr_1fr_auto_auto]"
+                >
+                  <Input
+                    placeholder="Kashida — cuff and pallu"
+                    value={v.label}
+                    onChange={(e) =>
+                      setOptionValue(i, vi, { label: e.target.value })
+                    }
+                  />
+                  <Input
+                    placeholder="Note (optional)"
+                    value={v.note ?? ""}
+                    onChange={(e) =>
+                      setOptionValue(i, vi, { note: e.target.value })
+                    }
+                  />
+                  <div className="flex items-center gap-x-2">
+                    {/* Off rather than deleted: a choice your embroiderer is
+                      *  booked out of comes back, and every order that already
+                      *  named it must keep resolving. */}
+                    <Switch
+                      id={`spec-option-value-available-${i}-${vi}`}
+                      checked={v.available !== false}
+                      onCheckedChange={(checked) =>
+                        setOptionValue(i, vi, { available: !!checked })
+                      }
+                    />
+                    <Label
+                      size="xsmall"
+                      htmlFor={`spec-option-value-available-${i}-${vi}`}
+                    >
+                      Available
+                    </Label>
+                  </div>
+                  <IconButton
+                    type="button"
+                    size="small"
+                    variant="transparent"
+                    aria-label={`Remove ${v.label || "choice"}`}
+                    onClick={() =>
+                      setOption(i, {
+                        values: (o.values ?? []).filter((_, j) => j !== vi),
+                      })
+                    }
+                  >
+                    <XMarkMini />
+                  </IconButton>
+                </div>
+              ))}
+              <div>
+                <Button
+                  type="button"
+                  size="small"
+                  variant="transparent"
+                  onClick={() =>
+                    setOption(i, {
+                      values: [
+                        ...(o.values ?? []),
+                        emptyOptionValue((o.values ?? []).length),
+                      ],
+                    })
+                  }
+                >
+                  <Plus />
+                  Add choice
+                </Button>
+              </div>
+            </div>
+          </div>
+        ))}
+
+        <div>
+          <Button
+            type="button"
+            size="small"
+            variant="secondary"
+            onClick={() =>
+              patch({ options: [...options, emptyOption(options.length)] })
+            }
+          >
+            <Plus />
+            Add something to choose
           </Button>
         </div>
       </section>

--- a/apps/partner-ui/src/hooks/api/products.tsx
+++ b/apps/partner-ui/src/hooks/api/products.tsx
@@ -805,6 +805,29 @@ export type ProductSpecField = {
   order?: number
 }
 
+export type ProductSpecOptionValue = {
+  id?: string
+  label: string
+  note?: string | null
+  order?: number
+  available?: boolean
+}
+
+/**
+ * A choice the CUSTOMER makes, as against `ProductSpecField` which is a fact the
+ * partner states. The partner names the axis, so "Embroidery", "Border" and
+ * "Color Pattern" are all this one shape.
+ */
+export type ProductSpecOption = {
+  id?: string
+  key: string
+  label?: string | null
+  help_text?: string | null
+  required?: boolean
+  order?: number
+  values: ProductSpecOptionValue[]
+}
+
 export type ProductSpec = {
   id?: string
   product_id?: string
@@ -817,9 +840,13 @@ export type ProductSpec = {
   custom_order_lead_time_days?: number | null
   colors?: ProductSpecColor[]
   fields?: ProductSpecField[]
+  options?: ProductSpecOption[]
 } | null
 
-/** The payload the upsert route accepts. `colors`/`fields` REPLACE when sent. */
+/**
+ * The payload the upsert route accepts. `colors`/`fields`/`options` REPLACE
+ * what is stored when sent, so omitting a key and sending `[]` differ.
+ */
 export type ProductSpecPayload = Omit<
   NonNullable<ProductSpec>,
   "id" | "product_id"

--- a/apps/storefront/src/lib/data/product-spec.ts
+++ b/apps/storefront/src/lib/data/product-spec.ts
@@ -30,6 +30,29 @@ export type StoreSpecField = {
   value?: string | null
 }
 
+export type StoreSpecOptionValue = {
+  id?: string
+  label: string
+  note?: string | null
+}
+
+/**
+ * A partner-defined choice on the spec — "Color Pattern", "Embroidery".
+ *
+ * `values` is already filtered to what is orderable by the read route, so an
+ * empty `values` on a `required` group means the piece cannot be ordered right
+ * now. The form says so rather than hiding the group, because a page that
+ * silently drops a required axis looks orderable and is not.
+ */
+export type StoreSpecOption = {
+  id?: string
+  key: string
+  label: string
+  help_text?: string | null
+  required: boolean
+  values: StoreSpecOptionValue[]
+}
+
 export type StoreProductSpec = {
   id?: string
   weave_technique?: string | null
@@ -40,6 +63,7 @@ export type StoreProductSpec = {
   custom_order_lead_time_days?: number | null
   colors: StoreSpecColor[]
   fields: StoreSpecField[]
+  options?: StoreSpecOption[]
 }
 
 export type StoreSpecTechnique = {
@@ -90,12 +114,15 @@ export async function addMadeToSpecToCart({
   quantity,
   color,
   note,
+  options,
   countryCode,
 }: {
   variantId: string
   quantity: number
   color?: string | null
   note?: string | null
+  /** Option key → chosen value label, as published by the spec read. */
+  options?: Record<string, string> | null
   countryCode: string
 }) {
   if (!variantId) {
@@ -120,6 +147,8 @@ export async function addMadeToSpecToCart({
         quantity,
         color: color || undefined,
         note: note || undefined,
+        options:
+          options && Object.keys(options).length ? options : undefined,
       },
       headers,
     })

--- a/apps/storefront/src/modules/common/components/line-item-options/index.tsx
+++ b/apps/storefront/src/modules/common/components/line-item-options/index.tsx
@@ -12,6 +12,7 @@ type MadeToSpec = {
   color_hex?: string | null
   lead_time_days?: number | null
   note?: string | null
+  options?: { key: string; label: string; value: string; note?: string | null }[]
 }
 
 const readMadeToSpec = (
@@ -75,6 +76,24 @@ const LineItemOptions = ({
                 : ""}
             </Text>
           </div>
+          {/* The partner-defined choices — "Color Pattern", "Embroidery".
+            *  Shown as label AND value: "Kashida — cuff and pallu" alone does
+            *  not say which question it answered, and on an order that is the
+            *  difference between a record and a riddle. */}
+          {!!madeToSpec.options?.length && (
+            <div className="flex flex-col gap-y-0.5">
+              {madeToSpec.options.map((option) => (
+                <Text
+                  key={option.key}
+                  className="txt-small text-ui-fg-subtle"
+                  data-testid="line-item-spec-option"
+                >
+                  {option.label}: {option.value}
+                </Text>
+              ))}
+            </div>
+          )}
+
           {madeToSpec.weave && (
             <Text className="txt-small text-ui-fg-muted">
               {madeToSpec.weave}

--- a/apps/storefront/src/modules/products/components/production-spec/made-to-order-form.tsx
+++ b/apps/storefront/src/modules/products/components/production-spec/made-to-order-form.tsx
@@ -34,6 +34,24 @@ const MadeToOrderForm = ({ spec, variants }: Props) => {
     spec.colors[0]?.name ?? null
   )
   const [note, setNote] = useState("")
+
+  const specOptions = spec.options ?? []
+
+  // Required groups default to their first orderable value so the common path
+  // is one click. Optional ones start UNSET on purpose — pre-selecting an
+  // add-on is how a customer ends up paying for embroidery they never chose.
+  const [selected, setSelected] = useState<Record<string, string>>(() =>
+    Object.fromEntries(
+      specOptions
+        .filter((o) => o.required && o.values.length)
+        .map((o) => [o.key, o.values[0].label])
+    )
+  )
+
+  // A required group the partner has nothing available for. The backend refuses
+  // these outright, so the button must too — otherwise the page invites a click
+  // whose only outcome is an error.
+  const blockedBy = specOptions.filter((o) => o.required && !o.values.length)
   const [isAdding, setIsAdding] = useState(false)
   const [error, setError] = useState<string | null>(null)
   const [added, setAdded] = useState(false)
@@ -47,6 +65,7 @@ const MadeToOrderForm = ({ spec, variants }: Props) => {
         quantity: 1,
         color,
         note,
+        options: selected,
         countryCode,
       })
       setAdded(true)
@@ -132,6 +151,76 @@ const MadeToOrderForm = ({ spec, variants }: Props) => {
         </div>
       )}
 
+      {specOptions.map((option) => (
+        <div key={option.key} className="flex flex-col gap-y-2">
+          <div className="flex flex-col">
+            <Text size="small" className="text-ui-fg-subtle">
+              {option.label}
+              {option.required ? "" : " (optional)"}
+            </Text>
+            {option.help_text && (
+              <Text size="xsmall" className="text-ui-fg-muted">
+                {option.help_text}
+              </Text>
+            )}
+          </div>
+
+          {!option.values.length ? (
+            <Text size="small" className="text-ui-fg-error">
+              None of the {option.label.toLowerCase()} choices can be made at the
+              moment.
+            </Text>
+          ) : (
+            <div className="flex flex-wrap gap-2">
+              {/* An optional group needs a way BACK to "not chosen". Without it
+                *  the first tap is irreversible, which is the same trap as
+                *  pre-selecting. */}
+              {(option.required
+                ? option.values
+                : [{ id: `${option.key}-none`, label: "", note: null }, ...option.values]
+              ).map((value) => {
+                const isClear = value.label === ""
+                const isSelected = isClear
+                  ? !selected[option.key]
+                  : selected[option.key] === value.label
+                return (
+                  <button
+                    key={value.id ?? value.label}
+                    type="button"
+                    aria-pressed={isSelected}
+                    onClick={() =>
+                      setSelected((prev) => {
+                        const next = { ...prev }
+                        if (isClear) {
+                          delete next[option.key]
+                        } else {
+                          next[option.key] = value.label
+                        }
+                        return next
+                      })
+                    }
+                    title={value.note ?? undefined}
+                    className={clx(
+                      "rounded-full border px-3 py-1 text-left transition-colors",
+                      isSelected
+                        ? "border-ui-fg-base bg-ui-bg-base"
+                        : "border-ui-border-base bg-ui-bg-subtle hover:border-ui-fg-muted"
+                    )}
+                  >
+                    <Text size="small">{isClear ? "No thanks" : value.label}</Text>
+                    {value.note && (
+                      <Text size="xsmall" className="text-ui-fg-muted">
+                        {value.note}
+                      </Text>
+                    )}
+                  </button>
+                )
+              })}
+            </div>
+          )}
+        </div>
+      ))}
+
       <div className="flex flex-col gap-y-2">
         <Text size="small" className="text-ui-fg-subtle">
           Anything we should know? (optional)
@@ -155,7 +244,7 @@ const MadeToOrderForm = ({ spec, variants }: Props) => {
       <Button
         onClick={handleSubmit}
         isLoading={isAdding}
-        disabled={isAdding || !variantId}
+        disabled={isAdding || !variantId || !!blockedBy.length}
         variant="secondary"
         className="w-full"
       >

--- a/e2e/helpers/e2e-seed.ts
+++ b/e2e/helpers/e2e-seed.ts
@@ -655,6 +655,54 @@ export async function seedShipmentGatePartner(
   return { email, password: SEED_PASSWORD, partnerId }
 }
 
+/**
+ * One CRM contact with a prior inbound activity, for the contact-detail spec.
+ *
+ * The CRM lives on a Hyperbee node, not Postgres — the e2e run uses the
+ * EMBEDDED store (`CRM_HYPERBEE=true`), so this writes through the module
+ * service exactly as the admin route does. If the module is disabled the
+ * resolve throws, which is the honest failure: a CRM spec against no CRM would
+ * otherwise "pass" by finding nothing.
+ *
+ * The activity matters as much as the person. An empty timeline renders the
+ * same empty-state whether the section works or not, so the spec needs at least
+ * one row it can point at.
+ */
+async function seedCrmContact(container: any): Promise<{
+  personId: string
+  personName: string
+  activityBody: string
+}> {
+  const crm: any = container.resolve("crm")
+
+  const first = "Noor"
+  const last = `Weaver-${Date.now()}`
+  const person = await crm.createCrmPeople({
+    first_name: first,
+    last_name: last,
+    email: `e2e-crm-${Date.now()}@jyt.test`,
+    phone: "+911234567890",
+    title: "Head weaver",
+  })
+  const created = Array.isArray(person) ? person[0] : person
+
+  const activityBody = "Asked for a photo of the border before sampling."
+  await crm.recordCrmActivity({
+    related_type: "person",
+    related_id: created.id,
+    activity_type: "message",
+    direction: "inbound",
+    channel: "whatsapp",
+    body: activityBody,
+  })
+
+  return {
+    personId: created.id,
+    personName: `${first} ${last}`,
+    activityBody,
+  }
+}
+
 const SEED_PASSWORD = "e2etest123!"
 const SEED_FILE = path.resolve(__dirname, "../../apps/backend/.e2e-seed.json")
 
@@ -782,6 +830,9 @@ export default async function e2eSeed({ container }: ExecArgs) {
     gate.currencyCode
   )
 
+  logger.info("E2E seed: creating the CRM contact + one logged activity...")
+  const crmContact = await seedCrmContact(container)
+
   const seedData = {
     email,
     password: SEED_PASSWORD,
@@ -811,6 +862,11 @@ export default async function e2eSeed({ container }: ExecArgs) {
     parkedRunLapsedPartnerId: parkedRun.lapsedPartnerId,
     parkedRunLapsedPartnerName: parkedRun.lapsedPartnerName,
     parkedRunFreshPartnerName: parkedRun.freshPartnerName,
+    // CRM contact fixture — consumed by crm-contact-activity.spec.ts (admin,
+    // CI). Requires CRM_HYPERBEE=true so the embedded store is registered.
+    crmPersonId: crmContact.personId,
+    crmPersonName: crmContact.personName,
+    crmActivityBody: crmContact.activityBody,
   }
 
   fs.writeFileSync(SEED_FILE, JSON.stringify(seedData, null, 2))

--- a/e2e/playwright.config.ts
+++ b/e2e/playwright.config.ts
@@ -18,7 +18,13 @@ export default defineConfig({
   // This config only boots the admin (`medusa develop` on :9000). Specs that
   // need the partner-ui (:5173) or a live LLM are tagged `@partnerui` and run
   // only locally — skip them on CI so a shared admin e2e stays deterministic.
-  grepInvert: process.env.CI ? /@partnerui/ : undefined,
+  //
+  // `@localstack` is the same idea for the other direction: a spec that needs a
+  // storefront on :8000 AND a seeded product. Note this is NOT implied by
+  // `@storefront` — the other storefront specs hit LIVE deployed sites and run
+  // here quite happily, which is exactly why the new tag was needed rather than
+  // widening the existing one.
+  grepInvert: process.env.CI ? /@partnerui|@localstack/ : undefined,
 
   webServer: {
     command: `pnpm exec medusa develop`,

--- a/e2e/specs/crm-contact-activity.spec.ts
+++ b/e2e/specs/crm-contact-activity.spec.ts
@@ -1,0 +1,168 @@
+import { test, expect } from "@playwright/test"
+import * as fs from "fs"
+import * as path from "path"
+
+const SEED_FILE = path.resolve(__dirname, "../../apps/backend/.e2e-seed.json")
+
+/**
+ * The CRM contact record: how you get OUT of it, and where the conversation
+ * lives.
+ *
+ * Two things were wrong with the first cut, and both are the kind that a
+ * typecheck and a green build sail straight past because they are about layout
+ * and navigation rather than types:
+ *
+ *  1. The page's only way back was a "Back" button, and the breadcrumb — the
+ *     admin's actual navigation — read the raw record id. A trail that says
+ *     `per_01J…` is a receipt, not navigation.
+ *  2. The activity LOGGER sat above the activity HISTORY, so the first thing
+ *     the page said was "type something" rather than "here is where this
+ *     conversation got to". Logging now happens in a drawer, and the timeline
+ *     is a section of the record.
+ *
+ * Requires `CRM_HYPERBEE=true` — the CRM is a Hyperbee node, not Postgres, and
+ * with no store registered these screens render an empty state that would let
+ * a broken section pass. The seed's `crmPersonId` is the guard: it cannot be
+ * written at all unless the module resolved.
+ */
+test.describe("CRM contact detail", () => {
+  let seed: {
+    email: string
+    password: string
+    crmPersonId: string
+    crmPersonName: string
+    crmActivityBody: string
+  }
+
+  test.beforeAll(() => {
+    if (!fs.existsSync(SEED_FILE)) {
+      throw new Error(
+        `E2E seed file not found at ${SEED_FILE}. Run "pnpm e2e:seed" first.`
+      )
+    }
+    seed = JSON.parse(fs.readFileSync(SEED_FILE, "utf-8"))
+    if (!seed.crmPersonId) {
+      throw new Error(
+        "E2E seed missing crmPersonId — re-run the seed with CRM_HYPERBEE=true."
+      )
+    }
+  })
+
+  const login = async (page: any) => {
+    await page.goto("/app/login")
+    // `networkidle` never settles against `medusa develop` (the dev server
+    // holds long-lived connections open), so wait on the form itself.
+    await page.locator('input[name="email"]').waitFor({ timeout: 60000 })
+    await page.locator('input[name="email"]').fill(seed.email)
+    await page.locator('input[name="password"]').fill(seed.password)
+    await page.locator('button[type="submit"]').click()
+    await page.waitForURL(/\/app\/(?!login)/, { timeout: 15000 })
+  }
+
+  test("names the contact in the breadcrumb instead of offering a Back button", async ({
+    page,
+  }) => {
+    await login(page)
+    await page.goto(`/app/crm/${seed.crmPersonId}`)
+
+    // The record loaded.
+    await expect(
+      page.getByRole("heading", { name: seed.crmPersonName })
+    ).toBeVisible({ timeout: 20000 })
+
+    // The breadcrumb says the person's NAME. It is fed by the route loader, so
+    // this also proves the loader ran — without it `match.data` is undefined
+    // and the crumb silently falls back to the id.
+    //
+    // Targeted as a listitem rather than by scoping to a `nav`: the admin's
+    // FIRST nav is the sidebar, and the breadcrumb is a plain list in the
+    // topbar. The page heading carries the same text, so a bare text match
+    // would pass on the heading alone and prove nothing about the crumb —
+    // `listitem` is what separates them.
+    const crumb = page.getByRole("listitem").filter({ hasText: seed.crmPersonName })
+    await expect(crumb).toHaveCount(1)
+    await expect(crumb).toBeVisible()
+
+    // …and specifically NOT the id, which is what it printed before.
+    await expect(
+      page.getByRole("listitem").filter({ hasText: seed.crmPersonId })
+    ).toHaveCount(0)
+
+    // The competing way out is gone. Scoped by role so the word "Back"
+    // appearing in body copy somewhere cannot fail this.
+    await expect(page.getByRole("button", { name: "Back" })).toHaveCount(0)
+  })
+
+  test("shows the timeline as its own section, with logging behind a drawer", async ({
+    page,
+  }) => {
+    await login(page)
+    await page.goto(`/app/crm/${seed.crmPersonId}`)
+
+    const activityHeading = page.getByRole("heading", { name: "Activity" })
+    await expect(activityHeading).toBeVisible({ timeout: 20000 })
+
+    // The seeded interaction is READ without opening anything…
+    await expect(page.getByText(seed.crmActivityBody)).toBeVisible()
+
+    // …and the section sits BELOW the contact details rather than above them,
+    // which is the whole point of the split. Geometric rather than structural:
+    // a class or wrapper rename should not fail this, a re-ordered page should.
+    const emailRow = page.getByText("Email", { exact: true }).first()
+    const [emailBox, activityBox] = await Promise.all([
+      emailRow.boundingBox(),
+      activityHeading.boundingBox(),
+    ])
+    if (!emailBox || !activityBox) {
+      throw new Error("Could not measure the contact detail sections")
+    }
+    expect(
+      activityBox.y,
+      `the Activity section (y=${activityBox.y}) should sit below the contact ` +
+        `details (Email row y=${emailBox.y}) — if it is above, the logger has ` +
+        `been put back in front of the history`
+    ).toBeGreaterThan(emailBox.y)
+
+    // The form is NOT on the page until asked for.
+    await expect(page.getByPlaceholder("Called about the sampling order", { exact: false })).toHaveCount(0)
+
+    await page.getByRole("button", { name: "Log activity" }).first().click()
+
+    // The drawer's own title, so this cannot be satisfied by the button that
+    // opened it.
+    await expect(
+      page.getByRole("heading", { name: "Log activity" })
+    ).toBeVisible({ timeout: 10000 })
+    await expect(page.getByText("What kind of contact was it?")).toBeVisible()
+  })
+
+  test("logs an activity from the drawer and shows it on the timeline", async ({
+    page,
+  }) => {
+    await login(page)
+    await page.goto(`/app/crm/${seed.crmPersonId}`)
+
+    await expect(page.getByRole("heading", { name: "Activity" })).toBeVisible({
+      timeout: 20000,
+    })
+
+    await page.getByRole("button", { name: "Log activity" }).first().click()
+    await expect(
+      page.getByRole("heading", { name: "Log activity" })
+    ).toBeVisible({ timeout: 10000 })
+
+    const body = `E2E note ${Date.now()}`
+    await page.getByRole("textbox").last().fill(body)
+
+    // The drawer's own submit, not the section button that opened it.
+    await page
+      .getByRole("button", { name: "Log activity", exact: true })
+      .last()
+      .click()
+
+    // It reaches the timeline — which means the write landed AND the list was
+    // invalidated. A drawer that closes on success while the section still
+    // shows the old list is the failure this catches.
+    await expect(page.getByText(body)).toBeVisible({ timeout: 20000 })
+  })
+})

--- a/e2e/specs/storefront-made-to-spec.spec.ts
+++ b/e2e/specs/storefront-made-to-spec.spec.ts
@@ -1,0 +1,177 @@
+import { test, expect } from "@playwright/test"
+
+/**
+ * Ordering a piece made to the partner's spec, where the CHOICES are the
+ * partner's own axes rather than product variants.
+ *
+ * `ikat-grid-patterns-blue-yellow` carried "Color Pattern" as a product option:
+ * 3 patterns × 2 spin types = six variants for a cloth that is woven after the
+ * order and never stocked. The pattern is now a spec option group, and
+ * "Embroidery" — which fits neither the colour palette nor the fixed spec
+ * fields — is a second one. This spec walks the customer's half of that.
+ *
+ * The two assertions that carry weight:
+ *
+ *  1. A value the partner switched OFF is not offered. It is still in the
+ *     database, so a storefront that rendered everything it was given would
+ *     show it and take the order.
+ *  2. The choice reaches the CART LINE. A configurator that collects choices
+ *     and drops them before the line item is worse than one that never asked.
+ *
+ * @storefront @localstack — the other `@storefront` specs hit LIVE deployed
+ * sites, so that tag alone would NOT have kept this out of the CI admin run;
+ * `@localstack` is what excludes it (see playwright.config.ts). Run it with the
+ * storefront config:
+ *
+ *   # 1. seed the product + spec
+ *   cd apps/backend && npx medusa exec src/scripts/seed-ikat-spec-local.ts
+ *   # 2. backend. The seed's events never reach the index engine (its bus dies
+ *   #    with the process), so /store/products returns [] with count: 1 —
+ *   #    disable the index for a local render.
+ *   MEDUSA_FF_INDEX_ENGINE=false npx medusa develop
+ *   # 3. storefront on :8000, then:
+ *   pnpm exec playwright test -c e2e/playwright.storefront.config.ts \
+ *     storefront-made-to-spec
+ *
+ * Point it at a deployed storefront once the spec is live there:
+ *   MADE_TO_SPEC_URL=https://…/in/products/… pnpm exec playwright test …
+ */
+
+const PRODUCT_URL =
+  process.env.MADE_TO_SPEC_URL ??
+  "http://localhost:8000/in/products/ikat-grid-patterns-blue-yellow"
+
+const CART_URL = new URL("../cart", PRODUCT_URL).toString()
+
+// Mirrors src/scripts/seed-ikat-spec-local.ts.
+const PATTERNS = [
+  "Pattern 1 - Blue/Mustard/Cream/Grey",
+  "Pattern 2 - Mustard/Dusty Blue/Grey",
+  "Pattern 3 - Blue/Yellow/Grey/Cream",
+]
+const EMBROIDERY_OFFERED = "Kashida — border and pallu"
+const EMBROIDERY_WITHDRAWN = "Sozni — fine, all over"
+
+/**
+ * Click a choice and confirm it took.
+ *
+ * The buttons are server-rendered but only respond once React has hydrated, so
+ * a bare `click()` can land on markup with no handler attached and vanish
+ * silently — the page still looks right, and the wrong value reaches the cart.
+ * It showed up as the FIRST click of a test being lost while later ones worked,
+ * and only under parallel workers.
+ *
+ * `toPass` re-clicks until the pressed state agrees. Making the suite serial
+ * would have hidden it instead of fixing it.
+ */
+const choose = async (page: any, name: string, pressed = true) => {
+  const button = page.getByRole("button", { name })
+  await expect(async () => {
+    await button.click()
+    await expect(button).toHaveAttribute("aria-pressed", String(pressed))
+  }).toPass({ timeout: 20_000 })
+}
+
+test.describe("Made-to-spec option groups @storefront @localstack", () => {
+  test.beforeEach(async ({ page }) => {
+    await page.setViewportSize({ width: 1440, height: 900 })
+    const response = await page.goto(PRODUCT_URL, {
+      waitUntil: "domcontentloaded",
+    })
+    // A 404 here means the product is not seeded or not on the storefront's
+    // sales channel. Failing loudly beats a skip that reads as a pass.
+    expect(
+      response?.status(),
+      `${PRODUCT_URL} did not load — seed the product and start the stack ` +
+        `(see the header of this file)`
+    ).toBeLessThan(400)
+  })
+
+  test("offers the partner's axes, and not the value they withdrew", async ({
+    page,
+  }) => {
+    await expect(page.getByText("Have it made for you")).toBeVisible()
+
+    // The required axis, with every published value.
+    await expect(page.getByText("Color Pattern", { exact: true })).toBeVisible()
+    for (const pattern of PATTERNS) {
+      await expect(page.getByRole("button", { name: pattern })).toBeVisible()
+    }
+
+    // The optional one, marked as optional so it does not read as a decision
+    // the customer must make.
+    await expect(page.getByText("Embroidery (optional)")).toBeVisible()
+    await expect(
+      page.getByRole("button", { name: EMBROIDERY_OFFERED })
+    ).toBeVisible()
+
+    // The withdrawn value is in the database and MUST NOT be on the page.
+    await expect(page.getByText(EMBROIDERY_WITHDRAWN)).toHaveCount(0)
+
+    // "Color Pattern" is no longer a variant axis — the variant picker offers
+    // only the spin type. If a pattern shows up here, the product still has the
+    // option and the six phantom variants came back.
+    const variantPicker = page.getByText("Select Spin Type")
+    await expect(variantPicker).toBeVisible()
+    await expect(page.getByRole("button", { name: "HandSpun" })).toBeVisible()
+  })
+
+  test("defaults the required axis and leaves the add-on unchosen", async ({
+    page,
+  }) => {
+    // A required group defaults to its first value so the common path is one
+    // click…
+    await expect(
+      page.getByRole("button", { name: PATTERNS[0] })
+    ).toHaveAttribute("aria-pressed", "true")
+
+    // …and an optional one starts UNSET, which is how a customer avoids paying
+    // for embroidery they never chose.
+    await expect(
+      page.getByRole("button", { name: EMBROIDERY_OFFERED })
+    ).toHaveAttribute("aria-pressed", "false")
+    await expect(page.getByRole("button", { name: "No thanks" })).toHaveAttribute(
+      "aria-pressed",
+      "true"
+    )
+
+    // The optional group can be un-chosen again — without "No thanks" the first
+    // tap would be irreversible.
+    await choose(page, EMBROIDERY_OFFERED)
+    await choose(page, "No thanks")
+    await expect(
+      page.getByRole("button", { name: EMBROIDERY_OFFERED })
+    ).toHaveAttribute("aria-pressed", "false")
+  })
+
+  test("carries both choices and the note onto the cart line", async ({
+    page,
+  }) => {
+    await choose(page, PATTERNS[2])
+    await choose(page, EMBROIDERY_OFFERED)
+
+    const note = `E2E ${Date.now()} — a wider border if possible.`
+    await page.getByPlaceholder("For a September wedding", { exact: false }).fill(note)
+
+    await page.getByRole("button", { name: "Add made-to-order piece" }).click()
+    await expect(
+      page.getByRole("button", { name: "Added — add another" })
+    ).toBeVisible({ timeout: 30_000 })
+
+    // Read it back on the CART, not the confirmation the form gave itself.
+    await page.goto(CART_URL, { waitUntil: "domcontentloaded" })
+
+    const line = page.getByTestId("line-item-made-to-spec").first()
+    await expect(line).toBeVisible({ timeout: 20_000 })
+
+    // Label AND value: the value alone would not say which question it
+    // answered, and on an order that is the difference between a record and a
+    // riddle.
+    await expect(line).toContainText(`Color Pattern: ${PATTERNS[2]}`)
+    await expect(line).toContainText(`Embroidery: ${EMBROIDERY_OFFERED}`)
+
+    // The lead time is snapshotted from the spec, not looked up live.
+    await expect(line).toContainText("Made to order")
+    await expect(line).toContainText(note)
+  })
+})


### PR DESCRIPTION
Closes #1356. Advances #1355 (step 1 is done and proven — see below).

Two independent changes; the commits are separated so they read on their own.

---

## 1. Partner-defined spec option groups (`ab40087`)

A spec could hold a colour **palette** and fixed **fields**. Neither can express a choice the customer *makes*, so "Embroidery" had nowhere to live — the palette is one axis and always colours, and a field is a fact the partner *states*. An `embroidery` column would have bought one word and left border, tassel and monogram to the next migration, so **the partner names the axis instead**.

### 🔑 A made-to-order choice is not a product variant

A variant is a stocked, priced thing. On prod, `ikat-grid-patterns-blue-yellow` carries `Color Pattern` (3) × `Spin Type` (2) = **six variants** for a cloth woven after the order and never stocked. Four of those SKUs will never be held.

### The rules, all server-side

| rule | why it is not the storefront's job |
|---|---|
| The set is closed — listed **and** `available` | a switched-off value is still in the database, which is exactly what a stale page offers |
| A **required** group with nothing available **refuses** the order | skipping it would let a piece be ordered without an axis it cannot be woven without, and the partner finds out at the loom |
| An unknown key is **rejected**, never ignored | discarding it quietly records an order the customer did not place |
| The selection is **copied**, never referenced | a partner renaming a value next month must not rewrite what someone bought last week |

### Verification

Driven end to end against a local stack, including in a browser:
- read route publishes only orderable values (3 seeded embroidery values, 2 published);
- omitting the required group → `400` naming the choices; picking the switched-off value → `400` (it is in the DB — the stale-page case);
- renamed the chosen value in Postgres, re-read the cart: it still showed the agreed name.

8 unit cases + 3 e2e cases. **7 of 8 unit cases confirmed to fail** against a deliberately broken resolver; **3 of 3 e2e cases fail** against the pre-change storefront.

### 🔥 The MCP contract test earned its keep

The #1348 guard caught `options` missing from `bodyParams` — the dispatcher's **forward list**, so `set_product_spec` would have accepted option groups and silently stripped them.

---

## 2. CRM contact screen (`abb8271`)

Two problems, both invisible to `tsc` and to a green build because they are about navigation and layout.

- The only way out was a **Back button**, and the breadcrumb printed the raw id. A trail that says `crmp_000001` is a receipt, not navigation. It now names the contact — which needs a route **loader**, because the breadcrumb reads `match.data` and without one that is `undefined` and the crumb silently falls back to the id. Back goes away rather than sitting beside it.
- The **logger sat above the history**, so the page opened by saying "type something" rather than "here is where this conversation got to". The timeline is now a section of the record; logging happens in a drawer over it.

The drawer is **controlled, not routed** — a routed modal opens on mount and navigates to `prev` on close, the `useRouteModal` trap from #1352 that neither `tsc` nor the build can see.

---

## Reviewer notes

- ⚠️ **`CRM_HYPERBEE=true` added to `e2e.yml`.** The CRM is a Hyperbee node, not Postgres; with no store registered these screens render an empty state a spec would pass against. The seed's `crmPersonId` is the guard — it cannot be written unless the module resolved. The embedded store is **single-writer**, so a running dev server holds the lock and the seed then fails; in CI they are sequential.
- ⚠️ **New `@localstack` tag in `playwright.config.ts`.** `@storefront` alone would *not* have kept the new spec out of CI — the existing storefront specs hit **live deployed sites** and run there happily. Caught only by running the full admin suite and seeing my own spec run where it should not have.
- The two spec editors (admin, partner-ui) are byte-identical apart from the header docblock and import path. **Port every change to both.**
- The storefront half is mirrored in the `storefront-starter` submodule (merged as Jaal-Yantra-Textiles/nextjs-starter-medusa#9); the pointer bump is in this PR. **That project needs its own Vercel redeploy.**

## Checks run locally

- backend `tsc`: 74 errors (baseline)
- unit suite: 3662 passed; only the 4 known-red baseline suites fail (reproduce on clean `main`)
- `check:prod-build` ✓ (its `workflow-schemas.json` side effect reverted)
- full CI-equivalent admin e2e after a fresh seed: **23 passed, 0 failed**

## ⚠️ Not in this PR, and needs a decision

Dropping `Color Pattern` from the **real prod product** destroys 4 of its 6 variants (prices, inventory, order-history references). Deliberately left alone. The migration itself is additive and safe.

🤖 Generated with [Claude Code](https://claude.com/claude-code)