### PR TITLE
fix(crm): wind the CRM's clock — schedule the engagement sweep

### DIFF
--- a/apps/backend/src/jobs/__tests__/sweep-crm-engagement.unit.spec.ts
+++ b/apps/backend/src/jobs/__tests__/sweep-crm-engagement.unit.spec.ts
@@ -1,0 +1,131 @@
+import sweepCrmEngagement, { config } from "../sweep-crm-engagement"
+import { crmEngagementSweepJob } from "../../api/admin/ops/maintenance-jobs/crm-engagement-sweep-job"
+
+/**
+ * #1355 — the CRM's only clock, and it was never wound.
+ *
+ * `crm-engagement-sweep` is the sole emitter of `crm.follow_up_due`,
+ * `crm.contact_stalled`, `crm.contact_replied` and `crm.contact_opted_out`.
+ * With no schedule, not one of those events could ever fire, so every visual
+ * flow triggering on `crm.*` was inert — and inert in the worst way, looking
+ * exactly like a flow whose condition simply never matched. 230 leads were
+ * imported and `/admin/crm/activities` returned `count: 0`.
+ *
+ * These cases pin the properties that decide whether that can recur: it must
+ * fire on its own, it must apply rather than rehearse, it must not go quiet
+ * when it fails, and it must not be a divergent copy of the operator's
+ * on-demand job.
+ */
+
+const logger = () => ({
+  info: jest.fn(),
+  warn: jest.fn(),
+  error: jest.fn(),
+})
+
+const containerWith = (log = logger()) =>
+  ({ resolve: jest.fn().mockReturnValue(log) }) as any
+
+describe("sweep-crm-engagement (scheduled)", () => {
+  afterEach(() => jest.restoreAllMocks())
+
+  describe("it fires on its own", () => {
+    it("declares a schedule — an unscheduled sweep is the whole defect", () => {
+      expect(config.schedule).toBeTruthy()
+      // 5 cron fields.
+      expect(String(config.schedule).trim().split(/\s+/)).toHaveLength(5)
+    })
+
+    it("runs at most once a day — the states it finds are day-scale", () => {
+      const [minute, hour] = String(config.schedule).split(/\s+/)
+      expect(minute).not.toBe("*")
+      expect(hour).not.toBe("*")
+    })
+
+    it("is named, so it is identifiable in the scheduler", () => {
+      expect(config.name).toBe("sweep-crm-engagement")
+    })
+  })
+
+  describe("it applies, and it is the same job the operator runs", () => {
+    it("delegates to the registered maintenance job rather than a copy", async () => {
+      const run = jest
+        .spyOn(crmEngagementSweepJob, "run")
+        .mockResolvedValue({
+          job_id: "crm-engagement-sweep",
+          dry_run: false,
+          applied: true,
+          summary: "3 contacts transitioned",
+          changes: [],
+        })
+
+      await sweepCrmEngagement(containerWith())
+
+      expect(run).toHaveBeenCalledTimes(1)
+    })
+
+    it("applies — a scheduled dry run would emit nothing and look healthy", async () => {
+      const run = jest
+        .spyOn(crmEngagementSweepJob, "run")
+        .mockResolvedValue({
+          job_id: "crm-engagement-sweep",
+          dry_run: false,
+          applied: false,
+          summary: "no transitions",
+          changes: [],
+        })
+
+      await sweepCrmEngagement(containerWith())
+
+      expect(run.mock.calls[0][1]).toMatchObject({ dry_run: false })
+    })
+  })
+
+  describe("it does not fail quietly", () => {
+    it("logs the summary of a successful sweep", async () => {
+      jest.spyOn(crmEngagementSweepJob, "run").mockResolvedValue({
+        job_id: "crm-engagement-sweep",
+        dry_run: false,
+        applied: true,
+        summary: "4 contacts transitioned",
+        changes: [],
+      })
+      const log = logger()
+
+      await sweepCrmEngagement(containerWith(log))
+
+      expect(log.info).toHaveBeenCalledWith(
+        expect.stringContaining("4 contacts transitioned")
+      )
+    })
+
+    it("surfaces per-contact errors the job collected instead of threw", async () => {
+      jest.spyOn(crmEngagementSweepJob, "run").mockResolvedValue({
+        job_id: "crm-engagement-sweep",
+        dry_run: false,
+        applied: true,
+        summary: "1 contact transitioned",
+        changes: [],
+        errors: [{ id: "per_1", message: "boom" }],
+      })
+      const log = logger()
+
+      await sweepCrmEngagement(containerWith(log))
+
+      expect(log.warn).toHaveBeenCalledWith(expect.stringContaining("per_1"))
+    })
+
+    it("swallows a thrown sweep but records it as an error", async () => {
+      jest
+        .spyOn(crmEngagementSweepJob, "run")
+        .mockRejectedValue(new Error("CRM store locked"))
+      const log = logger()
+
+      // Must not reject — one bad night cannot take the scheduler down.
+      await expect(sweepCrmEngagement(containerWith(log))).resolves.toBeUndefined()
+      expect(log.error).toHaveBeenCalledWith(
+        expect.stringContaining("CRM store locked")
+      )
+    })
+  })
+})

