### PR TITLE
fix(mcp): weight was silently stripped from every variant write, + bulk spec, assistant identity, orphan-store job

### DIFF
--- a/apps/backend/src/api/admin/mcp/lib/__tests__/tool-tiers.unit.spec.ts
+++ b/apps/backend/src/api/admin/mcp/lib/__tests__/tool-tiers.unit.spec.ts
@@ -92,6 +92,11 @@ describe("admin MCP tool tiers", () => {
       [
         "add_design_construction_detail",
         "add_inventory_raw_material",
+        // Same rule as set_product_spec, which it batches: a spec spends no
+        // money, calls no carrier and messages nobody. It stays `sensitive`,
+        // so the confirm gate still applies — and it needs that gate more than
+        // the single tool does, since one call can overwrite a hundred specs.
+        "bulk_set_product_spec",
         "create_crm_company",
         "create_crm_contact",
         "create_crm_opportunity",

--- a/apps/backend/src/api/admin/mcp/lib/registry.ts
+++ b/apps/backend/src/api/admin/mcp/lib/registry.ts
@@ -246,6 +246,64 @@ export const ADMIN_MCP_TOOLS: AdminMcpToolDef[] = [
       "Replaces the stored palette and custom fields when those keys are passed. The spec is the maker's own record of the product — check with the partner before overwriting one they authored.",
     nextSteps: ["get_product_spec"],
   },
+  {
+    name: "bulk_set_product_spec",
+    description: [
+      "Write ONE production spec across MANY products in a single call — the normal case when a run of pieces shares a weave, a parameter set and a palette. Sensitive: requires confirm:true. ALWAYS dry_run first.",
+      "",
+      "TARGETING:",
+      "- `spec` applies to every product listed.",
+      "- `products: [{ product_id, spec }]` — a row's own `spec` wins over the batch-wide one.",
+      "",
+      "Creates a spec where none exists and updates where one does; a mixed batch is fine and each row reports which happened (`created` / `updated`).",
+      "",
+      "⚠️ `colors`, `fields` and `options` REPLACE what is stored when present. The dry-run plan names, per product, which of the three it would replace — read it before confirming.",
+      "",
+      "Returns a PER-ROW outcome: one bad product id never discards the rest. Read `results` and `warnings`, not just the status.",
+      `⚠️ UNSCOPED — this reaches EVERY maker's catalogue, and a spec is the maker's own record of their product. Overwriting a hundred specs someone else authored is not recoverable from here. Capped at 100 products per call. ${PRODUCT_SPEC_WRITE_GUIDANCE}`,
+    ].join("\n"),
+    method: "POST",
+    path: "/admin/products/spec-bulk",
+    write: true,
+    sensitive: true,
+    tier: "write",
+    bodyParams: ["products", "spec", "dry_run"],
+    inputSchema: obj(
+      {
+        products: {
+          type: "array",
+          description:
+            "Products to write. A row's own `spec` wins over the batch-wide `spec`.",
+          items: {
+            type: "object",
+            properties: {
+              product_id: STR("Product id, e.g. 'prod_...'."),
+              spec: {
+                type: "object",
+                description: "Spec for this product only.",
+                properties: productSpecSchemaProps(),
+                additionalProperties: false,
+              },
+            },
+            required: ["product_id"],
+            additionalProperties: false,
+          },
+        },
+        spec: {
+          type: "object",
+          description:
+            "Applied to every row that carries no `spec` of its own. Provide this, or a `spec` on every row.",
+          properties: productSpecSchemaProps(),
+          additionalProperties: false,
+        },
+        dry_run: BOOL("Return the plan without writing. Do this first."),
+      },
+      ["products"]
+    ),
+    sideEffects:
+      "Replaces the stored palette, custom fields and option groups on EVERY listed product when those keys are passed, across any maker's catalogue.",
+    nextSteps: ["get_product_spec"],
+  },
 
   // ===== Customers =========================================================
   {

--- a/apps/backend/src/api/admin/mcp/lib/registry.ts
+++ b/apps/backend/src/api/admin/mcp/lib/registry.ts
@@ -28,6 +28,10 @@
  */
 import type { McpToolDef } from "../../../../lib/mcp-core"
 import {
+  PHYSICAL_AND_CUSTOMS_BODY_PARAMS,
+  physicalAndCustomsSchemaProps,
+} from "../../../../lib/product-attributes/tool-schema"
+import {
   PRODUCT_SPEC_BODY_PARAMS,
   PRODUCT_SPEC_WRITE_GUIDANCE,
   productSpecSchemaProps,
@@ -706,7 +710,18 @@ export const ADMIN_MCP_TOOLS: AdminMcpToolDef[] = [
     previewPath: "/admin/products/:id",
     write: true,
     sensitive: true,
-    bodyParams: ["title", "status", "description", "subtitle", "handle", "metadata"],
+    bodyParams: [
+      "title",
+      "status",
+      "description",
+      "subtitle",
+      "handle",
+      "metadata",
+      // Product-level physical + customs attributes. Core's UpdateProduct
+      // validator accepts all of them. Product-level weight is the fallback the
+      // shipping estimate uses when a variant carries none.
+      ...PHYSICAL_AND_CUSTOMS_BODY_PARAMS,
+    ],
     inputSchema: obj(
       {
         id: STR("Product id, e.g. 'prod_...'."),
@@ -715,6 +730,7 @@ export const ADMIN_MCP_TOOLS: AdminMcpToolDef[] = [
         description: STR("New description."),
         subtitle: STR("New subtitle."),
         handle: STR("New URL handle."),
+        ...physicalAndCustomsSchemaProps(),
         metadata: { type: "object", description: "Metadata to merge." },
       },
       ["id"]
@@ -916,12 +932,13 @@ export const ADMIN_MCP_TOOLS: AdminMcpToolDef[] = [
     bodyParams: [
       "title",
       "sku",
-      "hs_code",
-      "origin_country",
-      "material",
       "manage_inventory",
       "allow_backorder",
       "metadata",
+      // Core's UpdateProductVariant validator accepts all of these; they were
+      // simply never advertised, and the dispatcher drops unlisted keys in
+      // silence. `weight` in particular blocked every freight quote.
+      ...PHYSICAL_AND_CUSTOMS_BODY_PARAMS,
     ],
     inputSchema: obj(
       {
@@ -929,9 +946,7 @@ export const ADMIN_MCP_TOOLS: AdminMcpToolDef[] = [
         id: STR("Variant id, e.g. 'variant_...'."),
         title: STR("New variant title."),
         sku: STR("New SKU."),
-        hs_code: STR("HS/HSN customs code."),
-        origin_country: STR("ISO-2 country of manufacture."),
-        material: STR("Material description."),
+        ...physicalAndCustomsSchemaProps(),
         manage_inventory: { type: "boolean", description: "Track stock for this variant." },
         allow_backorder: { type: "boolean", description: "Allow ordering beyond stock." },
         metadata: { type: "object", description: "Metadata to merge." },

--- a/apps/backend/src/api/admin/ops/maintenance-jobs/__tests__/delete-orphan-store-job.unit.spec.ts
+++ b/apps/backend/src/api/admin/ops/maintenance-jobs/__tests__/delete-orphan-store-job.unit.spec.ts
@@ -1,0 +1,91 @@
+/**
+ * The refusal rules for a destructive job, pinned.
+ *
+ * Everything else in this job is plumbing; the part that matters is which
+ * stores it declines to delete. A store cannot be un-deleted, so each of these
+ * cases is a real outage avoided rather than a tidy invariant.
+ */
+
+import { checkOrphanStoreDeletable, type OrphanStoreFacts } from "../delete-orphan-store-job"
+
+const orphan: OrphanStoreFacts = {
+  store_id: "store_stray",
+  store_name: "Sharhlo Store",
+  has_partner: false,
+  product_count: 0,
+  order_count: 0,
+  stock_level_count: 0,
+  sales_channel_id: "sc_stray",
+  stock_location_id: "sloc_stray",
+  region_id: "reg_shared",
+  is_only_unlinked_store: false,
+}
+
+describe("checkOrphanStoreDeletable", () => {
+  it("allows a genuine orphan", () => {
+    expect(checkOrphanStoreDeletable(orphan)).toEqual({
+      deletable: true,
+      blockers: [],
+    })
+  })
+
+  it("refuses a store that belongs to a partner", () => {
+    const res = checkOrphanStoreDeletable({ ...orphan, has_partner: true })
+    expect(res.deletable).toBe(false)
+    expect(res.blockers[0]).toContain("linked to a partner")
+  })
+
+  it.each([
+    ["products", { product_count: 3 }, "product(s)"],
+    ["orders", { order_count: 1 }, "order(s)"],
+    ["stock", { stock_level_count: 7 }, "inventory level(s)"],
+  ])("refuses a store that still has %s", (_label, patch, needle) => {
+    const res = checkOrphanStoreDeletable({ ...orphan, ...patch })
+    expect(res.deletable).toBe(false)
+    expect(res.blockers.join(" ")).toContain(needle)
+  })
+
+  it("refuses to delete the LAST unlinked store", () => {
+    // The brand store is unlinked by definition. Deleting the only unlinked
+    // store turns resolveBrandLocationId's "found 2" throw into "found 0" —
+    // the job would have caused the very failure it exists to fix.
+    const res = checkOrphanStoreDeletable({
+      ...orphan,
+      is_only_unlinked_store: true,
+    })
+    expect(res.deletable).toBe(false)
+    expect(res.blockers.join(" ")).toContain("ONLY store without a partner link")
+  })
+
+  it("reports every blocker, not just the first", () => {
+    // An operator who clears one reason and re-runs should not meet a second.
+    const res = checkOrphanStoreDeletable({
+      ...orphan,
+      has_partner: true,
+      product_count: 2,
+      order_count: 1,
+      stock_level_count: 4,
+      is_only_unlinked_store: true,
+    })
+    expect(res.deletable).toBe(false)
+    expect(res.blockers).toHaveLength(5)
+  })
+
+  it("does not treat a missing channel or location as a reason to refuse", () => {
+    // A half-built store with no channel is exactly the stray worth removing.
+    const res = checkOrphanStoreDeletable({
+      ...orphan,
+      sales_channel_id: null,
+      stock_location_id: null,
+    })
+    expect(res.deletable).toBe(true)
+  })
+
+  it("never blocks on the region — it is preserved, not consulted", () => {
+    // The shared default region backs ~10 live storefronts. It is never a
+    // deletion candidate, so it must not be a deletion blocker either.
+    expect(
+      checkOrphanStoreDeletable({ ...orphan, region_id: null }).deletable
+    ).toBe(true)
+  })
+})

--- a/apps/backend/src/api/admin/ops/maintenance-jobs/delete-orphan-store-job.ts
+++ b/apps/backend/src/api/admin/ops/maintenance-jobs/delete-orphan-store-job.ts
@@ -1,0 +1,351 @@
+import { ContainerRegistrationKeys, MedusaError } from "@medusajs/framework/utils"
+import { z } from "@medusajs/framework/zod"
+
+import type {
+  MaintenanceChange,
+  MaintenanceJob,
+  MaintenanceJobResult,
+} from "./registry"
+
+/**
+ * Data Plumbing — remove an ORPHAN store: one linked to no partner, holding no
+ * products, no orders and no stock.
+ *
+ * ## Why this job exists
+ *
+ * A partner's store was created twice, two days apart, the first with a
+ * misspelled name. The abandoned one was never linked to a partner and never
+ * used — but it is not inert, because `resolveBrandLocationId()`
+ * (`workflows/consumption-logs/lib/apply-to-inventory.ts`) identifies the
+ * platform's brand store as *the* store with no partner link:
+ *
+ *     if (brandStores.length !== 1) throw ...
+ *
+ * Two unlinked stores therefore make that resolver throw. The same
+ * `is_default: !partner` inference drives `mcp/lib/store-resolver.ts`, which is
+ * why the stray also lists itself as a core storefront on the apex domain.
+ *
+ * There is no store DELETE route in core (`admin/stores/[id]` exports GET and
+ * POST only) and none of our own, which is why this is a job rather than a
+ * one-line curl.
+ *
+ * ## What it will NOT do
+ *
+ * 🔑 **Never the region.** A partner store's `default_region_id` is SHARED —
+ * on prod one region backs ~10 stores — so deleting it would take out live
+ * storefronts. The job deletes the store, and only those of its channel /
+ * location / publishable key that belong to it alone.
+ *
+ * 🔑 **Never a store that is doing anything.** Products, orders, stock levels
+ * or a partner link each abort that store, by name, rather than being reported
+ * as a warning someone might skim past. A store cannot be un-deleted.
+ *
+ * `store_id` is REQUIRED. There is no "find and delete all orphans" mode: an
+ * inferred list of things to destroy is exactly the wrong place for inference,
+ * and the brand store itself is unlinked by definition — a sweep would be one
+ * bad filter away from deleting it.
+ */
+
+const paramsSchema = z.object({
+  /** The store to remove. Required — deliberately no sweep mode. */
+  store_id: z.string().min(1),
+  /**
+   * Also delete the store's own sales channel, stock location and publishable
+   * key when nothing else uses them. Off by default: the store row alone is
+   * what breaks the brand-store inference.
+   */
+  cascade: z.boolean().optional().default(false),
+})
+
+export type OrphanStoreFacts = {
+  store_id: string
+  store_name?: string | null
+  has_partner: boolean
+  product_count: number
+  order_count: number
+  stock_level_count: number
+  sales_channel_id?: string | null
+  stock_location_id?: string | null
+  region_id?: string | null
+  is_only_unlinked_store: boolean
+}
+
+/**
+ * PURE: does this store qualify for deletion, and if not, exactly why.
+ *
+ * Every blocker is returned, not just the first — an operator who fixes one
+ * reason and re-runs should not discover a second on the next pass.
+ */
+export function checkOrphanStoreDeletable(facts: OrphanStoreFacts): {
+  deletable: boolean
+  blockers: string[]
+} {
+  const blockers: string[] = []
+
+  if (facts.has_partner) {
+    blockers.push(
+      `Store ${facts.store_id} IS linked to a partner — this job only removes unlinked strays.`
+    )
+  }
+  if (facts.product_count > 0) {
+    blockers.push(
+      `Store ${facts.store_id} has ${facts.product_count} product(s) on its sales channel.`
+    )
+  }
+  if (facts.order_count > 0) {
+    blockers.push(
+      `Store ${facts.store_id} has ${facts.order_count} order(s) on its sales channel.`
+    )
+  }
+  if (facts.stock_level_count > 0) {
+    blockers.push(
+      `Store ${facts.store_id} has ${facts.stock_level_count} inventory level(s) at its stock location.`
+    )
+  }
+  // The brand store is unlinked BY DEFINITION. If this is the only unlinked
+  // store, deleting it removes the very thing resolveBrandLocationId looks for
+  // — turning a throw about "found 2" into a throw about "found 0".
+  if (facts.is_only_unlinked_store) {
+    blockers.push(
+      `Store ${facts.store_id} is the ONLY store without a partner link, which is how the platform's brand store is identified. Deleting it would break brand-location resolution rather than fix it.`
+    )
+  }
+
+  return { deletable: blockers.length === 0, blockers }
+}
+
+export const deleteOrphanStoreJob: MaintenanceJob = {
+  id: "delete-orphan-store",
+  label: "Delete an orphan store",
+  description:
+    "Remove a store that is linked to no partner and holds no products, orders or stock. Refuses on any of those, and never touches the shared default region. Dry-run reports exactly what it would delete.",
+  params: [
+    {
+      name: "store_id",
+      type: "string",
+      required: true,
+      description: "The store to remove, e.g. 'store_...'.",
+    } as any,
+    {
+      name: "cascade",
+      type: "boolean",
+      required: false,
+      description:
+        "Also delete its own sales channel, stock location and publishable key when nothing else uses them.",
+    } as any,
+  ],
+
+  run: async (container, { dry_run, params }): Promise<MaintenanceJobResult> => {
+    const parsed = paramsSchema.safeParse(params)
+    if (!parsed.success) {
+      throw new MedusaError(
+        MedusaError.Types.INVALID_DATA,
+        parsed.error.issues.map((i) => i.message).join("; ")
+      )
+    }
+    const { store_id, cascade } = parsed.data
+
+    const query: any = container.resolve(ContainerRegistrationKeys.QUERY)
+
+    const { data: stores } = await query.graph({
+      entity: "stores",
+      fields: [
+        "id",
+        "name",
+        "default_sales_channel_id",
+        "default_location_id",
+        "default_region_id",
+      ],
+    })
+    const store = (stores ?? []).find((s: any) => s?.id === store_id)
+    if (!store) {
+      throw new MedusaError(
+        MedusaError.Types.NOT_FOUND,
+        `Store ${store_id} not found`
+      )
+    }
+
+    // Which stores a partner owns — the same rule resolveBrandLocationId uses.
+    const { data: partners } = await query.graph({
+      entity: "partners",
+      fields: ["id", "stores.id"],
+    })
+    const linkedStoreIds = new Set<string>()
+    for (const p of (partners ?? []) as any[]) {
+      for (const s of (p?.stores ?? []) as any[]) {
+        if (s?.id) linkedStoreIds.add(s.id)
+      }
+    }
+    const unlinkedStores = (stores ?? []).filter(
+      (s: any) => s?.id && !linkedStoreIds.has(s.id)
+    )
+
+    const channelId = store.default_sales_channel_id ?? null
+    const locationId = store.default_location_id ?? null
+
+    // Products / orders on its channel, stock at its location. Counted from
+    // rows, never from a `count` field: a filtered /admin/products count is
+    // unreliable (a fabricated channel id returns count 1, rows 0).
+    let productCount = 0
+    let orderCount = 0
+    if (channelId) {
+      const { data: products } = await query.graph({
+        entity: "product",
+        fields: ["id"],
+        filters: { sales_channels: { id: channelId } },
+      })
+      productCount = (products ?? []).length
+
+      const { data: orders } = await query.graph({
+        entity: "order",
+        fields: ["id"],
+        filters: { sales_channel_id: channelId },
+      })
+      orderCount = (orders ?? []).length
+    }
+
+    let stockLevelCount = 0
+    if (locationId) {
+      const { data: levels } = await query.graph({
+        entity: "inventory_level",
+        fields: ["id"],
+        filters: { location_id: locationId },
+      })
+      stockLevelCount = (levels ?? []).length
+    }
+
+    const facts: OrphanStoreFacts = {
+      store_id,
+      store_name: store.name,
+      has_partner: linkedStoreIds.has(store_id),
+      product_count: productCount,
+      order_count: orderCount,
+      stock_level_count: stockLevelCount,
+      sales_channel_id: channelId,
+      stock_location_id: locationId,
+      region_id: store.default_region_id ?? null,
+      is_only_unlinked_store: unlinkedStores.length <= 1,
+    }
+
+    const { deletable, blockers } = checkOrphanStoreDeletable(facts)
+
+    if (!deletable) {
+      return {
+        job_id: deleteOrphanStoreJob.id,
+        dry_run,
+        applied: false,
+        summary: `REFUSED — ${store.name ?? store_id} is not a deletable orphan: ${blockers.join(" ")}`,
+        changes: [],
+        errors: blockers.map((message) => ({ id: store_id, message })),
+      }
+    }
+
+    const changes: MaintenanceChange[] = [
+      {
+        entity: "store",
+        id: store_id,
+        field: "deleted",
+        before: store.name ?? store_id,
+        after: "(removed)",
+      },
+    ]
+    if (cascade) {
+      if (channelId) {
+        changes.push({
+          entity: "sales_channel",
+          id: channelId,
+          field: "deleted",
+          before: channelId,
+          after: "(removed)",
+        })
+      }
+      if (locationId) {
+        changes.push({
+          entity: "stock_location",
+          id: locationId,
+          field: "deleted",
+          before: locationId,
+          after: "(removed)",
+        })
+      }
+    }
+    // Stated on every run so the dry-run plan is explicit about the thing most
+    // worth being explicit about.
+    changes.push({
+      entity: "region",
+      id: facts.region_id ?? "(none)",
+      field: "preserved",
+      before: facts.region_id ?? "(none)",
+      after: "UNTOUCHED — shared with other stores",
+    })
+
+    if (dry_run) {
+      return {
+        job_id: deleteOrphanStoreJob.id,
+        dry_run,
+        applied: false,
+        summary: `Would delete store ${store.name ?? store_id} (${store_id})${
+          cascade ? " and its own sales channel + stock location" : ""
+        }. No products, orders or stock. Region ${facts.region_id ?? "(none)"} left untouched.`,
+        changes,
+        errors: [],
+      }
+    }
+
+    const errors: Array<{ id: string; message: string }> = []
+    const storeService: any = container.resolve("store")
+
+    try {
+      await storeService.softDeleteStores([store_id])
+    } catch (err: any) {
+      // Nothing else has run yet, so there is nothing to unwind.
+      throw new MedusaError(
+        MedusaError.Types.UNEXPECTED_STATE,
+        `Failed to delete store ${store_id}: ${err?.message ?? err}`
+      )
+    }
+
+    if (cascade) {
+      // Best-effort, and deliberately AFTER the store: the store row is what
+      // breaks brand resolution, so a channel that refuses to delete must not
+      // leave the store standing.
+      if (channelId) {
+        try {
+          const scService: any = container.resolve("sales_channel")
+          await scService.softDeleteSalesChannels([channelId])
+        } catch (err: any) {
+          errors.push({
+            id: channelId,
+            message: `Store deleted, but its sales channel was not: ${err?.message ?? err}`,
+          })
+        }
+      }
+      if (locationId) {
+        try {
+          const locService: any = container.resolve("stock_location")
+          await locService.softDeleteStockLocations([locationId])
+        } catch (err: any) {
+          errors.push({
+            id: locationId,
+            message: `Store deleted, but its stock location was not: ${err?.message ?? err}`,
+          })
+        }
+      }
+    }
+
+    return {
+      job_id: deleteOrphanStoreJob.id,
+      dry_run,
+      applied: true,
+      summary: `Deleted store ${store.name ?? store_id} (${store_id})${
+        cascade ? " and its own sales channel + stock location" : ""
+      }. Region ${facts.region_id ?? "(none)"} untouched.${
+        errors.length ? ` ${errors.length} cascade step(s) failed.` : ""
+      }`,
+      changes,
+      errors,
+    }
+  },
+}
+
+export default deleteOrphanStoreJob

--- a/apps/backend/src/api/admin/ops/maintenance-jobs/registry.ts
+++ b/apps/backend/src/api/admin/ops/maintenance-jobs/registry.ts
@@ -80,6 +80,7 @@ import { seedEmailTemplatesJob } from "./seed-jobs"
 import { seedInvestorPanelsJob } from "./seed-investor-panels-job"
 import { replayFxFanoutJob } from "./fanout-fx-job"
 import { backfillStoreCurrenciesJob } from "./backfill-store-currencies-job"
+import { deleteOrphanStoreJob } from "./delete-orphan-store-job"
 import { backfillPartnerEmailVerifiedJob } from "./backfill-partner-email-verified-job"
 import { backfillPartnerHostingProviderJob } from "./backfill-partner-hosting-provider-job"
 import { repointPartnerStorefrontSharedJob } from "./repoint-partner-storefront-shared-job"
@@ -5768,6 +5769,7 @@ export const MAINTENANCE_JOBS: MaintenanceJob[] = [
   reconcileInventoryMirrorJob,
   replayFxFanoutJob,
   backfillStoreCurrenciesJob,
+  deleteOrphanStoreJob,
   backfillPartnerEmailVerifiedJob,
   backfillPartnerHostingProviderJob,
   repointPartnerStorefrontSharedJob,

--- a/apps/backend/src/api/admin/products/spec-bulk/route.ts
+++ b/apps/backend/src/api/admin/products/spec-bulk/route.ts
@@ -1,0 +1,31 @@
+import { AuthenticatedMedusaRequest, MedusaResponse } from "@medusajs/framework/http"
+
+import { bulkUpsertProductSpecs } from "../../../../workflows/products/bulk-upsert-product-specs"
+import type { BulkProductSpecReqType } from "./validators"
+
+/**
+ * POST /admin/products/spec-bulk
+ *
+ * Write a production spec across many products in one call.
+ *
+ * Responds 200 with a PER-ROW outcome even when some rows failed — one bad
+ * product id must not discard the rest of the batch. Read `results`, not the
+ * status code.
+ *
+ * `dry_run: true` returns the same plan without writing, and each row says
+ * whether it would CREATE or UPDATE, plus which of `colors`/`fields`/`options`
+ * it would REPLACE wholesale.
+ *
+ * Unscoped by design — this is the admin surface and reaches the whole
+ * platform. Mirrored, ownership-scoped, by POST /partners/products/spec-bulk.
+ */
+export const POST = async (
+  req: AuthenticatedMedusaRequest,
+  res: MedusaResponse
+) => {
+  const body = (req as any).validatedBody as BulkProductSpecReqType
+
+  const result = await bulkUpsertProductSpecs(req.scope, body)
+
+  res.status(200).json(result)
+}

--- a/apps/backend/src/api/admin/products/spec-bulk/validators.ts
+++ b/apps/backend/src/api/admin/products/spec-bulk/validators.ts
@@ -1,0 +1,48 @@
+import { z } from "zod"
+
+import { PartnerProductSpecReq } from "../../../partners/products/validators"
+import { BULK_SPEC_MAX_PRODUCTS } from "../../../../workflows/products/bulk-upsert-product-specs"
+
+/**
+ * Body validation for the bulk production-spec write, shared by the admin route
+ * and its partner mirror.
+ *
+ * 🔑 The per-row spec shape is `PartnerProductSpecReq` itself — imported, not
+ * re-declared. A spec means one thing on this platform; a second copy of its
+ * rules here would be one edit away from the batch route accepting a spec the
+ * single route rejects, and the batch is exactly where that divergence would
+ * reach a hundred products before anyone noticed.
+ *
+ * That import direction (admin ← partners) looks backwards and is deliberate:
+ * the partner validator is the one the product-spec module's own tests pin, so
+ * it is the definition rather than a copy of one.
+ */
+export const BulkProductSpecReq = z
+  .object({
+    products: z
+      .array(
+        z
+          .object({
+            product_id: z.string().trim().min(1),
+            spec: PartnerProductSpecReq.optional(),
+          })
+          .strict()
+      )
+      .min(1)
+      .max(BULK_SPEC_MAX_PRODUCTS),
+    // Applied to every row that carries no `spec` of its own. This is the
+    // common case: one weave and one palette across a whole run.
+    spec: PartnerProductSpecReq.optional(),
+    dry_run: z.boolean().optional(),
+  })
+  .strict()
+  .refine(
+    (body) => !!body.spec || body.products.every((p) => !!p.spec),
+    {
+      message:
+        "Provide a batch-wide `spec`, or a `spec` on every product row. A row with neither has nothing to write.",
+      path: ["spec"],
+    }
+  )
+
+export type BulkProductSpecReqType = z.infer<typeof BulkProductSpecReq>

--- a/apps/backend/src/api/middlewares.ts
+++ b/apps/backend/src/api/middlewares.ts
@@ -201,6 +201,7 @@ import { CreateConversationSchema as PartnerCreateConversationSchema, UpdateConv
 import { CreateConversationSchema as AdminAssistantCreateConversationSchema, UpdateConversationSchema as AdminAssistantUpdateConversationSchema } from "./admin/assistant/conversations/validators";
 import { BulkHsCodesSchema } from "./admin/customs/hs-codes/validators";
 import { BulkUpdateProductsSchema } from "./admin/products/bulk-update/validators";
+import { BulkProductSpecReq } from "./admin/products/spec-bulk/validators";
 import {
   CreateExportLutSchema,
   UpdateExportLutSchema,
@@ -2739,6 +2740,24 @@ export default defineMiddlewares({
         createCorsPartnerMiddleware(),
         authenticate("partner", ["session", "bearer"]),
         validateAndTransformBody(wrapSchema(BulkUpdateProductsSchema)),
+      ],
+    },
+    // Bulk production-spec write. One weave, one param set and one palette
+    // across a whole run is the normal case; doing it product-by-product is
+    // twenty confirmations for one decision. Same validator on both surfaces —
+    // the partner route additionally ownership-checks every id in the handler.
+    {
+      matcher: "/admin/products/spec-bulk",
+      method: "POST",
+      middlewares: [validateAndTransformBody(wrapSchema(BulkProductSpecReq))],
+    },
+    {
+      matcher: "/partners/products/spec-bulk",
+      method: "POST",
+      middlewares: [
+        createCorsPartnerMiddleware(),
+        authenticate("partner", ["session", "bearer"]),
+        validateAndTransformBody(wrapSchema(BulkProductSpecReq)),
       ],
     },
     // Partner mirrors. These carry their own CORS + partner auth, and the POST

--- a/apps/backend/src/api/partners/assistant/chat/__tests__/identity-context.unit.spec.ts
+++ b/apps/backend/src/api/partners/assistant/chat/__tests__/identity-context.unit.spec.ts
@@ -1,0 +1,171 @@
+/**
+ * The identity block's WORDING is the mechanism (#1392), so it is what gets
+ * pinned.
+ *
+ * The point of injecting identity server-side is to stop the model spending a
+ * round trip rediscovering its own caller. That only works if the block reads
+ * as authoritative — a block the model does not trust is a block it calls
+ * `list_stores` alongside anyway, which is the bug with extra tokens.
+ */
+
+import {
+  formatPartnerIdentityBlock,
+  resolvePartnerIdentity,
+  type PartnerIdentity,
+} from "../identity-context"
+
+const base: PartnerIdentity = {
+  id: "01PARTNER",
+  name: "Sharlho",
+  handle: "sharlho",
+  workspace_type: "manufacturer",
+  is_verified: true,
+  country_code: "IN",
+  stores: [],
+}
+
+describe("formatPartnerIdentityBlock", () => {
+  it("returns nothing when identity could not be resolved", () => {
+    // No block at all, rather than a block saying "unknown" — the model should
+    // fall back to its tools, not be told a fact it cannot use.
+    expect(formatPartnerIdentityBlock(null)).toBeUndefined()
+  })
+
+  it("carries the partner's own identifying facts", () => {
+    const out = formatPartnerIdentityBlock(base)!
+    expect(out).toContain("01PARTNER")
+    expect(out).toContain("Sharlho")
+    expect(out).toContain("manufacturer")
+  })
+
+  it("tells the model not to look up what it was just given", () => {
+    const out = formatPartnerIdentityBlock(base)!.toLowerCase()
+    expect(out).toContain("do not look it up")
+  })
+
+  describe("with exactly one store", () => {
+    const one = {
+      ...base,
+      stores: [
+        {
+          id: "store_1",
+          name: "Sharlho Store",
+          default_sales_channel_id: "sc_1",
+          default_location_id: "sloc_1",
+          default_currency_code: "inr",
+        },
+      ],
+    }
+
+    it("hands over every id a store-scoped tool needs", () => {
+      const out = formatPartnerIdentityBlock(one)!
+      expect(out).toContain("store_1")
+      expect(out).toContain("sc_1")
+      expect(out).toContain("sloc_1")
+      expect(out).toContain("inr")
+    })
+
+    it("forbids asking which store when there is only one", () => {
+      // The failure this exists to prevent: asking a partner to choose between
+      // the single store they own, which reads as not knowing who they are.
+      const out = formatPartnerIdentityBlock(one)!
+      expect(out).toContain("ONE store")
+      expect(out.toLowerCase()).toContain("without asking which store")
+    })
+  })
+
+  describe("with several stores", () => {
+    const many = {
+      ...base,
+      stores: [
+        { id: "store_1", name: "First" },
+        { id: "store_2", name: "Second" },
+      ],
+    }
+
+    it("lists them all", () => {
+      const out = formatPartnerIdentityBlock(many)!
+      expect(out).toContain("store_1")
+      expect(out).toContain("store_2")
+      expect(out).toContain("First")
+      expect(out).toContain("Second")
+    })
+
+    it("still permits asking which — but by name, not by re-listing", () => {
+      const out = formatPartnerIdentityBlock(many)!
+      expect(out).toContain("DOES need the partner to say which")
+      expect(out).toContain("Do not call `list_stores`")
+    })
+  })
+
+  it("states plainly when the partner has no store", () => {
+    // 13 partners on prod are in exactly this state. "No store" is a real
+    // answer, and confirming it with a tool call is the wasted turn again.
+    const out = formatPartnerIdentityBlock(base)!
+    expect(out).toContain("NONE")
+    expect(out.toLowerCase()).toContain("no store yet")
+  })
+
+  it("omits fields the partner has not filled rather than printing blanks", () => {
+    const sparse = formatPartnerIdentityBlock({
+      id: "01P",
+      stores: [],
+    } as PartnerIdentity)!
+    expect(sparse).not.toContain("name:")
+    expect(sparse).not.toContain("null")
+    expect(sparse).not.toContain("undefined")
+  })
+})
+
+describe("resolvePartnerIdentity", () => {
+  const container = (graph: any) => ({ resolve: () => ({ graph }) })
+
+  it("returns null without a partner id, without touching the container", async () => {
+    const graph = jest.fn()
+
+    await expect(resolvePartnerIdentity(container(graph), null)).resolves.toBeNull()
+    expect(graph).not.toHaveBeenCalled()
+  })
+
+  it("never throws when the query fails", async () => {
+    // This only ever saves the model a lookup it can still do itself, so it
+    // must not be able to fail the turn.
+    const warn = jest.fn()
+    const res = await resolvePartnerIdentity(
+      container(() => {
+        throw new Error("db down")
+      }),
+      "01P",
+      { warn }
+    )
+
+    expect(res).toBeNull()
+    expect(warn).toHaveBeenCalled()
+  })
+
+  it("returns null when the partner row is gone", async () => {
+    const res = await resolvePartnerIdentity(
+      container(async () => ({ data: [] })),
+      "01P"
+    )
+    expect(res).toBeNull()
+  })
+
+  it("drops store rows with no id rather than emitting a broken one", async () => {
+    const res = await resolvePartnerIdentity(
+      container(async () => ({
+        data: [
+          {
+            id: "01P",
+            stores: [{ id: "store_1", name: "Real" }, { name: "Ghost" }],
+          },
+        ],
+      })),
+      "01P"
+    )
+
+    expect(res!.stores).toEqual([
+      expect.objectContaining({ id: "store_1", name: "Real" }),
+    ])
+  })
+})

--- a/apps/backend/src/api/partners/assistant/chat/identity-context.ts
+++ b/apps/backend/src/api/partners/assistant/chat/identity-context.ts
@@ -1,0 +1,184 @@
+import { ContainerRegistrationKeys } from "@medusajs/framework/utils"
+
+/**
+ * Who the partner is and which stores they have — resolved SERVER-SIDE, once
+ * per turn, and handed to the model in the system prompt (#1392).
+ *
+ * ## Why this exists
+ *
+ * The assistant was rediscovering its own caller. Every conversation, and often
+ * several times within one, the model would call `list_stores` /
+ * `get_partner_profile` to answer a question it could not act on without: which
+ * store am I writing to, what currency is it in, which sales channel.
+ *
+ * That is a strange thing to make a language model figure out. The request is
+ * already authenticated as this partner — the server knows the answer before
+ * the model has read the first token. Leaving it to a tool call costs a round
+ * trip, spends context on a payload the model then has to re-read every turn,
+ * and — worst — is *unreliable*: a model that forgets to look ends up asking
+ * the partner which store they mean, about a partner who only has one.
+ *
+ * So this is deliberately NOT a cache. `lib/assistant-context` already caches
+ * what the model *found*; this states what the server *knows*. A cache can miss
+ * and can go stale. This is recomputed every turn from one query and cannot be
+ * either.
+ *
+ * ## Scope, deliberately narrow
+ *
+ * Identity and stores only. Not orders, not products, not counts. The value
+ * here comes from being small enough to sit in every system prompt without
+ * argument; the moment it grows into a business summary it becomes a thing
+ * whose staleness matters, and it stops being free.
+ */
+
+export type PartnerIdentityStore = {
+  id: string
+  name?: string | null
+  default_sales_channel_id?: string | null
+  default_location_id?: string | null
+  default_currency_code?: string | null
+}
+
+export type PartnerIdentity = {
+  id: string
+  name?: string | null
+  handle?: string | null
+  workspace_type?: string | null
+  is_verified?: boolean | null
+  country_code?: string | null
+  stores: PartnerIdentityStore[]
+}
+
+/**
+ * One graph call. Failure returns `null` rather than throwing: this only ever
+ * saves the model a lookup it can still perform itself, so it must never be
+ * able to fail the turn — the same rule the prior-context cache follows.
+ */
+export const resolvePartnerIdentity = async (
+  container: any,
+  partnerId: string | null | undefined,
+  logger?: { warn: (m: string) => void }
+): Promise<PartnerIdentity | null> => {
+  if (!partnerId) return null
+
+  try {
+    const query = container.resolve(ContainerRegistrationKeys.QUERY) as any
+    const { data } = await query.graph({
+      entity: "partners",
+      fields: [
+        "id",
+        "name",
+        "handle",
+        "workspace_type",
+        "is_verified",
+        "country_code",
+        "stores.id",
+        "stores.name",
+        "stores.default_sales_channel_id",
+        "stores.default_location_id",
+        "stores.default_currency_code",
+      ],
+      filters: { id: partnerId },
+    })
+
+    const partner = data?.[0]
+    if (!partner) return null
+
+    return {
+      id: partner.id,
+      name: partner.name,
+      handle: partner.handle,
+      workspace_type: partner.workspace_type,
+      is_verified: partner.is_verified,
+      country_code: partner.country_code,
+      stores: ((partner as any).stores ?? []).map((s: any) => ({
+        id: s?.id,
+        name: s?.name,
+        default_sales_channel_id: s?.default_sales_channel_id,
+        default_location_id: s?.default_location_id,
+        default_currency_code: s?.default_currency_code,
+      })).filter((s: PartnerIdentityStore) => !!s.id),
+    }
+  } catch (e: any) {
+    logger?.warn(
+      `[partner-assistant] identity context unavailable: ${e?.message ?? e}`
+    )
+    return null
+  }
+}
+
+/**
+ * Render the block that goes into the system prompt.
+ *
+ * Pure, so the wording is unit-testable without a container — the wording is
+ * the whole mechanism here, and a block the model does not trust is a block it
+ * calls `list_stores` anyway.
+ */
+export const formatPartnerIdentityBlock = (
+  identity: PartnerIdentity | null
+): string | undefined => {
+  if (!identity) return undefined
+
+  const lines: string[] = []
+  lines.push("## Who you are talking to (already resolved — do not look it up)")
+  lines.push("")
+  lines.push(
+    "This is established from the authenticated request, not from a tool call. It is current as of this turn."
+  )
+  lines.push("")
+
+  const bits = [`id: ${identity.id}`]
+  if (identity.name) bits.push(`name: ${identity.name}`)
+  if (identity.handle) bits.push(`handle: ${identity.handle}`)
+  if (identity.workspace_type) bits.push(`type: ${identity.workspace_type}`)
+  if (identity.country_code) bits.push(`country: ${identity.country_code}`)
+  if (identity.is_verified != null)
+    bits.push(`verified: ${identity.is_verified ? "yes" : "no"}`)
+  lines.push(`Partner — ${bits.join(", ")}`)
+
+  if (!identity.stores.length) {
+    lines.push("")
+    lines.push(
+      "Stores — NONE. This partner has no store yet, so catalogue and storefront tools have nothing to write to. Say so plainly rather than calling `list_stores` to confirm it."
+    )
+  } else if (identity.stores.length === 1) {
+    const s = identity.stores[0]
+    lines.push("")
+    lines.push(
+      `Store — ${s.name ?? "(unnamed)"} (id: ${s.id}${
+        s.default_currency_code ? `, currency: ${s.default_currency_code}` : ""
+      }${
+        s.default_sales_channel_id
+          ? `, sales channel: ${s.default_sales_channel_id}`
+          : ""
+      }${
+        s.default_location_id ? `, stock location: ${s.default_location_id}` : ""
+      })`
+    )
+    lines.push("")
+    lines.push(
+      "🔑 There is exactly ONE store. Use this id for every store-scoped tool WITHOUT asking which store the partner means, and without calling `list_stores` first — asking a partner to choose between one option reads as not knowing who they are."
+    )
+  } else {
+    lines.push("")
+    lines.push(`Stores — ${identity.stores.length}:`)
+    for (const s of identity.stores) {
+      lines.push(
+        `  - ${s.name ?? "(unnamed)"} (id: ${s.id}${
+          s.default_currency_code ? `, ${s.default_currency_code}` : ""
+        })`
+      )
+    }
+    lines.push("")
+    lines.push(
+      "🔑 More than one store, so a store-scoped write DOES need the partner to say which — but ask them by NAME from this list. Do not call `list_stores` to rebuild it."
+    )
+  }
+
+  lines.push("")
+  lines.push(
+    "Carry these ids across the whole conversation. Re-fetching identity you were already given is a wasted turn the partner waits through."
+  )
+
+  return lines.join("\n")
+}

--- a/apps/backend/src/api/partners/assistant/chat/route.ts
+++ b/apps/backend/src/api/partners/assistant/chat/route.ts
@@ -65,6 +65,10 @@ import {
   mergeAttachments,
   renderAttachments,
 } from "./attachments"
+import {
+  formatPartnerIdentityBlock,
+  resolvePartnerIdentity,
+} from "./identity-context"
 import { normaliseUiMessages } from "../../../../lib/assistant-messages"
 import type { PartnerAssistantChatReq } from "./validators"
 
@@ -74,7 +78,7 @@ const ROLE = "ai_partner_assistant"
 const SYSTEM_PROMPT = `You are the JYT partner-portal assistant. You help partners (sellers, manufacturers, individual makers, and designers) set up and run their workspace by calling Partner API tools on their behalf.
 
 ## How to work
-- ALWAYS call \`get_partner_profile\` first to learn the partner's name, persona (workspace_type), and how far onboarding has progressed. Then help with what they asked.
+- The partner's identity and their store ids are GIVEN TO YOU below, resolved from the authenticated request. Do not call \`list_stores\` or \`get_partner_profile\` to rediscover them, and never ask "which store?" when only one is listed. Read \`get_partner_profile\` only when you need something that block does not carry — onboarding progress, metadata, or a field you are about to write.
 - For ONBOARDING: guide the partner conversationally. The essential gate is a business name + a persona (workspace_type: 'seller' | 'manufacturer' | 'individual' | 'designer'). Set those with \`update_partner_profile\`, and when both are set, merge \`metadata.onboarding_essentials_done = true\` into their existing metadata (read it from get_partner_profile first — metadata is REPLACED, not patched, so always spread the existing values). Record deeper answers (what they sell, team size, selling mode, etc.) with \`update_onboarding_profile\`.
 - For LAYOUT personalization: use the layout tools to reorder or hide sidebar/home widgets for zones 'sidebar.main' and 'home'.
 - To answer questions about their business, use the read tools (list_orders, list_products, list_stores, list_designs, list_inventory_items, list_notifications).
@@ -256,6 +260,18 @@ export const POST = async (
       )
     : undefined
 
+  // ---- Identity context (#1392) -------------------------------------------
+  // What the SERVER knows, as opposed to `priorContext` above, which caches
+  // what the model once FOUND. The request is already authenticated as this
+  // partner, so making the model call `list_stores` to learn which store it is
+  // writing to was always a round trip to rediscover the caller — and an
+  // unreliable one: a model that forgets to look asks the partner to choose
+  // between the single store they own.
+  //
+  // Recomputed every turn from one query, so unlike a cache it cannot go stale.
+  const identity = await resolvePartnerIdentity(req.scope, partnerId, logger)
+  const identityBlock = formatPartnerIdentityBlock(identity)
+
   // The escape hatch. Always active, so the model is never boxed in by a slice
   // that guessed wrong — it names the domains it needs and they light up on the
   // next step. This is also why the slice can be aggressive.
@@ -303,9 +319,11 @@ export const POST = async (
   const chatModel =
     resolved.source === "free" ? dynamicFreeToolTextModel : resolved.model
 
+  // Identity first, then the prior-context cache: the block the model must not
+  // second-guess should not sit below a block that is explicitly best-effort.
   const folded = foldSystemForProvider(
     resolved.providerType,
-    priorContext ? `${SYSTEM_PROMPT}\n\n${priorContext}` : SYSTEM_PROMPT,
+    [SYSTEM_PROMPT, identityBlock, priorContext].filter(Boolean).join("\n\n"),
     messages
   )
   const startedAt = Date.now()

--- a/apps/backend/src/api/partners/mcp/lib/registry.ts
+++ b/apps/backend/src/api/partners/mcp/lib/registry.ts
@@ -869,6 +869,64 @@ export const PARTNER_MCP_TOOLS: PartnerMcpToolDef[] = [
       "Replaces the stored palette and custom fields when those keys are passed.",
     nextSteps: ["get_product_spec"],
   },
+  {
+    name: "bulk_set_product_spec",
+    description: [
+      "Write ONE production spec across MANY of your products in a single call — the normal case when a run of pieces shares a weave, a parameter set and a palette and differs only in colourway. Sensitive: requires confirm:true. ALWAYS dry_run first.",
+      "",
+      "TARGETING:",
+      "- `spec` applies to every product listed.",
+      "- `products: [{ product_id, spec }]` — a row's own `spec` wins over the batch-wide one, so you can share a weave and vary the palette in the same call.",
+      "",
+      "Creates a spec where none exists and updates where one does — you do not have to know which, and a mixed batch is fine. Each row reports which actually happened (`created` / `updated`).",
+      "",
+      `⚠️ ${"`colors`, `fields` and `options` REPLACE what is stored when present"}. Omit a key to leave those rows untouched. Across a batch this is the sharpest edge here, so the dry-run plan names, per product, exactly which of the three it would replace — read it before confirming.`,
+      "",
+      "Returns a PER-ROW outcome: one bad product id never discards the rest, so read `results` and `warnings` rather than just the status. Everything is scoped to your own catalogue — a product that isn't yours comes back as an error row.",
+      `Capped at 100 products per call. ${PRODUCT_SPEC_WRITE_GUIDANCE}`,
+    ].join("\n"),
+    method: "POST",
+    path: "/partners/products/spec-bulk",
+    write: true,
+    sensitive: true,
+    bodyParams: ["products", "spec", "dry_run"],
+    inputSchema: obj(
+      {
+        products: {
+          type: "array",
+          description:
+            "Products to write. A row's own `spec` wins over the batch-wide `spec`.",
+          items: {
+            type: "object",
+            properties: {
+              product_id: STR("Product id, e.g. 'prod_...'."),
+              spec: {
+                type: "object",
+                description:
+                  "Spec for this product only. Same shape as the batch-wide `spec`.",
+                properties: productSpecSchemaProps(),
+                additionalProperties: false,
+              },
+            },
+            required: ["product_id"],
+            additionalProperties: false,
+          },
+        },
+        spec: {
+          type: "object",
+          description:
+            "Applied to every row that carries no `spec` of its own. Provide this, or a `spec` on every row.",
+          properties: productSpecSchemaProps(),
+          additionalProperties: false,
+        },
+        dry_run: BOOL("Return the plan without writing. Do this first."),
+      },
+      ["products"]
+    ),
+    sideEffects:
+      "Replaces the stored palette, custom fields and option groups on EVERY listed product when those keys are passed.",
+    nextSteps: ["get_product_spec"],
+  },
 
   // ===== Partner orders (detail + fulfillment) =============================
   {

--- a/apps/backend/src/api/partners/mcp/lib/registry.ts
+++ b/apps/backend/src/api/partners/mcp/lib/registry.ts
@@ -23,6 +23,10 @@
 
 import type { McpToolDef } from "../../../../lib/mcp-core"
 import {
+  PHYSICAL_AND_CUSTOMS_BODY_PARAMS,
+  physicalAndCustomsSchemaProps,
+} from "../../../../lib/product-attributes/tool-schema"
+import {
   PRODUCT_SPEC_BODY_PARAMS,
   PRODUCT_SPEC_WRITE_GUIDANCE,
   productSpecSchemaProps,
@@ -1867,7 +1871,18 @@ export const PARTNER_MCP_TOOLS: PartnerMcpToolDef[] = [
     path: "/partners/stores/:id/products/:productId/variants",
     pathParams: ["id", "productId"],
     write: true,
-    bodyParams: ["title", "sku", "options", "prices", "manage_inventory", "allow_backorder"],
+    bodyParams: [
+      "title",
+      "sku",
+      "options",
+      "prices",
+      "manage_inventory",
+      "allow_backorder",
+      // A variant born without a weight cannot be quoted for freight, and the
+      // partner has to come back and fix it through a second tool. Setting it
+      // at creation is the only way the data is right by default.
+      ...PHYSICAL_AND_CUSTOMS_BODY_PARAMS,
+    ],
     sideEffects:
       "creates the variant + its inventory item; the new variant starts at 0 stock.",
     nextSteps: ["set_inventory_level"],
@@ -1877,6 +1892,7 @@ export const PARTNER_MCP_TOOLS: PartnerMcpToolDef[] = [
         productId: STR("Product id."),
         title: STR("Variant title, e.g. 'Red / M'."),
         sku: STR("Stock-keeping unit."),
+        ...physicalAndCustomsSchemaProps(),
         options: {
           type: "object",
           description: "Option→value map, e.g. { Size: 'M', Color: 'Red' }.",
@@ -1917,13 +1933,14 @@ export const PARTNER_MCP_TOOLS: PartnerMcpToolDef[] = [
       "prices",
       "manage_inventory",
       "allow_backorder",
-      // Customs fields. The route already spreads the whole body into
-      // updateProductVariantsWorkflow, so these have always persisted — they
-      // were simply never exposed, which left the assistant unable to fix the
-      // missing-HSN failures that block international labels.
-      "hs_code",
-      "origin_country",
-      "material",
+      // Physical + customs fields. The route already spreads the whole body
+      // into updateProductVariantsWorkflow, so these have always persisted —
+      // they were simply never exposed. The customs trio was added first (it
+      // blocked international labels); `weight` and the dimensions were left
+      // out in the same way and blocked every freight quote, silently, because
+      // the dispatcher drops unlisted keys without a word. See
+      // lib/product-attributes/tool-schema.ts.
+      ...PHYSICAL_AND_CUSTOMS_BODY_PARAMS,
     ],
     inputSchema: obj(
       {
@@ -1932,11 +1949,7 @@ export const PARTNER_MCP_TOOLS: PartnerMcpToolDef[] = [
         variantId: STR("Variant id to update."),
         title: STR("New variant title."),
         sku: STR("New SKU."),
-        hs_code: STR(
-          "HS/HSN customs code. Required for international shipping labels."
-        ),
-        origin_country: STR("ISO-2 country of manufacture."),
-        material: STR("Material description for customs."),
+        ...physicalAndCustomsSchemaProps(),
         options: {
           type: "object",
           description: "Option→value map to change.",

--- a/apps/backend/src/api/partners/products/spec-bulk/route.ts
+++ b/apps/backend/src/api/partners/products/spec-bulk/route.ts
@@ -1,0 +1,53 @@
+import { AuthenticatedMedusaRequest, MedusaResponse } from "@medusajs/framework/http"
+
+import { assertProductOwnership } from "../lib/assert-product-ownership"
+import { bulkUpsertProductSpecs } from "../../../../workflows/products/bulk-upsert-product-specs"
+import type { BulkProductSpecReqType } from "../../../admin/products/spec-bulk/validators"
+
+/**
+ * POST /partners/products/spec-bulk
+ *
+ * Partner mirror of `POST /admin/products/spec-bulk`: write a production spec
+ * across many of the partner's OWN products in one call.
+ *
+ * Ownership is resolved per id through `assertProductOwnership` — the same
+ * helper the single-product spec route uses, called once per row rather than
+ * reimplemented as a set query. That is deliberate and its own docblock says
+ * why: an ownership rule that exists in two copies is one edit away from
+ * disagreeing with itself, and the copy that drifts is the one that lets a
+ * partner write someone else's catalogue. A batch route is the worst possible
+ * place to hold the drifting copy, because it would reach a hundred products
+ * before anyone noticed.
+ *
+ * Ids that fail the check become error rows saying "not found" — the same
+ * wording an id that genuinely does not exist produces, so a partner cannot use
+ * this route to discover that a product belongs to someone else.
+ */
+export const POST = async (
+  req: AuthenticatedMedusaRequest,
+  res: MedusaResponse
+) => {
+  const body = (req as any).validatedBody as BulkProductSpecReqType
+
+  const requested = Array.from(
+    new Set((body.products ?? []).map((p) => p.product_id))
+  )
+
+  const allowedProductIds = new Set<string>()
+  for (const productId of requested) {
+    try {
+      await assertProductOwnership(req, productId)
+      allowedProductIds.add(productId)
+    } catch {
+      // Left out of the allow-set; the workflow turns that into an error row.
+      // Swallowed rather than thrown so one foreign id cannot discard a batch
+      // of ninety-nine legitimate ones.
+    }
+  }
+
+  const result = await bulkUpsertProductSpecs(req.scope, body, {
+    allowedProductIds,
+  })
+
+  res.status(200).json(result)
+}

--- a/apps/backend/src/lib/mcp-core/__tests__/product-tool-field-coverage.unit.spec.ts
+++ b/apps/backend/src/lib/mcp-core/__tests__/product-tool-field-coverage.unit.spec.ts
@@ -1,0 +1,196 @@
+/**
+ * Every field a product/variant route ACCEPTS is either advertised by its MCP
+ * tool or written down here as a deliberate omission.
+ *
+ * ## Why this test exists
+ *
+ * `required-args.unit.spec.ts` already asserts `bodyParams ⊆ inputSchema` — the
+ * #1348 direction, "a param the route needs that the schema never offers is
+ * silently stripped". That check is one-directional, and it is structurally
+ * blind to the failure that actually happened:
+ *
+ *   `weight` was missing from BOTH `bodyParams` and `inputSchema` on every
+ *   single-record product/variant tool, while every route behind them accepted
+ *   it. The dispatcher's `pick()` is a pure allowlist walk, so the field was
+ *   dropped with no error and no warning — and because the `dry_run` plan is
+ *   built from the already-picked body, a dry run could not reveal it either.
+ *   The tool returned `ok: true`. Freight was unquotable for a third of a
+ *   catalogue and nothing anywhere said so.
+ *
+ * A field missing from both sides is invisible to a `bodyParams ⊆ schema`
+ * check. This test closes that direction by starting from the CONTRACT — core's
+ * own zod validators, imported rather than transcribed — and walking inward.
+ *
+ * ## The opt-out list is the point
+ *
+ * `DELIBERATELY_OMITTED` is not a way to silence the test. It is the mechanism
+ * that converts silence into a decision someone wrote down and dated. Adding a
+ * field to it should feel like a small commitment, because it is one.
+ */
+
+// Imported, never transcribed: a copy of core's field list here would rot the
+// moment core added a field, and rot silently — which is the exact failure this
+// test exists to catch. The `./api/*` subpath is in medusa's exports map.
+// eslint-disable-next-line @typescript-eslint/no-var-requires
+const coreProductValidators = require("@medusajs/medusa/api/admin/products/validators")
+const { UpdateProduct, UpdateProductVariant, CreateProductVariant } =
+  coreProductValidators
+
+import { PARTNER_MCP_TOOLS } from "../../../api/partners/mcp/lib/registry"
+import { ADMIN_MCP_TOOLS } from "../../../api/admin/mcp/lib/registry"
+import type { McpToolDef } from "../types"
+
+/** Keys a zod object validator accepts. */
+const acceptedKeys = (schema: any): string[] =>
+  Object.keys(schema?.shape ?? schema?._def?.shape?.() ?? {})
+
+const findTool = (tools: readonly McpToolDef[], name: string): McpToolDef => {
+  const tool = tools.find((t) => t.name === name)
+  if (!tool) throw new Error(`tool "${name}" not found — was it renamed?`)
+  return tool
+}
+
+/**
+ * Fields a tool knowingly does not expose, with the reason.
+ *
+ * Keyed by `<registry>:<tool>`. Anything not listed here MUST be advertised.
+ */
+const DELIBERATELY_OMITTED: Record<string, Record<string, string>> = {
+  "partner:update_product_variant": {
+    id: "path param, not a body field",
+    prices: "advertised separately with its own array schema",
+    options: "advertised separately with its own object schema",
+    metadata: "partner tools do not expose raw metadata writes",
+    variant_rank: "ordering is a UI concern, not an assistant one",
+    ean: "retail barcode symbologies; no partner has asked, and a wrong one is worse than none",
+    upc: "as ean",
+    barcode: "as ean",
+    thumbnail: "images go through the media tools, which handle upload + linking",
+  },
+  "partner:add_product_variant": {
+    prices: "advertised separately with its own array schema",
+    options: "advertised separately with its own object schema",
+    metadata: "partner tools do not expose raw metadata writes",
+    variant_rank: "ordering is a UI concern, not an assistant one",
+    ean: "as update_product_variant",
+    upc: "as update_product_variant",
+    barcode: "as update_product_variant",
+    inventory_items: "stock is seeded by set_inventory_level, which this tool already points at",
+  },
+  "admin:update_product_variant": {
+    id: "path param, not a body field",
+    prices: "use the pricing tools; a price write here would bypass the FX fanout",
+    options: "option writes go through the product tools",
+    variant_rank: "ordering is a UI concern",
+    ean: "as partner",
+    upc: "as partner",
+    barcode: "as partner",
+    thumbnail: "images go through the media tools",
+  },
+  "admin:update_product": {
+    variants: "variants have their own tools; a nested write here is a second, untested path",
+    options: "option writes have their own tool",
+    option_ids: "as options",
+    images: "images go through the media tools",
+    thumbnail: "images go through the media tools",
+    sales_channels: "channel membership is its own tool",
+    categories: "categories are their own tool",
+    tags: "tags are their own tool",
+    type_id: "product type is its own tool",
+    collection_id: "collections are their own tool",
+    shipping_profile_id: "shipping profiles are an ops concern, not an assistant one",
+    discountable: "pricing/promotions concern",
+    external_id: "integration bookkeeping, never assistant-written",
+    is_giftcard: "not a thing this catalogue sells",
+  },
+}
+
+const CASES: Array<{
+  key: string
+  tool: McpToolDef
+  validator: any
+  what: string
+}> = [
+  {
+    key: "partner:update_product_variant",
+    tool: findTool(PARTNER_MCP_TOOLS, "update_product_variant"),
+    validator: UpdateProductVariant,
+    what: "the partner route spreads the raw body into updateProductVariantsWorkflow, so core's contract is the real one",
+  },
+  {
+    key: "partner:add_product_variant",
+    tool: findTool(PARTNER_MCP_TOOLS, "add_product_variant"),
+    validator: CreateProductVariant,
+    what: "the partner route spreads the raw body into createProductVariantsWorkflow",
+  },
+  {
+    key: "admin:update_product_variant",
+    tool: findTool(ADMIN_MCP_TOOLS, "update_product_variant"),
+    validator: UpdateProductVariant,
+    what: "core route, core validator",
+  },
+  {
+    key: "admin:update_product",
+    tool: findTool(ADMIN_MCP_TOOLS, "update_product"),
+    validator: UpdateProduct,
+    what: "core route, core validator",
+  },
+]
+
+describe("product/variant MCP tools cover the fields their routes accept", () => {
+  describe.each(CASES)("$key", ({ key, tool, validator, what }) => {
+    const accepted = acceptedKeys(validator)
+    const omitted = DELIBERATELY_OMITTED[key] ?? {}
+
+    it(`sanity: the validator was importable and non-empty (${what})`, () => {
+      // Without this, a bad import path would make every assertion below pass
+      // over an empty set — the test would go green by testing nothing.
+      expect(accepted.length).toBeGreaterThan(5)
+    })
+
+    it("advertises every accepted field, or names it as a deliberate omission", () => {
+      const advertised = new Set(tool.bodyParams ?? [])
+      const unaccounted = accepted.filter(
+        (field) => !advertised.has(field) && !(field in omitted)
+      )
+
+      expect(unaccounted).toEqual([])
+    })
+
+    it("advertises nothing the route would reject", () => {
+      // The other direction, per-tool: a body param the validator does not
+      // accept is a 400 waiting to happen on a .strict() core route.
+      const strays = (tool.bodyParams ?? []).filter(
+        (field) => !accepted.includes(field)
+      )
+
+      expect(strays).toEqual([])
+    })
+
+    it("declares every advertised body param in its input schema", () => {
+      const props = Object.keys((tool.inputSchema as any)?.properties ?? {})
+      const undeclared = (tool.bodyParams ?? []).filter((f) => !props.includes(f))
+
+      expect(undeclared).toEqual([])
+    })
+
+    it("has no stale entries in its deliberate-omission list", () => {
+      // An omission for a field the validator no longer accepts is a note about
+      // a world that stopped existing. Delete it rather than let it rot.
+      const stale = Object.keys(omitted).filter((f) => !accepted.includes(f))
+
+      expect(stale).toEqual([])
+    })
+  })
+
+  it("weight is advertised on every tool that can write one", () => {
+    // The regression this whole file exists for, stated plainly so a future
+    // reader sees the point without reconstructing it from the generic checks.
+    for (const { key, tool } of CASES) {
+      expect({ key, weight: (tool.bodyParams ?? []).includes("weight") }).toEqual({
+        key,
+        weight: true,
+      })
+    }
+  })
+})

--- a/apps/backend/src/lib/mcp-core/dispatch.ts
+++ b/apps/backend/src/lib/mcp-core/dispatch.ts
@@ -82,6 +82,54 @@ const pick = (
   return out
 }
 
+/**
+ * Arguments the dispatcher itself consumes. They are never forwarded to a
+ * route, so their absence from `bodyParams` is correct, not a defect.
+ */
+const CONTROL_ARGS = new Set([
+  "dry_run",
+  "confirm",
+  "store",
+  "reason",
+  "context",
+])
+
+/**
+ * Argument names the caller sent that NO forwarding list claims.
+ *
+ * `pick()` is an allowlist walk, so an unlisted key is dropped completely
+ * silently — no error, no log, and (because the dry_run plan is built from the
+ * already-picked body) not visible in a rehearsal either. A registry row that
+ * forgot a field therefore looks *identical* to one that has it: the tool
+ * returns ok, the route 200s, and nothing is written.
+ *
+ * That is not hypothetical. `weight` was missing from every single-record
+ * product/variant tool while every route behind them accepted it; partners set
+ * weights through the assistant for days and nothing persisted.
+ *
+ * These are surfaced as warnings rather than rejected. Rejecting would turn
+ * every stale registry row into a hard failure for callers who are doing
+ * nothing wrong — but silence is what made the original bug survive, so the
+ * caller gets told.
+ */
+const droppedArgs = (
+  def: McpToolDef,
+  args: Record<string, unknown>
+): string[] => {
+  const claimed = new Set<string>([
+    ...(def.pathParams ?? []),
+    ...(def.queryParams ?? []),
+    ...(def.bodyParams ?? []),
+  ])
+  return Object.keys(args).filter(
+    (k) =>
+      !claimed.has(k) &&
+      !CONTROL_ARGS.has(k) &&
+      args[k] !== undefined &&
+      args[k] !== null
+  )
+}
+
 export async function dispatchMcpTool(
   ctx: McpContext,
   tools: McpToolDef[],
@@ -233,6 +281,11 @@ export async function dispatchMcpTool(
   const body = pick(def.bodyParams, args)
   const method = def.method ?? "GET"
 
+  // Anything the caller sent that no forwarding list claims. Reported on the
+  // plan AND on the result, so a dry run can finally reveal a dropped field
+  // instead of rehearsing a write that silently loses it.
+  const dropped = droppedArgs(def, args)
+
   const plan = {
     method,
     path,
@@ -240,6 +293,14 @@ export async function dispatchMcpTool(
     ...(Object.keys(body).length ? { body } : {}),
     ...(context ? { context } : {}),
     ...(reason ? { reason } : {}),
+    ...(dropped.length
+      ? {
+          dropped_arguments: dropped,
+          dropped_arguments_note: `This tool does not forward: ${dropped.join(
+            ", "
+          )}. These values were NOT sent and will NOT be saved.`,
+        }
+      : {}),
   }
 
   // Fetch the current object for writes that declare a previewPath — so the
@@ -334,7 +395,23 @@ export async function dispatchMcpTool(
       ms: Date.now() - startedAt,
       context,
     })
-    return { ok: true, tool: name, data: out }
+    return {
+      ok: true,
+      tool: name,
+      data: out,
+      // A 200 that quietly discarded half the caller's intent is the failure
+      // mode this whole change exists to end. Say so on the successful result,
+      // not only in the rehearsal.
+      ...(dropped.length
+        ? {
+            warnings: [
+              `Ignored ${dropped.length} argument(s) this tool does not accept: ${dropped.join(
+                ", "
+              )}. Those values were NOT saved.`,
+            ],
+          }
+        : {}),
+    }
   } catch (e) {
     const err = e as McpProxyError
     const error = `Error calling ${name} (${path}): ${err.message}`

--- a/apps/backend/src/lib/mcp-core/types.ts
+++ b/apps/backend/src/lib/mcp-core/types.ts
@@ -219,4 +219,12 @@ export type McpToolResult = {
   current?: unknown
   /** Human-readable warning for sensitive/dangerous actions. */
   warning?: string
+  /**
+   * Non-fatal notices about the call that ran — currently, arguments the tool
+   * does not forward and therefore silently discarded.
+   *
+   * Distinct from `warning`, which is pre-execution copy for the confirmation
+   * card. These describe what actually happened to a request that succeeded.
+   */
+  warnings?: string[]
 }

--- a/apps/backend/src/lib/product-attributes/tool-schema.ts
+++ b/apps/backend/src/lib/product-attributes/tool-schema.ts
@@ -1,0 +1,94 @@
+/**
+ * The MCP/assistant-facing vocabulary for a product's or variant's PHYSICAL and
+ * CUSTOMS attributes — weight, dimensions, and the customs trio.
+ *
+ * Lives here rather than in a registry for the reason `product-spec/tool-schema.ts`
+ * does: these fields belong to four tools across two registries
+ * (`update_product_variant`, `add_product_variant`, `update_product`), and a
+ * vocabulary copied four times is three edits away from four assistants
+ * believing different things about what a product weighs.
+ *
+ * ## Why this file exists at all
+ *
+ * `weight` was missing from `bodyParams` on every single-record product/variant
+ * tool while being accepted by every route behind them. Because the dispatcher's
+ * `pick()` (see `lib/mcp-core/dispatch.ts`) is a pure allowlist walk, the field
+ * was dropped with no error, no warning, and — since the `dry_run` plan is built
+ * from the already-picked body — a dry run that could not reveal the omission.
+ * The tool then returned `ok: true`. Partners set weights through the assistant
+ * for days and nothing was written.
+ *
+ * The fix was never a route change: core's `.strict()` validators for both
+ * `POST /admin/products/:id` and `POST /admin/products/:id/variants/:variantId`
+ * already accept all of these, and the partner routes spread the raw body into
+ * the workflow. The registry was the only thing in the way.
+ *
+ * 🔑 UNITS. `weight` is **grams** and dimensions are **centimetres** throughout
+ * this codebase — the shipping providers all read them that way. The model is
+ * the consumer of these descriptions, so the unit is stated in every one of
+ * them. A unitless "weight" invites a partner-facing kilogram.
+ */
+
+type SchemaProp = { type: string; description: string }
+
+const NUM = (description: string): SchemaProp => ({ type: "number", description })
+const STR = (description: string): SchemaProp => ({ type: "string", description })
+
+/**
+ * Body keys for physical dimensions, in registry order.
+ *
+ * Shipping cannot be quoted without `weight`: `/store/shipping-estimate`
+ * refuses a weightless variant rather than guessing one, so a variant created
+ * or updated without it is unquotable for freight.
+ */
+export const PHYSICAL_ATTRIBUTE_BODY_PARAMS = [
+  "weight",
+  "length",
+  "width",
+  "height",
+]
+
+/**
+ * Body keys for customs attributes, in registry order.
+ *
+ * `mid_code` sits here rather than with the others because it is the one core
+ * cascades product→variant alongside `hs_code`/`origin_country`/`material`.
+ */
+export const CUSTOMS_ATTRIBUTE_BODY_PARAMS = [
+  "hs_code",
+  "origin_country",
+  "material",
+  "mid_code",
+]
+
+/** Both sets, for a tool that should advertise everything a route accepts. */
+export const PHYSICAL_AND_CUSTOMS_BODY_PARAMS = [
+  ...PHYSICAL_ATTRIBUTE_BODY_PARAMS,
+  ...CUSTOMS_ATTRIBUTE_BODY_PARAMS,
+]
+
+/** JSON Schema properties for the physical dimensions. */
+export const physicalAttributeSchemaProps = (): Record<string, SchemaProp> => ({
+  weight: NUM(
+    "Shipping weight of ONE unit, in GRAMS (e.g. 115 for a 115g shawl). Required before freight can be quoted — a variant with no weight is refused by the shipping estimate rather than guessed at."
+  ),
+  length: NUM("Length in CENTIMETRES."),
+  width: NUM("Width in CENTIMETRES."),
+  height: NUM("Height in CENTIMETRES."),
+})
+
+/** JSON Schema properties for the customs attributes. */
+export const customsAttributeSchemaProps = (): Record<string, SchemaProp> => ({
+  hs_code: STR(
+    "HS/HSN customs code. Required for international shipping labels. Assign a real code — the last digits are ITC-HS sub-lines and must never be invented."
+  ),
+  origin_country: STR("ISO-2 country of manufacture, e.g. 'IN'."),
+  material: STR("Material description for customs, e.g. '100% pashmina wool'."),
+  mid_code: STR("Manufacturer Identification (MID) code for customs."),
+})
+
+/** Everything, for a tool that advertises both sets. */
+export const physicalAndCustomsSchemaProps = (): Record<string, SchemaProp> => ({
+  ...physicalAttributeSchemaProps(),
+  ...customsAttributeSchemaProps(),
+})

--- a/apps/backend/src/workflows/products/__tests__/bulk-upsert-product-specs.unit.spec.ts
+++ b/apps/backend/src/workflows/products/__tests__/bulk-upsert-product-specs.unit.spec.ts
@@ -1,0 +1,201 @@
+/**
+ * The rules that make a batch spec write safe, pinned.
+ *
+ * The write itself is `upsertProductSpecWorkflow`, already covered by the
+ * product-spec module's own suite. What is new here — and what can quietly go
+ * wrong across a hundred rows — is everything AROUND the write: which rows are
+ * allowed, which are silently collapsed, and whether a dry run tells the truth
+ * about what it would replace.
+ */
+
+jest.mock("../upsert-product-spec", () => ({
+  upsertProductSpecWorkflow: jest.fn(),
+}))
+
+import {
+  bulkUpsertProductSpecs,
+  BULK_SPEC_MAX_PRODUCTS,
+} from "../bulk-upsert-product-specs"
+import { upsertProductSpecWorkflow } from "../upsert-product-spec"
+
+const runMock = jest.fn()
+
+const makeContainer = (specsByProduct: Record<string, unknown> = {}) => ({
+  resolve: () => ({
+    findByProduct: async (id: string) => specsByProduct[id] ?? null,
+  }),
+})
+
+beforeEach(() => {
+  jest.clearAllMocks()
+  runMock.mockResolvedValue({ result: {} })
+  ;(upsertProductSpecWorkflow as unknown as jest.Mock).mockReturnValue({
+    run: runMock,
+  })
+})
+
+const SPEC = { weave_technique: "pashmina-plain" }
+
+describe("bulkUpsertProductSpecs", () => {
+  it("writes nothing at all under dry_run", async () => {
+    const res = await bulkUpsertProductSpecs(
+      makeContainer(),
+      { products: [{ product_id: "prod_1" }], spec: SPEC, dry_run: true }
+    )
+
+    expect(runMock).not.toHaveBeenCalled()
+    expect(res.dry_run).toBe(true)
+    expect(res.results[0]).toMatchObject({ product_id: "prod_1", ok: true })
+  })
+
+  it("reports created vs updated from what is actually stored", async () => {
+    const res = await bulkUpsertProductSpecs(
+      makeContainer({ prod_has: { id: "spec_1" } }),
+      {
+        products: [{ product_id: "prod_has" }, { product_id: "prod_none" }],
+        spec: SPEC,
+        dry_run: true,
+      }
+    )
+
+    expect(res.results).toEqual([
+      expect.objectContaining({ product_id: "prod_has", action: "updated" }),
+      expect.objectContaining({ product_id: "prod_none", action: "created" }),
+    ])
+  })
+
+  it("names the replace-wholesale keys so a dry run can be read as a warning", async () => {
+    // colors/fields/options REPLACE stored rows. Across a batch this is the
+    // sharpest edge, and a plan that does not name it is a plan that hides it.
+    const res = await bulkUpsertProductSpecs(
+      makeContainer(),
+      {
+        products: [{ product_id: "prod_1" }],
+        spec: { ...SPEC, colors: [], options: [] } as any,
+        dry_run: true,
+      }
+    )
+
+    expect(res.results[0].replaces).toEqual(["colors", "options"])
+  })
+
+  it("omits `replaces` when the spec touches none of those keys", async () => {
+    const res = await bulkUpsertProductSpecs(
+      makeContainer(),
+      { products: [{ product_id: "prod_1" }], spec: SPEC, dry_run: true }
+    )
+
+    expect(res.results[0].replaces).toBeUndefined()
+  })
+
+  it("lets a row's own spec win over the batch-wide one", async () => {
+    await bulkUpsertProductSpecs(makeContainer(), {
+      products: [
+        { product_id: "prod_1", spec: { weave_technique: "kani" } as any },
+        { product_id: "prod_2" },
+      ],
+      spec: SPEC,
+    })
+
+    expect(runMock).toHaveBeenCalledTimes(2)
+    expect(runMock.mock.calls[0][0].input.data).toEqual({
+      weave_technique: "kani",
+    })
+    expect(runMock.mock.calls[1][0].input.data).toEqual(SPEC)
+  })
+
+  it("turns an out-of-scope id into an error row instead of writing it", async () => {
+    const res = await bulkUpsertProductSpecs(
+      makeContainer(),
+      {
+        products: [{ product_id: "mine" }, { product_id: "someone_elses" }],
+        spec: SPEC,
+      },
+      { allowedProductIds: new Set(["mine"]) }
+    )
+
+    expect(runMock).toHaveBeenCalledTimes(1)
+    expect(runMock.mock.calls[0][0].input.product_id).toBe("mine")
+    expect(res.error_count).toBe(1)
+    // "not found", never "not yours" — a partner must not be able to use this
+    // route to discover that a product exists and belongs to someone else.
+    expect(res.results[1].error).toBe("Product someone_elses not found")
+  })
+
+  it("keeps the rest of the batch when one row throws", async () => {
+    runMock
+      .mockRejectedValueOnce(new Error("bad weave param"))
+      .mockResolvedValue({ result: {} })
+
+    const res = await bulkUpsertProductSpecs(makeContainer(), {
+      products: [{ product_id: "prod_bad" }, { product_id: "prod_good" }],
+      spec: SPEC,
+    })
+
+    expect(res.ok_count).toBe(1)
+    expect(res.error_count).toBe(1)
+    expect(res.results[0].error).toBe("bad weave param")
+    expect(res.results[1].ok).toBe(true)
+  })
+
+  it("collapses a duplicated product to its last entry, and says so", async () => {
+    // Writing twice would be worse than it looks: because colors/fields/options
+    // replace, the second write silently discards the first.
+    const res = await bulkUpsertProductSpecs(makeContainer(), {
+      products: [
+        { product_id: "prod_1", spec: { weave_technique: "first" } as any },
+        { product_id: "prod_1", spec: { weave_technique: "last" } as any },
+      ],
+    })
+
+    expect(runMock).toHaveBeenCalledTimes(1)
+    expect(runMock.mock.calls[0][0].input.data).toEqual({
+      weave_technique: "last",
+    })
+    expect(res.warnings.join(" ")).toContain("more than once")
+  })
+
+  it("errors the row when neither a row spec nor a batch spec is given", async () => {
+    const res = await bulkUpsertProductSpecs(makeContainer(), {
+      products: [{ product_id: "prod_1" }],
+    })
+
+    expect(runMock).not.toHaveBeenCalled()
+    expect(res.results[0].action).toBe("error")
+  })
+
+  it("caps the batch and warns rather than silently truncating", async () => {
+    const products = Array.from(
+      { length: BULK_SPEC_MAX_PRODUCTS + 5 },
+      (_, i) => ({ product_id: `prod_${i}` })
+    )
+
+    const res = await bulkUpsertProductSpecs(makeContainer(), {
+      products,
+      spec: SPEC,
+    })
+
+    expect(res.requested).toBe(BULK_SPEC_MAX_PRODUCTS)
+    expect(res.warnings.join(" ")).toContain("only the first")
+  })
+
+  it("still writes when the existing-spec lookup fails", async () => {
+    // The read only decides the created/updated label. Failing the row for it
+    // would refuse a legitimate write over a cosmetic detail.
+    const container = {
+      resolve: () => ({
+        findByProduct: async () => {
+          throw new Error("db hiccup")
+        },
+      }),
+    }
+
+    const res = await bulkUpsertProductSpecs(container, {
+      products: [{ product_id: "prod_1" }],
+      spec: SPEC,
+    })
+
+    expect(runMock).toHaveBeenCalledTimes(1)
+    expect(res.ok_count).toBe(1)
+  })
+})

--- a/apps/backend/src/workflows/products/bulk-upsert-product-specs.ts
+++ b/apps/backend/src/workflows/products/bulk-upsert-product-specs.ts
@@ -1,0 +1,212 @@
+import { ContainerRegistrationKeys } from "@medusajs/framework/utils"
+
+import { PRODUCT_SPEC_MODULE } from "../../modules/product-spec"
+import {
+  upsertProductSpecWorkflow,
+  type ProductSpecInput,
+} from "./upsert-product-spec"
+
+/**
+ * Write a production spec across MANY products in one call (#1342 follow-up).
+ *
+ * The single-product route (`POST /partners/products/:id/spec`) is the right
+ * shape for a partner editing one piece by hand, and the wrong shape for the
+ * thing partners actually do: they weave a run of twenty shawls that share a
+ * weave, a param set and a palette, and differ only in colourway. Setting that
+ * one product at a time is twenty confirmations for one decision.
+ *
+ * Deliberately mirrors `bulk-update-products.ts` rather than inventing a second
+ * batch idiom:
+ *
+ *  - **Per-row outcomes.** One bad product id never discards the rest of the
+ *    batch. Callers read `results[]`, not the status code.
+ *  - **`dry_run` returns the plan without writing**, and the plan names every
+ *    product it would touch and whether that would CREATE or UPDATE a spec.
+ *    A partner about to overwrite fifteen existing specs should see the word
+ *    "update" fifteen times before it happens, not after.
+ *  - **Scoping is the caller's to supply.** The partner route passes the ids it
+ *    has already ownership-checked; the admin route passes none. A batch route
+ *    that decides its own scope is one refactor away from a partner writing
+ *    someone else's catalogue.
+ *
+ * ## Upsert, and why there is no separate "create"
+ *
+ * `upsertProductSpecWorkflow` already creates when absent and updates when
+ * present, and the caller almost never knows which state a given product is in
+ * — that is the whole reason for reaching for a batch. Two tools would force
+ * the caller to find out first, and would fail half a batch that happened to be
+ * mixed. So: one entry point, and the per-row outcome reports which one
+ * actually happened (`created` | `updated`), which is the information the
+ * caller wanted from the distinction in the first place.
+ *
+ * ⚠️ `colors`, `fields` and `options` REPLACE what is stored when present — the
+ * same semantics as the single route. Omit a key to leave those rows alone.
+ * Applied across a batch this is the sharpest edge here, which is why the
+ * dry-run plan reports, per product, exactly which of the three would be
+ * replaced.
+ */
+
+/** Cap per call. Above this, the caller should page. */
+export const BULK_SPEC_MAX_PRODUCTS = 100
+
+export type BulkProductSpecItem = {
+  product_id: string
+  /** Per-row spec. Wins over `spec` when both are given. */
+  spec?: ProductSpecInput
+}
+
+export type BulkUpsertProductSpecsInput = {
+  /** Products to write. */
+  products: BulkProductSpecItem[]
+  /** Applied to every row that has no `spec` of its own. */
+  spec?: ProductSpecInput
+  dry_run?: boolean
+}
+
+export type BulkSpecScope = {
+  /**
+   * When present, any product id outside this set becomes an error row rather
+   * than a write. `undefined` means unscoped (admin).
+   */
+  allowedProductIds?: Set<string>
+}
+
+export type BulkSpecRowResult = {
+  product_id: string
+  ok: boolean
+  /** What happened, or what would happen under dry_run. */
+  action: "created" | "updated" | "skipped" | "error"
+  /** Which replace-wholesale keys this row carries. */
+  replaces?: string[]
+  error?: string
+}
+
+export type BulkUpsertProductSpecsResult = {
+  dry_run: boolean
+  requested: number
+  ok_count: number
+  error_count: number
+  results: BulkSpecRowResult[]
+  warnings: string[]
+}
+
+/** The keys whose presence replaces stored rows wholesale. */
+const REPLACE_KEYS = ["colors", "fields", "options"] as const
+
+export const bulkUpsertProductSpecs = async (
+  container: any,
+  input: BulkUpsertProductSpecsInput,
+  scope: BulkSpecScope = {}
+): Promise<BulkUpsertProductSpecsResult> => {
+  const dryRun = input.dry_run === true
+  const warnings: string[] = []
+
+  const rows = Array.isArray(input.products) ? input.products : []
+
+  if (rows.length > BULK_SPEC_MAX_PRODUCTS) {
+    warnings.push(
+      `Received ${rows.length} products; only the first ${BULK_SPEC_MAX_PRODUCTS} were processed. Send the rest in another call.`
+    )
+  }
+  const capped = rows.slice(0, BULK_SPEC_MAX_PRODUCTS)
+
+  // Deduplicate, keeping the LAST occurrence. Two rows for one product would
+  // otherwise write twice, and — because colors/fields/options replace — the
+  // second silently discards the first. Reporting it beats resolving it
+  // quietly.
+  const seen = new Map<string, BulkProductSpecItem>()
+  for (const row of capped) {
+    const id = String(row?.product_id ?? "").trim()
+    if (!id) continue
+    if (seen.has(id)) {
+      warnings.push(
+        `Product ${id} appeared more than once; only the last entry was applied.`
+      )
+    }
+    seen.set(id, row)
+  }
+
+  const service: any = container.resolve(PRODUCT_SPEC_MODULE)
+  const results: BulkSpecRowResult[] = []
+
+  for (const [productId, row] of seen) {
+    const spec = row.spec ?? input.spec
+
+    if (!spec || typeof spec !== "object") {
+      results.push({
+        product_id: productId,
+        ok: false,
+        action: "error",
+        error:
+          "No spec for this row. Provide `spec` on the row, or a batch-wide `spec`.",
+      })
+      continue
+    }
+
+    if (scope.allowedProductIds && !scope.allowedProductIds.has(productId)) {
+      // Same wording the single route's ownership check produces, so a partner
+      // cannot tell "not yours" from "does not exist".
+      results.push({
+        product_id: productId,
+        ok: false,
+        action: "error",
+        error: `Product ${productId} not found`,
+      })
+      continue
+    }
+
+    const replaces = REPLACE_KEYS.filter(
+      (k) => (spec as Record<string, unknown>)[k] !== undefined
+    )
+
+    let existing: unknown = null
+    try {
+      existing = await service.findByProduct(productId)
+    } catch {
+      // A read failure here only costs us the created/updated label; the write
+      // below is still the source of truth. Don't fail the row for it.
+      existing = null
+    }
+    const action = existing ? "updated" : "created"
+
+    if (dryRun) {
+      results.push({
+        product_id: productId,
+        ok: true,
+        action,
+        ...(replaces.length ? { replaces } : {}),
+      })
+      continue
+    }
+
+    try {
+      await upsertProductSpecWorkflow(container).run({
+        input: { product_id: productId, data: spec as any },
+      })
+      results.push({
+        product_id: productId,
+        ok: true,
+        action,
+        ...(replaces.length ? { replaces } : {}),
+      })
+    } catch (e: any) {
+      results.push({
+        product_id: productId,
+        ok: false,
+        action: "error",
+        error: e?.message ? String(e.message) : "Failed to write spec",
+      })
+    }
+  }
+
+  const okCount = results.filter((r) => r.ok).length
+
+  return {
+    dry_run: dryRun,
+    requested: seen.size,
+    ok_count: okCount,
+    error_count: results.length - okCount,
+    results,
+    warnings,
+  }
+}


### PR DESCRIPTION
Four related pieces, all found chasing one symptom: **freight was unquotable for a third of a catalogue and nothing said why.**

---

## 1. `weight` was silently stripped from every variant write (`141328ae2`)

The founder set variant weights through the assistant, saw correct-looking dry-run plans, and nothing persisted.

`weight` was missing from `bodyParams` on every single-record product/variant tool while **every route behind them accepted it**. `pick()` (`lib/mcp-core/dispatch.ts:72`) is a pure allowlist walk, so the field was dropped with no error and no warning — and because the dry-run plan is built from the already-picked body, **a rehearsal could not reveal it either**. The tool returned `ok: true`, the route 200'd, nothing was written. `/store/shipping-estimate` then refused those variants.

Registry-only fix: core's `.strict()` validators already accept `weight/length/width/height/mid_code`, and the partner routes spread the raw body into the workflow.

- The four rows fixed. `add_product_variant` had no customs fields either, so variants were born weightless **and** codeless.
- Vocabulary in **one file** (`lib/product-attributes/tool-schema.ts`) rather than four copies — the reason `product-spec/tool-schema.ts` gives.
- **Units stated in every description.** Weight is grams here; a unitless "weight" invites a partner-facing kilogram.
- The dispatcher now reports unforwarded arguments as `dropped_arguments` on the plan and `warnings` on the result. Not a rejection — a stale row would break callers doing nothing wrong — but the silence is what let this survive.

**The #1348 contract test could not have caught it.** `required-args.unit.spec.ts:43` asserts `bodyParams ⊆ inputSchema` — one-directional, and structurally blind to a field missing from *both*. The new test starts from **core's validators, imported rather than transcribed**, and asserts every accepted field is advertised or named in a `DELIBERATELY_OMITTED` list with a reason. Verified by mutation: removing `weight` turns 5 assertions red. Writing the omission list surfaced three pre-existing mismatches.

## 2. Bulk production-spec write (`9ab6f0d52`)

`POST /admin/products/spec-bulk` + partner mirror, `bulk_set_product_spec` on both registries. A partner weaving a run of twenty shawls that share a weave and palette had to confirm twenty times for one decision.

One entry point, not a create and an update: `upsertProductSpecWorkflow` already does both, and the caller reaching for a batch is exactly the one who doesn't know which state each product is in. The per-row outcome reports `created`/`updated`.

⚠️ `colors`/`fields`/`options` REPLACE stored rows. Across a hundred products that's the sharpest edge here, so the dry-run plan names per product which of the three it would replace.

Ownership calls `assertProductOwnership` once per row rather than reimplementing it as a set query — its own docblock says why, and a batch route is the worst place to hold a drifting copy. Failed ids report "not found", so the route can't be used to discover someone else's catalogue.

## 3. Assistant stops rediscovering its own caller (`8ed50171a`, closes the re-lookup half of #1392)

The system prompt's first instruction was *"ALWAYS call `get_partner_profile` first"*, so every conversation spent a round trip learning which store it was writing to — and unreliably: a model that forgets to look asks the partner which store they mean, about a partner who has one.

Identity + store ids now resolve server-side in one graph call into the system prompt. **Not a cache** — `lib/assistant-context` caches what the model *found*; this states what the server *knows*, recomputed every turn. Failure returns null and logs, never throws.

## 4. Orphan-store maintenance job (`ed2c45e08`)

A partner's store was created twice, two days apart, the first misspelled. The abandoned one is linked to no partner — and `resolveBrandLocationId()` identifies the brand store as *the* store with no partner link, so **two unlinked stores make it throw**.

There is no store DELETE route in core or ours, hence a job.

Verified against prod: no partner link, 0 products, 0 orders, no stock levels. **Its default region is shared with ~10 partner stores**, so the job never touches the region and says so as an explicit line in its dry-run plan. Refuses when the target is the ONLY unlinked store — that would turn "found 2" into "found 0", causing the failure it exists to fix.

---

## Verification

- `check:prod-build` green.
- tsc at the known 75-error baseline, none in changed files.
- New tests: 21 (field coverage) + 11 (bulk spec) + 13 (identity) + 9 (orphan job).
- The one red suite in the sweep is `audit-ai-platforms`, one of the four known-red baseline suites.

## After deploy

1. Probe `update_product_variant` with a weight and **read the row back** — a 200 proves the call, never the effect.
2. Backfill the 11 weightless variants.
3. Dry-run `delete-orphan-store` before the real run.

🤖 Generated with [Claude Code](https://claude.com/claude-code)