### PR TITLE
fix(shipping): an INR carrier rate could be added straight into a EUR total

### DIFF
--- a/apps/backend/src/lib/shipping-estimate.ts
+++ b/apps/backend/src/lib/shipping-estimate.ts
@@ -347,14 +347,20 @@ export async function buildShippingEstimate(
   const weightBucket = weightBucketGrams(totalWeightGrams)
   const cacheKey = `shipping-estimate:${carrier}:${originPostalCode}:${destinationPostalCode}:${countryCode}:${weightBucket}`
 
-  let calculated: ShippingEstimateOption[] = []
+  // 🔑 Carrier rates do NOT depend on the quote currency — the carrier answers
+  // in its own — so the cache holds them UNFILTERED and the currency guard is
+  // applied on both the hit and the miss path. Caching the filtered list under
+  // a key with no currency in it would serve an INR quote's survivors to a EUR
+  // one, which is the bug the guard exists to prevent, reintroduced through the
+  // cache.
+  let rawCalculated: ShippingEstimateOption[] = []
   let calculatedError: string | null = null
   let cacheHit = false
 
   const cacheService: any = scope.resolve(Modules.CACHE)
   const cached = await cacheService.get(cacheKey).catch(() => null)
   if (cached) {
-    calculated = cached as ShippingEstimateOption[]
+    rawCalculated = cached as ShippingEstimateOption[]
     cacheHit = true
   } else {
     try {
@@ -371,16 +377,17 @@ export async function buildShippingEstimate(
         destination_country: countryCode,
         weight_grams: weightBucket,
       })
-      calculated = (rates || []).map((r: any) => ({
-        courier_id: r.courier_id ?? null,
-        courier_name: r.courier_name ?? null,
-        amount: Number(r.amount),
-        currency_code: String(r.currency_code || "inr").toLowerCase(),
-        estimated_days: r.estimated_days ?? null,
-        is_recommended: !!r.is_recommended,
-        source: "calculated",
-      }))
-      await cacheService.set(cacheKey, calculated, 900).catch(() => {})
+      rawCalculated = (rates || [])
+        .map((r: any) => ({
+          courier_id: r.courier_id ?? null,
+          courier_name: r.courier_name ?? null,
+          amount: Number(r.amount),
+          currency_code: String(r.currency_code || "inr").toLowerCase(),
+          estimated_days: r.estimated_days ?? null,
+          is_recommended: !!r.is_recommended,
+          source: "calculated" as const,
+        }))
+      await cacheService.set(cacheKey, rawCalculated, 900).catch(() => {})
     } catch (err) {
       // A carrier that will not quote must not blank the whole estimate — the
       // manual options are still a real, quotable answer.
@@ -390,6 +397,35 @@ export async function buildShippingEstimate(
       )
     }
   }
+
+  /**
+   * 🔴 #1424's currency guard, which only ever covered the MANUAL branch.
+   *
+   * Carriers quote in their OWN currency — an Indian carrier answers in INR
+   * whatever the buyer is being billed in. `pickFreightOption` sorts on the raw
+   * `amount` and `composeQuoteMoney` adds it straight to the subtotal, so an
+   * INR rate on a EUR quote is not merely irrelevant: it silently WINS whenever
+   * its number is smaller, and is then added to a EUR total and rendered with a
+   * € sign.
+   *
+   * Seen on the first live international quote (Srinagar → Berlin, 3 kg, EUR):
+   * Shiprocket answered ₹3,788 / ₹5,232.50 / ₹14,436 alongside a €35 flat.
+   * €35 won ONLY because 35 is the smallest number — take the flat option away
+   * and the buyer's landed total becomes €4,718 + 3,788 = €8,506.
+   *
+   * Dropped rather than converted: converting needs an FX rate this function
+   * does not have, and a wrong rate is a wrong price wearing a confident label.
+   * Cross-border live rates in the buyer's own currency are a real gap, but a
+   * gap is recoverable and a mispriced consignment is not.
+   */
+  const calculated = rawCalculated.filter((r) => {
+    if (!quoteCurrency) return true
+    if (r.currency_code === quoteCurrency) return true
+    logger?.warn?.(
+      `[shipping-estimate] dropped ${carrier} rate ${r.amount} ${r.currency_code} — quote is in ${quoteCurrency}, and mixing currencies would corrupt the landed total`
+    )
+    return false
+  })
 
   return {
     lines,

--- a/apps/backend/src/modules/partner-quote/__tests__/build-quote-view.unit.spec.ts
+++ b/apps/backend/src/modules/partner-quote/__tests__/build-quote-view.unit.spec.ts
@@ -379,6 +379,63 @@ describe("buildQuoteView — the missing pickup location that read every tenant"
   })
 })
 
