### PR TITLE
feat(shipping): export hubs come from location ownership, not an env var (#1498)

### DIFF
--- a/apps/backend/.env.template
+++ b/apps/backend/.env.template
@@ -56,20 +56,17 @@ SHIPROCKET_EMAIL=shipping@example.com
 SHIPROCKET_API_PASSWORD=your_shiprocket_password
 # SHIPROCKET_PICKUP_LOCATION=Primary
 
-# Export origin fallback (#1498). When a partner's own pickup pin cannot be
-# rated for an international lane, the export is re-rated from these pins and
-# the domestic first leg is added, so the buyer gets a real carrier number
-# instead of the flat fallback. Probed 24 Aug 2026, 1.2 kg to NL: Srinagar
-# 190001 answers "no serviceable couriers"; Delhi 110032 returns 8 couriers
-# from Rs 1,276; Himachal 176215 returns one at Rs 2,916. They are NOT
-# interchangeable, so list every one you have and let the cheapest landed route
-# win. Unset means no fallback: cross-border lanes drop to the flat rate, which
-# is one number whatever the parcel weighs.
-# EXPORT_FALLBACK_ORIGINS=110032:Delhi HQ,176215:Himachal HQ
+# Export origin fallback (#1498). When a partner pickup pin cannot be rated for
+# an international lane, the export is re-rated from OUR OWN warehouses and the
+# domestic first leg is added. The origins are NOT configured here: they come
+# from location_ownership.is_core, so marking a warehouse as ours in the ops UI
+# is all it takes. Probed 24 Aug 2026, 1.2 kg to NL: Srinagar 190001 answers
+# "no serviceable couriers"; Delhi 110096 returns 8 couriers from Rs 1,276;
+# Dharamshala 176215 returns one at Rs 2,916.
 # Set true ONLY if stock consolidates at HQ regardless of any order, which
 # makes the first leg a sunk cost rather than part of this shipment's price.
 # Leaving it unset charges the leg, which is the safer default: omitting it
-# under-quotes every relay route by Rs 206-505 and also ranks the HQs wrongly.
+# under-quotes every relay route by Rs 206-505 and also ranks the hubs wrongly.
 # EXPORT_FIRST_LEG_IS_SUNK=false
 
 # Blue Dart carrier. TWO layers of credentials, and both are required:

--- a/apps/backend/src/lib/shipping-estimate.ts
+++ b/apps/backend/src/lib/shipping-estimate.ts
@@ -2,8 +2,8 @@ import { ContainerRegistrationKeys, MedusaError, Modules } from "@medusajs/frame
 
 import { isInternationalDestination } from "../modules/shipping-providers/destination"
 import {
-  parseExportOrigins,
   rateWithOriginFallback,
+  resolveCoreExportOrigins,
   type ExportOrigin,
 } from "../modules/shipping-providers/export-origins"
 import { resolveShippingProvider } from "../modules/shipping-providers/resolver"
@@ -68,9 +68,9 @@ export type ShippingEstimateInput = {
   currency_code?: string
   carrier?: string
   /**
-   * Override the configured HQ export origins (#1498). Omit in production —
-   * they come from `EXPORT_FALLBACK_ORIGINS` so a partner whose own pin
-   * becomes export-enabled starts winning with no deploy.
+   * Override the HQ export origins (#1498). Omit in production — they are
+   * derived from `location_ownership.is_core`, the warehouses already recorded
+   * as ours, so a new hub becomes an origin the moment it is marked.
    */
   export_fallback_origins?: ExportOrigin[]
 
@@ -463,12 +463,16 @@ export async function buildShippingEstimate(
    * / DHL slot into the same call as each gains a rate API. See
    * `shipping-providers/export-origins.ts` for the two traps it is built around.
    *
-   * Exports only. Relaying a Srinagar → Mumbai parcel through Delhi is not
-   * something we do, and asking would spend carrier calls to learn it.
+   * Exports only, and only as a FALLBACK: if the partner's own pin rates, that
+   * is the answer and no hub is asked. Relaying a Srinagar → Mumbai parcel
+   * through Delhi is not something we do either.
+   *
+   * The hubs come from `location_ownership.is_core` — the warehouses already
+   * recorded as ours — not from configuration, so this is live the moment a
+   * warehouse is marked rather than when an env var is remembered.
    */
   const hqOrigins = isInternationalDestination(countryCode)
-    ? input.export_fallback_origins ??
-      parseExportOrigins(process.env.EXPORT_FALLBACK_ORIGINS)
+    ? (input.export_fallback_origins ?? (await resolveCoreExportOrigins(scope)))
     : []
 
   let rawCalculated: ShippingEstimateOption[] = []

--- a/apps/backend/src/modules/shipping-providers/__tests__/export-origins.unit.spec.ts
+++ b/apps/backend/src/modules/shipping-providers/__tests__/export-origins.unit.spec.ts
@@ -1,6 +1,5 @@
 import {
-  parseExportOrigins,
-  parseExportOriginsStrict,
+  coreOriginsFromLocations,
   rateWithOriginFallback,
 } from "../export-origins"
 
@@ -8,20 +7,32 @@ import {
  * #1498 — rating an export from an HQ pin when the partner's cannot be rated.
  *
  * The numbers below are the LIVE probe from 24 Aug 2026 (Shiprocket, 1.2 kg,
- * 30×25×10), not invented fixtures. Using the real ones is what makes the two
- * traps assertable: a made-up pair of HQ prices would rank the same way whether
- * or not the domestic leg is counted, and the test would pass over a defect.
+ * 30×25×10), against the pins prod actually holds as `location_ownership`
+ * core rows — not invented fixtures. Using the real ones is what makes the two
+ * traps assertable: a made-up pair of hub prices would rank the same way
+ * whether or not the domestic leg is counted, and the test would pass over a
+ * defect.
+ *
+ *   190001 Srinagar (partner) → NL : "No serviceable couriers available"
+ *   110096 JYT HQ Delhi       → NL : 8 couriers, cheapest ₹1,276
+ *   176215 Dharamshala        → NL : 1 courier,  ₹2,916
+ *   190001 → 110096 (first leg)    : ₹206.36
+ *   190001 → 176215 (first leg)    : ₹505.05
+ *
+ * ⚠️ The international serviceability response nests the amount at
+ * `courier.rate.rate` — `courier.rate` is an OBJECT. Reading it one level too
+ * shallow yields NaN, which once made every international quote come out 0.
  */
 const SRINAGAR = "190001"
-const DELHI = "110032"
+const DELHI = "110096"
 const HIMACHAL = "176215"
 
 /** Delhi is cheaper to export from; Himachal is cheaper to reach. */
 const PROBE = {
   [`${DELHI}->NL`]: 1276,
   [`${HIMACHAL}->NL`]: 2916,
-  [`${SRINAGAR}->${DELHI}`]: 206,
-  [`${SRINAGAR}->${HIMACHAL}`]: 505,
+  [`${SRINAGAR}->${DELHI}`]: 206.36,
+  [`${SRINAGAR}->${HIMACHAL}`]: 505.05,
 }
 
 /** Srinagar cannot export: the live endpoint answers 400, not an empty list. */
@@ -49,34 +60,51 @@ const fakeRate = (opts: { throwOn?: string[]; empty?: string[] } = {}) =>
   })
 
 const HQ = [
-  { pincode: DELHI, label: "Delhi HQ" },
-  { pincode: HIMACHAL, label: "Himachal HQ" },
+  { pincode: DELHI, label: "JYT HQ Delhi" },
+  { pincode: HIMACHAL, label: "Dharamshala" },
 ]
 
-describe("parseExportOrigins", () => {
-  it("reads pin:label pairs and labels a bare pin", () => {
-    expect(parseExportOrigins("110032:Delhi HQ, 176215")).toEqual([
-      { pincode: "110032", label: "Delhi HQ" },
-      { pincode: "176215", label: "HQ 176215" },
+describe("coreOriginsFromLocations", () => {
+  it("turns owned warehouses into origins, labelled by name", () => {
+    expect(
+      coreOriginsFromLocations([
+        { id: "sloc_a", name: "JYT HQ Delhi", address: { postal_code: "110096" } },
+        { id: "sloc_b", name: "Dharamshala", address: { postal_code: "176215" } },
+      ])
+    ).toEqual([
+      { pincode: "110096", label: "JYT HQ Delhi" },
+      { pincode: "176215", label: "Dharamshala" },
     ])
   })
 
-  it("drops anything that is not a 6-digit PIN, and says what it dropped", () => {
-    // A malformed origin passed to the carrier buys a slower no, and on the
-    // international endpoint a missing pickup_postcode is a 400 for the whole
-    // request rather than for that origin.
-    const { origins, rejected } = parseExportOriginsStrict("110032,ABCDEF,1234")
-    expect(origins.map((o) => o.pincode)).toEqual(["110032"])
-    expect(rejected).toEqual(["ABCDEF", "1234"])
+  it("🔴 drops a warehouse whose address has no usable PIN", () => {
+    // Shiprocket's international endpoint 400s the WHOLE request without a
+    // usable pickup_postcode, so a half-filled address does not fail politely
+    // on its own row — it takes the retry with it.
+    expect(
+      coreOriginsFromLocations([
+        { id: "a", name: "No address", address: null },
+        { id: "b", name: "Short pin", address: { postal_code: "1100" } },
+        { id: "c", name: "Not a pin", address: { postal_code: "SW1A 1AA" } },
+        { id: "d", name: "Good", address: { postal_code: "110096" } },
+      ]).map((o) => o.pincode)
+    ).toEqual(["110096"])
   })
 
-  it("treats a repeated pin as one origin, not two routes", () => {
-    expect(parseExportOrigins("110032:Delhi,110032:Delhi again")).toHaveLength(1)
+  it("treats two warehouses in one PIN as one origin", () => {
+    // Two rate queries for the same pin is a carrier call spent learning that
+    // they are the same pin.
+    expect(
+      coreOriginsFromLocations([
+        { id: "a", name: "Delhi A", address: { postal_code: "110096" } },
+        { id: "b", name: "Delhi B", address: { postal_code: "110096" } },
+      ])
+    ).toHaveLength(1)
   })
 
-  it("is empty, not throwing, when nothing is configured", () => {
-    expect(parseExportOrigins(undefined)).toEqual([])
-    expect(parseExportOrigins("")).toEqual([])
+  it("is empty, not throwing, when nothing is owned", () => {
+    expect(coreOriginsFromLocations([])).toEqual([])
+    expect(coreOriginsFromLocations(undefined as any)).toEqual([])
   })
 })
 
@@ -112,12 +140,12 @@ describe("rateWithOriginFallback", () => {
     })
 
     expect(routes.map((r) => r.origin_label)).toEqual(
-      expect.arrayContaining(["Delhi HQ", "Himachal HQ"])
+      expect.arrayContaining(["JYT HQ Delhi", "Dharamshala"])
     )
-    // 1276 + 206 = 1482 beats 2916 + 505 = 3421. A single hardcoded fallback
-    // pointed at Himachal would over-quote by 2.3x.
-    expect(routes[0].origin_label).toBe("Delhi HQ")
-    expect(routes[0].total_amount).toBe(1482)
+    // 1276 + 206.36 = 1482.36 beats 2916 + 505.05 = 3421.05. A single hardcoded
+    // fallback pointed at Dharamshala would over-quote by 2.3x.
+    expect(routes[0].origin_label).toBe("JYT HQ Delhi")
+    expect(routes[0].total_amount).toBeCloseTo(1482.36, 2)
   })
 
   it("🔴 trap 2: the total is BOTH legs, and both are recorded", async () => {
@@ -133,10 +161,10 @@ describe("rateWithOriginFallback", () => {
     })
 
     expect(best.export_leg.amount).toBe(1276)
-    expect(best.domestic_leg?.amount).toBe(206)
+    expect(best.domestic_leg?.amount).toBeCloseTo(206.36, 2)
     expect(best.domestic_leg?.destination_pincode).toBe(DELHI)
     // Quoting the export leg alone under-quotes by the first leg, every time.
-    expect(best.total_amount).toBe(1482)
+    expect(best.total_amount).toBeCloseTo(1482.36, 2)
     expect(best.domestic_leg_unrated).toBe(false)
   })
 
@@ -152,8 +180,8 @@ describe("rateWithOriginFallback", () => {
       const table: Record<string, number> = {
         [`${DELHI}->NL`]: 2900,
         [`${HIMACHAL}->NL`]: 2800,
-        [`${SRINAGAR}->${DELHI}`]: 206,
-        [`${SRINAGAR}->${HIMACHAL}`]: 505,
+        [`${SRINAGAR}->${DELHI}`]: 206.36,
+        [`${SRINAGAR}->${HIMACHAL}`]: 505.05,
       }
       if (key === `${SRINAGAR}->NL`) throw new Error("no couriers")
       const amount = table[key]
@@ -172,10 +200,39 @@ describe("rateWithOriginFallback", () => {
       currencyCode: "inr",
     })
 
-    // Export alone would pick Himachal (2800 < 2900). Landed picks Delhi
-    // (3106 < 3305).
-    expect(routes[0].origin_label).toBe("Delhi HQ")
-    expect(routes[0].total_amount).toBe(3106)
+    // Export alone would pick Dharamshala (2800 < 2900). Landed picks Delhi
+    // (3106.36 < 3305.05).
+    expect(routes[0].origin_label).toBe("JYT HQ Delhi")
+    expect(routes[0].total_amount).toBeCloseTo(3106.36, 2)
+  })
+
+  it("🔴 does not ask a single hub when the partner's own pin rates", async () => {
+    // The relay is a FALLBACK, not a comparison. Rating every hub on every
+    // quote would spend a carrier call per hub on lanes that never needed one,
+    // and would silently start routing shipments through Delhi to save a few
+    // hundred rupees on lanes the partner can serve directly — a logistics
+    // decision nobody made, arriving as a pricing change.
+    const rate = jest.fn(async (q: any) =>
+      q.origin_pincode === SRINAGAR
+        ? [{ courier_name: "Direct", amount: 9999, currency_code: "inr" }]
+        : [{ courier_name: "Relay", amount: 10, currency_code: "inr" }]
+    )
+
+    const routes = await rateWithOriginFallback({
+      partnerOrigin: SRINAGAR,
+      hqOrigins: HQ,
+      destinationPincode: "1011AB",
+      destinationCountry: "NL",
+      weightGrams: 1200,
+      rate,
+      currencyCode: "inr",
+    })
+
+    // Even though a hub would be 1000x cheaper, it is never asked.
+    expect(rate).toHaveBeenCalledTimes(1)
+    expect(routes).toHaveLength(1)
+    expect(routes[0].via_hq).toBe(false)
+    expect(routes[0].total_amount).toBe(9999)
   })
 
   it("prefers the partner's own pin once it becomes serviceable, with no code change", async () => {

--- a/apps/backend/src/modules/shipping-providers/export-origins.ts
+++ b/apps/backend/src/modules/shipping-providers/export-origins.ts
@@ -51,13 +51,13 @@
  * Shiprocket is the only live international rate source, so day one is a
  * Shiprocket-only capability behind a carrier-agnostic seam.
  *
- * ## Why origins are configuration
+ * ## Where the origins come from
  *
- * `EXPORT_FALLBACK_ORIGINS="110032:Delhi HQ,176215:Himachal HQ"`. A partner who
- * later gets their own pin export-enabled simply starts winning — their origin
- * has no domestic leg to pay for, so it undercuts every HQ route — with no code
- * change and no list to edit. Constants would need a deploy to reflect a fact
- * that changed at the carrier.
+ * `location_ownership.is_core` — the warehouses we already record as ours. Not
+ * an environment variable: that made the whole feature inert until somebody
+ * remembered to set it, and made "we opened a warehouse" a deploy. A partner
+ * who later gets their own pin export-enabled needs no change at all, because
+ * a rateable partner origin means the relay never runs.
  *
  * ## 🔴 What it will not do
  *
@@ -117,48 +117,89 @@ export type RatedRoute = {
 }
 
 /**
- * PURE. Parse the configured HQ origins.
+ * PURE: turn owned stock locations into export origins.
  *
- * Shape: `"110032:Delhi HQ,176215:Himachal HQ"`. A bare pincode is allowed and
- * labels itself. Anything that is not a 6-digit Indian PIN is dropped rather
- * than passed to a carrier that would answer a slower no — but see
- * `parseExportOriginsStrict` if you want the rejects back.
+ * 🔴 A location with no valid 6-digit PIN is DROPPED, not passed through.
+ * Shiprocket's international endpoint 400s the whole request without a usable
+ * `pickup_postcode`, so a half-filled address would not fail politely on its
+ * own row — it would take the retry with it.
+ *
+ * Deduplicated by pincode: two warehouses in the same PIN are one rate query,
+ * not two, and asking twice would just spend a carrier call to learn that.
  */
-export function parseExportOrigins(raw?: string | null): ExportOrigin[] {
-  const { origins } = parseExportOriginsStrict(raw)
-  return origins
-}
-
-/** As above, but also reports what it threw away — for a config-check route. */
-export function parseExportOriginsStrict(raw?: string | null): {
-  origins: ExportOrigin[]
-  rejected: string[]
-} {
-  const origins: ExportOrigin[] = []
-  const rejected: string[] = []
+export function coreOriginsFromLocations(
+  locations: Array<{ id?: string; name?: string | null; address?: any }>
+): ExportOrigin[] {
+  const out: ExportOrigin[] = []
   const seen = new Set<string>()
-
-  for (const entry of String(raw || "").split(",")) {
-    const trimmed = entry.trim()
-    if (!trimmed) continue
-    const [pinPart, ...labelParts] = trimmed.split(":")
-    const pincode = pinPart.trim()
-    if (!/^\d{6}$/.test(pincode)) {
-      rejected.push(trimmed)
-      continue
-    }
-    // A duplicate pin is not a second route, it is the same call twice.
+  for (const loc of locations ?? []) {
+    const pincode = String(loc?.address?.postal_code ?? "").trim()
+    if (!/^\d{6}$/.test(pincode)) continue
     if (seen.has(pincode)) continue
     seen.add(pincode)
-    origins.push({
-      pincode,
-      label: labelParts.join(":").trim() || `HQ ${pincode}`,
-    })
+    out.push({ pincode, label: String(loc?.name || `HQ ${pincode}`) })
   }
-
-  return { origins, rejected }
+  return out
 }
 
+/**
+ * The export origins available to fall back on — our OWN warehouses.
+ *
+ * ## Why ownership, and not configuration
+ *
+ * An earlier cut read these from `EXPORT_FALLBACK_ORIGINS`. That made the whole
+ * feature inert until somebody remembered to set an environment variable, and
+ * made "we opened a warehouse" a deploy. `location_ownership.is_core` already
+ * records the exact fact this needs — *we own the stock here* — it is set from
+ * the ops UI, and a new hub starts winning the moment it is marked.
+ *
+ * ⚠️ It is a deliberate CONFLATION: `is_core` was written to answer "may we
+ * deduct consumption from this stock", and this reads it as "may we export from
+ * here". Those are the same set today (our warehouses) and there is no second
+ * table to disagree with. If they ever diverge, this is the line to split.
+ *
+ * 🔴 A location with NO ownership row is not an origin. The model treats an
+ * unrecorded location as not-ours precisely so an unknown location cannot be
+ * used by default, and that rule matters more here than it does for stock:
+ * `set-location-ownership seed:true` INFERS ownership from partner linkage and
+ * infers it wrongly — it proposes marking partner-adjacent locations core while
+ * leaving the real Delhi warehouse out. Applying that seed would silently turn
+ * a dozen unrelated addresses into export origins. Rows are set one at a time,
+ * on purpose.
+ *
+ * Never throws: an origin lookup that fails means "no fallback available",
+ * which degrades to the behaviour that existed before this feature. Failing the
+ * whole estimate because a query hiccuped would be a far worse trade.
+ */
+export async function resolveCoreExportOrigins(scope: any): Promise<ExportOrigin[]> {
+  try {
+    const { ContainerRegistrationKeys } = await import("@medusajs/framework/utils")
+    const ownership: any = scope.resolve("location_ownership")
+
+    const rows = await ownership.listLocationOwnerships(
+      { is_core: true },
+      { take: null }
+    )
+    const ids = ((rows ?? []) as any[])
+      .map((r) => r?.stock_location_id)
+      .filter(Boolean)
+    if (!ids.length) return []
+
+    const query: any = scope.resolve(ContainerRegistrationKeys.QUERY)
+    // 🔴 Filtered by id. `filters: { id: undefined }` is NO filter rather than
+    // "no rows" (#1433) — an empty list must never become every stock location
+    // on the platform, which here would export from a partner's own address.
+    const { data: locations } = await query.graph({
+      entity: "stock_locations",
+      fields: ["id", "name", "address.postal_code", "address.country_code"],
+      filters: { id: ids },
+    })
+
+    return coreOriginsFromLocations((locations ?? []) as any[])
+  } catch {
+    return []
+  }
+}
 /** What a carrier answered for one lane. `rate` returns [] for "will not carry". */
 export type RateFn = (query: {
   origin_pincode: string
@@ -272,6 +313,20 @@ export async function rateWithOriginFallback(args: {
     }
   }
 
+  /** Currency guard + a stable order. Applied to whichever set we return. */
+  const finish = (found: RatedRoute[]): RatedRoute[] => {
+    const inCurrency = wantCurrency
+      ? found.filter((r) => {
+          if (r.currency_code === wantCurrency) return true
+          logger?.warn?.(
+            `[export-origins] dropped a ${r.currency_code} route (${r.total_amount}) — the quote is in ${wantCurrency}.`
+          )
+          return false
+        })
+      : found
+    return inCurrency.sort(byAmountThenName)
+  }
+
   const routes: RatedRoute[] = []
 
   // ---- The partner's own pin ---------------------------------------------
@@ -296,6 +351,25 @@ export async function rateWithOriginFallback(args: {
       is_recommended: !!r.is_recommended,
     })
   }
+
+  /**
+   * 🔑 The relay is a FALLBACK, not a comparison.
+   *
+   * If the partner's own pin can be rated, that is the answer: the goods
+   * leave from where they are made, nobody trucks them across the country
+   * first, and the quote describes the shipment we would actually book. Only
+   * when the carrier refuses that origin — "No serviceable couriers available
+   * for given weight", which is a 400, not an empty list — is there a question
+   * to ask at all.
+   *
+   * Rating every origin on every quote and taking the cheapest would also have
+   * been defensible, and it is what an earlier cut did. It is wrong for two
+   * reasons: it spends a carrier call per hub on lanes that never needed one,
+   * and it would silently start relaying shipments through Delhi to save a few
+   * hundred rupees on lanes the partner can serve directly — a logistics
+   * decision nobody made, arriving as a pricing change.
+   */
+  if (routes.length) return finish(routes)
 
   // ---- Every configured HQ pin -------------------------------------------
   for (const hq of hqOrigins) {
@@ -378,15 +452,5 @@ export async function rateWithOriginFallback(args: {
     }
   }
 
-  const inCurrency = wantCurrency
-    ? routes.filter((r) => {
-        if (r.currency_code === wantCurrency) return true
-        logger?.warn?.(
-          `[export-origins] dropped a ${r.currency_code} route (${r.total_amount}) — the quote is in ${wantCurrency}.`
-        )
-        return false
-      })
-    : routes
-
-  return inCurrency.sort(byAmountThenName)
+  return finish(routes)
 }


### PR DESCRIPTION
Two changes to the HQ relay shipped in #1500, both **narrowing** it. Per founder direction: no config gate — just fall over to a hub when the carrier says the pin is not serviceable.

## 1. Origins are data, not configuration

`EXPORT_FALLBACK_ORIGINS` made the whole feature inert until somebody remembered to set it, and made "we opened a warehouse" a deploy.

`location_ownership.is_core` already records the exact fact this needs — *we own the stock here*. Set from the ops UI, one row at a time; a new hub becomes an export origin the moment it is marked. The env var is gone; the `export_fallback_origins` input override stays for tests.

⚠️ A deliberate conflation: `is_core` was written to answer *"may we deduct consumption from this stock"* and this reads it as *"may we export from here"*. Same set today, no second table to disagree with. That's the line to split if they ever diverge.

### 🔴 A location with no ownership row is not an origin

This matters more here than it does for stock. **`set-location-ownership seed:true` infers ownership from partner linkage and infers it wrongly.** Against prod it proposes:

| location | seed says | actually |
|---|---|---|
| Bhagalpur Silks, Le Atelier, Azmat Handloom, +5 | **core** | not ours |
| **Main Warehouse** | **not core** | ours |

because it keys on *"is this a partner store's default location"*. Applying that seed would silently turn a dozen unrelated addresses into export origins. **Do not run it.**

## 2. The relay is a fallback, not a comparison

It now runs **only** when the partner's own pin cannot be rated. If that pin answers, that is the answer.

#1500 rated every hub on every quote and took the cheapest. That spends a carrier call per hub on lanes that never needed one — and it would silently start routing shipments through Delhi to save a few hundred rupees on lanes the partner can serve directly. A logistics decision nobody made, arriving as a pricing change.

## Probed live against prod's actual pins, 24 Aug

| lane (1.2 kg, 30×25×10) | result |
|---|---|
| 190001 Srinagar (partner) → NL | ❌ *No serviceable couriers available* |
| **110096 JYT HQ Delhi** → NL | ✅ **8 couriers, cheapest ₹1,276** |
| 176215 Dharamshala → NL | ✅ 1 courier, ₹2,916 |
| 190001 → 110096 (first leg) | ₹206.36 |
| 190001 → 176215 (first leg) | ₹505.05 |

**Landed: ₹1,482.36 via Delhi vs ₹3,421.05 via Dharamshala.** Both traps hold on the real numbers — the hubs are 2.3× apart, and the first legs are what decide the winner.

Both are now `location_ownership` core rows on prod, so the fixtures are the pins production actually holds. A made-up pair would rank the same way whether or not the first leg is counted, and the trap-2 test would pass over the defect.

## ⚠️ Recorded while probing

The international serviceability response nests the amount at **`courier.rate.rate`** — `courier.rate` is an *object*. The client already handles this (reading it one level too shallow once made every international quote come out `0`); the note is now in the fixture so the next reader doesn't rediscover it against a live account.

## Verification

- 16 unit tests on the fallback — 4 new for the ownership derivation, 1 new asserting **no hub is asked when the partner pin rates**
- 856 unit tests green across the touched modules; 24 quote integration tests
- `check:prod-build` green

## What is live after this merges

Nothing is gated any more. Srinagar → NL will start quoting **₹1,482.36 landed** instead of the flat fallback.

🔴 **#1498 open question 4 is still unanswered**: exporting from Delhi rather than Srinagar may change what the customs declaration says (#348). Worth a look before the first real export ships on a relayed rate.

⚠️ The `JYT HQ Delhi` location I created carries the pin (110096) but its **street line is a placeholder** — rating only uses the pin, but a customs declaration would not.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_0158wJMZ1DmjNxXf5uGuBrQD