### PR TITLE
feat(visual-editor): body editor drawer, floating TipTap toolbar, inline editing fix

### DIFF
--- a/apps/backend/src/api/admin/websites/[id]/pages/[pageId]/blocks/validators.ts
+++ b/apps/backend/src/api/admin/websites/[id]/pages/[pageId]/blocks/validators.ts
@@ -19,6 +19,9 @@ export const BLOCK_TYPES = [
   "Product",
   "Section",
   "Custom",
+  "HeroWithImage",
+  "BentoGrid",
+  "Button",
 ] as const
 
 export const UNIQUE_BLOCKS = [
@@ -36,6 +39,9 @@ export const REPEATABLE_BLOCKS = [
   "Product",
   "Section",
   "Custom",
+  "HeroWithImage",
+  "BentoGrid",
+  "Button",
 ] as const
 
 export const BLOCK_STATUSES = ["Active", "Inactive", "Draft"] as const

--- a/apps/backend/src/api/partners/storefront/helpers.ts
+++ b/apps/backend/src/api/partners/storefront/helpers.ts
@@ -214,7 +214,9 @@ export const triggerStorefrontRevalidate = async (
 
   const url = domain.startsWith("http")
     ? `${domain.replace(/\/$/, "")}/api/revalidate`
-    : `https://${domain}/api/revalidate`
+    : domain.startsWith("localhost")
+      ? `${process.env.STOREFRONT_LOCAL_URL || "http://localhost:8000"}/api/revalidate`
+      : `https://${domain}/api/revalidate`
 
   const controller = new AbortController()
   const timer = setTimeout(() => controller.abort(), 5000)

--- a/apps/backend/src/api/partners/storefront/provision/route.ts
+++ b/apps/backend/src/api/partners/storefront/provision/route.ts
@@ -175,6 +175,42 @@ export const POST = async (
 
   const s3Config = getS3ImageConfig()
 
+  // Dev bypass: skip Vercel/hosting provider — just set storefront_domain so
+  // the partner UI can create websites and edit content locally.
+  const STOREFRONT_LOCAL_URL =
+    process.env.STOREFRONT_LOCAL_URL || "http://localhost:8000"
+
+  if (process.env.NODE_ENV !== "production") {
+    const localDomain = new URL(STOREFRONT_LOCAL_URL).hostname
+
+    // Check if already provisioned in dev
+    if (partnerData.storefront_domain || partnerData.metadata?.storefront_domain) {
+      throw new MedusaError(
+        MedusaError.Types.INVALID_DATA,
+        "Storefront already provisioned (dev mode). Remove it first to re-provision."
+      )
+    }
+
+    await updatePartnerWorkflow(req.scope).run({
+      input: {
+        id: partner.id,
+        data: {
+          storefront_domain: localDomain,
+          metadata: {
+            ...(partnerData.metadata || {}),
+            storefront_provisioned_at: new Date().toISOString(),
+          },
+        },
+      },
+    })
+
+    return res.status(201).json({
+      message: "Storefront provisioned (dev mode — no hosting provider)",
+      storefront_url: STOREFRONT_LOCAL_URL,
+      domain: localDomain,
+    })
+  }
+
   // Partner-level overrides take precedence over env fallbacks so each
   // partner can BYO repo/branch/root later without code changes.
   const storefrontRepo = partnerData.storefront_repo || STOREFRONT_REPO_ENV

--- a/apps/backend/src/api/partners/storefront/route.ts
+++ b/apps/backend/src/api/partners/storefront/route.ts
@@ -124,6 +124,32 @@ export const DELETE = async (
   const projectRef = refs.projectRef
   const storefrontDomain = refs.storefrontDomain
 
+  // Dev bypass: no hosting project to delete — just clear storefront metadata.
+  if (process.env.NODE_ENV !== "production" && !projectRef && storefrontDomain) {
+    await updatePartnerWorkflow(req.scope).run({
+      input: {
+        id: partner.id,
+        data: {
+          metadata: stripStorefrontKeys(partner.metadata),
+          storefront_domain: null,
+          hosting_provider: null,
+          deployment_account_id: null,
+          deployment_project_id: null,
+          deployment_project_name: null,
+          vercel_project_id: null,
+          vercel_project_name: null,
+          vercel_last_deployment_id: null,
+          vercel_linked: false,
+        },
+      },
+    })
+
+    return res.json({
+      message: "Storefront removed (dev mode)",
+      results: { metadata: { action: "cleared" } },
+    })
+  }
+
   if (!projectRef) {
     throw new MedusaError(
       MedusaError.Types.NOT_FOUND,

--- a/apps/backend/src/api/web/website/[domain]/[page]/route.ts
+++ b/apps/backend/src/api/web/website/[domain]/[page]/route.ts
@@ -33,6 +33,7 @@ export const GET = async (
         name: block.name,
         type: block.type,
         content: block.content,
+        settings: block.settings,
         order: block.order,
       })) || [],
     };

--- a/apps/backend/src/modules/website/migrations/Migration20260822120000.ts
+++ b/apps/backend/src/modules/website/migrations/Migration20260822120000.ts
@@ -1,0 +1,36 @@
+import { Migration } from "@mikro-orm/migrations"
+
+export class Migration20260822120000 extends Migration {
+
+  override async up(): Promise<void> {
+    this.addSql(`
+      ALTER TABLE IF EXISTS "block"
+      DROP CONSTRAINT IF EXISTS "block_type_check";
+    `)
+    this.addSql(`
+      ALTER TABLE "block"
+      ADD CONSTRAINT "block_type_check"
+      CHECK ("type" IN (
+        'Hero', 'Header', 'Footer', 'MainContent', 'ContactForm',
+        'Feature', 'Gallery', 'Testimonial', 'Product', 'Section', 'Custom',
+        'HeroWithImage', 'BentoGrid', 'Button'
+      ));
+    `)
+  }
+
+  override async down(): Promise<void> {
+    this.addSql(`
+      ALTER TABLE IF EXISTS "block"
+      DROP CONSTRAINT IF EXISTS "block_type_check";
+    `)
+    this.addSql(`
+      ALTER TABLE "block"
+      ADD CONSTRAINT "block_type_check"
+      CHECK ("type" IN (
+        'Hero', 'Header', 'Footer', 'MainContent', 'ContactForm',
+        'Feature', 'Gallery', 'Testimonial', 'Product', 'Section', 'Custom'
+      ));
+    `)
+  }
+
+}

--- a/apps/backend/src/modules/website/models/blocks.ts
+++ b/apps/backend/src/modules/website/models/blocks.ts
@@ -15,7 +15,10 @@ const UNIQUE_BLOCKS = [
     "Testimonial",
     "Product",
     "Section",
-    "Custom"
+    "Custom",
+    "HeroWithImage",
+    "BentoGrid",
+    "Button"
   ];
 
 const Block = model.define("block", {

--- a/apps/backend/src/workflows/partners/get-partner-storefront-status.ts
+++ b/apps/backend/src/workflows/partners/get-partner-storefront-status.ts
@@ -62,6 +62,30 @@ export const resolvePartnerStorefrontStatusStep = createStep(
     const refs = getStorefrontRefs(partner)
 
     if (!refs.projectRef) {
+      // Dev bypass: if storefront_domain is set but no hosting project ref,
+      // report as provisioned so the partner UI can create websites and
+      // edit content without a real hosting provider deployment.
+      if (
+        process.env.NODE_ENV !== "production" &&
+        refs.storefrontDomain
+      ) {
+        const isLocal = refs.storefrontDomain.startsWith("localhost")
+        const protocol = isLocal ? "http" : "https"
+        const storefrontUrl =
+          isLocal
+            ? (process.env.STOREFRONT_LOCAL_URL || "http://localhost:8000")
+            : `${protocol}://${refs.storefrontDomain}`
+        return new StepResponse({
+          provisioned: true,
+          provider: "local",
+          domain: refs.storefrontDomain,
+          storefront_url: storefrontUrl,
+          provisioned_at: refs.storefrontProvisionedAt,
+          project: { id: null, name: "Local Dev" },
+          latest_deployment: null,
+        } as PartnerStorefrontStatus)
+      }
+
       return new StepResponse({
         provisioned: false,
         provider: refs.providerName,

--- a/apps/backend/workflow-schemas.json
+++ b/apps/backend/workflow-schemas.json
@@ -3268,14 +3268,14 @@
         "type": "id",
         "required": true,
         "placeholder": "{{ $last.source_price_id }}",
-        "description": "Workflow: fanout-prices-from-source When a partner sets a manual price on a variant, this workflow creates auto-converted price rows in the partner's other supported currencies using FX rates from the fx_rates module. Algorithm: 1. Resolve the source price. 2. Recursion guard: query for the link `price ↔ fx_price_meta`. If the source already has an `fx_price_meta` row, fanout was the thing that created it — skip, otherwise the price.created event would trigger an infinite re-emit loop. 3. Resolve price_set → variant → product → first sales_channel → store. Skip if the chain breaks. 4. Read store.supported_currencies — these are the currencies the partner is willing to display prices in. 5. For each currency in supported_currencies that the price_set doesn't already have a row for, compute the converted amount via FX and call `addPrices` to attach a new price row to the price_set. 6. For each newly created price, create an `fx_price_meta` row (base_currency, base_amount, fx_rate, source_price_id) and a Medusa link between `price.id` and `fx_price_meta.id`. The link is the discriminator the recursion guard, UI badge, strip-on-edit, and daily re-rate all read. Why a separate fx_price_meta table: Medusa's `Price` model has no `metadata` column (verified). An earlier draft tried to stash the FX audit fields in `metadata` and it silently dropped — discovered when the recursion guard never fired. See apps/docs/notes/FX_AUTO_CONVERSION.md. Failure semantics: Per-currency errors during rate lookup are logged + counted but never abort the whole fanout. If `addPrices` itself fails the step throws so the workflow reports failure to the subscriber. / export type FanoutPricesInput = { /** Source price id (the one the partner just set)."
+        "description": "Workflow: fanout-prices-from-source When a partner sets a manual price on a variant, this workflow creates auto-converted price rows in the partner's other supported currencies using FX rates from the fx_rates module. Algorithm: 1. Resolve the source price. 2. Recursion guard: query for the link `price ↔ fx_price_meta`. If the source already has an `fx_price_meta` row, fanout was the thing that created it — skip, otherwise the price.created event would trigger an infinite re-emit loop. 3. Resolve price_set → variant → product → first sales_channel → store. Skip if the chain breaks. 4. Read store.supported_currencies — these are the currencies the partner is willing to display prices in. 5. For each currency in supported_currencies that the price_set doesn't already have a row for, compute the converted amount via FX and call `addPrices` to attach a new price row to the price_set. 6. For each newly created price, create an `fx_price_meta` row (base_currency, base_amount, fx_rate, source_price_id) and a Medusa link between `price.id` and `fx_price_meta.id`. The link is the discriminator the recursion guard, UI badge, strip-on-edit, and daily re-rate all read. Why a separate fx_price_meta table: Medusa's `Price` model has no `metadata` column (verified). An earlier draft tried to stash the FX audit fields in `metadata` and it silently dropped — discovered when the recursion guard never fired. See apps/docs/notes/FX_AUTO_CONVERSION.md. Failure semantics: Per-currency errors during rate lookup are logged + counted but never abort the whole fanout. If `addPrices` itself fails the step throws so the workflow reports failure to the subscriber. / /** Identity of a price WITHIN a price set: currency plus its quantity bounds. Bounds arrive as BigNumberValue — a string from `query.graph`, a number when we set it ourselves — so `50` and `\"50\"` must collapse to the same key or a tier is re-created on every fanout. `null`/`undefined` (an unbounded price) normalises to the empty string, which is distinct from any numeric bound. / export const tierKey = (currency: string, min: any, max: any): string => { const norm = (v: any) => v === null || v === undefined || v === \"\" ? \"\" : String(Number(v)) return `${String(currency).toLowerCase()}|${norm(min)}|${norm(max)}` } export type FanoutPricesInput = { /** Source price id (the one the partner just set)."
       },
       {
         "name": "store_id",
         "type": "id",
         "required": false,
         "placeholder": "{{ $last.store_id }}",
-        "description": "Workflow: fanout-prices-from-source When a partner sets a manual price on a variant, this workflow creates auto-converted price rows in the partner's other supported currencies using FX rates from the fx_rates module. Algorithm: 1. Resolve the source price. 2. Recursion guard: query for the link `price ↔ fx_price_meta`. If the source already has an `fx_price_meta` row, fanout was the thing that created it — skip, otherwise the price.created event would trigger an infinite re-emit loop. 3. Resolve price_set → variant → product → first sales_channel → store. Skip if the chain breaks. 4. Read store.supported_currencies — these are the currencies the partner is willing to display prices in. 5. For each currency in supported_currencies that the price_set doesn't already have a row for, compute the converted amount via FX and call `addPrices` to attach a new price row to the price_set. 6. For each newly created price, create an `fx_price_meta` row (base_currency, base_amount, fx_rate, source_price_id) and a Medusa link between `price.id` and `fx_price_meta.id`. The link is the discriminator the recursion guard, UI badge, strip-on-edit, and daily re-rate all read. Why a separate fx_price_meta table: Medusa's `Price` model has no `metadata` column (verified). An earlier draft tried to stash the FX audit fields in `metadata` and it silently dropped — discovered when the recursion guard never fired. See apps/docs/notes/FX_AUTO_CONVERSION.md. Failure semantics: Per-currency errors during rate lookup are logged + counted but never abort the whole fanout. If `addPrices` itself fails the step throws so the workflow reports failure to the subscriber. / export type FanoutPricesInput = { /** Source price id (the one the partner just set). */ source_price_id: string /** Optional: the store whose supported_currencies drive the fanout. Pass this from contexts where you already know the store (partner routes, scripts). When omitted, the workflow derives it by walking price_set → variant → product → sales_channel and looking up the store where `default_sales_channel_id` matches — useful as a fallback but slower and dependent on the product being linked to a sales_channel that's the default for exactly one store."
+        "description": "Workflow: fanout-prices-from-source When a partner sets a manual price on a variant, this workflow creates auto-converted price rows in the partner's other supported currencies using FX rates from the fx_rates module. Algorithm: 1. Resolve the source price. 2. Recursion guard: query for the link `price ↔ fx_price_meta`. If the source already has an `fx_price_meta` row, fanout was the thing that created it — skip, otherwise the price.created event would trigger an infinite re-emit loop. 3. Resolve price_set → variant → product → first sales_channel → store. Skip if the chain breaks. 4. Read store.supported_currencies — these are the currencies the partner is willing to display prices in. 5. For each currency in supported_currencies that the price_set doesn't already have a row for, compute the converted amount via FX and call `addPrices` to attach a new price row to the price_set. 6. For each newly created price, create an `fx_price_meta` row (base_currency, base_amount, fx_rate, source_price_id) and a Medusa link between `price.id` and `fx_price_meta.id`. The link is the discriminator the recursion guard, UI badge, strip-on-edit, and daily re-rate all read. Why a separate fx_price_meta table: Medusa's `Price` model has no `metadata` column (verified). An earlier draft tried to stash the FX audit fields in `metadata` and it silently dropped — discovered when the recursion guard never fired. See apps/docs/notes/FX_AUTO_CONVERSION.md. Failure semantics: Per-currency errors during rate lookup are logged + counted but never abort the whole fanout. If `addPrices` itself fails the step throws so the workflow reports failure to the subscriber. / /** Identity of a price WITHIN a price set: currency plus its quantity bounds. Bounds arrive as BigNumberValue — a string from `query.graph`, a number when we set it ourselves — so `50` and `\"50\"` must collapse to the same key or a tier is re-created on every fanout. `null`/`undefined` (an unbounded price) normalises to the empty string, which is distinct from any numeric bound. / export const tierKey = (currency: string, min: any, max: any): string => { const norm = (v: any) => v === null || v === undefined || v === \"\" ? \"\" : String(Number(v)) return `${String(currency).toLowerCase()}|${norm(min)}|${norm(max)}` } export type FanoutPricesInput = { /** Source price id (the one the partner just set). */ source_price_id: string /** Optional: the store whose supported_currencies drive the fanout. Pass this from contexts where you already know the store (partner routes, scripts). When omitted, the workflow derives it by walking price_set → variant → product → sales_channel and looking up the store where `default_sales_channel_id` matches — useful as a fallback but slower and dependent on the product being linked to a sales_channel that's the default for exactly one store."
       }
     ],
     "source": "custom_ts",
@@ -5208,6 +5208,103 @@
     "source": "custom_ts",
     "sourceFile": "src/workflows/partner/list-partner-people.ts"
   },
+  "mint-partner-quote": {
+    "fields": [
+      {
+        "name": "partner_id",
+        "type": "id",
+        "required": true,
+        "placeholder": "{{ $last.partner_id }}"
+      },
+      {
+        "name": "store",
+        "type": "object",
+        "required": true,
+        "placeholder": "{}"
+      },
+      {
+        "name": "buyer_email",
+        "type": "string",
+        "required": true,
+        "placeholder": "{{ $last.buyer_email }}"
+      },
+      {
+        "name": "recipient_name",
+        "type": "string",
+        "required": false,
+        "placeholder": "{{ $last.recipient_name }}"
+      },
+      {
+        "name": "recipient_company",
+        "type": "string",
+        "required": false,
+        "placeholder": "{{ $last.recipient_company }}"
+      },
+      {
+        "name": "partner_note",
+        "type": "string",
+        "required": false,
+        "placeholder": "{{ $last.partner_note }}"
+      },
+      {
+        "name": "destination_country_code",
+        "type": "string",
+        "required": true,
+        "placeholder": "{{ $last.destination_country_code }}"
+      },
+      {
+        "name": "destination_postal_code",
+        "type": "string",
+        "required": false,
+        "placeholder": "{{ $last.destination_postal_code }}"
+      },
+      {
+        "name": "destination_city",
+        "type": "string",
+        "required": false,
+        "placeholder": "{{ $last.destination_city }}"
+      },
+      {
+        "name": "currency_code",
+        "type": "string",
+        "required": true,
+        "placeholder": "{{ $last.currency_code }}"
+      },
+      {
+        "name": "region_id",
+        "type": "id",
+        "required": false,
+        "placeholder": "{{ $last.region_id }}"
+      },
+      {
+        "name": "carrier",
+        "type": "string",
+        "required": false,
+        "placeholder": "{{ $last.carrier }}"
+      },
+      {
+        "name": "ttl_days",
+        "type": "number",
+        "required": false,
+        "placeholder": "0"
+      },
+      {
+        "name": "created_by",
+        "type": "string",
+        "required": false,
+        "placeholder": "{{ $last.created_by }}"
+      },
+      {
+        "name": "now",
+        "type": "date",
+        "required": false,
+        "placeholder": "{{ $trigger.now }}",
+        "description": "Injected so the whole mint is deterministic under test."
+      }
+    ],
+    "source": "custom_ts",
+    "sourceFile": "src/workflows/partner-quote/mint-quote.ts"
+  },
   "cancel-partner-subscription": {
     "fields": [
       {
@@ -5306,6 +5403,13 @@
         "type": "id",
         "required": true,
         "placeholder": "{{ $last.id }}"
+      },
+      {
+        "name": "force",
+        "type": "boolean",
+        "required": false,
+        "placeholder": "false",
+        "description": "Delete even though orders are still in flight. See the planner's docs."
       }
     ],
     "source": "custom_ts",
@@ -6022,6 +6126,24 @@
     "source": "custom_ts",
     "sourceFile": "src/workflows/production-runs/accept-production-run.ts"
   },
+  "admin-accept-production-run": {
+    "fields": [
+      {
+        "name": "id",
+        "type": "id",
+        "required": false,
+        "placeholder": "{{ $last.id }}"
+      },
+      {
+        "name": "data",
+        "type": "object",
+        "required": false,
+        "placeholder": "{}"
+      }
+    ],
+    "source": "inferred",
+    "sourceFile": "src/workflows/production-runs/admin-accept-production-run.ts"
+  },
   "admin-complete-production-run": {
     "fields": [
       {
@@ -6046,6 +6168,42 @@
     ],
     "source": "custom_ts",
     "sourceFile": "src/workflows/production-runs/admin-complete-production-run.ts"
+  },
+  "admin-finish-production-run": {
+    "fields": [
+      {
+        "name": "id",
+        "type": "id",
+        "required": false,
+        "placeholder": "{{ $last.id }}"
+      },
+      {
+        "name": "data",
+        "type": "object",
+        "required": false,
+        "placeholder": "{}"
+      }
+    ],
+    "source": "inferred",
+    "sourceFile": "src/workflows/production-runs/admin-finish-production-run.ts"
+  },
+  "admin-start-production-run": {
+    "fields": [
+      {
+        "name": "id",
+        "type": "id",
+        "required": false,
+        "placeholder": "{{ $last.id }}"
+      },
+      {
+        "name": "data",
+        "type": "object",
+        "required": false,
+        "placeholder": "{}"
+      }
+    ],
+    "source": "inferred",
+    "sourceFile": "src/workflows/production-runs/admin-start-production-run.ts"
   },
   "approve-production-run": {
     "fields": [
@@ -6095,6 +6253,54 @@
     ],
     "source": "custom_ts",
     "sourceFile": "src/workflows/production-runs/assign-production-run-partner.ts"
+  },
+  "attach-media-to-production-run": {
+    "fields": [
+      {
+        "name": "production_run_id",
+        "type": "id",
+        "required": true,
+        "placeholder": "{{ $last.production_run_id }}"
+      },
+      {
+        "name": "media_url",
+        "type": "string",
+        "required": true,
+        "placeholder": "{{ $last.media_url }}"
+      },
+      {
+        "name": "media_mime_type",
+        "type": "string",
+        "required": false,
+        "placeholder": "{{ $last.media_mime_type }}"
+      },
+      {
+        "name": "filename",
+        "type": "string",
+        "required": false,
+        "placeholder": "{{ $last.filename }}"
+      },
+      {
+        "name": "message_id",
+        "type": "id",
+        "required": false,
+        "placeholder": "{{ $last.message_id }}"
+      },
+      {
+        "name": "conversation_id",
+        "type": "id",
+        "required": false,
+        "placeholder": "{{ $last.conversation_id }}"
+      },
+      {
+        "name": "actor_id",
+        "type": "id",
+        "required": false,
+        "placeholder": "{{ $last.actor_id }}"
+      }
+    ],
+    "source": "custom_ts",
+    "sourceFile": "src/workflows/production-runs/attach-media-to-production-run.ts"
   },
   "complete-production-run": {
     "fields": [

--- a/apps/partner-ui/src/components/block-editor/block-editor.tsx
+++ b/apps/partner-ui/src/components/block-editor/block-editor.tsx
@@ -119,6 +119,7 @@ export const BlockEditor = ({
 
   const REPEATABLE_TYPES = new Set([
     "Feature", "Gallery", "Testimonial", "Product", "Section", "Custom",
+    "HeroWithImage", "BentoGrid", "Button",
   ])
 
   const renderTypeSpecificEditor = () => {
@@ -377,6 +378,15 @@ export const BlockEditor = ({
           </>
         )
 
+      case "HeroWithImage":
+        return <HeroWithImageEditor content={content} updateContent={updateContent} />
+
+      case "BentoGrid":
+        return <BentoGridEditor content={content} updateContent={updateContent} />
+
+      case "Button":
+        return <ButtonBlockEditor content={content} updateContent={updateContent} />
+
       case "Custom":
         return (
           <>
@@ -554,12 +564,109 @@ export const BlockEditor = ({
               </div>
 
               <div>
+                <FieldLabel>Text Color</FieldLabel>
+                <div className="flex gap-x-2">
+                  <input
+                    className="flex-1 rounded-md border border-ui-border-base bg-ui-bg-field px-3 py-1.5 text-sm"
+                    value={(block.settings?.textColor as string) || ""}
+                    placeholder="#000000"
+                    onChange={(e) => updateSettings("textColor", e.target.value)}
+                  />
+                  <input
+                    type="color"
+                    value={(block.settings?.textColor as string) || "#000000"}
+                    onChange={(e) => updateSettings("textColor", e.target.value)}
+                    className="w-9 h-9 rounded border border-ui-border-base cursor-pointer"
+                  />
+                </div>
+              </div>
+
+              <div>
                 <FieldLabel>Padding (px)</FieldLabel>
                 <TextInput
                   value={(block.settings?.padding as string) || ""}
                   placeholder="0"
                   onChange={(v) => updateSettings("padding", v)}
                 />
+              </div>
+
+              <div className="grid grid-cols-2 gap-x-2">
+                <div>
+                  <FieldLabel>Pad Top</FieldLabel>
+                  <TextInput
+                    value={(block.settings?.paddingTop as string) || ""}
+                    placeholder="0"
+                    onChange={(v) => updateSettings("paddingTop", v)}
+                  />
+                </div>
+                <div>
+                  <FieldLabel>Pad Bottom</FieldLabel>
+                  <TextInput
+                    value={(block.settings?.paddingBottom as string) || ""}
+                    placeholder="0"
+                    onChange={(v) => updateSettings("paddingBottom", v)}
+                  />
+                </div>
+                <div>
+                  <FieldLabel>Pad Left</FieldLabel>
+                  <TextInput
+                    value={(block.settings?.paddingLeft as string) || ""}
+                    placeholder="0"
+                    onChange={(v) => updateSettings("paddingLeft", v)}
+                  />
+                </div>
+                <div>
+                  <FieldLabel>Pad Right</FieldLabel>
+                  <TextInput
+                    value={(block.settings?.paddingRight as string) || ""}
+                    placeholder="0"
+                    onChange={(v) => updateSettings("paddingRight", v)}
+                  />
+                </div>
+              </div>
+
+              <div>
+                <FieldLabel>Margin (px)</FieldLabel>
+                <TextInput
+                  value={(block.settings?.margin as string) || ""}
+                  placeholder="0"
+                  onChange={(v) => updateSettings("margin", v)}
+                />
+              </div>
+
+              <div className="grid grid-cols-2 gap-x-2">
+                <div>
+                  <FieldLabel>Margin Top</FieldLabel>
+                  <TextInput
+                    value={(block.settings?.marginTop as string) || ""}
+                    placeholder="0"
+                    onChange={(v) => updateSettings("marginTop", v)}
+                  />
+                </div>
+                <div>
+                  <FieldLabel>Margin Bottom</FieldLabel>
+                  <TextInput
+                    value={(block.settings?.marginBottom as string) || ""}
+                    placeholder="0"
+                    onChange={(v) => updateSettings("marginBottom", v)}
+                  />
+                </div>
+                <div>
+                  <FieldLabel>Margin Left</FieldLabel>
+                  <TextInput
+                    value={(block.settings?.marginLeft as string) || ""}
+                    placeholder="0"
+                    onChange={(v) => updateSettings("marginLeft", v)}
+                  />
+                </div>
+                <div>
+                  <FieldLabel>Margin Right</FieldLabel>
+                  <TextInput
+                    value={(block.settings?.marginRight as string) || ""}
+                    placeholder="0"
+                    onChange={(v) => updateSettings("marginRight", v)}
+                  />
+                </div>
               </div>
 
               <div>
@@ -573,11 +680,78 @@ export const BlockEditor = ({
                   </Select.Trigger>
                   <Select.Content>
                     <Select.Item value="default">Default</Select.Item>
-                    <Select.Item value="narrow">Narrow</Select.Item>
-                    <Select.Item value="wide">Wide</Select.Item>
+                    <Select.Item value="narrow">Narrow (680px)</Select.Item>
+                    <Select.Item value="medium">Medium (960px)</Select.Item>
+                    <Select.Item value="wide">Wide (1200px)</Select.Item>
                     <Select.Item value="full">Full Width</Select.Item>
                   </Select.Content>
                 </Select>
+              </div>
+
+              <div className="grid grid-cols-2 gap-x-2">
+                <div>
+                  <FieldLabel>Width</FieldLabel>
+                  <TextInput
+                    value={(block.settings?.width as string) || ""}
+                    placeholder="auto"
+                    onChange={(v) => updateSettings("width", v)}
+                  />
+                </div>
+                <div>
+                  <FieldLabel>Height</FieldLabel>
+                  <TextInput
+                    value={(block.settings?.height as string) || ""}
+                    placeholder="auto"
+                    onChange={(v) => updateSettings("height", v)}
+                  />
+                </div>
+              </div>
+
+              <div>
+                <FieldLabel>Border Radius (px)</FieldLabel>
+                <TextInput
+                  value={(block.settings?.borderRadius as string) || ""}
+                  placeholder="0"
+                  onChange={(v) => updateSettings("borderRadius", v)}
+                />
+              </div>
+
+              <div className="grid grid-cols-2 gap-x-2">
+                <div>
+                  <FieldLabel>Border Width</FieldLabel>
+                  <TextInput
+                    value={(block.settings?.borderWidth as string) || ""}
+                    placeholder="0"
+                    onChange={(v) => updateSettings("borderWidth", v)}
+                  />
+                </div>
+                <div>
+                  <FieldLabel>Border Color</FieldLabel>
+                  <input
+                    className="w-full rounded-md border border-ui-border-base bg-ui-bg-field px-3 py-1.5 text-sm"
+                    value={(block.settings?.borderColor as string) || ""}
+                    placeholder="#e5e7eb"
+                    onChange={(e) => updateSettings("borderColor", e.target.value)}
+                  />
+                </div>
+              </div>
+
+              <div>
+                <FieldLabel>Box Shadow</FieldLabel>
+                <TextInput
+                  value={(block.settings?.boxShadow as string) || ""}
+                  placeholder="e.g. 0 4px 6px rgba(0,0,0,0.1)"
+                  onChange={(v) => updateSettings("boxShadow", v)}
+                />
+              </div>
+
+              <div>
+                <FieldLabel>Aspect Ratio</FieldLabel>
+                <TextInput
+                  value={(block.settings?.aspectRatio as string) || ""}
+                  placeholder="e.g. 16/9"
+                  onChange={(v) => updateSettings("aspectRatio", v)}
+                />
               </div>
             </div>
           )}
@@ -748,5 +922,452 @@ const LinksEditor = ({
         </Button>
       </div>
     </div>
+  )
+}
+
+const HeroWithImageEditor = ({
+  content,
+  updateContent,
+}: {
+  content: Record<string, unknown>
+  updateContent: (key: string, value: unknown) => void
+}) => {
+  const buttons = (content.buttons as Array<{ label?: string; href?: string; variant?: string }>) || []
+
+  const updateButtons = (next: Array<{ label?: string; href?: string; variant?: string }>) => {
+    updateContent("buttons", next)
+  }
+
+  return (
+    <>
+      <div>
+        <FieldLabel>Eyebrow Text</FieldLabel>
+        <TextInput
+          value={(content.eyebrow as string) || ""}
+          onChange={(v) => updateContent("eyebrow", v)}
+          placeholder="New Collection"
+        />
+      </div>
+      <div>
+        <FieldLabel>Title</FieldLabel>
+        <TextInput
+          value={(content.title as string) || ""}
+          onChange={(v) => updateContent("title", v)}
+          placeholder="Hero Title"
+        />
+      </div>
+      <div>
+        <FieldLabel>Subtitle</FieldLabel>
+        <TextArea
+          value={(content.subtitle as string) || ""}
+          onChange={(v) => updateContent("subtitle", v)}
+          placeholder="Hero subtitle text"
+        />
+      </div>
+      <div>
+        <FieldLabel>Layout</FieldLabel>
+        <Select
+          value={(content.layout as string) || "image-right"}
+          onValueChange={(v) => updateContent("layout", v)}
+        >
+          <Select.Trigger>
+            <Select.Value placeholder="Image Right" />
+          </Select.Trigger>
+          <Select.Content>
+            <Select.Item value="image-right">Image Right</Select.Item>
+            <Select.Item value="image-left">Image Left</Select.Item>
+          </Select.Content>
+        </Select>
+      </div>
+      <ImageUrlInput
+        label="Image URL"
+        value={(content.image_url as string) || ""}
+        onChange={(v) => updateContent("image_url", v)}
+      />
+      <div>
+        <FieldLabel>Image Alt Text</FieldLabel>
+        <TextInput
+          value={(content.image_alt as string) || ""}
+          onChange={(v) => updateContent("image_alt", v)}
+          placeholder="Describe the image"
+        />
+      </div>
+      <div>
+        <FieldLabel>Buttons</FieldLabel>
+        <div className="space-y-2">
+          {buttons.map((btn, idx) => (
+            <div key={idx} className="rounded-md border border-ui-border-base p-2 space-y-2">
+              <div className="flex gap-x-1">
+                <input
+                  className="flex-1 rounded-md border border-ui-border-base bg-ui-bg-field px-2 py-1 text-sm"
+                  value={btn.label || ""}
+                  placeholder="Label"
+                  onChange={(e) => {
+                    const next = [...buttons]
+                    next[idx] = { ...next[idx], label: e.target.value }
+                    updateButtons(next)
+                  }}
+                />
+                <input
+                  className="flex-1 rounded-md border border-ui-border-base bg-ui-bg-field px-2 py-1 text-sm"
+                  value={btn.href || ""}
+                  placeholder="/link"
+                  onChange={(e) => {
+                    const next = [...buttons]
+                    next[idx] = { ...next[idx], href: e.target.value }
+                    updateButtons(next)
+                  }}
+                />
+                <IconButton
+                  variant="transparent"
+                  size="small"
+                  onClick={() => updateButtons(buttons.filter((_, i) => i !== idx))}
+                >
+                  <Trash />
+                </IconButton>
+              </div>
+              <Select
+                value={btn.variant || "primary"}
+                onValueChange={(v) => {
+                  const next = [...buttons]
+                  next[idx] = { ...next[idx], variant: v }
+                  updateButtons(next)
+                }}
+              >
+                <Select.Trigger>
+                  <Select.Value placeholder="Primary" />
+                </Select.Trigger>
+                <Select.Content>
+                  <Select.Item value="primary">Primary</Select.Item>
+                  <Select.Item value="secondary">Secondary</Select.Item>
+                </Select.Content>
+              </Select>
+            </div>
+          ))}
+          <Button
+            size="small"
+            variant="secondary"
+            onClick={() => updateButtons([...buttons, { label: "", href: "", variant: "primary" }])}
+          >
+            <Plus className="mr-1" />Add Button
+          </Button>
+        </div>
+      </div>
+    </>
+  )
+}
+
+const BentoGridEditor = ({
+  content,
+  updateContent,
+}: {
+  content: Record<string, unknown>
+  updateContent: (key: string, value: unknown) => void
+}) => {
+  const cards = (content.cards as Array<{
+    eyebrow?: string
+    title?: string
+    description?: string
+    image_url?: string
+    col_span?: string
+    row_span?: string
+    bg_color?: string
+    text_color?: string
+  }>) || []
+
+  const updateCards = (next: typeof cards) => {
+    updateContent("cards", next)
+  }
+
+  return (
+    <>
+      <div>
+        <FieldLabel>Title</FieldLabel>
+        <TextInput
+          value={(content.title as string) || ""}
+          onChange={(v) => updateContent("title", v)}
+          placeholder="Bento Grid Title"
+        />
+      </div>
+      <div>
+        <FieldLabel>Subtitle</FieldLabel>
+        <TextInput
+          value={(content.subtitle as string) || ""}
+          onChange={(v) => updateContent("subtitle", v)}
+          placeholder="Optional subtitle"
+        />
+      </div>
+      <div>
+        <FieldLabel>Columns</FieldLabel>
+        <Select
+          value={(content.columns as string) || "3"}
+          onValueChange={(v) => updateContent("columns", v)}
+        >
+          <Select.Trigger>
+            <Select.Value placeholder="3" />
+          </Select.Trigger>
+          <Select.Content>
+            <Select.Item value="2">2 Columns</Select.Item>
+            <Select.Item value="3">3 Columns</Select.Item>
+            <Select.Item value="4">4 Columns</Select.Item>
+          </Select.Content>
+        </Select>
+      </div>
+      <div>
+        <FieldLabel>Cards</FieldLabel>
+        <div className="space-y-3">
+          {cards.map((card, idx) => (
+            <div key={idx} className="rounded-md border border-ui-border-base p-3 space-y-2">
+              <div className="flex items-center justify-between">
+                <Text size="xsmall" className="font-semibold text-ui-fg-muted">
+                  Card {idx + 1}
+                </Text>
+                <IconButton
+                  variant="transparent"
+                  size="small"
+                  onClick={() => updateCards(cards.filter((_, i) => i !== idx))}
+                >
+                  <Trash />
+                </IconButton>
+              </div>
+              <TextInput
+                value={card.eyebrow || ""}
+                onChange={(v) => {
+                  const next = [...cards]
+                  next[idx] = { ...next[idx], eyebrow: v }
+                  updateCards(next)
+                }}
+                placeholder="Eyebrow (small label)"
+              />
+              <TextInput
+                value={card.title || ""}
+                onChange={(v) => {
+                  const next = [...cards]
+                  next[idx] = { ...next[idx], title: v }
+                  updateCards(next)
+                }}
+                placeholder="Card title"
+              />
+              <TextArea
+                value={card.description || ""}
+                onChange={(v) => {
+                  const next = [...cards]
+                  next[idx] = { ...next[idx], description: v }
+                  updateCards(next)
+                }}
+                placeholder="Card description"
+              />
+              <ImageUrlInput
+                label="Image URL"
+                value={card.image_url || ""}
+                onChange={(v) => {
+                  const next = [...cards]
+                  next[idx] = { ...next[idx], image_url: v }
+                  updateCards(next)
+                }}
+              />
+              <div className="grid grid-cols-2 gap-x-2">
+                <div>
+                  <FieldLabel>Col Span</FieldLabel>
+                  <Select
+                    value={card.col_span || "1"}
+                    onValueChange={(v) => {
+                      const next = [...cards]
+                      next[idx] = { ...next[idx], col_span: v }
+                      updateCards(next)
+                    }}
+                  >
+                    <Select.Trigger>
+                      <Select.Value placeholder="1" />
+                    </Select.Trigger>
+                    <Select.Content>
+                      <Select.Item value="1">1</Select.Item>
+                      <Select.Item value="2">2</Select.Item>
+                      <Select.Item value="3">3</Select.Item>
+                      <Select.Item value="4">4</Select.Item>
+                    </Select.Content>
+                  </Select>
+                </div>
+                <div>
+                  <FieldLabel>Row Span</FieldLabel>
+                  <Select
+                    value={card.row_span || "1"}
+                    onValueChange={(v) => {
+                      const next = [...cards]
+                      next[idx] = { ...next[idx], row_span: v }
+                      updateCards(next)
+                    }}
+                  >
+                    <Select.Trigger>
+                      <Select.Value placeholder="1" />
+                    </Select.Trigger>
+                    <Select.Content>
+                      <Select.Item value="1">1</Select.Item>
+                      <Select.Item value="2">2</Select.Item>
+                      <Select.Item value="3">3</Select.Item>
+                    </Select.Content>
+                  </Select>
+                </div>
+              </div>
+              <div className="grid grid-cols-2 gap-x-2">
+                <div>
+                  <FieldLabel>Card BG</FieldLabel>
+                  <input
+                    className="w-full rounded-md border border-ui-border-base bg-ui-bg-field px-2 py-1 text-sm"
+                    value={card.bg_color || ""}
+                    placeholder="#f5f5f5"
+                    onChange={(e) => {
+                      const next = [...cards]
+                      next[idx] = { ...next[idx], bg_color: e.target.value }
+                      updateCards(next)
+                    }}
+                  />
+                </div>
+                <div>
+                  <FieldLabel>Card Text</FieldLabel>
+                  <input
+                    className="w-full rounded-md border border-ui-border-base bg-ui-bg-field px-2 py-1 text-sm"
+                    value={card.text_color || ""}
+                    placeholder="#000000"
+                    onChange={(e) => {
+                      const next = [...cards]
+                      next[idx] = { ...next[idx], text_color: e.target.value }
+                      updateCards(next)
+                    }}
+                  />
+                </div>
+              </div>
+            </div>
+          ))}
+          <Button
+            size="small"
+            variant="secondary"
+            onClick={() => updateCards([...cards, { eyebrow: "", title: "New Card", description: "", col_span: "1", row_span: "1" }])}
+          >
+            <Plus className="mr-1" />Add Card
+          </Button>
+        </div>
+      </div>
+    </>
+  )
+}
+
+const ButtonBlockEditor = ({
+  content,
+  updateContent,
+}: {
+  content: Record<string, unknown>
+  updateContent: (key: string, value: unknown) => void
+}) => {
+  const buttons = (content.buttons as Array<{
+    label?: string
+    href?: string
+    variant?: string
+    size?: string
+  }>) || []
+
+  const updateButtons = (next: typeof buttons) => {
+    updateContent("buttons", next)
+  }
+
+  return (
+    <>
+      <div>
+        <FieldLabel>Alignment</FieldLabel>
+        <Select
+          value={(content.align as string) || "left"}
+          onValueChange={(v) => updateContent("align", v)}
+        >
+          <Select.Trigger>
+            <Select.Value placeholder="Left" />
+          </Select.Trigger>
+          <Select.Content>
+            <Select.Item value="left">Left</Select.Item>
+            <Select.Item value="center">Center</Select.Item>
+            <Select.Item value="right">Right</Select.Item>
+          </Select.Content>
+        </Select>
+      </div>
+      <div>
+        <FieldLabel>Buttons</FieldLabel>
+        <div className="space-y-2">
+          {buttons.map((btn, idx) => (
+            <div key={idx} className="rounded-md border border-ui-border-base p-2 space-y-2">
+              <div className="flex gap-x-1">
+                <input
+                  className="flex-1 rounded-md border border-ui-border-base bg-ui-bg-field px-2 py-1 text-sm"
+                  value={btn.label || ""}
+                  placeholder="Button Label"
+                  onChange={(e) => {
+                    const next = [...buttons]
+                    next[idx] = { ...next[idx], label: e.target.value }
+                    updateButtons(next)
+                  }}
+                />
+                <IconButton
+                  variant="transparent"
+                  size="small"
+                  onClick={() => updateButtons(buttons.filter((_, i) => i !== idx))}
+                >
+                  <Trash />
+                </IconButton>
+              </div>
+              <TextInput
+                value={btn.href || ""}
+                onChange={(v) => {
+                  const next = [...buttons]
+                  next[idx] = { ...next[idx], href: v }
+                  updateButtons(next)
+                }}
+                placeholder="/link"
+              />
+              <div className="grid grid-cols-2 gap-x-2">
+                <Select
+                  value={btn.variant || "primary"}
+                  onValueChange={(v) => {
+                    const next = [...buttons]
+                    next[idx] = { ...next[idx], variant: v }
+                    updateButtons(next)
+                  }}
+                >
+                  <Select.Trigger>
+                    <Select.Value placeholder="Primary" />
+                  </Select.Trigger>
+                  <Select.Content>
+                    <Select.Item value="primary">Primary</Select.Item>
+                    <Select.Item value="secondary">Secondary</Select.Item>
+                    <Select.Item value="ghost">Ghost</Select.Item>
+                  </Select.Content>
+                </Select>
+                <Select
+                  value={btn.size || "medium"}
+                  onValueChange={(v) => {
+                    const next = [...buttons]
+                    next[idx] = { ...next[idx], size: v }
+                    updateButtons(next)
+                  }}
+                >
+                  <Select.Trigger>
+                    <Select.Value placeholder="Medium" />
+                  </Select.Trigger>
+                  <Select.Content>
+                    <Select.Item value="small">Small</Select.Item>
+                    <Select.Item value="medium">Medium</Select.Item>
+                    <Select.Item value="large">Large</Select.Item>
+                  </Select.Content>
+                </Select>
+              </div>
+            </div>
+          ))}
+          <Button
+            size="small"
+            variant="secondary"
+            onClick={() => updateButtons([...buttons, { label: "", href: "#", variant: "primary", size: "medium" }])}
+          >
+            <Plus className="mr-1" />Add Button
+          </Button>
+        </div>
+      </div>
+    </>
   )
 }

--- a/apps/partner-ui/src/components/block-editor/block-editor.tsx
+++ b/apps/partner-ui/src/components/block-editor/block-editor.tsx
@@ -1,8 +1,8 @@
 import { useCallback, useState } from "react"
 import { Text, Button, IconButton, Tooltip, Select, Badge, Label } from "@medusajs/ui"
-import { Trash, Plus, Images, ChevronDown, ChevronRight, CursorArrowRays, ArrowUpMini, ArrowDownMini } from "@medusajs/icons"
+import { Trash, Plus, Images, ChevronDown, ChevronRight, CursorArrowRays, ArrowUpMini, ArrowDownMini, ArrowsPointingOut } from "@medusajs/icons"
 import { ContentBlock } from "../../hooks/api/content"
-import { TipTapEditor } from "../tiptap-editor/tiptap-editor"
+import { TipTapEditor, type TipTapActions } from "../tiptap-editor/tiptap-editor"
 
 
 type BlockEditorProps = {
@@ -15,6 +15,7 @@ type BlockEditorProps = {
   canMoveUp?: boolean
   canMoveDown?: boolean
   saveStatus: "saved" | "saving" | "unsaved"
+  onEditorReady?: (editor: any, actions: TipTapActions) => void
 }
 
 const FieldLabel = ({ children }: { children: React.ReactNode }) => (
@@ -94,6 +95,7 @@ export const BlockEditor = ({
   canMoveUp = true,
   canMoveDown = true,
   saveStatus,
+  onEditorReady,
 }: BlockEditorProps) => {
   const updateContent = useCallback(
     (key: string, value: unknown) => {
@@ -199,6 +201,7 @@ export const BlockEditor = ({
                 content={(content.body as Record<string, unknown>) || undefined}
                 onChange={(json) => updateContent("body", json)}
                 placeholder="Write your page content here..."
+                onEditorReady={onEditorReady}
               />
             </div>
           </>
@@ -221,6 +224,7 @@ export const BlockEditor = ({
                 content={(content.body as Record<string, unknown>) || undefined}
                 onChange={(json) => updateContent("body", json)}
                 placeholder="Write section content..."
+                onEditorReady={onEditorReady}
               />
             </div>
             <div>
@@ -403,6 +407,7 @@ export const BlockEditor = ({
                 content={(content.body as Record<string, unknown>) || undefined}
                 onChange={(json) => updateContent("body", json)}
                 placeholder="Write custom content..."
+                onEditorReady={onEditorReady}
               />
             </div>
           </>
@@ -424,6 +429,7 @@ export const BlockEditor = ({
                 content={(content.body as Record<string, unknown>) || undefined}
                 onChange={(json) => updateContent("body", json)}
                 placeholder="Write content..."
+                onEditorReady={onEditorReady}
               />
             </div>
           </>
@@ -581,93 +587,33 @@ export const BlockEditor = ({
                 </div>
               </div>
 
-              <div>
-                <FieldLabel>Padding (px)</FieldLabel>
-                <TextInput
-                  value={(block.settings?.padding as string) || ""}
-                  placeholder="0"
-                  onChange={(v) => updateSettings("padding", v)}
-                />
-              </div>
+              <SpacingControl
+                label="Padding"
+                value={(block.settings?.padding as string) || ""}
+                top={(block.settings?.paddingTop as string) || ""}
+                right={(block.settings?.paddingRight as string) || ""}
+                bottom={(block.settings?.paddingBottom as string) || ""}
+                left={(block.settings?.paddingLeft as string) || ""}
+                onChangeAll={(v) => updateSettings("padding", v)}
+                onChangeTop={(v) => updateSettings("paddingTop", v)}
+                onChangeRight={(v) => updateSettings("paddingRight", v)}
+                onChangeBottom={(v) => updateSettings("paddingBottom", v)}
+                onChangeLeft={(v) => updateSettings("paddingLeft", v)}
+              />
 
-              <div className="grid grid-cols-2 gap-x-2">
-                <div>
-                  <FieldLabel>Pad Top</FieldLabel>
-                  <TextInput
-                    value={(block.settings?.paddingTop as string) || ""}
-                    placeholder="0"
-                    onChange={(v) => updateSettings("paddingTop", v)}
-                  />
-                </div>
-                <div>
-                  <FieldLabel>Pad Bottom</FieldLabel>
-                  <TextInput
-                    value={(block.settings?.paddingBottom as string) || ""}
-                    placeholder="0"
-                    onChange={(v) => updateSettings("paddingBottom", v)}
-                  />
-                </div>
-                <div>
-                  <FieldLabel>Pad Left</FieldLabel>
-                  <TextInput
-                    value={(block.settings?.paddingLeft as string) || ""}
-                    placeholder="0"
-                    onChange={(v) => updateSettings("paddingLeft", v)}
-                  />
-                </div>
-                <div>
-                  <FieldLabel>Pad Right</FieldLabel>
-                  <TextInput
-                    value={(block.settings?.paddingRight as string) || ""}
-                    placeholder="0"
-                    onChange={(v) => updateSettings("paddingRight", v)}
-                  />
-                </div>
-              </div>
-
-              <div>
-                <FieldLabel>Margin (px)</FieldLabel>
-                <TextInput
-                  value={(block.settings?.margin as string) || ""}
-                  placeholder="0"
-                  onChange={(v) => updateSettings("margin", v)}
-                />
-              </div>
-
-              <div className="grid grid-cols-2 gap-x-2">
-                <div>
-                  <FieldLabel>Margin Top</FieldLabel>
-                  <TextInput
-                    value={(block.settings?.marginTop as string) || ""}
-                    placeholder="0"
-                    onChange={(v) => updateSettings("marginTop", v)}
-                  />
-                </div>
-                <div>
-                  <FieldLabel>Margin Bottom</FieldLabel>
-                  <TextInput
-                    value={(block.settings?.marginBottom as string) || ""}
-                    placeholder="0"
-                    onChange={(v) => updateSettings("marginBottom", v)}
-                  />
-                </div>
-                <div>
-                  <FieldLabel>Margin Left</FieldLabel>
-                  <TextInput
-                    value={(block.settings?.marginLeft as string) || ""}
-                    placeholder="0"
-                    onChange={(v) => updateSettings("marginLeft", v)}
-                  />
-                </div>
-                <div>
-                  <FieldLabel>Margin Right</FieldLabel>
-                  <TextInput
-                    value={(block.settings?.marginRight as string) || ""}
-                    placeholder="0"
-                    onChange={(v) => updateSettings("marginRight", v)}
-                  />
-                </div>
-              </div>
+              <SpacingControl
+                label="Margin"
+                value={(block.settings?.margin as string) || ""}
+                top={(block.settings?.marginTop as string) || ""}
+                right={(block.settings?.marginRight as string) || ""}
+                bottom={(block.settings?.marginBottom as string) || ""}
+                left={(block.settings?.marginLeft as string) || ""}
+                onChangeAll={(v) => updateSettings("margin", v)}
+                onChangeTop={(v) => updateSettings("marginTop", v)}
+                onChangeRight={(v) => updateSettings("marginRight", v)}
+                onChangeBottom={(v) => updateSettings("marginBottom", v)}
+                onChangeLeft={(v) => updateSettings("marginLeft", v)}
+              />
 
               <div>
                 <FieldLabel>Max Width</FieldLabel>
@@ -690,7 +636,7 @@ export const BlockEditor = ({
 
               <div className="grid grid-cols-2 gap-x-2">
                 <div>
-                  <FieldLabel>Width</FieldLabel>
+                  <FieldLabel>Width (px)</FieldLabel>
                   <TextInput
                     value={(block.settings?.width as string) || ""}
                     placeholder="auto"
@@ -698,7 +644,7 @@ export const BlockEditor = ({
                   />
                 </div>
                 <div>
-                  <FieldLabel>Height</FieldLabel>
+                  <FieldLabel>Height (px)</FieldLabel>
                   <TextInput
                     value={(block.settings?.height as string) || ""}
                     placeholder="auto"
@@ -709,11 +655,17 @@ export const BlockEditor = ({
 
               <div>
                 <FieldLabel>Border Radius (px)</FieldLabel>
-                <TextInput
-                  value={(block.settings?.borderRadius as string) || ""}
-                  placeholder="0"
-                  onChange={(v) => updateSettings("borderRadius", v)}
+                <input
+                  type="range"
+                  min="0"
+                  max="32"
+                  value={Number((block.settings?.borderRadius as string) || "0")}
+                  onChange={(e) => updateSettings("borderRadius", e.target.value)}
+                  className="w-full"
                 />
+                <Text size="xsmall" className="text-ui-fg-muted">
+                  {((block.settings?.borderRadius as string) || "0")}px
+                </Text>
               </div>
 
               <div className="grid grid-cols-2 gap-x-2">
@@ -1369,5 +1321,106 @@ const ButtonBlockEditor = ({
         </div>
       </div>
     </>
+  )
+}
+
+const SpacingControl = ({
+  label,
+  value,
+  top,
+  right,
+  bottom,
+  left,
+  onChangeAll,
+  onChangeTop,
+  onChangeRight,
+  onChangeBottom,
+  onChangeLeft,
+}: {
+  label: string
+  value: string
+  top: string
+  right: string
+  bottom: string
+  left: string
+  onChangeAll: (v: string) => void
+  onChangeTop: (v: string) => void
+  onChangeRight: (v: string) => void
+  onChangeBottom: (v: string) => void
+  onChangeLeft: (v: string) => void
+}) => {
+  const [expanded, setExpanded] = useState(false)
+  const hasPerSide = top || right || bottom || left
+  const sliderVal = value ? Number(value) : 0
+
+  return (
+    <div>
+      <div className="flex items-center justify-between mb-1">
+        <FieldLabel>{label}</FieldLabel>
+        <button
+          onClick={() => setExpanded((v) => !v)}
+          className="flex items-center gap-x-0.5 text-ui-fg-muted hover:text-ui-fg-base"
+        >
+          <ArrowsPointingOut className="w-3.5 h-3.5" />
+          <Text size="xsmall" className="text-ui-fg-muted">
+            {expanded ? "Simple" : "Per side"}
+          </Text>
+        </button>
+      </div>
+      {expanded ? (
+        <div className="grid grid-cols-2 gap-1">
+          <div className="flex items-center gap-x-1">
+            <Text size="xsmall" className="text-ui-fg-muted w-4">T</Text>
+            <input
+              className="flex-1 rounded-md border border-ui-border-base bg-ui-bg-field px-2 py-1 text-sm w-full"
+              value={top}
+              placeholder="0"
+              onChange={(e) => onChangeTop(e.target.value)}
+            />
+          </div>
+          <div className="flex items-center gap-x-1">
+            <Text size="xsmall" className="text-ui-fg-muted w-4">B</Text>
+            <input
+              className="flex-1 rounded-md border border-ui-border-base bg-ui-bg-field px-2 py-1 text-sm w-full"
+              value={bottom}
+              placeholder="0"
+              onChange={(e) => onChangeBottom(e.target.value)}
+            />
+          </div>
+          <div className="flex items-center gap-x-1">
+            <Text size="xsmall" className="text-ui-fg-muted w-4">L</Text>
+            <input
+              className="flex-1 rounded-md border border-ui-border-base bg-ui-bg-field px-2 py-1 text-sm w-full"
+              value={left}
+              placeholder="0"
+              onChange={(e) => onChangeLeft(e.target.value)}
+            />
+          </div>
+          <div className="flex items-center gap-x-1">
+            <Text size="xsmall" className="text-ui-fg-muted w-4">R</Text>
+            <input
+              className="flex-1 rounded-md border border-ui-border-base bg-ui-bg-field px-2 py-1 text-sm w-full"
+              value={right}
+              placeholder="0"
+              onChange={(e) => onChangeRight(e.target.value)}
+            />
+          </div>
+        </div>
+      ) : (
+        <div className="flex items-center gap-x-2">
+          <input
+            type="range"
+            min="0"
+            max="80"
+            value={sliderVal}
+            onChange={(e) => onChangeAll(e.target.value)}
+            className="flex-1"
+          />
+          <Text size="small" className="text-ui-fg-muted w-10 text-right">
+            {value || (hasPerSide ? "mixed" : "0")}px
+          </Text>
+        </div>
+      )}
+    </div>
   )
 }

--- a/apps/partner-ui/src/components/tiptap-editor/embed-extension.ts
+++ b/apps/partner-ui/src/components/tiptap-editor/embed-extension.ts
@@ -1,0 +1,86 @@
+// Imported via @tiptap/react (which re-exports @tiptap/core) — @tiptap/core is
+// not a direct dependency of this package, only hoisted at the workspace root.
+import { Node, mergeAttributes } from "@tiptap/react"
+
+/**
+ * The "Insert Video" flow emits nodes of type `youtube` | `vimeo` | `embed` |
+ * `video`. None of those exist in StarterKit, so `insertContent` was handing
+ * ProseMirror a node type its schema had never heard of — the insert threw and
+ * the video never appeared. These two nodes put the types in the schema.
+ *
+ * `Embed` covers the iframe-based providers (youtube/vimeo/generic embed) and
+ * `VideoFile` covers a direct MP4/WebM/OGG URL.
+ */
+
+const IFRAME_ALLOW =
+  "accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture"
+
+export const Embed = Node.create({
+  name: "embed",
+  group: "block",
+  atom: true,
+  draggable: true,
+
+  addAttributes() {
+    return {
+      src: { default: null },
+    }
+  },
+
+  // A single node class handles all three iframe providers, so `youtube` and
+  // `vimeo` are parsed/serialised as this node too.
+  addOptions() {
+    return { HTMLAttributes: {} }
+  },
+
+  parseHTML() {
+    return [{ tag: "iframe[src]" }]
+  },
+
+  renderHTML({ HTMLAttributes }) {
+    return [
+      "div",
+      { class: "tiptap-embed", style: "position:relative;padding-bottom:56.25%;height:0" },
+      [
+        "iframe",
+        mergeAttributes(this.options.HTMLAttributes, HTMLAttributes, {
+          style: "position:absolute;top:0;left:0;width:100%;height:100%",
+          frameborder: "0",
+          allow: IFRAME_ALLOW,
+          allowfullscreen: "true",
+        }),
+      ],
+    ]
+  },
+})
+
+export const VideoFile = Node.create({
+  name: "video",
+  group: "block",
+  atom: true,
+  draggable: true,
+
+  addAttributes() {
+    return {
+      src: { default: null },
+    }
+  },
+
+  addOptions() {
+    return { HTMLAttributes: {} }
+  },
+
+  parseHTML() {
+    return [{ tag: "video[src]" }]
+  },
+
+  renderHTML({ HTMLAttributes }) {
+    return [
+      "video",
+      mergeAttributes(this.options.HTMLAttributes, HTMLAttributes, {
+        controls: "true",
+        class: "tiptap-video",
+      }),
+    ]
+  },
+})

--- a/apps/partner-ui/src/components/tiptap-editor/tiptap-editor.tsx
+++ b/apps/partner-ui/src/components/tiptap-editor/tiptap-editor.tsx
@@ -1,11 +1,11 @@
-import { useEditor, EditorContent } from "@tiptap/react"
+import { useEditor, EditorContent, type Editor } from "@tiptap/react"
 import StarterKit from "@tiptap/starter-kit"
 import Underline from "@tiptap/extension-underline"
 import TextAlign from "@tiptap/extension-text-align"
 import Link from "@tiptap/extension-link"
 import Image from "@tiptap/extension-image"
 import Placeholder from "@tiptap/extension-placeholder"
-import { useCallback, useState, useRef } from "react"
+import { useCallback, useState, useRef, useEffect } from "react"
 import { Button, Input, Label, Checkbox, Text } from "@medusajs/ui"
 import { StackedDrawer } from "../modals/stacked-drawer"
 import { useStackedModal } from "../modals/stacked-modal-provider"
@@ -15,12 +15,21 @@ type TipTapEditorProps = {
   content?: Record<string, unknown>
   onChange?: (json: Record<string, unknown>) => void
   placeholder?: string
+  onEditorReady?: (editor: Editor, actions: TipTapActions) => void
+}
+
+export type TipTapActions = {
+  setLink: () => void
+  addImage: () => void
+  addVideo: () => void
+  triggerUpload: () => void
 }
 
 export const TipTapEditor = ({
   content,
   onChange,
   placeholder = "Start writing...",
+  onEditorReady,
 }: TipTapEditorProps) => {
   const editor = useEditor({
     immediatelyRender: false,
@@ -183,6 +192,34 @@ export const TipTapEditor = ({
       }).run()
     }
   }, [editor, videoUrl, parseVideoUrl, setStackedOpen])
+
+  const actionsRef = useRef<TipTapActions | null>(null)
+
+  useEffect(() => {
+    if (editor && onEditorReady) {
+      const actions: TipTapActions = {
+        setLink: () => {
+          const prev = editor.getAttributes("link").href || ""
+          setLinkUrl(prev)
+          setLinkOpenNewTab(editor.getAttributes("link").target === "_blank")
+          setStackedOpen(LINK_MODAL_ID, true)
+        },
+        addImage: () => {
+          setImageUrl("")
+          setStackedOpen(IMAGE_MODAL_ID, true)
+        },
+        addVideo: () => {
+          setVideoUrl("")
+          setStackedOpen(VIDEO_MODAL_ID, true)
+        },
+        triggerUpload: () => {
+          fileInputRef.current?.click()
+        },
+      }
+      actionsRef.current = actions
+      onEditorReady(editor, actions)
+    }
+  }, [editor, onEditorReady])
 
   if (!editor) return null
 

--- a/apps/partner-ui/src/components/tiptap-editor/tiptap-editor.tsx
+++ b/apps/partner-ui/src/components/tiptap-editor/tiptap-editor.tsx
@@ -6,7 +6,9 @@ import Link from "@tiptap/extension-link"
 import Image from "@tiptap/extension-image"
 import Placeholder from "@tiptap/extension-placeholder"
 import { useCallback, useState } from "react"
-import { Button, Drawer, Input, Label, Checkbox } from "@medusajs/ui"
+import { Button, Input, Label, Checkbox } from "@medusajs/ui"
+import { StackedDrawer } from "../modals/stacked-drawer"
+import { useStackedModal } from "../modals/stacked-modal-provider"
 
 type TipTapEditorProps = {
   content?: Record<string, unknown>
@@ -44,12 +46,13 @@ export const TipTapEditor = ({
     },
   })
 
-  const [linkOpen, setLinkOpen] = useState(false)
   const [linkUrl, setLinkUrl] = useState("")
   const [linkOpenNewTab, setLinkOpenNewTab] = useState(false)
-
-  const [imageOpen, setImageOpen] = useState(false)
   const [imageUrl, setImageUrl] = useState("")
+  const { setIsOpen: setStackedOpen } = useStackedModal()
+  const LINK_MODAL_ID = "tiptap-link"
+  const IMAGE_MODAL_ID = "tiptap-image"
+
 
   const sanitizeUrl = useCallback((url: string): string => {
     const trimmed = url.trim()
@@ -71,13 +74,13 @@ export const TipTapEditor = ({
     const isOpen = editor.getAttributes("link").target === "_blank"
     setLinkUrl(previousUrl)
     setLinkOpenNewTab(isOpen)
-    setLinkOpen(true)
+    setStackedOpen(LINK_MODAL_ID, true)
   }, [editor])
 
   const confirmSetLink = useCallback(() => {
     if (!editor) return
     const url = sanitizeUrl(linkUrl)
-    setLinkOpen(false)
+    setStackedOpen(LINK_MODAL_ID, false)
     if (!url) {
       editor.chain().focus().extendMarkRange("link").unsetLink().run()
       return
@@ -96,12 +99,12 @@ export const TipTapEditor = ({
   const addImage = useCallback(() => {
     if (!editor) return
     setImageUrl("")
-    setImageOpen(true)
+    setStackedOpen(IMAGE_MODAL_ID, true)
   }, [editor])
 
   const confirmAddImage = useCallback(() => {
     const url = sanitizeUrl(imageUrl)
-    setImageOpen(false)
+    setStackedOpen(IMAGE_MODAL_ID, false)
     if (url && editor) {
       editor.chain().focus().setImage({ src: url }).run()
     }
@@ -208,12 +211,12 @@ export const TipTapEditor = ({
         </div>
       </div>
 
-      <Drawer open={linkOpen} onOpenChange={setLinkOpen}>
-        <Drawer.Content>
-          <Drawer.Header>
-            <Drawer.Title>Insert Link</Drawer.Title>
-          </Drawer.Header>
-          <Drawer.Body className="space-y-4">
+      <StackedDrawer id={LINK_MODAL_ID}>
+        <StackedDrawer.Content>
+          <StackedDrawer.Header>
+            <StackedDrawer.Title>Insert Link</StackedDrawer.Title>
+          </StackedDrawer.Header>
+          <StackedDrawer.Body className="space-y-4">
             <div>
               <Label>URL</Label>
               <Input
@@ -232,24 +235,24 @@ export const TipTapEditor = ({
                 Open in new tab
               </Label>
             </div>
-          </Drawer.Body>
-          <Drawer.Footer>
-            <Button variant="secondary" onClick={() => setLinkOpen(false)}>
+          </StackedDrawer.Body>
+          <StackedDrawer.Footer>
+            <Button variant="secondary" onClick={() => setStackedOpen(LINK_MODAL_ID, false)}>
               Cancel
             </Button>
             <Button onClick={confirmSetLink}>
               {linkUrl.trim() ? "Apply" : "Remove link"}
             </Button>
-          </Drawer.Footer>
-        </Drawer.Content>
-      </Drawer>
+          </StackedDrawer.Footer>
+        </StackedDrawer.Content>
+      </StackedDrawer>
 
-      <Drawer open={imageOpen} onOpenChange={setImageOpen}>
-        <Drawer.Content>
-          <Drawer.Header>
-            <Drawer.Title>Insert Image</Drawer.Title>
-          </Drawer.Header>
-          <Drawer.Body className="space-y-4">
+      <StackedDrawer id={IMAGE_MODAL_ID}>
+        <StackedDrawer.Content>
+          <StackedDrawer.Header>
+            <StackedDrawer.Title>Insert Image</StackedDrawer.Title>
+          </StackedDrawer.Header>
+          <StackedDrawer.Body className="space-y-4">
             <div>
               <Label>Image URL</Label>
               <Input
@@ -271,17 +274,17 @@ export const TipTapEditor = ({
                 </div>
               ) : null
             })()}
-          </Drawer.Body>
-          <Drawer.Footer>
-            <Button variant="secondary" onClick={() => setImageOpen(false)}>
+          </StackedDrawer.Body>
+          <StackedDrawer.Footer>
+            <Button variant="secondary" onClick={() => setStackedOpen(IMAGE_MODAL_ID, false)}>
               Cancel
             </Button>
             <Button onClick={confirmAddImage} disabled={!sanitizeUrl(imageUrl)}>
               Insert
             </Button>
-          </Drawer.Footer>
-        </Drawer.Content>
-      </Drawer>
+          </StackedDrawer.Footer>
+        </StackedDrawer.Content>
+      </StackedDrawer>
     </>
   )
 }

--- a/apps/partner-ui/src/components/tiptap-editor/tiptap-editor.tsx
+++ b/apps/partner-ui/src/components/tiptap-editor/tiptap-editor.tsx
@@ -5,6 +5,7 @@ import TextAlign from "@tiptap/extension-text-align"
 import Link from "@tiptap/extension-link"
 import Image from "@tiptap/extension-image"
 import Placeholder from "@tiptap/extension-placeholder"
+import { Embed, VideoFile } from "./embed-extension"
 import { useCallback, useState, useRef, useEffect } from "react"
 import { Button, Input, Label, Checkbox, Text } from "@medusajs/ui"
 import { StackedDrawer } from "../modals/stacked-drawer"
@@ -49,6 +50,8 @@ export const TipTapEditor = ({
         HTMLAttributes: { class: "tiptap-image" },
       }),
       Placeholder.configure({ placeholder }),
+      Embed,
+      VideoFile,
     ],
     content: content || { type: "doc", content: [{ type: "paragraph" }] },
     onUpdate: ({ editor }) => {
@@ -61,6 +64,7 @@ export const TipTapEditor = ({
   const [imageUrl, setImageUrl] = useState("")
   const [videoUrl, setVideoUrl] = useState("")
   const [isUploading, setIsUploading] = useState(false)
+  const [uploadError, setUploadError] = useState<string | null>(null)
   const fileInputRef = useRef<HTMLInputElement>(null)
   const { setIsOpen: setStackedOpen } = useStackedModal()
   const { mutateAsync: uploadFiles } = usePartnerUpload()
@@ -127,6 +131,7 @@ export const TipTapEditor = ({
 
   const handleFileUpload = useCallback(async (files: FileList | null) => {
     if (!files || files.length === 0) return
+    setUploadError(null)
     setIsUploading(true)
     try {
       const result = await uploadFiles(Array.from(files))
@@ -134,13 +139,16 @@ export const TipTapEditor = ({
       if (uploadedUrl && editor) {
         editor.chain().focus().setImage({ src: uploadedUrl }).run()
       }
-    } catch {
-      // Fallback: show error in the image modal
-      const errUrl = ""
-      setImageUrl(errUrl)
+      setStackedOpen(IMAGE_MODAL_ID, false)
+    } catch (e) {
+      // Surface the failure in the image modal rather than closing it — the
+      // upload can be triggered without the modal ever being open, so open it.
+      setUploadError(
+        e instanceof Error ? e.message : "Upload failed. Please try again."
+      )
+      setStackedOpen(IMAGE_MODAL_ID, true)
     } finally {
       setIsUploading(false)
-      setStackedOpen(IMAGE_MODAL_ID, false)
     }
   }, [editor, uploadFiles, setStackedOpen])
 
@@ -150,6 +158,8 @@ export const TipTapEditor = ({
     setStackedOpen(VIDEO_MODAL_ID, true)
   }, [editor])
 
+  // `type` must be a node name registered above (`embed` or `video`), not a
+  // provider name — ProseMirror rejects a node type absent from the schema.
   const parseVideoUrl = useCallback((url: string): { src: string; type: string } | null => {
     const trimmed = url.trim()
     if (!trimmed) return null
@@ -161,17 +171,17 @@ export const TipTapEditor = ({
           ? parsed.pathname.slice(1)
           : parsed.searchParams.get("v") || parsed.pathname.split("/").pop()
         if (videoId) {
-          return { src: `https://www.youtube.com/embed/${videoId}`, type: "youtube" }
+          return { src: `https://www.youtube.com/embed/${videoId}`, type: "embed" }
         }
       }
       if (host === "vimeo.com") {
         const videoId = parsed.pathname.split("/").pop()
         if (videoId) {
-          return { src: `https://player.vimeo.com/video/${videoId}`, type: "vimeo" }
+          return { src: `https://player.vimeo.com/video/${videoId}`, type: "embed" }
         }
       }
       if (host === "player.vimeo.com") {
-        return { src: trimmed, type: "vimeo" }
+        return { src: trimmed, type: "embed" }
       }
       if (trimmed.match(/\.(mp4|webm|ogg)$/)) {
         return { src: trimmed, type: "video" }
@@ -192,8 +202,6 @@ export const TipTapEditor = ({
       }).run()
     }
   }, [editor, videoUrl, parseVideoUrl, setStackedOpen])
-
-  const actionsRef = useRef<TipTapActions | null>(null)
 
   useEffect(() => {
     if (editor && onEditorReady) {
@@ -216,8 +224,11 @@ export const TipTapEditor = ({
           fileInputRef.current?.click()
         },
       }
-      actionsRef.current = actions
       onEditorReady(editor, actions)
+      // On unmount the editor is destroyed, but the parent still holds this
+      // instance in a ref. Hand back null so the floating toolbar stops
+      // dispatching commands into a dead editor (it silently no-ops otherwise).
+      return () => onEditorReady(null as unknown as Editor, actions)
     }
   }, [editor, onEditorReady])
 
@@ -301,7 +312,12 @@ export const TipTapEditor = ({
           />
           <ToolbarButton label="Link" onClick={setLink} isActive={editor.isActive("link")} />
           <ToolbarButton label="Image" onClick={addImage} />
-          <ToolbarButton label="Upload" onClick={() => fileInputRef.current?.click()} />
+          <ToolbarButton
+            label={isUploading ? "Uploading…" : "Upload"}
+            onClick={() => {
+              if (!isUploading) fileInputRef.current?.click()
+            }}
+          />
           <ToolbarButton label="Video" onClick={addVideo} />
           <ToolbarButton
             label="Left"
@@ -387,6 +403,16 @@ export const TipTapEditor = ({
                 </div>
               ) : null
             })()}
+            {isUploading ? (
+              <Text size="xsmall" className="text-ui-fg-muted">
+                Uploading…
+              </Text>
+            ) : null}
+            {uploadError ? (
+              <Text size="xsmall" className="text-ui-fg-error">
+                {uploadError}
+              </Text>
+            ) : null}
           </StackedDrawer.Body>
           <StackedDrawer.Footer>
             <Button variant="secondary" onClick={() => setStackedOpen(IMAGE_MODAL_ID, false)}>
@@ -405,7 +431,12 @@ export const TipTapEditor = ({
         accept="image/*"
         multiple={false}
         style={{ display: "none" }}
-        onChange={(e) => handleFileUpload(e.target.files)}
+        onChange={(e) => {
+          const { files } = e.target
+          // Clear the value so picking the SAME file again still fires onChange.
+          e.target.value = ""
+          handleFileUpload(files)
+        }}
       />
 
       <StackedDrawer id={VIDEO_MODAL_ID}>

--- a/apps/partner-ui/src/components/tiptap-editor/tiptap-editor.tsx
+++ b/apps/partner-ui/src/components/tiptap-editor/tiptap-editor.tsx
@@ -5,10 +5,11 @@ import TextAlign from "@tiptap/extension-text-align"
 import Link from "@tiptap/extension-link"
 import Image from "@tiptap/extension-image"
 import Placeholder from "@tiptap/extension-placeholder"
-import { useCallback, useState } from "react"
-import { Button, Input, Label, Checkbox } from "@medusajs/ui"
+import { useCallback, useState, useRef } from "react"
+import { Button, Input, Label, Checkbox, Text } from "@medusajs/ui"
 import { StackedDrawer } from "../modals/stacked-drawer"
 import { useStackedModal } from "../modals/stacked-modal-provider"
+import { usePartnerUpload } from "../../hooks/api/uploads"
 
 type TipTapEditorProps = {
   content?: Record<string, unknown>
@@ -49,9 +50,14 @@ export const TipTapEditor = ({
   const [linkUrl, setLinkUrl] = useState("")
   const [linkOpenNewTab, setLinkOpenNewTab] = useState(false)
   const [imageUrl, setImageUrl] = useState("")
+  const [videoUrl, setVideoUrl] = useState("")
+  const [isUploading, setIsUploading] = useState(false)
+  const fileInputRef = useRef<HTMLInputElement>(null)
   const { setIsOpen: setStackedOpen } = useStackedModal()
+  const { mutateAsync: uploadFiles } = usePartnerUpload()
   const LINK_MODAL_ID = "tiptap-link"
   const IMAGE_MODAL_ID = "tiptap-image"
+  const VIDEO_MODAL_ID = "tiptap-video"
 
 
   const sanitizeUrl = useCallback((url: string): string => {
@@ -109,6 +115,74 @@ export const TipTapEditor = ({
       editor.chain().focus().setImage({ src: url }).run()
     }
   }, [editor, imageUrl, sanitizeUrl])
+
+  const handleFileUpload = useCallback(async (files: FileList | null) => {
+    if (!files || files.length === 0) return
+    setIsUploading(true)
+    try {
+      const result = await uploadFiles(Array.from(files))
+      const uploadedUrl = result?.files?.[0]?.url
+      if (uploadedUrl && editor) {
+        editor.chain().focus().setImage({ src: uploadedUrl }).run()
+      }
+    } catch {
+      // Fallback: show error in the image modal
+      const errUrl = ""
+      setImageUrl(errUrl)
+    } finally {
+      setIsUploading(false)
+      setStackedOpen(IMAGE_MODAL_ID, false)
+    }
+  }, [editor, uploadFiles, setStackedOpen])
+
+  const addVideo = useCallback(() => {
+    if (!editor) return
+    setVideoUrl("")
+    setStackedOpen(VIDEO_MODAL_ID, true)
+  }, [editor])
+
+  const parseVideoUrl = useCallback((url: string): { src: string; type: string } | null => {
+    const trimmed = url.trim()
+    if (!trimmed) return null
+    try {
+      const parsed = new URL(trimmed)
+      const host = parsed.hostname.replace("www.", "")
+      if (host === "youtube.com" || host === "youtu.be") {
+        const videoId = host === "youtu.be"
+          ? parsed.pathname.slice(1)
+          : parsed.searchParams.get("v") || parsed.pathname.split("/").pop()
+        if (videoId) {
+          return { src: `https://www.youtube.com/embed/${videoId}`, type: "youtube" }
+        }
+      }
+      if (host === "vimeo.com") {
+        const videoId = parsed.pathname.split("/").pop()
+        if (videoId) {
+          return { src: `https://player.vimeo.com/video/${videoId}`, type: "vimeo" }
+        }
+      }
+      if (host === "player.vimeo.com") {
+        return { src: trimmed, type: "vimeo" }
+      }
+      if (trimmed.match(/\.(mp4|webm|ogg)$/)) {
+        return { src: trimmed, type: "video" }
+      }
+      return { src: trimmed, type: "embed" }
+    } catch {
+      return null
+    }
+  }, [])
+
+  const confirmAddVideo = useCallback(() => {
+    const parsed = parseVideoUrl(videoUrl)
+    setStackedOpen(VIDEO_MODAL_ID, false)
+    if (parsed && editor) {
+      editor.chain().focus().insertContent({
+        type: parsed.type,
+        attrs: { src: parsed.src },
+      }).run()
+    }
+  }, [editor, videoUrl, parseVideoUrl, setStackedOpen])
 
   if (!editor) return null
 
@@ -190,6 +264,8 @@ export const TipTapEditor = ({
           />
           <ToolbarButton label="Link" onClick={setLink} isActive={editor.isActive("link")} />
           <ToolbarButton label="Image" onClick={addImage} />
+          <ToolbarButton label="Upload" onClick={() => fileInputRef.current?.click()} />
+          <ToolbarButton label="Video" onClick={addVideo} />
           <ToolbarButton
             label="Left"
             onClick={() => editor.chain().focus().setTextAlign("left").run()}
@@ -281,6 +357,64 @@ export const TipTapEditor = ({
             </Button>
             <Button onClick={confirmAddImage} disabled={!sanitizeUrl(imageUrl)}>
               Insert
+            </Button>
+          </StackedDrawer.Footer>
+        </StackedDrawer.Content>
+      </StackedDrawer>
+
+      <input
+        ref={fileInputRef}
+        type="file"
+        accept="image/*"
+        multiple={false}
+        style={{ display: "none" }}
+        onChange={(e) => handleFileUpload(e.target.files)}
+      />
+
+      <StackedDrawer id={VIDEO_MODAL_ID}>
+        <StackedDrawer.Content>
+          <StackedDrawer.Header>
+            <StackedDrawer.Title>Insert Video</StackedDrawer.Title>
+          </StackedDrawer.Header>
+          <StackedDrawer.Body className="space-y-4">
+            <div>
+              <Label>Video URL (YouTube, Vimeo, or MP4)</Label>
+              <Input
+                value={videoUrl}
+                onChange={(e) => setVideoUrl(e.target.value)}
+                placeholder="https://www.youtube.com/watch?v=..."
+                autoFocus
+              />
+            </div>
+            <Text size="xsmall" className="text-ui-fg-muted">
+              Paste a YouTube or Vimeo link, or a direct video file URL (MP4, WebM, OGG).
+            </Text>
+            {parseVideoUrl(videoUrl) && (
+              <div className="rounded-md border border-ui-border-base overflow-hidden max-h-40">
+                {parseVideoUrl(videoUrl)?.type === "video" ? (
+                  <video controls className="w-full h-auto">
+                    <source src={parseVideoUrl(videoUrl)?.src} />
+                  </video>
+                ) : (
+                  <div style={{ paddingBottom: "56.25%", position: "relative", height: 0 }}>
+                    <iframe
+                      src={parseVideoUrl(videoUrl)?.src}
+                      style={{ position: "absolute", top: 0, left: 0, width: "100%", height: "100%" }}
+                      frameBorder="0"
+                      allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture"
+                      allowFullScreen
+                    />
+                  </div>
+                )}
+              </div>
+            )}
+          </StackedDrawer.Body>
+          <StackedDrawer.Footer>
+            <Button variant="secondary" onClick={() => setStackedOpen(VIDEO_MODAL_ID, false)}>
+              Cancel
+            </Button>
+            <Button onClick={confirmAddVideo} disabled={!parseVideoUrl(videoUrl)}>
+              Insert Video
             </Button>
           </StackedDrawer.Footer>
         </StackedDrawer.Content>

--- a/apps/partner-ui/src/hooks/api/storefront.ts
+++ b/apps/partner-ui/src/hooks/api/storefront.ts
@@ -26,7 +26,7 @@ const invalidateStorefrontQueries = () => {
   queryClient.invalidateQueries({ queryKey: domainQueryKeys.detail("me") })
 }
 
-export type HostingProvider = "vercel" | "cloudflare" | "render" | "netlify"
+export type HostingProvider = "vercel" | "cloudflare" | "render" | "netlify" | "local"
 
 export interface StorefrontStatus {
   provisioned: boolean

--- a/apps/partner-ui/src/routes/content/content-detail/content-detail.tsx
+++ b/apps/partner-ui/src/routes/content/content-detail/content-detail.tsx
@@ -40,22 +40,19 @@ function setNestedValue(
     JSON.stringify(content || {})
   )
   const parts = field.split(".")
+  const isIndex = (p: string) => /^\d+$/.test(p)
   let obj: Record<string, unknown> = contentCopy
   for (let i = 0; i < parts.length - 1; i++) {
     const part = parts[i]
     if (UNSAFE_PROPS.has(part)) return contentCopy
-    const idx = parseInt(part, 10)
-    if (!isNaN(idx)) {
-      if (!obj[part]) {
-        obj[part] = []
-      }
-      obj = obj[part] as Record<string, unknown>
-    } else {
-      if (!obj[part]) {
-        obj[part] = {}
-      }
-      obj = obj[part] as Record<string, unknown>
+    if (obj[part] === undefined || obj[part] === null) {
+      // The container to create is decided by the NEXT segment, not this one:
+      // in `cards.0.title`, `cards` must become an array because `0` follows it.
+      // Deciding from the current segment produced `{ cards: { "0": {...} } }`,
+      // which every `cards.map(...)` renderer then choked on.
+      obj[part] = isIndex(parts[i + 1]) ? [] : {}
     }
+    obj = obj[part] as Record<string, unknown>
   }
   const lastPart = parts[parts.length - 1]
   if (UNSAFE_PROPS.has(lastPart)) return contentCopy
@@ -160,6 +157,15 @@ const ContentDetailInner = () => {
   const { mutateAsync: uploadFile } = usePartnerUpload()
 
   const handleEditorReady = useCallback((editor: any, actions: any) => {
+    // Called with null on unmount (see TipTapEditor) so a closed body-editor
+    // drawer does not leave a destroyed editor behind in the ref.
+    if (!editor) {
+      if (tiptapActionsRef.current === actions) {
+        tiptapEditorRef.current = null
+        tiptapActionsRef.current = null
+      }
+      return
+    }
     tiptapEditorRef.current = editor
     tiptapActionsRef.current = actions
   }, [])
@@ -175,6 +181,13 @@ const ContentDetailInner = () => {
   const { mutateAsync: deleteBlock } = useDeleteContentBlock(pageId!)
 
   const [blocks, setBlocks] = useState<ContentBlock[]>([])
+  // The postMessage handler below is registered once per pageId, so it closes
+  // over the `blocks` value from that render (always `[]`, since blocks load
+  // async). Mirror the state into a ref so the handler reads it live —
+  // without this, OPEN_BODY_EDITOR never finds its block (drawer never opens)
+  // and nested BLOCK_FIELD_EDITED sends an empty body (edit never persists).
+  const blocksRef = useRef<ContentBlock[]>([])
+  blocksRef.current = blocks
   const [selectedBlockId, setSelectedBlockId] = useState<string | null>(null)
   const [saveStatus, setSaveStatus] = useState<"saved" | "saving" | "unsaved">("saved")
   const [iframeReady, setIframeReady] = useState(false)
@@ -222,7 +235,7 @@ const ContentDetailInner = () => {
         setSaveStatus("saving")
         const contentUpdate = (() => {
           if (isNested) {
-            const block = blocks.find((b) => b.id === blockId)
+            const block = blocksRef.current.find((b) => b.id === blockId)
             if (!block) return {}
             return { content: setNestedValue(block.content, field, value) }
           }
@@ -258,7 +271,7 @@ const ContentDetailInner = () => {
       }
       if (data.type === "OPEN_BODY_EDITOR") {
         const { blockId, field } = data as any
-        const block = blocks.find((b) => b.id === blockId)
+        const block = blocksRef.current.find((b) => b.id === blockId)
         if (!block) return
         setBodyEditorBlockId(blockId)
         setBodyEditorField(field)
@@ -273,7 +286,7 @@ const ContentDetailInner = () => {
         const { command } = data as { command?: string }
         const editor = tiptapEditorRef.current
         const actions = tiptapActionsRef.current
-        if (!editor || !command) return
+        if (!editor || editor.isDestroyed || !command) return
 
         switch (command) {
           case "toggleBold":

--- a/apps/partner-ui/src/routes/content/content-detail/content-detail.tsx
+++ b/apps/partner-ui/src/routes/content/content-detail/content-detail.tsx
@@ -28,6 +28,7 @@ import {
 import { StackedDrawer } from "../../../components/modals/stacked-drawer"
 import { Skeleton } from "../../../components/common/skeleton"
 import { BlockEditor } from "../../../components/block-editor/block-editor"
+import { TipTapEditor } from "../../../components/tiptap-editor/tiptap-editor"
 import {
   useContentPage,
   useContentBlocks,
@@ -41,6 +42,7 @@ import {
 } from "../../../hooks/api/content"
 import { useStorefrontStatus } from "../../../hooks/api/storefront"
 import { FetchError } from "@medusajs/js-sdk"
+import { usePartnerUpload } from "../../../hooks/api/uploads"
 
 const BLOCK_TYPES = [
   "Hero",
@@ -117,6 +119,16 @@ const ContentDetailInner = () => {
   const navigate = useNavigate()
   const { handleSuccess } = useRouteModal()
   const iframeRef = useRef<HTMLIFrameElement>(null)
+  const toolbarFileInputRef = useRef<HTMLInputElement>(null)
+  const toolbarUploadBlockIdRef = useRef<string | null>(null)
+  const tiptapEditorRef = useRef<any>(null)
+  const tiptapActionsRef = useRef<any>(null)
+  const { mutateAsync: uploadFile } = usePartnerUpload()
+
+  const handleEditorReady = useCallback((editor: any, actions: any) => {
+    tiptapEditorRef.current = editor
+    tiptapActionsRef.current = actions
+  }, [])
 
   const { page, isPending: pageLoading } = useContentPage(pageId!)
   const { blocks: initialBlocks, isPending: blocksLoading } = useContentBlocks(pageId!)
@@ -134,8 +146,12 @@ const ContentDetailInner = () => {
   const [iframeReady, setIframeReady] = useState(false)
   const { setIsOpen: setStackedOpen } = useStackedModal()
   const ADD_BLOCK_ID = "add-block"
+  const BODY_EDITOR_ID = "body-editor"
   const [newBlockType, setNewBlockType] = useState<string>("MainContent")
   const [newBlockName, setNewBlockName] = useState("")
+  const [bodyEditorBlockId, setBodyEditorBlockId] = useState<string | null>(null)
+  const [bodyEditorField, setBodyEditorField] = useState<string>("body")
+  const [bodyEditorContent, setBodyEditorContent] = useState<Record<string, unknown> | null>(null)
 
   const storefrontUrl = storefrontStatus?.storefront_url
 
@@ -157,18 +173,55 @@ const ContentDetailInner = () => {
         }, 200)
       }
       if (data.type === "BLOCK_FIELD_EDITED") {
-        const { blockId, field, value } = data
+        const { blockId, field, value, isHtml } = data as any
+        const isNested = field.includes(".")
+
         setBlocks((prev) =>
-          prev.map((b) =>
-            b.id === blockId
-              ? { ...b, content: { ...b.content, [field]: value } }
-              : b
-          )
+          prev.map((b) => {
+            if (b.id !== blockId) return b
+            if (isNested) {
+              const parts = field.split(".")
+              const contentCopy = JSON.parse(JSON.stringify(b.content || {}))
+              let obj = contentCopy
+              for (let i = 0; i < parts.length - 1; i++) {
+                const idx = parseInt(parts[i], 10)
+                if (!isNaN(idx)) {
+                  obj = obj[parts[i]] = obj[parts[i]] || []
+                } else {
+                  obj = obj[parts[i]] = obj[parts[i]] || {}
+                }
+              }
+              const lastKey = parts[parts.length - 1]
+              const lastIdx = parseInt(lastKey, 10)
+              if (!isNaN(lastIdx)) {
+                obj[lastKey] = value
+              } else {
+                obj[lastKey] = value
+              }
+              return { ...b, content: contentCopy }
+            }
+            return { ...b, content: { ...b.content, [field]: value } }
+          })
         )
         setSaveStatus("saving")
+        const contentUpdate = (() => {
+          if (isNested) {
+            const parts = field.split(".")
+            const block = blocks.find((b) => b.id === blockId)
+            if (!block) return {}
+            const contentCopy = JSON.parse(JSON.stringify(block.content || {}))
+            let obj = contentCopy
+            for (let i = 0; i < parts.length - 1; i++) {
+              obj = obj[parts[i]] = obj[parts[i]] || []
+            }
+            obj[parts[parts.length - 1]] = value
+            return { content: contentCopy }
+          }
+          return { content: { [field]: value } }
+        })()
         updateBlock({
           blockId,
-          body: { content: { [field]: value } },
+          body: contentUpdate,
         })
           .then(() => setSaveStatus("saved"))
           .catch(() => setSaveStatus("unsaved"))
@@ -193,6 +246,47 @@ const ContentDetailInner = () => {
       }
       if (data.type === "REQUEST_ADD_BLOCK_AT") {
         setStackedOpen(ADD_BLOCK_ID, true)
+      }
+      if (data.type === "OPEN_BODY_EDITOR") {
+        const { blockId, field } = data as any
+        const block = blocks.find((b) => b.id === blockId)
+        if (!block) return
+        setBodyEditorBlockId(blockId)
+        setBodyEditorField(field)
+        setBodyEditorContent((block.content[field] as Record<string, unknown>) || null)
+        setStackedOpen(BODY_EDITOR_ID, true)
+      }
+      if (data.type === "REQUEST_IMAGE_UPLOAD") {
+        toolbarUploadBlockIdRef.current = (data as any).blockId
+        toolbarFileInputRef.current?.click()
+      }
+      if (data.type === "TOOLBAR_COMMAND") {
+        const { command } = data as any
+        const editor = tiptapEditorRef.current
+        const actions = tiptapActionsRef.current
+        if (!editor) return
+
+        const cmdMap: Record<string, () => void> = {
+          toggleBold: () => editor.chain().focus().toggleBold().run(),
+          toggleItalic: () => editor.chain().focus().toggleItalic().run(),
+          toggleUnderline: () => editor.chain().focus().toggleUnderline().run(),
+          toggleHeading1: () => editor.chain().focus().toggleHeading({ level: 1 }).run(),
+          toggleHeading2: () => editor.chain().focus().toggleHeading({ level: 2 }).run(),
+          toggleHeading3: () => editor.chain().focus().toggleHeading({ level: 3 }).run(),
+          toggleBulletList: () => editor.chain().focus().toggleBulletList().run(),
+          toggleOrderedList: () => editor.chain().focus().toggleOrderedList().run(),
+          toggleBlockquote: () => editor.chain().focus().toggleBlockquote().run(),
+          toggleCodeBlock: () => editor.chain().focus().toggleCodeBlock().run(),
+          alignLeft: () => editor.chain().focus().setTextAlign("left").run(),
+          alignCenter: () => editor.chain().focus().setTextAlign("center").run(),
+          alignRight: () => editor.chain().focus().setTextAlign("right").run(),
+          setLink: () => actions?.setLink(),
+          addImage: () => actions?.addImage(),
+          addVideo: () => actions?.addVideo(),
+          triggerUpload: () => actions?.triggerUpload(),
+        }
+        const fn = cmdMap[command]
+        if (fn) fn()
       }
     }
     window.addEventListener("message", handleMessage)
@@ -500,9 +594,33 @@ const ContentDetailInner = () => {
                 ref={iframeRef}
                 src={previewUrl}
                 className="w-full h-full border-0"
-                sandbox="allow-scripts allow-same-origin allow-forms"
+                sandbox="allow-scripts allow-same-origin allow-forms allow-modals"
               />
             </div>
+            <input
+              ref={toolbarFileInputRef}
+              type="file"
+              accept="image/*"
+              className="hidden"
+              onChange={async (e) => {
+                const file = e.target.files?.[0]
+                if (!file || !toolbarUploadBlockIdRef.current) return
+                try {
+                  const result = await uploadFile(file)
+                  const imageUrl = result.url || result.id
+                  if (iframeRef.current?.contentWindow) {
+                    iframeRef.current.contentWindow.postMessage(
+                      { type: "INSERT_IMAGE_AT_CURSOR", imageUrl },
+                      "*"
+                    )
+                  }
+                  toast.success("Image uploaded")
+                } catch {
+                  toast.error("Upload failed")
+                }
+                if (toolbarFileInputRef.current) toolbarFileInputRef.current.value = ""
+              }}
+            />
           </div>
 
           {/* Property panel */}
@@ -567,6 +685,7 @@ const ContentDetailInner = () => {
               canMoveUp={blocks.findIndex((b) => b.id === selectedBlock.id) > 0}
               canMoveDown={blocks.findIndex((b) => b.id === selectedBlock.id) < blocks.length - 1}
               saveStatus={saveStatus}
+              onEditorReady={handleEditorReady}
             />
           ) : (
             <div className="w-[340px] border-l border-ui-border-base flex flex-col items-center justify-center p-6 text-center shrink-0">
@@ -656,6 +775,63 @@ const ContentDetailInner = () => {
             <Plus className="mr-1.5" />Add Block
           </Button>
         </StackedDrawer.Footer>
+        </StackedDrawer.Content>
+      </StackedDrawer>
+
+      {/* Body Editor Drawer */}
+      <StackedDrawer id={BODY_EDITOR_ID}>
+        <StackedDrawer.Content>
+          <StackedDrawer.Header>
+            <StackedDrawer.Title>Rich Text Editor</StackedDrawer.Title>
+          </StackedDrawer.Header>
+          <StackedDrawer.Body>
+            {bodyEditorBlockId && (
+              <TipTapEditor
+                key={bodyEditorBlockId + "-" + bodyEditorField}
+                content={bodyEditorContent || undefined}
+                onChange={(json) => setBodyEditorContent(json)}
+                placeholder="Start writing..."
+                onEditorReady={handleEditorReady}
+              />
+            )}
+          </StackedDrawer.Body>
+          <StackedDrawer.Footer>
+            <Button
+              variant="secondary"
+              onClick={() => setStackedOpen(BODY_EDITOR_ID, false)}
+            >
+              Cancel
+            </Button>
+            <Button
+              onClick={() => {
+                if (!bodyEditorBlockId) return
+                setBlocks((prev) =>
+                  prev.map((b) =>
+                    b.id === bodyEditorBlockId
+                      ? { ...b, content: { ...b.content, [bodyEditorField]: bodyEditorContent } }
+                      : b
+                  )
+                )
+                setSaveStatus("saving")
+                updateBlock({
+                  blockId: bodyEditorBlockId,
+                  body: { content: { [bodyEditorField]: bodyEditorContent } },
+                })
+                  .then(() => {
+                    setSaveStatus("saved")
+                    setStackedOpen(BODY_EDITOR_ID, false)
+                    if (iframeRef.current) {
+                      setTimeout(() => {
+                        if (iframeRef.current) iframeRef.current.src = iframeRef.current.src
+                      }, 300)
+                    }
+                  })
+                  .catch(() => setSaveStatus("unsaved"))
+              }}
+            >
+              Save & Close
+            </Button>
+          </StackedDrawer.Footer>
         </StackedDrawer.Content>
       </StackedDrawer>
     </>

--- a/apps/partner-ui/src/routes/content/content-detail/content-detail.tsx
+++ b/apps/partner-ui/src/routes/content/content-detail/content-detail.tsx
@@ -31,10 +31,6 @@ import { BlockEditor } from "../../../components/block-editor/block-editor"
 
 const UNSAFE_PROPS = new Set(["__proto__", "constructor", "prototype"])
 
-function isSafeFieldPart(part: string): boolean {
-  return !UNSAFE_PROPS.has(part)
-}
-
 function setNestedValue(
   content: Record<string, unknown>,
   field: string,
@@ -44,25 +40,26 @@ function setNestedValue(
     JSON.stringify(content || {})
   )
   const parts = field.split(".")
-  if (!parts.every(isSafeFieldPart)) {
-    return contentCopy
-  }
   let obj: Record<string, unknown> = contentCopy
   for (let i = 0; i < parts.length - 1; i++) {
-    const idx = parseInt(parts[i], 10)
+    const part = parts[i]
+    if (UNSAFE_PROPS.has(part)) return contentCopy
+    const idx = parseInt(part, 10)
     if (!isNaN(idx)) {
-      if (!obj[parts[i]]) {
-        obj[parts[i]] = []
+      if (!obj[part]) {
+        obj[part] = []
       }
-      obj = obj[parts[i]] as Record<string, unknown>
+      obj = obj[part] as Record<string, unknown>
     } else {
-      if (!obj[parts[i]]) {
-        obj[parts[i]] = {}
+      if (!obj[part]) {
+        obj[part] = {}
       }
-      obj = obj[parts[i]] as Record<string, unknown>
+      obj = obj[part] as Record<string, unknown>
     }
   }
-  obj[parts[parts.length - 1]] = value
+  const lastPart = parts[parts.length - 1]
+  if (UNSAFE_PROPS.has(lastPart)) return contentCopy
+  obj[lastPart] = value
   return contentCopy
 }
 import { TipTapEditor } from "../../../components/tiptap-editor/tiptap-editor"
@@ -273,34 +270,66 @@ const ContentDetailInner = () => {
         toolbarFileInputRef.current?.click()
       }
       if (data.type === "TOOLBAR_COMMAND") {
-        const { command } = data as any
+        const { command } = data as { command?: string }
         const editor = tiptapEditorRef.current
         const actions = tiptapActionsRef.current
-        if (!editor) return
+        if (!editor || !command) return
 
-        const cmdMap: Record<string, () => void> = {
-          toggleBold: () => editor.chain().focus().toggleBold().run(),
-          toggleItalic: () => editor.chain().focus().toggleItalic().run(),
-          toggleUnderline: () => editor.chain().focus().toggleUnderline().run(),
-          toggleHeading1: () => editor.chain().focus().toggleHeading({ level: 1 }).run(),
-          toggleHeading2: () => editor.chain().focus().toggleHeading({ level: 2 }).run(),
-          toggleHeading3: () => editor.chain().focus().toggleHeading({ level: 3 }).run(),
-          toggleBulletList: () => editor.chain().focus().toggleBulletList().run(),
-          toggleOrderedList: () => editor.chain().focus().toggleOrderedList().run(),
-          toggleBlockquote: () => editor.chain().focus().toggleBlockquote().run(),
-          toggleCodeBlock: () => editor.chain().focus().toggleCodeBlock().run(),
-          alignLeft: () => editor.chain().focus().setTextAlign("left").run(),
-          alignCenter: () => editor.chain().focus().setTextAlign("center").run(),
-          alignRight: () => editor.chain().focus().setTextAlign("right").run(),
-          setLink: () => actions?.setLink(),
-          addImage: () => actions?.addImage(),
-          addVideo: () => actions?.addVideo(),
-          triggerUpload: () => actions?.triggerUpload(),
+        switch (command) {
+          case "toggleBold":
+            editor.chain().focus().toggleBold().run()
+            break
+          case "toggleItalic":
+            editor.chain().focus().toggleItalic().run()
+            break
+          case "toggleUnderline":
+            editor.chain().focus().toggleUnderline().run()
+            break
+          case "toggleHeading1":
+            editor.chain().focus().toggleHeading({ level: 1 }).run()
+            break
+          case "toggleHeading2":
+            editor.chain().focus().toggleHeading({ level: 2 }).run()
+            break
+          case "toggleHeading3":
+            editor.chain().focus().toggleHeading({ level: 3 }).run()
+            break
+          case "toggleBulletList":
+            editor.chain().focus().toggleBulletList().run()
+            break
+          case "toggleOrderedList":
+            editor.chain().focus().toggleOrderedList().run()
+            break
+          case "toggleBlockquote":
+            editor.chain().focus().toggleBlockquote().run()
+            break
+          case "toggleCodeBlock":
+            editor.chain().focus().toggleCodeBlock().run()
+            break
+          case "alignLeft":
+            editor.chain().focus().setTextAlign("left").run()
+            break
+          case "alignCenter":
+            editor.chain().focus().setTextAlign("center").run()
+            break
+          case "alignRight":
+            editor.chain().focus().setTextAlign("right").run()
+            break
+          case "setLink":
+            actions?.setLink()
+            break
+          case "addImage":
+            actions?.addImage()
+            break
+          case "addVideo":
+            actions?.addVideo()
+            break
+          case "triggerUpload":
+            actions?.triggerUpload()
+            break
+          default:
+            break
         }
-        const fn = Object.prototype.hasOwnProperty.call(cmdMap, command)
-          ? cmdMap[command]
-          : undefined
-        if (fn) fn()
       }
     }
     window.addEventListener("message", handleMessage)

--- a/apps/partner-ui/src/routes/content/content-detail/content-detail.tsx
+++ b/apps/partner-ui/src/routes/content/content-detail/content-detail.tsx
@@ -10,7 +10,6 @@ import {
   IconButton,
   Select,
   Label,
-  Drawer,
   Input,
 } from "@medusajs/ui"
 import {
@@ -24,7 +23,9 @@ import {
 import {
   RouteFocusModal,
   useRouteModal,
+  useStackedModal,
 } from "../../../components/modals"
+import { StackedDrawer } from "../../../components/modals/stacked-drawer"
 import { Skeleton } from "../../../components/common/skeleton"
 import { BlockEditor } from "../../../components/block-editor/block-editor"
 import {
@@ -105,11 +106,12 @@ const ContentDetailInner = () => {
   const [selectedBlockId, setSelectedBlockId] = useState<string | null>(null)
   const [saveStatus, setSaveStatus] = useState<"saved" | "saving" | "unsaved">("saved")
   const [iframeReady, setIframeReady] = useState(false)
-  const [addBlockOpen, setAddBlockOpen] = useState(false)
+  const { setIsOpen: setStackedOpen } = useStackedModal()
+  const ADD_BLOCK_ID = "add-block"
   const [newBlockType, setNewBlockType] = useState<string>("MainContent")
   const [newBlockName, setNewBlockName] = useState("")
 
-  const domain = storefrontStatus?.domain
+  const storefrontUrl = storefrontStatus?.storefront_url
 
   useEffect(() => {
     if (initialBlocks?.length) {
@@ -164,7 +166,7 @@ const ContentDetailInner = () => {
         }
       }
       if (data.type === "REQUEST_ADD_BLOCK_AT") {
-        setAddBlockOpen(true)
+        setStackedOpen(ADD_BLOCK_ID, true)
       }
     }
     window.addEventListener("message", handleMessage)
@@ -259,7 +261,7 @@ const ContentDetailInner = () => {
         setBlocks((prev) => [...prev, newBlock])
         setSelectedBlockId(newBlock.id)
       }
-      setAddBlockOpen(false)
+      setStackedOpen(ADD_BLOCK_ID, false)
       setNewBlockName("")
       toast.success(`Added "${name}" block`)
       if (iframeRef.current) {
@@ -319,8 +321,8 @@ const ContentDetailInner = () => {
   }
 
   const countryCode = "in"
-  const previewUrl = domain
-    ? `https://${domain}/${countryCode}/pages/${page?.slug || ""}?visual_editor=true`
+  const previewUrl = storefrontUrl
+    ? `${storefrontUrl}/${countryCode}/pages/${page?.slug || ""}?visual_editor=true`
     : `http://localhost:8000/${countryCode}/pages/${page?.slug || ""}?visual_editor=true`
 
   const isPublished = page?.status === "Published"
@@ -427,7 +429,7 @@ const ContentDetailInner = () => {
                     (t) => !usedUniqueTypes.has(t)
                   )
                   if (available) setNewBlockType(available)
-                  setAddBlockOpen(true)
+                  setStackedOpen(ADD_BLOCK_ID, true)
                 }}
               >
                 <Plus className="mr-1" />Add
@@ -555,11 +557,12 @@ const ContentDetailInner = () => {
       </RouteFocusModal.Body>
 
       {/* Add Block Drawer */}
-      <Drawer open={addBlockOpen} onOpenChange={setAddBlockOpen}>
-        <Drawer.Header>
-          <Drawer.Title>Add New Block</Drawer.Title>
-        </Drawer.Header>
-        <Drawer.Body className="space-y-4">
+      <StackedDrawer id={ADD_BLOCK_ID}>
+        <StackedDrawer.Content>
+        <StackedDrawer.Header>
+          <StackedDrawer.Title>Add New Block</StackedDrawer.Title>
+        </StackedDrawer.Header>
+        <StackedDrawer.Body className="space-y-4">
           <div>
             <Label>Block Type</Label>
             <Select value={newBlockType} onValueChange={setNewBlockType}>
@@ -615,16 +618,17 @@ const ContentDetailInner = () => {
               {newBlockType === "Custom" && "Custom block with full rich text editor."}
             </Text>
           </div>
-        </Drawer.Body>
-        <Drawer.Footer>
-          <Button variant="secondary" onClick={() => setAddBlockOpen(false)}>
+        </StackedDrawer.Body>
+        <StackedDrawer.Footer>
+          <Button variant="secondary" onClick={() => setStackedOpen(ADD_BLOCK_ID, false)}>
             Cancel
           </Button>
           <Button onClick={handleAddBlock} disabled={isCreatingBlock}>
             <Plus className="mr-1.5" />Add Block
           </Button>
-        </Drawer.Footer>
-      </Drawer>
+        </StackedDrawer.Footer>
+        </StackedDrawer.Content>
+      </StackedDrawer>
     </>
   )
 }

--- a/apps/partner-ui/src/routes/content/content-detail/content-detail.tsx
+++ b/apps/partner-ui/src/routes/content/content-detail/content-detail.tsx
@@ -28,6 +28,43 @@ import {
 import { StackedDrawer } from "../../../components/modals/stacked-drawer"
 import { Skeleton } from "../../../components/common/skeleton"
 import { BlockEditor } from "../../../components/block-editor/block-editor"
+
+const UNSAFE_PROPS = new Set(["__proto__", "constructor", "prototype"])
+
+function isSafeFieldPart(part: string): boolean {
+  return !UNSAFE_PROPS.has(part)
+}
+
+function setNestedValue(
+  content: Record<string, unknown>,
+  field: string,
+  value: unknown
+): Record<string, unknown> {
+  const contentCopy: Record<string, unknown> = JSON.parse(
+    JSON.stringify(content || {})
+  )
+  const parts = field.split(".")
+  if (!parts.every(isSafeFieldPart)) {
+    return contentCopy
+  }
+  let obj: Record<string, unknown> = contentCopy
+  for (let i = 0; i < parts.length - 1; i++) {
+    const idx = parseInt(parts[i], 10)
+    if (!isNaN(idx)) {
+      if (!obj[parts[i]]) {
+        obj[parts[i]] = []
+      }
+      obj = obj[parts[i]] as Record<string, unknown>
+    } else {
+      if (!obj[parts[i]]) {
+        obj[parts[i]] = {}
+      }
+      obj = obj[parts[i]] as Record<string, unknown>
+    }
+  }
+  obj[parts[parts.length - 1]] = value
+  return contentCopy
+}
 import { TipTapEditor } from "../../../components/tiptap-editor/tiptap-editor"
 import {
   useContentPage,
@@ -180,25 +217,7 @@ const ContentDetailInner = () => {
           prev.map((b) => {
             if (b.id !== blockId) return b
             if (isNested) {
-              const parts = field.split(".")
-              const contentCopy = JSON.parse(JSON.stringify(b.content || {}))
-              let obj = contentCopy
-              for (let i = 0; i < parts.length - 1; i++) {
-                const idx = parseInt(parts[i], 10)
-                if (!isNaN(idx)) {
-                  obj = obj[parts[i]] = obj[parts[i]] || []
-                } else {
-                  obj = obj[parts[i]] = obj[parts[i]] || {}
-                }
-              }
-              const lastKey = parts[parts.length - 1]
-              const lastIdx = parseInt(lastKey, 10)
-              if (!isNaN(lastIdx)) {
-                obj[lastKey] = value
-              } else {
-                obj[lastKey] = value
-              }
-              return { ...b, content: contentCopy }
+              return { ...b, content: setNestedValue(b.content, field, value) }
             }
             return { ...b, content: { ...b.content, [field]: value } }
           })
@@ -206,16 +225,9 @@ const ContentDetailInner = () => {
         setSaveStatus("saving")
         const contentUpdate = (() => {
           if (isNested) {
-            const parts = field.split(".")
             const block = blocks.find((b) => b.id === blockId)
             if (!block) return {}
-            const contentCopy = JSON.parse(JSON.stringify(block.content || {}))
-            let obj = contentCopy
-            for (let i = 0; i < parts.length - 1; i++) {
-              obj = obj[parts[i]] = obj[parts[i]] || []
-            }
-            obj[parts[parts.length - 1]] = value
-            return { content: contentCopy }
+            return { content: setNestedValue(block.content, field, value) }
           }
           return { content: { [field]: value } }
         })()
@@ -285,7 +297,9 @@ const ContentDetailInner = () => {
           addVideo: () => actions?.addVideo(),
           triggerUpload: () => actions?.triggerUpload(),
         }
-        const fn = cmdMap[command]
+        const fn = Object.prototype.hasOwnProperty.call(cmdMap, command)
+          ? cmdMap[command]
+          : undefined
         if (fn) fn()
       }
     }

--- a/apps/partner-ui/src/routes/content/content-detail/content-detail.tsx
+++ b/apps/partner-ui/src/routes/content/content-detail/content-detail.tsx
@@ -54,6 +54,9 @@ const BLOCK_TYPES = [
   "Header",
   "Footer",
   "Custom",
+  "HeroWithImage",
+  "BentoGrid",
+  "Button",
 ] as const
 
 const UNIQUE_BLOCK_TYPES = new Set([
@@ -76,6 +79,29 @@ const DEFAULT_CONTENT_FOR_TYPE: Record<string, Record<string, unknown>> = {
   Header: { links: [] },
   Footer: { text: "" },
   Custom: { title: "Custom Block", body: { type: "doc", content: [{ type: "paragraph" }] } },
+  HeroWithImage: {
+    eyebrow: "",
+    title: "New Hero with Image",
+    subtitle: "",
+    layout: "image-right",
+    image_url: "",
+    image_alt: "",
+    buttons: [{ label: "Shop Now", href: "#", variant: "primary" }],
+  },
+  BentoGrid: {
+    title: "Bento Grid",
+    subtitle: "",
+    columns: "3",
+    cards: [
+      { eyebrow: "", title: "Card 1", description: "Description here", col_span: "1", row_span: "1" },
+      { eyebrow: "", title: "Card 2", description: "Description here", col_span: "1", row_span: "1" },
+      { eyebrow: "", title: "Card 3", description: "Description here", col_span: "1", row_span: "1" },
+    ],
+  },
+  Button: {
+    align: "left",
+    buttons: [{ label: "Click Me", href: "#", variant: "primary", size: "medium" }],
+  },
 }
 
 export const ContentDetail = () => {
@@ -616,6 +642,9 @@ const ContentDetailInner = () => {
               {newBlockType === "Header" && "Page header with navigation links."}
               {newBlockType === "Footer" && "Page footer with text and links."}
               {newBlockType === "Custom" && "Custom block with full rich text editor."}
+              {newBlockType === "HeroWithImage" && "Hero section with title, subtitle, side image, and CTA buttons. Choose left/right image layout."}
+              {newBlockType === "BentoGrid" && "Bento grid layout with cards of varying sizes. Each card has eyebrow, title, description, and optional image with col/row span controls."}
+              {newBlockType === "Button" && "Standalone CTA button row. Add multiple buttons with labels, links, variants, and sizes."}
             </Text>
           </div>
         </StackedDrawer.Body>

--- a/apps/partner-ui/src/routes/settings/stores/stores.tsx
+++ b/apps/partner-ui/src/routes/settings/stores/stores.tsx
@@ -55,6 +55,8 @@ function hostingProviderLabel(provider: string | undefined): string {
       return "Netlify"
     case "render":
       return "Render"
+    case "local":
+      return "Local Dev"
     default:
       return "—"
   }
@@ -675,6 +677,7 @@ const CustomDomainSection = () => {
 const StorefrontDomainWrapper = () => {
   const { data: status, isPending } = useStorefrontStatus()
   if (isPending || !status?.provisioned) return null
+  if (status.provider === "local") return null
   return <CustomDomainSection />
 }
 


### PR DESCRIPTION
## Summary

- **Body editor drawer**: Clicking body text in the canvas opens a StackedDrawer with the full TipTap editor (H1/H2/H3/B/I/U/UL/OL/Quote/Code/Link/Image/Upload/Video/alignment) instead of using contentEditable inline
- **Floating toolbar**: Sends `TOOLBAR_COMMAND` messages to the parent which forwards to the TipTap editor instance — no more `document.execCommand`
- **Inline editing fix**: Simple text fields (title, subtitle, eyebrow, card titles) are now properly `contentEditable` — fixed `isRichText` check that was misclassifying simple text fields, added `user-select: text`, synchronous `enableInlineEditing` on first click, auto-focus with cursor placement
- **Toolbar spacing**: Increased offset from 44px to 56px above the block
- **onEditorReady**: TipTapEditor exposes editor instance + actions (setLink, addImage, addVideo, triggerUpload) via callback, wired through BlockEditor to all instances
- **Settings persistence**: Public web API now includes `settings` in block response
- **Nested field editing**: Dotted field paths (cards.0.title, testimonials.0.quote) supported in BLOCK_FIELD_EDITED handler
- **SpacingControl**: Replaced 8 individual padding inputs with slider + per-side advanced mode
- **New block editors**: HeroWithImage, BentoGrid, ButtonBlock with expanded advanced settings

## Submodule
- storefront-starter: `feat/block-enhancements` branch, commit `76d1050`

## Test
- Click a block on the canvas → simple text fields (title, subtitle) should be editable inline with cursor placement
- Click on body text → StackedDrawer opens with full TipTap editor
- Floating toolbar buttons forward to TipTap editor in side panel
- Save & Close in body editor drawer updates the preview