### PR TITLE
feat(quote): compute tax on a quote, and say so when it cannot

### DIFF
--- a/apps/backend/integration-tests/http/partner-quote-tax-jurisdiction.spec.ts
+++ b/apps/backend/integration-tests/http/partner-quote-tax-jurisdiction.spec.ts
@@ -1,0 +1,236 @@
+import { getSharedTestEnv, setupSharedTestSuite } from "./shared-test-setup"
+import { createAdminUser } from "../helpers/create-admin-user"
+import { Modules } from "@medusajs/framework/utils"
+import {
+  createShippingOptionsWorkflow,
+  createTaxRegionsWorkflow,
+} from "@medusajs/medusa/core-flows"
+import {
+  setupQuoteFixture,
+  mintBody,
+  type QuoteFixture,
+} from "../helpers/setup-quote-fixture"
+
+jest.setTimeout(240 * 1000)
+
+/**
+ * Whose tax is it — origin, not destination (#1439 S8 / #1447).
+ *
+ * The first cut of `resolveQuoteTax` asked the Tax module using the DESTINATION
+ * country alone, which quietly assumes the seller is registered wherever the
+ * buyer happens to be. Goods on this platform always dispatch from India, so a
+ * German buyer was shown 19% German VAT on an Indian export — a fifth added to
+ * the headline number of every EU quote. It over-quoted rather than
+ * under-quoted, so it lost deals instead of money, but it was never right.
+ *
+ * ## What only a container run can check
+ *
+ * That the origin is actually READ — off `store.default_location_id`, through
+ * `query.graph`, into the classifier. The pure classifier is unit-tested and
+ * would pass whether or not anything ever called it; `buildProvenance` sat
+ * written, tested and imported by nothing for months on exactly that gap
+ * (#1448). Here a domestic quote can only reach `calculated` if the origin
+ * resolved to IN and matched, so the assertion is a wiring proof, not a
+ * restatement of the unit test.
+ *
+ * The second thing only a real run shows: tax is computed INSIDE the
+ * freight-success branch, so an export needs a real lane to the destination
+ * before it has any tax status at all.
+ */
+
+const loud = async <T>(label: string, fn: () => Promise<T>): Promise<T> => {
+  try {
+    return await fn()
+  } catch (e: any) {
+    console.log(`[${label}] ${e.response?.status}`, JSON.stringify(e.response?.data))
+    throw e
+  }
+}
+
+setupSharedTestSuite(() => {
+  describe("quote tax jurisdiction (#1447)", () => {
+    let seed: QuoteFixture
+
+    beforeAll(async () => {
+      const { api, getContainer } = getSharedTestEnv()
+      const container = getContainer()
+      await createAdminUser(container)
+      seed = await setupQuoteFixture(api, getContainer)
+
+      // ---- An Indian tax region, or every quote is `unknown` --------------
+      // The harness truncates, so the canonical seed's rows are not here. 18%
+      // is India's standard GST rate, matching seed-canonical-tax-regions.ts.
+      const tax: any = container.resolve(Modules.TAX)
+      const existing = await tax.listTaxRegions({ country_code: "in" })
+      if (!existing.length) {
+        // ⚠️ Through the workflow, and WITH a `provider_id`. A region created
+        // straight off the service with no provider throws
+        // `AwilixResolutionError: Could not resolve 'null'` deep inside
+        // `TaxProviderService.retrieveProvider` the first time anything asks it
+        // for tax lines — and `resolveQuoteTax` catches that into
+        // `status: "unknown"`, so the quote reads as merely untaxed rather than
+        // misconfigured. `tp_system` ships with Medusa and is what
+        // seed-canonical-tax-regions.ts uses.
+        await createTaxRegionsWorkflow(container).run({
+          input: [
+            {
+              country_code: "in",
+              provider_id: "tp_system",
+              default_tax_rate: {
+                name: "India GST (standard)",
+                code: "IN-GST",
+                rate: 18,
+              },
+            } as any,
+          ],
+        })
+      }
+
+      // ---- A real lane to Germany ----------------------------------------
+      // Without one the mint's S6 preflight refuses the quote and tax is never
+      // reached: it is computed after freight succeeds, not alongside it.
+      const fulfillment: any = container.resolve(Modules.FULFILLMENT)
+      const link: any = container.resolve("link")
+      const profiles = await fulfillment.listShippingProfiles({})
+      const set = await fulfillment.createFulfillmentSets({
+        name: `Quote Export Shipping ${seed.unique}`,
+        type: "shipping",
+      })
+      const zone = await fulfillment.createServiceZones({
+        name: `Germany ${seed.unique}`,
+        fulfillment_set_id: set.id,
+        geo_zones: [{ type: "country", country_code: "de" }],
+      })
+      await link
+        .create({
+          [Modules.STOCK_LOCATION]: { stock_location_id: seed.locationId },
+          [Modules.FULFILLMENT]: { fulfillment_set_id: set.id },
+        })
+        .catch(() => {})
+      await createShippingOptionsWorkflow(container).run({
+        input: [
+          {
+            name: `Quote Export Freight ${seed.unique}`,
+            service_zone_id: zone.id,
+            shipping_profile_id: profiles[0].id,
+            provider_id: "manual_manual",
+            type: { label: "Flat", description: "Flat freight", code: "flat" },
+            price_type: "flat",
+            prices: [{ amount: 2500, currency_code: seed.currencyCode }],
+            rules: [
+              { attribute: "enabled_in_store", value: "true", operator: "eq" },
+              { attribute: "is_return", value: "false", operator: "eq" },
+            ],
+          } as any,
+        ],
+      })
+    })
+
+    /** Mint, then read the buyer view the storefront reads. */
+    const mintAndView = async (overrides: Record<string, any>) => {
+      const { api } = getSharedTestEnv()
+      const mint = await loud("mint", () =>
+        api.post("/partners/quotes", mintBody(seed, overrides), {
+          headers: seed.headers,
+        })
+      )
+      const token = mint.data.token
+      expect(token).toBeTruthy()
+      // The buyer route is a /store/* route, so it needs the storefront's
+      // publishable key even though the quote token is the actual credential.
+      const view = await loud("view", () =>
+        api.get(`/store/b2b/quotes/${token}`, {
+          headers: { "x-publishable-api-key": seed.publishableKey },
+        })
+      )
+      return view.data.quote
+    }
+
+    it("computes GST on a domestic quote — which proves the origin was read", async () => {
+      const quote = await mintAndView({
+        buyer_email: `buyer-domestic-${seed.unique}@jaalyantra.test`,
+        destination_country_code: "in",
+        destination_postal_code: "400001",
+      })
+
+      // 🔑 The wiring proof. If `resolveStoreOriginCountry` had returned null,
+      // this would be `unknown` — the classifier refuses to assume domestic.
+      // Reaching `calculated` means the store's stock location was read, came
+      // back IN, and matched the destination.
+      expect(quote.tax.status).toBe("calculated")
+      expect(quote.tax.total).toBeGreaterThan(0)
+      expect(quote.tax.reason).toBeNull()
+      expect(quote.tax.rates.length).toBeGreaterThan(0)
+      expect(quote.tax.rates.some((r: any) => r.on === "goods")).toBe(true)
+
+      const money = quote.live ?? quote.quoted
+      expect(money.tax_total).toBeGreaterThan(0)
+      // Exclusive prices: gross is strictly above goods+freight by the tax.
+      expect(money.gross_total).toBeCloseTo(
+        money.landed_total + money.tax_total,
+        2
+      )
+    })
+
+    it("zero-rates an export to Germany instead of charging German VAT", async () => {
+      const quote = await mintAndView({
+        buyer_email: `buyer-export-${seed.unique}@jaalyantra.test`,
+        destination_country_code: "de",
+        destination_postal_code: "10115",
+        destination_city: "Berlin",
+      })
+
+      expect(quote.tax.status).toBe("zero_rated_export")
+      // A REAL zero, not a missing number — the distinction the status carries.
+      expect(quote.tax.total).toBe(0)
+      expect(quote.tax.rates).toEqual([])
+
+      // 🔴 The regression this suite exists for. A destination-keyed lookup
+      // would have found no German tax region in this DB and said `unknown`;
+      // on prod, where the canonical seed HAS a `de` region at 19%, it would
+      // have said `calculated` and added a fifth to the total. Neither is right.
+      expect(quote.tax.status).not.toBe("calculated")
+      expect(quote.tax.rates.some((r: any) => r.rate === 19)).toBe(false)
+
+      const money = quote.live ?? quote.quoted
+      expect(money.tax_total).toBe(0)
+      // Nothing added: a zero-rated export's gross IS goods + freight.
+      expect(money.gross_total).toBeCloseTo(money.landed_total, 2)
+    })
+
+    it("tells the buyer duty is theirs — the half a bare zero would hide", async () => {
+      const quote = await mintAndView({
+        buyer_email: `buyer-duty-${seed.unique}@jaalyantra.test`,
+        destination_country_code: "de",
+        destination_postal_code: "10115",
+        destination_city: "Berlin",
+      })
+
+      // The zero is honest only because this sentence exists. Without it the
+      // page shows a complete-looking total and the buyer meets a customs bill
+      // they never budgeted for — #1430's shape.
+      const reason: string = quote.tax.reason
+      expect(reason).toBeTruthy()
+      expect(reason).toMatch(/export from IN to DE/)
+      expect(reason).toMatch(/zero-rated/)
+      expect(reason).toMatch(/duty/i)
+      expect(reason).toMatch(/payable by you/i)
+      expect(reason).toMatch(/NOT included/)
+    })
+
+    it("keeps the freight leg out of the export's tax, not merely out of its rate", async () => {
+      const quote = await mintAndView({
+        buyer_email: `buyer-freight-${seed.unique}@jaalyantra.test`,
+        destination_country_code: "de",
+        destination_postal_code: "10115",
+        destination_city: "Berlin",
+      })
+
+      const money = quote.live ?? quote.quoted
+      // Freight is really present — otherwise "no freight tax" would be
+      // vacuously true and this test would pass on a broken lane.
+      expect(money.freight).toBeGreaterThan(0)
+      expect(quote.tax.total).toBe(0)
+    })
+  })
+})

