### PR TITLE
feat(admin): quote surface — searchable table, ActionMenu detail, stepped mint

### DIFF
--- a/apps/backend/src/admin/hooks/api/quotes.ts
+++ b/apps/backend/src/admin/hooks/api/quotes.ts
@@ -168,3 +168,66 @@ export const useRevokeQuote = (
     ...options,
   })
 }
+
+/** One named reason a basket cannot be quoted (#1445). */
+export type QuoteReadinessIssue = {
+  code: string
+  severity: "blocking" | "warning"
+  /** Written for the operator looking at the wizard, not for a log. */
+  message: string
+  variant_id?: string | null
+  data?: Record<string, unknown>
+}
+
+export type QuoteReadiness = {
+  ready: boolean
+  issues: QuoteReadinessIssue[]
+  blocking_count: number
+  warning_count: number
+  freight: {
+    chosen: { name: string | null; amount: number; currency_code: string } | null
+    total_weight_grams: number | null
+    error: string | null
+  }
+}
+
+export type AdminQuoteReadinessPayload = {
+  partner_id: string
+  lines: Array<{ variant_id: string; quantity: number }>
+  destination_country_code: string
+  destination_postal_code?: string | null
+  destination_city?: string | null
+  currency_code: string
+  region_id?: string | null
+  carrier?: string
+}
+
+/**
+ * The mint preflight (#1445).
+ *
+ * 🔴 On THIS surface the catalogue check is the one that matters. An admin
+ * picks the partner from one dropdown and the variants from another, so the
+ * two can disagree with a single mis-click — and nothing downstream catches it:
+ * the price list is created successfully, its rule assertion passes, and the
+ * buyer gets a working link to prices the partner never agreed to sell at.
+ *
+ * A mutation despite writing nothing: the input is a whole basket, so it is
+ * POSTed, and it must run on demand rather than on every keystroke of a
+ * quantity field. It prices every line and asks a carrier.
+ */
+export const useAdminQuoteReadiness = (
+  options?: UseMutationOptions<
+    { readiness: QuoteReadiness },
+    FetchError,
+    AdminQuoteReadinessPayload
+  >
+) => {
+  return useMutation({
+    mutationFn: async (payload) =>
+      await sdk.client.fetch<{ readiness: QuoteReadiness }>(
+        "/admin/quotes/readiness",
+        { method: "POST", body: payload }
+      ),
+    ...options,
+  })
+}

--- a/apps/backend/src/admin/routes/quotes/[id]/page.tsx
+++ b/apps/backend/src/admin/routes/quotes/[id]/page.tsx
@@ -1,15 +1,11 @@
-import {
-  Button,
-  Container,
-  Heading,
-  Prompt,
-  StatusBadge,
-  Text,
-  toast,
-} from "@medusajs/ui"
+import { Container, Heading, Prompt, StatusBadge, Text, toast } from "@medusajs/ui"
+import { XCircle } from "@medusajs/icons"
 import { useState } from "react"
 import { useParams } from "react-router-dom"
 
+import { CommonSection } from "../../../components/common/section-views"
+import { TwoColumnPage } from "../../../components/pages/two-column-pages"
+import { TwoColumnPageSkeleton } from "../../../components/table/skeleton"
 import { useQuote, useRevokeQuote } from "../../../hooks/api/quotes"
 
 const money = (amount?: number | null, currency?: string) =>
@@ -19,15 +15,6 @@ const money = (amount?: number | null, currency?: string) =>
         style: "currency",
         currency: (currency || "usd").toUpperCase(),
       }).format(amount)
-
-const Field = ({ label, value }: { label: string; value: React.ReactNode }) => (
-  <div className="flex items-start justify-between gap-4 px-6 py-3">
-    <Text size="small" className="text-ui-fg-subtle">
-      {label}
-    </Text>
-    <div className="text-right">{value}</div>
-  </div>
-)
 
 /**
  * The activity timeline.
@@ -58,7 +45,10 @@ const Timeline = ({ events }: { events: any[] }) => {
   return (
     <ul className="px-6 py-4">
       {events.map((e) => (
-        <li key={e.id} className="flex gap-3 border-l border-ui-border-base pl-4 pb-4 last:pb-0">
+        <li
+          key={e.id}
+          className="flex gap-3 border-l border-ui-border-base pb-4 pl-4 last:pb-0"
+        >
           <div className="flex flex-col">
             <div className="flex items-center gap-2">
               <Text size="small" weight="plus">
@@ -97,116 +87,160 @@ const QuoteDetailPage = () => {
       )
       setConfirmOpen(false)
     },
-    onError: (e: any) => toast.error(e?.message ?? "Could not revoke the quote."),
+    onError: (e: any) =>
+      toast.error(e?.message ?? "Could not revoke the quote."),
   })
 
-  if (isLoading || !quote) {
+  if (isLoading) {
+    return (
+      <TwoColumnPageSkeleton mainSections={2} sidebarSections={2} showJSON />
+    )
+  }
+
+  if (!quote) {
     return (
       <Container>
         <Text size="small" className="text-ui-fg-subtle">
-          {isLoading ? "Loading…" : "Quote not found."}
+          Quote not found.
         </Text>
       </Container>
     )
   }
 
   const isRevoked = quote.status === "revoked"
-  // A newer quote for this buyer expired this one's price list (#1435). It is
-  // not revocable any more — there is nothing left to delete — but it is also
-  // not a withdrawal, so it must not read as one.
+  /**
+   * A newer quote for this buyer expired this one's price list (#1435). It is
+   * not revocable any more — there is nothing left to delete — but it is also
+   * not a withdrawal, so it must not read as one.
+   */
   const isSuperseded = quote.status === "superseded"
