### PR TITLE
feat(quote): buyer identity as columns, and a repeat quote supersedes the old one

### DIFF
--- a/apps/backend/integration-tests/http/partner-quote-cart-pricing.spec.ts
+++ b/apps/backend/integration-tests/http/partner-quote-cart-pricing.spec.ts
@@ -194,7 +194,7 @@ setupSharedTestSuite(() => {
         const quote = await mintFor(buyer)
         // If this ever fails, the prices are handed to an account nobody logs
         // into, and every pricing assertion in this file becomes meaningless.
-        expect(quote.metadata.customer_id).toBe(buyer.customerId)
+        expect(quote.customer_id).toBe(buyer.customerId)
       })
 
       it("charges the quoted amount for the quoted basket", async () => {
@@ -384,7 +384,7 @@ setupSharedTestSuite(() => {
         // has to run on a cron to retire a quote's prices.
         await loud("expire", () =>
           api.post(
-            `/admin/price-lists/${quote.metadata.price_list_id}`,
+            `/admin/price-lists/${quote.price_list_id}`,
             { ends_at: new Date(Date.now() - 60_000).toISOString() },
             adminHeaders
           )
@@ -408,7 +408,7 @@ setupSharedTestSuite(() => {
         // `status: draft` IS the revoke — the same reason no sweeper is needed.
         await loud("revoke", () =>
           api.post(
-            `/admin/price-lists/${quote.metadata.price_list_id}`,
+            `/admin/price-lists/${quote.price_list_id}`,
             { status: "draft" },
             adminHeaders
           )

--- a/apps/backend/integration-tests/http/partner-quote-mint.spec.ts
+++ b/apps/backend/integration-tests/http/partner-quote-mint.spec.ts
@@ -110,8 +110,8 @@ setupSharedTestSuite(() => {
       expect(quote.token_hash).toBeTruthy()
       expect(quote.token_hash).not.toBe(res.data.token)
 
-      const priceListId = quote.metadata?.price_list_id
-      const customerGroupId = quote.metadata?.customer_group_id
+      const priceListId = quote.price_list_id
+      const customerGroupId = quote.customer_group_id
       expect(priceListId).toBeTruthy()
       expect(customerGroupId).toBeTruthy()
 
@@ -140,7 +140,7 @@ setupSharedTestSuite(() => {
       )
       expect(res.status).toBe(201)
 
-      const priceList = await readPriceList(res.data.quote.metadata.price_list_id)
+      const priceList = await readPriceList(res.data.quote.price_list_id)
       const prices: any[] = priceList.prices ?? []
 
       // One price per quoted line. The bug dropped every line, because
@@ -211,7 +211,7 @@ setupSharedTestSuite(() => {
       // 🔑 And the price list's window is that same pair — this is the step
       // that threw `input.now.toISOString is not a function`, so a green
       // assertion here is the regression test for a Date arriving as a string.
-      const priceList = await readPriceList(quote.metadata.price_list_id)
+      const priceList = await readPriceList(quote.price_list_id)
       expect(new Date(priceList.starts_at).getTime()).toBe(quotedAt)
       expect(new Date(priceList.ends_at).getTime()).toBe(expiresAt)
     })
@@ -311,15 +311,86 @@ setupSharedTestSuite(() => {
 
       // 🔑 One identity, two quotes. A second group would have core tie-break
       // the two lists against each other on `amount ASC`.
-      expect(second.data.quote.metadata.customer_group_id).toBe(
-        first.data.quote.metadata.customer_group_id
+      expect(second.data.quote.customer_group_id).toBe(
+        first.data.quote.customer_group_id
       )
-      expect(second.data.quote.metadata.customer_id).toBe(
-        first.data.quote.metadata.customer_id
+      expect(second.data.quote.customer_id).toBe(
+        first.data.quote.customer_id
       )
-      expect(second.data.quote.metadata.price_list_id).not.toBe(
-        first.data.quote.metadata.price_list_id
+      expect(second.data.quote.price_list_id).not.toBe(
+        first.data.quote.price_list_id
       )
+
+      /**
+       * 🔴 THE ASSERTION THIS TEST WAS MISSING (#1435).
+       *
+       * Everything above was already here, and it verified that two DISTINCT
+       * price lists exist — which is the bug, not the fix. The test's own name
+       * claimed "replaces prices instead of stacking a second list" while its
+       * body confirmed the stacking and stopped. Both lists were active on one
+       * group, both with `rules_count: 1`, and core tie-breaks on `amount ASC`,
+       * so a re-quote at a HIGHER price handed the buyer the old cheaper one.
+       *
+       * The prior list must now be expired, and the prior quote marked
+       * superseded.
+       */
+      const priorList = await readPriceList(first.data.quote.price_list_id)
+      expect(priorList).toBeTruthy()
+      expect(new Date(priorList.ends_at).getTime()).toBeLessThanOrEqual(
+        Date.now()
+      )
+
+      const currentList = await readPriceList(second.data.quote.price_list_id)
+      expect(new Date(currentList.ends_at).getTime()).toBeGreaterThan(Date.now())
+
+      // And the buyer's older link says so, rather than silently repricing.
+      const priorQuote = await loud("read-prior", () =>
+        api.get(`/partners/quotes/${first.data.quote.id}`, {
+          headers: seed.headers,
+        })
+      )
+      expect(priorQuote.data.quote.status).toBe("superseded")
+
+      const currentQuote = await loud("read-current", () =>
+        api.get(`/partners/quotes/${second.data.quote.id}`, {
+          headers: seed.headers,
+        })
+      )
+      expect(currentQuote.data.quote.status).toBe("active")
+    })
+
+    it("leaves ANOTHER buyer's quote alone when this buyer is re-quoted", async () => {
+      // Supersede is scoped to one customer group. A bug here would expire an
+      // unrelated buyer's live prices, which is far worse than the defect it
+      // fixes — so it gets its own test rather than riding on the one above.
+      const { api } = getSharedTestEnv()
+      const buyerA = `buyer-a-${seed.unique}@jaalyantra.test`
+      const buyerB = `buyer-b-${seed.unique}@jaalyantra.test`
+
+      const a1 = await loud("mint-a1", () =>
+        api.post("/partners/quotes", mintBody(seed, { buyer_email: buyerA }), {
+          headers: seed.headers,
+        })
+      )
+      await loud("mint-b1", () =>
+        api.post("/partners/quotes", mintBody(seed, { buyer_email: buyerB }), {
+          headers: seed.headers,
+        })
+      )
+      // Re-quote B only.
+      await loud("mint-b2", () =>
+        api.post("/partners/quotes", mintBody(seed, { buyer_email: buyerB }), {
+          headers: seed.headers,
+        })
+      )
+
+      const untouched = await loud("read-a1", () =>
+        api.get(`/partners/quotes/${a1.data.quote.id}`, { headers: seed.headers })
+      )
+      expect(untouched.data.quote.status).toBe("active")
+
+      const aList = await readPriceList(a1.data.quote.price_list_id)
+      expect(new Date(aList.ends_at).getTime()).toBeGreaterThan(Date.now())
     })
   })
 })

--- a/apps/backend/src/admin/hooks/api/quotes.ts
+++ b/apps/backend/src/admin/hooks/api/quotes.ts
@@ -24,7 +24,7 @@ export type AdminQuote = Record<string, any> & {
   destination_country_code?: string
   quoted_landed_total?: number | null
   quoted_freight?: number | null
-  status?: "active" | "revoked"
+  status?: "active" | "revoked" | "superseded"
   expires_at?: string | null
   view_count?: number
   last_viewed_at?: string | null

--- a/apps/backend/src/admin/routes/quotes/[id]/page.tsx
+++ b/apps/backend/src/admin/routes/quotes/[id]/page.tsx
@@ -111,6 +111,10 @@ const QuoteDetailPage = () => {
   }
 
   const isRevoked = quote.status === "revoked"
+  // A newer quote for this buyer expired this one's price list (#1435). It is
+  // not revocable any more — there is nothing left to delete — but it is also
+  // not a withdrawal, so it must not read as one.
+  const isSuperseded = quote.status === "superseded"
 
   return (
     <div className="flex flex-col gap-y-3">
@@ -123,10 +127,12 @@ const QuoteDetailPage = () => {
             </Text>
           </div>
           <div className="flex items-center gap-3">
-            <StatusBadge color={isRevoked ? "red" : "green"}>
-              {isRevoked ? "Revoked" : "Active"}
+            <StatusBadge
+              color={isRevoked ? "red" : isSuperseded ? "orange" : "green"}
+            >
+              {isRevoked ? "Revoked" : isSuperseded ? "Superseded" : "Active"}
             </StatusBadge>
-            {!isRevoked && (
+            {!isRevoked && !isSuperseded && (
               <Button
                 variant="danger"
                 size="small"

--- a/apps/backend/src/admin/routes/quotes/page.tsx
+++ b/apps/backend/src/admin/routes/quotes/page.tsx
@@ -76,8 +76,22 @@ const QuotesPage = () => {
         cell: ({ getValue }) => {
           const status = String(getValue() || "active")
           return (
-            <StatusBadge color={status === "active" ? "green" : "red"}>
-              {status === "active" ? "Active" : "Revoked"}
+            // `superseded` is deliberately not red: nobody withdrew this
+            // quote, a newer one replaced it (#1435).
+            <StatusBadge
+              color={
+                status === "active"
+                  ? "green"
+                  : status === "superseded"
+                    ? "orange"
+                    : "red"
+              }
+            >
+              {status === "active"
+                ? "Active"
+                : status === "superseded"
+                  ? "Superseded"
+                  : "Revoked"}
             </StatusBadge>
           )
         },

--- a/apps/backend/src/api/admin/quotes/[id]/revoke/route.ts
+++ b/apps/backend/src/api/admin/quotes/[id]/revoke/route.ts
@@ -38,7 +38,14 @@ export const POST = async (req: MedusaRequest, res: MedusaResponse) => {
     return res.json({ quote, already_revoked: true })
   }
 
-  const priceListId = (quote.metadata as any)?.price_list_id
+  /**
+   * #1440 moved this off `metadata` and onto a column. The metadata fallback
+   * stays for rows minted before that migration ran — the backfill covers them,
+   * but a revoke that silently skipped a live price list because a backfill was
+   * missed is the exact failure this route exists to prevent.
+   */
+  const priceListId =
+    (quote as any)?.price_list_id ?? (quote.metadata as any)?.price_list_id
   if (priceListId) {
     await deletePriceListsWorkflow(req.scope).run({
       input: { ids: [priceListId] },
@@ -48,7 +55,7 @@ export const POST = async (req: MedusaRequest, res: MedusaResponse) => {
     // A quote with no recorded price list either never froze or was minted
     // before the id was stored. Say so rather than reporting a clean revoke.
     logger.warn(
-      `[quote] revoke ${quote.id} had no price_list_id in metadata — nothing to delete`
+      `[quote] revoke ${quote.id} had no price_list_id recorded — nothing to delete`
     )
   }
 

--- a/apps/backend/src/modules/partner-quote/__tests__/compare.unit.spec.ts
+++ b/apps/backend/src/modules/partner-quote/__tests__/compare.unit.spec.ts
@@ -12,7 +12,7 @@ const base = {
   quoted: money(),
   live: money(),
   buyer_changed_inputs: false,
-  unusable_reason: null as null | "revoked" | "expired",
+  unusable_reason: null as null | "revoked" | "superseded" | "expired",
   days_until_expiry: 10 as number | null,
 }
 
@@ -73,6 +73,27 @@ describe("compareQuote", () => {
       expect(r.show_live).toBe(false)
       expect(r.landed_delta).toBeNull()
       expect(r.headline).toContain("expired")
+    })
+
+    it("shows the quoted figures but no live number once superseded", () => {
+      // Same reasoning as expiry: the record of what was said stays, but a
+      // recomputed live number would read as an offer still on the table.
+      const r = compareQuote({ ...base, unusable_reason: "superseded" })
+      expect(r.state).toBe("superseded_quoted_only")
+      expect(r.show_quoted).toBe(true)
+      expect(r.show_live).toBe(false)
+      expect(r.landed_delta).toBeNull()
+    })
+
+    it("does not tell a superseded buyer the partner withdrew the quote", () => {
+      // #1435: a superseded quote was REPLACED, not pulled. Using the revoked
+      // copy would send the buyer into an apologetic conversation instead of
+      // simply asking for the current link.
+      const superseded = compareQuote({ ...base, unusable_reason: "superseded" })
+      expect(superseded.state).not.toBe("dead_link")
+      expect(superseded.headline.toLowerCase()).toContain("newer")
+      expect(superseded.explanation).not.toContain("withdrawn")
+      expect(superseded.explanation.toLowerCase()).toContain("updated quote")
     })
 
     it("does not tell a buyer to ask for a re-send of a withdrawn quote", () => {

--- a/apps/backend/src/modules/partner-quote/__tests__/token.unit.spec.ts
+++ b/apps/backend/src/modules/partner-quote/__tests__/token.unit.spec.ts
@@ -64,6 +64,24 @@ describe("partner-quote token", () => {
       ).toBe("expired")
     })
 
+    it("reports superseded ahead of expired — the buyer has somewhere to go", () => {
+      // #1435: a superseded quote is usually still inside its own TTL, but even
+      // once past it, "a newer quote replaced this" is the more useful thing to
+      // say than "this expired" — one of them points the buyer somewhere.
+      expect(
+        quoteUnusableReason({ status: "superseded", expires_at: days(-1) }, NOW)
+      ).toBe("superseded")
+      expect(
+        quoteUnusableReason({ status: "superseded", expires_at: days(7) }, NOW)
+      ).toBe("superseded")
+    })
+
+    it("reports revoked ahead of superseded — a withdrawal is the stronger fact", () => {
+      expect(
+        quoteUnusableReason({ status: "revoked", expires_at: days(7) }, NOW)
+      ).toBe("revoked")
+    })
+
     it("reports revoked ahead of expired — a withdrawn quote is not merely stale", () => {
       // The two states get different copy: "expired" invites a re-send,
       // "revoked" does not. Ordering them wrong would tell a buyer to ask for

--- a/apps/backend/src/modules/partner-quote/lib/compare.ts
+++ b/apps/backend/src/modules/partner-quote/lib/compare.ts
@@ -33,13 +33,14 @@ export type QuoteCompareInput = {
   /** True when the buyer has changed quantity or destination away from the quoted ones. */
   buyer_changed_inputs: boolean
   /** From `quoteUnusableReason`. */
-  unusable_reason: "revoked" | "expired" | null
+  unusable_reason: "revoked" | "superseded" | "expired" | null
   /** Whole days to expiry, from `daysUntilExpiry`. */
   days_until_expiry: number | null
 }
 
 export type QuoteDisplayState =
   | "dead_link"
+  | "superseded_quoted_only"
   | "expired_quoted_only"
   | "quoted_only"
   | "show_both"
@@ -88,6 +89,29 @@ export function compareQuote(input: QuoteCompareInput): QuoteCompareResult {
       explanation:
         "The partner who sent this quote has withdrawn it. Get in touch with them for a current one.",
       disclaimer: null,
+      expiry_notice: null,
+    }
+  }
+
+  if (unusable_reason === "superseded") {
+    // Deliberately NOT the revoked copy. Nobody withdrew this quote — a newer
+    // one replaced it, and its price list has been expired so it can no longer
+    // price a cart. Telling the buyer the partner "withdrew" it would be
+    // untrue and would send them into an apologetic conversation instead of
+    // simply asking for the current link.
+    //
+    // The quoted figures stay visible: this is still the record of what was
+    // said. No live number, because recomputing one here would read as an
+    // offer we are still making at these terms.
+    return {
+      state: "superseded_quoted_only",
+      show_quoted: quoted !== null,
+      show_live: false,
+      landed_delta: null,
+      headline: "A newer quote has replaced this one",
+      explanation:
+        "These are the figures as originally quoted. The partner has since sent an updated quote — ask them for the current link.",
+      disclaimer: DISCLAIMER,
       expiry_notice: null,
     }
   }

--- a/apps/backend/src/modules/partner-quote/lib/token.ts
+++ b/apps/backend/src/modules/partner-quote/lib/token.ts
@@ -47,8 +47,12 @@ export type QuoteLifecycle = {
 export function quoteUnusableReason(
   quote: QuoteLifecycle,
   now: Date
-): "revoked" | "expired" | null {
+): "revoked" | "superseded" | "expired" | null {
   if (quote.status === "revoked") return "revoked"
+  // Checked before expiry: a superseded quote is usually still inside its own
+  // TTL, and "a newer quote replaced this" is the more useful thing to say than
+  // "this expired" — the buyer has somewhere to go.
+  if (quote.status === "superseded") return "superseded"
   if (
     quote.expires_at &&
     new Date(quote.expires_at).getTime() <= now.getTime()

--- a/apps/backend/src/modules/partner-quote/migrations/Migration20260822061500.ts
+++ b/apps/backend/src/modules/partner-quote/migrations/Migration20260822061500.ts
@@ -1,0 +1,60 @@
+import { Migration } from "@medusajs/framework/mikro-orm/migrations";
+
+/**
+ * #1440 — promote the quote's buyer-identity ids out of `metadata` json into
+ * real columns, and widen `status` to carry `superseded`.
+ *
+ * The mint has always recorded `customer_id`, `customer_group_id` and
+ * `price_list_id`, but it recorded them in a json blob. That made the one query
+ * #1435 needs — "which other active price lists does this buyer's group already
+ * have?" — impossible through the module service, because a `list` filter
+ * cannot reach into a json key. So a repeat quote stacked a second price list
+ * on the same customer group and core tie-broke on `amount ASC`, handing a
+ * re-quoted buyer the older, cheaper prices.
+ *
+ * The backfill deliberately does NOT strip the keys from `metadata`. Leaving
+ * them costs nothing and keeps `down()` honest, and the revoke route reads the
+ * column with a metadata fallback precisely so a half-applied rollout cannot
+ * silently skip deleting a live price list. A follow-up can clear them once
+ * this has been verified in production.
+ */
+export class Migration20260822061500 extends Migration {
+
+  override async up(): Promise<void> {
+    this.addSql(`alter table if exists "partner_quote" add column if not exists "customer_id" text null;`);
+    this.addSql(`alter table if exists "partner_quote" add column if not exists "customer_group_id" text null;`);
+    this.addSql(`alter table if exists "partner_quote" add column if not exists "price_list_id" text null;`);
+
+    // The supersede lookup filters on this and nothing else.
+    this.addSql(`CREATE INDEX IF NOT EXISTS "IDX_partner_quote_customer_group_id" ON "partner_quote" ("customer_group_id") WHERE deleted_at IS NULL;`);
+
+    // Backfill. `coalesce` so a re-run is a no-op rather than an overwrite.
+    this.addSql(`update "partner_quote" set
+      "customer_id" = coalesce("customer_id", "metadata"->>'customer_id'),
+      "customer_group_id" = coalesce("customer_group_id", "metadata"->>'customer_group_id'),
+      "price_list_id" = coalesce("price_list_id", "metadata"->>'price_list_id')
+      where "metadata" is not null;`);
+
+    // `status` gains `superseded`. The original check was declared inline at
+    // create-table time, so Postgres auto-named it; `if exists` covers both the
+    // conventional name and an already-migrated database.
+    this.addSql(`alter table if exists "partner_quote" drop constraint if exists "partner_quote_status_check";`);
+    this.addSql(`alter table if exists "partner_quote" add constraint "partner_quote_status_check" check ("status" in ('active', 'revoked', 'superseded'));`);
+  }
+
+  override async down(): Promise<void> {
+    // Any row already marked superseded has no representation in the narrower
+    // set. Fold it back to `revoked` rather than `active`: its price list has
+    // been expired, so calling it active would describe a quote that cannot
+    // price anything as though it still could.
+    this.addSql(`update "partner_quote" set "status" = 'revoked' where "status" = 'superseded';`);
+    this.addSql(`alter table if exists "partner_quote" drop constraint if exists "partner_quote_status_check";`);
+    this.addSql(`alter table if exists "partner_quote" add constraint "partner_quote_status_check" check ("status" in ('active', 'revoked'));`);
+
+    this.addSql(`DROP INDEX IF EXISTS "IDX_partner_quote_customer_group_id";`);
+    this.addSql(`alter table if exists "partner_quote" drop column if exists "customer_id";`);
+    this.addSql(`alter table if exists "partner_quote" drop column if exists "customer_group_id";`);
+    this.addSql(`alter table if exists "partner_quote" drop column if exists "price_list_id";`);
+  }
+
+}

--- a/apps/backend/src/modules/partner-quote/models/partner-quote.ts
+++ b/apps/backend/src/modules/partner-quote/models/partner-quote.ts
@@ -87,10 +87,40 @@ const PartnerQuote = model.define("partner_quote", {
   quoted_weight_grams: model.number().nullable(),
   quoted_at: model.dateTime().nullable(),
 
+  // ===== Buyer identity — the edges this quote's prices hang off ==========
+  /**
+   * 🔴 These are NOT metadata, and they used to be (#1440).
+   *
+   * The mint creates a customer, a customer group named for the buyer, and a
+   * price list ruled on that group. Those three ids are what make the quoted
+   * number the number the cart charges, and what a revoke has to delete.
+   *
+   * They lived in `metadata` json until #1440, which made the one query that
+   * matters impossible: "what other active price lists does this buyer's group
+   * already have?" A module service `list` cannot filter on a json key, so a
+   * repeat quote silently STACKED a second price list on the same group and
+   * core tie-broke on `amount ASC` — handing a re-quoted buyer the older,
+   * cheaper prices (#1435). Columns, not a blob, is what makes supersede
+   * possible at all.
+   */
+  customer_id: model.text().nullable(),
+  // The index lives in the migration, not here — `.index()` is not available
+  // after `.nullable()`, and this module follows the same convention as
+  // `ai_usage`: indexes are maintained by the migrations.
+  customer_group_id: model.text().nullable(),
+  price_list_id: model.text().nullable(),
+
   // ===== Token + lifecycle ================================================
   // sha256(raw). The raw token is returned once, at mint.
   token_hash: model.text().unique(),
-  status: model.enum(["active", "revoked"]).default("active"),
+  /**
+   * `superseded` means a NEWER quote to the same buyer replaced this one, and
+   * this quote's price list has been expired so it can no longer price a cart.
+   * It is deliberately distinct from `revoked`: nobody withdrew this quote, and
+   * the buyer should be told a current one exists rather than that the partner
+   * pulled the offer.
+   */
+  status: model.enum(["active", "revoked", "superseded"]).default("active"),
   expires_at: model.dateTime().nullable(),
 
   // ===== Engagement (fire-and-forget; tracking must never 500 a buyer) =====
@@ -99,6 +129,11 @@ const PartnerQuote = model.define("partner_quote", {
   view_count: model.number().default(0),
 
   created_by: model.text().nullable(),
+  /**
+   * Genuinely incidental data only. The buyer identity ids that used to live
+   * here are now columns above — see the note on `customer_id`. Nothing
+   * load-bearing goes back in here.
+   */
   metadata: model.json().nullable(),
 })
 

--- a/apps/backend/src/workflows/partner-quote/mint-quote.ts
+++ b/apps/backend/src/workflows/partner-quote/mint-quote.ts
@@ -13,6 +13,7 @@ import {
 import {
   createPriceListsWorkflow,
   deletePriceListsWorkflow,
+  updatePriceListsWorkflow,
 } from "@medusajs/medusa/core-flows"
 
 import { PARTNER_QUOTE_MODULE } from "../../modules/partner-quote"
@@ -314,6 +315,162 @@ const mintPriceListStep = createStep(
   }
 )
 
+/**
+ * Retire every EARLIER active quote for this buyer (#1435).
+ *
+ * ## The bug this exists to fix
+ *
+ * `resolveQuoteBuyerStep`'s docblock has claimed since the module was written
+ * that a repeat buyer's second quote "replaces their prices rather than
+ * stacking a second list that core would tie-break against the first on
+ * `amount ASC`". **Nothing implemented that.** Two active price lists sat on
+ * one customer group, both with `rules_count: 1`, and core's tie-break picked
+ * the CHEAPEST — so a partner re-quoting the same buyer at a HIGHER price (
+ * materials moved, quantity dropped a tier) handed them the old, cheaper
+ * prices at checkout. The page showed the new number; the cart charged the old
+ * one. Expiry did not rescue it either: each list carries its own TTL from its
+ * own mint.
+ *
+ * A confident comment is not an implementation.
+ *
+ * ## Why `ends_at`, not delete
+ *
+ * Expiring the prior list is REVERSIBLE, and this step has to be: it runs
+ * before `persistQuoteStep`, so a later failure must put the buyer's previous
+ * quote back exactly as it was. A deleted price list cannot be restored, and
+ * compensating a destructive act with a re-create would mint a NEW list id
+ * that the old quote row does not point at. Setting `ends_at` to now stops the
+ * list pricing any cart immediately — expiry is native, there is no sweeper —
+ * and the compensation writes the original timestamp back.
+ *
+ * ## Ordering
+ *
+ * Runs AFTER the new price list is minted and verified, so a mint that fails
+ * its own rule check never touches the buyer's existing quote. At this point
+ * the new quote row does not exist yet, so every active quote found here is by
+ * definition a prior one — no need to exclude self.
+ */
+const supersedePriorQuotesStep = createStep(
+  "supersede-prior-quotes-step",
+  async (
+    input: { customer_group_id: string; now: Date },
+    { container }
+  ) => {
+    const service: any = container.resolve(PARTNER_QUOTE_MODULE)
+    const query: any = container.resolve(ContainerRegistrationKeys.QUERY)
+    const logger: any = container.resolve(ContainerRegistrationKeys.LOGGER)
+
+    // See the note in `mintPriceListStep`: a Date crossing a step boundary
+    // arrives as an ISO string, and tsc cannot see it.
+    const now = new Date(input.now)
+
+    const priors = await service.listPartnerQuotes({
+      customer_group_id: input.customer_group_id,
+      status: "active",
+    })
+
+    if (!priors?.length) {
+      return new StepResponse({ superseded: [] as string[] }, null)
+    }
+
+    const undo: Array<{
+      quote_id: string
+      price_list_id: string | null
+      previous_ends_at: string | null
+    }> = []
+
+    for (const prior of priors) {
+      let previousEndsAt: string | null = null
+
+      if (prior.price_list_id) {
+        // Read the CURRENT ends_at before overwriting it, so the compensation
+        // restores the real value rather than a guess.
+        const { data: lists } = await query.graph({
+          entity: "price_list",
+          fields: ["id", "ends_at"],
+          filters: { id: prior.price_list_id },
+        })
+        const existing = (lists ?? [])[0] as any
+        previousEndsAt = existing?.ends_at
+          ? new Date(existing.ends_at).toISOString()
+          : null
+
+        if (existing) {
+          await updatePriceListsWorkflow(container).run({
+            input: {
+              price_lists_data: [
+                { id: prior.price_list_id, ends_at: now.toISOString() } as any,
+              ],
+            },
+          })
+        } else {
+          // The list is already gone (revoked by hand, or cleaned up). Mark the
+          // quote anyway — but say so, rather than reporting a clean supersede.
+          logger.warn(
+            `[quote] supersede ${prior.id}: price list ${prior.price_list_id} no longer exists`
+          )
+        }
+      } else {
+        logger.warn(
+          `[quote] supersede ${prior.id}: no price_list_id recorded, nothing to expire`
+        )
+      }
+
+      await service.updatePartnerQuotes({
+        id: prior.id,
+        status: "superseded",
+      })
+
+      await service
+        .recordEvent({
+          quote_id: prior.id,
+          type: "superseded",
+          actor_type: "system",
+          message:
+            "A newer quote was minted for this buyer, so this quote's prices were expired.",
+          data: { price_list_id: prior.price_list_id ?? null },
+        })
+        .catch(() => {})
+
+      undo.push({
+        quote_id: prior.id,
+        price_list_id: prior.price_list_id ?? null,
+        previous_ends_at: previousEndsAt,
+      })
+    }
+
+    logger.info(
+      `[quote] superseded ${undo.length} prior quote(s) for group ${input.customer_group_id}`
+    )
+
+    return new StepResponse(
+      { superseded: undo.map((u) => u.quote_id) },
+      undo
+    )
+  },
+  async (undo, { container }) => {
+    if (!undo?.length) return
+    const service: any = container.resolve(PARTNER_QUOTE_MODULE)
+
+    for (const row of undo) {
+      if (row.price_list_id && row.previous_ends_at) {
+        await updatePriceListsWorkflow(container)
+          .run({
+            input: {
+              price_lists_data: [
+                { id: row.price_list_id, ends_at: row.previous_ends_at } as any,
+              ],
+            },
+          })
+          .catch(() => {})
+      }
+      await service
+        .updatePartnerQuotes({ id: row.quote_id, status: "active" })
+        .catch(() => {})
+    }
+  }
+)
+
 /** Persist the quote and its lines, and mint the token. */
 const persistQuoteStep = createStep(
   "persist-quote-step",
@@ -352,11 +509,11 @@ const persistQuoteStep = createStep(
       status: "active",
       expires_at: new Date(input.expires_at),
       created_by: input.mint.created_by ?? null,
-      metadata: {
-        customer_id: input.buyer.customer_id,
-        customer_group_id: input.buyer.customer_group_id,
-        price_list_id: input.price_list_id,
-      },
+      // #1440: columns, not metadata. `customer_group_id` is the key the
+      // supersede step queries on, and a json key cannot be filtered.
+      customer_id: input.buyer.customer_id,
+      customer_group_id: input.buyer.customer_group_id,
+      price_list_id: input.price_list_id,
     })
 
     await service.createPartnerQuoteLines(
@@ -430,6 +587,16 @@ export const mintQuoteWorkflow = createWorkflow(
       expires_at: timing.expires_at,
       now: timing.now,
       lines: priceRows,
+    } as any)
+
+    /**
+     * #1435 — retire the buyer's previous quotes AFTER the new price list is
+     * minted and verified, so a failed mint never disturbs a quote the buyer
+     * already holds. Its compensation restores them.
+     */
+    supersedePriorQuotesStep({
+      customer_group_id: buyer.customer_group_id,
+      now: timing.now,
     } as any)
 
     const persisted = persistQuoteStep({

--- a/apps/partner-ui/src/hooks/api/partner-quotes.tsx
+++ b/apps/partner-ui/src/hooks/api/partner-quotes.tsx
@@ -58,7 +58,7 @@ export type PartnerQuote = {
   quoted_weight_grams?: number | null
   quoted_at?: string | null
 
-  status: "active" | "revoked"
+  status: "active" | "revoked" | "superseded"
   expires_at?: string | null
 
   viewed_at?: string | null

--- a/apps/partner-ui/src/routes/orders/quote-list/components/quote-list-table.tsx
+++ b/apps/partner-ui/src/routes/orders/quote-list/components/quote-list-table.tsx
@@ -104,6 +104,11 @@ const useColumns = () => {
           if (quote.status === "revoked") {
             return <StatusBadge color="red">Revoked</StatusBadge>
           }
+          // A newer quote for the same buyer expired this one's price list
+          // (#1435). Not a withdrawal, so not red.
+          if (quote.status === "superseded") {
+            return <StatusBadge color="orange">Superseded</StatusBadge>
+          }
           if (isExpired(quote)) {
             return <StatusBadge color="grey">Expired</StatusBadge>
           }


### PR DESCRIPTION
Closes #1440. Fixes #1435. First slice of #1439.

## Identity out of `metadata`

The mint recorded `customer_id`, `customer_group_id` and `price_list_id` in a json blob. That made the one query #1435 needs — *"which other active price lists does this buyer's group already have?"* — impossible through the module service, because a `list` filter cannot reach into a json key.

So the blob was not untidiness. It was the blocker.

They are columns now, indexed on `customer_group_id`, with a migration and backfill. The backfill **deliberately leaves the metadata keys in place**: the revoke route reads the column with a metadata fallback, so a half-applied rollout cannot silently skip deleting a live price list. A follow-up can clear them once this is verified in production.

## A repeat quote no longer stacks

`resolveQuoteBuyerStep`'s docblock has claimed since the module was written that a repeat buyer's second quote *"replaces their prices rather than stacking a second list"*. **Nothing implemented that.**

Two active price lists sat on one customer group, both `rules_count: 1`, and core tie-breaks on `amount ASC` — so a partner re-quoting the same buyer at a **higher** price handed them the old, cheaper prices at checkout. The page showed the new number; the cart charged the old one.

`supersedePriorQuotesStep` runs **after** the new price list is minted and verified, so a failed mint never disturbs a quote the buyer already holds.

**It expires the prior list via `ends_at` rather than deleting it**, because this step must be reversible: a deleted price list cannot be restored, and re-creating one would mint an id the old quote row does not point at. The compensation writes the original timestamp back.

## `superseded` is not `revoked`

New status, deliberately distinct. Nobody withdrew a superseded quote — a newer one replaced it. The buyer is told that, rather than that the partner pulled the offer, which would send them into an apologetic conversation instead of just asking for the current link. Rendered in the admin list, the admin detail view, and the partner list.

## 🔑 The test that asserted the defect

`partner-quote-mint.spec.ts` already had a test named *"reuses one customer group per buyer, so a repeat quote replaces prices instead of stacking a second list"*.

Its body verified that two **distinct** price lists exist — the bug — and stopped. It passed on `main` the whole time the defect was live. Same shape as #1334/#1340, where a suite asserted the thing it was named to prevent.

It now asserts the prior list is expired and the prior quote reads `superseded`, plus a new sibling test that **another** buyer's live quote is untouched — supersede is scoped to one customer group, and getting that wrong would be worse than the defect it fixes.

## Verification

- `partner-quote` unit suite: **100 passed**
- `partner-quote-mint`: both supersede tests pass
- `partner-quote-cart-pricing`: 12 passed
- `check:prod-build`: green (config/schema artefacts reverted)

⚠️ **Two tests in these specs are red on `main` already**, for an unrelated freight-fixture reason — verified by stashing all local changes and re-running. Filed as **#1459**; not touched here.

## Deploy note

🔴 This carries a migration (`Migration20260822061500`). Read the migrate **step**, never the job — the job reports success while skipping. Backfill is `coalesce`-based so a re-run is a no-op.

🤖 Generated with [Claude Code](https://claude.com/claude-code)