### PR TITLE
fix: the FX fanout that OOM-killed prod twice, and the prices it never set

### DIFF
--- a/apps/backend/src/api/admin/assistant/chat/route.ts
+++ b/apps/backend/src/api/admin/assistant/chat/route.ts
@@ -56,6 +56,7 @@ import {
   loadAndFormatContext,
   resolveContextCache,
 } from "../../../../lib/assistant-context"
+import { normaliseUiMessages } from "../../../../lib/assistant-messages"
 import type { AdminAssistantChatReq } from "./validators"
 
 const FEATURE = "admin/assistant/chat"
@@ -276,23 +277,23 @@ export const POST = async (
     ])
   )
 
-  // Normalise inbound UI messages — strip tool parts from history.
-  const messages = body.messages.map((m: any) => {
-    const parts = Array.isArray(m.parts) ? m.parts : null
-    const textParts = parts
-      ? parts
-          .filter(
-            (p: any) =>
-              p?.type === "text" && typeof p.text === "string" && p.text.length > 0
-          )
-          .map((p: any) => ({ type: "text", text: p.text }))
-      : [{ type: "text", text: String(m.content ?? "") }]
-
-    return {
-      role: m.role,
-      parts: textParts.length ? textParts : [{ type: "text", text: "" }],
-    }
-  })
+  // Normalise inbound UI messages — strip tool parts from history, then bound
+  // what we keep. This route accepts a 5 MB body deliberately (a thread that
+  // ran a Data Plumbing job replays tool parts far past Express's 100 kB
+  // default), but nothing used to stop that 5 MB being copied through parse →
+  // zod → normalise → convertToModelMessages → fold.
+  //
+  // `capToolResult` above does NOT cover this: it bounds one tool result on the
+  // way OUT, not a thread replaying dozens of prior turns back IN.
+  // See lib/assistant-messages for the ceilings and why they sit above real use.
+  const normalised = normaliseUiMessages(body.messages)
+  const messages = normalised.messages
+  if (normalised.bounded) {
+    logger.warn(
+      `[${FEATURE}] payload bounded: dropped ${normalised.droppedMessages} old message(s), ` +
+        `truncated ${normalised.truncatedParts} part(s). Conversation ${body.id ?? "unknown"}.`
+    )
+  }
 
   // Attachments ride on the LAST user message — the turn they were sent with.
   // Appended as text so every provider handles it identically; a provider that

--- a/apps/backend/src/api/admin/stores/[id]/products/route.ts
+++ b/apps/backend/src/api/admin/stores/[id]/products/route.ts
@@ -11,7 +11,7 @@ import { createProductsWorkflow } from "@medusajs/medusa/core-flows"
 
 import { PARTNER_MODULE } from "../../../../../modules/partner"
 import { ensureInventoryLevelsForVariants } from "../../../../partners/helpers"