--- a/apps/backend/src/modules/partner-quote/__tests__/compare.unit.spec.ts
+++ b/apps/backend/src/modules/partner-quote/__tests__/compare.unit.spec.ts
@@ -5,6 +5,12 @@ const money = (over: Partial<QuoteMoney> = {}): QuoteMoney => ({
   subtotal: 600_000,
   freight: 21_000,
   landed_total: 621_000,
+  // S8 added these as REQUIRED fields and this fixture was not updated, so the
+  // branch was red on `check:prod-build` while every unit test passed — jest
+  // does not typecheck. Null, not 0: the comparison cases here are about goods
+  // and freight, and a 0 would assert a tax answer none of them make.
+  tax_total: null,
+  gross_total: null,
   ...over,
 })
 

--- a/apps/backend/src/modules/partner-quote/__tests__/quote-tax.unit.spec.ts
+++ b/apps/backend/src/modules/partner-quote/__tests__/quote-tax.unit.spec.ts
@@ -1,5 +1,11 @@
 import { composeQuoteMoney, frozenMoney } from "../lib/build-quote-view"
-import { foldTaxLines, unknownTaxReason } from "../lib/quote-tax"
+import {
+  classifyQuoteJurisdiction,
+  exportDisclosureReason,
+  foldTaxLines,
+  unknownOriginReason,
+  unknownTaxReason,
+} from "../lib/quote-tax"
 
 /**
  * Tax on a quote (#1439 S8).
@@ -149,5 +155,60 @@ describe("frozenMoney with tax", () => {
       quoted_tax_inclusive: true,
     } as any)
     expect(inclusive?.gross_total).toBe(1200)
+  })
+})
+
+/**
+ * Jurisdiction (#1447 / #1439 S8).
+ *
+ * The first cut asked the Tax module using the destination country alone, which
+ * assumes the seller is registered wherever the buyer is. Goods on this platform
+ * always dispatch from India, so that put 19% German VAT on an Indian export —
+ * a fifth added to the headline number of every EU quote.
+ */
+describe("classifyQuoteJurisdiction", () => {
+  it("is domestic when the goods do not cross a border", () => {
+    expect(classifyQuoteJurisdiction("IN", "IN")).toBe("domestic")
+  })
+
+  it("is an export whenever origin and destination differ", () => {
+    expect(classifyQuoteJurisdiction("IN", "DE")).toBe("export")
+    expect(classifyQuoteJurisdiction("IN", "GB")).toBe("export")
+    // Latvia is not special. KHT invoices as JYT's disclosed agent and is not
+    // VAT-registered, so an LV buyer is still an Indian export.
+    expect(classifyQuoteJurisdiction("IN", "LV")).toBe("export")
+  })
+
+  it("normalises case and whitespace on both sides", () => {
+    expect(classifyQuoteJurisdiction(" in ", "In")).toBe("domestic")
+    expect(classifyQuoteJurisdiction("in", "de")).toBe("export")
+  })
+
+  it("refuses to guess rather than assuming domestic", () => {
+    // Assuming domestic would put a confident 18% on a quote we cannot place —
+    // the same failure as a confident zero, in the other direction.
+    expect(classifyQuoteJurisdiction(null, "DE")).toBe("unknown_origin")
+    expect(classifyQuoteJurisdiction("", "DE")).toBe("unknown_origin")
+    expect(classifyQuoteJurisdiction("IND", "DE")).toBe("unknown_origin")
+    expect(classifyQuoteJurisdiction("IN", "")).toBe("unknown_origin")
+  })
+})
+
+describe("export and unknown-origin wording", () => {
+  it("names both countries and puts duty on the buyer, explicitly", () => {
+    const reason = exportDisclosureReason("in", "de")
+    expect(reason).toMatch(/export from IN to DE/)
+    expect(reason).toMatch(/zero-rated/)
+    // The half that matters: the zero is real, the omission is not.
+    expect(reason).toMatch(/duty/i)
+    expect(reason).toMatch(/payable by you/i)
+    expect(reason).toMatch(/NOT included/)
+  })
+
+  it("says the origin is unknown rather than implying no tax is due", () => {
+    const reason = unknownOriginReason("de")
+    expect(reason).toMatch(/could not establish/i)
+    expect(reason).toMatch(/DE/)
+    expect(reason).not.toMatch(/zero-rated/)
   })
 })

