### PR TITLE
fix(product-spec): the editor made a blank row it could not save

### DIFF
--- a/apps/backend/src/admin/components/forms/product-spec/__tests__/clean-spec-options.unit.spec.ts
+++ b/apps/backend/src/admin/components/forms/product-spec/__tests__/clean-spec-options.unit.spec.ts
@@ -1,0 +1,126 @@
+import { cleanSpecOptionsForSave } from "../clean-spec-options"
+
+/**
+ * The live failure this fixes, reported from the admin UI:
+ *
+ *   Invalid request: Value for field 'options, 0, values, 0, label' too small,
+ *   expected at least: '1'
+ *
+ * The form's `emptyOption` is born with one blank value — deliberately, because
+ * the route rejects a group with none — and `handleSave` cleaned `colors` and
+ * `fields` but never `options`. So the form created a row that the form then
+ * could not save, and answered a partner in zod field paths.
+ */
+
+const group = (over: Record<string, any> = {}) => ({
+  key: "embroidery",
+  label: "Embroidery",
+  values: [{ label: "None" }, { label: "Paisley border" }],
+  ...over,
+})
+
+describe("cleanSpecOptionsForSave", () => {
+  describe("the reported failure", () => {
+    it("drops the blank value row the form seeds", () => {
+      const r = cleanSpecOptionsForSave([
+        group({ values: [{ label: "None" }, { label: "" }] }),
+      ])
+
+      expect(r.ok).toBe(true)
+      if (!r.ok) throw new Error("unreachable")
+      expect(r.options[0].values).toEqual([{ label: "None", note: null }])
+    })
+
+    it("drops a whole group nobody touched — key, label and value all blank", () => {
+      const r = cleanSpecOptionsForSave([
+        group(),
+        { key: "", label: "", values: [{ label: "" }] },
+      ])
+
+      expect(r.ok).toBe(true)
+      if (!r.ok) throw new Error("unreachable")
+      expect(r.options).toHaveLength(1)
+    })
+
+    it("treats whitespace as blank", () => {
+      const r = cleanSpecOptionsForSave([
+        { key: "   ", label: "  ", values: [{ label: "   " }] },
+      ])
+      expect(r).toEqual({ ok: true, options: [] })
+    })
+  })
+
+  describe("a named group with no choices is an ERROR, not noise", () => {
+    it("refuses, naming the group in prose rather than a field path", () => {
+      const r = cleanSpecOptionsForSave([
+        group({ label: "Border", values: [{ label: "" }] }),
+      ])
+
+      expect(r.ok).toBe(false)
+      if (r.ok) throw new Error("unreachable")
+      expect(r.error).toContain("Border")
+      expect(r.error).not.toMatch(/options,|too small|z\.|values, 0/)
+    })
+
+    it("falls back to the key, then to a position, when there is no label", () => {
+      const byKey = cleanSpecOptionsForSave([
+        { key: "border", label: "", values: [] },
+      ])
+      expect(byKey.ok).toBe(false)
+      if (byKey.ok) throw new Error("unreachable")
+      expect(byKey.error).toContain("border")
+    })
+
+    it("refuses a named group with no key, in words", () => {
+      const r = cleanSpecOptionsForSave([
+        group({ key: "", label: "Embroidery" }),
+      ])
+
+      expect(r.ok).toBe(false)
+      if (r.ok) throw new Error("unreachable")
+      expect(r.error).toContain("Embroidery")
+      expect(r.error).toContain("key")
+    })
+  })
+
+  describe("it does not damage a good payload", () => {
+    it("keeps a complete group intact", () => {
+      const r = cleanSpecOptionsForSave([group()])
+
+      expect(r.ok).toBe(true)
+      if (!r.ok) throw new Error("unreachable")
+      expect(r.options[0]).toMatchObject({
+        key: "embroidery",
+        label: "Embroidery",
+      })
+      expect(r.options[0].values).toHaveLength(2)
+    })
+
+    it("trims rather than rejecting padded input", () => {
+      const r = cleanSpecOptionsForSave([
+        { key: " embroidery ", label: " Embroidery ", values: [{ label: " None " }] },
+      ])
+
+      expect(r.ok).toBe(true)
+      if (!r.ok) throw new Error("unreachable")
+      expect(r.options[0]).toMatchObject({ key: "embroidery", label: "Embroidery" })
+      expect(r.options[0].values?.[0].label).toBe("None")
+    })
+
+    it("preserves fields the cleaner has no business touching", () => {
+      const r = cleanSpecOptionsForSave([
+        group({ required: true, order: 3, values: [{ label: "None", available: false, order: 2 }] }),
+      ])
+
+      expect(r.ok).toBe(true)
+      if (!r.ok) throw new Error("unreachable")
+      expect(r.options[0]).toMatchObject({ required: true, order: 3 })
+      expect(r.options[0].values?.[0]).toMatchObject({ available: false, order: 2 })
+    })
+
+    it("handles no options at all", () => {
+      expect(cleanSpecOptionsForSave(undefined)).toEqual({ ok: true, options: [] })
+      expect(cleanSpecOptionsForSave([])).toEqual({ ok: true, options: [] })
+    })
+  })
+})

