### PR TITLE
feat(quote): a B2B per-line trade price, in the partner store's currency

### DIFF
--- a/apps/backend/integration-tests/http/partner-quote-line-override.spec.ts
+++ b/apps/backend/integration-tests/http/partner-quote-line-override.spec.ts
@@ -1,0 +1,231 @@
+import { getSharedTestEnv, setupSharedTestSuite } from "./shared-test-setup"
+import { createAdminUser } from "../helpers/create-admin-user"
+import { ContainerRegistrationKeys } from "@medusajs/framework/utils"
+import { PARTNER_QUOTE_MODULE } from "../../src/modules/partner-quote"
+import {
+  setupQuoteFixture,
+  mintBody,
+  type QuoteFixture,
+  VARIANT_A_TIER_PRICE,
+  VARIANT_B_PRICE,
+} from "../helpers/setup-quote-fixture"
+
+jest.setTimeout(240 * 1000)
+
+/**
+ * The B2B per-line trade price, against a database (#1439 S7).
+ *
+ * A B2B buyer does not pay retail, and until this slice a quote's
+ * `quoted_unit_amount` simply WAS the live catalog price at that quantity.
+ *
+ * ## What only a container run can check
+ *
+ * That the override reaches the PRICE LIST — the rows core will actually
+ * charge — and not merely the frozen columns. Those are two different writes,
+ * and a discount that lands on one but not the other is the worst outcome
+ * available: a quote page showing a trade price and a cart charging retail.
+ * The unit suite cannot see it; it is entirely in the wiring.
+ *
+ * The fixture is same-currency (INR store, INR quote), so no rate is fetched
+ * and the suite stays off the network. The FX arithmetic is pinned in
+ * `line-override.unit.spec.ts`, and `needsExchangeRate` is what keeps the
+ * common path from ever calling out.
+ */
+
+const loud = async <T>(label: string, fn: () => Promise<T>): Promise<T> => {
+  try {
+    return await fn()
+  } catch (e: any) {
+    console.log(`[${label}] ${e.response?.status}`, JSON.stringify(e.response?.data))
+    throw e
+  }
+}
+
+setupSharedTestSuite(() => {
+  describe("POST /partners/quotes — per-line override (#1446)", () => {
+    let seed: QuoteFixture
+
+    beforeAll(async () => {
+      const { api, getContainer } = getSharedTestEnv()
+      await createAdminUser(getContainer())
+      seed = await setupQuoteFixture(api, getContainer)
+    })
+
+    const readPriceRows = async (priceListId: string) => {
+      const container = getSharedTestEnv().getContainer()
+      const query: any = container.resolve(ContainerRegistrationKeys.QUERY)
+      const { data } = await query.graph({
+        entity: "price_list",
+        // ⚠️ No `variant_id` on a price-list price through the graph — a price
+        // belongs to a price SET, and the variant sits behind it. The quoted
+        // quantity is the usable key, and it is unique per line here.
+        fields: ["id", "prices.*"],
+        filters: { id: priceListId },
+      })
+      return ((data ?? [])[0]?.prices ?? []) as any[]
+    }
+
+    const readLines = async (quoteId: string) => {
+      const container = getSharedTestEnv().getContainer()
+      const service: any = container.resolve(PARTNER_QUOTE_MODULE)
+      return await service.listPartnerQuoteLines({ quote_id: quoteId })
+    }
+
+    it("quotes the catalog price when no override is given", async () => {
+      const { api } = getSharedTestEnv()
+      const res = await loud("mint-plain", () =>
+        api.post(
+          "/partners/quotes",
+          mintBody(seed, {
+            buyer_email: `buyer-plain-${seed.unique}@jaalyantra.test`,
+            lines: [{ variant_id: seed.variantA.id, quantity: 25 }],
+          }),
+          { headers: seed.headers }
+        )
+      )
+
+      const lines = await readLines(res.data.quote.id)
+      expect(Number(lines[0].quoted_unit_amount)).toBe(VARIANT_A_TIER_PRICE)
+      // Null, not zero and not a rate of 1: no decision was made, so none is
+      // recorded.
+      expect(lines[0].override_kind).toBeNull()
+      expect(lines[0].override_fx_rate).toBeNull()
+    })
+
+    it("applies a percentage to the PRICE LIST, not just the frozen row", async () => {
+      const { api } = getSharedTestEnv()
+      const res = await loud("mint-pct", () =>
+        api.post(
+          "/partners/quotes",
+          mintBody(seed, {
+            buyer_email: `buyer-pct-${seed.unique}@jaalyantra.test`,
+            lines: [
+              { variant_id: seed.variantA.id, quantity: 25, discount_percent: 20 },
+            ],
+          }),
+          { headers: seed.headers }
+        )
+      )
+
+      const expected = Math.round(VARIANT_A_TIER_PRICE * 0.8 * 100) / 100
+      const quote = res.data.quote
+
+      const lines = await readLines(quote.id)
+      expect(Number(lines[0].quoted_unit_amount)).toBe(expected)
+      expect(lines[0].override_kind).toBe("discount_percent")
+      expect(Number(lines[0].override_input_amount)).toBe(20)
+      // A percentage has no currency, and its rate is 1 by definition.
+      expect(lines[0].override_input_currency_code).toBeNull()
+      expect(Number(lines[0].override_fx_rate)).toBe(1)
+
+      // 🔴 THE assertion. The price list is what the cart charges; a discount
+      // that reached only the frozen row would show a trade price on the page
+      // and charge retail at checkout.
+      const rows = await readPriceRows(quote.price_list_id)
+      expect(rows).toHaveLength(1)
+      expect(Number(rows[0].amount)).toBe(expected)
+      expect(Number(rows[0].min_quantity)).toBe(25)
+      // And it is NOT the catalog price — the assertion that would still pass
+      // if the override had been dropped on the way to the price list.
+      expect(Number(rows[0].amount)).not.toBe(VARIANT_A_TIER_PRICE)
+
+      // And the basket totals follow the trade price, rather than the page
+      // and the price list disagreeing about the same quote.
+      expect(Number(quote.quoted_subtotal)).toBe(expected * 25)
+    })
+
+    it("applies a flat override, and leaves an un-overridden line alone", async () => {
+      const { api } = getSharedTestEnv()
+      const OVERRIDE = 19000
+      const res = await loud("mint-flat", () =>
+        api.post(
+          "/partners/quotes",
+          mintBody(seed, {
+            buyer_email: `buyer-flat-${seed.unique}@jaalyantra.test`,
+            lines: [
+              {
+                variant_id: seed.variantA.id,
+                quantity: 25,
+                override_unit_amount: OVERRIDE,
+              },
+              { variant_id: seed.variantB.id, quantity: 4 },
+            ],
+          }),
+          { headers: seed.headers }
+        )
+      )
+
+      const quote = res.data.quote
+      const lines = await readLines(quote.id)
+      const a = lines.find((l: any) => l.variant_id === seed.variantA.id)
+      const b = lines.find((l: any) => l.variant_id === seed.variantB.id)
+
+      expect(Number(a.quoted_unit_amount)).toBe(OVERRIDE)
+      expect(a.override_kind).toBe("override_unit_amount")
+      // Same currency, so the rate is 1 — but it is RECORDED as 1 rather than
+      // left null, because a conversion did happen, at parity.
+      expect(Number(a.override_fx_rate)).toBe(1)
+      expect(a.override_input_currency_code).toBe(seed.currencyCode)
+
+      // The other line is untouched: an override is per line, not per basket.
+      expect(Number(b.quoted_unit_amount)).toBe(VARIANT_B_PRICE)
+      expect(b.override_kind).toBeNull()
+
+      // Keyed on the quoted quantity, which is what distinguishes the two
+      // lines in the price list.
+      const rows = await readPriceRows(quote.price_list_id)
+      expect(Number(rows.find((r) => Number(r.min_quantity) === 25)?.amount)).toBe(
+        OVERRIDE
+      )
+      expect(Number(rows.find((r) => Number(r.min_quantity) === 4)?.amount)).toBe(
+        VARIANT_B_PRICE
+      )
+    })
+
+    it("🔴 refuses an override that would mint a price of zero, and writes NOTHING", async () => {
+      const { api } = getSharedTestEnv()
+      const container = getSharedTestEnv().getContainer()
+      const service: any = container.resolve(PARTNER_QUOTE_MODULE)
+      const before = (await service.listPartnerQuotes({})).length
+
+      await expect(
+        api.post(
+          "/partners/quotes",
+          mintBody(seed, {
+            buyer_email: `buyer-zero-${seed.unique}@jaalyantra.test`,
+            lines: [
+              { variant_id: seed.variantA.id, quantity: 25, discount_percent: 100 },
+            ],
+          }),
+          { headers: seed.headers }
+        )
+      ).rejects.toMatchObject({ response: { status: 400 } })
+
+      // An ACTIVE price of zero is one the cart cheerfully charges, so the
+      // refusal has to be total — no quote, no price list, no half-written row.
+      const after = (await service.listPartnerQuotes({})).length
+      expect(after).toBe(before)
+    })
+
+    it("refuses both override forms on one line", async () => {
+      const { api } = getSharedTestEnv()
+      await expect(
+        api.post(
+          "/partners/quotes",
+          mintBody(seed, {
+            buyer_email: `buyer-both-${seed.unique}@jaalyantra.test`,
+            lines: [
+              {
+                variant_id: seed.variantA.id,
+                quantity: 25,
+                discount_percent: 10,
+                override_unit_amount: 19000,
+              },
+            ],
+          }),
+          { headers: seed.headers }
+        )
+      ).rejects.toMatchObject({ response: { status: 400 } })
+    })
+  })
+})