--- a/apps/backend/src/modules/partner-quote/__tests__/quote-tax.unit.spec.ts
+++ b/apps/backend/src/modules/partner-quote/__tests__/quote-tax.unit.spec.ts
@@ -1,0 +1,153 @@
+import { composeQuoteMoney, frozenMoney } from "../lib/build-quote-view"
+import { foldTaxLines, unknownTaxReason } from "../lib/quote-tax"
+
+/**
+ * Tax on a quote (#1439 S8).
+ *
+ * Two assertions carry this file.
+ *
+ * 1. **Inclusive vs exclusive is an 18% error in the confident direction.**
+ *    When the prices already contain the tax, adding it again overcharges the
+ *    buyer by exactly the tax; when they do not, failing to add it under-quotes
+ *    a number the buyer is budgeting against. Both directions are pinned.
+ * 2. **Unknown is never zero.** `tax_total` and `gross_total` stay null
+ *    whenever the tax could not be determined, so no caller can add a
+ *    fabricated zero into a total. A quote that says "0 tax" is making a claim.
+ */
+
+describe("foldTaxLines", () => {
+  const goods = [{ id: "var_a", amount: 1000, on: "goods" as const }]
+  const withFreight = [
+    ...goods,
+    { id: "quote-freight", amount: 200, on: "freight" as const },
+  ]
+  const gst = (id: string) => ({
+    line_item_id: id,
+    rate: 18,
+    code: "IN-GST",
+    name: "India GST",
+  })
+
+  it("adds tax on top when the prices are tax-EXCLUSIVE", () => {
+    const { total } = foldTaxLines(goods, [gst("var_a")], false)
+    expect(total).toBe(180)
+  })
+
+  it("EXTRACTS tax from the price when they are tax-INCLUSIVE", () => {
+    // 1000 gross at 18% is 152.54 of tax, not 180 — the difference is the tax
+    // on the tax, and adding 180 here would overcharge every Indian quote.
+    const { total } = foldTaxLines(goods, [gst("var_a")], true)
+    expect(total).toBeCloseTo(152.54, 2)
+  })
+
+  it("taxes the freight leg as well as the goods", () => {
+    const lines = [gst("var_a"), { ...gst("x"), line_item_id: undefined, shipping_line_id: "quote-freight" }]
+    const { total, rates } = foldTaxLines(withFreight, lines as any, false)
+    expect(total).toBe(216) // 180 on goods + 36 on freight
+    // Two entries at the SAME percentage: "18% on goods" and "18% on freight"
+    // are facts a buyer reads separately.
+    expect(rates.map((r) => r.on).sort()).toEqual(["freight", "goods"])
+  })
+
+  it("ignores a taxable item the module returned no line for", () => {
+    // A zero-rated region returns a line AT rate 0; no line at all means the
+    // item was not matched, and inventing tax for it would be worse than none.
+    const { total, rates } = foldTaxLines(withFreight, [gst("var_a")], false)
+    expect(total).toBe(180)
+    expect(rates).toHaveLength(1)
+  })
+
+  it("carries a configured ZERO rate through as a real, calculated zero", () => {
+    const { total, rates } = foldTaxLines(
+      goods,
+      [{ line_item_id: "var_a", rate: 0, code: "GB-ZERO", name: "Zero rated" }],
+      false
+    )
+    // 🔑 This zero is a fact — a region that says "0%". It is a different
+    // thing from the null a missing region produces, and only one of the two
+    // may be shown to a buyer as a number.
+    expect(total).toBe(0)
+    expect(rates[0].code).toBe("GB-ZERO")
+  })
+
+  it("names the destination when it has to say it does not know", () => {
+    expect(unknownTaxReason("gb")).toContain("GB")
+    expect(unknownTaxReason("")).toContain("this destination")
+  })
+})
+
+describe("composeQuoteMoney with tax", () => {
+  const lines = [1000]
+
+  it("leaves tax UNKNOWN when none was resolved — never zero", () => {
+    const money = composeQuoteMoney(lines, 10, 200)
+    expect(money.landed_total).toBe(1200)
+    // Both null: a caller that adds these gets NaN and notices, which is the
+    // point. A 0 would silently become "no tax due".
+    expect(money.tax_total).toBeNull()
+    expect(money.gross_total).toBeNull()
+  })
+
+  it("ADDS tax to the gross when prices are tax-exclusive", () => {
+    const money = composeQuoteMoney(lines, 10, 200, {
+      total: 216,
+      inclusive: false,
+    })
+    expect(money.landed_total).toBe(1200)
+    expect(money.gross_total).toBe(1416)
+  })
+
+  it("🔴 does NOT add tax again when prices are tax-inclusive", () => {
+    const money = composeQuoteMoney(lines, 10, 200, {
+      total: 183.05,
+      inclusive: true,
+    })
+    // The tax is already inside the 1200. Adding it would overcharge the buyer
+    // by the whole tax amount.
+    expect(money.gross_total).toBe(1200)
+    // …and it is still disclosed, because a buyer reclaiming input credit
+    // needs the figure.
+    expect(money.tax_total).toBe(183.05)
+  })
+
+  it("keeps landed_total meaning exactly what it always meant", () => {
+    // Widening it would silently change every frozen `quoted_landed_total`
+    // already on disk and every comparison drawn against one.
+    const taxed = composeQuoteMoney(lines, 10, 200, { total: 216, inclusive: false })
+    const untaxed = composeQuoteMoney(lines, 10, 200)
+    expect(taxed.landed_total).toBe(untaxed.landed_total)
+  })
+})
+
+describe("frozenMoney with tax", () => {
+  const base = {
+    quoted_subtotal: 1000,
+    quoted_freight: 200,
+    quoted_landed_total: 1200,
+    lines: [{ variant_id: "var_a", quantity: 10 }],
+  }
+
+  it("reports UNKNOWN tax for a quote minted before tax existed", () => {
+    const money = frozenMoney(base as any)
+    // Those rows genuinely have no tax figure. Defaulting to 0 would
+    // retroactively assert that an untaxed quote was tax-free.
+    expect(money?.tax_total).toBeNull()
+    expect(money?.gross_total).toBeNull()
+  })
+
+  it("reads a frozen tax figure back on its recorded basis", () => {
+    const exclusive = frozenMoney({
+      ...base,
+      quoted_tax_total: 216,
+      quoted_tax_inclusive: false,
+    } as any)
+    expect(exclusive?.gross_total).toBe(1416)
+
+    const inclusive = frozenMoney({
+      ...base,
+      quoted_tax_total: 183.05,
+      quoted_tax_inclusive: true,
+    } as any)
+    expect(inclusive?.gross_total).toBe(1200)
+  })
+})

