### PR TITLE
fix(storefront): store product-categories children not expanding in footer

### DIFF
--- a/apps/backend/src/api/middlewares.ts
+++ b/apps/backend/src/api/middlewares.ts
@@ -963,7 +963,7 @@ export default defineMiddlewares({
             defaults: [
               "id", "name", "description", "handle", "rank",
               "parent_category_id", "created_at", "updated_at", "metadata",
-              "*parent_category", "*category_children",
+              "parent_category.*", "category_children.*",
             ],
             defaultLimit: 50,
             isList: true,

--- a/apps/backend/src/api/store/product-categories/route.ts
+++ b/apps/backend/src/api/store/product-categories/route.ts
@@ -44,7 +44,7 @@ export const GET = async (req: MedusaStoreRequest, res: MedusaResponse) => {
       fields: (req as any).queryConfig?.fields || [
         "id", "name", "description", "handle", "rank",
         "parent_category_id", "created_at", "updated_at", "metadata",
-        "*parent_category", "*category_children",
+        "parent_category.*", "category_children.*",
       ],
       filters,
       pagination: (req as any).queryConfig?.pagination,


### PR DESCRIPTION
## Problem
Storefront footer at uniquepashmina.com was not showing all categories. The store `/product-categories` endpoint used `*parent_category` / `*category_children` field expansion syntax, which does not correctly expand relation fields — the same bug that was fixed in the partners API in commit `d8cfe2ec8`.

## Fix
Switched to `parent_category.*` / `category_children.*` format in two places:
- `apps/backend/src/api/store/product-categories/route.ts` — the route handler's fallback fields
- `apps/backend/src/api/middlewares.ts` — the query validation middleware defaults

This matches the fix applied to the partners API (`apps/backend/src/api/partners/product-categories/route.ts`).