### PR TITLE
fix(messaging): give the rejection-reason select item a non-empty value

### DIFF
--- a/apps/backend/src/admin/routes/messaging/components/message-run-action-modal.tsx
+++ b/apps/backend/src/admin/routes/messaging/components/message-run-action-modal.tsx
@@ -37,8 +37,10 @@ type Props = {
   onRunCompleted?: (run: AdminProductionRun) => void
 }
 
+const NO_REJECTION = "none"
+
 const REJECTION_REASONS = [
-  { label: "—", value: "" },
+  { label: "—", value: NO_REJECTION },
   { label: "Stitching Defect", value: "stitching_defect" },
   { label: "Fabric Flaw", value: "fabric_flaw" },
   { label: "Color Mismatch", value: "color_mismatch" },
@@ -187,7 +189,10 @@ export const MessageRunActionModal = ({
       completeMutation.mutate({
         produced_quantity: produced,
         rejected_quantity: rejected,
-        rejection_reason: rejectionReason || undefined,
+        rejection_reason:
+          rejectionReason && rejectionReason !== NO_REJECTION
+            ? rejectionReason
+            : undefined,
         rejection_notes: rejectionNotes || undefined,
         partner_cost_estimate: costEstimate ? Number(costEstimate) : undefined,
         cost_type: costType,
@@ -425,7 +430,7 @@ export const MessageRunActionModal = ({
                   </div>
                 </div>
 
-                {rejectionReason && (
+                {rejectionReason && rejectionReason !== NO_REJECTION && (
                   <div className="mb-4">
                     <Label htmlFor="rejection-notes">Rejection notes</Label>
                     <Textarea


### PR DESCRIPTION
## Problem

In the messaging route's `Complete production run` modal, the **Rejection reason** `<Select.Item>` for the "—" (none) option had `value: ""`. Radix Select reserves the empty string to clear the selection and show the placeholder, so that item could not be selected at all.

## Fix

- Introduced a `NO_REJECTION = "none"` sentinel and gave the "—" item that non-empty value.
- Submitting maps the sentinel back to `undefined` so `"none"` is never sent to the backend as a rejection reason.
- The "Rejection notes" field now only renders for a real reason (`rejectionReason !== NO_REJECTION`).

## Files

- `apps/backend/src/admin/routes/messaging/components/message-run-action-modal.tsx`