### PR TITLE
fix(quotes): the mint ignored the hand-typed freight, so no export could be quoted (#1439 S12)

### DIFF
--- a/apps/backend/src/workflows/partner-quote/mint-quote.ts
+++ b/apps/backend/src/workflows/partner-quote/mint-quote.ts
@@ -272,6 +272,24 @@ const validateQuoteReadinessStep = createStep(
       currency_code: input.currency_code,
       region_id: input.region_id,
       carrier: input.carrier,
+      /**
+       * 🔴 The hand-typed freight, or the gate below can never be satisfied.
+       *
+       * This step called the assessor WITHOUT the override while the wizards
+       * called it WITH one, so the two disagreed about the same quote — the
+       * exact split `assessQuoteReadiness` warns about in its own docblock.
+       * It was survivable only while an unrateable lane still produced a
+       * `chosen` freight from a flat manual tier: both sides said "ready", for
+       * different reasons.
+       *
+       * The moment that flat tier stopped counting as a rate, the omission
+       * became fatal — a partner types the DHL rate, the wizard turns green,
+       * and the mint refuses with a message telling them to type the rate they
+       * just typed. Found by minting through the real route on prod; the
+       * wizard's own preflight cannot see it, because the wizard is the half
+       * that was already correct.
+       */
+      freight_override_amount: input.freight_override_amount ?? null,
       check_catalogue: false,
     })
 


### PR DESCRIPTION
Regression from the freight gate shipped in #1489, caught by minting through the real route on prod.

`validateQuoteReadinessStep` calls `assessQuoteReadiness` **without** `freight_override_amount`. Both readiness endpoints pass it, so the mint and the wizards were assessing the same quote from different inputs — the split the assessor's own docblock warns about.

That was survivable while an unrateable lane still produced a `chosen` freight from a flat manual tier: both halves said "ready", for different reasons. Once the flat tier stopped counting as a rate, it became fatal:

```
mint intl, no override      → 400  "…type the real rate in"     ✅ intended
mint intl, override 48.50   → 400  "…type the real rate in"     ❌ same message
```

A partner looks up the DHL rate, types it, the wizard turns green, and the mint refuses by telling them to type the rate they just typed. **Every cross-border quote was unmintable.**

## Why no test caught it

The S12 override test exists and is good — but it runs on a **rateable** lane, deliberately, so that an override has to beat a live answer rather than merely fill a hole. On a rateable lane the new gate never fires, so the missing argument is invisible. Reproducing this needs a fixture where the carrier leg fails, which does not exist yet — noted rather than papered over.

Verified `check:prod-build` passes. I'll re-run both prod lanes once this deploys.