### PR TITLE
feat(customers): adopt a buyer who already exists on the platform, and say so (#1515)

### DIFF
--- a/apps/backend/integration-tests/http/partner-customers-api.spec.ts
+++ b/apps/backend/integration-tests/http/partner-customers-api.spec.ts
@@ -95,6 +95,89 @@ setupSharedTestSuite(() => {
         expect(res.data.customer.email).toBe(`john-${unique}@example.com`)
       })
 
+      /**
+       * #1515. Core's unique index on `customer` is `(email, has_account)` and
+       * it is PLATFORM-WIDE, so this route's unconditional create turned any
+       * buyer who already existed anywhere into core's raw 400 — a message
+       * naming another store's data, shown verbatim in the partner UI. It bit
+       * the highest-value case: a buyer who already shops somewhere on the
+       * platform is exactly the one a partner wants to add.
+       */
+      it("🔴 ADOPTS a buyer who already exists elsewhere on the platform, and says so", async () => {
+        const unique = `${Date.now()}${Math.random().toString(36).slice(2, 6)}`
+        const email = `adopt-${unique}@example.com`
+
+        // Somebody else's customer, with somebody else's profile on it.
+        const seeded = await api.post(
+          "/admin/customers",
+          { email, first_name: "Original", last_name: "Owner" },
+          adminHeaders
+        )
+        expect(seeded.status).toBe(200)
+
+        const res = await api.post(
+          "/partners/customers",
+          { email, first_name: "Typed", last_name: "ByPartner" },
+          { headers: partner.headers }
+        )
+
+        // 200 and `adopted`, not 201 — the honest description is "you acquired
+        // an existing record", not "you created a customer".
+        expect(res.status).toBe(200)
+        expect(res.data.adopted).toBe(true)
+        expect(res.data.customer.id).toBe(seeded.data.customer.id)
+
+        // 🔑 The partner's typed fields are NOT written onto another store's
+        // profile. Overwriting them would be a silent cross-tenant edit.
+        expect(res.data.customer.first_name).toBe("Original")
+
+        // And they really are this store's customer now — adoption is a link,
+        // not a label.
+        const listed = await api.get("/partners/customers", {
+          headers: partner.headers,
+        })
+        expect(
+          (listed.data.customers as any[]).some(
+            (c) => c.id === seeded.data.customer.id
+          )
+        ).toBe(true)
+      })
+
+      it("answers cleanly when the buyer is already this store's customer", async () => {
+        const unique = `${Date.now()}${Math.random().toString(36).slice(2, 6)}`
+        const email = `mine-${unique}@example.com`
+
+        const first = await api.post(
+          "/partners/customers",
+          { email, first_name: "Mine" },
+          { headers: partner.headers }
+        )
+        expect(first.status).toBe(201)
+
+        const second = await api.post(
+          "/partners/customers",
+          { email, first_name: "Mine" },
+          { headers: partner.headers }
+        )
+
+        // Not a 400, and not a duplicate row.
+        expect(second.status).toBe(200)
+        expect(second.data.already_in_store).toBe(true)
+        expect(second.data.adopted).toBe(false)
+        expect(second.data.customer.id).toBe(first.data.customer.id)
+      })
+
+      it("names the missing field rather than letting core refuse obscurely", async () => {
+        const err = await api
+          .post("/partners/customers", { first_name: "No Email" }, {
+            headers: partner.headers,
+          })
+          .catch((e: any) => e.response)
+
+        expect(err.status).toBe(400)
+        expect(String(err.data.message)).toContain("email")
+      })
+
       it("should show created customer in the list", async () => {
         const unique = Date.now()
         await api.post(

--- a/apps/backend/src/api/partners/customers/route.ts
+++ b/apps/backend/src/api/partners/customers/route.ts
@@ -1,5 +1,5 @@
 import { AuthenticatedMedusaRequest, MedusaResponse } from "@medusajs/framework/http"
-import { ContainerRegistrationKeys, Modules } from "@medusajs/framework/utils"
+import { ContainerRegistrationKeys, MedusaError, Modules } from "@medusajs/framework/utils"
 import { getPartnerStore, tryGetPartnerStore } from "../helpers"
 
 export const GET = async (
@@ -60,21 +60,110 @@ export const GET = async (
   })
 }
 
+/**
+ * Add a buyer to the partner's store (#1515).
+ *
+ * ## Why this is not just `createCustomers`
+ *
+ * Core's unique index on `customer` is `(email, has_account)` and it is
+ * PLATFORM-WIDE. This route used to create unconditionally, so a partner
+ * adding a buyer who already existed anywhere on the platform got core's raw
+ * 400 — a message naming another store's data, surfaced verbatim in the
+ * partner UI. #1507 documented the same collision on the mint path and fixed
+ * it there; this is the other half.
+ *
+ * ## Adopt, and SAY SO
+ *
+ * The buyer is resolved in the same three steps the mint uses:
+ *
+ *   1. already one of this store's customers — nothing to do;
+ *   2. an existing platform-wide row, ADOPTED into this store by a link;
+ *   3. nobody — create them.
+ *
+ * 🔑 Step 2 answers with `adopted: true` rather than a bare 200, because the
+ * honest description of what happened is "you acquired someone else's existing
+ * record", not "you created a customer". The distinction is visible in the
+ * result: the fields the partner just typed are NOT written onto an adopted
+ * profile. Overwriting another store's `first_name` and `phone` with what this
+ * partner guessed would be a silent cross-tenant edit, and answering 201 while
+ * doing it would tell them they had created the row they are looking at.
+ *
+ * ⚠️ Adoption is a real disclosure either way: the customer then appears on
+ * `GET /partners/customers` carrying whatever profile another store collected.
+ * That is deliberate, and the alternative — #1507's world — was that the
+ * platform's highest-value buyers could not be added or quoted at all.
+ *
+ * 🔑 The lookup is an EXACT match on the normalised address, matching the
+ * mint's reasoning: core's index compares the stored string, so an exact
+ * lookup covers exactly the set of rows a create could collide with. Anything
+ * looser would adopt a customer core would have let us create alongside.
+ */
 export const POST = async (
   req: AuthenticatedMedusaRequest,
   res: MedusaResponse
 ) => {
   const { store } = await getPartnerStore(req.auth_context, req.scope)
 
-  const customerService = req.scope.resolve(Modules.CUSTOMER) as any
-  const customer = await customerService.createCustomers(req.body as any)
+  const body = (req.body ?? {}) as Record<string, any>
+  const email = String(body.email ?? "").trim().toLowerCase()
+  if (!email) {
+    throw new MedusaError(
+      MedusaError.Types.INVALID_DATA,
+      "A customer needs an email address."
+    )
+  }
 
-  // Link customer to store
+  const customerService = req.scope.resolve(Modules.CUSTOMER) as any
   const remoteLink = req.scope.resolve(ContainerRegistrationKeys.LINK) as any
+  const query = req.scope.resolve(ContainerRegistrationKeys.QUERY)
+
+  // 1. Already this store's customer.
+  const { data: storeRows } = await query.graph({
+    entity: "stores",
+    fields: ["customers.id", "customers.email"],
+    filters: { id: store.id },
+  })
+  const mine = (((storeRows ?? [])[0] as any)?.customers ?? []) as any[]
+  const alreadyOurs = mine.find(
+    (c) => String(c?.email ?? "").toLowerCase() === email
+  )
+  if (alreadyOurs) {
+    const [full] = await customerService.listCustomers({ id: alreadyOurs.id })
+    return res.json({
+      customer: full ?? alreadyOurs,
+      adopted: false,
+      already_in_store: true,
+    })
+  }
+
+  // 2. Somebody else's, platform-wide. Adopt them, and say so.
+  const existing: any[] = await customerService
+    .listCustomers({ email }, { take: 10 })
+    .catch(() => [])
+  /**
+   * A registered account OUTRANKS a guest with the same address, because the
+   * unique index is on the PAIR — both rows can exist for one person, and the
+   * one the buyer sees when they sign in is the account (#1507).
+   */
+  const adoptee = existing.find((c) => c?.has_account) ?? existing[0]
+
+  if (adoptee) {
+    await remoteLink.create({
+      [Modules.STORE]: { store_id: store.id },
+      [Modules.CUSTOMER]: { customer_id: adoptee.id },
+    })
+    return res.json({ customer: adoptee, adopted: true })
+  }
+
+  // 3. Nobody by that address. Create them.
+  const customer = await customerService.createCustomers({
+    ...body,
+    email,
+  })
   await remoteLink.create({
     [Modules.STORE]: { store_id: store.id },
     [Modules.CUSTOMER]: { customer_id: customer.id },
   })
 
-  res.status(201).json({ customer })
+  res.status(201).json({ customer, adopted: false })
 }

--- a/apps/partner-ui/src/hooks/api/customers.tsx
+++ b/apps/partner-ui/src/hooks/api/customers.tsx
@@ -69,16 +69,32 @@ export const useCustomers = (
   return { ...data, ...rest }
 }
 
+/**
+ * 🔑 The response carries more than a customer (#1515).
+ *
+ * A buyer who already exists ANYWHERE on the platform cannot be created again
+ * — core's unique index on `(email, has_account)` is platform-wide — so the
+ * route adopts the existing row into this store instead of refusing. When it
+ * does, `adopted` is true and the returned profile is the one ANOTHER store
+ * collected: the fields just typed into this form were deliberately not
+ * written over it. Callers must say so rather than reporting a create.
+ */
+export type PartnerCustomerCreateResponse = {
+  customer: HttpTypes.AdminCustomer
+  adopted?: boolean
+  already_in_store?: boolean
+}
+
 export const useCreateCustomer = (
   options?: UseMutationOptions<
-    { customer: HttpTypes.AdminCustomer },
+    PartnerCustomerCreateResponse,
     FetchError,
     HttpTypes.AdminCreateCustomer
   >
 ) => {
   return useMutation({
     mutationFn: (payload) =>
-      sdk.client.fetch<{ customer: HttpTypes.AdminCustomer }>(
+      sdk.client.fetch<PartnerCustomerCreateResponse>(
         "/partners/customers",
         { method: "POST", body: payload }
       ),

--- a/apps/partner-ui/src/routes/customers/customer-create/components/create-customer-form/create-customer-form.tsx
+++ b/apps/partner-ui/src/routes/customers/customer-create/components/create-customer-form/create-customer-form.tsx
@@ -47,12 +47,30 @@ export const CreateCustomerForm = () => {
         phone: data.phone || undefined,
       },
       {
-        onSuccess: ({ customer }) => {
-          toast.success(
-            t("customers.create.successToast", {
-              email: customer.email,
-            })
-          )
+        onSuccess: ({ customer, adopted, already_in_store }) => {
+          /**
+           * 🔑 Say which of the three things happened (#1515).
+           *
+           * A buyer who already exists anywhere on the platform is ADOPTED
+           * into this store rather than created — the row that comes back is
+           * the one another store built, and the names typed above were not
+           * written onto it. Reporting that as "customer created" would leave
+           * the partner believing the profile in front of them is the one they
+           * just entered.
+           */
+          if (already_in_store) {
+            toast.info(`${customer.email} is already one of your customers.`)
+          } else if (adopted) {
+            toast.success(
+              `${customer.email} already had an account on the platform and has been added to your store. Their existing profile is shown — the details you typed were not applied.`
+            )
+          } else {
+            toast.success(
+              t("customers.create.successToast", {
+                email: customer.email,
+              })
+            )
+          }
           handleSuccess(`/customers/${customer.id}`)
         },
         onError: (error) => {


### PR DESCRIPTION
Closes #1515.

## The collision

`POST /partners/customers` created unconditionally. Core's unique index on `customer` is `(email, has_account)` and it is **platform-wide**, so a partner adding a buyer who already existed anywhere on the platform got core's raw 400:

```
Customer with email: <addr>, has_account: false, already exists.
```

Nothing caught it, so the partner UI showed a core error naming **another store's data**. #1507 fixed the same collision on the mint path; this is the other half, and it answers the same question the same way.

## Adopt, and say so

The buyer is resolved in three steps, matching the mint:

1. already one of this store's customers — nothing to do;
2. **the platform-wide row, adopted into this store by a link**;
3. nobody — create them.

🔑 **Adoption answers 200 with `adopted: true`, not 201.** The honest description is *"you acquired an existing record"*, not *"you created a customer"* — and the distinction is visible in the result, because **the fields the partner just typed are not written onto an adopted profile.** Overwriting another store's `first_name` and `phone` with what this partner guessed would be a silent cross-tenant edit; answering 201 while doing it would tell them the profile in front of them is the one they entered.

Two smaller honesty fixes ride along: a buyer already in this store answers 200 with `already_in_store` instead of the old 400, and a missing email names the field rather than letting core refuse obscurely.

## Why the disclosure lands *after* the link

The alternative was a confirmation *before* it — *"this buyer already has an account, add them to your store?"*. That requires the server to answer **"does this email exist on the platform"**, and the dialog's presence or absence *is* that answer. Someone could type addresses — a competitor's customer list, a guess at a rival partner's buyers — and read off which are real.

If we want the partner to have the choice, the safe shape is a **pending-adoption token**: the server decides, returns the pending result plus a one-time token, and Yes posts the token back. You only ever learn about a customer you were already adding, and only once. Not built here.

## Verified

| | |
|---|---|
| `partner-customers-api.spec.ts` | **15/15** |
| `check:prod-build` | green |
| partner-ui | `tsc --noEmit` 4 pre-existing errors (unchanged on a clean tree), `build:preview` green |

The adoption test seeds a customer with a *different* profile and asserts the adopted row still reads `Original`, not the `Typed` name the partner submitted.

⚠️ `apps/partner-ui` still has no CI (#1482) — both files were typechecked and built by hand. The create-customer form has **not** been clicked.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_0158wJMZ1DmjNxXf5uGuBrQD
