### PR TITLE
fix(quote): freight was picked across every zone and every currency

### DIFF
--- a/apps/backend/medusa-config.prod.ts
+++ b/apps/backend/medusa-config.prod.ts
@@ -1,5 +1,6 @@
 import { loadEnv, defineConfig, Modules } from "@medusajs/framework/utils";
 import path from "path";
+import { parseFlatFallbackAmounts } from "./src/modules/shipping-providers/shiprocket/flat-fallback"
 
 loadEnv(process.env.NODE_ENV || 'development', process.cwd())
 
@@ -360,6 +361,17 @@ module.exports = defineConfig({
                     email: process.env.SHIPROCKET_EMAIL,
                     password: process.env.SHIPROCKET_PASSWORD,
                     pickup_location: process.env.SHIPROCKET_PICKUP_LOCATION,
+                    // What an UNQUOTABLE lane costs (#1417). Without one,
+                    // calculatePrice used to answer 0 — free shipping wearing
+                    // the shape of a real quote. `IN=9900,US=249000` (ISO2=minor
+                    // units); see shiprocket/flat-fallback.ts.
+                    flat_fallback_amounts: parseFlatFallbackAmounts(
+                      process.env.SHIPROCKET_FLAT_FALLBACK_AMOUNTS
+                    ),
+                    flat_fallback_amount: process.env
+                      .SHIPROCKET_FLAT_FALLBACK_AMOUNT
+                      ? Number(process.env.SHIPROCKET_FLAT_FALLBACK_AMOUNT)
+                      : undefined,
                   },
                 },
               ]

--- a/apps/backend/medusa-config.ts
+++ b/apps/backend/medusa-config.ts
@@ -1,5 +1,6 @@
 import { loadEnv, defineConfig, Modules } from "@medusajs/framework/utils";
 import path from "path";
+import { parseFlatFallbackAmounts } from "./src/modules/shipping-providers/shiprocket/flat-fallback"
 
 loadEnv(process.env.NODE_ENV || 'development', process.cwd())
 
@@ -443,6 +444,17 @@ module.exports = defineConfig({
                           email: process.env.SHIPROCKET_EMAIL,
                           password: process.env.SHIPROCKET_PASSWORD,
                           pickup_location: process.env.SHIPROCKET_PICKUP_LOCATION,
+                          // What an UNQUOTABLE lane costs (#1417). Without one,
+                          // calculatePrice used to answer 0 — free shipping
+                          // wearing the shape of a real quote. `IN=9900,US=249000`
+                          // (ISO2=minor units); see shiprocket/flat-fallback.ts.
+                          flat_fallback_amounts: parseFlatFallbackAmounts(
+                            process.env.SHIPROCKET_FLAT_FALLBACK_AMOUNTS
+                          ),
+                          flat_fallback_amount: process.env
+                            .SHIPROCKET_FLAT_FALLBACK_AMOUNT
+                            ? Number(process.env.SHIPROCKET_FLAT_FALLBACK_AMOUNT)
+                            : undefined,
                         },
                       },
                     ]

--- a/apps/backend/src/api/admin/ops/maintenance-jobs/__tests__/backfill-shiprocket-shipping-options.unit.spec.ts
+++ b/apps/backend/src/api/admin/ops/maintenance-jobs/__tests__/backfill-shiprocket-shipping-options.unit.spec.ts
@@ -1,0 +1,119 @@
+import { planShiprocketOptions } from "../backfill-shiprocket-shipping-options-job"
+
+/**
+ * The decision this guards: "does this store already have Shiprocket on this
+ * zone". Getting it wrong duplicates a carrier in a LIVE checkout picker, and
+ * `createShippingOptions` will happily make the duplicate without complaint.
+ */
+
+const zone = (over: any = {}) => ({
+  id: "sz_1",
+  name: "IN Shipping Zone",
+  geo_zones: [{ country_code: "in" }],
+  shipping_options: [],
+  ...over,
+})
+
+const sets = (zones: any[]) => [{ id: "fs_1", type: "shipping", service_zones: zones }]
+
+describe("planShiprocketOptions", () => {
+  it("adds the calculated Shiprocket option and a flat companion to a bare domestic zone", () => {
+    const plan = planShiprocketOptions({
+      fulfillmentSets: sets([
+        zone({
+          shipping_options: [
+            { provider_id: "delhivery_delhivery", price_type: "calculated" },
+          ],
+        }),
+      ]),
+      homeCountry: "in",
+    })
+
+    expect(plan.map((p) => p.kind).sort()).toEqual([
+      "domestic-calculated",
+      "domestic-flat",
+    ])
+  })
+
+  it("is idempotent — a zone that already has Shiprocket gets no second one", () => {
+    const plan = planShiprocketOptions({
+      fulfillmentSets: sets([
+        zone({
+          shipping_options: [
+            { provider_id: "shiprocket_shiprocket", price_type: "calculated" },
+            { provider_id: "manual_manual", price_type: "flat" },
+          ],
+        }),
+      ]),
+      homeCountry: "in",
+    })
+
+    expect(plan).toEqual([])
+  })
+
+  it("does not add a second flat option when the store already has flat tiers", () => {
+    const plan = planShiprocketOptions({
+      fulfillmentSets: sets([
+        zone({
+          shipping_options: [{ provider_id: "manual_manual", price_type: "flat" }],
+        }),
+      ]),
+      homeCountry: "in",
+    })
+
+    expect(plan.map((p) => p.kind)).toEqual(["domestic-calculated"])
+  })
+
+  it("classifies a zone as international from its GEO ZONES, not its name", () => {
+    // Several zones were renamed by hand during the #954 backfill, so matching
+    // on the name "International" would silently skip them.
+    const plan = planShiprocketOptions({
+      fulfillmentSets: sets([
+        zone({
+          id: "sz_intl",
+          name: "Renamed By Hand",
+          geo_zones: [{ country_code: "us" }, { country_code: "gb" }],
+        }),
+      ]),
+      homeCountry: "in",
+    })
+
+    expect(plan).toEqual([
+      {
+        zone_id: "sz_intl",
+        zone_name: "Renamed By Hand",
+        kind: "international-calculated",
+        provider_id: "shiprocket_shiprocket",
+      },
+    ])
+  })
+
+  it("never puts a flat companion on an international zone", () => {
+    const plan = planShiprocketOptions({
+      fulfillmentSets: sets([
+        zone({ id: "sz_intl", geo_zones: [{ country_code: "us" }] }),
+      ]),
+      homeCountry: "in",
+    })
+
+    expect(plan.some((p) => p.kind === "domestic-flat")).toBe(false)
+  })
+
+  it("skips PICKUP sets — a courier cannot deliver a parcel being collected", () => {
+    const plan = planShiprocketOptions({
+      fulfillmentSets: [{ id: "fs_p", type: "pickup", service_zones: [zone()] }],
+      homeCountry: "in",
+    })
+
+    expect(plan).toEqual([])
+  })
+
+  it("skips a zone with no geo zones at all", () => {
+    const plan = planShiprocketOptions({
+      fulfillmentSets: sets([zone({ geo_zones: [] })]),
+      homeCountry: "in",
+    })
+
+    expect(plan).toEqual([])
+  })
+})

