### PR TITLE
fix(e2e): add last_modified to content editor seed page

### DIFF
--- a/e2e/helpers/e2e-seed.ts
+++ b/e2e/helpers/e2e-seed.ts
@@ -878,6 +878,7 @@ async function seedContentEditorPartner(
     content: "Test content for visual editor",
     page_type: "Custom",
     status: "Published",
+    last_modified: new Date(),
   })
 
   // Seed blocks: one Hero (unique) + one Feature (repeatable)


### PR DESCRIPTION
Fixes the e2e seed crash from PR #1472. The Page model has a required `last_modified` dateTime field that was missing from the `seedContentEditorPartner` page creation.

Closes #1466