### PR TITLE
docs(shiprocket): the collection is wrong in four places, and misses DDP entirely

### DIFF
--- a/apps/docs/notes/SHIPROCKET_INTERNATIONAL_API.md
+++ b/apps/docs/notes/SHIPROCKET_INTERNATIONAL_API.md
@@ -102,6 +102,20 @@ Aramex International | ddp_tag=false  ddp_vcn=false  ddp_inclusive_vcn=false
                      | is_active=false
 ```
 
+**Accepting the DDP agreement in the dashboard changed none of this.** Re-rated
+immediately afterwards: `ddp_tag`, `ddp_vcn`, `ddp_inclusive_vcn`,
+`csb5_seller_kyc` and `is_active` all still `false`. And it is not
+destination-specific — the same flags come back `false` on NL, DE, FR, GB, CA,
+AU and AE alike, so whatever gates DDP is account-level, not a per-lane or
+per-region entitlement. (The US lane answers *"No serviceable couriers available
+for given weight"* at both 0.5 kg and 2 kg — that lane appears to be off
+entirely rather than weight-capped. DE and FR return two Aramex variants;
+everywhere else returns one.)
+
+🔑 So the panel's DDP toggle is **not** the switch. On the evidence,
+`csb5_seller_kyc: false` is the gate — it is the one flag that is false
+everywhere and that plausibly blocks a commercial-export route.
+
 Two blockers, both account-side rather than code:
 
 - **`csb5_seller_kyc: false`** while CSB-4's is true. CSB-5 is the commercial

--- a/apps/docs/notes/SHIPROCKET_INTERNATIONAL_API.md
+++ b/apps/docs/notes/SHIPROCKET_INTERNATIONAL_API.md
@@ -6,6 +6,18 @@ earlier web-research inference that "international reuses the domestic endpoint 
 HSN" — **it does not**. There is a full separate `/v1/external/international/*`
 namespace.
 
+> 🔴 **Re-verified against the LIVE API 2026-08-22, and the collection is not
+> trustworthy on its own.** Four things it gets wrong or omits: `ioss`/`eori`
+> exist and are marked required but are not; `pickup_postcode` is marked optional
+> and is not; `Terms_Of_Invoice` is marked required here and optional there; and
+> the entire DDP / duty / IOSS-fee block on the serviceability response is
+> **absent from the collection altogether**. Treat this file as the contract and
+> the collection as a hint — and probe before believing either.
+>
+> Collection JSON, for a future re-read (the docs site is JS-rendered and
+> WebFetch only gets the shell):
+> `https://www.postman.com/_api/collection/8407119-f5af337c-69fc-49c7-8418-e2f6ee461674?populate=true`
+
 Base URL is unchanged: `https://apiv2.shiprocket.in/v1/external`.
 
 ## Endpoints (international namespace)
@@ -34,7 +46,9 @@ not ISO) and these extra top-level fields:
 |---|---|---|---|---|
 | `currency` | **YES** | string | `INR,USD,GBP,EUR,AUD,CAD,SAR,AED,SGD`. **Amounts (`selling_price`, `sub_total`) are in THIS currency** — not forced to INR. | order currency |
 | `reasonOfExport` | **YES** | int | `0`=BONAFIDE_SAMPLE, `1`=SAMPLE, `2`=GIFT, `3`=COMMERCIAL | `3` (commercial sale) |
-| `Terms_Of_Invoice` | **YES** | string | `FOB` or `CIF` | `FOB` |
+| `Terms_Of_Invoice` | no | string | `FOB` or `CIF`. Earlier noted here as required; the collection says optional. **There is no `DDP`/`DAP` value — this field is the invoice VALUATION basis (does the declared value include freight/insurance), not who pays duty.** | `FOB` |
+| `ioss` | doc says **YES** | string | **The IOSS registration NUMBER, not a boolean.** Undocumented beyond the name — no description, no example. ⚠️ Live-verified 2026-08-22: an NL order creates fine with this ABSENT, so "required" is wrong at create time. Untested at AWB assign. | omit until IOSS-registered |
+| `eori` | doc says **YES** | string | The EORI number. Same caveats as `ioss`. | omit |
 | `purpose_of_shipment` | no | int | `0`=gift, `1`=sample, `2`=commercial | `2` |
 | `igstPaymentStatus` | no | char | `A`=not applicable, `B`=LUT/Export under Bond, `C`=Export against IGST payment | `A` |
 | `commodity` | no | bool | is the order a commodity | `true` |
@@ -53,9 +67,69 @@ not ISO) and these extra top-level fields:
 |---|---|---|---|
 | `weight` | **YES** | int | shipment weight |
 | `cod` | **YES** | int | **must be `0`** (no international COD) |
-| `delivery_country` | **YES** | string | **destination country ISO Alpha-2 code**, e.g. `US` (NB: create uses full name, serviceability uses ISO2) |
-| `order_id` | no | int | Shiprocket order id (skips weight/cod if given) |
-| `pickup_postcode` | no | int | non-primary pickup |
+| `delivery_country` | **YES** | string | destination country. ISO Alpha-2 (`NL`) and the full name (`Netherlands`) both work here — unlike create, which needs the full name. |
+| `order_id` | no | int | Shiprocket order id (skips weight/cod if given). ⚠️ See the note below — this form returned NO couriers for an NL order that the weight form priced fine. |
+| `pickup_postcode` | **YES, in practice** | int | 🔴 Documented optional, but omitting it 400s with `"Please fix request using below fields"` — **naming no fields**. Live-verified 2026-08-22; cost three attempts to find. Always send it. |
+
+## 🔑 The serviceability RESPONSE carries a customs block the docs never mention
+
+Live-verified 2026-08-22 against the prod account (probe: create → rate → cancel,
+no AWB ever assigned). **None of these appear anywhere in the Postman
+collection** — a full-text search of all 2 MB returns zero hits for "ddp",
+"duty", "duties" or "incoterm". The published contract is simply behind the API.
+
+Each entry in `data.available_courier_companies[]` carries:
+
+| Field | Meaning (inferred — Shiprocket documents none of it) |
+|---|---|
+| `ddp_tag`, `ddp_vcn`, `ddp_inclusive_vcn` | **Delivered Duty Paid.** So DDP IS expressible; it is simply not a `Terms_Of_Invoice` value. |
+| `tariff`, `tariff_data` | Duty. Empty/0 on every probe so far. |
+| `ioss_fee`, `eori_fee`, `international_vat_amount` | The EU VAT/IOSS/EORI money, per courier. |
+| `is_csb5`, `csb4_seller_kyc`, `csb5_seller_kyc` | Which export route the lane runs under, and whether the seller is KYC'd for it. |
+| `custom_clearance_type`, `cha_agent_id`, `clearance_cha_partner`, `custom_route_code` | Clearance agent wiring. |
+
+🔴 **This is the right place to read landed cost from — BEFORE assigning an AWB.**
+Serviceability is a free read; assign books and bills. Anything we ever show a
+buyer about duty must come from here, per shipment, and never from a config flag
+that says what we *intend* the incoterm to be.
+
+### Account state as observed 2026-08-22 (NL, 2 kg, €450)
+
+```
+Aramex International | ddp_tag=false  ddp_vcn=false  ddp_inclusive_vcn=false
+                     | ioss_fee=0  eori_fee=0  international_vat_amount=0  tariff=0
+                     | is_csb5=true  csb4_seller_kyc=true  csb5_seller_kyc=FALSE
+                     | is_active=false
+```
+
+Two blockers, both account-side rather than code:
+
+- **`csb5_seller_kyc: false`** while CSB-4's is true. CSB-5 is the commercial
+  export route that pairs with the LUT, and our create body classifies as CSB-5.
+  Most likely why every DDP/tariff/fee field reads zero.
+- **`is_active: false`**, on the only courier that serves the lane at all.
+
+Enabling IOSS/EORI in Settings → International Taxes changed **nothing** on the
+order record — reading the order back before and after is byte-identical. These
+are rate-level fields, not order fields.
+
+### Also observed
+
+- **`shipping_is_billing: true` is not honoured** — send an explicit `shipping_*`
+  block. Already recorded in `shiprocket/client.ts` (live-verified 2026-08-06),
+  but it was missing here, and it cost three attempts on this probe: the create
+  fails as `"Delivery pincode is not valid for Netherlands!"`, which reads as a
+  postcode-format problem and is nothing of the kind. Note it is `isd_code`, not
+  `billing_isd_code`.
+- **Only ONE courier serves NL** (Aramex International), and only via the
+  weight-based lookup. The `order_id` form answered *"No serviceable couriers
+  available for entered pincodes"* for the same pickup, with the Dutch postcode
+  in every format tried (`1015 CJ`, `1015`). Delivery-pincode matching is what
+  fails, not the postcode format.
+- **Cancelling spawns a clone.** Cancelling `ioss-probe-…` left a NEW order
+  named `ioss-probe-…-C` behind. A create/cancel probe that does not sweep
+  afterwards leaves live orders on the account. Always re-list and re-cancel;
+  never cancel anything carrying an AWB.
 
 ## Country-format gotcha (load-bearing)
 


### PR DESCRIPTION
Re-verified the international contract against the **live API** on 2026-08-22 with a create → rate → cancel probe. No AWB was ever assigned; all seven probe orders were swept and confirmed `CANCELED`, nothing billed.

## What the Postman collection gets wrong

| | |
|---|---|
| `ioss` / `eori` | Exist on `create/adhoc`, marked **required**, no description, no example. They are registration **numbers**, not booleans — and an NL order creates fine with both absent, so "required" is wrong at create time. |
| `pickup_postcode` | Marked optional on serviceability. It is not. Omitting it returns `400 "Please fix request using below fields"` — and then names no fields. |
| `Terms_Of_Invoice` | Optional in the collection; this doc had it as required. |
| **The whole customs block** | 🔑 Absent from the collection entirely. |

## 🔑 DDP is expressible after all

The **serviceability response** carries, per courier:

```
ddp_tag  ddp_vcn  ddp_inclusive_vcn
tariff  tariff_data
ioss_fee  eori_fee  international_vat_amount
is_csb5  csb4_seller_kyc  csb5_seller_kyc
custom_clearance_type  cha_agent_id  clearance_cha_partner
```

A full-text search of all 2 MB of the collection returns **zero** hits for "ddp", "duty", "duties" or "incoterm". I twice concluded from the documentation that Shiprocket could not do DDP. The live rate payload says otherwise — `Terms_Of_Invoice` is the invoice *valuation basis* (does declared value include freight and insurance), not who pays duty, and DDP lives somewhere the docs don't go. The docs were the wrong instrument; the panel was right.

## Account state that blocks it today

```
Aramex International | ddp_tag=false  ddp_vcn=false  ddp_inclusive_vcn=false
                     | ioss_fee=0  eori_fee=0  international_vat_amount=0  tariff=0
                     | is_csb5=true  csb4_seller_kyc=true  csb5_seller_kyc=FALSE
                     | is_active=false
```

Both blockers are account-side, not code: **CSB-5 seller KYC is not done** (CSB-4's is), and the only courier serving the lane comes back **inactive**. Raised with Shiprocket support separately.

## Also recorded

- Enabling IOSS/EORI in Settings → International Taxes changes **nothing** on the order record — reading the order back before and after is byte-identical. These are rate-level fields.
- **Only one courier serves NL**, and only via the weight-based lookup; the `order_id` form answers "No serviceable couriers available for entered pincodes" for the same pickup with the Dutch postcode in every format tried.
- **Cancelling spawns a clone** — a `-C` order left behind in `NEW`. A probe that doesn't sweep afterwards leaves live orders on the account. The sweep caught this; the per-run cancel did not.
- The **`shipping_is_billing: true`** trap, which was only ever written down in `shiprocket/client.ts`. It presents as `"Delivery pincode is not valid for Netherlands!"` — reads as a postcode-format problem, is nothing of the kind.

## 🔴 The operative consequence

Landed cost shown to a buyer must be read from the **serviceability response, per shipment** — a free call, before any AWB — never from a config flag stating what we *intend* the incoterm to be. Serviceability prices the lane without booking it, so there is no reason to ever promise DDP from configuration.

Docs only — no code paths touched.

🤖 Generated with [Claude Code](https://claude.com/claude-code)