### PR TITLE
feat: goods movement on the timeline, the inquiry in a modal, and ten photographs rescued (#1542, #1543, WhatsApp media)

### DIFF
--- a/apps/backend/src/admin/components/production-runs/goods-transfer-section.tsx
+++ b/apps/backend/src/admin/components/production-runs/goods-transfer-section.tsx
@@ -11,8 +11,10 @@ import {
   Textarea,
   toast,
 } from "@medusajs/ui"
+import { HandTruck, Trash, TruckFast, XCircle } from "@medusajs/icons"
 import { useState } from "react"
 
+import { ActionMenu, type Action } from "../common/action-menu"
 import {
   useCancelGoodsTransfer,
   useCreateGoodsTransfer,
@@ -106,13 +108,39 @@ export const GoodsTransferSection = ({ runId }: Props) => {
   const [notes, setNotes] = useState("")
   /** Set when the drawer was opened via "Re-book" on a cancelled hop. */
   const [replacing, setReplacing] = useState<AdminGoodsTransfer | null>(null)
+  /**
+   * "Record a movement that already happened" — the same drawer with the
+   * carrier question removed rather than merely defaulted.
+   *
+   * 🔴 It is not cosmetic. A carrier booking mints a REAL, billable Delhivery
+   * waybill and there is no sandbox, so the one affordance that can spend money
+   * should be absent from the flow whose whole premise is that the goods have
+   * already moved. A select that merely starts on "no carrier" is one stray
+   * click from a booking nobody meant to make (#1542).
+   */
+  const [recordOnly, setRecordOnly] = useState(false)
 
   const [cancelling, setCancelling] = useState<AdminGoodsTransfer | null>(null)
   const [cancelReason, setCancelReason] = useState("")
+  /** The "clear abandoned drafts" confirmation. */
+  const [clearingDrafts, setClearingDrafts] = useState(false)
+  const [isClearing, setIsClearing] = useState(false)
 
   const { goods_transfers: transfers = [], isLoading } = useGoodsTransfers(runId)
+  /**
+   * 🔴 This was `enabled: open` — the locations were only fetched once the
+   * drawer had been opened, and `locationName` falls back to the raw id. So the
+   * list a page-load lands on read
+   * "4 × sloc_01K2… → sloc_01K3…" until you happened to open the drawer, after
+   * which it silently became readable and stayed that way.
+   *
+   * Nothing failed and nothing logged, which is why it survived #1541: the
+   * interface was proven to compile and its API path proven by curl, and this
+   * is visible only to an eye on the screen. It is also needed unconditionally
+   * now — the "clear abandoned drafts" prompt names each row by location.
+   */
   const { stock_locations: locations = [] } = useStockLocations(undefined, {
-    enabled: open,
+    enabled: !!runId,
   } as any)
 
   const { mutateAsync: createTransfer, isPending: isCreating } =
@@ -133,6 +161,7 @@ export const GoodsTransferSection = ({ runId }: Props) => {
     setWeight("")
     setNotes("")
     setReplacing(null)
+    setRecordOnly(false)
   }
 
   /**
@@ -151,7 +180,52 @@ export const GoodsTransferSection = ({ runId }: Props) => {
     setNotes(t.notes ?? "")
     setCarrier(NO_CARRIER)
     setReplacing(t)
+    setRecordOnly(false)
     setOpen(true)
+  }
+
+  const openMovement = (opts?: { recordOnly?: boolean }) => {
+    resetForm()
+    setRecordOnly(!!opts?.recordOnly)
+    setOpen(true)
+  }
+
+  /** Drafts are the only rows that can be cleared — nothing was ever booked. */
+  const drafts = transfers.filter((t) => t.status === "draft")
+
+  /**
+   * Clear every abandoned draft in one go.
+   *
+   * The #891 run carries four of these from 9 Aug. Each is a hop somebody
+   * planned and never booked, and one-at-a-time is the only way to be rid of
+   * them today — so in practice nobody is, and the section reads as if five
+   * movements are pending when one is.
+   *
+   * Sequential rather than `Promise.all`: each delete invalidates the same
+   * query, and a partial failure must leave a count the operator can act on
+   * rather than a rejected batch that says nothing about which rows survived.
+   */
+  const handleClearDrafts = async () => {
+    setIsClearing(true)
+    let cleared = 0
+    let failed = 0
+    for (const draft of drafts) {
+      try {
+        await deleteDraft(draft.id)
+        cleared++
+      } catch {
+        failed++
+      }
+    }
+    setIsClearing(false)
+    setClearingDrafts(false)
+    if (failed) {
+      toast.error(
+        `Cleared ${cleared}, but ${failed} could not be cancelled. Reload and try again.`
+      )
+    } else {
+      toast.success(`Cleared ${cleared} abandoned draft${cleared === 1 ? "" : "s"}`)
+    }
   }
 
   const handleSubmit = async () => {
@@ -160,7 +234,9 @@ export const GoodsTransferSection = ({ runId }: Props) => {
       const res = await createTransfer({
         to_location_id: toLocationId,
         reason,
-        carrier: carrierValue(carrier),
+        // 🔑 recordOnly wins over the state: the select is not rendered, so
+        // `carrier` still holds whatever a previous open left there.
+        carrier: recordOnly ? undefined : carrierValue(carrier),
         quantity: positive(quantity),
         weight_grams: positive(weight),
         notes: notes.trim() || undefined,
@@ -209,16 +285,39 @@ export const GoodsTransferSection = ({ runId }: Props) => {
           <Heading level="h3">Goods movement</Heading>
           {transfers.length > 0 && <Badge size="2xsmall">{transfers.length}</Badge>}
         </div>
-        <Button
-          size="small"
-          variant="secondary"
-          onClick={() => {
-            resetForm()
-            setOpen(true)
-          }}
-        >
-          Move to next location
-        </Button>
+        <ActionMenu
+          groups={[
+            {
+              actions: [
+                {
+                  icon: <TruckFast />,
+                  label: "Move to next location",
+                  onClick: () => openMovement(),
+                },
+                {
+                  icon: <HandTruck />,
+                  label: "Record a movement that already happened",
+                  onClick: () => openMovement({ recordOnly: true }),
+                },
+              ],
+            },
+            {
+              actions: [
+                {
+                  icon: <Trash />,
+                  label: drafts.length
+                    ? `Clear ${drafts.length} abandoned draft${
+                        drafts.length === 1 ? "" : "s"
+                      }`
+                    : "Clear abandoned drafts",
+                  disabled: !drafts.length,
+                  disabledTooltip: "No planned-but-unbooked hops to clear.",
+                  onClick: () => setClearingDrafts(true),
+                },
+              ],
+            },
+          ]}
+        />
       </div>
 
       {isLoading ? null : transfers.length === 0 ? (
@@ -232,6 +331,29 @@ export const GoodsTransferSection = ({ runId }: Props) => {
           {transfers.map((t) => {
             const replacedBy = t.metadata?.replaced_by_transfer_id
             const replaces = t.metadata?.replaces_transfer_id
+
+            const rowActions: Action[] = []
+            if (t.status === "cancelled" && !replacedBy) {
+              rowActions.push({
+                icon: <TruckFast />,
+                label: "Re-book this movement",
+                onClick: () => openReplacement(t),
+              })
+            }
+            if (t.status === "draft" || t.status === "in_transit") {
+              rowActions.push({
+                icon: t.status === "draft" ? <Trash /> : <XCircle />,
+                label:
+                  t.status === "draft"
+                    ? "Cancel this planned hop"
+                    : "Record as cancelled by the carrier",
+                onClick: () => {
+                  setCancelling(t)
+                  setCancelReason("")
+                },
+              })
+            }
+
             return (
               <div key={t.id} className="flex flex-col gap-y-1">
                 <div className="flex items-center justify-between gap-x-3">
@@ -244,26 +366,10 @@ export const GoodsTransferSection = ({ runId }: Props) => {
                     <Badge size="2xsmall" color={STATUS_COLOR[t.status]}>
                       {t.status.replace("_", " ")}
                     </Badge>
-                    {t.status === "cancelled" && !replacedBy && (
-                      <Button
-                        size="small"
-                        variant="transparent"
-                        onClick={() => openReplacement(t)}
-                      >
-                        Re-book
-                      </Button>
-                    )}
-                    {(t.status === "draft" || t.status === "in_transit") && (
-                      <Button
-                        size="small"
-                        variant="transparent"
-                        onClick={() => {
-                          setCancelling(t)
-                          setCancelReason("")
-                        }}
-                      >
-                        Cancel
-                      </Button>
+                    {/* Only rendered when there is something to do — an empty
+                        "⋯" that opens onto nothing reads as a broken control. */}
+                    {rowActions.length > 0 && (
+                      <ActionMenu groups={[{ actions: rowActions }]} />
                     )}
                   </div>
                 </div>
@@ -291,7 +397,11 @@ export const GoodsTransferSection = ({ runId }: Props) => {
         <Drawer.Content>
           <Drawer.Header>
             <Drawer.Title>
-              {replacing ? "Re-book this movement" : "Move goods to the next location"}
+              {replacing
+                ? "Re-book this movement"
+                : recordOnly
+                  ? "Record a movement that already happened"
+                  : "Move goods to the next location"}
             </Drawer.Title>
           </Drawer.Header>
           {/* ⚠️ overflow-y-auto: a modal body without it does not scroll, and the
@@ -340,26 +450,34 @@ export const GoodsTransferSection = ({ runId }: Props) => {
               </Select>
             </div>
 
-            <div className="flex flex-col gap-y-1">
-              <Label size="small">Carrier</Label>
-              <Select value={carrier} onValueChange={setCarrier}>
-                <Select.Trigger>
-                  <Select.Value />
-                </Select.Trigger>
-                <Select.Content>
-                  {CARRIERS.map((c) => (
-                    <Select.Item key={c.value} value={c.value}>
-                      {c.label}
-                    </Select.Item>
-                  ))}
-                </Select.Content>
-              </Select>
+            {recordOnly ? (
               <Text size="xsmall" className="text-ui-fg-subtle">
-                Booking a carrier generates a REAL, billable waybill from the
-                source location's registered pickup. Leave it on "no carrier"
-                for a self-driven hop or a dry run.
+                No carrier will be contacted and no waybill booked — this records
+                a movement that has already happened. To book a courier, close
+                this and choose <strong>Move to next location</strong> instead.
               </Text>
-            </div>
+            ) : (
+              <div className="flex flex-col gap-y-1">
+                <Label size="small">Carrier</Label>
+                <Select value={carrier} onValueChange={setCarrier}>
+                  <Select.Trigger>
+                    <Select.Value />
+                  </Select.Trigger>
+                  <Select.Content>
+                    {CARRIERS.map((c) => (
+                      <Select.Item key={c.value} value={c.value}>
+                        {c.label}
+                      </Select.Item>
+                    ))}
+                  </Select.Content>
+                </Select>
+                <Text size="xsmall" className="text-ui-fg-subtle">
+                  Booking a carrier generates a REAL, billable waybill from the
+                  source location's registered pickup. Leave it on "no carrier"
+                  for a self-driven hop or a dry run.
+                </Text>
+              </div>
+            )}
 
             <div className="grid grid-cols-2 gap-3">
               <div className="flex flex-col gap-y-1">
@@ -403,7 +521,9 @@ export const GoodsTransferSection = ({ runId }: Props) => {
               disabled={!toLocationId}
               onClick={handleSubmit}
             >
-              {carrierValue(carrier) ? "Book & move" : "Record movement"}
+              {!recordOnly && carrierValue(carrier)
+                ? "Book & move"
+                : "Record movement"}
             </Button>
           </Drawer.Footer>
         </Drawer.Content>
@@ -440,6 +560,40 @@ export const GoodsTransferSection = ({ runId }: Props) => {
               disabled={isCancelling || isDeleting}
             >
               Cancel the transfer
+            </Prompt.Action>
+          </Prompt.Footer>
+        </Prompt.Content>
+      </Prompt>
+      <Prompt
+        open={clearingDrafts}
+        onOpenChange={(v) => !v && setClearingDrafts(false)}
+      >
+        <Prompt.Content>
+          <Prompt.Header>
+            <Prompt.Title>
+              Clear {drafts.length} abandoned draft
+              {drafts.length === 1 ? "" : "s"}?
+            </Prompt.Title>
+            <Prompt.Description>
+              These hops were planned and never booked, so nothing is being
+              undone with a carrier. Each row is marked cancelled and stays on
+              the run as the record that a movement was planned and abandoned.
+            </Prompt.Description>
+          </Prompt.Header>
+          {/* Named, not just counted — "clear 4 drafts" is a number, and the
+              operator is agreeing to specific rows. */}
+          <div className="flex flex-col gap-y-1 px-6 pb-4">
+            {drafts.map((d) => (
+              <Text key={d.id} size="xsmall" className="text-ui-fg-subtle">
+                {d.quantity} × {locationName(d.from_location_id)} →{" "}
+                {locationName(d.to_location_id)} · {d.reason}
+              </Text>
+            ))}
+          </div>
+          <Prompt.Footer>
+            <Prompt.Cancel>Keep them</Prompt.Cancel>
+            <Prompt.Action onClick={handleClearDrafts} disabled={isClearing}>
+              Clear them
             </Prompt.Action>
           </Prompt.Footer>
         </Prompt.Content>

--- a/apps/backend/src/admin/components/production-runs/production-run-activity-timeline.tsx
+++ b/apps/backend/src/admin/components/production-runs/production-run-activity-timeline.tsx
@@ -1,10 +1,14 @@
 import { Badge, Button, Container, Heading, Text } from "@medusajs/ui"
-import { useState } from "react"
+import { ReactNode, useState } from "react"
 
 import {
   AdminProductionRunActivity,
   useProductionRunActivities,
 } from "../../hooks/api/production-runs"
+import {
+  useGoodsTransfers,
+  type AdminGoodsTransfer,
+} from "../../hooks/api/goods-transfers"
 
 /**
  * The run's activity stream (#1093 / #1228 / #1239).
@@ -35,7 +39,29 @@ const NOTABLE_KINDS = new Set([
   "reassignment_needed",
   "reminder_escalated",
   "reminder_retried_same_partner",
+  "goods_transfer_cancelled",
 ])
+
+/**
+ * The goods-movement kinds (#1246 / #891 / #1542).
+ *
+ * 🔑 `_received` and `_delivered` are listed here BEFORE anything writes them.
+ * #891 S3 — the receive route — is still open, so no transfer can reach
+ * `delivered` today. Naming the kinds now means S3 ships a route and this
+ * timeline already renders it; the alternative is a second pass over this file
+ * by whoever writes S3, which is how a kind ends up rendering as
+ * "goods transfer received" in raw snake case forever.
+ */
+const TRANSFER_KINDS: Record<string, { dot: string; verb: string }> = {
+  goods_transfer_shipped: { dot: "bg-ui-tag-blue-icon", verb: "Shipped" },
+  goods_transfer_recorded: { dot: "bg-ui-tag-blue-icon", verb: "Recorded" },
+  goods_transfer_received: { dot: "bg-ui-tag-green-icon", verb: "Received" },
+  goods_transfer_delivered: { dot: "bg-ui-tag-green-icon", verb: "Delivered" },
+  goods_transfer_cancelled: { dot: "bg-ui-tag-red-icon", verb: "Cancelled" },
+}
+
+const isTransferKind = (kind?: string | null) =>
+  !!kind && kind in TRANSFER_KINDS
 
 const formatWhen = (value?: string | null) => {
   if (!value) return "-"
@@ -56,12 +82,17 @@ const formatKind = (kind?: string | null) =>
 /**
  * The few payload fields worth surfacing inline. Everything else stays in the
  * payload — this is a timeline, not a debugger.
+ *
+ * Transfer kinds carry their own richer block (see `TransferDetails`), so the
+ * fields it already prints — `reason`, the cancellation record — are skipped
+ * here rather than printed twice.
  */
 const detailLines = (activity: AdminProductionRunActivity): string[] => {
   const payload = activity.payload || {}
   const lines: string[] = []
+  const transfer = isTransferKind(activity.kind)
 
-  if (payload.reason) {
+  if (payload.reason && !transfer) {
     lines.push(`Reason: ${payload.reason}`)
   }
   if (payload.notes) {
@@ -70,7 +101,7 @@ const detailLines = (activity: AdminProductionRunActivity): string[] => {
   if (payload.rejection_reason) {
     lines.push(`Rejected: ${payload.rejection_reason}`)
   }
-  if (payload.cancelled_reason) {
+  if (payload.cancelled_reason && !transfer) {
     lines.push(`Cancelled: ${payload.cancelled_reason}`)
   }
   if (activity.kind === "output_corrected" && payload.quantity != null) {
@@ -80,6 +111,167 @@ const detailLines = (activity: AdminProductionRunActivity): string[] => {
     lines.push(`Template: ${activity.template_name}`)
   }
   return lines
+}
+
+const shortDate = (value?: string | null) => {
+  if (!value) return null
+  const d = new Date(value)
+  if (Number.isNaN(d.getTime())) return null
+  return d.toLocaleDateString("en-US", { month: "short", day: "numeric" })
+}
+
+/**
+ * One end of a cancelled → re-booked chain, said in words rather than as an id.
+ *
+ * 🔑 The raw `gtrf_01KZP7C2SJ…` the section prints is technically the answer and
+ * practically unreadable — two 26-character ULIDs differing in the middle are
+ * the same string to a human eye. Given the transfer we can say what it WAS,
+ * which is the thing an operator is actually trying to establish: that the
+ * 4 units on this row are the same 4 units that failed a fortnight ago, not
+ * four more.
+ *
+ * Falls back to the id when the transfer is not in the list (deleted, or a
+ * chain that reaches off this run) — an unresolvable id is still better than
+ * dropping the link silently.
+ */
+const describeTransfer = (
+  id: string,
+  byId: Map<string, AdminGoodsTransfer>
+): string => {
+  const t = byId.get(id)
+  if (!t) return id
+  const when = shortDate(t.shipped_at || t.created_at)
+  const units = `${t.quantity} unit${Number(t.quantity) === 1 ? "" : "s"}`
+  return `the ${units} hop${when ? ` of ${when}` : ""} (${t.status.replace("_", " ")})`
+}
+
+/**
+ * The goods-movement block: the lane, the waybill, the chain, the assertion.
+ *
+ * The activity `summary` already reads as a sentence — "4 units shipped
+ * Shramdaan → Dharamshala via Delhivery (AWB 41712510000114)" — so this does
+ * not repeat it. It adds what a sentence cannot carry: a clickable waybill, the
+ * link to the hop this one replaces, and the fact that a carrier cancellation
+ * is an ASSERTION somebody made rather than something we observed.
+ */
+const TransferDetails = ({
+  activity,
+  byId,
+}: {
+  activity: AdminProductionRunActivity
+  byId: Map<string, AdminGoodsTransfer>
+}): ReactNode => {
+  const payload = (activity.payload || {}) as Record<string, any>
+  const transferId = payload.goods_transfer_id
+    ? String(payload.goods_transfer_id)
+    : null
+  const transfer = transferId ? byId.get(transferId) : undefined
+  const meta = (transfer?.metadata ?? {}) as Record<string, any>
+
+  const awb = payload.awb ? String(payload.awb) : null
+  const trackingUrl = payload.tracking_url ? String(payload.tracking_url) : null
+  const carrier = payload.carrier ? String(payload.carrier) : null
+
+  const replaces = payload.replaces_transfer_id ?? meta.replaces_transfer_id
+  const replacedBy = meta.replaced_by_transfer_id
+
+  const cancellationReason =
+    payload.cancellation_reason ?? meta.cancellation_reason
+  const asserted =
+    payload.carrier_cancellation_asserted ?? meta.carrier_cancellation_asserted
+
+  /**
+   * A shortfall on receipt. Nothing writes this yet (#891 S3), but the shape is
+   * the same one `received_quantity` already has on the model, so it renders
+   * the day the route lands.
+   */
+  const received = payload.received_quantity ?? transfer?.received_quantity
+  const shortfall =
+    received != null &&
+    payload.quantity != null &&
+    Number(received) < Number(payload.quantity)
+
+  const rows: ReactNode[] = []
+
+  if (carrier || awb) {
+    rows.push(
+      <span key="awb">
+        {carrier && <span className="capitalize">{carrier}</span>}
+        {carrier && awb && " · "}
+        {awb &&
+          (trackingUrl ? (
+            <a
+              href={trackingUrl}
+              target="_blank"
+              rel="noreferrer noopener"
+              className="text-ui-fg-interactive hover:text-ui-fg-interactive-hover underline"
+            >
+              AWB {awb}
+            </a>
+          ) : (
+            <>AWB {awb}</>
+          ))}
+      </span>
+    )
+  }
+
+  if (payload.reason) {
+    rows.push(<span key="reason">Reason: {String(payload.reason)}</span>)
+  }
+
+  if (received != null) {
+    rows.push(
+      <span key="received" className={shortfall ? "text-ui-fg-error" : undefined}>
+        Received {String(received)} of {String(payload.quantity ?? "?")}
+        {shortfall ? " — short" : ""}
+      </span>
+    )
+  }
+
+  if (replaces) {
+    rows.push(
+      <span key="replaces" title={String(replaces)}>
+        Re-books {describeTransfer(String(replaces), byId)}
+      </span>
+    )
+  }
+  if (replacedBy) {
+    rows.push(
+      <span key="replacedBy" title={String(replacedBy)}>
+        Replaced by {describeTransfer(String(replacedBy), byId)}
+      </span>
+    )
+  }
+
+  if (cancellationReason) {
+    rows.push(<span key="why">Cancelled: {String(cancellationReason)}</span>)
+  }
+
+  /**
+   * 🔴 The provenance line, and the reason the timeline is the right home for
+   * it. `POST .../cancel` does NOT call the carrier — it records that a human
+   * says the carrier already did. An operator who read this row as a carrier
+   * fact would stop chasing a waybill that is still live.
+   */
+  if (asserted) {
+    rows.push(
+      <span key="asserted" className="italic">
+        Recorded by an admin — the carrier was not called.
+      </span>
+    )
+  }
+
+  if (!rows.length) return null
+
+  return (
+    <>
+      {rows.map((row, i) => (
+        <Text key={i} size="xsmall" className="text-ui-fg-muted mt-0.5">
+          {row}
+        </Text>
+      ))}
+    </>
+  )
 }
 
 export const ProductionRunActivityTimeline = ({ runId }: { runId: string }) => {
@@ -94,6 +286,29 @@ export const ProductionRunActivityTimeline = ({ runId }: { runId: string }) => {
     runId,
     { limit },
     { enabled: !!runId }
+  )
+
+  /**
+   * The transfers, to resolve a chain into words and to reach metadata the
+   * activity payload never carried.
+   *
+   * 🔑 This costs nothing: `GoodsTransferSection` on the same page already runs
+   * this exact query, and react-query dedupes on the key
+   * (`goodsTransferQueryKeys.list(runId)`). It is one request, read twice.
+   *
+   * It is also why the #891 pair — cancelled 25 Aug, re-booked the same day,
+   * both rows already in the database — reads as a chain here without any
+   * backfill. `replaces_transfer_id` was never written into the ACTIVITY
+   * payload, only onto the transfer, so an implementation that read the payload
+   * alone would render nothing for every hop that exists today and look correct
+   * doing it.
+   */
+  const { goods_transfers: transfers = [] } = useGoodsTransfers(runId, {
+    enabled: !!runId,
+  } as any)
+
+  const transfersById = new Map<string, AdminGoodsTransfer>(
+    (transfers as AdminGoodsTransfer[]).map((t) => [t.id, t])
   )
 
   return (
@@ -146,12 +361,15 @@ export const ProductionRunActivityTimeline = ({ runId }: { runId: string }) => {
             {activities.map((activity) => {
               const lines = detailLines(activity)
               const notable = NOTABLE_KINDS.has(activity.kind)
+              const transferKind = TRANSFER_KINDS[activity.kind]
 
               return (
                 <div key={activity.id} className="relative flex gap-3">
                   <div
                     className={`mt-[6px] h-[7px] w-[7px] shrink-0 rounded-full ring-2 ring-ui-bg-base ${
-                      DOT_CLASS[activity.activity_type] || DOT_CLASS.system
+                      transferKind?.dot ||
+                      DOT_CLASS[activity.activity_type] ||
+                      DOT_CLASS.system
                     }`}
                   />
                   <div className="flex-1">
@@ -173,7 +391,16 @@ export const ProductionRunActivityTimeline = ({ runId }: { runId: string }) => {
                           admin
                         </Badge>
                       )}
+                      {transferKind && (
+                        <Badge size="2xsmall" color="grey">
+                          {transferKind.verb}
+                        </Badge>
+                      )}
                     </div>
+
+                    {transferKind && (
+                      <TransferDetails activity={activity} byId={transfersById} />
+                    )}
 
                     {lines.map((line, i) => (
                       <Text

--- a/apps/backend/src/api/admin/ops/maintenance-jobs/__tests__/recover-whatsapp-media.unit.spec.ts
+++ b/apps/backend/src/api/admin/ops/maintenance-jobs/__tests__/recover-whatsapp-media.unit.spec.ts
@@ -1,0 +1,76 @@
+import {
+  isUnrecoveredMetaMediaUrl,
+  resolveMetaMediaId,
+} from "../recover-whatsapp-media-job"
+
+/**
+ * The two decisions that pick which photographs get re-fetched from Meta, and
+ * which id is used. Both operate on a URL shape Meta owns and can change, so
+ * they are the parts worth pinning.
+ */
+
+describe("isUnrecoveredMetaMediaUrl", () => {
+  it("recognises the lookaside URL that has been sitting in every stale row", () => {
+    expect(
+      isUnrecoveredMetaMediaUrl(
+        "https://lookaside.fbsbx.com/whatsapp_business/attachments/?mid=1451191166854891&source=getMedia&ext=1787661397&hash=ATwz"
+      )
+    ).toBe(true)
+  })
+
+  it("leaves our own stored URLs alone", () => {
+    expect(
+      isUnrecoveredMetaMediaUrl("https://media.jaalyantra.com/whatsapp/abc.jpg")
+    ).toBe(false)
+  })
+
+  it("matches on the HOST, not on the substring", () => {
+    // 🔑 A naive `includes("fbsbx")` would re-fetch this and OVERWRITE a
+    // perfectly good stored file with whatever Meta returned for the id.
+    expect(
+      isUnrecoveredMetaMediaUrl(
+        "https://media.jaalyantra.com/uploads/from-fbsbx.com-export.jpg"
+      )
+    ).toBe(false)
+  })
+
+  it("treats absent and unparseable values as nothing to do", () => {
+    expect(isUnrecoveredMetaMediaUrl(null)).toBe(false)
+    expect(isUnrecoveredMetaMediaUrl("")).toBe(false)
+    expect(isUnrecoveredMetaMediaUrl("not a url")).toBe(false)
+  })
+})
+
+describe("resolveMetaMediaId", () => {
+  it("prefers the stored column over the URL", () => {
+    // The column is the recorded fact; the URL shape is Meta's to change.
+    expect(
+      resolveMetaMediaId({
+        media_id: "999",
+        media_url: "https://lookaside.fbsbx.com/x/?mid=111",
+      })
+    ).toBe("999")
+  })
+
+  it("falls back to mid= for rows written before the column existed", () => {
+    expect(
+      resolveMetaMediaId({
+        media_id: null,
+        media_url:
+          "https://lookaside.fbsbx.com/whatsapp_business/attachments/?mid=1451191166854891&source=getMedia",
+      })
+    ).toBe("1451191166854891")
+  })
+
+  it("returns null rather than a guess when there is neither", () => {
+    // 🔑 Null is what makes the job REPORT the row instead of inventing an id
+    // and asking Meta about a photograph that was never ours.
+    expect(resolveMetaMediaId({ media_id: null, media_url: null })).toBeNull()
+    expect(
+      resolveMetaMediaId({
+        media_id: "   ",
+        media_url: "https://lookaside.fbsbx.com/x/?source=getMedia",
+      })
+    ).toBeNull()
+  })
+})

--- a/apps/backend/src/api/admin/ops/maintenance-jobs/recover-whatsapp-media-job.ts
+++ b/apps/backend/src/api/admin/ops/maintenance-jobs/recover-whatsapp-media-job.ts
@@ -1,0 +1,279 @@
+import { ContainerRegistrationKeys, MedusaError } from "@medusajs/framework/utils"
+import { z } from "zod"
+
+import { MESSAGING_MODULE } from "../../../../modules/messaging"
+import { downloadAndSaveWhatsAppMedia } from "../../../../workflows/whatsapp/whatsapp-media-helper"
+import type {
+  MaintenanceChange,
+  MaintenanceJob,
+  MaintenanceJobResult,
+} from "./registry"
+
+/**
+ * Re-fetch inbound WhatsApp media whose stored URL is Meta's, not ours.
+ *
+ * ## What went wrong
+ *
+ * `messaging_message.media_url` is written at row-creation time with the
+ * `lookaside.fbsbx.com` URL Meta puts in the webhook, and is meant to be
+ * overwritten with our own once the bytes are downloaded. Two paths left it
+ * un-overwritten:
+ *
+ *   1. **The consent gate returned first.** It sits before the media branch, so
+ *      anything sent before the partner agreed was never downloaded. On
+ *      2026-08-25 ten photographs from Bhagalpur Handloom SHG arrived in a
+ *      two-second burst twenty-eight seconds before consent was recorded.
+ *   2. **A newest-row race.** The post-download update matched "the newest row
+ *      in this conversation" against the message being handled; in a burst the
+ *      newest row is usually a different photograph, so the update silently
+ *      landed nowhere.
+ *
+ * Both are fixed forward. This is for the rows already written.
+ *
+ * ## 🔴 Why it is urgent
+ *
+ * A lookaside URL 401s without a bearer token AND carries an `ext=` expiry
+ * about five minutes out, so those rows have been broken thumbnails since
+ * minutes after they arrived. Meta retains the underlying media about **30
+ * days** — after that the photographs are gone for good. This job is worth
+ * running promptly and worth nothing at all a month late.
+ *
+ * ## Where the id comes from
+ *
+ * `media_id` is a real column now, but rows written before it exists have only
+ * the URL — which embeds `mid=<id>`. That is parsed as a FALLBACK, and only as
+ * one: Meta may reshape the URL whenever it likes, and a parser is not a
+ * schema. Anything with neither is reported, not guessed at.
+ */
+
+/** Hard cap per call — bounds both blast radius and Meta API spend. */
+export const MAX_MEDIA_RECOVERY_SCAN = 500
+
+const paramsSchema = z.object({
+  /** Restrict to one conversation (default: every conversation). */
+  conversation_id: z.string().min(1).optional(),
+  limit: z
+    .number()
+    .int()
+    .positive()
+    .max(MAX_MEDIA_RECOVERY_SCAN)
+    .optional()
+    .default(100),
+})
+
+/**
+ * PURE: is this row holding a URL only Meta can serve?
+ *
+ * Matched on the HOST, not on the presence of "fbsbx" anywhere in the string —
+ * a URL of ours that happened to contain that substring (a filename, a query
+ * parameter) would otherwise be re-fetched and overwritten.
+ */
+export function isUnrecoveredMetaMediaUrl(url: unknown): boolean {
+  const value = String(url ?? "").trim()
+  if (!value) return false
+  try {
+    const host = new URL(value).hostname.toLowerCase()
+    return host === "lookaside.fbsbx.com" || host.endsWith(".fbsbx.com")
+  } catch {
+    return false
+  }
+}
+
+/**
+ * PURE: the Meta media id for a row.
+ *
+ * The column first — it is the recorded fact. The URL's `mid=` only when there
+ * is no column value, because parsing a third party's URL shape is a guess that
+ * happens to work today.
+ */
+export function resolveMetaMediaId(row: {
+  media_id?: string | null
+  media_url?: string | null
+}): string | null {
+  const stored = String(row?.media_id ?? "").trim()
+  if (stored) return stored
+
+  const url = String(row?.media_url ?? "").trim()
+  if (!url) return null
+  try {
+    const mid = new URL(url).searchParams.get("mid")
+    const trimmed = String(mid ?? "").trim()
+    return trimmed || null
+  } catch {
+    return null
+  }
+}
+
+export const recoverWhatsappMediaJob: MaintenanceJob = {
+  id: "recover-whatsapp-media",
+  label: "Re-download inbound WhatsApp media still pointing at Meta",
+  description:
+    `Re-fetch inbound WhatsApp photographs whose messaging_message.media_url is still Meta's lookaside.fbsbx.com URL rather than ours. Those URLs 401 without a bearer token and expire about FIVE MINUTES after the message arrives, so every such row has been a broken thumbnail since shortly after it was received. Two paths produced them: the consent gate returns before the media branch runs (so anything sent before a partner agreed was never downloaded), and a newest-row race in the post-download update meant a burst of photos updated the wrong row or none. Both are fixed forward; this repairs the rows already written. 🔴 TIME-LIMITED: Meta retains the underlying media about 30 days, after which the photographs cannot be recovered at all. The media id is read from the media_id column, falling back to parsing mid= out of the stored URL for rows written before that column existed; a row with neither is reported rather than guessed at. Dry-run lists every row it would re-fetch WITHOUT calling Meta. Scans up to 'limit' rows per call (default 100, max ${MAX_MEDIA_RECOVERY_SCAN}).`,
+  params: [
+    {
+      name: "conversation_id",
+      type: "string",
+      required: false,
+      description: "Restrict to a single conversation (default: all)",
+    },
+    {
+      name: "limit",
+      type: "number",
+      required: false,
+      description: `Max rows to scan in one call (default 100, max ${MAX_MEDIA_RECOVERY_SCAN})`,
+    },
+  ],
+  run: async (container, { dry_run, params }): Promise<MaintenanceJobResult> => {
+    const parsed = paramsSchema.safeParse(params)
+    if (!parsed.success) {
+      throw new MedusaError(
+        MedusaError.Types.INVALID_DATA,
+        parsed.error.issues.map((i) => i.message).join("; ")
+      )
+    }
+    const { conversation_id, limit } = parsed.data
+
+    const logger: any = container.resolve(ContainerRegistrationKeys.LOGGER)
+    const messagingService: any = container.resolve(MESSAGING_MODULE)
+
+    const filters: Record<string, unknown> = { message_type: "media", direction: "inbound" }
+    if (conversation_id) filters.conversation_id = conversation_id
+
+    const rows: any[] = await messagingService.listMessagingMessages(filters, {
+      take: limit,
+      order: { created_at: "DESC" },
+    })
+
+    /**
+     * The owning partner per conversation.
+     *
+     * 🔴 Needed because `downloadAndSaveWhatsAppMedia` files the photograph in
+     * that PARTNER's folder. Passing the conversation id in the partner slot
+     * would have created a folder named after a conversation — the file would
+     * exist, and be exactly as unattributable as the WhatsApp inbox this whole
+     * feature was built to escape.
+     */
+    const conversationIds = [
+      ...new Set(rows.map((r) => r?.conversation_id).filter(Boolean)),
+    ]
+    const conversations: any[] = conversationIds.length
+      ? await messagingService.listMessagingConversations({
+          id: conversationIds,
+        })
+      : []
+    const partnerByConversation = new Map<string, string>(
+      conversations
+        .filter((c: any) => c?.id && c?.partner_id)
+        .map((c: any) => [c.id, c.partner_id])
+    )
+
+    /**
+     * Filtered in memory rather than by a `like` on the URL: the module service
+     * has no operator for it, and a hand-rolled SQL predicate on a third
+     * party's URL shape is the same guess this job exists to avoid.
+     */
+    const stale = rows.filter((r) => isUnrecoveredMetaMediaUrl(r?.media_url))
+
+    const changes: MaintenanceChange[] = []
+    const errors: Array<{ id: string; message: string }> = []
+    let recovered = 0
+
+    for (const row of stale) {
+      const mediaId = resolveMetaMediaId(row)
+      if (!mediaId) {
+        errors.push({
+          id: row.id,
+          message:
+            "No media_id on the row and no mid= in the stored URL — this photograph cannot be recovered.",
+        })
+        continue
+      }
+
+      const partnerId = partnerByConversation.get(row.conversation_id)
+      if (!partnerId) {
+        // Refuse rather than file it somewhere plausible. A photograph in the
+        // wrong partner's folder is worse than one still missing: it is
+        // evidence attributed to someone who did not send it.
+        errors.push({
+          id: row.id,
+          message: `Conversation ${row.conversation_id} has no partner_id — refusing to file this photograph against a guess.`,
+        })
+        continue
+      }
+
+      if (dry_run) {
+        changes.push({
+          entity: "messaging_message",
+          id: row.id,
+          field: `media_url (media_id ${mediaId}, partner ${partnerId})`,
+          before: row.media_url,
+          after: "would re-fetch from Meta",
+        })
+        continue
+      }
+
+      try {
+        /**
+         * 🔴 `mediaUrl` is deliberately NOT passed. The stored one is the dead
+         * lookaside URL; handing it over would make the helper try it, fail,
+         * and report a failure that looks like Meta losing the media rather
+         * than us sending a stale URL. Omitting it makes the helper mint a
+         * fresh one from the id, which is the whole point.
+         */
+        const saved = await downloadAndSaveWhatsAppMedia(container as any, {
+          mediaId,
+          mimeType: row.media_mime_type || undefined,
+          partnerId,
+          partnerName: row.sender_name || "WhatsApp",
+        })
+
+        if (!saved?.fileUrl) {
+          errors.push({
+            id: row.id,
+            message: `Meta returned nothing for media ${mediaId} — most likely past the ~30-day retention window.`,
+          })
+          continue
+        }
+
+        await messagingService.updateMessagingMessages({
+          id: row.id,
+          media_url: saved.fileUrl,
+          media_mime_type: saved.mimeType,
+          media_id: mediaId,
+          media_pending_reason: null,
+        })
+
+        changes.push({
+          entity: "messaging_message",
+          id: row.id,
+          field: "media_url",
+          before: row.media_url,
+          after: saved.fileUrl,
+        })
+        recovered++
+      } catch (e: any) {
+        errors.push({ id: row.id, message: e?.message ?? String(e) })
+        logger?.warn?.(
+          `[recover-whatsapp-media] ${row.id} (media ${mediaId}) failed: ${e?.message ?? e}`
+        )
+      }
+    }
+
+    const summary = dry_run
+      ? `Would re-fetch ${changes.length} of ${stale.length} stale media row(s) (${rows.length} inbound media scanned)${
+          errors.length ? `; ${errors.length} cannot be recovered` : ""
+        }.`
+      : `Recovered ${recovered} of ${stale.length} stale media row(s) (${rows.length} inbound media scanned)${
+          errors.length ? `; ${errors.length} failed` : ""
+        }.`
+
+    return {
+      job_id: "recover-whatsapp-media",
+      dry_run,
+      applied: !dry_run && recovered > 0,
+      summary,
+      changes,
+      ...(errors.length ? { errors } : {}),
+    }
+  },
+}

--- a/apps/backend/src/api/admin/ops/maintenance-jobs/registry.ts
+++ b/apps/backend/src/api/admin/ops/maintenance-jobs/registry.ts
@@ -83,6 +83,7 @@ import { backfillQuoteTenancyJob } from "./backfill-quote-tenancy-job"
 import { backfillStoreCurrenciesJob } from "./backfill-store-currencies-job"
 import { backfillShiprocketShippingOptionsJob } from "./backfill-shiprocket-shipping-options-job"
 import { backfillFreightOptionDataJob } from "./backfill-freight-option-data-job"
+import { recoverWhatsappMediaJob } from "./recover-whatsapp-media-job"
 import { capFreeShippingBandJob } from "./cap-free-shipping-band-job"
 import { deleteOrphanStoreJob } from "./delete-orphan-store-job"
 import { restoreOrphanStoreJob } from "./restore-orphan-store-job"
@@ -5778,6 +5779,7 @@ export const MAINTENANCE_JOBS: MaintenanceJob[] = [
   backfillStoreCurrenciesJob,
   backfillShiprocketShippingOptionsJob,
   backfillFreightOptionDataJob,
+  recoverWhatsappMediaJob,
   capFreeShippingBandJob,
   deleteOrphanStoreJob,
   restoreOrphanStoreJob,

--- a/apps/backend/src/api/middlewares.ts
+++ b/apps/backend/src/api/middlewares.ts
@@ -2598,6 +2598,21 @@ export default defineMiddlewares({
         adaptMulter(mediaUpload.array("files")),
       ],
     },
+    // Capability-sample photographs (#1543). Same multipart shape and the same
+    // reasons: bodyParser OFF because multer owns the body (Medusa already
+    // parses urlencoded on every route, and a second parser on a stream whose
+    // `end` has fired HANGS the request), and disk-backed because a weaver
+    // attaching four phone photos at once is tens of MB.
+    {
+      matcher: "/partners/capabilities/uploads",
+      method: "POST",
+      bodyParser: false,
+      middlewares: [
+        createCorsPartnerMiddleware(),
+        authenticate("partner", ["session", "bearer"]),
+        adaptMulter(mediaUpload.array("files")),
+      ],
+    },
     // Partner assistant context compaction — the client calls this when the
     // chat approaches the model's context window; the route returns a short
     // summary the client stores in place of the older turns.

--- a/apps/backend/src/api/partners/capabilities/route.ts
+++ b/apps/backend/src/api/partners/capabilities/route.ts
@@ -3,6 +3,7 @@ import { MedusaError } from "@medusajs/framework/utils"
 
 import { PARTNER_CAPABILITY_MODULE } from "../../../modules/partner_capability"
 import { getPartnerFromAuthContext } from "../helpers"
+import { resolveMediaFiles } from "../media-urls"
 import type {
   PartnerListCapabilitySamplesQuery,
   PartnerPostCapabilitySampleReq,
@@ -53,8 +54,33 @@ export const GET = async (req: AuthenticatedMedusaRequest, res: MedusaResponse) 
     }
   )
 
-  return res.json({ samples: samples ?? [], count })
+  const withMedia = await attachMediaUrls(req.scope, samples ?? [])
+
+  return res.json({ samples: withMedia, count })
 }
+
+/**
+ * Attach renderable `media` to each sample.
+ *
+ * 🔴 Without this the library is WRITE-ONLY. The row stores `media_file_ids`,
+ * the wizard gets `{ id, url }` back from its own upload and happily renders
+ * the photo it just chose — and then the partner reloads and every attachment
+ * is an empty square, because an id is not a URL and nothing on the read path
+ * ever turned one into the other. That failure appears only after a refresh,
+ * which is exactly the moment nobody tests.
+ *
+ * See `resolveMediaFiles`: the moodboard had the identical defect.
+ */
+const attachMediaUrls = async (scope: any, samples: any[]): Promise<any[]> =>
+  Promise.all(
+    samples.map(async (s) => ({
+      ...s,
+      media: await resolveMediaFiles(
+        scope,
+        Array.isArray(s?.media_file_ids) ? s.media_file_ids : []
+      ),
+    }))
+  )
 
 /**
  * POST /partners/capabilities — record something they have actually made.
@@ -96,8 +122,14 @@ export const POST = async (
     captured_at: capturedAt,
   } as any)
 
+  // Resolved here too, so a caller rendering from the create response and one
+  // rendering from the listing see the SAME shape. Two shapes for one row is
+  // how a `media` key ends up read as `media_files` on one screen and silently
+  // renders nothing.
+  const [withMedia] = await attachMediaUrls(req.scope, [sample])
+
   return res.status(201).json({
-    sample,
+    sample: withMedia ?? sample,
     captured_at_defaulted: !body.captured_at,
   })
 }

--- a/apps/backend/src/api/partners/capabilities/uploads/folder.ts
+++ b/apps/backend/src/api/partners/capabilities/uploads/folder.ts
@@ -1,0 +1,92 @@
+/**
+ * The folder a partner's capability photographs land in.
+ *
+ * `partner_capability_sample.media_file_ids` says "media_file ids", and it
+ * means it: a photograph that proves a partner can weave kani has to be
+ * findable in six months, when exactly that fabric is wanted again. The
+ * pre-existing `/partners/medias/uploads/*` pair puts objects at the BUCKET
+ * ROOT and writes no media record, so a photo uploaded that way is
+ * unattributable the moment the request ends — which is the state the
+ * WhatsApp inbox was already in and the whole reason this table exists.
+ *
+ * 🔑 A SEPARATE folder from the assistant's, not a shared "partner uploads"
+ * one. The two have different lifetimes and different meanings: an assistant
+ * attachment is context for one conversation, a capability sample is a
+ * library entry that deliberately outlives the inquiry that produced it.
+ * Pooling them would make the library unbrowsable within a season.
+ *
+ * The ensure/slug/link mechanics are the assistant folder's, deliberately —
+ * `linkFolderToPartnerPeople` is imported rather than copied, because the two
+ * copies would drift the first time the access model changed.
+ */
+import type { MedusaContainer } from "@medusajs/framework/types"
+
+import { MEDIA_MODULE } from "../../../../modules/media"
+import {
+  linkFolderToPartnerPeople,
+  type PartnerLike,
+} from "../../assistant/attachments/folder"
+
+/** Marker on folder.metadata, so ownership survives without the person link. */
+export const PARTNER_CAPABILITY_FOLDER_PURPOSE = "partner_capability_samples"
+
+/**
+ * Deterministic slug, derived from the partner ID and not the name.
+ *
+ * `folder.slug` is UNIQUE and two partners can share a display name while one
+ * of them may rename itself later; an id-derived slug is stable across both,
+ * and it is the lookup key for "does this partner already have a folder?", so
+ * deriving it differently in two places would silently accumulate folders.
+ */
+export const capabilityFolderSlug = (partnerId: string): string =>
+  `partner-capabilities-${String(partnerId).trim()}`
+
+export const capabilityFolderName = (partnerName?: string | null): string => {
+  const trimmed = String(partnerName ?? "").trim()
+  return trimmed ? `Capability samples — ${trimmed}` : "Capability samples"
+}
+
+export const capabilityFolderPath = (partnerId: string): string =>
+  `/${capabilityFolderSlug(partnerId)}`
+
+/**
+ * The folder id, creating it on first use. Idempotent: on a unique-slug
+ * collision the folder is re-read rather than the upload being failed, so two
+ * photos picked at once converge on one folder instead of racing.
+ */
+export const ensurePartnerCapabilityFolder = async (
+  container: MedusaContainer,
+  partner: PartnerLike
+): Promise<string> => {
+  const mediaService: any = container.resolve(MEDIA_MODULE)
+  const slug = capabilityFolderSlug(partner.id)
+
+  const existing = await mediaService.listFolders({ slug })
+  if (existing?.length) {
+    return existing[0].id
+  }
+
+  let folder: any
+  try {
+    folder = await mediaService.createFolders({
+      name: capabilityFolderName(partner.name),
+      slug,
+      description:
+        "Photographs of what this partner has actually made, evidencing their capability answers.",
+      path: capabilityFolderPath(partner.id),
+      level: 0,
+      is_public: false,
+      metadata: {
+        partner_id: partner.id,
+        purpose: PARTNER_CAPABILITY_FOLDER_PURPOSE,
+      },
+    })
+  } catch (e: any) {
+    const retry = await mediaService.listFolders({ slug })
+    if (retry?.length) return retry[0].id
+    throw e
+  }
+
+  await linkFolderToPartnerPeople(container, partner.id, folder.id)
+  return folder.id
+}

--- a/apps/backend/src/api/partners/capabilities/uploads/route.ts
+++ b/apps/backend/src/api/partners/capabilities/uploads/route.ts
@@ -1,0 +1,162 @@
+/**
+ * POST /partners/capabilities/uploads
+ *
+ * The photograph half of a capability sample (#1543 / #1531 slice 2).
+ *
+ * The inquiry wizard has always had a `photo` question kind, and the answer
+ * model has always carried `capability_sample_ids` — "the useful part of yes is
+ * the photograph proving it". Until now the wizard rendered that question as a
+ * sentence apologising for itself: *"Send the photo in your reply and we will
+ * attach it here."* So the one question whose answer cannot be typed was the
+ * one question that sent the partner back to WhatsApp, which is the exact loop
+ * #1531 exists to close.
+ *
+ * This returns `media_id` + `url` for each file. The caller then creates the
+ * sample (`POST /partners/capabilities`) with those ids and attaches the sample
+ * to an answer — two steps rather than one, because a sample OUTLIVES the
+ * inquiry that produced it and the partner may attach an existing one instead
+ * of a new photograph.
+ *
+ * Files arrive as multipart `files`; content is handed to the workflow as
+ * BASE64, not "binary"/latin1 — the file provider round-trips it through
+ * `Buffer.from(content, "base64")` and silently UTF-8-corrupts every byte
+ * >= 0x80 otherwise (#769).
+ */
+import {
+  AuthenticatedMedusaRequest,
+  MedusaResponse,
+} from "@medusajs/framework/http"
+import { ContainerRegistrationKeys, MedusaError } from "@medusajs/framework/utils"
+import fs from "fs"
+
+import { uploadAndOrganizeMediaWorkflow } from "../../../../workflows/media/upload-and-organize-media"
+import { getPartnerFromAuthContext } from "../../helpers"
+import { ensurePartnerCapabilityFolder } from "./folder"
+
+/**
+ * Images only. A capability sample is evidence somebody LOOKS at — a PDF spec
+ * sheet or a video would be stored, listed, and then silently render as a
+ * broken thumbnail in every surface that shows the library.
+ */
+const ALLOWED_MIME = /^image\/(jpeg|jpg|png|webp|gif|heic|heif)$/i
+
+/** Per-request cap. The composer enforces its own; this is the backstop. */
+const MAX_FILES = 10
+
+export const POST = async (
+  req: AuthenticatedMedusaRequest & { files?: Express.Multer.File[] },
+  res: MedusaResponse
+) => {
+  const logger: any = req.scope.resolve(ContainerRegistrationKeys.LOGGER)
+
+  const partner = await getPartnerFromAuthContext(req.auth_context, req.scope)
+  if (!partner?.id) {
+    throw new MedusaError(
+      MedusaError.Types.UNAUTHORIZED,
+      "No partner associated with this account"
+    )
+  }
+
+  const uploaded: Express.Multer.File[] = Array.isArray(req.files)
+    ? (req.files as Express.Multer.File[])
+    : (req as any).file
+      ? [(req as any).file as Express.Multer.File]
+      : []
+
+  if (!uploaded.length) {
+    throw new MedusaError(
+      MedusaError.Types.INVALID_DATA,
+      "No files were uploaded"
+    )
+  }
+  if (uploaded.length > MAX_FILES) {
+    throw new MedusaError(
+      MedusaError.Types.INVALID_DATA,
+      `Too many files in one request (max ${MAX_FILES}).`
+    )
+  }
+
+  const rejected = uploaded.filter((f) => !ALLOWED_MIME.test(f.mimetype || ""))
+  if (rejected.length) {
+    throw new MedusaError(
+      MedusaError.Types.INVALID_DATA,
+      `Only photographs can be attached. Rejected: ${rejected
+        .map((f) => `${f.originalname} (${f.mimetype || "unknown type"})`)
+        .join(", ")}`
+    )
+  }
+
+  const folderId = await ensurePartnerCapabilityFolder(req.scope, {
+    id: partner.id,
+    name: (partner as any).name,
+  })
+
+  const files = uploaded.map((file) => {
+    const buf = (file as any).buffer
+    const path = (file as any).path
+    const content = Buffer.isBuffer(buf)
+      ? buf.toString("base64")
+      : typeof path === "string"
+        ? fs.readFileSync(path).toString("base64")
+        : ""
+    return {
+      filename: file.originalname,
+      mimeType: file.mimetype,
+      content,
+      ...(typeof path === "string" ? { _tempPath: path } : {}),
+    } as any
+  })
+
+  try {
+    const { result } = await uploadAndOrganizeMediaWorkflow(req.scope).run({
+      input: {
+        files,
+        existingFolderId: folderId,
+        metadata: {
+          source: "partner_capability",
+          uploaded_by_partner_id: partner.id,
+          uploaded_by_partner_name: (partner as any).name ?? null,
+        },
+      },
+    })
+
+    const mediaFiles = (result as any)?.mediaFiles ?? []
+    const media = mediaFiles.map((m: any) => ({
+      media_id: m.id,
+      name: m.original_name || m.file_name,
+      type: m.mime_type,
+      url: m.file_path,
+    }))
+
+    /**
+     * 🔴 A stored row with no usable URL must fail LOUDLY.
+     *
+     * The id would be written into `media_file_ids` quite happily, the sample
+     * would list, and the library would show an empty square where the evidence
+     * is — a capability that reads as photographed and proves nothing. Refusing
+     * here costs one retry; accepting it costs the row's credibility for as
+     * long as it exists.
+     */
+    const urlless = media.filter((m: any) => !m.url)
+    if (urlless.length) {
+      throw new MedusaError(
+        MedusaError.Types.UNEXPECTED_STATE,
+        "The photograph was stored but no URL came back for it, so it has not been attached. Please try again."
+      )
+    }
+
+    return res.status(201).json({ folder_id: folderId, media })
+  } finally {
+    // Disk-backed multer writes to tmp; clean up regardless of outcome.
+    for (const file of uploaded) {
+      const p = (file as any).path
+      if (typeof p === "string") {
+        fs.promises.unlink(p).catch((e) =>
+          logger?.debug?.(
+            `[partners/capabilities/uploads] temp cleanup failed for ${p}: ${e?.message}`
+          )
+        )
+      }
+    }
+  }
+}

--- a/apps/backend/src/api/partners/inquiries/[inquiryId]/route.ts
+++ b/apps/backend/src/api/partners/inquiries/[inquiryId]/route.ts
@@ -10,6 +10,7 @@ import {
   loadInquiryForPartner,
 } from "../../../../modules/design_inquiry/lib/partner-inquiry-access"
 import { getPartnerFromAuthContext } from "../../helpers"
+import { resolveMediaFiles } from "../../media-urls"
 
 /**
  * GET /partners/inquiries/:inquiryId — the wizard, as this partner sees it.
@@ -43,9 +44,17 @@ export const GET = async (req: AuthenticatedMedusaRequest, res: MedusaResponse) 
 
   const query: any = req.scope.resolve(ContainerRegistrationKeys.QUERY)
 
-  const [questions, answers] = await Promise.all([
+  const [questions, answers, referenceMedia] = await Promise.all([
     listInquiryQuestions(req.scope, inquiry.id),
     listResponseAnswers(req.scope, response.id),
+    /**
+     * 🔴 The moodboard (#1543). `reference_media_ids` has been returned since
+     * this route was written, as bare ids — so a designer attached the
+     * references that explain what they are asking for, and the partner was
+     * asked "can you make this?" while being shown NOTHING. Nothing errored;
+     * the field was populated and the array was right there in the response.
+     */
+    resolveMediaFiles(req.scope, inquiry.reference_media_ids ?? []),
   ])
 
   let design: any = null
@@ -68,6 +77,8 @@ export const GET = async (req: AuthenticatedMedusaRequest, res: MedusaResponse) 
       title: inquiry.title,
       brief_note: inquiry.brief_note ?? null,
       reference_media_ids: inquiry.reference_media_ids ?? [],
+      /** Render from THIS. The ids above are what is stored, not what is shown. */
+      reference_media: referenceMedia,
       spec_version: inquiry.spec_version ?? null,
       status: inquiry.status,
       created_at: inquiry.created_at,

--- a/apps/backend/src/api/partners/media-urls.ts
+++ b/apps/backend/src/api/partners/media-urls.ts
@@ -1,0 +1,74 @@
+/**
+ * Turn `media_file` ids into something a browser can actually show.
+ *
+ * 🔴 Two partner-facing surfaces stored ids and served ids, which is
+ * write-only: an id is not a URL, and nothing on either read path ever turned
+ * one into the other.
+ *
+ *   · `partner_capability_sample.media_file_ids` — the partner uploads a
+ *     photograph, sees it (the upload response carries the URL), reloads, and
+ *     every attachment is an empty square.
+ *   · `design_inquiry.reference_media_ids` — the MOODBOARD. A designer attaches
+ *     the references that explain what they are asking for, the route returns
+ *     the ids, and the partner is asked "can you make this?" while being shown
+ *     nothing at all (#1543).
+ *
+ * Both failures are invisible from the write side and appear only on a screen,
+ * which is why one shared resolver rather than two: the next surface that
+ * stores media ids should not have to rediscover this.
+ */
+import { ContainerRegistrationKeys } from "@medusajs/framework/utils"
+
+import { MEDIA_MODULE } from "../../modules/media"
+
+export type ResolvedMedia = {
+  id: string
+  url: string
+  name?: string | null
+  type?: string | null
+}
+
+/**
+ * Best-effort, and deliberately so: a media row that has been deleted yields no
+ * entry rather than failing the whole listing. A library that still opens with
+ * one photograph missing is worth more than one that refuses to open, and the
+ * id list still records that something was attached.
+ *
+ * Order follows the ids as given — the sequence a moodboard was assembled in is
+ * part of what it says.
+ */
+export const resolveMediaFiles = async (
+  scope: any,
+  ids: Array<string | null | undefined> | null | undefined
+): Promise<ResolvedMedia[]> => {
+  const wanted = (ids ?? []).map((id) => String(id ?? "").trim()).filter(Boolean)
+  if (!wanted.length) return []
+
+  const logger: any = scope.resolve(ContainerRegistrationKeys.LOGGER)
+  try {
+    const mediaService: any = scope.resolve(MEDIA_MODULE)
+    const files = await mediaService.listMediaFiles({ id: [...new Set(wanted)] })
+    const byId = new Map((files ?? []).map((f: any) => [f.id, f]))
+
+    return wanted
+      .map((id) => {
+        const file: any = byId.get(id)
+        // No `file_path` means nothing renderable. Dropping it beats emitting
+        // `url: undefined`, which every consumer would faithfully put in an
+        // <img src> and display as a broken image.
+        if (!file?.file_path) return null
+        return {
+          id: file.id,
+          url: file.file_path,
+          name: file.original_name || file.file_name,
+          type: file.mime_type,
+        }
+      })
+      .filter(Boolean) as ResolvedMedia[]
+  } catch (e: any) {
+    logger?.warn?.(
+      `[partners] could not resolve media urls for ${wanted.length} id(s): ${e?.message ?? e}`
+    )
+    return []
+  }
+}

--- a/apps/backend/src/modules/messaging/migrations/.snapshot-messaging.json
+++ b/apps/backend/src/modules/messaging/migrations/.snapshot-messaging.json
@@ -121,6 +121,22 @@
           ],
           "mappedType": "enum"
         },
+        "default_sender_platform_id": {
+          "name": "default_sender_platform_id",
+          "type": "text",
+          "unsigned": false,
+          "autoincrement": false,
+          "primary": false,
+          "nullable": true,
+          "unique": false,
+          "length": null,
+          "precision": null,
+          "scale": null,
+          "default": null,
+          "comment": null,
+          "enumItems": [],
+          "mappedType": "text"
+        },
         "metadata": {
           "name": "metadata",
           "type": "jsonb",
@@ -354,7 +370,8 @@
             "sent",
             "delivered",
             "read",
-            "failed"
+            "failed",
+            "queued"
           ],
           "mappedType": "enum"
         },
@@ -438,6 +455,38 @@
           "enumItems": [],
           "mappedType": "text"
         },
+        "media_id": {
+          "name": "media_id",
+          "type": "text",
+          "unsigned": false,
+          "autoincrement": false,
+          "primary": false,
+          "nullable": true,
+          "unique": false,
+          "length": null,
+          "precision": null,
+          "scale": null,
+          "default": null,
+          "comment": null,
+          "enumItems": [],
+          "mappedType": "text"
+        },
+        "media_pending_reason": {
+          "name": "media_pending_reason",
+          "type": "text",
+          "unsigned": false,
+          "autoincrement": false,
+          "primary": false,
+          "nullable": true,
+          "unique": false,
+          "length": null,
+          "precision": null,
+          "scale": null,
+          "default": null,
+          "comment": null,
+          "enumItems": [],
+          "mappedType": "text"
+        },
         "reply_to_id": {
           "name": "reply_to_id",
           "type": "text",
@@ -469,6 +518,22 @@
           "comment": null,
           "enumItems": [],
           "mappedType": "json"
+        },
+        "fail_reason": {
+          "name": "fail_reason",
+          "type": "text",
+          "unsigned": false,
+          "autoincrement": false,
+          "primary": false,
+          "nullable": true,
+          "unique": false,
+          "length": null,
+          "precision": null,
+          "scale": null,
+          "default": null,
+          "comment": null,
+          "enumItems": [],
+          "mappedType": "text"
         },
         "metadata": {
           "name": "metadata",

--- a/apps/backend/src/modules/messaging/migrations/Migration20260825124753.ts
+++ b/apps/backend/src/modules/messaging/migrations/Migration20260825124753.ts
@@ -1,0 +1,33 @@
+import { Migration } from "@medusajs/framework/mikro-orm/migrations";
+
+/**
+ * `media_id` + `media_pending_reason` on `messaging_message`.
+ *
+ * Inbound WhatsApp media was persisted holding Meta's own
+ * `lookaside.fbsbx.com` URL, which 401s without a bearer token and carries an
+ * `ext=` expiry about five minutes out. When the download did not happen —
+ * because the sender had not consented yet, and the consent gate returns
+ * before the download — the row was left pointing at a URL that was dead
+ * within minutes, with nothing recorded that could fetch the bytes later.
+ *
+ * `media_id` is that record: Meta retains the bytes ~30 days, so the id is a
+ * 30-day claim on a photograph whose URL lives five minutes.
+ *
+ * 🔑 Generated alongside `fail_reason`, `default_sender_platform_id` and a
+ * status-constraint rewrite, all of which the generator re-emitted from a
+ * stale snapshot — they already ship in Migration20260630140000 and
+ * Migration20260418010000. They are removed here deliberately: the `up` was
+ * harmless (`add column if not exists`), but the generated `down` would have
+ * DROPPED two columns this migration never created.
+ */
+export class Migration20260825124753 extends Migration {
+
+  override async up(): Promise<void> {
+    this.addSql(`alter table if exists "messaging_message" add column if not exists "media_id" text null, add column if not exists "media_pending_reason" text null;`);
+  }
+
+  override async down(): Promise<void> {
+    this.addSql(`alter table if exists "messaging_message" drop column if exists "media_id", drop column if exists "media_pending_reason";`);
+  }
+
+}

--- a/apps/backend/src/modules/messaging/models/message.ts
+++ b/apps/backend/src/modules/messaging/models/message.ts
@@ -13,8 +13,34 @@ const Message = model.define("messaging_message", {
     context_type: model.text().nullable(),
     context_id: model.text().nullable(),
     context_snapshot: model.json().nullable(),
+    /**
+     * 🔴 For INBOUND WhatsApp media this starts as Meta's own
+     * `lookaside.fbsbx.com` URL and is overwritten with OUR stored URL once
+     * the bytes are downloaded. Meta's copy is useless to anyone but us: it
+     * 401s without a bearer token and carries an `ext=` expiry about FIVE
+     * MINUTES out. A row still holding a lookaside URL is a broken image, not
+     * a photograph — see `media_id`.
+     */
     media_url: model.text().nullable(),
     media_mime_type: model.text().nullable(),
+    /**
+     * Meta's media id, kept so a download that did not happen can still happen
+     * later.
+     *
+     * Meta retains the bytes ~30 days, so an id is a 30-day claim on the
+     * photograph while the URL beside it lives five minutes. Ten photographs
+     * from Bhagalpur Handloom SHG were nearly lost because this column did not
+     * exist: the id was recoverable only by regexing `mid=` out of a URL that
+     * Meta is free to reshape at any time.
+     */
+    media_id: model.text().nullable(),
+    /**
+     * Set when media arrived but was deliberately NOT downloaded — today only
+     * because the sender had not yet consented to the conversation being
+     * recorded, and fetching their photographs first is the thing consent is
+     * being asked about. Cleared when the backfill collects it.
+     */
+    media_pending_reason: model.text().nullable(),
     reply_to_id: model.text().nullable(),
     reply_to_snapshot: model.json().nullable(),
     // Human-readable reason a delivery failed (Meta error code/title/message).

--- a/apps/backend/src/workflows/production-runs/create-production-run-transfer.ts
+++ b/apps/backend/src/workflows/production-runs/create-production-run-transfer.ts
@@ -178,7 +178,20 @@ async function recordTransferActivity(
   container: MedusaContainer,
   run: { id: string; partner_id?: string | null },
   transfer: ProductionRunTransferResult,
-  extra: { reason?: string; notes?: string | null }
+  extra: {
+    reason?: string
+    notes?: string | null
+    /**
+     * The cancelled hop this one re-books, when there is one.
+     *
+     * 🔑 It lives on the transfer's metadata already, but the ACTIVITY row is
+     * the permanent record — a transfer can be hard-deleted, and the timeline
+     * is then the only place the chain survives. The admin timeline resolves it
+     * from either source (#1542) so rows written before this stamp still read
+     * as a chain; new rows carry it themselves.
+     */
+    replacesTransferId?: string | null
+  }
 ): Promise<void> {
   const logger: any = container.resolve(ContainerRegistrationKeys.LOGGER)
   try {
@@ -214,6 +227,7 @@ async function recordTransferActivity(
         quantity: transfer.quantity,
         reason: extra.reason ?? null,
         notes: extra.notes ?? null,
+        replaces_transfer_id: extra.replacesTransferId ?? null,
         carrier: transfer.carrier ?? null,
         awb: transfer.awb ?? null,
         tracking_url: transfer.tracking_url ?? null,
@@ -374,6 +388,7 @@ export async function createProductionRunTransfer(
     await recordTransferActivity(container, run, base, {
       reason: input.reason,
       notes: input.notes ?? null,
+      replacesTransferId: replaced?.id ?? null,
     })
     return base
   }
@@ -513,6 +528,7 @@ export async function createProductionRunTransfer(
   await recordTransferActivity(container, run, shipped, {
     reason: input.reason,
     notes: input.notes ?? null,
+    replacesTransferId: replaced?.id ?? null,
   })
 
   return shipped

--- a/apps/backend/src/workflows/whatsapp/whatsapp-message-handler.ts
+++ b/apps/backend/src/workflows/whatsapp/whatsapp-message-handler.ts
@@ -198,7 +198,9 @@ export async function handleIncomingMessage(
   })
 
   const conversationId = conversation?.id || null
-  const conversationMeta = conversation?.metadata || {}
+  // `let`: the consent gate below both writes to this and re-reads it in the
+  // same pass (mark pending → decide whether to prompt → collect on consent).
+  let conversationMeta: Record<string, any> = conversation?.metadata || {}
 
   // Create a scoped wrapper that auto-persists outbound bot replies
   // without mutating the shared WhatsAppService instance
@@ -288,8 +290,82 @@ export async function handleIncomingMessage(
 
   // If consent not yet given, send the consent prompt
   if (!consentGiven) {
+    /**
+     * 🔴 Media that arrives before consent must be REMEMBERED, not discarded.
+     *
+     * This gate returns before the media branch below ever runs, so the row
+     * keeps the `lookaside.fbsbx.com` URL it was created with — 401 without a
+     * bearer token, and dead about five minutes later. On 2026-08-25 ten
+     * photographs from Bhagalpur Handloom SHG arrived in a two-second burst
+     * twenty-eight seconds before consent was recorded, and every one became
+     * an unfixable broken thumbnail. Nothing errored.
+     *
+     * The bytes are deliberately NOT fetched here: downloading someone's
+     * photographs before they have agreed that the conversation is recorded is
+     * the exact thing this gate is asking permission for. Marking the row is
+     * enough — Meta holds the media ~30 days, so consent given any time in the
+     * next month still recovers all of it.
+     */
+    if (message.mediaId) {
+      await markMediaPendingConsent(scope, conversationId, message.messageId)
+      conversationMeta = {
+        ...conversationMeta,
+        media_pending_consent: true,
+      }
+      await updateConversationMetadata(scope, conversationId, conversationMeta)
+    }
+
+    /**
+     * 🔑 One prompt per BURST, not one per message.
+     *
+     * The gate fires per message, so those ten photographs produced nine
+     * identical "Welcome to JYT Commerce" prompts in the partner's chat. A
+     * consent request repeated ten times reads as a malfunction, which is a
+     * poor advertisement for the thing being consented to.
+     */
+    const lastPrompt = typeof conversationMeta.consent_prompted_at === "string"
+      ? Date.parse(conversationMeta.consent_prompted_at)
+      : NaN
+    const promptedRecently =
+      !Number.isNaN(lastPrompt) &&
+      Date.now() - lastPrompt < CONSENT_PROMPT_COOLDOWN_MS
+
+    if (promptedRecently) {
+      return { handled: true, action: "consent_already_requested" }
+    }
+
     await sendConsentRequest(whatsapp, message.from, partner.adminName)
+    await updateConversationMetadata(scope, conversationId, {
+      ...conversationMeta,
+      consent_prompted_at: new Date().toISOString(),
+    })
     return { handled: true, action: "consent_requested" }
+  }
+
+  /**
+   * Consent IS given. If anything arrived while it was not, collect it now.
+   *
+   * 🔑 Hung off the marker rather than off the consent-granting code, because
+   * consent is granted in FOUR places — the `consent_agree` button above,
+   * `connect-partner-whatsapp`, and two admin messaging routes — and a
+   * collector wired into one of them would work for that path and silently do
+   * nothing for the other three. This one runs whichever way consent arrived.
+   * (The conversation that exposed the bug was `admin_initiated`, i.e. not the
+   * button.)
+   */
+  if (conversationMeta.media_pending_consent === true) {
+    const collected = await collectMediaPendingConsent(scope, {
+      conversationId,
+      partnerId: partner.partnerId,
+      partnerName: partner.adminName,
+    })
+    if (collected.remaining === 0) {
+      conversationMeta = {
+        ...conversationMeta,
+        media_pending_consent: undefined,
+      }
+      await updateConversationMetadata(scope, conversationId, conversationMeta)
+    }
   }
 
   // If consent given but language not yet selected, prompt for it
@@ -452,16 +528,26 @@ export async function handleIncomingMessage(
         // messaging_message row so the inbox shows which run it belonged to.
         if (saved && conversationId) {
           const messagingService = scope.resolve(MESSAGING_MODULE) as any
-          const [latestMessages] = await messagingService.listAndCountMessagingMessages(
-            { conversation_id: conversationId },
-            { take: 1, order: { created_at: "DESC" } }
+          /**
+           * 🔴 Looked up by `wa_message_id`, NOT by "the newest row in this
+           * conversation".
+           *
+           * The newest-row version was a race that lost photographs silently:
+           * ten arriving in a two-second burst mean the newest row is usually
+           * NOT the one being handled, so the guard failed and the row kept
+           * Meta's `lookaside` URL — which 401s and expires in five minutes.
+           * Nothing threw; the update just quietly did not happen.
+           */
+          const [row] = await messagingService.listMessagingMessages(
+            { wa_message_id: message.messageId },
+            { take: 1 }
           )
-          const lastMsg = latestMessages?.[0]
-          if (lastMsg?.wa_message_id === message.messageId) {
+          if (row) {
             await messagingService.updateMessagingMessages({
-              id: lastMsg.id,
+              id: row.id,
               media_url: saved.fileUrl,
               media_mime_type: saved.mimeType,
+              media_pending_reason: null,
               content: message.text || `[${message.type}]`,
               ...(attachedRunId
                 ? { context_type: "production_run", context_id: attachedRunId }
@@ -1672,6 +1758,15 @@ async function persistInboundMessage(
     status: "delivered",
     media_url: message.mediaUrl || null,
     media_mime_type: message.mediaMimeType || null,
+    /**
+     * 🔴 Stored BECAUSE `media_url` above is Meta's `lookaside.fbsbx.com` URL
+     * at this point, and that URL 401s without a bearer token and expires
+     * about five minutes from now. If the download later in this handler does
+     * not happen, the id is the only thing that can still fetch the bytes —
+     * Meta keeps them ~30 days. Ten photographs were nearly lost for want of
+     * this one column.
+     */
+    media_id: message.mediaId || null,
     reply_to_id: replyToId,
     reply_to_snapshot: replyToSnapshot,
   })
@@ -1882,3 +1977,136 @@ async function handleProductCreateButtonReply(
   return { handled: true, action: "product_create_button_unknown" }
 }
 
+/**
+ * One consent prompt per burst. Ten photographs produced nine identical
+ * prompts; a window this size collapses any realistic burst into one.
+ */
+const CONSENT_PROMPT_COOLDOWN_MS = 10 * 60 * 1000
+
+/** Why a piece of media is sitting undownloaded. One value today. */
+const MEDIA_PENDING_CONSENT = "awaiting_consent"
+
+/**
+ * Mark an inbound media row as "arrived, deliberately not downloaded".
+ *
+ * Matched on `wa_message_id` rather than "the newest row in this conversation".
+ * 🔑 That newest-row shortcut is what the post-download update uses, and it is
+ * a race: ten photographs arriving in two seconds mean the newest row is
+ * frequently NOT the one being handled, so the update lands on the wrong row or
+ * on none. Meta's message id is the only stable handle.
+ */
+async function markMediaPendingConsent(
+  scope: any,
+  conversationId: string | null,
+  waMessageId?: string
+): Promise<void> {
+  if (!conversationId || !waMessageId) return
+  try {
+    const messagingService = scope.resolve(MESSAGING_MODULE) as any
+    const [row] = await messagingService.listMessagingMessages(
+      { wa_message_id: waMessageId },
+      { take: 1 }
+    )
+    if (!row) return
+    await messagingService.updateMessagingMessages({
+      id: row.id,
+      media_pending_reason: MEDIA_PENDING_CONSENT,
+    })
+  } catch (e: any) {
+    const logger: any = scope.resolve(ContainerRegistrationKeys.LOGGER)
+    logger?.warn?.(
+      `[whatsapp] could not mark media pending for ${waMessageId}: ${e?.message ?? e}`
+    )
+  }
+}
+
+/**
+ * Download everything that was held back while consent was outstanding.
+ *
+ * 🔴 The stale `media_url` on the row is NOT passed to the downloader. That URL
+ * is Meta's, it 401s, and its `ext=` expiry is long past — handing it over
+ * would make every recovery fail while looking like it tried. Passing the
+ * `media_id` alone makes the helper mint a FRESH url, which is the entire
+ * reason the id is stored.
+ *
+ * Returns how many are still outstanding so the caller only clears the
+ * conversation marker when the queue is genuinely empty. A partial recovery
+ * that cleared the flag would strand the remainder silently.
+ */
+async function collectMediaPendingConsent(
+  scope: any,
+  input: { conversationId: string | null; partnerId: string; partnerName: string }
+): Promise<{ collected: number; failed: number; remaining: number }> {
+  const logger: any = scope.resolve(ContainerRegistrationKeys.LOGGER)
+  if (!input.conversationId) return { collected: 0, failed: 0, remaining: 0 }
+
+  const messagingService = scope.resolve(MESSAGING_MODULE) as any
+  let pending: any[] = []
+  try {
+    pending = await messagingService.listMessagingMessages(
+      {
+        conversation_id: input.conversationId,
+        media_pending_reason: MEDIA_PENDING_CONSENT,
+      },
+      { take: 50, order: { created_at: "ASC" } }
+    )
+  } catch (e: any) {
+    logger?.warn?.(`[whatsapp] pending-media lookup failed: ${e?.message ?? e}`)
+    return { collected: 0, failed: 0, remaining: 0 }
+  }
+
+  let collected = 0
+  let failed = 0
+
+  for (const row of pending) {
+    if (!row?.media_id) {
+      // Nothing can be done for this one — it predates the id column. Clear
+      // the marker so it stops being retried on every inbound message, and say
+      // so on the row rather than leaving it looking merely un-processed.
+      await messagingService
+        .updateMessagingMessages({
+          id: row.id,
+          media_pending_reason: "unrecoverable_no_media_id",
+        })
+        .catch(() => {})
+      failed++
+      continue
+    }
+
+    try {
+      const saved = await downloadAndSaveWhatsAppMedia(scope, {
+        mediaId: row.media_id,
+        // mediaUrl deliberately omitted — see the header.
+        mimeType: row.media_mime_type || undefined,
+        partnerId: input.partnerId,
+        partnerName: input.partnerName,
+      })
+
+      if (!saved?.fileUrl) {
+        failed++
+        continue
+      }
+
+      await messagingService.updateMessagingMessages({
+        id: row.id,
+        media_url: saved.fileUrl,
+        media_mime_type: saved.mimeType,
+        media_pending_reason: null,
+      })
+      collected++
+    } catch (e: any) {
+      failed++
+      logger?.warn?.(
+        `[whatsapp] could not collect pending media ${row.media_id}: ${e?.message ?? e}`
+      )
+    }
+  }
+
+  if (collected || failed) {
+    logger?.info?.(
+      `[whatsapp] consent-pending media for ${input.conversationId}: collected ${collected}, failed ${failed}`
+    )
+  }
+
+  return { collected, failed, remaining: Math.max(0, pending.length - collected) }
+}

--- a/apps/partner-ui/src/dashboard-app/routes/get-partner-route.map.tsx
+++ b/apps/partner-ui/src/dashboard-app/routes/get-partner-route.map.tsx
@@ -97,14 +97,20 @@ export function getPartnerRouteMap(): RouteObject[] {
                 {
                   path: "",
                   lazy: () => import("../../routes/inquiries/inquiry-list"),
-                },
-                {
-                  path: ":id",
-                  handle: {
-                    breadcrumb: (match?: UIMatch) =>
-                      match?.params?.id || "Inquiry",
-                  },
-                  lazy: () => import("../../routes/inquiries/inquiry-detail"),
+                  // The wizard renders as a modal in the list's <Outlet/>, so
+                  // the list stays behind it (#1543). Still a real route: the
+                  // WhatsApp invite deeplinks straight here (#1531 S3).
+                  children: [
+                    {
+                      path: ":id",
+                      handle: {
+                        breadcrumb: (match?: UIMatch) =>
+                          match?.params?.id || "Inquiry",
+                      },
+                      lazy: () =>
+                        import("../../routes/inquiries/inquiry-detail"),
+                    },
+                  ],
                 },
               ],
             },

--- a/apps/partner-ui/src/hooks/api/partner-inquiries.tsx
+++ b/apps/partner-ui/src/hooks/api/partner-inquiries.tsx
@@ -8,7 +8,7 @@ import {
 } from "@tanstack/react-query"
 import qs from "qs"
 
-import { sdk } from "../../lib/client"
+import { sdk, backendUrl } from "../../lib/client/client"
 import { queryClient } from "../../lib/query-client"
 import { queryKeysFactory } from "../../lib/query-key-factory"
 
@@ -94,6 +94,15 @@ export type PartnerInquiryDetail = {
     title: string
     brief_note?: string | null
     reference_media_ids?: string[]
+    /**
+     * The moodboard, resolved to something renderable (#1543).
+     *
+     * 🔑 Render from THIS, never from `reference_media_ids`. The ids are what
+     * is stored; they were returned by the route from the day it was written
+     * and nothing could show them, so the partner was asked "can you make
+     * this?" while being shown nothing at all.
+     */
+    reference_media?: CapabilityMedia[] | null
     spec_version?: string | null
     status: "open" | "closed"
     created_at?: string
@@ -117,6 +126,14 @@ export type IncomingAnswer = {
   capability_sample_ids?: string[]
 }
 
+/** A photograph on a sample, resolved to something renderable by the route. */
+export type CapabilityMedia = {
+  id: string
+  url: string
+  name?: string | null
+  type?: string | null
+}
+
 export type CapabilitySample = {
   id: string
   partner_id: string
@@ -124,6 +141,13 @@ export type CapabilitySample = {
   technique?: string | null
   material?: string | null
   media_file_ids?: string[] | null
+  /**
+   * 🔑 Render from THIS, never from `media_file_ids`. An id is not a URL —
+   * the ids are what is stored, `media` is what the read path resolves them
+   * to, and a component that reached for the ids would show empty squares
+   * after every reload while looking perfectly correct on the upload itself.
+   */
+  media?: CapabilityMedia[] | null
   notes?: string | null
   source?: string
   captured_at?: string
@@ -314,6 +338,70 @@ export const useCreatePartnerCapability = (
         queryKey: partnerCapabilitiesQueryKeys.lists(),
       })
       options?.onSuccess?.(data, variables, context)
+    },
+    ...options,
+  })
+}
+
+/**
+ * Upload photographs for a capability sample (#1543).
+ *
+ * Two steps, not one: this returns `media` ids and URLs, and the caller then
+ * creates the SAMPLE with those ids. They are separate because a sample
+ * outlives the inquiry that produced it — a partner may attach one they
+ * already have rather than take a new photograph — so "upload a file" and
+ * "record what this proves" are genuinely different acts.
+ *
+ * 🔑 `content-type: null` is deliberate. The SDK sets `application/json` by
+ * default and the browser must be left to write its own multipart boundary;
+ * with the default header the request arrives as a body multer cannot parse
+ * and the route reports "No files were uploaded" about files that were
+ * definitely sent.
+ *
+ * The native-fetch fallback mirrors `usePartnerUpload` — mobile browsers have
+ * failed the SDK path with an opaque "fetch failed", and a weaver on a phone
+ * is exactly who this feature is for.
+ */
+export const useUploadCapabilityMedia = (
+  options?: UseMutationOptions<{ media: CapabilityMedia[] }, FetchError, File[]>
+) => {
+  return useMutation({
+    mutationFn: async (files: File[]) => {
+      const form = new FormData()
+      files.forEach((file) => form.append("files", file))
+
+      try {
+        return await sdk.client.fetch<{ media: CapabilityMedia[] }>(
+          "/partners/capabilities/uploads",
+          {
+            method: "POST",
+            body: form,
+            headers: { "content-type": null } as any,
+          }
+        )
+      } catch (sdkError: any) {
+        const isNetworkError =
+          sdkError?.message === "fetch failed" ||
+          sdkError?.message === "Failed to fetch" ||
+          sdkError?.message?.includes("network")
+        if (!isNetworkError) throw sdkError
+
+        const token = (sdk as any).client?.token || null
+        const headers: Record<string, string> = {}
+        if (token) headers["Authorization"] = `Bearer ${token}`
+
+        const res = await fetch(
+          `${backendUrl.replace(/\/$/, "")}/partners/capabilities/uploads`,
+          { method: "POST", headers, body: form, credentials: "include" }
+        )
+        if (!res.ok) {
+          const body = await res.text().catch(() => "Upload failed")
+          const err: any = new Error(body)
+          err.status = res.status
+          throw err
+        }
+        return res.json() as Promise<{ media: CapabilityMedia[] }>
+      }
     },
     ...options,
   })

--- a/apps/partner-ui/src/routes/inquiries/inquiry-detail/inquiry-detail.tsx
+++ b/apps/partner-ui/src/routes/inquiries/inquiry-detail/inquiry-detail.tsx
@@ -2,7 +2,6 @@ import {
   Badge,
   Button,
   Checkbox,
-  Container,
   Heading,
   Input,
   Label,
@@ -16,14 +15,18 @@ import {
 import { useEffect, useMemo, useRef, useState } from "react"
 import { useParams } from "react-router-dom"
 
-import { SingleColumnPage } from "../../../components/layout/pages"
+import { RouteFocusModal } from "../../../components/modals"
+import { FileUpload, type FileType } from "../../../components/common/file-upload"
 import {
   IncomingAnswer,
   InquiryQuestion,
   InquiryVerdict,
+  useCreatePartnerCapability,
+  usePartnerCapabilities,
   usePartnerInquiry,
   useSavePartnerInquiryAnswers,
   useSubmitPartnerInquiry,
+  useUploadCapabilityMedia,
 } from "../../../hooks/api/partner-inquiries"
 
 /**
@@ -81,17 +84,24 @@ const VERDICTS: Array<{
 /** The value a question starts from, so a half-finished wizard resumes. */
 const initialValues = (
   questions: InquiryQuestion[],
-  answers: Array<{ question_id: string; value?: unknown; note?: string | null }>
+  answers: Array<{
+    question_id: string
+    value?: unknown
+    note?: string | null
+    capability_sample_ids?: string[] | null
+  }>
 ) => {
   const byQuestion = new Map(answers.map((a) => [a.question_id, a]))
   const values: Record<string, unknown> = {}
   const notes: Record<string, string> = {}
+  const samples: Record<string, string[]> = {}
   for (const question of questions) {
     const existing = byQuestion.get(question.id)
     values[question.id] = existing?.value ?? null
     notes[question.id] = existing?.note ?? ""
+    samples[question.id] = existing?.capability_sample_ids ?? []
   }
-  return { values, notes }
+  return { values, notes, samples }
 }
 
 export const InquiryDetail = () => {
@@ -106,6 +116,8 @@ export const InquiryDetail = () => {
 
   const [values, setValues] = useState<Record<string, unknown>>({})
   const [notes, setNotes] = useState<Record<string, string>>({})
+  /** question_id → capability_sample ids attached to that answer (#1543). */
+  const [samples, setSamples] = useState<Record<string, string[]>>({})
   const [stepIndex, setStepIndex] = useState(0)
   const [verdict, setVerdict] = useState<InquiryVerdict | null>(null)
   const [leadTime, setLeadTime] = useState("")
@@ -137,6 +149,7 @@ export const InquiryDetail = () => {
     const seeded = initialValues(questions, answers ?? [])
     setValues(seeded.values)
     setNotes(seeded.notes)
+    setSamples(seeded.samples)
   }, [questions, answers, inquiryId])
 
   // Same reasoning as the seed above: the summary fields are read once, so a
@@ -195,11 +208,22 @@ export const InquiryDetail = () => {
         question_id: question.id,
         value: values[question.id] ?? null,
         note: notes[question.id]?.trim() ? notes[question.id].trim() : null,
+        capability_sample_ids: samples[question.id] ?? [],
       }))
       // An untouched question is left alone rather than written as an explicit
       // null: "not answered yet" and "answered with nothing" are different
       // things, and only one of them is worth showing in the comparison.
-      .filter((a) => a.value !== null || a.note !== null)
+      //
+      // 🔴 A photo question has NO `value` and NO `note` — the photograph IS
+      // the answer. Without the sample clause here, attaching a picture and
+      // pressing "Save and continue" would filter the answer out and save
+      // nothing, silently, on the one kind of question that cannot be retyped.
+      .filter(
+        (a) =>
+          a.value !== null ||
+          a.note !== null ||
+          (a.capability_sample_ids?.length ?? 0) > 0
+      )
 
   const goToStep = async (next: number) => {
     if (closed) {
@@ -244,19 +268,32 @@ export const InquiryDetail = () => {
 
   if (isLoading) {
     return (
-      <SingleColumnPage widgets={{ before: [], after: [] }}>
-        <Container>
+      <RouteFocusModal>
+        <RouteFocusModal.Header>
+          <RouteFocusModal.Title>Loading…</RouteFocusModal.Title>
+        </RouteFocusModal.Header>
+        <RouteFocusModal.Body className="overflow-y-auto px-6 py-6">
           <Text size="small" className="text-ui-fg-subtle">
             Loading…
           </Text>
-        </Container>
-      </SingleColumnPage>
+        </RouteFocusModal.Body>
+      </RouteFocusModal>
     )
   }
 
   return (
-    <SingleColumnPage widgets={{ before: [], after: [] }}>
-      <Container className="divide-y p-0">
+    <RouteFocusModal>
+      <RouteFocusModal.Header>
+        <RouteFocusModal.Title asChild>
+          <span className="sr-only">{inquiry?.title ?? "Inquiry"}</span>
+        </RouteFocusModal.Title>
+      </RouteFocusModal.Header>
+
+      {/* 🔴 overflow-y-auto is NOT optional on a FocusModal body. Without it
+          the body does not scroll, and on a phone — which is the whole point
+          of this wizard — the questions below the fold are unreachable and the
+          footer buttons sit off-screen. ~98 partner-ui modals still lack it. */}
+      <RouteFocusModal.Body className="flex flex-col divide-y overflow-y-auto p-0">
         <div className="flex items-start gap-4 px-6 py-4">
           {design?.thumbnail_url && (
             <img
@@ -282,6 +319,37 @@ export const InquiryDetail = () => {
             </Badge>
           )}
         </div>
+
+        {/* The moodboard (#1543).
+            🔴 This was returned by the route as bare ids from the day it was
+            written, and nothing rendered them — so a designer attached the
+            references that explain the ask, and the partner was asked "can you
+            make this?" while being shown nothing. Nothing errored: the field
+            was populated and the array was right there in the response. */}
+        {!!inquiry?.reference_media?.length && (
+          <div className="flex flex-col gap-2 px-6 py-4">
+            <Text size="small" weight="plus">
+              What we are after
+            </Text>
+            <div className="flex flex-wrap gap-2">
+              {inquiry.reference_media.map((m) => (
+                <a
+                  key={m.id}
+                  href={m.url}
+                  target="_blank"
+                  rel="noreferrer noopener"
+                  title={m.name ?? "Reference"}
+                >
+                  <img
+                    src={m.url}
+                    alt={m.name ?? ""}
+                    className="size-24 rounded-md border object-cover"
+                  />
+                </a>
+              ))}
+            </div>
+          </div>
+        )}
 
         {closed && (
           <div className="bg-ui-bg-subtle px-6 py-3">
@@ -322,12 +390,16 @@ export const InquiryDetail = () => {
                 question={question}
                 value={values[question.id]}
                 note={notes[question.id] ?? ""}
+                sampleIds={samples[question.id] ?? []}
                 disabled={closed}
                 onValue={(v) =>
                   setValues((prev) => ({ ...prev, [question.id]: v }))
                 }
                 onNote={(v) =>
                   setNotes((prev) => ({ ...prev, [question.id]: v }))
+                }
+                onSampleIds={(ids) =>
+                  setSamples((prev) => ({ ...prev, [question.id]: ids }))
                 }
               />
             ))}
@@ -403,7 +475,10 @@ export const InquiryDetail = () => {
           )}
         </div>
 
-        <div className="flex items-center justify-between px-6 py-4">
+      </RouteFocusModal.Body>
+
+      <RouteFocusModal.Footer>
+        <div className="flex w-full items-center justify-between">
           <Button
             size="small"
             variant="secondary"
@@ -432,8 +507,8 @@ export const InquiryDetail = () => {
             </Button>
           )}
         </div>
-      </Container>
-    </SingleColumnPage>
+      </RouteFocusModal.Footer>
+    </RouteFocusModal>
   )
 }
 
@@ -449,16 +524,20 @@ const QuestionField = ({
   question,
   value,
   note,
+  sampleIds,
   disabled,
   onValue,
   onNote,
+  onSampleIds,
 }: {
   question: InquiryQuestion
   value: unknown
   note: string
+  sampleIds: string[]
   disabled?: boolean
   onValue: (value: unknown) => void
   onNote: (value: string) => void
+  onSampleIds: (ids: string[]) => void
 }) => {
   const selected = Array.isArray(value) ? (value as string[]) : []
 
@@ -551,10 +630,12 @@ const QuestionField = ({
       )}
 
       {question.kind === "photo" && (
-        <Text size="small" className="text-ui-fg-subtle">
-          Send the photo in your reply and we will attach it here. Uploading
-          straight from this page arrives in the next release.
-        </Text>
+        <PhotoAnswer
+          question={question}
+          sampleIds={sampleIds}
+          disabled={disabled}
+          onSampleIds={onSampleIds}
+        />
       )}
 
       <Textarea
@@ -564,6 +645,146 @@ const QuestionField = ({
         value={note}
         onChange={(e) => onNote(e.target.value)}
       />
+    </div>
+  )
+}
+
+/**
+ * The photograph answer (#1543).
+ *
+ * The wizard has always HAD a `photo` question kind, the answer model has
+ * always carried `capability_sample_ids`, and the route has always validated
+ * them — and this rendered a sentence apologising for itself: *"Send the photo
+ * in your reply and we will attach it here."* So the one question whose answer
+ * cannot be typed was the one that sent the partner back to WhatsApp, which is
+ * the loop #1531 exists to close.
+ *
+ * ## Why two calls and not one
+ *
+ * Upload → create sample → attach the sample id. The middle step is not
+ * ceremony: a sample is a LIBRARY entry that outlives this inquiry, which is
+ * what stops the same partner being asked the same question next season. The
+ * inquiry is an event; the library is what it deposits into.
+ *
+ * ## 🔴 The id is attached only after the sample exists
+ *
+ * Not optimistically. `capability_sample_ids` is validated server-side against
+ * the partner's own library, so an id attached before its row existed would
+ * fail the NEXT step's autosave — and it would fail there, on a different
+ * screen, complaining about a question the partner had already left behind.
+ */
+const PhotoAnswer = ({
+  question,
+  sampleIds,
+  disabled,
+  onSampleIds,
+}: {
+  question: InquiryQuestion
+  sampleIds: string[]
+  disabled?: boolean
+  onSampleIds: (ids: string[]) => void
+}) => {
+  const upload = useUploadCapabilityMedia()
+  const createSample = useCreatePartnerCapability()
+
+  /**
+   * The partner's own library, so an attachment can be one they already have.
+   * Filtered to the ids on this answer for rendering; the whole list is what
+   * makes "I photographed this last month" a click rather than a re-shoot.
+   */
+  const { samples } = usePartnerCapabilities({ limit: 50 })
+  const attached = samples.filter((s) => sampleIds.includes(s.id))
+
+  const busy = upload.isPending || createSample.isPending
+
+  const handleFiles = async (files: FileType[]) => {
+    if (!files.length) return
+    try {
+      const { media } = await upload.mutateAsync(files.map((f) => f.file))
+      if (!media?.length) {
+        toast.error("Nothing came back from that upload. Please try again.")
+        return
+      }
+
+      const { sample } = await createSample.mutateAsync({
+        // The prompt is the most honest title available without asking the
+        // partner to name a file — they are photographing an ANSWER to it.
+        title: question.prompt,
+        media_file_ids: media.map((m) => m.id),
+      })
+
+      onSampleIds([...sampleIds, sample.id])
+      toast.success(
+        media.length === 1 ? "Photo attached" : `${media.length} photos attached`
+      )
+    } catch (e: any) {
+      toast.error(e?.message ?? "That photo could not be attached.")
+    }
+  }
+
+  return (
+    <div className="flex flex-col gap-3">
+      {attached.length > 0 && (
+        <div className="flex flex-wrap gap-2">
+          {attached.map((sample) =>
+            (sample.media ?? []).map((m) => (
+              <div key={m.id} className="relative">
+                <img
+                  src={m.url}
+                  alt={m.name ?? ""}
+                  className="size-20 rounded-md border object-cover"
+                />
+              </div>
+            ))
+          )}
+          {/* A sample whose photographs could not be resolved still counts as
+              attached — saying so is better than an empty row that reads as
+              nothing having been sent. */}
+          {attached
+            .filter((s) => !(s.media ?? []).length)
+            .map((s) => (
+              <div
+                key={s.id}
+                className="bg-ui-bg-subtle flex size-20 items-center justify-center rounded-md border p-2"
+              >
+                <Text size="xsmall" className="text-ui-fg-subtle text-center">
+                  Attached
+                </Text>
+              </div>
+            ))}
+        </div>
+      )}
+
+      {!disabled && (
+        <FileUpload
+          label={
+            attached.length ? "Add another photo" : "Take or choose a photo"
+          }
+          hint="A photo of the real thing tells us more than any description. JPG, PNG or HEIC."
+          multiple
+          formats={["image/jpeg", "image/png", "image/webp", "image/heic"]}
+          onUploaded={(files, rejected) => {
+            if (rejected?.length) {
+              toast.error(
+                `${rejected.length} file${rejected.length === 1 ? "" : "s"} could not be used — photos must be under 10MB.`
+              )
+            }
+            void handleFiles(files)
+          }}
+        />
+      )}
+
+      {busy && (
+        <Text size="small" className="text-ui-fg-subtle">
+          Uploading — keep this open until it finishes.
+        </Text>
+      )}
+
+      {disabled && !attached.length && (
+        <Text size="small" className="text-ui-fg-subtle">
+          No photo was attached to this answer.
+        </Text>
+      )}
     </div>
   )
 }

--- a/apps/partner-ui/src/routes/inquiries/inquiry-list/inquiry-list.tsx
+++ b/apps/partner-ui/src/routes/inquiries/inquiry-list/inquiry-list.tsx
@@ -1,5 +1,5 @@
 import { Badge, Button, Container, Heading, StatusBadge, Text } from "@medusajs/ui"
-import { Link } from "react-router-dom"
+import { Link, Outlet } from "react-router-dom"
 
 import { SingleColumnPage } from "../../../components/layout/pages"
 import {
@@ -138,6 +138,16 @@ export const InquiryList = () => {
           )
         })}
       </Container>
+
+      {/* The inquiry itself opens OVER this list (#1543). Nested rather than a
+          sibling route so the list stays visible behind the modal — closing it
+          returns to exactly the row you came from, which matters when a
+          partner has several to work through and is doing it on a phone.
+
+          🔑 It stays a ROUTE, not a piece of list state. The WhatsApp invite
+          deeplinks straight to /inquiries/:id (#1531 S3); a modal that only
+          existed as a `useState` on this page would 404 that link. */}
+      <Outlet />
     </SingleColumnPage>
   )
 }


### PR DESCRIPTION
Three commits, deliberately in one PR: only one carries a **migration**, and merging separately would mean back-to-back merges — the gate is per-push and the deploy per-tree, so a superseded run strands its migration permanently while still reporting `success`. One tree, one deploy.

---

## 1 · `#1542` — transfers on the timeline, action menu for stock moves

`#1541` shipped the goods-movement section with the timeline beside it telling the other half of the same story, and neither showing the other.

- The carrier and a waybill **linked to its tracking URL**; the cancellation reason; and for a carrier cancellation, *"Recorded by an admin — the carrier was not called."* That line is the point: `POST .../cancel` records that a human **says** the carrier voided the AWB, and an operator reading it as a carrier fact would stop chasing a waybill that is still live.
- The cancelled → re-booked pair reads as a chain, **in words rather than ULIDs**: *"Re-books the 4 units hop of Aug 9 (cancelled)."* Two 26-character ids differing in the middle are the same string to a human eye.
- 🔑 The chain resolves from the **transfer**, not only the activity payload. `replaces_transfer_id` was never stamped into the activity, so a payload-only implementation would render nothing for every hop that exists today — including the live `#891` pair — and look correct doing it. It is now stamped going forward too, because a transfer can be deleted and the timeline is then the only surviving record.
- `goods_transfer_received` / `_delivered` render **before anything writes them**, so `#891` S3 ships a route rather than a route plus a second pass over this file.
- Action menu: move · record a movement that already happened · clear N abandoned drafts (the `#891` run carries four from 9 Aug, and one-at-a-time is why nobody has). Drafts are **named** in the confirmation, not just counted.
- 🔴 "Record a movement that already happened" **removes** the carrier select rather than defaulting it, and forces `carrier: undefined`. Delhivery has no sandbox; the one control that can spend money should be absent from the flow whose premise is that the goods already moved.

**Found while wiring it:** the stock-locations query was `enabled: open`, so until you had opened the drawer once every row read `4 × sloc_01K2… → sloc_01K3…`. Nothing failed and nothing logged — visible only to an eye on the screen, which is what `#1541` never got.

## 2 · `#1543` — the inquiry in a modal, and the photograph

The wizard opens as a modal **over** the list (nested route, so the list stays behind and it remains deeplinkable — the WhatsApp invite goes straight to `/inquiries/:id`).

The `photo` question can finally take a photo. The kind has always existed, `capability_sample_ids` has always been on the model, the validator has always accepted it — and this rendered *"Uploading straight from this page arrives in the next release."* So the one question whose answer cannot be typed was the one that sent the partner back to WhatsApp.

🔴 **The moodboard has never reached the partner.** `reference_media_ids` has been returned since the route was written, as bare ids, and nothing resolved them. A designer attached the references explaining the ask; the partner was asked *"can you make this?"* while being shown nothing. Nothing errored — the field was populated and the array was right there.

Same defect, one rung along, so there is now **one** `resolveMediaFiles` rather than two.

## 3 · WhatsApp — ten photographs, lost 28 seconds before consent

Ten photos from Bhagalpur Handloom SHG landed in a two-second burst at **12:31:37–39**. Consent was recorded at **12:32:07**.

The consent gate returns *before* the media branch. The row is created earlier holding Meta's `lookaside.fbsbx.com` URL — which **401s** without a bearer token (probed) and whose `ext=1787661397` is an expiry **five minutes** out. The download that overwrites `media_url` never ran.

The tell is not that the URL looks odd — all ten rows have `content: ""`, and the post-download update sets `content`. Empty content **proves** the update never executed.

Same gate, second symptom: it fires per message, so ten photos produced **nine identical welcome prompts**.

- `media_id` is a real column. Meta retains media ~30 days, so an id is a 30-day claim on a photograph whose URL lives five minutes.
- Pre-consent media is **marked, not fetched** — downloading someone's photographs before they agree is the precise thing consent is being asked about. The collector hangs off a conversation marker, not off the consent-granting code: consent is granted in **four** places, and the conversation that exposed this was `admin_initiated`, not the button.
- 🔴 Second, independent bug: the post-download update matched *"the newest row in this conversation"*. In a burst that is usually a different photograph, so it landed on the wrong row or none. Now matched on `wa_message_id`.
- `recover-whatsapp-media` repairs the existing rows. It does **not** pass the stored URL to the downloader — that URL is dead, and passing it would make every recovery fail while looking like Meta had lost the media.

⏳ **Time-limited: the window closes ~24 Sep 2026.** All ten media ids are intact.

The generated migration also re-emitted `fail_reason`, `default_sender_platform_id` and a constraint rewrite from a stale snapshot; those ship in earlier migrations. Removed — the `up` was a harmless no-op, but the generated `down` would have **dropped two columns this migration never created**.

## Verified

- `pnpm check:prod-build` → `✓ Prod-config build passed.` (read the ✓ line, not a grep for `error TS`)
- `TEST_TYPE=unit` — recovery predicates 7/7, freight 24/24, transfer workflow 7/7
- partner-ui `tsc --noEmit` clean; the focused re-run's only hits are pre-existing react-query v5 arity warnings on untouched lines, surfaced by ad-hoc `--strict`

## Not verified

🔴 **The `#1542` admin UI still has not been clicked by a human.** I seeded a local fixture and got as far as a **401** — no admin session locally, and I don't enter credentials. It compiles and its data path is sound; that is all this proves.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_0158wJMZ1DmjNxXf5uGuBrQD