### PR TITLE
feat(production-runs): an admin surface for goods movement, and a way to re-book a cancelled hop

### DIFF
--- a/apps/backend/src/admin/components/production-runs/goods-transfer-section.tsx
+++ b/apps/backend/src/admin/components/production-runs/goods-transfer-section.tsx
@@ -1,0 +1,451 @@
+import {
+  Badge,
+  Button,
+  Drawer,
+  Heading,
+  Input,
+  Label,
+  Prompt,
+  Select,
+  Text,
+  Textarea,
+  toast,
+} from "@medusajs/ui"
+import { useState } from "react"
+
+import {
+  useCancelGoodsTransfer,
+  useCreateGoodsTransfer,
+  useDeleteGoodsTransfer,
+  useGoodsTransfers,
+  type AdminGoodsTransfer,
+} from "../../hooks/api/goods-transfers"
+import { useStockLocations } from "../../hooks/api/stock_location"
+import { SHIPMENT_CARRIERS } from "../../lib/shipment-carriers"
+
+/**
+ * Goods movement on a production run, for the ADMIN (#891 follow-up).
+ *
+ * The routes have existed since #891 S1 and only partner-ui ever grew a
+ * surface, so every admin transfer so far — including the live
+ * Shramdaan → Dharamshala hop — was booked by hand against the API. That is
+ * tolerable for a verification run and useless in an incident: when the carrier
+ * cancelled that waybill, the row went on saying `in_transit` and there was no
+ * screen on which anyone could say otherwise.
+ *
+ * What this adds beyond the partner section it mirrors:
+ *
+ * · **Record a carrier cancellation.** A booked hop can be marked cancelled
+ *   when the carrier has already voided the AWB. It does NOT call the carrier —
+ *   the copy says so, because an operator who believed it did would stop
+ *   chasing them.
+ * · **Re-book, keeping the history.** A cancelled hop can be re-created as a
+ *   NEW transfer that points back at it. Nothing is edited and nothing is
+ *   deleted: the first attempt really happened, and this list is the only
+ *   record of what physically moved.
+ */
+
+const REASONS = [
+  { value: "finishing", label: "Finishing / embroidery" },
+  { value: "qc", label: "Quality check" },
+  { value: "packaging", label: "Packaging" },
+  { value: "stock", label: "Into stock" },
+  { value: "customer", label: "On to the customer" },
+  { value: "other", label: "Other" },
+] as const
+
+/**
+ * "No carrier" is a real choice, not an empty state: a van run between two of
+ * our own locations is a movement worth recording.
+ *
+ * ⚠️ The sentinel exists because Radix reserves the empty string for "cleared"
+ * and THROWS on `<Select.Item value="">` — which took the whole partner drawer
+ * down with a render error the moment it opened. It never leaves this component.
+ */
+const NO_CARRIER = "none"
+
+const CARRIERS = [
+  { value: NO_CARRIER, label: "No carrier (self-driven)" },
+  ...SHIPMENT_CARRIERS.map((c) => ({ value: c.value, label: c.label })),
+]
+
+const carrierValue = (v: string): string | undefined =>
+  !v || v === NO_CARRIER ? undefined : v
+
+const STATUS_COLOR: Record<
+  AdminGoodsTransfer["status"],
+  "grey" | "blue" | "green" | "red"
+> = {
+  draft: "grey",
+  in_transit: "blue",
+  delivered: "green",
+  cancelled: "red",
+}
+
+/** Empty → undefined, else a positive number (a blank must not become 0). */
+const positive = (v: string): number | undefined => {
+  if (!v.trim()) return undefined
+  const n = Number(v)
+  return Number.isFinite(n) && n > 0 ? n : undefined
+}
+
+const errorMessage = (e: any): string =>
+  e?.message || e?.response?.data?.message || "Something went wrong"
+
+type Props = {
+  runId: string
+}
+
+export const GoodsTransferSection = ({ runId }: Props) => {
+  const [open, setOpen] = useState(false)
+  const [toLocationId, setToLocationId] = useState("")
+  const [reason, setReason] = useState<AdminGoodsTransfer["reason"]>("stock")
+  const [carrier, setCarrier] = useState<string>(NO_CARRIER)
+  const [quantity, setQuantity] = useState("")
+  const [weight, setWeight] = useState("")
+  const [notes, setNotes] = useState("")
+  /** Set when the drawer was opened via "Re-book" on a cancelled hop. */
+  const [replacing, setReplacing] = useState<AdminGoodsTransfer | null>(null)
+
+  const [cancelling, setCancelling] = useState<AdminGoodsTransfer | null>(null)
+  const [cancelReason, setCancelReason] = useState("")
+
+  const { goods_transfers: transfers = [], isLoading } = useGoodsTransfers(runId)
+  const { stock_locations: locations = [] } = useStockLocations(undefined, {
+    enabled: open,
+  } as any)
+
+  const { mutateAsync: createTransfer, isPending: isCreating } =
+    useCreateGoodsTransfer(runId)
+  const { mutateAsync: cancelTransfer, isPending: isCancelling } =
+    useCancelGoodsTransfer(runId)
+  const { mutateAsync: deleteDraft, isPending: isDeleting } =
+    useDeleteGoodsTransfer(runId)
+
+  const locationName = (id?: string | null) =>
+    locations.find((l: any) => l.id === id)?.name || id || "—"
+
+  const resetForm = () => {
+    setToLocationId("")
+    setReason("stock")
+    setCarrier(NO_CARRIER)
+    setQuantity("")
+    setWeight("")
+    setNotes("")
+    setReplacing(null)
+  }
+
+  /**
+   * Prefill from the hop being replaced. The destination, reason and quantity
+   * are what the operator already decided once; making them retype it is how a
+   * re-booking quietly becomes a DIFFERENT movement.
+   *
+   * The carrier is deliberately NOT prefilled. The last booking is the one that
+   * just failed, and a carrier chosen by default is a carrier nobody chose.
+   */
+  const openReplacement = (t: AdminGoodsTransfer) => {
+    setToLocationId(t.to_location_id ?? "")
+    setReason(t.reason)
+    setQuantity(t.quantity ? String(t.quantity) : "")
+    setWeight("")
+    setNotes(t.notes ?? "")
+    setCarrier(NO_CARRIER)
+    setReplacing(t)
+    setOpen(true)
+  }
+
+  const handleSubmit = async () => {
+    if (!toLocationId) return
+    try {
+      const res = await createTransfer({
+        to_location_id: toLocationId,
+        reason,
+        carrier: carrierValue(carrier),
+        quantity: positive(quantity),
+        weight_grams: positive(weight),
+        notes: notes.trim() || undefined,
+        replaces_transfer_id: replacing?.id,
+      })
+      const t = (res as any).goods_transfer
+      toast.success(
+        t?.awb
+          ? `Transfer booked — AWB ${t.awb}`
+          : "Transfer recorded (no carrier booked)"
+      )
+      setOpen(false)
+      resetForm()
+    } catch (e) {
+      toast.error(errorMessage(e))
+    }
+  }
+
+  const handleCancel = async () => {
+    if (!cancelling) return
+    const isBooked = cancelling.status !== "draft"
+    try {
+      if (isBooked) {
+        await cancelTransfer({
+          transferId: cancelling.id,
+          carrier_cancelled: true,
+          reason: cancelReason.trim() || undefined,
+        })
+      } else {
+        await deleteDraft(cancelling.id)
+      }
+      toast.success(
+        isBooked ? "Recorded as cancelled by the carrier" : "Draft cancelled"
+      )
+      setCancelling(null)
+      setCancelReason("")
+    } catch (e) {
+      toast.error(errorMessage(e))
+    }
+  }
+
+  return (
+    <div className="flex flex-col gap-y-3 border-t px-6 py-4">
+      <div className="flex items-center justify-between">
+        <div className="flex items-center gap-x-2">
+          <Heading level="h3">Goods movement</Heading>
+          {transfers.length > 0 && <Badge size="2xsmall">{transfers.length}</Badge>}
+        </div>
+        <Button
+          size="small"
+          variant="secondary"
+          onClick={() => {
+            resetForm()
+            setOpen(true)
+          }}
+        >
+          Move to next location
+        </Button>
+      </div>
+
+      {isLoading ? null : transfers.length === 0 ? (
+        <Text size="small" className="text-ui-fg-subtle">
+          This run's output hasn't moved. Record where it goes next — a
+          finishing or QC partner, a packaging warehouse, or into stock — so the
+          customer leg ships from where the goods actually are.
+        </Text>
+      ) : (
+        <div className="flex flex-col gap-y-2">
+          {transfers.map((t) => {
+            const replacedBy = t.metadata?.replaced_by_transfer_id
+            const replaces = t.metadata?.replaces_transfer_id
+            return (
+              <div key={t.id} className="flex flex-col gap-y-1">
+                <div className="flex items-center justify-between gap-x-3">
+                  <Text size="small">
+                    {t.quantity} × {locationName(t.from_location_id)} →{" "}
+                    {locationName(t.to_location_id)}
+                    <span className="text-ui-fg-subtle"> · {t.reason}</span>
+                  </Text>
+                  <div className="flex items-center gap-x-2">
+                    <Badge size="2xsmall" color={STATUS_COLOR[t.status]}>
+                      {t.status.replace("_", " ")}
+                    </Badge>
+                    {t.status === "cancelled" && !replacedBy && (
+                      <Button
+                        size="small"
+                        variant="transparent"
+                        onClick={() => openReplacement(t)}
+                      >
+                        Re-book
+                      </Button>
+                    )}
+                    {(t.status === "draft" || t.status === "in_transit") && (
+                      <Button
+                        size="small"
+                        variant="transparent"
+                        onClick={() => {
+                          setCancelling(t)
+                          setCancelReason("")
+                        }}
+                      >
+                        Cancel
+                      </Button>
+                    )}
+                  </div>
+                </div>
+                {/* The history the re-booking preserves, said out loud. */}
+                {(replaces || replacedBy || t.notes) && (
+                  <Text size="xsmall" className="text-ui-fg-subtle">
+                    {replaces && `Re-booking of ${replaces}. `}
+                    {replacedBy && `Replaced by ${replacedBy}. `}
+                    {t.notes}
+                  </Text>
+                )}
+              </div>
+            )
+          })}
+        </div>
+      )}
+
+      <Drawer
+        open={open}
+        onOpenChange={(v) => {
+          setOpen(v)
+          if (!v) resetForm()
+        }}
+      >
+        <Drawer.Content>
+          <Drawer.Header>
+            <Drawer.Title>
+              {replacing ? "Re-book this movement" : "Move goods to the next location"}
+            </Drawer.Title>
+          </Drawer.Header>
+          {/* ⚠️ overflow-y-auto: a modal body without it does not scroll, and the
+              footer buttons become unreachable on a short viewport. */}
+          <Drawer.Body className="flex flex-col gap-y-4 overflow-y-auto">
+            {replacing && (
+              <Text size="small" className="text-ui-fg-subtle">
+                Replaces <strong>{replacing.id}</strong>, which stays on the run
+                as the record that the first attempt happened. The two will link
+                to each other.
+              </Text>
+            )}
+
+            <div className="flex flex-col gap-y-1">
+              <Label size="small">Destination</Label>
+              <Select value={toLocationId} onValueChange={setToLocationId}>
+                <Select.Trigger>
+                  <Select.Value placeholder="Select a location" />
+                </Select.Trigger>
+                <Select.Content>
+                  {locations.map((l: any) => (
+                    <Select.Item key={l.id} value={l.id}>
+                      {l.name}
+                    </Select.Item>
+                  ))}
+                </Select.Content>
+              </Select>
+            </div>
+
+            <div className="flex flex-col gap-y-1">
+              <Label size="small">Reason</Label>
+              <Select
+                value={reason}
+                onValueChange={(v) => setReason(v as AdminGoodsTransfer["reason"])}
+              >
+                <Select.Trigger>
+                  <Select.Value />
+                </Select.Trigger>
+                <Select.Content>
+                  {REASONS.map((r) => (
+                    <Select.Item key={r.value} value={r.value}>
+                      {r.label}
+                    </Select.Item>
+                  ))}
+                </Select.Content>
+              </Select>
+            </div>
+
+            <div className="flex flex-col gap-y-1">
+              <Label size="small">Carrier</Label>
+              <Select value={carrier} onValueChange={setCarrier}>
+                <Select.Trigger>
+                  <Select.Value />
+                </Select.Trigger>
+                <Select.Content>
+                  {CARRIERS.map((c) => (
+                    <Select.Item key={c.value} value={c.value}>
+                      {c.label}
+                    </Select.Item>
+                  ))}
+                </Select.Content>
+              </Select>
+              <Text size="xsmall" className="text-ui-fg-subtle">
+                Booking a carrier generates a REAL, billable waybill from the
+                source location's registered pickup. Leave it on "no carrier"
+                for a self-driven hop or a dry run.
+              </Text>
+            </div>
+
+            <div className="grid grid-cols-2 gap-3">
+              <div className="flex flex-col gap-y-1">
+                <Label size="small">Units</Label>
+                <Input
+                  type="number"
+                  min={1}
+                  placeholder="All produced"
+                  value={quantity}
+                  onChange={(e) => setQuantity(e.target.value)}
+                />
+              </div>
+              <div className="flex flex-col gap-y-1">
+                <Label size="small">Weight (g)</Label>
+                <Input
+                  type="number"
+                  min={1}
+                  placeholder="500"
+                  value={weight}
+                  onChange={(e) => setWeight(e.target.value)}
+                />
+              </div>
+            </div>
+
+            <div className="flex flex-col gap-y-1">
+              <Label size="small">Notes</Label>
+              <Input
+                placeholder="Optional"
+                value={notes}
+                onChange={(e) => setNotes(e.target.value)}
+              />
+            </div>
+          </Drawer.Body>
+          <Drawer.Footer>
+            <Button variant="secondary" size="small" onClick={() => setOpen(false)}>
+              Close
+            </Button>
+            <Button
+              size="small"
+              isLoading={isCreating}
+              disabled={!toLocationId}
+              onClick={handleSubmit}
+            >
+              {carrierValue(carrier) ? "Book & move" : "Record movement"}
+            </Button>
+          </Drawer.Footer>
+        </Drawer.Content>
+      </Drawer>
+
+      <Prompt open={!!cancelling} onOpenChange={(v) => !v && setCancelling(null)}>
+        <Prompt.Content>
+          <Prompt.Header>
+            <Prompt.Title>
+              {cancelling?.status === "draft"
+                ? "Cancel this planned hop?"
+                : "Record this as cancelled?"}
+            </Prompt.Title>
+            <Prompt.Description>
+              {cancelling?.status === "draft"
+                ? "Nothing was booked, so nothing is being undone. The row stays as the record that a hop was planned and abandoned."
+                : "This marks the row cancelled. It does NOT cancel the waybill with the carrier — do that in their dashboard first, or the shipment keeps travelling while this says it stopped."}
+            </Prompt.Description>
+          </Prompt.Header>
+          {cancelling?.status !== "draft" && (
+            <div className="flex flex-col gap-y-1 px-6 pb-4">
+              <Label size="small">Why (kept on the record)</Label>
+              <Textarea
+                placeholder="e.g. Delhivery cancelled the waybill at their end"
+                value={cancelReason}
+                onChange={(e) => setCancelReason(e.target.value)}
+              />
+            </div>
+          )}
+          <Prompt.Footer>
+            <Prompt.Cancel>Keep it</Prompt.Cancel>
+            <Prompt.Action
+              onClick={handleCancel}
+              disabled={isCancelling || isDeleting}
+            >
+              Cancel the transfer
+            </Prompt.Action>
+          </Prompt.Footer>
+        </Prompt.Content>
+      </Prompt>
+    </div>
+  )
+}
+
+export default GoodsTransferSection

