### PR TITLE
fix(shipping): price the shekel lane, and stop a test from pinning the gap (#1538)

### DIFF
--- a/apps/backend/src/lib/__tests__/freight-default-rates.unit.spec.ts
+++ b/apps/backend/src/lib/__tests__/freight-default-rates.unit.spec.ts
@@ -67,14 +67,25 @@ describe("DEFAULT_QUOTE_FREIGHT_TIERS", () => {
     expect(resolveQuoteTierAmount(DEFAULT_QUOTE_FREIGHT_TIERS, 5001, "eur")).toBe(100)
   })
 
-  it("is priced in every currency the intl rate table covers except idr", () => {
+  it("prices EVERY currency the intl rate table covers, in every tier", () => {
     // A tier that matches but does not price the cart's currency returns null —
     // the option is simply not offered — so a gap here silently removes the
     // middle rung of the freight ladder rather than mispricing it.
+    //
+    // 🔴 This assertion used to read "…except idr", pinning the gap as correct
+    // (#1538). A test that names the hole is not a test, it is a comment that
+    // fails when somebody fills it in. It is now the invariant: add a currency
+    // to `INTL_FLAT_RATES` and this fails until the tiers price it too.
+    const expected = Object.keys(INTL_FLAT_RATES).sort()
     for (const tier of DEFAULT_QUOTE_FREIGHT_TIERS) {
-      expect(Object.keys(tier.amounts).sort()).toEqual(
-        ["aud", "cad", "eur", "gbp", "inr", "usd"]
-      )
+      expect(Object.keys(tier.amounts).sort()).toEqual(expected)
     }
+  })
+
+  it("prices ils — the currency that would have taken the USD figure verbatim", () => {
+    // ₪39 (the usd row, verbatim) is about $13 against an intended $39.
+    expect(intlFlatRateFor("ils").base).toBe(120)
+    expect(resolveQuoteTierAmount(DEFAULT_QUOTE_FREIGHT_TIERS, 2200, "ils")).toBe(195)
+    expect(resolveQuoteTierAmount(DEFAULT_QUOTE_FREIGHT_TIERS, 22000, "ils")).toBe(330)
   })
 })

--- a/apps/backend/src/lib/freight-default-rates.ts
+++ b/apps/backend/src/lib/freight-default-rates.ts
@@ -47,6 +47,18 @@ export type IntlFlatRate = {
  * not listed here — a real number rather than nothing, because the alternative
  * used to be `DEFAULT_FLAT_FALLBACK` (200), which is an INR-shaped number and
  * charged **€200** on a EUR cart against an intended €35.
+ *
+ * 🔴 The USD fallback is a floor, not a licence to leave a currency out. Taking
+ * the USD row VERBATIM is the same currency-blindness one rung down: an estate
+ * selling in shekels would have been stamped `ils: 39` — ₪39 is about $13
+ * against an intended $39, a third of the intended fallback and, being a
+ * plausible-looking number, nothing to notice. Every currency the estate
+ * actually sells in belongs in this table explicitly (#1538).
+ *
+ * The rows are not an FX conversion of one another — they are retail numbers,
+ * rounded the way a price list rounds — but they do sit in one band: $31–41 at
+ * the rates of 2026-08-24. A new row is placed inside that band and rounded,
+ * NOT computed to the cent, so it reads as the placeholder it is.
  */
 export const INTL_FLAT_RATES: Record<string, IntlFlatRate> = {
   usd: { base: 39, freeAbove: 350 },
@@ -56,6 +68,11 @@ export const INTL_FLAT_RATES: Record<string, IntlFlatRate> = {
   cad: { base: 50, freeAbove: 400 },
   inr: { base: 3200, freeAbove: 25000 },
   idr: { base: 550000, freeAbove: 5000000 },
+  // ≈$40 base / ≈$351 free-above at USD→ILS 2.9922 (ECB via Frankfurter,
+  // 2026-08-24). The handoff's proposed ₪145 was reasoned from a remembered
+  // ~3.7 shekel; the live rate is 2.99, which would have put it at $48 —
+  // a fifth above every other row in the table.
+  ils: { base: 120, freeAbove: 1050 },
 }
 
 /** The rate for a currency, falling back to the USD row. Never undefined. */
@@ -102,11 +119,29 @@ export const QUOTE_TIER_LIGHT_MAX_GRAMS = 5000
 export const DEFAULT_QUOTE_FREIGHT_TIERS: QuoteFreightTier[] = [
   {
     max_weight_grams: QUOTE_TIER_LIGHT_MAX_GRAMS,
-    amounts: { eur: 59, usd: 65, gbp: 52, aud: 95, cad: 88, inr: 5400 },
+    amounts: {
+      eur: 59,
+      usd: 65,
+      gbp: 52,
+      aud: 95,
+      cad: 88,
+      inr: 5400,
+      ils: 195,
+      idr: 1150000,
+    },
   },
   {
     max_weight_grams: null,
-    amounts: { eur: 100, usd: 110, gbp: 88, aud: 160, cad: 150, inr: 9200 },
+    amounts: {
+      eur: 100,
+      usd: 110,
+      gbp: 88,
+      aud: 160,
+      cad: 150,
+      inr: 9200,
+      ils: 330,
+      idr: 1950000,
+    },
   },
 ]
 
@@ -118,6 +153,14 @@ export const DEFAULT_QUOTE_FREIGHT_TIERS: QuoteFreightTier[] = [
  * created. The LIGHT tier is used deliberately: a misconfiguration that fell
  * back to these rows would then charge a parcel rate for a parcel rather than a
  * pallet rate for one.
+ *
+ * ⚠️ The `light["usd"]` fallback is currency-blind in the same way the
+ * `INTL_FLAT_RATES` usd row is — an unlisted currency gets the USD FIGURE, so
+ * a hypothetical `jpy` would carry a ¥65 row. It is inert today (every
+ * currency the estate sells in is now priced above, and `resolveQuoteTierAmount`
+ * returns null for one that is not, so the option is simply not offered), but
+ * it is a lookalike number waiting for a new currency. Add the currency to the
+ * tiers above rather than relying on this.
  */
 export function quoteTierPriceRows(
   currencies: Iterable<string>


### PR DESCRIPTION
Unblocks the **#1538** apply, which has been waiting on one number.

## The number

The backfill would stamp `ils: 39` on the estate's shekel options — `intlFlatRateFor` falls back to the **USD row verbatim**, and ₪39 is about **$13** against an intended $39. A third of the intended fallback, and a plausible-looking number, so nothing to notice.

The handoff proposed **₪145**, reasoned from a remembered ~3.7 shekel. The live ECB rate (Frankfurter, 2026-08-24) is **2.9922**, which puts ₪145 at **$48** — a fifth above every other row.

Every row in the table lands in one band once converted at today's rates:

| | usd | eur | gbp | aud | cad | inr | idr | **ils (new)** |
|---|---|---|---|---|---|---|---|---|
| `base` | 39 | 35 | 30 | 55 | 50 | 3200 | 550000 | **120** |
| in USD | $39 | $40.8 | $40.9 | $39.4 | $36.1 | $33.4 | $31.1 | **$40.1** |
| `freeAbove` in USD | $350 | $350 | $375 | $322 | $289 | $261 | $282 | **$351** |

`ils: { base: 120, freeAbove: 1050 }`. Rounded the way the other rows are, not computed to the cent — it is a placeholder and should read as one.

## The gap underneath it

`DEFAULT_QUOTE_FREIGHT_TIERS` priced neither `ils` nor `idr`. `resolveQuoteTierAmount` returns null for an unpriced currency, so the **14 quote-only options the backfill creates would have been inert on both lanes** — the middle rung of the ladder (carrier → quote tier → retail flat) missing, with nothing failing. Both are now priced: `ils` 195/330, `idr` 1150000/1950000, each ≈$65/$110 like their neighbours.

## The test asserted the hole

```
it("is priced in every currency the intl rate table covers except idr", …)
```

A test that names a gap is not a test — it is a comment that fails when somebody fills it in. It now reads the currency list off `INTL_FLAT_RATES`: add a currency there and this fails until the tiers price it too.

Both new assertions were **confirmed to fail with the `ils` row removed**, not merely observed passing.

## Verify

- `TEST_TYPE=unit npx jest --testPathPattern="freight-default-rates|quote-freight-tiers"` → 24 passed
- `pnpm check:prod-build` → `✓ Prod-config build passed.`

After deploy: re-dry-run `backfill-freight-option-data` and read the `ils` line before applying with `dry_run: false`.

## Still open on #1538

Tail 2 (€35 flat vs the observed €7.49 real rate) and tail 3 (€59/€100 tiers) are unanswered — both are edits to this same file plus a re-run with `overwrite: true`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_0158wJMZ1DmjNxXf5uGuBrQD