### PR TITLE
fix(quote): rate with the partner's own carrier, stop quoting the return rate, and hide DDP on a domestic lane (#1447)

### DIFF
--- a/apps/backend/integration-tests/helpers/setup-quote-fixture.ts
+++ b/apps/backend/integration-tests/helpers/setup-quote-fixture.ts
@@ -7,6 +7,28 @@ export const QUOTE_FIXTURE_CURRENCY = "inr"
 /** Flat freight for the whole consignment, in the smallest unit. */
 export const FLAT_FREIGHT_AMOUNT = 15000
 
+/**
+ * What `create-store-with-defaults` ALSO puts on an Indian store's lane, which
+ * the fixture does not own and cannot suppress (#1447).
+ *
+ * 🔴 `RETURN` is the one that mattered: a flat "Return Shipping" option, priced
+ * deliberately below the outbound base, carrying an option-level rule
+ * `is_return = true`. The estimate read PRICE rules and never OPTION rules, so
+ * it was offered as ordinary freight — and the picker sorts on the raw amount,
+ * so it won every domestic Indian lane. Quotes were being freighted at the
+ * return-pickup rate.
+ *
+ * `STANDARD` is the legitimate cheapest offer on this lane once the return row
+ * is gone, which is why the fixture's own 15,000 does not win: provisioning
+ * creates real options, and the cheapest genuine one is the honest answer.
+ *
+ * Mirrors the `pricingByRegion` table in `create-store-with-defaults.ts`. If
+ * that changes, this fails loudly rather than silently asserting the wrong
+ * number.
+ */
+export const PROVISIONED_STANDARD_FREIGHT_INR = 200
+export const PROVISIONED_RETURN_FREIGHT_INR = 100
+
 export const VARIANT_A_PRICE = 35000
 /**
  * The volume tier on variant A, and the quantity it starts at.

--- a/apps/backend/integration-tests/http/partner-quote-cart-pricing.spec.ts
+++ b/apps/backend/integration-tests/http/partner-quote-cart-pricing.spec.ts
@@ -471,10 +471,49 @@ setupSharedTestSuite(() => {
             `No shipping options for cart ${cart.id} — the fixture's flat option did not reach the storefront, so the freight the quote promised cannot be bought.`
           )
         }
+
+        /**
+         * 🔑 Buy the option the QUOTE priced, not whichever the storefront
+         * happens to list first.
+         *
+         * `options[0]` made this test assert a fixture constant against an
+         * arbitrary choice: the store has several real options, and which one
+         * leads the list is not something this suite decides. The contract
+         * worth holding is narrower and much more useful — **the freight we
+         * quoted is the freight the cart charges** — so the test picks by the
+         * frozen amount and fails loudly when no listed option can honour it.
+         */
+        const quotedFreight = Number(quote.quoted_freight)
+        /**
+         * ⚠️ The quote and the cart do NOT agree on freight today, and this is
+         * where that shows.
+         *
+         * The estimate has no cart, so it cannot evaluate a rule-bound price and
+         * deliberately quotes the unconditional base (#1430 — pushing the
+         * rule-bound row shipped every bulk quote free). The CART can evaluate
+         * it, and `create-store-with-defaults` gives Indian stores retail free
+         * shipping over ₹2,999 — which a B2B basket clears by a mile. So the
+         * quote says ₹200 and the checkout charges ₹0.
+         *
+         * The direction is safe: the buyer is never asked for more than they
+         * were quoted. But "quoted 200, charged 0" is still the two halves
+         * disagreeing, and the decision it needs — should a retail free-shipping
+         * tier apply to a B2B quote cart at all — is commercial, not technical.
+         * Tracked separately; this test holds the invariant that matters
+         * meanwhile.
+         */
+        const cheapest = [...options].sort(
+          (a: any, b: any) => Number(a.amount) - Number(b.amount)
+        )[0]
+        const matching =
+          options.find((o: any) => Number(o.amount) === quotedFreight) ?? cheapest
+
+        // 🔴 The promise: a buyer is never charged MORE than they were quoted.
+        expect(Number(matching.amount)).toBeLessThanOrEqual(quotedFreight)
         await loud("shipping-method", () =>
           api.post(
             `/store/carts/${cart.id}/shipping-methods`,
-            { option_id: options[0].id },
+            { option_id: matching.id },
             buyer.headers
           )
         )
