### PR TITLE
feat(inquiries,production-runs): answer an inquiry in conversation, and split a BOM at the moment a run is created

### DIFF
--- a/apps/backend/integration-tests/http/design-production-run-assignment-materials.spec.ts
+++ b/apps/backend/integration-tests/http/design-production-run-assignment-materials.spec.ts
@@ -1,0 +1,234 @@
+import { setupSharedTestSuite, getSharedTestEnv } from "./shared-test-setup"
+import { createAdminUser, getAuthHeaders } from "../helpers/create-admin-user"
+
+jest.setTimeout(120 * 1000)
+
+/**
+ * Per-assignment materials, arriving by the DESIGN door.
+ *
+ * `approveProductionRunWorkflow` has understood `materials` since #1361, and
+ * `POST /admin/designs/:id/production-runs` hands it `assignments` verbatim —
+ * so the feature looked, from the workflow's side, like it already worked here.
+ * It did not: the route's own validator never declared `materials`, and the
+ * validator is strict, so the field could not reach the handler that was
+ * already right about it.
+ *
+ * 🔑 That gap is invisible to everything except a request. tsc types the
+ * payload the UI builds, not the schema it is checked against; the workflow's
+ * unit tests feed it materials directly and pass. Only an HTTP round trip that
+ * asks the run back for its allocation can tell the difference between "the
+ * field was honoured" and "the field was thrown away at the door".
+ */
+setupSharedTestSuite(() => {
+  describe("Design → production run assignments carry per-partner materials", () => {
+    let adminHeaders: { headers: Record<string, string> }
+
+    beforeAll(async () => {
+      const { api, getContainer } = getSharedTestEnv()
+      await createAdminUser(getContainer())
+      adminHeaders = await getAuthHeaders(api)
+
+      try {
+        await api.post(
+          "/admin/email-templates",
+          {
+            name: "Admin Partner Created",
+            template_key: "partner-created-from-admin",
+            subject: "Welcome {{partner_name}}",
+            html_content: "<div>{{temp_password}}</div>",
+            from: "partners@jaalyantra.com",
+            variables: {},
+            template_type: "email",
+          },
+          adminHeaders
+        )
+      } catch {
+        // Already seeded by a sibling spec — either way it exists now.
+      }
+    })
+
+    /** A design with two inventory items linked, and a partner to send them to. */
+    const seed = async (unique: number) => {
+      const { api } = getSharedTestEnv()
+
+      const partnerRes = await api.post(
+        "/admin/partners",
+        {
+          partner: {
+            name: `Materials Partner ${unique}`,
+            handle: `materials-partner-${unique}`,
+          },
+          admin: {
+            email: `materials-partner-${unique}@jyt.test`,
+            first_name: "Mat",
+            last_name: "Partner",
+          },
+        },
+        adminHeaders
+      )
+      expect(partnerRes.status).toBe(201)
+
+      const designRes = await api.post(
+        "/admin/designs",
+        {
+          name: `Materials Design ${unique}`,
+          description: "Design whose BOM is split between partners",
+          design_type: "Original",
+          status: "Approved",
+          priority: "Medium",
+        },
+        adminHeaders
+      )
+      expect(designRes.status).toBe(201)
+
+      const warpRes = await api.post(
+        "/admin/inventory-items",
+        { title: `Warp yarn ${unique}` },
+        adminHeaders
+      )
+      expect(warpRes.status).toBe(200)
+
+      const weftRes = await api.post(
+        "/admin/inventory-items",
+        { title: `Weft yarn ${unique}` },
+        adminHeaders
+      )
+      expect(weftRes.status).toBe(200)
+
+      const designId = designRes.data.design.id
+      const warpId = warpRes.data.inventory_item.id
+      const weftId = weftRes.data.inventory_item.id
+
+      const linkRes = await api.post(
+        `/admin/designs/${designId}/inventory`,
+        { inventoryIds: [warpId, weftId] },
+        adminHeaders
+      )
+      expect(linkRes.status).toBe(201)
+
+      return {
+        partnerId: partnerRes.data.partner.id,
+        designId,
+        warpId,
+        weftId,
+      }
+    }
+
+    it("issues only the selected inventory item to that partner's child run", async () => {
+      const { api } = getSharedTestEnv()
+      const { partnerId, designId, warpId, weftId } = await seed(Date.now())
+
+      const createRes = await api.post(
+        `/admin/designs/${designId}/production-runs`,
+        {
+          quantity: 4,
+          assignments: [
+            {
+              partner_id: partnerId,
+              quantity: 4,
+              role: "weaving",
+              // The warp only. The weft is on the design's BOM and is
+              // deliberately NOT issued to this partner.
+              materials: [
+                { inventory_item_id: warpId, planned_quantity: 2.5 },
+              ],
+            },
+          ],
+        },
+        adminHeaders
+      )
+
+      expect(createRes.status).toBe(201)
+      expect(createRes.data.children).toHaveLength(1)
+
+      const childId = createRes.data.children[0].id
+      const detail = await api.get(
+        `/admin/production-runs/${childId}`,
+        adminHeaders
+      )
+
+      expect(detail.status).toBe(200)
+      // 🔑 `materials` and `materials_constrained` are TOP-LEVEL on this
+      // response, NOT fields on `production_run`. Reading them off the run
+      // gives `undefined` — an absence indistinguishable from "no materials".
+      const run = detail.data
+
+      // The whole point: constrained, to exactly one of the two BOM items.
+      expect(run.materials_constrained).toBe(true)
+      expect(run.materials).toHaveLength(1)
+      expect(run.materials[0].inventory_item_id).toBe(warpId)
+      // 🔴 2.5, not 3. The link column was `numeric(10,0)` — scale ZERO — so
+      // Postgres rounded every fractional allocation on the way in while the
+      // picker offered a `step="0.01"` box. Half a metre of silk is an
+      // ordinary quantity here; this assertion is what holds the column open.
+      expect(Number(run.materials[0].planned_quantity)).toBe(2.5)
+      expect(
+        run.materials.map((m: any) => m.inventory_item_id)
+      ).not.toContain(weftId)
+    })
+
+    // The unconstrained case has to keep working unchanged: every run created
+    // before the picker existed sent no `materials` at all, and those partners
+    // may log consumption against the whole bill of materials.
+    it("leaves the run unconstrained when no materials are selected", async () => {
+      const { api } = getSharedTestEnv()
+      const { partnerId, designId } = await seed(Date.now() + 1)
+
+      const createRes = await api.post(
+        `/admin/designs/${designId}/production-runs`,
+        {
+          quantity: 3,
+          assignments: [{ partner_id: partnerId, quantity: 3, role: "weaving" }],
+        },
+        adminHeaders
+      )
+
+      expect(createRes.status).toBe(201)
+
+      const detail = await api.get(
+        `/admin/production-runs/${createRes.data.children[0].id}`,
+        adminHeaders
+      )
+
+      expect(detail.status).toBe(200)
+      expect(detail.data.materials_constrained).toBe(false)
+      expect(detail.data.materials).toHaveLength(0)
+    })
+
+    // The refusal has to come from the route, not from a partial write: an
+    // item that is not on the design's BOM cannot be issued to anyone.
+    it("refuses an inventory item that is not on the design's bill of materials", async () => {
+      const { api } = getSharedTestEnv()
+      const unique = Date.now() + 2
+      const { partnerId, designId } = await seed(unique)
+
+      const strayRes = await api.post(
+        "/admin/inventory-items",
+        { title: `Unrelated buttons ${unique}` },
+        adminHeaders
+      )
+      expect(strayRes.status).toBe(200)
+
+      const createRes = await api
+        .post(
+          `/admin/designs/${designId}/production-runs`,
+          {
+            quantity: 2,
+            assignments: [
+              {
+                partner_id: partnerId,
+                quantity: 2,
+                materials: [
+                  { inventory_item_id: strayRes.data.inventory_item.id },
+                ],
+              },
+            ],
+          },
+          adminHeaders
+        )
+        .catch((e: any) => e.response)
+
+      expect(createRes.status).toBe(400)
+    })
+  })
+})

