### PR TITLE
fix(quotes): the refusal blamed the partner's typed rate, not the missing lane (#1439 S16)

### DIFF
--- a/apps/backend/src/modules/partner-quote/__tests__/quote-acceptance-view.unit.spec.ts
+++ b/apps/backend/src/modules/partner-quote/__tests__/quote-acceptance-view.unit.spec.ts
@@ -1,0 +1,92 @@
+import { composeQuoteAcceptance } from "../lib/quote-acceptance-view"
+
+/**
+ * What the buyer is told when they cannot press Accept (#1439 S11, copy #1439 S16).
+ *
+ * ## The distinction these tests exist to hold
+ *
+ * The gate is `quoted_shipping_option_id` — whether the destination has a
+ * shipping option at all — and NOT whether a person typed the freight.
+ *
+ * 🔴 The copy used to say the opposite: "Freight on this lane was quoted by
+ * hand, so the order cannot be placed online." That blamed the partner's typed
+ * rate for a gap in shipping configuration, and a partner who believes it stops
+ * typing rates — the exact opposite of what S12 added them for. An override
+ * preserves the underlying option, so a typed amount on a rateable lane accepts
+ * perfectly well (verified by minting one: ₹777 typed on a Mumbai lane, cart
+ * carried it).
+ *
+ * These assertions pin both halves: the reason must describe the DESTINATION,
+ * and must not mention the freight's provenance.
+ */
+const base = {
+  currency_code: "inr",
+  deposit_pct: 30,
+  quoted_shipping_option_id: "so_1",
+  accepted_cart_id: null,
+}
+
+describe("composeQuoteAcceptance — the refusal", () => {
+  it("accepts when the destination has a shipping option", () => {
+    const a = composeQuoteAcceptance({ quote: { ...base }, gross_total: 1000 })
+    expect(a.can_accept).toBe(true)
+    expect(a.blocked_reason).toBeNull()
+  })
+
+  it("🔴 blames the DESTINATION, never the hand-typed rate", () => {
+    const a = composeQuoteAcceptance({
+      quote: { ...base, quoted_shipping_option_id: null },
+      gross_total: 1000,
+    })
+    expect(a.can_accept).toBe(false)
+    expect(a.blocked_reason).toMatch(/destination|route/i)
+    // The regression: a partner told their typed rate broke the order stops
+    // typing rates, and unrateable lanes become unquotable again.
+    expect(a.blocked_reason).not.toMatch(/by hand|hand-typed|quoted by hand/i)
+  })
+
+  it("tells the buyer whose move it is", () => {
+    // A refusal with no next step reads as a dead end, and the buyer leaves.
+    const a = composeQuoteAcceptance({
+      quote: { ...base, quoted_shipping_option_id: null },
+      gross_total: 1000,
+    })
+    expect(a.blocked_reason).toMatch(/reply/i)
+  })
+
+  it("🔑 a hand-typed amount does NOT block, so long as the lane has an option", () => {
+    // The whole point. The override carries `shipping_option_id` through, so
+    // provenance is irrelevant to acceptance.
+    const a = composeQuoteAcceptance({
+      quote: { ...base, quoted_shipping_option_id: "so_1" },
+      gross_total: 1000,
+    })
+    expect(a.can_accept).toBe(true)
+  })
+
+  it("prefers the not-open reason over the shipping one", () => {
+    // A revoked quote must not be explained as a shipping gap — the buyer
+    // would chase a delivery question about a document that no longer stands.
+    const a = composeQuoteAcceptance({
+      quote: { ...base, quoted_shipping_option_id: null },
+      gross_total: 1000,
+      unusable_reason: "revoked",
+    })
+    expect(a.blocked_reason).toMatch(/no longer open/i)
+  })
+
+  it("refuses a quote with nothing to charge", () => {
+    const a = composeQuoteAcceptance({ quote: { ...base }, gross_total: 0 })
+    expect(a.can_accept).toBe(false)
+    expect(a.blocked_reason).toMatch(/no total/i)
+  })
+
+  it("says nothing is blocked once accepted", () => {
+    const a = composeQuoteAcceptance({
+      quote: { ...base, accepted_cart_id: "cart_1", quoted_shipping_option_id: null },
+      gross_total: 1000,
+    })
+    expect(a.accepted).toBe(true)
+    expect(a.blocked_reason).toBeNull()
+  })
+})

--- a/apps/backend/src/modules/partner-quote/lib/quote-acceptance-view.ts
+++ b/apps/backend/src/modules/partner-quote/lib/quote-acceptance-view.ts
@@ -6,15 +6,33 @@ import { splitDeposit } from "../../payment_schedule/lib/split"
  * ## Why the page is told it CANNOT accept, rather than finding out on click
  *
  * 🔴 Acceptance needs a `quoted_shipping_option_id`: the accepted cart's