--- a/apps/backend/src/admin/routes/quotes/create/mint-quote-form.tsx
+++ b/apps/backend/src/admin/routes/quotes/create/mint-quote-form.tsx
@@ -376,11 +376,20 @@ export const MintQuoteForm = () => {
             {lines.length === 0 ? (
               <Text size="small" className="text-ui-fg-subtle">
                 A quote is a basket — add at least one line. Multiple lines are
-                quoted as ONE consignment, so freight is charged once. Leave the
-                trade-price fields blank to quote at the catalog price; the unit
-                price is read in the partner store's own currency.
+                quoted as ONE consignment, so freight is charged once.
               </Text>
             ) : null}
+            {/* 🔴 Persistent, NOT part of the empty state: this is the note
+                that matters while someone is typing into the fields, and it
+                was briefly rendered only when there were no lines to type
+                into. A number entered in a USD quote is read in the partner
+                store's currency, and a field that does not say so is read as
+                the buyer's. */}
+            <Text size="small" className="text-ui-fg-subtle">
+              Leave the trade-price fields blank to quote at the catalog price.
+              A unit price is read in the partner store's own currency and
+              converted at mint; a discount is a percentage off the tier.
+            </Text>
             {lines.map((line, i) => (
               <div key={i} className="flex items-end gap-3">
                 <div className="flex flex-1 flex-col gap-y-2">

--- a/apps/backend/src/admin/routes/quotes/create/mint-quote-form.tsx
+++ b/apps/backend/src/admin/routes/quotes/create/mint-quote-form.tsx
@@ -22,7 +22,22 @@ import {
 import { MintedPanel } from "./minted-panel"
 import { ReadinessPanel } from "./readiness-panel"
 
-type Line = { variant_id: string; quantity: number }
+/**
+ * `discount_percent` and `override_unit_amount` are the trade price (#1446),
+ * and they are mutually exclusive per line — the backend refuses both together
+ * rather than ranking them.
+ *
+ * 🔑 The override is a unit price in the PARTNER STORE's default currency, not
+ * the quote's. The conversion happens once, at mint, at a rate the quote
+ * records; the label says so, because a number typed into a USD quote would
+ * otherwise be read as dollars.
+ */
+type Line = {
+  variant_id: string
+  quantity: number
+  discount_percent?: number | null
+  override_unit_amount?: number | null
+}
 
 /**
  * Mint a quote on a partner's behalf (#1419, stepped in #1444).
@@ -209,7 +224,17 @@ export const MintQuoteForm = () => {
   }
 
   const addLine = () =>
-    setLines((prev) => [...prev, { variant_id: "", quantity: 1 }])
+    setLines((prev) => [
+      ...prev,
+      {
+        variant_id: "",
+        quantity: 1,
+        // Undefined, never 0 — a blank field is "no override", and a 0 would
+        // ask the backend to mint an ACTIVE price of zero, which it refuses.
+        discount_percent: undefined,
+        override_unit_amount: undefined,
+      },
+    ])
 
   const isLast = tab === Tab.REVIEW
 
@@ -351,7 +376,9 @@ export const MintQuoteForm = () => {
             {lines.length === 0 ? (
               <Text size="small" className="text-ui-fg-subtle">
                 A quote is a basket — add at least one line. Multiple lines are
-                quoted as ONE consignment, so freight is charged once.
+                quoted as ONE consignment, so freight is charged once. Leave the
+                trade-price fields blank to quote at the catalog price; the unit
+                price is read in the partner store's own currency.
               </Text>
             ) : null}
             {lines.map((line, i) => (
@@ -379,16 +406,75 @@ export const MintQuoteForm = () => {
                     </Select.Content>
                   </Select>
                 </div>
-                <div className="w-28">
+                <div className="w-24">
                   <Input
                     type="number"
                     min={1}
+                    placeholder="Qty"
                     value={line.quantity}
                     onChange={(e) =>
                       setLines((prev) =>
                         prev.map((l, idx) =>
                           idx === i
                             ? { ...l, quantity: Number(e.target.value) }
+                            : l
+                        )
+                      )
+                    }
+                  />
+                </div>
+                {/* An empty string must clear back to undefined rather than
+                    becoming 0: `Number("")` is 0, and a 0 here is a request to
+                    mint a free line. */}
+                <div className="w-24">
+                  <Input
+                    type="number"
+                    min={0}
+                    max={100}
+                    placeholder="Disc %"
+                    disabled={
+                      line.override_unit_amount !== null &&
+                      line.override_unit_amount !== undefined
+                    }
+                    value={line.discount_percent ?? ""}
+                    onChange={(e) =>
+                      setLines((prev) =>
+                        prev.map((l, idx) =>
+                          idx === i
+                            ? {
+                                ...l,
+                                discount_percent:
+                                  e.target.value === ""
+                                    ? undefined
+                                    : Number(e.target.value),
+                              }
+                            : l
+                        )
+                      )
+                    }
+                  />
+                </div>
+                <div className="w-32">
+                  <Input
+                    type="number"
+                    min={0}
+                    placeholder="Unit price"
+                    disabled={
+                      line.discount_percent !== null &&
+                      line.discount_percent !== undefined
+                    }
+                    value={line.override_unit_amount ?? ""}
+                    onChange={(e) =>
+                      setLines((prev) =>
+                        prev.map((l, idx) =>
+                          idx === i
+                            ? {
+                                ...l,
+                                override_unit_amount:
+                                  e.target.value === ""
+                                    ? undefined
+                                    : Number(e.target.value),
+                              }
                             : l
                         )
                       )

--- a/apps/backend/src/api/partners/quotes/validators.ts
+++ b/apps/backend/src/api/partners/quotes/validators.ts
@@ -1,11 +1,49 @@
 import { z } from "@medusajs/framework/zod"
 
-const QuoteLine = z.object({
-  variant_id: z.string().min(1),
-  quantity: z.number().int().positive(),
-  position: z.number().int().nonnegative().optional(),
-  note: z.string().nullish(),
-})
+/**
+ * One line of the basket, with its optional trade price (#1439 S7).
+ *
+ * 🔑 `override_unit_amount` is entered in the PARTNER STORE's default
+ * currency, not the quote's. A partner negotiating in Mumbai thinks in rupees
+ * whatever currency the buyer is being quoted in, so the number they type is
+ * authoritative and the conversion happens once, at mint, at a rate persisted
+ * beside the result.
+ *
+ * The two forms are mutually exclusive by construction. "Which one wins" is
+ * not a question that should have an answer, so the schema refuses both rather
+ * than ranking them — and `resolveLineOverride` refuses them again, because the
+ * admin twin and any future caller reach the pure function too.
+ *
+ * 🔴 A resolved price of zero is refused downstream, not here. `0` is a valid
+ * number and a plausible typo, and an ACTIVE price of zero is one the cart
+ * cheerfully charges — see the note in `lib/line-override.ts`.
+ */
+const QuoteLine = z
+  .object({
+    variant_id: z.string().min(1),
+    quantity: z.number().int().positive(),
+    position: z.number().int().nonnegative().optional(),
+    note: z.string().nullish(),
+
+    /** 0-100, off the live catalog price at this line's quantity. */
+    discount_percent: z.number().min(0).max(100).nullish(),
+    /** A flat unit price, in the partner store's default currency. */
+    override_unit_amount: z.number().positive().nullish(),
+  })
+  .refine(
+    (l) =>
+      !(
+        l.discount_percent !== null &&
+        l.discount_percent !== undefined &&
+        l.override_unit_amount !== null &&
+        l.override_unit_amount !== undefined
+      ),
+    {
+      message:
+        "A line takes either a discount_percent or an override_unit_amount, never both.",
+      path: ["override_unit_amount"],
+    }
+  )
 
 export const PartnerMintQuoteReq = z.object({
   buyer_email: z.string().email(),

--- a/apps/backend/src/lib/fx/exchange-rate.ts
+++ b/apps/backend/src/lib/fx/exchange-rate.ts
@@ -1,0 +1,75 @@
+/**
+ * Live FX, one implementation (#1439 S7).
+ *
+ * Extracted verbatim from `workflows/designs/create-draft-order-from-designs.ts`,
+ * which is where it was born and where it stayed exported. A second caller
+ * — the B2B quote line override — must not reach into a designs workflow to
+ * convert a currency: that import would make the quote path depend on an
+ * unrelated workflow's module graph, and the next caller would copy the
+ * function instead.
+ *
+ * Rates come from the Frankfurter API (ECB data, free, no key) and update once
+ * per business day, so an in-memory hour of caching costs nothing in accuracy
+ * and takes the network off the hot path.
+ *
+ * 🔴 This THROWS on failure, deliberately, and callers must not swallow it.
+ * A conversion that silently falls back to rate 1 does not fail — it quotes a
+ * buyer 45,000 INR as 45,000 USD. Where an unavailable rate should not block
+ * the work, the caller's job is to refuse the OPERATION, not to invent a
+ * number. (Contrast `calculatePrice` on a shipping provider, where a defined
+ * logged fallback is right because a throw blanks the whole options list.)
+ */
+
+type FrankfurterResponse = {
+  base: string
+  date: string
+  rates: Record<string, number>
+}
+
+const frankfurterCache = new Map<string, { rate: number; fetchedAt: number }>()
+const CACHE_TTL_MS = 60 * 60 * 1000
+
+export async function fetchExchangeRate(
+  from: string,
+  to: string
+): Promise<number> {
+  const fromUpper = from.toUpperCase()
+  const toUpper = to.toUpperCase()
+
+  if (fromUpper === toUpper) return 1
+
+  const cacheKey = `${fromUpper}_${toUpper}`
+  const cached = frankfurterCache.get(cacheKey)
+  if (cached && Date.now() - cached.fetchedAt < CACHE_TTL_MS) {
+    return cached.rate
+  }
+
+  const url = `https://api.frankfurter.app/latest?from=${fromUpper}&to=${toUpper}`
+  const res = await fetch(url)
+
+  if (!res.ok) {
+    throw new Error(
+      `Failed to fetch exchange rate ${fromUpper}→${toUpper}: ${res.status} ${res.statusText}`
+    )
+  }
+
+  const data: FrankfurterResponse = await res.json()
+  const rate = data.rates[toUpper]
+
+  if (rate == null) {
+    throw new Error(`Exchange rate not available for ${fromUpper}→${toUpper}`)
+  }
+
+  frankfurterCache.set(cacheKey, { rate, fetchedAt: Date.now() })
+  return rate
+}
+
+/** PURE. Two decimals, because a price is money and not a float. */
+export function applyRate(amount: number, rate: number): number {
+  return Math.round(amount * rate * 100) / 100
+}
+
+/** Test seam: the cache is process-global and would leak between cases. */
+export function __clearExchangeRateCache(): void {
+  frankfurterCache.clear()
+}

--- a/apps/backend/src/modules/partner-quote/migrations/Migration20260822093000.ts
+++ b/apps/backend/src/modules/partner-quote/migrations/Migration20260822093000.ts
@@ -1,0 +1,48 @@
+import { Migration } from "@medusajs/framework/mikro-orm/migrations";
+
+/**
+ * #1439 S7 — record HOW a quoted line's price was reached.
+ *
+ * `quoted_unit_amount` was always the final number, but until now it was
+ * always the live catalog price: there was no discount concept anywhere in the
+ * quote path, so a partner could not quote a trade price at all.
+ *
+ * These four columns hold the partner's actual input beside the result. The
+ * input amount is what they TYPED, in the store's default currency — the one
+ * they negotiate in — and the rate is the one applied at mint. All three are
+ * needed together: a quoted number that cannot be reproduced once FX has moved
+ * is not evidence, and FX is precisely the input that will have moved by the
+ * time a buyer disputes a price.
+ *
+ * Every column is nullable and nothing is backfilled. A line quoted at its
+ * catalog price has no override, and writing a 0 or a rate of 1 onto historic
+ * rows would invent a decision nobody made.
+ */
+export class Migration20260822093000 extends Migration {
+
+  override async up(): Promise<void> {
+    this.addSql(`alter table if exists "partner_quote_line" add column if not exists "override_kind" text null;`);
+    // ⚠️ A DML `bigNumber` is TWO columns: the numeric one and a `raw_*` jsonb
+    // companion that carries the precision. Adding only the numeric one lets
+    // tsc, the model and every unit test pass, and then fails the INSERT at
+    // runtime with `column "raw_override_input_amount" does not exist` — which
+    // is exactly how this was caught, on the first real mint.
+    this.addSql(`alter table if exists "partner_quote_line" add column if not exists "override_input_amount" numeric null;`);
+    this.addSql(`alter table if exists "partner_quote_line" add column if not exists "raw_override_input_amount" jsonb null;`);
+    this.addSql(`alter table if exists "partner_quote_line" add column if not exists "override_input_currency_code" text null;`);
+    this.addSql(`alter table if exists "partner_quote_line" add column if not exists "override_fx_rate" real null;`);
+
+    this.addSql(`alter table if exists "partner_quote_line" drop constraint if exists "partner_quote_line_override_kind_check";`);
+    this.addSql(`alter table if exists "partner_quote_line" add constraint "partner_quote_line_override_kind_check" check ("override_kind" is null or "override_kind" in ('discount_percent', 'override_unit_amount'));`);
+  }
+
+  override async down(): Promise<void> {
+    this.addSql(`alter table if exists "partner_quote_line" drop constraint if exists "partner_quote_line_override_kind_check";`);
+    this.addSql(`alter table if exists "partner_quote_line" drop column if exists "override_kind";`);
+    this.addSql(`alter table if exists "partner_quote_line" drop column if exists "override_input_amount";`);
+    this.addSql(`alter table if exists "partner_quote_line" drop column if exists "raw_override_input_amount";`);
+    this.addSql(`alter table if exists "partner_quote_line" drop column if exists "override_input_currency_code";`);
+    this.addSql(`alter table if exists "partner_quote_line" drop column if exists "override_fx_rate";`);
+  }
+
+}

--- a/apps/backend/src/modules/partner-quote/models/partner-quote-line.ts
+++ b/apps/backend/src/modules/partner-quote/models/partner-quote-line.ts
@@ -45,6 +45,30 @@ const PartnerQuoteLine = model.define("partner_quote_line", {
   quoted_unit_weight_grams: model.number().nullable(),
   quoted_weight_source: model.enum(["variant", "product"]).nullable(),
 
+  // ===== The trade price, and how it was arrived at (#1439 S7) =============
+  /**
+   * A B2B buyer does not pay retail. `quoted_unit_amount` above is the FINAL
+   * number either way — these columns record how it was reached, so the quote
+   * is auditable rather than reverse-engineered later.
+   *
+   * 🔑 `override_input_amount` is what the partner actually TYPED, before any
+   * conversion, and `override_input_currency_code` is the partner store's
+   * default currency — the one they think in. `override_fx_rate` is the rate
+   * applied at mint. Without all three, a quoted number cannot be reproduced
+   * once the rate has moved, and an unreproducible number is not evidence.
+   *
+   * Null on every line that was quoted at its catalog price, which is most of
+   * them.
+   */
+  override_kind: model
+    .enum(["discount_percent", "override_unit_amount"])
+    .nullable(),
+  override_input_amount: model.bigNumber().nullable(),
+  /** Null for a percentage — a percentage has no currency. */
+  override_input_currency_code: model.text().nullable(),
+  /** 1 for a percentage and for a same-currency override. */
+  override_fx_rate: model.float().nullable(),
+
   /** Partner's per-line note to the buyer. Human-entered: render with {{ }}. */
   note: model.text().nullable(),
 

--- a/apps/backend/src/workflows/designs/create-draft-order-from-designs.ts
+++ b/apps/backend/src/workflows/designs/create-draft-order-from-designs.ts
@@ -7,6 +7,7 @@ import {
 import { ContainerRegistrationKeys, Modules } from "@medusajs/framework/utils"
 import { DESIGN_MODULE } from "../../modules/designs"
 import { pickDefaultCurrency } from "../../lib/resolve-store-currency"
+import { applyRate, fetchExchangeRate } from "../../lib/fx/exchange-rate"
 import {
   estimateDesignCostWorkflow,
   EstimateCostOutput,
@@ -99,51 +100,6 @@ const estimateDesignCostsStep = createStep(
 // Handles two source currencies:
 //   - Estimated prices: assumed to be in store default currency
 //   - Manual overrides: in override_currency (if provided), else store default
-
-type FrankfurterResponse = {
-  base: string
-  date: string
-  rates: Record<string, number>
-}
-
-const frankfurterCache = new Map<string, { rate: number; fetchedAt: number }>()
-const CACHE_TTL_MS = 60 * 60 * 1000
-
-async function fetchExchangeRate(from: string, to: string): Promise<number> {
-  const fromUpper = from.toUpperCase()
-  const toUpper = to.toUpperCase()
-
-  if (fromUpper === toUpper) return 1
-
-  const cacheKey = `${fromUpper}_${toUpper}`
-  const cached = frankfurterCache.get(cacheKey)
-  if (cached && Date.now() - cached.fetchedAt < CACHE_TTL_MS) {
-    return cached.rate
-  }
-
-  const url = `https://api.frankfurter.app/latest?from=${fromUpper}&to=${toUpper}`
-  const res = await fetch(url)
-
-  if (!res.ok) {
-    throw new Error(
-      `Failed to fetch exchange rate ${fromUpper}→${toUpper}: ${res.status} ${res.statusText}`
-    )
-  }
-
-  const data: FrankfurterResponse = await res.json()
-  const rate = data.rates[toUpper]
-
-  if (rate == null) {
-    throw new Error(`Exchange rate not available for ${fromUpper}→${toUpper}`)
-  }
-
-  frankfurterCache.set(cacheKey, { rate, fetchedAt: Date.now() })
-  return rate
-}
-
-function applyRate(amount: number, rate: number): number {
-  return Math.round(amount * rate * 100) / 100
-}
 
 const convertEstimateCurrencyStep = createStep(
   "convert-estimate-currency-step",
@@ -414,4 +370,9 @@ export default createDraftOrderFromDesignsWorkflow
 
 // ─── Exported for use in store checkout route ────────────────────────────────
 
+/**
+ * Kept as a re-export: the implementation moved to `lib/fx/exchange-rate.ts`
+ * when the B2B quote line override became its second caller (#1439 S7). A
+ * quote path must not import a designs workflow to convert a currency.
+ */
 export { fetchExchangeRate, applyRate }

--- a/apps/backend/src/workflows/partner-quote/__tests__/line-override.unit.spec.ts
+++ b/apps/backend/src/workflows/partner-quote/__tests__/line-override.unit.spec.ts
@@ -1,0 +1,164 @@
+import {
+  needsExchangeRate,
+  resolveLineOverride,
+} from "../lib/line-override"
+
+/**
+ * The trade price for one quoted line (#1439 S7).
+ *
+ * The assertion that matters most is the one about ZERO. `planQuotePrices`
+ * drops a null rather than defaulting, which keeps an unpriceable line out of
+ * the price list — but a zero is a perfectly valid number, so nothing drops it,
+ * and it becomes an ACTIVE price of zero that the cart cheerfully charges.
+ * Arithmetic is the fastest way to one, so every path that can produce it is
+ * pinned here.
+ */
+
+const base = {
+  live_unit_amount: 1000,
+  fx_rate: 1,
+  store_currency_code: "inr",
+  quote_currency_code: "inr",
+}
+
+describe("resolveLineOverride", () => {
+  it("leaves the catalog price alone when no override is given", () => {
+    const res = resolveLineOverride(base)
+    expect(res.unit_amount).toBe(1000)
+    expect(res.override).toBeNull()
+  })
+
+  it("passes a null live price straight through rather than inventing one", () => {
+    const res = resolveLineOverride({ ...base, live_unit_amount: null })
+    // Null, not 0 — `planQuotePrices` drops it, which is the correct outcome
+    // for a line the builder could not price.
+    expect(res.unit_amount).toBeNull()
+  })
+
+  it("takes a percentage off the live price", () => {
+    const res = resolveLineOverride({ ...base, discount_percent: 15 })
+    expect(res.unit_amount).toBe(850)
+    expect(res.override).toEqual({
+      kind: "discount_percent",
+      input_amount: 15,
+      // A percentage has no currency, and recording one would invite a reader
+      // to convert it.
+      input_currency_code: null,
+      fx_rate: 1,
+    })
+  })
+
+  it("takes a flat override in the STORE's currency and records what was typed", () => {
+    const res = resolveLineOverride({ ...base, override_unit_amount: 725 })
+    expect(res.unit_amount).toBe(725)
+    expect(res.override?.input_amount).toBe(725)
+    expect(res.override?.input_currency_code).toBe("inr")
+  })
+
+  it("converts a flat override into the quote currency and persists the rate", () => {
+    // The partner types rupees; the buyer is quoted in dollars.
+    const res = resolveLineOverride({
+      ...base,
+      quote_currency_code: "usd",
+      fx_rate: 0.012,
+      override_unit_amount: 60000,
+    })
+    expect(res.unit_amount).toBe(720)
+    // 🔑 The rate travels with the number. A quoted amount that cannot be
+    // reproduced later is not evidence, and FX is exactly the input that will
+    // have moved by the time anyone asks.
+    expect(res.override?.fx_rate).toBe(0.012)
+    expect(res.override?.input_amount).toBe(60000)
+    expect(res.override?.input_currency_code).toBe("inr")
+  })
+
+  describe("🔴 never mints a price of zero", () => {
+    it("refuses a 100% discount", () => {
+      expect(() =>
+        resolveLineOverride({ ...base, discount_percent: 100 })
+      ).toThrow(/ACTIVE price of zero/)
+    })
+
+    it("refuses a flat override of 0", () => {
+      expect(() =>
+        resolveLineOverride({ ...base, override_unit_amount: 0 })
+      ).toThrow(/ACTIVE price of zero/)
+    })
+
+    it("refuses a negative override", () => {
+      expect(() =>
+        resolveLineOverride({ ...base, override_unit_amount: -50 })
+      ).toThrow(/ACTIVE price of zero/)
+    })
+
+    it("refuses a discount that rounds down to nothing", () => {
+      // 99.999% of a 1000 unit price is 0.01 — still positive, still a real
+      // decision. 100% of 0.004 is what this guards.
+      expect(() =>
+        resolveLineOverride({ ...base, live_unit_amount: 0.004, discount_percent: 50 })
+      ).toThrow(/ACTIVE price of zero/)
+    })
+  })
+
+  it("refuses a discount_percent outside 0-100", () => {
+    expect(() => resolveLineOverride({ ...base, discount_percent: 120 })).toThrow(
+      /between 0 and 100/
+    )
+    expect(() => resolveLineOverride({ ...base, discount_percent: -5 })).toThrow(
+      /between 0 and 100/
+    )
+  })
+
+  it("refuses a percentage on a line with no live price", () => {
+    // A percentage OFF nothing is not a price.
+    expect(() =>
+      resolveLineOverride({ ...base, live_unit_amount: null, discount_percent: 10 })
+    ).toThrow(/needs a live price/)
+  })
+
+  it("refuses both kinds on one line — 'which wins' must have no answer", () => {
+    expect(() =>
+      resolveLineOverride({
+        ...base,
+        discount_percent: 10,
+        override_unit_amount: 700,
+      })
+    ).toThrow(/never both/)
+  })
+
+  it("refuses to convert without a usable rate rather than quoting rate 1", () => {
+    // 🔴 A silent fallback to 1 does not fail — it quotes 60,000 INR as
+    // 60,000 USD.
+    expect(() =>
+      resolveLineOverride({
+        ...base,
+        quote_currency_code: "usd",
+        fx_rate: 0,
+        override_unit_amount: 60000,
+      })
+    ).toThrow(/No usable exchange rate/)
+  })
+})
+
+describe("needsExchangeRate", () => {
+  const flat = [{ override_unit_amount: 700 }]
+
+  it("is false when the store and quote currencies match", () => {
+    // The common case must never touch the network, and an FX outage must
+    // never block a same-currency mint.
+    expect(needsExchangeRate(flat, "inr", "inr")).toBe(false)
+    // Case is a storage detail, not a different currency.
+    expect(needsExchangeRate(flat, "INR", "inr")).toBe(false)
+  })
+
+  it("is false when no line carries a flat override", () => {
+    // A percentage needs no rate: it applies to a number already in the quote
+    // currency.
+    expect(needsExchangeRate([{ override_unit_amount: null }], "inr", "usd")).toBe(false)
+    expect(needsExchangeRate([], "inr", "usd")).toBe(false)
+  })
+
+  it("is true only for a cross-currency flat override", () => {
+    expect(needsExchangeRate(flat, "inr", "usd")).toBe(true)
+  })
+})

--- a/apps/backend/src/workflows/partner-quote/lib/line-override.ts
+++ b/apps/backend/src/workflows/partner-quote/lib/line-override.ts
@@ -1,0 +1,189 @@
+import { MedusaError } from "@medusajs/framework/utils"
+
+import { applyRate } from "../../../lib/fx/exchange-rate"
+
+/**
+ * PURE: the trade price for one quoted line (#1439 S7).
+ *
+ * ## Why an override exists at all
+ *
+ * Until this, a quote's `quoted_unit_amount` WAS the live catalog price at that
+ * quantity — `planQuotePrices` copied whatever the builder produced. There was
+ * no discount concept anywhere in the quote path, so a partner could not
+ * actually quote a trade price. A B2B buyer does not pay retail.
+ *
+ * ## The override is entered in the STORE's default currency
+ *
+ * Founder's call, and it is the honest one: a partner negotiating in Mumbai
+ * thinks in rupees whatever currency the buyer is being quoted in. So the
+ * number they type is authoritative, and the conversion happens here, ONCE, at
+ * mint — never on read. The rate used is persisted alongside, because a quoted
+ * number that cannot be reproduced later is not evidence, and an FX rate is
+ * exactly the input that will have moved by the time anyone asks.
+ *
+ * ## What this is NOT
+ *
+ * Not a promotion. It belongs in the frozen quote, not in a discount rule the
+ * cart re-evaluates: the cart would then apply it to whatever the catalog price
+ * has become, and two numbers that were supposed to agree would drift.
+ */
+
+export type LineOverrideInput = {
+  /** The live catalog price at this line's quantity, in the QUOTE currency. */
+  live_unit_amount: number | null
+  /** 0-100. Applied to the live amount; no currency involved. */
+  discount_percent?: number | null
+  /** A flat unit price, in the STORE's default currency. */
+  override_unit_amount?: number | null
+  /** store default currency → quote currency. 1 when they are the same. */
+  fx_rate: number
+  store_currency_code: string
+  quote_currency_code: string
+}
+
+export type LineOverride = {
+  kind: "discount_percent" | "override_unit_amount"
+  /** Exactly what the partner typed, before any conversion. */
+  input_amount: number
+  /** Null for a percentage — a percentage has no currency. */
+  input_currency_code: string | null
+  /** The rate applied. 1 for a percentage, and for a same-currency override. */
+  fx_rate: number
+}
+
+export type ResolvedLine = {
+  /** The ONE number that reaches both the price list and the frozen row. */
+  unit_amount: number | null
+  override: LineOverride | null
+}
+
+/**
+ * Resolve one line.
+ *
+ * 🔴 Never returns a zero or negative amount — it throws instead.
+ *
+ * `planQuotePrices` drops a null rather than defaulting, and that is the
+ * safeguard that keeps an unpriceable line out of the price list. A ZERO is
+ * different and far worse: it is a perfectly valid number, so nothing drops it,
+ * and it becomes an ACTIVE price of zero that the cart cheerfully charges. The
+ * fastest route to one is arithmetic — `discount_percent: 100`, or an override
+ * of 0 typed into a form — so the refusal lives here, at the only place that
+ * can tell the difference between "no price" and "free".
+ *
+ * A partner who genuinely means free has to say so somewhere that states it,
+ * not arrive at it through a percentage field.
+ */
+export function resolveLineOverride(input: LineOverrideInput): ResolvedLine {
+  const live =
+    input.live_unit_amount === null || input.live_unit_amount === undefined
+      ? null
+      : Number(input.live_unit_amount)
+
+  const hasPercent =
+    input.discount_percent !== null &&
+    input.discount_percent !== undefined &&
+    Number.isFinite(Number(input.discount_percent))
+  const hasFlat =
+    input.override_unit_amount !== null &&
+    input.override_unit_amount !== undefined &&
+    Number.isFinite(Number(input.override_unit_amount))
+
+  if (hasPercent && hasFlat) {
+    // The validator refuses this too. Refusing it HERE as well is deliberate:
+    // the pure function is reachable from the admin twin and from any future
+    // caller, and "which one wins" is not a question that should have an
+    // answer.
+    throw new MedusaError(
+      MedusaError.Types.INVALID_DATA,
+      "A line takes either a discount_percent or an override_unit_amount, never both."
+    )
+  }
+
+  if (!hasPercent && !hasFlat) {
+    return { unit_amount: live, override: null }
+  }
+
+  const rate = Number(input.fx_rate)
+  if (!Number.isFinite(rate) || rate <= 0) {
+    throw new MedusaError(
+      MedusaError.Types.INVALID_DATA,
+      `No usable exchange rate for ${input.store_currency_code} → ${input.quote_currency_code}. ` +
+        "Nothing is quoted rather than quoting a converted number we cannot stand behind."
+    )
+  }
+
+  let amount: number
+  let override: LineOverride
+
+  if (hasFlat) {
+    const typed = Number(input.override_unit_amount)
+    // The rate is 1 when the two currencies match, so this is the same code
+    // path either way — no branch that only the cross-currency case exercises.
+    amount = applyRate(typed, rate)
+    override = {
+      kind: "override_unit_amount",
+      input_amount: typed,
+      input_currency_code: input.store_currency_code,
+      fx_rate: rate,
+    }
+  } else {
+    const percent = Number(input.discount_percent)
+    if (percent < 0 || percent > 100) {
+      throw new MedusaError(
+        MedusaError.Types.INVALID_DATA,
+        `discount_percent must be between 0 and 100 (got ${percent}).`
+      )
+    }
+    if (live === null) {
+      // A percentage OFF nothing is not a price. The line has no live amount,
+      // so there is nothing to discount and the mint must say so rather than
+      // quietly quoting the line at zero.
+      throw new MedusaError(
+        MedusaError.Types.INVALID_DATA,
+        "A discount_percent needs a live price to apply to, and this line has none."
+      )
+    }
+    amount = Math.round(live * (1 - percent / 100) * 100) / 100
+    override = {
+      kind: "discount_percent",
+      input_amount: percent,
+      // A percentage has no currency, and recording one would invite a reader
+      // to convert it.
+      input_currency_code: null,
+      fx_rate: 1,
+    }
+  }
+
+  if (!Number.isFinite(amount) || amount <= 0) {
+    throw new MedusaError(
+      MedusaError.Types.INVALID_DATA,
+      `A line override resolved to ${amount}, which would mint an ACTIVE price of zero or less. ` +
+        "Quote a real price, or leave the line at its catalog price."
+    )
+  }
+
+  return { unit_amount: amount, override }
+}
+
+/**
+ * PURE: does this basket need an FX rate at all?
+ *
+ * Asked before the network call so a same-currency mint — the overwhelming
+ * majority — never touches Frankfurter, and so a quote with no overrides can
+ * never be blocked by an FX outage.
+ */
+export function needsExchangeRate(
+  lines: Array<{ override_unit_amount?: number | null }>,
+  storeCurrency: string,
+  quoteCurrency: string
+): boolean {
+  if (String(storeCurrency).toUpperCase() === String(quoteCurrency).toUpperCase()) {
+    return false
+  }
+  return (lines || []).some(
+    (l) =>
+      l?.override_unit_amount !== null &&
+      l?.override_unit_amount !== undefined &&
+      Number.isFinite(Number(l.override_unit_amount))
+  )
+}

--- a/apps/backend/src/workflows/partner-quote/mint-quote.ts
+++ b/apps/backend/src/workflows/partner-quote/mint-quote.ts
@@ -24,6 +24,10 @@ import {
   quoteExpiryFrom,
   DEFAULT_QUOTE_TTL_DAYS,
 } from "../../modules/partner-quote/lib/token"
+import { composeQuoteMoney } from "../../modules/partner-quote/lib/build-quote-view"
+import { fetchExchangeRate } from "../../lib/fx/exchange-rate"
+import { pickDefaultCurrency } from "../../lib/resolve-store-currency"
+import { needsExchangeRate, resolveLineOverride } from "./lib/line-override"
 import {
   planQuotePrices,
   priceListScopedToGroup,
@@ -42,6 +46,10 @@ export type MintQuoteInput = {
     quantity: number
     position?: number
     note?: string | null
+    /** 0-100, off the live catalog price at this line's quantity (#1439 S7). */
+    discount_percent?: number | null
+    /** A flat unit price, in the PARTNER STORE's default currency. */
+    override_unit_amount?: number | null
   }>
   destination_country_code: string
   destination_postal_code?: string | null
@@ -256,6 +264,131 @@ const buildAndFreezeStep = createStep(
     }
 
     return new StepResponse(view)
+  }
+)
+
+/**
+ * Apply the partner's trade prices, and rewrite the view around them (#1439 S7).
+ *
+ * ## Why this replaces the numbers IN THE VIEW rather than beside them
+ *
+ * The whole point of `build-quote-view.ts` is that ONE builder feeds the page,
+ * the email and the freeze, so no second pricing path can disagree with what
+ * the buyer sees. An override carried alongside the view would create exactly
+ * that second path: the price list would hold the trade price while the frozen
+ * `quoted_subtotal` and the buyer's page still showed retail.
+ *
+ * So the override is folded back in — per line, and then the basket totals are
+ * recomposed from the overridden subtotals with the same `composeQuoteMoney`
+ * the builder used. Downstream, nothing knows an override happened; there is
+ * still exactly one number per line.
+ *
+ * Freight is untouched. A trade price is a discount on goods, not on shipping,
+ * and the consignment costs what it costs.
+ *
+ * ## FX is fetched at most once, and only when it is actually needed
+ *
+ * A same-currency mint — the overwhelming majority — never touches the
+ * network, so an FX outage cannot block one. When a rate IS needed and cannot
+ * be had, the mint FAILS: `fetchExchangeRate` throws and nothing here catches
+ * it. A conversion that silently falls back to 1 does not fail, it quotes
+ * 60,000 INR as 60,000 USD.
+ */
+const applyLineOverridesStep = createStep(
+  "apply-quote-line-overrides-step",
+  async (
+    payload: { mint: MintQuoteInput; view: any },
+    { container }
+  ) => {
+    const input = payload.mint
+    const view = payload.view
+    const overrideByVariant = new Map(
+      (input.lines ?? []).map((l) => [l.variant_id, l])
+    )
+
+    const anyOverride = (input.lines ?? []).some(
+      (l) =>
+        (l.discount_percent !== null && l.discount_percent !== undefined) ||
+        (l.override_unit_amount !== null && l.override_unit_amount !== undefined)
+    )
+    if (!anyOverride) {
+      // Nothing to do, and — importantly — no store read and no FX call on the
+      // path every ordinary quote takes.
+      return new StepResponse(view)
+    }
+
+    // ---- The currency the partner typed in ------------------------------
+    // Shaped by the same helper every other currency decision uses (#485), but
+    // with an EMPTY fallback rather than its default "inr": `resolveStoreCurrency`
+    // never throws and always returns a usable code, which is right for
+    // stamping a work order and wrong here. Guessing a currency for a number
+    // someone typed is how a rupee price gets quoted as dollars.
+    const query: any = container.resolve(ContainerRegistrationKeys.QUERY)
+    let storeCurrency = ""
+    try {
+      const { data: stores } = await query.graph({
+        entity: "store",
+        // `supported_currencies.*` MUST be expanded or the default flag is
+        // absent and every currency reads as "not default".
+        fields: ["id", "supported_currencies.*"],
+        filters: { id: input.store.id },
+      })
+      storeCurrency = pickDefaultCurrency((stores ?? [])[0], "")
+    } catch {
+      storeCurrency = ""
+    }
+
+    if (!storeCurrency) {
+      // 🔴 Never fall back to the quote currency. The override is a number in
+      // the partner's own currency; assuming it is already in the buyer's is
+      // how a rupee price gets quoted as dollars.
+      throw new MedusaError(
+        MedusaError.Types.INVALID_DATA,
+        "This store has no default currency, so a per-line override has no currency to be read in. " +
+          "Nothing was written."
+      )
+    }
+
+    const rate = needsExchangeRate(
+      input.lines ?? [],
+      storeCurrency,
+      input.currency_code
+    )
+      ? await fetchExchangeRate(storeCurrency, input.currency_code)
+      : 1
+
+    const lines = (view?.lines ?? []).map((l: any) => {
+      const requested = overrideByVariant.get(l.variant_id)
+      const resolved = resolveLineOverride({
+        live_unit_amount: l.live_unit_amount ?? null,
+        discount_percent: requested?.discount_percent ?? null,
+        override_unit_amount: requested?.override_unit_amount ?? null,
+        fx_rate: rate,
+        store_currency_code: storeCurrency,
+        quote_currency_code: input.currency_code,
+      })
+
+      return {
+        ...l,
+        live_unit_amount: resolved.unit_amount,
+        live_subtotal:
+          resolved.unit_amount === null
+            ? null
+            : resolved.unit_amount * Number(l.quantity),
+        override: resolved.override,
+      }
+    })
+
+    const priced = lines.filter((l: any) => l.live_subtotal !== null)
+    const live = view?.live
+      ? composeQuoteMoney(
+          priced.map((l: any) => Number(l.live_subtotal)),
+          priced.reduce((sum: number, l: any) => sum + Number(l.quantity), 0),
+          Number(view.live.freight ?? 0)
+        )
+      : view?.live ?? null
+
+    return new StepResponse({ ...view, lines, live })
   }
 )
 
@@ -574,6 +707,14 @@ const persistQuoteStep = createStep(
         quoted_unit_weight_grams: l.unit_weight_grams ?? null,
         quoted_weight_source: l.weight_source ?? null,
         note: l.note ?? null,
+        // #1439 S7 — HOW the price above was reached. Null on a line quoted at
+        // its catalog price, which is most of them. The three override fields
+        // travel together: without the input amount and the rate, a converted
+        // number cannot be reproduced once FX has moved.
+        override_kind: l.override?.kind ?? null,
+        override_input_amount: l.override?.input_amount ?? null,
+        override_input_currency_code: l.override?.input_currency_code ?? null,
+        override_fx_rate: l.override?.fx_rate ?? null,
       }))
     )
 
@@ -605,7 +746,19 @@ export const mintQuoteWorkflow = createWorkflow(
     validateQuoteReadinessStep(input)
 
     const buyer = resolveQuoteBuyerStep(input)
-    const view = buildAndFreezeStep({ mint: input, now: timing.now } as any)
+    const catalogView = buildAndFreezeStep({ mint: input, now: timing.now } as any)
+
+    /**
+     * The trade price (#1439 S7). Returns the SAME view with the overridden
+     * numbers folded in, so every consumer below — the price list, the frozen
+     * row, the basket totals — reads one number and no second pricing path
+     * exists. A basket with no overrides passes straight through, untouched
+     * and without a store read or an FX call.
+     */
+    const view = applyLineOverridesStep({
+      mint: input,
+      view: catalogView,
+    } as any)
 
     /**
      * 🔴 The amount to freeze is the LIVE one.

--- a/apps/partner-ui/src/routes/orders/quote-create/components/quote-create-form/quote-create-form.tsx
+++ b/apps/partner-ui/src/routes/orders/quote-create/components/quote-create-form/quote-create-form.tsx
@@ -84,6 +84,8 @@ export const QuoteCreateForm = ({
       ttl_days: 14,
       product_ids: [],
       quantities: {},
+      discounts: {},
+      overrides: {},
     },
     resolver: zodResolver(QuoteCreateSchema),
   })
@@ -109,11 +111,28 @@ export const QuoteCreateForm = ({
      */
     const lines = Object.entries(data.quantities ?? {})
       .filter(([, qty]) => typeof qty === "number" && qty > 0)
-      .map(([variant_id, qty], index) => ({
-        variant_id,
-        quantity: qty as number,
-        position: index,
-      }))
+      .map(([variant_id, qty], index) => {
+        /**
+         * A blank override cell is "no override", never a zero (#1446). Sent
+         * as 0 it would ask the backend to mint an ACTIVE price of zero — it
+         * refuses, but the refusal would arrive as a failed mint rather than
+         * as the no-op the partner intended. Dropped here, and only a real
+         * positive number is sent.
+         */
+        const discount = data.discounts?.[variant_id]
+        const override = data.overrides?.[variant_id]
+        return {
+          variant_id,
+          quantity: qty as number,
+          position: index,
+          ...(typeof discount === "number" && discount > 0
+            ? { discount_percent: discount }
+            : {}),
+          ...(typeof override === "number" && override > 0
+            ? { override_unit_amount: override }
+            : {}),
+        }
+      })
 
     if (!lines.length) {
       toast.error(

--- a/apps/partner-ui/src/routes/orders/quote-create/components/quote-create-form/quote-quantities-form.tsx
+++ b/apps/partner-ui/src/routes/orders/quote-create/components/quote-create-form/quote-quantities-form.tsx
@@ -24,7 +24,7 @@ const isProductRow = (row: Row): row is HttpTypes.AdminProduct =>
 const columnHelper = createDataGridHelper<Row, QuoteCreateSchemaType>()
 
 /**
- * Step 3 — how many of each variant.
+ * Step 3 — how many of each variant, and at what trade price.
  *
  * 🔴 The weight column is not decoration. Freight is quoted against the summed
  * basket weight, and platform-wide most variants carry no weight at either
@@ -97,6 +97,53 @@ const useQuoteGridColumns = (): ColumnDef<Row>[] => {
               )}
             </DataGrid.ReadonlyCell>
           )
+        },
+      }),
+      /**
+       * The trade price (#1446). Two columns and not one, because the two
+       * forms are genuinely different questions — "take 15% off the tier" and
+       * "the price is 19,000" — and collapsing them into one field with a mode
+       * toggle makes the grid guess which the partner meant.
+       *
+       * 🔴 The override is in the STORE's default currency, and the header
+       * says so. A partner typing 19000 into a USD quote means rupees; the
+       * conversion happens at mint, at a rate the quote records. A column that
+       * did not name the currency would be read as the buyer's.
+       */
+      columnHelper.column({
+        id: "discount_percent",
+        name: t("quotes.fields.discountPercent", "Discount %"),
+        header: t("quotes.fields.discountPercent", "Discount %"),
+        field: (context) => {
+          const entity = context.row.original
+          if (isProductRow(entity)) return null
+          return `discounts.${entity.id}` as const
+        },
+        type: "number",
+        cell: (context) => {
+          const entity = context.row.original
+          if (isProductRow(entity)) {
+            return <DataGrid.ReadonlyCell context={context} />
+          }
+          return <DataGrid.NumberCell context={context} min={0} max={100} />
+        },
+      }),
+      columnHelper.column({
+        id: "override_unit_amount",
+        name: t("quotes.fields.overrideUnitAmount", "Unit price"),
+        header: t("quotes.fields.overrideUnitAmount", "Unit price (store currency)"),
+        field: (context) => {
+          const entity = context.row.original
+          if (isProductRow(entity)) return null
+          return `overrides.${entity.id}` as const
+        },
+        type: "number",
+        cell: (context) => {
+          const entity = context.row.original
+          if (isProductRow(entity)) {
+            return <DataGrid.ReadonlyCell context={context} />
+          }
+          return <DataGrid.NumberCell context={context} min={0} />
         },
       }),
       columnHelper.column({

--- a/apps/partner-ui/src/routes/orders/quote-create/components/quote-create-form/schema.ts
+++ b/apps/partner-ui/src/routes/orders/quote-create/components/quote-create-form/schema.ts
@@ -36,6 +36,23 @@ export const QuoteProductsSchema = z.object({
  */
 export const QuoteQuantitiesSchema = z.object({
   quantities: z.record(z.string(), z.number().nullish()),
+
+  /**
+   * The trade price, per variant (#1446). Both are optional and mutually
+   * exclusive per line — the backend refuses both together rather than ranking
+   * them, so "which wins" has no answer to get wrong here either.
+   *
+   * 🔑 `overrides` is a unit price in the PARTNER STORE's default currency, not
+   * the quote's. A partner negotiating in Mumbai thinks in rupees whatever the
+   * buyer is being quoted in; the conversion happens once, at mint, at a rate
+   * the quote records.
+   *
+   * A blank cell is not a zero. Same rule as the quantity above: it means "no
+   * override", and it is dropped rather than sent — a 0 would ask the backend
+   * to mint an ACTIVE price of zero, which it refuses outright.
+   */
+  discounts: z.record(z.string(), z.number().nullish()),
+  overrides: z.record(z.string(), z.number().nullish()),
 })
 
 export const QuoteCreateSchema = QuoteBuyerSchema.merge(
@@ -57,4 +74,8 @@ export const QuoteBuyerFields = [
 ] as const
 
 export const QuoteProductFields = ["product_ids"] as const
-export const QuoteQuantityFields = ["quantities"] as const
+export const QuoteQuantityFields = [
+  "quantities",
+  "discounts",
+  "overrides",
+] as const

--- a/e2e/specs/admin-quote-mint-wizard.spec.ts
+++ b/e2e/specs/admin-quote-mint-wizard.spec.ts
@@ -1,0 +1,136 @@
+import { test, expect } from "@playwright/test"
+import * as fs from "fs"
+import * as path from "path"
+
+const SEED_FILE = path.resolve(__dirname, "../../apps/backend/.e2e-seed.json")
+
+/**
+ * The admin mint wizard, driven through a browser (#1439 S4 / #1446).
+ *
+ * 🔑 Why this file exists: the wizard shipped in #1463 and had never been
+ * opened in a browser, and #1446 has just added two fields to it that decide
+ * what a buyer is charged. tsc sees a component that compiles; only a render
+ * shows a step that will not advance, a hook called outside its provider
+ * (#1352), or a disabled-state that never actually disables.
+ *
+ * ## What this deliberately does NOT do
+ *
+ * It never completes a mint. A mint needs a partner whose store has a priced
+ * product on a quotable freight lane — the preflight (#1462) refuses anything
+ * less, correctly — and standing that world up in the e2e seed would duplicate
+ * `integration-tests/helpers/setup-quote-fixture.ts`, which already mints for
+ * real against a container on every run. The arithmetic, the price-list rows
+ * and the refusals are covered there.
+ *
+ * What is covered HERE is the half that suite cannot see: the form. Whether
+ * the steps gate, whether the two trade-price fields exclude each other, and
+ * whether clearing one leaves it EMPTY rather than zero.
+ */
+test.describe("Admin mint-quote wizard (#1446)", () => {
+  let seed: { email: string; password: string; parkedRunFreshPartnerName: string }
+
+  test.beforeAll(() => {
+    if (!fs.existsSync(SEED_FILE)) {
+      throw new Error(
+        `E2E seed file not found at ${SEED_FILE}. Run "pnpm e2e:seed" first.`
+      )
+    }
+    seed = JSON.parse(fs.readFileSync(SEED_FILE, "utf-8"))
+    if (!seed.parkedRunFreshPartnerName) {
+      throw new Error("E2E seed missing parkedRunFreshPartnerName — re-run the seed.")
+    }
+  })
+
+  const login = async (page: any) => {
+    await page.goto("/app/login")
+    // `networkidle` never settles against `medusa develop` (the dev server
+    // holds long-lived connections open), so wait on the form itself.
+    await page.locator('input[name="email"]').waitFor({ timeout: 60000 })
+    await page.locator('input[name="email"]').fill(seed.email)
+    await page.locator('input[name="password"]').fill(seed.password)
+    await page.locator('button[type="submit"]').click()
+    await page.waitForURL(/\/app\/(?!login)/, { timeout: 15000 })
+  }
+
+  /** Partner → Buyer → Lines, which is the only way to reach the fields. */
+  const openLinesStep = async (page: any) => {
+    await page.goto("/app/quotes/create")
+    await expect(page.getByRole("heading", { name: "Mint a quote" })).toBeVisible({
+      timeout: 30000,
+    })
+
+    const cont = page.getByRole("button", { name: "Continue" })
+
+    // 🔑 Step one gates step two. Choosing variants before a partner would let
+    // an admin build a basket that is then rejected wholesale, so Continue is
+    // dead until a partner is picked.
+    await expect(cont).toBeDisabled()
+
+    await page.getByText("Select a partner").click()
+    await page.getByRole("option", { name: seed.parkedRunFreshPartnerName }).click()
+    await expect(cont).toBeEnabled()
+    await cont.click()
+
+    await page.getByPlaceholder("procurement@example.com").fill("e2e-buyer@jyt.test")
+    await expect(cont).toBeEnabled()
+    await cont.click()
+
+    await expect(page.getByRole("button", { name: "Add line" })).toBeVisible({
+      timeout: 15000,
+    })
+  }
+
+  test("gates each step, and the trade-price fields appear on a line", async ({
+    page,
+  }) => {
+    await login(page)
+    await openLinesStep(page)
+
+    // An empty basket cannot advance: a quote with no lines has nothing to price.
+    await expect(page.getByRole("button", { name: "Continue" })).toBeDisabled()
+
+    await page.getByRole("button", { name: "Add line" }).click()
+
+    await expect(page.getByPlaceholder("Qty")).toBeVisible()
+    await expect(page.getByPlaceholder("Disc %")).toBeVisible()
+    await expect(page.getByPlaceholder("Unit price")).toBeVisible()
+
+    // 🔴 The copy must name whose currency the unit price is in. A number typed
+    // into a USD quote means the partner store's currency, and a field that did
+    // not say so would be read as the buyer's.
+    await expect(
+      page.getByText("read in the partner store's own currency", { exact: false })
+    ).toBeVisible()
+  })
+
+  test("🔑 the two trade-price forms exclude each other", async ({ page }) => {
+    await login(page)
+    await openLinesStep(page)
+    await page.getByRole("button", { name: "Add line" }).click()
+
+    const discount = page.getByPlaceholder("Disc %")
+    const unitPrice = page.getByPlaceholder("Unit price")
+
+    // Both live until one is used — "which wins" is a question that must never
+    // arise, so the UI removes the choice rather than ranking the answers.
+    await expect(discount).toBeEnabled()
+    await expect(unitPrice).toBeEnabled()
+
+    await discount.fill("15")
+    await expect(unitPrice).toBeDisabled()
+
+    // 🔴 Clearing returns the field to EMPTY, not 0. `Number("")` is 0, and a
+    // zero is a request to mint a free line — the backend refuses it, but the
+    // refusal would arrive as a failed mint rather than the no-op intended.
+    await discount.fill("")
+    await expect(discount).toHaveValue("")
+    await expect(unitPrice).toBeEnabled()
+
+    // And the same in the other direction.
+    await unitPrice.fill("19000")
+    await expect(discount).toBeDisabled()
+    await unitPrice.fill("")
+    await expect(unitPrice).toHaveValue("")
+    await expect(discount).toBeEnabled()
+  })
+})


### PR DESCRIPTION
Closes #1446. Part of #1439 (S7).

⚠️ **Carries a migration** (`Migration20260822093000`) — do not merge back-to-back with another PR until #1473 lands, or the gate can strand it.

## Why

Until this, a quote's `quoted_unit_amount` **was** the live catalog price at that quantity — `planQuotePrices` copied whatever the builder produced. There was no discount concept anywhere in the quote path, so a partner could not quote a trade price at all. A B2B buyer does not pay retail.

## Entered in the store's currency, converted once

A partner negotiating in Mumbai thinks in rupees whatever currency the buyer is quoted in, so the number they type is authoritative. The conversion happens at mint and nowhere else, and the rate is persisted beside the result: a quoted number that cannot be reproduced once FX has moved is not evidence, and FX is precisely the input that *will* have moved by the time a buyer disputes a price.

`override_kind`, `override_input_amount`, `override_input_currency_code` and `override_fx_rate` travel together on the line. Null on a line quoted at its catalog price — nothing is backfilled, because writing a rate of 1 onto historic rows invents a decision nobody made.

## The override is folded back *into* the view

Not carried beside it. The point of `build-quote-view.ts` is that one builder feeds the page, the email and the freeze so no second pricing path can disagree — and an override carried alongside would **be** that second path: the price list holding the trade price while the frozen totals and the buyer's page still showed retail. So line amounts are replaced and basket totals recomposed with the same `composeQuoteMoney` the builder used. Downstream, nothing knows an override happened.

Freight is untouched. A trade price discounts goods, not shipping.

## Never a price of zero

`planQuotePrices` drops a null rather than defaulting, which keeps an unpriceable line out of the list. A zero is different and far worse — a valid number nothing drops, which becomes an ACTIVE price the cart cheerfully charges. Arithmetic is the fastest route to one (`discount_percent: 100`, or a `0` typed into a form), so the refusal lives in the one place that can tell "no price" from "free". The integration test asserts the refusal is **total**: no quote, no price list, no half-written row.

Same reasoning on FX: `fetchExchangeRate` throws and nothing catches it. A fallback to rate 1 does not fail — it quotes 60,000 INR as 60,000 USD. A same-currency mint never makes the call, so an FX outage cannot block the common path.

## Wizards

Two fields per line, not one with a mode toggle: "take 15% off the tier" and "the price is 19,000" are different questions, and a single field that guesses would guess wrong on the day it matters. Each disables the other in the admin form; the partner grid gets two columns. The unit-price header **names the currency**, because a number typed into a USD quote is otherwise read as dollars. A blank field is "no override" and is dropped, never sent as 0 — `Number("")` is 0, so the inputs clear back to `undefined` explicitly.

## Also

`fetchExchangeRate`/`applyRate` moved out of `workflows/designs/create-draft-order-from-designs.ts` into `lib/fx/exchange-rate.ts`; old export kept as a re-export. The quote path must not import a designs workflow to convert a currency.

## Caught by the first real mint

A DML `bigNumber` is **two** columns. A migration that adds only the numeric one passes the model, tsc and every unit test, then fails the INSERT with `column "raw_override_input_amount" does not exist`.

## Tests

16 unit (every path to a zero, both-forms, out-of-range, missing rate, FX arithmetic) + 5 integration against a container, including that the override reaches the **price list** — the rows core actually charges — and not merely the frozen columns. A discount landing on one but not the other is the worst outcome available: a page showing a trade price and a cart charging retail.

🤖 Generated with [Claude Code](https://claude.com/claude-code)