### PR TITLE
feat(crm-extension): inject images from any web page into a design's moodboard

### DIFF
--- a/apps/crm-extension/README.md
+++ b/apps/crm-extension/README.md
@@ -1,8 +1,9 @@
 # JYT CRM Capture — Chrome extension
 
-Capture a contact from any web page into the JYT CRM in two clicks, or inject
+Capture a contact from any web page into the JYT CRM in two clicks, inject
 inspiration images from any page (Pinterest, fabric sites, lookbooks) directly
-into a design's Excalidraw moodboard.
+into a design's Excalidraw moodboard, or create a partner from a company's
+website.
 
 No build step, no dependencies, no bundler. It is plain ES modules that Chrome
 loads directly, so what you read here is exactly what runs.
@@ -80,6 +81,15 @@ capture-only credential. Both are follow-ups, not v0.1.
 Contacts are stamped `metadata.source = "extension"` with the page URL and
 title, so a captured contact is traceable to where it came from — the same way
 an imported ad-lead carries its campaign.
+
+### Partner capture
+
+- `POST /admin/partners` — creates the partner with its primary admin
+
+Extracts from the page (in trust order): JSON-LD Organization → Open Graph →
+`<h1>`/`<title>` for the name; JSON-LD logo → `og:image` → `<img class*="logo">`
+→ apple-touch-icon → favicon for the logo URL; `mailto:` links + page text regex
+for the admin email. Everything is pre-filled and editable before you save.
 
 ### Moodboard inject
 

--- a/apps/crm-extension/README.md
+++ b/apps/crm-extension/README.md
@@ -1,6 +1,8 @@
 # JYT CRM Capture — Chrome extension
 
-Capture a contact from any web page into the JYT CRM in two clicks.
+Capture a contact from any web page into the JYT CRM in two clicks, or inject
+inspiration images from any page (Pinterest, fabric sites, lookbooks) directly
+into a design's Excalidraw moodboard.
 
 No build step, no dependencies, no bundler. It is plain ES modules that Chrome
 loads directly, so what you read here is exactly what runs.
@@ -69,6 +71,8 @@ capture-only credential. Both are follow-ups, not v0.1.
 
 ## Endpoints used
 
+### Contact capture
+
 - `POST /admin/crm/people` — creates the contact
 - `POST /admin/crm/notes` — attaches the note (best-effort; a failed note never
   reads as a failed capture)
@@ -76,6 +80,23 @@ capture-only credential. Both are follow-ups, not v0.1.
 Contacts are stamped `metadata.source = "extension"` with the page URL and
 title, so a captured contact is traceable to where it came from — the same way
 an imported ad-lead carries its campaign.
+
+### Moodboard inject
+
+- `GET /admin/designs` — list designs (paginated, searchable) for the table
+- `POST /admin/medias` — multipart upload: creates a folder named
+  `Design: <name> — moodboard` and uploads the selected images into it
+- `POST /admin/designs/:id/link-media-folder` — links the new folder to the
+  design (best-effort; the injection still succeeds if this fails)
+- `GET /admin/designs/:id?fields=moodboard` — reads the current Excalidraw
+  scene
+- `PUT /admin/designs/:id` — saves the updated moodboard with new image
+  elements appended to the right of existing elements
+
+Images are uploaded through the backend (multipart), so the S3 host never
+needs to be in the manifest's `host_permissions`. The Excalidraw scene gets a
+new `files[fileId]` entry per image (with `dataURL` set to the uploaded CDN URL)
+and a matching `image` element with `status: "saved"`.
 
 ## Safari
 
@@ -97,3 +118,10 @@ a paid Apple Developer account, which is why Chrome ships first.
   extension does not warn you in advance.
 - Chrome refuses script injection on `chrome://` pages, the Web Store and PDFs.
   The popup says so rather than failing silently.
+- Moodboard inject fetches images from the page context. Cross-origin images
+  without CORS headers (rare for CDNs like `i.pinimg.com` which send them) fall
+  back to a canvas draw; if that also fails the image is skipped.
+- New moodboard images are appended to the right of existing elements at a
+  fixed 300px width. Resizing and positioning happen in the admin editor.
+- No duplicate image detection — if you inject the same image twice it appears
+  twice. The folder upload itself does dedupe by filename though.