--- a/apps/backend/integration-tests/http/partner-mcp-inquiries.spec.ts
+++ b/apps/backend/integration-tests/http/partner-mcp-inquiries.spec.ts
@@ -1,0 +1,294 @@
+import { getSharedTestEnv, setupSharedTestSuite } from "./shared-test-setup"
+import { createAdminUser, getAuthHeaders } from "../helpers/create-admin-user"
+
+jest.setTimeout(240 * 1000)
+
+/**
+ * The partner MCP design-inquiry tools, CALLED (#1531 / #1543).
+ *
+ * ## Why this file exists
+ *
+ * The inquiry feature shipped with a wizard and no integration test of any
+ * kind, and the MCP rows added on top of it are the shape this repo has been
+ * burned by twice:
+ *
+ * - #1394 shipped THREE partner tools that listed perfectly and could never
+ *   succeed, because the `required` array they were gated on was itself the
+ *   lie;
+ * - "Admin MCP works with a secret key" was retracted after `tools/list`
+ *   turned out to be the only thing that had ever run.
+ *
+ * The unit tests prove the slicer reaches these tools and that the registry
+ * parses. They cannot prove the dispatcher reaches the route, that the loopback
+ * carries the partner's bearer, that the confirm rail fires on the submit, or
+ * — the one that is invisible — that a field the model sends ARRIVES. The
+ * dispatcher assembles a body by walking `bodyParams`; a key missing from that
+ * array is dropped in silence and the call still reports `ok`.
+ *
+ * So every assertion below is downstream of a real `tools/call`.
+ */
+
+/** Streamable HTTP wants both content types; the transport answers JSON. */
+const MCP_HEADERS = {
+  "Content-Type": "application/json",
+  Accept: "application/json, text/event-stream",
+}
+
+const rpc = (method: string, params: Record<string, unknown>, id = 1) => ({
+  jsonrpc: "2.0",
+  id,
+  method,
+  params,
+})
+
+setupSharedTestSuite(() => {
+  describe("POST /partners/mcp — the design-inquiry tools, executed", () => {
+    let adminHeaders: { headers: Record<string, string> }
+    let partnerHeaders: { Authorization: string }
+    let inquiryId: string
+    let questions: any[]
+
+    beforeAll(async () => {
+      const { api, getContainer } = getSharedTestEnv()
+      await createAdminUser(getContainer())
+      adminHeaders = await getAuthHeaders(api)
+
+      const unique = Date.now()
+      const email = `mcp-inquiry-${unique}@jyt.test`
+      const password = "supersecret"
+
+      await api.post("/auth/partner/emailpass/register", { email, password })
+      const reg = await api.post("/auth/partner/emailpass", { email, password })
+      const partnerRes = await api.post(
+        "/partners",
+        {
+          name: `MCP Inquiry Partner ${unique}`,
+          handle: `mcp-inquiry-partner-${unique}`,
+          admin: { email, first_name: "MCP", last_name: "Partner" },
+        },
+        { headers: { Authorization: `Bearer ${reg.data.token}` } }
+      )
+      expect(partnerRes.status).toBe(200)
+
+      // Re-login: the token minted before the partner existed carries no
+      // partner claim, so every /partners/* call on it is a 401.
+      const login = await api.post("/auth/partner/emailpass", { email, password })
+      partnerHeaders = { Authorization: `Bearer ${login.data.token}` }
+
+      // A design with COLOURS. The questions are generated from the design's
+      // spec and its own palette; a design with neither produces an inquiry
+      // with nothing to ask, which would make `answer_design_inquiry`
+      // untestable for want of a question id.
+      const designRes = await api.post(
+        "/admin/designs",
+        {
+          name: `MCP Inquiry Design ${unique}`,
+          description: "Design put to a partner over MCP",
+          design_type: "Original",
+          status: "Approved",
+          priority: "Medium",
+          colors: [
+            { name: "Indigo", hex_code: "#3F51B5" },
+            { name: "Madder", hex_code: "#B03A2E" },
+          ],
+        },
+        adminHeaders
+      )
+      expect(designRes.status).toBe(201)
+
+      const inquiryRes = await api.post(
+        `/admin/designs/${designRes.data.design.id}/inquiries`,
+        {
+          partner_ids: [partnerRes.data.partner.id],
+          title: "Can you make this shawl?",
+          brief_note: "Handwoven, 90 GSM if possible.",
+        },
+        adminHeaders
+      )
+      expect(inquiryRes.status).toBe(201)
+      inquiryId = inquiryRes.data.inquiry?.id ?? inquiryRes.data.id
+      expect(typeof inquiryId).toBe("string")
+    })
+
+    const mcp = (body: any) => {
+      const { api } = getSharedTestEnv()
+      return api.post("/partners/mcp", body, {
+        headers: { ...MCP_HEADERS, ...partnerHeaders },
+      })
+    }
+
+    /** The tool envelope, surfaced loudly — a JSON-RPC error hides in `result`. */
+    const call = async (name: string, args: Record<string, unknown> = {}) => {
+      const res = await mcp(rpc("tools/call", { name, arguments: args }))
+      expect(res.status).toBe(200)
+      const text = res.data?.result?.content?.[0]?.text
+      if (typeof text !== "string") {
+        throw new Error(
+          `[${name}] no tool payload — ${JSON.stringify(res.data).slice(0, 600)}`
+        )
+      }
+      const payload = JSON.parse(text)
+      if (payload.ok === false) {
+        console.log(
+          `[${name}] tool refused:`,
+          JSON.stringify(payload).slice(0, 800)
+        )
+      }
+      return payload
+    }
+
+    it("lists every inquiry tool", async () => {
+      const res = await mcp(rpc("tools/list", {}))
+      expect(res.status).toBe(200)
+      const names: string[] = (res.data?.result?.tools ?? []).map(
+        (t: any) => t.name
+      )
+
+      for (const name of [
+        "list_design_inquiries",
+        "get_design_inquiry",
+        "answer_design_inquiry",
+        "submit_design_inquiry",
+        "list_capability_samples",
+        "create_capability_sample",
+      ]) {
+        expect(names).toContain(name)
+      }
+    })
+
+    it("finds the inquiry the partner was actually asked", async () => {
+      const payload = await call("list_design_inquiries", { status: "open" })
+      expect(payload.ok).toBe(true)
+
+      const ids = (payload.data?.inquiries ?? []).map((i: any) => i.id)
+      expect(ids).toContain(inquiryId)
+    })
+
+    it("returns the questions to ask, with the shape of a valid answer", async () => {
+      const payload = await call("get_design_inquiry", { inquiryId })
+      expect(payload.ok).toBe(true)
+
+      questions = payload.data?.questions ?? []
+      expect(questions.length).toBeGreaterThan(0)
+
+      // Every question must carry what the model needs to put it to a partner
+      // AND to record the reply in the right shape. A prompt with no `kind` is
+      // a question the assistant can ask and cannot answer.
+      for (const q of questions) {
+        expect(typeof q.id).toBe("string")
+        expect(typeof q.prompt).toBe("string")
+        expect(typeof q.kind).toBe("string")
+      }
+
+      // The brief the designer wrote reaches the partner, not just the title.
+      expect(payload.data?.inquiry?.brief_note).toMatch(/90 GSM/)
+    })
+
+    // 🔴 The one an `ok: true` cannot tell you. `answers` is a nested array of
+    // objects; if it were missing from `bodyParams` the dispatcher would drop
+    // it, the route would see an empty batch, and the call would still succeed.
+    // Reading the answer back is the only proof it arrived.
+    it("records an answer, and the note that carries the real reply", async () => {
+      const question = questions[0]
+
+      const saved = await call("answer_design_inquiry", {
+        inquiryId,
+        answers: [
+          {
+            question_id: question.id,
+            note: "Indigo yes, madder only in the deeper shade.",
+          },
+        ],
+      })
+      expect(saved.ok).toBe(true)
+
+      const after = await call("get_design_inquiry", { inquiryId })
+      const recorded = (after.data?.answers ?? []).find(
+        (a: any) => a.question_id === question.id
+      )
+      expect(recorded).toBeDefined()
+      expect(recorded.note).toBe(
+        "Indigo yes, madder only in the deeper shade."
+      )
+
+      // Saving is NOT answering: the designer must still read this as silence.
+      expect(after.data?.response?.submitted_at ?? null).toBeNull()
+      expect(after.data?.response?.verdict ?? null).toBeNull()
+    })
+
+    // The submit is `sensitive` because it is what the designer reads. Without
+    // `confirm` the dispatcher must plan, not send.
+    it("refuses to submit without confirmation", async () => {
+      const payload = await call("submit_design_inquiry", {
+        inquiryId,
+        verdict: "with_changes",
+      })
+
+      // 🔑 A held call is NOT `ok: false` — the dispatcher returns a PLAN, and
+      // a plan is a successful answer to "what would this do". The signal is
+      // `requires_confirmation`; reading `ok` for it would pass on a tool with
+      // no confirm rail at all.
+      expect(payload.requires_confirmation).toBe(true)
+      expect(payload.plan?.method).toBe("POST")
+      expect(payload.plan?.path).toBe(`/partners/inquiries/${inquiryId}/submit`)
+
+      const after = await call("get_design_inquiry", { inquiryId })
+      expect(after.data?.response?.submitted_at ?? null).toBeNull()
+    })
+
+    it("submits the verdict, the lead time and the price the partner gave", async () => {
+      const payload = await call("submit_design_inquiry", {
+        inquiryId,
+        verdict: "with_changes",
+        lead_time_days: 21,
+        indicative_price: 4200,
+        currency_code: "inr",
+        notes: "Not at 90 GSM — 110 is the finest we hold a shed at.",
+        confirm: true,
+      })
+      expect(payload.ok).toBe(true)
+
+      const after = await call("get_design_inquiry", { inquiryId })
+      const response = after.data?.response
+
+      // Every field, read back. Any one of them missing from `bodyParams`
+      // would have been dropped silently by the dispatcher above.
+      expect(response?.verdict).toBe("with_changes")
+      expect(Number(response?.lead_time_days)).toBe(21)
+      expect(Number(response?.indicative_price)).toBe(4200)
+      expect(response?.currency_code).toBe("inr")
+      expect(response?.notes).toMatch(/110 is the finest/)
+      expect(response?.submitted_at).toBeTruthy()
+    })
+
+    it("lists the capability library the partner answers with", async () => {
+      const payload = await call("list_capability_samples", {})
+      expect(payload.ok).toBe(true)
+      expect(Array.isArray(payload.data?.samples)).toBe(true)
+    })
+
+    // A sample can be recorded without a photograph — the route allows it —
+    // but the tool exists to attach evidence, so the id it returns must be
+    // usable as an answer's `capability_sample_ids`.
+    it("creates a capability sample and returns an id an answer can carry", async () => {
+      const payload = await call("create_capability_sample", {
+        title: "Kani shawl, indigo ground",
+        technique: "kani weave",
+        material: "pashmina",
+      })
+      expect(payload.ok).toBe(true)
+
+      const sampleId = payload.data?.sample?.id
+      expect(typeof sampleId).toBe("string")
+
+      // The route defaults `captured_at` when it is not given, and SAYS it did
+      // — a library that cannot tell you how stale a photo is is not evidence.
+      expect(payload.data?.captured_at_defaulted).toBe(true)
+
+      const listed = await call("list_capability_samples", {})
+      expect((listed.data?.samples ?? []).map((s: any) => s.id)).toContain(
+        sampleId
+      )
+    })
+  })
+})

