### PR TITLE
feat(quotes): let a partner withdraw their own quote, instead of asking an admin (#1517, #1452)

### DIFF
--- a/apps/backend/integration-tests/http/partner-mcp-quotes.spec.ts
+++ b/apps/backend/integration-tests/http/partner-mcp-quotes.spec.ts
@@ -110,6 +110,9 @@ setupSharedTestSuite(() => {
         "list_quotable_designs",
         "check_quote_readiness",
         "mint_quote",
+        // #1517: the withdraw half of the mint. Its absence is what made
+        // `mint_quote`'s guidance unexecutable.
+        "revoke_quote",
       ]) {
         expect(names).toContain(name)
       }
@@ -242,6 +245,45 @@ setupSharedTestSuite(() => {
       const byCompany = await call("list_quotes", { q: "MCP Buyer Pvt Ltd", limit: 50 })
       expect(byCompany.ok).toBe(true)
       expect((byCompany.data.quotes as any[]).some((q) => q.id === quote.id)).toBe(true)
+    })
+
+    /**
+     * 🔴 Mint then revoke in ONE test — same snapshot rule as the mint above.
+     *
+     * This is the tool #1452 asked for and #1517 built the route under. Its
+     * absence is why `mint_quote` shipped guidance telling the model to
+     * "revoke the old quote first": a prescribed action no tool on this
+     * surface could perform, which is #1394's shape exactly.
+     */
+    it("🔴 revoke_quote EXECUTES — the confirm rail fires, then the quote is revoked", async () => {
+      const minted = await call("mint_quote", {
+        ...basket({ buyer_email: `mcp-revoke-${seed.unique}@jaalyantra.test` }),
+        confirm: true,
+      })
+      expect(minted.ok).toBe(true)
+      const quoteId = minted.data?.quote?.id
+      expect(quoteId).toBeTruthy()
+
+      // `sensitive: true`: the buyer has already been told a number, and this
+      // deletes the price list behind it.
+      const gated = await call("revoke_quote", { id: quoteId })
+      expect(gated.requires_confirmation).toBe(true)
+      expect(gated.plan?.method).toBe("POST")
+      expect(gated.plan?.path).toBe(`/partners/quotes/${quoteId}/revoke`)
+
+      // Rehearsal only — nothing happened yet.
+      const stillActive = await call("get_quote", { id: quoteId })
+      expect(stillActive.data.quote.status).toBe("active")
+
+      const done = await call("revoke_quote", { id: quoteId, confirm: true })
+      expect(done.ok).toBe(true)
+      expect(done.data?.price_list_deleted).toBe(true)
+
+      // Asserted through the tool a model would actually read it back with,
+      // not on the revoke's own response — the route could report a revoke it
+      // did not persist and nothing here would differ.
+      const after = await call("get_quote", { id: quoteId })
+      expect(after.data.quote.status).toBe("revoked")
     })
 
     it("list_quotable_designs answers, so a design named in conversation can become a line", async () => {

--- a/apps/backend/integration-tests/http/partner-quote-revoke.spec.ts
+++ b/apps/backend/integration-tests/http/partner-quote-revoke.spec.ts
@@ -2,6 +2,7 @@ import { createAdminUser, getAuthHeaders } from "../helpers/create-admin-user"
 import {
   mintBody,
   setupQuoteFixture,
+  TEST_PARTNER_PASSWORD,
   type QuoteFixture,
 } from "../helpers/setup-quote-fixture"
 import { getSharedTestEnv, setupSharedTestSuite } from "./shared-test-setup"
@@ -41,27 +42,37 @@ jest.setTimeout(240 * 1000)
  * #1439 S11 defects.
  */
 setupSharedTestSuite(() => {
-  describe("POST /admin/quotes/:id/revoke (#1389 S5)", () => {
-    let seed: QuoteFixture
-    let adminHeaders: { headers: Record<string, string> }
+  /**
+   * 🔴 ONE fixture, at the TOP level, shared by both describes.
+   *
+   * The runner snapshots the database on the FIRST `beforeEach` and restores
+   * that snapshot before every test after it. A `beforeAll` nested in the
+   * second describe therefore runs AFTER the snapshot was taken, so everything
+   * it creates — including the partner's auth identity — is rolled back before
+   * its first test runs. The symptom is not a missing row: it is a **401 on
+   * every request in that describe**, which reads as a broken auth header.
+   */
+  let seed: QuoteFixture
+  let adminHeaders: { headers: Record<string, string> }
 
-    const container = () => getSharedTestEnv().getContainer()
+  const container = () => getSharedTestEnv().getContainer()
 
-    beforeAll(async () => {
-      const { api, getContainer } = getSharedTestEnv()
-      await createAdminUser(getContainer())
-      adminHeaders = await getAuthHeaders(api)
-      seed = await setupQuoteFixture(api, getContainer)
+  beforeAll(async () => {
+    const { api, getContainer } = getSharedTestEnv()
+    await createAdminUser(getContainer())
+    adminHeaders = await getAuthHeaders(api)
+    seed = await setupQuoteFixture(api, getContainer)
+  })
+
+  const mint = async (overrides: Record<string, any> = {}) => {
+    const { api } = getSharedTestEnv()
+    const res = await api.post("/partners/quotes", mintBody(seed, overrides), {
+      headers: seed.headers,
     })
+    return res.data
+  }
 
-    const mint = async (overrides: Record<string, any> = {}) => {
-      const { api } = getSharedTestEnv()
-      const res = await api.post("/partners/quotes", mintBody(seed, overrides), {
-        headers: seed.headers,
-      })
-      return res.data
-    }
-
+  describe("POST /admin/quotes/:id/revoke (#1389 S5)", () => {
     it("🔴 answers 200, not 500, and reports what it deleted", async () => {
       const minted = await mint({
         buyer_email: `revoke-${seed.unique}@jaalyantra.test`,
@@ -149,6 +160,146 @@ setupSharedTestSuite(() => {
         .catch((e: any) => e.response)
 
       expect(err.status).toBe(404)
+    })
+  })
+
+  /**
+   * The partner twin (#1517).
+   *
+   * A partner who mis-quoted could not withdraw it: there was no route, so no
+   * MCP tool, and `mint_quote`'s own guidance told the assistant to "revoke the
+   * old quote first" — an action nothing on that surface could perform. Their
+   * only recourse was to re-mint, which emails the buyer a NEW number they did
+   * not ask for, or to wait for expiry.
+   *
+   * The body is shared with the admin route (`lib/revoke-quote.ts`), so the
+   * assertions that matter here are the ones the admin route cannot make: that
+   * ownership is enforced against the AUTH CONTEXT rather than the URL, and
+   * that an accepted quote is refused.
+   */
+  describe("POST /partners/quotes/:id/revoke (#1517)", () => {
+    const revoke = (id: string, headers: Record<string, string> = seed.headers) =>
+      getSharedTestEnv()
+        .api.post(`/partners/quotes/${id}/revoke`, {}, { headers })
+        .catch((e: any) => e.response)
+
+    it("🔴 revokes the partner's own quote — 200, and the price list is GONE", async () => {
+      const minted = await mint({
+        buyer_email: `p-revoke-${seed.unique}@jaalyantra.test`,
+      })
+      const priceListId = minted.quote.price_list_id
+
+      const res = await revoke(minted.quote.id)
+
+      expect(res.status).toBe(200)
+      expect(res.data.quote.status).toBe("revoked")
+      expect(res.data.price_list_deleted).toBe(true)
+
+      /**
+       * The status flag is the cheap half. If the list outlives the quote the
+       * buyer keeps the quoted prices in any cart they build — the link dies
+       * and the discount does not, which is the failure nobody would notice.
+       */
+      expect(priceListId).toBeTruthy()
+      const pricing: any = container().resolve("pricing")
+      const lists = await pricing.listPriceLists({ id: [priceListId] })
+      expect(lists.length).toBe(0)
+
+      const service: any = container().resolve(PARTNER_QUOTE_MODULE)
+      const events = await service.listEvents(minted.quote.id)
+      const revoked = events.find((e: any) => e.type === "revoked")
+      // The log is what a disputed price is argued from, so it has to say WHO.
+      expect(revoked?.actor_type).toBe("partner")
+    })
+
+    it("🔴 404s another partner's quote — the id in the URL proves nothing", async () => {
+      const minted = await mint({
+        buyer_email: `p-revoke-x-${seed.unique}@jaalyantra.test`,
+      })
+
+      const { api } = getSharedTestEnv()
+      const unique = `${seed.unique}-x`
+      const email = `stranger-${unique}@medusa-test.com`
+      await api.post("/auth/partner/emailpass/register", {
+        email,
+        password: TEST_PARTNER_PASSWORD,
+      })
+      let login = await api.post("/auth/partner/emailpass", {
+        email,
+        password: TEST_PARTNER_PASSWORD,
+      })
+      await api.post(
+        "/partners",
+        {
+          name: `Stranger ${unique}`,
+          handle: `stranger-${unique}`,
+          admin: { email, first_name: "Stranger", last_name: "Partner" },
+        },
+        { headers: { Authorization: `Bearer ${login.data.token}` } }
+      )
+      // Re-login: the token minted before the partner existed carries no actor.
+      login = await api.post("/auth/partner/emailpass", {
+        email,
+        password: TEST_PARTNER_PASSWORD,
+      })
+
+      const res = await revoke(minted.quote.id, {
+        Authorization: `Bearer ${login.data.token}`,
+      })
+
+      // 404, not 403: a partner has no business learning that someone else's
+      // quote id is real (#1404).
+      expect(res.status).toBe(404)
+
+      // And it did not half-run. The owner's quote is untouched.
+      const service: any = container().resolve(PARTNER_QUOTE_MODULE)
+      const [after] = await service.listPartnerQuotes({ id: minted.quote.id })
+      expect(after.status).toBe("active")
+    })
+
+    it("🔴 refuses a quote the buyer has ALREADY ACCEPTED, and says why", async () => {
+      const minted = await mint({
+        buyer_email: `p-revoke-acc-${seed.unique}@jaalyantra.test`,
+      })
+      const service: any = container().resolve(PARTNER_QUOTE_MODULE)
+      await service.updatePartnerQuotes({
+        id: minted.quote.id,
+        accepted_at: new Date(),
+      })
+
+      const res = await revoke(minted.quote.id)
+
+      // 400 rather than 409: the framework REPLACES a CONFLICT message with a
+      // generic "retry with an Idempotency-Key" line, which would tell the
+      // partner to retry the one thing that cannot work.
+      expect(res.status).toBe(400)
+      expect(res.data.message).toContain("accepted")
+
+      // The price list must survive — the accepted cart is priced from it.
+      const [after] = await service.listPartnerQuotes({ id: minted.quote.id })
+      expect(after.status).toBe("active")
+      const pricing: any = container().resolve("pricing")
+      const lists = await pricing.listPriceLists({ id: [minted.quote.price_list_id] })
+      expect(lists.length).toBe(1)
+    })
+
+    it("is idempotent — a second revoke is a no-op, not an error", async () => {
+      const minted = await mint({
+        buyer_email: `p-revoke-idem-${seed.unique}@jaalyantra.test`,
+      })
+
+      const first = await revoke(minted.quote.id)
+      const second = await revoke(minted.quote.id)
+
+      expect(first.status).toBe(200)
+      expect(second.status).toBe(200)
+      expect(second.data.already_revoked).toBe(true)
+      expect(second.data.quote.status).toBe("revoked")
+    })
+
+    it("404s an unknown quote", async () => {
+      const res = await revoke("quote_does_not_exist")
+      expect(res.status).toBe(404)
     })
   })
 })

--- a/apps/backend/src/api/admin/mcp/lib/registry.ts
+++ b/apps/backend/src/api/admin/mcp/lib/registry.ts
@@ -4241,7 +4241,7 @@ export const ADMIN_MCP_TOOLS: AdminMcpToolDef[] = [
   {
     name: "revoke_quote",
     description:
-      "Revoke a quote: expire its price list and make the buyer's link 404. Use it before re-quoting the same buyer, because two active lists on one customer group tie-break to the CHEAPEST and a re-quote at a higher price would hand them the old one (#1435).",
+      "Revoke a quote: delete its frozen price list and make the buyer's link 404. Use it to WITHDRAW a quote that should not stand — a wrong price, a wrong buyer, a wrong lane. It is no longer needed before re-quoting the same buyer: the mint supersedes their previous quote itself, which is what #1435 fixed. Re-minting to kill a quote emails the buyer a second number they never asked for; revoking does not.",
     method: "POST",
     path: "/admin/quotes/:id/revoke",
     pathParams: ["id"],

--- a/apps/backend/src/api/admin/quotes/[id]/revoke/route.ts
+++ b/apps/backend/src/api/admin/quotes/[id]/revoke/route.ts
@@ -1,29 +1,23 @@
 import { MedusaRequest, MedusaResponse } from "@medusajs/framework/http"
-import { ContainerRegistrationKeys, MedusaError } from "@medusajs/framework/utils"
-import { deletePriceListsWorkflow } from "@medusajs/medusa/core-flows"
+import { MedusaError } from "@medusajs/framework/utils"
 
 import { PARTNER_QUOTE_MODULE } from "../../../../../modules/partner-quote"
+import { revokeQuote } from "../../../../../modules/partner-quote/lib/revoke-quote"
 
 /**
  * Revoke a quote (#1389 S5).
  *
- * 🔴 Flipping `status` alone is NOT a revoke. The quote's prices live in a real,
- * active price list scoped to the buyer's customer group — if that list survives,
- * the buyer keeps the quoted prices in any cart they build, whatever the quote
- * row says. The link dies and the discount does not.
- *
- * So this deletes the price list FIRST and only then marks the row. Doing it in
- * that order means a failure leaves a quote that still says "active" alongside a
- * list that is already gone — visibly inconsistent and safe. The reverse order
- * would leave a revoked-looking quote still quietly pricing carts, which is the
- * failure nobody would notice.
+ * An admin may revoke any quote — they have no partner of their own, so there
+ * is nothing to scope the lookup to. The partner twin at
+ * `/partners/quotes/:id/revoke` (#1517) scopes by the auth context instead;
+ * everything after the lookup is shared, in `lib/revoke-quote.ts`, including
+ * the reason the price list must die before the status is written.
  *
  * The buyer's page 404s either way: an unknown token and a revoked one are
  * deliberately indistinguishable to a prober.
  */
 export const POST = async (req: MedusaRequest, res: MedusaResponse) => {
   const service: any = req.scope.resolve(PARTNER_QUOTE_MODULE)
-  const logger: any = req.scope.resolve(ContainerRegistrationKeys.LOGGER)
 
   const quotes = await service.listPartnerQuotes({ id: req.params.id })
   const quote = quotes?.[0]
@@ -31,68 +25,10 @@ export const POST = async (req: MedusaRequest, res: MedusaResponse) => {
     throw new MedusaError(MedusaError.Types.NOT_FOUND, "Quote not found")
   }
 
-  if (quote.status === "revoked") {
-    // Idempotent: re-revoking is a no-op, not an error. An operator hitting the
-    // button twice must not see a failure that suggests the first one did not
-    // take.
-    return res.json({ quote, already_revoked: true })
-  }
-
-  /**
-   * #1440 moved this off `metadata` and onto a column. The metadata fallback
-   * stays for rows minted before that migration ran — the backfill covers them,
-   * but a revoke that silently skipped a live price list because a backfill was
-   * missed is the exact failure this route exists to prevent.
-   */
-  const priceListId =
-    (quote as any)?.price_list_id ?? (quote.metadata as any)?.price_list_id
-  if (priceListId) {
-    await deletePriceListsWorkflow(req.scope).run({
-      input: { ids: [priceListId] },
-    })
-    logger.info(`[quote] revoke ${quote.id} deleted price list ${priceListId}`)
-  } else {
-    // A quote with no recorded price list either never froze or was minted
-    // before the id was stored. Say so rather than reporting a clean revoke.
-    logger.warn(
-      `[quote] revoke ${quote.id} had no price_list_id recorded — nothing to delete`
-    )
-  }
-
-  /**
-   * 🔴 NOT array-destructured. `updateX` returns whatever the inner service
-   * returns: the `{ selector, data }` bulk form yields an ARRAY, the bare
-   * entity form used here yields a SINGLE OBJECT. Destructuring it threw
-   * `TypeError: (intermediate value) is not iterable` — and it threw *after*
-   * the price list had been deleted and the status written.
-   *
-   * So every revoke on prod did its whole job and then answered 500. That is
-   * the worst possible pairing for a destructive route: the operator sees a
-   * failure and retries an operation that already ran. Found by revoking four
-   * real quotes, not by reading this file — the sibling `already_revoked`
-   * branch returns the row from `listPartnerQuotes` and so has always been
-   * fine, which is exactly why a retry "worked" and hid the defect.
-   */
-  const updated = await service.updatePartnerQuotes({
-    id: quote.id,
-    status: "revoked",
+  const result = await revokeQuote(req.scope, quote, {
+    type: "admin",
+    id: (req as any).auth_context?.actor_id ?? null,
   })
 
-  await service
-    .recordEvent({
-      quote_id: quote.id,
-      type: "revoked",
-      actor_type: "admin",
-      actor_id: (req as any).auth_context?.actor_id ?? null,
-      message: priceListId
-        ? "Revoked by an admin; the quoted price list was deleted."
-        : "Revoked by an admin. No price list was recorded on the quote, so none was deleted.",
-      data: { price_list_id: priceListId ?? null },
-    })
-    .catch(() => {})
-
-  res.json({
-    quote: updated ?? { ...quote, status: "revoked" },
-    price_list_deleted: !!priceListId,
-  })
+  res.json(result)
 }

--- a/apps/backend/src/api/middlewares.ts
+++ b/apps/backend/src/api/middlewares.ts
@@ -5649,6 +5649,20 @@ export default defineMiddlewares({
         validateAndTransformBody(wrapSchema(AdminQuoteReadinessReq)),
       ],
     },
+    // A partner withdraws their own quote (#1517). Registered BEFORE
+    // /partners/quotes/:id for the same reason `readiness` and `designs` are:
+    // this file's ordering is the contract, and a route that lands after the
+    // parameterised one is a support ticket waiting to be filed.
+    //
+    // No body validator: the route reads none, exactly as the admin twin does.
+    {
+      matcher: "/partners/quotes/:id/revoke",
+      method: "POST",
+      middlewares: [
+        createCorsPartnerMiddleware(),
+        authenticate("partner", ["session", "bearer"]),
+      ],
+    },
     {
       matcher: "/partners/quotes/:id",
       method: "GET",

--- a/apps/backend/src/api/partners/mcp/lib/registry.ts
+++ b/apps/backend/src/api/partners/mcp/lib/registry.ts
@@ -3400,6 +3400,27 @@ export const PARTNER_MCP_TOOLS: PartnerMcpToolDef[] = [
     ]),
     sideEffects:
       "Creates a customer-group-scoped price list with a real expiry, sends the buyer an email containing the only copy of the quote link, and makes the quote acceptable into a cart. Re-quoting the same buyer SUPERSEDES their previous quote: its price list is expired and its status becomes 'superseded', so the newest quote is the one that prices their cart. The buyer's older link stops working — do not re-mint to 'correct' a quote the buyer is mid-conversation about without telling them.",
+    nextSteps: ["get_quote", "list_quotes", "revoke_quote"],
+  },
+  {
+    name: "revoke_quote",
+    description:
+      "Withdraw a quote the partner should not have sent: delete its frozen price list and make the buyer's link 404. Use it to CORRECT a mistake — a wrong price, a wrong buyer, a wrong lane — rather than re-minting, because re-minting emails the buyer a second number they never asked for. Not needed merely to re-quote the same buyer: minting already supersedes their previous quote. Sensitive.",
+    method: "POST",
+    path: "/partners/quotes/:id/revoke",
+    pathParams: ["id"],
+    write: true,
+    sensitive: true,
+    /**
+     * 🔴 No `bodyParams`, and no `reason` field — the route reads no body at
+     * all. Advertising one would be the #1348 defect exactly: the dispatcher's
+     * body assembly is an allowlist walk, so the model would supply a reason,
+     * get `ok: true`, and the reason would reach nothing. Better to offer
+     * nothing than to offer something that goes nowhere.
+     */
+    inputSchema: obj({ id: STR("Quote id, e.g. 'quo_...' / '01M0...'.") }, ["id"]),
+    sideEffects:
+      "Deletes the price list this quote froze, so the buyer stops getting the quoted prices in any cart, and their link 404s from then on. Not reversible: re-offering the same terms means minting a new quote, which emails them again. An ALREADY-ACCEPTED quote is refused here — the accepted cart is priced from it, so unwinding a live deal is an operator's call, not this tool's.",
     nextSteps: ["get_quote", "list_quotes"],
   },
 ]

--- a/apps/backend/src/api/partners/quotes/[id]/revoke/route.ts
+++ b/apps/backend/src/api/partners/quotes/[id]/revoke/route.ts
@@ -1,0 +1,80 @@
+import { AuthenticatedMedusaRequest, MedusaResponse } from "@medusajs/framework/http"
+import { MedusaError } from "@medusajs/framework/utils"
+
+import { PARTNER_QUOTE_MODULE } from "../../../../../modules/partner-quote"
+import { revokeQuote } from "../../../../../modules/partner-quote/lib/revoke-quote"
+import { getPartnerFromAuthContext } from "../../../helpers"
+
+/**
+ * A partner withdraws their own quote (#1517).
+ *
+ * ## Why this exists
+ *
+ * `/admin/quotes/:id/revoke` has existed since #1389 S5; this surface had no
+ * equivalent, so a partner who mis-quoted — wrong price, wrong buyer, wrong
+ * lane — could only ask an operator, and the buyer's link stayed live and
+ * acceptable until it expired. Worse, `mint_quote`'s own guidance told the
+ * assistant to "revoke the old quote first": an instruction naming an action
+ * no tool on this surface could perform (#1394's shape).
+ *
+ * Re-minting is not a substitute. It emails the buyer a NEW number they did
+ * not ask for and freezes a fresh price list; "I mis-quoted, please ignore
+ * that" had no expression here except silence until expiry.
+ *
+ * 🔑 Ownership is checked against the AUTH CONTEXT, not taken from the URL —
+ * the id in the path names a row that may belong to anyone, and validating
+ * only that it exists is the #1404 defect. Another partner's quote is a 404,
+ * not a 403: a partner has no business learning that someone else's quote id
+ * is real, and this route is destructive, so the guard is the only thing
+ * standing between a stranger's id and their buyer's prices.
+ */
+export const POST = async (req: AuthenticatedMedusaRequest, res: MedusaResponse) => {
+  const partner = await getPartnerFromAuthContext(req.auth_context, req.scope)
+  if (!partner) {
+    throw new MedusaError(
+      MedusaError.Types.UNAUTHORIZED,
+      "No partner associated with this account"
+    )
+  }
+
+  const service: any = req.scope.resolve(PARTNER_QUOTE_MODULE)
+  const quotes = await service.listPartnerQuotes({
+    id: req.params.id,
+    partner_id: partner.id,
+  })
+
+  const quote = quotes?.[0]
+  if (!quote) {
+    throw new MedusaError(MedusaError.Types.NOT_FOUND, "Quote not found")
+  }
+
+  /**
+   * 🔴 An accepted quote is not the partner's to withdraw.
+   *
+   * Acceptance is `accepted_at` plus an `accepted_cart_id` — a real cart the
+   * buyer built at these prices, possibly with a deposit already paid against
+   * it. Revoking deletes the price list, so the prices in that cart would move
+   * under a buyer who had already committed, and nothing would tell them. The
+   * admin route deliberately keeps that power, because unwinding a live deal
+   * is an operator's decision with a conversation attached; the partner
+   * surface refuses and says who can.
+   *
+   * NOT_ALLOWED, not CONFLICT: the framework's error handler REPLACES a
+   * CONFLICT message with a generic "you may retry with an Idempotency-Key"
+   * line, so the partner would be told to retry the one thing that cannot
+   * work, and never learn why.
+   */
+  if (quote.accepted_at) {
+    throw new MedusaError(
+      MedusaError.Types.NOT_ALLOWED,
+      "This quote has already been accepted by the buyer, so it cannot be revoked here — the accepted cart is priced from it. Ask an operator to unwind the deal."
+    )
+  }
+
+  const result = await revokeQuote(req.scope, quote, {
+    type: "partner",
+    id: req.auth_context?.actor_id ?? null,
+  })
+
+  res.json(result)
+}

--- a/apps/backend/src/lib/mcp-core/__tests__/quote-tool-field-coverage.unit.spec.ts
+++ b/apps/backend/src/lib/mcp-core/__tests__/quote-tool-field-coverage.unit.spec.ts
@@ -184,11 +184,30 @@ describe("quote MCP tools — the body vocabulary matches its validators (#1439)
     })
   })
 
-  it("only the admin surface can revoke", () => {
-    // Revocation reaches across partners; it is not a partner's own tool.
-    expect(find(ADMIN_MCP_TOOLS as McpToolDef[], "revoke_quote").sensitive).toBe(true)
-    expect(
-      (PARTNER_MCP_TOOLS as McpToolDef[]).find((t) => t.name === "revoke_quote")
-    ).toBeUndefined()
+  /**
+   * This assertion used to read "only the admin surface can revoke", on the
+   * reasoning that revocation reaches across partners. That conflated the
+   * ADMIN ROUTE's reach with the capability: a partner withdrawing their OWN
+   * quote reaches nobody else, and denying it meant a mis-quote could only be
+   * corrected by re-minting — which emails the buyer a second number — or by
+   * waiting for expiry. #1517 built the route; the tool follows it.
+   */
+  it("both surfaces can revoke, and both treat it as sensitive", () => {
+    for (const tools of [ADMIN_MCP_TOOLS, PARTNER_MCP_TOOLS] as McpToolDef[][]) {
+      const tool = find(tools, "revoke_quote")
+      expect(tool.write).toBe(true)
+      // The buyer has already been told a number by the time anyone revokes.
+      expect(tool.sensitive).toBe(true)
+      // 🔴 No body on either. The dispatcher's body assembly is an allowlist
+      // walk, so a `reason` field the route never reads would be accepted,
+      // reported `ok: true`, and dropped in silence (#1348).
+      expect(tool.bodyParams).toBeUndefined()
+    }
+  })
+
+  it("the partner's revoke names no partner_id — it is scoped by the caller", () => {
+    // The single field that would let a partner reach another partner's quote.
+    const tool = find(PARTNER_MCP_TOOLS as McpToolDef[], "revoke_quote")
+    expect(Object.keys((tool.inputSchema as any).properties)).toEqual(["id"])
   })
 })

--- a/apps/backend/src/lib/mcp-core/__tests__/route-validator-field-coverage.unit.spec.ts
+++ b/apps/backend/src/lib/mcp-core/__tests__/route-validator-field-coverage.unit.spec.ts
@@ -76,6 +76,14 @@ const NO_ROUTE_VALIDATOR = new Set<string>([
    * not inferred from the absence of a matcher.
    */
   "admin:revoke_quote",
+  /**
+   * The partner twin (#1517), for the same reason and verified the same way:
+   * the handler reads `req.params.id` and nothing else. Its ownership check is
+   * on the auth context rather than the body, so there is no body contract to
+   * bind here — `partner-mcp-quotes.spec.ts` proves the tool reaches the route,
+   * and `partner-quote-revoke.spec.ts` proves another partner's id 404s.
+   */
+  "partner:revoke_quote",
   // Core routes: core registers its own validator, so it never appears in this
   // repo's middlewares config. The four product/variant ones are contract-
   // checked against core's imported validators in the sibling spec.

--- a/apps/backend/src/modules/partner-quote/lib/revoke-quote.ts
+++ b/apps/backend/src/modules/partner-quote/lib/revoke-quote.ts
@@ -1,0 +1,112 @@
+import { ContainerRegistrationKeys } from "@medusajs/framework/utils"
+import { deletePriceListsWorkflow } from "@medusajs/medusa/core-flows"
+
+import { PARTNER_QUOTE_MODULE } from ".."
+
+/**
+ * Revoke one quote (#1389 S5, extracted for the partner surface in #1517).
+ *
+ * 🔴 Flipping `status` alone is NOT a revoke. The quote's prices live in a
+ * real, active price list scoped to the buyer's customer group — if that list
+ * survives, the buyer keeps the quoted prices in any cart they build, whatever
+ * the quote row says. The link dies and the discount does not.
+ *
+ * So the price list is deleted FIRST and only then is the row marked. Doing it
+ * in that order means a failure leaves a quote that still says "active"
+ * alongside a list that is already gone — visibly inconsistent and safe. The
+ * reverse order would leave a revoked-looking quote still quietly pricing
+ * carts, which is the failure nobody would notice.
+ *
+ * ## Why this is a function and not two handlers
+ *
+ * The partner route (#1517) needs precisely the admin route's body, and the
+ * admin route's body contains one defect worth never copying: it once
+ * destructured the `updatePartnerQuotes` result and threw AFTER the price list
+ * had been deleted and the status written, so every revoke on prod did its
+ * whole job and answered 500 — inviting a retry of a destructive operation.
+ * Two copies of that body is two places for it to come back. The ordering
+ * above, the idempotent early return and the un-destructured update now exist
+ * once, and both surfaces differ only in who is allowed to call them and what
+ * the audit line says.
+ *
+ * Ownership is NOT checked here. The caller has already decided the actor may
+ * touch this quote — the partner route by scoping its lookup to the partner in
+ * the auth context, the admin route because an admin may touch any of them —
+ * and a guard that runs after the row is in hand cannot re-derive who asked.
+ */
+export const revokeQuote = async (
+  scope: any,
+  quote: any,
+  actor: { type: "partner" | "admin"; id?: string | null }
+): Promise<{
+  quote: any
+  price_list_deleted: boolean
+  already_revoked?: boolean
+}> => {
+  const service: any = scope.resolve(PARTNER_QUOTE_MODULE)
+  const logger: any = scope.resolve(ContainerRegistrationKeys.LOGGER)
+
+  if (quote.status === "revoked") {
+    // Idempotent: re-revoking is a no-op, not an error. Anyone hitting the
+    // button twice must not see a failure that suggests the first one did not
+    // take.
+    return { quote, price_list_deleted: false, already_revoked: true }
+  }
+
+  /**
+   * #1440 moved this off `metadata` and onto a column. The metadata fallback
+   * stays for rows minted before that migration ran — the backfill covers them,
+   * but a revoke that silently skipped a live price list because a backfill was
+   * missed is the exact failure this code exists to prevent.
+   */
+  const priceListId =
+    (quote as any)?.price_list_id ?? (quote.metadata as any)?.price_list_id
+  if (priceListId) {
+    await deletePriceListsWorkflow(scope).run({ input: { ids: [priceListId] } })
+    logger.info(`[quote] revoke ${quote.id} deleted price list ${priceListId}`)
+  } else {
+    // A quote with no recorded price list either never froze or was minted
+    // before the id was stored. Say so rather than reporting a clean revoke.
+    logger.warn(
+      `[quote] revoke ${quote.id} had no price_list_id recorded — nothing to delete`
+    )
+  }
+
+  /**
+   * 🔴 NOT array-destructured. `updateX` returns whatever the inner service
+   * returns: the `{ selector, data }` bulk form yields an ARRAY, the bare
+   * entity form used here yields a SINGLE OBJECT. Destructuring it threw
+   * `TypeError: (intermediate value) is not iterable` — and it threw *after*
+   * the price list had been deleted and the status written.
+   *
+   * So every revoke on prod did its whole job and then answered 500. That is
+   * the worst possible pairing for a destructive route: the caller sees a
+   * failure and retries an operation that already ran. Found by revoking four
+   * real quotes, not by reading the file — the `already_revoked` branch above
+   * returns the row from `listPartnerQuotes` and so has always been fine,
+   * which is exactly why a retry "worked" and hid the defect.
+   */
+  const updated = await service.updatePartnerQuotes({
+    id: quote.id,
+    status: "revoked",
+  })
+
+  const by = actor.type === "admin" ? "an admin" : "the partner"
+  await service
+    .recordEvent({
+      quote_id: quote.id,
+      type: "revoked",
+      actor_type: actor.type,
+      actor_id: actor.id ?? null,
+      message: priceListId
+        ? `Revoked by ${by}; the quoted price list was deleted.`
+        : `Revoked by ${by}. No price list was recorded on the quote, so none was deleted.`,
+      data: { price_list_id: priceListId ?? null },
+    })
+    .catch(() => {})
+
+  return {
+    quote: updated ?? { ...quote, status: "revoked" },
+    price_list_deleted: !!priceListId,
+  }
+}


### PR DESCRIPTION
Closes #1517. Finishes the last item #1452 asked for.

## The gap

`POST /admin/quotes/:id/revoke` has existed since #1389 S5. This surface had no equivalent, so a partner who mis-quoted — wrong price, wrong buyer, wrong lane — could only ask an operator, and the buyer's link stayed live and acceptable until it expired.

Re-minting is not a substitute. It emails the buyer a **new** number they never asked for and freezes a fresh price list. *"I mis-quoted, please ignore that"* had no expression here except silence until expiry.

And `mint_quote`'s own `sideEffects` told the model to *"revoke the old quote first"* — prescribing an action **no tool on that surface could perform**. That is #1394's shape again. #1516 corrected the string; this builds the capability it named.

## What's here

- **`POST /partners/quotes/:id/revoke`**, scoped by the **auth context**, not the URL id. Another partner's quote is a **404, not a 403** — a partner has no business learning that someone else's quote id is real (#1404).
- **One shared body** in `modules/partner-quote/lib/revoke-quote.ts`. The price list is deleted *before* the status is written (the reverse order leaves a revoked-looking quote still quietly pricing carts), and `updatePartnerQuotes` is **not** array-destructured. Two copies of that body is two places for the 500-after-the-work defect to come back.
- **An already-accepted quote is refused here.** `accepted_at` plus a real `accepted_cart_id` means the buyer built a cart at these prices, possibly with a deposit paid. Revoking would move those prices under them silently. The admin route keeps that power; the partner surface refuses and says who can.
  - `NOT_ALLOWED`, not `CONFLICT` — the framework's error handler **replaces** a CONFLICT message with a generic *"retry with an Idempotency-Key"* line, so the partner would be told to retry the one thing that cannot work.
- **`revoke_quote` MCP row** — `write`, `sensitive`, **no body**. A `reason` field the route never reads would be accepted, reported `ok: true`, and dropped in silence (#1348).
- **Corrected the admin row's guidance**, which still told the model to revoke before re-quoting *"because two active lists tie-break to the cheapest"* — the same already-fixed-by-#1435 falsehood #1516 removed from `mint_quote`.

## The assertion that was wrong

A unit test asserted **"only the admin surface can revoke"**, reasoning that *"revocation reaches across partners"*. That conflated the admin **route's** reach with the capability: a partner withdrawing their own quote reaches nobody else. Replaced with the real invariants — both surfaces revoke, both are `sensitive`, neither takes a body, and the partner's names no `partner_id`.

## Verified

| | |
|---|---|
| `partner-quote-revoke.spec.ts` | **10/10** |
| `partner-mcp-quotes.spec.ts` | **7/7**, incl. a real `revoke_quote` `tools/call` |
| mcp-core registry unit specs | **40/40** |
| `check:prod-build` | green |

## ⚠️ Watch-out worth keeping

The partner tests first failed **5/5 with 401s**. The runner snapshots the database on the **first `beforeEach`**, so a `beforeAll` in a *second* describe runs after the snapshot and is rolled back before its first test. The symptom is not a missing row — it is a 401 on every request in that describe, which reads exactly like a broken auth header. One top-level fixture now, with the reason written into the file.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_0158wJMZ1DmjNxXf5uGuBrQD
