### PR TITLE
fix(quotes): the mint events reached no flow at all (#1439, #1420)

### DIFF
--- a/apps/backend/src/modules/partner-quote/events.ts
+++ b/apps/backend/src/modules/partner-quote/events.ts
@@ -1,0 +1,38 @@
+/**
+ * Events the quote path emits (#1439).
+ *
+ * ## Why these are constants and not string literals at the emit site
+ *
+ * Emitting an event is only half of making it usable. A visual flow can only be
+ * triggered by an event named in `visual-flow-event-trigger`'s `config.event`
+ * allowlist, and Medusa reports nothing at all when an event is missing from
+ * it: the emit succeeds, the flow sits active with that event as its trigger,
+ * executing the flow by hand works perfectly, and production does nothing.
+ *
+ * That is exactly what happened here — three real mints triggered zero flow
+ * executions while a hand-fired run of the same flow completed cleanly.
+ *
+ * So the names live in one place and `quote-events-are-subscribed.unit.spec.ts`
+ * asserts the subscriber carries every one of them. Adding an event here
+ * without wiring it there fails that test, which is the only signal this
+ * failure mode ever produces.
+ */
+export const PARTNER_QUOTE_EVENTS = {
+  /**
+   * A quote was minted and its buyer link exists. Carries `buyer_url`, because
+   * a flow that cannot name the link can send nothing useful. Emitted even when
+   * the built-in email fails — recovering a failed delivery is precisely a job
+   * for a flow.
+   */
+  MINTED: "partner_quote.minted",
+  /**
+   * A buyer accepted, and there is now a cart and a payment schedule. Fires on
+   * the FRESH acceptance only: a second click resolves to `already_accepted`
+   * and emits nothing, or a flow would mail the partner once per page refresh.
+   */
+  ACCEPTED: "partner_quote.accepted",
+} as const
+
+export const PARTNER_QUOTE_EVENT_NAMES: readonly string[] = Object.values(
+  PARTNER_QUOTE_EVENTS
+)

--- a/apps/backend/src/subscribers/__tests__/quote-events-are-subscribed.unit.spec.ts
+++ b/apps/backend/src/subscribers/__tests__/quote-events-are-subscribed.unit.spec.ts
@@ -1,0 +1,48 @@
+import { config } from "../visual-flow-event-trigger"
+import { PARTNER_QUOTE_EVENT_NAMES } from "../../modules/partner-quote/events"
+
+/**
+ * Every event the quote path emits must be one the visual-flow trigger is
+ * actually subscribed to.
+ *
+ * ## The failure this exists to catch
+ *
+ * `config.event` is an ALLOWLIST. Medusa delivers a subscriber only the events
+ * it names, and says nothing about the rest. So an event that is emitted but
+ * missing from that array produces the quietest possible failure:
+ *
+ *   - the emit succeeds, and logs nothing wrong
+ *   - an active flow names the event as its trigger and looks correctly wired
+ *   - executing that flow BY HAND completes and sends the email
+ *   - and in production, nothing happens at all, forever
+ *
+ * That is not hypothetical. `partner_quote.minted` was emitted, a flow was
+ * built and activated against it, a manual run of that flow sent the
+ * introduction correctly — and three real mints on prod produced ZERO
+ * executions. The subscriber's header even claimed custom events would be
+ * matched automatically, which is false.
+ *
+ * 🔑 A manual flow run proves the FLOW works. It bypasses the subscriber
+ * entirely, so it can never prove the flow will be triggered. Only this
+ * pairing does.
+ */
+describe("quote events reach the visual-flow trigger", () => {
+  const subscribed = new Set(
+    (Array.isArray(config.event) ? config.event : [config.event]) as string[]
+  )
+
+  it.each(PARTNER_QUOTE_EVENT_NAMES)(
+    "🔴 %s is in the subscriber's allowlist",
+    (eventName) => {
+      expect(subscribed.has(eventName)).toBe(true)
+    }
+  )
+
+  /**
+   * Guards the guard: if the events module were ever emptied, the `it.each`
+   * above would silently assert nothing and pass.
+   */
+  it("has quote events to check in the first place", () => {
+    expect(PARTNER_QUOTE_EVENT_NAMES.length).toBeGreaterThan(0)
+  })
+})

--- a/apps/backend/src/subscribers/visual-flow-event-trigger.ts
+++ b/apps/backend/src/subscribers/visual-flow-event-trigger.ts
@@ -12,10 +12,16 @@ import { executeVisualFlowWorkflow } from "../workflows/visual-flows"
  * This allows users to create event-triggered flows without needing to
  * manually create subscriber files.
  * 
- * Note: The event list below includes common events. The Event Bus dynamically
- * registers events as modules are loaded, so this list covers the most common
- * use cases. For custom events, users can emit them and they will be matched
- * if a flow is configured to listen for them.
+ * 🔴 The list in `config.event` below is an ALLOWLIST, and it is the whole
+ * story. This note used to say that custom events "can be emitted and they will
+ * be matched if a flow is configured to listen for them" — they will not.
+ * Medusa delivers a subscriber only the events it names, so an event missing
+ * from that array reaches no flow, matches nothing, and reports no error.
+ *
+ * The failure is quiet in the worst way: the event is emitted, an active flow
+ * names it as its trigger, executing that flow BY HAND works perfectly, and
+ * nothing whatsoever happens in production. Adding a trigger event therefore
+ * means editing this array — a flow alone is never enough.
  */
 export default async function visualFlowEventTriggerHandler({
   event,
@@ -236,7 +242,24 @@ export const config: SubscriberConfig = {
     "partner_product.proposed",
     "partner_product.approved",
     "partner_product.rejected",
-    
+
+    /**
+     * B2B quotes (#1439). `minted` carries the buyer's link, so a flow can
+     * introduce the maker before the quote lands; `accepted` fires once, on the
+     * fresh acceptance only, so a re-click cannot mail anyone twice.
+     *
+     * 🔴 This list is an ALLOWLIST, not documentation. The header above says
+     * custom events "will be matched if a flow is configured to listen for
+     * them" — that is not true, and cost a real debugging pass: the events were
+     * emitted, an active flow named `partner_quote.minted` as its trigger, the
+     * flow executed correctly when fired by hand, and three real mints
+     * triggered nothing at all. Medusa only delivers what is named here, so an
+     * event absent from this array reaches no flow and reports no error.
+     */
+    "partner_quote.minted",
+    "partner_quote.accepted",
+
+
     // Tasks
     "tasks.task.created",
     "tasks.task.updated",

--- a/apps/backend/src/workflows/partner-quote/accept-quote.ts
+++ b/apps/backend/src/workflows/partner-quote/accept-quote.ts
@@ -20,6 +20,7 @@ import {
 } from "@medusajs/medusa/core-flows"
 
 import { PARTNER_QUOTE_MODULE } from "../../modules/partner-quote"
+import { PARTNER_QUOTE_EVENTS } from "../../modules/partner-quote/events"
 import { PAYMENT_SCHEDULE_MODULE } from "../../modules/payment_schedule"
 import { quoteUnusableReason } from "../../modules/partner-quote/lib/token"
 
@@ -704,7 +705,7 @@ export const acceptQuoteWorkflow = createWorkflow(
        * per page refresh.
        */
       emitEventStep({
-        eventName: "partner_quote.accepted",
+        eventName: PARTNER_QUOTE_EVENTS.ACCEPTED,
         data: {
           id: input.quote_id,
           quote_id: input.quote_id,

--- a/apps/backend/src/workflows/partner-quote/deliver-quote-email.ts
+++ b/apps/backend/src/workflows/partner-quote/deliver-quote-email.ts
@@ -2,6 +2,7 @@ import { ContainerRegistrationKeys, Modules } from "@medusajs/framework/utils"
 
 import { BOT_SUPPRESSED_SEND_ID } from "../../lib/bot-recipients"
 import { PARTNER_QUOTE_MODULE } from "../../modules/partner-quote"
+import { PARTNER_QUOTE_EVENTS } from "../../modules/partner-quote/events"
 import { buildQuoteEmailData } from "../../modules/partner-quote/lib/quote-email"
 import { resolveQuoteBuyerLink } from "../../modules/partner-quote/lib/quote-link"
 import { sendQuoteEmailWorkflow } from "../email/workflows/send-quote-email"
@@ -89,7 +90,7 @@ export async function deliverQuoteEmail(
   try {
     const eventBus: any = scope.resolve(Modules.EVENT_BUS)
     await eventBus.emit({
-      name: "partner_quote.minted",
+      name: PARTNER_QUOTE_EVENTS.MINTED,
       data: {
         id: quote?.id,
         quote_id: quote?.id,


### PR DESCRIPTION
`visual-flow-event-trigger`'s `config.event` is an **allowlist**, and neither quote event was in it. Medusa delivers a subscriber only the events it names, so `partner_quote.minted` and `partner_quote.accepted` were emitted into nothing.

## Why it looked fine

- the emit succeeds and logs nothing wrong
- an active flow names the event as its trigger and looks correctly wired
- executing that flow **by hand** completes and sends the email
- production does nothing, forever

All four were true on prod. The introduction flow (`vflow_01M0QEND…`) ran perfectly when fired manually — and three real mints produced **zero** executions.

🔑 A manual flow run proves the FLOW works. It bypasses the subscriber entirely, so it can never prove the flow will be **triggered**. Only checking real executions after real mints found this.

The subscriber's own header claimed the opposite — that custom events *"can be emitted and they will be matched if a flow is configured to listen for them"*. That sentence is why the gap wasn't looked for, and it's replaced with what actually happens.

## Guard

Event names move to `modules/partner-quote/events.ts` so they have one owner, and `quote-events-are-subscribed.unit.spec.ts` asserts the subscriber carries every one. Adding an event without wiring it fails that test — the only signal this failure mode ever produces. Verified red by removing one name.

`check:prod-build` passes.