### PR TITLE
fix(partners): three cross-tenant holes in the pricing and customer-group surfaces

### DIFF
--- a/apps/backend/src/api/partners/__tests__/price-preference-scope.unit.spec.ts
+++ b/apps/backend/src/api/partners/__tests__/price-preference-scope.unit.spec.ts
@@ -1,0 +1,134 @@
+import {
+  checkPreferenceWritable,
+  isPreferenceInScope,
+  type PricePreferenceScope,
+} from "../price-preferences/lib/scope"
+import { missingOwnedIds } from "../helpers"
+
+/**
+ * Partner scoping for the one pricing surface with no partner dimension.
+ *
+ * `/partners/price-preferences` listed EVERY preference on the platform — the
+ * query carried no filters — and created, updated and deleted them with no
+ * ownership check beyond "are you a partner". The same routes are exposed to
+ * the partner AI assistant as `write: true` MCP tools.
+ */
+
+const scope = (over: Partial<PricePreferenceScope> = {}): PricePreferenceScope => ({
+  region_ids: ["reg_mine", "reg_shared"],
+  exclusive_region_ids: ["reg_mine"],
+  currency_codes: ["inr", "eur"],
+  ...over,
+})
+
+describe("isPreferenceInScope", () => {
+  it("shows a region preference for one of the partner's regions", () => {
+    expect(isPreferenceInScope({ attribute: "region_id", value: "reg_mine" }, scope())).toBe(true)
+  })
+
+  it("shows a SHARED region's preference — reading is wider than writing", () => {
+    // A preference that governs this partner's prices is theirs to see even
+    // when it is not theirs to change.
+    expect(isPreferenceInScope({ attribute: "region_id", value: "reg_shared" }, scope())).toBe(true)
+  })
+
+  it("hides another partner's region", () => {
+    expect(isPreferenceInScope({ attribute: "region_id", value: "reg_theirs" }, scope())).toBe(false)
+  })
+
+  it("shows a currency the partner's store supports, case-insensitively", () => {
+    expect(isPreferenceInScope({ attribute: "currency_code", value: "INR" }, scope())).toBe(true)
+  })
+
+  it("hides a currency the partner's store does not support", () => {
+    expect(isPreferenceInScope({ attribute: "currency_code", value: "usd" }, scope())).toBe(false)
+  })
+
+  it("hides an attribute we do not model, rather than defaulting to visible", () => {
+    expect(isPreferenceInScope({ attribute: "customer_group_id", value: "x" }, scope())).toBe(false)
+    expect(isPreferenceInScope({}, scope())).toBe(false)
+  })
+
+  it("shows nothing to a partner with no regions and no store", () => {
+    const empty = scope({ region_ids: [], exclusive_region_ids: [], currency_codes: [] })
+    expect(isPreferenceInScope({ attribute: "region_id", value: "reg_mine" }, empty)).toBe(false)
+    expect(isPreferenceInScope({ attribute: "currency_code", value: "inr" }, empty)).toBe(false)
+  })
+})
+
+describe("checkPreferenceWritable", () => {
+  it("allows a region that belongs to this partner alone", () => {
+    expect(checkPreferenceWritable({ attribute: "region_id", value: "reg_mine" }, scope())).toEqual({
+      writable: true,
+      reason: null,
+    })
+  })
+
+  it("REFUSES a shared region, and says it is shared", () => {
+    // On prod one region backs ~10 stores, so "linked to me" is not "mine".
+    const res = checkPreferenceWritable({ attribute: "region_id", value: "reg_shared" }, scope())
+    expect(res.writable).toBe(false)
+    expect(res.reason).toMatch(/shared with other partners/i)
+  })
+
+  it("refuses a region that is not the partner's at all, with a different reason", () => {
+    const res = checkPreferenceWritable({ attribute: "region_id", value: "reg_theirs" }, scope())
+    expect(res.writable).toBe(false)
+    expect(res.reason).toMatch(/not one of yours/i)
+  })
+
+  it("ALWAYS refuses a currency preference, even a supported one", () => {
+    // Platform-wide by construction: flipping tax-inclusivity for INR changes
+    // it for every store pricing in INR. There is no version of this write
+    // that is "yours".
+    const res = checkPreferenceWritable({ attribute: "currency_code", value: "inr" }, scope())
+    expect(res.writable).toBe(false)
+    expect(res.reason).toMatch(/every store pricing in inr/i)
+  })
+
+  it("refuses an unknown attribute", () => {
+    const res = checkPreferenceWritable({ attribute: "nonsense", value: "x" }, scope())
+    expect(res.writable).toBe(false)
+    expect(res.reason).toMatch(/unsupported/i)
+  })
+
+  it("never returns writable without also returning a null reason", () => {
+    for (const value of ["reg_mine", "reg_shared", "reg_theirs"]) {
+      const res = checkPreferenceWritable({ attribute: "region_id", value }, scope())
+      expect(res.writable).toBe(res.reason === null)
+    }
+  })
+})
+
+/**
+ * The "both ends" primitive. Two partner routes validated the id in the URL and
+ * ignored the ids in the body — one let a partner pull another partner's
+ * customers into their own group, the other let them push their own customer
+ * into someone else's group. The second matters most: once a customer group
+ * carries a negotiated B2B price list, that customer inherits pricing that was
+ * never theirs.
+ */
+describe("missingOwnedIds", () => {
+  it("returns nothing when every id is owned", () => {
+    expect(missingOwnedIds(["a", "b"], ["a"])).toEqual([])
+    expect(missingOwnedIds(["a", "b"], ["a", "b"])).toEqual([])
+  })
+
+  it("names exactly the ids that are not owned", () => {
+    expect(missingOwnedIds(["a"], ["a", "b", "c"])).toEqual(["b", "c"])
+  })
+
+  it("dedupes a repeated foreign id", () => {
+    expect(missingOwnedIds(["a"], ["b", "b"])).toEqual(["b"])
+  })
+
+  it("ignores empty entries on both sides rather than reporting them missing", () => {
+    expect(missingOwnedIds(["a", null, undefined], ["a", "", null as any])).toEqual([])
+  })
+
+  it("treats an empty owned set as owning nothing, not everything", () => {
+    // The dangerous default. A partner with no customers must not pass a check
+    // simply because the comparison set came back empty.
+    expect(missingOwnedIds([], ["a"])).toEqual(["a"])
+  })
+})