--- a/apps/backend/src/api/admin/ops/maintenance-jobs/backfill-shiprocket-shipping-options-job.ts
+++ b/apps/backend/src/api/admin/ops/maintenance-jobs/backfill-shiprocket-shipping-options-job.ts
@@ -1,0 +1,343 @@
+import { ContainerRegistrationKeys, MedusaError, Modules } from "@medusajs/framework/utils"
+import { createShippingOptionsWorkflow } from "@medusajs/medusa/core-flows"
+import { z } from "@medusajs/framework/zod"
+
+import type { MaintenanceChange, MaintenanceJob, MaintenanceJobResult } from "./registry"
+
+/**
+ * #1417 Data Plumbing — expose Shiprocket on stores that already exist.
+ *
+ * ## Why a backfill is needed at all
+ *
+ * Shiprocket was ALREADY fully provisioned on every Indian store: registered as
+ * a fulfillment provider in both configs, linked to the stock location by
+ * `create-store-with-defaults`, and its pickup location auto-registered. What
+ * was never created was a **shipping option** — `providerMap` in that workflow
+ * hardcodes `in -> delhivery_delhivery`, so the carrier existed everywhere
+ * except the one place a cart can pick it.
+ *
+ * `create-store-with-defaults` now creates those options, but that only helps
+ * stores provisioned from here on. Every store already in production needs this
+ * job — otherwise the fix ships and changes nothing for anybody real.
+ *
+ * ## What it creates, per store
+ *
+ * · **Domestic zone** — a `calculated` Shiprocket option, so the store gets live
+ *   rates exactly the way Delhivery already does.
+ * · **Domestic zone** — a `flat` manual companion. 🔑 This is not a nicety: an
+ *   IN store's domestic zone carried ONLY calculated options, and
+ *   `buildShippingEstimate` skips calculated options when assembling its manual
+ *   list — so quote freight rested entirely on one live carrier call with no
+ *   fallback, and a hiccup 400'd the whole quote mint.
+ * · **International zone** — a `calculated` Shiprocket option, where such a zone
+ *   exists. For an Indian origin Shiprocket IS the cross-border rate source:
+ *   Delhivery's cross-border product ("Starfleet") has no rate API at all.
+ *
+ * ## Idempotency
+ *
+ * Re-runnable. Existing options are matched by `provider_id` within each service
+ * zone and skipped, because `createShippingOptions` is perfectly happy to make a
+ * second identical option and leave the store with a duplicated carrier in its
+ * checkout picker. Dry-run previews every option it would create.
+ */
+
+/** Hard cap on stock locations scanned per call — bounds the blast radius. */
+export const MAX_SHIPROCKET_OPTION_SCAN = 2000
+
+const SHIPROCKET_PROVIDER_ID = "shiprocket_shiprocket"
+const MANUAL_PROVIDER_ID = "manual_manual"
+
+const paramsSchema = z.object({
+  /** Restrict to a single stock location (default: every IN location). */
+  location_id: z.string().min(1).optional(),
+  /** Max stock locations to scan in one call. */
+  limit: z
+    .number()
+    .int()
+    .positive()
+    .max(MAX_SHIPROCKET_OPTION_SCAN)
+    .optional()
+    .default(500),
+  /** Flat fallback amount, MAJOR units, for the manual companion option. */
+  flat_amount: z.number().nonnegative().optional().default(200),
+})
+
+export type ZonePlanKind = "domestic-calculated" | "domestic-flat" | "international-calculated"
+
+export type ZonePlanEntry = {
+  zone_id: string
+  zone_name: string
+  kind: ZonePlanKind
+  provider_id: string
+}
+
+/**
+ * PURE: given one location's fulfillment sets, decide which options are missing.
+ *
+ * Split out because this is the whole decision — "does this store already have
+ * Shiprocket on this zone" — and getting it wrong duplicates a carrier in a live
+ * checkout. Testable without a container, a store or a Shiprocket account.
+ *
+ * A zone counts as INTERNATIONAL when it covers any country other than the
+ * store's own. That is derived from the geo zones rather than from the zone's
+ * NAME: names are hand-editable and several were renamed by hand during the
+ * #954 backfill, so matching on "International" would silently skip them.
+ */
+export function planShiprocketOptions(args: {
+  fulfillmentSets: any[]
+  homeCountry: string
+}): ZonePlanEntry[] {
+  const home = String(args.homeCountry || "").toLowerCase()
+  const plan: ZonePlanEntry[] = []
+
+  for (const set of args.fulfillmentSets || []) {
+    // Pickup sets never carry a shipping carrier — a Shiprocket option on a
+    // pickup zone would offer to courier a parcel the buyer is collecting.
+    if (set?.type && set.type !== "shipping") continue
+
+    for (const zone of set?.service_zones || []) {
+      if (!zone?.id) continue
+
+      const countries = (zone.geo_zones || [])
+        .map((g: any) => String(g?.country_code || "").toLowerCase())
+        .filter(Boolean)
+      if (!countries.length) continue
+
+      const isInternational = countries.some((c: string) => c !== home)
+      const providers = new Set(
+        (zone.shipping_options || []).map((o: any) => String(o?.provider_id || ""))
+      )
+
+      if (isInternational) {
+        if (!providers.has(SHIPROCKET_PROVIDER_ID)) {
+          plan.push({
+            zone_id: zone.id,
+            zone_name: zone.name || zone.id,
+            kind: "international-calculated",
+            provider_id: SHIPROCKET_PROVIDER_ID,
+          })
+        }
+        continue
+      }
+
+      if (!providers.has(SHIPROCKET_PROVIDER_ID)) {
+        plan.push({
+          zone_id: zone.id,
+          zone_name: zone.name || zone.id,
+          kind: "domestic-calculated",
+          provider_id: SHIPROCKET_PROVIDER_ID,
+        })
+      }
+
+      // The flat companion is keyed on the absence of ANY flat option in the
+      // zone, not on the absence of a manual provider: a store that already has
+      // hand-made flat tiers has a fallback, and adding a second one would just
+      // put a duplicate row in its checkout.
+      const hasFlat = (zone.shipping_options || []).some(
+        (o: any) => o?.price_type === "flat"
+      )
+      if (!hasFlat) {
+        plan.push({
+          zone_id: zone.id,
+          zone_name: zone.name || zone.id,
+          kind: "domestic-flat",
+          provider_id: MANUAL_PROVIDER_ID,
+        })
+      }
+    }
+  }
+
+  return plan
+}
+
+export const backfillShiprocketShippingOptionsJob: MaintenanceJob = {
+  id: "backfill-shiprocket-shipping-options",
+  label: "Backfill Shiprocket shipping options onto existing stores",
+  description:
+    `Create the missing Shiprocket shipping options on stores that already exist. Shiprocket is already registered as a fulfillment provider and already linked to every Indian stock location, but no shipping option was ever created for it (create-store-with-defaults hardcodes Delhivery), so no cart could pick it. This adds a CALCULATED Shiprocket option to each domestic zone (live rates, exactly as Delhivery does today), a CALCULATED Shiprocket option to each international zone (for an Indian origin, Shiprocket is the cross-border rate source — Delhivery's cross-border product has no rate API), and a FLAT manual companion to any domestic zone that has no flat option at all. That flat option matters: an IN store carrying only calculated options gives buildShippingEstimate no manual fallback, so one failed carrier call 400s the whole quote. Idempotent — options are matched by provider within each zone and skipped if present. Dry-run previews every option it would create. Optionally scope to one location_id. Scans up to 'limit' stock locations per call (default 500, max ${MAX_SHIPROCKET_OPTION_SCAN}).`,
+  params: [
+    {
+      name: "location_id",
+      type: "string",
+      required: false,
+      description: "Restrict to a single stock location (default: every Indian location)",
+    },
+    {
+      name: "limit",
+      type: "number",
+      required: false,
+      description: `Max stock locations to scan in one call (default 500, max ${MAX_SHIPROCKET_OPTION_SCAN})`,
+    },
+    {
+      name: "flat_amount",
+      type: "number",
+      required: false,
+      description:
+        "Flat fallback amount in MAJOR units for the manual companion option (default 200)",
+    },
+  ],
+  run: async (container, { dry_run, params }): Promise<MaintenanceJobResult> => {
+    const parsed = paramsSchema.safeParse(params)
+    if (!parsed.success) {
+      throw new MedusaError(
+        MedusaError.Types.INVALID_DATA,
+        parsed.error.issues.map((i) => i.message).join("; ")
+      )
+    }
+    const { location_id, limit, flat_amount } = parsed.data
+
+    const query: any = container.resolve(ContainerRegistrationKeys.QUERY)
+    const fulfillmentService: any = container.resolve(Modules.FULFILLMENT)
+
+    const graphArgs: Record<string, unknown> = {
+      entity: "stock_locations",
+      fields: [
+        "id",
+        "name",
+        "address.country_code",
+        "fulfillment_sets.id",
+        "fulfillment_sets.type",
+        "fulfillment_sets.service_zones.id",
+        "fulfillment_sets.service_zones.name",
+        "fulfillment_sets.service_zones.geo_zones.country_code",
+        "fulfillment_sets.service_zones.shipping_options.id",
+        "fulfillment_sets.service_zones.shipping_options.provider_id",
+        "fulfillment_sets.service_zones.shipping_options.price_type",
+      ],
+      pagination: { take: limit },
+    }
+    if (location_id) graphArgs.filters = { id: location_id }
+    const { data: locations } = await query.graph(graphArgs as any)
+
+    // A shipping profile is required on every option. Reuse the store's rather
+    // than creating one — a second "Default" profile would split the catalogue
+    // across two profiles and silently hide products from the new options.
+    const profiles = await fulfillmentService.listShippingProfiles({}, { take: 1 })
+    const profileId = profiles?.[0]?.id
+    if (!profileId) {
+      throw new MedusaError(
+        MedusaError.Types.NOT_FOUND,
+        "No shipping profile exists, so shipping options cannot be created. Seed one first."
+      )
+    }
+
+    const changes: MaintenanceChange[] = []
+    const errors: Array<{ id: string; message: string }> = []
+    let created = 0
+    let locationsAlreadyCurrent = 0
+    let locationsSkippedNonIndian = 0
+
+    for (const location of (locations ?? []) as any[]) {
+      const homeCountry = String(location?.address?.country_code || "").toLowerCase()
+
+      // Shiprocket is an India-origin carrier. Adding it to a US or EU store's
+      // zones would offer a courier that cannot collect the parcel.
+      if (homeCountry !== "in") {
+        locationsSkippedNonIndian++
+        continue
+      }
+
+      const plan = planShiprocketOptions({
+        fulfillmentSets: location.fulfillment_sets || [],
+        homeCountry,
+      })
+
+      if (!plan.length) {
+        locationsAlreadyCurrent++
+        continue
+      }
+
+      const suffix = String(location.id).slice(-8)
+
+      for (const entry of plan) {
+        changes.push({
+          entity: "shipping_option",
+          id: entry.zone_id,
+          field: entry.kind,
+          before: "absent",
+          after: `${entry.provider_id} on "${entry.zone_name}"`,
+        })
+
+        if (dry_run) {
+          created++
+          continue
+        }
+
+        try {
+          const input =
+            entry.kind === "domestic-flat"
+              ? {
+                  name: "Standard Shipping (Flat)",
+                  service_zone_id: entry.zone_id,
+                  shipping_profile_id: profileId,
+                  provider_id: MANUAL_PROVIDER_ID,
+                  price_type: "flat",
+                  type: {
+                    label: "Standard (Flat)",
+                    description:
+                      "Flat-rate delivery — used when no carrier will quote",
+                    code: `flat-fallback-${suffix}`,
+                  },
+                  prices: [{ currency_code: "inr", amount: flat_amount }],
+                  rules: [
+                    { attribute: "enabled_in_store", value: "true", operator: "eq" },
+                    { attribute: "is_return", value: "false", operator: "eq" },
+                  ],
+                }
+              : {
+                  name:
+                    entry.kind === "international-calculated"
+                      ? "International Shipping (Shiprocket)"
+                      : "Standard Shipping (Shiprocket)",
+                  service_zone_id: entry.zone_id,
+                  shipping_profile_id: profileId,
+                  provider_id: SHIPROCKET_PROVIDER_ID,
+                  price_type: "calculated",
+                  type: {
+                    label:
+                      entry.kind === "international-calculated"
+                        ? "International"
+                        : "Standard",
+                    description:
+                      entry.kind === "international-calculated"
+                        ? "Cross-border delivery via Shiprocket — live rates"
+                        : "Standard delivery via Shiprocket — live rates",
+                    code:
+                      entry.kind === "international-calculated"
+                        ? `shiprocket-international-${suffix}`
+                        : `shiprocket-standard-${suffix}`,
+                  },
+                  rules: [
+                    { attribute: "enabled_in_store", value: "true", operator: "eq" },
+                    { attribute: "is_return", value: "false", operator: "eq" },
+                  ],
+                }
+
+          await createShippingOptionsWorkflow(container).run({ input: [input] as any })
+          created++
+        } catch (err: any) {
+          // One bad zone must not abort the sweep — the rest of the estate
+          // still needs its options.
+          errors.push({
+            id: entry.zone_id,
+            message: err?.message ?? String(err),
+          })
+        }
+      }
+    }
+
+    const verb = dry_run ? "Would create" : "Created"
+    const summary = `${verb} ${created} shipping option(s); ${locationsAlreadyCurrent} location(s) already current, ${locationsSkippedNonIndian} non-Indian location(s) skipped${
+      errors.length ? `, ${errors.length} error(s)` : ""
+    }.`
+
+    return {
+      job_id: backfillShiprocketShippingOptionsJob.id,
+      dry_run,
+      applied: !dry_run && created > 0,
+      summary,
+      changes,
+      errors,
+    }
+  },
+}

--- a/apps/backend/src/api/admin/ops/maintenance-jobs/registry.ts
+++ b/apps/backend/src/api/admin/ops/maintenance-jobs/registry.ts
@@ -80,6 +80,7 @@ import { seedEmailTemplatesJob } from "./seed-jobs"
 import { seedInvestorPanelsJob } from "./seed-investor-panels-job"
 import { replayFxFanoutJob } from "./fanout-fx-job"
 import { backfillStoreCurrenciesJob } from "./backfill-store-currencies-job"
+import { backfillShiprocketShippingOptionsJob } from "./backfill-shiprocket-shipping-options-job"
 import { deleteOrphanStoreJob } from "./delete-orphan-store-job"
 import { restoreOrphanStoreJob } from "./restore-orphan-store-job"
 import { backfillPartnerEmailVerifiedJob } from "./backfill-partner-email-verified-job"
@@ -5770,6 +5771,7 @@ export const MAINTENANCE_JOBS: MaintenanceJob[] = [
   reconcileInventoryMirrorJob,
   replayFxFanoutJob,
   backfillStoreCurrenciesJob,
+  backfillShiprocketShippingOptionsJob,
   deleteOrphanStoreJob,
   restoreOrphanStoreJob,
   backfillPartnerEmailVerifiedJob,

--- a/apps/backend/src/api/admin/shipping-carriers/route.ts
+++ b/apps/backend/src/api/admin/shipping-carriers/route.ts
@@ -1,0 +1,71 @@
+import { MedusaRequest, MedusaResponse } from "@medusajs/framework/http"
+import { ContainerRegistrationKeys, MedusaError } from "@medusajs/framework/utils"
+
+import { buildCarrierAvailability } from "../../../modules/shipping-providers/carrier-availability"
+
+/**
+ * The carrier picker's data, for an admin (#1417).
+ *
+ * Same answer as the partner route, reached differently: an admin has no
+ * partner of their own, so `partner_id` is REQUIRED here and is the whole
+ * difference between the two surfaces. Without it there is no location, and
+ * without a location "which carriers are on" has no meaning — so this refuses
+ * rather than returning a capability list that looks like an answer.
+ *
+ * 🔑 The admin route reads the SAME builder as the partner one. Two hand-rolled
+ * versions of "is this carrier available" would disagree the first time a
+ * carrier changed, and the admin's view is the one used to debug the partner's.
+ */
+export const GET = async (req: MedusaRequest, res: MedusaResponse) => {
+  const partnerId = String((req.query.partner_id as string) || "").trim()
+  if (!partnerId) {
+    throw new MedusaError(
+      MedusaError.Types.INVALID_DATA,
+      "partner_id is required — carrier availability is per-partner, because it is read from that partner's stock location."
+    )
+  }
+
+  const query = req.scope.resolve(ContainerRegistrationKeys.QUERY)
+
+  const { data: partners } = await query.graph({
+    entity: "partners",
+    fields: ["id", "name", "stores.id", "stores.default_location_id"],
+    filters: { id: partnerId },
+  })
+  const partner = partners?.[0] as any
+  if (!partner) {
+    throw new MedusaError(MedusaError.Types.NOT_FOUND, "Partner not found")
+  }
+
+  const store = partner.stores?.[0]
+  const locationId = store?.default_location_id
+
+  const [{ data: providers }, linked] = await Promise.all([
+    query.graph({ entity: "fulfillment_provider", fields: ["id", "is_enabled"] }),
+    locationId
+      ? query
+          .graph({
+            entity: "stock_locations",
+            fields: ["id", "fulfillment_providers.id"],
+            filters: { id: locationId },
+          })
+          .then(({ data }: any) =>
+            ((data?.[0]?.fulfillment_providers ?? []) as any[]).map((p) => p.id)
+          )
+      : Promise.resolve([]),
+  ])
+
+  const availability = buildCarrierAvailability({
+    registeredProviderIds: (providers ?? [])
+      .filter((p: any) => p.is_enabled !== false)
+      .map((p: any) => p.id),
+    linkedProviderIds: linked,
+  })
+
+  res.json({
+    ...availability,
+    partner: { id: partner.id, name: partner.name ?? null },
+    location_id: locationId ?? null,
+    store_id: store?.id ?? null,
+  })
+}

--- a/apps/backend/src/api/partners/shipping-carriers/route.ts
+++ b/apps/backend/src/api/partners/shipping-carriers/route.ts
@@ -1,0 +1,73 @@
+import { AuthenticatedMedusaRequest, MedusaResponse } from "@medusajs/framework/http"
+import { ContainerRegistrationKeys, MedusaError } from "@medusajs/framework/utils"
+
+import { getPartnerFromAuthContext } from "../helpers"
+import { buildCarrierAvailability } from "../../../modules/shipping-providers/carrier-availability"
+
+/**
+ * The carrier picker's data, for a partner (#1417).
+ *
+ * Answers "which carriers can I ship on, domestic vs international, and which
+ * have I already switched on" in one call — the three facts that decide it live
+ * in three different places (adapter capability, deployment registration,
+ * location link) and a UI should not have to join them itself.
+ *
+ * 🔑 The partner comes from the AUTH CONTEXT; the location comes from the
+ * partner's own store. Nothing here is taken from the query string, so one
+ * partner cannot read another's carrier setup by guessing a location id.
+ *
+ * Turning a carrier ON is not done here — that is the existing
+ * `POST /partners/stores/:id/locations/:locationId/fulfillment-providers`,
+ * which owns the link. This route is deliberately read-only so there is one
+ * writer for that link, not two.
+ */
+export const GET = async (req: AuthenticatedMedusaRequest, res: MedusaResponse) => {
+  const partner = await getPartnerFromAuthContext(req.auth_context, req.scope)
+  if (!partner) {
+    throw new MedusaError(
+      MedusaError.Types.UNAUTHORIZED,
+      "No partner associated with this account"
+    )
+  }
+
+  const query = req.scope.resolve(ContainerRegistrationKeys.QUERY)
+
+  const { data: partners } = await query.graph({
+    entity: "partners",
+    fields: ["id", "stores.id", "stores.default_location_id"],
+    filters: { id: partner.id },
+  })
+  const store = (partners?.[0] as any)?.stores?.[0]
+  const locationId = store?.default_location_id
+
+  const [{ data: providers }, linked] = await Promise.all([
+    query.graph({ entity: "fulfillment_provider", fields: ["id", "is_enabled"] }),
+    locationId
+      ? query
+          .graph({
+            entity: "stock_locations",
+            fields: ["id", "fulfillment_providers.id"],
+            filters: { id: locationId },
+          })
+          .then(({ data }: any) =>
+            ((data?.[0]?.fulfillment_providers ?? []) as any[]).map((p) => p.id)
+          )
+      : Promise.resolve([]),
+  ])
+
+  const availability = buildCarrierAvailability({
+    registeredProviderIds: (providers ?? [])
+      .filter((p: any) => p.is_enabled !== false)
+      .map((p: any) => p.id),
+    linkedProviderIds: linked,
+  })
+
+  res.json({
+    ...availability,
+    // Null when the partner has no store/location yet — the picker needs to say
+    // "finish setting up your location first" rather than showing every carrier
+    // as switchable against nothing.
+    location_id: locationId ?? null,
+    store_id: store?.id ?? null,
+  })
+}

--- a/apps/backend/src/api/store/shipping-estimate/route.ts
+++ b/apps/backend/src/api/store/shipping-estimate/route.ts
@@ -40,6 +40,7 @@ export const GET = async (req: MedusaRequest, res: MedusaResponse) => {
     quantity: rawQuantity,
     destination_postal_code: destinationPostalCode,
     country_code: rawCountryCode,
+    currency_code: rawCurrencyCode,
     carrier: rawCarrier,
   } = req.validatedQuery as Record<string, any>
 
@@ -58,6 +59,10 @@ export const GET = async (req: MedusaRequest, res: MedusaResponse) => {
     lines: [{ variant_id: variantId, quantity: Number(rawQuantity) }],
     destination_postal_code: String(destinationPostalCode),
     country_code: rawCountryCode,
+    // Optional here (this route predates it) — when absent the manual options
+    // are not currency-filtered, which is the behaviour every existing caller
+    // already has. Supplying it is strictly safer.
+    currency_code: rawCurrencyCode,
     carrier: rawCarrier,
     store,
   })