--- a/apps/backend/src/admin/hooks/api/goods-transfers.ts
+++ b/apps/backend/src/admin/hooks/api/goods-transfers.ts
@@ -1,0 +1,199 @@
+import { FetchError } from "@medusajs/js-sdk"
+import {
+  QueryKey,
+  UseMutationOptions,
+  UseQueryOptions,
+  useMutation,
+  useQuery,
+  useQueryClient,
+} from "@tanstack/react-query"
+
+import { sdk } from "../../lib/config"
+import { queryKeysFactory } from "../../lib/query-key-factory"
+import { productionRunQueryKeys } from "./production-runs"
+
+/**
+ * Goods transfers on a production run (#891), for the ADMIN dashboard.
+ *
+ * The routes have existed since #891 S1; only partner-ui ever grew a surface
+ * for them, so every admin transfer to date — including the live
+ * Shramdaan → Dharamshala hop — was booked by hand against the API. That is
+ * fine for a verification run and no way to operate: a hop the carrier
+ * cancelled cannot be corrected by someone who cannot see it.
+ */
+
+const GOODS_TRANSFERS_QUERY_KEY = "goods-transfers" as const
+export const goodsTransferQueryKeys = queryKeysFactory(GOODS_TRANSFERS_QUERY_KEY)
+
+export type GoodsTransferStatus = "draft" | "in_transit" | "delivered" | "cancelled"
+
+export type AdminGoodsTransfer = {
+  id: string
+  production_run_id: string
+  design_id: string | null
+  quantity: number
+  from_location_id: string
+  to_location_id: string | null
+  reason: "finishing" | "qc" | "packaging" | "stock" | "customer" | "other"
+  status: GoodsTransferStatus
+  shipment_id: string | null
+  shipped_at: string | null
+  received_at: string | null
+  received_quantity: number | null
+  notes: string | null
+  /** Carries `replaces_transfer_id` / `replaced_by_transfer_id` and the cancellation record. */
+  metadata: Record<string, any> | null
+  created_at: string
+  updated_at: string
+}
+
+export type AdminGoodsTransfersResponse = {
+  goods_transfers: AdminGoodsTransfer[]
+}
+
+export type AdminCreateGoodsTransferPayload = {
+  to_location_id: string
+  from_location_id?: string
+  reason?: AdminGoodsTransfer["reason"]
+  quantity?: number
+  /** Omit for a self-driven hop — a real movement with no AWB. */
+  carrier?: string
+  weight_grams?: number
+  dimensions_cm?: {
+    length?: number
+    width?: number
+    breadth?: number
+    height?: number
+  }
+  preferred_courier_id?: string | number
+  notes?: string
+  /** The cancelled hop this one re-books. Must be cancelled, and on this run. */
+  replaces_transfer_id?: string
+}
+
+export type AdminCancelGoodsTransferPayload = {
+  /**
+   * "The carrier has already cancelled this waybill." Required for a booked
+   * transfer — the route does not call the carrier, it records that someone
+   * did.
+   */
+  carrier_cancelled?: boolean
+  reason?: string
+}
+
+export const useGoodsTransfers = (
+  productionRunId: string,
+  options?: Omit<
+    UseQueryOptions<
+      AdminGoodsTransfersResponse,
+      FetchError,
+      AdminGoodsTransfersResponse,
+      QueryKey
+    >,
+    "queryFn" | "queryKey"
+  >
+) => {
+  const { data, ...rest } = useQuery({
+    queryKey: goodsTransferQueryKeys.list(productionRunId),
+    queryFn: async () =>
+      sdk.client.fetch<AdminGoodsTransfersResponse>(
+        `/admin/production-runs/${productionRunId}/transfers`,
+        { method: "GET" }
+      ),
+    ...options,
+  })
+
+  return { ...data, ...rest }
+}
+
+/**
+ * Everything that changes a transfer invalidates the run's DETAIL too, not just
+ * the transfer list: the run page reads its goods location from a delivered
+ * transfer, and the activity timeline gains a row on every one of these calls.
+ */
+const invalidate = (queryClient: any, productionRunId: string) => {
+  queryClient.invalidateQueries({
+    queryKey: goodsTransferQueryKeys.list(productionRunId),
+  })
+  queryClient.invalidateQueries({
+    queryKey: productionRunQueryKeys.detail(productionRunId),
+  })
+}
+
+export const useCreateGoodsTransfer = (
+  productionRunId: string,
+  options?: UseMutationOptions<
+    { goods_transfer: any },
+    FetchError,
+    AdminCreateGoodsTransferPayload
+  >
+) => {
+  const queryClient = useQueryClient()
+
+  return useMutation({
+    mutationFn: async (payload: AdminCreateGoodsTransferPayload) =>
+      sdk.client.fetch<{ goods_transfer: any }>(
+        `/admin/production-runs/${productionRunId}/transfers`,
+        { method: "POST", body: payload }
+      ),
+    onSuccess: (data, variables, _mutateResult, context) => {
+      invalidate(queryClient, productionRunId)
+      options?.onSuccess?.(data, variables, _mutateResult, context)
+    },
+    ...options,
+  })
+}
+
+/**
+ * Cancel a BOOKED hop, recording that the carrier already cancelled it.
+ * A draft is cancelled by `useDeleteGoodsTransfer` below — same outcome, but
+ * the two are separate calls because only one of them is an assertion about
+ * something that happened outside this system.
+ */
+export const useCancelGoodsTransfer = (
+  productionRunId: string,
+  options?: UseMutationOptions<
+    { goods_transfer: AdminGoodsTransfer },
+    FetchError,
+    { transferId: string } & AdminCancelGoodsTransferPayload
+  >
+) => {
+  const queryClient = useQueryClient()
+
+  return useMutation({
+    mutationFn: async ({ transferId, ...body }) =>
+      sdk.client.fetch<{ goods_transfer: AdminGoodsTransfer }>(
+        `/admin/production-runs/${productionRunId}/transfers/${transferId}/cancel`,
+        { method: "POST", body }
+      ),
+    onSuccess: (data, variables, _mutateResult, context) => {
+      invalidate(queryClient, productionRunId)
+      options?.onSuccess?.(data, variables, _mutateResult, context)
+    },
+    ...options,
+  })
+}
+
+export const useDeleteGoodsTransfer = (
+  productionRunId: string,
+  options?: UseMutationOptions<
+    { goods_transfer: AdminGoodsTransfer },
+    FetchError,
+    string
+  >
+) => {
+  const queryClient = useQueryClient()
+
+  return useMutation({
+    mutationFn: async (transferId: string) =>
+      sdk.client.fetch<{ goods_transfer: AdminGoodsTransfer }>(
+        `/admin/production-runs/${productionRunId}/transfers/${transferId}`,
+        { method: "DELETE" }
+      ),
+    onSuccess: (data, variables, _mutateResult, context) => {
+      invalidate(queryClient, productionRunId)
+      options?.onSuccess?.(data, variables, _mutateResult, context)
+    },
+    ...options,
+  })
+}

