### PR TITLE
fix(shipping): leave DOMESTIC free shipping open — cap international only

### DIFF
--- a/apps/backend/src/api/admin/ops/maintenance-jobs/__tests__/cap-free-shipping-band.unit.spec.ts
+++ b/apps/backend/src/api/admin/ops/maintenance-jobs/__tests__/cap-free-shipping-band.unit.spec.ts
@@ -1,12 +1,13 @@
 import { planFreeShippingCaps } from "../cap-free-shipping-band-job"
 
 /**
- * Free shipping had no upper bound, so every bulk order cleared it.
+ * International free shipping had no upper bound, so every bulk order cleared it.
  *
- * The assertions that matter are the ones about telling the two lanes apart and
- * about NOT acting. INR appears in both rate tables; if the lane were read from
- * the option's name, a hand-renamed zone (#954 renamed several) would get the
- * wrong ceiling and nothing would ever look wrong.
+ * The assertions that matter are the ones about NOT acting. Domestic is
+ * deliberately left open (founder call, 21 Aug 2026), so capping it would be a
+ * defect, not an improvement — and INR appears in BOTH rate tables, so a lane
+ * read from the option's name would cap the very tier that must stay open. A
+ * hand-renamed zone (#954 renamed several) is enough to trigger that.
  */
 
 const gte = (value: number) => ({
@@ -32,23 +33,20 @@ const option = (over: any = {}) => ({
 })
 
 describe("planFreeShippingCaps", () => {
-  it("caps a domestic INR tier at the domestic ceiling", () => {
-    const { plan } = planFreeShippingCaps([option()])
+  it("leaves a DOMESTIC tier open, and says it did so on purpose", () => {
+    // 🔴 The founder's call. ₹99-scale freight is absorbable, and a ceiling
+    // here would start charging retail carts that ship free today. Reported
+    // rather than silently passed over, so a reader can see it was examined.
+    const { plan, skipped } = planFreeShippingCaps([option()])
 
-    expect(plan).toHaveLength(1)
-    expect(plan[0]).toMatchObject({
-      price_id: "price_free",
-      currency_code: "inr",
-      free_above: 2999,
-      free_up_to: 25000,
-      lane: "domestic",
-    })
+    expect(plan).toHaveLength(0)
+    expect(skipped[0].reason).toMatch(/deliberately uncapped/)
   })
 
-  it("caps an INTERNATIONAL INR tier higher, from the threshold and not the name", () => {
+  it("caps an INTERNATIONAL INR tier, from the threshold and not the name", () => {
     // 🔑 Same currency, same misleading name, different lane. Only the existing
-    // threshold (25000, the international one) can tell them apart — and
-    // cross-border pricing steps at 5 kg, so the ceiling is a step higher.
+    // threshold (25000, the international one) can tell them apart. Get this
+    // wrong in the other direction and a domestic tier gets capped.
     const { plan } = planFreeShippingCaps([
       option({
         name: "Domestic Shipping · renamed-during-954",
@@ -79,12 +77,13 @@ describe("planFreeShippingCaps", () => {
   it("is idempotent — a tier that already has a ceiling is skipped", () => {
     const { plan, skipped } = planFreeShippingCaps([
       option({
+        name: "International Shipping · 68M3HY2V",
         prices: [
           {
             id: "price_free",
             amount: 0,
-            currency_code: "inr",
-            price_rules: [gte(2999), lte(25000)],
+            currency_code: "eur",
+            price_rules: [gte(300), lte(360)],
           },
         ],
       }),

--- a/apps/backend/src/api/admin/ops/maintenance-jobs/backfill-partner-shipping-options-job.ts
+++ b/apps/backend/src/api/admin/ops/maintenance-jobs/backfill-partner-shipping-options-job.ts
@@ -48,33 +48,46 @@ const DELHIVERY_PROVIDER = "delhivery_delhivery"
  * tail. Domestic is India (INR); everything else is a true cross-border rate.
  * `usd` is the fallback for unlisted currencies.
  *
- * 🔴 `freeUpTo` is the half that was missing, and its absence was expensive.
+ * 🔴 `freeUpTo` exists because a `gte` threshold cannot exclude bulk: a B2B
+ * consignment is LARGER than a retail basket, so it clears the bar harder, not
+ * less. Free shipping written as "over X" therefore applies in full to a
+ * seven-figure order.
  *
- * A `gte` threshold cannot exclude bulk: a B2B consignment is LARGER than a
- * retail basket, so it clears the bar harder. Free shipping written as
- * "over ₹2,999" therefore applies to a ₹36,00,000 order — and the first live
- * B2B quote duly landed on freight 0. (It reached 0 by a second route too: the
- * estimate never read `price_rules` at all — see #1430 — but fixing that only
- * made the quote honest, it did not stop the CART from shipping bulk free.)
+ * ## Domestic is deliberately UNCAPPED
  *
- * The ceiling is where retail stops, not where bulk starts, so it is set from
- * the largest plausible consumer basket. Founder call, 21 Aug 2026: ₹25,000
- * domestic; international one step higher (₹30,000-equivalent) because
- * cross-border pricing steps at 5 kg and more providers are coming online.
- * Non-INR ceilings are the same 1.2× step applied to this table's OWN existing
- * `freeAbove` ratios, so the currencies stay consistent with each other rather
- * than with a spot rate that will have moved by the time anyone reads this.
+ * Founder call, 21 Aug 2026: domestic keeps its open-ended free tier. Indian
+ * domestic freight is ₹99-scale, so absorbing it on a large order is a rounding
+ * error against the order itself, and capping it would start charging real
+ * retail carts that ship free today. `freeUpTo` is therefore OPTIONAL, and its
+ * absence is a decision rather than an oversight.
+ *
+ * ⚠️ The known consequence: a domestic B2B quote shows real freight (the quote
+ * estimate skips rule-bound prices — #1430) while the cart still ships free, so
+ * the buyer pays LESS than quoted. That direction is a pleasant surprise rather
+ * than a dispute, which is why it is acceptable here and would not be if it ran
+ * the other way.
+ *
+ * ## International IS capped
+ *
+ * Cross-border freight is not a rounding error, and its pricing steps at 5 kg —
+ * so an uncapped free tier there is a real loss on exactly the orders most
+ * likely to use it. The ceiling is one step (1.2×) above the existing
+ * threshold, applied to this table's OWN `freeAbove` ratios so the currencies
+ * stay consistent with each other rather than with a spot rate that will have
+ * moved by the time anyone reads this.
  */
 export const DOMESTIC_MANUAL_RATES: Record<
   string,
-  { base: number; freeAbove: number; freeUpTo: number }
+  { base: number; freeAbove: number; freeUpTo?: number }
 > = {
-  inr: { base: 99, freeAbove: 2999, freeUpTo: 25000 },
+  // No `freeUpTo` — see "Domestic is deliberately UNCAPPED" above.
+  inr: { base: 99, freeAbove: 2999 },
 }
 export const INTL_MANUAL_RATES: Record<
   string,
   { base: number; freeAbove: number; freeUpTo: number }
 > = {
+  // Every entry HAS a ceiling. Cross-border freight is not absorbable.
   usd: { base: 39, freeAbove: 350, freeUpTo: 420 },
   eur: { base: 35, freeAbove: 300, freeUpTo: 360 },
   gbp: { base: 30, freeAbove: 275, freeUpTo: 330 },
@@ -113,28 +126,35 @@ export const locationSuffix = (locationId: string): string =>
 
 /**
  * Build the flat tiered price list for a manual option: a default `base` price
- * plus a `0` price gated on a free-shipping BAND.
+ * plus a `0` price gated on the free-shipping tier.
  *
- * 🔑 Both bounds, always. A `gte` alone is an open-ended tail that every bulk
- * order clears — see the rate table above for what that cost.
+ * 🔑 The upper bound is emitted only when the rate table declares one. An
+ * absent `freeUpTo` means the tier is deliberately open-ended (domestic — see
+ * the rate table), NOT that a ceiling was forgotten. Defaulting one in here
+ * would silently start charging carts that ship free today.
  */
 const manualTieredPrices = (
   currencies: string[],
-  rates: Record<string, { base: number; freeAbove: number; freeUpTo: number }>
+  rates: Record<string, { base: number; freeAbove: number; freeUpTo?: number }>
 ): TieredPrice[] => {
   const out: TieredPrice[] = []
   for (const cur of currencies) {
     const rate =
       rates[cur] ?? rates["usd"] ?? { base: 39, freeAbove: 350, freeUpTo: 420 }
     out.push({ currency_code: cur, amount: rate.base })
-    out.push({
-      currency_code: cur,
-      amount: 0,
-      rules: [
-        { attribute: "item_total", operator: "gte" as const, value: rate.freeAbove },
-        { attribute: "item_total", operator: "lte" as const, value: rate.freeUpTo },
-      ],
-    })
+
+    const rules: any[] = [
+      { attribute: "item_total", operator: "gte" as const, value: rate.freeAbove },
+    ]
+    if (Number.isFinite(rate.freeUpTo)) {
+      rules.push({
+        attribute: "item_total",
+        operator: "lte" as const,
+        value: rate.freeUpTo,
+      })
+    }
+
+    out.push({ currency_code: cur, amount: 0, rules })
   }
   return out
 }

--- a/apps/backend/src/api/admin/ops/maintenance-jobs/cap-free-shipping-band-job.ts
+++ b/apps/backend/src/api/admin/ops/maintenance-jobs/cap-free-shipping-band-job.ts
@@ -26,18 +26,28 @@ import type { MaintenanceChange, MaintenanceJob, MaintenanceJobResult } from "./
  * the CART, which reads the rules correctly and would still have shipped a bulk
  * order free. Both halves are needed; neither substitutes for the other.)
  *
- * ## Which ceiling, and how this job knows
+ * ## INTERNATIONAL ONLY — domestic is deliberately left open
  *
- * The ceiling is where RETAIL stops, not where bulk starts, so it comes from
- * the rate table in `backfill-partner-shipping-options-job.ts` — the same
- * source new stores are provisioned from. Domestic ₹25,000; international one
- * step higher, because cross-border pricing steps at 5 kg.
+ * Founder call, 21 Aug 2026: Indian domestic freight is ₹99-scale, so
+ * absorbing it on a large order is a rounding error against the order itself,
+ * and capping it would start charging real retail carts that ship free today.
+ * The domestic rate table therefore declares no `freeUpTo`, and this job treats
+ * that absence as the decision it is: domestic rows are reported as
+ * intentionally uncapped, never "fixed".
+ *
+ * Cross-border freight is not absorbable, and its pricing steps at 5 kg, so an
+ * uncapped free tier there is a real loss on exactly the orders most likely to
+ * use it. Ceilings come from the rate table in
+ * `backfill-partner-shipping-options-job.ts` — the same source new stores are
+ * provisioned from.
  *
  * 🔑 Domestic and international are told apart by the EXISTING `gte` value, not
  * by the option's name. INR appears in both tables (2999 domestic, 25000
  * international) and the thresholds are distinct, so the row identifies its own
  * lane. Names were hand-edited during #954 and cannot be trusted for this —
- * the same trap that made the Shiprocket backfill classify from geo zones.
+ * the same trap that made the Shiprocket backfill classify from geo zones. That
+ * distinction is now load-bearing in BOTH directions: mistaking a domestic row
+ * for an international one would cap a tier the founder chose to leave open.
  *
  * A threshold matching NEITHER table was set by hand. This job reports it and
  * moves on rather than imposing a ceiling nobody chose.
@@ -61,7 +71,8 @@ export type FreeShippingCapPlan = {
   free_above: number
   /** The ceiling to add. */
   free_up_to: number
-  lane: "domestic" | "international"
+  /** Only ever "international" — see the header. */
+  lane: "international"
 }
 
 export type FreeShippingCapSkip = {
@@ -117,12 +128,19 @@ export function planFreeShippingCaps(options: any[]): {
       // 🔑 The lane comes from the threshold, never from the name.
       const domestic = DOMESTIC_MANUAL_RATES[currency]
       const intl = INTL_MANUAL_RATES[currency]
-      let lane: "domestic" | "international" | null = null
+      let lane: "international" | null = null
       let freeUpTo = 0
 
       if (domestic && domestic.freeAbove === freeAbove) {
-        lane = "domestic"
-        freeUpTo = domestic.freeUpTo
+        // Deliberately uncapped. Reported so a reader can see the row was
+        // examined and left alone, rather than silently missed.
+        skipped.push({
+          price_id: price.id,
+          shipping_option_name: name,
+          currency_code: currency,
+          reason: `Domestic free shipping is deliberately uncapped (founder call, 21 Aug 2026) — ₹99-scale freight is absorbable, and a ceiling would start charging retail carts that ship free today.`,
+        })
+        continue
       } else if (intl && intl.freeAbove === freeAbove) {
         lane = "international"
         freeUpTo = intl.freeUpTo
@@ -155,9 +173,9 @@ export function planFreeShippingCaps(options: any[]): {
 
 export const capFreeShippingBandJob: MaintenanceJob = {
   id: "cap-free-shipping-band",
-  label: "Close the open end of free shipping (bulk orders were shipping free)",
+  label: "Cap the international free-shipping tier (domestic stays open)",
   description:
-    "Every partner store's manual flat shipping option has a 0-priced row gated on `item_total >= N` — retail free shipping with no upper bound. A `gte` cannot exclude bulk: a B2B consignment is LARGER than a retail basket, so it clears the bar harder, and the first live B2B quote (₹36,00,000, 21 kg) shipped free. This adds the matching `item_total <= ceiling` rule so free shipping applies to a BAND. Ceilings come from the same rate table new stores are provisioned from — ₹25,000 domestic, one step higher international because cross-border pricing steps at 5 kg. Domestic and international are told apart by the EXISTING threshold, not by the option name (names were hand-edited during #954). A threshold matching neither table was set by hand: it is reported and left alone. Idempotent — a price that already has an `lte` is skipped. Dry-run previews every ceiling it would add.",
+    "Every partner store's manual flat shipping option has a 0-priced row gated on `item_total >= N` — retail free shipping with no upper bound. A `gte` cannot exclude bulk: a B2B consignment is LARGER than a retail basket, so it clears the bar harder, and the first live B2B quote (₹36,00,000, 21 kg) shipped free. This adds the matching `item_total <= ceiling` rule to INTERNATIONAL tiers only, so cross-border free shipping applies to a BAND. DOMESTIC IS LEFT OPEN ON PURPOSE (founder call, 21 Aug 2026): ₹99-scale freight is absorbable, and a ceiling would start charging retail carts that ship free today — domestic rows are reported as intentionally uncapped, never changed. Ceilings come from the same rate table new stores are provisioned from. Domestic and international are told apart by the EXISTING threshold, not by the option name (names were hand-edited during #954). A threshold matching neither table was set by hand: it is reported and left alone. Idempotent — a price that already has an `lte` is skipped. Dry-run previews every ceiling it would add.",
   params: [
     {
       name: "shipping_option_id",
@@ -237,8 +255,8 @@ export const capFreeShippingBandJob: MaintenanceJob = {
 
     const scanned = (options ?? []).length
     const summary = changes.length
-      ? `${dry_run ? "Would cap" : "Capped"} ${changes.length} free-shipping tier(s) across ${scanned} scanned option(s); ${skipped.length} hand-set threshold(s) left alone.`
-      : `No changes — scanned ${scanned} option(s); every free-shipping tier is already bounded. ${skipped.length} hand-set threshold(s) left alone.`
+      ? `${dry_run ? "Would cap" : "Capped"} ${changes.length} INTERNATIONAL free-shipping tier(s) across ${scanned} scanned option(s); ${skipped.length} tier(s) left alone (domestic-by-design or hand-set).`
+      : `No changes — scanned ${scanned} option(s); every international free-shipping tier is already bounded. ${skipped.length} tier(s) left alone (domestic-by-design or hand-set).`
 
     return {
       job_id: capFreeShippingBandJob.id,


### PR DESCRIPTION
Reverses half of #1431 **before it was ever run**. Founder call, 21 Aug 2026, on being shown the consequence.

## The reasoning

Capping domestic at ₹25,000 would start charging **real retail carts** that ship free today — and Indian domestic freight is ₹99-scale, so absorbing it on a large order is a rounding error against the order itself.

Cross-border is the opposite case. That freight is **not** absorbable and its pricing **steps at 5 kg**, so an uncapped free tier there is a real loss on exactly the orders most likely to use it. International keeps its ceiling.

| lane | free shipping | ceiling |
|---|---|---|
| **domestic INR** | ₹2,999 and up | **none, on purpose** |
| **international** | from the existing threshold | 1.2× step ($420, €360, £330, A$540, C$480, ₹30,000, Rp6,000,000) |

## What changed

`freeUpTo` is now **optional**, and `manualTieredPrices` emits the `lte` rule only when the rate table declares one. The absence is a decision, not an oversight, and the comment says so — defaulting a ceiling in would silently start charging carts that ship free.

`cap-free-shipping-band` **reports** domestic rows as intentionally uncapped rather than passing over them in silence, so a reader can see the row was examined and left alone.

## ⚠️ Known and accepted

A domestic B2B quote now shows **real freight** (the estimate skips rule-bound prices, #1430) while the **cart still ships free** — so the buyer pays *less* than quoted.

That direction is a pleasant surprise rather than a dispute, which is why it is acceptable here and would not be if it ran the other way.

## 🔑 The threshold-not-the-name rule is now load-bearing in both directions

INR appears in **both** rate tables (2999 domestic, 25000 international). Reading the lane from a hand-renamed option (#954 renamed several) would cap the very tier that must stay open — so the test for it asserts the domestic row is *left alone*, making that failure visible rather than merely absent.

Nothing was applied to prod under the old ceilings; the job had not been run.

```
cd apps/backend && npx jest --testPathPattern="cap-free-shipping|backfill-partner-shipping"
```

`pnpm check:prod-build` green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)