### PR TITLE
feat(quote): the DDP undertaking — three charges, entered as rates, honoured end to end (#1447)

### DIFF
--- a/apps/backend/integration-tests/http/partner-quote-tax-jurisdiction.spec.ts
+++ b/apps/backend/integration-tests/http/partner-quote-tax-jurisdiction.spec.ts
@@ -316,5 +316,42 @@ setupSharedTestSuite(() => {
       expect(quote.tax.status).toBe("zero_rated_export")
       expect(quote.tax.reason).toMatch(/payable by you/i)
     })
+
+    it("quotes DDP when the partner absorbs the duty, and freezes the undertaking", async () => {
+      const minted = await mintRaw({
+        buyer_email: `buyer-ddp-${seed.unique}@jaalyantra.test`,
+        destination_country_code: "de",
+        destination_postal_code: "10115",
+        destination_city: "Berlin",
+        duties_prepaid: true,
+      })
+
+      const row = await readQuote(minted.quote.id)
+      expect(row.duties_prepaid).toBe(true)
+      // Still a zero-rated export — DDP is about the DESTINATION's duty and has
+      // no bearing on how the origin treats the export.
+      expect(row.quoted_tax_status).toBe("zero_rated_export")
+      expect(row.quoted_tax_reason).toMatch(/nothing further to pay on delivery/i)
+      expect(row.quoted_tax_reason).not.toMatch(/payable by you/i)
+
+      // And the buyer sees the promise, not the warning.
+      const quote = await viewByToken(minted.token)
+      expect(quote.tax.reason).toMatch(/nothing further to pay on delivery/i)
+    })
+
+    it("🔴 defaults to buyer-pays — an omitted flag is never a promise", async () => {
+      const minted = await mintRaw({
+        buyer_email: `buyer-noddp-${seed.unique}@jaalyantra.test`,
+        destination_country_code: "de",
+        destination_postal_code: "10115",
+        destination_city: "Berlin",
+      })
+
+      const row = await readQuote(minted.quote.id)
+      expect(row.duties_prepaid).toBe(false)
+      // Over-warning costs a conversation; under-warning costs the buyer a
+      // customs bill they were told would not come.
+      expect(row.quoted_tax_reason).toMatch(/payable by you/i)
+    })
   })
 })

--- a/apps/backend/integration-tests/http/partner-quote-tax-jurisdiction.spec.ts
+++ b/apps/backend/integration-tests/http/partner-quote-tax-jurisdiction.spec.ts
@@ -324,8 +324,10 @@ setupSharedTestSuite(() => {
         destination_postal_code: "10115",
         destination_city: "Berlin",
         duties_prepaid: true,
-        duty_total: 12_000,
-        duty_basis: "EU 12% ad valorem, HS 6304.92",
+        duty_rate_percent: 8,
+        import_tax_rate_percent: 21,
+        ddp_fee_total: 1_981.57,
+        duty_basis: "EU: 8% duty, 21% NL VAT, HS 6304.92",
       })
 
       const row = await readQuote(minted.quote.id)
@@ -336,23 +338,35 @@ setupSharedTestSuite(() => {
       expect(row.quoted_tax_reason).toMatch(/nothing further to pay on delivery/i)
       expect(row.quoted_tax_reason).not.toMatch(/payable by you/i)
 
-      // 🔴 The INSERT is what a unit test cannot reach: a DML `bigNumber` is two
-      // columns, and a missing `raw_quoted_duty_total` fails here and nowhere else.
-      expect(Number(row.quoted_duty_total)).toBe(12_000)
-      expect(row.quoted_duty_basis).toBe("EU 12% ad valorem, HS 6304.92")
+      // 🔴 The INSERT is what a unit test cannot reach: each DML `bigNumber` is
+      // two columns, and a missing `raw_quoted_import_tax_total` fails here and
+      // nowhere else — model, tsc and every unit test pass without it.
+      const dutiable =
+        Number(row.quoted_subtotal) + Number(row.quoted_freight)
+      expect(Number(row.quoted_duty_total)).toBeCloseTo(dutiable * 0.08, 2)
+      expect(Number(row.quoted_import_tax_total)).toBeCloseTo(
+        (dutiable + Number(row.quoted_duty_total)) * 0.21,
+        2
+      )
+      expect(Number(row.quoted_ddp_fee_total)).toBeCloseTo(1_981.57, 2)
+      // The rates freeze too, so the amounts can be checked against a carrier
+      // invoice months later rather than merely believed.
+      expect(Number(row.quoted_duty_rate)).toBe(8)
+      expect(Number(row.quoted_import_tax_rate)).toBe(21)
+      expect(row.quoted_duty_basis).toBe("EU: 8% duty, 21% NL VAT, HS 6304.92")
 
-      // And the buyer sees the promise, the number behind it, and a total that
-      // actually contains it — the promise used to add nothing to the price.
+      // And the buyer sees the promise, the numbers behind it, and a total that
+      // actually contains them — the promise used to add nothing to the price.
       const quote = await viewByToken(minted.token)
       expect(quote.tax.reason).toMatch(/nothing further to pay on delivery/i)
-      expect(quote.duty).toEqual({
-        prepaid: true,
-        total: 12_000,
-        basis: "EU 12% ad valorem, HS 6304.92",
-      })
-      expect(quote.quoted.duty_total).toBe(12_000)
-      expect(quote.quoted.gross_total).toBe(
-        quote.quoted.landed_total + 12_000
+      expect(quote.duty.prepaid).toBe(true)
+      expect(quote.duty.import_tax).toBeGreaterThan(quote.duty.total)
+      expect(quote.quoted.gross_total).toBeCloseTo(
+        quote.quoted.landed_total +
+          quote.quoted.duty_total +
+          quote.quoted.import_tax_total +
+          quote.quoted.ddp_fee_total,
+        2
       )
     })
 
@@ -389,7 +403,8 @@ setupSharedTestSuite(() => {
         destination_postal_code: "10115",
         destination_city: "Berlin",
         duties_prepaid: true,
-        duty_total: 0,
+        duty_rate_percent: 0,
+        import_tax_rate_percent: 0,
         duty_basis: "GSP relief — 0% on HS 6304.92 for IN origin",
       })
 
@@ -397,6 +412,9 @@ setupSharedTestSuite(() => {
       // 0, not null: the difference between "checked, nil" and "left blank" is
       // the entire reason the basis column exists.
       expect(Number(row.quoted_duty_total)).toBe(0)
+      expect(Number(row.quoted_import_tax_total)).toBe(0)
+      // 0 with a rate of 0 recorded beside it — "checked, nil", not "blank".
+      expect(Number(row.quoted_duty_rate)).toBe(0)
       expect(row.quoted_duty_basis).toMatch(/GSP relief/i)
     })
 

--- a/apps/backend/integration-tests/http/partner-quote-tax-jurisdiction.spec.ts
+++ b/apps/backend/integration-tests/http/partner-quote-tax-jurisdiction.spec.ts
@@ -5,6 +5,7 @@ import {
   createShippingOptionsWorkflow,
   createTaxRegionsWorkflow,
 } from "@medusajs/medusa/core-flows"
+import { PARTNER_QUOTE_MODULE } from "../../src/modules/partner-quote"
 import {
   setupQuoteFixture,
   mintBody,
@@ -231,6 +232,89 @@ setupSharedTestSuite(() => {
       // vacuously true and this test would pass on a broken lane.
       expect(money.freight).toBeGreaterThan(0)
       expect(quote.tax.total).toBe(0)
+    })
+
+    /** The frozen row, straight off the module service. */
+    const readQuote = async (quoteId: string) => {
+      const service: any = getSharedTestEnv().getContainer().resolve(PARTNER_QUOTE_MODULE)
+      const rows = await service.listPartnerQuotes({ id: quoteId })
+      return rows?.[0]
+    }
+
+    const mintRaw = async (overrides: Record<string, any>) => {
+      const { api } = getSharedTestEnv()
+      const res = await loud("mint", () =>
+        api.post("/partners/quotes", mintBody(seed, overrides), {
+          headers: seed.headers,
+        })
+      )
+      return res.data
+    }
+
+    const viewByToken = async (token: string) => {
+      const { api } = getSharedTestEnv()
+      const res = await loud("view", () =>
+        api.get(`/store/b2b/quotes/${token}`, {
+          headers: { "x-publishable-api-key": seed.publishableKey },
+        })
+      )
+      return res.data.quote
+    }
+
+    it("FREEZES the tax at mint — the INSERT is the thing a unit test cannot reach", async () => {
+      const minted = await mintRaw({
+        buyer_email: `buyer-freeze-${seed.unique}@jaalyantra.test`,
+        destination_country_code: "in",
+        destination_postal_code: "400001",
+      })
+
+      const row = await readQuote(minted.quote.id)
+      // 🔑 Reaching this line at all is the point. `quoted_tax_total` is a DML
+      // bigNumber, which is TWO columns — model, tsc and every unit test pass
+      // with only the numeric one, then the INSERT dies on the missing
+      // `raw_quoted_tax_total`. That is how the S7 pair was caught (#1446).
+      expect(Number(row.quoted_tax_total)).toBeGreaterThan(0)
+      expect(row.quoted_tax_status).toBe("calculated")
+      expect(row.quoted_tax_inclusive).toBe(false)
+      expect(row.quoted_tax_reason).toBeNull()
+    })
+
+    it("freezes a zero-rated export as a REAL zero, with its disclosure", async () => {
+      const minted = await mintRaw({
+        buyer_email: `buyer-freeze-export-${seed.unique}@jaalyantra.test`,
+        destination_country_code: "de",
+        destination_postal_code: "10115",
+        destination_city: "Berlin",
+      })
+
+      const row = await readQuote(minted.quote.id)
+      expect(Number(row.quoted_tax_total)).toBe(0)
+      expect(row.quoted_tax_status).toBe("zero_rated_export")
+      // Frozen because it is evidence: on an export this sentence is the only
+      // place the buyer was told the duty is theirs.
+      expect(row.quoted_tax_reason).toMatch(/payable by you/i)
+    })
+
+    it("🔴 a REVOKED export quote still shows the duty disclosure", async () => {
+      const minted = await mintRaw({
+        buyer_email: `buyer-revoked-${seed.unique}@jaalyantra.test`,
+        destination_country_code: "de",
+        destination_postal_code: "10115",
+        destination_city: "Berlin",
+      })
+
+      const service: any = getSharedTestEnv().getContainer().resolve(PARTNER_QUOTE_MODULE)
+      await service.updatePartnerQuotes({ id: minted.quote.id, status: "revoked" })
+
+      const quote = await viewByToken(minted.token)
+      // buildQuoteView skips its ENTIRE live block once the quote is unusable,
+      // which left tax on {status:"unknown", reason:null}. The storefront only
+      // renders the notice when there is a reason, so before the frozen
+      // fallback this page showed totals and no tax block at all — on exactly
+      // the quotes that exist as a record of what was said.
+      expect(quote.live).toBeNull()
+      expect(quote.tax.status).toBe("zero_rated_export")
+      expect(quote.tax.reason).toMatch(/payable by you/i)
     })
   })
 })

--- a/apps/backend/integration-tests/http/partner-quote-tax-jurisdiction.spec.ts
+++ b/apps/backend/integration-tests/http/partner-quote-tax-jurisdiction.spec.ts
@@ -324,6 +324,8 @@ setupSharedTestSuite(() => {
         destination_postal_code: "10115",
         destination_city: "Berlin",
         duties_prepaid: true,
+        duty_total: 12_000,
+        duty_basis: "EU 12% ad valorem, HS 6304.92",
       })
 
       const row = await readQuote(minted.quote.id)
@@ -334,9 +336,68 @@ setupSharedTestSuite(() => {
       expect(row.quoted_tax_reason).toMatch(/nothing further to pay on delivery/i)
       expect(row.quoted_tax_reason).not.toMatch(/payable by you/i)
 
-      // And the buyer sees the promise, not the warning.
+      // 🔴 The INSERT is what a unit test cannot reach: a DML `bigNumber` is two
+      // columns, and a missing `raw_quoted_duty_total` fails here and nowhere else.
+      expect(Number(row.quoted_duty_total)).toBe(12_000)
+      expect(row.quoted_duty_basis).toBe("EU 12% ad valorem, HS 6304.92")
+
+      // And the buyer sees the promise, the number behind it, and a total that
+      // actually contains it — the promise used to add nothing to the price.
       const quote = await viewByToken(minted.token)
       expect(quote.tax.reason).toMatch(/nothing further to pay on delivery/i)
+      expect(quote.duty).toEqual({
+        prepaid: true,
+        total: 12_000,
+        basis: "EU 12% ad valorem, HS 6304.92",
+      })
+      expect(quote.quoted.duty_total).toBe(12_000)
+      expect(quote.quoted.gross_total).toBe(
+        quote.quoted.landed_total + 12_000
+      )
+    })
+
+    it("🔴 refuses a DDP promise with no duty figure behind it", async () => {
+      const { api } = getSharedTestEnv()
+
+      // The whole point of the slice: `duties_prepaid` alone told the buyer
+      // "nothing further to pay" and added nothing to the price, so the duty
+      // came out of margin by an amount nobody had computed.
+      await expect(
+        api.post(
+          "/partners/quotes",
+          mintBody(seed, {
+            buyer_email: `buyer-ddp-bare-${seed.unique}@jaalyantra.test`,
+            destination_country_code: "de",
+            destination_postal_code: "10115",
+            destination_city: "Berlin",
+            duties_prepaid: true,
+          }),
+          { headers: seed.headers }
+        )
+      ).rejects.toMatchObject({ response: { status: 400 } })
+    })
+
+    it("accepts a nil duty on a lane that is genuinely duty-free", async () => {
+      // "We checked, it is nil" is a fact and has to be sayable — the live case
+      // is AI-ECTA, under which Indian textiles enter Australia duty-free.
+      // Quoted on the DE lane here because that is the only geo zone this seed
+      // has freight for, and a mint with no quotable lane fails before it ever
+      // reaches the duty rule.
+      const minted = await mintRaw({
+        buyer_email: `buyer-ddp-nil-${seed.unique}@jaalyantra.test`,
+        destination_country_code: "de",
+        destination_postal_code: "10115",
+        destination_city: "Berlin",
+        duties_prepaid: true,
+        duty_total: 0,
+        duty_basis: "GSP relief — 0% on HS 6304.92 for IN origin",
+      })
+
+      const row = await readQuote(minted.quote.id)
+      // 0, not null: the difference between "checked, nil" and "left blank" is
+      // the entire reason the basis column exists.
+      expect(Number(row.quoted_duty_total)).toBe(0)
+      expect(row.quoted_duty_basis).toMatch(/GSP relief/i)
     })
 
     it("🔴 defaults to buyer-pays — an omitted flag is never a promise", async () => {

--- a/apps/backend/src/admin/hooks/api/quote-buyer-sources.ts
+++ b/apps/backend/src/admin/hooks/api/quote-buyer-sources.ts
@@ -127,3 +127,55 @@ export const useQuoteBuyerOptions = (search: string) => {
     isLoading: customers.isLoading || persons.isLoading,
   }
 }
+
+/**
+ * The carriers this partner can actually be quoted against (#1447).
+ *
+ * 🔑 Reads `/admin/shipping-carriers`, the SAME availability builder the
+ * carrier settings screen uses, rather than a hand-written list. A second list
+ * of "which carriers exist" drifts the first time one gains credentials, and
+ * the drift shows up as a quote priced against a carrier this deployment cannot
+ * call — which fails as a fallback rate, silently, not as an error.
+ *
+ * Gated on `partner_id` because availability is per-partner: it is read from
+ * that partner's stock location links. No partner picked yet ⇒ no query.
+ */
+export type QuoteCarrierOption = {
+  id: string
+  label: string
+  /** Selectable — integrated, registered on this deployment, linked here. */
+  available: boolean
+  /** Why not, when it is not. Rendered so a disabled row explains itself. */
+  blocked_reason: string | null
+  /** Can this carrier be TOLD the shipment is DDP (#1447)? */
+  can_declare_ddp: boolean
+}
+
+export const useQuoteCarriers = (partnerId?: string | null) => {
+  const { data, ...rest } = useQuery<{ carriers: any[] }, FetchError>({
+    queryFn: () =>
+      sdk.client.fetch<{ carriers: any[] }>("/admin/shipping-carriers", {
+        method: "GET",
+        query: { partner_id: partnerId },
+      }),
+    queryKey: ["quote-wizard-carriers", partnerId],
+    enabled: Boolean(partnerId),
+    placeholderData: keepPreviousData,
+  })
+
+  const options: QuoteCarrierOption[] = (data?.carriers ?? [])
+    .filter((c: any) => c?.integrated)
+    .map((c: any) => ({
+      id: String(c.id),
+      label: String(c.label ?? c.id),
+      // `enabled` is the location link — the partner's own selection. A
+      // registered-but-unlinked carrier is deliberately still offered here:
+      // a quote is not a shipment, and refusing to PRICE against a carrier
+      // someone is about to link is a worse failure than an unusual pick.
+      available: Boolean(c.registered),
+      blocked_reason: c.blocked_reason ?? null,
+      can_declare_ddp: Boolean(c.can_declare_ddp),
+    }))
+
+  return { options, ...rest }
+}

--- a/apps/backend/src/admin/hooks/api/quotes.ts
+++ b/apps/backend/src/admin/hooks/api/quotes.ts
@@ -24,6 +24,10 @@ export type AdminQuote = Record<string, any> & {
   destination_country_code?: string
   quoted_landed_total?: number | null
   quoted_freight?: number | null
+  /** #1447 — the DDP undertaking and the duty figure frozen behind it. */
+  duties_prepaid?: boolean | null
+  quoted_duty_total?: number | null
+  quoted_duty_basis?: string | null
   status?: "active" | "revoked" | "superseded"
   expires_at?: string | null
   view_count?: number

--- a/apps/backend/src/admin/hooks/api/quotes.ts
+++ b/apps/backend/src/admin/hooks/api/quotes.ts
@@ -72,6 +72,10 @@ export type AdminMintQuotePayload = {
   currency_code: string
   carrier?: string
   ttl_days?: number
+  /** DDP (#1447): the undertaking, the amount absorbed, and how it was reached. */
+  duties_prepaid?: boolean
+  duty_total?: number | null
+  duty_basis?: string | null
 }
 
 /**

--- a/apps/backend/src/admin/hooks/api/quotes.ts
+++ b/apps/backend/src/admin/hooks/api/quotes.ts
@@ -27,6 +27,10 @@ export type AdminQuote = Record<string, any> & {
   /** #1447 — the DDP undertaking and the duty figure frozen behind it. */
   duties_prepaid?: boolean | null
   quoted_duty_total?: number | null
+  quoted_import_tax_total?: number | null
+  quoted_ddp_fee_total?: number | null
+  quoted_duty_rate?: number | null
+  quoted_import_tax_rate?: number | null
   quoted_duty_basis?: string | null
   status?: "active" | "revoked" | "superseded"
   expires_at?: string | null
@@ -74,7 +78,11 @@ export type AdminMintQuotePayload = {
   ttl_days?: number
   /** DDP (#1447): the undertaking, the amount absorbed, and how it was reached. */
   duties_prepaid?: boolean
+  duty_rate_percent?: number | null
+  import_tax_rate_percent?: number | null
   duty_total?: number | null
+  import_tax_total?: number | null
+  ddp_fee_total?: number | null
   duty_basis?: string | null
 }
 

--- a/apps/backend/src/admin/routes/quotes/[id]/page.tsx
+++ b/apps/backend/src/admin/routes/quotes/[id]/page.tsx
@@ -191,8 +191,38 @@ const QuoteDetailPage = () => {
                       ),
                     },
                     {
+                      // 🔴 Listed separately and NOT folded into the duty: on
+                      // an EU lane this is the larger number by roughly 3×, and
+                      // a lump sum cannot be reconciled against a carrier's
+                      // itemised invoice months later.
+                      label: "Import tax (we pay)",
+                      value: money(
+                        quote.quoted_import_tax_total,
+                        quote.currency_code
+                      ),
+                    },
+                    {
+                      label: "Clearance fee",
+                      value: money(
+                        quote.quoted_ddp_fee_total,
+                        quote.currency_code
+                      ),
+                    },
+                    {
                       label: "Duty basis",
-                      value: quote.quoted_duty_basis || "—",
+                      value: [
+                        quote.quoted_duty_rate !== null &&
+                        quote.quoted_duty_rate !== undefined
+                          ? `${quote.quoted_duty_rate}% duty`
+                          : null,
+                        quote.quoted_import_tax_rate !== null &&
+                        quote.quoted_import_tax_rate !== undefined
+                          ? `${quote.quoted_import_tax_rate}% import tax`
+                          : null,
+                        quote.quoted_duty_basis || null,
+                      ]
+                        .filter(Boolean)
+                        .join(" · ") || "—",
                     },
                   ]
                 : []),

--- a/apps/backend/src/admin/routes/quotes/[id]/page.tsx
+++ b/apps/backend/src/admin/routes/quotes/[id]/page.tsx
@@ -174,6 +174,28 @@ const QuoteDetailPage = () => {
                 label: "Freight",
                 value: money(quote.quoted_freight, quote.currency_code),
               },
