### PR TITLE
fix(storefront): one dangling channel link 500'd EVERY partner storefront

### DIFF
--- a/apps/backend/src/api/admin/ops/maintenance-jobs/delete-orphan-store-job.ts
+++ b/apps/backend/src/api/admin/ops/maintenance-jobs/delete-orphan-store-job.ts
@@ -204,6 +204,20 @@ export const deleteOrphanStoreJob: MaintenanceJob = {
       orderCount = (orders ?? []).length
     }
 
+    // Publishable keys on that channel, resolved up front so the DRY RUN can
+    // name them. A rehearsal that omits an entity the real run deletes is a
+    // rehearsal of a different job — and this is the exact entity whose
+    // omission caused the 2026-08-21 storefront outage.
+    let orphanKeys: Array<{ id: string; title?: string }> = []
+    if (channelId) {
+      const { data: keys } = await query.graph({
+        entity: "api_key",
+        fields: ["id", "title", "type"],
+        filters: { type: "publishable", sales_channels: { id: channelId } },
+      })
+      orphanKeys = (keys ?? []) as any[]
+    }
+
     let stockLevelCount = 0
     if (locationId) {
       const { data: levels } = await query.graph({
@@ -250,6 +264,17 @@ export const deleteOrphanStoreJob: MaintenanceJob = {
       },
     ]
     if (cascade) {
+      // Before the channel, mirroring the deletion order — the key's link must
+      // go before the thing it points at.
+      for (const k of orphanKeys) {
+        changes.push({
+          entity: "publishable_key",
+          id: k.id,
+          field: "deleted",
+          before: k.title ?? k.id,
+          after: "(removed)",
+        })
+      }
       if (channelId) {
         changes.push({
           entity: "sales_channel",
@@ -285,7 +310,7 @@ export const deleteOrphanStoreJob: MaintenanceJob = {
         dry_run,
         applied: false,
         summary: `Would delete store ${store.name ?? store_id} (${store_id})${
-          cascade ? " and its own sales channel + stock location" : ""
+          cascade ? " and its own publishable key + sales channel + stock location" : ""
         }. No products, orders or stock. Region ${facts.region_id ?? "(none)"} left untouched.`,
         changes,
         errors: [],
@@ -309,7 +334,43 @@ export const deleteOrphanStoreJob: MaintenanceJob = {
       // Best-effort, and deliberately AFTER the store: the store row is what
       // breaks brand resolution, so a channel that refuses to delete must not
       // leave the store standing.
+      //
+      // 🔴 The publishable key goes FIRST, before its sales channel.
+      //
+      // This job's description promised to remove the key and no code ever
+      // did. On 2026-08-21 that took every partner storefront down: the
+      // channel was deleted, the key survived pointing at it, and
+      // `/web/storefront/resolve` expanded the dangling link to
+      // `sales_channels: [null]` and threw. That query is unfiltered across
+      // ALL publishable keys, so one orphan key broke resolution for every
+      // tenant, and the edge middleware served its no-storefront 404
+      // platform-wide.
+      //
+      // Deleting the key first means the link is gone before the channel is,
+      // so the dangling state never exists — not even in the window between
+      // two awaits, and not at all if the channel delete then fails.
       if (channelId) {
+        try {
+          const apiKeyService: any = container.resolve("api_key")
+          const keys = await apiKeyService.listApiKeys({
+            type: "publishable",
+            sales_channels: { id: channelId },
+          })
+          for (const k of keys ?? []) {
+            // A publishable key cannot be deleted until it is revoked; core
+            // refuses with "Cannot delete api keys that are not revoked".
+            if (!k.revoked_at) {
+              await apiKeyService.revoke(k.id, { revoked_by: "delete-orphan-store" })
+            }
+            await apiKeyService.deleteApiKeys([k.id])
+          }
+        } catch (err: any) {
+          errors.push({
+            id: channelId,
+            message: `Store deleted, but its publishable key was not — this leaves a dangling sales-channel link that breaks storefront resolution for EVERY tenant; remove it by hand: ${err?.message ?? err}`,
+          })
+        }
+
         try {
           const scService: any = container.resolve("sales_channel")
           await scService.softDeleteSalesChannels([channelId])
@@ -338,7 +399,7 @@ export const deleteOrphanStoreJob: MaintenanceJob = {
       dry_run,
       applied: true,
       summary: `Deleted store ${store.name ?? store_id} (${store_id})${
-        cascade ? " and its own sales channel + stock location" : ""
+        cascade ? " and its own publishable key + sales channel + stock location" : ""
       }. Region ${facts.region_id ?? "(none)"} untouched.${
         errors.length ? ` ${errors.length} cascade step(s) failed.` : ""
       }`,

--- a/apps/backend/src/api/web/storefront/__tests__/resolve-key.unit.spec.ts
+++ b/apps/backend/src/api/web/storefront/__tests__/resolve-key.unit.spec.ts
@@ -1,0 +1,135 @@
+import { hostToCandidates, resolveStorefrontForPartner } from "../resolve-key"
+
+/**
+ * The multi-tenant host → publishable-key walk, and the cross-tenant outage it
+ * caused on 2026-08-21.
+ *
+ * `resolveStorefrontForPartner` queries EVERY publishable key on the platform
+ * unfiltered, then `.find`s the one linked to this partner's sales channel.
+ * That makes the query a shared blast radius: the predicate runs against other
+ * tenants' rows on the way to this tenant's.
+ *
+ * An orphan store's sales channel was deleted while its publishable key
+ * survived. The dangling link expanded to `sales_channels: [null]`, the
+ * unguarded `sc.id` threw, and because the edge middleware treats any non-ok
+ * resolve as "no storefront at this host", EVERY partner storefront served the
+ * no-tenant 404 — including the ones whose own data was perfectly fine.
+ *
+ * The lesson these tests pin down: one tenant's dead row must not be able to
+ * take down another tenant's storefront.
+ */
+
+const key = (id: string, channelIds: (string | null)[]) => ({
+  id,
+  token: `pk_${id}`,
+  sales_channels: channelIds.map((c) => (c === null ? null : { id: c })),
+})
+
+const queryReturning = (apiKeys: any[]) => ({
+  graph: async () => ({ data: apiKeys }),
+})
+
+const partner = (over: any = {}) => ({
+  id: "partner_1",
+  name: "Sharlho",
+  handle: "sharlho",
+  metadata: {},
+  stores: [
+    {
+      id: "store_1",
+      name: "Sharlho Store",
+      default_sales_channel_id: "sc_live",
+      default_region_id: "reg_1",
+    },
+  ],
+  ...over,
+})
+
+describe("resolveStorefrontForPartner", () => {
+  it("resolves the key linked to the partner's sales channel", async () => {
+    const q = queryReturning([
+      key("apk_other", ["sc_other"]),
+      key("apk_mine", ["sc_live"]),
+    ])
+
+    const res = await resolveStorefrontForPartner(q as any, partner())
+
+    expect(res.publishable_key).toBe("pk_apk_mine")
+    expect(res.sales_channel_id).toBe("sc_live")
+    expect(res.store.id).toBe("store_1")
+  })
+
+  it("survives ANOTHER tenant's dangling sales-channel link", async () => {
+    // The regression. The orphan key sorts BEFORE the real one, so the
+    // predicate meets the dead link first — exactly what happened on prod.
+    const q = queryReturning([
+      key("apk_orphan", [null]),
+      key("apk_mine", ["sc_live"]),
+    ])
+
+    const res = await resolveStorefrontForPartner(q as any, partner())
+
+    expect(res.publishable_key).toBe("pk_apk_mine")
+  })
+
+  it("survives a key whose sales_channels is missing entirely", async () => {
+    const q = queryReturning([
+      { id: "apk_weird", token: "pk_weird" },
+      key("apk_mine", ["sc_live"]),
+    ])
+
+    await expect(
+      resolveStorefrontForPartner(q as any, partner())
+    ).resolves.toMatchObject({ publishable_key: "pk_apk_mine" })
+  })
+
+  it("returns a null key rather than throwing when nothing matches", async () => {
+    // A partner with no key is a configuration gap, not a crash — and the
+    // caller still needs the store/sales-channel it did resolve.
+    const q = queryReturning([key("apk_other", ["sc_other"])])
+
+    const res = await resolveStorefrontForPartner(q as any, partner())
+
+    expect(res.publishable_key).toBeNull()
+    expect(res.sales_channel_id).toBe("sc_live")
+  })
+
+  it("404s a partner with no store", async () => {
+    await expect(
+      resolveStorefrontForPartner(queryReturning([]) as any, partner({ stores: [] }))
+    ).rejects.toThrow(/No store configured/)
+  })
+
+  it("404s a store with no default sales channel", async () => {
+    const p = partner({
+      stores: [{ id: "store_1", name: "S", default_sales_channel_id: null }],
+    })
+
+    await expect(
+      resolveStorefrontForPartner(queryReturning([]) as any, p)
+    ).rejects.toThrow(/No sales channel configured/)
+  })
+})
+
+describe("hostToCandidates", () => {
+  it("lowercases, strips the port and strips a leading www.", () => {
+    expect(hostToCandidates("WWW.Sharlho.com:3000")).toEqual({
+      host: "sharlho.com",
+      subdomain: null,
+    })
+  })
+
+  it("extracts the first label as a subdomain only when there are 3+ labels", () => {
+    expect(hostToCandidates("sharlho.cicilabel.com").subdomain).toBe("sharlho")
+    expect(hostToCandidates("sharlho.com").subdomain).toBeNull()
+  })
+
+  it("treats an apex custom domain as having no subdomain", () => {
+    // Otherwise `uniquepashmina.com` would look for a partner handled
+    // "uniquepashmina" via the subdomain path and match by accident.
+    expect(hostToCandidates("uniquepashmina.com")).toEqual({
+      host: "uniquepashmina.com",
+      subdomain: null,
+    })
+  })
+})

--- a/apps/backend/src/api/web/storefront/resolve-key.ts
+++ b/apps/backend/src/api/web/storefront/resolve-key.ts
@@ -51,6 +51,22 @@ export async function resolveStorefrontForPartner(
   }
 
   // Find the publishable key linked to this sales channel.
+  //
+  // ⚠️ This query is UNFILTERED across every publishable key on the platform,
+  // so it is a shared blast radius: `.find` evaluates the predicate against
+  // other tenants' keys before reaching this one's. A single malformed row
+  // therefore breaks resolution for every partner ordered after it, not just
+  // the partner who owns it.
+  //
+  // That is not hypothetical. Deleting a store's sales channel while its
+  // publishable key survived left a dangling link, and the expansion returned
+  // `sales_channels: [null]`. The unguarded `sc.id` threw
+  // `TypeError: Cannot read properties of undefined (reading 'id')`, and EVERY
+  // partner storefront 404'd — the edge middleware treats a non-ok resolve as
+  // "no tenant here" and serves its no-storefront page.
+  //
+  // So `sc?.id` is not defensive noise. A dead link belonging to one tenant
+  // must never be able to take down another's storefront.
   const { data: apiKeys } = await query.graph({
     entity: "api_keys",
     fields: ["*", "sales_channels.*"],
@@ -58,7 +74,7 @@ export async function resolveStorefrontForPartner(
   })
 
   const matchingKey = (apiKeys || []).find((key: any) =>
-    (key.sales_channels || []).some((sc: any) => sc.id === salesChannelId)
+    (key?.sales_channels || []).some((sc: any) => sc?.id === salesChannelId)
   )
 
   return {


### PR DESCRIPTION
🔴 **Prod incident, 2026-08-21.** Every partner storefront — and every connected
custom domain — served the "no storefront wired up" page. Repaired on prod; this
PR fixes the two code defects behind it.

## What happened

Running `delete-orphan-store` with `cascade` removed a store's sales channel but
**not its publishable key**. The key survived pointing at a deleted channel, so
the graph expansion returned `sales_channels: [null]` and

```js
(key.sales_channels || []).some((sc) => sc.id === salesChannelId)
```

threw `TypeError: Cannot read properties of undefined (reading 'id')`.

## Why one orphan row took down every tenant

That query is **unfiltered across every publishable key on the platform**, so
`.find` evaluates the predicate against other tenants' rows on the way to this
tenant's. The orphan key sorted fifth of fifteen — so every partner whose key
sorted after it got a 500.

And `/web/storefront/resolve` is the tenant resolver: the edge middleware
(`apps/storefront-starter/src/middleware.ts`) treats **any** non-ok response as
"no storefront at this host" and serves its friendly no-tenant page with a 404.
So a backend `TypeError` surfaced to users as "Nothing to shop at this address"
on domains whose own data was perfectly correct.

The failure was also *silent in the obvious place*: the admin `/admin/api-keys`
route renders the same dangling link as a harmless empty array. Only the
`sales_channels.*` expansion exposes it as `[null]`.

## The fixes

**1. `resolve-key.ts` — guard both hops** (`key?.sales_channels`, `sc?.id`).

On a shared, unfiltered, cross-tenant query this is not defensive noise. It is
the property that *one tenant's malformed row cannot break another tenant's
storefront*. The comment in the file says so, with the incident, so nobody
"tidies" the `?.` away later.

**2. `delete-orphan-store-job.ts` — actually delete the publishable key.**

Its `description` and its docblock both already **claimed** it did — "its own
sales channel, stock location and publishable key" — and no code ever did. A
claim in a docblock is not an implementation.

- The key is removed **before** its sales channel, so the dangling state never
  exists: not in the window between two awaits, and not at all if the channel
  delete subsequently fails.
- It is **revoked first**, since core refuses with "Cannot delete api keys that
  are not revoked".
- The **dry run lists it too**. A rehearsal that omits an entity the real run
  deletes is a rehearsal of a different job — which is exactly how this shipped
  unnoticed, since the dry run I read before executing looked complete.
- The failure message says what a leftover key actually causes, rather than
  "could not delete key".

## Verification

- prod repaired: orphan key revoked + deleted; `/web/storefront/resolve` back to
  **200** for `sharlho.cicilabel.com`, `uniquepashmina.cicilabel.com`,
  `perennial.cicilabel.com`, `hr-handloom.cicilabel.com`, and the custom domains
  `uniquepashmina.com`, `www.uniquepashmina.com`, `sharlho.com`,
  `www.sharlho.com`. Storefronts render (200 after the region redirect).
- 9 new unit tests; **reverting the guard reproduces the exact production
  TypeError** in the regression test
- `check:prod-build` green

## Follow-up worth doing separately

`resolveStorefrontForPartner` should filter the `api_keys` query by the sales
channel instead of fetching every key and scanning. That removes the shared
blast radius entirely rather than making it survivable, but it is a behaviour
change to a hot public path and does not belong in an incident fix.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
