### PR TITLE
feat(store): public freight estimate for a bulk quantity

### DIFF
--- a/apps/backend/integration-tests/http/store-shipping-estimate.spec.ts
+++ b/apps/backend/integration-tests/http/store-shipping-estimate.spec.ts
@@ -1,0 +1,149 @@
+import { createAdminUser, getAuthHeaders } from "../helpers/create-admin-user"
+import { createTestCustomer } from "../helpers/create-customer"
+import { getSharedTestEnv, setupSharedTestSuite } from "./shared-test-setup"
+
+jest.setTimeout(120000)
+
+/**
+ * GET /store/shipping-estimate (#1389) — the public freight estimate a business
+ * buyer sees before committing to a bulk order.
+ *
+ * The assertion that matters most here is the REFUSAL. A variant with no
+ * shipping weight must produce an error naming the variant, never a quote built
+ * on a guessed weight: 11 of 33 variants on prod have no weight today, and a
+ * guessed number here is a freight cost a buyer makes a purchasing decision on.
+ * The internal fulfilment path does estimate (order 83 hit exactly that), which
+ * is why this route's opposite behaviour needs locking rather than assuming.
+ *
+ * Carrier rates are not asserted — no live carrier is registered in the test
+ * app — but the route must still answer with the manual tier and report the
+ * carrier failure in `calculated_error` rather than 500ing, which is asserted.
+ */
+setupSharedTestSuite(() => {
+  const { api, getContainer } = getSharedTestEnv()
+
+  describe("GET /store/shipping-estimate", () => {
+    let pk: string
+    let adminHeaders: any
+    let weightlessVariantId: string
+    let weighedVariantId: string
+
+    const storeHeaders = () => ({ headers: { "x-publishable-api-key": pk } })
+
+    beforeAll(async () => {
+      const container = getContainer()
+      await createAdminUser(container)
+      adminHeaders = await getAuthHeaders(api)
+      const { apiKey } = await createTestCustomer(container)
+      pk = apiKey.token
+
+      // Give the store a pickup location that has a postal code — the origin
+      // the estimate quotes from.
+      const loc = await api.post(
+        "/admin/stock-locations",
+        {
+          name: "Estimate Origin",
+          address: {
+            address_1: "1 Loom Street",
+            city: "Srinagar",
+            country_code: "in",
+            postal_code: "190001",
+          },
+        },
+        adminHeaders
+      )
+      const locationId = loc.data.stock_location.id
+
+      const storeService: any = container.resolve("store")
+      const [store] = await storeService.listStores({}, { take: 1 })
+      await storeService.updateStores({
+        id: store.id,
+        default_location_id: locationId,
+      })
+
+      const product = await api.post(
+        "/admin/products",
+        {
+          title: "Estimate Probe Shawl",
+          status: "published",
+          options: [{ title: "Spin", values: ["Hand", "Mill"] }],
+          variants: [
+            {
+              title: "Hand",
+              manage_inventory: false,
+              options: { Spin: "Hand" },
+              prices: [{ currency_code: "inr", amount: 1000 }],
+            },
+            {
+              title: "Mill",
+              manage_inventory: false,
+              options: { Spin: "Mill" },
+              weight: 250,
+              prices: [{ currency_code: "inr", amount: 900 }],
+            },
+          ],
+        },
+        adminHeaders
+      )
+      const variants = product.data.product.variants
+      weightlessVariantId = variants.find((v: any) => v.title === "Hand").id
+      weighedVariantId = variants.find((v: any) => v.title === "Mill").id
+    })
+
+    // The whole point of the route's design.
+    it("REFUSES to quote a variant with no shipping weight", async () => {
+      const res = await api
+        .get(
+          `/store/shipping-estimate?variant_id=${weightlessVariantId}&quantity=200&destination_postal_code=110001&country_code=in`,
+          storeHeaders()
+        )
+        .catch((e: any) => e.response)
+
+      expect(res.status).toBe(400)
+      // Names the variant so the catalogue gap is actionable, and says what to
+      // do about it rather than just failing.
+      expect(res.data.message).toMatch(/no shipping weight/i)
+      expect(res.data.message).toMatch(/Set a weight/i)
+    })
+
+    it("quotes total weight as unit weight x quantity", async () => {
+      const res = await api.get(
+        `/store/shipping-estimate?variant_id=${weighedVariantId}&quantity=200&destination_postal_code=110001&country_code=in`,
+        storeHeaders()
+      )
+
+      expect(res.status).toBe(200)
+      const est = res.data.estimate
+      expect(est.unit_weight_grams).toBe(250)
+      expect(est.total_weight_grams).toBe(250 * 200)
+      expect(est.origin_postal_code).toBe("190001")
+      expect(est.destination_postal_code).toBe("110001")
+      // Never presented as a final price.
+      expect(est.is_estimate).toBe(true)
+    })
+
+    // A carrier that cannot quote must degrade, not 500 — the manual tier is
+    // still a real answer for the buyer.
+    it("survives a carrier that cannot quote", async () => {
+      const res = await api.get(
+        `/store/shipping-estimate?variant_id=${weighedVariantId}&quantity=10&destination_postal_code=110001&country_code=in`,
+        storeHeaders()
+      )
+
+      expect(res.status).toBe(200)
+      expect(Array.isArray(res.data.estimate.calculated)).toBe(true)
+      expect(Array.isArray(res.data.estimate.manual)).toBe(true)
+    })
+
+    it("rejects a nonsensical quantity", async () => {
+      const res = await api
+        .get(
+          `/store/shipping-estimate?variant_id=${weighedVariantId}&quantity=0&destination_postal_code=110001`,
+          storeHeaders()
+        )
+        .catch((e: any) => e.response)
+
+      expect(res.status).toBe(400)
+    })
+  })
+})