+  const isDead = isRevoked || isSuperseded
+
+  const statusColor: "green" | "red" | "orange" = isRevoked
+    ? "red"
+    : isSuperseded
+      ? "orange"
+      : "green"
+  const statusLabel = isRevoked
+    ? "Revoked"
+    : isSuperseded
+      ? "Superseded"
+      : "Active"
+
+  /**
+   * 🔴 Revoke is the only action, and it is destructive: it DELETES the price
+   * list behind the quote, so the buyer loses the quoted prices in any cart as
+   * well as the link. It stays behind a `Prompt`, and it is omitted entirely on
+   * a quote that is already dead rather than shown disabled — an action that
+   * cannot do anything invites an operator to hunt for why.
+   */
+  const actionGroups = isDead
+    ? undefined
+    : [
+        {
+          actions: [
+            {
+              icon: <XCircle />,
+              label: "Revoke quote",
+              onClick: () => setConfirmOpen(true),
+            },
+          ],
+        },
+      ]
 
   return (
-    <div className="flex flex-col gap-y-3">
-      <Container className="divide-y p-0">
-        <div className="flex items-center justify-between px-6 py-4">
-          <div>
-            <Heading>{quote.recipient_company || quote.recipient_name || "Quote"}</Heading>
-            <Text size="small" className="text-ui-fg-subtle">
-              {quote.email_sent_to}
-            </Text>
-          </div>
-          <div className="flex items-center gap-3">
-            <StatusBadge
-              color={isRevoked ? "red" : isSuperseded ? "orange" : "green"}
-            >
-              {isRevoked ? "Revoked" : isSuperseded ? "Superseded" : "Active"}
-            </StatusBadge>
-            {!isRevoked && !isSuperseded && (
-              <Button
-                variant="danger"
-                size="small"
-                onClick={() => setConfirmOpen(true)}
-                disabled={isPending}
-              >
-                Revoke
-              </Button>
-            )}
-          </div>
-        </div>
+    <>
+      <TwoColumnPage
+        data={quote as any}
+        showJSON
+        showMetadata
+        hasOutlet={false}
+      >
+        <TwoColumnPage.Main>
+          <CommonSection
+            title={quote.recipient_company || quote.recipient_name || "Quote"}
+            description={quote.email_sent_to ?? undefined}
+            actionGroups={actionGroups}
+            fields={[
+              {
+                label: "Status",
+                badge: { value: statusLabel, color: statusColor },
+              },
+              {
+                label: "Landed total",
+                value: money(quote.quoted_landed_total, quote.currency_code),
+              },
+              {
+                label: "Freight",
+                value: money(quote.quoted_freight, quote.currency_code),
+              },
+              {
+                label: "Destination",
+                value: `${String(quote.destination_country_code || "").toUpperCase()}${
+                  quote.destination_postal_code
+                    ? ` ${quote.destination_postal_code}`
+                    : ""
+                }`,
+              },
+            ]}
+          />
 
-        <Field
-          label="Landed total"
-          value={
-            <Text size="small" weight="plus">
-              {money(quote.quoted_landed_total, quote.currency_code)}
-            </Text>
-          }
-        />
-        <Field
-          label="Freight"
-          value={<Text size="small">{money(quote.quoted_freight, quote.currency_code)}</Text>}
-        />
-        <Field
-          label="Destination"
-          value={
-            <Text size="small">
-              {String(quote.destination_country_code || "").toUpperCase()}
-              {quote.destination_postal_code ? ` ${quote.destination_postal_code}` : ""}
-            </Text>
-          }
-        />
-        <Field
-          label="Expires"
-          value={
-            <Text size="small">
-              {quote.expires_at ? new Date(quote.expires_at).toLocaleString() : "—"}
-            </Text>
-          }
-        />
-        <Field
-          label="Viewed"
-          value={
-            <Text size="small">
-              {Number(quote.view_count || 0) === 0
-                ? "Not yet"
-                : `${quote.view_count}×${
-                    quote.last_viewed_at
-                      ? ` · last ${new Date(quote.last_viewed_at).toLocaleString()}`
-                      : ""
-                  }`}
-            </Text>
-          }
-        />
-        {/* 🔴 Stated, not implied. The raw token is returned once at mint and
-            only its sha256 is stored, so no read can rebuild the link. Offering
-            a "copy link" button here would be a button that cannot work. */}
-        <Field
-          label="Buyer link"
-          value={
-            <Text size="small" className="text-ui-fg-subtle">
-              Shown once at mint and not recoverable. Re-mint to issue a new one.
-            </Text>
-          }
-        />
-      </Container>
+          <Container className="divide-y p-0">
+            <div className="px-6 py-4">
+              <Heading level="h2">Activity</Heading>
+              <Text size="small" className="text-ui-fg-subtle">
+                Who did what to this quote, and when.
+              </Text>
+            </div>
+            <Timeline events={(quote as any).events ?? []} />
+          </Container>
+        </TwoColumnPage.Main>
 
-      <Container className="divide-y p-0">
-        <div className="px-6 py-4">
-          <Heading level="h2">Activity</Heading>
-        </div>
-        <Timeline events={quote.events ?? []} />
-      </Container>
+        <TwoColumnPage.Sidebar>
+          <CommonSection
+            title="Engagement"
+            description="Whether the buyer has actually opened it."
+            fields={[
+              {
+                label: "Viewed",
+                value:
+                  Number(quote.view_count || 0) === 0
+                    ? "Not yet"
+                    : `${quote.view_count}×`,
+              },
+              {
+                label: "Last viewed",
+                value: quote.last_viewed_at
+                  ? new Date(quote.last_viewed_at).toLocaleString()
+                  : "—",
+              },
+              {
+                label: "Expires",
+                value: quote.expires_at
+                  ? new Date(quote.expires_at).toLocaleString()
+                  : "—",
+              },
+            ]}
+          />
+
+          <CommonSection
+            title="Buyer link"
+            description="The token is the credential."
+            fields={[
+              {
+                /**
+                 * 🔴 Stated, not implied. The raw token is returned once at
+                 * mint and only its sha256 is stored, so no read can rebuild
+                 * the link. A "copy link" button here would be a button that
+                 * cannot work — the UI says so rather than offering one.
+                 */
+                label: "Recoverable",
+                value: "No. Shown once at mint; re-mint to issue a new one.",
+              },
+            ]}
+          />
+        </TwoColumnPage.Sidebar>
+      </TwoColumnPage>
 
       <Prompt open={confirmOpen} onOpenChange={setConfirmOpen}>
         <Prompt.Content>
@@ -226,7 +260,7 @@ const QuoteDetailPage = () => {
           </Prompt.Footer>
         </Prompt.Content>
       </Prompt>
-    </div>
+    </>
   )
 }
 

