### PR TITLE
fix(partner-ui): correct the block editor's relative imports

### DIFF
--- a/apps/partner-ui/src/components/block-editor/block-editor.tsx
+++ b/apps/partner-ui/src/components/block-editor/block-editor.tsx
@@ -1,11 +1,12 @@
 import { useCallback, useState } from "react"
 import { Text, Button, IconButton, Tooltip, Select } from "@medusajs/ui"
 import { Trash, Plus, Images } from "@medusajs/icons"
-import { ContentBlock } from "../../../hooks/api/content"
-import { TipTapEditor } from "../../tiptap-editor/tiptap-editor"
+import { ContentBlock } from "../../hooks/api/content"
+import { TipTapEditor } from "../tiptap-editor/tiptap-editor"
+
 
 type BlockEditorProps = {
-  block: ContentBlock
+  block: ContentBlock 
   onUpdate: (blockId: string, updates: Partial<ContentBlock>) => void
   onDelete: (blockId: string) => void
   saveStatus: "saved" | "saving" | "unsaved"


### PR DESCRIPTION
`block-editor.tsx` sits at `src/components/block-editor/`, so its imports were each one level too high:

| before | resolved to | exists |
|---|---|---|
| `../../../hooks/api/content` | `apps/partner-ui/hooks/api/content` | ❌ |
| `../../tiptap-editor/tiptap-editor` | `apps/partner-ui/src/tiptap-editor/…` | ❌ |

Both are now one `..` shorter and point at the real `src/hooks/api/content.ts` and `src/components/tiptap-editor/tiptap-editor.tsx`, which I verified on disk.

partner-ui `tsc --noEmit` reports nothing in this file. The 4 remaining `TS1005` errors are pre-existing and live in the order claim/exchange forms, untouched here.

🤖 Generated with [Claude Code](https://claude.com/claude-code)