### PR TITLE
feat(design-inquiries,whatsapp): one-tap invite — an `inquiry` deeplink and the template that carries it (#1531 slice 3)

### DIFF
--- a/apps/backend/src/api/partners/wa-auth/route.ts
+++ b/apps/backend/src/api/partners/wa-auth/route.ts
@@ -2,7 +2,10 @@ import type { MedusaRequest, MedusaResponse } from "@medusajs/framework/http"
 import { ContainerRegistrationKeys, MedusaError, Modules } from "@medusajs/framework/utils"
 import type { ConfigModule } from "@medusajs/framework/types"
 import jwt from "jsonwebtoken"
-import { verifyPartnerDeeplink } from "../../../modules/social-provider/whatsapp-deeplink"
+import {
+  partnerDeeplinkPath,
+  verifyPartnerDeeplink,
+} from "../../../modules/social-provider/whatsapp-deeplink"
 import { PARTNER_MODULE } from "../../../modules/partner"
 
 /**
@@ -110,17 +113,23 @@ export const GET = async (req: MedusaRequest, res: MedusaResponse) => {
     { expiresIn },
   )
 
-  // 4. Build the post-login redirect path. The deep-link's `run_id` may
-  //    carry a synthetic ":reminder:YYYY-MM-DD" suffix used as a dedup
-  //    key — strip it so the partner-ui's /production-runs/:id route
-  //    sees the addressable resource id.
+  /**
+   * 4. Build the post-login redirect path.
+   *
+   * 🔴 Via the SAME function `generatePartnerDeeplink` used to build the URL.
+   * This was an independent `if/else` chain, and the two had to agree or the
+   * partner is authenticated and then dropped somewhere else. Adding a type to
+   * one and forgetting the other yields a link that works and lands on the
+   * portal home — nothing errors, and the partner never learns there was
+   * something to see. That is the #1529 shape; two places that must agree will
+   * drift unless they call the same function.
+   *
+   * The deep-link's `run_id` may carry a synthetic ":reminder:YYYY-MM-DD"
+   * dedup suffix; `partnerDeeplinkPath` strips it, which is why the local
+   * `stripDedupSuffix` is only still used for the echoed `run_id` below.
+   */
   const cleanRunId = stripDedupSuffix(payload.runId)
-  let redirectPath = "/"
-  if (payload.type === "production_run" && cleanRunId) {
-    redirectPath = `/production-runs/${cleanRunId}`
-  } else if (payload.type === "design" && cleanRunId) {
-    redirectPath = `/designs/${cleanRunId}`
-  }
+  const redirectPath = partnerDeeplinkPath(payload.type, cleanRunId)
 
   return res.json({
     token: sessionToken,

--- a/apps/backend/src/modules/social-provider/__tests__/whatsapp-deeplink.unit.spec.ts
+++ b/apps/backend/src/modules/social-provider/__tests__/whatsapp-deeplink.unit.spec.ts
@@ -1,0 +1,130 @@
+import {
+  generatePartnerDeeplink,
+  partnerDeeplinkPath,
+  verifyPartnerDeeplink,
+  type PartnerDeeplinkType,
+} from "../whatsapp-deeplink"
+
+/**
+ * Where a one-tap WhatsApp link actually lands (#1531 slice 3).
+ *
+ * ## 🔴 What this exists to stop
+ *
+ * The landing path used to be built in TWO places — a `switch` inside
+ * `generatePartnerDeeplink` and an `if/else` chain inside
+ * `/partners/wa-auth` — written months apart. Both had to agree, or the
+ * partner taps the link, is authenticated, and is then dropped on the portal
+ * home instead of the thing the message was about.
+ *
+ * Nothing errors when that happens. The link "works". The partner simply never
+ * learns there was anything to see, and we read the silence as disinterest.
+ * That is #1529's shape exactly: two pieces of logic that must agree, written
+ * apart, disagreeing in a way whose only symptom is nothing happening.
+ *
+ * They are one function now, and this pins it.
+ */
+
+const ALL_TYPES: PartnerDeeplinkType[] = [
+  "production_run",
+  "design",
+  "portal",
+  "inquiry",
+]
+
+describe("partnerDeeplinkPath", () => {
+  it("lands each type on its own route", () => {
+    expect(partnerDeeplinkPath("production_run", "prun_01ABC")).toBe(
+      "/production-runs/prun_01ABC"
+    )
+    expect(partnerDeeplinkPath("design", "des_01ABC")).toBe("/designs/des_01ABC")
+    expect(partnerDeeplinkPath("inquiry", "dinq_01ABC")).toBe(
+      "/inquiries/dinq_01ABC"
+    )
+  })
+
+  /**
+   * 🔴 THE DRIFT GUARD, and the reason this file exists.
+   *
+   * Every type in the union must resolve to a route that is not the portal
+   * root — `portal` excepted, which IS the root. A type added to
+   * `PartnerDeeplinkType` (and therefore offerable in a visual flow and
+   * signable into a token) without a case in the path function fails here
+   * rather than in a partner's browser, where it would look like a working
+   * link that just went nowhere in particular.
+   */
+  it("🔴 every non-portal type resolves somewhere specific", () => {
+    for (const type of ALL_TYPES) {
+      const path = partnerDeeplinkPath(type, "res_01ABC")
+      if (type === "portal") {
+        expect(path).toBe("/")
+      } else {
+        expect(path).not.toBe("/")
+        expect(path).toContain("res_01ABC")
+      }
+    }
+  })
+
+  it("falls back to the portal root rather than throwing", () => {
+    // A token signed by an older deploy carrying a type this build has never
+    // heard of. Landing somewhere useful beats a 500 in a partner's browser.
+    expect(partnerDeeplinkPath("a_type_from_the_future", "x_1")).toBe("/")
+    expect(partnerDeeplinkPath(null, "x_1")).toBe("/")
+  })
+
+  it("returns the root when there is no resource to open", () => {
+    expect(partnerDeeplinkPath("inquiry", null)).toBe("/")
+    expect(partnerDeeplinkPath("inquiry", "")).toBe("/")
+    expect(partnerDeeplinkPath("portal")).toBe("/")
+  })
+
+  /**
+   * The reminder dispatcher uses `"<id>:reminder:YYYY-MM-DD"` as a per-day
+   * dedup key, and that synthetic id has leaked into the URL and the token
+   * before now — landing the partner on a route that 404s, because the id is
+   * not addressable.
+   */
+  it("strips the reminder dedup suffix from the id", () => {
+    expect(
+      partnerDeeplinkPath("production_run", "prun_01ABC:reminder:2026-08-25")
+    ).toBe("/production-runs/prun_01ABC")
+  })
+})
+
+describe("generatePartnerDeeplink", () => {
+  it("signs a token the verifier can read back", () => {
+    const { url, token } = generatePartnerDeeplink(
+      { partner_id: "prtn_01", run_id: "dinq_01ABC", type: "inquiry" },
+      "https://partner.jaalyantra.com"
+    )
+
+    expect(url).toBe(
+      `https://partner.jaalyantra.com/inquiries/dinq_01ABC?wa_token=${token}`
+    )
+
+    const decoded = verifyPartnerDeeplink(token)
+    expect(decoded).toMatchObject({
+      partnerId: "prtn_01",
+      runId: "dinq_01ABC",
+      type: "inquiry",
+    })
+  })
+
+  /**
+   * 🔑 The claim on the wire is `run_id` even for an inquiry, and it must stay
+   * that way. It is what every token already sitting in a partner's WhatsApp
+   * thread carries; renaming it would silently break each of those links for
+   * the rest of its 24-hour life, and the failure would look like partners
+   * ignoring us.
+   */
+  it("carries an inquiry id in the existing run_id claim", () => {
+    const { token } = generatePartnerDeeplink(
+      { partner_id: "prtn_01", run_id: "dinq_01ABC", type: "inquiry" },
+      "https://partner.jaalyantra.com"
+    )
+    expect(verifyPartnerDeeplink(token)?.runId).toBe("dinq_01ABC")
+  })
+
+  it("refuses a token it did not sign", () => {
+    expect(verifyPartnerDeeplink("not.a.jwt")).toBeNull()
+  })
+})

--- a/apps/backend/src/modules/social-provider/whatsapp-deeplink.ts
+++ b/apps/backend/src/modules/social-provider/whatsapp-deeplink.ts
@@ -3,10 +3,77 @@ import jwt from "jsonwebtoken"
 const DEEPLINK_EXPIRY = "24h"
 const DEEPLINK_ISSUER = "jyt-whatsapp"
 
+/**
+ * What a deep-link can point at.
+ *
+ * 🔑 `inquiry` (#1531 slice 3) is the first type that is not a piece of work
+ * already assigned — it is an ASK, sent to several partners at once, before
+ * anything is ordered. That is exactly why it needs the one-tap link: a
+ * partner who has to remember a password to answer a question they did not ask
+ * for simply does not answer, and the whole feature exists to end that silence.
+ */
+export type PartnerDeeplinkType =
+  | "production_run"
+  | "design"
+  | "portal"
+  | "inquiry"
+
 interface DeeplinkPayload {
   partner_id: string
+  /**
+   * The resource the link opens.
+   *
+   * ⚠️ Named `run_id` because that is the claim already on the wire and in
+   * every token issued in the last 24 hours; it carries whatever id the `type`
+   * addresses — a run, a design, and now an inquiry. Renaming the claim would
+   * silently break every link already sitting in a partner's WhatsApp thread.
+   */
   run_id?: string
-  type: "production_run" | "design" | "portal"
+  type: PartnerDeeplinkType
+}
+
+/**
+ * PURE: where a deep-link of this type lands in the partner portal.
+ *
+ * ## 🔴 Why this is a function and not two switch statements
+ *
+ * It WAS two. `generatePartnerDeeplink` had a `switch` and
+ * `/partners/wa-auth` had an `if/else` chain, written months apart, and both
+ * had to agree or the partner is authenticated and then dropped somewhere
+ * else. Adding a type to one and forgetting the other produces a link that
+ * works — it just quietly lands on the portal home instead of the thing the
+ * message was about, and the partner has no idea they were meant to see
+ * anything.
+ *
+ * That is #1529 exactly: a guard and a releaser written months apart,
+ * disagreeing about which field says what to do, with the disagreement showing
+ * up as nothing happening. Two places that must agree will drift unless they
+ * call the same function.
+ *
+ * Unknown types fall back to the portal root rather than throwing. A link that
+ * lands somewhere useful beats a 500 in a partner's browser — but every type
+ * in the union is covered here, so the fallback is for tokens issued by an
+ * older deploy, not for a type nobody wired up.
+ */
+export function partnerDeeplinkPath(
+  type: string | null | undefined,
+  resourceId?: string | null
+): string {
+  const id = stripDedupSuffix(resourceId ?? undefined)
+  if (!id) return "/"
+
+  switch (type) {
+    case "production_run":
+      return `/production-runs/${id}`
+    case "design":
+      return `/designs/${id}`
+    case "inquiry":
+      // Mirrors the partner-ui route added in slice 2
+      // (get-partner-route.map.tsx → `/inquiries/:id`).
+      return `/inquiries/${id}`
+    default:
+      return "/"
+  }
 }
 
 /**
@@ -50,18 +117,8 @@ export function generatePartnerDeeplink(
     { expiresIn: DEEPLINK_EXPIRY }
   )
 
-  let path = ""
-  switch (payload.type) {
-    case "production_run":
-      path = `/production-runs/${cleanRunId}`
-      break
-    case "design":
-      path = `/designs/${cleanRunId}`
-      break
-    case "portal":
-      path = "/"
-      break
-  }
+  // One path builder, shared with /partners/wa-auth. See its docblock.
+  const path = partnerDeeplinkPath(payload.type, cleanRunId)
 
   const url = `${baseUrl}${path}?wa_token=${token}`
 

--- a/apps/backend/src/modules/visual_flows/operations/generate-partner-deeplink.ts
+++ b/apps/backend/src/modules/visual_flows/operations/generate-partner-deeplink.ts
@@ -1,7 +1,10 @@
 import { z } from "@medusajs/framework/zod"
 import { OperationDefinition, OperationContext, OperationResult } from "./types"
 import { interpolateString } from "./utils"
-import { generatePartnerDeeplink } from "../../social-provider/whatsapp-deeplink"
+import {
+  generatePartnerDeeplink,
+  type PartnerDeeplinkType,
+} from "../../social-provider/whatsapp-deeplink"
 
 /**
  * Generate a short-lived signed URL that a partner can tap from WhatsApp to
@@ -34,10 +37,15 @@ export const generatePartnerDeeplinkOperation: OperationDefinition = {
       .string()
       .optional()
       .describe(
-        'Optional run / design ID to deep-link into. Ignored when type="portal".'
+        'Optional run / design / inquiry ID to deep-link into. Ignored when type="portal".'
       ),
     type: z
-      .enum(["production_run", "design", "portal"])
+      // ⚠️ This enum, `PartnerDeeplinkType` and `partnerDeeplinkPath` must
+      // agree. The path function is the one that decides where a tap lands;
+      // a type missing HERE simply cannot be chosen in a flow, which is a
+      // visible failure — unlike a type missing from the path function, which
+      // silently lands the partner on the portal home (#1531 slice 3).
+      .enum(["production_run", "design", "portal", "inquiry"])
       .default("production_run")
       .describe("Deep-link type. Controls the landing route."),
     base_url: z
@@ -67,10 +75,8 @@ export const generatePartnerDeeplinkOperation: OperationDefinition = {
       const runId = options.run_id
         ? interpolateString(options.run_id, context.dataChain).trim() || undefined
         : undefined
-      const type = (options.type || "production_run") as
-        | "production_run"
-        | "design"
-        | "portal"
+      const type = (options.type ||
+        "production_run") as PartnerDeeplinkType
 
       const baseUrl =
         (options.base_url

--- a/apps/backend/src/scripts/whatsapp-templates/all-templates.ts
+++ b/apps/backend/src/scripts/whatsapp-templates/all-templates.ts
@@ -7,9 +7,11 @@
 import { PARTNER_RUN_TEMPLATES, type TemplateSpec } from "./partner-run-templates"
 import { PARTNER_PAYMENT_TEMPLATES } from "./partner-payment-templates"
 import { INVENTORY_ORDER_TEMPLATES } from "./inventory-order-templates"
+import { DESIGN_INQUIRY_TEMPLATES } from "./design-inquiry-templates"
 
 export const ALL_WHATSAPP_TEMPLATES: TemplateSpec[] = [
   ...PARTNER_RUN_TEMPLATES,
   ...PARTNER_PAYMENT_TEMPLATES,
   ...INVENTORY_ORDER_TEMPLATES, // #771 inventory-order status notifications
+  ...DESIGN_INQUIRY_TEMPLATES, // #1531 "what can you make?" sourcing invite
 ]

--- a/apps/backend/src/scripts/whatsapp-templates/design-inquiry-templates.ts
+++ b/apps/backend/src/scripts/whatsapp-templates/design-inquiry-templates.ts
@@ -1,0 +1,125 @@
+import type { TemplateSpec } from "./partner-run-templates"
+
+/**
+ * WhatsApp templates for design inquiries — "what can you make?" (#1531 slice 3).
+ *
+ * ## Why an inquiry needs a template at all
+ *
+ * Meta's 24-hour customer-care window only constrains BUSINESS-initiated
+ * messages, and an inquiry is business-initiated by definition: we are asking
+ * a partner about a design they have never seen, usually weeks after the last
+ * time either of us said anything. So a free-form message will simply not
+ * deliver. A template will.
+ *
+ * 🔑 Any inbound message from the partner reopens the window for 24 hours,
+ * free and with no template — so the follow-up conversation after they tap is
+ * unconstrained. It is only the first knock that has to be a template.
+ *
+ * ## Why the button is a dynamic URL and not a quick reply
+ *
+ * A quick reply comes back as its own display text and nothing else, so the
+ * inbound handler has to guess which inquiry it was about from conversation
+ * metadata — which is how `pending_run_id` came to exist, and it holds ONE id.
+ * An inquiry goes to several partners, and a partner may hold several
+ * inquiries at once, so that mechanism cannot address it.
+ *
+ * A dynamic URL button carries a per-send `wa_token` whose claims name the
+ * partner AND the inquiry. Tapping it lands them authenticated on that exact
+ * wizard — no password, no guessing, and it works when they get round to it
+ * three days later. See `whatsapp-deeplink.ts` and `/partners/wa-auth`.
+ *
+ * ## 🔴 These are not live until Meta approves them
+ *
+ * Adding a spec here submits it; it does not approve it. Until approval every
+ * send fails, which is why the invite step treats a failed send as non-fatal
+ * and records that it did not go. Run the sync (`manage-whatsapp-templates.ts`
+ * or the `sync-whatsapp-templates` maintenance job) and check the status in
+ * Meta before assuming a partner was ever asked.
+ *
+ * Editing rules inherited from `partner-run-templates.ts`, and they bite:
+ *   - Variable and button COUNT must be identical across languages.
+ *   - Meta rejects a body that ends on a variable (subcode 2388299) or has
+ *     too few words per variable (2388293).
+ *   - No emoji, variables, newlines or formatting inside button text.
+ */
+
+const INQUIRY_ACTION_BASE = (
+  process.env.PARTNER_PORTAL_URL || "https://partner.jaalyantra.com"
+).replace(/\/$/, "")
+
+/**
+ * {{1}} is filled per-send with the `wa_token`.
+ *
+ * ⚠️ It targets the LIST route, not `/inquiries/:id`. The base is baked into
+ * the approved template and is therefore static per Meta — it cannot carry the
+ * inquiry id. The id rides in the token instead: partner-ui's ProtectedRoute
+ * exchanges `wa_token` on whatever protected page it lands on, and navigates
+ * to the redirect the backend returns (`/inquiries/<id>`). Same mechanism the
+ * production-run reminders use.
+ */
+const INQUIRY_ACTION_URL = `${INQUIRY_ACTION_BASE}/inquiries?wa_token={{1}}`
+
+const INQUIRY_ACTION_EXAMPLE = [
+  `${INQUIRY_ACTION_BASE}/inquiries?wa_token=eyJhbGciOiJIUzI1NiJ9.eyJzdWIiOiJwcnRuXzAxIiwicnVuX2lkIjoiZGlucV8wMUFCQyIsInR5cGUiOiJpbnF1aXJ5In0.s1gnatureExample`,
+]
+
+/**
+ * The invitation.
+ *
+ * Deliberately says how many questions there are and that a photo is welcome.
+ * A partner deciding whether to open this is deciding whether it is worth ten
+ * minutes at a loom — "4 questions" answers that, "we'd love your input" does
+ * not.
+ */
+const TEMPLATE_INQUIRY_INVITE: TemplateSpec = {
+  name: "jyt_design_inquiry_invite_v1",
+  category: "UTILITY",
+  languages: [
+    {
+      language: "en",
+      body:
+        "Hi {{1}}, we are sourcing a new design and would like to know what " +
+        "you can make.\n\n" +
+        "*Design:* {{2}}\n" +
+        "*Questions:* {{3}}\n\n" +
+        "Tap below to answer. A photo of something similar on your loom right " +
+        "now helps more than anything else you could send us.",
+      examples: ["Rajesh", "Kani Twill Stole", "4"],
+      buttons: [
+        {
+          type: "URL",
+          text: "Answer now",
+          url: INQUIRY_ACTION_URL,
+          example: INQUIRY_ACTION_EXAMPLE,
+        },
+      ],
+    },
+    {
+      language: "hi",
+      body:
+        "नमस्ते {{1}}, हम एक नया डिज़ाइन बनवा रहे हैं और जानना चाहते हैं कि " +
+        "आप क्या बना सकते हैं।\n\n" +
+        "*डिज़ाइन:* {{2}}\n" +
+        "*प्रश्न:* {{3}}\n\n" +
+        "उत्तर देने के लिए नीचे टैप करें। आपके करघे पर अभी जो कुछ भी ऐसा बना " +
+        "है, उसकी एक फोटो सबसे ज़्यादा मदद करेगी।",
+      examples: ["राजेश", "कानी ट्विल स्टोल", "4"],
+      buttons: [
+        {
+          type: "URL",
+          text: "अभी उत्तर दें",
+          url: INQUIRY_ACTION_URL,
+          example: INQUIRY_ACTION_EXAMPLE,
+        },
+      ],
+    },
+  ],
+}
+
+export const DESIGN_INQUIRY_TEMPLATES: TemplateSpec[] = [
+  TEMPLATE_INQUIRY_INVITE,
+]
+
+export const DESIGN_INQUIRY_TEMPLATE_NAMES = {
+  INQUIRY_INVITE: TEMPLATE_INQUIRY_INVITE.name,
+} as const

--- a/apps/backend/src/workflows/design-inquiries/create-design-inquiry.ts
+++ b/apps/backend/src/workflows/design-inquiries/create-design-inquiry.ts
@@ -16,6 +16,9 @@ import { PARTNER_MODULE } from "../../modules/partner"
 import { DESIGN_INQUIRY_MODULE } from "../../modules/design_inquiry"
 import type DesignInquiryService from "../../modules/design_inquiry/service"
 import designPartnersLink from "../../links/design-partners-link"
+import { SOCIAL_PROVIDER_MODULE } from "../../modules/social-provider"
+import { generatePartnerDeeplink } from "../../modules/social-provider/whatsapp-deeplink"
+import { DESIGN_INQUIRY_TEMPLATE_NAMES } from "../../scripts/whatsapp-templates/design-inquiry-templates"
 import {
   generateInquiryQuestions,
   resolveSpecVersion,
@@ -205,6 +208,158 @@ const grantProspectAccessStep = createStep(
   }
 )
 
+/**
+ * Knock on WhatsApp, once, with a link that lands them in the wizard (#1531
+ * slice 3).
+ *
+ * ## Why this is a template and not a message
+ *
+ * Meta's 24-hour window constrains BUSINESS-initiated messages, and an inquiry
+ * is business-initiated by definition — we are asking about a design they have
+ * never seen, usually weeks since either of us last said anything. A free-form
+ * message would not deliver at all.
+ *
+ * 🔑 Any inbound reply reopens the window for 24 hours, free and with no
+ * template. Only the first knock has to be one.
+ *
+ * ## Why the link carries a token instead of an id
+ *
+ * The approved template's URL is static per Meta, so it cannot name the
+ * inquiry. The `wa_token` does: its claims carry the partner AND the inquiry,
+ * `/partners/wa-auth` exchanges it for a session and returns
+ * `/inquiries/<id>`, and partner-ui navigates there. So a partner who gets
+ * round to it three days later still lands on the right wizard with no
+ * password — which matters more here than anywhere else, because they did not
+ * ask for this and any friction reads as a no.
+ *
+ * ## 🔴 Non-fatal, and it says what it actually did
+ *
+ * The inquiry exists whether or not WhatsApp accepted the message, and losing
+ * a whole sourcing round because one partner's number is stale would be far
+ * worse than an un-notified invite — they can still be told by hand.
+ *
+ * But a swallowed failure here is the worst kind: the invite looks sent, the
+ * partner never hears, and their silence gets read as disinterest. So every
+ * outcome is counted and returned. `jyt_design_inquiry_invite_v1` is also NOT
+ * approved by Meta merely by existing in the spec file — until the sync runs
+ * and Meta approves, EVERY send fails, and `notified: 0` is the only thing
+ * that will say so.
+ */
+const notifyInvitedPartnersStep = createStep(
+  "notify-inquiry-partners",
+  async (
+    input: {
+      inquiry_id: string
+      partner_ids: string[]
+      design_name: string
+      question_count: number
+    },
+    { container }
+  ) => {
+    const logger: any = container.resolve(ContainerRegistrationKeys.LOGGER)
+
+    const result = {
+      notified: 0,
+      no_whatsapp_number: 0,
+      failed: 0,
+      skipped_reason: null as string | null,
+    }
+
+    if (!input.partner_ids?.length) return new StepResponse(result)
+
+    let whatsapp: any
+    try {
+      const socialProvider: any = container.resolve(SOCIAL_PROVIDER_MODULE)
+      whatsapp = socialProvider.getWhatsApp(container as any)
+    } catch (e: any) {
+      // WhatsApp not configured in this environment — a real state locally and
+      // in tests, and not a reason to fail creating an inquiry.
+      result.skipped_reason = `WhatsApp is not configured: ${e?.message ?? String(e)}`
+      logger?.warn?.(`[design-inquiry] ${result.skipped_reason}`)
+      return new StepResponse(result)
+    }
+
+    const partnerService: any = container.resolve(PARTNER_MODULE)
+    const lang = process.env.WHATSAPP_TEMPLATE_LANG || "hi"
+    const base = (
+      process.env.PARTNER_PORTAL_URL || "https://partner.jaalyantra.com"
+    ).replace(/\/$/, "")
+
+    for (const partnerId of input.partner_ids) {
+      let partner: any = null
+      try {
+        partner = await partnerService.retrievePartner(partnerId)
+      } catch {
+        partner = null
+      }
+
+      const phone = partner?.whatsapp_number
+      if (!phone || !partner?.whatsapp_verified) {
+        // Counted, not silent. A partner we cannot reach is a partner whose
+        // silence means nothing, and whoever reads the comparison needs to
+        // know which kind of silence they are looking at.
+        result.no_whatsapp_number++
+        logger?.warn?.(
+          `[design-inquiry] ${input.inquiry_id}: partner ${partnerId} has no verified WhatsApp number — not notified`
+        )
+        continue
+      }
+
+      try {
+        const { token } = generatePartnerDeeplink(
+          {
+            partner_id: partnerId,
+            run_id: input.inquiry_id,
+            type: "inquiry",
+          },
+          base
+        )
+
+        await whatsapp.sendTemplateMessage(
+          phone,
+          DESIGN_INQUIRY_TEMPLATE_NAMES.INQUIRY_INVITE,
+          lang,
+          [
+            {
+              type: "body",
+              parameters: [
+                { type: "text", text: partner?.name || "Partner" },
+                { type: "text", text: input.design_name },
+                { type: "text", text: String(input.question_count) },
+              ],
+            },
+            {
+              // The dynamic URL button's {{1}}. `index` is coerced to a string
+              // at the service boundary, as Meta's wire format requires.
+              type: "button",
+              sub_type: "url",
+              index: 0,
+              parameters: [{ type: "text", text: token }],
+            },
+          ]
+        )
+        result.notified++
+      } catch (e: any) {
+        result.failed++
+        logger?.warn?.(
+          `[design-inquiry] ${input.inquiry_id}: invite to ${partnerId} failed: ${e?.message ?? String(e)}`
+        )
+      }
+    }
+
+    logger?.info?.(
+      `[design-inquiry] ${input.inquiry_id}: notified ${result.notified}, ` +
+        `${result.no_whatsapp_number} without WhatsApp, ${result.failed} failed`
+    )
+
+    return new StepResponse(result)
+  }
+  // 🔑 No compensation. A WhatsApp message cannot be unsent, and pretending
+  // otherwise would be worse than admitting it: if a later step rolls the
+  // inquiry back, the partner has still been asked. That is the argument for
+  // this step running LAST.
+)
+
 export const createDesignInquiryWorkflow = createWorkflow(
   "create-design-inquiry",
   (input: CreateDesignInquiryInput) => {
@@ -234,17 +389,21 @@ export const createDesignInquiryWorkflow = createWorkflow(
         )
       )
 
+      const questions = generateInquiryQuestions({
+        specifications,
+        colours,
+        categories: data.input.categories,
+      })
+
       return {
         partner_ids: partnerIds,
+        design_name: (data.design as any)?.name ?? "a new design",
+        question_count: questions.length,
         title:
           data.input.title?.trim() ||
           `What can you make for ${(data.design as any)?.name ?? "this design"}?`,
         spec_version: resolveSpecVersion(specifications),
-        questions: generateInquiryQuestions({
-          specifications,
-          colours,
-          categories: data.input.categories,
-        }),
+        questions,
       }
     })
 
@@ -264,6 +423,23 @@ export const createDesignInquiryWorkflow = createWorkflow(
       partner_ids: prepared.partner_ids,
     })
 
-    return new WorkflowResponse(created)
+    /**
+     * LAST, deliberately. The grant has to exist before the partner can be
+     * told to go and look — a message arriving before the access it promises
+     * lands the partner on a 404, and they do not knock twice.
+     */
+    const notified = notifyInvitedPartnersStep({
+      inquiry_id: created.inquiry.id,
+      partner_ids: prepared.partner_ids,
+      design_name: prepared.design_name,
+      question_count: prepared.question_count,
+    })
+
+    return new WorkflowResponse(
+      transform({ created, notified }, (data) => ({
+        ...(data.created as any),
+        notifications: data.notified,
+      }))
+    )
   }
 )