--- a/apps/backend/src/api/partners/customer-groups/[id]/customers/route.ts
+++ b/apps/backend/src/api/partners/customer-groups/[id]/customers/route.ts
@@ -1,7 +1,30 @@
 import { AuthenticatedMedusaRequest, MedusaResponse } from "@medusajs/framework/http"
-import { ContainerRegistrationKeys } from "@medusajs/framework/utils"
-import { validatePartnerEntityOwnership } from "../../../helpers"
+import { Modules } from "@medusajs/framework/utils"
+import { linkCustomersToCustomerGroupWorkflow } from "@medusajs/medusa/core-flows"
+import {
+  validatePartnerEntityOwnership,
+  validatePartnerOwnsEntities,
+} from "../../../helpers"
 
+/**
+ * Manage the customers of one of the partner's customer groups.
+ *
+ * Two things were wrong here, and they were wrong in different ways.
+ *
+ * 🔴 **Only the group was validated.** `body.add` was an unchecked array of
+ * arbitrary customer ids, so a partner could pull ANOTHER partner's customers
+ * into their own group — and `body.remove` could dismiss links they did not
+ * own. Owning the resource in the URL says nothing about owning the ids in the
+ * body, so both ends are checked now.
+ *
+ * ⚠️ **It wrote a link that does not exist.** The customer ↔ customer_group
+ * relationship is internal to the CUSTOMER module, not a registered module
+ * link, so `remoteLink.create({ customer_group, customer })` threw — the same
+ * bug the sibling route `customers/:id/customer-groups` documents fixing in
+ * #495. That fix never reached this file, which is why the security hole was
+ * academic: the route could not succeed. It can now, so the guard has to be
+ * real.
+ */
 export const POST = async (
   req: AuthenticatedMedusaRequest,
   res: MedusaResponse
@@ -13,26 +36,27 @@ export const POST = async (
     req.scope
   )
 
-  const body = req.body as any
-  const remoteLink = req.scope.resolve(ContainerRegistrationKeys.LINK) as any
+  const body = req.body as { add?: string[]; remove?: string[] }
+  const add = body.add ?? []
+  const remove = body.remove ?? []
 
-  if (body.add?.length) {
-    for (const customerId of body.add) {
-      await remoteLink.create({
-        customer_group: { customer_group_id: req.params.id },
-        customer: { customer_id: customerId },
-      })
-    }
-  }
+  // Both ends. Every customer named in the body must be one of ours.
+  await validatePartnerOwnsEntities(
+    req.auth_context,
+    "customers",
+    [...add, ...remove],
+    req.scope
+  )
 
-  if (body.remove?.length) {
-    for (const customerId of body.remove) {
-      await remoteLink.dismiss({
-        customer_group: { customer_group_id: req.params.id },
-        customer: { customer_id: customerId },
-      })
-    }
-  }
+  await linkCustomersToCustomerGroupWorkflow(req.scope).run({
+    input: { id: req.params.id, add, remove },
+  })
 
-  res.json({ customer_group: { id: req.params.id } })
+  const customerService = req.scope.resolve(Modules.CUSTOMER) as any
+  const customer_group = await customerService.retrieveCustomerGroup(
+    req.params.id,
+    { relations: ["customers"] }
+  )
+
+  res.json({ customer_group })
 }

