### PR TITLE
fix(fx): fanout dropped quantity bounds, so bulk tiers were base-currency only

### DIFF
--- a/apps/backend/src/workflows/fx/__tests__/fanout-tier-key.unit.spec.ts
+++ b/apps/backend/src/workflows/fx/__tests__/fanout-tier-key.unit.spec.ts
@@ -1,0 +1,53 @@
+import { tierKey } from "../fanout-prices"
+
+/**
+ * `tierKey` is the identity of a price WITHIN a price set. The FX fanout uses
+ * it three times — to decide which (currency, tier) pairs already exist, to
+ * pick the rows `addPrices` just created, and to zip each converted row to its
+ * `fx_price_meta`. All three were keyed on currency ALONE before tiered
+ * pricing existed, which is why bulk breaks survived only in the base currency:
+ * the 50+ tier saw `usd` already present from the 1-49 tier and skipped, and
+ * when the per-price fanouts raced instead, a currency ended up with several
+ * unbounded rows and no boundaries at all (observed on prod: 3 AUD rows, each
+ * min_quantity/max_quantity null).
+ */
+describe("tierKey", () => {
+  it("separates tiers of the same currency", () => {
+    expect(tierKey("usd", 1, 49)).not.toBe(tierKey("usd", 50, 199))
+    expect(tierKey("usd", 50, 199)).not.toBe(tierKey("usd", 200, null))
+  })
+
+  it("separates currencies at the same tier", () => {
+    expect(tierKey("usd", 50, 199)).not.toBe(tierKey("aud", 50, 199))
+  })
+
+  // The bug this guards: bounds are BigNumberValue. `query.graph` returns them
+  // as strings, we set them as numbers. If those two don't collapse, every
+  // fanout believes the tier is missing and re-creates it.
+  it("collapses string and number bounds to the same key", () => {
+    expect(tierKey("usd", "50", "199")).toBe(tierKey("usd", 50, 199))
+    expect(tierKey("usd", "200", null)).toBe(tierKey("usd", 200, null))
+  })
+
+  it("is case-insensitive on the currency", () => {
+    expect(tierKey("USD", 1, 49)).toBe(tierKey("usd", 1, 49))
+  })
+
+  it("treats null, undefined and empty string as unbounded alike", () => {
+    const unbounded = tierKey("usd", null, null)
+    expect(tierKey("usd", undefined, undefined)).toBe(unbounded)
+    expect(tierKey("usd", "", "")).toBe(unbounded)
+  })
+
+  // An unbounded price is a DIFFERENT offer from one that starts at 1 — the
+  // legacy untiered rows are unbounded, so this must not collapse or the
+  // fanout would treat an existing plain price as covering the 1-49 tier.
+  it("keeps an unbounded price distinct from a bounded one", () => {
+    expect(tierKey("usd", null, null)).not.toBe(tierKey("usd", 1, 49))
+    expect(tierKey("usd", null, null)).not.toBe(tierKey("usd", 1, null))
+  })
+
+  it("distinguishes a min-only tier from a min+max tier", () => {
+    expect(tierKey("usd", 200, null)).not.toBe(tierKey("usd", 200, 999))
+  })
+})

--- a/apps/backend/src/workflows/fx/fanout-prices.ts
+++ b/apps/backend/src/workflows/fx/fanout-prices.ts
@@ -48,6 +48,20 @@ import FxRatesService from "../../modules/fx_rates/service"
  *   step throws so the workflow reports failure to the subscriber.
  */
 
+/**
+ * Identity of a price WITHIN a price set: currency plus its quantity bounds.
+ *
+ * Bounds arrive as BigNumberValue — a string from `query.graph`, a number when
+ * we set it ourselves — so `50` and `"50"` must collapse to the same key or a
+ * tier is re-created on every fanout. `null`/`undefined` (an unbounded price)
+ * normalises to the empty string, which is distinct from any numeric bound.
+ */
+export const tierKey = (currency: string, min: any, max: any): string => {
+  const norm = (v: any) =>
+    v === null || v === undefined || v === "" ? "" : String(Number(v))
+  return `${String(currency).toLowerCase()}|${norm(min)}|${norm(max)}`
+}
+
 export type FanoutPricesInput = {
   /** Source price id (the one the partner just set). */
   source_price_id: string
@@ -97,6 +111,12 @@ const fanoutPricesStep = createStep(
         "amount",
         "currency_code",
         "price_set_id",
+        // Quantity bounds make a price a TIER. Without them the fanout
+        // converted each tier into an unbounded row per currency, so bulk
+        // breaks existed in the base currency only and every other currency
+        // got N overlapping prices with no boundaries (#B2B tiered pricing).
+        "min_quantity",
+        "max_quantity",
         "fx_price_meta.id",
       ],
     })
@@ -170,20 +190,28 @@ const fanoutPricesStep = createStep(
       return new StepResponse(output)
     }
 
-    // 4. Find which currencies in the price_set are already priced.
+    // 4. Find which (currency, tier) pairs in the price_set are already
+    //    priced. Keying on currency ALONE was wrong once tiers existed: the
+    //    50+ tier would see `usd` present from the 1-49 tier and skip, so a
+    //    price set either lost tiers or — when the per-price fanouts raced —
+    //    gained several unbounded rows in the same currency.
     const { data: existingPrices } = await query.graph({
       entity: "price",
       filters: { price_set_id: source.price_set_id },
-      fields: ["id", "currency_code"],
+      fields: ["id", "currency_code", "min_quantity", "max_quantity"],
     })
     const alreadyPriced = new Set(
       (existingPrices ?? []).map((p: any) =>
-        String(p.currency_code).toLowerCase()
+        tierKey(p.currency_code, p.min_quantity, p.max_quantity)
       )
     )
 
     const sourceCurrency = String(source.currency_code).toLowerCase()
     const sourceAmount = Number(source.amount)