--- a/apps/backend/src/admin/components/forms/product-spec/clean-spec-options.ts
+++ b/apps/backend/src/admin/components/forms/product-spec/clean-spec-options.ts
@@ -1,0 +1,99 @@
+/**
+ * Strip half-written option rows before a spec is saved.
+ *
+ * `handleSave` already cleaned `colors` and `fields` — "losing the whole save
+ * over a row the admin forgot about is worse than silently ignoring it". When
+ * option groups shipped they were the one collection that never got added to
+ * that list, and the form MAKES a blank row on its own: `emptyOption` is born
+ * with one empty value, deliberately, because the route rejects a group with
+ * none. So adding a group and saving without typing a choice produced
+ *
+ *   Invalid request: Value for field 'options, 0, values, 0, label' too small,
+ *   expected at least: '1'
+ *
+ * — a zod path shown to a partner, about a row the form itself created.
+ *
+ * Two different mistakes hide in there and they must not be treated alike:
+ *
+ *   - A group nobody touched is noise. Drop it, exactly like a blank colour.
+ *   - A group that WAS named but has no choices left is a real error — the
+ *     piece would be unorderable if the group is `required` — so say that in
+ *     words rather than letting the route answer in field paths.
+ */
+
+export type CleanableOptionValue = {
+  label?: string | null
+  note?: string | null
+  order?: number
+  available?: boolean
+}
+
+export type CleanableOption = {
+  key?: string | null
+  label?: string | null
+  help_text?: string | null
+  required?: boolean
+  order?: number
+  values?: CleanableOptionValue[] | null
+}
+
+export type CleanSpecOptionsResult<T extends CleanableOption> =
+  | { ok: true; options: T[] }
+  | { ok: false; error: string }
+
+/** What a group is called when it has no label — for a readable message. */
+const nameOf = (o: CleanableOption, index: number): string =>
+  o.label?.trim() || o.key?.trim() || `Choice ${index + 1}`
+
+/**
+ * PURE: the options to send, or the message to show instead.
+ *
+ * Trims every label, drops values with none, then drops groups that are
+ * entirely untouched. Anything left that cannot be saved is reported as prose.
+ */
+export const cleanSpecOptionsForSave = <T extends CleanableOption>(
+  options: T[] | null | undefined
+): CleanSpecOptionsResult<T> => {
+  const cleaned = (options ?? []).map((o) => ({
+    ...o,
+    key: o.key?.trim() ?? "",
+    label: o.label?.trim() ? o.label.trim() : null,
+    help_text: o.help_text?.trim() ? o.help_text.trim() : null,
+    values: (o.values ?? [])
+      .filter((v) => (v.label ?? "").trim().length > 0)
+      .map((v) => ({
+        ...v,
+        label: (v.label ?? "").trim(),
+        note: v.note?.trim() ? v.note.trim() : null,
+      })),
+  })) as T[]
+
+  // Untouched groups: no name of any kind AND no surviving choices. The blank
+  // row the form seeds on "add a choice" is exactly this.
+  const kept = cleaned.filter(
+    (o) =>
+      (o.key ?? "").length > 0 ||
+      (o.label ?? null) !== null ||
+      (o.values ?? []).length > 0
+  )
+
+  const noValues = kept.findIndex((o) => (o.values ?? []).length === 0)
+  if (noValues !== -1) {
+    const name = nameOf(kept[noValues], noValues)
+    return {
+      ok: false,
+      error: `"${name}" has no choices for the customer to pick from. Add at least one, or remove the group.`,
+    }
+  }
+
+  const noKey = kept.findIndex((o) => !(o.key ?? "").length)
+  if (noKey !== -1) {
+    const name = nameOf(kept[noKey], noKey)
+    return {
+      ok: false,
+      error: `"${name}" needs a key — a short internal name like "embroidery".`,
+    }
+  }
+
+  return { ok: true, options: kept }
+}