--- a/apps/backend/src/api/partners/customers/[id]/customer-groups/route.ts
+++ b/apps/backend/src/api/partners/customers/[id]/customer-groups/route.ts
@@ -1,7 +1,10 @@
 import { AuthenticatedMedusaRequest, MedusaResponse } from "@medusajs/framework/http"
 import { Modules } from "@medusajs/framework/utils"
 import { linkCustomerGroupsToCustomerWorkflow } from "@medusajs/medusa/core-flows"
-import { validatePartnerEntityOwnership } from "../../../helpers"
+import {
+  validatePartnerEntityOwnership,
+  validatePartnerOwnsEntities,
+} from "../../../helpers"
 
 // Mirror admin POST /admin/customers/:id/customer-groups: the
 // customer <-> customer_group relationship is internal to the CUSTOMER module
@@ -20,13 +23,23 @@ export const POST = async (
   )
 
   const body = req.body as { add?: string[]; remove?: string[] }
+  const add = body.add ?? []
+  const remove = body.remove ?? []
+
+  // 🔴 Both ends. Validating the customer said nothing about the GROUPS named
+  // in the body, so a partner could drop their own customer into another
+  // partner's group. Harmless-looking until a group carries a negotiated B2B
+  // price list — at which point that customer silently inherits someone else's
+  // pricing.
+  await validatePartnerOwnsEntities(
+    req.auth_context,
+    "customer_groups",
+    [...add, ...remove],
+    req.scope
+  )
 
   await linkCustomerGroupsToCustomerWorkflow(req.scope).run({
-    input: {
-      id: req.params.id,
-      add: body.add ?? [],
-      remove: body.remove ?? [],
-    },
+    input: { id: req.params.id, add, remove },
   })
 
   const customerService = req.scope.resolve(Modules.CUSTOMER) as any

--- a/apps/backend/src/api/partners/helpers.ts
+++ b/apps/backend/src/api/partners/helpers.ts
@@ -239,6 +239,73 @@ export const validatePartnerEntityOwnership = async (
 }
 
 /**
+ * PURE: which of `ids` are missing from the set the partner owns.
+ *
+ * Split out so the "both ends" rule is testable without a database, and so the
+ * two callers cannot drift — an ownership rule that exists in two copies is one
+ * edit away from disagreeing with itself.
+ */
+export const missingOwnedIds = (
+    ownedIds: Array<string | null | undefined>,
+    ids: Array<string | null | undefined>,
+): string[] => {
+    const owned = new Set(ownedIds.filter(Boolean) as string[])
+    const missing = new Set<string>()
+    for (const id of ids) {
+        if (id && !owned.has(id)) missing.add(id)
+    }
+    return [...missing]
+}
+
+/**
+ * Assert the partner owns EVERY id in the list, else throw NOT_FOUND.
+ *
+ * 🔴 The rule this exists to enforce: **validate both ends of any request that
+ * names an id.** Owning the resource in the URL says nothing about owning the
+ * ids in the body. Two partner routes proved that — one let a partner add
+ * arbitrary customers to their own group, the other let them add their own
+ * customer to ANOTHER partner's group — and once customer groups carry
+ * negotiated B2B price lists, that second one hands a partner someone else's
+ * pricing.
+ *
+ * NOT_FOUND rather than NOT_ALLOWED, matching every other guard here: a partner
+ * probing ids must not be able to tell "exists but not yours" from "no such
+ * thing".
+ */
+export const validatePartnerOwnsEntities = async (
+    authContext: { actor_id?: string | null } | undefined,
+    entityType: "product_categories" | "product_collections" | "customers" | "customer_groups",
+    entityIds: string[],
+    container: MedusaContainer,
+): Promise<{ partner: any; store: any }> => {
+    const { partner, store } = await getPartnerStore(authContext, container)
+
+    const ids = (entityIds || []).filter(Boolean)
+    if (!ids.length) {
+        return { partner, store }
+    }
+
+    const query = container.resolve(ContainerRegistrationKeys.QUERY)
+    const { data } = await query.graph({
+        entity: "stores",
+        fields: [`${entityType}.id`],
+        filters: { id: store.id },
+    })
+
+    const owned = ((data?.[0] as any)?.[entityType] || []).map((e: any) => e?.id)
+    const missing = missingOwnedIds(owned, ids)
+
+    if (missing.length) {
+        throw new MedusaError(
+            MedusaError.Types.NOT_FOUND,
+            `${entityType.replace("_", " ")} not found: ${missing.join(", ")}`
+        )
+    }
+
+    return { partner, store }
+}
+
+/**
  * Pure ownership predicate (#778 C1): does this inventory order's linked partner
  * match the acting partner? Exported for unit testing.
  */

