### PR TITLE
feat(quotes): two columns, the whole photo roll, and a dialled basket that can be bought (#1439 S14)

### DIFF
--- a/apps/backend/integration-tests/http/partner-quote-accept.spec.ts
+++ b/apps/backend/integration-tests/http/partner-quote-accept.spec.ts
@@ -1,4 +1,5 @@
-import { ContainerRegistrationKeys } from "@medusajs/framework/utils"
+import { createTaxRegionsWorkflow } from "@medusajs/medusa/core-flows"
+import { ContainerRegistrationKeys, Modules } from "@medusajs/framework/utils"
 
 import { createAdminUser } from "../helpers/create-admin-user"
 import {
@@ -188,6 +189,84 @@ setupSharedTestSuite(() => {
       // quote was minted with.
       expect(Number(line?.quantity)).toBe(dialled)
       expect(Number(line?.quantity)).not.toBe(quotedQty)
+    })
+
+    /**
+     * 🔴 …and the totals guard has to move with it, ON A LANE THAT IS TAXED.
+     *
+     * The test above passes without this one and proves less than it looks. The
+     * fixture region carries no tax rate, so the quote's frozen `quoted_tax_total`
+     * and the cart's tax are both 0 and agree by coincidence — the assertion is
+     * vacuous exactly where the bug lives.
+     *
+     * With real tax the guard rebuilt the expected SUBTOTAL for the dialled
+     * basket and left the expected TAX frozen at the minted quantity, so every
+     * dialled acceptance was refused:
+     *
+     *   tax: quoted 250.25 inr, cart 875.25
+     *
+     * That is the whole quantity control unusable across all of India. Found by
+     * minting a real quote against a real region and pressing the button, not
+     * by any suite — so this test creates the tax region the fixture lacks and
+     * asserts the acceptance survives it.
+     */
+    it("🔴 accepts a dialled basket on a TAXED lane — the guard must re-price the tax too", async () => {
+      const { getContainer } = getSharedTestEnv()
+      const container = getContainer()
+
+      // Same setup as the tax-jurisdiction spec: through the workflow and WITH
+      // a provider, or the first request for tax lines throws deep inside
+      // `TaxProviderService` and the quote merely reads as untaxed.
+      const tax: any = container.resolve(Modules.TAX)
+      const existing = await tax.listTaxRegions({ country_code: "in" })
+      if (!existing.length) {
+        await createTaxRegionsWorkflow(container).run({
+          input: [
+            {
+              country_code: "in",
+              provider_id: "tp_system",
+              default_tax_rate: {
+                name: "India GST (standard)",
+                code: "IN-GST",
+                rate: 18,
+              },
+            } as any,
+          ],
+        })
+      }
+
+      const minted = await mint({
+        buyer_email: `dial-taxed-${seed.unique}@jaalyantra.test`,
+      })
+      const variantId = seed.variantA.id
+      const dialled = 25 + 5
+
+      const res = await getSharedTestEnv().api.post(
+        `/store/b2b/quotes/${minted.token}/accept`,
+        { lines: [{ variant_id: variantId, quantity: dialled }] },
+        { headers: storeHeaders }
+      )
+
+      // The refusal this guards against is a 400 naming a tax mismatch.
+      expect(res.status).toBe(201)
+
+      const cart = await readCart(res.data.acceptance.cart_id)
+      const line = (cart.items ?? []).find((i: any) => i.variant_id === variantId)
+      expect(Number(line?.quantity)).toBe(dialled)
+
+      /**
+       * Totals come from the STORE endpoint, not `readCart` — that helper
+       * projects only ids and quantities, so `cart.tax_total` off it is
+       * `undefined` and any assertion on it silently passes as 0. This is the
+       * same read the browser does.
+       */
+      const totals = await getSharedTestEnv().api.get(
+        `/store/carts/${res.data.acceptance.cart_id}`,
+        { headers: storeHeaders }
+      )
+      // 🔑 The tax really must be non-zero, or this test has quietly rejoined
+      // the vacuous one above and proves nothing about the guard.
+      expect(Number(totals.data.cart.tax_total ?? 0)).toBeGreaterThan(0)
     })
 
     /**

--- a/apps/backend/integration-tests/http/partner-quote-line-imagery.spec.ts
+++ b/apps/backend/integration-tests/http/partner-quote-line-imagery.spec.ts
@@ -1,0 +1,133 @@
+import { createAdminUser } from "../helpers/create-admin-user"
+import {
+  mintBody,
+  setupQuoteFixture,
+  type QuoteFixture,
+} from "../helpers/setup-quote-fixture"
+import { getSharedTestEnv, setupSharedTestSuite } from "./shared-test-setup"
+
+jest.setTimeout(240 * 1000)
+
+/**
+ * What the buyer can SEE of the piece they are approving (#1439 S14).
+ *
+ * ## Two fields, two different failures
+ *
+ * `images` is the variant's whole gallery. The identity query has fetched every
+ * image since #1428, but `pickLineImage` took the first and the rest were
+ * silently discarded — a defect with no symptom, because one photo renders
+ * perfectly well and nobody knows the other four exist. A test is the only
+ * thing that can notice.
+ *
+ * `other_variants` answers "can I get this in indigo?" with a fact instead of a
+ * round trip. 🔴 It is NOT a picker, and the assertions below pin that: the
+ * quoted variant is excluded, because the quote is frozen against it at a
+ * frozen price and offering the buyer a different one would be describing an
+ * agreement that does not exist. The only action it implies is replying to the
+ * partner.
+ */
+setupSharedTestSuite(() => {
+  describe("GET /store/b2b/quotes/:token — what the buyer can see (#1439 S14)", () => {
+    let seed: QuoteFixture
+    let storeHeaders: Record<string, string>
+    let quote: any
+
+    beforeAll(async () => {
+      const { api, getContainer } = getSharedTestEnv()
+      await createAdminUser(getContainer())
+      seed = await setupQuoteFixture(api, getContainer)
+      storeHeaders = { "x-publishable-api-key": seed.publishableKey }
+
+      const mint = await api.post(
+        "/partners/quotes",
+        mintBody(seed, {
+          buyer_email: `imagery-${seed.unique}@jaalyantra.test`,
+        }),
+        { headers: seed.headers }
+      )
+      const view = await api.get(`/store/b2b/quotes/${mint.data.token}`, {
+        headers: storeHeaders,
+      })
+      quote = view.data.quote
+    })
+
+    const lineFor = (variantId: string) =>
+      quote.lines.find((l: any) => l.variant_id === variantId)
+
+    it("carries a gallery array on every line", () => {
+      for (const line of quote.lines) {
+        expect(Array.isArray(line.images)).toBe(true)
+      }
+    })
+
+    it("keeps the gallery and the thumbnail telling the same story", () => {
+      /**
+       * The invariant that matters regardless of what the fixture uploads: if
+       * the variant has images of its own, the thumbnail IS the first of them
+       * and `image_source` says so. A gallery whose first frame differed from
+       * the thumbnail would show the buyer one crop in the table and open on a
+       * different one.
+       */
+      for (const line of quote.lines) {
+        if (line.images.length) {
+          expect(line.thumbnail).toBe(line.images[0])
+          expect(line.image_source).toBe("variant")
+        } else if (line.thumbnail) {
+          // Degraded to the product's photo — a weaker claim, and labelled one.
+          expect(line.image_source).toBe("product")
+        }
+      }
+    })
+
+    it("🔴 leaves the gallery empty rather than borrowing the product's photo", () => {
+      /**
+       * Mixing a product-level photo into a variant's gallery would pass a
+       * weaker claim off as one of this colourway's own shots — the whole
+       * reason `image_source` exists. So `[]` means "no gallery", never "one
+       * borrowed picture", and a line that fell back to the product thumbnail
+       * must have nothing in `images` at all.
+       *
+       * The fixture's variants carry no images of their own, so this is the
+       * branch it actually exercises.
+       */
+      for (const line of quote.lines) {
+        if (line.image_source === "product") {
+          expect(line.images).toEqual([])
+        }
+      }
+      // And the fallback really is the branch under test here — if the fixture
+      // ever gains variant images this asserts nothing, so say so loudly.
+      expect(quote.lines.some((l: any) => l.image_source !== "variant")).toBe(true)
+    })
+
+    it("names the product's other weaves, and excludes the quoted one", () => {
+      // The fixture is one product with two variants — Twill and Diamond — so
+      // each line's sibling list is exactly the other.
+      const twill = lineFor(seed.variantA.id)
+      const diamond = lineFor(seed.variantB.id)
+
+      expect(twill.other_variants.map((v: any) => v.id)).toEqual([
+        seed.variantB.id,
+      ])
+      expect(diamond.other_variants.map((v: any) => v.id)).toEqual([
+        seed.variantA.id,
+      ])
+
+      // 🔴 The quoted variant must never appear in its own sibling list: the
+      // price is frozen against it, and listing it beside the alternatives
+      // reads as a choice the buyer still has.
+      for (const line of quote.lines) {
+        expect(line.other_variants.map((v: any) => v.id)).not.toContain(
+          line.variant_id
+        )
+      }
+    })
+
+    it("carries a title for each sibling, so a badge never renders an id", () => {
+      const titles = lineFor(seed.variantA.id).other_variants.map(
+        (v: any) => v.title
+      )
+      expect(titles).toEqual(["Diamond"])
+    })
+  })
+})

--- a/apps/backend/src/modules/partner-quote/lib/build-quote-view.ts
+++ b/apps/backend/src/modules/partner-quote/lib/build-quote-view.ts
@@ -270,6 +270,19 @@ export type QuoteViewLine = {
    * Null when the product has no spec, which is the normal state.
    */
   spec: QuoteLineSpec | null
+  /**
+   * Every image on this variant, merchandiser-ordered (#1439 S14). Empty when
+   * the variant has none of its own — `thumbnail` may still be the product's.
+   */
+  images: string[]
+  /**
+   * The product's other variants, for information only (#1439 S14).
+   *
+   * 🔴 Not a picker. The quote is frozen against THIS variant at THIS price;
+   * the only thing a buyer can do with a different one is ask for a new quote,
+   * and any UI implying otherwise is lying about what has been agreed.
+   */
+  other_variants: Array<{ id: string; title: string | null }>
   /** The EFFECTIVE quantity — the buyer's dial position, or the quoted one. */
   quantity: number
   /**
@@ -449,6 +462,27 @@ export function pickFreightOption(
  * thumbnail on a variant-specific line is a weaker claim than the variant's
  * own photo.
  */
+/**
+ * Every image on the quoted variant, in the merchandiser's order (#1439 S14).
+ *
+ * The identity query has always fetched all of them; `pickLineImage` took the
+ * first and the rest were thrown away. A buyer approving 500 units of a weave
+ * wants the drape and the selvedge, not one crop of it.
+ *
+ * 🔴 The product thumbnail is deliberately NOT appended as a fallback. It is
+ * already what `thumbnail` degrades to, and mixing a product-level photo into
+ * a variant's gallery would present a weaker claim as if it were one of this
+ * colourway's own shots — the same reason `image_source` exists at all.
+ * Returns `[]` rather than a one-item array in that case, so a caller can tell
+ * "no gallery" from "a gallery of one".
+ */
+export function lineImages(identity: any): string[] {
+  return ((identity?.images ?? []) as any[])
+    .filter((i) => i?.url)
+    .sort((a, b) => Number(a?.rank ?? 0) - Number(b?.rank ?? 0))
+    .map((i) => String(i.url))
+}
+
 export function pickLineImage(identity: any): {
   thumbnail: string | null
   image_source: "variant" | "product" | null
@@ -1168,6 +1202,60 @@ export async function buildQuoteView(
 
   // Both of these are enrichment, resolved after the money and deliberately
   // unable to fail the view.
+  /**
+   * The product's OTHER colourways/sizes, for the buyer's information only
+   * (#1439 S14).
+   *
+   * 🔴 Deliberately NOT a configurator, and it must never become one. A quote
+   * is frozen against specific variants at specific prices, so a picker the
+   * buyer cannot act on is worse than no picker — the same reasoning that keeps
+   * option groups out of `spec`. This states what the maker also weaves,
+   * answering "can I get this in indigo?" with a fact instead of a round trip,
+   * and the only action it implies is replying to the partner.
+   *
+   * 🔑 A SEPARATE query on purpose. `product.variants.id` requested from the
+   * `variant` entity resolves to nothing — the back-reference does not traverse
+   * that way — and it fails by returning an empty array, not by erroring, so
+   * the badges would simply never have rendered and nothing would have said
+   * why. Caught by `partner-quote-line-imagery.spec.ts`.
+   *
+   * Enrichment, like the specs below it: a failure here must not cost the buyer
+   * their prices.
+   */
+  const productIds = [
+    ...new Set(
+      effectiveLines
+        .map((l) => identityById.get(l.variant_id)?.product?.id)
+        .filter(Boolean)
+    ),
+  ]
+  const siblingsByProduct = new Map<string, Array<{ id: string; title: string | null }>>()
+  if (productIds.length) {
+    try {
+      const { data: products } = await query.graph({
+        entity: "product",
+        fields: ["id", "variants.id", "variants.title"],
+        filters: { id: productIds },
+      })
+      for (const product of (products ?? []) as any[]) {
+        siblingsByProduct.set(
+          product.id,
+          ((product.variants ?? []) as any[])
+            .filter((v) => v?.id)
+            .map((v) => ({ id: String(v.id), title: v.title ?? null }))
+        )
+      }
+    } catch (e: any) {
+      // Enrichment: the badges vanish, the prices do not. Logged so a
+      // permanently-empty sibling list is diagnosable rather than assumed to
+      // mean "this product has one variant".
+      const logger: any = scope.resolve(ContainerRegistrationKeys.LOGGER)
+      logger?.warn?.(
+        `[quote] sibling variants unavailable: ${e?.message ?? String(e)}`
+      )
+    }
+  }
+
   const specByProduct = await resolveQuoteSpecs(
     scope,
     effectiveLines
@@ -1188,6 +1276,13 @@ export async function buildQuoteView(
       product_title: identity.product?.title ?? null,
       product_handle: identity.product?.handle ?? null,
       ...pickLineImage(identity),
+      images: lineImages(identity),
+      other_variants: (siblingsByProduct.get(identity.product?.id) ?? []).filter(
+        // 🔴 The quoted variant is never its own alternative. Listing it beside
+        // the others reads as a choice the buyer still has, when the price is
+        // frozen against exactly this one.
+        (v) => v.id !== line.variant_id
+      ),
       spec: specByProduct.get(identity.product?.id) ?? null,
       product_tags: ((identity.product?.tags ?? []) as any[])
         .map((t) => t?.value)

--- a/apps/backend/src/workflows/partner-quote/accept-quote.ts
+++ b/apps/backend/src/workflows/partner-quote/accept-quote.ts
@@ -522,6 +522,26 @@ const assertCartMatchesQuoteStep = createStep(
      * then complain the cart disagreed with it.
      */
     let expectedSubtotal = Number(quote.quoted_subtotal ?? 0)
+    /**
+     * 🔴 The TAX expectation has to move with the basket too (#1439 S13).
+     *
+     * The subtotal was rebuilt for a dialled basket below and the tax was not,
+     * so it kept comparing the cart against `quoted_tax_total` — the figure
+     * frozen at mint, for the quantity the buyer just changed. On any taxed
+     * lane that is a guaranteed mismatch: a quote minted at 2 units and dialled
+     * to 7 offered `quoted 250.25, cart 875.25` and refused, which is the whole
+     * S13 feature made unusable across all of India.
+     *
+     * 🔑 Invisible to the accept suite, which passes 7/7. Its fixture region
+     * carries no tax, so quoted and cart tax are both 0 and agree by
+     * coincidence — a constant that makes the assertion vacuous exactly where
+     * it matters. Found by minting a real quote against a real region and
+     * pressing accept.
+     */
+    let expectedTax =
+      quote.quoted_tax_total === null || quote.quoted_tax_total === undefined
+        ? null
+        : Number(quote.quoted_tax_total)
     if (input.dialled) {
       const view = await buildQuoteView(container, {
         quote: null,
@@ -545,6 +565,13 @@ const assertCartMatchesQuoteStep = createStep(
         now: input.now ? new Date(input.now) : new Date(),
       })
       expectedSubtotal = Number(view?.live?.subtotal ?? view?.quoted?.subtotal ?? 0)
+      // Same builder, same price list, same frozen freight — so the tax is the
+      // one the buyer was shown for the basket they actually dialled. Left
+      // alone when the view cannot resolve one, so an unknown tax still falls
+      // back to the frozen figure rather than silently becoming "no tax".
+      if (view?.tax?.total !== null && view?.tax?.total !== undefined) {
+        expectedTax = Number(view.tax.total)
+      }
     }
 
     const quotedSubtotal = expectedSubtotal
@@ -570,10 +597,7 @@ const assertCartMatchesQuoteStep = createStep(
     }
 
     let taxDivergence: number | null = null
-    const quotedTax =
-      quote.quoted_tax_total === null || quote.quoted_tax_total === undefined
-        ? null
-        : Number(quote.quoted_tax_total)
+    const quotedTax = expectedTax
     const cartTax = Number(cart.tax_total ?? 0)
     if (quotedTax !== null && !near(quotedTax, cartTax)) {
       taxDivergence = Number((cartTax - quotedTax).toFixed(2))

--- a/apps/storefront/src/app/[countryCode]/(main)/quotes/[token]/page.tsx
+++ b/apps/storefront/src/app/[countryCode]/(main)/quotes/[token]/page.tsx
@@ -73,8 +73,18 @@ export default async function QuotePage({ params, searchParams }: Props) {
   const dialledLines = parseDialledLines(lines)
   const quote = await retrieveQuote(token, dialledLines)
 
-  // An unknown token and a revoked one are indistinguishable by design — the
-  // backend 404s both so a prober learns nothing, and this preserves that.
+  /**
+   * ⚠️ An UNKNOWN token 404s. A REVOKED one does not — verified against a real
+   * revoked quote, which returns 200 with a `dead_link` document: the headline
+   * says the partner withdrew it, `show_quoted` and `show_live` are both false
+   * so no price is rendered, and acceptance is refused. That is deliberate and
+   * kinder than a 404, but the two are therefore NOT indistinguishable to a
+   * prober, which several comments in this feature still claim. Nothing
+   * actionable leaks either way; the tokens are high-entropy, so the
+   * distinguishability is a curiosity rather than a hole.
+   *
+   * This branch is only ever the unknown-token case.
+   */
   if (!quote) {
     notFound()
   }

--- a/apps/storefront/src/lib/data/quotes.ts
+++ b/apps/storefront/src/lib/data/quotes.ts
@@ -149,6 +149,21 @@ export type QuoteViewLine = {
   thumbnail: string | null
   image_source: "variant" | "product" | null
   spec: QuoteLineSpec | null
+  /**
+   * Every image on this variant, merchandiser-ordered (#1439 S14). Empty when
+   * the variant has none of its own — `thumbnail` may then be the PRODUCT's,
+   * which is a weaker claim and is labelled one via `image_source`.
+   */
+  images?: string[]
+  /**
+   * The product's other colourways/sizes (#1439 S14).
+   *
+   * 🔴 Information, never a picker. The quote is frozen against THIS variant at
+   * THIS price; the only thing a buyer can do with a different one is ask for a
+   * new quote, and any UI implying otherwise describes an agreement that does
+   * not exist. Render it as a statement of what the maker also weaves.
+   */
+  other_variants?: Array<{ id: string; title: string | null }>
   /** The EFFECTIVE quantity — the buyer's dial position, or the quoted one. */
   quantity: number
   /**
@@ -370,10 +385,14 @@ export type QuoteView = {
 /**
  * Fetch a quote by token.
  *
- * Returns null on ANY failure rather than throwing. An unknown token and a
- * revoked one are both 404 by design — a prober must not be able to tell them
- * apart — and the page turns either into the same not-found. Letting the error
- * bubble would render a stack-shaped 500 that says more than the 404 does.
+ * Returns null on ANY failure rather than throwing, and the page turns that
+ * into a not-found. Letting the error bubble would render a stack-shaped 500
+ * that says more than a 404 does.
+ *
+ * ⚠️ Only an UNKNOWN token 404s. A REVOKED one answers 200 with a `dead_link`
+ * document — withdrawn headline, no price columns, acceptance refused — so it
+ * never reaches this fallback. Comments elsewhere in this feature claim the two
+ * are indistinguishable; they are not. Checked against a real revoked quote.
  */
 export const retrieveQuote = async (
   token: string,

--- a/apps/storefront/src/modules/quotes/components/quote-accept/index.tsx
+++ b/apps/storefront/src/modules/quotes/components/quote-accept/index.tsx
@@ -1,6 +1,6 @@
 "use client"
 
-import { Button, Text } from "@medusajs/ui"
+import { Button, Text, clx } from "@medusajs/ui"
 import { useRouter } from "next/navigation"
 import { useState, useTransition } from "react"
 
@@ -36,10 +36,20 @@ const QuoteAcceptPanel = ({
   acceptance,
   countryCode,
   lines,
+  className,
 }: {
   token: string
   acceptance: QuoteAcceptance
   countryCode: string
+  /**
+   * Outer spacing, owned by the LAYOUT rather than by this panel (#1439 S14).
+   *
+   * It used to hardcode `mt-10`, which is right when it sits under the totals
+   * in a single column and wrong in the sticky right rail, where that margin
+   * pushes it away from the top the rail is pinned to. The panel should not
+   * have an opinion about where the page puts it.
+   */
+  className?: string
   /**
    * The basket as the server priced it, passed straight through to the accept
    * call (#1439 S13). Not read from the URL and not recomputed here — the
@@ -51,6 +61,12 @@ const QuoteAcceptPanel = ({
   const router = useRouter()
   const [pending, startTransition] = useTransition()
   const [error, setError] = useState<string | null>(null)
+
+  // `mt-10` only when the caller has no opinion — the single-column fallback.
+  const wrapper = clx(
+    "rounded-lg border border-ui-border-base p-6",
+    className ?? "mt-10"
+  )
 
   const money = (amount: number | null) =>
     amount === null
@@ -74,7 +90,7 @@ const QuoteAcceptPanel = ({
 
   if (acceptance.accepted) {
     return (
-      <div className="mt-10 rounded-lg border border-ui-border-base bg-ui-bg-subtle p-6">
+      <div className={clx(wrapper, "bg-ui-bg-subtle")}>
         <Text className="txt-medium-plus text-ui-fg-base">
           You have accepted this quote
         </Text>
@@ -95,7 +111,7 @@ const QuoteAcceptPanel = ({
 
   if (!acceptance.can_accept) {
     return (
-      <div className="mt-10 rounded-lg border border-ui-border-base bg-ui-bg-subtle p-6">
+      <div className={clx(wrapper, "bg-ui-bg-subtle")}>
         <Text className="txt-medium-plus text-ui-fg-base">
           This quote cannot be ordered online
         </Text>
@@ -107,7 +123,7 @@ const QuoteAcceptPanel = ({
   }
 
   return (
-    <div className="mt-10 rounded-lg border border-ui-border-base p-6">
+    <div className={wrapper}>
       <Text className="txt-medium-plus text-ui-fg-base">Ready to order?</Text>
 
       {/* The split is stated BEFORE the button, not on the next screen. The one
@@ -123,7 +139,9 @@ const QuoteAcceptPanel = ({
           </dd>
         </div>
         <div className="flex items-center justify-between">
-          <dt className="txt-small text-ui-fg-subtle">Balance, before dispatch</dt>
+          <dt className="txt-small text-ui-fg-subtle">
+            Balance, before dispatch
+          </dt>
           <dd className="txt-medium text-ui-fg-subtle">
             {money(acceptance.balance_amount)}
           </dd>

--- a/apps/storefront/src/modules/quotes/components/quote-image/index.tsx
+++ b/apps/storefront/src/modules/quotes/components/quote-image/index.tsx
@@ -1,40 +1,71 @@
 "use client"
 
-import { Text } from "@medusajs/ui"
+import { Text, clx } from "@medusajs/ui"
 import Image from "next/image"
-import { useEffect, useState } from "react"
+import { useCallback, useEffect, useState } from "react"
 
 /**
- * The quoted item's photo, enlargeable (#1389).
+ * The quoted item's photography, enlargeable (#1389, gallery in #1439 S14).
  *
  * A 64px thumbnail is enough to recognise a product and nowhere near enough to
  * approve one. A buyer signing off 500 units of a weave wants to see the cloth,
- * and "email me a bigger picture" is a day of round trip.
+ * the drape and the selvedge — and "email me a bigger picture" is a day of
+ * round trip.
  *
- * 🔴 Still no placeholder. If there is no image the caller renders nothing —
- * a plausible WRONG photo on a document someone is agreeing to is worse than an
+ * ## Why this now takes a list
+ *
+ * The backend has fetched every variant image since #1428; only the first was
+ * ever rendered and the rest were discarded silently. That is a defect with no
+ * symptom — one photo looks perfectly fine and nobody knows there were five.
+ *
+ * 🔴 Still no placeholder. If there is no image the caller renders nothing — a
+ * plausible WRONG photo on a document someone is agreeing to is worse than an
  * empty cell.
  *
  * The overlay is a plain fixed div rather than a dialog primitive: it must work
- * inside a table cell on a page with no app shell, and it closes on Escape,
- * on backdrop click and on the button — three ways out, because a buyer who
- * cannot dismiss an image abandons the quote.
+ * inside a table cell on a page with no app shell, and it closes on Escape, on
+ * backdrop click and on the button — three ways out, because a buyer who cannot
+ * dismiss an image abandons the quote.
  */
 const QuoteLineImage = ({
   src,
   alt,
   caption,
+  images,
 }: {
+  /** The frame shown in the table — always the first thing the buyer sees. */
   src: string
   alt: string
   caption?: string | null
+  /**
+   * The full gallery, when the variant has one. Omitted or short means this
+   * behaves exactly as it did before: one photo, one zoom.
+   */
+  images?: string[]
 }) => {
   const [open, setOpen] = useState(false)
+  const [index, setIndex] = useState(0)
+
+  // `src` is guaranteed to be the first frame by the backend (`thumbnail` IS
+  // `images[0]` whenever the variant has its own images), but a caller that
+  // passed a stray one must not produce a gallery missing the visible frame.
+  const frames = images?.length ? images : [src]
+  const many = frames.length > 1
+
+  const step = useCallback(
+    (delta: number) =>
+      setIndex((i) => (i + delta + frames.length) % frames.length),
+    [frames.length]
+  )
 
   useEffect(() => {
     if (!open) return
     const onKey = (e: KeyboardEvent) => {
       if (e.key === "Escape") setOpen(false)
+      // Arrow keys, because someone comparing five shots of a weave will not
+      // reach for the mouse between each one.
+      if (many && e.key === "ArrowRight") step(1)
+      if (many && e.key === "ArrowLeft") step(-1)
     }
     document.addEventListener("keydown", onKey)
     // The page behind must not scroll under the overlay.
@@ -44,28 +75,73 @@ const QuoteLineImage = ({
       document.removeEventListener("keydown", onKey)
       document.body.style.overflow = previous
     }
-  }, [open])
+  }, [open, many, step])
+
+  const openAt = (i: number) => {
+    setIndex(i)
+    setOpen(true)
+  }
 
   return (
     <>
-      <button
-        type="button"
-        onClick={() => setOpen(true)}
-        aria-label={`Enlarge photo of ${alt}`}
-        className="group relative h-16 w-16 shrink-0 overflow-hidden rounded-md bg-ui-bg-subtle outline-none focus-visible:ring-2 focus-visible:ring-ui-fg-interactive"
-      >
-        <Image
-          src={src}
-          alt={alt}
-          fill
-          sizes="64px"
-          quality={60}
-          className="object-cover object-center transition-transform duration-200 group-hover:scale-105"
-        />
-        <span className="pointer-events-none absolute inset-0 hidden items-center justify-center bg-black/40 text-[10px] font-medium text-white group-hover:flex">
-          View
-        </span>
-      </button>
+      <div className="flex shrink-0 flex-col gap-y-1">
+        <button
+          type="button"
+          onClick={() => openAt(0)}
+          aria-label={`Enlarge photo of ${alt}`}
+          className="group relative h-16 w-16 shrink-0 overflow-hidden rounded-md bg-ui-bg-subtle outline-none focus-visible:ring-2 focus-visible:ring-ui-fg-interactive"
+        >
+          <Image
+            src={src}
+            alt={alt}
+            fill
+            sizes="64px"
+            quality={60}
+            className="object-cover object-center transition-transform duration-200 group-hover:scale-105"
+          />
+          <span className="pointer-events-none absolute inset-0 hidden items-center justify-center bg-black/40 text-[10px] font-medium text-white group-hover:flex">
+            View
+          </span>
+        </button>
+
+        {/* The rest of the roll, small. Capped at four beside the main frame:
+            beyond that the row grows taller than the line it describes, and the
+            count tells the buyer the others exist. */}
+        {many ? (
+          <div className="flex items-center gap-x-1">
+            {frames.slice(1, 5).map((url, i) => (
+              <button
+                key={url}
+                type="button"
+                onClick={() => openAt(i + 1)}
+                aria-label={`Enlarge photo ${i + 2} of ${
+                  frames.length
+                } for ${alt}`}
+                className="relative h-7 w-7 shrink-0 overflow-hidden rounded bg-ui-bg-subtle outline-none focus-visible:ring-2 focus-visible:ring-ui-fg-interactive"
+              >
+                <Image
+                  src={url}
+                  alt=""
+                  fill
+                  sizes="28px"
+                  quality={40}
+                  className="object-cover object-center"
+                />
+              </button>
+            ))}
+            {frames.length > 5 ? (
+              <button
+                type="button"
+                onClick={() => openAt(5)}
+                aria-label={`See all ${frames.length} photos of ${alt}`}
+                className="h-7 shrink-0 rounded bg-ui-bg-subtle px-1.5 text-[10px] text-ui-fg-subtle hover:bg-ui-bg-subtle-hover"
+              >
+                +{frames.length - 5}
+              </button>
+            ) : null}
+          </div>
+        ) : null}
+      </div>
 
       {open ? (
         <div
@@ -83,20 +159,51 @@ const QuoteLineImage = ({
           >
             <div className="relative h-[70vh] w-full overflow-hidden rounded-lg bg-black/20">
               <Image
-                src={src}
+                src={frames[index]}
                 alt={alt}
                 fill
                 sizes="(max-width: 768px) 100vw, 768px"
                 quality={90}
                 className="object-contain"
               />
+
+              {many ? (
+                <>
+                  <button
+                    type="button"
+                    onClick={() => step(-1)}
+                    aria-label="Previous photo"
+                    className="absolute left-2 top-1/2 -translate-y-1/2 rounded-full bg-black/50 px-3 py-2 text-white hover:bg-black/70"
+                  >
+                    ‹
+                  </button>
+                  <button
+                    type="button"
+                    onClick={() => step(1)}
+                    aria-label="Next photo"
+                    className="absolute right-2 top-1/2 -translate-y-1/2 rounded-full bg-black/50 px-3 py-2 text-white hover:bg-black/70"
+                  >
+                    ›
+                  </button>
+                </>
+              ) : null}
             </div>
+
             <div className="flex items-center justify-between gap-x-4">
-              <Text className="txt-small text-white/80">{caption ?? alt}</Text>
+              <Text className="txt-small text-white/80">
+                {caption ?? alt}
+                {many ? (
+                  <span className="ml-2 text-white/50">
+                    {index + 1} / {frames.length}
+                  </span>
+                ) : null}
+              </Text>
               <button
                 type="button"
                 onClick={() => setOpen(false)}
-                className="rounded-md bg-white/10 px-3 py-1.5 text-sm text-white hover:bg-white/20"
+                className={clx(
+                  "rounded-md bg-white/10 px-3 py-1.5 text-sm text-white hover:bg-white/20"
+                )}
               >
                 Close
               </button>

--- a/apps/storefront/src/modules/quotes/components/quote-lines/index.tsx
+++ b/apps/storefront/src/modules/quotes/components/quote-lines/index.tsx
@@ -50,10 +50,12 @@ const LineRow = ({
         {line.thumbnail ? (
           <QuoteLineImage
             src={line.thumbnail}
+            images={line.images}
             alt={line.product_title ?? "Quoted item"}
             caption={
-              [line.product_title, line.variant_title].filter(Boolean).join(" — ") ||
-              null
+              [line.product_title, line.variant_title]
+                .filter(Boolean)
+                .join(" — ") || null
             }
           />
         ) : null}
@@ -62,10 +64,14 @@ const LineRow = ({
             {line.product_title ?? "Product"}
           </Text>
           {line.variant_title ? (
-            <Text className="txt-small text-ui-fg-subtle">{line.variant_title}</Text>
+            <Text className="txt-small text-ui-fg-subtle">
+              {line.variant_title}
+            </Text>
           ) : null}
           {line.note ? (
-            <Text className="txt-small text-ui-fg-muted italic mt-1">{line.note}</Text>
+            <Text className="txt-small text-ui-fg-muted italic mt-1">
+              {line.note}
+            </Text>
           ) : null}
           {/* A declared PRODUCT weight over-quotes a lighter variant, and at bulk
               quantities that can cross a carrier slab — so where the weight came
@@ -83,6 +89,32 @@ const LineRow = ({
             </Text>
           ) : null}
           {line.spec ? <QuoteLineSpecRows spec={line.spec} /> : null}
+
+          {/* 🔴 What the maker ALSO weaves — a fact, not a picker.
+              The quote is frozen against this variant at this price, so these
+              are deliberately inert: no links, no selection, and a sentence
+              saying the only way to act on one is to ask. A control here would
+              describe an agreement that does not exist, which is the same
+              reason the spec payload carries no option groups. */}
+          {line.other_variants?.length ? (
+            <div className="mt-2 flex flex-wrap items-center gap-1">
+              <Text className="txt-small text-ui-fg-muted mr-1">
+                Also made in:
+              </Text>
+              {line.other_variants.map((v) => (
+                <span
+                  key={v.id}
+                  className="rounded-full border border-ui-border-base px-2 py-0.5 txt-small text-ui-fg-subtle"
+                >
+                  {v.title ?? "Another finish"}
+                </span>
+              ))}
+              <Text className="txt-small text-ui-fg-muted w-full mt-1">
+                Ask your partner to quote one of these — this price covers the
+                weave above.
+              </Text>
+            </div>
+          ) : null}
         </div>
       </div>
     </td>
@@ -160,7 +192,10 @@ const QuoteLines = ({
   // sentence that stops a dialled page passing itself off as the partner's
   // offer — the totals below it are real, but nobody quoted them.
   const dialled = lines.some(
-    (l) => l.quoted_quantity !== null && l.quoted_quantity !== undefined && l.quoted_quantity !== l.quantity
+    (l) =>
+      l.quoted_quantity !== null &&
+      l.quoted_quantity !== undefined &&
+      l.quoted_quantity !== l.quantity
   )
 
   return (
@@ -181,7 +216,9 @@ const QuoteLines = ({
             ) : null}
             {showLive ? (
               <th className="py-3 pl-4 text-right">
-                <Text className="txt-small-plus text-ui-fg-subtle">Current</Text>
+                <Text className="txt-small-plus text-ui-fg-subtle">
+                  Current
+                </Text>
               </th>
             ) : null}
           </tr>
@@ -208,8 +245,8 @@ const QuoteLines = ({
       {dialled ? (
         <div className="mt-4 flex flex-wrap items-center justify-between gap-x-4 gap-y-2 rounded-md border border-ui-border-base bg-ui-bg-subtle px-4 py-3">
           <Text className="txt-small text-ui-fg-subtle">
-            You have changed the quantities. These prices are your partner&apos;s,
-            re-applied to the basket above.
+            You have changed the quantities. These prices are your
+            partner&apos;s, re-applied to the basket above.
           </Text>
           <a
             href={buildQuotedHref({ countryCode, token })}

--- a/apps/storefront/src/modules/quotes/templates/index.tsx
+++ b/apps/storefront/src/modules/quotes/templates/index.tsx
@@ -34,8 +34,16 @@ const QuoteTemplate = ({
   token: string
   countryCode: string
 }) => {
-  const { compare, recipient, producer, provenance, parties, acceptance, retail, assurance } =
-    quote
+  const {
+    compare,
+    recipient,
+    producer,
+    provenance,
+    parties,
+    acceptance,
+    retail,
+    assurance,
+  } = quote
 
   /**
    * The real split, so the wizard's last step says the numbers rather than "a
@@ -43,12 +51,18 @@ const QuoteTemplate = ({
    * invents a percentage is worse than a generic sentence.
    */
   const depositLine =
-    acceptance?.deposit_amount !== null && acceptance?.deposit_amount !== undefined
-      ? `Accepting turns this quote into an order and takes you to checkout. You pay ${acceptance.deposit_pct}% now (${convertToLocale({ amount: acceptance.deposit_amount, currency_code: acceptance.currency_code })}) and the balance before dispatch.`
+    acceptance?.deposit_amount !== null &&
+    acceptance?.deposit_amount !== undefined
+      ? `Accepting turns this quote into an order and takes you to checkout. You pay ${
+          acceptance.deposit_pct
+        }% now (${convertToLocale({
+          amount: acceptance.deposit_amount,
+          currency_code: acceptance.currency_code,
+        })}) and the balance before dispatch.`
       : null
 
   return (
-    <div className="content-container py-12 max-w-4xl">
+    <div className="content-container py-12 max-w-4xl lg:max-w-6xl">
       <div className="flex flex-col gap-y-2">
         <Heading level="h1" className="text-2xl-semi text-ui-fg-base">
           {compare.headline}
@@ -56,82 +70,113 @@ const QuoteTemplate = ({
         <Text className="text-ui-fg-subtle">{compare.explanation}</Text>
       </div>
 
-      {/* Both parties and their registrations — the two questions finance asks
+      {/* Two columns from `lg` up: the DOCUMENT on the left, the decision
+          pinned on the right (#1439 S14).
+
+          🔑 The single-column order is preserved exactly, because it was
+          already right. The rail is the second grid child, so when the grid
+          collapses on a phone the panel lands where it always did — under the
+          totals, above the argument for buying. No `order` juggling, and
+          nothing to get wrong at a breakpoint nobody tests. */}
+      <div className="grid grid-cols-1 gap-x-10 lg:grid-cols-[minmax(0,1fr)_22rem]">
+        <div className="min-w-0">
+          {/* Both parties and their registrations — the two questions finance asks
           of any quote it is sent. Falls back to the recipient-only card for a
           quote minted before `parties` existed. */}
-      {parties ? (
-        <QuotePartiesBlock parties={parties} partnerNote={recipient.partner_note} />
-      ) : (recipient.name || recipient.company) ? (
-        <div className="mt-6 rounded-lg border border-ui-border-base p-5">
-          <Text className="txt-small-plus text-ui-fg-subtle uppercase tracking-wide">
-            Prepared for
-          </Text>
-          <Text className="txt-medium-plus text-ui-fg-base mt-1">
-            {recipient.company || recipient.name}
-          </Text>
-          {recipient.company && recipient.name ? (
-            <Text className="txt-small text-ui-fg-subtle">{recipient.name}</Text>
+          {parties ? (
+            <QuotePartiesBlock
+              parties={parties}
+              partnerNote={recipient.partner_note}
+            />
+          ) : recipient.name || recipient.company ? (
+            <div className="mt-6 rounded-lg border border-ui-border-base p-5">
+              <Text className="txt-small-plus text-ui-fg-subtle uppercase tracking-wide">
+                Prepared for
+              </Text>
+              <Text className="txt-medium-plus text-ui-fg-base mt-1">
+                {recipient.company || recipient.name}
+              </Text>
+              {recipient.company && recipient.name ? (
+                <Text className="txt-small text-ui-fg-subtle">
+                  {recipient.name}
+                </Text>
+              ) : null}
+              {recipient.partner_note ? (
+                <Text className="txt-medium text-ui-fg-subtle mt-3 whitespace-pre-line">
+                  {recipient.partner_note}
+                </Text>
+              ) : null}
+            </div>
           ) : null}
-          {recipient.partner_note ? (
-            <Text className="txt-medium text-ui-fg-subtle mt-3 whitespace-pre-line">
-              {recipient.partner_note}
-            </Text>
-          ) : null}
-        </div>
-      ) : null}
 
-      {/* Above the prices. Almost everyone opening this link is opening their
+          {/* Above the prices. Almost everyone opening this link is opening their
           first, and "is this a bill?" has to be answered before the numbers. */}
-      <QuoteHowItWorks token={token} depositLine={depositLine} />
+          <QuoteHowItWorks token={token} depositLine={depositLine} />
 
-      {/* Whose hands make this. Rendered only when the backend says so — on the
+          {/* Whose hands make this. Rendered only when the backend says so — on the
           partner's own domain the partner IS the seller and naming them again
           is noise, so `producer` is null there. */}
-      <QuoteMakerSection producer={producer} provenance={provenance} />
+          <QuoteMakerSection producer={producer} provenance={provenance} />
 
-      {/* Amber, and above the prices rather than below them: a buyer who scrolls
+          {/* Amber, and above the prices rather than below them: a buyer who scrolls
           no further still needs to know the clock is running. */}
-      {compare.expiry_notice ? (
-        <div className="mt-6 rounded-lg border border-ui-tag-orange-border bg-ui-tag-orange-bg p-4">
-          <Text className="txt-medium text-ui-tag-orange-text">
-            {compare.expiry_notice}
-          </Text>
-        </div>
-      ) : null}
+          {compare.expiry_notice ? (
+            <div className="mt-6 rounded-lg border border-ui-tag-orange-border bg-ui-tag-orange-bg p-4">
+              <Text className="txt-medium text-ui-tag-orange-text">
+                {compare.expiry_notice}
+              </Text>
+            </div>
+          ) : null}
 
-      <div className="mt-10">
-        <Heading level="h2" className="text-xl-semi text-ui-fg-base mb-2">
-          Your basket
-        </Heading>
-        {/* The buyer may move quantities here; every number that follows is
+          <div className="mt-10">
+            <Heading level="h2" className="text-xl-semi text-ui-fg-base mb-2">
+              Your basket
+            </Heading>
+            {/* The buyer may move quantities here; every number that follows is
             re-computed by the SERVER from what they dial (#1439 S13), which is
             why the control is two links and a URL rather than client state. */}
-        <QuoteLines quote={quote} token={token} countryCode={countryCode} />
-      </div>
+            <QuoteLines quote={quote} token={token} countryCode={countryCode} />
+          </div>
 
-      <div className="mt-10">
-        <QuoteSummary quote={quote} />
-      </div>
+          <div className="mt-10">
+            <QuoteSummary quote={quote} />
+          </div>
 
-      {/* Directly under the money. A buyer who has just read the total is at
+          {/* Directly under the money. A buyer who has just read the total is at
           the moment of deciding; making them scroll past the maker's history
           to find the button loses them. */}
-      {acceptance ? (
-        <QuoteAcceptPanel
-          token={token}
-          acceptance={acceptance}
-          countryCode={countryCode}
-          /* 🔴 The basket AS PRICED ABOVE, not the quoted one. `quote.lines`
+        </div>
+
+        {/* Sticky, so the total and the button stay in view while the buyer
+            scrolls the lines they are buying. `self-start` is what makes
+            `sticky` work in a grid — a stretched item is already as tall as the
+            row and has nothing to stick within.
+
+            🔴 `top-20`, not `top-8`. The storefront's own nav is `sticky top-0`
+            at 64px and `z-50`, so a rail pinned nearer the top slides UNDER it
+            and the panel's heading is clipped — which is exactly what happened,
+            and no assertion about the layout caught it. Found by looking at a
+            screenshot. 80px clears the nav with a 16px gap. */}
+        <aside className="lg:sticky lg:top-20 lg:self-start">
+          {acceptance ? (
+            <QuoteAcceptPanel
+              token={token}
+              acceptance={acceptance}
+              countryCode={countryCode}
+              /* 🔴 The basket AS PRICED ABOVE, not the quoted one. `quote.lines`
              already carries the buyer's dial — the backend re-priced the whole
              document through it — so handing these straight to the accept call
              is what stops a cart being built for quantities the buyer moved
              away from and never saw again. */
-          lines={quote.lines.map((l) => ({
-            variant_id: l.variant_id,
-            quantity: l.quantity,
-          }))}
-        />
-      ) : null}
+              lines={quote.lines.map((l) => ({
+                variant_id: l.variant_id,
+                quantity: l.quantity,
+              }))}
+              className="mt-10 lg:mt-0"
+            />
+          ) : null}
+        </aside>
+      </div>
 
       {/* Who made this, and how. Below the money because it is the reason to
           say yes rather than part of the offer, and rendered only when the
@@ -144,7 +189,9 @@ const QuoteTemplate = ({
 
       {compare.disclaimer ? (
         <div className="mt-10 border-t border-ui-border-base pt-6">
-          <Text className="txt-small text-ui-fg-muted">{compare.disclaimer}</Text>
+          <Text className="txt-small text-ui-fg-muted">
+            {compare.disclaimer}
+          </Text>
         </div>
       ) : null}
     </div>


### PR DESCRIPTION
Closes the last two UI items on the #1439 handoff list. **Stacked on #1493** — review that first; this targets its branch so the diff stays honest.

## 🔴 The bug two throwaway test quotes found

Dialling a quantity **up and then accepting was impossible on any taxed lane**:

```
tax: quoted 250.25 inr, cart 875.25
```

`assertCartMatchesQuoteStep` rebuilds the expected **subtotal** for a dialled basket and left the expected **tax** frozen at the minted quantity. A quote minted at 2 units and dialled to 7 is refused. That is the whole S13 quantity control unusable across all of India — and #1493's UI is exactly what lets a buyer reach it.

The docblock already had the reasoning right — *"the frozen columns describe something nobody is buying"* — it just was not applied to tax. The expectation now comes from the same rebuilt view (same builder, same price list, same frozen freight), so it is the tax the buyer was actually shown.

**🔑 The accept suite passed 7/7 throughout.** Its fixture region carries no tax, so quoted and cart tax are both `0` and agree by coincidence — the assertion was vacuous precisely where the bug lived. The new regression test creates the tax region the fixture lacks and asserts the cart tax is non-zero so it cannot quietly rejoin the vacuous case. **Verified red without the fix, green with it.**

## Two columns

The deposit, balance, total and button now sit in a sticky rail beside the document instead of below it. A buyer used to scroll past the parties, the guide, the maker and every line before learning what they'd pay today.

🔴 **`top-20`, not `top-8`.** The storefront's own nav is `sticky top-0`, 64px, `z-50` — a rail pinned nearer the top slides under it and clips the panel heading. A screenshot caught that; no assertion did. (Confirmed the starter's nav is also `h-16` from source, rather than assuming.)

The single-column order is unchanged because it was already right: the rail is the second grid child, so when the grid collapses the panel lands where it always did — under the totals, above the argument for buying. No `order` juggling to get wrong at a breakpoint nobody tests.

## The whole photo roll

The identity query has fetched every variant image since #1428; `pickLineImage` took the first and the rest were discarded **in silence** — a defect with no symptom, because one photo renders fine and nobody knows there were five. The overlay now pages through them with arrow keys.

The product thumbnail is deliberately **not** appended as a fallback: it is already what `thumbnail` degrades to, and mixing a product-level photo into a variant's gallery presents a weaker claim as one of this colourway's own shots — the reason `image_source` exists at all.

## What else the maker weaves

`other_variants` answers *"can I get this in indigo?"* with a fact instead of a round trip.

🔴 **Not a picker, and it must never become one** — the same reasoning that keeps option groups out of `spec`. The quote is frozen against this variant at this price, so the badges are inert and say so; the only action offered is to ask the partner. The quoted variant is excluded from its own sibling list.

🔑 `product.variants.*` does **not** resolve as a nested back-reference from `variant` — it returns an empty array rather than erroring, so the badges would simply never have rendered and nothing would have said why. It is a separate product query now, with a test pinning it.

## Also corrected

Comments in this feature claimed an unknown token and a revoked one are indistinguishable 404s. **They are not.** A revoked quote answers 200 with a `dead_link` document — withdrawn headline, no price columns, acceptance refused. Nothing actionable leaks and tokens are high-entropy, so it is a curiosity rather than a hole, but the comment was telling the next person something false.

## Verified

Two throwaway quotes minted against a real local backend, driven end to end, then revoked with their price lists deleted:

| | result |
|---|---|
| domestic, dial 2 → 7 | re-priced ₹5,255.25 → ₹18,380.25; accepted; **cart holds qty 7 at exactly ₹18,380.25** |
| export IN→DE | zero-rated with a reason, hand-typed freight badged, import estimate outside totals, correctly **not** acceptable |

Rendered and looked at: desktop side-by-side with the rail pinned at `y=80` under the 64px nav, mobile stacked with `scrollWidth == 390` (no h-scroll), zoom opening on the right frame and closing on Escape, blocked-quote card reading correctly in the rail.

- `partner-quote-accept` **8/8** (one new), `partner-quote-line-imagery` **5/5** (new), `partner-quote-buyer-dial` **4/4** → **17/17**
- `TEST_TYPE=unit` unchanged from baseline (the 2 MCP reds are fixed on #1494, not this branch)
- `check:prod-build` green

⚠️ Not verified: the starter's own components rendered live — its dev server points at production. Byte-identical to the ones rendered above, and `tsc` holds at 179 there.

## Submodule

`apps/storefront-starter` → nextjs-starter-medusa#24, a descendant of #23's commit.