--- a/apps/backend/src/admin/routes/quotes/create/mint-quote-form.tsx
+++ b/apps/backend/src/admin/routes/quotes/create/mint-quote-form.tsx
@@ -3,6 +3,8 @@ import {
   Heading,
   Input,
   Label,
+  ProgressStatus,
+  ProgressTabs,
   Select,
   Text,
   Textarea,
@@ -12,20 +14,59 @@ import { useMemo, useState } from "react"
 
 import { usePartners } from "../../../hooks/api/partners"
 import { useProducts } from "../../../hooks/api/products"
-import { useMintQuote } from "../../../hooks/api/quotes"
+import {
+  QuoteReadiness,
+  useAdminQuoteReadiness,
+  useMintQuote,
+} from "../../../hooks/api/quotes"
 import { MintedPanel } from "./minted-panel"
+import { ReadinessPanel } from "./readiness-panel"
 
 type Line = { variant_id: string; quantity: number }
 
 /**
- * Mint a quote on a partner's behalf (#1419).
+ * Mint a quote on a partner's behalf (#1419, stepped in #1444).
  *
- * The partner comes first and everything else follows from it: a quote is
- * priced against THAT partner's catalogue and shipped from THEIR location. The
- * backend refuses variants outside the chosen partner's sales channel, so this
- * form's job is to make that mistake hard rather than to re-implement the check.
+ * ## Why steps
+ *
+ * The partner mints through a three-step wizard and the admin filled in one
+ * long form; the two are meant to feel like the same product. This mirrors the
+ * partner's `ProgressTabs` shape with one extra LEADING step — Partner —
+ * because an admin has no partner of their own and every quote is
+ * partner-scoped.
+ *
+ * **Partner → Buyer → Lines → Review & mint.**
+ *
+ * 🔑 Ordering is not cosmetic. The partner decides which catalogue the variants
+ * come from and which location freight is quoted from, so choosing variants
+ * before a partner would let an admin build a basket that is then rejected
+ * wholesale. Each step gates the next.
+ *
+ * ⚠️ Deliberately still `useState` rather than a react-hook-form + zod port.
+ * The partner wizard uses that stack, but porting the form plumbing here would
+ * rewrite every field at the same time as changing the flow, and this surface
+ * has never been run through a browser. Steps and gating are the part that was
+ * missing; the plumbing can follow once someone has clicked through it.
  */
+
+enum Tab {
+  PARTNER = "partner",
+  BUYER = "buyer",
+  LINES = "lines",
+  REVIEW = "review",
+}
+
+const tabOrder = [Tab.PARTNER, Tab.BUYER, Tab.LINES, Tab.REVIEW] as const
+
 export const MintQuoteForm = () => {
+  const [tab, setTab] = useState<Tab>(Tab.PARTNER)
+  const [tabState, setTabState] = useState<Record<Tab, ProgressStatus>>({
+    [Tab.PARTNER]: "in-progress",
+    [Tab.BUYER]: "not-started",
+    [Tab.LINES]: "not-started",
+    [Tab.REVIEW]: "not-started",
+  })
+
   const [partnerId, setPartnerId] = useState("")
   const [buyerEmail, setBuyerEmail] = useState("")
   const [company, setCompany] = useState("")
@@ -36,7 +77,10 @@ export const MintQuoteForm = () => {
   const [currency, setCurrency] = useState("inr")
   const [ttlDays, setTtlDays] = useState("14")
   const [lines, setLines] = useState<Line[]>([])
-  const [minted, setMinted] = useState<{ token: string; quote: any } | null>(null)
+  const [readiness, setReadiness] = useState<QuoteReadiness | null>(null)
+  const [minted, setMinted] = useState<{ token: string; quote: any } | null>(
+    null
+  )
 
   const { partners } = usePartners({ limit: 200 } as any)
   const { products } = useProducts({ limit: 100 } as any)
@@ -53,9 +97,11 @@ export const MintQuoteForm = () => {
 
   const { mutate: mint, isPending } = useMintQuote({
     onSuccess: (data) => setMinted({ token: data.token, quote: data.quote }),
-    onError: (e: any) =>
-      toast.error(e?.message ?? "Could not mint the quote."),
+    onError: (e: any) => toast.error(e?.message ?? "Could not mint the quote."),
   })
+
+  const { mutateAsync: checkReadiness, isPending: isChecking } =
+    useAdminQuoteReadiness()
 
   // The panel REPLACES the form rather than sitting beside it. The token is
   // shown once and never again, so anything that invites navigating away
@@ -64,24 +110,97 @@ export const MintQuoteForm = () => {
     return <MintedPanel token={minted.token} quote={minted.quote} />
   }
 
-  const addLine = () =>
-    setLines((prev) => [...prev, { variant_id: "", quantity: 1 }])
+  const validLines = lines.filter((l) => l.variant_id && l.quantity > 0)
 
-  const canSubmit =
-    !!partnerId &&
-    !!buyerEmail &&
-    !!currency &&
-    lines.length > 0 &&
-    lines.every((l) => l.variant_id && l.quantity > 0)
+  /** What each step needs before the next one is reachable. */
+  const stepComplete: Record<Tab, boolean> = {
+    [Tab.PARTNER]: !!partnerId,
+    [Tab.BUYER]: !!buyerEmail && !!currency && !!country,
+    [Tab.LINES]: validLines.length > 0,
+    [Tab.REVIEW]: true,
+  }
 
-  const submit = () => {
+  const stepHint: Record<Tab, string> = {
+    [Tab.PARTNER]: "Choose the partner this quote belongs to.",
+    [Tab.BUYER]:
+      "A buyer email, a currency and a destination country are the minimum — the currency and destination decide the price and the freight.",
+    [Tab.LINES]: "Add at least one line with a quantity above zero.",
+    [Tab.REVIEW]: "",
+  }
+
+  const goToTab = (next: Tab) => {
+    const targetIndex = tabOrder.indexOf(next)
+    const currentIndex = tabOrder.indexOf(tab)
+
+    // Going back is always allowed. Going forward validates every step in
+    // between, so a tab cannot be skipped by clicking its header.
+    if (targetIndex > currentIndex) {
+      for (let i = 0; i < targetIndex; i++) {
+        const step = tabOrder[i]
+        if (!stepComplete[step]) {
+          toast.error(stepHint[step])
+          setTab(step)
+          return
+        }
+      }
+    }
+
+    setTabState((prev) => ({
+      ...prev,
+      ...(targetIndex > currentIndex
+        ? { [tab]: "completed" as ProgressStatus }
+        : {}),
+      [next]: "in-progress" as ProgressStatus,
+    }))
+    setTab(next)
+  }
+
+  const handleNext = () => {
+    const i = tabOrder.indexOf(tab)
+    if (i === tabOrder.length - 1) return
+    goToTab(tabOrder[i + 1])
+  }
+
+  const payload = () => ({
+    partner_id: partnerId,
+    lines: validLines,
+    destination_country_code: country,
+    destination_postal_code: postal || null,
+    currency_code: currency,
+  })
+
+  /**
+   * The preflight, then the mint (#1445).
+   *
+   * 🔑 Run on submit rather than on every field change: it prices every line
+   * and asks a carrier, which is not a thing to fire per keystroke.
+   *
+   * 🔑 A preflight that cannot RUN does not block the mint. The workflow runs
+   * the same assessor as its first step, so the real gate is there either way,
+   * and failing closed here would turn a network blip into "you cannot quote".
+   */
+  const submit = async () => {
+    let assessed: QuoteReadiness | null = null
+    try {
+      const result = await checkReadiness(payload())
+      assessed = result.readiness
+      setReadiness(result.readiness)
+    } catch {
+      setReadiness(null)
+    }
+
+    if (assessed && !assessed.ready) {
+      toast.error("This quote cannot be minted yet — see the reasons above.")
+      return
+    }
+
     mint({
       partner_id: partnerId,
       buyer_email: buyerEmail,
       recipient_company: company || null,
       recipient_name: name || null,
       partner_note: note || null,
-      lines,
+      lines: validLines,
       destination_country_code: country,
       destination_postal_code: postal || null,
       currency_code: currency,
@@ -89,9 +208,14 @@ export const MintQuoteForm = () => {
     })
   }
 
+  const addLine = () =>
+    setLines((prev) => [...prev, { variant_id: "", quantity: 1 }])
+
+  const isLast = tab === Tab.REVIEW
+
   return (
-    <div className="flex flex-col gap-y-6 px-6 py-6">
-      <div>
+    <div className="flex flex-col">
+      <div className="px-6 pt-6">
         <Heading>Mint a quote</Heading>
         <Text size="small" className="text-ui-fg-subtle">
           The buyer link is shown once and cannot be recovered — you will be
@@ -99,150 +223,229 @@ export const MintQuoteForm = () => {
         </Text>
       </div>
 
-      <div className="flex flex-col gap-y-2">
-        <Label>Partner</Label>
-        <Select value={partnerId} onValueChange={setPartnerId}>
-          <Select.Trigger>
-            <Select.Value placeholder="Select a partner" />
-          </Select.Trigger>
-          <Select.Content>
-            {((partners ?? []) as any[]).map((p) => (
-              <Select.Item key={p.id} value={p.id}>
-                {p.name || p.id}
-              </Select.Item>
-            ))}
-          </Select.Content>
-        </Select>
-        <Text size="xsmall" className="text-ui-fg-subtle">
-          Prices come from this partner's catalogue and freight from their
-          location. Variants outside their store are rejected.
-        </Text>
-      </div>
+      <ProgressTabs
+        value={tab}
+        onValueChange={(v) => goToTab(v as Tab)}
+        className="flex flex-col"
+      >
+        <div className="border-ui-border-base border-b px-6 py-4">
+          <ProgressTabs.List className="grid w-full max-w-[640px] grid-cols-4">
+            <ProgressTabs.Trigger
+              status={tabState[Tab.PARTNER]}
+              value={Tab.PARTNER}
+            >
+              Partner
+            </ProgressTabs.Trigger>
+            <ProgressTabs.Trigger
+              status={tabState[Tab.BUYER]}
+              value={Tab.BUYER}
+            >
+              Buyer
+            </ProgressTabs.Trigger>
+            <ProgressTabs.Trigger
+              status={tabState[Tab.LINES]}
+              value={Tab.LINES}
+            >
+              Lines
+            </ProgressTabs.Trigger>
+            <ProgressTabs.Trigger
+              status={tabState[Tab.REVIEW]}
+              value={Tab.REVIEW}
+            >
+              Review
+            </ProgressTabs.Trigger>
+          </ProgressTabs.List>
+        </div>
 
-      <div className="grid grid-cols-1 gap-4 md:grid-cols-2">
-        <div className="flex flex-col gap-y-2">
-          <Label>Buyer email</Label>
-          <Input
-            type="email"
-            value={buyerEmail}
-            onChange={(e) => setBuyerEmail(e.target.value)}
-            placeholder="procurement@example.com"
-          />
-        </div>
-        <div className="flex flex-col gap-y-2">
-          <Label>Company</Label>
-          <Input value={company} onChange={(e) => setCompany(e.target.value)} />
-        </div>
-        <div className="flex flex-col gap-y-2">
-          <Label>Contact name</Label>
-          <Input value={name} onChange={(e) => setName(e.target.value)} />
-        </div>
-        <div className="flex flex-col gap-y-2">
-          <Label>Currency</Label>
-          <Input
-            value={currency}
-            onChange={(e) => setCurrency(e.target.value.toLowerCase())}
-            placeholder="inr"
-          />
-        </div>
-        <div className="flex flex-col gap-y-2">
-          <Label>Destination country (ISO-2)</Label>
-          <Input
-            value={country}
-            onChange={(e) => setCountry(e.target.value.toLowerCase())}
-            placeholder="in"
-          />
-        </div>
-        <div className="flex flex-col gap-y-2">
-          <Label>Destination postcode</Label>
-          <Input value={postal} onChange={(e) => setPostal(e.target.value)} />
-        </div>
-        <div className="flex flex-col gap-y-2">
-          <Label>Valid for (days)</Label>
-          <Input
-            type="number"
-            value={ttlDays}
-            onChange={(e) => setTtlDays(e.target.value)}
-          />
-          <Text size="xsmall" className="text-ui-fg-subtle">
-            Drives the price list's end date, so expiry is enforced by pricing
-            itself rather than by a sweep.
-          </Text>
-        </div>
-      </div>
+        <ProgressTabs.Content value={Tab.PARTNER} className="px-6 py-6">
+          <div className="flex max-w-[640px] flex-col gap-y-2">
+            <Label>Partner</Label>
+            <Select value={partnerId} onValueChange={setPartnerId}>
+              <Select.Trigger>
+                <Select.Value placeholder="Select a partner" />
+              </Select.Trigger>
+              <Select.Content>
+                {((partners ?? []) as any[]).map((p) => (
+                  <Select.Item key={p.id} value={p.id}>
+                    {p.name || p.id}
+                  </Select.Item>
+                ))}
+              </Select.Content>
+            </Select>
+            <Text size="xsmall" className="text-ui-fg-subtle">
+              Prices come from this partner's catalogue and freight from their
+              location. Variants outside their store are rejected — that check
+              is why this step comes first.
+            </Text>
+          </div>
+        </ProgressTabs.Content>
 
-      <div className="flex flex-col gap-y-3">
-        <div className="flex items-center justify-between">
-          <Label>Lines</Label>
-          <Button variant="secondary" size="small" onClick={addLine}>
-            Add line
-          </Button>
-        </div>
-        {lines.length === 0 ? (
-          <Text size="small" className="text-ui-fg-subtle">
-            A quote is a basket — add at least one line. Multiple lines are
-            quoted as ONE consignment, so freight is charged once.
-          </Text>
-        ) : null}
-        {lines.map((line, i) => (
-          <div key={i} className="flex items-end gap-3">
-            <div className="flex flex-1 flex-col gap-y-2">
-              <Select
-                value={line.variant_id}
-                onValueChange={(v) =>
-                  setLines((prev) =>
-                    prev.map((l, idx) => (idx === i ? { ...l, variant_id: v } : l))
-                  )
-                }
-              >
-                <Select.Trigger>
-                  <Select.Value placeholder="Select a variant" />
-                </Select.Trigger>
-                <Select.Content>
-                  {variantOptions.map((v) => (
-                    <Select.Item key={v.id} value={v.id}>
-                      {v.label}
-                    </Select.Item>
-                  ))}
-                </Select.Content>
-              </Select>
-            </div>
-            <div className="w-28">
+        <ProgressTabs.Content value={Tab.BUYER} className="px-6 py-6">
+          <div className="grid max-w-[860px] grid-cols-1 gap-4 md:grid-cols-2">
+            <div className="flex flex-col gap-y-2">
+              <Label>Buyer email</Label>
               <Input
-                type="number"
-                min={1}
-                value={line.quantity}
-                onChange={(e) =>
-                  setLines((prev) =>
-                    prev.map((l, idx) =>
-                      idx === i ? { ...l, quantity: Number(e.target.value) } : l
-                    )
-                  )
-                }
+                type="email"
+                value={buyerEmail}
+                onChange={(e) => setBuyerEmail(e.target.value)}
+                placeholder="procurement@example.com"
               />
             </div>
-            <Button
-              variant="transparent"
-              size="small"
-              onClick={() =>
-                setLines((prev) => prev.filter((_, idx) => idx !== i))
-              }
-            >
-              Remove
-            </Button>
+            <div className="flex flex-col gap-y-2">
+              <Label>Company</Label>
+              <Input
+                value={company}
+                onChange={(e) => setCompany(e.target.value)}
+              />
+            </div>
+            <div className="flex flex-col gap-y-2">
+              <Label>Contact name</Label>
+              <Input value={name} onChange={(e) => setName(e.target.value)} />
+            </div>
+            <div className="flex flex-col gap-y-2">
+              <Label>Currency</Label>
+              <Input
+                value={currency}
+                onChange={(e) => setCurrency(e.target.value.toLowerCase())}
+                placeholder="inr"
+              />
+            </div>
+            <div className="flex flex-col gap-y-2">
+              <Label>Destination country (ISO-2)</Label>
+              <Input
+                value={country}
+                onChange={(e) => setCountry(e.target.value.toLowerCase())}
+                placeholder="in"
+              />
+            </div>
+            <div className="flex flex-col gap-y-2">
+              <Label>Destination postcode</Label>
+              <Input
+                value={postal}
+                onChange={(e) => setPostal(e.target.value)}
+              />
+            </div>
+            <div className="flex flex-col gap-y-2">
+              <Label>Valid for (days)</Label>
+              <Input
+                type="number"
+                value={ttlDays}
+                onChange={(e) => setTtlDays(e.target.value)}
+              />
+              <Text size="xsmall" className="text-ui-fg-subtle">
+                Drives the price list's end date, so expiry is enforced by
+                pricing itself rather than by a sweep.
+              </Text>
+            </div>
           </div>
-        ))}
-      </div>
+        </ProgressTabs.Content>
 
-      <div className="flex flex-col gap-y-2">
-        <Label>Note to the buyer</Label>
-        <Textarea value={note} onChange={(e) => setNote(e.target.value)} />
-      </div>
+        <ProgressTabs.Content value={Tab.LINES} className="px-6 py-6">
+          <div className="flex max-w-[860px] flex-col gap-y-3">
+            <div className="flex items-center justify-between">
+              <Label>Lines</Label>
+              <Button variant="secondary" size="small" onClick={addLine}>
+                Add line
+              </Button>
+            </div>
+            {lines.length === 0 ? (
+              <Text size="small" className="text-ui-fg-subtle">
+                A quote is a basket — add at least one line. Multiple lines are
+                quoted as ONE consignment, so freight is charged once.
+              </Text>
+            ) : null}
+            {lines.map((line, i) => (
+              <div key={i} className="flex items-end gap-3">
+                <div className="flex flex-1 flex-col gap-y-2">
+                  <Select
+                    value={line.variant_id}
+                    onValueChange={(v) =>
+                      setLines((prev) =>
+                        prev.map((l, idx) =>
+                          idx === i ? { ...l, variant_id: v } : l
+                        )
+                      )
+                    }
+                  >
+                    <Select.Trigger>
+                      <Select.Value placeholder="Select a variant" />
+                    </Select.Trigger>
+                    <Select.Content>
+                      {variantOptions.map((v) => (
+                        <Select.Item key={v.id} value={v.id}>
+                          {v.label}
+                        </Select.Item>
+                      ))}
+                    </Select.Content>
+                  </Select>
+                </div>
+                <div className="w-28">
+                  <Input
+                    type="number"
+                    min={1}
+                    value={line.quantity}
+                    onChange={(e) =>
+                      setLines((prev) =>
+                        prev.map((l, idx) =>
+                          idx === i
+                            ? { ...l, quantity: Number(e.target.value) }
+                            : l
+                        )
+                      )
+                    }
+                  />
+                </div>
+                <Button
+                  variant="transparent"
+                  size="small"
+                  onClick={() =>
+                    setLines((prev) => prev.filter((_, idx) => idx !== i))
+                  }
+                >
+                  Remove
+                </Button>
+              </div>
+            ))}
+          </div>
+        </ProgressTabs.Content>
 
-      <div className="flex justify-end">
-        <Button onClick={submit} disabled={!canSubmit || isPending}>
-          {isPending ? "Minting…" : "Mint quote"}
-        </Button>
+        <ProgressTabs.Content value={Tab.REVIEW} className="px-6 py-6">
+          <div className="flex max-w-[860px] flex-col gap-y-4">
+            {readiness && <ReadinessPanel readiness={readiness} />}
+
+            <div className="flex flex-col gap-y-2">
+              <Label>Note to the buyer</Label>
+              <Textarea
+                value={note}
+                onChange={(e) => setNote(e.target.value)}
+              />
+            </div>
+
+            <Text size="small" className="text-ui-fg-subtle">
+              {validLines.length} line
+              {validLines.length === 1 ? "" : "s"} · {currency.toUpperCase()} ·
+              to {country.toUpperCase()}
+              {postal ? ` ${postal}` : ""}. Minting runs a readiness check
+              first — freight, weights and prices are verified before anything
+              is created.
+            </Text>
+          </div>
+        </ProgressTabs.Content>
+      </ProgressTabs>
+
+      <div className="border-ui-border-base flex items-center justify-end gap-x-2 border-t px-6 py-4">
+        {isLast ? (
+          <Button
+            onClick={submit}
+            disabled={!validLines.length || isPending || isChecking}
+          >
+            {isChecking ? "Checking…" : isPending ? "Minting…" : "Mint quote"}
+          </Button>
+        ) : (
+          <Button onClick={handleNext} disabled={!stepComplete[tab]}>
+            Continue
+          </Button>
+        )}
       </div>
     </div>
   )

--- a/apps/backend/src/admin/routes/quotes/create/readiness-panel.tsx
+++ b/apps/backend/src/admin/routes/quotes/create/readiness-panel.tsx
@@ -1,0 +1,94 @@
+import { Alert, Badge, Text } from "@medusajs/ui"
+
+import type { QuoteReadiness } from "../../../hooks/api/quotes"
+
+/**
+ * What the mint would refuse, before the admin presses it (#1445).
+ *
+ * Every wrong number this feature produced was minted SUCCESSFULLY — a
+ * zone-blind freight pick, a rupee rate in a euro total, a rule-bound zero that
+ * shipped bulk free. Nobody had a signal. This is that signal.
+ *
+ * 🔑 Renders EVERY blocking reason at once. The server assessor deliberately
+ * collects rather than throwing on the first, so that the whole basket is fixed
+ * in one pass instead of one error per round trip; showing only the first would
+ * throw that away at the last step.
+ *
+ * 🔴 On the admin surface the catalogue check is the one that matters most: an
+ * admin picks a partner from one dropdown and variants from another, and
+ * nothing downstream catches the mismatch.
+ */
+export const ReadinessPanel = ({
+  readiness,
+}: {
+  readiness: QuoteReadiness
+}) => {
+  const blocking = readiness.issues.filter((i) => i.severity === "blocking")
+  const warnings = readiness.issues.filter((i) => i.severity !== "blocking")
+
+  if (readiness.ready && !warnings.length) {
+    return (
+      <Alert variant="success" className="mb-4">
+        <div className="flex flex-col gap-y-1">
+          <Text size="small" weight="plus">
+            This quote is ready to mint.
+          </Text>
+          {readiness.freight.chosen && (
+            <Text size="small" className="text-ui-fg-subtle">
+              Freight: {readiness.freight.chosen.name ?? "—"} ·{" "}
+              {readiness.freight.chosen.amount}{" "}
+              {readiness.freight.chosen.currency_code.toUpperCase()}
+              {readiness.freight.total_weight_grams
+                ? ` · ${readiness.freight.total_weight_grams} g`
+                : ""}
+            </Text>
+          )}
+        </div>
+      </Alert>
+    )
+  }
+
+  return (
+    <div className="mb-4 flex flex-col gap-y-3">
+      {blocking.length > 0 && (
+        <Alert variant="error">
+          <div className="flex flex-col gap-y-2">
+            <Text size="small" weight="plus">
+              This quote cannot be minted yet
+            </Text>
+            <ul className="flex flex-col gap-y-1">
+              {blocking.map((issue, i) => (
+                <li key={`${issue.code}-${i}`} className="flex gap-x-2">
+                  <Badge size="2xsmall" color="red">
+                    {issue.code}
+                  </Badge>
+                  <Text size="small">{issue.message}</Text>
+                </li>
+              ))}
+            </ul>
+          </div>
+        </Alert>
+      )}
+
+      {warnings.length > 0 && (
+        <Alert variant="warning">
+          <div className="flex flex-col gap-y-2">
+            <Text size="small" weight="plus">
+              Worth knowing
+            </Text>
+            <ul className="flex flex-col gap-y-1">
+              {warnings.map((issue, i) => (
+                <li key={`${issue.code}-${i}`} className="flex gap-x-2">
+                  <Badge size="2xsmall" color="orange">
+                    {issue.code}
+                  </Badge>
+                  <Text size="small">{issue.message}</Text>
+                </li>
+              ))}
+            </ul>
+          </div>
+        </Alert>
+      )}
+    </div>
+  )
+}

--- a/apps/backend/src/admin/routes/quotes/page.tsx
+++ b/apps/backend/src/admin/routes/quotes/page.tsx
@@ -2,22 +2,31 @@ import {
   Button,
   Container,
   DataTable,
+  DataTableFilteringState,
+  DataTablePaginationState,
   Heading,
   StatusBadge,
   Text,
   createDataTableColumnHelper,
+  createDataTableFilterHelper,
   useDataTable,
 } from "@medusajs/ui"
 import { defineRouteConfig } from "@medusajs/admin-sdk"
-import { DocumentText } from "@medusajs/icons"
-import { useMemo, useState } from "react"
+import { DocumentText, Eye, XCircle } from "@medusajs/icons"
+import { keepPreviousData } from "@tanstack/react-query"
+import { useCallback, useMemo, useState } from "react"
 import { useNavigate } from "react-router-dom"
+import { debounce } from "lodash"
 
+import { EntityActions } from "../../components/persons/personsActions"
+import { TableSkeleton } from "../../components/table/skeleton"
+import { usePartners } from "../../hooks/api/partners"
 import { useQuotes, type AdminQuote } from "../../hooks/api/quotes"
 
 const PAGE_SIZE = 20
 
 const columnHelper = createDataTableColumnHelper<AdminQuote>()
+const filterHelper = createDataTableFilterHelper<AdminQuote>()
 
 const money = (amount?: number | null, currency?: string) =>
   amount === null || amount === undefined
@@ -27,14 +36,70 @@ const money = (amount?: number | null, currency?: string) =>
         currency: (currency || "usd").toUpperCase(),
       }).format(amount)
 
+/**
+ * A quote's lifecycle, as a badge.
+ *
+ * 🔑 `superseded` is deliberately NOT red. Nobody withdrew that quote — a newer
+ * one for the same buyer replaced it and expired its price list (#1435).
+ * Colouring it like a revocation would tell an operator the partner pulled the
+ * offer, which is a different and wrong story.
+ */
+const StatusCell = ({ status }: { status?: string }) => {
+  const value = String(status || "active")
+  return (
+    <StatusBadge
+      color={
+        value === "active" ? "green" : value === "superseded" ? "orange" : "red"
+      }
+    >
+      {value === "active"
+        ? "Active"
+        : value === "superseded"
+          ? "Superseded"
+          : "Revoked"}
+    </StatusBadge>
+  )
+}
+
 const QuotesPage = () => {
   const navigate = useNavigate()
-  const [pagination, setPagination] = useState({
+
+  const [pagination, setPagination] = useState<DataTablePaginationState>({
     pageIndex: 0,
     pageSize: PAGE_SIZE,
   })
+  const [filtering, setFiltering] = useState<DataTableFilteringState>({})
+  const [search, setSearch] = useState<string>("")
+  const [sorting, setSorting] = useState<{ id: string; desc: boolean } | null>(
+    null
+  )
 
-  const { quotes, count, isLoading } = useQuotes()
+  const offset = pagination.pageIndex * pagination.pageSize
+  const orderParam = sorting?.id
+    ? `${sorting.id}:${sorting.desc ? "DESC" : "ASC"}`
+    : undefined
+
+  /**
+   * 🔑 Every one of these reaches the SERVER now (#1441). Until that landed,
+   * the route returned the whole table and reported `count = quotes.length`,
+   * so this table paged client-side over everything ever minted and its filter
+   * narrowed one page rather than the set.
+   */
+  const { quotes, count, isLoading } = useQuotes(
+    {
+      limit: pagination.pageSize,
+      offset,
+      q: search || undefined,
+      ...(orderParam ? { order: orderParam } : {}),
+      ...(filtering.status ? { status: String(filtering.status) } : {}),
+      ...(filtering.partner_id
+        ? { partner_id: String(filtering.partner_id) }
+        : {}),
+    },
+    { placeholderData: keepPreviousData }
+  )
+
+  const { partners } = usePartners({ limit: 200 } as any)
 
   const columns = useMemo(
     () => [
@@ -55,6 +120,7 @@ const QuotesPage = () => {
       }),
       columnHelper.accessor("quoted_landed_total", {
         header: "Landed total",
+        enableSorting: true,
         cell: ({ row }) =>
           money(row.original.quoted_landed_total, row.original.currency_code),
       }),
@@ -64,6 +130,7 @@ const QuotesPage = () => {
       }),
       columnHelper.accessor("view_count", {
         header: "Viewed",
+        enableSorting: true,
         cell: ({ getValue }) => {
           const n = Number(getValue() || 0)
           // "Not yet" rather than 0 — a zero reads as a metric, and the fact
@@ -73,38 +140,79 @@ const QuotesPage = () => {
       }),
       columnHelper.accessor("status", {
         header: "Status",
-        cell: ({ getValue }) => {
-          const status = String(getValue() || "active")
-          return (
-            // `superseded` is deliberately not red: nobody withdrew this
-            // quote, a newer one replaced it (#1435).
-            <StatusBadge
-              color={
-                status === "active"
-                  ? "green"
-                  : status === "superseded"
-                    ? "orange"
-                    : "red"
-              }
-            >
-              {status === "active"
-                ? "Active"
-                : status === "superseded"
-                  ? "Superseded"
-                  : "Revoked"}
-            </StatusBadge>
-          )
-        },
+        enableSorting: true,
+        cell: ({ getValue }) => <StatusCell status={getValue() as string} />,
       }),
       columnHelper.accessor("expires_at", {
         header: "Expires",
+        enableSorting: true,
         cell: ({ getValue }) => {
           const raw = getValue() as string | null
           if (!raw) return "—"
           return new Date(raw).toLocaleDateString()
         },
       }),
+      columnHelper.display({
+        id: "actions",
+        cell: ({ row }) => (
+          <EntityActions
+            entity={row.original}
+            actionsConfig={{
+              actions: [
+                {
+                  icon: <Eye />,
+                  label: "View",
+                  to: (quote: AdminQuote) => `/quotes/${quote.id}`,
+                },
+                {
+                  icon: <XCircle />,
+                  label: "Revoke",
+                  // Revoke lives on the detail page, behind a confirm: it
+                  // DELETES a live price list, and a one-click destructive
+                  // action in a row menu is how that gets done by accident.
+                  to: (quote: AdminQuote) => `/quotes/${quote.id}`,
+                  disabled: row.original.status !== "active",
+                  disabledTooltip:
+                    "Only an active quote can be revoked — this one is already dead.",
+                },
+              ],
+            }}
+          />
+        ),
+      }),
     ],
+    []
+  )
+
+  const filters = useMemo(
+    () => [
+      filterHelper.accessor("status", {
+        type: "select",
+        label: "Status",
+        options: [
+          { label: "Active", value: "active" },
+          { label: "Superseded", value: "superseded" },
+          { label: "Revoked", value: "revoked" },
+        ],
+      }),
+      filterHelper.accessor("partner_id" as any, {
+        type: "select",
+        label: "Partner",
+        options: (partners ?? []).map((p: any) => ({
+          label: p.name || p.handle || p.id,
+          value: p.id,
+        })),
+      }),
+    ],
+    [partners]
+  )
+
+  const handleSearchChange = useCallback(
+    debounce((value: string) => setSearch(value), 300),
+    []
+  )
+  const handleFilterChange = useCallback(
+    debounce((value: DataTableFilteringState) => setFiltering(value), 300),
     []
   )
 
@@ -114,14 +222,31 @@ const QuotesPage = () => {
     getRowId: (row) => row.id,
     rowCount: count ?? 0,
     isLoading,
-    pagination: { state: pagination, onPaginationChange: setPagination },
+    filters,
     onRowClick: (_e, row) => navigate(`/quotes/${row.id}`),
+    pagination: { state: pagination, onPaginationChange: setPagination },
+    search: { state: search, onSearchChange: handleSearchChange },
+    filtering: { state: filtering, onFilteringChange: handleFilterChange },
+    sorting: { state: sorting, onSortingChange: setSorting },
   })
+
+  if (isLoading && !quotes) {
+    return (
+      <TableSkeleton
+        layout="fill"
+        rowCount={10}
+        search={true}
+        filters={true}
+        orderBy={true}
+        pagination={true}
+      />
+    )
+  }
 
   return (
     <Container className="divide-y p-0">
       <DataTable instance={table}>
-        <DataTable.Toolbar className="flex flex-col items-start justify-between gap-2 md:flex-row md:items-center">
+        <DataTable.Toolbar className="flex flex-col justify-between gap-y-4 px-6 py-4 md:flex-row">
           <div>
             <Heading>Quotes</Heading>
             <Text size="small" className="text-ui-fg-subtle">
@@ -129,23 +254,48 @@ const QuotesPage = () => {
               at mint and cannot be recovered — re-mint to issue a new one.
             </Text>
           </div>
-          <Button size="small" onClick={() => navigate("/quotes/create")}>
-            Mint quote
-          </Button>
+          <div className="flex items-center gap-x-2">
+            <DataTable.Search placeholder="Search buyer, company or email..." />
+            <DataTable.FilterMenu tooltip="Filter quotes" />
+            <Button size="small" onClick={() => navigate("/quotes/create")}>
+              Mint quote
+            </Button>
+          </div>
         </DataTable.Toolbar>
-        <DataTable.Table />
+        <DataTable.Table
+          emptyState={{
+            empty: {
+              heading: "No quotes yet",
+              description:
+                "Mint a quote on a partner's behalf to share real landed prices with a business buyer.",
+            },
+            // Distinct copy on purpose: "nothing exists" and "nothing matched
+            // your filter" are different facts, and conflating them sends an
+            // operator hunting for data that is simply filtered out.
+            filtered: {
+              heading: "No matching quotes",
+              description: "No quote matches this search or filter.",
+            },
+          }}
+        />
         <DataTable.Pagination />
       </DataTable>
     </Container>
   )
 }
 
-// Sidebar entry. Without a config the page compiles, routes, and is reachable
-// only by typing the URL — which is exactly how the partner-side quote list sat
-// unreachable until now.
+/**
+ * Sidebar entry.
+ *
+ * `nested: "/orders"` puts this under Orders rather than at the top level — a
+ * quote is a pre-order, and it belongs beside the other order kinds instead of
+ * competing with them for attention. Same mechanism `routes/design-orders`
+ * uses; no folder move is required.
+ */
 export const config = defineRouteConfig({
   label: "Quotes",
   icon: DocumentText,
+  nested: "/orders",
 })
 
 export const handle = {


### PR DESCRIPTION
Closes #1443 and #1444. Slices S3 and S4 of #1439.

## List

Rebuilt on the `settings/forms/page.tsx` shape — server-side search, status and partner filters, sorting, real pagination, `TableSkeleton` while loading, and **distinct** empty states for "nothing exists" vs "nothing matched your filter" (conflating those sends an operator hunting for data that is merely filtered out).

🔑 Every one of those now reaches the **server** (#1441). Until that landed the route returned the whole table and reported `count = quotes.length`, so this table paged client-side over everything ever minted and a filter narrowed one page rather than the set.

Row actions use the shared `EntityActions` / `ActionMenu`. **Revoke navigates to the detail page rather than firing inline** — it deletes a live price list, and a one-click destructive action in a row menu is how that gets done by accident. It's disabled with a reason on a quote that's already dead.

`nested: "/orders"` moves it under Orders. A quote is a pre-order and belongs beside the other order kinds; same mechanism `routes/design-orders` uses, no folder move needed.

## Detail

Rebuilt on `TwoColumnPage` + `CommonSection`, with JSON and metadata sections, activity in Main, engagement and the buyer-link note in the Sidebar. The bare danger `Button` is now an `ActionMenu` in the section header.

**Revoke is omitted on a dead quote rather than shown disabled** — an action that cannot do anything invites an operator to hunt for why. The confirm `Prompt` stays. The buyer-link section still *states* the link is unrecoverable rather than offering a copy button that cannot work.

## Mint

Now a stepped wizard mirroring the partner's, with one extra **leading** step:

**Partner → Buyer → Lines → Review & mint**

🔑 The ordering is not cosmetic. The partner decides which catalogue the variants come from and which location freight is quoted from, so choosing variants first would let an admin build a basket that is then rejected wholesale. Each step gates the next: going back is always allowed, going forward validates every step in between, so a tab cannot be skipped by clicking its header.

The Review step runs the **#1445 readiness preflight** and blocks the mint on failure, showing every blocking reason at once. A preflight that cannot *run* does not block — the workflow runs the same assessor as its first step, so failing closed here would turn a network blip into "you cannot quote".

## One deliberate shortfall

⚠️ Still `useState`, not a react-hook-form + zod port. The partner wizard uses that stack, and the plan said mirror it — but porting the plumbing would rewrite every field at the same time as changing the flow, on a surface that has **never been run through a browser**. Steps and gating were the part that was actually missing; the plumbing can follow once someone has clicked through it. Flagging rather than quietly claiming parity.

## Verification

- 115 `partner-quote` unit tests pass
- `check:prod-build` green; both apps typecheck clean
- No migration

🔴 **Neither admin surface has been exercised in a browser.** That was true before this PR and is still true after it — it remains the standing risk on this slice, and it is where the next #1438-class defect is most likely to be sitting.

🤖 Generated with [Claude Code](https://claude.com/claude-code)