### PR TITLE
feat(quotes): imagery, the production spec, and who is producing it (#1428)

### DIFF
--- a/apps/backend/src/api/store/b2b/quotes/[token]/route.ts
+++ b/apps/backend/src/api/store/b2b/quotes/[token]/route.ts
@@ -62,6 +62,19 @@ export const GET = async (req: MedusaRequest, res: MedusaResponse) => {
     currency_code: quote.currency_code,
     region_id: quote.region_id,
     store: { id: quote.store_id ?? undefined },
+    partner_id: quote.partner_id ?? null,
+    /**
+     * #1428 — whose storefront is serving this page.
+     *
+     * 🔑 NOT `quote.store_id`. Both mint paths resolve the store FROM the
+     * partner, so the quote can only ever answer "the partner's own" and the
+     * producer credit would never render. The serving storefront is the one
+     * that sent the publishable key, which is the same signal
+     * `/store/partner-showcase` uses to tell one's own shop from someone
+     * else's. Absent ⇒ the builder says nothing rather than guessing.
+     */
+    viewer_sales_channel_ids:
+      (req as any).publishable_key_context?.sales_channel_ids ?? null,
     now: new Date(),
   })
 

--- a/apps/backend/src/modules/partner-quote/__tests__/build-quote-view.unit.spec.ts
+++ b/apps/backend/src/modules/partner-quote/__tests__/build-quote-view.unit.spec.ts
@@ -1,5 +1,6 @@
 import {
   buildQuoteView,
+  pickLineImage,
   buyerChangedInputs,
   composeQuoteMoney,
   frozenMoney,
@@ -23,13 +24,33 @@ const VARIANTS = [
     id: "var_a",
     title: "Plain / Natural",
     weight: 105,
-    product: { id: "prod_a", title: "Pashmina Plain", handle: "pashmina-plain", weight: 115 },
+    // Deliberately out of rank order, and the product carries a DIFFERENT
+    // thumbnail — so "took the variant image" and "took the first row" and
+    // "fell back to the product" are three distinguishable outcomes.
+    images: [
+      { url: "https://cdn/var-a-2.jpg", rank: 1 },
+      { url: "https://cdn/var-a-1.jpg", rank: 0 },
+    ],
+    product: {
+      id: "prod_a",
+      title: "Pashmina Plain",
+      handle: "pashmina-plain",
+      weight: 115,
+      thumbnail: "https://cdn/prod-a.jpg",
+    },
   },
   {
     id: "var_b",
     title: "Striped / Indigo",
     weight: null,
-    product: { id: "prod_b", title: "Pashmina Striped", handle: "pashmina-striped", weight: 200 },
+    images: [],
+    product: {
+      id: "prod_b",
+      title: "Pashmina Striped",
+      handle: "pashmina-striped",
+      weight: 200,
+      thumbnail: "https://cdn/prod-b.jpg",
+    },
   },
 ]
 
@@ -326,6 +347,55 @@ describe("pure helpers", () => {
 
     expect(money?.landed_total).toBe(423_900)
     expect(money?.unit_amount).toBeCloseTo(807.69, 2)
+  })
+})
+
+describe("the line image (#1428)", () => {
+  it("prefers the variant's own image over the product thumbnail", async () => {
+    const captured: Captured = { contexts: [], rateWeights: [] }
+    const view = await buildQuoteView(
+      scopeWith(captured) as any,
+      baseInput({
+        lines: [
+          { variant_id: "var_a", quantity: 500 },
+          { variant_id: "var_b", quantity: 20 },
+        ],
+      })
+    )
+
+    const a = view.lines.find((l) => l.variant_id === "var_a")
+    // Rank 0, not the first row of the array — the merchandiser's ordering
+    // decides which photo the buyer sees.
+    expect(a?.thumbnail).toBe("https://cdn/var-a-1.jpg")
+    expect(a?.image_source).toBe("variant")
+    // prod_a also has a thumbnail; taking it would have been the bug.
+    expect(a?.thumbnail).not.toBe("https://cdn/prod-a.jpg")
+
+    const b = view.lines.find((l) => l.variant_id === "var_b")
+    expect(b?.thumbnail).toBe("https://cdn/prod-b.jpg")
+    expect(b?.image_source).toBe("product")
+  })
+
+  it("says nothing when neither level has an image", () => {
+    // A plausible WRONG image on a quote is worse than an empty cell — the
+    // buyer is agreeing to *that* item.
+    expect(pickLineImage({ images: [], product: {} })).toEqual({
+      thumbnail: null,
+      image_source: null,
+    })
+    expect(pickLineImage(undefined)).toEqual({
+      thumbnail: null,
+      image_source: null,
+    })
+  })
+
+  it("ignores image rows that carry no url", () => {
+    expect(
+      pickLineImage({
+        images: [{ url: null, rank: 0 }],
+        product: { thumbnail: "https://cdn/p.jpg" },
+      })
+    ).toEqual({ thumbnail: "https://cdn/p.jpg", image_source: "product" })
   })
 })
 