--- a/apps/backend/src/admin/routes/production-runs/[id]/page.tsx
+++ b/apps/backend/src/admin/routes/production-runs/[id]/page.tsx
@@ -33,6 +33,7 @@ import { TwoColumnPage } from "../../../components/pages/two-column-pages"
 import { TwoColumnPageSkeleton } from "../../../components/table/skeleton"
 import { ProductionRunChildrenSection } from "../../../components/production-runs/production-run-children-section"
 import { ProductionRunActivityTimeline } from "../../../components/production-runs/production-run-activity-timeline"
+import { GoodsTransferSection } from "../../../components/production-runs/goods-transfer-section"
 import { productionRunLoader } from "./loader"
 import {
   useAdminAcceptRun,
@@ -500,6 +501,19 @@ const ProductionRunDetailPage = () => {
 
         {/* Children / Sub-runs */}
         {isParent && <ProductionRunChildrenSection parentId={id} />}
+
+        {/*
+          Goods movement (#891). Shown on every run, not only completed ones as
+          the partner surface does: an admin is frequently the person recording
+          a hop after the fact, or correcting one the carrier cancelled, and
+          hiding the list until a status changes would hide exactly the row that
+          needs fixing.
+        */}
+        {!isParent && (
+          <Container className="divide-y p-0">
+            <GoodsTransferSection runId={id} />
+          </Container>
+        )}
 
         {/* Tasks */}
         {!isParent && (

--- a/apps/backend/src/api/admin/production-runs/[id]/transfers/[transferId]/cancel/route.ts
+++ b/apps/backend/src/api/admin/production-runs/[id]/transfers/[transferId]/cancel/route.ts
@@ -1,0 +1,157 @@
+import { MedusaRequest, MedusaResponse } from "@medusajs/framework/http"
+import { ContainerRegistrationKeys, MedusaError } from "@medusajs/framework/utils"
+import { z } from "@medusajs/framework/zod"
+
+import { FULLFILLED_ORDERS_MODULE } from "../../../../../../../modules/fullfilled_orders"
+import { PRODUCTION_RUNS_MODULE } from "../../../../../../../modules/production_runs"
+
+/**
+ * POST /admin/production-runs/:id/transfers/:transferId/cancel
+ *
+ * Record that a BOOKED hop is not happening (#891 follow-up).
+ *
+ * ## Why the DELETE beside this is not enough
+ *
+ * `DELETE .../transfers/:transferId` cancels a `draft` only, and refuses
+ * anything booked on the reasoning that cancelling an AWB is a carrier
+ * operation rather than a row edit. That reasoning is right and this does not
+ * weaken it — but it left no way to record the case that actually happens: the
+ * CARRIER cancelled the waybill at their end, and the row went on claiming
+ * `in_transit` for a consignment nobody is carrying. A transfer list that says
+ * "in transit" about a dead shipment is worse than one that says nothing.
+ *
+ * So this cancels a booked transfer only when the caller states plainly that
+ * the carrier has already cancelled it, and records WHO said so and WHEN.
+ * Without `carrier_cancelled: true`, a booked transfer is refused exactly as
+ * before.
+ *
+ * 🔴 It does NOT call the carrier. Nothing here voids a live waybill, and
+ * pretending otherwise is the failure mode worth avoiding: an operator who
+ * believed this call cancelled the AWB would stop chasing the carrier. This
+ * route is about the row.
+ *
+ * 🔴 A `delivered` transfer can never be cancelled. The goods arrived, so a
+ * cancellation would be a false statement about the physical world — and
+ * `resolveRunGoodsLocation` trusts a delivered transfer to say where stock is.
+ *
+ * Nothing is deleted. The cancelled row stays as the record that the hop was
+ * attempted, and a replacement created with `replaces_transfer_id` links to it
+ * in both directions.
+ */
+
+const CancelSchema = z.object({
+  /**
+   * "The carrier has already cancelled this waybill." Required to cancel a
+   * booked hop — an assertion the caller makes, recorded against them.
+   */
+  carrier_cancelled: z.boolean().optional().default(false),
+  /** Why. Kept on the row: a cancellation with no reason is a puzzle later. */
+  reason: z.string().trim().max(500).optional(),
+})
+
+export const POST = async (
+  req: MedusaRequest & { params: { id: string; transferId: string } },
+  res: MedusaResponse
+) => {
+  const { id: runId, transferId } = req.params
+  const parsed = CancelSchema.safeParse(req.body ?? {})
+  if (!parsed.success) {
+    throw new MedusaError(
+      MedusaError.Types.INVALID_DATA,
+      parsed.error.issues.map((i) => `${i.path.join(".")}: ${i.message}`).join("; ")
+    )
+  }
+  const { carrier_cancelled, reason } = parsed.data
+
+  const service: any = req.scope.resolve(FULLFILLED_ORDERS_MODULE)
+
+  const transfer = await service.retrieveGoodsTransfer(transferId).catch(() => null)
+  if (!transfer || transfer.production_run_id !== runId) {
+    throw new MedusaError(
+      MedusaError.Types.NOT_FOUND,
+      `Goods transfer ${transferId} not found on production run ${runId}`
+    )
+  }
+
+  if (transfer.status === "cancelled") {
+    return res
+      .status(200)
+      .json({ goods_transfer: transfer, message: "Already cancelled" })
+  }
+
+  if (transfer.status === "delivered") {
+    throw new MedusaError(
+      MedusaError.Types.NOT_ALLOWED,
+      "This transfer is delivered — the goods arrived, so it cannot be cancelled. Record a new transfer if they moved again."
+    )
+  }
+
+  if (transfer.status !== "draft" && !carrier_cancelled) {
+    throw new MedusaError(
+      MedusaError.Types.NOT_ALLOWED,
+      `This transfer is "${transfer.status}" and carries a carrier booking. Cancel the waybill with the carrier first, then repeat this call with carrier_cancelled: true to record it here — this route does not call the carrier.`
+    )
+  }
+
+  const actorId = (req as any).auth_context?.actor_id ?? null
+  const cancelledAt = new Date()
+
+  // Merged, never assigned — `metadata` is a shared blob, and an overwrite here
+  // would take a replacement back-link with it.
+  await service.updateGoodsTransfers({
+    id: transferId,
+    status: "cancelled",
+    metadata: {
+      ...((transfer.metadata ?? {}) as Record<string, unknown>),
+      cancelled_at: cancelledAt.toISOString(),
+      cancelled_by: actorId,
+      cancellation_reason: reason ?? null,
+      // Recorded as an ASSERTION, not as a carrier fact anything verified.
+      carrier_cancellation_asserted: carrier_cancelled,
+    },
+  })
+  const updated = await service.retrieveGoodsTransfer(transferId)
+
+  // Timeline row, best-effort — the cancellation is already persisted.
+  try {
+    const runService: any = req.scope.resolve(PRODUCTION_RUNS_MODULE)
+    const units = `${transfer.quantity} unit${
+      Number(transfer.quantity) === 1 ? "" : "s"
+    }`
+    await runService.createProductionRunActivities({
+      production_run_id: runId,
+      activity_type: "lifecycle_event",
+      kind: "goods_transfer_cancelled",
+      actor_type: "admin",
+      actor_id: actorId,
+      partner_id: null,
+      channel: null,
+      message_id: null,
+      template_name: null,
+      recipient: null,
+      summary: carrier_cancelled
+        ? `Carrier cancelled the shipment for ${units}${reason ? ` — ${reason}` : ""}`
+        : `Planned transfer of ${units} cancelled before booking`,
+      payload: {
+        goods_transfer_id: transferId,
+        from_location_id: transfer.from_location_id,
+        to_location_id: transfer.to_location_id,
+        quantity: transfer.quantity,
+        reason: transfer.reason ?? null,
+        previous_status: transfer.status,
+        shipment_id: transfer.shipment_id ?? null,
+        carrier_cancellation_asserted: carrier_cancelled,
+        cancellation_reason: reason ?? null,
+      },
+      occurred_at: cancelledAt,
+    })
+  } catch (e: any) {
+    req.scope
+      .resolve(ContainerRegistrationKeys.LOGGER)
+      .error(
+        `[admin.production-runs] transfer ${transferId} cancelled but timeline write failed: ${e?.message}`
+      )
+  }
+
+  res.status(200).json({ goods_transfer: updated })
+}

--- a/apps/backend/src/api/admin/production-runs/[id]/transfers/route.ts
+++ b/apps/backend/src/api/admin/production-runs/[id]/transfers/route.ts
@@ -36,6 +36,12 @@ const CreateTransferSchema = z.object({
     .optional(),
   preferred_courier_id: z.union([z.string(), z.number()]).optional(),
   notes: z.string().optional(),
+  /**
+   * Re-book a hop the carrier cancelled, keeping the original row (#891
+   * follow-up). Both transfers survive and link to each other; the named one
+   * must be `cancelled`, on this run, or the create is refused.
+   */
+  replaces_transfer_id: z.string().min(1).optional(),
 })
 
 export const POST = async (
@@ -64,6 +70,7 @@ export const POST = async (
     dimensionsCm: body.dimensions_cm as any,
     preferredCourierId: body.preferred_courier_id,
     notes: body.notes,
+    replacesTransferId: body.replaces_transfer_id,
     actingEmail: (req as any).auth_context?.app_metadata?.user_email,
   })
 

--- a/apps/backend/src/api/admin/quotes/route.ts
+++ b/apps/backend/src/api/admin/quotes/route.ts
@@ -4,6 +4,7 @@ import { ContainerRegistrationKeys, MedusaError } from "@medusajs/framework/util
 import { PARTNER_QUOTE_MODULE } from "../../../modules/partner-quote"
 import { buildQuoteListQuery } from "../../../modules/partner-quote/lib/list-query"
 import { withEffectiveStatus } from "../../../modules/partner-quote/lib/token"
+import { totalQuotedQuantity } from "../../../modules/partner-quote/lib/quote-email"
 import { resolveQuoteDesignLines } from "../../../modules/partner-quote/lib/design-lines"
 import { deliverQuoteEmail } from "../../../workflows/partner-quote/deliver-quote-email"
 import { mintQuoteWorkflow } from "../../../workflows/partner-quote/mint-quote"
@@ -198,6 +199,7 @@ export const POST = async (req: MedusaRequest, res: MedusaResponse) => {
     token: (result as any)?.token,
     partnerName: partner?.name ?? null,
     lineCount: body.lines.length,
+    totalQuantity: totalQuotedQuantity(body.lines),
     actorType: "admin",
     actorId: (req as any).auth_context?.actor_id ?? null,
   })

--- a/apps/backend/src/api/partners/quotes/route.ts
+++ b/apps/backend/src/api/partners/quotes/route.ts
@@ -5,6 +5,7 @@ import { PARTNER_QUOTE_MODULE } from "../../../modules/partner-quote"
 import { resolveQuoteDesignLines } from "../../../modules/partner-quote/lib/design-lines"
 import { buildQuoteListQuery } from "../../../modules/partner-quote/lib/list-query"
 import { withEffectiveStatus } from "../../../modules/partner-quote/lib/token"
+import { totalQuotedQuantity } from "../../../modules/partner-quote/lib/quote-email"
 import { deliverQuoteEmail } from "../../../workflows/partner-quote/deliver-quote-email"
 import { mintQuoteWorkflow } from "../../../workflows/partner-quote/mint-quote"
 import { getPartnerStore, tryGetPartnerStore } from "../helpers"
@@ -151,6 +152,7 @@ export const POST = async (
     token: (result as any)?.token,
     partnerName: partner?.name ?? null,
     lineCount: body.lines.length,
+    totalQuantity: totalQuotedQuantity(body.lines),
     actorType: "partner",
     actorId: partner.id,
   })

--- a/apps/backend/src/modules/partner-quote/__tests__/quote-email.unit.spec.ts
+++ b/apps/backend/src/modules/partner-quote/__tests__/quote-email.unit.spec.ts
@@ -1,5 +1,6 @@
 import {
   buildQuoteEmailData,
+  totalQuotedQuantity,
   formatQuoteDestination,
   formatQuoteExpiry,
   formatQuoteMoney,
@@ -78,6 +79,30 @@ describe("formatQuoteExpiry", () => {
   })
 })
 
+describe("totalQuotedQuantity", () => {
+  it("counts PIECES, not lines — the whole point", () => {
+    // The defect this replaces: one line of 29 scarves announced itself to the
+    // buyer as "1 item(s)", because `line_count` was rendered as a quantity.
+    expect(totalQuotedQuantity([{ quantity: 29 }])).toBe(29)
+    expect(
+      totalQuotedQuantity([{ quantity: 2 }, { quantity: 2 }, { quantity: 6 }])
+    ).toBe(10)
+  })
+
+  it("skips a line it cannot read rather than poisoning the whole count", () => {
+    // `Number(undefined)` is NaN, and one bad line would otherwise put
+    // "NaN piece(s)" in a buyer's inbox.
+    expect(totalQuotedQuantity([{ quantity: 5 }, {}, { quantity: "x" }])).toBe(5)
+    expect(totalQuotedQuantity([{ quantity: 5 }, { quantity: -3 }])).toBe(5)
+  })
+
+  it("answers 0 for nothing at all, without throwing", () => {
+    expect(totalQuotedQuantity([])).toBe(0)
+    expect(totalQuotedQuantity(null)).toBe(0)
+    expect(totalQuotedQuantity(undefined)).toBe(0)
+  })
+})
+
 describe("buildQuoteEmailData", () => {
   const build = (quote: any) =>
     buildQuoteEmailData({
@@ -85,6 +110,7 @@ describe("buildQuoteEmailData", () => {
       partnerName: "Unique Pashmina",
       quoteUrl: "https://shop.example.com/de/quotes/tok_abc",
       lineCount: 2,
+      totalQuantity: 40,
       now: NOW,
     })
 
@@ -96,6 +122,7 @@ describe("buildQuoteEmailData", () => {
       landed_total: "€4,210.50",
       destination: "Berlin, Germany",
       line_count: 2,
+      total_quantity: 40,
       expires_on: "September 15, 2026",
       current_year: 2026,
     })
@@ -123,6 +150,7 @@ describe("buildQuoteEmailData", () => {
         partnerName: null,
         quoteUrl: "u",
         lineCount: 1,
+        totalQuantity: 1,
         now: NOW,
       }).partner_name
     ).toBe("Jaal Yantra Textiles")

--- a/apps/backend/src/modules/partner-quote/lib/quote-email.ts
+++ b/apps/backend/src/modules/partner-quote/lib/quote-email.ts
@@ -21,8 +21,42 @@ export type QuoteEmailData = {
   landed_total: string
   destination: string
   line_count: number
+  /**
+   * The number of PIECES quoted, summed across every line (#1538 follow-up).
+   *
+   * 🔴 Added because `line_count` was being rendered as one. Both quote emails
+   * said "your quote for {{line_count}} item(s)", and `line_count` is
+   * `lines.length` — so a single line of 29 scarves announced itself as "1
+   * item(s)", and Marcha's six-line quote of ten pieces as "6". The number was
+   * right for a question nobody asked and wrong for the one the buyer reads.
+   *
+   * Both are kept. A buyer wants the pieces; the line count still says how the
+   * basket is broken up, and templates already reference it.
+   */
+  total_quantity: number
   expires_on: string
   current_year: number
+}
+
+/**
+ * PURE: how many pieces this quote is for.
+ *
+ * 🔑 Non-numeric and negative quantities are SKIPPED rather than coerced. A
+ * `Number(undefined)` is `NaN`, and one bad line would otherwise turn the whole
+ * count into "NaN item(s)" in a buyer's inbox — a wrong number that at least
+ * announces itself, unlike the one this replaces, but still not something to
+ * send. A line we cannot read contributes nothing and the rest still counts.
+ */
+export function totalQuotedQuantity(
+  lines: Array<{ quantity?: unknown }> | null | undefined
+): number {
+  let total = 0
+  for (const line of lines ?? []) {
+    const quantity = Number(line?.quantity)
+    if (!Number.isFinite(quantity) || quantity <= 0) continue
+    total += quantity
+  }
+  return total
 }
 
 /**
@@ -110,6 +144,8 @@ export function buildQuoteEmailData(input: {
   partnerName?: string | null
   quoteUrl: string
   lineCount: number
+  /** Pieces across every line — see `total_quantity` on the payload type. */
+  totalQuantity: number
   now: Date
 }): QuoteEmailData {
   const q = input.quote
@@ -131,6 +167,7 @@ export function buildQuoteEmailData(input: {
       countryCode: q.destination_country_code ?? null,
     }),
     line_count: input.lineCount,
+    total_quantity: input.totalQuantity,
     expires_on: formatQuoteExpiry(q.expires_at ?? null) ?? "the date shown on your quote",
     current_year: input.now.getUTCFullYear(),
   }

--- a/apps/backend/src/scripts/seed-quote-email-template.ts
+++ b/apps/backend/src/scripts/seed-quote-email-template.ts
@@ -27,7 +27,7 @@ export const QUOTE_TEMPLATE_DEFINITION = {
   <div style="padding:32px;">
     <p style="color:#18181B;font-size:16px;font-weight:500;margin:0;">Hi {{recipient_name}},</p>
     <p style="color:#52525B;font-size:14px;line-height:1.6;margin:12px 0;">
-      Your quote for {{line_count}} item(s) is ready to view. The link below shows your prices, the freight to {{destination}}, and the landed total.
+      Your quote for {{total_quantity}} piece(s) across {{line_count}} line(s) is ready to view. The link below shows your prices, the freight to {{destination}}, and the landed total.
     </p>
     <div style="background:#FAFAFA;border:1px solid #E4E4E7;border-radius:8px;padding:20px;margin:20px 0;">
       <p style="color:#71717A;font-size:12px;margin:0 0 4px;text-transform:uppercase;letter-spacing:0.05em;">Landed total</p>
@@ -54,11 +54,85 @@ export const QUOTE_TEMPLATE_DEFINITION = {
     quote_url: "The buyer link — https://<domain>/<countryCode>/quotes/<token>",
     landed_total: "Formatted landed total, e.g. Rs 36,00,000",
     destination: "Destination city/country the freight was quoted to",
-    line_count: "Number of quoted lines",
+    line_count: "Number of quoted LINES (rows on the quote), not pieces",
+    total_quantity: "Total PIECES across every line — what a buyer means by \"items\"",
     // Passed in, never computed here — see the header.
     expires_on: "Human-readable expiry date, from the quote's expires_at",
     current_year: "Current year (e.g. 2026)",
   },
 }
 
-export const quoteEmailTemplates = [QUOTE_TEMPLATE_DEFINITION]
+
+export const QUOTE_INTRODUCTION_TEMPLATE_KEY = "partner-quote-introduction"
+
+/**
+ * The partner introduction, sent just before the quote itself.
+ *
+ * 🔴 THIS TEMPLATE EXISTED ONLY IN THE PRODUCTION DATABASE. It was created
+ * through the admin UI and lives in no seed, no migration and no commit — so it
+ * could not be reviewed, tested, restored, or diffed, and the defect below sat
+ * in a buyer-facing email with nothing in the repository that could have caught
+ * it. It is checked in here for the same reason its sibling above is.
+ *
+ * 🔴 The defect: the copy read "Your quote for {{line_count}} item(s)", and
+ * `line_count` is `lines.length` — ROWS, not pieces. A single line of 29
+ * scarves introduced itself as "1 item(s)"; a six-line quote for ten pieces as
+ * "6". The word "item(s)" is what makes it wrong: the number was accurate for a
+ * question nobody asked and wrong for the one a buyer reads. Worse, the mint
+ * event carried no quantity at all, so no edit to this template alone could
+ * have fixed it — see `total_quantity` on the delivery workflow.
+ *
+ * 🔑 It is sent by a VISUAL FLOW listening on `partner_quote.minted`, not by
+ * the mint. Anything this template renders must therefore exist on that event's
+ * payload; a variable that is merely available inside the workflow is not
+ * available here.
+ */
+export const QUOTE_INTRODUCTION_TEMPLATE_DEFINITION = {
+  name: "B2B Partner Introduction",
+  template_key: QUOTE_INTRODUCTION_TEMPLATE_KEY,
+  from: "sales@jaalyantra.com",
+  subject: "An introduction to {{partner_name}}",
+  html_content: `<!DOCTYPE html><html lang="en"><head><meta charset="UTF-8"><meta name="viewport" content="width=device-width,initial-scale=1.0"></head>
+<body style="margin:0;padding:0;font-family:Inter,-apple-system,BlinkMacSystemFont,'Segoe UI',Roboto,sans-serif;background:#FAFAFA;">
+<div style="max-width:640px;margin:0 auto;background:#FFFFFF;border:1px solid #E4E4E7;border-radius:12px;overflow:hidden;margin-top:24px;margin-bottom:24px;">
+  <div style="background:#27272A;padding:32px;text-align:center;">
+    <h1 style="color:#FFFFFF;font-size:20px;font-weight:600;margin:0;">An introduction</h1>
+    <p style="color:#A1A1AA;font-size:13px;margin:6px 0 0;">Before your quote from {{partner_name}}</p>
+  </div>
+  <div style="padding:32px;">
+    <p style="color:#18181B;font-size:16px;font-weight:500;margin:0;">Hello,</p>
+    <p style="color:#52525B;font-size:14px;line-height:1.6;margin:12px 0;">
+      Your quote for {{total_quantity}} piece(s) across {{line_count}} line(s) is being prepared by <strong>{{partner_name}}</strong> and follows shortly in a separate email. Before it arrives, a word about who you are buying from.
+    </p>
+    <p style="color:#52525B;font-size:14px;line-height:1.6;margin:12px 0;">
+      {{partner_name}} is a maker on Jaal Yantra Textiles. The goods are produced in their own workshop and dispatched directly from it &mdash; there is no intermediate warehouse and no relabelling. The quote names the maker alongside the pieces, the freight and one total.
+    </p>
+    <div style="background:#FAFAFA;border:1px solid #E4E4E7;border-radius:8px;padding:20px;margin:20px 0;">
+      <p style="color:#71717A;font-size:12px;margin:0 0 8px;text-transform:uppercase;letter-spacing:0.05em;">What to expect</p>
+      <p style="color:#52525B;font-size:14px;line-height:1.6;margin:0;">
+        One quote covering the whole basket, shipped as a single consignment. Freight is charged once across all of it, not per line. Your prices are held for the validity period stated on the quote.
+      </p>
+    </div>
+    <p style="color:#71717A;font-size:13px;margin:12px 0 0;">
+      If anything in the quote does not match what you asked for, reply to this email and it will reach the people who prepared it.
+    </p>
+  </div>
+  <div style="background:#FAFAFA;padding:20px 32px;text-align:center;border-top:1px solid #E4E4E7;">
+    <p style="color:#71717A;font-size:11px;margin:0;">Sent by {{partner_name}} via Jaal Yantra Textiles</p>
+  </div>
+</div></body></html>`,
+  variables: {
+    partner_name: "The partner the buyer is being introduced to — always present on partner_quote.minted",
+    recipient_name: "Buyer contact name, or their company when no name was given",
+    recipient_company: "The buyer's company, when they gave one",
+    line_count: "Number of quoted LINES (rows on the quote), not pieces",
+    total_quantity: "Total PIECES across every line — what a buyer means by \"items\"",
+    destination: "Destination country the goods would ship to",
+    current_year: "Current year (e.g. 2026)",
+  },
+}
+
+export const quoteEmailTemplates = [
+  QUOTE_TEMPLATE_DEFINITION,
+  QUOTE_INTRODUCTION_TEMPLATE_DEFINITION,
+]

--- a/apps/backend/src/workflows/partner-quote/deliver-quote-email.ts
+++ b/apps/backend/src/workflows/partner-quote/deliver-quote-email.ts
@@ -54,6 +54,12 @@ export async function deliverQuoteEmail(
     token: string | null | undefined
     partnerName?: string | null
     lineCount: number
+    /**
+     * Pieces across every line. Distinct from `lineCount`, which is how many
+     * ROWS the quote has — the two were conflated in both emails' copy until
+     * a six-line quote for ten pieces introduced itself as "6 item(s)".
+     */
+    totalQuantity: number
     /** Who is being told, for the timeline. */
     actorType: "partner" | "admin"
     actorId?: string | null
@@ -104,6 +110,13 @@ export async function deliverQuoteEmail(
         total: quote?.quoted_landed_total ?? null,
         destination_country_code: quote?.destination_country_code ?? null,
         line_count: input.lineCount,
+        /**
+         * 🔑 The pieces, for any visual flow that renders a number to a buyer.
+         * Without it the introduction email had only `line_count` to reach for
+         * and no way to be right — the payload simply did not carry the
+         * quantity, so no amount of editing the template could have fixed it.
+         */
+        total_quantity: input.totalQuantity,
         actor_type: input.actorType,
       },
     })
@@ -151,6 +164,7 @@ export async function deliverQuoteEmail(
           partnerName: input.partnerName ?? null,
           quoteUrl: buyerUrl,
           lineCount: input.lineCount,
+          totalQuantity: input.totalQuantity,
           now: new Date(),
         }),
       },

