### PR TITLE
feat(content): GrapeJS-style visual block editor — all 6 phases

### DIFF
--- a/apps/backend/integration-tests/http/partner-blocks-api.spec.ts
+++ b/apps/backend/integration-tests/http/partner-blocks-api.spec.ts
@@ -1,0 +1,356 @@
+import { getSharedTestEnv, setupSharedTestSuite } from "./shared-test-setup"
+import { createAdminUser, getAuthHeaders } from "../helpers/create-admin-user"
+
+const TEST_PARTNER_PASSWORD = "supersecret"
+
+jest.setTimeout(60 * 1000)
+
+async function createPartnerWithAuth(api: any) {
+  const unique = Date.now() + Math.random().toString(36).slice(2, 6)
+  const email = `partner-blocks-${unique}@medusa-test.com`
+
+  await api.post("/auth/partner/emailpass/register", {
+    email,
+    password: TEST_PARTNER_PASSWORD,
+  })
+
+  const login1 = await api.post("/auth/partner/emailpass", {
+    email,
+    password: TEST_PARTNER_PASSWORD,
+  })
+  let headers = { Authorization: `Bearer ${login1.data.token}` }
+
+  const createRes = await api.post(
+    "/partners",
+    {
+      name: `BlocksTest ${unique}`,
+      handle: `blocks-test-${unique}`,
+      admin: {
+        email,
+        first_name: "Blocks",
+        last_name: "Tester",
+      },
+    },
+    { headers }
+  )
+  const partnerId = createRes.data.partner.id
+
+  const login2 = await api.post("/auth/partner/emailpass", {
+    email,
+    password: TEST_PARTNER_PASSWORD,
+  })
+  headers = { Authorization: `Bearer ${login2.data.token}` }
+
+  return { partnerId, headers, email }
+}
+
+setupSharedTestSuite(() => {
+  const { api, getContainer } = getSharedTestEnv()
+
+  describe("Partner Storefront Blocks API", () => {
+    let adminHeaders: Record<string, any>
+    let partnerHeaders: Record<string, string>
+    let partnerId: string
+    let websiteId: string
+    let pageId: string
+
+    beforeEach(async () => {
+      await createAdminUser(getContainer())
+      adminHeaders = await getAuthHeaders(api)
+
+      // Create a partner
+      const partner = await createPartnerWithAuth(api)
+      partnerHeaders = partner.headers
+      partnerId = partner.partnerId
+
+      // Create a website via admin API
+      const domain = `blocks-test-${Date.now()}.jyt.test`
+      const websiteRes = await api.post(
+        "/admin/websites",
+        {
+          domain,
+          name: "Blocks Test Website",
+          status: "Active",
+          primary_language: "en",
+        },
+        adminHeaders
+      )
+      websiteId = websiteRes.data.website.id
+
+      // Create a page via admin API
+      const pageRes = await api.post(
+        `/admin/websites/${websiteId}/pages`,
+        {
+          title: "Test Page",
+          slug: "test-page",
+          content: "Test content",
+          page_type: "Custom",
+          status: "Published",
+        },
+        adminHeaders
+      )
+      pageId = pageRes.data.page.id
+
+      // Link the partner to the website by setting storefront_domain
+      const partnerModule = getContainer().resolve("partner")
+      await partnerModule.updatePartners({
+        id: partnerId,
+        storefront_domain: domain,
+        website_id: websiteId,
+      })
+    })
+
+    describe("GET /partners/storefront/pages/:pageId/blocks", () => {
+      it("should list blocks for a partner's page", async () => {
+        // Seed a block via admin API
+        await api.post(
+          `/admin/websites/${websiteId}/pages/${pageId}/blocks`,
+          {
+            blocks: [
+              {
+                name: "Hero",
+                type: "Hero",
+                content: { title: "Welcome" },
+                status: "Active",
+              },
+            ],
+          },
+          adminHeaders
+        )
+
+        const res = await api.get(
+          `/partners/storefront/pages/${pageId}/blocks`,
+          { headers: partnerHeaders }
+        )
+
+        expect(res.status).toBe(200)
+        expect(res.data.blocks).toHaveLength(1)
+        expect(res.data.blocks[0].type).toBe("Hero")
+      })
+    })
+
+    describe("POST /partners/storefront/pages/:pageId/blocks", () => {
+      it("should create a block via partner API", async () => {
+        const res = await api.post(
+          `/partners/storefront/pages/${pageId}/blocks`,
+          {
+            blocks: [
+              {
+                name: "Main Hero",
+                type: "Hero",
+                content: { title: "Welcome", subtitle: "To our site" },
+                status: "Active",
+                order: 0,
+              },
+            ],
+          },
+          { headers: partnerHeaders }
+        )
+
+        expect(res.status).toBe(201)
+        expect(res.data.blocks).toHaveLength(1)
+        expect(res.data.blocks[0].type).toBe("Hero")
+        expect(res.data.blocks[0].name).toBe("Main Hero")
+      })
+
+      it("should return friendly error for duplicate unique block type", async () => {
+        // Create a Hero block first
+        await api.post(
+          `/partners/storefront/pages/${pageId}/blocks`,
+          {
+            blocks: [
+              {
+                name: "First Hero",
+                type: "Hero",
+                content: { title: "Welcome" },
+                status: "Active",
+              },
+            ],
+          },
+          { headers: partnerHeaders }
+        )
+
+        // Try to create another Hero
+        const res = await api
+          .post(
+            `/partners/storefront/pages/${pageId}/blocks`,
+            {
+              blocks: [
+                {
+                  name: "Duplicate Hero",
+                  type: "Hero",
+                  content: { title: "Welcome again" },
+                  status: "Active",
+                },
+              ],
+            },
+            { headers: partnerHeaders }
+          )
+          .catch((e) => e.response)
+
+        expect(res.status).toBe(400)
+        expect(res.data.errors).toBeDefined()
+        expect(res.data.errors[0].error).toContain("Hero")
+        expect(res.data.errors[0].error).toContain("already exists")
+      })
+
+      it("should return 207 for partial batch with unique duplicate + valid repeatable", async () => {
+        // Create a Hero block first
+        await api.post(
+          `/partners/storefront/pages/${pageId}/blocks`,
+          {
+            blocks: [
+              {
+                name: "First Hero",
+                type: "Hero",
+                content: { title: "Welcome" },
+                status: "Active",
+              },
+            ],
+          },
+          { headers: partnerHeaders }
+        )
+
+        // Batch: duplicate Hero + valid Feature
+        const res = await api
+          .post(
+            `/partners/storefront/pages/${pageId}/blocks`,
+            {
+              blocks: [
+                {
+                  name: "Dup Hero",
+                  type: "Hero",
+                  content: { title: "Nope" },
+                  status: "Active",
+                },
+                {
+                  name: "Feature 1",
+                  type: "Feature",
+                  content: { title: "Feature" },
+                  status: "Active",
+                },
+              ],
+            },
+            { headers: partnerHeaders }
+          )
+          .catch((e) => e.response)
+
+        expect(res.status).toBe(207)
+        expect(res.data.blocks).toHaveLength(1)
+        expect(res.data.blocks[0].type).toBe("Feature")
+        expect(res.data.errors).toHaveLength(1)
+        expect(res.data.errors[0].error).toContain("Hero")
+      })
+
+      it("should allow multiple repeatable block types", async () => {
+        const res = await api.post(
+          `/partners/storefront/pages/${pageId}/blocks`,
+          {
+            blocks: [
+              {
+                name: "Gallery 1",
+                type: "Gallery",
+                content: { images: [] },
+                status: "Active",
+              },
+              {
+                name: "Gallery 2",
+                type: "Gallery",
+                content: { images: [] },
+                status: "Active",
+              },
+            ],
+          },
+          { headers: partnerHeaders }
+        )
+
+        expect(res.status).toBe(201)
+        expect(res.data.blocks).toHaveLength(2)
+      })
+    })
+
+    describe("PUT /partners/storefront/pages/:pageId/blocks/:blockId", () => {
+      let blockId: string
+
+      beforeEach(async () => {
+        const res = await api.post(
+          `/partners/storefront/pages/${pageId}/blocks`,
+          {
+            blocks: [
+              {
+                name: "Feature Block",
+                type: "Feature",
+                content: { title: "Original" },
+                status: "Active",
+              },
+            ],
+          },
+          { headers: partnerHeaders }
+        )
+        blockId = res.data.blocks[0].id
+      })
+
+      it("should update block content via partner API", async () => {
+        const res = await api.put(
+          `/partners/storefront/pages/${pageId}/blocks/${blockId}`,
+          {
+            content: { title: "Updated" },
+            name: "Updated Feature",
+          },
+          { headers: partnerHeaders }
+        )
+
+        expect(res.status).toBe(200)
+        expect(res.data.block.name).toBe("Updated Feature")
+        expect(res.data.block.content).toEqual({ title: "Updated" })
+      })
+
+      it("should update block order via partner API", async () => {
+        const res = await api.put(
+          `/partners/storefront/pages/${pageId}/blocks/${blockId}`,
+          { order: 5 },
+          { headers: partnerHeaders }
+        )
+
+        expect(res.status).toBe(200)
+        expect(res.data.block.order).toBe(5)
+      })
+    })
+
+    describe("DELETE /partners/storefront/pages/:pageId/blocks/:blockId", () => {
+      it("should delete block via partner API", async () => {
+        const createRes = await api.post(
+          `/partners/storefront/pages/${pageId}/blocks`,
+          {
+            blocks: [
+              {
+                name: "To Delete",
+                type: "Custom",
+                content: {},
+                status: "Active",
+              },
+            ],
+          },
+          { headers: partnerHeaders }
+        )
+        const blockId = createRes.data.blocks[0].id
+
+        const res = await api.delete(
+          `/partners/storefront/pages/${pageId}/blocks/${blockId}`,
+          { headers: partnerHeaders }
+        )
+
+        expect(res.status).toBe(200)
+
+        // Verify deleted
+        const getRes = await api
+          .get(
+            `/partners/storefront/pages/${pageId}/blocks`,
+            { headers: partnerHeaders }
+          )
+          .catch((e) => e.response)
+        expect(getRes.data.blocks.find((b: any) => b.id === blockId)).toBeUndefined()
+      })
+    })
+  })
+})

