### PR TITLE
feat(mcp): quotes are reachable from both assistants (#1439, #1306)

### DIFF
--- a/apps/backend/src/api/admin/mcp/lib/registry.ts
+++ b/apps/backend/src/api/admin/mcp/lib/registry.ts
@@ -27,6 +27,18 @@
  * size is a per-request token cost.
  */
 import type { McpToolDef } from "../../../../lib/mcp-core"
+/**
+ * The quote vocabulary, shared with the partner surface (#1439). Both surfaces
+ * mint; a body list written out twice is one edit away from the two assistants
+ * believing different things about what a quote is (#1348).
+ */
+import {
+  QUOTE_MINT_BODY_PARAMS,
+  QUOTE_MINT_READINESS_BODY_PARAMS,
+  QUOTE_MINT_WRITE_GUIDANCE,
+  quoteMintSchemaProps,
+  quoteReadinessSchemaProps,
+} from "../../../../modules/partner-quote/tool-schema"
 import {
   PHYSICAL_AND_CUSTOMS_BODY_PARAMS,
   physicalAndCustomsSchemaProps,
@@ -4137,5 +4149,113 @@ export const ADMIN_MCP_TOOLS: AdminMcpToolDef[] = [
     ),
     sideEffects:
       "Also recomputes the contact's engagement_state, which is what visual flows select on. Logging an activity with kind 'opt_out' makes the contact permanently do_not_contact.",
+  },
+  // ===== B2B quotes (#1389 S5, #1439) =======================================
+  //
+  // 🔑 `partner_id` is the whole difference from the partner surface. An admin
+  // has no partner of their own, so the one being quoted FOR must be named —
+  // and it is exactly what the catalogue and price checks validate against. It
+  // is declared here and deliberately absent from the shared vocabulary,
+  // because on the partner surface a caller naming another partner's id is the
+  // one field that would let them freeze prices onto someone else's customers.
+  {
+    name: "list_quotes",
+    description:
+      "List B2B quotes across the platform (status, partner, buyer, totals, expiry, whether the buyer has viewed or accepted). Read.",
+    method: "GET",
+    path: "/admin/quotes",
+    queryParams: ["limit", "offset", "q", "status", "partner_id"],
+    inputSchema: obj({
+      ...PAGINATION,
+      status: STR(
+        "Filter by status: 'active' | 'accepted' | 'revoked' | 'superseded' | 'expired'."
+      ),
+      partner_id: STR("Only quotes minted for this partner."),
+    }),
+  },
+  {
+    name: "get_quote",
+    description:
+      "Get one B2B quote in full: its lines and frozen prices, freight, tax, any DDP undertaking, and the buyer's view/acceptance state. Read.",
+    method: "GET",
+    path: "/admin/quotes/:id",
+    pathParams: ["id"],
+    inputSchema: obj({ id: STR("Quote id.") }, ["id"]),
+  },
+  {
+    name: "check_quote_readiness",
+    description:
+      "Dry-run a quote for a partner: price the basket, rate the freight, resolve the tax, and report EVERY blocking problem at once — without minting anything, emailing anyone or freezing a price. Always call this before `mint_quote`.",
+    method: "POST",
+    path: "/admin/quotes/readiness",
+    /**
+     * 🔑 A POST that is not a write, declared the same way `resolve_admin_query`
+     * is: no `write` flag. The verb is a POST only because a basket does not fit
+     * in a query string — the route freezes nothing and sends nothing.
+     *
+     * On this surface every write is `sensitive` by invariant, so flagging it
+     * would put the rehearsal behind the confirm rail — which is how an
+     * assistant ends up skipping the preflight and minting blind.
+     */
+    bodyParams: [...QUOTE_MINT_READINESS_BODY_PARAMS, "partner_id"],
+    inputSchema: obj(
+      {
+        ...quoteReadinessSchemaProps(),
+        partner_id: STR("The partner being quoted for. Required on this surface."),
+      },
+      ["partner_id", "lines", "destination_country_code", "currency_code"]
+    ),
+    sideEffects:
+      "Writes nothing and sends nothing. Prices the basket live and rates freight with the carrier, so it can be slow and it does consume a carrier rate call.",
+    nextSteps: ["mint_quote"],
+  },
+  {
+    name: "mint_quote",
+    description:
+      "Mint a B2B quote on a partner's behalf: freeze prices into a price list scoped to this buyer, and email them a link they can accept and pay a deposit against. " +
+      QUOTE_MINT_WRITE_GUIDANCE,
+    method: "POST",
+    path: "/admin/quotes",
+    write: true,
+    sensitive: true,
+    bodyParams: [...QUOTE_MINT_BODY_PARAMS, "partner_id"],
+    inputSchema: obj(
+      {
+        ...quoteMintSchemaProps(),
+        partner_id: STR(
+          "The partner this quote is minted FOR. Their catalogue, their store, their carrier, their prices — required on this surface."
+        ),
+      },
+      [
+        "partner_id",
+        "buyer_email",
+        "lines",
+        "destination_country_code",
+        "currency_code",
+      ]
+    ),
+    sideEffects:
+      "Creates a customer-group-scoped price list with a real expiry, sends the buyer an email containing the only copy of the quote link, and makes the quote acceptable into a cart. Re-quoting the same buyer STACKS price lists — the cheapest active one wins (#1435), so revoke the old quote first.",
+    nextSteps: ["get_quote", "revoke_quote"],
+  },
+  {
+    name: "revoke_quote",
+    description:
+      "Revoke a quote: expire its price list and make the buyer's link 404. Use it before re-quoting the same buyer, because two active lists on one customer group tie-break to the CHEAPEST and a re-quote at a higher price would hand them the old one (#1435).",
+    method: "POST",
+    path: "/admin/quotes/:id/revoke",
+    pathParams: ["id"],
+    write: true,
+    sensitive: true,
+    /**
+     * 🔴 No `bodyParams`, and no `reason` field — the route reads no body at
+     * all. Advertising one would be the #1348 defect exactly: the dispatcher's
+     * body assembly is an allowlist walk, so the model would supply a reason,
+     * get `ok: true`, and the reason would reach nothing. Better to offer
+     * nothing than to offer something that goes nowhere.
+     */
+    inputSchema: obj({ id: STR("Quote to revoke.") }, ["id"]),
+    sideEffects:
+      "The buyer's link stops working immediately and is indistinguishable from an unknown token — they are NOT told. Tell them yourself if they have already been sent it. An already-accepted quote keeps its cart.",
   },
 ]

