### PR TITLE
fix(ops): both orphan-store jobs asked the api_key module service for a link

### DIFF
--- a/apps/backend/src/api/admin/ops/maintenance-jobs/__tests__/orphan-store-key-lookup.unit.spec.ts
+++ b/apps/backend/src/api/admin/ops/maintenance-jobs/__tests__/orphan-store-key-lookup.unit.spec.ts
@@ -137,7 +137,9 @@ describe("restore-orphan-store — counting the keys linked to a channel", () =>
 
     // A key IS linked, so the "mint a replacement" warning must not fire.
     expect(
-      result.errors.some((e: any) => e.message.includes("recreate_publishable_key"))
+      (result.errors ?? []).some((e: any) =>
+        e.message.includes("recreate_publishable_key")
+      )
     ).toBe(false)
   })
 })

--- a/apps/backend/src/api/admin/ops/maintenance-jobs/__tests__/orphan-store-key-lookup.unit.spec.ts
+++ b/apps/backend/src/api/admin/ops/maintenance-jobs/__tests__/orphan-store-key-lookup.unit.spec.ts
@@ -1,0 +1,143 @@
+import { restoreOrphanStoreJob } from "../restore-orphan-store-job"
+
+/**
+ * The publishable key ↔ sales channel relationship is a LINK, not a field on
+ * the ApiKey model — `ApiKey` declares only id/token/salt/redacted/title/type/
+ * last_used_at/created_by/revoked_by/revoked_at. So the module service cannot
+ * filter on `sales_channels` and throws when asked to; only Query resolves
+ * links.
+ *
+ * Both orphan-store jobs asked the module service anyway:
+ *
+ * - `restore-orphan-store` threw on EVERY real store. A store that does not
+ *   exist has no channel id, so the block was skipped and the refusal path
+ *   returned a clean 200 — which is exactly why the job looked healthy while
+ *   having never once worked. Its presence in the job registry proved it was
+ *   deployed, not that it ran.
+ * - `delete-orphan-store` made the same call inside a try/catch, so its key
+ *   removal — the step its own comment calls load-bearing — threw on its first
+ *   line and degraded into an error note, leaving behind the dangling
+ *   sales-channel link that took every storefront down.
+ *
+ * These tests fake the module service the way the real one behaves: it throws
+ * on an unknown property. The pure `check*` helpers cannot catch this, which is
+ * why every existing test in this folder passed throughout.
+ */
+
+const UNKNOWN_PROPERTY = new Error(
+  "Trying to query by not existing property ApiKey.sales_channels"
+)
+
+const makeContainer = (over: Record<string, any> = {}) => {
+  const apiKeyService = {
+    listApiKeys: jest.fn(async (filters: any) => {
+      if (filters && "sales_channels" in filters) {
+        throw UNKNOWN_PROPERTY
+      }
+      return []
+    }),
+    revoke: jest.fn(),
+    deleteApiKeys: jest.fn(),
+  }
+
+  const registry: Record<string, any> = {
+    store: {
+      listStores: jest.fn(async () => [
+        {
+          id: "store_1",
+          name: "Sharhlo Store",
+          deleted_at: "2026-08-20T23:14:28.901Z",
+          default_sales_channel_id: "sc_1",
+          default_location_id: "loc_1",
+        },
+      ]),
+      restoreStores: jest.fn(),
+    },
+    sales_channel: {
+      listSalesChannels: jest.fn(async () => [
+        { id: "sc_1", deleted_at: "2026-08-20T23:14:28.901Z" },
+      ]),
+      restoreSalesChannels: jest.fn(),
+    },
+    stock_location: {
+      listStockLocations: jest.fn(async () => [
+        { id: "loc_1", deleted_at: "2026-08-20T23:14:28.901Z" },
+      ]),
+      restoreStockLocations: jest.fn(),
+    },
+    api_key: apiKeyService,
+    query: { graph: jest.fn(async () => ({ data: [] })) },
+    ...over,
+  }
+
+  return {
+    container: { resolve: (key: string) => registry[key] } as any,
+    registry,
+    apiKeyService,
+  }
+}
+
+describe("restore-orphan-store — counting the keys linked to a channel", () => {
+  it("does not throw for a real store with a sales channel", async () => {
+    // The regression itself: before the fix this rejected, and the route
+    // returned a bare HTML 500 rather than a Medusa error.
+    const { container } = makeContainer()
+
+    const result = await restoreOrphanStoreJob.run(container, {
+      dry_run: true,
+      params: { store_id: "store_1" },
+    })
+
+    expect(result.applied).toBe(false)
+    expect(result.summary).toContain("Would restore store Sharhlo Store")
+  })
+
+  it("resolves the link through Query, never the api_key module service", async () => {
+    const { container, registry, apiKeyService } = makeContainer()
+
+    await restoreOrphanStoreJob.run(container, {
+      dry_run: true,
+      params: { store_id: "store_1" },
+    })
+
+    expect(apiKeyService.listApiKeys).not.toHaveBeenCalled()
+    expect(registry.query.graph).toHaveBeenCalledWith(
+      expect.objectContaining({
+        entity: "api_key",
+        filters: expect.objectContaining({
+          type: "publishable",
+          sales_channels: { id: "sc_1" },
+        }),
+      })
+    )
+  })
+
+  it("still refuses a store that does not exist — the path that always worked", async () => {
+    const { container } = makeContainer({
+      store: { listStores: jest.fn(async () => []), restoreStores: jest.fn() },
+    })
+
+    const result = await restoreOrphanStoreJob.run(container, {
+      dry_run: true,
+      params: { store_id: "store_nope" },
+    })
+
+    expect(result.summary).toContain("REFUSED")
+  })
+
+  it("reports the surviving key count when Query finds one", async () => {
+    const { container } = makeContainer({
+      query: { graph: jest.fn(async () => ({ data: [{ id: "apk_1" }] })) },
+    })
+
+    const result = await restoreOrphanStoreJob.run(container, {
+      dry_run: true,
+      params: { store_id: "store_1" },
+    })
+
+    // A key IS linked, so the "mint a replacement" warning must not fire.
+    expect(
+      result.errors.some((e: any) => e.message.includes("recreate_publishable_key"))
+    ).toBe(false)
+  })
+})

