### PR TITLE
test(mcp): cover the required-arg refusal on both HTTP surfaces (#1371)

### DIFF
--- a/apps/backend/integration-tests/http/mcp-required-args.spec.ts
+++ b/apps/backend/integration-tests/http/mcp-required-args.spec.ts
@@ -1,0 +1,153 @@
+import { getSharedTestEnv, setupSharedTestSuite } from "./shared-test-setup"
+import { createAdminUser, getAuthHeaders } from "../helpers/create-admin-user"
+
+jest.setTimeout(120000)
+
+/**
+ * #1371 item 3 — the confirm gate must not preview a call that cannot run.
+ *
+ * An argument-less `create_product` used to come back as a `requires_confirmation`
+ * plan, render an Approve card, and only 400 at the route *after* the partner
+ * pressed it. The dispatcher now refuses on any absent `inputSchema.required`
+ * argument ahead of every rail.
+ *
+ * The unit suite (`src/lib/mcp-core/__tests__/required-args.unit.spec.ts`) holds
+ * the registry contract and calls the dispatcher directly. This one drives the
+ * real HTTP surfaces end to end — BOTH of them, because the fix lives in shared
+ * mcp-core and a surface could regress independently. The partner MCP route had
+ * no HTTP coverage at all before this.
+ *
+ * Note the refusal happens before any loopback call, so neither case touches a
+ * route and nothing is ever written.
+ */
+const MCP_HEADERS = {
+  "Content-Type": "application/json",
+  Accept: "application/json, text/event-stream",
+}
+
+const rpc = (name: string, args: Record<string, unknown>, id = 1) => ({
+  jsonrpc: "2.0",
+  id,
+  method: "tools/call",
+  params: { name, arguments: args },
+})
+
+const TEST_PARTNER_PASSWORD = "supersecret"
+
+setupSharedTestSuite(() => {
+  describe("MCP required-argument refusal (#1371 item 3)", () => {
+    const { api, getContainer } = getSharedTestEnv()
+
+    const parse = (res: any) => JSON.parse(res.data.result.content[0].text)
+
+    describe("admin surface — POST /admin/mcp", () => {
+      let auth: { headers: Record<string, string> }
+
+      beforeEach(async () => {
+        await createAdminUser(getContainer())
+        auth = await getAuthHeaders(api)
+      })
+
+      const mcp = (body: any) =>
+        api.post("/admin/mcp", body, {
+          headers: { ...MCP_HEADERS, ...auth.headers },
+        })
+
+      it("refuses create_product with no arguments instead of asking to confirm", async () => {
+        const res = await mcp(rpc("create_product", {}))
+        expect(res.status).toBe(200)
+        expect(res.data.result.isError).toBe(true)
+
+        const out = parse(res)
+        expect(out.ok).toBe(false)
+        expect(out.tool).toBe("create_product")
+        expect(out.error).toMatch(/required argument/i)
+        expect(out.error).toMatch(/title/)
+        // The regression: never an approval card for a call that cannot run.
+        expect(out.requires_confirmation).toBeUndefined()
+        expect(out.plan).toBeUndefined()
+      })
+
+      it("still reaches the sensitive rail once the required argument is present", async () => {
+        const res = await mcp(
+          rpc("create_product", { title: "req-args-probe", dry_run: true })
+        )
+        const out = parse(res)
+        expect(out.ok).toBe(true)
+        expect(out.dry_run).toBe(true)
+        expect(out.plan.body.title).toBe("req-args-probe")
+        expect(out.warning).toMatch(/sensitive/i)
+      })
+    })
+
+    describe("partner surface — POST /partners/mcp", () => {
+      let headers: Record<string, string>
+
+      beforeEach(async () => {
+        const unique = Date.now() + Math.random().toString(36).slice(2, 6)
+        const email = `partner-reqargs-${unique}@medusa-test.com`
+
+        await api.post("/auth/partner/emailpass/register", {
+          email,
+          password: TEST_PARTNER_PASSWORD,
+        })
+        const login1 = await api.post("/auth/partner/emailpass", {
+          email,
+          password: TEST_PARTNER_PASSWORD,
+        })
+        await api.post(
+          "/partners",
+          {
+            name: `ReqArgs ${unique}`,
+            handle: `reqargs-${unique}`,
+            admin: { email, first_name: "Req", last_name: "Args" },
+          },
+          { headers: { Authorization: `Bearer ${login1.data.token}` } }
+        )
+        // Re-login so the token carries the partner in app_metadata.
+        const login2 = await api.post("/auth/partner/emailpass", {
+          email,
+          password: TEST_PARTNER_PASSWORD,
+        })
+        headers = { Authorization: `Bearer ${login2.data.token}` }
+      })
+
+      const mcp = (body: any) =>
+        api.post("/partners/mcp", body, {
+          headers: { ...MCP_HEADERS, ...headers },
+        })
+
+      it("refuses create_product with no arguments and names BOTH missing fields", async () => {
+        const res = await mcp(rpc("create_product", {}))
+        expect(res.status).toBe(200)
+        expect(res.data.result.isError).toBe(true)
+
+        const out = parse(res)
+        expect(out.ok).toBe(false)
+        expect(out.error).toMatch(/store_id/)
+        expect(out.error).toMatch(/product/)
+        expect(out.requires_confirmation).toBeUndefined()
+        expect(out.plan).toBeUndefined()
+      })
+
+      it("refuses even when the model supplies confirm: true", async () => {
+        const out = parse(await mcp(rpc("create_product", { confirm: true })))
+        expect(out.ok).toBe(false)
+        expect(out.error).toMatch(/required argument/i)
+      })
+
+      it("treats an empty-string argument as missing", async () => {
+        const out = parse(
+          await mcp(
+            rpc("create_product", {
+              store_id: "   ",
+              product: { title: "x" },
+            })
+          )
+        )
+        expect(out.ok).toBe(false)
+        expect(out.error).toMatch(/store_id/)
+      })
+    })
+  })
+})


### PR DESCRIPTION
Follow-up to #1376. Part of #1371 (item 3).

#1376 fixed the confirm gate previewing calls that cannot run, and shipped a unit suite that holds the registry contract and calls the dispatcher directly. This adds the layer above it: the **real HTTP surfaces**, end to end.

Worth doing because the fix lives in shared `mcp-core` and each surface mounts it separately — either could regress on its own. And **the partner MCP route had no HTTP-level coverage at all** before this; only admin and store did, which is notable given the partner surface is where the defect was found.

## Covered

Per surface (`POST /admin/mcp`, `POST /partners/mcp`):

- an argument-less `create_product` returns `isError: true`, names the missing fields, and carries **no `requires_confirmation` and no `plan`** — the approval card is gone
- a call carrying the required args still reaches the sensitive rail (`dry_run` plan + sensitive warning), so the gate itself is intact

Partner-only, mirroring the unit suite:

- refuses even when the model supplies `confirm: true`
- treats a whitespace-only string as missing

Required args differ per surface — admin `create_product` needs `title`, partner needs `store_id` + `product` — so both assertions are surface-specific rather than copy-pasted.

## Safety

The refusal fires before any loopback call, so no case here touches a route and nothing is written. That also means the partner tests need no store — only a registered partner.

## Verify

```
cd apps/backend
pnpm test:integration:http:shared ./integration-tests/http/mcp-required-args.spec.ts
```

Locally **5/5**:

```
admin surface — POST /admin/mcp
  ✓ refuses create_product with no arguments instead of asking to confirm
  ✓ still reaches the sensitive rail once the required argument is present
partner surface — POST /partners/mcp
  ✓ refuses create_product with no arguments and names BOTH missing fields
  ✓ refuses even when the model supplies confirm: true
  ✓ treats an empty-string argument as missing
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)