--- a/apps/backend/src/modules/partner-quote/lib/build-quote-view.ts
+++ b/apps/backend/src/modules/partner-quote/lib/build-quote-view.ts
@@ -257,6 +257,37 @@ export function pickLineImage(identity: any): {
  * for a real basket it is the blended per-unit figure, which is why the lines
  * carry their own and this is only ever the summary row.
  */
+/**
+ * The country the partner store dispatches from, or null.
+ *
+ * Reads `stock_location.address.country_code` directly rather than going through
+ * the shipping module's origin-address helper, which returns undefined unless
+ * the address also has a street line and a pincode (Blue Dart validates that
+ * block as a unit). A country has no such dependency, and a quote must not lose
+ * its tax treatment because a warehouse is missing a postcode.
+ *
+ * Never throws — a null lands the quote on `status: "unknown"` WITH a reason,
+ * which is the honest degradation. It must not become an assumed "domestic".
+ */
+async function resolveStoreOriginCountry(
+  scope: any,
+  locationId?: string | null
+): Promise<string | null> {
+  if (!locationId) return null
+  try {
+    const query: any = scope.resolve(ContainerRegistrationKeys.QUERY)
+    const { data: locs } = await query.graph({
+      entity: "stock_location",
+      fields: ["id", "address.country_code"],
+      filters: { id: locationId },
+    })
+    const code = String((locs ?? [])[0]?.address?.country_code || "").trim()
+    return /^[A-Za-z]{2}$/.test(code) ? code.toUpperCase() : null
+  } catch {
+    return null
+  }
+}
+
 export function composeQuoteMoney(
   lineSubtotals: number[],
   totalUnits: number,
@@ -524,8 +555,18 @@ export async function buildQuoteView(
       // freight leg — both of which only exist at this point. It never
       // throws; an unresolvable rate lands on `status: "unknown"` with a
       // reason rather than on a zero.
+      // Where the goods dispatch from. Read off the same stock location the
+      // freight leg was quoted against, so the tax treatment and the shipment
+      // cannot describe two different journeys. S6 makes this location blocking
+      // at mint, so by the time tax runs there is always one to read.
+      const originCountry = await resolveStoreOriginCountry(
+        scope,
+        input.store?.default_location_id
+      )
+
       tax = await resolveQuoteTax(scope, {
         region_id: input.region_id ?? null,
+        origin_country_code: originCountry,
         destination_country_code: input.destination_country_code,
         destination_postal_code: input.destination_postal_code ?? null,
         lines: effectiveLines.map((l) => ({

--- a/apps/backend/src/modules/partner-quote/lib/build-quote-view.ts
+++ b/apps/backend/src/modules/partner-quote/lib/build-quote-view.ts
@@ -15,6 +15,7 @@ import {
   type QuoteMoney,
 } from "./compare"
 import { resolveQuoteProducer, type QuoteProducer } from "./quote-producer"
+import { resolveQuoteTax, type QuoteTax } from "./quote-tax"
 import { resolveQuoteSpecs, type QuoteLineSpec } from "./quote-spec"
 import { daysUntilExpiry, quoteUnusableReason } from "./token"
 
@@ -82,6 +83,9 @@ export type QuoteViewQuote = {
   quoted_freight?: number | null
   quoted_landed_total?: number | null
   quoted_weight_grams?: number | null
+  /** #1439 S8. Null on every quote minted before tax existed. */
+  quoted_tax_total?: number | null
+  quoted_tax_inclusive?: boolean | null
   quoted_at?: Date | string | null
   recipient_name?: string | null
   recipient_company?: string | null
@@ -171,6 +175,12 @@ export type QuoteView = {
     options: ShippingEstimateOption[]
     error: string | null
   }
+  /**
+   * Tax on this quote (#1439 S8), and — when there is no number — the reason,
+   * which the page RENDERS. A missing tax block reads as "no tax due", so
+   * silence is not an option here the way it is for the producer band.
+   */
+  tax: QuoteTax
   compare: QuoteCompareResult
   recipient: {
     name: string | null
@@ -250,14 +260,36 @@ export function pickLineImage(identity: any): {
 export function composeQuoteMoney(
   lineSubtotals: number[],
   totalUnits: number,
-  freight: number
+  freight: number,
+  /**
+   * #1439 S8. Omitted ⇒ tax is UNKNOWN, not zero: `tax_total` and
+   * `gross_total` both stay null, and the caller is expected to say why.
+   */
+  tax?: { total: number | null; inclusive: boolean } | null
 ): QuoteMoney {
   const subtotal = lineSubtotals.reduce((sum, n) => sum + n, 0)
+  const landed = subtotal + freight
+
+  const taxTotal =
+    tax && tax.total !== null && tax.total !== undefined
+      ? Number(tax.total)
+      : null
+
   return {
     unit_amount: totalUnits > 0 ? subtotal / totalUnits : 0,
     subtotal,
     freight,
-    landed_total: subtotal + freight,
+    landed_total: landed,
+    tax_total: taxTotal,
+    /**
+     * 🔴 When the prices are tax-INCLUSIVE the tax is already inside
+     * `landed_total`, so adding it again would overcharge the buyer by the
+     * tax. `tax_total` is then the extracted portion — a disclosure, not an
+     * addition. Getting this backwards is an 18% error in the confident
+     * direction on every Indian quote.
+     */
+    gross_total:
+      taxTotal === null ? null : tax?.inclusive ? landed : landed + taxTotal,
   }
 }
 
@@ -275,11 +307,29 @@ export function frozenMoney(quote?: QuoteViewQuote | null): QuoteMoney | null {
     0
   )
   const subtotal = Number(quote.quoted_subtotal ?? 0)
+  const taxTotal =
+    quote.quoted_tax_total === null || quote.quoted_tax_total === undefined
+      ? null
+      : Number(quote.quoted_tax_total)
+  const landed = Number(quote.quoted_landed_total)
+
   return {
     unit_amount: totalUnits > 0 ? subtotal / totalUnits : 0,
     subtotal,
     freight: Number(quote.quoted_freight ?? 0),
-    landed_total: Number(quote.quoted_landed_total),
+    landed_total: landed,
+    /**
+     * Null on every quote minted before S8, and that is the honest answer for
+     * them: those rows genuinely have no tax figure. Defaulting to 0 would
+     * retroactively assert that an untaxed quote was tax-free.
+     */
+    tax_total: taxTotal,
+    gross_total:
+      taxTotal === null
+        ? null
+        : quote.quoted_tax_inclusive
+          ? landed
+          : landed + taxTotal,
   }
 }
 
@@ -381,6 +431,17 @@ export async function buildQuoteView(
   let chosen: ShippingEstimateOption | null = null
   let options: ShippingEstimateOption[] = []
   let freightError: string | null = null
+  /**
+   * Unknown until proven otherwise, and unknown is what a dead or unpriceable
+   * link keeps: there is no basket to tax, and a 0 would read as "no tax due".
+   */
+  let tax: QuoteTax = {
+    status: "unknown",
+    total: null,
+    inclusive: false,
+    rates: [],
+    reason: null,
+  }
   let liveUnitByVariant = new Map<string, number>()
   let weightByVariant = new Map<
     string,
@@ -459,12 +520,30 @@ export async function buildQuoteView(
         )
       }
 
+      // Tax LAST, because it is a function of the priced lines and the chosen
+      // freight leg — both of which only exist at this point. It never
+      // throws; an unresolvable rate lands on `status: "unknown"` with a
+      // reason rather than on a zero.
+      tax = await resolveQuoteTax(scope, {
+        region_id: input.region_id ?? null,
+        destination_country_code: input.destination_country_code,
+        destination_postal_code: input.destination_postal_code ?? null,
+        lines: effectiveLines.map((l) => ({
+          variant_id: l.variant_id,
+          product_id: identityById.get(l.variant_id)?.product?.id ?? null,
+          unit_amount: liveUnitByVariant.get(l.variant_id) ?? 0,
+          quantity: l.quantity,
+        })),
+        freight: { amount: Number(chosen.amount), option_id: (chosen as any)?.id ?? null },
+      })
+
       live = composeQuoteMoney(
         effectiveLines.map(
           (l) => (liveUnitByVariant.get(l.variant_id) ?? 0) * l.quantity
         ),
         effectiveLines.reduce((sum, l) => sum + l.quantity, 0),
-        Number(chosen.amount)
+        Number(chosen.amount),
+        tax
       )
     } catch (err) {
       // The quoted half — what the partner actually told this buyer — is still
@@ -554,6 +633,7 @@ export async function buildQuoteView(
     total_weight_grams:
       totalWeightGrams ?? input.quote?.quoted_weight_grams ?? null,
     freight: { chosen, options, error: freightError },
+    tax,
     compare,
     recipient: {
       name: input.quote?.recipient_name ?? null,

--- a/apps/backend/src/modules/partner-quote/lib/compare.ts
+++ b/apps/backend/src/modules/partner-quote/lib/compare.ts
@@ -22,7 +22,29 @@ export type QuoteMoney = {
   unit_amount: number
   subtotal: number
   freight: number
+  /**
+   * Goods plus freight, BEFORE tax when the prices are tax-exclusive.
+   *
+   * ⚠️ Kept meaning exactly what it always meant. Widening it to include tax
+   * would silently change every frozen `quoted_landed_total` already on disk
+   * and every comparison drawn against one, so the taxed figure is a new field
+   * instead — see `gross_total`.
+   */
   landed_total: number
+  /**
+   * Tax on goods and freight (#1439 S8). Null when it could not be
+   * determined, and NEVER 0 as a stand-in for that: zero is a claim. The
+   * quote's `tax.reason` says why, and the page renders it.
+   */
+  tax_total: number | null
+  /**
+   * What the buyer actually pays. Equal to `landed_total` when the prices are
+   * tax-inclusive (the tax is already inside them and `tax_total` is the
+   * extracted portion), and `landed_total + tax_total` when they are not.
+   * Null whenever tax is unknown — a gross total we cannot stand behind is
+   * worse than none.
+   */
+  gross_total: number | null
 }
 
 export type QuoteCompareInput = {

--- a/apps/backend/src/modules/partner-quote/lib/quote-tax.ts
+++ b/apps/backend/src/modules/partner-quote/lib/quote-tax.ts
@@ -50,12 +50,17 @@ export type QuoteTaxRate = {
 export type QuoteTax = {
   /**
    * - `calculated`: `total` is real.
+   * - `zero_rated_export`: the goods leave the seller's jurisdiction, so the
+   *   seller charges no tax. `total` is a REAL 0, not a missing number — but
+   *   duty and import tax fall on the buyer at their border and are not in it,
+   *   which is why `reason` is still populated and still has to be rendered.
    * - `not_applicable`: the region does not calculate tax automatically, so
    *   neither does the cart. Nothing is owed HERE, which is different from
    *   nothing being owed at all.
-   * - `unknown`: no rate is configured for this destination. Say so.
+   * - `unknown`: no rate is configured, or the origin could not be established.
+   *   Say so.
    */
-  status: "calculated" | "not_applicable" | "unknown"
+  status: "calculated" | "zero_rated_export" | "not_applicable" | "unknown"
   /** Null unless `calculated`. Never 0 as a stand-in for "we do not know". */
   total: number | null
   /**
@@ -70,6 +75,15 @@ export type QuoteTax = {
 
 export type QuoteTaxInput = {
   region_id?: string | null
+  /**
+   * Where the goods DISPATCH from — the partner store's default stock location
+   * country. Required to decide domestic vs export; without it the answer is
+   * `unknown`, never a destination-rate guess.
+   *
+   * S6's readiness gate makes `store.default_location_id` blocking, so a quote
+   * that got as far as tax always has one.
+   */
+  origin_country_code?: string | null
   destination_country_code: string
   destination_postal_code?: string | null
   destination_province_code?: string | null
@@ -159,6 +173,75 @@ export function foldTaxLines(
   return { total: Math.round(total * 100) / 100, rates }
 }
 
+/**
+ * PURE: domestic supply, cross-border export, or not enough information.
+ *
+ * ## Why the seller's jurisdiction decides this and the buyer's does not
+ *
+ * The first cut of this file asked the Tax module using the DESTINATION country
+ * alone, which quietly assumed the seller is registered wherever the buyer
+ * happens to be. On this platform the goods always dispatch from India, so a
+ * German buyer was being shown 19% German VAT on an Indian export invoice — a
+ * fifth added to the headline number, on every EU quote. It over-quoted rather
+ * than under-quoted, so it lost deals instead of money, but it was never right.
+ *
+ * The structure it has to model: JYT (India) is the supplier and the shipper.
+ * Kind Health Tech SIA invoices and collects on JYT's behalf for non-Indian
+ * buyers, which makes it a disclosed agent, not a second seller — the supply is
+ * still JYT's, still dispatched from India. KHT is also not VAT-registered
+ * (below the Latvian threshold), so no EU VAT arises through it either. An
+ * export is therefore zero-rated at origin whatever route the invoice takes.
+ *
+ * `unknown_origin` is deliberately NOT "assume domestic". Assuming would put a
+ * confident 18% on a quote we cannot place, which is the same failure as the
+ * confident zero this module was written to stop — only in the other direction.
+ */
+export function classifyQuoteJurisdiction(
+  originCountryCode?: string | null,
+  destinationCountryCode?: string | null
+): "domestic" | "export" | "unknown_origin" {
+  const origin = String(originCountryCode || "").trim().toUpperCase()
+  const destination = String(destinationCountryCode || "").trim().toUpperCase()
+  if (!/^[A-Z]{2}$/.test(origin) || !/^[A-Z]{2}$/.test(destination)) {
+    return "unknown_origin"
+  }
+  return origin === destination ? "domestic" : "export"
+}
+
+/**
+ * PURE: the wording on a zero-rated export.
+ *
+ * 🔴 The zero here is real and the sentence after it is the important half. The
+ * buyer is importer of record: their customs authority will charge import VAT
+ * and duty before the goods are released, neither of which is in this total.
+ * Import VAT a business reclaims; duty it does not. A procurement contact who
+ * budgets against a number labelled "landed" and then meets a customs bill has
+ * been misled by us, which is #1430's shape exactly — a confident figure that
+ * omits a real charge.
+ */
+export function exportDisclosureReason(
+  originCountryCode: string,
+  destinationCountryCode: string
+): string {
+  const from = String(originCountryCode || "").toUpperCase()
+  const to = String(destinationCountryCode || "").toUpperCase()
+  return (
+    `This is an export from ${from} to ${to}, so it is zero-rated and no ` +
+    `seller tax is charged. Import duty and import VAT/GST are payable by you ` +
+    `to ${to} customs on arrival and are NOT included in this total.`
+  )
+}
+
+/** PURE: the wording when the goods' origin cannot be established. */
+export function unknownOriginReason(destinationCountryCode: string): string {
+  const to = String(destinationCountryCode || "").toUpperCase()
+  return (
+    `We could not establish which country these goods ship from, so the tax ` +
+    `treatment for ${to || "this destination"} cannot be determined. This ` +
+    `total excludes tax, duty and import charges.`
+  )
+}
+
 /** PURE: the wording a buyer sees when there is no number to show them. */
 export function unknownTaxReason(countryCode: string): string {
   const cc = String(countryCode || "").toUpperCase()
@@ -195,6 +278,41 @@ export async function resolveQuoteTax(
   }
 
   if (!country) return base
+
+  // ---- Whose tax is it, before asking how much ---------------------------
+  // Jurisdiction first, because the Tax module cannot answer this: it maps an
+  // address to a configured rate and has no opinion about who is selling. Ask
+  // it about a German address and it will happily hand back 19%, which is the
+  // right rate for a German seller and the wrong one for an Indian exporter.
+  const jurisdiction = classifyQuoteJurisdiction(
+    input.origin_country_code,
+    country
+  )
+
+  if (jurisdiction === "unknown_origin") {
+    return {
+      status: "unknown",
+      total: null,
+      inclusive: false,
+      rates: [],
+      reason: unknownOriginReason(country),
+    }
+  }
+
+  if (jurisdiction === "export") {
+    return {
+      // A real zero, not a missing number — and `reason` still has to render,
+      // because duty and import VAT land on the buyer and are not in it.
+      status: "zero_rated_export",
+      total: 0,
+      inclusive: false,
+      rates: [],
+      reason: exportDisclosureReason(
+        String(input.origin_country_code || ""),
+        country
+      ),
+    }
+  }
 
   try {
     const query: any = scope.resolve(ContainerRegistrationKeys.QUERY)

--- a/apps/backend/src/modules/partner-quote/lib/quote-tax.ts
+++ b/apps/backend/src/modules/partner-quote/lib/quote-tax.ts
@@ -1,0 +1,307 @@
+import {
+  calculateAmountsWithTax,
+  ContainerRegistrationKeys,
+  Modules,
+} from "@medusajs/framework/utils"
+
+/**
+ * Tax on a quote (#1439 S8).
+ *
+ * ## What was wrong
+ *
+ * `composeQuoteMoney` was literally `subtotal + freight`, and grep for "tax"
+ * across the whole quote path returned nothing. "Landed" here meant goods plus
+ * freight — no GST, no VAT, no duty. A B2B buyer shown a "landed cost" with no
+ * tax in it is being shown a number they cannot budget against.
+ *
+ * ## Why this calls the Tax module rather than doing arithmetic
+ *
+ * A cart gets `tax_lines` for free once it has a shipping address. A quote has
+ * no cart and no address — only a destination country and postal code, and
+ * deliberately so: asking a procurement contact for address line 1 before they
+ * have a price is the wall this feature exists to remove. So the context is
+ * synthesized and handed to the same module a cart would use.
+ *
+ * 🔑 That is not a convenience, it is the requirement. S11 turns an accepted
+ * quote into a cart, and the cart will ask the Tax module with the real
+ * address. If this file computed its own percentages, the quote and the cart
+ * would disagree the first time a rate had a rule on it. For the same reason
+ * the totals go through core's own `calculateTaxTotal` — matching its rounding
+ * is the only way two numbers stay equal.
+ *
+ * ## Never a confident zero
+ *
+ * A destination with no configured tax region returns `status: "unknown"` and
+ * a `reason` the page is expected to RENDER. Zero is a claim; "we do not know"
+ * is the truth, and the difference is exactly how #1430 shipped bulk orders
+ * with free freight. `total` stays null in every non-calculated state so a
+ * caller cannot accidentally add it to anything.
+ */
+
+export type QuoteTaxRate = {
+  code: string | null
+  name: string
+  /** Percentage, as the Tax module reports it (18 means 18%). */
+  rate: number
+  /** Which leg it applied to — a buyer asks about freight tax separately. */
+  on: "goods" | "freight"
+}
+
+export type QuoteTax = {
+  /**
+   * - `calculated`: `total` is real.
+   * - `not_applicable`: the region does not calculate tax automatically, so
+   *   neither does the cart. Nothing is owed HERE, which is different from
+   *   nothing being owed at all.
+   * - `unknown`: no rate is configured for this destination. Say so.
+   */
+  status: "calculated" | "not_applicable" | "unknown"
+  /** Null unless `calculated`. Never 0 as a stand-in for "we do not know". */
+  total: number | null
+  /**
+   * True when the quoted prices ALREADY contain the tax — in which case
+   * `total` is extracted from the subtotal rather than added to it.
+   */
+  inclusive: boolean
+  rates: QuoteTaxRate[]
+  /** Rendered verbatim by the page whenever status is not `calculated`. */
+  reason: string | null
+}
+
+export type QuoteTaxInput = {
+  region_id?: string | null
+  destination_country_code: string
+  destination_postal_code?: string | null
+  destination_province_code?: string | null
+  lines: Array<{
+    variant_id: string
+    product_id?: string | null
+    unit_amount: number
+    quantity: number
+  }>
+  /** The one freight leg, already chosen. Null when none could be quoted. */
+  freight?: { amount: number; option_id?: string | null } | null
+}
+
+/** The shape `getTaxLines` answers with, narrowed to what is used here. */
+type RawTaxLine = {
+  rate?: number
+  code?: string | null
+  name?: string
+  line_item_id?: string
+  shipping_line_id?: string
+}
+
+/**
+ * PURE: fold the module's per-line rates into one total and a rate summary.
+ *
+ * Amounts come from core's `calculateAmountsWithTax`, not from
+ * `amount * rate / 100`, so the rounding is the rounding the cart will use.
+ *
+ * 🔴 NOT `calculateTaxTotal` — read its source before reaching for it. Passed
+ * `isTaxInclusive: true` it returns **0** and does no work: in core, an
+ * inclusive item's tax is extracted by `calculateAmountsWithTax`, which divides
+ * the gross by (1 + rate) to recover the taxable base first. Trusting the
+ * name would have reported ZERO TAX on every tax-inclusive quote — silently,
+ * and in the confident direction. A unit test caught it; nothing else would
+ * have.
+ */
+export function foldTaxLines(
+  taxable: Array<{
+    id: string
+    amount: number
+    on: "goods" | "freight"
+  }>,
+  lines: RawTaxLine[],
+  isTaxInclusive: boolean
+): { total: number; rates: QuoteTaxRate[] } {
+  const byId = new Map<string, RawTaxLine[]>()
+  for (const l of lines || []) {
+    const key = l.line_item_id ?? l.shipping_line_id ?? ""
+    if (!key) continue
+    byId.set(key, [...(byId.get(key) ?? []), l])
+  }
+
+  let total = 0
+  const rates: QuoteTaxRate[] = []
+  const seen = new Set<string>()
+
+  for (const item of taxable) {
+    const applicable = byId.get(item.id) ?? []
+    if (!applicable.length) continue
+
+    const { priceWithTax, priceWithoutTax } = calculateAmountsWithTax({
+      taxLines: applicable.map((l) => ({ rate: Number(l.rate ?? 0) })),
+      amount: item.amount,
+      includesTax: isTaxInclusive,
+    })
+    // The difference, either way round: added on top when exclusive, carved
+    // out of the price when inclusive.
+    total += Number(priceWithTax) - Number(priceWithoutTax)
+
+    for (const l of applicable) {
+      // One entry per distinct rate PER LEG: "18% GST on goods" and "18% GST
+      // on freight" are two facts a buyer reads separately, even at the same
+      // percentage.
+      const key = `${item.on}:${l.code ?? ""}:${l.rate ?? 0}`
+      if (seen.has(key)) continue
+      seen.add(key)
+      rates.push({
+        code: l.code ?? null,
+        name: l.name ?? "Tax",
+        rate: Number(l.rate ?? 0),
+        on: item.on,
+      })
+    }
+  }
+
+  // Money, to two places — the same shape every other amount here carries.
+  return { total: Math.round(total * 100) / 100, rates }
+}
+
+/** PURE: the wording a buyer sees when there is no number to show them. */
+export function unknownTaxReason(countryCode: string): string {
+  const cc = String(countryCode || "").toUpperCase()
+  return (
+    `No tax rate is configured for ${cc || "this destination"}, so this total ` +
+    `excludes tax. Any duty or import tax due on arrival is not included.`
+  )
+}
+
+const NOT_APPLICABLE_REASON =
+  "This destination's region does not apply tax automatically, so no tax is " +
+  "included. Any duty or import tax due on arrival is not included."
+
+/**
+ * Resolve the tax on a quote.
+ *
+ * Never throws. Tax is one block on a page that is mostly about a price, and a
+ * misconfigured region must not 500 a buyer's quote — but unlike the producer
+ * band, silence is NOT an acceptable degradation here, because a missing tax
+ * block reads as "no tax". Every failure lands on `unknown` WITH a reason.
+ */
+export async function resolveQuoteTax(
+  scope: any,
+  input: QuoteTaxInput
+): Promise<QuoteTax> {
+  const country = String(input.destination_country_code || "").toLowerCase()
+
+  const base: QuoteTax = {
+    status: "unknown",
+    total: null,
+    inclusive: false,
+    rates: [],
+    reason: unknownTaxReason(country),
+  }
+
+  if (!country) return base
+
+  try {
+    const query: any = scope.resolve(ContainerRegistrationKeys.QUERY)
+
+    // ---- The region decides the BASIS, not the rate ----------------------
+    // `automatic_taxes` and `is_tax_inclusive` are per-region and
+    // partner-settable, so they are read rather than assumed. A quote with no
+    // region falls back to tax-exclusive, which is Medusa's own default and
+    // the safer direction: it shows the tax as an addition rather than
+    // quietly claiming it was already in the price.
+    let isTaxInclusive = false
+    if (input.region_id) {
+      const { data: regions } = await query.graph({
+        entity: "region",
+        fields: ["id", "automatic_taxes", "is_tax_inclusive"],
+        filters: { id: input.region_id },
+      })
+      const region = ((regions ?? []) as any[])[0]
+      if (region && region.automatic_taxes === false) {
+        // The cart will not tax this either. Saying "unknown" would be wrong —
+        // this is a decision, not a gap.
+        return {
+          status: "not_applicable",
+          total: null,
+          inclusive: false,
+          rates: [],
+          reason: NOT_APPLICABLE_REASON,
+        }
+      }
+      isTaxInclusive = Boolean(region?.is_tax_inclusive)
+    }
+
+    // ---- Ask the same module the cart will ------------------------------
+    const taxService: any = scope.resolve(Modules.TAX)
+
+    const goods = (input.lines || [])
+      .filter((l) => Number.isFinite(Number(l.unit_amount)))
+      .map((l) => ({
+        id: l.variant_id,
+        amount: Number(l.unit_amount) * Number(l.quantity),
+        on: "goods" as const,
+      }))
+
+    const freightAmount = Number(input.freight?.amount ?? NaN)
+    const hasFreight = Number.isFinite(freightAmount) && freightAmount > 0
+    const FREIGHT_ID = "quote-freight"
+
+    if (!goods.length && !hasFreight) return base
+
+    const items = (input.lines || []).map((l) => ({
+      id: l.variant_id,
+      product_id: l.product_id ?? l.variant_id,
+      unit_price: Number(l.unit_amount),
+      quantity: Number(l.quantity),
+    }))
+    const shipping = hasFreight
+      ? [
+          {
+            id: FREIGHT_ID,
+            // The freight leg is a `ShippingEstimateOption` amount, not a cart
+            // shipping method, so there is no shipping-option row to point at
+            // when the estimate came from a carrier rate. The tax module only
+            // needs it to match option-scoped RULES; without one it falls
+            // through to the region's default rate, which is the right answer
+            // for an estimate.
+            shipping_option_id: input.freight?.option_id ?? "",
+            unit_price: freightAmount,
+          },
+        ]
+      : []
+
+    const taxLines: RawTaxLine[] = await taxService.getTaxLines(
+      [...items, ...shipping],
+      {
+        address: {
+          country_code: country,
+          province_code: input.destination_province_code ?? null,
+          postal_code: input.destination_postal_code ?? undefined,
+        },
+      }
+    )
+
+    if (!taxLines?.length) {
+      // A configured region with a zero rate DOES return a line at rate 0, so
+      // an empty answer means no region matched — a gap, not a zero.
+      return { ...base, inclusive: isTaxInclusive }
+    }
+
+    const taxable = [
+      ...goods,
+      ...(hasFreight
+        ? [{ id: FREIGHT_ID, amount: freightAmount, on: "freight" as const }]
+        : []),
+    ]
+
+    const { total, rates } = foldTaxLines(taxable, taxLines, isTaxInclusive)
+
+    return {
+      status: "calculated",
+      total,
+      inclusive: isTaxInclusive,
+      rates,
+      reason: null,
+    }
+  } catch {
+    // 🔑 Not silence. A tax block that vanishes reads as "no tax due", which is
+    // a claim; the buyer is told the number is missing instead.
+    return base
+  }
+}

--- a/apps/storefront/src/lib/data/quotes.ts
+++ b/apps/storefront/src/lib/data/quotes.ts
@@ -21,7 +21,37 @@ export type QuoteMoney = {
   unit_amount: number
   subtotal: number
   freight: number
+  /** Goods + freight. NOT a customs-landed cost — see `QuoteTax`. */
   landed_total: number
+  /** #1439 S8. Null means unknown, never zero. */
+  tax_total: number | null
+  /**
+   * `landed_total` + tax when the prices are tax-exclusive; equal to
+   * `landed_total` when they are inclusive (the tax is already inside it).
+   * Null whenever `tax_total` is.
+   */
+  gross_total: number | null
+}
+
+/**
+ * How tax was resolved for this quote (#1439 S8).
+ *
+ * 🔴 `reason` is rendered verbatim whenever `status` is not `calculated`. A tax
+ * block that silently disappears reads as "no tax due", which is a claim; on a
+ * `zero_rated_export` the zero is real but duty and import VAT still fall on the
+ * buyer at their border, and that sentence is the only place they are told.
+ */
+export type QuoteTax = {
+  status: "calculated" | "zero_rated_export" | "not_applicable" | "unknown"
+  total: number | null
+  inclusive: boolean
+  rates: Array<{
+    code: string | null
+    name: string
+    rate: number
+    on: "goods" | "freight"
+  }>
+  reason: string | null
 }
 
 /** One labelled fact about how the piece is made. #1428 */
@@ -125,6 +155,7 @@ export type QuoteView = {
   destination_postal_code: string | null
   live: QuoteMoney | null
   quoted: QuoteMoney | null
+  tax: QuoteTax
   total_weight_grams: number | null
   freight: {
     chosen: QuoteFreightOption | null

--- a/apps/storefront/src/modules/quotes/components/quote-summary/index.tsx
+++ b/apps/storefront/src/modules/quotes/components/quote-summary/index.tsx
@@ -1,14 +1,22 @@
 import { Heading, Text } from "@medusajs/ui"
 
 import { convertToLocale } from "@lib/util/money"
-import type { QuoteMoney, QuoteView } from "@lib/data/quotes"
+import type { QuoteMoney, QuoteTax, QuoteView } from "@lib/data/quotes"
 
 /**
- * The landed-cost summary — the number this whole feature exists to show.
+ * The cost summary — the number this whole feature exists to show.
  *
- * 🔑 "Landed" is the point: subtotal + freight, quoted as ONE consignment. A
- * buyer comparing suppliers is comparing what they actually pay, which is why
- * freight is a line here and not a footnote.
+ * 🔑 Subtotal + freight, quoted as ONE consignment. A buyer comparing suppliers
+ * is comparing what they actually pay, which is why freight is a line here and
+ * not a footnote.
+ *
+ * 🔴 It stopped being called "landed cost" on an export. Goods dispatch from
+ * India; on a cross-border sale the buyer is importer of record and pays import
+ * VAT and customs duty at their own border, neither of which is in this total.
+ * A procurement contact who budgets against something labelled "landed" and then
+ * meets a customs bill has been misled by us — the #1430 shape, a confident
+ * figure that omits a real charge. So the heading says "Quoted total" and
+ * `tax.reason` is rendered, not swallowed.
  */
 const Row = ({
   label,
@@ -44,15 +52,48 @@ const Row = ({
   </div>
 )
 
+/** The tax rows, or nothing when there is no number and no reason to give. */
+const TaxRows = ({
+  money,
+  tax,
+  currency_code,
+}: {
+  money: QuoteMoney
+  tax: QuoteTax
+  currency_code: string
+}) => {
+  if (money.tax_total === null || money.gross_total === null) {
+    return null
+  }
+  const label = tax.rates.length
+    ? Array.from(new Set(tax.rates.map((r) => r.name))).join(" + ")
+    : "Tax"
+  return (
+    <>
+      <Row
+        label={tax.inclusive ? `${label} (included)` : label}
+        value={convertToLocale({ amount: money.tax_total, currency_code })}
+      />
+      <Row
+        label="Total"
+        value={convertToLocale({ amount: money.gross_total, currency_code })}
+        strong
+      />
+    </>
+  )
+}
+
 const Column = ({
   title,
   money,
+  tax,
   currency_code,
   freightNote,
   emphasis,
 }: {
   title: string
   money: QuoteMoney
+  tax: QuoteTax
   currency_code: string
   freightNote?: string
   emphasis?: boolean
@@ -78,16 +119,23 @@ const Column = ({
         sub={freightNote}
       />
       <Row
-        label="Landed total"
+        // "Goods + freight" rather than "Landed": on an export it is neither
+        // landed nor final, and the same words have to be true in both cases.
+        label="Goods + freight"
         value={convertToLocale({ amount: money.landed_total, currency_code })}
-        strong
+        strong={money.gross_total === null}
       />
+      <TaxRows money={money} tax={tax} currency_code={currency_code} />
     </div>
   </div>
 )
 
 const QuoteSummary = ({ quote }: { quote: QuoteView }) => {
-  const { compare, freight, currency_code } = quote
+  const { compare, freight, currency_code, tax } = quote
+
+  // "Landed cost" is only honest when nothing further is charged on arrival.
+  const heading =
+    tax.status === "calculated" ? "Landed cost" : "Quoted total"
 
   const freightNote = freight.chosen
     ? [
@@ -103,7 +151,7 @@ const QuoteSummary = ({ quote }: { quote: QuoteView }) => {
   return (
     <div className="flex flex-col gap-y-4">
       <Heading level="h2" className="text-xl-semi text-ui-fg-base">
-        Landed cost
+        {heading}
       </Heading>
 
       <div
@@ -117,6 +165,7 @@ const QuoteSummary = ({ quote }: { quote: QuoteView }) => {
           <Column
             title="Quoted for you"
             money={quote.quoted}
+            tax={tax}
             currency_code={currency_code}
             freightNote={freightNote}
             emphasis
@@ -126,11 +175,26 @@ const QuoteSummary = ({ quote }: { quote: QuoteView }) => {
           <Column
             title="Current price"
             money={quote.live}
+            tax={tax}
             currency_code={currency_code}
             freightNote={freightNote}
           />
         ) : null}
       </div>
+
+      {/* 🔴 The tax disclosure. Rendered whenever the status is not
+          `calculated`, INCLUDING `zero_rated_export` where the zero is real —
+          because on an export the sentence about duty is the only warning the
+          buyer gets that a customs bill is coming. Dropping it would leave a
+          total that looks complete and is not. */}
+      {tax.status !== "calculated" && tax.reason ? (
+        <Text
+          className="txt-small text-ui-fg-subtle rounded-lg border border-ui-border-base bg-ui-bg-subtle p-3"
+          data-testid="quote-tax-notice"
+        >
+          {tax.reason}
+        </Text>
+      ) : null}
 
       {/* Freight is an ESTIMATE and says so. Carrier rates move, and the manual
           tier is a placeholder the partner is expected to edit — presenting it


### PR DESCRIPTION
Part of #1439 (S8), closes half of #1447. **Stacked on #1475** — base is `feat/quote-line-override`.

## Why

`composeQuoteMoney` was literally `subtotal + freight`, and grep for "tax" across the whole quote path returned nothing. "Landed" meant goods plus freight — no GST, no VAT, no duty. A B2B buyer shown a "landed cost" with no tax in it is being shown a number they cannot budget against.

## Calls the Tax module rather than doing arithmetic

A cart gets `tax_lines` for free once it has a shipping address. A quote has no cart and no address — only a destination country and postal code, deliberately, because asking a procurement contact for address line 1 before they have a price is the wall this feature exists to remove. So the context is synthesized and handed to the same module a cart would use.

That is the requirement, not a convenience: S11 turns an accepted quote into a cart, and the cart will ask the Tax module with the real address. A file computing its own percentages would disagree the first time a rate carried a rule.

## 🔴 `calculateTaxTotal` returns 0 for the inclusive case — by design

Read its source before reaching for it. Passed `isTaxInclusive: true` it returns zero and does no work: in core, an inclusive item's tax is extracted by `calculateAmountsWithTax`, which divides the gross by (1 + rate) to recover the taxable base first.

Trusting the name reported **zero tax on every tax-inclusive quote** — silently, in the confident direction. A unit test caught it; tsc could not, and no integration test would have flagged a plausible-looking zero.

The same distinction drives `gross_total`: when prices are tax-inclusive the tax is already inside `landed_total`, so adding it again overcharges the buyer by the whole tax. Both directions are pinned.

## Never a confident zero

A destination with no configured tax region returns `status: "unknown"` with a `reason` the page renders. `tax_total` and `gross_total` stay **null** in every non-calculated state, so a caller that adds them gets NaN and notices rather than silently publishing "no tax due". A region configured *at* 0% is different — that returns a real, calculated zero, and only one of the two may be shown to a buyer as a number.

`landed_total` keeps meaning exactly what it always meant. Widening it would silently change every frozen `quoted_landed_total` already on disk and every comparison drawn against one, so the taxed figure is a new field.

## Remaining for this slice

Freezing the tax figure on the quote row at mint (needs a migration), and rendering net / tax / gross on the buyer summary in both storefronts. The exports/LUT question in #1447 is deliberately untouched: an export of goods is zero-rated either way and the LUT decides only how the *exporter* discharges it, not what the buyer is shown — that needs a founder decision before it becomes code.

12 unit tests.

🤖 Generated with [Claude Code](https://claude.com/claude-code)