### PR TITLE
feat(quote): mint a quote that actually prices the buyer's cart (#1389 S3)

### DIFF
--- a/apps/backend/src/api/middlewares.ts
+++ b/apps/backend/src/api/middlewares.ts
@@ -305,6 +305,7 @@ import { BulkImportSchema } from "./admin/inventory-items/bulk-import/validators
 import { PartnerCreateStoreReq } from "./partners/stores/validators";
 import { PartnerCreateProductReq, PartnerArtisanProductDetailReq, PartnerProductSpecReq, PartnerStoreCreateProductReq, PartnerQuickCreateProductReq } from "./partners/products/validators";
 import { PartnerCreatePriceListReq, PartnerUpdatePriceListReq } from "./partners/price-lists/validators";
+import { PartnerMintQuoteReq } from "./partners/quotes/validators";
 import { BATCH_VARIANT_FIELDS } from "../workflows/partner/batch-partner-variants";
 import { StoreMadeToSpecReq } from "./store/carts/[id]/made-to-spec/validators";
 import {
@@ -5576,6 +5577,26 @@ export default defineMiddlewares({
       matcher: "/partners/customer-groups/:id/customers",
       method: "POST",
       middlewares: [authenticate("partner", ["session", "bearer"])],
+    },
+    // Partner B2B quotes (#1389 S3). The buyer half lives at
+    // /store/b2b/quotes/:token and is deliberately unauthenticated — the token
+    // IS the credential.
+    {
+      matcher: "/partners/quotes",
+      method: "GET",
+      middlewares: [
+        createCorsPartnerMiddleware(),
+        authenticate("partner", ["session", "bearer"]),
+      ],
+    },
+    {
+      matcher: "/partners/quotes",
+      method: "POST",
+      middlewares: [
+        createCorsPartnerMiddleware(),
+        authenticate("partner", ["session", "bearer"]),
+        validateAndTransformBody(wrapSchema(PartnerMintQuoteReq)),
+      ],
     },
     // Partner price list endpoints (#1405). Unlike customer-groups above,
     // every write body is validated — a price list carries money and the rule

--- a/apps/backend/src/api/partners/quotes/route.ts
+++ b/apps/backend/src/api/partners/quotes/route.ts
@@ -1,0 +1,68 @@
+import { AuthenticatedMedusaRequest, MedusaResponse } from "@medusajs/framework/http"
+import { ContainerRegistrationKeys } from "@medusajs/framework/utils"
+
+import { PARTNER_QUOTE_MODULE } from "../../../modules/partner-quote"
+import { mintQuoteWorkflow } from "../../../workflows/partner-quote/mint-quote"
+import { getPartnerStore, tryGetPartnerStore } from "../helpers"
+
+/** The partner's own quotes. Scoped by `partner_id`, never listed globally. */
+export const GET = async (
+  req: AuthenticatedMedusaRequest,
+  res: MedusaResponse
+) => {
+  const { partner, store } = await tryGetPartnerStore(req.auth_context, req.scope)
+  if (!store) {
+    return res.json({ quotes: [], count: 0 })
+  }
+
+  const service: any = req.scope.resolve(PARTNER_QUOTE_MODULE)
+  const quotes = await service.listPartnerQuotes({ partner_id: partner.id })
+
+  res.json({ quotes, count: quotes.length })
+}
+
+/**
+ * Mint a quote (#1389 S3).
+ *
+ * 🔑 The raw token is returned HERE and nowhere else — only its sha256 is
+ * persisted, so a database read cannot reconstruct a working link. If the
+ * caller loses this response, the quote must be re-minted.
+ */
+export const POST = async (
+  req: AuthenticatedMedusaRequest,
+  res: MedusaResponse
+) => {
+  const { partner, store } = await getPartnerStore(req.auth_context, req.scope)
+  const body = req.validatedBody as any
+
+  const { result } = await mintQuoteWorkflow(req.scope).run({
+    input: {
+      partner_id: partner.id,
+      store: { id: store.id, default_location_id: store.default_location_id },
+      buyer_email: body.buyer_email,
+      recipient_name: body.recipient_name ?? null,
+      recipient_company: body.recipient_company ?? null,
+      partner_note: body.partner_note ?? null,
+      lines: body.lines,
+      destination_country_code: body.destination_country_code,
+      destination_postal_code: body.destination_postal_code ?? null,
+      destination_city: body.destination_city ?? null,
+      currency_code: body.currency_code,
+      region_id: body.region_id ?? null,
+      carrier: body.carrier,
+      ttl_days: body.ttl_days,
+      created_by: req.auth_context?.actor_id ?? null,
+    },
+  })
+
+  const logger: any = req.scope.resolve(ContainerRegistrationKeys.LOGGER)
+  logger.info(
+    `[quote] partner=${partner.id} minted quote=${(result as any)?.quote?.id} lines=${body.lines.length}`
+  )
+
+  res.status(201).json({
+    quote: (result as any)?.quote,
+    /** Once. Never retrievable again. */
+    token: (result as any)?.token,
+  })
+}

--- a/apps/backend/src/api/partners/quotes/validators.ts
+++ b/apps/backend/src/api/partners/quotes/validators.ts
@@ -1,0 +1,29 @@
+import { z } from "@medusajs/framework/zod"
+
+const QuoteLine = z.object({
+  variant_id: z.string().min(1),
+  quantity: z.number().int().positive(),
+  position: z.number().int().nonnegative().optional(),
+  note: z.string().nullish(),
+})
+
+export const PartnerMintQuoteReq = z.object({
+  buyer_email: z.string().email(),
+  recipient_name: z.string().nullish(),
+  recipient_company: z.string().nullish(),
+  partner_note: z.string().nullish(),
+
+  /** A quote is a basket. A single-product quote is a one-line quote. */
+  lines: z.array(QuoteLine).min(1),
+
+  destination_country_code: z.string().min(2),
+  destination_postal_code: z.string().nullish(),
+  destination_city: z.string().nullish(),
+
+  currency_code: z.string().min(3),
+  region_id: z.string().nullish(),
+  carrier: z.string().optional(),
+
+  /** Drives `price_list.ends_at`, so expiry is native rather than swept. */
+  ttl_days: z.number().int().positive().max(365).optional(),
+})

--- a/apps/backend/src/api/store/b2b/quotes/[token]/route.ts
+++ b/apps/backend/src/api/store/b2b/quotes/[token]/route.ts
@@ -1,0 +1,73 @@
+import { MedusaRequest, MedusaResponse } from "@medusajs/framework/http"
+import { MedusaError } from "@medusajs/framework/utils"
+
+import { PARTNER_QUOTE_MODULE } from "../../../../../modules/partner-quote"
+import { buildQuoteView } from "../../../../../modules/partner-quote/lib/build-quote-view"
+import { hashQuoteToken } from "../../../../../modules/partner-quote/lib/token"
+
+/**
+ * The buyer's quote page (#1389 S3).
+ *
+ * The token in the URL is the only credential — there is no login, because
+ * asking a procurement contact to create an account before they can see a
+ * price is the wall this whole feature exists to remove. The link is
+ * deliberately MULTI-VIEW: forwarding it to procurement is the use case, not
+ * an abuse of it.
+ *
+ * 🔑 An unknown token and a revoked one must be indistinguishable to a prober,
+ * so both are 404. The row is looked up by sha256 — the raw token is never
+ * stored, so a database read cannot reconstruct a working link.
+ */
+export const GET = async (req: MedusaRequest, res: MedusaResponse) => {
+  const service: any = req.scope.resolve(PARTNER_QUOTE_MODULE)
+
+  const quote = await service.findByTokenHash(hashQuoteToken(req.params.token))
+  if (!quote) {
+    throw new MedusaError(MedusaError.Types.NOT_FOUND, "Quote not found")
+  }
+
+  const lines = await service.listPartnerQuoteLines({ quote_id: quote.id })
+
+  // The buyer may move their quantities; absent that, the quoted basket stands.
+  const requested = (req.query.lines as string | undefined) ?? null
+  let effectiveLines = (lines ?? []).map((l: any) => ({
+    variant_id: l.variant_id,
+    quantity: l.quantity,
+    position: l.position,
+    note: l.note,
+  }))
+
+  if (requested) {
+    try {
+      const dialled = JSON.parse(requested) as Array<{
+        variant_id: string
+        quantity: number
+      }>
+      const byVariant = new Map(dialled.map((d) => [d.variant_id, d.quantity]))
+      effectiveLines = effectiveLines.map((l: any) => ({
+        ...l,
+        quantity: Number(byVariant.get(l.variant_id) ?? l.quantity),
+      }))
+    } catch {
+      // A malformed dial is not worth a 400 — show the quoted basket instead of
+      // failing a buyer's page over a query string.
+    }
+  }
+
+  const view = await buildQuoteView(req.scope, {
+    quote: { ...quote, lines },
+    lines: effectiveLines,
+    destination_country_code: quote.destination_country_code,
+    destination_postal_code: quote.destination_postal_code,
+    currency_code: quote.currency_code,
+    region_id: quote.region_id,
+    store: { id: quote.store_id ?? undefined },
+    now: new Date(),
+  })
+
+  // Fire-and-forget by contract: view tracking has no business turning a
+  // buyer's quote page into a 500.
+  service.recordView(quote.id, new Date()).catch(() => {})
+
+  res.json({ quote: view })
+}

--- a/apps/backend/src/modules/partner-quote/lib/build-quote-view.ts
+++ b/apps/backend/src/modules/partner-quote/lib/build-quote-view.ts
@@ -17,8 +17,8 @@ import { daysUntilExpiry, quoteUnusableReason } from "./token"
  *
  * ## Three callers, one implementation
  *
- * 1. the public `/web/quotes/:token` route — what the buyer sees, recomputed
- *    live as they move the quantity dial;
+ * 1. the public `/store/b2b/quotes/:token` route — what the buyer sees,
+ *    recomputed live as they move the quantity dial;
  * 2. the email retrieval step — what the buyer receives;
  * 3. **mint**, where this same output is frozen into the row's `quoted_*`
  *    columns.

--- a/apps/backend/src/workflows/partner-quote/__tests__/plan-quote-prices.unit.spec.ts
+++ b/apps/backend/src/workflows/partner-quote/__tests__/plan-quote-prices.unit.spec.ts
@@ -1,0 +1,135 @@
+import {
+  planQuotePrices,
+  priceListScopedToGroup,
+} from "../lib/plan-quote-prices"
+
+/**
+ * The money half of quote minting (#1389 S3). Both functions here exist to make
+ * a dangerous default impossible, so those are the cases that matter.
+ */
+
+describe("planQuotePrices", () => {
+  it("turns each quoted line into one price row at its quantity", () => {
+    const rows = planQuotePrices(
+      [
+        { variant_id: "var_a", quantity: 500, quoted_unit_amount: 12.5 },
+        { variant_id: "var_b", quantity: 200, quoted_unit_amount: 30 },
+      ],
+      "inr"
+    )
+
+    expect(rows).toEqual([
+      { variant_id: "var_a", currency_code: "inr", amount: 12.5, min_quantity: 500, max_quantity: null },
+      { variant_id: "var_b", currency_code: "inr", amount: 30, min_quantity: 200, max_quantity: null },
+    ])
+  })
+
+  it("🔴 DROPS a line with no quoted amount — never writes it as zero", () => {
+    // A zero here would not fail loudly. It would become an ACTIVE price of
+    // zero that the cart charges, which is the worst failure this file has.
+    const rows = planQuotePrices(
+      [
+        { variant_id: "var_a", quantity: 500, quoted_unit_amount: null },
+        { variant_id: "var_b", quantity: 500 },
+        { variant_id: "var_c", quantity: 500, quoted_unit_amount: 10 },
+      ],
+      "inr"
+    )
+
+    expect(rows).toHaveLength(1)
+    expect(rows[0].variant_id).toBe("var_c")
+  })
+
+  it("leaves the ceiling open — 600 ordered still earns the 500 tier", () => {
+    const [row] = planQuotePrices(
+      [{ variant_id: "var_a", quantity: 500, quoted_unit_amount: 12 }],
+      "inr"
+    )
+    expect(row.min_quantity).toBe(500)
+    expect(row.max_quantity).toBeNull()
+  })
+
+  it("collapses a duplicated variant+quantity to the cheapest, as core would", () => {
+    const rows = planQuotePrices(
+      [
+        { variant_id: "var_a", quantity: 500, quoted_unit_amount: 14 },
+        { variant_id: "var_a", quantity: 500, quoted_unit_amount: 11 },
+      ],
+      "inr"
+    )
+    expect(rows).toHaveLength(1)
+    expect(rows[0].amount).toBe(11)
+  })
+
+  it("keeps two rows for the same variant at DIFFERENT quantities — that is a ladder", () => {
+    const rows = planQuotePrices(
+      [
+        { variant_id: "var_a", quantity: 100, quoted_unit_amount: 14 },
+        { variant_id: "var_a", quantity: 500, quoted_unit_amount: 11 },
+      ],
+      "inr"
+    )
+    expect(rows).toHaveLength(2)
+  })
+
+  it("skips junk quantities and missing variant ids rather than guessing", () => {
+    const rows = planQuotePrices(
+      [
+        { variant_id: "var_a", quantity: 0, quoted_unit_amount: 10 },
+        { variant_id: "var_a", quantity: -5, quoted_unit_amount: 10 },
+        { variant_id: "", quantity: 500, quoted_unit_amount: 10 },
+        { variant_id: "var_b", quantity: Number.NaN, quoted_unit_amount: 10 },
+      ],
+      "inr"
+    )
+    expect(rows).toEqual([])
+  })
+
+  it("returns nothing for an empty basket instead of throwing", () => {
+    expect(planQuotePrices([], "inr")).toEqual([])
+  })
+})
+
+describe("priceListScopedToGroup", () => {
+  it("🔴 treats rules_count = 0 as UNSCOPED — that list prices for everyone", () => {
+    expect(priceListScopedToGroup({ rules_count: 0 }, "cg_1")).toBe(false)
+  })
+
+  it("treats a missing list as unscoped — the dangerous default must be false", () => {
+    expect(priceListScopedToGroup(null, "cg_1")).toBe(false)
+  })
+
+  it("accepts a list ruled to the buyer's group", () => {
+    expect(
+      priceListScopedToGroup(
+        {
+          rules_count: 1,
+          price_list_rules: [
+            { attribute: "customer_group_id", value: [{ value: "cg_1" }] },
+          ],
+        },
+        "cg_1"
+      )
+    ).toBe(true)
+  })
+
+  it("rejects a list ruled to somebody ELSE's group", () => {
+    expect(
+      priceListScopedToGroup(
+        {
+          rules_count: 1,
+          price_list_rules: [
+            { attribute: "customer_group_id", value: [{ value: "cg_other" }] },
+          ],
+        },
+        "cg_1"
+      )
+    ).toBe(false)
+  })
+
+  it("trusts a positive rules_count when the rules were not expanded", () => {
+    // The count is the weaker signal, but it is the one that decides "applies
+    // to all", so a positive count without the expansion is not a failure.
+    expect(priceListScopedToGroup({ rules_count: 1 }, "cg_1")).toBe(true)
+  })
+})

--- a/apps/backend/src/workflows/partner-quote/lib/plan-quote-prices.ts
+++ b/apps/backend/src/workflows/partner-quote/lib/plan-quote-prices.ts
@@ -1,0 +1,120 @@
+/**
+ * PURE: turn a frozen quote basket into the rows of a price list (#1389 S3).
+ *
+ * ## Why a price list at all
+ *
+ * Core resolves a price by `price_list_id IS NOT NULL DESC`, then rules
+ * matched, then `amount ASC`, and only for an ACTIVE list inside its
+ * `starts_at`/`ends_at`. So a price list scoped to the buyer's customer group
+ * makes the quoted number the number the cart charges — and gets expiry and
+ * revoke natively, with no cron and no sweeper.
+ *
+ * ⚠️ This REVERSES S1's rule that "nothing frozen ever prices a cart". That
+ * rule existed because there was no way to make a buyer-specific price real.
+ * There is; the model docblocks are updated alongside this.
+ *
+ * ## The tier
+ *
+ * A quoted line says "500 units at this unit price". That is a floor, not an
+ * exact match: a buyer who orders 600 has earned the 500 tier. So each line
+ * becomes ONE price row with `min_quantity = quoted quantity` and no ceiling.
+ *
+ * Ordering FEWER than quoted falls through to the base price, which is correct
+ * — the discount was for the volume, and core simply finds no matching
+ * price-list row at quantity 100.
+ */
+
+export type QuotePriceLine = {
+  variant_id: string
+  quantity: number
+  /** The frozen unit amount. Same units the builder produced. */
+  quoted_unit_amount?: number | null
+}
+
+export type PlannedQuotePrice = {
+  variant_id: string
+  currency_code: string
+  amount: number
+  min_quantity: number
+  max_quantity: number | null
+}
+
+/**
+ * One price row per quoted line, skipping any line the builder could not
+ * price.
+ *
+ * 🔴 A line with no `quoted_unit_amount` is DROPPED, never defaulted to 0. A
+ * zero here would not fail loudly — it would become an ACTIVE price of zero
+ * that the cart happily charges, which is the worst possible failure mode for
+ * this file.
+ *
+ * Duplicate variants collapse to the CHEAPEST row at a given quantity, because
+ * that is what core would pick anyway (`amount ASC` breaks the tie) — better to
+ * write the row we know wins than to leave two and hope.
+ */
+export function planQuotePrices(
+  lines: QuotePriceLine[],
+  currencyCode: string
+): PlannedQuotePrice[] {
+  const byKey = new Map<string, PlannedQuotePrice>()
+
+  for (const line of lines || []) {
+    const qty = Number(line?.quantity)
+    const amount = line?.quoted_unit_amount
+
+    if (!line?.variant_id) continue
+    if (!Number.isFinite(qty) || qty <= 0) continue
+    if (amount === null || amount === undefined) continue
+    if (!Number.isFinite(Number(amount))) continue
+
+    const key = `${line.variant_id}:${qty}`
+    const row: PlannedQuotePrice = {
+      variant_id: line.variant_id,
+      currency_code: currencyCode,
+      amount: Number(amount),
+      min_quantity: qty,
+      max_quantity: null,
+    }
+
+    const existing = byKey.get(key)
+    if (!existing || row.amount < existing.amount) {
+      byKey.set(key, row)
+    }
+  }
+
+  return [...byKey.values()]
+}
+
+/**
+ * PURE: has this price list actually been scoped to the buyer?
+ *
+ * 🔴 `rules_count = 0` applies a price list to EVERYONE. Core does not treat an
+ * unruled list as an error — it treats it as universal — so a rule that
+ * silently failed to attach turns one buyer's negotiated discount into a
+ * platform-wide price cut. The rule is therefore asserted AFTER creation, from
+ * a re-read, not assumed from the payload we sent.
+ */
+export function priceListScopedToGroup(
+  priceList: { rules_count?: number | null; price_list_rules?: any[] } | null,
+  groupId: string
+): boolean {
+  if (!priceList) return false
+  if (!Number(priceList.rules_count ?? 0)) return false
+
+  const rules = priceList.price_list_rules ?? []
+  if (!rules.length) {
+    // rules_count is positive but the expansion was not requested; the count is
+    // the weaker signal, and it is the one that matters for "applies to all".
+    return true
+  }
+
+  return rules.some((r: any) => {
+    const attr = r?.attribute ?? r?.rule_attribute
+    if (attr && attr !== "customer_group_id") return false
+    const values = r?.value ?? r?.values
+    if (Array.isArray(values)) {
+      return values.some((v: any) => (v?.value ?? v) === groupId)
+    }
+    return values === groupId
+  })
+}

--- a/apps/backend/src/workflows/partner-quote/mint-quote.ts
+++ b/apps/backend/src/workflows/partner-quote/mint-quote.ts
@@ -1,0 +1,406 @@
+import {
+  createWorkflow,
+  createStep,
+  StepResponse,
+  WorkflowResponse,
+} from "@medusajs/framework/workflows-sdk"
+import {
+  ContainerRegistrationKeys,
+  MedusaError,
+  Modules,
+} from "@medusajs/framework/utils"
+import {
+  createPriceListsWorkflow,
+  deletePriceListsWorkflow,
+} from "@medusajs/medusa/core-flows"
+
+import { PARTNER_QUOTE_MODULE } from "../../modules/partner-quote"
+import { buildQuoteView } from "../../modules/partner-quote/lib/build-quote-view"
+import {
+  generateQuoteToken,
+  quoteExpiryFrom,
+  DEFAULT_QUOTE_TTL_DAYS,
+} from "../../modules/partner-quote/lib/token"
+import {
+  planQuotePrices,
+  priceListScopedToGroup,
+} from "./lib/plan-quote-prices"
+
+export type MintQuoteInput = {
+  partner_id: string
+  store: { id: string; default_location_id?: string | null }
+  buyer_email: string
+  recipient_name?: string | null
+  recipient_company?: string | null
+  partner_note?: string | null
+  lines: Array<{
+    variant_id: string
+    quantity: number
+    position?: number
+    note?: string | null
+  }>
+  destination_country_code: string
+  destination_postal_code?: string | null
+  destination_city?: string | null
+  currency_code: string
+  region_id?: string | null
+  carrier?: string
+  ttl_days?: number
+  created_by?: string | null
+  /** Injected so the whole mint is deterministic under test. */
+  now?: Date
+}
+
+/**
+ * Resolve mint time and expiry INSIDE a step.
+ *
+ * ⚠️ Not in the workflow body: `createWorkflow`'s function runs once to build
+ * the graph, and `input` there is a proxy — `input.ttl_days ?? DEFAULT` would
+ * be evaluated against the proxy at definition time, not against the caller's
+ * value at run time. `new Date()` in the body has the same problem, and would
+ * additionally freeze one timestamp across every future run.
+ */
+const prepareTimingStep = createStep(
+  "prepare-quote-timing-step",
+  async (input: { ttl_days?: number; now?: Date }) => {
+    const now = input?.now ? new Date(input.now) : new Date()
+    return new StepResponse({
+      now,
+      expires_at: quoteExpiryFrom(now, input?.ttl_days ?? DEFAULT_QUOTE_TTL_DAYS),
+    })
+  }
+)
+
+/**
+ * Find-or-create the buyer as a customer AND their own customer group, both
+ * linked to the partner's store.
+ *
+ * One group PER BUYER, not per quote: a repeat buyer keeps one identity, so
+ * their second quote replaces their prices rather than stacking a second list
+ * that core would tie-break against the first on `amount ASC`.
+ *
+ * Compensation deletes only what THIS run created — never the customer, who
+ * may have orders, and never a group that already existed.
+ */
+const resolveQuoteBuyerStep = createStep(
+  "resolve-quote-buyer-step",
+  async (input: MintQuoteInput, { container }) => {
+    const query: any = container.resolve(ContainerRegistrationKeys.QUERY)
+    const customerService: any = container.resolve(Modules.CUSTOMER)
+    const link: any = container.resolve(ContainerRegistrationKeys.LINK)
+
+    const email = input.buyer_email.trim().toLowerCase()
+
+    // Scoped to the store: another partner's customer with the same email is
+    // not this partner's buyer, and reusing them would leak a customer across
+    // tenants and hand them someone else's price list.
+    const { data: storeRows } = await query.graph({
+      entity: "stores",
+      fields: ["customers.id", "customers.email", "customer_groups.id", "customer_groups.name"],
+      filters: { id: input.store.id },
+    })
+    const storeRow = (storeRows ?? [])[0] as any
+
+    let customer = ((storeRow?.customers ?? []) as any[]).find(
+      (c) => String(c?.email ?? "").toLowerCase() === email
+    )
+    let createdCustomerId: string | null = null
+    if (!customer) {
+      customer = await customerService.createCustomers({
+        email,
+        company_name: input.recipient_company ?? undefined,
+      })
+      createdCustomerId = customer.id
+      await link.create({
+        [Modules.STORE]: { store_id: input.store.id },
+        [Modules.CUSTOMER]: { customer_id: customer.id },
+      })
+    }
+
+    const groupName = `Quote buyer — ${email}`
+    let group = ((storeRow?.customer_groups ?? []) as any[]).find(
+      (g) => g?.name === groupName
+    )
+    let createdGroupId: string | null = null
+    if (!group) {
+      group = await customerService.createCustomerGroups({ name: groupName })
+      createdGroupId = group.id
+      await link.create({
+        [Modules.STORE]: { store_id: input.store.id },
+        [Modules.CUSTOMER]: { customer_group_id: group.id },
+      })
+    }
+
+    // Idempotent by construction: adding a customer already in the group is a
+    // no-op, and a repeat quote for the same buyer takes this path every time.
+    await customerService.addCustomerToGroup({
+      customer_id: customer.id,
+      customer_group_id: group.id,
+    })
+
+    return new StepResponse(
+      { customer_id: customer.id, customer_group_id: group.id },
+      { createdCustomerId, createdGroupId, storeId: input.store.id }
+    )
+  },
+  async (undo, { container }) => {
+    if (!undo) return
+    const customerService: any = container.resolve(Modules.CUSTOMER)
+    const link: any = container.resolve(ContainerRegistrationKeys.LINK)
+
+    if (undo.createdGroupId) {
+      await link
+        .dismiss({
+          [Modules.STORE]: { store_id: undo.storeId },
+          [Modules.CUSTOMER]: { customer_group_id: undo.createdGroupId },
+        })
+        .catch(() => {})
+      await customerService
+        .deleteCustomerGroups([undo.createdGroupId])
+        .catch(() => {})
+    }
+    if (undo.createdCustomerId) {
+      await link
+        .dismiss({
+          [Modules.STORE]: { store_id: undo.storeId },
+          [Modules.CUSTOMER]: { customer_id: undo.createdCustomerId },
+        })
+        .catch(() => {})
+      await customerService
+        .deleteCustomers([undo.createdCustomerId])
+        .catch(() => {})
+    }
+  }
+)
+
+/**
+ * Build the view ONCE and freeze it. Everything downstream — the price list,
+ * the row, the email — is written from this single output, which is what stops
+ * a second pricing path from existing.
+ */
+const buildAndFreezeStep = createStep(
+  "build-and-freeze-quote-step",
+  async (
+    payload: { mint: MintQuoteInput; now: Date },
+    { container }
+  ) => {
+    const input = payload.mint
+    const view = await buildQuoteView(container, {
+      quote: null,
+      lines: input.lines,
+      destination_country_code: input.destination_country_code,
+      destination_postal_code: input.destination_postal_code ?? null,
+      currency_code: input.currency_code,
+      region_id: input.region_id ?? null,
+      store: input.store,
+      carrier: input.carrier,
+      now: payload.now,
+    })
+
+    if (!view.live) {
+      throw new MedusaError(
+        MedusaError.Types.INVALID_DATA,
+        `The quote could not be priced${
+          view.live_error ? `: ${view.live_error}` : ""
+        }. Nothing was written — a quote whose numbers we cannot stand behind must not be sent.`
+      )
+    }
+
+    return new StepResponse(view)
+  }
+)
+
+/**
+ * Write the buyer's prices for real, scoped to their group and dated to the
+ * quote — so `ends_at` IS the expiry and `status: draft` IS the revoke.
+ */
+const mintPriceListStep = createStep(
+  "mint-quote-price-list-step",
+  async (
+    input: {
+      partner_id: string
+      customer_group_id: string
+      currency_code: string
+      expires_at: Date
+      now: Date
+      lines: Array<{ variant_id: string; quantity: number; quoted_unit_amount: number | null }>
+    },
+    { container }
+  ) => {
+    const prices = planQuotePrices(input.lines, input.currency_code)
+    if (!prices.length) {
+      throw new MedusaError(
+        MedusaError.Types.INVALID_DATA,
+        "No quoted line carried a price, so there is nothing to mint."
+      )
+    }
+
+    const { result } = await createPriceListsWorkflow(container).run({
+      input: {
+        price_lists_data: [
+          {
+            title: `Quote — ${input.customer_group_id}`,
+            description: `Quoted prices for customer group ${input.customer_group_id}, minted ${input.now.toISOString()}.`,
+            status: "active",
+            type: "override",
+            starts_at: input.now.toISOString(),
+            ends_at: input.expires_at.toISOString(),
+            rules: { customer_group_id: [input.customer_group_id] },
+            prices,
+          } as any,
+        ],
+      },
+    })
+
+    const priceList = (result as any[])?.[0]
+    if (!priceList?.id) {
+      throw new MedusaError(
+        MedusaError.Types.UNEXPECTED_STATE,
+        "The price list was not created."
+      )
+    }
+
+    // 🔴 Assert the rule from a RE-READ, never from the payload we sent. A list
+    // with rules_count = 0 applies to EVERY customer on the platform, and core
+    // treats that as universal rather than as an error — so an unruled list is
+    // a silent platform-wide price cut. If the scope did not attach, delete it
+    // and fail loudly.
+    const query: any = container.resolve(ContainerRegistrationKeys.QUERY)
+    const { data: verify } = await query.graph({
+      entity: "price_list",
+      fields: ["id", "rules_count", "price_list_rules.*"],
+      filters: { id: priceList.id },
+    })
+
+    if (!priceListScopedToGroup((verify ?? [])[0], input.customer_group_id)) {
+      await deletePriceListsWorkflow(container)
+        .run({ input: { ids: [priceList.id] } })
+        .catch(() => {})
+      throw new MedusaError(
+        MedusaError.Types.UNEXPECTED_STATE,
+        `Price list ${priceList.id} was created without its customer-group rule, so it would have priced for everyone. It has been deleted.`
+      )
+    }
+
+    return new StepResponse(
+      { price_list_id: priceList.id, price_count: prices.length },
+      priceList.id
+    )
+  },
+  async (priceListId, { container }) => {
+    if (!priceListId) return
+    await deletePriceListsWorkflow(container)
+      .run({ input: { ids: [priceListId] } })
+      .catch(() => {})
+  }
+)
+
+/** Persist the quote and its lines, and mint the token. */
+const persistQuoteStep = createStep(
+  "persist-quote-step",
+  async (
+    input: {
+      mint: MintQuoteInput
+      view: any
+      buyer: { customer_id: string; customer_group_id: string }
+      price_list_id: string
+      expires_at: Date
+      now: Date
+    },
+    { container }
+  ) => {
+    const service: any = container.resolve(PARTNER_QUOTE_MODULE)
+    const { raw, hash } = generateQuoteToken()
+
+    const quote = await service.createPartnerQuotes({
+      partner_id: input.mint.partner_id,
+      store_id: input.mint.store.id,
+      destination_country_code: input.mint.destination_country_code,
+      destination_postal_code: input.mint.destination_postal_code ?? null,
+      destination_city: input.mint.destination_city ?? null,
+      currency_code: input.mint.currency_code,
+      region_id: input.mint.region_id ?? null,
+      recipient_name: input.mint.recipient_name ?? null,
+      recipient_company: input.mint.recipient_company ?? null,
+      email_sent_to: input.mint.buyer_email,
+      partner_note: input.mint.partner_note ?? null,
+      quoted_subtotal: input.view.live?.subtotal ?? null,
+      quoted_freight: input.view.live?.freight ?? null,
+      quoted_landed_total: input.view.live?.landed_total ?? null,
+      quoted_weight_grams: input.view.total_weight_grams ?? null,
+      quoted_at: input.now,
+      token_hash: hash,
+      status: "active",
+      expires_at: input.expires_at,
+      created_by: input.mint.created_by ?? null,
+      metadata: {
+        customer_id: input.buyer.customer_id,
+        customer_group_id: input.buyer.customer_group_id,
+        price_list_id: input.price_list_id,
+      },
+    })
+
+    await service.createPartnerQuoteLines(
+      (input.view.lines ?? []).map((l: any, i: number) => ({
+        quote_id: quote.id,
+        variant_id: l.variant_id,
+        product_id: l.product_id ?? null,
+        quantity: l.quantity,
+        position: l.position ?? i,
+        quoted_unit_amount: l.live_unit_amount ?? null,
+        quoted_subtotal: l.live_subtotal ?? null,
+        quoted_unit_weight_grams: l.unit_weight_grams ?? null,
+        quoted_weight_source: l.weight_source ?? null,
+        note: l.note ?? null,
+      }))
+    )
+
+    // The raw token leaves here exactly once. It is never persisted, so a DB
+    // read cannot reconstruct a working link.
+    return new StepResponse({ quote, token: raw }, quote.id)
+  },
+  async (quoteId, { container }) => {
+    if (!quoteId) return
+    const service: any = container.resolve(PARTNER_QUOTE_MODULE)
+    await service.deletePartnerQuotes([quoteId]).catch(() => {})
+  }
+)
+
+/**
+ * Mint a B2B quote (#1389 S3).
+ *
+ * Order matters and every step reverses. The email is deliberately NOT sent
+ * here: freeze before send, so a mail can never disagree with the row it
+ * describes.
+ */
+export const mintQuoteWorkflow = createWorkflow(
+  "mint-partner-quote",
+  (input: MintQuoteInput) => {
+    const timing = prepareTimingStep(input)
+
+    const buyer = resolveQuoteBuyerStep(input)
+    const view = buildAndFreezeStep({ mint: input, now: timing.now } as any)
+
+    const priceList = mintPriceListStep({
+      partner_id: input.partner_id,
+      customer_group_id: buyer.customer_group_id,
+      currency_code: input.currency_code,
+      expires_at: timing.expires_at,
+      now: timing.now,
+      lines: view.lines,
+    } as any)
+
+    const persisted = persistQuoteStep({
+      mint: input,
+      view,
+      buyer,
+      price_list_id: priceList.price_list_id,
+      expires_at: timing.expires_at,
+      now: timing.now,
+    } as any)
+
+    return new WorkflowResponse(persisted)
+  }
+)
+
+export default mintQuoteWorkflow


### PR DESCRIPTION
S1 and S2 built the quote on one rule: **nothing frozen ever prices a cart.** That rule existed because there was no way to make a buyer-specific price real. There is — so this reverses it, and the model docblocks asserting the old rule are updated with it.

## The mechanism is native

Core resolves a price by `price_list_id IS NOT NULL DESC`, then rules matched, then `amount ASC`, and only for an ACTIVE list inside `starts_at`/`ends_at`. A price list scoped to the buyer's customer group makes the quoted number the number the cart charges — and expiry and revoke come free: `ends_at` **is** the expiry, `status: draft` **is** the revoke. No cron, no sweeper.

## `mint-quote` workflow

Five steps, every one reversing:

1. **timing** — resolved in a STEP, not the workflow body. `createWorkflow`'s function runs once to build the graph and `input` there is a proxy, so `input.ttl_days ?? DEFAULT` would read the proxy at definition time, and `new Date()` in the body would freeze one timestamp across every future run.
2. **buyer** — find-or-create customer AND one group **per buyer**, both linked to the partner's store. Scoped through the store link: another partner's customer with the same email is not this partner's buyer. One group per buyer rather than per quote, so a repeat quote replaces their prices instead of stacking a second list that core tie-breaks on `amount ASC`.
3. **freeze** — `buildQuoteView` runs **once**; everything downstream is written from that single output, so no second pricing path can disagree with the page. Refuses to write anything if the basket could not be priced.
4. **price list** — dated to the quote, ruled to the group.
5. **persist** — quote + lines, token minted.

Compensation never deletes a customer (they may have orders) and never deletes a group that already existed.

### Two dangerous defaults, both closed

🔴 **The rule is asserted from a RE-READ after creation**, not assumed from the payload. `rules_count = 0` makes core apply a list to EVERY customer on the platform — it treats unruled as *universal*, not as an error — so a rule that silently failed to attach is a platform-wide price cut. If it did not attach, the list is deleted and the mint fails loudly.

🔴 **A line with no quoted amount is DROPPED, never defaulted to 0.** A zero would not fail loudly; it would become an ACTIVE price of zero that the cart charges.

## Routes

- `POST /partners/quotes` — mints. The raw token is returned **here and nowhere else**; only its sha256 is persisted, so a DB read cannot reconstruct a working link.
- `GET /partners/quotes` — the partner's own, scoped by `partner_id`.
- `GET /store/b2b/quotes/:token` — the buyer. No auth: the token **is** the credential, because asking procurement to create an account before seeing a price is the wall this feature exists to remove. Unknown and revoked tokens are both 404 so a prober cannot tell them apart. Accepts a quantity dial; a malformed one shows the quoted basket rather than 400-ing a buyer's page.

12 unit tests on the pure money half. `check:prod-build` green, `tsc` at the 75 baseline.

## Not here, deliberately

⏳ **Email.** Freeze before send, so a mail can never disagree with the row it describes.

⚠️ Needs the #1408 `store ↔ price_list` link migration on prod.

🤖 Generated with [Claude Code](https://claude.com/claude-code)