### PR TITLE
docs(quotes,shipping): write down the export relay, the FX guard and the tenant guard — and shrink the variant pills

### DIFF
--- a/apps/docs/docs/implementation/quotes/_category_.json
+++ b/apps/docs/docs/implementation/quotes/_category_.json
@@ -1,0 +1,8 @@
+{
+  "label": "B2B Quotes",
+  "position": 13,
+  "link": {
+    "type": "generated-index",
+    "description": "The partner quote pipeline — tenancy, line composition, and what a signed commercial document is allowed to carry."
+  }
+}

--- a/apps/docs/docs/implementation/quotes/design-lines.md
+++ b/apps/docs/docs/implementation/quotes/design-lines.md
@@ -1,0 +1,97 @@
+---
+title: "Quote lines: attaching a design, and refusing a foreign one"
+sidebar_label: "Design lines"
+sidebar_position: 2
+---
+
+# Design lines on a quote
+
+**Issues:** [#1501], [#1486] · **Shipped:** #1501
+**Code:** `apps/backend/src/modules/partner-quote/lib/design-lines.ts`, plus a
+panel in each of the two quote wizards.
+
+## The gap
+
+`design_by_variant` has existed since #1486 and the mint has always frozen it
+onto the line — but **only the design picker could write it**. A line found the
+ordinary way, in the product table, could never be told what it was made to; a
+line that arrived through a design could never be corrected or cleared.
+
+Half-writable: one entry point, no edit, no clear. The other half matches how
+partners actually work — they know the product, and the design is what they add
+afterwards.
+
+## 🔴 The hole it uncovered
+
+```js
+.filter((l) => l?.design_id && !l?.variant_id)   // a line WITH a variant skipped resolution entirely
+```
+
+So **any string at all** could be frozen onto a commercial document as its
+design — including another partner's design id. Nothing renders design data on
+the buyer page, which is the only reason this was not a leak. An unchecked
+foreign id on a signed document is the #1496 family and does not get to wait for
+a renderer to make it real.
+
+Every named design is now resolved, and a line that already names its variant
+must prove its design is **visible**. The refusal reuses the wording a missing
+design gets, so an id cannot be probed for existence by attaching it to a line.
+
+## Visibility, not resolvability — the asymmetry is the point
+
+| design | quoted ALONE | attached to a chosen variant |
+|---|---|---|
+| resolves to one variant | ✅ | ✅ |
+| no product behind it | ❌ nothing to price | ✅ **the ordinary case** — the sketch a catalogue product was made from |
+| sold as several variants | ❌ which SKU? | ✅ the SKU is already chosen |
+| not yours / not there | ❌ | ❌ |
+
+`DesignResolution` grows an explicit `visible` rather than inferring two
+questions from one field. The readiness preflight makes the same split —
+otherwise it reports *"sold as 3 variants"* as blocking on a line whose variant
+is already chosen, inventing a problem the partner cannot fix and did not have.
+
+:::danger The variant is never moved
+Attaching a design must not silently re-point the line at a different SKU. That
+would change *what is being sold* as a side effect of recording *what it was
+made from*.
+:::
+
+## Admin vs partner scoping
+
+The admin mint resolves design lines **unscoped by partner** — an admin
+legitimately quotes a design the producing partner does not own. The guard that
+matters on that surface is the next one: the resolved variant still has to be in
+that partner's sales channel (`assertVariantsInStore`), because an admin picks
+the partner from one dropdown and the variants from another, and a single
+mis-click would freeze one partner's prices onto another partner's customer
+group.
+
+## UI
+
+A panel under the quantities grid, not a grid column: a design is chosen from
+hundreds **by name**, which is a search, and that grid is a numeric keyboard
+surface whose arrow-key navigation a combobox fights. Only quantity-bearing
+variants are listed.
+
+Both wizards, deliberately — [#1380] landed a fix on four of five creation paths
+and the fifth was the one that mattered.
+
+## ⚠️ Watch-outs
+
+- 🔴 **`apps/partner-ui` still has no CI** — `tsconfig` excludes `apps/*`. Its
+  half was type-checked and built by hand. The two decisions with a way of being
+  quietly wrong are extracted into a pure module with vitest coverage, and the
+  admin copy carries the same assertions under jest so a drift goes red:
+  - an empty quantity must read as **not a line** — `Number("")` is `0`, the
+    same coercion that once parsed a truncated quote link as *remove this line*;
+  - clearing a design must **delete the key**, not write `""` — the payload
+    builder sends `design_id` whenever the entry is present, so `""` would
+    travel to the mint as a design id and be refused, turning "clear this field"
+    into a failed mint.
+- **The panels themselves have not been clicked.** There is no DOM harness in
+  either app.
+
+[#1380]: https://github.com/Jaal-Yantra-Textiles/v2/issues/1380
+[#1486]: https://github.com/Jaal-Yantra-Textiles/v2/issues/1486
+[#1501]: https://github.com/Jaal-Yantra-Textiles/v2/issues/1501

--- a/apps/docs/docs/implementation/quotes/minting.md
+++ b/apps/docs/docs/implementation/quotes/minting.md
@@ -1,0 +1,82 @@
+---
+title: "Minting a quote: the one workflow, and a live blocker"
+sidebar_label: "Minting"
+sidebar_position: 3
+---
+
+# Minting a quote
+
+**Code:** `apps/backend/src/workflows/partner-quote/mint-quote.ts`,
+`src/api/admin/quotes/route.ts`, `src/api/partners/quotes/route.ts`
+
+## One workflow, two surfaces
+
+Both `POST /admin/quotes` and `POST /partners/quotes` run
+`mintQuoteWorkflow`. A second inline implementation would drift from the one
+that freezes prices, creates the customer group, and **asserts the price-list
+rule from a re-read** — that assertion is the only thing standing between a
+quote and a platform-wide price cut.
+
+The admin body extends the partner **shape** and re-applies
+`dutyUndertakingRefinement`. `.extend` on an already-refined schema silently
+drops cross-field rules, and the rule it would drop is the one stopping a DDP
+quote from promising duty cover with no amount behind it ([#1447]).
+
+The only difference between the surfaces is `partner_id`: required to mint,
+optional to list. An admin mint is stamped `actor_type: "admin"` — the first
+question asked when a buyer challenges a price is who quoted it.
+
+## The raw token is returned once
+
+Only its sha256 is persisted. An admin list can therefore never show a working
+link for an existing quote and must not pretend to — the only way to get a fresh
+link is to mint again.
+
+## 🔴 Live blocker: an existing buyer cannot be quoted ([#1507])
+
+Minting to an email that already exists as a customer **anywhere on the
+platform** answers 400:
+
+```
+Customer with email: <addr>, has_account: false, already exists.
+```
+
+`resolve-quote-buyer-step` looks the buyer up **scoped to the store** — correct,
+because another partner's customer with the same email is not this partner's
+buyer — but `customer.email` is **globally unique** in core. The two rules are
+unsatisfiable together: the lookup cannot see the row, and the create collides
+with it.
+
+It bites exactly the highest-value case: an existing customer of one store
+asking a partner for a bulk price. Both mint surfaces are affected. The
+workaround used on 24 Aug was a `+tag` alias, which is not a fix — it mints a
+quote to an identity that is not the buyer's.
+
+:::note The compensation is sound
+The failed mint left no orphan: compensation deletes only what the run created
+and never the customer.
+:::
+
+## ⚠️ Other watch-outs
+
+- **`zodValidator` forces `.strict()`.** A field the schema does not name never
+  reaches the workflow — the deal silently takes default terms while the wizard
+  shows the number the partner typed. `deposit_pct` is the cautionary example.
+- **`freight_override_amount` is `.positive()`, not `.min(0)`.** A zero would be
+  free international shipping typed by accident, and this system has shipped
+  bulk orders free once already from a rule-gated `0 INR` row ([#1430]).
+- **Revoking is not a status flip.** The quote's prices live in a real, active
+  price list scoped to the buyer's customer group. `POST /admin/quotes/:id/revoke`
+  deletes the price list **first** and marks the row second: a failure then
+  leaves a visibly inconsistent but safe state, where the reverse order would
+  leave a revoked-looking quote still quietly pricing carts. It is idempotent.
+- **A repeat quote stacks price lists** ([#1435], unfixed). Two active lists on
+  one customer group means core tie-breaks to the **cheapest**, so a re-quote at
+  a higher price can hand the buyer the old one.
+- **Buyer tax id changes no number.** Quote tax follows the *seller's*
+  jurisdiction ([#1447]); the buyer's registration is a line on a document.
+
+[#1430]: https://github.com/Jaal-Yantra-Textiles/v2/issues/1430
+[#1435]: https://github.com/Jaal-Yantra-Textiles/v2/issues/1435
+[#1447]: https://github.com/Jaal-Yantra-Textiles/v2/issues/1447
+[#1507]: https://github.com/Jaal-Yantra-Textiles/v2/issues/1507

--- a/apps/docs/docs/implementation/quotes/tenant-isolation.md
+++ b/apps/docs/docs/implementation/quotes/tenant-isolation.md
@@ -1,0 +1,80 @@
+---
+title: "Quote tenant isolation: the guard fails closed"
+sidebar_label: "Tenant isolation"
+sidebar_position: 1
+---
+
+# Quote tenant isolation
+
+**Issues:** [#1496] (the leak), [#1439] · **Shipped:** #1499
+**Code:** `apps/backend/src/api/store/b2b/quotes/[token]/route.ts`
+
+## The leak
+
+A buyer quote page rendered on **every** partner storefront. Three different
+stores' publishable keys all returned 200 for the same token. There was no
+tenant check at all: the token was the only thing consulted, and a token is not
+a tenancy.
+
+## Why the first fix was still open
+
+S15 added a guard that refused only a **proven** mismatch. Where either side was
+unresolvable — quote without a `store_id`, key resolving to no store, store with
+no sales channel — it allowed the read and logged.
+
+That was deliberate. Failing closed on *"cannot tell"* is the [#1397] outcome:
+a dangling publishable key produced `sales_channels: [null]` on an unfiltered
+cross-tenant query and every partner storefront 500'd. A certain loss traded
+against a possible leak.
+
+**The sizing was wrong, and it was wrong because it came off a dev database.**
+24 of 28 stores looked channel-less and 12 of 16 quotes looked untagged; after
+filtering `E2E %` rows it was 0 of 2.
+
+## What prod actually said (24 Aug 2026)
+
+| measure | prod |
+|---|---|
+| `partner_quote` rows carrying `store_id` | **8 of 8** — nothing to backfill |
+| stores lacking `default_sales_channel_id` | **0 of 13** |
+| publishable keys resolving to a store | **14 of 14** |
+
+Nothing relied on any of the three hatches, so each is now a refusal.
+
+## The shape of the refusal
+
+**404**, with the same body an unknown token gets. A prober must not learn a
+token is real by being told they are on the wrong shop. A revoked quote is
+deliberately indistinguishable from an unknown one for the same reason.
+
+The *keyless* case never reaches this code — core rejects a missing
+`x-publishable-api-key` with a 400 before the route runs. So the "no sales
+channels" hatch could only ever have been the dangling key of #1397.
+
+## Verified on prod (24 Aug 2026)
+
+Live quote `01M0S1TMHCJ72FJ7766ZGAVMKB` on the Unique Pashmina storefront:
+
+| key | result |
+|---|---|
+| Unique Pashmina publishable key | **200** |
+| JYT Medu Store publishable key (same token) | **404** |
+
+## ⚠️ Watch-outs
+
+- **A store created without a default sales channel now locks its own buyers
+  out** rather than falling through. That is the intended trade — but it is why
+  both the guard's docblock and the `backfill-quote-tenancy` job report those
+  counts. Re-run the job before assuming the numbers still hold.
+- **The callee must refuse.** Passing the right id from the caller is not the
+  fix on its own; the same shape produced [#1433], where a missing filter meant
+  *no filter* rather than *no rows* and a public quote page priced freight from
+  every tenant's locations. Fix both ends.
+- **The two new tests were confirmed to fail against the old guard** before
+  being accepted. That check is the point — #1495 was a suite passing 7/7 over
+  an assertion its own fixture had made vacuous.
+
+[#1397]: https://github.com/Jaal-Yantra-Textiles/v2/pull/1397
+[#1433]: https://github.com/Jaal-Yantra-Textiles/v2/issues/1433
+[#1439]: https://github.com/Jaal-Yantra-Textiles/v2/issues/1439
+[#1496]: https://github.com/Jaal-Yantra-Textiles/v2/issues/1496

--- a/apps/docs/docs/implementation/shipping/_category_.json
+++ b/apps/docs/docs/implementation/shipping/_category_.json
@@ -1,0 +1,8 @@
+{
+  "label": "Shipping & Freight",
+  "position": 12,
+  "link": {
+    "type": "generated-index",
+    "description": "How a freight number is produced: which origin is rated, which options survive, and what currency the buyer is shown."
+  }
+}

--- a/apps/docs/docs/implementation/shipping/export-freight-relay.md
+++ b/apps/docs/docs/implementation/shipping/export-freight-relay.md
@@ -1,0 +1,140 @@
+---
+title: "Export Freight: rating from an HQ pin when the partner's cannot"
+sidebar_label: "Export freight relay"
+sidebar_position: 1
+---
+
+# Export freight: the origin relay
+
+**Issue:** [#1498] · **Shipped:** #1500, #1503, #1505, #1506 (2026-08-24)
+**Code:** `apps/backend/src/modules/shipping-providers/export-origins.ts`, `apps/backend/src/lib/shipping-estimate.ts`
+
+## The problem, in one sentence
+
+A partner in Srinagar cannot export. The carrier answers *"no serviceable
+couriers"* with a **400**, every international lane fell through to a flat
+manual row, and that row is the same number at 3 kg and at 22 kg — which is
+why international freight read as flat at any weight.
+
+Probed live against Shiprocket on 2026-08-24, 1.2 kg / 30×25×10:
+
+| origin | → NL | → DE |
+|---|---|---|
+| `190001` Srinagar (partner) | ❌ 400, no serviceable couriers | ❌ 400 |
+| `110032` / `110096` Delhi HQ | ✅ 8 couriers, from ₹1,276 | ✅ 5, from ₹1,852 |
+| `176215` Himachal HQ | ✅ 1 courier, ₹2,916 | ✅ 2, from ₹1,852 |
+
+The goods already route through a warehouse and export from there. The relay
+makes the *quote* describe the movement that actually happens.
+
+## What it does
+
+When the destination is international **and** the partner's own pin cannot be
+rated, every owned warehouse pin is tried, and the cheapest **complete** route
+wins. A route is two legs, and the total is both of them:
+
+| route | Srinagar → HQ | HQ → NL | landed |
+|---|---|---|---|
+| via Delhi | ₹206 | ₹1,276 | **₹1,482.36** |
+| via Himachal | ₹505 | ₹2,916 | ₹3,421.05 |
+
+The route travels **with** the number. Each calculated option carries a `route`
+object naming the hub, the two leg amounts, and whether the domestic leg could
+be priced — because a landed price that is silently two legs is unauditable.
+
+## Three decisions worth knowing
+
+### It is a fallback, not a comparison
+
+If the partner's own pin rates, that is the answer and no hub is asked. An
+earlier cut rated every origin on every quote and took the cheapest. That is
+wrong twice: it spends a carrier call per hub on lanes that never needed one,
+and it would silently start relaying domestic-capable shipments through Delhi
+to save a few hundred rupees — a logistics decision nobody made, arriving as a
+pricing change.
+
+### It lives above the provider
+
+The obvious home is inside `shiprocket/rate-context.ts`, and that would be
+wrong. *"If the partner's origin cannot be rated, retry from an HQ origin"* has
+nothing to do with Shiprocket — it applies identically to Blue Dart, DTDC and
+DHL as each gains a rate API. `rateWithOriginFallback` takes a `rate()`
+callback and names no carrier. Today Shiprocket is the only live international
+rate source, so day one is a Shiprocket-only capability behind a
+carrier-agnostic seam.
+
+### Origins are data, not configuration
+
+Hubs come from `location_ownership.is_core` — the warehouses already recorded
+as ours. An earlier cut read `EXPORT_FALLBACK_ORIGINS`; that env var is gone.
+It made the whole feature inert until somebody remembered to set it, and made
+"we opened a warehouse" a deploy. A new hub is live the moment it is marked.
+
+:::info Deliberate conflation
+`is_core` was written to answer *"may we deduct consumption from this stock"*,
+and this reads it as *"may we export from here"*. Those are the same set today
+and there is no second table to disagree with. If they diverge, that is the
+line to split.
+:::
+
+## Prod configuration (24 Aug 2026)
+
+Two core rows:
+
+| location | pin | → NL, 1.2 kg |
+|---|---|---|
+| `sloc_01JPAQVGYJR3CDP2Q2AYV7GRDR` Dharamshala | 176215 | 1 courier, ₹2,916 |
+| `sloc_01M0RXH3XXDVR2PDC7XKXH7VTP` JYT HQ Delhi | 110096 | 8 couriers, ₹1,276 |
+
+## Caching
+
+One carrier call **per leg**, cached 900s under a key of
+carrier · origin · destination · country · weight bucket. Per-leg rather than
+per-quote: `110032 → NL at 1.2 kg` is the same question for every partner, so
+the second partner to quote that lane pays nothing for it. Weights are bucketed
+to 500 g so a buyer dragging a quantity slider does not mint a rate per step.
+
+The cache holds the **unfiltered** carrier answer. Caching the currency-filtered
+list under a key with no currency in it would serve an INR quote's survivors to
+a EUR one — the very bug the guard exists to prevent, reintroduced through the
+cache.
+
+## 🔴 Watch-outs
+
+- **Never run `set-location-ownership seed:true`.** Its inference keys on *"is
+  this a partner store's default location"*, which is wrong for export
+  purposes. Against prod it proposes marking *Bhagalpur Silks*, *Le Atelier*,
+  *Azmat Handloom* and five others core while leaving **Main Warehouse** out.
+  Applying it would silently turn a dozen unrelated addresses into export
+  origins. Set rows one at a time.
+- **A rated route is not permission to ship it.** Readiness refuses a country
+  with no configured lane — *"No freight option could be quoted to DE from this
+  store's location"* (#1497) — **before** the relay is consulted. The relay only
+  helps a store that already has the lane configured.
+- **`EXPORT_FIRST_LEG_IS_SUNK` defaults to charging the first leg.** Setting it
+  to `true` under-quotes every relay route by ₹206–₹505 *and* ranks the hubs
+  wrongly, because the leg costs do not rank the same way the export costs do.
+  Set it only if stock demonstrably consolidates at HQ regardless of the order.
+- **HQ pins are not interchangeable.** Delhi is 2.3× cheaper than Himachal to
+  NL for the same parcel. A single hardcoded fallback silently over-quotes.
+- **The `JYT HQ Delhi` street line is a placeholder.** Rating only uses the
+  pin; a customs declaration does not — see the open question below.
+- **A location with no valid 6-digit PIN is dropped, not passed through.**
+  Shiprocket's international endpoint 400s the *whole request* on a bad
+  `pickup_postcode`, so a half-filled address would take the retry with it.
+- **The relay never returns 0.** A zero is indistinguishable from genuinely
+  free freight and shipped bulk orders free once already (#1430).
+- **A route whose two legs disagree on currency is dropped, not summed.**
+- **An origin lookup that fails is logged, never silent.** A swallowed failure
+  degrades to "no fallback available", which looks exactly like "correctly
+  configured and not needed" — the only signal of breakage would be the absence
+  of a signal.
+
+## Open question
+
+Does exporting from Delhi rather than Srinagar change the customs declaration
+([#348])? The seller tax ID and origin address on a declaration are not the pin
+used for rating. Unanswered.
+
+[#1498]: https://github.com/Jaal-Yantra-Textiles/v2/issues/1498
+[#348]: https://github.com/Jaal-Yantra-Textiles/v2/issues/348

--- a/apps/docs/docs/implementation/shipping/freight-currency-and-fx.md
+++ b/apps/docs/docs/implementation/shipping/freight-currency-and-fx.md
@@ -1,0 +1,94 @@
+---
+title: "Freight currency: why rates are converted and not dropped"
+sidebar_label: "Freight currency & FX"
+sidebar_position: 2
+---
+
+# Freight currency and FX
+
+**Issues:** [#1424] (the guard), [#1502]/[#1498] (the conversion) · **Shipped:** #1505
+**Code:** `apps/backend/src/lib/shipping-estimate.ts` — `convertCalculatedRates`
+
+## Why a currency guard exists at all
+
+`pickFreightOption` sorts on the raw `amount` and `composeQuoteMoney` adds it
+straight to the subtotal. So an INR rate on a EUR quote is not merely
+irrelevant — **it wins whenever its number is smaller**, and is then added to a
+EUR total and rendered with a euro sign.
+
+Seen live: Srinagar → Berlin answered ₹3,788 / ₹5,232 / ₹14,436 alongside a €35
+flat row, and €35 "won" only because 35 is the smallest number.
+
+## Why dropping them was not the end of it
+
+#1424 shipped the guard as a **drop**, reasoning that converting needs an FX
+rate the function does not have, and a wrong rate is a wrong price wearing a
+confident label. That was right about the danger and wrong about the remedy.
+
+Every carrier rate on an export lane is in INR. So on a EUR quote the
+calculated list was **always empty**, and the flat manual row won by
+**walkover** — not by being cheaper, but by being the only survivor. That row
+is €35 at 3 kg *and* €35 at 22 kg.
+
+:::danger The guard was underwriting a defect that looked unrelated
+"International freight is flat at any weight" and "we drop rates in the wrong
+currency" read as two separate problems. They were one. Always ask what was
+*removed* from a comparison before crediting the winner.
+:::
+
+## What it does now
+
+Calculated rates are converted through the FX the platform already caches,
+reusing `planShippingFxConversion` — the same pure function `resolveShippingFx`
+uses for order freight, so there is **one FX path**, not a second one to
+disagree with it. The rate, its source and the original amount are stamped onto
+the option:
+
+```json
+{
+  "courier_name": "SRX Priority Pro",
+  "amount": 36.42,
+  "currency_code": "eur",
+  "source": "calculated",
+  "route": { "via_hq": true, "origin_label": "JYT HQ Delhi",
+             "export_leg_amount": 3788, "domestic_leg_amount": 286.36 },
+  "fx": { "original_amount": 4074.36, "original_currency_code": "inr",
+          "fx_rate": 0.00893775308762373, "fx_source": "fx_rates",
+          "converted_at": "2026-08-24T04:54:13.809Z" }
+}
+```
+
+That stamp is what answers the original objection. A converted price can be
+reproduced after FX has moved — the label now shows its working.
+
+## The rules that did not change
+
+- 🔴 **A rate that cannot be converted is still dropped.** A cold FX cache must
+  not become a guess. That is the one thing the original drop got right.
+- 🔴 **Calculated rates only.** A manual option priced in another currency is a
+  different offer the partner published to buyers billed in that currency;
+  converting it would invent an offer nobody made. Those are filtered out
+  further up, beside the zone and rule checks.
+- 🔴 **The relay never sums two legs in different currencies.** Dropped, not
+  converted — a leg-level conversion belongs to the estimate layer that holds
+  the rate, not to the route builder.
+
+## Verified on prod (24 Aug 2026)
+
+Quote `01M0S1TMHCJ72FJ7766ZGAVMKB`, Srinagar → Berlin, 3.045 kg, EUR:
+
+| | |
+|---|---|
+| freight options | 10 — 7 calculated, **7 carrying an `fx` stamp** |
+| cheapest calculated | €36.42 via JYT HQ Delhi (₹3,788 export + ₹286.36 domestic) |
+| chosen | €35, the flat manual row |
+| FX rate used | `inr→eur` 0.00893775, `fx_source: fx_rates` |
+
+€35 still wins — **and that is the correct outcome**, because at 3 kg the flat
+row is genuinely cheaper by €1.42. The proof the fix works is the non-empty
+calculated list with converted amounts, not the chosen number. Before #1505 that
+list was empty at every weight.
+
+[#1424]: https://github.com/Jaal-Yantra-Textiles/v2/issues/1424
+[#1498]: https://github.com/Jaal-Yantra-Textiles/v2/issues/1498
+[#1502]: https://github.com/Jaal-Yantra-Textiles/v2/issues/1502

--- a/apps/storefront/src/lib/util/__tests__/quote-lines.test.ts
+++ b/apps/storefront/src/lib/util/__tests__/quote-lines.test.ts
@@ -3,6 +3,7 @@ import { describe, expect, it } from "vitest"
 import {
   buildDialHref,
   buildQuotedHref,
+  otherVariantLabel,
   parseDialledLines,
   serialiseDialledLines,
 } from "../quote-lines"
@@ -113,5 +114,52 @@ describe("buildQuotedHref", () => {
     expect(buildQuotedHref({ countryCode: "in", token: "tok_abc" })).toBe(
       "/in/quotes/tok_abc"
     )
+  })
+})
+
+/**
+ * "Also made in" pills.
+ *
+ * The label is the only part of a sibling variant that is not already true of
+ * the quoted one. Tested because the failure is silent in both directions: too
+ * eager and the pill says nothing the buyer can act on, too shy and five
+ * 45-character titles wrap to one per line and the difference is off the end of
+ * each.
+ */
+describe("otherVariantLabel", () => {
+  const QUOTED = "Pattern 1 - Blue/Mustard/Cream/Grey / HandSpun"
+
+  it("keeps only the option that differs", () => {
+    expect(
+      otherVariantLabel(QUOTED, "Pattern 1 - Blue/Mustard/Cream/Grey / MilSpun")
+    ).toBe("MilSpun")
+  })
+
+  it("keeps the pattern when that is what changed", () => {
+    expect(
+      otherVariantLabel(QUOTED, "Pattern 2 - Mustard/Dusty Blue/Grey / HandSpun")
+    ).toBe("Pattern 2 - Mustard/Dusty Blue/Grey")
+  })
+
+  it("keeps both segments when both differ", () => {
+    expect(
+      otherVariantLabel(QUOTED, "Pattern 3 - Blue/Yellow/Grey/Cream / MilSpun")
+    ).toBe("Pattern 3 - Blue/Yellow/Grey/Cream / MilSpun")
+  })
+
+  it("does not split on a slash inside one option value", () => {
+    expect(otherVariantLabel("Red/Blue", "Green/Blue")).toBe("Green/Blue")
+  })
+
+  it("🔴 falls back to the whole title rather than rendering an empty pill", () => {
+    // Same title, different variant: they differ on something this string does
+    // not spell out. An empty pill would read as a rendering fault.
+    expect(otherVariantLabel(QUOTED, QUOTED)).toBe(QUOTED)
+  })
+
+  it("survives a line with no variant title at all", () => {
+    expect(otherVariantLabel(null, "HandSpun")).toBe("HandSpun")
+    expect(otherVariantLabel(QUOTED, null)).toBe("Another finish")
+    expect(otherVariantLabel(QUOTED, "   ")).toBe("Another finish")
   })
 })

--- a/apps/storefront/src/lib/util/quote-lines.ts
+++ b/apps/storefront/src/lib/util/quote-lines.ts
@@ -33,6 +33,54 @@
 
 export type DialledLine = { variant_id: string; quantity: number }
 
+/** How Medusa joins option values into a variant title. */
+const VARIANT_OPTION_SEPARATOR = " / "
+
+/**
+ * The part of a sibling variant's title that is not already true of the quoted
+ * one — the label for an "Also made in" pill.
+ *
+ * On a real catalogue these titles are option joins that agree for most of
+ * their length: `Pattern 1 - Blue/Mustard/Cream/Grey / HandSpun` beside
+ * `Pattern 1 - Blue/Mustard/Cream/Grey / MilSpun`. Rendered whole they are ~45
+ * characters each, so five of them wrap to one per line inside a table cell —
+ * a vertical column of boxes — and the single word that distinguishes them sits
+ * at the far end of each, past where the eye stops.
+ *
+ * So the segments the quoted variant already carries are dropped and what is
+ * left is shown. The pill then says the only thing it is on the page to say.
+ *
+ * 🔑 Never returns empty. Two variants can differ on an option the title does
+ * not spell out, and an empty pill would read as a rendering fault while
+ * hiding a genuine alternative — so the full title is the fallback.
+ */
+export const otherVariantLabel = (
+  quotedTitle: string | null | undefined,
+  otherTitle: string | null | undefined
+): string => {
+  const other = String(otherTitle ?? "").trim()
+  if (!other) {
+    return "Another finish"
+  }
+
+  const quotedSegments = new Set(
+    String(quotedTitle ?? "")
+      .split(VARIANT_OPTION_SEPARATOR)
+      .map((segment) => segment.trim())
+      .filter(Boolean)
+  )
+
+  const distinguishing = other
+    .split(VARIANT_OPTION_SEPARATOR)
+    .map((segment) => segment.trim())
+    .filter(Boolean)
+    .filter((segment) => !quotedSegments.has(segment))
+
+  return distinguishing.length
+    ? distinguishing.join(VARIANT_OPTION_SEPARATOR)
+    : other
+}
+
 /**
  * Read the dial out of a search param.
  *

--- a/apps/storefront/src/modules/quotes/components/quote-lines/index.tsx
+++ b/apps/storefront/src/modules/quotes/components/quote-lines/index.tsx
@@ -1,8 +1,8 @@
-import { Text } from "@medusajs/ui"
+import { Badge, Text } from "@medusajs/ui"
 
 import { convertToLocale } from "@lib/util/money"
 import type { DialledLine } from "@lib/util/quote-lines"
-import { buildQuotedHref } from "@lib/util/quote-lines"
+import { buildQuotedHref, otherVariantLabel } from "@lib/util/quote-lines"
 import type { QuoteView, QuoteViewLine } from "@lib/data/quotes"
 import QuoteLineImage from "../quote-image"
 import QuoteLineSpecRows from "../quote-line-spec"
@@ -102,12 +102,17 @@ const LineRow = ({
                 Also made in:
               </Text>
               {line.other_variants.map((v) => (
-                <span
+                <Badge
                   key={v.id}
-                  className="rounded-full border border-ui-border-base px-2 py-0.5 txt-small text-ui-fg-subtle"
+                  size="2xsmall"
+                  className="whitespace-nowrap"
+                  /* The full title on hover: the label is deliberately only
+                     the difference, and a buyer comparing two finishes may
+                     want the whole name it belongs to. */
+                  title={v.title ?? undefined}
                 >
-                  {v.title ?? "Another finish"}
-                </span>
+                  {otherVariantLabel(line.variant_title, v.title)}
+                </Badge>
               ))}
               <Text className="txt-small text-ui-fg-muted w-full mt-1">
                 Ask your partner to quote one of these — this price covers the


### PR DESCRIPTION
Follows #1499, #1500, #1501, #1503, #1505, #1506. Related: #1439, #1498.

## Why

Six PRs shipped over 23–24 Aug and everything learned from them lives in GitHub comments and handoffs. The traps in particular are the kind nobody rediscovers cheaply — they were each found by minting a real quote, not by reading code.

## Five pages, two new Implementation sections

**Shipping & Freight**

| page | what it records |
|---|---|
| `export-freight-relay` | The live probe table (Srinagar 400s; Delhi 8 couriers from ₹1,276; Himachal 1 at ₹2,916), why it is a **fallback** and not a cheapest-of-all comparison, why the loop sits **above** the provider so Blue Dart / DTDC / DHL slot in, and why origins are **data** (`location_ownership.is_core`) rather than an env var. |
| `freight-currency-and-fx` | Why the #1424 guard existed, why dropping was quietly guaranteeing the "flat at any weight" defect it looked unrelated to, and what the `fx` stamp on a converted option is for. |

**B2B Quotes**

| page | what it records |
|---|---|
| `tenant-isolation` | The leak, why the fail-open half was sized off dev-DB rows that turned out to be e2e detritus (24-of-28 became 0-of-2), what prod actually measured, and why the refusal is a 404 rather than a 403. |
| `design-lines` | The `!l?.variant_id` filter that let **any string** be frozen onto a commercial document, and the visibility-vs-resolvability asymmetry. |
| `minting` | One workflow behind two surfaces, why revoke deletes the price list **before** marking the row, and the live blocker in #1507. |

Every red watch-out is written where the next person will look: never run `set-location-ownership seed:true`, a rated route is not permission to ship it (#1497), `EXPORT_FIRST_LEG_IS_SUNK` both under-quotes and misranks, a location with no valid PIN is dropped rather than passed through, and a cold FX cache must not become a guess.

## Also in here: the "also made in" pills

Reported from the live quote — five sibling variants at ~45 characters each wrapped to one per line inside the table cell, and the word that distinguishes them (`MilSpun`) sat at the far end of a string whose first 35 characters the buyer had already read on the line above.

```
before   [Pattern 1 - Blue/Mustard/Cream/Grey / MilSpun]      (one per line, ×5)
after    [MilSpun] [Pattern 2 - Mustard/Dusty Blue/Grey] [Pattern 3 - …]
```

`otherVariantLabel` drops the option segments the quoted variant already carries; pills are `Badge size="2xsmall"`; the full title is on hover because the label is deliberately partial. 🔑 It never returns empty — two variants can differ on an option the title does not spell out, so the whole title is the fallback.

## Verification

- `pnpm build` green in `apps/docs` — all five pages generated. The broken-link warnings in that output are pre-existing pages, none of them new.
- Watch-out prose **confirmed present in the built HTML**, not assumed: MDX braces eat the rest of a sentence with a successful build.
- `pnpm build` green in `apps/storefront`.
- 6 assertions added to `quote-lines.test.ts`. ⚠️ That suite **cannot start on clean `main`** — vitest 4 against a hoisted vite 5 — so the function was verified by executing it under `tsx`: 8/8 including both fallbacks. Filed as #1508.
- `tsc --noEmit` is not a usable gate on this app: 829 pre-existing errors, `Text` among them (#1455).

## 🔴 The submodule pointer is deliberately NOT bumped

`apps/storefront-starter` carries the identical pill change in Jaal-Yantra-Textiles/nextjs-starter-medusa#26. That must merge first; the pointer bump is a separate commit. A pointer moved to a commit that is not on the starter's `main` is a silent revert wearing one line of changed hash.
