### PR TITLE
fix(shipping): free shipping had no upper bound, so bulk always cleared it

### DIFF
--- a/apps/backend/src/api/admin/ops/maintenance-jobs/__tests__/cap-free-shipping-band.unit.spec.ts
+++ b/apps/backend/src/api/admin/ops/maintenance-jobs/__tests__/cap-free-shipping-band.unit.spec.ts
@@ -1,0 +1,136 @@
+import { planFreeShippingCaps } from "../cap-free-shipping-band-job"
+
+/**
+ * Free shipping had no upper bound, so every bulk order cleared it.
+ *
+ * The assertions that matter are the ones about telling the two lanes apart and
+ * about NOT acting. INR appears in both rate tables; if the lane were read from
+ * the option's name, a hand-renamed zone (#954 renamed several) would get the
+ * wrong ceiling and nothing would ever look wrong.
+ */
+
+const gte = (value: number) => ({
+  attribute: "item_total",
+  operator: "gte",
+  value: String(value),
+})
+const lte = (value: number) => ({
+  attribute: "item_total",
+  operator: "lte",
+  value: String(value),
+})
+
+const option = (over: any = {}) => ({
+  id: "so_1",
+  name: "Domestic Shipping · 68M3HY2V",
+  price_type: "flat",
+  prices: [
+    { id: "price_base", amount: 99, currency_code: "inr", price_rules: [] },
+    { id: "price_free", amount: 0, currency_code: "inr", price_rules: [gte(2999)] },
+  ],
+  ...over,
+})
+
+describe("planFreeShippingCaps", () => {
+  it("caps a domestic INR tier at the domestic ceiling", () => {
+    const { plan } = planFreeShippingCaps([option()])
+
+    expect(plan).toHaveLength(1)
+    expect(plan[0]).toMatchObject({
+      price_id: "price_free",
+      currency_code: "inr",
+      free_above: 2999,
+      free_up_to: 25000,
+      lane: "domestic",
+    })
+  })
+
+  it("caps an INTERNATIONAL INR tier higher, from the threshold and not the name", () => {
+    // 🔑 Same currency, same misleading name, different lane. Only the existing
+    // threshold (25000, the international one) can tell them apart — and
+    // cross-border pricing steps at 5 kg, so the ceiling is a step higher.
+    const { plan } = planFreeShippingCaps([
+      option({
+        name: "Domestic Shipping · renamed-during-954",
+        prices: [
+          { id: "price_free", amount: 0, currency_code: "inr", price_rules: [gte(25000)] },
+        ],
+      }),
+    ])
+
+    expect(plan[0]).toMatchObject({ lane: "international", free_up_to: 30000 })
+  })
+
+  it("leaves a hand-set threshold alone rather than imposing a ceiling", () => {
+    const { plan, skipped } = planFreeShippingCaps([
+      option({
+        prices: [
+          { id: "price_free", amount: 0, currency_code: "inr", price_rules: [gte(7500)] },
+        ],
+      }),
+    ])
+
+    // Nobody chose 25000 for this row. Guessing is how an operator's deliberate
+    // setting gets silently overwritten.
+    expect(plan).toHaveLength(0)
+    expect(skipped[0].reason).toMatch(/neither the domestic nor the international/)
+  })
+
+  it("is idempotent — a tier that already has a ceiling is skipped", () => {
+    const { plan, skipped } = planFreeShippingCaps([
+      option({
+        prices: [
+          {
+            id: "price_free",
+            amount: 0,
+            currency_code: "inr",
+            price_rules: [gte(2999), lte(25000)],
+          },
+        ],
+      }),
+    ])
+
+    expect(plan).toHaveLength(0)
+    // Not a skip either — nothing is wrong with it.
+    expect(skipped).toHaveLength(0)
+  })
+
+  it("ignores the unconditional base price and calculated options", () => {
+    const { plan } = planFreeShippingCaps([
+      option({ price_type: "calculated" }),
+      {
+        id: "so_2",
+        name: "Flat, no free tier",
+        price_type: "flat",
+        prices: [{ id: "p", amount: 99, currency_code: "inr", price_rules: [] }],
+      },
+    ])
+
+    expect(plan).toHaveLength(0)
+  })
+
+  it("caps every currency on a multi-currency international option", () => {
+    const { plan } = planFreeShippingCaps([
+      {
+        id: "so_intl",
+        name: "International Shipping · 68M3HY2V",
+        price_type: "flat",
+        prices: [
+          { id: "p_eur", amount: 0, currency_code: "eur", price_rules: [gte(300)] },
+          { id: "p_usd", amount: 0, currency_code: "usd", price_rules: [gte(350)] },
+          { id: "p_aud", amount: 0, currency_code: "aud", price_rules: [gte(450)] },
+          { id: "p_idr", amount: 0, currency_code: "idr", price_rules: [gte(5000000)] },
+        ],
+      },
+    ])
+
+    expect(
+      plan.map((p) => [p.currency_code, p.free_up_to])
+    ).toEqual([
+      ["eur", 360],
+      ["usd", 420],
+      ["aud", 540],
+      ["idr", 6000000],
+    ])
+  })
+})