--- a/apps/backend/src/jobs/sweep-crm-engagement.ts
+++ b/apps/backend/src/jobs/sweep-crm-engagement.ts
@@ -1,0 +1,69 @@
+import type { MedusaContainer } from "@medusajs/framework/types"
+import { ContainerRegistrationKeys } from "@medusajs/framework/utils"
+
+import { crmEngagementSweepJob } from "../api/admin/ops/maintenance-jobs/crm-engagement-sweep-job"
+
+/**
+ * The CRM's clock (#1355).
+ *
+ * `recordCrmActivity` recomputes a contact's engagement state whenever an
+ * activity arrives, so every transition DRIVEN BY SOMETHING HAPPENING already
+ * fires on its own. Two transitions are driven by time passing and nothing
+ * else — a follow-up coming due, and a contact going quiet long enough to count
+ * as stalled — and until this job runs, those are only ever discovered when
+ * somebody happens to open the record.
+ *
+ * That mattered more than it sounds. `crm-engagement-sweep` is the only emitter
+ * of `crm.follow_up_due` / `crm.contact_stalled` / `crm.contact_replied` /
+ * `crm.contact_opted_out`, and `visual-flow-event-trigger` routes those to any
+ * flow matching `crm.*`. With the job unscheduled, no CRM event could fire at
+ * all: every time-driven flow anyone builds is inert, silently, and looks like
+ * a flow that simply never matched. The 230 imported leads sat with
+ * `/admin/crm/activities` returning `count: 0`.
+ *
+ * The job body is the maintenance job itself rather than a copy of it, so the
+ * scheduled path and the operator's on-demand
+ * `run_maintenance_job("crm-engagement-sweep")` cannot drift apart. Emission is
+ * on TRANSITION only — see the job — so running daily does not re-notify a
+ * contact who has been sitting at `follow_up_due` for a week.
+ */
+export default async function sweepCrmEngagement(container: MedusaContainer) {
+  const logger: any = container.resolve(ContainerRegistrationKeys.LOGGER)
+
+  try {
+    const result = await crmEngagementSweepJob.run(container, {
+      dry_run: false,
+      params: {},
+    })
+
+    logger.info(`[crm-engagement-sweep] ${result.summary}`)
+
+    // Per-contact failures are collected rather than thrown, so surface them —
+    // otherwise a contact that fails every single night does so invisibly.
+    if (result.errors?.length) {
+      logger.warn(
+        `[crm-engagement-sweep] ${result.errors.length} contact(s) could not be swept: ` +
+          result.errors
+            .slice(0, 5)
+            .map((e) => `${e.id}: ${e.message}`)
+            .join("; ") +
+          (result.errors.length > 5 ? " …" : "")
+      )
+    }
+  } catch (e: any) {
+    // A thrown sweep must not take the scheduler down with it, but it must not
+    // pass quietly either — an absent signal read as "nothing to do" is exactly
+    // how this went unnoticed in the first place.
+    logger.error(`[crm-engagement-sweep] Sweep failed: ${e?.message}`)
+  }
+}
+
+export const config = {
+  name: "sweep-crm-engagement",
+  // Daily at 02:30 UTC (08:00 IST) — before the working day, so a follow-up
+  // falling due today is already surfaced when someone opens the pipeline.
+  // Daily is the right grain: the states it discovers are day-scale (a
+  // follow-up date, a contact gone quiet for N days), so sweeping hourly would
+  // do the same work 24 times to find the same transitions.
+  schedule: "30 2 * * *",
+}


### PR DESCRIPTION
## The defect

`crm-engagement-sweep` existed, was registered as a maintenance job, and had **never been scheduled**.

It is the *only* emitter of `crm.follow_up_due`, `crm.contact_stalled`, `crm.contact_replied` and `crm.contact_opted_out`, and `visual-flow-event-trigger` routes those to any flow matching `crm.*`. So no CRM event could fire at all — every time-driven flow anyone built was inert, and inert in the worst way: indistinguishable from a flow whose condition simply never matched.

`recordCrmActivity` already recomputes engagement when an activity arrives, so transitions driven by something *happening* were always fine. The two driven by **time passing** — a follow-up coming due, a contact going quiet — were discoverable only by someone opening the record. 230 leads were imported and `/admin/crm/activities` returns `count: 0`.

## The change

One scheduled job, `sweep-crm-engagement`, daily at **02:30 UTC (08:00 IST)** — before the working day, so a follow-up falling due today is already surfaced when someone opens the pipeline.

- **Daily, not hourly.** The states it finds are day-scale; hourly would repeat the same work 24 times to find the same transitions.
- **No re-notification.** Emission is on *transition* only (the job's own guard), so a contact sitting at `follow_up_due` for a week is not messaged every morning.
- **Delegates, does not copy.** The body calls `crmEngagementSweepJob.run` directly, so the scheduled path and the operator's on-demand `run_maintenance_job("crm-engagement-sweep")` cannot drift apart.
- **Fails loudly.** Per-contact errors the job collects (rather than throws) are logged as warnings; a thrown sweep is caught so it can't take the scheduler down, but is recorded as an error.

## Verification

8 unit cases on the properties that decide whether this recurs. Checked against two negative controls rather than assumed:

| control | result |
|---|---|
| schedule removed (the shipped state) | 1 case fails |
| scheduled run switched to `dry_run: true` — it would run nightly, emit nothing, and look perfectly healthy | 1 case fails |
| as committed | 8/8 pass |

`check:prod-build` green. CRM module confirmed registered in **both** `medusa-config.ts` and `medusa-config.prod.ts`.

## After merge

The schedule only starts on prod once the deploy lands. Verify by **probe**, not badge: `run_maintenance_job("crm-engagement-sweep", dry_run: true)` should report the transitions it would make, and `/admin/crm/activities` should stop being `count: 0` as flows begin acting.

Refs #1355

🤖 Generated with [Claude Code](https://claude.com/claude-code)