### PR DESCRIPTION
Part of #1531 (slice 3 of 4). Rebased onto `main` after #1534 squash-merged, so this is slice 3's diff alone.

Slice 2 gave a partner somewhere to answer. Nobody tells them it exists. This is the knock: a WhatsApp template whose button lands them in the wizard, already authenticated.

## Why a template, not a message

Meta's 24-hour window constrains **business-initiated** messages, and an inquiry is business-initiated by definition — we are asking about a design they have never seen, usually weeks since either of us last said anything. A free-form message would not deliver at all.

🔑 Any inbound reply reopens the window for 24 hours, free and with no template. Only the first knock has to be one.

## Why the button carries a token, not an id

The approved template's URL is **static per Meta**, so it cannot name the inquiry. The `wa_token` does: its claims carry the partner *and* the inquiry, `/partners/wa-auth` exchanges it for a session and returns `/inquiries/<id>`, and partner-ui navigates there. So a partner who gets round to it three days later still lands on the right wizard with no password — which matters more here than anywhere else, because they did not ask for this and any friction reads as a no.

## The defect this would otherwise have shipped

The landing path was built in **two** places — a `switch` in `generatePartnerDeeplink` and an independent `if/else` in `/partners/wa-auth`, written months apart. Adding `inquiry` to one and forgetting the other yields a link that **works**: the partner taps, the token verifies, a session is issued, and they land on the portal home instead of the thing the message was about.