--- a/apps/backend/src/api/admin/ops/maintenance-jobs/backfill-partner-shipping-options-job.ts
+++ b/apps/backend/src/api/admin/ops/maintenance-jobs/backfill-partner-shipping-options-job.ts
@@ -43,22 +43,45 @@ const DELHIVERY_PROVIDER = "delhivery_delhivery"
 
 /**
  * REAL flat manual rates (major currency units), keyed by region currency.
- * `base` is the default shipping amount; `freeAbove` is the cart item_total at or
- * above which shipping becomes free (a Medusa `item_total >= N` price rule — the
- * "price range"/tiered feature). Domestic is India (INR); everything else is a
- * true cross-border rate. `usd` is the fallback for unlisted currencies.
+ * `base` is the default shipping amount; free shipping applies to a BAND —
+ * `item_total >= freeAbove` AND `item_total <= freeUpTo` — not to an open-ended
+ * tail. Domestic is India (INR); everything else is a true cross-border rate.
+ * `usd` is the fallback for unlisted currencies.
+ *
+ * 🔴 `freeUpTo` is the half that was missing, and its absence was expensive.
+ *
+ * A `gte` threshold cannot exclude bulk: a B2B consignment is LARGER than a
+ * retail basket, so it clears the bar harder. Free shipping written as
+ * "over ₹2,999" therefore applies to a ₹36,00,000 order — and the first live
+ * B2B quote duly landed on freight 0. (It reached 0 by a second route too: the
+ * estimate never read `price_rules` at all — see #1430 — but fixing that only
+ * made the quote honest, it did not stop the CART from shipping bulk free.)
+ *
+ * The ceiling is where retail stops, not where bulk starts, so it is set from
+ * the largest plausible consumer basket. Founder call, 21 Aug 2026: ₹25,000
+ * domestic; international one step higher (₹30,000-equivalent) because
+ * cross-border pricing steps at 5 kg and more providers are coming online.
+ * Non-INR ceilings are the same 1.2× step applied to this table's OWN existing
+ * `freeAbove` ratios, so the currencies stay consistent with each other rather
+ * than with a spot rate that will have moved by the time anyone reads this.
  */
