### PR TITLE
feat(quote): refuse to mint what cannot be shipped or priced

### DIFF
--- a/apps/backend/integration-tests/http/partner-quote-mint.spec.ts
+++ b/apps/backend/integration-tests/http/partner-quote-mint.spec.ts
@@ -359,6 +359,136 @@ setupSharedTestSuite(() => {
       expect(currentQuote.data.quote.status).toBe("active")
     })
 
+    describe("the readiness preflight (#1445)", () => {
+      it("passes a basket that can actually be quoted, and previews the freight", async () => {
+        const { api } = getSharedTestEnv()
+        const body = mintBody(seed)
+        const res = await loud("readiness-ok", () =>
+          api.post(
+            "/partners/quotes/readiness",
+            {
+              lines: body.lines,
+              destination_country_code: body.destination_country_code,
+              destination_postal_code: body.destination_postal_code,
+              destination_city: body.destination_city,
+              currency_code: body.currency_code,
+              region_id: body.region_id,
+              carrier: body.carrier,
+            },
+            { headers: seed.headers }
+          )
+        )
+
+        expect(res.status).toBe(200)
+        expect(res.data.readiness.ready).toBe(true)
+        expect(res.data.readiness.blocking_count).toBe(0)
+        // It resolved a real freight option in the quote's own currency —
+        // the #1424/#1434 guard, asserted from outside.
+        expect(res.data.readiness.freight.chosen).toBeTruthy()
+        expect(res.data.readiness.freight.chosen.currency_code).toBe(
+          body.currency_code
+        )
+        expect(res.data.readiness.freight.total_weight_grams).toBeGreaterThan(0)
+      })
+
+      it("names the variant that does not exist rather than failing vaguely", async () => {
+        const { api } = getSharedTestEnv()
+        const body = mintBody(seed)
+        const res = await loud("readiness-missing-variant", () =>
+          api.post(
+            "/partners/quotes/readiness",
+            {
+              lines: [{ variant_id: "variant_does_not_exist", quantity: 5 }],
+              destination_country_code: body.destination_country_code,
+              destination_postal_code: body.destination_postal_code,
+              currency_code: body.currency_code,
+              region_id: body.region_id,
+              carrier: body.carrier,
+            },
+            { headers: seed.headers }
+          )
+        )
+
+        expect(res.data.readiness.ready).toBe(false)
+        const codes = res.data.readiness.issues.map((i: any) => i.code)
+        expect(codes).toContain("variant_missing")
+        const issue = res.data.readiness.issues.find(
+          (i: any) => i.code === "variant_missing"
+        )
+        expect(issue.variant_id).toBe("variant_does_not_exist")
+        expect(issue.severity).toBe("blocking")
+      })
+
+      it("reports EVERY blocking failure at once, not just the first", async () => {
+        // 🔑 The whole point of a preflight. Throwing on the first problem —
+        // which is what buildQuoteView does, correctly, on a render path —
+        // makes a partner fix one thing per round trip.
+        const { api } = getSharedTestEnv()
+        const body = mintBody(seed)
+        const res = await loud("readiness-multi", () =>
+          api.post(
+            "/partners/quotes/readiness",
+            {
+              lines: [
+                { variant_id: "variant_missing_one", quantity: 5 },
+                { variant_id: "variant_missing_two", quantity: 5 },
+              ],
+              destination_country_code: body.destination_country_code,
+              destination_postal_code: body.destination_postal_code,
+              currency_code: body.currency_code,
+              region_id: body.region_id,
+              carrier: body.carrier,
+            },
+            { headers: seed.headers }
+          )
+        )
+
+        expect(res.data.readiness.blocking_count).toBeGreaterThanOrEqual(2)
+        const ids = res.data.readiness.issues
+          .filter((i: any) => i.code === "variant_missing")
+          .map((i: any) => i.variant_id)
+        expect(ids).toEqual(
+          expect.arrayContaining(["variant_missing_one", "variant_missing_two"])
+        )
+      })
+
+      it("does not resolve `readiness` as a quote id", async () => {
+        // The static segment sits alongside /partners/quotes/:id. If the
+        // dynamic route won, this would 404 as an unknown quote and the
+        // preflight would silently not exist.
+        const { api } = getSharedTestEnv()
+        const res = await loud("readiness-routing", () =>
+          api.post(
+            "/partners/quotes/readiness",
+            {
+              lines: mintBody(seed).lines,
+              destination_country_code: "in",
+              destination_postal_code: "400001",
+              currency_code: seed.currencyCode,
+              region_id: seed.regionId,
+              carrier: "manual",
+            },
+            { headers: seed.headers }
+          )
+        )
+        expect(res.status).toBe(200)
+        expect(res.data.readiness).toBeDefined()
+      })
+
+      it("🔴 the MINT itself refuses an unquotable basket — the preflight is not advisory", async () => {
+        // A checklist a client can skip is not a gate. The same assessor runs
+        // as the first step of the workflow, before anything is created.
+        const { api } = getSharedTestEnv()
+        const body = mintBody(seed, {
+          lines: [{ variant_id: "variant_does_not_exist", quantity: 5 }],
+        })
+
+        await expect(
+          api.post("/partners/quotes", body, { headers: seed.headers })
+        ).rejects.toMatchObject({ response: { status: 400 } })
+      })
+    })
+
     it("pages, searches and sorts for real — the count is the SET, not the page", async () => {
       /**
        * #1441. Both list routes used to return the whole table and report

--- a/apps/backend/src/api/admin/quotes/readiness/route.ts
+++ b/apps/backend/src/api/admin/quotes/readiness/route.ts
@@ -1,0 +1,84 @@
+import { MedusaRequest, MedusaResponse } from "@medusajs/framework/http"
+import { ContainerRegistrationKeys, MedusaError } from "@medusajs/framework/utils"
+
+import { assessQuoteReadiness } from "../../../../modules/partner-quote/lib/quote-readiness"
+
+/**
+ * Can this basket be quoted, on a named partner's behalf? (#1445)
+ *
+ * The admin twin of `/partners/quotes/readiness`. Same assessor, one extra
+ * input: an admin has no partner of their own, so `partner_id` is required and
+ * the store is resolved from it.
+ *
+ * 🔴 `check_catalogue` matters far more here than on the partner surface. An
+ * admin picks the partner from one dropdown and the variants from another, so
+ * the two can disagree with a single mis-click — and nothing downstream
+ * catches it: the price list is created successfully, its rule assertion
+ * passes, and the buyer gets a working link to prices the partner never agreed
+ * to sell at.
+ *
+ * Writes nothing.
+ */
+export const POST = async (req: MedusaRequest, res: MedusaResponse) => {
+  const body = req.validatedBody as any
+  const partnerId = String(body.partner_id || "").trim()
+
+  const query = req.scope.resolve(ContainerRegistrationKeys.QUERY)
+  const { data: partners } = await query.graph({
+    entity: "partners",
+    fields: [
+      "id",
+      "name",
+      "stores.id",
+      "stores.default_location_id",
+      "stores.default_sales_channel_id",
+    ],
+    filters: { id: partnerId },
+  })
+
+  const partner = partners?.[0] as any
+  if (!partner) {
+    throw new MedusaError(MedusaError.Types.NOT_FOUND, "Partner not found")
+  }
+
+  const store = partner.stores?.[0]
+  if (!store?.id) {
+    // Answered as a readiness failure rather than thrown: "this partner has no
+    // store" is exactly the kind of thing this endpoint exists to report, and
+    // a 404 here would make the wizard show an error dialog instead of a
+    // checklist row the admin can act on.
+    return res.json({
+      readiness: {
+        ready: false,
+        issues: [
+          {
+            code: "store_location_missing",
+            severity: "blocking",
+            message: `${partner.name || partnerId} has no store, so a quote cannot be priced for them.`,
+          },
+        ],
+        blocking_count: 1,
+        warning_count: 0,
+        freight: { chosen: null, total_weight_grams: null, error: null },
+      },
+    })
+  }
+
+  const readiness = await assessQuoteReadiness(req.scope, {
+    lines: body.lines,
+    store: {
+      id: store.id,
+      default_location_id: store.default_location_id,
+      default_sales_channel_id: store.default_sales_channel_id,
+    },
+    destination_country_code: body.destination_country_code,
+    destination_postal_code: body.destination_postal_code ?? null,
+    currency_code: body.currency_code,
+    region_id: body.region_id ?? null,
+    carrier: body.carrier,
+    partner_label: partner.name || partnerId,
+    check_catalogue: true,
+  })
+
+  res.json({ readiness })
+}

--- a/apps/backend/src/api/admin/quotes/validators.ts
+++ b/apps/backend/src/api/admin/quotes/validators.ts
@@ -1,6 +1,9 @@
 import { z } from "@medusajs/framework/zod"
 
-import { PartnerMintQuoteReq } from "../../partners/quotes/validators"
+import {
+  PartnerMintQuoteReq,
+  QuoteReadinessReq,
+} from "../../partners/quotes/validators"
 
 /**
  * The admin mint body (#1389 S5).
@@ -18,3 +21,14 @@ export const AdminMintQuoteReq = PartnerMintQuoteReq.extend({
 })
 
 export type AdminMintQuoteReqType = z.infer<typeof AdminMintQuoteReq>
+
+/**
+ * The admin readiness body (#1445). Same addition as the mint: an admin has no
+ * partner of their own, so the one being quoted for must be named — and on this
+ * surface that partner is exactly what the catalogue check validates against.
+ */
+export const AdminQuoteReadinessReq = QuoteReadinessReq.extend({
+  partner_id: z.string().min(1),
+})
+
+export type AdminQuoteReadinessReqType = z.infer<typeof AdminQuoteReadinessReq>

--- a/apps/backend/src/api/middlewares.ts
+++ b/apps/backend/src/api/middlewares.ts
@@ -306,8 +306,8 @@ import { BulkImportSchema } from "./admin/inventory-items/bulk-import/validators
 import { PartnerCreateStoreReq } from "./partners/stores/validators";
 import { PartnerCreateProductReq, PartnerArtisanProductDetailReq, PartnerProductSpecReq, PartnerStoreCreateProductReq, PartnerQuickCreateProductReq } from "./partners/products/validators";
 import { PartnerCreatePriceListReq, PartnerUpdatePriceListReq } from "./partners/price-lists/validators";
-import { PartnerMintQuoteReq } from "./partners/quotes/validators";
-import { AdminMintQuoteReq } from "./admin/quotes/validators";
+import { PartnerMintQuoteReq, QuoteReadinessReq } from "./partners/quotes/validators";
+import { AdminMintQuoteReq, AdminQuoteReadinessReq } from "./admin/quotes/validators";
 import { BATCH_VARIANT_FIELDS } from "../workflows/partner/batch-partner-variants";
 import { StoreMadeToSpecReq } from "./store/carts/[id]/made-to-spec/validators";
 import {
@@ -5613,12 +5613,30 @@ export default defineMiddlewares({
         validateAndTransformBody(wrapSchema(PartnerMintQuoteReq)),
       ],
     },
+    // The readiness preflight (#1445). Registered BEFORE /partners/quotes/:id
+    // so "readiness" is never matched as a quote id.
+    {
+      matcher: "/partners/quotes/readiness",
+      method: "POST",
+      middlewares: [
+        createCorsPartnerMiddleware(),
+        authenticate("partner", ["session", "bearer"]),
+        validateAndTransformBody(wrapSchema(QuoteReadinessReq)),
+      ],
+    },
     // Admin quotes (#1389 S5). Same capability as the partner surface, but the
     // owning partner must be named — an admin has none of their own.
     {
       matcher: "/admin/quotes",
       method: "POST",
       middlewares: [validateAndTransformBody(wrapSchema(AdminMintQuoteReq))],
+    },
+    {
+      matcher: "/admin/quotes/readiness",
+      method: "POST",
+      middlewares: [
+        validateAndTransformBody(wrapSchema(AdminQuoteReadinessReq)),
+      ],
     },
     {
       matcher: "/partners/quotes/:id",

--- a/apps/backend/src/api/partners/quotes/readiness/route.ts
+++ b/apps/backend/src/api/partners/quotes/readiness/route.ts
@@ -1,0 +1,51 @@
+import {
+  AuthenticatedMedusaRequest,
+  MedusaResponse,
+} from "@medusajs/framework/http"
+
+import { getPartnerStore } from "../../helpers"
+import { assessQuoteReadiness } from "../../../../modules/partner-quote/lib/quote-readiness"
+
+/**
+ * Can this basket be quoted? (#1445)
+ *
+ * A read-only dry run of everything `mintQuoteWorkflow` would refuse on, so
+ * the wizard can show a blocking checklist instead of letting a partner press
+ * mint and collect one error at a time.
+ *
+ * 🔑 POST, not GET, because the input is a basket — a list of variants and
+ * quantities plus a destination — and putting that in a query string would
+ * both hit URL limits on a real bulk quote and log the whole thing.
+ *
+ * 🔴 Writes NOTHING. That is the contract: this is what a partner or an
+ * assistant is expected to call speculatively, repeatedly, before committing.
+ * The moment it has a side effect, nobody can call it freely and it stops
+ * being useful.
+ */
+export const POST = async (
+  req: AuthenticatedMedusaRequest,
+  res: MedusaResponse
+) => {
+  const { partner, store } = await getPartnerStore(req.auth_context, req.scope)
+  const body = req.validatedBody as any
+
+  const readiness = await assessQuoteReadiness(req.scope, {
+    lines: body.lines,
+    store: {
+      id: store.id,
+      default_location_id: store.default_location_id,
+      default_sales_channel_id: (store as any).default_sales_channel_id,
+    },
+    destination_country_code: body.destination_country_code,
+    destination_postal_code: body.destination_postal_code ?? null,
+    currency_code: body.currency_code,
+    region_id: body.region_id ?? null,
+    carrier: body.carrier,
+    partner_label: partner.name || partner.id,
+    // The partner picks from their own catalogue, so a mismatch here means the
+    // product left their sales channel after it was selected — worth saying.
+    check_catalogue: true,
+  })
+
+  res.json({ readiness })
+}

--- a/apps/backend/src/api/partners/quotes/validators.ts
+++ b/apps/backend/src/api/partners/quotes/validators.ts
@@ -27,3 +27,22 @@ export const PartnerMintQuoteReq = z.object({
   /** Drives `price_list.ends_at`, so expiry is native rather than swept. */
   ttl_days: z.number().int().positive().max(365).optional(),
 })
+
+/**
+ * The readiness preflight body (#1445).
+ *
+ * 🔑 Derived from the mint schema, not restated. It is deliberately the mint
+ * body minus the fields a dry run has no use for — the buyer's identity and
+ * the TTL. If the two drifted, the preflight would validate a shape the mint
+ * rejects, which is worse than having no preflight: it would tell a partner
+ * their quote is ready and then refuse it.
+ */
+export const QuoteReadinessReq = PartnerMintQuoteReq.omit({
+  buyer_email: true,
+  recipient_name: true,
+  recipient_company: true,
+  partner_note: true,
+  ttl_days: true,
+})
+
+export type QuoteReadinessReqType = z.infer<typeof QuoteReadinessReq>

--- a/apps/backend/src/modules/partner-quote/lib/quote-readiness.ts
+++ b/apps/backend/src/modules/partner-quote/lib/quote-readiness.ts
@@ -1,0 +1,350 @@
+import { ContainerRegistrationKeys, QueryContext } from "@medusajs/framework/utils"
+
+import {
+  buildShippingEstimate,
+  resolveUnitWeight,
+} from "../../../lib/shipping-estimate"
+import { pickFreightOption } from "./build-quote-view"
+
+/**
+ * Can this basket actually be quoted? (#1445 / #1439 S6)
+ *
+ * ## Why this exists
+ *
+ * Every wrong number this feature has produced was minted **successfully**.
+ * #1416 priced nothing. #1424 quoted a Mumbai consignment as "European
+ * Shipping" at 10 AUD. #1430 shipped every bulk order free. #1433 offered
+ * another tenant's pickup option. #1434 added a rupee rate into a euro total.
+ * In each case the mint returned 201 and the partner had no way to know.
+ *
+ * The system had no way to say *"I don't know"*, so it said something
+ * confident and false. This says it instead.
+ *
+ * ## Why it collects instead of throwing
+ *
+ * `buildQuoteView` throws on the FIRST problem, which is right for a render
+ * path and wrong for a preflight: a partner fixing a quote one error at a time
+ * plays whack-a-mole across five round trips. Every check here runs and every
+ * failure is named, so one pass shows the whole picture.
+ *
+ * 🔑 Weights are checked BEFORE the shipping estimate is called, deliberately.
+ * `buildShippingEstimate` refuses the whole basket on the first weightless
+ * line — correctly, since a landed total missing one line's freight is a wrong
+ * number wearing a confident label — but it cannot tell you *which* variants
+ * to fix. Checking first is what turns "this basket cannot ship" into "these
+ * two variants have no weight".
+ *
+ * ## What a failure means
+ *
+ * `blocking` means the mint would produce a number nobody should act on.
+ * `warning` means the quote is mintable but something downstream is missing —
+ * a tax region, today, because tax is not on the quote yet (#1447). Warnings
+ * must never be promoted to blocking silently: refusing to quote for a
+ * capability we have not shipped would be worse than the gap.
+ */
+
+export type QuoteReadinessCode =
+  | "store_location_missing"
+  | "store_sales_channel_missing"
+  | "variant_missing"
+  | "variant_not_in_catalogue"
+  | "line_unpriced"
+  | "weight_missing"
+  | "no_freight_option"
+  | "freight_currency_mismatch"
+  | "tax_region_missing"
+
+export type QuoteReadinessIssue = {
+  code: QuoteReadinessCode
+  severity: "blocking" | "warning"
+  /** Written for the partner staring at the wizard, not for a log. */
+  message: string
+  variant_id?: string | null
+  data?: Record<string, unknown>
+}
+
+export type QuoteReadinessResult = {
+  ready: boolean
+  issues: QuoteReadinessIssue[]
+  blocking_count: number
+  warning_count: number
+  /** What the preflight actually resolved, so the wizard can preview it. */
+  freight: {
+    chosen: { name: string | null; amount: number; currency_code: string } | null
+    total_weight_grams: number | null
+    error: string | null
+  }
+}
+
+export type QuoteReadinessInput = {
+  lines: Array<{ variant_id: string; quantity: number }>
+  store: {
+    id?: string | null
+    default_location_id?: string | null
+    default_sales_channel_id?: string | null
+  }
+  destination_country_code: string
+  destination_postal_code?: string | null
+  currency_code: string
+  region_id?: string | null
+  carrier?: string
+  /** How the partner is named back to the user in a catalogue mismatch. */
+  partner_label?: string
+  /**
+   * Whether catalogue ownership is checked. The partner surface is naturally
+   * scoped — a partner picks from their own catalogue — while an admin picks a
+   * partner from one dropdown and variants from another, and a single mis-click
+   * freezes one partner's prices onto another's customer group.
+   */
+  check_catalogue?: boolean
+}
+
+export async function assessQuoteReadiness(
+  scope: any,
+  input: QuoteReadinessInput
+): Promise<QuoteReadinessResult> {
+  const query: any = scope.resolve(ContainerRegistrationKeys.QUERY)
+  const issues: QuoteReadinessIssue[] = []
+
+  const lines = (input.lines ?? []).filter(
+    (l) => l?.variant_id && Number(l.quantity) > 0
+  )
+  const variantIds = Array.from(new Set(lines.map((l) => l.variant_id)))
+
+  // ---- The store can originate a shipment at all -------------------------
+  if (!input.store?.default_location_id) {
+    // `buildShippingEstimate` filters its location reads on this. Passing it
+    // undefined does not read "no locations" — `filters: { id: undefined }` is
+    // NO FILTER, which is how a public quote page once offered another
+    // tenant's "In Person Pickup" for a Mumbai delivery (#1433).
+    issues.push({
+      code: "store_location_missing",
+      severity: "blocking",
+      message:
+        "This store has no default stock location, so there is nowhere to ship from and freight cannot be quoted.",
+    })
+  }
+
+  if (input.check_catalogue && !input.store?.default_sales_channel_id) {
+    issues.push({
+      code: "store_sales_channel_missing",
+      severity: "blocking",
+      message: `${input.partner_label || "This partner"} has no default sales channel, so it cannot be verified that these variants belong to them.`,
+    })
+  }
+
+  // ---- The variants exist, belong here, and have a weight -----------------
+  const { data: variants = [] } = await query.graph({
+    entity: "variant",
+    fields: [
+      "id",
+      "title",
+      "weight",
+      "product.id",
+      "product.title",
+      "product.weight",
+      "product.sales_channels.id",
+    ],
+    filters: { id: variantIds },
+  })
+
+  const byId = new Map<string, any>((variants ?? []).map((v: any) => [v.id, v]))
+
+  for (const id of variantIds) {
+    const variant = byId.get(id)
+
+    if (!variant) {
+      issues.push({
+        code: "variant_missing",
+        severity: "blocking",
+        message: `Variant ${id} no longer exists, so it cannot be quoted.`,
+        variant_id: id,
+      })
+      continue
+    }
+
+    const label = variant.title
+      ? `${variant.product?.title ?? ""} ${variant.title}`.trim()
+      : id
+
+    if (input.check_catalogue && input.store?.default_sales_channel_id) {
+      const channels = (variant.product?.sales_channels ?? []) as any[]
+      if (
+        !channels.some((c) => c?.id === input.store.default_sales_channel_id)
+      ) {
+        issues.push({
+          code: "variant_not_in_catalogue",
+          severity: "blocking",
+          message: `"${label}" is not in ${input.partner_label || "this partner"}'s catalogue, so it cannot be quoted for them.`,
+          variant_id: id,
+        })
+      }
+    }
+
+    if (!resolveUnitWeight(variant)) {
+      // 140 of 183 variants are null at BOTH levels. Without a weight the
+      // freight leg is a guess, and a guessed landed total is the number a
+      // buyer commits to.
+      issues.push({
+        code: "weight_missing",
+        severity: "blocking",
+        message: `"${label}" has no weight on the variant or its product, so freight for it would be a guess.`,
+        variant_id: id,
+      })
+    }
+  }
+
+  // ---- Every line prices AT ITS OWN QUANTITY ------------------------------
+  for (const line of lines) {
+    if (!byId.has(line.variant_id)) continue
+
+    let unitAmount = NaN
+    try {
+      const { data: priced } = await query.graph({
+        entity: "variant",
+        fields: ["id", "calculated_price.*"],
+        filters: { id: line.variant_id },
+        context: {
+          calculated_price: QueryContext({
+            ...(input.region_id ? { region_id: input.region_id } : {}),
+            currency_code: input.currency_code,
+            // 🔴 The quantity IS the point: without it the pricing module
+            // answers with the qty-1 tier, and a "price at 500" rendered from a
+            // product payload is silently the price at 1.
+            quantity: line.quantity,
+          }),
+        },
+      })
+      unitAmount = Number(
+        (priced?.[0] as any)?.calculated_price?.calculated_amount
+      )
+    } catch {
+      unitAmount = NaN
+    }
+
+    if (!Number.isFinite(unitAmount)) {
+      // `planQuotePrices` DROPS a line with no amount rather than zeroing it —
+      // correct, but silent. A quote could mint showing more lines than it
+      // actually priced. This is where that becomes visible.
+      const label = byId.get(line.variant_id)?.title || line.variant_id
+      issues.push({
+        code: "line_unpriced",
+        severity: "blocking",
+        message: `"${label}" has no price in ${input.currency_code.toUpperCase()} at quantity ${line.quantity}, so it would be dropped from the quote.`,
+        variant_id: line.variant_id,
+        data: { quantity: line.quantity, currency_code: input.currency_code },
+      })
+    }
+  }
+
+  // ---- Freight actually resolves for this lane ---------------------------
+  let freight: QuoteReadinessResult["freight"] = {
+    chosen: null,
+    total_weight_grams: null,
+    error: null,
+  }
+
+  const canEstimate =
+    !issues.some(
+      (i) =>
+        i.severity === "blocking" &&
+        (i.code === "weight_missing" ||
+          i.code === "variant_missing" ||
+          i.code === "store_location_missing")
+    ) && lines.length > 0
+
+  if (canEstimate) {
+    try {
+      const estimate = await buildShippingEstimate(scope, {
+        lines: lines.map((l) => ({
+          variant_id: l.variant_id,
+          quantity: l.quantity,
+        })),
+        destination_postal_code: String(input.destination_postal_code ?? ""),
+        country_code: input.destination_country_code,
+        // Without this, manual options are compared across currencies and the
+        // cheapest NUMBER wins regardless of unit (#1424/#1434).
+        currency_code: input.currency_code,
+        carrier: input.carrier,
+        store: input.store as any,
+      })
+
+      const chosen = pickFreightOption(estimate)
+      freight = {
+        chosen: chosen
+          ? {
+              name: chosen.name ?? null,
+              amount: chosen.amount,
+              currency_code: chosen.currency_code,
+            }
+          : null,
+        total_weight_grams: estimate.total_weight_grams,
+        error: estimate.calculated_error,
+      }
+
+      if (!chosen) {
+        issues.push({
+          code: "no_freight_option",
+          severity: "blocking",
+          message: estimate.calculated_error
+            ? `No freight option could be quoted to ${input.destination_country_code.toUpperCase()}: ${estimate.calculated_error}`
+            : `No freight option could be quoted to ${input.destination_country_code.toUpperCase()} from this store's location.`,
+          data: { country_code: input.destination_country_code },
+        })
+      } else if (
+        String(chosen.currency_code).toLowerCase() !==
+        String(input.currency_code).toLowerCase()
+      ) {
+        // Should be impossible now the estimate is currency-filtered, but this
+        // is the exact defect that shipped twice (#1424, #1434) — a rate in one
+        // currency added straight into a total in another. Assert it at the
+        // boundary rather than trusting the layer below.
+        issues.push({
+          code: "freight_currency_mismatch",
+          severity: "blocking",
+          message: `The freight option resolved in ${chosen.currency_code.toUpperCase()} but this quote is in ${input.currency_code.toUpperCase()}.`,
+          data: {
+            freight_currency: chosen.currency_code,
+            quote_currency: input.currency_code,
+          },
+        })
+      }
+    } catch (e: any) {
+      issues.push({
+        code: "no_freight_option",
+        severity: "blocking",
+        message: `Freight could not be quoted for this lane: ${e?.message ?? String(e)}`,
+      })
+    }
+  }
+
+  // ---- Tax (warning until #1447 puts tax on the quote) --------------------
+  try {
+    const { data: taxRegions = [] } = await query.graph({
+      entity: "tax_region",
+      fields: ["id", "country_code"],
+      filters: { country_code: input.destination_country_code.toLowerCase() },
+    })
+    if (!taxRegions?.length) {
+      issues.push({
+        code: "tax_region_missing",
+        severity: "warning",
+        message: `No tax region is configured for ${input.destination_country_code.toUpperCase()}, so tax cannot be shown on this quote.`,
+        data: { country_code: input.destination_country_code },
+      })
+    }
+  } catch {
+    // A tax lookup failing must not block a mint today — tax is not on the
+    // quote yet. Silence here is the correct scope, not an oversight.
+  }
+
+  const blocking = issues.filter((i) => i.severity === "blocking")
+
+  return {
+    ready: blocking.length === 0,
+    issues,
+    blocking_count: blocking.length,
+    warning_count: issues.length - blocking.length,
+    freight,
+  }
+}

--- a/apps/backend/src/workflows/partner-quote/mint-quote.ts
+++ b/apps/backend/src/workflows/partner-quote/mint-quote.ts
@@ -18,6 +18,7 @@ import {
 
 import { PARTNER_QUOTE_MODULE } from "../../modules/partner-quote"
 import { buildQuoteView } from "../../modules/partner-quote/lib/build-quote-view"
+import { assessQuoteReadiness } from "../../modules/partner-quote/lib/quote-readiness"
 import {
   generateQuoteToken,
   quoteExpiryFrom,
@@ -173,6 +174,51 @@ const resolveQuoteBuyerStep = createStep(
         .deleteCustomers([undo.createdCustomerId])
         .catch(() => {})
     }
+  }
+)
+
+/**
+ * Refuse to quote what cannot be shipped or priced (#1445).
+ *
+ * Every wrong number this feature produced was minted SUCCESSFULLY — a
+ * zone-blind freight pick, a rupee rate in a euro total, a rule-bound zero
+ * that shipped bulk free. In each case the mint returned 201 and nobody knew.
+ * This is the gate that turns those into a refusal.
+ *
+ * 🔑 It reports EVERY blocking failure at once, not the first. A partner
+ * fixing a quote one error at a time plays whack-a-mole across five round
+ * trips; the wizards call the same assessor up front so the mint button is
+ * only live when it would produce a number worth acting on.
+ *
+ * ⚠️ `check_catalogue` is false here. The workflow's `store` input carries the
+ * location but not the sales channel, and the admin route already runs
+ * `assertVariantsInStore` with the channel it fetched. Checking with a missing
+ * channel would either refuse every quote or — worse — silently pass. The
+ * readiness ENDPOINTS do the catalogue half, where the channel is in hand.
+ */
+const validateQuoteReadinessStep = createStep(
+  "validate-quote-readiness-step",
+  async (input: MintQuoteInput, { container }) => {
+    const readiness = await assessQuoteReadiness(container, {
+      lines: input.lines,
+      store: input.store,
+      destination_country_code: input.destination_country_code,
+      destination_postal_code: input.destination_postal_code,
+      currency_code: input.currency_code,
+      region_id: input.region_id,
+      carrier: input.carrier,
+      check_catalogue: false,
+    })
+
+    if (!readiness.ready) {
+      const blocking = readiness.issues.filter((i) => i.severity === "blocking")
+      throw new MedusaError(
+        MedusaError.Types.INVALID_DATA,
+        `This quote cannot be minted:\n${blocking.map((i) => `• ${i.message}`).join("\n")}`
+      )
+    }
+
+    return new StepResponse(readiness)
   }
 )
 
@@ -553,6 +599,10 @@ export const mintQuoteWorkflow = createWorkflow(
   "mint-partner-quote",
   (input: MintQuoteInput) => {
     const timing = prepareTimingStep(input)
+
+    // Before anything is created. A readiness failure must cost nothing —
+    // no customer, no group, no price list, nothing to compensate.
+    validateQuoteReadinessStep(input)
 
     const buyer = resolveQuoteBuyerStep(input)
     const view = buildAndFreezeStep({ mint: input, now: timing.now } as any)

--- a/apps/partner-ui/src/hooks/api/partner-quotes.tsx
+++ b/apps/partner-ui/src/hooks/api/partner-quotes.tsx
@@ -213,3 +213,64 @@ export const useMintPartnerQuote = (
     ...options,
   })
 }
+
+/** One named reason a basket cannot be quoted (#1445). */
+export type QuoteReadinessIssue = {
+  code: string
+  severity: "blocking" | "warning"
+  /** Written for the partner looking at the wizard, not for a log. */
+  message: string
+  variant_id?: string | null
+  data?: Record<string, unknown>
+}
+
+export type QuoteReadiness = {
+  ready: boolean
+  issues: QuoteReadinessIssue[]
+  blocking_count: number
+  warning_count: number
+  freight: {
+    chosen: { name: string | null; amount: number; currency_code: string } | null
+    total_weight_grams: number | null
+    error: string | null
+  }
+}
+
+export type QuoteReadinessPayload = {
+  lines: Array<{ variant_id: string; quantity: number }>
+  destination_country_code: string
+  destination_postal_code?: string | null
+  destination_city?: string | null
+  currency_code: string
+  region_id?: string | null
+  carrier?: string
+}
+
+/**
+ * The mint preflight (#1445).
+ *
+ * 🔴 A mutation rather than a query even though it writes nothing: the input is
+ * a whole basket, so it is POSTed, and it must run on demand when the partner
+ * reaches the last step — not on every keystroke of a quantity field, which is
+ * what a `useQuery` keyed on the form state would do. It prices every line and
+ * asks a carrier; that is not a thing to fire per render.
+ *
+ * The mint runs the same assessor server-side, so skipping this changes what
+ * the partner SEES, never what the platform accepts.
+ */
+export const useQuoteReadiness = (
+  options?: UseMutationOptions<
+    { readiness: QuoteReadiness },
+    FetchError,
+    QuoteReadinessPayload
+  >
+) => {
+  return useMutation({
+    mutationFn: async (payload) =>
+      await sdk.client.fetch<{ readiness: QuoteReadiness }>(
+        "/partners/quotes/readiness",
+        { method: "POST", body: payload }
+      ),
+    ...options,
+  })
+}

--- a/apps/partner-ui/src/routes/orders/quote-create/components/quote-create-form/quote-create-form.tsx
+++ b/apps/partner-ui/src/routes/orders/quote-create/components/quote-create-form/quote-create-form.tsx
@@ -13,12 +13,15 @@ import { KeyboundForm } from "../../../../../components/utilities/keybound-form"
 import { useDocumentDirection } from "../../../../../hooks/use-document-direction"
 import {
   MintPartnerQuoteResponse,
+  QuoteReadiness,
   useMintPartnerQuote,
+  useQuoteReadiness,
 } from "../../../../../hooks/api/partner-quotes"
 import { QuoteBuyerForm } from "./quote-buyer-form"
 import { QuoteMintedPanel } from "./quote-minted-panel"
 import { QuoteProductsForm } from "./quote-products-form"
 import { QuoteQuantitiesForm } from "./quote-quantities-form"
+import { QuoteReadinessPanel } from "./quote-readiness-panel"
 import {
   QuoteBuyerFields,
   QuoteBuyerSchema,
@@ -87,6 +90,16 @@ export const QuoteCreateForm = ({
 
   const { mutateAsync, isPending } = useMintPartnerQuote()
 
+  /**
+   * #1445 — the preflight. Run on submit rather than on every quantity change:
+   * it prices every line and asks a carrier, which is not a thing to fire per
+   * keystroke. The mint runs the same assessor server-side, so this changes
+   * what the partner SEES, never what the platform accepts.
+   */
+  const { mutateAsync: checkReadiness, isPending: isChecking } =
+    useQuoteReadiness()
+  const [readiness, setReadiness] = useState<QuoteReadiness | null>(null)
+
   const handleSubmit = form.handleSubmit(async (data) => {
     /**
      * A blank or zero quantity means "not in this basket" — it is dropped, not
@@ -107,6 +120,42 @@ export const QuoteCreateForm = ({
         t(
           "quotes.create.noLines",
           "Set a quantity on at least one variant — a quote with no lines has nothing to price."
+        )
+      )
+      setTab(Tab.QUANTITY)
+      return
+    }
+
+    // Preflight before anything is created. A basket that cannot be shipped or
+    // priced is refused HERE, with every reason named at once, rather than
+    // minting a confident wrong number the way #1424/#1430/#1434 all did.
+    let assessed: QuoteReadiness | null = null
+    try {
+      const result = await checkReadiness({
+        lines: lines.map((l) => ({
+          variant_id: l.variant_id,
+          quantity: l.quantity,
+        })),
+        destination_country_code: data.destination_country_code,
+        destination_postal_code: data.destination_postal_code || null,
+        destination_city: data.destination_city || null,
+        currency_code: data.currency_code,
+      })
+      assessed = result.readiness
+      setReadiness(result.readiness)
+    } catch {
+      // 🔑 A preflight that cannot run must not block the mint. The workflow
+      // runs the same assessor as its first step, so the real gate is still
+      // there — failing closed here would turn an unrelated network blip into
+      // "you cannot quote".
+      setReadiness(null)
+    }
+
+    if (assessed && !assessed.ready) {
+      toast.error(
+        t(
+          "quotes.create.readiness.blockedToast",
+          "This quote cannot be minted yet — see the reasons above."
         )
       )
       setTab(Tab.QUANTITY)
@@ -277,7 +326,14 @@ export const QuoteCreateForm = ({
               className="size-full overflow-hidden"
               value={Tab.QUANTITY}
             >
-              <QuoteQuantitiesForm form={form} />
+              <div className="flex h-full flex-col overflow-y-auto">
+                {readiness && (
+                  <div className="px-6 pt-4 md:px-16">
+                    <QuoteReadinessPanel readiness={readiness} />
+                  </div>
+                )}
+                <QuoteQuantitiesForm form={form} />
+              </div>
             </ProgressTabs.Content>
           </RouteFocusModal.Body>
           <RouteFocusModal.Footer>
@@ -293,7 +349,7 @@ export const QuoteCreateForm = ({
                   type="submit"
                   variant="primary"
                   size="small"
-                  isLoading={isPending}
+                  isLoading={isPending || isChecking}
                 >
                   {t("quotes.create.mint", "Mint quote")}
                 </Button>

--- a/apps/partner-ui/src/routes/orders/quote-create/components/quote-create-form/quote-readiness-panel.tsx
+++ b/apps/partner-ui/src/routes/orders/quote-create/components/quote-create-form/quote-readiness-panel.tsx
@@ -1,0 +1,102 @@
+import { Alert, Badge, Text } from "@medusajs/ui"
+import { useTranslation } from "react-i18next"
+
+import type { QuoteReadiness } from "../../../../../hooks/api/partner-quotes"
+
+/**
+ * What the mint would refuse, before the partner presses it (#1445).
+ *
+ * Every wrong number this feature produced was minted SUCCESSFULLY — a
+ * zone-blind freight pick, a rupee rate in a euro total, a rule-bound zero
+ * that shipped bulk free. The partner had no signal at all. This is that
+ * signal.
+ *
+ * 🔑 Renders EVERY blocking reason at once. The server assessor deliberately
+ * collects rather than throwing on the first, so that a partner fixes the
+ * whole basket in one pass instead of one error per round trip; showing only
+ * the first would throw that away at the last step.
+ *
+ * Warnings are shown but never block — a missing tax region means tax cannot
+ * be displayed yet (#1447), which is a gap in what we have shipped, not a
+ * reason to refuse a partner their quote.
+ */
+export const QuoteReadinessPanel = ({
+  readiness,
+}: {
+  readiness: QuoteReadiness
+}) => {
+  const { t } = useTranslation()
+
+  const blocking = readiness.issues.filter((i) => i.severity === "blocking")
+  const warnings = readiness.issues.filter((i) => i.severity !== "blocking")
+
+  if (readiness.ready && !warnings.length) {
+    return (
+      <Alert variant="success" className="mb-4">
+        <div className="flex flex-col gap-y-1">
+          <Text size="small" weight="plus">
+            {t("quotes.create.readiness.ok", "This quote is ready to mint.")}
+          </Text>
+          {readiness.freight.chosen && (
+            <Text size="small" className="text-ui-fg-subtle">
+              {t("quotes.create.readiness.freight", "Freight")}:{" "}
+              {readiness.freight.chosen.name ?? "—"} ·{" "}
+              {readiness.freight.chosen.amount}{" "}
+              {readiness.freight.chosen.currency_code.toUpperCase()}
+              {readiness.freight.total_weight_grams
+                ? ` · ${readiness.freight.total_weight_grams} g`
+                : ""}
+            </Text>
+          )}
+        </div>
+      </Alert>
+    )
+  }
+
+  return (
+    <div className="mb-4 flex flex-col gap-y-3">
+      {blocking.length > 0 && (
+        <Alert variant="error">
+          <div className="flex flex-col gap-y-2">
+            <Text size="small" weight="plus">
+              {t(
+                "quotes.create.readiness.blocked",
+                "This quote cannot be minted yet"
+              )}
+            </Text>
+            <ul className="flex flex-col gap-y-1">
+              {blocking.map((issue, i) => (
+                <li key={`${issue.code}-${i}`} className="flex gap-x-2">
+                  <Badge size="2xsmall" color="red">
+                    {issue.code}
+                  </Badge>
+                  <Text size="small">{issue.message}</Text>
+                </li>
+              ))}
+            </ul>
+          </div>
+        </Alert>
+      )}
+
+      {warnings.length > 0 && (
+        <Alert variant="warning">
+          <div className="flex flex-col gap-y-2">
+            <Text size="small" weight="plus">
+              {t("quotes.create.readiness.warnings", "Worth knowing")}
+            </Text>
+            <ul className="flex flex-col gap-y-1">
+              {warnings.map((issue, i) => (
+                <li key={`${issue.code}-${i}`} className="flex gap-x-2">
+                  <Badge size="2xsmall" color="orange">
+                    {issue.code}
+                  </Badge>
+                  <Text size="small">{issue.message}</Text>
+                </li>
+              ))}
+            </ul>
+          </div>
+        </Alert>
+      )}
+    </div>
+  )
+}


### PR DESCRIPTION
Closes #1445. Slice S6 of #1439 — the highest-value slice in the epic.

## Why

**Every wrong number this feature has produced was minted successfully.**

| | |
|---|---|
| #1416 | priced nothing |
| #1424 | quoted a Mumbai consignment as "European Shipping" at 10 AUD |
| #1430 | shipped every bulk order free |
| #1433 | offered another tenant's pickup option |
| #1434 | added a rupee rate into a euro total |

In each case the mint returned `201` and the partner had no way to know. The system had no way to say *"I don't know"*, so it said something confident and false.

## What `assessQuoteReadiness` checks

- the store has a **default stock location** — a missing one is not "no locations"; `filters: { id: undefined }` is **no filter**, which is how a public quote page once offered another tenant's "In Person Pickup" for a Mumbai delivery
- every variant exists, and on the admin surface belongs to the **named partner**
- every variant has a **weight** at variant or product level (140 of 183 are null at both, and without one the freight leg is a guess)
- every line prices **at its own quantity** — `planQuotePrices` drops an unpriced line rather than zeroing it, which is correct but silent, so a quote could mint showing more lines than it priced
- a **freight option actually resolves** for the lane, **in the quote's currency**

## Two design points that matter

**It collects every failure instead of throwing on the first.** `buildQuoteView` throws early — right for a render path, wrong for a preflight, where it makes a partner fix one error per round trip. There's a test asserting two missing variants are both reported.

**Weights are checked before the shipping estimate runs.** The estimate refuses the whole basket on the first weightless line — correctly, since a landed total missing one line's freight is a wrong number wearing a confident label — but it cannot say *which* variants to fix. Checking first turns "this basket cannot ship" into "these two variants have no weight".

## Scope discipline

A missing tax region is a **warning, not blocking**. Tax isn't on the quote yet (#1447), and refusing to mint for a capability we haven't shipped would be worse than the gap.

## Not advisory

The same assessor runs as the **first step of `mintQuoteWorkflow`**, before anything is created — so a readiness failure costs nothing and has nothing to compensate. A checklist a client can skip is not a gate; there's a test that the mint itself 400s on an unquotable basket.

## New endpoints

`POST /partners/quotes/readiness` and `POST /admin/quotes/readiness`. Both **write nothing** — that is the contract, since this is meant to be called speculatively and repeatedly before committing. POST rather than GET because the input is a whole basket.

Registered **before** `/partners/quotes/:id` so `readiness` is never matched as a quote id — with a test, because that collision would have made the endpoint silently absent.

These are also what #1452's `check_quote_readiness` MCP tool will call.

## Partner wizard

Runs the preflight on **submit**, not on every quantity change — the assessor prices each line and asks a carrier, which is not a thing to fire per keystroke.

🔑 **A preflight that cannot run does not block the mint.** Failing closed would turn a network blip into "you cannot quote", and the workflow step is the real gate either way.

The admin wizard gets the same panel when it is rebuilt as a stepped flow in #1444 — adding it to the current flat form would be thrown away.

## Verification

- 115 `partner-quote` unit tests pass
- Mint integration: **13 of 14**, including 5 new readiness tests. The one failure is #1459, red on `main` already.
- `check:prod-build` green, both apps typecheck clean

No migration.

🤖 Generated with [Claude Code](https://claude.com/claude-code)