### PR TITLE
refactor(messaging): attach-media into a single workflow + integration tests

### DIFF
--- a/apps/backend/integration-tests/http/production-run-attach-media.spec.ts
+++ b/apps/backend/integration-tests/http/production-run-attach-media.spec.ts
@@ -1,0 +1,184 @@
+import { createAdminUser, getAuthHeaders } from "../helpers/create-admin-user"
+import { getSharedTestEnv, setupSharedTestSuite } from "./shared-test-setup"
+
+jest.setTimeout(60000)
+
+/**
+ * Attach-media from the messaging inbox — the admin action that appends a
+ * WhatsApp media URL to a run (metadata + activity note) and mirrors it onto
+ * the linked design's gallery. Pins the single-workflow behaviour end-to-end:
+ * run write, design mirror (de-duplicated), and the guards.
+ */
+setupSharedTestSuite(() => {
+  describe("Production run — attach media (messaging inbox)", () => {
+    const { api, getContainer } = getSharedTestEnv()
+    let adminHeaders: { headers: Record<string, string> }
+
+    async function createDesign(unique: number) {
+      const res = await api.post(
+        "/admin/designs",
+        {
+          name: `Attach Media Design ${unique}`,
+          description: "x",
+          design_type: "Original",
+          status: "Approved",
+          priority: "Medium",
+        },
+        adminHeaders
+      )
+      expect(res.status).toBe(201)
+      return res.data.design.id
+    }
+
+    async function createRun(designId: string) {
+      const res = await api.post(
+        "/admin/production-runs",
+        { design_id: designId, quantity: 5 },
+        adminHeaders
+      )
+      expect(res.status).toBe(201)
+      return res.data.production_run.id
+    }
+
+    async function getRun(runId: string) {
+      const res = await api.get(`/admin/production-runs/${runId}`, adminHeaders)
+      expect(res.status).toBe(200)
+      return res.data.production_run
+    }
+
+    async function getDesign(designId: string) {
+      const res = await api.get(`/admin/designs/${designId}`, adminHeaders)
+      expect(res.status).toBe(200)
+      return res.data.design
+    }
+
+    /** Non-throwing POST so error statuses can be asserted directly. */
+    async function post(path: string, body: any) {
+      return api.post(path, body, {
+        ...adminHeaders,
+        validateStatus: () => true,
+      })
+    }
+
+    beforeAll(async () => {
+      await createAdminUser(getContainer())
+      adminHeaders = await getAuthHeaders(api)
+    })
+
+    it("attaches media to the run and mirrors it onto the linked design", async () => {
+      const unique = Date.now()
+      const designId = await createDesign(unique)
+      const runId = await createRun(designId)
+
+      const mediaUrl = `https://cdn.jyt.test/wa/${unique}/sample.jpg`
+      const res = await api.post(
+        `/admin/production-runs/${runId}/attach-media`,
+        {
+          media_url: mediaUrl,
+          media_mime_type: "image/jpeg",
+          filename: "sample.jpg",
+          message_id: "msg_123",
+          conversation_id: "conv_456",
+        },
+        adminHeaders
+      )
+
+      expect(res.status).toBe(200)
+      expect(res.data.production_run.id).toBe(runId)
+      expect(res.data.design).toBeTruthy()
+      expect(res.data.design.id).toBe(designId)
+
+      // Run metadata carries the attachment…
+      const run = await getRun(runId)
+      const attached = run.metadata?.attached_media
+      expect(Array.isArray(attached)).toBe(true)
+      expect(attached).toHaveLength(1)
+      expect(attached[0].url).toBe(mediaUrl)
+      expect(attached[0].filename).toBe("sample.jpg")
+
+      // …and the design gallery carries the same URL.
+      const design = await getDesign(designId)
+      expect(Array.isArray(design.media_files)).toBe(true)
+      expect(design.media_files).toHaveLength(1)
+      expect(design.media_files[0].url).toBe(mediaUrl)
+
+      // An audit note was written to the timeline.
+      const activities = await api.get(
+        `/admin/production-runs/${runId}/activities`,
+        adminHeaders
+      )
+      const mediaNotes = activities.data.activities.filter(
+        (a: any) => a.kind === "media_attached"
+      )
+      expect(mediaNotes).toHaveLength(1)
+      expect(mediaNotes[0].payload.media_url).toBe(mediaUrl)
+    })
+
+    it("de-duplicates the URL on the design across repeated attaches", async () => {
+      const unique = Date.now() + 1
+      const designId = await createDesign(unique)
+      const runId = await createRun(designId)
+
+      const mediaUrl = `https://cdn.jyt.test/wa/${unique}/dup.jpg`
+      await api.post(
+        `/admin/production-runs/${runId}/attach-media`,
+        { media_url: mediaUrl },
+        adminHeaders
+      )
+      await api.post(
+        `/admin/production-runs/${runId}/attach-media`,
+        { media_url: mediaUrl },
+        adminHeaders
+      )
+
+      // Run metadata appends once per attach (two entries)…
+      const run = await getRun(runId)
+      expect(run.metadata.attached_media).toHaveLength(2)
+
+      // …but the design gallery stays de-duplicated (one entry).
+      const design = await getDesign(designId)
+      expect(design.media_files).toHaveLength(1)
+      expect(design.media_files[0].url).toBe(mediaUrl)
+    })
+
+    it("rejects a cancelled run", async () => {
+      const unique = Date.now() + 2
+      const designId = await createDesign(unique)
+      const runId = await createRun(designId)
+
+      const runService: any = getContainer().resolve("production_runs")
+      await runService.updateProductionRuns({
+        id: runId,
+        status: "cancelled",
+        cancelled_at: new Date(),
+      })
+
+      const res = await post(
+        `/admin/production-runs/${runId}/attach-media`,
+        { media_url: "https://cdn.jyt.test/wa/cancelled.jpg" }
+      )
+      expect(res.status).toBe(400)
+      expect(String(res.data?.message || "")).toContain("cancelled")
+    })
+
+    it("404s a missing run", async () => {
+      const res = await post(
+        "/admin/production-runs/prun_missing/attach-media",
+        { media_url: "https://cdn.jyt.test/wa/missing.jpg" }
+      )
+      expect(res.status).toBe(404)
+    })
+
+    it("rejects a non-URL media_url", async () => {
+      const unique = Date.now() + 3
+      const designId = await createDesign(unique)
+      const runId = await createRun(designId)
+
+      const res = await post(
+        `/admin/production-runs/${runId}/attach-media`,
+        { media_url: "not-a-url" }
+      )
+      expect(res.status).toBe(400)
+    })
+  })
+})