--- a/apps/backend/src/modules/partner-quote/__tests__/quote-producer.unit.spec.ts
+++ b/apps/backend/src/modules/partner-quote/__tests__/quote-producer.unit.spec.ts
@@ -1,0 +1,162 @@
+import {
+  producerStorefrontUrl,
+  resolveQuoteProducer,
+  shouldNameProducer,
+} from "../lib/quote-producer"
+
+/**
+ * "Who is producing this" (#1428).
+ *
+ * The assertion that matters is the one about NOT knowing. If "no publishable
+ * key" or "partner has no sales channel" were ever read as "therefore a JYT
+ * storefront", the band would name the partner on the partner's own site —
+ * which is the exact noise the condition exists to avoid, and it would look
+ * right in every happy-path test.
+ */
+
+const scopeWith = (partners: any[], opts: { throws?: boolean } = {}) => ({
+  resolve: () => ({
+    graph: async (args: any) => {
+      if (opts.throws) throw new Error("query fell over")
+      // Filtered by id, never a bare list — an unfiltered partner read on a
+      // public unauthenticated route is #1397.
+      expect(args.filters?.id).toBeDefined()
+      return { data: partners }
+    },
+  }),
+})
+
+const PARTNER = {
+  id: "part_1",
+  name: "Unique Pashmina",
+  handle: "unique-pashmina",
+  logo: "https://cdn/logo.png",
+  country_code: "IN",
+  is_verified: true,
+  status: "active",
+  custom_domain: "uniquepashmina.com",
+  custom_domain_verified: true,
+  storefront_domain: "unique-pashmina.jaalyantra.com",
+  stores: [{ default_sales_channel_id: "sc_partner" }],
+}
+
+describe("shouldNameProducer", () => {
+  it("names the producer when the viewer is on a DIFFERENT storefront", () => {
+    expect(shouldNameProducer(["sc_jyt"], ["sc_partner"])).toBe(true)
+  })
+
+  it("stays quiet on the partner's own storefront", () => {
+    expect(shouldNameProducer(["sc_partner"], ["sc_partner"])).toBe(false)
+  })
+
+  it("stays quiet when the key spans several channels, one of them the partner's", () => {
+    expect(shouldNameProducer(["sc_jyt", "sc_partner"], ["sc_partner"])).toBe(false)
+  })
+
+  it("stays quiet when the viewer is unknown — absence is not 'somewhere else'", () => {
+    expect(shouldNameProducer(null, ["sc_partner"])).toBe(false)
+    expect(shouldNameProducer([], ["sc_partner"])).toBe(false)
+  })
+
+  it("stays quiet when the partner has no channel to compare against", () => {
+    expect(shouldNameProducer(["sc_jyt"], [])).toBe(false)
+    expect(shouldNameProducer(["sc_jyt"], null)).toBe(false)
+  })
+
+  it("ignores null channel ids rather than treating them as a match", () => {
+    // 🔴 A dangling publishable key produces `sales_channels: [null]`. Two
+    // nulls comparing equal would silence the band on every storefront.
+    expect(shouldNameProducer([null as any], [null as any])).toBe(false)
+  })
+})
+
+describe("resolveQuoteProducer", () => {
+  it("returns the partner on a JYT storefront", async () => {
+    const producer = await resolveQuoteProducer(scopeWith([PARTNER]) as any, {
+      partner_id: "part_1",
+      viewer_sales_channel_ids: ["sc_jyt"],
+    })
+
+    expect(producer).toEqual({
+      id: "part_1",
+      name: "Unique Pashmina",
+      handle: "unique-pashmina",
+      logo: "https://cdn/logo.png",
+      country_code: "IN",
+      is_verified: true,
+      url: "https://uniquepashmina.com",
+    })
+  })
+
+  it("returns null on the partner's own storefront", async () => {
+    expect(
+      await resolveQuoteProducer(scopeWith([PARTNER]) as any, {
+        partner_id: "part_1",
+        viewer_sales_channel_ids: ["sc_partner"],
+      })
+    ).toBeNull()
+  })
+
+  it("never queries at all without a viewer or a partner", async () => {
+    const scope = { resolve: () => { throw new Error("must not resolve") } }
+
+    expect(
+      await resolveQuoteProducer(scope as any, {
+        partner_id: "part_1",
+        viewer_sales_channel_ids: null,
+      })
+    ).toBeNull()
+    expect(
+      await resolveQuoteProducer(scope as any, {
+        partner_id: null,
+        viewer_sales_channel_ids: ["sc_jyt"],
+      })
+    ).toBeNull()
+  })
+
+  it("does not present an inactive partner as a credential", async () => {
+    expect(
+      await resolveQuoteProducer(
+        scopeWith([{ ...PARTNER, status: "inactive" }]) as any,
+        { partner_id: "part_1", viewer_sales_channel_ids: ["sc_jyt"] }
+      )
+    ).toBeNull()
+  })
+
+  it("swallows a failed query — a credit line is not worth a buyer's 500", async () => {
+    expect(
+      await resolveQuoteProducer(scopeWith([], { throws: true }) as any, {
+        partner_id: "part_1",
+        viewer_sales_channel_ids: ["sc_jyt"],
+      })
+    ).toBeNull()
+  })
+})
+
+describe("producerStorefrontUrl", () => {
+  it("prefers a VERIFIED custom domain", () => {
+    expect(producerStorefrontUrl(PARTNER)).toBe("https://uniquepashmina.com")
+  })
+
+  it("refuses to link an unverified custom domain", () => {
+    // 🔴 `custom_domain` is whatever the partner typed into the connect form.
+    // Until verification says the DNS is ours, linking it points a buyer at a
+    // host we do not control.
+    expect(
+      producerStorefrontUrl({ ...PARTNER, custom_domain_verified: false })
+    ).toBe("https://unique-pashmina.jaalyantra.com")
+  })
+
+  it("is null when the partner has no reachable domain at all", () => {
+    expect(
+      producerStorefrontUrl({ custom_domain: null, storefront_domain: null })
+    ).toBeNull()
+    expect(producerStorefrontUrl(undefined)).toBeNull()
+  })
+
+  it("does not double up a scheme already in the column", () => {
+    expect(
+      producerStorefrontUrl({ storefront_domain: "https://Already.com" })
+    ).toBe("https://already.com")
+  })
+})

--- a/apps/backend/src/modules/partner-quote/__tests__/quote-spec.unit.spec.ts
+++ b/apps/backend/src/modules/partner-quote/__tests__/quote-spec.unit.spec.ts
@@ -1,0 +1,126 @@
+import { composeLineSpec, resolveQuoteSpecs } from "../lib/quote-spec"
+
+/**
+ * The spec on a quote (#1428) — facts, never choices.
+ *
+ * The load-bearing assertion is the negative one: a quote is frozen against
+ * SPECIFIC variants, so a colour palette rendered beside them would tell a
+ * procurement buyer they may pick a colour when neither this page nor the
+ * price list behind it can honour that.
+ */
+
+const SPEC = {
+  id: "spec_1",
+  product_id: "prod_a",
+  weave_technique: "pashmina-plain",
+  weave_label: null,
+  params: { gsm: 90, ends_per_inch: 72, unlisted_param: 7 },
+  finishes: ["hand wash cold", "dry flat"],
+  notes: "Workshop: watch the selvedge on loom 3.",
+  accepting_custom_orders: true,
+  colors: [{ id: "c1", name: "Natural", available: true }],
+  options: [{ id: "o1", key: "border", label: "Border", values: [] }],
+  fields: [
+    { key: "origin", label: "Origin", value: "Kanihama, Kashmir", order: 1 },
+    { key: "loom", label: "Loom", value: null, order: 0 },
+  ],
+}
+
+describe("composeLineSpec", () => {
+  it("labels a known param from the registry, with its unit and glyph", () => {
+    const spec = composeLineSpec(SPEC)!
+    const gsm = spec.rows.find((r) => r.key === "gsm")
+
+    // "Weight · 90 GSM", not "gsm · 90". The label, unit and icon come from
+    // weaving-techniques.ts, where the param is defined.
+    expect(gsm).toEqual({
+      key: "gsm",
+      label: "Weight",
+      value: "90",
+      unit: "GSM",
+      icon: "weight",
+    })
+    expect(spec.weave_label).toBe("Pashmina (plain)")
+  })
+
+  it("still renders a param the registry has never heard of", () => {
+    const row = composeLineSpec(SPEC)!.rows.find((r) => r.key === "unlisted_param")
+
+    // A spec written against a newer registry than this build must be a plain
+    // row, not a blank space and not a crash.
+    expect(row).toEqual({
+      key: "unlisted_param",
+      label: "Unlisted param",
+      value: "7",
+      unit: null,
+      icon: "note",
+    })
+  })
+
+  it("carries the partner's free extra fields, in their order, skipping empties", () => {
+    const spec = composeLineSpec(SPEC)!
+    expect(spec.rows.map((r) => r.key)).toContain("origin")
+    // `loom` has no value — an empty row on a signed-off document reads as
+    // missing data.
+    expect(spec.rows.map((r) => r.key)).not.toContain("loom")
+  })
+
+  it("returns the FACTS and drops every made-to-order CHOICE", () => {
+    const spec = composeLineSpec(SPEC) as any
+
+    expect(spec.finishes).toEqual(["hand wash cold", "dry flat"])
+    // 🔴 The whole point. A quote cannot honour a colour pick.
+    expect(spec.colors).toBeUndefined()
+    expect(spec.options).toBeUndefined()
+    expect(spec.accepting_custom_orders).toBeUndefined()
+    // Workshop notes are not customer copy — same rule the store spec route
+    // already applies.
+    expect(JSON.stringify(spec)).not.toMatch(/selvedge/)
+  })
+
+  it("is null when there is nothing worth heading a block with", () => {
+    expect(composeLineSpec(null)).toBeNull()
+    expect(
+      composeLineSpec({ params: {}, finishes: [], fields: [], weave_technique: null })
+    ).toBeNull()
+  })
+})
+
+describe("resolveQuoteSpecs", () => {
+  const scopeWith = (specs: any[], opts: { throws?: boolean } = {}) => ({
+    resolve: () => ({
+      listProductSpecs: async (filters: any, config: any) => {
+        if (opts.throws) throw new Error("module unavailable")
+        expect(filters.product_id).toEqual(["prod_a", "prod_b"])
+        // Only `fields`. Loading colours and options here would invite a later
+        // caller to render them.
+        expect(config.relations).toEqual(["fields"])
+        return specs
+      },
+    }),
+  })
+
+  it("reads a whole basket in one call, keyed by product", async () => {
+    const byProduct = await resolveQuoteSpecs(
+      scopeWith([SPEC]) as any,
+      ["prod_a", "prod_b", "prod_a"]
+    )
+
+    expect(byProduct.get("prod_a")?.weave_label).toBe("Pashmina (plain)")
+    // prod_b simply has no spec — the normal state for most products.
+    expect(byProduct.get("prod_b")).toBeUndefined()
+  })
+
+  it("renders the lines without a spec block when the module falls over", async () => {
+    const byProduct = await resolveQuoteSpecs(
+      scopeWith([], { throws: true }) as any,
+      ["prod_a", "prod_b"]
+    )
+    expect(byProduct.size).toBe(0)
+  })
+
+  it("does not resolve anything for a basket with no products", async () => {
+    const scope = { resolve: () => { throw new Error("must not resolve") } }
+    expect((await resolveQuoteSpecs(scope as any, [])).size).toBe(0)
+  })
+})