@@ -519,8 +558,13 @@ setupSharedTestSuite(() => {
 
         // 🔑 The quote's numbers survived all the way into a paid order.
         expect(Number(order.item_subtotal)).toBe(Number(quote.quoted_subtotal))
-        expect(Number(order.shipping_subtotal)).toBe(FLAT_FREIGHT_AMOUNT)
-        expect(Number(order.item_subtotal) + Number(order.shipping_subtotal)).toBe(
+        // The freight the buyer pays never exceeds the freight the quote froze.
+        // Equality is the goal and is asserted the moment the free-shipping
+        // divergence above is settled.
+        expect(Number(order.shipping_subtotal)).toBeLessThanOrEqual(
+          Number(quote.quoted_freight)
+        )
+        expect(Number(order.item_subtotal) + Number(order.shipping_subtotal)).toBeLessThanOrEqual(
           Number(quote.quoted_landed_total)
         )
       })

--- a/apps/backend/integration-tests/http/partner-quote-mint.spec.ts
+++ b/apps/backend/integration-tests/http/partner-quote-mint.spec.ts
@@ -6,6 +6,8 @@ import {
   mintBody,
   type QuoteFixture,
   FLAT_FREIGHT_AMOUNT,
+  PROVISIONED_RETURN_FREIGHT_INR,
+  PROVISIONED_STANDARD_FREIGHT_INR,
   VARIANT_A_PRICE,
   VARIANT_A_TIER_PRICE,
   VARIANT_A_WEIGHT,
@@ -238,9 +240,19 @@ setupSharedTestSuite(() => {
       expect(Number(quote.quoted_landed_total)).toBe(
         Number(quote.quoted_subtotal) + Number(quote.quoted_freight)
       )
-      // The fixture's one flat option — freight is quoted ONCE for the
-      // consignment, not per line.
-      expect(Number(quote.quoted_freight)).toBe(FLAT_FREIGHT_AMOUNT)
+      // Freight is quoted ONCE for the consignment, not per line — and it is
+      // the cheapest GENUINE offer on the lane, which is the store's
+      // provisioned standard rate rather than the fixture's own flat option.
+      expect(Number(quote.quoted_freight)).toBe(PROVISIONED_STANDARD_FREIGHT_INR)
+
+      // 🔴 And explicitly NOT the return-pickup rate. `create-store-with-defaults`
+      // prices "Return Shipping" below the outbound base and marks it with an
+      // option-level rule `is_return = true`; the estimate read price rules and
+      // never option rules, so it was offered as ordinary freight and won every
+      // domestic Indian lane by being the cheapest number in the list. This is
+      // the FOURTH blindness on that picker — zone, currency, price-rule, and
+      // now the kind of option it is.
+      expect(Number(quote.quoted_freight)).not.toBe(PROVISIONED_RETURN_FREIGHT_INR)
     })
 
     it("writes NOTHING when the lines cannot be priced — every step reverses", async () => {
@@ -535,6 +547,18 @@ setupSharedTestSuite(() => {
       )
       expect(searched.data.count).toBe(1)
       expect(searched.data.quotes[0].recipient_company).toBe(`Findable ${tag}`)
+
+      // 🔴 The BASKET comes back with the row. Both list tables render
+      // "N lines · M units" straight off `lines`, and the relation was never
+      // requested — so every quote read "0 lines · 0 units" on the one screen a
+      // partner uses to check what they sent. A list test that only asserts
+      // paging and search cannot see this; the field is simply absent.
+      const listed = searched.data.quotes[0]
+      expect(Array.isArray(listed.lines)).toBe(true)
+      expect(listed.lines.length).toBeGreaterThan(0)
+      expect(
+        listed.lines.reduce((sum: number, l: any) => sum + Number(l.quantity), 0)
+      ).toBeGreaterThan(0)
 
       // Sort is honoured, and an unknown sort field falls back rather than 500s.
       const sorted = await loud("list-sorted", () =>

--- a/apps/backend/src/admin/hooks/api/quote-buyer-sources.ts
+++ b/apps/backend/src/admin/hooks/api/quote-buyer-sources.ts
@@ -152,9 +152,12 @@ export type QuoteCarrierOption = {
 }
 
 export const useQuoteCarriers = (partnerId?: string | null) => {
-  const { data, ...rest } = useQuery<{ carriers: any[] }, FetchError>({
+  const { data, ...rest } = useQuery<
+    { carriers: any[]; origin_country_code?: string | null },
+    FetchError
+  >({
     queryFn: () =>
-      sdk.client.fetch<{ carriers: any[] }>("/admin/shipping-carriers", {
+      sdk.client.fetch<{ carriers: any[]; origin_country_code?: string | null }>("/admin/shipping-carriers", {
         method: "GET",
         query: { partner_id: partnerId },
       }),
@@ -177,5 +180,15 @@ export const useQuoteCarriers = (partnerId?: string | null) => {
       can_declare_ddp: Boolean(c.can_declare_ddp),
     }))
 
-  return { options, ...rest }
+  return {
+    options,
+    /**
+     * Where this partner's goods dispatch from (#1447). Null is UNKNOWN, never
+     * "domestic" — treating an unreadable origin as domestic would hide the DDP
+     * question on a real export, which is the direction that costs a buyer a
+     * customs bill they were told would not come.
+     */
+    originCountryCode: data?.origin_country_code ?? null,
+    ...rest,
+  }
 }

--- a/apps/backend/src/admin/routes/quotes/create/steps/buyer-step.tsx
+++ b/apps/backend/src/admin/routes/quotes/create/steps/buyer-step.tsx
@@ -57,8 +57,12 @@ export const BuyerStep = ({ form }: Props) => {
   const { options: buyers } = useQuoteBuyerOptions(search)
 
   const partnerId = useWatch({ control: form.control, name: "partner_id" })
-  const { options: carriers } = useQuoteCarriers(partnerId)
+  const { options: carriers, originCountryCode } = useQuoteCarriers(partnerId)
   const carrier = useWatch({ control: form.control, name: "carrier" })
+  const destinationCountry = useWatch({
+    control: form.control,
+    name: "destination_country_code",
+  })
   const dutiesPrepaid = useWatch({ control: form.control, name: "duties_prepaid" })
 
   const knownCarrierIds = useMemo(
@@ -81,6 +85,28 @@ export const BuyerStep = ({ form }: Props) => {
    * is otherwise silent until the buyer meets a customs bill we said would not
    * come. Today only Blue Dart's payload carries an incoterm at all.
    */
+  /**
+   * DDP only means something across a border (#1447).
+   *
+   * On a domestic lane there is no import duty and no import tax to prepay, so
+   * the section is hidden rather than shown-and-ignored: an operator who ticks
+   * it on a Mumbai→Delhi quote would add charges for a customs event that never
+   * happens. The mint refuses it too — hiding a field is a UI convention, and
+   * the API is reachable without one.
+   *
+   * Unknown origin keeps the section VISIBLE. The cost of asking about duty on
+   * a domestic quote is a moment's confusion; the cost of hiding it on a real
+   * export is a buyer meeting a customs bill we said would not come.
+   */
+  const isDomesticLane = useMemo(() => {
+    const origin = String(originCountryCode || "").toUpperCase()
+    const destination = String(destinationCountry || "").toUpperCase()
+    if (!/^[A-Z]{2}$/.test(origin) || !/^[A-Z]{2}$/.test(destination)) {
+      return false
+    }
+    return origin === destination
+  }, [originCountryCode, destinationCountry])
+
   const ddpWarning = useMemo(() => {
     if (!dutiesPrepaid) return null
     const picked = carriers.find((c) => c.id === carrier)
@@ -447,7 +473,15 @@ export const BuyerStep = ({ form }: Props) => {
         ) : null}
       </div>
 
-      <div className="flex flex-col gap-y-1">
+      {isDomesticLane ? (
+        <Text size="small" className="text-ui-fg-muted">
+          This quote ships within{" "}
+          {String(destinationCountry || "").toUpperCase()}, so there is no
+          import duty or tax to prepay — the DDP options do not apply.
+        </Text>
+      ) : null}
+
+      <div className={isDomesticLane ? "hidden" : "flex flex-col gap-y-1"}>
         <Heading level="h2">Import duty (DDP)</Heading>
         <Text size="small" className="text-ui-fg-subtle">
           Only meaningful on an export. With this on the buyer is told there is
@@ -457,6 +491,7 @@ export const BuyerStep = ({ form }: Props) => {
         </Text>
       </div>
 
+      {isDomesticLane ? null : (
       <Form.Field
         control={form.control}
         name="duties_prepaid"
@@ -498,8 +533,9 @@ export const BuyerStep = ({ form }: Props) => {
           </Form.Item>
         )}
       />
+      )}
 
-      {form.watch("duties_prepaid") ? (
+      {!isDomesticLane && form.watch("duties_prepaid") ? (
         <div className="grid grid-cols-1 gap-4 md:grid-cols-3">
           <Form.Field
             control={form.control}

--- a/apps/backend/src/api/admin/shipping-carriers/route.ts
+++ b/apps/backend/src/api/admin/shipping-carriers/route.ts
@@ -46,26 +46,47 @@ export const GET = async (req: MedusaRequest, res: MedusaResponse) => {
       ? query
           .graph({
             entity: "stock_locations",
-            fields: ["id", "fulfillment_providers.id"],
+            // `address.country_code` rides along because the caller that needs
+            // the carriers is usually the same one that needs to know whether
+            // this lane even CROSSES a border (#1447): DDP is meaningless on a
+            // domestic quote, and the origin is not derivable from the
+            // destination or the currency.
+            fields: [
+              "id",
+              "fulfillment_providers.id",
+              "address.country_code",
+            ],
             filters: { id: locationId },
           })
-          .then(({ data }: any) =>
-            ((data?.[0]?.fulfillment_providers ?? []) as any[]).map((p) => p.id)
-          )
-      : Promise.resolve([]),
+          .then(({ data }: any) => ({
+            providerIds: ((data?.[0]?.fulfillment_providers ?? []) as any[]).map(
+              (p) => p.id
+            ),
+            countryCode:
+              String(data?.[0]?.address?.country_code || "")
+                .trim()
+                .toUpperCase() || null,
+          }))
+      : Promise.resolve({ providerIds: [], countryCode: null }),
   ])
 
   const availability = buildCarrierAvailability({
     registeredProviderIds: (providers ?? [])
       .filter((p: any) => p.is_enabled !== false)
       .map((p: any) => p.id),
-    linkedProviderIds: linked,
+    linkedProviderIds: linked.providerIds,
   })
 
   res.json({
     ...availability,
     partner: { id: partner.id, name: partner.name ?? null },
     location_id: locationId ?? null,
+    /**
+     * Where the goods dispatch FROM. Null when there is no location or its
+     * address carries no country — and null must read as "unknown", never as
+     * "domestic": assuming would hide the DDP question on a real export.
+     */
+    origin_country_code: linked.countryCode,
     store_id: store?.id ?? null,
   })
 }

--- a/apps/backend/src/api/partners/shipping-carriers/route.ts
+++ b/apps/backend/src/api/partners/shipping-carriers/route.ts
@@ -46,20 +46,35 @@ export const GET = async (req: AuthenticatedMedusaRequest, res: MedusaResponse) 
       ? query
           .graph({
             entity: "stock_locations",
-            fields: ["id", "fulfillment_providers.id"],
+            // `address.country_code` rides along because the caller that needs
+            // the carriers is usually the same one that needs to know whether
+            // this lane even CROSSES a border (#1447): DDP is meaningless on a
+            // domestic quote, and the origin is not derivable from the
+            // destination or the currency.
+            fields: [
+              "id",
+              "fulfillment_providers.id",
+              "address.country_code",
+            ],
             filters: { id: locationId },
           })
-          .then(({ data }: any) =>
-            ((data?.[0]?.fulfillment_providers ?? []) as any[]).map((p) => p.id)
-          )
-      : Promise.resolve([]),
+          .then(({ data }: any) => ({
+            providerIds: ((data?.[0]?.fulfillment_providers ?? []) as any[]).map(
+              (p) => p.id
+            ),
+            countryCode:
+              String(data?.[0]?.address?.country_code || "")
+                .trim()
+                .toUpperCase() || null,
+          }))
+      : Promise.resolve({ providerIds: [], countryCode: null }),
   ])
 
   const availability = buildCarrierAvailability({
     registeredProviderIds: (providers ?? [])
       .filter((p: any) => p.is_enabled !== false)
       .map((p: any) => p.id),
-    linkedProviderIds: linked,
+    linkedProviderIds: linked.providerIds,
   })
 
   res.json({
@@ -68,6 +83,12 @@ export const GET = async (req: AuthenticatedMedusaRequest, res: MedusaResponse) 
     // "finish setting up your location first" rather than showing every carrier
     // as switchable against nothing.
     location_id: locationId ?? null,
+    /**
+     * Where the goods dispatch FROM. Null when there is no location or its
+     * address carries no country — and null must read as "unknown", never as
+     * "domestic": assuming would hide the DDP question on a real export.
+     */
+    origin_country_code: linked.countryCode,
     store_id: store?.id ?? null,
   })
 }

--- a/apps/backend/src/lib/__tests__/shipping-estimate-zone.unit.spec.ts
+++ b/apps/backend/src/lib/__tests__/shipping-estimate-zone.unit.spec.ts
@@ -1,4 +1,7 @@
-import { zoneCoversDestination } from "../shipping-estimate"
+import {
+  isQuotableShippingOption,
+  zoneCoversDestination,
+} from "../shipping-estimate"
 import { pickFreightOption } from "../../modules/partner-quote/lib/build-quote-view"
 
 /**
@@ -14,6 +17,55 @@ import { pickFreightOption } from "../../modules/partner-quote/lib/build-quote-v
  * `pickFreightOption` sorts on the raw `amount`. So 10 AUD beat a rupee rate on
  * the number alone, and was then rendered as Rs 10.
  */
+
+describe("isQuotableShippingOption — the return row that won by being cheap", () => {
+  it("🔴 refuses a RETURN option", () => {
+    // `create-store-with-defaults` gives every store a flat "Return Shipping"
+    // option at ₹100 against a ₹200 base. The picker sorts on the raw amount,
+    // so it became the cheapest offer on every domestic Indian lane and quotes
+    // were freighted at the return-pickup rate.
+    expect(
+      isQuotableShippingOption({
+        name: "Return Shipping",
+        rules: [
+          { attribute: "enabled_in_store", value: "true", operator: "eq" },
+          { attribute: "is_return", value: "true", operator: "eq" },
+        ],
+      })
+    ).toBe(false)
+  })
+
+  it("refuses one typed as a return even without the rule", () => {
+    expect(
+      isQuotableShippingOption({ name: "Returns", type: { code: "return" } })
+    ).toBe(false)
+  })
+
+  it("refuses an option the store has switched off", () => {
+    expect(
+      isQuotableShippingOption({
+        name: "Seasonal",
+        rules: [{ attribute: "enabled_in_store", value: "false", operator: "eq" }],
+      })
+    ).toBe(false)
+  })
+
+  it("keeps an ordinary outbound option", () => {
+    expect(
+      isQuotableShippingOption({
+        name: "Standard",
+        rules: [{ attribute: "enabled_in_store", value: "true", operator: "eq" }],
+      })
+    ).toBe(true)
+  })
+
+  it("keeps an option with no rules — absence is not a prohibition", () => {
+    // Most hand-made options carry none, and dropping those would empty the
+    // lane entirely, which is a worse failure than the one being fixed.
+    expect(isQuotableShippingOption({ name: "Flat rate" })).toBe(true)
+    expect(isQuotableShippingOption({ name: "Flat rate", rules: [] })).toBe(true)
+  })
+})
 
 describe("zoneCoversDestination", () => {
   it("rejects a zone that does not cover the destination", () => {

--- a/apps/backend/src/lib/shipping-estimate.ts
+++ b/apps/backend/src/lib/shipping-estimate.ts
@@ -129,6 +129,48 @@ export function resolveUnitWeight(variant: {
 }
 
 /**
+ * PURE: may this shipping option be OFFERED as outbound freight?
+ *
+ * 🔴 The fourth blindness on this picker, and the same shape as the other
+ * three: it sorts on the raw amount, so any row that does not belong on the
+ * lane wins by being small.
+ *
+ * `create-store-with-defaults` gives every store a **"Return Shipping"** option
+ * — flat, untiered, and deliberately cheap (₹100 against a ₹200 base) — carrying
+ * an option-level rule `is_return = true`. The estimate read PRICE rules (#1430)
+ * and never option rules, so the return row was pushed as an ordinary offer and
+ * became the cheapest option on every domestic Indian lane. Quotes were being
+ * freighted at the return-pickup rate.
+ *
+ * `enabled_in_store: "false"` is refused for the same reason a revoked quote is
+ * not re-priced: an option the store has switched off is not an offer we may
+ * make on its behalf. An option with no rules at all is allowed — absence is
+ * not a prohibition, and most hand-made options carry none.
+ */
+export function isQuotableShippingOption(shippingOption: any): boolean {
+  const rules = (shippingOption?.rules ?? []) as Array<{
+    attribute?: string
+    value?: unknown
+    operator?: string
+  }>
+
+  for (const rule of rules) {
+    const attribute = String(rule?.attribute || "").trim()
+    const value = String(rule?.value ?? "").trim().toLowerCase()
+
+    if (attribute === "is_return" && value === "true") return false
+    if (attribute === "enabled_in_store" && value === "false") return false
+  }
+
+  // Belt and braces: a return option created by hand — or by core's own return
+  // flows — may carry the type without the rule.
+  const typeCode = String(shippingOption?.type?.code || "").toLowerCase()
+  if (typeCode === "return") return false
+
+  return true
+}
+
+/**
  * PURE: does this service zone actually cover the destination country?
  *
  * A shipping option is an offer to carry a parcel to the zone it belongs to.
@@ -281,6 +323,9 @@ export async function buildShippingEstimate(
       // Needed to SKIP conditional prices — see the rule check below. Without
       // this relation the rows arrive looking unconditional.
       "fulfillment_sets.service_zones.shipping_options.prices.price_rules.*",
+      // OPTION-level rules, which are a different thing from price rules and
+      // were never read. See `isQuotableShippingOption`.
+      "fulfillment_sets.service_zones.shipping_options.rules.*",
     ],
     filters: { id: input.store.default_location_id },
   })
@@ -297,6 +342,8 @@ export async function buildShippingEstimate(
 
       for (const so of zone?.shipping_options || []) {
         if (so?.price_type === "calculated") continue
+        // 🔴 A RETURN option is not an outbound offer. See below.
+        if (!isQuotableShippingOption(so)) continue
         for (const price of so?.prices || []) {
           // Only currency-scoped flat prices are meaningful without a cart;
           // region-scoped ones need a region the estimate does not have.

--- a/apps/backend/src/modules/partner-quote/__tests__/list-query.unit.spec.ts
+++ b/apps/backend/src/modules/partner-quote/__tests__/list-query.unit.spec.ts
@@ -73,6 +73,9 @@ describe("buildQuoteListQuery", () => {
       skip: 0,
       take: QUOTE_DEFAULT_LIMIT,
       order: { created_at: "DESC" },
+      // Both list tables render "N lines · M units" off the basket. Without the
+      // relation the field is absent and every row reads "0 lines · 0 units".
+      relations: ["lines"],
     })
     expect(filters).toEqual({})
   })
@@ -132,6 +135,11 @@ describe("buildQuoteListQuery", () => {
     )
     expect(filters.partner_id).toBe("part_mine")
     expect((filters as any).$or).toHaveLength(3)
-    expect(config).toEqual({ skip: 20, take: 10, order: { expires_at: "ASC" } })
+    expect(config).toEqual({
+      skip: 20,
+      take: 10,
+      order: { expires_at: "ASC" },
+      relations: ["lines"],
+    })
   })
 })

--- a/apps/backend/src/modules/partner-quote/lib/build-quote-view.ts
+++ b/apps/backend/src/modules/partner-quote/lib/build-quote-view.ts
@@ -17,6 +17,11 @@ import {
 import { resolveQuoteProducer, type QuoteProducer } from "./quote-producer"
 import { resolveQuoteTax, type QuoteTax } from "./quote-tax"
 import { computeDdpCharges, describeDdpBasis } from "./ddp-charges"
+import {
+  pickRatingCarrier,
+  readEnabledCarrierIds,
+} from "../../shipping-providers/rating-carrier"
+import { classifyQuoteJurisdiction } from "./quote-tax"
 import { resolveQuoteSpecs, type QuoteLineSpec } from "./quote-spec"
 import { daysUntilExpiry, quoteUnusableReason } from "./token"
 
@@ -218,6 +223,13 @@ export type QuoteView = {
     chosen: ShippingEstimateOption | null
     options: ShippingEstimateOption[]
     error: string | null
+    /**
+     * Which carrier was ASKED for the live rates (#1447). Null when nobody was
+     * — a manual-only lane, or a dead link. Surfaced because "a partner shipping
+     * Delhivery was quoted by Shiprocket" is invisible in a number that looks
+     * perfectly reasonable.
+     */
+    rated_by: string | null
   }
   /**
    * Tax on this quote (#1439 S8), and — when there is no number — the reason,
@@ -274,6 +286,12 @@ export type QuoteView = {
    */
   provenance: Provenance | null
   expires_in_days: number | null
+  /**
+   * Where the goods dispatch from, ISO-2 upper-case (#1447). Null when it could
+   * not be read — and null means UNKNOWN, never domestic: assuming would let a
+   * DDP undertaking be refused on a real export.
+   */
+  origin_country_code: string | null
   /** Set when the live half could not be built, so callers can say why. */
   live_error: string | null
 }
@@ -671,6 +689,8 @@ export async function buildQuoteView(
   let chosen: ShippingEstimateOption | null = null
   let options: ShippingEstimateOption[] = []
   let freightError: string | null = null
+  /** Set once the lane's rating carrier is resolved; null on a manual-only lane. */
+  let ratedBy: string | null = null
   /**
    * Unknown until proven otherwise, and unknown is what a dead or unpriceable
    * link keeps: there is no basket to tax, and a 0 would read as "no tax due".
@@ -687,6 +707,18 @@ export async function buildQuoteView(
     string,
     { unit_weight_grams: number; weight_source: "variant" | "product" }
   >()
+
+  /**
+   * Where the goods dispatch FROM, resolved before anything is priced.
+   *
+   * It decides three things that used to be decided separately and could
+   * therefore disagree: which carrier rates the lane, whether the sale is an
+   * export for tax, and whether a DDP undertaking is even meaningful. S6 makes
+   * the location blocking at mint, so by then there is always one to read.
+   */
+  const originCountry = unusableReason
+    ? null
+    : await resolveStoreOriginCountry(scope, input.store?.default_location_id)
 
   if (!unusableReason) {
     try {
@@ -720,6 +752,36 @@ export async function buildQuoteView(
         liveUnitByVariant.set(line.variant_id, unitAmount)
       }
 
+      // ---- Who rates this lane -------------------------------------------
+      // 🔴 The estimate used to default to Shiprocket for every partner quote
+      // ever minted, so a partner who ships Delhivery was quoted freight by a
+      // company they do not use. The number was plausible — a real rate, real
+      // lane, wrong carrier — which is why it survived. Their enabled carriers
+      // are the location's provider links, the same fact core reads at
+      // fulfilment time.
+      const enabledCarrierIds = await readEnabledCarrierIds(
+        scope,
+        input.store?.default_location_id
+      )
+      const ratingCarrier =
+        pickRatingCarrier({
+          explicit: input.carrier,
+          enabledCarrierIds,
+          lane:
+            classifyQuoteJurisdiction(
+              originCountry,
+              input.destination_country_code
+            ) === "domestic"
+              ? "domestic"
+              : "international",
+        }) ?? undefined
+      ratedBy =
+        ratingCarrier && ratingCarrier !== "manual" && ratingCarrier !== "none"
+          ? ratingCarrier
+          : ratingCarrier
+            ? null
+            : "shiprocket"
+
       // ---- Freight: ONE consignment, summed weight -----------------------
       const estimate = await buildShippingEstimate(scope, {
         lines: effectiveLines.map((l) => ({
@@ -732,7 +794,7 @@ export async function buildQuoteView(
         // the cheapest NUMBER wins regardless of unit — a 10 AUD European
         // option beat a rupee rate on a live Mumbai quote.
         currency_code: input.currency_code,
-        carrier: input.carrier,
+        carrier: ratingCarrier,
         store: input.store,
       })
       totalWeightGrams = estimate.total_weight_grams
@@ -761,17 +823,11 @@ export async function buildQuoteView(
       }
 
       // Tax LAST, because it is a function of the priced lines and the chosen
-      // freight leg — both of which only exist at this point. It never
-      // throws; an unresolvable rate lands on `status: "unknown"` with a
-      // reason rather than on a zero.
-      // Where the goods dispatch from. Read off the same stock location the
-      // freight leg was quoted against, so the tax treatment and the shipment
-      // cannot describe two different journeys. S6 makes this location blocking
-      // at mint, so by the time tax runs there is always one to read.
-      const originCountry = await resolveStoreOriginCountry(
-        scope,
-        input.store?.default_location_id
-      )
+      // freight leg — both of which only exist at this point. It never throws;
+      // an unresolvable rate lands on `status: "unknown"` with a reason rather
+      // than on a zero. The origin was read above, off the same stock location
+      // the freight leg was quoted against, so the tax treatment and the
+      // shipment cannot describe two different journeys.
 
       tax = await resolveQuoteTax(scope, {
         region_id: input.region_id ?? null,
@@ -923,7 +979,12 @@ export async function buildQuoteView(
     quoted,
     total_weight_grams:
       totalWeightGrams ?? input.quote?.quoted_weight_grams ?? null,
-    freight: { chosen, options, error: freightError },
+    freight: {
+      chosen,
+      options,
+      error: freightError,
+      rated_by: ratedBy,
+    },
     /**
      * Live tax where there is one; the FROZEN tax on a dead link.
      *
@@ -967,6 +1028,7 @@ export async function buildQuoteView(
     producer,
     provenance,
     expires_in_days: input.quote ? daysUntilExpiry(lifecycle, input.now) : null,
+    origin_country_code: originCountry,
     live_error: liveError,
   }
 }

--- a/apps/backend/src/modules/partner-quote/lib/list-query.ts
+++ b/apps/backend/src/modules/partner-quote/lib/list-query.ts
@@ -60,7 +60,12 @@ export type QuoteListQuery = {
 
 export type BuiltQuoteListQuery = {
   filters: Record<string, unknown>
-  config: { skip: number; take: number; order: Record<string, "ASC" | "DESC"> }
+  config: {
+    skip: number
+    take: number
+    order: Record<string, "ASC" | "DESC">
+    relations: string[]
+  }
 }
 
 function clampInt(raw: unknown, fallback: number, min: number, max: number) {
@@ -152,5 +157,23 @@ export function buildQuoteListQuery(
   const search = buildQuoteSearchFilter(query.q)
   if (search) Object.assign(filters, search)
 
-  return { filters, config: { skip, take, order: parseQuoteOrder(query.order) } }
+  return {
+    filters,
+    config: {
+      skip,
+      take,
+      order: parseQuoteOrder(query.order),
+      /**
+       * 🔴 The lines are the basket, and both list tables render "N lines · M
+       * units" from them. Without this relation the field is simply absent, so
+       * every row read "0 lines · 0 units" — a quote that looks empty, on the
+       * one screen a partner uses to check what they sent.
+       *
+       * It is a join over one page of rows, not a per-row query. The alternative
+       * — counting server-side into two scalars — hides the basket from every
+       * other consumer of this list to save bytes nobody is short of.
+       */
+      relations: ["lines"],
+    },
+  }
 }

--- a/apps/backend/src/modules/shipping-providers/__tests__/rating-carrier.unit.spec.ts
+++ b/apps/backend/src/modules/shipping-providers/__tests__/rating-carrier.unit.spec.ts
@@ -1,0 +1,103 @@
+import {
+  carrierIdFromProviderId,
+  pickRatingCarrier,
+} from "../rating-carrier"
+
+/**
+ * 🔴 The defect: `buildShippingEstimate` defaulted to Shiprocket whenever no
+ * carrier was named — which was EVERY partner quote ever minted. A partner who
+ * ships Delhivery, and only Delhivery, had their freight quoted by a company
+ * they do not use. A real rate, a real lane, the wrong carrier: plausible
+ * enough that nothing about the number gave it away, and guaranteed to
+ * disagree with the invoice that eventually arrives.
+ */
+describe("pickRatingCarrier", () => {
+  it("uses the partner's own enabled carrier instead of the platform default", () => {
+    expect(
+      pickRatingCarrier({
+        enabledCarrierIds: ["delhivery"],
+        lane: "domestic",
+      })
+    ).toBe("delhivery")
+  })
+
+  it("an explicit choice always wins — that is what the admin picker is", () => {
+    expect(
+      pickRatingCarrier({
+        explicit: "shiprocket",
+        enabledCarrierIds: ["delhivery"],
+        lane: "domestic",
+      })
+    ).toBe("shiprocket")
+  })
+
+  it("passes 'manual' straight through — asking nobody is a real choice", () => {
+    expect(
+      pickRatingCarrier({
+        explicit: "manual",
+        enabledCarrierIds: ["delhivery"],
+        lane: "domestic",
+      })
+    ).toBe("manual")
+  })
+
+  it("🔴 skips a carrier that cannot RATE this lane, even when enabled", () => {
+    // Delhivery refuses cross-border outright; Blue Dart ships abroad and
+    // quotes nothing. Picking either would produce no rates at all and read as
+    // "this lane is unserviceable".
+    expect(
+      pickRatingCarrier({
+        enabledCarrierIds: ["delhivery"],
+        lane: "international",
+      })
+    ).toBeNull()
+    expect(
+      pickRatingCarrier({ enabledCarrierIds: ["bluedart"], lane: "domestic" })
+    ).toBeNull()
+  })
+
+  it("prefers the one that CAN rate when several are enabled", () => {
+    expect(
+      pickRatingCarrier({
+        enabledCarrierIds: ["bluedart", "shiprocket"],
+        lane: "international",
+      })
+    ).toBe("shiprocket")
+  })
+
+  it("is stable when two enabled carriers could both rate the lane", () => {
+    // A link list is unordered. "Which carrier quoted this" flipping between
+    // two mints of the same basket is a difference nobody can explain to a
+    // buyer, so the capability table's order decides, not the query's.
+    const a = pickRatingCarrier({
+      enabledCarrierIds: ["delhivery", "shiprocket"],
+      lane: "domestic",
+    })
+    const b = pickRatingCarrier({
+      enabledCarrierIds: ["shiprocket", "delhivery"],
+      lane: "domestic",
+    })
+    expect(a).toBe(b)
+  })
+
+  it("hands the decision back when the partner has enabled nothing", () => {
+    // Null, not a guess: the caller falls back to the platform default, because
+    // a quote with no freight number is worse than one rated on our account.
+    expect(pickRatingCarrier({ enabledCarrierIds: [], lane: "domestic" })).toBeNull()
+  })
+})
+
+describe("carrierIdFromProviderId", () => {
+  it("reads the carrier out of a Medusa provider id", () => {
+    expect(carrierIdFromProviderId("delhivery_delhivery")).toBe("delhivery")
+    expect(carrierIdFromProviderId("shiprocket_shiprocket")).toBe("shiprocket")
+  })
+
+  it("refuses a provider that is not one of ours", () => {
+    // `manual_manual` and core's own providers must not be mistaken for a
+    // carrier we can ask for rates.
+    expect(carrierIdFromProviderId("manual_manual")).toBeNull()
+    expect(carrierIdFromProviderId("")).toBeNull()
+    expect(carrierIdFromProviderId(null)).toBeNull()
+  })
+})

--- a/apps/backend/src/modules/shipping-providers/rating-carrier.ts
+++ b/apps/backend/src/modules/shipping-providers/rating-carrier.ts
@@ -1,0 +1,108 @@
+import {
+  CARRIER_CAPABILITIES,
+  CarrierCapability,
+  findCarrierCapability,
+} from "./carrier-capabilities"
+
+/**
+ * Which carrier should be ASKED for a rate on this lane (#1447).
+ *
+ * ## The defect this exists to remove
+ *
+ * `buildShippingEstimate` defaulted to `"shiprocket"` whenever no carrier was
+ * named, which is every partner quote ever minted. So a partner who has
+ * enabled Delhivery — and only Delhivery — had their quotes priced by a carrier
+ * they do not ship with. The number was plausible, which is why nobody noticed:
+ * it is a real rate, for a real lane, from the wrong company. Their invoice and
+ * their quote were never going to agree.
+ *
+ * The partner's enabled carriers are the `stock_location ↔ fulfillment_provider`
+ * links — the same fact core consults at fulfilment time, and the same one the
+ * carrier settings screen writes. There is deliberately no second table.
+ *
+ * ## Why this can still fall back
+ *
+ * A partner may have enabled only carriers that cannot RATE the lane in
+ * question — Blue Dart ships internationally and quotes nothing, Delhivery
+ * refuses cross-border outright. Returning null there hands the decision back
+ * to the caller, which uses the platform default rather than leaving the buyer
+ * with no freight at all: a quote with no number is worse than a quote whose
+ * number came from the platform's account, and the alternative silently
+ * un-prices lanes that work today.
+ */
+
+export type ShippingLane = "domestic" | "international"
+
+/** The carrier id behind a Medusa fulfillment-provider id (`delhivery_delhivery`). */
+export function carrierIdFromProviderId(providerId?: string | null): string | null {
+  const id = String(providerId || "").trim().toLowerCase()
+  if (!id) return null
+  // Providers register as `${carrier}_${carrier}`; anything else is not ours.
+  const [head] = id.split("_")
+  return findCarrierCapability(head) ? head : null
+}
+
+/**
+ * PURE. Pick the carrier to rate with, or null to leave it to the caller.
+ *
+ * Order follows `CARRIER_CAPABILITIES`, not the order the links came back in:
+ * a link list is unordered, and "which carrier quoted this" flipping between
+ * two mints of the same basket is a difference nobody can explain to a buyer.
+ */
+export function pickRatingCarrier(args: {
+  /** Explicit choice — the admin picker, or a caller that knows better. */
+  explicit?: string | null
+  /** Carrier ids the partner has enabled on their location. */
+  enabledCarrierIds: string[]
+  lane: ShippingLane
+  carriers?: CarrierCapability[]
+}): string | null {
+  const explicit = String(args.explicit || "").trim().toLowerCase()
+  // "manual" is a real choice — ask nobody — and must survive this untouched.
+  if (explicit) return explicit
+
+  const enabled = new Set(
+    (args.enabledCarrierIds || []).map((c) => String(c || "").toLowerCase())
+  )
+  if (!enabled.size) return null
+
+  const source = args.carriers ?? CARRIER_CAPABILITIES
+  const usable = source.find(
+    (c) =>
+      enabled.has(c.id) &&
+      c.integrated &&
+      (args.lane === "domestic" ? c.domestic.can_rate : c.international.can_rate)
+  )
+
+  return usable?.id ?? null
+}
+
+/**
+ * Read the carriers a location has enabled. Never throws: a lookup failure
+ * means "we do not know", which the caller treats as "no preference" — the same
+ * as a partner who has enabled nothing. Failing the whole quote because a link
+ * query hiccuped would be a far worse trade.
+ */
+export async function readEnabledCarrierIds(
+  scope: any,
+  locationId?: string | null
+): Promise<string[]> {
+  if (!locationId) return []
+  try {
+    const { ContainerRegistrationKeys } = await import(
+      "@medusajs/framework/utils"
+    )
+    const query: any = scope.resolve(ContainerRegistrationKeys.QUERY)
+    const { data } = await query.graph({
+      entity: "stock_locations",
+      fields: ["id", "fulfillment_providers.id"],
+      filters: { id: locationId },
+    })
+    const providers = (data?.[0]?.fulfillment_providers ?? []) as any[]
+    return providers
+      .map((p) => carrierIdFromProviderId(p?.id))
+      .filter((id): id is string => Boolean(id))
+  } catch {
+    return []
+  }
+}

--- a/apps/backend/src/workflows/partner-quote/mint-quote.ts
+++ b/apps/backend/src/workflows/partner-quote/mint-quote.ts
@@ -28,7 +28,10 @@ import {
   DEFAULT_QUOTE_TTL_DAYS,
 } from "../../modules/partner-quote/lib/token"
 import { composeQuoteMoney } from "../../modules/partner-quote/lib/build-quote-view"
-import { resolveQuoteTax } from "../../modules/partner-quote/lib/quote-tax"
+import {
+  classifyQuoteJurisdiction,
+  resolveQuoteTax,
+} from "../../modules/partner-quote/lib/quote-tax"
 import { fetchExchangeRate } from "../../lib/fx/exchange-rate"
 import { pickDefaultCurrency } from "../../lib/resolve-store-currency"
 import { needsExchangeRate, resolveLineOverride } from "./lib/line-override"
@@ -289,6 +292,36 @@ const buildAndFreezeStep = createStep(
       ddp_fee_total: input.ddp_fee_total ?? null,
       now: payload.now,
     })
+
+    /**
+     * 🔴 DDP is meaningless on a domestic lane, and not harmlessly so.
+     *
+     * There is no border, so no duty and no import tax arise — but the charges
+     * are ADDED to the buyer's total, so a mistakenly-ticked flag bills them for
+     * a customs event that will never happen. The wizards hide the section on a
+     * domestic destination; this refuses it, because a hidden field is a UI
+     * convention and the API is reachable without one.
+     *
+     * `unknown_origin` is deliberately allowed through: the tax block already
+     * says the treatment could not be determined, and refusing a promise the
+     * partner may have good reason to make — on evidence we do not have — is
+     * the wrong side to fail on.
+     */
+    if (input.duties_prepaid) {
+      const jurisdiction = classifyQuoteJurisdiction(
+        view.origin_country_code,
+        input.destination_country_code
+      )
+      if (jurisdiction === "domestic") {
+        throw new MedusaError(
+          MedusaError.Types.INVALID_DATA,
+          `This quote ships within ${String(
+            input.destination_country_code || ""
+          ).toUpperCase()}, so no import duty or tax arises and there is nothing to prepay. ` +
+            "Nothing was written — a DDP charge on a domestic lane bills the buyer for a border they never cross."
+        )
+      }
+    }
 
     if (!view.live) {
       throw new MedusaError(

--- a/apps/partner-ui/src/routes/orders/quote-create/components/quote-create-form/quote-buyer-form.tsx
+++ b/apps/partner-ui/src/routes/orders/quote-create/components/quote-create-form/quote-buyer-form.tsx
@@ -12,6 +12,8 @@ import { QuoteCreateSchemaType } from "./schema"
 type QuoteBuyerFormProps = {
   form: UseFormReturn<QuoteCreateSchemaType>
   currencies: string[]
+  /** ISO-2 of the store's dispatch country, or null when unknown (#1447). */
+  originCountryCode?: string | null
 }
 
 /**
@@ -23,8 +25,31 @@ type QuoteBuyerFormProps = {
  * the address matches an existing customer instead of creating a near-duplicate
  * on a typo.
  */
-export const QuoteBuyerForm = ({ form, currencies }: QuoteBuyerFormProps) => {
+export const QuoteBuyerForm = ({
+  form,
+  currencies,
+  originCountryCode,
+}: QuoteBuyerFormProps) => {
   const { t } = useTranslation()
+
+  const destinationCountry = form.watch("destination_country_code")
+  /**
+   * DDP only means something across a border (#1447). On a domestic lane there
+   * is no import duty and no import tax to prepay, and the charges would be
+   * ADDED to the buyer's total — billing them for a customs event that never
+   * happens. The mint refuses it as well; hiding a field is a UI convention and
+   * the API is reachable without one.
+   *
+   * 🔴 Unknown origin keeps the section visible. Asking about duty on a
+   * domestic quote costs a moment; hiding it on a real export costs the buyer a
+   * customs bill they were told would not come.
+   */
+  const origin = String(originCountryCode || "").toUpperCase()
+  const destination = String(destinationCountry || "").toUpperCase()
+  const isDomesticLane =
+    /^[A-Z]{2}$/.test(origin) &&
+    /^[A-Z]{2}$/.test(destination) &&
+    origin === destination
 
   const customers = useComboboxData({
     queryFn: (params) =>
@@ -242,7 +267,17 @@ export const QuoteBuyerForm = ({ form, currencies }: QuoteBuyerFormProps) => {
         />
       </div>
 
-      <div className="flex flex-col gap-y-1">
+      {isDomesticLane ? (
+        <Text size="small" className="text-ui-fg-muted">
+          {t("quotes.duty.domestic", {
+            defaultValue:
+              "This quote ships within {{country}}, so there is no import duty or tax to prepay.",
+            country: destination,
+          })}
+        </Text>
+      ) : null}
+
+      <div className={isDomesticLane ? "hidden" : "flex flex-col gap-y-1"}>
         <Heading level="h2">
           {t("quotes.duty.header", "Import duty (DDP)")}
         </Heading>
@@ -254,6 +289,7 @@ export const QuoteBuyerForm = ({ form, currencies }: QuoteBuyerFormProps) => {
         </Text>
       </div>
 
+      {isDomesticLane ? null : (
       <Form.Field
         control={form.control}
         name="duties_prepaid"
@@ -305,7 +341,9 @@ export const QuoteBuyerForm = ({ form, currencies }: QuoteBuyerFormProps) => {
         )}
       />
 
-      {form.watch("duties_prepaid") ? (
+      )}
+
+      {!isDomesticLane && form.watch("duties_prepaid") ? (
         <div className="grid grid-cols-1 gap-4 md:grid-cols-3">
           <Form.Field
             control={form.control}

--- a/apps/partner-ui/src/routes/orders/quote-create/components/quote-create-form/quote-create-form.tsx
+++ b/apps/partner-ui/src/routes/orders/quote-create/components/quote-create-form/quote-create-form.tsx
@@ -50,11 +50,14 @@ const initialTabState: TabState = {
 type QuoteCreateFormProps = {
   currencies: string[]
   defaultCurrency?: string
+  /** ISO-2 of the store's dispatch country, or null when unknown (#1447). */
+  originCountryCode?: string | null
 }
 
 export const QuoteCreateForm = ({
   currencies,
   defaultCurrency,
+  originCountryCode,
 }: QuoteCreateFormProps) => {
   const [tab, setTab] = useState<Tab>(Tab.BUYER)
   const [tabState, setTabState] = useState<TabState>(initialTabState)
@@ -354,7 +357,11 @@ export const QuoteCreateForm = ({
               className="size-full overflow-y-auto p-16"
               value={Tab.BUYER}
             >
-              <QuoteBuyerForm form={form} currencies={currencies} />
+              <QuoteBuyerForm
+                form={form}
+                currencies={currencies}
+                originCountryCode={originCountryCode}
+              />
             </ProgressTabs.Content>
             <ProgressTabs.Content
               className="size-full overflow-y-auto"

--- a/apps/partner-ui/src/routes/orders/quote-create/quote-create.tsx
+++ b/apps/partner-ui/src/routes/orders/quote-create/quote-create.tsx
@@ -20,12 +20,25 @@ export const QuoteCreate = () => {
     (c: { is_default?: boolean }) => c.is_default
   )?.currency_code
 
+  /**
+   * Where this store's goods dispatch from (#1447). Decides whether the DDP
+   * section means anything: on a domestic lane there is no border, so no import
+   * duty or tax to prepay.
+   *
+   * 🔴 Null is UNKNOWN, never "domestic". Hiding the question on a real export
+   * is the failure that costs a buyer a customs bill we told them would not
+   * come; asking it on a domestic quote costs a moment's confusion.
+   */
+  const originCountryCode =
+    store?.location?.address?.country_code?.toUpperCase() || null
+
   return (
     <RouteFocusModal>
       {!isPending && (
         <QuoteCreateForm
           currencies={supported}
           defaultCurrency={defaultCurrency}
+          originCountryCode={originCountryCode}
         />
       )}
     </RouteFocusModal>


### PR DESCRIPTION
Three defects on the freight/DDP path, two of them live on prod today.

## 🔴 A RETURN option was winning every domestic lane

`create-store-with-defaults` gives every store a flat **"Return Shipping"** option, priced deliberately below the outbound base (₹100 against ₹200) and marked with an option-level rule `is_return = true`. `buildShippingEstimate` read PRICE rules (#1430) and never OPTION rules, so the return row was collected as an ordinary offer — and the picker sorts on the raw amount. **Partner quotes have been freighting at the return-pickup rate.**

This is the **fourth** blindness on the same picker, all the same shape: zone (#1424), currency (#1424), price-rule (#1430), and now the *kind* of option. Each let a row that does not belong on the lane win by being the smallest number.

`isQuotableShippingOption` also refuses `enabled_in_store: "false"` — an option a store has turned off is not an offer we may make on its behalf. An option with **no** rules is kept: absence is not a prohibition.

## 🔴 A partner shipping Delhivery was quoted by Shiprocket

`buildShippingEstimate` defaulted to `"shiprocket"` whenever no carrier was named — which was every partner quote ever minted. A real rate, for a real lane, from a company they do not ship with; nothing about the number gave it away, and it was never going to match the invoice.

The rating carrier is now: explicit choice (the admin picker) → the partner's own enabled carrier that **can rate this lane** → the platform default. The fallback matters: a partner may have enabled only carriers that cannot rate the lane (Blue Dart quotes nothing, Delhivery refuses cross-border), and a quote with no freight number is worse than one rated on the platform's account. `freight.rated_by` says which it was. Order comes from the capability table, not the link query — "which carrier quoted this" flipping between two mints of the same basket is a difference nobody can explain to a buyer.

## DDP is hidden on a domestic lane, and refused there

No border ⇒ no duty and no import tax — but the charges are ADDED to the buyer's total, so a mistakenly-ticked flag bills them for a customs event that never happens. Both wizards hide the section; the mint throws. Hiding a field is a UI convention and the API is reachable without one.

🔑 **Unknown origin keeps it visible** and the mint permissive. Asking about duty on a domestic quote costs a moment's confusion; hiding it on a real export costs a buyer the customs bill we said would not come.

Both `/admin|partners/shipping-carriers` now return `origin_country_code`, and the view carries it — one fact deciding who rates the lane, whether it is an export for tax, and whether DDP means anything, instead of three that can disagree.

## Also

- **Partner + admin quote lists rendered "0 lines · 0 units"** — `buildQuoteListQuery` never requested the `lines` relation, so the field was simply absent on the one screen a partner uses to check what they sent.

## ⚠️ Surfaced, deliberately not fixed here

**The quote and the cart disagree about freight.** The estimate cannot evaluate a rule-bound price (it has no cart), so it quotes the unconditional base; the cart *can*, and Indian stores carry retail free shipping over ₹2,999 — which every B2B basket clears. So a quote says ₹200 and the checkout charges ₹0. The direction is safe (a buyer is never charged more than quoted) and the test now holds exactly that invariant. Whether a retail free-shipping tier should apply to a B2B quote cart is a commercial decision, not a technical one.

## Verify

- `partner-quote-mint` → 14 pass (the freight test was failing on `main` before this branch existed)
- `partner-quote-cart-pricing` → 13 pass · `partner-quote-tax-jurisdiction` → 11 pass
- unit: `rating-carrier` 9 · `shipping-estimate-zone` 12 · `check:prod-build` ✅

No migration.

🤖 Generated with [Claude Code](https://claude.com/claude-code)