### PR TITLE
fix(storefront): a published spec could never reach the product page

### DIFF
--- a/apps/storefront/src/lib/data/product-spec.ts
+++ b/apps/storefront/src/lib/data/product-spec.ts
@@ -80,6 +80,27 @@ export type StoreProductSpecResponse = {
 }
 
 /**
+ * How long a cached spec may be stale.
+ *
+ * A spec is edited by a partner or an admin in another application entirely,
+ * and nothing in this storefront is told when that happens: the tag below is
+ * attached but NOTHING ANYWHERE revalidates it, and `getCacheTag` returns ""
+ * for a visitor with no `_medusa_cache_id` cookie, so for most traffic there is
+ * no tag to revalidate in the first place. Without a TTL, `force-cache` then
+ * means what it says — the first response is served until the next deploy.
+ *
+ * That is not hypothetical: every product currently resolves to `spec: null`,
+ * so the null is what gets pinned, and the first spec anyone publishes would
+ * never appear. It is the same shape as the theme cache that served stale
+ * storefront content until redeploy (#1338).
+ *
+ * Five minutes: a spec is edited rarely and read on every product page, so this
+ * is still a cache hit essentially always, while an edit lands on its own
+ * without anyone knowing to go and clear anything.
+ */
+const SPEC_CACHE_TTL_SECONDS = 300
+
+/**
  * A product's spec, by id or handle.
  *
  * Most products have none, and that is not an error — an absent spec resolves
@@ -91,6 +112,7 @@ export const getProductSpec = async (
 ): Promise<StoreProductSpecResponse> => {
   const next = {
     ...(await getCacheOptions(`product-spec-${idOrHandle}`)),
+    revalidate: SPEC_CACHE_TTL_SECONDS,
   }
 
   return sdk.client
@@ -98,7 +120,17 @@ export const getProductSpec = async (
       `/store/products/${encodeURIComponent(idOrHandle)}/spec`,
       { next, cache: "force-cache" }
     )
-    .catch(() => ({ spec: null, technique: null }))
+    .catch((e) => {
+      // A failed read must still render the page — the spec block is optional.
+      // But it must not be INDISTINGUISHABLE from "this product has no spec":
+      // that is how a 500 gets read as a design decision and nobody looks.
+      console.error(
+        `[product-spec] Could not load the spec for ${idOrHandle}: ${
+          e?.message ?? e
+        }`
+      )
+      return { spec: null, technique: null }
+    })
 }
 
 /**


### PR DESCRIPTION
Found while setting up the manual end-to-end test of the product spec on a real product page (#1351 / #1356 rollout tail). The spec would have been created in the admin and **still not appeared** — and for a reason that looks exactly like the feature not working.

## The defect

`getProductSpec` fetches with `cache: "force-cache"` and **no TTL**.

The cache tag it attaches is revalidated by **nothing, anywhere** (`grep` for `product-spec-` across both repos returns no writer), and `getCacheTag` returns `""` for any visitor without a `_medusa_cache_id` cookie — so for most traffic there is no tag to revalidate in the first place. `force-cache` then means exactly what it says: **the first response is served until the next deploy.**

Every product currently resolves to `spec: null`, so the **null** is what gets pinned. Publish a spec, get a 200 on save, reload the page, see nothing.

This is the same shape as the theme cache that served stale storefront content until redeploy (#1338): *a 200 on the write proves the write, never the effect.*

## The change

| | |
|---|---|
| **300s TTL** | An edit made in another application lands on its own. A spec is edited rarely and read on every product page, so this is still a cache hit essentially always — and it self-heals without anyone knowing to go clear something. |
| **The `.catch` stops lying** | It collapsed *any* failure into `{ spec: null }`. The page must still render (the block is optional), but a 500 must not be indistinguishable from "this product has no spec" — that is how a real failure gets read as a design decision and nobody looks. |

## Both surfaces

`apps/storefront-starter` carried the identical fetch and the identical bug. Ported byte-identically and verified with a `diff` — it ships as [nextjs-starter-medusa#10](https://github.com/Jaal-Yantra-Textiles/nextjs-starter-medusa/pull/10) and needs its **own Vercel redeploy**. The submodule pointer is deliberately *not* bumped here; that follows once #10 merges.

## Verifying this on prod (the discriminating test)

`GET /store/products/<handle>/spec` returning `spec: null` proves nothing on its own — the route returns early before touching the option tables, so it answers the same whether the schema is there or not. The sequence that *does* discriminate:

1. Create a spec on a real product in the admin.
2. `GET /store/products/<handle>/spec` on the backend directly — this is uncached, and a spec coming back with its `options` also proves the `product_spec_option` tables exist on prod.
3. Load the storefront product page. If step 2 shows the spec and the page does not, the cache was the cause — observed, not inferred.

Refs #1356, #1351

🤖 Generated with [Claude Code](https://claude.com/claude-code)