### PR TITLE
feat(quotes): correct a quote in place before the buyer accepts

### DIFF
--- a/apps/backend/src/api/admin/quotes/[id]/adjust/route.ts
+++ b/apps/backend/src/api/admin/quotes/[id]/adjust/route.ts
@@ -1,0 +1,42 @@
+import { MedusaRequest, MedusaResponse } from "@medusajs/framework/http"
+import { MedusaError } from "@medusajs/framework/utils"
+
+import { PARTNER_QUOTE_MODULE } from "../../../../../modules/partner-quote"
+import { adjustQuote } from "../../../../../modules/partner-quote/lib/adjust-quote"
+import { withEffectiveStatus } from "../../../../../modules/partner-quote/lib/token"
+
+/**
+ * An admin corrects any quote, in place, before the buyer accepts.
+ *
+ * The same capability the partner has, reached differently: an admin may touch
+ * any quote, so there is no ownership scoping on the lookup. That is the whole
+ * difference between the two surfaces — the refusals themselves live in
+ * `adjustQuote` so the two cannot drift.
+ *
+ * 🔴 An admin gets NO override on the accepted-quote refusal, unlike revoke.
+ * Revoking a live deal is an operator's decision with a conversation attached;
+ * silently re-pricing one the buyer has already committed to is not a decision
+ * anybody should be able to make through an API.
+ */
+export const POST = async (req: MedusaRequest, res: MedusaResponse) => {
+  const service: any = req.scope.resolve(PARTNER_QUOTE_MODULE)
+
+  const quotes = await service.listPartnerQuotes({ id: req.params.id })
+  const quote = quotes?.[0]
+  if (!quote) {
+    throw new MedusaError(MedusaError.Types.NOT_FOUND, "Quote not found")
+  }
+
+  const result = await adjustQuote(
+    req.scope,
+    quote,
+    req.validatedBody as any,
+    { type: "admin", id: (req as any).auth_context?.actor_id ?? null }
+  )
+
+  res.json({
+    quote: withEffectiveStatus(result.quote, new Date()),
+    changes: result.changes,
+    notify_buyer: result.notify,
+  })
+}

--- a/apps/backend/src/api/middlewares.ts
+++ b/apps/backend/src/api/middlewares.ts
@@ -306,7 +306,7 @@ import { BulkImportSchema } from "./admin/inventory-items/bulk-import/validators
 import { PartnerCreateStoreReq } from "./partners/stores/validators";
 import { PartnerCreateProductReq, PartnerArtisanProductDetailReq, PartnerProductSpecReq, PartnerStoreCreateProductReq, PartnerQuickCreateProductReq } from "./partners/products/validators";
 import { PartnerCreatePriceListReq, PartnerUpdatePriceListReq } from "./partners/price-lists/validators";
-import { PartnerMintQuoteReq, QuoteReadinessReq } from "./partners/quotes/validators";
+import { AdjustQuoteReq, PartnerMintQuoteReq, QuoteReadinessReq } from "./partners/quotes/validators";
 import { AdminMintQuoteReq, AdminQuoteReadinessReq } from "./admin/quotes/validators";
 import { BATCH_VARIANT_FIELDS } from "../workflows/partner/batch-partner-variants";
 import { StoreMadeToSpecReq } from "./store/carts/[id]/made-to-spec/validators";
@@ -5649,6 +5649,13 @@ export default defineMiddlewares({
         validateAndTransformBody(wrapSchema(AdminQuoteReadinessReq)),
       ],
     },
+    // An admin corrects any quote in place, before acceptance. Same body as the
+    // partner surface — the refusals live in `adjustQuote` so they cannot drift.
+    {
+      matcher: "/admin/quotes/:id/adjust",
+      method: "POST",
+      middlewares: [validateAndTransformBody(wrapSchema(AdjustQuoteReq))],
+    },
     // A partner withdraws their own quote (#1517). Registered BEFORE
     // /partners/quotes/:id for the same reason `readiness` and `designs` are:
     // this file's ordering is the contract, and a route that lands after the
