### PR TITLE
fix(consumption): the brand-store heuristic broke on every partner deletion

### DIFF
--- a/apps/backend/src/workflows/consumption-logs/__tests__/resolve-brand-location.unit.spec.ts
+++ b/apps/backend/src/workflows/consumption-logs/__tests__/resolve-brand-location.unit.spec.ts
@@ -1,0 +1,118 @@
+import { resolveBrandLocationId } from "../lib/apply-to-inventory"
+
+/**
+ * The brand-store heuristic, and the soft-delete hole that broke it on prod.
+ *
+ * `deletePartnerWorkflow` soft-deletes a partner and its admins and leaves
+ * EVERYTHING else alone — the store, the sales channel, the stock location and
+ * the partner↔store link all survive untouched. `query.graph` excludes
+ * soft-deleted rows unless `withDeleted` is passed, so a deleted partner
+ * disappears from the query while its store does not, and the store gets
+ * counted as a second brand store.
+ *
+ * That is not hypothetical: the helper threw on prod ("found 2") until an
+ * orphan store was removed, and it would have re-broken on the next partner
+ * deletion.
+ */
+
+type GraphCall = { entity: string; withDeleted?: boolean }
+
+const containerWith = (
+  partners: any[],
+  stores: any[],
+  calls: GraphCall[] = []
+) => ({
+  resolve: () => ({
+    graph: async (args: any) => {
+      calls.push({ entity: args.entity, withDeleted: args.withDeleted })
+      if (args.entity === "partners") {
+        // Mimic the real default: soft-deleted rows are invisible unless asked for.
+        const visible = args.withDeleted
+          ? partners
+          : partners.filter((p) => !p.deleted_at)
+        return { data: visible }
+      }
+      return { data: stores }
+    },
+  }),
+})
+
+const BRAND = { id: "store_brand", default_location_id: "sloc_brand" }
+const PARTNER_STORE = { id: "store_partner", default_location_id: "sloc_p" }
+
+describe("resolveBrandLocationId", () => {
+  it("returns the one store no partner reaches", async () => {
+    const container = containerWith(
+      [{ id: "p1", stores: [{ id: PARTNER_STORE.id }] }],
+      [BRAND, PARTNER_STORE]
+    )
+
+    await expect(
+      resolveBrandLocationId(container as any)
+    ).resolves.toBe("sloc_brand")
+  })
+
+  it("still excludes the store of a SOFT-DELETED partner", async () => {
+    // The regression. Before `withDeleted: true`, the deleted partner vanished
+    // from the query, its surviving store looked unowned, and the count hit 2.
+    const container = containerWith(
+      [
+        { id: "p1", stores: [{ id: PARTNER_STORE.id }] },
+        {
+          id: "p2",
+          deleted_at: "2026-08-01T00:00:00.000Z",
+          stores: [{ id: "store_of_deleted_partner" }],
+        },
+      ],
+      [BRAND, PARTNER_STORE, { id: "store_of_deleted_partner" }]
+    )
+
+    await expect(
+      resolveBrandLocationId(container as any)
+    ).resolves.toBe("sloc_brand")
+  })
+
+  it("asks for deleted partners explicitly — the flag is opt-in, so omitting it is the bug", async () => {
+    const calls: GraphCall[] = []
+    const container = containerWith(
+      [{ id: "p1", stores: [{ id: PARTNER_STORE.id }] }],
+      [BRAND, PARTNER_STORE],
+      calls
+    )
+
+    await resolveBrandLocationId(container as any)
+
+    expect(calls.find((c) => c.entity === "partners")?.withDeleted).toBe(true)
+  })
+
+  it("throws, rather than guessing, when two stores look unowned", async () => {
+    const container = containerWith(
+      [{ id: "p1", stores: [{ id: PARTNER_STORE.id }] }],
+      [BRAND, PARTNER_STORE, { id: "store_stray" }]
+    )
+
+    await expect(resolveBrandLocationId(container as any)).rejects.toThrow(
+      /found 2/
+    )
+  })
+
+  it("throws when none look unowned", async () => {
+    const container = containerWith(
+      [{ id: "p1", stores: [{ id: BRAND.id }, { id: PARTNER_STORE.id }] }],
+      [BRAND, PARTNER_STORE]
+    )
+
+    await expect(resolveBrandLocationId(container as any)).rejects.toThrow(
+      /found 0/
+    )
+  })
+
+  it("throws when the brand store has no default location", async () => {
+    const container = containerWith(
+      [{ id: "p1", stores: [{ id: PARTNER_STORE.id }] }],
+      [{ id: "store_brand", default_location_id: null }, PARTNER_STORE]
+    )
+
+    await expect(resolveBrandLocationId(container as any)).rejects.toThrow()
+  })
+})

