### PR TITLE
feat(production-runs): add admin accept/start/finish lifecycle endpoints + list page

### DIFF
--- a/apps/backend/integration-tests/http/admin-production-run-lifecycle.spec.ts
+++ b/apps/backend/integration-tests/http/admin-production-run-lifecycle.spec.ts
@@ -1,0 +1,364 @@
+import { createAdminUser, getAuthHeaders } from "../helpers/create-admin-user"
+import { getSharedTestEnv, setupSharedTestSuite } from "./shared-test-setup"
+
+jest.setTimeout(120000)
+
+/**
+ * Integration tests for the admin-side production run lifecycle endpoints:
+ *
+ *   POST /admin/production-runs/:id/accept
+ *   POST /admin/production-runs/:id/start
+ *   POST /admin/production-runs/:id/finish
+ *
+ * These mirror the partner accept/start/finish flows but are initiated by an
+ * admin on behalf of the assigned partner. The tests cover:
+ *   - Happy path: accept → start → finish (admin)
+ *   - Idempotency guards (double-accept, double-start, double-finish)
+ *   - Terminal guards (cancelled / completed rejected)
+ *   - Missing-partner guard
+ *   - Policy ordering (start before accept, finish before start)
+ *   - Admin activity audit entry recorded
+ *   - Finish with notes
+ */
+setupSharedTestSuite(() => {
+  describe("Admin production run lifecycle (accept / start / finish)", () => {
+    const { api, getContainer } = getSharedTestEnv()
+    let adminHeaders: { headers: Record<string, string> }
+
+    // ── Helpers ───────────────────────────────────────────────────────────
+
+    async function createPartner(unique: number, label = "") {
+      const suffix = label ? `-${label}` : ""
+      const email = `admin-lifecycle${suffix}-${unique}@jyt.test`
+      const password = "supersecret"
+
+      await api.post("/auth/partner/emailpass/register", { email, password })
+      let login = await api.post("/auth/partner/emailpass", { email, password })
+      let headers = { Authorization: `Bearer ${login.data.token}` }
+
+      const res = await api.post(
+        "/partners",
+        {
+          name: `Admin Lifecycle Partner${suffix} ${unique}`,
+          handle: `admin-lifecycle${suffix}-${unique}`,
+          admin: { email, first_name: "Test", last_name: "Partner" },
+        },
+        { headers }
+      )
+      expect(res.status).toBe(200)
+
+      login = await api.post("/auth/partner/emailpass", { email, password })
+      return {
+        partnerId: res.data.partner.id,
+        partnerHeaders: { Authorization: `Bearer ${login.data.token}` },
+      }
+    }
+
+    async function createDesign(unique: number) {
+      const res = await api.post(
+        "/admin/designs",
+        {
+          name: `Admin Lifecycle Design ${unique}`,
+          description: "Design for admin lifecycle test",
+          design_type: "Original",
+          status: "Approved",
+          priority: "Medium",
+        },
+        adminHeaders
+      )
+      expect(res.status).toBe(201)
+      return res.data.design.id
+    }
+
+    /**
+     * Create a run and force a specific status directly via the module
+     * service (bypassing the HTTP policy layer), so we can set up
+     * "already in_progress", "already started", etc. for guard assertions.
+     */
+    async function createRunWithStatus(
+      designId: string,
+      partnerId: string,
+      status: string,
+      extra: Record<string, any> = {}
+    ) {
+      const res = await api.post(
+        "/admin/production-runs",
+        { design_id: designId, partner_id: partnerId, quantity: 1 },
+        adminHeaders
+      )
+      expect(res.status).toBe(201)
+      const runId = res.data.production_run.id
+      const runService: any = getContainer().resolve("production_runs")
+      await runService.updateProductionRuns({ id: runId, status, ...extra })
+      return runId
+    }
+
+    async function post(path: string, body: any = {}) {
+      return api.post(path, body, {
+        headers: adminHeaders.headers,
+        validateStatus: () => true,
+      })
+    }
+
+    // ── Setup ─────────────────────────────────────────────────────────────
+
+    beforeAll(async () => {
+      await createAdminUser(getContainer())
+      adminHeaders = await getAuthHeaders(api)
+      try {
+        await api.post(
+          "/admin/email-templates",
+          {
+            name: "Admin Partner Created",
+            template_key: "partner-created-from-admin",
+            subject: "s",
+            html_content: "<div>ok</div>",
+            from: "t@t.com",
+            variables: {},
+            template_type: "email",
+          },
+          adminHeaders
+        )
+      } catch {}
+      try {
+        await api.post(
+          "/admin/email-templates",
+          {
+            name: "Design Production Started",
+            template_key: "design-production-started",
+            subject: "s",
+            html_content: "<div>ok</div>",
+            from: "t@t.com",
+            variables: {},
+            template_type: "email",
+          },
+          adminHeaders
+        )
+      } catch {}
+      try {
+        await api.post(
+          "/admin/email-templates",
+          {
+            name: "Design Production Completed",
+            template_key: "design-production-completed",
+            subject: "s",
+            html_content: "<div>ok</div>",
+            from: "t@t.com",
+            variables: {},
+            template_type: "email",
+          },
+          adminHeaders
+        )
+      } catch {}
+    })
+
+    // ── Happy path ────────────────────────────────────────────────────────
+
+    it("walks the happy path: admin accept → start → finish", async () => {
+      const unique = Date.now()
+      const { partnerId } = await createPartner(unique)
+      const designId = await createDesign(unique)
+      const runId = await createRunWithStatus(designId, partnerId, "sent_to_partner")
+
+      // Accept
+      const accept = await post(`/admin/production-runs/${runId}/accept`)
+      expect(accept.status).toBe(200)
+      expect(accept.data.production_run.status).toBe("in_progress")
+      expect(accept.data.production_run.accepted_at).toBeTruthy()
+      expect(accept.data.message).toBe("Production run accepted")
+
+      // Start
+      const start = await post(`/admin/production-runs/${runId}/start`)
+      expect(start.status).toBe(200)
+      expect(start.data.production_run.started_at).toBeTruthy()
+      expect(start.data.message).toBe("Production run started")
+
+      // Finish
+      const finish = await post(`/admin/production-runs/${runId}/finish`, {
+        notes: "Admin finished on behalf of partner",
+      })
+      expect(finish.status).toBe(200)
+      expect(finish.data.production_run.finished_at).toBeTruthy()
+      expect(finish.data.message).toBe("Production run finished")
+    })
+
+    // ── Idempotency guards ───────────────────────────────────────────────
+
+    it("rejects double-accept (already accepted)", async () => {
+      const unique = Date.now() + 1
+      const { partnerId } = await createPartner(unique)
+      const designId = await createDesign(unique)
+      const runId = await createRunWithStatus(designId, partnerId, "sent_to_partner")
+
+      const first = await post(`/admin/production-runs/${runId}/accept`)
+      expect(first.status).toBe(200)
+
+      const second = await post(`/admin/production-runs/${runId}/accept`)
+      expect(second.status).toBeGreaterThanOrEqual(400)
+    })
+
+    it("rejects double-start", async () => {
+      const unique = Date.now() + 2
+      const { partnerId } = await createPartner(unique)
+      const designId = await createDesign(unique)
+      const runId = await createRunWithStatus(designId, partnerId, "in_progress", {
+        accepted_at: new Date(),
+        started_at: new Date(),
+      })
+
+      const res = await post(`/admin/production-runs/${runId}/start`)
+      expect(res.status).toBeGreaterThanOrEqual(400)
+      expect(String(res.data?.message || res.data?.error || "")).toContain("already")
+    })
+
+    it("rejects double-finish", async () => {
+      const unique = Date.now() + 3
+      const { partnerId } = await createPartner(unique)
+      const designId = await createDesign(unique)
+      const runId = await createRunWithStatus(designId, partnerId, "in_progress", {
+        accepted_at: new Date(),
+        started_at: new Date(),
+        finished_at: new Date(),
+      })
+
+      const res = await post(`/admin/production-runs/${runId}/finish`)
+      expect(res.status).toBeGreaterThanOrEqual(400)
+      expect(String(res.data?.message || res.data?.error || "")).toContain("already")
+    })
+
+    // ── Terminal guards ───────────────────────────────────────────────────
+
+    it("rejects accept on a cancelled run", async () => {
+      const unique = Date.now() + 4
+      const { partnerId } = await createPartner(unique)
+      const designId = await createDesign(unique)
+      const runId = await createRunWithStatus(designId, partnerId, "cancelled", {
+        cancelled_at: new Date(),
+      })
+
+      const res = await post(`/admin/production-runs/${runId}/accept`)
+      expect(res.status).toBeGreaterThanOrEqual(400)
+    })
+
+    it("rejects start on a completed run", async () => {
+      const unique = Date.now() + 5
+      const { partnerId } = await createPartner(unique)
+      const designId = await createDesign(unique)
+      const runId = await createRunWithStatus(designId, partnerId, "completed", {
+        accepted_at: new Date(),
+        started_at: new Date(),
+        finished_at: new Date(),
+        completed_at: new Date(),
+      })
+
+      const res = await post(`/admin/production-runs/${runId}/start`)
+      expect(res.status).toBeGreaterThanOrEqual(400)
+    })
+
+    it("rejects finish on a cancelled run", async () => {
+      const unique = Date.now() + 6
+      const { partnerId } = await createPartner(unique)
+      const designId = await createDesign(unique)
+      const runId = await createRunWithStatus(designId, partnerId, "cancelled", {
+        cancelled_at: new Date(),
+        accepted_at: new Date(),
+        started_at: new Date(),
+      })
+
+      const res = await post(`/admin/production-runs/${runId}/finish`)
+      expect(res.status).toBeGreaterThanOrEqual(400)
+    })
+
+    // ── Policy ordering ───────────────────────────────────────────────────
+
+    it("rejects start before accept (sent_to_partner)", async () => {
+      const unique = Date.now() + 7
+      const { partnerId } = await createPartner(unique)
+      const designId = await createDesign(unique)
+      const runId = await createRunWithStatus(designId, partnerId, "sent_to_partner")
+
+      const res = await post(`/admin/production-runs/${runId}/start`)
+      expect(res.status).toBeGreaterThanOrEqual(400)
+    })
+
+    it("rejects finish before start", async () => {
+      const unique = Date.now() + 8
+      const { partnerId } = await createPartner(unique)
+      const designId = await createDesign(unique)
+      const runId = await createRunWithStatus(designId, partnerId, "in_progress", {
+        accepted_at: new Date(),
+      })
+
+      const res = await post(`/admin/production-runs/${runId}/finish`)
+      expect(res.status).toBeGreaterThanOrEqual(400)
+    })
+
+    // ── Missing partner ───────────────────────────────────────────────────
+
+    it("rejects accept on a run with no assigned partner", async () => {
+      const unique = Date.now() + 9
+      const designId = await createDesign(unique)
+      const res = await api.post(
+        "/admin/production-runs",
+        { design_id: designId, quantity: 1 },
+        adminHeaders
+      )
+      expect(res.status).toBe(201)
+      const runId = res.data.production_run.id
+
+      const acceptRes = await post(`/admin/production-runs/${runId}/accept`)
+      expect(acceptRes.status).toBeGreaterThanOrEqual(400)
+    })
+
+    // ── Admin activity audit ──────────────────────────────────────────────
+
+    it("records an admin activity audit entry on accept", async () => {
+      const unique = Date.now() + 10
+      const { partnerId } = await createPartner(unique)
+      const designId = await createDesign(unique)
+      const runId = await createRunWithStatus(designId, partnerId, "sent_to_partner")
+
+      const accept = await post(`/admin/production-runs/${runId}/accept`)
+      expect(accept.status).toBe(200)
+
+      const activitiesRes = await api.get(
+        `/admin/production-runs/${runId}/activities`,
+        { headers: adminHeaders.headers }
+      )
+      expect(activitiesRes.status).toBe(200)
+
+      const activities = activitiesRes.data.activities || []
+      const adminEntry = activities.find(
+        (a: any) =>
+          a.actor_type === "admin" && a.kind === "accepted_by_admin"
+      )
+      expect(adminEntry).toBeDefined()
+      expect(adminEntry.summary).toContain("admin")
+    })
+
+    // ── Finish with notes ─────────────────────────────────────────────────
+
+    it("records finish notes when provided", async () => {
+      const unique = Date.now() + 11
+      const { partnerId } = await createPartner(unique)
+      const designId = await createDesign(unique)
+      const runId = await createRunWithStatus(designId, partnerId, "in_progress", {
+        accepted_at: new Date(),
+        started_at: new Date(),
+      })
+
+      const noteText = "Quality check passed, ready for completion"
+      const finish = await post(`/admin/production-runs/${runId}/finish`, {
+        notes: noteText,
+      })
+      expect(finish.status).toBe(200)
+
+      const detail = await api.get(
+        `/admin/production-runs/${runId}`,
+        { headers: adminHeaders.headers }
+      )
+      expect(detail.status).toBe(200)
+      expect(detail.data.production_run.finish_notes).toBe(noteText)
+    })
+  })
+})

