### PR TITLE
perf(partners): cut the variants/batch response enrichment, which was 97% of the save

### DIFF
--- a/apps/backend/src/api/partners/stores/[id]/products/[productId]/variants/batch/route.ts
+++ b/apps/backend/src/api/partners/stores/[id]/products/[productId]/variants/batch/route.ts
@@ -88,40 +88,67 @@ export const POST = async (
   }
   timer.mark("inventoryLevels")
 
+  /**
+   * Response enrichment. This was ~97% of the request.
+   *
+   * Measured on prod, warm, with the phase log this route already emits:
+   *
+   *   product                       variants written   responseQueries
+   *   ikkat      (1 option  x 2 values)      2               327 ms
+   *   grey/white (3 options x 3 values)      1              3211 ms
+   *   grey/white (3 options x 3 values)      9             15094 ms
+   *
+   * ONE variant of the option-heavy product cost 10x what TWO variants of the
+   * simple one did, so the cost tracks the product's OPTION graph and not the
+   * number of variants written. `options.option.*` walks from each variant's
+   * option VALUE back to the product option it belongs to — the same handful of
+   * parent options, re-resolved per variant, per value.
+   *
+   * Neither `options.option` nor `inventory_items` is read by anything.
+   * `remapVariantResponse` only reshapes `price_set.prices`, and the sole
+   * caller of this route (partner-ui `pricing-edit.tsx`) ignores the response
+   * body entirely — its `onSuccess` invalidates its queries and works from
+   * state it computed before the request. They were pass-through weight.
+   *
+   * `options.*` stays: it is a direct FK read on the variant, and it is what
+   * makes the returned variant identifiable as "Hand Spun / Grey".
+   */
   const variantFields = [
     "*",
     "product_id",
     "price_set.prices.*",
     "price_set.prices.price_rules.*",
     "options.*",
-    "options.option.*",
-    "inventory_items.*",
   ]
 
   let created: any[] = []
   let updated: any[] = []
 
