### PR TITLE
feat(admin): bring the mint wizard to parity with the partner one

### DIFF
--- a/apps/backend/src/admin/hooks/api/quote-buyer-sources.ts
+++ b/apps/backend/src/admin/hooks/api/quote-buyer-sources.ts
@@ -1,0 +1,129 @@
+import { FetchError } from "@medusajs/js-sdk"
+import { useQuery, keepPreviousData } from "@tanstack/react-query"
+
+import { sdk } from "../../lib/config"
+
+/**
+ * The three lists the mint wizard's Buyer step picks from (#1439 S4).
+ *
+ * ## Why regions, and not a free-text currency box
+ *
+ * The wizard used to ask for a currency and a destination country as two
+ * independent text inputs, which let an operator quote INR to a GB address —
+ * a combination no region supports, so the mint priced against nothing and the
+ * preflight refused it after the fact. A region carries BOTH facts, so picking
+ * one infers the currency and narrows the countries to those it actually
+ * covers. The impossible combination stops being expressible.
+ *
+ * ## Why two buyer lists rather than one
+ *
+ * A quote's buyer is resolved BY EMAIL at mint, so anything with an email is a
+ * valid starting point. Existing customers are the obvious source; CRM persons
+ * are the one that matters commercially, because a B2B quote is usually the
+ * FIRST thing a lead ever receives — they are not a customer yet, and requiring
+ * them to be one would mean typing the address by hand and risking a
+ * near-duplicate on a typo.
+ */
+
+export type QuoteRegionOption = {
+  id: string
+  name: string
+  currency_code: string
+  /** ISO-2, lower-case. Empty when the region declares no countries. */
+  countries: string[]
+}
+
+export const useQuoteRegions = () => {
+  const { data, ...rest } = useQuery<{ regions: any[] }, FetchError>({
+    queryFn: () => sdk.admin.region.list({ limit: 100, fields: "id,name,currency_code,countries.iso_2" }) as any,
+    queryKey: ["quote-wizard-regions"],
+    placeholderData: keepPreviousData,
+  })
+
+  const regions: QuoteRegionOption[] = (data?.regions ?? []).map((r: any) => ({
+    id: r.id,
+    name: r.name,
+    currency_code: String(r.currency_code || "").toLowerCase(),
+    countries: (r.countries ?? [])
+      .map((c: any) => String(c?.iso_2 || "").toLowerCase())
+      .filter(Boolean),
+  }))
+
+  return { regions, ...rest }
+}
+
+export type QuoteBuyerOption = {
+  /** The email IS the identity here — the mint resolves the buyer by it. */
+  email: string
+  label: string
+  company: string | null
+  name: string | null
+  source: "customer" | "lead"
+}
+
+const personName = (p: any): string | null =>
+  [p?.first_name, p?.last_name].filter(Boolean).join(" ") || null
+
+/**
+ * Existing customers and CRM people, merged and de-duplicated by email.
+ *
+ * 🔑 De-duplicated with the CUSTOMER winning. The same human is often both, and
+ * showing one address twice under two labels invites an operator to wonder
+ * which one is "the real" record — there is no such distinction at mint, which
+ * matches on the address alone.
+ *
+ * A person with no email is dropped rather than listed as unselectable: the
+ * only thing this picker produces is an email, so a row that cannot produce
+ * one is not a choice.
+ */
+export const useQuoteBuyerOptions = (search: string) => {
+  const query = search ? { q: search } : {}
+
+  const customers = useQuery<{ customers: any[] }, FetchError>({
+    queryFn: () => sdk.admin.customer.list({ limit: 20, ...query }) as any,
+    queryKey: ["quote-wizard-customers", search],
+    placeholderData: keepPreviousData,
+  })
+
+  const persons = useQuery<{ persons: any[] }, FetchError>({
+    queryFn: () =>
+      sdk.client.fetch<{ persons: any[] }>("/admin/persons", {
+        method: "GET",
+        query: { limit: 20, ...query },
+      }),
+    queryKey: ["quote-wizard-persons", search],
+    placeholderData: keepPreviousData,
+  })
+
+  const byEmail = new Map<string, QuoteBuyerOption>()
+
+  for (const p of persons.data?.persons ?? []) {
+    const email = String(p?.email || "").trim().toLowerCase()
+    if (!email) continue
+    byEmail.set(email, {
+      email,
+      label: [email, personName(p)].filter(Boolean).join(" · "),
+      company: p?.company_name ?? null,
+      name: personName(p),
+      source: "lead",
+    })
+  }
+
+  // Second, so a customer overwrites the CRM row for the same address.
+  for (const c of customers.data?.customers ?? []) {
+    const email = String(c?.email || "").trim().toLowerCase()
+    if (!email) continue
+    byEmail.set(email, {
+      email,
+      label: [email, personName(c)].filter(Boolean).join(" · "),
+      company: c?.company_name ?? null,
+      name: personName(c),
+      source: "customer",
+    })
+  }
+
+  return {
+    options: [...byEmail.values()],
+    isLoading: customers.isLoading || persons.isLoading,
+  }
+}

--- a/apps/backend/src/admin/routes/quotes/create/mint-quote-form.tsx
+++ b/apps/backend/src/admin/routes/quotes/create/mint-quote-form.tsx
@@ -1,19 +1,20 @@
+import { zodResolver } from "@hookform/resolvers/zod"
 import {
   Button,
   Heading,
-  Input,
-  Label,
   ProgressStatus,
   ProgressTabs,
   Select,
   Text,
-  Textarea,
   toast,
 } from "@medusajs/ui"
-import { useMemo, useState } from "react"
+import { useState } from "react"
+import { FieldPath, useForm } from "react-hook-form"
 
+import { Form } from "../../../components/common/form"
+import { RouteFocusModal } from "../../../components/modal/route-focus-modal"
+import { KeyboundForm } from "../../../components/utilitites/key-bound-form"
 import { usePartners } from "../../../hooks/api/partners"
