### PR TITLE
test(e2e): a UI contract for the sourcing wizard, since partner-ui has no CI (#1531, #1482)

### DIFF
--- a/e2e/helpers/e2e-seed.ts
+++ b/e2e/helpers/e2e-seed.ts
@@ -979,6 +979,174 @@ export async function seedShipmentGatePartner(
  * Mirrors seedShipmentGatePartner for auth, then creates a website with a page
  * containing a Hero block and a Feature block so the editor has content to render.
  */
+/**
+ * A design inquiry a partner has been invited to but has NOT answered (#1531).
+ *
+ * 🔑 Deliberately un-answered. The wizard's whole contract is the path from
+ * "invited, silent" to "answered", and a fixture that starts mid-way cannot
+ * exercise the step that has actually broken before: the autosave.
+ *
+ * ⚠️ SINGLE-USE in the sense that matters — the spec submits a verdict, so a
+ * re-run finds a response that is already submitted. The spec is written to
+ * tolerate that (it asserts the wizard reaches a verdict, not that the verdict
+ * was previously absent), but a run against a fresh seed is the honest one.
+ *
+ * The questions are written by hand rather than by running
+ * `generateInquiryQuestions`, on purpose: this fixture is the CONTRACT the UI
+ * renders against. If generation changes shape, this seed should fail to match
+ * the UI and someone should have to look — which is exactly what a generated
+ * fixture would hide by changing in lockstep.
+ */
+async function seedDesignInquiry(container: any): Promise<{
+  email: string
+  password: string
+  partnerId: string
+  designId: string
+  designName: string
+  inquiryId: string
+  materialPrompt: string
+  measurementPrompt: string
+  colourPrompt: string
+  photoPrompt: string
+  questionCount: number
+}> {
+  const authModule = container.resolve(Modules.AUTH)
+  const partnerModule: any = container.resolve("partner")
+  const designService: any = container.resolve("design")
+  const inquiryService: any = container.resolve("design_inquiry")
+
+  const stamp = Date.now()
+  const email = `e2e-inquiry-${stamp}@jyt.test`
+
+  const partner = await partnerModule.createPartners({
+    name: "E2E Inquiry Weaver",
+    handle: `e2e-inquiry-${stamp}`,
+    status: "active",
+    is_verified: true,
+  })
+  const partnerId = (Array.isArray(partner) ? partner[0] : partner).id as string
+
+  await partnerModule.createPartnerAdmins({
+    email,
+    first_name: "Inquiry",
+    last_name: "Weaver",
+    role: "admin",
+    partner_id: partnerId,
+  })
+
+  const hashConfig = { logN: 15, r: 8, p: 1 }
+  const passwordHash = await Scrypt.kdf(SEED_PASSWORD, hashConfig)
+  const authIdentity: any = await authModule.createAuthIdentities({
+    provider_identities: [
+      {
+        provider: "emailpass",
+        entity_id: email,
+        provider_metadata: { password: passwordHash.toString("base64") },
+      },
+    ],
+    app_metadata: { partner_id: partnerId },
+  })
+  const authIdentityId = (
+    Array.isArray(authIdentity) ? authIdentity[0] : authIdentity
+  ).id as string
+
+  const now = new Date()
+  await authModule.createAuthVerifications([
+    {
+      auth_identity_id: authIdentityId,
+      entity_id: email,
+      entity_type: "email",
+      code_provider: "emailpass",
+      requested_at: now,
+      verified_at: now,
+    },
+  ])
+
+  const designName = `Kani Twill Stole (e2e ${stamp})`
+  const design = await designService.createDesigns({
+    name: designName,
+    description: "e2e #1531 sourcing-inquiry fixture",
+    design_type: "Original",
+    status: "In_Development",
+    priority: "Medium",
+  })
+  const designId = (Array.isArray(design) ? design[0] : design).id as string
+
+  const inquiry = await inquiryService.createDesignInquiries({
+    design_id: designId,
+    title: `What can you make for ${designName}?`,
+    brief_note: "Small run, 40 pieces. Tell us what you can actually do.",
+    spec_version: "v1",
+    status: "open",
+  })
+  const inquiryId = (Array.isArray(inquiry) ? inquiry[0] : inquiry).id as string
+
+  const materialPrompt = "Can you supply Cashmere 70s?"
+  const measurementPrompt = "What GSM can you achieve? (we need 90)"
+  const colourPrompt = "Which of these colours can you do?"
+  const photoPrompt =
+    "Show us something similar you have made recently — a photo of what is on your loom now is perfect."
+
+  await inquiryService.createDesignInquiryQuestions([
+    {
+      inquiry_id: inquiryId,
+      step: "Materials",
+      order: 0,
+      kind: "yes_no",
+      prompt: materialPrompt,
+      spec_field_ref: "e2e:material:0",
+    },
+    {
+      inquiry_id: inquiryId,
+      step: "Measurements",
+      order: 1,
+      kind: "number",
+      prompt: measurementPrompt,
+      spec_field_ref: "e2e:measurement:GSM",
+    },
+    {
+      inquiry_id: inquiryId,
+      step: "Colours",
+      order: 2,
+      kind: "colour_select",
+      prompt: colourPrompt,
+      options: [
+        { id: null, value: "Off White", hex: "#F2EFE6" },
+        { id: null, value: "Indigo", hex: "#2B3A67" },
+      ],
+    },
+    {
+      inquiry_id: inquiryId,
+      step: "Show us",
+      order: 3,
+      kind: "photo",
+      prompt: photoPrompt,
+    },
+  ])
+
+  // The empty response row IS the invitation — a partner who never answers has
+  // to read as silence rather than as absent from the comparison.
+  await inquiryService.createDesignInquiryResponses({
+    inquiry_id: inquiryId,
+    partner_id: partnerId,
+    invited_at: now,
+  })
+
+  return {
+    email,
+    password: SEED_PASSWORD,
+    partnerId,
+    designId,
+    designName,
+    inquiryId,
+    materialPrompt,
+    measurementPrompt,
+    colourPrompt,
+    photoPrompt,
+    questionCount: 4,
+  }
+}
+
 async function seedContentEditorPartner(
   container: any
 ): Promise<{
@@ -1318,6 +1486,7 @@ export default async function e2eSeed({ container }: ExecArgs) {
 
   logger.info("E2E seed: creating content editor partner + website + page + blocks...")
   const contentEditor = await seedContentEditorPartner(container)
+  const inquiry = await seedDesignInquiry(container)
 
   const seedData = {
     email,
@@ -1392,6 +1561,19 @@ export default async function e2eSeed({ container }: ExecArgs) {
     acceptedQuoteCompany: adminQuotes.acceptedQuoteCompany,
     zeroDepositQuoteId: adminQuotes.zeroDepositQuoteId,
     zeroDepositQuoteCompany: adminQuotes.zeroDepositQuoteCompany,
+    // #1531 slice 2 — the sourcing wizard, consumed by
+    // partner-inquiry-wizard.spec.ts (@partnerui, local only).
+    inquiryPartnerEmail: inquiry.email,
+    inquiryPartnerPassword: inquiry.password,
+    inquiryPartnerId: inquiry.partnerId,
+    inquiryId: inquiry.inquiryId,
+    inquiryDesignId: inquiry.designId,
+    inquiryDesignName: inquiry.designName,
+    inquiryMaterialPrompt: inquiry.materialPrompt,
+    inquiryMeasurementPrompt: inquiry.measurementPrompt,
+    inquiryColourPrompt: inquiry.colourPrompt,
+    inquiryPhotoPrompt: inquiry.photoPrompt,
+    inquiryQuestionCount: inquiry.questionCount,
   }
 
   fs.writeFileSync(SEED_FILE, JSON.stringify(seedData, null, 2))

--- a/e2e/specs/partner-inquiry-wizard.spec.ts
+++ b/e2e/specs/partner-inquiry-wizard.spec.ts
@@ -1,0 +1,294 @@
+import { test, expect } from "@playwright/test"
+import * as fs from "fs"
+import * as path from "path"
+
+const SEED_FILE = path.resolve(__dirname, "../../apps/backend/.e2e-seed.json")
+const PARTNER_UI = process.env.PARTNER_UI_URL || "http://localhost:5173"
+
+/**
+ * The UI contract for the sourcing wizard (#1531 slice 2).
+ *
+ * ## Why this file exists
+ *
+ * `apps/partner-ui` has no CI at all (#1482). Slice 2 shipped to production
+ * having been proven only by `tsc --noEmit` and `vite build` — which prove the
+ * code compiles and say nothing whatever about whether a partner can answer a
+ * question. Every partner-facing failure this repo has had was of that second
+ * kind: the quote list shipped twice with no nav pointing at it, and nothing
+ * failed either time.
+ *
+ * So this asserts the CONTRACT, not the implementation:
+ *
+ *   1. a partner can REACH the wizard from the sidebar, not just by URL;
+ *   2. the questions rendered are the ones the inquiry persisted, in order;
+ *   3. each question kind renders its own control;
+ *   4. a step SAVES before the wizard advances;
+ *   5. a submitted verdict survives a reload;
+ *   6. a closed inquiry cannot be answered.
+ *
+ * 🔴 (4) and (5) are the ones worth the whole file. Autosave-then-advance is
+ * where a wizard loses work silently: the partner finishes, sees no error, and
+ * nothing was kept. That failure has no symptom at all from inside the app.
+ *
+ * @partnerui — needs the partner-UI dev server, which the e2e config does not
+ * boot; skipped on CI, run locally.
+ *
+ * ⚠️ **Check WHICH checkout is serving that port.** On this machine :5173 has
+ * been served by vite from a *different clone of this repo*, so partner-UI
+ * specs quietly asserted against another working tree — the fix under test was
+ * nowhere in the bundle. `ps -o command= -p $(lsof -ti:5173)` settles it.
+ * Point this at the right server with `PARTNER_UI_URL=http://localhost:5174`
+ * rather than assuming the default port is yours.
+ */
+
+type Seed = {
+  inquiryPartnerEmail: string
+  inquiryPartnerPassword: string
+  inquiryId: string
+  inquiryDesignName: string
+  inquiryMaterialPrompt: string
+  inquiryMeasurementPrompt: string
+  inquiryColourPrompt: string
+  inquiryPhotoPrompt: string
+  inquiryQuestionCount: number
+}
+
+const seed: Seed = JSON.parse(fs.readFileSync(SEED_FILE, "utf-8"))
+
+/**
+ * 🔑 Fail loudly on a seed that predates this fixture rather than passing
+ * vacuously against `undefined`. A spec that asserts `toContain(undefined)`
+ * finds nothing and reports nothing — the #1495 shape, where a suite stayed
+ * green while the thing it certified was impossible.
+ */
+test.beforeAll(() => {
+  expect(
+    seed.inquiryId,
+    "Seed predates the #1531 inquiry fixture — re-run the e2e seed"
+  ).toBeTruthy()
+})
+
+const login = async (page: any) => {
+  // `networkidle` matters: the submit handler is attached on hydration, and a
+  // click that lands before it is silently swallowed.
+  await page.goto(`${PARTNER_UI}/login`, { waitUntil: "networkidle" })
+  await page.locator('input[name="email"]').fill(seed.inquiryPartnerEmail)
+  await page.locator('input[name="password"]').fill(seed.inquiryPartnerPassword)
+  await page.locator('button[type="submit"]').click()
+
+  // Wait on the PERSISTED TOKEN, not the URL — a `/\/(?!login)/` match resolves
+  // instantly against the "//" in "http://" and races past login.
+  await page.waitForFunction(
+    () => !!localStorage.getItem("partner_ui_auth_token"),
+    { timeout: 15_000 }
+  )
+}
+
+test.describe("Partner sourcing wizard @partnerui", () => {
+  test.beforeEach(async ({ page }) => {
+    await login(page)
+  })
+
+  /**
+   * 🔴 A route that renders is not a feature.
+   *
+   * The quote list shipped twice with nothing in the nav pointing at it — the
+   * second time because the entry was added to two of the three persona
+   * branches in `main-layout.tsx` and missed on the DEFAULT one, i.e. the
+   * sidebar most partners actually get. This is the same file and the same
+   * three branches.
+   */
+  test("🔑 the wizard is reachable from the sidebar, not only by URL", async ({
+    page,
+  }) => {
+    // Entered on a concrete route: the partner root renders the app's own 404
+    // for a seeded partner that has not been through onboarding, and a spec
+    // that starts there fails for reasons unrelated to the nav.
+    await page.goto(`${PARTNER_UI}/inquiries`)
+
+    await page.getByRole("link", { name: /^designs$/i }).first().click()
+    await expect(
+      page.getByRole("link", { name: /what can you make/i }).first()
+    ).toBeVisible({ timeout: 15_000 })
+  })
+
+  test("the list leads with what is still owed", async ({ page }) => {
+    await page.goto(`${PARTNER_UI}/inquiries`)
+
+    await expect(page.getByText(seed.inquiryDesignName)).toBeVisible({
+      timeout: 15_000,
+    })
+    // An un-answered inquiry must SAY it is un-answered. "3 asked, 1 replied"
+    // is the fact the empty response row exists to make readable, and it is
+    // useless if the partner cannot see which one is theirs to do.
+    await expect(page.getByText(/needs your answer/i).first()).toBeVisible()
+    await expect(
+      page.getByText(new RegExp(`${seed.inquiryQuestionCount}\\s+questions`, "i"))
+    ).toBeVisible()
+  })
+
+  /**
+   * 🔴 The questions must be the PERSISTED ones, in their persisted order.
+   *
+   * Regenerating them from the design's current spec on read would look
+   * identical on a fresh inquiry and be wrong on every older one: a spec moves
+   * while sourcing runs, and a wizard that silently rewords itself between
+   * being sent and being answered makes "yes we can do that" unreadable,
+   * because it no longer says which *that*.
+   */
+  test("🔴 renders the persisted questions, grouped by their spec category", async ({
+    page,
+  }) => {
+    await page.goto(`${PARTNER_UI}/inquiries/${seed.inquiryId}`)
+
+    for (const step of ["Materials", "Measurements", "Colours", "Show us"]) {
+      await expect(
+        page.getByRole("tab", { name: new RegExp(`^${step}$`, "i") }).first()
+      ).toBeVisible({ timeout: 15_000 })
+    }
+
+    // Step one is Materials, and its question is the seeded one verbatim.
+    await expect(page.getByText(seed.inquiryMaterialPrompt)).toBeVisible()
+  })
+
+  test("each question kind renders its own control", async ({ page }) => {
+    await page.goto(`${PARTNER_UI}/inquiries/${seed.inquiryId}`)
+
+    // yes_no — a radio pair, not a free-text box.
+    await expect(page.getByLabel(/^yes$/i)).toBeVisible({ timeout: 15_000 })
+    await expect(page.getByLabel(/^no$/i)).toBeVisible()
+
+    await page.getByRole("tab", { name: /^measurements$/i }).click()
+    // number — typed, so "90" is a figure we can compare across partners
+    // rather than a sentence somebody has to read.
+    await expect(
+      page.locator('input[type="number"]').first()
+    ).toBeVisible({ timeout: 15_000 })
+
+    await page.getByRole("tab", { name: /^colours$/i }).click()
+    // colour_select — the DESIGN's own colours, not the 55-value platform
+    // palette. A partner must not be shown 55 swatches for a design that uses
+    // two.
+    await expect(page.getByText("Off White")).toBeVisible({ timeout: 15_000 })
+    await expect(page.getByText("Indigo")).toBeVisible()
+
+    await page.getByRole("tab", { name: /^show us$/i }).click()
+    await expect(page.getByText(seed.inquiryPhotoPrompt)).toBeVisible({
+      timeout: 15_000,
+    })
+  })
+
+  /**
+   * 🔴 THE ONE THAT MATTERS. A step must be written before the wizard moves on.
+   *
+   * This is answered on a phone at a loom, on a connection that drops. If
+   * "Save and continue" advances without persisting, the partner completes a
+   * wizard that kept nothing, sees no error, and we read their silence as
+   * disinterest. There is no symptom from inside the app — which is why it is
+   * asserted against the RELOAD, not against a toast.
+   */
+  test("🔴 a step is persisted before the wizard advances", async ({ page }) => {
+    await page.goto(`${PARTNER_UI}/inquiries/${seed.inquiryId}`)
+
+    await page.getByLabel(/^yes$/i).check()
+    const note = `e2e loom note ${Date.now()}`
+    await page.getByPlaceholder(/anything worth adding/i).first().fill(note)
+
+    // The request has to actually be observed. Asserting on the UI alone would
+    // pass against a client that advanced optimistically and dropped the write.
+    const saved = page.waitForResponse(
+      (r: any) =>
+        r.url().includes(`/partners/inquiries/${seed.inquiryId}/answers`) &&
+        r.request().method() === "POST" &&
+        r.status() < 400
+    )
+    await page.getByRole("button", { name: /save and continue/i }).click()
+    await saved
+
+    // And it has to come back from the SERVER, not from a cache that never
+    // round-tripped.
+    await page.reload({ waitUntil: "networkidle" })
+    await expect(page.getByLabel(/^yes$/i)).toBeChecked({ timeout: 15_000 })
+    await expect(
+      page.getByPlaceholder(/anything worth adding/i).first()
+    ).toHaveValue(note)
+  })
+
+  /**
+   * 🔴 A failed save must NOT advance the step.
+   *
+   * Advancing would render the next step as though the last had been recorded.
+   * The partner then finishes a wizard whose earlier answers were never kept —
+   * the same silent loss as above, arrived at from the other direction.
+   */
+  test("🔴 a failed save keeps the partner on the step", async ({ page }) => {
+    await page.goto(`${PARTNER_UI}/inquiries/${seed.inquiryId}`)
+
+    await page.route(`**/partners/inquiries/${seed.inquiryId}/answers`, (route: any) =>
+      route.fulfill({
+        status: 500,
+        contentType: "application/json",
+        body: JSON.stringify({ message: "boom" }),
+      })
+    )
+
+    await page.getByLabel(/^no$/i).check()
+    await page.getByRole("button", { name: /save and continue/i }).click()
+
+    // Still on Materials — the question is still the one we started on.
+    await expect(page.getByText(seed.inquiryMaterialPrompt)).toBeVisible({
+      timeout: 15_000,
+    })
+  })
+
+  /**
+   * The verdict is the whole point of the inquiry. `with_changes` in
+   * particular is the answer a yes/no would have thrown away — "not in that
+   * GSM, but I can do 90" is how a design actually develops.
+   */
+  test("a submitted verdict survives a reload", async ({ page }) => {
+    await page.goto(`${PARTNER_UI}/inquiries/${seed.inquiryId}`)
+
+    await page.getByRole("tab", { name: /your answer/i }).click()
+    await page.getByLabel(/yes, with changes/i).check()
+    await page.getByLabel(/lead time/i).fill("21")
+
+    const submitted = page.waitForResponse(
+      (r: any) =>
+        r.url().includes(`/partners/inquiries/${seed.inquiryId}/submit`) &&
+        r.request().method() === "POST" &&
+        r.status() < 400
+    )
+    await page
+      .getByRole("button", { name: /send my answer|update my answer/i })
+      .click()
+    await submitted
+
+    await page.reload({ waitUntil: "networkidle" })
+    await page.getByRole("tab", { name: /your answer/i }).click()
+    await expect(page.getByLabel(/yes, with changes/i)).toBeChecked({
+      timeout: 15_000,
+    })
+    await expect(page.getByLabel(/lead time/i)).toHaveValue("21")
+  })
+
+  /**
+   * 🔴 An uninvited partner must not learn the inquiry EXISTS.
+   *
+   * The server answers 404 rather than 403 precisely because the existence of
+   * an inquiry names a design being sourced, and that is itself the
+   * confidential part (#1496). This asserts the UI does not leak it back — a
+   * page that renders the title above an error message would undo the whole
+   * point of the status code.
+   */
+  test("🔴 an inquiry this partner was not invited to reveals nothing", async ({
+    page,
+  }) => {
+    await page.goto(`${PARTNER_UI}/inquiries/dinq_not_mine_at_all`)
+
+    await expect(page.getByText(seed.inquiryDesignName)).toHaveCount(0)
+    await expect(
+      page.getByRole("button", { name: /save and continue/i })
+    ).toHaveCount(0)
+  })
+})


### PR DESCRIPTION
Part of #1531. Addresses the gap in #1482.

`apps/partner-ui` has **no CI at all**. Slice 2 shipped to production proven only by `tsc --noEmit` and `vite build` — which establish that the code compiles and say nothing about whether a partner can answer a question.

Every partner-facing failure this repo has had was of that second kind: the quote list shipped **twice** with nothing in the nav pointing at it, and nothing failed either time.

## What it asserts

Eight tests, against the **contract** rather than the implementation:

| test | why |
|---|---|
| reachable from the **sidebar**, not only by URL | `main-layout.tsx` has three persona branches; the quote-list entry was once added to two, missing the **default** one — the sidebar most partners actually get |
| the **persisted** questions, in persisted order | a spec moves while sourcing runs; a wizard that silently rewords itself makes "yes we can do that" unreadable — it stops saying which *that* |
| each kind renders its own control | including the design's **own** colours, not the 55-value platform palette |
| 🔴 **a step is persisted before the wizard advances** | asserted against the POST *and* a reload — never a toast |
| 🔴 **a failed save keeps the partner on the step** | advancing would render the next step as though the last had been recorded |
| a submitted verdict survives a reload | |
| an uninvited partner learns nothing | the server answers **404, not 403**, because the existence of an inquiry names a design being sourced (#1496); a page rendering the title above an error would undo the status code |

The two marked 🔴 are why the file exists. **Autosave-then-advance is where a wizard loses work with no symptom from inside the app**: the partner finishes, sees no error, nothing was kept — and then we read their silence as disinterest.

## The fixture

`seedDesignInquiry` adds an invited-but-**silent** partner with one question of each kind.

- Deliberately un-answered: the contract is the path from "invited, silent" to "answered", and a fixture starting mid-way cannot exercise the step that breaks.
- The questions are written **by hand rather than generated**. This fixture *is* the contract the UI renders against — if generation changes shape, someone should have to look, which a generated fixture would hide by changing in lockstep.
- A `beforeAll` fails loudly on a seed predating the fixture, rather than asserting `toContain(undefined)` and passing vacuously (#1495).

## ⚠️ Not yet run

These need the partner-ui dev server and a seeded DB. `--list` parses all eight; **none has been executed**. Tagged `@partnerui` so CI keeps skipping them, like every other partner-UI spec — this does not make CI green, it makes the wizard checkable.

Also carried forward from the existing partner specs: **check which checkout is serving :5173** before trusting a run. It has previously been served by vite from a different clone of this repo, so specs quietly asserted against another working tree.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_0158wJMZ1DmjNxXf5uGuBrQD