### PR TITLE
feat(partners): partner deletion takes its tenant with it, and finally has an undo (#1399 items 1 + 3)

### DIFF
--- a/apps/backend/src/api/admin/ops/maintenance-jobs/__tests__/restore-orphan-store-job.unit.spec.ts
+++ b/apps/backend/src/api/admin/ops/maintenance-jobs/__tests__/restore-orphan-store-job.unit.spec.ts
@@ -1,0 +1,91 @@
+import {
+  checkOrphanStoreRestorable,
+  type OrphanStoreRestoreFacts,
+} from "../restore-orphan-store-job"
+
+/**
+ * The undo `delete-orphan-store` never had.
+ *
+ * It was run on prod without anyone confirming a restore path existed. None
+ * did — no `restoreStores` / `restoreSalesChannels` / `restoreStockLocations`
+ * call appeared anywhere in the codebase — even though all three deletions are
+ * soft and the rows were sitting there with `deleted_at` set the whole time.
+ */
+
+const facts = (over: Partial<OrphanStoreRestoreFacts> = {}): OrphanStoreRestoreFacts => ({
+  store_id: "store_1",
+  store_name: "Sharhlo Store",
+  store_exists: true,
+  store_deleted: true,
+  sales_channel_id: "sc_1",
+  sales_channel_deleted: true,
+  stock_location_id: "loc_1",
+  stock_location_deleted: true,
+  linked_key_count: 0,
+  ...over,
+})
+
+describe("checkOrphanStoreRestorable", () => {
+  it("restores a soft-deleted store and its siblings", () => {
+    const res = checkOrphanStoreRestorable(facts())
+
+    expect(res.restorable).toBe(true)
+    expect(res.blockers).toEqual([])
+  })
+
+  it("refuses a store that does not exist at all", () => {
+    const res = checkOrphanStoreRestorable(facts({ store_exists: false }))
+
+    expect(res.restorable).toBe(false)
+    expect(res.blockers.join(" ")).toContain("does not exist")
+  })
+
+  it("refuses a store that is not deleted, rather than no-op'ing on a typo", () => {
+    const res = checkOrphanStoreRestorable(facts({ store_deleted: false }))
+
+    expect(res.restorable).toBe(false)
+    expect(res.blockers.join(" ")).toContain("not deleted")
+  })
+
+  it("stops looking once the store itself is missing", () => {
+    // No point reporting sibling warnings about a store that isn't there.
+    const res = checkOrphanStoreRestorable(
+      facts({ store_exists: false, sales_channel_id: null })
+    )
+
+    expect(res.blockers).toHaveLength(1)
+    expect(res.warnings).toEqual([])
+  })
+
+  it("warns — never blocks — when a sibling is already live", () => {
+    // A partial restore is still a restore, and this job exists for incidents.
+    const res = checkOrphanStoreRestorable(
+      facts({ sales_channel_deleted: false, stock_location_deleted: false })
+    )
+
+    expect(res.restorable).toBe(true)
+    expect(res.warnings.join(" ")).toContain("already live")
+  })
+
+  it("says the publishable key is unrecoverable when none is linked", () => {
+    const res = checkOrphanStoreRestorable(facts({ linked_key_count: 0 }))
+
+    expect(res.warnings.join(" ")).toContain("unrecoverable")
+    expect(res.warnings.join(" ")).toContain("recreate_publishable_key")
+  })
+
+  it("stays quiet about the key when one is still linked", () => {
+    const res = checkOrphanStoreRestorable(facts({ linked_key_count: 1 }))
+
+    expect(res.warnings.join(" ")).not.toContain("unrecoverable")
+  })
+
+  it("warns when the store has no channel to restore", () => {
+    const res = checkOrphanStoreRestorable(
+      facts({ sales_channel_id: null, sales_channel_deleted: false })
+    )
+
+    expect(res.restorable).toBe(true)
+    expect(res.warnings.join(" ")).toContain("no default sales channel")
+  })
+})

--- a/apps/backend/src/api/admin/ops/maintenance-jobs/delete-orphan-store-job.ts
+++ b/apps/backend/src/api/admin/ops/maintenance-jobs/delete-orphan-store-job.ts
@@ -38,7 +38,19 @@ import type {
  *
  * 🔑 **Never a store that is doing anything.** Products, orders, stock levels
  * or a partner link each abort that store, by name, rather than being reported
- * as a warning someone might skim past. A store cannot be un-deleted.
+ * as a warning someone might skim past.
+ *
+ * ## The undo
+ *
+ * This docblock used to end "A store cannot be un-deleted", and that was wrong
+ * in the direction that costs you an incident: the store, channel and location
+ * removals are all SOFT, so they were always restorable — nobody had written
+ * the restore. `restore-orphan-store` now does (#1399 item 3).
+ *
+ * 🔴 The publishable key is the exception, and it is not recoverable. Core
+ * offers no soft delete for an api key and refuses to delete an unrevoked one,
+ * so the key below is revoked and hard-deleted, and its TOKEN is gone. The
+ * restore job can mint a replacement, but it is a different string.
  *
  * `store_id` is REQUIRED. There is no "find and delete all orphans" mode: an
  * inferred list of things to destroy is exactly the wrong place for inference,

--- a/apps/backend/src/api/admin/ops/maintenance-jobs/registry.ts
+++ b/apps/backend/src/api/admin/ops/maintenance-jobs/registry.ts
@@ -81,6 +81,7 @@ import { seedInvestorPanelsJob } from "./seed-investor-panels-job"
 import { replayFxFanoutJob } from "./fanout-fx-job"
 import { backfillStoreCurrenciesJob } from "./backfill-store-currencies-job"
 import { deleteOrphanStoreJob } from "./delete-orphan-store-job"
+import { restoreOrphanStoreJob } from "./restore-orphan-store-job"
 import { backfillPartnerEmailVerifiedJob } from "./backfill-partner-email-verified-job"
 import { backfillPartnerHostingProviderJob } from "./backfill-partner-hosting-provider-job"
 import { repointPartnerStorefrontSharedJob } from "./repoint-partner-storefront-shared-job"
@@ -5770,6 +5771,7 @@ export const MAINTENANCE_JOBS: MaintenanceJob[] = [
   replayFxFanoutJob,
   backfillStoreCurrenciesJob,
   deleteOrphanStoreJob,
+  restoreOrphanStoreJob,
   backfillPartnerEmailVerifiedJob,
   backfillPartnerHostingProviderJob,
   repointPartnerStorefrontSharedJob,

--- a/apps/backend/src/api/admin/ops/maintenance-jobs/restore-orphan-store-job.ts
+++ b/apps/backend/src/api/admin/ops/maintenance-jobs/restore-orphan-store-job.ts
@@ -1,0 +1,389 @@
+import { MedusaError } from "@medusajs/framework/utils"
+import { z } from "@medusajs/framework/zod"
+import {
+  createApiKeysWorkflow,
+  linkSalesChannelsToApiKeyWorkflow,
+} from "@medusajs/medusa/core-flows"
+
+import type {
+  MaintenanceChange,
+  MaintenanceJob,
+  MaintenanceJobResult,
+} from "./registry"
+
+/**
+ * Data Plumbing — the UNDO that `delete-orphan-store` never had.
+ *
+ * ## Why this exists
+ *
+ * On 2026-08-21 `delete-orphan-store` was run against prod without anyone
+ * first confirming a restore path existed. It did not: nothing in the codebase
+ * called `restoreStores`, `restoreSalesChannels` or `restoreStockLocations`,
+ * and the job's own docblock said "a store cannot be un-deleted".
+ *
+ * That was half true, and the half that was false is the dangerous half. All
+ * three of those removals are SOFT — the rows are intact with `deleted_at`
+ * set — so the restore was always mechanically available; it simply had never
+ * been written. The run then took every partner storefront on the platform
+ * down, and the absence of an undo turned a two-minute mistake into an
+ * incident.
+ *
+ * 🔑 **Verify the undo works before running the do.** This job is the undo.
+ *
+ * ## What it cannot bring back
+ *
+ * 🔴 **The publishable key.** `delete-orphan-store` HARD-deletes it
+ * (`deleteApiKeys`), because core refuses to delete an unrevoked key and offers
+ * no soft delete for one. That row is gone, and its token with it.
+ *
+ * `recreate_publishable_key` mints a NEW key and links it to the restored
+ * channel. That genuinely restores service — `/web/storefront/resolve` reads
+ * the token from the database on every request, so storefronts pick it up
+ * without redeployment — but the token STRING is different. Anything that
+ * hard-coded the old one stays broken, and this job cannot tell you what did.
+ * It is opt-in for that reason: silently minting a credential is not a restore.
+ */
+
+const paramsSchema = z.object({
+  /** The soft-deleted store to bring back. */
+  store_id: z.string().min(1),
+  /** Restore its sales channel too. On by default — a store without its channel serves nothing. */
+  restore_sales_channel: z.boolean().optional().default(true),
+  /** Restore its stock location too. */
+  restore_stock_location: z.boolean().optional().default(true),
+  /**
+   * Mint a NEW publishable key and link it to the restored channel. Off by
+   * default: the original token is unrecoverable and the replacement differs.
+   */
+  recreate_publishable_key: z.boolean().optional().default(false),
+})
+
+export type OrphanStoreRestoreFacts = {
+  store_id: string
+  store_name?: string | null
+  /** Whether the store row exists at all, once soft-deleted rows are included. */
+  store_exists: boolean
+  /** Whether it is actually deleted. Restoring a live store is a no-op worth refusing. */
+  store_deleted: boolean
+  sales_channel_id?: string | null
+  sales_channel_deleted: boolean
+  stock_location_id?: string | null
+  stock_location_deleted: boolean
+  /** Publishable keys currently linked to that channel — usually none, post-deletion. */
+  linked_key_count: number
+}
+
+/**
+ * PURE: can this store be restored, and if not, exactly why.
+ *
+ * Every blocker is returned, not just the first — the same rule the deletion
+ * side follows, for the same reason.
+ */
+export function checkOrphanStoreRestorable(facts: OrphanStoreRestoreFacts): {
+  restorable: boolean
+  blockers: string[]
+  warnings: string[]
+} {
+  const blockers: string[] = []
+  const warnings: string[] = []
+
+  if (!facts.store_exists) {
+    blockers.push(
+      `Store ${facts.store_id} does not exist, deleted or otherwise — there is nothing to restore.`
+    )
+    return { restorable: false, blockers, warnings }
+  }
+  if (!facts.store_deleted) {
+    blockers.push(
+      `Store ${facts.store_id} is not deleted. Restoring a live store would change nothing and hide a mistyped id.`
+    )
+  }
+
+  // Not blockers: a partial restore is still a restore, and refusing one
+  // because a single sibling row is already healthy would be unhelpful during
+  // exactly the kind of incident this job exists for.
+  if (facts.sales_channel_id && !facts.sales_channel_deleted) {
+    warnings.push(
+      `Sales channel ${facts.sales_channel_id} is already live — leaving it alone.`
+    )
+  }
+  if (!facts.sales_channel_id) {
+    warnings.push(
+      `Store ${facts.store_id} has no default sales channel recorded, so none can be restored. Its storefront will not resolve until one is attached.`
+    )
+  }
+  if (facts.stock_location_id && !facts.stock_location_deleted) {
+    warnings.push(
+      `Stock location ${facts.stock_location_id} is already live — leaving it alone.`
+    )
+  }
+  if (facts.linked_key_count === 0) {
+    warnings.push(
+      `No publishable key is linked to this store's channel. delete-orphan-store HARD-deletes the key, so the original token is unrecoverable; pass recreate_publishable_key to mint a new one.`
+    )
+  }
+
+  return { restorable: blockers.length === 0, blockers, warnings }
+}
+
+export const restoreOrphanStoreJob: MaintenanceJob = {
+  id: "restore-orphan-store",
+  label: "Restore a deleted store",
+  description:
+    "Undo delete-orphan-store: restore the soft-deleted store, its sales channel and its stock location. The publishable key was hard-deleted and cannot be recovered — optionally mint a replacement. Dry-run reports exactly what it would restore.",
+  params: [
+    {
+      name: "store_id",
+      type: "string",
+      required: true,
+      description: "The soft-deleted store to bring back, e.g. 'store_...'.",
+    } as any,
+    {
+      name: "restore_sales_channel",
+      type: "boolean",
+      required: false,
+      description: "Restore its sales channel too. Default true.",
+    } as any,
+    {
+      name: "restore_stock_location",
+      type: "boolean",
+      required: false,
+      description: "Restore its stock location too. Default true.",
+    } as any,
+    {
+      name: "recreate_publishable_key",
+      type: "boolean",
+      required: false,
+      description:
+        "Mint a NEW publishable key and link it to the restored channel. The original token is unrecoverable; the replacement is a different string.",
+    } as any,
+  ],
+
+  run: async (container, { dry_run, params }): Promise<MaintenanceJobResult> => {
+    const parsed = paramsSchema.safeParse(params)
+    if (!parsed.success) {
+      throw new MedusaError(
+        MedusaError.Types.INVALID_DATA,
+        parsed.error.issues.map((i) => i.message).join("; ")
+      )
+    }
+    const {
+      store_id,
+      restore_sales_channel,
+      restore_stock_location,
+      recreate_publishable_key,
+    } = parsed.data
+
+    const storeService: any = container.resolve("store")
+    const scService: any = container.resolve("sales_channel")
+    const locService: any = container.resolve("stock_location")
+    const apiKeyService: any = container.resolve("api_key")
+
+    // `withDeleted` is opt-in everywhere in Medusa, and the row we are looking
+    // for is by definition deleted — reading it without this returns nothing
+    // and looks exactly like "no such store".
+    const stores = await storeService.listStores(
+      { id: [store_id] },
+      { withDeleted: true }
+    )
+    const store = (stores ?? [])[0]
+
+    const channelId = store?.default_sales_channel_id ?? null
+    const locationId = store?.default_location_id ?? null
+
+    let channel: any = null
+    if (channelId) {
+      const rows = await scService.listSalesChannels(
+        { id: [channelId] },
+        { withDeleted: true }
+      )
+      channel = (rows ?? [])[0] ?? null
+    }
+
+    let location: any = null
+    if (locationId) {
+      const rows = await locService.listStockLocations(
+        { id: [locationId] },
+        { withDeleted: true }
+      )
+      location = (rows ?? [])[0] ?? null
+    }
+
+    let linkedKeyCount = 0
+    if (channelId) {
+      const keys = await apiKeyService.listApiKeys({
+        type: "publishable",
+        sales_channels: { id: channelId },
+      })
+      linkedKeyCount = (keys ?? []).length
+    }
+
+    const facts: OrphanStoreRestoreFacts = {
+      store_id,
+      store_name: store?.name ?? null,
+      store_exists: Boolean(store),
+      store_deleted: Boolean(store?.deleted_at),
+      sales_channel_id: channelId,
+      sales_channel_deleted: Boolean(channel?.deleted_at),
+      stock_location_id: locationId,
+      stock_location_deleted: Boolean(location?.deleted_at),
+      linked_key_count: linkedKeyCount,
+    }
+
+    const { restorable, blockers, warnings } =
+      checkOrphanStoreRestorable(facts)
+
+    if (!restorable) {
+      return {
+        job_id: restoreOrphanStoreJob.id,
+        dry_run,
+        applied: false,
+        summary: `REFUSED — ${store?.name ?? store_id} cannot be restored: ${blockers.join(" ")}`,
+        changes: [],
+        errors: blockers.map((message) => ({ id: store_id, message })),
+      }
+    }
+
+    const willRestoreChannel =
+      restore_sales_channel && Boolean(channelId) && facts.sales_channel_deleted
+    const willRestoreLocation =
+      restore_stock_location && Boolean(locationId) && facts.stock_location_deleted
+
+    const changes: MaintenanceChange[] = []
+    if (willRestoreChannel) {
+      changes.push({
+        entity: "sales_channel",
+        id: channelId as string,
+        field: "deleted_at",
+        before: "(deleted)",
+        after: "(restored)",
+      })
+    }
+    if (willRestoreLocation) {
+      changes.push({
+        entity: "stock_location",
+        id: locationId as string,
+        field: "deleted_at",
+        before: "(deleted)",
+        after: "(restored)",
+      })
+    }
+    changes.push({
+      entity: "store",
+      id: store_id,
+      field: "deleted_at",
+      before: "(deleted)",
+      after: "(restored)",
+    })
+    if (recreate_publishable_key && channelId) {
+      changes.push({
+        entity: "api_key",
+        id: "(new)",
+        field: "created",
+        before: "(hard-deleted, token unrecoverable)",
+        after: "NEW publishable key linked to the restored channel",
+      })
+    }
+
+    if (dry_run) {
+      return {
+        job_id: restoreOrphanStoreJob.id,
+        dry_run,
+        applied: false,
+        summary: `Would restore store ${store?.name ?? store_id} (${store_id})${
+          willRestoreChannel ? " + its sales channel" : ""
+        }${willRestoreLocation ? " + its stock location" : ""}${
+          recreate_publishable_key && channelId
+            ? " and mint a NEW publishable key (different token)"
+            : ""
+        }.`,
+        changes,
+        errors: warnings.map((message) => ({ id: store_id, message })),
+      }
+    }
+
+    const errors: Array<{ id: string; message: string }> = warnings.map(
+      (message) => ({ id: store_id, message })
+    )
+
+    // Channel and location come back BEFORE the store, mirroring the deletion
+    // order in reverse: the store is what other resolvers look at, so it must
+    // not become visible while the things it points at are still deleted.
+    if (willRestoreChannel) {
+      try {
+        await scService.restoreSalesChannels([channelId])
+      } catch (err: any) {
+        errors.push({
+          id: channelId as string,
+          message: `Could not restore the sales channel: ${err?.message ?? err}`,
+        })
+      }
+    }
+    if (willRestoreLocation) {
+      try {
+        await locService.restoreStockLocations([locationId])
+      } catch (err: any) {
+        errors.push({
+          id: locationId as string,
+          message: `Could not restore the stock location: ${err?.message ?? err}`,
+        })
+      }
+    }
+
+    try {
+      await storeService.restoreStores([store_id])
+    } catch (err: any) {
+      throw new MedusaError(
+        MedusaError.Types.UNEXPECTED_STATE,
+        `Failed to restore store ${store_id}: ${err?.message ?? err}`
+      )
+    }
+
+    let newKeyToken: string | null = null
+    if (recreate_publishable_key && channelId) {
+      try {
+        const { result } = await createApiKeysWorkflow(container).run({
+          input: {
+            api_keys: [
+              {
+                title: `${store?.name ?? store_id} storefront (restored)`,
+                type: "publishable",
+                created_by: "restore-orphan-store",
+              },
+            ],
+          },
+        })
+        const created = (result as any[])?.[0]
+        if (created?.id) {
+          // Link only AFTER the channel is back — a key pointing at a
+          // soft-deleted channel is the exact dangling state that 500'd every
+          // storefront on 2026-08-21.
+          await linkSalesChannelsToApiKeyWorkflow(container).run({
+            input: { id: created.id, add: [channelId], remove: [] },
+          })
+          newKeyToken = created.token ?? null
+        }
+      } catch (err: any) {
+        errors.push({
+          id: channelId as string,
+          message: `Store restored, but the replacement publishable key was not created: ${err?.message ?? err}`,
+        })
+      }
+    }
+
+    return {
+      job_id: restoreOrphanStoreJob.id,
+      dry_run,
+      applied: true,
+      summary: `Restored store ${store?.name ?? store_id} (${store_id})${
+        willRestoreChannel ? " + its sales channel" : ""
+      }${willRestoreLocation ? " + its stock location" : ""}${
+        newKeyToken ? ` with a NEW publishable key ${newKeyToken}` : ""
+      }.${errors.length ? ` ${errors.length} note(s)/failure(s) — read them.` : ""}`,
+      changes,
+      errors,
+    }
+  },
+}
+
+export default restoreOrphanStoreJob

--- a/apps/backend/src/api/admin/partners/[id]/route.ts
+++ b/apps/backend/src/api/admin/partners/[id]/route.ts
@@ -202,16 +202,27 @@ export const PUT = async (
   res.status(200).json({ partner: result })
 }
 
-// Delete a partner by id
+/**
+ * Soft-delete a partner, and with it the things that are meaningless without
+ * it: its store, that store's sales channel, and its products. The publishable
+ * key is UNLINKED rather than revoked or deleted — see
+ * `workflows/partners/lib/partner-deletion-plan.ts` for why each tier is what
+ * it is. Nothing here is hard-deleted, and commercial history is never touched.
+ *
+ * Refuses by default when the partner still has orders in flight. `?force=true`
+ * overrides that — the orders themselves stay untouched either way, but their
+ * storefront goes dark.
+ */
 export const DELETE = async (
   req: MedusaRequest,
   res: MedusaResponse
 ) => {
   const id = req.params.id
+  const force = String((req.query as any)?.force ?? "") === "true"
 
-  await deletePartnerWorkflow(req.scope).run({
-    input: { id },
+  const { result } = await deletePartnerWorkflow(req.scope).run({
+    input: { id, force },
   })
 
-  res.status(200).json({ id, object: "partner", deleted: true })
+  res.status(200).json({ id, object: "partner", deleted: true, result })
 }

--- a/apps/backend/src/workflows/partners/__tests__/partner-deletion-plan.unit.spec.ts
+++ b/apps/backend/src/workflows/partners/__tests__/partner-deletion-plan.unit.spec.ts
@@ -1,0 +1,121 @@
+import { planPartnerDeletion, type PartnerDeletionFacts } from "../lib/partner-deletion-plan"
+
+/**
+ * The partner-deletion cascade policy.
+ *
+ * Before this existed, deleting a partner soft-deleted the partner and its
+ * admins and nothing else — the store, its sales channel, its publishable key
+ * and its products all survived. That is how the orphan store behind the
+ * 2026-08-21 platform-wide storefront outage came to exist.
+ */
+
+const facts = (over: Partial<PartnerDeletionFacts> = {}): PartnerDeletionFacts => ({
+  partner_id: "part_1",
+  partner_name: "Unique Pashmina",
+  store_ids: ["store_1"],
+  sales_channel_ids: ["sc_1"],
+  publishable_keys: [{ id: "apk_1", sales_channel_ids: ["sc_1"] }],
+  product_ids: ["prod_1", "prod_2"],
+  live_order_ids: [],
+  force: false,
+  ...over,
+})
+
+describe("planPartnerDeletion", () => {
+  it("takes the store, its channel and its products with the partner", () => {
+    const plan = planPartnerDeletion(facts())
+
+    expect(plan.deletable).toBe(true)
+    expect(plan.soft_delete_store_ids).toEqual(["store_1"])
+    expect(plan.soft_delete_sales_channel_ids).toEqual(["sc_1"])
+    expect(plan.soft_delete_product_ids).toEqual(["prod_1", "prod_2"])
+  })
+
+  it("unlinks the publishable key rather than deleting or revoking it", () => {
+    // Revoking is a one-way door (UpdateApiKeyDTO carries only `title`), and a
+    // reversible deletion cannot contain an irreversible step. Deleting the row
+    // would lose the token the storefront is configured with.
+    const plan = planPartnerDeletion(facts())
+
+    expect(plan.unlink_keys).toEqual([
+      { key_id: "apk_1", sales_channel_ids: ["sc_1"] },
+    ])
+    expect(plan.preserved.join(" ")).toContain("SAME token")
+  })
+
+  it("leaves another tenant's channel link on a shared key alone", () => {
+    const plan = planPartnerDeletion(
+      facts({
+        publishable_keys: [
+          { id: "apk_shared", sales_channel_ids: ["sc_1", "sc_other"] },
+        ],
+      })
+    )
+
+    expect(plan.unlink_keys).toEqual([
+      { key_id: "apk_shared", sales_channel_ids: ["sc_1"] },
+    ])
+  })
+
+  it("ignores keys that touch none of this partner's channels", () => {
+    const plan = planPartnerDeletion(
+      facts({ publishable_keys: [{ id: "apk_2", sales_channel_ids: ["sc_other"] }] })
+    )
+
+    expect(plan.unlink_keys).toEqual([])
+  })
+
+  it("refuses a partner with orders still in flight", () => {
+    const plan = planPartnerDeletion(facts({ live_order_ids: ["order_9"] }))
+
+    expect(plan.deletable).toBe(false)
+    expect(plan.blockers.join(" ")).toContain("order_9")
+  })
+
+  it("carries NO actions on a refusal", () => {
+    // A caller must not be able to read `soft_delete_*` off a blocked plan and
+    // act on it anyway.
+    const plan = planPartnerDeletion(facts({ live_order_ids: ["order_9"] }))
+
+    expect(plan.unlink_keys).toEqual([])
+    expect(plan.soft_delete_store_ids).toEqual([])
+    expect(plan.soft_delete_sales_channel_ids).toEqual([])
+    expect(plan.soft_delete_product_ids).toEqual([])
+  })
+
+  it("names every live order it is refusing on, up to five", () => {
+    const ids = ["o1", "o2", "o3", "o4", "o5", "o6"]
+    const plan = planPartnerDeletion(facts({ live_order_ids: ids }))
+
+    expect(plan.blockers[0]).toContain("6 order(s)")
+    expect(plan.blockers[0]).toContain("o5")
+    expect(plan.blockers[0]).toContain("…")
+  })
+
+  it("proceeds under force, and says so", () => {
+    const plan = planPartnerDeletion(
+      facts({ live_order_ids: ["order_9"], force: true })
+    )
+
+    expect(plan.deletable).toBe(true)
+    expect(plan.preserved.join(" ")).toContain("FORCED")
+  })
+
+  it("never plans to touch commercial history, stock or the shared region", () => {
+    const preserved = planPartnerDeletion(facts()).preserved.join(" ")
+
+    expect(preserved).toContain("Orders")
+    expect(preserved).toContain("Stock location")
+    expect(preserved).toContain("region")
+  })
+
+  it("handles a partner with no store at all", () => {
+    const plan = planPartnerDeletion(
+      facts({ store_ids: [], sales_channel_ids: [], publishable_keys: [], product_ids: [] })
+    )
+
+    expect(plan.deletable).toBe(true)
+    expect(plan.unlink_keys).toEqual([])
+    expect(plan.soft_delete_store_ids).toEqual([])
+  })
+})

--- a/apps/backend/src/workflows/partners/delete-partner.ts
+++ b/apps/backend/src/workflows/partners/delete-partner.ts
@@ -4,12 +4,224 @@ import {
   StepResponse,
   WorkflowResponse,
 } from "@medusajs/framework/workflows-sdk"
+import { linkSalesChannelsToApiKeyWorkflow } from "@medusajs/medusa/core-flows"
+import { ContainerRegistrationKeys, MedusaError } from "@medusajs/framework/utils"
 import { PARTNER_MODULE } from "../../modules/partner"
 import PartnerService from "../../modules/partner/service"
+import {
+  planPartnerDeletion,
+  type PartnerDeletionFacts,
+  type PartnerDeletionPlan,
+} from "./lib/partner-deletion-plan"
 
 type DeletePartnerInput = {
   id: string
+  /** Delete even though orders are still in flight. See the planner's docs. */
+  force?: boolean
 }
+
+/**
+ * An order still in flight. Everything else is history: a completed, canceled,
+ * archived or draft order is not waiting on this partner for anything.
+ */
+const TERMINAL_ORDER_STATUSES = new Set([
+  "completed",
+  "canceled",
+  "archived",
+  "draft",
+])
+
+/**
+ * Read-only. Gathers what the partner owns, asks the pure planner what should
+ * travel with it, and refuses here — before anything has been written — if the
+ * partner is still doing business.
+ */
+const planPartnerCascadeStep = createStep(
+  "plan-partner-cascade-step",
+  async (input: DeletePartnerInput, { container }) => {
+    const query: any = container.resolve(ContainerRegistrationKeys.QUERY)
+
+    const { data: partners } = await query.graph({
+      entity: "partners",
+      fields: [
+        "id",
+        "name",
+        "stores.id",
+        "stores.default_sales_channel_id",
+        "products.id",
+        "orders.id",
+        "orders.status",
+      ],
+      filters: { id: input.id },
+    })
+    const partner = (partners ?? [])[0]
+    if (!partner) {
+      throw new MedusaError(
+        MedusaError.Types.NOT_FOUND,
+        `Partner ${input.id} not found`
+      )
+    }
+
+    const storeIds: string[] = []
+    const salesChannelIds: string[] = []
+    for (const s of (partner.stores ?? []) as any[]) {
+      if (s?.id) storeIds.push(s.id)
+      if (s?.default_sales_channel_id)
+        salesChannelIds.push(s.default_sales_channel_id)
+    }
+
+    // Publishable keys reachable from those channels. Their links are what we
+    // dismiss; the key rows themselves are never touched.
+    let publishableKeys: Array<{ id: string; sales_channel_ids: string[] }> = []
+    if (salesChannelIds.length) {
+      const { data: keys } = await query.graph({
+        entity: "api_keys",
+        fields: ["id", "sales_channels.id"],
+        filters: { type: "publishable" },
+      })
+      publishableKeys = ((keys ?? []) as any[])
+        .map((k) => ({
+          id: k?.id,
+          // `sc?.id` — a dangling link expands to a null element, and one
+          // tenant's dead row must never break another tenant's deletion.
+          sales_channel_ids: ((k?.sales_channels ?? []) as any[])
+            .map((sc) => sc?.id)
+            .filter(Boolean),
+        }))
+        .filter(
+          (k) =>
+            k.id && k.sales_channel_ids.some((id) => salesChannelIds.includes(id))
+        )
+    }
+
+    // Live orders, from BOTH scopings: work-orders hang off the partner↔order
+    // link, retail orders off the partner's sales channel. Checking only one
+    // would clear a partner that is mid-delivery on the other.
+    const liveOrderIds = new Set<string>()
+    for (const o of (partner.orders ?? []) as any[]) {
+      if (o?.id && !TERMINAL_ORDER_STATUSES.has(o?.status)) liveOrderIds.add(o.id)
+    }
+    if (salesChannelIds.length) {
+      const { data: retail } = await query.graph({
+        entity: "order",
+        fields: ["id", "status"],
+        filters: { sales_channel_id: salesChannelIds },
+      })
+      for (const o of (retail ?? []) as any[]) {
+        if (o?.id && !TERMINAL_ORDER_STATUSES.has(o?.status))
+          liveOrderIds.add(o.id)
+      }
+    }
+
+    const facts: PartnerDeletionFacts = {
+      partner_id: input.id,
+      partner_name: partner.name ?? null,
+      store_ids: storeIds,
+      sales_channel_ids: salesChannelIds,
+      publishable_keys: publishableKeys,
+      product_ids: ((partner.products ?? []) as any[])
+        .map((p) => p?.id)
+        .filter(Boolean),
+      live_order_ids: [...liveOrderIds],
+      force: input.force === true,
+    }
+
+    const plan = planPartnerDeletion(facts)
+
+    if (!plan.deletable) {
+      // Nothing has been written yet, so there is nothing to unwind.
+      throw new MedusaError(
+        MedusaError.Types.NOT_ALLOWED,
+        plan.blockers.join(" ")
+      )
+    }
+
+    return new StepResponse(plan)
+  }
+)
+
+/**
+ * Dismiss the key↔channel links FIRST, before the channel goes.
+ *
+ * 🔴 Order is the whole point. On 2026-08-21 a sales channel was removed while
+ * its publishable key survived; the key expanded to `sales_channels: [null]`
+ * and threw inside a query that walks EVERY tenant's keys, so one dead row
+ * 404'd every storefront on the platform. Unlinking first means the dangling
+ * state never exists — not between two awaits, and not at all if the channel
+ * soft-delete then fails.
+ */
+const unlinkPublishableKeysStep = createStep(
+  "unlink-partner-publishable-keys-step",
+  async (plan: PartnerDeletionPlan, { container }) => {
+    for (const k of plan.unlink_keys) {
+      await linkSalesChannelsToApiKeyWorkflow(container).run({
+        input: { id: k.key_id, add: [], remove: k.sales_channel_ids },
+      })
+    }
+    return new StepResponse({ count: plan.unlink_keys.length }, plan.unlink_keys)
+  },
+  async (unlinked: PartnerDeletionPlan["unlink_keys"] | undefined, { container }) => {
+    if (!unlinked?.length) return
+    for (const k of unlinked) {
+      await linkSalesChannelsToApiKeyWorkflow(container).run({
+        input: { id: k.key_id, add: k.sales_channel_ids, remove: [] },
+      })
+    }
+  }
+)
+
+const softDeletePartnerSalesChannelsStep = createStep(
+  "soft-delete-partner-sales-channels-step",
+  async (plan: PartnerDeletionPlan, { container }) => {
+    const ids = plan.soft_delete_sales_channel_ids
+    if (!ids.length) return new StepResponse({ count: 0 }, [])
+    const scService: any = container.resolve("sales_channel")
+    await scService.softDeleteSalesChannels(ids)
+    return new StepResponse({ count: ids.length }, ids)
+  },
+  async (ids: string[] | undefined, { container }) => {
+    if (!ids?.length) return
+    const scService: any = container.resolve("sales_channel")
+    await scService.restoreSalesChannels(ids)
+  }
+)
+
+const softDeletePartnerStoresStep = createStep(
+  "soft-delete-partner-stores-step",
+  async (plan: PartnerDeletionPlan, { container }) => {
+    const ids = plan.soft_delete_store_ids
+    if (!ids.length) return new StepResponse({ count: 0 }, [])
+    const storeService: any = container.resolve("store")
+    await storeService.softDeleteStores(ids)
+    return new StepResponse({ count: ids.length }, ids)
+  },
+  async (ids: string[] | undefined, { container }) => {
+    if (!ids?.length) return
+    const storeService: any = container.resolve("store")
+    await storeService.restoreStores(ids)
+  }
+)
+
+/**
+ * Products stop being purchasable, and stay restorable. Line items on past
+ * orders snapshot their own title and price, so history reads the same either
+ * way.
+ */
+const softDeletePartnerProductsStep = createStep(
+  "soft-delete-partner-products-step",
+  async (plan: PartnerDeletionPlan, { container }) => {
+    const ids = plan.soft_delete_product_ids
+    if (!ids.length) return new StepResponse({ count: 0 }, [])
+    const productService: any = container.resolve("product")
+    await productService.softDeleteProducts(ids)
+    return new StepResponse({ count: ids.length }, ids)
+  },
+  async (ids: string[] | undefined, { container }) => {
+    if (!ids?.length) return
+    const productService: any = container.resolve("product")
+    await productService.restoreProducts(ids)
+  }
+)
 
 const deletePartnerAdminsStep = createStep(
   "delete-partner-admins-step",
@@ -44,12 +256,32 @@ const softDeletePartnerStep = createStep(
   }
 )
 
+/**
+ * Soft-delete a partner and everything that is meaningless without it.
+ *
+ * The order is deliberate and is documented in `lib/partner-deletion-plan.ts`:
+ * key links, then channels, then stores, then products, then admins, then the
+ * partner itself. Every step compensates, so a failure anywhere leaves the
+ * tenant exactly as it was.
+ */
 export const deletePartnerWorkflow = createWorkflow(
   "delete-partner",
   (input: DeletePartnerInput) => {
+    const plan = planPartnerCascadeStep(input)
+
+    unlinkPublishableKeysStep(plan)
+    softDeletePartnerSalesChannelsStep(plan)
+    softDeletePartnerStoresStep(plan)
+    softDeletePartnerProductsStep(plan)
+
     deletePartnerAdminsStep(input)
-    const result = softDeletePartnerStep(input)
-    return new WorkflowResponse(result)
+    softDeletePartnerStep(input)
+
+    // The plan is what the caller wants back: not just "deleted: true", but
+    // exactly what travelled with the partner and what was deliberately left
+    // alone. A deletion whose scope you have to reconstruct later is how the
+    // 2026-08-21 orphan came to be a mystery.
+    return new WorkflowResponse(plan)
   }
 )
 

--- a/apps/backend/src/workflows/partners/lib/partner-deletion-plan.ts
+++ b/apps/backend/src/workflows/partners/lib/partner-deletion-plan.ts
@@ -1,0 +1,145 @@
+/**
+ * What travels with a partner when it is deleted — decided as policy, not
+ * inferred at each call site.
+ *
+ * ## Why this exists
+ *
+ * `deletePartnerWorkflow` used to soft-delete the partner and its admins and
+ * nothing else. The store, its sales channel, its publishable key, its products
+ * and the partner↔store link all survived, with no guard even on live orders.
+ *
+ * That partialness is not academic: it is exactly how the orphan "Sharhlo
+ * Store" came to exist, and removing that orphan is what took every partner
+ * storefront down on 2026-08-21. A deletion that leaves half a tenant standing
+ * manufactures the strays that a later cleanup has to guess about.
+ *
+ * ## The three tiers
+ *
+ * 🔑 **Nothing here is ever hard-deleted.** #1306 third-party MCP clients hold
+ * references, and the standing rule is forward, never delete. Every action in
+ * the plan is reversible by the workflow's own compensation.
+ *
+ * 1. **Travels with the partner** — meaningless without it: the store, its
+ *    sales channel, its products. All soft-deleted, all restorable.
+ * 2. **Never touched** — commercial history: orders, fulfilments, payouts,
+ *    production runs, inventory levels and the stock location holding them.
+ *    Deleting those corrupts accounting. The default region is shared across
+ *    ~10 stores on prod and is never in scope.
+ * 3. **Disabled, not deleted** — the publishable key. See below.
+ *
+ * ## Why the key is UNLINKED rather than revoked or deleted
+ *
+ * Revoking is the obvious "disable", and it is a ONE-WAY DOOR: core's
+ * `UpdateApiKeyDTO` carries `title` and nothing else, and there is no
+ * un-revoke. A reversible deletion cannot contain an irreversible step.
+ * Deleting the key outright is worse — the storefront's configured token would
+ * never come back.
+ *
+ * So the plan dismisses the key↔sales-channel LINK and leaves the key row
+ * intact. The storefront stops resolving (no key matches the channel), the
+ * token survives for a restore, and — the part that matters — the key is never
+ * left pointing at a soft-deleted channel. That dangling state is precisely
+ * what expanded to `sales_channels: [null]` and 500'd a cross-tenant query on
+ * 2026-08-21. Unlinking first means it never exists, not even between two
+ * awaits, and not at all if the channel soft-delete subsequently fails.
+ */
+
+export type PartnerDeletionFacts = {
+  partner_id: string
+  partner_name?: string | null
+  /** Stores linked to this partner (usually one). */
+  store_ids: string[]
+  /** Those stores' default sales channels. */
+  sales_channel_ids: string[]
+  /** Publishable keys linked to any of those channels, with their links. */
+  publishable_keys: Array<{ id: string; sales_channel_ids: string[] }>
+  /** Products this partner owns, via the partner↔product ownership link. */
+  product_ids: string[]
+  /**
+   * Orders that are still in flight — retail (on the partner's channel) and
+   * work-orders (on the partner↔order link). Terminal orders are history and
+   * never block.
+   */
+  live_order_ids: string[]
+  /** Operator override: delete anyway, live orders and all. */
+  force: boolean
+}
+
+export type PartnerDeletionPlan = {
+  deletable: boolean
+  blockers: string[]
+  /** Key↔channel links to dismiss, BEFORE any channel is soft-deleted. */
+  unlink_keys: Array<{ key_id: string; sales_channel_ids: string[] }>
+  soft_delete_sales_channel_ids: string[]
+  soft_delete_store_ids: string[]
+  soft_delete_product_ids: string[]
+  /** Human-readable, for the route response and the audit trail. */
+  preserved: string[]
+}
+
+/**
+ * PURE: given the facts, what should travel with this partner and what — if
+ * anything — should stop the deletion.
+ *
+ * Every blocker is returned, not just the first: an operator who clears one
+ * reason and retries should not discover a second on the next pass.
+ */
+export function planPartnerDeletion(
+  facts: PartnerDeletionFacts
+): PartnerDeletionPlan {
+  const blockers: string[] = []
+
+  if (facts.live_order_ids.length && !facts.force) {
+    const shown = facts.live_order_ids.slice(0, 5).join(", ")
+    const more = facts.live_order_ids.length > 5 ? ", …" : ""
+    blockers.push(
+      `Partner ${facts.partner_name ?? facts.partner_id} has ${facts.live_order_ids.length} order(s) still in flight (${shown}${more}). Deleting it would take their storefront and products out from under orders someone is waiting on. Complete or cancel them, or pass force: true.`
+    )
+  }
+
+  const deletable = blockers.length === 0
+
+  // A blocked plan carries no actions: nothing should read `soft_delete_*` off
+  // a refusal and act on it anyway.
+  if (!deletable) {
+    return {
+      deletable,
+      blockers,
+      unlink_keys: [],
+      soft_delete_sales_channel_ids: [],
+      soft_delete_store_ids: [],
+      soft_delete_product_ids: [],
+      preserved: [],
+    }
+  }
+
+  // Only links that actually point at THIS partner's channels are dismissed. A
+  // key shared with another tenant's channel keeps that link.
+  const channelIds = new Set(facts.sales_channel_ids)
+  const unlink_keys = facts.publishable_keys
+    .map((k) => ({
+      key_id: k.id,
+      sales_channel_ids: k.sales_channel_ids.filter((id) => channelIds.has(id)),
+    }))
+    .filter((k) => k.sales_channel_ids.length > 0)
+
+  return {
+    deletable,
+    blockers,
+    unlink_keys,
+    soft_delete_sales_channel_ids: [...facts.sales_channel_ids],
+    soft_delete_store_ids: [...facts.store_ids],
+    soft_delete_product_ids: [...facts.product_ids],
+    preserved: [
+      "Orders, fulfilments, payouts and production runs — commercial history, never deleted.",
+      "Stock location and its inventory levels — real stock, not a tenant artefact.",
+      "Default region — shared with other stores.",
+      "Publishable key rows — unlinked and inert, kept so a restore returns the SAME token.",
+      ...(facts.force && facts.live_order_ids.length
+        ? [
+            `FORCED past ${facts.live_order_ids.length} live order(s) — they are untouched, but their storefront is now dark.`,
+          ]
+        : []),
+    ],
+  }
+}


### PR DESCRIPTION
Closes #1399 items 1 and 3. Founder decision on the cascade policy: **soft-delete / disable, never hard-delete.**

## The problem

`deletePartnerWorkflow` soft-deleted the partner and its admins and **nothing else**. The store, its sales channel, its publishable key, its products and the partner↔store link all survived, with no guard even on a partner mid-delivery.

That is exactly how the orphan "Sharhlo Store" came to exist — and removing that orphan is what took every partner storefront down on 2026-08-21. A deletion that leaves half a tenant standing manufactures the strays a later cleanup has to guess about.

## The policy, in one pure function

`workflows/partners/lib/partner-deletion-plan.ts` — decided once, testable without a database.

| Tier | What | How |
|---|---|---|
| **Travels with the partner** | store, its sales channel, its products | soft-delete, restorable |
| **Never touched** | orders, fulfilments, payouts, production runs, stock location + inventory levels, shared default region | — |
| **Disabled, not deleted** | publishable key | link dismissed, row kept |

Nothing is hard-deleted. #1306 third-party MCP clients hold references; the standing rule is forward, never delete.

### Why the key is unlinked rather than revoked

Revoking is the obvious "disable" and it is a **one-way door**: core's `UpdateApiKeyDTO` carries `title` and nothing else, and there is no un-revoke. A reversible deletion cannot contain an irreversible step. Deleting the row is worse — the storefront's token never comes back.

So the plan dismisses the key↔channel **link** and keeps the key row. The storefront stops resolving, the token survives for a restore, and — the part that matters — the key is **never left pointing at a soft-deleted channel**. Unlinking runs **first**, so that dangling state never exists: not between two awaits, and not at all if the channel soft-delete then fails. That state is precisely what expanded to `sales_channels: [null]` and 500'd a cross-tenant query.

### The live-order guard

`DELETE /admin/partners/:id` now refuses a partner with orders in flight, counted from **both** scopings — work-orders on the partner↔order link, retail orders on the sales channel. Checking one would clear a partner mid-delivery on the other. `?force=true` overrides; the orders stay untouched either way, and the returned plan says so out loud.

Every step compensates. The workflow returns the plan — not just `deleted: true`, but what travelled and what was deliberately left alone.

## Item 3 — the undo

`delete-orphan-store` was run on prod without anyone confirming a restore path existed. **None did.** All three of its removals are soft, so the rows sat there with `deleted_at` set the whole time; nobody had written the restore, and its docblock claimed "a store cannot be un-deleted" — wrong in the direction that costs you an incident. That docblock is corrected here too.

`restore-orphan-store` refuses a store that is *not* deleted rather than no-op'ing on a typo, and **warns instead of blocking** when a sibling row is already live — a partial restore is still a restore, and this job exists for incidents.

🔴 The publishable key is the honest exception: core has no soft delete for an api key, so that token is gone. `recreate_publishable_key` mints a replacement and links it **after** the channel is back. Opt-in, because silently minting a credential is not a restore and the new token is a different string.

## Verification

- `18` new unit tests (10 planner, 8 restore job); `38 passed` across all touched specs.
- `check:prod-build` green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)