### PR TITLE
feat(products): pick colours from a palette, and draw the swatch (#1521)

### DIFF
--- a/apps/partner-ui/src/components/inputs/colour-picker/colour-picker.tsx
+++ b/apps/partner-ui/src/components/inputs/colour-picker/colour-picker.tsx
@@ -1,0 +1,156 @@
+import { Button, Input, Text, Tooltip, clx } from "@medusajs/ui"
+import { useMemo, useState } from "react"
+import { useTranslation } from "react-i18next"
+
+import type { PaletteValue } from "../../../hooks/api/products"
+
+export type ColourEntry = string | { value: string; hex: string }
+
+type ColourPickerProps = {
+  /** Palette values the partner may choose from — curated plus their own. */
+  palette: PaletteValue[]
+  value?: ColourEntry[]
+  onChange: (value: ColourEntry[]) => void
+  disabled?: boolean
+}
+
+const nameOf = (entry: ColourEntry) =>
+  typeof entry === "string" ? entry : entry.value
+
+const HEX = /^#([0-9a-fA-F]{6})$/
+
+/**
+ * Pick colours for a product from the shared palette.
+ *
+ * The swatch is the point: a colour name with no hex is unreadable to a buyer,
+ * which is why a colour added here must carry one. Selection is by name — the
+ * backend resolves names to the shared option's value ids, so the product ends
+ * up linked to the same "Terracotta" every other product uses rather than a
+ * private copy that drifts.
+ */
+export const ColourPicker = ({
+  palette,
+  value = [],
+  onChange,
+  disabled,
+}: ColourPickerProps) => {
+  const { t } = useTranslation()
+  const [customName, setCustomName] = useState("")
+  const [customHex, setCustomHex] = useState("#BF7B61")
+
+  const selected = useMemo(
+    () => new Set(value.map((v) => nameOf(v).toLowerCase())),
+    [value]
+  )
+
+  // Pending additions are not in the palette yet — show them alongside it so a
+  // partner can see and unpick a colour they just added but have not saved.
+  const pending = useMemo(
+    () =>
+      value.filter(
+        (v) =>
+          typeof v !== "string" &&
+          !palette.some(
+            (p) => p.value.toLowerCase() === v.value.toLowerCase()
+          )
+      ) as { value: string; hex: string }[],
+    [value, palette]
+  )
+
+  const toggle = (name: string) => {
+    if (disabled) {
+      return
+    }
+    if (selected.has(name.toLowerCase())) {
+      onChange(value.filter((v) => nameOf(v).toLowerCase() !== name.toLowerCase()))
+      return
+    }
+    onChange([...value, name])
+  }
+
+  const addCustom = () => {
+    const name = customName.trim()
+    if (!name || !HEX.test(customHex) || selected.has(name.toLowerCase())) {
+      return
+    }
+    onChange([...value, { value: name, hex: customHex }])
+    setCustomName("")
+  }
+
+  const swatches: { value: string; hex: string | null; custom: boolean }[] = [
+    ...palette,
+    ...pending.map((p) => ({ value: p.value, hex: p.hex, custom: true })),
+  ]
+
+  return (
+    <div className="flex flex-col gap-y-3">
+      <div className="flex flex-wrap gap-2">
+        {swatches.map((swatch) => {
+          const isSelected = selected.has(swatch.value.toLowerCase())
+          return (
+            <Tooltip key={swatch.value} content={swatch.value}>
+              <button
+                type="button"
+                aria-label={swatch.value}
+                aria-pressed={isSelected}
+                disabled={disabled}
+                onClick={() => toggle(swatch.value)}
+                className={clx(
+                  "size-7 rounded-full border transition-all",
+                  "border-ui-border-base",
+                  isSelected &&
+                    "ring-2 ring-ui-fg-interactive ring-offset-2 ring-offset-ui-bg-base",
+                  disabled && "cursor-not-allowed opacity-50"
+                )}
+                style={{ backgroundColor: swatch.hex ?? "transparent" }}
+              />
+            </Tooltip>
+          )
+        })}
+      </div>
+
+      {!!value.length && (
+        <Text size="small" className="text-ui-fg-subtle">
+          {value.map((v) => nameOf(v)).join(", ")}
+        </Text>
+      )}
+
+      <div className="flex items-center gap-x-2">
+        <Input
+          size="small"
+          placeholder={t(
+            "products.fields.options.customColourPlaceholder",
+            "Add another colour"
+          )}
+          value={customName}
+          disabled={disabled}
+          onChange={(e) => setCustomName(e.target.value)}
+          onKeyDown={(e) => {
+            if (e.key === "Enter") {
+              // Otherwise Enter submits the drawer with a half-typed colour.
+              e.preventDefault()
+              addCustom()
+            }
+          }}
+        />
+        <input
+          type="color"
+          aria-label={t("products.fields.options.customColourHex", "Colour")}
+          value={customHex}
+          disabled={disabled}
+          onChange={(e) => setCustomHex(e.target.value)}
+          className="size-8 shrink-0 cursor-pointer rounded-md border border-ui-border-base bg-ui-bg-field p-0.5"
+        />
+        <Button
+          type="button"
+          size="small"
+          variant="secondary"
+          disabled={disabled || !customName.trim()}
+          onClick={addCustom}
+        >
+          {t("actions.add", "Add")}
+        </Button>
+      </div>
+    </div>
+  )
+}

--- a/apps/partner-ui/src/components/inputs/colour-picker/index.ts
+++ b/apps/partner-ui/src/components/inputs/colour-picker/index.ts
@@ -1,0 +1,1 @@
+export * from "./colour-picker"

--- a/apps/partner-ui/src/hooks/api/products.tsx
+++ b/apps/partner-ui/src/hooks/api/products.tsx
@@ -983,3 +983,66 @@ export const useUpsertProductSpecFor = (
     ...options,
   })
 }