+describe("buildQuoteView — an INR carrier rate on a EUR quote", () => {
+  /**
+   * Found on the FIRST live international quote: Srinagar → Berlin, 3 kg, EUR.
+   *
+   * Carriers answer in their OWN currency. Shiprocket returned ₹3,788 /
+   * ₹5,232.50 / ₹14,436 alongside a €35 manual flat, and €35 won ONLY because
+   * 35 is the smallest raw number. Take the flat away and `composeQuoteMoney`
+   * adds 3788 straight onto a EUR subtotal: €4,718 becomes €8,506, rendered
+   * with a € sign.
+   *
+   * #1424 put this guard on the MANUAL branch and stopped there. The stub here
+   * quotes in INR, so an EUR quote must see no calculated option at all.
+   */
+  const EUR_FLAT = {
+    id: "so_intl",
+    name: "International Shipping",
+    price_type: "flat",
+    prices: [{ amount: 35, currency_code: "eur", price_rules: [] }],
+  }
+
+  it("never lets an INR carrier rate into a EUR total", async () => {
+    const captured: Captured = { contexts: [], rateWeights: [] }
+    const view = await buildQuoteView(
+      scopeWith(captured, { manual: [EUR_FLAT] }) as any,
+      baseInput({ currency_code: "eur", lines: [{ variant_id: "var_a", quantity: 29 }] })
+    )
+
+    // The INR stub rates (3900 / 4200) are cheaper as raw numbers than nothing,
+    // and 3900 would have been ADDED to a EUR subtotal.
+    expect(view.freight.options.every((o) => o.currency_code === "eur")).toBe(true)
+    expect(view.freight.chosen?.amount).toBe(35)
+    expect(view.freight.chosen?.currency_code).toBe("eur")
+  })
+
+  it("has no live half at all when only foreign-currency rates exist", async () => {
+    const captured: Captured = { contexts: [], rateWeights: [] }
+    const view = await buildQuoteView(
+      scopeWith(captured) as any,
+      baseInput({ currency_code: "eur" })
+    )
+
+    // No EUR option on the lane. Refusing is the point — a landed total built
+    // from an INR number would look perfectly ordinary.
+    expect(view.live).toBeNull()
+    expect(view.live_error).toMatch(/freight/i)
+  })
+
+  it("still keeps INR rates on an INR quote", async () => {
+    const captured: Captured = { contexts: [], rateWeights: [] }
+    const view = await buildQuoteView(scopeWith(captured) as any, baseInput())
+
+    // The guard must not over-correct into dropping the domestic case.
+    expect(view.freight.chosen?.amount).toBe(3900)
+    expect(view.freight.chosen?.currency_code).toBe("inr")
+  })
+})
+
 describe("buildQuoteView — lifecycle", () => {
   it("never re-prices a revoked link", async () => {
     const captured: Captured = { contexts: [], rateWeights: [] }


### PR DESCRIPTION
Found on the **first live international quote** — Srinagar → Berlin, 3 kg, EUR.

#1424 taught the freight picker that a manual option in another currency *"is not a cheaper answer, it is a different question"*, and put a currency guard on the **manual** branch. The **calculated** branch never got one.

Carriers answer in their own currency: an Indian carrier quotes INR whatever the buyer is being billed in. `pickFreightOption` sorts on the raw `amount` and `composeQuoteMoney` adds the winner straight onto the subtotal — so an INR rate on a EUR quote isn't merely irrelevant, it **wins whenever its number happens to be smaller**, and is then rendered with a euro sign.

## The live quote survived on luck

```
manual:      International Shipping · 68M3HY2V   €35
calculated:  SRX Priority Pro                    ₹3,788
             SRX Express                         ₹5,232.50
             SRX Premium Pro                     ₹14,436
```

€35 won **because 35 is the smallest number.** Remove the flat option and that buyer's landed total becomes **€4,718 + 3,788 = €8,506**.

## Dropped, not converted

Converting needs an FX rate this function does not have, and a wrong rate is a wrong price wearing a confident label. Cross-border live rates in the buyer's own currency are a real gap — and now a **visible** one: every drop is logged with the amount, its currency, and the quote's. A gap is recoverable; a mispriced consignment is not.

## ⚠️ The cache had to be restructured

`cacheKey` carries no currency, so caching the **filtered** list would serve one currency's survivors to another request — the same bug, reintroduced through the cache. Carrier rates don't depend on the quote currency, so the cache now holds them **unfiltered** and the guard runs on both the hit and the miss path.

I introduced that in my first cut of this fix and caught it before pushing; calling it out so a reviewer checks the ordering rather than only the filter.

## Tests

Three. Two were **confirmed to fail with the guard removed**; the third is the over-correction guard.

- an INR carrier rate never enters a EUR total, and the €35 flat is chosen
- when *only* foreign-currency rates exist there is **no live half at all** — refusing is the point, since a landed total built from an INR number looks perfectly ordinary
- an INR rate on an INR quote still wins, so domestic is untouched

```
cd apps/backend && npx jest --testPathPattern="shipping-estimate|partner-quote" --testPathIgnorePatterns="integration-tests"
```

`pnpm check:prod-build` green.

## Note on the live quotes

`01M0J4YGMYH4YCWPAMD8K422QV` (the Berlin one) froze **€35**, which is correct and unchanged by this fix. No data repair needed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)