### PR TITLE
feat: send a partner ONE material, not the whole design — and a detail band below the gallery (#1364, #1365)

### DIFF
--- a/apps/backend/src/admin/components/forms/production-run/__tests__/clean-assignment-materials.unit.spec.ts
+++ b/apps/backend/src/admin/components/forms/production-run/__tests__/clean-assignment-materials.unit.spec.ts
@@ -1,0 +1,61 @@
+import { cleanAssignmentMaterialsForSave } from "../clean-assignment-materials"
+
+const label = (id: string) =>
+  ({ iitem_silk: "Mulberry silk" } as Record<string, string>)[id] || id
+
+describe("cleanAssignmentMaterialsForSave", () => {
+  it("sends only the selected items", () => {
+    const result = cleanAssignmentMaterialsForSave([
+      { inventory_item_id: "iitem_silk", selected: true, planned_quantity: "40" },
+      { inventory_item_id: "iitem_lining", selected: false, planned_quantity: "" },
+    ])
+    expect(result.ok).toBe(true)
+    if (!result.ok) return
+    expect(result.materials).toEqual([
+      { inventory_item_id: "iitem_silk", planned_quantity: 40 },
+    ])
+  })
+
+  /**
+   * #1361's exact shape: an unselected row must never become a payload the API
+   * rejects. The form must not build something the form cannot save.
+   */
+  it.each([
+    [{ inventory_item_id: "", selected: true }],
+    [{ inventory_item_id: "iitem_silk", selected: false }],
+    [{ inventory_item_id: "iitem_silk" }],
+  ])("drops the untouched row %p as noise", (draft) => {
+    const result = cleanAssignmentMaterialsForSave([draft as any])
+    expect(result.ok && result.materials).toEqual([])
+  })
+
+  it("allows a selected item with no quantity — 'amount unstated' is a real answer", () => {
+    const result = cleanAssignmentMaterialsForSave([
+      { inventory_item_id: "iitem_silk", selected: true, planned_quantity: "" },
+    ])
+    expect(result.ok && result.materials).toEqual([
+      { inventory_item_id: "iitem_silk" },
+    ])
+  })
+
+  it.each(["0", "-2", "abc"])(
+    "refuses a selected item whose quantity was typed as %p, in words",
+    (qty) => {
+      const result = cleanAssignmentMaterialsForSave(
+        [{ inventory_item_id: "iitem_silk", selected: true, planned_quantity: qty }],
+        label
+      )
+      expect(result.ok).toBe(false)
+      if (result.ok) return
+      // Not a zod path. The backend would say
+      // "planned_quantity for iitem_silk must be a positive number".
+      expect(result.error).toContain("Mulberry silk")
+      expect(result.error).toContain("greater than 0")
+    }
+  )
+
+  it.each([undefined, null, []])("treats %p as no materials", (drafts) => {
+    const result = cleanAssignmentMaterialsForSave(drafts as any)
+    expect(result.ok && result.materials).toEqual([])
+  })
+})

--- a/apps/backend/src/admin/components/forms/production-run/clean-assignment-materials.ts
+++ b/apps/backend/src/admin/components/forms/production-run/clean-assignment-materials.ts
@@ -1,0 +1,76 @@
+/**
+ * What an assignment's material rows should become on save.
+ *
+ * #1361 is the reason this is a pure function with its own tests rather than a
+ * few lines inside the submit handler: the spec editor seeded a blank row by
+ * design, forgot to clean it, and answered a partner with
+ * `options, 0, values, 0, label` — a form that produced a payload the same form
+ * then rejected. The material picker has the identical shape. A chip that was
+ * toggled on and then off, or toggled on and never given a quantity, must not
+ * reach the API as `{ inventory_item_id: "", planned_quantity: 0 }`.
+ *
+ * Two cases that must NOT be treated alike:
+ *
+ *  - a row nobody selected is NOISE — dropped silently, like an untouched chip;
+ *  - a SELECTED item with a quantity that was typed and then emptied down to
+ *    zero or a non-number is a MISTAKE. The backend rejects a non-positive
+ *    planned_quantity, so returning it here in words beats a zod path.
+ *
+ * A selected item with NO quantity at all is legitimate: it means "this partner
+ * gets this material, amount unstated", which the backend stores as null.
+ */
+export type DraftMaterial = {
+  inventory_item_id: string
+  selected?: boolean
+  /** As typed. "" means the admin has not stated an amount. */
+  planned_quantity?: string | number | null
+  note?: string | null
+}
+
+export type CleanedMaterial = {
+  inventory_item_id: string
+  planned_quantity?: number
+  note?: string
+}
+
+export type CleanMaterialsResult =
+  | { ok: true; materials: CleanedMaterial[] }
+  | { ok: false; error: string }
+
+export const cleanAssignmentMaterialsForSave = (
+  drafts: DraftMaterial[] | null | undefined,
+  labelFor: (inventoryItemId: string) => string = (id) => id
+): CleanMaterialsResult => {
+  const out: CleanedMaterial[] = []
+
+  for (const draft of drafts || []) {
+    const id = (draft?.inventory_item_id || "").trim()
+    if (!id || !draft?.selected) {
+      continue
+    }
+
+    const raw = draft.planned_quantity
+    const stated = raw !== undefined && raw !== null && String(raw).trim() !== ""
+
+    if (!stated) {
+      out.push({ inventory_item_id: id, ...(draft.note ? { note: draft.note } : {}) })
+      continue
+    }
+
+    const qty = Number(raw)
+    if (!Number.isFinite(qty) || qty <= 0) {
+      return {
+        ok: false,
+        error: `Enter a quantity greater than 0 for ${labelFor(id)}, or clear it to leave the amount unstated.`,
+      }
+    }
+
+    out.push({
+      inventory_item_id: id,
+      planned_quantity: qty,
+      ...(draft.note ? { note: draft.note } : {}),
+    })
+  }
+
+  return { ok: true, materials: out }
+}

--- a/apps/backend/src/admin/routes/production-runs/[id]/@approve/page.tsx
+++ b/apps/backend/src/admin/routes/production-runs/[id]/@approve/page.tsx
@@ -21,7 +21,12 @@ import { useStackedModal } from "../../../../components/modal/stacked-modal/use-
 
 import { usePartners } from "../../../../hooks/api/partners"
 import { useTaskTemplates } from "../../../../hooks/api/task-templates"
-import { useApproveProductionRun } from "../../../../hooks/api/production-runs"
+import { useApproveProductionRun, useProductionRun } from "../../../../hooks/api/production-runs"
+import { useDesignInventory } from "../../../../hooks/api/designs"
+import {
+  cleanAssignmentMaterialsForSave,
+  type DraftMaterial,
+} from "../../../../components/forms/production-run/clean-assignment-materials"
 
 const assignmentSchema = z.object({
   partner_id: z.string().min(1, "Partner is required"),
@@ -30,6 +35,12 @@ const assignmentSchema = z.object({
   order: z.coerce.number().int().positive().optional(),
   template_names: z.array(z.string()).optional(),
   template_ids: z.array(z.string()).optional(),
+  /**
+   * Draft rows for the material picker — every BOM item, selected or not. They
+   * are cleaned into the API's `materials` on submit; an unselected row is
+   * noise and never leaves the form (#1361).
+   */
+  materials_draft: z.array(z.any()).optional(),
 })
 
 const approveSchema = z.object({
@@ -45,6 +56,7 @@ type Assignment = {
   order?: number
   template_names?: string[]
   template_ids?: string[]
+  materials_draft?: DraftMaterial[]
 }
 
 const MODAL_ID = "approve-assignments"
@@ -53,10 +65,13 @@ const AssignmentsModal = ({
   form,
   partners,
   templatesToShow,
+  bomItems,
 }: {
   form: any
   partners: any[]
   templatesToShow: any[]
+  /** The design's bill of materials — what an assignment may be a subset OF. */
+  bomItems: Array<{ id: string; label: string; planned_quantity?: number | null }>
 }) => {
   const { setIsOpen } = useStackedModal()
   const [local, setLocal] = useState<Assignment[]>([])
@@ -82,14 +97,33 @@ const AssignmentsModal = ({
   }, [form])
 
   const handleSave = useCallback(() => {
+    // Catch a bad quantity HERE, in the modal where the field is, rather than
+    // letting it surface as a zod path after the drawer has been submitted.
+    for (const [i, a] of local.entries()) {
+      const cleaned = cleanAssignmentMaterialsForSave(
+        a.materials_draft,
+        (id) => bomItems.find((b) => b.id === id)?.label || id
+      )
+      if (!cleaned.ok) {
+        toast.error(`Assignment ${i + 1}: ${cleaned.error}`)
+        return
+      }
+    }
     form.setValue("assignments", local, { shouldDirty: true })
     setIsOpen(MODAL_ID, false)
-  }, [form, local, setIsOpen])
+  }, [form, local, setIsOpen, bomItems])
 
   const addAssignment = () => {
     setLocal((prev) => [
       ...prev,
-      { partner_id: "", role: "", quantity: 1, order: undefined, template_ids: [] },
+      {
+        partner_id: "",
+        role: "",
+        quantity: 1,
+        order: undefined,
+        template_ids: [],
+        materials_draft: [],
+      },
     ])
   }
 
@@ -118,6 +152,42 @@ const AssignmentsModal = ({
           ? current.filter((t) => t !== id)
           : [...current, id]
         return { ...a, template_ids: next }
+      })
+    )
+  }
+
+  /**
+   * The material picker. Every BOM item is a row; `selected` is what makes it
+   * part of THIS assignment. Rows are kept even when unselected so a quantity
+   * typed, deselected and reselected is not lost mid-edit — and dropped on save
+   * by `cleanAssignmentMaterialsForSave`, never sent as a blank.
+   */
+  const materialDraft = (a: Assignment): DraftMaterial[] => {
+    const byId = new Map(
+      (a.materials_draft || []).map((d) => [d.inventory_item_id, d])
+    )
+    return bomItems.map(
+      (item) =>
+        byId.get(item.id) || {
+          inventory_item_id: item.id,
+          selected: false,
+          planned_quantity: "",
+        }
+    )
+  }
+
+  const updateMaterial = (
+    idx: number,
+    inventoryItemId: string,
+    patch: Partial<DraftMaterial>
+  ) => {
+    setLocal((prev) =>
+      prev.map((a, i) => {
+        if (i !== idx) return a
+        const rows = materialDraft(a).map((row) =>
+          row.inventory_item_id === inventoryItemId ? { ...row, ...patch } : row
+        )
+        return { ...a, materials_draft: rows }
       })
     )
   }
@@ -242,6 +312,66 @@ const AssignmentsModal = ({
                     })}
                   </div>
                 </div>
+
+                {bomItems.length > 0 && (
+                  <div className="mt-4">
+                    <Text size="small" weight="plus" className="mb-1">
+                      Materials for this partner
+                    </Text>
+                    <Text size="xsmall" className="text-ui-fg-subtle mb-2">
+                      Select which of the design&apos;s inventory items THIS
+                      partner is sent. Select none and they get the whole bill of
+                      materials, as before. Once you select any, they cannot log
+                      consumption against anything else.
+                    </Text>
+                    <div className="flex flex-col gap-2">
+                      {materialDraft(assignment).map((row) => {
+                        const item = bomItems.find(
+                          (b) => b.id === row.inventory_item_id
+                        )
+                        return (
+                          <div
+                            key={row.inventory_item_id}
+                            className="flex items-center gap-x-3"
+                          >
+                            <button
+                              type="button"
+                              className="rounded-md border px-3 py-1.5 text-sm"
+                              onClick={() =>
+                                updateMaterial(idx, row.inventory_item_id, {
+                                  selected: !row.selected,
+                                })
+                              }
+                            >
+                              <Badge color={row.selected ? "green" : "grey"}>
+                                {item?.label || row.inventory_item_id}
+                              </Badge>
+                            </button>
+                            {row.selected && (
+                              <Input
+                                type="number"
+                                min={0}
+                                step="0.01"
+                                className="max-w-[10rem]"
+                                placeholder={
+                                  item?.planned_quantity != null
+                                    ? `Design plans ${item.planned_quantity}`
+                                    : "Qty (optional)"
+                                }
+                                value={String(row.planned_quantity ?? "")}
+                                onChange={(e) =>
+                                  updateMaterial(idx, row.inventory_item_id, {
+                                    planned_quantity: e.target.value,
+                                  })
+                                }
+                              />
+                            )}
+                          </div>
+                        )
+                      })}
+                    </div>
+                  </div>
+                )}
               </div>
             ))}
 
