### PR TITLE
fix(partners): a product option add or edit wrote nothing (#1521)

### DIFF
--- a/apps/backend/integration-tests/http/partner-store-products-api.spec.ts
+++ b/apps/backend/integration-tests/http/partner-store-products-api.spec.ts
@@ -553,18 +553,153 @@ setupSharedTestSuite(() => {
     })
 
     describe("Product Option Management", () => {
-      it("creates a new option for the product", async () => {
+      // 🔑 The assertion this suite shipped with checked the 201 and the title
+      // in the RESPONSE, and never re-read the product. Product options went
+      // global in 2.16 — the route wrote `product_id`, which is a no-op — so it
+      // stayed green for months while every partner attempt to add an option
+      // changed nothing. Every test here re-reads the product.
+      const readOptions = async () => {
+        const res = await api.get(
+          `/partners/stores/${partner.storeId}/products/${partner.productId}`,
+          { headers: partner.headers }
+        )
+        return (res.data.product.options || []) as any[]
+      }
+
+      // ⚠️ One test, not three. The runner restores a snapshot before every
+      // test, so a chain split across `it`s reads as a convincing false
+      // "the option vanished" bug.
+      it("adds an option, merges a re-add, and saves an edited value", async () => {
+        // 1. Create — and the product must actually carry it.
+        const created = await api.post(
+          `/partners/stores/${partner.storeId}/products/${partner.productId}/options`,
+          { title: "Material", values: ["Cotton", "Polyester"] },
+          { headers: partner.headers }
+        )
+        expect(created.status).toBe(201)
+        expect(created.data.product_option.title).toBe("Material")
+
+        let onProduct = (await readOptions()).find((o) => o.title === "Material")
+        expect(onProduct).toBeDefined()
+        expect((onProduct.values || []).map((v: any) => v.value).sort()).toEqual(
+          ["Cotton", "Polyester"]
+        )
+
+        // 2. Re-adding the same title merges instead of colliding. On the old
+        // route this hit the global unique title index and answered 400, which
+        // is what pushed the assistant into add_product_variant instead.
+        const reused = await api.post(
+          `/partners/stores/${partner.storeId}/products/${partner.productId}/options`,
+          { title: "Material", values: ["Cotton", "Silk"] },
+          { headers: partner.headers }
+        )
+        expect(reused.status).toBe(200)
+        expect(reused.data.reused).toBe(true)
+
+        onProduct = (await readOptions()).find((o) => o.title === "Material")
+        expect((onProduct.values || []).map((v: any) => v.value).sort()).toEqual(
+          ["Cotton", "Polyester", "Silk"]
+        )
+
+        // 3. Editing values changes what the PRODUCT carries. The old route
+        // answered 200 with the new value in the body while the product still
+        // listed the old ones — the partner's "save button does nothing".
+        const saved = await api.post(
+          `/partners/stores/${partner.storeId}/products/${partner.productId}/options/${onProduct.id}`,
+          { title: "Material", values: ["Cotton", "Polyester", "Silk", "Linen"] },
+          { headers: partner.headers }
+        )
+        expect(saved.status).toBe(200)
+
+        onProduct = (await readOptions()).find((o) => o.title === "Material")
+        expect((onProduct.values || []).map((v: any) => v.value).sort()).toEqual(
+          ["Cotton", "Linen", "Polyester", "Silk"]
+        )
+      })
+
+      // Colour is ONE shared row every partner links, with a per-product value
+      // subset. Again one test: the runner rolls the DB back between them.
+      it("links the curated Colour palette with only the chosen subset", async () => {
+        const productService: any = getSharedTestEnv()
+          .getContainer()
+          .resolve("product")
+
+        await productService.createProductOptions({
+          title: "Colour",
+          is_exclusive: false,
+          values: [
+            { value: "Ivory", metadata: { hex: "#FAF8EF" } },
+            { value: "Terracotta", metadata: { hex: "#BF7B61" } },
+            { value: "Emerald", metadata: { hex: "#0EA347" } },
+          ],
+        })
+
         const res = await api.post(
           `/partners/stores/${partner.storeId}/products/${partner.productId}/options`,
-          {
-            title: "Material",
-            values: ["Cotton", "Polyester"],
-          },
+          { title: "Colour", values: ["Ivory", "Terracotta"] },
           { headers: partner.headers }
         )
         expect(res.status).toBe(201)
-        expect(res.data.product_option).toBeDefined()
-        expect(res.data.product_option.title).toBe("Material")
+
+        // ⚠️ Omitting the value-id subset links ALL of the option's values.
+        // The product asked for two of three and must get exactly two.
+        const onProduct = (await readOptions()).find((o) => o.title === "Colour")
+        expect((onProduct.values || []).map((v: any) => v.value).sort()).toEqual(
+          ["Ivory", "Terracotta"]
+        )
+        expect(
+          (onProduct.values || []).find((v: any) => v.value === "Ivory")
+            ?.metadata?.hex
+        ).toBe("#FAF8EF")
+
+        // A colour outside the palette is refused — with the vocabulary named.
+        const refused = await api.post(
+          `/partners/stores/${partner.storeId}/products/${partner.productId}/options`,
+          { title: "Colour", values: ["Neon Lime"] },
+          { headers: partner.headers, validateStatus: () => true }
+        )
+        expect(refused.status).toBe(400)
+        expect(refused.data.message).toContain("Neon Lime")
+
+        // ...unless the partner supplies a hex, which is the escape hatch.
+        const added = await api.post(
+          `/partners/stores/${partner.storeId}/products/${partner.productId}/options`,
+          {
+            title: "Colour",
+            values: [{ value: "Sea Green", hex: "#2E8B57" }],
+          },
+          { headers: partner.headers }
+        )
+        expect(added.status).toBe(200)
+
+        const withCustom = (await readOptions()).find(
+          (o) => o.title === "Colour"
+        )
+        const seaGreen = (withCustom.values || []).find(
+          (v: any) => v.value === "Sea Green"
+        )
+        // The hex must survive: core's add path reads only `value` and drops
+        // metadata, so this only passes because it is set in a second write.
+        expect(seaGreen?.metadata?.hex).toBe("#2E8B57")
+        expect(seaGreen?.metadata?.custom).toBe(true)
+
+        // A shared option must not be renamable from one partner's product.
+        const rename = await api.post(
+          `/partners/stores/${partner.storeId}/products/${partner.productId}/options/${withCustom.id}`,
+          { title: "Colours" },
+          { headers: partner.headers, validateStatus: () => true }
+        )
+        expect(rename.status).toBe(400)
+      })
+
+      it("refuses to write an option that belongs to another product", async () => {
+        const other = await createPartnerWithStoreAndProduct(api, adminHeaders)
+        const res = await api.post(
+          `/partners/stores/${partner.storeId}/products/${partner.productId}/options/${other.optionIds[0]}`,
+          { title: "Hijacked" },
+          { headers: partner.headers, validateStatus: () => true }
+        )
+        expect([400, 404]).toContain(res.status)
       })
     })
 

--- a/apps/backend/src/api/partners/mcp/lib/registry.ts
+++ b/apps/backend/src/api/partners/mcp/lib/registry.ts
@@ -1949,9 +1949,17 @@ export const PARTNER_MCP_TOOLS: PartnerMcpToolDef[] = [
   // (add a colour/size, fix a price, remove a variant). Options must exist
   // before variants can reference them. Routine writes except DELETE.
   {
+    name: "list_option_palettes",
+    description:
+      "List the curated option vocabularies (e.g. Colour) with their allowed values and hex codes. Call this BEFORE add_product_option whenever the option is a colour — the palette is the vocabulary, and a value outside it is refused unless you supply a hex for it.",
+    method: "GET",
+    path: "/partners/option-palettes",
+    inputSchema: obj({}, []),
+  },
+  {
     name: "add_product_option",
     description:
-      "Add an option (e.g. Size, Color) with its values to a product. Options must exist before variants can reference them via `options`.",
+      "Add an option (e.g. Size, Colour) with its values to a product. Add every option a variant will name BEFORE calling add_product_variant, or it fails on the option count. Safe to call again for an option the product already has — the new values are merged into it. Colour is a CURATED option shared by every partner: pass values from list_option_palettes, and to use a colour that is not in the palette pass an object with a hex, e.g. { value: 'Sea Green', hex: '#2E8B57' }.",
     method: "POST",
     path: "/partners/stores/:id/products/:productId/options",
     pathParams: ["id", "productId"],
@@ -1961,11 +1969,25 @@ export const PARTNER_MCP_TOOLS: PartnerMcpToolDef[] = [
       {
         id: STR("Store id."),
         productId: STR("Product id."),
-        title: STR("Option name, e.g. 'Size'."),
+        title: STR("Option name, e.g. 'Size' or 'Colour'."),
         values: {
           type: "array",
-          description: "Option values, e.g. ['S','M','L'].",
-          items: { type: "string" },
+          description:
+            "Option values. Strings for existing values, e.g. ['S','M','L'] or ['Ivory','Terracotta']. For a colour outside the curated palette, an object: { value: 'Sea Green', hex: '#2E8B57' }.",
+          items: {
+            anyOf: [
+              { type: "string" },
+              {
+                type: "object",
+                properties: {
+                  value: STR("The value's name, e.g. 'Sea Green'."),
+                  hex: STR("6-digit hex for a new colour, e.g. '#2E8B57'."),
+                },
+                required: ["value"],
+                additionalProperties: true,
+              },
+            ],
+          },
         },
       },
       ["id", "productId", "title", "values"]

--- a/apps/backend/src/api/partners/mcp/lib/tool-slice.ts
+++ b/apps/backend/src/api/partners/mcp/lib/tool-slice.ts
@@ -79,6 +79,9 @@ const PREFIX_DOMAINS: ReadonlyArray<readonly [string, PartnerToolDomain]> = [
   ["/partners/product-tags", "catalog"],
   ["/partners/product-types", "catalog"],
   ["/partners/price-preferences", "catalog"],
+  // The curated colour palette is the vocabulary for add_product_option, so it
+  // has to be loaded on the same turn the model reaches for that tool.
+  ["/partners/option-palettes", "catalog"],
   // discover = "copy a product from another store into mine" — it operates on
   // the partner's catalog, so it belongs here next to create_product.
   ["/partners/discover", "catalog"],

--- a/apps/backend/src/api/partners/option-palettes/route.ts
+++ b/apps/backend/src/api/partners/option-palettes/route.ts
@@ -1,0 +1,52 @@
+import {
+  AuthenticatedMedusaRequest,
+  MedusaResponse,
+} from "@medusajs/framework/http"
+import { Modules } from "@medusajs/framework/utils"
+
+/**
+ * The curated option vocabularies a partner can draw from — Colour and its
+ * palette today, any future shared taxonomy for free.
+ *
+ * Each entry carries the hex so the picker and both storefronts can draw a
+ * swatch without a second round trip.
+ *
+ * 🔑 A partner sees the curated values plus THEIR OWN additions, never another
+ * partner's. The values all live on one shared row, so without this filter a
+ * partner's private colour name would be listed for every competitor on the
+ * platform. The `product_product_option_value` pivot already stops anyone
+ * USING a value they did not select — this is about not showing it either.
+ */
+export const GET = async (
+  req: AuthenticatedMedusaRequest,
+  res: MedusaResponse
+) => {
+  const partnerId = (req.auth_context as any)?.app_metadata?.partner_id
+  const productService: any = req.scope.resolve(Modules.PRODUCT)
+
+  const options = await productService.listProductOptions(
+    { is_exclusive: false },
+    { relations: ["values"] }
+  )
+
+  const palettes = (options ?? []).map((option: any) => ({
+    id: option.id,
+    title: option.title,
+    values: (option.values ?? [])
+      .filter((v: any) => {
+        const meta = v.metadata ?? {}
+        if (!meta.custom) {
+          return true
+        }
+        return !meta.partner_id || meta.partner_id === partnerId
+      })
+      .map((v: any) => ({
+        id: v.id,
+        value: v.value,
+        hex: v.metadata?.hex ?? null,
+        custom: !!v.metadata?.custom,
+      })),
+  }))
+
+  res.json({ palettes, count: palettes.length })
+}

--- a/apps/backend/src/api/partners/stores/[id]/products/[productId]/options/[optionId]/route.ts
+++ b/apps/backend/src/api/partners/stores/[id]/products/[productId]/options/[optionId]/route.ts
@@ -1,39 +1,148 @@
-import { AuthenticatedMedusaRequest, MedusaResponse } from "@medusajs/framework/http"
-import { Modules } from "@medusajs/framework/utils"
-import { deleteProductOptionsWorkflow } from "@medusajs/medusa/core-flows"
+import {
+  AuthenticatedMedusaRequest,
+  MedusaResponse,
+} from "@medusajs/framework/http"
+import { MedusaError, Modules } from "@medusajs/framework/utils"
+import { setProductProductOptionsWorkflow } from "@medusajs/medusa/core-flows"
 import { validatePartnerStoreAccess } from "../../../../../../helpers"
+import {
+  listProductOptions,
+  normalizeTitle,
+  normalizeValueEntries,
+  resolveCuratedValueIds,
+} from "../shared"
+
+/**
+ * Resolve the option and prove it belongs to THIS product.
+ *
+ * Both writes below used to take `req.params.optionId` straight to the module
+ * service, which validated the store in the URL and then happily wrote to any
+ * option id in the database — the #1404 shape. Since 2.16 an option can be
+ * shared, so an unchecked DELETE could strip an option off another tenant's
+ * product. Validate both ends.
+ */
+const resolveOption = async (
+  scope: any,
+  productId: string,
+  optionId: string
+) => {
+  const option = (await listProductOptions(scope, productId)).find(
+    (o) => o.id === optionId
+  )
+
+  if (!option) {
+    throw new MedusaError(
+      MedusaError.Types.NOT_FOUND,
+      `Option ${optionId} is not an option of product ${productId}.`
+    )
+  }
+
+  return option
+}
 
 export const POST = async (
   req: AuthenticatedMedusaRequest,
   res: MedusaResponse
 ) => {
-  await validatePartnerStoreAccess(
-    req.auth_context,
-    req.params.id,
-    req.scope
-  )
+  await validatePartnerStoreAccess(req.auth_context, req.params.id, req.scope)
 
+  const productId = req.params.productId
+  const optionId = req.params.optionId
   const body = req.body as Record<string, any>
-  const productService = req.scope.resolve(Modules.PRODUCT) as any
-  const updated = await productService.updateProductOptions(
-    req.params.optionId,
-    body
+  const option = await resolveOption(req.scope, productId, optionId)
+
+  const productService: any = req.scope.resolve(Modules.PRODUCT)
+  const [optionRow] = await productService.listProductOptions(
+    { id: optionId },
+    { relations: ["values"] }
+  )
+  const isCurated = optionRow?.is_exclusive === false
+
+  const title = normalizeTitle(body.title)
+  if (title && title !== option.title) {
+    // 🔑 A curated option is ONE row shared by every partner that links it.
+    // Renaming it here would rename Colour across the whole platform from
+    // inside one partner's product page — a single-tenant action with a
+    // platform-wide blast radius, and nothing in the response would say so.
+    if (isCurated) {
+      throw new MedusaError(
+        MedusaError.Types.NOT_ALLOWED,
+        `"${option.title}" is a shared option and cannot be renamed from a product. Choose which of its values this product offers instead.`
+      )
+    }
+    await productService.updateProductOptions(optionId, { title })
+  }
+
+  // 🔑 The values a product can use live on `product_product_option_value`,
+  // NOT on the option. Writing `values` through the module service updated the
+  // option row and returned it in full — a 200 whose body showed the new value
+  // while the product still showed the old list. That response is what made the
+  // partner's save button look like it did nothing: it reported success, the
+  // refetch showed no change, and nothing was ever logged.
+  if (body.values !== undefined) {
+    const entries = normalizeValueEntries(body.values)
+    const desired = entries.map((e) => e.value)
+    const onProduct = new Map(option.values.map((v) => [v.value, v.id]))
+    const ownedValues = (optionRow?.values ?? []) as any[]
+    const wantedEntries = entries.filter((e) => !onProduct.has(e.value))
+    const wanted = wantedEntries.map((e) => e.value)
+
+    // On a curated option a partner selects from the palette (or adds one of
+    // their own with a hex); on their own option they author freely.
+    const add = isCurated
+      ? await resolveCuratedValueIds(
+          req.scope,
+          { id: optionId, title: option.title, values: ownedValues },
+          wantedEntries,
+          (req.auth_context as any)?.app_metadata?.partner_id
+        )
+      : wanted.map((value) => {
+          const owned = ownedValues.find((v) => v.value === value)
+          return owned ? owned.id : { value }
+        })
+
+    const desiredSet = new Set(desired)
+    const remove = option.values
+      .filter((v) => !desiredSet.has(v.value))
+      .map((v) => v.id)
+
+    if (add.length || remove.length) {
+      // Core refuses to drop a value a variant still uses, which is the
+      // refusal the partner should see rather than a silent no-op.
+      await setProductProductOptionsWorkflow(req.scope).run({
+        input: {
+          product_id: productId,
+          update: [{ product_option_id: optionId, add, remove }],
+        } as any,
+      })
+    }
+  }
+
+  const product_option = (await listProductOptions(req.scope, productId)).find(
+    (o) => o.id === optionId
   )
 
-  res.json({ product_option: updated })
+  res.json({ product_option })
 }
 
 export const DELETE = async (
   req: AuthenticatedMedusaRequest,
   res: MedusaResponse
 ) => {
-  await validatePartnerStoreAccess(
-    req.auth_context,
-    req.params.id,
-    req.scope
-  )
+  await validatePartnerStoreAccess(req.auth_context, req.params.id, req.scope)
 
-  await deleteProductOptionsWorkflow(req.scope).run({ input: { ids: [req.params.optionId] } })
+  const productId = req.params.productId
+  const optionId = req.params.optionId
+  await resolveOption(req.scope, productId, optionId)
 
-  res.json({ id: req.params.optionId, object: "product_option", deleted: true })
+  // Unlink rather than hard-delete. `deleteProductOptionsWorkflow` removes the
+  // option row itself, which for a shared option would take it off every other
+  // product that carries it. Core garbage-collects an exclusive option once it
+  // is no longer associated with any product, so this is still a delete for
+  // everything a partner can author.
+  await setProductProductOptionsWorkflow(req.scope).run({
+    input: { product_id: productId, remove: [optionId] } as any,
+  })
+
+  res.json({ id: optionId, object: "product_option", deleted: true })
 }

--- a/apps/backend/src/api/partners/stores/[id]/products/[productId]/options/route.ts
+++ b/apps/backend/src/api/partners/stores/[id]/products/[productId]/options/route.ts
@@ -1,23 +1,147 @@
-import { AuthenticatedMedusaRequest, MedusaResponse } from "@medusajs/framework/http"
-import { Modules } from "@medusajs/framework/utils"
+import {
+  AuthenticatedMedusaRequest,
+  MedusaResponse,
+} from "@medusajs/framework/http"
+import { MedusaError, Modules } from "@medusajs/framework/utils"
+import {
+  createAndLinkProductOptionsToProductWorkflow,
+  setProductProductOptionsWorkflow,
+} from "@medusajs/medusa/core-flows"
 import { validatePartnerStoreAccess } from "../../../../../helpers"
+import {
+  findCuratedOption,
+  listProductOptions,
+  normalizeTitle,
+  normalizeValueEntries,
+  resolveCuratedValueIds,
+  titlesMatch,
+} from "./shared"
 
 export const POST = async (
   req: AuthenticatedMedusaRequest,
   res: MedusaResponse
 ) => {
-  await validatePartnerStoreAccess(
-    req.auth_context,
-    req.params.id,
-    req.scope
-  )
+  await validatePartnerStoreAccess(req.auth_context, req.params.id, req.scope)
 
   const body = req.body as Record<string, any>
-  const productService = req.scope.resolve(Modules.PRODUCT) as any
-  const option = await productService.createProductOptions({
-    ...body,
-    product_id: req.params.productId,
-  })
+  const productId = req.params.productId
+  const title = normalizeTitle(body.title)
+  const entries = normalizeValueEntries(body.values)
+  const values = entries.map((e) => e.value)
+  const partnerId = (req.auth_context as any)?.app_metadata?.partner_id
 
-  res.status(201).json({ product_option: option })
+  if (!title) {
+    throw new MedusaError(
+      MedusaError.Types.INVALID_DATA,
+      "An option needs a title."
+    )
+  }
+
+  const existing = (await listProductOptions(req.scope, productId)).find((o) =>
+    titlesMatch(o.title, title)
+  )
+
+  // Re-adding an option the product already has is a merge, not a collision.
+  // The assistant reaches for `add_product_option` whenever it wants a value
+  // to exist; answering 400 taught it to give up and try to create the variant
+  // instead, which is the 400 the partner actually saw. Matching on
+  // (product, title) — never on the global title — keeps a partner's product
+  // from being bound to a row another tenant is also on.
+  if (existing) {
+    const productService: any = req.scope.resolve(Modules.PRODUCT)
+    const [optionRow] = await productService.listProductOptions(
+      { id: existing.id },
+      { relations: ["values"] }
+    )
+    const ownedValues = (optionRow?.values ?? []) as any[]
+    const onProduct = new Set(existing.values.map((v) => v.value))
+    const wantedEntries = entries.filter((e) => !onProduct.has(e.value))
+    const wanted = wantedEntries.map((e) => e.value)
+
+    // On a curated (shared) option a partner selects from the palette, or adds
+    // a colour of their own by supplying a hex — never renames, and never
+    // silently widens the vocabulary for everyone else.
+    const add = optionRow?.is_exclusive === false
+      ? await resolveCuratedValueIds(
+          req.scope,
+          { id: existing.id, title: existing.title, values: ownedValues },
+          wantedEntries,
+          partnerId
+        )
+      : wanted.map((value) => {
+          // The option may already own the value while the product's subset
+          // does not — attach by id rather than minting a duplicate row.
+          const owned = ownedValues.find((v) => v.value === value)
+          return owned ? owned.id : { value }
+        })
+
+    if (add.length) {
+      await setProductProductOptionsWorkflow(req.scope).run({
+        input: {
+          product_id: productId,
+          update: [{ product_option_id: existing.id, add }],
+        } as any,
+      })
+    }
+
+    const [product_option] = (
+      await listProductOptions(req.scope, productId)
+    ).filter((o) => o.id === existing.id)
+
+    res.json({ product_option, reused: true, added: add.length })
+    return
+  }
+
+  // Colour is a vocabulary every partner draws from, so it is one shared row
+  // that products LINK with their own value subset — not a per-product option
+  // each partner re-invents. The subset lives on `product_product_option_value`,
+  // and core refuses a variant that names a value outside it, so sharing the
+  // row does not share the selections.
+  const curated = await findCuratedOption(req.scope, title)
+
+  if (curated) {
+    const valueIds = await resolveCuratedValueIds(
+      req.scope,
+      curated,
+      entries,
+      partnerId
+    )
+
+    // ⚠️ Omitting `product_option_value_ids` links EVERY value on the option —
+    // all 55 colours onto a product that asked for two.
+    await setProductProductOptionsWorkflow(req.scope).run({
+      input: {
+        product_id: productId,
+        add: [
+          {
+            product_option_id: curated.id,
+            product_option_value_ids: valueIds,
+          },
+        ],
+      } as any,
+    })
+  } else {
+    await createAndLinkProductOptionsToProductWorkflow(req.scope).run({
+      input: {
+        product_id: productId,
+        add: [{ title, values, is_exclusive: true }],
+      } as any,
+    })
+  }
+
+  const product_option = (await listProductOptions(req.scope, productId)).find(
+    (o) => titlesMatch(o.title, title)
+  )
+
+  if (!product_option) {
+    // The workflow answered without throwing but the product does not carry
+    // the option — the exact silent failure this route shipped for months.
+    // Refuse loudly rather than hand back another convincing 201.
+    throw new MedusaError(
+      MedusaError.Types.UNEXPECTED_STATE,
+      `Option "${title}" was created but is not linked to product ${productId}.`
+    )
+  }
+
+  res.status(201).json({ product_option })
 }

--- a/apps/backend/src/api/partners/stores/[id]/products/[productId]/options/shared.ts
+++ b/apps/backend/src/api/partners/stores/[id]/products/[productId]/options/shared.ts
@@ -1,0 +1,249 @@
+import {
+  ContainerRegistrationKeys,
+  MedusaError,
+  Modules,
+} from "@medusajs/framework/utils"
+
+/**
+ * Product options went global in Medusa 2.16: `ProductOption` is now a
+ * standalone entity linked to products through a many-to-many pivot, and the
+ * per-product set of usable values lives on `product_product_option_value`.
+ *
+ * 🔑 `product_id` on the create payload is a NO-OP since that change. Writing
+ * it returns a clean 201 with `product_id: null` and leaves the product with
+ * exactly the options it had before — which is how every partner attempt to
+ * add an option silently did nothing, while minting a detached global row that
+ * squats its title platform-wide (the unique index covers `is_exclusive=false`).
+ *
+ * Everything in production is exclusive — all 98 in-use options — because that
+ * is what core creates for options authored on a product. Partner-authored
+ * options follow suit: scoped to the one product, invisible to other tenants,
+ * and outside the global title index so two partners can both have a "Color".
+ */
+export const PARTNER_OPTIONS_ARE_EXCLUSIVE = true
+
+export type ProductOptionValue = { id: string; value: string }
+export type ProductOptionRow = {
+  id: string
+  title: string
+  values: ProductOptionValue[]
+}
+
+/**
+ * The options a product actually carries, with the values in ITS subset —
+ * not every value the underlying option row happens to own.
+ */
+export const listProductOptions = async (
+  scope: any,
+  productId: string
+): Promise<ProductOptionRow[]> => {
+  const query: any = scope.resolve(ContainerRegistrationKeys.QUERY)
+  const { data } = await query.graph({
+    entity: "products",
+    fields: [
+      "id",
+      "options.id",
+      "options.title",
+      "options.values.id",
+      "options.values.value",
+    ],
+    filters: { id: productId },
+  })
+
+  return ((data?.[0]?.options ?? []) as any[]).map((option) => ({
+    id: option.id,
+    title: option.title,
+    values: ((option.values ?? []) as any[]).map((v) => ({
+      id: v.id,
+      value: v.value,
+    })),
+  }))
+}
+
+/** Option titles are matched for humans: trimmed, case-insensitive. */
+export const normalizeTitle = (title: unknown): string =>
+  String(title ?? "").trim()
+
+export const titlesMatch = (a: unknown, b: unknown): boolean =>
+  normalizeTitle(a).toLowerCase() === normalizeTitle(b).toLowerCase()
+
+/** Accepts `["S","M"]` or `[{ value: "S" }]`, which is what core emits back. */
+export const normalizeValues = (values: unknown): string[] => {
+  if (!Array.isArray(values)) {
+    return []
+  }
+  return values
+    .map((v) => (typeof v === "string" ? v : String((v as any)?.value ?? "")))
+    .map((v) => v.trim())
+    .filter(Boolean)
+}
+
+/**
+ * A curated option is a shared (`is_exclusive: false`) row that products LINK
+ * rather than re-create — Colour and its 55-value palette is the first one.
+ * Returns null for a title nobody has curated, which is the ordinary case: a
+ * partner inventing "Spin Type" gets an exclusive option of their own.
+ */
+export const findCuratedOption = async (
+  scope: any,
+  title: string
+): Promise<{ id: string; title: string; values: ProductOptionValue[] } | null> => {
+  const productService: any = scope.resolve(Modules.PRODUCT)
+  const rows = await productService.listProductOptions(
+    { is_exclusive: false },
+    { relations: ["values"] }
+  )
+  const match = (rows ?? []).find((o: any) => titlesMatch(o.title, title))
+  if (!match) {
+    return null
+  }
+  return {
+    id: match.id,
+    title: match.title,
+    values: (match.values ?? []).map((v: any) => ({ id: v.id, value: v.value })),
+  }
+}
+
+/**
+ * Map requested value names onto a curated option's existing value ids.
+ *
+ * 🔑 A curated option is shared across every partner, so a partner may only
+ * ever SELECT from it — never rename it and never mint a new value into it.
+ * Without this, one partner adding "Neon Lime" would widen the vocabulary for
+ * everyone, and the fixed palette would stop being fixed.
+ */
+export const resolvePaletteValueIds = (
+  option: { title: string; values: ProductOptionValue[] },
+  requested: string[]
+): string[] => {
+  const byName = new Map(
+    option.values.map((v) => [v.value.toLowerCase(), v.id])
+  )
+  const unknown = requested.filter((v) => !byName.has(v.toLowerCase()))
+
+  if (unknown.length) {
+    throw new MedusaError(
+      MedusaError.Types.NOT_ALLOWED,
+      `${option.title} is a curated option — "${unknown.join(
+        '", "'
+      )}" is not in its palette. Choose from: ${option.values
+        .map((v) => v.value)
+        .join(", ")}.`
+    )
+  }
+
+  return requested.map((v) => byName.get(v.toLowerCase()) as string)
+}
+
+export type ValueEntry = { value: string; hex?: string }
+
+/**
+ * Accepts `["Ivory", { value: "Sea Green", hex: "#2E8B57" }]`.
+ *
+ * An entry carrying a hex is a request to add a colour the curated palette does
+ * not have — the escape hatch. Plain strings must already exist in the palette.
+ */
+export const normalizeValueEntries = (values: unknown): ValueEntry[] => {
+  if (!Array.isArray(values)) {
+    return []
+  }
+  return values
+    .map((v) => {
+      if (typeof v === "string") {
+        return { value: v.trim() }
+      }
+      const entry = v as any
+      const value = String(entry?.value ?? "").trim()
+      const hex = entry?.hex ?? entry?.metadata?.hex
+      return hex ? { value, hex: String(hex).trim() } : { value }
+    })
+    .filter((v) => !!v.value)
+}
+
+const HEX = /^#([0-9a-fA-F]{6})$/
+
+/**
+ * Resolve requested values against a curated option, minting the ones the
+ * partner supplied a hex for.
+ *
+ * The 55 are the shared vocabulary, but a dyer's catalogue is not 55 colours
+ * long — the pre-existing data already carried "Custom Color 105g" and
+ * "Your Pick" because people needed a way through. So a partner MAY add one,
+ * on two conditions: it carries a hex (a colour with no swatch is the bug we
+ * are fixing), and it is stamped `custom` with its author so the picker can
+ * show a partner the 55 plus their own, and never another partner's.
+ *
+ * ⚠️ Minting is two writes. Core's add path reads only `valueEntry.value` and
+ * rebuilds the list as plain strings, so metadata passed inline is DROPPED —
+ * the hex has to be set afterwards, by id.
+ */
+export const resolveCuratedValueIds = async (
+  scope: any,
+  option: { id: string; title: string; values: ProductOptionValue[] },
+  requested: ValueEntry[],
+  partnerId?: string | null
+): Promise<string[]> => {
+  const productService: any = scope.resolve(Modules.PRODUCT)
+  const byName = new Map(option.values.map((v) => [v.value.toLowerCase(), v.id]))
+
+  const known = requested.filter((r) => byName.has(r.value.toLowerCase()))
+  const novel = requested.filter((r) => !byName.has(r.value.toLowerCase()))
+  const withoutHex = novel.filter((r) => !r.hex)
+
+  if (withoutHex.length) {
+    throw new MedusaError(
+      MedusaError.Types.NOT_ALLOWED,
+      `${option.title} is a shared palette — "${withoutHex
+        .map((r) => r.value)
+        .join('", "')}" is not in it. Pick an existing colour, or supply a hex to add it.`
+    )
+  }
+
+  const badHex = novel.filter((r) => !HEX.test(r.hex as string))
+  if (badHex.length) {
+    throw new MedusaError(
+      MedusaError.Types.INVALID_DATA,
+      `A new colour needs a 6-digit hex like #2E8B57 — got "${badHex
+        .map((r) => r.hex)
+        .join('", "')}".`
+    )
+  }
+
+  if (novel.length) {
+    // Keep existing values by id: this call REPLACES the list, and a value
+    // dropped here is a value pulled off every product already using it.
+    await productService.updateProductOptions(option.id, {
+      values: [
+        ...option.values.map((v) => ({ id: v.id, value: v.value })),
+        ...novel.map((r) => ({ value: r.value })),
+      ],
+    })
+
+    const [refreshed] = await productService.listProductOptions(
+      { id: option.id },
+      { relations: ["values"] }
+    )
+
+    for (const entry of novel) {
+      const row = (refreshed?.values ?? []).find(
+        (v: any) => v.value === entry.value
+      )
+      if (!row) {
+        continue
+      }
+      await productService.updateProductOptionValues(row.id, {
+        metadata: {
+          ...(row.metadata ?? {}),
+          hex: entry.hex,
+          custom: true,
+          ...(partnerId ? { partner_id: partnerId } : {}),
+        },
+      })
+      byName.set(entry.value.toLowerCase(), row.id)
+    }
+  }
+
+  return [...known, ...novel].map(
+    (r) => byName.get(r.value.toLowerCase()) as string
+  )
+}

--- a/apps/backend/src/lib/product-options/colour-palette.ts
+++ b/apps/backend/src/lib/product-options/colour-palette.ts
@@ -1,0 +1,74 @@
+/**
+ * The curated colour vocabulary — the whole of it.
+ *
+ * A partner picks from this list and nothing else. The names are what a buyer
+ * reads on the storefront; the hex is what gets drawn as the swatch, and it
+ * rides on `product_option_value.metadata.hex`.
+ *
+ * 🔑 This constant SEEDS the shared `Colour` option row — it is not the runtime
+ * source of truth. Once seeded, the palette lives in the database and is read
+ * back through the API, so an admin can add a 56th colour through
+ * `POST /admin/product-options/:id/values` without a deploy, and the partner
+ * picker and both storefronts pick it up on their next read.
+ */
+export const COLOUR_OPTION_TITLE = "Colour"
+
+export type PaletteColour = { value: string; hex: string }
+
+export const COLOUR_PALETTE: PaletteColour[] = [
+  { value: "Blush Mist", hex: "#FFEBE5" },
+  { value: "Dusty Mauve", hex: "#D8BCCE" },
+  { value: "Cotton Candy", hex: "#FBCDEB" },
+  { value: "Lilac", hex: "#D3A1CE" },
+  { value: "Coral Pink", hex: "#FF8886" },
+  { value: "Rose Quartz", hex: "#FFA4BA" },
+  { value: "Rust", hex: "#A83804" },
+  { value: "Raspberry", hex: "#D62768" },
+  { value: "Peach", hex: "#F7C1A4" },
+  { value: "Apricot", hex: "#E3825F" },
+  { value: "Salmon", hex: "#FA8C84" },
+  { value: "Melon", hex: "#FA8074" },
+  { value: "Tangerine", hex: "#FF6E27" },
+  { value: "Vermilion", hex: "#FF5939" },
+  { value: "Marigold", hex: "#FDC835" },
+  { value: "Amber", hex: "#DA8E2F" },
+  { value: "Copper", hex: "#BF6C3B" },
+  { value: "Mint Cream", hex: "#D5ECE1" },
+  { value: "Aqua", hex: "#7CE0EE" },
+  { value: "Turquoise", hex: "#6DE5D8" },
+  { value: "Periwinkle", hex: "#C7C4EB" },
+  { value: "Chartreuse", hex: "#CEF21F" },
+  { value: "Emerald", hex: "#0EA347" },
+  { value: "Forest Green", hex: "#06622E" },
+  { value: "Teal", hex: "#008489" },
+  { value: "Powder Blue", hex: "#B2C9F5" },
+  { value: "Slate Blue", hex: "#41668B" },
+  { value: "Cerulean", hex: "#189ECE" },
+  { value: "Azure", hex: "#1F6ED4" },
+  { value: "Cobalt", hex: "#1047A0" },
+  { value: "Midnight Blue", hex: "#020766" },
+  { value: "Ink", hex: "#2A2744" },
+  { value: "Heather", hex: "#97819B" },
+  { value: "Plum", hex: "#561543" },
+  { value: "Mulberry", hex: "#5D1648" },
+  { value: "Violet", hex: "#742D9F" },
+  { value: "Brick Red", hex: "#A72C38" },
+  { value: "Oxblood", hex: "#80011F" },
+  { value: "Magenta", hex: "#B0096B" },
+  { value: "Scarlet", hex: "#D02619" },
+  { value: "Maroon", hex: "#59131D" },
+  { value: "Sand", hex: "#E6CA9F" },
+  { value: "Terracotta", hex: "#BF7B61" },
+  { value: "Burnt Orange", hex: "#CC4714" },
+  { value: "Rosewood", hex: "#693E41" },
+  { value: "Chestnut", hex: "#6E391A" },
+  { value: "Sienna", hex: "#A95C26" },
+  { value: "Espresso", hex: "#4A2A14" },
+  { value: "Taupe", hex: "#75594C" },
+  { value: "Bark", hex: "#523F3A" },
+  { value: "Stone Grey", hex: "#7F7F84" },
+  { value: "Pearl Grey", hex: "#D6D6DB" },
+  { value: "Ivory", hex: "#FAF8EF" },
+  { value: "Black", hex: "#000000" },
+  { value: "Camel", hex: "#C79453" },
+]

--- a/apps/backend/src/scripts/seed-colour-palette.ts
+++ b/apps/backend/src/scripts/seed-colour-palette.ts
@@ -1,0 +1,115 @@
+/**
+ * Script: seed (or top up) the shared `Colour` product option.
+ *
+ * Colour is a vocabulary every partner draws from, so it is ONE non-exclusive
+ * option row that products link to — not a per-product option each partner
+ * re-invents. Each product picks its own subset through the
+ * `product_product_option_value` pivot, so two partners sharing the row still
+ * cannot see or use each other's selections.
+ *
+ * 🔑 The hex is the reason this is shared. With per-product options every
+ * product's "Terracotta" is a separate value row needing its own
+ * `metadata.hex` — copies free to drift, and a new product starts with none.
+ * One shared row means 55 values, 55 hexes, defined once.
+ *
+ * Idempotent: re-running adds only missing values and repairs missing/blank
+ * hexes. It never renames or removes anything.
+ *
+ * Usage:
+ *   npx medusa exec src/scripts/seed-colour-palette.ts
+ *   npx medusa exec src/scripts/seed-colour-palette.ts -- --dry-run
+ */
+import type { ExecArgs } from "@medusajs/framework/types"
+import { ContainerRegistrationKeys, Modules } from "@medusajs/framework/utils"
+import {
+  COLOUR_OPTION_TITLE,
+  COLOUR_PALETTE,
+} from "../lib/product-options/colour-palette"
+
+export default async function seedColourPalette({ container, args }: ExecArgs) {
+  const logger = container.resolve(ContainerRegistrationKeys.LOGGER) as any
+  const productService = container.resolve(Modules.PRODUCT) as any
+  const dryRun = ((args as any) || []).includes?.("--dry-run")
+
+  const [existing] = await productService.listProductOptions(
+    { title: COLOUR_OPTION_TITLE, is_exclusive: false },
+    { relations: ["values"] }
+  )
+
+  if (!existing) {
+    logger.info(
+      `[colour-palette] creating shared "${COLOUR_OPTION_TITLE}" with ${COLOUR_PALETTE.length} values`
+    )
+    if (dryRun) {
+      return
+    }
+    // Values carry their hex from birth here. The create path keeps object
+    // values intact; the ADD path further down does not (see below).
+    await productService.createProductOptions({
+      title: COLOUR_OPTION_TITLE,
+      is_exclusive: false,
+      values: COLOUR_PALETTE.map((c) => ({
+        value: c.value,
+        metadata: { hex: c.hex },
+      })),
+    })
+    logger.info(`[colour-palette] created.`)
+    return
+  }
+
+  const byValue = new Map<string, any>(
+    (existing.values ?? []).map((v: any) => [v.value, v])
+  )
+  const missing = COLOUR_PALETTE.filter((c) => !byValue.has(c.value))
+  const wrongHex = COLOUR_PALETTE.filter((c) => {
+    const row = byValue.get(c.value)
+    return row && row.metadata?.hex !== c.hex
+  })
+
+  logger.info(
+    `[colour-palette] "${COLOUR_OPTION_TITLE}" exists with ${byValue.size} values — ${missing.length} missing, ${wrongHex.length} needing a hex`
+  )
+
+  if (dryRun || (!missing.length && !wrongHex.length)) {
+    return
+  }
+
+  if (missing.length) {
+    // updateProductOptions replaces the value list, so send existing values as
+    // ids to keep them (and their variant links) exactly where they are.
+    await productService.updateProductOptions(existing.id, {
+      values: [
+        ...(existing.values ?? []).map((v: any) => ({ id: v.id, value: v.value })),
+        ...missing.map((c) => ({ value: c.value, metadata: { hex: c.hex } })),
+      ],
+    })
+  }
+
+  // Re-read: the values just created need their ids before the hex can be set.
+  const [refreshed] = await productService.listProductOptions(
+    { id: existing.id },
+    { relations: ["values"] }
+  )
+  const refreshedByValue = new Map<string, any>(
+    (refreshed?.values ?? []).map((v: any) => [v.value, v])
+  )
+
+  const repairs = COLOUR_PALETTE.map((c) => {
+    const row = refreshedByValue.get(c.value)
+    if (!row || row.metadata?.hex === c.hex) {
+      return null
+    }
+    return { id: row.id, metadata: { ...(row.metadata ?? {}), hex: c.hex } }
+  }).filter(Boolean) as any[]
+
+  // `updateProductOptionValues` takes (idOrSelector, data) — one call per row.
+  for (const repair of repairs) {
+    await productService.updateProductOptionValues(repair.id, {
+      metadata: repair.metadata,
+    })
+  }
+
+  logger.info(
+    `[colour-palette] added ${missing.length}, set hex on ${repairs.length}.`
+  )
+}


### PR DESCRIPTION
Closes #1521.

## The bug

Product options went global in **Medusa 2.16** — `ProductOption` is a standalone entity linked to products through a many-to-many pivot, with the per-product usable values on `product_product_option_value`. **`product_id` on the create payload has been a no-op ever since**, and the partner routes were never updated.

Both writes lied, on prod:

```
POST .../options {"title":"ZZ Probe Option 8241","values":["A","B"]}
→ 201  { id: "opt_01M0SMCG…", product_id: null }
GET  .../products/prod_01M0A6SN…  → options: [ "Type" ]     ← unchanged

POST .../options/:optionId  {…5 values + "ZZ Probe Value"}
→ 200  response body: 6 values      ← says it saved
GET  .../products/…                 → 5 values   ← didn't
```

That second one is the partner's report that **the save button does nothing**: a 200 whose body shows the new value, while the product reads the pivot and sees the old list. It's also why the assistant's `add_product_option` appeared to succeed and then failed on `add_product_variant` with *"Product has 1 option values but there were 2 provided"*.

Each failed create also minted a detached global row squatting that title platform-wide (unique index on `title` where `is_exclusive = false`). Two orphans — `Color` and `Colour`, both from assistant retries — had made **both spellings uncreatable for every partner**. Removed from prod.

## The design

Measured first: **all 98 in-use options on prod are `is_exclusive: true`**. Nothing anywhere links a global option — exclusive is what core creates for options authored on a product, so it's the whole existing data model.

- **Partner-authored options → exclusive.** Matches the data, and sidesteps the unique-title index so two partners can both have a "Colour".
- **Curated vocabularies → one shared row products LINK with a value subset.** Colour ships with 55 values, each carrying `metadata.hex`. The hex is the reason to share: per-product options mean every product's "Terracotta" is a separate row needing its own hex — copies free to drift, and a new product starts with none.
- **Re-adding a title the product already has merges** its values instead of colliding. Matching is on `(product, title)`, never the global title.

Sharing a row needs guards, so: a shared option **cannot be renamed** from inside one partner's product page, and its values may only be **selected** — unless the partner supplies a hex, which mints the colour stamped `custom` + `partner_id` and hides it from other partners' pickers. The escape hatch exists because the pre-existing data already carried `Custom Color 105g` and `Your Pick`; people needed a way through and invented one.

## Tenancy

Closes a hole of the #1404 shape: both writes validated the store in the URL and then wrote to **any** option id in the database. DELETE hard-deleted the option row, which for a shared option would strip it off another tenant's product. DELETE now unlinks; core garbage-collects an exclusive option once nothing links it.

## MCP

`list_option_palettes` (new, sliced into `catalog`) serves the vocabulary with hexes. `add_product_option`'s description now tells the model to add options *before* `add_product_variant`, that re-calling is safe, and how to pass a hex for a colour outside the palette — the guidance being what steered it wrong in the first place.

## Verification

- `check:prod-build` green; the two files it dirties reverted.
- Integration **21/21**.
- **The two original assertions fail on the old code** (`2 failed, 18 passed`) — they re-read the product after every write. The test this replaced asserted the 201 and the response body and never re-read, which is how it stayed green for months over a dead feature.

## Watch-outs

- ⚠️ Core's add path **drops metadata** — `normalizeProductOptionValueUpdates_` reads only `valueEntry.value` and rebuilds values as plain strings — so the hex is set in a **second write by value id**. Inline returns 200 with no colour.
- ⚠️ Omitting `product_option_value_ids` when linking attaches **every** value on the option — all 55 colours onto a product that asked for two.
- ⚠️ Two same-titled options on one product is broken by construction: core resolves variant options by title.
- No migrations in this PR.

Follow-up in progress: partner-ui swatch picker and swatch rendering in both storefronts. `metadata` is already on the store API's default field set, so those need no further backend change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_0158wJMZ1DmjNxXf5uGuBrQD