--- a/apps/backend/src/api/admin/websites/[id]/pages/[pageId]/blocks/validators.ts
+++ b/apps/backend/src/api/admin/websites/[id]/pages/[pageId]/blocks/validators.ts
@@ -21,6 +21,23 @@ export const BLOCK_TYPES = [
   "Custom",
 ] as const
 
+export const UNIQUE_BLOCKS = [
+  "Hero",
+  "Header",
+  "Footer",
+  "MainContent",
+  "ContactForm",
+] as const
+
+export const REPEATABLE_BLOCKS = [
+  "Feature",
+  "Gallery",
+  "Testimonial",
+  "Product",
+  "Section",
+  "Custom",
+] as const
+
 export const BLOCK_STATUSES = ["Active", "Inactive", "Draft"] as const
 
 const blockBaseSchema = z.object({

--- a/apps/backend/src/modules/website/models/blocks.ts
+++ b/apps/backend/src/modules/website/models/blocks.ts
@@ -24,7 +24,7 @@ const Block = model.define("block", {
   type: model.enum([
     ...UNIQUE_BLOCKS,
     ...REPEATABLE_BLOCKS
-  ]).default("Content"),
+  ]).default("Custom"),
   content: model.json(), // Flexible JSON structure for different block types
   settings: model.json().nullable(), // Block-specific settings (e.g., layout, styling)
   order: model.number().default(0), // For arranging blocks in order

--- a/apps/backend/src/workflows/website/page-blocks/create-batch-blocks.ts
+++ b/apps/backend/src/workflows/website/page-blocks/create-batch-blocks.ts
@@ -10,6 +10,14 @@ import WebsiteService from "../../../modules/website/service";
 
 import { CreateBlockStepInput } from "./create-block";
 
+const UNIQUE_BLOCK_TYPES = [
+  "Hero",
+  "Header",
+  "Footer",
+  "MainContent",
+  "ContactForm",
+];
+
 type Block = {
   id: string;
   name: string;
@@ -55,15 +63,42 @@ export const createBatchBlocksStep = createStep(
           continue;
         }
 
+        // Fetch existing blocks for this page so we can pre-check unique types
+        const [existingBlocks] = await websiteService.listAndCountBlocks({
+          page_id: pageId,
+        });
+        const existingUniqueTypes = new Set(
+          (existingBlocks || [])
+            .filter((b: any) =>
+              UNIQUE_BLOCK_TYPES.includes(b.type)
+            )
+            .map((b: any) => b.type)
+        );
+
         // Process each block for this page
         for (const block of blocks) {
+          // Pre-check: reject duplicate unique block types with a friendly message
+          if (
+            UNIQUE_BLOCK_TYPES.includes(block.type) &&
+            existingUniqueTypes.has(block.type)
+          ) {
+            errors.push({
+              type: block.type,
+              page_id: pageId,
+              error: `A ${block.type} block already exists on this page. Only one ${block.type} is allowed per page.`
+            });
+            continue;
+          }
+
           try {
-            // Create the block - any uniqueness violations will be caught by database constraints
             const newBlock = await websiteService.createBlocks({
               ...block
             });
 
             createdBlocks.push(newBlock);
+            if (UNIQUE_BLOCK_TYPES.includes(block.type)) {
+              existingUniqueTypes.add(block.type);
+            }
           } catch (error) {
             errors.push({
               type: block.type,

--- a/apps/partner-ui/src/components/block-editor/block-editor.tsx
+++ b/apps/partner-ui/src/components/block-editor/block-editor.tsx
@@ -1,14 +1,19 @@
 import { useCallback, useState } from "react"
-import { Text, Button, IconButton, Tooltip, Select } from "@medusajs/ui"
-import { Trash, Plus, Images } from "@medusajs/icons"
+import { Text, Button, IconButton, Tooltip, Select, Badge, Label } from "@medusajs/ui"
+import { Trash, Plus, Images, ChevronDown, ChevronRight, CursorArrowRays, ArrowUpMini, ArrowDownMini } from "@medusajs/icons"
 import { ContentBlock } from "../../hooks/api/content"
 import { TipTapEditor } from "../tiptap-editor/tiptap-editor"
 
 
 type BlockEditorProps = {
-  block: ContentBlock 
+  block: ContentBlock
   onUpdate: (blockId: string, updates: Partial<ContentBlock>) => void
   onDelete: (blockId: string) => void
+  onDuplicate?: (blockId: string) => void
+  onMoveUp?: (blockId: string) => void
+  onMoveDown?: (blockId: string) => void
+  canMoveUp?: boolean
+  canMoveDown?: boolean
   saveStatus: "saved" | "saving" | "unsaved"
 }
 
@@ -83,6 +88,11 @@ export const BlockEditor = ({
   block,
   onUpdate,
   onDelete,
+  onDuplicate,
+  onMoveUp,
+  onMoveDown,
+  canMoveUp = true,
+  canMoveDown = true,
   saveStatus,
 }: BlockEditorProps) => {
   const updateContent = useCallback(
@@ -105,6 +115,11 @@ export const BlockEditor = ({
 
   const type = block.type
   const content = block.content || {}
+  const [advancedOpen, setAdvancedOpen] = useState(false)
+
+  const REPEATABLE_TYPES = new Set([
+    "Feature", "Gallery", "Testimonial", "Product", "Section", "Custom",
+  ])
 
   const renderTypeSpecificEditor = () => {
     switch (type) {
@@ -408,11 +423,22 @@ export const BlockEditor = ({
 
   return (
     <div className="w-[340px] border-l border-ui-border-base overflow-y-auto bg-ui-bg-base p-4 shrink-0">
+      {/* Header: type badge + save status + actions */}
       <div className="flex items-center justify-between mb-4">
-        <Text size="small" className="font-semibold">
-          {block.type} Block
-        </Text>
         <div className="flex items-center gap-x-2">
+          <Badge
+            color={
+              block.status === "Active" ? "green" : block.status === "Draft" ? "orange" : "grey"
+            }
+            size="2xsmall"
+          >
+            {block.type}
+          </Badge>
+          <Text size="small" className="font-semibold">
+            {block.name || block.type}
+          </Text>
+        </div>
+        <div className="flex items-center gap-x-1">
           <Text
             size="xsmall"
             className={
@@ -423,22 +449,49 @@ export const BlockEditor = ({
                   : "text-ui-fg-error"
             }
           >
-            {saveStatus === "saved"
-              ? "Saved"
-              : saveStatus === "saving"
-                ? "Saving..."
-                : "Unsaved"}
+            {saveStatus === "saved" ? "Saved" : saveStatus === "saving" ? "Saving..." : "Unsaved"}
           </Text>
-          <Tooltip content="Delete block">
-            <IconButton
-              variant="transparent"
-              size="small"
-              onClick={() => onDelete(block.id)}
-            >
-              <Trash />
+        </div>
+      </div>
+
+      {/* Quick actions */}
+      <div className="flex items-center gap-x-1 mb-4 pb-3 border-b border-ui-border-base">
+        {onMoveUp && (
+          <Tooltip content="Move up">
+            <IconButton variant="transparent" size="small" disabled={!canMoveUp} onClick={() => onMoveUp(block.id)}>
+              <ArrowUpMini />
             </IconButton>
           </Tooltip>
-        </div>
+        )}
+        {onMoveDown && (
+          <Tooltip content="Move down">
+            <IconButton variant="transparent" size="small" disabled={!canMoveDown} onClick={() => onMoveDown(block.id)}>
+              <ArrowDownMini />
+            </IconButton>
+          </Tooltip>
+        )}
+        {onDuplicate && REPEATABLE_TYPES.has(block.type) && (
+          <Tooltip content="Duplicate block">
+            <IconButton variant="transparent" size="small" onClick={() => onDuplicate(block.id)}>
+              <Plus />
+            </IconButton>
+          </Tooltip>
+        )}
+        <div className="flex-1" />
+        <Tooltip content="Delete block">
+          <IconButton variant="transparent" size="small" onClick={() => onDelete(block.id)}>
+            <Trash />
+          </IconButton>
+        </Tooltip>
+      </div>
+
+      {/* Inline editing hint */}
+      <div className="flex items-center gap-x-2 mb-4 rounded-md bg-ui-bg-subtle p-2">
+        <CursorArrowRays className="text-ui-fg-muted opacity-50 w-4 h-4 shrink-0" />
+        <Text size="xsmall" className="text-ui-fg-subtle">
+          Click text on the canvas to edit it inline. Use this panel for
+          settings and complex fields.
+        </Text>
       </div>
 
       <div className="space-y-4">
@@ -469,49 +522,65 @@ export const BlockEditor = ({
 
         {renderTypeSpecificEditor()}
 
+        {/* Advanced settings (collapsible) */}
         <div className="pt-2 border-t border-ui-border-base">
-          <FieldLabel>Background Color</FieldLabel>
-          <div className="flex gap-x-2">
-            <input
-              className="flex-1 rounded-md border border-ui-border-base bg-ui-bg-field px-3 py-1.5 text-sm"
-              value={(block.settings?.backgroundColor as string) || ""}
-              placeholder="#ffffff"
-              onChange={(e) => updateSettings("backgroundColor", e.target.value)}
-            />
-            <input
-              type="color"
-              value={(block.settings?.backgroundColor as string) || "#ffffff"}
-              onChange={(e) => updateSettings("backgroundColor", e.target.value)}
-              className="w-9 h-9 rounded border border-ui-border-base cursor-pointer"
-            />
-          </div>
-        </div>
-
-        <div>
-          <FieldLabel>Padding (px)</FieldLabel>
-          <TextInput
-            value={(block.settings?.padding as string) || ""}
-            placeholder="0"
-            onChange={(v) => updateSettings("padding", v)}
-          />
-        </div>
-
-        <div>
-          <FieldLabel>Max Width</FieldLabel>
-          <Select
-            value={(block.settings?.max_width as string) || "default"}
-            onValueChange={(v) => updateSettings("max_width", v)}
+          <button
+            className="flex items-center gap-x-1 w-full text-left mb-2"
+            onClick={() => setAdvancedOpen((v) => !v)}
           >
-            <Select.Trigger>
-              <Select.Value placeholder="Default" />
-            </Select.Trigger>
-            <Select.Content>
-              <Select.Item value="default">Default</Select.Item>
-              <Select.Item value="narrow">Narrow</Select.Item>
-              <Select.Item value="wide">Wide</Select.Item>
-              <Select.Item value="full">Full Width</Select.Item>
-            </Select.Content>
-          </Select>
+            {advancedOpen ? <ChevronDown className="w-4 h-4 text-ui-fg-muted" /> : <ChevronRight className="w-4 h-4 text-ui-fg-muted" />}
+            <Text size="xsmall" className="text-ui-fg-muted font-semibold uppercase">
+              Advanced Settings
+            </Text>
+          </button>
+          {advancedOpen && (
+            <div className="space-y-3 pl-1">
+              <div>
+                <FieldLabel>Background Color</FieldLabel>
+                <div className="flex gap-x-2">
+                  <input
+                    className="flex-1 rounded-md border border-ui-border-base bg-ui-bg-field px-3 py-1.5 text-sm"
+                    value={(block.settings?.backgroundColor as string) || ""}
+                    placeholder="#ffffff"
+                    onChange={(e) => updateSettings("backgroundColor", e.target.value)}
+                  />
+                  <input
+                    type="color"
+                    value={(block.settings?.backgroundColor as string) || "#ffffff"}
+                    onChange={(e) => updateSettings("backgroundColor", e.target.value)}
+                    className="w-9 h-9 rounded border border-ui-border-base cursor-pointer"
+                  />
+                </div>
+              </div>
+
+              <div>
+                <FieldLabel>Padding (px)</FieldLabel>
+                <TextInput
+                  value={(block.settings?.padding as string) || ""}
+                  placeholder="0"
+                  onChange={(v) => updateSettings("padding", v)}
+                />
+              </div>
+
+              <div>
+                <FieldLabel>Max Width</FieldLabel>
+                <Select
+                  value={(block.settings?.max_width as string) || "default"}
+                  onValueChange={(v) => updateSettings("max_width", v)}
+                >
+                  <Select.Trigger>
+                    <Select.Value placeholder="Default" />
+                  </Select.Trigger>
+                  <Select.Content>
+                    <Select.Item value="default">Default</Select.Item>
+                    <Select.Item value="narrow">Narrow</Select.Item>
+                    <Select.Item value="wide">Wide</Select.Item>
+                    <Select.Item value="full">Full Width</Select.Item>
+                  </Select.Content>
+                </Select>
+              </div>
+            </div>
+          )}
         </div>
       </div>
     </div>

--- a/apps/partner-ui/src/hooks/api/content.ts
+++ b/apps/partner-ui/src/hooks/api/content.ts
@@ -245,6 +245,46 @@ export const useCreateContentBlock = (pageId: string) => {
   })
 }
 
+export const useUpdateContentBlock = (pageId: string) => {
+  return useMutation({
+    mutationFn: ({
+      blockId,
+      body,
+    }: {
+      blockId: string
+      body: Partial<ContentBlock>
+    }) =>
+      sdk.client.fetch<{ block: ContentBlock }>(
+        `/partners/storefront/pages/${pageId}/blocks/${blockId}`,
+        { method: "PUT", body }
+      ),
+    onSuccess: () => {
+      queryClient.invalidateQueries({
+        queryKey: contentQueryKeys.list({ type: "blocks", pageId }),
+      })
+    },
+  })
+}
+
+export const useReorderBlocks = (pageId: string) => {
+  return useMutation({
+    mutationFn: (orderedIds: string[]) =>
+      Promise.all(
+        orderedIds.map((blockId, idx) =>
+          sdk.client.fetch(
+            `/partners/storefront/pages/${pageId}/blocks/${blockId}`,
+            { method: "PUT", body: { order: idx } }
+          )
+        )
+      ),
+    onSuccess: () => {
+      queryClient.invalidateQueries({
+        queryKey: contentQueryKeys.list({ type: "blocks", pageId }),
+      })
+    },
+  })
+}
+
 export const useDeleteContentBlock = (pageId: string) => {
   return useMutation({
     mutationFn: (blockId: string) =>

--- a/apps/partner-ui/src/hooks/api/content.ts
+++ b/apps/partner-ui/src/hooks/api/content.ts
@@ -230,7 +230,10 @@ export const useCreateContentBlock = (pageId: string) => {
       order?: number
       status?: string
     }) =>
-      sdk.client.fetch<{ blocks: ContentBlock[] }>(
+      sdk.client.fetch<{
+        blocks: ContentBlock[]
+        errors?: Array<{ type: string; page_id: string; error: string }>
+      }>(
         `/partners/storefront/pages/${pageId}/blocks`,
         { method: "POST", body: { blocks: [payload] } }
       ),

--- a/apps/partner-ui/src/routes/content/content-detail/content-detail.tsx
+++ b/apps/partner-ui/src/routes/content/content-detail/content-detail.tsx
@@ -33,11 +33,12 @@ import {
   useUpdateContentPage,
   useDeleteContentPage,
   useCreateContentBlock,
+  useUpdateContentBlock,
+  useReorderBlocks,
   useDeleteContentBlock,
   ContentBlock,
 } from "../../../hooks/api/content"
 import { useStorefrontStatus } from "../../../hooks/api/storefront"
-import { sdk } from "../../../lib/client"
 import { FetchError } from "@medusajs/js-sdk"
 
 const BLOCK_TYPES = [
@@ -96,6 +97,8 @@ const ContentDetailInner = () => {
   const { mutateAsync: updatePage, isPending: isUpdatingPage } = useUpdateContentPage(pageId!)
   const { mutateAsync: deletePage } = useDeleteContentPage(pageId!)
   const { mutateAsync: createBlock, isPending: isCreatingBlock } = useCreateContentBlock(pageId!)
+  const { mutateAsync: updateBlock } = useUpdateContentBlock(pageId!)
+  const { mutateAsync: reorderBlocks } = useReorderBlocks(pageId!)
   const { mutateAsync: deleteBlock } = useDeleteContentBlock(pageId!)
 
   const [blocks, setBlocks] = useState<ContentBlock[]>([])
@@ -135,14 +138,10 @@ const ContentDetailInner = () => {
           )
         )
         setSaveStatus("saving")
-        sdk.client
-          .fetch(
-            `/partners/storefront/pages/${pageId}/blocks/${blockId}`,
-            {
-              method: "PUT",
-              body: { content: { [field]: value } },
-            }
-          )
+        updateBlock({
+          blockId,
+          body: { content: { [field]: value } },
+        })
           .then(() => setSaveStatus("saved"))
           .catch(() => setSaveStatus("unsaved"))
       }
@@ -155,14 +154,7 @@ const ContentDetailInner = () => {
           return reordered.map((b, idx) => ({ ...b, order: idx }))
         })
         setSaveStatus("saving")
-        Promise.all(
-          orderedIds.map((blockId, idx) =>
-            sdk.client.fetch(
-              `/partners/storefront/pages/${pageId}/blocks/${blockId}`,
-              { method: "PUT", body: { order: idx } }
-            )
-          )
-        )
+        reorderBlocks(orderedIds)
           .then(() => setSaveStatus("saved"))
           .catch(() => setSaveStatus("unsaved"))
         if (iframeRef.current) {
@@ -219,10 +211,7 @@ const ContentDetailInner = () => {
       }
 
       try {
-        await sdk.client.fetch(
-          `/partners/storefront/pages/${pageId}/blocks/${blockId}`,
-          { method: "PUT", body: updates }
-        )
+        await updateBlock({ blockId, body: updates })
         setSaveStatus("saved")
       } catch {
         setSaveStatus("unsaved")
@@ -524,13 +513,9 @@ const ContentDetailInner = () => {
                 if (idx <= 0) return
                 const reordered = [...blocks]
                 ;[reordered[idx - 1], reordered[idx]] = [reordered[idx], reordered[idx - 1]]
+                const orderedIds = reordered.map((b) => b.id)
                 setBlocks(reordered.map((b, i) => ({ ...b, order: i })))
-                reordered.forEach((b, i) => {
-                  sdk.client.fetch(
-                    `/partners/storefront/pages/${pageId}/blocks/${b.id}`,
-                    { method: "PUT", body: { order: i } }
-                  )
-                })
+                reorderBlocks(orderedIds)
                 if (iframeRef.current) {
                   setTimeout(() => {
                     if (iframeRef.current) iframeRef.current.src = iframeRef.current.src
@@ -542,13 +527,9 @@ const ContentDetailInner = () => {
                 if (idx < 0 || idx >= blocks.length - 1) return
                 const reordered = [...blocks]
                 ;[reordered[idx + 1], reordered[idx]] = [reordered[idx], reordered[idx + 1]]
+                const orderedIds = reordered.map((b) => b.id)
                 setBlocks(reordered.map((b, i) => ({ ...b, order: i })))
-                reordered.forEach((b, i) => {
-                  sdk.client.fetch(
-                    `/partners/storefront/pages/${pageId}/blocks/${b.id}`,
-                    { method: "PUT", body: { order: i } }
-                  )
-                })
+                reorderBlocks(orderedIds)
                 if (iframeRef.current) {
                   setTimeout(() => {
                     if (iframeRef.current) iframeRef.current.src = iframeRef.current.src

--- a/apps/partner-ui/src/routes/content/content-detail/content-detail.tsx
+++ b/apps/partner-ui/src/routes/content/content-detail/content-detail.tsx
@@ -38,6 +38,7 @@ import {
 } from "../../../hooks/api/content"
 import { useStorefrontStatus } from "../../../hooks/api/storefront"
 import { sdk } from "../../../lib/client"
+import { FetchError } from "@medusajs/js-sdk"
 
 const BLOCK_TYPES = [
   "Hero",
@@ -52,6 +53,14 @@ const BLOCK_TYPES = [
   "Footer",
   "Custom",
 ] as const
+
+const UNIQUE_BLOCK_TYPES = new Set([
+  "Hero",
+  "Header",
+  "Footer",
+  "MainContent",
+  "ContactForm",
+])
 
 const DEFAULT_CONTENT_FOR_TYPE: Record<string, Record<string, unknown>> = {
   Hero: { title: "New Hero", subtitle: "", align: "center" },
@@ -175,6 +184,12 @@ const ContentDetailInner = () => {
     [blocks, selectedBlockId, deleteBlock, initialBlocks]
   )
 
+  const usedUniqueTypes = new Set(
+    blocks
+      .filter((b) => UNIQUE_BLOCK_TYPES.has(b.type))
+      .map((b) => b.type)
+  )
+
   const handleAddBlock = useCallback(async () => {
     const name = newBlockName.trim() || newBlockType
     const maxOrder = blocks.reduce((max, b) => Math.max(max, b.order), -1)
@@ -194,8 +209,31 @@ const ContentDetailInner = () => {
       setAddBlockOpen(false)
       setNewBlockName("")
       toast.success(`Added "${name}" block`)
-    } catch {
-      toast.error("Failed to add block")
+      if (iframeRef.current) {
+        setTimeout(() => {
+          if (iframeRef.current) iframeRef.current.src = iframeRef.current.src
+        }, 300)
+      }
+    } catch (err: unknown) {
+      let msg = "Failed to add block"
+      if (err instanceof FetchError) {
+        try {
+          const body = (err as any).json ?? await err.json?.().catch(() => null)
+          const firstError = body?.errors?.[0]?.error
+          if (firstError && typeof firstError === "string") {
+            if (firstError.includes("unique") || firstError.includes("already exists")) {
+              msg = `A ${newBlockType} block already exists on this page. Only one ${newBlockType} is allowed per page.`
+            } else {
+              msg = firstError
+            }
+          } else if (typeof (err as any).message === "string" && (err as any).message.includes("unique")) {
+            msg = `A ${newBlockType} block already exists on this page. Only one ${newBlockType} is allowed per page.`
+          }
+        } catch {}
+      } else if (err instanceof Error && err.message) {
+        msg = err.message
+      }
+      toast.error(msg)
     }
   }, [newBlockName, newBlockType, blocks, createBlock])
 
@@ -331,7 +369,13 @@ const ContentDetailInner = () => {
               <Button
                 size="small"
                 variant="secondary"
-                onClick={() => setAddBlockOpen(true)}
+                onClick={() => {
+                  const available = BLOCK_TYPES.find(
+                    (t) => !usedUniqueTypes.has(t)
+                  )
+                  if (available) setNewBlockType(available)
+                  setAddBlockOpen(true)
+                }}
               >
                 <Plus className="mr-1" />Add
               </Button>
@@ -415,9 +459,19 @@ const ContentDetailInner = () => {
                 <Select.Value placeholder="Select block type" />
               </Select.Trigger>
               <Select.Content>
-                {BLOCK_TYPES.map((t) => (
-                  <Select.Item key={t} value={t}>{t}</Select.Item>
-                ))}
+                {BLOCK_TYPES.map((t) => {
+                  const alreadyUsed = usedUniqueTypes.has(t)
+                  return (
+                    <Select.Item
+                      key={t}
+                      value={t}
+                      disabled={alreadyUsed}
+                    >
+                      {t}
+                      {alreadyUsed && " (already added)"}
+                    </Select.Item>
+                  )
+                })}
               </Select.Content>
             </Select>
           </div>
@@ -429,6 +483,15 @@ const ContentDetailInner = () => {
               placeholder={`My ${newBlockType}`}
             />
           </div>
+          {UNIQUE_BLOCK_TYPES.has(newBlockType) && (
+            <div className="rounded-md bg-ui-bg-info p-3 border border-ui-border-base">
+              <Text size="xsmall" className="text-ui-fg-subtle">
+                <strong>{newBlockType}</strong> is a unique block type — only one
+                is allowed per page. Types like Feature, Gallery, Testimonial,
+                Product, Section, and Custom can be added multiple times.
+              </Text>
+            </div>
+          )}
           <div className="rounded-md bg-ui-bg-subtle p-3">
             <Text size="xsmall" className="text-ui-fg-muted">
               {newBlockType === "MainContent" && "Rich text content block with TipTap editor — perfect for page body text, headings, lists, and images."}

--- a/apps/partner-ui/src/routes/content/content-detail/content-detail.tsx
+++ b/apps/partner-ui/src/routes/content/content-detail/content-detail.tsx
@@ -494,6 +494,69 @@ const ContentDetailInner = () => {
               block={selectedBlock}
               onUpdate={handleBlockUpdate}
               onDelete={handleDeleteBlock}
+              onDuplicate={async (blockId) => {
+                const block = blocks.find((b) => b.id === blockId)
+                if (!block) return
+                const maxOrder = blocks.reduce((max, b) => Math.max(max, b.order), -1)
+                try {
+                  const result = await createBlock({
+                    name: `${block.name} (copy)`,
+                    type: block.type,
+                    content: { ...block.content },
+                    settings: block.settings,
+                    order: maxOrder + 1,
+                    status: "Active",
+                  })
+                  const newBlock = result?.blocks?.[0]
+                  if (newBlock) setBlocks((prev) => [...prev, newBlock])
+                  toast.success(`Duplicated "${block.name}"`)
+                  if (iframeRef.current) {
+                    setTimeout(() => {
+                      if (iframeRef.current) iframeRef.current.src = iframeRef.current.src
+                    }, 300)
+                  }
+                } catch {
+                  toast.error("Failed to duplicate block")
+                }
+              }}
+              onMoveUp={(blockId) => {
+                const idx = blocks.findIndex((b) => b.id === blockId)
+                if (idx <= 0) return
+                const reordered = [...blocks]
+                ;[reordered[idx - 1], reordered[idx]] = [reordered[idx], reordered[idx - 1]]
+                setBlocks(reordered.map((b, i) => ({ ...b, order: i })))
+                reordered.forEach((b, i) => {
+                  sdk.client.fetch(
+                    `/partners/storefront/pages/${pageId}/blocks/${b.id}`,
+                    { method: "PUT", body: { order: i } }
+                  )
+                })
+                if (iframeRef.current) {
+                  setTimeout(() => {
+                    if (iframeRef.current) iframeRef.current.src = iframeRef.current.src
+                  }, 300)
+                }
+              }}
+              onMoveDown={(blockId) => {
+                const idx = blocks.findIndex((b) => b.id === blockId)
+                if (idx < 0 || idx >= blocks.length - 1) return
+                const reordered = [...blocks]
+                ;[reordered[idx + 1], reordered[idx]] = [reordered[idx], reordered[idx + 1]]
+                setBlocks(reordered.map((b, i) => ({ ...b, order: i })))
+                reordered.forEach((b, i) => {
+                  sdk.client.fetch(
+                    `/partners/storefront/pages/${pageId}/blocks/${b.id}`,
+                    { method: "PUT", body: { order: i } }
+                  )
+                })
+                if (iframeRef.current) {
+                  setTimeout(() => {
+                    if (iframeRef.current) iframeRef.current.src = iframeRef.current.src
+                  }, 300)
+                }
+              }}
+              canMoveUp={blocks.findIndex((b) => b.id === selectedBlock.id) > 0}
+              canMoveDown={blocks.findIndex((b) => b.id === selectedBlock.id) < blocks.length - 1}
               saveStatus={saveStatus}
             />
           ) : (

--- a/apps/partner-ui/src/routes/content/content-detail/content-detail.tsx
+++ b/apps/partner-ui/src/routes/content/content-detail/content-detail.tsx
@@ -125,15 +125,46 @@ const ContentDetailInner = () => {
           if (iframeRef.current) iframeRef.current.src = iframeRef.current.src
         }, 200)
       }
+      if (data.type === "BLOCK_FIELD_EDITED") {
+        const { blockId, field, value } = data
+        setBlocks((prev) =>
+          prev.map((b) =>
+            b.id === blockId
+              ? { ...b, content: { ...b.content, [field]: value } }
+              : b
+          )
+        )
+        setSaveStatus("saving")
+        sdk.client
+          .fetch(
+            `/partners/storefront/pages/${pageId}/blocks/${blockId}`,
+            {
+              method: "PUT",
+              body: { content: { [field]: value } },
+            }
+          )
+          .then(() => setSaveStatus("saved"))
+          .catch(() => setSaveStatus("unsaved"))
+      }
     }
     window.addEventListener("message", handleMessage)
     return () => window.removeEventListener("message", handleMessage)
-  }, [])
+  }, [pageId])
 
   useEffect(() => {
     if (iframeReady && selectedBlockId && iframeRef.current?.contentWindow) {
       iframeRef.current.contentWindow.postMessage(
         { type: "SELECT_BLOCK", blockId: selectedBlockId },
+        "*"
+      )
+      iframeRef.current.contentWindow.postMessage(
+        { type: "ENABLE_INLINE_EDITING", blockId: selectedBlockId },
+        "*"
+      )
+    }
+    if (iframeReady && !selectedBlockId && iframeRef.current?.contentWindow) {
+      iframeRef.current.contentWindow.postMessage(
+        { type: "DISABLE_INLINE_EDITING" },
         "*"
       )
     }

--- a/apps/partner-ui/src/routes/content/content-detail/content-detail.tsx
+++ b/apps/partner-ui/src/routes/content/content-detail/content-detail.tsx
@@ -146,6 +146,34 @@ const ContentDetailInner = () => {
           .then(() => setSaveStatus("saved"))
           .catch(() => setSaveStatus("unsaved"))
       }
+      if (data.type === "BLOCK_REORDERED") {
+        const { orderedIds } = data as { orderedIds: string[] }
+        setBlocks((prev) => {
+          const reordered = orderedIds
+            .map((id) => prev.find((b) => b.id === id))
+            .filter(Boolean) as ContentBlock[]
+          return reordered.map((b, idx) => ({ ...b, order: idx }))
+        })
+        setSaveStatus("saving")
+        Promise.all(
+          orderedIds.map((blockId, idx) =>
+            sdk.client.fetch(
+              `/partners/storefront/pages/${pageId}/blocks/${blockId}`,
+              { method: "PUT", body: { order: idx } }
+            )
+          )
+        )
+          .then(() => setSaveStatus("saved"))
+          .catch(() => setSaveStatus("unsaved"))
+        if (iframeRef.current) {
+          setTimeout(() => {
+            if (iframeRef.current) iframeRef.current.src = iframeRef.current.src
+          }, 300)
+        }
+      }
+      if (data.type === "REQUEST_ADD_BLOCK_AT") {
+        setAddBlockOpen(true)
+      }
     }
     window.addEventListener("message", handleMessage)
     return () => window.removeEventListener("message", handleMessage)

--- a/apps/partner-ui/src/routes/content/content-detail/content-detail.tsx
+++ b/apps/partner-ui/src/routes/content/content-detail/content-detail.tsx
@@ -120,6 +120,11 @@ const ContentDetailInner = () => {
       if (!data || typeof data !== "object" || !("type" in data)) return
       if (data.type === "VISUAL_EDITOR_READY") setIframeReady(true)
       if (data.type === "BLOCK_CLICKED") setSelectedBlockId(data.blockId)
+      if (data.type === "BLOCK_PREVIEW_RELOAD_NEEDED" && iframeRef.current) {
+        setTimeout(() => {
+          if (iframeRef.current) iframeRef.current.src = iframeRef.current.src
+        }, 200)
+      }
     }
     window.addEventListener("message", handleMessage)
     return () => window.removeEventListener("message", handleMessage)

--- a/e2e/helpers/e2e-seed.ts
+++ b/e2e/helpers/e2e-seed.ts
@@ -774,6 +774,136 @@ export async function seedShipmentGatePartner(
 }
 
 /**
+ * Seed a partner + website + page + blocks for the visual block editor e2e spec.
+ * Mirrors seedShipmentGatePartner for auth, then creates a website with a page
+ * containing a Hero block and a Feature block so the editor has content to render.
+ */
+async function seedContentEditorPartner(
+  container: any
+): Promise<{
+  email: string
+  password: string
+  partnerId: string
+  pageId: string
+  websiteId: string
+}> {
+  const authModule = container.resolve(Modules.AUTH)
+  const link: any = container.resolve(ContainerRegistrationKeys.LINK)
+  const partnerModule: any = container.resolve("partner")
+  const websiteService = container.resolve("websites")
+  const storeModule: any = container.resolve(Modules.STORE)
+
+  const email = `e2e-content-${Date.now()}@jyt.test`
+
+  // Partner
+  const partner = await partnerModule.createPartners({
+    name: "E2E Content Partner",
+    handle: `e2e-content-${Date.now()}`,
+    status: "active",
+    is_verified: true,
+  })
+  const partnerId = Array.isArray(partner) ? partner[0].id : partner.id
+
+  await partnerModule.createPartnerAdmins({
+    email,
+    first_name: "Content",
+    last_name: "Editor",
+    role: "admin",
+    partner_id: partnerId,
+  })
+
+  // Auth identity + verification
+  const hashConfig = { logN: 15, r: 8, p: 1 }
+  const passwordHash = await Scrypt.kdf(SEED_PASSWORD, hashConfig)
+  const authIdentity: any = await authModule.createAuthIdentities({
+    provider_identities: [
+      {
+        provider: "emailpass",
+        entity_id: email,
+        provider_metadata: { password: passwordHash.toString("base64") },
+      },
+    ],
+    app_metadata: { partner_id: partnerId },
+  })
+  const authIdentityId = Array.isArray(authIdentity)
+    ? authIdentity[0].id
+    : authIdentity.id
+
+  const now = new Date()
+  await authModule.createAuthVerifications([
+    {
+      auth_identity_id: authIdentityId,
+      entity_id: email,
+      entity_type: "email",
+      code_provider: "emailpass",
+      requested_at: now,
+      verified_at: now,
+    },
+  ])
+
+  // Store
+  const createdStore: any = await storeModule.createStores({
+    name: `E2E Content Store ${Date.now()}`,
+  })
+  const storeId = Array.isArray(createdStore)
+    ? createdStore[0].id
+    : createdStore.id
+  await link.create({
+    partner: { partner_id: partnerId },
+    store: { store_id: storeId },
+  })
+
+  // Website
+  const domain = `e2e-content-${Date.now()}.jyt.test`
+  const website = await websiteService.createWebsites({
+    domain,
+    name: "E2E Content Website",
+    status: "Active",
+    primary_language: "en",
+  })
+
+  // Link partner to website
+  await partnerModule.updatePartners({
+    id: partnerId,
+    storefront_domain: domain,
+    website_id: website.id,
+  })
+
+  // Page
+  const pageService = container.resolve("websites")
+  const page = await pageService.createPages({
+    website_id: website.id,
+    title: "E2E Content Page",
+    slug: "e2e-content-page",
+    content: "Test content for visual editor",
+    page_type: "Custom",
+    status: "Published",
+  })
+
+  // Seed blocks: one Hero (unique) + one Feature (repeatable)
+  await websiteService.createBlocks({
+    page_id: page.id,
+    name: "Hero Section",
+    type: "Hero",
+    content: { title: "Welcome to our store", subtitle: "Handcrafted textiles" },
+    settings: { backgroundColor: "#f5f5f5", padding: "40", max_width: "wide" },
+    status: "Active",
+    order: 0,
+  })
+  await websiteService.createBlocks({
+    page_id: page.id,
+    name: "Feature Highlight",
+    type: "Feature",
+    content: { title: "Natural fibers", description: "100% organic cotton" },
+    settings: {},
+    status: "Active",
+    order: 1,
+  })
+
+  return { email, password: SEED_PASSWORD, partnerId, pageId: page.id, websiteId: website.id }
+}
+
+/**
  * One CRM contact with a prior inbound activity, for the contact-detail spec.
  *
  * The CRM lives on a Hyperbee node, not Postgres — the e2e run uses the
@@ -954,6 +1084,9 @@ export default async function e2eSeed({ container }: ExecArgs) {
   logger.info("E2E seed: creating the CRM contact + one logged activity...")
   const crmContact = await seedCrmContact(container)
 
+  logger.info("E2E seed: creating content editor partner + website + page + blocks...")
+  const contentEditor = await seedContentEditorPartner(container)
+
   const seedData = {
     email,
     password: SEED_PASSWORD,
@@ -988,6 +1121,13 @@ export default async function e2eSeed({ container }: ExecArgs) {
     crmPersonId: crmContact.personId,
     crmPersonName: crmContact.personName,
     crmActivityBody: crmContact.activityBody,
+    // Visual block editor fixture — consumed by visual-block-editor.spec.ts
+    // (@partnerui, local only).
+    contentEditorEmail: contentEditor.email,
+    contentEditorPassword: contentEditor.password,
+    contentEditorPartnerId: contentEditor.partnerId,
+    contentEditorPageId: contentEditor.pageId,
+    contentEditorWebsiteId: contentEditor.websiteId,
     // #1363 per-assignment material allocation — consumed by
     // production-run-material-allocation.spec.ts (admin, CI). SINGLE-USE like
     // every other run fixture: the spec approves the run, and an approved run

--- a/e2e/specs/visual-block-editor.spec.ts
+++ b/e2e/specs/visual-block-editor.spec.ts
@@ -1,0 +1,264 @@
+import { test, expect } from "@playwright/test"
+import * as fs from "fs"
+import * as path from "path"
+
+const SEED_FILE = path.resolve(__dirname, "../../apps/backend/.e2e-seed.json")
+const PARTNER_UI = process.env.PARTNER_UI_URL || "http://localhost:5173"
+
+test.describe("@partnerui Visual Block Editor (#1466)", () => {
+  let seed: {
+    contentEditorEmail: string
+    contentEditorPassword: string
+    contentEditorPageId: string
+  }
+
+  test.beforeAll(() => {
+    if (!fs.existsSync(SEED_FILE)) {
+      throw new Error(
+        `E2E seed file not found at ${SEED_FILE}. Run "pnpm e2e:seed" first.`
+      )
+    }
+    seed = JSON.parse(fs.readFileSync(SEED_FILE, "utf-8"))
+    if (!seed.contentEditorEmail) {
+      throw new Error("E2E seed missing contentEditorEmail — re-run the seed.")
+    }
+  })
+
+  test("content editor shows block list, canvas, and inspector", async ({
+    page,
+  }) => {
+    // Login via partner UI
+    await page.goto(`${PARTNER_UI}/login`, { waitUntil: "networkidle" })
+    await page.locator('input[name="email"]').fill(seed.contentEditorEmail)
+    await page.locator('input[name="password"]').fill(seed.contentEditorPassword)
+    await page.locator('button[type="submit"]').click()
+    await page.waitForFunction(
+      () => !!localStorage.getItem("partner_ui_auth_token"),
+      { timeout: 15_000 }
+    )
+
+    // Navigate to content editor for the seeded page
+    await page.goto(`${PARTNER_UI}/content/${seed.contentEditorPageId}`, {
+      waitUntil: "domcontentloaded",
+    })
+    await page.waitForLoadState("networkidle")
+
+    // Block list sidebar — should show the two seeded blocks
+    await expect(
+      page.getByText("Blocks (2)", { exact: false }).first()
+    ).toBeVisible({ timeout: 15_000 })
+
+    await expect(
+      page.getByText("Hero Section").first()
+    ).toBeVisible()
+    await expect(
+      page.getByText("Feature Highlight").first()
+    ).toBeVisible()
+
+    // "Add" button is visible
+    await expect(
+      page.getByRole("button", { name: /Add/i }).first()
+    ).toBeVisible()
+  })
+
+  test("add block drawer disables already-used unique types", async ({
+    page,
+  }) => {
+    await page.goto(`${PARTNER_UI}/login`, { waitUntil: "networkidle" })
+    await page.locator('input[name="email"]').fill(seed.contentEditorEmail)
+    await page.locator('input[name="password"]').fill(seed.contentEditorPassword)
+    await page.locator('button[type="submit"]').click()
+    await page.waitForFunction(
+      () => !!localStorage.getItem("partner_ui_auth_token"),
+      { timeout: 15_000 }
+    )
+
+    await page.goto(`${PARTNER_UI}/content/${seed.contentEditorPageId}`, {
+      waitUntil: "domcontentloaded",
+    })
+    await page.waitForLoadState("networkidle")
+
+    // Wait for block list to appear
+    await expect(
+      page.getByText("Hero Section").first()
+    ).toBeVisible({ timeout: 15_000 })
+
+    // Open the Add Block drawer
+    await page.getByRole("button", { name: /Add/i }).first().click()
+    await page.waitForLoadState("networkidle")
+
+    // The drawer should be open with a type selector
+    await expect(
+      page.getByText(/block type/i).first()
+    ).toBeVisible({ timeout: 10_000 })
+
+    // Hero should be listed but disabled (already added)
+    const heroOption = page.getByText("Hero", { exact: true }).first()
+    await expect(heroOption).toBeVisible()
+
+    // Feature should be available (repeatable)
+    await expect(
+      page.getByText("Feature", { exact: true }).first()
+    ).toBeVisible()
+  })
+
+  test("selecting a block shows contextual inspector with type badge", async ({
+    page,
+  }) => {
+    await page.goto(`${PARTNER_UI}/login`, { waitUntil: "networkidle" })
+    await page.locator('input[name="email"]').fill(seed.contentEditorEmail)
+    await page.locator('input[name="password"]').fill(seed.contentEditorPassword)
+    await page.locator('button[type="submit"]').click()
+    await page.waitForFunction(
+      () => !!localStorage.getItem("partner_ui_auth_token"),
+      { timeout: 15_000 }
+    )
+
+    await page.goto(`${PARTNER_UI}/content/${seed.contentEditorPageId}`, {
+      waitUntil: "domcontentloaded",
+    })
+    await page.waitForLoadState("networkidle")
+
+    // Wait for blocks to load
+    await expect(
+      page.getByText("Hero Section").first()
+    ).toBeVisible({ timeout: 15_000 })
+
+    // Click on the Feature block in the sidebar
+    await page.getByText("Feature Highlight").first().click()
+    await page.waitForLoadState("networkidle")
+
+    // Inspector panel should show the block type badge
+    await expect(
+      page.getByText("Feature", { exact: true }).first()
+    ).toBeVisible({ timeout: 10_000 })
+
+    // Should show the inline editing hint
+    await expect(
+      page.getByText(/click text on the canvas/i).first()
+    ).toBeVisible()
+
+    // Should show block name field
+    await expect(
+      page.locator('input').filter({ hasText: "" }).first()
+    ).toBeVisible()
+
+    // Advanced Settings should be collapsed by default
+    await expect(
+      page.getByText("Advanced Settings").first()
+    ).toBeVisible()
+
+    // Quick action buttons should be visible (move up/down, delete)
+    await expect(
+      page.getByRole("button").filter({ has: page.locator("svg") }).first()
+    ).toBeVisible()
+  })
+
+  test("advanced settings expand to show background, padding, max width", async ({
+    page,
+  }) => {
+    await page.goto(`${PARTNER_UI}/login`, { waitUntil: "networkidle" })
+    await page.locator('input[name="email"]').fill(seed.contentEditorEmail)
+    await page.locator('input[name="password"]').fill(seed.contentEditorPassword)
+    await page.locator('button[type="submit"]').click()
+    await page.waitForFunction(
+      () => !!localStorage.getItem("partner_ui_auth_token"),
+      { timeout: 15_000 }
+    )
+
+    await page.goto(`${PARTNER_UI}/content/${seed.contentEditorPageId}`, {
+      waitUntil: "domcontentloaded",
+    })
+    await page.waitForLoadState("networkidle")
+
+    await expect(
+      page.getByText("Hero Section").first()
+    ).toBeVisible({ timeout: 15_000 })
+
+    // Select the Hero block (has bg color set in seed)
+    await page.getByText("Hero Section").first().click()
+    await page.waitForLoadState("networkidle")
+
+    // Expand Advanced Settings
+    await page.getByText("Advanced Settings").first().click()
+
+    // Should now show Background Color, Padding, Max Width
+    await expect(
+      page.getByText("Background Color").first()
+    ).toBeVisible({ timeout: 5_000 })
+    await expect(
+      page.getByText("Padding (px)").first()
+    ).toBeVisible()
+    await expect(
+      page.getByText("Max Width").first()
+    ).toBeVisible()
+  })
+
+  test("iframe canvas loads and renders blocks", async ({ page }) => {
+    await page.goto(`${PARTNER_UI}/login`, { waitUntil: "networkidle" })
+    await page.locator('input[name="email"]').fill(seed.contentEditorEmail)
+    await page.locator('input[name="password"]').fill(seed.contentEditorPassword)
+    await page.locator('button[type="submit"]').click()
+    await page.waitForFunction(
+      () => !!localStorage.getItem("partner_ui_auth_token"),
+      { timeout: 15_000 }
+    )
+
+    await page.goto(`${PARTNER_UI}/content/${seed.contentEditorPageId}`, {
+      waitUntil: "domcontentloaded",
+    })
+    await page.waitForLoadState("networkidle")
+
+    // The iframe should be present
+    const iframe = page.locator("iframe").first()
+    await expect(iframe).toBeVisible({ timeout: 15_000 })
+
+    // Wait for iframe content to load and post VISUAL_EDITOR_READY
+    await page.waitForLoadState("networkidle")
+
+    // The iframe should have a src pointing to the storefront
+    const src = await iframe.getAttribute("src")
+    expect(src).toBeTruthy()
+
+    // Block list should populate (indicates iframe loaded and posted blocks)
+    await expect(
+      page.getByText("Blocks (2)", { exact: false }).first()
+    ).toBeVisible({ timeout: 20_000 })
+  })
+
+  test("screenshot: visual block editor full layout", async ({ page }) => {
+    test.skip(process.env.CI, "screenshot test — local only")
+
+    await page.goto(`${PARTNER_UI}/login`, { waitUntil: "networkidle" })
+    await page.locator('input[name="email"]').fill(seed.contentEditorEmail)
+    await page.locator('input[name="password"]').fill(seed.contentEditorPassword)
+    await page.locator('button[type="submit"]').click()
+    await page.waitForFunction(
+      () => !!localStorage.getItem("partner_ui_auth_token"),
+      { timeout: 15_000 }
+    )
+
+    await page.goto(`${PARTNER_UI}/content/${seed.contentEditorPageId}`, {
+      waitUntil: "domcontentloaded",
+    })
+    await page.waitForLoadState("networkidle")
+
+    await expect(
+      page.getByText("Hero Section").first()
+    ).toBeVisible({ timeout: 15_000 })
+
+    // Select Hero block to show inspector
+    await page.getByText("Hero Section").first().click()
+    await page.waitForLoadState("networkidle")
+
+    await expect(
+      page.getByText("Advanced Settings").first()
+    ).toBeVisible({ timeout: 10_000 })
+
+    // Take a screenshot for visual verification
+    await page.screenshot({
+      path: path.resolve(__dirname, "../screenshots/visual-block-editor.png"),
+      fullPage: true,
+    })
+  })
+})


### PR DESCRIPTION
## Visual Block Editor — All 6 Phases

### Phase 1: Fix Add Block for unique block types (#1465)
- Exported `UNIQUE_BLOCKS`/`REPEATABLE_BLOCKS` from `validators.ts`
- Pre-check unique block types in `createBatchBlocksWorkflow` with friendly error messages
- Disable already-used unique types in the Add Block dropdown with "(already added)" indicator
- Extract actual error from `FetchError` in `handleAddBlock` catch instead of generic toast
- Auto-refresh iframe canvas after successful block add
- Fixed Block model `type` enum default from "Content" (invalid) to "Custom"

### Phase 2: Complete storefront block renderers (#1467)
- Added proper renderers for all 11 block types (Header, Footer, Gallery, Feature, Testimonial, Product, ContactForm, Section, Custom)
- Each renderer wraps output in `data-block-id`/`data-block-type`/`data-block-name` attrs when `visual_editor=true`
- Each editable text field tagged with `data-field` attribute for the bridge to target
- Includes TipTapViewer link/image rendering and getWebsitePage TTL floor

### Phase 3: Generic updateBlockPreview in bridge (#1468)
- Replaced type-specific DOM mutations with generic `[data-field]` targeting
- String values update `textContent`, TipTap JSON renders to HTML, arrays signal `BLOCK_PREVIEW_RELOAD_NEEDED`
- Added `maxWidth` to supported settings

### Phase 4: Inline editing on canvas (#1469)
- `contentEditable` on `[data-field]` elements when a block is selected
- `BLOCK_FIELD_EDITED` message posted on blur with blockId, field, value
- Parent UI handles the message: updates local state + PUTs to backend
- `ENABLE_INLINE_EDITING`/`DISABLE_INLINE_EDITING` message types
- CSS for contentEditable focus/hover/empty states
- Click handler allows clicks within contentEditable fields

### Phase 5: Canvas drag/drop reordering (#1470)
- Native HTML5 Drag and Drop on the iframe canvas (no `@dnd-kit` dependency needed in storefront)
- Drag handle (hamburger icon) appears on selected blocks
- Drop position determined by mouse Y relative to target block midpoint
- `BLOCK_REORDERED { orderedIds }` posted to parent on drop
- Parent UI updates block order state + batch PUTs order updates
- "+" insert handles between blocks, posting `REQUEST_ADD_BLOCK_AT` to parent

### Phase 6: Contextual inspector panel (#1471)
- Block type badge + name + save status at top of inspector
- Quick actions: move up, move down, duplicate (repeatable types only), delete
- Inline-editing hint banner
- Advanced settings (background color, padding, max width) collapsed by default
- Wired up `onDuplicate`, `onMoveUp`, `onMoveDown` handlers with batch order updates

Closes #1465, Closes #1467, Closes #1468, Closes #1469, Closes #1470, Closes #1471
