### PR TITLE
ci: fail the deploy when ECS never rolled the new image

### DIFF
--- a/.github/workflows/deploy-to-aws.yml
+++ b/.github/workflows/deploy-to-aws.yml
@@ -321,6 +321,21 @@ jobs:
           copilot svc deploy --name medusa-server --env prod --force \
             --tag "${{ needs.build-and-push.outputs.image_tag }}"
 
+      # #1372 — `--force` above is NOT reliable. With `image.location` the CFN
+      # change set has no diff, ECS reports the deployment COMPLETED against the
+      # tasks already running, and copilot exits 0 having replaced nothing. This
+      # step is the only one in the pipeline that asks "is the new code running?"
+      # — it compares each running task's startedAt to the image's
+      # imagePushedAt, repairs via force-new-deployment if they are stale, and
+      # fails the job if the repair does not take.
+      - name: Assert medusa-server is running the new image
+        working-directory: deploy/aws
+        env:
+          AWS_REGION: ${{ env.AWS_REGION }}
+        run: |
+          ./assert-service-rolled.sh medusa-server \
+            "${{ needs.build-and-push.outputs.image_tag }}"
+
   deploy-worker:
     name: Deploy medusa-worker
     runs-on: ubuntu-latest
@@ -349,6 +364,18 @@ jobs:
         run: |
           copilot svc deploy --name medusa-worker --env prod --force \
             --tag "${{ needs.build-and-push.outputs.image_tag }}"
+
+      # See the medusa-server assertion above. The worker happened to roll on
+      # the run that exposed this (#1372) — which is exactly why the server's
+      # failure was invisible: two services, same workflow, different outcomes,
+      # one green check each.
+      - name: Assert medusa-worker is running the new image
+        working-directory: deploy/aws
+        env:
+          AWS_REGION: ${{ env.AWS_REGION }}
+        run: |
+          ./assert-service-rolled.sh medusa-worker \
+            "${{ needs.build-and-push.outputs.image_tag }}"
 
   # ─────────────────────────────────────────────────────────────────────────
   # 4. Health-check the public endpoint after both deploys are done.

--- a/deploy/aws/assert-service-rolled.sh
+++ b/deploy/aws/assert-service-rolled.sh
@@ -1,0 +1,96 @@
+#!/usr/bin/env bash
+#
+# Assert that an ECS service is actually RUNNING the image we just pushed —
+# and repair it if it isn't.
+#
+# Why this exists (#1372): the copilot manifests use `image.location` pinned to
+# `<repo>:latest`, so every deploy re-creates the SAME task definition revision.
+# CloudFormation sees no diff, ECS reports the deployment `COMPLETED` against
+# the tasks already running, and `copilot svc deploy --force` returns success
+# without replacing anything. On 20 Aug 2026 that left the API serving a commit
+# four hours older than the one whose deploy had just gone green — the build,
+# the push, the deploy job and the /health check all passed, because each was
+# truthfully answering a different question. None of them was asked "is the new
+# code running?".
+#
+# The only signal that settles it: a running task's startedAt must be LATER
+# than the image's imagePushedAt. A task started before the image was pushed is
+# running the previous image, whatever every other layer says.
+#
+# Usage: assert-service-rolled.sh <service-short-name> <image-tag>
+#   e.g. assert-service-rolled.sh medusa-server sha-5e288f41883…
+set -euo pipefail
+
+SVC_SHORT="${1:?service short name, e.g. medusa-server}"
+IMAGE_TAG="${2:?image tag that must be running, e.g. sha-<gitsha>}"
+REGION="${AWS_REGION:-us-east-1}"
+ECR_REPO="${ECR_REPO:-jyt-medusa}"
+CLUSTER_MATCH="${CLUSTER_MATCH:-cluster/jyt-prod-Cluster}"
+SERVICE_MATCH="${SERVICE_MATCH:-service/.*jyt-prod-${SVC_SHORT}-Service}"
+
+log() { echo "[assert-rolled:${SVC_SHORT}] $*"; }
+
+image_pushed_at() {
+  aws ecr describe-images --region "$REGION" --repository-name "$ECR_REPO" \
+    --image-ids imageTag="$IMAGE_TAG" \
+    --query 'imageDetails[0].imagePushedAt' --output text
+}
+
+find_cluster() {
+  aws ecs list-clusters --region "$REGION" --query 'clusterArns[]' --output text \
+    | tr '\t' '\n' | grep -m1 "$CLUSTER_MATCH"
+}
+
+find_service() {
+  aws ecs list-services --region "$REGION" --cluster "$1" --query 'serviceArns[]' --output text \
+    | tr '\t' '\n' | grep -m1 -E "$SERVICE_MATCH"
+}
+
+# Oldest startedAt across the service's running tasks. The OLDEST is the one
+# that matters: one fresh task alongside one stale task is still a half-rolled
+# service serving two different commits to alternating requests.
+oldest_task_start() {
+  local cluster="$1" service="$2" tasks
+  tasks=$(aws ecs list-tasks --region "$REGION" --cluster "$cluster" \
+            --service-name "$service" --desired-status RUNNING \
+            --query 'taskArns[]' --output text)
+  if [ -z "$tasks" ]; then echo "0"; return; fi
+  aws ecs describe-tasks --region "$REGION" --cluster "$cluster" --tasks $tasks \
+    --query 'min(tasks[].startedAt)' --output text
+}
+
+CLUSTER=$(find_cluster)
+SERVICE=$(find_service "$CLUSTER")
+PUSHED=$(image_pushed_at)
+log "cluster=${CLUSTER##*/} service=${SERVICE##*/}"
+log "image ${IMAGE_TAG} pushed at ${PUSHED}"
+
+check() {
+  local started
+  started=$(oldest_task_start "$CLUSTER" "$SERVICE")
+  log "oldest running task started at ${started}"
+  awk -v a="$started" -v b="$PUSHED" 'BEGIN { exit !(a > b) }'
+}
+
+if check; then
+  log "✅ every running task is newer than the image — the new code is live"
+  exit 0
+fi
+
+# Not rolled. This is the copilot --force no-op described above. Repair it with
+# the API call that always rolls, then re-assert — a repair we don't verify is
+# the same class of mistake as the deploy we didn't verify.
+log "⚠️  tasks predate the image — the deploy did NOT roll. Forcing a new deployment."
+aws ecs update-service --region "$REGION" --cluster "$CLUSTER" --service "$SERVICE" \
+  --force-new-deployment >/dev/null
+log "waiting for the service to stabilise…"
+aws ecs wait services-stable --region "$REGION" --cluster "$CLUSTER" --services "$SERVICE"
+
+if check; then
+  log "✅ repaired — tasks replaced and the new code is live"
+  exit 0
+fi
+
+log "❌ still running tasks older than the image after a forced deployment."
+log "   The deploy is NOT live. Failing rather than reporting a green deploy."
+exit 1