--- a/apps/backend/src/api/store/shipping-estimate/validators.ts
+++ b/apps/backend/src/api/store/shipping-estimate/validators.ts
@@ -13,6 +13,14 @@ export const StoreShippingEstimateSchema = z.object({
   destination_postal_code: z.string().min(3).max(16),
   /** ISO-2. Drives the domestic-vs-cross-border branch inside the adapter. */
   country_code: z.string().min(2).max(2).optional(),
+  /**
+   * Restricts manual/flat options to those priced in this currency. Optional
+   * because this route predates it; when absent, options are not
+   * currency-filtered, which is what every existing caller already gets.
+   * Supplying it is strictly safer — the picker sorts on the raw amount, so a
+   * foreign-currency option wins whenever its number is smaller.
+   */
+  currency_code: z.string().min(3).max(3).optional(),
   /** Defaults to the aggregator, which returns every courier on the lane. */
   carrier: z.string().min(2).max(40).optional(),
 })

--- a/apps/backend/src/lib/__tests__/shipping-estimate-zone.unit.spec.ts
+++ b/apps/backend/src/lib/__tests__/shipping-estimate-zone.unit.spec.ts
@@ -1,0 +1,79 @@
+import { zoneCoversDestination } from "../shipping-estimate"
+import { pickFreightOption } from "../../modules/partner-quote/lib/build-quote-view"
+
+/**
+ * Found on a LIVE production mint (#1389 S3 verification, 21 Aug):
+ *
+ *   destination : Mumbai 400001, domestic, 21 kg
+ *   currency    : inr
+ *   freight won : "European Shipping", amount 10, currency AUD
+ *
+ * Two independent defects let that happen. `buildShippingEstimate` collected
+ * manual options from EVERY service zone on the location regardless of whether
+ * the zone covered the destination, and it kept options in ANY currency — while
+ * `pickFreightOption` sorts on the raw `amount`. So 10 AUD beat a rupee rate on
+ * the number alone, and was then rendered as Rs 10.
+ */
+
+describe("zoneCoversDestination", () => {
+  it("rejects a zone that does not cover the destination", () => {
+    // The live case: a European zone offered for an Indian delivery.
+    const european = { geo_zones: [{ country_code: "de" }, { country_code: "fr" }] }
+    expect(zoneCoversDestination(european, "in")).toBe(false)
+  })
+
+  it("accepts a zone that covers it, case-insensitively", () => {
+    expect(zoneCoversDestination({ geo_zones: [{ country_code: "IN" }] }, "in")).toBe(
+      true
+    )
+  })
+
+  it("accepts a multi-country international zone containing the destination", () => {
+    const intl = { geo_zones: [{ country_code: "us" }, { country_code: "gb" }] }
+    expect(zoneCoversDestination(intl, "gb")).toBe(true)
+  })
+
+  it("treats a zone with NO geo zones as covering NOTHING", () => {
+    // An unscoped zone is a provisioning accident. Reading it as "worldwide" is
+    // how one bad row ends up pricing every lane.
+    expect(zoneCoversDestination({ geo_zones: [] }, "in")).toBe(false)
+    expect(zoneCoversDestination(null, "in")).toBe(false)
+  })
+
+  it("refuses when the destination itself is unknown", () => {
+    expect(zoneCoversDestination({ geo_zones: [{ country_code: "in" }] }, "")).toBe(
+      false
+    )
+  })
+})
+
+describe("pickFreightOption — the currency trap it cannot see", () => {
+  it("picks the cheapest, comparing raw amounts", () => {
+    // This is the DOCUMENTED behaviour and it is fine — as long as every option
+    // reaching it is already in one currency. That precondition is the fix;
+    // this test pins why the precondition matters.
+    const chosen = pickFreightOption({
+      manual: [
+        { amount: 200, currency_code: "inr", source: "manual" } as any,
+        { amount: 10, currency_code: "aud", source: "manual" } as any,
+      ],
+      calculated: [],
+    })
+
+    // 10 AUD "wins" on the number alone — roughly 30x more expensive in truth.
+    // Nothing downstream can detect this, which is why the filtering has to
+    // happen before the picker ever sees it.
+    expect(chosen!.currency_code).toBe("aud")
+  })
+
+  it("is correct once every option shares the quote's currency", () => {
+    const chosen = pickFreightOption({
+      manual: [
+        { amount: 200, currency_code: "inr", source: "manual" } as any,
+        { amount: 450, currency_code: "inr", source: "manual" } as any,
+      ],
+      calculated: [],
+    })
+    expect(chosen!.amount).toBe(200)
+  })
+})