--- a/apps/backend/src/workflows/production-runs/__tests__/replace-goods-transfer.unit.spec.ts
+++ b/apps/backend/src/workflows/production-runs/__tests__/replace-goods-transfer.unit.spec.ts
@@ -1,0 +1,63 @@
+import { assertReplaceableTransfer } from "../create-production-run-transfer"
+
+/**
+ * Re-booking a hop the carrier cancelled (#891 follow-up).
+ *
+ * The guard this covers decides whether a NEW transfer may point back at an old
+ * one. Both wrong answers cost something real:
+ *
+ * · allowing a transfer from ANOTHER run links two unrelated movements, and the
+ *   run's goods location is read from that list;
+ * · allowing a LIVE one leaves two open movements for the same consignment,
+ *   which double-counts the moment inventory learns to follow a transfer (S3).
+ */
+
+const RUN = "prod_run_01KYPM4G2S85PX61HT25T8BFDT"
+
+const transfer = (over: any = {}) => ({
+  id: "gtrf_old",
+  production_run_id: RUN,
+  status: "cancelled",
+  ...over,
+})
+
+describe("assertReplaceableTransfer", () => {
+  it("allows a cancelled hop on this run to be re-booked", () => {
+    expect(() =>
+      assertReplaceableTransfer(transfer(), RUN, "gtrf_old")
+    ).not.toThrow()
+  })
+
+  it("refuses a transfer that belongs to another run", () => {
+    expect(() =>
+      assertReplaceableTransfer(
+        transfer({ production_run_id: "prod_run_someone_else" }),
+        RUN,
+        "gtrf_old"
+      )
+    ).toThrow(/not found on production run/)
+  })
+
+  it("refuses a transfer that does not exist", () => {
+    // 🔑 A missing row must not be treated as "nothing to link" and quietly
+    // succeed: the operator asked to replace something specific.
+    expect(() => assertReplaceableTransfer(null, RUN, "gtrf_ghost")).toThrow(
+      /gtrf_ghost/
+    )
+  })
+
+  it.each(["draft", "in_transit", "delivered"])(
+    "refuses to replace a %s hop — it is still live",
+    (status) => {
+      expect(() =>
+        assertReplaceableTransfer(transfer({ status }), RUN, "gtrf_old")
+      ).toThrow(/not cancelled/)
+    }
+  )
+
+  it("names the status it refused, so the operator knows what to do next", () => {
+    expect(() =>
+      assertReplaceableTransfer(transfer({ status: "in_transit" }), RUN, "gtrf_old")
+    ).toThrow(/"in_transit"/)
+  })
+})