@@ -5661,6 +5668,18 @@ export default defineMiddlewares({
       middlewares: [
         createCorsPartnerMiddleware(),
         authenticate("partner", ["session", "bearer"]),
+      ],
+    },
+    // A partner corrects their own quote in place, before acceptance.
+    // Registered BEFORE /partners/quotes/:id for the same ordering reason as
+    // revoke above — this file's order is the contract.
+    {
+      matcher: "/partners/quotes/:id/adjust",
+      method: "POST",
+      middlewares: [
+        createCorsPartnerMiddleware(),
+        authenticate("partner", ["session", "bearer"]),
+        validateAndTransformBody(wrapSchema(AdjustQuoteReq)),
       ],
     },
     {

--- a/apps/backend/src/api/partners/quotes/[id]/adjust/route.ts
+++ b/apps/backend/src/api/partners/quotes/[id]/adjust/route.ts
@@ -1,0 +1,63 @@
+import { AuthenticatedMedusaRequest, MedusaResponse } from "@medusajs/framework/http"
+import { MedusaError } from "@medusajs/framework/utils"
+
+import { PARTNER_QUOTE_MODULE } from "../../../../../modules/partner-quote"
+import { adjustQuote } from "../../../../../modules/partner-quote/lib/adjust-quote"
+import { withEffectiveStatus } from "../../../../../modules/partner-quote/lib/token"
+import { getPartnerFromAuthContext } from "../../../helpers"
+
+/**
+ * A partner corrects their own quote, in place, before the buyer accepts.
+ *
+ * ## Why this is not "revoke and re-mint"
+ *
+ * Re-minting emails the buyer a NEW quote number for what is, from their side,
+ * a correction to the document they are already reading — and it mints a fresh
+ * price list and supersedes the old one, which is a great deal of machinery to
+ * move a shipping figure. The common case is exactly that: a lane no carrier
+ * would rate falls through to a flat tier nobody chose.
+ *
+ * The link, the quote number and the frozen prices all survive an adjustment.
+ *
+ * 🔑 Ownership is checked against the AUTH CONTEXT, not taken from the URL —
+ * the id in the path names a row that may belong to anyone, and validating only
+ * that it exists is the #1404 defect. Another partner's quote is a 404, not a
+ * 403: a partner has no business learning that someone else's quote id is real.
+ */
+export const POST = async (req: AuthenticatedMedusaRequest, res: MedusaResponse) => {
+  const partner = await getPartnerFromAuthContext(req.auth_context, req.scope)
+  if (!partner) {
+    throw new MedusaError(
+      MedusaError.Types.UNAUTHORIZED,
+      "No partner associated with this account"
+    )
+  }
+
+  const service: any = req.scope.resolve(PARTNER_QUOTE_MODULE)
+  const quotes = await service.listPartnerQuotes({
+    id: req.params.id,
+    partner_id: partner.id,
+  })
+
+  const quote = quotes?.[0]
+  if (!quote) {
+    throw new MedusaError(MedusaError.Types.NOT_FOUND, "Quote not found")
+  }
+
+  const result = await adjustQuote(
+    req.scope,
+    quote,
+    req.validatedBody as any,
+    { type: "partner", id: req.auth_context?.actor_id ?? null }
+  )
+
+  res.json({
+    quote: withEffectiveStatus(result.quote, new Date()),
+    changes: result.changes,
+    /**
+     * Whether the buyer should be told. The caller sends the mail — this route
+     * decides only whether it is warranted, so both surfaces agree on when.
+     */
+    notify_buyer: result.notify,
+  })
+}

--- a/apps/backend/src/api/partners/quotes/validators.ts
+++ b/apps/backend/src/api/partners/quotes/validators.ts
@@ -268,6 +268,45 @@ export const PartnerMintQuoteShape = z.object({
   deposit_pct: z.number().min(0).max(100).nullish(),
 })
 
+/**
+ * Correct a quote in place, before the buyer accepts (adjustment).
+ *
+ * 🔑 Deliberately NOT the mint shape minus fields. An adjustment may only touch
+ * what lives on the quote ROW; the basket and its prices live in a minted price
+ * list guarded by the mint's re-read assertion, and a second way to write them
+ * is a second way to cut prices platform-wide. See `adjust-quote.ts`.
+ *
+ * ⚠️ `zodValidator` forces `.strict()`, so a field absent here does not merely
+ * get ignored — it never reaches the handler. Anything adjustable must be named.
+ */
+export const AdjustQuoteShape = z.object({
+  /**
+   * 🔴 `.positive()`, never `.min(0)`. A zero here is free international
+   * shipping typed by accident, and this system has already shipped bulk orders
+   * free once from a rule-gated `0` row (#1430). Send `null` to mean "leave it".
+   */
+  freight_amount: z.number().positive().nullish(),
+  /** Who quoted it and on what basis — evidence, like `duty_basis`. */
+  freight_basis: z.string().max(500).nullish(),
+  partner_note: z.string().max(5000).nullish(),
+  /** Absolute, not a delta. Moves the price list's `ends_at` with it. */
+  expires_at: z.coerce.date().nullish(),
+})
+
+export const AdjustQuoteReq = AdjustQuoteShape.refine(
+  (b) =>
+    b.freight_amount !== undefined ||
+    b.freight_basis !== undefined ||
+    b.partner_note !== undefined ||
+    b.expires_at !== undefined,
+  {
+    message:
+      "An adjustment must change something — send freight_amount, freight_basis, partner_note or expires_at.",
+  }
+)
+
+export type AdjustQuoteReqType = z.infer<typeof AdjustQuoteShape>
+
 export const PartnerMintQuoteReq = PartnerMintQuoteShape.superRefine(
   dutyUndertakingRefinement
 )

--- a/apps/backend/src/modules/partner-quote/__tests__/adjust-quote.unit.spec.ts
+++ b/apps/backend/src/modules/partner-quote/__tests__/adjust-quote.unit.spec.ts
@@ -1,0 +1,112 @@
+import {
+  adjustmentNeedsNotice,
+  diffAdjustment,
+} from "../lib/adjust-quote"
+
+/**
+ * Correcting a quote in place, before the buyer accepts.
+ *
+ * A minted quote had two futures — accepted or revoked — so a mis-quoted
+ * freight could only be fixed by re-minting, which emails the buyer a NEW
+ * number for what is, to them, a correction to the document they are reading.
+ */
+const QUOTE = {
+  id: "pq_1",
+  quoted_freight: 35,
+  quoted_subtotal: 598.52,
+  quoted_tax_total: 0,
+  partner_note: "original note",
+  expires_at: new Date("2026-09-23T13:36:28.305Z"),
+}
+
+describe("diffAdjustment", () => {
+  it("reports nothing when the caller sent nothing", () => {
+    expect(diffAdjustment(QUOTE, {})).toEqual([])
+  })
+
+  it("🔴 reports nothing when the values sent are what is already stored", () => {
+    // A no-op must stay a no-op. Without this, saving a form nobody edited
+    // stamps `adjusted_at`, writes a timeline entry, and — worst — could mail
+    // the buyer about a change that did not happen.
+    const diffs = diffAdjustment(QUOTE, {
+      freight_amount: 35,
+      partner_note: "original note",
+      expires_at: new Date("2026-09-23T13:36:28.305Z"),
+    })
+    expect(diffs).toEqual([])
+  })
+
+  it("reports a freight change with both ends", () => {
+    expect(diffAdjustment(QUOTE, { freight_amount: 52 })).toEqual([
+      { field: "quoted_freight", from: 35, to: 52 },
+    ])
+  })
+
+  it("distinguishes an omitted key from an explicit null", () => {
+    // `undefined` means "leave it alone"; the note being cleared is a real
+    // change the buyer would see.
+    expect(diffAdjustment(QUOTE, { partner_note: null })).toEqual([
+      { field: "partner_note", from: "original note", to: null },
+    ])
+    expect(diffAdjustment(QUOTE, {})).toEqual([])
+  })
+
+  it("compares expiry as an instant, not as a string", () => {
+    // The same moment written two ways is not a change. A string comparison
+    // would call it one and re-date the price list for nothing.
+    const same = diffAdjustment(QUOTE, {
+      expires_at: "2026-09-23T13:36:28.305Z",
+    })
+    expect(same).toEqual([])
+
+    const moved = diffAdjustment(QUOTE, {
+      expires_at: "2026-10-23T13:36:28.305Z",
+    })
+    expect(moved).toHaveLength(1)
+    expect(moved[0].field).toBe("expires_at")
+  })
+
+  it("collects several changes at once", () => {
+    const diffs = diffAdjustment(QUOTE, {
+      freight_amount: 52,
+      partner_note: "corrected note",
+    })
+    expect(diffs.map((d) => d.field).sort()).toEqual([
+      "partner_note",
+      "quoted_freight",
+    ])
+  })
+})
+
+describe("adjustmentNeedsNotice", () => {
+  it("🔴 emails when the freight goes UP", () => {
+    // The buyer may have done their margin arithmetic on the old figure.
+    // Letting them discover a rise silently is how a correction reads as a
+    // bait-and-switch.
+    const diffs = diffAdjustment(QUOTE, { freight_amount: 52 })
+    expect(adjustmentNeedsNotice(diffs)).toBe(true)
+  })
+
+  it("stays silent when the freight goes DOWN", () => {
+    // A reduction in the buyer's favour needs no interruption — the page is
+    // always live, so they see it next time they open the link.
+    const diffs = diffAdjustment(QUOTE, { freight_amount: 28 })
+    expect(adjustmentNeedsNotice(diffs)).toBe(false)
+  })
+
+  it("never emails for a note or expiry change alone", () => {
+    // Re-sending a quote because somebody fixed a typo trains a buyer to
+    // ignore the mails that matter.
+    const noteOnly = diffAdjustment(QUOTE, { partner_note: "typo fixed" })
+    expect(adjustmentNeedsNotice(noteOnly)).toBe(false)
+
+    const expiryOnly = diffAdjustment(QUOTE, {
+      expires_at: "2026-10-23T13:36:28.305Z",
+    })
+    expect(adjustmentNeedsNotice(expiryOnly)).toBe(false)
+  })
+
+  it("is false on an empty diff", () => {
+    expect(adjustmentNeedsNotice([])).toBe(false)
+  })
+})

--- a/apps/backend/src/modules/partner-quote/lib/adjust-quote.ts
+++ b/apps/backend/src/modules/partner-quote/lib/adjust-quote.ts
@@ -1,0 +1,270 @@
+import { ContainerRegistrationKeys, MedusaError } from "@medusajs/framework/utils"
+import { updatePriceListsWorkflow } from "@medusajs/medusa/core-flows"
+
+import { PARTNER_QUOTE_MODULE } from ".."
+import { effectiveQuoteStatus } from "./token"
+
+/**
+ * Correct a quote in place, before the buyer accepts it.
+ *
+ * ## Why this exists
+ *
+ * A minted quote had exactly two futures: accepted, or revoked. So a partner
+ * who quoted the wrong freight — the common case, because a lane no carrier
+ * would rate falls through to a flat tier nobody chose — could only revoke and
+ * re-mint. That emails the buyer a NEW quote number for what is, to them, a
+ * correction to the document they are already reading. It also mints a fresh
+ * price list and supersedes the old one, which is a lot of machinery to move a
+ * shipping figure.
+ *
+ * An adjustment keeps the SAME link, the same quote number and the same frozen
+ * prices, and changes only the things that are columns on the row.
+ *
+ * ## 🔴 What it deliberately cannot change
+ *
+ * Line prices, quantities and variants. Those do not live on this row — they
+ * live in a real, active price list scoped to the buyer's customer group, and
+ * the mint guards writing it with a re-read assertion that `mint-quote`'s own
+ * docblock calls "the only thing standing between a quote and a platform-wide
+ * price cut". Re-implementing that assertion here, in a second place, to save a
+ * re-mint would be trading a small convenience for the largest blast radius in
+ * this module. Change the basket by re-minting; that path already supersedes
+ * the old quote correctly (#1435).
+ *
+ * ## 🔴 Expiry moves the price list too
+ *
+ * `expires_at` on this row is NOT where expiry is enforced — the minted price
+ * list carries a native `ends_at`, set from the same date at mint, and THAT is
+ * what stops the buyer's prices applying. Extending one without the other
+ * produces a page that says the quote is live above prices that have already
+ * stopped working. So both move, price list first: if that write fails the
+ * quote still shows the old, shorter date, which is the safe direction to be
+ * wrong in.
+ */
+
+export type QuoteAdjustment = {
+  /** In the QUOTE's currency. Stored with `source: "manual"` — see below. */
+  freight_amount?: number | null
+  /** Why that number. Evidence, exactly like `duty_basis`. */
+  freight_basis?: string | null
+  partner_note?: string | null
+  /** Absolute, not a delta. */
+  expires_at?: Date | string | null
+}
+
+export type AdjustmentDiff = {
+  field: string
+  from: unknown
+  to: unknown
+}
+
+/**
+ * PURE: what actually changed, ignoring keys the caller did not send and values
+ * that are already what they would be set to.
+ *
+ * 🔑 A no-op adjustment must be visible as a no-op. Without this, saving a form
+ * nobody edited would stamp `adjusted_at`, write a timeline event and — worse —
+ * potentially email the buyer about a change that did not happen.
+ */
+export function diffAdjustment(
+  quote: any,
+  adjustment: QuoteAdjustment
+): AdjustmentDiff[] {
+  const diffs: AdjustmentDiff[] = []
+
+  if (adjustment.freight_amount !== undefined) {
+    const to = adjustment.freight_amount
+    const from = quote?.quoted_freight
+    if (Number(from ?? NaN) !== Number(to ?? NaN)) {
+      diffs.push({ field: "quoted_freight", from: from ?? null, to: to ?? null })
+    }
+  }
+
+  if (adjustment.partner_note !== undefined) {
+    const to = adjustment.partner_note ?? null
+    const from = quote?.partner_note ?? null
+    if (String(from ?? "") !== String(to ?? "")) {
+      diffs.push({ field: "partner_note", from, to })
+    }
+  }
+
+  if (adjustment.expires_at !== undefined) {
+    const toMs = adjustment.expires_at
+      ? new Date(adjustment.expires_at as any).getTime()
+      : null
+    const fromMs = quote?.expires_at
+      ? new Date(quote.expires_at).getTime()
+      : null
+    if (toMs !== fromMs) {
+      diffs.push({
+        field: "expires_at",
+        from: fromMs ? new Date(fromMs).toISOString() : null,
+        to: toMs ? new Date(toMs).toISOString() : null,
+      })
+    }
+  }
+
+  return diffs
+}
+
+/**
+ * PURE: does the buyer need to be told?
+ *
+ * 🔑 Only when the number they owe goes UP. A reduction in the buyer's favour
+ * needs no interruption — they see it the next time they open the link, which
+ * is always live. A rise is different: they may have already done their margin
+ * arithmetic on the old figure, and letting them discover it silently is how a
+ * correction reads as a bait-and-switch.
+ *
+ * A note or expiry change alone never emails. Re-sending a quote because
+ * somebody fixed a typo trains a buyer to ignore the mails that matter.
+ */
+export function adjustmentNeedsNotice(diffs: AdjustmentDiff[]): boolean {
+  const freight = diffs.find((d) => d.field === "quoted_freight")
+  if (!freight) return false
+  return Number(freight.to ?? 0) > Number(freight.from ?? 0)
+}
+
+/**
+ * Apply an adjustment. Returns the updated row and what moved.
+ *
+ * Ownership is NOT checked here — the caller has already decided the actor may
+ * touch this quote, exactly as `revokeQuote` documents.
+ */
+export const adjustQuote = async (
+  scope: any,
+  quote: any,
+  adjustment: QuoteAdjustment,
+  actor: { type: "partner" | "admin"; id?: string | null },
+  now: Date = new Date()
+): Promise<{ quote: any; changes: AdjustmentDiff[]; notify: boolean }> => {
+  const service: any = scope.resolve(PARTNER_QUOTE_MODULE)
+  const logger: any = scope.resolve(ContainerRegistrationKeys.LOGGER)
+
+  /**
+   * 🔴 An accepted quote is not adjustable by anyone.
+   *
+   * Acceptance means a real cart exists at these figures, possibly with a
+   * deposit paid against it. Moving the freight afterwards changes what the
+   * buyer owes on an agreement they have already made, and nothing would tell
+   * them. This is the same refusal the partner revoke route makes, for the same
+   * reason — and unlike revoke, an admin gets no override here, because there
+   * is no version of "silently re-price a deal the buyer committed to" that is
+   * an operator's call to make.
+   *
+   * NOT_ALLOWED rather than CONFLICT: the framework's handler REPLACES a
+   * CONFLICT message with a generic "retry with an Idempotency-Key" line, so
+   * the caller would be told to retry the one thing that cannot work.
+   */
+  if (quote.accepted_at) {
+    throw new MedusaError(
+      MedusaError.Types.NOT_ALLOWED,
+      "This quote has already been accepted by the buyer, so it can no longer be adjusted — the accepted cart is priced from it. Re-quote instead."
+    )
+  }
+
+  /**
+   * 🔴 Only a LIVE quote can be corrected, and `status` alone does not say that
+   * (#1510): the column has no `expired` value, so a quote whose date passed
+   * still reads `active`. Adjusting a dead quote would produce a corrected
+   * document at a link that refuses to price anything.
+   */
+  const effective = effectiveQuoteStatus(quote, now)
+  if (effective !== "active") {
+    throw new MedusaError(
+      MedusaError.Types.NOT_ALLOWED,
+      `This quote is ${effective}, so it cannot be adjusted. Mint a new quote for this buyer instead.`
+    )
+  }
+
+  const changes = diffAdjustment(quote, adjustment)
+  if (!changes.length) {
+    // Idempotent, and honest: saving a form nobody edited must not stamp an
+    // adjustment, write a timeline entry, or mail the buyer.
+    return { quote, changes: [], notify: false }
+  }
+
+  const movedExpiry = changes.find((c) => c.field === "expires_at")
+
+  /**
+   * The price list FIRST — see the header. Its `ends_at` is where expiry is
+   * actually enforced; this row's `expires_at` is the copy people read.
+   */
+  if (movedExpiry && quote.price_list_id) {
+    try {
+      // `price_lists_data`, not `{selector, update}` — the same shape the
+      // supersede step in `mint-quote` uses. Caught by `check:prod-build`.
+      await updatePriceListsWorkflow(scope).run({
+        input: {
+          price_lists_data: [
+            { id: quote.price_list_id, ends_at: movedExpiry.to } as any,
+          ],
+        },
+      })
+    } catch (e: any) {
+      throw new MedusaError(
+        MedusaError.Types.UNEXPECTED_STATE,
+        `The quote's price list could not be re-dated (${e?.message ?? e}), so the expiry was not changed. Nothing else was written.`
+      )
+    }
+  }
+
+  const update: Record<string, any> = { id: quote.id, adjusted_at: now }
+
+  const freightChange = changes.find((c) => c.field === "quoted_freight")
+  if (freightChange) {
+    update.quoted_freight = freightChange.to
+    /**
+     * 🔴 `source` must travel with the amount.
+     *
+     * The buyer page only re-supplies a hand-named freight on re-read when the
+     * row says the freight was manual (#1439 S12). Writing the amount alone
+     * would leave the LIVE half re-running the estimate — so the page would
+     * render the corrected figure beside the old estimated one and visibly
+     * disagree with itself.
+     */
+    update.quoted_freight_source = "manual"
+    if (adjustment.freight_basis !== undefined) {
+      update.quoted_freight_basis = adjustment.freight_basis ?? null
+    }
+    // The landed total is the number the buyer reads; it must move with its
+    // parts rather than being recomputed by whoever renders next.
+    const subtotal = Number(quote.quoted_subtotal ?? 0)
+    const tax = Number(quote.quoted_tax_total ?? 0)
+    update.quoted_landed_total =
+      subtotal + Number(freightChange.to ?? 0) + tax
+  }
+
+  if (changes.some((c) => c.field === "partner_note")) {
+    update.partner_note = adjustment.partner_note ?? null
+  }
+  if (movedExpiry) {
+    update.expires_at = movedExpiry.to
+  }
+
+  // 🔑 NOT destructured. `updateX` returns an OBJECT for the entity form, and
+  // `const [x] = await ...` throws AFTER the write — the exact defect that made
+  // every revoke on prod answer 500 having already done its whole job.
+  const updated = await service.updatePartnerQuotes(update)
+
+  await service
+    .recordEvent({
+      quote_id: quote.id,
+      type: "adjusted",
+      actor_type: actor.type,
+      actor_id: actor.id ?? null,
+      message: changes
+        .map((c) => `${c.field}: ${String(c.from)} → ${String(c.to)}`)
+        .join("; "),
+      data: { changes },
+    })
+    .catch(() => {})
+
+  logger?.info?.(
+    `[quote] ${actor.type}=${actor.id ?? "?"} adjusted quote=${quote.id}: ${changes
+      .map((c) => c.field)
+      .join(",")}`
+  )
+
+  return { quote: updated, changes, notify: adjustmentNeedsNotice(changes) }
+}

--- a/apps/backend/src/modules/partner-quote/migrations/Migration20260825090000.ts
+++ b/apps/backend/src/modules/partner-quote/migrations/Migration20260825090000.ts
@@ -1,0 +1,20 @@
+import { Migration } from "@medusajs/framework/mikro-orm/migrations";
+
+/**
+ * Record when a quote was corrected in place, without touching the status enum.
+ *
+ * One additive nullable column — idempotent and safe to re-run (#1208). The
+ * enum is deliberately left alone: an adjusted quote is still `active`, and
+ * widening the enum would make every `status=active` filter miss it.
+ */
+export class Migration20260825090000 extends Migration {
+
+  override async up(): Promise<void> {
+    this.addSql(`alter table if exists "partner_quote" add column if not exists "adjusted_at" timestamptz null;`);
+  }
+
+  override async down(): Promise<void> {
+    this.addSql(`alter table if exists "partner_quote" drop column if exists "adjusted_at";`);
+  }
+
+}

--- a/apps/backend/src/modules/partner-quote/models/partner-quote.ts
+++ b/apps/backend/src/modules/partner-quote/models/partner-quote.ts
@@ -290,6 +290,21 @@ const PartnerQuote = model.define("partner_quote", {
    */
   status: model.enum(["active", "revoked", "superseded"]).default("active"),
   expires_at: model.dateTime().nullable(),
+  /**
+   * When this quote was last corrected in place, or null if never.
+   *
+   * 🔑 Deliberately NOT a status. An adjusted quote is still `active` — that is
+   * the entire point of adjusting rather than re-minting. A new enum value
+   * would need a migration AND would make every existing `status=active`
+   * filter silently stop seeing corrected quotes, which is the opposite of
+   * what an operator wants.
+   *
+   * Before this existed, correcting a mis-quoted freight meant revoke +
+   * re-mint: the buyer got an email with a NEW quote number for what was only
+   * ever a correction to the one they were already reading. The link is stable
+   * across an adjustment.
+   */
+  adjusted_at: model.dateTime().nullable(),
 
   // ===== Engagement (fire-and-forget; tracking must never 500 a buyer) =====
   viewed_at: model.dateTime().nullable(),

--- a/apps/partner-ui/src/hooks/api/partner-quotes.tsx
+++ b/apps/partner-ui/src/hooks/api/partner-quotes.tsx
@@ -469,7 +469,10 @@ export const useRevokePartnerQuote = (
         `/partners/quotes/${id}/revoke`,
         { method: "POST" }
       ),
-    onSuccess: async (data, variables, context) => {
+    // Forwarded by spread rather than by naming three params: react-query's
+    // `onSuccess` takes four, and naming a subset is a type error the rest of
+    // this file already carries. Spreading passes whatever arity it has.
+    onSuccess: async (...args) => {
       await Promise.all([
         queryClient.invalidateQueries({
           queryKey: partnerQuotesQueryKeys.lists(),
@@ -478,7 +481,7 @@ export const useRevokePartnerQuote = (
           queryKey: partnerQuotesQueryKeys.detail(id),
         }),
       ])
-      options?.onSuccess?.(data, variables, context)
+      options?.onSuccess?.(...args)
     },
     ...options,
   })


### PR DESCRIPTION
A minted quote had two futures: accepted or revoked. So a mis-quoted freight — the common case, because a lane no carrier will rate falls through to a flat tier nobody chose — could only be fixed by revoke + re-mint, which emails the buyer a **new quote number** for what is, to them, a correction to the document they're already reading.

An adjustment keeps the same link, number and frozen prices.

## Scope

Freight (+ basis), partner note, expiry — all columns on the quote row.

🔴 **Not** line prices, quantities or variants. Those live in the minted price list, guarded by the mint's re-read assertion that its own docblock calls *"the only thing standing between a quote and a platform-wide price cut"*. A second writer of that list is a second way to cut prices platform-wide.

## 🔴 Expiry moves the price list too

`expires_at` isn't where expiry is enforced — the price list's native `ends_at` is. Moving one without the other renders a page saying "live" above prices that stopped working. Both move, price list first.

## Refusals

- **Accepted → refused, admins included.** A real cart exists at those figures, possibly with a deposit. `NOT_ALLOWED`, not `CONFLICT` (the framework replaces CONFLICT's message with a generic idempotency-key line).
- **Dead → refused**, via `effectiveQuoteStatus` — `status` alone can't tell you, since the column has no `expired` value (#1510).

## Buyer notice

Only when the freight goes **up**. A reduction needs no interruption; the page is always live. Note/expiry alone never mails — re-sending over a typo trains buyers to ignore the mails that matter. `diffAdjustment` keeps a no-op a no-op, and compares expiry as an instant rather than a string.

## State, not status

`adjusted_at` + an `adjusted` timeline event with before → after. The quote stays `active` — a new enum value would need a migration *and* make every `status=active` filter silently miss corrected quotes. Starts answering #1509.

## Verified

- Unit **306/306** on partner-quote (10 new)
- `check:prod-build` **caught a real defect here** — `updatePriceListsWorkflow` takes `price_lists_data`, not `{selector, update}`. Fixed; my file compiles clean.
- ⚠️ `check:prod-build` still exits 1 locally on `payu-payment` / `stripe-connect-payment`, from a duplicate `@medusajs/types` (2.19.0 vs 2.14.2) in the local pnpm store. **Confirmed pre-existing** by stashing this branch and re-running — the clean tree fails identically on the same two untouched files. Please confirm against the CI check.

Also carries the partner-ui `useRevokePartnerQuote` type fix (spread-forward `onSuccess`); partner-ui tsc 1121 vs the 1122 baseline.

## Not in this PR

The related finding: **`revokeQuote` deletes the price list but not the quote's per-quote shipping option**, so every revoked hand-typed freight stays a candidate in future quotes' pickers. Found a stale **₹99** row on prod today that would win any INR quote by being smallest. Three orphans cleaned by hand; it will re-accumulate.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_0158wJMZ1DmjNxXf5uGuBrQD