### PR TITLE
fix(admin): the carrier picker took the mint wizard down on render (#1447)

### DIFF
--- a/apps/backend/src/admin/routes/quotes/create/mint-quote-form.tsx
+++ b/apps/backend/src/admin/routes/quotes/create/mint-quote-form.tsx
@@ -294,7 +294,10 @@ export const MintQuoteForm = () => {
       ttl_days: data.ttl_days,
       // Omitted rather than sent empty — the backend's own default is the one
       // thing that should decide what "no choice" means.
-      ...(data.carrier ? { carrier: data.carrier } : {}),
+      // Trimmed: the "type it yourself" branch starts empty, and a stray space
+      // would be sent as a carrier id nothing can resolve — which fails as a
+      // silent fallback to manual rates, not as an error.
+      ...(data.carrier?.trim() ? { carrier: data.carrier.trim() } : {}),
       // The pair travels together or not at all (#1447).
       duties_prepaid: data.duties_prepaid ?? false,
       ...(data.duties_prepaid

--- a/apps/backend/src/admin/routes/quotes/create/steps/buyer-step.tsx
+++ b/apps/backend/src/admin/routes/quotes/create/steps/buyer-step.tsx
@@ -38,7 +38,17 @@ type Props = { form: UseFormReturn<AdminQuoteCreateSchemaType> }
  * must therefore stay selectable, or the wizard could only ever quote people
  * who had already bought.
  */
-/** Sentinel for the "type it yourself" branch — never sent to the API. */
+/**
+ * Sentinels for the carrier picker — neither is ever sent to the API.
+ *
+ * 🔴 `DEFAULT_CARRIER` exists because Radix REFUSES a `Select.Item` with
+ * `value=""`: the empty string is reserved for "cleared, show the placeholder",
+ * so an item claiming it throws and takes the whole step down with it. The
+ * field's own empty value still means "platform default" — the sentinel only
+ * lives inside the picker.
+ */
+const DEFAULT_CARRIER = "__default__"
+/** The "type it yourself" branch, for a carrier registered after this build. */
 const OTHER_CARRIER = "__other__"
 
 export const BuyerStep = ({ form }: Props) => {
@@ -52,10 +62,17 @@ export const BuyerStep = ({ form }: Props) => {
   const dutiesPrepaid = useWatch({ control: form.control, name: "duties_prepaid" })
 
   const knownCarrierIds = useMemo(
-    () => new Set([...carriers.map((c) => c.id), "manual", ""]),
+    () => new Set([...carriers.map((c) => c.id), "manual"]),
     [carriers]
   )
-  const isOtherCarrier = Boolean(carrier) && !knownCarrierIds.has(carrier ?? "")
+  /**
+   * Held in state rather than inferred from the value, because "typing one"
+   * starts from an EMPTY field — inferring would collapse the branch the moment
+   * it opened, before a character was typed.
+   */
+  const [typingCarrier, setTypingCarrier] = useState(false)
+  const isOtherCarrier =
+    typingCarrier || (Boolean(carrier) && !knownCarrierIds.has(carrier ?? ""))
 
   /**
    * 🔴 The one warning worth interrupting for: quoting DDP on a carrier that
@@ -347,19 +364,29 @@ export const BuyerStep = ({ form }: Props) => {
               <Form.Control>
                 <Select
                   value={
-                    field.value && !knownCarrierIds.has(field.value)
+                    isOtherCarrier
                       ? OTHER_CARRIER
-                      : (field.value ?? "")
+                      : field.value
+                        ? field.value
+                        : DEFAULT_CARRIER
                   }
-                  onValueChange={(value) =>
-                    field.onChange(value === OTHER_CARRIER ? " " : value)
-                  }
+                  onValueChange={(value) => {
+                    if (value === OTHER_CARRIER) {
+                      setTypingCarrier(true)
+                      field.onChange("")
+                      return
+                    }
+                    setTypingCarrier(false)
+                    // The FIELD's empty string still means "platform default" —
+                    // only the picker needs a non-empty token for that row.
+                    field.onChange(value === DEFAULT_CARRIER ? "" : value)
+                  }}
                 >
                   <Select.Trigger>
                     <Select.Value placeholder="Platform default (Shiprocket)" />
                   </Select.Trigger>
                   <Select.Content>
-                    <Select.Item value="">
+                    <Select.Item value={DEFAULT_CARRIER}>
                       Platform default (Shiprocket)
                     </Select.Item>
                     {carriers.map((c) => (
@@ -402,8 +429,9 @@ export const BuyerStep = ({ form }: Props) => {
                 <Form.Label>Carrier id</Form.Label>
                 <Form.Control>
                   <Input
+                    autoFocus
                     placeholder="e.g. bluedart"
-                    value={(field.value ?? "").trim()}
+                    value={field.value ?? ""}
                     onChange={(e) => field.onChange(e.target.value)}
                   />
                 </Form.Control>


### PR DESCRIPTION
`<Select.Item value="">` throws in Radix — the empty string is reserved for "cleared, show the placeholder", so an item claiming it is refused and the whole Buyer step goes down with it. That was the **"Platform default (Shiprocket)"** row in the carrier picker added yesterday, so **admin minting has been broken since it shipped**.

🔴 Found by the founder trying to mint a real quote. Not by tsc, not by a unit test, not by `check:prod-build` — all three are blind to a runtime invariant inside a component library. "Neither wizard has ever been confirmed in a browser" has been in the watch-outs for three sessions; this is what was sitting behind it.

The **field's** empty string still means "platform default" — only the picker needs a non-empty token for that row, so the sentinel stays inside the component.

Two smaller things in the same pass:

- **"Other — type a carrier id" wrote a SPACE into the field** to encode itself, which would have been sent as a carrier id nothing can resolve — and an unresolvable carrier fails as a silent fallback to manual rates, not as an error. Now component state, and trimmed before sending.
- Selecting that branch **collapsed it immediately**, because "is the typed value unknown" is false while the field is still empty.

No schema, no migration, no API change.

## Verify

`pnpm check:prod-build` ✅ — and then the only verification that counts here: open the admin mint wizard and reach the Buyer step.

🤖 Generated with [Claude Code](https://claude.com/claude-code)