-  if (createdIds.length) {
+  // One query, not two. `created` and `updated` were fetched separately with
+  // identical field sets, so a batch doing both paid the enrichment twice.
+  const idsToFetch = [...createdIds, ...updatedIds]
+  if (idsToFetch.length) {
     const { data } = await query.graph({
       entity: "product_variants",
       fields: variantFields,
-      filters: { id: createdIds },
+      filters: { id: idsToFetch },
     })
-    created = (data as any[]).map((v) => remapVariantResponse(v))
+    const createdSet = new Set(createdIds)
+    for (const row of data as any[]) {
+      const mapped = remapVariantResponse(row)
+      if (createdSet.has(row.id)) {
+        created.push(mapped)
+      } else {
+        updated.push(mapped)
+      }
+    }
   }
-
-  if (updatedIds.length) {
-    const { data } = await query.graph({
-      entity: "product_variants",
-      fields: variantFields,
-      filters: { id: updatedIds },
-    })
-    updated = (data as any[]).map((v) => remapVariantResponse(v))
-  }
-  // The response-enrichment reads. `variantFields` expands price_set.prices.*,
-  // price_rules.*, options.option.* and inventory_items.* — and every FX fanout
-  // adds 5 more price rows per price to what this has to pull back.
-  timer.mark("responseQueries")
+  // Counts are logged alongside the timing because the whole diagnosis above
+  // turned on cost-per-variant differing 10x between two products. A duration
+  // with no denominator could not have shown that.
+  timer.mark(
+    `responseQueries(n=${idsToFetch.length})`
+  )
 
   // FX fanout — Medusa's pricing module doesn't emit a `price.created`
   // event we can subscribe to, so we kick off the fanout workflow here for

--- a/apps/backend/src/api/partners/stores/[id]/products/[productId]/variants/batch/route.ts
+++ b/apps/backend/src/api/partners/stores/[id]/products/[productId]/variants/batch/route.ts
@@ -1,7 +1,10 @@
 import { AuthenticatedMedusaRequest, MedusaResponse } from "@medusajs/framework/http"
 import { ContainerRegistrationKeys } from "@medusajs/framework/utils"
 import { batchProductVariantsWorkflow } from "@medusajs/medusa/core-flows"
-import { remapVariantResponse } from "@medusajs/medusa/api/admin/products/helpers"
+import {
+  refetchBatchVariants,
+  remapVariantResponse,
+} from "@medusajs/medusa/api/admin/products/helpers"
 import {
   collectVariantPriceIds,
   requestVariantPriceFanout,
@@ -74,10 +77,7 @@ export const POST = async (
   })
   timer.mark("batchWorkflow")
 
-  const query = req.scope.resolve(ContainerRegistrationKeys.QUERY)
-
   const createdIds = result.created?.map((v: any) => v.id) ?? []
-  const updatedIds = result.updated?.map((v: any) => v.id) ?? []
 
   // Auto-seed inventory_level rows at the partner's stock location for any
   // managed-inventory variants in the create batch. Same gap the single-POST
@@ -91,64 +91,95 @@ export const POST = async (
   /**
    * Response enrichment. This was ~97% of the request.
    *
-   * Measured on prod, warm, with the phase log this route already emits:
+   *   [variants/batch] total=16364ms auth=26ms batchWorkflow=358ms
+   *                    inventoryLevels=0ms responseQueries=15977ms fanoutEmit=3ms
+   *
+   * The write is 358ms. The re-read that shapes the response was 15977ms.
+   *
+   * This route hand-rolled that re-read. Medusa's own admin batch route does
+   * not — `admin/products/[id]/variants/batch` calls `refetchBatchVariants`,
+   * and comparing the two is what identified the difference:
+   *
+   *   - core fires the `created` and `updated` queries CONCURRENTLY through
+   *     `promiseAll`; we awaited them one after the other.
+   *   - core goes through `remoteQuery` (`entryPoint: "variant"`); we used
+   *     `query.graph({ entity: "product_variants" })`.
+   *   - core's default field set is an explicit list of scalars plus `*options`
+   *     and two named `price_rules` fields. It never expands `options.option`,
+   *     never asks for `inventory_items`, and never uses a bare `"*"`.
+   *
+   * So: use core's helper, with an explicit field list rather than a wide one.
+   * `refetchBatchVariants` is exported from the same module this file already
+   * imports `remapVariantResponse` from, so the response shape is unchanged.
+   *
+   * ⚠️ What the evidence does NOT support: that the wide fields were themselves
+   * the cost. The same expansion — `options.option.*` and `inventory_items.*`
+   * included — over the same 9 variants returns in ~1.3s through the admin read
+   * path, verified against prod, fields honoured rather than stripped. An
+   * earlier reading of these numbers blamed the product's option graph; that
+   * did not survive the check. What is left is the mechanism: the engine, the
+   * sequential await, and the fact that this query runs on the request scope
+   * immediately after that scope performed the write. This change aligns all
+   * three with core, which is the version that is actually exercised and tuned.
+   *
+   * Measured warm on prod before the change:
    *
    *   product                       variants written   responseQueries
    *   ikkat      (1 option  x 2 values)      2               327 ms
    *   grey/white (3 options x 3 values)      1              3211 ms
    *   grey/white (3 options x 3 values)      9             15094 ms
-   *
-   * ONE variant of the option-heavy product cost 10x what TWO variants of the
-   * simple one did, so the cost tracks the product's OPTION graph and not the
-   * number of variants written. `options.option.*` walks from each variant's
-   * option VALUE back to the product option it belongs to — the same handful of
-   * parent options, re-resolved per variant, per value.
-   *
-   * Neither `options.option` nor `inventory_items` is read by anything.
-   * `remapVariantResponse` only reshapes `price_set.prices`, and the sole
-   * caller of this route (partner-ui `pricing-edit.tsx`) ignores the response
-   * body entirely — its `onSuccess` invalidates its queries and works from
-   * state it computed before the request. They were pass-through weight.
-   *
-   * `options.*` stays: it is a direct FK read on the variant, and it is what
-   * makes the returned variant identifiable as "Hand Spun / Grey".
    */
   const variantFields = [
-    "*",
+    "id",
+    "title",
+    "sku",
+    "barcode",
+    "ean",
+    "upc",
+    "allow_backorder",
+    "manage_inventory",
+    "hs_code",
+    "origin_country",
+    "mid_code",
+    "material",
+    "weight",
+    "length",
+    "height",
+    "width",
+    "metadata",
+    "variant_rank",
     "product_id",
+    "created_at",
+    "updated_at",
+    "*options",
+    // Written pre-remapped. `remapKeysForVariant` only rewrites fields starting
+    // with `prices`/`*prices`, so these pass through untouched — and
+    // `remapVariantResponse` needs `price_set.prices` to build `prices`, which
+    // `collectVariantPriceIds` then reads to drive the FX fanout below. Getting
+    // this wrong would not fail loudly: the response would simply carry no
+    // prices and the fanout would silently have nothing to do.
     "price_set.prices.*",
-    "price_set.prices.price_rules.*",
-    "options.*",
+    "price_set.prices.price_rules.value",
+    "price_set.prices.price_rules.attribute",
   ]
 
-  let created: any[] = []
-  let updated: any[] = []
-
-  // One query, not two. `created` and `updated` were fetched separately with
-  // identical field sets, so a batch doing both paid the enrichment twice.
-  const idsToFetch = [...createdIds, ...updatedIds]
-  if (idsToFetch.length) {
-    const { data } = await query.graph({
-      entity: "product_variants",
-      fields: variantFields,
-      filters: { id: idsToFetch },
-    })
-    const createdSet = new Set(createdIds)
-    for (const row of data as any[]) {
-      const mapped = remapVariantResponse(row)
-      if (createdSet.has(row.id)) {
-        created.push(mapped)
-      } else {
-        updated.push(mapped)
-      }
-    }
-  }
-  // Counts are logged alongside the timing because the whole diagnosis above
-  // turned on cost-per-variant differing 10x between two products. A duration
-  // with no denominator could not have shown that.
-  timer.mark(
-    `responseQueries(n=${idsToFetch.length})`
+  const batchResults = await refetchBatchVariants(
+    {
+      created: result.created ?? [],
+      updated: result.updated ?? [],
+      deleted: result.deleted ?? [],
+    },
+    req.scope,
+    variantFields
   )
+
+  const created = batchResults.created.map((v: any) => remapVariantResponse(v))
+  const updated = batchResults.updated.map((v: any) => remapVariantResponse(v))
+
+  // The row count rides along with the timing. This whole diagnosis turned on
+  // cost-per-variant differing 10x between two products, and a duration with no
+  // denominator could not have shown that.
+  timer.mark(`responseQueries(n=${created.length + updated.length})`)
 
   // FX fanout — Medusa's pricing module doesn't emit a `price.created`
   // event we can subscribe to, so we kick off the fanout workflow here for


### PR DESCRIPTION
Fixes the Open 2 half of #1370.

## The measurement

#1369's phase log — running at last, once #1372 was cleared — put the cost in one place:

```
[variants/batch] total=16364ms auth=26ms batchWorkflow=358ms
                 inventoryLevels=0ms responseQueries=15977ms fanoutEmit=3ms
```

**The write is 358ms. The re-read that shapes the response was 15,977ms.**

Warm, on prod, before the change:

| product | variants written | responseQueries |
|---|---|---|
| ikkat (1 option × 2 values) | 2 | **327 ms** |
| grey/white (3 options × 3 values) | 1 | **3211 ms** |
| grey/white (3 options × 3 values) | 9 | **15094 ms** |

## What the fix is — and how it changed

My first pass blamed the wide field expansion, specifically `options.option.*` walking each variant's option value back to its parent option. **That hypothesis is dead**, and it was reading core's own implementation that killed it.

Medusa's admin batch route (`admin/products/[id]/variants/batch`) does not hand-roll this re-read at all. It calls `refetchBatchVariants`. Three differences from what this route was doing:

| | core | this route (before) |
|---|---|---|
| the two queries | **concurrent** via `promiseAll` | sequential `await`, one then the other |
| engine | `remoteQuery`, `entryPoint: "variant"` | `query.graph`, `entity: "product_variants"` |
| fields | explicit scalars + `*options` + two named `price_rules` fields | bare `"*"` + `options.option.*` + `inventory_items.*` + `price_rules.*` |

Core **never** expands `options.option`, **never** asks for `inventory_items`, and **never** uses a bare `"*"`.

So the route now calls that helper with an explicit field list. It's exported from the same module the route already imported `remapVariantResponse` from, so **the response shape is unchanged**.

## The evidence that retired the first hypothesis

I probed the admin read path against prod with the *same* expansion — `options.option.*` and `inventory_items.*` included — over the same 9 variants:

```
200  1.26s
{"keys":["id","inventory_items","options"],
 "opt0":{"option":{"id":"opt_01M0A4N30MRX729SWGG2WZF43E","title":"Color", …}},
 "inv":[]}
```

1.3s, and the response proves the fields were **honoured, not silently stripped** — `options[0].option` came back fully populated. The wide fields are not inherently expensive.

🔑 What's left is the mechanism, not the field list: the engine, the sequential await, and a query issued on the request scope *immediately after that scope performed the write*. Aligning all three with core is the change that follows from the evidence rather than from the story I'd built around it.

## Care point

The field list is written **pre-remapped** deliberately. `remapKeysForVariant` only rewrites names starting `prices`/`*prices`, so `price_set.prices.*` passes through untouched — and `remapVariantResponse` needs `price_set.prices` to build `prices`, which `collectVariantPriceIds` then reads to drive the FX fanout. ⚠️ Getting this wrong would not fail loudly: the response would simply carry no prices and the fanout would have nothing to do.

## Verified

- `tsc` at the 48-error baseline, none in the touched file
- `check:prod-build` green, no config side effects

**Check against:** the next save on the 9-variant product (`prod_01M0A4N30MEBF1FBVBB5RTDHZR`, draft). `responseQueries` should fall from ~15s toward the ~330ms the simple product already achieves. The phase mark now carries the row count so the comparison has a denominator — the whole diagnosis turned on cost-per-variant differing 10× between two products, which a bare duration could never have shown.

⚠️ Note this ships through the pipeline #1372 just exposed, so confirm it is actually running before trusting any measurement — PR #1373 adds that guard.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