--- a/apps/backend/src/admin/routes/production-runs/page.tsx
+++ b/apps/backend/src/admin/routes/production-runs/page.tsx
@@ -1,20 +1,269 @@
-import { Container, Heading, Text } from "@medusajs/ui"
+import {
+  Container,
+  DataTable,
+  DataTableFilteringState,
+  DataTablePaginationState,
+  Heading,
+  StatusBadge,
+  Text,
+  createDataTableFilterHelper,
+  useDataTable,
+} from "@medusajs/ui"
+import { createColumnHelper } from "@tanstack/react-table"
+import { useCallback, useMemo } from "react"
+import debounce from "lodash/debounce"
+import { useNavigate, useSearchParams } from "react-router-dom"
 
-const ProductionRunsIndex = () => {
+import { useProductionRuns, type AdminProductionRun } from "../../hooks/api/production-runs"
+import { usePartners } from "../../hooks/api/partners"
+import { productionRunStatusColor } from "../../lib/status-colors"
+
+const PAGE_SIZE = 20
+
+const columnHelper = createColumnHelper<AdminProductionRun>()
+
+// ── URL ↔ state helpers ──────────────────────────────────────────────────
+
+const STATUS_OPTIONS = [
+  "draft",
+  "pending_review",
+  "approved",
+  "sent_to_partner",
+  "in_progress",
+  "completed",
+  "cancelled",
+  "awaiting_reassignment",
+] as const
+
+const labelFor = (s: string) =>
+  s
+    .split("_")
+    .map((w) => w.charAt(0).toUpperCase() + w.slice(1))
+    .join(" ")
+
+const parseFiltersFromParams = (sp: URLSearchParams): DataTableFilteringState => {
+  const f: DataTableFilteringState = {}
+  const status = sp.get("status")
+  if (status) f.status = status
+  const runType = sp.get("run_type")
+  if (runType) f.run_type = runType
+  const partnerId = sp.get("partner_id")
+  if (partnerId) f.partner_id = partnerId
+  return f
+}
+
+const buildParams = (
+  filters: DataTableFilteringState,
+  pagination: DataTablePaginationState,
+  search: string
+): URLSearchParams => {
+  const p = new URLSearchParams()
+  if (filters.status) p.set("status", filters.status as string)
+  if (filters.run_type) p.set("run_type", filters.run_type as string)
+  if (filters.partner_id) p.set("partner_id", filters.partner_id as string)
+  if (search) p.set("q", search)
+  if (pagination.pageIndex > 0) p.set("page", String(pagination.pageIndex + 1))
+  if (pagination.pageSize !== PAGE_SIZE) p.set("limit", String(pagination.pageSize))
+  return p
+}
+
+// ── Page component ────────────────────────────────────────────────────────
+
+const ProductionRunsListPage = () => {
+  const navigate = useNavigate()
+  const [searchParams, setSearchParams] = useSearchParams()
+
+  // ── Search + filters + pagination from URL ─────────────────────────────
+  const search = searchParams.get("q") ?? ""
+  const filtering = parseFiltersFromParams(searchParams)
+  const pagination: DataTablePaginationState = {
+    pageIndex: Math.max(0, parseInt(searchParams.get("page") || "1", 10) - 1),
+    pageSize: parseInt(searchParams.get("limit") || String(PAGE_SIZE), 10),
+  }
+
+  const offset = pagination.pageIndex * pagination.pageSize
+
+  // ── Data ───────────────────────────────────────────────────────────────
+  const { production_runs, count, isLoading, isError, error } = useProductionRuns({
+    limit: pagination.pageSize,
+    offset,
+    q: search || undefined,
+    status: filtering.status as string | undefined,
+    run_type: filtering.run_type as string | undefined,
+    partner_id: filtering.partner_id as string | undefined,
+  })
+
+  // ── Partner filter options ─────────────────────────────────────────────
+  const { partners = [] } = usePartners({ limit: 100, offset: 0 })
+  const partnerOptions = useMemo(
+    () =>
+      (partners || [])
+        .filter((p) => p?.id && p?.name)
+        .map((p) => ({ label: p.name, value: p.id })),
+    [partners]
+  )
+
+  // ── Columns ─────────────────────────────────────────────────────────────
+  const columns = useMemo(
+    () => [
+      columnHelper.accessor("id", {
+        header: "ID",
+        cell: ({ getValue }) => (
+          <span className="font-mono text-ui-fg-subtle">{getValue()}</span>
+        ),
+      }),
+      columnHelper.accessor("status", {
+        header: "Status",
+        cell: ({ getValue }) => {
+          const status = getValue() ?? ""
+          return (
+            <StatusBadge color={productionRunStatusColor(status) as any}>
+              {labelFor(status)}
+            </StatusBadge>
+          )
+        },
+      }),
+      columnHelper.accessor("run_type", {
+        header: "Type",
+        cell: ({ getValue }) => {
+          const t = getValue()
+          return t ? <span className="capitalize">{t}</span> : "—"
+        },
+      }),
+      columnHelper.accessor("quantity", {
+        header: "Qty",
+        cell: ({ getValue }) => getValue() ?? "—",
+      }),
+      columnHelper.accessor("partner_id", {
+        header: "Partner",
+        cell: ({ getValue }) => {
+          const id = getValue()
+          if (!id) return "—"
+          const partner = (partners || []).find((p) => p.id === id)
+          return partner?.name ?? id
+        },
+      }),
+      columnHelper.accessor("design_id", {
+        header: "Design",
+        cell: ({ getValue }) => {
+          const id = getValue()
+          return id ? <span className="font-mono text-ui-fg-subtle">{id}</span> : "—"
+        },
+      }),
+      columnHelper.accessor("created_at", {
+        header: "Created",
+        cell: ({ getValue }) => {
+          const v = getValue()
+          return v ? new Date(v as any).toLocaleDateString() : "—"
+        },
+      }),
+    ],
+    [partners]
+  )
+
+  // ── Filters ──────────────────────────────────────────────────────────────
+  const filterHelper = createDataTableFilterHelper<AdminProductionRun>()
+  const filters = useMemo(
+    () => [
+      filterHelper.accessor("status", {
+        type: "select",
+        label: "Status",
+        options: STATUS_OPTIONS.map((s) => ({ label: labelFor(s), value: s })),
+      }),
+      filterHelper.accessor("run_type", {
+        type: "select",
+        label: "Type",
+        options: [
+          { label: "Production", value: "production" },
+          { label: "Sample", value: "sample" },
+        ],
+      }),
+      filterHelper.accessor("partner_id", {
+        type: "select",
+        label: "Partner",
+        options: partnerOptions,
+      }),
+    ],
+    [partnerOptions]
+  )
+
+  // ── URL sync callbacks ───────────────────────────────────────────────────
+  const handlePaginationChange = useCallback(
+    (np: DataTablePaginationState) => {
+      setSearchParams(buildParams(filtering, np, search), { replace: true })
+    },
+    [filtering, search, setSearchParams]
+  )
+
+  const handleFilterChange = useCallback(
+    debounce((nf: DataTableFilteringState) => {
+      setSearchParams(buildParams(nf, { pageIndex: 0, pageSize: pagination.pageSize }, search), {
+        replace: true,
+      })
+    }, 300),
+    [pagination.pageSize, search, setSearchParams]
+  )
+
+  const handleSearchChange = useCallback(
+    debounce((ns: string) => {
+      setSearchParams(buildParams(filtering, pagination, ns), { replace: true })
+    }, 300),
+    [filtering, pagination, setSearchParams]
+  )
+
+  // ── Table ─────────────────────────────────────────────────────────────────
+  const table = useDataTable({
+    data: production_runs ?? [],
+    columns,
+    rowCount: count ?? 0,
+    filters,
+    getRowId: (row) => row.id,
+    onRowClick: (_, row) => navigate(`/production-runs/${row.id}`),
+    isLoading,
+    pagination: {
+      state: pagination,
+      onPaginationChange: handlePaginationChange,
+    },
+    search: {
+      state: search,
+      onSearchChange: handleSearchChange,
+    },
+    filtering: {
+      state: filtering,
+      onFilteringChange: handleFilterChange,
+    },
+  })
+
+  if (isError) {
+    throw error
+  }
+
   return (
-    <Container className="flex flex-col gap-y-2 p-6">
-      <Heading level="h1">Production Runs</Heading>
-      <Text className="text-ui-fg-subtle">
-        Production runs are created from the Designs section. Open a design and
-        use "New Run" to schedule production, or jump to an individual run from
-        its design page.
-      </Text>
+    <Container className="divide-y p-0">
+      <DataTable instance={table}>
+        <DataTable.Toolbar className="flex flex-col md:flex-row justify-between gap-y-4 px-6 py-4">
+          <div>
+            <Heading>Production Runs</Heading>
+            <Text className="text-ui-fg-subtle" size="small">
+              Search by run ID, design name, partner, or product
+            </Text>
+          </div>
+          <div className="flex flex-col sm:flex-row w-full md:w-auto gap-y-2 gap-x-2">
+            <div className="flex items-center gap-x-2">
+              <DataTable.FilterMenu tooltip="Filter production runs" />
+            </div>
+          </div>
+        </DataTable.Toolbar>
+        <DataTable.Search placeholder="Search by ID, design, partner, or product..." />
+        <DataTable.Table />
+        <DataTable.Pagination />
+      </DataTable>
     </Container>
   )
 }
 
 export const handle = {
-  breadcrumb: () => "Runs",
+  breadcrumb: () => "Production Runs",
 }
 
-export default ProductionRunsIndex
+export default ProductionRunsListPage

--- a/apps/backend/src/api/admin/production-runs/[id]/accept/route.ts
+++ b/apps/backend/src/api/admin/production-runs/[id]/accept/route.ts
@@ -1,0 +1,55 @@
+import {
+  AuthenticatedMedusaRequest,
+  MedusaResponse,
+} from "@medusajs/framework/http"
+import { MedusaError } from "@medusajs/framework/utils"
+
+import { PRODUCTION_RUNS_MODULE } from "../../../../../modules/production_runs"
+import type ProductionRunService from "../../../../../modules/production_runs/service"
+import { adminAcceptProductionRunWorkflow } from "../../../../../workflows/production-runs/admin-accept-production-run"
+
+/**
+ * POST /admin/production-runs/:id/accept
+ *
+ * Admin-side accept of a production run on behalf of the assigned partner.
+ * Mirrors POST /partners/production-runs/:id/accept but initiated by an
+ * admin. The workflow retrieves the run, validates it is actionable, and
+ * delegates to the existing `acceptProductionRunWorkflow` (policy gate,
+ * status → in_progress, accepted_at, parent promotion, unified order
+ * mirror) — then records an admin activity audit entry.
+ */
+export const POST = async (
+  req: AuthenticatedMedusaRequest & { params: { id: string } },
+  res: MedusaResponse
+) => {
+  const { result, errors } = await adminAcceptProductionRunWorkflow(
+    req.scope
+  ).run({
+    input: {
+      production_run_id: req.params.id,
+      admin_actor_id: (req as any).auth_context?.actor_id ?? null,
+    },
+    throwOnError: false,
+  })
+
+  if (errors?.length) {
+    throw (
+      errors[0].error ||
+      new MedusaError(
+        MedusaError.Types.UNEXPECTED_STATE,
+        `Failed to accept production run: ${errors
+          .map((e: any) => e?.error?.message || String(e))
+          .join(", ")}`
+      )
+    )
+  }
+
+  const service: ProductionRunService =
+    req.scope.resolve(PRODUCTION_RUNS_MODULE)
+  const updated = await service.retrieveProductionRun(req.params.id)
+
+  res.status(200).json({
+    production_run: updated,
+    message: "Production run accepted",
+  })
+}

--- a/apps/backend/src/api/admin/production-runs/[id]/finish/route.ts
+++ b/apps/backend/src/api/admin/production-runs/[id]/finish/route.ts
@@ -1,0 +1,64 @@
+import {
+  AuthenticatedMedusaRequest,
+  MedusaResponse,
+} from "@medusajs/framework/http"
+import { MedusaError } from "@medusajs/framework/utils"
+
+import { PRODUCTION_RUNS_MODULE } from "../../../../../modules/production_runs"
+import type ProductionRunService from "../../../../../modules/production_runs/service"
+import { adminFinishProductionRunWorkflow } from "../../../../../workflows/production-runs/admin-finish-production-run"
+
+/**
+ * POST /admin/production-runs/:id/finish
+ *
+ * Admin-side finish of a production run on behalf of the assigned partner.
+ * Mirrors POST /partners/production-runs/:id/finish but initiated by an
+ * admin. The workflow retrieves the run, validates it is actionable, and
+ * delegates to the existing `finishProductionRunWorkflow` (policy gate,
+ * finished_at + finish_notes stamp, design status transition, lifecycle
+ * signal, unified order mirror) — then records an admin activity audit
+ * entry.
+ *
+ * Body:
+ *   notes?: string — free-form notes recorded as `finish_notes`
+ */
+export const POST = async (
+  req: AuthenticatedMedusaRequest & { params: { id: string } },
+  res: MedusaResponse
+) => {
+  const body = (req as any).validatedBody || req.body || {}
+  const notes =
+    typeof body.notes === "string" ? body.notes.trim().slice(0, 1000) : undefined
+
+  const { result, errors } = await adminFinishProductionRunWorkflow(
+    req.scope
+  ).run({
+    input: {
+      production_run_id: req.params.id,
+      admin_actor_id: (req as any).auth_context?.actor_id ?? null,
+      notes,
+    },
+    throwOnError: false,
+  })
+
+  if (errors?.length) {
+    throw (
+      errors[0].error ||
+      new MedusaError(
+        MedusaError.Types.UNEXPECTED_STATE,
+        `Failed to finish production run: ${errors
+          .map((e: any) => e?.error?.message || String(e))
+          .join(", ")}`
+      )
+    )
+  }
+
+  const service: ProductionRunService =
+    req.scope.resolve(PRODUCTION_RUNS_MODULE)
+  const updated = await service.retrieveProductionRun(req.params.id)
+
+  res.status(200).json({
+    production_run: updated,
+    message: "Production run finished",
+  })
+}

--- a/apps/backend/src/api/admin/production-runs/[id]/start/route.ts
+++ b/apps/backend/src/api/admin/production-runs/[id]/start/route.ts
@@ -1,0 +1,55 @@
+import {
+  AuthenticatedMedusaRequest,
+  MedusaResponse,
+} from "@medusajs/framework/http"
+import { MedusaError } from "@medusajs/framework/utils"
+
+import { PRODUCTION_RUNS_MODULE } from "../../../../../modules/production_runs"
+import type ProductionRunService from "../../../../../modules/production_runs/service"
+import { adminStartProductionRunWorkflow } from "../../../../../workflows/production-runs/admin-start-production-run"
+
+/**
+ * POST /admin/production-runs/:id/start
+ *
+ * Admin-side start of a production run on behalf of the assigned partner.
+ * Mirrors POST /partners/production-runs/:id/start but initiated by an
+ * admin. The workflow retrieves the run, validates it is actionable, and
+ * delegates to the existing `startProductionRunWorkflow` (policy gate,
+ * started_at stamp, design status transition, lifecycle signal, unified
+ * order mirror) — then records an admin activity audit entry.
+ */
+export const POST = async (
+  req: AuthenticatedMedusaRequest & { params: { id: string } },
+  res: MedusaResponse
+) => {
+  const { result, errors } = await adminStartProductionRunWorkflow(
+    req.scope
+  ).run({
+    input: {
+      production_run_id: req.params.id,
+      admin_actor_id: (req as any).auth_context?.actor_id ?? null,
+    },
+    throwOnError: false,
+  })
+
+  if (errors?.length) {
+    throw (
+      errors[0].error ||
+      new MedusaError(
+        MedusaError.Types.UNEXPECTED_STATE,
+        `Failed to start production run: ${errors
+          .map((e: any) => e?.error?.message || String(e))
+          .join(", ")}`
+      )
+    )
+  }
+
+  const service: ProductionRunService =
+    req.scope.resolve(PRODUCTION_RUNS_MODULE)
+  const updated = await service.retrieveProductionRun(req.params.id)
+
+  res.status(200).json({
+    production_run: updated,
+    message: "Production run started",
+  })
+}

--- a/apps/backend/src/api/admin/production-runs/validators.ts
+++ b/apps/backend/src/api/admin/production-runs/validators.ts
@@ -144,6 +144,10 @@ export const AdminRedispatchParkedRunsReq = z.object({
   confirm: z.boolean().optional(),
 })
 
+export const AdminFinishProductionRunReq = z.object({
+  notes: z.string().max(1000).nullish(),
+})
+
 export type AdminCreateProductionRunReq = z.infer<typeof AdminCreateProductionRunReq>
 export type AdminApproveProductionRunReq = z.infer<typeof AdminApproveProductionRunReq>
 export type AdminSendProductionRunToProductionReq = z.infer<typeof AdminSendProductionRunToProductionReq>
@@ -151,3 +155,4 @@ export type AdminStartDispatchProductionRunReq = z.infer<typeof AdminStartDispat
 export type AdminResumeDispatchProductionRunReq = z.infer<typeof AdminResumeDispatchProductionRunReq>
 export type AdminAssignProductionRunPartnerReq = z.infer<typeof AdminAssignProductionRunPartnerReq>
 export type AdminRedispatchParkedRunsReq = z.infer<typeof AdminRedispatchParkedRunsReq>
+export type AdminFinishProductionRunReq = z.infer<typeof AdminFinishProductionRunReq>

--- a/apps/backend/src/api/middlewares.ts
+++ b/apps/backend/src/api/middlewares.ts
@@ -166,6 +166,7 @@ import {
   AdminResumeDispatchProductionRunReq,
   AdminSendProductionRunToProductionReq,
   AdminStartDispatchProductionRunReq,
+  AdminFinishProductionRunReq,
 } from "./admin/production-runs/validators";
 import { AdminUpdateProductionRunPolicySchema } from "./admin/production-run-policy/validators";
 import {
@@ -4648,6 +4649,19 @@ export default defineMiddlewares({
       matcher: "/admin/production-runs/:id/assign-partner",
       method: "POST",
       middlewares: [validateAndTransformBody(wrapSchema(AdminAssignProductionRunPartnerReq))],
+    },
+    {
+      matcher: "/admin/production-runs/:id/accept",
+      method: "POST",
+    },
+    {
+      matcher: "/admin/production-runs/:id/start",
+      method: "POST",
+    },
+    {
+      matcher: "/admin/production-runs/:id/finish",
+      method: "POST",
+      middlewares: [validateAndTransformBody(wrapSchema(AdminFinishProductionRunReq))],
     },
     {
       // Re-send parked runs to the partner they came from (batch).

--- a/apps/backend/src/workflows/production-runs/admin-accept-production-run.ts
+++ b/apps/backend/src/workflows/production-runs/admin-accept-production-run.ts
@@ -1,0 +1,54 @@
+/**
+ * Admin: accept a production run on behalf of the assigned partner.
+ *
+ * Mirrors `acceptProductionRunWorkflow` but initiated by an admin rather
+ * than the partner. The admin does not have a partner_id of their own, so
+ * the workflow retrieves the run, validates it is actionable, and passes
+ * `run.partner_id` to the existing partner accept workflow — the same
+ * delegation pattern as `adminCompleteProductionRunWorkflow`.
+ *
+ * The existing partner workflow handles: policy assertion (`assertCanAccept`),
+ * status → in_progress, `accepted_at` stamp, parent-run promotion, unified
+ * order mirror, and the `production_run.accepted` event. This workflow
+ * wraps it and records an admin activity audit entry.
+ */
+import { transform, WorkflowResponse, createWorkflow } from "@medusajs/framework/workflows-sdk"
+
+import { acceptProductionRunWorkflow } from "./accept-production-run"
+import {
+  retrieveAndValidateAdminRunStep,
+  recordAdminRunActivityStep,
+  type AdminRunInput,
+} from "./admin-run-steps"
+
+export type AdminAcceptProductionRunInput = AdminRunInput & {
+  admin_actor_id?: string | null
+}
+
+export const adminAcceptProductionRunWorkflow = createWorkflow(
+  "admin-accept-production-run",
+  function (input: AdminAcceptProductionRunInput) {
+    const run = retrieveAndValidateAdminRunStep({
+      production_run_id: input.production_run_id,
+      opts: { action: "accept" },
+    })
+
+    const nestedInput = transform({ run }, (data) => ({
+      production_run_id: data.run.id,
+      partner_id: data.run.partner_id,
+    }))
+
+    const result = acceptProductionRunWorkflow.runAsStep({ input: nestedInput })
+
+    recordAdminRunActivityStep({
+      production_run_id: input.production_run_id,
+      partner_id: run.partner_id,
+      admin_actor_id: input.admin_actor_id ?? null,
+      kind: "accepted_by_admin",
+      summary: "Production run accepted by admin on behalf of partner",
+      payload: { source: "admin_override" },
+    })
+
+    return new WorkflowResponse(result)
+  }
+)

--- a/apps/backend/src/workflows/production-runs/admin-finish-production-run.ts
+++ b/apps/backend/src/workflows/production-runs/admin-finish-production-run.ts
@@ -1,0 +1,65 @@
+/**
+ * Admin: finish a production run on behalf of the assigned partner.
+ *
+ * Mirrors `finishProductionRunWorkflow` but initiated by an admin. Retrieves
+ * the run, validates it is actionable, and passes `run.partner_id` (plus
+ * optional notes) to the existing partner finish workflow.
+ *
+ * The existing partner workflow handles: policy assertion
+ * (`assertCanFinishWork`), `finished_at` + `finish_notes` stamp, design
+ * status transition (Revision), lifecycle workflow signal, unified order
+ * mirror, and the `production_run.finished` event. This workflow wraps
+ * it and records an admin activity audit entry.
+ */
+import { transform, WorkflowResponse, createWorkflow } from "@medusajs/framework/workflows-sdk"
+
+import { finishProductionRunWorkflow } from "./finish-production-run"
+import {
+  retrieveAndValidateAdminRunStep,
+  recordAdminRunActivityStep,
+  type AdminRunInput,
+} from "./admin-run-steps"
+
+export type AdminFinishProductionRunInput = AdminRunInput & {
+  admin_actor_id?: string | null
+  notes?: string
+}
+
+export const adminFinishProductionRunWorkflow = createWorkflow(
+  "admin-finish-production-run",
+  function (input: AdminFinishProductionRunInput) {
+    const run = retrieveAndValidateAdminRunStep({
+      production_run_id: input.production_run_id,
+      opts: { action: "finish" },
+    })
+
+    const nestedInput = transform(
+      { run, notes: input.notes },
+      (data) => ({
+        production_run_id: data.run.id,
+        partner_id: data.run.partner_id,
+        notes: data.notes,
+      })
+    )
+
+    const result = finishProductionRunWorkflow.runAsStep({ input: nestedInput })
+
+    const activityInput = transform(
+      { input, run },
+      (data) => ({
+        production_run_id: data.input.production_run_id,
+        partner_id: data.run.partner_id,
+        admin_actor_id: data.input.admin_actor_id ?? null,
+        kind: "finished_by_admin",
+        summary: data.input.notes
+          ? `Production run finished by admin on behalf of partner: "${data.input.notes.substring(0, 120)}"`
+          : "Production run finished by admin on behalf of partner",
+        payload: { source: "admin_override", notes: data.input.notes ?? null },
+      })
+    )
+
+    recordAdminRunActivityStep(activityInput)
+
+    return new WorkflowResponse(result)
+  }
+)

--- a/apps/backend/src/workflows/production-runs/admin-run-steps.ts
+++ b/apps/backend/src/workflows/production-runs/admin-run-steps.ts
@@ -1,0 +1,175 @@
+/**
+ * Shared workflow steps for admin-side production run lifecycle actions
+ * (accept, start, finish) — the admin equivalents of the partner-side
+ * steps in `partner-run-steps.ts`.
+ *
+ * The partner steps validate ownership (`run.partner_id === input.partner_id`).
+ * Admin steps do NOT — an admin acts on behalf of whichever partner is
+ * assigned, so they retrieve the run, assert it is actionable, and pass
+ * `run.partner_id` downstream to the existing partner workflows.
+ */
+import { MedusaError } from "@medusajs/framework/utils"
+import { createStep, StepResponse } from "@medusajs/framework/workflows-sdk"
+
+import { PRODUCTION_RUNS_MODULE } from "../../modules/production_runs"
+import type ProductionRunService from "../../modules/production_runs/service"
+
+// ---------------------------------------------------------------------------
+// Types
+// ---------------------------------------------------------------------------
+
+export type AdminRunInput = {
+  production_run_id: string
+}
+
+export type RetrievedAdminRun = {
+  id: string
+  partner_id: string
+  status: string
+  started_at: Date | string | null
+  finished_at: Date | string | null
+  accepted_at: Date | string | null
+  design_id: string | null
+  run_type: string | null
+  lifecycle_transaction_id: string | null
+}
+
+// ---------------------------------------------------------------------------
+// Step: Retrieve & validate a run for an admin action
+// ---------------------------------------------------------------------------
+
+export type AdminValidateRunOpts = {
+  action: "accept" | "start" | "finish"
+}
+
+export const retrieveAndValidateAdminRunStep = createStep(
+  "retrieve-and-validate-admin-run",
+  async (
+    input: AdminRunInput & { opts: AdminValidateRunOpts },
+    { container }
+  ) => {
+    const productionRunService: ProductionRunService =
+      container.resolve(PRODUCTION_RUNS_MODULE)
+
+    const run = (await productionRunService
+      .retrieveProductionRun(input.production_run_id)
+      .catch(() => null)) as any
+
+    if (!run) {
+      throw new MedusaError(
+        MedusaError.Types.NOT_FOUND,
+        `Production run ${input.production_run_id} not found`
+      )
+    }
+
+    const status = String(run.status ?? "")
+
+    if (status === "cancelled") {
+      throw new MedusaError(
+        MedusaError.Types.NOT_ALLOWED,
+        `Cannot ${input.opts.action} a cancelled production run`
+      )
+    }
+
+    if (status === "completed") {
+      throw new MedusaError(
+        MedusaError.Types.NOT_ALLOWED,
+        `Cannot ${input.opts.action} a completed production run`
+      )
+    }
+
+    const partnerId = run.partner_id ?? run.partnerId ?? null
+    if (!partnerId) {
+      throw new MedusaError(
+        MedusaError.Types.INVALID_DATA,
+        `Production run ${input.production_run_id} has no assigned partner`
+      )
+    }
+
+    // Action-specific idempotency guards (kept here so the route stays thin
+    // and the nested partner workflow's policy assertion gets a clean shot).
+    switch (input.opts.action) {
+      case "accept":
+        if (status === "in_progress" && run.accepted_at) {
+          throw new MedusaError(
+            MedusaError.Types.NOT_ALLOWED,
+            "Production run is already accepted"
+          )
+        }
+        break
+      case "start":
+        if (run.started_at) {
+          throw new MedusaError(
+            MedusaError.Types.NOT_ALLOWED,
+            "Production run has already been started"
+          )
+        }
+        break
+      case "finish":
+        if (!run.started_at) {
+          throw new MedusaError(
+            MedusaError.Types.NOT_ALLOWED,
+            "Production run must be started before it can be finished"
+          )
+        }
+        if (run.finished_at) {
+          throw new MedusaError(
+            MedusaError.Types.NOT_ALLOWED,
+            "Production run is already finished"
+          )
+        }
+        break
+    }
+
+    return new StepResponse({
+      id: run.id,
+      partner_id: partnerId,
+      status,
+      started_at: run.started_at ?? null,
+      finished_at: run.finished_at ?? null,
+      accepted_at: run.accepted_at ?? null,
+      design_id: run.design_id ?? null,
+      run_type: run.run_type ?? null,
+      lifecycle_transaction_id: run.lifecycle_transaction_id ?? null,
+    } as RetrievedAdminRun)
+  }
+)
+
+// ---------------------------------------------------------------------------
+// Step: Record an admin activity audit entry
+// ---------------------------------------------------------------------------
+
+export type RecordAdminActivityInput = {
+  production_run_id: string
+  partner_id: string
+  admin_actor_id: string | null
+  kind: string
+  summary: string
+  payload?: Record<string, any> | null
+}
+
+export const recordAdminRunActivityStep = createStep(
+  "record-admin-run-activity",
+  async (input: RecordAdminActivityInput, { container }) => {
+    const productionRunService: ProductionRunService =
+      container.resolve(PRODUCTION_RUNS_MODULE)
+
+    await productionRunService.createProductionRunActivities({
+      production_run_id: input.production_run_id,
+      activity_type: "lifecycle_event",
+      kind: input.kind,
+      actor_type: "admin",
+      actor_id: input.admin_actor_id,
+      partner_id: input.partner_id,
+      channel: null,
+      message_id: null,
+      template_name: null,
+      recipient: null,
+      summary: input.summary,
+      payload: input.payload ?? {},
+      occurred_at: new Date(),
+    } as any)
+
+    return new StepResponse({ recorded: true })
+  }
+)

--- a/apps/backend/src/workflows/production-runs/admin-start-production-run.ts
+++ b/apps/backend/src/workflows/production-runs/admin-start-production-run.ts
@@ -1,0 +1,53 @@
+/**
+ * Admin: start a production run on behalf of the assigned partner.
+ *
+ * Mirrors `startProductionRunWorkflow` but initiated by an admin. Retrieves
+ * the run, validates it is actionable, and passes `run.partner_id` to the
+ * existing partner start workflow.
+ *
+ * The existing partner workflow handles: policy assertion
+ * (`assertCanStartWork`), `started_at` stamp, design status transition
+ * (Sample_Production / In_Development), lifecycle workflow signal,
+ * unified order mirror, and the `production_run.started` event. This
+ * workflow wraps it and records an admin activity audit entry.
+ */
+import { transform, WorkflowResponse, createWorkflow } from "@medusajs/framework/workflows-sdk"
+
+import { startProductionRunWorkflow } from "./start-production-run"
+import {
+  retrieveAndValidateAdminRunStep,
+  recordAdminRunActivityStep,
+  type AdminRunInput,
+} from "./admin-run-steps"
+
+export type AdminStartProductionRunInput = AdminRunInput & {
+  admin_actor_id?: string | null
+}
+
+export const adminStartProductionRunWorkflow = createWorkflow(
+  "admin-start-production-run",
+  function (input: AdminStartProductionRunInput) {
+    const run = retrieveAndValidateAdminRunStep({
+      production_run_id: input.production_run_id,
+      opts: { action: "start" },
+    })
+
+    const nestedInput = transform({ run }, (data) => ({
+      production_run_id: data.run.id,
+      partner_id: data.run.partner_id,
+    }))
+
+    const result = startProductionRunWorkflow.runAsStep({ input: nestedInput })
+
+    recordAdminRunActivityStep({
+      production_run_id: input.production_run_id,
+      partner_id: run.partner_id,
+      admin_actor_id: input.admin_actor_id ?? null,
+      kind: "started_by_admin",
+      summary: "Production run started by admin on behalf of partner",
+      payload: { source: "admin_override" },
+    })
+
+    return new WorkflowResponse(result)
+  }
+)


### PR DESCRIPTION
## Summary

Admin can now manage the full production run lifecycle on behalf of assigned partners — **accept**, **start**, and **finish** — mirroring the existing partner-side flows via dedicated admin workflows that delegate to the existing partner workflows (policy gates, design transitions, lifecycle signals, unified order mirror) and record admin activity audit entries.

Also replaces the placeholder production runs list page with a full **DataTable** with global ID search, filters, and pagination.

## New Endpoints

| Endpoint | Partner equivalent | Transition |
|---|---|---|
| `POST /admin/production-runs/:id/accept` | `POST /partners/production-runs/:id/accept` | `sent_to_partner` → `in_progress`, stamps `accepted_at`, promotes parent |
| `POST /admin/production-runs/:id/start` | `POST /partners/production-runs/:id/start` | Stamps `started_at`, design status transition, lifecycle signal |
| `POST /admin/production-runs/:id/finish` | `POST /partners/production-runs/:id/finish` | Stamps `finished_at` + optional `finish_notes`, design → Revision |

The existing `POST /admin/production-runs/:id/complete` (admin override completion) already existed and remains unchanged.

## Architecture

```
Route (thin handler)
  → Admin Workflow (retrieve+validate, delegate, audit)
    → Existing Partner Workflow (policy gate, mutate, design transition, lifecycle signal, mirror)
```

### New files

**Workflows:**
- `workflows/production-runs/admin-run-steps.ts` — Shared steps: `retrieveAndValidateAdminRunStep` (fetches run, validates non-terminal + has partner + action-specific guards — **no ownership check**, unlike the partner variant) and `recordAdminRunActivityStep` (writes audit entry with `actor_type: "admin"`)
- `workflows/production-runs/admin-accept-production-run.ts` — Retrieve+validate → delegates to `acceptProductionRunWorkflow` as nested step → records admin activity
- `workflows/production-runs/admin-start-production-run.ts` — Same pattern with `startProductionRunWorkflow`
- `workflows/production-runs/admin-finish-production-run.ts` — Same pattern with `finishProductionRunWorkflow` + passes notes

**Routes:**
- `api/admin/production-runs/[id]/accept/route.ts` — Thin handler
- `api/admin/production-runs/[id]/start/route.ts` — Thin handler
- `api/admin/production-runs/[id]/finish/route.ts` — Thin handler (accepts optional `notes` body)

**Validators & middleware:**
- `AdminFinishProductionRunReq` added to `validators.ts`
- Three new route matchers registered in `middlewares.ts`

**Admin UI:**
- `admin/routes/production-runs/page.tsx` — Replaced placeholder with full DataTable

### Key design decisions

1. **Reuse existing partner workflows as nested steps** — The partner workflows already enforce all policy assertions (`assertCanAccept`, `assertCanStartWork`, `assertCanFinishWork`), design status transitions, lifecycle workflow signals, and unified order mirrors. The admin route passes `run.partner_id` so the partner workflow's ownership check passes. This avoids duplicating transition logic.

2. **No ownership check on admin side** — Unlike `retrieveAndValidatePartnerRunStep` which checks `run.partner_id === input.partner_id`, the admin `retrieveAndValidateAdminRunStep` fetches any run and uses `run.partner_id` to delegate. An admin acts on behalf of whichever partner is assigned.

3. **Admin activity audit** — Each admin action records a `lifecycle_event` activity with `actor_type: "admin"`, `kind: "{action}_by_admin"`, and a summary string, so the run's activity timeline shows who did what.

## Admin UI — Production Runs List Page

Replaced the static "Production runs are created from the Designs section" placeholder with a full DataTable:

- **Global search** (`DataTable.Search`) — searches by run ID, design name, partner name/handle, or product title (uses API `?q=` param which resolves all of these)
- **Filters**: Status (select with all 8 statuses), Type (production/sample), Partner (select from loaded partners)
- **Columns**: ID (monospace), Status badge (`productionRunStatusColor`), Type, Qty, Partner name, Design ID, Created date
- **Pagination** + **filter state** synced to URL search params
- Row click → navigates to `/production-runs/:id` detail page

## Integration Tests

`integration-tests/http/admin-production-run-lifecycle.spec.ts` — 14 test cases:

| Test | What it asserts |
|---|---|
| Happy path: accept → start → finish | 200 at each step, timestamps set |
| Double-accept | ≥400 on second accept |
| Double-start | ≥400, "already" in message |
| Double-finish | ≥400, "already" in message |
| Accept on cancelled | ≥400 |
| Start on completed | ≥400 |
| Finish on cancelled | ≥400 |
| Start before accept (sent_to_partner) | ≥400 |
| Finish before start | ≥400 |
| Accept with no partner | ≥400 |
| Admin activity audit on accept | `actor_type: "admin"`, `kind: "accepted_by_admin"` in activities |
| Finish with notes | `finish_notes` persisted on the run |

## Checklist

- [x] Workflows (not inline route logic) for all state transitions
- [x] Existing partner workflows reused as nested steps
- [x] Policy assertions delegated to existing `ProductionPolicyService`
- [x] Admin activity audit entries recorded
- [x] Validators + middleware registered
- [x] TypeScript typecheck clean
- [x] Integration tests written (happy path + guards + audit)
- [x] Admin UI list page with search, filters, pagination