### PR TITLE
feat(admin): create a product into a partner's store, on the record

### DIFF
--- a/apps/backend/src/api/admin/mcp/lib/__tests__/create-product-for-partner.unit.spec.ts
+++ b/apps/backend/src/api/admin/mcp/lib/__tests__/create-product-for-partner.unit.spec.ts
@@ -1,0 +1,87 @@
+import { ADMIN_MCP_TOOLS } from "../registry"
+import { isSensitive } from "../../../../../lib/mcp-core"
+
+/**
+ * `create_product_for_partner` — an admin creating a product inside someone
+ * else's live shop.
+ *
+ * Two failure modes are worth pinning. The first is #1348's: `bodyParams` is
+ * the dispatcher's forward list, so any field the schema advertises but the
+ * list omits is silently STRIPPED — and here the droppable fields are
+ * `variants` and their prices, whose loss is invisible until a customer finds
+ * an unbuyable product on a partner's storefront. The second is authority: the
+ * route derives the sales channel from the store, and a caller that could pass
+ * its own would be able to create a product into one partner's store pointing
+ * at another's.
+ */
+const tool = ADMIN_MCP_TOOLS.find((t) => t.name === "create_product_for_partner")
+
+describe("create_product_for_partner", () => {
+  it("is registered", () => {
+    expect(tool).toBeTruthy()
+  })
+
+  it("targets the store-scoped route, not core /admin/products", () => {
+    // Core /admin/products binds no sales channel and seeds no inventory
+    // levels — the product is invisible and reads 0 stock everywhere.
+    expect(tool?.method).toBe("POST")
+    expect(tool?.path).toBe("/admin/stores/:id/products")
+    expect(tool?.pathParams).toEqual(["id"])
+  })
+
+  it("is a sensitive write — it publishes into someone else's business", () => {
+    expect(tool?.write).toBe(true)
+    expect(isSensitive(tool as any)).toBe(true)
+  })
+
+  describe("the forward list is a contract with the schema", () => {
+    const schemaProps = Object.keys(
+      (tool?.inputSchema as any)?.properties ?? {}
+    )
+    const forwarded = new Set(tool?.bodyParams ?? [])
+
+    it("forwards every field the schema advertises, minus the path param", () => {
+      const stripped = schemaProps
+        .filter((k) => !(tool?.pathParams ?? []).includes(k))
+        .filter((k) => !forwarded.has(k))
+
+      // A field here is one the tool INVITES a caller to send and then drops.
+      expect(stripped).toEqual([])
+    })
+
+    it("advertises every field it forwards — no invisible parameters", () => {
+      const undocumented = [...forwarded].filter(
+        (k) => !schemaProps.includes(k)
+      )
+      expect(undocumented).toEqual([])
+    })
+
+    it("carries variants and prices, the fields whose loss is invisible", () => {
+      expect(forwarded.has("variants")).toBe(true)
+      expect(forwarded.has("options")).toBe(true)
+      expect(forwarded.has("images")).toBe(true)
+    })
+
+    it("does NOT let a caller choose the sales channel", () => {
+      // The route derives it from the store. Accepting one would allow a
+      // product to be created into one partner's store while listing in
+      // another's channel.
+      expect(forwarded.has("sales_channels")).toBe(false)
+      expect(schemaProps).not.toContain("sales_channels")
+    })
+  })
+
+  it("requires the store and a title, and nothing else", () => {
+    expect((tool?.inputSchema as any)?.required).toEqual(["id", "title"])
+  })
+
+  it("points the caller at the spec tool next — the two are separate writes", () => {
+    // Made-to-order choices are spec option groups, not product options.
+    expect(tool?.nextSteps).toContain("set_product_spec")
+  })
+
+  it("says out loud that it records and announces the act", () => {
+    expect(tool?.sideEffects).toMatch(/ownership link|records/i)
+    expect(tool?.sideEffects).toContain("product.created_for_partner")
+  })
+})

