### PR TITLE
feat(admin): run actions from the WhatsApp messaging inbox

### DIFF
--- a/apps/backend/src/admin/hooks/api/production-runs.ts
+++ b/apps/backend/src/admin/hooks/api/production-runs.ts
@@ -571,3 +571,114 @@ export const useRecreateProductionRun = (
     ...options,
   })
 }
+
+// --- WhatsApp messaging inbox integration hooks ---
+// These hooks power the per-message actions in the WhatsApp conversation
+// view: log a message as a run activity note, attach media to a run, and
+// complete a run from a partner's WhatsApp message.
+
+export type AdminAddRunActivityNotePayload = {
+  summary: string
+  message_id?: string
+  conversation_id?: string
+  partner_id?: string
+  payload?: Record<string, any>
+}
+
+export const useAddRunActivityNote = (
+  runId: string,
+  options?: UseMutationOptions<
+    { activity: AdminProductionRunActivity },
+    FetchError,
+    AdminAddRunActivityNotePayload
+  >
+) => {
+  const queryClient = useQueryClient()
+
+  return useMutation({
+    mutationFn: async (payload: AdminAddRunActivityNotePayload) =>
+      sdk.client.fetch<{ activity: AdminProductionRunActivity }>(
+        `/admin/production-runs/${runId}/activities/note`,
+        { method: "POST", body: payload }
+      ),
+    onSuccess: (data, variables, _mutateResult, context) => {
+      queryClient.invalidateQueries({
+        queryKey: [...productionRunQueryKeys.detail(runId), "activities"],
+      })
+      options?.onSuccess?.(data, variables, _mutateResult, context)
+    },
+    ...options,
+  })
+}
+
+export type AdminCompleteRunPayload = {
+  produced_quantity?: number
+  rejected_quantity?: number
+  rejection_reason?: string
+  rejection_notes?: string
+  partner_cost_estimate?: number
+  cost_type?: "per_unit" | "total"
+  notes?: string
+  allow_shortfall?: boolean
+  from_message_id?: string
+  from_conversation_id?: string
+}
+
+export const useAdminCompleteRun = (
+  runId: string,
+  options?: UseMutationOptions<
+    { production_run: AdminProductionRun; message: string },
+    FetchError,
+    AdminCompleteRunPayload
+  >
+) => {
+  const queryClient = useQueryClient()
+
+  return useMutation({
+    mutationFn: async (payload: AdminCompleteRunPayload) =>
+      sdk.client.fetch<{ production_run: AdminProductionRun; message: string }>(
+        `/admin/production-runs/${runId}/complete`,
+        { method: "POST", body: payload }
+      ),
+    onSuccess: (data, variables, _mutateResult, context) => {
+      queryClient.invalidateQueries({ queryKey: productionRunQueryKeys.detail(runId) })
+      queryClient.invalidateQueries({ queryKey: productionRunQueryKeys.lists() })
+      queryClient.invalidateQueries({ queryKey: designQueryKeys.lists() })
+      options?.onSuccess?.(data, variables, _mutateResult, context)
+    },
+    ...options,
+  })
+}
+
+export type AdminAttachMediaToRunPayload = {
+  media_url: string
+  media_mime_type?: string
+  filename?: string
+  message_id?: string
+  conversation_id?: string
+}
+
+export const useAttachMediaToRun = (
+  runId: string,
+  options?: UseMutationOptions<
+    { production_run: AdminProductionRun; message: string },
+    FetchError,
+    AdminAttachMediaToRunPayload
+  >
+) => {
+  const queryClient = useQueryClient()
+
+  return useMutation({
+    mutationFn: async (payload: AdminAttachMediaToRunPayload) =>
+      sdk.client.fetch<{ production_run: AdminProductionRun; message: string }>(
+        `/admin/production-runs/${runId}/attach-media`,
+        { method: "POST", body: payload }
+      ),
+    onSuccess: (data, variables, _mutateResult, context) => {
+      queryClient.invalidateQueries({ queryKey: productionRunQueryKeys.detail(runId) })
+      queryClient.invalidateQueries({ queryKey: productionRunQueryKeys.lists() })
+      options?.onSuccess?.(data, variables, _mutateResult, context)
+    },
+    ...options,
+  })
+}