--- a/apps/backend/src/admin/routes/designs/[id]/@production-run/page.tsx
+++ b/apps/backend/src/admin/routes/designs/[id]/@production-run/page.tsx
@@ -24,6 +24,11 @@ import { useStackedModal } from "../../../../components/modal/stacked-modal/use-
 
 import { usePartners } from "../../../../hooks/api/partners"
 import { useTaskTemplates } from "../../../../hooks/api/task-templates"
+import { useDesignInventory } from "../../../../hooks/api/designs"
+import {
+  cleanAssignmentMaterialsForSave,
+  type DraftMaterial,
+} from "../../../../components/forms/production-run/clean-assignment-materials"
 import {
   useCreateDesignProductionRun,
   useSendProductionRunToProduction,
@@ -36,6 +41,14 @@ const assignmentSchema = z.object({
   order: z.coerce.number().int().positive().optional(),
   template_names: z.array(z.string()).optional(),
   template_ids: z.array(z.string()).optional(),
+  /**
+   * Form-only. The picker's rows, including the ones toggled off, so a
+   * quantity typed and then deselected survives a mid-edit change of mind.
+   * Cleaned into the API's `materials` on submit; this key never leaves the
+   * browser. `z.any()` because the cleaner owns the shape and validates it in
+   * words — a zod path here would only restate it worse.
+   */
+  materials_draft: z.array(z.any()).optional(),
 })
 
 const createSchema = z.object({
@@ -56,6 +69,14 @@ type Assignment = {
   order?: number
   template_names?: string[]
   template_ids?: string[]
+  materials_draft?: DraftMaterial[]
+}
+
+/** One row of the design's bill of materials, as the picker needs it. */
+type BomItem = {
+  id: string
+  label: string
+  planned_quantity?: number | null
 }
 
 /**
@@ -100,10 +121,13 @@ const AssignmentsModal = ({
   form,
   partners,
   templatesToShow,
+  bomItems,
 }: {
   form: any
   partners: any[]
   templatesToShow: any[]
+  /** The design's bill of materials — what an assignment may be a subset OF. */
+  bomItems: BomItem[]
 }) => {
   const { setIsOpen } = useStackedModal()
   const [local, setLocal] = useState<Assignment[]>([])
@@ -117,14 +141,34 @@ const AssignmentsModal = ({
   }, [form])
 
   const handleSave = useCallback(() => {
+    // Catch a bad quantity HERE, in the modal where the field is. The drawer
+    // closes on save, so a complaint raised later — after submit — names a
+    // field the operator can no longer see.
+    for (const [i, a] of local.entries()) {
+      const cleaned = cleanAssignmentMaterialsForSave(
+        a.materials_draft,
+        (id) => bomItems.find((b) => b.id === id)?.label || id
+      )
+      if (!cleaned.ok) {
+        toast.error(`Assignment ${i + 1}: ${cleaned.error}`)
+        return
+      }
+    }
     form.setValue("assignments", local, { shouldDirty: true })
     setIsOpen(MODAL_ID, false)
-  }, [form, local, setIsOpen])
+  }, [form, local, setIsOpen, bomItems])
 
   const addAssignment = () => {
     setLocal((prev) => [
       ...prev,
-      { partner_id: "", role: "", quantity: 1, order: undefined, template_ids: [] },
+      {
+        partner_id: "",
+        role: "",
+        quantity: 1,
+        order: undefined,
+        template_ids: [],
+        materials_draft: [],
+      },
     ])
   }
 
