### PR TITLE
perf(partners): phase-time the slow variants/batch save, batch its N+1

### DIFF
--- a/apps/backend/src/api/partners/__tests__/ensure-inventory-levels.unit.spec.ts
+++ b/apps/backend/src/api/partners/__tests__/ensure-inventory-levels.unit.spec.ts
@@ -1,0 +1,187 @@
+import {
+  ContainerRegistrationKeys,
+  Modules,
+} from "@medusajs/framework/utils"
+
+import { ensureInventoryLevelsForVariants } from "../helpers"
+
+/**
+ * The N+1 in the inventory-level seeder.
+ *
+ * It used to call `listInventoryLevels({ inventory_item_id: itemId })` once per
+ * item, sequentially, before writing anything — so a partner saving N variants
+ * paid N round trips, and the create-product path calls this with every variant
+ * on the product at once. The query-count assertions below are the fix; the
+ * behavioural ones pin that batching did not change what gets written.
+ */
+
+const makeScope = (opts: {
+  locationIds: string[]
+  variants: any[]
+  existingLevels: any[]
+}) => {
+  const calls = { listInventoryLevels: 0, createInventoryLevels: 0 }
+  const created: any[] = []
+  const listFilters: any[] = []
+
+  const inventoryService = {
+    listInventoryLevels: async (filter: any) => {
+      calls.listInventoryLevels++
+      listFilters.push(filter)
+      const wanted = Array.isArray(filter.inventory_item_id)
+        ? filter.inventory_item_id
+        : [filter.inventory_item_id]
+      return opts.existingLevels.filter((l) =>
+        wanted.includes(l.inventory_item_id)
+      )
+    },
+    createInventoryLevels: async (rows: any[]) => {
+      calls.createInventoryLevels++
+      created.push(...rows)
+      return rows
+    },
+  }
+
+  const query = {
+    graph: async ({ entity }: any) => {
+      if (entity === "sales_channels") {
+        return {
+          data: [{ stock_locations: opts.locationIds.map((id) => ({ id })) }],
+        }
+      }
+      return { data: opts.variants }
+    },
+  }
+
+  const scope = {
+    resolve: (key: string) => {
+      if (key === ContainerRegistrationKeys.QUERY) return query
+      if (key === Modules.INVENTORY) return inventoryService
+      throw new Error(`unexpected resolve(${String(key)})`)
+    },
+  }
+
+  return { scope, calls, created, listFilters }
+}
+
+const managedVariant = (n: number) => ({
+  manage_inventory: true,
+  inventory_items: [{ inventory: { id: `iitem_${n}` } }],
+})
+
+describe("ensureInventoryLevelsForVariants", () => {
+  it("makes ONE listInventoryLevels call regardless of variant count", async () => {
+    const { scope, calls } = makeScope({
+      locationIds: ["sloc_1"],
+      variants: Array.from({ length: 25 }, (_, i) => managedVariant(i)),
+      existingLevels: [],
+    })
+
+    await ensureInventoryLevelsForVariants(
+      scope as any,
+      { id: "store_1", default_sales_channel_id: "sc_1" },
+      Array.from({ length: 25 }, (_, i) => `variant_${i}`)
+    )
+
+    // Was 25 before — one per item, sequential.
+    expect(calls.listInventoryLevels).toBe(1)
+  })
+
+  it("passes every item id in a single array filter", async () => {
+    const { scope, listFilters } = makeScope({
+      locationIds: ["sloc_1"],
+      variants: [managedVariant(0), managedVariant(1), managedVariant(2)],
+      existingLevels: [],
+    })
+
+    await ensureInventoryLevelsForVariants(
+      scope as any,
+      { id: "store_1", default_sales_channel_id: "sc_1" },
+      ["v0", "v1", "v2"]
+    )
+
+    expect(listFilters).toHaveLength(1)
+    expect(listFilters[0].inventory_item_id).toEqual([
+      "iitem_0",
+      "iitem_1",
+      "iitem_2",
+    ])
+  })
+
+  it("still seeds a level per item per location", async () => {
+    const { scope, created } = makeScope({
+      locationIds: ["sloc_1", "sloc_2"],
+      variants: [managedVariant(0), managedVariant(1)],
+      existingLevels: [],
+    })
+
+    await ensureInventoryLevelsForVariants(
+      scope as any,
+      { id: "store_1", default_sales_channel_id: "sc_1" },
+      ["v0", "v1"]
+    )
+
+    expect(created).toHaveLength(4)
+    expect(created.every((r) => r.stocked_quantity === 0)).toBe(true)
+  })
+
+  it("does NOT duplicate a level that already exists — per item, not globally", async () => {
+    // The batching bug to avoid: attributing one item's existing levels to all
+    // items. iitem_0 already has sloc_1; iitem_1 has nothing.
+    const { scope, created } = makeScope({
+      locationIds: ["sloc_1"],
+      variants: [managedVariant(0), managedVariant(1)],
+      existingLevels: [
+        { inventory_item_id: "iitem_0", location_id: "sloc_1" },
+      ],
+    })
+
+    await ensureInventoryLevelsForVariants(
+      scope as any,
+      { id: "store_1", default_sales_channel_id: "sc_1" },
+      ["v0", "v1"]
+    )
+
+    expect(created).toEqual([
+      { inventory_item_id: "iitem_1", location_id: "sloc_1", stocked_quantity: 0 },
+    ])
+  })
+
+  it("skips variants that do not manage inventory", async () => {
+    const { scope, created, calls } = makeScope({
+      locationIds: ["sloc_1"],
+      variants: [{ manage_inventory: false, inventory_items: [] }],
+      existingLevels: [],
+    })
+
+    await ensureInventoryLevelsForVariants(
+      scope as any,
+      { id: "store_1", default_sales_channel_id: "sc_1" },
+      ["v0"]
+    )
+
+    expect(created).toHaveLength(0)
+    expect(calls.listInventoryLevels).toBe(0)
+  })
+
+  it("no-ops without variants or a default sales channel", async () => {
+    const { scope, calls } = makeScope({
+      locationIds: ["sloc_1"],
+      variants: [managedVariant(0)],
+      existingLevels: [],
+    })
+
+    await ensureInventoryLevelsForVariants(
+      scope as any,
+      { id: "store_1", default_sales_channel_id: null },
+      ["v0"]
+    )
+    await ensureInventoryLevelsForVariants(
+      scope as any,
+      { id: "store_1", default_sales_channel_id: "sc_1" },
+      []
+    )
+
+    expect(calls.listInventoryLevels).toBe(0)
+  })
+})