--- a/apps/backend/src/workflows/production-runs/create-production-run-transfer.ts
+++ b/apps/backend/src/workflows/production-runs/create-production-run-transfer.ts
@@ -63,6 +63,21 @@ export type CreateProductionRunTransferInput = {
   /** Acting user's email recorded on a freshly-registered pickup (#427). */
   actingEmail?: string
   notes?: string
+  /**
+   * The cancelled hop this one replaces (#891 follow-up).
+   *
+   * 🔑 A re-booking is a NEW row, never an edit of the old one. The original
+   * carries an AWB the carrier really issued and really cancelled; rewriting it
+   * would erase the fact that the first attempt happened, and the transfer list
+   * is the only record of what physically moved. So both rows survive and point
+   * at each other — `replaces_transfer_id` here, `replaced_by_transfer_id`
+   * there.
+   *
+   * 🔴 Only a CANCELLED transfer can be replaced. Replacing a live one would
+   * leave two open movements for the same goods, and the second would silently
+   * double-count the moment inventory learns to follow a transfer (S3).
+   */
+  replacesTransferId?: string
   /** Who reads the error — carrier-account failures are not a partner's doing. */
   audience?: "admin" | "partner"
 }
@@ -213,6 +228,38 @@ async function recordTransferActivity(
   }
 }
 
