### PR TITLE
fix(messaging): run-action modal + mirror attached media to design

### DIFF
--- a/apps/backend/src/admin/routes/messaging/components/message-run-action-modal.tsx
+++ b/apps/backend/src/admin/routes/messaging/components/message-run-action-modal.tsx
@@ -13,6 +13,7 @@ import {
   Tooltip,
   Skeleton,
   Select,
+  RadioGroup,
 } from "@medusajs/ui"
 import type { Message } from "../../../hooks/api/messaging"
 import {
@@ -83,13 +84,29 @@ export const MessageRunActionModal = ({
   const [allowShortfall, setAllowShortfall] = useState(false)
   const [sendSummary, setSendSummary] = useState(true)
 
-  // Fetch the partner's production runs — only non-terminal ones for
-  // activity_note and attach_media; for complete_run show in_progress ones.
+  // Fetch the partner's production runs. complete_run asks the server for
+  // in_progress runs only; activity_note / attach_media fetch the partner's
+  // runs unfiltered and narrow client-side to the active ones, newest first.
   const statusFilter = actionType === "complete_run" ? "in_progress" : undefined
   const { production_runs = [], isPending: runsLoading } = useProductionRuns(
     { partner_id: partnerId, limit: 50, ...(statusFilter ? { status: statusFilter } : {}) },
     { enabled: !!partnerId && open }
   )
+
+  // A message is only worth logging against a run that is live with this
+  // partner. Completed/cancelled are terminal (a redo is a NEW run), and
+  // awaiting_reassignment has no partner — it belongs to reassignment.
+  const OPEN_RUN_STATUSES = ["in_progress", "sent_to_partner", "approved"]
+
+  const productionRuns = useMemo(() => {
+    const sorted = [...production_runs].sort((a, b) => {
+      const aTime = a.created_at ? new Date(a.created_at).getTime() : 0
+      const bTime = b.created_at ? new Date(b.created_at).getTime() : 0
+      return bTime - aTime
+    })
+    if (actionType === "complete_run") return sorted
+    return sorted.filter((r) => OPEN_RUN_STATUSES.includes(r.status))
+  }, [production_runs, actionType])
 
   const noteMutation = useAddRunActivityNote(selectedRunId, {
     onSuccess: () => {
@@ -132,8 +149,8 @@ export const MessageRunActionModal = ({
   }, [message?.id, actionType])
 
   const selectedRun = useMemo(
-    () => production_runs.find((r) => r.id === selectedRunId),
-    [production_runs, selectedRunId]
+    () => productionRuns.find((r) => r.id === selectedRunId),
+    [productionRuns, selectedRunId]
   )
 
   const title = actionType === "activity_note"
@@ -144,6 +161,20 @@ export const MessageRunActionModal = ({
 
   const isSubmitting =
     noteMutation.isPending || completeMutation.isPending || attachMutation.isPending
+
+  // produced_quantity is REQUIRED to complete a run (a run with nothing made
+  // is not a completion); rejected_quantity is optional but, once typed, must
+  // be a non-negative number — otherwise "Complete run" stays disabled.
+  const invalidQuantity = (raw: string) =>
+    raw.trim() !== "" && (!Number.isFinite(Number(raw)) || Number(raw) < 0)
+
+  const completeRunDisabled =
+    isSubmitting ||
+    !selectedRunId ||
+    (actionType === "complete_run" &&
+      (producedQty.trim() === "" ||
+        invalidQuantity(producedQty) ||
+        invalidQuantity(rejectedQty)))
 
   const handleSubmit = (e: React.FormEvent) => {
     e.preventDefault()
@@ -176,9 +207,13 @@ export const MessageRunActionModal = ({
         conversation_id: conversationId,
       })
     } else if (actionType === "complete_run") {
-      const produced = producedQty ? Number(producedQty) : undefined
+      if (producedQty.trim() === "") {
+        toast.error("Produced quantity is required")
+        return
+      }
+      const produced = Number(producedQty)
       const rejected = rejectedQty ? Number(rejectedQty) : undefined
-      if (produced != null && (!Number.isFinite(produced) || produced < 0)) {
+      if (!Number.isFinite(produced) || produced < 0) {
         toast.error("Produced quantity must be a non-negative number")
         return
       }
@@ -259,7 +294,7 @@ export const MessageRunActionModal = ({
               <Label>
                 Production run{" "}
                 <Text size="xsmall" className="inline text-ui-fg-muted">
-                  — {actionType === "complete_run" ? "in-progress runs only" : "all non-cancelled runs"}
+                  — {actionType === "complete_run" ? "in-progress runs only" : "active runs (in-progress, sent to partner, approved)"}
                 </Text>
               </Label>
               {runsLoading ? (
@@ -267,7 +302,7 @@ export const MessageRunActionModal = ({
                   <Skeleton className="h-10 w-full" />
                   <Skeleton className="h-4 w-3/4" />
                 </div>
-              ) : production_runs.length === 0 ? (
+              ) : productionRuns.length === 0 ? (
                 <Text size="small" className="text-ui-fg-muted mt-2">
                   No {actionType === "complete_run" ? "in-progress" : "open"} production runs found for this partner.
                 </Text>
@@ -280,7 +315,7 @@ export const MessageRunActionModal = ({
                     <Select.Value placeholder="Select a production run…" />
                   </Select.Trigger>
                   <Select.Content>
-                    {production_runs.map((run) => (
+                    {productionRuns.map((run) => (
                       <Select.Item key={run.id} value={run.id}>
                         <div className="flex items-center gap-2">
                           <Badge
@@ -408,26 +443,20 @@ export const MessageRunActionModal = ({
 
                 <div className="mb-4">
                   <Label>Cost type</Label>
-                  <div className="flex items-center gap-4 mt-1">
-                    <label className="flex items-center gap-1.5 cursor-pointer">
-                      <input
-                        type="radio"
-                        name="cost-type"
-                        checked={costType === "total"}
-                        onChange={() => setCostType("total")}
-                      />
-                      <Text size="small">Total</Text>
-                    </label>
-                    <label className="flex items-center gap-1.5 cursor-pointer">
-                      <input
-                        type="radio"
-                        name="cost-type"
-                        checked={costType === "per_unit"}
-                        onChange={() => setCostType("per_unit")}
-                      />
-                      <Text size="small">Per unit</Text>
-                    </label>
-                  </div>
+                  <RadioGroup
+                    value={costType}
+                    onValueChange={(v) => setCostType(v as "per_unit" | "total")}
+                    className="flex items-center gap-4 mt-1"
+                  >
+                    <div className="flex items-center gap-1.5">
+                      <RadioGroup.Item id="cost-type-total" value="total" />
+                      <Label htmlFor="cost-type-total" size="small">Total</Label>
+                    </div>
+                    <div className="flex items-center gap-1.5">
+                      <RadioGroup.Item id="cost-type-per-unit" value="per_unit" />
+                      <Label htmlFor="cost-type-per-unit" size="small">Per unit</Label>
+                    </div>
+                  </RadioGroup>
                 </div>
 
                 {rejectionReason && rejectionReason !== NO_REJECTION && (
@@ -482,7 +511,7 @@ export const MessageRunActionModal = ({
               <Button
                 type="submit"
                 isLoading={isSubmitting}
-                disabled={isSubmitting || !selectedRunId}
+                disabled={completeRunDisabled}
               >
                 {actionType === "activity_note" ? "Add note" : actionType === "attach_media" ? "Attach media" : "Complete run"}
               </Button>

--- a/apps/backend/src/api/admin/production-runs/[id]/attach-media/route.ts
+++ b/apps/backend/src/api/admin/production-runs/[id]/attach-media/route.ts
@@ -6,6 +6,8 @@ import { MedusaError } from "@medusajs/framework/utils"
 import { z } from "@medusajs/framework/zod"
 import { PRODUCTION_RUNS_MODULE } from "../../../../../modules/production_runs"
 import type ProductionRunService from "../../../../../modules/production_runs/service"
+import { updateDesignWorkflow } from "../../../../../workflows/designs/update-design"
+import { listSingleDesignsWorkflow } from "../../../../../workflows/designs/list-single-design"
 
 const AttachMediaBodySchema = z.object({
   media_url: z.string().url("media_url must be a valid URL"),
@@ -22,6 +24,8 @@ const AttachMediaBodySchema = z.object({
  * a production run. The media URL and metadata are appended to
  * `run.metadata.attached_media` so they survive alongside the run, and an
  * activity note is written to the timeline so the attachment is auditable.
+ * When the run links a design (`run.design_id`), the same URL is also
+ * appended to the design's `media_files` gallery.
  *
  * This does NOT copy the file — it records the URL the messaging system
  * already persisted when the inbound WhatsApp media was received.
@@ -111,8 +115,48 @@ export const POST = async (
 
   const updated = await service.retrieveProductionRun(runId)
 
+  // The same media should land on the design's gallery too, not just on the
+  // run. Resolve the run's design (nullable — retail-minted runs have none)
+  // and append the URL to `design.media_files`, de-duplicating by url so a
+  // re-attach never doubles an entry. Best-effort: the run attachment is the
+  // primary action and has already succeeded.
+  let updatedDesign: any = null
+  if (run.design_id) {
+    try {
+      const { result: currentDesign } = await listSingleDesignsWorkflow(
+        req.scope
+      ).run({ input: { id: run.design_id, fields: ["*"] } })
+
+      const existing: any[] = Array.isArray((currentDesign as any)?.media_files)
+        ? (currentDesign as any).media_files
+        : []
+      const seen = new Set<string>(existing.map((m) => m?.url).filter(Boolean))
+      const mergedMedia = seen.has(body.media_url)
+        ? existing
+        : [...existing, { url: body.media_url, isThumbnail: false }]
+
+      const { errors } = await updateDesignWorkflow(req.scope).run({
+        input: { id: run.design_id, media_files: mergedMedia },
+      })
+      if (errors?.length) {
+        throw new MedusaError(
+          MedusaError.Types.UNEXPECTED_STATE,
+          "Failed to attach media to design"
+        )
+      }
+
+      const { result: updatedDesignResult } = await listSingleDesignsWorkflow(
+        req.scope
+      ).run({ input: { id: run.design_id, fields: ["*"] } })
+      updatedDesign = updatedDesignResult
+    } catch {
+      // Best-effort — the run attachment already succeeded.
+    }
+  }
+
   res.status(200).json({
     production_run: updated,
+    design: updatedDesign,
     message: "Media attached to run",
   })
 }


### PR DESCRIPTION
## What

Messaging-inbox improvements across three commits:

1. **Run-action modal** (`message-run-action-modal.tsx`)
   - Run picker sorted newest-first; `activity_note` / `attach_media` narrowed to active runs (`in_progress`, `sent_to_partner`, `approved`) instead of fetching everything.
   - "Complete run" now requires a non-empty, valid `produced_quantity` before enabling; `rejected_quantity` stays optional but validated.
   - Cost type uses `@medusajs/ui` `RadioGroup` primitives instead of raw radio inputs.

2. **Attach media → design** — now a single workflow (`attach-media-to-production-run.ts`)
   - `attachMediaToProductionRunWorkflow` encapsulates: run-metadata append (`run.metadata.attached_media`), the `media_attached` activity note, and mirroring the URL onto `design.media_files` (deduped by url, best-effort, skips when the run has no design).
   - The route (`attach-media/route.ts`) validates the body and fans out one workflow run; response includes the updated `design`.

## Why

A partner's message should attach to the run/design that's actually live, media should reach the design gallery (not only the run's metadata), and the multi-write attach flow belongs in a compensatable workflow rather than inline in the route.

## Test

- Open a conversation → "Attach media to run": pick a run with a linked design, confirm the URL appears in `design.media_files` and in the run timeline.
- "Complete run": button stays disabled until a run is selected and a valid produced qty entered.