### PR TITLE
fix(quotes): stop one buyer's freight winning another's quote, and stop readiness reading silence as a rate (#1527, #1528)

### DIFF
--- a/apps/backend/src/lib/__tests__/shipping-estimate-zone.unit.spec.ts
+++ b/apps/backend/src/lib/__tests__/shipping-estimate-zone.unit.spec.ts
@@ -3,6 +3,11 @@ import {
   zoneCoversDestination,
 } from "../shipping-estimate"
 import { pickFreightOption } from "../../modules/partner-quote/lib/build-quote-view"
+import {
+  QUOTE_FREIGHT_OPTION_RULE_ATTRIBUTE,
+  QUOTE_FREIGHT_OPTION_TYPE_CODE,
+  quoteFreightOptionName,
+} from "../../modules/partner-quote/lib/quote-freight-option"
 
 /**
  * Found on a LIVE production mint (#1389 S3 verification, 21 Aug):
@@ -64,6 +69,127 @@ describe("isQuotableShippingOption — the return row that won by being cheap", 
     // lane entirely, which is a worse failure than the one being fixed.
     expect(isQuotableShippingOption({ name: "Flat rate" })).toBe(true)
     expect(isQuotableShippingOption({ name: "Flat rate", rules: [] })).toBe(true)
+  })
+})
+
+/**
+ * 🔴 ONE BUYER'S NEGOTIATED FREIGHT IS NEVER AN OFFER TO ANOTHER (#1527).
+ *
+ * Accepting a quote mints a flat option priced at that quote's frozen freight,
+ * ruled `quote_id eq <id>`. That rule hides it from other CARTS — core's rule
+ * engine does the hiding, via `hooks/quote-shipping-options-context.ts`. This
+ * estimate never goes near core's rule engine: it reads a location's options
+ * straight out of `query.graph`. So every per-quote option ever minted stood
+ * here as an ordinary candidate for unrelated quotes.
+ *
+ * Live on prod 25 Aug, in one store:
+ *
+ *   Quoted freight — 01M0Q7T0…   35 eur
+ *   Quoted freight — 01M0QF8C…   99 inr   ← wins ANY inr quote
+ *   Quoted freight — 01M0QGQ4…   48.5 eur
+ *
+ * all three from REVOKED quotes, two already surfaced on a real customer's
+ * quote. `pickFreightOption` sorts on the raw amount, so ₹99 beats every real
+ * rate on every INR lane regardless of weight, lane or destination.
+ *
+ * 🔑 Fourth instance of one shape — zone-blind (#1424), rule-blind (#1430),
+ * the return row (#1485), and now this: a row nobody chose for *this* shipment
+ * winning it by being small.
+ *
+ * The refusal lives in the callee. Deleting the option on revoke (which
+ * `revokeQuote` now also does) would still leave a LIVE quote's freight
+ * standing as a candidate for the next buyer, and would depend on every future
+ * path that kills a quote remembering to clean up.
+ */
+describe("isQuotableShippingOption — one buyer's freight is not another's offer", () => {
+  it("🔴 refuses an option scoped to a quote by its rule", () => {
+    expect(
+      isQuotableShippingOption({
+        name: quoteFreightOptionName("01M0QF8CN2S0TPA0HTKD0YHGJ7"),
+        rules: [
+          { attribute: "enabled_in_store", value: "true", operator: "eq" },
+          {
+            attribute: QUOTE_FREIGHT_OPTION_RULE_ATTRIBUTE,
+            value: "01M0QF8CN2S0TPA0HTKD0YHGJ7",
+            operator: "eq",
+          },
+        ],
+      })
+    ).toBe(false)
+  })
+
+  /**
+   * The rule is refused whatever quote it names and whatever the quote's state
+   * — there is deliberately no "is this quote still alive?" test. A live
+   * quote's freight is exactly as wrong an answer for a different buyer as a
+   * dead one's, and it is the LIVE case a teardown could never reach.
+   */
+  it("🔴 refuses it for a live quote too, not only an abandoned one", () => {
+    expect(
+      isQuotableShippingOption({
+        name: "Quoted freight — some_active_quote",
+        rules: [
+          {
+            attribute: QUOTE_FREIGHT_OPTION_RULE_ATTRIBUTE,
+            value: "some_active_quote",
+            operator: "eq",
+          },
+        ],
+      })
+    ).toBe(false)
+  })
+
+  /**
+   * Belt and braces, and the belt was DEAD until #1527: the estimate's query
+   * never asked for `shipping_options.type`, so this read a field that could
+   * not arrive — on the return check too. Absence in the instrument, not in
+   * the world; the same reading error as #1528. The field is fetched now, so
+   * the type code has to be honoured.
+   */
+  it("refuses one carrying only the quoted-freight type code", () => {
+    expect(
+      isQuotableShippingOption({
+        name: "Quoted freight — x",
+        type: { code: QUOTE_FREIGHT_OPTION_TYPE_CODE },
+      })
+    ).toBe(false)
+  })
+
+  /**
+   * 🔴 The store's OWN flat option must survive. It is the donor lane every
+   * quote to that country is rated against and frozen onto; refusing it would
+   * take the lane down for every quote at once — a far worse failure than the
+   * leak being fixed. Only the `quote_id` rule and the minted type code
+   * disqualify an option, never the word "freight" in its name.
+   */
+  it("keeps the store's own configured option, however it is named", () => {
+    expect(
+      isQuotableShippingOption({
+        name: "International Shipping · 68M3HY2V",
+        rules: [{ attribute: "enabled_in_store", value: "true", operator: "eq" }],
+        type: { code: "international-shipping-68m3hy2v" },
+      })
+    ).toBe(true)
+    // Named confusingly, but carrying neither disqualifier.
+    expect(isQuotableShippingOption({ name: "Freight (quoted)" })).toBe(true)
+  })
+})
+
+/**
+ * The option's name is an IDENTIFIER, not a label (#1527).
+ *
+ * `revokeQuote`'s teardown finds the option by this exact string, so the
+ * minting step and the teardown must never be able to disagree about it — and
+ * a mismatch would be invisible, because a teardown that matches nothing does
+ * not fail. Hence one constructor, pinned here.
+ */
+describe("quoteFreightOptionName", () => {
+  it("is the exact string acceptance mints and revoke looks for", () => {
+    expect(quoteFreightOptionName("01M0QF8CN2S0TPA0HTKD0YHGJ7")).toBe(
+      "Quoted freight — 01M0QF8CN2S0TPA0HTKD0YHGJ7"
+    )
+    // An em dash, not a hyphen. An exact-match filter does not forgive it.
+    expect(quoteFreightOptionName("q_1")).toContain("—")
   })
 })
 

--- a/apps/backend/src/lib/shipping-estimate.ts
+++ b/apps/backend/src/lib/shipping-estimate.ts
@@ -146,6 +146,30 @@ export type ShippingEstimate = {
   manual: ShippingEstimateOption[]
   calculated: ShippingEstimateOption[]
   calculated_error: string | null
+  /**
+   * Was a carrier actually asked to rate this lane? (#1528)
+   *
+   * 🔴 An empty `calculated` list means two completely different things, and
+   * the estimate was the only place that could still tell them apart:
+   *
+   * - `carrier === "manual" | "none"` — a deliberate decision to ask NOBODY.
+   *   The store's flat tiers ARE the whole answer, and there is nothing to
+   *   report.
+   * - a carrier that was asked and returned nothing — no rates, and no error
+   *   either. `calculated_error` stays null, so downstream the two are
+   *   indistinguishable, and readiness read the silence as "the carrier rated
+   *   the lane and the flat tier won".
+   *
+   * It did not. On 25 Aug a real Amsterdam quote (1080 g, EUR) went out on a
+   * flat €35 at `ready: true`, hours after the same lane returned seven
+   * carrier options with the cheapest at €36.42. The guard written to stop a
+   * flat tier standing in for an unknown rate was blind to the case where the
+   * carrier says nothing at all.
+   *
+   * So the fact is recorded here rather than re-derived. See
+   * `needsManualFreightRate`.
+   */
+  carrier_consulted: boolean
   cache_hit: boolean
   is_estimate: true
 }
@@ -193,6 +217,31 @@ export function resolveUnitWeight(variant: {
  * not re-priced: an option the store has switched off is not an offer we may
  * make on its behalf. An option with no rules at all is allowed — absence is
  * not a prohibition, and most hand-made options carry none.
+ *
+ * ## 🔴 A `quote_id` rule means the option belongs to ONE buyer (#1527)
+ *
+ * Accepting a quote mints a flat option priced at that quote's frozen freight,
+ * carrying `quote_id eq <id>` so it is invisible to every other CART. That
+ * hiding is done by core's rule engine, via
+ * `hooks/quote-shipping-options-context.ts` — and this estimate never goes
+ * through core's rule engine. It reads the zone's options straight out of
+ * `query.graph`, so every per-quote option ever minted stood as an ordinary
+ * candidate here, for unrelated quotes, priced at whatever one buyer once
+ * negotiated.
+ *
+ * Live on prod 25 Aug: a `99 INR` row from a revoked test quote. The picker
+ * sorts on the raw amount, so it would have won **any** INR quote by being the
+ * smallest number — regardless of weight, lane or destination. The fourth time
+ * this exact shape has shipped (#1424 zone-blind, #1430 rule-blind, #1485 the
+ * return option): a row nobody chose for *this* shipment winning it by being
+ * small.
+ *
+ * 🔑 The refusal lives HERE, in the callee, and not only in the teardown that
+ * deletes the option on revoke (`revokeQuote`). Teardown alone would leave a
+ * *live* quote's negotiated freight standing as a candidate for the next
+ * buyer, and would depend on every future path that kills a quote remembering
+ * to clean up. One buyer's freight is never an offer to another, dead or
+ * alive.
  */
 export function isQuotableShippingOption(shippingOption: any): boolean {
   const rules = (shippingOption?.rules ?? []) as Array<{
@@ -207,12 +256,21 @@ export function isQuotableShippingOption(shippingOption: any): boolean {
 
     if (attribute === "is_return" && value === "true") return false
     if (attribute === "enabled_in_store" && value === "false") return false
+    // 🔴 Scoped to one quote's cart — see the header. Not ours to offer.
+    if (attribute === "quote_id") return false
   }
 
   // Belt and braces: a return option created by hand — or by core's own return
-  // flows — may carry the type without the rule.
+  // flows — may carry the type without the rule. Likewise a per-quote option,
+  // whose type code acceptance sets deliberately (`quoted-freight`).
+  //
+  // ⚠️ This read was DEAD until #1527: the estimate's own query never asked for
+  // `shipping_options.type`, so `type` arrived undefined on every option and
+  // both belts checked a field that was always absent. Absence in the
+  // instrument, not in the world — the same reading error as #1528. The field
+  // is fetched now.
   const typeCode = String(shippingOption?.type?.code || "").toLowerCase()
-  if (typeCode === "return") return false
+  if (typeCode === "return" || typeCode === "quoted-freight") return false
 
   return true
 }
@@ -449,6 +507,10 @@ export async function buildShippingEstimate(
       // OPTION-level rules, which are a different thing from price rules and
       // were never read. See `isQuotableShippingOption`.
       "fulfillment_sets.service_zones.shipping_options.rules.*",
+      // The type code is the second half of `isQuotableShippingOption`'s belt
+      // and braces, and went unfetched until #1527 — so it checked a field
+      // that could never arrive. Proven path: `/partners/stores/:id/shipping-options`.
+      "fulfillment_sets.service_zones.shipping_options.type.*",
     ],
     filters: { id: input.store.default_location_id },
   })
@@ -534,6 +596,9 @@ export async function buildShippingEstimate(
       manual,
       calculated: [],
       calculated_error: null,
+      // Nobody was asked, on purpose. This is what stops the empty list above
+      // being read as a carrier that failed silently (#1528).
+      carrier_consulted: false,
       cache_hit: false,
       is_estimate: true,
     }
@@ -748,6 +813,9 @@ export async function buildShippingEstimate(
     manual,
     calculated,
     calculated_error: calculatedError,
+    // A carrier WAS asked on this path, whatever it answered — including
+    // nothing at all, which is the case #1528 was blind to.
+    carrier_consulted: true,
     cache_hit: cacheHit,
     // Never present these as a final price: carrier rates move, and the manual
     // tier is a placeholder the partner is expected to edit.

--- a/apps/backend/src/modules/partner-quote/__tests__/quote-readiness.unit.spec.ts
+++ b/apps/backend/src/modules/partner-quote/__tests__/quote-readiness.unit.spec.ts
@@ -1,7 +1,8 @@
 import { needsManualFreightRate } from "../lib/quote-readiness"
 
 /**
- * When a lane cannot be rated, refuse rather than invent (#1439 S12 tail).
+ * When a lane cannot be rated, refuse rather than invent (#1439 S12 tail,
+ * widened by #1528).
  *
  * ## What this pins
  *
@@ -16,45 +17,129 @@ import { needsManualFreightRate } from "../lib/quote-readiness"
  * rule-blind (#1430), and the return option winning every domestic lane
  * (#1485). None looked broken, because none was ever missing.
  *
- * The remedy already exists. S12's `freight_override_amount` lets a partner
- * read the real DHL rate and type it, badged "By hand" with its basis
- * recorded. So the rule is: carrier failed AND nobody typed a rate ⇒ refuse
- * and say so. A typed rate answers the question outright.
+ * ## 🔴 Why the suite was green while the defect was live (#1528)
+ *
+ * Every case below the fold used to pass an ERROR STRING. The guard was
+ * `Boolean(calculatedError) && override === null`, so the tests exercised the
+ * only branch it had, all agreed, and the case that actually shipped — a
+ * carrier answering an EMPTY LIST with no error at all — was never written
+ * down. A real Amsterdam quote went out at `ready: true` on a flat €35, hours
+ * after the same lane returned seven carrier options with the cheapest at
+ * €36.42.
+ *
+ * So the fixtures here now say what the carrier DID, not merely what it
+ * raised. `carrierConsulted` is the load-bearing one: without it an empty list
+ * cannot be told apart from a store that deliberately prices by hand, and
+ * refusing that would block every manual lane on purpose.
  */
+
+/** The shape under test, with the benign answer as the default. */
+const ask = (over: Partial<Parameters<typeof needsManualFreightRate>[0]> = {}) =>
+  needsManualFreightRate({
+    calculatedError: null,
+    carrierConsulted: true,
+    chosenSource: "calculated",
+    override: null,
+    ...over,
+  })
+
 describe("needsManualFreightRate", () => {
   it("🔴 refuses when the carrier failed and nobody typed a rate", () => {
     expect(
-      needsManualFreightRate("No serviceable couriers available", null)
+      ask({
+        calculatedError: "No serviceable couriers available",
+        chosenSource: "manual",
+      })
+    ).toBe(true)
+  })
+
+  /**
+   * 🔴 THE CASE THAT SHIPPED (#1528).
+   *
+   * No error, no rates, and a flat tier about to be frozen as if a carrier had
+   * chosen it. Under the old guard this returned `false` — which is exactly
+   * how a €35 flat rate reached a real customer while readiness reported
+   * `ready=true, blocking=0, error=null`.
+   *
+   * 🔑 This assertion fails on the previous implementation. That is the point
+   * of writing it: a test that passes both before and after certifies nothing
+   * (#1495).
+   */
+  it("🔴 refuses when the carrier was asked and returned NOTHING — no rates, no error", () => {
+    expect(
+      ask({
+        calculatedError: null,
+        carrierConsulted: true,
+        chosenSource: "manual",
+      })
     ).toBe(true)
   })
 
   it("accepts once someone has typed the rate", () => {
     expect(
-      needsManualFreightRate("No serviceable couriers available", 4200)
+      ask({
+        calculatedError: "No serviceable couriers available",
+        chosenSource: "manual",
+        override: 4200,
+      })
     ).toBe(false)
   })
 
   /**
-   * A rated lane is not second-guessed. The domestic lane rates cleanly and
-   * must keep minting without anyone typing anything.
+   * A carrier rate won the lane. Whatever else the estimate reported, the
+   * number being frozen is a real quote for this weight to this destination —
+   * which is the only question this guard is asking.
    */
-  it("says nothing when the carrier answered", () => {
-    expect(needsManualFreightRate(null, null)).toBe(false)
-    expect(needsManualFreightRate(undefined, null)).toBe(false)
+  it("says nothing when a carrier rate is the figure being frozen", () => {
+    expect(ask({ chosenSource: "calculated" })).toBe(false)
+    // Even alongside a partial failure: some couriers erred, one still rated.
+    expect(
+      ask({ calculatedError: "courier X timed out", chosenSource: "calculated" })
+    ).toBe(false)
+  })
+
+  /**
+   * 🔑 `carrier: "manual"` / `"none"` is an explicit decision to ask NOBODY —
+   * `buildShippingEstimate` returns early with an empty `calculated` list and
+   * a null error, which is byte-identical to the failure above.
+   *
+   * Only `carrier_consulted` separates them, and getting this wrong is not a
+   * small mistake in the safe direction: it would refuse every hand-priced
+   * lane the store has configured on purpose, and no quote from such a store
+   * could be minted at all.
+   */
+  it("stays silent when no carrier was consulted — pricing by hand is the plan", () => {
+    expect(
+      ask({
+        calculatedError: null,
+        carrierConsulted: false,
+        chosenSource: "manual",
+      })
+    ).toBe(false)
   })
 
   /**
    * 🔴 Zero is a typed answer, not an absence. `freight_override_amount` is
-   * validated `.positive()` at the API boundary precisely so a zero cannot be
-   * typed by accident — but this predicate must not be the thing that treats a
-   * present number as missing, or free freight would silently become
-   * "unrateable" instead of being refused where it is actually checked.
+   * how a partner says "I looked this lane up and it ships free" — a real
+   * commercial decision on a sample or a make-good. Treating 0 as "nothing was
+   * typed" would refuse the one quote the partner was most deliberate about.
    */
   it("treats a typed zero as an answer, not as absence", () => {
-    expect(needsManualFreightRate("carrier down", 0)).toBe(false)
+    expect(
+      ask({
+        calculatedError: "carrier down",
+        chosenSource: "manual",
+        override: 0,
+      })
+    ).toBe(false)
   })
 
-  it("ignores an empty error string — that is not a failure", () => {
-    expect(needsManualFreightRate("", null)).toBe(false)
+  /**
+   * An empty error string is not a failure — but with the guard widened it no
+   * longer matters what the string says. What decides is whether a carrier
+   * rate is the number being frozen.
+   */
+  it("does not depend on the error string once a carrier rate won", () => {
+    expect(ask({ calculatedError: "", chosenSource: "calculated" })).toBe(false)
   })
 })

--- a/apps/backend/src/modules/partner-quote/lib/quote-freight-option.ts
+++ b/apps/backend/src/modules/partner-quote/lib/quote-freight-option.ts
@@ -1,0 +1,137 @@
+import { ContainerRegistrationKeys } from "@medusajs/framework/utils"
+import { deleteShippingOptionsWorkflow } from "@medusajs/medusa/core-flows"
+
+/**
+ * The per-quote freight option: how it is named, and how it is torn down
+ * (#1527).
+ *
+ * ## What this option is
+ *
+ * Accepting a quote cannot hand core an amount — `refreshCartShippingMethodsWorkflow`
+ * rewrites every shipping method's amount from its option on each cart
+ * refresh, and deletes the method outright when the option no longer prices.
+ * So the frozen freight has to BE a shipping option's price, and acceptance
+ * mints one: flat, priced at `quoted_freight`, in the donor option's zone,
+ * carrying a rule `quote_id eq <id>` so core's rule engine shows it to that
+ * quote's cart and to no other.
+ *
+ * ## Why it needs a teardown
+ *
+ * The rule hides it from other CARTS. It never hid it from the freight
+ * ESTIMATE, which reads a location's options straight out of `query.graph` and
+ * evaluates no rules — so every option ever minted stood as a candidate for
+ * unrelated quotes. Three were live on prod on 25 Aug, all belonging to
+ * revoked quotes, and two of them surfaced on a real customer's quote:
+ *
+ * ```
+ * Quoted freight — 01M0Q7T078TQ36D3PQV1AGG472    35 eur
+ * Quoted freight — 01M0QF8CN2S0TPA0HTKD0YHGJ7    99 inr   ← wins any INR quote
+ * Quoted freight — 01M0QGQ4SW665XZH1QMTSFWX7Z    48.5 eur
+ * ```
+ *
+ * The picker sorts on the raw amount, so ₹99 beats every real rate on every
+ * INR lane regardless of weight or destination. Fourth instance of one shape:
+ * a row nobody chose for *this* shipment winning it by being small (#1424,
+ * #1430, #1485).
+ *
+ * ## 🔑 This is the SECOND line of defence, not the first
+ *
+ * `isQuotableShippingOption` now refuses any option carrying a `quote_id` rule
+ * outright, which is what actually closes the hole — teardown alone would
+ * leave a *live* quote's negotiated freight standing as a candidate for the
+ * next buyer, and would rely on every future path that kills a quote
+ * remembering to call this. This exists so dead rows do not accumulate in a
+ * partner's option list forever, not to make the picker safe.
+ *
+ * ## 🔴 What must survive
+ *
+ * The store's own configured flat option — the one the quote was RATED against
+ * and froze in `quoted_shipping_option_id` — is not ours to delete. It is
+ * shared by every quote on that lane. Deleting it would take the lane down for
+ * all of them, which is a far worse failure than the leak being fixed. Hence
+ * the identity is checked three ways before anything is removed: the name we
+ * ourselves constructed, the `quote_id` rule naming THIS quote, and an
+ * explicit refusal to touch the donor id.
+ */
+
+/** The type code acceptance stamps on the option it mints. */
+export const QUOTE_FREIGHT_OPTION_TYPE_CODE = "quoted-freight"
+
+/** The option-level rule attribute that scopes it to one quote's cart. */
+export const QUOTE_FREIGHT_OPTION_RULE_ATTRIBUTE = "quote_id"
+
+/**
+ * The option's name, constructed in exactly one place.
+ *
+ * 🔑 It is an identifier, not a label. The teardown finds the option by this
+ * exact string, so the minting step and the teardown must never be able to
+ * disagree about it — which they could, silently and forever, if each built
+ * its own template. The leak is invisible either way: nothing fails when a
+ * teardown matches nothing.
+ */
+export const quoteFreightOptionName = (quoteId: string): string =>
+  `Quoted freight — ${quoteId}`
+
+/**
+ * Delete the freight option(s) this quote minted for itself. Idempotent.
+ *
+ * Returns the ids removed, so the caller can record what it actually did
+ * rather than claiming a clean teardown it never performed — the same reason
+ * `revokeQuote` logs when a quote had no price list to delete.
+ *
+ * Never throws. A quote being revoked has already had its price list deleted
+ * and its status written; failing the whole revoke because a cleanup could not
+ * complete would leave the caller retrying a destructive operation that
+ * already ran (the #1517 defect). The option being left behind is now harmless
+ * — see the header — so a warning is the correct severity.
+ */
+export const deleteQuoteFreightOptions = async (
+  scope: any,
+  quote: { id: string; quoted_shipping_option_id?: string | null }
+): Promise<{ deleted_shipping_option_ids: string[] }> => {
+  const query: any = scope.resolve(ContainerRegistrationKeys.QUERY)
+  const logger: any = scope.resolve(ContainerRegistrationKeys.LOGGER)
+
+  try {
+    const { data: options = [] } = await query.graph({
+      entity: "shipping_options",
+      fields: ["id", "name", "rules.*"],
+      // 🔴 An EXACT name, never a bare list. `filters: { name: undefined }` is
+      // NO filter, and an unfiltered read here would hand the delete below
+      // every shipping option on the platform (#1397/#1433).
+      filters: { name: quoteFreightOptionName(quote.id) },
+    })
+
+    const ids = (options ?? [])
+      .filter((o: any) => {
+        // The donor option is the store's own and is shared by every quote on
+        // the lane. A name collision alone must never be able to remove it.
+        if (o?.id && o.id === quote.quoted_shipping_option_id) return false
+
+        // And it must actually claim to belong to THIS quote. A store that
+        // hand-named an option the same thing is not ours to delete.
+        return (o?.rules ?? []).some(
+          (r: any) =>
+            String(r?.attribute || "").trim() ===
+              QUOTE_FREIGHT_OPTION_RULE_ATTRIBUTE &&
+            String(r?.value ?? "").trim() === String(quote.id)
+        )
+      })
+      .map((o: any) => o.id)
+
+    if (!ids.length) {
+      return { deleted_shipping_option_ids: [] }
+    }
+
+    await deleteShippingOptionsWorkflow(scope).run({ input: { ids } })
+    logger?.info?.(
+      `[quote] teardown ${quote.id} deleted freight option(s) ${ids.join(", ")}`
+    )
+    return { deleted_shipping_option_ids: ids }
+  } catch (e: any) {
+    logger?.warn?.(
+      `[quote] teardown ${quote.id} could not delete its freight option: ${e?.message ?? String(e)}`
+    )
+    return { deleted_shipping_option_ids: [] }
+  }
+}

--- a/apps/backend/src/modules/partner-quote/lib/quote-readiness.ts
+++ b/apps/backend/src/modules/partner-quote/lib/quote-readiness.ts
@@ -73,12 +73,66 @@ export type QuoteReadinessCode =
  *
  * A typed override answers the question outright: someone looked up the real
  * rate, so there is nothing to refuse.
+ *
+ * ## 🔴 Why this asks "did a carrier rate it?" and not "did a carrier error?"
+ *
+ * It used to be `Boolean(calculatedError) && override === null` — it fired only
+ * when the carrier *raised* something. A carrier that returns an EMPTY LIST
+ * without erroring leaves `calculated_error` null, so the guard stayed silent,
+ * readiness answered `ready: true`, and the quote went out on the flat tier
+ * (#1528).
+ *
+ * That happened, on a real customer quote to Amsterdam: `ready=true`,
+ * `blocking=0`, `error=null`, freight €35 flat — hours after the same lane had
+ * returned seven carrier options with the cheapest at €36.42. I read the
+ * guard's silence as evidence the carrier had rated the lane and told the
+ * founder so. It was absence in my instrument, not in the world.
+ *
+ * The bitter part is that this guard's own docblock says it exists because
+ * *"the number is never absent, so nothing looks broken"* — and it reproduced
+ * that failure through itself. So the question it asks is now the one that
+ * actually matters: **is the figure we are about to freeze one a carrier
+ * gave us?** An error, an empty answer and a timeout are all the same thing to
+ * a buyer.
+ *
+ * Three states, not two:
+ *
+ * | carrier | verdict |
+ * |---|---|
+ * | not asked (`carrier: "manual"`/`"none"`) | fine — pricing by hand is the plan |
+ * | asked, errored | refuse |
+ * | asked, returned nothing | refuse |
+ * | asked, rated, and a rated option won | fine |
+ *
+ * 🔑 `carrierConsulted` is the load-bearing input. Without it an empty
+ * `calculated` list cannot be told apart from a deliberate decision to ask
+ * nobody, and refusing THAT would block every hand-priced lane the store has
+ * configured on purpose.
  */
-export function needsManualFreightRate(
-  calculatedError: string | null | undefined,
+export function needsManualFreightRate(input: {
+  /** Whatever the carrier raised, if it raised anything. */
+  calculatedError: string | null | undefined
+  /**
+   * Was a carrier asked at all? `ShippingEstimate.carrier_consulted`. False
+   * means "manual" was chosen deliberately and there is nothing to report.
+   */
+  carrierConsulted: boolean
+  /**
+   * Where the figure about to be frozen came from. `"calculated"` is a real
+   * carrier rate; `"manual"` is a store-configured flat tier that does not
+   * move with weight.
+   */
+  chosenSource: "manual" | "calculated" | null | undefined
+  /** A rate someone looked up and typed. Zero IS an answer. */
   override: number | null
-): boolean {
-  return Boolean(calculatedError) && override === null
+}): boolean {
+  if (input.override !== null) return false
+  // Nobody was asked. The flat tier is the intended answer, not a stand-in.
+  if (!input.carrierConsulted) return false
+  // A carrier rate won: whatever else went wrong, the number is a real quote
+  // for this lane at this weight.
+  if (input.chosenSource === "calculated") return false
+  return true
 }
 
 export type QuoteReadinessIssue = {
@@ -102,6 +156,16 @@ export type QuoteReadinessResult = {
     chosen: { name: string | null; amount: number; currency_code: string } | null
     total_weight_grams: number | null
     error: string | null
+    /**
+     * Whether a carrier was asked, and how many rates came back (#1528).
+     *
+     * 🔑 `error: null` was never enough to conclude the lane had been rated —
+     * a carrier can answer nothing without failing. The count is reported so
+     * the operator reads a fact rather than inferring one from a silence, the
+     * way I did.
+     */
+    carrier_consulted: boolean
+    carrier_rated_count: number
   }
 }
 
@@ -279,6 +343,8 @@ export async function assessQuoteReadiness(
     chosen: null,
     total_weight_grams: null,
     error: null,
+    carrier_consulted: false,
+    carrier_rated_count: 0,
   }
 
   const canEstimate =
@@ -348,6 +414,8 @@ export async function assessQuoteReadiness(
           : null,
         total_weight_grams: estimate.total_weight_grams,
         error: estimate.calculated_error,
+        carrier_consulted: estimate.carrier_consulted,
+        carrier_rated_count: (estimate.calculated ?? []).length,
       }
 
       if (!chosen) {
@@ -359,7 +427,16 @@ export async function assessQuoteReadiness(
             : `No freight option could be quoted to ${input.destination_country_code.toUpperCase()} from this store's location.`,
           data: { country_code: input.destination_country_code },
         })
-      } else if (needsManualFreightRate(estimate.calculated_error, override)) {
+      } else if (
+        needsManualFreightRate({
+          calculatedError: estimate.calculated_error,
+          carrierConsulted: estimate.carrier_consulted,
+          // The override branch above builds `chosen` by hand with no source,
+          // but it also sets `override`, which short-circuits first.
+          chosenSource: (chosen as any)?.source ?? null,
+          override,
+        })
+      ) {
         /**
          * 🔴 A FLAT TIER IS NOT A RATE FOR A LANE NOBODY COULD RATE.
          *
@@ -386,14 +463,22 @@ export async function assessQuoteReadiness(
           code: "freight_needs_manual_rate",
           severity: "blocking",
           message:
-            `No carrier could rate freight to ${input.destination_country_code.toUpperCase()} ` +
-            `(${estimate.calculated_error}), so the only figure available is a flat rate that does ` +
+            `No carrier rated freight to ${input.destination_country_code.toUpperCase()} ` +
+            // 🔴 Say WHICH silence this was. Interpolating a null error read
+            // "(null)" and told the operator nothing — and the empty-answer
+            // case is precisely the one that used to pass unremarked (#1528).
+            (estimate.calculated_error
+              ? `(${estimate.calculated_error})`
+              : `(the carrier was asked and returned no rates at all — no error either)`) +
+            `, so the only figure available is a flat rate that does ` +
             `not change with weight. Look up the real rate (DHL and the like) and type it in — ` +
             `it will be shown to the buyer as quoted by hand.`,
           data: {
             country_code: input.destination_country_code,
             fallback_amount: chosen.amount,
             fallback_name: chosen.name ?? null,
+            carrier_rated_count: (estimate.calculated ?? []).length,
+            carrier_returned_nothing: !estimate.calculated_error,
           },
         })
       } else if (

--- a/apps/backend/src/modules/partner-quote/lib/revoke-quote.ts
+++ b/apps/backend/src/modules/partner-quote/lib/revoke-quote.ts
@@ -2,6 +2,7 @@ import { ContainerRegistrationKeys } from "@medusajs/framework/utils"
 import { deletePriceListsWorkflow } from "@medusajs/medusa/core-flows"
 
 import { PARTNER_QUOTE_MODULE } from ".."
+import { deleteQuoteFreightOptions } from "./quote-freight-option"
 
 /**
  * Revoke one quote (#1389 S5, extracted for the partner surface in #1517).
@@ -16,6 +17,21 @@ import { PARTNER_QUOTE_MODULE } from ".."
  * alongside a list that is already gone — visibly inconsistent and safe. The
  * reverse order would leave a revoked-looking quote still quietly pricing
  * carts, which is the failure nobody would notice.
+ *
+ * ## 🔴 The prices are not the only thing the quote owns (#1527)
+ *
+ * An accepted quote also minted itself a shipping option carrying its frozen
+ * freight. That survived every revoke, and three of them were live on prod on
+ * 25 Aug — including a `99 INR` row that, because the freight picker sorts on
+ * the raw amount, would win **any** INR quote by being the smallest number.
+ * Two had already surfaced as candidates on a real customer's quote.
+ *
+ * A revoke that leaves part of the quote standing is not a revoke, for the
+ * same reason a status flip alone is not one. So the option goes with the
+ * price list. It is torn down AFTER them both, deliberately: unlike the price
+ * list it is no longer dangerous once `isQuotableShippingOption` refuses
+ * anything carrying a `quote_id` rule, so it must never be the thing that
+ * fails a revoke.
  *
  * ## Why this is a function and not two handlers
  *
@@ -41,6 +57,8 @@ export const revokeQuote = async (
 ): Promise<{
   quote: any
   price_list_deleted: boolean
+  /** Which of the quote's OWN freight options were torn down (#1527). */
+  deleted_shipping_option_ids: string[]
   already_revoked?: boolean
 }> => {
   const service: any = scope.resolve(PARTNER_QUOTE_MODULE)
@@ -50,7 +68,12 @@ export const revokeQuote = async (
     // Idempotent: re-revoking is a no-op, not an error. Anyone hitting the
     // button twice must not see a failure that suggests the first one did not
     // take.
-    return { quote, price_list_deleted: false, already_revoked: true }
+    return {
+      quote,
+      price_list_deleted: false,
+      deleted_shipping_option_ids: [],
+      already_revoked: true,
+    }
   }
 
   /**
@@ -91,6 +114,18 @@ export const revokeQuote = async (
     status: "revoked",
   })
 
+  /**
+   * 🔑 After the status is written, and never allowed to throw.
+   *
+   * The option is inert by this point — the estimate refuses any option
+   * carrying a `quote_id` rule — so this is hygiene, and hygiene must not be
+   * able to fail a destructive operation that has already completed. That is
+   * exactly how every revoke on prod once did its whole job and answered 500,
+   * inviting a retry.
+   */
+  const { deleted_shipping_option_ids: deletedOptionIds } =
+    await deleteQuoteFreightOptions(scope, quote)
+
   const by = actor.type === "admin" ? "an admin" : "the partner"
   await service
     .recordEvent({
@@ -101,12 +136,16 @@ export const revokeQuote = async (
       message: priceListId
         ? `Revoked by ${by}; the quoted price list was deleted.`
         : `Revoked by ${by}. No price list was recorded on the quote, so none was deleted.`,
-      data: { price_list_id: priceListId ?? null },
+      data: {
+        price_list_id: priceListId ?? null,
+        deleted_shipping_option_ids: deletedOptionIds,
+      },
     })
     .catch(() => {})
 
   return {
     quote: updated ?? { ...quote, status: "revoked" },
     price_list_deleted: !!priceListId,
+    deleted_shipping_option_ids: deletedOptionIds,
   }
 }

--- a/apps/backend/src/workflows/partner-quote/accept-quote.ts
+++ b/apps/backend/src/workflows/partner-quote/accept-quote.ts
@@ -19,6 +19,11 @@ import {
   emitEventStep,
 } from "@medusajs/medusa/core-flows"
 
+import {
+  QUOTE_FREIGHT_OPTION_RULE_ATTRIBUTE,
+  QUOTE_FREIGHT_OPTION_TYPE_CODE,
+  quoteFreightOptionName,
+} from "../../modules/partner-quote/lib/quote-freight-option"
 import { PARTNER_QUOTE_MODULE } from "../../modules/partner-quote"
 import { PARTNER_QUOTE_EVENTS } from "../../modules/partner-quote/events"
 import { PAYMENT_SCHEDULE_MODULE } from "../../modules/payment_schedule"
@@ -309,7 +314,10 @@ const createQuoteFreightOptionStep = createStep(
     const { result } = await createShippingOptionsWorkflow(container).run({
       input: [
         {
-          name: `Quoted freight — ${quote.id}`,
+          // 🔑 Constructed in ONE place: `revokeQuote`'s teardown finds this
+          // option by this exact string, so the two must not be able to drift
+          // (#1527). A teardown that matches nothing fails silently.
+          name: quoteFreightOptionName(quote.id),
           service_zone_id: source.service_zone_id,
           shipping_profile_id: source.shipping_profile_id,
           provider_id: source.provider_id,
@@ -321,10 +329,23 @@ const createQuoteFreightOptionStep = createStep(
             // domestic lane in #1485, and the picker now refuses anything whose
             // type code says return. Naming this one carefully keeps it out of
             // that blast radius.
-            code: "quoted-freight",
+            //
+            // ⚠️ Careful naming was NOT enough. This option was still offered
+            // to unrelated quotes, because the estimate reads options straight
+            // out of `query.graph` and evaluates no rules — the `quote_id`
+            // rule below hides it from other CARTS only. `isQuotableShippingOption`
+            // now refuses this type code and this rule attribute outright
+            // (#1527).
+            code: QUOTE_FREIGHT_OPTION_TYPE_CODE,
           },
           prices: [{ currency_code: quote.currency_code, amount: freight }],
-          rules: [{ attribute: "quote_id", operator: "eq", value: String(quote.id) }],
+          rules: [
+            {
+              attribute: QUOTE_FREIGHT_OPTION_RULE_ATTRIBUTE,
+              operator: "eq",
+              value: String(quote.id),
+            },
+          ],
         } as any,
       ],
     })


### PR DESCRIPTION
Closes #1527. Closes #1528.

Two defects found by minting a real customer quote on prod, not by reading code. Same family: a plausible number standing in for an unknown one, with nothing looking broken because nothing was ever missing.

## #1527 — a per-quote freight option was an offer to everyone

Accepting a quote mints a flat option priced at that quote's frozen freight, ruled `quote_id eq <id>`. That rule hides it from other **carts**, via core's rule engine. The freight **estimate** never goes near core's rule engine — it reads a location's options straight out of `query.graph` — so every option ever minted stood there as an ordinary candidate for unrelated quotes.

Three were live on prod, all from revoked quotes, two already surfaced on a real customer's quote. `pickFreightOption` sorts on the raw amount, so the **`99 INR`** row would have won *any* INR quote regardless of weight, lane or destination. Fourth instance of that shape (#1424 zone-blind, #1430 rule-blind, #1485 the return row).

**The refusal goes in the callee.** `isQuotableShippingOption` now rejects any option carrying a `quote_id` rule or the `quoted-freight` type code. Teardown alone would have left a **live** quote's negotiated freight standing for the next buyer, and would depend on every future path that kills a quote remembering to clean up. `revokeQuote` also tears the option down — hygiene, after the status is written and never able to throw, since a revoke that answers 500 after doing its whole job invites a retry of a destructive operation (#1517).

Along the way: the estimate's query never fetched `shipping_options.type`, so the type-code half of that guard's belt and braces read a field that could not arrive — **dead since #1485**. It is fetched now (proven path: `/partners/stores/:id/shipping-options`).

## #1528 — readiness could not see "the carrier returned nothing"

`needsManualFreightRate` was `Boolean(calculatedError) && override === null`. A carrier answering an **empty list without erroring** leaves `calculated_error` null, so the guard stayed silent, readiness said `ready: true`, and the quote went out on a flat tier.

That happened on a real Amsterdam quote — €35 flat, `blocking=0`, `error=null` — hours after the same lane returned seven carrier options with the cheapest at €36.42. I read the guard's silence as evidence the lane had been rated and said so. Absence in the instrument, not in the world.

The guard's own docblock says it exists because *"the number is never absent, so nothing looks broken"* — and it reproduced that failure through itself. It now asks the question that matters: **is the figure about to be frozen one a carrier actually gave us?**

| carrier | before | after |
|---|---|---|
| not asked (`carrier: "manual"`) | silent | silent — pricing by hand is the plan |
| asked, errored | refuse | refuse |
| **asked, returned nothing** | **silent, `ready: true`** | **refuse** |
| asked, rated, rated option won | fine | fine |

`carrier_consulted` is added to `ShippingEstimate` and is load-bearing: without it an empty list cannot be told apart from a deliberate decision to ask nobody, and refusing *that* would block every hand-priced lane on purpose.

## Tests

The empty-list case is asserted specifically and **fails on the previous implementation** — verified by reverting the guard body and re-running. The old suite only ever passed an error string, which is why this shipped green (#1495).

Readiness also reports `carrier_rated_count` now, so an operator reads a fact instead of inferring one from a silence.

## Verify

- `TEST_TYPE=unit npx jest --testPathPattern="quote-readiness|shipping-estimate-zone"` — 27 pass
- Full unit suite at the known 3-suite/4-test baseline
- `pnpm check:prod-build` green
- **On prod:** mint a quote with `freight_override_amount`, revoke it, then read another quote's `freight.options` — the withdrawn quote's row must not appear.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_0158wJMZ1DmjNxXf5uGuBrQD