### PR TITLE
feat(partner-mcp): add storefront page-block write tools

### DIFF
--- a/apps/backend/src/api/admin/websites/[id]/pages/[pageId]/blocks/validators.ts
+++ b/apps/backend/src/api/admin/websites/[id]/pages/[pageId]/blocks/validators.ts
@@ -1,28 +1,35 @@
 import { z } from "@medusajs/framework/zod";
 
+/**
+ * The block vocabulary, exported so the surfaces that OFFER these values read
+ * the same list the validator enforces (see the page validator's note for why
+ * this must never be restated). `Hero` and `MainContent` are what the
+ * storefront `[slug]` renderer turns into a heading band and a prose section;
+ * the unique ones may only appear once per page.
+ */
+export const BLOCK_TYPES = [
+  "Hero",
+  "Header",
+  "Footer",
+  "MainContent",
+  "ContactForm",
+  "Feature",
+  "Gallery",
+  "Testimonial",
+  "Product",
+  "Section",
+  "Custom",
+] as const
+
+export const BLOCK_STATUSES = ["Active", "Inactive", "Draft"] as const
+
 const blockBaseSchema = z.object({
   name: z.string().min(1, "Name is required"),
-  type: z.enum([
-    "Hero",
-    "Header",
-    "Footer",
-    "MainContent",
-    "ContactForm",
-    "Feature",
-    "Gallery",
-    "Testimonial",
-    "Product",
-    "Section",
-    "Custom"
-  ]),
+  type: z.enum(BLOCK_TYPES),
   content: z.record(z.string(), z.unknown()),
   settings: z.record(z.string(), z.unknown()).optional(),
   order: z.number().optional(),
-  status: z.enum([
-    "Active",
-    "Inactive",
-    "Draft"
-  ]).optional(),
+  status: z.enum(BLOCK_STATUSES).optional(),
   metadata: z.record(z.string(), z.unknown()).optional(),
 });
 