--- a/apps/backend/src/modules/partner-quote/lib/build-quote-view.ts
+++ b/apps/backend/src/modules/partner-quote/lib/build-quote-view.ts
@@ -10,6 +10,8 @@ import {
   type QuoteCompareResult,
   type QuoteMoney,
 } from "./compare"
+import { resolveQuoteProducer, type QuoteProducer } from "./quote-producer"
+import { resolveQuoteSpecs, type QuoteLineSpec } from "./quote-spec"
 import { daysUntilExpiry, quoteUnusableReason } from "./token"
 
 /**
@@ -102,6 +104,14 @@ export type BuildQuoteViewInput = {
   region_id?: string | null
   /** The partner store: origin location and pricing scope. */
   store: { id?: string; default_location_id?: string | null }
+  /** The producing partner. Only needed to render the credit — never priced. */
+  partner_id?: string | null
+  /**
+   * The sales channels of the storefront SERVING this page, from its
+   * publishable key. Decides whether naming the producer is a selling point or
+   * noise — see `quote-producer.ts`. Absent ⇒ say nothing.
+   */
+  viewer_sales_channel_ids?: string[] | null
   carrier?: string
   /** Passed in so the whole view is deterministic under test. */
   now: Date
@@ -113,6 +123,19 @@ export type QuoteViewLine = {
   product_id: string | null
   product_title: string | null
   product_handle: string | null
+  /**
+   * The variant's own image where it has one, else the product thumbnail.
+   * 🔑 Null rather than a stand-in: a WRONG image on a quote is worse than no
+   * image, because the buyer is agreeing to *that* item.
+   */
+  thumbnail: string | null
+  /** Which level the image came from, so a caller can caption it honestly. */
+  image_source: "variant" | "product" | null
+  /**
+   * What the piece is made to — FACTS only, never the made-to-order choices.
+   * Null when the product has no spec, which is the normal state.
+   */
+  spec: QuoteLineSpec | null
   quantity: number
   position: number
   note: string | null
@@ -150,6 +173,11 @@ export type QuoteView = {
     company: string | null
     partner_note: string | null
   }
+  /**
+   * The producing partner, when the viewer is NOT on that partner's own
+   * storefront. Null means "say nothing", never "unknown producer".
+   */
+  producer: QuoteProducer | null
   expires_in_days: number | null
   /** Set when the live half could not be built, so callers can say why. */
   live_error: string | null
@@ -169,6 +197,35 @@ export function pickFreightOption(
     .filter((o) => Number.isFinite(Number(o?.amount)))
     .sort((a, b) => Number(a.amount) - Number(b.amount))
   return all[0] ?? null
+}
+
+/**
+ * PURE: the one image for a quoted line — variant first, product thumbnail
+ * second, nothing third (#1428).
+ *
+ * 🔴 Never a placeholder and never "any image on the product". A buyer signing
+ * off a seven-figure consignment is agreeing to *that* item, so a plausible
+ * wrong picture is more damaging than an empty cell. Where the image came from
+ * travels with it, the same way `weight_source` does, because a PRODUCT
+ * thumbnail on a variant-specific line is a weaker claim than the variant's
+ * own photo.
+ */
+export function pickLineImage(identity: any): {
+  thumbnail: string | null
+  image_source: "variant" | "product" | null
+} {
+  const images = ((identity?.images ?? []) as any[]).filter((i) => i?.url)
+  if (images.length) {
+    // `rank` is the merchandiser's ordering; fall back to array order when a
+    // row predates it rather than dropping to the product thumbnail.
+    const first = [...images].sort(
+      (a, b) => Number(a?.rank ?? 0) - Number(b?.rank ?? 0)
+    )[0]
+    if (first?.url) return { thumbnail: String(first.url), image_source: "variant" }
+  }
+  const productThumb = identity?.product?.thumbnail
+  if (productThumb) return { thumbnail: String(productThumb), image_source: "product" }
+  return { thumbnail: null, image_source: null }
 }
 
 /**
@@ -275,7 +332,18 @@ export async function buildQuoteView(
   // just without a price they cannot act on.
   const { data: variants } = await query.graph({
     entity: "variant",
-    fields: ["id", "title", "product.id", "product.title", "product.handle"],
+    fields: [
+      "id",
+      "title",
+      // #1428: the buyer was looking at a spreadsheet. Variant images first —
+      // the product thumbnail is the fallback, not the answer.
+      "images.url",
+      "images.rank",
+      "product.id",
+      "product.title",
+      "product.handle",
+      "product.thumbnail",
+    ],
     filters: { id: effectiveLines.map((l) => l.variant_id) },
   })
   const identityById = new Map<string, any>(
@@ -394,6 +462,15 @@ export async function buildQuoteView(
     }
   }
 
+  // Both of these are enrichment, resolved after the money and deliberately
+  // unable to fail the view.
+  const specByProduct = await resolveQuoteSpecs(
+    scope,
+    effectiveLines
+      .map((l) => identityById.get(l.variant_id)?.product?.id)
+      .filter(Boolean)
+  )
+
   const lines: QuoteViewLine[] = effectiveLines.map((line, index) => {
     const identity = identityById.get(line.variant_id)
     const frozen = frozenByVariant.get(line.variant_id)
@@ -406,6 +483,8 @@ export async function buildQuoteView(
       product_id: identity.product?.id ?? null,
       product_title: identity.product?.title ?? null,
       product_handle: identity.product?.handle ?? null,
+      ...pickLineImage(identity),
+      spec: specByProduct.get(identity.product?.id) ?? null,
       quantity: line.quantity,
       position: line.position ?? frozen?.position ?? index,
       note: line.note ?? frozen?.note ?? null,
@@ -423,6 +502,14 @@ export async function buildQuoteView(
         weight?.unit_weight_grams ?? frozen?.quoted_unit_weight_grams ?? null,
       weight_source: weight?.weight_source ?? frozen?.quoted_weight_source ?? null,
     }
+  })
+
+  // Resolved AFTER the money, and deliberately unable to fail the view: a
+  // credit line is not worth a buyer's 500. Returns null whenever we cannot
+  // positively tell that the viewer is off the partner's own storefront.
+  const producer = await resolveQuoteProducer(scope, {
+    partner_id: input.partner_id ?? null,
+    viewer_sales_channel_ids: input.viewer_sales_channel_ids ?? null,
   })
 
   const compare = compareQuote({
@@ -454,6 +541,7 @@ export async function buildQuoteView(
       company: input.quote?.recipient_company ?? null,
       partner_note: input.quote?.partner_note ?? null,
     },
+    producer,
     expires_in_days: input.quote ? daysUntilExpiry(lifecycle, input.now) : null,
     live_error: liveError,
   }

--- a/apps/backend/src/modules/partner-quote/lib/quote-producer.ts
+++ b/apps/backend/src/modules/partner-quote/lib/quote-producer.ts
@@ -1,0 +1,148 @@
+import { ContainerRegistrationKeys } from "@medusajs/framework/utils"
+
+/**
+ * "Who is producing this", and the rule for when it is worth saying (#1428).
+ *
+ * ## Why this is conditional rather than always-on
+ *
+ * On a partner's own domain the partner IS the seller. Naming them again under
+ * their own logo is noise, and reads like a disclosure the page is obliged to
+ * make rather than the selling point it actually is. On a JYT-served
+ * storefront the buyer has no idea whose hands made the cloth, and on a
+ * handloom product that is the single most persuasive fact on the page.
+ *
+ * ## How "whose storefront is this" is decided
+ *
+ * NOT from the quote — `store_id` is always the partner's own store, because
+ * both mint paths resolve it from the partner (`getPartnerStore`, and
+ * `partner.stores[0]` on the admin route). Comparing the quote against itself
+ * would answer "the partner's own" every single time and the band would never
+ * render.
+ *
+ * The serving storefront comes from the REQUEST: the publishable key the
+ * storefront sends resolves to its sales channels, which is the same signal
+ * `/store/partner-showcase` already uses to tell "my own shop" from "someone
+ * else's". If those channels include the partner's, the buyer is on the
+ * partner's own shop.
+ *
+ * 🔑 Three states, not two — "cannot tell" is its own answer and it means SAY
+ * NOTHING. A page served without a publishable key, or a partner with no sales
+ * channel, must not be read as "therefore a JYT storefront": that would name a
+ * producer on the partner's own site, which is precisely the noise this
+ * condition exists to avoid.
+ */
+
+export type QuoteProducer = {
+  id: string
+  name: string | null
+  handle: string | null
+  logo: string | null
+  country_code: string | null
+  is_verified: boolean
+  /** The partner's own shop, or null when they have no reachable domain. */
+  url: string | null
+}
+
+/**
+ * PURE: where "produced by" points.
+ *
+ * The order goes to this partner regardless of which storefront took it, so
+ * the credit links to THEIR shop rather than to a profile page of ours.
+ *
+ * 🔑 An UNVERIFIED custom domain is not a link. `custom_domain` is whatever the
+ * partner typed into the connect form; until verification says the DNS is
+ * ours, linking it points a buyer at a host we do not control. The provisioned
+ * subdomain is always ours, so it is the fallback rather than the second
+ * choice.
+ */
+export function producerStorefrontUrl(partner: any): string | null {
+  const host = partner?.custom_domain_verified
+    ? partner?.custom_domain || partner?.storefront_domain
+    : partner?.storefront_domain
+
+  const clean = String(host ?? "").trim().toLowerCase()
+  if (!clean) return null
+  // Stored as a bare host; a scheme in the column would otherwise double up.
+  if (clean.startsWith("http://") || clean.startsWith("https://")) return clean
+  return `https://${clean}`
+}
+
+/**
+ * PURE. True only when we positively know the viewer is somewhere OTHER than
+ * the producing partner's own storefront. Unknown on either side ⇒ false.
+ */
+export function shouldNameProducer(
+  viewerSalesChannelIds: string[] | null | undefined,
+  partnerSalesChannelIds: string[] | null | undefined
+): boolean {
+  const viewer = (viewerSalesChannelIds ?? []).filter(Boolean)
+  const partner = (partnerSalesChannelIds ?? []).filter(Boolean)
+  if (!viewer.length || !partner.length) return false
+  return !viewer.some((id) => partner.includes(id))
+}
+
+/**
+ * Resolve the producing partner, or null when the band should not render.
+ *
+ * Never throws: a credit line has no business turning a buyer's quote page
+ * into a 500. Every failure — no partner, no channel, same channel, a query
+ * that fell over — collapses to the same "say nothing".
+ */
+export async function resolveQuoteProducer(
+  scope: any,
+  input: {
+    partner_id?: string | null
+    viewer_sales_channel_ids?: string[] | null
+  }
+): Promise<QuoteProducer | null> {
+  if (!input.partner_id) return null
+  if (!(input.viewer_sales_channel_ids ?? []).length) return null
+
+  try {
+    const query: any = scope.resolve(ContainerRegistrationKeys.QUERY)
+    // Filtered by id. An unfiltered partner read on a public, unauthenticated
+    // route is how one dangling key took every storefront down (#1397).
+    const { data: partners } = await query.graph({
+      entity: "partners",
+      fields: [
+        "id",
+        "name",
+        "handle",
+        "logo",
+        "country_code",
+        "is_verified",
+        "status",
+        "custom_domain",
+        "custom_domain_verified",
+        "storefront_domain",
+        "stores.default_sales_channel_id",
+      ],
+      filters: { id: input.partner_id },
+    })
+
+    const partner = ((partners ?? []) as any[])[0]
+    if (!partner) return null
+    // An inactive partner is not a credential to show a buyer.
+    if (partner.status && partner.status !== "active") return null
+
+    const partnerChannels = ((partner.stores ?? []) as any[])
+      .map((s) => s?.default_sales_channel_id)
+      .filter(Boolean)
+
+    if (!shouldNameProducer(input.viewer_sales_channel_ids, partnerChannels)) {
+      return null
+    }
+
+    return {
+      id: partner.id,
+      name: partner.name ?? null,
+      handle: partner.handle ?? null,
+      logo: partner.logo ?? null,
+      country_code: partner.country_code ?? null,
+      is_verified: Boolean(partner.is_verified),
+      url: producerStorefrontUrl(partner),
+    }
+  } catch {
+    return null
+  }
+}

--- a/apps/backend/src/modules/partner-quote/lib/quote-spec.ts
+++ b/apps/backend/src/modules/partner-quote/lib/quote-spec.ts
@@ -1,0 +1,141 @@
+import { PRODUCT_SPEC_MODULE } from "../../product-spec"
+import { WEAVE_TECHNIQUES } from "../../product-spec/weaving-techniques"
+
+/**
+ * "What the piece is made to", on the quote (#1428).
+ *
+ * ## Facts, not choices
+ *
+ * The product page's spec block does two jobs: it states FACTS (this cloth is
+ * 240 GSM, 60 ends per inch, handwoven) and it offers CHOICES (pick a colour,
+ * pick an embroidery). Only the facts belong on a quote.
+ *
+ * 🔴 The choices are deliberately dropped. A quote is frozen against SPECIFIC
+ * variants at specific prices; rendering a palette next to them would tell a
+ * procurement buyer they may pick a colour, and nothing on this page — or in
+ * the price list behind it — can honour that. A configurator the buyer cannot
+ * act on is worse than no configurator, and `accepting_custom_orders` is a
+ * different transaction from the one this link exists to close.
+ *
+ * ## Rows come from the registry, never from a lookup here
+ *
+ * The stored spec carries param KEYS (`gsm`, `ends_per_inch`); a buyer needs
+ * labels, units and a glyph. Those live in `weaving-techniques.ts`, which is
+ * where a param is DEFINED — a mapping kept here would silently lose its entry
+ * the day someone adds a param, and the row would render naked with nobody
+ * noticing. A key the registry does not know still renders, as a plain row.
+ */
+
+export type QuoteSpecRow = {
+  key: string
+  label: string
+  value: string
+  unit: string | null
+  /** A glyph NAME from the registry. The storefront draws it; see spec-icon. */
+  icon: string
+}
+
+export type QuoteLineSpec = {
+  weave_label: string | null
+  rows: QuoteSpecRow[]
+  finishes: string[]
+}
+
+/** `ends_per_inch` → `Ends per inch`. Only ever a fallback for an unknown key. */
+const humanise = (key: string) =>
+  String(key)
+    .replace(/[_-]+/g, " ")
+    .replace(/^\w/, (c) => c.toUpperCase())
+
+/**
+ * PURE: one spec row set, or null when the spec says nothing worth showing.
+ *
+ * Null rather than an empty block: a "Specification" heading over no rows
+ * reads as missing data on a document a buyer is signing off.
+ */
+export function composeLineSpec(spec: any): QuoteLineSpec | null {
+  if (!spec) return null
+
+  const technique =
+    WEAVE_TECHNIQUES.find((t) => t.slug === spec.weave_technique) ?? null
+  const paramDefs = new Map(
+    (technique?.params ?? []).map((p) => [p.key, p])
+  )
+
+  const rows: QuoteSpecRow[] = []
+
+  const params = (spec.params ?? {}) as Record<string, unknown>
+  for (const [key, raw] of Object.entries(params)) {
+    if (raw === null || raw === undefined || raw === "") continue
+    const def = paramDefs.get(key)
+    rows.push({
+      key,
+      label: def?.label ?? humanise(key),
+      value: String(raw),
+      unit: def?.unit ?? null,
+      // An unknown param is a plain row, never a blank space and never a crash.
+      icon: def?.icon ?? "note",
+    })
+  }
+
+  // Free extra fields — what the registry could not express. Ordered by the
+  // partner, because they wrote them in the order they wanted them read.
+  const fields = [...((spec.fields ?? []) as any[])].sort(
+    (a, b) => Number(a?.order ?? 0) - Number(b?.order ?? 0)
+  )
+  for (const field of fields) {
+    if (!field?.value) continue
+    rows.push({
+      key: String(field.key ?? ""),
+      label: field.label || humanise(String(field.key ?? "")),
+      value: String(field.value),
+      unit: null,
+      icon: "note",
+    })
+  }
+
+  const finishes = ((spec.finishes ?? []) as any[])
+    .map((f) => (typeof f === "string" ? f : f?.label ?? f?.name))
+    .filter(Boolean)
+    .map(String)
+
+  const weaveLabel = spec.weave_label || technique?.label || null
+
+  if (!rows.length && !finishes.length && !weaveLabel) return null
+
+  return { weave_label: weaveLabel, rows, finishes }
+}
+
+/**
+ * Specs for a whole basket in ONE read, keyed by product id.
+ *
+ * Never throws. A missing spec is the normal state for most products, and a
+ * spec module that fell over is not worth a buyer's 500 — both collapse to the
+ * same "render the line without a spec block".
+ */
+export async function resolveQuoteSpecs(
+  scope: any,
+  productIds: string[]
+): Promise<Map<string, QuoteLineSpec>> {
+  const ids = Array.from(new Set(productIds.filter(Boolean)))
+  const byProduct = new Map<string, QuoteLineSpec>()
+  if (!ids.length) return byProduct
+
+  try {
+    const service: any = scope.resolve(PRODUCT_SPEC_MODULE)
+    // `fields` only — the colour and option relations are the CHOICES half,
+    // and loading them here would invite a later caller to render them.
+    const specs = await service.listProductSpecs(
+      { product_id: ids },
+      { relations: ["fields"] }
+    )
+    for (const spec of (specs ?? []) as any[]) {
+      const composed = composeLineSpec(spec)
+      if (composed && spec.product_id) byProduct.set(spec.product_id, composed)
+    }
+  } catch {
+    return byProduct
+  }
+
+  return byProduct
+}

--- a/apps/storefront/src/lib/data/quotes.ts
+++ b/apps/storefront/src/lib/data/quotes.ts
@@ -24,12 +24,56 @@ export type QuoteMoney = {
   landed_total: number
 }
 
+/** One labelled fact about how the piece is made. #1428 */
+export type QuoteSpecRow = {
+  key: string
+  label: string
+  value: string
+  unit: string | null
+  /** A glyph NAME from the backend's weaving-technique registry, not an asset. */
+  icon: string
+}
+
+/**
+ * What the piece is made to.
+ *
+ * 🔑 FACTS only. The made-to-order choices — the palette, the option groups —
+ * are deliberately absent from this payload: a quote is frozen against
+ * specific variants at specific prices, and a configurator the buyer cannot
+ * act on is worse than no configurator.
+ */
+export type QuoteLineSpec = {
+  weave_label: string | null
+  rows: QuoteSpecRow[]
+  finishes: string[]
+}
+
+/** The producing partner, when the buyer is NOT on that partner's own shop. */
+export type QuoteProducer = {
+  id: string
+  name: string | null
+  handle: string | null
+  logo: string | null
+  country_code: string | null
+  is_verified: boolean
+  /** The partner's own shop. Null when they have no verified/provisioned host. */
+  url: string | null
+}
+
 export type QuoteViewLine = {
   variant_id: string
   variant_title: string | null
   product_id: string | null
   product_title: string | null
   product_handle: string | null
+  /**
+   * The variant's own image, else the product thumbnail, else nothing.
+   * 🔴 Never substitute a placeholder photo: the buyer is agreeing to *that*
+   * item, and a plausible wrong picture is worse than an empty cell.
+   */
+  thumbnail: string | null
+  image_source: "variant" | "product" | null
+  spec: QuoteLineSpec | null
   quantity: number
   position: number
   note: string | null
@@ -78,6 +122,12 @@ export type QuoteView = {
     company: string | null
     partner_note: string | null
   }
+  /**
+   * Null means "say nothing", never "unknown producer". The backend decides;
+   * on the partner's own storefront the partner IS the seller and naming them
+   * again is noise.
+   */
+  producer: QuoteProducer | null
   expires_in_days: number | null
   live_error: string | null
 }

--- a/apps/storefront/src/modules/products/components/production-spec/spec-icon.tsx
+++ b/apps/storefront/src/modules/products/components/production-spec/spec-icon.tsx
@@ -1,0 +1,146 @@
+/**
+ * #1364 — the glyph beside a spec row.
+ *
+ * The name comes from the weaving-technique registry, which is where a param is
+ * defined; it is NOT looked up here on the param's key. A mapping kept
+ * storefront-side would silently lose its entry the day someone adds a param —
+ * the row would still render, just naked, and nobody would notice.
+ *
+ * An unrecognised name falls back to a neutral mark. A spec written against a
+ * newer registry than this storefront has deployed must render a plain row, not
+ * a blank space and certainly not a crash.
+ *
+ * Drawn as inline SVG on a 24-box with `currentColor`, so the glyphs inherit the
+ * partner's text colour and need no asset pipeline, no sprite and no request.
+ * Deliberately about MEASUREMENT rather than decoration: a row reading
+ * "Weight · 240 GSM" wants a scale, not a picture of cloth.
+ */
+
+export type SpecIconName =
+  | "weave"
+  | "weight"
+  | "warp"
+  | "weft"
+  | "yarn"
+  | "width"
+  | "angle"
+  | "density"
+  | "loom"
+  | "metal"
+  | "finish"
+  | "note"
+
+const PATHS: Record<SpecIconName, React.ReactNode> = {
+  // Interlaced warp and weft — the thing itself.
+  weave: (
+    <>
+      <path d="M4 8h16M4 12h16M4 16h16" />
+      <path d="M8 4v16M12 4v16M16 4v16" />
+    </>
+  ),
+  // A balance. GSM is grams per square metre.
+  weight: (
+    <>
+      <path d="M12 4v16M7 20h10" />
+      <path d="M4 8h16" />
+      <path d="M4 8l-2 5a3 3 0 006 0L4 8zM20 8l-2 5a3 3 0 006 0l-4-5z" />
+    </>
+  ),
+  // Warp runs the length of the cloth — vertical.
+  warp: <path d="M6 3v18M10 3v18M14 3v18M18 3v18" />,
+  // Weft crosses it — horizontal.
+  weft: <path d="M3 6h18M3 10h18M3 14h18M3 18h18" />,
+  // A cone of yarn.
+  yarn: (
+    <>
+      <path d="M12 3l5 15H7L12 3z" />
+      <path d="M8 21h8" />
+      <path d="M9 12h6M8 15h8" />
+    </>
+  ),
+  // Loom width — a measured span.
+  width: (
+    <>
+      <path d="M3 12h18" />
+      <path d="M6 9l-3 3 3 3M18 9l3 3-3 3" />
+      <path d="M3 5v3M21 5v3" />
+    </>
+  ),
+  // The angle of a twill line.
+  angle: (
+    <>
+      <path d="M4 20h16" />
+      <path d="M4 20L18 6" />
+      <path d="M4 20a8 8 0 007-4" />
+    </>
+  ),
+  // Knots per square inch — a filled grid.
+  density: (
+    <>
+      <path d="M4 4h16v16H4z" />
+      <path d="M8 8h.01M12 8h.01M16 8h.01M8 12h.01M12 12h.01M16 12h.01M8 16h.01M12 16h.01M16 16h.01" />
+    </>
+  ),
+  // The loom's own machinery — shafts, hooks, bobbins.
+  loom: (
+    <>
+      <path d="M4 5h16v14H4z" />
+      <path d="M4 9h16M4 15h16" />
+      <path d="M9 5v14M15 5v14" />
+    </>
+  ),
+  // Zari — metal thread.
+  metal: (
+    <>
+      <path d="M12 3l2.2 5.6L20 10l-4.4 3.4L17 19l-5-3-5 3 1.4-5.6L4 10l5.8-1.4L12 3z" />
+    </>
+  ),
+  // Finishing — a treatment applied after weaving.
+  finish: (
+    <>
+      <path d="M12 3v4M12 17v4M3 12h4M17 12h4" />
+      <path d="M5.6 5.6l2.8 2.8M15.6 15.6l2.8 2.8M18.4 5.6l-2.8 2.8M8.4 15.6l-2.8 2.8" />
+    </>
+  ),
+  // The neutral fallback: a partner's own field, or a param this build has
+  // never heard of.
+  note: (
+    <>
+      <path d="M5 4h11l3 3v13H5z" />
+      <path d="M15 4v4h4" />
+      <path d="M9 12h6M9 16h4" />
+    </>
+  ),
+}
+
+const SpecIcon = ({
+  name,
+  className,
+}: {
+  name?: string | null
+  className?: string
+}) => {
+  const key = (name || "note") as SpecIconName
+  const path = PATHS[key] ?? PATHS.note
+
+  return (
+    <svg
+      viewBox="0 0 24 24"
+      width="16"
+      height="16"
+      fill="none"
+      stroke="currentColor"
+      strokeWidth="1.4"
+      strokeLinecap="round"
+      strokeLinejoin="round"
+      aria-hidden="true"
+      focusable="false"
+      className={className}
+      data-spec-icon={key}
+    >
+      {path}
+    </svg>
+  )
+}
+
+export default SpecIcon

--- a/apps/storefront/src/modules/quotes/components/quote-line-spec/index.tsx
+++ b/apps/storefront/src/modules/quotes/components/quote-line-spec/index.tsx
@@ -1,0 +1,59 @@
+import { Text } from "@medusajs/ui"
+
+import type { QuoteLineSpec } from "@lib/data/quotes"
+import SpecIcon from "@modules/products/components/production-spec/spec-icon"
+
+/**
+ * "What this is made to", under a quoted line (#1428).
+ *
+ * The founder's ask was "we need more details" — a buyer weighing a
+ * seven-figure consignment was looking at a spreadsheet. On a handloom product
+ * the construction IS the product, so it belongs beside the price rather than
+ * a click away on a page the buyer may never open.
+ *
+ * 🔑 Facts only, and the backend already enforces that: no palette, no option
+ * groups, no "accepting custom orders". A quote is frozen against specific
+ * variants, so offering a choice here would be a promise nothing behind this
+ * page can keep.
+ *
+ * The glyph name comes from the backend's registry, where the param is
+ * defined. `SpecIcon` falls back to a neutral mark, so a spec written against a
+ * newer registry than this storefront has deployed renders a plain row rather
+ * than a blank space.
+ */
+const QuoteLineSpecRows = ({ spec }: { spec: QuoteLineSpec }) => (
+  <div className="mt-3 flex flex-col gap-y-1">
+    {spec.weave_label ? (
+      <Text className="txt-small-plus text-ui-fg-subtle">{spec.weave_label}</Text>
+    ) : null}
+
+    {spec.rows.length ? (
+      <ul className="flex flex-wrap gap-x-4 gap-y-1">
+        {spec.rows.map((row) => (
+          <li
+            key={row.key || row.label}
+            className="flex items-center gap-x-1.5 text-ui-fg-muted"
+          >
+            <SpecIcon name={row.icon} className="shrink-0" />
+            <Text className="txt-small">
+              {row.label}
+              {" · "}
+              <span className="text-ui-fg-subtle">
+                {row.value}
+                {row.unit ? ` ${row.unit}` : ""}
+              </span>
+            </Text>
+          </li>
+        ))}
+      </ul>
+    ) : null}
+
+    {spec.finishes.length ? (
+      <Text className="txt-small text-ui-fg-muted">
+        Finish: {spec.finishes.join(", ")}
+      </Text>
+    ) : null}
+  </div>
+)
+
+export default QuoteLineSpecRows

--- a/apps/storefront/src/modules/quotes/components/quote-lines/index.tsx
+++ b/apps/storefront/src/modules/quotes/components/quote-lines/index.tsx
@@ -1,7 +1,9 @@
 import { Text } from "@medusajs/ui"
+import Image from "next/image"
 
 import { convertToLocale } from "@lib/util/money"
 import type { QuoteView, QuoteViewLine } from "@lib/data/quotes"
+import QuoteLineSpecRows from "../quote-line-spec"
 
 /**
  * The quoted basket, line by line.
@@ -31,23 +33,50 @@ const LineRow = ({
 }) => (
   <tr className="border-b border-ui-border-base last:border-b-0">
     <td className="py-4 pr-4 align-top">
-      <Text className="txt-medium-plus text-ui-fg-base">
-        {line.product_title ?? "Product"}
-      </Text>
-      {line.variant_title ? (
-        <Text className="txt-small text-ui-fg-subtle">{line.variant_title}</Text>
-      ) : null}
-      {line.note ? (
-        <Text className="txt-small text-ui-fg-muted italic mt-1">{line.note}</Text>
-      ) : null}
-      {/* A declared PRODUCT weight over-quotes a lighter variant, and at bulk
-          quantities that can cross a carrier slab — so where the weight came
-          from travels with the number rather than being buried. */}
-      {line.weight_source === "product" ? (
-        <Text className="txt-small text-ui-fg-muted mt-1">
-          Weight estimated from the product, not this variant.
-        </Text>
-      ) : null}
+      <div className="flex gap-x-4">
+        {/* 🔴 No placeholder photo. A plausible WRONG image on a quote is worse
+            than an empty cell — the buyer is agreeing to *that* item. The box
+            is reserved either way so the rows stay aligned. */}
+        {line.thumbnail ? (
+          <div className="relative h-16 w-16 shrink-0 overflow-hidden rounded-md bg-ui-bg-subtle">
+            <Image
+              src={line.thumbnail}
+              alt={line.product_title ?? "Quoted item"}
+              fill
+              sizes="64px"
+              quality={60}
+              className="object-cover object-center"
+            />
+          </div>
+        ) : null}
+        <div className="min-w-0">
+          <Text className="txt-medium-plus text-ui-fg-base">
+            {line.product_title ?? "Product"}
+          </Text>
+          {line.variant_title ? (
+            <Text className="txt-small text-ui-fg-subtle">{line.variant_title}</Text>
+          ) : null}
+          {line.note ? (
+            <Text className="txt-small text-ui-fg-muted italic mt-1">{line.note}</Text>
+          ) : null}
+          {/* A declared PRODUCT weight over-quotes a lighter variant, and at bulk
+              quantities that can cross a carrier slab — so where the weight came
+              from travels with the number rather than being buried. */}
+          {line.weight_source === "product" ? (
+            <Text className="txt-small text-ui-fg-muted mt-1">
+              Weight estimated from the product, not this variant.
+            </Text>
+          ) : null}
+          {/* A PRODUCT thumbnail on a variant-specific line is a weaker claim than
+              the variant's own photo, so it is captioned rather than passed off. */}
+          {line.image_source === "product" ? (
+            <Text className="txt-small text-ui-fg-muted mt-1">
+              Image shows the product; this variant may differ.
+            </Text>
+          ) : null}
+          {line.spec ? <QuoteLineSpecRows spec={line.spec} /> : null}
+        </div>
+      </div>
     </td>
     <td className="py-4 px-4 align-top text-right whitespace-nowrap">
       <Text className="txt-medium text-ui-fg-base">{line.quantity}</Text>