+    // The tier this source price belongs to. Converted rows must carry the
+    // SAME bounds — an converted amount without them is not the same offer.
+    const sourceMinQty = source.min_quantity ?? null
+    const sourceMaxQty = source.max_quantity ?? null
 
     // 5. For each missing currency, compute converted amount.
     const newPrices: Array<{
@@ -195,7 +223,7 @@ const fanoutPricesStep = createStep(
     for (const sc of supportedCurrencies) {
       const target = String(sc.currency_code).toLowerCase()
       if (target === sourceCurrency) continue
-      if (alreadyPriced.has(target)) {
+      if (alreadyPriced.has(tierKey(target, sourceMinQty, sourceMaxQty))) {
         output.skipped_currencies.push(target)
         continue
       }
@@ -233,6 +261,9 @@ const fanoutPricesStep = createStep(
         prices: newPrices.map((p) => ({
           amount: p.amount,
           currency_code: p.currency_code,
+          // Carry the source tier's bounds onto the converted row.
+          ...(sourceMinQty !== null ? { min_quantity: sourceMinQty } : {}),
+          ...(sourceMaxQty !== null ? { max_quantity: sourceMaxQty } : {}),
         })),
       })
     } catch (err) {
@@ -246,11 +277,19 @@ const fanoutPricesStep = createStep(
       return new StepResponse(output)
     }
 
-    const createdPrices: Array<{ id: string; currency_code: string }> = (
-      returnedPriceSet?.prices ?? []
-    ).filter((p: any) => {
-      const c = String(p.currency_code).toLowerCase()
-      return newPrices.some((np) => np.currency_code === c)
+    // Match on (currency, tier), not currency alone. A tiered price set holds
+    // several rows per currency, so a currency-only match would also pick up
+    // OTHER tiers' rows and zip their fx_price_meta to the wrong price.
+    const createdPrices: Array<{
+      id: string
+      currency_code: string
+      min_quantity?: any
+      max_quantity?: any
+    }> = (returnedPriceSet?.prices ?? []).filter((p: any) => {
+      const k = tierKey(p.currency_code, p.min_quantity, p.max_quantity)
+      return newPrices.some(
+        (np) => tierKey(np.currency_code, sourceMinQty, sourceMaxQty) === k
+      )
     })
 
     // 7. Write FxPriceMeta rows + Medusa links. One row + one link
@@ -258,7 +297,9 @@ const fanoutPricesStep = createStep(
     const metasToCreate = createdPrices
       .map((p) => {
         const match = newPrices.find(
-          (np) => np.currency_code === String(p.currency_code).toLowerCase()
+          (np) =>
+            tierKey(np.currency_code, sourceMinQty, sourceMaxQty) ===
+            tierKey(p.currency_code, p.min_quantity, p.max_quantity)
         )
         if (!match) return null
         return {


### PR DESCRIPTION
Prerequisite for B2B bulk pricing.

## What already works

Medusa's pricing module supports `min_quantity`/`max_quantity` natively and `calculatePrices` takes a quantity context. The partner `variants/batch` route has **no body validator**, so the bounds already pass straight through — **tiered pricing needs no new write path.**

Verified on prod: three INR breaks (1-49 @ ₹1000, 50-199 @ ₹850, 200+ @ ₹700) persisted and round-tripped on an independent read-back.

## What broke it

The FX fanout selected only `["amount", "currency_code"]` off the source price and created each converted row with just those two fields. Every foreign-currency row came out unbounded.

Observed on prod — 3 tiers × 5 currencies = 15 converted rows, **every one `min_quantity: null, max_quantity: null`**:

```
aud amount=12.49 min=null max=null
aud amount=14.7  min=null max=null
aud amount=10.29 min=null max=null      <- three overlapping AUD prices,
inr amount=1000  min=1   max=49             no boundary to choose between
inr amount=850   min=50  max=199
inr amount=700   min=200 max=null
```

Tiers worked in INR and nowhere else. The partner storefront sells in six currencies, so this blocked bulk pricing for every non-Indian buyer — exactly the B2B audience.

## The fix

Keying on currency alone was wrong in **three** places once tiers exist:

1. the already-priced check — the 50+ tier sees `usd` present from the 1-49 tier and skips (or, when the per-price fanouts race, doesn't, which is how three unbounded AUD rows appeared)
2. picking the rows `addPrices` returned
3. zipping each converted row to its `fx_price_meta` — a currency-only match would attach FX metadata to **another tier's price**

All three now key on `(currency, min_quantity, max_quantity)` via `tierKey`, and the source tier's bounds are carried onto the converted rows.

`tierKey` normalises BigNumberValue so `50` and `"50"` collapse — `query.graph` returns strings, we write numbers, and if those diverged every fanout would re-create the tier forever. Unbounded stays distinct from a `1-49` bound, so legacy untiered rows are not mistaken for a first tier.

## Tests

Unit spec locks the key's identity rules (tier separation, currency separation, string/number collapse, unbounded-vs-bounded). `check:prod-build` passes; fx suites 19/19.

⚠️ The unit spec covers the key, not the end-to-end fanout — that part is workflow-driven. **The defect was found by probing prod, not by tests, so it should be re-verified the same way after deploy**: set tiers on a probe variant, read back, confirm the converted rows carry bounds.

🤖 Generated with [Claude Code](https://claude.com/claude-code)