--- a/apps/backend/src/api/admin/ops/maintenance-jobs/delete-orphan-store-job.ts
+++ b/apps/backend/src/api/admin/ops/maintenance-jobs/delete-orphan-store-job.ts
@@ -364,9 +364,18 @@ export const deleteOrphanStoreJob: MaintenanceJob = {
       if (channelId) {
         try {
           const apiKeyService: any = container.resolve("api_key")
-          const keys = await apiKeyService.listApiKeys({
-            type: "publishable",
-            sales_channels: { id: channelId },
+          // 🔴 `sales_channels` is a LINK, not a field on the ApiKey model —
+          // the module service cannot filter on it and throws. This block used
+          // `apiKeyService.listApiKeys({ sales_channels: … })`, which meant the
+          // key removal this job's own comment calls load-bearing threw on its
+          // first line, got converted into an error note, and left behind the
+          // exact dangling link the comment describes. Only Query resolves
+          // links — which is how the dry-run path 140 lines above already does
+          // it, so the preview reported keys the apply could never remove.
+          const { data: keys } = await query.graph({
+            entity: "api_key",
+            fields: ["id", "title", "revoked_at"],
+            filters: { type: "publishable", sales_channels: { id: channelId } },
           })
           for (const k of keys ?? []) {
             // A publishable key cannot be deleted until it is revoked; core

--- a/apps/backend/src/api/admin/ops/maintenance-jobs/restore-orphan-store-job.ts
+++ b/apps/backend/src/api/admin/ops/maintenance-jobs/restore-orphan-store-job.ts
@@ -1,4 +1,4 @@
-import { MedusaError } from "@medusajs/framework/utils"
+import { ContainerRegistrationKeys, MedusaError } from "@medusajs/framework/utils"
 import { z } from "@medusajs/framework/zod"
 import {
   createApiKeysWorkflow,
@@ -177,7 +177,7 @@ export const restoreOrphanStoreJob: MaintenanceJob = {
     const storeService: any = container.resolve("store")
     const scService: any = container.resolve("sales_channel")
     const locService: any = container.resolve("stock_location")
-    const apiKeyService: any = container.resolve("api_key")
+    const query: any = container.resolve(ContainerRegistrationKeys.QUERY)
 
     // `withDeleted` is opt-in everywhere in Medusa, and the row we are looking
     // for is by definition deleted — reading it without this returns nothing
@@ -211,9 +211,16 @@ export const restoreOrphanStoreJob: MaintenanceJob = {
 
     let linkedKeyCount = 0
     if (channelId) {
-      const keys = await apiKeyService.listApiKeys({
-        type: "publishable",
-        sales_channels: { id: channelId },
+      // 🔴 `sales_channels` is a LINK, not a field on the ApiKey model, so the
+      // module service throws on it — only Query resolves links. This line read
+      // `apiKeyService.listApiKeys({ sales_channels: … })` and threw for EVERY
+      // real store: a store that does not exist has no channel id, so the block
+      // was skipped and the refusal path returned 200, which is why the job
+      // looked healthy. Registration is not function.
+      const { data: keys } = await query.graph({
+        entity: "api_key",
+        fields: ["id"],
+        filters: { type: "publishable", sales_channels: { id: channelId } },
       })
       linkedKeyCount = (keys ?? []).length
     }


### PR DESCRIPTION
`sales_channels` is a **link**, not a field on the `ApiKey` model — which declares only `id/token/salt/redacted/title/type/last_used_at/created_by/revoked_by/revoked_at`. The module service cannot filter on it and throws. Only Query resolves links.

Both orphan-store jobs asked the module service anyway, and failed in opposite directions.

## `restore-orphan-store` 500'd on every real store

The undo shipped in #1401 has never worked. Verified against prod: it returns a bare HTML **500**, twice, for `store_01KKNSS3WERBNFF5X8FPJSCQME`.

🔑 It looked healthy because the block is guarded by `if (channelId)`. A store that does not exist has no channel id, so the guard skips it and the refusal path returns a clean 200. Every cheap check passed — the job appears in `GET /admin/ops/maintenance-jobs`, and a bogus id refuses politely. **Registration is not function; a listing is not a successful call.**

## `delete-orphan-store` still recreates the outage

The same call sits inside a `try/catch`, so the key removal its own comment calls load-bearing throws on its first line and degrades into an error note. Run it today and it soft-deletes the channel while the publishable key survives pointing at it — the exact dangling link that expanded to `sales_channels: [null]` and took every partner storefront down on 2026-08-21.

**The fix for that outage was itself broken.**

🔑 The tell was in the same file: 140 lines above, the dry-run path already does it correctly with `query.graph`. Dry-run and apply used **different code paths**, so the preview reported keys the apply could never remove.

## Tests

4 new, faking the module service the way the real one behaves — throwing on an unknown property. **Confirmed red before the fix**: 3 of 4 fail, and the one that passes is the nonexistent-store path, which is precisely why this stayed invisible.

The 17 existing tests in this folder passed before and after. They only exercise the pure `check*` helpers; nothing ever executed `run()`.

`tsc` clean (75 = baseline). 21 tests pass across the three orphan-store suites.

## After merge

Sharhlo Store (`store_01KKNSS3WERBNFF5X8FPJSCQME`) is soft-deleted and intact, waiting on this to deploy before the restore can run. Its publishable key was hard-deleted, so the restore will need a decision on `recreate_publishable_key` — it mints a **different token**.

🤖 Generated with [Claude Code](https://claude.com/claude-code)