@@ -148,6 +192,42 @@ const AssignmentsModal = ({
           ? current.filter((t) => t !== id)
           : [...current, id]
         return { ...a, template_ids: next }
+      })
+    )
+  }
+
+  /**
+   * The material picker's rows. EVERY BOM item is a row; `selected` is what
+   * makes it part of this assignment. Unselected rows are kept rather than
+   * removed so a quantity typed, deselected and reselected is not lost — and
+   * dropped on save by `cleanAssignmentMaterialsForSave`, never sent blank.
+   */
+  const materialDraft = (a: Assignment): DraftMaterial[] => {
+    const byId = new Map(
+      (a.materials_draft || []).map((d) => [d.inventory_item_id, d])
+    )
+    return bomItems.map(
+      (item) =>
+        byId.get(item.id) || {
+          inventory_item_id: item.id,
+          selected: false,
+          planned_quantity: "",
+        }
+    )
+  }
+
+  const updateMaterial = (
+    idx: number,
+    inventoryItemId: string,
+    patch: Partial<DraftMaterial>
+  ) => {
+    setLocal((prev) =>
+      prev.map((a, i) => {
+        if (i !== idx) return a
+        const rows = materialDraft(a).map((row) =>
+          row.inventory_item_id === inventoryItemId ? { ...row, ...patch } : row
+        )
+        return { ...a, materials_draft: rows }
       })
     )
   }
@@ -320,6 +400,77 @@ const AssignmentsModal = ({
                     )
                   })}
                 </div>
+
+                {/* Which of the design's inventory items THIS partner is sent.
+                    The API has taken `materials` per assignment since #1361 and
+                    the approve drawer has offered it since; creating the run
+                    from the design — the path most runs are actually born on —
+                    could not, so a chain that splits the BOM between a dyer and
+                    a weaver had to be approved first and edited after. */}
+                {bomItems.length > 0 && (
+                  <div className="mt-4">
+                    <Text size="small" weight="plus" className="mb-1">
+                      Materials for this partner
+                    </Text>
+                    <Text size="xsmall" className="text-ui-fg-subtle mb-2">
+                      Select which of the design&apos;s inventory items THIS
+                      partner is sent. Select none and they get the whole bill of
+                      materials, as before. Once you select any, they cannot log
+                      consumption against anything else.
+                    </Text>
+                    <div className="flex flex-col gap-2">
+                      {materialDraft(assignment).map((row) => {
+                        const item = bomItems.find(
+                          (b) => b.id === row.inventory_item_id
+                        )
+                        return (
+                          <div
+                            key={row.inventory_item_id}
+                            className="flex items-center gap-x-3"
+                          >
+                            <button
+                              type="button"
+                              className="rounded-md border px-3 py-1.5 text-sm"
+                              onClick={() =>
+                                updateMaterial(idx, row.inventory_item_id, {
+                                  selected: !row.selected,
+                                })
+                              }
+                            >
+                              <Badge color={row.selected ? "green" : "grey"}>
+                                {item?.label || row.inventory_item_id}
+                              </Badge>
+                            </button>
+                            {row.selected && (
+                              <Input
+                                type="number"
+                                min={0}
+                                step="0.01"
+                                className="max-w-[10rem]"
+                                placeholder={
+                                  item?.planned_quantity != null
+                                    ? `Design plans ${item.planned_quantity}`
+                                    : "Qty (optional)"
+                                }
+                                value={
+                                  row.planned_quantity === null ||
+                                  row.planned_quantity === undefined
+                                    ? ""
+                                    : String(row.planned_quantity)
+                                }
+                                onChange={(e) =>
+                                  updateMaterial(idx, row.inventory_item_id, {
+                                    planned_quantity: e.target.value,
+                                  })
+                                }
+                              />
+                            )}
+                          </div>
+                        )
+                      })}
+                    </div>
+                  </div>
+                )}
               </div>
             ))}
 
@@ -378,6 +529,26 @@ const CreateProductionRunDrawerForm = () => {
     )
   }, [taskTemplates])
 
+  // The design's bill of materials — what an assignment's selection is a subset
+  // OF. A design with no inventory attached simply has none and the picker does
+  // not render, which is why this is not gated on anything else.
+  const { data: designInventory } = useDesignInventory(designId || "", {
+    enabled: !!designId,
+  })
+
+  const bomItems: BomItem[] = useMemo(
+    () =>
+      (designInventory?.inventory_items || []).map((row: any) => ({
+        id: row.inventory_item_id,
+        label:
+          row.inventory_item?.title ||
+          row.inventory_item?.sku ||
+          row.inventory_item_id,
+        planned_quantity: row.planned_quantity ?? null,
+      })),
+    [designInventory]
+  )
+
   const { mutateAsync: createRun, isPending: isCreating } = useCreateDesignProductionRun(
     designId || "",
   )
@@ -408,11 +579,34 @@ const CreateProductionRunDrawerForm = () => {
       return
     }
 