+
+const OPTION_PALETTES_QUERY_KEY = "option_palettes" as const
+export const optionPalettesQueryKeys = queryKeysFactory(
+  OPTION_PALETTES_QUERY_KEY
+)
+
+export type PaletteValue = {
+  id: string
+  value: string
+  hex: string | null
+  custom: boolean
+}
+
+export type OptionPalette = {
+  id: string
+  title: string
+  values: PaletteValue[]
+}
+
+/**
+ * The curated option vocabularies — Colour and its palette today.
+ *
+ * The backend returns the shared values plus THIS partner's own additions and
+ * nobody else's, so the list can be rendered as-is. Values carry their hex, so
+ * a swatch needs no second request.
+ */
+export const useOptionPalettes = (
+  options?: Omit<
+    UseQueryOptions<
+      { palettes: OptionPalette[] },
+      FetchError,
+      { palettes: OptionPalette[] },
+      QueryKey
+    >,
+    "queryFn" | "queryKey"
+  >
+) => {
+  const { data, ...rest } = useQuery({
+    queryKey: optionPalettesQueryKeys.lists(),
+    queryFn: () =>
+      sdk.client.fetch<{ palettes: OptionPalette[] }>(
+        "/partners/option-palettes",
+        { method: "GET" }
+      ),
+    staleTime: 5 * 60 * 1000,
+    ...options,
+  })
+
+  return { ...data, ...rest }
+}
+
+/**
+ * The palette for a given option title, or null when the partner is authoring
+ * an option of their own (Material, Spin Type) and should get a free-text list.
+ */
+export const usePaletteForTitle = (title?: string) => {
+  const { palettes, isPending } = useOptionPalettes()
+  const normalized = (title ?? "").trim().toLowerCase()
+  const palette =
+    (palettes ?? []).find((p) => p.title.trim().toLowerCase() === normalized) ??
+    null
+  return { palette, isPending }
+}

