### PR TITLE
feat(quote): wire buildProvenance — the maker section was written and imported by nothing

### DIFF
--- a/apps/backend/integration-tests/http/partner-quote-provenance.spec.ts
+++ b/apps/backend/integration-tests/http/partner-quote-provenance.spec.ts
@@ -1,0 +1,256 @@
+import { getSharedTestEnv, setupSharedTestSuite } from "./shared-test-setup"
+import { createAdminUser } from "../helpers/create-admin-user"
+import { ContainerRegistrationKeys } from "@medusajs/framework/utils"
+import {
+  setupQuoteFixture,
+  mintBody,
+  type QuoteFixture,
+} from "../helpers/setup-quote-fixture"
+
+jest.setTimeout(240 * 1000)
+
+/**
+ * The maker section on the buyer's quote page, against a database (#1439 S9).
+ *
+ * ## Why a container run and not just the unit suites
+ *
+ * `buildProvenance` is pure and fully unit-tested, and `resolve-provenance` has
+ * its own suite against a fake scope. Both were green while the feature did not
+ * exist at all — nothing imported the shaper for months. Everything that can
+ * still be wrong now lives in the WIRING, and none of it is visible to a fake:
+ *
+ * - the product-side graph alias is the linked MODEL name,
+ *   `artisan_product_detail`. `artisan_detail.*` returns nothing, silently —
+ *   that exact mistake cost #859 its maker story;
+ * - the onboarding profile is reached through a module service, not the graph;
+ * - `partners` must be filtered by id on a PUBLIC unauthenticated route
+ *   (#1397);
+ * - and the public route has to actually put the block in its response.
+ *
+ * ## The assertion that matters most
+ *
+ * Not that the rows render — that the COMMERCIAL terms do not. This payload is
+ * served to anyone holding the link, with no login. `commission_bps`,
+ * `price_range`, `payment_collection` and `selling_mode` all sit on the very
+ * profile row this reads from, and the shaper's exclusion list is the only
+ * thing keeping them off a buyer's screen. A test that only checks for
+ * "Made by" would pass just as happily with the whole row published.
+ */
+
+const loud = async <T>(label: string, fn: () => Promise<T>): Promise<T> => {
+  try {
+    return await fn()
+  } catch (e: any) {
+    console.log(`[${label}] ${e.response?.status}`, JSON.stringify(e.response?.data))
+    throw e
+  }
+}
+
+setupSharedTestSuite(() => {
+  describe("GET /store/b2b/quotes/:token — provenance (#1448)", () => {
+    let seed: QuoteFixture
+    let storeHeaders: Record<string, string>
+
+    const MAKER_STORY = "Woven on pit looms in the Kashmir valley."
+
+    beforeAll(async () => {
+      const { api, getContainer } = getSharedTestEnv()
+      await createAdminUser(getContainer())
+      seed = await setupQuoteFixture(api, getContainer)
+      storeHeaders = { "x-publishable-api-key": seed.publishableKey }
+
+      const container = getContainer()
+
+      // The partner half. `is_verified` is written through the module because
+      // no partner-facing route may set its own verification — that is the
+      // point of the flag.
+      const partnerModule: any = container.resolve("partner")
+      await partnerModule.updatePartners({
+        id: seed.partnerId,
+        is_verified: true,
+        country_code: "IN",
+      })
+
+      // The onboarding profile, through the route a partner actually uses —
+      // carrying the commercial fields that must NOT come back out.
+      await loud("onboarding", () =>
+        api.put(
+          "/partners/onboarding-profile",
+          {
+            what_they_sell: "home_textiles",
+            person_type: "artisan",
+            team_size: 12,
+            does_weaving: true,
+            price_range: "luxury",
+            commission_bps: 1500,
+            payment_collection: "through_us",
+            selling_mode: "core_channel_listing",
+          },
+          { headers: seed.headers }
+        )
+      )
+
+      // The product half, likewise through the partner's own route.
+      await loud("artisan-detail", () =>
+        api.post(
+          `/partners/products/${seed.productId}/artisan-detail`,
+          {
+            maker_story: MAKER_STORY,
+            lead_time_days: 21,
+            min_order_quantity: 50,
+            made_to_order: true,
+          },
+          { headers: seed.headers }
+        )
+      )
+    })
+
+    /** Mint a quote and read it back as the buyer would. */
+    const mintAndView = async (overrides: Record<string, any> = {}) => {
+      const { api } = getSharedTestEnv()
+      const mint = await loud("mint", () =>
+        api.post("/partners/quotes", mintBody(seed, overrides), {
+          headers: seed.headers,
+        })
+      )
+      const token = mint.data.token
+      const view = await loud("view", () =>
+        api.get(`/store/b2b/quotes/${token}`, { headers: storeHeaders })
+      )
+      return { quote: view.data.quote, minted: mint.data.quote }
+    }
+
+    it("renders the maker's facts and story on the buyer's page", async () => {
+      const { quote } = await mintAndView({
+        buyer_email: `buyer-prov-${seed.unique}@jaalyantra.test`,
+        // ONE product, so every per-product fact is basket-wide and the full
+        // row set is expected.
+        lines: [{ variant_id: seed.variantA.id, quantity: 25 }],
+      })
+
+      const provenance = quote.provenance
+      expect(provenance).toBeTruthy()
+      expect(provenance.maker_name).toBe(`QuoteTest ${seed.unique}`)
+      expect(provenance.maker_story).toBe(MAKER_STORY)
+
+      const byKey = Object.fromEntries(
+        (provenance.rows ?? []).map((r: any) => [r.key, r])
+      )
+      // Partner-level, from two different records — proof both halves of the
+      // fetch landed, not just the one that is easy to reach.
+      expect(byKey.maker?.value).toBe(`QuoteTest ${seed.unique}`)
+      expect(byKey.country?.value).toBe("India")
+      expect(byKey.verified).toBeTruthy()
+      expect(byKey.maker_type?.value).toBe("Artisan")
+      expect(byKey.weaving).toBeTruthy()
+      // Product-level, through the link alias that silently returns nothing
+      // when it is spelled `artisan_detail`.
+      expect(byKey.made_to_order).toBeTruthy()
+      expect(byKey.lead_time?.value).toBe("21 days")
+      expect(byKey.min_order_quantity?.value).toBe("50 units")
+
+      // Every row carries where it came from — an unattributed fact is a claim.
+      for (const row of provenance.rows) {
+        expect(["partner", "partner-onboarding-profile", "artisan-product-detail"])
+          .toContain(row.source)
+        // And no row is ever a blank or an em-dash: absent means ABSENT.
+        expect(String(row.value).trim().length).toBeGreaterThan(0)
+        expect(row.value).not.toBe("—")
+      }
+    })
+
+    it("🔴 publishes NO commercial term to the buyer", async () => {
+      const { quote } = await mintAndView({
+        buyer_email: `buyer-leak-${seed.unique}@jaalyantra.test`,
+        lines: [{ variant_id: seed.variantA.id, quantity: 25 }],
+      })
+
+      // 🔑 Assert there is something to leak FROM first. This test passed
+      // vacuously on the very first run — `provenance` was null, and
+      // JSON.stringify(null) contains none of the secrets. A leak test that
+      // is green when the feature is absent proves nothing at all.
+      expect(quote.provenance).toBeTruthy()
+      expect(quote.provenance.rows.length).toBeGreaterThan(0)
+
+      // The WHOLE provenance block, not just the rows: a leak through
+      // maker_story or a stray passthrough field counts the same.
+      const published = JSON.stringify(quote.provenance).toLowerCase()
+      for (const secret of [
+        "commission",
+        "1500",
+        "price_range",
+        "luxury",
+        "payment_collection",
+        "through_us",
+        "selling_mode",
+        "core_channel_listing",
+        "supplies_to_platform",
+        "tax_id",
+      ]) {
+        expect(published).not.toContain(secret)
+      }
+    })
+
+    it("keeps the partner facts but drops per-product claims on a MIXED basket", async () => {
+      // A second product with NO artisan detail row. Its lead time is not
+      // "the same" — it is unknown, and stating the first product's over the
+      // whole quote would be a claim about an item it was never made about.
+      const { api, getContainer } = getSharedTestEnv()
+      const second = await loud("second-product", () =>
+        api.post(
+          "/partners/products",
+          {
+            store_id: seed.storeId,
+            product: {
+              title: `Undocumented Stole ${seed.unique}`,
+              status: "published",
+              options: [{ title: "Weave", values: ["Plain"] }],
+              variants: [
+                {
+                  title: "Plain",
+                  sku: `UP-UND-${seed.unique}`,
+                  options: { Weave: "Plain" },
+                  manage_inventory: false,
+                  weight: 400,
+                  length: 40,
+                  width: 30,
+                  height: 5,
+                  prices: [{ amount: 31000, currency_code: seed.currencyCode }],
+                },
+              ],
+            },
+          },
+          { headers: seed.headers }
+        )
+      )
+      const secondVariantId = second.data.product.variants[0].id
+
+      const link = getContainer().resolve(ContainerRegistrationKeys.LINK) as any
+      await link
+        .create({
+          product: { product_id: second.data.product.id },
+          sales_channel: { sales_channel_id: seed.salesChannelId },
+        })
+        .catch(() => {})
+
+      const { quote } = await mintAndView({
+        buyer_email: `buyer-mixed-${seed.unique}@jaalyantra.test`,
+        lines: [
+          { variant_id: seed.variantA.id, quantity: 25 },
+          { variant_id: secondVariantId, quantity: 10 },
+        ],
+      })
+
+      const keys = (quote.provenance?.rows ?? []).map((r: any) => r.key)
+      // Who they are still holds for the whole basket…
+      expect(keys).toContain("maker")
+      expect(keys).toContain("weaving")
+      // …but nothing that was only ever true of one product survives, and the
+      // story is silent rather than borrowed from line one.
+      expect(keys).not.toContain("lead_time")
+      expect(keys).not.toContain("min_order_quantity")
+      expect(keys).not.toContain("made_to_order")
+      expect(quote.provenance.maker_story).toBeNull()
+    })
+  })
+})