--- a/apps/backend/src/api/admin/mcp/lib/registry.ts
+++ b/apps/backend/src/api/admin/mcp/lib/registry.ts
@@ -33,6 +33,36 @@ import {
   productSpecSchemaProps,
 } from "../../../../modules/product-spec/tool-schema"
 
+/**
+ * The FORWARD LIST for `create_product_for_partner`.
+ *
+ * `bodyParams` is what the dispatcher actually sends; a field the schema
+ * advertises but this omits is silently STRIPPED, and the caller gets a
+ * successful-looking create missing whatever it named (#1348). Variants and
+ * prices are exactly the fields whose loss is invisible until someone opens
+ * the storefront and finds an unbuyable product.
+ *
+ * `sales_channels` is deliberately ABSENT: the route derives it from the store,
+ * and letting a caller pass one would let a product be created into a partner's
+ * store while pointing somewhere else entirely.
+ */
+const PARTNER_PRODUCT_BODY_PARAMS = [
+  "title",
+  "handle",
+  "status",
+  "description",
+  "subtitle",
+  "thumbnail",
+  "images",
+  "options",
+  "variants",
+  "collection_id",
+  "type_id",
+  "categories",
+  "tags",
+  "metadata",
+]
+
 /** Admin tool definition. Alias of the shared core tool model. */
 export type AdminMcpToolDef = McpToolDef
 
@@ -541,6 +571,90 @@ export const ADMIN_MCP_TOOLS: AdminMcpToolDef[] = [
     ),
     sideEffects: "Creates a new product in 'draft' status unless status is set.",
     nextSteps: ["get_product", "update_product"],