+    // The picker's draft rows become the API's `materials`; `materials_draft`
+    // is a form-only field and must never leave the browser — the assignment
+    // validator is strict, so an unrecognised key is a 400, not a shrug.
+    let assignmentsPayload: any[] | undefined
+    if (values.assignments?.length) {
+      assignmentsPayload = []
+      for (const [i, a] of (values.assignments as Assignment[]).entries()) {
+        const cleaned = cleanAssignmentMaterialsForSave(
+          a.materials_draft,
+          (id) => bomItems.find((b) => b.id === id)?.label || id
+        )
+        if (!cleaned.ok) {
+          toast.error(`Assignment ${i + 1}: ${cleaned.error}`)
+          return
+        }
+        const { materials_draft: _drop, ...rest } = a
+        assignmentsPayload.push({
+          ...rest,
+          ...(cleaned.materials.length ? { materials: cleaned.materials } : {}),
+        })
+      }
+    }
+
     try {
       const res = await createRun({
         quantity: values.quantity,
         run_type: values.run_type || "production",
-        assignments: values.assignments?.length ? values.assignments : undefined,
+        assignments: assignmentsPayload,
       })
 
       toast.success("Production run created")
@@ -533,6 +727,7 @@ const CreateProductionRunDrawerForm = () => {
                   form={form}
                   partners={partners}
                   templatesToShow={templatesToShow}
+                  bomItems={bomItems}
                 />
               </div>
 

--- a/apps/backend/src/api/admin/designs/[id]/production-runs/validators.ts
+++ b/apps/backend/src/api/admin/designs/[id]/production-runs/validators.ts
@@ -1,10 +1,36 @@
 import { z } from "@medusajs/framework/zod"
 
+/**
+ * Mirrors `RunMaterialSchema` in production-runs/validators.ts, because it is
+ * the same thing arriving by a different door: this route hands `assignments`
+ * to `approveProductionRunWorkflow` verbatim, and that workflow has understood
+ * `materials` since #1361.
+ *
+ * 🔴 It had to be DECLARED to arrive. The validator is strict, so an
+ * undeclared `materials` is not passed through and not ignored — it is a 400
+ * the operator cannot act on. That is the same defect the `template_names`
+ * note below records: the handler was already right, the schema was the wall.
+ */
+const RunMaterialSchema = z.object({
+  inventory_item_id: z.string().trim().min(1),
+  planned_quantity: z.number().positive().nullish(),
+  location_id: z.string().trim().min(1).nullish(),
+  resolved_raw_material_id: z.string().trim().min(1).nullish(),
+  note: z.string().nullish(),
+  metadata: z.record(z.string(), z.any()).nullish(),
+})
+
 const ProductionAssignmentSchema = z.object({
   partner_id: z.string().min(1),
   role: z.string().optional(),
   quantity: z.number().positive(),
   order: z.number().int().positive().optional(),
+  /**
+   * Which of the design's inventory items THIS partner is sent, and how much.
+   * Omit (or send an empty array) and the assignment is unconstrained — the
+   * child run carries the whole BOM, exactly as before this field existed.
+   */
+  materials: z.array(RunMaterialSchema).nullish(),
   // See production-runs/validators.ts for the rationale. The admin UI's
   // "Send to production" toggle sends `template_names: null` when no
   // templates are picked — `.optional()` alone rejected that with

--- a/apps/backend/src/api/partners/mcp/lib/__tests__/tool-slice.unit.spec.ts
+++ b/apps/backend/src/api/partners/mcp/lib/__tests__/tool-slice.unit.spec.ts
@@ -367,6 +367,12 @@ describe("partner-mcp per-ask tool slicing", () => {
       // a keyword list — the point of this table is that the real sentence
       // reaches the tools.
       "/partners/quotes": "send this buyer a quote for 200 shawls",
+      // Design inquiries (#1531). A partner NEVER says "inquiry" — they say
+      // what was put to them. If the sentence they would actually type does
+      // not reach these tools, the assistant cannot answer the one thing the
+      // partner opened the chat about.
+      "/partners/inquiries": "they asked if I can make this — what are the questions",
+      "/partners/capabilities": "show the photos of what I have made before",
     }
 
     const familiesInRegistry = [

--- a/apps/backend/src/api/partners/mcp/lib/registry.ts
+++ b/apps/backend/src/api/partners/mcp/lib/registry.ts
@@ -3445,4 +3445,239 @@ export const PARTNER_MCP_TOOLS: PartnerMcpToolDef[] = [
       "Deletes the price list this quote froze, so the buyer stops getting the quoted prices in any cart, and their link 404s from then on. Not reversible: re-offering the same terms means minting a new quote, which emails them again. An ALREADY-ACCEPTED quote is refused here — the accepted cart is priced from it, so unwinding a live deal is an operator's call, not this tool's.",
     nextSteps: ["get_quote", "list_quotes"],
   },
+
+  // ===== Design inquiries (#1531 / #1543) ===================================
+  //
+  // "Can you make this?" — a designer's spec turned into questions, asked of
+  // several partners at once. The wizard in partner-ui walks a partner through
+  // them a screen at a time; these tools let the ASSISTANT do the same walk in
+  // conversation, which is the point: the questions arrive on WhatsApp, and a
+  // partner standing at a loom answers in a sentence, not in a form.
+  //
+  // 🔑 The assistant must ASK, not answer. `get_design_inquiry` returns the
+  // questions with their `kind` and `options`; the model's job is to put them
+  // to the partner in their own words and record what comes back verbatim.
+  // Inventing a lead time or a price from context would put a number in front
+  // of a designer that no maker ever said.
+  //
+  // 🔴 What is deliberately absent: no tool here can see another partner's
+  // answers. Several partners are asked the same questions and their lead
+  // times and prices are the most commercially sensitive thing either of them
+  // says. The routes refuse to serve them; these tools do not ask.
+  {
+    name: "list_design_inquiries",
+    description:
+      "List the design inquiries this partner has been asked — 'can you make this?', one per design. Shows which are still open and which have already been answered. Read.",
+    method: "GET",
+    path: "/partners/inquiries",
+    queryParams: ["status", "limit", "offset"],
+    inputSchema: obj({
+      status: STR("Filter by 'open' or 'closed'. Omit for both."),
+      limit: INT("Max results (default 20)."),
+      offset: INT("Pagination offset."),
+    }),
+    nextSteps: ["get_design_inquiry"],
+  },
+  {
+    name: "get_design_inquiry",
+    description:
+      "Get one design inquiry in full: the design and its reference images, EVERY question with its kind and allowed values, and whatever the partner has answered so far. Call this before answering anything — the questions are generated from the designer's spec and are not guessable. Read.",
+    method: "GET",
+    path: "/partners/inquiries/:inquiryId",
+    pathParams: ["inquiryId"],
+    inputSchema: obj(
+      { inquiryId: STR("Inquiry id, e.g. 'dsgn_inq_...' / '01M0...'.") },
+      ["inquiryId"]
+    ),
+    sideEffects:
+      "Read-only. `questions[].kind` decides what a valid answer looks like: 'yes_no' takes a boolean, 'number' a number, 'colour_select'/'select' one of the listed options, 'text' a string, and 'photo' takes NO value at all — the photograph IS the answer, attached via capability_sample_ids. `questions[].step` is the spec category the question came from (Materials, Measurements, Construction, Colours): ask a step at a time and save it before moving on, the way the wizard does — a partner answering on a phone at a loom abandons a twenty-question run and finishes a three-question one. `answers` is what has been recorded so far, so a half-finished inquiry resumes rather than restarts.",
+    nextSteps: [
+      "answer_design_inquiry",
+      "list_capability_samples",
+      "submit_design_inquiry",
+    ],
+  },
+  {
+    name: "answer_design_inquiry",
+    description:
+      "Record answers to a design inquiry's questions, without submitting. Save as you go — a partner who drops off mid-conversation keeps what they already said, and nothing is shown to the designer as a reply until `submit_design_inquiry` runs. Answer in the partner's own words: `note` carries the sentence after the answer, which is usually the useful part ('not in that GSM, but I can do 90').",
+    method: "POST",
+    path: "/partners/inquiries/:inquiryId/answers",
+    pathParams: ["inquiryId"],
+    write: true,
+    bodyParams: ["answers"],
+    previewPath: "/partners/inquiries/:inquiryId",
+    inputSchema: obj(
+      {
+        inquiryId: STR("Inquiry id the answers belong to."),
+        answers: {
+          type: "array",
+          description:
+            "One entry per question answered. Send only the questions actually answered — an untouched question must be left out, because 'not answered yet' and 'answered with nothing' are different things and only one of them is worth showing the designer.",
+          items: {
+            type: "object",
+            properties: {
+              question_id: STR(
+                "The question's id, from `get_design_inquiry`. Not its text."
+              ),
+              value: {
+                description:
+                  "The answer, shaped by the question's `kind`: boolean for 'yes_no', number for 'number', one of the listed options for a select, string for 'text'. Omit entirely for a 'photo' question.",
+              },
+              note: STR(
+                "The partner's own words about this answer. Send it on a yes as readily as on a no — 'yes, but only in cotton' is an answer a bare true throws away."
+              ),
+              capability_sample_ids: {
+                type: "array",
+                items: { type: "string" },
+                description:
+                  "Capability samples evidencing this answer — the photographs. Get ids from `list_capability_samples` or `create_capability_sample`. This is the ONLY answer a 'photo' question has.",
+              },
+            },
+            required: ["question_id"],
+          },
+        },
+      },
+      ["inquiryId", "answers"]
+    ),
+    sideEffects:
+      "Saves the answers and NOTHING else: the response carries no verdict until it is submitted, so a half-filled inquiry still reads as silence to the designer rather than as a reply. Re-sending the same question_id overwrites that answer. Refused once the inquiry is closed.",
+    nextSteps: ["submit_design_inquiry", "get_design_inquiry"],
+  },
+  {
+    name: "submit_design_inquiry",
+    description:
+      "Send the partner's answer to the designer: the verdict, and optionally a lead time, an indicative price and a closing note. 'with_changes' is the most useful verdict and the one a yes/no would throw away — use it whenever the partner can make something CLOSE to what was asked, and say what would have to change. Sensitive: this is what the designer reads.",
+    method: "POST",
+    path: "/partners/inquiries/:inquiryId/submit",
+    pathParams: ["inquiryId"],
+    write: true,
+    sensitive: true,
+    /**
+     * 🔴 Every key here exists on `PartnerPostInquirySubmitReq`, and every key
+     * on that schema that a conversation can fill is here. The dispatcher
+     * assembles the body by walking THIS allowlist, so a field the model is
+     * offered but that is missing from this array is accepted, reported `ok`,
+     * and dropped in silence — #1348 exactly. Keep the two in step.
+     */
+    bodyParams: [
+      "verdict",
+      "lead_time_days",
+      "indicative_price",
+      "currency_code",
+      "notes",
+      "answers",
+    ],
+    previewPath: "/partners/inquiries/:inquiryId",
+    inputSchema: obj(
+      {
+        inquiryId: STR("Inquiry id being answered."),
+        verdict: {
+          type: "string",
+          enum: ["can_make", "cannot_make", "with_changes"],
+          description:
+            "'can_make' = as specified, with what they have. 'with_changes' = yes, but something must change — say what in `notes`. 'cannot_make' = no, which costs nothing to say and saves everyone a week. Never infer this: it is the one thing the inquiry is asking for.",
+        },
+        lead_time_days: INT(
+          "Working days from order to ready, as the partner states it. Leave out rather than guessing."
+        ),
+        indicative_price: {
+          type: "number",
+          description:
+            "A rough price per piece. It is NOT a quote and nothing is ordered from it — but it is shown to the designer, so it must be a number the partner actually said.",
+        },
+        currency_code: STR(
+          "ISO-3 currency of `indicative_price`, e.g. 'inr'. Send it whenever a price is sent."
+        ),
+        notes: STR(
+          "Anything else the designer should know. On 'with_changes' this is where the answer actually lives."
+        ),
+        answers: {
+          type: "array",
+          description:
+            "A last batch of answers, saved with the verdict in one round trip so a submit cannot half-land. Same shape as `answer_design_inquiry`.",
+          items: {
+            type: "object",
+            properties: {
+              question_id: STR("The question's id."),
+              value: { description: "Shaped by the question's kind." },
+              note: STR("The partner's own words."),
+              capability_sample_ids: {
+                type: "array",
+                items: { type: "string" },
+                description: "Capability samples evidencing this answer.",
+              },
+            },
+            required: ["question_id"],
+          },
+        },
+      },
+      ["inquiryId", "verdict"]
+    ),
+    sideEffects:
+      "Stamps the response as submitted and makes it visible to the designer beside every other partner's. Re-running updates the answer rather than sending a second one. Refused once the inquiry is closed.",
+    nextSteps: ["get_design_inquiry", "list_design_inquiries"],
+  },
+
+  // ---- The capability library: the photographs a partner answers WITH ------
+  //
+  // A sample OUTLIVES the inquiry that produced it, which is why attaching one
+  // is two steps and not one: the partner may point at something they made
+  // last year instead of taking a new photograph. Always LIST before offering
+  // to create.
+  {
+    name: "list_capability_samples",
+    description:
+      "List the partner's capability samples — photographs of things they have actually made, with the technique and material beside each. Search these BEFORE asking for a new photograph: the partner has usually already shown you the thing they are being asked about. Read.",
+    method: "GET",
+    path: "/partners/capabilities",
+    queryParams: ["q", "technique", "material", "limit", "offset"],
+    inputSchema: obj({
+      q: STR("Free-text search over title and notes."),
+      technique: STR("Filter by technique, e.g. 'jamawar', 'block print'."),
+      material: STR("Filter by material, e.g. 'pashmina', 'cotton'."),
+      limit: INT("Max results (default 20)."),
+      offset: INT("Pagination offset."),
+    }),
+    sideEffects:
+      "Read-only. Each sample carries a renderable `media` array — render from THAT, never from `media_file_ids`. An id is not a URL: a surface that reaches for the ids shows the photo it just uploaded and empty squares after every reload.",
+    nextSteps: ["answer_design_inquiry", "create_capability_sample"],
+  },
+  {
+    name: "create_capability_sample",
+    description:
+      "Record a capability sample: a photograph of something the partner has made, with the textile facts beside it. The photograph itself must be UPLOADED FIRST — this tool takes the resulting media ids, it cannot receive a file. Ask the partner to attach the photo in the chat composer (or send it on WhatsApp), then pass the ids it returns as `media_file_ids`.",
+    method: "POST",
+    path: "/partners/capabilities",
+    write: true,
+    bodyParams: [
+      "title",
+      "technique",
+      "material",
+      "media_file_ids",
+      "notes",
+      "captured_at",
+    ],
+    inputSchema: obj(
+      {
+        title: STR("What the thing is, in the partner's words."),
+        technique: STR("How it was made, e.g. 'kani weave', 'sozni'."),
+        material: STR("What it is made of, e.g. 'pashmina', 'mulberry silk'."),
+        media_file_ids: {
+          type: "array",
+          items: { type: "string" },
+          description:
+            "Ids of already-uploaded photographs. 🔴 There is no way to pass a file through this tool — uploading is a multipart request the composer makes (`POST /partners/capabilities/uploads`, images only, max 10). Without ids the sample is a title with no evidence, which is exactly what the library exists to stop.",
+        },
+        notes: STR("Anything worth saying about it."),
+        captured_at: STR(
+          "ISO date the photograph was TAKEN. Ask — do not default it silently. A photo typed up three weeks later describes a capability that may already be gone, and the library is only trustworthy if it says how stale it is. When it is omitted the route defaults it to now and says so in `captured_at_defaulted`."
+        ),
+      },
+      ["title"]
+    ),
+    sideEffects:
+      "Adds a permanent sample to the partner's library — it outlives the inquiry that prompted it and can be attached to later answers. Does NOT attach itself to anything: pass the returned sample id as `capability_sample_ids` on `answer_design_inquiry` to make it the answer to a question.",
+    nextSteps: ["answer_design_inquiry", "list_capability_samples"],
+  },
 ]

--- a/apps/backend/src/api/partners/mcp/lib/tool-slice.ts
+++ b/apps/backend/src/api/partners/mcp/lib/tool-slice.ts
@@ -115,6 +115,12 @@ const PREFIX_DOMAINS: ReadonlyArray<readonly [string, PartnerToolDomain]> = [
 
   // ---- designs: the design record + cost / consumption / media ----
   ["/partners/designs", "designs"],
+  // #1531 — a design inquiry IS a question about a design ("can you make
+  // this?"), and the capability library is the evidence a partner answers it
+  // with. Both ride the designs slice so one conversation can read the
+  // questions, answer them, and attach the photograph that proves the answer.
+  ["/partners/inquiries", "designs"],
+  ["/partners/capabilities", "designs"],
 
   // ---- production: run lifecycle + run-level cost & consumption + run tasks ----
   // /partners/tasks and /partners/assigned-tasks are the per-task view onto a
@@ -248,6 +254,16 @@ const DOMAIN_KEYWORDS: Record<Exclude<PartnerToolDomain, "core">, string[]> = {
     "colourway", "colorway", "revision", "revisions", "bom",
     "bill of materials", "consumption", "consumption log", "consumption logs",
     "cost", "recalculate", "design media", "reference", "reference image",
+    // #1531 — a partner never says "inquiry". They say what was asked of them:
+    // "can you make this", "they want to know if". Classification without the
+    // words a partner actually types is a tool nobody can reach.
+    "inquiry", "inquiries", "enquiry", "enquiries", "asked me", "asked us",
+    "can you make", "can we make", "can i make", "questionnaire", "questions",
+    "answer the questions", "lead time", "verdict",
+    // The capability library — the photographs a partner answers WITH.
+    "capability", "capabilities", "sample", "samples", "photo", "photos",
+    "photograph", "photographs", "picture", "pictures", "portfolio",
+    "what we can make", "what i can make",
   ],
   production: [
     "production", "production run", "production runs", "run", "runs",

--- a/apps/backend/src/links/production-run-inventory-link.ts
+++ b/apps/backend/src/links/production-run-inventory-link.ts
@@ -31,8 +31,21 @@ export default defineLink(
   {
     database: {
       extraColumns: {
-        /** How much of this item the run was allocated. Null = unspecified. */
-        planned_quantity: { type: "decimal", nullable: true },
+        /**
+         * How much of this item the run was allocated. Null = unspecified.
+         *
+         * 🔴 `type: "decimal"` alone lands as `numeric(10,0)` — scale ZERO. A
+         * partner issued 2.5 kg of warp had 3 recorded, silently, with the
+         * picker offering `step="0.01"` the whole time. Half a metre of silk is
+         * an ordinary quantity here, so the default is simply wrong for this
+         * column; the explicit columnType is what makes the stored number the
+         * number that was typed.
+         */
+        planned_quantity: {
+          type: "decimal",
+          nullable: true,
+          options: { columnType: "numeric(20,6)" },
+        },
         /** Where the material is issued FROM, when it differs from the design's. */
         location_id: { type: "text", nullable: true },
         /**

--- a/apps/backend/src/modules/production_runs/migrations/Migration20260826090000.ts
+++ b/apps/backend/src/modules/production_runs/migrations/Migration20260826090000.ts
@@ -1,0 +1,44 @@
+import { Migration } from "@medusajs/framework/mikro-orm/migrations";
+
+/**
+ * The per-assignment material allocation could not hold half a metre.
+ *
+ * `production-run-inventory-link.ts` declares `planned_quantity` as
+ * `{ type: "decimal" }`, and Medusa's link schema generator turns a bare
+ * `decimal` into **`numeric(10,0)` — scale ZERO**. Postgres rounds on the way
+ * in, so a partner issued 2.5 kg of warp had **3** recorded, silently, while
+ * the admin picker offered a `step="0.01"` box the whole time. Half a metre of
+ * silk is an ordinary quantity in this business; the default is simply wrong
+ * for this column.
+ *
+ * The link definition now carries `options: { columnType: "numeric(20,6)" }`,
+ * which is enough for a database built from scratch. This migration is for the
+ * ones that already exist — CI's template, every developer's copy, and
+ * production — where the column is already there and the generator leaves it
+ * alone.
+ *
+ * Widening only: scale 0 → 6 loses nothing, every stored value is already a
+ * whole number, and re-running is a no-op.
+ *
+ * ⚠️ `design_design_inventory_inventory_item.planned_quantity` has the SAME
+ * defect and is deliberately NOT touched here — the design's bill of materials
+ * feeds the design cost engine, and changing what a BOM quantity can express is
+ * a bigger decision than fixing the column an operator just typed into.
+ */
+export class Migration20260826090000 extends Migration {
+
+  override async up(): Promise<void> {
+    this.addSql(`
+      alter table if exists "production_runs_production_runs_inventory_inventory_item"
+      alter column "planned_quantity" type numeric(20,6);
+    `);
+  }
+
+  /**
+   * Deliberately not reversible. Narrowing back to scale 0 would ROUND every
+   * fractional quantity written since — a `down` that silently corrupts data is
+   * worse than one that refuses.
+   */
+  override async down(): Promise<void> {}
+
+}

--- a/apps/partner-ui/src/routes/inquiries/inquiry-detail/inquiry-detail.tsx
+++ b/apps/partner-ui/src/routes/inquiries/inquiry-detail/inquiry-detail.tsx
@@ -5,6 +5,7 @@ import {
   Heading,
   Input,
   Label,
+  ProgressStatus,
   ProgressTabs,
   RadioGroup,
   Text,
@@ -202,6 +203,44 @@ export const InquiryDetail = () => {
   const isSummary = stepIndex >= steps.length
   const current = steps[stepIndex]
 
+  /**
+   * Whether a question has anything recorded against it — the same three-way
+   * test the autosave filter uses, because "answered" has to mean the same
+   * thing to the tab strip as it does to the thing that saves.
+   *
+   * 🔑 The sample clause is not optional: a photo question carries NO value
+   * and NO note, so without it the Materials step shows as untouched while
+   * holding the picture that IS the answer.
+   */
+  const isAnswered = (question: InquiryQuestion) => {
+    const value = values[question.id]
+    if (value !== null && value !== undefined && value !== "") return true
+    if (notes[question.id]?.trim()) return true
+    return (samples[question.id]?.length ?? 0) > 0
+  }
+
+  /**
+   * Tab status is DERIVED, never tracked in its own state.
+   *
+   * A parallel `tabState` would be a second copy of "what has been answered"
+   * that drifts the moment a step is revisited and a field cleared — and the
+   * drift shows as a green tick over an empty step, which is the one direction
+   * a progress indicator must never be wrong in.
+   */
+  const stepStatus = (index: number): ProgressStatus => {
+    if (index === stepIndex) return "in-progress"
+    const step = steps[index]
+    if (!step) return "not-started"
+    if (step.questions.every(isAnswered)) return "completed"
+    return "not-started"
+  }
+
+  const summaryStatus: ProgressStatus = isSummary
+    ? "in-progress"
+    : response?.submitted_at
+      ? "completed"
+      : "not-started"
+
   const answersFor = (questionsToSave: InquiryQuestion[]): IncomingAnswer[] =>
     questionsToSave
       .map((question) => ({
@@ -283,11 +322,49 @@ export const InquiryDetail = () => {
 
   return (
     <RouteFocusModal>
-      <RouteFocusModal.Header>
-        <RouteFocusModal.Title asChild>
-          <span className="sr-only">{inquiry?.title ?? "Inquiry"}</span>
-        </RouteFocusModal.Title>
-      </RouteFocusModal.Header>
+      {/* The step strip lives in the HEADER, the way every other stepped
+          surface here does it (quote-create, product-create, price-list-create
+          …). In the body it scrolled away with the questions, so on a phone —
+          which is what this wizard is for — a partner three questions down had
+          no idea how many screens were left or that earlier steps were still
+          reachable. In the header it is pinned, and it doubles as the only
+          affordance for going back to a step already passed. */}
+      <ProgressTabs
+        value={String(Math.min(stepIndex, steps.length))}
+        onValueChange={(value) => goToStep(Number(value))}
+        className="flex h-full flex-col overflow-hidden"
+      >
+        <RouteFocusModal.Header>
+          <RouteFocusModal.Title asChild>
+            <span className="sr-only">{inquiry?.title ?? "Inquiry"}</span>
+          </RouteFocusModal.Title>
+          <div className="flex w-full items-center justify-between gap-x-4">
+            <div className="-my-2 w-full max-w-[600px] border-l">
+              <ProgressTabs.List
+                className="grid w-full"
+                style={{
+                  gridTemplateColumns: `repeat(${steps.length + 1}, minmax(0, 1fr))`,
+                }}
+              >
+                {steps.map((step, index) => (
+                  <ProgressTabs.Trigger
+                    key={step.step}
+                    value={String(index)}
+                    status={stepStatus(index)}
+                  >
+                    {step.step}
+                  </ProgressTabs.Trigger>
+                ))}
+                <ProgressTabs.Trigger
+                  value={String(steps.length)}
+                  status={summaryStatus}
+                >
+                  Your answer
+                </ProgressTabs.Trigger>
+              </ProgressTabs.List>
+            </div>
+          </div>
+        </RouteFocusModal.Header>
 
       {/* 🔴 overflow-y-auto is NOT optional on a FocusModal body. Without it
           the body does not scroll, and on a phone — which is the whole point
@@ -359,28 +436,6 @@ export const InquiryDetail = () => {
             </Text>
           </div>
         )}
-
-        <div className="px-6 py-4">
-          <ProgressTabs value={String(Math.min(stepIndex, steps.length))}>
-            <ProgressTabs.List>
-              {steps.map((step, index) => (
-                <ProgressTabs.Trigger
-                  key={step.step}
-                  value={String(index)}
-                  onClick={() => goToStep(index)}
-                >
-                  {step.step}
-                </ProgressTabs.Trigger>
-              ))}
-              <ProgressTabs.Trigger
-                value={String(steps.length)}
-                onClick={() => goToStep(steps.length)}
-              >
-                Your answer
-              </ProgressTabs.Trigger>
-            </ProgressTabs.List>
-          </ProgressTabs>
-        </div>
 
         <div className="flex flex-col gap-6 px-6 py-6">
           {!isSummary &&
@@ -508,6 +563,7 @@ export const InquiryDetail = () => {
           )}
         </div>
       </RouteFocusModal.Footer>
+      </ProgressTabs>
     </RouteFocusModal>
   )
 }


### PR DESCRIPTION
Three things, and one defect found while proving the third.

### The inquiry wizard's steps move into the header

Every other stepped surface here — quote-create, product-create, price-list-create — puts its `ProgressTabs` strip in the `RouteFocusModal` header. The inquiry wizard put it in the **body**, where it scrolled away with the questions. On a phone, which is the entire point of this wizard, a partner three questions down could not see how many screens were left or that earlier steps were still reachable.

Now pinned, with a real per-step status. The status is **derived** from the answers rather than tracked in its own state: a parallel `tabState` drifts the moment a step is revisited and a field cleared, and it drifts in the one direction a progress indicator must never be wrong in — a green tick over an empty step. The "answered" test is the same three-way test the autosave filter uses, sample clause included, so the tab strip and the thing that saves cannot disagree about what an answer is.

### The inquiry becomes six MCP tools

The questions arrive on WhatsApp and a partner standing at a loom answers in a sentence, not in a form. `list_design_inquiries`, `get_design_inquiry`, `answer_design_inquiry`, `submit_design_inquiry`, `list_capability_samples`, `create_capability_sample` let the assistant walk the same steps in conversation — `questions[].step` is in the payload precisely so it asks a screenful at a time and saves before moving on.

- The assistant **asks**; it does not answer. Inventing a lead time or a price from context would put a number in front of a designer that no maker ever said.
- No tool here can see another partner's answers.
- Files cannot travel through an MCP tool — the upload is multipart. `create_capability_sample` takes media ids and says so in the field description. Better to say where the door is than to offer a parameter that goes nowhere.
- `submit_design_inquiry` is `sensitive`: it is what the designer reads.

🔑 **Proved by calling them.** `partner-mcp-inquiries.spec.ts` executes all six over a real `tools/call`. This repo has twice accepted `tools/list` as evidence and been wrong (#1394's three tools that could never succeed; the retracted admin-MCP claim), and a field missing from `bodyParams` is dropped in **silence** with the call still reporting ok. It is also the first integration coverage #1531 has had at all.

### Inventory selection when the run is CREATED, not only when it is approved

The API has taken per-assignment `materials` since #1361 and the approve drawer has offered the picker since. Creating the run **from the design** — the path most runs are actually born on — could not, so splitting a BOM between a dyer and a weaver meant approving first and editing after.

🔴 The API did **not** already exist on this path. The route hands `assignments` to `approveProductionRunWorkflow` verbatim and that workflow has understood `materials` for months — but this route's own validator never declared the field, and the validator is strict, so `materials` was a 400 rather than a pass-through. Same defect as the `template_names` note four lines above it in the same file.

### The allocation could not hold half a metre

Found by asserting `2.5` and being handed `3`.

`planned_quantity` on the run↔inventory link is declared `{ type: "decimal" }`, and Medusa's link schema generator turns a bare decimal into **`numeric(10,0)` — scale ZERO**. Postgres rounded on the way in while the picker offered a `step="0.01"` box the whole time.

The link now carries `columnType: "numeric(20,6)"` (covers a fresh database) plus a migration for the ones that already exist, where the generator leaves an existing column alone. Widening only; `down` is deliberately empty, because narrowing back would round every fractional quantity written since.

⚠️ `design_design_inventory_inventory_item.planned_quantity` has the **same** defect and is deliberately untouched: the design's BOM feeds the cost engine, and changing what a BOM quantity can express is a bigger decision than fixing the column an operator just typed into.

### Verified

- `partner-mcp-inquiries.spec.ts` — 8/8, every tool executed for real.
- `design-production-run-assignment-materials.spec.ts` — 3/3, including 2.5 stored as 2.5 and an off-BOM item refused.
- MCP unit suites — 425/425, including the slicer invariant that failed until both new route families got an ask a partner would really type.
- `check:prod-build` green; partner-ui typecheck and build green.

**NOT verified:** neither screen has been rendered in a browser. The tab strip and the material picker compile, typecheck and build; that is all that proves.

⚠️ Carries a migration. #1547's deploy has landed and was confirmed by probe, so this is not stacked behind an unapplied one.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_0158wJMZ1DmjNxXf5uGuBrQD