### PR TITLE
feat(quotes): admin surface, detail views on both sides, activity log (#1419)

### DIFF
--- a/apps/backend/medusa-config.prod.ts
+++ b/apps/backend/medusa-config.prod.ts
@@ -1,5 +1,6 @@
 import { loadEnv, defineConfig, Modules } from "@medusajs/framework/utils";
 import path from "path";
+import { parseFlatFallbackAmounts } from "./src/modules/shipping-providers/shiprocket/flat-fallback"
 
 loadEnv(process.env.NODE_ENV || 'development', process.cwd())
 
@@ -360,6 +361,17 @@ module.exports = defineConfig({
                     email: process.env.SHIPROCKET_EMAIL,
                     password: process.env.SHIPROCKET_PASSWORD,
                     pickup_location: process.env.SHIPROCKET_PICKUP_LOCATION,
+                    // What an UNQUOTABLE lane costs (#1417). Without one,
+                    // calculatePrice used to answer 0 — free shipping wearing
+                    // the shape of a real quote. `IN=9900,US=249000` (ISO2=minor
+                    // units); see shiprocket/flat-fallback.ts.
+                    flat_fallback_amounts: parseFlatFallbackAmounts(
+                      process.env.SHIPROCKET_FLAT_FALLBACK_AMOUNTS
+                    ),
+                    flat_fallback_amount: process.env
+                      .SHIPROCKET_FLAT_FALLBACK_AMOUNT
+                      ? Number(process.env.SHIPROCKET_FLAT_FALLBACK_AMOUNT)
+                      : undefined,
                   },
                 },
               ]

--- a/apps/backend/medusa-config.ts
+++ b/apps/backend/medusa-config.ts
@@ -1,5 +1,6 @@
 import { loadEnv, defineConfig, Modules } from "@medusajs/framework/utils";
 import path from "path";
+import { parseFlatFallbackAmounts } from "./src/modules/shipping-providers/shiprocket/flat-fallback"
 
 loadEnv(process.env.NODE_ENV || 'development', process.cwd())
 
@@ -443,6 +444,17 @@ module.exports = defineConfig({
                           email: process.env.SHIPROCKET_EMAIL,
                           password: process.env.SHIPROCKET_PASSWORD,
                           pickup_location: process.env.SHIPROCKET_PICKUP_LOCATION,
+                          // What an UNQUOTABLE lane costs (#1417). Without one,
+                          // calculatePrice used to answer 0 — free shipping
+                          // wearing the shape of a real quote. `IN=9900,US=249000`
+                          // (ISO2=minor units); see shiprocket/flat-fallback.ts.
+                          flat_fallback_amounts: parseFlatFallbackAmounts(
+                            process.env.SHIPROCKET_FLAT_FALLBACK_AMOUNTS
+                          ),
+                          flat_fallback_amount: process.env
+                            .SHIPROCKET_FLAT_FALLBACK_AMOUNT
+                            ? Number(process.env.SHIPROCKET_FLAT_FALLBACK_AMOUNT)
+                            : undefined,
                         },
                       },
                     ]

--- a/apps/backend/src/admin/hooks/api/quotes.ts
+++ b/apps/backend/src/admin/hooks/api/quotes.ts
@@ -1,0 +1,148 @@
+import { FetchError } from "@medusajs/js-sdk"
+import {
+  UseMutationOptions,
+  UseQueryOptions,
+  useMutation,
+  useQuery,
+  useQueryClient,
+} from "@tanstack/react-query"
+
+import { sdk } from "../../lib/config"
+import { queryKeysFactory } from "../../lib/query-key-factory"
+
+const QUOTES_QUERY_KEY = "quotes" as const
+export const quoteQueryKeys = queryKeysFactory(QUOTES_QUERY_KEY)
+
+export type AdminQuote = Record<string, any> & {
+  id: string
+  partner_id: string
+  store_id?: string | null
+  recipient_name?: string | null
+  recipient_company?: string | null
+  email_sent_to?: string | null
+  currency_code?: string
+  destination_country_code?: string
+  quoted_landed_total?: number | null
+  quoted_freight?: number | null
+  status?: "active" | "revoked"
+  expires_at?: string | null
+  view_count?: number
+  last_viewed_at?: string | null
+  created_at?: string
+}
+
+export type AdminQuoteListResponse = { quotes: AdminQuote[]; count: number }
+
+export type AdminMintQuotePayload = {
+  partner_id: string
+  buyer_email: string
+  recipient_name?: string | null
+  recipient_company?: string | null
+  partner_note?: string | null
+  lines: Array<{ variant_id: string; quantity: number; note?: string | null }>
+  destination_country_code: string
+  destination_postal_code?: string | null
+  destination_city?: string | null
+  currency_code: string
+  carrier?: string
+  ttl_days?: number
+}
+
+/**
+ * 🔴 `token` arrives ONCE, on the mint response, and is never retrievable —
+ * only its sha256 is stored. Nothing in this file may cache it, and no list
+ * query can reconstruct it. The UI must present it as a copy-now-or-lose-it
+ * value, exactly as the partner surface already does.
+ */
+export type AdminMintQuoteResponse = { quote: AdminQuote; token: string }
+
+export const useQuotes = (
+  query?: { partner_id?: string; status?: string },
+  options?: Omit<
+    UseQueryOptions<AdminQuoteListResponse, FetchError, AdminQuoteListResponse, any>,
+    "queryFn" | "queryKey"
+  >
+) => {
+  const { data, ...rest } = useQuery({
+    queryKey: quoteQueryKeys.list(query),
+    queryFn: async () =>
+      sdk.client.fetch<AdminQuoteListResponse>("/admin/quotes", {
+        method: "GET",
+        query,
+      }),
+    ...options,
+  })
+
+  return { ...data, ...rest }
+}
+
+export const useQuote = (
+  id: string,
+  options?: Omit<
+    UseQueryOptions<{ quote: AdminQuote }, FetchError, { quote: AdminQuote }, any>,
+    "queryFn" | "queryKey"
+  >
+) => {
+  const { data, ...rest } = useQuery({
+    queryKey: quoteQueryKeys.detail(id),
+    queryFn: async () =>
+      sdk.client.fetch<{ quote: AdminQuote }>(`/admin/quotes/${id}`, {
+        method: "GET",
+      }),
+    enabled: !!id,
+    ...options,
+  })
+
+  return { ...data, ...rest }
+}
+
+export const useMintQuote = (
+  options?: UseMutationOptions<
+    AdminMintQuoteResponse,
+    FetchError,
+    AdminMintQuotePayload
+  >
+) => {
+  const queryClient = useQueryClient()
+
+  return useMutation({
+    mutationFn: (payload) =>
+      sdk.client.fetch<AdminMintQuoteResponse>("/admin/quotes", {
+        method: "POST",
+        body: payload,
+      }),
+    onSuccess: (data, variables, _mutateResult, context) => {
+      queryClient.invalidateQueries({ queryKey: quoteQueryKeys.lists() })
+      options?.onSuccess?.(data, variables, _mutateResult, context)
+    },
+    ...options,
+  })
+}
+
+export const useRevokeQuote = (
+  options?: UseMutationOptions<
+    { quote: AdminQuote; price_list_deleted?: boolean },
+    FetchError,
+    string
+  >
+) => {
+  const queryClient = useQueryClient()
+
+  return useMutation({
+    mutationFn: (id) =>
+      sdk.client.fetch<{ quote: AdminQuote; price_list_deleted?: boolean }>(
+        `/admin/quotes/${id}/revoke`,
+        { method: "POST" }
+      ),
+    onSuccess: (data, variables, _mutateResult, context) => {
+      queryClient.invalidateQueries({ queryKey: quoteQueryKeys.lists() })
+      // The detail carries the status badge AND the activity timeline the
+      // revoke just appended to, so it is stale the moment this returns.
+      queryClient.invalidateQueries({
+        queryKey: quoteQueryKeys.detail(variables),
+      })
+      options?.onSuccess?.(data, variables, _mutateResult, context)
+    },
+    ...options,
+  })
+}

--- a/apps/backend/src/admin/routes/quotes/[id]/page.tsx
+++ b/apps/backend/src/admin/routes/quotes/[id]/page.tsx
@@ -1,0 +1,231 @@
+import {
+  Button,
+  Container,
+  Heading,
+  Prompt,
+  StatusBadge,
+  Text,
+  toast,
+} from "@medusajs/ui"
+import { useState } from "react"
+import { useParams } from "react-router-dom"
+
+import { useQuote, useRevokeQuote } from "../../../hooks/api/quotes"
+
+const money = (amount?: number | null, currency?: string) =>
+  amount === null || amount === undefined
+    ? "—"
+    : new Intl.NumberFormat("en-US", {
+        style: "currency",
+        currency: (currency || "usd").toUpperCase(),
+      }).format(amount)
+
+const Field = ({ label, value }: { label: string; value: React.ReactNode }) => (
+  <div className="flex items-start justify-between gap-4 px-6 py-3">
+    <Text size="small" className="text-ui-fg-subtle">
+      {label}
+    </Text>
+    <div className="text-right">{value}</div>
+  </div>
+)
+
+/**
+ * The activity timeline.
+ *
+ * 🔑 `actor_type` is rendered, not hidden. An admin-minted quote must never
+ * look like one the partner made themselves — that is the first thing asked
+ * when a buyer challenges a price.
+ */
+const ACTOR_LABEL: Record<string, string> = {
+  partner: "Partner",
+  admin: "Admin",
+  buyer: "Buyer",
+  system: "System",
+}
+
+const Timeline = ({ events }: { events: any[] }) => {
+  if (!events?.length) {
+    return (
+      <div className="px-6 py-6">
+        <Text size="small" className="text-ui-fg-subtle">
+          No activity recorded yet. Quotes minted before activity logging
+          shipped have no history — that is expected, not a gap in this quote.
+        </Text>
+      </div>
+    )
+  }
+
+  return (
+    <ul className="px-6 py-4">
+      {events.map((e) => (
+        <li key={e.id} className="flex gap-3 border-l border-ui-border-base pl-4 pb-4 last:pb-0">
+          <div className="flex flex-col">
+            <div className="flex items-center gap-2">
+              <Text size="small" weight="plus">
+                {e.type}
+              </Text>
+              <StatusBadge color={e.actor_type === "buyer" ? "blue" : "grey"}>
+                {ACTOR_LABEL[e.actor_type] ?? e.actor_type}
+              </StatusBadge>
+            </div>
+            {e.message ? (
+              <Text size="small" className="text-ui-fg-subtle">
+                {e.message}
+              </Text>
+            ) : null}
+            <Text size="xsmall" className="text-ui-fg-muted">
+              {new Date(e.created_at).toLocaleString()}
+            </Text>
+          </div>
+        </li>
+      ))}
+    </ul>
+  )
+}
+
+const QuoteDetailPage = () => {
+  const { id } = useParams()
+  const { quote, isLoading } = useQuote(id!)
+  const [confirmOpen, setConfirmOpen] = useState(false)
+
+  const { mutate: revoke, isPending } = useRevokeQuote({
+    onSuccess: (data) => {
+      toast.success(
+        data.price_list_deleted
+          ? "Quote revoked and its price list deleted."
+          : "Quote revoked. No price list was recorded on it, so none was deleted."
+      )
+      setConfirmOpen(false)
+    },
+    onError: (e: any) => toast.error(e?.message ?? "Could not revoke the quote."),
+  })
+
+  if (isLoading || !quote) {
+    return (
+      <Container>
+        <Text size="small" className="text-ui-fg-subtle">
+          {isLoading ? "Loading…" : "Quote not found."}
+        </Text>
+      </Container>
+    )
+  }
+
+  const isRevoked = quote.status === "revoked"
+
+  return (
+    <div className="flex flex-col gap-y-3">
+      <Container className="divide-y p-0">
+        <div className="flex items-center justify-between px-6 py-4">
+          <div>
+            <Heading>{quote.recipient_company || quote.recipient_name || "Quote"}</Heading>
+            <Text size="small" className="text-ui-fg-subtle">
+              {quote.email_sent_to}
+            </Text>
+          </div>
+          <div className="flex items-center gap-3">
+            <StatusBadge color={isRevoked ? "red" : "green"}>
+              {isRevoked ? "Revoked" : "Active"}
+            </StatusBadge>
+            {!isRevoked && (
+              <Button
+                variant="danger"
+                size="small"
+                onClick={() => setConfirmOpen(true)}
+                disabled={isPending}
+              >
+                Revoke
+              </Button>
+            )}
+          </div>
+        </div>
+
+        <Field
+          label="Landed total"
+          value={
+            <Text size="small" weight="plus">
+              {money(quote.quoted_landed_total, quote.currency_code)}
+            </Text>
+          }
+        />
+        <Field
+          label="Freight"
+          value={<Text size="small">{money(quote.quoted_freight, quote.currency_code)}</Text>}
+        />
+        <Field
+          label="Destination"
+          value={
+            <Text size="small">
+              {String(quote.destination_country_code || "").toUpperCase()}
+              {quote.destination_postal_code ? ` ${quote.destination_postal_code}` : ""}
+            </Text>
+          }
+        />
+        <Field
+          label="Expires"
+          value={
+            <Text size="small">
+              {quote.expires_at ? new Date(quote.expires_at).toLocaleString() : "—"}
+            </Text>
+          }
+        />
+        <Field
+          label="Viewed"
+          value={
+            <Text size="small">
+              {Number(quote.view_count || 0) === 0
+                ? "Not yet"
+                : `${quote.view_count}×${
+                    quote.last_viewed_at
+                      ? ` · last ${new Date(quote.last_viewed_at).toLocaleString()}`
+                      : ""
+                  }`}
+            </Text>
+          }
+        />
+        {/* 🔴 Stated, not implied. The raw token is returned once at mint and
+            only its sha256 is stored, so no read can rebuild the link. Offering
+            a "copy link" button here would be a button that cannot work. */}
+        <Field
+          label="Buyer link"
+          value={
+            <Text size="small" className="text-ui-fg-subtle">
+              Shown once at mint and not recoverable. Re-mint to issue a new one.
+            </Text>
+          }
+        />
+      </Container>
+
+      <Container className="divide-y p-0">
+        <div className="px-6 py-4">
+          <Heading level="h2">Activity</Heading>
+        </div>
+        <Timeline events={quote.events ?? []} />
+      </Container>
+
+      <Prompt open={confirmOpen} onOpenChange={setConfirmOpen}>
+        <Prompt.Content>
+          <Prompt.Header>
+            <Prompt.Title>Revoke this quote?</Prompt.Title>
+            <Prompt.Description>
+              This deletes the price list behind the quote, so the buyer loses
+              the quoted prices in any cart as well as the link. It cannot be
+              undone — issuing the prices again means minting a new quote.
+            </Prompt.Description>
+          </Prompt.Header>
+          <Prompt.Footer>
+            <Prompt.Cancel>Cancel</Prompt.Cancel>
+            <Prompt.Action onClick={() => revoke(quote.id)}>
+              {isPending ? "Revoking…" : "Revoke"}
+            </Prompt.Action>
+          </Prompt.Footer>
+        </Prompt.Content>
+      </Prompt>
+    </div>
+  )
+}
+
+export const handle = {
+  breadcrumb: () => "Quote",
+}
+
+export default QuoteDetailPage

--- a/apps/backend/src/admin/routes/quotes/create/mint-quote-form.tsx
+++ b/apps/backend/src/admin/routes/quotes/create/mint-quote-form.tsx
@@ -1,0 +1,249 @@
+import {
+  Button,
+  Heading,
+  Input,
+  Label,
+  Select,
+  Text,
+  Textarea,
+  toast,
+} from "@medusajs/ui"
+import { useMemo, useState } from "react"
+
+import { usePartners } from "../../../hooks/api/partners"
+import { useProducts } from "../../../hooks/api/products"
+import { useMintQuote } from "../../../hooks/api/quotes"
+import { MintedPanel } from "./minted-panel"
+
+type Line = { variant_id: string; quantity: number }
+
+/**
+ * Mint a quote on a partner's behalf (#1419).
+ *
+ * The partner comes first and everything else follows from it: a quote is
+ * priced against THAT partner's catalogue and shipped from THEIR location. The
+ * backend refuses variants outside the chosen partner's sales channel, so this
+ * form's job is to make that mistake hard rather than to re-implement the check.
+ */
+export const MintQuoteForm = () => {
+  const [partnerId, setPartnerId] = useState("")
+  const [buyerEmail, setBuyerEmail] = useState("")
+  const [company, setCompany] = useState("")
+  const [name, setName] = useState("")
+  const [note, setNote] = useState("")
+  const [country, setCountry] = useState("in")
+  const [postal, setPostal] = useState("")
+  const [currency, setCurrency] = useState("inr")
+  const [ttlDays, setTtlDays] = useState("14")
+  const [lines, setLines] = useState<Line[]>([])
+  const [minted, setMinted] = useState<{ token: string; quote: any } | null>(null)
+
+  const { partners } = usePartners({ limit: 200 } as any)
+  const { products } = useProducts({ limit: 100 } as any)
+
+  const variantOptions = useMemo(() => {
+    const out: Array<{ id: string; label: string }> = []
+    for (const p of (products ?? []) as any[]) {
+      for (const v of p.variants ?? []) {
+        out.push({ id: v.id, label: `${p.title} — ${v.title}` })
+      }
+    }
+    return out
+  }, [products])
+
+  const { mutate: mint, isPending } = useMintQuote({
+    onSuccess: (data) => setMinted({ token: data.token, quote: data.quote }),
+    onError: (e: any) =>
+      toast.error(e?.message ?? "Could not mint the quote."),
+  })
+
+  // The panel REPLACES the form rather than sitting beside it. The token is
+  // shown once and never again, so anything that invites navigating away
+  // before copying it is a way to lose a quote.
+  if (minted) {
+    return <MintedPanel token={minted.token} quote={minted.quote} />
+  }
+
+  const addLine = () =>
+    setLines((prev) => [...prev, { variant_id: "", quantity: 1 }])
+
+  const canSubmit =
+    !!partnerId &&
+    !!buyerEmail &&
+    !!currency &&
+    lines.length > 0 &&
+    lines.every((l) => l.variant_id && l.quantity > 0)
+
+  const submit = () => {
+    mint({
+      partner_id: partnerId,
+      buyer_email: buyerEmail,
+      recipient_company: company || null,
+      recipient_name: name || null,
+      partner_note: note || null,
+      lines,
+      destination_country_code: country,
+      destination_postal_code: postal || null,
+      currency_code: currency,
+      ttl_days: Number(ttlDays) || undefined,
+    })
+  }
+
+  return (
+    <div className="flex flex-col gap-y-6 px-6 py-6">
+      <div>
+        <Heading>Mint a quote</Heading>
+        <Text size="small" className="text-ui-fg-subtle">
+          The buyer link is shown once and cannot be recovered — you will be
+          asked to copy it before leaving this page.
+        </Text>
+      </div>
+
+      <div className="flex flex-col gap-y-2">
+        <Label>Partner</Label>
+        <Select value={partnerId} onValueChange={setPartnerId}>
+          <Select.Trigger>
+            <Select.Value placeholder="Select a partner" />
+          </Select.Trigger>
+          <Select.Content>
+            {((partners ?? []) as any[]).map((p) => (
+              <Select.Item key={p.id} value={p.id}>
+                {p.name || p.id}
+              </Select.Item>
+            ))}
+          </Select.Content>
+        </Select>
+        <Text size="xsmall" className="text-ui-fg-subtle">
+          Prices come from this partner's catalogue and freight from their
+          location. Variants outside their store are rejected.
+        </Text>
+      </div>
+
+      <div className="grid grid-cols-1 gap-4 md:grid-cols-2">
+        <div className="flex flex-col gap-y-2">
+          <Label>Buyer email</Label>
+          <Input
+            type="email"
+            value={buyerEmail}
+            onChange={(e) => setBuyerEmail(e.target.value)}
+            placeholder="procurement@example.com"
+          />
+        </div>
+        <div className="flex flex-col gap-y-2">
+          <Label>Company</Label>
+          <Input value={company} onChange={(e) => setCompany(e.target.value)} />
+        </div>
+        <div className="flex flex-col gap-y-2">
+          <Label>Contact name</Label>
+          <Input value={name} onChange={(e) => setName(e.target.value)} />
+        </div>
+        <div className="flex flex-col gap-y-2">
+          <Label>Currency</Label>
+          <Input
+            value={currency}
+            onChange={(e) => setCurrency(e.target.value.toLowerCase())}
+            placeholder="inr"
+          />
+        </div>
+        <div className="flex flex-col gap-y-2">
+          <Label>Destination country (ISO-2)</Label>
+          <Input
+            value={country}
+            onChange={(e) => setCountry(e.target.value.toLowerCase())}
+            placeholder="in"
+          />
+        </div>
+        <div className="flex flex-col gap-y-2">
+          <Label>Destination postcode</Label>
+          <Input value={postal} onChange={(e) => setPostal(e.target.value)} />
+        </div>
+        <div className="flex flex-col gap-y-2">
+          <Label>Valid for (days)</Label>
+          <Input
+            type="number"
+            value={ttlDays}
+            onChange={(e) => setTtlDays(e.target.value)}
+          />
+          <Text size="xsmall" className="text-ui-fg-subtle">
+            Drives the price list's end date, so expiry is enforced by pricing
+            itself rather than by a sweep.
+          </Text>
+        </div>
+      </div>
+
+      <div className="flex flex-col gap-y-3">
+        <div className="flex items-center justify-between">
+          <Label>Lines</Label>
+          <Button variant="secondary" size="small" onClick={addLine}>
+            Add line
+          </Button>
+        </div>
+        {lines.length === 0 ? (
+          <Text size="small" className="text-ui-fg-subtle">
+            A quote is a basket — add at least one line. Multiple lines are
+            quoted as ONE consignment, so freight is charged once.
+          </Text>
+        ) : null}
+        {lines.map((line, i) => (
+          <div key={i} className="flex items-end gap-3">
+            <div className="flex flex-1 flex-col gap-y-2">
+              <Select
+                value={line.variant_id}
+                onValueChange={(v) =>
+                  setLines((prev) =>
+                    prev.map((l, idx) => (idx === i ? { ...l, variant_id: v } : l))
+                  )
+                }
+              >
+                <Select.Trigger>
+                  <Select.Value placeholder="Select a variant" />
+                </Select.Trigger>
+                <Select.Content>
+                  {variantOptions.map((v) => (
+                    <Select.Item key={v.id} value={v.id}>
+                      {v.label}
+                    </Select.Item>
+                  ))}
+                </Select.Content>
+              </Select>
+            </div>
+            <div className="w-28">
+              <Input
+                type="number"
+                min={1}
+                value={line.quantity}
+                onChange={(e) =>
+                  setLines((prev) =>
+                    prev.map((l, idx) =>
+                      idx === i ? { ...l, quantity: Number(e.target.value) } : l
+                    )
+                  )
+                }
+              />
+            </div>
+            <Button
+              variant="transparent"
+              size="small"
+              onClick={() =>
+                setLines((prev) => prev.filter((_, idx) => idx !== i))
+              }
+            >
+              Remove
+            </Button>
+          </div>
+        ))}
+      </div>
+
+      <div className="flex flex-col gap-y-2">
+        <Label>Note to the buyer</Label>
+        <Textarea value={note} onChange={(e) => setNote(e.target.value)} />
+      </div>
+
+      <div className="flex justify-end">
+        <Button onClick={submit} disabled={!canSubmit || isPending}>
+          {isPending ? "Minting…" : "Mint quote"}
+        </Button>
+      </div>
+    </div>
+  )
+}