--- a/apps/backend/src/api/middlewares.ts
+++ b/apps/backend/src/api/middlewares.ts
@@ -214,6 +214,7 @@ import { TestBlogEmailSchema } from "./admin/websites/[id]/pages/[pageId]/subs/t
 import { listSocialPlatformsQuerySchema, SocialPlatformSchema, UpdateSocialPlatformSchema, ConnectWhatsAppSchema } from "./admin/social-platforms/validators";
 import { CreateDeploymentAccountSchema, UpdateDeploymentAccountSchema, ListDeploymentAccountsQuerySchema } from "./admin/deployment-accounts/validators";
 import { StoreAiSearchSchema } from "./store/ai/search/validators";
+import { StoreShippingEstimateSchema } from "./store/shipping-estimate/validators";
 import { StoreAiChatSchema } from "./store/ai/chat/validators";
 import { StoreGenerateAiImageReqSchema } from "./store/ai/imagegen/validators";
 import { StoreTryOnReqSchema } from "./store/ai/tryon/validators";
@@ -4472,6 +4473,19 @@ export default defineMiddlewares({
       middlewares: [
         authenticate("customer", ["session", "bearer"]),
         validateAndTransformBody(wrapSchema(AccessFeeConfirmSchema)),
+      ],
+    },
+
+    // Public freight estimate for a bulk quantity (#1389). Scoped to a store
+    // by the publishable key's sales channel — which IDENTIFIES the storefront
+    // but does not protect the route: the key ships in the browser bundle. The
+    // route is built to be cheap to hammer (manual options cost no carrier
+    // call; calculated rates are cached per lane) rather than hard to reach.
+    {
+      matcher: "/store/shipping-estimate",
+      method: "GET",
+      middlewares: [
+        validateAndTransformQuery(wrapSchema(StoreShippingEstimateSchema), {}),
       ],
     },
 

--- a/apps/backend/src/api/store/shipping-estimate/route.ts
+++ b/apps/backend/src/api/store/shipping-estimate/route.ts
@@ -1,0 +1,208 @@
+import { MedusaRequest, MedusaResponse } from "@medusajs/framework/http"
+import { ContainerRegistrationKeys, MedusaError, Modules } from "@medusajs/framework/utils"
+
+import { getStoreFromPublishableKey } from "../helpers"
+import { resolveShippingProvider } from "../../../modules/shipping-providers/resolver"
+
+/**
+ * GET /store/shipping-estimate
+ *
+ * Public, storefront-facing freight estimate for a quantity of one variant —
+ * the number a business buyer needs before committing to a bulk order (#1389).
+ *
+ * SCOPING, AND WHAT IT IS NOT
+ * ---------------------------
+ * The store is resolved from the publishable key's sales channel, the same way
+ * every other store route scopes itself. ⚠️ That is IDENTIFICATION, not
+ * protection: the key ships inside the storefront's JS bundle
+ * (`NEXT_PUBLIC_MEDUSA_PUBLISHABLE_KEY`) and is visible in any browser's
+ * network tab. Anyone can lift it. So this route is designed to be cheap to
+ * hammer rather than hard to reach:
+ *
+ *   - manual/flat options are read from the DB and cost NO carrier call at all,
+ *     which is the common case;
+ *   - calculated rates are cached per (carrier, origin, destination, weight
+ *     bucket), so repeated quotes for the same lane hit the cache, not the
+ *     provider.
+ *
+ * There is no HTTP rate limiter here because the store API has none anywhere
+ * yet; adding one is a separate piece of infrastructure, tracked on #1389.
+ *
+ * 🔑 WEIGHT IS REFUSED, NEVER GUESSED
+ * The order-83 path estimates a weight when no variant carries one, and that is
+ * fine for an internal fulfilment retry. It is NOT fine here: a guessed weight
+ * becomes a freight number a buyer decides on. A variant without a weight gets
+ * a 422 naming the variant, so the gap is fixed in the catalogue rather than
+ * papered over in the quote.
+ */
+export const GET = async (req: MedusaRequest, res: MedusaResponse) => {
+  const query = req.scope.resolve(ContainerRegistrationKeys.QUERY)
+  const logger: any = req.scope.resolve(ContainerRegistrationKeys.LOGGER)
+
+  const {
+    variant_id: variantId,
+    quantity: rawQuantity,
+    destination_postal_code: destinationPostalCode,
+    country_code: rawCountryCode,
+    carrier: rawCarrier,
+  } = req.validatedQuery as Record<string, any>
+
+  const quantity = Number(rawQuantity)
+  const countryCode = String(rawCountryCode || "in").toLowerCase()
+
+  const store = await getStoreFromPublishableKey(
+    (req as any).publishable_key_context || { sales_channel_ids: [] },
+    req.scope
+  )
+  if (!store) {
+    throw new MedusaError(
+      MedusaError.Types.NOT_FOUND,
+      "No store is linked to this publishable key's sales channel"
+    )
+  }
+
+  // ---- Weight ------------------------------------------------------------
+  const { data: variants } = await query.graph({
+    entity: "variant",
+    fields: ["id", "title", "weight", "product.id", "product.title"],
+    filters: { id: variantId },
+  })
+  const variant = variants?.[0] as any
+  if (!variant) {
+    throw new MedusaError(
+      MedusaError.Types.NOT_FOUND,
+      `Variant ${variantId} not found`
+    )
+  }
+
+  const unitWeight = Number(variant.weight)
+  if (!unitWeight || Number.isNaN(unitWeight) || unitWeight <= 0) {
+    // Deliberately a refusal, not a fallback. See the header.
+    throw new MedusaError(
+      MedusaError.Types.INVALID_DATA,
+      `Variant "${variant.title || variant.id}" has no shipping weight, so freight cannot be quoted for it. Set a weight on the variant first.`
+    )
+  }
+  const weightGrams = Math.round(unitWeight * quantity)
+
+  // ---- Origin ------------------------------------------------------------
+  const { data: locations } = await query.graph({
+    entity: "stock_locations",
+    fields: ["id", "name", "address.postal_code", "address.country_code"],
+    filters: { id: store.default_location_id },
+  })
+  const originPostalCode = String(
+    (locations?.[0] as any)?.address?.postal_code || ""
+  ).trim()
+  if (!originPostalCode) {
+    throw new MedusaError(
+      MedusaError.Types.INVALID_DATA,
+      "This store's pickup location has no postal code, so freight cannot be quoted. Add one to the location."
+    )
+  }
+
+  // ---- Manual / flat options — no carrier call ---------------------------
+  const { data: optionLocations } = await query.graph({
+    entity: "stock_locations",
+    fields: [
+      "id",
+      "fulfillment_sets.service_zones.shipping_options.id",
+      "fulfillment_sets.service_zones.shipping_options.name",
+      "fulfillment_sets.service_zones.shipping_options.price_type",
+      "fulfillment_sets.service_zones.shipping_options.prices.*",
+    ],
+    filters: { id: store.default_location_id },
+  })
+
+  const manual: any[] = []
+  for (const fs of (optionLocations?.[0] as any)?.fulfillment_sets || []) {
+    for (const zone of fs?.service_zones || []) {
+      for (const so of zone?.shipping_options || []) {
+        if (so?.price_type === "calculated") continue
+        for (const price of so?.prices || []) {
+          // Only currency-scoped flat prices are meaningful without a cart;
+          // region-scoped ones need a region the estimate does not have.
+          if (!price?.currency_code) continue
+          manual.push({
+            shipping_option_id: so.id,
+            name: so.name,
+            amount: Number(price.amount),
+            currency_code: String(price.currency_code).toLowerCase(),
+            source: "manual",
+          })
+        }
+      }
+    }
+  }
+
+  // ---- Calculated rates — cached per lane --------------------------------
+  const carrier = String(rawCarrier || "shiprocket").toLowerCase()
+  // Bucket the weight so near-identical quantities share a cache entry rather
+  // than minting one per quantity a buyer drags a slider through.
+  const weightBucket = Math.ceil(weightGrams / 500) * 500
+  const cacheKey = `shipping-estimate:${carrier}:${originPostalCode}:${destinationPostalCode}:${countryCode}:${weightBucket}`
+
+  let calculated: any[] = []
+  let calculatedError: string | null = null
+  let cacheHit = false
+
+  const cacheService: any = req.scope.resolve(Modules.CACHE)
+  const cached = await cacheService.get(cacheKey).catch(() => null)
+  if (cached) {
+    calculated = cached as any[]
+    cacheHit = true
+  } else {
+    try {
+      const provider = await resolveShippingProvider(req.scope, carrier)
+      if (!provider.getRates) {
+        throw new MedusaError(
+          MedusaError.Types.NOT_ALLOWED,
+          `${carrier} does not support rate quotes`
+        )
+      }
+      const rates = await provider.getRates({
+        origin_pincode: originPostalCode,
+        destination_pincode: String(destinationPostalCode),
+        destination_country: countryCode,
+        weight_grams: weightBucket,
+      })
+      calculated = (rates || []).map((r: any) => ({
+        courier_id: r.courier_id ?? null,
+        courier_name: r.courier_name ?? null,
+        amount: Number(r.amount),
+        currency_code: String(r.currency_code || "inr").toLowerCase(),
+        estimated_days: r.estimated_days ?? null,
+        is_recommended: !!r.is_recommended,
+        source: "calculated",
+      }))
+      await cacheService.set(cacheKey, calculated, 900).catch(() => {})
+    } catch (err) {
+      // A carrier that will not quote must not blank the whole estimate — the
+      // manual options are still a real, quotable answer.
+      calculatedError = err instanceof Error ? err.message : String(err)
+      logger?.warn?.(
+        `[store/shipping-estimate] ${carrier} rates failed for ${originPostalCode}->${destinationPostalCode}: ${calculatedError}`
+      )
+    }
+  }
+
+  res.json({
+    estimate: {
+      variant_id: variant.id,
+      product_title: variant.product?.title ?? null,
+      quantity,
+      unit_weight_grams: unitWeight,
+      total_weight_grams: weightGrams,
+      origin_postal_code: originPostalCode,
+      destination_postal_code: String(destinationPostalCode),
+      country_code: countryCode,
+      manual,
+      calculated,
+      calculated_error: calculatedError,
+      cache_hit: cacheHit,
+      // Never present these as a final price: carrier rates move, and the
+      // manual tier is a placeholder the partner is expected to edit.
+      is_estimate: true,
+    },
+  })
+}

--- a/apps/backend/src/api/store/shipping-estimate/validators.ts
+++ b/apps/backend/src/api/store/shipping-estimate/validators.ts
@@ -1,0 +1,22 @@
+import { z } from "zod"
+
+/**
+ * Query for the public freight estimate (#1389).
+ *
+ * Everything arrives as a string on a GET, so numerics are coerced. `quantity`
+ * is capped: this is a bulk-order estimate, but an unbounded quantity is just a
+ * way to mint unique cache keys and drive carrier calls from a public route.
+ */
+export const StoreShippingEstimateSchema = z.object({
+  variant_id: z.string().min(1),
+  quantity: z.coerce.number().int().positive().max(100000),
+  destination_postal_code: z.string().min(3).max(16),
+  /** ISO-2. Drives the domestic-vs-cross-border branch inside the adapter. */
+  country_code: z.string().min(2).max(2).optional(),
+  /** Defaults to the aggregator, which returns every courier on the lane. */
+  carrier: z.string().min(2).max(40).optional(),
+})
+
+export type StoreShippingEstimateReq = z.infer<
+  typeof StoreShippingEstimateSchema
+>


### PR DESCRIPTION
First backend piece of the B2B bulk-order page (#1389). A business buyer sets a quantity and destination on a product link and sees what the freight actually costs — no account, no cart.

```
GET /store/shipping-estimate
  ?variant_id=…&quantity=200&destination_postal_code=…&country_code=in
  x-publishable-api-key: pk_…
→ { estimate: { manual: [...], calculated: [...], total_weight_grams, is_estimate: true } }
```

Returns the store's **manual/flat** options *and* **live calculated** carrier rates. `is_estimate: true` is deliberate — carrier rates move, and the manual tier is a placeholder the partner is expected to edit. Neither is a final price.

## Scoping is not protection

The store resolves from the publishable key's sales channel, like every other store route. That **identifies** the storefront but does **not** protect the route: the key is `NEXT_PUBLIC_MEDUSA_PUBLISHABLE_KEY`, ships inside the browser bundle, and is visible in any network tab. Anyone can lift it.

So the route is built to be **cheap to hammer** rather than hard to reach:

- manual/flat options are read from the DB and cost **no carrier call** — the common case
- calculated rates are cached 15m per `(carrier, origin, destination, weight bucket)`
- weight is bucketed to 500g, so dragging a quantity slider shares cache entries instead of minting one carrier call per quantity

No HTTP rate limiter here: **the store API has none anywhere yet**, so that is separate infrastructure rather than something to invent in this PR. Tracked on #1389.

## Weight is refused, never guessed

A variant with no weight gets an error naming it, not a quote.

The internal fulfilment path *does* estimate a weight when none is set — order 83 hit exactly that — which is right for a fulfilment retry and wrong here. **11 of 33 variants on prod have no weight**, and a guessed number becomes freight a buyer makes a purchasing decision on. The error says which variant and what to do about it, so the catalogue gap gets fixed rather than papered over.

## Degradation

A carrier that cannot quote does not blank the estimate: the manual tier still answers and the failure is reported in `calculated_error`. A partial answer beats none.

## Tests

Refusal, weight arithmetic (`unit × quantity`), carrier-failure degradation, bad quantity — 4/4. Carrier rates themselves aren't asserted (no live carrier is registered in the test app), which is why the degradation path is asserted instead.

`tsc` at the 75 baseline; `check:prod-build` passes.

## Follow-ups on #1389

- storefront quantity + destination UI
- rate limiting for the store API
- `weave_label` derivation so the spec renders "Pashmina plain", not `pashmina-plain`

🤖 Generated with [Claude Code](https://claude.com/claude-code)