- * freight option is built in that option's service zone, so the number the
- * buyer pays and the number they were quoted come from the same lane. A quote
- * whose freight was named by hand on a lane that rated NOTHING has no option to
- * carry over — it can be quoted and cannot be accepted. That is a real state
- * today on exactly the cross-border lanes where the carrier answers "no
- * serviceable couriers".
+ * freight option is built in that option's SERVICE ZONE, so the number the
+ * buyer pays and the number they were quoted come from the same lane. With no
+ * option there is no zone, and therefore no way to put freight on the cart at
+ * all. The alternatives are worse — a cart with no freight line (the buyer pays
+ * for goods only and we absorb the shipping), or freight attached to no real
+ * lane.
  *
  * A button that 500s on click is how a buyer decides the supplier is not
  * serious. The refusal is computed here and rendered as a reason.
+ *
+ * ## ⚠️ Hand-typed freight is NOT what blocks this
+ *
+ * The wording here used to say it was, and that was wrong twice over.
+ *
+ * An override deliberately PRESERVES the underlying option
+ * (`shipping_option_id: chosen?.shipping_option_id` in `build-quote-view`), so
+ * a typed amount on a lane a carrier can rate accepts perfectly well — proved
+ * by minting one: `freight_override_amount: 777` on a Mumbai lane accepted, and
+ * the cart carried it. The id is null only when NOTHING was quotable for the
+ * destination.
+ *
+ * So the old copy blamed the partner's typed rate for a gap in shipping
+ * configuration — and a partner who believes it stops typing rates, which is
+ * the exact opposite of what #1439 S12 added them for.
+ *
+ * 🔑 The honest statement is about the DESTINATION, not about who named the
+ * number.
  *
  * ## The amount shown is the GROSS total
  *
@@ -64,8 +82,12 @@ export function composeQuoteAcceptance(input: {
       return "This quote is no longer open. Ask for a fresh one and it will be priced again."
     }
     if (!q.quoted_shipping_option_id) {
-      // The honest version. Not "something went wrong".
-      return "Freight on this lane was quoted by hand, so the order cannot be placed online yet. Reply to this quote and we will raise it for you."
+      /**
+       * About the destination, not about the freight's provenance — see the
+       * note above. Says what is true, what happens next, and whose move it is,
+       * without asking the buyer to care why.
+       */
+      return "We cannot take this order online for your destination yet — there is no online delivery set up for this route. Reply to this quote and we will arrange it for you."
     }
     if (total === null || !Number.isFinite(total) || total <= 0) {
       return "This quote has no total to charge. Ask for a fresh one."


### PR DESCRIPTION
## The copy was wrong about its own cause

A buyer on a lane with no shipping option was told:

> Freight on this lane was quoted by hand, so the order cannot be placed online yet.

The gate is `quoted_shipping_option_id` — whether the **destination** has a shipping option. Hand-typing the freight has nothing to do with it.

An override deliberately preserves the underlying option:

```ts
shipping_option_id: chosen?.shipping_option_id
```

| | option id | accepts? |
|---|---|---|
| typed amount, lane a carrier **can** rate | preserved | ✅ yes |
| typed amount, lane where **nothing** rated | null | ❌ blocked |

**Verified by minting one:** `freight_override_amount: 777` on a Mumbai lane → `can_accept: true`, accepted, cart carried ₹815.85 (777 + 5% inclusive). So provenance is irrelevant to acceptance.

## Why it mattered

The old wording blamed a partner's typed rate for a gap in shipping configuration. A partner who believes it **stops typing rates** — the exact opposite of what #1439 S12 added them for, and it would make every unrateable lane unquotable again.

## Now

> We cannot take this order online for your destination yet — there is no online delivery set up for this route. Reply to this quote and we will arrange it for you.

What is true, what happens next, whose move it is — without asking the buyer to care why.

## Why the block itself is correct (for now)

`acceptQuoteWorkflow` builds the cart's shipping method inside that option's **service zone**. No option, no zone, no way to put freight on the cart. The alternatives are worse: a cart with no freight line (buyer pays goods only, we absorb the shipping), or freight attached to no real lane.

To actually open those lanes, create a stored flat shipping option in a service zone covering the destination — the typed amount then rides on it with no code change. That is configuration and a commercial decision, not part of this PR.

## ⚠️ The deeper question, carried to the handoff

**A quote that cannot be accepted probably should not be minted in that shape.** Today the partner mints, the buyer receives a link, reads real prices, and only then discovers they cannot buy. The readiness preflight is where that should surface — either refusing, or telling the partner plainly that this one will have to be raised by hand. Logged on #1439 to unlock next session.

## Verification
- 7 new unit tests, including one asserting the reason names the destination and one asserting it never mentions hand-typing again
- `TEST_TYPE=unit`: 3 failed suites / 4 tests — unchanged pre-existing baseline
- `check:prod-build` green