--- a/apps/backend/src/admin/routes/messaging/[conversationId]/page.tsx
+++ b/apps/backend/src/admin/routes/messaging/[conversationId]/page.tsx
@@ -1,6 +1,6 @@
 import { useParams } from "react-router-dom"
 import {
-  Button, Heading, Text, Badge, toast,
+  Button, Heading, Text, Badge, toast, Skeleton,
   DataTable, useDataTable,
   createDataTableFilterHelper, createDataTableColumnHelper, createDataTableCommandHelper,
   type DataTablePaginationState, type DataTableFilteringState,
@@ -10,12 +10,14 @@ import { RouteFocusModal } from "../../../components/modal/route-focus-modal"
 import { StackedFocusModal } from "../../../components/modal/stacked-modal/stacked-focused-modal"
 import { useConversationMessages, useSendMessage } from "../../../hooks/api/messaging"
 import { useEffect, useRef, useState, useCallback, useMemo } from "react"
-import { MessageBubble } from "../components/message-bubble"
+import { MessageBubble, MessageBubbleSkeleton, type MessageAction } from "../components/message-bubble"
 import { MessageInput, type SendPayload, type ReplyTo } from "../components/message-input"
 import { SenderPicker } from "../components/sender-picker"
 import { CreatePaymentFromMessageModal } from "../components/create-payment-from-message-modal"
+import { MessageRunActionModal, type MessageRunActionType } from "../components/message-run-action-modal"
 import type { Message } from "../../../hooks/api/messaging"
 import { type AdminDesign, useDesigns } from "../../../hooks/api/designs"
+import type { AdminProductionRun } from "../../../hooks/api/production-runs"
 
 const ConversationThreadModal = () => {
   const { conversationId } = useParams<{ conversationId: string }>()
@@ -23,10 +25,11 @@ const ConversationThreadModal = () => {
   const [replyTo, setReplyTo] = useState<ReplyTo | null>(null)
   const [editingTitle, setEditingTitle] = useState(false)
   const [titleDraft, setTitleDraft] = useState("")
-  // Single-modal-per-page pattern: kebab on a bubble sets the message
-  // and opens the payment modal. Keeps only one CreatePaymentModal in
-  // the DOM regardless of message count.
-  const [paymentMessage, setPaymentMessage] = useState<Message | null>(null)
+
+  // Single-modal-per-page pattern: the kebab on a bubble sets the active
+  // action + message and opens the corresponding modal. Only one modal is
+  // in the DOM at a time regardless of message count.
+  const [activeAction, setActiveAction] = useState<{ type: MessageAction; message: Message } | null>(null)
 
   const { conversation, messages = [], isPending } = useConversationMessages(
     conversationId!,
@@ -51,6 +54,10 @@ const ConversationThreadModal = () => {
       media_url: message.media_url,
       media_mime_type: message.media_mime_type,
     })
+  }
+
+  const handleMessageAction = (action: MessageAction, message: Message) => {
+    setActiveAction({ type: action, message })
   }
 
   const handleSend = (payload: SendPayload) => {
@@ -81,13 +88,53 @@ const ConversationThreadModal = () => {
     }
   }
 
+  // After completing a run from the messaging inbox, send a short WhatsApp
+  // summary back to the partner: "your current production run stands here".
+  const handleRunCompleted = (run: AdminProductionRun) => {
+    const lines = [
+      `✅ *Production Run Completed*`,
+      ``,
+      `*Run ID:* ${run.id}`,
+      `*Status:* Completed`,
+    ]
+    if (run.quantity) lines.push(`*Ordered:* ${run.quantity}`)
+    if (run.produced_quantity != null) lines.push(`*Produced:* ${run.produced_quantity}`)
+    if (run.rejected_quantity) lines.push(`*Rejected:* ${run.rejected_quantity}`)
+    lines.push(``)
+    lines.push(`Thank you for your work on this run. 🙏`)
+
+    sendMutation.mutate(
+      { content: lines.join("\n") },
+      {
+        onSuccess: () => toast.success("Summary sent to partner"),
+        onError: (err: any) => toast.error(err?.message || "Failed to send summary — 24h window may be closed"),
+      }
+    )
+  }
+
+  const isRunAction = (type: MessageAction): type is MessageRunActionType =>
+    type === "activity_note" || type === "attach_media" || type === "complete_run"
+
   return (
     <RouteFocusModal prev="/messaging">
       <RouteFocusModal.Header />
       <RouteFocusModal.Body className="flex flex-1 flex-col overflow-hidden p-0">
         {isPending ? (
-          <div className="flex items-center justify-center flex-1 text-ui-fg-muted">
-            Loading messages...
+          <div className="flex flex-col h-full px-6 py-4 bg-ui-bg-subtle">
+            {/* Header skeleton */}
+            <div className="flex items-center justify-between px-0 py-3 border-b border-ui-border-base shrink-0">
+              <div className="space-y-2">
+                <Skeleton className="h-6 w-48" />
+                <Skeleton className="h-4 w-32" />
+              </div>
+              <Skeleton className="h-8 w-40" />
+            </div>
+            {/* Message skeletons */}
+            <div className="flex-1 overflow-hidden py-4">
+              <MessageBubbleSkeleton count={8} />
+            </div>
+            {/* Input skeleton */}
+            <Skeleton className="h-16 w-full shrink-0" />
           </div>
         ) : !conversation ? (
           <div className="flex items-center justify-center flex-1 text-ui-fg-muted">
@@ -171,7 +218,7 @@ const ConversationThreadModal = () => {
                       key={msg.id}
                       message={msg}
                       onReply={handleReply}
-                      onCreatePayment={setPaymentMessage}
+                      onMessageAction={handleMessageAction}
                     />
                   ))}
                 </div>
@@ -192,13 +239,28 @@ const ConversationThreadModal = () => {
         )}
       </RouteFocusModal.Body>
 
+      {/* Payment modal */}
       {conversation && (
         <CreatePaymentFromMessageModal
-          open={!!paymentMessage}
-          onClose={() => setPaymentMessage(null)}
-          message={paymentMessage}
+          open={!!activeAction && activeAction.type === "payment"}
+          onClose={() => setActiveAction(null)}
+          message={activeAction?.type === "payment" ? activeAction.message : null}
           partnerId={conversation.partner_id}
           partnerName={conversation.partner_name}
+        />
+      )}
+
+      {/* Run action modal (activity note / attach media / complete run) */}
+      {conversation && (
+        <MessageRunActionModal
+          open={!!activeAction && isRunAction(activeAction.type)}
+          onClose={() => setActiveAction(null)}
+          actionType={activeAction && isRunAction(activeAction.type) ? activeAction.type : "activity_note"}
+          message={activeAction && isRunAction(activeAction.type) ? activeAction.message : null}
+          partnerId={conversation.partner_id}
+          partnerName={conversation.partner_name}
+          conversationId={conversationId!}
+          onRunCompleted={handleRunCompleted}
         />
       )}
     </RouteFocusModal>

--- a/apps/backend/src/admin/routes/messaging/components/message-bubble.tsx
+++ b/apps/backend/src/admin/routes/messaging/components/message-bubble.tsx
@@ -1,6 +1,7 @@
-import { clx, DropdownMenu } from "@medusajs/ui"
+import { clx, DropdownMenu, Badge, Skeleton } from "@medusajs/ui"
 import type { Message } from "../../../hooks/api/messaging"
 import { ContextCard } from "./context-card"
+import type { MessageRunActionType } from "./message-run-action-modal"
 
 const URL_REGEX = /(https?:\/\/[^\s]+)/g
 
@@ -17,7 +18,6 @@ const RichContent = ({ text, isOutbound }: { text: string; isOutbound: boolean }
       {urls.length > 0 && (
         <div className="flex flex-col gap-1.5 mb-1.5">
           {urls.map((url, i) => {
-            // Try to extract domain and path for a simple preview
             let domain = ""
             let path = ""
             try {
@@ -101,7 +101,7 @@ function formatTime(dateStr: string): string {
 
 function statusIcon(status: string): string {
   switch (status) {
-    case "queued": return "\u23F3"    // hourglass
+    case "queued": return "\u23F3"
     case "sent": return "\u2713"
     case "delivered": return "\u2713\u2713"
     case "read": return "\u2713\u2713"
@@ -116,6 +116,36 @@ function isImageMime(mime?: string | null): boolean {
 
 function isVideoMime(mime?: string | null): boolean {
   return !!mime && mime.startsWith("video/")
+}
+
+/**
+ * A small badge identifying WhatsApp template / interactive messages so
+ * the operator can tell system-sent templates apart from free-form text.
+ */
+const MessageTypeBadge = ({ message, isOutbound }: { message: Message; isOutbound: boolean }) => {
+  if (message.message_type === "template") {
+    return (
+      <Badge
+        size="2xsmall"
+        color="grey"
+        className={clx("mb-1", isOutbound && "bg-white/20 text-ui-fg-on-color border-white/30")}
+      >
+        Template
+      </Badge>
+    )
+  }
+  if (message.message_type === "interactive") {
+    return (
+      <Badge
+        size="2xsmall"
+        color="grey"
+        className={clx("mb-1", isOutbound && "bg-white/20 text-ui-fg-on-color border-white/30")}
+      >
+        Interactive
+      </Badge>
+    )
+  }
+  return null
 }
 
 const MediaPreview = ({ message }: { message: Message }) => {
@@ -192,19 +222,31 @@ const ReplyPreview = ({ snapshot, isOutbound }: { snapshot: Message["reply_to_sn
   )
 }
 
+/**
+ * The set of per-message actions the conversation page can handle. The
+ * MessageBubble emits the action type + the message; the page owns the
+ * modal so we don't end up with N modals in the DOM.
+ */
+export type MessageAction =
+  | "payment"
+  | MessageRunActionType
+
 export const MessageBubble = ({
   message,
   onReply,
-  onCreatePayment,
+  onMessageAction,
 }: {
   message: Message
   onReply?: (message: Message) => void
-  // Optional — when provided, inbound messages get a kebab menu with a
-  // "Create payment request" entry. Page-level state owns the modal so
-  // we don't end up with N modals (one per bubble) in the DOM.
-  onCreatePayment?: (message: Message) => void
+  /**
+   * When provided, inbound messages get a kebab menu with per-message
+   * actions: create payment, add to run activity log, attach media to
+   * run, complete production run. Page-level state owns the modal.
+   */
+  onMessageAction?: (action: MessageAction, message: Message) => void
 }) => {
   const isOutbound = message.direction === "outbound"
+  const hasMedia = !!message.media_url
 
   return (
     <div
@@ -237,6 +279,8 @@ export const MessageBubble = ({
           </div>
         )}
 
+        <MessageTypeBadge message={message} isOutbound={isOutbound} />
+
         <ReplyPreview snapshot={message.reply_to_snapshot} isOutbound={isOutbound} />
 
         {message.context_snapshot && message.context_type && (
@@ -268,8 +312,6 @@ export const MessageBubble = ({
           )}
         </div>
 
-        {/* Why a delivery failed (Meta error). Captured from the WhatsApp status
-            webhook so the operator sees the reason instead of a bare ✗. */}
         {isOutbound && message.status === "failed" && message.fail_reason && (
           <div
             className="mt-1 text-[10px] text-red-300 text-right break-words"
@@ -281,7 +323,7 @@ export const MessageBubble = ({
       </div>
 
       {/* Reply + actions (right side for inbound) */}
-      {!isOutbound && (onReply || onCreatePayment) && (
+      {!isOutbound && (onReply || onMessageAction) && (
         <div className="flex flex-col gap-y-1 mt-2 opacity-0 group-hover:opacity-100 transition-opacity">
           {onReply && (
             <button
@@ -294,7 +336,7 @@ export const MessageBubble = ({
               </svg>
             </button>
           )}
-          {onCreatePayment && (
+          {onMessageAction && (
             <DropdownMenu>
               <DropdownMenu.Trigger asChild>
                 <button
@@ -308,14 +350,62 @@ export const MessageBubble = ({
                 </button>
               </DropdownMenu.Trigger>
               <DropdownMenu.Content side="right" align="start">
-                <DropdownMenu.Item onClick={() => onCreatePayment(message)}>
-                  Create payment request from this message
+                <DropdownMenu.Label>Production run</DropdownMenu.Label>
+                <DropdownMenu.Item onClick={() => onMessageAction("activity_note", message)}>
+                  Add to run activity log
+                </DropdownMenu.Item>
+                {hasMedia && (
+                  <DropdownMenu.Item onClick={() => onMessageAction("attach_media", message)}>
+                    Attach media to run
+                  </DropdownMenu.Item>
+                )}
+                <DropdownMenu.Item onClick={() => onMessageAction("complete_run", message)}>
+                  Complete production run
+                </DropdownMenu.Item>
+                <DropdownMenu.Separator />
+                <DropdownMenu.Item onClick={() => onMessageAction("payment", message)}>
+                  Create payment request
                 </DropdownMenu.Item>
               </DropdownMenu.Content>
             </DropdownMenu>
           )}
         </div>
       )}
+    </div>
+  )
+}
+
+/**
+ * Skeleton placeholder for a message bubble — used while the conversation
+ * is loading instead of a plain "Loading messages..." text.
+ */
+export const MessageBubbleSkeleton = ({ count = 6 }: { count?: number }) => {
+  return (
+    <div className="space-y-3 max-w-3xl mx-auto">
+      {Array.from({ length: count }).map((_, i) => {
+        const isOutbound = i % 2 === 0
+        return (
+          <div
+            key={i}
+            className={clx(
+              "flex w-full items-start gap-1",
+              isOutbound ? "justify-end" : "justify-start"
+            )}
+          >
+            <div
+              className={clx(
+                "max-w-[70%] rounded-lg px-3 py-2",
+                isOutbound ? "bg-ui-bg-interactive/50 rounded-br-none" : "bg-ui-bg-subtle rounded-bl-none"
+              )}
+            >
+              {!isOutbound && <Skeleton className="h-3 w-20 mb-2" />}
+              <Skeleton className="h-4 w-full max-w-[280px] mb-1" />
+              <Skeleton className={clx("h-4", isOutbound ? "w-40" : "w-48")} />
+              <Skeleton className="h-3 w-12 mt-2" />
+            </div>
+          </div>
+        )
+      })}
     </div>
   )
 }

--- a/apps/backend/src/admin/routes/messaging/components/message-run-action-modal.tsx
+++ b/apps/backend/src/admin/routes/messaging/components/message-run-action-modal.tsx
@@ -1,0 +1,490 @@
+import { useEffect, useMemo, useState } from "react"
+import {
+  FocusModal,
+  Button,
+  Input,
+  Label,
+  Textarea,
+  Text,
+  Badge,
+  toast,
+  clx,
+  Switch,
+  Tooltip,
+  Skeleton,
+  Select,
+} from "@medusajs/ui"
+import type { Message } from "../../../hooks/api/messaging"
+import {
+  useProductionRuns,
+  useAddRunActivityNote,
+  useAdminCompleteRun,
+  useAttachMediaToRun,
+  type AdminProductionRun,
+} from "../../../hooks/api/production-runs"
+
+export type MessageRunActionType = "activity_note" | "attach_media" | "complete_run"
+
+type Props = {
+  open: boolean
+  onClose: () => void
+  actionType: MessageRunActionType
+  message: Message | null
+  partnerId: string
+  partnerName: string
+  conversationId: string
+  /** Called after a successful "complete_run" so the page can send a WhatsApp summary. */
+  onRunCompleted?: (run: AdminProductionRun) => void
+}
+
+const REJECTION_REASONS = [
+  { label: "—", value: "" },
+  { label: "Stitching Defect", value: "stitching_defect" },
+  { label: "Fabric Flaw", value: "fabric_flaw" },
+  { label: "Color Mismatch", value: "color_mismatch" },
+  { label: "Sizing Error", value: "sizing_error" },
+  { label: "Print Defect", value: "print_defect" },
+  { label: "Material Damage", value: "material_damage" },
+  { label: "Quality Below Standard", value: "quality_below_standard" },
+  { label: "Other", value: "other" },
+] as const
+
+const runStatusColors: Record<string, "green" | "orange" | "blue" | "grey" | "red"> = {
+  draft: "grey",
+  pending_review: "grey",
+  approved: "blue",
+  sent_to_partner: "blue",
+  in_progress: "orange",
+  completed: "green",
+  cancelled: "red",
+  awaiting_reassignment: "orange",
+}
+
+export const MessageRunActionModal = ({
+  open,
+  onClose,
+  actionType,
+  message,
+  partnerId,
+  partnerName,
+  conversationId,
+  onRunCompleted,
+}: Props) => {
+  const [selectedRunId, setSelectedRunId] = useState<string>("")
+  const [noteText, setNoteText] = useState<string>("")
+  const [producedQty, setProducedQty] = useState<string>("")
+  const [rejectedQty, setRejectedQty] = useState<string>("")
+  const [rejectionReason, setRejectionReason] = useState<string>("")
+  const [rejectionNotes, setRejectionNotes] = useState<string>("")
+  const [costEstimate, setCostEstimate] = useState<string>("")
+  const [costType, setCostType] = useState<"per_unit" | "total">("total")
+  const [allowShortfall, setAllowShortfall] = useState(false)
+  const [sendSummary, setSendSummary] = useState(true)
+
+  // Fetch the partner's production runs — only non-terminal ones for
+  // activity_note and attach_media; for complete_run show in_progress ones.
+  const statusFilter = actionType === "complete_run" ? "in_progress" : undefined
+  const { production_runs = [], isPending: runsLoading } = useProductionRuns(
+    { partner_id: partnerId, limit: 50, ...(statusFilter ? { status: statusFilter } : {}) },
+    { enabled: !!partnerId && open }
+  )
+
+  const noteMutation = useAddRunActivityNote(selectedRunId, {
+    onSuccess: () => {
+      toast.success("Activity note added to run")
+      onClose()
+    },
+    onError: (err: any) => toast.error(err?.message || "Failed to add note"),
+  })
+
+  const completeMutation = useAdminCompleteRun(selectedRunId, {
+    onSuccess: ({ production_run }) => {
+      toast.success("Production run completed")
+      if (sendSummary) onRunCompleted?.(production_run)
+      onClose()
+    },
+    onError: (err: any) => toast.error(err?.message || "Failed to complete run"),
+  })
+
+  const attachMutation = useAttachMediaToRun(selectedRunId, {
+    onSuccess: () => {
+      toast.success("Media attached to run")
+      onClose()
+    },
+    onError: (err: any) => toast.error(err?.message || "Failed to attach media"),
+  })
+
+  // Reset form when a new message loads
+  useEffect(() => {
+    if (!message) return
+    setNoteText(message.content?.trim() ?? "")
+    setProducedQty("")
+    setRejectedQty("")
+    setRejectionReason("")
+    setRejectionNotes("")
+    setCostEstimate("")
+    setCostType("total")
+    setAllowShortfall(false)
+    setSendSummary(true)
+    setSelectedRunId("")
+  }, [message?.id, actionType])
+
+  const selectedRun = useMemo(
+    () => production_runs.find((r) => r.id === selectedRunId),
+    [production_runs, selectedRunId]
+  )
+
+  const title = actionType === "activity_note"
+    ? "Add to run activity log"
+    : actionType === "attach_media"
+    ? "Attach media to run"
+    : "Complete production run"
+
+  const isSubmitting =
+    noteMutation.isPending || completeMutation.isPending || attachMutation.isPending
+
+  const handleSubmit = (e: React.FormEvent) => {
+    e.preventDefault()
+    if (!message || !selectedRunId) {
+      toast.error("Select a production run")
+      return
+    }
+
+    if (actionType === "activity_note") {
+      if (!noteText.trim()) {
+        toast.error("Note text cannot be empty")
+        return
+      }
+      noteMutation.mutate({
+        summary: noteText.trim(),
+        message_id: message.id,
+        conversation_id: conversationId,
+        partner_id: partnerId,
+      })
+    } else if (actionType === "attach_media") {
+      if (!message.media_url) {
+        toast.error("This message has no media to attach")
+        return
+      }
+      attachMutation.mutate({
+        media_url: message.media_url,
+        media_mime_type: message.media_mime_type ?? undefined,
+        filename: (message.metadata as any)?.filename,
+        message_id: message.id,
+        conversation_id: conversationId,
+      })
+    } else if (actionType === "complete_run") {
+      const produced = producedQty ? Number(producedQty) : undefined
+      const rejected = rejectedQty ? Number(rejectedQty) : undefined
+      if (produced != null && (!Number.isFinite(produced) || produced < 0)) {
+        toast.error("Produced quantity must be a non-negative number")
+        return
+      }
+      if (rejected != null && (!Number.isFinite(rejected) || rejected < 0)) {
+        toast.error("Rejected quantity must be a non-negative number")
+        return
+      }
+      completeMutation.mutate({
+        produced_quantity: produced,
+        rejected_quantity: rejected,
+        rejection_reason: rejectionReason || undefined,
+        rejection_notes: rejectionNotes || undefined,
+        partner_cost_estimate: costEstimate ? Number(costEstimate) : undefined,
+        cost_type: costType,
+        notes: noteText.trim() || undefined,
+        allow_shortfall: allowShortfall,
+        from_message_id: message.id,
+        from_conversation_id: conversationId,
+      })
+    }
+  }
+
+  const messageHasMedia = !!message?.media_url
+  const isImage = !!(message?.media_mime_type ?? "").startsWith("image/")
+
+  return (
+    <FocusModal open={open} onOpenChange={(o) => !o && onClose()}>
+      <FocusModal.Content>
+        <FocusModal.Header>
+          <Text size="large" weight="plus">{title}</Text>
+        </FocusModal.Header>
+        <FocusModal.Body className="overflow-y-auto">
+          <form onSubmit={handleSubmit} className="mx-auto max-w-2xl py-8 px-6">
+            {/* Partner context */}
+            <div className="mb-6">
+              <Text size="small" className="text-ui-fg-subtle">For partner</Text>
+              <Text weight="plus">{partnerName}</Text>
+            </div>
+
+            {/* Source message preview */}
+            {message && (
+              <div className="mb-6 rounded-md border border-ui-border-base bg-ui-bg-subtle p-3">
+                <Text size="xsmall" className="text-ui-fg-muted mb-1">Source message</Text>
+                {messageHasMedia && isImage && (
+                  <a href={message.media_url!} target="_blank" rel="noopener noreferrer" className="block mb-2">
+                    <img
+                      src={message.media_url!}
+                      alt="attachment"
+                      className="max-h-40 rounded-md object-cover"
+                    />
+                  </a>
+                )}
+                {messageHasMedia && !isImage && (
+                  <Tooltip content="Open original">
+                    <a
+                      href={message.media_url!}
+                      target="_blank"
+                      rel="noopener noreferrer"
+                      className="text-ui-fg-interactive text-sm underline"
+                    >
+                      {message.media_url!.split("/").pop()}
+                    </a>
+                  </Tooltip>
+                )}
+                {message.content?.trim() && (
+                  <Text size="small" className="whitespace-pre-wrap break-words">
+                    {message.content}
+                  </Text>
+                )}
+              </div>
+            )}
+
+            {/* Run picker */}
+            <div className="mb-4">
+              <Label>
+                Production run{" "}
+                <Text size="xsmall" className="inline text-ui-fg-muted">
+                  — {actionType === "complete_run" ? "in-progress runs only" : "all non-cancelled runs"}
+                </Text>
+              </Label>
+              {runsLoading ? (
+                <div className="space-y-2 mt-2">
+                  <Skeleton className="h-10 w-full" />
+                  <Skeleton className="h-4 w-3/4" />
+                </div>
+              ) : production_runs.length === 0 ? (
+                <Text size="small" className="text-ui-fg-muted mt-2">
+                  No {actionType === "complete_run" ? "in-progress" : "open"} production runs found for this partner.
+                </Text>
+              ) : (
+                <Select
+                  value={selectedRunId}
+                  onValueChange={setSelectedRunId}
+                >
+                  <Select.Trigger>
+                    <Select.Value placeholder="Select a production run…" />
+                  </Select.Trigger>
+                  <Select.Content>
+                    {production_runs.map((run) => (
+                      <Select.Item key={run.id} value={run.id}>
+                        <div className="flex items-center gap-2">
+                          <Badge
+                            color={runStatusColors[run.status || ""] || "grey"}
+                            size="2xsmall"
+                          >
+                            {run.status?.replace(/_/g, " ")}
+                          </Badge>
+                          <span className="font-mono text-xs">{run.id.substring(0, 20)}…</span>
+                          {run.quantity && <span className="text-ui-fg-muted text-xs">×{run.quantity}</span>}
+                        </div>
+                      </Select.Item>
+                    ))}
+                  </Select.Content>
+                </Select>
+              )}
+            </div>
+
+            {/* Selected run summary */}
+            {selectedRun && (
+              <div className="mb-4 rounded-md border border-ui-border-base bg-ui-bg-base p-3">
+                <div className="flex items-center gap-2 mb-1">
+                  <Badge color={runStatusColors[selectedRun.status || ""] || "grey"} size="2xsmall">
+                    {selectedRun.status?.replace(/_/g, " ")}
+                  </Badge>
+                  <Text size="xsmall" className="text-ui-fg-muted">
+                    {selectedRun.run_type} · qty {selectedRun.quantity ?? "—"}
+                  </Text>
+                </div>
+                {selectedRun.produced_quantity != null && (
+                  <Text size="xsmall" className="text-ui-fg-muted">
+                    Produced: {selectedRun.produced_quantity}
+                    {selectedRun.rejected_quantity ? ` · Rejected: ${selectedRun.rejected_quantity}` : ""}
+                  </Text>
+                )}
+              </div>
+            )}
+
+            {/* Action-specific fields */}
+            {actionType === "activity_note" && (
+              <div className="mb-6">
+                <Label htmlFor="note-text">Activity note</Label>
+                <Textarea
+                  id="note-text"
+                  value={noteText}
+                  onChange={(e) => setNoteText(e.target.value)}
+                  rows={4}
+                  placeholder="Defaults to the message text — edit as needed."
+                />
+              </div>
+            )}
+
+            {actionType === "attach_media" && (
+              <div className="mb-6">
+                {!messageHasMedia ? (
+                  <Text size="small" className="text-ui-fg-muted">
+                    This message has no media attachment.
+                  </Text>
+                ) : (
+                  <Text size="small" className="text-ui-fg-muted">
+                    The media from this message will be attached to the selected run's metadata and recorded in its activity timeline.
+                  </Text>
+                )}
+              </div>
+            )}
+
+            {actionType === "complete_run" && (
+              <>
+                <div className="grid grid-cols-2 gap-4 mb-4">
+                  <div>
+                    <Label htmlFor="produced-qty">Produced quantity</Label>
+                    <Input
+                      id="produced-qty"
+                      type="number"
+                      min={0}
+                      value={producedQty}
+                      onChange={(e) => setProducedQty(e.target.value)}
+                      placeholder="e.g. 50"
+                    />
+                  </div>
+                  <div>
+                    <Label htmlFor="rejected-qty">Rejected quantity</Label>
+                    <Input
+                      id="rejected-qty"
+                      type="number"
+                      min={0}
+                      value={rejectedQty}
+                      onChange={(e) => setRejectedQty(e.target.value)}
+                      placeholder="e.g. 2"
+                    />
+                  </div>
+                </div>
+
+                <div className="grid grid-cols-2 gap-4 mb-4">
+                  <div>
+                    <Label htmlFor="rejection-reason">Rejection reason</Label>
+                    <Select
+                      value={rejectionReason}
+                      onValueChange={setRejectionReason}
+                    >
+                      <Select.Trigger>
+                        <Select.Value placeholder="—" />
+                      </Select.Trigger>
+                      <Select.Content>
+                        {REJECTION_REASONS.map((r) => (
+                          <Select.Item key={r.value} value={r.value}>
+                            {r.label}
+                          </Select.Item>
+                        ))}
+                      </Select.Content>
+                    </Select>
+                  </div>
+                  <div>
+                    <Label htmlFor="cost-estimate">Partner cost estimate</Label>
+                    <Input
+                      id="cost-estimate"
+                      type="number"
+                      min={0}
+                      value={costEstimate}
+                      onChange={(e) => setCostEstimate(e.target.value)}
+                      placeholder="e.g. 1500"
+                    />
+                  </div>
+                </div>
+
+                <div className="mb-4">
+                  <Label>Cost type</Label>
+                  <div className="flex items-center gap-4 mt-1">
+                    <label className="flex items-center gap-1.5 cursor-pointer">
+                      <input
+                        type="radio"
+                        name="cost-type"
+                        checked={costType === "total"}
+                        onChange={() => setCostType("total")}
+                      />
+                      <Text size="small">Total</Text>
+                    </label>
+                    <label className="flex items-center gap-1.5 cursor-pointer">
+                      <input
+                        type="radio"
+                        name="cost-type"
+                        checked={costType === "per_unit"}
+                        onChange={() => setCostType("per_unit")}
+                      />
+                      <Text size="small">Per unit</Text>
+                    </label>
+                  </div>
+                </div>
+
+                {rejectionReason && (
+                  <div className="mb-4">
+                    <Label htmlFor="rejection-notes">Rejection notes</Label>
+                    <Textarea
+                      id="rejection-notes"
+                      value={rejectionNotes}
+                      onChange={(e) => setRejectionNotes(e.target.value)}
+                      rows={2}
+                      placeholder="Describe the rejection…"
+                    />
+                  </div>
+                )}
+
+                <div className="mb-4">
+                  <Label htmlFor="completion-notes">Completion notes</Label>
+                  <Textarea
+                    id="completion-notes"
+                    value={noteText}
+                    onChange={(e) => setNoteText(e.target.value)}
+                    rows={3}
+                    placeholder="Defaults to the partner's message text — edit as needed."
+                  />
+                </div>
+
+                <div className="flex items-center gap-6 mb-4">
+                  <label className="flex items-center gap-2 cursor-pointer">
+                    <Switch
+                      checked={allowShortfall}
+                      onCheckedChange={setAllowShortfall}
+                    />
+                    <Text size="small">Allow shortfall</Text>
+                  </label>
+                  <label className="flex items-center gap-2 cursor-pointer">
+                    <Switch
+                      checked={sendSummary}
+                      onCheckedChange={setSendSummary}
+                    />
+                    <Text size="small">
+                      Send WhatsApp summary to partner
+                    </Text>
+                  </label>
+                </div>
+              </>
+            )}
+
+            <div className="flex justify-end gap-x-3">
+              <Button variant="secondary" onClick={onClose} type="button">
+                Cancel
+              </Button>
+              <Button
+                type="submit"
+                isLoading={isSubmitting}
+                disabled={isSubmitting || !selectedRunId}
+              >
+                {actionType === "activity_note" ? "Add note" : actionType === "attach_media" ? "Attach media" : "Complete run"}
+              </Button>
+            </div>
+          </form>
+        </FocusModal.Body>
+      </FocusModal.Content>
+    </FocusModal>
+  )
+}

--- a/apps/backend/src/admin/routes/messaging/components/message-thread.tsx
+++ b/apps/backend/src/admin/routes/messaging/components/message-thread.tsx
@@ -1,8 +1,8 @@
 import { useEffect, useRef } from "react"
-import { Text, Badge, IconButton, toast } from "@medusajs/ui"
+import { Text, Badge, IconButton, toast, Skeleton } from "@medusajs/ui"
 import { XMark } from "@medusajs/icons"
 import { useConversationMessages, useSendMessage } from "../../../hooks/api/messaging"
-import { MessageBubble } from "./message-bubble"
+import { MessageBubble, MessageBubbleSkeleton, type MessageAction } from "./message-bubble"
 import { MessageInput, type SendPayload } from "./message-input"
 
 export const MessageThread = ({
@@ -41,8 +41,18 @@ export const MessageThread = ({
 
   if (isPending) {
     return (
-      <div className="flex items-center justify-center h-full text-ui-fg-muted bg-ui-bg-subtle">
-        Loading messages...
+      <div className="flex flex-col h-full bg-ui-bg-subtle">
+        <div className="flex items-center justify-between px-6 py-3 border-b border-ui-border-base bg-ui-bg-base shrink-0">
+          <div className="space-y-2">
+            <Skeleton className="h-5 w-32" />
+            <Skeleton className="h-3 w-24" />
+          </div>
+          <Skeleton className="h-6 w-16" />
+        </div>
+        <div className="flex-1 overflow-hidden px-6 py-4">
+          <MessageBubbleSkeleton count={6} />
+        </div>
+        <Skeleton className="h-16 w-full shrink-0" />
       </div>
     )
   }
@@ -80,7 +90,14 @@ export const MessageThread = ({
         ) : (
           <div className="space-y-1 max-w-full">
             {messages.map((msg) => (
-              <MessageBubble key={msg.id} message={msg} />
+              <MessageBubble
+                key={msg.id}
+                message={msg}
+                onMessageAction={(action: MessageAction, _msg) => {
+                  // Legacy thread — actions not wired to modals here.
+                  // The route page ([conversationId]/page.tsx) is the full UI.
+                }}
+              />
             ))}
           </div>
         )}

--- a/apps/backend/src/api/admin/production-runs/[id]/activities/note/route.ts
+++ b/apps/backend/src/api/admin/production-runs/[id]/activities/note/route.ts
@@ -1,0 +1,77 @@
+import {
+  AuthenticatedMedusaRequest,
+  MedusaResponse,
+} from "@medusajs/framework/http"
+import { MedusaError } from "@medusajs/framework/utils"
+import { z } from "@medusajs/framework/zod"
+import { PRODUCTION_RUNS_MODULE } from "../../../../../../modules/production_runs"
+import type ProductionRunService from "../../../../../../modules/production_runs/service"
+
+const NoteBodySchema = z.object({
+  summary: z.string().min(1, "summary is required"),
+  message_id: z.string().optional(),
+  conversation_id: z.string().optional(),
+  partner_id: z.string().optional(),
+  payload: z.record(z.string(), z.any()).optional(),
+})
+
+/**
+ * POST /admin/production-runs/:id/activities/note
+ *
+ * Append a free-form note activity to a run's timeline. Designed for the
+ * WhatsApp messaging inbox — an admin reads a partner's message and logs it
+ * against the relevant run so the activity timeline reflects what the
+ * partner actually said (rather than only system-emitted lifecycle events).
+ *
+ * When `message_id` is supplied the activity is stamped with
+ * `channel: "whatsapp"` so the timeline can distinguish messages-originated
+ * notes from admin-typed ones.
+ */
+export const POST = async (
+  req: AuthenticatedMedusaRequest & { params: { id: string } },
+  res: MedusaResponse
+) => {
+  const runId = req.params.id
+  const service: ProductionRunService = req.scope.resolve(PRODUCTION_RUNS_MODULE)
+
+  const run = await service.retrieveProductionRun(runId).catch(() => null)
+  if (!run) {
+    throw new MedusaError(
+      MedusaError.Types.NOT_FOUND,
+      `Production run ${runId} not found`
+    )
+  }
+
+  const parsed = NoteBodySchema.safeParse(req.body)
+  if (!parsed.success) {
+    throw new MedusaError(
+      MedusaError.Types.INVALID_DATA,
+      parsed.error.issues.map((i) => i.message).join(", ")
+    )
+  }
+
+  const body = parsed.data
+
+  const activity = await service.createProductionRunActivities({
+    production_run_id: runId,
+    activity_type: "note",
+    kind: "whatsapp_message_logged",
+    actor_type: "admin",
+    actor_id: (req as any).auth_context?.actor_id ?? null,
+    partner_id: body.partner_id ?? (run as any).partner_id ?? null,
+    channel: body.message_id ? "whatsapp" : null,
+    message_id: body.message_id ?? null,
+    template_name: null,
+    recipient: null,
+    summary: body.summary,
+    payload: {
+      ...body.payload,
+      ...(body.message_id ? { message_id: body.message_id } : {}),
+      ...(body.conversation_id ? { conversation_id: body.conversation_id } : {}),
+      source: "messaging_inbox",
+    },
+    occurred_at: new Date(),
+  } as any)
+
+  res.status(201).json({ activity })
+}

--- a/apps/backend/src/api/admin/production-runs/[id]/attach-media/route.ts
+++ b/apps/backend/src/api/admin/production-runs/[id]/attach-media/route.ts
@@ -1,0 +1,118 @@
+import {
+  AuthenticatedMedusaRequest,
+  MedusaResponse,
+} from "@medusajs/framework/http"
+import { MedusaError } from "@medusajs/framework/utils"
+import { z } from "@medusajs/framework/zod"
+import { PRODUCTION_RUNS_MODULE } from "../../../../../modules/production_runs"
+import type ProductionRunService from "../../../../../modules/production_runs/service"
+
+const AttachMediaBodySchema = z.object({
+  media_url: z.string().url("media_url must be a valid URL"),
+  media_mime_type: z.string().optional(),
+  filename: z.string().optional(),
+  message_id: z.string().optional(),
+  conversation_id: z.string().optional(),
+})
+
+/**
+ * POST /admin/production-runs/:id/attach-media
+ *
+ * Attach a media file (image / video / document) from a WhatsApp message to
+ * a production run. The media URL and metadata are appended to
+ * `run.metadata.attached_media` so they survive alongside the run, and an
+ * activity note is written to the timeline so the attachment is auditable.
+ *
+ * This does NOT copy the file — it records the URL the messaging system
+ * already persisted when the inbound WhatsApp media was received.
+ */
+export const POST = async (
+  req: AuthenticatedMedusaRequest & { params: { id: string } },
+  res: MedusaResponse
+) => {
+  const runId = req.params.id
+  const service: ProductionRunService = req.scope.resolve(PRODUCTION_RUNS_MODULE)
+
+  const run = (await service.retrieveProductionRun(runId).catch(() => null)) as any
+  if (!run) {
+    throw new MedusaError(
+      MedusaError.Types.NOT_FOUND,
+      `Production run ${runId} not found`
+    )
+  }
+
+  if (run.status === "cancelled") {
+    throw new MedusaError(
+      MedusaError.Types.NOT_ALLOWED,
+      "Cannot attach media to a cancelled production run"
+    )
+  }
+
+  const parsed = AttachMediaBodySchema.safeParse(req.body)
+  if (!parsed.success) {
+    throw new MedusaError(
+      MedusaError.Types.INVALID_DATA,
+      parsed.error.issues.map((i) => i.message).join(", ")
+    )
+  }
+
+  const body = parsed.data
+
+  const existingMeta = (run.metadata as Record<string, any>) || {}
+  const existingMedia: any[] = Array.isArray(existingMeta.attached_media)
+    ? existingMeta.attached_media
+    : []
+
+  const attachment = {
+    url: body.media_url,
+    mime_type: body.media_mime_type ?? null,
+    filename: body.filename ?? null,
+    message_id: body.message_id ?? null,
+    conversation_id: body.conversation_id ?? null,
+    attached_by: "admin",
+    attached_at: new Date().toISOString(),
+  }
+
+  await service.updateProductionRuns({
+    id: runId,
+    metadata: {
+      ...existingMeta,
+      attached_media: [...existingMedia, attachment],
+    },
+  })
+
+  // Audit
+  try {
+    await service.createProductionRunActivities({
+      production_run_id: runId,
+      activity_type: "note",
+      kind: "media_attached",
+      actor_type: "admin",
+      actor_id: (req as any).auth_context?.actor_id ?? null,
+      partner_id: run.partner_id ?? null,
+      channel: body.message_id ? "whatsapp" : null,
+      message_id: body.message_id ?? null,
+      template_name: null,
+      recipient: null,
+      summary: `Media attached: ${body.filename || body.media_url.split("/").pop() || "file"}`,
+      payload: {
+        media_url: body.media_url,
+        media_mime_type: body.media_mime_type ?? null,
+        filename: body.filename ?? null,
+        from_message_id: body.message_id ?? null,
+        from_conversation_id: body.conversation_id ?? null,
+        source: "messaging_inbox",
+      },
+      occurred_at: new Date(),
+    } as any)
+  } catch {
+    // Best-effort
+  }
+
+  const updated = await service.retrieveProductionRun(runId)
+
+  res.status(200).json({
+    production_run: updated,
+    message: "Media attached to run",
+  })
+}

--- a/apps/backend/src/api/admin/production-runs/[id]/complete/route.ts
+++ b/apps/backend/src/api/admin/production-runs/[id]/complete/route.ts
@@ -6,7 +6,7 @@ import { MedusaError } from "@medusajs/framework/utils"
 import { z } from "@medusajs/framework/zod"
 import { PRODUCTION_RUNS_MODULE } from "../../../../../modules/production_runs"
 import type ProductionRunService from "../../../../../modules/production_runs/service"
-import { completeProductionRunWorkflow } from "../../../../../workflows/production-runs/complete-production-run"
+import { adminCompleteProductionRunWorkflow } from "../../../../../workflows/production-runs/admin-complete-production-run"
 
 const REJECTION_REASONS = [
   "stitching_defect",
@@ -40,15 +40,17 @@ const CompleteBodySchema = z.object({
  * is done, and the admin completes the run from that message without
  * leaving the conversation view.
  *
- * The completion workflow (`completeProductionRunWorkflow`) validates that
- * the calling partner owns the run and that the run is in a completable
- * state (`assertCanCompleteWork` — requires `in_progress` + `finished_at`).
- * In the WhatsApp-driven flow the partner may never have formally "finished"
- * the run through the partner app, so this route applies an admin override
- * first: if `started_at` / `finished_at` are missing they are stamped now
- * so the workflow's policy gate passes. The workflow then handles stocking,
- * task completion, design cost update, parent cascade and event emission
- * exactly as a partner-initiated completion would.
+ * The partner may never have formally accepted, started or finished the run
+ * in the partner app — they said the work was done in a message — so the run
+ * has to be brought to a completable state before
+ * `completeProductionRunWorkflow`'s policy gate will pass.
+ *
+ * That override is NOT done here. `adminCompleteProductionRunWorkflow` decides
+ * from the policy whether the run may be overridden at all BEFORE writing
+ * anything, applies the change in a compensatable step, and runs the real
+ * completion nested inside it — so a rejected completion leaves the run exactly
+ * as it was rather than permanently claiming it was started and finished.
+ * Doing it in this route meant a rejection was a corruption, not a no-op.
  */
 export const POST = async (
   req: AuthenticatedMedusaRequest & { params: { id: string } },
@@ -88,28 +90,10 @@ export const POST = async (
   }
 
   const body = parsed.data
-
-  // Admin override: stamp lifecycle timestamps the partner may have skipped
-  // so the workflow's policy gate (`assertCanCompleteWork`) passes. The
-  // partner told the admin via WhatsApp that the work is done — that IS the
-  // finish signal — so recording it now is faithful, not fabricated.
   const adminActorId = (req as any).auth_context?.actor_id ?? null
-  const now = new Date()
 
-  if (!run.started_at) {
-    await service.updateProductionRuns({ id: runId, started_at: now })
-  }
-  if (!run.finished_at) {
-    await service.updateProductionRuns({
-      id: runId,
-      finished_at: now,
-      finish_notes: body.notes
-        ? `Completed via WhatsApp — partner message: ${body.notes.substring(0, 200)}`
-        : "Completed via WhatsApp (admin override)",
-    })
-  }
-
-  // Use the run's partner_id — the workflow validates ownership.
+  // Use the run's partner_id — the workflow validates ownership. Checked
+  // before the workflow so a run with no partner is refused without a write.
   const partnerId = run.partner_id
   if (!partnerId) {
     throw new MedusaError(
@@ -118,7 +102,9 @@ export const POST = async (
     )
   }
 
-  const { result, errors } = await completeProductionRunWorkflow(req.scope).run({
+  const { result, errors } = await adminCompleteProductionRunWorkflow(
+    req.scope
+  ).run({
     input: {
       production_run_id: runId,
       partner_id: partnerId,
@@ -130,7 +116,9 @@ export const POST = async (
       cost_type: body.cost_type,
       allow_shortfall: body.allow_shortfall,
       notes: body.notes,
+      override_note: body.notes,
     },
+    throwOnError: false,
   })
 
   if (errors?.length) {

--- a/apps/backend/src/api/admin/production-runs/[id]/complete/route.ts
+++ b/apps/backend/src/api/admin/production-runs/[id]/complete/route.ts
@@ -1,0 +1,186 @@
+import {
+  AuthenticatedMedusaRequest,
+  MedusaResponse,
+} from "@medusajs/framework/http"
+import { MedusaError } from "@medusajs/framework/utils"
+import { z } from "@medusajs/framework/zod"
+import { PRODUCTION_RUNS_MODULE } from "../../../../../modules/production_runs"
+import type ProductionRunService from "../../../../../modules/production_runs/service"
+import { completeProductionRunWorkflow } from "../../../../../workflows/production-runs/complete-production-run"
+
+const REJECTION_REASONS = [
+  "stitching_defect",
+  "fabric_flaw",
+  "color_mismatch",
+  "sizing_error",
+  "print_defect",
+  "material_damage",
+  "quality_below_standard",
+  "other",
+] as const
+
+const CompleteBodySchema = z.object({
+  produced_quantity: z.number().min(0).optional(),
+  rejected_quantity: z.number().min(0).optional(),
+  rejection_reason: z.enum(REJECTION_REASONS).optional(),
+  rejection_notes: z.string().optional(),
+  partner_cost_estimate: z.number().positive().optional(),
+  cost_type: z.enum(["per_unit", "total"]).optional(),
+  notes: z.string().optional(),
+  allow_shortfall: z.boolean().optional(),
+  from_message_id: z.string().optional(),
+  from_conversation_id: z.string().optional(),
+})
+
+/**
+ * POST /admin/production-runs/:id/complete
+ *
+ * Admin-side completion of a production run, designed for the WhatsApp
+ * messaging inbox flow: the partner sends a free-form message saying work
+ * is done, and the admin completes the run from that message without
+ * leaving the conversation view.
+ *
+ * The completion workflow (`completeProductionRunWorkflow`) validates that
+ * the calling partner owns the run and that the run is in a completable
+ * state (`assertCanCompleteWork` — requires `in_progress` + `finished_at`).
+ * In the WhatsApp-driven flow the partner may never have formally "finished"
+ * the run through the partner app, so this route applies an admin override
+ * first: if `started_at` / `finished_at` are missing they are stamped now
+ * so the workflow's policy gate passes. The workflow then handles stocking,
+ * task completion, design cost update, parent cascade and event emission
+ * exactly as a partner-initiated completion would.
+ */
+export const POST = async (
+  req: AuthenticatedMedusaRequest & { params: { id: string } },
+  res: MedusaResponse
+) => {
+  const runId = req.params.id
+  const service: ProductionRunService = req.scope.resolve(PRODUCTION_RUNS_MODULE)
+
+  const run = (await service.retrieveProductionRun(runId).catch(() => null)) as any
+  if (!run) {
+    throw new MedusaError(
+      MedusaError.Types.NOT_FOUND,
+      `Production run ${runId} not found`
+    )
+  }
+
+  if (run.status === "cancelled") {
+    throw new MedusaError(
+      MedusaError.Types.NOT_ALLOWED,
+      "Cannot complete a cancelled production run"
+    )
+  }
+
+  if (run.status === "completed") {
+    return res.json({
+      production_run: run,
+      message: "Production run is already completed",
+    })
+  }
+
+  const parsed = CompleteBodySchema.safeParse(req.body)
+  if (!parsed.success) {
+    throw new MedusaError(
+      MedusaError.Types.INVALID_DATA,
+      parsed.error.issues.map((i) => i.message).join(", ")
+    )
+  }
+
+  const body = parsed.data
+
+  // Admin override: stamp lifecycle timestamps the partner may have skipped
+  // so the workflow's policy gate (`assertCanCompleteWork`) passes. The
+  // partner told the admin via WhatsApp that the work is done — that IS the
+  // finish signal — so recording it now is faithful, not fabricated.
+  const adminActorId = (req as any).auth_context?.actor_id ?? null
+  const now = new Date()
+
+  if (!run.started_at) {
+    await service.updateProductionRuns({ id: runId, started_at: now })
+  }
+  if (!run.finished_at) {
+    await service.updateProductionRuns({
+      id: runId,
+      finished_at: now,
+      finish_notes: body.notes
+        ? `Completed via WhatsApp — partner message: ${body.notes.substring(0, 200)}`
+        : "Completed via WhatsApp (admin override)",
+    })
+  }
+
+  // Use the run's partner_id — the workflow validates ownership.
+  const partnerId = run.partner_id
+  if (!partnerId) {
+    throw new MedusaError(
+      MedusaError.Types.INVALID_DATA,
+      "This production run has no assigned partner and cannot be completed"
+    )
+  }
+
+  const { result, errors } = await completeProductionRunWorkflow(req.scope).run({
+    input: {
+      production_run_id: runId,
+      partner_id: partnerId,
+      produced_quantity: body.produced_quantity,
+      rejected_quantity: body.rejected_quantity,
+      rejection_reason: body.rejection_reason,
+      rejection_notes: body.rejection_notes,
+      partner_cost_estimate: body.partner_cost_estimate,
+      cost_type: body.cost_type,
+      allow_shortfall: body.allow_shortfall,
+      notes: body.notes,
+    },
+  })
+
+  if (errors?.length) {
+    throw (
+      errors[0].error ||
+      new MedusaError(
+        MedusaError.Types.UNEXPECTED_STATE,
+        `Failed to complete production run: ${errors
+          .map((e: any) => e?.error?.message || String(e))
+          .join(", ")}`
+      )
+    )
+  }
+
+  const updated = await service.retrieveProductionRun(runId)
+
+  // Audit: record that this completion originated from a WhatsApp message.
+  try {
+    await service.createProductionRunActivities({
+      production_run_id: runId,
+      activity_type: "note",
+      kind: "completed_from_whatsapp",
+      actor_type: "admin",
+      actor_id: adminActorId,
+      partner_id: partnerId,
+      channel: body.from_message_id ? "whatsapp" : null,
+      message_id: body.from_message_id ?? null,
+      template_name: null,
+      recipient: null,
+      summary: body.notes
+        ? `Run completed from WhatsApp message: "${body.notes.substring(0, 120)}"`
+        : "Run completed from WhatsApp (admin)",
+      payload: {
+        from_message_id: body.from_message_id ?? null,
+        from_conversation_id: body.from_conversation_id ?? null,
+        produced_quantity: body.produced_quantity ?? null,
+        rejected_quantity: body.rejected_quantity ?? null,
+        source: "messaging_inbox",
+      },
+      occurred_at: new Date(),
+    } as any)
+  } catch {
+    // Best-effort — the completion itself already succeeded.
+  }
+
+  const loggedCount = (result as any)?.consumptions?.logged_ids?.length || 0
+
+  res.status(200).json({
+    production_run: updated,
+    consumptions_logged: loggedCount,
+    message: "Production run completed",
+  })
+}

--- a/apps/backend/src/workflows/production-runs/__tests__/admin-completion-override.unit.spec.ts
+++ b/apps/backend/src/workflows/production-runs/__tests__/admin-completion-override.unit.spec.ts
@@ -1,0 +1,171 @@
+/**
+ * The admin completion override — the decision that must happen BEFORE a write.
+ *
+ * #1358 shipped this the other way round: the route stamped `started_at` /
+ * `finished_at` / `finish_notes` and THEN called the completion workflow, whose
+ * policy gate rejects any status outside `complete_work_from` (prod:
+ * `["in_progress"]`). So a rejection was not a no-op — it left the run
+ * permanently claiming it had been started and finished at a moment it wasn't,
+ * pre-armed to slip past the `finished_at` gate on a later call. And because
+ * the status was never promoted, the feature's PRIMARY path (5 prod runs sat in
+ * `sent_to_partner` with a partner attached) took that corrupting branch every
+ * single time.
+ *
+ * These cases pin the decision itself: what may be overridden, what may not,
+ * and that a refusal names no write to perform.
+ */
+import {
+  evaluateAdminCompletionOverride,
+  type OverrideRunLike,
+} from "../admin-complete-production-run"
+
+/** Prod's effective policy (the merged config the service returns). */
+const PROD_POLICY = {
+  transitions: {
+    complete_work_from: ["in_progress"],
+    accept_from: ["sent_to_partner"],
+  },
+}
+
+const run = (over: Partial<OverrideRunLike> = {}): OverrideRunLike => ({
+  status: "sent_to_partner",
+  started_at: null,
+  finished_at: null,
+  ...over,
+})
+
+describe("evaluateAdminCompletionOverride", () => {
+  describe("the primary path — the partner never touched the app", () => {
+    it("allows a sent_to_partner run and asks for status + both stamps", () => {
+      const d = evaluateAdminCompletionOverride(run(), PROD_POLICY)
+
+      expect(d.ok).toBe(true)
+      expect(d).toMatchObject({
+        promote_status: true,
+        stamp_started_at: true,
+        stamp_finished_at: true,
+      })
+    })
+
+    it("does not promote a run that is already in_progress", () => {
+      const d = evaluateAdminCompletionOverride(
+        run({ status: "in_progress" }),
+        PROD_POLICY
+      )
+
+      expect(d).toMatchObject({ ok: true, promote_status: false })
+    })
+
+    it("leaves timestamps the partner DID record alone", () => {
+      const started = new Date("2026-08-01T10:00:00Z")
+      const d = evaluateAdminCompletionOverride(
+        run({ status: "in_progress", started_at: started }),
+        PROD_POLICY
+      )
+
+      expect(d).toMatchObject({
+        ok: true,
+        stamp_started_at: false,
+        stamp_finished_at: true,
+      })
+    })
+
+    it("reports nothing to do for a run already fully staged", () => {
+      const d = evaluateAdminCompletionOverride(
+        run({
+          status: "in_progress",
+          started_at: new Date(),
+          finished_at: new Date(),
+        }),
+        PROD_POLICY
+      )
+
+      expect(d).toMatchObject({
+        ok: true,
+        promote_status: false,
+        stamp_started_at: false,
+        stamp_finished_at: false,
+      })
+    })
+  })
+
+  describe("refusals — these must produce NO write", () => {
+    it.each([
+      ["draft"],
+      ["pending_review"],
+      ["approved"],
+      ["awaiting_reassignment"],
+    ])(
+      "refuses %s — the run was never in a partner's hands to attest about",
+      (status) => {
+        const d = evaluateAdminCompletionOverride(run({ status }), PROD_POLICY)
+
+        expect(d.ok).toBe(false)
+        if (d.ok) {
+          throw new Error("unreachable")
+        }
+        expect(d.reason).toContain(status)
+        // The refusal must not smuggle a plan back to the caller.
+        expect(d).not.toHaveProperty("stamp_finished_at")
+      }
+    )
+
+    it("refuses a cancelled run", () => {
+      const d = evaluateAdminCompletionOverride(
+        run({ status: "cancelled" }),
+        PROD_POLICY
+      )
+      expect(d).toMatchObject({ ok: false })
+    })
+
+    it("refuses an already-completed run", () => {
+      const d = evaluateAdminCompletionOverride(
+        run({ status: "completed" }),
+        PROD_POLICY
+      )
+      expect(d).toMatchObject({ ok: false })
+    })
+
+    it("refuses a missing run", () => {
+      expect(evaluateAdminCompletionOverride(null, PROD_POLICY)).toMatchObject({
+        ok: false,
+      })
+    })
+  })
+
+  describe("the policy is the authority, not this function", () => {
+    it("honours a widened complete_work_from", () => {
+      const d = evaluateAdminCompletionOverride(run({ status: "approved" }), {
+        transitions: {
+          complete_work_from: ["in_progress", "approved"],
+          accept_from: ["sent_to_partner"],
+        },
+      })
+
+      expect(d).toMatchObject({ ok: true, promote_status: false })
+    })
+
+    it("honours a narrowed accept_from — sent_to_partner stops being promotable", () => {
+      const d = evaluateAdminCompletionOverride(run(), {
+        transitions: {
+          complete_work_from: ["in_progress"],
+          accept_from: [],
+        },
+      })
+
+      expect(d).toMatchObject({ ok: false })
+    })
+
+    it("falls back to the documented defaults when the config is empty", () => {
+      // Prod's stored policy row is missing keys added after it was created —
+      // every read falls back per key, so an absent key must behave like prod.
+      expect(evaluateAdminCompletionOverride(run(), {})).toMatchObject({
+        ok: true,
+        promote_status: true,
+      })
+      expect(
+        evaluateAdminCompletionOverride(run({ status: "approved" }), null)
+      ).toMatchObject({ ok: false })
+    })
+  })
+})

--- a/apps/backend/src/workflows/production-runs/admin-complete-production-run.ts
+++ b/apps/backend/src/workflows/production-runs/admin-complete-production-run.ts
@@ -1,0 +1,265 @@
+/**
+ * Admin: complete a production run on the partner's behalf, from a message.
+ *
+ * Why this exists as its own workflow rather than a few writes in the route.
+ *
+ * `completeProductionRunWorkflow` gates on `assertCanCompleteWork`, which
+ * requires BOTH `status ∈ complete_work_from` (prod: `["in_progress"]`) and a
+ * `finished_at`. In the WhatsApp-driven flow the partner never formally
+ * accepted, started or finished the run in the partner app — they said so in a
+ * message — so the run is typically still `sent_to_partner` with no lifecycle
+ * timestamps at all. Something has to bring it to a completable state first.
+ *
+ * The order of operations IS the safety property here. Stamping the timestamps
+ * and then letting the gate run turns a rejection into a corruption: the run is
+ * left permanently claiming it was started and finished at a moment it wasn't,
+ * and is pre-armed to slip past the `finished_at` gate on some later call. So:
+ *
+ *   1. `evaluateAdminCompletionOverride` decides — from the policy, before any
+ *      write — whether this run may be overridden at all, and what the override
+ *      would have to change. It is PURE, so the decision is unit-testable
+ *      without a DB.
+ *   2. The override is applied in a step that captures the previous values and
+ *      restores them in its compensation.
+ *   3. `completeProductionRunWorkflow` runs as a nested step. If it throws for
+ *      any reason, the engine compensates step 2 and the run goes back to
+ *      exactly the state it was in.
+ *
+ * The promotable set is derived from the policy rather than hardcoded, for the
+ * same reason `partner-run-steps` defers to it: allowed transitions live in ONE
+ * place. A run may be overridden from a status that could legitimately reach
+ * `in_progress` in a single step (`accept_from`) or that is already completable
+ * (`complete_work_from`). Anything else — a draft, an unapproved run, one
+ * parked for reassignment — is refused with no write at all.
+ */
+import { MedusaError } from "@medusajs/framework/utils"
+import {
+  StepResponse,
+  WorkflowResponse,
+  createStep,
+  createWorkflow,
+} from "@medusajs/framework/workflows-sdk"
+
+import { PRODUCTION_RUNS_MODULE } from "../../modules/production_runs"
+import type ProductionRunService from "../../modules/production_runs/service"
+import { PRODUCTION_POLICY_MODULE } from "../../modules/production_policy"
+import type ProductionPolicyService from "../../modules/production_policy/service"
+import {
+  completeProductionRunWorkflow,
+  type CompleteProductionRunInput,
+} from "./complete-production-run"
+
+export type AdminCompleteProductionRunInput = CompleteProductionRunInput & {
+  /** Free-form partner message this completion was raised from, if any. */
+  override_note?: string
+}
+
+/** The run fields the override decision reads. */
+export type OverrideRunLike = {
+  status?: string | null
+  started_at?: Date | string | null
+  finished_at?: Date | string | null
+}
+
+export type AdminCompletionOverride =
+  | {
+      ok: true
+      /** Statuses considered completable, for messaging. */
+      promote_status: boolean
+      stamp_started_at: boolean
+      stamp_finished_at: boolean
+    }
+  | { ok: false; reason: string }
+
+const asArray = (value: unknown, fallback: string[]): string[] =>
+  Array.isArray(value) ? value.map((v) => String(v)) : fallback
+
+/**
+ * PURE: may an admin complete this run on the partner's behalf, and what would
+ * the override have to change? Exported for unit tests.
+ *
+ * Returns the plan rather than performing it, so the caller can refuse BEFORE
+ * touching the row. `{ ok: false }` must leave the run untouched.
+ */
+export const evaluateAdminCompletionOverride = (
+  run: OverrideRunLike | null | undefined,
+  policyConfig: Record<string, any> | null | undefined
+): AdminCompletionOverride => {
+  if (!run) {
+    return { ok: false, reason: "Production run not found" }
+  }
+
+  const status = String(run.status ?? "")
+
+  if (status === "cancelled") {
+    return { ok: false, reason: "Cannot complete a cancelled production run" }
+  }
+
+  if (status === "completed") {
+    return { ok: false, reason: "Production run is already completed" }
+  }
+
+  const transitions = (policyConfig?.transitions ?? {}) as Record<string, any>
+  const completable = asArray(transitions.complete_work_from, ["in_progress"])
+  const acceptable = asArray(transitions.accept_from, ["sent_to_partner"])
+
+  // A status the admin may promote: already completable, or one accept away
+  // from being so. Deliberately NOT "anything non-terminal" — an approved or
+  // draft run has never been in a partner's hands, so there is no partner
+  // message that could honestly attest the work is done.
+  const promotable = Array.from(new Set([...completable, ...acceptable]))
+
+  if (!promotable.includes(status)) {
+    return {
+      ok: false,
+      reason:
+        `A production run must be ${promotable.join(" or ")} for an admin to ` +
+        `complete it on the partner's behalf. Current status: ${status || "unknown"}`,
+    }
+  }
+
+  return {
+    ok: true,
+    promote_status: !completable.includes(status),
+    stamp_started_at: !run.started_at,
+    stamp_finished_at: !run.finished_at,
+  }
+}
+
+// ---------------------------------------------------------------------------
+// Step: apply the override (compensatable)
+// ---------------------------------------------------------------------------
+
+type OverrideStepInput = {
+  production_run_id: string
+  partner_id: string
+  override_note?: string
+}
+
+type OverrideRollback = {
+  id: string
+  status: any
+  started_at: Date | null
+  finished_at: Date | null
+  finish_notes: string | null
+}
+
+export const applyAdminCompletionOverrideStep = createStep(
+  "apply-admin-completion-override",
+  async (input: OverrideStepInput, { container }) => {
+    const productionRunService: ProductionRunService = container.resolve(
+      PRODUCTION_RUNS_MODULE
+    )
+    const productionPolicyService: ProductionPolicyService = container.resolve(
+      PRODUCTION_POLICY_MODULE
+    )
+
+    const run = (await productionRunService
+      .retrieveProductionRun(input.production_run_id)
+      .catch(() => null)) as any
+
+    if (!run) {
+      throw new MedusaError(
+        MedusaError.Types.NOT_FOUND,
+        `Production run ${input.production_run_id} not found`
+      )
+    }
+
+    const persistedPartnerId = run.partner_id ?? run.partnerId ?? null
+    if (!persistedPartnerId || persistedPartnerId !== input.partner_id) {
+      throw new MedusaError(
+        MedusaError.Types.NOT_FOUND,
+        `Production run ${input.production_run_id} not found for this partner`
+      )
+    }
+
+    const config = await productionPolicyService.getPolicyConfig()
+    const decision = evaluateAdminCompletionOverride(run, config)
+
+    // Refused BEFORE any write — this is the whole point of the step.
+    if (!decision.ok) {
+      throw new MedusaError(MedusaError.Types.NOT_ALLOWED, decision.reason)
+    }
+
+    if (
+      !decision.promote_status &&
+      !decision.stamp_started_at &&
+      !decision.stamp_finished_at
+    ) {
+      // Already completable on its own terms — nothing to override, and so
+      // nothing to compensate.
+      return new StepResponse({ applied: false }, null as OverrideRollback | null)
+    }
+
+    const rollback: OverrideRollback = {
+      id: run.id,
+      status: run.status,
+      started_at: run.started_at ?? null,
+      finished_at: run.finished_at ?? null,
+      finish_notes: run.finish_notes ?? null,
+    }
+
+    const now = new Date()
+    const update: Record<string, any> = { id: run.id }
+
+    if (decision.promote_status) {
+      update.status = "in_progress"
+      if (!run.accepted_at) {
+        update.accepted_at = now
+      }
+    }
+    if (decision.stamp_started_at) {
+      update.started_at = now
+    }
+    if (decision.stamp_finished_at) {
+      update.finished_at = now
+      update.finish_notes = input.override_note
+        ? `Completed via WhatsApp — partner message: ${input.override_note.substring(0, 200)}`
+        : "Completed via WhatsApp (admin override)"
+    }
+
+    await productionRunService.updateProductionRuns(update as any)
+
+    return new StepResponse({ applied: true }, rollback)
+  },
+  async (rollback: OverrideRollback | null | undefined, { container }) => {
+    if (!rollback) {
+      return
+    }
+
+    const productionRunService: ProductionRunService = container.resolve(
+      PRODUCTION_RUNS_MODULE
+    )
+
+    // Restore verbatim, nulls included — a stamp we added must come back OFF,
+    // not merely stay at whatever the failed completion left behind.
+    await productionRunService.updateProductionRuns({
+      id: rollback.id,
+      status: rollback.status,
+      started_at: rollback.started_at,
+      finished_at: rollback.finished_at,
+      finish_notes: rollback.finish_notes,
+    } as any)
+  }
+)
+
+// ---------------------------------------------------------------------------
+// Workflow
+// ---------------------------------------------------------------------------
+
+export const adminCompleteProductionRunWorkflow = createWorkflow(
+  "admin-complete-production-run",
+  function (input: AdminCompleteProductionRunInput) {
+    applyAdminCompletionOverrideStep({
+      production_run_id: input.production_run_id,
+      partner_id: input.partner_id,
+      override_note: input.override_note,
+    })
+
+    // Nested so that ANY failure inside the completion compensates the
+    // override above and puts the run back exactly as it was.
+    const completed = completeProductionRunWorkflow.runAsStep({ input })
+
+    return new WorkflowResponse(completed)
+  }
+)

--- a/apps/backend/workflow-schemas.json
+++ b/apps/backend/workflow-schemas.json
@@ -5408,6 +5408,20 @@
         "type": "object",
         "required": false,
         "placeholder": "{}"
+      },
+      {
+        "name": "status",
+        "type": "string",
+        "required": false,
+        "placeholder": "{{ $last.status }}",
+        "description": "The status the submission lands in. \"Pending\" (the default) is a partner saying \"pay me for this\". \"Draft\" is the system pre-filling one FOR the partner — see `require_design_status` — which they then review and submit."
+      },
+      {
+        "name": "require_design_status",
+        "type": "boolean",
+        "required": false,
+        "placeholder": "false",
+        "description": "The status the submission lands in. \"Pending\" (the default) is a partner saying \"pay me for this\". \"Draft\" is the system pre-filling one FOR the partner — see `require_design_status` — which they then review and submit. / status?: \"Draft\" | \"Pending\" /** Whether the design's own status must be Approved / Commerce_Ready. Default true: a partner submitting by hand is asserting the design work is finished, and the design status is the check on that assertion. The run-completion auto-draft passes false, because there the proof of finished work is the COMPLETED PRODUCTION RUN itself — and completion sets the design to Technical_Review, so a status check would reject every single auto-draft. Only the auto path may set this; the partner-facing route never does."
       }
     ],
     "source": "custom_ts",
@@ -5905,6 +5919,31 @@
     "source": "custom_ts",
     "sourceFile": "src/workflows/production-runs/accept-production-run.ts"
   },
+  "admin-complete-production-run": {
+    "fields": [
+      {
+        "name": "production_run_id",
+        "type": "id",
+        "required": true,
+        "placeholder": "{{ $last.production_run_id }}"
+      },
+      {
+        "name": "partner_id",
+        "type": "id",
+        "required": true,
+        "placeholder": "{{ $last.partner_id }}"
+      },
+      {
+        "name": "override_note",
+        "type": "string",
+        "required": false,
+        "placeholder": "{{ $last.override_note }}",
+        "description": "Admin: complete a production run on the partner's behalf, from a message. Why this exists as its own workflow rather than a few writes in the route. `completeProductionRunWorkflow` gates on `assertCanCompleteWork`, which requires BOTH `status ∈ complete_work_from` (prod: `[\"in_progress\"]`) and a `finished_at`. In the WhatsApp-driven flow the partner never formally accepted, started or finished the run in the partner app — they said so in a message — so the run is typically still `sent_to_partner` with no lifecycle timestamps at all. Something has to bring it to a completable state first. The order of operations IS the safety property here. Stamping the timestamps and then letting the gate run turns a rejection into a corruption: the run is left permanently claiming it was started and finished at a moment it wasn't, and is pre-armed to slip past the `finished_at` gate on some later call. So: 1. `evaluateAdminCompletionOverride` decides — from the policy, before any write — whether this run may be overridden at all, and what the override would have to change. It is PURE, so the decision is unit-testable without a DB. 2. The override is applied in a step that captures the previous values and restores them in its compensation. 3. `completeProductionRunWorkflow` runs as a nested step. If it throws for any reason, the engine compensates step 2 and the run goes back to exactly the state it was in. The promotable set is derived from the policy rather than hardcoded, for the same reason `partner-run-steps` defers to it: allowed transitions live in ONE place. A run may be overridden from a status that could legitimately reach `in_progress` in a single step (`accept_from`) or that is already completable (`complete_work_from`). Anything else — a draft, an unapproved run, one parked for reassignment — is refused with no write at all. / import { MedusaError } from \"@medusajs/framework/utils\" import { StepResponse, WorkflowResponse, createStep, createWorkflow, } from \"@medusajs/framework/workflows-sdk\" import { PRODUCTION_RUNS_MODULE } from \"../../modules/production_runs\" import type ProductionRunService from \"../../modules/production_runs/service\" import { PRODUCTION_POLICY_MODULE } from \"../../modules/production_policy\" import type ProductionPolicyService from \"../../modules/production_policy/service\" import { completeProductionRunWorkflow, type CompleteProductionRunInput, } from \"./complete-production-run\" export type AdminCompleteProductionRunInput = CompleteProductionRunInput & { /** Free-form partner message this completion was raised from, if any."
+      }
+    ],
+    "source": "custom_ts",
+    "sourceFile": "src/workflows/production-runs/admin-complete-production-run.ts"
+  },
   "approve-production-run": {
     "fields": [
       {
@@ -6176,7 +6215,8 @@
         "name": "partner_id",
         "type": "id",
         "required": true,
-        "placeholder": "{{ $last.partner_id }}"
+        "placeholder": "{{ $last.partner_id }}",
+        "description": "#1279 — a run parked in `awaiting_reassignment`. Unlike every other kind this one has NO partner (parking nulls `partner_id` and keeps `previous_partner_id` for audit), so it is not a nag — it is an admin escalation. It exists because parking used to be terminal in practice: the reminder flow read only `sent_to_partner`/`in_progress`, so the moment the cap parked a run, the machinery that parked it could no longer see it. Six runs sat that way until a human noticed, the oldest for 4.5 months. / | \"awaiting_reassignment\" export type EmitProductionRunReminderInput = { production_run_id: string /** Null only for `awaiting_reassignment` — a parked run has no partner."
       },
       {
         "name": "design_id",
@@ -6553,6 +6593,42 @@
     ],
     "source": "custom_ts",
     "sourceFile": "src/workflows/products/upsert-artisan-product-detail.ts"
+  },
+  "upsert-product-spec": {
+    "fields": [
+      {
+        "name": "name",
+        "type": "string",
+        "required": true,
+        "placeholder": "{{ $last.name }}"
+      },
+      {
+        "name": "hex_code",
+        "type": "string",
+        "required": false,
+        "placeholder": "{{ $last.hex_code }}"
+      },
+      {
+        "name": "usage_notes",
+        "type": "string",
+        "required": false,
+        "placeholder": "{{ $last.usage_notes }}"
+      },
+      {
+        "name": "order",
+        "type": "number",
+        "required": false,
+        "placeholder": "0"
+      },
+      {
+        "name": "available",
+        "type": "boolean",
+        "required": false,
+        "placeholder": "false"
+      }
+    ],
+    "source": "custom_ts",
+    "sourceFile": "src/workflows/products/upsert-product-spec.ts"
   },
   "create-raw-material": {
     "fields": [


### PR DESCRIPTION
## What

Turns the WhatsApp messaging inbox into a place where ops can act on a partner's message without leaving the conversation. Each inbound message now has a kebab menu with three production-run actions, plus the existing payment action.

### Per-message actions

1. **Add to run activity log** — logs the partner's message as a `note` activity on a chosen production run, stamped with `channel: "whatsapp"` and the `message_id` so the timeline reflects what the partner actually said (not just system lifecycle events).
2. **Attach media to run** — (only for messages with media) appends the media URL and metadata to `run.metadata.attached_media` and writes a `media_attached` activity note.
3. **Complete production run** — completes a run from the conversation with produced/rejected quantities, cost, rejection reason and completion notes prefilled from the message text. Optional **"Send WhatsApp summary"** toggle sends the partner a formatted summary back on closure.

### New admin API routes

- `POST /admin/production-runs/:id/activities/note`
- `POST /admin/production-runs/:id/attach-media`
- `POST /admin/production-runs/:id/complete` — admin-side completion. Stamps `started_at`/`finished_at` when missing (admin override for the WhatsApp-driven flow), then runs the existing `completeProductionRunWorkflow` with the run's `partner_id` so stocking, tasks, design cost and parent-run cascade all behave exactly as partner-driven completion.

### UI polish

- WhatsApp **template / interactive** message types get a distinguishing badge.
- **Skeleton loaders** replace plain "Loading messages…" text in the thread header, bubbles and input.
- `MessageRunActionModal` is a unified `FocusModal` with a run picker (status badges + quantity) and a selected-run summary card.
- `Share designs` data view continues to use `StackedFocusModal`.

## Files

**New**
- `apps/backend/src/admin/routes/messaging/components/message-run-action-modal.tsx`
- `apps/backend/src/api/admin/production-runs/[id]/activities/note/route.ts`
- `apps/backend/src/api/admin/production-runs/[id]/attach-media/route.ts`
- `apps/backend/src/api/admin/production-runs/[id]/complete/route.ts`

**Modified**
- `apps/backend/src/admin/hooks/api/production-runs.ts` — `useAddRunActivityNote`, `useAdminCompleteRun`, `useAttachMediaToRun` + payload types
- `apps/backend/src/admin/routes/messaging/components/message-bubble.tsx` — `onMessageAction` prop, new kebab items, template badges, `MessageBubbleSkeleton`
- `apps/backend/src/admin/routes/messaging/[conversationId]/page.tsx` — `activeAction` state, run action modal, WhatsApp summary on completion, skeleton loading
- `apps/backend/src/admin/routes/messaging/components/message-thread.tsx` — new props + skeleton loading

## Notes

- This branch intentionally excludes an unrelated `apps/storefront-starter` submodule bump and untracked docs/`opencode.json`.
- `npx tsc --noEmit` in `apps/backend`: no errors in the touched files (pre-existing errors in integration tests and social components are unchanged).