+/**
+ * PURE: may this cancelled hop be replaced by a new one?
+ *
+ * Split out because it is the whole decision, and both wrong answers are
+ * expensive: replacing a transfer on ANOTHER run links two unrelated movements
+ * and misreports where goods are, while replacing a LIVE one leaves two open
+ * movements for the same consignment — which double-counts the moment
+ * inventory learns to follow a transfer (S3). Testable without a container, a
+ * carrier account, or a real waybill.
+ *
+ * Throws rather than returning false: every caller's only sensible response is
+ * to stop, and a boolean invites one of them not to.
+ */
+export function assertReplaceableTransfer(
+  replaced: { id?: string; production_run_id?: string; status?: string } | null,
+  runId: string,
+  requestedId: string
+): void {
+  if (!replaced || replaced.production_run_id !== runId) {
+    throw new MedusaError(
+      MedusaError.Types.NOT_FOUND,
+      `Goods transfer ${requestedId} not found on production run ${runId}, so it cannot be the hop this one replaces.`
+    )
+  }
+  if (replaced.status !== "cancelled") {
+    throw new MedusaError(
+      MedusaError.Types.NOT_ALLOWED,
+      `Transfer ${replaced.id} is "${replaced.status}", not cancelled — replacing a live hop would leave two open movements for the same goods. Cancel it first.`
+    )
+  }
+}
+
 export async function createProductionRunTransfer(
   container: MedusaContainer,
   input: CreateProductionRunTransferInput
@@ -254,6 +301,23 @@ export async function createProductionRunTransfer(
     )
   }
 
