### PR TITLE
fix(e2e): unbreak the Actions selector that has failed on main since 25 Aug

### DIFF
--- a/e2e/specs/production-run-reassign.spec.ts
+++ b/e2e/specs/production-run-reassign.spec.ts
@@ -101,7 +101,20 @@ test.describe("Production run manual reassignment (#1228)", () => {
     // reassignment source (a plain correction before the partner accepts).
     await page.goto(`/app/production-runs/${seed.parkedRunId}`)
 
-    await page.getByRole("button", { name: "Actions" }).click()
+    /**
+     * `exact: true` — Playwright matches an accessible name by SUBSTRING and
+     * case-insensitively by default, so `{ name: "Actions" }` also matches the
+     * shared ActionMenu's `aria-label="Open actions menu"`. This page carries
+     * both that menu and its own `aria-label="Actions"` IconButton, so the
+     * query resolved to two elements and Playwright refused in strict mode.
+     *
+     * 🔑 The page is not at fault and neither is the assertion — two distinct
+     * menus on one screen is legitimate. The collision appeared when the shared
+     * ActionMenu gained its aria-label in #1488 (836841ffb), which is why a test
+     * nobody touched started failing: the DOM this queries changed underneath a
+     * selector that was only ever unambiguous by luck.
+     */
+    await page.getByRole("button", { name: "Actions", exact: true }).click()
     const differentPartner = page.getByText("Assign a different partner")
     await expect(differentPartner).toBeVisible({ timeout: 10000 })
     await differentPartner.click()


### PR DESCRIPTION
## One line, and it unblocks e2e for every branch

`e2e/specs/production-run-reassign.spec.ts:104` has failed on **8 consecutive
e2e runs since 25 Aug — 4 of them on `main`**. Every PR since inherits a red
e2e, so nobody's branch can be green.

```
strict mode violation: getByRole('button', { name: 'Actions' })
resolved to 2 elements:
  1) aria-label="Actions"            production-runs/[id]/page.tsx:287
  2) aria-label="Open actions menu"  components/common/action-menu.tsx:48
```

Playwright matches an accessible name by **substring, case-insensitively**, so a
query for `"Actions"` also matches `"Open actions menu"`. The shared `ActionMenu`
gained that `aria-label` in **#1488** (`836841ffb`) — which is why a spec nobody
had touched started failing. The DOM changed underneath a selector that was only
ever unambiguous by accident.

## This is not papering over a regression

Worth stating plainly, because "make the failing test pass" is exactly how real
bugs get buried:

- **The page is fine.** Two distinct menus on one screen is legitimate — a
  page-level dropdown and a shared ActionMenu.
- **The assertion is fine.** It still tests the reassignment flow it always did.
- **Only the query was ambiguous**, and `exact: true` is the fix Playwright's own
  error message suggests (`aka getByRole('button', { name: 'Actions', exact: true })`).

🔑 I verified `exact: true` selects the **right** menu, not merely a unique one:
"Assign a different partner" — the item this test clicks on the very next line —
lives inside the `aria-label="Actions"` DropdownMenu at `page.tsx:309`, which is
the button that survives the exact match. Checked in the source rather than
inferred from the error text.

I also swept the rest of `e2e/` for the same collision. The only other
actions-menu query is `/open actions menu/i` in `admin-quote-surface.spec.ts`,
which cannot match a bare `"Actions"` — so this is the only affected spec.

## Not verified locally

The e2e job does `cp apps/backend/.env.test apps/backend/.env` and rebuilds the
database. Running it here would clobber the dev environment for a one-line
selector change. CI is the right instrument, and it's ~8 minutes.

## Unrelated, but you should know

`main` is **also red on `test (2)`** at `db9465c18` — a different failure from
this one. PRs only run `test (1)`, so a green PR certifies one shard of eight.
That is the same blind spot that let main sit red for four days last week. Not
addressed here.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_0158wJMZ1DmjNxXf5uGuBrQD