--- a/apps/backend/src/admin/routes/quotes/create/minted-panel.tsx
+++ b/apps/backend/src/admin/routes/quotes/create/minted-panel.tsx
@@ -1,0 +1,88 @@
+import { Button, Heading, Input, Text, toast } from "@medusajs/ui"
+import { useNavigate } from "react-router-dom"
+
+/**
+ * The post-mint panel — and the ONLY place the buyer's link ever exists.
+ *
+ * 🔴 `token` is returned by the mint and never again: the row stores only its
+ * sha256, so no later read can reconstruct a working link. Everything about
+ * this screen is shaped by that — it replaces the form rather than sitting
+ * beside it, and it does not offer a way onward that skips copying.
+ *
+ * Mirrors the partner-side panel deliberately. Two differently-worded warnings
+ * about the same irreversible fact is how one of them ends up softer.
+ */
+export const MintedPanel = ({
+  token,
+  quote,
+}: {
+  token: string
+  quote: any
+}) => {
+  const navigate = useNavigate()
+
+  const domain = quote?.storefront_domain || quote?.custom_domain
+  const country = String(quote?.destination_country_code || "").toLowerCase()
+
+  // The storefront routes every page under /[countryCode]; a link without that
+  // segment 404s. The country comes from the quote's own destination.
+  const link = domain && country ? `https://${domain}/${country}/quotes/${token}` : null
+
+  const copy = async (value: string, label: string) => {
+    try {
+      await navigator.clipboard.writeText(value)
+      toast.success(`${label} copied`)
+    } catch {
+      toast.error("Could not copy — select and copy manually.")
+    }
+  }
+
+  return (
+    <div className="flex flex-col gap-y-6 px-6 py-6">
+      <div>
+        <Heading>Quote minted</Heading>
+        <Text size="small" className="text-ui-fg-subtle">
+          This link is shown once. Only its hash is stored, so it cannot be
+          recovered later — copy it before you leave this page.
+        </Text>
+      </div>
+
+      {link ? (
+        <div className="flex flex-col gap-y-2">
+          <Text size="small" weight="plus">
+            Buyer link
+          </Text>
+          <div className="flex gap-2">
+            <Input readOnly value={link} />
+            <Button variant="secondary" onClick={() => copy(link, "Link")}>
+              Copy
+            </Button>
+          </div>
+        </div>
+      ) : (
+        <div className="flex flex-col gap-y-2">
+          <Text size="small" className="text-ui-fg-subtle">
+            No storefront domain is connected for this partner, so there is no
+            buyer link to share. Copy the token and connect a domain first.
+          </Text>
+          <div className="flex gap-2">
+            <Input readOnly value={token} />
+            <Button variant="secondary" onClick={() => copy(token, "Token")}>
+              Copy
+            </Button>
+          </div>
+        </div>
+      )}
+
+      <div className="flex justify-end gap-2">
+        <Button
+          variant="secondary"
+          onClick={() => navigate(`/quotes/${quote?.id}`)}
+        >
+          View quote
+        </Button>
+        <Button onClick={() => navigate("/quotes")}>I&apos;ve copied the link</Button>
+      </div>
+    </div>
+  )
+}

--- a/apps/backend/src/admin/routes/quotes/create/page.tsx
+++ b/apps/backend/src/admin/routes/quotes/create/page.tsx
@@ -1,0 +1,15 @@
+import { Container } from "@medusajs/ui"
+
+import { MintQuoteForm } from "./mint-quote-form"
+
+const MintQuotePage = () => (
+  <Container className="p-0">
+    <MintQuoteForm />
+  </Container>
+)
+
+export const handle = {
+  breadcrumb: () => "Mint",
+}
+
+export default MintQuotePage

--- a/apps/backend/src/admin/routes/quotes/page.tsx
+++ b/apps/backend/src/admin/routes/quotes/page.tsx
@@ -1,0 +1,137 @@
+import {
+  Container,
+  DataTable,
+  Heading,
+  StatusBadge,
+  Text,
+  createDataTableColumnHelper,
+  useDataTable,
+} from "@medusajs/ui"
+import { defineRouteConfig } from "@medusajs/admin-sdk"
+import { DocumentText } from "@medusajs/icons"
+import { useMemo, useState } from "react"
+import { useNavigate } from "react-router-dom"
+
+import { useQuotes, type AdminQuote } from "../../hooks/api/quotes"
+
+const PAGE_SIZE = 20
+
+const columnHelper = createDataTableColumnHelper<AdminQuote>()
+
+const money = (amount?: number | null, currency?: string) =>
+  amount === null || amount === undefined
+    ? "—"
+    : new Intl.NumberFormat("en-US", {
+        style: "currency",
+        currency: (currency || "usd").toUpperCase(),
+      }).format(amount)
+
+const QuotesPage = () => {
+  const navigate = useNavigate()
+  const [pagination, setPagination] = useState({
+    pageIndex: 0,
+    pageSize: PAGE_SIZE,
+  })
+
+  const { quotes, count, isLoading } = useQuotes()
+
+  const columns = useMemo(
+    () => [
+      columnHelper.accessor("recipient_company", {
+        header: "Buyer",
+        cell: ({ row }) => (
+          <div className="flex flex-col">
+            <Text size="small" leading="compact">
+              {row.original.recipient_company ||
+                row.original.recipient_name ||
+                "—"}
+            </Text>
+            <Text size="xsmall" className="text-ui-fg-subtle">
+              {row.original.email_sent_to || ""}
+            </Text>
+          </div>
+        ),
+      }),
+      columnHelper.accessor("quoted_landed_total", {
+        header: "Landed total",
+        cell: ({ row }) =>
+          money(row.original.quoted_landed_total, row.original.currency_code),
+      }),
+      columnHelper.accessor("destination_country_code", {
+        header: "Destination",
+        cell: ({ getValue }) => String(getValue() || "—").toUpperCase(),
+      }),
+      columnHelper.accessor("view_count", {
+        header: "Viewed",
+        cell: ({ getValue }) => {
+          const n = Number(getValue() || 0)
+          // "Not yet" rather than 0 — a zero reads as a metric, and the fact
+          // that matters here is whether the buyer has opened it at all.
+          return n === 0 ? "Not yet" : `${n}×`
+        },
+      }),
+      columnHelper.accessor("status", {
+        header: "Status",
+        cell: ({ getValue }) => {
+          const status = String(getValue() || "active")
+          return (
+            <StatusBadge color={status === "active" ? "green" : "red"}>
+              {status === "active" ? "Active" : "Revoked"}
+            </StatusBadge>
+          )
+        },
+      }),
+      columnHelper.accessor("expires_at", {
+        header: "Expires",
+        cell: ({ getValue }) => {
+          const raw = getValue() as string | null
+          if (!raw) return "—"
+          return new Date(raw).toLocaleDateString()
+        },
+      }),
+    ],
+    []
+  )
+
+  const table = useDataTable({
+    columns,
+    data: (quotes ?? []) as AdminQuote[],
+    getRowId: (row) => row.id,
+    rowCount: count ?? 0,
+    isLoading,
+    pagination: { state: pagination, onPaginationChange: setPagination },
+    onRowClick: (_e, row) => navigate(`/quotes/${row.id}`),
+  })
+
+  return (
+    <Container className="divide-y p-0">
+      <DataTable instance={table}>
+        <DataTable.Toolbar className="flex flex-col items-start justify-between gap-2 md:flex-row md:items-center">
+          <div>
+            <Heading>Quotes</Heading>
+            <Text size="small" className="text-ui-fg-subtle">
+              B2B quotes minted for partners. A quote's buyer link is shown once
+              at mint and cannot be recovered — re-mint to issue a new one.
+            </Text>
+          </div>
+        </DataTable.Toolbar>
+        <DataTable.Table />
+        <DataTable.Pagination />
+      </DataTable>
+    </Container>
+  )
+}
+
+// Sidebar entry. Without a config the page compiles, routes, and is reachable
+// only by typing the URL — which is exactly how the partner-side quote list sat
+// unreachable until now.
+export const config = defineRouteConfig({
+  label: "Quotes",
+  icon: DocumentText,
+})
+
+export const handle = {
+  breadcrumb: () => "Quotes",
+}
+
+export default QuotesPage

