### PR TITLE
fix(storefront): four Next 16 routes read params without awaiting

### DIFF
--- a/apps/storefront/src/app/[countryCode]/(main)/order/[id]/transfer/[token]/accept/page.tsx
+++ b/apps/storefront/src/app/[countryCode]/(main)/order/[id]/transfer/[token]/accept/page.tsx
@@ -5,9 +5,11 @@ import TransferImage from "@modules/order/components/transfer-image"
 export default async function TransferPage({
   params,
 }: {
-  params: { id: string; token: string }
+  // `params` is a Promise on Next 16 — synchronous access silently yields
+  // `undefined` here, which sent the transfer calls out with no id or token.
+  params: Promise<{ id: string; token: string }>
 }) {
-  const { id, token } = params
+  const { id, token } = await params
 
   const { success, error } = await acceptTransferRequest(id, token)
 

--- a/apps/storefront/src/app/[countryCode]/(main)/order/[id]/transfer/[token]/decline/page.tsx
+++ b/apps/storefront/src/app/[countryCode]/(main)/order/[id]/transfer/[token]/decline/page.tsx
@@ -5,9 +5,11 @@ import TransferImage from "@modules/order/components/transfer-image"
 export default async function TransferPage({
   params,
 }: {
-  params: { id: string; token: string }
+  // `params` is a Promise on Next 16 — synchronous access silently yields
+  // `undefined` here, which sent the transfer calls out with no id or token.
+  params: Promise<{ id: string; token: string }>
 }) {
-  const { id, token } = params
+  const { id, token } = await params
 
   const { success, error } = await declineTransferRequest(id, token)
 

--- a/apps/storefront/src/app/[countryCode]/(main)/order/[id]/transfer/[token]/page.tsx
+++ b/apps/storefront/src/app/[countryCode]/(main)/order/[id]/transfer/[token]/page.tsx
@@ -5,9 +5,11 @@ import TransferImage from "@modules/order/components/transfer-image"
 export default async function TransferPage({
   params,
 }: {
-  params: { id: string; token: string }
+  // `params` is a Promise on Next 16 — synchronous access silently yields
+  // `undefined` here, which sent the transfer calls out with no id or token.
+  params: Promise<{ id: string; token: string }>
 }) {
-  const { id, token } = params
+  const { id, token } = await params
 
   return (
     <div className="flex flex-col gap-y-4 items-start w-2/5 mx-auto mt-10 mb-20">

--- a/apps/storefront/src/app/[countryCode]/(main)/quotes/[token]/page.tsx
+++ b/apps/storefront/src/app/[countryCode]/(main)/quotes/[token]/page.tsx
@@ -4,8 +4,18 @@ import { notFound } from "next/navigation"
 import { retrieveQuote } from "@lib/data/quotes"
 import QuoteTemplate from "@modules/quotes/templates"
 
+/**
+ * 🔴 `params` is a PROMISE. Next 15 still allowed synchronous access with a
+ * deprecation warning; Next 16 removed that fallback, so reading `.token` off
+ * the unawaited promise yields `undefined` — and this app is on Next 16 while
+ * `apps/storefront-starter` is on Next 15. This file was ported verbatim
+ * between the two (#1427), which is exactly how the shape regressed: the
+ * fetch went out as `/store/b2b/quotes/undefined`, the backend correctly 404'd
+ * an unknown token, and `retrieveQuote`'s catch-all turned it into a
+ * not-found page. Identical files across two majors is the bug, not the fix.
+ */
 type Props = {
-  params: { countryCode: string; token: string }
+  params: Promise<{ countryCode: string; token: string }>
 }
 
 /**
@@ -29,7 +39,8 @@ export const metadata: Metadata = {
 export const dynamic = "force-dynamic"
 
 export default async function QuotePage({ params }: Props) {
-  const quote = await retrieveQuote(params.token)
+  const { token } = await params
+  const quote = await retrieveQuote(token)
 
   // An unknown token and a revoked one are indistinguishable by design — the
   // backend 404s both so a prober learns nothing, and this preserves that.

--- a/apps/storefront/src/lib/data/quotes.ts
+++ b/apps/storefront/src/lib/data/quotes.ts
@@ -156,7 +156,22 @@ export const retrieveQuote = async (
       }
     )
     return quote ?? null
-  } catch {
+  } catch (e: any) {
+    /**
+     * The buyer-facing behaviour is unchanged: null becomes a 404, and an
+     * unknown token stays indistinguishable from a revoked one.
+     *
+     * 🔑 But the OPERATOR needs the cause. Every failure here — a bad token, an
+     * unreachable backend, a missing publishable key, a 500 in the view builder
+     * — used to collapse into the same silent 404, which made a Next 16 params
+     * regression (#1427: the token arrived as the literal string `undefined`)
+     * indistinguishable from a revoked link. Log the token LENGTH, never the
+     * token: it is the credential.
+     */
+    console.error(
+      `[quotes] retrieveQuote failed: token_len=${token?.length ?? 0} ` +
+        `status=${e?.status ?? "n/a"} message=${e?.message ?? String(e)}`
+    )
     return null
   }
 }


### PR DESCRIPTION
## The bug

`params` is a Promise. Next 15 kept a synchronous-access fallback with a deprecation warning; **Next 16 removed it**. `apps/storefront` is on **16.2.9**, so four routes silently read `undefined`.

| Route | Effect |
|---|---|
| `quotes/[token]` | The buyer quote page 404'd on **every** load |
| `order/[id]/transfer/[token]` + `accept/` + `decline/` | `id` **and** `token` both undefined — the transfer calls have gone out with neither since the Next 16 upgrade |

The quote page fetched `/store/b2b/quotes/undefined`; the backend correctly 404'd an unknown token, and `retrieveQuote`'s catch-all turned that into a not-found page. Found from a Vercel log line, after the same real token was proven to return `200` from the backend **using that tenant's own publishable key** — so cross-tenant serving was never the problem, and neither was the deploy.

The order-transfer routes have been broken the same way and unnoticed, because nobody has exercised that flow.

## Why identical code behaved differently

Every other page in the app already uses `params: Promise<…>` + `await props.params`; these four were the stragglers. The quote page was ported **verbatim** from `apps/storefront-starter` (#1427), which is on Next **15**, where the old shape still worked.

Identical files across two framework majors is the bug, not the fix. The starter's copy is updated in the same shape (Jaal-Yantra-Textiles/nextjs-starter-medusa#17, merged) so both stay identical **and** correct.

## Diagnosability

`retrieveQuote` still returns `null` and still 404s — an unknown token must stay indistinguishable from a revoked one — but it now logs the real cause server-side first. Every failure used to collapse into the same silent 404, which is why this took several rounds to find. Logs the token **length**, never the token.

## Worth a separate look

`apps/storefront/next.config.js` sets `typescript.ignoreBuildErrors: true`, and its `tsconfig.json` includes `.next/types/**/*.ts` — where Next emits its `PageProps` conformance check. The type system was positioned to catch exactly this defect, and the build is configured to discard it. Filed separately.

## Verify

Load a real quote token on cicilabel and confirm it renders. ⚠️ `apps/storefront` is a Vercel app the ECS pipeline does not deploy — it needs its own redeploy; verify by loading the page, not by a green badge.

🤖 Generated with [Claude Code](https://claude.com/claude-code)