### PR TITLE
fix(content): trigger storefront revalidation on block/page edits + TipTap UI dialogs

### DIFF
--- a/apps/backend/src/api/partners/storefront/pages/[pageId]/blocks/[blockId]/route.ts
+++ b/apps/backend/src/api/partners/storefront/pages/[pageId]/blocks/[blockId]/route.ts
@@ -2,7 +2,10 @@ import {
   AuthenticatedMedusaRequest,
   MedusaResponse,
 } from "@medusajs/framework/http"
-import { validatePartnerBlockOwnership } from "../../../../helpers"
+import {
+  validatePartnerBlockOwnership,
+  triggerStorefrontRevalidate,
+} from "../../../../helpers"
 import { updateBlockWorkflow } from "../../../../../../../workflows/website/page-blocks/update-block"
 import { deleteBlockWorkflow } from "../../../../../../../workflows/website/page-blocks/delete-block"
 
@@ -32,7 +35,7 @@ export const PUT = async (
   req: AuthenticatedMedusaRequest,
   res: MedusaResponse
 ) => {
-  await validatePartnerBlockOwnership(
+  const { website } = await validatePartnerBlockOwnership(
     req.auth_context,
     req.params.pageId,
     req.params.blockId,
@@ -47,7 +50,11 @@ export const PUT = async (
     },
   })
 
-  res.json({ block: result })
+  const revalidation = await triggerStorefrontRevalidate(website, {
+    paths: ["/"],
+  })
+
+  res.json({ block: result, revalidation })
 }
 
 /**
@@ -58,7 +65,7 @@ export const DELETE = async (
   req: AuthenticatedMedusaRequest,
   res: MedusaResponse
 ) => {
-  await validatePartnerBlockOwnership(
+  const { website } = await validatePartnerBlockOwnership(
     req.auth_context,
     req.params.pageId,
     req.params.blockId,
@@ -68,6 +75,8 @@ export const DELETE = async (
   const { result } = await deleteBlockWorkflow(req.scope).run({
     input: { block_id: req.params.blockId },
   })
+
+  await triggerStorefrontRevalidate(website, { paths: ["/"] })
 
   res.json(result)
 }

--- a/apps/backend/src/api/partners/storefront/pages/[pageId]/blocks/route.ts
+++ b/apps/backend/src/api/partners/storefront/pages/[pageId]/blocks/route.ts
@@ -2,7 +2,10 @@ import {
   AuthenticatedMedusaRequest,
   MedusaResponse,
 } from "@medusajs/framework/http"
-import { validatePartnerPageOwnership } from "../../../helpers"
+import {
+  validatePartnerPageOwnership,
+  triggerStorefrontRevalidate,
+} from "../../../helpers"
 import { createBlockWorkflow } from "../../../../../../workflows/website/page-blocks/create-block"
 import { createBatchBlocksWorkflow } from "../../../../../../workflows/website/page-blocks/create-batch-blocks"
 import { listBlocksWorkflow } from "../../../../../../workflows/website/page-blocks/list-blocks"
@@ -41,7 +44,7 @@ export const POST = async (
   req: AuthenticatedMedusaRequest,
   res: MedusaResponse
 ) => {
-  await validatePartnerPageOwnership(
+  const { website } = await validatePartnerPageOwnership(
     req.auth_context,
     req.params.pageId,
     req.scope
@@ -67,6 +70,7 @@ export const POST = async (
           errors: result.errors,
         })
       }
+      await triggerStorefrontRevalidate(website, { paths: ["/"] })
       return res.status(207).json({
         message: "Some blocks created, some failed",
         blocks: result.created,
@@ -74,6 +78,7 @@ export const POST = async (
       })
     }
 
+    await triggerStorefrontRevalidate(website, { paths: ["/"] })
     return res.status(201).json({
       message: "All blocks created successfully",
       blocks: result.created,
@@ -87,6 +92,8 @@ export const POST = async (
       page_id: pageId,
     },
   })
+
+  await triggerStorefrontRevalidate(website, { paths: ["/"] })
 
   res.status(201).json({ block: result })
 }

--- a/apps/backend/src/api/partners/storefront/pages/[pageId]/route.ts
+++ b/apps/backend/src/api/partners/storefront/pages/[pageId]/route.ts
@@ -2,7 +2,10 @@ import {
   AuthenticatedMedusaRequest,
   MedusaResponse,
 } from "@medusajs/framework/http"
-import { validatePartnerPageOwnership } from "../../helpers"
+import {
+  validatePartnerPageOwnership,
+  triggerStorefrontRevalidate,
+} from "../../helpers"
 import { updatePageWorkflow } from "../../../../../workflows/website/website-page/update-page"
 import { deletePageWorkflow } from "../../../../../workflows/website/website-page/delete-page"
 
@@ -45,7 +48,11 @@ export const PUT = async (
     },
   })
 
-  res.json({ page: result })
+  const revalidation = await triggerStorefrontRevalidate(website, {
+    paths: ["/"],
+  })
+
+  res.json({ page: result, revalidation })
 }
 
 /**
@@ -56,7 +63,7 @@ export const DELETE = async (
   req: AuthenticatedMedusaRequest,
   res: MedusaResponse
 ) => {
-  await validatePartnerPageOwnership(
+  const { website } = await validatePartnerPageOwnership(
     req.auth_context,
     req.params.pageId,
     req.scope
@@ -65,6 +72,8 @@ export const DELETE = async (
   const { result } = await deletePageWorkflow(req.scope).run({
     input: { id: req.params.pageId },
   })
+
+  await triggerStorefrontRevalidate(website, { paths: ["/"] })
 
   res.json(result)
 }

--- a/apps/backend/src/api/partners/storefront/pages/route.ts
+++ b/apps/backend/src/api/partners/storefront/pages/route.ts
@@ -2,7 +2,7 @@ import {
   AuthenticatedMedusaRequest,
   MedusaResponse,
 } from "@medusajs/framework/http"
-import { getPartnerWebsite } from "../helpers"
+import { getPartnerWebsite, triggerStorefrontRevalidate } from "../helpers"
 import { createPageWorkflow } from "../../../../workflows/website/website-page/create-page"
 import { listPageWorkflow } from "../../../../workflows/website/website-page/list-page"
 
@@ -63,6 +63,8 @@ export const POST = async (
       genMetaDataLLM: (req.validatedBody as any).genMetaDataLLM || false,
     },
   })
+
+  await triggerStorefrontRevalidate(website, { paths: ["/"] })
 
   res.status(201).json({ page: result })
 }

--- a/apps/partner-ui/src/components/tiptap-editor/tiptap-editor.tsx
+++ b/apps/partner-ui/src/components/tiptap-editor/tiptap-editor.tsx
@@ -5,8 +5,8 @@ import TextAlign from "@tiptap/extension-text-align"
 import Link from "@tiptap/extension-link"
 import Image from "@tiptap/extension-image"
 import Placeholder from "@tiptap/extension-placeholder"
-import { useCallback } from "react"
-import { Button } from "@medusajs/ui"
+import { useCallback, useState } from "react"
+import { Button, Dialog, Input, Label, Checkbox } from "@medusajs/ui"
 
 type TipTapEditorProps = {
   content?: Record<string, unknown>
@@ -44,24 +44,68 @@ export const TipTapEditor = ({
     },
   })
 
-  const addImage = useCallback(() => {
-    const url = window.prompt("Image URL")
-    if (url && editor) {
-      editor.chain().focus().setImage({ src: url }).run()
+  const [linkOpen, setLinkOpen] = useState(false)
+  const [linkUrl, setLinkUrl] = useState("")
+  const [linkOpenNewTab, setLinkOpenNewTab] = useState(false)
+
+  const [imageOpen, setImageOpen] = useState(false)
+  const [imageUrl, setImageUrl] = useState("")
+
+  const sanitizeUrl = useCallback((url: string): string => {
+    const trimmed = url.trim()
+    if (!trimmed) return ""
+    try {
+      const parsed = new URL(trimmed)
+      if (parsed.protocol === "http:" || parsed.protocol === "https:") {
+        return parsed.toString()
+      }
+    } catch {
+      return ""
     }
-  }, [editor])
+    return ""
+  }, [])
 
   const setLink = useCallback(() => {
     if (!editor) return
-    const previousUrl = editor.getAttributes("link").href
-    const url = window.prompt("URL", previousUrl)
-    if (url === null) return
-    if (url === "") {
+    const previousUrl = editor.getAttributes("link").href || ""
+    const isOpen = editor.getAttributes("link").target === "_blank"
+    setLinkUrl(previousUrl)
+    setLinkOpenNewTab(isOpen)
+    setLinkOpen(true)
+  }, [editor])
+
+  const confirmSetLink = useCallback(() => {
+    if (!editor) return
+    const url = sanitizeUrl(linkUrl)
+    setLinkOpen(false)
+    if (!url) {
       editor.chain().focus().extendMarkRange("link").unsetLink().run()
       return
     }
-    editor.chain().focus().extendMarkRange("link").setLink({ href: url }).run()
+    editor
+      .chain()
+      .focus()
+      .extendMarkRange("link")
+      .setLink({
+        href: url,
+        target: linkOpenNewTab ? "_blank" : null,
+      })
+      .run()
+  }, [editor, linkUrl, linkOpenNewTab, sanitizeUrl])
+
+  const addImage = useCallback(() => {
+    if (!editor) return
+    setImageUrl("")
+    setImageOpen(true)
   }, [editor])
+
+  const confirmAddImage = useCallback(() => {
+    const url = sanitizeUrl(imageUrl)
+    setImageOpen(false)
+    if (url && editor) {
+      editor.chain().focus().setImage({ src: url }).run()
+    }
+  }, [editor, imageUrl, sanitizeUrl])
 
   if (!editor) return null
 
@@ -88,79 +132,156 @@ export const TipTapEditor = ({
   )
 
   return (
-    <div className="rounded-md border border-ui-border-base overflow-hidden">
-      <div className="flex flex-wrap gap-1 p-2 border-b border-ui-border-base bg-ui-bg-subtle">
-        <ToolbarButton
-          label="H1"
-          onClick={() => editor.chain().focus().toggleHeading({ level: 1 }).run()}
-          isActive={editor.isActive("heading", { level: 1 })}
-        />
-        <ToolbarButton
-          label="H2"
-          onClick={() => editor.chain().focus().toggleHeading({ level: 2 }).run()}
-          isActive={editor.isActive("heading", { level: 2 })}
-        />
-        <ToolbarButton
-          label="H3"
-          onClick={() => editor.chain().focus().toggleHeading({ level: 3 }).run()}
-          isActive={editor.isActive("heading", { level: 3 })}
-        />
-        <ToolbarButton
-          label="B"
-          onClick={() => editor.chain().focus().toggleBold().run()}
-          isActive={editor.isActive("bold")}
-        />
-        <ToolbarButton
-          label="I"
-          onClick={() => editor.chain().focus().toggleItalic().run()}
-          isActive={editor.isActive("italic")}
-        />
-        <ToolbarButton
-          label="U"
-          onClick={() => editor.chain().focus().toggleUnderline().run()}
-          isActive={editor.isActive("underline")}
-        />
-        <ToolbarButton
-          label="UL"
-          onClick={() => editor.chain().focus().toggleBulletList().run()}
-          isActive={editor.isActive("bulletList")}
-        />
-        <ToolbarButton
-          label="OL"
-          onClick={() => editor.chain().focus().toggleOrderedList().run()}
-          isActive={editor.isActive("orderedList")}
-        />
-        <ToolbarButton
-          label="Quote"
-          onClick={() => editor.chain().focus().toggleBlockquote().run()}
-          isActive={editor.isActive("blockquote")}
-        />
-        <ToolbarButton
-          label="Code"
-          onClick={() => editor.chain().focus().toggleCodeBlock().run()}
-          isActive={editor.isActive("codeBlock")}
-        />
-        <ToolbarButton label="Link" onClick={setLink} isActive={editor.isActive("link")} />
-        <ToolbarButton label="Image" onClick={addImage} />
-        <ToolbarButton
-          label="Left"
-          onClick={() => editor.chain().focus().setTextAlign("left").run()}
-          isActive={editor.isActive({ textAlign: "left" })}
-        />
-        <ToolbarButton
-          label="Center"
-          onClick={() => editor.chain().focus().setTextAlign("center").run()}
-          isActive={editor.isActive({ textAlign: "center" })}
-        />
-        <ToolbarButton
-          label="Right"
-          onClick={() => editor.chain().focus().setTextAlign("right").run()}
-          isActive={editor.isActive({ textAlign: "right" })}
-        />
+    <>
+      <div className="rounded-md border border-ui-border-base overflow-hidden">
+        <div className="flex flex-wrap gap-1 p-2 border-b border-ui-border-base bg-ui-bg-subtle">
+          <ToolbarButton
+            label="H1"
+            onClick={() => editor.chain().focus().toggleHeading({ level: 1 }).run()}
+            isActive={editor.isActive("heading", { level: 1 })}
+          />
+          <ToolbarButton
+            label="H2"
+            onClick={() => editor.chain().focus().toggleHeading({ level: 2 }).run()}
+            isActive={editor.isActive("heading", { level: 2 })}
+          />
+          <ToolbarButton
+            label="H3"
+            onClick={() => editor.chain().focus().toggleHeading({ level: 3 }).run()}
+            isActive={editor.isActive("heading", { level: 3 })}
+          />
+          <ToolbarButton
+            label="B"
+            onClick={() => editor.chain().focus().toggleBold().run()}
+            isActive={editor.isActive("bold")}
+          />
+          <ToolbarButton
+            label="I"
+            onClick={() => editor.chain().focus().toggleItalic().run()}
+            isActive={editor.isActive("italic")}
+          />
+          <ToolbarButton
+            label="U"
+            onClick={() => editor.chain().focus().toggleUnderline().run()}
+            isActive={editor.isActive("underline")}
+          />
+          <ToolbarButton
+            label="UL"
+            onClick={() => editor.chain().focus().toggleBulletList().run()}
+            isActive={editor.isActive("bulletList")}
+          />
+          <ToolbarButton
+            label="OL"
+            onClick={() => editor.chain().focus().toggleOrderedList().run()}
+            isActive={editor.isActive("orderedList")}
+          />
+          <ToolbarButton
+            label="Quote"
+            onClick={() => editor.chain().focus().toggleBlockquote().run()}
+            isActive={editor.isActive("blockquote")}
+          />
+          <ToolbarButton
+            label="Code"
+            onClick={() => editor.chain().focus().toggleCodeBlock().run()}
+            isActive={editor.isActive("codeBlock")}
+          />
+          <ToolbarButton label="Link" onClick={setLink} isActive={editor.isActive("link")} />
+          <ToolbarButton label="Image" onClick={addImage} />
+          <ToolbarButton
+            label="Left"
+            onClick={() => editor.chain().focus().setTextAlign("left").run()}
+            isActive={editor.isActive({ textAlign: "left" })}
+          />
+          <ToolbarButton
+            label="Center"
+            onClick={() => editor.chain().focus().setTextAlign("center").run()}
+            isActive={editor.isActive({ textAlign: "center" })}
+          />
+          <ToolbarButton
+            label="Right"
+            onClick={() => editor.chain().focus().setTextAlign("right").run()}
+            isActive={editor.isActive({ textAlign: "right" })}
+          />
+        </div>
+        <div className="tiptap-content-wrapper min-h-[200px] max-h-[400px] overflow-y-auto bg-white">
+          <EditorContent editor={editor} />
+        </div>
       </div>
-      <div className="tiptap-content-wrapper min-h-[200px] max-h-[400px] overflow-y-auto bg-white">
-        <EditorContent editor={editor} />
-      </div>
-    </div>
+
+      <Dialog open={linkOpen} onOpenChange={setLinkOpen}>
+        <Dialog.Content>
+          <Dialog.Header>
+            <Dialog.Title>Insert Link</Dialog.Title>
+          </Dialog.Header>
+          <div className="space-y-4 py-4">
+            <div>
+              <Label>URL</Label>
+              <Input
+                value={linkUrl}
+                onChange={(e) => setLinkUrl(e.target.value)}
+                placeholder="https://..."
+                autoFocus
+              />
+            </div>
+            <div className="flex items-center gap-x-2">
+              <Checkbox
+                checked={linkOpenNewTab}
+                onCheckedChange={(v) => setLinkOpenNewTab(v === true)}
+              />
+              <Label className="cursor-pointer" onClick={() => setLinkOpenNewTab((p) => !p)}>
+                Open in new tab
+              </Label>
+            </div>
+          </div>
+          <Dialog.Footer>
+            <Button variant="secondary" onClick={() => setLinkOpen(false)}>
+              Cancel
+            </Button>
+            <Button onClick={confirmSetLink}>
+              {linkUrl.trim() ? "Apply" : "Remove link"}
+            </Button>
+          </Dialog.Footer>
+        </Dialog.Content>
+      </Dialog>
+
+      <Dialog open={imageOpen} onOpenChange={setImageOpen}>
+        <Dialog.Content>
+          <Dialog.Header>
+            <Dialog.Title>Insert Image</Dialog.Title>
+          </Dialog.Header>
+          <div className="space-y-4 py-4">
+            <div>
+              <Label>Image URL</Label>
+              <Input
+                value={imageUrl}
+                onChange={(e) => setImageUrl(e.target.value)}
+                placeholder="https://..."
+                autoFocus
+              />
+            </div>
+            {(() => {
+              const safe = sanitizeUrl(imageUrl)
+              return safe ? (
+                <div className="rounded-md border border-ui-border-base overflow-hidden max-h-40">
+                  <img
+                    src={safe}
+                    alt="Preview"
+                    className="w-full h-auto object-contain"
+                  />
+                </div>
+              ) : null
+            })()}
+          </div>
+          <Dialog.Footer>
+            <Button variant="secondary" onClick={() => setImageOpen(false)}>
+              Cancel
+            </Button>
+            <Button onClick={confirmAddImage} disabled={!sanitizeUrl(imageUrl)}>
+              Insert
+            </Button>
+          </Dialog.Footer>
+        </Dialog.Content>
+      </Dialog>
+    </>
   )
 }


### PR DESCRIPTION
## Problem
When a partner updates page content in the partner-ui, the changes never appeared on the live storefront — old data persisted indefinitely. The TipTap editor in the partner-ui showed new data from the (uncached) partner API, but the storefront read from the (force-cached) public web API with no invalidation link between them.

**Root cause:**  (the webhook that drops the Next.js data cache) was wired up **only** for theme edits. Block create/update/delete and page create/update/delete all wrote to the DB but never told the storefront to flush its cache.

## Fixes

### 1. Backend — Revalidation on all block/page mutations
Added  to:
- `PUT /partners/storefront/pages/:pageId/blocks/:blockId` (block content edit — the main partner editing flow)
- `DELETE /partners/storefront/pages/:pageId/blocks/:blockId`
- `POST /partners/storefront/pages/:pageId/blocks`
- `PUT /partners/storefront/pages/:pageId` (publish/unpublish/metadata)
- `DELETE /partners/storefront/pages/:pageId`
- `POST /partners/storefront/pages`

The PUT routes return a `revalidation` outcome so the partner-ui can surface whether the edit went live (matching how the theme route already does it).

### 2. Storefront (submodule) — Cache TTL floor
`getWebsitePage` already has `WEBSITE_CACHE_TTL_SECONDS` revalidate floor on the submodule's main branch (matching `getWebsite`), so a failed webhook is self-healing (5min max staleness) instead of permanent.

### 3. Storefront (submodule) — TipTapViewer link + image support
The TipTapViewer already handles `link` marks and `image` nodes on the submodule's main branch, so content created with the TipTap editor's Link and Image toolbar buttons renders correctly on the storefront.

### 4. Partner-UI — Replace window.prompt with Medusa UI Dialogs
Replaced the two `window.prompt` calls in the TipTap editor:
- **Link button** — opens a Medusa UI `Dialog` with URL input + "open in new tab" checkbox
- **Image button** — opens a Medusa UI `Dialog` with URL input + live preview

Both use `@medusajs/ui` primitives (`Dialog`, `Input`, `Label`, `Checkbox`, `Button`) instead of blocking browser dialogs.