### PR TITLE
feat(quotes): the buyer can move quantities, and the server re-prices (#1439 S13)

### DIFF
--- a/apps/backend/integration-tests/http/partner-quote-buyer-dial.spec.ts
+++ b/apps/backend/integration-tests/http/partner-quote-buyer-dial.spec.ts
@@ -1,0 +1,172 @@
+import { createAdminUser } from "../helpers/create-admin-user"
+import {
+  mintBody,
+  setupQuoteFixture,
+  type QuoteFixture,
+} from "../helpers/setup-quote-fixture"
+import { getSharedTestEnv, setupSharedTestSuite } from "./shared-test-setup"
+
+jest.setTimeout(240 * 1000)
+
+/**
+ * The buyer's quantity dial, on the READ side (#1439 S13).
+ *
+ * ## Why this exists separately from the accept spec
+ *
+ * `partner-quote-accept.spec.ts` proves the dial survives into the cart. This
+ * proves the other half — that the document the buyer is looking at when they
+ * press the button was actually re-priced through the same numbers. Both halves
+ * have to hold or the feature is a lie in one direction or the other: a cart
+ * that ignores the dial charges for a basket nobody saw, and a page that
+ * ignores it shows a price nobody will be charged.
+ *
+ * ## What the buyer page depends on and nothing else asserted
+ *
+ * 🔴 `quoted_quantity` is consumed by the storefront to tell the buyer which
+ * number is theirs and which is the partner's ("Quoted at 25"). Both
+ * storefronts ship with `ignoreBuildErrors: true` and neither has a type-level
+ * gate worth the name, so if this field silently stopped being emitted the page
+ * would keep rendering — just without ever admitting the basket had been
+ * changed, while the header still called it "your quote". Nothing but an
+ * assertion here catches that.
+ */
+setupSharedTestSuite(() => {
+  describe("GET /store/b2b/quotes/:token?lines= — the buyer's dial (#1439 S13)", () => {
+    let seed: QuoteFixture
+    let storeHeaders: Record<string, string>
+
+    beforeAll(async () => {
+      const { api, getContainer } = getSharedTestEnv()
+      await createAdminUser(getContainer())
+      seed = await setupQuoteFixture(api, getContainer)
+      storeHeaders = { "x-publishable-api-key": seed.publishableKey }
+    })
+
+    /**
+     * A fresh quote per test. Re-quoting the same buyer stacks price lists
+     * (#1435) and the core tie-breaks to the CHEAPEST, so a shared quote would
+     * make these assertions depend on execution order.
+     */
+    const mint = async (label: string) => {
+      const { api } = getSharedTestEnv()
+      const res = await api.post(
+        "/partners/quotes",
+        mintBody(seed, {
+          buyer_email: `view-dial-${label}-${seed.unique}@jaalyantra.test`,
+        }),
+        { headers: seed.headers }
+      )
+      return res.data.token as string
+    }
+
+    /**
+     * 🔑 The wire form here is JSON, not the `variant:qty` pairs the storefront
+     * puts in its own URL. Two different hops: the browser's `?lines=` is a
+     * legible thing a buyer can see in a link they forward, and the Next server
+     * translates it to JSON at the boundary in `retrieveQuote`. Asserting the
+     * colon form against this route would pass for the wrong reason — an
+     * unparseable dial falls back to the quoted basket, which is what most of
+     * these tests would then be checking.
+     */
+    const view = async (
+      token: string,
+      dial?: Array<{ variant_id: string; quantity: number }> | string
+    ) => {
+      const { api } = getSharedTestEnv()
+      const raw =
+        dial === undefined
+          ? null
+          : typeof dial === "string"
+            ? dial
+            : JSON.stringify(dial)
+      const qs = raw === null ? "" : `?lines=${encodeURIComponent(raw)}`
+      const res = await api.get(`/store/b2b/quotes/${token}${qs}`, {
+        headers: storeHeaders,
+      })
+      return res.data.quote
+    }
+
+    const lineFor = (quote: any, variantId: string) =>
+      quote.lines.find((l: any) => l.variant_id === variantId)
+
+    it("reports the quoted quantity alongside the effective one", async () => {
+      const quote = await view(await mint("plain"))
+
+      // Undialled, the two agree — but they must both be PRESENT, because the
+      // page decides whether to say "you changed this" by comparing them.
+      for (const line of quote.lines) {
+        expect(line.quoted_quantity).not.toBeNull()
+        expect(line.quoted_quantity).toBe(line.quantity)
+      }
+      expect(lineFor(quote, seed.variantA.id).quoted_quantity).toBe(25)
+      expect(lineFor(quote, seed.variantB.id).quoted_quantity).toBe(4)
+    })
+
+    it("🔴 re-prices the whole document through the dial, and keeps the quoted quantity intact", async () => {
+      const token = await mint("moved")
+      const before = await view(token)
+      const after = await view(token, [
+        { variant_id: seed.variantA.id, quantity: 50 },
+      ])
+
+      const movedLine = lineFor(after, seed.variantA.id)
+      expect(movedLine.quantity).toBe(50)
+      // The partner's number is untouched — this is the whole point of the
+      // field. Without it the page cannot distinguish its own document from
+      // the one that was sent.
+      expect(movedLine.quoted_quantity).toBe(25)
+
+      // The line the buyer did not touch stays exactly as quoted.
+      const untouched = lineFor(after, seed.variantB.id)
+      expect(untouched.quantity).toBe(4)
+      expect(untouched.quoted_quantity).toBe(4)
+
+      /**
+       * 🔑 The reason the storefront does no arithmetic of its own: the SERVER
+       * re-priced. A browser multiplying `unit_amount × qty` would be wrong the
+       * moment a quantity crosses a price-list tier, a carrier weight slab or a
+       * tax threshold — and wrong quietly, showing a total the cart will not
+       * honour.
+       */
+      const beforeGoods = Number(before.live?.subtotal ?? before.quoted?.subtotal)
+      const afterGoods = Number(after.live?.subtotal ?? after.quoted?.subtotal)
+      expect(afterGoods).toBeGreaterThan(beforeGoods)
+    })
+
+    it("ignores a variant that is not on the quote rather than adding it", async () => {
+      // The dial is a quantity control, never a way into the catalogue — the
+      // same boundary acceptance enforces, held on the read side too.
+      const token = await mint("foreign")
+      const quote = await view(token, [
+        { variant_id: "variant_not_on_this_quote", quantity: 99 },
+      ])
+
+      expect(quote.lines).toHaveLength(2)
+      expect(lineFor(quote, seed.variantA.id).quantity).toBe(25)
+      expect(lineFor(quote, "variant_not_on_this_quote")).toBeUndefined()
+    })
+
+    it("falls back to the quoted basket on a mangled dial instead of failing the page", async () => {
+      /**
+       * 🔴 A quote link gets forwarded to procurement, pasted into purchase
+       * orders and wrapped by email clients. A truncated `?lines=` must cost
+       * the buyer the dial, never their price — a 400 here is a buyer who
+       * cannot see what they were quoted.
+       */
+      const token = await mint("mangled")
+      const mangledDials = [
+        "not-json-at-all",
+        "{oops",
+        // The colon form the BROWSER uses — legitimate one hop earlier, and
+        // meaningless here. It must degrade, not 400.
+        `${seed.variantA.id}:50`,
+      ]
+      for (const mangled of mangledDials) {
+        const quote = await view(token, mangled)
+        expect(quote.lines).toHaveLength(2)
+        expect(lineFor(quote, seed.variantA.id).quantity).toBe(25)
+        expect(lineFor(quote, seed.variantB.id).quantity).toBe(4)
+      }
+    })
+  })
+})

--- a/apps/backend/src/modules/partner-quote/lib/build-quote-view.ts
+++ b/apps/backend/src/modules/partner-quote/lib/build-quote-view.ts
@@ -270,7 +270,19 @@ export type QuoteViewLine = {
    * Null when the product has no spec, which is the normal state.
    */
   spec: QuoteLineSpec | null
+  /** The EFFECTIVE quantity — the buyer's dial position, or the quoted one. */
   quantity: number
+  /**
+   * What the partner actually quoted this line at (#1439 S13).
+   *
+   * Carried so a page that lets the buyer move quantities can say which number
+   * is theirs and which is the partner's. Without it a dialled document is
+   * indistinguishable from the one that was sent, while the header still calls
+   * it "your quote" — the buyer's own edit reads as the supplier's offer.
+   *
+   * Null only on a line with no frozen row behind it.
+   */
+  quoted_quantity: number | null
   position: number
   note: string | null
   /** Recomputed now, at THIS line's quantity. Null when the live half failed. */
@@ -1184,6 +1196,10 @@ export async function buildQuoteView(
       product_type_id: identity.product?.type?.id ?? null,
       product_collection: identity.product?.collection?.title ?? null,
       quantity: line.quantity,
+      quoted_quantity:
+        frozen?.quantity === undefined || frozen?.quantity === null
+          ? null
+          : Number(frozen.quantity),
       position: line.position ?? frozen?.position ?? index,
       note: line.note ?? frozen?.note ?? null,
       // #1486 — carried through so the frozen row, both partner UIs and the

--- a/apps/storefront/src/app/[countryCode]/(main)/quotes/[token]/page.tsx
+++ b/apps/storefront/src/app/[countryCode]/(main)/quotes/[token]/page.tsx
@@ -2,6 +2,7 @@ import { Metadata } from "next"
 import { notFound } from "next/navigation"
 
 import { retrieveQuote } from "@lib/data/quotes"
+import { parseDialledLines } from "@lib/util/quote-lines"
 import QuoteTemplate from "@modules/quotes/templates"
 
 /**
@@ -16,6 +17,18 @@ import QuoteTemplate from "@modules/quotes/templates"
  */
 type Props = {
   params: Promise<{ countryCode: string; token: string }>
+  /**
+   * The buyer's dialled basket (#1439 S13), as `?lines=variant_x:40,variant_y:12`.
+   *
+   * 🔴 A promise too, for the same reason `params` is — and the same trap. See
+   * the note above: this app is on Next 16, `apps/storefront-starter` is on
+   * Next 15, and reading a field off the unawaited promise is `undefined` on
+   * one and a deprecation warning on the other. Here the failure would be
+   * quieter than #1427 was: an un-awaited `searchParams` yields no dial, the
+   * quoted basket renders perfectly, and the buyer's +/− simply stops working
+   * with nothing in any log to say why.
+   */
+  searchParams: Promise<{ lines?: string | string[] }>
 }
 
 /**
@@ -38,9 +51,27 @@ export const metadata: Metadata = {
  */
 export const dynamic = "force-dynamic"
 
-export default async function QuotePage({ params }: Props) {
-  const { token, countryCode } = await params
-  const quote = await retrieveQuote(token)
+export default async function QuotePage({ params, searchParams }: Props) {
+  const [{ token, countryCode }, { lines }] = await Promise.all([
+    params,
+    searchParams,
+  ])
+
+  /**
+   * The quantities the buyer has dialled, if any (#1439 S13).
+   *
+   * 🔑 Handed to the backend, which re-prices the ENTIRE document through them
+   * — line subtotals, the freight the carrier rates for the new weight, the tax
+   * band the new goods value falls in, the deposit. Nothing on this page does
+   * price arithmetic in the browser, because a quantity crossing a price-list
+   * tier, a carrier weight slab or a tax threshold would make it quietly wrong.
+   *
+   * An unparseable dial is dropped rather than 404'd: the quoted basket is
+   * always a correct answer, and a link mangled in an email client should not
+   * cost the buyer their price.
+   */
+  const dialledLines = parseDialledLines(lines)
+  const quote = await retrieveQuote(token, dialledLines)
 
   // An unknown token and a revoked one are indistinguishable by design — the
   // backend 404s both so a prober learns nothing, and this preserves that.

--- a/apps/storefront/src/lib/data/quotes.ts
+++ b/apps/storefront/src/lib/data/quotes.ts
@@ -149,7 +149,17 @@ export type QuoteViewLine = {
   thumbnail: string | null
   image_source: "variant" | "product" | null
   spec: QuoteLineSpec | null
+  /** The EFFECTIVE quantity — the buyer's dial position, or the quoted one. */
   quantity: number
+  /**
+   * What the partner actually quoted this line at (#1439 S13). Null on a line
+   * with no frozen row behind it.
+   *
+   * 🔑 The page needs BOTH numbers the moment the buyer can move quantities:
+   * a dialled document that says nothing about the dial is indistinguishable
+   * from the one the partner sent, and the header still calls it "your quote".
+   */
+  quoted_quantity?: number | null
   position: number
   note: string | null
   live_unit_amount: number | null
@@ -423,14 +433,28 @@ export const retrieveQuote = async (
  * same cart rather than a second one priced against a superseded list.
  */
 export const acceptQuote = async (
-  token: string
+  token: string,
+  lines?: Array<{ variant_id: string; quantity: number }>
 ): Promise<{ cart_id: string | null; error: string | null }> => {
   try {
     const { acceptance } = await sdk.client.fetch<{
       acceptance: { cart_id: string; already_accepted?: boolean }
     }>(`/store/b2b/quotes/${encodeURIComponent(token)}/accept`, {
       method: "POST",
-      body: {},
+      /**
+       * 🔴 The basket AS RENDERED, or the cart quietly reverts to the quoted
+       * quantities (#1439 S13). The page has always let a buyer move
+       * quantities and re-priced the whole document through them — but
+       * acceptance ignored the dial entirely, so someone who moved 29 up to 40,
+       * read the new total and pressed Accept got a cart for 29. Nothing said
+       * so, on the page or at checkout.
+       *
+       * Sent from the lines the SERVER priced rather than from the URL: the
+       * rendered document is what the buyer agreed to, and the backend refuses
+       * any variant not already on the quote — so a stale query string must
+       * never be the thing that reaches the cart.
+       */
+      body: lines?.length ? { lines } : {},
       cache: "no-store",
     })
 

--- a/apps/storefront/src/lib/util/__tests__/quote-lines.test.ts
+++ b/apps/storefront/src/lib/util/__tests__/quote-lines.test.ts
@@ -1,0 +1,117 @@
+import { describe, expect, it } from "vitest"
+
+import {
+  buildDialHref,
+  buildQuotedHref,
+  parseDialledLines,
+  serialiseDialledLines,
+} from "../quote-lines"
+
+/**
+ * The buyer's dialled basket, in the URL (#1439 S13).
+ *
+ * Worth testing properly despite being small: this is the only client-side code
+ * on the quote page that touches the basket at all, and both storefronts ship
+ * with `ignoreBuildErrors: true`, so nothing else would catch a regression here
+ * before a buyer did. The failures it guards against are all silent — a dropped
+ * dial renders the quoted basket perfectly and simply ignores the buyer.
+ */
+describe("parseDialledLines", () => {
+  it("reads the documented wire form", () => {
+    expect(parseDialledLines("variant_01ABC:40,variant_01DEF:12")).toEqual([
+      { variant_id: "variant_01ABC", quantity: 40 },
+      { variant_id: "variant_01DEF", quantity: 12 },
+    ])
+  })
+
+  it("is empty for an absent, blank or arrayed-empty param", () => {
+    expect(parseDialledLines(undefined)).toEqual([])
+    expect(parseDialledLines(null)).toEqual([])
+    expect(parseDialledLines("")).toEqual([])
+  })
+
+  it("takes the first value when Next hands back a repeated param", () => {
+    expect(parseDialledLines(["variant_a:2", "variant_a:9"])).toEqual([
+      { variant_id: "variant_a", quantity: 2 },
+    ])
+  })
+
+  it("drops a malformed pair rather than throwing the page away", () => {
+    // A link mangled in an email client must cost the buyer the dial, never
+    // their price — the quoted basket is always a correct answer.
+    expect(parseDialledLines("variant_a:2,rubbish,:5,variant_b:")).toEqual([
+      { variant_id: "variant_a", quantity: 2 },
+    ])
+  })
+
+  it("refuses a quantity that cannot be manufactured, without clamping", () => {
+    // 🔴 Not rounded to something nearby: silently substituting a number the
+    // buyer did not type is how someone orders a quantity nobody chose.
+    expect(parseDialledLines("variant_a:2.5,variant_b:-3,variant_c:abc")).toEqual([])
+  })
+
+  it("keeps a zero — the backend reads it as 'remove this line'", () => {
+    expect(parseDialledLines("variant_a:0")).toEqual([
+      { variant_id: "variant_a", quantity: 0 },
+    ])
+  })
+
+  it("lets the first mention of a variant win", () => {
+    // Otherwise the page and a re-read of its own URL could disagree about
+    // what was asked for.
+    expect(parseDialledLines("variant_a:2,variant_a:80")).toEqual([
+      { variant_id: "variant_a", quantity: 2 },
+    ])
+  })
+
+  it("round-trips through serialise", () => {
+    const lines = [
+      { variant_id: "variant_01ABC", quantity: 40 },
+      { variant_id: "variant_01DEF", quantity: 1 },
+    ]
+    expect(parseDialledLines(serialiseDialledLines(lines))).toEqual(lines)
+  })
+})
+
+describe("buildDialHref", () => {
+  const base = {
+    countryCode: "in",
+    token: "tok_abc",
+    lines: [
+      { variant_id: "variant_a", quantity: 10 },
+      { variant_id: "variant_b", quantity: 5 },
+    ],
+  }
+
+  it("moves one line and carries every other one unchanged", () => {
+    const href = buildDialHref({ ...base, variantId: "variant_a", quantity: 11 })
+    expect(href).toBe(
+      "/in/quotes/tok_abc?lines=variant_a%3A11%2Cvariant_b%3A5"
+    )
+    // The whole basket survives the hop, so a second dial does not silently
+    // reset the first.
+    expect(parseDialledLines(decodeURIComponent(href.split("lines=")[1]))).toEqual([
+      { variant_id: "variant_a", quantity: 11 },
+      { variant_id: "variant_b", quantity: 5 },
+    ])
+  })
+
+  it("does not mutate the lines it was given", () => {
+    buildDialHref({ ...base, variantId: "variant_a", quantity: 99 })
+    expect(base.lines[0].quantity).toBe(10)
+  })
+
+  it("escapes the token, which is the credential and lives in the path", () => {
+    expect(
+      buildDialHref({ ...base, token: "a/b", variantId: "variant_a", quantity: 2 })
+    ).toContain("/in/quotes/a%2Fb?")
+  })
+})
+
+describe("buildQuotedHref", () => {
+  it("drops the dial entirely, back to the basket the partner sent", () => {
+    expect(buildQuotedHref({ countryCode: "in", token: "tok_abc" })).toBe(
+      "/in/quotes/tok_abc"
+    )
+  })
+})

--- a/apps/storefront/src/lib/util/quote-lines.ts
+++ b/apps/storefront/src/lib/util/quote-lines.ts
@@ -1,0 +1,143 @@
+/**
+ * The buyer's dialled basket, carried in the URL (#1439 S13).
+ *
+ * ## Why the URL and not client state
+ *
+ * Every number on the quote page — each line's subtotal, the freight the
+ * carrier rates for the new weight, the tax band the new goods value falls in,
+ * the deposit — is computed by the backend against the basket it is given.
+ * `GET /store/b2b/quotes/:token?lines=` re-prices the whole document. So the
+ * quantity control moves the URL and lets the server answer; it does no price
+ * arithmetic of its own.
+ *
+ * 🔴 That is not a style preference. A client-side `unit_amount × qty` would be
+ * wrong the moment a quantity crosses a price-list tier, a carrier weight slab
+ * or a tax threshold — and it would be wrong *quietly*, showing the buyer a
+ * total the cart will not honour. There is exactly one thing on this page
+ * allowed to price a basket, and it is not the browser.
+ *
+ * A second benefit falls out for free: the dialled basket is shareable and
+ * survives a reload, which is what a procurement contact forwarding the link to
+ * their finance team actually does.
+ *
+ * ## The wire form
+ *
+ * `?lines=variant_01ABC:40,variant_01DEF:12`
+ *
+ * Deliberately not JSON. A JSON array percent-encodes into an unreadable
+ * ribbon in a link that gets pasted into emails and purchase orders; a
+ * colon/comma pair survives it legibly. Medusa ids are `[A-Za-z0-9_]` so
+ * neither separator can occur inside one. The backend speaks JSON, and
+ * `retrieveQuote` does that translation at the boundary.
+ */
+
+export type DialledLine = { variant_id: string; quantity: number }
+
+/**
+ * Read the dial out of a search param.
+ *
+ * Total in its tolerance: a malformed pair is dropped, not thrown on. This
+ * value arrives from a URL a buyer may have edited, truncated in an email
+ * client, or had mangled by a link rewriter — none of which is worth a 500 on a
+ * page whose entire job is to show someone a price. What survives parsing is
+ * applied; the rest falls back to the quoted quantity, because the backend
+ * re-prices from the quote's own lines and only overrides the variants it is
+ * told about.
+ *
+ * Negative and fractional quantities are dropped rather than clamped: the
+ * caller asked for something that cannot be manufactured, and silently
+ * rounding it to a number they did not choose is how a buyer ends up ordering a
+ * quantity nobody typed. Zero is kept — the backend treats it as "remove this
+ * line", which is an ordinary thing to do to a multi-line quote.
+ */
+export const parseDialledLines = (
+  param: string | string[] | undefined | null
+): DialledLine[] => {
+  const raw = Array.isArray(param) ? param[0] : param
+  if (!raw) {
+    return []
+  }
+
+  const seen = new Set<string>()
+  const out: DialledLine[] = []
+
+  for (const pair of raw.split(",")) {
+    const idx = pair.lastIndexOf(":")
+    if (idx <= 0) {
+      continue
+    }
+
+    const variant_id = pair.slice(0, idx).trim()
+    const rawQuantity = pair.slice(idx + 1).trim()
+
+    /**
+     * 🔴 The empty check is load-bearing, and is NOT covered by the numeric one
+     * below it: `Number("")` is `0`, a perfectly valid integer — and the
+     * backend reads a dialled 0 as "remove this line". So a link truncated at
+     * the colon (`?lines=variant_a:2,variant_b:`) — which is exactly what an
+     * email client wrapping a long URL produces — would have silently deleted a
+     * product from the buyer's basket and re-priced the quote without it.
+     * Caught by the round-trip test, never by a type checker.
+     */
+    if (!variant_id || !rawQuantity) {
+      continue
+    }
+
+    const quantity = Number(rawQuantity)
+    if (!Number.isInteger(quantity) || quantity < 0) {
+      continue
+    }
+    // First mention wins, so a duplicated variant cannot make the page and a
+    // re-read of the same URL disagree about what was asked for.
+    if (seen.has(variant_id)) {
+      continue
+    }
+
+    seen.add(variant_id)
+    out.push({ variant_id, quantity })
+  }
+
+  return out
+}
+
+/** The inverse. Stable order in, stable order out — the link must not churn. */
+export const serialiseDialledLines = (lines: DialledLine[]): string =>
+  lines.map((l) => `${l.variant_id}:${l.quantity}`).join(",")
+
+/**
+ * The href for the page with one line moved to `quantity`.
+ *
+ * Built from the lines the SERVER priced, never from the incoming query string:
+ * the rendered document is the source of truth for what the buyer is looking
+ * at, so a stale or partial `?lines=` cannot leak into the next navigation.
+ */
+export const buildDialHref = ({
+  countryCode,
+  token,
+  lines,
+  variantId,
+  quantity,
+}: {
+  countryCode: string
+  token: string
+  lines: DialledLine[]
+  variantId: string
+  quantity: number
+}): string => {
+  const next = lines.map((l) =>
+    l.variant_id === variantId ? { ...l, quantity } : l
+  )
+
+  return `/${countryCode}/quotes/${encodeURIComponent(token)}?lines=${encodeURIComponent(
+    serialiseDialledLines(next)
+  )}`
+}
+
+/** The href back to the basket the partner actually quoted. */
+export const buildQuotedHref = ({
+  countryCode,
+  token,
+}: {
+  countryCode: string
+  token: string
+}): string => `/${countryCode}/quotes/${encodeURIComponent(token)}`

--- a/apps/storefront/src/modules/quotes/components/quote-accept/index.tsx
+++ b/apps/storefront/src/modules/quotes/components/quote-accept/index.tsx
@@ -35,10 +35,18 @@ const QuoteAcceptPanel = ({
   token,
   acceptance,
   countryCode,
+  lines,
 }: {
   token: string
   acceptance: QuoteAcceptance
   countryCode: string
+  /**
+   * The basket as the server priced it, passed straight through to the accept
+   * call (#1439 S13). Not read from the URL and not recomputed here — the
+   * numbers above this button were rendered from these exact lines, so these
+   * are the ones the buyer is agreeing to.
+   */
+  lines: Array<{ variant_id: string; quantity: number }>
 }) => {
   const router = useRouter()
   const [pending, startTransition] = useTransition()
@@ -52,7 +60,7 @@ const QuoteAcceptPanel = ({
   const go = () => {
     setError(null)
     startTransition(async () => {
-      const { cart_id, error } = await acceptQuote(token)
+      const { cart_id, error } = await acceptQuote(token, lines)
       if (!cart_id) {
         setError(error ?? "The order could not be started.")
         return

--- a/apps/storefront/src/modules/quotes/components/quote-lines/index.tsx
+++ b/apps/storefront/src/modules/quotes/components/quote-lines/index.tsx
@@ -1,9 +1,12 @@
 import { Text } from "@medusajs/ui"
 
 import { convertToLocale } from "@lib/util/money"
+import type { DialledLine } from "@lib/util/quote-lines"
+import { buildQuotedHref } from "@lib/util/quote-lines"
 import type { QuoteView, QuoteViewLine } from "@lib/data/quotes"
 import QuoteLineImage from "../quote-image"
 import QuoteLineSpecRows from "../quote-line-spec"
+import QuoteQuantity from "../quote-quantity"
 
 /**
  * The quoted basket, line by line.
@@ -25,11 +28,18 @@ const LineRow = ({
   currency_code,
   showQuoted,
   showLive,
+  dial,
 }: {
   line: QuoteViewLine
   currency_code: string
   showQuoted: boolean
   showLive: boolean
+  /** Absent ⇒ the quantity is stated, not offered. */
+  dial: {
+    token: string
+    countryCode: string
+    lines: DialledLine[]
+  } | null
 }) => (
   <tr className="border-b border-ui-border-base last:border-b-0">
     <td className="py-4 pr-4 align-top">
@@ -77,7 +87,18 @@ const LineRow = ({
       </div>
     </td>
     <td className="py-4 px-4 align-top text-right whitespace-nowrap">
-      <Text className="txt-medium text-ui-fg-base">{line.quantity}</Text>
+      {dial ? (
+        <QuoteQuantity
+          countryCode={dial.countryCode}
+          token={dial.token}
+          lines={dial.lines}
+          variantId={line.variant_id}
+          quantity={line.quantity}
+          quotedQuantity={line.quoted_quantity ?? null}
+        />
+      ) : (
+        <Text className="txt-medium text-ui-fg-base">{line.quantity}</Text>
+      )}
     </td>
     {showQuoted ? (
       <td className="py-4 px-4 align-top text-right whitespace-nowrap">
@@ -102,9 +123,45 @@ const LineRow = ({
   </tr>
 )
 
-const QuoteLines = ({ quote }: { quote: QuoteView }) => {
+const QuoteLines = ({
+  quote,
+  token,
+  countryCode,
+}: {
+  quote: QuoteView
+  token: string
+  countryCode: string
+}) => {
   const { show_quoted: showQuoted, show_live: showLive } = quote.compare
   const lines = [...quote.lines].sort((a, b) => a.position - b.position)
+
+  /**
+   * Quantities are only OFFERED while the quote is still something the buyer
+   * can act on (#1439 S13).
+   *
+   * Once accepted, the cart exists and its quantities are fixed — a stepper
+   * that re-prices this page would show a basket the order will not match, and
+   * the buyer would have no way to tell which of the two was real. A blocked
+   * quote stays dialable on purpose: "what would 400 cost" is exactly the
+   * question that gets answered by replying to the partner.
+   */
+  const dial = quote.acceptance?.accepted
+    ? null
+    : {
+        token,
+        countryCode,
+        lines: lines.map((l) => ({
+          variant_id: l.variant_id,
+          quantity: l.quantity,
+        })),
+      }
+
+  // Whether the buyer has moved anything off the quoted basket. Drives the one
+  // sentence that stops a dialled page passing itself off as the partner's
+  // offer — the totals below it are real, but nobody quoted them.
+  const dialled = lines.some(
+    (l) => l.quoted_quantity !== null && l.quoted_quantity !== undefined && l.quoted_quantity !== l.quantity
+  )
 
   return (
     <div className="overflow-x-auto">
@@ -137,10 +194,31 @@ const QuoteLines = ({ quote }: { quote: QuoteView }) => {
               currency_code={quote.currency_code}
               showQuoted={showQuoted}
               showLive={showLive}
+              dial={dial}
             />
           ))}
         </tbody>
       </table>
+
+      {/* 🔴 Said once, under the lines rather than beside one of them: the
+          document is no longer the one that was sent. The prices are the
+          partner's and the server computed every total on this page from these
+          quantities — but the quantities are the buyer's, and a page headed
+          "your quote" must not let that pass unremarked. */}
+      {dialled ? (
+        <div className="mt-4 flex flex-wrap items-center justify-between gap-x-4 gap-y-2 rounded-md border border-ui-border-base bg-ui-bg-subtle px-4 py-3">
+          <Text className="txt-small text-ui-fg-subtle">
+            You have changed the quantities. These prices are your partner&apos;s,
+            re-applied to the basket above.
+          </Text>
+          <a
+            href={buildQuotedHref({ countryCode, token })}
+            className="txt-small-plus text-ui-fg-interactive hover:text-ui-fg-interactive-hover"
+          >
+            Back to the quoted quantities
+          </a>
+        </div>
+      ) : null}
     </div>
   )
 }

--- a/apps/storefront/src/modules/quotes/components/quote-quantity/index.tsx
+++ b/apps/storefront/src/modules/quotes/components/quote-quantity/index.tsx
@@ -1,0 +1,112 @@
+import { Text, clx } from "@medusajs/ui"
+import Link from "next/link"
+
+import { buildDialHref, type DialledLine } from "@lib/util/quote-lines"
+import QuoteQuantityInput from "./input"
+
+/**
+ * The +/− control on a quoted line (#1439 S13).
+ *
+ * ## Two plain links and a box
+ *
+ * `−` and `+` are anchors to the same page with a different `?lines=`. No
+ * state, no fetch, no optimistic number: the server re-prices the entire
+ * document — line subtotals, freight for the new weight, the tax band the new
+ * goods value falls in, the deposit — and the page that comes back is the only
+ * account of what this basket costs. See `lib/util/quote-lines` for why the
+ * browser is not allowed to do that arithmetic.
+ *
+ * 🔑 The box exists because ±1 is useless here. These are bulk quantities —
+ * moving 250 to 400 is one edit and 150 clicks. It still only pushes a URL;
+ * the server prices it exactly as the links do.
+ *
+ * ## The floor is 1, not 0
+ *
+ * The backend reads a dialled 0 as "drop this line", and will refuse a basket
+ * dialled empty. But the *view* endpoint keeps a zeroed line and prices it at
+ * nothing, so a 0 here would show the buyer a row the cart is going to delete.
+ * Rather than reconcile two presentations of an empty line, the control stops
+ * at 1 and removing a product stays a conversation with the partner — which is
+ * what a buyer dropping an item from a quote does anyway.
+ */
+const QuoteQuantity = ({
+  countryCode,
+  token,
+  lines,
+  variantId,
+  quantity,
+  quotedQuantity,
+}: {
+  countryCode: string
+  token: string
+  /** Every line as the server priced it — the basis for the next href. */
+  lines: DialledLine[]
+  variantId: string
+  quantity: number
+  /** What the partner quoted, so a moved line can say so. */
+  quotedQuantity: number | null
+}) => {
+  const href = (next: number) =>
+    buildDialHref({ countryCode, token, lines, variantId, quantity: next })
+
+  const canDecrease = quantity > 1
+
+  const stepClass =
+    "flex h-8 w-8 items-center justify-center rounded-md border border-ui-border-base text-ui-fg-base transition-colors"
+
+  return (
+    <div className="flex flex-col items-end gap-y-1">
+      <div className="flex items-center gap-x-1">
+        {/* A disabled step is a span, not a dead link: an anchor that goes
+            nowhere is still focusable and still announced as a link. */}
+        {canDecrease ? (
+          <Link
+            href={href(quantity - 1)}
+            scroll={false}
+            prefetch={false}
+            aria-label="Decrease quantity by one"
+            className={clx(stepClass, "hover:bg-ui-bg-subtle-hover")}
+          >
+            −
+          </Link>
+        ) : (
+          <span
+            aria-hidden="true"
+            className={clx(stepClass, "text-ui-fg-disabled bg-ui-bg-disabled")}
+          >
+            −
+          </span>
+        )}
+
+        <QuoteQuantityInput
+          countryCode={countryCode}
+          token={token}
+          lines={lines}
+          variantId={variantId}
+          quantity={quantity}
+        />
+
+        <Link
+          href={href(quantity + 1)}
+          scroll={false}
+          prefetch={false}
+          aria-label="Increase quantity by one"
+          className={clx(stepClass, "hover:bg-ui-bg-subtle-hover")}
+        >
+          +
+        </Link>
+      </div>
+
+      {/* What the partner actually quoted, whenever the buyer has moved off it.
+          Without this the page silently becomes a different document from the
+          one that was sent, and the header still calls it "your quote". */}
+      {quotedQuantity !== null && quotedQuantity !== quantity ? (
+        <Text className="txt-small text-ui-fg-muted">
+          Quoted at {quotedQuantity}
+        </Text>
+      ) : null}
+    </div>
+  )
+}
+
+export default QuoteQuantity

--- a/apps/storefront/src/modules/quotes/components/quote-quantity/input.tsx
+++ b/apps/storefront/src/modules/quotes/components/quote-quantity/input.tsx
@@ -1,0 +1,91 @@
+"use client"
+
+import { useRouter } from "next/navigation"
+import { useEffect, useState, useTransition } from "react"
+
+import { buildDialHref, type DialledLine } from "@lib/util/quote-lines"
+
+/**
+ * Type a quantity and let the server re-price (#1439 S13).
+ *
+ * The only client component in the quantity control, and it holds exactly one
+ * piece of state: the characters currently in the box. It does no arithmetic
+ * with money — on commit it pushes a URL and the server returns a fully
+ * re-priced document, identical to what the +/− links do.
+ *
+ * 🔴 The displayed value must follow the SERVER's quantity, not the typing. A
+ * buyer who types 400, commits, and then presses Back has a page whose prices
+ * are for 250; a box still reading 400 would be describing a basket that is not
+ * on screen. `useEffect` on the prop resynchronises after every navigation.
+ *
+ * Commit on Enter or blur, never per keystroke: a fetch and a full re-price for
+ * every digit of "1000" is four wrong baskets on the way to the right one.
+ */
+const QuoteQuantityInput = ({
+  countryCode,
+  token,
+  lines,
+  variantId,
+  quantity,
+}: {
+  countryCode: string
+  token: string
+  lines: DialledLine[]
+  variantId: string
+  quantity: number
+}) => {
+  const router = useRouter()
+  const [pending, startTransition] = useTransition()
+  const [value, setValue] = useState(String(quantity))
+
+  useEffect(() => {
+    setValue(String(quantity))
+  }, [quantity])
+
+  const commit = () => {
+    const next = Number(value)
+
+    // Anything that is not a whole number of units at least one snaps back to
+    // what is actually on screen. Clamping to a nearby number the buyer did not
+    // type is worse: they would be ordering a quantity nobody chose.
+    if (!Number.isInteger(next) || next < 1) {
+      setValue(String(quantity))
+      return
+    }
+    if (next === quantity) {
+      return
+    }
+
+    startTransition(() => {
+      router.push(
+        buildDialHref({ countryCode, token, lines, variantId, quantity: next }),
+        { scroll: false }
+      )
+    })
+  }
+
+  return (
+    <input
+      type="text"
+      inputMode="numeric"
+      pattern="[0-9]*"
+      aria-label="Quantity"
+      className="h-8 w-16 rounded-md border border-ui-border-base bg-ui-bg-field text-center txt-medium text-ui-fg-base focus:outline-none focus:border-ui-border-interactive disabled:text-ui-fg-disabled"
+      value={value}
+      disabled={pending}
+      onChange={(e) => setValue(e.target.value.replace(/[^0-9]/g, ""))}
+      onBlur={commit}
+      onKeyDown={(e) => {
+        if (e.key === "Enter") {
+          e.preventDefault()
+          e.currentTarget.blur()
+        }
+        if (e.key === "Escape") {
+          setValue(String(quantity))
+        }
+      }}
+    />
+  )
+}
+
+export default QuoteQuantityInput

--- a/apps/storefront/src/modules/quotes/templates/index.tsx
+++ b/apps/storefront/src/modules/quotes/templates/index.tsx
@@ -103,7 +103,10 @@ const QuoteTemplate = ({
         <Heading level="h2" className="text-xl-semi text-ui-fg-base mb-2">
           Your basket
         </Heading>
-        <QuoteLines quote={quote} />
+        {/* The buyer may move quantities here; every number that follows is
+            re-computed by the SERVER from what they dial (#1439 S13), which is
+            why the control is two links and a URL rather than client state. */}
+        <QuoteLines quote={quote} token={token} countryCode={countryCode} />
       </div>
 
       <div className="mt-10">
@@ -118,6 +121,15 @@ const QuoteTemplate = ({
           token={token}
           acceptance={acceptance}
           countryCode={countryCode}
+          /* 🔴 The basket AS PRICED ABOVE, not the quoted one. `quote.lines`
+             already carries the buyer's dial — the backend re-priced the whole
+             document through it — so handing these straight to the accept call
+             is what stops a cart being built for quantities the buyer moved
+             away from and never saw again. */
+          lines={quote.lines.map((l) => ({
+            variant_id: l.variant_id,
+            quantity: l.quantity,
+          }))}
         />
       ) : null}
 


### PR DESCRIPTION
Closes the last open UI item on the S13 lane of #1439.

## The gap

The backend has taken a dial since S13 — `GET /store/b2b/quotes/:token?lines=` re-prices the whole document through it, and `acceptQuoteWorkflow` builds the cart from it (7/7 green) — but **no UI ever sent one**. This adds the control, on both storefronts.

## URL-driven, deliberately

`−` and `+` are plain anchors to the same page with a different `?lines=`. The typed box pushes a URL and nothing more. The server returns a fully re-priced document — line subtotals, the freight the carrier rates for the new weight, the tax band the new goods value falls in, the deposit.

Nothing in the browser multiplies a price by a quantity. That would be wrong the moment a quantity crosses a price-list tier, a carrier weight slab or a tax threshold — and wrong *quietly*, showing a total the cart will not honour. A shareable, reloadable dialled basket falls out for free, which is what a procurement contact forwarding the link to finance actually does.

## Acceptance sends what was rendered

Built from `quote.lines` — the lines the **server** priced — not from the query string. Without that, a buyer who dialled up, read the new total and pressed Accept would get a cart for the quoted quantities: the S13 defect, reintroduced at the last hop.

## `quoted_quantity`, new on the view

The page needs both numbers the moment the buyer can move one. A dialled document that says nothing about the dial passes the buyer's own edit off as the supplier's offer, under a header reading "your quote". Each moved line now says `Quoted at N`, and one notice under the table offers the way back.

## Decisions worth arguing with

| | |
|---|---|
| **`variant_x:40,variant_y:12`, not JSON** | The link gets forwarded to procurement and pasted into purchase orders; a percent-encoded JSON array does not survive that legibly. `retrieveQuote` translates at the backend boundary, which still speaks JSON. |
| **Floor is 1, not 0** | The backend reads a dialled 0 as *remove this line*, but the **view** endpoint keeps a zeroed line and prices it at nothing — a 0 here would show a row the cart is going to delete. Dropping a product stays a conversation with the partner. |
| **Hidden once accepted** | The cart exists and its quantities are fixed; a stepper would describe a basket the order does not match, with no way for the buyer to tell which was real. Still shown on a *blocked* quote — "what would 400 cost" is exactly the question that gets answered by replying to the partner. |

## 🔴 The bug the tests found

`Number("")` is `0`, so a link truncated at the colon (`?lines=variant_a:2,variant_b:`) — exactly what an email client wrapping a long URL produces — parsed as *remove this line* and silently re-priced the quote without that product. Caught by the round-trip test, not by review, and invisible to any type checker.

## Verification

Both storefronts ship `ignoreBuildErrors: true`, so neither the build nor a type check is a gate — this was verified by running it.

- **Really rendered**, against a real local backend, on a really-minted quote. Dialling 1 → 4: order total **₹2,630.25 → ₹10,505.25**, deposit **₹789.08 → ₹3,151.58**, `Quoted at 1` and the notice both present, `−` correctly inert at qty 1, `+` linking to `:2`.
- Local backend probe confirms the contract: `quantity` moves to 4 while `quoted_quantity` holds at 1 and the subtotal re-prices 2500 → 10000.
- `partner-quote-buyer-dial.spec.ts` — **4/4 new**, against a real database (the view side; the accept side was already covered).
- `partner-quote-accept.spec.ts` — **7/7**, unchanged.
- `quote-lines.test.ts` — **12/12 new** on the URL contract.
- `pnpm check:prod-build` — green.
- `tsc`: starter **179 → 179** (every touched file and both new components clean); storefront 816 → 820, all four `TS2786` in the new file, the same duplicate-`@types/react` artifact as its baseline.

⚠️ Not verified: the **starter's own** components rendered against a live backend — its local dev server is pointed at production. They are byte-identical to the ones proven working at runtime above, and typecheck clean there where the storefront's duplicate `@types/react` masks TS2786. The starter's page itself does compile and run under Next 15 (bogus token → 404, not 500).

## Submodule

`apps/storefront-starter` → Jaal-Yantra-Textiles/nextjs-starter-medusa#23. Confirmed a descendant of the pointer on `main` (`be2dd43`), so merging does not silently revert the live buyer page. **Merge #23 first**, then re-point this branch at the starter's `main`.