### PR TITLE
fix(quote): the buyer page priced freight from EVERY tenant's locations

### DIFF
--- a/apps/backend/src/api/store/b2b/quotes/[token]/route.ts
+++ b/apps/backend/src/api/store/b2b/quotes/[token]/route.ts
@@ -1,5 +1,5 @@
 import { MedusaRequest, MedusaResponse } from "@medusajs/framework/http"
-import { MedusaError } from "@medusajs/framework/utils"
+import { ContainerRegistrationKeys, MedusaError } from "@medusajs/framework/utils"
 
 import { PARTNER_QUOTE_MODULE } from "../../../../../modules/partner-quote"
 import { buildQuoteView } from "../../../../../modules/partner-quote/lib/build-quote-view"
@@ -54,6 +54,31 @@ export const GET = async (req: MedusaRequest, res: MedusaResponse) => {
     }
   }
 
+  // 🔴 The store's PICKUP LOCATION, not just its id.
+  //
+  // `buildShippingEstimate` filters its location reads on
+  // `store.default_location_id`. Passing only `{ id }` left that undefined, and
+  // `filters: { id: undefined }` is NO FILTER — so this page collected manual
+  // shipping options from EVERY stock location on the platform. Found live on
+  // the second prod mint: the buyer was offered another partner's "European
+  // Shipping", "Private" and "In Person Pickup" (for a Mumbai delivery), while
+  // this store's own domestic option was missing entirely — and the page's
+  // freight therefore disagreed with the freight the mint had frozen seconds
+  // earlier. Cross-tenant read on a public, unauthenticated route; same shape
+  // as #1397.
+  //
+  // The estimate now refuses a missing location outright, so this can only fail
+  // loudly. Kept as a filtered read by id — never a bare list.
+  const query: any = req.scope.resolve(ContainerRegistrationKeys.QUERY)
+  const { data: stores } = quote.store_id
+    ? await query.graph({
+        entity: "stores",
+        fields: ["id", "default_location_id"],
+        filters: { id: quote.store_id },
+      })
+    : { data: [] }
+  const store = (stores ?? [])[0] as any
+
   const view = await buildQuoteView(req.scope, {
     quote: { ...quote, lines },
     lines: effectiveLines,
@@ -61,7 +86,10 @@ export const GET = async (req: MedusaRequest, res: MedusaResponse) => {
     destination_postal_code: quote.destination_postal_code,
     currency_code: quote.currency_code,
     region_id: quote.region_id,
-    store: { id: quote.store_id ?? undefined },
+    store: {
+      id: quote.store_id ?? undefined,
+      default_location_id: store?.default_location_id ?? null,
+    },
     partner_id: quote.partner_id ?? null,
     /**
      * #1428 — whose storefront is serving this page.

--- a/apps/backend/src/lib/shipping-estimate.ts
+++ b/apps/backend/src/lib/shipping-estimate.ts
@@ -236,6 +236,23 @@ export async function buildShippingEstimate(
   const totalWeightGrams = lines.reduce((sum, l) => sum + l.line_weight_grams, 0)
 
   // ---- Origin ------------------------------------------------------------
+  // 🔴 REFUSE rather than read everything. `filters: { id: undefined }` is not
+  // "no location", it is NO FILTER — every stock location on the platform, from
+  // every tenant. That is how one dangling publishable key took every
+  // storefront down (#1397), and it is how the public quote page ended up
+  // offering a buyer another partner's "In Person Pickup" while omitting the
+  // store's own domestic option.
+  //
+  // A missing origin cannot produce a right answer, so it must not produce a
+  // confident wrong one. The caller is the only thing that knows which store
+  // this is; if it did not say, that is the bug, and it should be loud.
+  if (!input.store?.default_location_id) {
+    throw new MedusaError(
+      MedusaError.Types.INVALID_DATA,
+      "No pickup location was given for this store, so freight cannot be quoted. (Refusing to read every location on the platform.)"
+    )
+  }
+
   const { data: locations } = await query.graph({
     entity: "stock_locations",
     fields: ["id", "name", "address.postal_code", "address.country_code"],

--- a/apps/backend/src/modules/partner-quote/__tests__/build-quote-view.unit.spec.ts
+++ b/apps/backend/src/modules/partner-quote/__tests__/build-quote-view.unit.spec.ts
@@ -341,6 +341,44 @@ describe("buildQuoteView — the free-shipping row that quoted every bulk consig
   })
 })
 
+describe("buildQuoteView — the missing pickup location that read every tenant", () => {
+  /**
+   * Found on the SECOND live prod mint. The public `/store/b2b/quotes/:token`
+   * route passed `store: { id }` and no `default_location_id`, and
+   * `filters: { id: undefined }` is NOT "no location" — it is NO FILTER.
+   *
+   * The buyer's page therefore collected manual shipping options from EVERY
+   * stock location on the platform. A Mumbai consignment was offered another
+   * partner's "European Shipping", "Private" and "In Person Pickup", while this
+   * store's own domestic option was missing — so the page's freight disagreed
+   * with the freight the mint had frozen minutes earlier.
+   *
+   * A cross-tenant read on a public, unauthenticated route: the #1397 shape.
+   * A missing origin cannot produce a right answer, so it must not produce a
+   * confident wrong one.
+   */
+  it("refuses to price at all when no pickup location was given", async () => {
+    const captured: Captured = { contexts: [], rateWeights: [] }
+    const view = await buildQuoteView(
+      scopeWith(captured) as any,
+      baseInput({ store: { id: "store_1" } })
+    )
+
+    // No live half, and it says why — rather than a landed total built from
+    // somebody else's shipping options.
+    expect(view.live).toBeNull()
+    expect(view.live_error).toMatch(/pickup location/i)
+    expect(view.live_error).toMatch(/every location on the platform/i)
+  })
+
+  it("still prices normally once the location is given", async () => {
+    const captured: Captured = { contexts: [], rateWeights: [] }
+    const view = await buildQuoteView(scopeWith(captured) as any, baseInput())
+
+    expect(view.live).not.toBeNull()
+  })
+})
+
 describe("buildQuoteView — lifecycle", () => {
   it("never re-prices a revoked link", async () => {
     const captured: Captured = { contexts: [], rateWeights: [] }


### PR DESCRIPTION
Found on the **second live prod mint**, by comparing the buyer page against the numbers the mint had frozen minutes earlier. They disagreed — which the whole module is designed to make impossible.

## What happened

The public `/store/b2b/quotes/:token` route passed `store: { id }` and **no `default_location_id`**. `buildShippingEstimate` filters its location reads on that field, and:

🔴 **`filters: { id: undefined }` is not "no location" — it is NO FILTER.**

So the buyer's page collected manual shipping options from **every stock location on the platform**. Observed live on quote `01M0J4HQ1GVAM9F3P7KZ6X2CQX`:

| what the page offered | whose it is |
|---|---|
| European Shipping — ₹200 | another tenant |
| Private — ₹100 | another tenant |
| In Person Pickup — ₹100 | another tenant, **for a Mumbai delivery** |
| ~~Domestic Shipping · 68M3HY2V — ₹99~~ | **this store's own — missing** |

The page quoted **₹100** against the **₹99** the mint had frozen. A cross-tenant read, reachable from a public, unauthenticated route — the #1397 shape.

## Two independent problems, two fixes

**1. `buildShippingEstimate` refuses a missing pickup location** instead of reading every location on the platform. A missing origin cannot produce a right answer, so it must not produce a confident wrong one. The lesson from #1397 is precisely this: **a missing id must never degrade into "all rows"**.

**2. The route resolves `default_location_id`** and passes it — as a filtered read by id, never a bare list.

## Blast radius

Every call site was grepped, not assumed. The only other caller, `/store/shipping-estimate`, resolves its store with `fields: ["*"]` and so carried the location all along — unaffected. Confirmed by probing it live: it returned the store's own ₹99 option and nothing else, which is what made the discrepancy visible in the first place.

## Tests

Two, and the first was **confirmed to fail with the guard removed**:

- with no location, the view has **no live half** and says why — rather than a landed total built from somebody else's shipping options
- with a location it prices normally, so the guard cannot over-correct into refusing valid quotes

```
cd apps/backend && npx jest --testPathPattern="shipping-estimate|partner-quote" --testPathIgnorePatterns="integration-tests"
```

`pnpm check:prod-build` green.

## Note on the live quote

`01M0J4HQ1GVAM9F3P7KZ6X2CQX`'s **frozen** numbers are correct (₹99) — the mint passes the location properly. Only the page's live half was wrong, and it corrects itself on deploy. No data repair needed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)