+  },
+  {
+    // Creating a product for someone ELSE, into their live shop. Core
+    // `create_product` above wraps Medusa's `/admin/products`, which binds no
+    // sales channel and seeds no inventory levels — the product is invisible on
+    // every storefront and every variant reads 0 stock. Every store-scoped
+    // product route lived under `/partners/*` behind partner auth, so an admin
+    // had no way to do this at all.
+    name: "create_product_for_partner",
+    description:
+      "Create a product INSIDE a partner's store, on their behalf — binds it to the store's sales channel, seeds inventory levels and materialises FX prices, so it actually appears on their storefront. Use this instead of create_product whenever the product belongs in a partner shop; create_product makes a product that is in NO sales channel and therefore invisible. The act is recorded against the partner and announced to them. Sensitive: requires confirm:true.",
+    method: "POST",
+    path: "/admin/stores/:id/products",
+    pathParams: ["id"],
+    write: true,
+    // Sensitive because it publishes into someone else's business, not merely
+    // because it writes: the product lands on the partner's public storefront
+    // and is attributed to them.
+    sensitive: true,
+    bodyParams: PARTNER_PRODUCT_BODY_PARAMS,
+    inputSchema: obj(
+      {
+        id: STR("Store id to create the product in, e.g. 'store_...'. Get it from list_stores."),
+        title: STR("Product title (required)."),
+        handle: STR("URL handle. Derived from the title when omitted."),
+        status: STR("'draft' | 'proposed' | 'published' | 'rejected'. Defaults to draft — publish deliberately."),
+        description: STR("Product description."),
+        subtitle: STR("Optional subtitle."),
+        thumbnail: STR("Thumbnail URL."),
+        images: {
+          type: "array",
+          description: "Images as [{ url }].",
+          items: {
+            type: "object",
+            properties: { url: { type: "string" } },
+            required: ["url"],
+          },
+        },
+        options: {
+          type: "array",
+          description:
+            "PRODUCT options (the variant axes, e.g. Size). NOT the made-to-order choices — those are spec option groups, set with set_product_spec.",
+          items: {
+            type: "object",
+            properties: {
+              title: { type: "string" },
+              values: { type: "array", items: { type: "string" } },
+            },
+            required: ["title", "values"],
+          },
+        },
+        variants: {
+          type: "array",
+          description:
+            "Variants with prices, e.g. [{ title, options: { Size: 'M' }, prices: [{ amount, currency_code }] }]. A product with no variant cannot be bought.",
+          items: { type: "object", additionalProperties: true },
+        },
+        collection_id: STR("Optional collection id."),
+        type_id: STR("Optional product type id."),
+        categories: {
+          type: "array",
+          description: "Categories as [{ id }].",
+          items: {
+            type: "object",
+            properties: { id: { type: "string" } },
+            required: ["id"],
+          },
+        },
+        tags: {
+          type: "array",
+          description: "Tags as [{ id }].",
+          items: {
+            type: "object",
+            properties: { id: { type: "string" } },
+            required: ["id"],
+          },
+        },
+        metadata: { type: "object", description: "Optional key/value metadata." },
+      },
+      ["id", "title"]
+    ),
+    sideEffects:
+      "Creates the product in the partner's store bound to its default sales channel, seeds 0-quantity inventory levels at the store location, and fans out FX prices. Records who created it on the partner-product ownership link and emits product.created_for_partner so the partner can be told. Refuses if the store has no sales channel or no linked partner.",
+    nextSteps: ["set_product_spec", "get_product", "update_product"],
   },
   {
     name: "update_product",

--- a/apps/backend/src/api/admin/stores/[id]/products/__tests__/provenance.unit.spec.ts
+++ b/apps/backend/src/api/admin/stores/[id]/products/__tests__/provenance.unit.spec.ts
@@ -1,0 +1,165 @@
+import {
+  buildProductProvenance,
+  recordProductProvenance,
+  type ProductProvenanceInput,
+} from "../lib/provenance"
+
+/**
+ * An admin can now create a product straight into a partner's store, where it
+ * goes live on their public storefront. The thing that must not happen is a
+ * product appearing in someone's shop that they did not make, with no record of
+ * who put it there — so these cases pin the two properties that decide whether
+ * that record can be trusted: `created_on_behalf` is DERIVED rather than
+ * accepted from the caller, and the announcement fires for exactly the case
+ * that warrants it.
+ */
+
+const input = (over: Partial<ProductProvenanceInput> = {}): ProductProvenanceInput => ({
+  owner_partner_id: "partner_owner",
+  product_id: "prod_1",
+  store_id: "store_1",
+  actor_type: "admin",
+  actor_id: "user_admin",
+  source: "admin_store_products",
+  ...over,
+})
+
+describe("buildProductProvenance", () => {
+  it("marks an admin create as on-behalf", () => {
+    expect(buildProductProvenance(input())).toEqual({
+      created_by_actor_type: "admin",
+      created_by_actor_id: "user_admin",
+      created_on_behalf: true,
+      store_id: "store_1",
+      source: "admin_store_products",
+    })
+  })
+
+  it("does NOT mark a partner creating in their own store as on-behalf", () => {
+    const p = buildProductProvenance(
+      input({
+        actor_type: "partner",
+        actor_partner_id: "partner_owner",
+        actor_id: "padm_1",
+      })
+    )
+    expect(p.created_on_behalf).toBe(false)
+  })
+
+  it("marks a partner creating in ANOTHER partner's store as on-behalf", () => {
+    // A partner can serve another partner's store — see links/partner-order.ts.
+    const p = buildProductProvenance(
+      input({ actor_type: "partner", actor_partner_id: "partner_other" })
+    )
+    expect(p.created_on_behalf).toBe(true)
+  })
+
+  it("treats an UNKNOWN acting partner as on-behalf, not as the owner", () => {
+    // The unsafe default would be to assume the actor is the owner and record
+    // false — that is the value that makes an unattributed create look normal.
+    const p = buildProductProvenance(input({ actor_type: "partner" }))
+    expect(p.created_on_behalf).toBe(true)
+  })
+
+  it("cannot be told what to record — on_behalf is derived, not passed", () => {
+    const sneaky = { ...input(), created_on_behalf: false } as any
+    expect(buildProductProvenance(sneaky).created_on_behalf).toBe(true)
+  })
+
+  it("keeps a missing actor id as null rather than inventing one", () => {
+    expect(buildProductProvenance(input({ actor_id: null }))).toMatchObject({
+      created_by_actor_id: null,
+    })
+  })
+})
+
+describe("recordProductProvenance", () => {
+  const scopeWith = (over: { link?: any; bus?: any; log?: any } = {}) => {
+    const link = over.link ?? { create: jest.fn().mockResolvedValue(undefined) }
+    const bus = over.bus ?? { emit: jest.fn().mockResolvedValue(undefined) }
+    const log = over.log ?? { warn: jest.fn(), error: jest.fn(), info: jest.fn() }
+    const scope = {
+      resolve: jest.fn((key: string) => {
+        if (key === "link") return link
+        if (key === "event_bus") return bus
+        if (key === "logger") return log
+        return undefined
+      }),
+    }
+    return { scope, link, bus, log }
+  }
+
+  it("writes the provenance columns onto the ownership link", async () => {
+    const { scope, link } = scopeWith()
+
+    await recordProductProvenance(scope, input())
+
+    const payload = link.create.mock.calls[0][0]
+    expect(payload.data).toMatchObject({
+      created_by_actor_type: "admin",
+      created_on_behalf: true,
+      store_id: "store_1",
+      source: "admin_store_products",
+    })
+    expect(payload.partner).toEqual({ partner_id: "partner_owner" })
+  })
+
+  it("announces an on-behalf create so the partner can be told", async () => {
+    const { scope, bus } = scopeWith()
+
+    const out = await recordProductProvenance(scope, input())
+
+    expect(out).toEqual({ linked: true, announced: true })
+    expect(bus.emit).toHaveBeenCalledWith(
+      expect.objectContaining({ name: "product.created_for_partner" })
+    )
+  })
+
+  it("stays quiet when a partner creates their own product", async () => {
+    const { scope, bus } = scopeWith()
+
+    const out = await recordProductProvenance(
+      scope,
+      input({ actor_type: "partner", actor_partner_id: "partner_owner" })
+    )
+
+    expect(bus.emit).not.toHaveBeenCalled()
+    expect(out.announced).toBe(false)
+  })
+
+  describe("a failed audit is reported, never swallowed", () => {
+    it("does not throw when the link write fails — the product already exists", async () => {
+      const { scope, log } = scopeWith({
+        link: { create: jest.fn().mockRejectedValue(new Error("link down")) },
+      })
+
+      const out = await recordProductProvenance(scope, input())
+
+      expect(out.linked).toBe(false)
+      expect(log.warn).toHaveBeenCalledWith(expect.stringContaining("link down"))
+    })
+
+    it("still announces even if the link write failed", async () => {
+      // The partner learning about it does not depend on our bookkeeping.
+      const { scope, bus } = scopeWith({
+        link: { create: jest.fn().mockRejectedValue(new Error("nope")) },
+      })
+
+      const out = await recordProductProvenance(scope, input())
+
+      expect(bus.emit).toHaveBeenCalled()
+      expect(out).toEqual({ linked: false, announced: true })
+    })
+
+    it("does not throw when the announcement fails, and says so", async () => {
+      const { scope, log } = scopeWith({
+        bus: { emit: jest.fn().mockRejectedValue(new Error("bus down")) },
+      })
+
+      const out = await recordProductProvenance(scope, input())
+
+      expect(out).toEqual({ linked: true, announced: false })
+      expect(log.warn).toHaveBeenCalledWith(expect.stringContaining("bus down"))
+    })
+  })
+})

--- a/apps/backend/src/api/admin/stores/[id]/products/lib/provenance.ts
+++ b/apps/backend/src/api/admin/stores/[id]/products/lib/provenance.ts
@@ -1,0 +1,132 @@
+import { ContainerRegistrationKeys, Modules } from "@medusajs/framework/utils"
+
+import { PARTNER_MODULE } from "../../../../../../modules/partner"
+
+/**
+ * Who created a product into a partner's store, and on whose behalf.
+ *
+ * An admin can create a product directly into a partner's shop, where it goes
+ * live on their public storefront. A product the owner did not make must not
+ * have to be reconstructed later from a timestamp and a guess, so the fact is
+ * written onto the ownership link itself (`links/partner-product.ts`) rather
+ * than into product `metadata`, which is a shared junk drawer any writer may
+ * overwrite.
+ */
+
+export type ProductProvenanceInput = {
+  /** Partner who OWNS the product — the store's partner. */
+  owner_partner_id: string
+  product_id: string
+  store_id: string
+  actor_type: "admin" | "partner"
+  actor_id?: string | null
+  source: string
+  /**
+   * When a partner acts, the partner id behind the actor. Lets the builder
+   * decide on-behalf-ness by comparing owner to actor rather than trusting
+   * the caller to have worked it out.
+   */
+  actor_partner_id?: string | null
+}
+
+export type ProductProvenanceColumns = {
+  created_by_actor_type: string
+  created_by_actor_id: string | null
+  created_on_behalf: boolean
+  store_id: string
+  source: string
+}
+
+/**
+ * PURE: the provenance columns for one create. Exported for unit tests.
+ *
+ * `created_on_behalf` is DERIVED, never passed in. An admin acting on a
+ * partner's store is always on-behalf; a partner acting on their own store
+ * never is; a partner acting on someone else's store (a partner can serve
+ * another partner's store — see links/partner-order.ts) is. Deriving it means
+ * a caller cannot record a convenient answer, and the flag stays trustworthy
+ * for the readers that branch on it.
+ */
+export const buildProductProvenance = (
+  input: ProductProvenanceInput
+): ProductProvenanceColumns => {
+  const onBehalf =
+    input.actor_type === "admin"
+      ? true
+      : // A partner actor is only "themselves" when the acting partner IS the
+        // owner. An unknown acting partner cannot be assumed to be the owner.
+        input.actor_partner_id !== input.owner_partner_id
+
+  return {
+    created_by_actor_type: input.actor_type,
+    created_by_actor_id: input.actor_id ?? null,
+    created_on_behalf: onBehalf,
+    store_id: input.store_id,
+    source: input.source,
+  }
+}
+
+/**
+ * Write the ownership link carrying its provenance, then announce it.
+ *
+ * The event is not decoration. A product appearing in someone's live shop that
+ * they did not create should not be silent — `product.created_for_partner` is
+ * the seam a visual flow uses to tell them (same pattern as
+ * `partner_product.proposed`). Kept off the generic product firehose so flows
+ * wake only on this.
+ *
+ * Never throws: the product already exists by this point, and losing the audit
+ * row must not unwind a successful create. It DOES report failures — an audit
+ * that fails silently is worse than none, because it reads as "nobody did this
+ * on anyone's behalf".
+ */
+export const recordProductProvenance = async (
+  scope: any,
+  input: ProductProvenanceInput
+): Promise<{ linked: boolean; announced: boolean }> => {
+  const logger: any = scope.resolve(ContainerRegistrationKeys.LOGGER)
+  const columns = buildProductProvenance(input)
+
+  let linked = false
+  try {
+    const remoteLink = scope.resolve(ContainerRegistrationKeys.LINK) as any
+    await remoteLink.create({
+      [PARTNER_MODULE]: { partner_id: input.owner_partner_id },
+      [Modules.PRODUCT]: { product_id: input.product_id },
+      data: columns,
+    })
+    linked = true
+  } catch (e: any) {
+    logger?.warn?.(
+      `[product-provenance] Could not link product ${input.product_id} to partner ${input.owner_partner_id}: ${e?.message ?? e}`
+    )
+  }
+
+  let announced = false
+  // Only announce the case worth announcing. A partner creating their own
+  // product needs no notification about it.
+  if (columns.created_on_behalf) {
+    try {
+      const eventBus = scope.resolve(Modules.EVENT_BUS) as any
+      await eventBus.emit({
+        name: "product.created_for_partner",
+        data: {
+          id: input.product_id,
+          product_id: input.product_id,
+          partner_id: input.owner_partner_id,
+          store_id: input.store_id,
+          actor_type: columns.created_by_actor_type,
+          actor_id: columns.created_by_actor_id,
+          source: columns.source,
+        },
+      })
+      announced = true
+    } catch (e: any) {
+      logger?.warn?.(
+        `[product-provenance] Could not announce product ${input.product_id} to partner ${input.owner_partner_id}: ${e?.message ?? e}`
+      )
+    }
+  }
+
+  return { linked, announced }
+}

--- a/apps/backend/src/api/admin/stores/[id]/products/route.ts
+++ b/apps/backend/src/api/admin/stores/[id]/products/route.ts
@@ -1,0 +1,130 @@
+import {
+  AuthenticatedMedusaRequest,
+  MedusaResponse,
+} from "@medusajs/framework/http"
+import {
+  ContainerRegistrationKeys,
+  MedusaError,
+  Modules,
+} from "@medusajs/framework/utils"
+import { createProductsWorkflow } from "@medusajs/medusa/core-flows"
+
+import { PARTNER_MODULE } from "../../../../../modules/partner"
+import { ensureInventoryLevelsForVariants } from "../../../../partners/helpers"
+import { fanoutVariantPrices } from "../../../../../workflows/fx/fanout-variant-prices"
+import { recordProductProvenance } from "./lib/provenance"
+
+/**
+ * POST /admin/stores/:id/products
+ *
+ * Create a product INTO a partner's store, as an admin, on their behalf.
+ *
+ * Why this route exists: core `POST /admin/products` creates a product that
+ * belongs to no sales channel, so it is invisible on every storefront, and it
+ * seeds no inventory levels, so every variant reads 0 stock everywhere and the
+ * partner-ui inventory page 404s on it. Every store-scoped product route lived
+ * under `/partners/*` and required partner auth, so an admin had no way to put
+ * a product into a partner's shop at all — support could not do it, and the
+ * admin assistant could not either.
+ *
+ * This mirrors `POST /partners/stores/:id/products` step for step (sales
+ * channel injection, inventory levels, FX price fanout) with two differences:
+ * the actor is an admin rather than the store's owner, and the act is
+ * RECORDED. A product landing on someone's live storefront that they did not
+ * create must be attributable and must not be silent — see `lib/provenance.ts`.
+ *
+ * Deliberately NOT applying the `core_channel_listing` proposal override: that
+ * gate exists to make an artisan's product wait for admin review, and an admin
+ * is already the reviewer. Forcing `proposed` here would mean an admin creating
+ * a product and then having to approve their own work.
+ */
+export const POST = async (
+  req: AuthenticatedMedusaRequest & { params: { id: string } },
+  res: MedusaResponse
+) => {
+  const storeId = req.params.id
+  const query: any = req.scope.resolve(ContainerRegistrationKeys.QUERY)
+
+  const storeService: any = req.scope.resolve(Modules.STORE)
+  const [store] = await storeService.listStores({ id: storeId })
+  if (!store) {
+    throw new MedusaError(
+      MedusaError.Types.NOT_FOUND,
+      `Store ${storeId} not found`
+    )
+  }
+
+  // Without a sales channel the product exists and is invisible — a silent
+  // half-success, so refuse instead.
+  if (!store.default_sales_channel_id) {
+    throw new MedusaError(
+      MedusaError.Types.INVALID_DATA,
+      `Store ${storeId} has no default sales channel configured, so a product created in it would not appear on any storefront`
+    )
+  }
+
+  // The owning partner is what makes this "on behalf of" someone rather than
+  // just an admin write. Resolved BEFORE the create: a product we could not
+  // attribute is exactly what this route exists to prevent, so refuse rather
+  // than create an unattributable product in someone's shop.
+  const { data: partnerRows } = await query.graph({
+    entity: "partner",
+    fields: ["id", "name"],
+    filters: { stores: { id: storeId } },
+  })
+  const ownerPartner = partnerRows?.[0]
+  if (!ownerPartner?.id) {
+    throw new MedusaError(
+      MedusaError.Types.INVALID_DATA,
+      `Store ${storeId} is not linked to a partner, so a product created in it could not be attributed to an owner`
+    )
+  }
+
+  const body = { ...((req.body as Record<string, any>) || {}) }
+  if (!body.title) {
+    throw new MedusaError(
+      MedusaError.Types.INVALID_DATA,
+      "title is required to create a product"
+    )
+  }
+
+  body.sales_channels = [{ id: store.default_sales_channel_id }]
+
+  const { result } = await createProductsWorkflow(req.scope).run({
+    input: { products: [body] as any },
+  })
+
+  const product = result?.[0]
+
+  // Ownership + provenance + the partner-facing announcement. Never throws;
+  // returns what it managed so the response can be honest about it.
+  const provenance = await recordProductProvenance(req.scope, {
+    owner_partner_id: ownerPartner.id,
+    product_id: product?.id,
+    store_id: store.id,
+    actor_type: "admin",
+    actor_id: req.auth_context?.actor_id ?? null,
+    source: "admin_store_products",
+  })
+
+  // Without location levels the variant reads 0 stock everywhere and
+  // partner-ui 404s on the item. Idempotent + never throws.
+  const variantIds = (product?.variants || []).map((v: any) => v.id)
+  await ensureInventoryLevelsForVariants(req.scope, store, variantIds)
+
+  // Materialise auto-converted prices in the store's other supported
+  // currencies, or the product reads "not available" outside its native
+  // region. Idempotent + never throws.
+  await fanoutVariantPrices(req.scope, { storeId: store.id, variantIds })
+
+  res.status(201).json({
+    product,
+    partner_id: ownerPartner.id,
+    store_id: store.id,
+    created_on_behalf: true,
+    // Surfaced rather than swallowed: if the audit link or the partner
+    // announcement failed, the caller should know the product exists WITHOUT
+    // its provenance, not be told everything went fine.
+    provenance,
+  })
+}

--- a/apps/backend/src/links/partner-product.ts
+++ b/apps/backend/src/links/partner-product.ts
@@ -7,6 +7,19 @@ import ProductModule from "@medusajs/medusa/product"
 // this link lets the cross-list subscriber resolve product → owning partner
 // cleanly on publish (instead of the fragile product → sales_channel → store →
 // partner multi-hop). One partner owns many products; a product has one owner.
+//
+// The extra columns record HOW the product came to be owned, not just that it
+// is. An admin can now create a product directly into a partner's store on
+// their behalf, and a product appearing in someone's live shop that they did
+// not create is exactly the thing that must not be reconstructed later from a
+// timestamp and a guess. Provenance belongs on the ownership record itself —
+// stamping it into product `metadata` would put an audit fact in a junk drawer
+// that anything may overwrite.
+//
+// All columns are nullable: rows written before this existed have genuinely
+// unknown provenance, and NULL is the honest answer for them. `created_on_behalf`
+// is the one flag readers actually branch on — false/NULL means the owner made
+// it themselves.
 export default defineLink(
   {
     linkable: PartnerModule.linkable.partner,
@@ -16,5 +29,26 @@ export default defineLink(
   {
     linkable: ProductModule.linkable.product,
     isList: true,
+  },
+  {
+    database: {
+      extraColumns: {
+        /** "admin" | "partner" — which kind of actor performed the create. */
+        created_by_actor_type: { type: "text", nullable: true },
+        /** The acting user/partner-admin id, so the act is attributable. */
+        created_by_actor_id: { type: "text", nullable: true },
+        /**
+         * TRUE only when someone other than the owner created it for them.
+         * The flag readers branch on; keeping it explicit means a consumer
+         * never has to infer intent from actor_type.
+         */
+        created_on_behalf: { type: "boolean", nullable: true },
+        /** Which of the partner's stores it was created into. */
+        store_id: { type: "text", nullable: true },
+        /** Route/surface that wrote it, e.g. "admin_store_products". */
+        source: { type: "text", nullable: true },
+        metadata: { type: "json", nullable: true },
+      },
+    },
   }
 )


### PR DESCRIPTION
## The gap

An admin had **no way** to put a product into a partner's shop.

Every store-scoped product route lives under `/partners/*` behind partner auth, and core `POST /admin/products` binds no sales channel and seeds no inventory levels — so what it makes is **invisible on every storefront** and reads **0 stock everywhere** (the partner-ui inventory page 404s on it). Support couldn't do it; the admin assistant couldn't either.

Confirmed against the live prod tool list before building: admin `create_product` / `update_product` forward only `title, status, description, subtitle, handle, metadata` — no `sales_channels`, no `variants`, no prices, and no store-scoped route on that surface at all.

## The route

`POST /admin/stores/:id/products` mirrors `POST /partners/stores/:id/products` step for step — sales-channel injection, inventory levels, FX price fanout — with an admin actor.

It **refuses before creating** when the store has no sales channel, or no linked partner. A product nobody can see, or one nobody can be said to own, is exactly what this route exists to prevent — and a half-successful create in someone else's shop is worse than a rejection.

It deliberately does **not** apply the `core_channel_listing` proposal override. That gate makes an artisan's product wait for admin review, and an admin *is* the reviewer; forcing `proposed` would mean creating a product and then approving your own work.

## The act is recorded, not inferred

A product appearing on someone's public storefront that they did not create must not have to be reconstructed later from a timestamp and a guess.

Provenance goes onto the partner↔product **ownership link as real columns** — `created_by_actor_type`, `created_by_actor_id`, `created_on_behalf`, `store_id`, `source` — rather than into product `metadata`. An audit fact does not belong in a shared junk drawer any writer may overwrite. All columns are nullable: rows written before this have genuinely unknown provenance, and NULL is the honest answer for them.

**`created_on_behalf` is derived, never accepted from the caller.** An admin is always on-behalf; a partner acting on their own store never is; an unknown acting partner is *not* assumed to be the owner. A caller cannot record a convenient answer, so the flag stays worth branching on.

It emits **`product.created_for_partner`** — for the on-behalf case only — so a flow can tell the partner. A product going live in someone's shop with nothing telling them is the failure mode worth spending an event on. A partner creating their own product stays silent.

The audit never throws (the product already exists by then) but it never fails *quietly* either: failures are logged and the response reports `provenance: { linked, announced }` so a caller learns the product exists **without** its provenance rather than being told everything was fine.

## The forward list

`bodyParams` carries `variants`, `options`, `images` and prices — the fields whose loss is **invisible** until a customer finds an unbuyable product. `sales_channels` is deliberately absent: the route derives it from the store, and accepting one would let a product be created into one partner's store while listing in another's.

A test asserts the forward list and the advertised schema are the same set **in both directions**, so #1348's silent strip cannot recur here.

## Verification

| | |
|---|---|
| provenance | 12 cases |
| MCP contract | 10 cases |
| admin-MCP invariant suites | **149/149**, incl. the "every admin write is sensitive" characterization |
| `check:prod-build` | green |

Checked against controls rather than assumed:

- trusting the caller's `created_on_behalf` → **1 case fails**
- announcing every create, not just on-behalf ones → **1 case fails**
- dropping `variants` from the forward list (the #1348 defect) → **2 cases fail**

## Deploy note

This changes `src/links/partner-product.ts`, which the deploy's migrate gate matches (`^apps/backend/src/links/`), so the link migration will run. The columns are additive and nullable, so existing rows are unaffected.

Refs #1356

🤖 Generated with [Claude Code](https://claude.com/claude-code)