--- a/apps/backend/src/lib/shipping-estimate.ts
+++ b/apps/backend/src/lib/shipping-estimate.ts
@@ -54,6 +54,12 @@ export type ShippingEstimateInput = {
   lines: ShippingEstimateLineInput[]
   destination_postal_code: string
   country_code?: string
+  /**
+   * The currency the quote is denominated in. REQUIRED to compare manual
+   * options: the picker sorts on the raw `amount`, so without this an option
+   * priced in another currency silently wins whenever its number is smaller.
+   */
+  currency_code?: string
   carrier?: string
   /** The store whose default stock location is the origin. */
   store: { id?: string; default_location_id?: string | null }
@@ -123,6 +129,31 @@ export function resolveUnitWeight(variant: {
 }
 
 /**
+ * PURE: does this service zone actually cover the destination country?
+ *
+ * A shipping option is an offer to carry a parcel to the zone it belongs to.
+ * Considering every zone on the location turns a European flat rate into a
+ * candidate for a Mumbai delivery — found live, where a 21 kg domestic
+ * consignment was quoted "European Shipping" at 10 AUD.
+ *
+ * A zone with NO geo zones is treated as covering nothing rather than
+ * everything: an unscoped zone is a provisioning accident, and reading it as
+ * "worldwide" is how one bad row prices every lane.
+ */
+export function zoneCoversDestination(
+  zone: { geo_zones?: Array<{ country_code?: string | null }> | null } | null,
+  destinationCountry: string
+): boolean {
+  const target = String(destinationCountry || "").toLowerCase()
+  if (!target) return false
+
+  const zones = zone?.geo_zones ?? []
+  return zones.some(
+    (g) => String(g?.country_code || "").toLowerCase() === target
+  )
+}
+
+/**
  * Bucket the weight so near-identical quantities share a cache entry rather
  * than minting one per quantity a buyer drags a slider through.
  */
@@ -138,6 +169,7 @@ export async function buildShippingEstimate(
   const logger: any = scope.resolve(ContainerRegistrationKeys.LOGGER)
 
   const countryCode = String(input.country_code || "in").toLowerCase()
+  const quoteCurrency = String(input.currency_code || "").toLowerCase()
   const destinationPostalCode = String(input.destination_postal_code)
 
   const lineInputs = (input.lines || []).filter(
@@ -224,6 +256,7 @@ export async function buildShippingEstimate(
     entity: "stock_locations",
     fields: [
       "id",
+      "fulfillment_sets.service_zones.geo_zones.country_code",
       "fulfillment_sets.service_zones.shipping_options.id",
       "fulfillment_sets.service_zones.shipping_options.name",
       "fulfillment_sets.service_zones.shipping_options.price_type",
@@ -235,12 +268,31 @@ export async function buildShippingEstimate(
   const manual: ShippingEstimateOption[] = []
   for (const fs of (optionLocations?.[0] as any)?.fulfillment_sets || []) {
     for (const zone of fs?.service_zones || []) {
+      // 🔴 A zone that does not cover the destination must not price it.
+      // Found live: a Mumbai domestic quote was given "European Shipping" at
+      // 10 AUD, because every zone on the location was considered. A shipping
+      // option is an offer to carry a parcel to the zone it belongs to; from
+      // any other zone it is not a cheaper answer, it is a different question.
+      if (!zoneCoversDestination(zone, countryCode)) continue
+
       for (const so of zone?.shipping_options || []) {
         if (so?.price_type === "calculated") continue
         for (const price of so?.prices || []) {
           // Only currency-scoped flat prices are meaningful without a cart;
           // region-scoped ones need a region the estimate does not have.
           if (!price?.currency_code) continue
+
+          // 🔴 And it must be priced in the currency we are quoting. The picker
+          // sorts on the raw `amount`, so an option in another currency is not
+          // merely irrelevant — it silently WINS whenever its number happens to
+          // be smaller. 10 AUD beat 200 INR and was then rendered as Rs 10.
+          if (
+            quoteCurrency &&
+            String(price.currency_code).toLowerCase() !== quoteCurrency
+          ) {
+            continue
+          }
+
           manual.push({
             shipping_option_id: so.id,
             name: so.name,

--- a/apps/backend/src/modules/partner-quote/lib/build-quote-view.ts
+++ b/apps/backend/src/modules/partner-quote/lib/build-quote-view.ts
@@ -347,6 +347,10 @@ export async function buildQuoteView(
         })),
         destination_postal_code: String(input.destination_postal_code ?? ""),
         country_code: input.destination_country_code,
+        // Without this the manual options are compared across currencies and
+        // the cheapest NUMBER wins regardless of unit — a 10 AUD European
+        // option beat a rupee rate on a live Mumbai quote.
+        currency_code: input.currency_code,
         carrier: input.carrier,
         store: input.store,
       })

--- a/apps/backend/src/modules/shipping-providers/__tests__/carrier-capabilities.unit.spec.ts
+++ b/apps/backend/src/modules/shipping-providers/__tests__/carrier-capabilities.unit.spec.ts
@@ -1,0 +1,88 @@
+import {
+  CARRIER_CAPABILITIES,
+  capabilitiesCoverSupportedCarriers,
+  findCarrierCapability,
+  groupCarriersByLane,
+} from "../carrier-capabilities"
+import { buildCarrierAvailability } from "../carrier-availability"
+
+describe("carrier capabilities", () => {
+  it("covers every carrier the resolver claims to support", () => {
+    // The two lists drift silently otherwise: a carrier gains a client and the
+    // picker never learns about it.
+    const { ok, missing } = capabilitiesCoverSupportedCarriers()
+    expect(missing).toEqual([])
+    expect(ok).toBe(true)
+  })
+
+  it("keeps RATING and SHIPPING separate — Blue Dart ships both lanes, rates neither", () => {
+    // The whole reason for two axes. Collapsing them would offer Blue Dart as a
+    // live-rate carrier and then quote every lane at the fallback.
+    const bluedart = findCarrierCapability("bluedart")!
+    expect(bluedart.international.can_ship).toBe(true)
+    expect(bluedart.international.can_rate).toBe(false)
+    expect(bluedart.domestic.can_rate).toBe(false)
+  })
+
+  it("records that Delhivery cannot go international at all", () => {
+    const delhivery = findCarrierCapability("delhivery")!
+    expect(delhivery.domestic.can_rate).toBe(true)
+    expect(delhivery.international.can_ship).toBe(false)
+    expect(delhivery.international.can_rate).toBe(false)
+  })
+
+  it("has Shiprocket as the only carrier that rates cross-border", () => {
+    const { international } = groupCarriersByLane()
+    expect(international.rating.map((c) => c.id)).toEqual(["shiprocket"])
+  })
+
+  it("surfaces DTDC as un-integrated rather than hiding it", () => {
+    const dtdc = CARRIER_CAPABILITIES.find((c) => c.id === "dtdc")!
+    expect(dtdc.integrated).toBe(false)
+    expect(groupCarriersByLane().unavailable.map((c) => c.id)).toContain("dtdc")
+  })
+})
+
+describe("buildCarrierAvailability", () => {
+  it("marks a registered+linked carrier enabled, and an unregistered one blocked", () => {
+    const { carriers } = buildCarrierAvailability({
+      registeredProviderIds: ["shiprocket_shiprocket"],
+      linkedProviderIds: ["shiprocket_shiprocket"],
+    })
+
+    const shiprocket = carriers.find((c) => c.id === "shiprocket")!
+    expect(shiprocket.enabled).toBe(true)
+    expect(shiprocket.blocked_reason).toBeNull()
+
+    // Delhivery exists as an adapter but has no credentials on this deployment.
+    const delhivery = carriers.find((c) => c.id === "delhivery")!
+    expect(delhivery.registered).toBe(false)
+    expect(delhivery.enabled).toBe(false)
+    expect(delhivery.blocked_reason).toContain("credentials")
+  })
+
+  it("never lists a blocked carrier as selectable for a lane", () => {
+    // A picker built from these lists cannot offer an unusable row.
+    const { domestic, international } = buildCarrierAvailability({
+      registeredProviderIds: [],
+      linkedProviderIds: [],
+    })
+
+    expect(domestic.rating).toEqual([])
+    expect(domestic.shipping).toEqual([])
+    expect(international.rating).toEqual([])
+  })
+
+  it("distinguishes registered-but-not-linked from linked", () => {
+    const { carriers } = buildCarrierAvailability({
+      registeredProviderIds: ["delhivery_delhivery"],
+      linkedProviderIds: [],
+    })
+
+    const delhivery = carriers.find((c) => c.id === "delhivery")!
+    expect(delhivery.registered).toBe(true)
+    expect(delhivery.enabled).toBe(false)
+    // Registered means selectable — the partner simply has not switched it on.
+    expect(delhivery.blocked_reason).toBeNull()
+  })
+})

--- a/apps/backend/src/modules/shipping-providers/carrier-availability.ts
+++ b/apps/backend/src/modules/shipping-providers/carrier-availability.ts
@@ -1,0 +1,99 @@
+import {
+  CARRIER_CAPABILITIES,
+  CarrierCapability,
+  fulfillmentProviderId,
+  groupCarriersByLane,
+} from "./carrier-capabilities"
+
+/**
+ * "Which carriers can this location actually use, and for which lane?" (#1417)
+ *
+ * Three facts have to meet before a carrier is genuinely available, and each is
+ * held somewhere different:
+ *
+ * 1. **Capability** — can the adapter rate/ship this lane at all
+ *    (`carrier-capabilities.ts`).
+ * 2. **Registration** — is the provider registered in this deployment. Gated on
+ *    credentials in `medusa-config`, so a carrier with no keys never appears.
+ * 3. **Linkage** — is it linked to THIS stock location
+ *    (`stock_location ↔ fulfillment_provider`), which is where a partner's own
+ *    selection already lives.
+ *
+ * 🔑 There is deliberately no new table here. The partner→carrier mapping is
+ * already the location link — a second store of the same fact would drift from
+ * it, and the link is what core consults at fulfilment time regardless of what
+ * any side table said.
+ *
+ * The shape is built PURE so the composition is testable without a container:
+ * the routes fetch the two id lists and hand them in.
+ */
+
+export type CarrierAvailability = CarrierCapability & {
+  /** Registered as a fulfillment provider in this deployment. */
+  registered: boolean
+  /** Linked to the location in question — i.e. this partner selected it. */
+  enabled: boolean
+  /** The Medusa fulfillment-provider id, for add/remove calls. */
+  provider_id: string
+  /**
+   * Why it cannot be turned on right now, if it cannot. Null when selectable.
+   * Surfaced so a greyed-out row in the picker can say WHY rather than just
+   * being unclickable.
+   */
+  blocked_reason: string | null
+}
+
+export function buildCarrierAvailability(args: {
+  /** Fulfillment provider ids registered in this deployment. */
+  registeredProviderIds: string[]
+  /** Fulfillment provider ids linked to this location. */
+  linkedProviderIds: string[]
+  carriers?: CarrierCapability[]
+}): {
+  carriers: CarrierAvailability[]
+  domestic: { rating: string[]; shipping: string[] }
+  international: { rating: string[]; shipping: string[] }
+} {
+  const registered = new Set(args.registeredProviderIds || [])
+  const linked = new Set(args.linkedProviderIds || [])
+  const source = args.carriers ?? CARRIER_CAPABILITIES
+
+  const carriers: CarrierAvailability[] = source.map((capability) => {
+    const providerId = fulfillmentProviderId(capability.id)
+    const isRegistered = registered.has(providerId)
+
+    let blocked: string | null = null
+    if (!capability.integrated) {
+      blocked = `${capability.label} is not integrated yet.`
+    } else if (!isRegistered) {
+      // The commonest real case: the adapter exists but this deployment has no
+      // credentials for it, so the provider was never registered.
+      blocked = `${capability.label} is not configured on this deployment — its credentials are missing.`
+    }
+
+    return {
+      ...capability,
+      provider_id: providerId,
+      registered: isRegistered,
+      enabled: linked.has(providerId),
+      blocked_reason: blocked,
+    }
+  })
+
+  // The lane lists name only carriers that could actually be switched on here,
+  // so a picker built from them cannot offer an unusable row.
+  const selectable = carriers.filter((c) => !c.blocked_reason)
+  const grouped = groupCarriersByLane(selectable)
+
+  return {
+    carriers,
+    domestic: {
+      rating: grouped.domestic.rating.map((c) => c.id),
+      shipping: grouped.domestic.shipping.map((c) => c.id),
+    },
+    international: {
+      rating: grouped.international.rating.map((c) => c.id),
+      shipping: grouped.international.shipping.map((c) => c.id),
+    },
+  }
+}

--- a/apps/backend/src/modules/shipping-providers/carrier-capabilities.ts
+++ b/apps/backend/src/modules/shipping-providers/carrier-capabilities.ts
@@ -1,0 +1,157 @@
+import { SUPPORTED_CARRIERS } from "./resolver"
+
+/**
+ * What each carrier can actually DO, split by lane (#1417).
+ *
+ * ## Why two axes and not one
+ *
+ * "Supports international" is not one fact. A carrier can carry a parcel
+ * abroad and still be unable to PRICE the lane, and the two failures look
+ * nothing alike: an unratable carrier shows the buyer a fallback number, an
+ * unshippable one fails at label time, long after the buyer has paid.
+ *
+ * Blue Dart is exactly that case — it ships domestic AND international (product
+ * code `H`/IPC), but its adapter has no `getRates` at all, so it can never
+ * appear as a calculated option. Collapsing this into a single "supports
+ * international" flag would have offered it as a live-rate carrier and then
+ * quoted every lane at the fallback.
+ *
+ * ## This is derived from the adapters, not aspirational
+ *
+ * Every flag below is what the code in `shipping-providers/<carrier>` actually
+ * implements today, verified against the adapters:
+ *
+ * · **Shiprocket** — rates and ships both lanes. `getRates` branches on the
+ *   destination country into `/international/courier/serviceability`.
+ * · **Delhivery** — domestic only, and it REFUSES international explicitly:
+ *   this integration drives the domestic Express API, while exports run on
+ *   Delhivery Cross Border, a separate service with no rate API. That refusal
+ *   is why Shiprocket is the cross-border rate source for an Indian origin.
+ * · **Blue Dart** — ships both lanes, rates NEITHER (no `getRates`).
+ * · **DTDC** — not integrated. Listed so the gap is visible in the UI rather
+ *   than being a carrier nobody remembers we do not have.
+ *
+ * 🔑 When a carrier gains a capability, this table and the adapter must move
+ * together. A flag set here that the adapter cannot honour is worse than no
+ * flag: it puts a carrier in front of a buyer that cannot complete the job.
+ */
+
+export type CarrierLaneCapability = {
+  /** Can return live rates for this lane (`getRates` handles it). */
+  can_rate: boolean
+  /** Can create a shipment/label for this lane. */
+  can_ship: boolean
+}
+
+export type CarrierCapability = {
+  id: string
+  label: string
+  /** False when there is no adapter at all — surfaced, not hidden. */
+  integrated: boolean
+  /** True when the platform holds the account; false = partner brings keys. */
+  platform_account: boolean
+  domestic: CarrierLaneCapability
+  international: CarrierLaneCapability
+  /** Why a lane is unavailable, when that needs explaining to a human. */
+  notes?: string
+}
+
+export const CARRIER_CAPABILITIES: CarrierCapability[] = [
+  {
+    id: "shiprocket",
+    label: "Shiprocket",
+    integrated: true,
+    platform_account: true,
+    domestic: { can_rate: true, can_ship: true },
+    international: { can_rate: true, can_ship: true },
+    notes:
+      "Rates and ships both lanes. For an Indian origin this is the cross-border rate source, because Delhivery's export product has no rate API.",
+  },
+  {
+    id: "delhivery",
+    label: "Delhivery",
+    integrated: true,
+    platform_account: true,
+    domestic: { can_rate: true, can_ship: true },
+    international: { can_rate: false, can_ship: false },
+    notes:
+      "Domestic (Express) only. International exports run on Delhivery Cross Border — a separate service we have no API access to — so the adapter refuses cross-border rather than failing at label time.",
+  },
+  {
+    id: "bluedart",
+    label: "Blue Dart",
+    integrated: true,
+    platform_account: true,
+    domestic: { can_rate: false, can_ship: true },
+    international: { can_rate: false, can_ship: true },
+    notes:
+      "Ships both lanes (international via product code H/IPC) but cannot quote either — the adapter implements no rate call, so it can only be used as a flat-priced or manually-priced option.",
+  },
+  {
+    id: "dtdc",
+    label: "DTDC",
+    integrated: false,
+    platform_account: false,
+    domestic: { can_rate: false, can_ship: false },
+    international: { can_rate: false, can_ship: false },
+    notes: "Not integrated. No adapter exists yet.",
+  },
+]
+
+/** The Medusa fulfillment-provider id a carrier registers under. */
+export function fulfillmentProviderId(carrierId: string): string {
+  return `${carrierId}_${carrierId}`
+}
+
+export function findCarrierCapability(
+  carrierId?: string | null
+): CarrierCapability | undefined {
+  const id = String(carrierId || "").toLowerCase()
+  return CARRIER_CAPABILITIES.find((c) => c.id === id)
+}
+
+/**
+ * Split the carriers by lane for a picker.
+ *
+ * `rating` and `shipping` are separate lists on purpose — a UI that shows one
+ * combined list has to pick which failure to hide, and both matter. `shipping`
+ * is the superset: a carrier that can rate can always ship, but not the reverse.
+ */
+export function groupCarriersByLane(
+  carriers: CarrierCapability[] = CARRIER_CAPABILITIES
+): {
+  domestic: { rating: CarrierCapability[]; shipping: CarrierCapability[] }
+  international: { rating: CarrierCapability[]; shipping: CarrierCapability[] }
+  unavailable: CarrierCapability[]
+} {
+  const usable = carriers.filter((c) => c.integrated)
+
+  return {
+    domestic: {
+      rating: usable.filter((c) => c.domestic.can_rate),
+      shipping: usable.filter((c) => c.domestic.can_ship),
+    },
+    international: {
+      rating: usable.filter((c) => c.international.can_rate),
+      shipping: usable.filter((c) => c.international.can_ship),
+    },
+    unavailable: carriers.filter((c) => !c.integrated),
+  }
+}
+
+/**
+ * 🔴 Guard: every carrier the resolver claims to support must appear here.
+ *
+ * The two lists drift silently otherwise — a carrier gains a client and the
+ * picker never learns about it, or this table names one the resolver cannot
+ * build. Exported rather than run at import time so it fails a TEST rather than
+ * a boot.
+ */
+export function capabilitiesCoverSupportedCarriers(): {
+  ok: boolean
+  missing: string[]
+} {
+  const known = new Set(CARRIER_CAPABILITIES.map((c) => c.id))
+  const missing = SUPPORTED_CARRIERS.filter((c) => !known.has(c))
+  return { ok: missing.length === 0, missing }
+}

--- a/apps/backend/src/modules/shipping-providers/shiprocket/__tests__/flat-fallback.unit.spec.ts
+++ b/apps/backend/src/modules/shipping-providers/shiprocket/__tests__/flat-fallback.unit.spec.ts
@@ -1,0 +1,86 @@
+import {
+  parseFlatFallbackAmounts,
+  resolveFlatFallbackAmount,
+} from "../flat-fallback"
+
+describe("resolveFlatFallbackAmount", () => {
+  it("prefers the country-specific amount over the catch-all", () => {
+    // A domestic lane and a cross-border one are not the same order of
+    // magnitude; one number for both is wrong in one direction or the other.
+    expect(
+      resolveFlatFallbackAmount(
+        { flat_fallback_amounts: { US: 249000 }, flat_fallback_amount: 9900 },
+        "US"
+      )
+    ).toEqual({ amount: 249000 })
+  })
+
+  it("matches the country case-insensitively", () => {
+    expect(
+      resolveFlatFallbackAmount({ flat_fallback_amounts: { us: 249000 } }, "US")
+        .amount
+    ).toBe(249000)
+  })
+
+  it("falls through to the catch-all for an unlisted country", () => {
+    expect(
+      resolveFlatFallbackAmount(
+        { flat_fallback_amounts: { US: 249000 }, flat_fallback_amount: 9900 },
+        "AE"
+      )
+    ).toEqual({ amount: 9900 })
+  })
+
+  it("honours a configured ZERO instead of treating it as absent", () => {
+    // "This lane is free" is a real answer somebody chose. Only ABSENCE may
+    // fall through — the whole point of this module is that an unchosen 0 and a
+    // chosen 0 must stop being the same value.
+    expect(
+      resolveFlatFallbackAmount({ flat_fallback_amounts: { IN: 0 } }, "IN")
+    ).toEqual({ amount: 0 })
+  })
+
+  it("defaults an absent destination to IN", () => {
+    expect(
+      resolveFlatFallbackAmount({ flat_fallback_amounts: { IN: 9900 } }, undefined)
+        .amount
+    ).toBe(9900)
+  })
+
+  it("refuses — naming the country — when nothing is configured", () => {
+    const { amount, reason } = resolveFlatFallbackAmount({}, "US")
+
+    expect(amount).toBeUndefined()
+    expect(reason).toContain("US")
+  })
+
+  it("refuses when the config itself is absent", () => {
+    expect(resolveFlatFallbackAmount(undefined, "IN").amount).toBeUndefined()
+  })
+})
+
+describe("parseFlatFallbackAmounts", () => {
+  it("parses ISO2=minor-unit pairs", () => {
+    expect(parseFlatFallbackAmounts("IN=9900,US=249000")).toEqual({
+      IN: 9900,
+      US: 249000,
+    })
+  })
+
+  it("uppercases keys and tolerates whitespace", () => {
+    expect(parseFlatFallbackAmounts(" in = 9900 ")).toEqual({ IN: 9900 })
+  })
+
+  it("DROPS malformed pairs rather than coercing them to zero", () => {
+    // A typo that silently became 0 would be the original silent-zero bug with
+    // extra steps. Dropping it surfaces as the loud "nothing configured" error.
+    expect(parseFlatFallbackAmounts("IN=abc,US=249000")).toEqual({ US: 249000 })
+    expect(parseFlatFallbackAmounts("IN=-5")).toBeUndefined()
+    expect(parseFlatFallbackAmounts("IN")).toBeUndefined()
+  })
+
+  it("returns undefined for empty input", () => {
+    expect(parseFlatFallbackAmounts("")).toBeUndefined()
+    expect(parseFlatFallbackAmounts(undefined)).toBeUndefined()
+  })
+})

--- a/apps/backend/src/modules/shipping-providers/shiprocket/__tests__/flat-fallback.unit.spec.ts
+++ b/apps/backend/src/modules/shipping-providers/shiprocket/__tests__/flat-fallback.unit.spec.ts
@@ -1,4 +1,5 @@
 import {
+  DEFAULT_FLAT_FALLBACK,
   parseFlatFallbackAmounts,
   resolveFlatFallbackAmount,
 } from "../flat-fallback"
@@ -47,15 +48,35 @@ describe("resolveFlatFallbackAmount", () => {
     ).toBe(9900)
   })
 
-  it("refuses — naming the country — when nothing is configured", () => {
+  it("falls back to a DEFINED, non-zero default when nothing is configured", () => {
+    // Deliberately not a refusal: no provider in this codebase throws from
+    // calculatePrice, and a throw that propagates takes the whole shipping
+    // options listing with it — leaving the buyer nothing, not even the manual
+    // flat option that exists for exactly this case.
     const { amount, reason } = resolveFlatFallbackAmount({}, "US")
 
-    expect(amount).toBeUndefined()
+    expect(amount).toBe(DEFAULT_FLAT_FALLBACK)
+    expect(amount).toBeGreaterThan(0)
+    // The reason still travels, so the caller can log that this was a default
+    // rather than a chosen number. That log is the only thing separating this
+    // from the silent zero it replaced.
     expect(reason).toContain("US")
   })
 
-  it("refuses when the config itself is absent", () => {
-    expect(resolveFlatFallbackAmount(undefined, "IN").amount).toBeUndefined()
+  it("defaults when the config itself is absent", () => {
+    expect(resolveFlatFallbackAmount(undefined, "IN").amount).toBe(
+      DEFAULT_FLAT_FALLBACK
+    )
+  })
+
+  it("still prefers a CONFIGURED amount over the default", () => {
+    const { amount, reason } = resolveFlatFallbackAmount(
+      { flat_fallback_amount: 777 },
+      "IN"
+    )
+    expect(amount).toBe(777)
+    // No reason: this number was chosen, so there is nothing to warn about.
+    expect(reason).toBeUndefined()
   })
 })
 

--- a/apps/backend/src/modules/shipping-providers/shiprocket/__tests__/rate-context.unit.spec.ts
+++ b/apps/backend/src/modules/shipping-providers/shiprocket/__tests__/rate-context.unit.spec.ts
@@ -1,0 +1,146 @@
+import {
+  deriveShiprocketRateContext,
+  resolveConsignmentDimensions,
+  resolveConsignmentWeightGrams,
+} from "../rate-context"
+
+/**
+ * The defect these guard (#1417): `calculatePrice` required a 6-digit PIN on
+ * BOTH ends and never passed `destination_country`, so every cross-border cart
+ * was quoted 0 — free international shipping, shaped exactly like a real quote.
+ *
+ * 🔑 An assertion that cannot tell success from failure is not a test. The
+ * cross-border cases below assert on `destination_country` being POPULATED, not
+ * merely that a context came back: the old code would have produced a context
+ * too, just a domestic one aimed at the wrong endpoint.
+ */
+
+const ctx = (over: any = {}) => ({
+  from_location: { address: { postal_code: "110001" } },
+  shipping_address: { postal_code: "400001", country_code: "IN" },
+  items: [],
+  ...over,
+})
+
+describe("deriveShiprocketRateContext", () => {
+  it("quotes a domestic lane without a destination country", () => {
+    const { context, reason } = deriveShiprocketRateContext(ctx())
+
+    expect(reason).toBeUndefined()
+    expect(context).toMatchObject({
+      origin_pincode: "110001",
+      destination_pincode: "400001",
+      international: false,
+    })
+    // Must stay undefined domestically — the client reaches for its cross-border
+    // product on the PRESENCE of a foreign country, not on the string "IN".
+    expect(context!.destination_country).toBeUndefined()
+  })
+
+  it("quotes a cross-border lane whose postcode is not a 6-digit PIN", () => {
+    // The regression: "SW1A 1AA" fails /^\d{6}$/, which is exactly how every
+    // international cart used to fall through to a silent 0.
+    const { context, reason } = deriveShiprocketRateContext(
+      ctx({ shipping_address: { postal_code: "SW1A 1AA", country_code: "gb" } })
+    )
+
+    expect(reason).toBeUndefined()
+    expect(context!.international).toBe(true)
+    // Uppercased, because Shiprocket's `delivery_country` expects ISO2 upper.
+    expect(context!.destination_country).toBe("GB")
+  })
+
+  it("quotes a cross-border lane with NO postcode at all", () => {
+    const { context } = deriveShiprocketRateContext(
+      ctx({ shipping_address: { country_code: "AE" } })
+    )
+
+    expect(context!.destination_country).toBe("AE")
+    expect(context!.destination_pincode).toBe("")
+  })
+
+  it("refuses a domestic lane whose destination pincode is malformed", () => {
+    const { context, reason } = deriveShiprocketRateContext(
+      ctx({ shipping_address: { postal_code: "40001", country_code: "IN" } })
+    )
+
+    expect(context).toBeUndefined()
+    expect(reason).toContain("40001")
+  })
+
+  it("treats an absent country as domestic and holds it to the PIN shape", () => {
+    // A missing country must not be quoted as if it were a local lane, and must
+    // not silently take the cross-border branch either.
+    const { context, reason } = deriveShiprocketRateContext(
+      ctx({ shipping_address: { postal_code: "SW1A 1AA" } })
+    )
+
+    expect(context).toBeUndefined()
+    expect(reason).toContain("6-digit")
+  })
+
+  it("refuses when the ORIGIN has no valid pincode, in both modes", () => {
+    for (const shipping_address of [
+      { postal_code: "400001", country_code: "IN" },
+      { postal_code: "SW1A 1AA", country_code: "GB" },
+    ]) {
+      const { context, reason } = deriveShiprocketRateContext(
+        ctx({ from_location: { address: { postal_code: "" } }, shipping_address })
+      )
+
+      // The international endpoint 400s without `pickup_postcode`, so the origin
+      // is required cross-border too — not just domestically.
+      expect(context).toBeUndefined()
+      expect(reason).toContain("pickup location")
+    }
+  })
+})
+
+describe("resolveConsignmentWeightGrams", () => {
+  it("sums variant weight × quantity", () => {
+    expect(
+      resolveConsignmentWeightGrams([
+        { quantity: 2, variant: { weight: 300 } },
+        { quantity: 1, variant: { weight: 150 } },
+      ])
+    ).toBe(750)
+  })
+
+  it("falls back to the PRODUCT weight when the variant has none", () => {
+    // 140 of 183 variants platform-wide carry no weight of their own, so this
+    // is the common path, not the edge case.
+    expect(
+      resolveConsignmentWeightGrams([
+        { quantity: 3, variant: { product: { weight: 100 } } },
+      ])
+    ).toBe(300)
+  })
+
+  it("estimates rather than refusing when nothing carries a weight", () => {
+    // Unlike the quote builder, which refuses: a cart must stay checkout-able.
+    expect(resolveConsignmentWeightGrams([{ quantity: 3, variant: {} }])).toBe(1200)
+    expect(resolveConsignmentWeightGrams([])).toBe(400)
+  })
+})
+
+describe("resolveConsignmentDimensions", () => {
+  it("stacks: widest footprint, summed height — matching createFulfillment", () => {
+    // Deriving the quote box differently from the SHIPMENT box would price a
+    // parcel we never send.
+    expect(
+      resolveConsignmentDimensions([
+        { quantity: 2, variant: { length: 30, width: 20, height: 5 } },
+        { quantity: 1, variant: { length: 10, width: 25, height: 4 } },
+      ])
+    ).toEqual({ length: 30, width: 25, height: 14 })
+  })
+
+  it("returns undefined when no item carries a complete box", () => {
+    // A fabricated box is worse than none: the carrier prices it as fact, and
+    // international couriers charge on volumetric weight.
+    expect(
+      resolveConsignmentDimensions([{ quantity: 1, variant: { length: 30, width: 20 } }])
+    ).toBeUndefined()
+    expect(resolveConsignmentDimensions([])).toBeUndefined()
+  })
+})

--- a/apps/backend/src/modules/shipping-providers/shiprocket/flat-fallback.ts
+++ b/apps/backend/src/modules/shipping-providers/shiprocket/flat-fallback.ts
@@ -1,0 +1,91 @@
+/**
+ * The flat rate a Shiprocket lane falls back to when the carrier will not quote
+ * it (#1417).
+ *
+ * ## Why a fallback at all
+ *
+ * `calculatePrice` used to answer an unquotable lane with `0`. A zero is
+ * indistinguishable from a genuinely free lane, so nothing downstream — not the
+ * cart, not the order, not a report — can tell a carrier outage from a
+ * promotion. It shipped free international freight for as long as it existed.
+ *
+ * The two honest answers are "refuse" and "charge a known flat rate". A refusal
+ * blocks checkout on a carrier hiccup, so this takes the flat rate: the buyer
+ * always gets a number, and it is a number somebody chose.
+ *
+ * ## Why an unconfigured fallback THROWS
+ *
+ * Defaulting the default (to 0, or to some invented amount) reintroduces
+ * exactly the silent-zero bug this replaces. If nobody has said what an
+ * unquotable Indian lane costs, we do not know — and saying so loudly at
+ * checkout is recoverable, whereas shipping thousands of free parcels is not.
+ *
+ * So: configure `flat_fallback_amounts` (or at minimum `flat_fallback_amount`)
+ * and the fallback is silent and cheap; leave it unset and the first carrier
+ * outage tells you, once, in an error naming the country.
+ *
+ * Amounts are MINOR units (paise for INR), matching how Medusa carries money.
+ */
+
+export type FlatFallbackConfig = {
+  /** Per-destination-country minor-unit amounts, keyed by ISO2 (case-insensitive). */
+  flat_fallback_amounts?: Record<string, number>
+  /** Applied when no country-specific amount is configured. */
+  flat_fallback_amount?: number
+}
+
+/**
+ * PURE: pick the fallback amount for a destination, or explain that none is
+ * configured. A country-specific amount always beats the catch-all — a domestic
+ * lane and a cross-border one are not the same order of magnitude, and one
+ * number for both is wrong in one direction or the other.
+ */
+export function resolveFlatFallbackAmount(
+  config: FlatFallbackConfig | undefined,
+  destinationCountry: string | undefined
+): { amount?: number; reason?: string } {
+  const country = String(destinationCountry || "IN").toUpperCase()
+
+  const byCountry = config?.flat_fallback_amounts
+  if (byCountry) {
+    for (const [key, value] of Object.entries(byCountry)) {
+      if (String(key).toUpperCase() !== country) continue
+      // A configured 0 is a real answer — "this lane is free" — and must be
+      // honoured. Only ABSENCE falls through, which is why this checks the
+      // number's validity rather than its truthiness.
+      if (Number.isFinite(Number(value))) return { amount: Number(value) }
+    }
+  }
+
+  const fallback = config?.flat_fallback_amount
+  if (Number.isFinite(Number(fallback))) return { amount: Number(fallback) }
+
+  return {
+    reason: `no flat fallback rate is configured for ${country}. Set \`flat_fallback_amounts\` (or \`flat_fallback_amount\`) on the Shiprocket provider so an unquotable lane has a price instead of silently costing nothing.`,
+  }
+}
+
+/**
+ * Read the fallback config off env, for the medusa-config provider block.
+ *
+ * `SHIPROCKET_FLAT_FALLBACK_AMOUNTS` is `IN=9900,US=249000` — ISO2=minor units,
+ * comma-separated. Malformed pairs are DROPPED rather than coerced: a typo that
+ * silently became 0 would be the original bug with extra steps, and a dropped
+ * pair surfaces as the loud "no flat fallback configured" error.
+ */
+export function parseFlatFallbackAmounts(
+  raw?: string
+): Record<string, number> | undefined {
+  if (!raw?.trim()) return undefined
+
+  const out: Record<string, number> = {}
+  for (const pair of raw.split(",")) {
+    const [country, amount] = pair.split("=").map((s) => s?.trim())
+    if (!country || !amount) continue
+    const parsed = Number(amount)
+    if (!Number.isFinite(parsed) || parsed < 0) continue
+    out[country.toUpperCase()] = parsed
+  }
+
+  return Object.keys(out).length ? out : undefined
+}

--- a/apps/backend/src/modules/shipping-providers/shiprocket/flat-fallback.ts
+++ b/apps/backend/src/modules/shipping-providers/shiprocket/flat-fallback.ts
@@ -52,8 +52,20 @@ export type FlatFallbackConfig = {
  */
 export function resolveFlatFallbackAmount(
   config: FlatFallbackConfig | undefined,
-  destinationCountry: string | undefined
+  destinationCountry: string | undefined,
+  /**
+   * The shipping option's own `data` blob. This is the FIRST place we look,
+   * because it is the only per-store lever: `create-store-with-defaults` stamps
+   * the same amount here that it prices the manual companion option at, so when
+   * the carrier will not quote, the manual provider's number is literally what
+   * takes over — not a constant that merely happens to match. An operator
+   * editing the flat option's price can edit this alongside it.
+   */
+  optionData?: Record<string, unknown>
 ): { amount?: number; reason?: string } {
+  const fromOption = Number((optionData as any)?.flat_fallback_amount)
+  if (Number.isFinite(fromOption)) return { amount: fromOption }
+
   const country = String(destinationCountry || "IN").toUpperCase()
 
   const byCountry = config?.flat_fallback_amounts

--- a/apps/backend/src/modules/shipping-providers/shiprocket/flat-fallback.ts
+++ b/apps/backend/src/modules/shipping-providers/shiprocket/flat-fallback.ts
@@ -13,22 +13,32 @@
  * blocks checkout on a carrier hiccup, so this takes the flat rate: the buyer
  * always gets a number, and it is a number somebody chose.
  *
- * ## Why an unconfigured fallback THROWS
+ * ## Why an unconfigured fallback does NOT throw
  *
- * Defaulting the default (to 0, or to some invented amount) reintroduces
- * exactly the silent-zero bug this replaces. If nobody has said what an
- * unquotable Indian lane costs, we do not know — and saying so loudly at
- * checkout is recoverable, whereas shipping thousands of free parcels is not.
+ * An earlier cut of this threw when nothing was configured, on the reasoning
+ * that a defaulted default reintroduces the silent zero. Refuting fact: NO
+ * provider in this codebase throws from `calculatePrice` — Delhivery, live in
+ * production today, returns 0 on both a bad pincode and a carrier error. So a
+ * throw here has no precedent, and if it propagates it takes the WHOLE shipping
+ * options listing with it, leaving the buyer no options at all — including the
+ * manual flat one that exists precisely for this case. That is strictly worse
+ * than what it replaced.
  *
- * So: configure `flat_fallback_amounts` (or at minimum `flat_fallback_amount`)
- * and the fallback is silent and cheap; leave it unset and the first carrier
- * outage tells you, once, in an error naming the country.
+ * `DEFAULT_FLAT_FALLBACK` is the compromise: a real, non-zero, LOGGED amount
+ * matching the flat companion option `create-store-with-defaults` provisions, so
+ * behaviour is defined with no configuration at all. It is not the silent zero —
+ * it is distinguishable from a free lane and it announces itself in the log.
+ * Override per-country when the real numbers are known.
  *
- * Amounts are MINOR units (paise for INR), matching how Medusa carries money.
+ * Amounts are in the store's own price units (rupees for INR), matching what
+ * the carrier returns and what the flat companion option is priced in.
  */
 
+/** Matches the flat companion option provisioned by create-store-with-defaults. */
+export const DEFAULT_FLAT_FALLBACK = 200
+
 export type FlatFallbackConfig = {
-  /** Per-destination-country minor-unit amounts, keyed by ISO2 (case-insensitive). */
+  /** Per-destination-country amounts in store price units, keyed by ISO2 (case-insensitive). */
   flat_fallback_amounts?: Record<string, number>
   /** Applied when no country-specific amount is configured. */
   flat_fallback_amount?: number
@@ -60,15 +70,18 @@ export function resolveFlatFallbackAmount(
   const fallback = config?.flat_fallback_amount
   if (Number.isFinite(Number(fallback))) return { amount: Number(fallback) }
 
+  // Defined, non-zero and logged by the caller. See the header for why this is
+  // a default rather than a refusal.
   return {
-    reason: `no flat fallback rate is configured for ${country}. Set \`flat_fallback_amounts\` (or \`flat_fallback_amount\`) on the Shiprocket provider so an unquotable lane has a price instead of silently costing nothing.`,
+    amount: DEFAULT_FLAT_FALLBACK,
+    reason: `no flat fallback is configured for ${country}; used the default ${DEFAULT_FLAT_FALLBACK}`,
   }
 }
 
 /**
  * Read the fallback config off env, for the medusa-config provider block.
  *
- * `SHIPROCKET_FLAT_FALLBACK_AMOUNTS` is `IN=9900,US=249000` — ISO2=minor units,
+ * `SHIPROCKET_FLAT_FALLBACK_AMOUNTS` is `IN=200,US=3200` — ISO2=amount in store price units,
  * comma-separated. Malformed pairs are DROPPED rather than coerced: a typo that
  * silently became 0 would be the original bug with extra steps, and a dropped
  * pair surfaces as the loud "no flat fallback configured" error.

--- a/apps/backend/src/modules/shipping-providers/shiprocket/rate-context.ts
+++ b/apps/backend/src/modules/shipping-providers/shiprocket/rate-context.ts
@@ -1,0 +1,189 @@
+import { isInternationalDestination } from "../destination"
+import type { Dimensions } from "../provider-interface"
+
+/**
+ * Turn Medusa's `calculatePrice` context into a carrier rate query — PURE, so
+ * the rule that decides a buyer's freight is testable without a container, a
+ * cart or a live Shiprocket account (#1417).
+ *
+ * ## Why this exists
+ *
+ * `ShiprocketFulfillmentService.calculatePrice` derived all of this inline and
+ * got two things wrong in a way nothing could see:
+ *
+ * 1. It required a **6-digit PIN on both ends**. A foreign postcode never
+ *    matches, so every cross-border cart fell straight into the catch-all and
+ *    was quoted **0** — free shipping, wearing the same shape as a real quote.
+ * 2. It never passed `destination_country`, so even a lane that *did* pass the
+ *    regex went to the domestic `/courier/serviceability` endpoint, which
+ *    answers a foreign destination with an empty courier list and calls that
+ *    success.
+ *
+ * The order-level rate workflow (`workflows/orders/shiprocket-rates.ts`) has
+ * had this right for a while — it branches on the destination country and lets
+ * a cross-border quote through without a pincode. This brings the cart path
+ * onto the same rule instead of leaving two freight derivations to disagree.
+ *
+ * ## The asymmetry is deliberate
+ *
+ * Domestic serviceability genuinely needs the delivery pincode. A cross-border
+ * quote is priced on destination COUNTRY + weight, so a missing/foreign postal
+ * code must not block it — but the ORIGIN pincode is required in both modes
+ * (Shiprocket's international endpoint 400s without `pickup_postcode`).
+ */
+
+export type ShiprocketRateContext = {
+  origin_pincode: string
+  destination_pincode: string
+  destination_country?: string
+  weight_grams: number
+  dimensions_cm?: Dimensions
+  international: boolean
+}
+
+/** Shiprocket's own pincode shape. Indian PINs are exactly six digits. */
+const isIndianPincode = (value: string): boolean => /^\d{6}$/.test(value)
+
+/**
+ * The weight a consignment is quoted at.
+ *
+ * Unlike `buildShippingEstimate` — which REFUSES when no weight exists, because
+ * a quote is a number a buyer decides on — a cart must still be checkout-able,
+ * so this estimates. That difference is intentional and is the same split the
+ * order-83 fulfilment path already makes.
+ *
+ * 🔑 140 of 183 variants platform-wide carry no weight at either level, so the
+ * estimate branch is the COMMON path here, not the edge case.
+ */
+export function resolveConsignmentWeightGrams(items: any[]): number {
+  let totalWeight = 0
+  let totalQty = 0
+  let hasWeight = false
+
+  for (const item of items || []) {
+    const qty = Number(item?.quantity) || 1
+    totalQty += qty
+    // A variant with no weight of its own inherits the PRODUCT's — the same
+    // fallback `resolveUnitWeight` makes for the quote builder. Without it a
+    // basket of product-weighted variants quotes as if it were weightless.
+    const unit =
+      Number(item?.variant?.weight) || Number(item?.variant?.product?.weight) || 0
+    if (unit > 0) {
+      hasWeight = true
+      totalWeight += unit * qty
+    }
+  }
+
+  if (!hasWeight) return Math.max(400, totalQty * 400)
+  return totalWeight
+}
+
+/**
+ * The consignment's box.
+ *
+ * Dimensions are NOT cosmetic on a cross-border quote — international couriers
+ * price on VOLUMETRIC weight and the size also decides who will carry it at all
+ * (live-verified: 60×50×40 dropped a lane from 5 couriers to 2 and ₹3119 to
+ * ₹8477). Quoting without them understates the price and offers couriers that
+ * cannot take the parcel.
+ *
+ * 🔑 The stacking rule — widest footprint, summed height — is NOT a fresh
+ * invention: it is exactly what `createFulfillment` in this same service already
+ * does when it hands a parcel to the carrier. Deriving the quote box differently
+ * from the shipment box would price a parcel we never send, which is the same
+ * class of defect as having two freight paths that disagree.
+ *
+ * All-or-nothing per item, mirroring `parseRateQuery`: a partial box (length but
+ * no height) cannot be turned into a volume, and inventing the missing side
+ * would silently change the price. When NO item carries a full box we return
+ * undefined and let the carrier price on weight alone — a fabricated box is
+ * worse than no box, because the carrier would price it as fact.
+ */
+export function resolveConsignmentDimensions(
+  items: any[]
+): Dimensions | undefined {
+  let maxLength = 0
+  let maxWidth = 0
+  let totalHeight = 0
+
+  for (const item of items || []) {
+    const v = item?.variant
+    const length = Number(v?.length)
+    const width = Number(v?.width)
+    const height = Number(v?.height)
+    if (!(length > 0) || !(width > 0) || !(height > 0)) continue
+
+    const qty = Number(item?.quantity) || 1
+    if (length > maxLength) maxLength = length
+    if (width > maxWidth) maxWidth = width
+    totalHeight += height * qty
+  }
+
+  if (!(maxLength > 0) || !(maxWidth > 0) || !(totalHeight > 0)) return undefined
+  return { length: maxLength, width: maxWidth, height: totalHeight }
+}
+
+/**
+ * Derive the rate query, or explain why the lane cannot be quoted.
+ *
+ * Returns `{ context }` when quotable and `{ reason }` when not. It does NOT
+ * throw: the caller decides what an unquotable lane costs, and that decision
+ * (flat fallback vs. refusal) is policy, not derivation.
+ */
+export function deriveShiprocketRateContext(context: any): {
+  context?: ShiprocketRateContext
+  reason?: string
+} {
+  const originPincode = String(
+    context?.from_location?.address?.postal_code || ""
+  ).trim()
+  const destinationPincode = String(
+    context?.shipping_address?.postal_code || ""
+  ).trim()
+  const destinationCountry = String(
+    context?.shipping_address?.country_code || ""
+  )
+    .trim()
+    .toUpperCase()
+
+  const international = isInternationalDestination(destinationCountry)
+
+  // Required in BOTH modes — the international endpoint 400s without a
+  // `pickup_postcode`, so sending one we know is missing just buys a slower no.
+  if (!isIndianPincode(originPincode)) {
+    return {
+      reason:
+        "the pickup location has no valid 6-digit pincode, so Shiprocket cannot be asked for a rate",
+    }
+  }
+
+  // Domestic serviceability is keyed on the delivery pincode; cross-border is
+  // keyed on the country, and a foreign postal code is not six digits by
+  // design. Only enforce the shape where it is actually the lookup key.
+  //
+  // An ABSENT country counts as domestic (`isInternationalDestination("")` is
+  // false), so it lands here and is held to the Indian pincode shape — which is
+  // the right refusal: we would otherwise quote a cross-border lane as if it
+  // were local.
+  if (!international && !isIndianPincode(destinationPincode)) {
+    return {
+      reason: `the destination pincode "${destinationPincode}" is not a valid 6-digit Indian pincode`,
+    }
+  }
+
+  const items = (context?.items || []) as any[]
+
+  return {
+    context: {
+      origin_pincode: originPincode,
+      destination_pincode: destinationPincode,
+      // Domestic stays undefined so the client keeps its existing branch: it
+      // reaches for the cross-border product on the presence of a foreign
+      // country, not on the string "IN".
+      destination_country: international ? destinationCountry : undefined,
+      weight_grams: resolveConsignmentWeightGrams(items),
+      dimensions_cm: resolveConsignmentDimensions(items),
+      international,
+    },
+  }
+}

--- a/apps/backend/src/modules/shipping-providers/shiprocket/service.ts
+++ b/apps/backend/src/modules/shipping-providers/shiprocket/service.ts
@@ -84,7 +84,7 @@ class ShiprocketFulfillmentService extends AbstractFulfillmentProviderService {
    * replaced.
    */
   async calculatePrice(
-    _optionData: Record<string, unknown>,
+    optionData: Record<string, unknown>,
     _data: Record<string, unknown>,
     context: any
   ): Promise<CalculatedShippingOptionPrice> {
@@ -94,7 +94,7 @@ class ShiprocketFulfillmentService extends AbstractFulfillmentProviderService {
     ).toUpperCase()
 
     if (!derived.context) {
-      return this.flatFallback(destinationCountry, derived.reason!)
+      return this.flatFallback(destinationCountry, derived.reason!, optionData)
     }
 
     const rateContext = derived.context
@@ -119,7 +119,8 @@ class ShiprocketFulfillmentService extends AbstractFulfillmentProviderService {
           destinationCountry,
           `Shiprocket returned no courier for ${rateContext.origin_pincode} → ${
             rateContext.destination_country || rateContext.destination_pincode
-          }`
+          }`,
+          optionData
         )
       }
 
@@ -129,7 +130,7 @@ class ShiprocketFulfillmentService extends AbstractFulfillmentProviderService {
       }
     } catch (e: any) {
       this.logger.error(`Shiprocket calculatePrice error: ${e.message}`)
-      return this.flatFallback(destinationCountry, e.message)
+      return this.flatFallback(destinationCountry, e.message, optionData)
     }
   }
 
@@ -144,11 +145,13 @@ class ShiprocketFulfillmentService extends AbstractFulfillmentProviderService {
    */
   private flatFallback(
     destinationCountry: string,
-    reason: string
+    reason: string,
+    optionData?: Record<string, unknown>
   ): CalculatedShippingOptionPrice {
     const { amount, reason: unconfigured } = resolveFlatFallbackAmount(
       this.fallbackConfig,
-      destinationCountry
+      destinationCountry,
+      optionData
     )
 
     this.logger.warn(

--- a/apps/backend/src/modules/shipping-providers/shiprocket/service.ts
+++ b/apps/backend/src/modules/shipping-providers/shiprocket/service.ts
@@ -1,4 +1,7 @@
-import { AbstractFulfillmentProviderService } from "@medusajs/framework/utils"
+import {
+  AbstractFulfillmentProviderService,
+  MedusaError,
+} from "@medusajs/framework/utils"
 import {
   CreateFulfillmentResult,
   FulfillmentOption,
@@ -11,6 +14,8 @@ import {
 } from "@medusajs/framework/types"
 import { ShiprocketClient, ShiprocketOptions } from "./client"
 import { CreateShipmentInput, ShipmentItem } from "../provider-interface"
+import { deriveShiprocketRateContext } from "./rate-context"
+import { FlatFallbackConfig, resolveFlatFallbackAmount } from "./flat-fallback"
 
 type InjectedDeps = { logger: Logger }
 
@@ -28,11 +33,20 @@ class ShiprocketFulfillmentService extends AbstractFulfillmentProviderService {
 
   protected client: ShiprocketClient
   protected logger: Logger
+  /** What an unquotable lane costs. See `flat-fallback.ts`. */
+  protected fallbackConfig: FlatFallbackConfig
 
-  constructor({ logger }: InjectedDeps, options: ShiprocketOptions) {
+  constructor(
+    { logger }: InjectedDeps,
+    options: ShiprocketOptions & FlatFallbackConfig
+  ) {
     super()
     this.logger = logger
     this.client = new ShiprocketClient(options)
+    this.fallbackConfig = {
+      flat_fallback_amounts: options?.flat_fallback_amounts,
+      flat_fallback_amount: options?.flat_fallback_amount,
+    }
   }
 
   async getFulfillmentOptions(): Promise<FulfillmentOption[]> {
@@ -58,46 +72,104 @@ class ShiprocketFulfillmentService extends AbstractFulfillmentProviderService {
     return true
   }
 
+  /**
+   * Price the cart's lane (#1417).
+   *
+   * Domestic AND international. The derivation lives in `deriveShiprocketRateContext`
+   * (pure, unit-tested) and the client already branches on `destination_country`
+   * into the `/international/*` endpoint — this method's job is only to ask, and
+   * to decide what an unquotable lane costs.
+   *
+   * 🔴 It no longer answers `0`. Every path that cannot produce a live rate —
+   * an underivable lane, a carrier error, an empty courier list — resolves to
+   * the configured flat fallback, and if none is configured it THROWS naming the
+   * country. See `flat-fallback.ts` for why a defaulted default is not an option.
+   */
   async calculatePrice(
     _optionData: Record<string, unknown>,
     _data: Record<string, unknown>,
     context: any
   ): Promise<CalculatedShippingOptionPrice> {
+    const derived = deriveShiprocketRateContext(context)
+    const destinationCountry = String(
+      context?.shipping_address?.country_code || ""
+    ).toUpperCase()
+
+    if (!derived.context) {
+      return this.flatFallbackOrThrow(destinationCountry, derived.reason!)
+    }
+
+    const rateContext = derived.context
+
     try {
-      const originPin = String(context?.from_location?.address?.postal_code || "")
-      const destPin = String(context?.shipping_address?.postal_code || "")
-      const isValidPin = (p: string) => /^\d{6}$/.test(p)
-      if (!isValidPin(originPin) || !isValidPin(destPin)) {
-        return { calculated_amount: 0, is_calculated_price_tax_inclusive: false }
-      }
-
-      const items = (context?.items || []) as any[]
-      let totalWeight = 0
-      let totalQty = 0
-      let hasWeight = false
-      for (const item of items) {
-        const qty = item.quantity || 1
-        totalQty += qty
-        if (item.variant?.weight) {
-          hasWeight = true
-          totalWeight += item.variant.weight * qty
-        }
-      }
-      if (!hasWeight) totalWeight = Math.max(400, totalQty * 400)
-
       const rates = await this.client.getRates({
-        origin_pincode: originPin,
-        destination_pincode: destPin,
-        weight_grams: totalWeight,
+        origin_pincode: rateContext.origin_pincode,
+        destination_pincode: rateContext.destination_pincode,
+        destination_country: rateContext.destination_country,
+        weight_grams: rateContext.weight_grams,
+        dimensions_cm: rateContext.dimensions_cm,
       })
+
       const recommended = rates.find((r) => r.is_recommended) || rates[0]
+
+      // An EMPTY courier list is a refusal wearing a 200 — it is how the
+      // domestic endpoint answers a lane it will not carry. Treating it as a
+      // successful quote of 0 is precisely the bug this method used to have, so
+      // it falls back like any other failure.
+      if (!recommended || !Number.isFinite(Number(recommended.amount))) {
+        return this.flatFallbackOrThrow(
+          destinationCountry,
+          `Shiprocket returned no courier for ${rateContext.origin_pincode} → ${
+            rateContext.destination_country || rateContext.destination_pincode
+          }`
+        )
+      }
+
       return {
-        calculated_amount: recommended?.amount || 0,
+        calculated_amount: Number(recommended.amount),
         is_calculated_price_tax_inclusive: true,
       }
     } catch (e: any) {
       this.logger.error(`Shiprocket calculatePrice error: ${e.message}`)
-      return { calculated_amount: 0, is_calculated_price_tax_inclusive: false }
+      return this.flatFallbackOrThrow(destinationCountry, e.message)
+    }
+  }
+
+  /**
+   * The flat rate, or a loud refusal when nobody has configured one.
+   *
+   * The `reason` is logged rather than returned: the buyer must not be shown a
+   * carrier's internal complaint, but an operator needs to know the lane fell
+   * back rather than quoting live — otherwise a carrier outage looks exactly
+   * like normal pricing.
+   */
+  private flatFallbackOrThrow(
+    destinationCountry: string,
+    reason: string
+  ): CalculatedShippingOptionPrice {
+    const { amount, reason: unconfigured } = resolveFlatFallbackAmount(
+      this.fallbackConfig,
+      destinationCountry
+    )
+
+    if (amount === undefined) {
+      throw new MedusaError(
+        MedusaError.Types.NOT_ALLOWED,
+        `Shiprocket could not quote this shipment (${reason}), and ${unconfigured}`
+      )
+    }
+
+    this.logger.warn(
+      `[shiprocket] falling back to the flat rate ${amount} for ${
+        destinationCountry || "IN"
+      } — ${reason}`
+    )
+
+    return {
+      calculated_amount: amount,
+      // A flat rate is a figure WE set, so it carries no carrier tax treatment
+      // to inherit. Claiming tax-inclusive here would quietly shrink it.
+      is_calculated_price_tax_inclusive: false,
     }
   }
 

--- a/apps/backend/src/modules/shipping-providers/shiprocket/service.ts
+++ b/apps/backend/src/modules/shipping-providers/shiprocket/service.ts
@@ -1,7 +1,4 @@
-import {
-  AbstractFulfillmentProviderService,
-  MedusaError,
-} from "@medusajs/framework/utils"
+import { AbstractFulfillmentProviderService } from "@medusajs/framework/utils"
 import {
   CreateFulfillmentResult,
   FulfillmentOption,
@@ -81,9 +78,10 @@ class ShiprocketFulfillmentService extends AbstractFulfillmentProviderService {
    * to decide what an unquotable lane costs.
    *
    * 🔴 It no longer answers `0`. Every path that cannot produce a live rate —
-   * an underivable lane, a carrier error, an empty courier list — resolves to
-   * the configured flat fallback, and if none is configured it THROWS naming the
-   * country. See `flat-fallback.ts` for why a defaulted default is not an option.
+   * an underivable lane, a carrier error, an empty courier list — resolves to a
+   * flat fallback: the configured one, else a defined non-zero default. It never
+   * throws; see `flat-fallback.ts` for why a throw here is worse than what it
+   * replaced.
    */
   async calculatePrice(
     _optionData: Record<string, unknown>,
@@ -96,7 +94,7 @@ class ShiprocketFulfillmentService extends AbstractFulfillmentProviderService {
     ).toUpperCase()
 
     if (!derived.context) {
-      return this.flatFallbackOrThrow(destinationCountry, derived.reason!)
+      return this.flatFallback(destinationCountry, derived.reason!)
     }
 
     const rateContext = derived.context
@@ -117,7 +115,7 @@ class ShiprocketFulfillmentService extends AbstractFulfillmentProviderService {
       // successful quote of 0 is precisely the bug this method used to have, so
       // it falls back like any other failure.
       if (!recommended || !Number.isFinite(Number(recommended.amount))) {
-        return this.flatFallbackOrThrow(
+        return this.flatFallback(
           destinationCountry,
           `Shiprocket returned no courier for ${rateContext.origin_pincode} → ${
             rateContext.destination_country || rateContext.destination_pincode
@@ -131,19 +129,20 @@ class ShiprocketFulfillmentService extends AbstractFulfillmentProviderService {
       }
     } catch (e: any) {
       this.logger.error(`Shiprocket calculatePrice error: ${e.message}`)
-      return this.flatFallbackOrThrow(destinationCountry, e.message)
+      return this.flatFallback(destinationCountry, e.message)
     }
   }
 
   /**
-   * The flat rate, or a loud refusal when nobody has configured one.
+   * The flat rate for a lane the carrier would not quote.
    *
    * The `reason` is logged rather than returned: the buyer must not be shown a
    * carrier's internal complaint, but an operator needs to know the lane fell
    * back rather than quoting live — otherwise a carrier outage looks exactly
-   * like normal pricing.
+   * like normal pricing. 🔑 That log line is the ONLY thing separating this from
+   * the silent zero it replaced, so it must never be dropped to reduce noise.
    */
-  private flatFallbackOrThrow(
+  private flatFallback(
     destinationCountry: string,
     reason: string
   ): CalculatedShippingOptionPrice {
@@ -152,21 +151,14 @@ class ShiprocketFulfillmentService extends AbstractFulfillmentProviderService {
       destinationCountry
     )
 
-    if (amount === undefined) {
-      throw new MedusaError(
-        MedusaError.Types.NOT_ALLOWED,
-        `Shiprocket could not quote this shipment (${reason}), and ${unconfigured}`
-      )
-    }
-
     this.logger.warn(
       `[shiprocket] falling back to the flat rate ${amount} for ${
         destinationCountry || "IN"
-      } — ${reason}`
+      } — ${reason}${unconfigured ? ` (${unconfigured})` : ""}`
     )
 
     return {
-      calculated_amount: amount,
+      calculated_amount: amount!,
       // A flat rate is a figure WE set, so it carries no carrier tax treatment
       // to inherit. Claiming tax-inclusive here would quietly shrink it.
       is_calculated_price_tax_inclusive: false,

--- a/apps/backend/src/workflows/stores/create-store-with-defaults.ts
+++ b/apps/backend/src/workflows/stores/create-store-with-defaults.ts
@@ -656,6 +656,11 @@ const autoLinkFulfillmentProvidersStep = createStep(
               `(${isCarrier ? `calculated/${providerId}` : "flat tiered/manual"})`
             )
 
+            // The flat rate a lane falls back to, in the store's own price
+            // units. One constant so the manual companion option and the
+            // Shiprocket option's `data.flat_fallback_amount` cannot drift.
+            const FLAT_FALLBACK_AMOUNT = 200
+
             // --- Shiprocket, alongside Delhivery (#1417) ---------------------
             //
             // Shiprocket was ALREADY linked to every IN stock location above and
@@ -682,6 +687,12 @@ const autoLinkFulfillmentProvidersStep = createStep(
                     shipping_profile_id: profileId,
                     provider_id: "shiprocket_shiprocket",
                     price_type: "calculated",
+                    // What this option costs when Shiprocket will not quote the
+                    // lane. Stamped here — the same number the manual companion
+                    // below is priced at — so the fallback IS the manual
+                    // provider's price rather than a constant that happens to
+                    // match it. Editable per store alongside that option.
+                    data: { flat_fallback_amount: FLAT_FALLBACK_AMOUNT },
                     type: {
                       label: "Standard",
                       description: "Standard delivery via Shiprocket — live rates",
@@ -710,7 +721,12 @@ const autoLinkFulfillmentProvidersStep = createStep(
                       description: "Flat-rate delivery — used when no carrier will quote",
                       code: `flat-fallback-${suffix}`,
                     },
-                    prices: [{ currency_code: input.currencyCode.toLowerCase(), amount: 200 }],
+                    prices: [
+                      {
+                        currency_code: input.currencyCode.toLowerCase(),
+                        amount: FLAT_FALLBACK_AMOUNT,
+                      },
+                    ],
                     rules: [
                       { attribute: "enabled_in_store", value: "true", operator: "eq" },
                       { attribute: "is_return", value: "false", operator: "eq" },

--- a/apps/backend/src/workflows/stores/create-store-with-defaults.ts
+++ b/apps/backend/src/workflows/stores/create-store-with-defaults.ts
@@ -637,6 +637,80 @@ const autoLinkFulfillmentProvidersStep = createStep(
               `(${isDelhivery ? "calculated/Delhivery" : "flat tiered/manual"})`
             )
 
+            // --- Shiprocket, alongside Delhivery (#1417) ---------------------
+            //
+            // Shiprocket was ALREADY linked to every IN stock location above and
+            // registered as a fulfillment provider in both configs — but no
+            // shipping option was ever created for it, because `providerMap`
+            // hardcodes `in -> delhivery_delhivery`. So it was provisioned and
+            // invisible: a carrier the store could not actually pick.
+            //
+            // 🔑 The flat companion is the point of this block, not a nicety. An
+            // IN store's domestic zone carried ONLY calculated options, and
+            // `buildShippingEstimate` skips calculated options when assembling
+            // its manual list — so the store's entire quote freight rested on one
+            // live rate call with no fallback, and a carrier hiccup 400'd the
+            // whole mint. A flat option gives that path something to fall back to.
+            if (
+              countryLower === "in" &&
+              enabledIds.includes("shiprocket_shiprocket")
+            ) {
+              try {
+                await createShippingOptionsWorkflow(container).run({
+                  input: [{
+                    name: "Standard Shipping (Shiprocket)",
+                    service_zone_id: serviceZone.id,
+                    shipping_profile_id: profileId,
+                    provider_id: "shiprocket_shiprocket",
+                    price_type: "calculated",
+                    type: {
+                      label: "Standard",
+                      description: "Standard delivery via Shiprocket — live rates",
+                      code: `shiprocket-standard-${suffix}`,
+                    },
+                    rules: [
+                      { attribute: "enabled_in_store", value: "true", operator: "eq" },
+                      { attribute: "is_return", value: "false", operator: "eq" },
+                    ],
+                  }] as any,
+                })
+
+                await createShippingOptionsWorkflow(container).run({
+                  input: [{
+                    name: "Standard Shipping (Flat)",
+                    service_zone_id: serviceZone.id,
+                    shipping_profile_id: profileId,
+                    // Deliberately `manual_manual`, not Shiprocket: this option
+                    // exists FOR the case where no carrier will quote, so routing
+                    // it through a carrier would reintroduce the dependency it is
+                    // meant to remove.
+                    provider_id: "manual_manual",
+                    price_type: "flat",
+                    type: {
+                      label: "Standard (Flat)",
+                      description: "Flat-rate delivery — used when no carrier will quote",
+                      code: `flat-fallback-${suffix}`,
+                    },
+                    prices: [{ currency_code: input.currencyCode.toLowerCase(), amount: 200 }],
+                    rules: [
+                      { attribute: "enabled_in_store", value: "true", operator: "eq" },
+                      { attribute: "is_return", value: "false", operator: "eq" },
+                    ],
+                  }] as any,
+                })
+
+                console.log(
+                  `[create-store] Created Shiprocket calculated + flat fallback options`
+                )
+              } catch (srErr: any) {
+                // Best-effort, like every other carrier block here: a store with
+                // Delhivery options is still a usable store.
+                console.error(
+                  `[create-store] Failed to create Shiprocket options: ${srErr.message}`
+                )
+              }
+            }
+
             // --- International coverage (mirrors the #954 DP backfill) --------
             // Add an "International" zone covering every OTHER region's countries
             // so a new storefront can sell cross-border out of the box — a manual
@@ -746,9 +820,53 @@ const autoLinkFulfillmentProvidersStep = createStep(
                   })
                 }
 
+                // Shiprocket cross-border, for IN-origin stores (#1417).
+                //
+                // 🔑 For an Indian origin, Shiprocket IS the cross-border rate
+                // source — Delhivery's cross-border product ("Starfleet") has no
+                // rate API at all, and DHL only appears when its own carrier is
+                // enabled. Without this the international zone offered an IN
+                // store nothing but the hand-set manual placeholder.
+                //
+                // The client already branches to `/international/courier/serviceability`
+                // on the destination country, and `calculatePrice` now passes that
+                // country through — before #1417 it did not, so this option would
+                // have quoted every foreign cart via the India-only endpoint and
+                // been answered with an empty courier list.
+                if (
+                  countryLower === "in" &&
+                  enabledIds.includes("shiprocket_shiprocket")
+                ) {
+                  await createShippingOptionsWorkflow(container).run({
+                    input: [
+                      {
+                        name: `International Shipping (Shiprocket) (${suffix})`,
+                        price_type: "calculated",
+                        provider_id: "shiprocket_shiprocket",
+                        service_zone_id: intlZone.id,
+                        shipping_profile_id: profileId,
+                        type: {
+                          label: "International",
+                          description: "Cross-border delivery via Shiprocket — live rates",
+                          code: `shiprocket-international-${suffix}`,
+                        },
+                        rules: [
+                          { attribute: "enabled_in_store", value: "true", operator: "eq" },
+                          { attribute: "is_return", value: "false", operator: "eq" },
+                        ],
+                      },
+                    ] as any,
+                  })
+                }
+
                 console.log(
                   `[create-store] Created International zone (${intlCountries.size} countries) ` +
-                    `+ manual${dhlEnabled ? " + DHL" : ""} option(s)`
+                    `+ manual${dhlEnabled ? " + DHL" : ""}${
+                      countryLower === "in" &&
+                      enabledIds.includes("shiprocket_shiprocket")
+                        ? " + Shiprocket"
+                        : ""
+                    } option(s)`
                 )
               }
             } catch (intlErr: any) {

--- a/apps/backend/src/workflows/stores/create-store-with-defaults.ts
+++ b/apps/backend/src/workflows/stores/create-store-with-defaults.ts
@@ -493,17 +493,36 @@ const autoLinkFulfillmentProvidersStep = createStep(
           }
 
           if (profileId) {
-            // Determine provider and currency-specific pricing
-            const providerMap: Record<string, string> = {
-              in: "delhivery_delhivery",
+            // Determine provider and currency-specific pricing.
+            //
+            // The primary carrier per country, in PREFERENCE order — the first
+            // one actually registered wins. It used to be a bare
+            // `{ in: "delhivery_delhivery" }`, which meant a store whose
+            // Delhivery credentials were absent still got a Delhivery option
+            // (and no other), so its only calculated carrier was one that could
+            // never answer. Preferring a registered carrier makes the map
+            // describe what the store CAN ship on rather than what we hoped.
+            //
+            // Shiprocket sits second rather than first only because Delhivery is
+            // the incumbent on live IN stores; both get an option either way —
+            // the Shiprocket block further down adds its own regardless, so this
+            // ordering decides the "Standard Shipping" default, not availability.
+            const providerPreference: Record<string, string[]> = {
+              in: ["delhivery_delhivery", "shiprocket_shiprocket"],
             }
-            const providerId = providerMap[countryLower] || "manual_manual"
+            const providerId =
+              (providerPreference[countryLower] || []).find((id) =>
+                enabledIds.includes(id)
+              ) || "manual_manual"
 
-            // For Delhivery (calculated pricing) — Delhivery's API returns real-time rates
-            // For manual provider — use flat tiered pricing based on country/currency
-            const isDelhivery = providerId === "delhivery_delhivery"
+            // A real carrier prices via calculatePrice (live rates); the manual
+            // provider cannot, so it gets flat tiered pricing instead. Keyed on
+            // "is this a carrier" rather than on Delhivery's id specifically,
+            // so adding a carrier to the preference list above does not silently
+            // fall through to the manual branch.
+            const isCarrier = providerId !== "manual_manual"
 
-            if (isDelhivery) {
+            if (isCarrier) {
               // Delhivery: use calculated pricing (calls calculatePrice on the provider)
               await createShippingOptionsWorkflow(container).run({
                 input: [{
@@ -514,7 +533,7 @@ const autoLinkFulfillmentProvidersStep = createStep(
                   price_type: "calculated",
                   type: {
                     label: "Standard",
-                    description: "Standard delivery via Delhivery",
+                    description: "Standard delivery — live carrier rates",
                     code: "standard",
                   },
                   rules: [
@@ -534,7 +553,7 @@ const autoLinkFulfillmentProvidersStep = createStep(
                   price_type: "calculated",
                   type: {
                     label: "Return",
-                    description: "Return pickup via Delhivery",
+                    description: "Return pickup — live carrier rates",
                     code: "return",
                   },
                   rules: [
@@ -634,7 +653,7 @@ const autoLinkFulfillmentProvidersStep = createStep(
 
             console.log(
               `[create-store] Created shipping options for ${countryLabel} ` +
-              `(${isDelhivery ? "calculated/Delhivery" : "flat tiered/manual"})`
+              `(${isCarrier ? `calculated/${providerId}` : "flat tiered/manual"})`
             )
 
             // --- Shiprocket, alongside Delhivery (#1417) ---------------------

--- a/apps/partner-ui/src/routes/orders/quote-create/components/quote-create-form/quote-minted-panel.tsx
+++ b/apps/partner-ui/src/routes/orders/quote-create/components/quote-create-form/quote-minted-panel.tsx
@@ -26,9 +26,18 @@ export const QuoteMintedPanel = ({ result }: QuoteMintedPanelProps) => {
   const domain =
     (partner as any)?.custom_domain || (partner as any)?.storefront_domain
 
-  const link = domain
-    ? `https://${domain}/quotes/${result.token}`
-    : null
+  // Both storefronts route every page under `app/[countryCode]/`, so a link
+  // without that segment 404s. It does not need a new field: the quote already
+  // carries a REQUIRED `destination_country_code`, so the segment is inferred
+  // from the buyer's own destination rather than guessed or defaulted.
+  const countryCode = String(
+    (result as any)?.quote?.destination_country_code || ""
+  ).toLowerCase()
+
+  const link =
+    domain && countryCode
+      ? `https://${domain}/${countryCode}/quotes/${result.token}`
+      : null
 
   const copy = async (value: string, label: string) => {
     try {


### PR DESCRIPTION
Found on a **live production mint** while verifying #1389 S3.

## What happened

```
destination : Mumbai 400001, domestic, 21 kg consignment
currency    : inr
freight won : "European Shipping" — amount 10, currency AUD
```

It was then presented to the buyer as **₹10**.

## Two independent defects

`buildShippingEstimate` collected manual options from **every** service zone on the location, whether or not the zone covered the destination, and kept them in **any** currency — while `pickFreightOption` sorts on the raw `amount`. So 10 AUD beat a rupee rate on the number alone.

Neither half is detectable downstream: the winning option is well-formed, the total adds up, and the page renders it with confidence. It is exactly the *wrong number wearing a confident label* this epic exists to prevent — sitting in the epic's own freight path.

## Fixes

- **`zoneCoversDestination`** (pure, tested) — a service zone that does not list the destination country cannot price it. A shipping option is an offer to carry a parcel to *its* zone; from any other zone it is not a cheaper answer, it is a different question.
  A zone with **no** geo zones covers **nothing** rather than everything: an unscoped zone is a provisioning accident, and reading it as worldwide is how one bad row prices every lane.

- **`currency_code` on `ShippingEstimateInput`**, threaded from the quote builder and exposed (optional) on the public estimate route. Options not priced in the quote's currency are dropped *before* the picker sees them, because the picker cannot see units and never could.

The currency filter is opt-in by absence — a caller supplying no currency gets exactly today's behaviour, so nothing existing changes shape.

## Verify

```
cd apps/backend && npx jest --testPathPattern="shipping-estimate-zone"
```

192 unit tests green; `check:prod-build` passed after the last edit.

## Watch-out

The quote that exposed this is **real and still active on prod** (`01M0HWNEBN61NC6SC60AK04JWJ`, Unique Pashmina, expires 4 Sep). Its frozen freight is `0` and its live freight was the AUD option. Re-check it once this deploys — and note the frozen `0` does not self-heal, since freezing happened at mint.

🤖 Generated with [Claude Code](https://claude.com/claude-code)