--- a/apps/storefront/src/modules/quotes/components/quote-producer/index.tsx
+++ b/apps/storefront/src/modules/quotes/components/quote-producer/index.tsx
@@ -1,0 +1,107 @@
+import { Text } from "@medusajs/ui"
+
+import type { QuoteProducer } from "@lib/data/quotes"
+
+/**
+ * "Who is producing this" (#1428).
+ *
+ * On a handloom product this is a selling point, not a disclosure obligation —
+ * a buyer comparing suppliers wants to know whose hands make the cloth.
+ *
+ * 🔑 Whether it renders at all is the BACKEND's decision. On the partner's own
+ * domain the partner IS the seller, so naming them again under their own logo
+ * is noise; the backend returns `producer: null` there. A null here means "say
+ * nothing", never "unknown producer" — so this component renders nothing at
+ * all rather than an empty band with a heading.
+ *
+ * The name links to the partner's OWN shop, because that is where the order
+ * goes whichever storefront took it — so the link is a statement of fact, not
+ * a referral. `url` is null when the partner has no verified custom domain and
+ * no provisioned subdomain, and then the name is plain text: an unverified
+ * domain is a host we do not control and must not be handed to a buyer.
+ */
+const REGION_NAMES =
+  typeof Intl !== "undefined" && (Intl as any).DisplayNames
+    ? new (Intl as any).DisplayNames(["en"], { type: "region" })
+    : null
+
+const QuoteProducerBand = ({ producer }: { producer: QuoteProducer }) => {
+  if (!producer.name) return null
+
+  // An ISO code is a database value, not something to show a buyer. An
+  // unrecognised code falls through to nothing rather than printing "IN".
+  let country: string | null = null
+  if (producer.country_code) {
+    try {
+      country = REGION_NAMES?.of(producer.country_code.toUpperCase()) ?? null
+      if (country === producer.country_code.toUpperCase()) country = null
+    } catch {
+      country = null
+    }
+  }
+
+  return (
+    <div className="mt-6 flex items-center gap-x-4 rounded-lg border border-ui-border-base p-5">
+      {producer.logo ? (
+        <div className="relative h-12 w-12 shrink-0 overflow-hidden rounded-full bg-ui-bg-subtle">
+          {/* 🔴 A plain <img>, deliberately, where the rest of this app uses
+              next/image. A partner logo can be on ANY host they uploaded it
+              to, and next/image hard-errors the request on a hostname missing
+              from `remotePatterns` — a 48px avatar is not worth a 500 on a
+              buyer's quote page. Catalog images stay on next/image because
+              they come from the bucket the whole storefront already renders. */}
+          {/* eslint-disable-next-line @next/next/no-img-element */}
+          <img
+            src={producer.logo}
+            alt={producer.name}
+            width={48}
+            height={48}
+            loading="lazy"
+            className="h-full w-full object-cover object-center"
+          />
+        </div>
+      ) : null}
+      <div className="flex flex-col">
+        <Text className="txt-small-plus uppercase tracking-wide text-ui-fg-subtle">
+          Produced by
+        </Text>
+        <Text className="txt-medium-plus text-ui-fg-base">
+          {producer.url ? (
+            <a
+              href={producer.url}
+              target="_blank"
+              // A quote link is a credential in the URL. `noopener noreferrer`
+              // stops the opened shop from reaching back through
+              // `window.opener` or reading this page's token off the referrer.
+              rel="noopener noreferrer"
+              className="hover:text-ui-fg-interactive-hover text-ui-fg-interactive"
+            >
+              {producer.name}
+            </a>
+          ) : (
+            producer.name
+          )}
+          {producer.is_verified ? (
+            <span
+              className="ml-2 align-middle txt-small text-ui-fg-subtle"
+              title="Verified partner"
+            >
+              Verified
+            </span>
+          ) : null}
+        </Text>
+        {country ? (
+          <Text className="txt-small text-ui-fg-subtle">{country}</Text>
+        ) : null}
+        {/* Founder, 21 Aug: the order goes to them regardless of which
+            storefront took it. Saying so turns the credit from a disclosure
+            into what it actually is — the reason to buy. */}
+        <Text className="txt-small text-ui-fg-muted mt-1">
+          Your order is made and dispatched by this workshop.
+        </Text>
+      </div>
+    </div>
+  )
+}
+
+export default QuoteProducerBand

