### PR TITLE
feat(quotes): the buyer quote page on apps/storefront too (#1389 S4)

### DIFF
--- a/apps/storefront/src/app/[countryCode]/(main)/quotes/[token]/page.tsx
+++ b/apps/storefront/src/app/[countryCode]/(main)/quotes/[token]/page.tsx
@@ -1,0 +1,41 @@
+import { Metadata } from "next"
+import { notFound } from "next/navigation"
+
+import { retrieveQuote } from "@lib/data/quotes"
+import QuoteTemplate from "@modules/quotes/templates"
+
+type Props = {
+  params: { countryCode: string; token: string }
+}
+
+/**
+ * 🔴 A quote link must never be indexed or crawled: the token IS the credential.
+ * `noindex, nofollow` is the minimum. The link is otherwise deliberately
+ * multi-view, because forwarding it to procurement is the use case, not an
+ * abuse of it.
+ */
+export const metadata: Metadata = {
+  title: "Your quote",
+  description: "Your quoted prices and landed cost.",
+  robots: { index: false, follow: false },
+}
+
+/**
+ * Rendered per request, never cached or statically generated: the backend
+ * records `viewed_at` / `view_count` on read, so a cached page would silently
+ * stop the view tracking the partner relies on — and would risk serving one
+ * token's document under another's key.
+ */
+export const dynamic = "force-dynamic"
+
+export default async function QuotePage({ params }: Props) {
+  const quote = await retrieveQuote(params.token)
+
+  // An unknown token and a revoked one are indistinguishable by design — the
+  // backend 404s both so a prober learns nothing, and this preserves that.
+  if (!quote) {
+    notFound()
+  }
+
+  return <QuoteTemplate quote={quote} />
+}

--- a/apps/storefront/src/lib/data/quotes.ts
+++ b/apps/storefront/src/lib/data/quotes.ts
@@ -1,0 +1,112 @@
+"use server"
+
+import { sdk } from "@lib/config"
+
+/**
+ * The buyer's quote (#1389 S4).
+ *
+ * The token in the URL is the only credential — there is no login, because
+ * asking a procurement contact to create an account before they can see a price
+ * is the wall this whole feature exists to remove. The link is deliberately
+ * multi-view: forwarding it to procurement is the use case, not an abuse of it.
+ *
+ * 🔴 Deliberately NOT cached. Every other fetcher here uses `force-cache` with
+ * a tag, but a quote is a per-token document whose backend records `viewed_at` /
+ * `view_count` on read — caching it would both leak one buyer's quote to another
+ * token's cache entry if the key were ever wrong, and silently stop the view
+ * tracking the partner relies on to know the buyer looked.
+ */
+
+export type QuoteMoney = {
+  unit_amount: number
+  subtotal: number
+  freight: number
+  landed_total: number
+}
+
+export type QuoteViewLine = {
+  variant_id: string
+  variant_title: string | null
+  product_id: string | null
+  product_title: string | null
+  product_handle: string | null
+  quantity: number
+  position: number
+  note: string | null
+  live_unit_amount: number | null
+  live_subtotal: number | null
+  quoted_unit_amount: number | null
+  quoted_subtotal: number | null
+  unit_weight_grams: number | null
+  weight_source: "variant" | "product" | null
+}
+
+export type QuoteFreightOption = {
+  name?: string
+  courier_name?: string | null
+  amount: number
+  currency_code: string
+  estimated_days?: number | null
+  source: "manual" | "calculated"
+}
+
+export type QuoteView = {
+  lines: QuoteViewLine[]
+  currency_code: string
+  destination_country_code: string
+  destination_postal_code: string | null
+  live: QuoteMoney | null
+  quoted: QuoteMoney | null
+  total_weight_grams: number | null
+  freight: {
+    chosen: QuoteFreightOption | null
+    options: QuoteFreightOption[]
+    error: string | null
+  }
+  compare: {
+    state: string
+    show_quoted: boolean
+    show_live: boolean
+    landed_delta: number | null
+    headline: string
+    explanation: string
+    disclaimer: string | null
+    expiry_notice: string | null
+  }
+  recipient: {
+    name: string | null
+    company: string | null
+    partner_note: string | null
+  }
+  expires_in_days: number | null
+  live_error: string | null
+}
+
+/**
+ * Fetch a quote by token.
+ *
+ * Returns null on ANY failure rather than throwing. An unknown token and a
+ * revoked one are both 404 by design — a prober must not be able to tell them
+ * apart — and the page turns either into the same not-found. Letting the error
+ * bubble would render a stack-shaped 500 that says more than the 404 does.
+ */
+export const retrieveQuote = async (
+  token: string,
+  lines?: Array<{ variant_id: string; quantity: number }>
+): Promise<QuoteView | null> => {
+  try {
+    const { quote } = await sdk.client.fetch<{ quote: QuoteView }>(
+      `/store/b2b/quotes/${encodeURIComponent(token)}`,
+      {
+        method: "GET",
+        // The buyer may move their quantities; absent that, the quoted basket
+        // stands. Serialised because the backend parses it as JSON.
+        query: lines?.length ? { lines: JSON.stringify(lines) } : undefined,
+        cache: "no-store",
+      }
+    )
+    return quote ?? null
+  } catch {
+    return null
+  }
+}

--- a/apps/storefront/src/modules/quotes/components/quote-lines/index.tsx
+++ b/apps/storefront/src/modules/quotes/components/quote-lines/index.tsx
@@ -1,0 +1,121 @@
+import { Text } from "@medusajs/ui"
+
+import { convertToLocale } from "@lib/util/money"
+import type { QuoteView, QuoteViewLine } from "@lib/data/quotes"
+
+/**
+ * The quoted basket, line by line.
+ *
+ * 🔑 Which columns appear is the BACKEND's decision (`compare.show_quoted` /
+ * `show_live`), not this component's. A dead link, a pre-freeze quote and a
+ * quote whose live price has moved are three different documents, and the rule
+ * that tells them apart lives in `compare.ts` alongside the headline and the
+ * disclaimer. Re-deriving it here would give the page and its own explanation
+ * two different opinions.
+ */
+const money = (amount: number | null | undefined, currency_code: string) =>
+  amount === null || amount === undefined
+    ? "—"
+    : convertToLocale({ amount, currency_code })
+
+const LineRow = ({
+  line,
+  currency_code,
+  showQuoted,
+  showLive,
+}: {
+  line: QuoteViewLine
+  currency_code: string
+  showQuoted: boolean
+  showLive: boolean
+}) => (
+  <tr className="border-b border-ui-border-base last:border-b-0">
+    <td className="py-4 pr-4 align-top">
+      <Text className="txt-medium-plus text-ui-fg-base">
+        {line.product_title ?? "Product"}
+      </Text>
+      {line.variant_title ? (
+        <Text className="txt-small text-ui-fg-subtle">{line.variant_title}</Text>
+      ) : null}
+      {line.note ? (
+        <Text className="txt-small text-ui-fg-muted italic mt-1">{line.note}</Text>
+      ) : null}
+      {/* A declared PRODUCT weight over-quotes a lighter variant, and at bulk
+          quantities that can cross a carrier slab — so where the weight came
+          from travels with the number rather than being buried. */}
+      {line.weight_source === "product" ? (
+        <Text className="txt-small text-ui-fg-muted mt-1">
+          Weight estimated from the product, not this variant.
+        </Text>
+      ) : null}
+    </td>
+    <td className="py-4 px-4 align-top text-right whitespace-nowrap">
+      <Text className="txt-medium text-ui-fg-base">{line.quantity}</Text>
+    </td>
+    {showQuoted ? (
+      <td className="py-4 px-4 align-top text-right whitespace-nowrap">
+        <Text className="txt-medium text-ui-fg-base">
+          {money(line.quoted_unit_amount, currency_code)}
+        </Text>
+        <Text className="txt-small text-ui-fg-subtle">
+          {money(line.quoted_subtotal, currency_code)}
+        </Text>
+      </td>
+    ) : null}
+    {showLive ? (
+      <td className="py-4 pl-4 align-top text-right whitespace-nowrap">
+        <Text className="txt-medium text-ui-fg-base">
+          {money(line.live_unit_amount, currency_code)}
+        </Text>
+        <Text className="txt-small text-ui-fg-subtle">
+          {money(line.live_subtotal, currency_code)}
+        </Text>
+      </td>
+    ) : null}
+  </tr>
+)
+
+const QuoteLines = ({ quote }: { quote: QuoteView }) => {
+  const { show_quoted: showQuoted, show_live: showLive } = quote.compare
+  const lines = [...quote.lines].sort((a, b) => a.position - b.position)
+
+  return (
+    <div className="overflow-x-auto">
+      <table className="w-full min-w-[32rem]">
+        <thead>
+          <tr className="border-b border-ui-border-strong">
+            <th className="py-3 pr-4 text-left">
+              <Text className="txt-small-plus text-ui-fg-subtle">Item</Text>
+            </th>
+            <th className="py-3 px-4 text-right">
+              <Text className="txt-small-plus text-ui-fg-subtle">Qty</Text>
+            </th>
+            {showQuoted ? (
+              <th className="py-3 px-4 text-right">
+                <Text className="txt-small-plus text-ui-fg-subtle">Quoted</Text>
+              </th>
+            ) : null}
+            {showLive ? (
+              <th className="py-3 pl-4 text-right">
+                <Text className="txt-small-plus text-ui-fg-subtle">Current</Text>
+              </th>
+            ) : null}
+          </tr>
+        </thead>
+        <tbody>
+          {lines.map((line) => (
+            <LineRow
+              key={line.variant_id}
+              line={line}
+              currency_code={quote.currency_code}
+              showQuoted={showQuoted}
+              showLive={showLive}
+            />
+          ))}
+        </tbody>
+      </table>
+    </div>
+  )
+}
+
+export default QuoteLines

--- a/apps/storefront/src/modules/quotes/components/quote-summary/index.tsx
+++ b/apps/storefront/src/modules/quotes/components/quote-summary/index.tsx
@@ -1,0 +1,160 @@
+import { Heading, Text } from "@medusajs/ui"
+
+import { convertToLocale } from "@lib/util/money"
+import type { QuoteMoney, QuoteView } from "@lib/data/quotes"
+
+/**
+ * The landed-cost summary — the number this whole feature exists to show.
+ *
+ * 🔑 "Landed" is the point: subtotal + freight, quoted as ONE consignment. A
+ * buyer comparing suppliers is comparing what they actually pay, which is why
+ * freight is a line here and not a footnote.
+ */
+const Row = ({
+  label,
+  value,
+  strong,
+  sub,
+}: {
+  label: string
+  value: string
+  strong?: boolean
+  sub?: string
+}) => (
+  <div className="flex items-start justify-between gap-4 py-2">
+    <div>
+      <Text
+        className={
+          strong ? "txt-medium-plus text-ui-fg-base" : "txt-medium text-ui-fg-subtle"
+        }
+      >
+        {label}
+      </Text>
+      {sub ? <Text className="txt-small text-ui-fg-muted">{sub}</Text> : null}
+    </div>
+    <Text
+      className={
+        strong
+          ? "txt-medium-plus text-ui-fg-base whitespace-nowrap"
+          : "txt-medium text-ui-fg-base whitespace-nowrap"
+      }
+    >
+      {value}
+    </Text>
+  </div>
+)
+
+const Column = ({
+  title,
+  money,
+  currency_code,
+  freightNote,
+  emphasis,
+}: {
+  title: string
+  money: QuoteMoney
+  currency_code: string
+  freightNote?: string
+  emphasis?: boolean
+}) => (
+  <div
+    className={`flex flex-col rounded-lg border p-5 ${
+      emphasis
+        ? "border-ui-border-interactive bg-ui-bg-subtle"
+        : "border-ui-border-base"
+    }`}
+  >
+    <Text className="txt-small-plus text-ui-fg-subtle uppercase tracking-wide">
+      {title}
+    </Text>
+    <div className="mt-3 divide-y divide-ui-border-base">
+      <Row
+        label="Subtotal"
+        value={convertToLocale({ amount: money.subtotal, currency_code })}
+      />
+      <Row
+        label="Freight"
+        value={convertToLocale({ amount: money.freight, currency_code })}
+        sub={freightNote}
+      />
+      <Row
+        label="Landed total"
+        value={convertToLocale({ amount: money.landed_total, currency_code })}
+        strong
+      />
+    </div>
+  </div>
+)
+
+const QuoteSummary = ({ quote }: { quote: QuoteView }) => {
+  const { compare, freight, currency_code } = quote
+
+  const freightNote = freight.chosen
+    ? [
+        freight.chosen.courier_name || freight.chosen.name,
+        freight.chosen.estimated_days
+          ? `~${freight.chosen.estimated_days} days`
+          : null,
+      ]
+        .filter(Boolean)
+        .join(" · ")
+    : undefined
+
+  return (
+    <div className="flex flex-col gap-y-4">
+      <Heading level="h2" className="text-xl-semi text-ui-fg-base">
+        Landed cost
+      </Heading>
+
+      <div
+        className={`grid gap-4 ${
+          compare.show_quoted && compare.show_live
+            ? "grid-cols-1 sm:grid-cols-2"
+            : "grid-cols-1"
+        }`}
+      >
+        {compare.show_quoted && quote.quoted ? (
+          <Column
+            title="Quoted for you"
+            money={quote.quoted}
+            currency_code={currency_code}
+            freightNote={freightNote}
+            emphasis
+          />
+        ) : null}
+        {compare.show_live && quote.live ? (
+          <Column
+            title="Current price"
+            money={quote.live}
+            currency_code={currency_code}
+            freightNote={freightNote}
+          />
+        ) : null}
+      </div>
+
+      {/* Freight is an ESTIMATE and says so. Carrier rates move, and the manual
+          tier is a placeholder the partner is expected to edit — presenting it
+          as final would be the one number on this page we cannot stand behind. */}
+      {freight.error ? (
+        <Text className="txt-small text-ui-fg-muted">
+          Freight could not be quoted live for this lane, so the figure above is
+          an indicative rate.
+        </Text>
+      ) : null}
+
+      {quote.total_weight_grams ? (
+        <Text className="txt-small text-ui-fg-muted">
+          Quoted as one consignment of{" "}
+          {(quote.total_weight_grams / 1000).toFixed(2)} kg to{" "}
+          {quote.destination_country_code?.toUpperCase()}
+          {quote.destination_postal_code
+            ? ` ${quote.destination_postal_code}`
+            : ""}
+          .
+        </Text>
+      ) : null}
+    </div>
+  )
+}
+
+export default QuoteSummary

--- a/apps/storefront/src/modules/quotes/templates/index.tsx
+++ b/apps/storefront/src/modules/quotes/templates/index.tsx
@@ -1,0 +1,81 @@
+import { Heading, Text } from "@medusajs/ui"
+
+import type { QuoteView } from "@lib/data/quotes"
+import QuoteLines from "../components/quote-lines"
+import QuoteSummary from "../components/quote-summary"
+
+/**
+ * The buyer's quote page (#1389 S4).
+ *
+ * There is no login and no account. The token in the URL is the whole
+ * credential, because asking a procurement contact to sign up before they can
+ * see a price is the wall this feature exists to remove.
+ *
+ * 🔑 Every judgement on this page — the headline, what the buyer is looking at,
+ * the disclaimer, the expiry nudge, which price columns exist — comes from the
+ * backend's `compare` block. This template renders those decisions; it does not
+ * re-make them. Two opinions about whether a quote is stale is how a page ends
+ * up contradicting its own header.
+ */
+const QuoteTemplate = ({ quote }: { quote: QuoteView }) => {
+  const { compare, recipient } = quote
+
+  return (
+    <div className="content-container py-12 max-w-4xl">
+      <div className="flex flex-col gap-y-2">
+        <Heading level="h1" className="text-2xl-semi text-ui-fg-base">
+          {compare.headline}
+        </Heading>
+        <Text className="text-ui-fg-subtle">{compare.explanation}</Text>
+      </div>
+
+      {(recipient.name || recipient.company) && (
+        <div className="mt-6 rounded-lg border border-ui-border-base p-5">
+          <Text className="txt-small-plus text-ui-fg-subtle uppercase tracking-wide">
+            Prepared for
+          </Text>
+          <Text className="txt-medium-plus text-ui-fg-base mt-1">
+            {recipient.company || recipient.name}
+          </Text>
+          {recipient.company && recipient.name ? (
+            <Text className="txt-small text-ui-fg-subtle">{recipient.name}</Text>
+          ) : null}
+          {recipient.partner_note ? (
+            <Text className="txt-medium text-ui-fg-subtle mt-3 whitespace-pre-line">
+              {recipient.partner_note}
+            </Text>
+          ) : null}
+        </div>
+      )}
+
+      {/* Amber, and above the prices rather than below them: a buyer who scrolls
+          no further still needs to know the clock is running. */}
+      {compare.expiry_notice ? (
+        <div className="mt-6 rounded-lg border border-ui-tag-orange-border bg-ui-tag-orange-bg p-4">
+          <Text className="txt-medium text-ui-tag-orange-text">
+            {compare.expiry_notice}
+          </Text>
+        </div>
+      ) : null}
+
+      <div className="mt-10">
+        <Heading level="h2" className="text-xl-semi text-ui-fg-base mb-2">
+          Your basket
+        </Heading>
+        <QuoteLines quote={quote} />
+      </div>
+
+      <div className="mt-10">
+        <QuoteSummary quote={quote} />
+      </div>
+
+      {compare.disclaimer ? (
+        <div className="mt-10 border-t border-ui-border-base pt-6">
+          <Text className="txt-small text-ui-fg-muted">{compare.disclaimer}</Text>
+        </div>
+      ) : null}
+    </div>
+  )
+}
+
+export default QuoteTemplate


### PR DESCRIPTION
The page shipped on `storefront-starter` first, because that is the multi-tenant app behind the shared `storefront-shared` Vercel project — the one every repointed partner domain actually serves. **It is live and rendering there**, verified against a real minted quote.

`apps/storefront` is a separate app and had no such route, so a quote link pointing at a domain served by *this* app would 404. This ports the same page with the same rules:

- **uncached** and `force-dynamic` — the backend records `viewed_at` / `view_count` on read, so a cached page silently stops the view tracking the partner relies on, and a cached per-token document risks being served under another token's key;
- `noindex, nofollow` — the token **is** the credential;
- any fetch failure becomes the same not-found, preserving the backend's deliberate inability to distinguish an unknown token from a revoked one;
- every judgement (headline, disclaimer, expiry nudge, which price columns render) still comes from the backend's `compare` block rather than being re-derived here.

## Verify

`npm run build` — green, route present as dynamic:

```
├ ƒ /[countryCode]/quotes/[token]
```

## ⚠️ On the tsc output

These files produce 26 `TS2786` "cannot be used as a JSX component" errors. That is **this app's existing React 19 typing state, not a regression** — the baseline is **605** platform-wide, including `Text` in `gallery/page.tsx`. Verified by stashing: 605 before, 631 after, and every new one is the same pattern the app already has everywhere. The build is the gate here, and it passes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)