+              /**
+               * Shown only on a DDP quote, and shown with its basis (#1447).
+               * This is a liability we took on: somebody has to arrange the
+               * clearance and pay this, and until a carrier can do it that
+               * somebody is a person reading this page. A DDP quote whose duty
+               * figure is invisible here is one nobody can honour.
+               */
+              ...(quote.duties_prepaid
+                ? [
+                    {
+                      label: "Duty (we pay)",
+                      value: money(
+                        quote.quoted_duty_total,
+                        quote.currency_code
+                      ),
+                    },
+                    {
+                      label: "Duty basis",
+                      value: quote.quoted_duty_basis || "—",
+                    },
+                  ]
+                : []),
               {
                 label: "Destination",
                 value: `${String(quote.destination_country_code || "").toUpperCase()}${

--- a/apps/backend/src/admin/routes/quotes/create/mint-quote-form.tsx
+++ b/apps/backend/src/admin/routes/quotes/create/mint-quote-form.tsx
@@ -113,6 +113,11 @@ export const MintQuoteForm = () => {
       quantities: {},
       discounts: {},
       overrides: {},
+      // Never on by default: a DDP promise nobody arranged clearance for tells
+      // the buyer there is nothing to pay and then hands them a customs bill.
+      duties_prepaid: false,
+      duty_total: null,
+      duty_basis: null,
     },
     resolver: zodResolver(AdminQuoteCreateSchema) as any,
   })
@@ -282,6 +287,14 @@ export const MintQuoteForm = () => {
       currency_code: data.currency_code,
       region_id: data.region_id,
       ttl_days: data.ttl_days,
+      // The pair travels together or not at all (#1447).
+      duties_prepaid: data.duties_prepaid ?? false,
+      ...(data.duties_prepaid
+        ? {
+            duty_total: data.duty_total ?? null,
+            duty_basis: data.duty_basis || null,
+          }
+        : {}),
     } as any)
   })
 

--- a/apps/backend/src/admin/routes/quotes/create/mint-quote-form.tsx
+++ b/apps/backend/src/admin/routes/quotes/create/mint-quote-form.tsx
@@ -109,6 +109,9 @@ export const MintQuoteForm = () => {
       destination_postal_code: "",
       destination_city: "",
       ttl_days: 14,
+      // Empty = the platform default rate source. Never "manual" by default:
+      // that would silently stop asking any carrier for a live rate.
+      carrier: "",
       product_ids: [],
       quantities: {},
       discounts: {},
@@ -116,7 +119,9 @@ export const MintQuoteForm = () => {
       // Never on by default: a DDP promise nobody arranged clearance for tells
       // the buyer there is nothing to pay and then hands them a customs bill.
       duties_prepaid: false,
-      duty_total: null,
+      duty_rate_percent: null,
+      import_tax_rate_percent: null,
+      ddp_fee_total: null,
       duty_basis: null,
     },
     resolver: zodResolver(AdminQuoteCreateSchema) as any,
@@ -287,11 +292,18 @@ export const MintQuoteForm = () => {
       currency_code: data.currency_code,
       region_id: data.region_id,
       ttl_days: data.ttl_days,
+      // Omitted rather than sent empty — the backend's own default is the one
+      // thing that should decide what "no choice" means.
+      ...(data.carrier ? { carrier: data.carrier } : {}),
       // The pair travels together or not at all (#1447).
       duties_prepaid: data.duties_prepaid ?? false,
       ...(data.duties_prepaid
         ? {
-            duty_total: data.duty_total ?? null,
+            // Rates, not money — the mint computes the amounts against the
+            // basket it actually prices.
+            duty_rate_percent: data.duty_rate_percent ?? null,
+            import_tax_rate_percent: data.import_tax_rate_percent ?? null,
+            ddp_fee_total: data.ddp_fee_total ?? null,
             duty_basis: data.duty_basis || null,
           }
         : {}),

--- a/apps/backend/src/admin/routes/quotes/create/schema.ts
+++ b/apps/backend/src/admin/routes/quotes/create/schema.ts
@@ -12,7 +12,55 @@ export const QuotePartnerSchema = z.object({
   partner_id: z.string().min(1),
 })
 
-export const QuoteBuyerSchema = z.object({
+/**
+ * The DDP rule, mirrored from `dutyUndertakingRefinement` in
+ * `src/api/partners/quotes/validators.ts` (#1447).
+ *
+ * 🔴 `duties_prepaid` alone tells the buyer "nothing further to pay on
+ * delivery" and adds nothing to the price — the duty is absorbed out of margin
+ * by an amount nobody computed. The backend refuses it; this is what puts the
+ * refusal on the field rather than at the end of a failed mint.
+ */
+export const dutyUndertakingRefinement = (
+  value: {
+    duties_prepaid?: boolean
+    duty_total?: number | null
+    duty_basis?: string | null
+  },
+  ctx: z.RefinementCtx
+) => {
+  const prepaid = Boolean(value.duties_prepaid)
+  const hasAmount = value.duty_total !== null && value.duty_total !== undefined
+
+  if (prepaid && !hasAmount) {
+    ctx.addIssue({
+      code: "custom",
+      message:
+        "Enter the duty we are absorbing on this quote — 0 is fine where the lane is duty-free.",
+      path: ["duty_total"],
+    })
+  }
+
+  if (prepaid && !String(value.duty_basis ?? "").trim()) {
+    ctx.addIssue({
+      code: "custom",
+      message:
+        "Say how the figure was reached — whoever pays the customs invoice is not who typed it.",
+      path: ["duty_basis"],
+    })
+  }
+
+  if (!prepaid && hasAmount) {
+    ctx.addIssue({
+      code: "custom",
+      message:
+        "A duty amount only applies on a DDP quote. Without it the buyer pays duty at their own border.",
+      path: ["duty_total"],
+    })
+  }
+}
+
+export const QuoteBuyerShape = z.object({
   buyer_email: z.string().email(),
   recipient_name: z.string().optional(),
   recipient_company: z.string().optional(),
@@ -34,7 +82,16 @@ export const QuoteBuyerSchema = z.object({
 
   /** Drives `price_list.ends_at`, so expiry is native rather than swept. */
   ttl_days: z.number().int().positive().max(365).optional(),
+
+  /** DDP (#1447) — per quote, never a default. See the refinement above. */
+  duties_prepaid: z.boolean().optional(),
+  duty_total: z.number().min(0).nullish(),
+  duty_basis: z.string().max(500).nullish(),
 })
+
+export const QuoteBuyerSchema = QuoteBuyerShape.superRefine(
+  dutyUndertakingRefinement
+)
 
 export const QuoteProductsSchema = z.object({
   product_ids: z.array(z.object({ id: z.string() })),
@@ -54,9 +111,14 @@ export const QuoteQuantitiesSchema = z.object({
   overrides: z.record(z.string(), z.number().nullish()),
 })
 
-export const AdminQuoteCreateSchema = QuotePartnerSchema.merge(QuoteBuyerSchema)
+/**
+ * ⚠️ Merged from the SHAPE and re-refined — `.merge()` on a refined schema drops
+ * the cross-field rule in silence, and the rule it drops is the DDP one.
+ */
+export const AdminQuoteCreateSchema = QuotePartnerSchema.merge(QuoteBuyerShape)
   .merge(QuoteProductsSchema)
   .merge(QuoteQuantitiesSchema)
+  .superRefine(dutyUndertakingRefinement)
 
 export type AdminQuoteCreateSchemaType = z.infer<typeof AdminQuoteCreateSchema>
 
@@ -72,5 +134,8 @@ export const QuoteBuyerFields = [
   "destination_postal_code",
   "destination_city",
   "ttl_days",
+  "duties_prepaid",
+  "duty_total",
+  "duty_basis",
 ] as const
 export const QuoteProductFields = ["product_ids"] as const

--- a/apps/backend/src/admin/routes/quotes/create/schema.ts
+++ b/apps/backend/src/admin/routes/quotes/create/schema.ts
@@ -24,38 +24,52 @@ export const QuotePartnerSchema = z.object({
 export const dutyUndertakingRefinement = (
   value: {
     duties_prepaid?: boolean
+    duty_rate_percent?: number | null
+    import_tax_rate_percent?: number | null
     duty_total?: number | null
+    import_tax_total?: number | null
+    ddp_fee_total?: number | null
     duty_basis?: string | null
   },
   ctx: z.RefinementCtx
 ) => {
   const prepaid = Boolean(value.duties_prepaid)
-  const hasAmount = value.duty_total !== null && value.duty_total !== undefined
+  const given = (v: unknown) => v !== null && v !== undefined
+  const hasDuty = given(value.duty_rate_percent) || given(value.duty_total)
+  const hasImportTax =
+    given(value.import_tax_rate_percent) || given(value.import_tax_total)
 
-  if (prepaid && !hasAmount) {
+  if (prepaid && !hasDuty) {
+    ctx.addIssue({
+      code: "custom",
+      message: "Enter the duty rate for this destination — 0% is fine where the lane is duty-free.",
+      path: ["duty_rate_percent"],
+    })
+  }
+
+  if (prepaid && !hasImportTax) {
     ctx.addIssue({
       code: "custom",
       message:
-        "Enter the duty we are absorbing on this quote — 0 is fine where the lane is duty-free.",
-      path: ["duty_total"],
+        "Enter the destination import tax rate. It is usually the biggest of the three — 21% VAT on goods + freight + duty against an 8% duty — so leaving it out under-funds most of the promise.",
+      path: ["import_tax_rate_percent"],
     })
   }
 
   if (prepaid && !String(value.duty_basis ?? "").trim()) {
     ctx.addIssue({
       code: "custom",
-      message:
-        "Say how the figure was reached — whoever pays the customs invoice is not who typed it.",
+      message: "Say how you got these rates — whoever pays the customs invoice is not who typed them.",
       path: ["duty_basis"],
     })
   }
 
-  if (!prepaid && hasAmount) {
+  if (!prepaid && (hasDuty || hasImportTax || given(value.ddp_fee_total))) {
     ctx.addIssue({
       code: "custom",
       message:
-        "A duty amount only applies on a DDP quote. Without it the buyer pays duty at their own border.",
-      path: ["duty_total"],
+        "These only apply on a DDP quote. Without it the buyer pays duty and import tax at their own border.",
+      path: ["duty_rate_percent"],
     })
   }
 }
@@ -83,9 +97,32 @@ export const QuoteBuyerShape = z.object({
   /** Drives `price_list.ends_at`, so expiry is native rather than swept. */
   ttl_days: z.number().int().positive().max(365).optional(),
 
+  /**
+   * Which carrier is asked for live rates on this quote.
+   *
+   * 🔑 Empty means the platform default (Shiprocket), which is what every quote
+   * minted before this used. It is NOT "no freight": manual/flat shipping
+   * options are always included whatever this says, so a lane with no carrier
+   * answer still prices — see `lib/shipping-estimate.ts`.
+   *
+   * Free text rather than an enum on purpose: the picker offers the carriers
+   * this deployment actually has, and "manual" for a lane priced by hand, but a
+   * carrier registered after this build must still be typeable.
+   */
+  carrier: z.string().max(60).optional(),
+
   /** DDP (#1447) — per quote, never a default. See the refinement above. */
   duties_prepaid: z.boolean().optional(),
-  duty_total: z.number().min(0).nullish(),
+  /**
+   * Rates, not amounts. The mint computes the money against the basket it
+   * actually prices — duty on goods + freight, import tax on goods + freight +
+   * duty — because this form cannot know either figure before then, and a
+   * client-side estimate frozen as a commitment is worse than no preview.
+   */
+  duty_rate_percent: z.number().min(0).max(100).nullish(),
+  import_tax_rate_percent: z.number().min(0).max(100).nullish(),
+  /** The carrier's charge for advancing duty and tax. An amount, not a rate. */
+  ddp_fee_total: z.number().min(0).nullish(),
   duty_basis: z.string().max(500).nullish(),
 })
 
@@ -134,8 +171,11 @@ export const QuoteBuyerFields = [
   "destination_postal_code",
   "destination_city",
   "ttl_days",
+  "carrier",
   "duties_prepaid",
-  "duty_total",
+  "duty_rate_percent",
+  "import_tax_rate_percent",
+  "ddp_fee_total",
   "duty_basis",
 ] as const
 export const QuoteProductFields = ["product_ids"] as const

--- a/apps/backend/src/admin/routes/quotes/create/steps/buyer-step.tsx
+++ b/apps/backend/src/admin/routes/quotes/create/steps/buyer-step.tsx
@@ -1,4 +1,4 @@
-import { Heading, Input, Select, Text, Textarea } from "@medusajs/ui"
+import { Heading, Input, Select, Switch, Text, Textarea } from "@medusajs/ui"
 import { useMemo, useState } from "react"
 import { UseFormReturn, useWatch } from "react-hook-form"
 
@@ -294,6 +294,108 @@ export const BuyerStep = ({ form }: Props) => {
           </Form.Item>
         )}
       />
+
+      <div className="flex flex-col gap-y-1">
+        <Heading level="h2">Import duty (DDP)</Heading>
+        <Text size="small" className="text-ui-fg-subtle">
+          Only meaningful on an export. With this on the buyer is told there is
+          nothing further to pay on delivery — which means we pay their customs
+          bill, and until a carrier can price and clear it DDP, somebody
+          arranges that by hand.
+        </Text>
+      </div>
+
+      <Form.Field
+        control={form.control}
+        name="duties_prepaid"
+        render={({ field: { value, onChange, ...rest } }) => (
+          <Form.Item>
+            <div className="flex items-start justify-between gap-4 rounded-lg border border-ui-border-base p-4">
+              <div className="flex flex-col gap-y-1">
+                <Form.Label>We pay the import duty</Form.Label>
+                <Form.Hint>
+                  Off means the buyer is importer of record: duty and import VAT
+                  are theirs, and the quote says so in as many words.
+                </Form.Hint>
+              </div>
+              <Form.Control>
+                <Switch
+                  checked={Boolean(value)}
+                  onCheckedChange={(checked) => {
+                    onChange(checked)
+                    if (!checked) {
+                      // A stray amount on a non-DDP quote would be added to a
+                      // total whose buyer was told duty is theirs to pay.
+                      form.setValue("duty_total", null)
+                      form.setValue("duty_basis", null)
+                      form.clearErrors(["duty_total", "duty_basis"])
+                    }
+                  }}
+                  {...rest}
+                />
+              </Form.Control>
+            </div>
+            <Form.ErrorMessage />
+          </Form.Item>
+        )}
+      />
+
+      {form.watch("duties_prepaid") ? (
+        <div className="grid grid-cols-1 gap-4 md:grid-cols-2">
+          <Form.Field
+            control={form.control}
+            name="duty_total"
+            render={({ field }) => (
+              <Form.Item>
+                <Form.Label>Duty we absorb</Form.Label>
+                <Form.Control>
+                  <Input
+                    type="number"
+                    min={0}
+                    step="0.01"
+                    placeholder="0.00"
+                    value={field.value ?? ""}
+                    onChange={(e) =>
+                      field.onChange(
+                        e.target.value === "" ? null : Number(e.target.value)
+                      )
+                    }
+                  />
+                </Form.Control>
+                <Form.Hint>
+                  In the quote's currency, added to the buyer's total. Nothing
+                  derives it — HS codes are incomplete and the carrier tariff
+                  APIs are gated — so this figure is what we commit to.
+                </Form.Hint>
+                <Form.ErrorMessage />
+              </Form.Item>
+            )}
+          />
+
+          <Form.Field
+            control={form.control}
+            name="duty_basis"
+            render={({ field }) => (
+              <Form.Item>
+                <Form.Label>How you got there</Form.Label>
+                <Form.Control>
+                  <Input
+                    placeholder="EU 12% ad valorem, HS 6304.92"
+                    {...field}
+                    value={field.value ?? ""}
+                  />
+                </Form.Control>
+                <Form.Hint>
+                  A nil duty is a real answer — say why (AI-ECTA makes Indian
+                  textiles duty-free into AU). A bare 0 cannot tell "checked"
+                  from "left blank".
+                </Form.Hint>
+                <Form.ErrorMessage />
+              </Form.Item>
+            )}
+          />
+        </div>
+      ) : null}
     </div>
   )
 }

--- a/apps/backend/src/admin/routes/quotes/create/steps/buyer-step.tsx
+++ b/apps/backend/src/admin/routes/quotes/create/steps/buyer-step.tsx
@@ -6,6 +6,7 @@ import { Form } from "../../../../components/common/form"
 import { Combobox } from "../../../../components/inputs/combobox/combobox"
 import {
   useQuoteBuyerOptions,
+  useQuoteCarriers,
   useQuoteRegions,
 } from "../../../../hooks/api/quote-buyer-sources"
 import { AdminQuoteCreateSchemaType } from "../schema"
@@ -37,10 +38,42 @@ type Props = { form: UseFormReturn<AdminQuoteCreateSchemaType> }
  * must therefore stay selectable, or the wizard could only ever quote people
  * who had already bought.
  */
+/** Sentinel for the "type it yourself" branch — never sent to the API. */
+const OTHER_CARRIER = "__other__"
+
 export const BuyerStep = ({ form }: Props) => {
   const [search, setSearch] = useState("")
   const { regions } = useQuoteRegions()
   const { options: buyers } = useQuoteBuyerOptions(search)
+
+  const partnerId = useWatch({ control: form.control, name: "partner_id" })
+  const { options: carriers } = useQuoteCarriers(partnerId)
+  const carrier = useWatch({ control: form.control, name: "carrier" })
+  const dutiesPrepaid = useWatch({ control: form.control, name: "duties_prepaid" })
+
+  const knownCarrierIds = useMemo(
+    () => new Set([...carriers.map((c) => c.id), "manual", ""]),
+    [carriers]
+  )
+  const isOtherCarrier = Boolean(carrier) && !knownCarrierIds.has(carrier ?? "")
+
+  /**
+   * 🔴 The one warning worth interrupting for: quoting DDP on a carrier that
+   * cannot be TOLD the shipment is DDP. The promise is still keepable — someone
+   * arranges clearance by hand — but it stops being automatic, and the failure
+   * is otherwise silent until the buyer meets a customs bill we said would not
+   * come. Today only Blue Dart's payload carries an incoterm at all.
+   */
+  const ddpWarning = useMemo(() => {
+    if (!dutiesPrepaid) return null
+    const picked = carriers.find((c) => c.id === carrier)
+    if (!picked) {
+      return "This quote promises DDP. Nothing on the default rate source can declare a shipment duty-paid, so clearance has to be arranged by hand."
+    }
+    return picked.can_declare_ddp
+      ? `${picked.label} can be told the shipment is DDP — the incoterm follows the sale.`
+      : `${picked.label} cannot declare a shipment DDP, so the duty we promised has to be arranged with the carrier by hand.`
+  }, [carrier, carriers, dutiesPrepaid])
 
   const regionId = useWatch({ control: form.control, name: "region_id" })
   const region = useMemo(
@@ -296,6 +329,97 @@ export const BuyerStep = ({ form }: Props) => {
       />
 
       <div className="flex flex-col gap-y-1">
+        <Heading level="h2">Freight source</Heading>
+        <Text size="small" className="text-ui-fg-subtle">
+          Which carrier is asked for a live rate on this lane. Manual and flat
+          shipping options are always included whatever is picked here, so a
+          lane no carrier will quote still prices.
+        </Text>
+      </div>
+
+      <div className="grid grid-cols-1 gap-4 md:grid-cols-2">
+        <Form.Field
+          control={form.control}
+          name="carrier"
+          render={({ field }) => (
+            <Form.Item>
+              <Form.Label optional>Carrier</Form.Label>
+              <Form.Control>
+                <Select
+                  value={
+                    field.value && !knownCarrierIds.has(field.value)
+                      ? OTHER_CARRIER
+                      : (field.value ?? "")
+                  }
+                  onValueChange={(value) =>
+                    field.onChange(value === OTHER_CARRIER ? " " : value)
+                  }
+                >
+                  <Select.Trigger>
+                    <Select.Value placeholder="Platform default (Shiprocket)" />
+                  </Select.Trigger>
+                  <Select.Content>
+                    <Select.Item value="">
+                      Platform default (Shiprocket)
+                    </Select.Item>
+                    {carriers.map((c) => (
+                      <Select.Item
+                        key={c.id}
+                        value={c.id}
+                        disabled={!c.available}
+                      >
+                        {c.label}
+                        {c.can_declare_ddp ? " · can ship DDP" : ""}
+                        {c.available ? "" : ` · ${c.blocked_reason ?? "unavailable"}`}
+                      </Select.Item>
+                    ))}
+                    {/* A lane priced entirely by the partner's own manual
+                        tiers — no carrier is called at all. */}
+                    <Select.Item value="manual">
+                      Manual rates only — ask no carrier
+                    </Select.Item>
+                    <Select.Item value={OTHER_CARRIER}>
+                      Other — type a carrier id
+                    </Select.Item>
+                  </Select.Content>
+                </Select>
+              </Form.Control>
+              <Form.Hint>
+                {ddpWarning ??
+                  "Leave on the default unless this lane is quoted somewhere else."}
+              </Form.Hint>
+              <Form.ErrorMessage />
+            </Form.Item>
+          )}
+        />
+
+        {isOtherCarrier ? (
+          <Form.Field
+            control={form.control}
+            name="carrier"
+            render={({ field }) => (
+              <Form.Item>
+                <Form.Label>Carrier id</Form.Label>
+                <Form.Control>
+                  <Input
+                    placeholder="e.g. bluedart"
+                    value={(field.value ?? "").trim()}
+                    onChange={(e) => field.onChange(e.target.value)}
+                  />
+                </Form.Control>
+                <Form.Hint>
+                  The id the adapter registers under. A carrier this deployment
+                  has no client for cannot return a rate — the quote falls back
+                  to manual options rather than failing, so check the spelling.
+                </Form.Hint>
+                <Form.ErrorMessage />
+              </Form.Item>
+            )}
+          />
+        ) : null}
+      </div>
+
+      <div className="flex flex-col gap-y-1">
         <Heading level="h2">Import duty (DDP)</Heading>
         <Text size="small" className="text-ui-fg-subtle">
           Only meaningful on an export. With this on the buyer is told there is
@@ -326,9 +450,16 @@ export const BuyerStep = ({ form }: Props) => {
                     if (!checked) {
                       // A stray amount on a non-DDP quote would be added to a
                       // total whose buyer was told duty is theirs to pay.
-                      form.setValue("duty_total", null)
+                      form.setValue("duty_rate_percent", null)
+                      form.setValue("import_tax_rate_percent", null)
+                      form.setValue("ddp_fee_total", null)
                       form.setValue("duty_basis", null)
-                      form.clearErrors(["duty_total", "duty_basis"])
+                      form.clearErrors([
+                        "duty_rate_percent",
+                        "import_tax_rate_percent",
+                        "ddp_fee_total",
+                        "duty_basis",
+                      ])
                     }
                   }}
                   {...rest}
@@ -341,13 +472,73 @@ export const BuyerStep = ({ form }: Props) => {
       />
 
       {form.watch("duties_prepaid") ? (
-        <div className="grid grid-cols-1 gap-4 md:grid-cols-2">
+        <div className="grid grid-cols-1 gap-4 md:grid-cols-3">
           <Form.Field
             control={form.control}
-            name="duty_total"
+            name="duty_rate_percent"
             render={({ field }) => (
               <Form.Item>
-                <Form.Label>Duty we absorb</Form.Label>
+                <Form.Label>Duty rate %</Form.Label>
+                <Form.Control>
+                  <Input
+                    type="number"
+                    min={0}
+                    max={100}
+                    step="0.01"
+                    placeholder="8"
+                    value={field.value ?? ""}
+                    onChange={(e) =>
+                      field.onChange(
+                        e.target.value === "" ? null : Number(e.target.value)
+                      )
+                    }
+                  />
+                </Form.Control>
+                <Form.Hint>
+                  Applied to goods + freight. 0% is a real answer — AI-ECTA
+                  makes Indian textiles duty-free into Australia.
+                </Form.Hint>
+                <Form.ErrorMessage />
+              </Form.Item>
+            )}
+          />
+
+          <Form.Field
+            control={form.control}
+            name="import_tax_rate_percent"
+            render={({ field }) => (
+              <Form.Item>
+                <Form.Label>Import VAT / GST %</Form.Label>
+                <Form.Control>
+                  <Input
+                    type="number"
+                    min={0}
+                    max={100}
+                    step="0.01"
+                    placeholder="21"
+                    value={field.value ?? ""}
+                    onChange={(e) =>
+                      field.onChange(
+                        e.target.value === "" ? null : Number(e.target.value)
+                      )
+                    }
+                  />
+                </Form.Control>
+                <Form.Hint>
+                  Charged on goods + freight + duty — a value that already
+                  includes the duty. Usually the largest of the three.
+                </Form.Hint>
+                <Form.ErrorMessage />
+              </Form.Item>
+            )}
+          />
+
+          <Form.Field
+            control={form.control}
+            name="ddp_fee_total"
+            render={({ field }) => (
+              <Form.Item>
+                <Form.Label>Carrier clearance fee</Form.Label>
                 <Form.Control>
                   <Input
                     type="number"
@@ -363,37 +554,39 @@ export const BuyerStep = ({ form }: Props) => {
                   />
                 </Form.Control>
                 <Form.Hint>
-                  In the quote's currency, added to the buyer's total. Nothing
-                  derives it — HS codes are incomplete and the carrier tariff
-                  APIs are gated — so this figure is what we commit to.
+                  What the carrier charges to advance the duty and tax — DHL
+                  calls it duty-tax-paid. In the quote's currency.
                 </Form.Hint>
                 <Form.ErrorMessage />
               </Form.Item>
             )}
           />
 
-          <Form.Field
-            control={form.control}
-            name="duty_basis"
-            render={({ field }) => (
-              <Form.Item>
-                <Form.Label>How you got there</Form.Label>
-                <Form.Control>
-                  <Input
-                    placeholder="EU 12% ad valorem, HS 6304.92"
-                    {...field}
-                    value={field.value ?? ""}
-                  />
-                </Form.Control>
-                <Form.Hint>
-                  A nil duty is a real answer — say why (AI-ECTA makes Indian
-                  textiles duty-free into AU). A bare 0 cannot tell "checked"
-                  from "left blank".
-                </Form.Hint>
-                <Form.ErrorMessage />
-              </Form.Item>
-            )}
-          />
+          <div className="md:col-span-3">
+            <Form.Field
+              control={form.control}
+              name="duty_basis"
+              render={({ field }) => (
+                <Form.Item>
+                  <Form.Label>How you got these rates</Form.Label>
+                  <Form.Control>
+                    <Input
+                      placeholder="EU: 8% duty, 21% NL VAT, HS 6304.92 — DHL landed-cost planner"
+                      {...field}
+                      value={field.value ?? ""}
+                    />
+                  </Form.Control>
+                  <Form.Hint>
+                    The amounts are computed at mint against the basket that is
+                    actually priced and frozen alongside these rates, so the
+                    figure can be checked against the carrier's invoice later
+                    rather than merely believed.
+                  </Form.Hint>
+                  <Form.ErrorMessage />
+                </Form.Item>
+              )}
+            />
+          </div>
         </div>
       ) : null}
     </div>

--- a/apps/backend/src/api/admin/quotes/route.ts
+++ b/apps/backend/src/api/admin/quotes/route.ts
@@ -110,6 +110,10 @@ export const POST = async (req: MedusaRequest, res: MedusaResponse) => {
       region_id: body.region_id ?? null,
       carrier: body.carrier,
       duties_prepaid: body.duties_prepaid ?? false,
+      // The number behind the promise (#1447). The validator has already
+      // refused one without the other, so these two travel together or not at all.
+      duty_total: body.duty_total ?? null,
+      duty_basis: body.duty_basis ?? null,
       ttl_days: body.ttl_days,
       // Stamped with the ADMIN's actor id, not the partner's — otherwise an
       // admin-minted quote is indistinguishable from one the partner made

--- a/apps/backend/src/api/admin/quotes/route.ts
+++ b/apps/backend/src/api/admin/quotes/route.ts
@@ -114,6 +114,12 @@ export const POST = async (req: MedusaRequest, res: MedusaResponse) => {
       // refused one without the other, so these two travel together or not at all.
       duty_total: body.duty_total ?? null,
       duty_basis: body.duty_basis ?? null,
+      // The rate form is the normal one; the AMOUNTS are computed by the view
+      // against the basket it actually priced, never taken from the client.
+      duty_rate_percent: body.duty_rate_percent ?? null,
+      import_tax_rate_percent: body.import_tax_rate_percent ?? null,
+      import_tax_total: body.import_tax_total ?? null,
+      ddp_fee_total: body.ddp_fee_total ?? null,
       ttl_days: body.ttl_days,
       // Stamped with the ADMIN's actor id, not the partner's — otherwise an
       // admin-minted quote is indistinguishable from one the partner made

--- a/apps/backend/src/api/admin/quotes/route.ts
+++ b/apps/backend/src/api/admin/quotes/route.ts
@@ -109,6 +109,7 @@ export const POST = async (req: MedusaRequest, res: MedusaResponse) => {
       currency_code: body.currency_code,
       region_id: body.region_id ?? null,
       carrier: body.carrier,
+      duties_prepaid: body.duties_prepaid ?? false,
       ttl_days: body.ttl_days,
       // Stamped with the ADMIN's actor id, not the partner's — otherwise an
       // admin-minted quote is indistinguishable from one the partner made

--- a/apps/backend/src/api/admin/quotes/validators.ts
+++ b/apps/backend/src/api/admin/quotes/validators.ts
@@ -1,8 +1,9 @@
 import { z } from "@medusajs/framework/zod"
 
 import {
-  PartnerMintQuoteReq,
-  QuoteReadinessReq,
+  dutyUndertakingRefinement,
+  PartnerMintQuoteShape,
+  QuoteReadinessShape,
 } from "../../partners/quotes/validators"
 
 /**
@@ -15,10 +16,15 @@ import {
  *
  * The only addition is `partner_id`: an admin has no partner of their own, so
  * the quote's owner has to be named explicitly.
+ *
+ * ⚠️ It extends the SHAPE and re-applies `dutyUndertakingRefinement`. `.extend`
+ * on an already-refined schema is what drops cross-field rules silently, and the
+ * rule this drops is the one that stops a DDP quote promising duty cover with no
+ * amount behind it (#1447).
  */
-export const AdminMintQuoteReq = PartnerMintQuoteReq.extend({
+export const AdminMintQuoteReq = PartnerMintQuoteShape.extend({
   partner_id: z.string().min(1),
-})
+}).superRefine(dutyUndertakingRefinement)
 
 export type AdminMintQuoteReqType = z.infer<typeof AdminMintQuoteReq>
 
@@ -27,8 +33,8 @@ export type AdminMintQuoteReqType = z.infer<typeof AdminMintQuoteReq>
  * partner of their own, so the one being quoted for must be named — and on this
  * surface that partner is exactly what the catalogue check validates against.
  */
-export const AdminQuoteReadinessReq = QuoteReadinessReq.extend({
+export const AdminQuoteReadinessReq = QuoteReadinessShape.extend({
   partner_id: z.string().min(1),
-})
+}).superRefine(dutyUndertakingRefinement)
 
 export type AdminQuoteReadinessReqType = z.infer<typeof AdminQuoteReadinessReq>

--- a/apps/backend/src/api/partners/quotes/__tests__/duty-undertaking.unit.spec.ts
+++ b/apps/backend/src/api/partners/quotes/__tests__/duty-undertaking.unit.spec.ts
@@ -1,0 +1,100 @@
+import { AdminMintQuoteReq } from "../../../admin/quotes/validators"
+import { PartnerMintQuoteReq, QuoteReadinessReq } from "../validators"
+
+/**
+ * The DDP promise may not travel without its number (#1447).
+ *
+ * 🔴 `duties_prepaid` used to be accepted alone. It flips the buyer's page to
+ * "nothing further to pay on delivery" and adds nothing to the price, so the
+ * duty is absorbed out of margin by an amount nobody computed — and the quote
+ * carries no record that a figure was ever owed.
+ *
+ * All FOUR schemas are asserted here on purpose. The admin twin extends the
+ * shape and the readiness preflight omits from it; `.extend()` and `.omit()` on
+ * an already-refined schema drop cross-field rules silently, so a passing
+ * partner-only test would prove nothing about the surface an admin mints from.
+ */
+const body = (over: Record<string, any> = {}) => ({
+  buyer_email: "buyer@example.com",
+  lines: [{ variant_id: "var_a", quantity: 500 }],
+  destination_country_code: "de",
+  currency_code: "eur",
+  ...over,
+})
+
+const readiness = (over: Record<string, any> = {}) => {
+  const { buyer_email, ...rest } = body(over)
+  return rest
+}
+
+describe("the DDP undertaking needs a duty figure", () => {
+  it("refuses duties_prepaid with no amount", () => {
+    const parsed = PartnerMintQuoteReq.safeParse(
+      body({ duties_prepaid: true, duty_basis: "EU 12% ad valorem" })
+    )
+
+    expect(parsed.success).toBe(false)
+    expect(JSON.stringify(parsed.error?.issues)).toContain("duty_total")
+  })
+
+  it("refuses duties_prepaid with an amount and no basis", () => {
+    // A bare 0 cannot say whether it means "checked, AI-ECTA, nil" or "left
+    // blank", and the person who meets the customs invoice is not the one who
+    // typed it.
+    const parsed = PartnerMintQuoteReq.safeParse(
+      body({ duties_prepaid: true, duty_total: 0 })
+    )
+
+    expect(parsed.success).toBe(false)
+    expect(JSON.stringify(parsed.error?.issues)).toContain("duty_basis")
+  })
+
+  it("accepts a nil duty stated with its basis", () => {
+    const parsed = PartnerMintQuoteReq.safeParse(
+      body({
+        destination_country_code: "au",
+        duties_prepaid: true,
+        duty_total: 0,
+        duty_basis: "AI-ECTA — Indian textiles enter AU duty-free",
+      })
+    )
+
+    expect(parsed.success).toBe(true)
+  })
+
+  it("refuses a duty amount on a quote that is not DDP", () => {
+    const parsed = PartnerMintQuoteReq.safeParse(body({ duty_total: 12_000 }))
+
+    expect(parsed.success).toBe(false)
+  })
+
+  it("leaves an ordinary quote alone", () => {
+    expect(PartnerMintQuoteReq.safeParse(body()).success).toBe(true)
+  })
+
+  it("holds on the ADMIN mint, which extends the shape", () => {
+    expect(
+      AdminMintQuoteReq.safeParse(
+        body({ partner_id: "part_1", duties_prepaid: true })
+      ).success
+    ).toBe(false)
+    expect(
+      AdminMintQuoteReq.safeParse(
+        body({
+          partner_id: "part_1",
+          duties_prepaid: true,
+          duty_total: 12_000,
+          duty_basis: "EU 12% ad valorem, HS 6304.92",
+        })
+      ).success
+    ).toBe(true)
+  })
+
+  it("holds on the readiness preflight, which omits from the shape", () => {
+    // A preflight that accepted what the mint rejects tells a partner their
+    // quote is ready and then refuses it.
+    expect(
+      QuoteReadinessReq.safeParse(readiness({ duties_prepaid: true })).success
+    ).toBe(false)
+  })
+})

--- a/apps/backend/src/api/partners/quotes/__tests__/duty-undertaking.unit.spec.ts
+++ b/apps/backend/src/api/partners/quotes/__tests__/duty-undertaking.unit.spec.ts
@@ -2,12 +2,16 @@ import { AdminMintQuoteReq } from "../../../admin/quotes/validators"
 import { PartnerMintQuoteReq, QuoteReadinessReq } from "../validators"
 
 /**
- * The DDP promise may not travel without its number (#1447).
+ * The DDP promise may not travel without its numbers (#1447).
  *
  * 🔴 `duties_prepaid` used to be accepted alone. It flips the buyer's page to
  * "nothing further to pay on delivery" and adds nothing to the price, so the
- * duty is absorbed out of margin by an amount nobody computed — and the quote
- * carries no record that a figure was ever owed.
+ * charges are absorbed out of margin by an amount nobody computed — and the
+ * quote carries no record that anything was ever owed.
+ *
+ * 🔴 And there are THREE of them. On DHL's own numbers for a 70,000 INR
+ * consignment to NL, the duty is 6,143 and the import VAT is 17,416 — funding
+ * only the duty under-writes the promise by most of its value.
  *
  * All FOUR schemas are asserted here on purpose. The admin twin extends the
  * shape and the readiness preflight omits from it; `.extend()` and `.omit()` on
@@ -28,33 +32,54 @@ const readiness = (over: Record<string, any> = {}) => {
 }
 
 describe("the DDP undertaking needs a duty figure", () => {
-  it("refuses duties_prepaid with no amount", () => {
+  it("refuses duties_prepaid with no duty answer at all", () => {
     const parsed = PartnerMintQuoteReq.safeParse(
-      body({ duties_prepaid: true, duty_basis: "EU 12% ad valorem" })
+      body({
+        duties_prepaid: true,
+        import_tax_rate_percent: 21,
+        duty_basis: "EU, NL VAT",
+      })
     )
 
     expect(parsed.success).toBe(false)
-    expect(JSON.stringify(parsed.error?.issues)).toContain("duty_total")
+    expect(JSON.stringify(parsed.error?.issues)).toContain("duty")
   })
 
-  it("refuses duties_prepaid with an amount and no basis", () => {
+  it("🔴 refuses a DDP quote that funds the duty and forgets the import tax", () => {
+    // The whole point of the split. 8% duty is the small half; the 21% VAT on
+    // (goods + freight + duty) is the big one, and a promise funded at a
+    // quarter of its value fails silently, on our side of the ledger.
+    const parsed = PartnerMintQuoteReq.safeParse(
+      body({
+        duties_prepaid: true,
+        duty_rate_percent: 8,
+        duty_basis: "EU 8% ad valorem, HS 6304.92",
+      })
+    )
+
+    expect(parsed.success).toBe(false)
+    expect(JSON.stringify(parsed.error?.issues)).toContain("import_tax")
+  })
+
+  it("refuses a DDP quote with figures and no basis", () => {
     // A bare 0 cannot say whether it means "checked, AI-ECTA, nil" or "left
     // blank", and the person who meets the customs invoice is not the one who
     // typed it.
     const parsed = PartnerMintQuoteReq.safeParse(
-      body({ duties_prepaid: true, duty_total: 0 })
+      body({ duties_prepaid: true, duty_total: 0, import_tax_total: 0 })
     )
 
     expect(parsed.success).toBe(false)
     expect(JSON.stringify(parsed.error?.issues)).toContain("duty_basis")
   })
 
-  it("accepts a nil duty stated with its basis", () => {
+  it("accepts nil charges stated with their basis", () => {
     const parsed = PartnerMintQuoteReq.safeParse(
       body({
         destination_country_code: "au",
         duties_prepaid: true,
         duty_total: 0,
+        import_tax_total: 0,
         duty_basis: "AI-ECTA — Indian textiles enter AU duty-free",
       })
     )
@@ -62,10 +87,46 @@ describe("the DDP undertaking needs a duty figure", () => {
     expect(parsed.success).toBe(true)
   })
 
-  it("refuses a duty amount on a quote that is not DDP", () => {
-    const parsed = PartnerMintQuoteReq.safeParse(body({ duty_total: 12_000 }))
+  it("accepts the rate form, which is the normal one", () => {
+    const parsed = PartnerMintQuoteReq.safeParse(
+      body({
+        duties_prepaid: true,
+        duty_rate_percent: 8,
+        import_tax_rate_percent: 21,
+        ddp_fee_total: 1_981.57,
+        duty_basis: "EU: 8% duty, 21% NL VAT, DHL DTP fee",
+      })
+    )
+
+    expect(parsed.success).toBe(true)
+  })
+
+  it("refuses a rate AND an amount for the same charge", () => {
+    // Ranking them would mean "which one wins" has an answer. It should not —
+    // the same rule the per-line discount/override pair follows.
+    const parsed = PartnerMintQuoteReq.safeParse(
+      body({
+        duties_prepaid: true,
+        duty_rate_percent: 8,
+        duty_total: 6_143.36,
+        import_tax_rate_percent: 21,
+        duty_basis: "both, by mistake",
+      })
+    )
 
     expect(parsed.success).toBe(false)
+  })
+
+  it("refuses DDP figures on a quote that is not DDP", () => {
+    expect(PartnerMintQuoteReq.safeParse(body({ duty_total: 12_000 })).success).toBe(
+      false
+    )
+    expect(
+      PartnerMintQuoteReq.safeParse(body({ import_tax_rate_percent: 21 })).success
+    ).toBe(false)
+    expect(
+      PartnerMintQuoteReq.safeParse(body({ ddp_fee_total: 1_981.57 })).success
+    ).toBe(false)
   })
 
   it("leaves an ordinary quote alone", () => {
@@ -83,8 +144,9 @@ describe("the DDP undertaking needs a duty figure", () => {
         body({
           partner_id: "part_1",
           duties_prepaid: true,
-          duty_total: 12_000,
-          duty_basis: "EU 12% ad valorem, HS 6304.92",
+          duty_rate_percent: 8,
+          import_tax_rate_percent: 21,
+          duty_basis: "EU: 8% duty, 21% NL VAT, HS 6304.92",
         })
       ).success
     ).toBe(true)

--- a/apps/backend/src/api/partners/quotes/route.ts
+++ b/apps/backend/src/api/partners/quotes/route.ts
@@ -66,6 +66,7 @@ export const POST = async (
       currency_code: body.currency_code,
       region_id: body.region_id ?? null,
       carrier: body.carrier,
+      duties_prepaid: body.duties_prepaid ?? false,
       ttl_days: body.ttl_days,
       created_by: req.auth_context?.actor_id ?? null,
     },

--- a/apps/backend/src/api/partners/quotes/route.ts
+++ b/apps/backend/src/api/partners/quotes/route.ts
@@ -71,6 +71,12 @@ export const POST = async (
       // refused one without the other, so these two travel together or not at all.
       duty_total: body.duty_total ?? null,
       duty_basis: body.duty_basis ?? null,
+      // The rate form is the normal one; the AMOUNTS are computed by the view
+      // against the basket it actually priced, never taken from the client.
+      duty_rate_percent: body.duty_rate_percent ?? null,
+      import_tax_rate_percent: body.import_tax_rate_percent ?? null,
+      import_tax_total: body.import_tax_total ?? null,
+      ddp_fee_total: body.ddp_fee_total ?? null,
       ttl_days: body.ttl_days,
       created_by: req.auth_context?.actor_id ?? null,
     },

--- a/apps/backend/src/api/partners/quotes/route.ts
+++ b/apps/backend/src/api/partners/quotes/route.ts
@@ -67,6 +67,10 @@ export const POST = async (
       region_id: body.region_id ?? null,
       carrier: body.carrier,
       duties_prepaid: body.duties_prepaid ?? false,
+      // The number behind the promise (#1447). The validator has already
+      // refused one without the other, so these two travel together or not at all.
+      duty_total: body.duty_total ?? null,
+      duty_basis: body.duty_basis ?? null,
       ttl_days: body.ttl_days,
       created_by: req.auth_context?.actor_id ?? null,
     },

--- a/apps/backend/src/api/partners/quotes/validators.ts
+++ b/apps/backend/src/api/partners/quotes/validators.ts
@@ -45,7 +45,73 @@ const QuoteLine = z
     }
   )
 
-export const PartnerMintQuoteReq = z.object({
+/**
+ * A quote may not promise duty cover without saying how much (#1447).
+ *
+ * 🔴 `duties_prepaid` on its own tells the buyer "import duty is included and
+ * paid by us" and adds NOTHING to the price — the amount comes out of margin,
+ * uncomputed, and nobody downstream learns a figure was ever owed. Nothing can
+ * derive it for us yet (HS codes are incomplete; Shiprocket's tariff endpoint is
+ * gated on CSB-5 KYC), so the number is entered by hand and the schema refuses
+ * the promise without it.
+ *
+ * `0` is accepted and is a real answer — AI-ECTA makes Indian textiles duty-free
+ * into Australia — which is exactly why `duty_basis` is required alongside it:
+ * a bare 0 cannot say whether it means "checked, nil" or "left blank".
+ *
+ * The reverse is refused too. A duty amount on a quote that is NOT DDP would be
+ * added to a total whose buyer was told duty is theirs to pay on arrival —
+ * charging them twice for the same border.
+ *
+ * Shared by all four mint/readiness schemas rather than restated: a preflight
+ * that accepted what the mint rejects would tell a partner their quote is ready
+ * and then refuse it.
+ */
+export const dutyUndertakingRefinement = (
+  body: { duties_prepaid?: boolean | null; duty_total?: number | null; duty_basis?: string | null },
+  ctx: z.RefinementCtx
+) => {
+  const prepaid = Boolean(body.duties_prepaid)
+  const hasAmount = body.duty_total !== null && body.duty_total !== undefined
+
+  if (prepaid && !hasAmount) {
+    ctx.addIssue({
+      code: "custom",
+      message:
+        "A DDP quote must carry duty_total — the amount of destination duty we are undertaking to pay, in the quote currency. " +
+        "Without it the buyer is promised duty cover that adds nothing to the price and is absorbed out of margin. " +
+        "Enter 0 with a duty_basis where the lane is genuinely duty-free (e.g. AI-ECTA into AU).",
+      path: ["duty_total"],
+    })
+  }
+
+  if (prepaid && !String(body.duty_basis ?? "").trim()) {
+    ctx.addIssue({
+      code: "custom",
+      message:
+        "A DDP quote must carry duty_basis — how the figure was arrived at (e.g. \"EU 12% ad valorem, HS 6304.92\", \"AI-ECTA duty-free\"). " +
+        "It is the only record of why we committed to this amount, and whoever meets the customs invoice is not who typed it.",
+      path: ["duty_basis"],
+    })
+  }
+
+  if (!prepaid && hasAmount) {
+    ctx.addIssue({
+      code: "custom",
+      message:
+        "duty_total is only valid with duties_prepaid. On a non-DDP quote the buyer pays duty at their own border, so adding it here charges them twice.",
+      path: ["duty_total"],
+    })
+  }
+}
+
+/**
+ * The mint body's SHAPE, before the cross-field rule.
+ *
+ * Kept as a plain object because the admin twin extends it and the readiness
+ * preflight omits from it — neither survives on a refined schema.
+ */
+export const PartnerMintQuoteShape = z.object({
   buyer_email: z.string().email(),
   recipient_name: z.string().nullish(),
   recipient_company: z.string().nullish(),
@@ -63,6 +129,13 @@ export const PartnerMintQuoteReq = z.object({
    * it must never be a default.
    */
   duties_prepaid: z.boolean().optional(),
+  /**
+   * The duty we undertake to pay, in the QUOTE currency, and how that number
+   * was reached. Required together with `duties_prepaid` — see
+   * `dutyUndertakingRefinement`.
+   */
+  duty_total: z.number().min(0).nullish(),
+  duty_basis: z.string().max(500).nullish(),
 
   currency_code: z.string().min(3),
   region_id: z.string().nullish(),
@@ -71,6 +144,10 @@ export const PartnerMintQuoteReq = z.object({
   /** Drives `price_list.ends_at`, so expiry is native rather than swept. */
   ttl_days: z.number().int().positive().max(365).optional(),
 })
+
+export const PartnerMintQuoteReq = PartnerMintQuoteShape.superRefine(
+  dutyUndertakingRefinement
+)
 
 /**
  * The readiness preflight body (#1445).
@@ -81,12 +158,16 @@ export const PartnerMintQuoteReq = z.object({
  * rejects, which is worse than having no preflight: it would tell a partner
  * their quote is ready and then refuse it.
  */
-export const QuoteReadinessReq = PartnerMintQuoteReq.omit({
+export const QuoteReadinessShape = PartnerMintQuoteShape.omit({
   buyer_email: true,
   recipient_name: true,
   recipient_company: true,
   partner_note: true,
   ttl_days: true,
 })
+
+export const QuoteReadinessReq = QuoteReadinessShape.superRefine(
+  dutyUndertakingRefinement
+)
 
 export type QuoteReadinessReqType = z.infer<typeof QuoteReadinessReq>

--- a/apps/backend/src/api/partners/quotes/validators.ts
+++ b/apps/backend/src/api/partners/quotes/validators.ts
@@ -57,6 +57,12 @@ export const PartnerMintQuoteReq = z.object({
   destination_country_code: z.string().min(2),
   destination_postal_code: z.string().nullish(),
   destination_city: z.string().nullish(),
+  /**
+   * Quote this as DDP: we pay the destination duty and import tax, the buyer
+   * pays nothing on arrival. Opt-in per quote — see the model docblock for why
+   * it must never be a default.
+   */
+  duties_prepaid: z.boolean().optional(),
 
   currency_code: z.string().min(3),
   region_id: z.string().nullish(),

--- a/apps/backend/src/api/partners/quotes/validators.ts
+++ b/apps/backend/src/api/partners/quotes/validators.ts
@@ -48,6 +48,17 @@ const QuoteLine = z
 /**
  * A quote may not promise duty cover without saying how much (#1447).
  *
+ * ## Three charges, not one
+ *
+ * DHL's landed-cost planner on a 70,000 INR consignment to NL: duty 6,143 (8%
+ * of goods + freight), import VAT 17,416 (21% of goods + freight + duty), and
+ * a 1,982 carrier fee for advancing them. 🔴 **The duty is the small half.** A
+ * partner who funds only the duty under-writes "nothing further to pay" by
+ * roughly three quarters of its value, and nobody finds out, because the
+ * shortfall lands on margin rather than on the buyer. So the schema requires a
+ * duty answer AND an import-tax answer, each of which may be `0` when the lane
+ * genuinely carries none.
+ *
  * 🔴 `duties_prepaid` on its own tells the buyer "import duty is included and
  * paid by us" and adds NOTHING to the price — the amount comes out of margin,
  * uncomputed, and nobody downstream learns a figure was ever owed. Nothing can
@@ -68,20 +79,41 @@ const QuoteLine = z
  * and then refuse it.
  */
 export const dutyUndertakingRefinement = (
-  body: { duties_prepaid?: boolean | null; duty_total?: number | null; duty_basis?: string | null },
+  body: {
+    duties_prepaid?: boolean | null
+    duty_total?: number | null
+    duty_rate_percent?: number | null
+    import_tax_total?: number | null
+    import_tax_rate_percent?: number | null
+    ddp_fee_total?: number | null
+    duty_basis?: string | null
+  },
   ctx: z.RefinementCtx
 ) => {
   const prepaid = Boolean(body.duties_prepaid)
-  const hasAmount = body.duty_total !== null && body.duty_total !== undefined
+  const given = (v: unknown) => v !== null && v !== undefined
+  const hasDuty = given(body.duty_total) || given(body.duty_rate_percent)
+  const hasImportTax =
+    given(body.import_tax_total) || given(body.import_tax_rate_percent)
 
-  if (prepaid && !hasAmount) {
+  if (prepaid && !hasDuty) {
     ctx.addIssue({
       code: "custom",
       message:
-        "A DDP quote must carry duty_total — the amount of destination duty we are undertaking to pay, in the quote currency. " +
-        "Without it the buyer is promised duty cover that adds nothing to the price and is absorbed out of margin. " +
+        "A DDP quote must say what duty we are absorbing — a rate (duty_rate_percent) or a flat duty_total. " +
         "Enter 0 with a duty_basis where the lane is genuinely duty-free (e.g. AI-ECTA into AU).",
-      path: ["duty_total"],
+      path: ["duty_rate_percent"],
+    })
+  }
+
+  if (prepaid && !hasImportTax) {
+    ctx.addIssue({
+      code: "custom",
+      message:
+        "A DDP quote must also say what destination import tax we are absorbing (import_tax_rate_percent, or a flat import_tax_total). " +
+        "It is usually the LARGEST of the three charges — 21% VAT on goods + freight + duty dwarfs an 8% duty — so funding only the duty under-writes the promise by most of its value. " +
+        "Enter 0 where none is due.",
+      path: ["import_tax_rate_percent"],
     })
   }
 
@@ -89,17 +121,38 @@ export const dutyUndertakingRefinement = (
     ctx.addIssue({
       code: "custom",
       message:
-        "A DDP quote must carry duty_basis — how the figure was arrived at (e.g. \"EU 12% ad valorem, HS 6304.92\", \"AI-ECTA duty-free\"). " +
-        "It is the only record of why we committed to this amount, and whoever meets the customs invoice is not who typed it.",
+        "A DDP quote must carry duty_basis — how the figures were arrived at (e.g. \"EU: 8% duty, 21% NL VAT, HS 6304.92\"). " +
+        "It is the only record of why we committed to these amounts, and whoever meets the customs invoice is not who typed them.",
       path: ["duty_basis"],
     })
   }
 
-  if (!prepaid && hasAmount) {
+  if (given(body.duty_total) && given(body.duty_rate_percent)) {
     ctx.addIssue({
       code: "custom",
       message:
-        "duty_total is only valid with duties_prepaid. On a non-DDP quote the buyer pays duty at their own border, so adding it here charges them twice.",
+        "Give a duty RATE or a flat duty amount, never both — 'which one wins' is a question that should not have an answer.",
+      path: ["duty_total"],
+    })
+  }
+
+  if (given(body.import_tax_total) && given(body.import_tax_rate_percent)) {
+    ctx.addIssue({
+      code: "custom",
+      message:
+        "Give an import tax RATE or a flat amount, never both.",
+      path: ["import_tax_total"],
+    })
+  }
+
+  if (
+    !prepaid &&
+    (hasDuty || hasImportTax || given(body.ddp_fee_total))
+  ) {
+    ctx.addIssue({
+      code: "custom",
+      message:
+        "Duty, import tax and the DDP fee are only valid with duties_prepaid. On a non-DDP quote the buyer pays them at their own border, so charging them here bills the same border twice.",
       path: ["duty_total"],
     })
   }
@@ -136,6 +189,17 @@ export const PartnerMintQuoteShape = z.object({
    */
   duty_total: z.number().min(0).nullish(),
   duty_basis: z.string().max(500).nullish(),
+  /**
+   * The rate form — preferred, because the amounts are then computed against
+   * the basket the mint actually prices rather than the one the wizard guessed.
+   * Capped at 100: a duty rate above that is a typo, and a typo here is a
+   * liability we take on.
+   */
+  duty_rate_percent: z.number().min(0).max(100).nullish(),
+  import_tax_rate_percent: z.number().min(0).max(100).nullish(),
+  import_tax_total: z.number().min(0).nullish(),
+  /** The carrier's advance/disbursement fee. An amount, never a rate. */
+  ddp_fee_total: z.number().min(0).nullish(),
 
   currency_code: z.string().min(3),
   region_id: z.string().nullish(),

--- a/apps/backend/src/lib/shipping-estimate.ts
+++ b/apps/backend/src/lib/shipping-estimate.ts
@@ -344,6 +344,31 @@ export async function buildShippingEstimate(
 
   // ---- Calculated rates — cached per lane --------------------------------
   const carrier = String(input.carrier || "shiprocket").toLowerCase()
+
+  /**
+   * "manual" is an explicit choice to ask NO carrier (#1447).
+   *
+   * 🔑 Distinct from a carrier that fails: a failure logs, sets
+   * `calculated_error` and warrants an "indicative rate" notice on the buyer's
+   * page. This is someone deciding the lane is priced by hand, so there is
+   * nothing to report and nothing to retry — the manual tiers gathered above
+   * are the whole answer.
+   */
+  if (carrier === "manual" || carrier === "none") {
+    return {
+      lines,
+      total_weight_grams: totalWeightGrams,
+      origin_postal_code: originPostalCode,
+      destination_postal_code: destinationPostalCode,
+      country_code: countryCode,
+      manual,
+      calculated: [],
+      calculated_error: null,
+      cache_hit: false,
+      is_estimate: true,
+    }
+  }
+
   const weightBucket = weightBucketGrams(totalWeightGrams)
   const cacheKey = `shipping-estimate:${carrier}:${originPostalCode}:${destinationPostalCode}:${countryCode}:${weightBucket}`
 

--- a/apps/backend/src/modules/partner-quote/__tests__/build-quote-view.unit.spec.ts
+++ b/apps/backend/src/modules/partner-quote/__tests__/build-quote-view.unit.spec.ts
@@ -347,6 +347,26 @@ describe("buildQuoteView — the free-shipping row that quoted every bulk consig
     expect(view.freight.chosen?.amount).toBe(3900)
   })
 
+  it("asks NO carrier when the quote is priced manually (#1447)", async () => {
+    const captured: Captured = { contexts: [], rateWeights: [] }
+    ;(global as any).__rateWeights = []
+
+    const view = await buildQuoteView(
+      scopeWith(captured, {
+        manual: [{ ...FREE_OVER_2999, prices: [FREE_OVER_2999.prices[0]] }],
+      }) as any,
+      baseInput({ carrier: "manual" })
+    )
+
+    // 🔑 Distinct from a carrier that FAILED: nothing is retried, nothing is
+    // logged as an error, and the page must not tell the buyer the figure is an
+    // indicative fallback. Someone chose to price this lane by hand.
+    expect((global as any).__rateWeights).toHaveLength(0)
+    expect(view.freight.options.map((o) => o.source)).not.toContain("calculated")
+    expect(view.freight.chosen?.amount).toBe(99)
+    expect(view.freight.error).toBeNull()
+  })
+
   it("still keeps an ordinary unconditional flat price", async () => {
     const captured: Captured = { contexts: [], rateWeights: [] }
     const view = await buildQuoteView(
@@ -711,33 +731,33 @@ describe("buildQuoteView — provenance", () => {
  */
 describe("prepaid duty (#1447)", () => {
   it("adds the duty to what the buyer pays, and never to landed_total", () => {
-    const money = composeQuoteMoney(
-      [100_000],
-      100,
-      5_000,
-      { total: 0, inclusive: false },
-      12_000
-    )
+    const money = composeQuoteMoney([100_000], 100, 5_000, { total: 0, inclusive: false }, {
+      duty: 8_400,
+      import_tax: 22_764,
+      fee: 1_982,
+    })
 
     // `landed_total` keeps the meaning every frozen row on disk already has.
     expect(money.landed_total).toBe(105_000)
-    expect(money.duty_total).toBe(12_000)
-    expect(money.gross_total).toBe(117_000)
+    expect(money.duty_total).toBe(8_400)
+    // 🔴 The import tax is the big one — funding only the duty would leave
+    // three quarters of this promise on our margin.
+    expect(money.import_tax_total).toBe(22_764)
+    expect(money.ddp_fee_total).toBe(1_982)
+    expect(money.gross_total).toBe(138_146)
   })
 
   it("adds the duty on tax-INCLUSIVE prices too", () => {
     // Tax is already inside the prices; duty is a destination-border charge the
     // line prices know nothing about, so the two are not symmetrical.
-    const money = composeQuoteMoney(
-      [100_000],
-      100,
-      5_000,
-      { total: 16_017, inclusive: true },
-      12_000
-    )
+    const money = composeQuoteMoney([100_000], 100, 5_000, { total: 16_017, inclusive: true }, {
+      duty: 8_400,
+      import_tax: 22_764,
+      fee: 1_982,
+    })
 
     expect(money.tax_total).toBe(16_017)
-    expect(money.gross_total).toBe(117_000)
+    expect(money.gross_total).toBe(138_146)
   })
 
   it("carries no duty figure when none was given — null, not zero", () => {
@@ -746,13 +766,19 @@ describe("prepaid duty (#1447)", () => {
     // Null is "not a DDP quote"; 0 would be "duty applies to this lane and is
     // nil", which is a claim about AI-ECTA we have not made here.
     expect(money.duty_total).toBeNull()
+    expect(money.import_tax_total).toBeNull()
     expect(money.gross_total).toBe(105_000)
   })
 
   it("keeps a nil duty distinguishable from no duty", () => {
-    const money = composeQuoteMoney([100_000], 100, 5_000, { total: 0, inclusive: false }, 0)
+    const money = composeQuoteMoney([100_000], 100, 5_000, { total: 0, inclusive: false }, {
+      duty: 0,
+      import_tax: 0,
+      fee: 0,
+    })
 
     expect(money.duty_total).toBe(0)
+    expect(money.import_tax_total).toBe(0)
     expect(money.gross_total).toBe(105_000)
   })
 
@@ -763,12 +789,15 @@ describe("prepaid duty (#1447)", () => {
       quoted_landed_total: 105_000,
       quoted_tax_total: 0,
       quoted_tax_inclusive: false,
-      quoted_duty_total: 12_000,
+      quoted_duty_total: 8_400,
+      quoted_import_tax_total: 22_764,
+      quoted_ddp_fee_total: 1_982,
       lines: [{ variant_id: "var_a", quantity: 100 }],
     })
 
-    expect(money?.duty_total).toBe(12_000)
-    expect(money?.gross_total).toBe(117_000)
+    expect(money?.duty_total).toBe(8_400)
+    expect(money?.import_tax_total).toBe(22_764)
+    expect(money?.gross_total).toBe(138_146)
   })
 
   it("reports no duty figure for a quote minted before the column existed", () => {
@@ -782,6 +811,7 @@ describe("prepaid duty (#1447)", () => {
     })
 
     expect(money?.duty_total).toBeNull()
+    expect(money?.import_tax_total).toBeNull()
     // Unchanged for every quote already on disk.
     expect(money?.gross_total).toBe(105_000)
   })
@@ -792,15 +822,33 @@ describe("prepaid duty (#1447)", () => {
       scopeWith(captured) as any,
       baseInput({
         duties_prepaid: true,
-        duty_total: 12_000,
-        duty_basis: "EU 12% ad valorem, HS 6304.92",
+        duty_rate_percent: 8,
+        import_tax_rate_percent: 21,
+        ddp_fee_total: 1_981.57,
+        duty_basis: "EU: 8% duty, 21% NL VAT, HS 6304.92",
       })
     )
 
+    // 🔴 Computed against the basket that was actually priced — 500 units at
+    // the qty-tier price of 800, plus the freight the lane really quoted. A
+    // wizard cannot know either before the mint runs, so a client-side figure
+    // would be an estimate frozen as a commitment.
+    const dutiable = (view.live?.subtotal ?? 0) + (view.live?.freight ?? 0)
     expect(view.duty.prepaid).toBe(true)
-    expect(view.duty.total).toBe(12_000)
-    expect(view.duty.basis).toBe("EU 12% ad valorem, HS 6304.92")
-    expect(view.live?.duty_total).toBe(12_000)
+    expect(view.duty.total).toBeCloseTo(dutiable * 0.08, 2)
+    expect(view.duty.import_tax).toBeCloseTo(
+      (dutiable + (view.duty.total ?? 0)) * 0.21,
+      2
+    )
+    expect(view.duty.carrier_fee).toBe(1_981.57)
+    expect(view.duty.combined_total).toBeCloseTo(
+      (view.duty.total ?? 0) + (view.duty.import_tax ?? 0) + 1_981.57,
+      2
+    )
+    expect(view.duty.duty_rate_percent).toBe(8)
+    expect(view.duty.import_tax_rate_percent).toBe(21)
+    expect(view.duty.basis).toBe("EU: 8% duty, 21% NL VAT, HS 6304.92")
+    expect(view.live?.import_tax_total).toBe(view.duty.import_tax)
   })
 
   it("refuses to carry a duty amount on a quote that is NOT DDP", async () => {
@@ -810,13 +858,21 @@ describe("prepaid duty (#1447)", () => {
       // The API refuses this pairing, but the builder is reached by the admin
       // twin and the freeze as well. A stray amount here would be added to a
       // total whose buyer was told duty is theirs to pay on arrival.
-      baseInput({ duties_prepaid: false, duty_total: 12_000, duty_basis: "typo" })
+      baseInput({
+        duties_prepaid: false,
+        duty_rate_percent: 8,
+        import_tax_rate_percent: 21,
+        duty_basis: "typo",
+      })
     )
 
     expect(view.duty.prepaid).toBe(false)
     expect(view.duty.total).toBeNull()
+    expect(view.duty.import_tax).toBeNull()
+    expect(view.duty.combined_total).toBeNull()
     expect(view.duty.basis).toBeNull()
     expect(view.live?.duty_total).toBeNull()
+    expect(view.live?.import_tax_total).toBeNull()
   })
 
   it("still states the undertaking on a DEAD link", async () => {
@@ -827,8 +883,12 @@ describe("prepaid duty (#1447)", () => {
         quote: {
           status: "revoked",
           duties_prepaid: true,
-          quoted_duty_total: 12_000,
-          quoted_duty_basis: "EU 12% ad valorem, HS 6304.92",
+          quoted_duty_total: 6_143.36,
+          quoted_import_tax_total: 17_416.43,
+          quoted_ddp_fee_total: 1_981.57,
+          quoted_duty_rate: 8,
+          quoted_import_tax_rate: 21,
+          quoted_duty_basis: "EU: 8% duty, 21% NL VAT, HS 6304.92",
           quoted_subtotal: 100_000,
           quoted_freight: 5_000,
           quoted_landed_total: 105_000,
@@ -844,9 +904,12 @@ describe("prepaid duty (#1447)", () => {
     // quote is the RECORD of what was promised, so the promise has to survive it.
     expect(view.live).toBeNull()
     expect(view.duty.prepaid).toBe(true)
-    expect(view.duty.total).toBe(12_000)
-    expect(view.duty.basis).toBe("EU 12% ad valorem, HS 6304.92")
-    expect(view.quoted?.duty_total).toBe(12_000)
-    expect(view.quoted?.gross_total).toBe(117_000)
+    expect(view.duty.total).toBe(6_143.36)
+    expect(view.duty.import_tax).toBe(17_416.43)
+    expect(view.duty.carrier_fee).toBe(1_981.57)
+    expect(view.duty.basis).toBe("EU: 8% duty, 21% NL VAT, HS 6304.92")
+    expect(view.quoted?.duty_total).toBe(6_143.36)
+    // 105,000 + 6,143.36 + 17,416.43 + 1,981.57
+    expect(view.quoted?.gross_total).toBeCloseTo(130_541.36, 2)
   })
 })

--- a/apps/backend/src/modules/partner-quote/__tests__/build-quote-view.unit.spec.ts
+++ b/apps/backend/src/modules/partner-quote/__tests__/build-quote-view.unit.spec.ts
@@ -699,3 +699,154 @@ describe("buildQuoteView — provenance", () => {
     expect(view.live?.landed_total).toBeGreaterThan(0)
   })
 })
+
+/**
+ * The manual customs duty (#1447).
+ *
+ * 🔴 The defect these exist to keep dead: `duties_prepaid` told the buyer
+ * "import duty is included and paid by us" while `composeQuoteMoney` was
+ * `subtotal + freight (+ tax)`. The promise added nothing to the price, so the
+ * duty came out of margin by an amount nobody had computed and nothing
+ * downstream ever learned a figure was owed.
+ */
+describe("prepaid duty (#1447)", () => {
+  it("adds the duty to what the buyer pays, and never to landed_total", () => {
+    const money = composeQuoteMoney(
+      [100_000],
+      100,
+      5_000,
+      { total: 0, inclusive: false },
+      12_000
+    )
+
+    // `landed_total` keeps the meaning every frozen row on disk already has.
+    expect(money.landed_total).toBe(105_000)
+    expect(money.duty_total).toBe(12_000)
+    expect(money.gross_total).toBe(117_000)
+  })
+
+  it("adds the duty on tax-INCLUSIVE prices too", () => {
+    // Tax is already inside the prices; duty is a destination-border charge the
+    // line prices know nothing about, so the two are not symmetrical.
+    const money = composeQuoteMoney(
+      [100_000],
+      100,
+      5_000,
+      { total: 16_017, inclusive: true },
+      12_000
+    )
+
+    expect(money.tax_total).toBe(16_017)
+    expect(money.gross_total).toBe(117_000)
+  })
+
+  it("carries no duty figure when none was given — null, not zero", () => {
+    const money = composeQuoteMoney([100_000], 100, 5_000, { total: 0, inclusive: false })
+
+    // Null is "not a DDP quote"; 0 would be "duty applies to this lane and is
+    // nil", which is a claim about AI-ECTA we have not made here.
+    expect(money.duty_total).toBeNull()
+    expect(money.gross_total).toBe(105_000)
+  })
+
+  it("keeps a nil duty distinguishable from no duty", () => {
+    const money = composeQuoteMoney([100_000], 100, 5_000, { total: 0, inclusive: false }, 0)
+
+    expect(money.duty_total).toBe(0)
+    expect(money.gross_total).toBe(105_000)
+  })
+
+  it("reads the frozen duty back onto the quoted half", () => {
+    const money = frozenMoney({
+      quoted_subtotal: 100_000,
+      quoted_freight: 5_000,
+      quoted_landed_total: 105_000,
+      quoted_tax_total: 0,
+      quoted_tax_inclusive: false,
+      quoted_duty_total: 12_000,
+      lines: [{ variant_id: "var_a", quantity: 100 }],
+    })
+
+    expect(money?.duty_total).toBe(12_000)
+    expect(money?.gross_total).toBe(117_000)
+  })
+
+  it("reports no duty figure for a quote minted before the column existed", () => {
+    const money = frozenMoney({
+      quoted_subtotal: 100_000,
+      quoted_freight: 5_000,
+      quoted_landed_total: 105_000,
+      quoted_tax_total: 0,
+      quoted_tax_inclusive: false,
+      lines: [{ variant_id: "var_a", quantity: 100 }],
+    })
+
+    expect(money?.duty_total).toBeNull()
+    // Unchanged for every quote already on disk.
+    expect(money?.gross_total).toBe(105_000)
+  })
+
+  it("surfaces the undertaking, the amount and the basis at mint", async () => {
+    const captured: Captured = { contexts: [], rateWeights: [] }
+    const view = await buildQuoteView(
+      scopeWith(captured) as any,
+      baseInput({
+        duties_prepaid: true,
+        duty_total: 12_000,
+        duty_basis: "EU 12% ad valorem, HS 6304.92",
+      })
+    )
+
+    expect(view.duty.prepaid).toBe(true)
+    expect(view.duty.total).toBe(12_000)
+    expect(view.duty.basis).toBe("EU 12% ad valorem, HS 6304.92")
+    expect(view.live?.duty_total).toBe(12_000)
+  })
+
+  it("refuses to carry a duty amount on a quote that is NOT DDP", async () => {
+    const captured: Captured = { contexts: [], rateWeights: [] }
+    const view = await buildQuoteView(
+      scopeWith(captured) as any,
+      // The API refuses this pairing, but the builder is reached by the admin
+      // twin and the freeze as well. A stray amount here would be added to a
+      // total whose buyer was told duty is theirs to pay on arrival.
+      baseInput({ duties_prepaid: false, duty_total: 12_000, duty_basis: "typo" })
+    )
+
+    expect(view.duty.prepaid).toBe(false)
+    expect(view.duty.total).toBeNull()
+    expect(view.duty.basis).toBeNull()
+    expect(view.live?.duty_total).toBeNull()
+  })
+
+  it("still states the undertaking on a DEAD link", async () => {
+    const captured: Captured = { contexts: [], rateWeights: [] }
+    const view = await buildQuoteView(
+      scopeWith(captured) as any,
+      baseInput({
+        quote: {
+          status: "revoked",
+          duties_prepaid: true,
+          quoted_duty_total: 12_000,
+          quoted_duty_basis: "EU 12% ad valorem, HS 6304.92",
+          quoted_subtotal: 100_000,
+          quoted_freight: 5_000,
+          quoted_landed_total: 105_000,
+          quoted_tax_total: 0,
+          quoted_tax_inclusive: false,
+          lines: [{ variant_id: "var_a", quantity: 100 }],
+        },
+      })
+    )
+
+    // The live half is skipped entirely on a dead link — the same path that
+    // silently dropped the whole tax block until `frozenTaxFallback`. A revoked
+    // quote is the RECORD of what was promised, so the promise has to survive it.
+    expect(view.live).toBeNull()
+    expect(view.duty.prepaid).toBe(true)
+    expect(view.duty.total).toBe(12_000)
+    expect(view.duty.basis).toBe("EU 12% ad valorem, HS 6304.92")
+    expect(view.quoted?.duty_total).toBe(12_000)
+    expect(view.quoted?.gross_total).toBe(117_000)
+  })
+})

--- a/apps/backend/src/modules/partner-quote/__tests__/compare.unit.spec.ts
+++ b/apps/backend/src/modules/partner-quote/__tests__/compare.unit.spec.ts
@@ -13,6 +13,8 @@ const money = (over: Partial<QuoteMoney> = {}): QuoteMoney => ({
   // #1447 added `duty_total` the same way, and this fixture is where the
   // omission shows up: red on `check:prod-build`, green on jest.
   duty_total: null,
+  import_tax_total: null,
+  ddp_fee_total: null,
   gross_total: null,
   ...over,
 })

--- a/apps/backend/src/modules/partner-quote/__tests__/compare.unit.spec.ts
+++ b/apps/backend/src/modules/partner-quote/__tests__/compare.unit.spec.ts
@@ -10,6 +10,9 @@ const money = (over: Partial<QuoteMoney> = {}): QuoteMoney => ({
   // does not typecheck. Null, not 0: the comparison cases here are about goods
   // and freight, and a 0 would assert a tax answer none of them make.
   tax_total: null,
+  // #1447 added `duty_total` the same way, and this fixture is where the
+  // omission shows up: red on `check:prod-build`, green on jest.
+  duty_total: null,
   gross_total: null,
   ...over,
 })

--- a/apps/backend/src/modules/partner-quote/__tests__/ddp-charges.unit.spec.ts
+++ b/apps/backend/src/modules/partner-quote/__tests__/ddp-charges.unit.spec.ts
@@ -1,0 +1,129 @@
+import {
+  computeDdpCharges,
+  describeDdpBasis,
+  hasConflictingDdpInput,
+} from "../lib/ddp-charges"
+
+/**
+ * Pinned to DHL Express's own landed-cost planner, 2026-08-22 — a 70,000 INR
+ * consignment of 10 units to the Netherlands, transport 6,792:
+ *
+ *   customs duty       8% × 76,792  =  6,143.36
+ *   import VAT        21% × 82,935  = 17,416.43
+ *   duty-tax-paid fee                =  1,981.57
+ *
+ * 🔴 The two failure modes this file exists to catch are both silent and both
+ * land on our margin: applying the VAT rate to the goods alone (under by ~1,290
+ * here), and funding the duty while forgetting the tax (under by 17,416).
+ */
+describe("computeDdpCharges — the DHL worked example", () => {
+  const example = computeDdpCharges({
+    subtotal: 70_000,
+    freight: 6_792,
+    duty_rate_percent: 8,
+    import_tax_rate_percent: 21,
+    ddp_fee_total: 1_981.57,
+  })
+
+  it("assesses duty on goods PLUS freight", () => {
+    expect(example.dutiable_value).toBe(76_792)
+    expect(example.duty).toBe(6_143.36)
+  })
+
+  it("🔴 cascades — import tax is charged on a value that includes the duty", () => {
+    expect(example.import_tax).toBe(17_416.43)
+    // Assessed on the goods alone it would be 14,700; on goods + freight but
+    // without the duty, 16,126.32. Both are wrong in the same direction.
+    expect(example.import_tax).toBeGreaterThan(16_126.32)
+  })
+
+  it("sums to what DHL quoted as the DDP part of the landed cost", () => {
+    expect(example.carrier_fee).toBe(1_981.57)
+    expect(example.total).toBe(25_541.36)
+    // Goods + freight + the undertaking = DHL's total, give or take the
+    // surcharges that sit outside our freight figure.
+    expect(example.total + 76_792).toBeCloseTo(102_333.36, 2)
+  })
+
+  it("keeps the rates, so the figure can be re-derived rather than believed", () => {
+    expect(example.duty_rate_percent).toBe(8)
+    expect(example.import_tax_rate_percent).toBe(21)
+  })
+})
+
+describe("computeDdpCharges — the other forms", () => {
+  it("takes flat amounts where a rate cannot express the tariff line", () => {
+    // A specific duty is charged per kilo or per item; no percentage says it.
+    const charges = computeDdpCharges({
+      subtotal: 70_000,
+      freight: 6_792,
+      duty_total: 4_500,
+      import_tax_total: 12_000,
+    })
+
+    expect(charges.duty).toBe(4_500)
+    expect(charges.import_tax).toBe(12_000)
+    expect(charges.duty_rate_percent).toBeNull()
+    expect(charges.total).toBe(16_500)
+  })
+
+  it("returns zeros for a charge nobody described", () => {
+    // Deliberately not an error here: only the validator knows whether "no
+    // answer" means a duty-free lane or a half-filled form.
+    const charges = computeDdpCharges({ subtotal: 70_000, freight: 6_792 })
+
+    expect(charges.duty).toBe(0)
+    expect(charges.import_tax).toBe(0)
+    expect(charges.total).toBe(0)
+  })
+
+  it("treats a nil RATE as the real answer it is", () => {
+    // AI-ECTA: Indian textiles enter Australia duty-free, and a 0% duty still
+    // leaves a GST to compute on the CIF value.
+    const charges = computeDdpCharges({
+      subtotal: 70_000,
+      freight: 6_792,
+      duty_rate_percent: 0,
+      import_tax_rate_percent: 10,
+    })
+
+    expect(charges.duty).toBe(0)
+    expect(charges.import_tax).toBe(7_679.2)
+    expect(charges.duty_rate_percent).toBe(0)
+  })
+
+  it("flags a rate and an amount given for the same charge", () => {
+    expect(
+      hasConflictingDdpInput({
+        subtotal: 1,
+        freight: 0,
+        duty_rate_percent: 8,
+        duty_total: 500,
+      })
+    ).toBe(true)
+    expect(
+      hasConflictingDdpInput({
+        subtotal: 1,
+        freight: 0,
+        duty_rate_percent: 8,
+        import_tax_total: 500,
+      })
+    ).toBe(false)
+  })
+
+  it("writes down what was applied to what", () => {
+    const description = describeDdpBasis(
+      computeDdpCharges({
+        subtotal: 70_000,
+        freight: 6_792,
+        duty_rate_percent: 8,
+        import_tax_rate_percent: 21,
+        ddp_fee_total: 1_981.57,
+      })
+    )
+
+    expect(description).toContain("duty 8% of goods + freight")
+    expect(description).toContain("import tax 21% of goods + freight + duty")
+    expect(description).toContain("carrier duty-tax-paid fee")
+  })
+})

--- a/apps/backend/src/modules/partner-quote/__tests__/quote-tax.unit.spec.ts
+++ b/apps/backend/src/modules/partner-quote/__tests__/quote-tax.unit.spec.ts
@@ -306,3 +306,37 @@ describe("frozenTaxFallback", () => {
     expect(asExport.status).not.toBe(asUnknown.status)
   })
 })
+
+/**
+ * DDP — the partner absorbs destination duty (#1447).
+ *
+ * 🔴 The sentence this produces is a PROMISE, and the only one on the page that
+ * software alone cannot keep: the shipment has to actually clear DDP. Shiprocket
+ * reports `ddp_tag: false` on every lane today, so until a carrier supports it
+ * this is honoured by hand. That is exactly why it is per-quote and frozen — a
+ * global default would tell a buyer there is nothing to pay on a shipment
+ * nobody arranged clearance for, and they would meet a customs bill anyway.
+ */
+describe("exportDisclosureReason — duties prepaid", () => {
+  it("still says zero-rated, because the export treatment is unchanged", () => {
+    // DDP is who pays the DESTINATION's duty. It has no bearing on whether the
+    // origin zero-rates the export.
+    expect(exportDisclosureReason("in", "de", true)).toMatch(/zero-rated/)
+  })
+
+  it("promises nothing further on delivery, and drops the buyer-pays wording", () => {
+    const r = exportDisclosureReason("in", "de", true)
+    expect(r).toMatch(/included in this price/i)
+    expect(r).toMatch(/nothing further to pay on delivery/i)
+    // The two must never coexist — a page saying both is a page saying neither.
+    expect(r).not.toMatch(/payable by you/i)
+    expect(r).not.toMatch(/NOT included/)
+  })
+
+  it("defaults to buyer-pays when the flag is absent", () => {
+    // 🔑 The safe direction. An omitted flag must never be read as a promise:
+    // over-warning costs a conversation, under-warning costs the customs bill.
+    expect(exportDisclosureReason("in", "de")).toMatch(/payable by you/i)
+    expect(exportDisclosureReason("in", "de", false)).toMatch(/payable by you/i)
+  })
+})

--- a/apps/backend/src/modules/partner-quote/__tests__/quote-tax.unit.spec.ts
+++ b/apps/backend/src/modules/partner-quote/__tests__/quote-tax.unit.spec.ts
@@ -1,4 +1,8 @@
-import { composeQuoteMoney, frozenMoney } from "../lib/build-quote-view"
+import {
+  composeQuoteMoney,
+  frozenMoney,
+  frozenTaxFallback,
+} from "../lib/build-quote-view"
 import {
   classifyQuoteJurisdiction,
   exportDisclosureReason,
@@ -210,5 +214,95 @@ describe("export and unknown-origin wording", () => {
     expect(reason).toMatch(/could not establish/i)
     expect(reason).toMatch(/DE/)
     expect(reason).not.toMatch(/zero-rated/)
+  })
+})
+
+/**
+ * Freezing the tax (#1439 S8 tail).
+ *
+ * S8 computed tax only at READ time, so a rate change moved the tax on a quote
+ * already sent while the subtotal and freight frozen beside it stayed put — the
+ * quote silently disagreed with itself.
+ *
+ * The sharper bug the fallback fixes: `buildQuoteView` skips its whole live
+ * block when the quote is revoked/superseded/expired, leaving `tax` on its
+ * `{status:"unknown", reason:null}` default. The page renders its notice only
+ * when there IS a reason, so a dead link showed frozen totals and NO tax block
+ * — "a missing tax block reads as no tax due", landing on precisely the quotes
+ * that exist as a record of what was said.
+ */
+describe("frozenTaxFallback", () => {
+  const liveUnknownEmpty = {
+    status: "unknown" as const,
+    total: null,
+    inclusive: false,
+    rates: [],
+    reason: null,
+  }
+
+  const frozenExport = {
+    quoted_tax_total: 0,
+    quoted_tax_inclusive: false,
+    quoted_tax_status: "zero_rated_export",
+    quoted_tax_reason:
+      "This is an export from IN to DE, so it is zero-rated and no seller tax is charged. Import duty and import VAT/GST are payable by you to DE customs on arrival and are NOT included in this total.",
+  }
+
+  it("shows what the buyer was told when the live half produced nothing", () => {
+    const r = frozenTaxFallback(liveUnknownEmpty, frozenExport)
+    expect(r.status).toBe("zero_rated_export")
+    expect(r.total).toBe(0)
+    // The half that matters on a dead export quote.
+    expect(r.reason).toMatch(/payable by you/i)
+  })
+
+  it("a LIVE answer always wins, including a live unknown that has a reason", () => {
+    // That reason describes the quote as it stands now; the frozen one does not.
+    const liveWithReason = {
+      ...liveUnknownEmpty,
+      reason: "No tax rate is configured for DE.",
+    }
+    expect(frozenTaxFallback(liveWithReason, frozenExport).reason).toBe(
+      "No tax rate is configured for DE."
+    )
+
+    const liveCalculated = {
+      status: "calculated" as const,
+      total: 18,
+      inclusive: false,
+      rates: [],
+      reason: null,
+    }
+    expect(frozenTaxFallback(liveCalculated, frozenExport).status).toBe(
+      "calculated"
+    )
+  })
+
+  it("stays unknown for a quote minted before tax existed", () => {
+    // No frozen status ⇒ nothing to fall back to. Inventing one would claim a
+    // tax treatment for a row that never had one.
+    expect(frozenTaxFallback(liveUnknownEmpty, {}).status).toBe("unknown")
+    expect(frozenTaxFallback(liveUnknownEmpty, null).reason).toBeNull()
+  })
+
+  it("does not resurrect a rate breakdown alongside a frozen total", () => {
+    // Reprinting last week's percentages next to a frozen number invites the
+    // reader to re-derive it and find it does not reconcile.
+    expect(frozenTaxFallback(liveUnknownEmpty, frozenExport).rates).toEqual([])
+  })
+
+  it("distinguishes a frozen zero-rated export from a frozen unknown", () => {
+    // 🔑 The reason all four columns are frozen rather than just the number: a
+    // bare 0 cannot say which of these it is, and only one is a fact.
+    const asUnknown = frozenTaxFallback(liveUnknownEmpty, {
+      quoted_tax_total: null,
+      quoted_tax_status: "unknown",
+      quoted_tax_reason: "No tax rate is configured for ZZ.",
+    })
+    expect(asUnknown.total).toBeNull()
+
+    const asExport = frozenTaxFallback(liveUnknownEmpty, frozenExport)
+    expect(asExport.total).toBe(0)
+    expect(asExport.status).not.toBe(asUnknown.status)
   })
 })

--- a/apps/backend/src/modules/partner-quote/lib/build-quote-view.ts
+++ b/apps/backend/src/modules/partner-quote/lib/build-quote-view.ts
@@ -86,6 +86,9 @@ export type QuoteViewQuote = {
   /** #1439 S8. Null on every quote minted before tax existed. */
   quoted_tax_total?: number | null
   quoted_tax_inclusive?: boolean | null
+  /** #1439 S8 tail. Frozen so a dead link can still say WHY the tax is what it is. */
+  quoted_tax_status?: string | null
+  quoted_tax_reason?: string | null
   quoted_at?: Date | string | null
   recipient_name?: string | null
   recipient_company?: string | null
@@ -321,6 +324,45 @@ export function composeQuoteMoney(
      */
     gross_total:
       taxTotal === null ? null : tax?.inclusive ? landed : landed + taxTotal,
+  }
+}
+
+/**
+ * PURE: prefer the live tax, fall back to the frozen one.
+ *
+ * Only substitutes when the live half produced nothing usable — an `unknown`
+ * with no reason, which is the default the builder starts from and the exact
+ * state a dead link leaves it in. A live answer always wins, including a live
+ * `unknown` that carries a reason, because that reason describes the quote as
+ * it stands now.
+ *
+ * Returns the frozen row untouched when there is one, so what renders is what
+ * the buyer was told at mint rather than a reconstruction of it.
+ */
+export function frozenTaxFallback(
+  live: QuoteTax,
+  quote?: QuoteViewQuote | null
+): QuoteTax {
+  const liveIsEmpty = live.status === "unknown" && !live.reason
+  if (!liveIsEmpty) return live
+
+  const status = quote?.quoted_tax_status
+  if (!status) return live
+
+  const total =
+    quote?.quoted_tax_total === null || quote?.quoted_tax_total === undefined
+      ? null
+      : Number(quote.quoted_tax_total)
+
+  return {
+    status: status as QuoteTax["status"],
+    total,
+    inclusive: Boolean(quote?.quoted_tax_inclusive),
+    // Not frozen: a rate BREAKDOWN is a live explanation of a live number, and
+    // reprinting last week's percentages beside a frozen total invites the
+    // reader to re-derive it and find it does not reconcile.
+    rates: [],
+    reason: quote?.quoted_tax_reason ?? null,
   }
 }
 
@@ -674,7 +716,22 @@ export async function buildQuoteView(
     total_weight_grams:
       totalWeightGrams ?? input.quote?.quoted_weight_grams ?? null,
     freight: { chosen, options, error: freightError },
-    tax,
+    /**
+     * Live tax where there is one; the FROZEN tax on a dead link.
+     *
+     * 🔴 The live block is skipped entirely when `unusableReason` is set, which
+     * left `tax` on its `{status:"unknown", reason:null}` default for every
+     * revoked, superseded and expired quote. The page renders its notice only
+     * when there IS a reason, so those quotes showed frozen subtotal and
+     * freight and NO tax block at all — the "a missing tax block reads as no
+     * tax due" failure this module was written to prevent, landing on exactly
+     * the quotes that exist as evidence of what was said.
+     *
+     * Falling back to the frozen row shows what the buyer was actually told,
+     * which is the same reasoning that keeps the frozen totals visible on a
+     * dead link rather than recomputing a number we are no longer offering.
+     */
+    tax: frozenTaxFallback(tax, input.quote),
     compare,
     recipient: {
       name: input.quote?.recipient_name ?? null,

--- a/apps/backend/src/modules/partner-quote/lib/build-quote-view.ts
+++ b/apps/backend/src/modules/partner-quote/lib/build-quote-view.ts
@@ -90,6 +90,9 @@ export type QuoteViewQuote = {
   quoted_tax_status?: string | null
   quoted_tax_reason?: string | null
   duties_prepaid?: boolean | null
+  /** #1447. The duty figure we committed to, and how it was arrived at. */
+  quoted_duty_total?: number | null
+  quoted_duty_basis?: string | null
   quoted_at?: Date | string | null
   recipient_name?: string | null
   recipient_company?: string | null
@@ -130,6 +133,16 @@ export type BuildQuoteViewInput = {
    * (the row does not exist yet); afterwards it is read off the frozen quote.
    */
   duties_prepaid?: boolean
+  /**
+   * The duty we are undertaking to pay, in the quote currency, and the note
+   * saying how the partner got there (#1447). Supplied by the mint; afterwards
+   * both are read off the frozen row so a re-read cannot invent a new figure.
+   *
+   * Only meaningful with `duties_prepaid` — the API refuses one without the
+   * other, so a DDP promise always carries a number.
+   */
+  duty_total?: number | null
+  duty_basis?: string | null
   /** Passed in so the whole view is deterministic under test. */
   now: Date
 }
@@ -190,6 +203,26 @@ export type QuoteView = {
    * silence is not an option here the way it is for the producer band.
    */
   tax: QuoteTax
+  /**
+   * The DDP undertaking and the number behind it (#1447).
+   *
+   * `prepaid` without a `total` is the state this slice exists to make
+   * impossible: it is a promise that duty is covered with nothing added to the
+   * price, paid out of margin by an amount nobody worked out. The API refuses
+   * that combination at mint; the block is shaped so a caller can still SEE it
+   * on a legacy row rather than render a confident "nothing further to pay".
+   *
+   * Read from the frozen quote on a dead link, exactly like `tax` — the
+   * undertaking is part of what the buyer was told, and a revoked quote is the
+   * record of it.
+   */
+  duty: {
+    prepaid: boolean
+    /** Quote currency. Null = no figure; 0 = duty applies and is nil. */
+    total: number | null
+    /** "EU 12% ad valorem, HS 6304.92", "AI-ECTA duty-free". */
+    basis: string | null
+  }
   compare: QuoteCompareResult
   recipient: {
     name: string | null
@@ -305,7 +338,13 @@ export function composeQuoteMoney(
    * #1439 S8. Omitted ⇒ tax is UNKNOWN, not zero: `tax_total` and
    * `gross_total` both stay null, and the caller is expected to say why.
    */
-  tax?: { total: number | null; inclusive: boolean } | null
+  tax?: { total: number | null; inclusive: boolean } | null,
+  /**
+   * #1447. The customs duty we undertook to pay, in the quote currency.
+   * Omitted ⇒ not a DDP quote, and no duty row renders. Passing `0` is a
+   * different statement: duty applies to this lane and it is nil.
+   */
+  duty?: number | null
 ): QuoteMoney {
   const subtotal = lineSubtotals.reduce((sum, n) => sum + n, 0)
   const landed = subtotal + freight
@@ -315,12 +354,24 @@ export function composeQuoteMoney(
       ? Number(tax.total)
       : null
 
+  const dutyTotal =
+    duty === null || duty === undefined || !Number.isFinite(Number(duty))
+      ? null
+      : Number(duty)
+
   return {
     unit_amount: totalUnits > 0 ? subtotal / totalUnits : 0,
     subtotal,
     freight,
     landed_total: landed,
     tax_total: taxTotal,
+    /**
+     * 🔴 Duty is ADDED in both bases. Unlike tax it is never "already
+     * inside" the prices: it is a charge at the destination border that the
+     * line prices know nothing about, which is precisely why quoting DDP
+     * without adding it took the amount out of our own margin.
+     */
+    duty_total: dutyTotal,
     /**
      * 🔴 When the prices are tax-INCLUSIVE the tax is already inside
      * `landed_total`, so adding it again would overcharge the buyer by the
@@ -329,7 +380,9 @@ export function composeQuoteMoney(
      * direction on every Indian quote.
      */
     gross_total:
-      taxTotal === null ? null : tax?.inclusive ? landed : landed + taxTotal,
+      taxTotal === null
+        ? null
+        : (tax?.inclusive ? landed : landed + taxTotal) + (dutyTotal ?? 0),
   }
 }
 
@@ -390,6 +443,10 @@ export function frozenMoney(quote?: QuoteViewQuote | null): QuoteMoney | null {
     quote.quoted_tax_total === null || quote.quoted_tax_total === undefined
       ? null
       : Number(quote.quoted_tax_total)
+  const dutyTotal =
+    quote.quoted_duty_total === null || quote.quoted_duty_total === undefined
+      ? null
+      : Number(quote.quoted_duty_total)
   const landed = Number(quote.quoted_landed_total)
 
   return {
@@ -403,12 +460,13 @@ export function frozenMoney(quote?: QuoteViewQuote | null): QuoteMoney | null {
      * retroactively assert that an untaxed quote was tax-free.
      */
     tax_total: taxTotal,
+    /** Same rule, same reason (#1447): null is "no figure", 0 is "nil duty". */
+    duty_total: dutyTotal,
     gross_total:
       taxTotal === null
         ? null
-        : quote.quoted_tax_inclusive
-          ? landed
-          : landed + taxTotal,
+        : (quote.quoted_tax_inclusive ? landed : landed + taxTotal) +
+          (dutyTotal ?? 0),
   }
 }
 
@@ -503,6 +561,31 @@ export async function buildQuoteView(
     (input.quote?.lines || []).map((l) => [l.variant_id, l])
   )
   const quoted = frozenMoney(input.quote)
+
+  /**
+   * The DDP undertaking and its number, resolved ONCE for the whole view.
+   *
+   * At mint the row does not exist yet, so both arrive on the input; on every
+   * later read they come off the frozen quote, which is what stops a re-read
+   * from inventing a duty figure the buyer was never shown.
+   *
+   * 🔴 A duty amount is only ever carried when the quote is actually DDP. A
+   * number left behind on a non-DDP quote would be added to a total the buyer
+   * was told they pay duty on top of — charging them twice for the same border.
+   */
+  const dutiesPrepaid = Boolean(
+    input.duties_prepaid ?? input.quote?.duties_prepaid
+  )
+  const frozenDuty =
+    input.quote?.quoted_duty_total === null ||
+    input.quote?.quoted_duty_total === undefined
+      ? null
+      : Number(input.quote.quoted_duty_total)
+  const dutyTotal = !dutiesPrepaid
+    ? null
+    : input.duty_total === null || input.duty_total === undefined
+      ? frozenDuty
+      : Number(input.duty_total)
 
   let live: QuoteMoney | null = null
   let liveError: string | null = null
@@ -617,9 +700,7 @@ export async function buildQuoteView(
         origin_country_code: originCountry,
         // Mint supplies it directly; a later page read takes it off the frozen
         // row, so the buyer sees the same promise on every visit.
-        duties_prepaid: Boolean(
-          input.duties_prepaid ?? input.quote?.duties_prepaid
-        ),
+        duties_prepaid: dutiesPrepaid,
         destination_country_code: input.destination_country_code,
         destination_postal_code: input.destination_postal_code ?? null,
         lines: effectiveLines.map((l) => ({
@@ -637,7 +718,11 @@ export async function buildQuoteView(
         ),
         effectiveLines.reduce((sum, l) => sum + l.quantity, 0),
         Number(chosen.amount),
-        tax
+        tax,
+        // Not recomputed from the lane: nobody can price this lane's duty yet
+        // (see the model docblock). It is the figure the partner committed to,
+        // carried so the total the buyer pays actually contains the promise.
+        dutyTotal
       )
     } catch (err) {
       // The quoted half — what the partner actually told this buyer — is still
@@ -743,6 +828,15 @@ export async function buildQuoteView(
      * dead link rather than recomputing a number we are no longer offering.
      */
     tax: frozenTaxFallback(tax, input.quote),
+    duty: {
+      prepaid: dutiesPrepaid,
+      total: dutyTotal,
+      // Gated on the undertaking for the same reason the amount is: a basis
+      // note on a quote that is not DDP describes a promise nobody made.
+      basis: dutiesPrepaid
+        ? (input.duty_basis ?? input.quote?.quoted_duty_basis ?? null)
+        : null,
+    },
     compare,
     recipient: {
       name: input.quote?.recipient_name ?? null,

--- a/apps/backend/src/modules/partner-quote/lib/build-quote-view.ts
+++ b/apps/backend/src/modules/partner-quote/lib/build-quote-view.ts
@@ -311,7 +311,7 @@ export function pickLineImage(identity: any): {
  * Never throws — a null lands the quote on `status: "unknown"` WITH a reason,
  * which is the honest degradation. It must not become an assumed "domestic".
  */
-async function resolveStoreOriginCountry(
+export async function resolveStoreOriginCountry(
   scope: any,
   locationId?: string | null
 ): Promise<string | null> {

--- a/apps/backend/src/modules/partner-quote/lib/build-quote-view.ts
+++ b/apps/backend/src/modules/partner-quote/lib/build-quote-view.ts
@@ -16,6 +16,7 @@ import {
 } from "./compare"
 import { resolveQuoteProducer, type QuoteProducer } from "./quote-producer"
 import { resolveQuoteTax, type QuoteTax } from "./quote-tax"
+import { computeDdpCharges, describeDdpBasis } from "./ddp-charges"
 import { resolveQuoteSpecs, type QuoteLineSpec } from "./quote-spec"
 import { daysUntilExpiry, quoteUnusableReason } from "./token"
 
@@ -90,8 +91,12 @@ export type QuoteViewQuote = {
   quoted_tax_status?: string | null
   quoted_tax_reason?: string | null
   duties_prepaid?: boolean | null
-  /** #1447. The duty figure we committed to, and how it was arrived at. */
+  /** #1447. The DDP charges we committed to, and how they were arrived at. */
   quoted_duty_total?: number | null
+  quoted_import_tax_total?: number | null
+  quoted_ddp_fee_total?: number | null
+  quoted_duty_rate?: number | null
+  quoted_import_tax_rate?: number | null
   quoted_duty_basis?: string | null
   quoted_at?: Date | string | null
   recipient_name?: string | null
@@ -143,6 +148,23 @@ export type BuildQuoteViewInput = {
    */
   duty_total?: number | null
   duty_basis?: string | null
+  /**
+   * The rate form (#1447), and the preferred one. The wizard collects the two
+   * percentages and the AMOUNTS ARE COMPUTED HERE, against the quote's own
+   * subtotal and freight — the wizard cannot know those before the mint prices
+   * the basket, so a client-computed amount would be an estimate frozen as a
+   * commitment.
+   *
+   * Duty is assessed on goods + freight; import tax on goods + freight + duty.
+   * The cascade is the part people get wrong by hand, always in the direction
+   * that under-funds the promise.
+   */
+  duty_rate_percent?: number | null
+  import_tax_rate_percent?: number | null
+  /** A flat import tax, where a rate does not express the lane. */
+  import_tax_total?: number | null
+  /** The carrier's charge for advancing duty and tax. Always an amount. */
+  ddp_fee_total?: number | null
   /** Passed in so the whole view is deterministic under test. */
   now: Date
 }
@@ -218,8 +240,17 @@ export type QuoteView = {
    */
   duty: {
     prepaid: boolean
-    /** Quote currency. Null = no figure; 0 = duty applies and is nil. */
+    /** Customs duty. Quote currency. Null = no figure; 0 = applies and is nil. */
     total: number | null
+    /** Destination VAT/GST we also pay — usually the LARGEST of the three. */
+    import_tax: number | null
+    /** The carrier's fee for advancing duty and tax on our behalf. */
+    carrier_fee: number | null
+    /** What the undertaking adds to the buyer's total: the three summed. */
+    combined_total: number | null
+    /** The rates applied, so the figures can be re-derived, not just believed. */
+    duty_rate_percent: number | null
+    import_tax_rate_percent: number | null
     /** "EU 12% ad valorem, HS 6304.92", "AI-ECTA duty-free". */
     basis: string | null
   }
@@ -340,11 +371,12 @@ export function composeQuoteMoney(
    */
   tax?: { total: number | null; inclusive: boolean } | null,
   /**
-   * #1447. The customs duty we undertook to pay, in the quote currency.
-   * Omitted ⇒ not a DDP quote, and no duty row renders. Passing `0` is a
-   * different statement: duty applies to this lane and it is nil.
+   * #1447. The DDP undertaking, in the quote currency: customs duty, the
+   * destination import tax we also pay, and the carrier's fee for advancing
+   * them. Omitted ⇒ not a DDP quote, and no duty rows render. A `0` is a
+   * different statement: the charge applies to this lane and it is nil.
    */
-  duty?: number | null
+  ddp?: { duty?: number | null; import_tax?: number | null; fee?: number | null } | null
 ): QuoteMoney {
   const subtotal = lineSubtotals.reduce((sum, n) => sum + n, 0)
   const landed = subtotal + freight
@@ -354,10 +386,19 @@ export function composeQuoteMoney(
       ? Number(tax.total)
       : null
 
-  const dutyTotal =
-    duty === null || duty === undefined || !Number.isFinite(Number(duty))
+  const num = (v: unknown): number | null =>
+    v === null || v === undefined || !Number.isFinite(Number(v))
       ? null
-      : Number(duty)
+      : Number(v)
+
+  const dutyTotal = num(ddp?.duty)
+  const importTaxTotal = num(ddp?.import_tax)
+  const ddpFeeTotal = num(ddp?.fee)
+  // What the undertaking adds to the buyer's total. Absent parts count as 0
+  // here — but only after each has been recorded as null above, so "nil duty"
+  // and "no duty figure" stay distinguishable in what gets frozen and shown.
+  const ddpTotal =
+    (dutyTotal ?? 0) + (importTaxTotal ?? 0) + (ddpFeeTotal ?? 0)
 
   return {
     unit_amount: totalUnits > 0 ? subtotal / totalUnits : 0,
@@ -372,6 +413,8 @@ export function composeQuoteMoney(
      * without adding it took the amount out of our own margin.
      */
     duty_total: dutyTotal,
+    import_tax_total: importTaxTotal,
+    ddp_fee_total: ddpFeeTotal,
     /**
      * 🔴 When the prices are tax-INCLUSIVE the tax is already inside
      * `landed_total`, so adding it again would overcharge the buyer by the
@@ -382,7 +425,7 @@ export function composeQuoteMoney(
     gross_total:
       taxTotal === null
         ? null
-        : (tax?.inclusive ? landed : landed + taxTotal) + (dutyTotal ?? 0),
+        : (tax?.inclusive ? landed : landed + taxTotal) + ddpTotal,
   }
 }
 
@@ -443,10 +486,13 @@ export function frozenMoney(quote?: QuoteViewQuote | null): QuoteMoney | null {
     quote.quoted_tax_total === null || quote.quoted_tax_total === undefined
       ? null
       : Number(quote.quoted_tax_total)
-  const dutyTotal =
-    quote.quoted_duty_total === null || quote.quoted_duty_total === undefined
-      ? null
-      : Number(quote.quoted_duty_total)
+  const frozenNumber = (v: unknown): number | null =>
+    v === null || v === undefined ? null : Number(v)
+  const dutyTotal = frozenNumber(quote.quoted_duty_total)
+  const importTaxTotal = frozenNumber(quote.quoted_import_tax_total)
+  const ddpFeeTotal = frozenNumber(quote.quoted_ddp_fee_total)
+  const ddpTotal =
+    (dutyTotal ?? 0) + (importTaxTotal ?? 0) + (ddpFeeTotal ?? 0)
   const landed = Number(quote.quoted_landed_total)
 
   return {
@@ -462,11 +508,12 @@ export function frozenMoney(quote?: QuoteViewQuote | null): QuoteMoney | null {
     tax_total: taxTotal,
     /** Same rule, same reason (#1447): null is "no figure", 0 is "nil duty". */
     duty_total: dutyTotal,
+    import_tax_total: importTaxTotal,
+    ddp_fee_total: ddpFeeTotal,
     gross_total:
       taxTotal === null
         ? null
-        : (quote.quoted_tax_inclusive ? landed : landed + taxTotal) +
-          (dutyTotal ?? 0),
+        : (quote.quoted_tax_inclusive ? landed : landed + taxTotal) + ddpTotal,
   }
 }
 
@@ -576,16 +623,47 @@ export async function buildQuoteView(
   const dutiesPrepaid = Boolean(
     input.duties_prepaid ?? input.quote?.duties_prepaid
   )
-  const frozenDuty =
-    input.quote?.quoted_duty_total === null ||
-    input.quote?.quoted_duty_total === undefined
-      ? null
-      : Number(input.quote.quoted_duty_total)
-  const dutyTotal = !dutiesPrepaid
-    ? null
-    : input.duty_total === null || input.duty_total === undefined
-      ? frozenDuty
-      : Number(input.duty_total)
+  const frozen = (v: unknown): number | null =>
+    v === null || v === undefined ? null : Number(v)
+
+  /**
+   * Rates win over amounts, and the INPUT wins over the frozen row.
+   *
+   * The rates are what make the live column internally consistent: if the buyer
+   * moves a quantity, the duty moves with the subtotal it is assessed on. The
+   * frozen amounts are never recomputed — `frozenMoney` reads the columns — so
+   * "what you were quoted" stays what was quoted.
+   */
+  const ddpRates = {
+    duty_rate_percent:
+      input.duty_rate_percent ?? frozen(input.quote?.quoted_duty_rate),
+    import_tax_rate_percent:
+      input.import_tax_rate_percent ??
+      frozen(input.quote?.quoted_import_tax_rate),
+  }
+  const ddpAmounts = {
+    duty_total: input.duty_total ?? frozen(input.quote?.quoted_duty_total),
+    import_tax_total:
+      input.import_tax_total ?? frozen(input.quote?.quoted_import_tax_total),
+    ddp_fee_total:
+      input.ddp_fee_total ?? frozen(input.quote?.quoted_ddp_fee_total),
+  }
+  /** Filled once the live basket is priced; falls back to the frozen figures. */
+  let ddpCharges = dutiesPrepaid
+    ? {
+        duty: ddpAmounts.duty_total,
+        import_tax: ddpAmounts.import_tax_total,
+        carrier_fee: ddpAmounts.ddp_fee_total,
+        duty_rate_percent: ddpRates.duty_rate_percent,
+        import_tax_rate_percent: ddpRates.import_tax_rate_percent,
+      }
+    : {
+        duty: null as number | null,
+        import_tax: null as number | null,
+        carrier_fee: null as number | null,
+        duty_rate_percent: null as number | null,
+        import_tax_rate_percent: null as number | null,
+      }
 
   let live: QuoteMoney | null = null
   let liveError: string | null = null
@@ -712,17 +790,51 @@ export async function buildQuoteView(
         freight: { amount: Number(chosen.amount), option_id: (chosen as any)?.id ?? null },
       })
 
+      const liveSubtotals = effectiveLines.map(
+        (l) => (liveUnitByVariant.get(l.variant_id) ?? 0) * l.quantity
+      )
+
+      if (dutiesPrepaid) {
+        /**
+         * 🔴 The amounts are computed HERE, from the basket that was actually
+         * priced — never taken from the client. A wizard can only estimate the
+         * subtotal and cannot know the freight at all before this runs, so a
+         * client-computed figure would be a guess frozen as a commitment.
+         *
+         * Duty on goods + freight; import tax on goods + freight + duty. The
+         * cascade is the arithmetic people get wrong by hand, and the error
+         * always lands the same way: under-funding a promise we then eat.
+         */
+        const charges = computeDdpCharges({
+          subtotal: liveSubtotals.reduce((sum, n) => sum + n, 0),
+          freight: Number(chosen.amount),
+          ...ddpRates,
+          ...ddpAmounts,
+        })
+        ddpCharges = {
+          duty: charges.duty,
+          import_tax: charges.import_tax,
+          carrier_fee: charges.carrier_fee,
+          duty_rate_percent: charges.duty_rate_percent,
+          import_tax_rate_percent: charges.import_tax_rate_percent,
+        }
+      }
+
       live = composeQuoteMoney(
-        effectiveLines.map(
-          (l) => (liveUnitByVariant.get(l.variant_id) ?? 0) * l.quantity
-        ),
+        liveSubtotals,
         effectiveLines.reduce((sum, l) => sum + l.quantity, 0),
         Number(chosen.amount),
         tax,
-        // Not recomputed from the lane: nobody can price this lane's duty yet
-        // (see the model docblock). It is the figure the partner committed to,
-        // carried so the total the buyer pays actually contains the promise.
-        dutyTotal
+        // Nobody can price this lane's duty from a carrier API yet (see the
+        // model docblock), so these are the partner's rates applied to the real
+        // basket — carried into the total so the promise is actually funded.
+        dutiesPrepaid
+          ? {
+              duty: ddpCharges.duty,
+              import_tax: ddpCharges.import_tax,
+              fee: ddpCharges.carrier_fee,
+            }
+          : null
       )
     } catch (err) {
       // The quoted half — what the partner actually told this buyer — is still
@@ -830,7 +942,16 @@ export async function buildQuoteView(
     tax: frozenTaxFallback(tax, input.quote),
     duty: {
       prepaid: dutiesPrepaid,
-      total: dutyTotal,
+      total: ddpCharges.duty,
+      import_tax: ddpCharges.import_tax,
+      carrier_fee: ddpCharges.carrier_fee,
+      combined_total: dutiesPrepaid
+        ? (ddpCharges.duty ?? 0) +
+          (ddpCharges.import_tax ?? 0) +
+          (ddpCharges.carrier_fee ?? 0)
+        : null,
+      duty_rate_percent: ddpCharges.duty_rate_percent,
+      import_tax_rate_percent: ddpCharges.import_tax_rate_percent,
       // Gated on the undertaking for the same reason the amount is: a basis
       // note on a quote that is not DDP describes a promise nobody made.
       basis: dutiesPrepaid

--- a/apps/backend/src/modules/partner-quote/lib/build-quote-view.ts
+++ b/apps/backend/src/modules/partner-quote/lib/build-quote-view.ts
@@ -89,6 +89,7 @@ export type QuoteViewQuote = {
   /** #1439 S8 tail. Frozen so a dead link can still say WHY the tax is what it is. */
   quoted_tax_status?: string | null
   quoted_tax_reason?: string | null
+  duties_prepaid?: boolean | null
   quoted_at?: Date | string | null
   recipient_name?: string | null
   recipient_company?: string | null
@@ -124,6 +125,11 @@ export type BuildQuoteViewInput = {
    */
   viewer_sales_channel_ids?: string[] | null
   carrier?: string
+  /**
+   * Quote as DDP — we pay destination duty and import tax. Supplied by the mint
+   * (the row does not exist yet); afterwards it is read off the frozen quote.
+   */
+  duties_prepaid?: boolean
   /** Passed in so the whole view is deterministic under test. */
   now: Date
 }
@@ -609,6 +615,11 @@ export async function buildQuoteView(
       tax = await resolveQuoteTax(scope, {
         region_id: input.region_id ?? null,
         origin_country_code: originCountry,
+        // Mint supplies it directly; a later page read takes it off the frozen
+        // row, so the buyer sees the same promise on every visit.
+        duties_prepaid: Boolean(
+          input.duties_prepaid ?? input.quote?.duties_prepaid
+        ),
         destination_country_code: input.destination_country_code,
         destination_postal_code: input.destination_postal_code ?? null,
         lines: effectiveLines.map((l) => ({

--- a/apps/backend/src/modules/partner-quote/lib/compare.ts
+++ b/apps/backend/src/modules/partner-quote/lib/compare.ts
@@ -38,9 +38,20 @@ export type QuoteMoney = {
    */
   tax_total: number | null
   /**
-   * What the buyer actually pays. Equal to `landed_total` when the prices are
-   * tax-inclusive (the tax is already inside them and `tax_total` is the
-   * extracted portion), and `landed_total + tax_total` when they are not.
+   * Customs duty WE undertook to pay, in the quote currency (#1447). Null when
+   * the quote is not DDP or no figure was given; `0` is a real answer (Indian
+   * textiles enter Australia duty-free under AI-ECTA) and reads differently
+   * from null on purpose.
+   *
+   * ⚠️ It is NOT inside `landed_total` and never will be — same argument as
+   * tax: widening `landed_total` would silently restate every frozen
+   * `quoted_landed_total` on disk and every comparison drawn against one.
+   */
+  duty_total: number | null
+  /**
+   * What the buyer actually pays. `landed_total`, plus tax when the prices are
+   * tax-exclusive (when they are inclusive the tax is already inside it and
+   * `tax_total` is the extracted portion), plus any prepaid duty.
    * Null whenever tax is unknown — a gross total we cannot stand behind is
    * worse than none.
    */

--- a/apps/backend/src/modules/partner-quote/lib/compare.ts
+++ b/apps/backend/src/modules/partner-quote/lib/compare.ts
@@ -49,9 +49,20 @@ export type QuoteMoney = {
    */
   duty_total: number | null
   /**
+   * Destination VAT/GST we pay on a DDP quote, and the carrier's fee for
+   * advancing the money (#1447). Same null-vs-zero rule as `duty_total`.
+   *
+   * 🔴 `import_tax_total` is typically the LARGEST of the three — 21% of
+   * (goods + freight + duty) dwarfs an 8% duty. Funding only the duty is the
+   * failure this split exists to make impossible.
+   */
+  import_tax_total: number | null
+  ddp_fee_total: number | null
+  /**
    * What the buyer actually pays. `landed_total`, plus tax when the prices are
    * tax-exclusive (when they are inclusive the tax is already inside it and
-   * `tax_total` is the extracted portion), plus any prepaid duty.
+   * `tax_total` is the extracted portion), plus the whole DDP undertaking —
+   * duty, import tax and the carrier's advance fee.
    * Null whenever tax is unknown — a gross total we cannot stand behind is
    * worse than none.
    */

--- a/apps/backend/src/modules/partner-quote/lib/ddp-charges.ts
+++ b/apps/backend/src/modules/partner-quote/lib/ddp-charges.ts
@@ -1,0 +1,165 @@
+/**
+ * What a DDP undertaking actually costs us (#1447).
+ *
+ * ## Why this is not one number
+ *
+ * DHL Express's landed-cost planner, on a 70,000 INR consignment to NL:
+ *
+ * | | |
+ * |---|---|
+ * | Customs duty | 8% of (goods + freight) = **6,143.36** |
+ * | Import VAT | 21% of (goods + freight + duty) = **17,416.43** |
+ * | Duty-tax-paid fee | **1,981.57** — the carrier's charge for advancing it |
+ *
+ * 🔴 **The duty is the small half.** Import VAT is 2.8× larger, and a partner
+ * who reads "duty" and types 6,143 under-funds a "nothing further to pay"
+ * promise by roughly 19,400 on that shipment. The three are separate columns
+ * for the same reason the tax status is separate from the tax total: when a
+ * carrier invoice arrives months later, "which of the three was wrong" is the
+ * only question worth being able to answer.
+ *
+ * ## The base cascades, which is what people get wrong by hand
+ *
+ * Duty is charged on the CIF value — goods plus freight and insurance — and
+ * import VAT is then charged on that value INCLUDING the duty. Applying both
+ * rates to the goods value alone under-states the total, silently and in our
+ * favour, which is why the wizard collects RATES and this computes the amounts.
+ *
+ * ⚠️ `freight` here is the quote's own freight figure standing in for "freight
+ * and insurance". A carrier's dutiable-freight definition can differ slightly
+ * (DHL's planner excluded its own fuel surcharge from the duty base), so treat
+ * the result as a good estimate of a real liability, not as a customs ruling.
+ *
+ * ## Two modes, never both
+ *
+ * Rates are the normal case. Amounts exist because not every tariff line is ad
+ * valorem — a specific duty is charged per kilo or per item and no percentage
+ * expresses it. Supplying both is refused rather than ranked, exactly like the
+ * per-line discount/override pair (#1446): "which one wins" is a question that
+ * should not have an answer.
+ */
+
+export type DdpChargeInput = {
+  /** Goods total, in the quote currency. */
+  subtotal: number
+  /** The one freight leg, in the quote currency. */
+  freight: number
+  /** Ad valorem duty rate, e.g. 8 for 8%. */
+  duty_rate_percent?: number | null
+  /** Destination VAT/GST rate, e.g. 21 for 21%. */
+  import_tax_rate_percent?: number | null
+  /** A flat duty amount, for a specific (non-ad-valorem) tariff line. */
+  duty_total?: number | null
+  /** A flat import tax amount, where a rate does not express it. */
+  import_tax_total?: number | null
+  /** The carrier's advance/disbursement fee. Always an amount — it is a fee
+   *  schedule, not a rate on the goods. */
+  ddp_fee_total?: number | null
+}
+
+export type DdpCharges = {
+  /** Goods + freight — the value duty is assessed on. */
+  dutiable_value: number
+  duty: number
+  /** Assessed on `dutiable_value + duty`, not on the goods alone. */
+  import_tax: number
+  carrier_fee: number
+  /** What the undertaking adds to the buyer's total. */
+  total: number
+  /** The rates actually applied, frozen so the figure can be re-derived. */
+  duty_rate_percent: number | null
+  import_tax_rate_percent: number | null
+}
+
+const money = (n: number) => Math.round(n * 100) / 100
+
+const isNumber = (v: unknown): v is number =>
+  typeof v === "number" && Number.isFinite(v)
+
+/** True when this input names a rate AND an amount for the same charge. */
+export function hasConflictingDdpInput(input: DdpChargeInput): boolean {
+  return (
+    (isNumber(input.duty_rate_percent) && isNumber(input.duty_total)) ||
+    (isNumber(input.import_tax_rate_percent) && isNumber(input.import_tax_total))
+  )
+}
+
+/**
+ * PURE. Compute the three charges from whichever form the partner supplied.
+ *
+ * A missing rate AND a missing amount for a charge yields 0 for it — the caller
+ * is responsible for refusing an EMPTY undertaking, because "zero duty on this
+ * lane" and "nobody said" are different statements and only the validator has
+ * the context to tell them apart.
+ */
+export function computeDdpCharges(input: DdpChargeInput): DdpCharges {
+  const subtotal = isNumber(input.subtotal) ? input.subtotal : 0
+  const freight = isNumber(input.freight) ? input.freight : 0
+  const dutiableValue = money(subtotal + freight)
+
+  const dutyRate = isNumber(input.duty_rate_percent)
+    ? input.duty_rate_percent
+    : null
+  const importTaxRate = isNumber(input.import_tax_rate_percent)
+    ? input.import_tax_rate_percent
+    : null
+
+  const duty = money(
+    dutyRate !== null
+      ? (dutiableValue * dutyRate) / 100
+      : isNumber(input.duty_total)
+        ? input.duty_total
+        : 0
+  )
+
+  // 🔴 The cascade. The taxable value includes the duty just computed — this is
+  // the line that makes 21% on a 76,792 base come out as 17,416 rather than
+  // 16,126, and getting it wrong under-funds the promise by the difference.
+  const taxableValue = money(dutiableValue + duty)
+  const importTax = money(
+    importTaxRate !== null
+      ? (taxableValue * importTaxRate) / 100
+      : isNumber(input.import_tax_total)
+        ? input.import_tax_total
+        : 0
+  )
+
+  const carrierFee = money(
+    isNumber(input.ddp_fee_total) ? input.ddp_fee_total : 0
+  )
+
+  return {
+    dutiable_value: dutiableValue,
+    duty,
+    import_tax: importTax,
+    carrier_fee: carrierFee,
+    total: money(duty + importTax + carrierFee),
+    duty_rate_percent: dutyRate,
+    import_tax_rate_percent: importTaxRate,
+  }
+}
+
+/**
+ * PURE: a one-line, human-readable derivation, for the frozen basis note.
+ *
+ * Written down because the person who meets the carrier's invoice months later
+ * is not the person who typed the rates, and "8% + 21%" on its own does not say
+ * what they were applied to.
+ */
+export function describeDdpBasis(charges: DdpCharges): string {
+  const parts: string[] = []
+  parts.push(
+    charges.duty_rate_percent !== null
+      ? `duty ${charges.duty_rate_percent}% of goods + freight`
+      : `duty entered as a flat amount`
+  )
+  parts.push(
+    charges.import_tax_rate_percent !== null
+      ? `import tax ${charges.import_tax_rate_percent}% of goods + freight + duty`
+      : `import tax entered as a flat amount`
+  )
+  if (charges.carrier_fee > 0) {
+    parts.push(`carrier duty-tax-paid fee`)
+  }
+  return parts.join("; ")
+}

--- a/apps/backend/src/modules/partner-quote/lib/quote-tax.ts
+++ b/apps/backend/src/modules/partner-quote/lib/quote-tax.ts
@@ -84,6 +84,15 @@ export type QuoteTaxInput = {
    * that got as far as tax always has one.
    */
   origin_country_code?: string | null
+  /**
+   * The partner has undertaken to pay the destination duty and import tax on
+   * this quote (DDP), so the buyer owes nothing on arrival.
+   *
+   * Per-quote and never a default: it is a promise that only holds if the
+   * shipment actually clears DDP — by the carrier when one supports it, or
+   * arranged by hand until then.
+   */
+  duties_prepaid?: boolean
   destination_country_code: string
   destination_postal_code?: string | null
   destination_province_code?: string | null
@@ -221,13 +230,30 @@ export function classifyQuoteJurisdiction(
  */
 export function exportDisclosureReason(
   originCountryCode: string,
-  destinationCountryCode: string
+  destinationCountryCode: string,
+  dutiesPrepaid = false
 ): string {
   const from = String(originCountryCode || "").toUpperCase()
   const to = String(destinationCountryCode || "").toUpperCase()
-  return (
+  const zeroRated =
     `This is an export from ${from} to ${to}, so it is zero-rated and no ` +
-    `seller tax is charged. Import duty and import VAT/GST are payable by you ` +
+    `seller tax is charged.`
+
+  if (dutiesPrepaid) {
+    // 🔴 This sentence is a PROMISE, and it is the only one on the page we
+    // cannot keep from software alone: the shipment has to actually clear DDP,
+    // by the carrier or by hand. It is therefore per-quote and frozen, never a
+    // global setting — a default that silently applied to a quote nobody
+    // arranged clearance for would tell a buyer there is nothing to pay and
+    // then hand them a customs bill.
+    return (
+      `${zeroRated} Import duty and taxes are included in this price and are ` +
+      `paid by us — there is nothing further to pay on delivery.`
+    )
+  }
+
+  return (
+    `${zeroRated} Import duty and import VAT/GST are payable by you ` +
     `to ${to} customs on arrival and are NOT included in this total.`
   )
 }
@@ -309,7 +335,8 @@ export async function resolveQuoteTax(
       rates: [],
       reason: exportDisclosureReason(
         String(input.origin_country_code || ""),
-        country
+        country,
+        Boolean(input.duties_prepaid)
       ),
     }
   }

--- a/apps/backend/src/modules/partner-quote/migrations/Migration20260822164500.ts
+++ b/apps/backend/src/modules/partner-quote/migrations/Migration20260822164500.ts
@@ -40,6 +40,8 @@ export class Migration20260822164500 extends Migration {
     this.addSql(`alter table if exists "partner_quote" add column if not exists "quoted_tax_inclusive" boolean null;`);
     this.addSql(`alter table if exists "partner_quote" add column if not exists "quoted_tax_status" text null;`);
     this.addSql(`alter table if exists "partner_quote" add column if not exists "quoted_tax_reason" text null;`);
+    // The partner's DDP undertaking, frozen with the rest of what was promised.
+    this.addSql(`alter table if exists "partner_quote" add column if not exists "duties_prepaid" boolean null;`);
 
     // Mirrors the QuoteTax union. A status outside it means something wrote a
     // value the renderer has no branch for, which would surface as a silently
@@ -55,6 +57,7 @@ export class Migration20260822164500 extends Migration {
     this.addSql(`alter table if exists "partner_quote" drop column if exists "quoted_tax_inclusive";`);
     this.addSql(`alter table if exists "partner_quote" drop column if exists "quoted_tax_status";`);
     this.addSql(`alter table if exists "partner_quote" drop column if exists "quoted_tax_reason";`);
+    this.addSql(`alter table if exists "partner_quote" drop column if exists "duties_prepaid";`);
   }
 
 }

--- a/apps/backend/src/modules/partner-quote/migrations/Migration20260822164500.ts
+++ b/apps/backend/src/modules/partner-quote/migrations/Migration20260822164500.ts
@@ -1,0 +1,60 @@
+import { Migration } from "@medusajs/framework/mikro-orm/migrations";
+
+/**
+ * #1439 S8 (tail) — freeze the tax figure at mint.
+ *
+ * S8 computed tax but only ever at READ time, so a quote's tax moved whenever a
+ * rate or a region setting changed while the subtotal and freight frozen beside
+ * it stayed put. A buyer opening a quote a week later could be shown a landed
+ * total whose parts no longer added up to what was sent. Freezing the tax is
+ * the same argument that froze the subtotal.
+ *
+ * `frozenMoney` has read `quoted_tax_total` / `quoted_tax_inclusive` since S8
+ * landed — the columns simply never existed, so it returned null every time.
+ * Written, tested, and fed by nothing, exactly like `buildProvenance` (#1448).
+ *
+ * ## Why four columns and not one
+ *
+ * A frozen `0` on its own cannot say whether it means "zero-rated export, no
+ * tax due" or "we could not determine it" — and that distinction is the entire
+ * reason `QuoteTax.status` exists rather than a bare number. `quoted_tax_reason`
+ * preserves the sentence the buyer was shown; on an export that sentence is the
+ * only place they were told import duty is theirs to pay, which makes it
+ * evidence rather than decoration.
+ *
+ * ⚠️ A DML `bigNumber` is TWO columns: the numeric one and a `raw_*` jsonb
+ * companion carrying the precision. Adding only the numeric one lets the model,
+ * tsc and every unit test pass, then fails the INSERT at runtime with
+ * `column "raw_quoted_tax_total" does not exist` — how the S7 pair (#1446) was
+ * caught, on the first real mint.
+ *
+ * Every column is nullable and nothing is backfilled. Quotes minted before S8
+ * genuinely have no tax figure; writing a 0 onto them would retroactively
+ * assert they were tax-free.
+ */
+export class Migration20260822164500 extends Migration {
+
+  override async up(): Promise<void> {
+    this.addSql(`alter table if exists "partner_quote" add column if not exists "quoted_tax_total" numeric null;`);
+    this.addSql(`alter table if exists "partner_quote" add column if not exists "raw_quoted_tax_total" jsonb null;`);
+    this.addSql(`alter table if exists "partner_quote" add column if not exists "quoted_tax_inclusive" boolean null;`);
+    this.addSql(`alter table if exists "partner_quote" add column if not exists "quoted_tax_status" text null;`);
+    this.addSql(`alter table if exists "partner_quote" add column if not exists "quoted_tax_reason" text null;`);
+
+    // Mirrors the QuoteTax union. A status outside it means something wrote a
+    // value the renderer has no branch for, which would surface as a silently
+    // missing tax block — the failure this slice exists to prevent.
+    this.addSql(`alter table if exists "partner_quote" drop constraint if exists "partner_quote_quoted_tax_status_check";`);
+    this.addSql(`alter table if exists "partner_quote" add constraint "partner_quote_quoted_tax_status_check" check ("quoted_tax_status" is null or "quoted_tax_status" in ('calculated', 'zero_rated_export', 'not_applicable', 'unknown'));`);
+  }
+
+  override async down(): Promise<void> {
+    this.addSql(`alter table if exists "partner_quote" drop constraint if exists "partner_quote_quoted_tax_status_check";`);
+    this.addSql(`alter table if exists "partner_quote" drop column if exists "quoted_tax_total";`);
+    this.addSql(`alter table if exists "partner_quote" drop column if exists "raw_quoted_tax_total";`);
+    this.addSql(`alter table if exists "partner_quote" drop column if exists "quoted_tax_inclusive";`);
+    this.addSql(`alter table if exists "partner_quote" drop column if exists "quoted_tax_status";`);
+    this.addSql(`alter table if exists "partner_quote" drop column if exists "quoted_tax_reason";`);
+  }
+
+}

--- a/apps/backend/src/modules/partner-quote/migrations/Migration20260822190000.ts
+++ b/apps/backend/src/modules/partner-quote/migrations/Migration20260822190000.ts
@@ -1,0 +1,47 @@
+import { Migration } from "@medusajs/framework/mikro-orm/migrations";
+
+/**
+ * #1447 — the manual customs duty figure behind the DDP undertaking.
+ *
+ * `duties_prepaid` (Migration20260822164500) told the buyer "import duty is
+ * included and paid by us" and added **nothing** to the price: `composeQuoteMoney`
+ * was `subtotal + freight (+ tax)` and the word "duty" appeared only in prose.
+ * The promise was kept out of margin, by an amount nobody computed.
+ *
+ * Deriving duty is genuinely blocked — 138 HS-code gaps across 65 products, EU
+ * 2–14% with possible GSP relief, and Shiprocket returns `tariff: 0` / `tariff_data: []`
+ * pending CSB-5 KYC — so the partner enters the number and it freezes with the
+ * rest of what was promised.
+ *
+ * ## Why a basis column and not just an amount
+ *
+ * A frozen `0` cannot say whether it means "AI-ECTA, Indian textiles enter
+ * Australia duty-free" or "someone ticked DDP and left the box empty". That is
+ * the same ambiguity that made `quoted_tax_status`/`quoted_tax_reason` necessary
+ * beside `quoted_tax_total`, and it matters more here: this number is a
+ * liability we take on, and the person who meets the customs invoice months
+ * later is not the person who typed it.
+ *
+ * ⚠️ A DML `bigNumber` is TWO columns — the numeric one and its `raw_*` jsonb
+ * companion. Adding only the numeric one passes the model, tsc and every unit
+ * test, then fails the INSERT at runtime with `column "raw_quoted_duty_total"
+ * does not exist` (how the S7 pair was caught, on the first real mint).
+ *
+ * Nullable, nothing backfilled: a quote minted before this genuinely has no
+ * duty figure, and writing 0 would retroactively assert it was duty-free.
+ */
+export class Migration20260822190000 extends Migration {
+
+  override async up(): Promise<void> {
+    this.addSql(`alter table if exists "partner_quote" add column if not exists "quoted_duty_total" numeric null;`);
+    this.addSql(`alter table if exists "partner_quote" add column if not exists "raw_quoted_duty_total" jsonb null;`);
+    this.addSql(`alter table if exists "partner_quote" add column if not exists "quoted_duty_basis" text null;`);
+  }
+
+  override async down(): Promise<void> {
+    this.addSql(`alter table if exists "partner_quote" drop column if exists "quoted_duty_total";`);
+    this.addSql(`alter table if exists "partner_quote" drop column if exists "raw_quoted_duty_total";`);
+    this.addSql(`alter table if exists "partner_quote" drop column if exists "quoted_duty_basis";`);
+  }
+
+}

--- a/apps/backend/src/modules/partner-quote/migrations/Migration20260822213000.ts
+++ b/apps/backend/src/modules/partner-quote/migrations/Migration20260822213000.ts
@@ -1,0 +1,48 @@
+import { Migration } from "@medusajs/framework/mikro-orm/migrations";
+
+/**
+ * #1447 — a DDP undertaking is THREE charges, not one.
+ *
+ * `quoted_duty_total` alone funded the smaller half. DHL Express's landed-cost
+ * planner, on a 70,000 INR consignment to the Netherlands:
+ *
+ *   customs duty      8% × (goods + freight)          =  6,143.36
+ *   import VAT       21% × (goods + freight + duty)   = 17,416.43
+ *   duty-tax-paid fee (carrier's advance charge)      =  1,981.57
+ *
+ * The VAT is 2.8× the duty, and the base CASCADES — VAT is assessed on a value
+ * that already includes the duty. A partner told to "enter the duty" funds
+ * 6,143 of a 25,541 promise, and nobody finds out, because the shortfall lands
+ * on our margin rather than on the buyer.
+ *
+ * The rates are frozen beside the amounts so the figure can be re-derived
+ * against a carrier invoice months later instead of merely believed. Null rates
+ * mean a flat amount was entered — a specific duty is charged per kilo, and no
+ * percentage expresses it.
+ *
+ * ⚠️ Two of these are DML `bigNumber`s, so four columns: each numeric one needs
+ * its `raw_*` jsonb companion or the INSERT fails at runtime while the model,
+ * tsc and every unit test pass. The rates are plain numbers — they are not
+ * money and carry no precision context.
+ */
+export class Migration20260822213000 extends Migration {
+
+  override async up(): Promise<void> {
+    this.addSql(`alter table if exists "partner_quote" add column if not exists "quoted_import_tax_total" numeric null;`);
+    this.addSql(`alter table if exists "partner_quote" add column if not exists "raw_quoted_import_tax_total" jsonb null;`);
+    this.addSql(`alter table if exists "partner_quote" add column if not exists "quoted_ddp_fee_total" numeric null;`);
+    this.addSql(`alter table if exists "partner_quote" add column if not exists "raw_quoted_ddp_fee_total" jsonb null;`);
+    this.addSql(`alter table if exists "partner_quote" add column if not exists "quoted_duty_rate" real null;`);
+    this.addSql(`alter table if exists "partner_quote" add column if not exists "quoted_import_tax_rate" real null;`);
+  }
+
+  override async down(): Promise<void> {
+    this.addSql(`alter table if exists "partner_quote" drop column if exists "quoted_import_tax_total";`);
+    this.addSql(`alter table if exists "partner_quote" drop column if exists "raw_quoted_import_tax_total";`);
+    this.addSql(`alter table if exists "partner_quote" drop column if exists "quoted_ddp_fee_total";`);
+    this.addSql(`alter table if exists "partner_quote" drop column if exists "raw_quoted_ddp_fee_total";`);
+    this.addSql(`alter table if exists "partner_quote" drop column if exists "quoted_duty_rate";`);
+    this.addSql(`alter table if exists "partner_quote" drop column if exists "quoted_import_tax_rate";`);
+  }
+
+}

--- a/apps/backend/src/modules/partner-quote/models/partner-quote.ts
+++ b/apps/backend/src/modules/partner-quote/models/partner-quote.ts
@@ -118,6 +118,31 @@ const PartnerQuote = model.define("partner_quote", {
    * on a shipment nobody arranged clearance for.
    */
   duties_prepaid: model.boolean().nullable(),
+  /**
+   * The customs duty WE undertook to pay on this quote, in the quote currency.
+   *
+   * 🔴 This exists because `duties_prepaid` on its own promised the buyer duty
+   * was covered while adding NOTHING to the price — the partner absorbed an
+   * amount nobody had worked out, silently, out of margin. Deriving it
+   * automatically is blocked (138 HS-code gaps across 65 products, EU 2–14%
+   * with possible GSP relief, and Shiprocket's `tariff` returns 0 pending
+   * CSB-5 KYC), so until a carrier can price it the partner enters the number
+   * and we honour that number by hand.
+   *
+   * Null means no duty figure — either not a DDP quote, or a legacy row minted
+   * before this column. `0` is a real, deliberate answer: AI-ECTA makes Indian
+   * textiles duty-free into Australia, and "we checked, it is nil" is a fact,
+   * not a gap. `quoted_duty_basis` is what tells those two apart to a human,
+   * which is why they freeze together.
+   */
+  quoted_duty_total: model.bigNumber().nullable(),
+  /**
+   * How that number was arrived at — "EU 12% ad valorem, HS 6304.92", "AI-ECTA
+   * duty-free". Evidence, not decoration: it is the only record of WHY we
+   * committed to a figure, and the person who later pays the customs invoice
+   * is not the person who typed it.
+   */
+  quoted_duty_basis: model.text().nullable(),
   quoted_at: model.dateTime().nullable(),
 
   // ===== Buyer identity — the edges this quote's prices hang off ==========

--- a/apps/backend/src/modules/partner-quote/models/partner-quote.ts
+++ b/apps/backend/src/modules/partner-quote/models/partner-quote.ts
@@ -143,6 +143,28 @@ const PartnerQuote = model.define("partner_quote", {
    * is not the person who typed it.
    */
   quoted_duty_basis: model.text().nullable(),
+  /**
+   * The other two thirds of a DDP undertaking.
+   *
+   * 🔴 Duty is the SMALL half. DHL's landed-cost planner on a 70,000 INR
+   * consignment to NL: duty 6,143 (8% of goods + freight), import VAT 17,416
+   * (21% of goods + freight + duty), carrier duty-tax-paid fee 1,982. A partner
+   * who reads "duty" and funds only the duty under-writes the promise by
+   * roughly 19,400 — and the buyer never finds out, because we eat it.
+   *
+   * Three columns rather than one lump because a carrier's invoice arrives
+   * months later itemised, and "which of the three was wrong" is the only
+   * question worth being able to answer against it.
+   */
+  quoted_import_tax_total: model.bigNumber().nullable(),
+  quoted_ddp_fee_total: model.bigNumber().nullable(),
+  /**
+   * The rates the amounts were derived from, frozen so the figure can be
+   * re-derived rather than merely believed. Null on a lane priced by a flat
+   * amount — a specific duty is charged per kilo and no percentage says it.
+   */
+  quoted_duty_rate: model.number().nullable(),
+  quoted_import_tax_rate: model.number().nullable(),
   quoted_at: model.dateTime().nullable(),
 
   // ===== Buyer identity — the edges this quote's prices hang off ==========

--- a/apps/backend/src/modules/partner-quote/models/partner-quote.ts
+++ b/apps/backend/src/modules/partner-quote/models/partner-quote.ts
@@ -85,6 +85,29 @@ const PartnerQuote = model.define("partner_quote", {
   // LEVEL each line's weight came from is on the line, because a basket can
   // mix a variant-weighted item with a product-weighted one.
   quoted_weight_grams: model.number().nullable(),
+  /**
+   * Tax as it stood at mint (#1439 S8).
+   *
+   * 🔴 Without these the tax was recomputed on every page load while the
+   * subtotal and freight beside it stayed frozen, so a rate change moved the
+   * tax on a quote already sent — and the quote silently disagreed with itself.
+   * Freezing it is the same argument that froze the subtotal.
+   *
+   * All four are frozen together on purpose. `quoted_tax_total` alone is
+   * ambiguous: a frozen `0` cannot say whether it means "zero-rated export, no
+   * tax due" or "we could not work it out", and that distinction is the whole
+   * reason `QuoteTax.status` exists. `quoted_tax_reason` preserves the sentence
+   * the buyer was actually shown — on an export that sentence is the only place
+   * they were told duty is theirs, which makes it evidence, not decoration.
+   *
+   * Null on every quote minted before S8. That is the honest answer for them:
+   * those rows have no tax figure, and defaulting to 0 would retroactively
+   * assert they were tax-free.
+   */
+  quoted_tax_total: model.bigNumber().nullable(),
+  quoted_tax_inclusive: model.boolean().nullable(),
+  quoted_tax_status: model.text().nullable(),
+  quoted_tax_reason: model.text().nullable(),
   quoted_at: model.dateTime().nullable(),
 
   // ===== Buyer identity — the edges this quote's prices hang off ==========

--- a/apps/backend/src/modules/partner-quote/models/partner-quote.ts
+++ b/apps/backend/src/modules/partner-quote/models/partner-quote.ts
@@ -108,6 +108,16 @@ const PartnerQuote = model.define("partner_quote", {
   quoted_tax_inclusive: model.boolean().nullable(),
   quoted_tax_status: model.text().nullable(),
   quoted_tax_reason: model.text().nullable(),
+  /**
+   * The partner undertook to pay destination duty and import tax on this quote.
+   *
+   * 🔴 Per-quote, frozen, and never defaulted true. It is the one promise on
+   * the buyer's page that software alone cannot keep: the shipment has to
+   * actually clear DDP — by a carrier that supports it, or arranged by hand
+   * until one does. A global setting would tell a buyer there is nothing to pay
+   * on a shipment nobody arranged clearance for.
+   */
+  duties_prepaid: model.boolean().nullable(),
   quoted_at: model.dateTime().nullable(),
 
   // ===== Buyer identity — the edges this quote's prices hang off ==========

--- a/apps/backend/src/modules/shipping-providers/__tests__/carrier-capabilities.unit.spec.ts
+++ b/apps/backend/src/modules/shipping-providers/__tests__/carrier-capabilities.unit.spec.ts
@@ -1,6 +1,7 @@
 import {
   CARRIER_CAPABILITIES,
   capabilitiesCoverSupportedCarriers,
+  carrierCanDeclareDdp,
   findCarrierCapability,
   groupCarriersByLane,
 } from "../carrier-capabilities"
@@ -84,5 +85,33 @@ describe("buildCarrierAvailability", () => {
     expect(delhivery.enabled).toBe(false)
     // Registered means selectable — the partner simply has not switched it on.
     expect(delhivery.blocked_reason).toBeNull()
+  })
+})
+
+/**
+ * DDP by carrier (#1447).
+ *
+ * 🔴 The distinction this pins down: DECLARING a shipment DDP is code, being
+ * BILLED the duty is a commercial arrangement. A quote sold DDP that ships on a
+ * carrier we cannot declare it to is a promise someone keeps by hand — and the
+ * failure mode is silent, landing on the buyer at their own border weeks after
+ * they paid.
+ */
+describe("who can be told a shipment is DDP", () => {
+  it("says only Blue Dart today — it is the one payload with an incoterm", () => {
+    expect(carrierCanDeclareDdp("bluedart")).toBe(true)
+    // Shiprocket's DDP is real but gated on CSB-5 seller KYC; every lane
+    // reports ddp_tag: false. Delhivery's lives on Cross Border, which is a
+    // panel selection on a service we hold no API for.
+    expect(carrierCanDeclareDdp("shiprocket")).toBe(false)
+    expect(carrierCanDeclareDdp("delhivery")).toBe(false)
+  })
+
+  it("🔴 answers FALSE for a carrier it does not know", () => {
+    // The safe answer routes the promise to a human. Guessing true would let a
+    // DDP sale ship duty-unpaid without anyone noticing.
+    expect(carrierCanDeclareDdp("dhl")).toBe(false)
+    expect(carrierCanDeclareDdp(null)).toBe(false)
+    expect(carrierCanDeclareDdp(undefined)).toBe(false)
   })
 })

--- a/apps/backend/src/modules/shipping-providers/bluedart/__tests__/bluedart-adapter.unit.spec.ts
+++ b/apps/backend/src/modules/shipping-providers/bluedart/__tests__/bluedart-adapter.unit.spec.ts
@@ -239,6 +239,29 @@ describe("BlueDartProviderAdapter.createShipment", () => {
     expect(intlCalls[0].body.Request.Consignee.ConsigneeCountryCode).toBe("IL")
   })
 
+  it("declares DAP by default and DDP only when the sale was made DDP (#1447)", async () => {
+    const intlInput = {
+      ...BASE_INPUT,
+      currency: "USD",
+      to: { ...BASE_INPUT.to, country: "IL", pincode: "9100000", city: "Jerusalem" },
+    }
+
+    const { adapter: dap, calls: dapCalls } = buildAdapter()
+    await dap.createShipment(intlInput)
+    // An ordinary export IS duty-unpaid — the consignee is importer of record.
+    expect(dapCalls[0].body.Request.Services.IncotermCode).toBe("DAP")
+
+    const { adapter: ddp, calls: ddpCalls } = buildAdapter()
+    await ddp.createShipment({
+      ...intlInput,
+      customs: { ...(intlInput as any).customs, incoterm: "DDP" as const },
+    })
+    // 🔴 This was hardcoded "DAP". A quote sold DDP shipped duty-unpaid hands
+    // the buyer the customs bill we promised would not come — weeks after they
+    // paid, with our own invoice as the evidence they were told otherwise.
+    expect(ddpCalls[0].body.Request.Services.IncotermCode).toBe("DDP")
+  })
+
   it("collects nothing at the door on a prepaid order", async () => {
     const { adapter, calls } = buildAdapter()
     await adapter.createShipment(BASE_INPUT)

--- a/apps/backend/src/modules/shipping-providers/bluedart/adapter.ts
+++ b/apps/backend/src/modules/shipping-providers/bluedart/adapter.ts
@@ -304,7 +304,15 @@ export class BlueDartProviderAdapter implements ShippingProviderClient {
     return {
       CurrencyCode: (input.currency || "INR").toUpperCase(),
       IsCommercialShipment: input.customs?.commodity !== false,
-      IncotermCode: "DAP",
+      /**
+       * 🔴 Was hardcoded "DAP" — delivered at place, duty UNPAID. On a sale
+       * made DDP that declaration is the opposite of what the buyer was told,
+       * and the correction arrives as a customs bill weeks after they paid.
+       *
+       * Defaults to DAP still, because duty-unpaid is what an ordinary export
+       * is; DDP is only sent when the sale actually carried the undertaking.
+       */
+      IncotermCode: input.customs?.incoterm === "DDP" ? "DDP" : "DAP",
       TermsOfTrade: input.customs?.terms_of_invoice === "CIF" ? "CIF" : "FOB",
       ExportReason:
         input.customs?.reason_of_export === 2 ? "Gift" : "Sale of Goods",

--- a/apps/backend/src/modules/shipping-providers/carrier-capabilities.ts
+++ b/apps/backend/src/modules/shipping-providers/carrier-capabilities.ts
@@ -52,6 +52,16 @@ export type CarrierCapability = {
   platform_account: boolean
   domestic: CarrierLaneCapability
   international: CarrierLaneCapability
+  /**
+   * Can the adapter DECLARE the shipment delivered-duty-paid (#1447)?
+   *
+   * 🔑 This is about what we can tell the carrier, not about whether the
+   * account is set up to be billed the duty. Declaring is code; being billed is
+   * a commercial arrangement with the carrier, and one does not imply the
+   * other. A quote sold DDP that ships on a carrier with `false` here is a
+   * promise being kept by hand — which is the current state of every lane.
+   */
+  can_declare_ddp: boolean
   /** Why a lane is unavailable, when that needs explaining to a human. */
   notes?: string
 }
@@ -64,8 +74,13 @@ export const CARRIER_CAPABILITIES: CarrierCapability[] = [
     platform_account: true,
     domestic: { can_rate: true, can_ship: true },
     international: { can_rate: true, can_ship: true },
+    // `ddp_tag`, `ioss_fee` and `tariff` are on the serviceability RESPONSE and
+    // are absent from the published collection entirely. Every lane currently
+    // returns `ddp_tag: false`, gated account-wide on `csb5_seller_kyc: false`;
+    // accepting the DDP agreement in the panel did not change it.
+    can_declare_ddp: false,
     notes:
-      "Rates and ships both lanes. For an Indian origin this is the cross-border rate source, because Delhivery's export product has no rate API.",
+      "Rates and ships both lanes. For an Indian origin this is the cross-border rate source, because Delhivery's export product has no rate API. DDP is a real Shiprocket capability but is gated on CSB-5 seller KYC — every lane reports ddp_tag: false today.",
   },
   {
     id: "delhivery",
@@ -74,8 +89,14 @@ export const CARRIER_CAPABILITIES: CarrierCapability[] = [
     platform_account: true,
     domestic: { can_rate: true, can_ship: true },
     international: { can_rate: false, can_ship: false },
+    // Delhivery support (2026-08-22) confirms DDP exists on their cross-border
+    // product: "For Commercial please select the DDP mode from incoterm", and
+    // "Free on domicile" for sample shipments. Both are PANEL selections on
+    // Delhivery Cross Border. The domestic Express API this adapter drives has
+    // no incoterm field at all, so we cannot set it from code.
+    can_declare_ddp: false,
     notes:
-      "Domestic (Express) only. International exports run on Delhivery Cross Border — a separate service we have no API access to — so the adapter refuses cross-border rather than failing at label time.",
+      "Domestic (Express) only. International exports run on Delhivery Cross Border — a separate service we have no API access to — so the adapter refuses cross-border rather than failing at label time. DDP exists there (support: select DDP from incoterm for commercial, Free on domicile for samples) but only as a panel selection; nothing in the API we hold can declare it.",
   },
   {
     id: "bluedart",
@@ -84,8 +105,12 @@ export const CARRIER_CAPABILITIES: CarrierCapability[] = [
     platform_account: true,
     domestic: { can_rate: false, can_ship: true },
     international: { can_rate: false, can_ship: true },
+    // The only adapter that can say it: `IncotermCode` on the international
+    // services block, which followed the sale as of #1447 (it was hardcoded
+    // "DAP" — duty unpaid — before that).
+    can_declare_ddp: true,
     notes:
-      "Ships both lanes (international via product code H/IPC) but cannot quote either — the adapter implements no rate call, so it can only be used as a flat-priced or manually-priced option.",
+      "Ships both lanes (international via product code H/IPC) but cannot quote either — the adapter implements no rate call, so it can only be used as a flat-priced or manually-priced option. It is the one carrier whose payload carries an incoterm, so a DDP sale can at least be DECLARED DDP; whether the account is billed the duty is a commercial arrangement, not a flag.",
   },
   {
     id: "dtdc",
@@ -94,6 +119,7 @@ export const CARRIER_CAPABILITIES: CarrierCapability[] = [
     platform_account: false,
     domestic: { can_rate: false, can_ship: false },
     international: { can_rate: false, can_ship: false },
+    can_declare_ddp: false,
     notes: "Not integrated. No adapter exists yet.",
   },
 ]
@@ -101,6 +127,17 @@ export const CARRIER_CAPABILITIES: CarrierCapability[] = [
 /** The Medusa fulfillment-provider id a carrier registers under. */
 export function fulfillmentProviderId(carrierId: string): string {
   return `${carrierId}_${carrierId}`
+}
+
+/**
+ * Can this carrier be told the shipment is DDP?
+ *
+ * 🔴 Unknown carrier ⇒ FALSE. The safe answer is "we cannot declare it", which
+ * routes the promise to a human; guessing true would let a DDP sale ship
+ * silently as duty-unpaid, and the buyer finds out at their border.
+ */
+export function carrierCanDeclareDdp(carrierId?: string | null): boolean {
+  return Boolean(findCarrierCapability(carrierId)?.can_declare_ddp)
 }
 
 export function findCarrierCapability(

--- a/apps/backend/src/modules/shipping-providers/provider-interface.ts
+++ b/apps/backend/src/modules/shipping-providers/provider-interface.ts
@@ -68,8 +68,31 @@ export type CustomsDeclaration = {
   reason_of_export?: 0 | 1 | 2 | 3
   /** 0 gift · 1 sample · 2 commercial. Default 2. */
   purpose_of_shipment?: 0 | 1 | 2
-  /** Incoterms on the commercial invoice. Default "FOB". */
+  /**
+   * The invoice VALUATION basis. Default "FOB".
+   *
+   * ⚠️ Not an incoterm in the "who pays duty" sense, despite the name and
+   * despite Shiprocket calling its field `Terms_Of_Invoice`. It says whether
+   * the declared value includes freight and insurance. Reading it as the
+   * delivery term is how a DDP sale ends up declared duty-unpaid.
+   */
   terms_of_invoice?: "FOB" | "CIF"
+  /**
+   * Who clears and pays destination duty (#1447).
+   *
+   * · `DAP` — delivered at place, duty UNPAID: the consignee is importer of
+   *   record and meets the customs bill. This is the default and was, until
+   *   this field existed, the only thing any adapter could say.
+   * · `DDP` — delivered duty paid: WE clear and pay. Only send this when the
+   *   sale was actually made DDP (`partner_quote.duties_prepaid`) and the
+   *   carrier can honour it — see `can_declare_ddp` in `carrier-capabilities`.
+   *
+   * 🔴 A DDP sale shipped as DAP hands the buyer the customs bill we promised
+   * they would not get, weeks after they paid, with our invoice as the
+   * evidence they were told otherwise. Blue Dart's adapter hardcoded `"DAP"`
+   * before this.
+   */
+  incoterm?: "DAP" | "DDP"
   /** IGST: A not-applicable · B LUT/Export-under-Bond · C against IGST payment. Default "A". */
   igst_payment_status?: "A" | "B" | "C"
   /** Whether the order is a commodity. Default true. */

--- a/apps/backend/src/workflows/partner-quote/mint-quote.ts
+++ b/apps/backend/src/workflows/partner-quote/mint-quote.ts
@@ -57,6 +57,8 @@ export type MintQuoteInput = {
   currency_code: string
   region_id?: string | null
   carrier?: string
+  /** Quote as DDP — we pay the destination duty and import tax (#1447). */
+  duties_prepaid?: boolean
   ttl_days?: number
   created_by?: string | null
   /** Injected so the whole mint is deterministic under test. */
@@ -251,6 +253,9 @@ const buildAndFreezeStep = createStep(
       region_id: input.region_id ?? null,
       store: input.store,
       carrier: input.carrier,
+      // The row does not exist yet, so the undertaking is supplied directly —
+      // it changes the disclosure the buyer is shown, which then gets frozen.
+      duties_prepaid: input.duties_prepaid ?? false,
       now: payload.now,
     })
 
@@ -696,6 +701,9 @@ const persistQuoteStep = createStep(
       quoted_tax_inclusive: input.view.tax?.inclusive ?? null,
       quoted_tax_status: input.view.tax?.status ?? null,
       quoted_tax_reason: input.view.tax?.reason ?? null,
+      // Frozen with the rest: it is part of what the buyer was promised, and a
+      // later page read must show the same undertaking, not re-derive it.
+      duties_prepaid: input.mint.duties_prepaid ?? false,
       quoted_at: new Date(input.now),
       token_hash: hash,
       status: "active",

--- a/apps/backend/src/workflows/partner-quote/mint-quote.ts
+++ b/apps/backend/src/workflows/partner-quote/mint-quote.ts
@@ -17,7 +17,10 @@ import {
 } from "@medusajs/medusa/core-flows"
 
 import { PARTNER_QUOTE_MODULE } from "../../modules/partner-quote"
-import { buildQuoteView } from "../../modules/partner-quote/lib/build-quote-view"
+import {
+  buildQuoteView,
+  resolveStoreOriginCountry,
+} from "../../modules/partner-quote/lib/build-quote-view"
 import { assessQuoteReadiness } from "../../modules/partner-quote/lib/quote-readiness"
 import {
   generateQuoteToken,
@@ -25,6 +28,7 @@ import {
   DEFAULT_QUOTE_TTL_DAYS,
 } from "../../modules/partner-quote/lib/token"
 import { composeQuoteMoney } from "../../modules/partner-quote/lib/build-quote-view"
+import { resolveQuoteTax } from "../../modules/partner-quote/lib/quote-tax"
 import { fetchExchangeRate } from "../../lib/fx/exchange-rate"
 import { pickDefaultCurrency } from "../../lib/resolve-store-currency"
 import { needsExchangeRate, resolveLineOverride } from "./lib/line-override"
@@ -398,6 +402,50 @@ const applyLineOverridesStep = createStep(
     })
 
     const priced = lines.filter((l: any) => l.live_subtotal !== null)
+
+    /**
+     * 🔴 Tax is RE-ASKED against the overridden prices, not carried over.
+     *
+     * `buildQuoteView` computed it from the catalogue prices, before this step
+     * existed to discount them. A 20% trade price on a domestic quote therefore
+     * froze 18% GST on the RETAIL subtotal — tax on money the buyer was never
+     * asked for, in the confident direction, on exactly the quotes a partner
+     * had negotiated. The number that gets frozen is `view.tax`, so this was
+     * wrong in the row as well as on the page.
+     *
+     * Same module, same inputs, one different set of line amounts — so the
+     * quote and the cart that later prices itself still cannot disagree.
+     * `resolveQuoteTax` never throws: an unresolvable rate lands on `unknown`
+     * WITH a reason, which is what the page renders.
+     */
+    const originCountry = await resolveStoreOriginCountry(
+      container,
+      input.store?.default_location_id
+    )
+    const chosenFreight = view?.freight?.chosen ?? null
+    const tax =
+      view?.live && chosenFreight
+        ? await resolveQuoteTax(container, {
+            region_id: input.region_id ?? null,
+            origin_country_code: originCountry,
+            duties_prepaid: Boolean(input.duties_prepaid),
+            destination_country_code: input.destination_country_code,
+            destination_postal_code: input.destination_postal_code ?? null,
+            lines: priced.map((l: any) => ({
+              variant_id: l.variant_id,
+              product_id: l.product_id ?? null,
+              // The OVERRIDDEN unit price. Passing the catalogue one here is
+              // the whole defect this re-ask exists to remove.
+              unit_amount: Number(l.live_unit_amount ?? 0),
+              quantity: Number(l.quantity ?? 0),
+            })),
+            freight: {
+              amount: Number(chosenFreight.amount ?? 0),
+              option_id: (chosenFreight as any)?.id ?? null,
+            },
+          })
+        : view?.tax
+
     /**
      * 🔴 Tax and duty are carried across the recompose, not dropped.
      *
@@ -407,25 +455,20 @@ const applyLineOverridesStep = createStep(
      * quotes a partner had priced by hand. The freeze reads `view.tax`
      * separately, so the row was right and only the page was wrong, which is
      * why it survived.
-     *
-     * ⚠️ The tax AMOUNT here is still the one computed against pre-override
-     * prices, so a discounted quote overstates it. Tracked on #1447 — fixing
-     * it means re-asking the Tax module with the overridden lines, which is a
-     * change to what gets frozen, not to what gets rendered.
      */
     const live = view?.live
       ? composeQuoteMoney(
           priced.map((l: any) => Number(l.live_subtotal)),
           priced.reduce((sum: number, l: any) => sum + Number(l.quantity), 0),
           Number(view.live.freight ?? 0),
-          view.tax
-            ? { total: view.tax.total ?? null, inclusive: Boolean(view.tax.inclusive) }
+          tax
+            ? { total: tax.total ?? null, inclusive: Boolean(tax.inclusive) }
             : null,
           view.live.duty_total ?? null
         )
       : view?.live ?? null
 
-    return new StepResponse({ ...view, lines, live })
+    return new StepResponse({ ...view, lines, live, tax })
   }
 )
 

--- a/apps/backend/src/workflows/partner-quote/mint-quote.ts
+++ b/apps/backend/src/workflows/partner-quote/mint-quote.ts
@@ -59,6 +59,17 @@ export type MintQuoteInput = {
   carrier?: string
   /** Quote as DDP — we pay the destination duty and import tax (#1447). */
   duties_prepaid?: boolean
+  /**
+   * The duty amount we are undertaking to pay, in the QUOTE currency, and the
+   * note saying how it was arrived at (#1447).
+   *
+   * Entered by hand because nothing can derive it yet: HS codes are incomplete
+   * and Shiprocket's tariff endpoint is gated on CSB-5 KYC. The validator
+   * refuses `duties_prepaid` without an amount, so no quote can promise duty
+   * cover and add nothing to the price.
+   */
+  duty_total?: number | null
+  duty_basis?: string | null
   ttl_days?: number
   created_by?: string | null
   /** Injected so the whole mint is deterministic under test. */
@@ -256,6 +267,8 @@ const buildAndFreezeStep = createStep(
       // The row does not exist yet, so the undertaking is supplied directly —
       // it changes the disclosure the buyer is shown, which then gets frozen.
       duties_prepaid: input.duties_prepaid ?? false,
+      duty_total: input.duty_total ?? null,
+      duty_basis: input.duty_basis ?? null,
       now: payload.now,
     })
 
@@ -385,11 +398,30 @@ const applyLineOverridesStep = createStep(
     })
 
     const priced = lines.filter((l: any) => l.live_subtotal !== null)
+    /**
+     * 🔴 Tax and duty are carried across the recompose, not dropped.
+     *
+     * This call used to pass subtotals and freight only, so `tax_total`,
+     * `duty_total` and `gross_total` all came back null on any quote with a
+     * trade price — the buyer page showed no total at all, on precisely the
+     * quotes a partner had priced by hand. The freeze reads `view.tax`
+     * separately, so the row was right and only the page was wrong, which is
+     * why it survived.
+     *
+     * ⚠️ The tax AMOUNT here is still the one computed against pre-override
+     * prices, so a discounted quote overstates it. Tracked on #1447 — fixing
+     * it means re-asking the Tax module with the overridden lines, which is a
+     * change to what gets frozen, not to what gets rendered.
+     */
     const live = view?.live
       ? composeQuoteMoney(
           priced.map((l: any) => Number(l.live_subtotal)),
           priced.reduce((sum: number, l: any) => sum + Number(l.quantity), 0),
-          Number(view.live.freight ?? 0)
+          Number(view.live.freight ?? 0),
+          view.tax
+            ? { total: view.tax.total ?? null, inclusive: Boolean(view.tax.inclusive) }
+            : null,
+          view.live.duty_total ?? null
         )
       : view?.live ?? null
 
@@ -704,6 +736,12 @@ const persistQuoteStep = createStep(
       // Frozen with the rest: it is part of what the buyer was promised, and a
       // later page read must show the same undertaking, not re-derive it.
       duties_prepaid: input.mint.duties_prepaid ?? false,
+      // The duty figure freezes with the promise it backs. Read off the VIEW,
+      // which has already refused to carry an amount on a non-DDP quote, so a
+      // stray number in the body cannot be stored against a quote whose buyer
+      // was told duty is theirs to pay.
+      quoted_duty_total: input.view.duty?.total ?? null,
+      quoted_duty_basis: input.view.duty?.basis ?? null,
       quoted_at: new Date(input.now),
       token_hash: hash,
       status: "active",

--- a/apps/backend/src/workflows/partner-quote/mint-quote.ts
+++ b/apps/backend/src/workflows/partner-quote/mint-quote.ts
@@ -74,6 +74,16 @@ export type MintQuoteInput = {
    */
   duty_total?: number | null
   duty_basis?: string | null
+  /**
+   * The rate form, and the normal one. The amounts are computed by
+   * `buildQuoteView` against the basket it actually priced — duty on
+   * goods + freight, import tax on goods + freight + duty.
+   */
+  duty_rate_percent?: number | null
+  import_tax_rate_percent?: number | null
+  import_tax_total?: number | null
+  /** The carrier's fee for advancing duty and tax. Always an amount. */
+  ddp_fee_total?: number | null
   ttl_days?: number
   created_by?: string | null
   /** Injected so the whole mint is deterministic under test. */
@@ -273,6 +283,10 @@ const buildAndFreezeStep = createStep(
       duties_prepaid: input.duties_prepaid ?? false,
       duty_total: input.duty_total ?? null,
       duty_basis: input.duty_basis ?? null,
+      duty_rate_percent: input.duty_rate_percent ?? null,
+      import_tax_rate_percent: input.import_tax_rate_percent ?? null,
+      import_tax_total: input.import_tax_total ?? null,
+      ddp_fee_total: input.ddp_fee_total ?? null,
       now: payload.now,
     })
 
@@ -784,6 +798,15 @@ const persistQuoteStep = createStep(
       // stray number in the body cannot be stored against a quote whose buyer
       // was told duty is theirs to pay.
       quoted_duty_total: input.view.duty?.total ?? null,
+      // The other two thirds. Duty alone funds ~a quarter of a real EU
+      // undertaking — the import tax is the big one and the carrier charges a
+      // fee for advancing both.
+      quoted_import_tax_total: input.view.duty?.import_tax ?? null,
+      quoted_ddp_fee_total: input.view.duty?.carrier_fee ?? null,
+      // Frozen so the amounts can be re-derived against a carrier invoice
+      // months later rather than merely believed.
+      quoted_duty_rate: input.view.duty?.duty_rate_percent ?? null,
+      quoted_import_tax_rate: input.view.duty?.import_tax_rate_percent ?? null,
       quoted_duty_basis: input.view.duty?.basis ?? null,
       quoted_at: new Date(input.now),
       token_hash: hash,

--- a/apps/backend/src/workflows/partner-quote/mint-quote.ts
+++ b/apps/backend/src/workflows/partner-quote/mint-quote.ts
@@ -683,6 +683,19 @@ const persistQuoteStep = createStep(
       quoted_freight: input.view.live?.freight ?? null,
       quoted_landed_total: input.view.live?.landed_total ?? null,
       quoted_weight_grams: input.view.total_weight_grams ?? null,
+      // Tax frozen alongside the rest (#1439 S8). Read off `view.tax` rather
+      // than `view.live.tax_total`: the money object carries the NUMBER, and a
+      // number alone cannot distinguish "zero-rated export" from "we could not
+      // work it out" — both are a 0 and only one of them is a fact.
+      //
+      // `?? null` throughout, never `?? 0`. A quote whose tax could not be
+      // resolved must freeze as unknown; writing 0 would turn a gap into a
+      // confident claim of no tax due, which is the failure this whole slice is
+      // built around.
+      quoted_tax_total: input.view.tax?.total ?? null,
+      quoted_tax_inclusive: input.view.tax?.inclusive ?? null,
+      quoted_tax_status: input.view.tax?.status ?? null,
+      quoted_tax_reason: input.view.tax?.reason ?? null,
       quoted_at: new Date(input.now),
       token_hash: hash,
       status: "active",

--- a/apps/docs/notes/DELHIVERY_INTERNATIONAL_PARITY.md
+++ b/apps/docs/notes/DELHIVERY_INTERNATIONAL_PARITY.md
@@ -79,3 +79,39 @@ international orders.
 
 Real Delhivery cross-border. It needs the service activated, full seller
 KYC/IEC/AD-code onboarding, and a spec from Delhivery. That belongs under #649.
+
+## DDP on Delhivery — support's answer, 2026-08-22
+
+Delhivery support, verbatim:
+
+> For sample shipment you can select the **Free on domicile** option for DDP mode.
+>
+> For Commercial please select the **DDP mode from incoterm**.
+
+So **yes, Delhivery can do DDP** — and it lands exactly where this audit already
+put it: on **Cross Border**, whose order object carries "INCO Terms" (see the
+table above). Both are selections made on that product, not on the Express API
+this integration drives. `POST /api/cmu/create.json` has no incoterm field at
+all, and the 18-API doc set behind the Delhivery MCP returns **zero** matches for
+"incoterm", "DDP", "duty" or "customs".
+
+**What that means for us today:**
+
+- We cannot set it from code. Nothing in the API surface we hold can declare a
+  shipment DDP on Delhivery. `carrier_capabilities.can_declare_ddp` is therefore
+  `false` for Delhivery — the flag describes what the ADAPTER can say, not what
+  the carrier can do.
+- The blocker is the same one as everywhere else on this lane: **Cross Border
+  activation + seller KYC**, listed above as mandatory before order creation.
+- 🔑 Note the shape of the correction. This is the second carrier where the
+  capability existed and the docs we could reach did not mention it — Shiprocket
+  was the first (`ddp_tag`/`ioss_fee`/`tariff` are on the serviceability
+  response and absent from the 2 MB collection). Twice now, reading the
+  documentation produced a confident "this carrier cannot do DDP" and the
+  carrier's own people said otherwise. **Ask the carrier before concluding from
+  the docs.**
+
+Blue Dart is currently the only adapter that can declare it: its international
+services block carries `IncotermCode`, which was hardcoded `"DAP"` (duty
+UNPAID) until #1447 and now follows the sale. Declaring it is not the same as
+being billed for it — that is a commercial arrangement per account.

--- a/apps/partner-ui/src/hooks/api/partner-quotes.tsx
+++ b/apps/partner-ui/src/hooks/api/partner-quotes.tsx
@@ -104,6 +104,13 @@ export type MintPartnerQuotePayload = {
   region_id?: string | null
   carrier?: string
   ttl_days?: number
+  /**
+   * DDP (#1447): we pay the destination duty, and the amount we are absorbing
+   * plus how it was reached. The backend refuses the flag without the pair.
+   */
+  duties_prepaid?: boolean
+  duty_total?: number | null
+  duty_basis?: string | null
 }
 
 export type ListPartnerQuotesParams = {

--- a/apps/partner-ui/src/hooks/api/partner-quotes.tsx
+++ b/apps/partner-ui/src/hooks/api/partner-quotes.tsx
@@ -109,7 +109,11 @@ export type MintPartnerQuotePayload = {
    * plus how it was reached. The backend refuses the flag without the pair.
    */
   duties_prepaid?: boolean
+  duty_rate_percent?: number | null
+  import_tax_rate_percent?: number | null
   duty_total?: number | null
+  import_tax_total?: number | null
+  ddp_fee_total?: number | null
   duty_basis?: string | null
 }
 

--- a/apps/partner-ui/src/routes/orders/quote-create/components/quote-create-form/quote-buyer-form.tsx
+++ b/apps/partner-ui/src/routes/orders/quote-create/components/quote-create-form/quote-buyer-form.tsx
@@ -1,4 +1,4 @@
-import { Heading, Input, Text, Textarea } from "@medusajs/ui"
+import { Heading, Input, Switch, Text, Textarea } from "@medusajs/ui"
 import { UseFormReturn } from "react-hook-form"
 import { useTranslation } from "react-i18next"
 
@@ -241,6 +241,125 @@ export const QuoteBuyerForm = ({ form, currencies }: QuoteBuyerFormProps) => {
           )}
         />
       </div>
+
+      <div className="flex flex-col gap-y-1">
+        <Heading level="h2">
+          {t("quotes.duty.header", "Import duty (DDP)")}
+        </Heading>
+        <Text size="small" className="text-ui-fg-subtle">
+          {t(
+            "quotes.duty.hint",
+            "Only for an export. Turn this on and the buyer is told there is nothing further to pay on delivery — which means we pay their customs bill, and someone has to arrange that clearance by hand until a carrier can."
+          )}
+        </Text>
+      </div>
+
+      <Form.Field
+        control={form.control}
+        name="duties_prepaid"
+        render={({ field: { value, onChange, ...rest } }) => (
+          <Form.Item>
+            <div className="flex items-start justify-between gap-4 rounded-lg border border-ui-border-base p-4">
+              <div className="flex flex-col gap-y-1">
+                <Form.Label>
+                  {t("quotes.fields.dutiesPrepaid", "We pay the import duty")}
+                </Form.Label>
+                <Form.Hint>
+                  {t(
+                    "quotes.fields.dutiesPrepaidHint",
+                    "Leave off and the buyer is the importer of record — duty and import VAT are theirs, and the quote says so."
+                  )}
+                </Form.Hint>
+              </div>
+              <Form.Control>
+                <Switch
+                  checked={Boolean(value)}
+                  onCheckedChange={(checked) => {
+                    onChange(checked)
+                    if (!checked) {
+                      /**
+                       * 🔴 Clear the pair when the undertaking is withdrawn. A
+                       * duty amount left behind on a non-DDP quote is refused
+                       * by the backend, and it would be worse if it were not:
+                       * it would be added to a total whose buyer was told duty
+                       * is theirs to pay on arrival.
+                       */
+                      form.setValue("duty_total", null)
+                      form.setValue("duty_basis", null)
+                      form.clearErrors(["duty_total", "duty_basis"])
+                    }
+                  }}
+                  {...rest}
+                />
+              </Form.Control>
+            </div>
+            <Form.ErrorMessage />
+          </Form.Item>
+        )}
+      />
+
+      {form.watch("duties_prepaid") ? (
+        <div className="grid grid-cols-1 gap-4 md:grid-cols-2">
+          <Form.Field
+            control={form.control}
+            name="duty_total"
+            render={({ field: { onChange, value, ...rest } }) => (
+              <Form.Item>
+                <Form.Label>
+                  {t("quotes.fields.dutyTotal", "Duty we absorb")}
+                </Form.Label>
+                <Form.Control>
+                  <Input
+                    type="number"
+                    min={0}
+                    step="0.01"
+                    placeholder="0.00"
+                    value={value ?? ""}
+                    onChange={(e) => {
+                      const next = e.target.value
+                      onChange(next === "" ? null : Number(next))
+                    }}
+                    {...rest}
+                  />
+                </Form.Control>
+                <Form.Hint>
+                  {t(
+                    "quotes.fields.dutyTotalHint",
+                    "In the quote's currency. It is added to the buyer's total — nothing derives it, so this figure is the one we are committing to."
+                  )}
+                </Form.Hint>
+                <Form.ErrorMessage />
+              </Form.Item>
+            )}
+          />
+
+          <Form.Field
+            control={form.control}
+            name="duty_basis"
+            render={({ field }) => (
+              <Form.Item>
+                <Form.Label>
+                  {t("quotes.fields.dutyBasis", "How you got there")}
+                </Form.Label>
+                <Form.Control>
+                  <Input
+                    placeholder="EU 12% ad valorem, HS 6304.92"
+                    {...field}
+                    value={field.value ?? ""}
+                  />
+                </Form.Control>
+                <Form.Hint>
+                  {t(
+                    "quotes.fields.dutyBasisHint",
+                    "A nil duty is a real answer — say why (e.g. AI-ECTA: Indian textiles enter Australia duty-free). A bare 0 cannot tell 'checked' from 'left blank'."
+                  )}
+                </Form.Hint>
+                <Form.ErrorMessage />
+              </Form.Item>
+            )}
+          />
+        </div>
+      ) : null}
     </div>
   )
 }

--- a/apps/partner-ui/src/routes/orders/quote-create/components/quote-create-form/quote-buyer-form.tsx
+++ b/apps/partner-ui/src/routes/orders/quote-create/components/quote-create-form/quote-buyer-form.tsx
@@ -284,9 +284,16 @@ export const QuoteBuyerForm = ({ form, currencies }: QuoteBuyerFormProps) => {
                        * it would be added to a total whose buyer was told duty
                        * is theirs to pay on arrival.
                        */
-                      form.setValue("duty_total", null)
+                      form.setValue("duty_rate_percent", null)
+                      form.setValue("import_tax_rate_percent", null)
+                      form.setValue("ddp_fee_total", null)
                       form.setValue("duty_basis", null)
-                      form.clearErrors(["duty_total", "duty_basis"])
+                      form.clearErrors([
+                        "duty_rate_percent",
+                        "import_tax_rate_percent",
+                        "ddp_fee_total",
+                        "duty_basis",
+                      ])
                     }
                   }}
                   {...rest}
@@ -299,14 +306,82 @@ export const QuoteBuyerForm = ({ form, currencies }: QuoteBuyerFormProps) => {
       />
 
       {form.watch("duties_prepaid") ? (
-        <div className="grid grid-cols-1 gap-4 md:grid-cols-2">
+        <div className="grid grid-cols-1 gap-4 md:grid-cols-3">
           <Form.Field
             control={form.control}
-            name="duty_total"
+            name="duty_rate_percent"
             render={({ field: { onChange, value, ...rest } }) => (
               <Form.Item>
                 <Form.Label>
-                  {t("quotes.fields.dutyTotal", "Duty we absorb")}
+                  {t("quotes.fields.dutyRate", "Duty rate %")}
+                </Form.Label>
+                <Form.Control>
+                  <Input
+                    type="number"
+                    min={0}
+                    max={100}
+                    step="0.01"
+                    placeholder="8"
+                    value={value ?? ""}
+                    onChange={(e) => {
+                      const next = e.target.value
+                      onChange(next === "" ? null : Number(next))
+                    }}
+                    {...rest}
+                  />
+                </Form.Control>
+                <Form.Hint>
+                  {t(
+                    "quotes.fields.dutyRateHint",
+                    "Applied to goods + freight. 0% is a real answer — AI-ECTA makes Indian textiles duty-free into Australia."
+                  )}
+                </Form.Hint>
+                <Form.ErrorMessage />
+              </Form.Item>
+            )}
+          />
+
+          <Form.Field
+            control={form.control}
+            name="import_tax_rate_percent"
+            render={({ field: { onChange, value, ...rest } }) => (
+              <Form.Item>
+                <Form.Label>
+                  {t("quotes.fields.importTaxRate", "Import VAT / GST %")}
+                </Form.Label>
+                <Form.Control>
+                  <Input
+                    type="number"
+                    min={0}
+                    max={100}
+                    step="0.01"
+                    placeholder="21"
+                    value={value ?? ""}
+                    onChange={(e) => {
+                      const next = e.target.value
+                      onChange(next === "" ? null : Number(next))
+                    }}
+                    {...rest}
+                  />
+                </Form.Control>
+                <Form.Hint>
+                  {t(
+                    "quotes.fields.importTaxRateHint",
+                    "Applied to goods + freight + duty — it is charged on a value that already includes the duty, and it is usually the largest of the three."
+                  )}
+                </Form.Hint>
+                <Form.ErrorMessage />
+              </Form.Item>
+            )}
+          />
+
+          <Form.Field
+            control={form.control}
+            name="ddp_fee_total"
+            render={({ field: { onChange, value, ...rest } }) => (
+              <Form.Item>
+                <Form.Label optional>
+                  {t("quotes.fields.ddpFee", "Carrier clearance fee")}
                 </Form.Label>
                 <Form.Control>
                   <Input
@@ -324,8 +399,8 @@ export const QuoteBuyerForm = ({ form, currencies }: QuoteBuyerFormProps) => {
                 </Form.Control>
                 <Form.Hint>
                   {t(
-                    "quotes.fields.dutyTotalHint",
-                    "In the quote's currency. It is added to the buyer's total — nothing derives it, so this figure is the one we are committing to."
+                    "quotes.fields.ddpFeeHint",
+                    "What the carrier charges for advancing the duty and tax (DHL calls it duty-tax-paid). In the quote's currency."
                   )}
                 </Form.Hint>
                 <Form.ErrorMessage />
@@ -333,31 +408,33 @@ export const QuoteBuyerForm = ({ form, currencies }: QuoteBuyerFormProps) => {
             )}
           />
 
-          <Form.Field
-            control={form.control}
-            name="duty_basis"
-            render={({ field }) => (
-              <Form.Item>
-                <Form.Label>
-                  {t("quotes.fields.dutyBasis", "How you got there")}
-                </Form.Label>
-                <Form.Control>
-                  <Input
-                    placeholder="EU 12% ad valorem, HS 6304.92"
-                    {...field}
-                    value={field.value ?? ""}
-                  />
-                </Form.Control>
-                <Form.Hint>
-                  {t(
-                    "quotes.fields.dutyBasisHint",
-                    "A nil duty is a real answer — say why (e.g. AI-ECTA: Indian textiles enter Australia duty-free). A bare 0 cannot tell 'checked' from 'left blank'."
-                  )}
-                </Form.Hint>
-                <Form.ErrorMessage />
-              </Form.Item>
-            )}
-          />
+          <div className="md:col-span-3">
+            <Form.Field
+              control={form.control}
+              name="duty_basis"
+              render={({ field }) => (
+                <Form.Item>
+                  <Form.Label>
+                    {t("quotes.fields.dutyBasis", "How you got these rates")}
+                  </Form.Label>
+                  <Form.Control>
+                    <Input
+                      placeholder="EU: 8% duty, 21% NL VAT, HS 6304.92 — DHL landed-cost planner"
+                      {...field}
+                      value={field.value ?? ""}
+                    />
+                  </Form.Control>
+                  <Form.Hint>
+                    {t(
+                      "quotes.fields.dutyBasisHint",
+                      "The amounts are computed at mint against the basket that is actually priced, and frozen with these rates — so the figure can be checked against the carrier's invoice later instead of merely believed."
+                    )}
+                  </Form.Hint>
+                  <Form.ErrorMessage />
+                </Form.Item>
+              )}
+            />
+          </div>
         </div>
       ) : null}
     </div>

--- a/apps/partner-ui/src/routes/orders/quote-create/components/quote-create-form/quote-create-form.tsx
+++ b/apps/partner-ui/src/routes/orders/quote-create/components/quote-create-form/quote-create-form.tsx
@@ -89,7 +89,9 @@ export const QuoteCreateForm = ({
       // Never defaulted on: a DDP promise applied by default would tell a buyer
       // there is nothing to pay on a shipment nobody arranged clearance for.
       duties_prepaid: false,
-      duty_total: null,
+      duty_rate_percent: null,
+      import_tax_rate_percent: null,
+      ddp_fee_total: null,
       duty_basis: null,
     },
     resolver: zodResolver(QuoteCreateSchema),
@@ -203,7 +205,12 @@ export const QuoteCreateForm = ({
         duties_prepaid: data.duties_prepaid ?? false,
         ...(data.duties_prepaid
           ? {
-              duty_total: data.duty_total ?? null,
+              // Rates, not money: the mint computes the amounts against the
+              // basket it actually prices. This form knows neither the tiered
+              // subtotal nor the freight until then.
+              duty_rate_percent: data.duty_rate_percent ?? null,
+              import_tax_rate_percent: data.import_tax_rate_percent ?? null,
+              ddp_fee_total: data.ddp_fee_total ?? null,
               duty_basis: data.duty_basis || null,
             }
           : {}),

--- a/apps/partner-ui/src/routes/orders/quote-create/components/quote-create-form/quote-create-form.tsx
+++ b/apps/partner-ui/src/routes/orders/quote-create/components/quote-create-form/quote-create-form.tsx
@@ -86,6 +86,11 @@ export const QuoteCreateForm = ({
       quantities: {},
       discounts: {},
       overrides: {},
+      // Never defaulted on: a DDP promise applied by default would tell a buyer
+      // there is nothing to pay on a shipment nobody arranged clearance for.
+      duties_prepaid: false,
+      duty_total: null,
+      duty_basis: null,
     },
     resolver: zodResolver(QuoteCreateSchema),
   })
@@ -193,6 +198,15 @@ export const QuoteCreateForm = ({
         destination_city: data.destination_city || null,
         currency_code: data.currency_code,
         ttl_days: data.ttl_days,
+        // Sent as a pair or not at all — the backend refuses the promise
+        // without its number, and the number without the promise (#1447).
+        duties_prepaid: data.duties_prepaid ?? false,
+        ...(data.duties_prepaid
+          ? {
+              duty_total: data.duty_total ?? null,
+              duty_basis: data.duty_basis || null,
+            }
+          : {}),
       },
       {
         onSuccess: (result) => {

--- a/apps/partner-ui/src/routes/orders/quote-create/components/quote-create-form/schema.ts
+++ b/apps/partner-ui/src/routes/orders/quote-create/components/quote-create-form/schema.ts
@@ -25,38 +25,52 @@ import { z } from "@medusajs/framework/zod"
 export const dutyUndertakingRefinement = (
   value: {
     duties_prepaid?: boolean
+    duty_rate_percent?: number | null
+    import_tax_rate_percent?: number | null
     duty_total?: number | null
+    import_tax_total?: number | null
+    ddp_fee_total?: number | null
     duty_basis?: string | null
   },
   ctx: z.RefinementCtx
 ) => {
   const prepaid = Boolean(value.duties_prepaid)
-  const hasAmount = value.duty_total !== null && value.duty_total !== undefined
+  const given = (v: unknown) => v !== null && v !== undefined
+  const hasDuty = given(value.duty_rate_percent) || given(value.duty_total)
+  const hasImportTax =
+    given(value.import_tax_rate_percent) || given(value.import_tax_total)
 
-  if (prepaid && !hasAmount) {
+  if (prepaid && !hasDuty) {
+    ctx.addIssue({
+      code: "custom",
+      message: "Enter the duty rate for this destination — 0% is fine where the lane is duty-free.",
+      path: ["duty_rate_percent"],
+    })
+  }
+
+  if (prepaid && !hasImportTax) {
     ctx.addIssue({
       code: "custom",
       message:
-        "Enter the duty we are absorbing on this quote — 0 is fine where the lane is duty-free.",
-      path: ["duty_total"],
+        "Enter the destination import tax rate. It is usually the biggest of the three — 21% VAT on goods + freight + duty against an 8% duty — so leaving it out under-funds most of the promise.",
+      path: ["import_tax_rate_percent"],
     })
   }
 
   if (prepaid && !String(value.duty_basis ?? "").trim()) {
     ctx.addIssue({
       code: "custom",
-      message:
-        "Say how the figure was reached — whoever pays the customs invoice is not who typed it.",
+      message: "Say how you got these rates — whoever pays the customs invoice is not who typed them.",
       path: ["duty_basis"],
     })
   }
 
-  if (!prepaid && hasAmount) {
+  if (!prepaid && (hasDuty || hasImportTax || given(value.ddp_fee_total))) {
     ctx.addIssue({
       code: "custom",
       message:
-        "A duty amount only applies on a DDP quote. Without it the buyer pays duty at their own border.",
-      path: ["duty_total"],
+        "These only apply on a DDP quote. Without it the buyer pays duty and import tax at their own border.",
+      path: ["duty_rate_percent"],
     })
   }
 }
@@ -81,7 +95,16 @@ export const QuoteBuyerShape = z.object({
    * actually clear DDP, arranged by hand until a carrier can price it.
    */
   duties_prepaid: z.boolean().optional(),
-  duty_total: z.number().min(0).nullish(),
+  /**
+   * Rates, not amounts. The mint computes the money against the basket it
+   * actually prices — duty on goods + freight, import tax on goods + freight +
+   * duty — because this form cannot know either figure before then, and a
+   * client-side estimate frozen as a commitment is worse than no preview.
+   */
+  duty_rate_percent: z.number().min(0).max(100).nullish(),
+  import_tax_rate_percent: z.number().min(0).max(100).nullish(),
+  /** The carrier's charge for advancing duty and tax. An amount, not a rate. */
+  ddp_fee_total: z.number().min(0).nullish(),
   duty_basis: z.string().max(500).nullish(),
 })
 
@@ -143,7 +166,9 @@ export const QuoteBuyerFields = [
   "currency_code",
   "ttl_days",
   "duties_prepaid",
-  "duty_total",
+  "duty_rate_percent",
+  "import_tax_rate_percent",
+  "ddp_fee_total",
   "duty_basis",
 ] as const
 

--- a/apps/partner-ui/src/routes/orders/quote-create/components/quote-create-form/schema.ts
+++ b/apps/partner-ui/src/routes/orders/quote-create/components/quote-create-form/schema.ts
@@ -8,7 +8,60 @@ import { z } from "@medusajs/framework/zod"
  * existing customer and typing their address are the same request. The picker
  * exists so a typo cannot silently create a second customer.
  */
-export const QuoteBuyerSchema = z.object({
+/**
+ * The DDP rule, mirrored from `dutyUndertakingRefinement` in the backend
+ * validators (#1447).
+ *
+ * 🔴 Mirrored rather than skipped because the wizard is where the promise is
+ * made. `duties_prepaid` alone tells the buyer "nothing further to pay on
+ * delivery" and adds nothing to the price, so the duty comes out of margin by
+ * an amount nobody computed. The backend refuses it either way — this is what
+ * makes the refusal legible on the field instead of arriving as a failed mint.
+ *
+ * `0` is a real answer (AI-ECTA: Indian textiles enter Australia duty-free),
+ * which is why the basis is required with it: a bare 0 cannot say whether it
+ * means "checked, nil" or "left blank".
+ */
+export const dutyUndertakingRefinement = (
+  value: {
+    duties_prepaid?: boolean
+    duty_total?: number | null
+    duty_basis?: string | null
+  },
+  ctx: z.RefinementCtx
+) => {
+  const prepaid = Boolean(value.duties_prepaid)
+  const hasAmount = value.duty_total !== null && value.duty_total !== undefined
+
+  if (prepaid && !hasAmount) {
+    ctx.addIssue({
+      code: "custom",
+      message:
+        "Enter the duty we are absorbing on this quote — 0 is fine where the lane is duty-free.",
+      path: ["duty_total"],
+    })
+  }
+
+  if (prepaid && !String(value.duty_basis ?? "").trim()) {
+    ctx.addIssue({
+      code: "custom",
+      message:
+        "Say how the figure was reached — whoever pays the customs invoice is not who typed it.",
+      path: ["duty_basis"],
+    })
+  }
+
+  if (!prepaid && hasAmount) {
+    ctx.addIssue({
+      code: "custom",
+      message:
+        "A duty amount only applies on a DDP quote. Without it the buyer pays duty at their own border.",
+      path: ["duty_total"],
+    })
+  }
+}
+
+export const QuoteBuyerShape = z.object({
   buyer_email: z.string().email(),
   recipient_name: z.string().optional(),
   recipient_company: z.string().optional(),
@@ -21,7 +74,20 @@ export const QuoteBuyerSchema = z.object({
   currency_code: z.string().min(3),
   /** Drives `price_list.ends_at`, so expiry is native rather than swept. */
   ttl_days: z.number().int().positive().max(365).optional(),
+
+  /**
+   * DDP (#1447) — we pay the destination duty and import tax, and the buyer
+   * pays nothing on arrival. Per quote, never a default: the shipment has to
+   * actually clear DDP, arranged by hand until a carrier can price it.
+   */
+  duties_prepaid: z.boolean().optional(),
+  duty_total: z.number().min(0).nullish(),
+  duty_basis: z.string().max(500).nullish(),
 })
+
+export const QuoteBuyerSchema = QuoteBuyerShape.superRefine(
+  dutyUndertakingRefinement
+)
 
 export const QuoteProductsSchema = z.object({
   product_ids: z.array(z.object({ id: z.string() })),
@@ -55,9 +121,14 @@ export const QuoteQuantitiesSchema = z.object({
   overrides: z.record(z.string(), z.number().nullish()),
 })
 
-export const QuoteCreateSchema = QuoteBuyerSchema.merge(
-  QuoteProductsSchema
-).merge(QuoteQuantitiesSchema)
+/**
+ * ⚠️ Merged from the SHAPE and re-refined. `.merge()` on an already-refined
+ * schema drops the cross-field rule silently, and the rule it drops is the one
+ * that stops a DDP quote promising duty cover with no amount behind it.
+ */
+export const QuoteCreateSchema = QuoteBuyerShape.merge(QuoteProductsSchema)
+  .merge(QuoteQuantitiesSchema)
+  .superRefine(dutyUndertakingRefinement)
 
 export type QuoteCreateSchemaType = z.infer<typeof QuoteCreateSchema>
 
@@ -71,6 +142,9 @@ export const QuoteBuyerFields = [
   "destination_city",
   "currency_code",
   "ttl_days",
+  "duties_prepaid",
+  "duty_total",
+  "duty_basis",
 ] as const
 
 export const QuoteProductFields = ["product_ids"] as const

--- a/apps/storefront/src/lib/data/quotes.ts
+++ b/apps/storefront/src/lib/data/quotes.ts
@@ -26,11 +26,17 @@ export type QuoteMoney = {
   /** #1439 S8. Null means unknown, never zero. */
   tax_total: number | null
   /**
-   * Customs duty WE pay on a DDP quote (#1447). Null = not a DDP quote or no
-   * figure; `0` = duty applies to this lane and is nil (AI-ECTA into AU).
-   * Never inside `landed_total`.
+   * The DDP undertaking, split (#1447). Null = not a DDP quote or no figure;
+   * `0` = the charge applies to this lane and is nil (AI-ECTA into AU).
+   * None of them is inside `landed_total`.
+   *
+   * 🔴 `import_tax_total` is usually the LARGEST: 21% of goods + freight + duty
+   * against an 8% duty. `ddp_fee_total` is the carrier's charge for advancing
+   * the money.
    */
   duty_total: number | null
+  import_tax_total: number | null
+  ddp_fee_total: number | null
   /**
    * `landed_total`, plus tax when the prices are tax-exclusive (when inclusive
    * the tax is already inside it), plus any prepaid duty.
@@ -169,7 +175,16 @@ export type QuoteView = {
    */
   duty: {
     prepaid: boolean
+    /** Customs duty. */
     total: number | null
+    /** Destination VAT/GST we also pay. */
+    import_tax: number | null
+    /** The carrier's fee for advancing duty and tax. */
+    carrier_fee: number | null
+    /** The three summed — what the undertaking adds to the buyer's total. */
+    combined_total: number | null
+    duty_rate_percent: number | null
+    import_tax_rate_percent: number | null
     basis: string | null
   }
   total_weight_grams: number | null

--- a/apps/storefront/src/lib/data/quotes.ts
+++ b/apps/storefront/src/lib/data/quotes.ts
@@ -26,8 +26,14 @@ export type QuoteMoney = {
   /** #1439 S8. Null means unknown, never zero. */
   tax_total: number | null
   /**
-   * `landed_total` + tax when the prices are tax-exclusive; equal to
-   * `landed_total` when they are inclusive (the tax is already inside it).
+   * Customs duty WE pay on a DDP quote (#1447). Null = not a DDP quote or no
+   * figure; `0` = duty applies to this lane and is nil (AI-ECTA into AU).
+   * Never inside `landed_total`.
+   */
+  duty_total: number | null
+  /**
+   * `landed_total`, plus tax when the prices are tax-exclusive (when inclusive
+   * the tax is already inside it), plus any prepaid duty.
    * Null whenever `tax_total` is.
    */
   gross_total: number | null
@@ -156,6 +162,16 @@ export type QuoteView = {
   live: QuoteMoney | null
   quoted: QuoteMoney | null
   tax: QuoteTax
+  /**
+   * The DDP undertaking and the duty figure behind it (#1447). `prepaid` with a
+   * null `total` is a legacy row: the promise was made before anything computed
+   * the amount, so the page must not print a confident "nothing further to pay".
+   */
+  duty: {
+    prepaid: boolean
+    total: number | null
+    basis: string | null
+  }
   total_weight_grams: number | null
   freight: {
     chosen: QuoteFreightOption | null

--- a/apps/storefront/src/modules/quotes/components/quote-summary/index.tsx
+++ b/apps/storefront/src/modules/quotes/components/quote-summary/index.tsx
@@ -52,7 +52,15 @@ const Row = ({
   </div>
 )
 
-/** The tax rows, or nothing when there is no number and no reason to give. */
+/**
+ * The tax row, the duty row and the total — or nothing, when there is no number
+ * to stand behind.
+ *
+ * 🔴 The duty row exists because "we pay the duty" used to add nothing to the
+ * price (#1447). A DDP quote whose total is silently identical to a non-DDP one
+ * is a promise kept out of margin by an amount nobody wrote down; showing it as
+ * its own line is what makes the undertaking legible to the buyer AND to us.
+ */
 const TaxRows = ({
   money,
   tax,
@@ -74,6 +82,14 @@ const TaxRows = ({
         label={tax.inclusive ? `${label} (included)` : label}
         value={convertToLocale({ amount: money.tax_total, currency_code })}
       />
+      {money.duty_total !== null ? (
+        <Row
+          // Named for who pays it, not for what it is: the buyer's question is
+          // "is there a customs bill coming", and the answer here is no.
+          label="Import duty (paid by us)"
+          value={convertToLocale({ amount: money.duty_total, currency_code })}
+        />
+      ) : null}
       <Row
         label="Total"
         value={convertToLocale({ amount: money.gross_total, currency_code })}

--- a/apps/storefront/src/modules/quotes/components/quote-summary/index.tsx
+++ b/apps/storefront/src/modules/quotes/components/quote-summary/index.tsx
@@ -76,18 +76,46 @@ const TaxRows = ({
   const label = tax.rates.length
     ? Array.from(new Set(tax.rates.map((r) => r.name))).join(" + ")
     : "Tax"
+
+  /**
+   * One row, three numbers underneath it.
+   *
+   * `null` on every part means "not a DDP quote"; a `0` part is a real answer
+   * and stays in the breakdown, because "duty: nil" is information and a blank
+   * is not.
+   */
+  const ddpParts = [
+    money.duty_total !== null
+      ? `duty ${convertToLocale({ amount: money.duty_total, currency_code })}`
+      : null,
+    money.import_tax_total !== null
+      ? `import tax ${convertToLocale({ amount: money.import_tax_total, currency_code })}`
+      : null,
+    money.ddp_fee_total
+      ? `clearance ${convertToLocale({ amount: money.ddp_fee_total, currency_code })}`
+      : null,
+  ].filter(Boolean) as string[]
+  const ddpTotal = ddpParts.length
+    ? (money.duty_total ?? 0) +
+      (money.import_tax_total ?? 0) +
+      (money.ddp_fee_total ?? 0)
+    : null
+  const ddpBreakdown = ddpParts.length > 1 ? ddpParts.join(" · ") : undefined
   return (
     <>
       <Row
         label={tax.inclusive ? `${label} (included)` : label}
         value={convertToLocale({ amount: money.tax_total, currency_code })}
       />
-      {money.duty_total !== null ? (
+      {ddpTotal !== null ? (
         <Row
           // Named for who pays it, not for what it is: the buyer's question is
-          // "is there a customs bill coming", and the answer here is no.
-          label="Import duty (paid by us)"
-          value={convertToLocale({ amount: money.duty_total, currency_code })}
+          // "is there a customs bill coming", and the answer here is no. The
+          // split sits underneath, because a procurement contact reconciling
+          // against their own broker's estimate needs to see the parts.
+          label="Import duty & taxes (paid by us)"
+          value={convertToLocale({ amount: ddpTotal, currency_code })}
+          sub={ddpBreakdown}
         />
       ) : null}
       <Row


### PR DESCRIPTION
Closes the #1447 tail. Buyer-page half is starter [#21](https://github.com/Jaal-Yantra-Textiles/nextjs-starter-medusa/pull/21), already merged; the pointer moves with this PR.

## The defect

`duties_prepaid` told the buyer *"import duty and taxes are included and paid by us — nothing further to pay on delivery"* and added **nothing** to the price. `composeQuoteMoney` was `subtotal + freight (+ tax)`; the word "duty" appeared only in prose. The promise was honoured out of margin, by an amount nobody had computed, and no row anywhere recorded that a figure was ever owed.

## A DDP undertaking is three charges, and "duty" is the small half

DHL Express's landed-cost planner, on a 70,000 INR consignment to NL (transport 6,792):

| | |
|---|---|
| customs duty | 8% × (goods + freight) = **6,143.36** |
| import VAT | 21% × (goods + freight + **duty**) = **17,416.43** |
| duty-tax-paid fee | **1,981.57** — the carrier's charge for advancing it |

The VAT is 2.8× the duty and the base **cascades**. A partner told to "enter the duty" funds a quarter of a 25,541 promise — ~36% of goods value — and nobody finds out, because the shortfall lands on us rather than on the buyer.

- Three frozen columns plus both rates. A carrier invoice arrives itemised months later; "which of the three was wrong" is the only question worth being able to answer.
- `computeDdpCharges` is pure and pinned to the DHL numbers as its fixture.
- **The wizards collect RATES; the amounts are computed server-side** against the basket the mint actually prices. A wizard knows neither the tiered subtotal nor the freight beforehand, and a client-side estimate frozen as a commitment is worse than no preview.
- The validator requires a duty answer AND an import-tax answer (either may be `0`), refuses a rate and an amount for the same charge, and refuses any of it without `duties_prepaid`. Re-applied after every `.extend()`/`.merge()` — those drop cross-field rules in silence.

## Also in here

- **Tax was computed on pre-override prices.** `buildQuoteView` asked the Tax module with catalogue prices; `applyLineOverridesStep` then discounted them and nobody re-asked. A 20% trade price on a domestic quote froze 18% GST on the RETAIL subtotal — wrong in the frozen row, not just on the page.
- **Blue Dart hardcoded `IncotermCode: "DAP"`** — delivered at place, duty *unpaid*. A DDP sale would have been declared to the carrier as the exact opposite of what the buyer was promised. `CustomsDeclaration.incoterm` now follows the sale, and `can_declare_ddp` joins the capability table (Blue Dart true; Shiprocket false — CSB-5 KYC; Delhivery false — DDP is a Cross Border panel selection, per their support, on an API we do not hold).
- **Carrier picker at mint (admin).** The mint always took a `carrier` and no wizard exposed it. Reads the same `/admin/shipping-carriers` availability builder the settings screen uses, plus "manual rates only" and a free-text id. On a DDP quote it states whether that carrier can be *told* the shipment is duty-paid.
- `carrier: "manual"` now genuinely asks no carrier — distinct from a carrier that failed, so nothing is logged as an error and the buyer is not shown an "indicative rate" notice.
- Frozen tax at mint, and `frozenTaxFallback` so a revoked/expired quote still shows the disclosure it was sent with.

## Verify

- `pnpm test:integration:http:shared ./integration-tests/http/partner-quote-tax-jurisdiction` → **11 pass**, including the real INSERT (each DML `bigNumber` is two columns; a missing `raw_*` fails only here)
- `pnpm exec jest --testPathPattern="(partner-quote|quotes|carrier|bluedart|shipping-estimate).*unit.spec"` → **285 pass**
- `pnpm check:prod-build` ✅

## Carries three migrations

`Migration20260822164500` (tax freeze + `duties_prepaid`), `Migration20260822190000` (duty + basis), `Migration20260822213000` (import tax, clearance fee, both rates). Read the migrate **step**, not the badge.

## Known gaps, stated rather than implied

- 🔴 **Nothing links a quote to the fulfilment that ships it** (S11). `incoterm` therefore has no automatic source — a DDP sale is honoured by hand, and `can_declare_ddp` is what a future check will read.
- Declaring DDP ≠ the account being billed for it. That is a commercial arrangement per carrier, and **no lane is verified**.
- Neither wizard has been confirmed in a browser.

🤖 Generated with [Claude Code](https://claude.com/claude-code)