### PR TITLE
feat(quotes): convert a carrier's freight into the quote currency instead of dropping it (#1502)

### DIFF
--- a/apps/backend/src/lib/__tests__/shipping-estimate.unit.spec.ts
+++ b/apps/backend/src/lib/__tests__/shipping-estimate.unit.spec.ts
@@ -1,4 +1,8 @@
-import { resolveUnitWeight, weightBucketGrams } from "../shipping-estimate"
+import {
+  convertCalculatedRates,
+  resolveUnitWeight,
+  weightBucketGrams,
+} from "../shipping-estimate"
 
 /**
  * The weight rule behind every freight number a buyer sees.
@@ -64,5 +68,151 @@ describe("weightBucketGrams", () => {
     for (const g of [1, 499, 750, 1001, 12_345]) {
       expect(weightBucketGrams(g)).toBeGreaterThanOrEqual(g)
     }
+  })
+})
+
+describe("convertCalculatedRates — the drop that guaranteed flat freight (#1502)", () => {
+  const inr = (amount: number) => ({
+    courier_name: "SRX",
+    amount,
+    currency_code: "inr",
+    source: "calculated" as const,
+  })
+
+  it("🔴 converts a carrier rate into the quote currency instead of dropping it", async () => {
+    // The measured Srinagar → Berlin lane: ₹3,771 export + ₹286.36 first leg
+    // = ₹4,057.36 landed, against a €35 flat that is €35 at 3 kg AND at 22 kg.
+    // Dropped, the flat row won by WALKOVER — not by being cheaper, but by
+    // being the only survivor.
+    const out = await convertCalculatedRates({
+      rates: [inr(4057.36)],
+      quoteCurrency: "eur",
+      lookup: async () => 0.0106,
+      convertedAt: "2026-08-24T00:00:00.000Z",
+    })
+
+    expect(out).toHaveLength(1)
+    expect(out[0].currency_code).toBe("eur")
+    // Rounded to the minor unit — left at full precision the total picks up a
+    // fraction of a cent no invoice will agree with.
+    expect(out[0].amount).toBeCloseTo(43.01, 2)
+  })
+
+  it("🔴 records the rate and the original, so the price can be reproduced", async () => {
+    // The objection that kept these rates being dropped was "a wrong FX rate is
+    // a wrong price wearing a confident label". Recording the working is what
+    // answers it — without this, nobody can check a quote after FX has moved.
+    const [opt] = await convertCalculatedRates({
+      rates: [inr(4057.36)],
+      quoteCurrency: "eur",
+      lookup: async () => 0.0106,
+      convertedAt: "2026-08-24T00:00:00.000Z",
+    })
+
+    expect(opt.fx).toEqual({
+      original_amount: 4057.36,
+      original_currency_code: "inr",
+      fx_rate: 0.0106,
+      fx_source: "fx_rates",
+      converted_at: "2026-08-24T00:00:00.000Z",
+    })
+  })
+
+  it("🔴 still DROPS a rate it cannot convert — a cold cache is not a guess", async () => {
+    // The one thing the original #1424 drop got right, and it must survive.
+    const warn = jest.fn()
+    const out = await convertCalculatedRates({
+      rates: [inr(4057.36)],
+      quoteCurrency: "eur",
+      lookup: async () => null,
+      convertedAt: "2026-08-24T00:00:00.000Z",
+      logger: { warn },
+    })
+
+    expect(out).toEqual([])
+    expect(warn).toHaveBeenCalled()
+  })
+
+  it("refuses a zero or negative rate rather than pricing through it", async () => {
+    for (const bad of [0, -1, NaN]) {
+      expect(
+        await convertCalculatedRates({
+          rates: [inr(4057.36)],
+          quoteCurrency: "eur",
+          lookup: async () => bad,
+          convertedAt: "2026-08-24T00:00:00.000Z",
+        })
+      ).toEqual([])
+    }
+  })
+
+  it("leaves a rate already in the quote currency untouched, with no fx stamp", async () => {
+    const lookup = jest.fn(async () => 0.0106)
+    const [opt] = await convertCalculatedRates({
+      rates: [inr(4057.36)],
+      quoteCurrency: "inr",
+      lookup,
+      convertedAt: "2026-08-24T00:00:00.000Z",
+    })
+
+    expect(opt.amount).toBe(4057.36)
+    expect(opt.fx).toBeUndefined()
+    // An `fx` stamp on an unconverted number would claim a conversion that
+    // never happened, and no rate should be fetched at all.
+    expect(lookup).not.toHaveBeenCalled()
+  })
+
+  it("passes everything through when there is no target currency", async () => {
+    // `/store/shipping-estimate` has no quote to denominate against.
+    const out = await convertCalculatedRates({
+      rates: [inr(100), inr(200)],
+      quoteCurrency: "",
+      lookup: async () => {
+        throw new Error("must not be consulted")
+      },
+      convertedAt: "2026-08-24T00:00:00.000Z",
+    })
+    expect(out).toHaveLength(2)
+  })
+
+  it("looks a currency up ONCE however many rates share it", async () => {
+    // Eight couriers on one lane is eight rates and one exchange rate.
+    const lookup = jest.fn(async () => 0.0106)
+    await convertCalculatedRates({
+      rates: [inr(1000), inr(2000), inr(3000)],
+      quoteCurrency: "eur",
+      lookup,
+      convertedAt: "2026-08-24T00:00:00.000Z",
+    })
+    expect(lookup).toHaveBeenCalledTimes(1)
+  })
+
+  it("🔴 makes the comparison honest, and it now MOVES with weight", async () => {
+    // The defect was never "flat wins". It was "flat wins because the
+    // alternative was thrown away". Converted, the carrier number enters the
+    // comparison and — unlike the flat row — it scales:
+    //
+    //    3 kg : the real lane is about EUR 43 against a EUR 35 flat
+    //   22 kg : the same lane is hundreds, and EUR 35 is still EUR 35
+    //
+    // So at light weights the flat row wins ON MERIT, and at heavy ones it
+    // stops being the answer. Neither was true while the rate was discarded.
+    const light = await convertCalculatedRates({
+      rates: [inr(4057.36)],
+      quoteCurrency: "eur",
+      lookup: async () => 0.0106,
+      convertedAt: "2026-08-24T00:00:00.000Z",
+    })
+    const heavy = await convertCalculatedRates({
+      rates: [inr(28000)],
+      quoteCurrency: "eur",
+      lookup: async () => 0.0106,
+      convertedAt: "2026-08-24T00:00:00.000Z",
+    })
+
+    expect(light[0].amount).toBeCloseTo(43.01, 2)
+    expect(heavy[0].amount).toBeCloseTo(296.8, 1)
+    // The whole point: the number responds to the consignment.
+    expect(heavy[0].amount).toBeGreaterThan(light[0].amount * 5)
   })
 })

--- a/apps/backend/src/lib/shipping-estimate.ts
+++ b/apps/backend/src/lib/shipping-estimate.ts
@@ -1,5 +1,6 @@
 import { ContainerRegistrationKeys, MedusaError, Modules } from "@medusajs/framework/utils"
 
+import { planShippingFxConversion } from "../modules/partner_billing/shipping-ledger"
 import { isInternationalDestination } from "../modules/shipping-providers/destination"
 import {
   rateWithOriginFallback,
@@ -88,6 +89,21 @@ export type ShippingEstimateOption = {
   estimated_days?: number | null
   is_recommended?: boolean
   source: "manual" | "calculated"
+  /**
+   * Set when this amount was CONVERTED from the carrier's own currency (#1502).
+   *
+   * 🔑 The rate travels with the number rather than being logged. A converted
+   * price that records only its result cannot be reproduced once FX has moved,
+   * so nobody can later check whether a quote was priced honestly — which is
+   * the whole objection that kept these rates being dropped instead.
+   */
+  fx?: {
+    original_amount: number
+    original_currency_code: string
+    fx_rate: number
+    fx_source: "operator" | "fx_rates"
+    converted_at: string
+  }
   /**
    * How this number was actually routed (#1498). Present only on a relay —
    * absent means the partner's own pin exported it directly.
@@ -224,6 +240,82 @@ export function zoneCoversDestination(
   return zones.some(
     (g) => String(g?.country_code || "").toLowerCase() === target
   )
+}
+
+/**
+ * PURE (given a rate lookup): put every CALCULATED rate into the quote's
+ * currency, or drop the ones that cannot get there (#1502).
+ *
+ * Split out of `buildShippingEstimate` because this is the rule that decides a
+ * buyer's freight number, and a rule that can only be exercised through a
+ * container, a cache and a live carrier is a rule nothing checks.
+ *
+ * The `lookup` is injected for the same reason `resolveShippingFx` resolves the
+ * rate at the container edge: under module isolation the arithmetic and the
+ * rate cannot live in the same place, so the rate arrives as a finished fact.
+ */
+export async function convertCalculatedRates(args: {
+  rates: ShippingEstimateOption[]
+  /** The quote's currency, lower-case. Empty means "no target" — pass through. */
+  quoteCurrency: string
+  /** from-currency → rate, or null when no path exists. Called once per currency. */
+  lookup: (fromCurrency: string) => Promise<number | null>
+  convertedAt: string
+  logger?: { warn?: (m: string) => void }
+  /** Only for the log line. */
+  carrier?: string
+}): Promise<ShippingEstimateOption[]> {
+  const { rates, quoteCurrency, lookup, convertedAt, logger } = args
+  const out: ShippingEstimateOption[] = []
+  const cache = new Map<string, number | null>()
+
+  for (const r of rates ?? []) {
+    // No target currency means nothing to convert TO. Pass through rather than
+    // invent one — this is the `/store/shipping-estimate` single-currency case.
+    if (!quoteCurrency || r.currency_code === quoteCurrency) {
+      out.push(r)
+      continue
+    }
+
+    if (!cache.has(r.currency_code)) {
+      cache.set(r.currency_code, await lookup(r.currency_code))
+    }
+
+    const planned = planShippingFxConversion({
+      amount: r.amount,
+      currency_code: r.currency_code,
+      orderCurrency: quoteCurrency,
+      rate: cache.get(r.currency_code) ?? null,
+      source: "fx_rates",
+      convertedAt,
+    })
+
+    // 🔴 Still dropped when there is no rate. A cold FX cache must not become a
+    // guess: that is the one thing the original #1424 drop got right.
+    if (!planned) {
+      logger?.warn?.(
+        `[shipping-estimate] dropped ${args.carrier ?? "carrier"} rate ${r.amount} ` +
+          `${r.currency_code} — no rate to ${quoteCurrency}, and mixing currencies ` +
+          `would corrupt the landed total`
+      )
+      continue
+    }
+
+    out.push({
+      ...r,
+      amount: planned.amount,
+      currency_code: planned.currency_code.toLowerCase(),
+      fx: {
+        original_amount: planned.fx.original_amount,
+        original_currency_code: planned.fx.original_currency_code.toLowerCase(),
+        fx_rate: planned.fx.fx_rate,
+        fx_source: planned.fx.fx_source,
+        converted_at: planned.fx.converted_at,
+      },
+    })
+  }
+
+  return out
 }
 
 /**
@@ -579,32 +671,72 @@ export async function buildShippingEstimate(
   }
 
   /**
-   * 🔴 #1424's currency guard, which only ever covered the MANUAL branch.
+   * 🔴 #1424's currency guard — now a CONVERSION, not a drop (#1502).
    *
-   * Carriers quote in their OWN currency — an Indian carrier answers in INR
+   * ## What the guard was right about
+   *
+   * Carriers quote in their OWN currency: an Indian carrier answers in INR
    * whatever the buyer is being billed in. `pickFreightOption` sorts on the raw
    * `amount` and `composeQuoteMoney` adds it straight to the subtotal, so an
-   * INR rate on a EUR quote is not merely irrelevant: it silently WINS whenever
-   * its number is smaller, and is then added to a EUR total and rendered with a
-   * € sign.
+   * INR rate on a EUR quote is not merely irrelevant — it silently WINS
+   * whenever its number is smaller, and is then added to a EUR total and
+   * rendered with a € sign. Seen live: Srinagar → Berlin answered ₹3,788 /
+   * ₹5,232 / ₹14,436 alongside a €35 flat, and €35 "won" only because 35 is the
+   * smallest number.
    *
-   * Seen on the first live international quote (Srinagar → Berlin, 3 kg, EUR):
-   * Shiprocket answered ₹3,788 / ₹5,232.50 / ₹14,436 alongside a €35 flat.
-   * €35 won ONLY because 35 is the smallest number — take the flat option away
-   * and the buyer's landed total becomes €4,718 + 3,788 = €8,506.
+   * ## Why dropping them was not the end of it
    *
-   * Dropped rather than converted: converting needs an FX rate this function
-   * does not have, and a wrong rate is a wrong price wearing a confident label.
-   * Cross-border live rates in the buyer's own currency are a real gap, but a
-   * gap is recoverable and a mispriced consignment is not.
+   * The guard shipped as a drop, on the reasoning that converting needs an FX
+   * rate this function does not have and a wrong rate is a wrong price wearing
+   * a confident label. That was right about the danger and wrong about the
+   * remedy, and #1498 made the cost obvious:
+   *
+   * Every carrier rate for an export lane is in INR, so on a EUR quote the
+   * calculated list is ALWAYS empty and the flat manual row wins by WALKOVER —
+   * not by being cheaper, but by being the only survivor. That row is €35 at
+   * 3 kg and €35 at 22 kg. The measured cost of the same 3 kg lane is ₹4,057
+   * landed (≈ €43), and it rises with weight while €35 never moves. So the
+   * drop was quietly guaranteeing the "international freight is flat at any
+   * weight" defect it looked unrelated to.
+   *
+   * ## The rate comes from outside, and travels with the number
+   *
+   * Same shape as `resolveShippingFx` already uses for order freight, and the
+   * same pure `planShippingFxConversion` does the arithmetic and the
+   * minor-unit rounding — one FX path, not a second one to disagree with it.
+   * The rate, its source and the original amount are recorded on the option, so
+   * a converted price can be reproduced after FX has moved. That is what
+   * removes the "confident label" problem: the label now shows its working.
+   *
+   * 🔑 A rate that CANNOT be converted is still dropped, exactly as before. A
+   * cold FX cache must not become a guess.
+   *
+   * ⚠️ CALCULATED rates only. A manual option priced in another currency is a
+   * different offer the partner made to buyers billed in that currency;
+   * converting it would invent an offer nobody published. Those are filtered
+   * out further up, on the currency check beside the zone and rule checks.
    */