+  /**
+   * The hop being re-booked, when this is a replacement.
+   *
+   * Validated BEFORE anything is created: a replacement that names a transfer
+   * on another run, or one that is still live, is a mistake worth refusing
+   * rather than a link worth writing. Checked here rather than in the route so
+   * the partner mirror gets the same guard for free.
+   */
+  let replaced: any = null
+  if (input.replacesTransferId) {
+    replaced = await transferService
+      .retrieveGoodsTransfer(input.replacesTransferId)
+      .catch(() => null)
+
+    assertReplaceableTransfer(replaced, run.id, input.replacesTransferId)
+  }
+
   const quantity = transferQuantity(run, input.quantity)
 
   // The transfer row is created FIRST, before any carrier call. Two reasons:
@@ -270,7 +334,32 @@ export async function createProductionRunTransfer(
     reason: input.reason || "stock",
     status: "draft",
     notes: input.notes ?? null,
+    metadata: replaced ? { replaces_transfer_id: replaced.id } : null,
   })
+
+  /**
+   * Point the cancelled row FORWARD at its replacement.
+   *
+   * Best-effort and merged, never assigned: `metadata` is a shared blob, and
+   * the new transfer already carries the backward link — so a failure here
+   * costs a convenience, not the history. Losing whatever else was in that blob
+   * to a wholesale overwrite would cost real information.
+   */
+  if (replaced) {
+    try {
+      await transferService.updateGoodsTransfers({
+        id: replaced.id,
+        metadata: {
+          ...((replaced.metadata ?? {}) as Record<string, unknown>),
+          replaced_by_transfer_id: transfer.id,
+        },
+      })
+    } catch (e: any) {
+      logger.error(
+        `[goods-transfer] ${transfer.id} replaces ${replaced.id} but the back-link write failed: ${e?.message}`
+      )
+    }
+  }
 
   const base: ProductionRunTransferResult = {
     transfer_id: transfer.id,


### PR DESCRIPTION
Delhivery cancelled the waybill on the live #891 hop (`gtrf_01KZP7C2SJ…`, Shramdaan India Warehouse → Dharamshala, 3 jackets). The row still says **`in_transit`**, and there is no screen in the admin on which anyone can say otherwise.

## Why there was no screen

The transfer routes have existed since #891 S1 and **only partner-ui ever grew a surface**. Every admin transfer to date — that live hop included — was booked by hand against the API. Fine for a verification run; useless the moment something needs correcting.

## Two things were missing, not one

**1. Recording a carrier-side cancellation.** `DELETE .../transfers/:id` cancels a `draft` only, refusing anything booked because cancelling an AWB is a carrier operation, not a row edit. That reasoning is right and this doesn't weaken it — but it left the case that actually happens unrepresentable. `POST .../transfers/:id/cancel` records it, and **only when the caller states plainly that the carrier already has**.

🔴 It does not call the carrier, and the UI says so where an operator will read it — *"do that in their dashboard first, or the shipment keeps travelling while this says it stopped."* Someone who believed this voided the AWB would stop chasing them. The assertion is stored as an assertion (`carrier_cancellation_asserted`), with who and when, never as a verified carrier fact.

🔴 A `delivered` transfer can never be cancelled. The goods arrived, and `resolveRunGoodsLocation` trusts a delivered transfer to say where stock is.

**2. Re-booking without losing the history.** A replacement is a **new row** carrying `replaces_transfer_id`; the cancelled one gains `replaced_by_transfer_id`. Nothing is edited, nothing is deleted — the first attempt really happened, and this list is the only record of what physically moved. Both links are rendered in the list.

Only a **cancelled** hop may be replaced. Replacing a live one leaves two open movements for the same consignment, which double-counts the moment inventory learns to follow a transfer (S3).

## Interface details worth a look

- The drawer **prefills destination, reason and quantity** from the hop being replaced — making an operator retype them is how a re-booking quietly becomes a *different* movement — but **never the carrier**. The last booking is the one that just failed, and a carrier chosen by default is a carrier nobody chose.
- The section renders on every run, not only completed ones as the partner surface does: an admin is usually recording a hop after the fact or fixing one that broke, and hiding the list until a status changes hides exactly the row that needs fixing.
- Carrier options come from the shared `SHIPMENT_CARRIERS` list, so admin and partner offer the same set.
- ⚠️ `Drawer.Body` carries `overflow-y-auto` — without it the modal body doesn't scroll and the footer buttons are unreachable on a short viewport (~98 partner-ui modals still have this).
- ⚠️ The carrier `Select` uses a `none` sentinel rather than `""`: Radix reserves the empty string and **throws** on `<Select.Item value="">`, which took the partner drawer down with a render error the moment it opened.

## Verification

- `assertReplaceableTransfer` extracted as a pure guard — 6 cases: another run's transfer, a missing one, and each of `draft` / `in_transit` / `delivered` refused.
- 22 pass across the transfer suites. `check:prod-build` ✓ (schema drift reverted per the standing rule).
- ⚠️ **The UI itself has not been clicked.** The admin dashboard builds, which proves it compiles, not that the drawer opens.

## After this deploys

The stuck hop can be resolved from the run page: cancel it with a reason, then Re-book — same destination, same 3 units, a fresh waybill, and the cancelled row preserved beside it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_0158wJMZ1DmjNxXf5uGuBrQD