--- a/apps/storefront/src/modules/quotes/templates/index.tsx
+++ b/apps/storefront/src/modules/quotes/templates/index.tsx
@@ -2,6 +2,7 @@ import { Heading, Text } from "@medusajs/ui"
 
 import type { QuoteView } from "@lib/data/quotes"
 import QuoteLines from "../components/quote-lines"
+import QuoteProducerBand from "../components/quote-producer"
 import QuoteSummary from "../components/quote-summary"
 
 /**
@@ -18,7 +19,7 @@ import QuoteSummary from "../components/quote-summary"
  * up contradicting its own header.
  */
 const QuoteTemplate = ({ quote }: { quote: QuoteView }) => {
-  const { compare, recipient } = quote
+  const { compare, recipient, producer } = quote
 
   return (
     <div className="content-container py-12 max-w-4xl">
@@ -47,6 +48,11 @@ const QuoteTemplate = ({ quote }: { quote: QuoteView }) => {
           ) : null}
         </div>
       )}
+
+      {/* Whose hands make this. Rendered only when the backend says so — on the
+          partner's own domain the partner IS the seller and naming them again
+          is noise, so `producer` is null there. */}
+      {producer ? <QuoteProducerBand producer={producer} /> : null}
 
       {/* Amber, and above the prices rather than below them: a buyer who scrolls
           no further still needs to know the clock is running. */}


