### PR TITLE
feat(quotes,shipping): make `active` mean active, state the size, split export origins (#1510, #1517, #1498)

### DIFF
--- a/apps/backend/src/admin/components/forms/product-spec/product-spec-edit-form.tsx
+++ b/apps/backend/src/admin/components/forms/product-spec/product-spec-edit-form.tsx
@@ -37,6 +37,9 @@ const EMPTY: ProductSpecPayload = {
   weave_technique: null,
   weave_label: null,
   params: null,
+  finished_length_cm: null,
+  finished_width_cm: null,
+  size_label: null,
   finishes: [],
   notes: null,
   accepting_custom_orders: false,
@@ -68,6 +71,9 @@ export const ProductSpecEditForm = () => {
       weave_technique: spec.weave_technique ?? null,
       weave_label: spec.weave_label ?? null,
       params: spec.params ?? null,
+      finished_length_cm: spec.finished_length_cm ?? null,
+      finished_width_cm: spec.finished_width_cm ?? null,
+      size_label: spec.size_label ?? null,
       finishes: spec.finishes ?? [],
       notes: spec.notes ?? null,
       accepting_custom_orders: !!spec.accepting_custom_orders,
@@ -97,6 +103,9 @@ export const ProductSpecEditForm = () => {
     const payload: ProductSpecPayload = {
       ...value,
       weave_label: value.weave_label?.trim() ? value.weave_label.trim() : null,
+      // An emptied box means "no size", not an empty string the validator will
+      // store and every surface will then render as a blank "Size:" line.
+      size_label: value.size_label?.trim() ? value.size_label.trim() : null,
       notes: value.notes?.trim() ? value.notes.trim() : null,
       colors: (value.colors ?? []).filter((c) => c.name.trim()),
       fields: (value.fields ?? []).filter((f) => (f.label ?? f.key).trim()),

--- a/apps/backend/src/admin/components/product-spec-form.tsx
+++ b/apps/backend/src/admin/components/product-spec-form.tsx
@@ -235,6 +235,75 @@ export const ProductSpecForm = ({
           </div>
         </div>
 
+        {/* The FINISHED piece.
+            🔴 Outside the technique block on purpose: size is a property of the
+            article, not of how it was woven, so a product with no technique
+            still has one. `loom_width_cm` is a different measurement — the
+            cloth ON the loom, before it is cut, hemmed and washed. */}
+        <div className="grid gap-4 md:grid-cols-3">
+          <div className="flex flex-col gap-y-2">
+            <Label size="small" weight="plus">
+              Size name
+            </Label>
+            <Input
+              placeholder="Stole"
+              value={value.size_label ?? ""}
+              onChange={(e) => patch({ size_label: e.target.value })}
+            />
+          </div>
+          <div className="flex flex-col gap-y-2">
+            <Label size="small" weight="plus">
+              Finished length
+            </Label>
+            <div className="flex items-center gap-x-2">
+              <Input
+                type="number"
+                min={1}
+                max={2000}
+                placeholder="200"
+                value={value.finished_length_cm ?? ""}
+                onChange={(e) =>
+                  patch({
+                    finished_length_cm: e.target.value
+                      ? Number(e.target.value)
+                      : null,
+                  })
+                }
+              />
+              <Text size="xsmall" className="text-ui-fg-muted">
+                cm
+              </Text>
+            </div>
+          </div>
+          <div className="flex flex-col gap-y-2">
+            <Label size="small" weight="plus">
+              Finished width
+            </Label>
+            <div className="flex items-center gap-x-2">
+              <Input
+                type="number"
+                min={1}
+                max={2000}
+                placeholder="70"
+                value={value.finished_width_cm ?? ""}
+                onChange={(e) =>
+                  patch({
+                    finished_width_cm: e.target.value
+                      ? Number(e.target.value)
+                      : null,
+                  })
+                }
+              />
+              <Text size="xsmall" className="text-ui-fg-muted">
+                cm
+              </Text>
+            </div>
+          </div>
+          <Text size="xsmall" className="text-ui-fg-muted md:col-span-3">
+            Shown on the product page and on every quote for this product.
+          </Text>
+        </div>
+
         {!!technique?.presets.length && (
           <div className="flex flex-wrap items-center gap-2">
             <Text size="xsmall" className="text-ui-fg-muted">

--- a/apps/backend/src/admin/hooks/api/product-spec.ts
+++ b/apps/backend/src/admin/hooks/api/product-spec.ts
@@ -86,6 +86,15 @@ export type ProductSpec = {
   weave_technique?: string | null
   weave_label?: string | null
   params?: Record<string, number> | null
+  /**
+   * The FINISHED piece, in centimetres. NOT a weave param — those are keyed to
+   * the chosen technique and rejected without one; a size belongs to the
+   * article and survives a product that has no weave at all.
+   */
+  finished_length_cm?: number | null
+  finished_width_cm?: number | null
+  /** What the trade calls that size — "Stole", "Full shawl". */
+  size_label?: string | null
   finishes?: string[] | null
   notes?: string | null
   accepting_custom_orders?: boolean | null

--- a/apps/backend/src/admin/hooks/api/quotes.ts
+++ b/apps/backend/src/admin/hooks/api/quotes.ts
@@ -82,7 +82,14 @@ export type AdminQuote = Record<string, any> & {
   quoted_duty_rate?: number | null
   quoted_import_tax_rate?: number | null
   quoted_duty_basis?: string | null
+  /** The STORED column. `expired` is never one of its values — see below. */
   status?: "active" | "revoked" | "superseded"
+  /**
+   * What `status` means today (#1510). Computed by the route from `status` and
+   * `expires_at`, so an expired quote stops reading `active` on every screen
+   * that shows the word. Render this; keep `status` for what the row stores.
+   */
+  status_effective?: "active" | "expired" | "revoked" | "superseded"
   expires_at?: string | null
   /**
    * Terms and acceptance (#1439 S11). `deposit_pct` is null when nobody named

--- a/apps/backend/src/admin/routes/quotes/[id]/page.tsx
+++ b/apps/backend/src/admin/routes/quotes/[id]/page.tsx
@@ -191,20 +191,35 @@ const QuoteDetailPage = () => {
           ? "red"
           : "grey"
 
-  const isRevoked = quote.status === "revoked"
+  /**
+   * #1510 — the EFFECTIVE status, so this page and the list it was opened from
+   * read the same word. `status` alone said "active" on a quote whose link the
+   * buyer page was already refusing to price.
+   */
+  const effectiveStatus = quote.status_effective ?? quote.status
+
+  const isRevoked = effectiveStatus === "revoked"
   /**
    * A newer quote for this buyer expired this one's price list (#1435). It is
    * not revocable any more — there is nothing left to delete — but it is also
    * not a withdrawal, so it must not read as one.
    */
-  const isSuperseded = quote.status === "superseded"
-  const isDead = isRevoked || isSuperseded
+  const isSuperseded = effectiveStatus === "superseded"
+  /**
+   * Its clock ran out. Like `superseded`, nothing went wrong and nobody pulled
+   * it — but the price list carries a native `ends_at`, so there is likewise
+   * nothing left for Revoke to do.
+   */
+  const isExpired = effectiveStatus === "expired"
+  const isDead = isRevoked || isSuperseded || isExpired
 
-  const statusColor: "green" | "red" | "orange" = isRevoked
+  const statusColor: "green" | "red" | "orange" | "grey" = isRevoked
     ? "red"
     : isSuperseded
       ? "orange"
-      : "green"
+      : isExpired
+        ? "grey"
+        : "green"
   /**
    * Acceptance does not replace the status — an accepted quote is still active
    * until it is paid, and collapsing the two hides which of them the buyer is
@@ -214,9 +229,11 @@ const QuoteDetailPage = () => {
     ? "Revoked"
     : isSuperseded
       ? "Superseded"
-      : quote.accepted_at
-        ? "Active · Accepted"
-        : "Active"
+      : isExpired
+        ? "Expired"
+        : quote.accepted_at
+          ? "Active · Accepted"
+          : "Active"
 
   /**
    * 🔴 Revoke is the only action, and it is destructive: it DELETES the price

--- a/apps/backend/src/admin/routes/quotes/page.tsx
+++ b/apps/backend/src/admin/routes/quotes/page.tsx
@@ -44,19 +44,30 @@ const money = (amount?: number | null, currency?: string) =>
  * Colouring it like a revocation would tell an operator the partner pulled the
  * offer, which is a different and wrong story.
  */
+const STATUS_LABELS: Record<string, string> = {
+  active: "Active",
+  expired: "Expired",
+  superseded: "Superseded",
+  revoked: "Revoked",
+}
+
+/**
+ * 🔴 `expired` is not red either, and for the same reason as `superseded`:
+ * nothing went wrong, the offer simply ran out its clock. Grey says "over"
+ * without saying "withdrawn".
+ */
+const STATUS_COLORS: Record<string, "green" | "orange" | "red" | "grey"> = {
+  active: "green",
+  expired: "grey",
+  superseded: "orange",
+  revoked: "red",
+}
+
 const StatusCell = ({ status }: { status?: string }) => {
   const value = String(status || "active")
   return (
-    <StatusBadge
-      color={
-        value === "active" ? "green" : value === "superseded" ? "orange" : "red"
-      }
-    >
-      {value === "active"
-        ? "Active"
-        : value === "superseded"
-          ? "Superseded"
-          : "Revoked"}
+    <StatusBadge color={STATUS_COLORS[value] ?? "red"}>
+      {STATUS_LABELS[value] ?? value}
     </StatusBadge>
   )
 }
@@ -140,8 +151,16 @@ const QuotesPage = () => {
       }),
       columnHelper.accessor("status", {
         header: "Status",
+        // Sorts on the STORED column, because that is the one the database can
+        // order by. The badge shows the effective word (#1510).
         enableSorting: true,
-        cell: ({ getValue }) => <StatusCell status={getValue() as string} />,
+        cell: ({ row }) => (
+          <StatusCell
+            status={
+              (row.original as any).status_effective ?? row.original.status
+            }
+          />
+        ),
       }),
       columnHelper.accessor("expires_at", {
         header: "Expires",
@@ -171,7 +190,9 @@ const QuotesPage = () => {
                   // DELETES a live price list, and a one-click destructive
                   // action in a row menu is how that gets done by accident.
                   to: (quote: AdminQuote) => `/quotes/${quote.id}`,
-                  disabled: row.original.status !== "active",
+                  disabled:
+                    ((row.original as any).status_effective ??
+                      row.original.status) !== "active",
                   disabledTooltip:
                     "Only an active quote can be revoked — this one is already dead.",
                 },
@@ -191,6 +212,9 @@ const QuotesPage = () => {
         label: "Status",
         options: [
           { label: "Active", value: "active" },
+          // #1510 — `expired` is not a stored status; the list route translates
+          // it into "active, and the date has passed".
+          { label: "Expired", value: "expired" },
           { label: "Superseded", value: "superseded" },
           { label: "Revoked", value: "revoked" },
         ],

--- a/apps/backend/src/admin/widgets/stock-location-ownership.tsx
+++ b/apps/backend/src/admin/widgets/stock-location-ownership.tsx
@@ -25,6 +25,8 @@ type OwnershipRow = {
   id: string
   stock_location_id: string
   is_core: boolean
+  /** #1498 — null means "nobody has decided", which is not the same as false. */
+  is_export_origin?: boolean | null
   note?: string | null
 }
 
@@ -48,6 +50,17 @@ const LocationOwnershipWidget = ({
     (r) => r.stock_location_id === locationId
   )
   const isCore = Boolean(row?.is_core)
+  const exportState = row?.is_export_origin
+  const isExportOrigin = exportState === true
+  /**
+   * Nobody on the platform has stated an export answer yet, so the relay is
+   * still inferring hubs from `is_core`. Worth saying out loud on this page: it
+   * is why a location that holds stock but cannot export is currently offered
+   * as an export origin.
+   */
+  const inferring = !(ownership?.location_ownership ?? []).some(
+    (r) => r.is_export_origin === true || r.is_export_origin === false
+  )
 
   const { mutate, isPending } = useMutation({
     mutationFn: async (next: boolean) =>
@@ -57,6 +70,10 @@ const LocationOwnershipWidget = ({
         body: {
           stock_location_id: locationId,
           is_core: next,
+          // 🔑 `is_export_origin` is deliberately NOT sent. Omitted means
+          // "leave the stored answer alone" — sending `false` here would make
+          // an unrelated stock edit silently switch the whole platform off the
+          // inference (see the validator).
           note: next ? "marked ours from the location page" : "marked not ours",
         },
       }),
@@ -70,6 +87,31 @@ const LocationOwnershipWidget = ({
     },
     onError: (error: any) => {
       toast.error(error?.message || "Failed to update location ownership")
+    },
+  })
+
+  const exportMutation = useMutation({
+    mutationFn: async (next: boolean) =>
+      sdk.client.fetch("/admin/location-ownership", {
+        method: "POST",
+        body: {
+          stock_location_id: locationId,
+          // The route upserts the whole row, so the stock answer has to travel
+          // with it or the toggle would silently un-mark an owned location.
+          is_core: isCore,
+          is_export_origin: next,
+        },
+      }),
+    onSuccess: (_res, next) => {
+      queryClient.invalidateQueries({ queryKey: QUERY_KEY })
+      toast.success(
+        next
+          ? "Exports may leave from here"
+          : "Exports will never be routed through here"
+      )
+    },
+    onError: (error: any) => {
+      toast.error(error?.message || "Failed to update the export setting")
     },
   })
 
@@ -104,6 +146,53 @@ const LocationOwnershipWidget = ({
             checked={isCore}
             disabled={isPending || !locationId}
             onCheckedChange={(next) => mutate(next)}
+          />
+        )}
+      </div>
+
+      {/* #1498 — a SECOND question, not the same one.
+          "We own the stock here" and "an export may leave from here" were one
+          flag, and the freight relay read the first as the second. Prod's two
+          owned locations include Dharamshala, which is not a hub — so a
+          shipment was relayed somewhere it cannot be exported from, priced as
+          though it had worked. */}
+      <div className="flex items-center justify-between gap-x-4 px-6 py-4">
+        <div>
+          <div className="flex items-center gap-x-2">
+            <Text size="small" weight="plus">
+              Export origin
+            </Text>
+            {isLoading ? null : (
+              <Badge color={isExportOrigin ? "green" : "grey"}>
+                {exportState === true
+                  ? "Exports from here"
+                  : exportState === false
+                    ? "Never"
+                    : "Not decided"}
+              </Badge>
+            )}
+          </div>
+          <Text size="small" className="text-ui-fg-subtle">
+            {isExportOrigin
+              ? "International quotes a partner's own pin cannot be rated for will be routed through here."
+              : "International shipments are never routed through this location."}
+          </Text>
+          {inferring && !isLoading ? (
+            <Text size="small" className="text-ui-fg-muted">
+              Nobody has answered this for any location yet, so exports are
+              still being routed through every location marked “ours” — which
+              includes warehouses that hold stock but cannot export. Answering
+              it here, for any one location, switches that guess off everywhere.
+            </Text>
+          ) : null}
+        </div>
+        {isLoading ? (
+          <Skeleton className="h-6 w-10" />
+        ) : (
+          <Switch
+            checked={isExportOrigin}
+            disabled={exportMutation.isPending || !locationId}
+            onCheckedChange={(next) => exportMutation.mutate(next)}
           />
         )}
       </div>

--- a/apps/backend/src/api/admin/location-ownership/route.ts
+++ b/apps/backend/src/api/admin/location-ownership/route.ts
@@ -24,7 +24,7 @@ export const GET = async (req: MedusaRequest, res: MedusaResponse) => {
  * rather than toggling anything inferred.
  */
 export const POST = async (req: MedusaRequest, res: MedusaResponse) => {
-  const { stock_location_id, is_core, note } =
+  const { stock_location_id, is_core, is_export_origin, note } =
     req.validatedBody as AdminPostLocationOwnershipReq
 
   const service: any = req.scope.resolve(LOCATION_OWNERSHIP_MODULE)
@@ -37,11 +37,15 @@ export const POST = async (req: MedusaRequest, res: MedusaResponse) => {
     ? await service.updateLocationOwnerships({
         id: existing.id,
         is_core,
+        // Omitted means "leave the stored answer alone"; an explicit null
+        // clears it back to undecided. See the validator.
+        ...(is_export_origin !== undefined ? { is_export_origin } : {}),
         ...(note !== undefined ? { note } : {}),
       })
     : await service.createLocationOwnerships({
         stock_location_id,
         is_core,
+        is_export_origin: is_export_origin ?? null,
         note: note ?? null,
       })
 

--- a/apps/backend/src/api/admin/location-ownership/validators.ts
+++ b/apps/backend/src/api/admin/location-ownership/validators.ts
@@ -3,6 +3,16 @@ import { z } from "@medusajs/framework/zod"
 export const AdminPostLocationOwnershipReq = z.object({
   stock_location_id: z.string().min(1),
   is_core: z.boolean(),
+  /**
+   * Whether an export may LEAVE from here (#1498).
+   *
+   * 🔑 OPTIONAL, and `null` is a real value distinct from omitting it. Omitted
+   * leaves whatever is stored alone; `null` clears the answer back to "nobody
+   * has decided", which puts this row back under the `is_core` inference. A
+   * caller that always sent `false` by default would silently switch the whole
+   * platform off the inference on the first unrelated ownership edit.
+   */
+  is_export_origin: z.boolean().nullable().optional(),
   note: z.string().nullable().optional(),
 })
 

--- a/apps/backend/src/api/admin/quotes/[id]/route.ts
+++ b/apps/backend/src/api/admin/quotes/[id]/route.ts
@@ -2,6 +2,7 @@ import { MedusaRequest, MedusaResponse } from "@medusajs/framework/http"
 import { MedusaError } from "@medusajs/framework/utils"
 
 import { PARTNER_QUOTE_MODULE } from "../../../../modules/partner-quote"
+import { withEffectiveStatus } from "../../../../modules/partner-quote/lib/token"
 import { loadScheduleForQuote } from "../../../../modules/payment_schedule/lib/for-quote"
 
 /**
@@ -29,5 +30,12 @@ export const GET = async (req: MedusaRequest, res: MedusaResponse) => {
     loadScheduleForQuote(req.scope, quote),
   ])
 
-  res.json({ quote: { ...quote, lines, events, payment_schedule } })
+  // #1510 — `status` is the stored fact; `status_effective` is what it means
+  // today. The detail page reads the same word as the list it was opened from.
+  res.json({
+    quote: withEffectiveStatus(
+      { ...quote, lines, events, payment_schedule },
+      new Date()
+    ),
+  })
 }

--- a/apps/backend/src/api/admin/quotes/route.ts
+++ b/apps/backend/src/api/admin/quotes/route.ts
@@ -3,6 +3,7 @@ import { ContainerRegistrationKeys, MedusaError } from "@medusajs/framework/util
 
 import { PARTNER_QUOTE_MODULE } from "../../../modules/partner-quote"
 import { buildQuoteListQuery } from "../../../modules/partner-quote/lib/list-query"
+import { withEffectiveStatus } from "../../../modules/partner-quote/lib/token"
 import { resolveQuoteDesignLines } from "../../../modules/partner-quote/lib/design-lines"
 import { deliverQuoteEmail } from "../../../workflows/partner-quote/deliver-quote-email"
 import { mintQuoteWorkflow } from "../../../workflows/partner-quote/mint-quote"
@@ -35,14 +36,22 @@ import { assertVariantsInStore } from "./lib/assert-variants-in-store"
 export const GET = async (req: MedusaRequest, res: MedusaResponse) => {
   const service: any = req.scope.resolve(PARTNER_QUOTE_MODULE)
 
-  const { filters, config } = buildQuoteListQuery(req.query as any)
+  // 🔑 ONE `now` for the filter and the stamp (#1510), so a row cannot be
+  // selected as active and then labelled expired in the same response.
+  const now = new Date()
+  const { filters, config } = buildQuoteListQuery(req.query as any, {}, now)
 
   const [quotes, count] = await service.listAndCountPartnerQuotes(
     filters,
     config
   )
 
-  res.json({ quotes, count, limit: config.take, offset: config.skip })
+  res.json({
+    quotes: (quotes ?? []).map((q: any) => withEffectiveStatus(q, now)),
+    count,
+    limit: config.take,
+    offset: config.skip,
+  })
 }
 
 /**

--- a/apps/backend/src/api/partners/products/validators.ts
+++ b/apps/backend/src/api/partners/products/validators.ts
@@ -105,6 +105,16 @@ export const PartnerProductSpecReq = z
     // Values are numbers per the catalog's param defs; ranges checked in the
     // workflow against the technique that was actually chosen.
     params: z.record(z.string(), z.number()).nullable().optional(),
+    /**
+     * The FINISHED piece, in centimetres — what a buyer means by "size".
+     *
+     * Bounded at 2000 cm to catch the typo (a 20-metre shawl), not to tell a
+     * weaver what is possible; the same posture as the param ranges. Integers,
+     * because the column is one and a half centimetre on a shawl is noise.
+     */
+    finished_length_cm: z.number().int().min(1).max(2000).nullable().optional(),
+    finished_width_cm: z.number().int().min(1).max(2000).nullable().optional(),
+    size_label: z.string().trim().max(80).nullable().optional(),
     finishes: z.array(z.string().trim().min(1).max(120)).max(20).nullable().optional(),
     notes: z.string().trim().max(5000).nullable().optional(),
     accepting_custom_orders: z.boolean().optional(),

--- a/apps/backend/src/api/partners/quotes/[id]/route.ts
+++ b/apps/backend/src/api/partners/quotes/[id]/route.ts
@@ -2,6 +2,7 @@ import { AuthenticatedMedusaRequest, MedusaResponse } from "@medusajs/framework/
 import { MedusaError } from "@medusajs/framework/utils"
 
 import { PARTNER_QUOTE_MODULE } from "../../../../modules/partner-quote"
+import { withEffectiveStatus } from "../../../../modules/partner-quote/lib/token"
 import { loadScheduleForQuote } from "../../../../modules/payment_schedule/lib/for-quote"
 import { getPartnerFromAuthContext } from "../../helpers"
 
@@ -42,5 +43,12 @@ export const GET = async (req: AuthenticatedMedusaRequest, res: MedusaResponse) 
     loadScheduleForQuote(req.scope, quote),
   ])
 
-  res.json({ quote: { ...quote, lines, events, payment_schedule } })
+  // #1510 — `status` is the stored fact; `status_effective` is what it means
+  // today. The detail page reads the same word as the list it was opened from.
+  res.json({
+    quote: withEffectiveStatus(
+      { ...quote, lines, events, payment_schedule },
+      new Date()
+    ),
+  })
 }

--- a/apps/backend/src/api/partners/quotes/route.ts
+++ b/apps/backend/src/api/partners/quotes/route.ts
@@ -4,6 +4,7 @@ import { ContainerRegistrationKeys } from "@medusajs/framework/utils"
 import { PARTNER_QUOTE_MODULE } from "../../../modules/partner-quote"
 import { resolveQuoteDesignLines } from "../../../modules/partner-quote/lib/design-lines"
 import { buildQuoteListQuery } from "../../../modules/partner-quote/lib/list-query"
+import { withEffectiveStatus } from "../../../modules/partner-quote/lib/token"
 import { deliverQuoteEmail } from "../../../workflows/partner-quote/deliver-quote-email"
 import { mintQuoteWorkflow } from "../../../workflows/partner-quote/mint-quote"
 import { getPartnerStore, tryGetPartnerStore } from "../helpers"
@@ -27,16 +28,27 @@ export const GET = async (
   }
 
   const service: any = req.scope.resolve(PARTNER_QUOTE_MODULE)
-  const { filters, config } = buildQuoteListQuery(req.query as any, {
-    partner_id: partner.id,
-  })
+  // 🔑 ONE `now` for the filter and the stamp (#1510). Two calls to `new Date()`
+  // could straddle an `expires_at`, and a row would be selected as active and
+  // then labelled expired in the same response.
+  const now = new Date()
+  const { filters, config } = buildQuoteListQuery(
+    req.query as any,
+    { partner_id: partner.id },
+    now
+  )
 
   const [quotes, count] = await service.listAndCountPartnerQuotes(
     filters,
     config
   )
 
-  res.json({ quotes, count, limit: config.take, offset: config.skip })
+  res.json({
+    quotes: (quotes ?? []).map((q: any) => withEffectiveStatus(q, now)),
+    count,
+    limit: config.take,
+    offset: config.skip,
+  })
 }
 
 /**

--- a/apps/backend/src/api/store/products/[id]/spec/route.ts
+++ b/apps/backend/src/api/store/products/[id]/spec/route.ts
@@ -102,6 +102,14 @@ export const GET = async (req: MedusaRequest, res: MedusaResponse) => {
       weave_technique: spec.weave_technique ?? null,
       weave_label: spec.weave_label ?? null,
       params: spec.params ?? null,
+      /**
+       * The FINISHED piece's size — what a buyer means when they ask "how big
+       * is it". Deliberately not folded into `params`: those are keyed to the
+       * weave technique, and a product with no technique still has a size.
+       */
+      finished_length_cm: spec.finished_length_cm ?? null,
+      finished_width_cm: spec.finished_width_cm ?? null,
+      size_label: spec.size_label ?? null,
       finishes: spec.finishes ?? [],
       accepting_custom_orders: !!spec.accepting_custom_orders,
       custom_order_lead_time_days: spec.custom_order_lead_time_days ?? null,

--- a/apps/backend/src/modules/location_ownership/migrations/Migration20260824150000.ts
+++ b/apps/backend/src/modules/location_ownership/migrations/Migration20260824150000.ts
@@ -1,0 +1,24 @@
+import { Migration } from "@medusajs/framework/mikro-orm/migrations";
+
+/**
+ * Split "may we export from here" out of "do we own the stock here" (#1498).
+ *
+ * NULLABLE with no default and no backfill, deliberately. Every existing row
+ * keeps saying nothing, the resolver keeps inferring from `is_core` while that
+ * is true of the whole set, and the behaviour on prod does not move until an
+ * operator marks the first real export hub. A backfill here would have written
+ * "Dharamshala is an export origin" as though somebody had decided it.
+ *
+ * One additive nullable column — idempotent and safe to re-run (#1208).
+ */
+export class Migration20260824150000 extends Migration {
+
+  override async up(): Promise<void> {
+    this.addSql(`alter table if exists "location_ownership" add column if not exists "is_export_origin" boolean null;`);
+  }
+
+  override async down(): Promise<void> {
+    this.addSql(`alter table if exists "location_ownership" drop column if exists "is_export_origin";`);
+  }
+
+}

--- a/apps/backend/src/modules/location_ownership/models/location-ownership.ts
+++ b/apps/backend/src/modules/location_ownership/models/location-ownership.ts
@@ -22,6 +22,23 @@ const LocationOwnership = model.define("location_ownership", {
   stock_location_id: model.text().unique(),
   /** True when we own the stock held here and may deduct consumption from it. */
   is_core: model.boolean().default(false),
+  /**
+   * Whether an export may LEAVE from here (#1498).
+   *
+   * 🔴 Split from `is_core` on purpose. `is_core` answers "may we deduct
+   * consumption from this stock"; the freight relay was reading it as "may we
+   * export from here", and the two are not the same question. Prod has exactly
+   * two `is_core` locations and one of them is **Dharamshala**, which is not an
+   * export hub — a shipment relayed there to be exported would be relayed to
+   * the wrong place, and priced as though it worked.
+   *
+   * 🔑 NULLABLE, and null is not false. A row written before this column
+   * existed has no opinion, and the resolver falls back to `is_core` for the
+   * whole set in that case — so nothing changes until an operator states the
+   * first explicit answer, and the day they do, the inference stops entirely.
+   * A `false` here is a decision; a null is the absence of one.
+   */
+  is_export_origin: model.boolean().nullable(),
   /** Why it was marked this way — free text for the operator who set it. */
   note: model.text().nullable(),
 })

--- a/apps/backend/src/modules/partner-quote/__tests__/list-query.unit.spec.ts
+++ b/apps/backend/src/modules/partner-quote/__tests__/list-query.unit.spec.ts
@@ -1,6 +1,7 @@
 import {
   buildQuoteListQuery,
   buildQuoteSearchFilter,
+  buildQuoteStatusFilter,
   parseQuoteOrder,
   QUOTE_DEFAULT_LIMIT,
   QUOTE_MAX_LIMIT,
@@ -141,5 +142,80 @@ describe("buildQuoteListQuery", () => {
       order: { expires_at: "ASC" },
       relations: ["lines"],
     })
+  })
+})
+
+/**
+ * #1510 — `active` did not mean active.
+ *
+ * `partner_quote.status` has no `expired` value and nothing moves a row out of
+ * `active` when its date passes, so every list filtered to `status=active`
+ * counted dead quotes as live while the buyer page refused to price the very
+ * same link. The translation has to happen in the FILTER rather than over the
+ * page, or `count` and the pager describe a different set from the rows.
+ */
+describe("buildQuoteStatusFilter", () => {
+  const NOW = new Date("2026-08-24T12:00:00.000Z")
+
+  it("passes a real stored status straight through", () => {
+    expect(buildQuoteStatusFilter("revoked", NOW)).toEqual({ status: "revoked" })
+    expect(buildQuoteStatusFilter("superseded", NOW)).toEqual({
+      status: "superseded",
+    })
+  })
+
+  it("translates `expired` into 'stored active, and the date has passed'", () => {
+    expect(buildQuoteStatusFilter("expired", NOW)).toEqual({
+      status: "active",
+      $and: [{ expires_at: { $lte: NOW } }],
+    })
+  })
+
+  it("narrows `active` to rows whose date has NOT passed", () => {
+    expect(buildQuoteStatusFilter("active", NOW)).toEqual({
+      status: "active",
+      $and: [{ $or: [{ expires_at: null }, { expires_at: { $gt: NOW } }] }],
+    })
+  })
+
+  it("keeps a quote with no expiry in `active` forever", () => {
+    // Matches `quoteUnusableReason`, which only calls a quote expired when it
+    // has a date AND that date has passed. A null here must not vanish from
+    // both lists at once.
+    const clause: any = buildQuoteStatusFilter("active", NOW)
+    expect(clause.$and[0].$or).toContainEqual({ expires_at: null })
+  })
+})
+
+describe("buildQuoteListQuery — effective status (#1510)", () => {
+  const NOW = new Date("2026-08-24T12:00:00.000Z")
+
+  it("applies the expiry predicate to the filters", () => {
+    const { filters } = buildQuoteListQuery({ status: "expired" }, {}, NOW)
+    expect(filters).toMatchObject({ status: "active" })
+    expect((filters as any).$and).toEqual([{ expires_at: { $lte: NOW } }])
+  })
+
+  it("🔴 does not let the expiry clause trample the free-text search", () => {
+    // Both wanted `$or`, and `Object.assign` would have kept whichever ran
+    // last — silently turning "active quotes for Acme" into one or the other.
+    const { filters } = buildQuoteListQuery(
+      { status: "active", q: "acme" },
+      { partner_id: "part_mine" },
+      NOW
+    )
+    expect((filters as any).$or).toHaveLength(3)
+    expect((filters as any).$and).toHaveLength(1)
+    expect(filters.partner_id).toBe("part_mine")
+  })
+
+  it("intersects with an `$and` the caller already pinned", () => {
+    const { filters } = buildQuoteListQuery(
+      { status: "active" },
+      { $and: [{ store_id: "store_1" }] },
+      NOW
+    )
+    expect((filters as any).$and).toHaveLength(2)
+    expect((filters as any).$and[0]).toEqual({ store_id: "store_1" })
   })
 })

--- a/apps/backend/src/modules/partner-quote/__tests__/quote-size.unit.spec.ts
+++ b/apps/backend/src/modules/partner-quote/__tests__/quote-size.unit.spec.ts
@@ -1,0 +1,135 @@
+import {
+  formatDimensions,
+  resolveLineSize,
+  sizeFromProduct,
+  sizeFromSpec,
+  sizeFromVariant,
+} from "../lib/quote-size"
+
+/**
+ * "How big is the thing I am buying?"
+ *
+ * A quote stated the ends-per-inch and the GSM and never the size of the piece,
+ * because the three places a partner may have written it down were all invisible
+ * to this payload.
+ */
+describe("formatDimensions", () => {
+  it("states both dimensions with a unit", () => {
+    expect(formatDimensions(200, 70)).toBe("200 × 70 cm")
+  })
+
+  it("still says something with only one dimension", () => {
+    // A 200 cm stole of unstated width tells a buyer more than nothing does.
+    expect(formatDimensions(200, null)).toBe("200 cm")
+    expect(formatDimensions(null, 70)).toBe("70 cm")
+  })
+
+  it("🔴 treats 0 and junk as ABSENT, not as a measurement", () => {
+    // Both arrive from the database looking plausible on a row nobody filled
+    // in, and both would render as "0 × 0 cm" beside a price.
+    expect(formatDimensions(0, 0)).toBeNull()
+    expect(formatDimensions("", null)).toBeNull()
+    expect(formatDimensions("abc", null)).toBeNull()
+    expect(formatDimensions(undefined, undefined)).toBeNull()
+  })
+})
+
+describe("sizeFromVariant", () => {
+  const variant = (title: string, value: string) => ({
+    options: [{ value, option: { title } }],
+  })
+
+  it("reads the value of a size-ish option", () => {
+    expect(sizeFromVariant(variant("Size", "200 × 70 cm"))).toBe("200 × 70 cm")
+    expect(sizeFromVariant(variant("Dimensions", "King"))).toBe("King")
+  })
+
+  it("is case- and whitespace-insensitive about the option title", () => {
+    expect(sizeFromVariant(variant("  SIZE ", "Stole"))).toBe("Stole")
+  })
+
+  it("ignores options that are not about size", () => {
+    expect(sizeFromVariant(variant("Colour", "Rust"))).toBeNull()
+    expect(sizeFromVariant({ options: [] })).toBeNull()
+    expect(sizeFromVariant(undefined)).toBeNull()
+  })
+})
+
+describe("sizeFromSpec", () => {
+  it("joins the trade name to the measurement", () => {
+    expect(
+      sizeFromSpec({
+        size_label: "Stole",
+        finished_length_cm: 200,
+        finished_width_cm: 70,
+      })
+    ).toBe("Stole · 200 × 70 cm")
+  })
+
+  it("says whichever half exists", () => {
+    // A buyer who knows "Stole" does not want to decode 200 × 70; one who does
+    // not know the word needs the numbers. Either alone still helps.
+    expect(sizeFromSpec({ size_label: "Stole" })).toBe("Stole")
+    expect(
+      sizeFromSpec({ finished_length_cm: 200, finished_width_cm: 70 })
+    ).toBe("200 × 70 cm")
+  })
+
+  it("is null on a spec that states no size", () => {
+    expect(sizeFromSpec({ weave_technique: "twill" })).toBeNull()
+    expect(sizeFromSpec(null)).toBeNull()
+  })
+
+  it("🔴 never reads loom width as the finished size", () => {
+    // Different measurement: the cloth ON the loom, before it is cut, hemmed
+    // and washed. Quoting it as the article's size overstates it every time.
+    expect(sizeFromSpec({ params: { loom_width_cm: 90 } })).toBeNull()
+  })
+})
+
+describe("sizeFromProduct", () => {
+  it("reads the catalogue dimensions the product page already shows", () => {
+    expect(sizeFromProduct({ length: 200, width: 70 })).toBe("200 × 70 cm")
+  })
+
+  it("is null on the catalogue's usual state — nothing filled in", () => {
+    expect(sizeFromProduct({ length: null, width: null })).toBeNull()
+  })
+})
+
+describe("resolveLineSize", () => {
+  it("prefers the VARIANT — it is the SKU being quoted", () => {
+    const size = resolveLineSize({
+      variant: { options: [{ value: "Full shawl", option: { title: "Size" } }] },
+      spec_size: "Stole · 200 × 70 cm",
+      product: { length: 111, width: 11 },
+    })
+    expect(size).toEqual({ label: "Full shawl", source: "variant" })
+  })
+
+  it("falls back to the spec when size is not an option", () => {
+    const size = resolveLineSize({
+      variant: { options: [{ value: "Rust", option: { title: "Colour" } }] },
+      spec_size: "Stole · 200 × 70 cm",
+      product: { length: 111, width: 11 },
+    })
+    expect(size).toEqual({ label: "Stole · 200 × 70 cm", source: "spec" })
+  })
+
+  it("falls back to the product's catalogue dimensions last", () => {
+    const size = resolveLineSize({
+      variant: { options: [] },
+      spec_size: null,
+      product: { length: 200, width: 70 },
+    })
+    // Weakest claim, and it is labelled one so the page can caveat it — the
+    // same treatment `image_source` and `weight_source` get.
+    expect(size).toEqual({ label: "200 × 70 cm", source: "product" })
+  })
+
+  it("is null when nobody stated a size anywhere", () => {
+    expect(
+      resolveLineSize({ variant: { options: [] }, spec_size: null, product: {} })
+    ).toBeNull()
+  })
+})

--- a/apps/backend/src/modules/partner-quote/__tests__/token.unit.spec.ts
+++ b/apps/backend/src/modules/partner-quote/__tests__/token.unit.spec.ts
@@ -1,11 +1,13 @@
 import {
   DEFAULT_QUOTE_TTL_DAYS,
   daysUntilExpiry,
+  effectiveQuoteStatus,
   generateQuoteToken,
   hashQuoteToken,
   isQuoteUsable,
   quoteExpiryFrom,
   quoteUnusableReason,
+  withEffectiveStatus,
 } from "../lib/token"
 
 const NOW = new Date("2026-08-21T12:00:00.000Z")
@@ -122,5 +124,84 @@ describe("partner-quote token", () => {
         daysUntilExpiry({ status: "active", expires_at: null }, NOW)
       ).toBeNull()
     })
+  })
+})
+
+/**
+ * #1510 — the word an operator reads to answer "is this offer still standing".
+ */
+describe("effectiveQuoteStatus", () => {
+  it("is `active` while the quote is inside its own TTL", () => {
+    expect(
+      effectiveQuoteStatus({ status: "active", expires_at: days(7) }, NOW)
+    ).toBe("active")
+  })
+
+  it("🔴 is `expired` once the date has passed, though the column says active", () => {
+    // The whole defect: the stored enum has no `expired`, so this row read
+    // `active` on every list while the buyer page refused to price its link.
+    expect(
+      effectiveQuoteStatus({ status: "active", expires_at: days(-1) }, NOW)
+    ).toBe("expired")
+  })
+
+  it("keeps `revoked` and `superseded` ahead of expiry", () => {
+    // A superseded quote is usually still inside its TTL, and "a newer quote
+    // replaced this" is the more useful thing to say. Precedence is decided
+    // once, in `quoteUnusableReason` — this only proves it is not re-decided.
+    expect(
+      effectiveQuoteStatus({ status: "superseded", expires_at: days(-1) }, NOW)
+    ).toBe("superseded")
+    expect(
+      effectiveQuoteStatus({ status: "revoked", expires_at: days(-1) }, NOW)
+    ).toBe("revoked")
+  })
+
+  it("never expires a quote with no expiry", () => {
+    expect(
+      effectiveQuoteStatus({ status: "active", expires_at: null }, NOW)
+    ).toBe("active")
+  })
+
+  it("agrees with the buyer page, by construction", () => {
+    // Not a tautology worth skipping: the list and the buyer page forming two
+    // opinions is the failure the issue asks to avoid, and this is the
+    // assertion that breaks if someone re-derives expiry here later.
+    for (const q of [
+      { status: "active", expires_at: days(-1) },
+      { status: "active", expires_at: days(1) },
+      { status: "revoked", expires_at: days(1) },
+      { status: "superseded", expires_at: days(-1) },
+    ]) {
+      expect(effectiveQuoteStatus(q, NOW)).toBe(
+        quoteUnusableReason(q, NOW) ?? "active"
+      )
+    }
+  })
+
+  it("survives a `now` that has been through JSON", () => {
+    // Same trap `quoteUnusableReason` documents: a Date crossing a workflow
+    // step boundary arrives as an ISO string.
+    expect(
+      effectiveQuoteStatus(
+        { status: "active", expires_at: days(-1) },
+        NOW.toISOString()
+      )
+    ).toBe("expired")
+  })
+})
+
+describe("withEffectiveStatus", () => {
+  it("adds the computed word WITHOUT replacing the stored one", () => {
+    // Both travel: a superseded quote and an expired one are different
+    // conversations, and overwriting `status` would make the API disagree with
+    // the column it is named after.
+    const stamped = withEffectiveStatus(
+      { id: "pq_1", status: "active", expires_at: days(-1) },
+      NOW
+    )
+    expect(stamped.status).toBe("active")
+    expect(stamped.status_effective).toBe("expired")
+    expect(stamped.id).toBe("pq_1")
   })
 })

--- a/apps/backend/src/modules/partner-quote/lib/build-quote-view.ts
+++ b/apps/backend/src/modules/partner-quote/lib/build-quote-view.ts
@@ -30,6 +30,7 @@ import {
 } from "../../shipping-providers/rating-carrier"
 import { classifyQuoteJurisdiction } from "./quote-tax"
 import { resolveQuoteSpecs, type QuoteLineSpec } from "./quote-spec"
+import { resolveLineSize, type QuoteLineSize } from "./quote-size"
 import { daysUntilExpiry, quoteUnusableReason } from "./token"
 /**
  * Imported, never restated. `customer.groups.id` vs `customer_group_id` is the
@@ -270,6 +271,8 @@ export type QuoteViewLine = {
    * Null when the product has no spec, which is the normal state.
    */
   spec: QuoteLineSpec | null
+  /** The finished piece's size, and which source stated it. Null when nobody did. */
+  size: QuoteLineSize | null
   /**
    * Every image on this variant, merchandiser-ordered (#1439 S14). Empty when
    * the variant has none of its own — `thumbnail` may still be the product's.
@@ -794,6 +797,19 @@ export async function buildQuoteView(
       "product.title",
       "product.handle",
       "product.thumbnail",
+      /**
+       * Size, from the two places a partner may have stated it.
+       *
+       * The variant's own option value is the strongest claim — it is the SKU
+       * being quoted — and the product's catalogue dimensions are the weakest
+       * but cost nothing, since they are already filled in for the "Product
+       * information" tab. The middle source is the production spec, resolved
+       * separately below. See `quote-size.ts` for the ordering.
+       */
+      "options.value",
+      "options.option.title",
+      "product.length",
+      "product.width",
       // What the piece IS, for a buyer deciding whether it fits their shelf
       // (#1428 follow-up). Tags are the merchandising vocabulary the catalogue
       // already uses, so they need no new field and cannot drift from it.
@@ -1311,6 +1327,17 @@ export async function buildQuoteView(
         (v) => v.id !== line.variant_id
       ),
       spec: specByProduct.get(identity.product?.id) ?? null,
+      /**
+       * "How big is it" — the question a buyer approving a consignment asks
+       * before any of the weave numbers. Resolved from the strongest source
+       * that has an answer, and the source travels with it so the page can
+       * caveat a product-level claim on a variant-specific line.
+       */
+      size: resolveLineSize({
+        variant: identity,
+        spec_size: specByProduct.get(identity.product?.id)?.size ?? null,
+        product: identity.product,
+      }),
       product_tags: ((identity.product?.tags ?? []) as any[])
         .map((t) => t?.value)
         .filter((v: any): v is string => typeof v === "string" && v.length > 0),

--- a/apps/backend/src/modules/partner-quote/lib/list-query.ts
+++ b/apps/backend/src/modules/partner-quote/lib/list-query.ts
@@ -58,6 +58,42 @@ export type QuoteListQuery = {
   partner_id?: unknown
 }
 
+/**
+ * The stored `status` clause for a requested EFFECTIVE status (#1510).
+ *
+ * `expired` is not a value of `PartnerQuote.status` — it is `active` plus a
+ * date that has passed — so a list cannot simply pass the word through. It has
+ * to be translated into a predicate, and it has to be translated HERE rather
+ * than filtered out of the page afterwards: `count`, the pager and the filter
+ * must all describe the same set. Post-filtering a page would give a table that
+ * says "20 of 34" over eleven visible rows.
+ *
+ * 🔴 The expiry predicate is nested under `$and` rather than written as a
+ * top-level `$or`, because the free-text search already owns `$or` and the two
+ * would trample each other on `Object.assign` — silently, and in favour of
+ * whichever ran last. Same pattern as `/admin/abandoned-carts`.
+ *
+ * A NULL `expires_at` is active forever, matching `quoteUnusableReason`, which
+ * only calls a quote expired when it has a date AND that date has passed.
+ */
+export function buildQuoteStatusFilter(
+  status: string,
+  now: Date
+): Record<string, unknown> {
+  if (status === "expired") {
+    return { status: "active", $and: [{ expires_at: { $lte: now } }] }
+  }
+
+  if (status === "active") {
+    return {
+      status: "active",
+      $and: [{ $or: [{ expires_at: null }, { expires_at: { $gt: now } }] }],
+    }
+  }
+
+  return { status }
+}
+
 export type BuiltQuoteListQuery = {
   filters: Record<string, unknown>
   config: {
@@ -137,7 +173,9 @@ export function buildQuoteSearchFilter(raw: unknown): Record<string, unknown> | 
 export function buildQuoteListQuery(
   query: QuoteListQuery,
   /** Filters the caller pins and the client cannot override — e.g. the partner's own id. */
-  scoped: Record<string, unknown> = {}
+  scoped: Record<string, unknown> = {},
+  /** Passed in so `status=active|expired` stays deterministic under test. */
+  now: Date = new Date()
 ): BuiltQuoteListQuery {
   const take = clampInt(query.limit, QUOTE_DEFAULT_LIMIT, 1, QUOTE_MAX_LIMIT)
   const skip = clampInt(query.offset, 0, 0, Number.MAX_SAFE_INTEGER)
@@ -145,7 +183,16 @@ export function buildQuoteListQuery(
   const filters: Record<string, unknown> = { ...scoped }
 
   const status = String(query.status ?? "").trim()
-  if (status) filters.status = status
+  if (status) {
+    const clause = buildQuoteStatusFilter(status, now)
+    // `$and` may already be pinned by the caller; intersect rather than replace.
+    const and = clause.$and as unknown[] | undefined
+    delete clause.$and
+    Object.assign(filters, clause)
+    if (and) {
+      filters.$and = [...((filters.$and as unknown[]) ?? []), ...and]
+    }
+  }
 
   // Only honoured when the caller did not already pin it. A partner listing
   // their own quotes must never be able to widen the scope by query string.

--- a/apps/backend/src/modules/partner-quote/lib/quote-size.ts
+++ b/apps/backend/src/modules/partner-quote/lib/quote-size.ts
@@ -1,0 +1,135 @@
+/**
+ * "How big is the thing I am buying?", on the quote line.
+ *
+ * ## Why this needed a helper at all
+ *
+ * A buyer approving a consignment could read the ends-per-inch and the GSM but
+ * not the size of the piece. Nothing on the quote carried it: the production
+ * spec described the WEAVE, `loom_width_cm` is the cloth on the loom rather
+ * than the finished article, and the product's own `length/width/height` live
+ * on a tab of the product page the buyer opening a quote link never sees.
+ *
+ * ## Three sources, in the order a partner would trust them
+ *
+ * 1. **The variant.** If size is a product OPTION, the variant IS a size and
+ *    the partner has already stated it per-SKU. Nothing else can be more
+ *    specific than the thing being quoted.
+ * 2. **The production spec.** `size_label` + finished dimensions — authored
+ *    once for the product, which is where a made-to-order piece states it.
+ * 3. **The product's own dimensions.** Medusa's `length`/`width`, already shown
+ *    on the product page's "Product information" tab, so a partner who filled
+ *    those in gets the size on a quote for free.
+ *
+ * 🔑 The chain resolves to ONE answer and says which source it came from, the
+ * same way `weight_source` and `image_source` do on this view. A product-level
+ * size on a variant-specific line is a weaker claim than the variant's own, and
+ * a buyer signing off a consignment is entitled to know which they are reading.
+ *
+ * 🔴 A FACT, never a picker. The quote is frozen against specific variants at
+ * specific prices, so offering a size to choose would describe an agreement
+ * nothing behind the page can honour — the same rule that keeps the palette and
+ * the option groups out of `quote-spec.ts`.
+ */
+
+export type QuoteLineSize = {
+  /** One line, ready to render. "Stole · 200 × 70 cm" */
+  label: string
+  /** Which claim this is, so the page can caveat a weak one. */
+  source: "variant" | "spec" | "product"
+}
+
+/** Option titles that mean "how big". Matched case- and space-insensitively. */
+const SIZE_OPTION_TITLES = ["size", "dimensions", "dimension", "measurements"]
+
+const clean = (v: unknown): string | null => {
+  const s = String(v ?? "").trim()
+  return s ? s : null
+}
+
+/**
+ * A number that means something. `0` is not a size, and neither is `NaN` — both
+ * arrive from the database as plausible-looking values on a row nobody filled
+ * in, and both would render as "0 × 0 cm" beside a price.
+ */
+const dim = (v: unknown): number | null => {
+  if (v === null || v === undefined || v === "") return null
+  const n = Number(v)
+  return Number.isFinite(n) && n > 0 ? n : null
+}
+
+/** "200 × 70 cm", "200 cm", or null when neither number is there. */
+export function formatDimensions(
+  length: unknown,
+  width: unknown,
+  unit = "cm"
+): string | null {
+  const l = dim(length)
+  const w = dim(width)
+  if (l && w) return `${l} × ${w} ${unit}`
+  // One dimension alone is still worth saying — a 200 cm stole of unstated
+  // width tells a buyer more than nothing does.
+  if (l) return `${l} ${unit}`
+  if (w) return `${w} ${unit}`
+  return null
+}
+
+/** The variant's own size, when size is one of the product's options. */
+export function sizeFromVariant(variant: any): string | null {
+  const options = (variant?.options ?? []) as any[]
+  for (const o of options) {
+    const title = clean(o?.option?.title)?.toLowerCase()
+    if (title && SIZE_OPTION_TITLES.includes(title)) {
+      const value = clean(o?.value)
+      if (value) return value
+    }
+  }
+  return null
+}
+
+/** The production spec's finished size — a name, a measurement, or both. */
+export function sizeFromSpec(spec: any): string | null {
+  const label = clean(spec?.size_label)
+  const measured = formatDimensions(
+    spec?.finished_length_cm,
+    spec?.finished_width_cm
+  )
+  if (label && measured) return `${label} · ${measured}`
+  return label ?? measured
+}
+
+/**
+ * The product's catalogue dimensions.
+ *
+ * Medusa stores these unitless — the product page prints "200L x 70W x 30H"
+ * with no unit at all — so this states cm rather than inventing a unit field.
+ * Every product in this catalogue is measured in cm; if that ever stops being
+ * true it is a data problem, not a formatting one, and it should be fixed where
+ * the number is entered.
+ */
+export function sizeFromProduct(product: any): string | null {
+  return formatDimensions(product?.length, product?.width)
+}
+
+/**
+ * The one answer, from the strongest source that has one.
+ *
+ * `spec_size` arrives already composed (by `composeLineSpec`, via
+ * `sizeFromSpec`) rather than as a raw spec row, so the spec module keeps
+ * ownership of what its own columns mean and this file owns only the ordering.
+ */
+export function resolveLineSize(input: {
+  variant?: any
+  spec_size?: string | null
+  product?: any
+}): QuoteLineSize | null {
+  const fromVariant = sizeFromVariant(input.variant)
+  if (fromVariant) return { label: fromVariant, source: "variant" }
+
+  const fromSpec = clean(input.spec_size)
+  if (fromSpec) return { label: fromSpec, source: "spec" }
+
+  const fromProduct = sizeFromProduct(input.product)
+  if (fromProduct) return { label: fromProduct, source: "product" }
+
+  return null
+}

--- a/apps/backend/src/modules/partner-quote/lib/quote-spec.ts
+++ b/apps/backend/src/modules/partner-quote/lib/quote-spec.ts
@@ -1,5 +1,6 @@
 import { PRODUCT_SPEC_MODULE } from "../../product-spec"
 import { WEAVE_TECHNIQUES } from "../../product-spec/weaving-techniques"
+import { sizeFromSpec } from "./quote-size"
 
 /**
  * "What the piece is made to", on the quote (#1428).
@@ -39,6 +40,17 @@ export type QuoteLineSpec = {
   weave_label: string | null
   rows: QuoteSpecRow[]
   finishes: string[]
+  /**
+   * The FINISHED piece, as one ready-to-render line ("Stole · 200 × 70 cm").
+   *
+   * Kept out of `rows` on purpose. The rows are the weave — a wall of
+   * comparable numbers a buyer skims — and the size is the one measurement they
+   * came looking for. Burying it between the yarn counts is how it goes unread.
+   *
+   * 🔴 This is the spec's answer, not the line's. The line resolves a stronger
+   * one from the variant when size is a product option; see `quote-size.ts`.
+   */
+  size: string | null
 }
 
 /** `ends_per_inch` → `Ends per inch`. Only ever a fallback for an unknown key. */
@@ -100,10 +112,14 @@ export function composeLineSpec(spec: any): QuoteLineSpec | null {
     .map(String)
 
   const weaveLabel = spec.weave_label || technique?.label || null
+  const size = sizeFromSpec(spec)
 
-  if (!rows.length && !finishes.length && !weaveLabel) return null
+  // 🔴 `size` counts. A spec carrying ONLY a finished size used to compose to
+  // null and take the whole block with it — the same shape as #1524, where
+  // "nothing to show" was measured too narrowly and a configured band vanished.
+  if (!rows.length && !finishes.length && !weaveLabel && !size) return null
 
-  return { weave_label: weaveLabel, rows, finishes }
+  return { weave_label: weaveLabel, rows, finishes, size }
 }
 
 /**

--- a/apps/backend/src/modules/partner-quote/lib/token.ts
+++ b/apps/backend/src/modules/partner-quote/lib/token.ts
@@ -105,3 +105,61 @@ export function daysUntilExpiry(
   const ms = new Date(quote.expires_at).getTime() - nowMs
   return Math.max(0, Math.ceil(ms / (24 * 60 * 60 * 1000)))
 }
+
+/**
+ * The four words an operator may read on a quote.
+ *
+ * `expired` is deliberately NOT in `PartnerQuote.status` — see below.
+ */
+export const EFFECTIVE_QUOTE_STATUSES = [
+  "active",
+  "expired",
+  "revoked",
+  "superseded",
+] as const
+
+export type EffectiveQuoteStatus = (typeof EFFECTIVE_QUOTE_STATUSES)[number]
+
+/**
+ * What the quote's status ACTUALLY is, now (#1510).
+ *
+ * `PartnerQuote.status` is `active | revoked | superseded` and nothing moves a
+ * row out of `active` when `expires_at` passes — so every list filtered to
+ * `status=active` counted dead quotes as live, while the buyer page (which
+ * derives expiry at read time) correctly refused to price the very same link.
+ * The defect was never a mispriced quote: it was that `active` did not mean
+ * active, on the one word an operator reads to answer "is this offer still
+ * standing".
+ *
+ * 🔑 Derived, not swept. A cron that flipped rows would mutate a partner's
+ * record behind their back and would need a migration to widen the enum; this
+ * keeps `status` as the stored FACT and adds the computed one beside it. The
+ * model's docblock has said "expiry is derived at read time" since S3 — this
+ * is the list half of that promise, which was simply never written.
+ *
+ * 🔴 Built on `quoteUnusableReason` rather than re-deriving expiry, so the list
+ * and the buyer page cannot form two opinions about the same row. That is the
+ * exact failure the issue asks to avoid, and it is also why the precedence
+ * (revoked → superseded → expired) is stated in one place only.
+ */
+export function effectiveQuoteStatus(
+  quote: QuoteLifecycle,
+  now: Date | string | number
+): EffectiveQuoteStatus {
+  return quoteUnusableReason(quote, now) ?? "active"
+}
+
+/**
+ * A quote row with `status_effective` beside its stored `status`.
+ *
+ * Both fields travel, always. Dropping `status` would hide the fact an
+ * operator may need — a superseded quote and an expired one are different
+ * conversations — and replacing it in place would make the API disagree with
+ * the column it is named after.
+ */
+export function withEffectiveStatus<T extends QuoteLifecycle>(
+  quote: T,
+  now: Date | string | number
+): T & { status_effective: EffectiveQuoteStatus } {
+  return { ...quote, status_effective: effectiveQuoteStatus(quote, now) }
+}

--- a/apps/backend/src/modules/product-spec/migrations/Migration20260824140000.ts
+++ b/apps/backend/src/modules/product-spec/migrations/Migration20260824140000.ts
@@ -1,0 +1,24 @@
+import { Migration } from "@medusajs/framework/mikro-orm/migrations";
+
+/**
+ * The finished piece's size on the production spec.
+ *
+ * Three nullable columns and nothing else, so this is idempotent and safe to
+ * re-run — the #1208 concern. Every existing spec keeps working with all three
+ * null, which is exactly what "no size stated" means everywhere downstream.
+ */
+export class Migration20260824140000 extends Migration {
+
+  override async up(): Promise<void> {
+    this.addSql(`alter table if exists "product_spec" add column if not exists "finished_length_cm" integer null;`);
+    this.addSql(`alter table if exists "product_spec" add column if not exists "finished_width_cm" integer null;`);
+    this.addSql(`alter table if exists "product_spec" add column if not exists "size_label" text null;`);
+  }
+
+  override async down(): Promise<void> {
+    this.addSql(`alter table if exists "product_spec" drop column if exists "finished_length_cm";`);
+    this.addSql(`alter table if exists "product_spec" drop column if exists "finished_width_cm";`);
+    this.addSql(`alter table if exists "product_spec" drop column if exists "size_label";`);
+  }
+
+}

--- a/apps/backend/src/modules/product-spec/models/product-spec.ts
+++ b/apps/backend/src/modules/product-spec/models/product-spec.ts
@@ -44,6 +44,36 @@ const ProductSpec = model.define("product_spec", {
   // "dry flat"). Seeded from the technique, then edited freely.
   finishes: model.json().nullable(),
 
+  /**
+   * The FINISHED piece's size (#1510 follow-up — "which size am I buying?").
+   *
+   * 🔴 Not a weave param. `validateWeaveParams` rejects any key the chosen
+   * technique does not list and refuses params outright without a technique, so
+   * a shared "size" param would either have to be bolted onto all eleven
+   * techniques or would be unavailable to every product that has no weave at
+   * all. Size belongs to the piece, not to how it was woven.
+   *
+   * Centimetres, always, because a quote crosses borders and a unitless number
+   * beside a price is how a buyer orders the wrong thing. The storefront
+   * converts for display if it ever needs to; the stored fact does not move.
+   *
+   * `loom_width_cm` is a different measurement and must not be confused with
+   * this one: that is the width of the cloth ON the loom, before it is cut,
+   * hemmed and washed.
+   */
+  finished_length_cm: model.number().nullable(),
+  finished_width_cm: model.number().nullable(),
+
+  /**
+   * What the partner CALLS that size — "Stole", "Full shawl", "King".
+   *
+   * Mirrors `weave_label` over `weave_technique`: the name the trade uses,
+   * shown alongside the measurement rather than instead of it. A buyer who
+   * knows "Stole" does not want to decode 200 × 70, and a buyer who does not
+   * know the word needs the numbers.
+   */
+  size_label: model.text().nullable(),
+
   // Free-form notes for the workshop — anything that is guidance rather than
   // data ("warp tension eases in monsoon; allow an extra day").
   notes: model.text().nullable(),

--- a/apps/backend/src/modules/product-spec/tool-schema.ts
+++ b/apps/backend/src/modules/product-spec/tool-schema.ts
@@ -18,6 +18,9 @@ export const PRODUCT_SPEC_BODY_PARAMS = [
   "weave_technique",
   "weave_label",
   "params",
+  "finished_length_cm",
+  "finished_width_cm",
+  "size_label",
   "finishes",
   "notes",
   "accepting_custom_orders",
@@ -49,6 +52,21 @@ export const productSpecSchemaProps = () => ({
     description:
       "Measured parameters keyed by the catalog's param keys (gsm, ends_per_inch, picks_per_inch, warp_yarn_count, weft_yarn_count, loom_width_cm, plus technique-specific ones). Values are numbers and are REJECTED if outside the chosen technique's min/max — call get_spec_catalog first to see the ranges.",
     additionalProperties: { type: "number" },
+  },
+  finished_length_cm: {
+    type: "integer",
+    description:
+      "The FINISHED piece's length in centimetres, 1-2000. NOT a weave param and NOT loom_width_cm — that is the cloth on the loom, before it is cut, hemmed and washed. A product with no weave technique still has a size.",
+  },
+  finished_width_cm: {
+    type: "integer",
+    description:
+      "The FINISHED piece's width in centimetres, 1-2000. See finished_length_cm.",
+  },
+  size_label: {
+    type: "string",
+    description:
+      "What the trade calls that size — 'Stole', 'Full shawl', 'King' (≤ 80 chars). Shown alongside the measurement, not instead of it.",
   },
   finishes: {
     type: "array",

--- a/apps/backend/src/modules/shipping-providers/__tests__/export-origins.unit.spec.ts
+++ b/apps/backend/src/modules/shipping-providers/__tests__/export-origins.unit.spec.ts
@@ -1,5 +1,6 @@
 import {
   coreOriginsFromLocations,
+  exportOriginRows,
   rateWithOriginFallback,
 } from "../export-origins"
 
@@ -383,5 +384,66 @@ describe("rateWithOriginFallback", () => {
     })
     // The caller falls back to its flat rate — this must not manufacture one.
     expect(routes).toEqual([])
+  })
+})
+
+/**
+ * #1498 — "we own the stock here" is not "an export may leave from here".
+ *
+ * The relay read `is_core` as both. Prod has exactly two `is_core` locations
+ * and one is Dharamshala, which holds stock and is not an export hub, so a
+ * shipment could be relayed somewhere it cannot be exported from — and priced
+ * as though it had worked.
+ */
+describe("exportOriginRows", () => {
+  const DELHI = { stock_location_id: "sloc_delhi", is_core: true }
+  const DHARAMSHALA = { stock_location_id: "sloc_dh", is_core: true }
+  const PARTNER = { stock_location_id: "sloc_partner", is_core: false }
+
+  it("falls back to `is_core` while NOBODY has answered", () => {
+    // Today's behaviour, unchanged: this ships inert until an operator decides.
+    const rows = exportOriginRows([DELHI, DHARAMSHALA, PARTNER])
+    expect(rows.map((r) => r.stock_location_id)).toEqual([
+      "sloc_delhi",
+      "sloc_dh",
+    ])
+  })
+
+  it("🔴 stops inferring ENTIRELY once any row states an answer", () => {
+    // The all-or-nothing rule. A per-row `?? is_core` fallback would leave
+    // Dharamshala exporting on the old rule the moment Delhi was marked — so
+    // the first correct answer would have changed nothing.
+    const rows = exportOriginRows([
+      { ...DELHI, is_export_origin: true },
+      DHARAMSHALA,
+      PARTNER,
+    ])
+    expect(rows.map((r) => r.stock_location_id)).toEqual(["sloc_delhi"])
+  })
+
+  it("treats an explicit `false` as an answer, not as silence", () => {
+    // Marking the NON-hub is the other way an operator may state it, and it
+    // must switch the inference off just as firmly.
+    const rows = exportOriginRows([
+      DELHI,
+      { ...DHARAMSHALA, is_export_origin: false },
+    ])
+    expect(rows).toEqual([])
+  })
+
+  it("does not require a hub to be core", () => {
+    // A bonded warehouse we export from but hold no stock in is a real shape,
+    // and it is the reason these are two columns rather than one.
+    const rows = exportOriginRows([
+      { ...PARTNER, is_export_origin: true },
+      DHARAMSHALA,
+    ])
+    expect(rows.map((r) => r.stock_location_id)).toEqual(["sloc_partner"])
+  })
+
+  it("is empty rather than everything on no rows at all", () => {
+    // `filters: { id: undefined }` is NO filter (#1433). An empty origin set
+    // must degrade to "no relay available", never to "every location".
+    expect(exportOriginRows([])).toEqual([])
   })
 })

--- a/apps/backend/src/modules/shipping-providers/export-origins.ts
+++ b/apps/backend/src/modules/shipping-providers/export-origins.ts
@@ -53,11 +53,18 @@
  *
  * ## Where the origins come from
  *
- * `location_ownership.is_core` — the warehouses we already record as ours. Not
- * an environment variable: that made the whole feature inert until somebody
- * remembered to set it, and made "we opened a warehouse" a deploy. A partner
- * who later gets their own pin export-enabled needs no change at all, because
- * a rateable partner origin means the relay never runs.
+ * `location_ownership.is_export_origin` — the hubs an operator has marked as
+ * places an export may leave from. Not an environment variable: that made the
+ * whole feature inert until somebody remembered to set it, and made "we opened
+ * a warehouse" a deploy. A partner who later gets their own pin export-enabled
+ * needs no change at all, because a rateable partner origin means the relay
+ * never runs.
+ *
+ * 🔴 Until an operator states the first one, this falls back to `is_core` —
+ * the behaviour that shipped first, and a documented conflation: `is_core`
+ * means "we own the stock here", not "we can export from here". Prod's two
+ * core locations include Dharamshala, which is not a hub. See
+ * `exportOriginRows` for why the fallback is all-or-nothing.
  *
  * ## 🔴 What it will not do
  *
@@ -143,20 +150,54 @@ export function coreOriginsFromLocations(
 }
 
 /**
- * The export origins available to fall back on — our OWN warehouses.
+ * PURE: which ownership rows may be exported FROM.
+ *
+ * ## The split (#1498)
+ *
+ * `is_core` answers "may we deduct consumption from this stock". This function
+ * answers "may an export leave from here", and they are not the same question:
+ * prod has exactly two `is_core` locations and one is **Dharamshala**, which
+ * holds our stock and is not an export hub. Reading one as the other relayed
+ * shipments to a warehouse that cannot export them and priced the result as
+ * though it worked.
+ *
+ * 🔑 The fallback is ALL-OR-NOTHING, and that is the whole design.
+ *
+ * - If ANY row states `is_export_origin`, only the rows that state `true` are
+ *   origins. The inference stops the moment there is a real answer, including
+ *   for the rows that still say nothing — otherwise marking Delhi `true` would
+ *   leave Dharamshala quietly exporting on the old rule, which is the exact bug
+ *   this splits apart.
+ * - If NO row states anything, every `is_core` row is an origin — today's
+ *   behaviour, unchanged, so this ships inert until an operator decides.
+ *
+ * 🔴 A per-row `?? is_core` fallback would look kinder and be wrong for that
+ * reason: it makes the first correct answer a no-op.
+ */
+export function exportOriginRows<T extends { is_core?: boolean; is_export_origin?: boolean | null }>(
+  rows: T[]
+): T[] {
+  const stated = (rows ?? []).filter(
+    (r) => r?.is_export_origin === true || r?.is_export_origin === false
+  )
+  if (stated.length) return stated.filter((r) => r.is_export_origin === true)
+  return (rows ?? []).filter((r) => r?.is_core === true)
+}
+
+/**
+ * The export origins available to fall back on — our OWN export hubs.
  *
  * ## Why ownership, and not configuration
  *
  * An earlier cut read these from `EXPORT_FALLBACK_ORIGINS`. That made the whole
  * feature inert until somebody remembered to set an environment variable, and
- * made "we opened a warehouse" a deploy. `location_ownership.is_core` already
- * records the exact fact this needs — *we own the stock here* — it is set from
- * the ops UI, and a new hub starts winning the moment it is marked.
+ * made "we opened a warehouse" a deploy. `location_ownership` already records
+ * the facts this needs, it is set from the ops UI, and a new hub starts winning
+ * the moment it is marked.
  *
- * ⚠️ It is a deliberate CONFLATION: `is_core` was written to answer "may we
- * deduct consumption from this stock", and this reads it as "may we export from
- * here". Those are the same set today (our warehouses) and there is no second
- * table to disagree with. If they ever diverge, this is the line to split.
+ * ⚠️ It USED to read `is_core` and call that "may we export from here" — a
+ * conflation this file documented and #1498 has now split. See
+ * `exportOriginRows` for what replaced it and why the fallback is all-or-nothing.
  *
  * 🔴 A location with NO ownership row is not an origin. The model treats an
  * unrecorded location as not-ours precisely so an unknown location cannot be
@@ -176,10 +217,17 @@ export async function resolveCoreExportOrigins(scope: any): Promise<ExportOrigin
     const { ContainerRegistrationKeys } = await import("@medusajs/framework/utils")
     const ownership: any = scope.resolve("location_ownership")
 
-    const rows = await ownership.listLocationOwnerships(
-      { is_core: true },
-      { take: null }
-    )
+    /**
+     * 🔴 Read ALL rows, not `{ is_core: true }`.
+     *
+     * The all-or-nothing rule needs to know whether ANY row has stated an
+     * export opinion, and a filtered read cannot see a row that says
+     * `is_export_origin: false` on a non-core location. The table is one row
+     * per stock location — tens, not thousands — so this is a cheap full read
+     * and the alternative is a wrong answer.
+     */
+    const allRows = await ownership.listLocationOwnerships({}, { take: null })
+    const rows = exportOriginRows((allRows ?? []) as any[])
     const ids = ((rows ?? []) as any[])
       .map((r) => r?.stock_location_id)
       .filter(Boolean)

--- a/apps/backend/src/workflows/products/upsert-product-spec.ts
+++ b/apps/backend/src/workflows/products/upsert-product-spec.ts
@@ -48,6 +48,10 @@ export type ProductSpecInput = {
   weave_technique?: string | null
   weave_label?: string | null
   params?: Record<string, number> | null
+  /** The FINISHED piece, in centimetres. Not a weave param — see the model. */
+  finished_length_cm?: number | null
+  finished_width_cm?: number | null
+  size_label?: string | null
   finishes?: string[] | null
   notes?: string | null
   accepting_custom_orders?: boolean

--- a/apps/partner-ui/src/components/forms/product-spec-form/product-spec-form.tsx
+++ b/apps/partner-ui/src/components/forms/product-spec-form/product-spec-form.tsx
@@ -234,6 +234,76 @@ export const ProductSpecForm = ({
           </div>
         </div>
 
+        {/* The FINISHED piece.
+            🔴 Outside the technique block on purpose: size is a property of the
+            article, not of how it was woven, so a product with no technique
+            still has one. `loom_width_cm` below is a different measurement —
+            the cloth ON the loom, before it is cut, hemmed and washed. */}
+        <div className="grid gap-4 md:grid-cols-3">
+          <div className="flex flex-col gap-y-2">
+            <Label size="small" weight="plus">
+              Size name
+            </Label>
+            <Input
+              placeholder="Stole"
+              value={value.size_label ?? ""}
+              onChange={(e) => patch({ size_label: e.target.value })}
+            />
+          </div>
+          <div className="flex flex-col gap-y-2">
+            <Label size="small" weight="plus">
+              Finished length
+            </Label>
+            <div className="flex items-center gap-x-2">
+              <Input
+                type="number"
+                min={1}
+                max={2000}
+                placeholder="200"
+                value={value.finished_length_cm ?? ""}
+                onChange={(e) =>
+                  patch({
+                    finished_length_cm: e.target.value
+                      ? Number(e.target.value)
+                      : null,
+                  })
+                }
+              />
+              <Text size="xsmall" className="text-ui-fg-muted">
+                cm
+              </Text>
+            </div>
+          </div>
+          <div className="flex flex-col gap-y-2">
+            <Label size="small" weight="plus">
+              Finished width
+            </Label>
+            <div className="flex items-center gap-x-2">
+              <Input
+                type="number"
+                min={1}
+                max={2000}
+                placeholder="70"
+                value={value.finished_width_cm ?? ""}
+                onChange={(e) =>
+                  patch({
+                    finished_width_cm: e.target.value
+                      ? Number(e.target.value)
+                      : null,
+                  })
+                }
+              />
+              <Text size="xsmall" className="text-ui-fg-muted">
+                cm
+              </Text>
+            </div>
+          </div>
+          <Text size="xsmall" className="text-ui-fg-muted md:col-span-3">
+            Shown on the product page and on every quote for this product. A
+            buyer approving a consignment asks this before anything else.
+          </Text>
+        </div>
+
         {!!technique?.presets.length && (
           <div className="flex flex-wrap items-center gap-2">
             <Text size="xsmall" className="text-ui-fg-muted">

--- a/apps/partner-ui/src/hooks/api/partner-quotes.tsx
+++ b/apps/partner-ui/src/hooks/api/partner-quotes.tsx
@@ -88,7 +88,14 @@ export type PartnerQuote = {
   quoted_weight_grams?: number | null
   quoted_at?: string | null
 
+  /** The STORED column. `expired` is never one of its values — see below. */
   status: "active" | "revoked" | "superseded"
+  /**
+   * What `status` means today (#1510). Computed server-side from `status` and
+   * `expires_at` by the same helper the buyer's quote page uses, so an expired
+   * quote stops reading `active` on every screen that shows the word.
+   */
+  status_effective?: "active" | "expired" | "revoked" | "superseded"
   expires_at?: string | null
 
   /**
@@ -431,4 +438,48 @@ export const usePartnerQuotableDesigns = (
     count: data?.count ?? 0,
     ...rest,
   }
+}
+
+/** What the revoke route answers with. */
+export type RevokePartnerQuoteResponse = {
+  quote: PartnerQuote
+  /** Whether the minted price list was actually deleted, for the toast. */
+  price_list_deleted?: boolean
+}
+
+/**
+ * A partner withdraws their own quote (#1517).
+ *
+ * 🔴 DESTRUCTIVE. It deletes the price list behind the quote, so the buyer
+ * loses the quoted prices in any cart they have built as well as the link.
+ * The caller must put it behind a confirm — a one-click revoke in a row menu is
+ * how that gets done by accident.
+ *
+ * Invalidates the DETAIL as well as the list: the page the partner is standing
+ * on is the one whose badge has just changed, and leaving it stale shows
+ * "Active" beside a toast that says it was revoked.
+ */
+export const useRevokePartnerQuote = (
+  id: string,
+  options?: UseMutationOptions<RevokePartnerQuoteResponse, FetchError, void>
+) => {
+  return useMutation({
+    mutationFn: async () =>
+      await sdk.client.fetch<RevokePartnerQuoteResponse>(
+        `/partners/quotes/${id}/revoke`,
+        { method: "POST" }
+      ),
+    onSuccess: async (data, variables, context) => {
+      await Promise.all([
+        queryClient.invalidateQueries({
+          queryKey: partnerQuotesQueryKeys.lists(),
+        }),
+        queryClient.invalidateQueries({
+          queryKey: partnerQuotesQueryKeys.detail(id),
+        }),
+      ])
+      options?.onSuccess?.(data, variables, context)
+    },
+    ...options,
+  })
 }

--- a/apps/partner-ui/src/hooks/api/products.tsx
+++ b/apps/partner-ui/src/hooks/api/products.tsx
@@ -850,6 +850,15 @@ export type ProductSpec = {
   weave_technique?: string | null
   weave_label?: string | null
   params?: Record<string, number> | null
+  /**
+   * The FINISHED piece, in centimetres. NOT a weave param — those are keyed to
+   * the chosen technique and rejected without one; a size belongs to the
+   * article and survives a product that has no weave at all.
+   */
+  finished_length_cm?: number | null
+  finished_width_cm?: number | null
+  /** What the trade calls that size — "Stole", "Full shawl". */
+  size_label?: string | null
   finishes?: string[] | null
   notes?: string | null
   accepting_custom_orders?: boolean | null

--- a/apps/partner-ui/src/routes/orders/quote-detail/quote-detail.tsx
+++ b/apps/partner-ui/src/routes/orders/quote-detail/quote-detail.tsx
@@ -1,9 +1,18 @@
-import { Container, Heading, StatusBadge, Text } from "@medusajs/ui"
+import {
+  Button,
+  Container,
+  Heading,
+  StatusBadge,
+  Text,
+  toast,
+  usePrompt,
+} from "@medusajs/ui"
 import { useTranslation } from "react-i18next"
 import { useParams } from "react-router-dom"
 
 import {
   usePartnerQuote,
+  useRevokePartnerQuote,
   type PartnerQuoteEvent,
 } from "../../../hooks/api/partner-quotes"
 import { PaymentSchedulePanel } from "./components/payment-schedule-panel"
@@ -96,6 +105,44 @@ export const QuoteDetail = () => {
   // branch resolve to whichever matched last.
   const { quoteId } = useParams()
   const { quote, isLoading } = usePartnerQuote(quoteId!)
+  const prompt = usePrompt()
+  const revoke = useRevokePartnerQuote(quoteId!)
+
+  const handleRevoke = async () => {
+    /**
+     * 🔴 Behind a confirm, and the confirm says what is actually lost.
+     *
+     * Revoking DELETES the price list behind the quote, so a buyer who has
+     * already built a cart at these prices loses them too — not just the link.
+     * A partner who reads "revoke this quote?" does not know that; the sentence
+     * has to say it.
+     */
+    const confirmed = await prompt({
+      title: t("quotes.revoke.title", "Withdraw this quote?"),
+      description: t(
+        "quotes.revoke.description",
+        "The buyer's link stops working immediately and the prices frozen for them are deleted — including in any cart they have already built. This cannot be undone; a corrected quote has to be minted fresh, which sends them a new number."
+      ),
+      confirmText: t("quotes.revoke.confirm", "Withdraw"),
+      cancelText: t("general.cancel", "Cancel"),
+      variant: "danger",
+    })
+    if (!confirmed) return
+
+    try {
+      await revoke.mutateAsync()
+      toast.success(
+        t("quotes.revoke.success", "Quote withdrawn. The buyer's link is dead.")
+      )
+    } catch (e: any) {
+      // The route's refusals are written for the partner reading them — an
+      // accepted quote names who can unwind it — so show the message rather
+      // than a generic failure.
+      toast.error(
+        e?.message ?? t("quotes.revoke.error", "Could not withdraw the quote.")
+      )
+    }
+  }
 
   if (isLoading || !quote) {
     return (
@@ -109,7 +156,39 @@ export const QuoteDetail = () => {
     )
   }
 
-  const isRevoked = (quote as any).status === "revoked"
+  /**
+   * #1510 — the EFFECTIVE status. `status` alone read "Active" on a quote whose
+   * link the buyer page was already refusing to price.
+   */
+  const status =
+    (quote as any).status_effective ?? (quote as any).status ?? "active"
+  const isAccepted = !!(quote as any).accepted_at
+  /**
+   * Revoke is offered only while there is something to revoke.
+   *
+   * An accepted quote is deliberately NOT the partner's to withdraw — the
+   * buyer built a cart at these prices and may have paid a deposit against it,
+   * so unwinding is an operator's decision with a conversation attached. The
+   * route refuses it; this hides the button rather than letting a partner press
+   * it and read an error to find out.
+   */
+  const canRevoke = status === "active" && !isAccepted
+
+  const STATUS_BADGE: Record<
+    string,
+    { color: "green" | "red" | "orange" | "grey"; label: string }
+  > = {
+    active: { color: "green", label: t("quotes.status.active", "Active") },
+    // Not red: nothing went wrong, the offer simply ran out its clock.
+    expired: { color: "grey", label: t("quotes.status.expired", "Expired") },
+    // Not red either: a newer quote replaced this one; nobody withdrew it.
+    superseded: {
+      color: "orange",
+      label: t("quotes.status.superseded", "Superseded"),
+    },
+    revoked: { color: "red", label: t("quotes.status.revoked", "Revoked") },
+  }
+  const badge = STATUS_BADGE[status] ?? STATUS_BADGE.active
 
   return (
     <div className="flex flex-col gap-y-3">
@@ -134,11 +213,20 @@ export const QuoteDetail = () => {
                 {t("quotes.status.accepted", "Accepted")}
               </StatusBadge>
             ) : null}
-            <StatusBadge color={isRevoked ? "red" : "green"}>
-              {isRevoked
-                ? t("quotes.status.revoked", "Revoked")
-                : t("quotes.status.active", "Active")}
-            </StatusBadge>
+            <StatusBadge color={badge.color}>{badge.label}</StatusBadge>
+            {/* #1517 — a partner can withdraw their own mis-quote rather than
+                asking an operator, or re-minting and emailing the buyer a new
+                number they never asked for. */}
+            {canRevoke ? (
+              <Button
+                size="small"
+                variant="secondary"
+                onClick={handleRevoke}
+                isLoading={revoke.isPending}
+              >
+                {t("quotes.revoke.action", "Withdraw")}
+              </Button>
+            ) : null}
           </div>
         </div>
 

--- a/apps/partner-ui/src/routes/orders/quote-list/components/quote-list-table.tsx
+++ b/apps/partner-ui/src/routes/orders/quote-list/components/quote-list-table.tsx
@@ -16,12 +16,26 @@ const PAGE_SIZE = 20
 const columnHelper = createDataTableColumnHelper<PartnerQuote>()
 
 /**
- * A quote is expired when its own `expires_at` has passed. Core enforces this
- * natively on the minted price list (`ends_at`), so this is presentation only —
- * the buyer's prices stop applying whether or not this badge renders.
+ * The word to put on the badge (#1510).
+ *
+ * 🔑 The SERVER decides. `status_effective` is computed by the list route from
+ * the same helper the buyer page uses, so the table, the detail page and the
+ * quote link cannot form three opinions about whether an offer still stands.
+ * This table used to derive expiry itself — with `<` where the server uses
+ * `<=`, which is exactly how two surfaces start disagreeing on the boundary.
+ *
+ * The local derivation survives only as a rollout bridge: partner-ui deploys
+ * separately from the backend, and a UI that got there first must not put
+ * "Active" on a dead quote for the length of one deploy.
  */
-const isExpired = (quote: PartnerQuote) =>
-  !!quote.expires_at && new Date(quote.expires_at).getTime() < Date.now()
+const effectiveStatus = (quote: PartnerQuote) => {
+  if (quote.status_effective) return quote.status_effective
+  if (quote.status !== "active") return quote.status
+  return quote.expires_at &&
+    new Date(quote.expires_at).getTime() <= Date.now()
+    ? "expired"
+    : "active"
+}
 
 const useColumns = () => {
   const { t } = useTranslation()
@@ -100,16 +114,16 @@ const useColumns = () => {
       columnHelper.accessor("status", {
         header: t("fields.status", "Status"),
         cell: ({ row }) => {
-          const quote = row.original
-          if (quote.status === "revoked") {
+          const status = effectiveStatus(row.original)
+          if (status === "revoked") {
             return <StatusBadge color="red">Revoked</StatusBadge>
           }
           // A newer quote for the same buyer expired this one's price list
           // (#1435). Not a withdrawal, so not red.
-          if (quote.status === "superseded") {
+          if (status === "superseded") {
             return <StatusBadge color="orange">Superseded</StatusBadge>
           }
-          if (isExpired(quote)) {
+          if (status === "expired") {
             return <StatusBadge color="grey">Expired</StatusBadge>
           }
           return <StatusBadge color="green">Active</StatusBadge>

--- a/apps/partner-ui/src/routes/products/product-spec/product-spec.tsx
+++ b/apps/partner-ui/src/routes/products/product-spec/product-spec.tsx
@@ -38,6 +38,9 @@ const EMPTY: ProductSpecPayload = {
   weave_technique: null,
   weave_label: null,
   params: null,
+  finished_length_cm: null,
+  finished_width_cm: null,
+  size_label: null,
   finishes: [],
   notes: null,
   accepting_custom_orders: false,
@@ -68,6 +71,9 @@ const ProductSpecEditor = ({ id }: { id: string }) => {
       weave_technique: spec.weave_technique ?? null,
       weave_label: spec.weave_label ?? null,
       params: spec.params ?? null,
+      finished_length_cm: spec.finished_length_cm ?? null,
+      finished_width_cm: spec.finished_width_cm ?? null,
+      size_label: spec.size_label ?? null,
       finishes: spec.finishes ?? [],
       notes: spec.notes ?? null,
       accepting_custom_orders: !!spec.accepting_custom_orders,
@@ -106,6 +112,9 @@ const ProductSpecEditor = ({ id }: { id: string }) => {
     const payload: ProductSpecPayload = {
       ...value,
       weave_label: value.weave_label?.trim() ? value.weave_label.trim() : null,
+      // An emptied box means "no size", not an empty string every surface then
+      // renders as a blank "Size:" line.
+      size_label: value.size_label?.trim() ? value.size_label.trim() : null,
       notes: value.notes?.trim() ? value.notes.trim() : null,
       colors: (value.colors ?? []).filter((c) => c.name.trim()),
       fields: (value.fields ?? []).filter((f) => (f.label ?? f.key).trim()),

--- a/apps/storefront/src/lib/data/quotes.ts
+++ b/apps/storefront/src/lib/data/quotes.ts
@@ -89,6 +89,20 @@ export type QuoteLineSpec = {
   weave_label: string | null
   rows: QuoteSpecRow[]
   finishes: string[]
+  /** The spec's own answer to "how big". The LINE may have a stronger one. */
+  size: string | null
+}
+
+/**
+ * The finished piece's size, and which source stated it.
+ *
+ * `variant` is the SKU being quoted and is the strongest claim; `product` is
+ * the catalogue's dimensions and is the weakest, so the page says so — the
+ * same treatment `image_source` and `weight_source` get.
+ */
+export type QuoteLineSize = {
+  label: string
+  source: "variant" | "spec" | "product"
 }
 
 /** The producing partner, when the buyer is NOT on that partner's own shop. */
@@ -149,6 +163,8 @@ export type QuoteViewLine = {
   thumbnail: string | null
   image_source: "variant" | "product" | null
   spec: QuoteLineSpec | null
+  /** "How big is it" — the question that comes before any weave number. */
+  size?: QuoteLineSize | null
   /**
    * Every image on this variant, merchandiser-ordered (#1439 S14). Empty when
    * the variant has none of its own — `thumbnail` may then be the PRODUCT's,

--- a/apps/storefront/src/modules/quotes/components/quote-lines/index.tsx
+++ b/apps/storefront/src/modules/quotes/components/quote-lines/index.tsx
@@ -68,6 +68,14 @@ const LineRow = ({
               {line.variant_title}
             </Text>
           ) : null}
+          {/* How big it is, directly under what it is — the question a buyer
+              approving a consignment asks before any weave number. A quote used
+              to state the ends-per-inch and never the size of the piece. */}
+          {line.size ? (
+            <Text className="txt-small text-ui-fg-subtle">
+              Size: {line.size.label}
+            </Text>
+          ) : null}
           {line.note ? (
             <Text className="txt-small text-ui-fg-muted italic mt-1">
               {line.note}
@@ -86,6 +94,14 @@ const LineRow = ({
           {line.image_source === "product" ? (
             <Text className="txt-small text-ui-fg-muted mt-1">
               Image shows the product; this variant may differ.
+            </Text>
+          ) : null}
+          {/* A PRODUCT-level size on a variant-specific line is the same weaker
+              claim as a product thumbnail, and gets the same caveat rather than
+              being passed off as the variant's own measurement. */}
+          {line.size?.source === "product" ? (
+            <Text className="txt-small text-ui-fg-muted mt-1">
+              Size is the product&apos;s; this variant may differ.
             </Text>
           ) : null}
           {line.spec ? <QuoteLineSpecRows spec={line.spec} /> : null}


### PR DESCRIPTION
Closes #1510. Advances #1498 and completes the UI half of #1517.

## `active` did not mean active (#1510)

`partner_quote.status` has no `expired` value and nothing moves a row out of `active` when `expires_at` passes. The buyer page was always right — it derives expiry at read time and refuses to price a dead link — but every surface reading the COLUMN was wrong. Prod reported *"8 of 8 active"* with no way to tell how many still stood.

Derived, not swept: `status` stays the stored fact, `status_effective` is computed beside it **from `quoteUnusableReason`** — the helper the buyer page already calls. No enum widened, so no migration.

🔴 `status=active|expired` is translated in the **filter**, not over the page, or `count` and the pager describe a different set from the rows. The expiry predicate nests under `$and` because the free-text search already owns `$or`.

Partner-ui had been deriving expiry itself, with `<` where the server uses `<=` — that copy is now only a deploy-order bridge.

## A quote never said how big the thing was (#1498)

A buyer approving a consignment could read the ends-per-inch and the GSM and not the size of the piece.

`product_spec` gains `finished_length_cm` / `finished_width_cm` / `size_label`. 🔴 Not weave params — `validateWeaveParams` rejects any key the technique does not list and refuses params without a technique, so a shared "size" param would be unavailable to every product with no weave.

`resolveLineSize` picks one answer from the strongest source that has one (variant option → spec → product dimensions) and reports which. A product-level size on a variant-specific line gets the same caveat a product thumbnail already gets.

🔴 A fact, never a picker.

The MCP contract test caught the missing `bodyParams` entries — a field absent from that list is silently stripped (#1348).

## The revoke button (#1517)

`/partners/quotes/:id/revoke` shipped API- and MCP-only. Partner-ui now has it, behind a confirm that says the price list is deleted — so a buyer who already built a cart loses the prices too, not just the link. Hidden rather than disabled on an accepted quote.

## `is_core` was answering a question it was not asked (#1498)

`is_core` means "we own the stock here". The freight relay read it as "an export may leave from here" — `export-origins.ts` documented the conflation and named this as the line to split. Prod has exactly two `is_core` locations and one is **Dharamshala**, which holds stock and is not an export hub.

`is_export_origin` is nullable and null is not false. 🔑 **All-or-nothing**: while nobody has answered, every `is_core` row is an origin (today's behaviour — ships inert); the moment any row states true *or* false the inference stops for the whole set. A per-row `?? is_core` fallback would leave Dharamshala exporting the day Delhi was marked, making the first correct answer a no-op.

## Verified

- `check:prod-build` green **after the last edit**
- Unit 385/385 (partner-quote, product-spec, partners/products) + 21/21 export-origins
- `apps/storefront` `next build` exit 0
- ⚠️ `apps/partner-ui` still has no CI; typecheck/build run by hand and **the revoke button and the spec size fields have not been clicked**

## Merge order

Contains a submodule bump to `nextjs-starter-medusa#30` (the storefront half of the size line). `4681e15` is an ancestor of the new pointer, so it is not a silent revert — but **merge starter#30 first**.

## Still to do on prod, deliberately not here

Mark Delhi an export origin and Dharamshala not; correct Dharamshala's `province` (it reads `Himachal Nagar`). 🔴 Do **not** ship a province→state-code guard against that data — it would fail toward "no export origin", i.e. flat freight at any weight.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_0158wJMZ1DmjNxXf5uGuBrQD