### PR TITLE
fix(storefront): scope the publishable-key lookup to one tenant (#1399 item 2)

### DIFF
--- a/apps/backend/src/api/web/storefront/__tests__/resolve-key.unit.spec.ts
+++ b/apps/backend/src/api/web/storefront/__tests__/resolve-key.unit.spec.ts
@@ -4,10 +4,11 @@ import { hostToCandidates, resolveStorefrontForPartner } from "../resolve-key"
  * The multi-tenant host → publishable-key walk, and the cross-tenant outage it
  * caused on 2026-08-21.
  *
- * `resolveStorefrontForPartner` queries EVERY publishable key on the platform
- * unfiltered, then `.find`s the one linked to this partner's sales channel.
- * That makes the query a shared blast radius: the predicate runs against other
- * tenants' rows on the way to this tenant's.
+ * `resolveStorefrontForPartner` USED TO query every publishable key on the
+ * platform unfiltered, then `.find` the one linked to this partner's sales
+ * channel. That made the query a shared blast radius: the predicate ran against
+ * other tenants' rows on the way to this tenant's. It is now filtered by sales
+ * channel at the database (#1399 item 2), and the guard below it stays.
  *
  * An orphan store's sales channel was deleted while its publishable key
  * survived. The dangling link expanded to `sales_channels: [null]`, the
@@ -131,5 +132,51 @@ describe("hostToCandidates", () => {
       host: "uniquepashmina.com",
       subdomain: null,
     })
+  })
+})
+
+/**
+ * #1399 item 2 — the blast radius itself, not just its symptom.
+ *
+ * The `sc?.id` guard makes a dangling link survivable. Filtering the query
+ * makes another tenant's rows unreachable, which is the stronger property: the
+ * outage needed BOTH a malformed row and a query willing to walk it.
+ */
+describe("resolveStorefrontForPartner — query scoping", () => {
+  const capturingQuery = (apiKeys: any[]) => {
+    const calls: any[] = []
+    return {
+      calls,
+      query: {
+        graph: async (args: any) => {
+          calls.push(args)
+          return { data: apiKeys }
+        },
+      },
+    }
+  }
+
+  it("filters the api_keys query by THIS partner's sales channel", async () => {
+    const { calls, query } = capturingQuery([key("apk_mine", ["sc_live"])])
+
+    await resolveStorefrontForPartner(query as any, partner())
+
+    expect(calls).toHaveLength(1)
+    expect(calls[0].entity).toBe("api_keys")
+    expect(calls[0].filters).toEqual({
+      type: "publishable",
+      sales_channels: { id: "sc_live" },
+    })
+  })
+
+  it("never asks for keys unscoped to a sales channel", async () => {
+    // A regression here is invisible in behaviour — every assertion about the
+    // returned key still passes — and only shows up as another platform-wide
+    // outage the next time one row goes bad.
+    const { calls, query } = capturingQuery([key("apk_mine", ["sc_live"])])
+
+    await resolveStorefrontForPartner(query as any, partner())
+
+    expect(calls[0].filters?.sales_channels).toBeDefined()
   })
 })

--- a/apps/backend/src/api/web/storefront/resolve-key.ts
+++ b/apps/backend/src/api/web/storefront/resolve-key.ts
@@ -52,25 +52,27 @@ export async function resolveStorefrontForPartner(
 
   // Find the publishable key linked to this sales channel.
   //
-  // ⚠️ This query is UNFILTERED across every publishable key on the platform,
-  // so it is a shared blast radius: `.find` evaluates the predicate against
-  // other tenants' keys before reaching this one's. A single malformed row
-  // therefore breaks resolution for every partner ordered after it, not just
-  // the partner who owns it.
+  // 🔴 FILTERED BY SALES CHANNEL, deliberately.
   //
-  // That is not hypothetical. Deleting a store's sales channel while its
-  // publishable key survived left a dangling link, and the expansion returned
-  // `sales_channels: [null]`. The unguarded `sc.id` threw
-  // `TypeError: Cannot read properties of undefined (reading 'id')`, and EVERY
-  // partner storefront 404'd — the edge middleware treats a non-ok resolve as
-  // "no tenant here" and serves its no-storefront page.
+  // This query used to fetch EVERY publishable key on the platform and scan for
+  // a match, which made it a shared blast radius: `.find` evaluated the
+  // predicate against other tenants' keys on the way to this one's. On
+  // 2026-08-21 a store's sales channel was deleted while its publishable key
+  // survived, the dangling link expanded to `sales_channels: [null]`, and the
+  // unguarded `sc.id` threw. Every partner whose key sorted after the orphan's
+  // got a 500 — and the edge middleware treats a non-ok resolve as "no tenant
+  // here", so it served a friendly 404 and every storefront, custom domains
+  // included, went dark.
   //
-  // So `sc?.id` is not defensive noise. A dead link belonging to one tenant
-  // must never be able to take down another's storefront.
+  // Filtering at the database is the property that makes that impossible
+  // rather than merely survivable: another tenant's rows are never walked while
+  // resolving this one's. The `sc?.id` guard below stays anyway — it now only
+  // has to hold against THIS partner's own malformed row, which is a blast
+  // radius of one.
   const { data: apiKeys } = await query.graph({
     entity: "api_keys",
     fields: ["*", "sales_channels.*"],
-    filters: { type: "publishable" },
+    filters: { type: "publishable", sales_channels: { id: salesChannelId } },
   })
 
   const matchingKey = (apiKeys || []).find((key: any) =>


### PR DESCRIPTION
Closes #1399 item 2.

#1397 made a dangling sales-channel link **survivable**. This removes the reason it could reach another tenant at all.

## The problem

`resolveStorefrontForPartner` fetched **every** publishable key on the platform and scanned for the one matching this partner's sales channel:

```ts
filters: { type: "publishable" }   // ← all tenants
...
(apiKeys || []).find((key) => (key.sales_channels || []).some((sc) => sc.id === salesChannelId))
```

So `.find` evaluated the predicate against other tenants' rows on the way to this one's. On 2026-08-21 one orphan key — pointing at a deleted channel, expanding to `sales_channels: [null]` — threw, and **every partner whose key sorted after it 500'd**. The edge middleware treats a non-ok resolve as "no storefront at this host", so the whole platform, custom domains included, served a friendly 404.

## The change

The query filters on `sales_channels.id` at the database. Another tenant's rows are never walked while resolving this one's, so a malformed row can only break the storefront that owns it — blast radius of one instead of all.

The `sc?.id` guard from #1397 stays: it is cheap, and it is now what holds when a partner's **own** row goes bad.

## Tests

Two new assertions that the filter is on the query itself. A regression here is **invisible in behaviour** — every existing assertion about the returned key still passes — and would only resurface as the next platform-wide outage.

`11 passed` in `resolve-key.unit.spec.ts`. `check:prod-build` green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)