### PR TITLE
perf(partners): phase-time both partner product-create routes (#1370)

### DIFF
--- a/apps/backend/src/api/partners/helpers.ts
+++ b/apps/backend/src/api/partners/helpers.ts
@@ -545,3 +545,42 @@ export const getPartnerSalesChannelId = async (
 
     return { partner, store, salesChannelId: store.default_sales_channel_id }
 }
+/**
+ * Phase timing for partner write routes (#1370).
+ *
+ * These saves are slow in a way no single measurement has yet explained: a
+ * `variants/batch` price save runs 14-50s with the write itself at ~700ms, and
+ * a `POST .../products` create 504'd at the 60s edge while the product row
+ * landed 1.3s in and the worker finished its subscribers and FX fanout
+ * normally. Three theories have already died (the option graph, core's refetch
+ * helper, inline subscribers), and phase timing is the one technique that has
+ * actually moved the diagnosis — it is what identified the 97% response re-read
+ * on variants/batch.
+ *
+ * Shared rather than copied because the create paths come in pairs: the legacy
+ * `POST /partners/products` that the assistant's `create_product` tool posts to,
+ * and the store-scoped `POST /partners/stores/:id/products` that the partner UI
+ * actually calls. Instrumenting one and reasoning about the other is how the
+ * partner-facing path stays unmeasured.
+ *
+ * Deliberately `info` and always on: the slow saves are intermittent, and a
+ * flag we switch on after a partner complains is off during every occurrence
+ * worth measuring.
+ */
+export const phaseTimer = (logger: any, label: string, requestId: string) => {
+  const t0 = Date.now()
+  let last = t0
+  const marks: string[] = []
+  return {
+    mark(name: string) {
+      const now = Date.now()
+      marks.push(`${name}=${now - last}ms`)
+      last = now
+    },
+    done(suffix = "") {
+      logger?.info?.(
+        `[${label}] ${requestId} total=${Date.now() - t0}ms ${marks.join(" ")}${suffix}`
+      )
+    },
+  }
+}

--- a/apps/backend/src/api/partners/products/route.ts
+++ b/apps/backend/src/api/partners/products/route.ts
@@ -126,6 +126,43 @@ import { requestVariantPriceFanout } from "../../../workflows/fx/fanout-variant-
 import { PARTNER_MODULE } from "../../../modules/partner"
 import { PARTNER_ONBOARDING_PROFILE_MODULE } from "../../../modules/partner-onboarding-profile"
 
+/**
+ * Phase timing for this route (#1370).
+ *
+ * A `Zari Work Pashmina` create with 2 variants took >70s server-side and 504'd
+ * at the 60s edge, while the product row was written 1.3s in — the partner sees
+ * a failure for a product that exists, and the worker logs show its subscribers
+ * and FX fanout completing normally. So the time is spent on the server AFTER
+ * the write, in a phase nothing currently measures.
+ *
+ * Unlike variants/batch this route has no response re-read to blame, and the
+ * same run showed ZERO redis-cache timeouts, so neither of the two standing
+ * theories covers it. Rather than theorise a third, measure: this route had no
+ * instrumentation at all, and phase timing is what identified the 97% re-read
+ * on the sibling route.
+ *
+ * Deliberately `info` and always on — the slow saves are intermittent, and a
+ * flag we turn on after a partner complains is off during every occurrence
+ * worth measuring.
+ */
+const phaseTimer = (logger: any, requestId: string) => {
+  const t0 = Date.now()
+  let last = t0
+  const marks: string[] = []
+  return {
+    mark(name: string) {
+      const now = Date.now()
+      marks.push(`${name}=${now - last}ms`)
+      last = now
+    },
+    done(suffix = "") {
+      logger?.info?.(
+        `[partners/products] ${requestId} total=${Date.now() - t0}ms ${marks.join(" ")}${suffix}`
+      )
+    },
+  }
+}
+
 export const POST = async (
   req: AuthenticatedMedusaRequest,
   res: MedusaResponse
@@ -133,6 +170,9 @@ export const POST = async (
   if (!req.auth_context?.actor_id) {
     throw new MedusaError(MedusaError.Types.UNAUTHORIZED, "Partner authentication required")
   }
+
+  const logger: any = req.scope.resolve(ContainerRegistrationKeys.LOGGER)
+  const timer = phaseTimer(logger, req.get("x-request-id") || "-")
 
   const partner = await getPartnerFromAuthContext(req.auth_context, req.scope)
   if (!partner) {
@@ -180,11 +220,14 @@ export const POST = async (
     ],
   }
 
+  timer.mark("prepare")
+
   const { result } = await createProductsWorkflow(req.scope).run({
     input: {
       products: [productInput],
     },
   })
+  timer.mark("createWorkflow")
 
   const created = result?.[0]
 
@@ -198,6 +241,7 @@ export const POST = async (
   // throws (see ensureInventoryLevelsForVariants).
   const variantIds = (created?.variants || []).map((v: any) => v.id)
   await ensureInventoryLevelsForVariants(req.scope, store, variantIds)
+  timer.mark("inventoryLevels")
 
   // FX fanout — materialise auto-converted prices in the store's other
   // supported currencies. EXACTLY the same gap as the inventory levels above,
@@ -214,6 +258,7 @@ export const POST = async (
   // never inline. See requestVariantPriceFanout for why that distinction is a
   // availability concern and not a latency one.
   await requestVariantPriceFanout(req.scope, { storeId: store.id, variantIds })
+  timer.mark("fanoutEmit")
 
   // Record product → owning partner so the cross-list subscriber can resolve
   // ownership cleanly on publish (see links/partner-product.ts).
@@ -236,6 +281,8 @@ export const POST = async (
       })
       .catch(() => {})
   }
+  timer.mark("linkAndEvent")
+  timer.done(` variants=${variantIds.length}`)
 
   return res.status(201).json({
     message: isCoreChannelListing ? "Product proposed" : "Product created",

--- a/apps/backend/src/api/partners/products/route.ts
+++ b/apps/backend/src/api/partners/products/route.ts
@@ -121,47 +121,10 @@ import { AuthenticatedMedusaRequest, MedusaResponse } from "@medusajs/framework/
 import { MedusaError, ContainerRegistrationKeys, Modules } from "@medusajs/framework/utils"
 import { PartnerCreateProductReq } from "./validators"
 import { createProductsWorkflow } from "@medusajs/medusa/core-flows"
-import { getPartnerFromAuthContext, ensureInventoryLevelsForVariants } from "../helpers"
+import { getPartnerFromAuthContext, ensureInventoryLevelsForVariants, phaseTimer } from "../helpers"
 import { requestVariantPriceFanout } from "../../../workflows/fx/fanout-variant-prices"
 import { PARTNER_MODULE } from "../../../modules/partner"
 import { PARTNER_ONBOARDING_PROFILE_MODULE } from "../../../modules/partner-onboarding-profile"
-
-/**
- * Phase timing for this route (#1370).
- *
- * A `Zari Work Pashmina` create with 2 variants took >70s server-side and 504'd
- * at the 60s edge, while the product row was written 1.3s in — the partner sees
- * a failure for a product that exists, and the worker logs show its subscribers
- * and FX fanout completing normally. So the time is spent on the server AFTER
- * the write, in a phase nothing currently measures.
- *
- * Unlike variants/batch this route has no response re-read to blame, and the
- * same run showed ZERO redis-cache timeouts, so neither of the two standing
- * theories covers it. Rather than theorise a third, measure: this route had no
- * instrumentation at all, and phase timing is what identified the 97% re-read
- * on the sibling route.
- *
- * Deliberately `info` and always on — the slow saves are intermittent, and a
- * flag we turn on after a partner complains is off during every occurrence
- * worth measuring.
- */
-const phaseTimer = (logger: any, requestId: string) => {
-  const t0 = Date.now()
-  let last = t0
-  const marks: string[] = []
-  return {
-    mark(name: string) {
-      const now = Date.now()
-      marks.push(`${name}=${now - last}ms`)
-      last = now
-    },
-    done(suffix = "") {
-      logger?.info?.(
-        `[partners/products] ${requestId} total=${Date.now() - t0}ms ${marks.join(" ")}${suffix}`
-      )
-    },
-  }
-}
 
 export const POST = async (
   req: AuthenticatedMedusaRequest,
@@ -172,7 +135,7 @@ export const POST = async (
   }
 
   const logger: any = req.scope.resolve(ContainerRegistrationKeys.LOGGER)
-  const timer = phaseTimer(logger, req.get("x-request-id") || "-")
+  const timer = phaseTimer(logger, "partners/products", req.get("x-request-id") || "-")
 
   const partner = await getPartnerFromAuthContext(req.auth_context, req.scope)
   if (!partner) {

--- a/apps/backend/src/api/partners/stores/[id]/products/route.ts
+++ b/apps/backend/src/api/partners/stores/[id]/products/route.ts
@@ -1,7 +1,9 @@
 import { AuthenticatedMedusaRequest, MedusaResponse } from "@medusajs/framework/http"
+import { ContainerRegistrationKeys } from "@medusajs/framework/utils"
 import { createProductsWorkflow } from "@medusajs/medusa/core-flows"
 import {
   ensureInventoryLevelsForVariants,
+  phaseTimer,
   validatePartnerStoreAccess,
 } from "../../../helpers"
 import listStoreProductsWorkflow from "../../../../../workflows/partner/list-store-products"
@@ -38,11 +40,20 @@ export const POST = async (
   req: AuthenticatedMedusaRequest,
   res: MedusaResponse
 ) => {
+  const logger: any = req.scope.resolve(ContainerRegistrationKeys.LOGGER)
+  const timer = phaseTimer(
+    logger,
+    "partners/stores/products",
+    req.get("x-request-id") || "-"
+  )
+
   const { partner, store } = await validatePartnerStoreAccess(
     req.auth_context,
     req.params.id,
     req.scope
   )
+
+  timer.mark("auth")
 
   const body = req.body as Record<string, any>
 
@@ -65,11 +76,14 @@ export const POST = async (
     body.status = "proposed"
   }
 
+  timer.mark("proposalGate")
+
   const { result } = await createProductsWorkflow(req.scope).run({
     input: {
       products: [body] as any,
     },
   })
+  timer.mark("createWorkflow")
 
   const product = result[0]
 
@@ -78,17 +92,21 @@ export const POST = async (
   if (isCoreChannelListing && product?.id) {
     await recordArtisanProposal(req.scope, partner.id, product.id)
   }
+  timer.mark("proposalRecord")
 
   // Auto-seed inventory_level rows at the partner's stock location(s) for
   // any managed-inventory variants on the new product. Without this, the
   // partner-ui inventory page 404s on those items.
   const variantIds = (product?.variants || []).map((v: any) => v.id)
   await ensureInventoryLevelsForVariants(req.scope, store, variantIds)
+  timer.mark("inventoryLevels")
 
   // FX fanout — materialise auto-converted prices in the store's other
   // supported currencies so the product isn't "not available" in non-native
   // regions. Idempotent + never throws (see fanout-variant-prices.ts).
   await requestVariantPriceFanout(req.scope, { storeId: store.id, variantIds })
+  timer.mark("fanoutEmit")
+  timer.done(` variants=${variantIds.length}`)
 
   res.status(201).json({ product })
 }


### PR DESCRIPTION
Part of #1370. Instrumentation only — no behaviour change.

## Why

Creating `Zari Work Pashmina` (2 variants, 1 price each) through `POST /partners/products` on prod:

- client got **504 after 61.2s** (the Cloudflare edge timeout)
- the product row was written **1.3s in** (`created_at 08:20:19.503`, request started `08:20:18`)
- the server logged the request at `08:21:31` with **`status: null`, `duration: null`, `response_size: 0`** — it never produced a response
- the worker meanwhile did everything correctly and quickly: `classify-product-tax-class → assigned`, `fx.fanout_requested → 2 price(s) processed, 10 auto-price(s) created, 0 failed`

So the partner sees a hard failure for a product that exists and is fully processed. ~70s is spent on the server **after** the write, in a phase nothing measures.

## Why not just fix it

Neither standing theory covers this run:

- **It is not the response re-read.** This route has none — that is `variants/batch`'s problem.
- **It is not the redis-cache timeouts.** The `variants/batch` slow window logged 67 × `[redis-cache] Redis connection error ... Command timed out` against **0** in a quiet control window, which looked like the answer. This create logged **zero**, and the window was re-queried after ingestion lag (24 → 70 lines) to be sure the silence was real.
- **It is not inline subscribers.** They ran on the worker, as designed.

This thread has already burned two confident diagnoses (the option graph, then core's helper). Phase timing is what actually identified the 97% re-read on the sibling route, and this route had no instrumentation at all — so measure first.

## What it adds

`prepare` / `createWorkflow` / `inventoryLevels` / `fanoutEmit` / `linkAndEvent`, plus the variant count:

```
[partners/products] <request-id> total=…ms prepare=…ms createWorkflow=…ms \
  inventoryLevels=…ms fanoutEmit=…ms linkAndEvent=…ms variants=N
```

Always-on `info`, matching the sibling route — these saves are intermittent, and a flag switched on after a partner complains is off during every occurrence worth measuring. The variant count rides along because cost-per-variant is what made the last diagnosis legible.

## Verify

`check:prod-build` ✓. After deploy, create a product through the partner assistant or the API and read:

```
aws logs filter-log-events --log-group-name /copilot/jyt-prod-medusa-server \
  --start-time <ms> --filter-pattern '"[partners/products]"'
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)