### PR TITLE
fix(quotes): the tenant guard now refuses what it cannot identify (#1439, #1496)

### DIFF
--- a/apps/backend/integration-tests/http/partner-quote-tenant-isolation.spec.ts
+++ b/apps/backend/integration-tests/http/partner-quote-tenant-isolation.spec.ts
@@ -1,4 +1,4 @@
-import { createAdminUser } from "../helpers/create-admin-user"
+import { createAdminUser, getAuthHeaders } from "../helpers/create-admin-user"
 import {
   mintBody,
   setupQuoteFixture,
@@ -27,24 +27,27 @@ jest.setTimeout(240 * 1000)
  * not why it would be safe: these links are forwarded to procurement, pasted
  * into purchase orders and quoted back in support threads.
  *
- * ## What this does NOT assert
+ * ## It fails CLOSED, and these tests are what say so
  *
- * The guard refuses only a PROVEN mismatch — both sides resolvable and
- * different. It deliberately allows (and logs) the unresolvable cases, because
- * 24 of 28 stores carry no `default_sales_channel_id` and 12 of 16 existing
- * quotes have no `store_id`, so failing closed would take the buyer page down
- * for most tenants. Those two backfills are what turns this into a real
- * boundary; see `quote-tenant-guard.ts`.
+ * S15 shipped this refusing only a PROVEN mismatch — both sides resolvable and
+ * different — and allowing every unresolvable case, sized off dev-database
+ * counts that turned out to be e2e detritus. Measured on prod 2026-08-24:
+ * 8 of 8 quotes carry a `store_id`, 0 of 13 stores lack
+ * `default_sales_channel_id`, and all 14 publishable keys resolve to a store.
+ * Nothing was relying on the gap, so each escape hatch is now a refusal and
+ * each has a test below. See `quote-tenant-guard.ts`.
  */
 setupSharedTestSuite(() => {
   describe("GET/POST /store/b2b/quotes/:token — tenant isolation (#1439 S15)", () => {
     let seedA: QuoteFixture
     let seedB: QuoteFixture
     let token: string
+    let adminConfig: any
 
     beforeAll(async () => {
       const { api, getContainer } = getSharedTestEnv()
       await createAdminUser(getContainer())
+      adminConfig = await getAuthHeaders(api)
 
       // Two independent tenants. The fixture provisions its own store, sales
       // channel and publishable key each time, which is exactly the shape of
@@ -101,6 +104,74 @@ setupSharedTestSuite(() => {
           {},
           { headers: { "x-publishable-api-key": seedB.publishableKey } }
         )
+        .catch((e: any) => e)
+
+      expect(err?.response?.status).toBe(404)
+    })
+
+    it("🔴 404s a quote that carries no store_id at all", async () => {
+      // The first escape hatch S15 left open. A pre-S15 row (or a mint path
+      // that drops the column) is a document no storefront can be shown to
+      // own — it used to render on every one of them.
+      //
+      // 🔑 This mints its own quote and strips the column rather than reusing
+      // the shared one, so it cannot disturb the acceptance test below.
+      const { api, getContainer } = getSharedTestEnv()
+      const mint = await api.post(
+        "/partners/quotes",
+        mintBody(seedA, {
+          buyer_email: `untagged-${seedA.unique}@jaalyantra.test`,
+        }),
+        { headers: seedA.headers }
+      )
+      const orphanToken = mint.data.token
+
+      // The control: it renders on its own storefront while tagged.
+      const before = await api.get(`/store/b2b/quotes/${orphanToken}`, {
+        headers: { "x-publishable-api-key": seedA.publishableKey },
+      })
+      expect(before.status).toBe(200)
+
+      const service: any = getContainer().resolve("partnerQuote")
+      // The entity form returns an object, not an array — do not destructure.
+      await service.updatePartnerQuotes({ id: mint.data.quote.id, store_id: null })
+
+      const err = await api
+        .get(`/store/b2b/quotes/${orphanToken}`, {
+          headers: { "x-publishable-api-key": seedA.publishableKey },
+        })
+        .catch((e: any) => e)
+
+      expect(err?.response?.status).toBe(404)
+    })
+
+    it("🔴 404s when the calling key resolves to no store", async () => {
+      // The second and third hatches, which are one situation in practice: a
+      // key whose sales channel is nobody's default (the #1397 dangling key)
+      // leaves the caller unidentifiable. Unidentifiable is not permission.
+      const { api } = getSharedTestEnv()
+      const orphanKey = await api.post(
+        "/admin/api-keys",
+        { title: `Orphan ${seedA.unique}`, type: "publishable" },
+        adminConfig
+      )
+      const channel = await api.post(
+        "/admin/sales-channels",
+        { name: `Orphan channel ${seedA.unique}` },
+        adminConfig
+      )
+      // Linked to a channel that is no store's default_sales_channel_id, so
+      // `getStoreFromPublishableKey` returns null.
+      await api.post(
+        `/admin/api-keys/${orphanKey.data.api_key.id}/sales-channels`,
+        { add: [channel.data.sales_channel.id] },
+        adminConfig
+      )
+
+      const err = await api
+        .get(`/store/b2b/quotes/${token}`, {
+          headers: { "x-publishable-api-key": orphanKey.data.api_key.token },
+        })
         .catch((e: any) => e)
 
       expect(err?.response?.status).toBe(404)

--- a/apps/backend/src/modules/partner-quote/lib/quote-tenant-guard.ts
+++ b/apps/backend/src/modules/partner-quote/lib/quote-tenant-guard.ts
@@ -22,30 +22,33 @@ import { getStoreFromPublishableKey } from "../../../api/store/helpers"
  * token being high-entropy is a reason it is unlikely to be *found*, never a
  * reason it is safe once forwarded, logged, or pasted into a support thread.
  *
- * ## Why it refuses only a PROVEN mismatch
+ * ## It now FAILS CLOSED — and here is the evidence that made that safe
  *
- * 🔴 Failing closed on "cannot tell" would take the feature down for most
- * tenants, which is the actual #1397 outcome and worse than the leak. The data
- * says so plainly: **24 of 28 stores carry no `default_sales_channel_id`**, and
- * that column is the only path from a publishable key back to a store — so the
- * caller is unresolvable most of the time. **12 of 16 existing quotes have a
- * null `store_id`**, because the column postdates them.
+ * S15 shipped this guard refusing only a *proven* mismatch: where either side
+ * was unresolvable it allowed the read and logged, because failing closed on
+ * "cannot tell" is the #1397 outcome — the buyer page down for whole tenants,
+ * a certain loss traded against a possible leak. That sizing came off a dev
+ * database and was wrong: the counts were dominated by e2e detritus.
  *
- * So the rule is: refuse when both sides resolve AND disagree. Otherwise allow
- * and log, because a buyer who cannot open the quote they were sent is a
- * certain loss while this leak is a possible one.
+ * Measured against **prod** on 2026-08-24 (`backfill-quote-tenancy`, dry run,
+ * plus a key/store cross-check):
  *
- * That is a deliberate half-measure and it should not stay one. It becomes a
- * real boundary once both backfills are done:
- *   1. `store_id` on every `partner_quote` row, and
- *   2. `default_sales_channel_id` on every `store`.
- * Then flip the two `return`s below to throws. The warnings exist to tell you
- * when that is safe — a clean log means nothing is relying on the gap.
+ *   - **8 of 8** `partner_quote` rows carry a `store_id`. Nothing to backfill.
+ *   - **0 of 13** stores lack `default_sales_channel_id`.
+ *   - **14 of 14** publishable keys carry exactly one sales channel, and every
+ *     one of those channels is some store's default — so every live caller
+ *     resolves.
+ *
+ * So none of the three escape hatches has anything real behind it, and each is
+ * now a refusal. Re-run that job before assuming this still holds: a new store
+ * created without a default sales channel would lock its own buyers out, which
+ * is why `check_quote_readiness` and the job both report the count.
  *
  * ## Why 404 and not 403
  *
  * The same reason an unknown token 404s: a prober must not learn that a token
- * is real by being told they are on the wrong shop.
+ * is real by being told they are on the wrong shop. Every refusal below is the
+ * same body a nonexistent token gets.
  */
 export async function assertQuoteVisibleToCaller(
   req: any,
@@ -54,40 +57,37 @@ export async function assertQuoteVisibleToCaller(
   const logger: any = req.scope.resolve(ContainerRegistrationKeys.LOGGER)
   const quoteStoreId = quote?.store_id ?? null
 
+  const refuse = (why: string): never => {
+    // Logged as a refusal, not an error: the common cause is a link forwarded
+    // to the wrong shop, not an attack. It still must not render.
+    logger?.warn?.(`[quote] read REFUSED for ${quote?.id}: ${why}`)
+    throw new MedusaError(MedusaError.Types.NOT_FOUND, "Quote not found")
+  }
+
   if (!quoteStoreId) {
-    logger?.warn?.(
-      `[quote] tenant check SKIPPED for ${quote?.id}: the quote has no store_id ` +
-        `(minted before the column). It will render on any storefront.`
-    )
-    return
+    // Pre-S15 rows had no store_id. Prod has none left; one appearing again
+    // means a mint path is dropping the column, not that a buyer is stuck.
+    refuse("the quote carries no store_id, so no storefront can own it")
   }
 
   const ctx = (req as any).publishable_key_context
   if (!ctx?.sales_channel_ids?.length) {
-    logger?.warn?.(
-      `[quote] tenant check SKIPPED for ${quote?.id}: the request carries no ` +
-        `publishable-key sales channels, so the calling store is unknown.`
-    )
-    return
+    // Core rejects a *missing* x-publishable-api-key with a 400 before the
+    // route runs, so reaching here means the key exists and resolves to no
+    // sales channel — the dangling key of #1397.
+    refuse("the calling key resolves to no sales channel, so the store is unknown")
   }
 
   const store = await getStoreFromPublishableKey(ctx, req.scope)
   if (!store?.id) {
-    logger?.warn?.(
-      `[quote] tenant check SKIPPED for ${quote?.id}: no store resolves from the ` +
-        `calling key's sales channels (${ctx.sales_channel_ids.join(",")}) — ` +
-        `the store is probably missing default_sales_channel_id.`
+    refuse(
+      `no store resolves from the calling key's sales channels ` +
+        `(${ctx.sales_channel_ids.join(",")}) — the store is probably missing ` +
+        `default_sales_channel_id`
     )
-    return
   }
 
   if (store.id !== quoteStoreId) {
-    // Logged as a refusal, not an error: the common cause is a link forwarded
-    // to the wrong shop, not an attack. It still must not render.
-    logger?.warn?.(
-      `[quote] cross-tenant read REFUSED: quote ${quote?.id} belongs to ` +
-        `${quoteStoreId}, requested through store ${store.id}.`
-    )
-    throw new MedusaError(MedusaError.Types.NOT_FOUND, "Quote not found")
+    refuse(`it belongs to ${quoteStoreId}, requested through store ${store.id}`)
   }
 }


### PR DESCRIPTION
Closes the fail-open half of the buyer-page tenant guard added in #1496.

## Why it was open, and why that reasoning was wrong

S15's guard refused only a **proven** mismatch. Where either side was unresolvable it allowed the read and logged. That was deliberate — failing closed on "cannot tell" is the #1397 outcome, whole tenants' buyer pages 404ing, a certain loss traded against a possible leak.

The sizing came off a **dev** database and was wrong. 24 of 28 stores looked channel-less and 12 of 16 quotes looked untagged; after filtering `E2E %` rows it was 0 of 2.

## What prod actually says (24 Aug)

`backfill-quote-tenancy` dry run, plus a key/store cross-check:

| measure | prod |
|---|---|
| `partner_quote` rows carrying `store_id` | **8 of 8** — nothing to backfill |
| stores lacking `default_sales_channel_id` | **0 of 13** |
| publishable keys resolving to a store | **14 of 14** |

Nothing is relying on any of the three hatches, so each is now a refusal.

## Shape of the refusal

404, with the same body an unknown token gets — a prober must not learn a token is real by being told they are on the wrong shop.

The *keyless* case never reaches this code: core rejects a missing `x-publishable-api-key` with a 400 before the route runs (probed on prod). So the "no sales channels" hatch could only ever have been the dangling key of #1397.

## Verification

`partner-quote-tenant-isolation` 6/6, and the two new tests were confirmed to **fail against the old guard** before being accepted:

```
✕ 🔴 404s a quote that carries no store_id at all
✕ 🔴 404s when the calling key resolves to no store
```

That check is the point — #1495 was a suite passing 7/7 over an assertion made vacuous by its own fixture.

Also green: `partner-quote-accept`, `partner-quote-buyer-dial`, `partner-quote-live-reprice` (14/14), and `check:prod-build`.

## Watch-out

A store created **without** a default sales channel would now lock its own buyers out rather than falling through. That is the intended trade, but it is why both this guard's docblock and the maintenance job report that count — re-run the job before assuming the numbers still hold.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_0158wJMZ1DmjNxXf5uGuBrQD