-import { fanoutVariantPrices } from "../../../../../workflows/fx/fanout-variant-prices"
+import { requestVariantPriceFanout } from "../../../../../workflows/fx/fanout-variant-prices"
 import { recordProductProvenance } from "./lib/provenance"
 
 /**
@@ -115,7 +115,7 @@ export const POST = async (
   // Materialise auto-converted prices in the store's other supported
   // currencies, or the product reads "not available" outside its native
   // region. Idempotent + never throws.
-  await fanoutVariantPrices(req.scope, { storeId: store.id, variantIds })
+  await requestVariantPriceFanout(req.scope, { storeId: store.id, variantIds })
 
   res.status(201).json({
     product,

--- a/apps/backend/src/api/partners/assistant/chat/route.ts
+++ b/apps/backend/src/api/partners/assistant/chat/route.ts
@@ -65,6 +65,7 @@ import {
   mergeAttachments,
   renderAttachments,
 } from "./attachments"
+import { normaliseUiMessages } from "../../../../lib/assistant-messages"
 import type { PartnerAssistantChatReq } from "./validators"
 
 const FEATURE = "partners/assistant/chat"
@@ -163,23 +164,19 @@ export const POST = async (
     ])
   )
 
-  // Normalise inbound UI messages — strip tool parts from history.
-  const messages = body.messages.map((m: any) => {
-    const parts = Array.isArray(m.parts) ? m.parts : null
-    const textParts = parts
-      ? parts
-          .filter(
-            (p: any) =>
-              p?.type === "text" && typeof p.text === "string" && p.text.length > 0
-          )
-          .map((p: any) => ({ type: "text", text: p.text }))
-      : [{ type: "text", text: String(m.content ?? "") }]
-
-    return {
-      role: m.role,
-      parts: textParts.length ? textParts : [{ type: "text", text: "" }],
-    }
-  })
+  // Normalise inbound UI messages — strip tool parts from history, then bound
+  // what we keep. The route accepts a 5 MB body deliberately (it must be able
+  // to RECEIVE replayed tool parts), but nothing used to stop that 5 MB being
+  // copied through parse → zod → normalise → convertToModelMessages → fold.
+  // See ./normalise for the ceilings and why they sit well above real use.
+  const normalised = normaliseUiMessages(body.messages)
+  const messages = normalised.messages
+  if (normalised.bounded) {
+    logger.warn(
+      `[${FEATURE}] payload bounded: dropped ${normalised.droppedMessages} old message(s), ` +
+        `truncated ${normalised.truncatedParts} part(s). Conversation ${body.id ?? "unknown"}.`
+    )
+  }
 
   // ---- Photo context ------------------------------------------------------
   // Recovered from the partner's assistant folder rather than the message

--- a/apps/backend/src/api/partners/discover/products/[id]/copy/route.ts
+++ b/apps/backend/src/api/partners/discover/products/[id]/copy/route.ts
@@ -2,7 +2,7 @@ import { AuthenticatedMedusaRequest, MedusaResponse } from "@medusajs/framework/
 import { ContainerRegistrationKeys, MedusaError } from "@medusajs/framework/utils"
 import { createProductsWorkflow } from "@medusajs/medusa/core-flows"
 import { getPartnerStore } from "../../../../helpers"
-import { fanoutVariantPrices } from "../../../../../../workflows/fx/fanout-variant-prices"
+import { requestVariantPriceFanout } from "../../../../../../workflows/fx/fanout-variant-prices"
 
 /**
  * POST /partners/discover/products/:id/copy
@@ -139,7 +139,7 @@ export const POST = async (
   // FX fanout — the copied product's prices came from the source channel in
   // one currency; materialise this store's other supported currencies.
   // Idempotent + never throws.
-  await fanoutVariantPrices(req.scope, {
+  await requestVariantPriceFanout(req.scope, {
     storeId: store.id,
     variantIds: ((created as any)?.variants || []).map((v: any) => v.id),
   })

--- a/apps/backend/src/api/partners/products/route.ts
+++ b/apps/backend/src/api/partners/products/route.ts
@@ -122,6 +122,7 @@ import { MedusaError, ContainerRegistrationKeys, Modules } from "@medusajs/frame
 import { PartnerCreateProductReq } from "./validators"
 import { createProductsWorkflow } from "@medusajs/medusa/core-flows"
 import { getPartnerFromAuthContext, ensureInventoryLevelsForVariants } from "../helpers"
+import { requestVariantPriceFanout } from "../../../workflows/fx/fanout-variant-prices"
 import { PARTNER_MODULE } from "../../../modules/partner"
 import { PARTNER_ONBOARDING_PROFILE_MODULE } from "../../../modules/partner-onboarding-profile"
 
@@ -197,6 +198,22 @@ export const POST = async (
   // throws (see ensureInventoryLevelsForVariants).
   const variantIds = (created?.variants || []).map((v: any) => v.id)
   await ensureInventoryLevelsForVariants(req.scope, store, variantIds)
+
+  // FX fanout — materialise auto-converted prices in the store's other
+  // supported currencies. EXACTLY the same gap as the inventory levels above,
+  // on exactly the same route, and it survived the sweep that fixed the other
+  // seven callers: fanout-variant-prices.ts documents adding this to
+  // create-product / quick-create / single-variant / discover-copy, but this
+  // legacy route — the one `create_product` (assistant + every MCP client)
+  // actually posts to — was never in that list. Effect: a price set through
+  // the assistant or MCP existed only in the store's native currency and read
+  // as "not available" in every other region, while the same product created
+  // through the partner UI fanned out correctly.
+  //
+  // Async (emits fx.fanout_requested; the worker's subscriber does the work) —
+  // never inline. See requestVariantPriceFanout for why that distinction is a
+  // availability concern and not a latency one.
+  await requestVariantPriceFanout(req.scope, { storeId: store.id, variantIds })
 
   // Record product → owning partner so the cross-list subscriber can resolve
   // ownership cleanly on publish (see links/partner-product.ts).

--- a/apps/backend/src/api/partners/stores/[id]/products/[productId]/variants/[variantId]/route.ts
+++ b/apps/backend/src/api/partners/stores/[id]/products/[productId]/variants/[variantId]/route.ts
@@ -6,7 +6,7 @@ import {
 } from "@medusajs/medusa/core-flows"
 import { remapVariantResponse } from "@medusajs/medusa/api/admin/products/helpers"
 import { scopeAndAggregateVariantInventory, validatePartnerStoreAccess } from "../../../../../../helpers"
-import { fanoutVariantPrices } from "../../../../../../../../workflows/fx/fanout-variant-prices"
+import { requestVariantPriceFanout } from "../../../../../../../../workflows/fx/fanout-variant-prices"
 
 export const GET = async (
   req: AuthenticatedMedusaRequest,
@@ -103,7 +103,7 @@ export const POST = async (
   // other supported currencies. Idempotent (existing currencies are skipped) +
   // never throws.
   if (variant?.id) {
-    await fanoutVariantPrices(req.scope, {
+    await requestVariantPriceFanout(req.scope, {
       storeId: store.id,
       variantIds: [variant.id],
     })

--- a/apps/backend/src/api/partners/stores/[id]/products/[productId]/variants/batch/route.ts
+++ b/apps/backend/src/api/partners/stores/[id]/products/[productId]/variants/batch/route.ts
@@ -4,7 +4,7 @@ import { batchProductVariantsWorkflow } from "@medusajs/medusa/core-flows"
 import { remapVariantResponse } from "@medusajs/medusa/api/admin/products/helpers"
 import {
   collectVariantPriceIds,
-  fanoutVariantPrices,
+  requestVariantPriceFanout,
 } from "../../../../../../../../workflows/fx/fanout-variant-prices"
 import {
   ensureInventoryLevelsForVariants,
@@ -83,7 +83,7 @@ export const POST = async (
   // every non-auto price on the touched variants. Idempotent + never throws;
   // see fanout-variant-prices.ts.
   const touched = [...created, ...updated]
-  await fanoutVariantPrices(req.scope, {
+  await requestVariantPriceFanout(req.scope, {
     storeId: store.id,
     priceIds: collectVariantPriceIds(touched),
   })

--- a/apps/backend/src/api/partners/stores/[id]/products/[productId]/variants/route.ts
+++ b/apps/backend/src/api/partners/stores/[id]/products/[productId]/variants/route.ts
@@ -7,7 +7,7 @@ import {
   scopeAndAggregateVariantInventory,
   validatePartnerStoreAccess,
 } from "../../../../../helpers"
-import { fanoutVariantPrices } from "../../../../../../../workflows/fx/fanout-variant-prices"
+import { requestVariantPriceFanout } from "../../../../../../../workflows/fx/fanout-variant-prices"
 
 export const GET = async (
   req: AuthenticatedMedusaRequest,
@@ -86,7 +86,7 @@ export const POST = async (
   // FX fanout — auto-convert the new variant's prices into the store's other
   // supported currencies. Idempotent + never throws.
   if (variant?.id) {
-    await fanoutVariantPrices(req.scope, {
+    await requestVariantPriceFanout(req.scope, {
       storeId: store.id,
       variantIds: [variant.id],
     })

--- a/apps/backend/src/api/partners/stores/[id]/products/quick/route.ts
+++ b/apps/backend/src/api/partners/stores/[id]/products/quick/route.ts
@@ -5,7 +5,7 @@ import {
   createProductsWorkflow,
 } from "@medusajs/medusa/core-flows"
 import { validatePartnerStoreAccess } from "../../../../helpers"
-import { fanoutVariantPrices } from "../../../../../../workflows/fx/fanout-variant-prices"
+import { requestVariantPriceFanout } from "../../../../../../workflows/fx/fanout-variant-prices"
 
 /**
  * POST /partners/stores/:id/products/quick
@@ -122,7 +122,7 @@ export const POST = async (
 
   // FX fanout — auto-convert the single price into the store's other
   // supported currencies. Idempotent + never throws.
-  await fanoutVariantPrices(req.scope, {
+  await requestVariantPriceFanout(req.scope, {
     storeId: store.id,
     variantIds: (product?.variants || []).map((v: any) => v.id),
   })

--- a/apps/backend/src/api/partners/stores/[id]/products/route.ts
+++ b/apps/backend/src/api/partners/stores/[id]/products/route.ts
@@ -5,7 +5,7 @@ import {
   validatePartnerStoreAccess,
 } from "../../../helpers"
 import listStoreProductsWorkflow from "../../../../../workflows/partner/list-store-products"
-import { fanoutVariantPrices } from "../../../../../workflows/fx/fanout-variant-prices"
+import { requestVariantPriceFanout } from "../../../../../workflows/fx/fanout-variant-prices"
 import {
   isCoreChannelListingPartner,
   recordArtisanProposal,
@@ -88,7 +88,7 @@ export const POST = async (
   // FX fanout — materialise auto-converted prices in the store's other
   // supported currencies so the product isn't "not available" in non-native
   // regions. Idempotent + never throws (see fanout-variant-prices.ts).
-  await fanoutVariantPrices(req.scope, { storeId: store.id, variantIds })
+  await requestVariantPriceFanout(req.scope, { storeId: store.id, variantIds })
 
   res.status(201).json({ product })
 }

--- a/apps/backend/src/lib/__tests__/assistant-messages.unit.spec.ts
+++ b/apps/backend/src/lib/__tests__/assistant-messages.unit.spec.ts
@@ -1,0 +1,178 @@
+import {
+  normaliseUiMessages,
+  MAX_PART_TEXT_CHARS,
+  MAX_TOTAL_TEXT_CHARS,
+  TRUNCATION_MARKER,
+} from "../assistant-messages"
+
+const text = (t: string) => ({ type: "text", text: t })
+const user = (t: string) => ({ role: "user", parts: [text(t)] })
+
+describe("normaliseUiMessages — behaviour preserved", () => {
+  it("flattens text parts and keeps role", () => {
+    const { messages } = normaliseUiMessages([
+      { role: "user", parts: [text("hello"), text("world")] },
+    ])
+    expect(messages).toEqual([
+      { role: "user", parts: [text("hello"), text("world")] },
+    ])
+  })
+
+  it("strips non-text parts (tool calls, files) from history", () => {
+    const { messages } = normaliseUiMessages([
+      {
+        role: "assistant",
+        parts: [
+          { type: "tool-call", toolName: "create_product", input: { big: "x" } },
+          text("done"),
+          { type: "file", url: "https://example.com/a.png" },
+        ],
+      },
+    ])
+    expect(messages[0].parts).toEqual([text("done")])
+  })
+
+  it("falls back to `content` when there are no parts", () => {
+    const { messages } = normaliseUiMessages([{ role: "user", content: "hi" }])
+    expect(messages[0].parts).toEqual([text("hi")])
+  })
+
+  it("emits one empty text part when a message has nothing usable", () => {
+    const { messages } = normaliseUiMessages([{ role: "user", parts: [] }])
+    expect(messages[0].parts).toEqual([text("")])
+  })
+
+  it("reports bounded=false for an ordinary conversation", () => {
+    const result = normaliseUiMessages([user("hi"), user("there")])
+    expect(result.bounded).toBe(false)
+    expect(result.droppedMessages).toBe(0)
+    expect(result.truncatedParts).toBe(0)
+  })
+
+  it("tolerates null / undefined input", () => {
+    expect(normaliseUiMessages(null).messages).toEqual([])
+    expect(normaliseUiMessages(undefined).messages).toEqual([])
+  })
+})
+
+describe("normaliseUiMessages — the bounds", () => {
+  it("truncates a single oversized part and marks it", () => {
+    const result = normaliseUiMessages([user("a".repeat(MAX_PART_TEXT_CHARS + 5_000))])
+    const out = result.messages[0].parts[0].text
+    expect(out.length).toBe(MAX_PART_TEXT_CHARS + TRUNCATION_MARKER.length)
+    expect(out.endsWith(TRUNCATION_MARKER)).toBe(true)
+    expect(result.truncatedParts).toBe(1)
+    expect(result.bounded).toBe(true)
+  })
+
+  it("leaves a part exactly at the limit untouched", () => {
+    const result = normaliseUiMessages([user("a".repeat(MAX_PART_TEXT_CHARS))])
+    expect(result.messages[0].parts[0].text).not.toContain(TRUNCATION_MARKER)
+    expect(result.bounded).toBe(false)
+  })
+
+  it("caps total retained text across the whole thread", () => {
+    // 20 messages × 100k chars = 2M chars, well past the 600k budget.
+    const thread = Array.from({ length: 20 }, () => user("a".repeat(100_000)))
+    const result = normaliseUiMessages(thread)
+    const total = result.messages.reduce(
+      (sum, m) => sum + m.parts.reduce((s, p) => s + p.text.length, 0),
+      0
+    )
+    expect(total).toBeLessThanOrEqual(MAX_TOTAL_TEXT_CHARS)
+    expect(result.droppedMessages).toBeGreaterThan(0)
+    expect(result.bounded).toBe(true)
+  })
+
+  it("drops the OLDEST turns, never the newest — the newest is what's being answered", () => {
+    // Each part stays UNDER the per-part cap so this exercises the thread
+    // budget, not the truncator: 8 x 90k = 720k against a 600k budget.
+    const thread = [
+      user("oldest " + "a".repeat(90_000)),
+      ...Array.from({ length: 6 }, () => user("filler " + "b".repeat(90_000))),
+      user("NEWEST"),
+    ]
+    const { messages } = normaliseUiMessages(thread)
+    const joined = messages.map((m) => m.parts[0].text).join("|")
+    expect(joined).toContain("NEWEST")
+    expect(joined).not.toContain("oldest")
+  })
+
+  it("preserves chronological order after trimming", () => {
+    const thread = [
+      ...Array.from({ length: 8 }, () => user("a".repeat(90_000))),
+      user("SECOND"),
+      user("THIRD"),
+    ]
+    const { messages } = normaliseUiMessages(thread)
+    const kept = messages.map((m) => m.parts[0].text)
+    expect(kept[kept.length - 1]).toBe("THIRD")
+    expect(kept[kept.length - 2]).toBe("SECOND")
+  })
+
+  it("never returns an empty thread, even when the newest message alone busts the budget", () => {
+    const result = normaliseUiMessages([user("z".repeat(MAX_TOTAL_TEXT_CHARS * 3))])
+    expect(result.messages).toHaveLength(1)
+    expect(result.messages[0].parts[0].text.length).toBeLessThanOrEqual(
+      MAX_TOTAL_TEXT_CHARS + TRUNCATION_MARKER.length
+    )
+    expect(result.bounded).toBe(true)
+  })
+
+  it("bounds a 5 MB body — the size the route is willing to receive", () => {
+    // What the route's bodyParser actually permits, spread over the 60-message
+    // schema cap. Unbounded, all of this was retained and copied repeatedly.
+    const thread = Array.from({ length: 60 }, (_, i) =>
+      user(`turn ${i} ` + "x".repeat(87_000))
+    )
+    const result = normaliseUiMessages(thread)
+    const total = result.messages.reduce(
+      (sum, m) => sum + m.parts.reduce((s, p) => s + p.text.length, 0),
+      0
+    )
+    expect(total).toBeLessThanOrEqual(MAX_TOTAL_TEXT_CHARS)
+    // And the turn the model must answer survived.
+    const last = result.messages[result.messages.length - 1].parts[0].text
+    expect(last.startsWith("turn 59 ")).toBe(true)
+  })
+})
+
+/**
+ * Drift guard.
+ *
+ * The bound landed on the partner assistant first and the admin assistant kept
+ * its own byte-identical copy of the flattening step with no ceiling on it —
+ * the same defect, live on a second surface, invisible to tsc and to every
+ * other test. This asserts BOTH routes go through the shared helper, so a
+ * future edit cannot quietly re-open the hole on one of them.
+ *
+ * Reads the sources as text on purpose: importing the routes drags in the
+ * Medusa container, the MCP registries and the AI SDK.
+ */
+describe("both assistant surfaces use the shared bound", () => {
+  const fs = require("fs") as typeof import("fs")
+  const path = require("path") as typeof import("path")
+
+  const ROUTES = [
+    ["partner", "src/api/partners/assistant/chat/route.ts"],
+    ["admin", "src/api/admin/assistant/chat/route.ts"],
+  ] as const
+
+  const read = (rel: string) =>
+    fs.readFileSync(path.join(__dirname, "..", "..", "..", rel), "utf8")
+
+  it.each(ROUTES)("%s chat route imports normaliseUiMessages", (_name, rel) => {
+    expect(read(rel)).toMatch(
+      /import\s*\{\s*normaliseUiMessages\s*\}\s*from\s*".*lib\/assistant-messages"/
+    )
+  })
+
+  it.each(ROUTES)(
+    "%s chat route has no inline re-implementation of the flattening step",
+    (_name, rel) => {
+      // The signature of the old hand-rolled block. Its return shape
+      // (`parts: textParts.length ? ... : ...`) is what made it unbounded.
+      expect(read(rel)).not.toContain("textParts.length ? textParts")
+    }
+  )
+})