-import { useProducts } from "../../../hooks/api/products"
 import {
   QuoteReadiness,
   useAdminQuoteReadiness,
@@ -21,183 +22,241 @@ import {
 } from "../../../hooks/api/quotes"
 import { MintedPanel } from "./minted-panel"
 import { ReadinessPanel } from "./readiness-panel"
+import {
+  AdminQuoteCreateSchema,
+  AdminQuoteCreateSchemaType,
+  QuoteBuyerFields,
+  QuoteBuyerSchema,
+  QuotePartnerFields,
+  QuotePartnerSchema,
+  QuoteProductFields,
+  QuoteProductsSchema,
+} from "./schema"
+import { BuyerStep } from "./steps/buyer-step"
+import { ProductsStep } from "./steps/products-step"
+import { QuantitiesStep } from "./steps/quantities-step"
 
 /**
- * `discount_percent` and `override_unit_amount` are the trade price (#1446),
- * and they are mutually exclusive per line — the backend refuses both together
- * rather than ranking them.
+ * Mint a quote on a partner's behalf (#1419, stepped in #1444, brought to
+ * parity with the partner wizard in #1446).
  *
- * 🔑 The override is a unit price in the PARTNER STORE's default currency, not
- * the quote's. The conversion happens once, at mint, at a rate the quote
- * records; the label says so, because a number typed into a USD quote would
- * otherwise be read as dollars.
- */
-type Line = {
-  variant_id: string
-  quantity: number
-  discount_percent?: number | null
-  override_unit_amount?: number | null
-}
-
-/**
- * Mint a quote on a partner's behalf (#1419, stepped in #1444).
+ * ## Why it looks like the partner's wizard
  *
- * ## Why steps
+ * The two are the same product wearing different chrome, and they had drifted
+ * badly: the partner minted through a focus-modal wizard with a customer
+ * picker, a product table and an editable grid, while the admin filled in a
+ * page-level form with a `<Select>` of every variant in the catalogue and two
+ * free-text boxes for currency and country. Anything learned on one surface was
+ * useless on the other, and the admin one could not be used against a real
+ * catalogue at all.
  *
- * The partner mints through a three-step wizard and the admin filled in one
- * long form; the two are meant to feel like the same product. This mirrors the
- * partner's `ProgressTabs` shape with one extra LEADING step — Partner —
- * because an admin has no partner of their own and every quote is
- * partner-scoped.
+ * This is the partner's shape — `RouteFocusModal.Form` + `ProgressTabs`, one
+ * step per question — with ONE extra leading step. An admin has no partner of
+ * their own, and every quote is partner-scoped: the partner decides which
+ * catalogue the variants come from and which location freight is quoted from,
+ * so choosing products before a partner would build a basket that is then
+ * rejected wholesale.
  *
- * **Partner → Buyer → Lines → Review & mint.**
+ * **Partner → Buyer → Products → Quantities.**
  *
- * 🔑 Ordering is not cosmetic. The partner decides which catalogue the variants
- * come from and which location freight is quoted from, so choosing variants
- * before a partner would let an admin build a basket that is then rejected
- * wholesale. Each step gates the next.
+ * ## The minted panel does not navigate away
  *
- * ⚠️ Deliberately still `useState` rather than a react-hook-form + zod port.
- * The partner wizard uses that stack, but porting the form plumbing here would
- * rewrite every field at the same time as changing the flow, and this surface
- * has never been run through a browser. Steps and gating are the part that was
- * missing; the plumbing can follow once someone has clicked through it.
+ * 🔴 The raw token is returned by the API exactly once and only its sha256 is
+ * stored. A successful mint therefore swaps the modal body for the panel
+ * holding the only copy of the link, and does NOT call `handleSuccess` the way
+ * every other create flow does — that would discard the buyer's link and force
+ * a re-mint.
  */
 
 enum Tab {
   PARTNER = "partner",
   BUYER = "buyer",
-  LINES = "lines",
-  REVIEW = "review",
+  PRODUCTS = "products",
+  QUANTITIES = "quantities",
 }
 
-const tabOrder = [Tab.PARTNER, Tab.BUYER, Tab.LINES, Tab.REVIEW] as const
+const tabOrder = [Tab.PARTNER, Tab.BUYER, Tab.PRODUCTS, Tab.QUANTITIES] as const
+
+type TabState = Record<Tab, ProgressStatus>
+
+const initialTabState: TabState = {
+  [Tab.PARTNER]: "in-progress",
+  [Tab.BUYER]: "not-started",
+  [Tab.PRODUCTS]: "not-started",
+  [Tab.QUANTITIES]: "not-started",
+}
 
 export const MintQuoteForm = () => {
   const [tab, setTab] = useState<Tab>(Tab.PARTNER)
-  const [tabState, setTabState] = useState<Record<Tab, ProgressStatus>>({
-    [Tab.PARTNER]: "in-progress",
-    [Tab.BUYER]: "not-started",
-    [Tab.LINES]: "not-started",
-    [Tab.REVIEW]: "not-started",
-  })
-
-  const [partnerId, setPartnerId] = useState("")
-  const [buyerEmail, setBuyerEmail] = useState("")
-  const [company, setCompany] = useState("")
-  const [name, setName] = useState("")
-  const [note, setNote] = useState("")
-  const [country, setCountry] = useState("in")
-  const [postal, setPostal] = useState("")
-  const [currency, setCurrency] = useState("inr")
-  const [ttlDays, setTtlDays] = useState("14")
-  const [lines, setLines] = useState<Line[]>([])
-  const [readiness, setReadiness] = useState<QuoteReadiness | null>(null)
+  const [tabState, setTabState] = useState<TabState>(initialTabState)
   const [minted, setMinted] = useState<{ token: string; quote: any } | null>(
     null
   )
+  const [readiness, setReadiness] = useState<QuoteReadiness | null>(null)
 
   const { partners } = usePartners({ limit: 200 } as any)
-  const { products } = useProducts({ limit: 100 } as any)
 
-  const variantOptions = useMemo(() => {
-    const out: Array<{ id: string; label: string }> = []
-    for (const p of (products ?? []) as any[]) {
-      for (const v of p.variants ?? []) {
-        out.push({ id: v.id, label: `${p.title} — ${v.title}` })
-      }
-    }
-    return out
-  }, [products])
-
-  const { mutate: mint, isPending } = useMintQuote({
-    onSuccess: (data) => setMinted({ token: data.token, quote: data.quote }),
-    onError: (e: any) => toast.error(e?.message ?? "Could not mint the quote."),
+  const form = useForm<AdminQuoteCreateSchemaType>({
+    defaultValues: {
+      partner_id: "",
+      buyer_email: "",
+      recipient_name: "",
+      recipient_company: "",
+      partner_note: "",
+      region_id: "",
+      currency_code: "",
+      destination_country_code: "",
+      destination_postal_code: "",
+      destination_city: "",
+      ttl_days: 14,
+      product_ids: [],
+      quantities: {},
+      discounts: {},
+      overrides: {},
+    },
+    resolver: zodResolver(AdminQuoteCreateSchema) as any,
   })
 
+  const { mutate: mint, isPending } = useMintQuote({
+    onSuccess: (data: any) => setMinted({ token: data.token, quote: data.quote }),
+    onError: (e: any) => toast.error(e?.message ?? "Could not mint the quote."),
+  })
   const { mutateAsync: checkReadiness, isPending: isChecking } =
     useAdminQuoteReadiness()
 
-  // The panel REPLACES the form rather than sitting beside it. The token is
-  // shown once and never again, so anything that invites navigating away
-  // before copying it is a way to lose a quote.
-  if (minted) {
-    return <MintedPanel token={minted.token} quote={minted.quote} />
+  /**
+   * Validate only the fields belonging to the steps being skipped past.
+   * Same mechanism the partner wizard uses: a tab cannot be reached by
+   * clicking its header while an earlier one is incomplete, and the error is
+   * attached to the field rather than shouted in a toast.
+   */
+  const partialFormValidation = (
+    fields: readonly FieldPath<AdminQuoteCreateSchemaType>[],
+    schema: any
+  ) => {
+    form.clearErrors(fields as any)
+
+    const values = fields.reduce((acc, key) => {
+      acc[key] = form.getValues(key as any)
+      return acc
+    }, {} as Record<string, unknown>)
+
+    const validation = schema.safeParse(values)
+    if (validation.success) return true
+
+    for (const issue of validation.error.issues) {
+      form.setError(issue.path.join(".") as any, {
+        type: issue.code,
+        message: issue.message,
+      })
+    }
+    return false
   }
 
-  const validLines = lines.filter((l) => l.variant_id && l.quantity > 0)
+  const handleChangeTab = (update: Tab) => {
+    if (tab === update) return
 
-  /** What each step needs before the next one is reachable. */
-  const stepComplete: Record<Tab, boolean> = {
-    [Tab.PARTNER]: !!partnerId,
-    [Tab.BUYER]: !!buyerEmail && !!currency && !!country,
-    [Tab.LINES]: validLines.length > 0,
-    [Tab.REVIEW]: true,
-  }
+    // Going back is always allowed — an operator correcting an earlier answer
+    // must not be made to re-pass the steps after it.
+    if (tabOrder.indexOf(update) < tabOrder.indexOf(tab)) {
+      setTabState((prev) => ({ ...prev, [update]: "in-progress" }))
+      setTab(update)
+      return
+    }
 
-  const stepHint: Record<Tab, string> = {
-    [Tab.PARTNER]: "Choose the partner this quote belongs to.",
-    [Tab.BUYER]:
-      "A buyer email, a currency and a destination country are the minimum — the currency and destination decide the price and the freight.",
-    [Tab.LINES]: "Add at least one line with a quantity above zero.",
-    [Tab.REVIEW]: "",
-  }
-
-  const goToTab = (next: Tab) => {
-    const targetIndex = tabOrder.indexOf(next)
-    const currentIndex = tabOrder.indexOf(tab)
-
-    // Going back is always allowed. Going forward validates every step in
-    // between, so a tab cannot be skipped by clicking its header.
-    if (targetIndex > currentIndex) {
-      for (let i = 0; i < targetIndex; i++) {
-        const step = tabOrder[i]
-        if (!stepComplete[step]) {
-          toast.error(stepHint[step])
-          setTab(step)
+    for (const current of tabOrder.slice(0, tabOrder.indexOf(update))) {
+      if (current === Tab.PARTNER) {
+        if (!partialFormValidation(QuotePartnerFields, QuotePartnerSchema)) {
+          setTabState((prev) => ({ ...prev, [current]: "in-progress" }))
+          setTab(current)
+          return
+        }
+      } else if (current === Tab.BUYER) {
+        if (!partialFormValidation(QuoteBuyerFields, QuoteBuyerSchema)) {
+          setTabState((prev) => ({ ...prev, [current]: "in-progress" }))
+          setTab(current)
+          return
+        }
+      } else if (current === Tab.PRODUCTS) {
+        if (!partialFormValidation(QuoteProductFields, QuoteProductsSchema)) {
+          setTabState((prev) => ({ ...prev, [current]: "in-progress" }))
+          setTab(current)
+          return
+        }
+        if (!form.getValues("product_ids").length) {
+          toast.error("Pick at least one product.")
+          setTab(current)
           return
         }
       }
+      setTabState((prev) => ({ ...prev, [current]: "completed" }))
     }
 
-    setTabState((prev) => ({
-      ...prev,
-      ...(targetIndex > currentIndex
-        ? { [tab]: "completed" as ProgressStatus }
-        : {}),
-      [next]: "in-progress" as ProgressStatus,
-    }))
-    setTab(next)
+    setTabState((prev) => ({ ...prev, [update]: "in-progress" }))
+    setTab(update)
   }
 
-  const handleNext = () => {
+  const handleNextTab = () => {
     const i = tabOrder.indexOf(tab)
     if (i === tabOrder.length - 1) return
-    goToTab(tabOrder[i + 1])
+    handleChangeTab(tabOrder[i + 1])
   }
 
-  const payload = () => ({
-    partner_id: partnerId,
-    lines: validLines,
-    destination_country_code: country,
-    destination_postal_code: postal || null,
-    currency_code: currency,
-  })
+  const handleSubmit = form.handleSubmit(async (data) => {
+    /**
+     * A blank or zero quantity means "not in this basket" — dropped, not sent
+     * as a zero. Same for a blank override: sent as 0 it would ask the backend
+     * to mint an ACTIVE price of zero, which it refuses outright.
+     */
+    const lines = Object.entries(data.quantities ?? {})
+      .filter(([, qty]) => typeof qty === "number" && qty > 0)
+      .map(([variant_id, qty], index) => {
+        const discount = data.discounts?.[variant_id]
+        const override = data.overrides?.[variant_id]
+        return {
+          variant_id,
+          quantity: qty as number,
+          position: index,
+          ...(typeof discount === "number" && discount > 0
+            ? { discount_percent: discount }
+            : {}),
+          ...(typeof override === "number" && override > 0
+            ? { override_unit_amount: override }
+            : {}),
+        }
+      })
 
-  /**
-   * The preflight, then the mint (#1445).
-   *
-   * 🔑 Run on submit rather than on every field change: it prices every line
-   * and asks a carrier, which is not a thing to fire per keystroke.
-   *
-   * 🔑 A preflight that cannot RUN does not block the mint. The workflow runs
-   * the same assessor as its first step, so the real gate is there either way,
-   * and failing closed here would turn a network blip into "you cannot quote".
-   */
-  const submit = async () => {
+    if (!lines.length) {
+      toast.error(
+        "Set a quantity on at least one variant — a quote with no lines has nothing to price."
+      )
+      setTab(Tab.QUANTITIES)
+      return
+    }
+
+    /**
+     * The preflight, then the mint (#1445). Run on submit rather than per
+     * keystroke: it prices every line and asks a carrier.
+     *
+     * 🔑 A preflight that cannot RUN does not block the mint — the workflow
+     * runs the same assessor as its first step, so the real gate is there
+     * either way, and failing closed here would turn a network blip into "you
+     * cannot quote".
+     */
     let assessed: QuoteReadiness | null = null
     try {
-      const result = await checkReadiness(payload())
+      const result = await checkReadiness({
+        partner_id: data.partner_id,
+        lines: lines.map((l) => ({
+          variant_id: l.variant_id,
+          quantity: l.quantity,
+        })),
+        destination_country_code: data.destination_country_code,
+        destination_postal_code: data.destination_postal_code || null,
+        destination_city: data.destination_city || null,
+        currency_code: data.currency_code,
+        region_id: data.region_id,
+      } as any)
       assessed = result.readiness
       setReadiness(result.readiness)
     } catch {
@@ -206,342 +265,192 @@ export const MintQuoteForm = () => {
 
     if (assessed && !assessed.ready) {
       toast.error("This quote cannot be minted yet — see the reasons above.")
+      setTab(Tab.QUANTITIES)
       return
     }
 
     mint({
-      partner_id: partnerId,
-      buyer_email: buyerEmail,
-      recipient_company: company || null,
-      recipient_name: name || null,
-      partner_note: note || null,
-      lines: validLines,
-      destination_country_code: country,
-      destination_postal_code: postal || null,
-      currency_code: currency,
-      ttl_days: Number(ttlDays) || undefined,
-    })
+      partner_id: data.partner_id,
+      buyer_email: data.buyer_email,
+      recipient_company: data.recipient_company || null,
+      recipient_name: data.recipient_name || null,
+      partner_note: data.partner_note || null,
+      lines,
+      destination_country_code: data.destination_country_code,
+      destination_postal_code: data.destination_postal_code || null,
+      destination_city: data.destination_city || null,
+      currency_code: data.currency_code,
+      region_id: data.region_id,
+      ttl_days: data.ttl_days,
+    } as any)
+  })
+
+  if (minted) {
+    return (
+      <RouteFocusModal.Body className="flex-1 overflow-y-auto">
+        <MintedPanel token={minted.token} quote={minted.quote} />
+      </RouteFocusModal.Body>
+    )
   }
 
-  const addLine = () =>
-    setLines((prev) => [
-      ...prev,
-      {
-        variant_id: "",
-        quantity: 1,
-        // Undefined, never 0 — a blank field is "no override", and a 0 would
-        // ask the backend to mint an ACTIVE price of zero, which it refuses.
-        discount_percent: undefined,
-        override_unit_amount: undefined,
-      },
-    ])
-
-  const isLast = tab === Tab.REVIEW
-
   return (
-    <div className="flex flex-col">
-      <div className="px-6 pt-6">
-        <Heading>Mint a quote</Heading>
-        <Text size="small" className="text-ui-fg-subtle">
-          The buyer link is shown once and cannot be recovered — you will be
-          asked to copy it before leaving this page.
-        </Text>
-      </div>
-
+    <RouteFocusModal.Form form={form}>
       <ProgressTabs
         value={tab}
-        onValueChange={(v) => goToTab(v as Tab)}
-        className="flex flex-col"
+        onValueChange={(value) => handleChangeTab(value as Tab)}
+        className="flex h-full flex-col overflow-hidden"
       >
-        <div className="border-ui-border-base border-b px-6 py-4">
-          <ProgressTabs.List className="grid w-full max-w-[640px] grid-cols-4">
-            <ProgressTabs.Trigger
-              status={tabState[Tab.PARTNER]}
+        <KeyboundForm onSubmit={handleSubmit} className="flex h-full flex-col">
+          <RouteFocusModal.Header>
+            <div className="-my-2 w-full max-w-[720px] border-l">
+              <ProgressTabs.List className="grid w-full grid-cols-4">
+                <ProgressTabs.Trigger
+                  status={tabState[Tab.PARTNER]}
+                  value={Tab.PARTNER}
+                >
+                  Partner
+                </ProgressTabs.Trigger>
+                <ProgressTabs.Trigger
+                  status={tabState[Tab.BUYER]}
+                  value={Tab.BUYER}
+                >
+                  Buyer
+                </ProgressTabs.Trigger>
+                <ProgressTabs.Trigger
+                  status={tabState[Tab.PRODUCTS]}
+                  value={Tab.PRODUCTS}
+                >
+                  Products
+                </ProgressTabs.Trigger>
+                <ProgressTabs.Trigger
+                  status={tabState[Tab.QUANTITIES]}
+                  value={Tab.QUANTITIES}
+                >
+                  Quantities
+                </ProgressTabs.Trigger>
+              </ProgressTabs.List>
+            </div>
+          </RouteFocusModal.Header>
+
+          {/*
+            ⚠️ `overflow-hidden` here and `overflow-y-auto` on each tab's
+            content, not the other way round: a FocusModal.Body does not scroll
+            on its own, and the grid steps manage their own height.
+          */}
+          <RouteFocusModal.Body className="size-full overflow-hidden">
+            <ProgressTabs.Content
+              className="size-full overflow-y-auto p-16"
               value={Tab.PARTNER}
             >
-              Partner
-            </ProgressTabs.Trigger>
-            <ProgressTabs.Trigger
-              status={tabState[Tab.BUYER]}
+              <div className="flex flex-col gap-y-8">
+                <div className="flex flex-col gap-y-1">
+                  <Heading level="h2">Partner</Heading>
+                  <Text size="small" className="text-ui-fg-subtle">
+                    Prices come from this partner's catalogue and freight from
+                    their location. Variants outside their store are rejected —
+                    that check is why this step comes first.
+                  </Text>
+                </div>
+
+                <Form.Field
+                  control={form.control}
+                  name="partner_id"
+                  render={({ field }) => (
+                    <Form.Item>
+                      <Form.Label>Partner</Form.Label>
+                      <Form.Control>
+                        <Select
+                          value={field.value}
+                          onValueChange={field.onChange}
+                        >
+                          <Select.Trigger>
+                            <Select.Value placeholder="Select a partner" />
+                          </Select.Trigger>
+                          <Select.Content>
+                            {((partners ?? []) as any[]).map((p) => (
+                              <Select.Item key={p.id} value={p.id}>
+                                {p.name || p.id}
+                              </Select.Item>
+                            ))}
+                          </Select.Content>
+                        </Select>
+                      </Form.Control>
+                      <Form.ErrorMessage />
+                    </Form.Item>
+                  )}
+                />
+              </div>
+            </ProgressTabs.Content>
+
+            <ProgressTabs.Content
+              className="size-full overflow-y-auto p-16"
               value={Tab.BUYER}
             >
-              Buyer
-            </ProgressTabs.Trigger>
-            <ProgressTabs.Trigger
-              status={tabState[Tab.LINES]}
-              value={Tab.LINES}
+              <BuyerStep form={form} />
+            </ProgressTabs.Content>
+
+            <ProgressTabs.Content
+              className="size-full overflow-y-auto"
+              value={Tab.PRODUCTS}
             >
-              Lines
-            </ProgressTabs.Trigger>
-            <ProgressTabs.Trigger
-              status={tabState[Tab.REVIEW]}
-              value={Tab.REVIEW}
+              <ProductsStep form={form} />
+            </ProgressTabs.Content>
+
+            <ProgressTabs.Content
+              className="size-full overflow-hidden"
+              value={Tab.QUANTITIES}
             >
-              Review
-            </ProgressTabs.Trigger>
-          </ProgressTabs.List>
-        </div>
-
-        <ProgressTabs.Content value={Tab.PARTNER} className="px-6 py-6">
-          <div className="flex max-w-[640px] flex-col gap-y-2">
-            <Label>Partner</Label>
-            <Select value={partnerId} onValueChange={setPartnerId}>
-              <Select.Trigger>
-                <Select.Value placeholder="Select a partner" />
-              </Select.Trigger>
-              <Select.Content>
-                {((partners ?? []) as any[]).map((p) => (
-                  <Select.Item key={p.id} value={p.id}>
-                    {p.name || p.id}
-                  </Select.Item>
-                ))}
-              </Select.Content>
-            </Select>
-            <Text size="xsmall" className="text-ui-fg-subtle">
-              Prices come from this partner's catalogue and freight from their
-              location. Variants outside their store are rejected — that check
-              is why this step comes first.
-            </Text>
-          </div>
-        </ProgressTabs.Content>
-
-        <ProgressTabs.Content value={Tab.BUYER} className="px-6 py-6">
-          <div className="grid max-w-[860px] grid-cols-1 gap-4 md:grid-cols-2">
-            <div className="flex flex-col gap-y-2">
-              <Label>Buyer email</Label>
-              <Input
-                type="email"
-                value={buyerEmail}
-                onChange={(e) => setBuyerEmail(e.target.value)}
-                placeholder="procurement@example.com"
-              />
-            </div>
-            <div className="flex flex-col gap-y-2">
-              <Label>Company</Label>
-              <Input
-                value={company}
-                onChange={(e) => setCompany(e.target.value)}
-              />
-            </div>
-            <div className="flex flex-col gap-y-2">
-              <Label>Contact name</Label>
-              <Input value={name} onChange={(e) => setName(e.target.value)} />
-            </div>
-            <div className="flex flex-col gap-y-2">
-              <Label>Currency</Label>
-              <Input
-                value={currency}
-                onChange={(e) => setCurrency(e.target.value.toLowerCase())}
-                placeholder="inr"
-              />
-            </div>
-            <div className="flex flex-col gap-y-2">
-              <Label>Destination country (ISO-2)</Label>
-              <Input
-                value={country}
-                onChange={(e) => setCountry(e.target.value.toLowerCase())}
-                placeholder="in"
-              />
-            </div>
-            <div className="flex flex-col gap-y-2">
-              <Label>Destination postcode</Label>
-              <Input
-                value={postal}
-                onChange={(e) => setPostal(e.target.value)}
-              />
-            </div>
-            <div className="flex flex-col gap-y-2">
-              <Label>Valid for (days)</Label>
-              <Input
-                type="number"
-                value={ttlDays}
-                onChange={(e) => setTtlDays(e.target.value)}
-              />
-              <Text size="xsmall" className="text-ui-fg-subtle">
-                Drives the price list's end date, so expiry is enforced by
-                pricing itself rather than by a sweep.
-              </Text>
-            </div>
-          </div>
-        </ProgressTabs.Content>
-
-        <ProgressTabs.Content value={Tab.LINES} className="px-6 py-6">
-          <div className="flex max-w-[860px] flex-col gap-y-3">
-            <div className="flex items-center justify-between">
-              <Label>Lines</Label>
-              <Button variant="secondary" size="small" onClick={addLine}>
-                Add line
-              </Button>
-            </div>
-            {lines.length === 0 ? (
-              <Text size="small" className="text-ui-fg-subtle">
-                A quote is a basket — add at least one line. Multiple lines are
-                quoted as ONE consignment, so freight is charged once.
-              </Text>
-            ) : null}
-            {/* 🔴 Persistent, NOT part of the empty state: this is the note
-                that matters while someone is typing into the fields, and it
-                was briefly rendered only when there were no lines to type
-                into. A number entered in a USD quote is read in the partner
-                store's currency, and a field that does not say so is read as
-                the buyer's. */}
-            <Text size="small" className="text-ui-fg-subtle">
-              Leave the trade-price fields blank to quote at the catalog price.
-              A unit price is read in the partner store's own currency and
-              converted at mint; a discount is a percentage off the tier.
-            </Text>
-            {lines.map((line, i) => (
-              <div key={i} className="flex items-end gap-3">
-                <div className="flex flex-1 flex-col gap-y-2">
-                  <Select
-                    value={line.variant_id}
-                    onValueChange={(v) =>
-                      setLines((prev) =>
-                        prev.map((l, idx) =>
-                          idx === i ? { ...l, variant_id: v } : l
-                        )
-                      )
-                    }
-                  >
-                    <Select.Trigger>
-                      <Select.Value placeholder="Select a variant" />
-                    </Select.Trigger>
-                    <Select.Content>
-                      {variantOptions.map((v) => (
-                        <Select.Item key={v.id} value={v.id}>
-                          {v.label}
-                        </Select.Item>
-                      ))}
-                    </Select.Content>
-                  </Select>
+              <div className="flex h-full flex-col overflow-y-auto">
+                {readiness && (
+                  <div className="px-6 pt-4 md:px-16">
+                    <ReadinessPanel readiness={readiness} />
+                  </div>
+                )}
+                <div className="px-6 pt-4 md:px-16">
+                  <Text size="small" className="text-ui-fg-subtle">
+                    Leave the trade-price fields blank to quote at the catalog
+                    price. A unit price is read in the partner store's own
+                    currency and converted at mint; a discount is a percentage
+                    off the tier.
+                  </Text>
                 </div>
-                <div className="w-24">
-                  <Input
-                    type="number"
-                    min={1}
-                    placeholder="Qty"
-                    value={line.quantity}
-                    onChange={(e) =>
-                      setLines((prev) =>
-                        prev.map((l, idx) =>
-                          idx === i
-                            ? { ...l, quantity: Number(e.target.value) }
-                            : l
-                        )
-                      )
-                    }
-                  />
-                </div>
-                {/* An empty string must clear back to undefined rather than
-                    becoming 0: `Number("")` is 0, and a 0 here is a request to
-                    mint a free line. */}
-                <div className="w-24">
-                  <Input
-                    type="number"
-                    min={0}
-                    max={100}
-                    placeholder="Disc %"
-                    disabled={
-                      line.override_unit_amount !== null &&
-                      line.override_unit_amount !== undefined
-                    }
-                    value={line.discount_percent ?? ""}
-                    onChange={(e) =>
-                      setLines((prev) =>
-                        prev.map((l, idx) =>
-                          idx === i
-                            ? {
-                                ...l,
-                                discount_percent:
-                                  e.target.value === ""
-                                    ? undefined
-                                    : Number(e.target.value),
-                              }
-                            : l
-                        )
-                      )
-                    }
-                  />
-                </div>
-                <div className="w-32">
-                  <Input
-                    type="number"
-                    min={0}
-                    placeholder="Unit price"
-                    disabled={
-                      line.discount_percent !== null &&
-                      line.discount_percent !== undefined
-                    }
-                    value={line.override_unit_amount ?? ""}
-                    onChange={(e) =>
-                      setLines((prev) =>
-                        prev.map((l, idx) =>
-                          idx === i
-                            ? {
-                                ...l,
-                                override_unit_amount:
-                                  e.target.value === ""
-                                    ? undefined
-                                    : Number(e.target.value),
-                              }
-                            : l
-                        )
-                      )
-                    }
-                  />
-                </div>
-                <Button
-                  variant="transparent"
-                  size="small"
-                  onClick={() =>
-                    setLines((prev) => prev.filter((_, idx) => idx !== i))
-                  }
-                >
-                  Remove
-                </Button>
+                <QuantitiesStep form={form} />
               </div>
-            ))}
-          </div>
-        </ProgressTabs.Content>
+            </ProgressTabs.Content>
+          </RouteFocusModal.Body>
 
-        <ProgressTabs.Content value={Tab.REVIEW} className="px-6 py-6">
-          <div className="flex max-w-[860px] flex-col gap-y-4">
-            {readiness && <ReadinessPanel readiness={readiness} />}
-
-            <div className="flex flex-col gap-y-2">
-              <Label>Note to the buyer</Label>
-              <Textarea
-                value={note}
-                onChange={(e) => setNote(e.target.value)}
-              />
+          <RouteFocusModal.Footer>
+            <div className="flex items-center justify-end gap-x-2">
+              <RouteFocusModal.Close asChild>
+                <Button variant="secondary" size="small">
+                  Cancel
+                </Button>
+              </RouteFocusModal.Close>
+              {tab === Tab.QUANTITIES ? (
+                <Button
+                  key="submit"
+                  type="submit"
+                  variant="primary"
+                  size="small"
+                  isLoading={isPending || isChecking}
+                >
+                  Mint quote
+                </Button>
+              ) : (
+                <Button
+                  key="next"
+                  type="button"
+                  variant="primary"
+                  size="small"
+                  onClick={handleNextTab}
+                >
+                  Continue
+                </Button>
+              )}
             </div>
-
-            <Text size="small" className="text-ui-fg-subtle">
-              {validLines.length} line
-              {validLines.length === 1 ? "" : "s"} · {currency.toUpperCase()} ·
-              to {country.toUpperCase()}
-              {postal ? ` ${postal}` : ""}. Minting runs a readiness check
-              first — freight, weights and prices are verified before anything
-              is created.
-            </Text>
-          </div>
-        </ProgressTabs.Content>
+          </RouteFocusModal.Footer>
+        </KeyboundForm>
       </ProgressTabs>
-
-      <div className="border-ui-border-base flex items-center justify-end gap-x-2 border-t px-6 py-4">
-        {isLast ? (
-          <Button
-            onClick={submit}
-            disabled={!validLines.length || isPending || isChecking}
-          >
-            {isChecking ? "Checking…" : isPending ? "Minting…" : "Mint quote"}
-          </Button>
-        ) : (
-          <Button onClick={handleNext} disabled={!stepComplete[tab]}>
-            Continue
-          </Button>
-        )}
-      </div>
-    </div>
+    </RouteFocusModal.Form>
   )
 }

--- a/apps/backend/src/admin/routes/quotes/create/page.tsx
+++ b/apps/backend/src/admin/routes/quotes/create/page.tsx
@@ -1,11 +1,22 @@
-import { Container } from "@medusajs/ui"
+import { RouteFocusModal } from "../../../components/modal/route-focus-modal"
 
 import { MintQuoteForm } from "./mint-quote-form"
 
+/**
+ * Minting lives in a focus modal, like every other create route on this admin.
+ *
+ * It shipped as a plain `Container` on the page, which made it the one create
+ * flow that navigated AWAY from wherever the operator was — and the quote list
+ * is exactly the context you want back the moment a mint finishes.
+ *
+ * 🔑 The hook lives in the CHILD. `useRouteModal` reads a context that
+ * `RouteFocusModal` itself provides, so a component that renders the modal
+ * cannot also call the hook — that is #1352, and it throws at render.
+ */
 const MintQuotePage = () => (
-  <Container className="p-0">
+  <RouteFocusModal prev="/quotes">
     <MintQuoteForm />
-  </Container>
+  </RouteFocusModal>
 )
 
 export const handle = {

--- a/apps/backend/src/admin/routes/quotes/create/schema.ts
+++ b/apps/backend/src/admin/routes/quotes/create/schema.ts
@@ -1,0 +1,76 @@
+import { z } from "@medusajs/framework/zod"
+
+/**
+ * Mirrors `apps/backend/src/api/admin/quotes/validators.ts`, which is itself
+ * the partner mint schema plus `partner_id`.
+ *
+ * 🔑 No `customer_id`. The mint find-or-creates the buyer BY EMAIL scoped to
+ * the partner's store, so an id would be discarded — the picker exists so a
+ * typo cannot silently create a second customer, not to pass a reference.
+ */
+export const QuotePartnerSchema = z.object({
+  partner_id: z.string().min(1),
+})
+
+export const QuoteBuyerSchema = z.object({
+  buyer_email: z.string().email(),
+  recipient_name: z.string().optional(),
+  recipient_company: z.string().optional(),
+  partner_note: z.string().optional(),
+
+  /**
+   * The region is the wizard's own field — the mint takes `region_id`,
+   * `currency_code` and `destination_country_code` separately, and this is
+   * what keeps the three consistent. Picking a region sets the currency and
+   * narrows the countries to the ones it covers, so "INR to a GB address" —
+   * which no region supports and the preflight refused after the fact — stops
+   * being expressible.
+   */
+  region_id: z.string().min(1),
+  currency_code: z.string().min(3),
+  destination_country_code: z.string().min(2),
+  destination_postal_code: z.string().optional(),
+  destination_city: z.string().optional(),
+
+  /** Drives `price_list.ends_at`, so expiry is native rather than swept. */
+  ttl_days: z.number().int().positive().max(365).optional(),
+})
+
+export const QuoteProductsSchema = z.object({
+  product_ids: z.array(z.object({ id: z.string() })),
+})
+
+/**
+ * Quantity per variant, keyed by variant id, plus the trade price (#1446).
+ *
+ * A blank or zero quantity is NOT a zero-priced line — it means "not in this
+ * basket" and is dropped before the request is built. Same for a blank
+ * override: sent as 0 it would ask the backend to mint an ACTIVE price of
+ * zero, which it refuses.
+ */
+export const QuoteQuantitiesSchema = z.object({
+  quantities: z.record(z.string(), z.number().nullish()),
+  discounts: z.record(z.string(), z.number().nullish()),
+  overrides: z.record(z.string(), z.number().nullish()),
+})
+
+export const AdminQuoteCreateSchema = QuotePartnerSchema.merge(QuoteBuyerSchema)
+  .merge(QuoteProductsSchema)
+  .merge(QuoteQuantitiesSchema)
+
+export type AdminQuoteCreateSchemaType = z.infer<typeof AdminQuoteCreateSchema>
+
+export const QuotePartnerFields = ["partner_id"] as const
+export const QuoteBuyerFields = [
+  "buyer_email",
+  "recipient_name",
+  "recipient_company",
+  "partner_note",
+  "region_id",
+  "currency_code",
+  "destination_country_code",
+  "destination_postal_code",
+  "destination_city",
+  "ttl_days",
+] as const
+export const QuoteProductFields = ["product_ids"] as const

--- a/apps/backend/src/admin/routes/quotes/create/steps/buyer-step.tsx
+++ b/apps/backend/src/admin/routes/quotes/create/steps/buyer-step.tsx
@@ -1,0 +1,299 @@
+import { Heading, Input, Select, Text, Textarea } from "@medusajs/ui"
+import { useMemo, useState } from "react"
+import { UseFormReturn, useWatch } from "react-hook-form"
+
+import { Form } from "../../../../components/common/form"
+import { Combobox } from "../../../../components/inputs/combobox/combobox"
+import {
+  useQuoteBuyerOptions,
+  useQuoteRegions,
+} from "../../../../hooks/api/quote-buyer-sources"
+import { AdminQuoteCreateSchemaType } from "../schema"
+
+type Props = { form: UseFormReturn<AdminQuoteCreateSchemaType> }
+
+/**
+ * Step 2 — who the quote is for, and where it lands.
+ *
+ * ## The region is the field; currency and country are consequences
+ *
+ * This step used to ask for a currency and a destination country as two free
+ * text inputs. That let an operator type "inr" against a GB address — a
+ * combination no region supports, so the mint priced against nothing and the
+ * preflight refused it only after every other step had been filled in.
+ *
+ * 🔑 A region carries both facts, so picking one SETS the currency and narrows
+ * the country list to the ones it actually covers. The impossible combination
+ * stops being expressible rather than being validated after the fact. The
+ * currency stays visible but read-only: an operator needs to see what the
+ * buyer will be quoted in, and needs not to be able to contradict the region.
+ *
+ * ## Two buyer lists, one field
+ *
+ * Existing customers AND CRM people, because a B2B quote is usually the FIRST
+ * thing a lead ever receives — they are not a customer yet. Both resolve to an
+ * email, which is the only thing the mint uses: it find-or-creates the buyer by
+ * address, scoped to the partner's store. A typed address that matches nothing
+ * must therefore stay selectable, or the wizard could only ever quote people
+ * who had already bought.
+ */
+export const BuyerStep = ({ form }: Props) => {
+  const [search, setSearch] = useState("")
+  const { regions } = useQuoteRegions()
+  const { options: buyers } = useQuoteBuyerOptions(search)
+
+  const regionId = useWatch({ control: form.control, name: "region_id" })
+  const region = useMemo(
+    () => regions.find((r) => r.id === regionId) ?? null,
+    [regions, regionId]
+  )
+
+  const onRegionChange = (value: string) => {
+    const next = regions.find((r) => r.id === value)
+    form.setValue("region_id", value, { shouldDirty: true })
+    if (!next) return
+
+    form.setValue("currency_code", next.currency_code, { shouldDirty: true })
+
+    // Keep a country the operator already chose if the new region covers it;
+    // otherwise fall to the region's first. Silently clearing a destination
+    // they typed would be worse than moving it somewhere the region supports.
+    const current = form.getValues("destination_country_code")
+    const nextCountry = next.countries.includes(current)
+      ? current
+      : next.countries[0] ?? ""
+    form.setValue("destination_country_code", nextCountry, { shouldDirty: true })
+  }
+
+  const buyerOptions = buyers.map((b) => ({
+    label: b.source === "lead" ? `${b.label} · lead` : b.label,
+    value: b.email,
+  }))
+
+  const onBuyerSelected = (email: string) => {
+    const picked = buyers.find((b) => b.email === email)
+    if (!picked) return
+    // Only fill what is EMPTY. An operator who has already typed a company
+    // name meant it; a picker that overwrote it would lose a correction with
+    // no undo.
+    if (!form.getValues("recipient_company") && picked.company) {
+      form.setValue("recipient_company", picked.company, { shouldDirty: true })
+    }
+    if (!form.getValues("recipient_name") && picked.name) {
+      form.setValue("recipient_name", picked.name, { shouldDirty: true })
+    }
+  }
+
+  return (
+    <div className="flex flex-col gap-y-8">
+      <div className="flex flex-col gap-y-1">
+        <Heading level="h2">Buyer</Heading>
+        <Text size="small" className="text-ui-fg-subtle">
+          Pick an existing customer or a CRM lead, or type a new address —
+          either way the buyer is matched by email, and created if they are new.
+        </Text>
+      </div>
+
+      <div className="grid grid-cols-1 gap-4 md:grid-cols-2">
+        <Form.Field
+          control={form.control}
+          name="buyer_email"
+          render={({ field }) => (
+            <Form.Item>
+              <Form.Label>Buyer email</Form.Label>
+              <Form.Control>
+                <Combobox
+                  options={buyerOptions}
+                  searchValue={search}
+                  onSearchValueChange={setSearch}
+                  placeholder="procurement@example.com"
+                  /**
+                   * A brand-new buyer is the common case for a B2B quote, so a
+                   * typed address that matches nothing must still be
+                   * selectable — the mint creates the customer. Without this
+                   * the wizard could only ever quote people who had already
+                   * bought.
+                   */
+                  onCreateOption={(value) => field.onChange(value)}
+                  noResultsPlaceholder="Press enter to quote a new buyer"
+                  {...field}
+                  value={field.value ?? ""}
+                  onChange={(value?: string | string[]) => {
+                    field.onChange(value)
+                    if (typeof value === "string") onBuyerSelected(value)
+                  }}
+                />
+              </Form.Control>
+              <Form.ErrorMessage />
+            </Form.Item>
+          )}
+        />
+
+        <Form.Field
+          control={form.control}
+          name="recipient_company"
+          render={({ field }) => (
+            <Form.Item>
+              <Form.Label>Company</Form.Label>
+              <Form.Control>
+                <Input {...field} value={field.value ?? ""} />
+              </Form.Control>
+            </Form.Item>
+          )}
+        />
+
+        <Form.Field
+          control={form.control}
+          name="recipient_name"
+          render={({ field }) => (
+            <Form.Item>
+              <Form.Label>Contact name</Form.Label>
+              <Form.Control>
+                <Input {...field} value={field.value ?? ""} />
+              </Form.Control>
+            </Form.Item>
+          )}
+        />
+
+        <Form.Field
+          control={form.control}
+          name="region_id"
+          render={({ field }) => (
+            <Form.Item>
+              <Form.Label>Region</Form.Label>
+              <Form.Control>
+                <Select value={field.value} onValueChange={onRegionChange}>
+                  <Select.Trigger>
+                    <Select.Value placeholder="Select a region" />
+                  </Select.Trigger>
+                  <Select.Content>
+                    {regions.map((r) => (
+                      <Select.Item key={r.id} value={r.id}>
+                        {r.name} · {r.currency_code.toUpperCase()}
+                      </Select.Item>
+                    ))}
+                  </Select.Content>
+                </Select>
+              </Form.Control>
+              <Form.Hint>
+                Sets the currency and the destinations this quote can reach.
+              </Form.Hint>
+              <Form.ErrorMessage />
+            </Form.Item>
+          )}
+        />
+
+        <Form.Field
+          control={form.control}
+          name="destination_country_code"
+          render={({ field }) => (
+            <Form.Item>
+              <Form.Label>Destination country</Form.Label>
+              <Form.Control>
+                <Select
+                  value={field.value}
+                  onValueChange={field.onChange}
+                  disabled={!region}
+                >
+                  <Select.Trigger>
+                    <Select.Value
+                      placeholder={
+                        region ? "Select a country" : "Pick a region first"
+                      }
+                    />
+                  </Select.Trigger>
+                  <Select.Content>
+                    {(region?.countries ?? []).map((c) => (
+                      <Select.Item key={c} value={c}>
+                        {c.toUpperCase()}
+                      </Select.Item>
+                    ))}
+                  </Select.Content>
+                </Select>
+              </Form.Control>
+              <Form.ErrorMessage />
+            </Form.Item>
+          )}
+        />
+
+        <Form.Field
+          control={form.control}
+          name="currency_code"
+          render={({ field }) => (
+            <Form.Item>
+              <Form.Label>Currency</Form.Label>
+              <Form.Control>
+                {/* Read-only on purpose: it comes from the region, and an
+                    operator who could contradict it would be quoting a
+                    currency the region cannot price. */}
+                <Input
+                  {...field}
+                  value={String(field.value ?? "").toUpperCase()}
+                  readOnly
+                  disabled
+                />
+              </Form.Control>
+            </Form.Item>
+          )}
+        />
+
+        <Form.Field
+          control={form.control}
+          name="destination_postal_code"
+          render={({ field }) => (
+            <Form.Item>
+              <Form.Label>Destination postal code</Form.Label>
+              <Form.Control>
+                <Input {...field} value={field.value ?? ""} placeholder="400001" />
+              </Form.Control>
+              <Form.Hint>
+                Freight is quoted against this. Without it the lane falls back
+                to a country-level rate.
+              </Form.Hint>
+            </Form.Item>
+          )}
+        />
+
+        <Form.Field
+          control={form.control}
+          name="ttl_days"
+          render={({ field }) => (
+            <Form.Item>
+              <Form.Label>Valid for (days)</Form.Label>
+              <Form.Control>
+                <Input
+                  type="number"
+                  min={1}
+                  max={365}
+                  value={field.value ?? ""}
+                  onChange={(e) =>
+                    field.onChange(
+                      e.target.value === "" ? undefined : Number(e.target.value)
+                    )
+                  }
+                />
+              </Form.Control>
+              <Form.Hint>
+                Becomes the price list's end date, so expiry is enforced by
+                core rather than swept by a job.
+              </Form.Hint>
+            </Form.Item>
+          )}
+        />
+      </div>
+
+      <Form.Field
+        control={form.control}
+        name="partner_note"
+        render={({ field }) => (
+          <Form.Item>
+            <Form.Label>Note to the buyer</Form.Label>
+            <Form.Control>
+              <Textarea {...field} value={field.value ?? ""} rows={3} />
+            </Form.Control>
+          </Form.Item>
+        )}
+      />
+    </div>
+  )
+}

--- a/apps/backend/src/admin/routes/quotes/create/steps/products-step.tsx
+++ b/apps/backend/src/admin/routes/quotes/create/steps/products-step.tsx
@@ -1,0 +1,184 @@
+import {
+  Checkbox,
+  DataTable,
+  DataTablePaginationState,
+  Heading,
+  Text,
+  useDataTable,
+} from "@medusajs/ui"
+import { keepPreviousData } from "@tanstack/react-query"
+import { useMemo, useState } from "react"
+import { UseFormReturn, useWatch } from "react-hook-form"
+
+import { Thumbnail } from "../../../../components/common/thumbnail"
+import { useProducts } from "../../../../hooks/api/products"
+import { AdminQuoteCreateSchemaType } from "../schema"
+
+type Props = { form: UseFormReturn<AdminQuoteCreateSchemaType> }
+
+const PAGE_SIZE = 20
+
+/**
+ * Step 3 — which products are in the basket.
+ *
+ * The same shape the partner wizard uses: a real table with server-side search
+ * and pagination, not a `<Select>` of every variant in the catalogue. The
+ * select was fine for a two-line demo and unusable against a real catalogue —
+ * it loaded 100 products, flattened them to variants, and offered no way to
+ * find one.
+ *
+ * 🔴 Deselecting a product DROPS the quantities its variants carried. Otherwise
+ * a line the operator removed here would still be sent at the quantity they
+ * had typed, and a quantity is a real price on a real price list.
+ *
+ * A product with no variants is not selectable: there would be nothing to
+ * quote.
+ */
+export const ProductsStep = ({ form }: Props) => {
+  const { control, setValue } = form
+  const selected = useWatch({ control, name: "product_ids" })
+  const quantities = useWatch({ control, name: "quantities" })
+  const discounts = useWatch({ control, name: "discounts" })
+  const overrides = useWatch({ control, name: "overrides" })
+
+  const [pagination, setPagination] = useState<DataTablePaginationState>({
+    pageIndex: 0,
+    pageSize: PAGE_SIZE,
+  })
+  const [search, setSearch] = useState("")
+
+  const { products, count, isLoading } = useProducts(
+    {
+      limit: pagination.pageSize,
+      offset: pagination.pageIndex * pagination.pageSize,
+      ...(search ? { q: search } : {}),
+    } as any,
+    { placeholderData: keepPreviousData }
+  )
+
+  const selectedIds = useMemo(
+    () => new Set((selected ?? []).map((p) => p.id)),
+    [selected]
+  )
+
+  const toggle = (product: any) => {
+    if (!(product.variants ?? []).length) return
+
+    const next = new Set(selectedIds)
+    if (next.has(product.id)) {
+      next.delete(product.id)
+    } else {
+      next.add(product.id)
+    }
+
+    setValue(
+      "product_ids",
+      [...next].map((id) => ({ id })),
+      { shouldDirty: true, shouldTouch: true }
+    )
+
+    if (selectedIds.has(product.id)) {
+      // Removed — drop everything keyed on its variants, across all three
+      // per-variant maps. Leaving a stale override behind would price a line
+      // the operator believes they deleted.
+      const orphans = new Set(
+        ((product.variants ?? []) as any[]).map((v) => v.id)
+      )
+      const prune = (map: Record<string, any> | undefined) =>
+        Object.fromEntries(
+          Object.entries(map ?? {}).filter(([variantId]) => !orphans.has(variantId))
+        )
+
+      setValue("quantities", prune(quantities), { shouldDirty: true })
+      setValue("discounts", prune(discounts), { shouldDirty: true })
+      setValue("overrides", prune(overrides), { shouldDirty: true })
+    }
+  }
+
+  const columns = useMemo(
+    () => [
+      {
+        id: "select",
+        header: "",
+        cell: ({ row }: any) => {
+          const product = row.original
+          const noVariants = !(product.variants ?? []).length
+          return (
+            <Checkbox
+              checked={selectedIds.has(product.id)}
+              disabled={noVariants}
+              onCheckedChange={() => toggle(product)}
+            />
+          )
+        },
+        size: 36,
+      },
+      {
+        id: "title",
+        header: "Product",
+        cell: ({ row }: any) => (
+          <div className="flex items-center gap-x-3">
+            <Thumbnail src={row.original.thumbnail} size="small" />
+            <span className="truncate">{row.original.title}</span>
+          </div>
+        ),
+      },
+      {
+        id: "variants",
+        header: "Variants",
+        cell: ({ row }: any) => {
+          const n = (row.original.variants ?? []).length
+          // Named, not blank: "0" here is the reason the row cannot be picked,
+          // and an operator hunting for a missing product needs to see why.
+          return n === 0 ? (
+            <span className="text-ui-fg-muted">No variants — cannot quote</span>
+          ) : (
+            `${n}`
+          )
+        },
+      },
+      {
+        id: "status",
+        header: "Status",
+        cell: ({ row }: any) => row.original.status ?? "—",
+      },
+    ],
+    [selectedIds, quantities, discounts, overrides]
+  )
+
+  const table = useDataTable({
+    columns: columns as any,
+    data: (products ?? []) as any[],
+    getRowId: (row: any) => row.id,
+    rowCount: count ?? 0,
+    isLoading,
+    onRowClick: (_e: any, row: any) => toggle(row.original ?? row),
+    pagination: { state: pagination, onPaginationChange: setPagination },
+    search: {
+      state: search,
+      onSearchChange: (value: string) => {
+        setSearch(value)
+        setPagination((prev) => ({ ...prev, pageIndex: 0 }))
+      },
+    },
+  })
+
+  return (
+    <div className="flex h-full flex-col">
+      <div className="flex flex-col gap-y-1 px-6 pt-6">
+        <Heading level="h2">Products</Heading>
+        <Text size="small" className="text-ui-fg-subtle">
+          Pick everything this buyer is being quoted. The whole basket ships as
+          ONE consignment, so freight is charged once across all of it.
+        </Text>
+      </div>
+      <DataTable instance={table}>
+        <DataTable.Toolbar className="flex justify-end px-6 py-4">
+          <DataTable.Search placeholder="Search products..." />
+        </DataTable.Toolbar>
+        <DataTable.Table />
+        <DataTable.Pagination />
+      </DataTable>
+    </div>
+  )
+}

--- a/apps/backend/src/admin/routes/quotes/create/steps/quantities-step.tsx
+++ b/apps/backend/src/admin/routes/quotes/create/steps/quantities-step.tsx
@@ -1,0 +1,244 @@
+import { Button, Input, Label, Text } from "@medusajs/ui"
+import { ColumnDef } from "@tanstack/react-table"
+import { useMemo, useState } from "react"
+import { UseFormReturn, useWatch } from "react-hook-form"
+
+import { Thumbnail } from "../../../../components/common/thumbnail"
+import { DataGrid } from "../../../../components/data-grid/data-grid"
+import { DataGridNumberCell } from "../../../../components/data-grid/components/data-grid-number-cell"
+import { DataGridReadonlyCell } from "../../../../components/data-grid/components/data-grid-readonly-cell"
+import { createDataGridHelper } from "../../../../components/data-grid/helpers/create-data-grid-column-helper"
+import { useProducts } from "../../../../hooks/api/products"
+import { AdminQuoteCreateSchemaType } from "../schema"
+
+type Props = { form: UseFormReturn<AdminQuoteCreateSchemaType> }
+
+type Row = any
+
+const isProductRow = (row: Row): boolean => "variants" in (row ?? {})
+
+const columnHelper = createDataGridHelper<Row, AdminQuoteCreateSchemaType>()
+
+/**
+ * Step 4 — how many of each variant, and at what trade price.
+ *
+ * Mirrors the partner wizard's grid, including the two things that are easy to
+ * drop when porting:
+ *
+ * 🔴 The weight column is not decoration. Freight is quoted against the summed
+ * basket weight, and platform-wide most variants carry no weight at either
+ * level — a line with no weight cannot be quoted at all, and the operator needs
+ * to see that BEFORE minting rather than discover it in a quote that came back
+ * short. Which LEVEL the weight came from matters too: a declared product
+ * weight over-quotes a lighter variant, and at bulk quantities that can cross a
+ * carrier slab.
+ *
+ * 🔴 The unit-price column is in the PARTNER STORE's currency, not the quote's,
+ * and the header says so. A number typed against a USD quote is otherwise read
+ * as dollars; the conversion happens once at mint, at a rate the quote records.
+ */
+export const QuantitiesStep = ({ form }: Props) => {
+  const ids = useWatch({ control: form.control, name: "product_ids" })
+  const { products } = useProducts({ limit: 100 } as any)
+
+  const selected = useMemo(() => {
+    const wanted = new Set((ids ?? []).map((p) => p.id))
+    return ((products ?? []) as Row[]).filter(
+      (p) => isProductRow(p) && wanted.has(p.id)
+    )
+  }, [products, ids])
+
+  const columns = useMemo<ColumnDef<Row>[]>(
+    () => [
+      columnHelper.column({
+        id: "title",
+        header: "Product",
+        cell: (context: any) => {
+          const entity = context.row.original
+          if (isProductRow(entity)) {
+            return (
+              <DataGridReadonlyCell context={context}>
+                <div className="flex h-full w-full items-center gap-x-2 overflow-hidden">
+                  <Thumbnail src={entity.thumbnail} size="small" />
+                  <span className="truncate">{entity.title}</span>
+                </div>
+              </DataGridReadonlyCell>
+            )
+          }
+          return (
+            <DataGridReadonlyCell context={context} color="normal">
+              <span className="truncate">{entity.title}</span>
+            </DataGridReadonlyCell>
+          )
+        },
+        disableHiding: true,
+      }),
+      columnHelper.column({
+        id: "weight",
+        header: "Unit weight",
+        cell: (context: any) => {
+          const entity = context.row.original
+          if (isProductRow(entity)) {
+            return <DataGridReadonlyCell context={context} />
+          }
+
+          const variantWeight = entity.weight
+          // The listing nests variants under their product, so the fallback
+          // lives on the parent row — variants carry no back-reference here.
+          const productWeight = context.row.getParentRow()?.original?.weight
+          const resolved = variantWeight ?? productWeight ?? null
+          const source = variantWeight != null ? "variant" : "product"
+
+          return (
+            <DataGridReadonlyCell context={context} color="normal">
+              {resolved == null ? (
+                <span className="text-ui-fg-error truncate">
+                  No weight — cannot quote
+                </span>
+              ) : (
+                <span className="truncate">
+                  {resolved} g
+                  {source === "product" ? (
+                    <span className="text-ui-fg-subtle"> (product)</span>
+                  ) : null}
+                </span>
+              )}
+            </DataGridReadonlyCell>
+          )
+        },
+      }),
+      columnHelper.column({
+        id: "discount_percent",
+        name: "Discount %",
+        header: "Discount %",
+        field: (context: any) => {
+          const entity = context.row.original
+          if (isProductRow(entity)) return null
+          return `discounts.${entity.id}` as const
+        },
+        type: "number",
+        cell: (context: any) => {
+          const entity = context.row.original
+          if (isProductRow(entity)) {
+            return <DataGridReadonlyCell context={context} />
+          }
+          return <DataGridNumberCell context={context} min={0} max={100} />
+        },
+      }),
+      columnHelper.column({
+        id: "override_unit_amount",
+        name: "Unit price",
+        header: "Unit price (store currency)",
+        field: (context: any) => {
+          const entity = context.row.original
+          if (isProductRow(entity)) return null
+          return `overrides.${entity.id}` as const
+        },
+        type: "number",
+        cell: (context: any) => {
+          const entity = context.row.original
+          if (isProductRow(entity)) {
+            return <DataGridReadonlyCell context={context} />
+          }
+          return <DataGridNumberCell context={context} min={0} />
+        },
+      }),
+      columnHelper.column({
+        id: "quantity",
+        name: "Quantity",
+        header: "Quantity",
+        field: (context: any) => {
+          const entity = context.row.original
+          if (isProductRow(entity)) return null
+          return `quantities.${entity.id}` as const
+        },
+        type: "number",
+        cell: (context: any) => {
+          const entity = context.row.original
+          if (isProductRow(entity)) {
+            return <DataGridReadonlyCell context={context} />
+          }
+          return <DataGridNumberCell context={context} min={0} />
+        },
+      }),
+    ],
+    []
+  )
+
+  /**
+   * One percentage across the whole basket (#1446).
+   *
+   * 🔑 It writes into the per-line fields rather than becoming a quote-level
+   * discount of its own. The backend stores the override PER LINE with the
+   * rate and input it was reached by, because that is what makes a quoted
+   * number reproducible later — a basket-level percentage would have to be
+   * re-derived against catalogue prices that have since moved. So this is a
+   * typing shortcut with no server-side counterpart, which is exactly what it
+   * should be.
+   *
+   * It fills every variant of every selected product, including ones with no
+   * quantity yet: a line added afterwards would otherwise silently miss the
+   * discount the operator believes they applied to "everything".
+   */
+  const [bulkDiscount, setBulkDiscount] = useState<string>("")
+
+  const applyToAll = () => {
+    const percent = Number(bulkDiscount)
+    if (!Number.isFinite(percent) || percent <= 0 || percent > 100) return
+
+    const next: Record<string, number> = {}
+    for (const product of selected) {
+      for (const variant of (product.variants ?? []) as Row[]) {
+        next[variant.id] = percent
+      }
+    }
+
+    form.setValue("discounts", next, { shouldDirty: true })
+    // A flat unit price and a percentage are mutually exclusive per line, and
+    // the backend refuses both together. Applying a blanket percentage clears
+    // the prices it would otherwise collide with, rather than minting a basket
+    // that 400s on submit.
+    form.setValue("overrides", {}, { shouldDirty: true })
+  }
+
+  return (
+    <div className="flex h-full flex-col">
+      <div className="flex flex-wrap items-end gap-x-3 gap-y-2 px-6 pb-4 md:px-16">
+        <div className="flex flex-col gap-y-1">
+          <Label size="small">Discount % on every line</Label>
+          <Input
+            type="number"
+            min={0}
+            max={100}
+            className="w-32"
+            placeholder="e.g. 15"
+            value={bulkDiscount}
+            onChange={(e) => setBulkDiscount(e.target.value)}
+          />
+        </div>
+        <Button
+          type="button"
+          variant="secondary"
+          size="small"
+          onClick={applyToAll}
+          disabled={!bulkDiscount}
+        >
+          Apply to all
+        </Button>
+        <Text size="small" className="text-ui-fg-subtle">
+          A shortcut for the column — every line is still quoted, stored and
+          audited individually, and any line can be overridden afterwards.
+        </Text>
+      </div>
+
+      <DataGrid
+        columns={columns}
+        data={selected}
+        getSubRows={(row: Row) =>
+          isProductRow(row) ? row.variants ?? [] : undefined
+        }
+        state={form}
+      />
+    </div>
+  )
+}

--- a/e2e/specs/admin-quote-mint-wizard.spec.ts
+++ b/e2e/specs/admin-quote-mint-wizard.spec.ts
@@ -8,23 +8,23 @@ const SEED_FILE = path.resolve(__dirname, "../../apps/backend/.e2e-seed.json")
  * The admin mint wizard, driven through a browser (#1439 S4 / #1446).
  *
  * 🔑 Why this file exists: the wizard shipped in #1463 and had never been
- * opened in a browser, and #1446 has just added two fields to it that decide
- * what a buyer is charged. tsc sees a component that compiles; only a render
- * shows a step that will not advance, a hook called outside its provider
- * (#1352), or a disabled-state that never actually disables.
+ * opened in a browser. tsc sees a component that compiles; only a render shows
+ * a step that will not advance, a hook called outside its provider (#1352), or
+ * a modal body that does not scroll.
  *
  * ## What this deliberately does NOT do
  *
  * It never completes a mint. A mint needs a partner whose store has a priced
- * product on a quotable freight lane — the preflight (#1462) refuses anything
- * less, correctly — and standing that world up in the e2e seed would duplicate
+ * product on a quotable freight lane — the preflight refuses anything less,
+ * correctly — and standing that world up in the e2e seed would duplicate
  * `integration-tests/helpers/setup-quote-fixture.ts`, which already mints for
  * real against a container on every run. The arithmetic, the price-list rows
  * and the refusals are covered there.
  *
- * What is covered HERE is the half that suite cannot see: the form. Whether
- * the steps gate, whether the two trade-price fields exclude each other, and
- * whether clearing one leaves it EMPTY rather than zero.
+ * What is covered HERE is the half that suite cannot see: that it opens as a
+ * modal at all, that the steps gate, and that picking a region INFERS the
+ * currency instead of leaving two free-text boxes that can contradict each
+ * other.
  */
 test.describe("Admin mint-quote wizard (#1446)", () => {
   let seed: { email: string; password: string; parkedRunFreshPartnerName: string }
@@ -52,85 +52,79 @@ test.describe("Admin mint-quote wizard (#1446)", () => {
     await page.waitForURL(/\/app\/(?!login)/, { timeout: 15000 })
   }
 
-  /** Partner → Buyer → Lines, which is the only way to reach the fields. */
-  const openLinesStep = async (page: any) => {
-    await page.goto("/app/quotes/create")
-    await expect(page.getByRole("heading", { name: "Mint a quote" })).toBeVisible({
+  const openWizard = async (page: any) => {
+    await page.goto("/app/quotes")
+    await expect(page.getByRole("heading", { name: "Quotes" })).toBeVisible({
       timeout: 30000,
     })
-
-    const cont = page.getByRole("button", { name: "Continue" })
-
-    // 🔑 Step one gates step two. Choosing variants before a partner would let
-    // an admin build a basket that is then rejected wholesale, so Continue is
-    // dead until a partner is picked.
-    await expect(cont).toBeDisabled()
-
-    await page.getByText("Select a partner").click()
-    await page.getByRole("option", { name: seed.parkedRunFreshPartnerName }).click()
-    await expect(cont).toBeEnabled()
-    await cont.click()
-
-    await page.getByPlaceholder("procurement@example.com").fill("e2e-buyer@jyt.test")
-    await expect(cont).toBeEnabled()
-    await cont.click()
-
-    await expect(page.getByRole("button", { name: "Add line" })).toBeVisible({
-      timeout: 15000,
-    })
+    await page.getByRole("button", { name: "Mint quote" }).click()
+    // 🔑 A dialog, not a page. It shipped as a plain Container — the one
+    // create flow that navigated away from wherever the operator was.
+    await expect(page.getByRole("dialog")).toBeVisible({ timeout: 30000 })
   }
 
-  test("gates each step, and the trade-price fields appear on a line", async ({
+  test("opens as a focus modal with all four steps", async ({ page }) => {
+    await login(page)
+    await openWizard(page)
+
+    for (const step of ["Partner", "Buyer", "Products", "Quantities"]) {
+      await expect(page.getByRole("tab", { name: step })).toBeVisible()
+    }
+  })
+
+  test("will not leave the Partner step until a partner is chosen", async ({
     page,
   }) => {
     await login(page)
-    await openLinesStep(page)
+    await openWizard(page)
 
-    // An empty basket cannot advance: a quote with no lines has nothing to price.
-    await expect(page.getByRole("button", { name: "Continue" })).toBeDisabled()
+    // Every quote is partner-scoped: the partner decides which catalogue the
+    // variants come from and which location freight is quoted from, so
+    // choosing products first would build a basket rejected wholesale.
+    await page.getByRole("button", { name: "Continue" }).click()
+    await expect(page.getByRole("tab", { name: "Partner" })).toHaveAttribute(
+      "aria-selected",
+      "true"
+    )
 
-    await page.getByRole("button", { name: "Add line" }).click()
+    await page.getByText("Select a partner").click()
+    await page.getByRole("option", { name: seed.parkedRunFreshPartnerName }).click()
+    await page.getByRole("button", { name: "Continue" }).click()
 
-    await expect(page.getByPlaceholder("Qty")).toBeVisible()
-    await expect(page.getByPlaceholder("Disc %")).toBeVisible()
-    await expect(page.getByPlaceholder("Unit price")).toBeVisible()
-
-    // 🔴 The copy must name whose currency the unit price is in. A number typed
-    // into a USD quote means the partner store's currency, and a field that did
-    // not say so would be read as the buyer's.
-    await expect(
-      page.getByText("read in the partner store's own currency", { exact: false })
-    ).toBeVisible()
+    await expect(page.getByRole("tab", { name: "Buyer" })).toHaveAttribute(
+      "aria-selected",
+      "true",
+      { timeout: 15000 }
+    )
   })
 
-  test("🔑 the two trade-price forms exclude each other", async ({ page }) => {
+  test("🔑 picking a region infers the currency and narrows the destinations", async ({
+    page,
+  }) => {
     await login(page)
-    await openLinesStep(page)
-    await page.getByRole("button", { name: "Add line" }).click()
+    await openWizard(page)
 
-    const discount = page.getByPlaceholder("Disc %")
-    const unitPrice = page.getByPlaceholder("Unit price")
+    await page.getByText("Select a partner").click()
+    await page.getByRole("option", { name: seed.parkedRunFreshPartnerName }).click()
+    await page.getByRole("button", { name: "Continue" }).click()
+    await expect(page.getByText("Buyer", { exact: true }).first()).toBeVisible({
+      timeout: 15000,
+    })
 
-    // Both live until one is used — "which wins" is a question that must never
-    // arise, so the UI removes the choice rather than ranking the answers.
-    await expect(discount).toBeEnabled()
-    await expect(unitPrice).toBeEnabled()
+    // Currency and destination used to be two free-text boxes, which let an
+    // operator quote INR to a GB address — a combination no region supports.
+    const currency = page.locator('input[name="currency_code"]')
+    await expect(currency).toBeDisabled()
+    await expect(currency).toHaveValue("")
 
-    await discount.fill("15")
-    await expect(unitPrice).toBeDisabled()
+    // The country list is dead until a region says which countries exist.
+    await expect(page.getByText("Pick a region first")).toBeVisible()
 
-    // 🔴 Clearing returns the field to EMPTY, not 0. `Number("")` is 0, and a
-    // zero is a request to mint a free line — the backend refuses it, but the
-    // refusal would arrive as a failed mint rather than the no-op intended.
-    await discount.fill("")
-    await expect(discount).toHaveValue("")
-    await expect(unitPrice).toBeEnabled()
+    await page.getByText("Select a region").click()
+    await page.getByRole("option").first().click()
 
-    // And the same in the other direction.
-    await unitPrice.fill("19000")
-    await expect(discount).toBeDisabled()
-    await unitPrice.fill("")
-    await expect(unitPrice).toHaveValue("")
-    await expect(discount).toBeEnabled()
+    // The region wrote the currency; nobody typed it.
+    await expect(currency).not.toHaveValue("")
+    await expect(page.getByText("Pick a region first")).toBeHidden()
   })
 })


### PR DESCRIPTION
Part of #1439 (S4/S7). **Stacked on #1475** — base is `feat/quote-line-override`, so review/merge that first.

## Why

The two mint surfaces are the same product wearing different chrome, and they had drifted badly. The partner minted through a focus-modal wizard with a customer picker, a searchable product table and an editable grid. The admin filled in a page-level form with a `<Select>` of every variant in the catalogue and two free-text boxes for currency and country. Nothing learned on one surface transferred to the other, and the admin one could not be used against a real catalogue at all.

## It is a focus modal now

It shipped as a plain `Container` — the one create flow that navigated *away* from wherever the operator was, when the quote list is exactly the context you want back the moment a mint finishes.

🔑 The hook lives in the child: `useRouteModal` reads a context `RouteFocusModal` provides, so a component rendering the modal cannot also call the hook. That's #1352, and it throws at render.

## The region is a field; currency and country are consequences

Currency and destination were independent text inputs, which let an operator quote INR against a GB address — a combination no region supports, so the mint priced against nothing and the preflight refused it only after every other step was filled in. Picking a region sets the currency and narrows the countries to those it covers. **The impossible combination stops being expressible** rather than being validated after the fact. Currency stays visible but read-only.

## Buyers come from customers *and* CRM leads

Merged and de-duplicated by email, customer winning — the same human is often both, and one address under two labels invites "which is the real record?" when the mint matches on the address alone. Leads matter commercially: a B2B quote is usually the first thing a lead ever receives. A typed address that matches nothing stays selectable, or the wizard could only quote people who had already bought.

## Products are a table; quantities are a grid

Server-side search and pagination instead of a flattened variant select. Deselecting a product drops the quantities, discounts and overrides its variants carried — otherwise a removed line is still sent at the price that was typed, and that is a real row on a real price list. The grid keeps the weight column and its provenance: most variants platform-wide carry no weight at either level, a line without one cannot be quoted, and a product-level weight over-quotes a lighter variant hard enough to cross a carrier slab in bulk.

## A basket-wide discount, as a typing shortcut only

It writes into the per-line fields rather than becoming a quote-level discount. The backend stores each override with the input and rate it was reached by, which is what makes a quoted number reproducible after catalogue prices move; a basket-level percentage would have to be re-derived against prices that no longer exist. Applying it clears any flat unit prices, since the two forms are mutually exclusive per line.

## ⚠️ Not verified in a browser yet

The e2e spec is rewritten to match (dialog not page, four steps, Partner gating, region→currency inference), but the local `medusa develop` is serving an admin bundle built before these edits, so a run proves only that the routes resolve. Restart the dev server before trusting a pass or failure. Possible cause worth confirming: running `check:prod-build` while the dev server is up rewrites `.medusa`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)