--- a/apps/backend/src/api/partners/mcp/lib/registry.ts
+++ b/apps/backend/src/api/partners/mcp/lib/registry.ts
@@ -2958,7 +2958,8 @@ export const PARTNER_MCP_TOOLS: PartnerMcpToolDef[] = [
   },
   {
     name: "list_price_preferences",
-    description: "List pricing preferences (e.g. tax-inclusive settings per currency/region).",
+    description:
+      "List pricing preferences (tax-inclusive settings per currency/region). Scoped: returns only preferences for this partner's own regions and their store's supported currencies.",
     method: "GET",
     path: "/partners/price-preferences",
     inputSchema: obj({}),
@@ -2966,15 +2967,15 @@ export const PARTNER_MCP_TOOLS: PartnerMcpToolDef[] = [
   {
     name: "create_price_preference",
     description:
-      "Create a pricing preference — e.g. mark prices tax-inclusive for a currency or region. `attribute` is 'currency_code' or 'region_id'; `value` is the code/id.",
+      "Create a pricing preference — mark prices tax-inclusive for a REGION this partner owns exclusively. `attribute` must be 'region_id'; `value` is the region id. Currency-level preferences are refused: they apply to every store pricing in that currency, not just this one. A region shared with another partner is refused too.",
     method: "POST",
     path: "/partners/price-preferences",
     write: true,
     bodyParams: ["attribute", "value", "is_tax_inclusive"],
     inputSchema: obj(
       {
-        attribute: STR("'currency_code' or 'region_id'."),
-        value: STR("The currency code or region id the preference applies to."),
+        attribute: STR("Must be 'region_id'. Currency-level preferences are platform-wide and are refused."),
+        value: STR("The region id the preference applies to. Must be a region this partner owns exclusively."),
         is_tax_inclusive: BOOL("Whether prices for this attribute include tax."),
       },
       ["attribute", "value"]
@@ -2982,7 +2983,8 @@ export const PARTNER_MCP_TOOLS: PartnerMcpToolDef[] = [
   },
   {
     name: "update_price_preference",
-    description: "Update a pricing preference.",
+    description:
+      "Update a pricing preference. Only preferences on a region this partner owns exclusively can be changed; currency-level and shared-region preferences are refused with the reason.",
     method: "POST",
     path: "/partners/price-preferences/:id",
     pathParams: ["id"],
@@ -2992,8 +2994,8 @@ export const PARTNER_MCP_TOOLS: PartnerMcpToolDef[] = [
     inputSchema: obj(
       {
         id: STR("Price preference id."),
-        attribute: STR("'currency_code' or 'region_id'."),
-        value: STR("Currency code or region id."),
+        attribute: STR("Must be 'region_id'; currency-level preferences are refused."),
+        value: STR("Region id — must be exclusively this partner's."),
         is_tax_inclusive: BOOL("Whether prices include tax."),
       },
       ["id"]
@@ -3001,7 +3003,8 @@ export const PARTNER_MCP_TOOLS: PartnerMcpToolDef[] = [
   },
   {
     name: "delete_price_preference",
-    description: "Delete a pricing preference.",
+    description:
+      "Delete a pricing preference. Only preferences on a region this partner owns exclusively can be deleted.",
     method: "DELETE",
     path: "/partners/price-preferences/:id",
     pathParams: ["id"],

--- a/apps/backend/src/api/partners/price-preferences/[id]/route.ts
+++ b/apps/backend/src/api/partners/price-preferences/[id]/route.ts
@@ -1,19 +1,28 @@
 import { AuthenticatedMedusaRequest, MedusaResponse } from "@medusajs/framework/http"
 import { ContainerRegistrationKeys, MedusaError, Modules } from "@medusajs/framework/utils"
 import { deletePricePreferencesWorkflow } from "@medusajs/medusa/core-flows"
-import { getPartnerFromAuthContext } from "../../helpers"
 
-export const GET = async (
-  req: AuthenticatedMedusaRequest,
-  res: MedusaResponse
-) => {
-  const partner = await getPartnerFromAuthContext(req.auth_context, req.scope)
-  if (!partner) {
-    throw new MedusaError(
-      MedusaError.Types.UNAUTHORIZED,
-      "No partner associated with this account"
-    )
-  }
+import {
+  assertPreferenceWritable,
+  isPreferenceInScope,
+  resolvePricePreferenceScope,
+} from "../lib/scope"
+
+/**
+ * A single price preference, scoped to what this partner may see and change.
+ *
+ * All three verbs previously took the id straight from the URL with no check
+ * beyond "are you a partner", so any partner could read, edit or DELETE any
+ * other partner's tax-inclusivity setting.
+ *
+ * Out-of-scope reads 404 rather than 403, matching every other partner guard:
+ * a partner probing ids must not learn that something exists but is not theirs.
+ * Writes, by contrast, return NOT_ALLOWED **with the reason** — a partner who
+ * can see a preference and cannot change it deserves to know whether that is
+ * because it is shared or because it is platform-wide.
+ */
+const loadInScope = async (req: AuthenticatedMedusaRequest) => {
+  const { scope } = await resolvePricePreferenceScope(req.auth_context, req.scope)
 
   const { id } = req.params
   const query = req.scope.resolve(ContainerRegistrationKeys.QUERY)
@@ -23,29 +32,54 @@ export const GET = async (
     filters: { id },
   })
 
-  if (!preferences?.[0]) {
-    throw new MedusaError(MedusaError.Types.NOT_FOUND, `Price preference ${id} not found`)
+  const preference = (preferences || [])[0] as any
+  if (!preference || !isPreferenceInScope(preference, scope)) {
+    throw new MedusaError(
+      MedusaError.Types.NOT_FOUND,
+      `Price preference ${id} not found`
+    )
   }
 
-  res.json({ price_preference: preferences[0] })
+  return { preference, scope }
+}
+
+export const GET = async (
+  req: AuthenticatedMedusaRequest,
+  res: MedusaResponse
+) => {
+  const { preference } = await loadInScope(req)
+  res.json({ price_preference: preference })
 }
 
 export const POST = async (
   req: AuthenticatedMedusaRequest,
   res: MedusaResponse
 ) => {
-  const partner = await getPartnerFromAuthContext(req.auth_context, req.scope)
-  if (!partner) {
-    throw new MedusaError(
-      MedusaError.Types.UNAUTHORIZED,
-      "No partner associated with this account"
+  const { preference, scope } = await loadInScope(req)
+
+  // Checked against the STORED row, not the body: an update that renamed the
+  // attribute or value in the payload would otherwise be checked against the
+  // thing it was becoming rather than the thing it is.
+  assertPreferenceWritable(preference, scope)
+
+  const body = req.body as Record<string, any>
+  // …and against the incoming shape too, so a write cannot move a preference
+  // out of scope on its way through.
+  if (body?.attribute !== undefined || body?.value !== undefined) {
+    assertPreferenceWritable(
+      {
+        attribute: body?.attribute ?? preference.attribute,
+        value: body?.value ?? preference.value,
+      },
+      scope
     )
   }
 
-  const { id } = req.params
-  const body = req.body as Record<string, any>
   const pricingService = req.scope.resolve(Modules.PRICING) as any
-  const updated = await pricingService.updatePricePreferences(id, body)
+  const updated = await pricingService.updatePricePreferences(
+    req.params.id,
+    body
+  )
 
   res.json({ price_preference: updated })
 }
@@ -54,16 +88,12 @@ export const DELETE = async (
   req: AuthenticatedMedusaRequest,
   res: MedusaResponse
 ) => {
-  const partner = await getPartnerFromAuthContext(req.auth_context, req.scope)
-  if (!partner) {
-    throw new MedusaError(
-      MedusaError.Types.UNAUTHORIZED,
-      "No partner associated with this account"
-    )
-  }
+  const { preference, scope } = await loadInScope(req)
+  assertPreferenceWritable(preference, scope)
 
-  const { id } = req.params
-  await deletePricePreferencesWorkflow(req.scope).run({ input: [id] })
+  await deletePricePreferencesWorkflow(req.scope).run({
+    input: [req.params.id],
+  })
 
-  res.json({ id, object: "price_preference", deleted: true })
+  res.json({ id: req.params.id, object: "price_preference", deleted: true })
 }

--- a/apps/backend/src/api/partners/price-preferences/lib/scope.ts
+++ b/apps/backend/src/api/partners/price-preferences/lib/scope.ts
@@ -1,0 +1,203 @@
+import { ContainerRegistrationKeys, MedusaError } from "@medusajs/framework/utils"
+import type { MedusaContainer } from "@medusajs/framework/types"
+
+import { getPartnerFromAuthContext, tryGetPartnerStore } from "../../helpers"
+import partnerRegionLink from "../../../../links/partner-region"
+
+/**
+ * Partner scoping for price preferences — the one pricing surface that cannot
+ * be scoped by ownership alone.
+ *
+ * ## What was wrong
+ *
+ * These routes checked only "are you *a* partner". `GET` ran
+ * `query.graph({ entity: "price_preferences", fields: ["*"] })` with **no
+ * filters**, and the writes called `createPricePreferences(req.body)` /
+ * `updatePricePreferences(id, body)` / the delete workflow with no ownership
+ * check at all. Any partner could read, edit and delete every other partner's
+ * tax-inclusivity setting — and the same routes are exposed to the partner AI
+ * assistant as `write: true` MCP tools.
+ *
+ * ## Why scoping here is different
+ *
+ * A `price_preference` is keyed by `(attribute, value)` where attribute is
+ * `currency_code` or `region_id`. **Neither has a partner dimension.**
+ *
+ * - `currency_code` is platform-wide by construction. Flipping tax-inclusivity
+ *   for `inr` changes it for every store pricing in INR. There is no version of
+ *   that write which is "yours", so it is refused outright.
+ * - `region_id` is scopeable — but only when the region belongs to this partner
+ *   and to NO other partner. On prod a single region backs roughly ten stores,
+ *   so "linked to me" is not the same as "mine", and the shared case has to be
+ *   refused too or the hole simply moves.
+ *
+ * Reads are wider than writes on purpose: a partner may legitimately need to
+ * SEE the preference that governs their prices even when it is shared and they
+ * must not change it.
+ */
+
+export type PricePreferenceScope = {
+  /** Regions linked to this partner. */
+  region_ids: string[]
+  /** Regions linked to this partner and to no other partner. */
+  exclusive_region_ids: string[]
+  /** Currencies this partner's store supports, lower-cased. */
+  currency_codes: string[]
+}
+
+export type PricePreferenceLike = {
+  attribute?: string | null
+  value?: string | null
+}
+
+const norm = (v: unknown): string => String(v ?? "").trim().toLowerCase()
+
+/**
+ * PURE: may this partner SEE this preference?
+ *
+ * Deliberately permissive relative to writability — a preference that governs
+ * a partner's own prices is theirs to read even when it is shared.
+ */
+export function isPreferenceInScope(
+  pref: PricePreferenceLike,
+  scope: PricePreferenceScope
+): boolean {
+  const attribute = norm(pref.attribute)
+  const value = pref.value ?? ""
+
+  if (attribute === "region_id") {
+    return scope.region_ids.includes(value)
+  }
+  if (attribute === "currency_code") {
+    return scope.currency_codes.includes(norm(value))
+  }
+  // An attribute we do not model is not ours to show.
+  return false
+}
+
+/**
+ * PURE: may this partner CHANGE this preference, and if not, exactly why.
+ *
+ * The reason is returned rather than a bare boolean because every refusal here
+ * is one a partner will reasonably want explained — "this is shared" and "this
+ * is not yours" are different answers and deserve different copy.
+ */
+export function checkPreferenceWritable(
+  pref: PricePreferenceLike,
+  scope: PricePreferenceScope
+): { writable: boolean; reason: string | null } {
+  const attribute = norm(pref.attribute)
+  const value = pref.value ?? ""
+
+  if (attribute === "currency_code") {
+    return {
+      writable: false,
+      reason:
+        `A price preference on a currency applies to every store pricing in ${norm(value) || "that currency"}, ` +
+        `not just yours, so it cannot be changed from a partner account. Set it per region instead, or ask an administrator.`,
+    }
+  }
+
+  if (attribute === "region_id") {
+    if (!scope.region_ids.includes(value)) {
+      return {
+        writable: false,
+        reason: `Region ${value || "(none)"} is not one of yours.`,
+      }
+    }
+    if (!scope.exclusive_region_ids.includes(value)) {
+      return {
+        writable: false,
+        reason:
+          `Region ${value} is shared with other partners, so changing its tax-inclusivity would change theirs too. ` +
+          `Ask an administrator if this needs to move.`,
+      }
+    }
+    return { writable: true, reason: null }
+  }
+
+  return {
+    writable: false,
+    reason: `Unsupported price-preference attribute "${pref.attribute ?? ""}".`,
+  }
+}
+
+/** Throws NOT_ALLOWED with the specific reason, or returns cleanly. */
+export function assertPreferenceWritable(
+  pref: PricePreferenceLike,
+  scope: PricePreferenceScope
+): void {
+  const { writable, reason } = checkPreferenceWritable(pref, scope)
+  if (!writable) {
+    throw new MedusaError(
+      MedusaError.Types.NOT_ALLOWED,
+      reason ?? "This price preference cannot be changed from a partner account."
+    )
+  }
+}
+
+/**
+ * Resolve what this partner may see and change.
+ *
+ * Exclusivity is computed from the partner↔region link itself: a region is only
+ * writable when this partner is the sole partner linked to it.
+ */
+export async function resolvePricePreferenceScope(
+  authContext: { actor_id?: string | null } | undefined,
+  container: MedusaContainer
+): Promise<{ partner: any; scope: PricePreferenceScope }> {
+  const partner = await getPartnerFromAuthContext(authContext, container)
+  if (!partner) {
+    throw new MedusaError(
+      MedusaError.Types.UNAUTHORIZED,
+      "No partner associated with this account"
+    )
+  }
+
+  const query: any = container.resolve(ContainerRegistrationKeys.QUERY)
+
+  // Every partner↔region link, so we can tell "mine" from "mine alone".
+  const { data: links } = await query.graph({
+    entity: partnerRegionLink.entryPoint,
+    fields: ["partner_id", "region_id"],
+  })
+
+  const regionIds: string[] = []
+  const partnersByRegion = new Map<string, Set<string>>()
+  for (const l of (links || []) as any[]) {
+    if (!l?.region_id) continue
+    if (!partnersByRegion.has(l.region_id)) {
+      partnersByRegion.set(l.region_id, new Set())
+    }
+    if (l.partner_id) partnersByRegion.get(l.region_id)!.add(l.partner_id)
+    if (l.partner_id === partner.id) regionIds.push(l.region_id)
+  }
+
+  const exclusiveRegionIds = regionIds.filter(
+    (id) => (partnersByRegion.get(id)?.size ?? 0) === 1
+  )
+
+  // Currencies come from the partner's store; a storeless partner sees none
+  // rather than everything.
+  const { store } = await tryGetPartnerStore(authContext, container)
+  let currencyCodes: string[] = []
+  if (store?.id) {
+    const { data: stores } = await query.graph({
+      entity: "stores",
+      fields: ["id", "supported_currencies.currency_code"],
+      filters: { id: store.id },
+    })
+    currencyCodes = (((stores?.[0] as any)?.supported_currencies || []) as any[])
+      .map((c) => norm(c?.currency_code))
+      .filter(Boolean)
+  }
+
+  return {
+    partner,
+    scope: {
+      region_ids: [...new Set(regionIds)],
+      exclusive_region_ids: [...new Set(exclusiveRegionIds)],
+      currency_codes: [...new Set(currencyCodes)],
+    },
+  }
+}

--- a/apps/backend/src/api/partners/price-preferences/route.ts
+++ b/apps/backend/src/api/partners/price-preferences/route.ts
@@ -1,18 +1,26 @@
 import { AuthenticatedMedusaRequest, MedusaResponse } from "@medusajs/framework/http"
-import { ContainerRegistrationKeys, MedusaError, Modules } from "@medusajs/framework/utils"
-import { getPartnerFromAuthContext } from "../helpers"
+import { ContainerRegistrationKeys, Modules } from "@medusajs/framework/utils"
 
+import {
+  assertPreferenceWritable,
+  isPreferenceInScope,
+  resolvePricePreferenceScope,
+} from "./lib/scope"
+
+/**
+ * Partner-scoped price preferences (tax-inclusivity per currency or region).
+ *
+ * This route used to list EVERY price preference on the platform — the query
+ * carried no filters — and create one from an unchecked body. The only guard
+ * was "are you a partner". See `lib/scope.ts` for why this surface needs a
+ * scope rule rather than an ownership link: a `price_preference` is keyed by
+ * currency or region, and neither has a partner dimension.
+ */
 export const GET = async (
   req: AuthenticatedMedusaRequest,
   res: MedusaResponse
 ) => {
-  const partner = await getPartnerFromAuthContext(req.auth_context, req.scope)
-  if (!partner) {
-    throw new MedusaError(
-      MedusaError.Types.UNAUTHORIZED,
-      "No partner associated with this account"
-    )
-  }
+  const { scope } = await resolvePricePreferenceScope(req.auth_context, req.scope)
 
   const query = req.scope.resolve(ContainerRegistrationKeys.QUERY)
   const { data: preferences } = await query.graph({
@@ -20,9 +28,16 @@ export const GET = async (
     fields: ["*"],
   })
 
+  // Filtered in the handler rather than the query: the scope is a union of two
+  // different attributes, and expressing that as graph filters would be a
+  // second copy of the rule that `lib/scope.ts` already owns.
+  const visible = ((preferences || []) as any[]).filter((p) =>
+    isPreferenceInScope(p, scope)
+  )
+
   res.json({
-    price_preferences: preferences || [],
-    count: preferences?.length || 0,
+    price_preferences: visible,
+    count: visible.length,
     offset: 0,
     limit: 20,
   })
@@ -32,15 +47,14 @@ export const POST = async (
   req: AuthenticatedMedusaRequest,
   res: MedusaResponse
 ) => {
-  const partner = await getPartnerFromAuthContext(req.auth_context, req.scope)
-  if (!partner) {
-    throw new MedusaError(
-      MedusaError.Types.UNAUTHORIZED,
-      "No partner associated with this account"
-    )
-  }
+  const { scope } = await resolvePricePreferenceScope(req.auth_context, req.scope)
 
   const body = req.body as Record<string, any>
+  assertPreferenceWritable(
+    { attribute: body?.attribute, value: body?.value },
+    scope
+  )
+
   const pricingService = req.scope.resolve(Modules.PRICING) as any
   const preference = await pricingService.createPricePreferences(body)
 


### PR DESCRIPTION
Found while planning quote-minted price lists (#1389). Each is a partner reaching another partner's data, and the third becomes a **pricing leak** the moment customer groups start carrying negotiated B2B prices — so it has to land first.

## 1. 🔴 `/partners/price-preferences` was entirely unscoped

`GET` ran `query.graph({ entity: "price_preferences", fields: ["*"] })` with **no filters** and returned every preference on the platform. `POST` called `createPricePreferences(req.body)`. The `:id` routes — update and **DELETE** included — took the id straight from the URL. The only guard on any of them was *"are you a partner"*. All four are exposed to the partner AI assistant as `write: true` MCP tools.

This one can't be fixed with an ownership link, because a `price_preference` is keyed by `(attribute, value)` where attribute is `currency_code` or `region_id` and **neither has a partner dimension**:

- **`currency_code` is platform-wide by construction.** Flipping tax-inclusivity for `inr` changes it for every store pricing in INR. There is no version of that write which is "yours" → refused outright, with the reason.
- **`region_id` is scopeable** — but only when the region belongs to this partner *and to no other partner*. On prod a single region backs ~10 stores, so "linked to me" is not "mine"; the shared case is refused too, or the hole just moves.

Reads are deliberately **wider** than writes: a preference that governs a partner's prices is theirs to *see* even when it isn't theirs to change. Out-of-scope reads 404 rather than 403, matching every other guard here. Writes return `NOT_ALLOWED` **with the reason** — "this is shared" and "this is not yours" are different answers.

MCP descriptions were promising what the routes now refuse, so they state the constraint instead; otherwise the assistant retries a call that cannot succeed.

## 2. 🔴 `customers/:id/customer-groups` validated the customer, not the groups

`body.add` was an unchecked array of arbitrary `customer_group_id`s passed to `linkCustomerGroupsToCustomerWorkflow`. A partner could drop their own customer into another partner's group. **Once a group carries a negotiated price list, that customer silently inherits pricing that was never theirs.**

## 3. ⚠️ `customer-groups/:id/customers` had the mirror hole — and could never work

Same missing validation on `body.add`/`body.remove`, plus it wrote `remoteLink.create({ customer_group, customer })` — a link that is **not registered**. The sibling route's own comment documents that 500ing in #495; the fix never reached this file. That's why the hole was academic: the route couldn't succeed. It now uses `linkCustomersToCustomerGroupWorkflow`, so the route works *and* the guard is load-bearing.

## The rule, in one place

`validatePartnerOwnsEntities()` joins the guard vocabulary in `api/partners/helpers.ts`, with `missingOwnedIds` split out pure:

> **Validate both ends of any request that names an id.** Owning the resource in the URL says nothing about owning the ids in the body.

The same primitive is what the price-list work needs for the `customer_group_id` a quote scopes its list to.

## Verification

18 unit tests, including the dangerous default — **an empty owned set must own nothing, not everything**, since a partner with no customers must not pass a check because the comparison set came back empty. `check:prod-build` green; 419 MCP/partner unit tests still pass.

Not fixed here, same shape, lower severity: `/partners/tax-rates` and `/partners/shipping-profiles` are also unscoped (global read, unchecked create).

🤖 Generated with [Claude Code](https://claude.com/claude-code)