--- a/apps/backend/src/lib/assistant-messages.ts
+++ b/apps/backend/src/lib/assistant-messages.ts
@@ -1,0 +1,157 @@
+/**
+ * Bounded normalisation of inbound UI messages.
+ *
+ * Shared by BOTH assistant surfaces — /partners/assistant/chat and
+ * /admin/assistant/chat. The two routes carried a byte-identical copy of this
+ * flattening step and an identical absence of any size bound; they live here
+ * now so a limit raised for one cannot silently skip the other.
+ *
+ * Both routes accept a 5 MB body ON PURPOSE: the AI-SDK transport replays the
+ * whole thread including tool parts, and a turn that ran a tool with a large
+ * result blows straight through Express's 100 kB default. They have to be able
+ * to RECEIVE that. What they must not do is carry it.
+ *
+ * Nothing bounded anything before. `messages` was capped at 60 entries, but a
+ * message could hold unlimited parts, each with an unlimited `text`, and the
+ * schemas are `.passthrough()` so every unknown key survived too. That payload
+ * was then copied several times over on its way to the provider — parsed,
+ * zod-cloned, normalised, `convertToModelMessages`'d, folded — so the peak cost
+ * of one turn was a multiple of a body size that had no ceiling below 5 MB.
+ *
+ * So: bound what is RETAINED, not what is received.
+ *
+ * Distinct from the admin route's `capToolResult`, which bounds a single tool
+ * result on the way OUT (64 kB per call). That does nothing about a thread
+ * replaying dozens of prior turns back IN, which is this function's job.
+ *
+ * The limits are deliberately generous. Context compaction is a separate,
+ * client-driven mechanism (POST /{partners,admin}/assistant/summarize) and this
+ * must not quietly do that job badly — these ceilings sit above any thread a
+ * real model context can hold, so they catch runaway and abuse, never a normal
+ * conversation. When one does bite, the route logs it rather than silently
+ * changing what the user said.
+ */
+
+/**
+ * Longest single text part we keep. A part beyond this is truncated with a
+ * visible marker — the model is told the text was cut rather than being
+ * handed a sentence that stops mid-word.
+ */
+export const MAX_PART_TEXT_CHARS = 100_000
+
+/**
+ * Total characters of message text retained across the whole thread.
+ * ~600k chars is roughly 150k tokens: comfortably more than any context window
+ * this assistant runs against, and ~1.2 MB of UTF-16 rather than an unbounded
+ * multiple of the 5 MB body.
+ */
+export const MAX_TOTAL_TEXT_CHARS = 600_000
+
+export const TRUNCATION_MARKER = "\n\n[… truncated by the server: this message exceeded the per-message size limit]"
+
+export type NormalisedMessage = {
+  role: "system" | "user" | "assistant"
+  parts: Array<{ type: "text"; text: string }>
+}
+
+export type NormaliseResult = {
+  messages: NormalisedMessage[]
+  /** True when anything was dropped or cut — the caller logs this. */
+  bounded: boolean
+  /** How many whole messages were dropped from the OLDEST end. */
+  droppedMessages: number
+  /** How many individual parts were truncated. */
+  truncatedParts: number
+}
+
+/**
+ * Strip everything that isn't text (tool parts, attachments metadata, unknown
+ * passthrough keys), then apply the size bounds.
+ *
+ * Trimming runs OLDEST-FIRST — the newest turns are the ones the model is
+ * actually answering, and dropping those to keep stale history would be worse
+ * than useless. The most recent message is always kept, truncated if need be,
+ * so the function can never return an empty thread.
+ */
+export function normaliseUiMessages(
+  raw: Array<any> | undefined | null
+): NormaliseResult {
+  const input = Array.isArray(raw) ? raw : []
+
+  // 1. Flatten to text-only parts (the pre-existing behaviour).
+  const flattened: NormalisedMessage[] = input.map((m: any) => {
+    const parts = Array.isArray(m?.parts) ? m.parts : null
+    const textParts = parts
+      ? parts
+          .filter(
+            (p: any) =>
+              p?.type === "text" && typeof p.text === "string" && p.text.length > 0
+          )
+          .map((p: any) => ({ type: "text" as const, text: p.text as string }))
+      : [{ type: "text" as const, text: String(m?.content ?? "") }]
+
+    return {
+      role: m?.role,
+      parts: textParts.length ? textParts : [{ type: "text" as const, text: "" }],
+    }
+  })
+
+  // 2. Per-part ceiling.
+  let truncatedParts = 0
+  for (const message of flattened) {
+    message.parts = message.parts.map((p) => {
+      if (p.text.length <= MAX_PART_TEXT_CHARS) return p
+      truncatedParts++
+      return {
+        type: "text" as const,
+        text: p.text.slice(0, MAX_PART_TEXT_CHARS) + TRUNCATION_MARKER,
+      }
+    })
+  }
+
+  // 3. Whole-thread budget, spent newest-first so the oldest turns fall away.
+  const sizeOf = (m: NormalisedMessage) =>
+    m.parts.reduce((sum, p) => sum + p.text.length, 0)
+
+  let budget = MAX_TOTAL_TEXT_CHARS
+  const keptReversed: NormalisedMessage[] = []
+  for (let i = flattened.length - 1; i >= 0; i--) {
+    const message = flattened[i]
+    const cost = sizeOf(message)
+    if (cost <= budget) {
+      budget -= cost
+      keptReversed.push(message)
+      continue
+    }
+    // The newest message alone can exceed the whole budget. Keep it anyway,
+    // cut to fit — returning nothing would turn a big turn into a blank one.
+    if (keptReversed.length === 0) {
+      truncatedParts++
+      keptReversed.push({
+        role: message.role,
+        parts: [
+          {
+            type: "text" as const,
+            text:
+              message.parts
+                .map((p) => p.text)
+                .join("\n")
+                .slice(0, MAX_TOTAL_TEXT_CHARS) + TRUNCATION_MARKER,
+          },
+        ],
+      })
+      budget = 0
+    }
+    break
+  }
+
+  const messages = keptReversed.reverse()
+  const droppedMessages = flattened.length - messages.length
+
+  return {
+    messages,
+    bounded: droppedMessages > 0 || truncatedParts > 0,
+    droppedMessages,
+    truncatedParts,
+  }
+}