--- a/apps/backend/src/admin/components/forms/product-spec/product-spec-edit-form.tsx
+++ b/apps/backend/src/admin/components/forms/product-spec/product-spec-edit-form.tsx
@@ -1,4 +1,5 @@
 import { Button, Heading, Text, toast } from "@medusajs/ui"
+import { cleanSpecOptionsForSave } from "./clean-spec-options"
 import { useEffect, useState } from "react"
 import { useParams } from "react-router-dom"
 
@@ -84,12 +85,22 @@ export const ProductSpecEditForm = () => {
     // Drop half-written rows rather than sending them: the route rejects a
     // colour with no name, and losing the whole save over a row the admin
     // forgot about is worse than silently ignoring it.
+    // Options were the one collection this never cleaned, and the form SEEDS a
+    // blank value row by design — so adding a group and saving answered the
+    // partner with `options, 0, values, 0, label` about a row the form made.
+    const cleanedOptions = cleanSpecOptionsForSave(value.options)
+    if (!cleanedOptions.ok) {
+      toast.error(cleanedOptions.error)
+      return
+    }
+
     const payload: ProductSpecPayload = {
       ...value,
       weave_label: value.weave_label?.trim() ? value.weave_label.trim() : null,
       notes: value.notes?.trim() ? value.notes.trim() : null,
       colors: (value.colors ?? []).filter((c) => c.name.trim()),
       fields: (value.fields ?? []).filter((f) => (f.label ?? f.key).trim()),
+      options: cleanedOptions.options,
     }
 
     try {

--- a/apps/backend/src/modules/product-spec/__tests__/spec-mcp-tools.unit.spec.ts
+++ b/apps/backend/src/modules/product-spec/__tests__/spec-mcp-tools.unit.spec.ts
@@ -147,3 +147,49 @@ describe("production-spec MCP tools", () => {
     }
   })
 })
+
+/**
+ * #1348's lesson, applied to the option groups: an MCP row is a CONTRACT with
+ * the route validator behind it. Where the two disagree, the caller finds out
+ * by 400 — and the message is a zod field path.
+ *
+ * The live report that prompted this: the admin spec editor answered a partner
+ * with `Value for field 'options, 0, values, 0, label' too small, expected at
+ * least: '1'`. The form was fixed to stop sending blank rows, but a model
+ * calling `set_product_spec` could send exactly the same payload, and the tool
+ * schema said nothing about it — `label` was merely `required`, with no
+ * minLength. These cases pin the schema to the validator's actual limits.
+ */
+describe("set_product_spec options schema mirrors the route validator", () => {
+  const { PRODUCT_SPEC_TOOL_SCHEMA_PROPS = null } = require("../tool-schema") as any
+  const props =
+    PRODUCT_SPEC_TOOL_SCHEMA_PROPS ?? require("../tool-schema").productSpecSchemaProps()
+  const options = props.options
+  const group = options.items
+  const value = group.properties.values.items
+
+  it("bounds the option list the way the validator does (max 12)", () => {
+    expect(options.maxItems).toBe(12)
+  })
+
+  it("requires a non-empty value label — z.string().trim().min(1)", () => {
+    expect(value.properties.label.minLength).toBe(1)
+    expect(value.properties.label.maxLength).toBe(160)
+    expect(value.required).toContain("label")
+  })
+
+  it("requires a non-empty option key — z.string().trim().min(1).max(60)", () => {
+    expect(group.properties.key.minLength).toBe(1)
+    expect(group.properties.key.maxLength).toBe(60)
+    expect(group.required).toContain("key")
+  })
+
+  it("states that a group needs at least one value, and at most 40", () => {
+    expect(group.properties.values.minItems).toBe(1)
+    expect(group.properties.values.maxItems).toBe(40)
+  })
+
+  it("caps the group label at the validator's 120", () => {
+    expect(group.properties.label.maxLength).toBe(120)
+  })
+})

