### PR TITLE
fix(quote): a rule-bound 0 price made every bulk consignment ship free

### DIFF
--- a/apps/backend/src/lib/shipping-estimate.ts
+++ b/apps/backend/src/lib/shipping-estimate.ts
@@ -261,6 +261,9 @@ export async function buildShippingEstimate(
       "fulfillment_sets.service_zones.shipping_options.name",
       "fulfillment_sets.service_zones.shipping_options.price_type",
       "fulfillment_sets.service_zones.shipping_options.prices.*",
+      // Needed to SKIP conditional prices — see the rule check below. Without
+      // this relation the rows arrive looking unconditional.
+      "fulfillment_sets.service_zones.shipping_options.prices.price_rules.*",
     ],
     filters: { id: input.store.default_location_id },
   })
@@ -292,6 +295,23 @@ export async function buildShippingEstimate(
           ) {
             continue
           }
+
+          // 🔴 A RULE-BOUND price is not an offer this estimate can make.
+          //
+          // `create-store-with-defaults` gives every Indian store a second
+          // price row of 0 INR gated on `item_total >= 2999` — retail free
+          // shipping. Pushed unconditionally, that 0 is the cheapest option on
+          // the lane and the picker takes it, so EVERY quote from such a store
+          // was quoting freight 0. Found live: the first prod B2B quote
+          // (₹36,00,000, 21 kg to Mumbai) froze `quoted_freight: 0`.
+          //
+          // The estimate has no cart, so it cannot evaluate `item_total` — and
+          // it must not guess. Same reasoning as the currency check above and
+          // the region one below it: a price whose applicability we cannot
+          // establish is not a cheaper answer, it is a different question.
+          // This is the THIRD blindness on this picker — zone (#1424),
+          // currency (#1424), and now rule.
+          if ((price?.price_rules?.length ?? 0) > 0) continue
 
           manual.push({
             shipping_option_id: so.id,

--- a/apps/backend/src/modules/partner-quote/__tests__/build-quote-view.unit.spec.ts
+++ b/apps/backend/src/modules/partner-quote/__tests__/build-quote-view.unit.spec.ts
@@ -103,6 +103,11 @@ const scopeWith = (
                       {
                         service_zones: [
                           {
+                            // A zone with no geo zones covers NOTHING (#1424),
+                            // so a manual fixture has to declare its lane.
+                            geo_zones: manualOptions.length
+                              ? [{ country_code: "in" }]
+                              : [],
                             shipping_options: manualOptions,
                           },
                         ],
@@ -263,6 +268,76 @@ describe("buildQuoteView — freight", () => {
     expect(view.live_error).toMatch(/postal code/i)
     expect(view.quoted?.landed_total).toBe(403_900)
     expect(view.compare.show_quoted).toBe(true)
+  })
+})
+
+describe("buildQuoteView — the free-shipping row that quoted every bulk consignment at zero", () => {
+  /**
+   * Found on the FIRST live prod B2B quote: ₹36,00,000, 21 kg to Mumbai,
+   * `quoted_freight: 0`.
+   *
+   * `create-store-with-defaults` gives every Indian store a second price row of
+   * 0 INR gated on `item_total >= 2999` — retail free shipping. The estimate
+   * read `prices[]` and pushed every row as its own option WITHOUT looking at
+   * `price_rules`, so the 0 was always on the lane and always the cheapest.
+   *
+   * This is the third blindness on the same picker: zone, currency (both
+   * #1424), and now rule.
+   */
+  const FREE_OVER_2999 = {
+    id: "so_flat",
+    name: "Domestic Shipping",
+    price_type: "flat",
+    prices: [
+      { amount: 99, currency_code: "inr", price_rules: [] },
+      {
+        amount: 0,
+        currency_code: "inr",
+        price_rules: [
+          { attribute: "item_total", operator: "gte", value: "2999" },
+        ],
+      },
+    ],
+  }
+
+  it("does not take a rule-bound 0 as the cheapest option", async () => {
+    const captured: Captured = { contexts: [], rateWeights: [] }
+    const view = await buildQuoteView(
+      scopeWith(captured, { manual: [FREE_OVER_2999] }) as any,
+      baseInput()
+    )
+
+    // 0 would be the bug. 99 is the unconditional flat, and it is genuinely
+    // cheaper than the 3900 carrier rate, so it is the honest answer here.
+    expect(view.freight.chosen?.amount).toBe(99)
+    expect(view.live?.freight).toBe(99)
+    expect(view.freight.options.map((o) => o.amount)).not.toContain(0)
+  })
+
+  it("drops the conditional row even when it is the ONLY price", async () => {
+    const captured: Captured = { contexts: [], rateWeights: [] }
+    const view = await buildQuoteView(
+      scopeWith(captured, {
+        manual: [{ ...FREE_OVER_2999, prices: [FREE_OVER_2999.prices[1]] }],
+      }) as any,
+      baseInput()
+    )
+
+    // The estimate has no cart and must not guess: with nothing unconditional
+    // on the lane, the carrier rate stands rather than a free ride.
+    expect(view.freight.chosen?.amount).toBe(3900)
+  })
+
+  it("still keeps an ordinary unconditional flat price", async () => {
+    const captured: Captured = { contexts: [], rateWeights: [] }
+    const view = await buildQuoteView(
+      scopeWith(captured, {
+        manual: [{ ...FREE_OVER_2999, prices: [FREE_OVER_2999.prices[0]] }],
+      }) as any,
+      baseInput()
+    )
+
+    expect(view.freight.chosen?.amount).toBe(99)
   })
 })
 


### PR DESCRIPTION
Found while preparing the **second** prod mint, by reading the **first** one's frozen numbers back: `quoted_freight: 0` on a ₹36,00,000, 21 kg Mumbai consignment.

The handoff recorded that as fallout from #1424's zone-blindness, still frozen from before the fix. **It is not.** It is a third, independent defect, and it is live on every Indian partner store today.

## What actually happens

`create-store-with-defaults` gives every Indian store's domestic flat option **two** price rows:

| amount | rule |
|---|---|
| 99 INR | — |
| **0 INR** | `item_total >= 2999` |

Ordinary retail free shipping. But `buildShippingEstimate` iterated `prices[]` and pushed every currency-matching row as its own option **without ever looking at `price_rules`** — so the 0 sat on the lane unconditionally, and `pickFreightOption` sorts ascending and takes the first.

🔴 **The 0 did not win because the basket cleared ₹2,999. It won because the threshold was never read.** Every quote from such a store quoted freight 0, at any basket size.

Verified on prod — `so_01KX82PP88XQSMY60JDZ5P1VJ6` (`Domestic Shipping · 68M3HY2V`, the store behind the live quote) carries exactly that pair, and it is the default shape on every partner store provisioned this way.

This is the **third** blindness on the same picker: zone, currency (both #1424), and now rule.

## The fix

Skip any price row carrying `price_rules`, and add the relation to the graph query — `prices.*` does not include it, which is exactly why those rows arrived looking unconditional.

Same reasoning as the currency guard immediately above it: this estimate has no cart, so it cannot evaluate `item_total` and must not guess. A price whose applicability we cannot establish is not a cheaper answer, it is a different question.

## ⚠️ One thing to decide separately

A quote now shows **real freight** where the **cart** would still apply free shipping, so the two disagree until that retail rule is scoped away from B2B (raise the threshold, scope it to the retail sales channel, or accept free freight on bulk).

Quoting a number we cannot stand behind is the worse of the two failures, so this ships — but the pricing policy needs a founder call.

## Tests

Three, and **each was confirmed to fail with the guard removed** (2 of 3 flip; the third is the over-correction guard):

- the rule-bound 0 is not taken — 99 is
- a lane whose only price is conditional falls through to the carrier rate, not a free ride
- an ordinary unconditional flat is still kept

```
cd apps/backend && npx jest --testPathPattern="shipping-estimate|partner-quote" --testPathIgnorePatterns="integration-tests"
```

`pnpm check:prod-build` green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)