-export const DOMESTIC_MANUAL_RATES: Record<string, { base: number; freeAbove: number }> = {
-  inr: { base: 99, freeAbove: 2999 },
+export const DOMESTIC_MANUAL_RATES: Record<
+  string,
+  { base: number; freeAbove: number; freeUpTo: number }
+> = {
+  inr: { base: 99, freeAbove: 2999, freeUpTo: 25000 },
 }
-export const INTL_MANUAL_RATES: Record<string, { base: number; freeAbove: number }> = {
-  usd: { base: 39, freeAbove: 350 },
-  eur: { base: 35, freeAbove: 300 },
-  gbp: { base: 30, freeAbove: 275 },
-  aud: { base: 55, freeAbove: 450 },
-  cad: { base: 50, freeAbove: 400 },
-  inr: { base: 3200, freeAbove: 25000 },
-  idr: { base: 550000, freeAbove: 5000000 },
+export const INTL_MANUAL_RATES: Record<
+  string,
+  { base: number; freeAbove: number; freeUpTo: number }
+> = {
+  usd: { base: 39, freeAbove: 350, freeUpTo: 420 },
+  eur: { base: 35, freeAbove: 300, freeUpTo: 360 },
+  gbp: { base: 30, freeAbove: 275, freeUpTo: 330 },
+  aud: { base: 55, freeAbove: 450, freeUpTo: 540 },
+  cad: { base: 50, freeAbove: 400, freeUpTo: 480 },
+  inr: { base: 3200, freeAbove: 25000, freeUpTo: 30000 },
+  idr: { base: 550000, freeAbove: 5000000, freeUpTo: 6000000 },
 }
 
 const enabledRule = { attribute: "enabled_in_store", value: "true", operator: "eq" as const }
@@ -90,20 +113,27 @@ export const locationSuffix = (locationId: string): string =>
 
 /**
  * Build the flat tiered price list for a manual option: a default `base` price
- * plus a `0` price gated on `item_total >= freeAbove` (free-shipping tier).
+ * plus a `0` price gated on a free-shipping BAND.
+ *
+ * 🔑 Both bounds, always. A `gte` alone is an open-ended tail that every bulk
+ * order clears — see the rate table above for what that cost.
  */
 const manualTieredPrices = (
   currencies: string[],
-  rates: Record<string, { base: number; freeAbove: number }>
+  rates: Record<string, { base: number; freeAbove: number; freeUpTo: number }>
 ): TieredPrice[] => {
   const out: TieredPrice[] = []
   for (const cur of currencies) {
-    const rate = rates[cur] ?? rates["usd"] ?? { base: 39, freeAbove: 350 }
+    const rate =
+      rates[cur] ?? rates["usd"] ?? { base: 39, freeAbove: 350, freeUpTo: 420 }
     out.push({ currency_code: cur, amount: rate.base })
     out.push({
       currency_code: cur,
       amount: 0,
-      rules: [{ attribute: "item_total", operator: "gte" as const, value: rate.freeAbove }],
+      rules: [
+        { attribute: "item_total", operator: "gte" as const, value: rate.freeAbove },
+        { attribute: "item_total", operator: "lte" as const, value: rate.freeUpTo },
+      ],
     })
   }
   return out

--- a/apps/backend/src/api/admin/ops/maintenance-jobs/cap-free-shipping-band-job.ts
+++ b/apps/backend/src/api/admin/ops/maintenance-jobs/cap-free-shipping-band-job.ts
@@ -1,0 +1,256 @@
+import { ContainerRegistrationKeys, MedusaError, Modules } from "@medusajs/framework/utils"
+import { z } from "@medusajs/framework/zod"
+
+import {
+  DOMESTIC_MANUAL_RATES,
+  INTL_MANUAL_RATES,
+} from "./backfill-partner-shipping-options-job"
+import type { MaintenanceChange, MaintenanceJob, MaintenanceJobResult } from "./registry"
+
+/**
+ * Close the open end of free shipping (#1428 follow-up, founder call 21 Aug 2026).
+ *
+ * ## The bug this repairs
+ *
+ * Every partner store's manual flat shipping option carries a second price row
+ * of 0 gated on `item_total >= freeAbove` — retail free shipping. There was no
+ * upper bound.
+ *
+ * 🔴 A `gte` threshold cannot exclude bulk. A B2B consignment is LARGER than a
+ * retail basket, so it clears the bar harder, not less. "Free over ₹2,999"
+ * therefore applies to a ₹36,00,000 order, and the first live B2B quote duly
+ * landed on freight 0.
+ *
+ * (#1430 fixed a *different* route to the same 0 — the quote estimate never
+ * read `price_rules` at all. That made the QUOTE honest. It did nothing about
+ * the CART, which reads the rules correctly and would still have shipped a bulk
+ * order free. Both halves are needed; neither substitutes for the other.)
+ *
+ * ## Which ceiling, and how this job knows
+ *
+ * The ceiling is where RETAIL stops, not where bulk starts, so it comes from
+ * the rate table in `backfill-partner-shipping-options-job.ts` — the same
+ * source new stores are provisioned from. Domestic ₹25,000; international one
+ * step higher, because cross-border pricing steps at 5 kg.
+ *
+ * 🔑 Domestic and international are told apart by the EXISTING `gte` value, not
+ * by the option's name. INR appears in both tables (2999 domestic, 25000
+ * international) and the thresholds are distinct, so the row identifies its own
+ * lane. Names were hand-edited during #954 and cannot be trusted for this —
+ * the same trap that made the Shiprocket backfill classify from geo zones.
+ *
+ * A threshold matching NEITHER table was set by hand. This job reports it and
+ * moves on rather than imposing a ceiling nobody chose.
+ *
+ * Idempotent: a price that already has an `lte` is left alone.
+ */
+
+export const MAX_OPTION_SCAN = 2000
+
+const paramsSchema = z.object({
+  shipping_option_id: z.string().min(1).optional(),
+  limit: z.number().int().positive().max(MAX_OPTION_SCAN).optional().default(MAX_OPTION_SCAN),
+})
+
+export type FreeShippingCapPlan = {
+  price_id: string
+  shipping_option_id: string
+  shipping_option_name: string
+  currency_code: string
+  /** The threshold already on the row — what identified the lane. */
+  free_above: number
+  /** The ceiling to add. */
+  free_up_to: number
+  lane: "domestic" | "international"
+}
+
+export type FreeShippingCapSkip = {
+  price_id: string
+  shipping_option_name: string
+  currency_code: string
+  reason: string
+}
+
+/**
+ * PURE: which 0-priced rows still have an open-ended free-shipping tail.
+ *
+ * Exported for unit tests — this is the whole decision, and it must be
+ * inspectable without a database.
+ */
+export function planFreeShippingCaps(options: any[]): {
+  plan: FreeShippingCapPlan[]
+  skipped: FreeShippingCapSkip[]
+} {
+  const plan: FreeShippingCapPlan[] = []
+  const skipped: FreeShippingCapSkip[] = []
+
+  for (const option of options ?? []) {
+    // Calculated options carry no flat price rows to bound.
+    if (option?.price_type === "calculated") continue
+
+    for (const price of option?.prices ?? []) {
+      const rules = (price?.price_rules ?? []) as any[]
+      const gte = rules.find(
+        (r) => r?.attribute === "item_total" && r?.operator === "gte"
+      )
+      if (!gte) continue
+
+      const name = option?.name ?? option?.id ?? "?"
+      const currency = String(price?.currency_code ?? "").toLowerCase()
+
+      // Already bounded — the whole point of being idempotent.
+      if (rules.some((r) => r?.attribute === "item_total" && r?.operator === "lte")) {
+        continue
+      }
+
+      const freeAbove = Number(gte.value)
+      if (!Number.isFinite(freeAbove)) {
+        skipped.push({
+          price_id: price.id,
+          shipping_option_name: name,
+          currency_code: currency,
+          reason: `Threshold "${gte.value}" is not a number.`,
+        })
+        continue
+      }
+
+      // 🔑 The lane comes from the threshold, never from the name.
+      const domestic = DOMESTIC_MANUAL_RATES[currency]
+      const intl = INTL_MANUAL_RATES[currency]
+      let lane: "domestic" | "international" | null = null
+      let freeUpTo = 0
+
+      if (domestic && domestic.freeAbove === freeAbove) {
+        lane = "domestic"
+        freeUpTo = domestic.freeUpTo
+      } else if (intl && intl.freeAbove === freeAbove) {
+        lane = "international"
+        freeUpTo = intl.freeUpTo
+      }
+
+      if (!lane) {
+        skipped.push({
+          price_id: price.id,
+          shipping_option_name: name,
+          currency_code: currency,
+          reason: `Threshold ${freeAbove} ${currency} matches neither the domestic nor the international rate table — set by hand, so no ceiling is imposed.`,
+        })
+        continue
+      }
+
+      plan.push({
+        price_id: price.id,
+        shipping_option_id: option.id,
+        shipping_option_name: name,
+        currency_code: currency,
+        free_above: freeAbove,
+        free_up_to: freeUpTo,
+        lane,
+      })
+    }
+  }
+
+  return { plan, skipped }
+}
+
+export const capFreeShippingBandJob: MaintenanceJob = {
+  id: "cap-free-shipping-band",
+  label: "Close the open end of free shipping (bulk orders were shipping free)",
+  description:
+    "Every partner store's manual flat shipping option has a 0-priced row gated on `item_total >= N` — retail free shipping with no upper bound. A `gte` cannot exclude bulk: a B2B consignment is LARGER than a retail basket, so it clears the bar harder, and the first live B2B quote (₹36,00,000, 21 kg) shipped free. This adds the matching `item_total <= ceiling` rule so free shipping applies to a BAND. Ceilings come from the same rate table new stores are provisioned from — ₹25,000 domestic, one step higher international because cross-border pricing steps at 5 kg. Domestic and international are told apart by the EXISTING threshold, not by the option name (names were hand-edited during #954). A threshold matching neither table was set by hand: it is reported and left alone. Idempotent — a price that already has an `lte` is skipped. Dry-run previews every ceiling it would add.",
+  params: [
+    {
+      name: "shipping_option_id",
+      type: "string",
+      required: false,
+      description: "Restrict to a single shipping option (default: every flat option)",
+    },
+    {
+      name: "limit",
+      type: "number",
+      required: false,
+      description: `Max shipping options to scan in one call (default & max ${MAX_OPTION_SCAN})`,
+    },
+  ],
+  run: async (container, { dry_run, params }): Promise<MaintenanceJobResult> => {
+    const parsed = paramsSchema.safeParse(params)
+    if (!parsed.success) {
+      throw new MedusaError(
+        MedusaError.Types.INVALID_DATA,
+        parsed.error.issues.map((i) => i.message).join("; ")
+      )
+    }
+    const { shipping_option_id, limit } = parsed.data
+
+    const query: any = container.resolve(ContainerRegistrationKeys.QUERY)
+    const pricing: any = container.resolve(Modules.PRICING)
+
+    const { data: options } = await query.graph({
+      entity: "shipping_option",
+      fields: [
+        "id",
+        "name",
+        "price_type",
+        "prices.id",
+        "prices.amount",
+        "prices.currency_code",
+        // ⚠️ `prices.*` does NOT include this relation. Without it every row
+        // arrives looking unconditional — the same blind spot that hid #1430.
+        "prices.price_rules.*",
+      ],
+      ...(shipping_option_id ? { filters: { id: shipping_option_id } } : {}),
+      pagination: { take: limit },
+    })
+
+    const { plan, skipped } = planFreeShippingCaps((options ?? []) as any[])
+
+    const changes: MaintenanceChange[] = []
+    const errors: Array<{ id: string; message: string }> = []
+
+    for (const item of plan) {
+      changes.push({
+        entity: "price_rule",
+        id: item.price_id,
+        field: `item_total ceiling (${item.lane}, ${item.shipping_option_name})`,
+        before: `free at or above ${item.free_above} ${item.currency_code}, no upper bound`,
+        after: `free between ${item.free_above} and ${item.free_up_to} ${item.currency_code}`,
+      })
+
+      if (dry_run) continue
+
+      try {
+        // ⚠️ `CreatePriceRuleDTO` omits `operator` in @medusajs/types, but the
+        // model has it and the existing `gte` rows carry it. The types are
+        // behind the model; the cast is deliberate, not laziness.
+        await pricing.createPriceRules([
+          {
+            price_id: item.price_id,
+            attribute: "item_total",
+            operator: "lte",
+            value: String(item.free_up_to),
+          },
+        ] as any)
+      } catch (e: any) {
+        errors.push({ id: item.price_id, message: e?.message ?? String(e) })
+      }
+    }
+
+    const scanned = (options ?? []).length
+    const summary = changes.length
+      ? `${dry_run ? "Would cap" : "Capped"} ${changes.length} free-shipping tier(s) across ${scanned} scanned option(s); ${skipped.length} hand-set threshold(s) left alone.`
+      : `No changes — scanned ${scanned} option(s); every free-shipping tier is already bounded. ${skipped.length} hand-set threshold(s) left alone.`
+
+    return {
+      job_id: capFreeShippingBandJob.id,
+      dry_run,
+      applied: !dry_run && changes.length > 0 && errors.length < changes.length,
+      summary,
+      changes,
+      errors: errors.length
+        ? errors
+        : skipped.length
+          ? skipped.map((s) => ({ id: s.price_id, message: s.reason }))
+          : undefined,
+    }
+  },
+}

--- a/apps/backend/src/api/admin/ops/maintenance-jobs/registry.ts
+++ b/apps/backend/src/api/admin/ops/maintenance-jobs/registry.ts
@@ -81,6 +81,7 @@ import { seedInvestorPanelsJob } from "./seed-investor-panels-job"
 import { replayFxFanoutJob } from "./fanout-fx-job"
 import { backfillStoreCurrenciesJob } from "./backfill-store-currencies-job"
 import { backfillShiprocketShippingOptionsJob } from "./backfill-shiprocket-shipping-options-job"
+import { capFreeShippingBandJob } from "./cap-free-shipping-band-job"
 import { deleteOrphanStoreJob } from "./delete-orphan-store-job"
 import { restoreOrphanStoreJob } from "./restore-orphan-store-job"
 import { backfillPartnerEmailVerifiedJob } from "./backfill-partner-email-verified-job"
@@ -5772,6 +5773,7 @@ export const MAINTENANCE_JOBS: MaintenanceJob[] = [
   replayFxFanoutJob,
   backfillStoreCurrenciesJob,
   backfillShiprocketShippingOptionsJob,
+  capFreeShippingBandJob,
   deleteOrphanStoreJob,
   restoreOrphanStoreJob,
   backfillPartnerEmailVerifiedJob,


### PR DESCRIPTION
Founder call, 21 Aug 2026, after #1430 exposed the shape of the problem.

Every partner store's manual flat shipping option carries a 0-priced row gated on `item_total >= N` — retail free shipping, with **nothing on the other side of it**.

🔴 **A `gte` threshold cannot exclude bulk.** A B2B consignment is *larger* than a retail basket, so it clears the bar harder, not less. "Free over ₹2,999" applies in full to a ₹36,00,000 order.

## Why #1430 wasn't enough

#1430 fixed a **different route to the same 0**: the quote estimate never read `price_rules` at all. That made the *quote* honest. It did nothing about the **cart**, which reads the rules correctly and would still have shipped a bulk order free — so quote and cart would have disagreed, which is exactly the failure this module's design is built to prevent.

Both halves are needed. Neither substitutes for the other.

## What lands

**1. New stores are born correct.** `DOMESTIC_MANUAL_RATES` / `INTL_MANUAL_RATES` gain `freeUpTo`, and `manualTieredPrices` emits the matching `item_total <= N`. Free shipping is a **band**, not a tail.

**2. `cap-free-shipping-band`** — a maintenance job that repairs the ~19 stores already provisioned. Idempotent, dry-run previews every ceiling.

## The ceilings

| lane | ceiling |
|---|---|
| domestic INR | **₹25,000** |
| international INR | **₹30,000** |
| intl USD / EUR / GBP / AUD / CAD / IDR | the same 1.2× step |

International sits one step higher because **cross-border pricing steps at 5 kg** and more providers are coming online. Non-INR ceilings apply that step to this table's **own** existing `freeAbove` ratios, so the currencies stay consistent with each other rather than with a spot rate that will have moved by the time anyone reads them.

## 🔑 The lane comes from the threshold, never the name

INR appears in **both** tables (2999 domestic, 25000 international) and the two values are distinct, so each row identifies its own lane. Option names were hand-edited during #954 and cannot carry this — the same trap that made the Shiprocket backfill classify from geo zones rather than names.

A threshold matching **neither** table was set by hand. It is reported and left alone rather than overwritten with a ceiling nobody chose.

⚠️ `prices.*` in `query.graph` does **not** include `price_rules`. Asking for it explicitly is what makes these rows visible at all — the same blind spot that hid #1430 for three sessions.

## Tests

Six on the pure planner, aimed at the two things that would fail silently:

- an **international** INR tier on a **misleadingly-named** option still gets the international ceiling
- a hand-set threshold is **skipped**, not guessed at
- idempotence: an already-bounded tier is neither capped nor reported as a problem
- every currency on a multi-currency international option is capped

```
cd apps/backend && npx jest --testPathPattern="cap-free-shipping|backfill-partner-shipping"
```

`pnpm check:prod-build` green.

## Verify on prod after deploy

Dry-run first — it should name every open tier and no hand-set one.

🤖 Generated with [Claude Code](https://claude.com/claude-code)