### PR TITLE
fix(mcp): validate required args before the confirm gate (#1371)

### DIFF
--- a/apps/backend/src/api/mcp/lib/registry.ts
+++ b/apps/backend/src/api/mcp/lib/registry.ts
@@ -575,6 +575,7 @@ const CHECKOUT_WRITE_TOOLS: McpToolDef[] = [
       properties: {
         region_id: { type: "string", description: "Region id (reg_...) — the cart's region." },
         ...FIELDS_PROP,
+        ...PAGINATION_PROPS,
         ...STORE_PROP,
       },
     },

--- a/apps/backend/src/api/partners/mcp/lib/registry.ts
+++ b/apps/backend/src/api/partners/mcp/lib/registry.ts
@@ -162,6 +162,13 @@ const CONSUMPTION_LOG_BODY = [
   "inventoryItemId", "rawMaterialId", "productionRunId", "quantity",
   "unitCost", "unitOfMeasure", "consumptionType", "notes", "locationId", "metadata",
 ]
+/**
+ * The run-scoped tool carries the run in its path, so it never offers
+ * `productionRunId` as an argument — and must not claim to forward one.
+ */
+const RUN_CONSUMPTION_LOG_BODY = CONSUMPTION_LOG_BODY.filter(
+  (k) => k !== "productionRunId"
+)
 const consumptionLogSchema = (withRun: boolean) =>
   obj(
     {
@@ -634,7 +641,7 @@ export const PARTNER_MCP_TOOLS: PartnerMcpToolDef[] = [
     path: "/partners/production-runs/:id/consumption-logs",
     pathParams: ["id"],
     write: true,
-    bodyParams: CONSUMPTION_LOG_BODY,
+    bodyParams: RUN_CONSUMPTION_LOG_BODY,
     inputSchema: {
       ...consumptionLogSchema(false),
       properties: {
@@ -1629,7 +1636,7 @@ export const PARTNER_MCP_TOOLS: PartnerMcpToolDef[] = [
     path: "/partners/stores/:id/products",
     pathParams: ["id"],
     queryParams: ["q", "limit", "offset"],
-    inputSchema: obj({ id: STR("Store id.") }, ["id"]),
+    inputSchema: obj({ id: STR("Store id."), ...PAGINATION }, ["id"]),
   },
   {
     name: "get_store_product",
@@ -1824,7 +1831,7 @@ export const PARTNER_MCP_TOOLS: PartnerMcpToolDef[] = [
     path: "/partners/stores/:id/product-variants",
     pathParams: ["id"],
     queryParams: ["q", "limit", "offset"],
-    inputSchema: obj({ id: STR("Store id.") }, ["id"]),
+    inputSchema: obj({ id: STR("Store id."), ...PAGINATION }, ["id"]),
   },
   // ---- Product option + variant writes: edit a product after create_product
   // (add a colour/size, fix a price, remove a variant). Options must exist

--- a/apps/backend/src/lib/mcp-core/__tests__/required-args.unit.spec.ts
+++ b/apps/backend/src/lib/mcp-core/__tests__/required-args.unit.spec.ts
@@ -1,0 +1,157 @@
+/**
+ * Contract: a tool's `inputSchema.required` is the ONE declaration of what it
+ * must be called with, and the dispatcher enforces it before any rail (#1371).
+ *
+ * That makes the array load-bearing in a way it was not before: a name in
+ * `required` that the model cannot supply now refuses the tool on every call
+ * instead of being ignored. These tests hold both ends of that — the registries
+ * declare only satisfiable requirements, and the dispatcher refuses rather than
+ * previewing when one is absent.
+ *
+ * Sibling of the #1348 family (an MCP row must match its route's validator);
+ * here the row is right and the *call* is empty.
+ */
+import { dispatchMcpTool } from "../dispatch"
+import { buildToolInputSchema } from "../schema"
+import type { McpContext, McpToolDef } from "../types"
+import { PARTNER_MCP_TOOLS } from "../../../api/partners/mcp/lib/registry"
+import { ADMIN_MCP_TOOLS } from "../../../api/admin/mcp/lib/registry"
+import { STORE_MCP_TOOLS } from "../../../api/mcp/lib/registry"
+
+const SURFACES: [string, McpToolDef[]][] = [
+  ["partner", PARTNER_MCP_TOOLS as McpToolDef[]],
+  ["admin", ADMIN_MCP_TOOLS as McpToolDef[]],
+  ["store", STORE_MCP_TOOLS as McpToolDef[]],
+]
+
+describe("mcp-core required-argument contract", () => {
+  describe.each(SURFACES)("%s registry", (_surface, tools) => {
+    it("declares every required arg as a property the model can actually supply", () => {
+      const offenders: string[] = []
+      for (const def of tools) {
+        const required: string[] = def.inputSchema?.required ?? []
+        const properties = def.inputSchema?.properties ?? {}
+        const undeclared = required.filter((r) => !(r in properties))
+        if (undeclared.length) {
+          offenders.push(`${def.name}: ${undeclared.join(", ")}`)
+        }
+      }
+      // A required name with no matching property is unsatisfiable — the
+      // dispatcher would refuse the tool on every call, forever.
+      expect(offenders).toEqual([])
+    })
+
+    it("declares every forwarded param as a property too", () => {
+      const offenders: string[] = []
+      for (const def of tools) {
+        // The BUILT schema — framework args (context, dry_run, confirm,
+        // reason) are injected, not written into the registry row.
+        const properties = buildToolInputSchema(def).properties ?? {}
+        const forwarded = [
+          ...(def.pathParams ?? []),
+          ...(def.queryParams ?? []),
+          ...(def.bodyParams ?? []),
+        ]
+        const undeclared = forwarded.filter((p) => !(p in properties))
+        if (undeclared.length) {
+          offenders.push(`${def.name}: ${undeclared.join(", ")}`)
+        }
+      }
+      // The #1348 direction: a param the route needs that the schema never
+      // offers is silently stripped on every call.
+      expect(offenders).toEqual([])
+    })
+  })
+
+  describe("dispatch refuses instead of previewing", () => {
+    const ctx = (): McpContext =>
+      ({
+        baseUrl: "http://localhost:9000",
+        surface: "partner",
+        enableWrite: true,
+        enableSensitive: true,
+      } as unknown as McpContext)
+
+    const createProduct = (PARTNER_MCP_TOOLS as McpToolDef[]).find(
+      (t) => t.name === "create_product"
+    )!
+
+    it("is a sensitive write requiring store_id and product", () => {
+      expect(createProduct.sensitive).toBe(true)
+      expect(createProduct.inputSchema.required).toEqual([
+        "store_id",
+        "product",
+      ])
+    })
+
+    it("refuses an argument-less create_product rather than asking to confirm", async () => {
+      const result: any = await dispatchMcpTool(
+        ctx(),
+        PARTNER_MCP_TOOLS as McpToolDef[],
+        "create_product",
+        {}
+      )
+      expect(result.ok).toBe(false)
+      // The regression: this used to come back as an Approve card, and only
+      // 400'd after the partner pressed it.
+      expect(result.requires_confirmation).toBeUndefined()
+      expect(result.error).toMatch(/store_id/)
+      expect(result.error).toMatch(/product/)
+    })
+
+    it("refuses even when the model passes confirm: true", async () => {
+      const result: any = await dispatchMcpTool(
+        ctx(),
+        PARTNER_MCP_TOOLS as McpToolDef[],
+        "create_product",
+        { confirm: true }
+      )
+      expect(result.ok).toBe(false)
+      expect(result.error).toMatch(/required argument/)
+    })
+
+    it("refuses a dry_run that could not run for real", async () => {
+      const result: any = await dispatchMcpTool(
+        ctx(),
+        PARTNER_MCP_TOOLS as McpToolDef[],
+        "create_product",
+        { dry_run: true }
+      )
+      expect(result.ok).toBe(false)
+      expect(result.dry_run).toBeUndefined()
+    })
+
+    it("treats an empty-string argument as missing", async () => {
+      const result: any = await dispatchMcpTool(
+        ctx(),
+        PARTNER_MCP_TOOLS as McpToolDef[],
+        "create_product",
+        { store_id: "   ", product: { title: "x" } }
+      )
+      expect(result.ok).toBe(false)
+      expect(result.error).toMatch(/store_id/)
+    })
+
+    it("emits one refused observability event naming the missing args", async () => {
+      const events: any[] = []
+      const observed = {
+        ...ctx(),
+        observe: (e: any) => events.push(e),
+      } as unknown as McpContext
+      await dispatchMcpTool(
+        observed,
+        PARTNER_MCP_TOOLS as McpToolDef[],
+        "create_product",
+        {}
+      )
+      expect(events).toHaveLength(1)
+      expect(events[0]).toMatchObject({
+        surface: "partner",
+        tool: "create_product",
+        executed: false,
+        ok: false,
+        outcome: "refused",
+      })
+    })
+  })
+})

--- a/apps/backend/src/lib/mcp-core/dispatch.ts
+++ b/apps/backend/src/lib/mcp-core/dispatch.ts
@@ -44,6 +44,31 @@ const substitutePath = (
   return { path }
 }
 
+/**
+ * Names in `inputSchema.required` that carry no value in `args` (#1371).
+ *
+ * The schema's `required` array is the ONE place a tool declares what it must
+ * be called with, so it is what the dispatcher enforces — no second list to
+ * drift out of step with it. Empty strings count as missing (matching
+ * `substitutePath`); `false` and `0` do not.
+ */
+const missingRequired = (
+  def: McpToolDef,
+  args: Record<string, unknown>
+): string[] => {
+  const required = def.inputSchema?.required
+  if (!Array.isArray(required)) return []
+  return required.filter((key: unknown) => {
+    if (typeof key !== "string") return false
+    const value = args[key]
+    return (
+      value === undefined ||
+      value === null ||
+      (typeof value === "string" && value.trim() === "")
+    )
+  }) as string[]
+}
+
 const pick = (
   keys: string[] | undefined,
   args: Record<string, unknown>
@@ -77,6 +102,21 @@ export async function dispatchMcpTool(
   }
 
   const args = rawArgs || {}
+
+  // --- Required arguments: refuse BEFORE any rail (#1371) ---------------------
+  // A call missing what the tool declares it needs cannot succeed at the route,
+  // so it must never reach the confirm gate: an argument-less `create_product`
+  // used to render an Approve card and only 400 *after* the partner pressed it.
+  // Returning it as a refusal instead hands the model an error it can retry —
+  // which it does — rather than asking a human to approve an impossible action.
+  const missing = missingRequired(def, args)
+  if (missing.length) {
+    return fail(
+      `Tool '${name}' was called without required argument(s): ${missing.join(
+        ", "
+      )}. Supply them and call it again.`
+    )
+  }
 
   // --- Native tools: run in-process via the surface handler -------------------
   // Store discovery / key resolution etc. — no route, no write/rail gating


### PR DESCRIPTION
Closes part of #1371 (item 3).

## Problem

A partner was shown an **Approve** card for a `create_product` call carrying no arguments at all. It 400'd *after* they pressed it:

```
1. outcome=confirm  executed=false ok=true          ← no context=
2. outcome=run      executed=true  ok=false  ms=40
     error="Route /partners/products responded 400: Invalid request:
            Field 'store_id' is required; Field 'product' is required"
```

The approval POST measured `req_size=110` — a bare JSON-RPC envelope. The model emitted an empty call, the UI forwarded exactly that, and the confirm gate previewed it without ever checking it could run.

## Fix

`dispatchMcpTool` now refuses when any `inputSchema.required` argument is absent, **before the native branch and every rail** — so no gate can render a card for an impossible action. The model gets a retryable error instead, which the logs show it recovers from on its own (entries 3–4 of that same window).

Enforcement reads the schema's own `required` array rather than a new field, so there is no second list to drift out of step with it — the [#1348](https://github.com/Jaal-Yantra-Textiles/v2/issues/1348) lesson, from the other side: there the row's forward-list was wrong, here the row is right and the *call* is empty.

Empty strings count as missing (matching `substitutePath`); `false` and `0` do not.

## The audit is the interesting part

Enforcing `required` makes that array load-bearing — a typo in it would now brick a tool on every call. So I checked all **371 tools** across the three registries (276 declare `required`). The change breaks **nothing**.

The reverse check found 4 **pre-existing** defects — params forwarded to a route that the schema never offered, so `additionalProperties: false` meant the model could not supply them:

| tool | missing properties | effect |
|---|---|---|
| `list_store_products` | `q`, `limit`, `offset` | pagination + search unusable |
| `list_store_product_variants` | `q`, `limit`, `offset` | pagination + search unusable |
| `list_payment_providers` (store) | `limit`, `offset` | pagination unusable |
| `log_production_run_consumption` | — | forwarded a `productionRunId` it cannot offer (run is in the path) |

Both registries already had the right helper (`PAGINATION` / `PAGINATION_PROPS`); those rows just never spread it.

## Contract test

`required-args.unit.spec.ts` holds both ends across all three surfaces:

- every `required` name is a real property (**unsatisfiable requirement = permanently bricked tool**)
- every forwarded param is a real property (the #1348 direction)
- an argument-less `create_product` refuses, and **does not** come back `requires_confirmation` — including with `confirm: true` and with `dry_run: true`
- one `outcome=refused` observability event naming the missing args

## Not covered here

Items 1, 2, 4 and 5 of #1371 remain open. Note in particular the issue's own warning: the prompt also requires *stocked vs made-to-order* and *weight/dimensions* before `create_product`, so this alone does not make photo→product work end to end.

## Verify

```
cd apps/backend
npx jest --testPathPattern="required-args"
```

- new contract suite **12/12**
- 25 MCP unit suites, **554/554**
- `check:prod-build` ✓

🤖 Generated with [Claude Code](https://claude.com/claude-code)