### PR TITLE
feat(quotes): attach a design to any quote line, and refuse a foreign one (#1501)

### DIFF
--- a/apps/backend/integration-tests/http/partner-quote-design-lines.spec.ts
+++ b/apps/backend/integration-tests/http/partner-quote-design-lines.spec.ts
@@ -151,6 +151,95 @@ setupSharedTestSuite(() => {
       expect(String(err.data?.message ?? "")).toContain("does not exist")
     })
 
+
+    it("🔴 attaches a design to a line picked as a PRODUCT (#1501)", async () => {
+      // The other half of #1486. `design_by_variant` has always been frozen
+      // onto the line, but only the design PICKER could write it — a line found
+      // the ordinary way, in the product table, could never be told what it was
+      // made to. Both ids on one line: the variant prices it, the design says
+      // what it is.
+      const { api } = getSharedTestEnv()
+      const res = await api.post(
+        "/partners/quotes",
+        mintBody(seed, {
+          buyer_email: `attach-${seed.unique}@jaalyantra.test`,
+          lines: [
+            { variant_id: seed.variantB.id, design_id: sketchDesignId, quantity: 10 },
+          ],
+        }),
+        { headers: seed.headers }
+      )
+
+      expect(res.status).toBe(201)
+
+      const query: any = container().resolve(ContainerRegistrationKeys.QUERY)
+      const { data } = await query.graph({
+        entity: "partner_quote",
+        fields: ["id", "lines.variant_id", "lines.design_id"],
+        filters: { id: res.data.quote.id },
+      })
+      const line = ((data?.[0] as any)?.lines ?? [])[0]
+
+      // 🔑 The variant is NOT moved to whatever the design resolves to.
+      expect(line.variant_id).toBe(seed.variantB.id)
+      expect(line.design_id).toBe(sketchDesignId)
+    })
+
+    it("accepts an UNBACKED design as provenance — visibility, not resolvability", async () => {
+      // `sketchDesignId` has no product behind it, so quoting it ALONE is
+      // refused two tests above. Once the variant is chosen, "which design is
+      // this" has a perfectly good answer, and refusing it would block the
+      // ordinary case of recording the sketch a catalogue product was made
+      // from. Covered by the test above; this pins the asymmetry explicitly.
+      const { api } = getSharedTestEnv()
+      const err = await api
+        .post(
+          "/partners/quotes",
+          mintBody(seed, {
+            buyer_email: `sketch-alone-${seed.unique}@jaalyantra.test`,
+            lines: [{ design_id: sketchDesignId, quantity: 10 }],
+          }),
+          { headers: seed.headers }
+        )
+        .catch((e: any) => e.response)
+
+      expect(err.status).toBe(400)
+      expect(String(err.data?.message ?? "")).toContain("no product behind it")
+    })
+
+    it("🔴 refuses ANOTHER partner's design even on a line that names its variant (#1501)", async () => {
+      // The hole. A line with a variant skipped design resolution entirely, so
+      // any string at all could be frozen onto a commercial document as its
+      // design — including another partner's design id. Nothing renders it
+      // today, which is the only reason it was not a leak; an unchecked foreign
+      // id on a signed document is the #1496 family.
+      const { api } = getSharedTestEnv()
+      const service: any = container().resolve(DESIGN_MODULE)
+      const other = await service.createDesigns({
+        name: "Not ours either",
+        description: "owned by another partner",
+        owner_partner_id: "part_also_not_ours",
+      })
+      const otherId = (Array.isArray(other) ? other[0] : other).id
+
+      const err = await api
+        .post(
+          "/partners/quotes",
+          mintBody(seed, {
+            buyer_email: `foreign-attach-${seed.unique}@jaalyantra.test`,
+            lines: [
+              { variant_id: seed.variantA.id, design_id: otherId, quantity: 10 },
+            ],
+          }),
+          { headers: seed.headers }
+        )
+        .catch((e: any) => e.response)
+
+      expect(err.status).toBe(400)
+      // The same words a missing design gets, so an id cannot be probed for
+      // existence by attaching it to a line that already has its variant.
+      expect(String(err.data?.message ?? "")).toContain("does not exist")
+    })
     it("the readiness preflight REPORTS an unquotable design instead of throwing", async () => {
       const { api } = getSharedTestEnv()
       const body = mintBody(seed, {

--- a/apps/backend/src/admin/routes/quotes/create/__tests__/line-designs.unit.spec.ts
+++ b/apps/backend/src/admin/routes/quotes/create/__tests__/line-designs.unit.spec.ts
@@ -1,0 +1,75 @@
+import { assignDesign, designLineRows } from "../line-designs"
+
+/**
+ * The admin twin of `partner-ui`'s `quote-line-designs.spec.ts` (#1501).
+ *
+ * ⚠️ The two wizards cannot share a module — different build graphs — so they
+ * share ASSERTIONS instead. If one copy drifts, one of these two files goes
+ * red; without them the two mint surfaces would quietly disagree about what a
+ * cleared design field means, which is the kind of difference nobody notices
+ * until a quote mints wrong on one of them.
+ */
+
+const PRODUCTS = [
+  {
+    title: "Kashida Shawl",
+    variants: [
+      { id: "var_s", title: "S", sku: "KAS-S" },
+      { id: "var_m", title: "M", sku: "KAS-M" },
+    ],
+  },
+  {
+    title: "Pashmina Stole",
+    variants: [{ id: "var_one", title: null, sku: "PAS-1" }],
+  },
+]
+
+describe("designLineRows (admin)", () => {
+  it("lists only the variants carrying a quantity", () => {
+    expect(designLineRows(PRODUCTS, { var_m: 200 }).map((r) => r.id)).toEqual([
+      "var_m",
+    ])
+  })
+
+  it("🔴 treats an empty quantity as no line, not as zero", () => {
+    // `Number("")` is 0. The same coercion already parsed a truncated quote
+    // link as "remove this line".
+    expect(designLineRows(PRODUCTS, { var_m: "" })).toEqual([])
+    expect(designLineRows(PRODUCTS, { var_m: 0 })).toEqual([])
+    expect(designLineRows(PRODUCTS, { var_m: "200" })).toHaveLength(1)
+  })
+
+  it("falls back to the SKU when a variant has no title", () => {
+    expect(designLineRows(PRODUCTS, { var_one: 5 })[0].label).toBe(
+      "Pashmina Stole — PAS-1"
+    )
+  })
+
+  it("is empty rather than throwing when nothing is selected", () => {
+    expect(designLineRows([], {})).toEqual([])
+    expect(designLineRows(PRODUCTS, undefined)).toEqual([])
+  })
+})
+
+describe("assignDesign (admin)", () => {
+  it("sets a design on a line", () => {
+    expect(assignDesign({}, "var_m", "des_1")).toEqual({ var_m: "des_1" })
+  })
+
+  it("🔴 DELETES the key when cleared rather than writing an empty string", () => {
+    const cleared = assignDesign({ var_m: "des_1" }, "var_m", undefined)
+    expect("var_m" in cleared).toBe(false)
+    expect(assignDesign({ var_m: "des_1" }, "var_m", "")).toEqual({})
+  })
+
+  it("leaves every other line alone", () => {
+    expect(
+      assignDesign({ var_s: "des_a", var_m: "des_b" }, "var_m", "des_c")
+    ).toEqual({ var_s: "des_a", var_m: "des_c" })
+  })
+
+  it("returns a NEW object so the form sees a change", () => {
+    const current = { var_s: "des_a" }
+    expect(assignDesign(current, "var_m", "des_b")).not.toBe(current)
+  })
+})

--- a/apps/backend/src/admin/routes/quotes/create/line-designs-panel.tsx
+++ b/apps/backend/src/admin/routes/quotes/create/line-designs-panel.tsx
@@ -1,0 +1,132 @@
+import { Badge, Text } from "@medusajs/ui"
+import { useMemo, useState } from "react"
+import { UseFormReturn, useWatch } from "react-hook-form"
+
+import { Combobox } from "../../../components/inputs/combobox/combobox"
+import { useQuotableDesigns } from "../../../hooks/api/quotes"
+import { assignDesign, designLineRows } from "./line-designs"
+import { AdminQuoteCreateSchemaType } from "./schema"
+
+type Props = {
+  form: UseFormReturn<AdminQuoteCreateSchemaType>
+  products: any[]
+}
+
+/**
+ * Say which design each line was made to — the admin twin (#1501).
+ *
+ * ## The gap
+ *
+ * `design_by_variant` has existed since #1486 and the mint has always frozen it
+ * onto the line, but it could only be WRITTEN by the design picker in the
+ * previous step. A line found the ordinary way, in the product table, could
+ * never be told what it was made to, and a line that arrived through a design
+ * could never be corrected. The field was half-writable: one entry point, no
+ * edit, no clear.
+ *
+ * ## Why here and not as a grid column
+ *
+ * A design is chosen from hundreds by name, which is a search. The quantities
+ * grid is a numeric keyboard surface whose arrow-key navigation a combobox
+ * would fight.
+ *
+ * ## 🔑 Designs are listed UNSCOPED
+ *
+ * Same rule the design picker already follows: an admin legitimately quotes a
+ * design the producing partner does not own, and narrowing by partner hid
+ * exactly those designs behind what looked like an empty catalogue. The mint
+ * still asserts the resolved variant is in the chosen partner's sales channel.
+ */
+export const AdminLineDesignsPanel = ({ form, products }: Props) => {
+  const [search, setSearch] = useState("")
+
+  const quantities = useWatch({ control: form.control, name: "quantities" })
+  const designByVariant = useWatch({
+    control: form.control,
+    name: "design_by_variant",
+  })
+
+  const { designs, isLoading } = useQuotableDesigns({
+    q: search.trim() || undefined,
+    limit: 50,
+  })
+
+  const lines = useMemo(
+    () => designLineRows(products as any[], quantities as any),
+    [products, quantities]
+  )
+
+  /**
+   * 🔴 Every design, not only the quotable ones.
+   *
+   * The picker in the previous step greys out a design with no product behind
+   * it, because there it has to RESOLVE to a variant. Here the variant is
+   * already chosen and the design only says what the line was made to — a
+   * sketch with no product of its own is the ordinary answer to that, and the
+   * backend accepts it on a line that names its variant.
+   */
+  const options = useMemo(
+    () => (designs ?? []).map((d: any) => ({ label: d.name ?? d.id, value: d.id })),
+    [designs]
+  )
+
+  const assignedCount = lines.filter(
+    (l) => (designByVariant as any)?.[l.id]
+  ).length
+
+  if (!lines.length) return null
+
+  return (
+    <div className="mx-6 mb-4 flex flex-col gap-y-3 rounded-lg border border-ui-border-base bg-ui-bg-subtle px-4 py-3 md:mx-16">
+      <div className="flex items-center gap-x-2">
+        <Text size="small" weight="plus">
+          Design for each line
+        </Text>
+        <Text size="small" className="text-ui-fg-subtle">
+          Optional. Records what the line was made to; it does not change the
+          price.
+        </Text>
+        {assignedCount > 0 && (
+          <Badge size="2xsmall" className="ml-auto">
+            {assignedCount}/{lines.length}
+          </Badge>
+        )}
+      </div>
+
+      <div className="flex flex-col gap-y-2">
+        {lines.map((line) => (
+          <div
+            key={line.id}
+            className="flex flex-col gap-y-1 md:flex-row md:items-center md:gap-x-3"
+          >
+            <Text size="small" className="truncate md:w-1/2">
+              {line.label}
+            </Text>
+            <div className="md:w-1/2">
+              <Combobox
+                options={options}
+                value={((designByVariant as any)?.[line.id] as string) ?? ""}
+                onChange={(v) =>
+                  form.setValue(
+                    "design_by_variant",
+                    assignDesign(
+                      designByVariant as any,
+                      line.id,
+                      v as string | undefined
+                    ),
+                    { shouldDirty: true }
+                  )
+                }
+                searchValue={search}
+                onSearchValueChange={setSearch}
+                allowClear
+                isFetchingNextPage={isLoading}
+                placeholder="No design"
+              />
+            </div>
+          </div>
+        ))}
+      </div>
+    </div>
+  )
+}

--- a/apps/backend/src/admin/routes/quotes/create/line-designs.ts
+++ b/apps/backend/src/admin/routes/quotes/create/line-designs.ts
@@ -1,0 +1,62 @@
+/**
+ * The two decisions behind "which design was this line made to" (#1501).
+ *
+ * ⚠️ A DELIBERATE second copy of `partner-ui`'s `quote-line-designs.ts`, not a
+ * shared module. The two wizards live in different build graphs — `tsconfig`
+ * excludes `apps/*` and the admin bundle cannot import from the partner app —
+ * so the only ways to share are a package or a copy. Both files are pure, both
+ * are tested, and each test file asserts the same behaviour, so a drift shows
+ * up as a failing test rather than as two mint surfaces quietly disagreeing.
+ */
+
+export type DesignLineRow = { id: string; label: string }
+
+/**
+ * The variants that are actually LINES.
+ *
+ * 🔴 Quantity-bearing only, or an admin who selected a ten-variant product to
+ * quote one of them is asked to attribute nine lines that will never be minted.
+ *
+ * 🔑 `Number("")` is `0`, which is why the guard is `> 0` and not a truthiness
+ * check — an empty quantity cell must read as "not a line", and a truthiness
+ * check on the raw string would call "0" a line and 0 not one.
+ */
+export function designLineRows(
+  products: Array<{ title?: string | null; variants?: any[] | null }>,
+  quantities: Record<string, unknown> | undefined
+): DesignLineRow[] {
+  const out: DesignLineRow[] = []
+  for (const product of products ?? []) {
+    for (const variant of product?.variants ?? []) {
+      if (!variant?.id) continue
+      const qty = Number(quantities?.[variant.id])
+      if (!Number.isFinite(qty) || qty <= 0) continue
+      out.push({
+        id: variant.id,
+        label: `${product.title ?? "Product"} — ${
+          variant.title ?? variant.sku ?? variant.id
+        }`,
+      })
+    }
+  }
+  return out
+}
+
+/**
+ * Set or clear one line's design.
+ *
+ * 🔴 Clearing DELETES the key. Writing `""` looks equivalent and is not: the
+ * payload builder sends `design_id` whenever the entry is present, so an empty
+ * string would travel to the mint as a design id and be refused as one that
+ * does not exist — clearing a field would produce a failed mint.
+ */
+export function assignDesign(
+  current: Record<string, string> | undefined,
+  variantId: string,
+  designId?: string | null
+): Record<string, string> {
+  const next = { ...(current ?? {}) }
+  if (!designId) delete next[variantId]
+  else next[variantId] = designId
+  return next
+}

--- a/apps/backend/src/admin/routes/quotes/create/steps/quantities-step.tsx
+++ b/apps/backend/src/admin/routes/quotes/create/steps/quantities-step.tsx
@@ -9,6 +9,7 @@ import { DataGridNumberCell } from "../../../../components/data-grid/components/
 import { DataGridReadonlyCell } from "../../../../components/data-grid/components/data-grid-readonly-cell"
 import { createDataGridHelper } from "../../../../components/data-grid/helpers/create-data-grid-column-helper"
 import { useProducts } from "../../../../hooks/api/products"
+import { AdminLineDesignsPanel } from "../line-designs-panel"
 import { AdminQuoteCreateSchemaType } from "../schema"
 
 type Props = { form: UseFormReturn<AdminQuoteCreateSchemaType> }
@@ -239,6 +240,13 @@ export const QuantitiesStep = ({ form }: Props) => {
         }
         state={form}
       />
+
+      {/*
+        Below the grid, not inside it (#1501): a design is picked from hundreds
+        by NAME, which is a search, and the grid is a numeric keyboard surface
+        whose arrow-key navigation a combobox would fight.
+      */}
+      <AdminLineDesignsPanel form={form} products={selected} />
     </div>
   )
 }

--- a/apps/backend/src/modules/partner-quote/__tests__/design-lines.unit.spec.ts
+++ b/apps/backend/src/modules/partner-quote/__tests__/design-lines.unit.spec.ts
@@ -18,6 +18,7 @@ import { toQuotableDesign } from "../lib/quotable-designs"
 const resolved = (designId: string, variantId: string): DesignResolution => ({
   design_id: designId,
   design_name: "Kashida Shawl",
+  visible: true,
   variant_id: variantId,
   candidates: [
     { variant_id: variantId, title: "One size", sku: "KAS-1", product_id: "prod_1", product_title: "Kashida Shawl" },
@@ -28,6 +29,7 @@ const resolved = (designId: string, variantId: string): DesignResolution => ({
 const ambiguous = (designId: string): DesignResolution => ({
   design_id: designId,
   design_name: "Kashida Shawl",
+  visible: true,
   variant_id: null,
   candidates: [
     { variant_id: "var_s", title: "S", sku: "KAS-S", product_id: "prod_1", product_title: "Kashida Shawl" },
@@ -39,9 +41,25 @@ const ambiguous = (designId: string): DesignResolution => ({
 const unbacked = (designId: string): DesignResolution => ({
   design_id: designId,
   design_name: "Sketch only",
+  visible: true,
   variant_id: null,
   candidates: [],
   reason: '"Sketch only" has no product behind it yet, so there is nothing to price. Create a product from the design first.',
+})
+
+/**
+ * A design that is not this caller's to quote — or does not exist.
+ *
+ * 🔑 The two answer IDENTICALLY on purpose, so an id cannot be probed for
+ * existence by attaching it to a quote line.
+ */
+const invisible = (designId: string): DesignResolution => ({
+  design_id: designId,
+  design_name: null,
+  visible: false,
+  variant_id: null,
+  candidates: [],
+  reason: `Design ${designId} does not exist.`,
 })
 
 describe("applyDesignResolutions", () => {
@@ -102,6 +120,56 @@ describe("applyDesignResolutions", () => {
     )
 
     expect(errors).toHaveLength(2)
+  })
+
+  it("🔴 refuses a design this caller may not quote, even on a line that names its variant", () => {
+    // The hole #1501 closes. A line with a variant skipped design resolution
+    // ENTIRELY, so any string at all — including another partner's design id —
+    // was frozen onto the quote as its design. Nothing renders it today, which
+    // is the only reason it was not a leak.
+    const { errors } = applyDesignResolutions(
+      [{ variant_id: "var_mine", design_id: "des_theirs", quantity: 50 }],
+      new Map([["des_theirs", invisible("des_theirs")]])
+    )
+
+    expect(errors).toHaveLength(1)
+    // The same words a design that does not exist gets, so an id cannot be
+    // probed for existence by attaching it to a line.
+    expect(errors[0]).toContain("does not exist")
+  })
+
+  it("does NOT move the line to the design's own variant", () => {
+    // Attaching a design to a line the partner already chose must never
+    // silently re-point it at a different SKU — that would change what is being
+    // sold as a side effect of recording what it was made from.
+    const { lines, errors } = applyDesignResolutions(
+      [{ variant_id: "var_chosen", design_id: "des_1", quantity: 50 }],
+      new Map([["des_1", resolved("des_1", "var_other")]])
+    )
+
+    expect(errors).toEqual([])
+    expect(lines[0].variant_id).toBe("var_chosen")
+    expect(lines[0].design_id).toBe("des_1")
+  })
+
+  it("accepts an UNBACKED design as provenance once the variant is chosen", () => {
+    // Visibility, not resolvability. "No product behind it" is a perfectly good
+    // answer to "which design is this" when the buyer is being sold a variant
+    // that already exists — refusing it would block the ordinary case of
+    // recording the sketch a catalogue product was made from.
+    const { errors } = applyDesignResolutions(
+      [{ variant_id: "var_chosen", design_id: "des_2", quantity: 50 }],
+      new Map([["des_2", unbacked("des_2")]])
+    )
+    expect(errors).toEqual([])
+  })
+
+  it("accepts an AMBIGUOUS design as provenance too", () => {
+    const { errors } = applyDesignResolutions(
+      [{ variant_id: "var_m", design_id: "des_1", quantity: 50 }],
+      new Map([["des_1", ambiguous("des_1")]])
+    )
+    expect(errors).toEqual([])
   })
 
   it("leaves a plain product line completely alone", () => {

--- a/apps/backend/src/modules/partner-quote/lib/design-lines.ts
+++ b/apps/backend/src/modules/partner-quote/lib/design-lines.ts
@@ -44,6 +44,15 @@ export type DesignVariantCandidate = {
 export type DesignResolution = {
   design_id: string
   design_name: string | null
+  /**
+   * The design is real AND this caller may quote it. False answers "not yours"
+   * and "not there" identically, deliberately, so an id cannot be probed.
+   *
+   * 🔑 Distinct from `variant_id`: a design can be perfectly visible and still
+   * not resolvable (no product behind it, or sold as several variants). A line
+   * that already names its variant needs only the first fact.
+   */
+  visible: boolean
   /** The one variant to quote through, or null when that is not decidable. */
   variant_id: string | null
   /** Everything it COULD be quoted through. One entry means resolved. */
@@ -114,6 +123,7 @@ export async function resolveDesignVariants(
       out.set(designId, {
         design_id: designId,
         design_name: null,
+        visible: false,
         variant_id: null,
         candidates: [],
         reason: `Design ${designId} does not exist.`,
@@ -126,6 +136,7 @@ export async function resolveDesignVariants(
     out.set(designId, {
       design_id: designId,
       design_name: design.name ?? null,
+      visible: true,
       variant_id: candidates.length === 1 ? candidates[0].variant_id : null,
       candidates,
       reason:
@@ -278,14 +289,35 @@ export function applyDesignResolutions(
     const designId = line.design_id ? String(line.design_id) : null
     if (!designId) return line
 
-    if (line.variant_id) {
-      // Both given — the design is provenance, the variant is the choice.
-      return line
-    }
-
     const resolution = resolutions.get(designId)
     if (!resolution) {
       errors.push(`Design ${designId} could not be looked up.`)
+      return line
+    }
+
+    if (line.variant_id) {
+      /**
+       * Both given — the design is provenance, the variant is the choice
+       * (#1501). The variant is NEVER overwritten: attaching a design to a
+       * line the partner already chose must not silently move the line to a
+       * different SKU.
+       *
+       * 🔴 But it is still asserted VISIBLE, which it was not before. A line
+       * that named its own variant skipped design resolution entirely, so any
+       * string at all could be frozen onto a commercial document as its
+       * design — including another partner's design id. Nothing rendered it,
+       * which is the only reason it was not a leak; an unchecked foreign id on
+       * a signed document is the #1496 family and does not get to wait for a
+       * renderer to make it real.
+       *
+       * Visibility, not resolvability: a design with no product behind it, or
+       * one sold as several variants, is a perfectly good ANSWER to "which
+       * design is this" once the variant is already chosen. Only the resolving
+       * path needs it narrowed to one.
+       */
+      if (!resolution.visible) {
+        errors.push(resolution.reason ?? `Design ${designId} does not exist.`)
+      }
       return line
     }
 
@@ -311,7 +343,10 @@ export async function resolveQuoteDesignLines(
   input: { lines: QuoteLineInput[]; partner_id?: string | null }
 ): Promise<QuoteLineInput[]> {
   const designIds = (input.lines ?? [])
-    .filter((l) => l?.design_id && !l?.variant_id)
+    // EVERY design named, not only the ones being resolved TO a variant: a
+    // line that already has its variant still has to prove the design it
+    // claims is one this caller may quote (#1501).
+    .filter((l) => l?.design_id)
     .map((l) => String(l.design_id))
 
   if (!designIds.length) return input.lines ?? []
@@ -357,7 +392,10 @@ export async function resolveDesignLinesForReadiness(
   }>
 }> {
   const designIds = (input.lines ?? [])
-    .filter((l) => l?.design_id && !l?.variant_id)
+    // EVERY design named, not only the ones being resolved TO a variant: a
+    // line that already has its variant still has to prove the design it
+    // claims is one this caller may quote (#1501).
+    .filter((l) => l?.design_id)
     .map((l) => String(l.design_id))
 
   if (!designIds.length) return { lines: input.lines ?? [], issues: [] }
@@ -369,9 +407,28 @@ export async function resolveDesignLinesForReadiness(
 
   const { lines } = applyDesignResolutions(input.lines, resolutions)
 
+  /**
+   * Two different questions, so two different tests (#1501).
+   *
+   * A design on a line with NO variant must resolve to exactly one — that is
+   * the whole job. A design attached to a line that already names its variant
+   * only has to be one this caller may quote: "sold as 3 variants" is a fine
+   * answer to "which design is this" when the variant is already chosen, and
+   * reporting it as blocking would invent a problem the partner cannot fix
+   * and did not have.
+   */
+  const resolvingIds = new Set(
+    (input.lines ?? [])
+      .filter((l) => l?.design_id && !l?.variant_id)
+      .map((l) => String(l.design_id))
+  )
+
   const issues = designIds
     .map((id) => resolutions.get(id))
-    .filter((r): r is DesignResolution => Boolean(r) && !r!.variant_id)
+    .filter((r): r is DesignResolution => {
+      if (!r) return false
+      return resolvingIds.has(r.design_id) ? !r.variant_id : !r.visible
+    })
     .map((r) => ({
       code: "design_unresolved" as const,
       severity: "blocking" as const,

--- a/apps/partner-ui/src/routes/orders/quote-create/components/quote-create-form/__tests__/quote-line-designs.spec.ts
+++ b/apps/partner-ui/src/routes/orders/quote-create/components/quote-create-form/__tests__/quote-line-designs.spec.ts
@@ -1,0 +1,71 @@
+import { describe, expect, it } from "vitest"
+
+import { assignDesign, designLineRows } from "../quote-line-designs"
+
+const PRODUCTS = [
+  {
+    title: "Kashida Shawl",
+    variants: [
+      { id: "var_s", title: "S", sku: "KAS-S" },
+      { id: "var_m", title: "M", sku: "KAS-M" },
+    ],
+  },
+  {
+    title: "Pashmina Stole",
+    variants: [{ id: "var_one", title: null, sku: "PAS-1" }],
+  },
+]
+
+describe("designLineRows", () => {
+  it("lists only the variants carrying a quantity", () => {
+    // A ten-variant product selected to quote one of them must not produce nine
+    // rows asking the partner to attribute lines that will never be minted.
+    const rows = designLineRows(PRODUCTS, { var_m: 200 })
+    expect(rows.map((r) => r.id)).toEqual(["var_m"])
+  })
+
+  it("🔴 treats an empty quantity as no line, not as zero", () => {
+    // `Number("")` is 0, and a truthiness check on the raw cell would get this
+    // exactly backwards. The same coercion already parsed a truncated quote
+    // link as "remove this line" once.
+    expect(designLineRows(PRODUCTS, { var_m: "" })).toEqual([])
+    expect(designLineRows(PRODUCTS, { var_m: 0 })).toEqual([])
+    expect(designLineRows(PRODUCTS, { var_m: "200" })).toHaveLength(1)
+  })
+
+  it("falls back to the SKU when a variant has no title", () => {
+    const rows = designLineRows(PRODUCTS, { var_one: 5 })
+    expect(rows[0].label).toBe("Pashmina Stole — PAS-1")
+  })
+
+  it("is empty rather than throwing when nothing is selected", () => {
+    expect(designLineRows([], {})).toEqual([])
+    expect(designLineRows(PRODUCTS, undefined)).toEqual([])
+  })
+})
+
+describe("assignDesign", () => {
+  it("sets a design on a line", () => {
+    expect(assignDesign({}, "var_m", "des_1")).toEqual({ var_m: "des_1" })
+  })
+
+  it("🔴 DELETES the key when cleared rather than writing an empty string", () => {
+    // The payload builder sends `design_id` whenever the entry is present, so
+    // "" would travel to the mint as a design id and be refused as one that
+    // does not exist — clearing a field would produce a failed mint.
+    const cleared = assignDesign({ var_m: "des_1" }, "var_m", undefined)
+    expect("var_m" in cleared).toBe(false)
+    expect(assignDesign({ var_m: "des_1" }, "var_m", "")).toEqual({})
+  })
+
+  it("leaves every other line alone", () => {
+    expect(
+      assignDesign({ var_s: "des_a", var_m: "des_b" }, "var_m", "des_c")
+    ).toEqual({ var_s: "des_a", var_m: "des_c" })
+  })
+
+  it("returns a NEW object so the form sees a change", () => {
+    const current = { var_s: "des_a" }
+    expect(assignDesign(current, "var_m", "des_b")).not.toBe(current)
+  })
+})

--- a/apps/partner-ui/src/routes/orders/quote-create/components/quote-create-form/quote-line-designs-panel.tsx
+++ b/apps/partner-ui/src/routes/orders/quote-create/components/quote-create-form/quote-line-designs-panel.tsx
@@ -1,0 +1,151 @@
+import { Badge, Text } from "@medusajs/ui"
+import { HttpTypes } from "@medusajs/types"
+import { useMemo, useState } from "react"
+import { UseFormReturn, useWatch } from "react-hook-form"
+import { useTranslation } from "react-i18next"
+
+import { Combobox } from "../../../../../components/inputs/combobox"
+import { usePartnerQuotableDesigns } from "../../../../../hooks/api/partner-quotes"
+import { assignDesign, designLineRows } from "./quote-line-designs"
+import { QuoteCreateSchemaType } from "./schema"
+
+type QuoteLineDesignsPanelProps = {
+  form: UseFormReturn<QuoteCreateSchemaType>
+  products: HttpTypes.AdminProduct[]
+}
+
+/**
+ * Say which design each line was made to (#1501).
+ *
+ * ## The gap this closes
+ *
+ * `design_by_variant` has existed since #1486, and the mint has always frozen
+ * it onto the line. But it could only ever be WRITTEN by the design picker in
+ * the previous step — tick a design there and the product behind it joins the
+ * basket, carrying the design. A line the partner found the ordinary way, in
+ * the product table, could never be told what it was made to, and a line that
+ * arrived through a design could never be corrected.
+ *
+ * So the field was half-writable: one entry point, no edit, no clear. This is
+ * the other half, and it is the one that matches how partners actually work —
+ * they know the product, and the design is the thing they add afterwards.
+ *
+ * ## Why here rather than as a grid column
+ *
+ * A design is chosen from hundreds by name, which is a search, not a dropdown.
+ * The quantities grid is a numeric keyboard surface — every other cell in it
+ * takes a number and the arrow keys move between them — and dropping a
+ * searchable combobox into that would fight the navigation it depends on.
+ *
+ * ## 🔑 Only lines that are actually in the basket
+ *
+ * A variant with no quantity is not a line, so it is not listed. Otherwise a
+ * partner who selected a ten-variant product to quote one of them would be
+ * asked to attribute nine lines that will never be minted, and the panel would
+ * be longer than the quote.
+ */
+export const QuoteLineDesignsPanel = ({
+  form,
+  products,
+}: QuoteLineDesignsPanelProps) => {
+  const { t } = useTranslation()
+  const [search, setSearch] = useState("")
+
+  const quantities = useWatch({ control: form.control, name: "quantities" })
+  const designByVariant = useWatch({
+    control: form.control,
+    name: "design_by_variant",
+  })
+
+  const { designs, isLoading } = usePartnerQuotableDesigns({
+    q: search.trim() || undefined,
+    limit: 50,
+  })
+
+  /** Every variant carrying a quantity, with the words a partner recognises. */
+  const lines = useMemo(
+    () => designLineRows(products as any[], quantities as any),
+    [products, quantities]
+  )
+
+  /**
+   * 🔴 Every design, not only the quotable ones.
+   *
+   * The picker in the previous step greys out a design with no product behind
+   * it, because there it has to RESOLVE to a variant. Here the variant is
+   * already chosen and the design is only saying what the line was made to —
+   * a sketch with no product of its own is the ordinary answer to that, and
+   * the backend accepts it on a line that names its variant.
+   */
+  const options = useMemo(
+    () =>
+      (designs ?? []).map((d) => ({
+        label: d.name ?? d.id,
+        value: d.id,
+      })),
+    [designs]
+  )
+
+  const assign = (variantId: string, designId?: string) => {
+    form.setValue(
+      "design_by_variant",
+      assignDesign(designByVariant as any, variantId, designId),
+      { shouldDirty: true }
+    )
+  }
+
+  const assignedCount = lines.filter(
+    (l) => (designByVariant as any)?.[l.id]
+  ).length
+
+  if (!lines.length) return null
+
+  return (
+    <div className="flex flex-col gap-y-3 rounded-lg border border-ui-border-base bg-ui-bg-subtle px-4 py-3">
+      <div className="flex items-center gap-x-2">
+        <Text size="small" weight="plus">
+          {t("quotes.create.lineDesigns.heading", "Design for each line")}
+        </Text>
+        <Text size="small" className="text-ui-fg-subtle">
+          {t(
+            "quotes.create.lineDesigns.hint",
+            "Optional. Records what the line was made to; it does not change the price."
+          )}
+        </Text>
+        {assignedCount > 0 && (
+          <Badge size="2xsmall" className="ml-auto">
+            {assignedCount}/{lines.length}
+          </Badge>
+        )}
+      </div>
+
+      <div className="flex flex-col gap-y-2">
+        {lines.map((line) => (
+          <div
+            key={line.id}
+            className="flex flex-col gap-y-1 md:flex-row md:items-center md:gap-x-3"
+          >
+            <Text size="small" className="truncate md:w-1/2">
+              {line.label}
+            </Text>
+            <div className="md:w-1/2">
+              <Combobox
+                options={options}
+                value={((designByVariant as any)?.[line.id] as string) ?? ""}
+                onChange={(v) => assign(line.id, v as string | undefined)}
+                searchValue={search}
+                onSearchValueChange={setSearch}
+                allowClear
+                isFetchingNextPage={isLoading}
+                placeholder={t(
+                  "quotes.create.lineDesigns.placeholder",
+                  "No design"
+                )}
+              />
+            </div>
+          </div>
+        ))}
+      </div>
+    </div>
+  )
+}

--- a/apps/partner-ui/src/routes/orders/quote-create/components/quote-create-form/quote-line-designs.ts
+++ b/apps/partner-ui/src/routes/orders/quote-create/components/quote-create-form/quote-line-designs.ts
@@ -1,0 +1,62 @@
+/**
+ * The two decisions behind "which design was this line made to" (#1501).
+ *
+ * Extracted from the panel because `apps/partner-ui` has no CI and no DOM test
+ * harness, so anything left inside a component is checked by nothing at all.
+ * Both of these have a way of being quietly wrong.
+ */
+
+export type DesignLineRow = { id: string; label: string }
+
+/**
+ * The variants that are actually LINES.
+ *
+ * 🔴 Quantity-bearing only. A partner who selected a ten-variant product to
+ * quote one of them would otherwise be asked to attribute nine lines that will
+ * never be minted, and the panel would be longer than the quote.
+ *
+ * 🔑 `Number("")` is `0`, which is why the guard is `> 0` and not a truthiness
+ * check — an empty quantity cell must read as "not a line", and a truthiness
+ * check on the raw string would call "0" a line and 0 not one.
+ */
+export function designLineRows(
+  products: Array<{ title?: string | null; variants?: any[] | null }>,
+  quantities: Record<string, unknown> | undefined
+): DesignLineRow[] {
+  const out: DesignLineRow[] = []
+  for (const product of products ?? []) {
+    for (const variant of product?.variants ?? []) {
+      if (!variant?.id) continue
+      const qty = Number(quantities?.[variant.id])
+      if (!Number.isFinite(qty) || qty <= 0) continue
+      out.push({
+        id: variant.id,
+        label: `${product.title ?? "Product"} — ${
+          variant.title ?? variant.sku ?? variant.id
+        }`,
+      })
+    }
+  }
+  return out
+}
+
+/**
+ * Set or clear one line's design.
+ *
+ * 🔴 Clearing DELETES the key. Writing `""` looks equivalent and is not: the
+ * payload builder sends `design_id` whenever the entry is present, so an empty
+ * string would travel to the mint as a design id and be refused as one that
+ * does not exist — a partner clearing a field would get a failed mint.
+ *
+ * Returns a new object; the form holds this value and React must see a change.
+ */
+export function assignDesign(
+  current: Record<string, string> | undefined,
+  variantId: string,
+  designId?: string | null
+): Record<string, string> {
+  const next = { ...(current ?? {}) }
+  if (!designId) delete next[variantId]
+  else next[variantId] = designId
+  return next
+}

--- a/apps/partner-ui/src/routes/orders/quote-create/components/quote-create-form/quote-quantities-form.tsx
+++ b/apps/partner-ui/src/routes/orders/quote-create/components/quote-create-form/quote-quantities-form.tsx
@@ -11,6 +11,7 @@ import {
 } from "../../../../../components/data-grid"
 import { useProducts } from "../../../../../hooks/api/products"
 import { QuoteCreateSchemaType } from "./schema"
+import { QuoteLineDesignsPanel } from "./quote-line-designs-panel"
 
 type QuoteQuantitiesFormProps = {
   form: UseFormReturn<QuoteCreateSchemaType>
@@ -197,11 +198,22 @@ export const QuoteQuantitiesForm = ({ form }: QuoteQuantitiesFormProps) => {
   }
 
   return (
-    <DataGrid
-      columns={columns}
-      data={selected}
-      getSubRows={(row) => (isProductRow(row) ? row.variants ?? [] : undefined)}
-      state={form}
-    />
+    <div className="flex size-full flex-col gap-y-4 overflow-y-auto">
+      <DataGrid
+        columns={columns}
+        data={selected}
+        getSubRows={(row) => (isProductRow(row) ? row.variants ?? [] : undefined)}
+        state={form}
+      />
+      {/*
+        Below the grid, not inside it (#1501): a design is picked from hundreds
+        by NAME, which is a search, and the grid is a numeric keyboard surface
+        whose arrow-key navigation a combobox would fight.
+      */}
+      <QuoteLineDesignsPanel
+        form={form}
+        products={selected.filter(isProductRow)}
+      />
+    </div>
   )
 }


### PR DESCRIPTION
## The gap

`design_by_variant` has existed since #1486 and the mint has always frozen it onto the line — but **only the design picker could write it**. Tick a design in the products step and the product behind it joins the basket carrying the design. A line found the ordinary way, in the product table, could never be told what it was made to; a line that arrived through a design could never be corrected or cleared.

Half-writable: one entry point, no edit, no clear. This is the other half, and it matches how partners work — they know the product, and the design is what they add afterwards.

## 🔴 The hole this uncovered

```js
.filter((l) => l?.design_id && !l?.variant_id)   // <- a line with a variant skipped resolution ENTIRELY
```

So **any string at all** could be frozen onto a commercial document as its design — including another partner's design id. Nothing renders design data on the buyer page, which is the only reason this was not a leak; an unchecked foreign id on a signed document is the #1496 family and does not get to wait for a renderer to make it real.

Every named design is now resolved, and a line that already names its variant must prove its design is **visible**. The refusal reuses the wording a missing design gets, so an id cannot be probed for existence by attaching it to a line.

## Visibility, not resolvability — the asymmetry is the point

| design | quoted ALONE | attached to a chosen variant |
|---|---|---|
| resolves to one variant | ✅ | ✅ |
| no product behind it | ❌ nothing to price | ✅ **the ordinary case** — the sketch a catalogue product was made from |
| sold as several variants | ❌ which SKU? | ✅ the SKU is already chosen |
| not yours / not there | ❌ | ❌ |

`DesignResolution` grows an explicit `visible` rather than the two questions being inferred from one field. The readiness preflight makes the same split — otherwise it reports "sold as 3 variants" as blocking on a line whose variant is already chosen, inventing a problem the partner cannot fix and did not have.

**The variant is never moved.** Attaching a design must not silently re-point the line at a different SKU — that would change what is being sold as a side effect of recording what it was made from.

## UI, in both wizards

A panel under the quantities grid, not a grid column: a design is chosen from hundreds by **name**, which is a search, and that grid is a numeric keyboard surface whose arrow-key navigation a combobox fights. Only quantity-bearing variants are listed.

Both wizards deliberately — #1380 landed a fix on four of five creation paths and the fifth was the one that mattered.

## 🔴 `apps/partner-ui` still has no CI

Its half is type-checked (no new errors against the 4 pre-existing ones), `tsup` and `vite build` both pass, and the two decisions with a way of being quietly wrong are extracted into a pure module with vitest coverage:

- an empty quantity must read as **not a line** — `Number("")` is `0`, the same coercion that once parsed a truncated quote link as *remove this line*
- clearing a design must **delete the key**, not write `""` — the payload builder sends `design_id` whenever the entry is present, so `""` would travel to the mint as a design id and be refused, turning "clear this field" into a failed mint

The admin copy carries the same assertions under jest, so a drift between the two goes red rather than leaving the two mint surfaces quietly disagreeing.

**The panels themselves have not been clicked** — there is no DOM harness in either app.

## Verification

- 8 design-line integration tests; the foreign-design refusal **confirmed to fail on old code**
- 16 backend unit tests, 8 admin + 8 partner-ui pure-logic tests
- 381 unit tests green across the touched modules
- `check:prod-build` green

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_0158wJMZ1DmjNxXf5uGuBrQD