### PR TITLE
feat(partners): scope price lists to a store, and validate both ends of a rule (#1405 item 1)

### DIFF
--- a/apps/backend/src/api/middlewares.ts
+++ b/apps/backend/src/api/middlewares.ts
@@ -304,6 +304,7 @@ import { ListInventoryItemRawMaterialsQuerySchema } from "./admin/inventory-item
 import { BulkImportSchema } from "./admin/inventory-items/bulk-import/validators";
 import { PartnerCreateStoreReq } from "./partners/stores/validators";
 import { PartnerCreateProductReq, PartnerArtisanProductDetailReq, PartnerProductSpecReq, PartnerStoreCreateProductReq, PartnerQuickCreateProductReq } from "./partners/products/validators";
+import { PartnerCreatePriceListReq, PartnerUpdatePriceListReq } from "./partners/price-lists/validators";
 import { BATCH_VARIANT_FIELDS } from "../workflows/partner/batch-partner-variants";
 import { StoreMadeToSpecReq } from "./store/carts/[id]/made-to-spec/validators";
 import {
@@ -5575,6 +5576,51 @@ export default defineMiddlewares({
       matcher: "/partners/customer-groups/:id/customers",
       method: "POST",
       middlewares: [authenticate("partner", ["session", "bearer"])],
+    },
+    // Partner price list endpoints (#1405). Unlike customer-groups above,
+    // every write body is validated — a price list carries money and the rule
+    // that decides whose money it is.
+    {
+      matcher: "/partners/price-lists",
+      method: "GET",
+      middlewares: [
+        createCorsPartnerMiddleware(),
+        authenticate("partner", ["session", "bearer"]),
+      ],
+    },
+    {
+      matcher: "/partners/price-lists",
+      method: "POST",
+      middlewares: [
+        createCorsPartnerMiddleware(),
+        authenticate("partner", ["session", "bearer"]),
+        validateAndTransformBody(wrapSchema(PartnerCreatePriceListReq)),
+      ],
+    },
+    {
+      matcher: "/partners/price-lists/:id",
+      method: "GET",
+      middlewares: [
+        createCorsPartnerMiddleware(),
+        authenticate("partner", ["session", "bearer"]),
+      ],
+    },
+    {
+      matcher: "/partners/price-lists/:id",
+      method: "POST",
+      middlewares: [
+        createCorsPartnerMiddleware(),
+        authenticate("partner", ["session", "bearer"]),
+        validateAndTransformBody(wrapSchema(PartnerUpdatePriceListReq)),
+      ],
+    },
+    {
+      matcher: "/partners/price-lists/:id",
+      method: "DELETE",
+      middlewares: [
+        createCorsPartnerMiddleware(),
+        authenticate("partner", ["session", "bearer"]),
+      ],
     },
     // Partner Order endpoints
     {

--- a/apps/backend/src/api/partners/__tests__/price-list-scope.unit.spec.ts
+++ b/apps/backend/src/api/partners/__tests__/price-list-scope.unit.spec.ts
@@ -1,0 +1,78 @@
+import { validatePriceListRules } from "../price-lists/helpers"
+import { validatePartnerOwnsEntities } from "../helpers"
+
+jest.mock("../helpers", () => ({
+  validatePartnerOwnsEntities: jest.fn(),
+}))
+
+/**
+ * Partner scoping for price lists (#1405).
+ *
+ * A price list carries money, and `rules.customer_group_id` is the field that
+ * decides WHOSE money. Owning the list says nothing about owning the group it
+ * is scoped to — the same "validate both ends" rule that #1404 established for
+ * customer groups, applied to the surface that actually prices a cart.
+ */
+
+const mocked = validatePartnerOwnsEntities as jest.MockedFunction<
+  typeof validatePartnerOwnsEntities
+>
+
+const auth = { actor_id: "partner_mine" }
+const container = {} as any
+
+beforeEach(() => {
+  mocked.mockReset()
+  mocked.mockResolvedValue({ partner: {}, store: {} } as any)
+})
+
+describe("validatePriceListRules", () => {
+  it("asserts ownership of every customer group named in the rules", async () => {
+    await validatePriceListRules(
+      auth,
+      { customer_group_id: ["cg_mine", "cg_also_mine"] },
+      container
+    )
+
+    expect(mocked).toHaveBeenCalledWith(
+      auth,
+      "customer_groups",
+      ["cg_mine", "cg_also_mine"],
+      container
+    )
+  })
+
+  it("propagates the NOT_FOUND when a group belongs to another partner", async () => {
+    mocked.mockRejectedValue(new Error("customer groups not found: cg_theirs"))
+
+    await expect(
+      validatePriceListRules(auth, { customer_group_id: ["cg_theirs"] }, container)
+    ).rejects.toThrow("cg_theirs")
+  })
+
+  it("checks EVERY id, not just the first — a valid id must not smuggle in a foreign one", async () => {
+    await validatePriceListRules(
+      auth,
+      { customer_group_id: ["cg_mine", "cg_theirs"] },
+      container
+    )
+
+    expect(mocked.mock.calls[0][2]).toEqual(["cg_mine", "cg_theirs"])
+  })
+
+  it("skips the check when no customer group rule is present", async () => {
+    // region_id and currency_code are platform-wide by design — there is no
+    // partner dimension to assert, and calling the guard would 404 nothing.
+    await validatePriceListRules(auth, { region_id: ["reg_1"] }, container)
+
+    expect(mocked).not.toHaveBeenCalled()
+  })
+
+  it("skips the check for an absent, null or empty rule set", async () => {
+    await validatePriceListRules(auth, undefined, container)
+    await validatePriceListRules(auth, null, container)
+    await validatePriceListRules(auth, { customer_group_id: [] }, container)
+
+    expect(mocked).not.toHaveBeenCalled()
+  })
+})

--- a/apps/backend/src/api/partners/helpers.ts
+++ b/apps/backend/src/api/partners/helpers.ts
@@ -210,9 +210,23 @@ export const resolvePartnerShipFromLocation = async (
     return { partner, locationId: picked?.id ?? null }
 }
 
+/**
+ * Every core entity a partner can own, keyed by the `field` its store link
+ * declares in `src/links/`. Deliberately a closed union: an entity type only
+ * belongs here once a `store ↔ …` link exists, because both guards below ask
+ * the store for `${entityType}.id` and a missing link resolves to an empty
+ * list — which reads as "you own nothing" and 404s every legitimate request.
+ */
+export type PartnerScopedEntity =
+    | "product_categories"
+    | "product_collections"
+    | "customers"
+    | "customer_groups"
+    | "price_lists"
+
 export const validatePartnerEntityOwnership = async (
     authContext: { actor_id?: string | null } | undefined,
-    entityType: "product_categories" | "product_collections" | "customers" | "customer_groups",
+    entityType: PartnerScopedEntity,
     entityId: string,
     container: MedusaContainer,
 ): Promise<{ partner: any; store: any }> => {
@@ -274,7 +288,7 @@ export const missingOwnedIds = (
  */
 export const validatePartnerOwnsEntities = async (
     authContext: { actor_id?: string | null } | undefined,
-    entityType: "product_categories" | "product_collections" | "customers" | "customer_groups",
+    entityType: PartnerScopedEntity,
     entityIds: string[],
     container: MedusaContainer,
 ): Promise<{ partner: any; store: any }> => {

--- a/apps/backend/src/api/partners/price-lists/[id]/route.ts
+++ b/apps/backend/src/api/partners/price-lists/[id]/route.ts
@@ -1,0 +1,86 @@
+import { AuthenticatedMedusaRequest, MedusaResponse } from "@medusajs/framework/http"
+import { ContainerRegistrationKeys, Modules } from "@medusajs/framework/utils"
+import {
+  deletePriceListsWorkflow,
+  updatePriceListsWorkflow,
+} from "@medusajs/medusa/core-flows"
+import { validatePartnerEntityOwnership } from "../../helpers"
+import { validatePriceListRules } from "../helpers"
+
+/**
+ * `validatePartnerEntityOwnership` is the FIRST statement of every handler
+ * here — it resolves the partner's store and asserts the id in the URL is
+ * linked to it, throwing NOT_FOUND (never NOT_ALLOWED) so a partner probing
+ * ids cannot tell "exists but not yours" from "no such thing".
+ */
+export const GET = async (
+  req: AuthenticatedMedusaRequest,
+  res: MedusaResponse
+) => {
+  await validatePartnerEntityOwnership(
+    req.auth_context,
+    "price_lists",
+    req.params.id,
+    req.scope
+  )
+
+  const query = req.scope.resolve(ContainerRegistrationKeys.QUERY)
+  const { data } = await query.graph({
+    entity: "price_lists",
+    fields: ["*", "prices.*", "price_list_rules.*"],
+    filters: { id: req.params.id },
+  })
+
+  res.json({ price_list: data?.[0] })
+}
+
+export const POST = async (
+  req: AuthenticatedMedusaRequest,
+  res: MedusaResponse
+) => {
+  await validatePartnerEntityOwnership(
+    req.auth_context,
+    "price_lists",
+    req.params.id,
+    req.scope
+  )
+
+  const body = req.validatedBody as any
+  // Owning the list says nothing about owning the groups an update re-scopes it
+  // to — an update can move a list onto another partner's customer group just
+  // as easily as a create can.
+  await validatePriceListRules(req.auth_context, body?.rules, req.scope)
+
+  const { result } = await updatePriceListsWorkflow(req.scope).run({
+    input: { price_lists_data: [{ ...body, id: req.params.id }] },
+  })
+
+  res.json({ price_list: (result as any[])[0] })
+}
+
+export const DELETE = async (
+  req: AuthenticatedMedusaRequest,
+  res: MedusaResponse
+) => {
+  const { store } = await validatePartnerEntityOwnership(
+    req.auth_context,
+    "price_lists",
+    req.params.id,
+    req.scope
+  )
+
+  // Dismiss the link BEFORE the delete, so the dangling state that took every
+  // storefront down (a surviving row pointing at a deleted entity) is never
+  // written, even for an instant.
+  const remoteLink = req.scope.resolve(ContainerRegistrationKeys.LINK) as any
+  await remoteLink.dismiss({
+    [Modules.STORE]: { store_id: store.id },
+    [Modules.PRICING]: { price_list_id: req.params.id },
+  })
+
+  await deletePriceListsWorkflow(req.scope).run({
+    input: { ids: [req.params.id] },
+  })
+
+  res.json({ id: req.params.id, object: "price_list", deleted: true })
+}

--- a/apps/backend/src/api/partners/price-lists/helpers.ts
+++ b/apps/backend/src/api/partners/price-lists/helpers.ts
@@ -1,0 +1,33 @@
+import { MedusaContainer } from "@medusajs/framework"
+import { validatePartnerOwnsEntities } from "../helpers"
+
+/**
+ * 🔴 Validate BOTH ENDS of a price-list write.
+ *
+ * A price list's own ownership says nothing about the ids inside its `rules`.
+ * `rules.customer_group_id` is precisely the field that decides whose customers
+ * get these prices — so a partner who could name another partner's group would
+ * be handing themselves someone else's buyers, or worse, quietly repricing
+ * them. Same class as the two holes closed in #1404.
+ *
+ * Only `customer_group_id` is checked because it is the only rule key that
+ * names a partner-scoped entity today; `region_id` and `currency_code` are
+ * platform-wide by design.
+ */
+export const validatePriceListRules = async (
+  authContext: { actor_id?: string | null } | undefined,
+  rules: Record<string, string[]> | undefined | null,
+  container: MedusaContainer,
+): Promise<void> => {
+  const groupIds = rules?.customer_group_id
+  if (!groupIds?.length) {
+    return
+  }
+
+  await validatePartnerOwnsEntities(
+    authContext,
+    "customer_groups",
+    groupIds,
+    container,
+  )
+}

--- a/apps/backend/src/api/partners/price-lists/route.ts
+++ b/apps/backend/src/api/partners/price-lists/route.ts
@@ -1,0 +1,75 @@
+import { AuthenticatedMedusaRequest, MedusaResponse } from "@medusajs/framework/http"
+import { ContainerRegistrationKeys, Modules } from "@medusajs/framework/utils"
+import { createPriceListsWorkflow, deletePriceListsWorkflow } from "@medusajs/medusa/core-flows"
+import { getPartnerStore, tryGetPartnerStore } from "../helpers"
+import { validatePriceListRules } from "./helpers"
+
+/**
+ * Price lists are global in core. Everything here reads and writes through the
+ * `store ↔ price_list` link (`src/links/store-price-list.ts`) so a partner only
+ * ever sees their own — the same shape as `../customer-groups/`, but with a
+ * body validator, which that surface lacks.
+ */
+export const GET = async (
+  req: AuthenticatedMedusaRequest,
+  res: MedusaResponse
+) => {
+  const { store } = await tryGetPartnerStore(req.auth_context, req.scope)
+  if (!store) {
+    return res.json({ price_lists: [], count: 0, offset: 0, limit: 20 })
+  }
+
+  const query = req.scope.resolve(ContainerRegistrationKeys.QUERY)
+  const { data } = await query.graph({
+    entity: "stores",
+    fields: ["price_lists.*", "price_lists.prices.*", "price_lists.price_list_rules.*"],
+    filters: { id: store.id },
+  })
+
+  const price_lists = (data?.[0] as any)?.price_lists || []
+
+  res.json({
+    price_lists,
+    count: price_lists.length,
+    offset: 0,
+    limit: 20,
+  })
+}
+
+export const POST = async (
+  req: AuthenticatedMedusaRequest,
+  res: MedusaResponse
+) => {
+  const { store } = await getPartnerStore(req.auth_context, req.scope)
+
+  const body = req.validatedBody as any
+  await validatePriceListRules(req.auth_context, body?.rules, req.scope)
+
+  const { result } = await createPriceListsWorkflow(req.scope).run({
+    input: { price_lists_data: [body] },
+  })
+
+  const price_list = (result as any[])[0]
+
+  // Link the price list to the store — without this the list is invisible to
+  // every guard and every list read, i.e. it exists but belongs to no one.
+  //
+  // ⚠️ An unlinked price list is not merely invisible: `rules_count = 0` makes
+  // core apply it to EVERY customer on the platform, and no partner surface can
+  // then see it to delete it. So the create is rolled back if the link fails —
+  // a half-written tenant boundary is worse than no write at all.
+  const remoteLink = req.scope.resolve(ContainerRegistrationKeys.LINK) as any
+  try {
+    await remoteLink.create({
+      [Modules.STORE]: { store_id: store.id },
+      [Modules.PRICING]: { price_list_id: price_list.id },
+    })
+  } catch (e) {
+    await deletePriceListsWorkflow(req.scope).run({
+      input: { ids: [price_list.id] },
+    })
+    throw e
+  }
+
+  res.status(201).json({ price_list })
+}

--- a/apps/backend/src/api/partners/price-lists/validators.ts
+++ b/apps/backend/src/api/partners/price-lists/validators.ts
@@ -1,0 +1,44 @@
+import { z } from "@medusajs/framework/zod"
+
+/**
+ * A price row inside a price list. `min_quantity`/`max_quantity` are what make
+ * a quote's tier ladder real — core matches a price when
+ * `min_quantity <= qty AND max_quantity >= qty`.
+ */
+const PriceListPrice = z.object({
+  variant_id: z.string().min(1),
+  currency_code: z.string().min(1),
+  amount: z.number(),
+  min_quantity: z.number().int().nonnegative().nullish(),
+  max_quantity: z.number().int().nonnegative().nullish(),
+  rules: z.record(z.string(), z.string()).optional(),
+})
+
+/**
+ * 🔴 `rules` is the field that decides WHO a price list applies to, and a list
+ * created with no rules at all has `rules_count = 0` — which core happily
+ * matches for every customer on the platform. It stays optional because core
+ * allows it, but the route asserts ownership of any `customer_group_id` named
+ * here: owning the list says nothing about owning the group you scope it to.
+ */
+const PriceListRules = z.record(z.string(), z.array(z.string()))
+
+export const PartnerCreatePriceListReq = z.object({
+  title: z.string().min(1),
+  description: z.string().min(1),
+  starts_at: z.string().nullish(),
+  ends_at: z.string().nullish(),
+  status: z.enum(["active", "draft"]).optional(),
+  type: z.enum(["sale", "override"]).optional(),
+  rules: PriceListRules.optional(),
+  prices: z.array(PriceListPrice).optional(),
+})
+
+export const PartnerUpdatePriceListReq = z.object({
+  title: z.string().min(1).optional(),
+  description: z.string().min(1).nullish(),
+  starts_at: z.string().nullish(),
+  ends_at: z.string().nullish(),
+  status: z.enum(["active", "draft"]).optional(),
+  rules: PriceListRules.optional(),
+})

--- a/apps/backend/src/links/store-price-list.ts
+++ b/apps/backend/src/links/store-price-list.ts
@@ -1,0 +1,18 @@
+import { defineLink } from "@medusajs/framework/utils"
+import StoreModule from "@medusajs/medusa/store"
+import PricingModule from "@medusajs/medusa/pricing"
+
+/**
+ * Price lists are GLOBAL in core — nothing about a price list says whose it is.
+ * This link is what makes `validatePartnerEntityOwnership(…, "price_lists", …)`
+ * able to answer that question, exactly as it already does for customer groups,
+ * customers, product categories and collections.
+ *
+ * It is a hard prerequisite for quote-minted pricing (#1389 S3): a quote writes
+ * a price list scoped to a buyer's customer group, and a partner must not be
+ * able to read, edit or delete another partner's negotiated prices.
+ */
+export default defineLink(
+  StoreModule.linkable.store,
+  { linkable: PricingModule.linkable.priceList, isList: true, field: "price_lists" }
+)


### PR DESCRIPTION
The prerequisite for quote-minted pricing (#1389 S3). Price lists are global in core — nothing about one says whose it is — so there was no way to give a partner a price-list surface without handing them the platform's.

## `store ↔ price_list`

`src/links/store-price-list.ts` with `field: "price_lists"` is what makes ownership answerable. The two guards in `api/partners/helpers.ts` already ask the store for `${entityType}.id`; they took a closed literal union, now named `PartnerScopedEntity` so the two copies cannot drift, with `"price_lists"` added.

The union stays closed deliberately: an entity type only belongs in it once a store link exists, because a missing link resolves to an empty list, which reads as "you own nothing" and 404s every legitimate request.

## `/partners/price-lists`

Mirrors `api/partners/customer-groups/` — `tryGetPartnerStore` on list-GET, `getPartnerStore` + link on POST, `validatePartnerEntityOwnership` as the first statement of every `[id]` handler — but **with** `validateAndTransformBody`, which customer-groups lacks. NOT_FOUND rather than NOT_ALLOWED throughout.

Two ordering decisions:

- **Create rolls back if the link fails.** An unlinked price list is not merely invisible — `rules_count = 0` makes core apply it to EVERY customer on the platform, and no partner surface can then see it to delete it.
- **DELETE dismisses the link BEFORE deleting the list**, so the dangling state that took every storefront down is never written.

## Validate both ends

`rules.customer_group_id` decides whose customers get these prices. Owning the list says nothing about owning the group it is scoped to, and an update can re-scope a list onto another partner's group just as easily as a create can — so both call `validatePriceListRules`. Same class as #1404, on the surface that actually prices a cart.

Only `customer_group_id` is checked: it is the one rule key naming a partner-scoped entity. `region_id` and `currency_code` are platform-wide.

5 unit tests. `check:prod-build` green, `tsc` at the 75 baseline.

⚠️ **Deploy tail:** the link table is new, so prod needs the migration run before these routes work.

🤖 Generated with [Claude Code](https://claude.com/claude-code)