### PR TITLE
feat(quote): real pagination, search and sort on both quote list endpoints

### DIFF
--- a/apps/backend/integration-tests/http/partner-quote-mint.spec.ts
+++ b/apps/backend/integration-tests/http/partner-quote-mint.spec.ts
@@ -359,6 +359,101 @@ setupSharedTestSuite(() => {
       expect(currentQuote.data.quote.status).toBe("active")
     })
 
+    it("pages, searches and sorts for real — the count is the SET, not the page", async () => {
+      /**
+       * #1441. Both list routes used to return the whole table and report
+       * `count = quotes.length`, so the admin pager was a client-side illusion
+       * and the partner route ignored `limit`/`offset` outright while the hook
+       * sent them. A pager over an unwindowed set moves nothing.
+       */
+      const { api } = getSharedTestEnv()
+      const tag = `page-${seed.unique}`
+
+      // Three quotes, distinguishable by company so search can pick one out.
+      for (const n of [1, 2, 3]) {
+        await loud(`mint-page-${n}`, () =>
+          api.post(
+            "/partners/quotes",
+            mintBody(seed, {
+              buyer_email: `${tag}-${n}@jaalyantra.test`,
+              recipient_company: n === 2 ? `Findable ${tag}` : `Other ${tag}`,
+            }),
+            { headers: seed.headers }
+          )
+        )
+      }
+
+      const firstPage = await loud("list-page-1", () =>
+        api.get("/partners/quotes?limit=2&offset=0", { headers: seed.headers })
+      )
+      expect(firstPage.data.quotes).toHaveLength(2)
+      // The count describes everything that matches, not this window.
+      expect(firstPage.data.count).toBeGreaterThan(2)
+      expect(firstPage.data.limit).toBe(2)
+
+      const secondPage = await loud("list-page-2", () =>
+        api.get("/partners/quotes?limit=2&offset=2", { headers: seed.headers })
+      )
+      // A real window moved: no id appears on both pages.
+      const firstIds = firstPage.data.quotes.map((q: any) => q.id)
+      const secondIds = secondPage.data.quotes.map((q: any) => q.id)
+      expect(secondIds.some((id: string) => firstIds.includes(id))).toBe(false)
+
+      // Search narrows the SET, not the page.
+      const searched = await loud("list-search", () =>
+        api.get(`/partners/quotes?q=Findable ${tag}`, { headers: seed.headers })
+      )
+      expect(searched.data.count).toBe(1)
+      expect(searched.data.quotes[0].recipient_company).toBe(`Findable ${tag}`)
+
+      // Sort is honoured, and an unknown sort field falls back rather than 500s.
+      const sorted = await loud("list-sorted", () =>
+        api.get("/partners/quotes?order=created_at:ASC&limit=100", {
+          headers: seed.headers,
+        })
+      )
+      const times = sorted.data.quotes.map((q: any) =>
+        new Date(q.created_at).getTime()
+      )
+      expect([...times].sort((a, b) => a - b)).toEqual(times)
+
+      const junkSort = await loud("list-junk-sort", () =>
+        api.get("/partners/quotes?order=token_hash:ASC", {
+          headers: seed.headers,
+        })
+      )
+      expect(junkSort.status).toBe(200)
+    })
+
+    it("🔴 a partner cannot widen their own scope with a query param", async () => {
+      // The route pins `partner_id` to the authenticated partner. If a query
+      // param could override it, any partner could list every other partner's
+      // quotes — the #1397/#1433 cross-tenant shape, on the one route that
+      // exists precisely to be scoped.
+      const { api } = getSharedTestEnv()
+      // ⚠️ Mint inside this test: the runner restores a DB snapshot before EVERY
+      // test, so rows created by a sibling test are already gone by the time
+      // this one runs — an empty list here would read as a passing assertion.
+      await loud("mint-scope", () =>
+        api.post(
+          "/partners/quotes",
+          mintBody(seed, { buyer_email: `scope-${seed.unique}@jaalyantra.test` }),
+          { headers: seed.headers }
+        )
+      )
+
+      const mine = await loud("list-mine", () =>
+        api.get("/partners/quotes?limit=100", { headers: seed.headers })
+      )
+      const spoofed = await loud("list-spoofed", () =>
+        api.get("/partners/quotes?partner_id=part_someone_else&limit=100", {
+          headers: seed.headers,
+        })
+      )
+      expect(spoofed.data.count).toBe(mine.data.count)
+      expect(spoofed.data.count).toBeGreaterThan(0)
+    })
+
     it("leaves ANOTHER buyer's quote alone when this buyer is re-quoted", async () => {
       // Supersede is scoped to one customer group. A bug here would expire an
       // unrelated buyer's live prices, which is far worse than the defect it

--- a/apps/backend/src/admin/hooks/api/quotes.ts
+++ b/apps/backend/src/admin/hooks/api/quotes.ts
@@ -31,7 +31,29 @@ export type AdminQuote = Record<string, any> & {
   created_at?: string
 }
 
-export type AdminQuoteListResponse = { quotes: AdminQuote[]; count: number }
+/**
+ * 🔑 `count` is the number of MATCHING rows, not the length of `quotes`.
+ * Until #1441 the route returned the whole table and reported its length, so
+ * anything paging on this was paging over a lie. `limit`/`offset` echo what
+ * the server actually applied after clamping.
+ */
+export type AdminQuoteListResponse = {
+  quotes: AdminQuote[]
+  count: number
+  limit?: number
+  offset?: number
+}
+
+export type AdminQuoteListQuery = {
+  partner_id?: string
+  status?: string
+  /** Free text over buyer email, company and recipient name. */
+  q?: string
+  limit?: number
+  offset?: number
+  /** `field:ASC|DESC`. An unknown field falls back to `created_at:DESC`. */
+  order?: string
+}
 
 export type AdminMintQuotePayload = {
   partner_id: string
@@ -57,7 +79,7 @@ export type AdminMintQuotePayload = {
 export type AdminMintQuoteResponse = { quote: AdminQuote; token: string }
 
 export const useQuotes = (
-  query?: { partner_id?: string; status?: string },
+  query?: AdminQuoteListQuery,
   options?: Omit<
     UseQueryOptions<AdminQuoteListResponse, FetchError, AdminQuoteListResponse, any>,
     "queryFn" | "queryKey"

--- a/apps/backend/src/api/admin/quotes/route.ts
+++ b/apps/backend/src/api/admin/quotes/route.ts
@@ -2,6 +2,7 @@ import { MedusaRequest, MedusaResponse } from "@medusajs/framework/http"
 import { ContainerRegistrationKeys, MedusaError } from "@medusajs/framework/utils"
 
 import { PARTNER_QUOTE_MODULE } from "../../../modules/partner-quote"
+import { buildQuoteListQuery } from "../../../modules/partner-quote/lib/list-query"
 import { mintQuoteWorkflow } from "../../../workflows/partner-quote/mint-quote"
 import { assertVariantsInStore } from "./lib/assert-variants-in-store"
 
@@ -19,20 +20,27 @@ import { assertVariantsInStore } from "./lib/assert-variants-in-store"
  * only thing standing between a quote and a platform-wide price cut.
  */
 
-/** List across partners, or scoped to one. */
+/**
+ * List across partners, or scoped to one.
+ *
+ * 🔑 `count` is the number of MATCHING rows, not the length of this page.
+ * It used to be `quotes.length` over an unpaginated read, which made the
+ * admin table's pager a client-side illusion over the whole table and its
+ * count meaningless. Paging, search and sort semantics are shared with
+ * `/partners/quotes` via `buildQuoteListQuery` so the two surfaces cannot
+ * drift.
+ */
 export const GET = async (req: MedusaRequest, res: MedusaResponse) => {
   const service: any = req.scope.resolve(PARTNER_QUOTE_MODULE)
 
-  const partnerId = String((req.query.partner_id as string) || "").trim()
-  const status = String((req.query.status as string) || "").trim()
+  const { filters, config } = buildQuoteListQuery(req.query as any)
 
-  const filters: Record<string, unknown> = {}
-  if (partnerId) filters.partner_id = partnerId
-  if (status) filters.status = status
+  const [quotes, count] = await service.listAndCountPartnerQuotes(
+    filters,
+    config
+  )
 
-  const quotes = await service.listPartnerQuotes(filters)
-
-  res.json({ quotes, count: quotes?.length ?? 0 })
+  res.json({ quotes, count, limit: config.take, offset: config.skip })
 }
 
 /**

--- a/apps/backend/src/api/partners/quotes/route.ts
+++ b/apps/backend/src/api/partners/quotes/route.ts
@@ -2,10 +2,19 @@ import { AuthenticatedMedusaRequest, MedusaResponse } from "@medusajs/framework/
 import { ContainerRegistrationKeys } from "@medusajs/framework/utils"
 
 import { PARTNER_QUOTE_MODULE } from "../../../modules/partner-quote"
+import { buildQuoteListQuery } from "../../../modules/partner-quote/lib/list-query"
 import { mintQuoteWorkflow } from "../../../workflows/partner-quote/mint-quote"
 import { getPartnerStore, tryGetPartnerStore } from "../helpers"
 
-/** The partner's own quotes. Scoped by `partner_id`, never listed globally. */
+/**
+ * The partner's own quotes. Scoped by `partner_id`, never listed globally.
+ *
+ * 🔑 `partner_id` is passed as a PINNED filter, which `buildQuoteListQuery`
+ * refuses to let a query string override. The list previously ignored
+ * `limit`/`offset` entirely while `usePartnerQuotes` sent them, so the table's
+ * pager moved a window over a set that was never windowed and `count` was the
+ * length of everything.
+ */
 export const GET = async (
   req: AuthenticatedMedusaRequest,
   res: MedusaResponse
@@ -16,9 +25,16 @@ export const GET = async (
   }
 
   const service: any = req.scope.resolve(PARTNER_QUOTE_MODULE)
-  const quotes = await service.listPartnerQuotes({ partner_id: partner.id })
+  const { filters, config } = buildQuoteListQuery(req.query as any, {
+    partner_id: partner.id,
+  })
 
-  res.json({ quotes, count: quotes.length })
+  const [quotes, count] = await service.listAndCountPartnerQuotes(
+    filters,
+    config
+  )
+
+  res.json({ quotes, count, limit: config.take, offset: config.skip })
 }
 
 /**

--- a/apps/backend/src/modules/partner-quote/__tests__/list-query.unit.spec.ts
+++ b/apps/backend/src/modules/partner-quote/__tests__/list-query.unit.spec.ts
@@ -1,0 +1,137 @@
+import {
+  buildQuoteListQuery,
+  buildQuoteSearchFilter,
+  parseQuoteOrder,
+  QUOTE_DEFAULT_LIMIT,
+  QUOTE_MAX_LIMIT,
+} from "../lib/list-query"
+
+describe("parseQuoteOrder", () => {
+  it("defaults to newest first", () => {
+    // A quote list is a work queue: the one just minted is the one being
+    // talked about.
+    expect(parseQuoteOrder(undefined)).toEqual({ created_at: "DESC" })
+    expect(parseQuoteOrder("")).toEqual({ created_at: "DESC" })
+  })
+
+  it("reads the `field:DIRECTION` shape the admin DataTable sends", () => {
+    expect(parseQuoteOrder("expires_at:ASC")).toEqual({ expires_at: "ASC" })
+    expect(parseQuoteOrder("expires_at:DESC")).toEqual({ expires_at: "DESC" })
+    expect(parseQuoteOrder("expires_at:desc")).toEqual({ expires_at: "DESC" })
+  })
+
+  it("reads the `-field` shape", () => {
+    expect(parseQuoteOrder("-quoted_landed_total")).toEqual({
+      quoted_landed_total: "DESC",
+    })
+  })
+
+  it("ignores a field that is not on the allowlist", () => {
+    // 🔴 `order` reaches the ORM. "Whatever the client sent" is not a column
+    // name, and token_hash in particular must never be a sort key — sorting by
+    // a credential is a way to learn about it.
+    expect(parseQuoteOrder("token_hash:ASC")).toEqual({ created_at: "DESC" })
+    expect(parseQuoteOrder("; drop table:ASC")).toEqual({ created_at: "DESC" })
+    expect(parseQuoteOrder("metadata:DESC")).toEqual({ created_at: "DESC" })
+  })
+
+  it("does not throw on a malformed sort — a bad param is not worth a 400", () => {
+    expect(() => parseQuoteOrder(":::")).not.toThrow()
+    expect(parseQuoteOrder(":::")).toEqual({ created_at: "DESC" })
+  })
+})
+
+describe("buildQuoteSearchFilter", () => {
+  it("is null for an absent or blank query", () => {
+    expect(buildQuoteSearchFilter(undefined)).toBeNull()
+    expect(buildQuoteSearchFilter("   ")).toBeNull()
+  })
+
+  it("matches the three things a human remembers about a quote", () => {
+    const f = buildQuoteSearchFilter("acme") as any
+    const fields = f.$or.map((c: any) => Object.keys(c)[0])
+    expect(fields).toEqual([
+      "email_sent_to",
+      "recipient_company",
+      "recipient_name",
+    ])
+    expect(f.$or[0].email_sent_to).toEqual({ $ilike: "%acme%" })
+  })
+
+  it("never searches the token or its hash", () => {
+    // A quote must not be findable by anything resembling its credential.
+    const f = buildQuoteSearchFilter("abc") as any
+    const fields = f.$or.map((c: any) => Object.keys(c)[0])
+    expect(fields).not.toContain("token_hash")
+  })
+})
+
+describe("buildQuoteListQuery", () => {
+  it("defaults to one page, newest first", () => {
+    const { filters, config } = buildQuoteListQuery({})
+    expect(config).toEqual({
+      skip: 0,
+      take: QUOTE_DEFAULT_LIMIT,
+      order: { created_at: "DESC" },
+    })
+    expect(filters).toEqual({})
+  })
+
+  it("clamps limit to a ceiling — `?limit=100000` is a table scan on request", () => {
+    expect(buildQuoteListQuery({ limit: 100000 }).config.take).toBe(
+      QUOTE_MAX_LIMIT
+    )
+    expect(buildQuoteListQuery({ limit: 0 }).config.take).toBe(1)
+    expect(buildQuoteListQuery({ limit: -5 }).config.take).toBe(1)
+  })
+
+  it("falls back rather than NaN-ing on junk paging params", () => {
+    // These arrive as strings off a query string, and `Number("abc")` is NaN —
+    // handed to `skip`/`take` that is an empty page, which reads as "this
+    // partner has no quotes".
+    expect(buildQuoteListQuery({ limit: "abc" }).config.take).toBe(
+      QUOTE_DEFAULT_LIMIT
+    )
+    expect(buildQuoteListQuery({ offset: "abc" }).config.skip).toBe(0)
+    expect(buildQuoteListQuery({ offset: -10 }).config.skip).toBe(0)
+  })
+
+  it("reads paging from strings, because a query string has no numbers", () => {
+    const { config } = buildQuoteListQuery({ limit: "50", offset: "100" })
+    expect(config.take).toBe(50)
+    expect(config.skip).toBe(100)
+  })
+
+  it("applies status and partner filters", () => {
+    const { filters } = buildQuoteListQuery({
+      status: "superseded",
+      partner_id: "part_1",
+    })
+    expect(filters).toMatchObject({
+      status: "superseded",
+      partner_id: "part_1",
+    })
+  })
+
+  it("🔴 refuses to let a query string widen a pinned scope", () => {
+    // The partner route pins `partner_id` to the authenticated partner. If a
+    // query param could override it, any partner could list every other
+    // partner's quotes — the #1397/#1433 cross-tenant shape, on a route that
+    // exists precisely to be scoped.
+    const { filters } = buildQuoteListQuery(
+      { partner_id: "someone_else" },
+      { partner_id: "part_mine" }
+    )
+    expect(filters.partner_id).toBe("part_mine")
+  })
+
+  it("combines a pinned scope with search and paging", () => {
+    const { filters, config } = buildQuoteListQuery(
+      { q: "acme", limit: "10", offset: "20", order: "expires_at:ASC" },
+      { partner_id: "part_mine" }
+    )
+    expect(filters.partner_id).toBe("part_mine")
+    expect((filters as any).$or).toHaveLength(3)
+    expect(config).toEqual({ skip: 20, take: 10, order: { expires_at: "ASC" } })
+  })
+})

--- a/apps/backend/src/modules/partner-quote/lib/list-query.ts
+++ b/apps/backend/src/modules/partner-quote/lib/list-query.ts
@@ -1,0 +1,156 @@
+/**
+ * PURE: turn a quote list request's query string into module-service filters
+ * and config (#1441).
+ *
+ * ## Why this is shared
+ *
+ * `/admin/quotes` and `/partners/quotes` are the same list with a different
+ * scope — the admin may span partners, the partner is pinned to their own.
+ * Everything else about paging, searching and sorting must behave identically,
+ * because the two UIs are meant to feel like one product. Two hand-rolled
+ * copies is how they drift.
+ *
+ * ## What this replaces
+ *
+ * Both routes previously returned the **entire** table and reported
+ * `count = quotes.length`. `/partners/quotes` ignored `limit`/`offset` outright
+ * even though `usePartnerQuotes` sent them, and the admin `DataTable` paged
+ * client-side over everything ever minted. So both surfaces paged over a lie:
+ * the pager moved, the count never meant anything, and a filter narrowed one
+ * page rather than the set.
+ *
+ * 🔑 A caller-supplied sort field is checked against an allowlist rather than
+ * passed through. `order` reaches the ORM, and "whatever the client sent" is
+ * not a column name — an unknown field should be ignored, not handed onward.
+ */
+
+/** Sortable columns. Anything else is ignored in favour of the default. */
+export const QUOTE_SORTABLE_FIELDS = [
+  "created_at",
+  "updated_at",
+  "expires_at",
+  "quoted_landed_total",
+  "quoted_at",
+  "status",
+  "viewed_at",
+  "last_viewed_at",
+  "view_count",
+] as const
+
+/**
+ * Newest first. A quote list is a work queue — the one just minted is the one
+ * being talked about.
+ */
+export const QUOTE_DEFAULT_ORDER: Record<string, "ASC" | "DESC"> = {
+  created_at: "DESC",
+}
+
+export const QUOTE_DEFAULT_LIMIT = 20
+/** A ceiling, not a suggestion: `?limit=100000` is a table scan on request. */
+export const QUOTE_MAX_LIMIT = 100
+
+export type QuoteListQuery = {
+  limit?: unknown
+  offset?: unknown
+  q?: unknown
+  order?: unknown
+  status?: unknown
+  partner_id?: unknown
+}
+
+export type BuiltQuoteListQuery = {
+  filters: Record<string, unknown>
+  config: { skip: number; take: number; order: Record<string, "ASC" | "DESC"> }
+}
+
+function clampInt(raw: unknown, fallback: number, min: number, max: number) {
+  const text = String(raw ?? "").trim()
+  // 🔑 An ABSENT param must fall back, not clamp. `Number("")` is 0 — finite —
+  // so testing only `Number.isFinite` treated "no limit given" as "limit 0" and
+  // clamped it to 1, silently serving one row per page on every default list.
+  // Caught by its own unit test; it would have looked like a UI paging bug.
+  if (!text) return fallback
+  const n = Number(text)
+  if (!Number.isFinite(n)) return fallback
+  return Math.min(max, Math.max(min, Math.floor(n)))
+}
+
+/**
+ * Parse `field:DIRECTION`, or a `-field` prefix for descending.
+ *
+ * Returns the default for anything unrecognised rather than throwing: a
+ * malformed sort is not worth failing a list over, and silently ordering by
+ * something the caller did not ask for is less harmful than a 400 on a page
+ * load.
+ */
+export function parseQuoteOrder(raw: unknown): Record<string, "ASC" | "DESC"> {
+  const value = String(raw ?? "").trim()
+  if (!value) return { ...QUOTE_DEFAULT_ORDER }
+
+  let field = value
+  let direction: "ASC" | "DESC" = "ASC"
+
+  if (value.includes(":")) {
+    const [f, d] = value.split(":")
+    field = (f || "").trim()
+    direction = String(d || "").trim().toUpperCase() === "DESC" ? "DESC" : "ASC"
+  } else if (value.startsWith("-")) {
+    field = value.slice(1).trim()
+    direction = "DESC"
+  }
+
+  if (!(QUOTE_SORTABLE_FIELDS as readonly string[]).includes(field)) {
+    return { ...QUOTE_DEFAULT_ORDER }
+  }
+
+  return { [field]: direction }
+}
+
+/**
+ * The free-text clause.
+ *
+ * Matches the three things a human actually remembers about a quote: who it
+ * went to, the company on it, and the person's name. Deliberately NOT the
+ * token or its hash — a quote must not be findable by anything resembling its
+ * credential, and an operator searching by token is a workflow we do not want
+ * to make easy.
+ */
+export function buildQuoteSearchFilter(raw: unknown): Record<string, unknown> | null {
+  const q = String(raw ?? "").trim()
+  if (!q) return null
+
+  const like = { $ilike: `%${q}%` }
+  return {
+    $or: [
+      { email_sent_to: like },
+      { recipient_company: like },
+      { recipient_name: like },
+    ],
+  }
+}
+
+export function buildQuoteListQuery(
+  query: QuoteListQuery,
+  /** Filters the caller pins and the client cannot override — e.g. the partner's own id. */
+  scoped: Record<string, unknown> = {}
+): BuiltQuoteListQuery {
+  const take = clampInt(query.limit, QUOTE_DEFAULT_LIMIT, 1, QUOTE_MAX_LIMIT)
+  const skip = clampInt(query.offset, 0, 0, Number.MAX_SAFE_INTEGER)
+
+  const filters: Record<string, unknown> = { ...scoped }
+
+  const status = String(query.status ?? "").trim()
+  if (status) filters.status = status
+
+  // Only honoured when the caller did not already pin it. A partner listing
+  // their own quotes must never be able to widen the scope by query string.
+  const partnerId = String(query.partner_id ?? "").trim()
+  if (partnerId && scoped.partner_id === undefined) {
+    filters.partner_id = partnerId
+  }
+
+  const search = buildQuoteSearchFilter(query.q)
+  if (search) Object.assign(filters, search)
+
+  return { filters, config: { skip, take, order: parseQuoteOrder(query.order) } }
+}


### PR DESCRIPTION
Closes #1441. Slice S2 of #1439. Unblocks #1443 (the admin DataTable).

## The problem

Both list routes returned the **entire** table and reported `count = quotes.length`.

- `/partners/quotes` ignored `limit`/`offset` **outright**, even though `usePartnerQuotes({limit, offset})` sent them and the partner table read `offset` from the URL.
- The admin `DataTable` paged client-side over everything ever minted.

So both surfaces paged over a lie: the pager moved, the count never meant anything, and a filter narrowed one page rather than the set. Any search/filter UI built on that would have been cosmetic.

## The change

`buildQuoteListQuery` is shared by both routes, because they are the same list with a different scope — the admin may span partners, the partner is pinned to their own. Two hand-rolled copies is how they drift.

- `limit` (default 20, hard ceiling 100), `offset`, `q`, `order`
- `q` matches buyer email, recipient company and recipient name — **deliberately not** the token or its hash. A quote must not be findable by anything resembling its credential.
- `order` accepts `field:DIRECTION` (what the admin DataTable sends) and `-field`. The field is checked against an **allowlist** rather than passed through: `order` reaches the ORM, and "whatever the client sent" is not a column name. An unrecognised sort falls back rather than 400s — a bad param isn't worth failing a page load over.
- `listAndCountPartnerQuotes`, so `count` describes the matching set. `limit`/`offset` are echoed back post-clamp.

## 🔴 A pinned scope cannot be widened by query string

The partner route passes `partner_id` as a **pinned** filter, and `buildQuoteListQuery` ignores a `?partner_id=` param when one is pinned. Without that, any authenticated partner could list every other partner's quotes by adding a query param — the #1397/#1433 cross-tenant shape, on the one route that exists precisely to be scoped. It has its own integration test.

## The unit test earned its keep immediately

It caught a real bug in the helper while I was writing it: `Number("")` is `0` and therefore **finite**, so testing only `Number.isFinite` treated *"no limit given"* as *"limit 0"* and clamped it to 1. Every default list would have served **one row per page** — and it would have looked like a UI paging bug, not a parser bug.

## Verification

- 115 `partner-quote` unit tests pass (15 new)
- Mint integration suite: **8 of 9**. The one failure is #1459, already red on `main` — verified previously by stashing and re-running.
- `check:prod-build` green

⚠️ The new scope test mints its own quote deliberately: the runner restores a DB snapshot before **every** test, so rows from a sibling test are already gone — an empty list would have read as a passing assertion.

No migration. No deploy-order constraint.

🤖 Generated with [Claude Code](https://claude.com/claude-code)