### PR TITLE
fix: partner category tree expansion and product list category filter

### DIFF
--- a/apps/backend/integration-tests/http/partner-catalog-api.spec.ts
+++ b/apps/backend/integration-tests/http/partner-catalog-api.spec.ts
@@ -110,6 +110,54 @@ setupSharedTestSuite(() => {
         expect(Array.isArray(res.data.product_categories)).toBe(true)
       })
 
+      it("GET /partners/product-categories respects parent_category_id=null and include_descendants_tree", async () => {
+        const unique = Date.now()
+
+        // Create a parent category
+        const parentRes = await api.post(
+          "/partners/product-categories",
+          { name: `Parent ${unique}`, handle: `parent-${unique}` },
+          { headers: partner.headers }
+        )
+        const parentId = parentRes.data.product_category.id
+
+        // Create two child categories under the parent
+        for (let i = 0; i < 2; i++) {
+          await api.post(
+            "/partners/product-categories",
+            {
+              name: `Child ${i} ${unique}`,
+              handle: `child-${i}-${unique}`,
+              parent_category_id: parentId,
+              is_internal: true,
+            },
+            { headers: partner.headers }
+          )
+        }
+
+        // Query root categories only, with descendants tree
+        const res = await api.get(
+          "/partners/product-categories?parent_category_id=null&include_descendants_tree=true",
+          { headers: partner.headers }
+        )
+        expect(res.status).toBe(200)
+        expect(Array.isArray(res.data.product_categories)).toBe(true)
+
+        // No child should appear as a top-level row
+        const topLevelIds = res.data.product_categories.map((c: any) => c.id)
+        const childNames = res.data.product_categories.map((c: any) => c.name)
+        expect(childNames).not.toContain(`Child 0 ${unique}`)
+        expect(childNames).not.toContain(`Child 1 ${unique}`)
+
+        // The parent should be present and have category_children populated
+        const parent = res.data.product_categories.find(
+          (c: any) => c.id === parentId
+        )
+        expect(parent).toBeDefined()
+        expect(parent.category_children).toBeDefined()
+        expect(parent.category_children.length).toBe(2)
+      })
+
       it("POST /partners/product-categories creates a category", async () => {
         const unique = Date.now()
         const res = await api.post(

--- a/apps/backend/src/api/partners/product-categories/route.ts
+++ b/apps/backend/src/api/partners/product-categories/route.ts
@@ -16,7 +16,7 @@ export const GET = async (
 
   const query = req.scope.resolve(ContainerRegistrationKeys.QUERY)
 
-  // First get linked category IDs from the store
+  // Get linked category IDs from the store
   const { data: storeData } = await query.graph({
     entity: "stores",
     fields: ["product_categories.id"],
@@ -36,8 +36,34 @@ export const GET = async (
     })
   }
 
-  // Then fetch full category data
-  const { data: categories } = await query.graph({
+  // Parse query params (the partner route has no zod middleware, so read raw)
+  const rawQuery = (req.query || {}) as Record<string, any>
+  const q = rawQuery.q as string | undefined
+  const parentCategoryId = rawQuery.parent_category_id as string | undefined
+  const includeDescendantsTree =
+    rawQuery.include_descendants_tree === true ||
+    rawQuery.include_descendants_tree === "true"
+  const includeAncestorsTree =
+    rawQuery.include_ancestors_tree === true ||
+    rawQuery.include_ancestors_tree === "true"
+  const limit = Math.min(parseInt(rawQuery.limit as string) || 50, 200)
+  const offset = parseInt(rawQuery.offset as string) || 0
+
+  // Build filters combining store scope with query params.
+  // The product module service (ProductCategoryService.list) natively handles
+  // include_descendants_tree and include_ancestors_tree by extracting them
+  // as transformOptions before querying MikroORM — same as the admin route.
+  const filters: any = { id: linkedIds }
+  if (q) filters.q = q
+  if (parentCategoryId === "null") {
+    filters.parent_category_id = null
+  } else if (parentCategoryId && parentCategoryId !== "undefined") {
+    filters.parent_category_id = parentCategoryId
+  }
+  if (includeDescendantsTree) filters.include_descendants_tree = true
+  if (includeAncestorsTree) filters.include_ancestors_tree = true
+
+  const { data: categories, metadata } = await query.graph({
     entity: "product_category",
     fields: [
       "id",
@@ -50,19 +76,21 @@ export const GET = async (
       "metadata",
       "created_at",
       "updated_at",
-      "parent_category.id",
-      "parent_category.name",
-      "category_children.id",
-      "category_children.name",
+      "parent_category.*",
+      "category_children.*",
     ],
-    filters: { id: linkedIds },
+    filters,
+    pagination: {
+      skip: offset,
+      take: limit,
+    },
   })
 
   res.json({
     product_categories: categories || [],
-    count: categories?.length || 0,
-    offset: 0,
-    limit: 20,
+    count: metadata?.count ?? categories?.length ?? 0,
+    offset: metadata?.skip ?? offset,
+    limit: metadata?.take ?? limit,
   })
 }
 

--- a/apps/partner-ui/src/routes/products/product-list/components/product-list-table/use-product-table-filters.tsx
+++ b/apps/partner-ui/src/routes/products/product-list/components/product-list-table/use-product-table-filters.tsx
@@ -3,6 +3,7 @@ import { useTranslation } from "react-i18next"
 import { createDataTableFilterHelper } from "@medusajs/ui"
 import { HttpTypes } from "@medusajs/types"
 import { useDataTableDateFilters } from "../../../../../components/data-table/helpers/general/use-data-table-date-filters"
+import { useProductCategories } from "../../../../../hooks/api/categories"
 import { useProductTypes } from "../../../../../hooks/api/product-types"
 import { useProductTags } from "../../../../../hooks/api"
 import { useSalesChannels } from "../../../../../hooks/api/sales-channels"
@@ -25,6 +26,15 @@ export const useProductTableFilters = () => {
     limit: 1000,
     offset: 0,
   })
+
+  const { product_categories } = useProductCategories(
+    {
+      parent_category_id: "null",
+      include_descendants_tree: true,
+      limit: 100,
+    },
+    { enabled: true }
+  )
 
   const { sales_channels } = useSalesChannels({
     limit: 1000,
@@ -55,6 +65,19 @@ export const useProductTableFilters = () => {
           options: product_tags.map((t) => ({
             label: t.value,
             value: t.id,
+          })),
+        })
+      )
+    }
+
+    if (product_categories?.length) {
+      filters.push(
+        filterHelper.accessor("category_id", {
+          label: t("fields.categories"),
+          type: "multiselect",
+          options: product_categories.map((c) => ({
+            label: c.name,
+            value: c.id,
           })),
         })
       )


### PR DESCRIPTION
## Problem
The partner category GET endpoint (`GET /partners/product-categories`) returned ALL linked categories as flat rows, ignoring `parent_category_id`, `include_descendants_tree`, `q`, and pagination params. Sub-categories appeared as separate top-level rows in the partner UI instead of being nested under their parents.

## Root Cause
The backend handler hardcoded its response — it never read query params. It fetched all store-linked categories and returned them flat, including children.

## Fix
- **Backend** (`apps/backend/src/api/partners/product-categories/route.ts`): Rewrite GET handler to parse `parent_category_id`, `include_descendants_tree`, `include_ancestors_tree`, `q`, `limit`, `offset` from the raw query and pass them as filters to `query.graph()`. The product module service (`ProductCategoryService.list()`) natively handles `include_descendants_tree` (extracts it as `transformOptions` for MikroORM tree expansion) and `parent_category_id: null` (WHERE IS NULL) — same mechanism the admin route uses.
- **Field expansion**: Use `category_children.*` and `parent_category.*` format (not `*category_children`) since the partner route has no zod middleware to transform the `*` prefix.
- **Frontend** (`use-product-table-filters.tsx`): Add a category filter to the product list table for admin parity.
- **Test**: Added integration test verifying parent/child tree behavior — creates a parent + 2 children, asserts only the parent appears as a top-level row with `category_children` populated.

## Test Results
```
✓ GET /partners/product-categories lists categories
✓ GET /partners/product-categories respects parent_category_id=null and include_descendants_tree
✓ POST /partners/product-categories creates a category
✓ links a product to a category
```