--- a/apps/partner-ui/src/routes/orders/order-create-claim/components/claim-create-form/claim-create-form.tsx
+++ b/apps/partner-ui/src/routes/orders/order-create-claim/components/claim-create-form/claim-create-form.tsx
@@ -528,9 +528,12 @@ export const ClaimCreateForm = ({
         .filter(Boolean)
 
       const variants = (
-        await sdk.client.fetch<any>("/partners/product-variants", { method: "GET", query: {
-          id: variantIds,
-          fields: "*inventory.location_levels",
+        await sdk.client.fetch<any>("/partners/product-variants", {
+          method: "GET",
+          query: {
+            id: variantIds,
+            fields: "*inventory.location_levels",
+          },
         })
       ).variants
 

--- a/apps/partner-ui/src/routes/orders/order-create-claim/components/claim-create-form/claim-outbound-section.tsx
+++ b/apps/partner-ui/src/routes/orders/order-create-claim/components/claim-create-form/claim-outbound-section.tsx
@@ -270,9 +270,12 @@ export const ClaimOutboundSection = ({
         .filter(Boolean)
 
       const variants = (
-        await sdk.client.fetch<any>("/partners/product-variants", { method: "GET", query: {
-          id: variantIds,
-          fields: "*inventory.location_levels",
+        await sdk.client.fetch<any>("/partners/product-variants", {
+          method: "GET",
+          query: {
+            id: variantIds,
+            fields: "*inventory.location_levels",
+          },
         })
       ).variants
 

--- a/apps/partner-ui/src/routes/orders/order-create-exchange/components/exchange-create-form/exchange-inbound-section.tsx
+++ b/apps/partner-ui/src/routes/orders/order-create-exchange/components/exchange-create-form/exchange-inbound-section.tsx
@@ -317,9 +317,12 @@ export const ExchangeInboundSection = ({
         .filter(Boolean)
 
       const variants = (
-        await sdk.client.fetch<any>("/partners/product-variants", { method: "GET", query: {
-          id: variantIds,
-          fields: "*inventory.location_levels",
+        await sdk.client.fetch<any>("/partners/product-variants", {
+          method: "GET",
+          query: {
+            id: variantIds,
+            fields: "*inventory.location_levels",
+          },
         })
       ).variants
 

--- a/apps/partner-ui/src/routes/orders/order-create-exchange/components/exchange-create-form/exchange-outbound-section.tsx
+++ b/apps/partner-ui/src/routes/orders/order-create-exchange/components/exchange-create-form/exchange-outbound-section.tsx
@@ -278,9 +278,12 @@ export const ExchangeOutboundSection = ({
         .filter(Boolean)
 
       const variants = (
-        await sdk.client.fetch<any>("/partners/product-variants", { method: "GET", query: {
-          id: variantIds,
-          fields: "*inventory.location_levels",
+        await sdk.client.fetch<any>("/partners/product-variants", {
+          method: "GET",
+          query: {
+            id: variantIds,
+            fields: "*inventory.location_levels",
+          },
         })
       ).variants
 

--- a/apps/partner-ui/src/routes/products/product-create-option/components/create-product-option-form/create-product-option-form.tsx
+++ b/apps/partner-ui/src/routes/products/product-create-option/components/create-product-option-form/create-product-option-form.tsx
@@ -9,15 +9,29 @@ import { Form } from "../../../../../components/common/form"
 import { ChipInput } from "../../../../../components/inputs/chip-input"
 import { RouteDrawer, useRouteModal } from "../../../../../components/modals"
 import { KeyboundForm } from "../../../../../components/utilities/keybound-form"
-import { useCreateProductOption } from "../../../../../hooks/api/products"
+import {
+  useCreateProductOption,
+  usePaletteForTitle,
+} from "../../../../../hooks/api/products"
+import { ColourPicker } from "../../../../../components/inputs/colour-picker"
 
 type EditProductOptionsFormProps = {
   product: HttpTypes.AdminProduct
 }
 
+// A colour the partner adds arrives as { value, hex } — the backend needs the
+// hex to store a swatch, and a plain string would be refused as "not in the
+// palette". Existing values stay plain strings.
 const CreateProductOptionSchema = z.object({
   title: z.string().min(1),
-  values: z.array(z.string()).optional(),
+  values: z
+    .array(
+      z.union([
+        z.string(),
+        z.object({ value: z.string(), hex: z.string() }),
+      ])
+    )
+    .optional(),
 })
 
 export const CreateProductOptionForm = ({
@@ -33,6 +47,10 @@ export const CreateProductOptionForm = ({
     },
     resolver: zodResolver(CreateProductOptionSchema),
   })
+
+  // Watch the title so typing "Colour" swaps the chip list for the palette.
+  const titleValue = form.watch("title")
+  const { palette } = usePaletteForTitle(titleValue)
 
   const { mutateAsync, isPending } = useCreateProductOption(product.id)
 
@@ -91,12 +109,24 @@ export const CreateProductOptionForm = ({
                     {t("products.fields.options.variations")}
                   </Form.Label>
                   <Form.Control>
-                    <ChipInput
-                      {...field}
-                      placeholder={t(
-                        "products.fields.options.variantionsPlaceholder"
-                      )}
-                    />
+                    {/* Colour is a shared vocabulary, so it gets swatches
+                        rather than free text — a typed "teal" would be a
+                        colour with no hex, which renders as nothing on the
+                        storefront. Any other option stays a plain chip list. */}
+                    {palette ? (
+                      <ColourPicker
+                        palette={palette.values}
+                        value={field.value}
+                        onChange={field.onChange}
+                      />
+                    ) : (
+                      <ChipInput
+                        {...field}
+                        placeholder={t(
+                          "products.fields.options.variantionsPlaceholder"
+                        )}
+                      />
+                    )}
                   </Form.Control>
                   <Form.ErrorMessage />
                 </Form.Item>

--- a/apps/partner-ui/src/routes/products/product-edit-option/components/edit-product-option-form/edit-product-option-form.tsx
+++ b/apps/partner-ui/src/routes/products/product-edit-option/components/edit-product-option-form/edit-product-option-form.tsx
@@ -9,19 +9,36 @@ import { Form } from "../../../../../components/common/form"
 import { ChipInput } from "../../../../../components/inputs/chip-input"
 import { RouteDrawer, useRouteModal } from "../../../../../components/modals"
 import { KeyboundForm } from "../../../../../components/utilities/keybound-form"
-import { useUpdateProductOption } from "../../../../../hooks/api/products"
+import {
+  usePaletteForTitle,
+  useUpdateProductOption,
+} from "../../../../../hooks/api/products"
+import { ColourPicker } from "../../../../../components/inputs/colour-picker"
 
 type EditProductOptionFormProps = {
   option: HttpTypes.AdminProductOption
+  /** From the route — `option.product_id` is null since options went global. */
+  productId: string
 }
 
+// A colour the partner adds arrives as { value, hex } — the backend needs the
+// hex to store a swatch, and a plain string would be refused as "not in the
+// palette". Existing values stay plain strings.
 const CreateProductOptionSchema = z.object({
   title: z.string().min(1),
-  values: z.array(z.string()).optional(),
+  values: z
+    .array(
+      z.union([
+        z.string(),
+        z.object({ value: z.string(), hex: z.string() }),
+      ])
+    )
+    .optional(),
 })
 
 export const CreateProductOptionForm = ({
   option,
+  productId,
 }: EditProductOptionFormProps) => {
   const { t } = useTranslation()
   const { handleSuccess } = useRouteModal()
@@ -34,10 +51,10 @@ export const CreateProductOptionForm = ({
     resolver: zodResolver(CreateProductOptionSchema),
   })
 
-  const { mutateAsync, isPending } = useUpdateProductOption(
-    option.product_id,
-    option.id
-  )
+  const titleValue = form.watch("title")
+  const { palette } = usePaletteForTitle(titleValue)
+
+  const { mutateAsync, isPending } = useUpdateProductOption(productId, option.id)
 
   const handleSubmit = form.handleSubmit(async (values) => {
     mutateAsync(
@@ -92,12 +109,22 @@ export const CreateProductOptionForm = ({
                     {t("products.fields.options.variations")}
                   </Form.Label>
                   <Form.Control>
-                    <ChipInput
-                      {...field}
-                      placeholder={t(
-                        "products.fields.options.variantionsPlaceholder"
-                      )}
-                    />
+                    {/* Swatches for the shared Colour vocabulary, free text
+                        for an option the partner authored themselves. */}
+                    {palette ? (
+                      <ColourPicker
+                        palette={palette.values}
+                        value={field.value}
+                        onChange={field.onChange}
+                      />
+                    ) : (
+                      <ChipInput
+                        {...field}
+                        placeholder={t(
+                          "products.fields.options.variantionsPlaceholder"
+                        )}
+                      />
+                    )}
                   </Form.Control>
                   <Form.ErrorMessage />
                 </Form.Item>

--- a/apps/partner-ui/src/routes/products/product-edit-option/product-edit-option.tsx
+++ b/apps/partner-ui/src/routes/products/product-edit-option/product-edit-option.tsx
@@ -29,7 +29,12 @@ export const ProductEditOption = () => {
       <RouteDrawer.Header>
         <Heading>{t("products.options.edit.header")}</Heading>
       </RouteDrawer.Header>
-      {option && <CreateProductOptionForm option={option} />}
+      {option && (
+        // Pass the product id from the route: `option.product_id` is null on
+        // every option since 2.16 made options global, so the form cannot get
+        // it from the option itself.
+        <CreateProductOptionForm option={option} productId={id!} />
+      )}
     </RouteDrawer>
   )
 }

--- a/apps/storefront/src/modules/products/components/product-actions/option-select.tsx
+++ b/apps/storefront/src/modules/products/components/product-actions/option-select.tsx
@@ -11,6 +11,21 @@ type OptionSelectProps = {
   "data-testid"?: string
 }
 
+/**
+ * A colour carries its hex on the option value's `metadata`, which the Store
+ * API already returns on its default field set — so the swatch costs no extra
+ * request and no backend change.
+ *
+ * The name stays next to the swatch rather than being replaced by it: a bare
+ * circle is unreadable to a screen reader and ambiguous between close shades,
+ * and any value without a hex (Size, Material, or a colour an admin has not
+ * given one yet) still has to render as a perfectly ordinary button.
+ */
+const hexOf = (value: unknown): string | null => {
+  const hex = (value as any)?.metadata?.hex
+  return typeof hex === "string" && /^#([0-9a-fA-F]{6})$/.test(hex) ? hex : null
+}
+
 const OptionSelect: React.FC<OptionSelectProps> = ({
   option,
   current,
@@ -19,7 +34,10 @@ const OptionSelect: React.FC<OptionSelectProps> = ({
   "data-testid": dataTestId,
   disabled,
 }) => {
-  const filteredOptions = (option.values ?? []).map((v) => v.value)
+  const filteredOptions = (option.values ?? []).map((v) => ({
+    value: v.value,
+    hex: hexOf(v),
+  }))
 
   return (
     <div className="flex flex-col gap-y-3">
@@ -31,20 +49,28 @@ const OptionSelect: React.FC<OptionSelectProps> = ({
         {filteredOptions.map((v) => {
           return (
             <button
-              onClick={() => updateOption(option.id, v)}
-              key={v}
+              onClick={() => updateOption(option.id, v.value)}
+              key={v.value}
               className={clx(
                 "border-ui-border-base bg-ui-bg-subtle border text-small-regular h-10 rounded-rounded p-2 flex-1 ",
                 {
-                  "border-ui-border-interactive": v === current,
+                  "border-ui-border-interactive": v.value === current,
                   "hover:shadow-elevation-card-rest transition-shadow ease-in-out duration-150":
-                    v !== current,
-                }
+                    v.value !== current,
+                },
+                v.hex && "flex items-center justify-center gap-x-2"
               )}
               disabled={disabled}
               data-testid="option-button"
             >
-              {v}
+              {v.hex && (
+                <span
+                  aria-hidden="true"
+                  className="inline-block size-4 shrink-0 rounded-full border border-ui-border-base"
+                  style={{ backgroundColor: v.hex }}
+                />
+              )}
+              {v.value}
             </button>
           )
         })}


### PR DESCRIPTION
The partner + storefront half of #1521. Backend landed in #1522.

## Partner UI

Typing **Colour** as the option title swaps the free-text chip list for a swatch grid. Every other option keeps the chip list — Material and Spin Type are the partner's own vocabulary and always were.

A colour outside the palette is added with the colour input beside the field, which sends `{ value, hex }`. The backend refuses a bare name, and rightly: a colour with no hex renders as nothing on the storefront.

## Storefronts

Both render the swatch **next to** the value name, not instead of it — a bare circle is unreadable to a screen reader and ambiguous between close shades, and any value with no hex has to keep rendering as an ordinary button.

The hex rides on the option value's `metadata`, which the Store API already returns on its **default field set**, so neither app needed a backend change. `apps/storefront-starter` shipped as [nextjs-starter-medusa#28](https://github.com/Jaal-Yantra-Textiles/nextjs-starter-medusa/pull/28); the submodule pointer moves to the squashed commit on its `main` (`9d953c2`).

## The one that would have gone unnoticed

The **edit-option form built its URL from `option.product_id`**, which has been `null` on every option since 2.16 made options global. It was harmless while the route ignored the product id; with #1522's tenant guard it becomes `products/null/...` and a 404 — the fix would have shipped and broken editing. The form now takes the product id from the route.

## Also

Four unbalanced `sdk.client.fetch(…{ query: {` calls in the claim/exchange forms. They're unreachable — `get-route.map.tsx` is not the map this app mounts — but they're **syntax errors**, and they were what stood between `apps/partner-ui` and a typecheck gate (#1482). Now that they're gone, `tsc --noEmit` can become a real check on this app.

## Verification

- partner-ui `vite build` green.
- storefront-starter `next build` green; no new `tsc` errors in the changed file (179 are pre-existing).
- ⚠️ **Not clicked yet** — `apps/partner-ui` still has no CI (#1482). The picker needs a real click once the palette is seeded on prod.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_0158wJMZ1DmjNxXf5uGuBrQD