--- a/apps/backend/src/subscribers/fx-fanout-prices.ts
+++ b/apps/backend/src/subscribers/fx-fanout-prices.ts
@@ -1,0 +1,66 @@
+import { SubscriberArgs, type SubscriberConfig } from "@medusajs/framework"
+import { ContainerRegistrationKeys } from "@medusajs/framework/utils"
+
+import {
+  fanoutVariantPrices,
+  FX_FANOUT_REQUESTED,
+  type FxFanoutRequestedPayload,
+} from "../workflows/fx/fanout-variant-prices"
+
+/**
+ * FX price fanout, moved off the request path.
+ *
+ * Partner/admin routes that write variant prices now emit
+ * `fx.fanout_requested` (see requestVariantPriceFanout) instead of running the
+ * fanout inline. This handler does the work — and because subscribers only run
+ * in WORKER mode, the work lands on the background service rather than in the
+ * public API container.
+ *
+ * That placement is the point. The fanout runs one full workflow-engine
+ * execution per price; doing that inside a request meant a partner saving a
+ * multi-variant product could allocate hundreds of megabytes in the container
+ * that also serves the storefront. On 2026-08-19 it OOM-killed prod twice
+ * (exit 137, 11:38 and 23:42 UTC) — memory 57% → 99% of a 2 GB task inside one
+ * minute, event loop blocked so hard the process stopped logging for 65s.
+ * Here, the same overload costs a worker restart and a retry, not a 503.
+ *
+ * The fanout itself stays bounded (FANOUT_MAX_CONCURRENCY) — moving work to a
+ * 1 GB worker only helps if the work has a ceiling. Both halves are required.
+ *
+ * Idempotent by construction: the workflow's `fx_price_meta` recursion guard
+ * skips prices that fanout already derived, and its "already priced" check
+ * skips currencies the price_set already carries. A redelivered event is a
+ * no-op, so at-least-once delivery is safe.
+ */
+export default async function fxFanoutPricesHandler({
+  event: { data },
+  container,
+}: SubscriberArgs<FxFanoutRequestedPayload>) {
+  const logger = container.resolve(ContainerRegistrationKeys.LOGGER) as any
+
+  if (!data?.store_id) return
+  if (!data.price_ids?.length && !data.variant_ids?.length) return
+
+  // fanoutVariantPrices never throws — it logs and returns a result. The
+  // try/catch is for the resolve/plumbing around it, so a bad event can never
+  // take the subscriber (and with it the worker) down.
+  try {
+    const result = await fanoutVariantPrices(container, {
+      storeId: data.store_id,
+      ...(data.price_ids?.length ? { priceIds: data.price_ids } : {}),
+      ...(data.variant_ids?.length ? { variantIds: data.variant_ids } : {}),
+    })
+    logger?.info?.(
+      `[fanout] store ${data.store_id}: ${result.price_ids.length} price(s) processed, ` +
+        `${result.created_count} auto-price(s) created, ${result.failed_count} failed`
+    )
+  } catch (e: any) {
+    logger?.warn?.(
+      `[fanout] handler failed for store ${data.store_id}: ${e?.message ?? e}`
+    )
+  }
+}
+
+export const config: SubscriberConfig = {
+  event: FX_FANOUT_REQUESTED,
+}

