### PR TITLE
feat(shipping): rate an export from an HQ pin when the partner's cannot (#1498)

### DIFF
--- a/apps/backend/.env.template
+++ b/apps/backend/.env.template
@@ -56,6 +56,22 @@ SHIPROCKET_EMAIL=shipping@example.com
 SHIPROCKET_API_PASSWORD=your_shiprocket_password
 # SHIPROCKET_PICKUP_LOCATION=Primary
 
+# Export origin fallback (#1498). When a partner's own pickup pin cannot be
+# rated for an international lane, the export is re-rated from these pins and
+# the domestic first leg is added, so the buyer gets a real carrier number
+# instead of the flat fallback. Probed 24 Aug 2026, 1.2 kg to NL: Srinagar
+# 190001 answers "no serviceable couriers"; Delhi 110032 returns 8 couriers
+# from Rs 1,276; Himachal 176215 returns one at Rs 2,916. They are NOT
+# interchangeable, so list every one you have and let the cheapest landed route
+# win. Unset means no fallback: cross-border lanes drop to the flat rate, which
+# is one number whatever the parcel weighs.
+# EXPORT_FALLBACK_ORIGINS=110032:Delhi HQ,176215:Himachal HQ
+# Set true ONLY if stock consolidates at HQ regardless of any order, which
+# makes the first leg a sunk cost rather than part of this shipment's price.
+# Leaving it unset charges the leg, which is the safer default: omitting it
+# under-quotes every relay route by Rs 206-505 and also ranks the HQs wrongly.
+# EXPORT_FIRST_LEG_IS_SUNK=false
+
 # Blue Dart carrier. TWO layers of credentials, and both are required:
 #   1. the developer.dhl.com API gateway pair, which mints a 24h JWT
 #   2. the Blue Dart shipping account, which travels in the request BODY

--- a/apps/backend/src/lib/__tests__/shipping-estimate-zone.unit.spec.ts
+++ b/apps/backend/src/lib/__tests__/shipping-estimate-zone.unit.spec.ts
@@ -129,3 +129,71 @@ describe("pickFreightOption — the currency trap it cannot see", () => {
     expect(chosen!.amount).toBe(200)
   })
 })
+
+describe("pickFreightOption — a calculated winner still needs a lane (#1498)", () => {
+  it("🔴 borrows the shipping_option_id from a manual option on the lane", () => {
+    // A carrier rate is a courier and a price, not a Medusa shipping option.
+    // Acceptance mints the cart's freight option in the service zone of the
+    // option the quote was rated against and REFUSES when none was frozen — so
+    // without this, every quote won by a live rate priced fine and could not be
+    // bought. It stayed hidden while cross-border lanes fell to the flat
+    // fallback; #1498 makes carrier rates win them for the first time.
+    const chosen = pickFreightOption({
+      manual: [
+        {
+          shipping_option_id: "so_intl",
+          amount: 3500,
+          currency_code: "inr",
+          source: "manual",
+        } as any,
+      ],
+      calculated: [
+        {
+          courier_name: "SRX Economy",
+          amount: 1482,
+          currency_code: "inr",
+          source: "calculated",
+        } as any,
+      ],
+    })
+
+    expect(chosen!.amount).toBe(1482)
+    expect(chosen!.source).toBe("calculated")
+    // The ZONE is borrowed, never the price.
+    expect(chosen!.shipping_option_id).toBe("so_intl")
+  })
+
+  it("leaves the id null when the store has no lane at all, so acceptance can say so", () => {
+    // The honest answer: the store genuinely has no configured option to that
+    // country, which is the refusal #1497 wrote. Inventing an id here would
+    // charge the freight on somebody else's zone.
+    const chosen = pickFreightOption({
+      manual: [],
+      calculated: [
+        { amount: 1482, currency_code: "inr", source: "calculated" } as any,
+      ],
+    })
+    expect(chosen!.shipping_option_id).toBeUndefined()
+  })
+
+  it("does not overwrite an id the winner already has", () => {
+    const chosen = pickFreightOption({
+      manual: [
+        {
+          shipping_option_id: "so_cheap",
+          amount: 200,
+          currency_code: "inr",
+          source: "manual",
+        } as any,
+        {
+          shipping_option_id: "so_other",
+          amount: 900,
+          currency_code: "inr",
+          source: "manual",
+        } as any,
+      ],
+      calculated: [],
+    })
+    expect(chosen!.shipping_option_id).toBe("so_cheap")
+  })
+})

--- a/apps/backend/src/lib/shipping-estimate.ts
+++ b/apps/backend/src/lib/shipping-estimate.ts
@@ -1,5 +1,11 @@
 import { ContainerRegistrationKeys, MedusaError, Modules } from "@medusajs/framework/utils"
 
+import { isInternationalDestination } from "../modules/shipping-providers/destination"
+import {
+  parseExportOrigins,
+  rateWithOriginFallback,
+  type ExportOrigin,
+} from "../modules/shipping-providers/export-origins"
 import { resolveShippingProvider } from "../modules/shipping-providers/resolver"
 
 /**
@@ -61,6 +67,13 @@ export type ShippingEstimateInput = {
    */
   currency_code?: string
   carrier?: string
+  /**
+   * Override the configured HQ export origins (#1498). Omit in production —
+   * they come from `EXPORT_FALLBACK_ORIGINS` so a partner whose own pin
+   * becomes export-enabled starts winning with no deploy.
+   */
+  export_fallback_origins?: ExportOrigin[]
+
   /** The store whose default stock location is the origin. */
   store: { id?: string; default_location_id?: string | null }
 }