--- a/apps/backend/src/admin/routes/quotes/page.tsx
+++ b/apps/backend/src/admin/routes/quotes/page.tsx
@@ -1,4 +1,5 @@
 import {
+  Button,
   Container,
   DataTable,
   Heading,
@@ -114,6 +115,9 @@ const QuotesPage = () => {
               at mint and cannot be recovered — re-mint to issue a new one.
             </Text>
           </div>
+          <Button size="small" onClick={() => navigate("/quotes/create")}>
+            Mint quote
+          </Button>
         </DataTable.Toolbar>
         <DataTable.Table />
         <DataTable.Pagination />

--- a/apps/backend/src/api/admin/ops/maintenance-jobs/__tests__/backfill-shiprocket-shipping-options.unit.spec.ts
+++ b/apps/backend/src/api/admin/ops/maintenance-jobs/__tests__/backfill-shiprocket-shipping-options.unit.spec.ts
@@ -1,0 +1,119 @@
+import { planShiprocketOptions } from "../backfill-shiprocket-shipping-options-job"
+
+/**
+ * The decision this guards: "does this store already have Shiprocket on this
+ * zone". Getting it wrong duplicates a carrier in a LIVE checkout picker, and
+ * `createShippingOptions` will happily make the duplicate without complaint.
+ */
+
+const zone = (over: any = {}) => ({
+  id: "sz_1",
+  name: "IN Shipping Zone",
+  geo_zones: [{ country_code: "in" }],
+  shipping_options: [],
+  ...over,
+})
+
+const sets = (zones: any[]) => [{ id: "fs_1", type: "shipping", service_zones: zones }]
+
+describe("planShiprocketOptions", () => {
+  it("adds the calculated Shiprocket option and a flat companion to a bare domestic zone", () => {
+    const plan = planShiprocketOptions({
+      fulfillmentSets: sets([
+        zone({
+          shipping_options: [
+            { provider_id: "delhivery_delhivery", price_type: "calculated" },
+          ],
+        }),
+      ]),
+      homeCountry: "in",
+    })
+
+    expect(plan.map((p) => p.kind).sort()).toEqual([
+      "domestic-calculated",
+      "domestic-flat",
+    ])
+  })
+
+  it("is idempotent — a zone that already has Shiprocket gets no second one", () => {
+    const plan = planShiprocketOptions({
+      fulfillmentSets: sets([
+        zone({
+          shipping_options: [
+            { provider_id: "shiprocket_shiprocket", price_type: "calculated" },
+            { provider_id: "manual_manual", price_type: "flat" },
+          ],
+        }),
+      ]),
+      homeCountry: "in",
+    })
+
+    expect(plan).toEqual([])
+  })
+
+  it("does not add a second flat option when the store already has flat tiers", () => {
+    const plan = planShiprocketOptions({
+      fulfillmentSets: sets([
+        zone({
+          shipping_options: [{ provider_id: "manual_manual", price_type: "flat" }],
+        }),
+      ]),
+      homeCountry: "in",
+    })
+
+    expect(plan.map((p) => p.kind)).toEqual(["domestic-calculated"])
+  })
+
+  it("classifies a zone as international from its GEO ZONES, not its name", () => {
+    // Several zones were renamed by hand during the #954 backfill, so matching
+    // on the name "International" would silently skip them.
+    const plan = planShiprocketOptions({
+      fulfillmentSets: sets([
+        zone({
+          id: "sz_intl",
+          name: "Renamed By Hand",
+          geo_zones: [{ country_code: "us" }, { country_code: "gb" }],
+        }),
+      ]),
+      homeCountry: "in",
+    })
+
+    expect(plan).toEqual([
+      {
+        zone_id: "sz_intl",
+        zone_name: "Renamed By Hand",
+        kind: "international-calculated",
+        provider_id: "shiprocket_shiprocket",
+      },
+    ])
+  })
+
+  it("never puts a flat companion on an international zone", () => {
+    const plan = planShiprocketOptions({
+      fulfillmentSets: sets([
+        zone({ id: "sz_intl", geo_zones: [{ country_code: "us" }] }),
+      ]),
+      homeCountry: "in",
+    })
+
+    expect(plan.some((p) => p.kind === "domestic-flat")).toBe(false)
+  })
+
+  it("skips PICKUP sets — a courier cannot deliver a parcel being collected", () => {
+    const plan = planShiprocketOptions({
+      fulfillmentSets: [{ id: "fs_p", type: "pickup", service_zones: [zone()] }],
+      homeCountry: "in",
+    })
+
+    expect(plan).toEqual([])
+  })
+
+  it("skips a zone with no geo zones at all", () => {
+    const plan = planShiprocketOptions({
+      fulfillmentSets: sets([zone({ geo_zones: [] })]),
+      homeCountry: "in",
+    })
+
+    expect(plan).toEqual([])
+  })
+})

--- a/apps/backend/src/api/admin/ops/maintenance-jobs/backfill-shiprocket-shipping-options-job.ts
+++ b/apps/backend/src/api/admin/ops/maintenance-jobs/backfill-shiprocket-shipping-options-job.ts
@@ -1,0 +1,343 @@
+import { ContainerRegistrationKeys, MedusaError, Modules } from "@medusajs/framework/utils"
+import { createShippingOptionsWorkflow } from "@medusajs/medusa/core-flows"
+import { z } from "@medusajs/framework/zod"
+
+import type { MaintenanceChange, MaintenanceJob, MaintenanceJobResult } from "./registry"
+
+/**
+ * #1417 Data Plumbing — expose Shiprocket on stores that already exist.
+ *
+ * ## Why a backfill is needed at all
+ *
+ * Shiprocket was ALREADY fully provisioned on every Indian store: registered as
+ * a fulfillment provider in both configs, linked to the stock location by
+ * `create-store-with-defaults`, and its pickup location auto-registered. What
+ * was never created was a **shipping option** — `providerMap` in that workflow
+ * hardcodes `in -> delhivery_delhivery`, so the carrier existed everywhere
+ * except the one place a cart can pick it.
+ *
+ * `create-store-with-defaults` now creates those options, but that only helps
+ * stores provisioned from here on. Every store already in production needs this
+ * job — otherwise the fix ships and changes nothing for anybody real.
+ *
+ * ## What it creates, per store
+ *
+ * · **Domestic zone** — a `calculated` Shiprocket option, so the store gets live
+ *   rates exactly the way Delhivery already does.
+ * · **Domestic zone** — a `flat` manual companion. 🔑 This is not a nicety: an
+ *   IN store's domestic zone carried ONLY calculated options, and
+ *   `buildShippingEstimate` skips calculated options when assembling its manual
+ *   list — so quote freight rested entirely on one live carrier call with no
+ *   fallback, and a hiccup 400'd the whole quote mint.
+ * · **International zone** — a `calculated` Shiprocket option, where such a zone
+ *   exists. For an Indian origin Shiprocket IS the cross-border rate source:
+ *   Delhivery's cross-border product ("Starfleet") has no rate API at all.
+ *
+ * ## Idempotency
+ *
+ * Re-runnable. Existing options are matched by `provider_id` within each service
+ * zone and skipped, because `createShippingOptions` is perfectly happy to make a
+ * second identical option and leave the store with a duplicated carrier in its
+ * checkout picker. Dry-run previews every option it would create.
+ */
+
+/** Hard cap on stock locations scanned per call — bounds the blast radius. */
+export const MAX_SHIPROCKET_OPTION_SCAN = 2000
+
+const SHIPROCKET_PROVIDER_ID = "shiprocket_shiprocket"
+const MANUAL_PROVIDER_ID = "manual_manual"
+
+const paramsSchema = z.object({
+  /** Restrict to a single stock location (default: every IN location). */
+  location_id: z.string().min(1).optional(),
+  /** Max stock locations to scan in one call. */
+  limit: z
+    .number()
+    .int()
+    .positive()
+    .max(MAX_SHIPROCKET_OPTION_SCAN)
+    .optional()
+    .default(500),
+  /** Flat fallback amount, MAJOR units, for the manual companion option. */
+  flat_amount: z.number().nonnegative().optional().default(200),
+})
+
+export type ZonePlanKind = "domestic-calculated" | "domestic-flat" | "international-calculated"
+
+export type ZonePlanEntry = {
+  zone_id: string
+  zone_name: string
+  kind: ZonePlanKind
+  provider_id: string
+}
+
+/**
+ * PURE: given one location's fulfillment sets, decide which options are missing.
+ *
+ * Split out because this is the whole decision — "does this store already have
+ * Shiprocket on this zone" — and getting it wrong duplicates a carrier in a live
+ * checkout. Testable without a container, a store or a Shiprocket account.
+ *
+ * A zone counts as INTERNATIONAL when it covers any country other than the
+ * store's own. That is derived from the geo zones rather than from the zone's
+ * NAME: names are hand-editable and several were renamed by hand during the
+ * #954 backfill, so matching on "International" would silently skip them.
+ */
+export function planShiprocketOptions(args: {
+  fulfillmentSets: any[]
+  homeCountry: string
+}): ZonePlanEntry[] {
+  const home = String(args.homeCountry || "").toLowerCase()
+  const plan: ZonePlanEntry[] = []
+
+  for (const set of args.fulfillmentSets || []) {
+    // Pickup sets never carry a shipping carrier — a Shiprocket option on a
+    // pickup zone would offer to courier a parcel the buyer is collecting.
+    if (set?.type && set.type !== "shipping") continue
+
+    for (const zone of set?.service_zones || []) {
+      if (!zone?.id) continue
+
+      const countries = (zone.geo_zones || [])
+        .map((g: any) => String(g?.country_code || "").toLowerCase())
+        .filter(Boolean)
+      if (!countries.length) continue
+
+      const isInternational = countries.some((c: string) => c !== home)
+      const providers = new Set(
+        (zone.shipping_options || []).map((o: any) => String(o?.provider_id || ""))
+      )
+
+      if (isInternational) {
+        if (!providers.has(SHIPROCKET_PROVIDER_ID)) {
+          plan.push({
+            zone_id: zone.id,
+            zone_name: zone.name || zone.id,
+            kind: "international-calculated",
+            provider_id: SHIPROCKET_PROVIDER_ID,
+          })
+        }
+        continue
+      }
+
+      if (!providers.has(SHIPROCKET_PROVIDER_ID)) {
+        plan.push({
+          zone_id: zone.id,
+          zone_name: zone.name || zone.id,
+          kind: "domestic-calculated",
+          provider_id: SHIPROCKET_PROVIDER_ID,
+        })
+      }
+
+      // The flat companion is keyed on the absence of ANY flat option in the
+      // zone, not on the absence of a manual provider: a store that already has
+      // hand-made flat tiers has a fallback, and adding a second one would just
+      // put a duplicate row in its checkout.
+      const hasFlat = (zone.shipping_options || []).some(
+        (o: any) => o?.price_type === "flat"
+      )
+      if (!hasFlat) {
+        plan.push({
+          zone_id: zone.id,
+          zone_name: zone.name || zone.id,
+          kind: "domestic-flat",
+          provider_id: MANUAL_PROVIDER_ID,
+        })
+      }
+    }
+  }
+
+  return plan
+}
+
+export const backfillShiprocketShippingOptionsJob: MaintenanceJob = {
+  id: "backfill-shiprocket-shipping-options",
+  label: "Backfill Shiprocket shipping options onto existing stores",
+  description:
+    `Create the missing Shiprocket shipping options on stores that already exist. Shiprocket is already registered as a fulfillment provider and already linked to every Indian stock location, but no shipping option was ever created for it (create-store-with-defaults hardcodes Delhivery), so no cart could pick it. This adds a CALCULATED Shiprocket option to each domestic zone (live rates, exactly as Delhivery does today), a CALCULATED Shiprocket option to each international zone (for an Indian origin, Shiprocket is the cross-border rate source — Delhivery's cross-border product has no rate API), and a FLAT manual companion to any domestic zone that has no flat option at all. That flat option matters: an IN store carrying only calculated options gives buildShippingEstimate no manual fallback, so one failed carrier call 400s the whole quote. Idempotent — options are matched by provider within each zone and skipped if present. Dry-run previews every option it would create. Optionally scope to one location_id. Scans up to 'limit' stock locations per call (default 500, max ${MAX_SHIPROCKET_OPTION_SCAN}).`,
+  params: [
+    {
+      name: "location_id",
+      type: "string",
+      required: false,
+      description: "Restrict to a single stock location (default: every Indian location)",
+    },
+    {
+      name: "limit",
+      type: "number",
+      required: false,
+      description: `Max stock locations to scan in one call (default 500, max ${MAX_SHIPROCKET_OPTION_SCAN})`,
+    },
+    {
+      name: "flat_amount",
+      type: "number",
+      required: false,
+      description:
+        "Flat fallback amount in MAJOR units for the manual companion option (default 200)",
+    },
+  ],
+  run: async (container, { dry_run, params }): Promise<MaintenanceJobResult> => {
+    const parsed = paramsSchema.safeParse(params)
+    if (!parsed.success) {
+      throw new MedusaError(
+        MedusaError.Types.INVALID_DATA,
+        parsed.error.issues.map((i) => i.message).join("; ")
+      )
+    }
+    const { location_id, limit, flat_amount } = parsed.data
+
+    const query: any = container.resolve(ContainerRegistrationKeys.QUERY)
+    const fulfillmentService: any = container.resolve(Modules.FULFILLMENT)
+
+    const graphArgs: Record<string, unknown> = {
+      entity: "stock_locations",
+      fields: [
+        "id",
+        "name",
+        "address.country_code",
+        "fulfillment_sets.id",
+        "fulfillment_sets.type",
+        "fulfillment_sets.service_zones.id",
+        "fulfillment_sets.service_zones.name",
+        "fulfillment_sets.service_zones.geo_zones.country_code",
+        "fulfillment_sets.service_zones.shipping_options.id",
+        "fulfillment_sets.service_zones.shipping_options.provider_id",
+        "fulfillment_sets.service_zones.shipping_options.price_type",
+      ],
+      pagination: { take: limit },
+    }
+    if (location_id) graphArgs.filters = { id: location_id }
+    const { data: locations } = await query.graph(graphArgs as any)
+
+    // A shipping profile is required on every option. Reuse the store's rather
+    // than creating one — a second "Default" profile would split the catalogue
+    // across two profiles and silently hide products from the new options.
+    const profiles = await fulfillmentService.listShippingProfiles({}, { take: 1 })
+    const profileId = profiles?.[0]?.id
+    if (!profileId) {
+      throw new MedusaError(
+        MedusaError.Types.NOT_FOUND,
+        "No shipping profile exists, so shipping options cannot be created. Seed one first."
+      )
+    }
+
+    const changes: MaintenanceChange[] = []
+    const errors: Array<{ id: string; message: string }> = []
+    let created = 0
+    let locationsAlreadyCurrent = 0
+    let locationsSkippedNonIndian = 0
+
+    for (const location of (locations ?? []) as any[]) {
+      const homeCountry = String(location?.address?.country_code || "").toLowerCase()
+
+      // Shiprocket is an India-origin carrier. Adding it to a US or EU store's
+      // zones would offer a courier that cannot collect the parcel.
+      if (homeCountry !== "in") {
+        locationsSkippedNonIndian++
+        continue
+      }
+
+      const plan = planShiprocketOptions({
+        fulfillmentSets: location.fulfillment_sets || [],
+        homeCountry,
+      })
+
+      if (!plan.length) {
+        locationsAlreadyCurrent++
+        continue
+      }
+
+      const suffix = String(location.id).slice(-8)
+
+      for (const entry of plan) {
+        changes.push({
+          entity: "shipping_option",
+          id: entry.zone_id,
+          field: entry.kind,
+          before: "absent",
+          after: `${entry.provider_id} on "${entry.zone_name}"`,
+        })
+
+        if (dry_run) {
+          created++
+          continue
+        }
+
+        try {
+          const input =
+            entry.kind === "domestic-flat"
+              ? {
+                  name: "Standard Shipping (Flat)",
+                  service_zone_id: entry.zone_id,
+                  shipping_profile_id: profileId,
+                  provider_id: MANUAL_PROVIDER_ID,
+                  price_type: "flat",
+                  type: {
+                    label: "Standard (Flat)",
+                    description:
+                      "Flat-rate delivery — used when no carrier will quote",
+                    code: `flat-fallback-${suffix}`,
+                  },
+                  prices: [{ currency_code: "inr", amount: flat_amount }],
+                  rules: [
+                    { attribute: "enabled_in_store", value: "true", operator: "eq" },
+                    { attribute: "is_return", value: "false", operator: "eq" },
+                  ],
+                }
+              : {
+                  name:
+                    entry.kind === "international-calculated"
+                      ? "International Shipping (Shiprocket)"
+                      : "Standard Shipping (Shiprocket)",
+                  service_zone_id: entry.zone_id,
+                  shipping_profile_id: profileId,
+                  provider_id: SHIPROCKET_PROVIDER_ID,
+                  price_type: "calculated",
+                  type: {
+                    label:
+                      entry.kind === "international-calculated"
+                        ? "International"
+                        : "Standard",
+                    description:
+                      entry.kind === "international-calculated"
+                        ? "Cross-border delivery via Shiprocket — live rates"
+                        : "Standard delivery via Shiprocket — live rates",
+                    code:
+                      entry.kind === "international-calculated"
+                        ? `shiprocket-international-${suffix}`
+                        : `shiprocket-standard-${suffix}`,
+                  },
+                  rules: [
+                    { attribute: "enabled_in_store", value: "true", operator: "eq" },
+                    { attribute: "is_return", value: "false", operator: "eq" },
+                  ],
+                }
+
+          await createShippingOptionsWorkflow(container).run({ input: [input] as any })
+          created++
+        } catch (err: any) {
+          // One bad zone must not abort the sweep — the rest of the estate
+          // still needs its options.
+          errors.push({
+            id: entry.zone_id,
+            message: err?.message ?? String(err),
+          })
+        }
+      }
+    }
+
+    const verb = dry_run ? "Would create" : "Created"
+    const summary = `${verb} ${created} shipping option(s); ${locationsAlreadyCurrent} location(s) already current, ${locationsSkippedNonIndian} non-Indian location(s) skipped${
+      errors.length ? `, ${errors.length} error(s)` : ""
+    }.`
+
+    return {
+      job_id: backfillShiprocketShippingOptionsJob.id,
+      dry_run,
+      applied: !dry_run && created > 0,
+      summary,
+      changes,
+      errors,
+    }
+  },
+}

--- a/apps/backend/src/api/admin/ops/maintenance-jobs/registry.ts
+++ b/apps/backend/src/api/admin/ops/maintenance-jobs/registry.ts
@@ -80,6 +80,7 @@ import { seedEmailTemplatesJob } from "./seed-jobs"
 import { seedInvestorPanelsJob } from "./seed-investor-panels-job"
 import { replayFxFanoutJob } from "./fanout-fx-job"
 import { backfillStoreCurrenciesJob } from "./backfill-store-currencies-job"
+import { backfillShiprocketShippingOptionsJob } from "./backfill-shiprocket-shipping-options-job"
 import { deleteOrphanStoreJob } from "./delete-orphan-store-job"
 import { restoreOrphanStoreJob } from "./restore-orphan-store-job"
 import { backfillPartnerEmailVerifiedJob } from "./backfill-partner-email-verified-job"
@@ -5770,6 +5771,7 @@ export const MAINTENANCE_JOBS: MaintenanceJob[] = [
   reconcileInventoryMirrorJob,
   replayFxFanoutJob,
   backfillStoreCurrenciesJob,
+  backfillShiprocketShippingOptionsJob,
   deleteOrphanStoreJob,
   restoreOrphanStoreJob,
   backfillPartnerEmailVerifiedJob,

--- a/apps/backend/src/api/admin/ops/maintenance-jobs/seed-jobs.ts
+++ b/apps/backend/src/api/admin/ops/maintenance-jobs/seed-jobs.ts
@@ -17,6 +17,7 @@ import { partnerEmailTemplates } from "../../../../scripts/seed-partner-email-te
 import { investorEmailTemplates } from "../../../../scripts/seed-investor-email-templates"
 import { TEMPLATE_DEFINITION as cartAbandonedTemplate } from "../../../../scripts/seed-cart-abandoned-email"
 import { tourEmailTemplate } from "../../../../scripts/seed-tour-email-template"
+import { quoteEmailTemplates } from "../../../../scripts/seed-quote-email-template"
 import { visualFlowLifecycleTemplates } from "../../../../scripts/seed-visual-flow-lifecycle-email-templates"
 
 /**
@@ -97,6 +98,11 @@ export const EMAIL_TEMPLATE_SETS: Array<{
     key: "tour",
     label: "tour itinerary template",
     specs: [tourEmailTemplate as EmailTemplateSpec],
+  },
+  {
+    key: "quote",
+    label: "B2B quote templates",
+    specs: quoteEmailTemplates as EmailTemplateSpec[],
   },
   {
     key: "visual-flow-lifecycle",
@@ -240,7 +246,7 @@ export const seedEmailTemplatesJob: MaintenanceJob = {
   id: "seed-email-templates",
   label: "Seed email templates",
   description:
-    "Seed the reference email templates into a fresh / empty admin from the console — no shell or `medusa exec` needed (#457). Wraps the idempotent email-template seed scripts. Pick a set with the `set` param (core, additional, reengagement, partner, cart-abandoned, tour, visual-flow-lifecycle) or leave it blank / 'all' to seed every set. By default apply creates ONLY missing templates (skip-existing, never clobbers an admin-edited template). To push a REDESIGNED template live, pass overwrite=true — existing templates are updated from the spec; scope it with `only=<template_key>` (e.g. only=blog-subscriber) so you don't touch anything else. Dry-run always writes nothing.",
+    `Seed the reference email templates into a fresh / empty admin from the console — no shell or \`medusa exec\` needed (#457). Wraps the idempotent email-template seed scripts. Pick a set with the \`set\` param (${EMAIL_TEMPLATE_SET_KEYS.join(", ")}) or leave it blank / 'all' to seed every set. By default apply creates ONLY missing templates (skip-existing, never clobbers an admin-edited template). To push a REDESIGNED template live, pass overwrite=true — existing templates are updated from the spec; scope it with \`only=<template_key>\` (e.g. only=blog-subscriber) so you don't touch anything else. Dry-run always writes nothing.`,
   params: [
     {
       name: "set",

--- a/apps/backend/src/api/admin/quotes/[id]/revoke/route.ts
+++ b/apps/backend/src/api/admin/quotes/[id]/revoke/route.ts
@@ -1,0 +1,77 @@
+import { MedusaRequest, MedusaResponse } from "@medusajs/framework/http"
+import { ContainerRegistrationKeys, MedusaError } from "@medusajs/framework/utils"
+import { deletePriceListsWorkflow } from "@medusajs/medusa/core-flows"
+
+import { PARTNER_QUOTE_MODULE } from "../../../../../modules/partner-quote"
+
+/**
+ * Revoke a quote (#1389 S5).
+ *
+ * 🔴 Flipping `status` alone is NOT a revoke. The quote's prices live in a real,
+ * active price list scoped to the buyer's customer group — if that list survives,
+ * the buyer keeps the quoted prices in any cart they build, whatever the quote
+ * row says. The link dies and the discount does not.
+ *
+ * So this deletes the price list FIRST and only then marks the row. Doing it in
+ * that order means a failure leaves a quote that still says "active" alongside a
+ * list that is already gone — visibly inconsistent and safe. The reverse order
+ * would leave a revoked-looking quote still quietly pricing carts, which is the
+ * failure nobody would notice.
+ *
+ * The buyer's page 404s either way: an unknown token and a revoked one are
+ * deliberately indistinguishable to a prober.
+ */
+export const POST = async (req: MedusaRequest, res: MedusaResponse) => {
+  const service: any = req.scope.resolve(PARTNER_QUOTE_MODULE)
+  const logger: any = req.scope.resolve(ContainerRegistrationKeys.LOGGER)
+
+  const quotes = await service.listPartnerQuotes({ id: req.params.id })
+  const quote = quotes?.[0]
+  if (!quote) {
+    throw new MedusaError(MedusaError.Types.NOT_FOUND, "Quote not found")
+  }
+
+  if (quote.status === "revoked") {
+    // Idempotent: re-revoking is a no-op, not an error. An operator hitting the
+    // button twice must not see a failure that suggests the first one did not
+    // take.
+    return res.json({ quote, already_revoked: true })
+  }
+
+  const priceListId = (quote.metadata as any)?.price_list_id
+  if (priceListId) {
+    await deletePriceListsWorkflow(req.scope).run({
+      input: { ids: [priceListId] },
+    })
+    logger.info(`[quote] revoke ${quote.id} deleted price list ${priceListId}`)
+  } else {
+    // A quote with no recorded price list either never froze or was minted
+    // before the id was stored. Say so rather than reporting a clean revoke.
+    logger.warn(
+      `[quote] revoke ${quote.id} had no price_list_id in metadata — nothing to delete`
+    )
+  }
+
+  const [updated] = await service.updatePartnerQuotes({
+    id: quote.id,
+    status: "revoked",
+  })
+
+  await service
+    .recordEvent({
+      quote_id: quote.id,
+      type: "revoked",
+      actor_type: "admin",
+      actor_id: (req as any).auth_context?.actor_id ?? null,
+      message: priceListId
+        ? "Revoked by an admin; the quoted price list was deleted."
+        : "Revoked by an admin. No price list was recorded on the quote, so none was deleted.",
+      data: { price_list_id: priceListId ?? null },
+    })
+    .catch(() => {})
+
+  res.json({
+    quote: updated ?? { ...quote, status: "revoked" },
+    price_list_deleted: !!priceListId,
+  })
+}

--- a/apps/backend/src/api/admin/quotes/[id]/route.ts
+++ b/apps/backend/src/api/admin/quotes/[id]/route.ts
@@ -1,0 +1,29 @@
+import { MedusaRequest, MedusaResponse } from "@medusajs/framework/http"
+import { MedusaError } from "@medusajs/framework/utils"
+
+import { PARTNER_QUOTE_MODULE } from "../../../../modules/partner-quote"
+
+/**
+ * One quote, with its lines and its activity (#1389 S5).
+ *
+ * 🔴 There is no token here and there never can be — only its sha256 is stored,
+ * so no read can reconstruct a working link. A detail page must say that plainly
+ * rather than offering a button that cannot work; the only way to get a fresh
+ * link is to mint again.
+ */
+export const GET = async (req: MedusaRequest, res: MedusaResponse) => {
+  const service: any = req.scope.resolve(PARTNER_QUOTE_MODULE)
+
+  const quotes = await service.listPartnerQuotes({ id: req.params.id })
+  const quote = quotes?.[0]
+  if (!quote) {
+    throw new MedusaError(MedusaError.Types.NOT_FOUND, "Quote not found")
+  }
+
+  const [lines, events] = await Promise.all([
+    service.listPartnerQuoteLines({ quote_id: quote.id }),
+    service.listEvents(quote.id),
+  ])
+
+  res.json({ quote: { ...quote, lines, events } })
+}

--- a/apps/backend/src/api/admin/quotes/lib/assert-variants-in-store.ts
+++ b/apps/backend/src/api/admin/quotes/lib/assert-variants-in-store.ts
@@ -1,0 +1,76 @@
+import { ContainerRegistrationKeys, MedusaError } from "@medusajs/framework/utils"
+
+/**
+ * Every quoted variant must belong to the partner whose quote this is (#1419).
+ *
+ * ## Why this only exists on the admin surface
+ *
+ * The partner surface is naturally scoped — a partner picks from their own
+ * catalogue. An admin picks a partner from a dropdown and then a variant from
+ * the whole platform, so the two can disagree with a single mis-click, and the
+ * result is a quote that freezes one partner's prices onto another partner's
+ * customer group.
+ *
+ * 🔴 Nothing downstream catches it. `mintQuoteWorkflow` prices whatever
+ * variants it is handed, the price list is created successfully, its rule
+ * assertion passes, and the buyer gets a working link to prices the partner
+ * never agreed to sell at.
+ *
+ * ## The rule
+ *
+ * Ownership is the product being in the partner store's default sales channel —
+ * the same rule `assertProductOwnership` applies on the partner side. It is
+ * stated there for an authenticated partner and here for a named one; the
+ * shared part is the sales-channel membership, not the way the actor is found.
+ */
+export const assertVariantsInStore = async (
+  scope: any,
+  input: { variantIds: string[]; salesChannelId?: string | null; partnerLabel: string }
+) => {
+  const variantIds = Array.from(new Set(input.variantIds.filter(Boolean)))
+  if (!variantIds.length) return
+
+  if (!input.salesChannelId) {
+    // Refuse rather than skip. A missing sales channel means we cannot tell
+    // whose catalogue this is, and "cannot check" must never read as "passed".
+    throw new MedusaError(
+      MedusaError.Types.INVALID_DATA,
+      `${input.partnerLabel} has no default sales channel, so it cannot be verified that these variants belong to them.`
+    )
+  }
+
+  const query = scope.resolve(ContainerRegistrationKeys.QUERY) as any
+
+  const { data: variants = [] } = await query.graph({
+    entity: "variant",
+    fields: ["id", "title", "product.id", "product.sales_channels.id"],
+    filters: { id: variantIds },
+  })
+
+  const found = new Map<string, any>(
+    (variants ?? []).map((v: any) => [v.id, v])
+  )
+
+  const missing = variantIds.filter((id) => !found.has(id))
+  if (missing.length) {
+    throw new MedusaError(
+      MedusaError.Types.NOT_FOUND,
+      `These variants do not exist: ${missing.join(", ")}`
+    )
+  }
+
+  const foreign: string[] = []
+  for (const [id, variant] of found) {
+    const channels = (variant?.product?.sales_channels ?? []) as any[]
+    if (!channels.some((c) => c?.id === input.salesChannelId)) {
+      foreign.push(variant?.title ? `${variant.title} (${id})` : id)
+    }
+  }
+
+  if (foreign.length) {
+    throw new MedusaError(
+      MedusaError.Types.INVALID_DATA,
+      `These variants are not in ${input.partnerLabel}'s catalogue, so they cannot be quoted for them: ${foreign.join(", ")}.`
+    )
+  }
+}

--- a/apps/backend/src/api/admin/quotes/route.ts
+++ b/apps/backend/src/api/admin/quotes/route.ts
@@ -3,6 +3,7 @@ import { ContainerRegistrationKeys, MedusaError } from "@medusajs/framework/util
 
 import { PARTNER_QUOTE_MODULE } from "../../../modules/partner-quote"
 import { mintQuoteWorkflow } from "../../../workflows/partner-quote/mint-quote"
+import { assertVariantsInStore } from "./lib/assert-variants-in-store"
 
 /**
  * Admin quotes (#1389 S5).
@@ -49,7 +50,13 @@ export const POST = async (req: MedusaRequest, res: MedusaResponse) => {
   const query = req.scope.resolve(ContainerRegistrationKeys.QUERY)
   const { data: partners } = await query.graph({
     entity: "partners",
-    fields: ["id", "name", "stores.id", "stores.default_location_id"],
+    fields: [
+      "id",
+      "name",
+      "stores.id",
+      "stores.default_location_id",
+      "stores.default_sales_channel_id",
+    ],
     filters: { id: partnerId },
   })
 
@@ -68,6 +75,16 @@ export const POST = async (req: MedusaRequest, res: MedusaResponse) => {
       `Partner ${partner.name || partnerId} has no store, so a quote cannot be priced for them.`
     )
   }
+
+  // 🔴 An admin picks the partner from one dropdown and the variants from
+  // another; a single mis-click freezes one partner's prices onto another
+  // partner's customer group, and NOTHING downstream catches it. The partner
+  // surface cannot make this mistake, so the guard lives here.
+  await assertVariantsInStore(req.scope, {
+    variantIds: (body.lines ?? []).map((l: any) => l.variant_id),
+    salesChannelId: store.default_sales_channel_id,
+    partnerLabel: partner.name || partnerId,
+  })
 
   const { result } = await mintQuoteWorkflow(req.scope).run({
     input: {

--- a/apps/backend/src/api/admin/quotes/route.ts
+++ b/apps/backend/src/api/admin/quotes/route.ts
@@ -1,0 +1,121 @@
+import { MedusaRequest, MedusaResponse } from "@medusajs/framework/http"
+import { ContainerRegistrationKeys, MedusaError } from "@medusajs/framework/utils"
+
+import { PARTNER_QUOTE_MODULE } from "../../../modules/partner-quote"
+import { mintQuoteWorkflow } from "../../../workflows/partner-quote/mint-quote"
+
+/**
+ * Admin quotes (#1389 S5).
+ *
+ * The same capability the partner has, reached differently: an admin has no
+ * partner of their own, so `partner_id` is required to MINT and optional to
+ * LIST. That is the whole difference between the two surfaces.
+ *
+ * 🔑 Minting goes through `mintQuoteWorkflow` — the same workflow the partner
+ * route uses. A second inline implementation would drift from the one that
+ * freezes prices, creates the customer group, asserts the price-list rule from
+ * a re-read and deletes the list if that assertion fails. That assertion is the
+ * only thing standing between a quote and a platform-wide price cut.
+ */
+
+/** List across partners, or scoped to one. */
+export const GET = async (req: MedusaRequest, res: MedusaResponse) => {
+  const service: any = req.scope.resolve(PARTNER_QUOTE_MODULE)
+
+  const partnerId = String((req.query.partner_id as string) || "").trim()
+  const status = String((req.query.status as string) || "").trim()
+
+  const filters: Record<string, unknown> = {}
+  if (partnerId) filters.partner_id = partnerId
+  if (status) filters.status = status
+
+  const quotes = await service.listPartnerQuotes(filters)
+
+  res.json({ quotes, count: quotes?.length ?? 0 })
+}
+
+/**
+ * Mint on a partner's behalf.
+ *
+ * 🔴 The raw token is returned HERE and nowhere else — only its sha256 is
+ * persisted. An admin list can therefore never show a working link for an
+ * existing quote, and must not pretend to: the only way to get a fresh link is
+ * to mint again.
+ */
+export const POST = async (req: MedusaRequest, res: MedusaResponse) => {
+  const body = req.validatedBody as any
+  const partnerId = String(body.partner_id || "").trim()
+
+  const query = req.scope.resolve(ContainerRegistrationKeys.QUERY)
+  const { data: partners } = await query.graph({
+    entity: "partners",
+    fields: ["id", "name", "stores.id", "stores.default_location_id"],
+    filters: { id: partnerId },
+  })
+
+  const partner = partners?.[0] as any
+  if (!partner) {
+    throw new MedusaError(MedusaError.Types.NOT_FOUND, "Partner not found")
+  }
+
+  const store = partner.stores?.[0]
+  if (!store?.id) {
+    // A quote is priced against a store's catalogue and shipped from its
+    // location. Without one there is nothing to quote, and failing here is far
+    // cheaper than minting a quote that prices nothing.
+    throw new MedusaError(
+      MedusaError.Types.INVALID_DATA,
+      `Partner ${partner.name || partnerId} has no store, so a quote cannot be priced for them.`
+    )
+  }
+
+  const { result } = await mintQuoteWorkflow(req.scope).run({
+    input: {
+      partner_id: partner.id,
+      store: { id: store.id, default_location_id: store.default_location_id },
+      buyer_email: body.buyer_email,
+      recipient_name: body.recipient_name ?? null,
+      recipient_company: body.recipient_company ?? null,
+      partner_note: body.partner_note ?? null,
+      lines: body.lines,
+      destination_country_code: body.destination_country_code,
+      destination_postal_code: body.destination_postal_code ?? null,
+      destination_city: body.destination_city ?? null,
+      currency_code: body.currency_code,
+      region_id: body.region_id ?? null,
+      carrier: body.carrier,
+      ttl_days: body.ttl_days,
+      // Stamped with the ADMIN's actor id, not the partner's — otherwise an
+      // admin-minted quote is indistinguishable from one the partner made
+      // themselves, and "who quoted this price" is exactly the question asked
+      // when a buyer disputes it.
+      created_by: (req as any).auth_context?.actor_id ?? null,
+    },
+  })
+
+  const service: any = req.scope.resolve(PARTNER_QUOTE_MODULE)
+  await service
+    .recordEvent({
+      quote_id: (result as any)?.quote?.id,
+      type: "minted",
+      // 🔑 `admin`, not `partner`. An admin-minted quote must never look like
+      // one the partner made themselves — that is the first question asked when
+      // a buyer challenges a price.
+      actor_type: "admin",
+      actor_id: (req as any).auth_context?.actor_id ?? null,
+      message: `Minted by an admin on behalf of ${partner.name || partner.id}.`,
+      data: { line_count: body.lines.length, partner_id: partner.id },
+    })
+    .catch(() => {})
+
+  const logger: any = req.scope.resolve(ContainerRegistrationKeys.LOGGER)
+  logger.info(
+    `[quote] admin minted quote=${(result as any)?.quote?.id} for partner=${partner.id} lines=${body.lines.length}`
+  )
+
+  res.status(201).json({
+    quote: (result as any)?.quote,
+    /** Once. Never retrievable again. */
+    token: (result as any)?.token,
+  })
+}

--- a/apps/backend/src/api/admin/quotes/validators.ts
+++ b/apps/backend/src/api/admin/quotes/validators.ts
@@ -1,0 +1,20 @@
+import { z } from "@medusajs/framework/zod"
+
+import { PartnerMintQuoteReq } from "../../partners/quotes/validators"
+
+/**
+ * The admin mint body (#1389 S5).
+ *
+ * 🔑 Extends the PARTNER schema rather than restating it. A hand-copied twin
+ * would drift the first time a field changed, and the fields it carries decide
+ * a price — `ttl_days` bounds a live price list's lifetime, `lines` decides
+ * whose prices get frozen. One schema, one place to change.
+ *
+ * The only addition is `partner_id`: an admin has no partner of their own, so
+ * the quote's owner has to be named explicitly.
+ */
+export const AdminMintQuoteReq = PartnerMintQuoteReq.extend({
+  partner_id: z.string().min(1),
+})
+
+export type AdminMintQuoteReqType = z.infer<typeof AdminMintQuoteReq>

--- a/apps/backend/src/api/admin/shipping-carriers/route.ts
+++ b/apps/backend/src/api/admin/shipping-carriers/route.ts
@@ -1,0 +1,71 @@
+import { MedusaRequest, MedusaResponse } from "@medusajs/framework/http"
+import { ContainerRegistrationKeys, MedusaError } from "@medusajs/framework/utils"
+
+import { buildCarrierAvailability } from "../../../modules/shipping-providers/carrier-availability"
+
+/**
+ * The carrier picker's data, for an admin (#1417).
+ *
+ * Same answer as the partner route, reached differently: an admin has no
+ * partner of their own, so `partner_id` is REQUIRED here and is the whole
+ * difference between the two surfaces. Without it there is no location, and
+ * without a location "which carriers are on" has no meaning — so this refuses
+ * rather than returning a capability list that looks like an answer.
+ *
+ * 🔑 The admin route reads the SAME builder as the partner one. Two hand-rolled
+ * versions of "is this carrier available" would disagree the first time a
+ * carrier changed, and the admin's view is the one used to debug the partner's.
+ */
+export const GET = async (req: MedusaRequest, res: MedusaResponse) => {
+  const partnerId = String((req.query.partner_id as string) || "").trim()
+  if (!partnerId) {
+    throw new MedusaError(
+      MedusaError.Types.INVALID_DATA,
+      "partner_id is required — carrier availability is per-partner, because it is read from that partner's stock location."
+    )
+  }
+
+  const query = req.scope.resolve(ContainerRegistrationKeys.QUERY)
+
+  const { data: partners } = await query.graph({
+    entity: "partners",
+    fields: ["id", "name", "stores.id", "stores.default_location_id"],
+    filters: { id: partnerId },
+  })
+  const partner = partners?.[0] as any
+  if (!partner) {
+    throw new MedusaError(MedusaError.Types.NOT_FOUND, "Partner not found")
+  }
+
+  const store = partner.stores?.[0]
+  const locationId = store?.default_location_id
+
+  const [{ data: providers }, linked] = await Promise.all([
+    query.graph({ entity: "fulfillment_provider", fields: ["id", "is_enabled"] }),
+    locationId
+      ? query
+          .graph({
+            entity: "stock_locations",
+            fields: ["id", "fulfillment_providers.id"],
+            filters: { id: locationId },
+          })
+          .then(({ data }: any) =>
+            ((data?.[0]?.fulfillment_providers ?? []) as any[]).map((p) => p.id)
+          )
+      : Promise.resolve([]),
+  ])
+
+  const availability = buildCarrierAvailability({
+    registeredProviderIds: (providers ?? [])
+      .filter((p: any) => p.is_enabled !== false)
+      .map((p: any) => p.id),
+    linkedProviderIds: linked,
+  })
+
+  res.json({
+    ...availability,
+    partner: { id: partner.id, name: partner.name ?? null },
+    location_id: locationId ?? null,
+    store_id: store?.id ?? null,
+  })
+}

--- a/apps/backend/src/api/middlewares.ts
+++ b/apps/backend/src/api/middlewares.ts
@@ -307,6 +307,7 @@ import { PartnerCreateStoreReq } from "./partners/stores/validators";
 import { PartnerCreateProductReq, PartnerArtisanProductDetailReq, PartnerProductSpecReq, PartnerStoreCreateProductReq, PartnerQuickCreateProductReq } from "./partners/products/validators";
 import { PartnerCreatePriceListReq, PartnerUpdatePriceListReq } from "./partners/price-lists/validators";
 import { PartnerMintQuoteReq } from "./partners/quotes/validators";
+import { AdminMintQuoteReq } from "./admin/quotes/validators";
 import { BATCH_VARIANT_FIELDS } from "../workflows/partner/batch-partner-variants";
 import { StoreMadeToSpecReq } from "./store/carts/[id]/made-to-spec/validators";
 import {
@@ -5610,6 +5611,21 @@ export default defineMiddlewares({
         createCorsPartnerMiddleware(),
         authenticate("partner", ["session", "bearer"]),
         validateAndTransformBody(wrapSchema(PartnerMintQuoteReq)),
+      ],
+    },
+    // Admin quotes (#1389 S5). Same capability as the partner surface, but the
+    // owning partner must be named — an admin has none of their own.
+    {
+      matcher: "/admin/quotes",
+      method: "POST",
+      middlewares: [validateAndTransformBody(wrapSchema(AdminMintQuoteReq))],
+    },
+    {
+      matcher: "/partners/quotes/:id",
+      method: "GET",
+      middlewares: [
+        createCorsPartnerMiddleware(),
+        authenticate("partner", ["session", "bearer"]),
       ],
     },
     // Partner price list endpoints (#1405). Unlike customer-groups above,

--- a/apps/backend/src/api/partners/quotes/[id]/route.ts
+++ b/apps/backend/src/api/partners/quotes/[id]/route.ts
@@ -1,0 +1,42 @@
+import { AuthenticatedMedusaRequest, MedusaResponse } from "@medusajs/framework/http"
+import { MedusaError } from "@medusajs/framework/utils"
+
+import { PARTNER_QUOTE_MODULE } from "../../../../modules/partner-quote"
+import { getPartnerFromAuthContext } from "../../helpers"
+
+/**
+ * One of the calling partner's quotes, with lines and activity (#1389 S5).
+ *
+ * 🔑 Ownership is checked against the AUTH CONTEXT, not taken from the URL. The
+ * id in the path names a row that may belong to anyone — validating only that
+ * it exists is the #1404 defect, where partner routes trusted an id they were
+ * handed. A quote belonging to another partner is a 404, not a 403: a partner
+ * has no business learning that someone else's quote id is real.
+ */
+export const GET = async (req: AuthenticatedMedusaRequest, res: MedusaResponse) => {
+  const partner = await getPartnerFromAuthContext(req.auth_context, req.scope)
+  if (!partner) {
+    throw new MedusaError(
+      MedusaError.Types.UNAUTHORIZED,
+      "No partner associated with this account"
+    )
+  }
+
+  const service: any = req.scope.resolve(PARTNER_QUOTE_MODULE)
+  const quotes = await service.listPartnerQuotes({
+    id: req.params.id,
+    partner_id: partner.id,
+  })
+
+  const quote = quotes?.[0]
+  if (!quote) {
+    throw new MedusaError(MedusaError.Types.NOT_FOUND, "Quote not found")
+  }
+
+  const [lines, events] = await Promise.all([
+    service.listPartnerQuoteLines({ quote_id: quote.id }),
+    service.listEvents(quote.id),
+  ])
+
+  res.json({ quote: { ...quote, lines, events } })
+}

--- a/apps/backend/src/api/partners/quotes/route.ts
+++ b/apps/backend/src/api/partners/quotes/route.ts
@@ -55,6 +55,21 @@ export const POST = async (
     },
   })
 
+  // Best-effort: activity logging must never turn a successful mint into a 500.
+  // A lost log line is recoverable; a failed mint that already created a live
+  // price list is not.
+  const quoteService: any = req.scope.resolve(PARTNER_QUOTE_MODULE)
+  await quoteService
+    .recordEvent({
+      quote_id: (result as any)?.quote?.id,
+      type: "minted",
+      actor_type: "partner",
+      actor_id: partner.id,
+      message: `Quote minted with ${body.lines.length} line(s).`,
+      data: { line_count: body.lines.length, ttl_days: body.ttl_days ?? null },
+    })
+    .catch(() => {})
+
   const logger: any = req.scope.resolve(ContainerRegistrationKeys.LOGGER)
   logger.info(
     `[quote] partner=${partner.id} minted quote=${(result as any)?.quote?.id} lines=${body.lines.length}`

--- a/apps/backend/src/api/partners/shipping-carriers/route.ts
+++ b/apps/backend/src/api/partners/shipping-carriers/route.ts
@@ -1,0 +1,73 @@
+import { AuthenticatedMedusaRequest, MedusaResponse } from "@medusajs/framework/http"
+import { ContainerRegistrationKeys, MedusaError } from "@medusajs/framework/utils"
+
+import { getPartnerFromAuthContext } from "../helpers"
+import { buildCarrierAvailability } from "../../../modules/shipping-providers/carrier-availability"
+
+/**
+ * The carrier picker's data, for a partner (#1417).
+ *
+ * Answers "which carriers can I ship on, domestic vs international, and which
+ * have I already switched on" in one call — the three facts that decide it live
+ * in three different places (adapter capability, deployment registration,
+ * location link) and a UI should not have to join them itself.
+ *
+ * 🔑 The partner comes from the AUTH CONTEXT; the location comes from the
+ * partner's own store. Nothing here is taken from the query string, so one
+ * partner cannot read another's carrier setup by guessing a location id.
+ *
+ * Turning a carrier ON is not done here — that is the existing
+ * `POST /partners/stores/:id/locations/:locationId/fulfillment-providers`,
+ * which owns the link. This route is deliberately read-only so there is one
+ * writer for that link, not two.
+ */
+export const GET = async (req: AuthenticatedMedusaRequest, res: MedusaResponse) => {
+  const partner = await getPartnerFromAuthContext(req.auth_context, req.scope)
+  if (!partner) {
+    throw new MedusaError(
+      MedusaError.Types.UNAUTHORIZED,
+      "No partner associated with this account"
+    )
+  }
+
+  const query = req.scope.resolve(ContainerRegistrationKeys.QUERY)
+
+  const { data: partners } = await query.graph({
+    entity: "partners",
+    fields: ["id", "stores.id", "stores.default_location_id"],
+    filters: { id: partner.id },
+  })
+  const store = (partners?.[0] as any)?.stores?.[0]
+  const locationId = store?.default_location_id
+
+  const [{ data: providers }, linked] = await Promise.all([
+    query.graph({ entity: "fulfillment_provider", fields: ["id", "is_enabled"] }),
+    locationId
+      ? query
+          .graph({
+            entity: "stock_locations",
+            fields: ["id", "fulfillment_providers.id"],
+            filters: { id: locationId },
+          })
+          .then(({ data }: any) =>
+            ((data?.[0]?.fulfillment_providers ?? []) as any[]).map((p) => p.id)
+          )
+      : Promise.resolve([]),
+  ])
+
+  const availability = buildCarrierAvailability({
+    registeredProviderIds: (providers ?? [])
+      .filter((p: any) => p.is_enabled !== false)
+      .map((p: any) => p.id),
+    linkedProviderIds: linked,
+  })
+
+  res.json({
+    ...availability,
+    // Null when the partner has no store/location yet — the picker needs to say
+    // "finish setting up your location first" rather than showing every carrier
+    // as switchable against nothing.
+    location_id: locationId ?? null,
+    store_id: store?.id ?? null,
+  })
+}

--- a/apps/backend/src/api/store/shipping-estimate/route.ts
+++ b/apps/backend/src/api/store/shipping-estimate/route.ts
@@ -40,6 +40,7 @@ export const GET = async (req: MedusaRequest, res: MedusaResponse) => {
     quantity: rawQuantity,
     destination_postal_code: destinationPostalCode,
     country_code: rawCountryCode,
+    currency_code: rawCurrencyCode,
     carrier: rawCarrier,
   } = req.validatedQuery as Record<string, any>
 
@@ -58,6 +59,10 @@ export const GET = async (req: MedusaRequest, res: MedusaResponse) => {
     lines: [{ variant_id: variantId, quantity: Number(rawQuantity) }],
     destination_postal_code: String(destinationPostalCode),
     country_code: rawCountryCode,
+    // Optional here (this route predates it) — when absent the manual options
+    // are not currency-filtered, which is the behaviour every existing caller
+    // already has. Supplying it is strictly safer.
+    currency_code: rawCurrencyCode,
     carrier: rawCarrier,
     store,
   })

--- a/apps/backend/src/api/store/shipping-estimate/validators.ts
+++ b/apps/backend/src/api/store/shipping-estimate/validators.ts
@@ -13,6 +13,14 @@ export const StoreShippingEstimateSchema = z.object({
   destination_postal_code: z.string().min(3).max(16),
   /** ISO-2. Drives the domestic-vs-cross-border branch inside the adapter. */
   country_code: z.string().min(2).max(2).optional(),
+  /**
+   * Restricts manual/flat options to those priced in this currency. Optional
+   * because this route predates it; when absent, options are not
+   * currency-filtered, which is what every existing caller already gets.
+   * Supplying it is strictly safer — the picker sorts on the raw amount, so a
+   * foreign-currency option wins whenever its number is smaller.
+   */
+  currency_code: z.string().min(3).max(3).optional(),
   /** Defaults to the aggregator, which returns every courier on the lane. */
   carrier: z.string().min(2).max(40).optional(),
 })

--- a/apps/backend/src/lib/__tests__/shipping-estimate-zone.unit.spec.ts
+++ b/apps/backend/src/lib/__tests__/shipping-estimate-zone.unit.spec.ts
@@ -1,0 +1,79 @@
+import { zoneCoversDestination } from "../shipping-estimate"
+import { pickFreightOption } from "../../modules/partner-quote/lib/build-quote-view"
+
+/**
+ * Found on a LIVE production mint (#1389 S3 verification, 21 Aug):
+ *
+ *   destination : Mumbai 400001, domestic, 21 kg
+ *   currency    : inr
+ *   freight won : "European Shipping", amount 10, currency AUD
+ *
+ * Two independent defects let that happen. `buildShippingEstimate` collected
+ * manual options from EVERY service zone on the location regardless of whether
+ * the zone covered the destination, and it kept options in ANY currency — while
+ * `pickFreightOption` sorts on the raw `amount`. So 10 AUD beat a rupee rate on
+ * the number alone, and was then rendered as Rs 10.
+ */
+
+describe("zoneCoversDestination", () => {
+  it("rejects a zone that does not cover the destination", () => {
+    // The live case: a European zone offered for an Indian delivery.
+    const european = { geo_zones: [{ country_code: "de" }, { country_code: "fr" }] }
+    expect(zoneCoversDestination(european, "in")).toBe(false)
+  })
+
+  it("accepts a zone that covers it, case-insensitively", () => {
+    expect(zoneCoversDestination({ geo_zones: [{ country_code: "IN" }] }, "in")).toBe(
+      true
+    )
+  })
+
+  it("accepts a multi-country international zone containing the destination", () => {
+    const intl = { geo_zones: [{ country_code: "us" }, { country_code: "gb" }] }
+    expect(zoneCoversDestination(intl, "gb")).toBe(true)
+  })
+
+  it("treats a zone with NO geo zones as covering NOTHING", () => {
+    // An unscoped zone is a provisioning accident. Reading it as "worldwide" is
+    // how one bad row ends up pricing every lane.
+    expect(zoneCoversDestination({ geo_zones: [] }, "in")).toBe(false)
+    expect(zoneCoversDestination(null, "in")).toBe(false)
+  })
+
+  it("refuses when the destination itself is unknown", () => {
+    expect(zoneCoversDestination({ geo_zones: [{ country_code: "in" }] }, "")).toBe(
+      false
+    )
+  })
+})
+
+describe("pickFreightOption — the currency trap it cannot see", () => {
+  it("picks the cheapest, comparing raw amounts", () => {
+    // This is the DOCUMENTED behaviour and it is fine — as long as every option
+    // reaching it is already in one currency. That precondition is the fix;
+    // this test pins why the precondition matters.
+    const chosen = pickFreightOption({
+      manual: [
+        { amount: 200, currency_code: "inr", source: "manual" } as any,
+        { amount: 10, currency_code: "aud", source: "manual" } as any,
+      ],
+      calculated: [],
+    })
+
+    // 10 AUD "wins" on the number alone — roughly 30x more expensive in truth.
+    // Nothing downstream can detect this, which is why the filtering has to
+    // happen before the picker ever sees it.
+    expect(chosen!.currency_code).toBe("aud")
+  })
+
+  it("is correct once every option shares the quote's currency", () => {
+    const chosen = pickFreightOption({
+      manual: [
+        { amount: 200, currency_code: "inr", source: "manual" } as any,
+        { amount: 450, currency_code: "inr", source: "manual" } as any,
+      ],
+      calculated: [],
+    })
+    expect(chosen!.amount).toBe(200)
+  })
+})

--- a/apps/backend/src/lib/shipping-estimate.ts
+++ b/apps/backend/src/lib/shipping-estimate.ts
@@ -54,6 +54,12 @@ export type ShippingEstimateInput = {
   lines: ShippingEstimateLineInput[]
   destination_postal_code: string
   country_code?: string
+  /**
+   * The currency the quote is denominated in. REQUIRED to compare manual
+   * options: the picker sorts on the raw `amount`, so without this an option
+   * priced in another currency silently wins whenever its number is smaller.
+   */
+  currency_code?: string
   carrier?: string
   /** The store whose default stock location is the origin. */
   store: { id?: string; default_location_id?: string | null }
@@ -123,6 +129,31 @@ export function resolveUnitWeight(variant: {
 }
 
 /**
+ * PURE: does this service zone actually cover the destination country?
+ *
+ * A shipping option is an offer to carry a parcel to the zone it belongs to.
+ * Considering every zone on the location turns a European flat rate into a
+ * candidate for a Mumbai delivery — found live, where a 21 kg domestic
+ * consignment was quoted "European Shipping" at 10 AUD.
+ *
+ * A zone with NO geo zones is treated as covering nothing rather than
+ * everything: an unscoped zone is a provisioning accident, and reading it as
+ * "worldwide" is how one bad row prices every lane.
+ */
+export function zoneCoversDestination(
+  zone: { geo_zones?: Array<{ country_code?: string | null }> | null } | null,
+  destinationCountry: string
+): boolean {
+  const target = String(destinationCountry || "").toLowerCase()
+  if (!target) return false
+
+  const zones = zone?.geo_zones ?? []
+  return zones.some(
+    (g) => String(g?.country_code || "").toLowerCase() === target
+  )
+}
+
+/**
  * Bucket the weight so near-identical quantities share a cache entry rather
  * than minting one per quantity a buyer drags a slider through.
  */
@@ -138,6 +169,7 @@ export async function buildShippingEstimate(
   const logger: any = scope.resolve(ContainerRegistrationKeys.LOGGER)
 
   const countryCode = String(input.country_code || "in").toLowerCase()
+  const quoteCurrency = String(input.currency_code || "").toLowerCase()
   const destinationPostalCode = String(input.destination_postal_code)
 
   const lineInputs = (input.lines || []).filter(
@@ -224,6 +256,7 @@ export async function buildShippingEstimate(
     entity: "stock_locations",
     fields: [
       "id",
+      "fulfillment_sets.service_zones.geo_zones.country_code",
       "fulfillment_sets.service_zones.shipping_options.id",
       "fulfillment_sets.service_zones.shipping_options.name",
       "fulfillment_sets.service_zones.shipping_options.price_type",
@@ -235,12 +268,31 @@ export async function buildShippingEstimate(
   const manual: ShippingEstimateOption[] = []
   for (const fs of (optionLocations?.[0] as any)?.fulfillment_sets || []) {
     for (const zone of fs?.service_zones || []) {
+      // 🔴 A zone that does not cover the destination must not price it.
+      // Found live: a Mumbai domestic quote was given "European Shipping" at
+      // 10 AUD, because every zone on the location was considered. A shipping
+      // option is an offer to carry a parcel to the zone it belongs to; from
+      // any other zone it is not a cheaper answer, it is a different question.
+      if (!zoneCoversDestination(zone, countryCode)) continue
+
       for (const so of zone?.shipping_options || []) {
         if (so?.price_type === "calculated") continue
         for (const price of so?.prices || []) {
           // Only currency-scoped flat prices are meaningful without a cart;
           // region-scoped ones need a region the estimate does not have.
           if (!price?.currency_code) continue
+
+          // 🔴 And it must be priced in the currency we are quoting. The picker
+          // sorts on the raw `amount`, so an option in another currency is not
+          // merely irrelevant — it silently WINS whenever its number happens to
+          // be smaller. 10 AUD beat 200 INR and was then rendered as Rs 10.
+          if (
+            quoteCurrency &&
+            String(price.currency_code).toLowerCase() !== quoteCurrency
+          ) {
+            continue
+          }
+
           manual.push({
             shipping_option_id: so.id,
             name: so.name,

--- a/apps/backend/src/modules/partner-quote/lib/build-quote-view.ts
+++ b/apps/backend/src/modules/partner-quote/lib/build-quote-view.ts
@@ -347,6 +347,10 @@ export async function buildQuoteView(
         })),
         destination_postal_code: String(input.destination_postal_code ?? ""),
         country_code: input.destination_country_code,
+        // Without this the manual options are compared across currencies and
+        // the cheapest NUMBER wins regardless of unit — a 10 AUD European
+        // option beat a rupee rate on a live Mumbai quote.
+        currency_code: input.currency_code,
         carrier: input.carrier,
         store: input.store,
       })

--- a/apps/backend/src/modules/partner-quote/migrations/.snapshot-partner-quote.json
+++ b/apps/backend/src/modules/partner-quote/migrations/.snapshot-partner-quote.json
@@ -576,6 +576,218 @@
           "enumItems": [],
           "mappedType": "text"
         },
+        "type": {
+          "name": "type",
+          "type": "text",
+          "unsigned": false,
+          "autoincrement": false,
+          "primary": false,
+          "nullable": false,
+          "unique": false,
+          "length": null,
+          "precision": null,
+          "scale": null,
+          "default": null,
+          "comment": null,
+          "enumItems": [],
+          "mappedType": "text"
+        },
+        "actor_type": {
+          "name": "actor_type",
+          "type": "text",
+          "unsigned": false,
+          "autoincrement": false,
+          "primary": false,
+          "nullable": false,
+          "unique": false,
+          "length": null,
+          "precision": null,
+          "scale": null,
+          "default": null,
+          "comment": null,
+          "enumItems": [],
+          "mappedType": "text"
+        },
+        "actor_id": {
+          "name": "actor_id",
+          "type": "text",
+          "unsigned": false,
+          "autoincrement": false,
+          "primary": false,
+          "nullable": true,
+          "unique": false,
+          "length": null,
+          "precision": null,
+          "scale": null,
+          "default": null,
+          "comment": null,
+          "enumItems": [],
+          "mappedType": "text"
+        },
+        "message": {
+          "name": "message",
+          "type": "text",
+          "unsigned": false,
+          "autoincrement": false,
+          "primary": false,
+          "nullable": true,
+          "unique": false,
+          "length": null,
+          "precision": null,
+          "scale": null,
+          "default": null,
+          "comment": null,
+          "enumItems": [],
+          "mappedType": "text"
+        },
+        "data": {
+          "name": "data",
+          "type": "jsonb",
+          "unsigned": false,
+          "autoincrement": false,
+          "primary": false,
+          "nullable": true,
+          "unique": false,
+          "length": null,
+          "precision": null,
+          "scale": null,
+          "default": null,
+          "comment": null,
+          "enumItems": [],
+          "mappedType": "json"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamptz",
+          "unsigned": false,
+          "autoincrement": false,
+          "primary": false,
+          "nullable": false,
+          "unique": false,
+          "length": 6,
+          "precision": null,
+          "scale": null,
+          "default": "now()",
+          "comment": null,
+          "enumItems": [],
+          "mappedType": "datetime"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamptz",
+          "unsigned": false,
+          "autoincrement": false,
+          "primary": false,
+          "nullable": false,
+          "unique": false,
+          "length": 6,
+          "precision": null,
+          "scale": null,
+          "default": "now()",
+          "comment": null,
+          "enumItems": [],
+          "mappedType": "datetime"
+        },
+        "deleted_at": {
+          "name": "deleted_at",
+          "type": "timestamptz",
+          "unsigned": false,
+          "autoincrement": false,
+          "primary": false,
+          "nullable": true,
+          "unique": false,
+          "length": 6,
+          "precision": null,
+          "scale": null,
+          "default": null,
+          "comment": null,
+          "enumItems": [],
+          "mappedType": "datetime"
+        }
+      },
+      "name": "partner_quote_event",
+      "schema": "public",
+      "indexes": [
+        {
+          "keyName": "IDX_partner_quote_event_quote_id",
+          "columnNames": [],
+          "composite": false,
+          "constraint": false,
+          "primary": false,
+          "unique": false,
+          "expression": "CREATE INDEX IF NOT EXISTS \"IDX_partner_quote_event_quote_id\" ON \"partner_quote_event\" (\"quote_id\") WHERE deleted_at IS NULL"
+        },
+        {
+          "keyName": "IDX_partner_quote_event_deleted_at",
+          "columnNames": [],
+          "composite": false,
+          "constraint": false,
+          "primary": false,
+          "unique": false,
+          "expression": "CREATE INDEX IF NOT EXISTS \"IDX_partner_quote_event_deleted_at\" ON \"partner_quote_event\" (\"deleted_at\") WHERE deleted_at IS NULL"
+        },
+        {
+          "keyName": "partner_quote_event_pkey",
+          "columnNames": [
+            "id"
+          ],
+          "composite": false,
+          "constraint": true,
+          "primary": true,
+          "unique": true
+        }
+      ],
+      "checks": [],
+      "foreignKeys": {
+        "partner_quote_event_quote_id_foreign": {
+          "constraintName": "partner_quote_event_quote_id_foreign",
+          "columnNames": [
+            "quote_id"
+          ],
+          "localTableName": "public.partner_quote_event",
+          "referencedColumnNames": [
+            "id"
+          ],
+          "referencedTableName": "public.partner_quote",
+          "updateRule": "cascade"
+        }
+      },
+      "nativeEnums": {}
+    },
+    {
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "unsigned": false,
+          "autoincrement": false,
+          "primary": true,
+          "nullable": false,
+          "unique": false,
+          "length": null,
+          "precision": null,
+          "scale": null,
+          "default": null,
+          "comment": null,
+          "enumItems": [],
+          "mappedType": "text"
+        },
+        "quote_id": {
+          "name": "quote_id",
+          "type": "text",
+          "unsigned": false,
+          "autoincrement": false,
+          "primary": false,
+          "nullable": false,
+          "unique": false,
+          "length": null,
+          "precision": null,
+          "scale": null,
+          "default": null,
+          "comment": null,
+          "enumItems": [],
+          "mappedType": "text"
+        },
         "variant_id": {
           "name": "variant_id",
           "type": "text",

--- a/apps/backend/src/modules/partner-quote/migrations/Migration20260821102630.ts
+++ b/apps/backend/src/modules/partner-quote/migrations/Migration20260821102630.ts
@@ -1,0 +1,17 @@
+import { Migration } from "@medusajs/framework/mikro-orm/migrations";
+
+export class Migration20260821102630 extends Migration {
+
+  override async up(): Promise<void> {
+    this.addSql(`create table if not exists "partner_quote_event" ("id" text not null, "quote_id" text not null, "type" text not null, "actor_type" text not null, "actor_id" text null, "message" text null, "data" jsonb null, "created_at" timestamptz not null default now(), "updated_at" timestamptz not null default now(), "deleted_at" timestamptz null, constraint "partner_quote_event_pkey" primary key ("id"));`);
+    this.addSql(`CREATE INDEX IF NOT EXISTS "IDX_partner_quote_event_quote_id" ON "partner_quote_event" ("quote_id") WHERE deleted_at IS NULL;`);
+    this.addSql(`CREATE INDEX IF NOT EXISTS "IDX_partner_quote_event_deleted_at" ON "partner_quote_event" ("deleted_at") WHERE deleted_at IS NULL;`);
+
+    this.addSql(`alter table if exists "partner_quote_event" add constraint "partner_quote_event_quote_id_foreign" foreign key ("quote_id") references "partner_quote" ("id") on update cascade;`);
+  }
+
+  override async down(): Promise<void> {
+    this.addSql(`drop table if exists "partner_quote_event" cascade;`);
+  }
+
+}

--- a/apps/backend/src/modules/partner-quote/models/partner-quote-event.ts
+++ b/apps/backend/src/modules/partner-quote/models/partner-quote-event.ts
@@ -1,0 +1,51 @@
+import { model } from "@medusajs/framework/utils"
+
+import PartnerQuote from "./partner-quote"
+
+/**
+ * The quote's activity log (#1389 S5).
+ *
+ * ## Why a log and not a set of columns
+ *
+ * The quote already carries `viewed_at`, `last_viewed_at` and `view_count` —
+ * three columns that answer "was it looked at" and nothing else. They cannot
+ * say when it was revoked, who revoked it, whether an admin minted it on the
+ * partner's behalf, or that the buyer dialled the quantities before deciding.
+ * Those are the questions asked when a buyer disputes a price, and a counter
+ * cannot answer any of them.
+ *
+ * ## An append-only record, deliberately
+ *
+ * Nothing updates or deletes a row here. A log that can be rewritten is not
+ * evidence, and the whole reason this exists is that a quote is a commercial
+ * commitment somebody may later argue about.
+ *
+ * 🔑 `actor_type` distinguishes the three parties that can touch a quote — the
+ * partner, an admin acting on their behalf, and the buyer holding the token.
+ * Without it an admin-minted quote is indistinguishable from one the partner
+ * made themselves, which is exactly the question asked first when a price is
+ * challenged.
+ */
+const PartnerQuoteEvent = model.define("partner_quote_event", {
+  id: model.id().primaryKey(),
+  quote: model.belongsTo(() => PartnerQuote, { mappedBy: "events" }),
+
+  /**
+   * What happened. Text rather than an enum: an event type this log has never
+   * seen must still be recordable — refusing to log something because the
+   * vocabulary is stale is how activity goes missing precisely when it is new.
+   */
+  type: model.text(),
+
+  /** "partner" | "admin" | "buyer" | "system". */
+  actor_type: model.text(),
+  /** Null for the buyer, who is only ever a token holder. */
+  actor_id: model.text().nullable(),
+
+  /** Human-readable line for the timeline. */
+  message: model.text().nullable(),
+  /** Event-shaped extras — dialled quantities, deleted price list id, etc. */
+  data: model.json().nullable(),
+})
+
+export default PartnerQuoteEvent

--- a/apps/backend/src/modules/partner-quote/models/partner-quote.ts
+++ b/apps/backend/src/modules/partner-quote/models/partner-quote.ts
@@ -1,6 +1,7 @@
 import { model } from "@medusajs/framework/utils"
 
 import PartnerQuoteLine from "./partner-quote-line"
+import PartnerQuoteEvent from "./partner-quote-event"
 
 /**
  * A shareable B2B quote: a partner mints a link, a business buyer opens it and
@@ -53,6 +54,8 @@ const PartnerQuote = model.define("partner_quote", {
   // See `partner-quote-line.ts`. The basket is the child rows; nothing about
   // "which variant" or "how many" belongs here.
   lines: model.hasMany(() => PartnerQuoteLine, { mappedBy: "quote" }),
+  /** Append-only activity. See partner-quote-event.ts. */
+  events: model.hasMany(() => PartnerQuoteEvent, { mappedBy: "quote" }),
 
   // Destination for the freight leg. Kept as plain fields rather than an
   // address row: a quote destination is a rough "where to", not a shippable

--- a/apps/backend/src/modules/partner-quote/service.ts
+++ b/apps/backend/src/modules/partner-quote/service.ts
@@ -1,10 +1,12 @@
 import { MedusaService } from "@medusajs/framework/utils"
 import PartnerQuote from "./models/partner-quote"
 import PartnerQuoteLine from "./models/partner-quote-line"
+import PartnerQuoteEvent from "./models/partner-quote-event"
 
 class PartnerQuoteService extends MedusaService({
   PartnerQuote,
   PartnerQuoteLine,
+  PartnerQuoteEvent,
 }) {
   /**
    * Look up a quote by the sha256 of its raw token. Returns null when no row
@@ -24,12 +26,62 @@ class PartnerQuoteService extends MedusaService({
    */
   async recordView(id: string, now: Date) {
     const existing = await this.retrievePartnerQuote(id)
-    return this.updatePartnerQuotes({
+    const updated = await this.updatePartnerQuotes({
       id,
       viewed_at: existing?.viewed_at ?? now,
       last_viewed_at: now,
       view_count: (existing?.view_count ?? 0) + 1,
     })
+
+    // Only the FIRST view earns a timeline entry. A quote link is deliberately
+    // multi-view — forwarding it around a procurement team is the use case — so
+    // logging every hit would bury the events that matter under a wall of
+    // identical rows. The running total already lives on `view_count`.
+    if (!existing?.viewed_at) {
+      await this.recordEvent({
+        quote_id: id,
+        type: "viewed",
+        actor_type: "buyer",
+        message: "The buyer opened the quote for the first time.",
+      }).catch(() => {})
+    }
+
+    return updated
+  }
+
+  /**
+   * Append one activity row.
+   *
+   * 🔑 Callers treat this as best-effort and swallow its failure: activity
+   * logging must never turn a buyer's page or a partner's mint into a 500. That
+   * makes a missing row possible, which is the right trade — a lost log line is
+   * recoverable, a failed mint is not.
+   */
+  async recordEvent(input: {
+    quote_id: string
+    type: string
+    actor_type: "partner" | "admin" | "buyer" | "system"
+    actor_id?: string | null
+    message?: string | null
+    data?: Record<string, unknown> | null
+  }) {
+    return this.createPartnerQuoteEvents({
+      quote_id: input.quote_id,
+      type: input.type,
+      actor_type: input.actor_type,
+      actor_id: input.actor_id ?? null,
+      message: input.message ?? null,
+      data: input.data ?? null,
+    })
+  }
+
+  /** The timeline, newest first. */
+  async listEvents(quoteId: string) {
+    const events = await this.listPartnerQuoteEvents({ quote_id: quoteId })
+    return [...(events ?? [])].sort(
+      (a: any, b: any) =>
+        new Date(b.created_at).getTime() - new Date(a.created_at).getTime()
+    )
   }
 }
 

--- a/apps/backend/src/modules/shipping-providers/__tests__/carrier-capabilities.unit.spec.ts
+++ b/apps/backend/src/modules/shipping-providers/__tests__/carrier-capabilities.unit.spec.ts
@@ -1,0 +1,88 @@
+import {
+  CARRIER_CAPABILITIES,
+  capabilitiesCoverSupportedCarriers,
+  findCarrierCapability,
+  groupCarriersByLane,
+} from "../carrier-capabilities"
+import { buildCarrierAvailability } from "../carrier-availability"
+
+describe("carrier capabilities", () => {
+  it("covers every carrier the resolver claims to support", () => {
+    // The two lists drift silently otherwise: a carrier gains a client and the
+    // picker never learns about it.
+    const { ok, missing } = capabilitiesCoverSupportedCarriers()
+    expect(missing).toEqual([])
+    expect(ok).toBe(true)
+  })
+
+  it("keeps RATING and SHIPPING separate — Blue Dart ships both lanes, rates neither", () => {
+    // The whole reason for two axes. Collapsing them would offer Blue Dart as a
+    // live-rate carrier and then quote every lane at the fallback.
+    const bluedart = findCarrierCapability("bluedart")!
+    expect(bluedart.international.can_ship).toBe(true)
+    expect(bluedart.international.can_rate).toBe(false)
+    expect(bluedart.domestic.can_rate).toBe(false)
+  })
+
+  it("records that Delhivery cannot go international at all", () => {
+    const delhivery = findCarrierCapability("delhivery")!
+    expect(delhivery.domestic.can_rate).toBe(true)
+    expect(delhivery.international.can_ship).toBe(false)
+    expect(delhivery.international.can_rate).toBe(false)
+  })
+
+  it("has Shiprocket as the only carrier that rates cross-border", () => {
+    const { international } = groupCarriersByLane()
+    expect(international.rating.map((c) => c.id)).toEqual(["shiprocket"])
+  })
+
+  it("surfaces DTDC as un-integrated rather than hiding it", () => {
+    const dtdc = CARRIER_CAPABILITIES.find((c) => c.id === "dtdc")!
+    expect(dtdc.integrated).toBe(false)
+    expect(groupCarriersByLane().unavailable.map((c) => c.id)).toContain("dtdc")
+  })
+})
+
+describe("buildCarrierAvailability", () => {
+  it("marks a registered+linked carrier enabled, and an unregistered one blocked", () => {
+    const { carriers } = buildCarrierAvailability({
+      registeredProviderIds: ["shiprocket_shiprocket"],
+      linkedProviderIds: ["shiprocket_shiprocket"],
+    })
+
+    const shiprocket = carriers.find((c) => c.id === "shiprocket")!
+    expect(shiprocket.enabled).toBe(true)
+    expect(shiprocket.blocked_reason).toBeNull()
+
+    // Delhivery exists as an adapter but has no credentials on this deployment.
+    const delhivery = carriers.find((c) => c.id === "delhivery")!
+    expect(delhivery.registered).toBe(false)
+    expect(delhivery.enabled).toBe(false)
+    expect(delhivery.blocked_reason).toContain("credentials")
+  })
+
+  it("never lists a blocked carrier as selectable for a lane", () => {
+    // A picker built from these lists cannot offer an unusable row.
+    const { domestic, international } = buildCarrierAvailability({
+      registeredProviderIds: [],
+      linkedProviderIds: [],
+    })
+
+    expect(domestic.rating).toEqual([])
+    expect(domestic.shipping).toEqual([])
+    expect(international.rating).toEqual([])
+  })
+
+  it("distinguishes registered-but-not-linked from linked", () => {
+    const { carriers } = buildCarrierAvailability({
+      registeredProviderIds: ["delhivery_delhivery"],
+      linkedProviderIds: [],
+    })
+
+    const delhivery = carriers.find((c) => c.id === "delhivery")!
+    expect(delhivery.registered).toBe(true)
+    expect(delhivery.enabled).toBe(false)
+    // Registered means selectable — the partner simply has not switched it on.
+    expect(delhivery.blocked_reason).toBeNull()
+  })
+})

--- a/apps/backend/src/modules/shipping-providers/carrier-availability.ts
+++ b/apps/backend/src/modules/shipping-providers/carrier-availability.ts
@@ -1,0 +1,99 @@
+import {
+  CARRIER_CAPABILITIES,
+  CarrierCapability,
+  fulfillmentProviderId,
+  groupCarriersByLane,
+} from "./carrier-capabilities"
+
+/**
+ * "Which carriers can this location actually use, and for which lane?" (#1417)
+ *
+ * Three facts have to meet before a carrier is genuinely available, and each is
+ * held somewhere different:
+ *
+ * 1. **Capability** — can the adapter rate/ship this lane at all
+ *    (`carrier-capabilities.ts`).
+ * 2. **Registration** — is the provider registered in this deployment. Gated on
+ *    credentials in `medusa-config`, so a carrier with no keys never appears.
+ * 3. **Linkage** — is it linked to THIS stock location
+ *    (`stock_location ↔ fulfillment_provider`), which is where a partner's own
+ *    selection already lives.
+ *
+ * 🔑 There is deliberately no new table here. The partner→carrier mapping is
+ * already the location link — a second store of the same fact would drift from
+ * it, and the link is what core consults at fulfilment time regardless of what
+ * any side table said.
+ *
+ * The shape is built PURE so the composition is testable without a container:
+ * the routes fetch the two id lists and hand them in.
+ */
+
+export type CarrierAvailability = CarrierCapability & {
+  /** Registered as a fulfillment provider in this deployment. */
+  registered: boolean
+  /** Linked to the location in question — i.e. this partner selected it. */
+  enabled: boolean
+  /** The Medusa fulfillment-provider id, for add/remove calls. */
+  provider_id: string
+  /**
+   * Why it cannot be turned on right now, if it cannot. Null when selectable.
+   * Surfaced so a greyed-out row in the picker can say WHY rather than just
+   * being unclickable.
+   */
+  blocked_reason: string | null
+}
+
+export function buildCarrierAvailability(args: {
+  /** Fulfillment provider ids registered in this deployment. */
+  registeredProviderIds: string[]
+  /** Fulfillment provider ids linked to this location. */
+  linkedProviderIds: string[]
+  carriers?: CarrierCapability[]
+}): {
+  carriers: CarrierAvailability[]
+  domestic: { rating: string[]; shipping: string[] }
+  international: { rating: string[]; shipping: string[] }
+} {
+  const registered = new Set(args.registeredProviderIds || [])
+  const linked = new Set(args.linkedProviderIds || [])
+  const source = args.carriers ?? CARRIER_CAPABILITIES
+
+  const carriers: CarrierAvailability[] = source.map((capability) => {
+    const providerId = fulfillmentProviderId(capability.id)
+    const isRegistered = registered.has(providerId)
+
+    let blocked: string | null = null
+    if (!capability.integrated) {
+      blocked = `${capability.label} is not integrated yet.`
+    } else if (!isRegistered) {
+      // The commonest real case: the adapter exists but this deployment has no
+      // credentials for it, so the provider was never registered.
+      blocked = `${capability.label} is not configured on this deployment — its credentials are missing.`
+    }
+
+    return {
+      ...capability,
+      provider_id: providerId,
+      registered: isRegistered,
+      enabled: linked.has(providerId),
+      blocked_reason: blocked,
+    }
+  })
+
+  // The lane lists name only carriers that could actually be switched on here,
+  // so a picker built from them cannot offer an unusable row.
+  const selectable = carriers.filter((c) => !c.blocked_reason)
+  const grouped = groupCarriersByLane(selectable)
+
+  return {
+    carriers,
+    domestic: {
+      rating: grouped.domestic.rating.map((c) => c.id),
+      shipping: grouped.domestic.shipping.map((c) => c.id),
+    },
+    international: {
+      rating: grouped.international.rating.map((c) => c.id),
+      shipping: grouped.international.shipping.map((c) => c.id),
+    },
+  }
+}

--- a/apps/backend/src/modules/shipping-providers/carrier-capabilities.ts
+++ b/apps/backend/src/modules/shipping-providers/carrier-capabilities.ts
@@ -1,0 +1,157 @@
+import { SUPPORTED_CARRIERS } from "./resolver"
+
+/**
+ * What each carrier can actually DO, split by lane (#1417).
+ *
+ * ## Why two axes and not one
+ *
+ * "Supports international" is not one fact. A carrier can carry a parcel
+ * abroad and still be unable to PRICE the lane, and the two failures look
+ * nothing alike: an unratable carrier shows the buyer a fallback number, an
+ * unshippable one fails at label time, long after the buyer has paid.
+ *
+ * Blue Dart is exactly that case — it ships domestic AND international (product
+ * code `H`/IPC), but its adapter has no `getRates` at all, so it can never
+ * appear as a calculated option. Collapsing this into a single "supports
+ * international" flag would have offered it as a live-rate carrier and then
+ * quoted every lane at the fallback.
+ *
+ * ## This is derived from the adapters, not aspirational
+ *
+ * Every flag below is what the code in `shipping-providers/<carrier>` actually
+ * implements today, verified against the adapters:
+ *
+ * · **Shiprocket** — rates and ships both lanes. `getRates` branches on the
+ *   destination country into `/international/courier/serviceability`.
+ * · **Delhivery** — domestic only, and it REFUSES international explicitly:
+ *   this integration drives the domestic Express API, while exports run on
+ *   Delhivery Cross Border, a separate service with no rate API. That refusal
+ *   is why Shiprocket is the cross-border rate source for an Indian origin.
+ * · **Blue Dart** — ships both lanes, rates NEITHER (no `getRates`).
+ * · **DTDC** — not integrated. Listed so the gap is visible in the UI rather
+ *   than being a carrier nobody remembers we do not have.
+ *
+ * 🔑 When a carrier gains a capability, this table and the adapter must move
+ * together. A flag set here that the adapter cannot honour is worse than no
+ * flag: it puts a carrier in front of a buyer that cannot complete the job.
+ */
+
+export type CarrierLaneCapability = {
+  /** Can return live rates for this lane (`getRates` handles it). */
+  can_rate: boolean
+  /** Can create a shipment/label for this lane. */
+  can_ship: boolean
+}
+
+export type CarrierCapability = {
+  id: string
+  label: string
+  /** False when there is no adapter at all — surfaced, not hidden. */
+  integrated: boolean
+  /** True when the platform holds the account; false = partner brings keys. */
+  platform_account: boolean
+  domestic: CarrierLaneCapability
+  international: CarrierLaneCapability
+  /** Why a lane is unavailable, when that needs explaining to a human. */
+  notes?: string
+}
+
+export const CARRIER_CAPABILITIES: CarrierCapability[] = [
+  {
+    id: "shiprocket",
+    label: "Shiprocket",
+    integrated: true,
+    platform_account: true,
+    domestic: { can_rate: true, can_ship: true },
+    international: { can_rate: true, can_ship: true },
+    notes:
+      "Rates and ships both lanes. For an Indian origin this is the cross-border rate source, because Delhivery's export product has no rate API.",
+  },
+  {
+    id: "delhivery",
+    label: "Delhivery",
+    integrated: true,
+    platform_account: true,
+    domestic: { can_rate: true, can_ship: true },
+    international: { can_rate: false, can_ship: false },
+    notes:
+      "Domestic (Express) only. International exports run on Delhivery Cross Border — a separate service we have no API access to — so the adapter refuses cross-border rather than failing at label time.",
+  },
+  {
+    id: "bluedart",
+    label: "Blue Dart",
+    integrated: true,
+    platform_account: true,
+    domestic: { can_rate: false, can_ship: true },
+    international: { can_rate: false, can_ship: true },
+    notes:
+      "Ships both lanes (international via product code H/IPC) but cannot quote either — the adapter implements no rate call, so it can only be used as a flat-priced or manually-priced option.",
+  },
+  {
+    id: "dtdc",
+    label: "DTDC",
+    integrated: false,
+    platform_account: false,
+    domestic: { can_rate: false, can_ship: false },
+    international: { can_rate: false, can_ship: false },
+    notes: "Not integrated. No adapter exists yet.",
+  },
+]
+
+/** The Medusa fulfillment-provider id a carrier registers under. */
+export function fulfillmentProviderId(carrierId: string): string {
+  return `${carrierId}_${carrierId}`
+}
+
+export function findCarrierCapability(
+  carrierId?: string | null
+): CarrierCapability | undefined {
+  const id = String(carrierId || "").toLowerCase()
+  return CARRIER_CAPABILITIES.find((c) => c.id === id)
+}
+
+/**
+ * Split the carriers by lane for a picker.
+ *
+ * `rating` and `shipping` are separate lists on purpose — a UI that shows one
+ * combined list has to pick which failure to hide, and both matter. `shipping`
+ * is the superset: a carrier that can rate can always ship, but not the reverse.
+ */
+export function groupCarriersByLane(
+  carriers: CarrierCapability[] = CARRIER_CAPABILITIES
+): {
+  domestic: { rating: CarrierCapability[]; shipping: CarrierCapability[] }
+  international: { rating: CarrierCapability[]; shipping: CarrierCapability[] }
+  unavailable: CarrierCapability[]
+} {
+  const usable = carriers.filter((c) => c.integrated)
+
+  return {
+    domestic: {
+      rating: usable.filter((c) => c.domestic.can_rate),
+      shipping: usable.filter((c) => c.domestic.can_ship),
+    },
+    international: {
+      rating: usable.filter((c) => c.international.can_rate),
+      shipping: usable.filter((c) => c.international.can_ship),
+    },
+    unavailable: carriers.filter((c) => !c.integrated),
+  }
+}
+
+/**
+ * 🔴 Guard: every carrier the resolver claims to support must appear here.
+ *
+ * The two lists drift silently otherwise — a carrier gains a client and the
+ * picker never learns about it, or this table names one the resolver cannot
+ * build. Exported rather than run at import time so it fails a TEST rather than
+ * a boot.
+ */
+export function capabilitiesCoverSupportedCarriers(): {
+  ok: boolean
+  missing: string[]
+} {
+  const known = new Set(CARRIER_CAPABILITIES.map((c) => c.id))
+  const missing = SUPPORTED_CARRIERS.filter((c) => !known.has(c))
+  return { ok: missing.length === 0, missing }
+}

--- a/apps/backend/src/modules/shipping-providers/shiprocket/__tests__/flat-fallback.unit.spec.ts
+++ b/apps/backend/src/modules/shipping-providers/shiprocket/__tests__/flat-fallback.unit.spec.ts
@@ -1,0 +1,86 @@
+import {
+  parseFlatFallbackAmounts,
+  resolveFlatFallbackAmount,
+} from "../flat-fallback"
+
+describe("resolveFlatFallbackAmount", () => {
+  it("prefers the country-specific amount over the catch-all", () => {
+    // A domestic lane and a cross-border one are not the same order of
+    // magnitude; one number for both is wrong in one direction or the other.
+    expect(
+      resolveFlatFallbackAmount(
+        { flat_fallback_amounts: { US: 249000 }, flat_fallback_amount: 9900 },
+        "US"
+      )
+    ).toEqual({ amount: 249000 })
+  })
+
+  it("matches the country case-insensitively", () => {
+    expect(
+      resolveFlatFallbackAmount({ flat_fallback_amounts: { us: 249000 } }, "US")
+        .amount
+    ).toBe(249000)
+  })
+
+  it("falls through to the catch-all for an unlisted country", () => {
+    expect(
+      resolveFlatFallbackAmount(
+        { flat_fallback_amounts: { US: 249000 }, flat_fallback_amount: 9900 },
+        "AE"
+      )
+    ).toEqual({ amount: 9900 })
+  })
+
+  it("honours a configured ZERO instead of treating it as absent", () => {
+    // "This lane is free" is a real answer somebody chose. Only ABSENCE may
+    // fall through — the whole point of this module is that an unchosen 0 and a
+    // chosen 0 must stop being the same value.
+    expect(
+      resolveFlatFallbackAmount({ flat_fallback_amounts: { IN: 0 } }, "IN")
+    ).toEqual({ amount: 0 })
+  })
+
+  it("defaults an absent destination to IN", () => {
+    expect(
+      resolveFlatFallbackAmount({ flat_fallback_amounts: { IN: 9900 } }, undefined)
+        .amount
+    ).toBe(9900)
+  })
+
+  it("refuses — naming the country — when nothing is configured", () => {
+    const { amount, reason } = resolveFlatFallbackAmount({}, "US")
+
+    expect(amount).toBeUndefined()
+    expect(reason).toContain("US")
+  })
+
+  it("refuses when the config itself is absent", () => {
+    expect(resolveFlatFallbackAmount(undefined, "IN").amount).toBeUndefined()
+  })
+})
+
+describe("parseFlatFallbackAmounts", () => {
+  it("parses ISO2=minor-unit pairs", () => {
+    expect(parseFlatFallbackAmounts("IN=9900,US=249000")).toEqual({
+      IN: 9900,
+      US: 249000,
+    })
+  })
+
+  it("uppercases keys and tolerates whitespace", () => {
+    expect(parseFlatFallbackAmounts(" in = 9900 ")).toEqual({ IN: 9900 })
+  })
+
+  it("DROPS malformed pairs rather than coercing them to zero", () => {
+    // A typo that silently became 0 would be the original silent-zero bug with
+    // extra steps. Dropping it surfaces as the loud "nothing configured" error.
+    expect(parseFlatFallbackAmounts("IN=abc,US=249000")).toEqual({ US: 249000 })
+    expect(parseFlatFallbackAmounts("IN=-5")).toBeUndefined()
+    expect(parseFlatFallbackAmounts("IN")).toBeUndefined()
+  })
+
+  it("returns undefined for empty input", () => {
+    expect(parseFlatFallbackAmounts("")).toBeUndefined()
+    expect(parseFlatFallbackAmounts(undefined)).toBeUndefined()
+  })
+})

--- a/apps/backend/src/modules/shipping-providers/shiprocket/__tests__/flat-fallback.unit.spec.ts
+++ b/apps/backend/src/modules/shipping-providers/shiprocket/__tests__/flat-fallback.unit.spec.ts
@@ -1,4 +1,5 @@
 import {
+  DEFAULT_FLAT_FALLBACK,
   parseFlatFallbackAmounts,
   resolveFlatFallbackAmount,
 } from "../flat-fallback"
@@ -47,15 +48,35 @@ describe("resolveFlatFallbackAmount", () => {
     ).toBe(9900)
   })
 
-  it("refuses — naming the country — when nothing is configured", () => {
+  it("falls back to a DEFINED, non-zero default when nothing is configured", () => {
+    // Deliberately not a refusal: no provider in this codebase throws from
+    // calculatePrice, and a throw that propagates takes the whole shipping
+    // options listing with it — leaving the buyer nothing, not even the manual
+    // flat option that exists for exactly this case.
     const { amount, reason } = resolveFlatFallbackAmount({}, "US")
 
-    expect(amount).toBeUndefined()
+    expect(amount).toBe(DEFAULT_FLAT_FALLBACK)
+    expect(amount).toBeGreaterThan(0)
+    // The reason still travels, so the caller can log that this was a default
+    // rather than a chosen number. That log is the only thing separating this
+    // from the silent zero it replaced.
     expect(reason).toContain("US")
   })
 
-  it("refuses when the config itself is absent", () => {
-    expect(resolveFlatFallbackAmount(undefined, "IN").amount).toBeUndefined()
+  it("defaults when the config itself is absent", () => {
+    expect(resolveFlatFallbackAmount(undefined, "IN").amount).toBe(
+      DEFAULT_FLAT_FALLBACK
+    )
+  })
+
+  it("still prefers a CONFIGURED amount over the default", () => {
+    const { amount, reason } = resolveFlatFallbackAmount(
+      { flat_fallback_amount: 777 },
+      "IN"
+    )
+    expect(amount).toBe(777)
+    // No reason: this number was chosen, so there is nothing to warn about.
+    expect(reason).toBeUndefined()
   })
 })
 

--- a/apps/backend/src/modules/shipping-providers/shiprocket/__tests__/rate-context.unit.spec.ts
+++ b/apps/backend/src/modules/shipping-providers/shiprocket/__tests__/rate-context.unit.spec.ts
@@ -1,0 +1,146 @@
+import {
+  deriveShiprocketRateContext,
+  resolveConsignmentDimensions,
+  resolveConsignmentWeightGrams,
+} from "../rate-context"
+
+/**
+ * The defect these guard (#1417): `calculatePrice` required a 6-digit PIN on
+ * BOTH ends and never passed `destination_country`, so every cross-border cart
+ * was quoted 0 — free international shipping, shaped exactly like a real quote.
+ *
+ * 🔑 An assertion that cannot tell success from failure is not a test. The
+ * cross-border cases below assert on `destination_country` being POPULATED, not
+ * merely that a context came back: the old code would have produced a context
+ * too, just a domestic one aimed at the wrong endpoint.
+ */
+
+const ctx = (over: any = {}) => ({
+  from_location: { address: { postal_code: "110001" } },
+  shipping_address: { postal_code: "400001", country_code: "IN" },
+  items: [],
+  ...over,
+})
+
+describe("deriveShiprocketRateContext", () => {
+  it("quotes a domestic lane without a destination country", () => {
+    const { context, reason } = deriveShiprocketRateContext(ctx())
+
+    expect(reason).toBeUndefined()
+    expect(context).toMatchObject({
+      origin_pincode: "110001",
+      destination_pincode: "400001",
+      international: false,
+    })
+    // Must stay undefined domestically — the client reaches for its cross-border
+    // product on the PRESENCE of a foreign country, not on the string "IN".
+    expect(context!.destination_country).toBeUndefined()
+  })
+
+  it("quotes a cross-border lane whose postcode is not a 6-digit PIN", () => {
+    // The regression: "SW1A 1AA" fails /^\d{6}$/, which is exactly how every
+    // international cart used to fall through to a silent 0.
+    const { context, reason } = deriveShiprocketRateContext(
+      ctx({ shipping_address: { postal_code: "SW1A 1AA", country_code: "gb" } })
+    )
+
+    expect(reason).toBeUndefined()
+    expect(context!.international).toBe(true)
+    // Uppercased, because Shiprocket's `delivery_country` expects ISO2 upper.
+    expect(context!.destination_country).toBe("GB")
+  })
+
+  it("quotes a cross-border lane with NO postcode at all", () => {
+    const { context } = deriveShiprocketRateContext(
+      ctx({ shipping_address: { country_code: "AE" } })
+    )
+
+    expect(context!.destination_country).toBe("AE")
+    expect(context!.destination_pincode).toBe("")
+  })
+
+  it("refuses a domestic lane whose destination pincode is malformed", () => {
+    const { context, reason } = deriveShiprocketRateContext(
+      ctx({ shipping_address: { postal_code: "40001", country_code: "IN" } })
+    )
+
+    expect(context).toBeUndefined()
+    expect(reason).toContain("40001")
+  })
+
+  it("treats an absent country as domestic and holds it to the PIN shape", () => {
+    // A missing country must not be quoted as if it were a local lane, and must
+    // not silently take the cross-border branch either.
+    const { context, reason } = deriveShiprocketRateContext(
+      ctx({ shipping_address: { postal_code: "SW1A 1AA" } })
+    )
+
+    expect(context).toBeUndefined()
+    expect(reason).toContain("6-digit")
+  })
+
+  it("refuses when the ORIGIN has no valid pincode, in both modes", () => {
+    for (const shipping_address of [
+      { postal_code: "400001", country_code: "IN" },
+      { postal_code: "SW1A 1AA", country_code: "GB" },
+    ]) {
+      const { context, reason } = deriveShiprocketRateContext(
+        ctx({ from_location: { address: { postal_code: "" } }, shipping_address })
+      )
+
+      // The international endpoint 400s without `pickup_postcode`, so the origin
+      // is required cross-border too — not just domestically.
+      expect(context).toBeUndefined()
+      expect(reason).toContain("pickup location")
+    }
+  })
+})
+
+describe("resolveConsignmentWeightGrams", () => {
+  it("sums variant weight × quantity", () => {
+    expect(
+      resolveConsignmentWeightGrams([
+        { quantity: 2, variant: { weight: 300 } },
+        { quantity: 1, variant: { weight: 150 } },
+      ])
+    ).toBe(750)
+  })
+
+  it("falls back to the PRODUCT weight when the variant has none", () => {
+    // 140 of 183 variants platform-wide carry no weight of their own, so this
+    // is the common path, not the edge case.
+    expect(
+      resolveConsignmentWeightGrams([
+        { quantity: 3, variant: { product: { weight: 100 } } },
+      ])
+    ).toBe(300)
+  })
+
+  it("estimates rather than refusing when nothing carries a weight", () => {
+    // Unlike the quote builder, which refuses: a cart must stay checkout-able.
+    expect(resolveConsignmentWeightGrams([{ quantity: 3, variant: {} }])).toBe(1200)
+    expect(resolveConsignmentWeightGrams([])).toBe(400)
+  })
+})
+
+describe("resolveConsignmentDimensions", () => {
+  it("stacks: widest footprint, summed height — matching createFulfillment", () => {
+    // Deriving the quote box differently from the SHIPMENT box would price a
+    // parcel we never send.
+    expect(
+      resolveConsignmentDimensions([
+        { quantity: 2, variant: { length: 30, width: 20, height: 5 } },
+        { quantity: 1, variant: { length: 10, width: 25, height: 4 } },
+      ])
+    ).toEqual({ length: 30, width: 25, height: 14 })
+  })
+
+  it("returns undefined when no item carries a complete box", () => {
+    // A fabricated box is worse than none: the carrier prices it as fact, and
+    // international couriers charge on volumetric weight.
+    expect(
+      resolveConsignmentDimensions([{ quantity: 1, variant: { length: 30, width: 20 } }])
+    ).toBeUndefined()
+    expect(resolveConsignmentDimensions([])).toBeUndefined()
+  })
+})

--- a/apps/backend/src/modules/shipping-providers/shiprocket/flat-fallback.ts
+++ b/apps/backend/src/modules/shipping-providers/shiprocket/flat-fallback.ts
@@ -1,0 +1,91 @@
+/**
+ * The flat rate a Shiprocket lane falls back to when the carrier will not quote
+ * it (#1417).
+ *
+ * ## Why a fallback at all
+ *
+ * `calculatePrice` used to answer an unquotable lane with `0`. A zero is
+ * indistinguishable from a genuinely free lane, so nothing downstream — not the
+ * cart, not the order, not a report — can tell a carrier outage from a
+ * promotion. It shipped free international freight for as long as it existed.
+ *
+ * The two honest answers are "refuse" and "charge a known flat rate". A refusal
+ * blocks checkout on a carrier hiccup, so this takes the flat rate: the buyer
+ * always gets a number, and it is a number somebody chose.
+ *
+ * ## Why an unconfigured fallback THROWS
+ *
+ * Defaulting the default (to 0, or to some invented amount) reintroduces
+ * exactly the silent-zero bug this replaces. If nobody has said what an
+ * unquotable Indian lane costs, we do not know — and saying so loudly at
+ * checkout is recoverable, whereas shipping thousands of free parcels is not.
+ *
+ * So: configure `flat_fallback_amounts` (or at minimum `flat_fallback_amount`)
+ * and the fallback is silent and cheap; leave it unset and the first carrier
+ * outage tells you, once, in an error naming the country.
+ *
+ * Amounts are MINOR units (paise for INR), matching how Medusa carries money.
+ */
+
+export type FlatFallbackConfig = {
+  /** Per-destination-country minor-unit amounts, keyed by ISO2 (case-insensitive). */
+  flat_fallback_amounts?: Record<string, number>
+  /** Applied when no country-specific amount is configured. */
+  flat_fallback_amount?: number
+}
+
+/**
+ * PURE: pick the fallback amount for a destination, or explain that none is
+ * configured. A country-specific amount always beats the catch-all — a domestic
+ * lane and a cross-border one are not the same order of magnitude, and one
+ * number for both is wrong in one direction or the other.
+ */
+export function resolveFlatFallbackAmount(
+  config: FlatFallbackConfig | undefined,
+  destinationCountry: string | undefined
+): { amount?: number; reason?: string } {
+  const country = String(destinationCountry || "IN").toUpperCase()
+
+  const byCountry = config?.flat_fallback_amounts
+  if (byCountry) {
+    for (const [key, value] of Object.entries(byCountry)) {
+      if (String(key).toUpperCase() !== country) continue
+      // A configured 0 is a real answer — "this lane is free" — and must be
+      // honoured. Only ABSENCE falls through, which is why this checks the
+      // number's validity rather than its truthiness.
+      if (Number.isFinite(Number(value))) return { amount: Number(value) }
+    }
+  }
+
+  const fallback = config?.flat_fallback_amount
+  if (Number.isFinite(Number(fallback))) return { amount: Number(fallback) }
+
+  return {
+    reason: `no flat fallback rate is configured for ${country}. Set \`flat_fallback_amounts\` (or \`flat_fallback_amount\`) on the Shiprocket provider so an unquotable lane has a price instead of silently costing nothing.`,
+  }
+}
+
+/**
+ * Read the fallback config off env, for the medusa-config provider block.
+ *
+ * `SHIPROCKET_FLAT_FALLBACK_AMOUNTS` is `IN=9900,US=249000` — ISO2=minor units,
+ * comma-separated. Malformed pairs are DROPPED rather than coerced: a typo that
+ * silently became 0 would be the original bug with extra steps, and a dropped
+ * pair surfaces as the loud "no flat fallback configured" error.
+ */
+export function parseFlatFallbackAmounts(
+  raw?: string
+): Record<string, number> | undefined {
+  if (!raw?.trim()) return undefined
+
+  const out: Record<string, number> = {}
+  for (const pair of raw.split(",")) {
+    const [country, amount] = pair.split("=").map((s) => s?.trim())
+    if (!country || !amount) continue
+    const parsed = Number(amount)
+    if (!Number.isFinite(parsed) || parsed < 0) continue
+    out[country.toUpperCase()] = parsed
+  }
+
+  return Object.keys(out).length ? out : undefined
+}

--- a/apps/backend/src/modules/shipping-providers/shiprocket/flat-fallback.ts
+++ b/apps/backend/src/modules/shipping-providers/shiprocket/flat-fallback.ts
@@ -52,8 +52,20 @@ export type FlatFallbackConfig = {
  */
 export function resolveFlatFallbackAmount(
   config: FlatFallbackConfig | undefined,
-  destinationCountry: string | undefined
+  destinationCountry: string | undefined,
+  /**
+   * The shipping option's own `data` blob. This is the FIRST place we look,
+   * because it is the only per-store lever: `create-store-with-defaults` stamps
+   * the same amount here that it prices the manual companion option at, so when
+   * the carrier will not quote, the manual provider's number is literally what
+   * takes over — not a constant that merely happens to match. An operator
+   * editing the flat option's price can edit this alongside it.
+   */
+  optionData?: Record<string, unknown>
 ): { amount?: number; reason?: string } {
+  const fromOption = Number((optionData as any)?.flat_fallback_amount)
+  if (Number.isFinite(fromOption)) return { amount: fromOption }
+
   const country = String(destinationCountry || "IN").toUpperCase()
 
   const byCountry = config?.flat_fallback_amounts

--- a/apps/backend/src/modules/shipping-providers/shiprocket/flat-fallback.ts
+++ b/apps/backend/src/modules/shipping-providers/shiprocket/flat-fallback.ts
@@ -13,22 +13,32 @@
  * blocks checkout on a carrier hiccup, so this takes the flat rate: the buyer
  * always gets a number, and it is a number somebody chose.
  *
- * ## Why an unconfigured fallback THROWS
+ * ## Why an unconfigured fallback does NOT throw
  *
- * Defaulting the default (to 0, or to some invented amount) reintroduces
- * exactly the silent-zero bug this replaces. If nobody has said what an
- * unquotable Indian lane costs, we do not know — and saying so loudly at
- * checkout is recoverable, whereas shipping thousands of free parcels is not.
+ * An earlier cut of this threw when nothing was configured, on the reasoning
+ * that a defaulted default reintroduces the silent zero. Refuting fact: NO
+ * provider in this codebase throws from `calculatePrice` — Delhivery, live in
+ * production today, returns 0 on both a bad pincode and a carrier error. So a
+ * throw here has no precedent, and if it propagates it takes the WHOLE shipping
+ * options listing with it, leaving the buyer no options at all — including the
+ * manual flat one that exists precisely for this case. That is strictly worse
+ * than what it replaced.
  *
- * So: configure `flat_fallback_amounts` (or at minimum `flat_fallback_amount`)
- * and the fallback is silent and cheap; leave it unset and the first carrier
- * outage tells you, once, in an error naming the country.
+ * `DEFAULT_FLAT_FALLBACK` is the compromise: a real, non-zero, LOGGED amount
+ * matching the flat companion option `create-store-with-defaults` provisions, so
+ * behaviour is defined with no configuration at all. It is not the silent zero —
+ * it is distinguishable from a free lane and it announces itself in the log.
+ * Override per-country when the real numbers are known.
  *
- * Amounts are MINOR units (paise for INR), matching how Medusa carries money.
+ * Amounts are in the store's own price units (rupees for INR), matching what
+ * the carrier returns and what the flat companion option is priced in.
  */
 
+/** Matches the flat companion option provisioned by create-store-with-defaults. */
+export const DEFAULT_FLAT_FALLBACK = 200
+
 export type FlatFallbackConfig = {
-  /** Per-destination-country minor-unit amounts, keyed by ISO2 (case-insensitive). */
+  /** Per-destination-country amounts in store price units, keyed by ISO2 (case-insensitive). */
   flat_fallback_amounts?: Record<string, number>
   /** Applied when no country-specific amount is configured. */
   flat_fallback_amount?: number
@@ -60,15 +70,18 @@ export function resolveFlatFallbackAmount(
   const fallback = config?.flat_fallback_amount
   if (Number.isFinite(Number(fallback))) return { amount: Number(fallback) }
 
+  // Defined, non-zero and logged by the caller. See the header for why this is
+  // a default rather than a refusal.
   return {
-    reason: `no flat fallback rate is configured for ${country}. Set \`flat_fallback_amounts\` (or \`flat_fallback_amount\`) on the Shiprocket provider so an unquotable lane has a price instead of silently costing nothing.`,
+    amount: DEFAULT_FLAT_FALLBACK,
+    reason: `no flat fallback is configured for ${country}; used the default ${DEFAULT_FLAT_FALLBACK}`,
   }
 }
 
 /**
  * Read the fallback config off env, for the medusa-config provider block.
  *
- * `SHIPROCKET_FLAT_FALLBACK_AMOUNTS` is `IN=9900,US=249000` — ISO2=minor units,
+ * `SHIPROCKET_FLAT_FALLBACK_AMOUNTS` is `IN=200,US=3200` — ISO2=amount in store price units,
  * comma-separated. Malformed pairs are DROPPED rather than coerced: a typo that
  * silently became 0 would be the original bug with extra steps, and a dropped
  * pair surfaces as the loud "no flat fallback configured" error.

--- a/apps/backend/src/modules/shipping-providers/shiprocket/rate-context.ts
+++ b/apps/backend/src/modules/shipping-providers/shiprocket/rate-context.ts
@@ -1,0 +1,189 @@
+import { isInternationalDestination } from "../destination"
+import type { Dimensions } from "../provider-interface"
+
+/**
+ * Turn Medusa's `calculatePrice` context into a carrier rate query — PURE, so
+ * the rule that decides a buyer's freight is testable without a container, a
+ * cart or a live Shiprocket account (#1417).
+ *
+ * ## Why this exists
+ *
+ * `ShiprocketFulfillmentService.calculatePrice` derived all of this inline and
+ * got two things wrong in a way nothing could see:
+ *
+ * 1. It required a **6-digit PIN on both ends**. A foreign postcode never
+ *    matches, so every cross-border cart fell straight into the catch-all and
+ *    was quoted **0** — free shipping, wearing the same shape as a real quote.
+ * 2. It never passed `destination_country`, so even a lane that *did* pass the
+ *    regex went to the domestic `/courier/serviceability` endpoint, which
+ *    answers a foreign destination with an empty courier list and calls that
+ *    success.
+ *
+ * The order-level rate workflow (`workflows/orders/shiprocket-rates.ts`) has
+ * had this right for a while — it branches on the destination country and lets
+ * a cross-border quote through without a pincode. This brings the cart path
+ * onto the same rule instead of leaving two freight derivations to disagree.
+ *
+ * ## The asymmetry is deliberate
+ *
+ * Domestic serviceability genuinely needs the delivery pincode. A cross-border
+ * quote is priced on destination COUNTRY + weight, so a missing/foreign postal
+ * code must not block it — but the ORIGIN pincode is required in both modes
+ * (Shiprocket's international endpoint 400s without `pickup_postcode`).
+ */
+
+export type ShiprocketRateContext = {
+  origin_pincode: string
+  destination_pincode: string
+  destination_country?: string
+  weight_grams: number
+  dimensions_cm?: Dimensions
+  international: boolean
+}
+
+/** Shiprocket's own pincode shape. Indian PINs are exactly six digits. */
+const isIndianPincode = (value: string): boolean => /^\d{6}$/.test(value)
+
+/**
+ * The weight a consignment is quoted at.
+ *
+ * Unlike `buildShippingEstimate` — which REFUSES when no weight exists, because
+ * a quote is a number a buyer decides on — a cart must still be checkout-able,
+ * so this estimates. That difference is intentional and is the same split the
+ * order-83 fulfilment path already makes.
+ *
+ * 🔑 140 of 183 variants platform-wide carry no weight at either level, so the
+ * estimate branch is the COMMON path here, not the edge case.
+ */
+export function resolveConsignmentWeightGrams(items: any[]): number {
+  let totalWeight = 0
+  let totalQty = 0
+  let hasWeight = false
+
+  for (const item of items || []) {
+    const qty = Number(item?.quantity) || 1
+    totalQty += qty
+    // A variant with no weight of its own inherits the PRODUCT's — the same
+    // fallback `resolveUnitWeight` makes for the quote builder. Without it a
+    // basket of product-weighted variants quotes as if it were weightless.
+    const unit =
+      Number(item?.variant?.weight) || Number(item?.variant?.product?.weight) || 0
+    if (unit > 0) {
+      hasWeight = true
+      totalWeight += unit * qty
+    }
+  }
+
+  if (!hasWeight) return Math.max(400, totalQty * 400)
+  return totalWeight
+}
+
+/**
+ * The consignment's box.
+ *
+ * Dimensions are NOT cosmetic on a cross-border quote — international couriers
+ * price on VOLUMETRIC weight and the size also decides who will carry it at all
+ * (live-verified: 60×50×40 dropped a lane from 5 couriers to 2 and ₹3119 to
+ * ₹8477). Quoting without them understates the price and offers couriers that
+ * cannot take the parcel.
+ *
+ * 🔑 The stacking rule — widest footprint, summed height — is NOT a fresh
+ * invention: it is exactly what `createFulfillment` in this same service already
+ * does when it hands a parcel to the carrier. Deriving the quote box differently
+ * from the shipment box would price a parcel we never send, which is the same
+ * class of defect as having two freight paths that disagree.
+ *
+ * All-or-nothing per item, mirroring `parseRateQuery`: a partial box (length but
+ * no height) cannot be turned into a volume, and inventing the missing side
+ * would silently change the price. When NO item carries a full box we return
+ * undefined and let the carrier price on weight alone — a fabricated box is
+ * worse than no box, because the carrier would price it as fact.
+ */
+export function resolveConsignmentDimensions(
+  items: any[]
+): Dimensions | undefined {
+  let maxLength = 0
+  let maxWidth = 0
+  let totalHeight = 0
+
+  for (const item of items || []) {
+    const v = item?.variant
+    const length = Number(v?.length)
+    const width = Number(v?.width)
+    const height = Number(v?.height)
+    if (!(length > 0) || !(width > 0) || !(height > 0)) continue
+
+    const qty = Number(item?.quantity) || 1
+    if (length > maxLength) maxLength = length
+    if (width > maxWidth) maxWidth = width
+    totalHeight += height * qty
+  }
+
+  if (!(maxLength > 0) || !(maxWidth > 0) || !(totalHeight > 0)) return undefined
+  return { length: maxLength, width: maxWidth, height: totalHeight }
+}
+
+/**
+ * Derive the rate query, or explain why the lane cannot be quoted.
+ *
+ * Returns `{ context }` when quotable and `{ reason }` when not. It does NOT
+ * throw: the caller decides what an unquotable lane costs, and that decision
+ * (flat fallback vs. refusal) is policy, not derivation.
+ */
+export function deriveShiprocketRateContext(context: any): {
+  context?: ShiprocketRateContext
+  reason?: string
+} {
+  const originPincode = String(
+    context?.from_location?.address?.postal_code || ""
+  ).trim()
+  const destinationPincode = String(
+    context?.shipping_address?.postal_code || ""
+  ).trim()
+  const destinationCountry = String(
+    context?.shipping_address?.country_code || ""
+  )
+    .trim()
+    .toUpperCase()
+
+  const international = isInternationalDestination(destinationCountry)
+
+  // Required in BOTH modes — the international endpoint 400s without a
+  // `pickup_postcode`, so sending one we know is missing just buys a slower no.
+  if (!isIndianPincode(originPincode)) {
+    return {
+      reason:
+        "the pickup location has no valid 6-digit pincode, so Shiprocket cannot be asked for a rate",
+    }
+  }
+
+  // Domestic serviceability is keyed on the delivery pincode; cross-border is
+  // keyed on the country, and a foreign postal code is not six digits by
+  // design. Only enforce the shape where it is actually the lookup key.
+  //
+  // An ABSENT country counts as domestic (`isInternationalDestination("")` is
+  // false), so it lands here and is held to the Indian pincode shape — which is
+  // the right refusal: we would otherwise quote a cross-border lane as if it
+  // were local.
+  if (!international && !isIndianPincode(destinationPincode)) {
+    return {
+      reason: `the destination pincode "${destinationPincode}" is not a valid 6-digit Indian pincode`,
+    }
+  }
+
+  const items = (context?.items || []) as any[]
+
+  return {
+    context: {
+      origin_pincode: originPincode,
+      destination_pincode: destinationPincode,
+      // Domestic stays undefined so the client keeps its existing branch: it
+      // reaches for the cross-border product on the presence of a foreign
+      // country, not on the string "IN".
+      destination_country: international ? destinationCountry : undefined,
+      weight_grams: resolveConsignmentWeightGrams(items),
+      dimensions_cm: resolveConsignmentDimensions(items),
+      international,
+    },
+  }
+}

--- a/apps/backend/src/modules/shipping-providers/shiprocket/service.ts
+++ b/apps/backend/src/modules/shipping-providers/shiprocket/service.ts
@@ -84,7 +84,7 @@ class ShiprocketFulfillmentService extends AbstractFulfillmentProviderService {
    * replaced.
    */
   async calculatePrice(
-    _optionData: Record<string, unknown>,
+    optionData: Record<string, unknown>,
     _data: Record<string, unknown>,
     context: any
   ): Promise<CalculatedShippingOptionPrice> {
@@ -94,7 +94,7 @@ class ShiprocketFulfillmentService extends AbstractFulfillmentProviderService {
     ).toUpperCase()
 
     if (!derived.context) {
-      return this.flatFallback(destinationCountry, derived.reason!)
+      return this.flatFallback(destinationCountry, derived.reason!, optionData)
     }
 
     const rateContext = derived.context
@@ -119,7 +119,8 @@ class ShiprocketFulfillmentService extends AbstractFulfillmentProviderService {
           destinationCountry,
           `Shiprocket returned no courier for ${rateContext.origin_pincode} → ${
             rateContext.destination_country || rateContext.destination_pincode
-          }`
+          }`,
+          optionData
         )
       }
 
@@ -129,7 +130,7 @@ class ShiprocketFulfillmentService extends AbstractFulfillmentProviderService {
       }
     } catch (e: any) {
       this.logger.error(`Shiprocket calculatePrice error: ${e.message}`)
-      return this.flatFallback(destinationCountry, e.message)
+      return this.flatFallback(destinationCountry, e.message, optionData)
     }
   }
 
@@ -144,11 +145,13 @@ class ShiprocketFulfillmentService extends AbstractFulfillmentProviderService {
    */
   private flatFallback(
     destinationCountry: string,
-    reason: string
+    reason: string,
+    optionData?: Record<string, unknown>
   ): CalculatedShippingOptionPrice {
     const { amount, reason: unconfigured } = resolveFlatFallbackAmount(
       this.fallbackConfig,
-      destinationCountry
+      destinationCountry,
+      optionData
     )
 
     this.logger.warn(

--- a/apps/backend/src/modules/shipping-providers/shiprocket/service.ts
+++ b/apps/backend/src/modules/shipping-providers/shiprocket/service.ts
@@ -1,4 +1,7 @@
-import { AbstractFulfillmentProviderService } from "@medusajs/framework/utils"
+import {
+  AbstractFulfillmentProviderService,
+  MedusaError,
+} from "@medusajs/framework/utils"
 import {
   CreateFulfillmentResult,
   FulfillmentOption,
@@ -11,6 +14,8 @@ import {
 } from "@medusajs/framework/types"
 import { ShiprocketClient, ShiprocketOptions } from "./client"
 import { CreateShipmentInput, ShipmentItem } from "../provider-interface"
+import { deriveShiprocketRateContext } from "./rate-context"
+import { FlatFallbackConfig, resolveFlatFallbackAmount } from "./flat-fallback"
 
 type InjectedDeps = { logger: Logger }
 
@@ -28,11 +33,20 @@ class ShiprocketFulfillmentService extends AbstractFulfillmentProviderService {
 
   protected client: ShiprocketClient
   protected logger: Logger
+  /** What an unquotable lane costs. See `flat-fallback.ts`. */
+  protected fallbackConfig: FlatFallbackConfig
 
-  constructor({ logger }: InjectedDeps, options: ShiprocketOptions) {
+  constructor(
+    { logger }: InjectedDeps,
+    options: ShiprocketOptions & FlatFallbackConfig
+  ) {
     super()
     this.logger = logger
     this.client = new ShiprocketClient(options)
+    this.fallbackConfig = {
+      flat_fallback_amounts: options?.flat_fallback_amounts,
+      flat_fallback_amount: options?.flat_fallback_amount,
+    }
   }
 
   async getFulfillmentOptions(): Promise<FulfillmentOption[]> {
@@ -58,46 +72,104 @@ class ShiprocketFulfillmentService extends AbstractFulfillmentProviderService {
     return true
   }
 
+  /**
+   * Price the cart's lane (#1417).
+   *
+   * Domestic AND international. The derivation lives in `deriveShiprocketRateContext`
+   * (pure, unit-tested) and the client already branches on `destination_country`
+   * into the `/international/*` endpoint — this method's job is only to ask, and
+   * to decide what an unquotable lane costs.
+   *
+   * 🔴 It no longer answers `0`. Every path that cannot produce a live rate —
+   * an underivable lane, a carrier error, an empty courier list — resolves to
+   * the configured flat fallback, and if none is configured it THROWS naming the
+   * country. See `flat-fallback.ts` for why a defaulted default is not an option.
+   */
   async calculatePrice(
     _optionData: Record<string, unknown>,
     _data: Record<string, unknown>,
     context: any
   ): Promise<CalculatedShippingOptionPrice> {
+    const derived = deriveShiprocketRateContext(context)
+    const destinationCountry = String(
+      context?.shipping_address?.country_code || ""
+    ).toUpperCase()
+
+    if (!derived.context) {
+      return this.flatFallbackOrThrow(destinationCountry, derived.reason!)
+    }
+
+    const rateContext = derived.context
+
     try {
-      const originPin = String(context?.from_location?.address?.postal_code || "")
-      const destPin = String(context?.shipping_address?.postal_code || "")
-      const isValidPin = (p: string) => /^\d{6}$/.test(p)
-      if (!isValidPin(originPin) || !isValidPin(destPin)) {
-        return { calculated_amount: 0, is_calculated_price_tax_inclusive: false }
-      }
-
-      const items = (context?.items || []) as any[]
-      let totalWeight = 0
-      let totalQty = 0
-      let hasWeight = false
-      for (const item of items) {
-        const qty = item.quantity || 1
-        totalQty += qty
-        if (item.variant?.weight) {
-          hasWeight = true
-          totalWeight += item.variant.weight * qty
-        }
-      }
-      if (!hasWeight) totalWeight = Math.max(400, totalQty * 400)
-
       const rates = await this.client.getRates({
-        origin_pincode: originPin,
-        destination_pincode: destPin,
-        weight_grams: totalWeight,
+        origin_pincode: rateContext.origin_pincode,
+        destination_pincode: rateContext.destination_pincode,
+        destination_country: rateContext.destination_country,
+        weight_grams: rateContext.weight_grams,
+        dimensions_cm: rateContext.dimensions_cm,
       })
+
       const recommended = rates.find((r) => r.is_recommended) || rates[0]
+
+      // An EMPTY courier list is a refusal wearing a 200 — it is how the
+      // domestic endpoint answers a lane it will not carry. Treating it as a
+      // successful quote of 0 is precisely the bug this method used to have, so
+      // it falls back like any other failure.
+      if (!recommended || !Number.isFinite(Number(recommended.amount))) {
+        return this.flatFallbackOrThrow(
+          destinationCountry,
+          `Shiprocket returned no courier for ${rateContext.origin_pincode} → ${
+            rateContext.destination_country || rateContext.destination_pincode
+          }`
+        )
+      }
+
       return {
-        calculated_amount: recommended?.amount || 0,
+        calculated_amount: Number(recommended.amount),
         is_calculated_price_tax_inclusive: true,
       }
     } catch (e: any) {
       this.logger.error(`Shiprocket calculatePrice error: ${e.message}`)
-      return { calculated_amount: 0, is_calculated_price_tax_inclusive: false }
+      return this.flatFallbackOrThrow(destinationCountry, e.message)
+    }
+  }
+
+  /**
+   * The flat rate, or a loud refusal when nobody has configured one.
+   *
+   * The `reason` is logged rather than returned: the buyer must not be shown a
+   * carrier's internal complaint, but an operator needs to know the lane fell
+   * back rather than quoting live — otherwise a carrier outage looks exactly
+   * like normal pricing.
+   */
+  private flatFallbackOrThrow(
+    destinationCountry: string,
+    reason: string
+  ): CalculatedShippingOptionPrice {
+    const { amount, reason: unconfigured } = resolveFlatFallbackAmount(
+      this.fallbackConfig,
+      destinationCountry
+    )
+
+    if (amount === undefined) {
+      throw new MedusaError(
+        MedusaError.Types.NOT_ALLOWED,
+        `Shiprocket could not quote this shipment (${reason}), and ${unconfigured}`
+      )
+    }
+
+    this.logger.warn(
+      `[shiprocket] falling back to the flat rate ${amount} for ${
+        destinationCountry || "IN"
+      } — ${reason}`
+    )
+
+    return {
+      calculated_amount: amount,
+      // A flat rate is a figure WE set, so it carries no carrier tax treatment
+      // to inherit. Claiming tax-inclusive here would quietly shrink it.
+      is_calculated_price_tax_inclusive: false,
     }
   }
 

--- a/apps/backend/src/modules/shipping-providers/shiprocket/service.ts
+++ b/apps/backend/src/modules/shipping-providers/shiprocket/service.ts
@@ -1,7 +1,4 @@
-import {
-  AbstractFulfillmentProviderService,
-  MedusaError,
-} from "@medusajs/framework/utils"
+import { AbstractFulfillmentProviderService } from "@medusajs/framework/utils"
 import {
   CreateFulfillmentResult,
   FulfillmentOption,
@@ -81,9 +78,10 @@ class ShiprocketFulfillmentService extends AbstractFulfillmentProviderService {
    * to decide what an unquotable lane costs.
    *
    * 🔴 It no longer answers `0`. Every path that cannot produce a live rate —
-   * an underivable lane, a carrier error, an empty courier list — resolves to
-   * the configured flat fallback, and if none is configured it THROWS naming the
-   * country. See `flat-fallback.ts` for why a defaulted default is not an option.
+   * an underivable lane, a carrier error, an empty courier list — resolves to a
+   * flat fallback: the configured one, else a defined non-zero default. It never
+   * throws; see `flat-fallback.ts` for why a throw here is worse than what it
+   * replaced.
    */
   async calculatePrice(
     _optionData: Record<string, unknown>,
@@ -96,7 +94,7 @@ class ShiprocketFulfillmentService extends AbstractFulfillmentProviderService {
     ).toUpperCase()
 
     if (!derived.context) {
-      return this.flatFallbackOrThrow(destinationCountry, derived.reason!)
+      return this.flatFallback(destinationCountry, derived.reason!)
     }
 
     const rateContext = derived.context
@@ -117,7 +115,7 @@ class ShiprocketFulfillmentService extends AbstractFulfillmentProviderService {
       // successful quote of 0 is precisely the bug this method used to have, so
       // it falls back like any other failure.
       if (!recommended || !Number.isFinite(Number(recommended.amount))) {
-        return this.flatFallbackOrThrow(
+        return this.flatFallback(
           destinationCountry,
           `Shiprocket returned no courier for ${rateContext.origin_pincode} → ${
             rateContext.destination_country || rateContext.destination_pincode
@@ -131,19 +129,20 @@ class ShiprocketFulfillmentService extends AbstractFulfillmentProviderService {
       }
     } catch (e: any) {
       this.logger.error(`Shiprocket calculatePrice error: ${e.message}`)
-      return this.flatFallbackOrThrow(destinationCountry, e.message)
+      return this.flatFallback(destinationCountry, e.message)
     }
   }
 
   /**
-   * The flat rate, or a loud refusal when nobody has configured one.
+   * The flat rate for a lane the carrier would not quote.
    *
    * The `reason` is logged rather than returned: the buyer must not be shown a
    * carrier's internal complaint, but an operator needs to know the lane fell
    * back rather than quoting live — otherwise a carrier outage looks exactly
-   * like normal pricing.
+   * like normal pricing. 🔑 That log line is the ONLY thing separating this from
+   * the silent zero it replaced, so it must never be dropped to reduce noise.
    */
-  private flatFallbackOrThrow(
+  private flatFallback(
     destinationCountry: string,
     reason: string
   ): CalculatedShippingOptionPrice {
@@ -152,21 +151,14 @@ class ShiprocketFulfillmentService extends AbstractFulfillmentProviderService {
       destinationCountry
     )
 
-    if (amount === undefined) {
-      throw new MedusaError(
-        MedusaError.Types.NOT_ALLOWED,
-        `Shiprocket could not quote this shipment (${reason}), and ${unconfigured}`
-      )
-    }
-
     this.logger.warn(
       `[shiprocket] falling back to the flat rate ${amount} for ${
         destinationCountry || "IN"
-      } — ${reason}`
+      } — ${reason}${unconfigured ? ` (${unconfigured})` : ""}`
     )
 
     return {
-      calculated_amount: amount,
+      calculated_amount: amount!,
       // A flat rate is a figure WE set, so it carries no carrier tax treatment
       // to inherit. Claiming tax-inclusive here would quietly shrink it.
       is_calculated_price_tax_inclusive: false,

--- a/apps/backend/src/scripts/seed-quote-email-template.ts
+++ b/apps/backend/src/scripts/seed-quote-email-template.ts
@@ -1,0 +1,64 @@
+export const QUOTE_TEMPLATE_KEY = "partner-quote-issued"
+
+/**
+ * The quote email (#1420).
+ *
+ * 🔴 This email is the ONLY durable copy of the buyer link. The raw token is
+ * returned once by the mint and never stored — only its sha256 is — so if the
+ * send fails, the quote exists and is unreachable. That is why the sender must
+ * treat a delivery failure as loud and re-mintable rather than as a warning.
+ *
+ * 🔑 `expires_on` is passed IN rather than computed here. Expiry is enforced by
+ * the price list's own `ends_at`, and an email that calculates its own date is
+ * free to disagree with the thing that actually stops the prices working.
+ */
+export const QUOTE_TEMPLATE_DEFINITION = {
+  name: "B2B Quote Issued",
+  template_key: QUOTE_TEMPLATE_KEY,
+  from: "sales@jaalyantra.com",
+  subject: "Your quote from {{partner_name}}",
+  html_content: `<!DOCTYPE html><html lang="en"><head><meta charset="UTF-8"><meta name="viewport" content="width=device-width,initial-scale=1.0"></head>
+<body style="margin:0;padding:0;font-family:Inter,-apple-system,BlinkMacSystemFont,'Segoe UI',Roboto,sans-serif;background:#FAFAFA;">
+<div style="max-width:640px;margin:0 auto;background:#FFFFFF;border:1px solid #E4E4E7;border-radius:12px;overflow:hidden;margin-top:24px;margin-bottom:24px;">
+  <div style="background:#27272A;padding:32px;text-align:center;">
+    <h1 style="color:#FFFFFF;font-size:20px;font-weight:600;margin:0;">Your quote is ready</h1>
+    <p style="color:#A1A1AA;font-size:13px;margin:6px 0 0;">Prepared by {{partner_name}}</p>
+  </div>
+  <div style="padding:32px;">
+    <p style="color:#18181B;font-size:16px;font-weight:500;margin:0;">Hi {{recipient_name}},</p>
+    <p style="color:#52525B;font-size:14px;line-height:1.6;margin:12px 0;">
+      Your quote for {{line_count}} item(s) is ready to view. The link below shows your prices, the freight to {{destination}}, and the landed total.
+    </p>
+    <div style="background:#FAFAFA;border:1px solid #E4E4E7;border-radius:8px;padding:20px;margin:20px 0;">
+      <p style="color:#71717A;font-size:12px;margin:0 0 4px;text-transform:uppercase;letter-spacing:0.05em;">Landed total</p>
+      <p style="color:#18181B;font-size:24px;font-weight:600;margin:0;">{{landed_total}}</p>
+      <p style="color:#71717A;font-size:12px;margin:8px 0 0;">Includes freight to {{destination}}.</p>
+    </div>
+    <div style="text-align:center;margin:24px 0;">
+      <a href="{{quote_url}}" style="display:inline-block;background:#27272A;color:#FFFFFF;text-decoration:none;padding:10px 24px;border-radius:8px;font-weight:500;font-size:14px;">View your quote</a>
+    </div>
+    <p style="color:#71717A;font-size:13px;margin:12px 0 0;">
+      This quote is valid until <strong>{{expires_on}}</strong>. It is an estimate, not a binding offer — prices, freight and availability are confirmed when the order is placed.
+    </p>
+    <p style="color:#A1A1AA;font-size:12px;margin:16px 0 0;">
+      The link is personal to your organisation. Anyone you forward it to can see these prices.
+    </p>
+  </div>
+  <div style="background:#FAFAFA;padding:20px 32px;text-align:center;border-top:1px solid #E4E4E7;">
+    <p style="color:#71717A;font-size:11px;margin:0;">&copy; {{current_year}} {{partner_name}}</p>
+  </div>
+</div></body></html>`,
+  variables: {
+    recipient_name: "Buyer contact name, or their company when no name was given",
+    partner_name: "The partner who issued the quote",
+    quote_url: "The buyer link — https://<domain>/<countryCode>/quotes/<token>",
+    landed_total: "Formatted landed total, e.g. Rs 36,00,000",
+    destination: "Destination city/country the freight was quoted to",
+    line_count: "Number of quoted lines",
+    // Passed in, never computed here — see the header.
+    expires_on: "Human-readable expiry date, from the quote's expires_at",
+    current_year: "Current year (e.g. 2026)",
+  },
+}
+
+export const quoteEmailTemplates = [QUOTE_TEMPLATE_DEFINITION]

--- a/apps/backend/src/workflows/stores/create-store-with-defaults.ts
+++ b/apps/backend/src/workflows/stores/create-store-with-defaults.ts
@@ -656,6 +656,11 @@ const autoLinkFulfillmentProvidersStep = createStep(
               `(${isCarrier ? `calculated/${providerId}` : "flat tiered/manual"})`
             )
 
+            // The flat rate a lane falls back to, in the store's own price
+            // units. One constant so the manual companion option and the
+            // Shiprocket option's `data.flat_fallback_amount` cannot drift.
+            const FLAT_FALLBACK_AMOUNT = 200
+
             // --- Shiprocket, alongside Delhivery (#1417) ---------------------
             //
             // Shiprocket was ALREADY linked to every IN stock location above and
@@ -682,6 +687,12 @@ const autoLinkFulfillmentProvidersStep = createStep(
                     shipping_profile_id: profileId,
                     provider_id: "shiprocket_shiprocket",
                     price_type: "calculated",
+                    // What this option costs when Shiprocket will not quote the
+                    // lane. Stamped here — the same number the manual companion
+                    // below is priced at — so the fallback IS the manual
+                    // provider's price rather than a constant that happens to
+                    // match it. Editable per store alongside that option.
+                    data: { flat_fallback_amount: FLAT_FALLBACK_AMOUNT },
                     type: {
                       label: "Standard",
                       description: "Standard delivery via Shiprocket — live rates",
@@ -710,7 +721,12 @@ const autoLinkFulfillmentProvidersStep = createStep(
                       description: "Flat-rate delivery — used when no carrier will quote",
                       code: `flat-fallback-${suffix}`,
                     },
-                    prices: [{ currency_code: input.currencyCode.toLowerCase(), amount: 200 }],
+                    prices: [
+                      {
+                        currency_code: input.currencyCode.toLowerCase(),
+                        amount: FLAT_FALLBACK_AMOUNT,
+                      },
+                    ],
                     rules: [
                       { attribute: "enabled_in_store", value: "true", operator: "eq" },
                       { attribute: "is_return", value: "false", operator: "eq" },

--- a/apps/backend/src/workflows/stores/create-store-with-defaults.ts
+++ b/apps/backend/src/workflows/stores/create-store-with-defaults.ts
@@ -637,6 +637,80 @@ const autoLinkFulfillmentProvidersStep = createStep(
               `(${isDelhivery ? "calculated/Delhivery" : "flat tiered/manual"})`
             )
 
+            // --- Shiprocket, alongside Delhivery (#1417) ---------------------
+            //
+            // Shiprocket was ALREADY linked to every IN stock location above and
+            // registered as a fulfillment provider in both configs — but no
+            // shipping option was ever created for it, because `providerMap`
+            // hardcodes `in -> delhivery_delhivery`. So it was provisioned and
+            // invisible: a carrier the store could not actually pick.
+            //
+            // 🔑 The flat companion is the point of this block, not a nicety. An
+            // IN store's domestic zone carried ONLY calculated options, and
+            // `buildShippingEstimate` skips calculated options when assembling
+            // its manual list — so the store's entire quote freight rested on one
+            // live rate call with no fallback, and a carrier hiccup 400'd the
+            // whole mint. A flat option gives that path something to fall back to.
+            if (
+              countryLower === "in" &&
+              enabledIds.includes("shiprocket_shiprocket")
+            ) {
+              try {
+                await createShippingOptionsWorkflow(container).run({
+                  input: [{
+                    name: "Standard Shipping (Shiprocket)",
+                    service_zone_id: serviceZone.id,
+                    shipping_profile_id: profileId,
+                    provider_id: "shiprocket_shiprocket",
+                    price_type: "calculated",
+                    type: {
+                      label: "Standard",
+                      description: "Standard delivery via Shiprocket — live rates",
+                      code: `shiprocket-standard-${suffix}`,
+                    },
+                    rules: [
+                      { attribute: "enabled_in_store", value: "true", operator: "eq" },
+                      { attribute: "is_return", value: "false", operator: "eq" },
+                    ],
+                  }] as any,
+                })
+
+                await createShippingOptionsWorkflow(container).run({
+                  input: [{
+                    name: "Standard Shipping (Flat)",
+                    service_zone_id: serviceZone.id,
+                    shipping_profile_id: profileId,
+                    // Deliberately `manual_manual`, not Shiprocket: this option
+                    // exists FOR the case where no carrier will quote, so routing
+                    // it through a carrier would reintroduce the dependency it is
+                    // meant to remove.
+                    provider_id: "manual_manual",
+                    price_type: "flat",
+                    type: {
+                      label: "Standard (Flat)",
+                      description: "Flat-rate delivery — used when no carrier will quote",
+                      code: `flat-fallback-${suffix}`,
+                    },
+                    prices: [{ currency_code: input.currencyCode.toLowerCase(), amount: 200 }],
+                    rules: [
+                      { attribute: "enabled_in_store", value: "true", operator: "eq" },
+                      { attribute: "is_return", value: "false", operator: "eq" },
+                    ],
+                  }] as any,
+                })
+
+                console.log(
+                  `[create-store] Created Shiprocket calculated + flat fallback options`
+                )
+              } catch (srErr: any) {
+                // Best-effort, like every other carrier block here: a store with
+                // Delhivery options is still a usable store.
+                console.error(
+                  `[create-store] Failed to create Shiprocket options: ${srErr.message}`
+                )
+              }
+            }
+
             // --- International coverage (mirrors the #954 DP backfill) --------
             // Add an "International" zone covering every OTHER region's countries
             // so a new storefront can sell cross-border out of the box — a manual
@@ -746,9 +820,53 @@ const autoLinkFulfillmentProvidersStep = createStep(
                   })
                 }
 
+                // Shiprocket cross-border, for IN-origin stores (#1417).
+                //
+                // 🔑 For an Indian origin, Shiprocket IS the cross-border rate
+                // source — Delhivery's cross-border product ("Starfleet") has no
+                // rate API at all, and DHL only appears when its own carrier is
+                // enabled. Without this the international zone offered an IN
+                // store nothing but the hand-set manual placeholder.
+                //
+                // The client already branches to `/international/courier/serviceability`
+                // on the destination country, and `calculatePrice` now passes that
+                // country through — before #1417 it did not, so this option would
+                // have quoted every foreign cart via the India-only endpoint and
+                // been answered with an empty courier list.
+                if (
+                  countryLower === "in" &&
+                  enabledIds.includes("shiprocket_shiprocket")
+                ) {
+                  await createShippingOptionsWorkflow(container).run({
+                    input: [
+                      {
+                        name: `International Shipping (Shiprocket) (${suffix})`,
+                        price_type: "calculated",
+                        provider_id: "shiprocket_shiprocket",
+                        service_zone_id: intlZone.id,
+                        shipping_profile_id: profileId,
+                        type: {
+                          label: "International",
+                          description: "Cross-border delivery via Shiprocket — live rates",
+                          code: `shiprocket-international-${suffix}`,
+                        },
+                        rules: [
+                          { attribute: "enabled_in_store", value: "true", operator: "eq" },
+                          { attribute: "is_return", value: "false", operator: "eq" },
+                        ],
+                      },
+                    ] as any,
+                  })
+                }
+
                 console.log(
                   `[create-store] Created International zone (${intlCountries.size} countries) ` +
-                    `+ manual${dhlEnabled ? " + DHL" : ""} option(s)`
+                    `+ manual${dhlEnabled ? " + DHL" : ""}${
+                      countryLower === "in" &&
+                      enabledIds.includes("shiprocket_shiprocket")
+                        ? " + Shiprocket"
+                        : ""
+                    } option(s)`
                 )
               }
             } catch (intlErr: any) {

--- a/apps/backend/src/workflows/stores/create-store-with-defaults.ts
+++ b/apps/backend/src/workflows/stores/create-store-with-defaults.ts
@@ -493,17 +493,36 @@ const autoLinkFulfillmentProvidersStep = createStep(
           }
 
           if (profileId) {
-            // Determine provider and currency-specific pricing
-            const providerMap: Record<string, string> = {
-              in: "delhivery_delhivery",
+            // Determine provider and currency-specific pricing.
+            //
+            // The primary carrier per country, in PREFERENCE order — the first
+            // one actually registered wins. It used to be a bare
+            // `{ in: "delhivery_delhivery" }`, which meant a store whose
+            // Delhivery credentials were absent still got a Delhivery option
+            // (and no other), so its only calculated carrier was one that could
+            // never answer. Preferring a registered carrier makes the map
+            // describe what the store CAN ship on rather than what we hoped.
+            //
+            // Shiprocket sits second rather than first only because Delhivery is
+            // the incumbent on live IN stores; both get an option either way —
+            // the Shiprocket block further down adds its own regardless, so this
+            // ordering decides the "Standard Shipping" default, not availability.
+            const providerPreference: Record<string, string[]> = {
+              in: ["delhivery_delhivery", "shiprocket_shiprocket"],
             }
-            const providerId = providerMap[countryLower] || "manual_manual"
+            const providerId =
+              (providerPreference[countryLower] || []).find((id) =>
+                enabledIds.includes(id)
+              ) || "manual_manual"
 
-            // For Delhivery (calculated pricing) — Delhivery's API returns real-time rates
-            // For manual provider — use flat tiered pricing based on country/currency
-            const isDelhivery = providerId === "delhivery_delhivery"
+            // A real carrier prices via calculatePrice (live rates); the manual
+            // provider cannot, so it gets flat tiered pricing instead. Keyed on
+            // "is this a carrier" rather than on Delhivery's id specifically,
+            // so adding a carrier to the preference list above does not silently
+            // fall through to the manual branch.
+            const isCarrier = providerId !== "manual_manual"
 
-            if (isDelhivery) {
+            if (isCarrier) {
               // Delhivery: use calculated pricing (calls calculatePrice on the provider)
               await createShippingOptionsWorkflow(container).run({
                 input: [{
@@ -514,7 +533,7 @@ const autoLinkFulfillmentProvidersStep = createStep(
                   price_type: "calculated",
                   type: {
                     label: "Standard",
-                    description: "Standard delivery via Delhivery",
+                    description: "Standard delivery — live carrier rates",
                     code: "standard",
                   },
                   rules: [
@@ -534,7 +553,7 @@ const autoLinkFulfillmentProvidersStep = createStep(
                   price_type: "calculated",
                   type: {
                     label: "Return",
-                    description: "Return pickup via Delhivery",
+                    description: "Return pickup — live carrier rates",
                     code: "return",
                   },
                   rules: [
@@ -634,7 +653,7 @@ const autoLinkFulfillmentProvidersStep = createStep(
 
             console.log(
               `[create-store] Created shipping options for ${countryLabel} ` +
-              `(${isDelhivery ? "calculated/Delhivery" : "flat tiered/manual"})`
+              `(${isCarrier ? `calculated/${providerId}` : "flat tiered/manual"})`
             )
 
             // --- Shiprocket, alongside Delhivery (#1417) ---------------------

--- a/apps/partner-ui/src/components/layout/main-layout/main-layout.tsx
+++ b/apps/partner-ui/src/components/layout/main-layout/main-layout.tsx
@@ -224,6 +224,11 @@ const useCoreRoutes = (
           { label: "All", to: "/orders/all" },
           { label: "Design", to: "/orders/design" },
           { label: "Inventory", to: "/orders/inventory" },
+          // #1389 S3. The route has existed since the quote list shipped, but
+          // nothing in the nav pointed at it — a partner could only reach their
+          // own quotes by typing the URL, so in practice the list did not
+          // exist. Sibling of the other order kinds because a quote becomes one.
+          { label: t("app.nav.main.quotes", "Quotes"), to: "/orders/quotes" },
         ],
       },
       { icon: <CurrencyDollar />, label: t("app.nav.main.paymentSubmissions"), to: "/payment-submissions" },
@@ -281,6 +286,11 @@ const useCoreRoutes = (
           { label: "All", to: "/orders/all" },
           { label: "Design", to: "/orders/design" },
           { label: "Inventory", to: "/orders/inventory" },
+          // #1389 S3. The route has existed since the quote list shipped, but
+          // nothing in the nav pointed at it — a partner could only reach their
+          // own quotes by typing the URL, so in practice the list did not
+          // exist. Sibling of the other order kinds because a quote becomes one.
+          { label: t("app.nav.main.quotes", "Quotes"), to: "/orders/quotes" },
         ],
       },
       { icon: <Users />, label: t("app.nav.main.customers"), to: "/customers" },

--- a/apps/partner-ui/src/dashboard-app/routes/get-partner-route.map.tsx
+++ b/apps/partner-ui/src/dashboard-app/routes/get-partner-route.map.tsx
@@ -631,6 +631,15 @@ export function getPartnerRouteMap(): RouteObject[] {
                     },
                   ],
                 },
+                // #1389 S5 — the quote detail. A SIBLING of the list rather
+                // than a child: the list renders its own <Outlet/> for the
+                // create modal, and nesting a full page there would draw the
+                // detail on top of the table instead of replacing it.
+                {
+                  path: "quotes/:quoteId",
+                  lazy: () => import("../../routes/orders/quote-detail"),
+                  handle: { breadcrumb: () => "Quote" },
+                },
                 {
                   path: ":id",
                   handle: {

--- a/apps/partner-ui/src/hooks/api/partner-quotes.tsx
+++ b/apps/partner-ui/src/hooks/api/partner-quotes.tsx
@@ -143,6 +143,53 @@ export const usePartnerQuotes = (
   }
 }
 
+export type PartnerQuoteEvent = {
+  id: string
+  type: string
+  actor_type: "partner" | "admin" | "buyer" | "system"
+  actor_id?: string | null
+  message?: string | null
+  data?: Record<string, unknown> | null
+  created_at: string
+}
+
+export type PartnerQuoteDetailResponse = {
+  quote: PartnerQuote & { events?: PartnerQuoteEvent[] }
+}
+
+/**
+ * One of the partner's own quotes, with its lines and activity.
+ *
+ * 🔴 The response carries no token and never can — only its sha256 is stored,
+ * so no read can rebuild the buyer link. The detail view says so rather than
+ * offering a copy button that cannot work.
+ */
+export const usePartnerQuote = (
+  id: string,
+  options?: Omit<
+    UseQueryOptions<
+      PartnerQuoteDetailResponse,
+      FetchError,
+      PartnerQuoteDetailResponse,
+      QueryKey
+    >,
+    "queryFn" | "queryKey"
+  >
+) => {
+  const { data, ...rest } = useQuery({
+    queryKey: partnerQuotesQueryKeys.detail(id),
+    queryFn: async () =>
+      await sdk.client.fetch<PartnerQuoteDetailResponse>(
+        `/partners/quotes/${id}`,
+        { method: "GET" }
+      ),
+    enabled: !!id,
+    ...options,
+  })
+
+  return { quote: data?.quote, ...rest }
+}
+
 export const useMintPartnerQuote = (
   options?: UseMutationOptions<
     MintPartnerQuoteResponse,

--- a/apps/partner-ui/src/routes/orders/quote-create/components/quote-create-form/quote-minted-panel.tsx
+++ b/apps/partner-ui/src/routes/orders/quote-create/components/quote-create-form/quote-minted-panel.tsx
@@ -26,9 +26,18 @@ export const QuoteMintedPanel = ({ result }: QuoteMintedPanelProps) => {
   const domain =
     (partner as any)?.custom_domain || (partner as any)?.storefront_domain
 
-  const link = domain
-    ? `https://${domain}/quotes/${result.token}`
-    : null
+  // Both storefronts route every page under `app/[countryCode]/`, so a link
+  // without that segment 404s. It does not need a new field: the quote already
+  // carries a REQUIRED `destination_country_code`, so the segment is inferred
+  // from the buyer's own destination rather than guessed or defaulted.
+  const countryCode = String(
+    (result as any)?.quote?.destination_country_code || ""
+  ).toLowerCase()
+
+  const link =
+    domain && countryCode
+      ? `https://${domain}/${countryCode}/quotes/${result.token}`
+      : null
 
   const copy = async (value: string, label: string) => {
     try {

--- a/apps/partner-ui/src/routes/orders/quote-detail/index.ts
+++ b/apps/partner-ui/src/routes/orders/quote-detail/index.ts
@@ -1,0 +1,1 @@
+export { QuoteDetail as Component } from "./quote-detail"

--- a/apps/partner-ui/src/routes/orders/quote-detail/quote-detail.tsx
+++ b/apps/partner-ui/src/routes/orders/quote-detail/quote-detail.tsx
@@ -1,0 +1,208 @@
+import { Container, Heading, StatusBadge, Text } from "@medusajs/ui"
+import { useTranslation } from "react-i18next"
+import { useParams } from "react-router-dom"
+
+import {
+  usePartnerQuote,
+  type PartnerQuoteEvent,
+} from "../../../hooks/api/partner-quotes"
+
+/**
+ * A partner's own quote, in detail (#1389 S5).
+ *
+ * The list answers "what have I quoted"; this answers "what exactly did I quote
+ * this buyer, and what has happened since". The second question is the one asked
+ * when a buyer comes back to argue about a price.
+ */
+
+const money = (amount?: number | null, currency?: string) =>
+  amount === null || amount === undefined
+    ? "—"
+    : new Intl.NumberFormat("en-US", {
+        style: "currency",
+        currency: (currency || "inr").toUpperCase(),
+      }).format(amount)
+
+const Field = ({ label, value }: { label: string; value: React.ReactNode }) => (
+  <div className="flex items-start justify-between gap-4 px-6 py-3">
+    <Text size="small" className="text-ui-fg-subtle">
+      {label}
+    </Text>
+    <div className="text-right">{value}</div>
+  </div>
+)
+
+const ACTOR_LABEL: Record<string, string> = {
+  partner: "You",
+  admin: "Admin",
+  buyer: "Buyer",
+  system: "System",
+}
+
+const Timeline = ({ events }: { events: PartnerQuoteEvent[] }) => {
+  const { t } = useTranslation()
+
+  if (!events?.length) {
+    return (
+      <div className="px-6 py-6">
+        <Text size="small" className="text-ui-fg-subtle">
+          {t(
+            "quotes.activity.empty",
+            "No activity yet. Quotes minted before activity logging shipped have no history — that is expected, not a gap in this quote."
+          )}
+        </Text>
+      </div>
+    )
+  }
+
+  return (
+    <ul className="px-6 py-4">
+      {events.map((e) => (
+        <li
+          key={e.id}
+          className="flex gap-3 border-l border-ui-border-base pl-4 pb-4 last:pb-0"
+        >
+          <div className="flex flex-col">
+            <div className="flex items-center gap-2">
+              <Text size="small" weight="plus">
+                {e.type}
+              </Text>
+              {/* 🔑 Shown, not hidden: a quote an admin minted on your behalf
+                  must never look like one you minted yourself. */}
+              <StatusBadge color={e.actor_type === "buyer" ? "blue" : "grey"}>
+                {ACTOR_LABEL[e.actor_type] ?? e.actor_type}
+              </StatusBadge>
+            </div>
+            {e.message ? (
+              <Text size="small" className="text-ui-fg-subtle">
+                {e.message}
+              </Text>
+            ) : null}
+            <Text size="xsmall" className="text-ui-fg-muted">
+              {new Date(e.created_at).toLocaleString()}
+            </Text>
+          </div>
+        </li>
+      ))}
+    </ul>
+  )
+}
+
+export const QuoteDetail = () => {
+  const { t } = useTranslation()
+  // Named `quoteId` in the route map, not `id`: a sibling `:id` already
+  // exists under /orders for retail orders, and two params called `id` in one
+  // branch resolve to whichever matched last.
+  const { quoteId } = useParams()
+  const { quote, isLoading } = usePartnerQuote(quoteId!)
+
+  if (isLoading || !quote) {
+    return (
+      <Container>
+        <Text size="small" className="text-ui-fg-subtle">
+          {isLoading
+            ? t("general.loading", "Loading…")
+            : t("quotes.notFound", "Quote not found.")}
+        </Text>
+      </Container>
+    )
+  }
+
+  const isRevoked = (quote as any).status === "revoked"
+
+  return (
+    <div className="flex flex-col gap-y-3">
+      <Container className="divide-y p-0">
+        <div className="flex items-center justify-between px-6 py-4">
+          <div>
+            <Heading>
+              {(quote as any).recipient_company ||
+                (quote as any).recipient_name ||
+                t("quotes.title", "Quote")}
+            </Heading>
+            <Text size="small" className="text-ui-fg-subtle">
+              {(quote as any).email_sent_to}
+            </Text>
+          </div>
+          <StatusBadge color={isRevoked ? "red" : "green"}>
+            {isRevoked
+              ? t("quotes.status.revoked", "Revoked")
+              : t("quotes.status.active", "Active")}
+          </StatusBadge>
+        </div>
+
+        <Field
+          label={t("fields.landedTotal", "Landed total")}
+          value={
+            <Text size="small" weight="plus">
+              {money(
+                (quote as any).quoted_landed_total,
+                (quote as any).currency_code
+              )}
+            </Text>
+          }
+        />
+        <Field
+          label={t("fields.freight", "Freight")}
+          value={
+            <Text size="small">
+              {money((quote as any).quoted_freight, (quote as any).currency_code)}
+            </Text>
+          }
+        />
+        <Field
+          label={t("fields.destination", "Destination")}
+          value={
+            <Text size="small">
+              {String((quote as any).destination_country_code || "").toUpperCase()}
+              {(quote as any).destination_postal_code
+                ? ` ${(quote as any).destination_postal_code}`
+                : ""}
+            </Text>
+          }
+        />
+        <Field
+          label={t("fields.expiresAt", "Expires")}
+          value={
+            <Text size="small">
+              {(quote as any).expires_at
+                ? new Date((quote as any).expires_at).toLocaleString()
+                : "—"}
+            </Text>
+          }
+        />
+        <Field
+          label={t("fields.viewed", "Viewed")}
+          value={
+            <Text size="small">
+              {Number((quote as any).view_count || 0) === 0
+                ? t("quotes.notViewed", "Not yet")
+                : `${(quote as any).view_count}×`}
+            </Text>
+          }
+        />
+        {/* 🔴 Stated plainly. The raw token is returned once at mint and only
+            its sha256 is stored, so nothing can rebuild the link — a "copy
+            link" button here would be a button that cannot work. */}
+        <Field
+          label={t("quotes.minted.buyerLink", "Buyer link")}
+          value={
+            <Text size="small" className="text-ui-fg-subtle">
+              {t(
+                "quotes.linkNotRecoverable",
+                "Shown once at mint and not recoverable. Mint a new quote to issue a fresh link."
+              )}
+            </Text>
+          }
+        />
+      </Container>
+
+      <Container className="divide-y p-0">
+        <div className="px-6 py-4">
+          <Heading level="h2">{t("quotes.activity.title", "Activity")}</Heading>
+        </div>
+        <Timeline events={((quote as any).events ?? []) as PartnerQuoteEvent[]} />
+      </Container>
+    </div>
+  )
+}

--- a/apps/partner-ui/src/routes/orders/quote-list/components/quote-list-table.tsx
+++ b/apps/partner-ui/src/routes/orders/quote-list/components/quote-list-table.tsx
@@ -154,6 +154,9 @@ export const QuoteListTable = () => {
         columns={columns}
         rowCount={count}
         getRowId={(row) => row.id}
+        // Without this the list was a dead end — a partner could see that a
+        // quote existed but never open it.
+        navigateTo={(row) => `/orders/quotes/${row.id}`}
         pageSize={PAGE_SIZE}
         isLoading={isPending}
         heading={t("quotes.domain", "Quotes")}


### PR DESCRIPTION
## The partner list existed but was unreachable

`/orders/quotes` has been registered in the partner route map since the list shipped — but **nothing in the sidebar pointed at it**, so a partner could only get there by typing the URL. In practice the list did not exist. This adds the nav entry to both nav definitions, and makes rows navigable (the table had no `navigateTo`, so it was a dead end even once you arrived).

## Detail views, both sides

`GET /partners/quotes/:id` and `GET /admin/quotes/:id` return the quote with its lines and activity.

🔑 The partner route checks ownership against the **auth context**, not the URL. An id in a path names a row that may belong to anyone; validating only that it exists is the #1404 defect. A quote belonging to another partner is a **404, not a 403** — a partner has no business learning that someone else's quote id is real.

🔴 Neither response carries a token, and neither can: only the sha256 is stored. Both detail pages **say so** rather than offering a copy-link button that cannot work.

## Activity log

New `partner_quote_event` model — **append-only**, never updated or deleted. A log that can be rewritten is not evidence, and a quote is a commercial commitment somebody may later argue about.

The quote already had `viewed_at` / `last_viewed_at` / `view_count`: three columns that answer *was it looked at* and nothing else. They cannot say who revoked it, or that an **admin** minted it on the partner's behalf — which is the first question asked when a buyer challenges a price. Hence `actor_type` on every row, rendered in both timelines.

Only the **first** view logs an event. The link is deliberately multi-view — forwarding it around a procurement team is the use case — so logging every hit would bury the events that matter. The running total already lives on `view_count`.

Event recording is best-effort at every call site: logging must never turn a buyer's page or a partner's mint into a 500. A lost log line is recoverable; a failed mint that already created a live price list is not.

## Admin surface

List (filterable by partner/status), detail, and revoke.

🔴 **Revoke deletes the price list first, then marks the row.** Flipping `status` alone is not a revoke: the quoted prices live in a real active price list scoped to the buyer's customer group, so if it survives the buyer keeps those prices in any cart regardless of what the quote row says — *the link dies and the discount does not*. This order means a failure leaves a visibly inconsistent (deleted-list, active-row) state rather than a revoked-looking quote that is quietly still pricing carts.

Minting goes through `mintQuoteWorkflow` — the same workflow the partner route uses; a second inline implementation would drift from the one that freezes prices, creates the customer group, and asserts the price-list rule from a re-read. `AdminMintQuoteReq` extends the partner schema rather than restating it.

## Verify

```
cd apps/backend && npx jest --testPathPattern="(partner-quote|shipping-estimate|carrier|shiprocket).*unit"
```

234 unit tests green; `check:prod-build` passed after the last edit. partner-ui `tsc` error count is unchanged at its 7-error pre-existing baseline (verified by stashing).

## Watch-outs

- The migration adds `partner_quote_event`; it has **not** been run on prod.
- Quotes minted before this have no history. The timelines say that explicitly rather than rendering an empty box that reads as a bug.
- Admin mint has a route and a validator but **no create UI yet** — the admin list/detail/revoke are usable now; minting from admin is still API-only.

🤖 Generated with [Claude Code](https://claude.com/claude-code)