@@ -288,6 +418,30 @@ const ApproveProductionRunDrawerForm = () => {
   const { partners = [] } = usePartners({ limit: 100, offset: 0 })
   const { task_templates: taskTemplates = [] } = useTaskTemplates({ limit: 100, offset: 0 })
 
+  // The design's bill of materials — what an assignment's selection is a subset
+  // OF. A run with no design (the #1112 product-only path) simply has none, and
+  // the picker does not render.
+  const { production_run } = useProductionRun(runId || "", undefined, {
+    enabled: !!runId,
+  } as any)
+  const designId = (production_run as any)?.design_id || ""
+  const { data: designInventory } = useDesignInventory(designId, {
+    enabled: !!designId,
+  })
+
+  const bomItems = useMemo(
+    () =>
+      (designInventory?.inventory_items || []).map((row: any) => ({
+        id: row.inventory_item_id,
+        label:
+          row.inventory_item?.title ||
+          row.inventory_item?.sku ||
+          row.inventory_item_id,
+        planned_quantity: row.planned_quantity ?? null,
+      })),
+    [designInventory]
+  )
+
   const templatesToShow = useMemo(() => {
     return [...(taskTemplates || [])].sort((a: any, b: any) =>
       String(a?.name || "").localeCompare(String(b?.name || ""))
@@ -307,9 +461,31 @@ const ApproveProductionRunDrawerForm = () => {
       return
     }
 
+    // Build the API payload: the picker's draft rows become `materials`, and
+    // `materials_draft` — a form-only field — never leaves the browser.
+    let payload: any[] | undefined
+    if (values.assignments?.length) {
+      payload = []
+      for (const [i, a] of (values.assignments as Assignment[]).entries()) {
+        const cleaned = cleanAssignmentMaterialsForSave(
+          a.materials_draft,
+          (id) => bomItems.find((b) => b.id === id)?.label || id
+        )
+        if (!cleaned.ok) {
+          toast.error(`Assignment ${i + 1}: ${cleaned.error}`)
+          return
+        }
+        const { materials_draft: _drop, ...rest } = a
+        payload.push({
+          ...rest,
+          ...(cleaned.materials.length ? { materials: cleaned.materials } : {}),
+        })
+      }
+    }
+
     try {
       await approveRun({
-        assignments: values.assignments?.length ? values.assignments : undefined,
+        assignments: payload,
       })
       toast.success("Production run approved")
       handleSuccess()
@@ -339,6 +515,7 @@ const ApproveProductionRunDrawerForm = () => {
                   form={form}
                   partners={partners}
                   templatesToShow={templatesToShow}
+                  bomItems={bomItems}
                 />
               </div>
 

--- a/apps/backend/src/api/admin/design-work-orders/route.ts
+++ b/apps/backend/src/api/admin/design-work-orders/route.ts
@@ -17,6 +17,15 @@ export const GET = async (req: MedusaRequest, res: MedusaResponse) => {
   const scService: any = req.scope.resolve(Modules.SALES_CHANNEL)
   const limit = Number((req.query as any).limit) || 20
   const offset = Number((req.query as any).offset) || 0
+  // Filters. Without these the only way to find ONE work-order was to page the
+  // whole channel and match by eye — and the route already loads every order in
+  // it unbounded, so the caller paid for that either way.
+  const idFilter = ((req.query as any).id || "").trim()
+  // The COMMISSIONING order this work-order was collated from. The bridge
+  // between the two order ids: given a customer order, find its work-order.
+  const sourceOrderFilter = ((req.query as any).source_order_id || "").trim()
+  const partnerFilter = ((req.query as any).partner_id || "").trim()
+  const runStatusFilter = ((req.query as any).run_status || "").trim()
 
   const [channel] = await scService.listSalesChannels({
     name: PARTNER_WORK_ORDERS_CHANNEL,
@@ -50,11 +59,22 @@ export const GET = async (req: MedusaRequest, res: MedusaResponse) => {
     filters: { sales_channel_id: channel.id },
   })
 
-  const collated = (orders || []).filter(
-    (o: any) =>
-      o?.metadata?.collated_design_order === true &&
-      (o?.production_runs?.length ?? 0) > 0
-  )
+  const collated = (orders || []).filter((o: any) => {
+    if (o?.metadata?.collated_design_order !== true) return false
+    const runs = o?.production_runs ?? []
+    if (!runs.length) return false
+    if (idFilter && o.id !== idFilter) return false
+    if (sourceOrderFilter && o?.metadata?.source_order_id !== sourceOrderFilter) {
+      return false
+    }
+    if (partnerFilter && !runs.some((r: any) => r?.partner_id === partnerFilter)) {
+      return false
+    }
+    if (runStatusFilter && !runs.some((r: any) => r?.status === runStatusFilter)) {
+      return false
+    }
+    return true
+  })
   collated.sort((a: any, b: any) => (a.created_at < b.created_at ? 1 : -1))
 
   const count = collated.length

--- a/apps/backend/src/api/admin/mcp/lib/__tests__/production-run-materials-and-collation.unit.spec.ts
+++ b/apps/backend/src/api/admin/mcp/lib/__tests__/production-run-materials-and-collation.unit.spec.ts
@@ -1,0 +1,174 @@
+import { ADMIN_MCP_TOOLS } from "../registry"
+import { PARTNER_MCP_TOOLS } from "../../../../partners/mcp/lib/registry"
+import {
+  AdminApproveProductionRunReq,
+  AdminCreateProductionRunReq,
+} from "../../../production-runs/validators"
+
+/**
+ * Two things this suite pins.
+ *
+ * 1. THE COLLATION IS REACHABLE. One order can hold many runs (#826 S3a), but
+ *    there are TWO order ids and they are not interchangeable: `run.order_id`
+ *    is the COMMISSIONING order, while the collated work-order holds its runs
+ *    through the order↔production_run LINK. Passing a work-order id to
+ *    `order_id` matched nothing and returned an empty list — indistinguishable
+ *    from "that order has no runs". A model cannot be expected to know that
+ *    from a parameter called `order_id`, so the registry has to say it.
+ *
+ * 2. THE ROW MATCHES ITS VALIDATOR. #1348 and #1361 both bit here: `bodyParams`
+ *    is the dispatcher's FORWARD LIST, so a field the schema advertises but the
+ *    list omits is silently stripped, and a schema that is laxer than the zod
+ *    validator hands the model an unreadable 400 instead of a usable limit.
+ */
+
+const admin = (name: string) => ADMIN_MCP_TOOLS.find((t) => t.name === name)
+const partner = (name: string) => PARTNER_MCP_TOOLS.find((t) => t.name === name)
+
+describe("collated orders are reachable from an MCP tool", () => {
+  const listRuns = admin("list_production_runs")
+  const listWorkOrders = admin("list_design_work_orders")
+
+  it("can filter runs by the collated WORK-ORDER, not just the commissioning order", () => {
+    expect(listRuns?.queryParams).toContain("work_order_id")
+    expect(
+      (listRuns?.inputSchema as any)?.properties?.work_order_id
+    ).toBeTruthy()
+  })
+
+  it("warns that order_id is the commissioning order and will look empty otherwise", () => {
+    // The dangerous answer here is a confident empty list.
+    const desc = (listRuns?.inputSchema as any)?.properties?.order_id?.description ?? ""
+    expect(desc.toLowerCase()).toContain("commissioning")
+    expect(desc).toContain("work_order_id")
+  })
+
+  it("can find ONE work-order, and can bridge from a customer order to it", () => {
+    // Without these the only way to reach a single work-order was to page the
+    // whole channel and match by eye.
+    expect(listWorkOrders?.queryParams).toEqual(
+      expect.arrayContaining(["id", "source_order_id"])
+    )
+    const props = (listWorkOrders?.inputSchema as any)?.properties ?? {}
+    expect(props.id).toBeTruthy()
+    expect(props.source_order_id).toBeTruthy()
+  })
+
+  it("declares every filter it advertises (a schema-only filter is dropped)", () => {
+    const props = Object.keys((listWorkOrders?.inputSchema as any)?.properties ?? {})
+    for (const p of props) {
+      expect(listWorkOrders?.queryParams).toContain(p)
+    }
+  })
+})
+
+describe("the per-assignment material allocation is callable", () => {
+  const create = admin("create_production_run")
+  const update = admin("update_production_run")
+  const approve = admin("approve_production_run")
+
+  it.each([
+    ["create_production_run", create],
+    ["update_production_run", update],
+  ])("%s forwards materials — a schema-only field is STRIPPED", (_n, tool) => {
+    expect((tool?.inputSchema as any)?.properties?.materials).toBeTruthy()
+    expect(tool?.bodyParams).toContain("materials")
+  })
+
+  it("approve_production_run offers materials PER ASSIGNMENT, not per run", () => {
+    // The whole point: two partners on one design can be sent different
+    // materials. A run-level field could not express that.
+    const items = (approve?.inputSchema as any)?.properties?.assignments?.items
+    expect(items?.properties?.materials).toBeTruthy()
+    expect(approve?.bodyParams).toContain("assignments")
+  })
+
+  it("approve_production_run also offers template_ids, the preferred form (#1268)", () => {
+    const items = (approve?.inputSchema as any)?.properties?.assignments?.items
+    expect(items?.properties?.template_ids).toBeTruthy()
+  })
+
+  describe("the schema mirrors the validator's real limits", () => {
+    const materialItem = (admin("create_production_run")?.inputSchema as any)
+      ?.properties?.materials?.items
+
+    it("requires inventory_item_id", () => {
+      expect(materialItem?.required).toContain("inventory_item_id")
+      // …and the validator agrees.
+      expect(
+        AdminCreateProductionRunReq.safeParse({
+          design_id: "design_1",
+          materials: [{ planned_quantity: 4 }],
+        }).success
+      ).toBe(false)
+    })
+
+    it("says planned_quantity must be positive, rather than letting a model find out via a 400", () => {
+      expect(materialItem?.properties?.planned_quantity?.description).toMatch(
+        /positive/i
+      )
+      expect(
+        AdminCreateProductionRunReq.safeParse({
+          design_id: "design_1",
+          materials: [{ inventory_item_id: "iitem_1", planned_quantity: 0 }],
+        }).success
+      ).toBe(false)
+    })
+
+    it("tells the model the list must be a SUBSET of the design's inventory", () => {
+      // The validator cannot check this (it cannot see the BOM), so the
+      // description is the only place a model can learn it before the write.
+      const desc =
+        (admin("create_production_run")?.inputSchema as any)?.properties
+          ?.materials?.description ?? ""
+      expect(desc.toLowerCase()).toContain("subset")
+      expect(desc).toContain("list_design_inventory")
+    })
+
+    it("says that omitting it leaves the run unconstrained", () => {
+      // Absence is "nobody chose", not "chose nothing" — a model that reads it
+      // the other way would think an omitted list forbids everything.
+      const desc =
+        (admin("update_production_run")?.inputSchema as any)?.properties
+          ?.materials?.description ?? ""
+      expect(desc.toLowerCase()).toContain("unconstrained")
+    })
+
+    it("accepts a well-formed assignment allocation end to end", () => {
+      expect(
+        AdminApproveProductionRunReq.safeParse({
+          assignments: [
+            {
+              partner_id: "pt_1",
+              materials: [{ inventory_item_id: "iitem_1", planned_quantity: 40 }],
+            },
+          ],
+        }).success
+      ).toBe(true)
+    })
+
+    it("still accepts an assignment with no materials at all", () => {
+      expect(
+        AdminApproveProductionRunReq.safeParse({
+          assignments: [{ partner_id: "pt_1" }],
+        }).success
+      ).toBe(true)
+    })
+  })
+})
+
+describe("the partner can read what they were assigned", () => {
+  it("has a single-run read, which the run list does not cover", () => {
+    // log_production_run_consumption points at it; a tool that names a
+    // nonexistent tool is the #1348 shape from the other side.
+    const get = partner("get_production_run")
+    expect(get).toBeTruthy()
+    expect(get?.path).toBe("/partners/production-runs/:id")
+  })
+
+  it("warns the consumption tool that the run may be constrained", () => {
+    const log = partner("log_production_run_consumption")
+    expect(log?.description).toMatch(/assigned material list/i)
+    expect(log?.description).toMatch(/refused/i)
+  })
+})

--- a/apps/backend/src/api/admin/mcp/lib/registry.ts
+++ b/apps/backend/src/api/admin/mcp/lib/registry.ts
@@ -91,6 +91,40 @@ const PAGINATION = {
   q: { type: "string", description: "Free-text search filter." },
 } as const
 
+// The per-assignment material allocation, as the model sees it. Mirrors
+// `RunMaterialSchema` in the production-run validators — the row IS a contract
+// with its validator (#1348/#1361), so `planned_quantity` carries the same
+// "must be positive" limit here rather than letting a model discover it as a 400.
+const RUN_MATERIALS_PARAM = {
+  type: "array" as const,
+  description:
+    "The materials THIS assignment is sent: a SUBSET of the design's bill of materials (call list_design_inventory first to see what is available), with how much of each. Omit to leave the run unconstrained — the partner then sees the design's whole BOM, which is the behaviour every run had before this existed. Once set, the partner is REFUSED when logging consumption against anything outside the list.",
+  items: {
+    type: "object" as const,
+    properties: {
+      inventory_item_id: {
+        type: "string",
+        description:
+          "Inventory item id. MUST already be linked to the design — the write is rejected otherwise, it does not link it for you.",
+      },
+      planned_quantity: {
+        type: "number",
+        description:
+          "How much of this item this partner is issued. Must be POSITIVE — 0 is not an allocation, and it is rejected.",
+      },
+      location_id: { type: "string", description: "Stock location to issue from, if not the design's." },
+      resolved_raw_material_id: {
+        type: "string",
+        description:
+          "Which colour/variant of a pinned raw-material group this run uses. Per-run, so two runs of one design can be two colours.",
+      },
+      note: { type: "string", description: "Free note for the partner about this material." },
+    },
+    required: ["inventory_item_id"],
+  },
+}
+
+
 export const ADMIN_MCP_TOOLS: AdminMcpToolDef[] = [
   // ===== Grounding =========================================================
   {
@@ -314,7 +348,7 @@ export const ADMIN_MCP_TOOLS: AdminMcpToolDef[] = [
   {
     name: "list_production_runs",
     description:
-      "List production runs / work orders (paginated). Free-text search via q (matches run id and the design, partner or product the run is for). Filter by status, partner, design, product, order, run type or parent run. Use to see open runs, their stage and assigned partner.",
+      "List production runs / work orders (paginated). Free-text search via q (matches run id and the design, partner or product the run is for). Filter by status, partner, design, product, order, run type or parent run. Use to see open runs, their stage and assigned partner. NOTE there are TWO order ids and they are not interchangeable — see order_id vs work_order_id.",
     method: "GET",
     path: "/admin/production-runs",
     // `q` was withheld here until #1172 — the route accepted the param but never
@@ -328,6 +362,7 @@ export const ADMIN_MCP_TOOLS: AdminMcpToolDef[] = [
       "design_id",
       "product_id",
       "order_id",
+      "work_order_id",
       "parent_run_id",
       "run_type",
       "include_tasks",
@@ -344,7 +379,12 @@ export const ADMIN_MCP_TOOLS: AdminMcpToolDef[] = [
       partner_id: STR("Only runs assigned to this partner."),
       design_id: STR("Only runs for this design."),
       product_id: STR("Only runs for this product."),
-      order_id: STR("Only runs for this order."),
+      order_id: STR(
+        "Only runs for this COMMISSIONING order — the customer order that caused the work. This is NOT the collated design work-order: passing a work-order id here returns an empty list, which looks exactly like 'that order has no runs'. Use work_order_id for that."
+      ),
+      work_order_id: STR(
+        "Only runs collated under this design WORK-ORDER (the kind=design order from list_design_work_orders). One order can hold many runs — that collation is the whole point of a work-order."
+      ),
       parent_run_id: STR("Only child runs of this parent run."),
       run_type: STR("'production' | 'sample'."),
       include_tasks: STR("Pass 'true' to include each run's tasks."),
@@ -1888,7 +1928,7 @@ export const ADMIN_MCP_TOOLS: AdminMcpToolDef[] = [
   {
     name: "get_production_run",
     description:
-      "Get a single production run by id, with its linked tasks. Use to read the run's status, quantity, assigned partner, dispatch state and cost fields.",
+      "Get a single production run by id, with its linked tasks and its assigned materials. Use to read the run's status, quantity, assigned partner, dispatch state and cost fields. `materials` is what THIS run was allocated; `materials_constrained: false` means no selection was made and the partner may use the design's whole bill of materials.",
     method: "GET",
     path: "/admin/production-runs/:id",
     pathParams: ["id"],
@@ -1964,6 +2004,7 @@ export const ADMIN_MCP_TOOLS: AdminMcpToolDef[] = [
       "order_id",
       "order_line_item_id",
       "metadata",
+      "materials",
     ],
     inputSchema: obj(
       {
@@ -1976,6 +2017,7 @@ export const ADMIN_MCP_TOOLS: AdminMcpToolDef[] = [
         order_id: STR("Optional originating order id."),
         order_line_item_id: STR("Optional originating order line item id."),
         metadata: { type: "object", description: "Optional key/value metadata." },
+        materials: RUN_MATERIALS_PARAM,
       },
       ["design_id"]
     ),
@@ -1985,7 +2027,7 @@ export const ADMIN_MCP_TOOLS: AdminMcpToolDef[] = [
   {
     name: "update_production_run",
     description:
-      "Update a production run's quantity, role, run type, partner cost estimate, or correct the output the partner reported (produced_quantity / rejected_quantity). Sensitive: requires confirm:true. Structural edits (quantity/role/run_type) are REJECTED once the run has been accepted or started, and any edit is rejected on a cancelled run — but output corrections are allowed precisely BECAUSE the run is completed. Use dry_run to see the current run first.",
+      "Update a production run's quantity, role, run type, assigned materials, partner cost estimate, or correct the output the partner reported (produced_quantity / rejected_quantity). Sensitive: requires confirm:true. Structural edits (quantity/role/run_type) are REJECTED once the run has been accepted or started, and any edit is rejected on a cancelled run — but output corrections are allowed precisely BECAUSE the run is completed. Use dry_run to see the current run first.",
     method: "POST",
     path: "/admin/production-runs/:id",
     pathParams: ["id"],
@@ -2001,6 +2043,7 @@ export const ADMIN_MCP_TOOLS: AdminMcpToolDef[] = [
       "produced_quantity",
       "rejected_quantity",
       "correction_reason",
+      "materials",
     ],
     inputSchema: obj(
       {
@@ -2030,6 +2073,12 @@ export const ADMIN_MCP_TOOLS: AdminMcpToolDef[] = [
             "Partner cost estimate. Note: the dispatcher drops null arguments, so this tool can set a cost but not clear one — clear it from the admin UI.",
         },
         cost_type: STR("'total' | 'per_unit'."),
+        materials: {
+          ...RUN_MATERIALS_PARAM,
+          description:
+            RUN_MATERIALS_PARAM.description +
+            " REPLACES the run's whole allocation — it is not merged, so send the complete list. Send [] to clear it and make the run unconstrained again. Pre-acceptance only: rejected once the partner has accepted or started, like quantity/role/run_type.",
+        },
       },
       ["id"]
     ),
@@ -2051,7 +2100,7 @@ export const ADMIN_MCP_TOOLS: AdminMcpToolDef[] = [
         assignments: {
           type: "array",
           description:
-            "Partner assignments. Each: { partner_id (required), role?, quantity?, order? (dispatch sequence), template_names? (task templates to auto-dispatch; omit or null for none) }.",
+            "Partner assignments. Each: { partner_id (required), role?, quantity?, order? (dispatch sequence), template_ids?/template_names? (task templates to auto-dispatch; omit or null for none), materials? (the subset of the design's inventory THIS partner is sent) }. Different partners can be given different materials from the same design — that is what makes this an assignment rather than a copy of the design.",
           items: obj(
             {
               partner_id: STR("Partner to assign (required)."),
@@ -2061,8 +2110,14 @@ export const ADMIN_MCP_TOOLS: AdminMcpToolDef[] = [
               template_names: {
                 type: "array",
                 items: { type: "string" },
-                description: "Task templates to instantiate and auto-dispatch for this partner.",
+                description: "Task templates to instantiate and auto-dispatch for this partner. A name may match two templates, and dispatch REFUSES an ambiguous one — prefer template_ids.",
               },
+              template_ids: {
+                type: "array",
+                items: { type: "string" },
+                description: "The same selection BY ID, and the preferred form (#1268): an id survives a rename and cannot be ambiguous. Wins over template_names when both are sent.",
+              },
+              materials: RUN_MATERIALS_PARAM,
             },
             ["partner_id"]
           ),
@@ -2320,13 +2375,28 @@ export const ADMIN_MCP_TOOLS: AdminMcpToolDef[] = [
   {
     name: "list_design_work_orders",
     description:
-      "List collated design work-orders — each with its per-design production runs, the designs themselves and the assigned partners. This is the single best read for 'what is in production right now'.",
+      "List collated design work-orders — each with its per-design production runs, the designs themselves and the assigned partners. One work-order collates the N runs of a commissioning order, so this is where 'this order has several runs' is visible. The single best read for 'what is in production right now'. Pass source_order_id to go from a CUSTOMER order to the work-order it produced, or id to fetch just one.",
     method: "GET",
     path: "/admin/design-work-orders",
-    queryParams: ["limit", "offset"],
+    queryParams: [
+      "limit",
+      "offset",
+      "id",
+      "source_order_id",
+      "partner_id",
+      "run_status",
+    ],
     inputSchema: obj({
       limit: { type: "integer", description: "Max results (default 20)." },
       offset: { type: "integer", description: "Pagination offset." },
+      id: STR("Fetch a single work-order by its order id."),
+      source_order_id: STR(
+        "The COMMISSIONING order the work-order was collated from — the bridge from a customer order to its work-order. (Going the other way, from a work-order to its runs, is list_production_runs with work_order_id.)"
+      ),
+      partner_id: STR("Only work-orders with at least one run assigned to this partner."),
+      run_status: STR(
+        "Only work-orders with at least one run in this status, e.g. 'sent_to_partner'. A work-order's runs can be in different statuses, so this is 'contains', not 'is'."
+      ),
     }),
   },
   {

--- a/apps/backend/src/api/admin/production-runs/[id]/route.ts
+++ b/apps/backend/src/api/admin/production-runs/[id]/route.ts
@@ -93,6 +93,10 @@ import { ContainerRegistrationKeys, MedusaError } from "@medusajs/framework/util
 
 import { PRODUCTION_RUNS_MODULE } from "../../../../modules/production_runs"
 import type ProductionRunService from "../../../../modules/production_runs/service"
+import {
+  readRunAllocation,
+  setRunAllocation,
+} from "../../../../lib/production-run-allocation"
 
 export const GET = async (req: MedusaRequest, res: MedusaResponse) => {
   const id = req.params.id
@@ -117,7 +121,16 @@ export const GET = async (req: MedusaRequest, res: MedusaResponse) => {
     // ignore if link not yet synced
   }
 
-  return res.status(200).json({ production_run: run, tasks })
+  const allocation = await readRunAllocation(req.scope, id)
+
+  return res.status(200).json({
+    production_run: run,
+    tasks,
+    // What this run was actually assigned, as opposed to what its design can be
+    // made of. Empty = no selection was made; the run is unconstrained.
+    materials: allocation,
+    materials_constrained: allocation.length > 0,
+  })
 }
 
 /**
@@ -136,6 +149,13 @@ export const GET = async (req: MedusaRequest, res: MedusaResponse) => {
  * an append-only activity row recording who changed what from what, since the
  * number feeds cost-per-unit, the design cost engine, goods-transfer quantities
  * and the public production story.
+ *
+ * `materials` — the per-assignment allocation — follows the STRUCTURAL rule, not
+ * the correction rule: it is what the partner was sent, so it is editable while
+ * the assignment is still a proposal and frozen once they have accepted it.
+ * Sending it REPLACES the allocation wholesale (the same shape as
+ * `PUT /admin/production-run-policy`); sending `[]` or `null` clears it, which
+ * returns the run to unconstrained — the whole design BOM available again.
  */
 export const POST = async (req: MedusaRequest, res: MedusaResponse) => {
   const id = req.params.id
@@ -212,7 +232,37 @@ export const POST = async (req: MedusaRequest, res: MedusaResponse) => {
   if (producedCorrection !== undefined) update.produced_quantity = producedCorrection
   if (rejectedCorrection !== undefined) update.rejected_quantity = rejectedCorrection
 
+  // The allocation lives in link rows, not columns, so it is applied
+  // separately — and gated BEFORE anything is written, not after.
+  const touchesMaterials = body.materials !== undefined
+  if (touchesMaterials) {
+    if (run.accepted_at || run.started_at) {
+      throw new MedusaError(
+        MedusaError.Types.NOT_ALLOWED,
+        "Cannot change the assigned materials after the run has been accepted or started"
+      )
+    }
+    if (run.status === "completed") {
+      throw new MedusaError(
+        MedusaError.Types.NOT_ALLOWED,
+        "Cannot edit a completed production run"
+      )
+    }
+    await setRunAllocation(req.scope, {
+      production_run_id: id,
+      design_id: run.design_id ?? null,
+      materials: body.materials,
+    })
+  }
+
   if (Object.keys(update).length === 0) {
+    if (touchesMaterials) {
+      const refreshed = await productionRunService.retrieveProductionRun(id)
+      return res.json({
+        production_run: refreshed,
+        materials: await readRunAllocation(req.scope, id),
+      })
+    }
     return res.json({ production_run: run, message: "No changes" })
   }
 
@@ -276,5 +326,10 @@ export const POST = async (req: MedusaRequest, res: MedusaResponse) => {
     }
   }
 
-  res.json({ production_run: updated })
+  res.json({
+    production_run: updated,
+    ...(touchesMaterials
+      ? { materials: await readRunAllocation(req.scope, id) }
+      : {}),
+  })
 }

--- a/apps/backend/src/api/admin/production-runs/route.ts
+++ b/apps/backend/src/api/admin/production-runs/route.ts
@@ -206,6 +206,7 @@ export const POST = async (
       order_id: body.order_id,
       order_line_item_id: body.order_line_item_id,
       metadata: body.metadata,
+      materials: body.materials ?? undefined,
     },
   })
 
@@ -236,8 +237,16 @@ export const GET = async (req: MedusaRequest, res: MedusaResponse) => {
   if (q.product_id) {
     filters.product_id = q.product_id
   }
-  // #826 — filter by the commissioning order so the admin design-order detail
-  // can list all the per-design runs a produce fanned out for that one order.
+  // #826 — filter by the COMMISSIONING order (the customer order that caused
+  // the work) so the admin design-order detail can list all the per-design runs
+  // a produce fanned out for that one order.
+  //
+  // ⚠️ This is `run.order_id`, and it is NOT the collated work-order. Since
+  // #826 S3a a design work-order is a SEPARATE `kind=design` order that holds
+  // the runs through the order↔production_run LINK, while `run.order_id` keeps
+  // pointing at the commissioning order. Passing a work-order id here therefore
+  // matched nothing and returned an empty list — indistinguishable from "that
+  // order has no runs". `work_order_id` below answers the other question.
   if (q.order_id) {
     filters.order_id = q.order_id
   }
@@ -255,6 +264,38 @@ export const GET = async (req: MedusaRequest, res: MedusaResponse) => {
   }
 
   const query = req.scope.resolve(ContainerRegistrationKeys.QUERY)
+
+  // Filter by the COLLATED work-order — the runs reachable through the
+  // order↔production_run link rather than through `run.order_id`. Resolved to
+  // ids first because the link is what holds the relation; there is no column
+  // to filter on. An unknown/unlinked work-order yields an id list of `[]`,
+  // which must produce an empty page rather than an unfiltered one.
+  let workOrderRunIds: string[] | null = null
+  if (q.work_order_id) {
+    const { data: linked } = await (query as any).graph({
+      entity: "order",
+      fields: ["id", "production_runs.id"],
+      filters: { id: q.work_order_id },
+    })
+    const node = (linked || [])[0]
+    const linkedRuns = Array.isArray(node?.production_runs)
+      ? node.production_runs
+      : node?.production_runs
+      ? [node.production_runs]
+      : []
+    workOrderRunIds = linkedRuns
+      .map((r: any) => r?.id)
+      .filter(Boolean) as string[]
+    if (!workOrderRunIds!.length) {
+      return res.status(200).json({
+        production_runs: [],
+        count: 0,
+        limit,
+        offset,
+      })
+    }
+    filters.id = workOrderRunIds
+  }
 
   // #1172 — `q` was not read at all, so a search term was dropped without error
   // and the caller got back an unfiltered first page. Sits alongside the

--- a/apps/backend/src/api/admin/production-runs/validators.ts
+++ b/apps/backend/src/api/admin/production-runs/validators.ts
@@ -1,5 +1,21 @@
 import { z } from "@medusajs/framework/zod"
 
+/**
+ * The materials an assignment is issued — a subset of the design's bill of
+ * materials, not a free-form list. The workflow re-checks membership against
+ * the design (the validator cannot see the BOM); this shape only guarantees the
+ * fields it can. `planned_quantity` is `.positive()` because "allocate 0 of the
+ * silk" would pass the consumption gate while promising nothing.
+ */
+const RunMaterialSchema = z.object({
+  inventory_item_id: z.string().trim().min(1),
+  planned_quantity: z.number().positive().nullish(),
+  location_id: z.string().trim().min(1).nullish(),
+  resolved_raw_material_id: z.string().trim().min(1).nullish(),
+  note: z.string().nullish(),
+  metadata: z.record(z.string(), z.any()).nullish(),
+})
+
 const AssignmentSchema = z.object({
   partner_id: z.string().min(1),
   role: z.string().optional(),
@@ -20,6 +36,12 @@ const AssignmentSchema = z.object({
    * tolerance as the names, for the same reason.
    */
   template_ids: z.array(z.string()).nullish(),
+  /**
+   * Which of the design's inventory items THIS partner is sent, and how much.
+   * Omit (or send an empty array) and the assignment is unconstrained — the
+   * child run carries the whole BOM, exactly as before this field existed.
+   */
+  materials: z.array(RunMaterialSchema).nullish(),
 })
 
 export const AdminCreateProductionRunReq = z.object({
@@ -32,6 +54,7 @@ export const AdminCreateProductionRunReq = z.object({
   order_id: z.string().optional(),
   order_line_item_id: z.string().optional(),
   metadata: z.record(z.string(), z.any()).optional(),
+  materials: z.array(RunMaterialSchema).nullish(),
 })
 
 export const AdminApproveProductionRunReq = z.object({

--- a/apps/backend/src/api/partners/mcp/lib/registry.ts
+++ b/apps/backend/src/api/partners/mcp/lib/registry.ts
@@ -629,7 +629,7 @@ export const PARTNER_MCP_TOOLS: PartnerMcpToolDef[] = [
   {
     name: "log_production_run_consumption",
     description:
-      "Record material/energy/labor consumed by a production run. Quantity > 0; inventoryItemId required.",
+      "Record material/energy/labor consumed by a production run. Quantity > 0; inventoryItemId required. The run may have an ASSIGNED material list — a subset of the design's bill of materials chosen when the work was given to you. If it does, consumption against anything outside that list is REFUSED; read the run first (get_production_run → materials) rather than picking from the design's full BOM.",
     method: "POST",
     path: "/partners/production-runs/:id/consumption-logs",
     pathParams: ["id"],
@@ -970,6 +970,15 @@ export const PARTNER_MCP_TOOLS: PartnerMcpToolDef[] = [
       run_type: { type: "string", enum: ["production", "sample"], description: "Run type filter." },
       design_id: STR("Filter to runs for a specific design."),
     }),
+  },
+  {
+    name: "get_production_run",
+    description:
+      "Get one of the partner's production runs, with its tasks and — the part the list does not carry — the MATERIALS this run was assigned. `materials_constrained: true` means only those items may be consumed against the run; `false` means no selection was made and the design's whole bill of materials is available, as it always was. Read this before log_production_run_consumption.",
+    method: "GET",
+    path: "/partners/production-runs/:id",
+    pathParams: ["id"],
+    inputSchema: obj({ id: STR("Production-run id.") }, ["id"]),
   },
   {
     name: "list_customers",

--- a/apps/backend/src/api/partners/production-runs/[id]/route.ts
+++ b/apps/backend/src/api/partners/production-runs/[id]/route.ts
@@ -106,6 +106,7 @@ import { ContainerRegistrationKeys, MedusaError } from "@medusajs/framework/util
 
 import { PRODUCTION_RUNS_MODULE } from "../../../../modules/production_runs"
 import type ProductionRunService from "../../../../modules/production_runs/service"
+import { readRunAllocation } from "../../../../lib/production-run-allocation"
 
 export async function GET(
   req: AuthenticatedMedusaRequest & { params: { id: string } },
@@ -163,9 +164,28 @@ export async function GET(
     ? (node as any).order[0]?.id
     : (node as any)?.order?.id
 
+  // The materials THIS run was assigned. Empty means no selection was ever
+  // made, which is not the same as "no materials" — the UI falls back to the
+  // design's full bill of materials in that case, as it always did. Sent as an
+  // explicit `materials_constrained` flag so the client does not have to infer
+  // that distinction from an empty array and get it wrong.
+  const allocation = await readRunAllocation(req.scope, id)
+
+  // Also hung on the run itself: every consumer that has the run object (the
+  // card is rendered from three places) then has the allocation with it,
+  // instead of some of them silently falling back to the design's full BOM and
+  // offering the partner materials the consumption gate will refuse.
+  const runWithMaterials = {
+    ...(node as any),
+    materials: allocation,
+    materials_constrained: allocation.length > 0,
+  }
+
   return res.status(200).json({
-    production_run: node,
+    production_run: runWithMaterials,
     tasks: node?.tasks || [],
     unified_order_id: unifiedOrderId,
+    materials: allocation,
+    materials_constrained: allocation.length > 0,
   })
 }

--- a/apps/backend/src/api/partners/storefront/website/theme/__tests__/resolve-detail-band.unit.spec.ts
+++ b/apps/backend/src/api/partners/storefront/website/theme/__tests__/resolve-detail-band.unit.spec.ts
@@ -1,0 +1,130 @@
+import { resolveDetailBand } from "../resolve-detail-band"
+import { detailBandSchema } from "../detail-band"
+
+/**
+ * #1364 — the product detail band.
+ *
+ * The band lists blocks for EVERY product, but each product answers for itself.
+ * These cases pin the two halves of that: the arrangement comes from the theme,
+ * and a block whose product has nothing to show does not render a heading over
+ * a blank.
+ */
+const band = (over: any = {}) =>
+  ({
+    enabled: true,
+    layout: "grid-2",
+    blocks: [
+      { source: "spec" },
+      { source: "maker" },
+      { source: "care", body: "Dry clean only." },
+    ],
+    ...over,
+  }) as any
+
+describe("resolveDetailBand", () => {
+  it("keeps only the blocks this product can actually fill", () => {
+    const resolved = resolveDetailBand(band(), { spec: true, maker: false })
+    expect(resolved?.blocks.map((b) => b.source)).toEqual(["spec", "care"])
+  })
+
+  it("uses the theme's layout and the source's default label", () => {
+    const resolved = resolveDetailBand(band(), { spec: true })
+    expect(resolved?.layout).toBe("grid-2")
+    expect(resolved?.blocks[0].label).toBe("Made to")
+  })
+
+  it("lets the partner rename a block without changing where it reads from", () => {
+    const resolved = resolveDetailBand(
+      band({ blocks: [{ source: "spec", label: "How it's woven" }] }),
+      { spec: true }
+    )
+    expect(resolved?.blocks[0]).toEqual({
+      source: "spec",
+      label: "How it's woven",
+    })
+  })
+
+  /**
+   * The whole reason this function exists. A theme that lists spec + maker +
+   * care would otherwise render three headings over three blanks on a product
+   * that has none of them — advertising detail nobody wrote.
+   */
+  it("drops the band entirely when nothing survives", () => {
+    expect(
+      resolveDetailBand(band({ blocks: [{ source: "spec" }] }), { spec: false })
+    ).toBeNull()
+  })
+
+  it("drops a theme-authored block with no copy — there is no product to fall back to", () => {
+    expect(
+      resolveDetailBand(band({ blocks: [{ source: "care", body: "   " }] }), {})
+    ).toBeNull()
+  })
+
+  it("keeps a disabled block out without making the partner delete it", () => {
+    const resolved = resolveDetailBand(
+      band({
+        blocks: [
+          { source: "spec", enabled: false },
+          { source: "care", body: "Dry clean only." },
+        ],
+      }),
+      { spec: true }
+    )
+    expect(resolved?.blocks.map((b) => b.source)).toEqual(["care"])
+  })
+
+  /**
+   * THE CONTROL THAT MUST NOT FIRE. Every theme that predates the band has no
+   * `detail_band` key, and those product pages must render exactly as before.
+   */
+  it.each([undefined, null, {}, { enabled: false }])(
+    "renders nothing for %p",
+    (value) => {
+      expect(resolveDetailBand(value as any, { spec: true, maker: true })).toBeNull()
+    }
+  )
+
+  it("defaults to rows — a lone block in a 2-up grid is a half-width card beside dead space", () => {
+    const resolved = resolveDetailBand(
+      { enabled: true, blocks: [{ source: "spec" }] } as any,
+      { spec: true }
+    )
+    expect(resolved?.layout).toBe("rows")
+  })
+
+  it("ignores a body written on a per-product source — a theme cannot state a fact about a piece", () => {
+    const resolved = resolveDetailBand(
+      band({ blocks: [{ source: "spec", body: "invented" }] }),
+      { spec: true }
+    )
+    expect(resolved?.blocks[0].body).toBeUndefined()
+  })
+})
+
+describe("the schema the partner and the assistant write through", () => {
+  it("accepts every layout the resolver can return", () => {
+    for (const layout of ["grid-2", "grid-3", "rows", "tabs", "accordion"]) {
+      expect(detailBandSchema.safeParse({ enabled: true, layout }).success).toBe(
+        true
+      )
+    }
+  })
+
+  it("rejects a block with no source — there would be nothing to read", () => {
+    expect(
+      detailBandSchema.safeParse({ blocks: [{ label: "Care" }] }).success
+    ).toBe(false)
+  })
+
+  it("rejects an invented source rather than silently rendering nothing", () => {
+    expect(
+      detailBandSchema.safeParse({ blocks: [{ source: "reviews" }] }).success
+    ).toBe(false)
+  })
+
+  it("caps the band at 8 blocks", () => {
+    const nine = Array.from({ length: 9 }, () => ({ source: "spec" }))
+    expect(detailBandSchema.safeParse({ blocks: nine }).success).toBe(false)
+  })
+})

--- a/apps/backend/src/api/partners/storefront/website/theme/detail-band.ts
+++ b/apps/backend/src/api/partners/storefront/website/theme/detail-band.ts
@@ -1,0 +1,100 @@
+import { z } from "@medusajs/framework/zod"
+
+/**
+ * The product detail band (#1364) — the full-width region BELOW the gallery.
+ *
+ * Everything on a product page used to live in one three-column row, and the
+ * only authorable "more detail" was `description_layout`, which chose a
+ * container for two HARDCODED panels ("Product Information" and "Shipping &
+ * Returns") inside a 300px sticky column. A partner could pick tabs or an
+ * accordion; they could not add a panel, remove one, write one, or put anything
+ * side by side. Between that row and Related Products the page was empty.
+ *
+ * The split that makes this authorable without making every product page a
+ * bespoke build:
+ *
+ *   THE THEME decides the SHAPE — which blocks, in what order, arranged how.
+ *   THE PRODUCT provides the SUBSTANCE — its own spec, its own maker, its own
+ *   fields.
+ *
+ * So a partner arranges their product page once and every product follows it,
+ * while each product still says something true about itself. A block whose
+ * product has nothing to show renders NOTHING — not an empty card with a
+ * heading, which would advertise detail the partner never provided (the same
+ * rule `ProductionSpec` already applies to a spec row with nothing written on
+ * it).
+ */
+
+/** How the band arranges its blocks. */
+export const DETAIL_BAND_LAYOUTS = [
+  /** Side by side, two across on desktop, stacked on mobile. */
+  "grid-2",
+  /** Three across — for short blocks; long prose gets cramped. */
+  "grid-3",
+  /** Full-width sections, one under the next. */
+  "rows",
+  /** One tab per block. Hides everything but the active block. */
+  "tabs",
+  /** One collapsible per block, all closed but the first. */
+  "accordion",
+] as const
+
+/**
+ * Where a block's content comes from. Every source is something the product
+ * ALREADY has — nothing here asks a partner to re-enter what they have already
+ * told us somewhere else.
+ */
+export const DETAIL_BLOCK_SOURCES = [
+  /** The production spec: weave, measured params, finishes (with icons). */
+  "spec",
+  /** The partner's own named spec fields — per-product free text. */
+  "spec_fields",
+  /** Material, origin, type, weight, dimensions — the old hardcoded tab. */
+  "attributes",
+  /** The maker/artisan story, when the product has one. */
+  "maker",
+  /** Care & shipping copy. Theme-level: the same promise on every product. */
+  "care",
+  "shipping",
+] as const
+
+export type DetailBandLayout = (typeof DETAIL_BAND_LAYOUTS)[number]
+export type DetailBlockSource = (typeof DETAIL_BLOCK_SOURCES)[number]
+
+export const detailBlockSchema = z.object({
+  source: z.enum(DETAIL_BLOCK_SOURCES),
+  /** Heading shown for this block. Falls back to the source's default label. */
+  label: z.string().trim().min(1).max(80).optional(),
+  /**
+   * Body copy for the THEME-level sources (`care`, `shipping`). Ignored for the
+   * per-product sources, which read the product — a theme cannot state a fact
+   * about a piece it has never seen.
+   */
+  body: z.string().max(4000).optional(),
+  /**
+   * Off keeps the block in the list, with its label and body, instead of making
+   * the partner delete and retype it to try a layout without it.
+   */
+  enabled: z.boolean().optional(),
+})
+
+export const detailBandSchema = z.object({
+  enabled: z.boolean().optional(),
+  layout: z.enum(DETAIL_BAND_LAYOUTS).optional(),
+  /** Optional heading above the whole band. */
+  heading: z.string().trim().max(120).optional(),
+  blocks: z.array(detailBlockSchema).max(8).optional(),
+})
+
+export type DetailBlock = z.infer<typeof detailBlockSchema>
+export type DetailBand = z.infer<typeof detailBandSchema>
+
+/** The default label for each source, when the partner has not renamed it. */
+export const DEFAULT_BLOCK_LABELS: Record<DetailBlockSource, string> = {
+  spec: "Made to",
+  spec_fields: "Details",
+  attributes: "Product information",
+  maker: "Made by",
+  care: "Care",
+  shipping: "Shipping & returns",
+}

--- a/apps/backend/src/api/partners/storefront/website/theme/resolve-detail-band.ts
+++ b/apps/backend/src/api/partners/storefront/website/theme/resolve-detail-band.ts
@@ -1,0 +1,94 @@
+import {
+  DEFAULT_BLOCK_LABELS,
+  type DetailBand,
+  type DetailBandLayout,
+  type DetailBlockSource,
+} from "./detail-band"
+
+/**
+ * Which blocks a given product actually renders, and how.
+ *
+ * Kept pure and kept HERE — the storefronts carry a byte-identical port (the
+ * same arrangement #1360 used for the spec fetch), so the rule can be exercised
+ * without booting Next.
+ *
+ * The rule that matters is the one about emptiness. The theme lists blocks for
+ * EVERY product, but a product with no spec, no maker and no partner fields
+ * would otherwise render three headings over three blanks — advertising detail
+ * nobody provided, which is worse than the empty band we started with. So a
+ * block is dropped when its product has nothing for it, and the whole band is
+ * dropped when nothing survives.
+ *
+ * `available` is what the CALLER found on the product. It is deliberately not
+ * computed here: the storefront knows whether `getProductSpec` returned rows,
+ * and this function must stay free of fetches so it can be tested.
+ */
+export type BlockAvailability = Partial<Record<DetailBlockSource, boolean>>
+
+export type ResolvedDetailBlock = {
+  source: DetailBlockSource
+  label: string
+  /** Only ever set for the theme-level sources. */
+  body?: string
+}
+
+export type ResolvedDetailBand = {
+  layout: DetailBandLayout
+  heading?: string
+  blocks: ResolvedDetailBlock[]
+}
+
+/** Sources whose content is written in the THEME, not read off the product. */
+const THEME_AUTHORED: DetailBlockSource[] = ["care", "shipping"]
+
+export const resolveDetailBand = (
+  band: DetailBand | null | undefined,
+  available: BlockAvailability
+): ResolvedDetailBand | null => {
+  // Absent is off. The band is new, so every theme that predates it has no
+  // `detail_band` key at all, and those pages must look exactly as they did.
+  if (!band || band.enabled !== true) {
+    return null
+  }
+
+  const blocks: ResolvedDetailBlock[] = []
+
+  for (const block of band.blocks || []) {
+    if (block.enabled === false) {
+      continue
+    }
+
+    const source = block.source
+    const label = (block.label || "").trim() || DEFAULT_BLOCK_LABELS[source]
+
+    if (THEME_AUTHORED.includes(source)) {
+      // A care block with nothing written IS the empty case — there is no
+      // product to fall back to.
+      const body = (block.body || "").trim()
+      if (!body) {
+        continue
+      }
+      blocks.push({ source, label, body })
+      continue
+    }
+
+    // Everything else reads the product, and the caller has already looked.
+    if (!available[source]) {
+      continue
+    }
+    blocks.push({ source, label })
+  }
+
+  if (!blocks.length) {
+    return null
+  }
+
+  return {
+    // `rows` rather than a grid: a band of one block in a 2-up grid renders a
+    // half-width card against dead space, and a partner who never chose a
+    // layout has not asked for that.
+    layout: band.layout || "rows",
+    ...(band.heading?.trim() ? { heading: band.heading.trim() } : {}),
+    blocks,
+  }
+}

--- a/apps/backend/src/api/partners/storefront/website/theme/safe-patch-schema.ts
+++ b/apps/backend/src/api/partners/storefront/website/theme/safe-patch-schema.ts
@@ -20,6 +20,7 @@
  *      applies it.
  */
 import { z } from "@medusajs/framework/zod"
+import { detailBandSchema } from "./detail-band"
 
 const hexColorStrict = z
   .string()
@@ -199,6 +200,12 @@ export const safeThemePatchSchema = z.object({
       show_breadcrumbs: z.boolean().optional(),
       show_sku: z.boolean().optional(),
       cta_text: z.string().optional(),
+      // #1364 — the band below the gallery. Safe for the chat surface: every
+      // per-product source reads content the product already has, and the two
+      // theme-authored ones (care, shipping) are plain copy. The assistant
+      // cannot invent a fact about a piece here, only choose what to show and
+      // how to arrange it.
+      detail_band: detailBandSchema.optional(),
     })
     .optional(),
   cart: z
@@ -260,6 +267,19 @@ home_sections:
 
 ## Product Page
 product_page: show_related_products (boolean), related_heading, show_breadcrumbs (boolean), show_sku (boolean), cta_text
+
+### The detail band — the full-width region BELOW the product image
+product_page.detail_band: { enabled (boolean), heading, layout, blocks[] }
+  - layout: "grid-2" | "grid-3" | "rows" | "tabs" | "accordion"
+  - blocks[]: { source, label, body, enabled (boolean) } — at most 8
+  - source (required, one of): "spec" (weave/params/finishes, shown with icons)
+    | "spec_fields" (the partner's own named fields on that product)
+    | "attributes" (material, origin, type, weight, dimensions)
+    | "maker" (the artisan story) | "care" | "shipping"
+  - "body" applies ONLY to "care" and "shipping", which are the same copy on
+    every product. The other sources read the product itself — do NOT write a
+    body for them, it is ignored. A block whose product has nothing to show is
+    hidden automatically, so it is safe to list one every product may not have.
 
 ## Cart
 cart: heading, empty_message, empty_cta_text, checkout_button_text, show_free_shipping_bar (boolean)

--- a/apps/backend/src/api/partners/storefront/website/theme/validators.ts
+++ b/apps/backend/src/api/partners/storefront/website/theme/validators.ts
@@ -1,4 +1,5 @@
 import { z } from "@medusajs/framework/zod"
+import { detailBandSchema } from "./detail-band"
 
 const hexColor = z
   .string()
@@ -229,6 +230,10 @@ export const websiteThemeSchema = z.object({
       // the collapsed layout.
       gallery_position: z.enum(["left", "center", "right"]).optional(),
       description_layout: z.enum(["tabs", "accordion", "stacked"]).optional(),
+      // #1364 — the full-width band BELOW the gallery. Distinct from
+      // `description_layout`, which only ever chose a container for two
+      // hardcoded panels inside the 300px sticky column.
+      detail_band: detailBandSchema.optional(),
       cta_text: z.string().optional(),
       sample_product_name: z.string().optional(),
       sample_product_price: z.string().optional(),

--- a/apps/backend/src/api/store/products/[id]/spec/route.ts
+++ b/apps/backend/src/api/store/products/[id]/spec/route.ts
@@ -122,6 +122,10 @@ export const GET = async (req: MedusaRequest, res: MedusaResponse) => {
             key: p.key,
             label: p.label,
             unit: p.unit,
+            // #1364 — the glyph the storefront draws beside this row. Sent from
+            // the registry rather than mapped storefront-side on the param
+            // name, so a param added here cannot quietly render naked.
+            icon: p.icon,
           })),
         }
       : null,

--- a/apps/backend/src/lib/production-run-allocation.ts
+++ b/apps/backend/src/lib/production-run-allocation.ts
@@ -1,0 +1,162 @@
+import {
+  ContainerRegistrationKeys,
+  MedusaError,
+  Modules,
+} from "@medusajs/framework/utils"
+import type { LinkDefinition, MedusaContainer } from "@medusajs/framework/types"
+import type { Link } from "@medusajs/modules-sdk"
+
+import ProductionRunInventoryLink from "../links/production-run-inventory-link"
+import DesignInventoryLink from "../links/design-inventory-link"
+import { PRODUCTION_RUNS_MODULE } from "../modules/production_runs"
+import {
+  normalizeRunMaterials,
+  type NormalizedRunMaterial,
+  type RunMaterialInput,
+} from "../workflows/production-runs/lib/run-materials"
+
+export type RunAllocationRow = {
+  inventory_item_id: string
+  planned_quantity: number | null
+  location_id: string | null
+  resolved_raw_material_id: string | null
+  note: string | null
+  metadata: Record<string, any> | null
+  inventory_item?: any
+}
+
+/**
+ * Read a run's material allocation — the items THIS run was assigned, as
+ * opposed to everything its design can be made of.
+ *
+ * Returns `[]` for every run that predates the allocation and for any run
+ * approved without a `materials` array. That emptiness is load-bearing and must
+ * be passed on unchanged: callers distinguish "no selection was made" (the run
+ * is unconstrained, keep the old whole-BOM behaviour) from "these items and no
+ * others". Do not paper over it with the design BOM here — the caller needs to
+ * know which of the two it is looking at.
+ */
+export const readRunAllocation = async (
+  container: MedusaContainer,
+  productionRunId: string
+): Promise<RunAllocationRow[]> => {
+  const query: any = container.resolve(ContainerRegistrationKeys.QUERY)
+
+  const { data } = await query.graph({
+    entity: ProductionRunInventoryLink.entryPoint,
+    fields: [
+      "inventory_item_id",
+      "planned_quantity",
+      "location_id",
+      "resolved_raw_material_id",
+      "note",
+      "metadata",
+      "inventory_item.id",
+      "inventory_item.title",
+      "inventory_item.sku",
+    ],
+    filters: { production_runs_id: productionRunId },
+  })
+
+  return (data || [])
+    .filter((row: any) => row?.inventory_item_id)
+    .map((row: any) => ({
+      inventory_item_id: row.inventory_item_id,
+      planned_quantity:
+        row.planned_quantity === null || row.planned_quantity === undefined
+          ? null
+          : Number(row.planned_quantity),
+      location_id: row.location_id ?? null,
+      resolved_raw_material_id: row.resolved_raw_material_id ?? null,
+      note: row.note ?? null,
+      metadata: row.metadata ?? null,
+      inventory_item: row.inventory_item ?? null,
+    }))
+}
+
+/** Readable labels for a refusal message: `iitem_x` helps nobody on a shop floor. */
+export const allocationLabels = (
+  rows: RunAllocationRow[]
+): Record<string, string> => {
+  const out: Record<string, string> = {}
+  for (const r of rows) {
+    const label = r.inventory_item?.title || r.inventory_item?.sku
+    if (label) out[r.inventory_item_id] = label
+  }
+  return out
+}
+
+/**
+ * Replace a run's allocation wholesale.
+ *
+ * Wholesale on purpose, and worth saying out loud: this is the same shape as
+ * `PUT /admin/production-run-policy`, which replaces its config entirely — a
+ * caller sending a partial list gets a partial allocation, not a merge. Sending
+ * an empty array (or null) clears the allocation and returns the run to
+ * unconstrained, which is a real and sometimes correct outcome: it means "I no
+ * longer want to narrow what this partner may use".
+ *
+ * Validates against the design's bill of materials BEFORE dismissing anything,
+ * so a rejected edit leaves the existing allocation exactly as it was.
+ */
+export const setRunAllocation = async (
+  container: MedusaContainer,
+  input: {
+    production_run_id: string
+    design_id: string | null
+    materials: RunMaterialInput[] | null | undefined
+  }
+): Promise<NormalizedRunMaterial[]> => {
+  const query: any = container.resolve(ContainerRegistrationKeys.QUERY)
+
+  let bomItemIds: string[] | null = null
+  if (input.design_id && input.materials?.length) {
+    const { data: bomRows } = await query.graph({
+      entity: DesignInventoryLink.entryPoint,
+      fields: ["inventory_item_id"],
+      filters: { design_id: input.design_id },
+    })
+    bomItemIds = (bomRows || [])
+      .map((r: any) => r.inventory_item_id)
+      .filter(Boolean)
+  }
+
+  const normalized = normalizeRunMaterials(input.materials, bomItemIds)
+  if (!normalized.ok) {
+    throw new MedusaError(MedusaError.Types.INVALID_DATA, normalized.error)
+  }
+
+  const remoteLink = container.resolve(ContainerRegistrationKeys.LINK) as Link
+  const existing = await readRunAllocation(container, input.production_run_id)
+
+  if (existing.length) {
+    await remoteLink.dismiss(
+      existing.map((row) => ({
+        [PRODUCTION_RUNS_MODULE]: {
+          production_runs_id: input.production_run_id,
+        },
+        [Modules.INVENTORY]: { inventory_item_id: row.inventory_item_id },
+      })) as LinkDefinition[]
+    )
+  }
+
+  if (normalized.materials.length) {
+    await remoteLink.create(
+      normalized.materials.map((m) => ({
+        [PRODUCTION_RUNS_MODULE]: {
+          production_runs_id: input.production_run_id,
+        },
+        [Modules.INVENTORY]: { inventory_item_id: m.inventory_item_id },
+        data: {
+          planned_quantity: m.planned_quantity,
+          location_id: m.location_id,
+          resolved_raw_material_id: m.resolved_raw_material_id,
+          note: m.note,
+          metadata: m.metadata,
+        },
+      })) as LinkDefinition[]
+    )
+  }
+
+  return normalized.materials
+}

--- a/apps/backend/src/links/production-run-inventory-link.ts
+++ b/apps/backend/src/links/production-run-inventory-link.ts
@@ -1,0 +1,50 @@
+import { defineLink } from "@medusajs/framework/utils"
+import ProductionRunsModule from "../modules/production_runs"
+import InventoryModule from "@medusajs/medusa/inventory"
+
+/**
+ * The per-ASSIGNMENT material allocation: which of a design's inventory items
+ * THIS run was actually sent out with, and how much of each.
+ *
+ * Before this link, a run snapshotted the design's ENTIRE bill of materials
+ * (`fetchDesignInventorySnapshotStep` filtered on `design_id` alone) and the
+ * partner's consumption picker offered every item the design had ever been
+ * linked to. A design with five inventory items handed to two partners asked
+ * both of them about all five — there was no way to say "this partner is only
+ * getting the silk".
+ *
+ * Authoritative on purpose. `run.snapshot.inventory_links` is narrowed to match
+ * this allocation, but the snapshot is a json blob that a metadata-shaped write
+ * can replace wholesale, and consumption is REJECTED against items outside the
+ * allocation — a rule that decides a 400 must not be read out of a blob. The
+ * snapshot stays what it always was: point-in-time provenance.
+ *
+ * ABSENCE IS NOT AN EMPTY ALLOCATION. Every run created before this link has
+ * zero rows here, and so does any run approved without a `materials` array.
+ * Those runs keep the old behaviour (the whole design BOM is available) — the
+ * enforcement only engages once someone has actually made a selection. A run
+ * with rows here is constrained to them; a run with none is unconstrained.
+ */
+export default defineLink(
+  { linkable: ProductionRunsModule.linkable.productionRuns, isList: true },
+  { linkable: InventoryModule.linkable.inventoryItem, isList: true },
+  {
+    database: {
+      extraColumns: {
+        /** How much of this item the run was allocated. Null = unspecified. */
+        planned_quantity: { type: "decimal", nullable: true },
+        /** Where the material is issued FROM, when it differs from the design's. */
+        location_id: { type: "text", nullable: true },
+        /**
+         * #817 S4 — the colour actually chosen for THIS run. The design↔group
+         * link carries a single `resolved_raw_material_id` for the whole design,
+         * so two runs of one design in two colours collide there. Per-run is the
+         * only grain at which that answer is true.
+         */
+        resolved_raw_material_id: { type: "text", nullable: true },
+        note: { type: "text", nullable: true },
+        metadata: { type: "json", nullable: true },
+      },
+    },
+  }
+)

--- a/apps/backend/src/modules/product-spec/weaving-techniques.ts
+++ b/apps/backend/src/modules/product-spec/weaving-techniques.ts
@@ -27,7 +27,37 @@ export interface WeaveParamDef {
   max: number
   step: number
   default: number
+  /**
+   * #1364 — which glyph a storefront draws beside this row.
+   *
+   * Lives HERE rather than in a storefront lookup keyed on the param name, for
+   * the same reason the label and the unit do: this file is where a param is
+   * defined, and a mapping kept anywhere else silently loses its entry the day
+   * someone adds a param — the row would still render, just naked, and nobody
+   * would notice. A storefront that does not recognise a name falls back to a
+   * neutral mark, so an unknown icon is a plain row and never a crash.
+   */
+  icon: SpecIcon
 }
+
+/**
+ * The glyph vocabulary. Deliberately small and about MEASUREMENT rather than
+ * decoration — a row saying "Weight 240 GSM" wants a scale, not a picture of
+ * cloth. Storefronts draw these; they are names, not assets.
+ */
+export type SpecIcon =
+  | "weave"
+  | "weight"
+  | "warp"
+  | "weft"
+  | "yarn"
+  | "width"
+  | "angle"
+  | "density"
+  | "loom"
+  | "metal"
+  | "finish"
+  | "note"
 
 /** A ready-made spec — picking one auto-fills the whole form. */
 export interface WeavePreset {
@@ -79,6 +109,7 @@ const GSM: WeaveParamDef = {
   max: 900,
   step: 5,
   default: 120,
+  icon: "weight",
 }
 const ENDS: WeaveParamDef = {
   key: "ends_per_inch",
@@ -88,6 +119,7 @@ const ENDS: WeaveParamDef = {
   max: 200,
   step: 1,
   default: 60,
+  icon: "warp",
 }
 const PICKS: WeaveParamDef = {
   key: "picks_per_inch",
@@ -97,6 +129,7 @@ const PICKS: WeaveParamDef = {
   max: 200,
   step: 1,
   default: 60,
+  icon: "weft",
 }
 const WARP_COUNT: WeaveParamDef = {
   key: "warp_yarn_count",
@@ -106,6 +139,7 @@ const WARP_COUNT: WeaveParamDef = {
   max: 200,
   step: 1,
   default: 40,
+  icon: "yarn",
 }
 const WEFT_COUNT: WeaveParamDef = {
   key: "weft_yarn_count",
@@ -115,6 +149,7 @@ const WEFT_COUNT: WeaveParamDef = {
   max: 200,
   step: 1,
   default: 40,
+  icon: "yarn",
 }
 const LOOM_WIDTH: WeaveParamDef = {
   key: "loom_width_cm",
@@ -124,6 +159,7 @@ const LOOM_WIDTH: WeaveParamDef = {
   max: 300,
   step: 1,
   default: 91,
+  icon: "width",
 }
 
 export const WEAVE_TECHNIQUES: WeaveTechnique[] = [
@@ -169,6 +205,7 @@ export const WEAVE_TECHNIQUES: WeaveTechnique[] = [
         max: 75,
         step: 5,
         default: 45,
+  icon: "angle",
       },
     ],
     defaultFinishes: ["hand wash", "press on reverse"],
@@ -232,6 +269,7 @@ export const WEAVE_TECHNIQUES: WeaveTechnique[] = [
         max: 200,
         step: 1,
         default: 40,
+        icon: "loom",
       },
     ],
     defaultFinishes: ["dry clean only"],
@@ -275,6 +313,7 @@ export const WEAVE_TECHNIQUES: WeaveTechnique[] = [
         max: 200,
         step: 1,
         default: 25,
+        icon: "density",
       },
     ],
     defaultFinishes: ["do not soak", "hand wash cold"],
@@ -308,6 +347,7 @@ export const WEAVE_TECHNIQUES: WeaveTechnique[] = [
         max: 100,
         step: 1,
         default: 15,
+        icon: "metal",
       },
     ],
     defaultFinishes: ["dry clean only", "store folded in muslin"],
@@ -331,6 +371,7 @@ export const WEAVE_TECHNIQUES: WeaveTechnique[] = [
         max: 10000,
         step: 100,
         default: 1200,
+        icon: "loom",
       },
     ],
     defaultFinishes: ["dry clean"],
@@ -354,6 +395,7 @@ export const WEAVE_TECHNIQUES: WeaveTechnique[] = [
         max: 32,
         step: 1,
         default: 8,
+        icon: "loom",
       },
     ],
     defaultFinishes: ["hand wash"],

--- a/apps/backend/src/workflows/consumption-logs/log-consumption.ts
+++ b/apps/backend/src/workflows/consumption-logs/log-consumption.ts
@@ -14,6 +14,11 @@ import ConsumptionLogService from "../../modules/consumption_log/service"
 import { DESIGN_MODULE } from "../../modules/designs"
 import DesignService from "../../modules/designs/service"
 import { PRODUCTION_RUNS_MODULE } from "../../modules/production_runs"
+import {
+  allocationLabels,
+  readRunAllocation,
+} from "../../lib/production-run-allocation"
+import { checkConsumptionAgainstAllocation } from "../production-runs/lib/run-materials"
 
 // Energy/labor consumption types that don't require an inventory item
 const NON_INVENTORY_TYPES = ["energy_electricity", "energy_water", "energy_gas", "labor"]
@@ -84,6 +89,43 @@ const validateInventoryItemStep = createStep(
     }
 
     return new StepResponse(item)
+  }
+)
+
+/**
+ * A run may only consume what it was assigned.
+ *
+ * Deliberately here in the WORKFLOW rather than on the partner route: three
+ * routes reach this workflow (partner run, partner design, admin design) and a
+ * guard on one path is not a guard — #1314 refused loudly on the manual path
+ * while the automatic one went through silently. Every consumption that names a
+ * production run passes through this step.
+ *
+ * Runs to completion BEFORE the log row is created, so a refusal writes nothing.
+ *
+ * Silent on runs with no allocation, which is every run made before this
+ * existed. See run-materials.ts — absence is "nobody chose", not "chose
+ * nothing", and treating them alike would 400 the entire existing floor.
+ */
+const assertConsumptionWithinAllocationStep = createStep(
+  "log-consumption-assert-within-allocation",
+  async (
+    input: { production_run_id: string; inventory_item_id: string },
+    { container }
+  ) => {
+    const allocation = await readRunAllocation(container, input.production_run_id)
+
+    const verdict = checkConsumptionAgainstAllocation({
+      allocatedInventoryItemIds: allocation.map((a) => a.inventory_item_id),
+      inventoryItemId: input.inventory_item_id,
+      labelsById: allocationLabels(allocation),
+    })
+
+    if (!verdict.allowed) {
+      throw new MedusaError(MedusaError.Types.NOT_ALLOWED, verdict.reason)
+    }
+
+    return new StepResponse({ constrained: verdict.constrained })
   }
 )
 
@@ -198,6 +240,24 @@ export const logConsumptionWorkflow = createWorkflow(
 
     when(hasInventoryItem, (data) => data.has_item).then(() => {
       validateInventoryItemStep({ inventory_item_id: hasInventoryItem.inventory_item_id })
+    })
+
+    // Only material consumption against a named run can be off-plan; energy and
+    // labour have no inventory item to be outside the allocation.
+    const allocationCheck = transform({ input }, (data) => ({
+      production_run_id: data.input.production_run_id || "",
+      inventory_item_id: data.input.inventory_item_id || "",
+      applies:
+        !!data.input.production_run_id &&
+        !!data.input.inventory_item_id &&
+        !NON_INVENTORY_TYPES.includes(data.input.consumption_type || ""),
+    }))
+
+    when(allocationCheck, (data) => data.applies).then(() => {
+      assertConsumptionWithinAllocationStep({
+        production_run_id: allocationCheck.production_run_id,
+        inventory_item_id: allocationCheck.inventory_item_id,
+      })
     })
 
     const log = createConsumptionLogStep(input)

--- a/apps/backend/src/workflows/production-runs/__tests__/run-materials.unit.spec.ts
+++ b/apps/backend/src/workflows/production-runs/__tests__/run-materials.unit.spec.ts
@@ -1,0 +1,159 @@
+import {
+  checkConsumptionAgainstAllocation,
+  normalizeRunMaterials,
+} from "../lib/run-materials"
+
+/**
+ * The per-assignment material allocation.
+ *
+ * Before this existed, a run snapshotted its design's ENTIRE bill of materials
+ * and every partner was asked to account for all of it — a design with five
+ * inventory items handed to two partners asked both about all five. These cases
+ * pin the two rules that make an assignment a real selection, and, just as
+ * importantly, the case where the rules must NOT fire.
+ */
+describe("normalizeRunMaterials", () => {
+  const bom = ["iitem_silk", "iitem_thread", "iitem_lining"]
+
+  it("keeps only what was chosen, out of everything the design can use", () => {
+    const result = normalizeRunMaterials(
+      [{ inventory_item_id: "iitem_silk", planned_quantity: 40 }],
+      bom
+    )
+    expect(result.ok).toBe(true)
+    if (!result.ok) return
+    expect(result.materials).toHaveLength(1)
+    expect(result.materials[0]).toMatchObject({
+      inventory_item_id: "iitem_silk",
+      planned_quantity: 40,
+    })
+  })
+
+  it("carries the per-run colour choice, which the design-level link cannot hold", () => {
+    // The design↔group link has ONE resolved_raw_material_id for the whole
+    // design, so two runs of one design in two colours collide there.
+    const a = normalizeRunMaterials(
+      [{ inventory_item_id: "iitem_silk", resolved_raw_material_id: "rm_indigo" }],
+      bom
+    )
+    const b = normalizeRunMaterials(
+      [{ inventory_item_id: "iitem_silk", resolved_raw_material_id: "rm_madder" }],
+      bom
+    )
+    expect(a.ok && a.materials[0].resolved_raw_material_id).toBe("rm_indigo")
+    expect(b.ok && b.materials[0].resolved_raw_material_id).toBe("rm_madder")
+  })
+
+  it("refuses an item the design does not use", () => {
+    // Quietly dropping it would ship the partner a short BOM and say nothing.
+    const result = normalizeRunMaterials(
+      [{ inventory_item_id: "iitem_from_another_design" }],
+      bom
+    )
+    expect(result.ok).toBe(false)
+    if (result.ok) return
+    expect(result.error).toContain("iitem_from_another_design")
+    expect(result.error).toContain("bill of materials")
+  })
+
+  it("refuses the same item twice — two answers to 'how much'", () => {
+    const result = normalizeRunMaterials(
+      [
+        { inventory_item_id: "iitem_silk", planned_quantity: 40 },
+        { inventory_item_id: "iitem_silk", planned_quantity: 12 },
+      ],
+      bom
+    )
+    expect(result.ok).toBe(false)
+    if (result.ok) return
+    expect(result.error).toContain("twice")
+  })
+
+  it.each([0, -3])("refuses planned_quantity %p", (qty) => {
+    // "Allocate 0 of the silk" passes the consumption gate while promising
+    // nothing — an omission written down as if it were a decision.
+    const result = normalizeRunMaterials(
+      [{ inventory_item_id: "iitem_silk", planned_quantity: qty }],
+      bom
+    )
+    expect(result.ok).toBe(false)
+    if (result.ok) return
+    expect(result.error).toContain("positive")
+  })
+
+  it("leaves planned_quantity null when it was not stated", () => {
+    const result = normalizeRunMaterials([{ inventory_item_id: "iitem_silk" }], bom)
+    expect(result.ok && result.materials[0].planned_quantity).toBeNull()
+  })
+
+  it("skips the subset rule when the run has no design (#1112 product-only path)", () => {
+    // There is nothing to be a subset OF; failing everything would be wrong.
+    const result = normalizeRunMaterials(
+      [{ inventory_item_id: "iitem_anything" }],
+      null
+    )
+    expect(result.ok).toBe(true)
+  })
+
+  it.each([undefined, null, []])("treats %p as no allocation, not an error", (m) => {
+    const result = normalizeRunMaterials(m as any, bom)
+    expect(result.ok).toBe(true)
+    if (!result.ok) return
+    expect(result.materials).toEqual([])
+  })
+})
+
+describe("checkConsumptionAgainstAllocation", () => {
+  it("refuses an item outside the allocation, and says what IS assigned", () => {
+    const verdict = checkConsumptionAgainstAllocation({
+      allocatedInventoryItemIds: ["iitem_silk", "iitem_thread"],
+      inventoryItemId: "iitem_lining",
+      labelsById: {
+        iitem_silk: "Mulberry silk",
+        iitem_thread: "Cotton thread",
+        iitem_lining: "Lining",
+      },
+    })
+    expect(verdict.allowed).toBe(false)
+    if (verdict.allowed) return
+    // A partner cannot act on `iitem_lining is not allowed`.
+    expect(verdict.reason).toContain("Lining")
+    expect(verdict.reason).toContain("Mulberry silk")
+    expect(verdict.reason).toContain("Cotton thread")
+  })
+
+  it("allows an item inside the allocation", () => {
+    const verdict = checkConsumptionAgainstAllocation({
+      allocatedInventoryItemIds: ["iitem_silk"],
+      inventoryItemId: "iitem_silk",
+    })
+    expect(verdict).toEqual({ allowed: true, constrained: true })
+  })
+
+  /**
+   * THE CONTROL THAT MUST NOT FIRE.
+   *
+   * Every run made before this feature has no allocation, as does any
+   * assignment sent without `materials`. Reading that emptiness as "chose
+   * nothing" rather than "nobody chose" would 400 the entire existing floor —
+   * the failure would look exactly like the feature working.
+   */
+  it.each([undefined, null, []])(
+    "leaves a run with %p allocation unconstrained",
+    (allocation) => {
+      const verdict = checkConsumptionAgainstAllocation({
+        allocatedInventoryItemIds: allocation as any,
+        inventoryItemId: "iitem_anything_at_all",
+      })
+      expect(verdict).toEqual({ allowed: true, constrained: false })
+    }
+  )
+
+  it("requires an inventory item once an allocation exists", () => {
+    const verdict = checkConsumptionAgainstAllocation({
+      allocatedInventoryItemIds: ["iitem_silk"],
+      inventoryItemId: undefined,
+    })
+    expect(verdict.allowed).toBe(false)
+  })
+})

--- a/apps/backend/src/workflows/production-runs/approve-production-run.ts
+++ b/apps/backend/src/workflows/production-runs/approve-production-run.ts
@@ -1,4 +1,4 @@
-import { ContainerRegistrationKeys, MedusaError } from "@medusajs/framework/utils"
+import { ContainerRegistrationKeys, MedusaError, Modules } from "@medusajs/framework/utils"
 import {
   createStep,
   createWorkflow,
@@ -7,6 +7,7 @@ import {
   transform,
 } from "@medusajs/framework/workflows-sdk"
 import type { LinkDefinition } from "@medusajs/framework/types"
+import type { Link } from "@medusajs/modules-sdk"
 
 import { PRODUCTION_RUNS_MODULE } from "../../modules/production_runs"
 import type ProductionRunService from "../../modules/production_runs/service"
@@ -18,6 +19,12 @@ import { DESIGN_MODULE } from "../../modules/designs"
 import { PARTNER_MODULE } from "../../modules/partner"
 import designPartnersLink from "../../links/design-partners-link"
 import { dualWriteChildRunOrdersStep } from "./dual-write-unified-run-order"
+import DesignInventoryLink from "../../links/design-inventory-link"
+import {
+  normalizeRunMaterials,
+  type NormalizedRunMaterial,
+  type RunMaterialInput,
+} from "./lib/run-materials"
 
 export type ProductionRunAssignment = {
   partner_id: string
@@ -32,6 +39,16 @@ export type ProductionRunAssignment = {
   template_names?: string[]
   /** Templates BY ID — preferred. Wins over `template_names` when both are sent. */
   template_ids?: string[]
+  /**
+   * The materials THIS partner is being sent: a subset of the design's bill of
+   * materials, with the quantity issued to them.
+   *
+   * Omit and the assignment behaves exactly as it always has — the child run
+   * carries the whole design BOM and the partner is asked to account for all of
+   * it. That was the only available behaviour before this field existed, which
+   * is why absence has to keep meaning "unconstrained" rather than "nothing".
+   */
+  materials?: RunMaterialInput[]
 }
 
 export type ApproveProductionRunInput = {
@@ -77,6 +94,38 @@ const approveProductionRunStep = createStep(
 
     await productionPolicyService.assertCanApprove(original as any)
 
+    // Validate every assignment's material allocation BEFORE anything is
+    // written. An invalid `materials` array must be a no-op, not a parent left
+    // flipped to `approved` with no children to show for it (#1358's shape:
+    // the rejection that is a corruption because the write already happened).
+    const requestedAssignments = input.assignments || []
+    const wantsMaterials = requestedAssignments.some((a) => a.materials?.length)
+    let bomItemIds: string[] | null = null
+    if (wantsMaterials && (original as any).design_id) {
+      const query: any = container.resolve(ContainerRegistrationKeys.QUERY)
+      const { data: bomRows } = await query.graph({
+        entity: DesignInventoryLink.entryPoint,
+        fields: ["inventory_item_id"],
+        filters: { design_id: (original as any).design_id },
+      })
+      bomItemIds = (bomRows || [])
+        .map((r: any) => r.inventory_item_id)
+        .filter(Boolean)
+    }
+
+    const allocationByIndex: NormalizedRunMaterial[][] = requestedAssignments.map(
+      (a, idx) => {
+        const normalized = normalizeRunMaterials(a.materials, bomItemIds)
+        if (!normalized.ok) {
+          throw new MedusaError(
+            MedusaError.Types.INVALID_DATA,
+            `assignment ${idx} (partner ${a.partner_id}): ${normalized.error}`
+          )
+        }
+        return normalized.materials
+      }
+    )
+
     const updatedParent = await productionRunService.updateProductionRuns({
       id: original.id,
       status: "approved" as any,
@@ -98,13 +147,38 @@ const approveProductionRunStep = createStep(
     const { unified_order_id: _omitParentOrderRef, ...inheritedMetadata } =
       ((original as any).metadata ?? {}) as Record<string, any>
 
-    const childPayloads = assignments.map((a) => {
+    const childPayloads = assignments.map((a, idx) => {
       const quantity = a.quantity ?? (original as any).quantity ?? 1
+      const allocation = allocationByIndex[idx] || []
 
       const originalSnapshot = (original as any).snapshot
+      // Narrow the child's snapshot to what this partner is actually getting.
+      // The parent still carries the full BOM — it is the design's plan; the
+      // child carries the issue list, which is a different fact.
+      const parentLinks: any[] = Array.isArray(originalSnapshot?.inventory_links)
+        ? originalSnapshot.inventory_links
+        : []
+      const parentLinkById = new Map(
+        parentLinks.map((l: any) => [l.inventory_item_id, l])
+      )
+      const narrowedLinks = allocation.length
+        ? allocation.map((m) => {
+            const base: any = parentLinkById.get(m.inventory_item_id) || {}
+            return {
+              ...base,
+              inventory_item_id: m.inventory_item_id,
+              planned_quantity: m.planned_quantity ?? base.planned_quantity ?? null,
+              location_id: m.location_id ?? base.location_id ?? null,
+              resolved_raw_material_id: m.resolved_raw_material_id ?? null,
+              metadata: { ...(base.metadata || {}), ...(m.metadata || {}) },
+            }
+          })
+        : parentLinks
+
       const snapshot = originalSnapshot
         ? {
             ...originalSnapshot,
+            inventory_links: narrowedLinks,
             provenance: {
               ...(originalSnapshot as any).provenance,
               partner_id: a.partner_id,
@@ -139,6 +213,32 @@ const approveProductionRunStep = createStep(
     const children = Array.isArray(createdChildren) ? createdChildren : [createdChildren]
 
     const childIds = children.map((c: any) => c.id).filter(Boolean)
+
+    // The authoritative allocation. Written after the children exist (it needs
+    // their ids) but validated long before — see above.
+    const allocationLinks: LinkDefinition[] = []
+    for (let i = 0; i < children.length; i++) {
+      const childId = (children[i] as any)?.id
+      const allocation = allocationByIndex[i] || []
+      if (!childId || !allocation.length) continue
+      for (const m of allocation) {
+        allocationLinks.push({
+          [PRODUCTION_RUNS_MODULE]: { production_runs_id: childId },
+          [Modules.INVENTORY]: { inventory_item_id: m.inventory_item_id },
+          data: {
+            planned_quantity: m.planned_quantity,
+            location_id: m.location_id,
+            resolved_raw_material_id: m.resolved_raw_material_id,
+            note: m.note,
+            metadata: m.metadata,
+          },
+        })
+      }
+    }
+    if (allocationLinks.length) {
+      const remoteLink = container.resolve(ContainerRegistrationKeys.LINK) as Link
+      await remoteLink.create(allocationLinks)
+    }
 
     // Compute depends_on_run_ids based on assignment order
     const hasOrdering = assignments.some((a) => a.order != null)
@@ -178,21 +278,32 @@ const approveProductionRunStep = createStep(
 
       return new StepResponse(
         { parent: updatedParent, children: refreshedChildren },
-        { parentOriginal: original, childIds }
+        { parentOriginal: original, childIds, allocationLinks }
       )
     }
 
     return new StepResponse(
       { parent: updatedParent, children },
-      { parentOriginal: original, childIds }
+      { parentOriginal: original, childIds, allocationLinks }
     )
   },
   async (
-    rollbackData: { parentOriginal: any; childIds: string[] } | undefined,
+    rollbackData:
+      | {
+          parentOriginal: any
+          childIds: string[]
+          allocationLinks?: LinkDefinition[]
+        }
+      | undefined,
     { container }
   ) => {
     if (!rollbackData) {
       return
+    }
+
+    if (rollbackData.allocationLinks?.length) {
+      const remoteLink = container.resolve(ContainerRegistrationKeys.LINK) as Link
+      await remoteLink.dismiss(rollbackData.allocationLinks)
     }
 
     const productionRunService: ProductionRunService = container.resolve(

--- a/apps/backend/src/workflows/production-runs/create-production-run.ts
+++ b/apps/backend/src/workflows/production-runs/create-production-run.ts
@@ -15,6 +15,11 @@ import type ProductionRunService from "../../modules/production_runs/service"
 
 import { TASKS_MODULE } from "../../modules/tasks"
 import DesignInventoryLink from "../../links/design-inventory-link"
+import {
+  normalizeRunMaterials,
+  type NormalizedRunMaterial,
+  type RunMaterialInput,
+} from "./lib/run-materials"
 import { dualWriteUnifiedRunOrderStep } from "./dual-write-unified-run-order"
 
 const sanitizeBigInt = (value: any): any => {
@@ -53,6 +58,13 @@ export type CreateProductionRunInput = {
   order_line_item_id?: string
   metadata?: Record<string, any>
   task_ids?: string[]
+  /**
+   * The per-assignment material allocation: WHICH of the design's inventory
+   * items this run is actually sent out with, and how much of each. Omit to
+   * keep the historical behaviour — the whole design BOM stays available to the
+   * partner. Must be a subset of the design's linked inventory items.
+   */
+  materials?: RunMaterialInput[]
   // Roadmap #6 Phase 4 — partner self-serve runs.
   status?:
     | "draft"
@@ -102,24 +114,29 @@ const fetchDesignSnapshotStep = createStep(
 
 const fetchDesignInventorySnapshotStep = createStep(
   "fetch-design-inventory-snapshot",
-  async (input: Pick<CreateProductionRunInput, "design_id">, { container }) => {
+  async (
+    input: Pick<CreateProductionRunInput, "design_id" | "materials">,
+    { container }
+  ) => {
     const query: any = container.resolve(ContainerRegistrationKeys.QUERY)
 
-    const { data: linkRows } = await query.graph({
-      entity: DesignInventoryLink.entryPoint,
-      fields: [
-        "*",
-        "inventory_item.*",
-        "inventory_item.raw_materials.*",
-        "inventory_item.location_levels.*",
-        "inventory_item.location_levels.stock_locations.*",
-      ],
-      filters: {
-        design_id: input.design_id,
-      },
-    })
+    const { data: linkRows } = input.design_id
+      ? await query.graph({
+          entity: DesignInventoryLink.entryPoint,
+          fields: [
+            "*",
+            "inventory_item.*",
+            "inventory_item.raw_materials.*",
+            "inventory_item.location_levels.*",
+            "inventory_item.location_levels.stock_locations.*",
+          ],
+          filters: {
+            design_id: input.design_id,
+          },
+        })
+      : { data: [] }
 
-    const inventoryLinks = (linkRows || []).map((row: any) => {
+    const bomLinks = (linkRows || []).map((row: any) => {
       const sanitizedRow = sanitizeBigInt(row)
       return {
         inventory_item_id: sanitizedRow.inventory_item_id,
@@ -132,7 +149,91 @@ const fetchDesignInventorySnapshotStep = createStep(
       }
     })
 
-    return new StepResponse({ inventory_links: inventoryLinks })
+    // No allocation asked for → the run snapshots the whole BOM, exactly as it
+    // always did. "Nobody chose" is not "chose nothing"; see run-materials.ts.
+    const normalized = normalizeRunMaterials(
+      input.materials,
+      input.design_id ? bomLinks.map((l: any) => l.inventory_item_id) : null
+    )
+    if (!normalized.ok) {
+      throw new MedusaError(MedusaError.Types.INVALID_DATA, normalized.error)
+    }
+    if (!normalized.materials.length) {
+      return new StepResponse({
+        inventory_links: bomLinks,
+        allocation: [] as NormalizedRunMaterial[],
+      })
+    }
+
+    // Narrow the snapshot to the allocation, and let the assignment's
+    // planned_quantity win over the design's — the design says how much the
+    // GARMENT needs, the assignment says how much THIS partner is being issued.
+    const bomById = new Map(bomLinks.map((l: any) => [l.inventory_item_id, l]))
+    const inventoryLinks = normalized.materials.map((m) => {
+      const bom: any = bomById.get(m.inventory_item_id) || {}
+      return {
+        ...bom,
+        inventory_item_id: m.inventory_item_id,
+        planned_quantity:
+          m.planned_quantity ?? bom.planned_quantity ?? null,
+        location_id: m.location_id ?? bom.location_id ?? null,
+        resolved_raw_material_id: m.resolved_raw_material_id ?? null,
+        metadata: { ...(bom.metadata || {}), ...(m.metadata || {}) },
+      }
+    })
+
+    return new StepResponse({
+      inventory_links: inventoryLinks,
+      allocation: normalized.materials,
+    })
+  }
+)
+
+/**
+ * Persist the allocation as real link rows. The snapshot above is provenance;
+ * THIS is what the consumption gate reads, because a rule that decides a 400
+ * must not live in a json blob a wholesale write can replace.
+ */
+const linkProductionRunMaterialsStep = createStep(
+  "link-production-run-materials",
+  async (
+    input: {
+      production_run_id: string
+      allocation: NormalizedRunMaterial[]
+    },
+    { container }
+  ) => {
+    if (!input.allocation?.length) {
+      return new StepResponse([] as LinkDefinition[], [] as LinkDefinition[])
+    }
+
+    const remoteLink = container.resolve(ContainerRegistrationKeys.LINK) as Link
+
+    const links: LinkDefinition[] = input.allocation.map((m) => ({
+      [PRODUCTION_RUNS_MODULE]: {
+        production_runs_id: input.production_run_id,
+      },
+      [Modules.INVENTORY]: {
+        inventory_item_id: m.inventory_item_id,
+      },
+      data: {
+        planned_quantity: m.planned_quantity,
+        location_id: m.location_id,
+        resolved_raw_material_id: m.resolved_raw_material_id,
+        note: m.note,
+        metadata: m.metadata,
+      },
+    }))
+
+    await remoteLink.create(links)
+    return new StepResponse(links, links)
+  },
+  async (links: LinkDefinition[] | undefined, { container }) => {
+    if (!links?.length) {
+      return
+    }
+    const remoteLink = container.resolve(ContainerRegistrationKeys.LINK) as Link
+    await remoteLink.dismiss(links)
   }
 )
 
@@ -219,7 +320,10 @@ const createProductionRunStep = createStep(
     input: {
       payload: CreateProductionRunInput
       design?: any
-      inventory?: { inventory_links: any[] } | null
+      inventory?: {
+        inventory_links: any[]
+        allocation?: NormalizedRunMaterial[]
+      } | null
       captured_at: Date
       snapshot: Record<string, any>
     },
@@ -316,8 +420,13 @@ export const createProductionRunWorkflow = createWorkflow(
       () => fetchDesignSnapshotStep({ design_id: input.design_id })
     )
     const inventory = when({ input }, (data) =>
-      Boolean(data.input.design_id)
-    ).then(() => fetchDesignInventorySnapshotStep({ design_id: input.design_id }))
+      Boolean(data.input.design_id) || Boolean(data.input.materials?.length)
+    ).then(() =>
+      fetchDesignInventorySnapshotStep({
+        design_id: input.design_id,
+        materials: input.materials,
+      })
+    )
     const product = when({ input }, (data) => !data.input.design_id).then(() =>
       fetchProductSnapshotStep({ product_id: input.product_id })
     )
@@ -393,6 +502,18 @@ export const createProductionRunWorkflow = createWorkflow(
       linkProductionRunToProductStep({
         production_run_id: productionRunId,
         product_id: input.product_id,
+      })
+    })
+
+    // The allocation rows. Gated on the input, not on the step result, so a run
+    // created without `materials` writes nothing and stays unconstrained.
+    when({ input }, (data) => Boolean(data.input.materials?.length)).then(() => {
+      linkProductionRunMaterialsStep({
+        production_run_id: productionRunId,
+        allocation: transform(
+          { inventory },
+          (d) => ((d.inventory as any)?.allocation || []) as NormalizedRunMaterial[]
+        ),
       })
     })
 

--- a/apps/backend/src/workflows/production-runs/lib/run-materials.ts
+++ b/apps/backend/src/workflows/production-runs/lib/run-materials.ts
@@ -1,0 +1,156 @@
+// The per-assignment material allocation, as pure rules.
+//
+// A design's bill of materials answers "what can this design be made of". It has
+// never answered "what is THIS partner being sent", and the two were conflated:
+// every run snapshotted the whole BOM and every partner was asked to account for
+// all of it. These functions are the missing distinction, kept free of the
+// container so the rules can be exercised directly — including the cases where
+// they must NOT fire.
+
+export type RunMaterialInput = {
+  inventory_item_id: string
+  /** How much of this item the assignment gets. Omit to leave unstated. */
+  planned_quantity?: number | null
+  location_id?: string | null
+  /** #817 S4 — the colour chosen for this run, when the design pinned a group. */
+  resolved_raw_material_id?: string | null
+  note?: string | null
+  metadata?: Record<string, any> | null
+}
+
+export type NormalizedRunMaterial = Required<
+  Pick<RunMaterialInput, "inventory_item_id">
+> & {
+  planned_quantity: number | null
+  location_id: string | null
+  resolved_raw_material_id: string | null
+  note: string | null
+  metadata: Record<string, any> | null
+}
+
+export type NormalizeResult =
+  | { ok: true; materials: NormalizedRunMaterial[] }
+  | { ok: false; error: string }
+
+/**
+ * Validate and normalise an assignment's `materials` array.
+ *
+ * `designInventoryItemIds` is the design's BOM. Pass `null` when the run has no
+ * design (the #1112 product-only provenance path) — there is nothing to be a
+ * subset OF, so the subset rule is skipped rather than failing everything.
+ *
+ * Rejects rather than repairs, in three cases that a silent fix would turn into
+ * a wrong material issue:
+ *
+ *  - an item the design does not use — allocating it means someone picked from
+ *    the wrong design, and quietly dropping it ships a partner a short BOM;
+ *  - the same item twice — two answers to "how much", and last-wins would pick
+ *    one at random;
+ *  - a non-positive planned_quantity — "allocate 0 of the silk" is not an
+ *    allocation, it is an omission written down, and it would pass the
+ *    consumption gate while promising nothing.
+ */
+export const normalizeRunMaterials = (
+  materials: RunMaterialInput[] | null | undefined,
+  designInventoryItemIds: string[] | null
+): NormalizeResult => {
+  if (materials === null || materials === undefined) {
+    return { ok: true, materials: [] }
+  }
+  if (!Array.isArray(materials)) {
+    return { ok: false, error: "materials must be an array" }
+  }
+
+  const bom = designInventoryItemIds ? new Set(designInventoryItemIds) : null
+  const seen = new Set<string>()
+  const out: NormalizedRunMaterial[] = []
+
+  for (const raw of materials) {
+    const id = typeof raw?.inventory_item_id === "string"
+      ? raw.inventory_item_id.trim()
+      : ""
+    if (!id) {
+      return { ok: false, error: "each material needs an inventory_item_id" }
+    }
+    if (seen.has(id)) {
+      return {
+        ok: false,
+        error: `inventory item ${id} is listed twice; give it one planned_quantity`,
+      }
+    }
+    if (bom && !bom.has(id)) {
+      return {
+        ok: false,
+        error: `inventory item ${id} is not part of this design's bill of materials — link it to the design first`,
+      }
+    }
+
+    const qty = raw.planned_quantity
+    if (qty !== undefined && qty !== null) {
+      if (typeof qty !== "number" || !Number.isFinite(qty) || qty <= 0) {
+        return {
+          ok: false,
+          error: `planned_quantity for ${id} must be a positive number`,
+        }
+      }
+    }
+
+    seen.add(id)
+    out.push({
+      inventory_item_id: id,
+      planned_quantity: qty === undefined || qty === null ? null : qty,
+      location_id: raw.location_id ?? null,
+      resolved_raw_material_id: raw.resolved_raw_material_id ?? null,
+      note: raw.note ?? null,
+      metadata: raw.metadata ?? null,
+    })
+  }
+
+  return { ok: true, materials: out }
+}
+
+export type ConsumptionGateResult =
+  | { allowed: true; constrained: boolean }
+  | { allowed: false; reason: string }
+
+/**
+ * May this run log consumption against this inventory item?
+ *
+ * The load-bearing case is the one that must stay open: **a run with no
+ * allocation is unconstrained**. Every run that existed before this feature has
+ * zero allocation rows, as does any assignment made without a `materials` array,
+ * and treating "nobody chose" the same as "chose nothing" would 400 the entire
+ * existing floor. The gate engages only once a selection actually exists.
+ */
+export const checkConsumptionAgainstAllocation = (input: {
+  /** The run's allocated inventory item ids. Empty/absent = unconstrained. */
+  allocatedInventoryItemIds: string[] | null | undefined
+  inventoryItemId: string | null | undefined
+  /** Titles/skus by item id, purely to make the refusal readable. */
+  labelsById?: Record<string, string>
+}): ConsumptionGateResult => {
+  const allocated = (input.allocatedInventoryItemIds || []).filter(Boolean)
+  if (!allocated.length) {
+    return { allowed: true, constrained: false }
+  }
+
+  const itemId = input.inventoryItemId
+  if (!itemId) {
+    return {
+      allowed: false,
+      reason:
+        "this run has an assigned material list, so consumption must name an inventory item",
+    }
+  }
+
+  if (allocated.includes(itemId)) {
+    return { allowed: true, constrained: true }
+  }
+
+  const labels = input.labelsById || {}
+  const assigned = allocated.map((id) => labels[id] || id).join(", ")
+  return {
+    allowed: false,
+    reason: `${labels[itemId] || itemId} is not assigned to this run. Assigned: ${assigned}.`,
+  }
+}

--- a/apps/backend/workflow-schemas.json
+++ b/apps/backend/workflow-schemas.json
@@ -6182,6 +6182,13 @@
         "placeholder": "{{ $last.task_ids }}"
       },
       {
+        "name": "materials",
+        "type": "array",
+        "required": false,
+        "placeholder": "{{ $last.materials }}",
+        "description": "The per-assignment material allocation: WHICH of the design's inventory items this run is actually sent out with, and how much of each. Omit to keep the historical behaviour — the whole design BOM stays available to the partner. Must be a subset of the design's linked inventory items."
+      },
+      {
         "name": "execution_mode",
         "type": "string",
         "required": false,

--- a/apps/partner-ui/src/components/work-orders/production-run-card.tsx
+++ b/apps/partner-ui/src/components/work-orders/production-run-card.tsx
@@ -21,6 +21,7 @@ import { InformationCircleSolid, ExclamationCircle } from "@medusajs/icons"
 import { useState } from "react"
 import { Link } from "react-router-dom"
 
+import { resolveRunMaterialOptions } from "../../lib/run-materials"
 import { planCompletionOutput } from "../../lib/completion-output"
 import { PartnerDesign } from "../../hooks/api/partner-designs"
 import {
@@ -933,7 +934,11 @@ const CompleteRunForm = ({
   isSample: boolean
   existingConsumptionCount: number
 }) => {
-  const inventoryItems = (design?.inventory_items || []) as Array<Record<string, any>>
+  // Only what THIS run was assigned. Falls back to the design's full bill of
+  // materials when the run carries no allocation — which is every run made
+  // before assignments could carry materials.
+  const { options: inventoryItems, constrained: materialsConstrained } =
+    resolveRunMaterialOptions(run, design)
   const tasks = run.tasks || []
   const pendingTasks = tasks.filter(
     (t: any) => t.status !== "completed" && t.status !== "cancelled"
@@ -1309,6 +1314,19 @@ const CompleteRunForm = ({
             </Badge>
           )}
         </div>
+
+        {materialsConstrained && (
+          <Text size="xsmall" className="text-ui-fg-subtle mb-2">
+            This run was assigned specific materials
+            {inventoryItems.some((i) => i.planned_quantity != null)
+              ? ` — ${inventoryItems
+                  .filter((i) => i.planned_quantity != null)
+                  .map((i) => `${i.title || i.sku || i.id}: ${i.planned_quantity}`)
+                  .join(", ")}`
+              : ""}
+            . Only these can be logged against it.
+          </Text>
+        )}
 
         {existingConsumptionCount > 0 ? (
           <Text size="xsmall" className="text-ui-fg-subtle mb-3">

--- a/apps/partner-ui/src/hooks/api/content.ts
+++ b/apps/partner-ui/src/hooks/api/content.ts
@@ -342,6 +342,29 @@ export type WebsiteTheme = {
     image_layout?: "gallery" | "single" | "grid"
     gallery_position?: "left" | "center" | "right"
     description_layout?: "tabs" | "accordion" | "stacked"
+    /**
+     * #1364 — the full-width band BELOW the gallery. `description_layout` above
+     * only ever chose a container for two hardcoded panels inside the narrow
+     * sticky column; this decides what appears under the image.
+     */
+    detail_band?: {
+      enabled?: boolean
+      heading?: string
+      layout?: "grid-2" | "grid-3" | "rows" | "tabs" | "accordion"
+      blocks?: Array<{
+        source:
+          | "spec"
+          | "spec_fields"
+          | "attributes"
+          | "maker"
+          | "care"
+          | "shipping"
+        label?: string
+        /** Only read for the theme-authored sources (care, shipping). */
+        body?: string
+        enabled?: boolean
+      }>
+    }
     cta_text?: string
     sample_product_name?: string
     sample_product_price?: string

--- a/apps/partner-ui/src/lib/__tests__/run-materials.spec.ts
+++ b/apps/partner-ui/src/lib/__tests__/run-materials.spec.ts
@@ -1,0 +1,53 @@
+import { describe, expect, it } from "vitest"
+
+import { resolveRunMaterialOptions } from "../run-materials"
+
+const design = {
+  inventory_items: [
+    { id: "iitem_silk", title: "Mulberry silk" },
+    { id: "iitem_thread", title: "Cotton thread" },
+    { id: "iitem_lining", title: "Lining" },
+  ],
+}
+
+describe("resolveRunMaterialOptions", () => {
+  it("offers ONLY what the run was assigned, not the whole design", () => {
+    const { options, constrained } = resolveRunMaterialOptions(
+      {
+        materials: [
+          {
+            inventory_item_id: "iitem_silk",
+            planned_quantity: "40",
+            inventory_item: { id: "iitem_silk", title: "Mulberry silk" },
+          },
+        ],
+      },
+      design
+    )
+    expect(constrained).toBe(true)
+    expect(options.map((o) => o.id)).toEqual(["iitem_silk"])
+    // Offering the other two would offer a choice the save then rejects.
+    expect(options[0].planned_quantity).toBe(40)
+  })
+
+  /** The control: an unallocated run must not lose its materials list. */
+  it.each([undefined, null, []])(
+    "falls back to the design BOM when materials is %p",
+    (materials) => {
+      const { options, constrained } = resolveRunMaterialOptions(
+        { materials },
+        design
+      )
+      expect(constrained).toBe(false)
+      expect(options.map((o) => o.id)).toEqual([
+        "iitem_silk",
+        "iitem_thread",
+        "iitem_lining",
+      ])
+    }
+  )
+
+  it("survives a design with no BOM at all", () => {
+    expect(resolveRunMaterialOptions({}, {}).options).toEqual([])
+  })
+})

--- a/apps/partner-ui/src/lib/run-materials.ts
+++ b/apps/partner-ui/src/lib/run-materials.ts
@@ -1,0 +1,52 @@
+/**
+ * Which materials to offer a partner for a run.
+ *
+ * The consumption picker used to read `design.inventory_items` — the design's
+ * whole bill of materials — so a design with five items handed to two partners
+ * asked both of them about all five. A run can now be ASSIGNED a subset, and
+ * the backend REFUSES consumption outside it, so offering the full BOM would
+ * mean offering choices the save is going to reject.
+ *
+ * The fallback is the important half: a run with no allocation is unconstrained
+ * (nobody chose — not "chose nothing"), and every run that predates the feature
+ * is in that state. Those must keep seeing the full BOM.
+ */
+export type RunMaterialOption = {
+  id: string
+  title?: string
+  sku?: string
+  /** Set only when the run was allocated this item. */
+  planned_quantity?: number | null
+}
+
+export const resolveRunMaterialOptions = (
+  run: any,
+  design: any
+): { options: RunMaterialOption[]; constrained: boolean } => {
+  const allocation = Array.isArray(run?.materials) ? run.materials : []
+
+  if (allocation.length) {
+    return {
+      constrained: true,
+      options: allocation.map((row: any) => ({
+        id: row.inventory_item_id,
+        title: row.inventory_item?.title,
+        sku: row.inventory_item?.sku,
+        planned_quantity:
+          row.planned_quantity === null || row.planned_quantity === undefined
+            ? null
+            : Number(row.planned_quantity),
+      })),
+    }
+  }
+
+  const bom = Array.isArray(design?.inventory_items) ? design.inventory_items : []
+  return {
+    constrained: false,
+    options: bom.map((item: any) => ({
+      id: item.id,
+      title: item.title,
+      sku: item.sku,
+    })),
+  }
+}

--- a/apps/partner-ui/src/routes/settings/theme/theme.tsx
+++ b/apps/partner-ui/src/routes/settings/theme/theme.tsx
@@ -10,6 +10,7 @@ import {
   Tooltip,
   IconButton,
   Badge,
+  Textarea,
 } from "@medusajs/ui"
 import { ArrowPath, Plus, Trash, Sparkles } from "@medusajs/icons"
 
@@ -2304,6 +2305,178 @@ function SectionsOrderEditor({ hs, updateForm }: SubEditorProps) {
   )
 }
 
+
+/**
+ * #1364 — the detail band: the full-width region BELOW the product gallery.
+ *
+ * Not to be confused with "Description Layout" above it, which only ever chose
+ * a container for two hardcoded panels inside the narrow sticky column. This
+ * one decides what appears under the image, and how it is arranged.
+ *
+ * The blocks are a fixed vocabulary rather than free-form content, because
+ * every source reads something the PRODUCT already has — its spec, its maker,
+ * its own fields. The theme picks which of those to show and in what order; it
+ * cannot state a fact about a piece it has never seen. The two exceptions,
+ * Care and Shipping, are the same promise on every product and so are written
+ * here, once.
+ *
+ * A block whose product has nothing to show is hidden on that product. That is
+ * what makes one arrangement safe across a whole catalogue: turning on "Made
+ * by" does not put an empty heading on the pieces with no maker story.
+ */
+const DETAIL_BAND_SOURCES = [
+  { value: "spec", label: "Made to", hint: "Weave, measurements and finishes, with icons" },
+  { value: "spec_fields", label: "Details", hint: "The extra fields you named on each product" },
+  { value: "attributes", label: "Product information", hint: "Material, origin, type, weight, size" },
+  { value: "maker", label: "Made by", hint: "The maker story, where a product has one" },
+  { value: "care", label: "Care", hint: "Your own copy — same on every product" },
+  { value: "shipping", label: "Shipping & returns", hint: "Your own copy — same on every product" },
+] as const
+
+const DETAIL_BAND_LAYOUTS = [
+  { value: "rows", label: "Rows" },
+  { value: "grid-2", label: "2 across" },
+  { value: "grid-3", label: "3 across" },
+  { value: "tabs", label: "Tabs" },
+  { value: "accordion", label: "Collapsible" },
+] as const
+
+type DetailBandValue = NonNullable<
+  NonNullable<WebsiteTheme["product_page"]>["detail_band"]
+>
+
+const DetailBandEditor = ({
+  band,
+  onChange,
+}: {
+  band?: DetailBandValue
+  onChange: (band: DetailBandValue) => void
+}) => {
+  const b = band || {}
+  const blocks = b.blocks || []
+
+  const patch = (next: Partial<DetailBandValue>) => onChange({ ...b, ...next })
+
+  const toggleSource = (source: string) => {
+    const existing = blocks.find((x) => x.source === source)
+    if (existing) {
+      patch({ blocks: blocks.filter((x) => x.source !== source) })
+      return
+    }
+    patch({ blocks: [...blocks, { source: source as any }] })
+  }
+
+  const patchBlock = (source: string, next: Record<string, any>) =>
+    patch({
+      blocks: blocks.map((x) => (x.source === source ? { ...x, ...next } : x)),
+    })
+
+  return (
+    <div className="space-y-3 rounded-lg border border-ui-border-base p-3">
+      <div className="flex items-center justify-between">
+        <div>
+          <Label size="xsmall">Detail band</Label>
+          <Text size="xsmall" className="text-ui-fg-subtle">
+            Blocks shown below the product image
+          </Text>
+        </div>
+        <Switch
+          checked={b.enabled === true}
+          onCheckedChange={(v) => patch({ enabled: v })}
+        />
+      </div>
+
+      {b.enabled && (
+        <>
+          <FieldInput
+            label="Heading (optional)"
+            value={b.heading || ""}
+            onChange={(v) => patch({ heading: v })}
+            placeholder="About this piece"
+          />
+
+          <div className="space-y-1">
+            <Label size="xsmall">Arrangement</Label>
+            <div className="grid grid-cols-3 gap-1">
+              {DETAIL_BAND_LAYOUTS.map((l) => (
+                <button
+                  key={l.value}
+                  className={`px-2 py-1 text-xs rounded border ${
+                    (b.layout || "rows") === l.value
+                      ? "border-ui-fg-interactive bg-ui-bg-interactive text-ui-fg-on-color"
+                      : "border-ui-border-base text-ui-fg-subtle"
+                  }`}
+                  onClick={() => patch({ layout: l.value })}
+                >
+                  {l.label}
+                </button>
+              ))}
+            </div>
+          </div>
+
+          <div className="space-y-2">
+            <Label size="xsmall">Blocks</Label>
+            {DETAIL_BAND_SOURCES.map((src) => {
+              const block = blocks.find((x) => x.source === src.value)
+              const on = !!block
+              const authored = src.value === "care" || src.value === "shipping"
+              return (
+                <div key={src.value} className="rounded border border-ui-border-base p-2">
+                  <div className="flex items-center justify-between gap-x-2">
+                    <div className="min-w-0">
+                      <Text size="xsmall" weight="plus">{src.label}</Text>
+                      <Text size="xsmall" className="text-ui-fg-subtle">
+                        {src.hint}
+                      </Text>
+                    </div>
+                    <Switch checked={on} onCheckedChange={() => toggleSource(src.value)} />
+                  </div>
+
+                  {on && (
+                    <div className="mt-2 space-y-2">
+                      <FieldInput
+                        label="Heading"
+                        value={block?.label || ""}
+                        onChange={(v) => patchBlock(src.value, { label: v })}
+                        placeholder={src.label}
+                      />
+                      {authored && (
+                        <div className="space-y-1">
+                          <Label size="xsmall">Text</Label>
+                          <Textarea
+                            rows={3}
+                            value={block?.body || ""}
+                            onChange={(e) =>
+                              patchBlock(src.value, { body: e.target.value })
+                            }
+                            placeholder={
+                              src.value === "care"
+                                ? "Hand wash cold, dry flat in shade…"
+                                : "Dispatched in 2–3 working days…"
+                            }
+                          />
+                          {/* Without copy there is no product to fall back to,
+                              so the block simply will not appear. Saying so
+                              here beats a partner wondering why. */}
+                          {!(block?.body || "").trim() && (
+                            <Text size="xsmall" className="text-ui-fg-muted">
+                              Add text or this block stays hidden.
+                            </Text>
+                          )}
+                        </div>
+                      )}
+                    </div>
+                  )}
+                </div>
+              )
+            })}
+          </div>
+        </>
+      )}
+    </div>
+  )
+}
+
 function ProductPagePanel({ form, updateForm }: PanelProps) {
   const pp = form.product_page || {}
   const colors = form.colors || {}
@@ -2379,6 +2552,11 @@ function ProductPagePanel({ form, updateForm }: PanelProps) {
             ))}
           </div>
         </div>
+
+        <DetailBandEditor
+          band={pp.detail_band}
+          onChange={(band) => updateForm("product_page", { ...pp, detail_band: band })}
+        />
 
         <FieldInput
           label="Add to Cart Text"

--- a/e2e/helpers/e2e-seed.ts
+++ b/e2e/helpers/e2e-seed.ts
@@ -399,6 +399,124 @@ async function seedParkedProductionRun(container: any): Promise<{
 }
 
 /**
+ * #1363 — a design with a MULTI-ITEM bill of materials and an approvable run,
+ * so the per-assignment material allocation can be driven through the admin UI.
+ *
+ * The BOM has to have more than one item or the fixture cannot discriminate:
+ * the whole defect was that a run carried EVERY item its design was linked to,
+ * and a one-item design looks identical whether the feature works or not. Three
+ * items means an assignment that takes one is visibly a choice.
+ *
+ * Two partners, because the point is that two assignments off the SAME design
+ * can be sent different materials. The run is left in `pending_review` — the
+ * status `approve` is allowed from — so the spec drives the real approval, not
+ * a shortcut into the end state.
+ */
+async function seedAllocationDesignRun(container: any): Promise<{
+  runId: string
+  designId: string
+  designName: string
+  partnerAName: string
+  partnerBName: string
+  materialALabel: string
+  materialBLabel: string
+  materialCLabel: string
+  materialAId: string
+  materialCId: string
+}> {
+  const partnerModule: any = container.resolve("partner")
+  const designService: any = container.resolve("design")
+  const runService: any = container.resolve("production_runs")
+  const inventoryService: any = container.resolve(Modules.INVENTORY)
+  const remoteLink: any = container.resolve(ContainerRegistrationKeys.LINK)
+
+  const stamp = Date.now()
+
+  const mkPartner = async (label: string) => {
+    const created = await partnerModule.createPartners({
+      name: `E2E Alloc ${label} ${stamp}`,
+      handle: `e2e-alloc-${label.toLowerCase()}-${stamp}`,
+      status: "active",
+      is_verified: true,
+    })
+    const row = Array.isArray(created) ? created[0] : created
+    return { id: row.id as string, name: row.name as string }
+  }
+
+  const partnerA = await mkPartner("Weaver")
+  const partnerB = await mkPartner("Finisher")
+
+  const designName = `Allocation Fixture (e2e ${stamp})`
+  const design = await designService.createDesigns({
+    name: designName,
+    description: "e2e #1363 per-assignment material allocation fixture",
+    design_type: "Original",
+    status: "Commerce_Ready",
+    priority: "Medium",
+  })
+  const designId = (Array.isArray(design) ? design[0] : design).id as string
+
+  // The bill of materials. Stamped titles because the spec selects on them and
+  // a repeat seed must not produce two chips reading the same thing.
+  const specs = [
+    { title: `E2E Mulberry Silk ${stamp}`, planned: 40 },
+    { title: `E2E Cotton Thread ${stamp}`, planned: 2 },
+    { title: `E2E Lining ${stamp}`, planned: 12 },
+  ]
+
+  const items: Array<{ id: string; title: string }> = []
+  for (const spec of specs) {
+    const created = await inventoryService.createInventoryItems({
+      title: spec.title,
+      sku: `e2e-alloc-${items.length}-${stamp}`,
+      requires_shipping: false,
+    })
+    const row = Array.isArray(created) ? created[0] : created
+    items.push({ id: row.id as string, title: spec.title })
+  }
+
+  await remoteLink.create(
+    items.map((item, i) => ({
+      design: { design_id: designId },
+      [Modules.INVENTORY]: { inventory_item_id: item.id },
+      data: { planned_quantity: specs[i].planned },
+    }))
+  )
+
+  const run = await runService.createProductionRuns({
+    design_id: designId,
+    quantity: 6,
+    run_type: "production",
+    // The parent snapshots the design's FULL BOM — that is what it is, the
+    // design's plan. The children get narrowed to what each partner is issued.
+    snapshot: {
+      design: { id: designId, name: designName },
+      inventory_links: items.map((item, i) => ({
+        inventory_item_id: item.id,
+        planned_quantity: specs[i].planned,
+        inventory_item: { id: item.id, title: item.title },
+      })),
+    },
+    captured_at: new Date(),
+    status: "pending_review",
+  })
+  const runId = (Array.isArray(run) ? run[0] : run).id as string
+
+  return {
+    runId,
+    designId,
+    designName,
+    partnerAName: partnerA.name,
+    partnerBName: partnerB.name,
+    materialALabel: specs[0].title,
+    materialBLabel: specs[1].title,
+    materialCLabel: specs[2].title,
+    materialAId: items[0].id,
+    materialCId: items[2].id,
+  }
+}
+
+/**
  * #1113 — seed a design carrying a full brief (concept + aesthetic anchor +
  * persona + competitors + price point + milestones + design budget), so the
  * designer-invite → brief-moodboard flow (S1 invite/accept + S2 generate) can be
@@ -822,6 +940,9 @@ export default async function e2eSeed({ container }: ExecArgs) {
   logger.info("E2E seed: creating the #1228 parked production run + partners...")
   const parkedRun = await seedParkedProductionRun(container)
 
+  logger.info("E2E seed: creating the #1363 allocation design (3-item BOM) + approvable run...")
+  const allocation = await seedAllocationDesignRun(container)
+
   logger.info("E2E seed: creating the gate order's partner fee (payout spec)...")
   const gateFee = await seedPartnerFeeForGateOrder(
     container,
@@ -867,6 +988,20 @@ export default async function e2eSeed({ container }: ExecArgs) {
     crmPersonId: crmContact.personId,
     crmPersonName: crmContact.personName,
     crmActivityBody: crmContact.activityBody,
+    // #1363 per-assignment material allocation — consumed by
+    // production-run-material-allocation.spec.ts (admin, CI). SINGLE-USE like
+    // every other run fixture: the spec approves the run, and an approved run
+    // cannot be approved again.
+    allocationRunId: allocation.runId,
+    allocationDesignId: allocation.designId,
+    allocationDesignName: allocation.designName,
+    allocationPartnerAName: allocation.partnerAName,
+    allocationPartnerBName: allocation.partnerBName,
+    allocationMaterialALabel: allocation.materialALabel,
+    allocationMaterialBLabel: allocation.materialBLabel,
+    allocationMaterialCLabel: allocation.materialCLabel,
+    allocationMaterialAId: allocation.materialAId,
+    allocationMaterialCId: allocation.materialCId,
   }
 
   fs.writeFileSync(SEED_FILE, JSON.stringify(seedData, null, 2))

--- a/e2e/specs/production-run-material-allocation.spec.ts
+++ b/e2e/specs/production-run-material-allocation.spec.ts
@@ -1,0 +1,261 @@
+import { test, expect } from "@playwright/test"
+import * as fs from "fs"
+import * as path from "path"
+
+const SEED_FILE = path.resolve(__dirname, "../../apps/backend/.e2e-seed.json")
+
+/**
+ * #1363 — a partner is sent ONE material, not the whole design.
+ *
+ * Before this, `fetchDesignInventorySnapshotStep` filtered on `design_id`
+ * alone: every run carried its design's entire bill of materials, and the
+ * partner's consumption picker offered every item the design had ever been
+ * linked to. A design with three inventory items handed to two partners asked
+ * both of them about all three.
+ *
+ * This drives the real admin approval — open the drawer, add two assignments,
+ * give each partner a DIFFERENT material — and then checks the two things a
+ * green screen does not prove:
+ *
+ *   1. the allocation was persisted, per child run, and the two children differ;
+ *   2. the gate actually refuses. A selection nothing enforces is decoration,
+ *      and the enforcement lives in `logConsumptionWorkflow`, not on a route,
+ *      because three routes reach it (#1314: a guard on one path is not a
+ *      guard). The refusal is asserted through a DIFFERENT route than the
+ *      partner one, which is the whole point of putting it in the workflow.
+ *
+ * And the control that must NOT fire: the parent run, which nobody allocated,
+ * stays unconstrained. Every run that predates this feature is in that state,
+ * so reading "nobody chose" as "chose nothing" would 400 the existing floor —
+ * and would look exactly like the feature working.
+ *
+ * SINGLE-USE fixture, like every other run fixture here: the spec approves the
+ * run, and an approved run cannot be approved again. Re-seed between runs.
+ */
+test.describe("Production run per-assignment material allocation (#1363)", () => {
+  let seed: {
+    email: string
+    password: string
+    allocationRunId: string
+    allocationDesignId: string
+    allocationPartnerAName: string
+    allocationPartnerBName: string
+    allocationMaterialALabel: string
+    allocationMaterialBLabel: string
+    allocationMaterialCLabel: string
+    allocationMaterialAId: string
+    allocationMaterialCId: string
+  }
+
+  test.beforeAll(() => {
+    if (!fs.existsSync(SEED_FILE)) {
+      throw new Error(
+        `E2E seed file not found at ${SEED_FILE}. Run "pnpm e2e:seed" first.`
+      )
+    }
+    seed = JSON.parse(fs.readFileSync(SEED_FILE, "utf-8"))
+    if (!seed.allocationRunId) {
+      throw new Error("E2E seed missing allocationRunId — re-run the seed.")
+    }
+  })
+
+  const login = async (page: any) => {
+    await page.goto("/app/login")
+    // `networkidle` never settles against `medusa develop` (long-lived
+    // connections), so wait on the form itself.
+    await page.locator('input[name="email"]').waitFor({ timeout: 60000 })
+    await page.locator('input[name="email"]').fill(seed.email)
+    await page.locator('input[name="password"]').fill(seed.password)
+    await page.locator('button[type="submit"]').click()
+    await page.waitForURL(/\/app\/(?!login)/, { timeout: 15000 })
+  }
+
+  /** Fill one assignment card: partner, then the material chip (+ quantity). */
+  const fillAssignment = async (
+    page: any,
+    index: number,
+    partnerName: string,
+    materialLabel: string,
+    quantity: string
+  ) => {
+    const card = page.locator("text=Assignment " + (index + 1)).locator("..").locator("..")
+
+    // Partner select — Radix, so open then pick by name.
+    await card.getByText("Select partner").click()
+    await page.getByRole("option", { name: partnerName }).click()
+
+    // The material chip. Selecting it is what puts the item in THIS assignment;
+    // an unselected chip must never reach the payload (#1361's shape).
+    await card.getByRole("button", { name: materialLabel }).click()
+
+    const qtyInput = card.locator('input[type="number"]').last()
+    await qtyInput.fill(quantity)
+  }
+
+  test("sends each partner only the material they were assigned, and refuses the rest", async ({
+    page,
+  }) => {
+    await login(page)
+    await page.goto(`/app/production-runs/${seed.allocationRunId}`)
+
+    const approve = page.getByRole("button", { name: /^Approve$/ })
+    await expect(approve.first()).toBeVisible({ timeout: 20000 })
+    await approve.first().click()
+
+    await expect(
+      page.getByRole("heading", { name: "Approve Production Run" })
+    ).toBeVisible({ timeout: 15000 })
+
+    // Open the assignments modal.
+    await page.getByRole("button", { name: /Assignments/i }).last().click()
+    await expect(
+      page.getByRole("heading", { name: "Assignments" })
+    ).toBeVisible({ timeout: 10000 })
+
+    // The picker offers the design's BOM — all three items — as the set an
+    // assignment may be a subset OF.
+    await page.getByRole("button", { name: "+ Add Assignment" }).click()
+    for (const label of [
+      seed.allocationMaterialALabel,
+      seed.allocationMaterialBLabel,
+      seed.allocationMaterialCLabel,
+    ]) {
+      await expect(page.getByRole("button", { name: label }).first()).toBeVisible()
+    }
+
+    await fillAssignment(
+      page,
+      0,
+      seed.allocationPartnerAName,
+      seed.allocationMaterialALabel,
+      "24"
+    )
+
+    await page.getByRole("button", { name: "+ Add Assignment" }).click()
+    await fillAssignment(
+      page,
+      1,
+      seed.allocationPartnerBName,
+      seed.allocationMaterialCLabel,
+      "8"
+    )
+
+    await page.getByRole("button", { name: "Save Assignments" }).click()
+    // The drawer now shows the count, which is the only on-screen proof the
+    // picker produced a payload at all rather than silently dropping it.
+    await expect(
+      page.getByRole("button", { name: /Manage Assignments \(2\)/ })
+    ).toBeVisible({ timeout: 10000 })
+
+    await page.getByRole("button", { name: /^Approve$/ }).last().click()
+
+    // Wait for the mutation to SETTLE, not just to be sent. The drawer closes
+    // on success; querying straight after the click read zero children off a
+    // request still in flight — a green click is not a completed write.
+    await expect(
+      page.getByRole("heading", { name: "Approve Production Run" })
+    ).toBeHidden({ timeout: 30000 })
+
+    // ── What a green screen does not prove ────────────────────────────────
+    const children = await page.request
+      .get(
+        `/admin/production-runs?parent_run_id=${seed.allocationRunId}&limit=10`
+      )
+      .then((r) => r.json())
+
+    expect(children.production_runs).toHaveLength(2)
+
+    const allocations: Record<string, string[]> = {}
+    for (const child of children.production_runs) {
+      const detail = await page.request
+        .get(`/admin/production-runs/${child.id}`)
+        .then((r) => r.json())
+      expect(detail.materials_constrained).toBe(true)
+      allocations[child.id] = (detail.materials || []).map(
+        (m: any) => m.inventory_item_id
+      )
+    }
+
+    const sets = Object.values(allocations)
+    // Each child got exactly ONE material…
+    expect(sets.every((s) => s.length === 1)).toBe(true)
+    // …and they are DIFFERENT ones. Two partners, two materials, one design —
+    // the thing the old whole-BOM snapshot could not express.
+    expect(new Set(sets.flat()).size).toBe(2)
+
+    const childWithA = Object.entries(allocations).find(([, ids]) =>
+      ids.includes(seed.allocationMaterialAId)
+    )
+    expect(childWithA).toBeTruthy()
+    const runWithSilk = childWithA![0]
+
+    // ── The gate ─────────────────────────────────────────────────────────
+    // Asserted through the ADMIN design route, not the partner run route the
+    // UI uses. The check lives in the workflow precisely so every path that
+    // reaches it is covered, and a spec that only exercised the path the guard
+    // was written on would prove nothing about the other two.
+    const offPlan = await page.request.post(
+      `/admin/designs/${seed.allocationDesignId}/consumption-logs`,
+      {
+        data: {
+          productionRunId: runWithSilk,
+          inventoryItemId: seed.allocationMaterialCId,
+          quantity: 1,
+          unitOfMeasure: "Meter",
+          consumptionType: "production",
+        },
+      }
+    )
+    expect(offPlan.ok()).toBe(false)
+    expect(await offPlan.text()).toContain("not assigned to this run")
+
+    // …and the assigned one still goes through, so the refusal above is the
+    // allocation talking and not a broken route.
+    const onPlan = await page.request.post(
+      `/admin/designs/${seed.allocationDesignId}/consumption-logs`,
+      {
+        data: {
+          productionRunId: runWithSilk,
+          inventoryItemId: seed.allocationMaterialAId,
+          quantity: 1,
+          unitOfMeasure: "Meter",
+          consumptionType: "production",
+        },
+      }
+    )
+    expect(onPlan.status()).toBe(201)
+  })
+
+  /**
+   * THE CONTROL THAT MUST NOT FIRE.
+   *
+   * The parent was never allocated anything, and neither was any run created
+   * before #1363. Those must stay unconstrained — the whole BOM available — or
+   * the feature 400s work that was fine yesterday.
+   */
+  test("leaves a run nobody allocated unconstrained", async ({ page }) => {
+    await login(page)
+
+    const detail = await page.request
+      .get(`/admin/production-runs/${seed.allocationRunId}`)
+      .then((r) => r.json())
+
+    expect(detail.materials_constrained).toBe(false)
+    expect(detail.materials).toEqual([])
+
+    // Any item of the design is still loggable against it.
+    const anyItem = await page.request.post(
+      `/admin/designs/${seed.allocationDesignId}/consumption-logs`,
+      {
+        data: {
+          productionRunId: seed.allocationRunId,
+          inventoryItemId: seed.allocationMaterialCId,
+          quantity: 1,
+          unitOfMeasure: "Meter",
+          consumptionType: "production",
+        },
+      }
+    )
+    expect(anyItem.status()).toBe(201)
+  })
+})


### PR DESCRIPTION
Closes #1364. Advances #1365 (band done; configurator specced, not built).
Starter half merged: Jaal-Yantra-Textiles/nextjs-starter-medusa#11 → `471fda6`.

---

# #1364 — per-assignment inventory allocation

## The gap

A design's bill of materials answers *"what can this design be made of"*. Nothing answered *"what is THIS partner being sent"*, and the two were conflated:

- `fetchDesignInventorySnapshotStep` filtered on **`design_id` alone** — every run snapshotted the design's entire BOM
- `ProductionRunAssignment` had **no materials field**
- `production-run-card.tsx:936` read `design.inventory_items` straight off the design

A design with five inventory items handed to two partners asked **both of them about all five**.

## The shape

New `production_runs ↔ inventory_item` link carrying `planned_quantity`, `location_id`, and a **per-run** `resolved_raw_material_id` — the design↔group link holds one resolved colour for a *whole design*, so two runs of one design in two colours already collided there.

The link is **authoritative**; `run.snapshot.inventory_links` is narrowed to match but stays provenance only. A rule that decides a 400 must not be read out of a json blob a wholesale write can replace.

**Enforcement lives in `logConsumptionWorkflow`, not on a route.** Three routes reach it (partner run, partner design, admin design) and a guard on one path is not a guard (#1314). It runs to completion *before* the log row is created, so a refusal writes nothing, and it names the assigned materials by title rather than by id.

**Approve validates before it writes.** Every assignment's allocation is checked before the parent is flipped to `approved` — #1358's shape, where a rejection is a corruption because the write already happened.

Editable via `update_production_run` until the partner accepts, then frozen like `quantity`/`role`/`run_type`. Sending it **REPLACES** the allocation wholesale; `[]` clears it.

## 🔑 Absence is not an empty allocation

Every run that predates this has zero rows, as does any assignment made without `materials`. Those stay **unconstrained** — the whole BOM available, exactly as before. Reading "nobody chose" as "chose nothing" would 400 the entire existing floor, **and the failure would look exactly like the feature working**. Three unit cases and one e2e case pin it.

## The collation was unreachable from MCP

One order holds many runs (#826 S3a), but there are **two order ids** and the registry never said which was which:

| id | `list_production_runs(order_id=…)` |
|---|---|
| commissioning order (`run.order_id`) | ✅ returns the runs |
| collated work-order (holds runs via the **link**) | ❌ returns `[]` |

An empty list is indistinguishable from "this order has no runs". Adds `work_order_id`, filters on `/admin/design-work-orders` (**it had none**, and loaded every order in the channel to slice in memory), a partner `get_production_run`, and descriptions that say which id is which. Also adds `template_ids` to `approve_production_run`, missing despite #1268 making ids the preferred form.

## UI

Admin approve form gets a per-assignment material picker, cleaned by a pure `cleanAssignmentMaterialsForSave` — #1361's exact shape, where a form built a row it could not save. The partner picker now offers the run's allocation, falling back to the design BOM when there is none.

---

# #1365 — the detail band below the gallery

`product_page.detail_band = { enabled, heading, layout, blocks[] }`. Layouts `rows | grid-2 | grid-3 | tabs | accordion`; sources `spec | spec_fields | attributes | maker | care | shipping`.

**The theme decides the shape; the product supplies the substance.** A block its product cannot fill is hidden, and the band is dropped when nothing survives — otherwise a product with no spec, maker or fields renders three headings over three blanks. Absence is off, so every theme that exists today is unchanged.

Icons on the spec rows come from `WeaveParamDef` in the weaving-technique registry — where a param is *defined*. A storefront-side lookup keyed on the param name would lose its entry the day someone adds one; making the field **required** turned that silent gap into five compiler errors naming exactly the params that had been missed.

🔑 **The theme drift guard (#1338) refused the first commit** — a setting nothing renders and no partner can set is the failure this repo keeps hitting. Both downstream halves were built rather than added to `EXEMPT`.

⚠️ **`apps/storefront` has no theme system at all** (no `WebsiteTheme`, no `product_page` — grepped, zero hits). The band is starter-only, which is also why the drift guard reads only the starter.

---

# Verification

| | |
|---|---|
| backend unit | **3781 pass**, known 4-suite/5-test red baseline unchanged |
| new unit cases | 44 (#1364) + 16 (#1365 resolver) + 11 (form cleaner) |
| e2e | **2 new, run in a real browser against a real DB** |
| `tsc` | 75 = baseline (`.medusa` build state moves it 74↔75; measured both sides) |
| `check:prod-build` | green |
| partner-ui | 55 pass, tsc 4 = baseline |

**Controls were verified to fail**, not assumed to:
- 2 MCP cases fail with `materials` dropped from `bodyParams` only (the #1348 hole)
- 4 rule cases fail without the subset / unconstrained rules
- the e2e **failed for real first** — it queried while the approve mutation was still in flight, and the failure snapshot showed the drawer's button still disabled. *A green click is not a completed write.* The write had landed: silk 24 → weaver, lining 8 → finisher, read back out of the link table.

# ⚠️ After merge

- **`db:migrate` must run on prod** — the link table does not exist there. The deploy workflow's gated migration task should pick it up (`src/links/**` changed), but **check the step, not the badge**.
- **The starter needs its OWN Vercel redeploy.** Moving the pointer does not deploy it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)