--- a/apps/backend/src/lib/provenance/__tests__/resolve-provenance.unit.spec.ts
+++ b/apps/backend/src/lib/provenance/__tests__/resolve-provenance.unit.spec.ts
@@ -236,12 +236,28 @@ describe("resolveQuoteProvenance", () => {
     expect(res?.rows.map((r) => r.key)).toEqual(["maker", "country", "verified"])
   })
 
-  it("says nothing for an inactive partner", async () => {
+  it("says nothing for an INACTIVE partner — their credentials are withdrawn", async () => {
     const res = await resolveQuoteProvenance(
-      scopeWith({ partners: [{ ...PARTNER, status: "suspended" }] }) as any,
+      scopeWith({ partners: [{ ...PARTNER, status: "inactive" }] }) as any,
       { partner_id: "part_1", product_ids: ["prod_a"] }
     )
     expect(res).toBeNull()
+  })
+
+  it("🔑 still speaks for a PENDING partner — that is the default status", async () => {
+    // Every partner the registration route creates is `pending`, and nothing
+    // about minting a quote requires an admin to have flipped it. Refusing
+    // pending would render this section for almost nobody.
+    const res = await resolveQuoteProvenance(
+      scopeWith({
+        partners: [{ ...PARTNER, status: "pending", is_verified: false }],
+        products: [{ id: "prod_a", artisan_product_detail: DETAIL_A }],
+      }) as any,
+      { partner_id: "part_1", product_ids: ["prod_a"] }
+    )
+    expect(res?.maker_name).toBe("Unique Pashmina")
+    // …but the one row that is a CLAIM stays gated on is_verified.
+    expect(res?.rows.map((r) => r.key)).not.toContain("verified")
   })
 
   it("says nothing when the quote has no partner", async () => {

--- a/apps/backend/src/lib/provenance/__tests__/resolve-provenance.unit.spec.ts
+++ b/apps/backend/src/lib/provenance/__tests__/resolve-provenance.unit.spec.ts
@@ -1,0 +1,259 @@
+import {
+  consensusArtisanDetail,
+  hasProvenance,
+  resolveQuoteProvenance,
+} from "../resolve-provenance"
+
+/**
+ * The half of provenance that reads the database (#1439 S9).
+ *
+ * `build-provenance.ts` decides WHAT a buyer sees and has its own suite. These
+ * tests are about the two things this file can get wrong and the shaper cannot:
+ *
+ * 1. **Misattribution across a basket.** A quote can mix a made-to-order shawl
+ *    with a stocked scarf. Printing the shawl's lead time over the whole quote
+ *    is a claim about an item it was never made about — so the assertion that
+ *    matters is that a MIXED basket loses those rows entirely rather than
+ *    taking the first line's.
+ * 2. **Failing loud.** Provenance is a credit line; every failure must collapse
+ *    to `null`, never to a 500 on the buyer's page.
+ */
+
+const PARTNER = {
+  id: "part_1",
+  name: "Unique Pashmina",
+  handle: "unique-pashmina",
+  country_code: "IN",
+  is_verified: true,
+  workspace_type: "artisan",
+  status: "active",
+}
+
+const PROFILE = {
+  what_they_sell: "home_textiles",
+  person_type: "artisan",
+  team_size: 12,
+  does_weaving: true,
+  // Commercial fields are present on the ROW and must not reach the buyer.
+  commission_bps: 1500,
+  price_range: "luxury",
+  payment_collection: "through_us",
+  selling_mode: "core_channel_listing",
+}
+
+const DETAIL_A = {
+  maker_story: "Woven on pit looms in the Kashmir valley.",
+  lead_time_days: 21,
+  lead_time_label: null,
+  min_order_quantity: 50,
+  made_to_order: true,
+}
+
+const scopeWith = (
+  over: {
+    partners?: any[]
+    products?: any[]
+    profile?: any
+    graphThrows?: boolean
+    profileThrows?: boolean
+    captureFilters?: any[]
+  } = {}
+) => ({
+  resolve: (key: string) => {
+    if (String(key) === "partner_onboarding_profile") {
+      return {
+        findByPartner: async () => {
+          if (over.profileThrows) throw new Error("module fell over")
+          return over.profile === undefined ? PROFILE : over.profile
+        },
+      }
+    }
+    return {
+      graph: async (args: any) => {
+        if (over.graphThrows) throw new Error("query fell over")
+        over.captureFilters?.push({ entity: args.entity, filters: args.filters })
+        // 🔑 Never an unfiltered read. `filters: { id: undefined }` is NO
+        // FILTER, not "no rows" (#1433) — here it would read every artisan
+        // detail row in the database onto one buyer's page.
+        expect(args.filters?.id).toBeDefined()
+        if (args.entity === "partners") {
+          return { data: over.partners === undefined ? [PARTNER] : over.partners }
+        }
+        if (args.entity === "product") {
+          return { data: over.products ?? [] }
+        }
+        return { data: [] }
+      },
+    }
+  },
+})
+
+describe("consensusArtisanDetail", () => {
+  it("keeps everything for a single-product quote", () => {
+    expect(consensusArtisanDetail([DETAIL_A], 1)).toEqual(DETAIL_A)
+  })
+
+  it("keeps only the fields every product agrees on", () => {
+    const res = consensusArtisanDetail(
+      [DETAIL_A, { ...DETAIL_A, lead_time_days: 40, maker_story: "A different story." }],
+      2
+    )
+    expect(res?.min_order_quantity).toBe(50)
+    expect(res?.made_to_order).toBe(true)
+    // The two facts that disagreed are gone, not averaged and not first-wins.
+    expect(res?.lead_time_days).toBeNull()
+    expect(res?.maker_story).toBeNull()
+  })
+
+  it("drops everything when one quoted product has no detail row at all", () => {
+    // Unanimous across the two rows that exist — but still a false statement
+    // about the third product, which we know nothing about.
+    expect(consensusArtisanDetail([DETAIL_A, DETAIL_A, null], 3)).toBeNull()
+  })
+
+  it("is null when no product carries a detail row", () => {
+    expect(consensusArtisanDetail([null, null], 2)).toBeNull()
+  })
+})
+
+describe("hasProvenance", () => {
+  it("is false for a partner we know nothing about", () => {
+    expect(hasProvenance({ maker_name: null, maker_story: null, rows: [] })).toBe(false)
+  })
+
+  it("is true when there is a story but no rows", () => {
+    expect(
+      hasProvenance({ maker_name: null, maker_story: "Woven by hand.", rows: [] })
+    ).toBe(true)
+  })
+})
+
+describe("resolveQuoteProvenance", () => {
+  it("shapes partner, profile and the basket's agreed product facts", async () => {
+    const res = await resolveQuoteProvenance(
+      scopeWith({ products: [{ id: "prod_a", artisan_product_detail: DETAIL_A }] }) as any,
+      { partner_id: "part_1", product_ids: ["prod_a"] }
+    )
+
+    expect(res?.maker_name).toBe("Unique Pashmina")
+    expect(res?.maker_story).toBe("Woven on pit looms in the Kashmir valley.")
+    expect(res?.rows.map((r) => r.key)).toEqual([
+      "maker",
+      "country",
+      "verified",
+      "maker_type",
+      "specialises_in",
+      "team_size",
+      "weaving",
+      "made_to_order",
+      "lead_time",
+      "min_order_quantity",
+    ])
+  })
+
+  it("publishes NO commercial term, whatever the profile row carries", async () => {
+    const res = await resolveQuoteProvenance(
+      scopeWith({ products: [{ id: "prod_a", artisan_product_detail: DETAIL_A }] }) as any,
+      { partner_id: "part_1", product_ids: ["prod_a"] }
+    )
+
+    const published = JSON.stringify(res).toLowerCase()
+    for (const leak of [
+      "commission",
+      "1500",
+      "luxury",
+      "price_range",
+      "payment_collection",
+      "through_us",
+      "selling_mode",
+      "core_channel_listing",
+    ]) {
+      expect(published).not.toContain(leak)
+    }
+  })
+
+  it("keeps the partner half when the basket's products disagree", async () => {
+    const res = await resolveQuoteProvenance(
+      scopeWith({
+        products: [
+          { id: "prod_a", artisan_product_detail: DETAIL_A },
+          {
+            id: "prod_b",
+            artisan_product_detail: { ...DETAIL_A, maker_story: "Another story.", lead_time_days: 40 },
+          },
+        ],
+      }) as any,
+      { partner_id: "part_1", product_ids: ["prod_a", "prod_b"] }
+    )
+
+    // Who they are still holds for the whole basket…
+    expect(res?.rows.map((r) => r.key)).toContain("maker")
+    expect(res?.rows.map((r) => r.key)).toContain("weaving")
+    // …but a per-product claim that isn't basket-wide is silent, not blended.
+    expect(res?.rows.map((r) => r.key)).not.toContain("lead_time")
+    expect(res?.maker_story).toBeNull()
+  })
+
+  it("degrades to fewer rows for a sparse partner, never to blank ones", async () => {
+    const res = await resolveQuoteProvenance(
+      scopeWith({
+        partners: [{ id: "part_1", name: "Thin Partner", status: "active" }],
+        profile: null,
+        products: [],
+      }) as any,
+      { partner_id: "part_1", product_ids: [] }
+    )
+
+    expect(res?.rows.map((r) => r.key)).toEqual(["maker"])
+    expect(res?.rows.every((r) => Boolean(r.value))).toBe(true)
+    expect(res?.maker_story).toBeNull()
+  })
+
+  it("never queries products when the quote has none to name", async () => {
+    const captureFilters: any[] = []
+    await resolveQuoteProvenance(
+      scopeWith({ captureFilters, profile: null }) as any,
+      { partner_id: "part_1", product_ids: [null, undefined as any] }
+    )
+
+    expect(captureFilters.map((c) => c.entity)).toEqual(["partners"])
+  })
+
+  it("says nothing rather than 500ing when the query falls over", async () => {
+    const res = await resolveQuoteProvenance(scopeWith({ graphThrows: true }) as any, {
+      partner_id: "part_1",
+      product_ids: ["prod_a"],
+    })
+    expect(res).toBeNull()
+  })
+
+  it("survives a partner who never finished onboarding", async () => {
+    const res = await resolveQuoteProvenance(
+      scopeWith({ profileThrows: true, products: [] }) as any,
+      { partner_id: "part_1", product_ids: [] }
+    )
+    // The name and country are partner-level; the profile rows are simply gone.
+    expect(res?.rows.map((r) => r.key)).toEqual(["maker", "country", "verified"])
+  })
+
+  it("says nothing for an inactive partner", async () => {
+    const res = await resolveQuoteProvenance(
+      scopeWith({ partners: [{ ...PARTNER, status: "suspended" }] }) as any,
+      { partner_id: "part_1", product_ids: ["prod_a"] }
+    )
+    expect(res).toBeNull()
+  })
+
+  it("says nothing when the quote has no partner", async () => {
+    const res = await resolveQuoteProvenance(scopeWith() as any, { partner_id: null })
+    expect(res).toBeNull()
+  })
+
+  it("returns null rather than an empty section when nothing is known", async () => {
+    const res = await resolveQuoteProvenance(
+      scopeWith({ partners: [{ id: "part_1", status: "active" }], profile: null }) as any,
+      { partner_id: "part_1", product_ids: [] }
+    )
+    expect(res).toBeNull()
+  })
+})

--- a/apps/backend/src/lib/provenance/resolve-provenance.ts
+++ b/apps/backend/src/lib/provenance/resolve-provenance.ts
@@ -109,9 +109,23 @@ export async function resolveQuoteProvenance(
     })
 
     const partner = ((partners ?? []) as any[])[0]
-    // An inactive partner's credentials are not a thing to show a buyer —
-    // same rule as the producer band.
-    if (!partner || (partner.status && partner.status !== "active")) return null
+    /**
+     * Only `inactive` is silent — deliberately NOT the producer band's
+     * "active or nothing" rule.
+     *
+     * 🔑 `pending` is the DEFAULT status of every partner the registration
+     * route creates, and nothing about minting a quote requires an admin to
+     * have flipped it. Refusing pending would have made this section render
+     * for almost nobody — a feature that is present, green and invisible,
+     * which is the exact condition #1448 exists to end. Caught by the
+     * integration run: the fixture partner mints a perfectly good quote and
+     * lands on `pending`.
+     *
+     * A disabled partner is different: their credentials are withdrawn, so
+     * they are not shown. And the one row that is an actual CLAIM — "Verified
+     * supplier" — is gated on `is_verified` inside the shaper, never on this.
+     */
+    if (!partner || partner.status === "inactive") return null
 
     let profile: any = null
     try {

--- a/apps/backend/src/lib/provenance/resolve-provenance.ts
+++ b/apps/backend/src/lib/provenance/resolve-provenance.ts
@@ -1,0 +1,170 @@
+import { ContainerRegistrationKeys } from "@medusajs/framework/utils"
+
+import { PARTNER_ONBOARDING_PROFILE_MODULE } from "../../modules/partner-onboarding-profile"
+import {
+  buildProvenance,
+  type Provenance,
+  type ProvenanceFacts,
+} from "./build-provenance"
+
+/**
+ * Fetch the facts `buildProvenance` shapes, for one quote (#1439 S9).
+ *
+ * The shaper has existed and been fully unit-tested since #1389 S2 and was
+ * imported by nothing. This is the missing half: it reads the three records —
+ * `partner`, `partner_onboarding_profile`, `artisan_product_detail` — and hands
+ * them over. It decides NOTHING about what a buyer sees; that is
+ * `build-provenance.ts`, and in particular its exclusion list is the security
+ * boundary. Do not shape rows here.
+ *
+ * ## Never throws
+ *
+ * Same contract as `resolveQuoteProducer`: provenance is enrichment, and a
+ * maker credit has no business turning a buyer's quote page into a 500. Every
+ * failure — no partner, no profile, a query that fell over — collapses to
+ * `null`, which the page reads as "say nothing".
+ *
+ * ## A basket has many products, and only ONE maker section
+ *
+ * The partner half is quote-level, so it is unambiguous. The product half is
+ * not: a basket can mix a made-to-order shawl with a stocked scarf, and
+ * printing the shawl's 21-day lead time over the whole quote is a claim about
+ * items it was never made about. So the product facts are reduced to what every
+ * quoted product AGREES on (`consensusArtisanDetail`) and the rest is dropped.
+ * A single-product quote — the common case — therefore keeps everything.
+ */
+
+/** The subset of `artisan_product_detail` that provenance reads. */
+export type ArtisanDetailFacts = NonNullable<ProvenanceFacts["artisan_detail"]>
+
+/**
+ * PURE: the product facts that hold for the WHOLE basket.
+ *
+ * A field survives only when every detail row that has an opinion agrees, and
+ * only when every quoted product HAS a detail row — a product with no row is a
+ * product we know nothing about, and an unanimous "21 days" across two of three
+ * items is still a false statement about the third.
+ *
+ * 🔑 Absent ⇒ absent. This never falls back to the first line: silently
+ * attributing one product's maker story to a mixed basket is exactly the
+ * misattribution the omit-don't-em-dash rule exists to prevent.
+ */
+export function consensusArtisanDetail(
+  details: Array<ArtisanDetailFacts | null | undefined>,
+  productCount: number
+): ArtisanDetailFacts | null {
+  const present = details.filter(Boolean) as ArtisanDetailFacts[]
+  if (!present.length) return null
+  // One product with no detail row at all ⇒ nothing is basket-wide.
+  if (productCount > 0 && present.length !== productCount) return null
+
+  const agreed = <K extends keyof ArtisanDetailFacts>(
+    key: K
+  ): ArtisanDetailFacts[K] | null => {
+    const values = present.map((d) => d?.[key] ?? null)
+    const first = values[0]
+    // `null` counts as an opinion here: "made to order" on one item and unset
+    // on another is a disagreement, not a default.
+    return values.every((v) => v === first) ? (first as any) : null
+  }
+
+  return {
+    maker_story: agreed("maker_story"),
+    lead_time_days: agreed("lead_time_days"),
+    lead_time_label: agreed("lead_time_label"),
+    min_order_quantity: agreed("min_order_quantity"),
+    made_to_order: agreed("made_to_order"),
+  }
+}
+
+/** PURE: is there anything here worth rendering a section for? */
+export function hasProvenance(p: Provenance | null | undefined): boolean {
+  return Boolean(p && (p.rows.length > 0 || p.maker_story))
+}
+
+export async function resolveQuoteProvenance(
+  scope: any,
+  input: { partner_id?: string | null; product_ids?: Array<string | null> }
+): Promise<Provenance | null> {
+  if (!input.partner_id) return null
+
+  try {
+    const query: any = scope.resolve(ContainerRegistrationKeys.QUERY)
+
+    // Filtered by id, always. An unfiltered partner read on a public,
+    // unauthenticated route is how one dangling key took every storefront
+    // down (#1397).
+    const { data: partners } = await query.graph({
+      entity: "partners",
+      fields: [
+        "id",
+        "name",
+        "handle",
+        "country_code",
+        "is_verified",
+        "workspace_type",
+        "status",
+      ],
+      filters: { id: input.partner_id },
+    })
+
+    const partner = ((partners ?? []) as any[])[0]
+    // An inactive partner's credentials are not a thing to show a buyer —
+    // same rule as the producer band.
+    if (!partner || (partner.status && partner.status !== "active")) return null
+
+    let profile: any = null
+    try {
+      const onboarding: any = scope.resolve(PARTNER_ONBOARDING_PROFILE_MODULE)
+      profile = await onboarding.findByPartner(input.partner_id)
+    } catch {
+      // A partner who never finished onboarding still has a name and a
+      // country. Losing the profile half costs rows, not the section.
+      profile = null
+    }
+
+    const productIds = [...new Set((input.product_ids ?? []).filter(Boolean))] as string[]
+    let artisanDetail: ArtisanDetailFacts | null = null
+    if (productIds.length) {
+      // 🔑 Only ever with a non-empty id list. `filters: { id: [] }` /
+      // `undefined` is NO FILTER, not "no rows" (#1433) — here that would
+      // read every artisan detail row in the database.
+      const { data: products } = await query.graph({
+        entity: "product",
+        // The product-side alias is the linked MODEL name; `artisan_detail.*`
+        // silently returns nothing (see links/product-artisan-detail.ts).
+        fields: ["id", "artisan_product_detail.*"],
+        filters: { id: productIds },
+      })
+      artisanDetail = consensusArtisanDetail(
+        ((products ?? []) as any[]).map((p) => p?.artisan_product_detail ?? null),
+        productIds.length
+      )
+    }
+
+    const provenance = buildProvenance({
+      partner: {
+        name: partner.name ?? null,
+        handle: partner.handle ?? null,
+        country_code: partner.country_code ?? null,
+        is_verified: partner.is_verified ?? null,
+        workspace_type: partner.workspace_type ?? null,
+      },
+      onboarding_profile: profile
+        ? {
+            what_they_sell: profile.what_they_sell ?? null,
+            person_type: profile.person_type ?? null,
+            team_size: profile.team_size ?? null,
+            does_weaving: profile.does_weaving ?? null,
+            does_stock: profile.does_stock ?? null,
+          }
+        : null,
+      artisan_detail: artisanDetail,
+    })
+
+    // A heading over an empty list is worse than no section at all.
+    return hasProvenance(provenance) ? provenance : null
+  } catch {
+    return null
+  }
+}

--- a/apps/backend/src/modules/partner-quote/__tests__/build-quote-view.unit.spec.ts
+++ b/apps/backend/src/modules/partner-quote/__tests__/build-quote-view.unit.spec.ts
@@ -58,11 +58,20 @@ type Captured = { contexts: any[]; rateWeights: number[] }
 
 const scopeWith = (
   captured: Captured,
-  over: { manual?: any[]; noOriginPostalCode?: boolean } = {}
+  over: {
+    manual?: any[]
+    noOriginPostalCode?: boolean
+    partner?: any
+    profile?: any
+    artisanDetail?: any
+  } = {}
 ) => {
   const manualOptions = over.manual ?? []
   return {
     resolve: (key: string) => {
+      if (String(key) === "partner_onboarding_profile") {
+        return { findByPartner: async () => over.profile ?? null }
+      }
       if (String(key).includes("cach")) {
         return { get: async () => null, set: async () => {} }
       }
@@ -92,6 +101,16 @@ const scopeWith = (
           if (args.entity === "variant") {
             const ids = Array.isArray(args.filters.id) ? args.filters.id : [args.filters.id]
             return { data: VARIANTS.filter((v) => ids.includes(v.id)) }
+          }
+          if (args.entity === "partners") {
+            return { data: over.partner ? [over.partner] : [] }
+          }
+          if (args.entity === "product") {
+            return {
+              data: over.artisanDetail
+                ? [{ id: "prod_a", artisan_product_detail: over.artisanDetail }]
+                : [],
+            }
           }
           if (args.entity === "stock_locations") {
             if (args.fields.some((f: string) => f.includes("fulfillment_sets"))) {
@@ -637,5 +656,46 @@ describe("buyerChangedInputs", () => {
         destination_postal_code: "400001",
       })
     ).toBe(true)
+  })
+})
+
+/**
+ * #1439 S9 — the maker section. The shaper and its resolver have their own
+ * suites; what matters HERE is only that the view carries the section and that
+ * a partner we cannot resolve costs a credit line rather than the whole page.
+ */
+describe("buildQuoteView — provenance", () => {
+  it("carries the maker section for a quote with a partner", async () => {
+    const captured: Captured = { contexts: [], rateWeights: [] }
+    const view = await buildQuoteView(
+      scopeWith(captured, {
+        partner: {
+          id: "part_1",
+          name: "Unique Pashmina",
+          country_code: "IN",
+          is_verified: true,
+          status: "active",
+        },
+        profile: { person_type: "artisan", does_weaving: true },
+        artisanDetail: { maker_story: "Woven on pit looms.", lead_time_days: 21 },
+      }) as any,
+      baseInput({ partner_id: "part_1" })
+    )
+
+    expect(view.provenance?.maker_name).toBe("Unique Pashmina")
+    expect(view.provenance?.maker_story).toBe("Woven on pit looms.")
+    expect(view.provenance?.rows.map((r) => r.key)).toContain("weaving")
+  })
+
+  it("prices the quote regardless of whether provenance resolves", async () => {
+    const captured: Captured = { contexts: [], rateWeights: [] }
+    const view = await buildQuoteView(
+      scopeWith(captured) as any,
+      baseInput({ partner_id: "part_missing" })
+    )
+
+    // Null is "say nothing", and the money is untouched by it.
+    expect(view.provenance).toBeNull()
+    expect(view.live?.landed_total).toBeGreaterThan(0)
   })
 })

--- a/apps/backend/src/modules/partner-quote/lib/build-quote-view.ts
+++ b/apps/backend/src/modules/partner-quote/lib/build-quote-view.ts
@@ -1,6 +1,10 @@
 import { ContainerRegistrationKeys, MedusaError, QueryContext } from "@medusajs/framework/utils"
 
 import {
+  resolveQuoteProvenance,
+} from "../../../lib/provenance/resolve-provenance"
+import type { Provenance } from "../../../lib/provenance/build-provenance"
+import {
   buildShippingEstimate,
   type ShippingEstimate,
   type ShippingEstimateOption,
@@ -178,6 +182,14 @@ export type QuoteView = {
    * storefront. Null means "say nothing", never "unknown producer".
    */
   producer: QuoteProducer | null
+  /**
+   * Who made this and how — the partner's public-safe credentials plus the
+   * product facts the whole basket agrees on (#1439 S9). Null means "say
+   * nothing": a thin partner profile degrades to silence, never to a grid of
+   * blanks. Rendered by the buyer page; the shaper's exclusion list is what
+   * keeps commercial terms off it.
+   */
+  provenance: Provenance | null
   expires_in_days: number | null
   /** Set when the live half could not be built, so callers can say why. */
   live_error: string | null
@@ -512,6 +524,13 @@ export async function buildQuoteView(
     viewer_sales_channel_ids: input.viewer_sales_channel_ids ?? null,
   })
 
+  // Same contract as the producer band: resolved after the money and unable to
+  // fail the view. A maker credit is not worth a buyer's 500.
+  const provenance = await resolveQuoteProvenance(scope, {
+    partner_id: input.partner_id ?? null,
+    product_ids: lines.map((l) => l.product_id),
+  })
+
   const compare = compareQuote({
     quoted,
     live,
@@ -542,6 +561,7 @@ export async function buildQuoteView(
       partner_note: input.quote?.partner_note ?? null,
     },
     producer,
+    provenance,
     expires_in_days: input.quote ? daysUntilExpiry(lifecycle, input.now) : null,
     live_error: liveError,
   }

--- a/apps/storefront/src/lib/data/quotes.ts
+++ b/apps/storefront/src/lib/data/quotes.ts
@@ -60,6 +60,30 @@ export type QuoteProducer = {
   url: string | null
 }
 
+/** One labelled, public-safe fact about the maker. #1439 S9 */
+export type ProvenanceRow = {
+  /** Stable machine key, so a renderer can style or reorder without parsing labels. */
+  key: string
+  label: string
+  value: string
+  /** Which record the fact came from — an unattributed fact is a claim. */
+  source: "partner" | "partner-onboarding-profile" | "artisan-product-detail"
+}
+
+/**
+ * Who made this, and how.
+ *
+ * 🔑 The backend OMITS a row whose fact is absent rather than em-dashing it, and
+ * excludes every commercial term. Render `rows` as given — never add a
+ * placeholder value, and never widen this shape client-side.
+ */
+export type Provenance = {
+  maker_name: string | null
+  /** Free prose, rendered as a paragraph rather than a row. */
+  maker_story: string | null
+  rows: ProvenanceRow[]
+}
+
 export type QuoteViewLine = {
   variant_id: string
   variant_title: string | null
@@ -128,6 +152,11 @@ export type QuoteView = {
    * again is noise.
    */
   producer: QuoteProducer | null
+  /**
+   * The maker section. Null means "say nothing" — a partner with a thin profile
+   * degrades to fewer rows, and one we know nothing about to no section at all.
+   */
+  provenance: Provenance | null
   expires_in_days: number | null
   live_error: string | null
 }

--- a/apps/storefront/src/modules/quotes/components/quote-provenance/index.tsx
+++ b/apps/storefront/src/modules/quotes/components/quote-provenance/index.tsx
@@ -1,0 +1,63 @@
+import { Heading, Text } from "@medusajs/ui"
+
+import type { Provenance } from "@lib/data/quotes"
+
+/**
+ * Who made this, and how (#1439 S9).
+ *
+ * 🔑 Every judgement here belongs to the BACKEND's `buildProvenance`. It
+ * decides which facts are public-safe — commercial terms, the partner's price
+ * band and their tax identifiers are all deliberately excluded there — and it
+ * OMITS a row whose fact is absent rather than em-dashing it. So this component
+ * renders `rows` as given: it must never add a fallback value, a placeholder or
+ * a "not specified", because an em-dash reads as "we know this and it is
+ * nothing", which is a different and wrong claim about a supplier.
+ *
+ * `provenance: null` means say nothing at all — the section, heading included,
+ * simply does not exist. A sparse partner therefore shows fewer rows; it never
+ * shows a grid of blanks.
+ *
+ * The story is prose and gets a paragraph; the rest are labelled facts and get
+ * a list. `source` is not rendered — it exists so a future surface can caption
+ * where a fact came from without parsing labels.
+ */
+const QuoteProvenanceSection = ({ provenance }: { provenance: Provenance }) => {
+  const { maker_name, maker_story, rows } = provenance
+  if (!rows.length && !maker_story) return null
+
+  return (
+    <div className="mt-10">
+      <Heading level="h2" className="text-xl-semi text-ui-fg-base mb-2">
+        {maker_name ? `About ${maker_name}` : "About this maker"}
+      </Heading>
+
+      {maker_story ? (
+        <Text className="txt-medium text-ui-fg-subtle whitespace-pre-line">
+          {maker_story}
+        </Text>
+      ) : null}
+
+      {rows.length ? (
+        <dl
+          className={`grid grid-cols-1 gap-x-8 gap-y-3 small:grid-cols-2 ${
+            maker_story ? "mt-6" : "mt-4"
+          }`}
+        >
+          {rows.map((row) => (
+            <div
+              key={row.key}
+              className="flex flex-col border-t border-ui-border-base pt-3"
+            >
+              <dt className="txt-small text-ui-fg-muted uppercase tracking-wide">
+                {row.label}
+              </dt>
+              <dd className="txt-medium text-ui-fg-base">{row.value}</dd>
+            </div>
+          ))}
+        </dl>
+      ) : null}
+    </div>
+  )
+}
+
+export default QuoteProvenanceSection

--- a/apps/storefront/src/modules/quotes/templates/index.tsx
+++ b/apps/storefront/src/modules/quotes/templates/index.tsx
@@ -3,6 +3,7 @@ import { Heading, Text } from "@medusajs/ui"
 import type { QuoteView } from "@lib/data/quotes"
 import QuoteLines from "../components/quote-lines"
 import QuoteProducerBand from "../components/quote-producer"
+import QuoteProvenanceSection from "../components/quote-provenance"
 import QuoteSummary from "../components/quote-summary"
 
 /**
@@ -19,7 +20,7 @@ import QuoteSummary from "../components/quote-summary"
  * up contradicting its own header.
  */
 const QuoteTemplate = ({ quote }: { quote: QuoteView }) => {
-  const { compare, recipient, producer } = quote
+  const { compare, recipient, producer, provenance } = quote
 
   return (
     <div className="content-container py-12 max-w-4xl">
@@ -74,6 +75,11 @@ const QuoteTemplate = ({ quote }: { quote: QuoteView }) => {
       <div className="mt-10">
         <QuoteSummary quote={quote} />
       </div>
+
+      {/* Who made this, and how. Below the money because it is the reason to
+          say yes rather than part of the offer, and rendered only when the
+          backend has something true to say. */}
+      {provenance ? <QuoteProvenanceSection provenance={provenance} /> : null}
 
       {compare.disclaimer ? (
         <div className="mt-10 border-t border-ui-border-base pt-6">

--- a/e2e/helpers/e2e-seed.ts
+++ b/e2e/helpers/e2e-seed.ts
@@ -322,6 +322,122 @@ async function seedProvenanceProductRun(container: any): Promise<string> {
 }
 
 /**
+ * #1439 S3/S4 — two quotes on one partner, so the admin quote surface can be
+ * driven in a browser (#1463 shipped without ever having been).
+ *
+ * Written straight through the module service rather than by driving a real
+ * mint: the mint needs a partner store with a priced product and a quotable
+ * freight lane, and the fixture only needs the END state the surface renders.
+ * The mint path itself is covered against a real container by
+ * `integration-tests/http/partner-quote-mint.spec.ts`.
+ *
+ * 🔑 TWO quotes, and the second is `superseded` on purpose. Active-only
+ * fixtures would let the surface treat every dead quote as a revocation, and
+ * "the partner withdrew this offer" is a different and wrong story to tell an
+ * operator about a quote that was simply re-issued (#1435).
+ *
+ * `token_hash` is random rather than a hash of a known token: the raw token is
+ * never persisted, and a fixture that pretended otherwise would model a
+ * recoverable link, which is exactly what the detail page states cannot exist.
+ */
+async function seedAdminQuotes(container: any): Promise<{
+  partnerId: string
+  partnerName: string
+  activeQuoteId: string
+  activeQuoteCompany: string
+  supersededQuoteId: string
+  supersededQuoteCompany: string
+}> {
+  const partnerModule: any = container.resolve("partner")
+  const quoteService: any = container.resolve("partner_quote")
+
+  const stamp = Date.now()
+
+  const createdPartner = await partnerModule.createPartners({
+    name: `E2E Quote Partner ${stamp}`,
+    handle: `e2e-quote-${stamp}`,
+    status: "active",
+    is_verified: true,
+  })
+  const partner = Array.isArray(createdPartner) ? createdPartner[0] : createdPartner
+
+  // Stamped company names: the spec SEARCHES for these, and the search reaches
+  // the server (#1461), so a duplicate from a previous seed would make a
+  // one-row assertion flap.
+  const activeCompany = `E2E Active Buyer ${stamp} Pvt Ltd`
+  const supersededCompany = `E2E Superseded Buyer ${stamp} Pvt Ltd`
+
+  const mkQuote = async (suffix: string, over: Record<string, any>) => {
+    const created = await quoteService.createPartnerQuotes({
+      partner_id: partner.id,
+      destination_country_code: "in",
+      destination_postal_code: "400001",
+      destination_city: "Mumbai",
+      currency_code: "inr",
+      quoted_subtotal: 800000,
+      quoted_freight: 15000,
+      quoted_landed_total: 815000,
+      quoted_weight_grams: 11800,
+      quoted_at: new Date(),
+      // 32 random hex chars — shaped like the sha256 the mint stores, and
+      // unique because the column is.
+      token_hash: `e2e${stamp}${Math.random().toString(16).slice(2)}${suffix}`,
+      expires_at: new Date(Date.now() + 7 * 24 * 3600 * 1000),
+      ...over,
+    })
+    const row = Array.isArray(created) ? created[0] : created
+
+    await quoteService.createPartnerQuoteLines([
+      {
+        quote_id: row.id,
+        variant_id: `variant_e2e_${stamp}_${suffix}`,
+        quantity: 25,
+        position: 0,
+        quoted_unit_amount: 28000,
+        quoted_subtotal: 700000,
+        quoted_unit_weight_grams: 400,
+        quoted_weight_source: "variant",
+      },
+    ])
+
+    return row.id as string
+  }
+
+  const activeQuoteId = await mkQuote("a", {
+    recipient_name: "Priya Menon",
+    recipient_company: activeCompany,
+    email_sent_to: `e2e-active-${stamp}@buyer.test`,
+    status: "active",
+  })
+
+  const supersededQuoteId = await mkQuote("s", {
+    recipient_name: "Rahul Iyer",
+    recipient_company: supersededCompany,
+    email_sent_to: `e2e-superseded-${stamp}@buyer.test`,
+    status: "superseded",
+  })
+
+  // One activity row, so the timeline renders its real shape rather than its
+  // "no activity recorded yet" fallback — the actor badge is the thing an
+  // operator reads first when a buyer challenges a price.
+  await quoteService.recordEvent({
+    quote_id: activeQuoteId,
+    type: "minted",
+    actor_type: "admin",
+    message: "Quote minted on the partner's behalf.",
+  })
+
+  return {
+    partnerId: partner.id as string,
+    partnerName: partner.name as string,
+    activeQuoteId,
+    activeQuoteCompany: activeCompany,
+    supersededQuoteId,
+    supersededQuoteCompany: supersededCompany,
+  }
+}
+
+/**
  * #1228 — a production run parked in `awaiting_reassignment`, plus the two
  * partners the reassign drawer picks between: the one that let it lapse
  * (`previous_partner_id`, the "same partner again" option) and a fresh one.
@@ -1082,6 +1198,9 @@ export default async function e2eSeed({ container }: ExecArgs) {
     gate.currencyCode
   )
 
+  logger.info("E2E seed: creating the #1439 admin quote fixtures (active + superseded)...")
+  const adminQuotes = await seedAdminQuotes(container)
+
   logger.info("E2E seed: creating the CRM contact + one logged activity...")
   const crmContact = await seedCrmContact(container)
 
@@ -1143,6 +1262,15 @@ export default async function e2eSeed({ container }: ExecArgs) {
     allocationMaterialCLabel: allocation.materialCLabel,
     allocationMaterialAId: allocation.materialAId,
     allocationMaterialCId: allocation.materialCId,
+    // #1439 S3/S4 admin quote surface — consumed by admin-quote-surface.spec.ts
+    // (admin, CI). NOT single-use: the spec cancels out of the revoke prompt
+    // rather than confirming it, so a re-run finds the same active quote.
+    quotePartnerId: adminQuotes.partnerId,
+    quotePartnerName: adminQuotes.partnerName,
+    activeQuoteId: adminQuotes.activeQuoteId,
+    activeQuoteCompany: adminQuotes.activeQuoteCompany,
+    supersededQuoteId: adminQuotes.supersededQuoteId,
+    supersededQuoteCompany: adminQuotes.supersededQuoteCompany,
   }
 
   fs.writeFileSync(SEED_FILE, JSON.stringify(seedData, null, 2))

--- a/e2e/specs/admin-quote-surface.spec.ts
+++ b/e2e/specs/admin-quote-surface.spec.ts
@@ -1,0 +1,176 @@
+import { test, expect } from "@playwright/test"
+import * as fs from "fs"
+import * as path from "path"
+
+const SEED_FILE = path.resolve(__dirname, "../../apps/backend/.e2e-seed.json")
+
+/**
+ * #1439 S3/S4 — the admin quote surface, driven through a browser.
+ *
+ * 🔑 Why this file exists: #1463 shipped the list, the detail page and the mint
+ * wizard, and **not one of them had ever been opened in a browser**. Every
+ * check that gated it — tsc, unit tests, `check:prod-build` — sees a component
+ * that compiles, not a page that renders. The failures this covers are the ones
+ * only a render can show: a hook called outside its provider (#1352), a table
+ * whose search never reaches the server (#1441), a route that 404s because its
+ * nesting moved.
+ *
+ * ## What is deliberately NOT done here
+ *
+ * The spec never CONFIRMS the revoke. Revoking deletes the price list behind
+ * the quote, and a fixture the suite destroys on first run is a fixture that
+ * passes once and then fails for a reason that has nothing to do with the code.
+ * The prompt is opened and cancelled — which is the assertion that matters
+ * anyway: that the destructive action is gated rather than one-click.
+ */
+test.describe("Admin quote surface (#1439 S3/S4)", () => {
+  let seed: {
+    email: string
+    password: string
+    quotePartnerName: string
+    activeQuoteId: string
+    activeQuoteCompany: string
+    supersededQuoteId: string
+    supersededQuoteCompany: string
+  }
+
+  test.beforeAll(() => {
+    if (!fs.existsSync(SEED_FILE)) {
+      throw new Error(
+        `E2E seed file not found at ${SEED_FILE}. Run "pnpm e2e:seed" first.`
+      )
+    }
+    seed = JSON.parse(fs.readFileSync(SEED_FILE, "utf-8"))
+    if (!seed.activeQuoteId) {
+      throw new Error("E2E seed missing activeQuoteId — re-run the seed.")
+    }
+  })
+
+  const login = async (page: any) => {
+    await page.goto("/app/login")
+    // `networkidle` never settles against `medusa develop` (the dev server
+    // holds long-lived connections open), so wait on the form itself.
+    await page.locator('input[name="email"]').waitFor({ timeout: 60000 })
+    await page.locator('input[name="email"]').fill(seed.email)
+    await page.locator('input[name="password"]').fill(seed.password)
+    await page.locator('button[type="submit"]').click()
+    await page.waitForURL(/\/app\/(?!login)/, { timeout: 15000 })
+  }
+
+  test("lists quotes and narrows to one on a server-side search", async ({
+    page,
+  }) => {
+    await login(page)
+    await page.goto("/app/quotes")
+
+    await expect(page.getByRole("heading", { name: "Quotes" })).toBeVisible({
+      timeout: 30000,
+    })
+
+    // Both fixtures are in the table before anything is typed.
+    await expect(page.getByText(seed.activeQuoteCompany)).toBeVisible({
+      timeout: 30000,
+    })
+
+    /**
+     * 🔑 The assertion that matters: the OTHER quote disappears. Until #1461
+     * the route returned every quote and the table filtered the page it had
+     * already been handed — which looks identical for a one-page fixture and
+     * is wrong the moment there are more quotes than a page. Asserting only
+     * "the match is visible" would have passed against that bug.
+     */
+    const search = page.getByPlaceholder("Search buyer, company or email...")
+    await search.fill(seed.activeQuoteCompany)
+
+    await expect(page.getByText(seed.supersededQuoteCompany)).toBeHidden({
+      timeout: 30000,
+    })
+    await expect(page.getByText(seed.activeQuoteCompany)).toBeVisible()
+  })
+
+  test("opens a quote from its row and shows the frozen totals and activity", async ({
+    page,
+  }) => {
+    await login(page)
+    await page.goto("/app/quotes")
+
+    await page.getByText(seed.activeQuoteCompany).first().click()
+    await page.waitForURL(new RegExp(`/app/quotes/${seed.activeQuoteId}`), {
+      timeout: 30000,
+    })
+
+    // The frozen evidence, and the buyer engagement the partner asks about.
+    await expect(page.getByText("Landed total")).toBeVisible({ timeout: 30000 })
+    await expect(page.getByText("Freight")).toBeVisible()
+    await expect(page.getByText("Not yet")).toBeVisible()
+
+    // 🔑 The link cannot be recovered, and the page says so instead of
+    // offering a copy button that could not work.
+    await expect(
+      page.getByText("Shown once at mint", { exact: false })
+    ).toBeVisible()
+
+    // The activity row, with its actor. An admin-minted quote must never look
+    // like one the partner made themselves.
+    await expect(page.getByText("minted", { exact: false }).first()).toBeVisible()
+    await expect(page.getByText("Admin", { exact: true }).first()).toBeVisible()
+  })
+
+  test("gates revoke behind a confirm that says what it deletes", async ({
+    page,
+  }) => {
+    await login(page)
+    await page.goto(`/app/quotes/${seed.activeQuoteId}`)
+
+    await expect(page.getByText("Landed total")).toBeVisible({ timeout: 30000 })
+
+    await page.getByRole("button", { name: /revoke quote/i }).first().click()
+    await expect(page.getByText("Revoke this quote?")).toBeVisible({
+      timeout: 15000,
+    })
+    // The consequence is stated, not implied: the price list goes with it.
+    await expect(
+      page.getByText("deletes the price list", { exact: false })
+    ).toBeVisible()
+
+    // Cancel, deliberately — see the file header.
+    await page.getByRole("button", { name: /^cancel$/i }).click()
+    await expect(page.getByText("Revoke this quote?")).toBeHidden()
+  })
+
+  test("shows a superseded quote as superseded, and offers no revoke on it", async ({
+    page,
+  }) => {
+    await login(page)
+    await page.goto(`/app/quotes/${seed.supersededQuoteId}`)
+
+    /**
+     * 🔑 Nobody withdrew this quote — a newer one for the same buyer replaced
+     * it and expired its price list (#1435). Rendering it as "Revoked" would
+     * tell an operator the partner pulled the offer, which is a different and
+     * wrong story. And there is nothing left to delete, so the action is
+     * absent rather than shown disabled.
+     */
+    await expect(page.getByText("Superseded").first()).toBeVisible({
+      timeout: 30000,
+    })
+    await expect(page.getByText("Revoked")).toBeHidden()
+    await expect(page.getByRole("button", { name: /revoke quote/i })).toHaveCount(
+      0
+    )
+  })
+
+  test("reaches the mint wizard from the list", async ({ page }) => {
+    await login(page)
+    await page.goto("/app/quotes")
+
+    await page.getByRole("button", { name: "Mint quote" }).click()
+    await page.waitForURL(/\/app\/quotes\/create/, { timeout: 30000 })
+
+    // The wizard renders its first step rather than a blank route — a page
+    // that compiles is not a page that mounts (#1352).
+    await expect(page.locator("form, [role=dialog]").first()).toBeVisible({
+      timeout: 30000,
+    })
+  })
+})


### PR DESCRIPTION
Closes #1448. Part of #1439 (S9). Storefront-starter half: Jaal-Yantra-Textiles/nextjs-starter-medusa#18 — merge together.

## The find

`src/lib/provenance/build-provenance.ts` has existed since #1389 S2, is fully unit-tested, and its docblock says it is "rendered by both the quote page and the quote email". `grep buildProvenance` matched only its own file and its test. This is the missing half.

## What was added

`resolve-provenance.ts` reads the three records the shaper needs — `partner`, `partner_onboarding_profile`, `artisan_product_detail` — and hands them over. It decides **nothing** about what a buyer sees; the shaper's exclusion list (`commission_bps`, `payment_collection`, `selling_mode`, `supplies_to_platform`, `tax_id`, `price_range`) is the security boundary and stays where it is.

Same contract as `resolveQuoteProducer`: it never throws. A maker credit has no business turning a buyer's quote page into a 500.

## A basket has many products and only one maker section

The partner half is quote-level and unambiguous. The product half is not: a basket can mix a made-to-order shawl with a stocked scarf, and printing the shawl's 21-day lead time over the whole quote is a claim about items it was never made about. `consensusArtisanDetail` keeps only what every quoted product agrees on, and drops everything when any quoted product has no detail row at all — unanimous across two of three items is still a false statement about the third. It never falls back to line one.

## Two things the container run caught

**`pending` is the default partner status.** The resolver first refused anything not `active`, mirroring the producer band — but every partner the registration route creates is `pending`, and nothing about minting a quote requires an admin to flip it. The section would have rendered for almost nobody: present, green and invisible, which is the exact condition this issue exists to end. Now only `inactive` is silent; the one row that is a *claim*, "Verified supplier", stays gated on `is_verified` inside the shaper.

**The leak test passed vacuously.** `JSON.stringify(null)` contains no commercial terms, so "publishes no commercial term" was green on the run where provenance came back null. It now asserts there is something to leak *from* first.

## Tests

- 17 resolver unit tests, including the mixed basket and the exclusion list
- 2 on `buildQuoteView`: the section is carried, and an unresolvable partner costs a credit line rather than the price
- 3 integration tests against a real container — the graph alias (`artisan_product_detail`, not `artisan_detail`, which returns nothing silently), the module-service read, the id-filtered partner query on a public route (#1397), and the route actually returning the block

## Also in this PR

`e2e/specs/admin-quote-surface.spec.ts` — #1463 shipped the quote list, detail page and mint wizard and **not one had ever been opened in a browser**. Covers list render, server-side search narrowing (asserting the *other* quote disappears, which is what distinguishes a real server filter from the pre-#1441 client-side one), detail, the revoke prompt gated-and-cancelled, and a superseded quote offering no revoke. The fixture writes two quotes through the module service; the mint path itself is already covered against a container by `partner-quote-mint.spec.ts`.

Not yet run — needs the local stack up.

🤖 Generated with [Claude Code](https://claude.com/claude-code)