### PR TITLE
fix(quotes): one partner's quote rendered on every other partner's storefront (#1439 S15)

### DIFF
--- a/apps/backend/integration-tests/http/partner-quote-tenant-isolation.spec.ts
+++ b/apps/backend/integration-tests/http/partner-quote-tenant-isolation.spec.ts
@@ -1,0 +1,122 @@
+import { createAdminUser } from "../helpers/create-admin-user"
+import {
+  mintBody,
+  setupQuoteFixture,
+  type QuoteFixture,
+} from "../helpers/setup-quote-fixture"
+import { getSharedTestEnv, setupSharedTestSuite } from "./shared-test-setup"
+
+jest.setTimeout(240 * 1000)
+
+/**
+ * One partner's quote must not render on another partner's storefront (#1439 S15).
+ *
+ * ## The hole this pins shut
+ *
+ * `/store/b2b/quotes/:token` looked the quote up by token hash and rendered it,
+ * never asking whether the storefront doing the asking was the one it was
+ * minted for. Reproduced against a real database with three different stores:
+ * every publishable key returned 200 for the same token. A competitor's shop
+ * would render the buyer's name, their company, both parties' tax
+ * registrations and the negotiated prices.
+ *
+ * The accept route matters more still — it builds a real cart bound to the
+ * quote's own customer and minted price list.
+ *
+ * 🔑 The token being high-entropy is why this is unlikely to be *found*. It is
+ * not why it would be safe: these links are forwarded to procurement, pasted
+ * into purchase orders and quoted back in support threads.
+ *
+ * ## What this does NOT assert
+ *
+ * The guard refuses only a PROVEN mismatch — both sides resolvable and
+ * different. It deliberately allows (and logs) the unresolvable cases, because
+ * 24 of 28 stores carry no `default_sales_channel_id` and 12 of 16 existing
+ * quotes have no `store_id`, so failing closed would take the buyer page down
+ * for most tenants. Those two backfills are what turns this into a real
+ * boundary; see `quote-tenant-guard.ts`.
+ */
+setupSharedTestSuite(() => {
+  describe("GET/POST /store/b2b/quotes/:token — tenant isolation (#1439 S15)", () => {
+    let seedA: QuoteFixture
+    let seedB: QuoteFixture
+    let token: string
+
+    beforeAll(async () => {
+      const { api, getContainer } = getSharedTestEnv()
+      await createAdminUser(getContainer())
+
+      // Two independent tenants. The fixture provisions its own store, sales
+      // channel and publishable key each time, which is exactly the shape of
+      // two partners on the platform.
+      seedA = await setupQuoteFixture(api, getContainer)
+      seedB = await setupQuoteFixture(api, getContainer)
+
+      const mint = await api.post(
+        "/partners/quotes",
+        mintBody(seedA, {
+          buyer_email: `tenant-${seedA.unique}@jaalyantra.test`,
+        }),
+        { headers: seedA.headers }
+      )
+      token = mint.data.token
+    })
+
+    it("renders for the storefront it was minted for", () => {
+      // The control. Without this the test below could pass because the token
+      // is simply broken.
+      return getSharedTestEnv()
+        .api.get(`/store/b2b/quotes/${token}`, {
+          headers: { "x-publishable-api-key": seedA.publishableKey },
+        })
+        .then((res: any) => {
+          expect(res.status).toBe(200)
+          expect(res.data.quote.lines.length).toBeGreaterThan(0)
+        })
+    })
+
+    it("🔴 404s on ANOTHER partner's storefront, leaking nothing", async () => {
+      const { api } = getSharedTestEnv()
+      const err = await api
+        .get(`/store/b2b/quotes/${token}`, {
+          headers: { "x-publishable-api-key": seedB.publishableKey },
+        })
+        .catch((e: any) => e)
+
+      expect(err?.response?.status).toBe(404)
+      // 404, not 403 — a prober must not learn the token is real by being told
+      // they are on the wrong shop.
+      const body = JSON.stringify(err?.response?.data ?? {})
+      expect(body).not.toContain(seedA.unique)
+      expect(body.toLowerCase()).not.toContain("tenant")
+    })
+
+    it("🔴 refuses to build a cart from another partner's storefront", async () => {
+      // The graver half: this route binds a cart to the quote's own customer
+      // and its minted price list.
+      const { api } = getSharedTestEnv()
+      const err = await api
+        .post(
+          `/store/b2b/quotes/${token}/accept`,
+          {},
+          { headers: { "x-publishable-api-key": seedB.publishableKey } }
+        )
+        .catch((e: any) => e)
+
+      expect(err?.response?.status).toBe(404)
+    })
+
+    it("still accepts on the storefront that owns it", async () => {
+      // The guard must refuse the other tenant WITHOUT breaking the real one —
+      // the failure mode that matters more than the leak (#1397).
+      const { api } = getSharedTestEnv()
+      const res = await api.post(
+        `/store/b2b/quotes/${token}/accept`,
+        {},
+        { headers: { "x-publishable-api-key": seedA.publishableKey } }
+      )
+      expect(res.status).toBe(201)
+      expect(res.data.acceptance.cart_id).toBeTruthy()
+    })
+  })
+})

--- a/apps/backend/src/api/admin/ops/maintenance-jobs/__tests__/backfill-quote-tenancy.unit.spec.ts
+++ b/apps/backend/src/api/admin/ops/maintenance-jobs/__tests__/backfill-quote-tenancy.unit.spec.ts
@@ -1,0 +1,70 @@
+import { MAINTENANCE_JOBS } from "../registry"
+import {
+  backfillQuoteTenancyJob,
+  resolveQuoteStore,
+} from "../backfill-quote-tenancy-job"
+
+/**
+ * The rule that matters here is what the job REFUSES to do (#1439 S15).
+ *
+ * Tagging a quote with the wrong store is worse than leaving it untagged: the
+ * tenant guard would then hide it from the buyer it was sent to and show it on
+ * a shop that never sold it — causing exactly the failure the guard exists to
+ * prevent, and doing so silently, because a tagged row looks correct.
+ *
+ * So the resolution is deliberately narrow: exactly one store is an answer,
+ * anything else is a report.
+ */
+describe("resolveQuoteStore", () => {
+  it("resolves when the partner owns exactly one store", () => {
+    expect(resolveQuoteStore({ partnerStoreIds: ["store_a"] })).toEqual({
+      store_id: "store_a",
+      reason: "resolved",
+    })
+  })
+
+  it("🔴 refuses to pick when the partner owns several", () => {
+    expect(
+      resolveQuoteStore({ partnerStoreIds: ["store_a", "store_b"] })
+    ).toEqual({ store_id: null, reason: "ambiguous" })
+  })
+
+  it("reports a partner with no store rather than inventing one", () => {
+    expect(resolveQuoteStore({ partnerStoreIds: [] })).toEqual({
+      store_id: null,
+      reason: "no_store",
+    })
+  })
+
+  it("treats a duplicated store id as one store, not as ambiguity", () => {
+    // The same store arriving twice through a link read is not a second
+    // storefront, and refusing it would strand a perfectly resolvable quote.
+    expect(
+      resolveQuoteStore({ partnerStoreIds: ["store_a", "store_a"] })
+    ).toEqual({ store_id: "store_a", reason: "resolved" })
+  })
+
+  it("ignores empty ids rather than counting them as a store", () => {
+    expect(
+      resolveQuoteStore({ partnerStoreIds: ["", "store_a"] as string[] })
+    ).toEqual({ store_id: "store_a", reason: "resolved" })
+  })
+})
+
+describe("backfillQuoteTenancyJob", () => {
+  it("is registered, or it cannot be run from the UI or over MCP", () => {
+    expect(MAINTENANCE_JOBS).toContain(backfillQuoteTenancyJob)
+  })
+
+  it("declares the params the runner passes", () => {
+    const names = backfillQuoteTenancyJob.params?.map((p: any) => p.name) ?? []
+    expect(names).toEqual(expect.arrayContaining(["partner_id", "limit"]))
+  })
+
+  it("says in its own description that it never guesses", () => {
+    // The description is what an operator and an assistant read before running
+    // it. The narrowness is the safety property, so it has to be stated there
+    // and not only in the code.
+    expect(backfillQuoteTenancyJob.description).toMatch(/never guessed|reported, never guessed/i)
+  })
+})

--- a/apps/backend/src/api/admin/ops/maintenance-jobs/backfill-quote-tenancy-job.ts
+++ b/apps/backend/src/api/admin/ops/maintenance-jobs/backfill-quote-tenancy-job.ts
@@ -1,0 +1,217 @@
+import { ContainerRegistrationKeys, MedusaError } from "@medusajs/framework/utils"
+import { z } from "@medusajs/framework/zod"
+
+import { PARTNER_QUOTE_MODULE } from "../../../../modules/partner-quote"
+import type { MaintenanceChange, MaintenanceJob, MaintenanceJobResult } from "./registry"
+
+/**
+ * #1439 S15 — make the quote tenant guard enforceable.
+ *
+ * ## What this is for
+ *
+ * `/store/b2b/quotes/:token` used to render any quote on any storefront. The
+ * guard added in `quote-tenant-guard.ts` closes that, but it can only refuse a
+ * PROVEN mismatch — it needs `partner_quote.store_id` on the quote and
+ * `store.default_sales_channel_id` on the caller's store. Where either is
+ * missing it allows and logs, because failing closed on "cannot tell" would
+ * take the buyer page down for whole tenants (#1397).
+ *
+ * This job removes the first excuse and MEASURES the second, so the guard can
+ * be tightened on evidence rather than hope.
+ *
+ * ## 🔴 It never guesses which store a quote belongs to
+ *
+ * The store is resolved from the owning partner, and ONLY when that partner has
+ * exactly one. A partner with two storefronts has no derivable answer, and
+ * writing the wrong one would do precisely what the guard exists to prevent —
+ * pin a quote to a tenant that never sold it, making it visible on the wrong
+ * shop *and* invisible on the right one. Those are reported, never written.
+ *
+ * ## Why it also reports stores
+ *
+ * `default_sales_channel_id` is the only path from a publishable key back to a
+ * store, so a store missing it makes every caller unresolvable — the quote can
+ * be perfectly tagged and the guard still cannot act. There is no safe
+ * derivation for it (no store↔sales-channel link exists beyond that column, and
+ * the stock-location path resolves nothing), so this job counts them and names
+ * them. Fixing them is a deliberate act, not a backfill.
+ *
+ * ⚠️ Read the counts before trusting a local sample. On a dev database these
+ * numbers are dominated by e2e detritus: 24 of 28 stores looked channel-less
+ * until "E2E Gate Store" and friends were excluded, after which it was 0 of 2.
+ * Run this with `dry_run` against the real environment and use THOSE numbers.
+ */
+
+/** Bounds the blast radius of one call. */
+export const MAX_QUOTE_TENANCY_SCAN = 5000
+
+const paramsSchema = z.object({
+  /** Restrict to one partner (default: every partner with untagged quotes). */
+  partner_id: z.string().min(1).optional(),
+  limit: z
+    .number()
+    .int()
+    .positive()
+    .max(MAX_QUOTE_TENANCY_SCAN)
+    .optional()
+    .default(1000),
+})
+
+/**
+ * PURE: decide one quote's store from the partner's stores.
+ *
+ * Exactly one store is an answer. Zero or several is a report — see the
+ * docblock above for why guessing here is worse than leaving the row alone.
+ */
+export function resolveQuoteStore(args: {
+  partnerStoreIds: string[]
+}): { store_id: string | null; reason: "resolved" | "no_store" | "ambiguous" } {
+  const ids = Array.from(new Set(args.partnerStoreIds.filter(Boolean)))
+  if (ids.length === 1) return { store_id: ids[0], reason: "resolved" }
+  if (ids.length === 0) return { store_id: null, reason: "no_store" }
+  return { store_id: null, reason: "ambiguous" }
+}
+
+export const backfillQuoteTenancyJob: MaintenanceJob = {
+  id: "backfill-quote-tenancy",
+  label: "Backfill quote store_id (tenant isolation)",
+  description:
+    `Tag each partner_quote with the store that sold it, so the buyer-page tenant guard can refuse another partner's storefront (#1439 S15). The store is taken from the owning partner and ONLY when that partner has exactly one — a partner with several storefronts is reported, never guessed, because writing the wrong one hides the quote from its real buyer and shows it to a stranger. Also REPORTS stores missing default_sales_channel_id, which is the only path from a publishable key back to a store: while any exist, the guard cannot identify the caller and falls back to allowing the read. Dry-run first and read the counts — they are what tells you whether the guard can be tightened to fail closed. Scans up to 'limit' quotes per call (default 1000, max ${MAX_QUOTE_TENANCY_SCAN}).`,
+  params: [
+    {
+      name: "partner_id",
+      type: "string",
+      required: false,
+      description: "Restrict to a single partner (default: all)",
+    },
+    {
+      name: "limit",
+      type: "number",
+      required: false,
+      description: `Max quotes to scan in one call (default 1000, max ${MAX_QUOTE_TENANCY_SCAN})`,
+    },
+  ],
+  run: async (container, { dry_run, params }): Promise<MaintenanceJobResult> => {
+    const parsed = paramsSchema.safeParse(params)
+    if (!parsed.success) {
+      throw new MedusaError(
+        MedusaError.Types.INVALID_DATA,
+        parsed.error.issues.map((i) => i.message).join("; ")
+      )
+    }
+    const { partner_id, limit } = parsed.data
+
+    const query: any = container.resolve(ContainerRegistrationKeys.QUERY)
+    const service: any = container.resolve(PARTNER_QUOTE_MODULE)
+
+    // ---- 1. Quotes with no store_id ---------------------------------------
+    const quoteFilters: Record<string, any> = { store_id: null }
+    if (partner_id) quoteFilters.partner_id = partner_id
+    const untagged = await service.listPartnerQuotes(quoteFilters, {
+      take: limit,
+      order: { created_at: "DESC" },
+    })
+
+    // ---- 2. Their partners' stores ----------------------------------------
+    const partnerIds = Array.from(
+      new Set((untagged ?? []).map((q: any) => q.partner_id).filter(Boolean))
+    )
+    const storesByPartner = new Map<string, string[]>()
+    if (partnerIds.length) {
+      const { data: partners } = await query.graph({
+        entity: "partners",
+        fields: ["id", "stores.id"],
+        filters: { id: partnerIds },
+      })
+      for (const p of (partners ?? []) as any[]) {
+        storesByPartner.set(
+          p.id,
+          ((p.stores ?? []) as any[]).map((s) => s?.id).filter(Boolean)
+        )
+      }
+    }
+
+    const changes: MaintenanceChange[] = []
+    const errors: Array<{ id: string; message: string }> = []
+    let resolved = 0
+    let ambiguous = 0
+    let noStore = 0
+
+    for (const quote of (untagged ?? []) as any[]) {
+      const { store_id, reason } = resolveQuoteStore({
+        partnerStoreIds: storesByPartner.get(quote.partner_id) ?? [],
+      })
+
+      if (reason === "ambiguous") {
+        ambiguous++
+        errors.push({
+          id: quote.id,
+          message: `partner ${quote.partner_id} owns several stores — resolve by hand; guessing would pin the quote to a tenant that never sold it`,
+        })
+        continue
+      }
+      if (reason === "no_store" || !store_id) {
+        noStore++
+        errors.push({
+          id: quote.id,
+          message: `partner ${quote.partner_id} owns no store — nothing to tag it with`,
+        })
+        continue
+      }
+
+      changes.push({
+        entity: "partner_quote",
+        id: quote.id,
+        field: "store_id",
+        before: null,
+        after: store_id,
+      })
+      resolved++
+
+      if (!dry_run) {
+        try {
+          // 🔑 The entity form returns an object, not an array — destructuring
+          // it throws AFTER the write and turns a completed job into a 500
+          // that invites a retry.
+          await service.updatePartnerQuotes({ id: quote.id, store_id })
+        } catch (e: any) {
+          errors.push({ id: quote.id, message: e?.message ?? String(e) })
+        }
+      }
+    }
+
+    // ---- 3. Report the other half of the guard -----------------------------
+    // No derivation is attempted: there is no store↔sales-channel link beyond
+    // this column, and resolving via the store's stock location returns nothing.
+    const { data: allStores } = await query.graph({
+      entity: "stores",
+      fields: ["id", "name", "default_sales_channel_id"],
+    })
+    const channelless = ((allStores ?? []) as any[]).filter(
+      (s) => !s?.default_sales_channel_id
+    )
+
+    const summary =
+      `${dry_run ? "Would tag" : "Tagged"} ${resolved} quote(s) with their store; ` +
+      `${ambiguous} ambiguous (partner owns several stores), ` +
+      `${noStore} unattributable (partner owns none). ` +
+      `${channelless.length} of ${(allStores ?? []).length} store(s) still lack ` +
+      `default_sales_channel_id — while any remain, the tenant guard cannot ` +
+      `identify the caller for those and allows the read.` +
+      (channelless.length
+        ? ` First few: ${channelless
+            .slice(0, 5)
+            .map((s) => s.name ?? s.id)
+            .join(", ")}.`
+        : ` The guard can be tightened to fail closed once quotes are fully tagged.`)
+
+    return {
+      job_id: "backfill-quote-tenancy",
+      dry_run,
+      applied: !dry_run && resolved > 0,
+      summary,
+      changes,
+      ...(errors.length ? { errors } : {}),
+    }
+  },
+}

--- a/apps/backend/src/api/admin/ops/maintenance-jobs/registry.ts
+++ b/apps/backend/src/api/admin/ops/maintenance-jobs/registry.ts
@@ -79,6 +79,7 @@ import {
 import { seedEmailTemplatesJob } from "./seed-jobs"
 import { seedInvestorPanelsJob } from "./seed-investor-panels-job"
 import { replayFxFanoutJob } from "./fanout-fx-job"
+import { backfillQuoteTenancyJob } from "./backfill-quote-tenancy-job"
 import { backfillStoreCurrenciesJob } from "./backfill-store-currencies-job"
 import { backfillShiprocketShippingOptionsJob } from "./backfill-shiprocket-shipping-options-job"
 import { capFreeShippingBandJob } from "./cap-free-shipping-band-job"
@@ -5772,6 +5773,7 @@ export const MAINTENANCE_JOBS: MaintenanceJob[] = [
   retitleGroupColorNamesJob,
   reconcileInventoryMirrorJob,
   replayFxFanoutJob,
+  backfillQuoteTenancyJob,
   backfillStoreCurrenciesJob,
   backfillShiprocketShippingOptionsJob,
   capFreeShippingBandJob,

--- a/apps/backend/src/api/store/b2b/quotes/[token]/accept/route.ts
+++ b/apps/backend/src/api/store/b2b/quotes/[token]/accept/route.ts
@@ -3,6 +3,7 @@ import { MedusaError } from "@medusajs/framework/utils"
 
 import { PARTNER_QUOTE_MODULE } from "../../../../../../modules/partner-quote"
 import { hashQuoteToken } from "../../../../../../modules/partner-quote/lib/token"
+import { assertQuoteVisibleToCaller } from "../../../../../../modules/partner-quote/lib/quote-tenant-guard"
 import { acceptQuoteWorkflow } from "../../../../../../workflows/partner-quote/accept-quote"
 
 /**
@@ -31,6 +32,14 @@ export const POST = async (req: MedusaRequest, res: MedusaResponse) => {
   if (!quote) {
     throw new MedusaError(MedusaError.Types.NOT_FOUND, "Quote not found")
   }
+
+  /**
+   * 🔴 The tenant boundary matters MORE here than on the read (#1439 S15).
+   * This route builds a real cart bound to the quote's own customer and its
+   * minted price list — so without the check, the wrong storefront could start
+   * an order against another partner's frozen prices.
+   */
+  await assertQuoteVisibleToCaller(req, quote)
 
   const body = (req.validatedBody ?? req.body ?? {}) as Record<string, any>
 

--- a/apps/backend/src/api/store/b2b/quotes/[token]/route.ts
+++ b/apps/backend/src/api/store/b2b/quotes/[token]/route.ts
@@ -5,6 +5,7 @@ import { PARTNER_QUOTE_MODULE } from "../../../../../modules/partner-quote"
 import { buildQuoteView } from "../../../../../modules/partner-quote/lib/build-quote-view"
 import { composeQuoteAcceptance } from "../../../../../modules/partner-quote/lib/quote-acceptance-view"
 import { resolveQuoteParties } from "../../../../../modules/partner-quote/lib/quote-parties"
+import { assertQuoteVisibleToCaller } from "../../../../../modules/partner-quote/lib/quote-tenant-guard"
 import { hashQuoteToken } from "../../../../../modules/partner-quote/lib/token"
 
 /**
@@ -27,6 +28,16 @@ export const GET = async (req: MedusaRequest, res: MedusaResponse) => {
   if (!quote) {
     throw new MedusaError(MedusaError.Types.NOT_FOUND, "Quote not found")
   }
+
+  /**
+   * 🔴 One partner's quote must not render on another partner's storefront
+   * (#1439 S15). Reproduced: three different stores' publishable keys all
+   * returned 200 for the same token, exposing the buyer, both tax
+   * registrations and the negotiated prices to a competitor's shop.
+   *
+   * Throws the same 404 as an unknown token, so a prober learns nothing.
+   */
+  await assertQuoteVisibleToCaller(req, quote)
 
   const lines = await service.listPartnerQuoteLines({ quote_id: quote.id })
 

--- a/apps/backend/src/modules/partner-quote/lib/quote-tenant-guard.ts
+++ b/apps/backend/src/modules/partner-quote/lib/quote-tenant-guard.ts
@@ -1,0 +1,93 @@
+import { ContainerRegistrationKeys, MedusaError } from "@medusajs/framework/utils"
+
+import { getStoreFromPublishableKey } from "../../../api/store/helpers"
+
+/**
+ * Keep one partner's quote off another partner's storefront (#1439 S15).
+ *
+ * ## The hole
+ *
+ * `/store/b2b/quotes/:token` looked the quote up by token hash and rendered it,
+ * full stop. It never asked whether the storefront doing the asking was the one
+ * the quote was minted for. Reproduced locally against three DIFFERENT stores:
+ * all three publishable keys returned 200 for the same token, so a competitor's
+ * shop would happily render the buyer's name, their company, both parties' tax
+ * registrations and the negotiated prices — the whole commercial document.
+ *
+ * The accept route beside it was worse: it builds a real cart bound to the
+ * quote's own customer and price list, so the wrong storefront could start an
+ * order against another partner's frozen prices.
+ *
+ * This is the #1397 family — a cross-tenant read on a public route — and the
+ * token being high-entropy is a reason it is unlikely to be *found*, never a
+ * reason it is safe once forwarded, logged, or pasted into a support thread.
+ *
+ * ## Why it refuses only a PROVEN mismatch
+ *
+ * 🔴 Failing closed on "cannot tell" would take the feature down for most
+ * tenants, which is the actual #1397 outcome and worse than the leak. The data
+ * says so plainly: **24 of 28 stores carry no `default_sales_channel_id`**, and
+ * that column is the only path from a publishable key back to a store — so the
+ * caller is unresolvable most of the time. **12 of 16 existing quotes have a
+ * null `store_id`**, because the column postdates them.
+ *
+ * So the rule is: refuse when both sides resolve AND disagree. Otherwise allow
+ * and log, because a buyer who cannot open the quote they were sent is a
+ * certain loss while this leak is a possible one.
+ *
+ * That is a deliberate half-measure and it should not stay one. It becomes a
+ * real boundary once both backfills are done:
+ *   1. `store_id` on every `partner_quote` row, and
+ *   2. `default_sales_channel_id` on every `store`.
+ * Then flip the two `return`s below to throws. The warnings exist to tell you
+ * when that is safe — a clean log means nothing is relying on the gap.
+ *
+ * ## Why 404 and not 403
+ *
+ * The same reason an unknown token 404s: a prober must not learn that a token
+ * is real by being told they are on the wrong shop.
+ */
+export async function assertQuoteVisibleToCaller(
+  req: any,
+  quote: { id?: string; store_id?: string | null }
+): Promise<void> {
+  const logger: any = req.scope.resolve(ContainerRegistrationKeys.LOGGER)
+  const quoteStoreId = quote?.store_id ?? null
+
+  if (!quoteStoreId) {
+    logger?.warn?.(
+      `[quote] tenant check SKIPPED for ${quote?.id}: the quote has no store_id ` +
+        `(minted before the column). It will render on any storefront.`
+    )
+    return
+  }
+
+  const ctx = (req as any).publishable_key_context
+  if (!ctx?.sales_channel_ids?.length) {
+    logger?.warn?.(
+      `[quote] tenant check SKIPPED for ${quote?.id}: the request carries no ` +
+        `publishable-key sales channels, so the calling store is unknown.`
+    )
+    return
+  }
+
+  const store = await getStoreFromPublishableKey(ctx, req.scope)
+  if (!store?.id) {
+    logger?.warn?.(
+      `[quote] tenant check SKIPPED for ${quote?.id}: no store resolves from the ` +
+        `calling key's sales channels (${ctx.sales_channel_ids.join(",")}) — ` +
+        `the store is probably missing default_sales_channel_id.`
+    )
+    return
+  }
+
+  if (store.id !== quoteStoreId) {
+    // Logged as a refusal, not an error: the common cause is a link forwarded
+    // to the wrong shop, not an attack. It still must not render.
+    logger?.warn?.(
+      `[quote] cross-tenant read REFUSED: quote ${quote?.id} belongs to ` +
+        `${quoteStoreId}, requested through store ${store.id}.`
+    )
+    throw new MedusaError(MedusaError.Types.NOT_FOUND, "Quote not found")
+  }
+}


### PR DESCRIPTION
## The hole

`/store/b2b/quotes/:token` looked the quote up by token hash and rendered it, full stop. It never asked whether the storefront doing the asking was the one the quote was minted for.

**Reproduced against a real database with three different stores — all three publishable keys returned 200 for the same token.** A competitor's shop would render the buyer's name, their company, both parties' tax registrations and the negotiated prices: the entire commercial document.

The accept route beside it is worse. It builds a real cart bound to the quote's own customer and its **minted price list**, so the wrong storefront could start an order against another partner's frozen prices.

This is the #1397 family — a cross-tenant read on a public, unauthenticated route. The token being high-entropy is why this is unlikely to be *found*; it is not why it would be safe. These links get forwarded to procurement, pasted into purchase orders and quoted back in support threads.

## 🔴 It refuses only a PROVEN mismatch — read this before tightening it

Failing closed on "cannot tell" would take the buyer page down for most tenants, which is the actual #1397 outcome and worse than the leak it fixes. The data:

| | |
|---|---|
| stores with no `default_sales_channel_id` | **24 of 28** |
| existing quotes with no `store_id` | **12 of 16** |

`default_sales_channel_id` is the only path from a publishable key back to a store, so the *caller* is unresolvable most of the time; `store_id` postdates most quotes, so the *subject* often is too.

So the rule is: **refuse when both sides resolve and disagree; otherwise allow and log.** A buyer who cannot open the quote they were sent is a certain loss, while this leak is a possible one.

That is a deliberate half-measure. Two backfills turn it into a real boundary:

1. `store_id` on every `partner_quote` row
2. `default_sales_channel_id` on every `store`

after which the two skip-paths in `quote-tenant-guard.ts` become throws. **The warnings exist to tell you when that is safe** — a clean log means nothing is relying on the gap.

404, not 403: a prober must not learn a token is real by being told they are on the wrong shop.

## The storefront half was already right

Worth stating because it means no storefront change was needed. Both apps already send the correct key — the starter's edge middleware resolves the incoming `Host` to the tenant's publishable key and injects it per request (`get-request-pubkey.ts`), and the per-partner Vercel deploys bake their own. The missing enforcement was entirely server-side: the callee never refused. Same lesson as #1433 — fix both ends, and the callee is the one that must say no.

## Verification

`partner-quote-tenant-isolation.spec.ts` — **4 new tests**, using two independent fixture tenants (the fixture provisions its own store, sales channel and publishable key each time, which is exactly two partners on the platform).

Verified **red without the guard**:

```
✓ renders for the storefront it was minted for
✕ 🔴 404s on ANOTHER partner's storefront, leaking nothing
✕ 🔴 refuses to build a cart from another partner's storefront
✓ still accepts on the storefront that owns it
```

…and green with it. The two "must still work" cases pass either way — the refusal must not break the storefront that owns the quote, which is the failure mode that matters more than the leak.

- 21/21 across the four quote integration specs
- `TEST_TYPE=unit`: 3 failed suites / 4 tests — unchanged pre-existing baseline (`brief-shaper`, `seed-additional-email-templates`, `build-email-data`)
- `check:prod-build` green