### PR DESCRIPTION
Closes #1428.

The buyer page is live and correct but thin — a procurement contact weighing a seven-figure consignment was reading a spreadsheet. Founder, 21 Aug: **"we need more details."**

## 1. Line imagery

`pickLineImage` takes the variant's own image (by the merchandiser's `rank`, **not** array order), else the product thumbnail, else nothing.

🔴 Never a placeholder. A plausible *wrong* image on a quote is worse than an empty cell, because the buyer is agreeing to *that* item. Which level it came from travels with it and is captioned, the same way `weight_source` already does.

## 2. The production spec — facts, never choices

Weave label, params resolved against `weaving-techniques.ts` for their labels/units/glyphs, finishes, and the partner's free extra fields.

🔴 The made-to-order **choices** are dropped deliberately. A quote is frozen against specific variants at specific prices; rendering a palette beside them would tell a buyer they may pick a colour, and neither this page nor the price list behind it can honour that. Workshop `notes` stay unpublished, matching the rule `/store/products/:id/spec` already applies.

## 3. Who is producing it

On a JYT-served storefront the buyer has no idea whose hands make the cloth — on a handloom product that is the most persuasive fact on the page. On the partner's own domain the partner *is* the seller and naming them again is noise.

🔑 **The signal is not `quote.store_id`.** Both mint paths resolve the store *from* the partner (`getPartnerStore`, `partner.stores[0]`), so the quote can only ever answer "the partner's own" and the band would never render. It comes from the **request** — the publishable key's sales channels, the same signal `/store/partner-showcase` uses to tell one's own shop from someone else's.