--- a/apps/backend/src/api/admin/mcp/lib/tool-slice.ts
+++ b/apps/backend/src/api/admin/mcp/lib/tool-slice.ts
@@ -52,8 +52,26 @@ const PREFIX_DOMAINS: ReadonlyArray<readonly [string, AdminToolDomain]> = [
   ["/admin/ops", "observability"],
   ["/admin/orders", "orders"],
   ["/admin/order-edits", "orders"],
+  // B2B quotes (#1439). Pre-order rather than post-purchase, but this is the
+  // sales slice — a quote is what becomes the cart, and the same conversation
+  // covers both.
+  ["/admin/quotes", "orders"],
   ["/admin/products", "catalog"],
   ["/admin/stores", "catalog"],
+  /**
+   * Taxonomy. Categories and collections are how the catalogue is ORGANISED,
+   * so they ride with it — an operator filing a product is having a catalogue
+   * conversation, not a separate one.
+   *
+   * ⚠️ These two families were unclassified on `main` before #1439's quote rows
+   * were added: the tools were registered without a prefix entry, which makes
+   * them unreachable from any sliced ask (the slice is what the model is given,
+   * so an unclassified tool may as well not exist). The same twelve rows were
+   * also undeclared in `route-validator-field-coverage`'s unbound list. Both
+   * gaps are the same unfinished registry addition, fixed in passing.
+   */
+  ["/admin/product-categories", "catalog"],
+  ["/admin/collections", "catalog"],
   // Customs/HS-code tooling operates on the catalogue, so it belongs to the
   // catalog slice. Without this entry the tools classify as undefined and never
   // light up for a customs question.
@@ -125,6 +143,9 @@ const DOMAIN_KEYWORDS: Record<Exclude<AdminToolDomain, "core">, string[]> = {
     "ship", "shipped", "shipping", "shipment", "deliver", "delivered",
     "delivery", "courier", "awb", "waybill", "label", "tracking", "cancel",
     "refund", "return", "line item", "line items", "checkout", "purchase",
+    // B2B quotes (#1439) — the ask that reaches `mint_quote` and its preflight.
+    "quote", "quotes", "quoted", "quotation", "rfq", "mint a quote",
+    "deposit", "moq", "bulk order", "wholesale",
   ],
   catalog: [
     "product", "products", "variant", "variants", "sku", "catalog",

--- a/apps/backend/src/api/partners/mcp/lib/__tests__/tool-slice.unit.spec.ts
+++ b/apps/backend/src/api/partners/mcp/lib/__tests__/tool-slice.unit.spec.ts
@@ -359,6 +359,10 @@ describe("partner-mcp per-ask tool slicing", () => {
       "/partners/payment-collections": "mark this payment collection as paid",
       "/partners/stores/:id/payment-providers":
         "which payment providers are enabled for my store",
+      // B2B quotes (#1439). Phrased as a partner would actually ask it, not as
+      // a keyword list — the point of this table is that the real sentence
+      // reaches the tools.
+      "/partners/quotes": "send this buyer a quote for 200 shawls",
     }
 
     const familiesInRegistry = [

--- a/apps/backend/src/api/partners/mcp/lib/registry.ts
+++ b/apps/backend/src/api/partners/mcp/lib/registry.ts
@@ -31,6 +31,20 @@ import {
   PRODUCT_SPEC_WRITE_GUIDANCE,
   productSpecSchemaProps,
 } from "../../../../modules/product-spec/tool-schema"
+/**
+ * The quote vocabulary is shared with the admin surface (#1439). Both surfaces
+ * mint, and a body list written out twice is one edit away from the two
+ * assistants believing different things about what a quote is — the shape of
+ * #1348, where an MCP row and its route validator disagreed and the field was
+ * dropped in silence.
+ */
+import {
+  QUOTE_MINT_BODY_PARAMS,
+  QUOTE_MINT_READINESS_BODY_PARAMS,
+  QUOTE_MINT_WRITE_GUIDANCE,
+  quoteMintSchemaProps,
+  quoteReadinessSchemaProps,
+} from "../../../../modules/partner-quote/tool-schema"
 // The page + block vocabulary comes from the validator that enforces it, never a copy.
 import {
   PAGE_STATUSES,
@@ -3300,5 +3314,92 @@ export const PARTNER_MCP_TOOLS: PartnerMcpToolDef[] = [
       },
       ["order_id", "items"]
     ),
+  },
+  // ===== B2B quotes (#1439) =================================================
+  //
+  // 🔑 `mint_quote` is the only tool on this surface that freezes prices into a
+  // real price list, emails a buyer and hands them something they can pay a
+  // deposit against. It is `sensitive` for that reason and not because it is
+  // hard to undo — revoking works — but because the buyer has already been
+  // told a number by the time anyone notices.
+  {
+    name: "list_quotes",
+    description:
+      "List the partner's B2B quotes (status, buyer, totals, expiry, whether the buyer has viewed or accepted). Read.",
+    method: "GET",
+    path: "/partners/quotes",
+    queryParams: ["limit", "offset", "q", "status"],
+    inputSchema: obj({
+      ...PAGINATION,
+      status: STR(
+        "Filter by status: 'active' | 'accepted' | 'revoked' | 'superseded' | 'expired'."
+      ),
+    }),
+  },
+  {
+    name: "get_quote",
+    description:
+      "Get one B2B quote in full: its lines and frozen prices, freight, tax, any DDP undertaking, and the buyer's view/acceptance state. Read.",
+    method: "GET",
+    path: "/partners/quotes/:id",
+    pathParams: ["id"],
+    inputSchema: obj({ id: STR("Quote id, e.g. 'quo_...' / '01M0...'.") }, ["id"]),
+  },
+  {
+    name: "list_quotable_designs",
+    description:
+      "List the designs this partner may quote, with the variant each one is sold through. Use it to turn a design the partner names in conversation into a line — a design that resolves to no single variant cannot be quoted and is reported here rather than at mint. Read.",
+    method: "GET",
+    path: "/partners/quotes/designs",
+    queryParams: ["limit", "offset", "q"],
+    inputSchema: obj({ ...PAGINATION }),
+  },
+  {
+    name: "check_quote_readiness",
+    description:
+      "Dry-run a quote: price the basket, rate the freight, resolve the tax, and report EVERY blocking problem at once — without minting anything, emailing anyone or freezing a price. Always call this before `mint_quote`.",
+    method: "POST",
+    path: "/partners/quotes/readiness",
+    /**
+     * 🔑 A POST that is not a write, declared the same way `resolve_admin_query`
+     * is: no `write` flag. The verb is a POST only because a basket does not fit
+     * in a query string — the route freezes nothing, sends nothing and stores
+     * nothing.
+     *
+     * That matters beyond tidiness. Flagging it `write` would put the rehearsal
+     * behind the write gate and the confirm rail, which is how an assistant
+     * ends up skipping the preflight and minting blind — and would deny it
+     * outright to a read-scoped credential, which is precisely the caller who
+     * most needs to check a quote before asking a human to mint it.
+     */
+    bodyParams: QUOTE_MINT_READINESS_BODY_PARAMS,
+    inputSchema: obj(quoteReadinessSchemaProps(), [
+      "lines",
+      "destination_country_code",
+      "currency_code",
+    ]),
+    sideEffects:
+      "Writes nothing and sends nothing. Prices the basket live and rates freight with the carrier, so it can be slow and it does consume a carrier rate call.",
+    nextSteps: ["mint_quote"],
+  },
+  {
+    name: "mint_quote",
+    description:
+      "Mint a B2B quote: freeze prices into a price list scoped to this buyer, and email them a link they can accept and pay a deposit against. " +
+      QUOTE_MINT_WRITE_GUIDANCE,
+    method: "POST",
+    path: "/partners/quotes",
+    write: true,
+    sensitive: true,
+    bodyParams: QUOTE_MINT_BODY_PARAMS,
+    inputSchema: obj(quoteMintSchemaProps(), [
+      "buyer_email",
+      "lines",
+      "destination_country_code",
+      "currency_code",
+    ]),
+    sideEffects:
+      "Creates a customer-group-scoped price list with a real expiry, sends the buyer an email containing the only copy of the quote link, and makes the quote acceptable into a cart. Re-quoting the same buyer STACKS price lists — the cheapest active one wins (#1435), so revoke the old quote first.",
+    nextSteps: ["get_quote", "list_quotes"],
   },
 ]

--- a/apps/backend/src/api/partners/mcp/lib/tool-slice.ts
+++ b/apps/backend/src/api/partners/mcp/lib/tool-slice.ts
@@ -66,6 +66,11 @@ const PREFIX_DOMAINS: ReadonlyArray<readonly [string, PartnerToolDomain]> = [
   // operator creating a return needs the reason slug, so they ride together.
   ["/partners/refund-reasons", "orders"],
   ["/partners/return-reasons", "orders"],
+  // B2B quotes (#1439). Pre-order rather than post-purchase, but this is the
+  // sales slice and it is where the partner UI puts them too — a partner
+  // quoting a buyer and a partner fulfilling that buyer's order are one
+  // conversation, and the quote is what becomes the cart.
+  ["/partners/quotes", "orders"],
 
   // ---- catalog: the partner's own product record + taxonomy ----
   ["/partners/products", "catalog"],
@@ -184,6 +189,9 @@ const DOMAIN_KEYWORDS: Record<Exclude<PartnerToolDomain, "core">, string[]> = {
     "refund", "return", "returns", "claim", "claims", "exchange", "exchanges",
     "line item", "line items", "mark as delivered", "mark delivered",
     "order edit", "order edits", "edit order", "request edit", "confirm edit",
+    // B2B quotes (#1439) — the ask that reaches `mint_quote` and its preflight.
+    "quote", "quotes", "quoted", "quotation", "rfq", "mint a quote",
+    "deposit", "moq", "bulk order", "wholesale",
   ],
   catalog: [
     "product", "products", "variant", "variants", "sku", "catalog",

--- a/apps/backend/src/lib/mcp-core/__tests__/quote-tool-field-coverage.unit.spec.ts
+++ b/apps/backend/src/lib/mcp-core/__tests__/quote-tool-field-coverage.unit.spec.ts
@@ -1,0 +1,194 @@
+/**
+ * The quote tools' vocabulary, checked against the validators that enforce it
+ * (#1439, #1348).
+ *
+ * ## Why this is not covered by the file next door
+ *
+ * `route-validator-field-coverage.unit.spec.ts` resolves each tool's real
+ * validator out of `middlewares.ts` and compares it to `bodyParams`. That is
+ * the important check and it now covers these tools too. What it cannot see is
+ * everything ROUND the body list:
+ *
+ * - `quoteMintSchemaProps()` is a separate object. A field can be in
+ *   `bodyParams` and have no JSON-Schema property, in which case the model is
+ *   never told it exists — and the #1371 required-args gate is blind to it,
+ *   because that gate reads the tool's own `required` list, which is precisely
+ *   the thing that would be wrong (#1394).
+ * - The preflight body is `omit()`ed from the mint shape in the validator and
+ *   filtered from the mint list here. Two subtractions, done in two places,
+ *   that must produce the same set — or the preflight validates a shape the
+ *   mint rejects and tells a partner their quote is ready before refusing it.
+ * - `partner_id` must be on the admin tools and must NOT be on the partner
+ *   ones. A partner naming another partner's id is the single field that would
+ *   let them freeze prices onto someone else's customer group.
+ *
+ * ## The failure mode being guarded
+ *
+ * The dispatcher's body assembly is a pure allowlist walk. A field the model
+ * supplies that is missing from `bodyParams` is dropped in **silence**: no
+ * error, `ok: true`, and a quote minted on terms nobody chose. `dry_run` cannot
+ * reveal it either, because the plan is rendered from the already-picked body.
+ * Every assertion below exists because that failure is invisible at runtime.
+ */
+
+import { PARTNER_MCP_TOOLS } from "../../../api/partners/mcp/lib/registry"
+import { ADMIN_MCP_TOOLS } from "../../../api/admin/mcp/lib/registry"
+import {
+  PartnerMintQuoteShape,
+  QuoteReadinessShape,
+} from "../../../api/partners/quotes/validators"
+import {
+  QUOTE_MINT_BODY_PARAMS,
+  QUOTE_MINT_READINESS_BODY_PARAMS,
+  quoteMintSchemaProps,
+  quoteReadinessSchemaProps,
+} from "../../../modules/partner-quote/tool-schema"
+import type { McpToolDef } from "../types"
+
+const find = (tools: McpToolDef[], name: string): McpToolDef => {
+  const tool = tools.find((t) => t.name === name)
+  if (!tool) {
+    throw new Error(`tool ${name} is not registered`)
+  }
+  return tool
+}
+
+/** Keys the Zod schema actually accepts, read off the schema itself. */
+const shapeKeys = (schema: any): string[] => Object.keys(schema.shape)
+
+describe("quote MCP tools — the body vocabulary matches its validators (#1439)", () => {
+  describe("the mint body", () => {
+    it("advertises exactly what the validator accepts", () => {
+      // Both directions. A stray is a guaranteed 400 (`zodValidator` forces
+      // `.strict()`); a missing one is the silent strip.
+      expect([...QUOTE_MINT_BODY_PARAMS].sort()).toEqual(
+        shapeKeys(PartnerMintQuoteShape).sort()
+      )
+    })
+
+    it("describes every field it forwards", () => {
+      // A field in `bodyParams` with no schema property is one the model is
+      // never told about, so it can only ever be sent by accident.
+      const described = Object.keys(quoteMintSchemaProps())
+      expect([...QUOTE_MINT_BODY_PARAMS].sort()).toEqual(described.sort())
+    })
+
+    it("describes nothing it cannot forward", () => {
+      for (const key of Object.keys(quoteMintSchemaProps())) {
+        expect(QUOTE_MINT_BODY_PARAMS).toContain(key)
+      }
+    })
+  })
+
+  describe("the readiness body", () => {
+    it("subtracts exactly what the validator subtracts", () => {
+      /**
+       * 🔴 The two subtractions are done in different files by different
+       * mechanisms — `QuoteReadinessShape.omit({...})` there, a `filter` here.
+       * This is the only thing keeping them equal. If the validator ever keeps
+       * a field this drops, the preflight passes a basket the mint then
+       * refuses; the partner is told they are ready and then told they are not.
+       */
+      expect([...QUOTE_MINT_READINESS_BODY_PARAMS].sort()).toEqual(
+        shapeKeys(QuoteReadinessShape).sort()
+      )
+    })
+
+    it("keeps freight_override_amount, which decides whether the lane must be rateable", () => {
+      // Dropping it would make the preflight refuse exactly the cross-border
+      // quotes an override exists to unblock.
+      expect(QUOTE_MINT_READINESS_BODY_PARAMS).toContain("freight_override_amount")
+    })
+
+    it("describes exactly the fields it forwards", () => {
+      expect([...QUOTE_MINT_READINESS_BODY_PARAMS].sort()).toEqual(
+        Object.keys(quoteReadinessSchemaProps()).sort()
+      )
+    })
+  })
+
+  describe.each([
+    ["partner", PARTNER_MCP_TOOLS as McpToolDef[], false],
+    ["admin", ADMIN_MCP_TOOLS as McpToolDef[], true],
+  ])("the %s surface", (_surface, tools, isAdmin) => {
+    it("registers the four read/write quote tools", () => {
+      for (const name of [
+        "list_quotes",
+        "get_quote",
+        "check_quote_readiness",
+        "mint_quote",
+      ]) {
+        expect(find(tools, name)).toBeTruthy()
+      }
+    })
+
+    it("forwards the shared mint vocabulary", () => {
+      const mint = find(tools, "mint_quote")
+      for (const key of QUOTE_MINT_BODY_PARAMS) {
+        expect(mint.bodyParams).toContain(key)
+      }
+    })
+
+    it("offers every forwarded field in its input schema", () => {
+      /**
+       * The #1348 direction: `bodyParams ⊆ inputSchema`. A key the dispatcher
+       * would forward but the model is never shown is unreachable — the tool
+       * cannot be called correctly, and nothing says so.
+       */
+      for (const name of ["mint_quote", "check_quote_readiness"]) {
+        const tool = find(tools, name)
+        const props = Object.keys((tool.inputSchema as any).properties ?? {})
+        for (const key of tool.bodyParams ?? []) {
+          expect(props).toContain(key)
+        }
+      }
+    })
+
+    it("marks minting sensitive, and the rehearsal not", () => {
+      // Minting emails a buyer a number. The preflight writes nothing, and a
+      // confirm-gate on it is how an assistant skips it and mints blind.
+      expect(find(tools, "mint_quote").sensitive).toBe(true)
+      expect(find(tools, "check_quote_readiness").sensitive).toBeFalsy()
+    })
+
+    it(
+      isAdmin
+        ? "requires partner_id, because an admin has no partner of their own"
+        : "🔴 never accepts partner_id — it would let a partner price onto another's customers",
+      () => {
+        for (const name of ["mint_quote", "check_quote_readiness"]) {
+          const tool = find(tools, name)
+          const props = Object.keys((tool.inputSchema as any).properties ?? {})
+          if (isAdmin) {
+            expect(tool.bodyParams).toContain("partner_id")
+            expect(props).toContain("partner_id")
+            expect((tool.inputSchema as any).required).toContain("partner_id")
+          } else {
+            expect(tool.bodyParams).not.toContain("partner_id")
+            expect(props).not.toContain("partner_id")
+          }
+        }
+      }
+    )
+
+    it("requires the fields a quote cannot be built without", () => {
+      const required = (find(tools, "mint_quote").inputSchema as any).required
+      for (const key of [
+        "buyer_email",
+        "lines",
+        "destination_country_code",
+        "currency_code",
+      ]) {
+        expect(required).toContain(key)
+      }
+    })
+  })
+
+  it("only the admin surface can revoke", () => {
+    // Revocation reaches across partners; it is not a partner's own tool.
+    expect(find(ADMIN_MCP_TOOLS as McpToolDef[], "revoke_quote").sensitive).toBe(true)
+    expect(
+      (PARTNER_MCP_TOOLS as McpToolDef[]).find((t) => t.name === "revoke_quote")
+    ).toBeUndefined()
+  })
+})

--- a/apps/backend/src/lib/mcp-core/__tests__/route-validator-field-coverage.unit.spec.ts
+++ b/apps/backend/src/lib/mcp-core/__tests__/route-validator-field-coverage.unit.spec.ts
@@ -68,11 +68,37 @@ import { buildToolInputSchema } from "../schema"
  * A tool landing here is NOT proven safe. It is proven unchecked-by-this-file.
  */
 const NO_ROUTE_VALIDATOR = new Set<string>([
+  /**
+   * The revoke route takes NO body — it works entirely off the `:id` in the
+   * path. Nothing to bind, and nothing advertised: the tool declares no
+   * `bodyParams`, because a field the route never reads would be accepted,
+   * reported `ok: true` and dropped (#1348). Verified by reading the handler,
+   * not inferred from the absence of a matcher.
+   */
+  "admin:revoke_quote",
   // Core routes: core registers its own validator, so it never appears in this
   // repo's middlewares config. The four product/variant ones are contract-
   // checked against core's imported validators in the sibling spec.
   "admin:create_product",
   "admin:update_product",
+  /**
+   * Category and collection tools wrap core's own `/admin/product-categories`
+   * and `/admin/collections` routes, so core registers the validators and they
+   * never appear in this repo's middlewares config — the same reason as the
+   * product rows above.
+   *
+   * ⚠️ These six were failing this test on `main` before #1439's quote rows
+   * were added: they were registered without being declared here, which is
+   * exactly the "small commitment" this list exists to force. Declared rather
+   * than deleted, because the tools work — what was missing was the note
+   * saying nobody had bound them.
+   */
+  "admin:create_product_category",
+  "admin:update_product_category",
+  "admin:set_category_products",
+  "admin:create_product_collection",
+  "admin:update_product_collection",
+  "admin:set_collection_products",
   "admin:update_product_variant",
   "admin:create_product_for_partner",
   "admin:update_customer",

--- a/apps/backend/src/lib/mcp-scope.ts
+++ b/apps/backend/src/lib/mcp-scope.ts
@@ -153,7 +153,14 @@ export const isMcpMachinePrincipal = (principal: McpPrincipal): boolean =>
  *   - `/admin/assistant/vision` is a POST that only looks at an already-stored
  *     image (`read_image`). It is POST because the image reference goes in the
  *     body, not because anything changes.
+ *   - `/admin/quotes/readiness` is the quote preflight (`check_quote_readiness`,
+ *     #1445). POST because a basket does not fit in a query string; it freezes
+ *     no prices, emails nobody and stores nothing. Reachable by a read-scoped
+ *     credential on purpose — that caller is exactly the one who should be able
+ *     to check a quote before asking a human to mint it. ⚠️ It is not free: it
+ *     prices live and asks a carrier to rate the lane, so it costs a rate call.
  *
+
  * An invariant test asserts every non-GET tool that is not flagged `write` has
  * its path listed here — so a future read-only POST tool fails the suite instead
  * of silently 403ing for read-only credentials.
@@ -162,6 +169,7 @@ export const MCP_SCOPE_EXEMPT_ADMIN_PATHS: readonly string[] = [
   "/admin/mcp",
   "/admin/mcp/resolve-query",
   "/admin/assistant/vision",
+  "/admin/quotes/readiness",
 ]
 
 export type ResolvedMcpScope = {

--- a/apps/backend/src/modules/partner-quote/tool-schema.ts
+++ b/apps/backend/src/modules/partner-quote/tool-schema.ts
@@ -221,3 +221,46 @@ export const quoteMintSchemaProps = () => ({
       "Where the hand-typed freight came from, e.g. 'DHL Express Worldwide, Srinagar to Berlin, 3.05 kg, quoted 24 Aug'. Always send it with `freight_override_amount`.",
   },
 })
+
+/**
+ * Fields the readiness preflight has no use for (#1445).
+ *
+ * 🔑 This list mirrors `QuoteReadinessShape.omit({...})` in the partner
+ * validator, and `quote-tool-field-coverage.unit.spec.ts` asserts the two agree
+ * by importing that schema. Restating it is safe only because the restatement
+ * is checked — if the validator drops or keeps a field and this does not, the
+ * test fails rather than the preflight silently validating a shape the mint
+ * rejects.
+ *
+ * The reasoning behind each: the buyer's identity and note are who they are,
+ * not what the basket costs; `ttl_days` and `deposit_pct` are terms, and a dry
+ * run freezes nothing to apply them to; `freight_basis` is evidence for a
+ * frozen row. `freight_override_amount` is deliberately NOT here — it decides
+ * whether the lane has to be rateable, so a preflight without it would refuse
+ * exactly the cross-border quotes an override exists to unblock.
+ */
+export const QUOTE_READINESS_OMITTED_PARAMS = [
+  "buyer_email",
+  "recipient_name",
+  "recipient_company",
+  "buyer_tax_id",
+  "buyer_tax_id_type",
+  "partner_note",
+  "ttl_days",
+  "deposit_pct",
+  "freight_basis",
+] as const
+
+/** The preflight body, DERIVED from the mint body so a new field reaches both. */
+export const QUOTE_MINT_READINESS_BODY_PARAMS = QUOTE_MINT_BODY_PARAMS.filter(
+  (k) => !(QUOTE_READINESS_OMITTED_PARAMS as readonly string[]).includes(k)
+)
+
+/** The preflight's schema properties, derived the same way for the same reason. */
+export const quoteReadinessSchemaProps = () => {
+  const props: Record<string, any> = quoteMintSchemaProps()
+  for (const key of QUOTE_READINESS_OMITTED_PARAMS) {
+    delete props[key]
+  }
+  return props
+}


### PR DESCRIPTION
Closes the MCP item on the #1439 handoff list.

## The gap

`modules/partner-quote/tool-schema.ts` has carried the quote vocabulary since S8 — 24 body params, their JSON-Schema properties, the write guidance, and a docblock promising a coverage test. **No registry row ever imported it.** Neither assistant could see a quote, let alone mint one.

## Tools

| Tool | Partner | Admin |
|---|:-:|:-:|
| `list_quotes` / `get_quote` | ✅ | ✅ |
| `check_quote_readiness` | ✅ | ✅ |
| `mint_quote` | ✅ | ✅ |
| `list_quotable_designs` | ✅ | — |
| `revoke_quote` | — | ✅ |

`revoke_quote` is admin-only because revocation reaches across partners.

## `partner_id` is the whole difference between the surfaces

An admin has no partner of their own, so it is required. On the partner surface it must **never** be accepted — a partner naming another partner's id is the single field that would let them freeze prices onto someone else's customer group. So it is declared beside each admin row and kept out of the shared vocabulary entirely, and the test asserts both directions.

## 🔴 Three defects the existing invariant suites caught

**`revoke_quote` advertised a `reason` field.** The route reads no body at all. The model would have supplied one, been told `ok: true`, and the reason would have reached nothing — #1348 exactly. Removed rather than plumbed: better to offer nothing than something that goes nowhere. Declared in `NO_ROUTE_VALIDATOR` with the reason, verified by reading the handler rather than inferred from a missing matcher.

**`check_quote_readiness` was flagged `write: true`.** Every admin write is `sensitive` by invariant, so that would have put the *rehearsal* behind the confirm rail — the surest way to make an assistant skip the preflight and mint blind — and denied it outright to a read-scoped credential, which is precisely the caller who should be able to check a quote before asking a human to mint it. It is now a read-only POST declared the way `resolve_admin_query` is, with its path added to `MCP_SCOPE_EXEMPT_ADMIN_PATHS` — whose docblock had already anticipated this exact case.

**The readiness body is subtracted twice, in two places.** `QuoteReadinessShape.omit({...})` in the validator, a `filter` here. If they drift, the preflight validates a shape the mint rejects — telling a partner their quote is ready and then refusing it. Now derived from the mint list and asserted against `QuoteReadinessShape` itself.

## Coverage

The generic `route-validator-field-coverage` spec now covers these tools automatically — it resolves each one's real Zod validator out of `middlewares.ts` and compares it to `bodyParams`. The new `quote-tool-field-coverage.unit.spec.ts` (19 tests) covers what that one structurally cannot see: the JSON-Schema property object, the two-place readiness subtraction, and the `partner_id` asymmetry.

## Fixed in passing — both red on `main` before this branch

Both are the same unfinished registry addition, confirmed red against a clean stash before I touched them:

- **6** category/collection tools undeclared in `route-validator-field-coverage`'s unbound list. They wrap core's own routes, so core registers the validators — a legitimate declaration, just never written down.
- **12** unclassified in the admin slicer. An unclassified tool is absent from every sliced ask, so it may as well not be registered.

## Verification

| | Test Suites | Tests |
|---|---|---|
| `main` | **5 failed** / 387 | **7 failed** / 4456 |
| this branch | **3 failed** / 388 | **4 failed** / 4476 |

Two red suites removed, 20 tests added. The three remaining are pre-existing and unrelated (`brief-shaper`, `seed-additional-email-templates`, `build-email-data`).

- All 16 MCP unit suites: **369/369**
- `pnpm check:prod-build`: green

⚠️ Not verified: an end-to-end `tools/call` against a running MCP surface. Per `reference_admin_mcp_already_works_with_secret_key`, `tools/list` succeeding proves nothing about a call — so the claim here is scoped to what the contract tests actually assert: the advertised vocabulary matches the validators the routes register. Worth one real `mint_quote` dry-run before relying on it.

Independent of #1493 (storefront only) — no shared files.