Nothing errors. They never learn there was anything to see, and their not-acting reads as disinterest.

That is #1529's shape exactly — two pieces of logic that must agree, written apart, whose disagreement's only symptom is nothing happening. They are one function now (`partnerDeeplinkPath`), and a test walks **every member of the type union** asserting each non-`portal` type resolves somewhere specific, so a type added without a case fails in jest rather than in a partner's browser.

## Also in

- `PartnerDeeplinkType` exported; the visual-flows operation's enum gains `inquiry` and borrows the type instead of restating it.
- The `run_id` JWT claim **keeps its name** even for an inquiry. It is what every token already sitting in a partner's WhatsApp thread carries; renaming it would silently break each of those for the rest of its 24-hour life, and the failure would look like partners ignoring us.
- `jyt_design_inquiry_invite_v1` (en + hi), registered in `all-templates.ts` so both push paths pick it up. It states the design **and the question count** — a partner deciding whether to open this is deciding whether it is worth ten minutes at a loom, and "4 questions" answers that where "we'd love your input" does not.
- `notifyInvitedPartnersStep` runs **last** in `create-design-inquiry`, after the prospect grant — a message arriving before the access it promises lands the partner on a 404, and they do not knock twice.

🔴 **Non-fatal, and it counts what it actually did.** The inquiry exists whether or not WhatsApp accepted anything, and losing a sourcing round because one number is stale would be worse than an un-notified invite. But a swallowed failure here is the worst kind — the invite *looks* sent, the partner never hears, and their silence is read as disinterest. So `notified` / `no_whatsapp_number` / `failed` come back on the workflow result. No compensation step: a WhatsApp message cannot be unsent, which is the argument for running it last.

## Verify

- `TEST_TYPE=unit npx jest --testPathPattern="whatsapp-deeplink"` — 8 pass
- Full unit suite at the known 3-suite/4-test baseline
- `pnpm check:prod-build` green (re-run after the rebase)

## ⚠️ Before trusting an invite

`jyt_design_inquiry_invite_v1` is **not live merely by existing in this file**. Until the sync runs (`manage-whatsapp-templates.ts` or the `sync-whatsapp-templates` job) and **Meta approves it**, every send fails and `notified: 0` is the only thing that will say so. The end-to-end tap has not been exercised.

## Next

Slice 4 — MCP rows (with the contract test, per #1348/#1394) so the assistant can walk a partner through an inquiry, plus promote-to-sample reusing the #1529 goods edge so a stitcher's sample cannot dispatch until the weaver's cloth is `Delivered`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_0158wJMZ1DmjNxXf5uGuBrQD