-  const calculated = rawCalculated.filter((r) => {
-    if (!quoteCurrency) return true
-    if (r.currency_code === quoteCurrency) return true
-    logger?.warn?.(
-      `[shipping-estimate] dropped ${carrier} rate ${r.amount} ${r.currency_code} — quote is in ${quoteCurrency}, and mixing currencies would corrupt the landed total`
-    )
-    return false
+  const calculated = await convertCalculatedRates({
+    rates: rawCalculated,
+    quoteCurrency,
+    convertedAt: new Date().toISOString(),
+    carrier,
+    logger,
+    lookup: async (from) => {
+      try {
+        const fx: any = scope.resolve("fx_rates")
+        const r = Number(await fx.getRate(from, quoteCurrency))
+        return Number.isFinite(r) && r > 0 ? r : null
+      } catch (e: any) {
+        // `getRate` throws NOT_FOUND when the cache has no path between the two
+        // currencies — a cold cache, or one the provider does not quote.
+        logger?.warn?.(
+          `[shipping-estimate] no ${from}->${quoteCurrency} rate (${e?.message}); ` +
+            `carrier rates in ${from} will be dropped rather than guessed.`
+        )
+        return null
+      }
+    },
   })
 
   return {


### PR DESCRIPTION
#1424 found that carrier rates arrive in the **carrier's** currency, and that `pickFreightOption` sorts on the raw amount — so an INR rate on a EUR quote doesn't merely fail to help, it *wins* whenever its number is smaller and is then rendered with a euro sign. The fix was to **drop** any rate not already in the quote currency: converting needs an FX rate the function doesn't have, and *"a wrong FX rate is a wrong price wearing a confident label"*.

Right about the danger. Wrong about the remedy — and #1498 made the cost plain.

## What the drop was quietly guaranteeing

Every carrier rate on an export lane is in INR. So on a EUR quote the calculated list is **always empty**, and the flat manual row wins by **walkover** — not by being cheaper, but by being the only survivor.

Measured on the live Srinagar → Berlin lane, 3.045 kg:

| leg | |
|---|---|
| export 110096 → DE | ₹3,771 |
| first leg 190003 → 110096 | ₹286.36 |
| **landed** | **₹4,057.36** ≈ €43 |
| **what the buyer saw** | **€35** — the flat row, unopposed |

And that flat row is €35 at 3 kg **and €35 at 22 kg**. So the drop was underwriting the "international freight is flat at any weight" defect it looked unrelated to — and it made #1498's entire relay invisible on every EUR-denominated quote.

## The rate comes from outside, and travels with the number

Same shape `resolveShippingFx` already uses for order freight, and the same pure `planShippingFxConversion` does the arithmetic and the minor-unit rounding — **one FX path**, not a second one to disagree with it. Under module isolation the rate can't be resolved where the arithmetic lives, so it arrives as a finished fact.

The rate, its source and the original amount are recorded on the option:

```json
"fx": {
  "original_amount": 4057.36,
  "original_currency_code": "inr",
  "fx_rate": 0.0106,
  "fx_source": "fx_rates",
  "converted_at": "2026-08-24T…"
}
```

That answers the "confident label" objection directly: the label now **shows its working**, and a converted price stays reproducible after FX has moved.

## What has NOT changed

- **A rate that cannot be converted is still dropped**, with the same warning. A cold FX cache must not become a guess — that part of #1424 was simply correct.
- Zero, negative and unparseable rates are refused rather than priced through.
- **Manual options in another currency are still dropped**, further up. A manual price is an offer the partner published to buyers billed in that currency; converting it would invent an offer nobody made. Only *calculated* carrier rates are converted.

## The comparison is now honest in both directions

At 3 kg the €35 flat genuinely beats the converted €43 and **should** win. At 22 kg the same lane converts to hundreds and the flat row stops being the answer. Neither was true while the rate was discarded.

The policy is extracted as `convertCalculatedRates` with the lookup injected — a rule that decides a buyer's freight and can only be exercised through a container, a cache and a live carrier is a rule nothing checks.

## Verification

- 8 new unit tests, including that it still drops on a cold cache and that it looks a currency up once for eight couriers
- 969 unit tests green across the touched modules; 40 quote integration tests
- `check:prod-build` green

## ⚠️ Watch-out

**This needs an `inr→eur` rate in the `fx_rates` cache to do anything.** With a cold cache the behaviour is exactly today's — dropped and logged. Confirming that against prod is the next step, and if the cache is cold the fix is to seed/refresh it, not to change this.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_0158wJMZ1DmjNxXf5uGuBrQD