--- a/apps/backend/src/api/partners/helpers.ts
+++ b/apps/backend/src/api/partners/helpers.ts
@@ -481,13 +481,28 @@ export const ensureInventoryLevelsForVariants = async (
             stocked_quantity?: number
         }> = []
 
+        // ONE query for every item, not one per item. This used to loop
+        // `listInventoryLevels({ inventory_item_id: itemId })` sequentially, so
+        // a partner saving N variants paid N round trips before a single level
+        // was written — and the create-product path calls this with every
+        // variant on the product at once. The filter takes an array; nothing
+        // about the per-item shape was required.
+        const existing = await inventoryService.listInventoryLevels({
+            inventory_item_id: inventoryItemIds,
+        })
+
+        // item id -> locations it already has a level at.
+        const existingByItem = new Map<string, Set<string>>()
+        for (const level of (existing as any[]) || []) {
+            const itemId = level?.inventory_item_id
+            if (!itemId) continue
+            if (!existingByItem.has(itemId)) existingByItem.set(itemId, new Set())
+            existingByItem.get(itemId)!.add(level.location_id)
+        }
+
         for (const itemId of inventoryItemIds) {
-            const existing = await inventoryService.listInventoryLevels({
-                inventory_item_id: itemId,
-            })
-            const existingLocationIds = new Set(
-                (existing as any[]).map((l) => l.location_id),
-            )
+            const existingLocationIds =
+                existingByItem.get(itemId) ?? new Set<string>()
             for (const locId of locationIds) {
                 if (!existingLocationIds.has(locId)) {
                     levelsToCreate.push({

--- a/apps/backend/src/api/partners/stores/[id]/products/[productId]/variants/batch/route.ts
+++ b/apps/backend/src/api/partners/stores/[id]/products/[productId]/variants/batch/route.ts
@@ -11,15 +11,54 @@ import {
   validatePartnerStoreAccess,
 } from "../../../../../../helpers"
 
+/**
+ * Phase timing for this route.
+ *
+ * Partner price saves through here run 5-29s (8.4s / 17.0s / 5.1s / 28.6s over
+ * four prod samples) against a database sitting at 3-5% CPU with full burst
+ * credits and sub-millisecond latency — so the cost is in-process, not the DB,
+ * and the variance is large enough that averages would lie.
+ *
+ * Log evidence already narrows it: on the 28.6s sample the request began at
+ * 01:00:15.1 and `product-variant.updated` fired at 01:00:15.9, so the actual
+ * variant write took under a second and ~27.5s went somewhere after it. This
+ * says exactly where, on real partner traffic, without a reproduction.
+ *
+ * Deliberately `info` and always on: the slow saves are intermittent, and a
+ * flag we have to turn on after a partner complains is a flag that is off
+ * during every occurrence worth measuring.
+ */
+const phaseTimer = (logger: any, requestId: string) => {
+  const t0 = Date.now()
+  let last = t0
+  const marks: string[] = []
+  return {
+    mark(name: string) {
+      const now = Date.now()
+      marks.push(`${name}=${now - last}ms`)
+      last = now
+    },
+    done() {
+      logger?.info?.(
+        `[variants/batch] ${requestId} total=${Date.now() - t0}ms ${marks.join(" ")}`
+      )
+    },
+  }
+}
+
 export const POST = async (
   req: AuthenticatedMedusaRequest,
   res: MedusaResponse
 ) => {
+  const logger: any = req.scope.resolve(ContainerRegistrationKeys.LOGGER)
+  const timer = phaseTimer(logger, req.get("x-request-id") || "-")
+
   const { store } = await validatePartnerStoreAccess(
     req.auth_context,
     req.params.id,
     req.scope
   )
+  timer.mark("auth")
 
   const productId = req.params.productId
   const body = (req.body ?? {}) as Record<string, any>
@@ -33,6 +72,7 @@ export const POST = async (
   const { result } = await batchProductVariantsWorkflow(req.scope).run({
     input,
   })
+  timer.mark("batchWorkflow")
 
   const query = req.scope.resolve(ContainerRegistrationKeys.QUERY)
 
@@ -46,6 +86,7 @@ export const POST = async (
   if (createdIds.length) {
     await ensureInventoryLevelsForVariants(req.scope, store, createdIds)
   }
+  timer.mark("inventoryLevels")
 
   const variantFields = [
     "*",
@@ -77,6 +118,10 @@ export const POST = async (
     })
     updated = (data as any[]).map((v) => remapVariantResponse(v))
   }
+  // The response-enrichment reads. `variantFields` expands price_set.prices.*,
+  // price_rules.*, options.option.* and inventory_items.* — and every FX fanout
+  // adds 5 more price rows per price to what this has to pull back.
+  timer.mark("responseQueries")
 
   // FX fanout — Medusa's pricing module doesn't emit a `price.created`
   // event we can subscribe to, so we kick off the fanout workflow here for
@@ -87,6 +132,8 @@ export const POST = async (
     storeId: store.id,
     priceIds: collectVariantPriceIds(touched),
   })
+  timer.mark("fanoutEmit")
+  timer.done()
 
   res.json({
     created,


### PR DESCRIPTION
## The symptom

Partner price saves through `variants/batch` are slow, chronically, and getting worse:

| when | duration |
|---|---|
| 17 Aug 11:25 | 8.4s |
| 19 Aug 10:38 | 17.0s |
| 19 Aug 23:45 | 5.1s |
| 20 Aug 01:00 | **28.6s** |

## What it is not — from live metrics, not assumption

- **Not the database.** During the 28.6s sample RDS sat at **3–5% CPU**, `CPUCreditBalance` pinned at its 288 maximum, sub-millisecond read/write latency.
- **Not the FX fanout.** The 5.1s sample is the one that ran the *old inline* fanout and created auto-prices — and it was the **fastest** of the four.
- **Not the core write.** The 28.6s request began at 01:00:15.1 and `product-variant.updated` fired at 01:00:15.9. The variant write finished in **under a second**; ~27.5s went somewhere after it.

## So: measure, don't guess

That leaves the post-write half — the inventory seeding and the two response-enrichment `query.graph` calls. Rather than pick one and refactor on a hunch, this adds per-phase timings:

```
[variants/batch] <req-id> total=28650ms auth=…  batchWorkflow=…
                 inventoryLevels=…  responseQueries=…  fanoutEmit=…
```

Logged at `info` on **every** request, always on. These saves are intermittent; a flag we switch on after a partner complains is a flag that was off during every occurrence worth measuring.

## One certain fix along the way

`ensureInventoryLevelsForVariants` called `listInventoryLevels({ inventory_item_id: itemId })` **once per item, sequentially**, before writing anything — so a partner saving N variants paid N round trips, and `create-product` calls it with every variant on the product at once. The filter accepts an array; nothing needed the per-item shape.

**I do not expect this to be the whole 28.6s on a 2-variant save.** It is a real cost on wide products, and it was worth fixing while in the code. The instrumentation will say what the rest is.

## Verification

- 6 new tests. **2 fail against the old loop** (25 calls vs 1) — verified by reverting.
- The batching bug worth avoiding — attributing one item's existing levels to all items — is pinned by its own test.
- 207/207 across touched suites, `tsc` at the 74-error baseline, `check:prod-build` green with no config side effects.

## Follow-up, not in this PR

FX **rate fetching** was raised as another async candidate. It is already safe: `getRate` reads the cached `fx_rates` table and the network refresh (`refreshRatesFromProvider`) runs from a seeded scheduled flow, never in a request. Worth noting separately that `getRate` can do up to 3 queries per call including a full `listFxRates({})` scan as its cross-rate fallback — wasteful, but it runs on the worker now and blocks no partner.

🤖 Generated with [Claude Code](https://claude.com/claude-code)