--- a/apps/backend/src/workflows/fx/__tests__/fanout-variant-prices.unit.spec.ts
+++ b/apps/backend/src/workflows/fx/__tests__/fanout-variant-prices.unit.spec.ts
@@ -1,4 +1,4 @@
-import { collectVariantPriceIds } from "../fanout-variant-prices"
+import { collectVariantPriceIds, mapWithConcurrency } from "../fanout-variant-prices"
 
 /**
  * Pure price-id extraction for the shared FX fanout helper. The workflow-driven
@@ -38,5 +38,97 @@ describe("collectVariantPriceIds", () => {
     expect(
       collectVariantPriceIds([{ prices: [{ id: "p1" }, { amount: 5 }] }])
     ).toEqual(["p1"])
+  })
+})
+
+/**
+ * The concurrency bound. This is the fix for the 2026-08-19 prod OOM kills
+ * (exit 137, twice in one day) — the helper used to launch one full
+ * workflow-engine run per price ALL AT ONCE, so peak memory scaled with the
+ * number of prices a partner happened to save rather than with a fixed pool.
+ *
+ * These tests assert the invariant that actually matters: never more than
+ * `limit` tasks in flight. Every one of them passes trivially against
+ * `Promise.allSettled(items.map(...))` EXCEPT the peak-concurrency assertions,
+ * which is the point — those are the ones that fail without the pool.
+ */
+describe("mapWithConcurrency", () => {
+  /** Runs `n` tasks that all park until released, recording peak overlap. */
+  const runTracked = async (n: number, limit: number) => {
+    let inFlight = 0
+    let peak = 0
+    const order: number[] = []
+    await mapWithConcurrency(
+      Array.from({ length: n }, (_, i) => i),
+      limit,
+      async (i) => {
+        inFlight++
+        peak = Math.max(peak, inFlight)
+        order.push(i)
+        // Yield across a few microtask ticks so overlapping tasks actually
+        // interleave — a synchronous body would never reveal a bound.
+        await new Promise((r) => setTimeout(r, 1))
+        inFlight--
+      }
+    )
+    return { peak, order }
+  }
+
+  it("never exceeds the limit — fails against unbounded Promise.allSettled", async () => {
+    const { peak } = await runTracked(50, 4)
+    expect(peak).toBeLessThanOrEqual(4)
+  })
+
+  it("holds the bound when the work greatly outnumbers the pool", async () => {
+    const { peak } = await runTracked(200, 4)
+    expect(peak).toBeLessThanOrEqual(4)
+  })
+
+  it("processes every item exactly once", async () => {
+    const { order } = await runTracked(50, 4)
+    expect(order).toHaveLength(50)
+    expect(new Set(order).size).toBe(50)
+  })
+
+  it("does not spawn more workers than there are items", async () => {
+    const { peak } = await runTracked(2, 16)
+    expect(peak).toBeLessThanOrEqual(2)
+  })
+
+  it("still runs concurrently — it is a bound, not a serialiser", async () => {
+    const { peak } = await runTracked(20, 4)
+    expect(peak).toBeGreaterThan(1)
+  })
+
+  it("tolerates an empty list without hanging", async () => {
+    await expect(mapWithConcurrency([], 4, async () => {})).resolves.toBeUndefined()
+  })
+
+  it("treats a limit below 1 as a pool of 1 rather than spawning nothing", async () => {
+    const seen: number[] = []
+    await mapWithConcurrency([1, 2, 3], 0, async (i) => {
+      seen.push(i)
+    })
+    expect(seen).toEqual([1, 2, 3])
+  })
+
+  it("keeps draining after a task throws mid-run", async () => {
+    // fanoutVariantPrices' task swallows its own errors, but the runner must
+    // not lose the rest of the queue if one ever escapes.
+    const seen: number[] = []
+    const task = async (i: number) => {
+      seen.push(i)
+      if (i === 1) throw new Error("boom")
+    }
+    await expect(
+      mapWithConcurrency([0, 1, 2, 3], 2, async (i) => {
+        try {
+          await task(i)
+        } catch {
+          /* mirrors the helper's per-price catch */
+        }
+      })
+    ).resolves.toBeUndefined()
+    expect(seen).toHaveLength(4)
   })
 })