--- a/apps/backend/src/modules/product-spec/tool-schema.ts
+++ b/apps/backend/src/modules/product-spec/tool-schema.ts
@@ -99,6 +99,7 @@ export const productSpecSchemaProps = () => ({
   },
   options: {
     type: "array",
+    maxItems: 12,
     description:
       "Choices the CUSTOMER makes when ordering this made to order — embroidery, a border, a colour pattern. Distinct from `fields`, which are facts the partner states and the customer cannot change. Use these instead of product variants when the choice doesn't change what is kept in stock. REPLACES the stored options wholesale when passed — omit to leave alone, pass [] to delete all. Max 12.",
     items: {
@@ -106,10 +107,13 @@ export const productSpecSchemaProps = () => ({
       properties: {
         key: {
           type: "string",
+          minLength: 1,
+          maxLength: 60,
           description: "Option key, e.g. 'embroidery' (≤ 60 chars).",
         },
         label: {
           type: "string",
+          maxLength: 120,
           description: "What the customer sees, e.g. 'Embroidery' (≤ 120 chars).",
         },
         help_text: {
@@ -124,13 +128,23 @@ export const productSpecSchemaProps = () => ({
         order: { type: "integer", description: "Display order (0–999)." },
         values: {
           type: "array",
+          minItems: 1,
+          maxItems: 40,
           description:
             "The selectable values. At least 1, max 40 — a group with none is rejected.",
           items: {
             type: "object",
             properties: {
               label: {
+                // The validator is `z.string().trim().min(1)`. Stating that
+                // here as well is the point of the row: a caller that sends
+                // "" should be told by the schema, not by a 400 naming
+                // `options, 0, values, 0, label` — which is exactly what the
+                // spec editor did to a partner before the form learned to
+                // strip its own blank rows.
                 type: "string",
+                minLength: 1,
+                maxLength: 160,
                 description: "What the customer picks by (≤ 160 chars).",
               },
               note: {

--- a/apps/partner-ui/src/routes/products/product-spec/clean-spec-options.ts
+++ b/apps/partner-ui/src/routes/products/product-spec/clean-spec-options.ts
@@ -1,0 +1,99 @@
+/**
+ * Strip half-written option rows before a spec is saved.
+ *
+ * `handleSave` already cleaned `colors` and `fields` — "losing the whole save
+ * over a row the admin forgot about is worse than silently ignoring it". When
+ * option groups shipped they were the one collection that never got added to
+ * that list, and the form MAKES a blank row on its own: `emptyOption` is born
+ * with one empty value, deliberately, because the route rejects a group with
+ * none. So adding a group and saving without typing a choice produced
+ *
+ *   Invalid request: Value for field 'options, 0, values, 0, label' too small,
+ *   expected at least: '1'
+ *
+ * — a zod path shown to a partner, about a row the form itself created.
+ *
+ * Two different mistakes hide in there and they must not be treated alike:
+ *
+ *   - A group nobody touched is noise. Drop it, exactly like a blank colour.
+ *   - A group that WAS named but has no choices left is a real error — the
+ *     piece would be unorderable if the group is `required` — so say that in
+ *     words rather than letting the route answer in field paths.
+ */
+
+export type CleanableOptionValue = {
+  label?: string | null
+  note?: string | null
+  order?: number
+  available?: boolean
+}
+
+export type CleanableOption = {
+  key?: string | null
+  label?: string | null
+  help_text?: string | null
+  required?: boolean
+  order?: number
+  values?: CleanableOptionValue[] | null
+}
+
+export type CleanSpecOptionsResult<T extends CleanableOption> =
+  | { ok: true; options: T[] }
+  | { ok: false; error: string }
+
+/** What a group is called when it has no label — for a readable message. */
+const nameOf = (o: CleanableOption, index: number): string =>
+  o.label?.trim() || o.key?.trim() || `Choice ${index + 1}`
+
+/**
+ * PURE: the options to send, or the message to show instead.
+ *
+ * Trims every label, drops values with none, then drops groups that are
+ * entirely untouched. Anything left that cannot be saved is reported as prose.
+ */
+export const cleanSpecOptionsForSave = <T extends CleanableOption>(
+  options: T[] | null | undefined
+): CleanSpecOptionsResult<T> => {
+  const cleaned = (options ?? []).map((o) => ({
+    ...o,
+    key: o.key?.trim() ?? "",
+    label: o.label?.trim() ? o.label.trim() : null,
+    help_text: o.help_text?.trim() ? o.help_text.trim() : null,
+    values: (o.values ?? [])
+      .filter((v) => (v.label ?? "").trim().length > 0)
+      .map((v) => ({
+        ...v,
+        label: (v.label ?? "").trim(),
+        note: v.note?.trim() ? v.note.trim() : null,
+      })),
+  })) as T[]
+
+  // Untouched groups: no name of any kind AND no surviving choices. The blank
+  // row the form seeds on "add a choice" is exactly this.
+  const kept = cleaned.filter(
+    (o) =>
+      (o.key ?? "").length > 0 ||
+      (o.label ?? null) !== null ||
+      (o.values ?? []).length > 0
+  )
+
+  const noValues = kept.findIndex((o) => (o.values ?? []).length === 0)
+  if (noValues !== -1) {
+    const name = nameOf(kept[noValues], noValues)
+    return {
+      ok: false,
+      error: `"${name}" has no choices for the customer to pick from. Add at least one, or remove the group.`,
+    }
+  }
+
+  const noKey = kept.findIndex((o) => !(o.key ?? "").length)
+  if (noKey !== -1) {
+    const name = nameOf(kept[noKey], noKey)
+    return {
+      ok: false,
+      error: `"${name}" needs a key — a short internal name like "embroidery".`,
+    }
+  }
+
+  return { ok: true, options: kept }
+}

--- a/apps/partner-ui/src/routes/products/product-spec/product-spec.tsx
+++ b/apps/partner-ui/src/routes/products/product-spec/product-spec.tsx
@@ -1,4 +1,5 @@
 import { Button, Heading, Text, toast } from "@medusajs/ui"
+import { cleanSpecOptionsForSave } from "./clean-spec-options"
 import { useEffect, useState } from "react"
 import { useParams } from "react-router-dom"
 
@@ -93,12 +94,22 @@ const ProductSpecEditor = ({ id }: { id: string }) => {
     // Drop half-written rows rather than sending them: the route rejects a
     // colour with no name, and losing the whole save over an empty row the
     // partner forgot about is a worse outcome than silently ignoring it.
+    // Options were the one collection this never cleaned, and the form SEEDS a
+    // blank value row by design — so adding a group and saving answered the
+    // partner with `options, 0, values, 0, label` about a row the form made.
+    const cleanedOptions = cleanSpecOptionsForSave(value.options)
+    if (!cleanedOptions.ok) {
+      toast.error(cleanedOptions.error)
+      return
+    }
+
     const payload: ProductSpecPayload = {
       ...value,
       weave_label: value.weave_label?.trim() ? value.weave_label.trim() : null,
       notes: value.notes?.trim() ? value.notes.trim() : null,
       colors: (value.colors ?? []).filter((c) => c.name.trim()),
       fields: (value.fields ?? []).filter((f) => (f.label ?? f.key).trim()),
+      options: cleanedOptions.options,
     }
 
     try {


### PR DESCRIPTION
Reported live from the admin UI while creating an option group:

```
Invalid request: Value for field 'options, 0, values, 0, label'
too small, expected at least: '1'
```

## The defect

`emptyOption` is **born with one blank value** — deliberately, because the route rejects a group with none and "add a choice" is a step a partner can otherwise miss and be told about only on save.

But `handleSave` cleaned `colors` and `fields` and **never learned about `options`**. Its own comment states the principle it then didn't apply to the new collection:

> *Drop half-written rows rather than sending them: the route rejects a colour with no name, and losing the whole save over a row the admin forgot about is worse than silently ignoring it.*

So the form created a row that the form could not save, and answered a partner in zod field paths.

## The fix

`cleanSpecOptionsForSave` — pure, unit-tested — trims labels, drops values with none, and drops untouched groups, the same treatment colours and fields already had. It keeps two cases apart that must **not** be treated alike:

| case | treatment |
|---|---|
| A group nobody touched (no key, no label, no named values) | Noise — dropped, like a blank colour |
| A group that **was** named but has no choices left | A real mistake — the piece is unorderable if the group is `required` — so: `"Border" has no choices for the customer to pick from. Add at least one, or remove the group.` |

Ported **byte-identically** to the partner-ui editor, which had the same `handleSave` and the same gap (`diff`-verified — the two editors are identical by design).

## The MCP row had the same hole

The validator is `z.string().trim().min(1)`, but `set_product_spec`'s tool schema marked `label` only as `required` — **no `minLength`** — so a model could send `""` and get the identical 400, with the identical unreadable message.

Per #1348, *an MCP row is a contract with its validator*. The schema now states the validator's actual limits rather than describing them in prose:

- `minLength`/`maxLength` on the option key (1–60) and value label (1–160)
- `minItems: 1` / `maxItems: 40` on `values`
- `maxItems: 12` on the option list
- `maxLength: 120` on the group label

## Verification

- **10 new cases** on the cleaner, including the exact reported payload.
- **5 new cases** pinning the tool schema to the validator's limits, appended to the existing contract suite — **30/30 pass**, so the 25 that were already there are untouched.
- `check:prod-build` green; `tsc` clean in both `apps/backend` and `apps/partner-ui`.

Refs #1356, #1351

🤖 Generated with [Claude Code](https://claude.com/claude-code)