--- a/apps/backend/src/workflows/consumption-logs/lib/apply-to-inventory.ts
+++ b/apps/backend/src/workflows/consumption-logs/lib/apply-to-inventory.ts
@@ -379,6 +379,14 @@ export async function resolveCoreLocationIds(
  * a trap: prod carries legacy duplicates named after partners (`Shramdaan` vs
  * the partner's `Shramdaan India Warehouse`). Partner stores are reachable
  * through the partner↔store link, so the brand store is what's left over.
+ *
+ * ⚠️ `withDeleted` is not optional here. `deletePartnerWorkflow` SOFT-deletes a
+ * partner and leaves its store and its partner↔store link entirely alone, so
+ * without this flag a deleted partner vanishes from the query while its store
+ * does not — and the store is then mistaken for a second brand store, throwing
+ * on every caller. A store that belonged to a deleted partner is still not the
+ * brand store. This was live on prod: the heuristic threw until the orphan
+ * store was cleaned up, and would have re-broken on the next deletion.
  */
 export async function resolveBrandLocationId(
   container: MedusaContainer
@@ -388,6 +396,7 @@ export async function resolveBrandLocationId(
   const { data: partners } = await query.graph({
     entity: "partners",
     fields: ["id", "stores.id"],
+    withDeleted: true,
   })
   const partnerStoreIds = new Set<string>()
   for (const p of (partners || []) as any[]) {


### PR DESCRIPTION
Found while investigating how partners are deleted (follow-up to the
`delete-orphan-store` run).

## The bug

`resolveBrandLocationId` identifies the brand store as the one store no partner
reaches, then throws unless it finds **exactly one**. It was throwing on prod.

The cause is a soft-delete hole. `deletePartnerWorkflow` soft-deletes the
partner and its admins and **leaves everything else alone** — the store, the
sales channel, the stock location and the partner↔store link all survive
untouched. But `query.graph` excludes soft-deleted rows unless `withDeleted` is
passed, so the deleted partner disappears from the query **while its store does
not**. The store is then counted as a second brand store, and every caller
throws: `apply-to-inventory`, the `apply-committed-consumption` job, and the
orphan-store job's own safety check.

So **every partner deletion silently arms this**, and the failure surfaces later
somewhere unrelated.

## The fix

`withDeleted: true` on the partners query. A store that belonged to a deleted
partner is still not the brand store — which is exactly what the heuristic's own
docblock already claims it means.

⚠️ Prod currently sits at exactly one brand store again, because an orphan store
was removed today. **That is a coincidence of the data, not a fix** — the next
partner deletion would have re-broken it silently.

## Verification

Six unit tests over a faked container, including one asserting the flag is
passed **at all** — it is opt-in, so omitting it is the entire bug and a test
that only checks the output would pass against a lucky dataset. Both
soft-delete tests were confirmed to fail without the change.

## Still open (your call)

Partner deletion currently leaves the store, sales channel, publishable key,
products and links all live. That is precisely how the orphan store this began
with came to exist. Worth deciding deliberately: keep soft-delete (reversible,
preserves commercial history) but make it **complete**, versus leaving it
partial.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