--- a/apps/backend/src/api/partners/mcp/lib/__tests__/dispatch.unit.spec.ts
+++ b/apps/backend/src/api/partners/mcp/lib/__tests__/dispatch.unit.spec.ts
@@ -156,6 +156,8 @@ describe("partner-mcp registry + dispatch", () => {
         "update_storefront_website", "get_storefront_analytics",
         "update_storefront_analytics", "list_storefront_pages",
         "get_storefront_page", "list_storefront_page_blocks",
+        "add_storefront_page_blocks", "update_storefront_page_block",
+        "delete_storefront_page_block",
         "create_storefront_page", "update_storefront_page",
         "get_storefront_domain", "update_storefront_domain",
         "verify_storefront_domain", "provision_storefront",
@@ -173,6 +175,11 @@ describe("partner-mcp registry + dispatch", () => {
       // Routine page edits are writes but not sensitive (no confirmation friction).
       expect(isSensitive(byName("update_storefront_page"))).toBe(false)
       expect(byName("update_storefront_page").write).toBe(true)
+      // Adding/editing blocks is a routine write; deleting a block is a DELETE,
+      // so it is implicitly sensitive.
+      expect(isSensitive(byName("add_storefront_page_blocks"))).toBe(false)
+      expect(isSensitive(byName("update_storefront_page_block"))).toBe(false)
+      expect(isSensitive(byName("delete_storefront_page_block"))).toBe(true)
     })
 
     it("covers store config (Tier 3) under /partners/stores/:id", () => {

--- a/apps/backend/src/api/partners/mcp/lib/registry.ts
+++ b/apps/backend/src/api/partners/mcp/lib/registry.ts
@@ -27,11 +27,15 @@ import {
   PRODUCT_SPEC_WRITE_GUIDANCE,
   productSpecSchemaProps,
 } from "../../../../modules/product-spec/tool-schema"
-// The page vocabulary comes from the validator that enforces it, never a copy.
+// The page + block vocabulary comes from the validator that enforces it, never a copy.
 import {
   PAGE_STATUSES,
   PAGE_TYPES,
 } from "../../../admin/websites/[id]/pages/validators"
+import {
+  BLOCK_STATUSES,
+  BLOCK_TYPES,
+} from "../../../admin/websites/[id]/pages/[pageId]/blocks/validators"
 
 /**
  * Partner tool definition. The declarative model now lives in the shared
@@ -85,6 +89,52 @@ const PAGE_STATUS_ENUM = {
   description:
     "Page status. Capitalised. 'Published' is LIVE on the storefront; new pages should be 'Draft' unless the partner asked to publish.",
   enum: [...PAGE_STATUSES],
+} as const
+
+/**
+ * Block vocabulary, taken from the blocks validator rather than restated.
+ * `Hero` + `MainContent` are what the storefront actually renders (a heading
+ * band, then prose sections); the unique types may only appear once per page.
+ */
+const BLOCK_TYPE_ENUM = {
+  type: "string",
+  description:
+    "Block type. Use 'Hero' for the top heading band and 'MainContent' for body prose — these are the two the storefront renders as designed. Other values render as a fallback dump.",
+  enum: [...BLOCK_TYPES],
+} as const
+
+const BLOCK_STATUS_ENUM = {
+  type: "string",
+  description: "Block status. Leave as 'Active' so the block shows on the page.",
+  enum: [...BLOCK_STATUSES],
+} as const
+
+/** One block's content, keyed by type. */
+const BLOCK_SCHEMA = obj(
+  {
+    name: STR("Internal label shown in the editor's block list, e.g. 'Hero' or 'Our story'."),
+    type: BLOCK_TYPE_ENUM,
+    content: {
+      type: "object",
+      additionalProperties: true,
+      description:
+        "Block content, keyed by type. Hero: { title, subtitle?, align? ('left'|'center') }. MainContent: { title?, body } where body is plain text and blank lines split paragraphs.",
+    },
+    settings: { type: "object", additionalProperties: true },
+    order: { type: "integer", description: "Render order (0-based). Omit to append after existing blocks." },
+    status: BLOCK_STATUS_ENUM,
+    metadata: { type: "object", additionalProperties: true },
+  },
+  ["name", "type", "content"]
+)
+
+const BLOCKS_ARRAY = {
+  type: "array",
+  minItems: 1,
+  maxItems: 12,
+  items: BLOCK_SCHEMA,
+  description:
+    "The blocks to add, in render order. First ask the partner what they want in each section.",
 } as const
 
 /** Unit-of-measure enum shared by consumption-log tools. */
@@ -1242,11 +1292,86 @@ export const PARTNER_MCP_TOOLS: PartnerMcpToolDef[] = [
   },
   {
     name: "list_storefront_page_blocks",
-    description: "List the content blocks of a storefront page.",
+    description: "List the content blocks of a storefront page (ids, types, content, order).",
     method: "GET",
     path: "/partners/storefront/pages/:pageId/blocks",
     pathParams: ["pageId"],
     inputSchema: obj({ pageId: STR("Page id.") }, ["pageId"]),
+  },
+  // Blocks — not the page's `content` text — are what the storefront renders.
+  // A page with an empty blocks array shows only its title, so these tools are
+  // how a page actually gets its Hero + MainContent layout. The model is
+  // instructed to ASK the partner what they want in each block before calling.
+  {
+    name: "add_storefront_page_blocks",
+    description:
+      "Add content blocks to a storefront page. Blocks are what the storefront renders — a page without them shows only its title. ASK the partner what they want in each section first (the Hero heading/subtitle, then MainContent body copy), then send a `blocks` array in render order.",
+    method: "POST",
+    path: "/partners/storefront/pages/:pageId/blocks",
+    pathParams: ["pageId"],
+    write: true,
+    previewPath: "/partners/storefront/pages/:pageId/blocks",
+    bodyParams: ["blocks"],
+    inputSchema: obj(
+      {
+        pageId: STR("Page id to add blocks to."),
+        blocks: BLOCKS_ARRAY,
+      },
+      ["pageId", "blocks"]
+    ),
+    sideEffects:
+      "Appends blocks to the page. If the page is already 'Published' these changes are live immediately — confirm with the partner before editing a live page.",
+    nextSteps: ["get_storefront_page", "list_storefront_page_blocks"],
+  },
+  {
+    name: "update_storefront_page_block",
+    description:
+      "Update a block on a storefront page (its title, subtitle, body, order, …). Get the block ids from list_storefront_page_blocks, then pass only the fields that change; `content` merges over the existing content rather than replacing it. ASK the partner what changed before editing.",
+    method: "PUT",
+    path: "/partners/storefront/pages/:pageId/blocks/:blockId",
+    pathParams: ["pageId", "blockId"],
+    write: true,
+    previewPath: "/partners/storefront/pages/:pageId/blocks/:blockId",
+    bodyParams: ["name", "type", "content", "settings", "order", "status", "metadata"],
+    inputSchema: obj(
+      {
+        pageId: STR("Page id the block belongs to."),
+        blockId: STR("Block id from list_storefront_page_blocks."),
+        name: STR("Optional internal label."),
+        type: BLOCK_TYPE_ENUM,
+        content: {
+          type: "object",
+          additionalProperties: true,
+          description:
+            "Block content, keyed by type. Hero: { title, subtitle?, align? ('left'|'center') }. MainContent: { title?, body } where body is plain text and blank lines split paragraphs. Merged over the existing content.",
+        },
+        settings: { type: "object", additionalProperties: true },
+        order: { type: "integer", description: "Render order (0-based)." },
+        status: BLOCK_STATUS_ENUM,
+        metadata: { type: "object", additionalProperties: true },
+      },
+      ["pageId", "blockId"]
+    ),
+    sideEffects:
+      "Editing a block on a 'Published' page is live immediately — confirm with the partner before editing a live page.",
+  },
+  {
+    name: "delete_storefront_page_block",
+    description:
+      "Delete a block from a storefront page. Sensitive — the block is removed immediately and cannot be recovered.",
+    method: "DELETE",
+    path: "/partners/storefront/pages/:pageId/blocks/:blockId",
+    pathParams: ["pageId", "blockId"],
+    write: true,
+    inputSchema: obj(
+      {
+        pageId: STR("Page id the block belongs to."),
+        blockId: STR("Block id from list_storefront_page_blocks."),
+      },
+      ["pageId", "blockId"]
+    ),
+    sideEffects:
+      "The block is deleted permanently. On a 'Published' page this changes the live site immediately.",
   },
   // The two page writes below mirror `postPagesSchema` / `updatePageSchema`
   // field for field. They did not, and the gap was invisible from here: the row
@@ -1258,7 +1383,7 @@ export const PARTNER_MCP_TOOLS: PartnerMcpToolDef[] = [
   {
     name: "create_storefront_page",
     description:
-      "Create a storefront page. `content` is REQUIRED — it is the page's body text, and the route rejects the call without it. Blocks are NOT part of this call: create the page, then use the page-block tools to lay it out. Call list_storefront_pages first so you do not reuse an existing slug.",
+      "Create a storefront page. `content` is REQUIRED — it is the page's body text, and the route rejects the call without it (write a short lead/summary; the storefront renders BLOCKS, not this field). Blocks are NOT part of this call: after creating, ASK the partner what they want in each section and lay the page out with add_storefront_page_blocks (Hero + MainContent). Call list_storefront_pages first so you do not reuse an existing slug.",
     method: "POST",
     path: "/partners/storefront/pages",
     write: true,
@@ -1282,12 +1407,12 @@ export const PARTNER_MCP_TOOLS: PartnerMcpToolDef[] = [
     ),
     sideEffects:
       "A page created with status 'Published' is immediately visible on the live storefront. Omit status (or send 'Draft') unless the partner asked to publish.",
-    nextSteps: ["get_storefront_page", "list_storefront_page_blocks"],
+    nextSteps: ["add_storefront_page_blocks", "get_storefront_page", "list_storefront_page_blocks"],
   },
   {
     name: "update_storefront_page",
     description:
-      "Update a storefront page. Every field is optional here — pass only what changes. Blocks are NOT part of this call; use the page-block tools.",
+      "Update a storefront page. Every field is optional here — pass only what changes. Blocks are NOT part of this call; use add/update/delete_storefront_page_block to change the layout.",
     method: "PUT",
     path: "/partners/storefront/pages/:pageId",
     pathParams: ["pageId"],

--- a/apps/backend/src/api/partners/storefront/__tests__/page-tool-contract.unit.spec.ts
+++ b/apps/backend/src/api/partners/storefront/__tests__/page-tool-contract.unit.spec.ts
@@ -19,6 +19,12 @@ import {
   postPagesSchema,
   updatePageSchema,
 } from "../../../admin/websites/[id]/pages/validators"
+import {
+  BLOCK_TYPES,
+  BLOCK_STATUSES,
+  createBlocksSchema,
+  updateBlockSchema,
+} from "../../../admin/websites/[id]/pages/[pageId]/blocks/validators"
 
 const tool = (name: string) => {
   const def = PARTNER_MCP_TOOLS.find((t) => t.name === name)
@@ -126,5 +132,71 @@ describe("one page vocabulary", () => {
     )
     expect(pageTools).toContain("import { PAGE_TYPES }")
     expect(pageTools).not.toMatch(/const PAGE_TYPES = \[/)
+  })
+})
+
+describe("block tools ↔ blocks validator", () => {
+  const blockShape = (createBlocksSchema as any).shape.blocks.element.shape
+
+  const addDef = tool("add_storefront_page_blocks")
+  const updateDef = tool("update_storefront_page_block")
+
+  it("add_storefront_page_blocks requires name/type/content on every block", () => {
+    const missing = requiredKeys(blockShape).filter(
+      (k) => !(addDef.inputSchema.properties.blocks.items.required ?? []).includes(k)
+    )
+    expect(missing).toEqual([])
+  })
+
+  it("add_storefront_page_blocks forwards only `blocks` (pageId is a path param)", () => {
+    const declared = Object.keys(addDef.inputSchema.properties).filter(
+      (k) => !(addDef.pathParams ?? []).includes(k)
+    )
+    expect(declared).toEqual(["blocks"])
+    expect(addDef.bodyParams).toEqual(["blocks"])
+  })
+
+  it("offers exactly the block enum values the route accepts", () => {
+    expect(addDef.inputSchema.properties.blocks.items.properties.type.enum).toEqual([...BLOCK_TYPES])
+    expect(addDef.inputSchema.properties.blocks.items.properties.status.enum).toEqual([...BLOCK_STATUSES])
+    expect(updateDef.inputSchema.properties.type.enum).toEqual([...BLOCK_TYPES])
+    expect(updateDef.inputSchema.properties.status.enum).toEqual([...BLOCK_STATUSES])
+  })
+
+  it("passes a realistic block payload through the real validator", () => {
+    const payload = {
+      blocks: [
+        {
+          name: "Hero",
+          type: "Hero",
+          content: { title: "About us", subtitle: "Our story", align: "center" },
+          order: 0,
+          status: "Active",
+        },
+        {
+          name: "Our story",
+          type: "MainContent",
+          content: { body: "We are a weaving collective in Kashmir." },
+          order: 1,
+        },
+      ],
+    }
+    expect(() => createBlocksSchema.parse(payload)).not.toThrow()
+  })
+
+  it("update_storefront_page_block forwards only fields the validator accepts", () => {
+    const shape = (updateBlockSchema as any).shape
+    const declared = Object.keys(updateDef.inputSchema.properties).filter(
+      (k) => !(updateDef.pathParams ?? []).includes(k)
+    )
+    expect(declared.filter((k) => !updateDef.bodyParams.includes(k))).toEqual([])
+    expect(updateDef.bodyParams.filter((k: string) => !(k in shape))).toEqual([])
+  })
+
+  it("delete_storefront_page_block is a sensitive DELETE on the block path", () => {
+    const del = tool("delete_storefront_page_block")
+    expect(del.method).toBe("DELETE")
+    expect(del.pathParams).toEqual(["pageId", "blockId"])
+    expect(del.path).toBe("/partners/storefront/pages/:pageId/blocks/:blockId")
   })
 })


### PR DESCRIPTION
## What

The partner MCP could **read** storefront pages but had no way to **lay them out**. The storefront renders **blocks** (Hero + MainContent) — not the page's `content` string — yet the only page write tools were `create_storefront_page` / `update_storefront_page`, neither of which accepts `blocks` (the route's `postPagesSchema` strips it on the way through).

Result: a page created through the MCP kept an empty `blocks` array and showed only its title. The About Us page (excellent plain-text content, no block structure) is the concrete case this fixes.

## Changes

- **`add_storefront_page_blocks`** — POST `/partners/storefront/pages/:pageId/blocks`
- **`update_storefront_page_block`** — PUT `/partners/storefront/pages/:pageId/blocks/:blockId` (content merges, not replaces)
- **`delete_storefront_page_block`** — DELETE (confirm-gated)

All three are loopback-proxy rows over the block routes that already existed.

- `BLOCK_TYPES` / `BLOCK_STATUSES` are now exported from the blocks validator and imported by the registry (single source of truth, matching the existing `PAGE_TYPES` pattern).
- Tool descriptions instruct the assistant to **ask the partner what belongs in each block** (Hero heading/subtitle, MainContent body) before writing, and document the per-type content shape.
- `create_storefront_page` / `update_storefront_page` now point at the block tools instead of implying `content` is what renders.

## Tests

New `block tools ↔ blocks validator` contract suite in `page-tool-contract.unit.spec.ts` (schemas match `createBlocksSchema`/`updateBlockSchema`, enum equality, realistic Hero+MainContent payload passes the real validator). Extended `dispatch.unit.spec.ts` coverage for sensitivity classification (add/update are plain writes, delete is a sensitive DELETE).

`TEST_TYPE=unit … jest --testPathPattern="page-tool-contract|dispatch.unit.spec"` → 100/100 pass.