### PR DESCRIPTION
Closes #1372.

## What happened

The deploy for `5e288f418` (#1369) went fully green — build, push, migrate, `Deploy medusa-server`, `/health` — while the API kept serving `7f2c67dd7`. Both server tasks were started at **00:37 / 00:42**, four hours before the new image was pushed at **04:43:55**. The worker rolled at 04:50; the server never did.

The job log shows it:

```
         Revision  Rollout      Desired  Running  Failed  Pending
PRIMARY  104       [completed]  2        2        0       0
```

No second deployment draining, nothing pending. `Deploy medusa-server` finished in **1m37s**; `Deploy medusa-worker` took **5m11s**.

**Mechanism:** the manifests pin `image.location` to `<repo>:latest`, so every deploy re-creates the *same* task definition revision (`:104`). CFN sees no diff, ECS reports COMPLETED against the tasks already running, and `copilot svc deploy --force` exits 0 having replaced nothing.

🔑 **Every existing signal was truthfully answering a different question.** The build built, the image pushed, the stack converged, `/health` returned 200 — because the *old* tasks are perfectly healthy. Nothing was asking whether the new code was running, so nothing reported that it wasn't.

## The change

`deploy/aws/assert-service-rolled.sh`, run after each `copilot svc deploy`:

1. Compares the **oldest** running task's `startedAt` to the image's `imagePushedAt`. Oldest, because one fresh task beside one stale task is a service handing two different commits to alternating requests.
2. If stale → `update-service --force-new-deployment`, `wait services-stable`, **re-assert**. A repair we don't verify is the same mistake as the deploy we didn't verify.
3. If still stale → **exit 1**. Failing is the point; the previous behaviour was to report success over old code.

It discovers the cluster and service ARNs itself (copilot appends generated suffixes), so there is nothing to keep in sync by hand.

## Verification — on live prod, not in theory

- Forced the roll manually: both server tasks replaced (`startedAt` 05:43:41 / 05:44:13 vs image 04:43:55). The new PRIMARY appeared at 0/0 alongside the old ACTIVE at 2/2 — **precisely the state that was absent at 04:50**, which is the diagnosis confirming itself.
- Script passes on **both** services, discovery included:

```
[assert-rolled:medusa-server] oldest running task started at 1787204621.176
[assert-rolled:medusa-server] ✅ every running task is newer than the image
[assert-rolled:medusa-worker] oldest running task started at 1787201431.372
[assert-rolled:medusa-worker] ✅ every running task is newer than the image
```

- `bash -n` clean; workflow YAML parses.
- ⚠️ The **repair path has not executed against a genuinely stale service** — the roll was already forced by hand before the script ran. Its happy path and its discovery are proven; its repair branch is reviewed, not exercised. The next stale deploy is its real first test.

## What this unblocked immediately

With `5e288f418` finally live, the instrumentation the stale deploy had been hiding produced its first line:

```
[variants/batch] total=16364ms auth=26ms batchWorkflow=358ms
                 inventoryLevels=0ms responseQueries=15977ms fanoutEmit=3ms
```

**97.6% of a partner price save is the response-enrichment re-read.** The core write is 358ms. That is #1370's answer, and it was unavailable for as long as the deploy was silently stale.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
