### PR TITLE
fix(partners): update_store_product wrote nothing on every MCP call

### DIFF
--- a/apps/backend/integration-tests/http/partner-store-products-api.spec.ts
+++ b/apps/backend/integration-tests/http/partner-store-products-api.spec.ts
@@ -214,6 +214,48 @@ setupSharedTestSuite(() => {
         expect(res.status).toBe(200)
         expect(res.data.product.title).toBe("Updated Product Title")
       })
+
+      // The MCP tool `update_store_product` declares `bodyParams: ["product",
+      // "metadata"]`, so a model's write arrives NESTED. The route used to pass
+      // the raw body straight to `updateProducts`, which ignores unknown keys
+      // without throwing — so the call returned 200 with the product echoed
+      // back UNCHANGED and wrote nothing. Verified broken on prod before the
+      // fix. Asserting on the response is what hid it: the read-back below is
+      // the assertion that catches it.
+      it("accepts the MCP-shaped NESTED body and actually persists it", async () => {
+        const res = await api.post(
+          `/partners/stores/${partner.storeId}/products/${partner.productId}`,
+          { product: { title: "Nested Shape Title", subtitle: "nested-ok" } },
+          { headers: partner.headers }
+        )
+        expect(res.status).toBe(200)
+
+        const readBack = await api.get(
+          `/partners/stores/${partner.storeId}/products/${partner.productId}`,
+          { headers: partner.headers }
+        )
+        expect(readBack.data.product.title).toBe("Nested Shape Title")
+        expect(readBack.data.product.subtitle).toBe("nested-ok")
+      })
+
+      it("keeps top-level metadata when the body is nested", async () => {
+        const res = await api.post(
+          `/partners/stores/${partner.storeId}/products/${partner.productId}`,
+          {
+            product: { title: "Nested With Metadata" },
+            metadata: { b2b_min_order_qty: 50 },
+          },
+          { headers: partner.headers }
+        )
+        expect(res.status).toBe(200)
+
+        const readBack = await api.get(
+          `/partners/stores/${partner.storeId}/products/${partner.productId}`,
+          { headers: partner.headers }
+        )
+        expect(readBack.data.product.title).toBe("Nested With Metadata")
+        expect(readBack.data.product.metadata?.b2b_min_order_qty).toBe(50)
+      })
     })
 
     describe("Product Variant Management", () => {

--- a/apps/backend/src/api/partners/stores/[id]/products/[productId]/route.ts
+++ b/apps/backend/src/api/partners/stores/[id]/products/[productId]/route.ts
@@ -100,7 +100,20 @@ export const POST = async (
     req.scope
   )
 
-  const body = req.body as Record<string, any>
+  // Two callers, two body shapes. partner-ui posts the product fields FLAT
+  // (`{ title, status, … }`); the MCP tool `update_store_product` declares
+  // `bodyParams: ["product", "metadata"]` and therefore nests them under
+  // `product`. `updateProducts` ignores unknown keys silently, so the nested
+  // shape returned 200 with `ok: true` and wrote NOTHING (verified on prod).
+  // Accept both: unwrap `product` when present, keeping top-level `metadata`.
+  const raw = req.body as Record<string, any>
+  const body =
+    raw && typeof raw.product === "object" && raw.product !== null
+      ? {
+          ...(raw.product as Record<string, any>),
+          ...(raw.metadata !== undefined ? { metadata: raw.metadata } : {}),
+        }
+      : raw
   const productService = req.scope.resolve(Modules.PRODUCT) as any
   const updated = await productService.updateProducts(req.params.productId, body)
 


### PR DESCRIPTION
## The defect

`update_store_product` returned **200 with `ok: true` and wrote nothing** — on every call a model ever made.

The MCP row declares `bodyParams: ["product", "metadata"]`, so the write arrives **nested** under `product`. The route has no validator and passes `req.body` straight to `updateProducts`, which expects the fields **flat** — the shape partner-ui posts, which is why this survived unnoticed. `updateProducts` ignores unknown keys without throwing, so `{ product: { title } }` updated nothing and threw nothing.

## Verified on prod, both directions

| body | result |
|---|---|
| `{"product":{"title":"…","subtitle":"…"}}` (MCP shape) | 200, title/subtitle **unchanged** on independent read-back |
| `{"title":"…","subtitle":"…"}` (partner-ui shape) | 200, updated |

## The fix

Unwrap `product` when present, keeping top-level `metadata`. The flat shape is untouched, so partner-ui is unaffected.

## Tests

Two integration tests in `partner-store-products-api.spec.ts`, **both confirmed RED without the route change** (failing with the exact prod symptom — title unchanged). Suite is 19/19 green with it.

They assert via a **read-back**, not the response body. The pre-existing update test asserted on the response — which echoes the unchanged product — and passed throughout.

## Why the existing guard missed it

The #1348 contract test compares a registry row against a **zod shape**. This route has none, so the expected body shape is implicit in the handler and the drift was invisible to it. Worth considering a follow-up that flags rows whose route has no validator.

🤖 Generated with [Claude Code](https://claude.com/claude-code)