### PR TITLE
fix: wrap Select.Item in Select.Content in block editor

### DIFF
--- a/apps/partner-ui/src/components/block-editor/block-editor.tsx
+++ b/apps/partner-ui/src/components/block-editor/block-editor.tsx
@@ -133,8 +133,13 @@ export const BlockEditor = ({
                 value={(content.align as string) || "center"}
                 onValueChange={(v) => updateContent("align", v)}
               >
-                <Select.Item value="center">Center</Select.Item>
-                <Select.Item value="left">Left</Select.Item>
+                <Select.Trigger>
+                  <Select.Value placeholder="Center" />
+                </Select.Trigger>
+                <Select.Content>
+                  <Select.Item value="center">Center</Select.Item>
+                  <Select.Item value="left">Left</Select.Item>
+                </Select.Content>
               </Select>
             </div>
             <ImageUrlInput
@@ -208,10 +213,15 @@ export const BlockEditor = ({
                 value={(content.layout as string) || "full"}
                 onValueChange={(v) => updateContent("layout", v)}
               >
-                <Select.Item value="full">Full Width</Select.Item>
-                <Select.Item value="split">Split</Select.Item>
-                <Select.Item value="image-left">Image Left</Select.Item>
-                <Select.Item value="image-right">Image Right</Select.Item>
+                <Select.Trigger>
+                  <Select.Value placeholder="Full Width" />
+                </Select.Trigger>
+                <Select.Content>
+                  <Select.Item value="full">Full Width</Select.Item>
+                  <Select.Item value="split">Split</Select.Item>
+                  <Select.Item value="image-left">Image Left</Select.Item>
+                  <Select.Item value="image-right">Image Right</Select.Item>
+                </Select.Content>
               </Select>
             </div>
             <ImageUrlInput
@@ -446,9 +456,14 @@ export const BlockEditor = ({
             value={block.status}
             onValueChange={(v) => onUpdate(block.id, { status: v as ContentBlock["status"] })}
           >
-            <Select.Item value="Active">Active</Select.Item>
-            <Select.Item value="Inactive">Inactive</Select.Item>
-            <Select.Item value="Draft">Draft</Select.Item>
+            <Select.Trigger>
+              <Select.Value placeholder="Active" />
+            </Select.Trigger>
+            <Select.Content>
+              <Select.Item value="Active">Active</Select.Item>
+              <Select.Item value="Inactive">Inactive</Select.Item>
+              <Select.Item value="Draft">Draft</Select.Item>
+            </Select.Content>
           </Select>
         </div>
 
@@ -487,10 +502,15 @@ export const BlockEditor = ({
             value={(block.settings?.max_width as string) || "default"}
             onValueChange={(v) => updateSettings("max_width", v)}
           >
-            <Select.Item value="default">Default</Select.Item>
-            <Select.Item value="narrow">Narrow</Select.Item>
-            <Select.Item value="wide">Wide</Select.Item>
-            <Select.Item value="full">Full Width</Select.Item>
+            <Select.Trigger>
+              <Select.Value placeholder="Default" />
+            </Select.Trigger>
+            <Select.Content>
+              <Select.Item value="default">Default</Select.Item>
+              <Select.Item value="narrow">Narrow</Select.Item>
+              <Select.Item value="wide">Wide</Select.Item>
+              <Select.Item value="full">Full Width</Select.Item>
+            </Select.Content>
           </Select>
         </div>
       </div>
@@ -586,9 +606,14 @@ const GalleryEditor = ({
             })
           }
         >
-          <Select.Item value="2">2 Columns</Select.Item>
-          <Select.Item value="3">3 Columns</Select.Item>
-          <Select.Item value="4">4 Columns</Select.Item>
+          <Select.Trigger>
+            <Select.Value placeholder="3 Columns" />
+          </Select.Trigger>
+          <Select.Content>
+            <Select.Item value="2">2 Columns</Select.Item>
+            <Select.Item value="3">3 Columns</Select.Item>
+            <Select.Item value="4">4 Columns</Select.Item>
+          </Select.Content>
         </Select>
       </div>
     </>

--- a/apps/partner-ui/src/routes/content/content-detail/content-detail.tsx
+++ b/apps/partner-ui/src/routes/content/content-detail/content-detail.tsx
@@ -411,9 +411,14 @@ const ContentDetailInner = () => {
           <div>
             <Label>Block Type</Label>
             <Select value={newBlockType} onValueChange={setNewBlockType}>
-              {BLOCK_TYPES.map((t) => (
-                <Select.Item key={t} value={t}>{t}</Select.Item>
-              ))}
+              <Select.Trigger>
+                <Select.Value placeholder="Select block type" />
+              </Select.Trigger>
+              <Select.Content>
+                {BLOCK_TYPES.map((t) => (
+                  <Select.Item key={t} value={t}>{t}</Select.Item>
+                ))}
+              </Select.Content>
             </Select>
           </div>
           <div>


### PR DESCRIPTION
## Problem
All `Select` components in the content block editor and the add-block drawer were missing `Select.Trigger` and `Select.Content` wrappers, causing a `SelectItem must be used within SelectContent` runtime error.

## Fix
Added the required `Select.Trigger` + `Select.Value` + `Select.Content` wrapper structure to all 6 `Select` components:
- Alignment select (Hero block)
- Layout select (Section block)
- Status select (block editor sidebar)
- Max Width select (block editor sidebar)
- Columns select (Gallery block)
- Block Type select (Add Block drawer in content-detail)

## Files Changed
- `apps/partner-ui/src/components/block-editor/block-editor.tsx`
- `apps/partner-ui/src/routes/content/content-detail/content-detail.tsx`