--- a/apps/backend/src/workflows/fx/fanout-variant-prices.ts
+++ b/apps/backend/src/workflows/fx/fanout-variant-prices.ts
@@ -1,4 +1,4 @@
-import { ContainerRegistrationKeys } from "@medusajs/framework/utils"
+import { ContainerRegistrationKeys, Modules } from "@medusajs/framework/utils"
 
 import fanoutPricesWorkflow from "./fanout-prices"
 
@@ -65,11 +65,60 @@ export type FanoutVariantPricesResult = {
 }
 
 /**
+ * How many `fanoutPricesWorkflow` runs may be in flight at once.
+ *
+ * This is a MEMORY bound, not a throughput tuning knob. Each run is a full
+ * workflow-engine execution (own context, steps, Redis-persisted state, DB
+ * work), so the peak footprint of a fanout is `concurrency × per-run cost`,
+ * NOT `per-run cost`. Before this was bounded the helper launched one run per
+ * price simultaneously — a partner saving a multi-variant product across a
+ * multi-currency store fanned out into hundreds of concurrent workflow runs.
+ *
+ * That is what OOM-killed the prod API container twice on 2026-08-19 (11:38
+ * and 23:42 UTC, exit 137): memory went 57% → 99% of a 2 GB task inside ONE
+ * minute, with the event loop blocked long enough to stop logging for 65s.
+ * Both kills came through this helper — once via `create_product`, once via
+ * `variants/batch`.
+ *
+ * The old code claimed "bounded concurrency via Promise.allSettled" in this
+ * very docblock. `Promise.allSettled` bounds NOTHING; it waits on whatever it
+ * is handed, all of which starts immediately. The comment described the
+ * intent and hid the defect for as long as it stood.
+ */
+export const FANOUT_MAX_CONCURRENCY = 4
+
+/**
+ * Run `task` over `items` with at most `limit` in flight at a time.
+ *
+ * A fixed pool of workers pulling from a shared cursor, rather than
+ * fixed-size batches: a slow price never idles the other workers waiting for
+ * its batch to drain. Each task is expected to swallow its own errors — this
+ * runner never rejects.
+ */
+export async function mapWithConcurrency<T>(
+  items: T[],
+  limit: number,
+  task: (item: T) => Promise<void>
+): Promise<void> {
+  let cursor = 0
+  const workers = Array.from(
+    { length: Math.max(1, Math.min(limit, items.length)) },
+    async () => {
+      while (cursor < items.length) {
+        const item = items[cursor++]
+        await task(item)
+      }
+    }
+  )
+  await Promise.all(workers)
+}
+
+/**
  * Fire-and-forget FX fanout for freshly written variant prices. Resolves the
  * target price ids from `priceIds` (preferred) or by looking them up from
- * `variantIds`, then runs `fanoutPricesWorkflow` once per price with bounded
- * concurrency via Promise.allSettled. Never throws — the worst case is a
- * logged warning and no auto-prices, exactly the pre-existing behaviour.
+ * `variantIds`, then runs `fanoutPricesWorkflow` once per price, at most
+ * FANOUT_MAX_CONCURRENCY at a time. Never throws — the worst case is a logged
+ * warning and no auto-prices, exactly the pre-existing behaviour.
  */
 export async function fanoutVariantPrices(
   scope: any,
@@ -102,8 +151,10 @@ export async function fanoutVariantPrices(
 
     if (!priceIds.length) return result
 
-    await Promise.allSettled(
-      priceIds.map(async (priceId) => {
+    await mapWithConcurrency(
+      priceIds,
+      FANOUT_MAX_CONCURRENCY,
+      async (priceId) => {
         try {
           const { result: fanoutResult } = await fanoutPricesWorkflow(scope).run({
             input: { source_price_id: priceId, store_id: input.storeId },
@@ -123,7 +174,7 @@ export async function fanoutVariantPrices(
           const message = err instanceof Error ? err.message : String(err)
           logger.warn(`[fanout] price ${priceId} workflow failed: ${message}`)
         }
-      })
+      }
     )
   } catch (err) {
     // Resolving the query graph / anything above must never break the save.
@@ -135,3 +186,58 @@ export async function fanoutVariantPrices(
 }
 
 export default fanoutVariantPrices
+
+/**
+ * Event that asks for an FX fanout to be performed off the request path.
+ * Handled by src/subscribers/fx-fanout-prices.ts, which runs on the WORKER.
+ */
+export const FX_FANOUT_REQUESTED = "fx.fanout_requested"
+
+export type FxFanoutRequestedPayload = {
+  store_id: string
+  price_ids?: string[]
+  variant_ids?: string[]
+}
+
+/**
+ * ASYNC entry point — what routes should call.
+ *
+ * Emits FX_FANOUT_REQUESTED and returns immediately; the actual fanout runs in
+ * the worker's subscriber. Three reasons this is not just a perf nicety:
+ *
+ *  1. MEMORY. The fanout's peak footprint is `concurrency × workflow-run cost`.
+ *     Running it inline put that peak inside the public API container, which is
+ *     the one that gets OOM-killed and takes the storefront down with it (twice
+ *     on 2026-08-19). The worker can die and retry without a single 503.
+ *  2. LATENCY. The partner's save used to block on every price's workflow run.
+ *  3. DURABILITY. Inline, a fanout interrupted mid-flight (deploy, OOM, client
+ *     disconnect) left prices half-materialised with nothing to resume it.
+ *
+ * Never throws. If the event bus itself is unreachable the fanout is skipped
+ * and logged — exactly the pre-existing "worst case is no auto-prices"
+ * contract, and never a failed save for the partner.
+ */
+export async function requestVariantPriceFanout(
+  scope: any,
+  input: FanoutVariantPricesInput
+): Promise<void> {
+  const logger: any = scope.resolve(ContainerRegistrationKeys.LOGGER)
+  const payload: FxFanoutRequestedPayload = {
+    store_id: input.storeId,
+    ...(input.priceIds?.length ? { price_ids: input.priceIds } : {}),
+    ...(input.variantIds?.length ? { variant_ids: input.variantIds } : {}),
+  }
+
+  // Nothing to fan out — don't wake the worker for an empty job.
+  if (!payload.price_ids?.length && !payload.variant_ids?.length) return
+
+  try {
+    const eventBus: any = scope.resolve(Modules.EVENT_BUS)
+    await eventBus.emit({ name: FX_FANOUT_REQUESTED, data: payload })
+  } catch (err) {
+    const message = err instanceof Error ? err.message : String(err)
+    logger?.warn?.(
+      `[fanout] could not enqueue FX fanout for store ${input.storeId}: ${message}`
+    )
+  }
+}

--- a/deploy/aws/copilot/medusa-server/manifest.yml
+++ b/deploy/aws/copilot/medusa-server/manifest.yml
@@ -32,16 +32,44 @@ image:
   port: 9000
 
 cpu: 512        # 0.5 vCPU
-memory: 2048    # 2 GB. Bumped on 2026-05-20 along with RDS max_connections
-                # bump to 200 (was 79) and switch to fixed count: 1. Even
-                # so, rolling deploys still see some concurrent-bootstrap
-                # failures; investigation continues (task #18).
+memory: 4096    # 4 GB. Was 2048 (bumped 2026-05-20 alongside the RDS
+                # max_connections bump to 200). Raised to 4096 on 2026-08-20
+                # after two OOM kills in one day (exit 137, 11:38 + 23:42 UTC):
+                # memory went 57% → 99% of the 2 GB inside a single minute.
+                # 512 CPU / 4096 MB is a valid Fargate combination.
+                #
+                # Headroom is the SECOND line of defence, not the fix. The
+                # cause was an unbounded FX price fanout (one workflow run per
+                # price, all launched at once) — now bounded AND moved to the
+                # worker. Without those, 4 GB just buys a bigger burst before
+                # the same kill.
 
-# Fixed count: 1. Autoscaling disabled.
-# Default ECS rolling deploy with desired=1: 1 new task launches + 1 old
-# drains. Total of 2 tasks in flight = manageable connection demand.
-# Re-enable autoscaling once the boot-stall is understood/fixed.
-count: 1
+# Autoscaling, re-enabled 2026-08-20 (was `count: 1`, disabled pending the
+# task #18 boot-stall investigation).
+#
+# The MIN of 2 is the part that matters for availability, and it is why this
+# changed. At count: 1 a single task death is a full outage — that is exactly
+# what the 23:42 OOM was: ~2 minutes of hard 503 on v3.jaalyantra.com while
+# ECS rescheduled. At min 2 the ALB simply stops routing to the dead target.
+#
+# Be honest about what the scaling rules do and do not cover: ECS target
+# tracking reacts over MINUTES. It would not have prevented either OOM, both of
+# which went from steady-state to dead inside 60 seconds. These thresholds are
+# for sustained load; the redundancy is for sudden death.
+#
+# Connection math (the original reason autoscaling was switched off): observed
+# prod usage is 4-10 connections steady, 35 at its worst — against
+# max_connections 200. 4 server tasks + the worker + a rolling deploy's extra
+# task stays far inside that.
+count:
+  range: 2-4
+  cooldown:
+    # Scale OUT fast, scale IN slowly: adding a task is cheap and reversible,
+    # while dropping one under load is how you get a retry storm.
+    in: 300s
+    out: 60s
+  cpu_percentage: 70
+  memory_percentage: 75
 
 # Public subnets for Phase 0 (saves $32/mo NAT Gateway).
 # Tighten to private+NAT in Phase 1 hardening.
@@ -53,6 +81,18 @@ network:
 variables:
   NODE_ENV: production
   MEDUSA_WORKER_MODE: server
+  # Node has to be TOLD the container limit. Without this it sizes its heap
+  # from the HOST's memory, never approaches its own ceiling, and gets
+  # SIGKILLed by the cgroup instead — which is precisely why both 2026-08-19
+  # kills produced a bare "Killed" + exit 137 with no stack trace, no heap
+  # dump, and nothing to debug from. With it, an over-allocating request throws
+  # a catchable JS heap error that names the allocation site, and the process
+  # GCs harder before it gets there.
+  #
+  # 3072 of the task's 4096 leaves ~1 GB for what V8 does not count as
+  # old-space: native modules, Buffers, stream machinery, RSS overhead. Setting
+  # this at or near the task memory puts you straight back to a kernel kill.
+  NODE_OPTIONS: --max-old-space-size=3072
   # #707/#712 — base URL for partner-portal product links in WhatsApp confirmation
   # messages. Read by buildPartnerProductUrl (src/workflows/whatsapp/partner-product-url.ts),
   # which falls back to a hardcoded default if unset; this makes the prod value explicit.

--- a/deploy/aws/copilot/medusa-worker/manifest.yml
+++ b/deploy/aws/copilot/medusa-worker/manifest.yml
@@ -10,7 +10,13 @@ image:
   # No `port:` — this service doesn't accept inbound HTTP.
 
 cpu: 512        # 0.5 vCPU
-memory: 1024    # 1 GB
+memory: 2048    # 2 GB. Was 1024. Raised 2026-08-20 because the FX price
+                # fanout MOVED HERE — routes now emit fx.fanout_requested and
+                # src/subscribers/fx-fanout-prices.ts does the work, so the
+                # burst that OOM-killed the API container twice now lands on
+                # this service. Moving an unbounded job onto a SMALLER box just
+                # relocates the outage; the fanout is bounded
+                # (FANOUT_MAX_CONCURRENCY) and this has room for that bound.
 
 # Fixed singleton on Fargate Spot.
 # Running 2+ would double-execute scheduled jobs and subscribers.
@@ -25,6 +31,10 @@ variables:
   NODE_ENV: production
   MEDUSA_WORKER_MODE: worker
   DISABLE_MEDUSA_ADMIN: "true"
+  # Same reasoning as the server manifest: without an explicit heap ceiling
+  # Node sizes old-space from the HOST and is SIGKILLed by the cgroup with no
+  # stack trace. 1536 of 2048 leaves headroom for non-heap memory.
+  NODE_OPTIONS: --max-old-space-size=1536
   # #707/#712 — base URL for partner-portal product links in WhatsApp confirmation
   # messages. The worker runs the subscribers (visual-flow-event-trigger →
   # createDraftProductFromExtractionWorkflow) that build these links via


### PR DESCRIPTION
## The outage

Prod (`v3.jaalyantra.com`) was OOM-killed **twice on 19 Aug** — exit 137, 11:38 and 23:42 UTC — about **2 minutes of hard 503** each time while ECS rescheduled. It self-healed, which is why nothing paged.

## Cause

`fanoutVariantPrices` ran one **full workflow-engine execution per price, all launched at once**:

```js
await Promise.allSettled(priceIds.map(...))   // ← bounds nothing
```

Peak memory scaled with how many prices a partner happened to save. Minute-level `MemoryUtilization` shows **57% → 99% of a 2 GB task inside one minute**, with the event loop blocked hard enough to stop logging for 65s before the bare `Killed`. Both kills route through this helper (11:38 via `create_product`, 23:42 via `variants/batch`); RDS connections spiking to 35 in the same window corroborate it.

The docblock said *"bounded concurrency via Promise.allSettled"*. It bounds nothing — it waits on what it is handed, all of which starts immediately. The comment described the intent and hid the defect.

A flat memory graph is not a healthy one: it sat at exactly 52–54% for twelve hours, which reads as a slow leak until you pull `period=60`.

## Fix

**Bound it** — `mapWithConcurrency` worker pool, `FANOUT_MAX_CONCURRENCY = 4`.

**Move it off the request path** — routes emit `fx.fanout_requested`; `subscribers/fx-fanout-prices.ts` does the work. Subscribers are worker-only, so an overload now costs a worker restart rather than a storefront outage. Worker **1 GB → 2 GB**: moving an unbounded job onto a smaller box only relocates the outage.

## The prices that never set

Separately, and the reason prices set through the assistant or MCP never appeared in other currencies: **`/partners/products` — the route `create_product` posts to — was never in the fanout sweep.** Seven other callers were fixed; this one was missed, so those products existed only in the store's native currency and read "not available" in every other region, while the same product made in the partner UI fanned out fine.

The same route had the **identical gap for inventory levels**, already found and commented directly above the line this adds.

## Assistant payload bounds (both surfaces)

Both chat routes accept a 5 MB body deliberately — they must be able to *receive* replayed tool parts — but nothing stopped that 5 MB being copied through parse → zod → normalise → `convertToModelMessages` → fold. `messages` was capped at 60 entries; parts per message, text per part, and passthrough keys were all unbounded.

`lib/assistant-messages.ts` bounds what is **retained**, not what is received: 100k chars per part, 600k per thread, oldest-first trim, newest turn always kept. The ceilings sit above any real model context, so they catch runaway rather than conversation, and the routes log when one bites.

The two routes carried a **byte-identical** copy of the flattening step — which is how the admin surface ended up with the same defect. Shared helper plus a drift guard asserting both routes use it. Distinct from admin's `capToolResult`, which bounds one result on the way *out*.

## Infra

| | |
|---|---|
| `NODE_OPTIONS=--max-old-space-size` | **Both** manifests. Without it Node sizes its heap from the **host** and is SIGKILLed by the cgroup — which is why both kills gave a bare `Killed` with no stack trace and no heap dump. |
| Server memory | 2 GB → 4 GB. Headroom is the second line of defence, not the fix. |
| Server count | `1` → `range: 2-4`. |

**The `min: 2` is the availability change, not the scaling rules.** At `count: 1` a single task death is a full outage — that is exactly what the 23:42 kill was. ECS target tracking reacts over *minutes* and would **not** have caught either 60-second spike. Connection math: 4–10 steady, 35 at worst, against `max_connections` 200.

## Verification

- **223/223** assistant + fx unit tests (18 suites).
- The concurrency bound: **2 of 12 tests fail against the old code** — verified by reverting `mapWithConcurrency` to the one-liner and re-running.
- The drift guard: **both admin assertions fail** when the admin route is reverted to its inline copy — verified the same way.
- `tsc` at the **74-error baseline**, none in touched files.
- `check:prod-build` green, no `medusa-config.ts` / `workflow-schemas.json` side effects.

## Deploy note

Merging triggers `deploy-to-aws.yml`, which runs `copilot svc deploy` for both services — so the memory, `NODE_OPTIONS` and autoscaling changes ship with the code. Expect the server to settle at **2 tasks**.

🤖 Generated with [Claude Code](https://claude.com/claude-code)