### PR TITLE
fix(quotes): quote the buyer who already exists, instead of colliding with them (#1507)

### DIFF
--- a/apps/backend/integration-tests/http/partner-quote-mint.spec.ts
+++ b/apps/backend/integration-tests/http/partner-quote-mint.spec.ts
@@ -1,6 +1,6 @@
 import { getSharedTestEnv, setupSharedTestSuite } from "./shared-test-setup"
 import { createAdminUser } from "../helpers/create-admin-user"
-import { ContainerRegistrationKeys } from "@medusajs/framework/utils"
+import { ContainerRegistrationKeys, Modules } from "@medusajs/framework/utils"
 import {
   setupQuoteFixture,
   mintBody,
@@ -436,6 +436,99 @@ setupSharedTestSuite(() => {
         })
       )
       expect(currentQuote.data.quote.status).toBe("active")
+    })
+
+    /**
+     * #1507 — the buyer who already exists somewhere else on the platform.
+     *
+     * 🔑 This is the case that cannot be reached by typing a fresh address
+     * into the wizard, which is why it survived every green suite: every test
+     * above mints to `...-${seed.unique}@jaalyantra.test`, an address that has
+     * never existed. Only a buyer who is ALREADY a customer — of another
+     * store, or of the core store — hits it, and that is the buyer worth the
+     * most: an existing customer asking a partner for a bulk price.
+     *
+     * The two rules that collided: the lookup was scoped to the store, so the
+     * row was invisible; `customer.email` is unique platform-wide, so the
+     * create that followed hit the row it could not see. A flat 400 naming
+     * another store's data, with no path around it in the UI.
+     */
+    describe("a buyer who already exists off this store (#1507)", () => {
+      /** Straight at the module, so the row exists with NO link to any store. */
+      const createUnlinkedCustomer = async (
+        email: string,
+        extra: Record<string, any> = {}
+      ) => {
+        const container = getSharedTestEnv().getContainer()
+        const customerService: any = container.resolve(Modules.CUSTOMER)
+        return await customerService.createCustomers({ email, ...extra })
+      }
+
+      /** The store's own customers, straight from the link — not from a route. */
+      const storeCustomerIds = async (): Promise<string[]> => {
+        const container = getSharedTestEnv().getContainer()
+        const query: any = container.resolve(ContainerRegistrationKeys.QUERY)
+        const { data } = await query.graph({
+          entity: "stores",
+          fields: ["customers.id"],
+          filters: { id: seed.storeId },
+        })
+        return (((data ?? [])[0]?.customers ?? []) as any[]).map((c) => c.id)
+      }
+
+      it("🔴 quotes them — adopting the existing customer instead of colliding with them", async () => {
+        const { api } = getSharedTestEnv()
+        const email = `buyer-elsewhere-${seed.unique}@jaalyantra.test`
+        const stranger = await createUnlinkedCustomer(email)
+
+        expect(await storeCustomerIds()).not.toContain(stranger.id)
+
+        // 🔴 On the old code this is the 400: "Customer with email: ...,
+        // has_account: false, already exists."
+        const minted = await loud("mint-existing-buyer", () =>
+          api.post("/partners/quotes", mintBody(seed, { buyer_email: email }), {
+            headers: seed.headers,
+          })
+        )
+
+        expect(minted.status).toBe(201)
+
+        // 🔑 The SAME person, not a second row wearing their address. A quote
+        // minted to a duplicate identity would price a buyer who does not
+        // exist — the `+tag` workaround in prose form.
+        expect(minted.data.quote.customer_id).toBe(stranger.id)
+
+        // And they are this partner's buyer from here on, which is what makes
+        // the group, the price list and the acceptance resolve.
+        expect(await storeCustomerIds()).toContain(stranger.id)
+      })
+
+      it("attaches the quote to the real account, not the guest row with the same address", async () => {
+        const { api } = getSharedTestEnv()
+        const email = `buyer-account-${seed.unique}@jaalyantra.test`
+
+        // Core's unique index is on the PAIR `(email, has_account)`, so both
+        // of these are legal and both are the same human being.
+        const guest = await createUnlinkedCustomer(email)
+        const account = await createUnlinkedCustomer(email, { has_account: true })
+        expect(account.id).not.toBe(guest.id)
+
+        const minted = await loud("mint-account-buyer", () =>
+          api.post("/partners/quotes", mintBody(seed, { buyer_email: email }), {
+            headers: seed.headers,
+          })
+        )
+
+        expect(minted.status).toBe(201)
+
+        /**
+         * 🔑 The group carries the price list, so whichever identity is picked
+         * here is the identity that gets the price. Picking the guest would
+         * mint a quote the buyer cannot see once they sign in — priced,
+         * delivered, and inert.
+         */
+        expect(minted.data.quote.customer_id).toBe(account.id)
+      })
     })
 
     describe("the readiness preflight (#1445)", () => {

--- a/apps/backend/src/workflows/partner-quote/mint-quote.ts
+++ b/apps/backend/src/workflows/partner-quote/mint-quote.ts
@@ -148,8 +148,34 @@ const prepareTimingStep = createStep(
  * their second quote replaces their prices rather than stacking a second list
  * that core would tie-break against the first on `amount ASC`.
  *
+ * 🔑 The buyer is resolved in THREE steps, in order (#1507). Core's unique
+ * index is on `(email, has_account)` platform-wide, so a store-scoped lookup
+ * on its own is unsatisfiable: a buyer who already exists on ANY other store
+ * is invisible to it, and the create that follows collides with the very row
+ * it could not see. That 400 bit precisely the highest-value case — an
+ * existing customer of one store asking a partner for a bulk price. So:
+ *
+ *   1. this store's own customers — a buyer already ours stays ours;
+ *   2. failing that, the platform-wide row for that address, ADOPTED into this
+ *      store by a link. Quoting someone is a deliberate act that names their
+ *      address, so this CREATES the relationship rather than discovering one:
+ *      a partner still cannot reach a buyer whose address they did not type;
+ *   3. failing that, create, as before.
+ *
+ * ⚠️ Adoption is a real disclosure: that customer then appears on
+ * `GET /partners/customers` carrying whatever profile another store collected
+ * — name, phone, addresses. That is the trade, taken deliberately, because the
+ * alternative is that the buyer cannot be quoted at all.
+ *
+ * ⚠️ A registered account OUTRANKS a guest row with the same address. Both can
+ * exist, since the index is on the pair — and attaching the quote to the guest
+ * would price a session the buyer never signs into. The group carries the
+ * price list, so whichever identity we pick here is the identity that gets the
+ * price.
+ *
  * Compensation deletes only what THIS run created — never the customer, who
- * may have orders, and never a group that already existed.
+ * may have orders, and never a group that already existed. An adoption link is
+ * dismissed without touching the customer behind it.
  */
 const resolveQuoteBuyerStep = createStep(
   "resolve-quote-buyer-step",
@@ -160,9 +186,9 @@ const resolveQuoteBuyerStep = createStep(
 
     const email = input.buyer_email.trim().toLowerCase()
 
-    // Scoped to the store: another partner's customer with the same email is
-    // not this partner's buyer, and reusing them would leak a customer across
-    // tenants and hand them someone else's price list.
+    // Scoped to the store first: a buyer this partner has already dealt with
+    // is theirs, and must keep the one identity their earlier price lists and
+    // orders hang off.
     const { data: storeRows } = await query.graph({
       entity: "stores",
       fields: ["customers.id", "customers.email", "customer_groups.id", "customer_groups.name"],
@@ -174,16 +200,38 @@ const resolveQuoteBuyerStep = createStep(
       (c) => String(c?.email ?? "").toLowerCase() === email
     )
     let createdCustomerId: string | null = null
+    let linkedCustomerId: string | null = null
     if (!customer) {
-      customer = await customerService.createCustomers({
-        email,
-        company_name: input.recipient_company ?? undefined,
-      })
-      createdCustomerId = customer.id
+      /**
+       * #1507. Exact match on the normalised address, deliberately: core's
+       * unique index compares the stored string, so an exact lookup covers
+       * exactly the set of rows a create could collide with — no more, no
+       * fewer. Anything looser would adopt a customer core would have let us
+       * create alongside.
+       */
+      const existing: any[] = await customerService
+        .listCustomers({ email }, { take: 10 })
+        .catch(() => [])
+
+      customer = existing.find((c) => c?.has_account) ?? existing[0]
+
+      if (!customer) {
+        customer = await customerService.createCustomers({
+          email,
+          company_name: input.recipient_company ?? undefined,
+        })
+        createdCustomerId = customer.id
+      }
+
+      // Adopted or created, the buyer belongs to this store from here on.
+      // ⚠️ Nothing on an ADOPTED customer's profile is overwritten —
+      // `recipient_company` names the consignee on THIS quote, not who they
+      // are everywhere else.
       await link.create({
         [Modules.STORE]: { store_id: input.store.id },
         [Modules.CUSTOMER]: { customer_id: customer.id },
       })
+      linkedCustomerId = customer.id
     }
 
     const groupName = `Quote buyer — ${email}`
@@ -209,7 +257,7 @@ const resolveQuoteBuyerStep = createStep(
 
     return new StepResponse(
       { customer_id: customer.id, customer_group_id: group.id },
-      { createdCustomerId, createdGroupId, storeId: input.store.id }
+      { createdCustomerId, linkedCustomerId, createdGroupId, storeId: input.store.id }
     )
   },
   async (undo, { container }) => {
@@ -228,13 +276,18 @@ const resolveQuoteBuyerStep = createStep(
         .deleteCustomerGroups([undo.createdGroupId])
         .catch(() => {})
     }
-    if (undo.createdCustomerId) {
+    // Dismiss whichever link THIS run made — adoption included. Deleting the
+    // customer is a separate, narrower question: only a customer this run
+    // brought into existence may go, never one we merely adopted.
+    if (undo.linkedCustomerId) {
       await link
         .dismiss({
           [Modules.STORE]: { store_id: undo.storeId },
-          [Modules.CUSTOMER]: { customer_id: undo.createdCustomerId },
+          [Modules.CUSTOMER]: { customer_id: undo.linkedCustomerId },
         })
         .catch(() => {})
+    }
+    if (undo.createdCustomerId) {
       await customerService
         .deleteCustomers([undo.createdCustomerId])
         .catch(() => {})


### PR DESCRIPTION
Closes #1507.

## The bug

`resolve-quote-buyer-step` looked the buyer up **scoped to the store**, then created them if it found nothing. But core's unique index on `customer` is `(email, has_account)` **platform-wide**, so the two rules were unsatisfiable together:

- the lookup is per-store, so a buyer who already exists on *any* other store is invisible to it;
- the create is global, so it collides with that invisible row.

```
POST /partners/quotes  { "buyer_email": "saranshis@pm.me", ... }
→ 400 {"message":"Customer with email: saranshis@pm.me, has_account: false, already exists."}
```

It presented as a flat 400 in the wizard, naming another store's data, with no path around it in the UI. Both mint surfaces (`/admin/quotes` and `/partners/quotes`) share the workflow, so both failed.

**It bit precisely the highest-value case** — an existing customer of one store asking a partner for a bulk price — and it is unreachable by typing a fresh address into the wizard, which is why every suite stayed green through it. The workaround in use was a `+tag` alias, which mints a commercial document to an identity that is not the buyer's.

## The fix

Three lookups, in order:

1. **this store's own customers** — a buyer already ours stays ours, and keeps the identity their earlier price lists hang off;
2. failing that, **the platform-wide row for that address, adopted into this store** by a link;
3. failing that, create, as before.

Adoption is not discovery: quoting someone is a deliberate act that names their address, so a partner still cannot reach a buyer whose address they did not type.

**A registered account outranks a guest row with the same address.** Both can exist — the index is on the pair — and the customer *group* carries the price list, so whichever identity is picked here is the identity that gets the price. Attaching the quote to the guest would price a session the buyer never signs into: delivered, and inert.

Nothing on an adopted customer's profile is overwritten. `recipient_company` names the consignee on *this* quote, not who they are everywhere else.

Compensation now dismisses whichever link **this run** made, adoption included, and still deletes only a customer this run brought into existence — never one it merely adopted.

## The trade, stated plainly

Adoption is a real disclosure: the customer then appears on `GET /partners/customers` carrying whatever profile another store collected — name, phone, addresses. That is deliberate, and it is the decision this PR takes on behalf of option 1 in the issue. The alternative was that the buyer could not be quoted at all.

## Verification

Two new integration tests, both of which **fail on the old code with the exact production message**:

```
[mint-existing-buyer] 400 {"message":"Customer with email: buyer-elsewhere-…, has_account: false, already exists."}
[mint-account-buyer]  400 {"message":"Customer with email: buyer-account-…,   has_account: false, already exists."}
✕ 🔴 quotes them — adopting the existing customer instead of colliding with them
✕ attaches the quote to the real account, not the guest row with the same address
```

With the fix: `partner-quote-mint` 18/18, `partner-quote-accept` + `partner-quote-tenant-isolation` 14/14, `check:prod-build` green.

```
pnpm test:integration:http:shared ./integration-tests/http/partner-quote-mint.spec.ts
```

## Not in this PR

`POST /partners/customers` (`src/api/partners/customers/route.ts:70`) has the **same collision** — a partner adding an existing buyer by hand hits the identical wall. It is a different decision, though: a "create" call that silently returns someone else's existing row is surprising in a way that a mint adopting a named buyer is not. Filed as #1515, with the three options written out, rather than folded in here.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_0158wJMZ1DmjNxXf5uGuBrQD