**Three states, not two.** "Cannot tell" is its own answer and it means *say nothing*. No key, no partner channel, an inactive partner, a query that fell over — all collapse to `producer: null`, and null means "say nothing", never "unknown producer". Neither enrichment can fail the view.

The name links to the partner's own shop, because that is where the order goes whichever storefront took it. An **unverified** custom domain is never linked — it is whatever the partner typed into the connect form, and until verification says the DNS is ours it points a buyer at a host we do not control.

## Both storefronts

The page lives in `apps/storefront` and `apps/storefront-starter` (submodule — the one actually serving partner domains). Both carry identical files. `spec-icon.tsx` is backported to `apps/storefront`, which had been ported before #1364.

Submodule PR: Jaal-Yantra-Textiles/nextjs-starter-medusa#16

Two deliberate deviations from house style, both commented in place:
- The partner **logo is a plain `<img>`** — a logo can live on any host the partner uploaded it to, and `next/image` hard-errors on a hostname missing from `remotePatterns`. A 48px avatar is not worth a 500 on a buyer's quote page.
- The producer link carries `rel="noopener noreferrer"` — **the quote token is in the URL**, and the referrer header would hand it to the opened shop.

## Tests

23 new unit tests. The load-bearing ones are the negative ones:

- an unknown viewer is **not** read as "therefore somewhere else"
- two `null` channel ids (what a dangling publishable key produces, #1397) do **not** compare equal
- the spec payload contains no colours, no options, no workshop notes
- a product thumbnail is **not** taken when the variant has its own image

`pnpm check:prod-build` green. `tsc --noEmit` clean on every touched file.

## Verify

```
cd apps/backend && npx jest --testPathPattern="partner-quote" --testPathIgnorePatterns="integration-tests"
```

Then open a real minted quote and confirm: images render, the spec rows carry units, and the producer band is **absent** on the partner's own domain.

🤖 Generated with [Claude Code](https://claude.com/claude-code)