### PR TITLE
fix(website): the storefront's TipTap viewer dropped every image, video and link

### DIFF
--- a/apps/storefront/src/modules/website/components/tiptap-viewer.tsx
+++ b/apps/storefront/src/modules/website/components/tiptap-viewer.tsx
@@ -32,6 +32,16 @@ function textWithMarks(textNode: any): string {
         return `<code>${acc}</code>`
       case "underline":
         return `<u>${acc}</u>`
+      case "link": {
+        // Dropped until now: an anchor mark fell through to `default`, so a
+        // link the author wrote rendered as unclickable text with nothing to
+        // say it had ever been one.
+        const href = escapeHtml(m.attrs?.href || "")
+        const target = m.attrs?.target
+          ? ` target="${escapeHtml(m.attrs.target)}"`
+          : ""
+        return `<a href="${href}"${target} rel="noopener noreferrer">${acc}</a>`
+      }
       default:
         return acc
     }
@@ -68,6 +78,39 @@ function renderNode(node: any): string {
     }
     case "hardBreak":
       return "<br/>"
+
+    /**
+     * 🔴 These four cases are why this file was edited.
+     *
+     * An image, a video and an embed are all ATOM nodes: they carry their
+     * payload in `attrs` and have no `content`. Falling through to `default`
+     * returns `children`, which for an atom is the empty string — so every
+     * picture and every video a partner inserted rendered as NOTHING, with no
+     * error anywhere. The sibling viewer in `apps/storefront-starter` has
+     * handled them for a while; this copy quietly did not.
+     */
+    case "image": {
+      const src = escapeHtml(node.attrs?.src || "")
+      const alt = escapeHtml(node.attrs?.alt || "")
+      return src ? `<img src="${src}" alt="${alt}" class="tiptap-image" />` : ""
+    }
+    case "youtube":
+    case "vimeo":
+    case "embed": {
+      // `youtube-nocookie` for the same reason as the starter: it is the host
+      // content blockers leave alone, and a blank 16:9 hole gets reported by
+      // nobody.
+      const raw = String(node.attrs?.src || "")
+      const src = escapeHtml(
+        raw.replace(/^https:\/\/(www\.)?youtube\.com\//, "https://www.youtube-nocookie.com/")
+      )
+      if (!src) return ""
+      return `<div class="tiptap-video-wrapper" style="position:relative;padding-bottom:56.25%;height:0;overflow:hidden"><iframe src="${src}" title="Embedded video" loading="lazy" referrerpolicy="strict-origin-when-cross-origin" frameborder="0" allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture" allowfullscreen style="position:absolute;top:0;left:0;width:100%;height:100%"></iframe></div>`
+    }
+    case "video": {
+      const src = escapeHtml(node.attrs?.src || "")
+      return src ? `<video controls class="tiptap-video" src="${src}"></video>` : ""
+    }
     default:
       return children
   }


### PR DESCRIPTION
Found while chasing a partner's *"the YouTube embed does not render"* report. The report turned out **not** to be a render bug — the stored node is a real `embed`, the served HTML carries the iframe, no CSP anywhere — but tracing it turned up the defect next door.

## What was wrong

`apps/storefront`'s copy of the TipTap viewer had **no case** for `image`, `embed`, `youtube`, `vimeo` or `video`, and **no `link` mark**.

Those nodes are **atoms**: they carry their payload in `attrs` and have no `content`. Falling through to `default` returns `children` — the empty string. So every picture and every video a partner inserted rendered as **nothing**, and a link rendered as unclickable text. No error, no warning, no trace.

The starter's copy has handled all of them for a while. This one quietly did not — the same divergence shape as #1438, except here the two files had already drifted apart rather than being identical.

## What's here

- `image`, `embed`/`youtube`/`vimeo`, `video`, and the `link` mark.
- Written in **this file's own style** (bare tags, no class soup) rather than copied across. The two apps are on different Next majors and copying between them is exactly how #1438 happened.
- `youtube-nocookie.com` with `title`, `loading="lazy"` and a referrer policy, matching the starter: it is the host content blockers leave alone, and a blank 16:9 hole is a defect nobody reports.

`pnpm build` green.

## Companion

The starter half is [Jaal-Yantra-Textiles/nextjs-starter-medusa#27](https://github.com/Jaal-Yantra-Textiles/nextjs-starter-medusa/pull/27) — bare-link promotion, the same nocookie hardening, and de-duplicating a byte-identical second renderer in `visual-editor-bridge.tsx`.

⚠️ **The submodule pointer is deliberately NOT bumped in this PR.** It moves in a follow-up once #27 is squash-merged, to the *squashed* commit on the starter's `main` — never the branch commit the PR was built from.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_0158wJMZ1DmjNxXf5uGuBrQD