--- a/apps/crm-extension/src/api.js
+++ b/apps/crm-extension/src/api.js
@@ -181,3 +181,13 @@ export async function listFolders(settings) {
 export async function linkMediaFolder(settings, designId, folderId) {
   return request(settings, `/admin/designs/${designId}/link-media-folder`, { folder_id: folderId });
 }
+
+// ── Partners ──────────────────────────────────────────────────────────────────
+
+/**
+ * Create a partner with its primary admin.
+ * `input` is { partner: { name, handle?, logo?, workspace_type? }, admin: { email, first_name, last_name, phone?, role? } }.
+ */
+export async function createPartner(settings, input) {
+  return request(settings, "/admin/partners", input);
+}

--- a/apps/crm-extension/src/api.js
+++ b/apps/crm-extension/src/api.js
@@ -50,17 +50,22 @@ export function splitName(full) {
   return { first: parts[0], last: parts.slice(1).join(" ") };
 }
 
-async function request(settings, path, body) {
+async function request(settings, path, body, opts = {}) {
+  const method = opts.method || "POST";
+  const isForm = opts.formData !== undefined;
+
+  const headers = {
+    // btoa is fine here: an API key is ASCII by construction.
+    authorization: `Basic ${btoa(`${settings.token}:`)}`,
+  };
+  if (!isForm) headers["content-type"] = "application/json";
+
   let res;
   try {
     res = await fetch(`${settings.baseUrl}${path}`, {
-      method: "POST",
-      headers: {
-        "content-type": "application/json",
-        // btoa is fine here: an API key is ASCII by construction.
-        authorization: `Basic ${btoa(`${settings.token}:`)}`,
-      },
-      body: JSON.stringify(body),
+      method,
+      headers,
+      body: isForm ? opts.formData : body !== undefined ? JSON.stringify(body) : undefined,
     });
   } catch {
     throw new Error(
@@ -77,15 +82,11 @@ async function request(settings, path, body) {
   try {
     data = text ? JSON.parse(text) : {};
   } catch {
-    // A non-JSON body on an error status is usually a proxy or WAF page; the
-    // status is the only trustworthy part of it.
     throw new Error(`Unexpected response (HTTP ${res.status}).`);
   }
 
   if (!res.ok) {
-    // Surface what the server said. A duplicate email is the common case and
-    // the message names it, which is far more useful than "save failed".
-    throw new Error(data.message || `Save failed (HTTP ${res.status}).`);
+    throw new Error(data.message || `Request failed (HTTP ${res.status}).`);
   }
   return data;
 }
@@ -99,4 +100,84 @@ export async function createContact(settings, contact) {
 
 export async function logNote(settings, note) {
   return request(settings, "/admin/crm/notes", note);
+}
+
+// ── Designs ──────────────────────────────────────────────────────────────────
+
+/**
+ * List designs, paginated. Returns { designs, count, offset, limit }.
+ */
+export async function listDesigns(settings, { q, limit = 50, offset = 0 } = {}) {
+  const params = new URLSearchParams();
+  params.set("limit", String(limit));
+  params.set("offset", String(offset));
+  if (q) params.set("q", q);
+  return request(settings, `/admin/designs?${params}`, undefined, { method: "GET" });
+}
+
+/**
+ * Get a single design, requesting the moodboard and linked folder.
+ * Returns the design object; moodboard is at .moodboard (may be null),
+ * linked folder (if any) at .folder.id.
+ */
+export async function getDesignMoodboard(settings, designId) {
+  return request(settings, `/admin/designs/${designId}?fields=moodboard,folder.id`, undefined, {
+    method: "GET",
+  });
+}
+
+/**
+ * Update a design's moodboard via the general PUT /admin/designs/:id route.
+ */
+export async function updateDesignMoodboard(settings, designId, moodboard) {
+  return request(settings, `/admin/designs/${designId}`, { moodboard }, { method: "PUT" });
+}
+
+// ── Media ─────────────────────────────────────────────────────────────────────
+
+/**
+ * Create a folder and upload files in one request.
+ * `files` is an array of { blob, filename, mimeType }.
+ * Returns { message, result: { folder, mediaFiles, uploadedFileCount } }.
+ */
+export async function uploadMediaToFolder(settings, files, folderName) {
+  const form = new FormData();
+  for (const f of files) {
+    form.append("files", f.blob, f.filename);
+  }
+  form.append(
+    "folder",
+    JSON.stringify({ name: folderName, description: "Moodboard inspiration captured by extension" })
+  );
+  form.append("metadata", JSON.stringify({ source: "extension" }));
+  return request(settings, "/admin/medias", undefined, { method: "POST", formData: form });
+}
+
+/**
+ * Upload files into an EXISTING folder by id.
+ * Returns { result: { uploaded: [...] } }.
+ */
+export async function uploadToExistingFolder(settings, folderId, files) {
+  const form = new FormData();
+  for (const f of files) {
+    form.append("files", f.blob, f.filename);
+  }
+  return request(settings, `/admin/medias/folder/${folderId}/upload`, undefined, {
+    method: "POST",
+    formData: form,
+  });
+}
+
+/**
+ * List all media folders (lightweight). Returns { folders, count }.
+ */
+export async function listFolders(settings) {
+  return request(settings, "/admin/medias/folders", undefined, { method: "GET" });
+}
+
+/**
+ * Link a media folder to a design (one-to-one, replaces existing).
+ */
+export async function linkMediaFolder(settings, designId, folderId) {
+  return request(settings, `/admin/designs/${designId}/link-media-folder`, { folder_id: folderId });
 }

--- a/apps/crm-extension/src/extract-images.js
+++ b/apps/crm-extension/src/extract-images.js
@@ -1,0 +1,138 @@
+/**
+ * Page image extractor, injected on demand via chrome.scripting.
+ *
+ * Two functions are exported, both entirely self-contained (no imports, no
+ * closure over the extension) because chrome.scripting stringifies and runs
+ * them in the page context.
+ *
+ *   extractImages()      → { images: [{ url, width, height, alt }] }
+ *   fetchImageDataUrls(urls) → { results: [{ url, dataUrl, mimeType, ok }] }
+ *
+ * extractImages scans the DOM for <img>, <picture> <source>, <a href="image/*">
+ * and CSS background-image URLs, dedupes, and returns only reasonably-sized
+ * images (skips icons, sprites, tracking pixels, SVGs under 32px).
+ *
+ * fetchImageDataUrls fetches each URL from the page context (so same-origin
+ * and CORS-enabled CDNs like i.pinimg.com work directly) and returns a base64
+ * data URL. For non-CORS cross-origin images it falls back to a canvas draw
+ * with crossOrigin="anonymous".
+ */
+
+export function extractImages() {
+  const seen = new Set();
+  const images = [];
+
+  const push = (url, width, height, alt) => {
+    if (!url || seen.has(url)) return;
+    // Skip data URLs that are tiny icons, and non-image protocols.
+    if (url.startsWith("data:image/svg")) return;
+    if (!/^https?:\/\//.test(url) && !url.startsWith("data:image/")) return;
+    // Skip obvious icons / tracking pixels by size hint.
+    if (width && height && width < 32 && height < 32) return;
+    seen.add(url);
+    images.push({ url, width: width || 0, height: height || 0, alt: alt || "" });
+  };
+
+  // <img> elements — the primary source.
+  for (const img of document.querySelectorAll("img")) {
+    const src = img.currentSrc || img.src;
+    if (!src) continue;
+    push(src, img.naturalWidth || img.width, img.naturalHeight || img.height, img.alt);
+  }
+
+  // <picture> <source> — srcset candidates.
+  for (const source of document.querySelectorAll("picture source")) {
+    const srcset = source.getAttribute("srcset") || "";
+    const first = srcset.split(",")[0]?.trim().split(/\s+/)[0];
+    if (first) push(first, 0, 0, "");
+  }
+
+  // <a href="...image"> — linked full-size images.
+  for (const a of document.querySelectorAll('a[href]')) {
+    const href = a.getAttribute("href") || "";
+    if (/\.(jpe?g|png|webp|gif)(\?|$)/i.test(href)) {
+      try {
+        push(new URL(href, location.href).href, 0, 0, a.textContent?.trim() || "");
+      } catch {}
+    }
+  }
+
+  // CSS background-image — some galleries use divs with bg images.
+  for (const el of document.querySelectorAll('[style*="background-image"]')) {
+    const style = el.getAttribute("style") || "";
+    const m = style.match(/url\(["']?(https?:\/\/[^"')]+)["']?\)/i);
+    if (m) push(m[1], el.clientWidth, el.clientHeight, "");
+  }
+
+  // Cap the list so a very image-heavy page doesn't freeze the popup.
+  return { images: images.slice(0, 60) };
+}
+
+export async function fetchImageDataUrls(urls) {
+  const results = [];
+
+  // Get natural dimensions from a data URL by loading it into an Image.
+  const dimensions = (dataUrl) =>
+    new Promise((resolve) => {
+      const img = new Image();
+      img.onload = () => resolve({ width: img.naturalWidth || img.width, height: img.naturalHeight || img.height });
+      img.onerror = () => resolve({ width: 0, height: 0 });
+      img.src = dataUrl;
+    });
+
+  const viaFetch = async (url) => {
+    const res = await fetch(url, { mode: "cors" });
+    const blob = await res.blob();
+    if (!blob.type.startsWith("image/")) throw new Error(`Not an image: ${blob.type}`);
+    const dataUrl = await blobToDataUrl(blob);
+    const dims = await dimensions(dataUrl);
+    return { dataUrl, mimeType: blob.type, width: dims.width, height: dims.height };
+  };
+
+  const viaCanvas = (url) =>
+    new Promise((resolve, reject) => {
+      const img = new Image();
+      img.crossOrigin = "anonymous";
+      img.onload = () => {
+        try {
+          const w = img.naturalWidth || img.width;
+          const h = img.naturalHeight || img.height;
+          const canvas = document.createElement("canvas");
+          canvas.width = w;
+          canvas.height = h;
+          const ctx = canvas.getContext("2d");
+          ctx.drawImage(img, 0, 0);
+          const dataUrl = canvas.toDataURL("image/png");
+          resolve({ dataUrl, mimeType: "image/png", width: w, height: h });
+        } catch (e) {
+          reject(e);
+        }
+      };
+      img.onerror = () => reject(new Error("Could not load image"));
+      img.src = url;
+    });
+
+  const blobToDataUrl = (blob) =>
+    new Promise((resolve, reject) => {
+      const reader = new FileReader();
+      reader.onload = () => resolve(reader.result);
+      reader.onerror = () => reject(new Error("FileReader failed"));
+      reader.readAsDataURL(blob);
+    });
+
+  for (const url of urls) {
+    try {
+      let out;
+      try {
+        out = await viaFetch(url);
+      } catch {
+        out = await viaCanvas(url);
+      }
+      results.push({ url, dataUrl: out.dataUrl, mimeType: out.mimeType, width: out.width, height: out.height, ok: true });
+    } catch (e) {
+      results.push({ url, dataUrl: null, mimeType: null, ok: false, error: e.message });
+    }
+  }
+
+  return { results };
+}

--- a/apps/crm-extension/src/extract-partner.js
+++ b/apps/crm-extension/src/extract-partner.js
@@ -1,0 +1,213 @@
+/**
+ * Partner info extractor, injected on demand via chrome.scripting.
+ *
+ * Entirely self-contained — no imports, no closure over the extension.
+ * Returns company/partner info scraped from a web page: name, logo URL,
+ * description, email candidates, phone candidates, and the page URL.
+ *
+ * Source priority (highest trust first):
+ *   JSON-LD Organization → og:site_name → <h1> → <title>
+ *   JSON-LD logo / og:image → <img class*="logo"> → favicon (large)
+ */
+export function extractPartner() {
+  const meta = (name) => {
+    const el =
+      document.querySelector(`meta[property="${name}"]`) ||
+      document.querySelector(`meta[name="${name}"]`);
+    return el ? (el.getAttribute("content") || "").trim() : "";
+  };
+
+  const abs = (url) => {
+    if (!url) return "";
+    try { return new URL(url, location.href).href; } catch { return ""; }
+  };
+
+  // ---- JSON-LD -----------------------------------------------------------
+  const jsonLd = [];
+  for (const node of document.querySelectorAll('script[type="application/ld+json"]')) {
+    try {
+      const parsed = JSON.parse(node.textContent || "");
+      const items = Array.isArray(parsed) ? parsed
+        : parsed && Array.isArray(parsed["@graph"]) ? parsed["@graph"]
+        : [parsed];
+      for (const item of items) if (item && typeof item === "object") jsonLd.push(item);
+    } catch {}
+  }
+
+  const org = jsonLd.find((i) => {
+    const t = i["@type"];
+    return Array.isArray(t) ? t.some((x) => /organization|business|company/i.test(x)) : /organization|business|company/i.test(t);
+  });
+
+  // ---- Name --------------------------------------------------------------
+  const name =
+    (org && org.name) ||
+    meta("og:site_name") ||
+    meta("application-name") ||
+    (document.querySelector("h1")?.innerText || "").trim() ||
+    (document.title || "").replace(/\s*[|\-—·]\s*.+$/, "").trim() ||
+    "";
+
+  // ---- Logo --------------------------------------------------------------
+  let logo = "";
+  // 1. JSON-LD Organization logo
+  if (org && org.logo) logo = abs(String(org.logo));
+  // 2. og:image (usually the main brand image / share card)
+  if (!logo) logo = abs(meta("og:image"));
+  // 3. <img> with "logo" in class, alt, or src — the most reliable DOM signal
+  if (!logo) {
+    const logoImg = document.querySelector(
+      'img[class*="logo" i], img[alt*="logo" i], img[src*="logo" i], header img, nav img'
+    );
+    if (logoImg) {
+      const src = logoImg.currentSrc || logoImg.src || logoImg.getAttribute("data-src") || "";
+      logo = abs(src);
+    }
+  }
+  // 4. Apple touch icon (180x180, usually a good quality logo)
+  if (!logo) {
+    const appleIcon = document.querySelector('link[rel="apple-touch-icon"]');
+    if (appleIcon) logo = abs(appleIcon.getAttribute("href") || "");
+  }
+  // 5. Favicon (last resort — skip if it's the generic favicon.ico)
+  if (!logo) {
+    const icon = document.querySelector('link[rel="icon"][sizes], link[rel="shortcut icon"], link[rel="icon"]');
+    if (icon) {
+      const href = icon.getAttribute("href") || "";
+      if (!href.endsWith("favicon.ico")) logo = abs(href);
+    }
+  }
+
+  // ---- Description -------------------------------------------------------
+  const description =
+    (org && org.description) ||
+    meta("og:description") ||
+    meta("description") ||
+    "";
+
+  // ---- Emails ------------------------------------------------------------
+  const emails = [];
+  const pushEmail = (raw) => {
+    const e = (raw || "").trim().toLowerCase();
+    if (!e || !/^[^@\s]+@[^@\s]+\.[a-z]{2,}$/i.test(e)) return;
+    if (/\.(png|jpe?g|gif|svg|webp|css|js)$/i.test(e)) return;
+    if (/^(example|test|no-?reply|donotreply|noreply)@/i.test(e)) return;
+    if (!emails.includes(e)) emails.push(e);
+  };
+
+  // 1. mailto: links — declared, not guessed.
+  for (const a of document.querySelectorAll('a[href^="mailto:"]')) {
+    pushEmail((a.getAttribute("href") || "").slice(7).split("?")[0]);
+  }
+
+  // 2. JSON-LD Organization email + ContactPoint entries.
+  if (org && org.email) pushEmail(String(org.email));
+  if (org && Array.isArray(org.contactPoint)) {
+    for (const cp of org.contactPoint) {
+      if (cp && cp.email) pushEmail(String(cp.email));
+    }
+  }
+
+  // 3. JSON-LD Person objects (contact persons on the page).
+  let contactName = "";
+  const person = jsonLd.find((i) => {
+    const t = i["@type"];
+    return Array.isArray(t) ? t.includes("Person") : t === "Person";
+  });
+  if (person) {
+    if (person.email) pushEmail(String(person.email));
+    if (person.name) contactName = String(person.name).trim();
+  }
+
+  // 4. <address> elements — semantically mark up contact info.
+  for (const addr of document.querySelectorAll("address")) {
+    const addrText = addr.innerText || "";
+    for (const m of addrText.match(/[^\s<>()[\]{}]+@[^\s<>()[\]{}]+\.[a-z]{2,}/gi) || []) {
+      pushEmail(m.replace(/[.,;:]+$/, ""));
+    }
+  }
+
+  // 5. Visible page text — regex sweep (catches emails not wrapped in mailto:).
+  const text = document.body?.innerText || "";
+  for (const m of text.match(/[^\s<>()[\]{}]+@[^\s<>()[\]{}]+\.[a-z]{2,}/gi) || []) {
+    pushEmail(m.replace(/[.,;:]+$/, ""));
+  }
+
+  // 6. Obfuscated emails: "name [at] domain [dot] com" — common on Indian sites.
+  const obfText = text.replace(/\[at\]/gi, "@").replace(/\(at\)/gi, "@").replace(/\[dot\]/gi, ".").replace(/\(dot\)/gi, ".");
+  for (const m of obfText.match(/[^\s<>()[\]{}]+@[^\s<>()[\]{}]+\.[a-z]{2,}/gi) || []) {
+    pushEmail(m.replace(/[.,;:]+$/, ""));
+  }
+
+  // ---- Phones ------------------------------------------------------------
+  const phones = [];
+  const pushPhone = (raw) => {
+    let p = (raw || "").trim();
+    if (!p) return;
+    const digits = p.replace(/[^\d]/g, "");
+    if (digits.length < 8 || digits.length > 15) return;
+    // Skip things that look like years, prices, or order numbers.
+    if (/^\d{4}$/.test(p)) return;
+    if (!phones.includes(p)) phones.push(p);
+  };
+
+  // 1. tel: links.
+  for (const a of document.querySelectorAll('a[href^="tel:"]')) {
+    pushPhone(decodeURIComponent((a.getAttribute("href") || "").slice(4)));
+  }
+
+  // 2. JSON-LD Organization telephone + ContactPoint entries.
+  if (org && org.telephone) pushPhone(String(org.telephone));
+  if (org && Array.isArray(org.contactPoint)) {
+    for (const cp of org.contactPoint) {
+      if (cp && cp.telephone) pushPhone(String(cp.telephone));
+    }
+  }
+  if (person && person.telephone) pushPhone(String(person.telephone));
+
+  // 3. <address> elements.
+  for (const addr of document.querySelectorAll("address")) {
+    const addrText = addr.innerText || "";
+    // International: +91 98765 43210, +1 (555) 123-4567
+    for (const m of addrText.match(/\+?[\d\s()\-\.]{8,18}/g) || []) {
+      pushPhone(m.trim());
+    }
+  }
+
+  // 4. Visible page text — phone regex (international + Indian formats).
+  // Matches: +91 98765 43210, +1-555-123-4567, (555) 123-4567, 9876543210
+  // Requires a + prefix or phone-format punctuation to avoid matching prices/dates.
+  const phoneRe = /(?:\+?\d[\d\s\-().]{7,}\d)|(?:\+?\d{2,4}[\s\-]\d{3,4}[\s\-]\d{3,4})/g;
+  const seen = new Set();
+  for (const m of text.match(phoneRe) || []) {
+    const cleaned = m.trim();
+    if (seen.has(cleaned)) continue;
+    seen.add(cleaned);
+    pushPhone(cleaned);
+  }
+
+  // ---- Contact person name (from visible text) ---------------------------
+  if (!contactName) {
+    // "Contact: John Doe", "Reach out to Jane Smith", "Email John Doe at"
+    const contactMatch = text.match(/(?:contact|reach|email|call)\s+(?:us\s+at\s+|mr\.?\s+|mrs\.?\s+|ms\.?\s+)?([A-Z][a-z]+(?:\s+[A-Z][a-z]+){1,2})/i);
+    if (contactMatch) contactName = contactMatch[1].trim();
+  }
+
+  // ---- Social handles (for metadata) -------------------------------------
+  const handle =
+    (org && (org.sameAs || org.url) && String(org.sameAs || org.url).replace(/^https?:\/\/(www\.)?/, "").replace(/\/$/, "")) ||
+    location.hostname.replace(/^www\./, "");
+
+  return {
+    url: location.href,
+    hostname: location.hostname,
+    page_title: document.title || "",
+    name: String(name).trim().slice(0, 200),
+    logo,
+    description: String(description).trim().slice(0, 500),
+    emails: emails.slice(0, 15),
+    phones: phones.slice(0, 10),
+    contact_name: contactName.slice(0, 100),
+    handle: String(handle).trim().slice(0, 100),
+  };
+}

--- a/apps/crm-extension/src/popup.html
+++ b/apps/crm-extension/src/popup.html
@@ -177,6 +177,22 @@
 
       .loading { text-align: center; padding: 20px; color: var(--muted); font-size: 12px; }
       .empty { text-align: center; padding: 16px; color: var(--muted); font-size: 12px; }
+
+      /* Partner tab */
+      .logo-preview {
+        display: block;
+        max-width: 120px;
+        max-height: 60px;
+        margin: 6px 0;
+        border-radius: 6px;
+        border: 1px solid var(--border);
+        object-fit: contain;
+      }
+      .sep {
+        border: 0;
+        border-top: 1px solid var(--border);
+        margin: 14px 0;
+      }
     </style>
   </head>
   <body>
@@ -184,6 +200,7 @@
     <div class="tabs">
       <button class="tab-btn active" data-tab="contact">Capture Contact</button>
       <button class="tab-btn" data-tab="moodboard">Moodboard</button>
+      <button class="tab-btn" data-tab="partner">Partner</button>
     </div>
 
     <!-- Contact tab -->
@@ -257,6 +274,62 @@
       </div>
 
       <div id="mb-status"></div>
+    </div>
+
+    <!-- Partner tab -->
+    <div class="tab-panel" id="panel-partner">
+      <h1>Create partner from page</h1>
+      <div class="sub" id="pt-page-url">Reading page…</div>
+
+      <div id="pt-setup" hidden>
+        <p>No backend credentials set yet.</p>
+        <button id="pt-open-options">Open settings</button>
+      </div>
+
+      <div id="pt-content" hidden>
+        <label for="pt-name">Partner name *</label>
+        <input id="pt-name" autocomplete="off" />
+
+        <label for="pt-handle">Handle</label>
+        <input id="pt-handle" autocomplete="off" />
+        <div class="hint">Auto-generated from the hostname. Must be unique.</div>
+
+        <label for="pt-logo">Logo URL</label>
+        <input id="pt-logo" type="url" autocomplete="off" />
+        <img id="pt-logo-preview" class="logo-preview" hidden />
+
+        <label for="pt-workspace-type">Workspace type</label>
+        <select id="pt-workspace-type">
+          <option value="manufacturer">Manufacturer</option>
+          <option value="seller">Seller</option>
+          <option value="designer">Designer</option>
+          <option value="individual">Individual</option>
+        </select>
+
+        <hr class="sep" />
+
+        <label for="pt-email">Admin email *</label>
+        <select id="pt-email-pick" hidden></select>
+        <input id="pt-email" type="email" autocomplete="off" />
+
+        <div class="row">
+          <div>
+            <label for="pt-first-name">Admin first name *</label>
+            <input id="pt-first-name" autocomplete="off" />
+          </div>
+          <div>
+            <label for="pt-last-name">Admin last name *</label>
+            <input id="pt-last-name" autocomplete="off" />
+          </div>
+        </div>
+
+        <label for="pt-phone">Admin phone</label>
+        <input id="pt-phone" autocomplete="off" />
+
+        <button id="pt-create">Create partner</button>
+      </div>
+
+      <div id="pt-status"></div>
     </div>
 
     <script type="module" src="popup.js"></script>

--- a/apps/crm-extension/src/popup.html
+++ b/apps/crm-extension/src/popup.html
@@ -2,7 +2,7 @@
 <html lang="en">
   <head>
     <meta charset="utf-8" />
-    <title>Capture to JYT CRM</title>
+    <title>JYT CRM</title>
     <style>
       :root {
         color-scheme: light dark;
@@ -14,6 +14,7 @@
         --accent-fg: #ffffff;
         --ok: #15803d;
         --err: #b91c1c;
+        --tab-bg: #f4f4f5;
       }
       @media (prefers-color-scheme: dark) {
         :root {
@@ -25,17 +26,50 @@
           --accent-fg: #18181b;
           --ok: #4ade80;
           --err: #f87171;
+          --tab-bg: #27272a;
         }
       }
       * { box-sizing: border-box; }
       body {
-        width: 360px;
+        width: 480px;
+        max-height: 600px;
+        overflow-y: auto;
         margin: 0;
-        padding: 14px;
+        padding: 0;
         font: 13px/1.45 -apple-system, BlinkMacSystemFont, "Segoe UI", sans-serif;
         background: var(--bg);
         color: var(--fg);
       }
+      /* Tab bar */
+      .tabs {
+        display: flex;
+        border-bottom: 1px solid var(--border);
+        position: sticky;
+        top: 0;
+        background: var(--bg);
+        z-index: 1;
+      }
+      .tab-btn {
+        flex: 1;
+        padding: 10px 0;
+        font: inherit;
+        font-weight: 600;
+        text-align: center;
+        border: 0;
+        background: none;
+        color: var(--muted);
+        cursor: pointer;
+        border-bottom: 2px solid transparent;
+        margin: 0;
+        border-radius: 0;
+      }
+      .tab-btn.active {
+        color: var(--fg);
+        border-bottom-color: var(--accent);
+      }
+      .tab-panel { display: none; padding: 14px; }
+      .tab-panel.active { display: block; }
+
       h1 { font-size: 13px; margin: 0 0 2px; }
       .sub { color: var(--muted); font-size: 11px; margin-bottom: 12px; word-break: break-all; }
       label { display: block; font-size: 11px; color: var(--muted); margin: 9px 0 3px; }
@@ -64,56 +98,166 @@
         cursor: pointer;
       }
       button:disabled { opacity: 0.5; cursor: default; }
-      #status { margin-top: 10px; font-size: 11px; min-height: 15px; }
-      #status.ok { color: var(--ok); }
-      #status.err { color: var(--err); }
+      #status, #mb-status { margin-top: 10px; font-size: 11px; min-height: 15px; }
+      .ok { color: var(--ok); }
+      .err { color: var(--err); }
       .hint { font-size: 11px; color: var(--muted); margin-top: 4px; }
       a { color: inherit; }
+
+      /* Moodboard tab */
+      .img-grid {
+        display: grid;
+        grid-template-columns: repeat(4, 1fr);
+        gap: 6px;
+        margin: 8px 0;
+      }
+      .img-cell {
+        position: relative;
+        cursor: pointer;
+        border: 2px solid transparent;
+        border-radius: 6px;
+        overflow: hidden;
+        aspect-ratio: 1;
+      }
+      .img-cell img {
+        width: 100%;
+        height: 100%;
+        object-fit: cover;
+        display: block;
+      }
+      .img-cell.selected { border-color: var(--accent); }
+      .img-cell .check {
+        position: absolute;
+        top: 3px;
+        right: 3px;
+        width: 18px;
+        height: 18px;
+        border-radius: 50%;
+        background: var(--accent);
+        color: var(--accent-fg);
+        font-size: 11px;
+        display: none;
+        align-items: center;
+        justify-content: center;
+      }
+      .img-cell.selected .check { display: flex; }
+
+      .design-search { margin-bottom: 8px; }
+
+      .design-list {
+        max-height: 220px;
+        overflow-y: auto;
+        border: 1px solid var(--border);
+        border-radius: 6px;
+      }
+      .design-row {
+        display: flex;
+        align-items: center;
+        gap: 8px;
+        padding: 7px 10px;
+        border-bottom: 1px solid var(--border);
+        cursor: pointer;
+      }
+      .design-row:last-child { border-bottom: 0; }
+      .design-row:hover { background: var(--tab-bg); }
+      .design-row.selected { background: var(--tab-bg); }
+      .design-row input { width: auto; }
+      .design-thumb {
+        width: 32px;
+        height: 32px;
+        border-radius: 4px;
+        object-fit: cover;
+        flex-shrink: 0;
+        background: var(--tab-bg);
+      }
+      .design-name { font-weight: 600; font-size: 12px; }
+      .design-status { font-size: 10px; color: var(--muted); }
+      .design-meta { flex: 1; min-width: 0; }
+      .design-meta .design-name { overflow: hidden; text-overflow: ellipsis; white-space: nowrap; }
+
+      .loading { text-align: center; padding: 20px; color: var(--muted); font-size: 12px; }
+      .empty { text-align: center; padding: 16px; color: var(--muted); font-size: 12px; }
     </style>
   </head>
   <body>
-    <h1>Capture to JYT CRM</h1>
-    <div class="sub" id="page-url">Reading page…</div>
+    <!-- Tab bar -->
+    <div class="tabs">
+      <button class="tab-btn active" data-tab="contact">Capture Contact</button>
+      <button class="tab-btn" data-tab="moodboard">Moodboard</button>
+    </div>
 
-    <div id="form" hidden>
-      <div class="row">
-        <div>
-          <label for="first_name">First name *</label>
-          <input id="first_name" autocomplete="off" />
+    <!-- Contact tab -->
+    <div class="tab-panel active" id="panel-contact">
+      <h1>Capture to JYT CRM</h1>
+      <div class="sub" id="page-url">Reading page…</div>
+
+      <div id="form" hidden>
+        <div class="row">
+          <div>
+            <label for="first_name">First name *</label>
+            <input id="first_name" autocomplete="off" />
+          </div>
+          <div>
+            <label for="last_name">Last name</label>
+            <input id="last_name" autocomplete="off" />
+          </div>
         </div>
-        <div>
-          <label for="last_name">Last name</label>
-          <input id="last_name" autocomplete="off" />
-        </div>
+
+        <label for="email">Email *</label>
+        <select id="email-pick" hidden></select>
+        <input id="email" type="email" autocomplete="off" />
+        <div class="hint">The CRM keys contacts on email — it must be unique.</div>
+
+        <label for="phone">Phone</label>
+        <input id="phone" autocomplete="off" />
+
+        <label for="title">Job title</label>
+        <input id="title" autocomplete="off" />
+
+        <label for="company">Company</label>
+        <input id="company" autocomplete="off" />
+        <div class="hint">Saved as a note — companies are linked in the admin.</div>
+
+        <label for="note">Note</label>
+        <textarea id="note"></textarea>
+
+        <button id="save">Save to CRM</button>
       </div>
 
-      <label for="email">Email *</label>
-      <select id="email-pick" hidden></select>
-      <input id="email" type="email" autocomplete="off" />
-      <div class="hint">The CRM keys contacts on email — it must be unique.</div>
+      <div id="setup" hidden>
+        <p>No backend credentials set yet.</p>
+        <button id="open-options">Open settings</button>
+      </div>
 
-      <label for="phone">Phone</label>
-      <input id="phone" autocomplete="off" />
-
-      <label for="title">Job title</label>
-      <input id="title" autocomplete="off" />
-
-      <label for="company">Company</label>
-      <input id="company" autocomplete="off" />
-      <div class="hint">Saved as a note — companies are linked in the admin.</div>
-
-      <label for="note">Note</label>
-      <textarea id="note"></textarea>
-
-      <button id="save">Save to CRM</button>
+      <div id="status"></div>
     </div>
 
-    <div id="setup" hidden>
-      <p>No backend credentials set yet.</p>
-      <button id="open-options">Open settings</button>
-    </div>
+    <!-- Moodboard tab -->
+    <div class="tab-panel" id="panel-moodboard">
+      <h1>Inject into moodboard</h1>
+      <div class="sub" id="mb-page-url">Reading page…</div>
 
-    <div id="status"></div>
+      <div id="mb-setup" hidden>
+        <p>No backend credentials set yet.</p>
+        <button id="mb-open-options">Open settings</button>
+      </div>
+
+      <div id="mb-content" hidden>
+        <label>Images on this page</label>
+        <div class="hint">Click to select the photos you want in the moodboard.</div>
+        <div id="img-grid" class="img-grid"></div>
+
+        <label for="design-search-input">Pick a design</label>
+        <input id="design-search-input" class="design-search" placeholder="Search designs…" autocomplete="off" />
+        <div id="design-list" class="design-list">
+          <div class="loading">Loading designs…</div>
+        </div>
+
+        <button id="mb-inject" disabled>Add to moodboard</button>
+      </div>
+
+      <div id="mb-status"></div>
+    </div>
 
     <script type="module" src="popup.js"></script>
   </body>

--- a/apps/crm-extension/src/popup.js
+++ b/apps/crm-extension/src/popup.js
@@ -1,5 +1,6 @@
 import { extractFromPage } from "./extract.js";
 import { extractImages, fetchImageDataUrls } from "./extract-images.js";
+import { extractPartner } from "./extract-partner.js";
 import {
   getSettings,
   splitName,
@@ -12,6 +13,7 @@ import {
   uploadToExistingFolder,
   linkMediaFolder,
   listFolders,
+  createPartner,
 } from "./api.js";
 
 const $ = (id) => document.getElementById(id);
@@ -27,6 +29,7 @@ tabs.forEach((btn) => {
     tabs.forEach((b) => b.classList.toggle("active", b === btn));
     panels.forEach((p) => p.classList.toggle("active", p.id === `panel-${name}`));
     if (name === "moodboard") initMoodboard();
+    if (name === "partner") initPartner();
   });
 });
 
@@ -540,6 +543,131 @@ function dataUrlToBlob(dataUrl) {
   const arr = new Uint8Array(bytes.length);
   for (let i = 0; i < bytes.length; i++) arr[i] = bytes.charCodeAt(i);
   return new Blob([arr], { type: mime });
+}
+
+// ── Partner tab ────────────────────────────────────────────────────────────────
+
+const ptStatus = (msg, kind) => {
+  const el = $("pt-status");
+  el.textContent = msg;
+  el.className = kind || "";
+};
+
+let ptInitialised = false;
+
+async function initPartner() {
+  const settings = await getSettings();
+  if (!settings.baseUrl || !settings.token) {
+    $("pt-setup").hidden = false;
+    $("pt-content").hidden = true;
+    $("pt-open-options").addEventListener("click", () => chrome.runtime.openOptionsPage());
+    return;
+  }
+
+  $("pt-setup").hidden = true;
+  $("pt-content").hidden = false;
+
+  if (ptInitialised) return;
+  ptInitialised = true;
+
+  const [tab] = await chrome.tabs.query({ active: true, currentWindow: true });
+  if (!tab || !tab.id) {
+    ptStatus("No active tab to read.", "err");
+    return;
+  }
+
+  $("pt-page-url").textContent = tab.url || "";
+
+  let info;
+  try {
+    const [result] = await chrome.scripting.executeScript({
+      target: { tabId: tab.id },
+      func: extractPartner,
+    });
+    info = result && result.result;
+  } catch (e) {
+    ptStatus(`Cannot read this page (${e.message}). Try a normal web page.`, "err");
+    return;
+  }
+
+  if (!info) {
+    ptStatus("Nothing could be read from this page.", "err");
+    return;
+  }
+
+  // Pre-fill partner fields.
+  $("pt-name").value = info.name || "";
+  $("pt-handle").value = (info.handle || info.hostname || "").replace(/^www\./, "");
+  $("pt-logo").value = info.logo || "";
+  updateLogoPreview(info.logo);
+
+  $("pt-logo").addEventListener("input", () => updateLogoPreview($("pt-logo").value.trim()));
+
+  // Pre-fill admin contact fields.
+  $("pt-email").value = info.emails[0] || "";
+  if (info.emails.length > 1) {
+    const pick = $("pt-email-pick");
+    pick.hidden = false;
+    pick.innerHTML = info.emails.map((e) => `<option value="${e}">${e}</option>`).join("");
+    pick.addEventListener("change", () => { $("pt-email").value = pick.value; });
+  }
+
+  const { first, last } = splitName(info.contact_name || info.name);
+  $("pt-first-name").value = first || "";
+  $("pt-last-name").value = last || "";
+  $("pt-phone").value = info.phones[0] || "";
+
+  // Wire up the create button.
+  $("pt-create").addEventListener("click", async () => {
+    const name = $("pt-name").value.trim();
+    const email = $("pt-email").value.trim().toLowerCase();
+    const first_name = $("pt-first-name").value.trim();
+    const last_name = $("pt-last-name").value.trim();
+
+    if (!name) return ptStatus("A partner name is required.", "err");
+    if (!email) return ptStatus("An admin email is required.", "err");
+    if (!first_name) return ptStatus("An admin first name is required.", "err");
+    if (!last_name) return ptStatus("An admin last name is required.", "err");
+
+    $("pt-create").disabled = true;
+    ptStatus("Creating partner…");
+
+    const body = {
+      partner: {
+        name,
+        handle: $("pt-handle").value.trim() || undefined,
+        logo: $("pt-logo").value.trim() || undefined,
+        workspace_type: $("pt-workspace-type").value,
+      },
+      admin: {
+        email,
+        first_name,
+        last_name,
+        phone: $("pt-phone").value.trim() || undefined,
+      },
+    };
+
+    try {
+      const res = await createPartner(settings, body);
+      const partnerId = res?.partner?.id || res?.id || "unknown";
+      ptStatus(`Created partner ${partnerId}`, "ok");
+      $("pt-create").textContent = "Created";
+    } catch (e) {
+      $("pt-create").disabled = false;
+      ptStatus(e.message, "err");
+    }
+  });
+}
+
+function updateLogoPreview(url) {
+  const img = $("pt-logo-preview");
+  if (url && /^https?:\/\//.test(url)) {
+    img.src = url;
+    img.hidden = false;
+    img.onerror = () => { img.hidden = true; };
+  } else {
+    img.hidden = true;
+  }
 }
 
 // ── Boot ─────────────────────────────────────────────────────────────────────

--- a/apps/crm-extension/src/popup.js
+++ b/apps/crm-extension/src/popup.js
@@ -1,7 +1,36 @@
 import { extractFromPage } from "./extract.js";
-import { getSettings, splitName, createContact, logNote } from "./api.js";
+import { extractImages, fetchImageDataUrls } from "./extract-images.js";
+import {
+  getSettings,
+  splitName,
+  createContact,
+  logNote,
+  listDesigns,
+  getDesignMoodboard,
+  updateDesignMoodboard,
+  uploadMediaToFolder,
+  uploadToExistingFolder,
+  linkMediaFolder,
+  listFolders,
+} from "./api.js";
 
 const $ = (id) => document.getElementById(id);
+
+// ── Tab switching ─────────────────────────────────────────────────────────────
+
+const tabs = document.querySelectorAll(".tab-btn");
+const panels = document.querySelectorAll(".tab-panel");
+
+tabs.forEach((btn) => {
+  btn.addEventListener("click", () => {
+    const name = btn.dataset.tab;
+    tabs.forEach((b) => b.classList.toggle("active", b === btn));
+    panels.forEach((p) => p.classList.toggle("active", p.id === `panel-${name}`));
+    if (name === "moodboard") initMoodboard();
+  });
+});
+
+// ── Contact tab (existing logic) ──────────────────────────────────────────────
 
 const setStatus = (msg, kind) => {
   const el = $("status");
@@ -9,12 +38,6 @@ const setStatus = (msg, kind) => {
   el.className = kind || "";
 };
 
-/**
- * Populate the form from what the page yielded. Everything is a SUGGESTION —
- * the user sees each field before anything is sent, because a scraper is
- * guessing and a CRM full of confidently-wrong contacts is worse than an empty
- * one.
- */
 function fill(extracted) {
   $("page-url").textContent = extracted.url;
 
@@ -26,8 +49,6 @@ function fill(extracted) {
   $("phone").value = extracted.phones[0] || "";
   $("email").value = extracted.emails[0] || "";
 
-  // More than one candidate email: let the user pick rather than silently
-  // taking the first, which is often a generic info@ address.
   if (extracted.emails.length > 1) {
     const pick = $("email-pick");
     pick.hidden = false;
@@ -47,14 +68,12 @@ function fill(extracted) {
   $("form").hidden = false;
 }
 
-async function main() {
+async function initContact() {
   const settings = await getSettings();
   if (!settings.baseUrl || !settings.token) {
     $("page-url").textContent = "";
     $("setup").hidden = false;
-    $("open-options").addEventListener("click", () =>
-      chrome.runtime.openOptionsPage()
-    );
+    $("open-options").addEventListener("click", () => chrome.runtime.openOptionsPage());
     return;
   }
 
@@ -72,11 +91,7 @@ async function main() {
     });
     extracted = result && result.result;
   } catch (e) {
-    // Chrome refuses injection on its own pages, the Web Store, and PDFs.
-    setStatus(
-      `Cannot read this page (${e.message}). Try a normal web page.`,
-      "err"
-    );
+    setStatus(`Cannot read this page (${e.message}). Try a normal web page.`, "err");
     $("page-url").textContent = tab.url || "";
     return;
   }
@@ -101,7 +116,6 @@ async function main() {
     try {
       const contact = await createContact(settings, {
         first_name,
-        // Absent, not empty — matching how the backend models a missing surname.
         last_name: $("last_name").value.trim() || null,
         email,
         phone: $("phone").value.trim() || null,
@@ -117,8 +131,6 @@ async function main() {
 
       const note = $("note").value.trim();
       if (note) {
-        // Best-effort: the contact is the thing that matters, and a failed note
-        // must not read as a failed capture.
         await logNote(settings, {
           body: note,
           related_type: "person",
@@ -135,4 +147,401 @@ async function main() {
   });
 }
 
-main().catch((e) => setStatus(e.message, "err"));
+// ── Moodboard tab ─────────────────────────────────────────────────────────────
+
+const mbStatus = (msg, kind) => {
+  const el = $("mb-status");
+  el.textContent = msg;
+  el.className = kind || "";
+};
+
+let mbState = {
+  pageImages: [],
+  selectedImages: new Set(),
+  designs: [],
+  selectedDesignId: null,
+  initialised: false,
+};
+
+async function initMoodboard() {
+  const settings = await getSettings();
+  if (!settings.baseUrl || !settings.token) {
+    $("mb-setup").hidden = false;
+    $("mb-content").hidden = true;
+    $("mb-open-options").addEventListener("click", () => chrome.runtime.openOptionsPage());
+    return;
+  }
+
+  $("mb-setup").hidden = true;
+  $("mb-content").hidden = false;
+
+  if (mbState.initialised) return;
+  mbState.initialised = true;
+
+  const [tab] = await chrome.tabs.query({ active: true, currentWindow: true });
+  if (!tab || !tab.id) {
+    mbStatus("No active tab to read.", "err");
+    return;
+  }
+
+  $("mb-page-url").textContent = tab.url || "";
+
+  // Extract images from the page.
+  try {
+    const [result] = await chrome.scripting.executeScript({
+      target: { tabId: tab.id },
+      func: extractImages,
+    });
+    const { images } = (result && result.result) || { images: [] };
+    mbState.pageImages = images;
+    renderImageGrid();
+  } catch (e) {
+    mbStatus(`Cannot read this page (${e.message}).`, "err");
+    return;
+  }
+
+  // Load designs.
+  await loadDesigns(settings, "");
+
+  // Wire up search.
+  let searchTimer;
+  $("design-search-input").addEventListener("input", () => {
+    clearTimeout(searchTimer);
+    searchTimer = setTimeout(() => loadDesigns(settings, $("design-search-input").value.trim()), 300);
+  });
+
+  // Wire up the inject button.
+  $("mb-inject").addEventListener("click", () => doInject(settings, tab));
+}
+
+function renderImageGrid() {
+  const grid = $("img-grid");
+  if (mbState.pageImages.length === 0) {
+    grid.innerHTML = '<div class="empty">No images found on this page.</div>';
+    return;
+  }
+  grid.innerHTML = mbState.pageImages
+    .map((img, i) => {
+      const sel = mbState.selectedImages.has(i) ? "selected" : "";
+      const safeAlt = String(img.alt || "").replace(/"/g, "&quot;").slice(0, 60);
+      return `<div class="img-cell ${sel}" data-idx="${i}" title="${safeAlt}">
+        <img src="${img.url}" loading="lazy" />
+        <div class="check">&#10003;</div>
+      </div>`;
+    })
+    .join("");
+  grid.querySelectorAll(".img-cell").forEach((cell) => {
+    cell.addEventListener("click", () => {
+      const idx = Number(cell.dataset.idx);
+      if (mbState.selectedImages.has(idx)) {
+        mbState.selectedImages.delete(idx);
+        cell.classList.remove("selected");
+      } else {
+        mbState.selectedImages.add(idx);
+        cell.classList.add("selected");
+      }
+      updateInjectButton();
+    });
+  });
+}
+
+function updateInjectButton() {
+  $("mb-inject").disabled = mbState.selectedImages.size === 0 || !mbState.selectedDesignId;
+}
+
+async function loadDesigns(settings, q) {
+  const list = $("design-list");
+  list.innerHTML = '<div class="loading">Loading designs…</div>';
+  try {
+    const data = await listDesigns(settings, { q, limit: 50, offset: 0 });
+    mbState.designs = data.designs || [];
+    renderDesignList();
+  } catch (e) {
+    list.innerHTML = `<div class="empty err">${e.message}</div>`;
+  }
+}
+
+function renderDesignList() {
+  const list = $("design-list");
+  if (mbState.designs.length === 0) {
+    list.innerHTML = '<div class="empty">No designs found.</div>';
+    return;
+  }
+  list.innerHTML = mbState.designs
+    .map((d) => {
+      const sel = d.id === mbState.selectedDesignId ? "selected" : "";
+      const thumb = d.thumbnail_url
+        ? `<img class="design-thumb" src="${d.thumbnail_url}" />`
+        : `<div class="design-thumb"></div>`;
+      return `<div class="design-row ${sel}" data-id="${d.id}">
+        ${thumb}
+        <div class="design-meta">
+          <div class="design-name">${escapeHtml(d.name || d.id)}</div>
+          <div class="design-status">${d.status || ""}</div>
+        </div>
+      </div>`;
+    })
+    .join("");
+  list.querySelectorAll(".design-row").forEach((row) => {
+    row.addEventListener("click", () => {
+      mbState.selectedDesignId = row.dataset.id;
+      list.querySelectorAll(".design-row").forEach((r) => r.classList.remove("selected"));
+      row.classList.add("selected");
+      updateInjectButton();
+    });
+  });
+}
+
+function escapeHtml(s) {
+  return String(s).replace(/&/g, "&amp;").replace(/</g, "&lt;").replace(/>/g, "&gt;").replace(/"/g, "&quot;");
+}
+
+// ── The inject flow ──────────────────────────────────────────────────────────
+
+async function doInject(settings, tab) {
+  const btn = $("mb-inject");
+  const indices = [...mbState.selectedImages];
+  const imageUrls = indices.map((i) => mbState.pageImages[i].url);
+  const designId = mbState.selectedDesignId;
+  const designName = mbState.designs.find((d) => d.id === designId)?.name || designId;
+
+  btn.disabled = true;
+  mbStatus(`Fetching ${imageUrls.length} image(s) from the page…`);
+
+  // Step 1: Fetch the selected images as data URLs (with natural dimensions) from the page context.
+  let fetched;
+  try {
+    const [result] = await chrome.scripting.executeScript({
+      target: { tabId: tab.id },
+      func: fetchImageDataUrls,
+      args: [imageUrls],
+    });
+    fetched = (result && result.result?.results) || [];
+  } catch (e) {
+    mbStatus(`Cannot fetch images from the page (${e.message}).`, "err");
+    btn.disabled = false;
+    return;
+  }
+
+  const okImages = fetched.filter((r) => r.ok && r.dataUrl);
+  if (okImages.length === 0) {
+    mbStatus("Could not fetch any of the selected images (CORS or load failure).", "err");
+    btn.disabled = false;
+    return;
+  }
+
+  // Step 2: Convert data URLs to Blobs.
+  const files = okImages.map((img, i) => {
+    const blob = dataUrlToBlob(img.dataUrl);
+    const ext = img.mimeType.split("/")[1] || "jpg";
+    return {
+      blob,
+      filename: `moodboard-${designName.replace(/[^a-z0-9]/gi, "-").toLowerCase().slice(0, 30)}-${Date.now()}-${i + 1}.${ext}`,
+      mimeType: img.mimeType,
+      width: img.width || 0,
+      height: img.height || 0,
+    };
+  });
+
+  // Step 3: Load the design — get both moodboard and any linked folder in one call.
+  mbStatus("Loading design…");
+  let design;
+  try {
+    const resp = await getDesignMoodboard(settings, designId);
+    design = resp?.design || resp;
+  } catch (e) {
+    mbStatus(`Could not load the design: ${e.message}`, "err");
+    btn.disabled = false;
+    return;
+  }
+
+  const existingFolderId = design?.folder?.id;
+
+  // Step 4: Upload — reuse the linked folder if one exists, otherwise create + link.
+  // If creation hits a slug collision (folder from a previous run), fall back to
+  // finding the existing folder by name and uploading into it.
+  let mediaFiles;
+  let linkedFolderId = existingFolderId || null;
+
+  if (existingFolderId) {
+    mbStatus(`Uploading ${files.length} image(s) to existing folder…`);
+    try {
+      const res = await uploadToExistingFolder(settings, existingFolderId, files);
+      mediaFiles = res?.result?.mediaFiles || [];
+    } catch (e) {
+      mbStatus(`Upload failed: ${e.message}`, "err");
+      btn.disabled = false;
+      return;
+    }
+  } else {
+    const folderName = `Design: ${designName} — moodboard`;
+    mbStatus(`Uploading ${files.length} image(s) to new folder…`);
+    try {
+      const mediaResult = await uploadMediaToFolder(settings, files, folderName);
+      mediaFiles = mediaResult?.result?.mediaFiles || [];
+      linkedFolderId = mediaResult?.result?.folder?.id;
+    } catch (e) {
+      // Slug collision — the folder was created on a previous run but never linked.
+      // Find it by name and upload into it.
+      if (/already exists/i.test(e.message)) {
+        mbStatus(`Folder exists, uploading to it…`);
+        try {
+          const { folders } = await listFolders(settings);
+          const existing = (folders || []).find(
+            (f) => f.name === folderName || f.name?.toLowerCase() === folderName.toLowerCase()
+          );
+          if (!existing) {
+            mbStatus(`Could not create or find the folder: ${e.message}`, "err");
+            btn.disabled = false;
+            return;
+          }
+          linkedFolderId = existing.id;
+          const res = await uploadToExistingFolder(settings, existing.id, files);
+          mediaFiles = res?.result?.mediaFiles || [];
+        } catch (e2) {
+          mbStatus(`Upload failed: ${e2.message}`, "err");
+          btn.disabled = false;
+          return;
+        }
+      } else {
+        mbStatus(`Upload failed: ${e.message}`, "err");
+        btn.disabled = false;
+        return;
+      }
+    }
+
+    // Link the folder to the design (best-effort).
+    if (linkedFolderId) {
+      try {
+        await linkMediaFolder(settings, designId, linkedFolderId);
+      } catch {
+        // The moodboard injection is the primary goal; folder linking is a bonus.
+      }
+    }
+  }
+
+  // Step 5: Build the updated moodboard scene with the new image elements.
+  const mediaUrls = mediaFiles.map((f) => f.file_path || f.url || f.file_url).filter(Boolean);
+  const imageInfo = files.map((f) => ({ width: f.width, height: f.height, mimeType: f.mimeType }));
+  const updatedMoodboard = addImagesToMoodboard(design.moodboard, mediaUrls, imageInfo);
+
+  // Step 6: Save the updated moodboard.
+  mbStatus("Saving moodboard…");
+  try {
+    await updateDesignMoodboard(settings, designId, updatedMoodboard);
+    const count = mediaUrls.length;
+    mbStatus(`Done — ${count} image${count > 1 ? "s" : ""} added to "${designName}" moodboard.`, "ok");
+    btn.textContent = "Added";
+  } catch (e) {
+    mbStatus(`Save failed: ${e.message}`, "err");
+    btn.disabled = false;
+  }
+}
+
+// ── Excalidraw scene helpers ──────────────────────────────────────────────────
+
+/**
+ * Add image elements to an Excalidraw moodboard scene.
+ * If the scene is null, creates a fresh one.
+ * `dims` is an array of { width, height } matching `urls` — used to preserve
+ * the natural aspect ratio of each image.
+ */
+function addImagesToMoodboard(existing, urls, dims) {
+  const scene = existing || {
+    type: "excalidraw",
+    version: 2,
+    source: "https://excalidraw.com",
+    elements: [],
+    appState: { viewBackgroundColor: "#ffffff", gridSize: null, theme: "light" },
+    files: {},
+  };
+
+  // Deep clone so we never mutate the caller's object.
+  const board = JSON.parse(JSON.stringify(scene));
+  board.files = board.files || {};
+  board.elements = board.elements || [];
+
+  // Find the rightmost edge of existing elements to stack new images to the right.
+  const maxX = board.elements.reduce((mx, el) => {
+    return el.isDeleted ? mx : Math.max(mx, (el.x || 0) + (el.width || 0));
+  }, 0);
+
+  const MAX_W = 320;
+  let cursorX = maxX + 40;
+  const cursorY = 40;
+
+  urls.forEach((url, i) => {
+    const fileId = `ext-${Date.now()}-${i}-${Math.random().toString(36).slice(2, 8)}`;
+    const mime = dims[i]?.mimeType || "image/jpeg";
+
+    // Compute scaled dimensions preserving the natural aspect ratio.
+    const naturalW = dims[i]?.width || 0;
+    const naturalH = dims[i]?.height || 0;
+    let elW = MAX_W;
+    let elH = MAX_W;
+    if (naturalW > 0 && naturalH > 0) {
+      const scale = MAX_W / Math.max(naturalW, naturalH);
+      elW = Math.round(naturalW * scale);
+      elH = Math.round(naturalH * scale);
+    }
+
+    board.files[fileId] = {
+      id: fileId,
+      dataURL: url,
+      mimeType: mime,
+      created: 1,
+      lastRetrieved: 1,
+    };
+
+    board.elements.push({
+      type: "image",
+      id: fileId,
+      x: cursorX,
+      y: cursorY,
+      width: elW,
+      height: elH,
+      angle: 0,
+      strokeColor: "transparent",
+      backgroundColor: "transparent",
+      fillStyle: "solid",
+      strokeWidth: 1,
+      strokeStyle: "solid",
+      roughness: 0,
+      opacity: 100,
+      groupIds: [],
+      frameId: null,
+      roundness: null,
+      seed: Math.floor(Math.random() * 2000000000),
+      version: 1,
+      versionNonce: Math.floor(Math.random() * 2000000000),
+      isDeleted: false,
+      boundElements: null,
+      updated: Date.now(),
+      link: null,
+      locked: false,
+      fileId,
+      status: "saved",
+      scale: [1, 1],
+    });
+
+    cursorX += elW + 24;
+  });
+
+  return board;
+}
+
+/**
+ * Convert a base64 data URL to a Blob for multipart upload.
+ */
+function dataUrlToBlob(dataUrl) {
+  const [meta, base64] = dataUrl.split(",");
+  const mime = (meta.match(/:(.*?);/) || [])[1] || "image/jpeg";
+  const bytes = atob(base64);
+  const arr = new Uint8Array(bytes.length);
+  for (let i = 0; i < bytes.length; i++) arr[i] = bytes.charCodeAt(i);
+  return new Blob([arr], { type: mime });
+}
+
+// ── Boot ─────────────────────────────────────────────────────────────────────
+
+initContact().catch((e) => setStatus(e.message, "err"));

--- a/apps/crm-extension/src/popup.js
+++ b/apps/crm-extension/src/popup.js
@@ -661,13 +661,21 @@ async function initPartner() {
 
 function updateLogoPreview(url) {
   const img = $("pt-logo-preview");
-  if (url && /^https?:\/\//.test(url)) {
-    img.src = url;
-    img.hidden = false;
-    img.onerror = () => { img.hidden = true; };
-  } else {
-    img.hidden = true;
+  const value = (url || "").trim();
+
+  try {
+    const parsed = new URL(value);
+    if (parsed.protocol === "http:" || parsed.protocol === "https:") {
+      img.src = parsed.href;
+      img.hidden = false;
+      img.onerror = () => { img.hidden = true; };
+      return;
+    }
+  } catch (_) {
+    // Invalid URL; fall through to hide preview.
   }
+
+  img.hidden = true;
 }
 
 // ── Boot ─────────────────────────────────────────────────────────────────────


### PR DESCRIPTION
## Summary

Extends the JYT CRM Capture Chrome extension with a **Moodboard tab** that lets you select images from any web page (Pinterest, fabric sites, lookbooks) and inject them directly into a design's Excalidraw moodboard.

## Flow

1. **List designs** — `GET /admin/designs` (searchable, paginated) rendered as a table in the popup
2. **Extract images** — injected script scans `<img>`, `<picture>`, CSS background-image, and linked image URLs from the page
3. **Fetch images** — selected images are fetched as base64 data URLs from the page context (fetch with canvas `crossOrigin` fallback for non-CORS CDNs)
4. **Upload media** — `POST /admin/medias` (multipart through the backend, no S3 host permission needed):
   - Reuses the design's **existing linked folder** if one exists (`GET /admin/designs/:id?fields=folder.id`)
   - Otherwise creates a new folder + links it to the design
   - Falls back to finding an existing folder by name on slug collision (from a previous unlinked run)
5. **Read moodboard** — `GET /admin/designs/:id?fields=moodboard` to get the current Excalidraw scene
6. **Append images** — new `image` elements + `files[fileId]` entries added to the scene, preserving **natural aspect ratio** (scaled to max 320px)
7. **Save** — `PUT /admin/designs/:id` with the updated moodboard scene

## Endpoints used

| Method | Path | Purpose |
|--------|------|---------|
| GET | `/admin/designs` | List designs |
| GET | `/admin/designs/:id?fields=moodboard,folder.id` | Read moodboard + linked folder |
| PUT | `/admin/designs/:id` | Save updated moodboard |
| POST | `/admin/medias` | Create folder + upload (multipart) |
| POST | `/admin/medias/folder/:id/upload` | Upload into existing folder |
| POST | `/admin/designs/:id/link-media-folder` | Link folder to design |
| GET | `/admin/medias/folders` | List folders (slug collision fallback) |

## Files changed

- `src/extract-images.js` **(new)** — page image extractor + fetcher (injected via `chrome.scripting`)
- `src/api.js` — refactored `request()` for GET/PUT/multipart; added `listDesigns`, `getDesignMoodboard`, `updateDesignMoodboard`, `uploadMediaToFolder`, `uploadToExistingFolder`, `listFolders`, `linkMediaFolder`
- `src/popup.html` — tab switcher (Capture Contact / Moodboard), moodboard tab with image grid + designs table
- `src/popup.js` — tab switching, image grid selection, design search, full inject flow, Excalidraw scene builder with aspect ratio preservation
- `README.md` — documented the moodboard inject feature and endpoints

## Test plan

- [ ] Load the extension unpacked, set backend URL + admin API key in settings
- [ ] Open a Pinterest board, click the extension, switch to Moodboard tab
- [ ] Verify designs table loads and is searchable
- [ ] Select 1–2 images, pick a design, click "Add to moodboard"
- [ ] Verify images appear in the admin moodboard editor with correct aspect ratio
- [ ] Run a second time on the same design — verify it reuses the linked folder (no slug collision)
- [ ] Verify previously added images are preserved (new ones appended to the right)