@@ -75,6 +88,24 @@ export type ShippingEstimateOption = {
   estimated_days?: number | null
   is_recommended?: boolean
   source: "manual" | "calculated"
+  /**
+   * How this number was actually routed (#1498). Present only on a relay —
+   * absent means the partner's own pin exported it directly.
+   *
+   * 🔑 It travels with the amount rather than being logged, because a landed
+   * price that is silently two legs is unauditable: nobody can later say why a
+   * Srinagar quote carries a Delhi courier or where the extra ₹206 came from,
+   * and the margin cannot be checked.
+   */
+  route?: {
+    via_hq: boolean
+    origin_pincode: string
+    origin_label: string | null
+    export_leg_amount: number
+    domestic_leg_amount: number | null
+    /** The relay is real but its first leg has no price — an under-quote. */
+    domestic_leg_unrated: boolean
+  }
 }
 
 export type ShippingEstimateLine = {
@@ -417,57 +448,130 @@ export async function buildShippingEstimate(
   }
 
   const weightBucket = weightBucketGrams(totalWeightGrams)
-  const cacheKey = `shipping-estimate:${carrier}:${originPostalCode}:${destinationPostalCode}:${countryCode}:${weightBucket}`
 
-  // 🔑 Carrier rates do NOT depend on the quote currency — the carrier answers
-  // in its own — so the cache holds them UNFILTERED and the currency guard is
-  // applied on both the hit and the miss path. Caching the filtered list under
-  // a key with no currency in it would serve an INR quote's survivors to a EUR
-  // one, which is the bug the guard exists to prevent, reintroduced through the
-  // cache.
+  /**
+   * 🔑 The origin is no longer necessarily the partner's pin (#1498).
+   *
+   * A partner in Srinagar cannot export: 190001 → NL is a 400, *no serviceable
+   * couriers*, so the lane dropped to the flat fallback — which is one number
+   * whatever the parcel weighs. That is the whole reason international freight
+   * read flat at any weight. Delhi HQ rates the same parcel at ₹1,276 across 8
+   * couriers, and the goods route through a warehouse anyway.
+   *
+   * The loop lives ABOVE the provider on purpose: "retry from an HQ origin" is
+   * a fact about how we move goods, not about Shiprocket, and Blue Dart / DTDC
+   * / DHL slot into the same call as each gains a rate API. See
+   * `shipping-providers/export-origins.ts` for the two traps it is built around.
+   *
+   * Exports only. Relaying a Srinagar → Mumbai parcel through Delhi is not
+   * something we do, and asking would spend carrier calls to learn it.
+   */
+  const hqOrigins = isInternationalDestination(countryCode)
+    ? input.export_fallback_origins ??
+      parseExportOrigins(process.env.EXPORT_FALLBACK_ORIGINS)
+    : []
+
   let rawCalculated: ShippingEstimateOption[] = []
   let calculatedError: string | null = null
   let cacheHit = false
 
   const cacheService: any = scope.resolve(Modules.CACHE)
-  const cached = await cacheService.get(cacheKey).catch(() => null)
-  if (cached) {
-    rawCalculated = cached as ShippingEstimateOption[]
-    cacheHit = true
-  } else {
-    try {
-      const provider = await resolveShippingProvider(scope, carrier)
-      if (!provider.getRates) {
-        throw new MedusaError(
-          MedusaError.Types.NOT_ALLOWED,
-          `${carrier} does not support rate quotes`
-        )
-      }
-      const rates = await provider.getRates({
-        origin_pincode: originPostalCode,
-        destination_pincode: destinationPostalCode,
-        destination_country: countryCode,
-        weight_grams: weightBucket,
-      })
-      rawCalculated = (rates || [])
-        .map((r: any) => ({
-          courier_id: r.courier_id ?? null,
-          courier_name: r.courier_name ?? null,
-          amount: Number(r.amount),
-          currency_code: String(r.currency_code || "inr").toLowerCase(),
-          estimated_days: r.estimated_days ?? null,
-          is_recommended: !!r.is_recommended,
-          source: "calculated" as const,
-        }))
-      await cacheService.set(cacheKey, rawCalculated, 900).catch(() => {})
-    } catch (err) {
-      // A carrier that will not quote must not blank the whole estimate — the
-      // manual options are still a real, quotable answer.
-      calculatedError = err instanceof Error ? err.message : String(err)
-      logger?.warn?.(
-        `[shipping-estimate] ${carrier} rates failed for ${originPostalCode}->${destinationPostalCode}: ${calculatedError}`
+
+  /**
+   * One carrier call per LEG, cached per leg.
+   *
+   * 🔑 Per-leg rather than per-quote: `110032 → NL at 1.2 kg` is the same
+   * question for every partner on the platform, so the second partner to quote
+   * that lane pays nothing for it. A cache keyed on the whole route would miss
+   * every time the first leg differed.
+   *
+   * 🔑 Held UNFILTERED by currency — the carrier answers in its own, and the
+   * guard is applied on both the hit and the miss path. Caching the filtered
+   * list under a key with no currency in it would serve an INR quote's
+   * survivors to a EUR one, which is the bug the guard exists to prevent,
+   * reintroduced through the cache.
+   */
+  const rateLeg = async (q: {
+    origin_pincode: string
+    destination_pincode: string
+    destination_country?: string
+    weight_grams: number
+  }): Promise<any[]> => {
+    const legKey =
+      `shipping-estimate:${carrier}:${q.origin_pincode}:` +
+      `${q.destination_pincode}:${q.destination_country || ""}:${q.weight_grams}`
+    const hit = await cacheService.get(legKey).catch(() => null)
+    if (hit) {
+      cacheHit = true
+      return hit as any[]
+    }
+    const provider = await resolveShippingProvider(scope, carrier)
+    if (!provider.getRates) {
+      throw new MedusaError(
+        MedusaError.Types.NOT_ALLOWED,
+        `${carrier} does not support rate quotes`
       )
     }
+    const rates = (await provider.getRates(q)) || []
+    await cacheService.set(legKey, rates, 900).catch(() => {})
+    return rates
+  }
+
+  try {
+    const routes = await rateWithOriginFallback({
+      partnerOrigin: originPostalCode,
+      hqOrigins,
+      destinationPincode: destinationPostalCode,
+      destinationCountry: countryCode,
+      weightGrams: weightBucket,
+      rate: rateLeg,
+      // Filtered downstream against the quote currency, so the fallback keeps
+      // every currency and lets the existing guard do the dropping and the
+      // logging in one place.
+      currencyCode: null,
+      chargeDomesticLeg: process.env.EXPORT_FIRST_LEG_IS_SUNK !== "true",
+      logger,
+    })
+
+    if (!routes.length && hqOrigins.length) {
+      // Distinguishable in the log from "we never tried": an operator needs to
+      // know the relay was attempted and refused, not that it is unconfigured.
+      logger?.warn?.(
+        `[shipping-estimate] no origin could rate ${originPostalCode} -> ` +
+          `${countryCode}, including ${hqOrigins.length} HQ pin(s).`
+      )
+    }
+
+    rawCalculated = routes.map((r) => ({
+      courier_id: r.courier_id,
+      courier_name: r.courier_name,
+      amount: r.total_amount,
+      currency_code: r.currency_code,
+      estimated_days: r.estimated_days,
+      is_recommended: r.is_recommended,
+      source: "calculated" as const,
+      // 🔑 The route travels WITH the number. A landed price that is silently
+      // two legs is unauditable: nobody can later say why a Srinagar quote
+      // carries a Delhi courier, or where the extra ₹206 came from.
+      route:
+        r.via_hq || r.domestic_leg
+          ? {
+              via_hq: r.via_hq,
+              origin_pincode: r.origin_pincode,
+              origin_label: r.origin_label,
+              export_leg_amount: r.export_leg.amount,
+              domestic_leg_amount: r.domestic_leg?.amount ?? null,
+              domestic_leg_unrated: r.domestic_leg_unrated,
+            }
+          : undefined,
+    }))
+  } catch (err) {
+    // A carrier that will not quote must not blank the whole estimate — the
+    // manual options are still a real, quotable answer.
+    calculatedError = err instanceof Error ? err.message : String(err)
+    logger?.warn?.(
+      `[shipping-estimate] ${carrier} rates failed for ${originPostalCode}->${destinationPostalCode}: ${calculatedError}`
+    )
   }
 
   /**

--- a/apps/backend/src/modules/partner-quote/lib/build-quote-view.ts
+++ b/apps/backend/src/modules/partner-quote/lib/build-quote-view.ts
@@ -441,6 +441,28 @@ export type QuoteView = {
  * Cheapest, not "recommended": a recommendation is the carrier's commercial
  * opinion, and a buyer comparing suppliers is comparing the number they would
  * actually pay. Every option is still returned, so the page can show the rest.
+ *
+ * ## 🔴 Why a CALCULATED winner borrows a lane from a manual one (#1498)
+ *
+ * A carrier rate is a courier and a price. It is not a Medusa shipping option,
+ * so it carries no `shipping_option_id` — and acceptance needs one: it mints
+ * the cart's flat freight option in the SAME service zone and shipping profile
+ * as the option the quote was rated against, and refuses outright when the
+ * quote froze none (`create-quote-freight-option-step`).
+ *
+ * So a quote whose freight came from a live rate could never be accepted. That
+ * stayed hidden while cross-border lanes fell to the flat fallback and won on
+ * the manual row; #1498 makes carrier rates win international lanes for the
+ * first time, which would have turned a pricing improvement into "this quote
+ * cannot be bought" — the #1497 failure again, and again discovered by the
+ * buyer at the last step.
+ *
+ * The donor is any manual option still standing, and by this point that list is
+ * already filtered to zones covering the destination, to the quote currency and
+ * to non-return options. Its ZONE is all that is borrowed — never its price.
+ * When there is no manual option at all the id stays null and acceptance
+ * refuses with the message #1497 wrote, which is the honest answer: the store
+ * genuinely has no configured lane to that country.
  */
 export function pickFreightOption(
   estimate: Pick<ShippingEstimate, "manual" | "calculated">
@@ -448,7 +470,12 @@ export function pickFreightOption(
   const all = [...(estimate.calculated || []), ...(estimate.manual || [])]
     .filter((o) => Number.isFinite(Number(o?.amount)))
     .sort((a, b) => Number(a.amount) - Number(b.amount))
-  return all[0] ?? null
+  const winner = all[0] ?? null
+  if (!winner || winner.shipping_option_id) return winner
+
+  const laneOption = (estimate.manual || []).find((o) => o.shipping_option_id)
+  if (!laneOption) return winner
+  return { ...winner, shipping_option_id: laneOption.shipping_option_id }
 }
 
 /**

--- a/apps/backend/src/modules/shipping-providers/__tests__/export-origins.unit.spec.ts
+++ b/apps/backend/src/modules/shipping-providers/__tests__/export-origins.unit.spec.ts
@@ -1,0 +1,330 @@
+import {
+  parseExportOrigins,
+  parseExportOriginsStrict,
+  rateWithOriginFallback,
+} from "../export-origins"
+
+/**
+ * #1498 — rating an export from an HQ pin when the partner's cannot be rated.
+ *
+ * The numbers below are the LIVE probe from 24 Aug 2026 (Shiprocket, 1.2 kg,
+ * 30×25×10), not invented fixtures. Using the real ones is what makes the two
+ * traps assertable: a made-up pair of HQ prices would rank the same way whether
+ * or not the domestic leg is counted, and the test would pass over a defect.
+ */
+const SRINAGAR = "190001"
+const DELHI = "110032"
+const HIMACHAL = "176215"
+
+/** Delhi is cheaper to export from; Himachal is cheaper to reach. */
+const PROBE = {
+  [`${DELHI}->NL`]: 1276,
+  [`${HIMACHAL}->NL`]: 2916,
+  [`${SRINAGAR}->${DELHI}`]: 206,
+  [`${SRINAGAR}->${HIMACHAL}`]: 505,
+}
+
+/** Srinagar cannot export: the live endpoint answers 400, not an empty list. */
+const fakeRate = (opts: { throwOn?: string[]; empty?: string[] } = {}) =>
+  jest.fn(async (q: any) => {
+    const key = q.destination_country
+      ? `${q.origin_pincode}->${q.destination_country}`
+      : `${q.origin_pincode}->${q.destination_pincode}`
+    if (opts.throwOn?.includes(key)) {
+      throw new Error("No serviceable couriers available for given weight")
+    }
+    if (opts.empty?.includes(key)) return []
+    const amount = (PROBE as any)[key]
+    if (!amount) return []
+    return [
+      {
+        courier_id: `c-${key}`,
+        courier_name: `Courier ${key}`,
+        amount,
+        currency_code: "inr",
+        estimated_days: 6,
+        is_recommended: true,
+      },
+    ]
+  })
+
+const HQ = [
+  { pincode: DELHI, label: "Delhi HQ" },
+  { pincode: HIMACHAL, label: "Himachal HQ" },
+]
+
+describe("parseExportOrigins", () => {
+  it("reads pin:label pairs and labels a bare pin", () => {
+    expect(parseExportOrigins("110032:Delhi HQ, 176215")).toEqual([
+      { pincode: "110032", label: "Delhi HQ" },
+      { pincode: "176215", label: "HQ 176215" },
+    ])
+  })
+
+  it("drops anything that is not a 6-digit PIN, and says what it dropped", () => {
+    // A malformed origin passed to the carrier buys a slower no, and on the
+    // international endpoint a missing pickup_postcode is a 400 for the whole
+    // request rather than for that origin.
+    const { origins, rejected } = parseExportOriginsStrict("110032,ABCDEF,1234")
+    expect(origins.map((o) => o.pincode)).toEqual(["110032"])
+    expect(rejected).toEqual(["ABCDEF", "1234"])
+  })
+
+  it("treats a repeated pin as one origin, not two routes", () => {
+    expect(parseExportOrigins("110032:Delhi,110032:Delhi again")).toHaveLength(1)
+  })
+
+  it("is empty, not throwing, when nothing is configured", () => {
+    expect(parseExportOrigins(undefined)).toEqual([])
+    expect(parseExportOrigins("")).toEqual([])
+  })
+})
+
+describe("rateWithOriginFallback", () => {
+  it("rates the export from an HQ when the partner's own pin 400s", async () => {
+    const rate = fakeRate({ throwOn: [`${SRINAGAR}->NL`] })
+    const routes = await rateWithOriginFallback({
+      partnerOrigin: SRINAGAR,
+      hqOrigins: HQ,
+      destinationPincode: "1011AB",
+      destinationCountry: "NL",
+      weightGrams: 1200,
+      rate,
+      currencyCode: "inr",
+    })
+
+    // Without this the lane has no carrier answer at all and falls to the flat
+    // rate, which is why international freight read flat at any weight.
+    expect(routes.length).toBeGreaterThan(0)
+    expect(routes[0].via_hq).toBe(true)
+  })
+
+  it("🔴 trap 1: tries EVERY HQ rather than one, and takes the cheapest", async () => {
+    const rate = fakeRate({ throwOn: [`${SRINAGAR}->NL`] })
+    const routes = await rateWithOriginFallback({
+      partnerOrigin: SRINAGAR,
+      hqOrigins: HQ,
+      destinationPincode: "1011AB",
+      destinationCountry: "NL",
+      weightGrams: 1200,
+      rate,
+      currencyCode: "inr",
+    })
+
+    expect(routes.map((r) => r.origin_label)).toEqual(
+      expect.arrayContaining(["Delhi HQ", "Himachal HQ"])
+    )
+    // 1276 + 206 = 1482 beats 2916 + 505 = 3421. A single hardcoded fallback
+    // pointed at Himachal would over-quote by 2.3x.
+    expect(routes[0].origin_label).toBe("Delhi HQ")
+    expect(routes[0].total_amount).toBe(1482)
+  })
+
+  it("🔴 trap 2: the total is BOTH legs, and both are recorded", async () => {
+    const rate = fakeRate({ throwOn: [`${SRINAGAR}->NL`] })
+    const [best] = await rateWithOriginFallback({
+      partnerOrigin: SRINAGAR,
+      hqOrigins: HQ,
+      destinationPincode: "1011AB",
+      destinationCountry: "NL",
+      weightGrams: 1200,
+      rate,
+      currencyCode: "inr",
+    })
+
+    expect(best.export_leg.amount).toBe(1276)
+    expect(best.domestic_leg?.amount).toBe(206)
+    expect(best.domestic_leg?.destination_pincode).toBe(DELHI)
+    // Quoting the export leg alone under-quotes by the first leg, every time.
+    expect(best.total_amount).toBe(1482)
+    expect(best.domestic_leg_unrated).toBe(false)
+  })
+
+  it("🔴 trap 2, ranking: the legs re-order the HQs, they do not just shift them", async () => {
+    // The point of counting the first leg is not a bigger number, it is a
+    // DIFFERENT winner where the cheap export is far from the partner. Delhi
+    // exports cheaper but from here Himachal is nearer — invert the export
+    // prices and the ranking must follow the landed total, not the export.
+    const rate = jest.fn(async (q: any) => {
+      const key = q.destination_country
+        ? `${q.origin_pincode}->${q.destination_country}`
+        : `${q.origin_pincode}->${q.destination_pincode}`
+      const table: Record<string, number> = {
+        [`${DELHI}->NL`]: 2900,
+        [`${HIMACHAL}->NL`]: 2800,
+        [`${SRINAGAR}->${DELHI}`]: 206,
+        [`${SRINAGAR}->${HIMACHAL}`]: 505,
+      }
+      if (key === `${SRINAGAR}->NL`) throw new Error("no couriers")
+      const amount = table[key]
+      return amount
+        ? [{ courier_name: key, amount, currency_code: "inr" }]
+        : []
+    })
+
+    const routes = await rateWithOriginFallback({
+      partnerOrigin: SRINAGAR,
+      hqOrigins: HQ,
+      destinationPincode: "1011AB",
+      destinationCountry: "NL",
+      weightGrams: 1200,
+      rate,
+      currencyCode: "inr",
+    })
+
+    // Export alone would pick Himachal (2800 < 2900). Landed picks Delhi
+    // (3106 < 3305).
+    expect(routes[0].origin_label).toBe("Delhi HQ")
+    expect(routes[0].total_amount).toBe(3106)
+  })
+
+  it("prefers the partner's own pin once it becomes serviceable, with no code change", async () => {
+    // The configured HQ list does not need editing when a partner's own pin is
+    // export-enabled: a direct route pays no first leg, so it undercuts.
+    const rate = jest.fn(async (q: any) => {
+      const key = q.destination_country
+        ? `${q.origin_pincode}->${q.destination_country}`
+        : `${q.origin_pincode}->${q.destination_pincode}`
+      const table: Record<string, number> = {
+        [`${SRINAGAR}->NL`]: 1400,
+        ...PROBE,
+      }
+      const amount = table[key]
+      return amount
+        ? [{ courier_name: key, amount, currency_code: "inr" }]
+        : []
+    })
+
+    const routes = await rateWithOriginFallback({
+      partnerOrigin: SRINAGAR,
+      hqOrigins: HQ,
+      destinationPincode: "1011AB",
+      destinationCountry: "NL",
+      weightGrams: 1200,
+      rate,
+      currencyCode: "inr",
+    })
+
+    expect(routes[0].via_hq).toBe(false)
+    expect(routes[0].origin_pincode).toBe(SRINAGAR)
+    expect(routes[0].total_amount).toBe(1400)
+  })
+
+  it("does not rate a relay through the partner's own pin", async () => {
+    const rate = fakeRate()
+    await rateWithOriginFallback({
+      partnerOrigin: DELHI,
+      hqOrigins: HQ,
+      destinationPincode: "1011AB",
+      destinationCountry: "NL",
+      weightGrams: 1200,
+      rate,
+      currencyCode: "inr",
+    })
+    const legs = rate.mock.calls.map((c: any[]) => c[0])
+    expect(
+      legs.some(
+        (l: any) => l.origin_pincode === DELHI && l.destination_pincode === DELHI
+      )
+    ).toBe(false)
+  })
+
+  it("🔴 never returns a zero, whatever the carrier answers", async () => {
+    // A zero is indistinguishable from genuinely free freight, and shipped bulk
+    // orders free once already (#1430).
+    const rate = jest.fn(async () => [
+      { courier_name: "Bogus", amount: 0, currency_code: "inr" },
+    ])
+    const routes = await rateWithOriginFallback({
+      partnerOrigin: SRINAGAR,
+      hqOrigins: HQ,
+      destinationPincode: "1011AB",
+      destinationCountry: "NL",
+      weightGrams: 1200,
+      rate,
+      currencyCode: "inr",
+    })
+    expect(routes).toEqual([])
+  })
+
+  it("🔴 refuses to add legs priced in different currencies", async () => {
+    const rate = jest.fn(async (q: any) =>
+      q.destination_country
+        ? [{ courier_name: "Intl", amount: 35, currency_code: "eur" }]
+        : [{ courier_name: "Dom", amount: 206, currency_code: "inr" }]
+    )
+    const routes = await rateWithOriginFallback({
+      partnerOrigin: SRINAGAR,
+      hqOrigins: [HQ[0]],
+      destinationPincode: "1011AB",
+      destinationCountry: "NL",
+      weightGrams: 1200,
+      rate,
+      // Srinagar answers EUR too, so the direct route survives the currency
+      // filter; only the mixed-currency RELAY must be dropped.
+      currencyCode: "eur",
+    })
+    expect(routes.every((r) => !r.via_hq)).toBe(true)
+  })
+
+  it("keeps a route whose first leg could not be priced, but marks it", async () => {
+    // Refusing it would drop the lane to the flat rate, which is worse. It must
+    // not be presented as a landed price though.
+    const rate = fakeRate({
+      throwOn: [`${SRINAGAR}->NL`],
+      empty: [`${SRINAGAR}->${DELHI}`, `${SRINAGAR}->${HIMACHAL}`],
+    })
+    const warn = jest.fn()
+    const routes = await rateWithOriginFallback({
+      partnerOrigin: SRINAGAR,
+      hqOrigins: HQ,
+      destinationPincode: "1011AB",
+      destinationCountry: "NL",
+      weightGrams: 1200,
+      rate,
+      currencyCode: "inr",
+      logger: { warn },
+    })
+
+    expect(routes[0].domestic_leg).toBeNull()
+    expect(routes[0].domestic_leg_unrated).toBe(true)
+    expect(routes[0].total_amount).toBe(1276)
+    expect(warn).toHaveBeenCalled()
+  })
+
+  it("skips the first leg entirely when it is declared a sunk cost", async () => {
+    const rate = fakeRate({ throwOn: [`${SRINAGAR}->NL`] })
+    const routes = await rateWithOriginFallback({
+      partnerOrigin: SRINAGAR,
+      hqOrigins: HQ,
+      destinationPincode: "1011AB",
+      destinationCountry: "NL",
+      weightGrams: 1200,
+      rate,
+      currencyCode: "inr",
+      chargeDomesticLeg: false,
+    })
+
+    expect(routes[0].total_amount).toBe(1276)
+    expect(routes[0].domestic_leg).toBeNull()
+    // Not "unrated" — nobody failed to price it, we chose not to charge it.
+    expect(routes[0].domestic_leg_unrated).toBe(false)
+  })
+
+  it("returns nothing when no origin can be rated at all", async () => {
+    const rate = jest.fn(async () => {
+      throw new Error("no couriers")
+    })
+    const routes = await rateWithOriginFallback({
+      partnerOrigin: SRINAGAR,
+      hqOrigins: HQ,
+      destinationPincode: "1011AB",
+      destinationCountry: "NL",
+      weightGrams: 1200,
+      rate,
+      currencyCode: "inr",
+    })
+    // The caller falls back to its flat rate — this must not manufacture one.
+    expect(routes).toEqual([])
+  })
+})

--- a/apps/backend/src/modules/shipping-providers/export-origins.ts
+++ b/apps/backend/src/modules/shipping-providers/export-origins.ts
@@ -1,0 +1,392 @@
+/**
+ * Rate an export from an HQ pin when the partner's own cannot be rated (#1498).
+ *
+ * ## The fact this encodes
+ *
+ * A partner in Srinagar cannot export directly. Probed live against Shiprocket
+ * on 2026-08-24, 1.2 kg / 30×25×10:
+ *
+ * | origin | → NL | → DE |
+ * |---|---|---|
+ * | 190001 Srinagar (partner) | ❌ 400, *no serviceable couriers* | ❌ 400 |
+ * | 110032 Delhi HQ | ✅ 8 couriers, from ₹1,276 | ✅ 5, from ₹1,852 |
+ * | 176215 Himachal HQ | ✅ 1 courier, ₹2,916 | ✅ 2, from ₹1,852 |
+ *
+ * The goods already route through a warehouse and export from there — this
+ * makes the *quote* describe the movement that actually happens. It is also the
+ * root cause of international freight reading flat at any weight: the partner
+ * pin 400s and every lane drops to `flatFallback`, which is one number
+ * regardless of weight.
+ *
+ * ## 🔴 Trap 1 — HQ pins are NOT interchangeable
+ *
+ * Delhi returns 8 couriers at ₹1,276 to NL; Himachal returns one at ₹2,916 —
+ * **2.3×** for the same parcel. A single hardcoded fallback silently
+ * over-quotes, so every configured origin is tried and the cheapest COMPLETE
+ * route wins.
+ *
+ * ## 🔴 Trap 2 — the export leg is not the price
+ *
+ * Routing through an HQ is two legs, and only one of them is the export:
+ *
+ * | route | Srinagar → HQ | HQ → NL | true landed |
+ * |---|---|---|---|
+ * | via Delhi | ₹206 | ₹1,276 | **₹1,482** |
+ * | via Himachal | ₹505 | ₹2,916 | ₹3,421 |
+ *
+ * Quoting the export leg alone under-quotes by ₹206–₹505 every time, absorbed
+ * by us — and it also picks the wrong HQ, because the leg costs do not rank the
+ * same way the export costs do. So the domestic leg is rated too and added.
+ *
+ * ## Why this lives ABOVE the provider
+ *
+ * The obvious place for this is inside `shiprocket/rate-context.ts`, and that
+ * would be wrong. "If the partner's origin cannot be rated, retry from an HQ
+ * origin" has nothing to do with Shiprocket — it is a property of how we move
+ * goods, and it applies identically to Blue Dart, DTDC and DHL as each gains a
+ * rate API. What differs per carrier is COVERAGE: which origins and
+ * destinations it will actually carry.
+ *
+ * So this takes a `rate()` callback and knows about no carrier at all. Today
+ * Shiprocket is the only live international rate source, so day one is a
+ * Shiprocket-only capability behind a carrier-agnostic seam.
+ *
+ * ## Why origins are configuration
+ *
+ * `EXPORT_FALLBACK_ORIGINS="110032:Delhi HQ,176215:Himachal HQ"`. A partner who
+ * later gets their own pin export-enabled simply starts winning — their origin
+ * has no domestic leg to pay for, so it undercuts every HQ route — with no code
+ * change and no list to edit. Constants would need a deploy to reflect a fact
+ * that changed at the carrier.
+ *
+ * ## 🔴 What it will not do
+ *
+ * - It never returns 0. A zero is indistinguishable from genuinely free freight
+ *   and shipped bulk orders free once already (#1430).
+ * - It never sums across currencies. `pickFreightOption` sorts on the raw
+ *   amount, so a leg in another currency does not merely fail to help — it wins
+ *   by being a smaller number (#1424). A route whose legs disagree on currency
+ *   is dropped, not converted: converting needs an FX rate this has no business
+ *   holding.
+ * - It never silently drops the domestic leg. An HQ route whose first leg could
+ *   not be rated is still returned — refusing it would mean falling back to the
+ *   flat rate, which is worse — but it is marked `domestic_leg_unrated` and
+ *   logged, so the caller can present it as indicative rather than landed.
+ */
+
+export type ExportOrigin = {
+  /** The pickup pincode handed to the carrier. */
+  pincode: string
+  /** Human label for logs and the audit trail ("Delhi HQ"). */
+  label: string
+}
+
+export type RouteLeg = {
+  origin_pincode: string
+  destination_pincode: string | null
+  destination_country: string | null
+  amount: number
+  currency_code: string
+  courier_id: string | null
+  courier_name: string | null
+  estimated_days: number | null
+}
+
+export type RatedRoute = {
+  /** The pin the export was actually rated from. */
+  origin_pincode: string
+  /** Null when this is the partner's own pin — the no-relay route. */
+  origin_label: string | null
+  /** True when the goods move to an HQ first. */
+  via_hq: boolean
+  export_leg: RouteLeg
+  domestic_leg: RouteLeg | null
+  /**
+   * 🔴 True when the goods MUST move to the HQ but that leg could not be
+   * priced, so `total_amount` is the export leg alone and is an under-quote of
+   * unknown size. Never true on a direct route.
+   */
+  domestic_leg_unrated: boolean
+  /** Landed freight: both legs. This is the number a buyer should see. */
+  total_amount: number
+  currency_code: string
+  courier_id: string | null
+  courier_name: string | null
+  estimated_days: number | null
+  is_recommended: boolean
+}
+
+/**
+ * PURE. Parse the configured HQ origins.
+ *
+ * Shape: `"110032:Delhi HQ,176215:Himachal HQ"`. A bare pincode is allowed and
+ * labels itself. Anything that is not a 6-digit Indian PIN is dropped rather
+ * than passed to a carrier that would answer a slower no — but see
+ * `parseExportOriginsStrict` if you want the rejects back.
+ */
+export function parseExportOrigins(raw?: string | null): ExportOrigin[] {
+  const { origins } = parseExportOriginsStrict(raw)
+  return origins
+}
+
+/** As above, but also reports what it threw away — for a config-check route. */
+export function parseExportOriginsStrict(raw?: string | null): {
+  origins: ExportOrigin[]
+  rejected: string[]
+} {
+  const origins: ExportOrigin[] = []
+  const rejected: string[] = []
+  const seen = new Set<string>()
+
+  for (const entry of String(raw || "").split(",")) {
+    const trimmed = entry.trim()
+    if (!trimmed) continue
+    const [pinPart, ...labelParts] = trimmed.split(":")
+    const pincode = pinPart.trim()
+    if (!/^\d{6}$/.test(pincode)) {
+      rejected.push(trimmed)
+      continue
+    }
+    // A duplicate pin is not a second route, it is the same call twice.
+    if (seen.has(pincode)) continue
+    seen.add(pincode)
+    origins.push({
+      pincode,
+      label: labelParts.join(":").trim() || `HQ ${pincode}`,
+    })
+  }
+
+  return { origins, rejected }
+}
+
+/** What a carrier answered for one lane. `rate` returns [] for "will not carry". */
+export type RateFn = (query: {
+  origin_pincode: string
+  destination_pincode: string
+  destination_country?: string
+  weight_grams: number
+}) => Promise<
+  Array<{
+    courier_id?: string | null
+    courier_name?: string | null
+    amount: number
+    currency_code?: string | null
+    estimated_days?: number | null
+    is_recommended?: boolean
+  }>
+>
+
+const toLeg = (
+  rate: any,
+  query: { origin: string; destPin: string | null; destCountry: string | null }
+): RouteLeg => ({
+  origin_pincode: query.origin,
+  destination_pincode: query.destPin,
+  destination_country: query.destCountry,
+  amount: Number(rate.amount),
+  currency_code: String(rate.currency_code || "inr").toLowerCase(),
+  courier_id: rate.courier_id ?? null,
+  courier_name: rate.courier_name ?? null,
+  estimated_days: rate.estimated_days ?? null,
+})
+
+/** A rate we would rather have no answer than believe. */
+const isUsable = (r: any): boolean =>
+  Number.isFinite(Number(r?.amount)) && Number(r.amount) > 0
+
+/** Cheapest first, then by courier name so a tie does not flip between mints. */
+const byAmountThenName = (a: RatedRoute, b: RatedRoute): number =>
+  a.total_amount - b.total_amount ||
+  String(a.courier_name || "").localeCompare(String(b.courier_name || ""))
+
+/**
+ * Rate a lane from the partner's own pin AND every configured HQ pin, and
+ * return every complete route, cheapest first.
+ *
+ * Carrier-agnostic by construction: it is handed `rate`, and asks it the same
+ * question per origin. A provider that cannot serve an origin must answer with
+ * an empty list or throw — either is a clean "no" here, never a 0.
+ *
+ * The partner's own origin is always tried first and, when it works, is
+ * normally the winner: it carries no domestic leg, so it undercuts every relay
+ * route on the same carrier. It is not privileged beyond that — if an HQ route
+ * genuinely lands cheaper, it wins, which is the whole point of trying all of
+ * them.
+ */
+export async function rateWithOriginFallback(args: {
+  partnerOrigin: string
+  hqOrigins: ExportOrigin[]
+  destinationPincode: string
+  destinationCountry?: string | null
+  weightGrams: number
+  rate: RateFn
+  /**
+   * Only routes priced in this currency are returned. Omit to accept whatever
+   * the carrier answers in, which is right for a single-currency caller and
+   * wrong for a quote — see the currency note in the header.
+   */
+  currencyCode?: string | null
+  /**
+   * Charge the domestic first leg. Default true: quoting the export leg alone
+   * under-quotes every relay route, and it also ranks the HQs wrongly. Set
+   * false only if stock demonstrably consolidates at HQ regardless of the
+   * order, which makes that leg a genuinely sunk cost.
+   */
+  chargeDomesticLeg?: boolean
+  logger?: { warn?: (m: string) => void; info?: (m: string) => void }
+}): Promise<RatedRoute[]> {
+  const {
+    partnerOrigin,
+    hqOrigins,
+    destinationPincode,
+    weightGrams,
+    rate,
+    logger,
+  } = args
+  const destinationCountry = args.destinationCountry
+    ? String(args.destinationCountry).toUpperCase()
+    : undefined
+  const chargeDomesticLeg = args.chargeDomesticLeg !== false
+  const wantCurrency = args.currencyCode
+    ? String(args.currencyCode).toLowerCase()
+    : null
+
+  const askExport = async (origin: string): Promise<any[]> => {
+    try {
+      const rates = await rate({
+        origin_pincode: origin,
+        destination_pincode: destinationPincode,
+        destination_country: destinationCountry,
+        weight_grams: weightGrams,
+      })
+      return (rates || []).filter(isUsable)
+    } catch (e: any) {
+      // A carrier refusing an origin is the ordinary case this exists for —
+      // Srinagar → NL is a 400, not an outage. Log at info, not warn.
+      logger?.info?.(
+        `[export-origins] ${origin} → ${
+          destinationCountry || destinationPincode
+        } could not be rated: ${e?.message ?? e}`
+      )
+      return []
+    }
+  }
+
+  const routes: RatedRoute[] = []
+
+  // ---- The partner's own pin ---------------------------------------------
+  for (const r of await askExport(partnerOrigin)) {
+    const leg = toLeg(r, {
+      origin: partnerOrigin,
+      destPin: destinationPincode || null,
+      destCountry: destinationCountry ?? null,
+    })
+    routes.push({
+      origin_pincode: partnerOrigin,
+      origin_label: null,
+      via_hq: false,
+      export_leg: leg,
+      domestic_leg: null,
+      domestic_leg_unrated: false,
+      total_amount: leg.amount,
+      currency_code: leg.currency_code,
+      courier_id: leg.courier_id,
+      courier_name: leg.courier_name,
+      estimated_days: leg.estimated_days,
+      is_recommended: !!r.is_recommended,
+    })
+  }
+
+  // ---- Every configured HQ pin -------------------------------------------
+  for (const hq of hqOrigins) {
+    // Rating a relay through the pin we already rated directly is the same
+    // route counted twice, with a phantom leg to itself bolted on.
+    if (hq.pincode === partnerOrigin) continue
+
+    const exportRates = await askExport(hq.pincode)
+    if (!exportRates.length) continue
+
+    // 🔴 Trap 2. Rated once per HQ, not once per courier: the first leg is the
+    // same movement whichever courier flies the parcel out.
+    let domesticLeg: RouteLeg | null = null
+    if (chargeDomesticLeg) {
+      try {
+        const legRates = (
+          await rate({
+            origin_pincode: partnerOrigin,
+            destination_pincode: hq.pincode,
+            weight_grams: weightGrams,
+          })
+        ).filter(isUsable)
+        // Cheapest: the first leg is a commodity movement, not a service the
+        // buyer chose.
+        const cheapest = legRates.sort(
+          (a, b) => Number(a.amount) - Number(b.amount)
+        )[0]
+        if (cheapest) {
+          domesticLeg = toLeg(cheapest, {
+            origin: partnerOrigin,
+            destPin: hq.pincode,
+            destCountry: null,
+          })
+        }
+      } catch (e: any) {
+        logger?.warn?.(
+          `[export-origins] the first leg ${partnerOrigin} → ${hq.pincode} (${hq.label}) could not be rated: ${e?.message ?? e}`
+        )
+      }
+      if (!domesticLeg) {
+        logger?.warn?.(
+          `[export-origins] routing via ${hq.label} with NO price for the ` +
+            `${partnerOrigin} → ${hq.pincode} leg — the quoted freight is the ` +
+            `export leg alone and under-quotes the real movement.`
+        )
+      }
+    }
+
+    for (const r of exportRates) {
+      const leg = toLeg(r, {
+        origin: hq.pincode,
+        destPin: destinationPincode || null,
+        destCountry: destinationCountry ?? null,
+      })
+
+      // 🔴 Never sum across currencies. Dropped, never converted.
+      if (domesticLeg && domesticLeg.currency_code !== leg.currency_code) {
+        logger?.warn?.(
+          `[export-origins] dropped the ${hq.label} route: its legs are priced ` +
+            `in ${domesticLeg.currency_code} and ${leg.currency_code}, and ` +
+            `adding them would corrupt the landed total.`
+        )
+        continue
+      }
+
+      routes.push({
+        origin_pincode: hq.pincode,
+        origin_label: hq.label,
+        via_hq: true,
+        export_leg: leg,
+        domestic_leg: domesticLeg,
+        domestic_leg_unrated: chargeDomesticLeg && !domesticLeg,
+        total_amount: leg.amount + (domesticLeg?.amount ?? 0),
+        currency_code: leg.currency_code,
+        courier_id: leg.courier_id,
+        courier_name: leg.courier_name,
+        estimated_days: leg.estimated_days,
+        is_recommended: !!r.is_recommended,
+      })
+    }
+  }
+
+  const inCurrency = wantCurrency
+    ? routes.filter((r) => {
+        if (r.currency_code === wantCurrency) return true
+        logger?.warn?.(
+          `[export-origins] dropped a ${r.currency_code} route (${r.total_amount}) — the quote is in ${wantCurrency}.`
+        )
+        return false
+      })
+    : routes
+
+  return inCurrency.sort(byAmountThenName)
+}


### PR DESCRIPTION
Closes the rating half of #1498.

## The fact

Probed live against Shiprocket, 24 Aug, 1.2 kg / 30×25×10:

| origin | → NL | → DE |
|---|---|---|
| 190001 Srinagar (partner) | ❌ 400, *no serviceable couriers* | ❌ 400 |
| **110032 Delhi HQ** | ✅ **8 couriers, from ₹1,276** | ✅ 5, from ₹1,852 |
| 176215 Himachal HQ | ✅ 1 courier, ₹2,916 | ✅ 2, from ₹1,852 |

This is also why international freight read **flat at any weight**: the partner pin 400s, the lane drops to `flatFallback`, and that is one number whatever the parcel weighs. Hand-typed intl rates in use have been ₹3,500–4,200; a rated Delhi route is about a third.

## Carrier-agnostic by construction

`export-origins.ts` takes a `rate()` callback and names no carrier. The origin-fallback loop is a property of how we physically move goods, not of Shiprocket, and Blue Dart / DTDC / DHL slot into the same call as each gains a rate API — what differs per carrier is *coverage*.

## The two traps, both with tests

**1. HQ pins are not interchangeable.** Delhi is 2.3× cheaper to NL. Every configured origin is tried; the cheapest **complete** route wins.

**2. The export leg is not the price.**

| route | Srinagar→HQ | HQ→NL | landed |
|---|---|---|---|
| via Delhi | ₹206 | ₹1,276 | **₹1,482** |
| via Himachal | ₹505 | ₹2,916 | ₹3,421 |

There is a test that inverts the export prices so the first leg *changes the winner* — otherwise the assertion would pass whether or not the leg is counted.

## What it refuses to do

- **Never returns 0** (#1430).
- **Never sums across currencies** (#1424) — dropped, never converted.
- **Never silently drops an unrateable first leg.** The route survives (refusing means the flat rate, which is worse) but is marked `domestic_leg_unrated` and logged.

## Configuration, not constants

```
EXPORT_FALLBACK_ORIGINS=110032:Delhi HQ,176215:Himachal HQ
EXPORT_FIRST_LEG_IS_SUNK=false   # default; see open question 1
```

A partner whose own pin becomes export-enabled starts winning with no deploy — a direct route pays no first leg, so it undercuts every relay.

## 🔴 The gap this uncovered

A carrier rate has no `shipping_option_id`, and acceptance **requires** one — it mints the cart's freight option in the service zone of the option the quote was rated against, and refuses when the quote froze none. **A quote won by a live rate priced fine and could never be bought.**

That was invisible while cross-border lanes fell to the flat fallback and won on a manual row. Shipping this without the fix would have turned a pricing improvement into "this quote cannot be bought" — #1497 again, found by the buyer at the last step.

A calculated winner now borrows the **zone** (never the price) of a manual option already filtered to the lane. Where the store has no lane at all, the id stays null and #1497's refusal stands — that is the honest answer.

## Open questions from #1498, and what I did

| # | question | this PR |
|---|---|---|
| 1 | is the domestic leg a sunk cost? | **charges it** by default; `EXPORT_FIRST_LEG_IS_SUNK=true` flips it. Omitting under-quotes *and* misranks. |
| 2 | which HQ holds the goods? | **not modelled** — rating cannot see stock. Cheapest landed route wins. Still open. |
| 3 | one freight line or two? | **one landed number**, both legs recorded on `freight.chosen.route` so margin is auditable. |
| 4 | customs origin | **untouched.** Exporting from Delhi rather than Srinagar may change the declaration — needs a check against #348 before this is switched on in prod. |

## Verification

- 15 new unit tests on the fallback, all using the **live probe numbers** rather than invented ones
- 3 on the picker; the lane-borrowing one **confirmed to fail on old code**
- 851 unit tests green across the touched modules; 40 quote integration tests green
- `check:prod-build` green

## Watch-outs

- **Inert until `EXPORT_FALLBACK_ORIGINS` is set.** Merging changes nothing on prod by itself — deliberate, given open question 4.
- Only fires on **international** lanes. Relaying a domestic parcel through Delhi is not something we do.
- No UI yet: `freight.chosen.route` is in the API but no page renders "via Delhi HQ". Follow-up.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_0158wJMZ1DmjNxXf5uGuBrQD