--- a/apps/backend/src/api/admin/production-runs/[id]/attach-media/route.ts
+++ b/apps/backend/src/api/admin/production-runs/[id]/attach-media/route.ts
@@ -4,10 +4,7 @@ import {
 } from "@medusajs/framework/http"
 import { MedusaError } from "@medusajs/framework/utils"
 import { z } from "@medusajs/framework/zod"
-import { PRODUCTION_RUNS_MODULE } from "../../../../../modules/production_runs"
-import type ProductionRunService from "../../../../../modules/production_runs/service"
-import { updateDesignWorkflow } from "../../../../../workflows/designs/update-design"
-import { listSingleDesignsWorkflow } from "../../../../../workflows/designs/list-single-design"
+import { attachMediaToProductionRunWorkflow } from "../../../../../workflows/production-runs/attach-media-to-production-run"
 
 const AttachMediaBodySchema = z.object({
   media_url: z.string().url("media_url must be a valid URL"),
@@ -27,6 +24,9 @@ const AttachMediaBodySchema = z.object({
  * When the run links a design (`run.design_id`), the same URL is also
  * appended to the design's `media_files` gallery.
  *
+ * All of that is done inside `attachMediaToProductionRunWorkflow` — this
+ * route only validates the body and fans out the single workflow run.
+ *
  * This does NOT copy the file — it records the URL the messaging system
  * already persisted when the inbound WhatsApp media was received.
  */
@@ -35,22 +35,6 @@ export const POST = async (
   res: MedusaResponse
 ) => {
   const runId = req.params.id
-  const service: ProductionRunService = req.scope.resolve(PRODUCTION_RUNS_MODULE)
-
-  const run = (await service.retrieveProductionRun(runId).catch(() => null)) as any
-  if (!run) {
-    throw new MedusaError(
-      MedusaError.Types.NOT_FOUND,
-      `Production run ${runId} not found`
-    )
-  }
-
-  if (run.status === "cancelled") {
-    throw new MedusaError(
-      MedusaError.Types.NOT_ALLOWED,
-      "Cannot attach media to a cancelled production run"
-    )
-  }
 
   const parsed = AttachMediaBodySchema.safeParse(req.body)
   if (!parsed.success) {
@@ -62,101 +46,34 @@ export const POST = async (
 
   const body = parsed.data
 
-  const existingMeta = (run.metadata as Record<string, any>) || {}
-  const existingMedia: any[] = Array.isArray(existingMeta.attached_media)
-    ? existingMeta.attached_media
-    : []
-
-  const attachment = {
-    url: body.media_url,
-    mime_type: body.media_mime_type ?? null,
-    filename: body.filename ?? null,
-    message_id: body.message_id ?? null,
-    conversation_id: body.conversation_id ?? null,
-    attached_by: "admin",
-    attached_at: new Date().toISOString(),
-  }
-
-  await service.updateProductionRuns({
-    id: runId,
-    metadata: {
-      ...existingMeta,
-      attached_media: [...existingMedia, attachment],
+  const { result, errors } = await attachMediaToProductionRunWorkflow(
+    req.scope
+  ).run({
+    input: {
+      production_run_id: runId,
+      media_url: body.media_url,
+      media_mime_type: body.media_mime_type ?? null,
+      filename: body.filename ?? null,
+      message_id: body.message_id ?? null,
+      conversation_id: body.conversation_id ?? null,
+      actor_id: (req as any).auth_context?.actor_id ?? null,
     },
+    throwOnError: false,
   })
 
-  // Audit
-  try {
-    await service.createProductionRunActivities({
-      production_run_id: runId,
-      activity_type: "note",
-      kind: "media_attached",
-      actor_type: "admin",
-      actor_id: (req as any).auth_context?.actor_id ?? null,
-      partner_id: run.partner_id ?? null,
-      channel: body.message_id ? "whatsapp" : null,
-      message_id: body.message_id ?? null,
-      template_name: null,
-      recipient: null,
-      summary: `Media attached: ${body.filename || body.media_url.split("/").pop() || "file"}`,
-      payload: {
-        media_url: body.media_url,
-        media_mime_type: body.media_mime_type ?? null,
-        filename: body.filename ?? null,
-        from_message_id: body.message_id ?? null,
-        from_conversation_id: body.conversation_id ?? null,
-        source: "messaging_inbox",
-      },
-      occurred_at: new Date(),
-    } as any)
-  } catch {
-    // Best-effort
-  }
-
-  const updated = await service.retrieveProductionRun(runId)
-
-  // The same media should land on the design's gallery too, not just on the
-  // run. Resolve the run's design (nullable — retail-minted runs have none)
-  // and append the URL to `design.media_files`, de-duplicating by url so a
-  // re-attach never doubles an entry. Best-effort: the run attachment is the
-  // primary action and has already succeeded.
-  let updatedDesign: any = null
-  if (run.design_id) {
-    try {
-      const { result: currentDesign } = await listSingleDesignsWorkflow(
-        req.scope
-      ).run({ input: { id: run.design_id, fields: ["*"] } })
-
-      const existing: any[] = Array.isArray((currentDesign as any)?.media_files)
-        ? (currentDesign as any).media_files
-        : []
-      const seen = new Set<string>(existing.map((m) => m?.url).filter(Boolean))
-      const mergedMedia = seen.has(body.media_url)
-        ? existing
-        : [...existing, { url: body.media_url, isThumbnail: false }]
-
-      const { errors } = await updateDesignWorkflow(req.scope).run({
-        input: { id: run.design_id, media_files: mergedMedia },
-      })
-      if (errors?.length) {
-        throw new MedusaError(
-          MedusaError.Types.UNEXPECTED_STATE,
-          "Failed to attach media to design"
-        )
-      }
-
-      const { result: updatedDesignResult } = await listSingleDesignsWorkflow(
-        req.scope
-      ).run({ input: { id: run.design_id, fields: ["*"] } })
-      updatedDesign = updatedDesignResult
-    } catch {
-      // Best-effort — the run attachment already succeeded.
-    }
+  if (errors?.length) {
+    throw (
+      errors[0].error ||
+      new MedusaError(
+        MedusaError.Types.UNEXPECTED_STATE,
+        "Failed to attach media to run"
+      )
+    )
   }
 
   res.status(200).json({
-    production_run: updated,
-    design: updatedDesign,
+    production_run: result.production_run,
+    design: result.design,
     message: "Media attached to run",
   })
 }

--- a/apps/backend/src/workflows/production-runs/attach-media-to-production-run.ts
+++ b/apps/backend/src/workflows/production-runs/attach-media-to-production-run.ts
@@ -1,0 +1,215 @@
+import { MedusaError } from "@medusajs/framework/utils"
+import {
+  createStep,
+  createWorkflow,
+  StepResponse,
+  WorkflowResponse,
+} from "@medusajs/framework/workflows-sdk"
+
+import { PRODUCTION_RUNS_MODULE } from "../../modules/production_runs"
+import type ProductionRunService from "../../modules/production_runs/service"
+import { DESIGN_MODULE } from "../../modules/designs"
+import type DesignService from "../../modules/designs/service"
+
+export type AttachMediaToProductionRunInput = {
+  production_run_id: string
+  media_url: string
+  media_mime_type?: string | null
+  filename?: string | null
+  message_id?: string | null
+  conversation_id?: string | null
+  actor_id?: string | null
+}
+
+type RunAttachComp = {
+  id: string
+  prev_metadata: Record<string, any> | null
+}
+
+/**
+ * Append the media to the run (metadata + activity note) and gate the run's
+ * validity up front, so a bad id or a cancelled run fails the whole workflow
+ * before anything is written.
+ */
+const attachMediaToRunStep = createStep(
+  "attach-media-to-run",
+  async (input: AttachMediaToProductionRunInput, { container }) => {
+    const service: ProductionRunService = container.resolve(PRODUCTION_RUNS_MODULE)
+
+    const run = (await service
+      .retrieveProductionRun(input.production_run_id)
+      .catch(() => null)) as any
+    if (!run) {
+      throw new MedusaError(
+        MedusaError.Types.NOT_FOUND,
+        `Production run ${input.production_run_id} not found`
+      )
+    }
+    if (run.status === "cancelled") {
+      throw new MedusaError(
+        MedusaError.Types.NOT_ALLOWED,
+        "Cannot attach media to a cancelled production run"
+      )
+    }
+
+    const existingMeta = (run.metadata as Record<string, any>) || {}
+    const existingMedia: any[] = Array.isArray(existingMeta.attached_media)
+      ? existingMeta.attached_media
+      : []
+
+    const attachment = {
+      url: input.media_url,
+      mime_type: input.media_mime_type ?? null,
+      filename: input.filename ?? null,
+      message_id: input.message_id ?? null,
+      conversation_id: input.conversation_id ?? null,
+      attached_by: "admin",
+      attached_at: new Date().toISOString(),
+    }
+
+    await service.updateProductionRuns({
+      id: run.id,
+      metadata: {
+        ...existingMeta,
+        attached_media: [...existingMedia, attachment],
+      },
+    })
+
+    // Audit note — best-effort, never fails the attachment.
+    try {
+      await service.createProductionRunActivities({
+        production_run_id: run.id,
+        activity_type: "note",
+        kind: "media_attached",
+        actor_type: "admin",
+        actor_id: input.actor_id ?? null,
+        partner_id: run.partner_id ?? null,
+        channel: input.message_id ? "whatsapp" : null,
+        message_id: input.message_id ?? null,
+        template_name: null,
+        recipient: null,
+        summary: `Media attached: ${input.filename || input.media_url.split("/").pop() || "file"}`,
+        payload: {
+          media_url: input.media_url,
+          media_mime_type: input.media_mime_type ?? null,
+          filename: input.filename ?? null,
+          from_message_id: input.message_id ?? null,
+          from_conversation_id: input.conversation_id ?? null,
+          source: "messaging_inbox",
+        },
+        occurred_at: new Date(),
+      } as any)
+    } catch {
+      // Best-effort audit
+    }
+
+    const updated = await service.retrieveProductionRun(run.id)
+
+    return new StepResponse(
+      { production_run: updated, design_id: run.design_id ?? null },
+      { id: run.id, prev_metadata: run.metadata ?? null }
+    )
+  },
+  async (comp: RunAttachComp, { container }) => {
+    const service: ProductionRunService = container.resolve(PRODUCTION_RUNS_MODULE)
+    await service.updateProductionRuns({
+      id: comp.id,
+      metadata: comp.prev_metadata,
+    })
+  }
+)
+
+type DesignAttachComp = {
+  id: string | null
+  prev_media_files: any[] | null
+}
+
+/**
+ * Mirror the media onto the design's gallery. Deliberately best-effort and
+ * non-failing: a retail-minted run has no `design_id`, and the run attachment
+ * is the primary action, so a missing design is a skip, not an error.
+ */
+const attachMediaToDesignStep = createStep<
+  { design_id: string | null; media_url: string },
+  { design: any },
+  DesignAttachComp
+>(
+  "attach-media-to-design",
+  async (
+    input,
+    { container }
+  ): Promise<StepResponse<{ design: any }, DesignAttachComp>> => {
+    const skip = (): StepResponse<{ design: any }, DesignAttachComp> =>
+      new StepResponse({ design: null }, { id: null, prev_media_files: null })
+
+    if (!input.design_id) {
+      return skip()
+    }
+
+    try {
+      const service: DesignService = container.resolve(DESIGN_MODULE)
+      const design = (await service
+        .retrieveDesign(input.design_id)
+        .catch(() => null)) as any
+      if (!design) {
+        return skip()
+      }
+
+      const existing: any[] = Array.isArray(design.media_files)
+        ? design.media_files
+        : []
+      const seen = new Set<string>(
+        existing.map((m) => m?.url).filter(Boolean)
+      )
+      if (seen.has(input.media_url)) {
+        return new StepResponse(
+          { design },
+          { id: design.id, prev_media_files: design.media_files ?? null }
+        )
+      }
+
+      const mergedMedia = [
+        ...existing,
+        { url: input.media_url, isThumbnail: false },
+      ]
+      await service.updateDesigns({
+        id: design.id,
+        media_files: mergedMedia,
+      } as any)
+
+      const updated = await service.retrieveDesign(design.id)
+      return new StepResponse(
+        { design: updated },
+        { id: design.id, prev_media_files: design.media_files ?? null }
+      )
+    } catch {
+      // Best-effort — the run attachment already succeeded.
+      return skip()
+    }
+  },
+  async (comp, { container }) => {
+    if (!comp?.id) return
+    const service: DesignService = container.resolve(DESIGN_MODULE)
+    await service.updateDesigns({
+      id: comp.id,
+      media_files: comp.prev_media_files,
+    } as any)
+  }
+)
+
+export const attachMediaToProductionRunWorkflow = createWorkflow(
+  "attach-media-to-production-run",
+  (input: AttachMediaToProductionRunInput) => {
+    const runResult = attachMediaToRunStep(input)
+    const designResult = attachMediaToDesignStep({
+      design_id: runResult.design_id,
+      media_url: input.media_url,
+    })
+    return new WorkflowResponse({
+      production_run: runResult.production_run,
+      design: designResult.design,
+    })
+  }
+)
+
+export default attachMediaToProductionRunWorkflow


### PR DESCRIPTION
## What

Follow-up to #1378 (which merged the modal change and the inline attach-media logic). This PR moves the attach-media logic out of the route and into a single compensatable workflow, and adds HTTP integration coverage.

- **`attachMediaToProductionRunWorkflow`** (`src/workflows/production-runs/attach-media-to-production-run.ts`)
  - `attach-media-to-run`: validates the run (404 missing / 400 cancelled), appends to `run.metadata.attached_media`, writes the `media_attached` activity note; compensates by restoring prior metadata.
  - `attach-media-to-design`: best-effort mirror onto `design.media_files` (deduped by url, skips when the run has no design); compensates by restoring prior media.
- **Route** (`attach-media/route.ts`) now validates the body and fans out one workflow run, returning `{ production_run, design, message }`.

- **Tests** (`integration-tests/http/production-run-attach-media.spec.ts`) cover: run+design mirror, activity note, URL de-duplication, and the cancelled/missing/non-URL guards.

## Why

The multi-write attach flow (run metadata + activity + design mirror) belongs in a compensatable workflow rather than inline in the route.

## Test

- `pnpm --filter @jyt/backend test:integration:http -- --testPathPattern="production-run-attach-media"` — 5 passing.