### PR TITLE
fix(payments): the payout screen listed designs — a design is not a payable thing (#1556)

### DIFF
--- a/apps/backend/integration-tests/http/payment-submissions-api.spec.ts
+++ b/apps/backend/integration-tests/http/payment-submissions-api.spec.ts
@@ -722,6 +722,397 @@ setupSharedTestSuite(() => {
 
   // ─── Admin: List Submissions ──────────────────────────────────────────────
 
+  /**
+   * A COMPLETED production run for this partner, written straight through the
+   * module service.
+   *
+   * The fixture only needs the end state, and driving a real dispatch →
+   * accept → complete cycle would drag partner auth and the whole run lifecycle
+   * into a test about payment. Mirrors the shape completion leaves behind,
+   * including the parent/child convention: the partner and the money live on
+   * the CHILD run, and a parent carries `partner_id: null`.
+   */
+  async function createCompletedRun(
+    designId: string,
+    designName: string,
+    overrides: Record<string, any> = {}
+  ) {
+    const container = getContainer()
+    const runService: any = container.resolve("production_runs")
+    const run = await runService.createProductionRuns({
+      design_id: designId,
+      partner_id: partnerId,
+      quantity: 9,
+      produced_quantity: 4,
+      partner_cost_estimate: 1200,
+      cost_type: "per_unit",
+      run_type: "production",
+      status: "completed",
+      completed_at: new Date(),
+      snapshot: { design: { id: designId, name: designName } },
+      captured_at: new Date(),
+      ...overrides,
+    })
+    return (Array.isArray(run) ? run[0] : run).id as string
+  }
+
+  // ─── Payable runs (#1556) ─────────────────────────────────────────────────
+
+  describe("GET /admin/payment-submissions/payable-runs", () => {
+    it("requires partner_id rather than listing every completed run", async () => {
+      // An unfiltered variant would return every partner's runs. That exact
+      // shape — a missing filter reading as "no filter" rather than "no rows" —
+      // is how one dangling key produced unfiltered cross-tenant results.
+      const res = await api
+        .get("/admin/payment-submissions/payable-runs", adminHeaders)
+        .catch((e: any) => e.response)
+
+      expect(res.status).toBe(400)
+    })
+
+    it("prices a run from the run, and bills the PRODUCED quantity", async () => {
+      // The design says 5000/unit; the run says 1200/unit and 4 pieces made.
+      // Pricing off the design here would bill 5000 x 9 = 45,000 for work worth
+      // 4,800 — the two figures are not close, and the run is the agreed one.
+      const d1 = await createDesign("Payable Run Design", {
+        estimated_cost: 5000,
+      })
+      await linkDesignToPartner(d1, partnerId)
+      const runId = await createCompletedRun(d1, "Payable Run Design")
+
+      const res = await api.get(
+        `/admin/payment-submissions/payable-runs?partner_id=${partnerId}`,
+        adminHeaders
+      )
+
+      expect(res.status).toBe(200)
+      const row = res.data.payable_runs.find((r: any) => r.run_id === runId)
+      expect(row).toBeDefined()
+      expect(row.ordered_quantity).toBe(9)
+      expect(row.produced_quantity).toBe(4)
+      // 🔑 The founder rule: pay for what was MADE, not what was ordered.
+      expect(row.payable_quantity).toBe(4)
+      expect(row.quantity_basis).toBe("produced")
+      expect(row.unit_amount).toBe(1200)
+      expect(row.amount).toBe(4800)
+      expect(row.payable).toBe(true)
+      expect(row.billed).toBeNull()
+    })
+
+    it("divides a 'total' cost_type back out to a per-unit rate", async () => {
+      // `partner_cost_estimate` is stored verbatim and paired with `cost_type`;
+      // a "total" of 3600 across 3 ordered pieces is 1200/unit. Reading it as
+      // per-unit would bill 3600 x 3.
+      const d1 = await createDesign("Total Cost Run", { estimated_cost: 100 })
+      await linkDesignToPartner(d1, partnerId)
+      await createCompletedRun(d1, "Total Cost Run", {
+        quantity: 3,
+        produced_quantity: 3,
+        partner_cost_estimate: 3600,
+        cost_type: "total",
+      })
+
+      const res = await api.get(
+        `/admin/payment-submissions/payable-runs?partner_id=${partnerId}`,
+        adminHeaders
+      )
+      const row = res.data.payable_runs[0]
+      expect(row.unit_amount).toBe(1200)
+      expect(row.amount).toBe(3600)
+    })
+
+    it("falls back to the ordered quantity and SAYS SO when output was never recorded", async () => {
+      // "We never recorded output" and "they made zero" must not look alike.
+      const d1 = await createDesign("No Output Run", { estimated_cost: 100 })
+      await linkDesignToPartner(d1, partnerId)
+      await createCompletedRun(d1, "No Output Run", {
+        quantity: 5,
+        produced_quantity: null,
+      })
+
+      const res = await api.get(
+        `/admin/payment-submissions/payable-runs?partner_id=${partnerId}`,
+        adminHeaders
+      )
+      const row = res.data.payable_runs[0]
+      expect(row.produced_quantity).toBeNull()
+      expect(row.payable_quantity).toBe(5)
+      expect(row.quantity_basis).toBe("ordered")
+    })
+
+    it("marks a run with no agreed rate unpayable instead of billing zero", async () => {
+      // A run with no cost is not a zero-value payout — it is a run whose price
+      // has not been settled. Surfaced, not silently dropped.
+      const d1 = await createDesign("Unpriced Run", { estimated_cost: 100 })
+      await linkDesignToPartner(d1, partnerId)
+      await createCompletedRun(d1, "Unpriced Run", {
+        partner_cost_estimate: null,
+      })
+
+      const res = await api.get(
+        `/admin/payment-submissions/payable-runs?partner_id=${partnerId}`,
+        adminHeaders
+      )
+      const row = res.data.payable_runs[0]
+      expect(row.payable).toBe(false)
+      expect(row.unit_amount).toBe(0)
+    })
+
+    it("never returns another partner's runs, nor an unfinished one", async () => {
+      const other = await createPartnerWithAuth(
+        Math.floor(Math.random() * 100000)
+      )
+      const d1 = await createDesign("Other Partner Run", {
+        estimated_cost: 100,
+      })
+      await linkDesignToPartner(d1, other.partnerId)
+      const otherRunId = await createCompletedRun(d1, "Other Partner Run", {
+        partner_id: other.partnerId,
+      })
+
+      const d2 = await createDesign("In Progress Run", { estimated_cost: 100 })
+      await linkDesignToPartner(d2, partnerId)
+      const inProgressId = await createCompletedRun(d2, "In Progress Run", {
+        status: "in_progress",
+      })
+
+      const res = await api.get(
+        `/admin/payment-submissions/payable-runs?partner_id=${partnerId}`,
+        adminHeaders
+      )
+
+      const ids = res.data.payable_runs.map((r: any) => r.run_id)
+      expect(ids).not.toContain(otherRunId)
+      expect(ids).not.toContain(inProgressId)
+    })
+  })
+
+  describe("POST /admin/payment-submissions — run provenance (#1556)", () => {
+    it("records which runs a line paid for, and reports them as billed", async () => {
+      const d1 = await createDesign("Provenance Design", {
+        estimated_cost: 5000,
+      })
+      await linkDesignToPartner(d1, partnerId)
+      const runId = await createCompletedRun(d1, "Provenance Design")
+
+      const res = await api.post(
+        "/admin/payment-submissions",
+        {
+          partner_id: partnerId,
+          design_ids: [d1],
+          quantities: { [d1]: 4 },
+          unit_amounts: { [d1]: 1200 },
+          production_run_ids: { [d1]: [runId] },
+        },
+        adminHeaders
+      )
+      expect(res.status).toBe(201)
+      const submissionId = res.data.payment_submission.id
+
+      const detail = await api.get(
+        `/admin/payment-submissions/${submissionId}`,
+        adminHeaders
+      )
+      const item = detail.data.payment_submission.items[0]
+      // A real column, not a metadata key — this is what the double-pay guard
+      // reads, and a guard reading an untyped blob reads nothing when the key
+      // is misspelt.
+      expect(item.production_run_ids).toEqual([runId])
+
+      const runs = await api.get(
+        `/admin/payment-submissions/payable-runs?partner_id=${partnerId}`,
+        adminHeaders
+      )
+      const row = runs.data.payable_runs.find((r: any) => r.run_id === runId)
+      expect(row.billed).not.toBeNull()
+      expect(row.billed.submission_id).toBe(submissionId)
+      expect(Number(row.billed.quantity)).toBe(4)
+    })
+
+    it("refuses to pay for the same run twice, even after the first payout closed", async () => {
+      // 🔴 The case the design-level guard cannot catch. "Is this design in an
+      // OPEN submission" stops being true the moment the first submission is
+      // Approved or Paid — after which the same finished run can be claimed
+      // again and the second claim looks exactly as legitimate as the first.
+      const d1 = await createDesign("Double Pay Design", {
+        estimated_cost: 5000,
+      })
+      await linkDesignToPartner(d1, partnerId)
+      const runId = await createCompletedRun(d1, "Double Pay Design")
+
+      const first = await api.post(
+        "/admin/payment-submissions",
+        {
+          partner_id: partnerId,
+          design_ids: [d1],
+          quantities: { [d1]: 4 },
+          unit_amounts: { [d1]: 1200 },
+          production_run_ids: { [d1]: [runId] },
+        },
+        adminHeaders
+      )
+      expect(first.status).toBe(201)
+
+      // Close the first payout so the design-level guard is out of the way and
+      // ONLY the run-level guard is under test.
+      const approved = await api.post(
+        `/admin/payment-submissions/${first.data.payment_submission.id}/review`,
+        { action: "approve", paid_to_id: paidToId },
+        adminHeaders
+      )
+      expect(approved.status).toBe(200)
+
+      const second = await api
+        .post(
+          "/admin/payment-submissions",
+          {
+            partner_id: partnerId,
+            design_ids: [d1],
+            quantities: { [d1]: 4 },
+            unit_amounts: { [d1]: 1200 },
+            production_run_ids: { [d1]: [runId] },
+          },
+          adminHeaders
+        )
+        .catch((e: any) => e.response)
+
+      expect(second.status).toBe(400)
+      expect(second.data.message).toContain("already paid for")
+      expect(second.data.message).toContain(runId)
+    })
+
+    it("releases a run when its submission was rejected", async () => {
+      // A Rejected submission never paid anyone. The exact situation the
+      // Shramdaan correction hit: a payout billed the wrong quantity, was
+      // rejected, and the replacement has to be allowed to bill the same run.
+      const d1 = await createDesign("Rejected Release Design", {
+        estimated_cost: 5000,
+      })
+      await linkDesignToPartner(d1, partnerId)
+      const runId = await createCompletedRun(d1, "Rejected Release Design")
+
+      const first = await api.post(
+        "/admin/payment-submissions",
+        {
+          partner_id: partnerId,
+          design_ids: [d1],
+          quantities: { [d1]: 4 },
+          unit_amounts: { [d1]: 1200 },
+          production_run_ids: { [d1]: [runId] },
+        },
+        adminHeaders
+      )
+      await api.post(
+        `/admin/payment-submissions/${first.data.payment_submission.id}/review`,
+        { action: "reject", rejection_reason: "Quantity corrected 4 -> 7" },
+        adminHeaders
+      )
+
+      const replacement = await api.post(
+        "/admin/payment-submissions",
+        {
+          partner_id: partnerId,
+          design_ids: [d1],
+          quantities: { [d1]: 7 },
+          unit_amounts: { [d1]: 1200 },
+          production_run_ids: { [d1]: [runId] },
+        },
+        adminHeaders
+      )
+
+      expect(replacement.status).toBe(201)
+      expect(Number(replacement.data.payment_submission.total_amount)).toBe(8400)
+    })
+
+    it("refuses a run that belongs to another partner", async () => {
+      const other = await createPartnerWithAuth(
+        Math.floor(Math.random() * 100000)
+      )
+      const d1 = await createDesign("Cross Partner Design", {
+        estimated_cost: 5000,
+      })
+      // Linked to BOTH so the ownership check under test is the RUN's, not the
+      // design's — otherwise this passes for the wrong reason.
+      await linkDesignToPartner(d1, partnerId)
+      await linkDesignToPartner(d1, other.partnerId)
+      const foreignRun = await createCompletedRun(d1, "Cross Partner Design", {
+        partner_id: other.partnerId,
+      })
+
+      const res = await api
+        .post(
+          "/admin/payment-submissions",
+          {
+            partner_id: partnerId,
+            design_ids: [d1],
+            quantities: { [d1]: 4 },
+            unit_amounts: { [d1]: 1200 },
+            production_run_ids: { [d1]: [foreignRun] },
+          },
+          adminHeaders
+        )
+        .catch((e: any) => e.response)
+
+      // 400, not 403 — MedusaError.Types.NOT_ALLOWED maps to a 400 here, the
+      // same as the existing "Designs not assigned to this partner" check.
+      // The MESSAGE is what distinguishes the two refusals.
+      expect(res.status).toBe(400)
+      expect(res.data.message).toContain("does not belong to this partner")
+    })
+
+    it("refuses a run that is not completed", async () => {
+      const d1 = await createDesign("Unfinished Design", {
+        estimated_cost: 5000,
+      })
+      await linkDesignToPartner(d1, partnerId)
+      const runId = await createCompletedRun(d1, "Unfinished Design", {
+        status: "in_progress",
+      })
+
+      const res = await api
+        .post(
+          "/admin/payment-submissions",
+          {
+            partner_id: partnerId,
+            design_ids: [d1],
+            quantities: { [d1]: 4 },
+            unit_amounts: { [d1]: 1200 },
+            production_run_ids: { [d1]: [runId] },
+          },
+          adminHeaders
+        )
+        .catch((e: any) => e.response)
+
+      expect(res.status).toBe(400)
+      expect(res.data.message).toContain("not completed")
+    })
+
+    it("refuses a run that belongs to a different design", async () => {
+      const d1 = await createDesign("Claim Design", { estimated_cost: 5000 })
+      const d2 = await createDesign("Actual Design", { estimated_cost: 5000 })
+      await linkDesignToPartner(d1, partnerId)
+      await linkDesignToPartner(d2, partnerId)
+      const runOfD2 = await createCompletedRun(d2, "Actual Design")
+
+      const res = await api
+        .post(
+          "/admin/payment-submissions",
+          {
+            partner_id: partnerId,
+            design_ids: [d1],
+            quantities: { [d1]: 4 },
+            unit_amounts: { [d1]: 1200 },
+            production_run_ids: { [d1]: [runOfD2] },
+          },
+          adminHeaders
+        )
+        .catch((e: any) => e.response)
+
+      expect(res.status).toBe(400)
+      expect(res.data.message).toContain("is not a run of design")
+    })
+  })
+
   describe("GET /admin/payment-submissions", () => {
     it("should list all submissions", async () => {
       const d1 = await createDesign("Admin List Design")

--- a/apps/backend/src/admin/components/creates/create-payment-submission.tsx
+++ b/apps/backend/src/admin/components/creates/create-payment-submission.tsx
@@ -18,7 +18,11 @@ import { RouteFocusModal } from "../modal/route-focus-modal"
 import { useDesigns, type AdminDesign } from "../../hooks/api/designs"
 import { usePartnerTasks, type AdminPartnerTask } from "../../hooks/api/partner-tasks"
 import { usePartners } from "../../hooks/api/partners-admin"
-import { useCreatePaymentSubmission } from "../../hooks/api/payment-submissions"
+import {
+  useCreatePaymentSubmission,
+  usePayableRuns,
+  type PayableRun,
+} from "../../hooks/api/payment-submissions"
 
 const ELIGIBLE_DESIGN_STATUSES = ["Commerce_Ready", "Approved"] as const
 const ELIGIBLE_TASK_STATUSES = ["completed"] as const
@@ -35,16 +39,45 @@ const getTaskCost = (t: AdminPartnerTask): number => {
  * Admin-initiated payment submission flow.
  *
  * 1. Pick a partner (searchable).
- * 2. Once picked, load that partner's eligible designs + tasks.
- * 3. Select items across the two tabs, override costs inline, add notes.
+ * 2. Once picked, load that partner's payable production RUNS, plus the older
+ *    design and task lists.
+ * 3. Select items, adjust quantity/rate inline, add notes.
  * 4. Submit — creates a Pending submission under the partner's name via the
  *    shared createPaymentSubmissionWorkflow.
+ *
+ * ## Why "Runs" is the default tab
+ *
+ * This screen used to open on DESIGNS, and that was the bug. A design is a
+ * recipe — produced many times — and it carries only a PER-UNIT cost. Billing
+ * from it meant billing that per-unit figure exactly once, with no quantity
+ * input anywhere on the screen: ₹850 for nine finished garments (#1554).
+ *
+ * A run is the payable thing. It knows the rate the partner agreed
+ * (`partner_cost_estimate` + `cost_type`) and how many pieces they actually
+ * made (`produced_quantity`), and it is the unit that can be marked as paid so
+ * the next submission refuses to pay for it twice.
+ *
+ * 🔑 The quantity defaults to PRODUCED, not ordered — a partner is paid for
+ * what they made. Where the two disagree the row says so out loud rather than
+ * silently picking one.
+ *
+ * The designs and tasks tabs are kept: work that never had a run (and task
+ * work, which is not production output at all) still has to be payable.
  */
 export const CreatePaymentSubmissionComponent = () => {
   const navigate = useNavigate()
 
   const [partnerId, setPartnerId] = useState<string>("")
-  const [activeTab, setActiveTab] = useState<"designs" | "tasks">("designs")
+  const [activeTab, setActiveTab] = useState<"runs" | "designs" | "tasks">(
+    "runs"
+  )
+  const [selectedRunIds, setSelectedRunIds] = useState<Set<string>>(new Set())
+  const [runQuantityOverrides, setRunQuantityOverrides] = useState<
+    Record<string, number>
+  >({})
+  const [runRateOverrides, setRunRateOverrides] = useState<
+    Record<string, number>
+  >({})
   const [selectedDesignIds, setSelectedDesignIds] = useState<Set<string>>(
     new Set()
   )
@@ -79,6 +112,16 @@ export const CreatePaymentSubmissionComponent = () => {
     enabled: !!partnerId,
   })
 
+  // Payable production runs — the primary source of truth for what to pay.
+  const { payable_runs: payableRuns, isPending: runsLoading } =
+    usePayableRuns(partnerId || undefined)
+
+  /** Runs that can actually be billed now: priced, and not already paid for. */
+  const selectableRuns = useMemo(
+    () => payableRuns.filter((r) => r.payable && !r.billed),
+    [payableRuns]
+  )
+
   const eligibleDesigns = useMemo(
     () =>
       designs.filter((d) =>
@@ -103,6 +146,9 @@ export const CreatePaymentSubmissionComponent = () => {
     useCreatePaymentSubmission()
 
   const resetSelection = () => {
+    setSelectedRunIds(new Set())
+    setRunQuantityOverrides({})
+    setRunRateOverrides({})
     setSelectedDesignIds(new Set())
     setSelectedTaskIds(new Set())
     setDesignCostOverrides({})
@@ -122,6 +168,65 @@ export const CreatePaymentSubmissionComponent = () => {
       return next
     })
   }, [])
+
+  const toggleRun = useCallback((id: string) => {
+    setSelectedRunIds((prev) => {
+      const next = new Set(prev)
+      next.has(id) ? next.delete(id) : next.add(id)
+      return next
+    })
+  }, [])
+
+  const selectAllRuns = useCallback(() => {
+    setSelectedRunIds((prev) =>
+      prev.size === selectableRuns.length
+        ? new Set()
+        : new Set(selectableRuns.map((r) => r.run_id))
+    )
+  }, [selectableRuns])
+
+  /** Units billed for a run — the produced figure unless an admin retyped it. */
+  const getRunQuantity = useCallback(
+    (run: PayableRun): number =>
+      runQuantityOverrides[run.run_id] != null
+        ? runQuantityOverrides[run.run_id]
+        : run.payable_quantity,
+    [runQuantityOverrides]
+  )
+
+  /** The per-unit rate — the run's agreed rate unless an admin retyped it. */
+  const getRunRate = useCallback(
+    (run: PayableRun): number =>
+      runRateOverrides[run.run_id] != null
+        ? runRateOverrides[run.run_id]
+        : run.unit_amount,
+    [runRateOverrides]
+  )
+
+  const getRunAmount = useCallback(
+    (run: PayableRun): number =>
+      Math.round(getRunQuantity(run) * getRunRate(run) * 100) / 100,
+    [getRunQuantity, getRunRate]
+  )
+
+  const handleRunNumberChange = (
+    setter: React.Dispatch<React.SetStateAction<Record<string, number>>>,
+    id: string,
+    value: string
+  ) => {
+    const num = parseFloat(value)
+    // An empty or unparseable box falls back to the run's own figure rather
+    // than to zero — a half-typed number must never silently bill nothing.
+    if (value === "" || isNaN(num)) {
+      setter((prev) => {
+        const next = { ...prev }
+        delete next[id]
+        return next
+      })
+    } else {
+      setter((prev) => ({ ...prev, [id]: num }))
+    }
+  }
 
   const toggleTask = useCallback((id: string) => {
     setSelectedTaskIds((prev) => {
@@ -191,7 +296,63 @@ export const CreatePaymentSubmissionComponent = () => {
   }
 
   // ─── Totals ─────────────────────────────────────────────────────────
-  const totalSelected = selectedDesignIds.size + selectedTaskIds.size
+  const selectedRuns = useMemo(
+    () => selectableRuns.filter((r) => selectedRunIds.has(r.run_id)),
+    [selectableRuns, selectedRunIds]
+  )
+
+  /**
+   * Selected runs folded into the design-keyed shape the workflow bills in.
+   *
+   * A submission line is keyed by DESIGN, so two completed runs of the same
+   * design collapse into one line whose quantity is their sum. Where those runs
+   * were priced at the SAME rate the line keeps that rate and the breakdown
+   * still reads "n × rate". Where the rates DIFFER there is no single honest
+   * rate to state, so the line carries a typed total instead and records no
+   * unit_amount — deriving one by dividing the total back out would invent a
+   * rate nobody agreed to.
+   */
+  const runLinesByDesign = useMemo(() => {
+    const byDesign = new Map<
+      string,
+      { runs: PayableRun[]; quantity: number; amount: number; rates: Set<number> }
+    >()
+
+    for (const run of selectedRuns) {
+      const entry = byDesign.get(run.design_id) ?? {
+        runs: [],
+        quantity: 0,
+        amount: 0,
+        rates: new Set<number>(),
+      }
+      entry.runs.push(run)
+      entry.quantity += getRunQuantity(run)
+      entry.amount = Math.round((entry.amount + getRunAmount(run)) * 100) / 100
+      entry.rates.add(getRunRate(run))
+      byDesign.set(run.design_id, entry)
+    }
+
+    return byDesign
+  }, [selectedRuns, getRunQuantity, getRunAmount, getRunRate])
+
+  const runsTotal = useMemo(
+    () => selectedRuns.reduce((sum, r) => sum + getRunAmount(r), 0),
+    [selectedRuns, getRunAmount]
+  )
+
+  /**
+   * A design cannot be billed twice in one submission — the workflow writes one
+   * line per design, so a design picked in BOTH the runs tab and the designs
+   * tab would silently lose one of the two amounts.
+   */
+  const conflictingDesignIds = useMemo(
+    () =>
+      [...runLinesByDesign.keys()].filter((id) => selectedDesignIds.has(id)),
+    [runLinesByDesign, selectedDesignIds]
+  )
+
+  const totalSelected =
+    selectedRuns.length + selectedDesignIds.size + selectedTaskIds.size
 
   const totalAmount = useMemo(() => {
     const designTotal = eligibleDesigns
@@ -200,8 +361,9 @@ export const CreatePaymentSubmissionComponent = () => {
     const taskTotal = eligibleTasks
       .filter((t) => selectedTaskIds.has(t.id))
       .reduce((sum, t) => sum + getEffectiveTaskCost(t), 0)
-    return designTotal + taskTotal
+    return designTotal + taskTotal + runsTotal
   }, [
+    runsTotal,
     eligibleDesigns,
     selectedDesignIds,
     getEffectiveDesignCost,
@@ -217,7 +379,30 @@ export const CreatePaymentSubmissionComponent = () => {
       return
     }
     if (totalSelected === 0) {
-      toast.error("Select at least one design or task")
+      toast.error("Select at least one run, design or task")
+      return
+    }
+
+    if (conflictingDesignIds.length) {
+      const names = conflictingDesignIds.map(
+        (id) =>
+          runLinesByDesign.get(id)?.runs[0]?.design_name ||
+          eligibleDesigns.find((d) => d.id === id)?.name ||
+          id
+      )
+      toast.error(
+        `Already billed via a production run — deselect it in the Designs tab: ${names.join(", ")}`
+      )
+      return
+    }
+
+    const zeroRateRuns = selectedRuns.filter((r) => getRunAmount(r) <= 0)
+    if (zeroRateRuns.length) {
+      toast.error(
+        `Enter a rate and quantity for: ${zeroRateRuns
+          .map((r) => r.design_name || r.run_id)
+          .join(", ")}`
+      )
       return
     }
 
@@ -245,17 +430,53 @@ export const CreatePaymentSubmissionComponent = () => {
        * `cost_overrides` / `task_cost_overrides` directly and folds them onto
        * the metadata channel itself.
        */
+      // Fold the selected runs into the design-keyed money contract. See
+      // `runLinesByDesign` for why a mixed-rate design becomes a typed total
+      // rather than an invented per-unit rate.
+      const quantities: Record<string, number> = {}
+      const unitAmounts: Record<string, number> = {}
+      const runCostOverrides: Record<string, number> = { ...designCostOverrides }
+      const productionRunIds: Record<string, string[]> = {}
+
+      for (const [designId, line] of runLinesByDesign.entries()) {
+        quantities[designId] = line.quantity
+        productionRunIds[designId] = line.runs.map((r) => r.run_id)
+        if (line.rates.size === 1) {
+          unitAmounts[designId] = [...line.rates][0]
+        } else {
+          runCostOverrides[designId] = line.amount
+        }
+      }
+
+      const runDesignIds = [...runLinesByDesign.keys()]
+
       const { payment_submission } = await createSubmission({
         partner_id: partnerId,
-        design_ids: Array.from(selectedDesignIds),
+        design_ids: [
+          ...new Set([...runDesignIds, ...Array.from(selectedDesignIds)]),
+        ],
         task_ids: Array.from(selectedTaskIds),
         notes: notes || undefined,
-        cost_overrides: Object.keys(designCostOverrides).length
-          ? designCostOverrides
+        quantities: Object.keys(quantities).length ? quantities : undefined,
+        unit_amounts: Object.keys(unitAmounts).length ? unitAmounts : undefined,
+        cost_overrides: Object.keys(runCostOverrides).length
+          ? runCostOverrides
           : undefined,
         task_cost_overrides: Object.keys(taskCostOverrides).length
           ? taskCostOverrides
           : undefined,
+        // The evidence behind the money: which finished runs this pays for, so
+        // the next submission can refuse to pay for them again.
+        production_run_ids: runDesignIds.length ? productionRunIds : undefined,
+        /**
+         * 🔑 Paying out a COMPLETED RUN, whose proof of finished work is the
+         * run itself. Completion moves a design to Technical_Review, so the
+         * design-status gate would reject every run-sourced payout — and the
+         * only way through used to be editing the design's status, i.e.
+         * changing what the record asserts about technical review in order to
+         * release a payment. Only sent when runs are actually being billed.
+         */
+        require_design_status: runDesignIds.length ? false : undefined,
       })
       toast.success("Payment submission created")
       navigate(`/payment-submissions/${payment_submission.id}`)
@@ -284,7 +505,10 @@ export const CreatePaymentSubmissionComponent = () => {
             {totalSelected > 0 && (
               <Text className="text-ui-fg-subtle">
                 {totalSelected} item{totalSelected !== 1 ? "s" : ""} ={" "}
-                <span className="font-semibold text-ui-fg-base">
+                <span
+                  className="font-semibold text-ui-fg-base"
+                  data-testid="submission-total"
+                >
                   INR {totalAmount.toLocaleString()}
                 </span>
               </Text>
@@ -354,15 +578,28 @@ export const CreatePaymentSubmissionComponent = () => {
           {!partnerId ? (
             <Container className="p-8">
               <Text className="text-ui-fg-subtle text-center">
-                Pick a partner to load their eligible designs and tasks.
+                Pick a partner to load their payable production runs.
               </Text>
             </Container>
           ) : (
             <Tabs
               value={activeTab}
-              onValueChange={(v) => setActiveTab(v as "designs" | "tasks")}
+              onValueChange={(v) =>
+                setActiveTab(v as "runs" | "designs" | "tasks")
+              }
             >
               <Tabs.List>
+                <Tabs.Trigger value="runs">
+                  Production runs{" "}
+                  <Badge size="2xsmall" color="grey" className="ml-2">
+                    {selectableRuns.length}
+                  </Badge>
+                  {selectedRunIds.size > 0 && (
+                    <Badge size="2xsmall" color="green" className="ml-1">
+                      {selectedRunIds.size} picked
+                    </Badge>
+                  )}
+                </Tabs.Trigger>
                 <Tabs.Trigger value="designs">
                   Designs{" "}
                   <Badge size="2xsmall" color="grey" className="ml-2">
@@ -386,6 +623,27 @@ export const CreatePaymentSubmissionComponent = () => {
                   )}
                 </Tabs.Trigger>
               </Tabs.List>
+
+              <Tabs.Content value="runs" className="mt-4">
+                <RunsPanel
+                  runs={payableRuns}
+                  isLoading={runsLoading}
+                  selectedIds={selectedRunIds}
+                  onToggle={toggleRun}
+                  onSelectAll={selectAllRuns}
+                  quantityOverrides={runQuantityOverrides}
+                  rateOverrides={runRateOverrides}
+                  onQuantityChange={(id, value) =>
+                    handleRunNumberChange(setRunQuantityOverrides, id, value)
+                  }
+                  onRateChange={(id, value) =>
+                    handleRunNumberChange(setRunRateOverrides, id, value)
+                  }
+                  getQuantity={getRunQuantity}
+                  getRate={getRunRate}
+                  getAmount={getRunAmount}
+                />
+              </Tabs.Content>
 
               <Tabs.Content value="designs" className="mt-4">
                 <DesignsPanel
@@ -417,6 +675,252 @@ export const CreatePaymentSubmissionComponent = () => {
         </div>
       </RouteFocusModal.Body>
     </>
+  )
+}
+
+// ─── Production runs panel ────────────────────────────────────────────
+/**
+ * One row per completed RUN — the thing that actually carries a rate and a
+ * piece count. The screen this replaces listed designs and had no quantity
+ * input at all, which is how a per-unit rate came to be billed once (#1554).
+ *
+ * Rows that cannot be billed are shown rather than filtered away: a run with no
+ * agreed rate, and a run already paid for, are both things an admin looking for
+ * "why isn't this here" needs to SEE. They are visibly non-selectable instead.
+ */
+const RunsPanel = ({
+  runs,
+  isLoading,
+  selectedIds,
+  onToggle,
+  onSelectAll,
+  quantityOverrides,
+  rateOverrides,
+  onQuantityChange,
+  onRateChange,
+  getQuantity,
+  getRate,
+  getAmount,
+}: {
+  runs: PayableRun[]
+  isLoading: boolean
+  selectedIds: Set<string>
+  onToggle: (id: string) => void
+  onSelectAll: () => void
+  quantityOverrides: Record<string, number>
+  rateOverrides: Record<string, number>
+  onQuantityChange: (id: string, value: string) => void
+  onRateChange: (id: string, value: string) => void
+  getQuantity: (run: PayableRun) => number
+  getRate: (run: PayableRun) => number
+  getAmount: (run: PayableRun) => number
+}) => {
+  if (isLoading) {
+    return (
+      <Container className="p-8">
+        <Text className="text-ui-fg-subtle text-center">
+          Loading production runs...
+        </Text>
+      </Container>
+    )
+  }
+
+  if (!runs.length) {
+    return (
+      <Container className="p-8">
+        <Text className="text-ui-fg-subtle text-center">
+          No completed production runs for this partner. A run has to be
+          completed before it can be paid for.
+        </Text>
+      </Container>
+    )
+  }
+
+  const selectable = runs.filter((r) => r.payable && !r.billed)
+
+  return (
+    <div className="flex flex-col gap-y-2">
+      <div className="mb-1 flex items-center justify-between">
+        <Heading level="h3">{selectable.length} payable</Heading>
+        {selectable.length > 0 && (
+          <Button variant="secondary" size="small" onClick={onSelectAll}>
+            {selectedIds.size === selectable.length
+              ? "Deselect All"
+              : "Select All"}
+          </Button>
+        )}
+      </div>
+
+      {runs.map((run) => {
+        const isSelectable = run.payable && !run.billed
+        const isSelected = selectedIds.has(run.run_id)
+        const quantity = getQuantity(run)
+        const rate = getRate(run)
+        const amount = getAmount(run)
+
+        // The two figures disagreeing is the normal case, not an error — it is
+        // the whole reason the basis is stated instead of assumed.
+        const shortfall =
+          run.produced_quantity !== null &&
+          run.ordered_quantity !== null &&
+          run.produced_quantity !== run.ordered_quantity
+
+        return (
+          <Container
+            key={run.run_id}
+            className={`p-4 transition ${
+              isSelected ? "ring-2 ring-ui-border-interactive" : ""
+            } ${isSelectable ? "" : "opacity-60"}`}
+            data-testid="payable-run-row"
+            data-run-id={run.run_id}
+          >
+            <div className="flex items-center gap-3">
+              <div
+                className={isSelectable ? "cursor-pointer" : "cursor-not-allowed"}
+                onClick={() => isSelectable && onToggle(run.run_id)}
+              >
+                <Checkbox checked={isSelected} disabled={!isSelectable} />
+              </div>
+
+              <div
+                className="flex-1 min-w-0"
+                onClick={() => isSelectable && onToggle(run.run_id)}
+              >
+                <div className="flex items-center gap-2">
+                  <Text weight="plus" className="truncate">
+                    {run.design_name || "Unnamed design"}
+                  </Text>
+                  {run.design_status && (
+                    <Badge color="grey" size="2xsmall">
+                      {run.design_status.replace(/_/g, " ")}
+                    </Badge>
+                  )}
+                  {run.billed && (
+                    <Badge color="orange" size="2xsmall">
+                      Already paid — {run.billed.status}
+                    </Badge>
+                  )}
+                  {!run.payable && (
+                    <Badge color="red" size="2xsmall">
+                      No agreed rate
+                    </Badge>
+                  )}
+                </div>
+
+                <div className="mt-1 flex flex-wrap items-center gap-x-4 gap-y-1">
+                  {/* Produced vs ordered, side by side. Which one the amount is
+                      built from is stated, never inferred by the reader. */}
+                  <Text size="small" className="text-ui-fg-subtle">
+                    Produced{" "}
+                    <span className="font-semibold text-ui-fg-base">
+                      {run.produced_quantity ?? "—"}
+                    </span>{" "}
+                    of {run.ordered_quantity ?? "—"} ordered
+                  </Text>
+                  {run.quantity_basis === "ordered" && (
+                    <Text size="small" className="text-ui-fg-warning">
+                      no output recorded — billing the ordered quantity
+                    </Text>
+                  )}
+                  {shortfall && run.quantity_basis === "produced" && (
+                    <Text size="small" className="text-ui-fg-subtle">
+                      paying on produced
+                    </Text>
+                  )}
+                  {run.rejected_quantity ? (
+                    <Text size="small" className="text-ui-fg-subtle">
+                      {run.rejected_quantity} rejected
+                    </Text>
+                  ) : null}
+                  {/*
+                    Long enough to be UNAMBIGUOUS. Runs are created in
+                    parent/child pairs within the same millisecond, so their
+                    ULIDs share a long prefix — prod's own pair differs only at
+                    character 15. A shorter truncation renders two different
+                    runs as the same string.
+                  */}
+                  <Text size="small" className="text-ui-fg-muted font-mono">
+                    {run.run_id.slice(0, 24)}...
+                  </Text>
+                </div>
+
+                {run.billed && (
+                  <Text size="xsmall" className="text-ui-fg-muted mt-1">
+                    Paid for by submission {run.billed.submission_id} (
+                    {run.billed.quantity} unit
+                    {run.billed.quantity === 1 ? "" : "s"})
+                  </Text>
+                )}
+                {!run.billed && run.design_has_open_submission && (
+                  <Text size="xsmall" className="text-ui-fg-warning mt-1">
+                    This design is already in an open submission — creating
+                    another will be refused until that one is resolved.
+                  </Text>
+                )}
+              </div>
+
+              {isSelectable && (
+                <div className="flex items-center gap-2 shrink-0">
+                  <div className="flex flex-col items-end gap-1">
+                    <Text size="xsmall" className="text-ui-fg-muted">
+                      Qty
+                    </Text>
+                    <Input
+                      type="number"
+                      size="small"
+                      className="w-20 text-right"
+                      aria-label={`Quantity for ${run.design_name || run.run_id}`}
+                      value={
+                        quantityOverrides[run.run_id] != null
+                          ? String(quantityOverrides[run.run_id])
+                          : String(run.payable_quantity)
+                      }
+                      onChange={(e) =>
+                        onQuantityChange(run.run_id, e.target.value)
+                      }
+                      onClick={(e) => e.stopPropagation()}
+                    />
+                  </div>
+                  <div className="flex flex-col items-end gap-1">
+                    <Text size="xsmall" className="text-ui-fg-muted">
+                      Rate
+                    </Text>
+                    <Input
+                      type="number"
+                      size="small"
+                      className="w-24 text-right"
+                      aria-label={`Rate for ${run.design_name || run.run_id}`}
+                      value={
+                        rateOverrides[run.run_id] != null
+                          ? String(rateOverrides[run.run_id])
+                          : String(run.unit_amount)
+                      }
+                      onChange={(e) => onRateChange(run.run_id, e.target.value)}
+                      onClick={(e) => e.stopPropagation()}
+                    />
+                  </div>
+                  <div className="flex flex-col items-end gap-1 w-28">
+                    <Text size="xsmall" className="text-ui-fg-muted">
+                      Amount
+                    </Text>
+                    {/* The arithmetic, shown. A partner disputing a payment
+                        reads "7 × 1,200", not a bare 8,400. */}
+                    <Text
+                      weight="plus"
+                      className="text-right"
+                      data-testid={`run-amount-${run.run_id}`}
+                    >
+                      {quantity} × {rate.toLocaleString()} ={" "}
+                      {amount.toLocaleString()}
+                    </Text>
+                  </div>
+                </div>
+              )}
+            </div>
+          </Container>
+        )
+      })}
+    </div>
   )
 }
 

--- a/apps/backend/src/admin/hooks/api/payment-submissions.ts
+++ b/apps/backend/src/admin/hooks/api/payment-submissions.ts
@@ -93,7 +93,50 @@ export interface CreateAdminPaymentSubmissionPayload {
    * still in Technical_Review was to edit the design's status.
    */
   require_design_status?: boolean
+  /**
+   * Which completed runs each design line pays for, keyed by design id.
+   *
+   * 🔴 Typed, and deliberately not folded into `metadata` — this is what stops
+   * the same finished run being paid for twice, and a guard reading an untyped
+   * blob is one spelling mistake away from reading nothing.
+   */
+  production_run_ids?: Record<string, string[]>
   metadata?: Record<string, any>
+}
+
+/**
+ * One completed production run a partner can be paid for.
+ *
+ * 🔑 A RUN, not a design. The rate and the piece count live on the run; a
+ * design is a recipe that has been produced many times, and pricing off it
+ * bills a per-unit figure once (#1554).
+ */
+export interface PayableRun {
+  run_id: string
+  design_id: string
+  design_name: string | null
+  design_status: string | null
+  completed_at: string | null
+  ordered_quantity: number | null
+  /** Null when output was never recorded — distinct from "made zero". */
+  produced_quantity: number | null
+  rejected_quantity: number | null
+  /** What this row bills for: produced, falling back to ordered. */
+  payable_quantity: number
+  quantity_basis: "produced" | "ordered"
+  unit_amount: number
+  amount: number
+  cost_type: "per_unit" | "total" | null
+  partner_cost_estimate: number | null
+  /** False when no rate was ever agreed — not a zero-value payout. */
+  payable: boolean
+  billed: { submission_id: string; status: string; quantity: number } | null
+  design_has_open_submission: boolean
+}
+
+export interface PayableRunsResponse {
+  payable_runs: PayableRun[]
+  count: number
 }
 
 // ─── Reconciliation Types ───────────────────────────────────────────────────
@@ -179,6 +222,33 @@ export const usePaymentSubmissions = (
     ...options,
   })
   return { ...data, ...rest }
+}
+
+/**
+ * The completed runs a partner can be paid for.
+ *
+ * Disabled until a partner is chosen — the endpoint REQUIRES `partner_id`
+ * (an unfiltered variant would list every completed run on the platform), so
+ * firing it early is a guaranteed 400 rather than an empty list.
+ */
+export const usePayableRuns = (
+  partnerId: string | undefined,
+  options?: Omit<
+    UseQueryOptions<PayableRunsResponse, FetchError, PayableRunsResponse, QueryKey>,
+    "queryFn" | "queryKey"
+  >
+) => {
+  const { data, ...rest } = useQuery({
+    queryFn: async () =>
+      sdk.client.fetch<PayableRunsResponse>(
+        `/admin/payment-submissions/payable-runs`,
+        { method: "GET", query: { partner_id: partnerId } }
+      ) as Promise<PayableRunsResponse>,
+    queryKey: paymentSubmissionQueryKeys.list({ payable_runs: partnerId }),
+    enabled: !!partnerId,
+    ...options,
+  })
+  return { payable_runs: data?.payable_runs ?? [], count: data?.count ?? 0, ...rest }
 }
 
 export const usePaymentSubmission = (

--- a/apps/backend/src/api/admin/payment-submissions/payable-runs/route.ts
+++ b/apps/backend/src/api/admin/payment-submissions/payable-runs/route.ts
@@ -1,0 +1,217 @@
+import type { MedusaRequest, MedusaResponse } from "@medusajs/framework/http"
+import { ContainerRegistrationKeys, MedusaError } from "@medusajs/framework/utils"
+
+import { PAYMENT_SUBMISSIONS_MODULE } from "../../../../modules/payment_submissions"
+import PaymentSubmissionsService from "../../../../modules/payment_submissions/service"
+import { runUnitCost } from "../../../../workflows/production-runs/lib/run-payable"
+
+/**
+ * GET /admin/payment-submissions/payable-runs?partner_id=…
+ *
+ * The completed production runs a partner can be paid for, one row per RUN.
+ *
+ * ## Why this exists
+ *
+ * The admin submission screen listed DESIGNS. A design is not a payable thing —
+ * it is a recipe, produced many times, and the money lives on the run: the rate
+ * a partner agreed to (`partner_cost_estimate` + `cost_type`) and how many
+ * finished pieces they actually made (`produced_quantity`). Listing designs
+ * meant the screen had no quantity to show and no rate to show, so it billed
+ * `design.estimated_cost` — a PER-UNIT figure — exactly once. That is #1554,
+ * and it was ₹850 for nine garments.
+ *
+ * Pricing from the design is not a near-miss either: for Bakshi's Design the
+ * design's own cost would have billed 11,530.80 where the run says 7,650, and
+ * Denim Trouser has no design cost at all and would have billed 0.
+ *
+ * ## The quantity this bills
+ *
+ * 🔑 `payable_quantity` is the PRODUCED quantity, not the ordered one — the
+ * founder rule is that a partner is paid for what they made. `runPayableAmount`
+ * (the auto-draft path) still multiplies by `run.quantity`, which is why a run
+ * ordered 9 and produced 4 drafts 9 units' worth unless a caller says
+ * otherwise. This endpoint is that caller: it states produced and ordered
+ * side by side so the screen shows which one it is billing and the reviewer can
+ * see the two disagree.
+ *
+ * Runs with no produced figure fall back to ordered and are flagged
+ * `produced_quantity: null`, so "we never recorded output" is visibly distinct
+ * from "they made zero".
+ *
+ * ## What "already paid for" means
+ *
+ * A run is billed when a payment line records it in `production_run_ids` and
+ * that submission is not Rejected. This is a stronger guard than the existing
+ * "is this design in an OPEN submission" check, which stops being true the
+ * moment a submission is Approved or Paid — after which the same finished run
+ * could be claimed again and the second claim would look exactly as legitimate
+ * as the first.
+ *
+ * ⚠️ Lines written before `production_run_ids` existed record nothing, so a run
+ * paid for by one of them reads `billed: null` here. `design_has_open_submission`
+ * is reported alongside precisely so the screen can still warn: it is the older,
+ * weaker signal, and it is the only one those rows carry.
+ */
+export const GET = async (req: MedusaRequest, res: MedusaResponse) => {
+  const partnerId = String(
+    (req.validatedQuery as any)?.partner_id ?? (req.query as any)?.partner_id ?? ""
+  ).trim()
+
+  if (!partnerId) {
+    throw new MedusaError(
+      MedusaError.Types.INVALID_DATA,
+      "partner_id is required"
+    )
+  }
+
+  const query: any = req.scope.resolve(ContainerRegistrationKeys.QUERY)
+
+  // Completed runs of this partner. A parent run carries `partner_id: null`
+  // (runs come in parent/child pairs — the parent holds the total, the child
+  // holds the partner and the money), so filtering on the partner excludes
+  // parents without needing a second rule for them.
+  const { data: runs } = await query.graph({
+    entity: "production_runs",
+    fields: [
+      "id",
+      "design_id",
+      "partner_id",
+      "status",
+      "quantity",
+      "produced_quantity",
+      "rejected_quantity",
+      "partner_cost_estimate",
+      "cost_type",
+      "completed_at",
+    ],
+    filters: { partner_id: partnerId, status: "completed" },
+  })
+
+  const completedRuns = ((runs || []) as any[]).filter((r) => !!r.design_id)
+
+  if (!completedRuns.length) {
+    return res.status(200).json({ payable_runs: [], count: 0 })
+  }
+
+  const designIds = [
+    ...new Set(completedRuns.map((r) => String(r.design_id))),
+  ]
+
+  const { data: designs } = await query.graph({
+    entity: "designs",
+    fields: ["id", "name", "status", "estimated_cost", "production_cost"],
+    filters: { id: designIds },
+  })
+  const designById = new Map(
+    ((designs || []) as any[]).map((d) => [d.id, d])
+  )
+
+  // Prior payment lines for these designs. Scoped to the designs in play rather
+  // than every line ever written: a run belongs to exactly one design, so a
+  // prior billing of it can only sit on a line for that design.
+  const service: PaymentSubmissionsService = req.scope.resolve(
+    PAYMENT_SUBMISSIONS_MODULE
+  )
+  const priorItems = (await service.listPaymentSubmissionItems(
+    { design_id: designIds },
+    { relations: ["submission"] }
+  )) as any[]
+
+  const billedRuns = new Map<
+    string,
+    { submission_id: string; status: string; quantity: number }
+  >()
+  const designsWithOpenSubmission = new Set<string>()
+  const OPEN_STATUSES = new Set([
+    "Draft",
+    "Pending",
+    "Under_Review",
+  ])
+
+  for (const item of priorItems || []) {
+    const status = String(item.submission?.status || "")
+    // A Rejected submission never paid anyone — its lines release their runs.
+    if (status === "Rejected") continue
+
+    if (OPEN_STATUSES.has(status) && item.design_id) {
+      designsWithOpenSubmission.add(String(item.design_id))
+    }
+
+    for (const runId of (item.production_run_ids || []) as string[]) {
+      if (!billedRuns.has(runId)) {
+        billedRuns.set(runId, {
+          submission_id: String(item.submission?.id || item.submission_id || ""),
+          status,
+          quantity: Number(item.quantity ?? 1),
+        })
+      }
+    }
+  }
+
+  const payable_runs = completedRuns
+    .map((run) => {
+      const design = designById.get(String(run.design_id))
+
+      // The per-unit rate the partner agreed, derived from the run rather than
+      // the design. `runUnitCost` divides a "total" cost_type back out and
+      // takes a "per_unit" one verbatim — one place, one convention.
+      const unit_amount = runUnitCost(run)
+
+      const produced = Number(run.produced_quantity)
+      const hasProduced = Number.isFinite(produced) && produced > 0
+      const ordered = Number(run.quantity)
+      const payable_quantity = hasProduced
+        ? produced
+        : Number.isFinite(ordered) && ordered > 0
+          ? ordered
+          : 1
+
+      return {
+        run_id: String(run.id),
+        design_id: String(run.design_id),
+        design_name: design?.name ?? null,
+        design_status: design?.status ?? null,
+        completed_at: run.completed_at ?? null,
+        ordered_quantity: Number.isFinite(ordered) ? ordered : null,
+        produced_quantity: hasProduced ? produced : null,
+        rejected_quantity:
+          run.rejected_quantity === null || run.rejected_quantity === undefined
+            ? null
+            : Number(run.rejected_quantity),
+        /** What this row bills for: produced, or ordered when output was never recorded. */
+        payable_quantity,
+        quantity_basis: hasProduced ? "produced" : "ordered",
+        unit_amount,
+        amount: Math.round(unit_amount * payable_quantity * 100) / 100,
+        cost_type: run.cost_type ?? null,
+        partner_cost_estimate:
+          run.partner_cost_estimate === null ||
+          run.partner_cost_estimate === undefined
+            ? null
+            : Number(run.partner_cost_estimate),
+        /**
+         * A run with no agreed rate is NOT a zero-value payout — it is a run
+         * whose price hasn't been settled. Surfaced rather than hidden so the
+         * screen can say why it can't be billed.
+         */
+        payable: unit_amount > 0,
+        billed: billedRuns.get(String(run.id)) ?? null,
+        design_has_open_submission: designsWithOpenSubmission.has(
+          String(run.design_id)
+        ),
+      }
+    })
+    .sort((a, b) => {
+      // Unbilled first (that's the work), then newest completion.
+      if (!!a.billed !== !!b.billed) return a.billed ? 1 : -1
+      return (
+        new Date(b.completed_at || 0).getTime() -
+        new Date(a.completed_at || 0).getTime()
+      )
+    })
+
+  return res.status(200).json({
+    payable_runs,
+    count: payable_runs.length,
+  })
+}

--- a/apps/backend/src/api/admin/payment-submissions/route.ts
+++ b/apps/backend/src/api/admin/payment-submissions/route.ts
@@ -47,6 +47,7 @@ export const POST = async (req: MedusaRequest, res: MedusaResponse) => {
     documents?: Array<{ id?: string; url: string; filename?: string; mimeType?: string }>
     quantities?: Record<string, number>
     unit_amounts?: Record<string, number>
+    production_run_ids?: Record<string, string[]>
     status?: "Draft" | "Pending"
     require_design_status?: boolean
     metadata?: Record<string, any>
@@ -61,6 +62,9 @@ export const POST = async (req: MedusaRequest, res: MedusaResponse) => {
       documents: body.documents,
       status: body.status,
       require_design_status: body.require_design_status,
+      // Typed input, not folded into metadata — this is the double-pay guard's
+      // evidence, and it must not be reachable by a misspelt JSON key.
+      production_run_ids: body.production_run_ids,
       metadata: {
         // Typed money fields win over the metadata channel and land on it —
         // see `foldMoneyFieldsIntoMetadata` for why the precedence is per-field

--- a/apps/backend/src/api/admin/payment-submissions/validators.ts
+++ b/apps/backend/src/api/admin/payment-submissions/validators.ts
@@ -18,6 +18,16 @@ export const AdminListPaymentSubmissionsQuerySchema = z.object({
   offset: z.coerce.number().int().min(0).default(0).optional(),
 })
 
+/**
+ * The payable-runs lookup. `partner_id` is required rather than optional-with-
+ * a-default: this endpoint answers "what can I pay THIS partner for", and a
+ * missing filter would return every completed run on the platform — the shape
+ * that made one dangling key return unfiltered cross-tenant rows (#1397).
+ */
+export const AdminPayableRunsQuerySchema = z.object({
+  partner_id: z.string().min(1, "partner_id is required"),
+})
+
 export const AdminReviewPaymentSubmissionSchema = z.object({
   action: z.enum(["approve", "reject"]),
   rejection_reason: z.string().optional(),

--- a/apps/backend/src/api/middlewares.ts
+++ b/apps/backend/src/api/middlewares.ts
@@ -260,6 +260,7 @@ import {
 } from "./partners/payment-submissions/validators";
 import {
   AdminListPaymentSubmissionsQuerySchema,
+  AdminPayableRunsQuerySchema,
   AdminReviewPaymentSubmissionSchema,
   CreateAdminPaymentSubmissionSchema,
 } from "./admin/payment-submissions/validators";
@@ -3599,6 +3600,14 @@ export default defineMiddlewares({
     },
 
     // ── Payment Submissions (Admin) ─────────────────────────────────────────
+    {
+      // Must be declared before "/admin/payment-submissions/:id" — a literal
+      // segment and a param segment both match this path, and the first entry
+      // that matches is the one whose validation runs.
+      matcher: "/admin/payment-submissions/payable-runs",
+      method: "GET",
+      middlewares: [validateAndTransformQuery(wrapSchema(AdminPayableRunsQuerySchema), {})],
+    },
     {
       matcher: "/admin/payment-submissions/:id/review",
       method: "POST",

--- a/apps/backend/src/api/partners/payment-submissions/route.ts
+++ b/apps/backend/src/api/partners/payment-submissions/route.ts
@@ -80,6 +80,8 @@ export const POST = async (
       task_ids: body.task_ids || [],
       notes: body.notes,
       documents: body.documents,
+      // Typed input, not folded into metadata — see the field's docs.
+      production_run_ids: body.production_run_ids,
       // Typed money fields win over the metadata channel and land on it.
       metadata: foldMoneyFieldsIntoMetadata(body),
     },

--- a/apps/backend/src/modules/payment_submissions/migrations/Migration20260826210000.ts
+++ b/apps/backend/src/modules/payment_submissions/migrations/Migration20260826210000.ts
@@ -1,0 +1,38 @@
+import { Migration } from "@medusajs/framework/mikro-orm/migrations";
+
+/**
+ * Record WHICH production runs a payment line paid for (#1556).
+ *
+ * The admin submission screen listed designs, so a payout was only ever
+ * traceable to a design — and a design is produced many times. Nothing on the
+ * submission said which of those runs the money covered, which means nothing
+ * could tell whether a run had already been paid for. The only guard was
+ * "this design is in an open submission", which goes away the moment that
+ * submission is Approved or Paid: the same completed run could then be billed
+ * again, and the second payout would look exactly as legitimate as the first.
+ *
+ * 🔴 A real column rather than a `metadata` key. The auto-draft subscriber
+ * already stashed `metadata.production_run_id` on the SUBMISSION, and that is
+ * precisely the shape #1557 took out of the money path: `metadata` is
+ * validated as `z.record(z.string(), z.any())` at every boundary, so a
+ * misspelt key validates and the guard silently reads nothing. A field that
+ * decides whether someone gets paid twice belongs in the schema.
+ *
+ * jsonb (an ARRAY of run ids) because the line is keyed by design: two
+ * completed runs of one design collapse into a single item whose quantity is
+ * their sum, and both ids must survive that.
+ *
+ * ⚠️ The model definition alone only covers a database built from scratch —
+ * the generator leaves an existing table alone. Hence the explicit DDL.
+ */
+export class Migration20260826210000 extends Migration {
+
+  override async up(): Promise<void> {
+    this.addSql(`alter table if exists "payment_submission_item" add column if not exists "production_run_ids" jsonb null;`);
+  }
+
+  override async down(): Promise<void> {
+    this.addSql(`alter table if exists "payment_submission_item" drop column if exists "production_run_ids";`);
+  }
+
+}

--- a/apps/backend/src/modules/payment_submissions/models/payment_submission_item.ts
+++ b/apps/backend/src/modules/payment_submissions/models/payment_submission_item.ts
@@ -45,6 +45,25 @@ const PaymentSubmissionItem = model.define("payment_submission_item", {
   quantity: model.float().default(1),
   unit_amount: model.bigNumber().nullable(),
   cost_breakdown: model.json().nullable(),
+  /**
+   * The production run(s) this line pays for, as an array of run ids.
+   *
+   * 🔴 A real column, deliberately NOT `metadata.production_run_id`. The
+   * provenance of a payout decides whether the SAME run can be billed twice,
+   * and `metadata` is validated as `z.record(z.string(), z.any())` everywhere
+   * it is accepted — a misspelt key would validate cleanly and leave the
+   * double-pay guard reading nothing. (#1557's lesson, applied to the field
+   * that now guards the money rather than merely describing it.)
+   *
+   * An array rather than a single id because a submission line is keyed by
+   * DESIGN: two completed runs of one design collapse into one item whose
+   * quantity is their sum, and both run ids have to survive that.
+   *
+   * NULL on every row written before this existed, and on any line that was
+   * not sourced from a run (a hand-picked design, a task). Absent means "no
+   * run recorded", never "no run involved".
+   */
+  production_run_ids: model.json().nullable(),
   metadata: model.json().nullable(),
   submission: model.belongsTo(() => PaymentSubmission, {
     mappedBy: "items",

--- a/apps/backend/src/workflows/payment_submissions/__tests__/money-fields.unit.spec.ts
+++ b/apps/backend/src/workflows/payment_submissions/__tests__/money-fields.unit.spec.ts
@@ -73,4 +73,22 @@ describe("foldMoneyFieldsIntoMetadata", () => {
     expect(out.source_production_run_id).toBe("prod_run_1")
     expect(out.design_unit_amounts).toEqual({ d1: 1150 })
   })
+
+  it("never folds production_run_ids onto the metadata channel", () => {
+    // 🔴 The four money fields ride metadata because the partner form has
+    // always posted them that way and must keep working. `production_run_ids`
+    // has no such legacy caller, and it is the evidence the double-pay guard
+    // reads — so it goes to the workflow as a TYPED input and must not appear
+    // on the untyped blob at all. Folding it "for consistency" would put the
+    // one field that decides whether someone is paid twice back into the
+    // channel #1557 took the money out of.
+    const out = foldMoneyFieldsIntoMetadata({
+      quantities: { d1: 4 },
+      production_run_ids: { d1: ["prod_run_1"] },
+    } as any)
+
+    expect(out.production_run_ids).toBeUndefined()
+    expect(out.design_production_run_ids).toBeUndefined()
+    expect(Object.keys(out)).toEqual(["design_quantities"])
+  })
 })

--- a/apps/backend/src/workflows/payment_submissions/create-payment-submission.ts
+++ b/apps/backend/src/workflows/payment_submissions/create-payment-submission.ts
@@ -49,6 +49,16 @@ export type CreatePaymentSubmissionInput = {
    * does.
    */
   require_design_status?: boolean
+  /**
+   * Which completed production runs each design line pays for, keyed by design
+   * id. Optional — a hand-picked design line has no run behind it and stays
+   * exactly as it is today.
+   *
+   * 🔴 A typed input, never `metadata`. This is what stops the same finished
+   * run being paid for twice, and a guard that reads an untyped blob is one
+   * spelling mistake away from reading nothing at all (#1557).
+   */
+  production_run_ids?: Record<string, string[]>
 }
 
 type ValidatedDesign = {
@@ -64,6 +74,8 @@ type ValidatedDesign = {
    */
   unit_amount: number | null
   cost_breakdown: Record<string, unknown> | null
+  /** The completed run ids this line pays for, or null when it came from none. */
+  production_run_ids: string[] | null
 }
 
 type ValidatedTask = {
@@ -89,6 +101,13 @@ type TaskGraphResult = {
   actual_cost: number | null
   cost_currency: string | null
   cost_type: string | null
+}
+
+type ProductionRunGraphResult = {
+  id: string
+  design_id: string | null
+  partner_id: string | null
+  status: string | null
 }
 
 type DesignPartnerLinkResult = {
@@ -229,6 +248,8 @@ const validateDesignsForSubmissionStep = createStep(
       require_design_status?: boolean
       /** Draft submissions also block a second Draft — see below. */
       status?: "Draft" | "Pending"
+      /** design id → the completed run ids that line pays for. */
+      production_run_ids?: Record<string, string[]>
     },
     { container }
   ) => {
@@ -344,6 +365,104 @@ const validateDesignsForSubmissionStep = createStep(
       )
     }
 
+    /**
+     * 6. The runs a line claims to be paying for must actually be that
+     *    partner's, that design's, finished — and not already paid for.
+     *
+     * 🔴 This is the guard the design-level check in step 5 cannot be. That
+     * one asks "is this design in an OPEN submission", which stops being true
+     * the moment the submission is Approved or Paid. A design is produced many
+     * times, so once the first payout closes, the very same completed run can
+     * be submitted again and the second claim looks identical to the first.
+     * Nothing in the record could tell them apart, because nothing recorded
+     * which run was paid for.
+     *
+     * Scoped to items of the SAME designs rather than every item ever written:
+     * a run belongs to exactly one design, so a prior billing of it can only
+     * live on a line for that design. Exact, and bounded by the request.
+     */
+    const claimedRuns = input.production_run_ids || {}
+    const allClaimedRunIds = [
+      ...new Set(Object.values(claimedRuns).flat().filter(Boolean)),
+    ]
+
+    if (allClaimedRunIds.length) {
+      const { data: runs } = await query.graph({
+        entity: "production_runs",
+        fields: ["id", "design_id", "partner_id", "status"],
+        filters: { id: allClaimedRunIds },
+      })
+      const typedRuns = (runs || []) as unknown as ProductionRunGraphResult[]
+      const runById = new Map(typedRuns.map((r) => [r.id, r]))
+
+      const missing = allClaimedRunIds.filter((id) => !runById.has(id))
+      if (missing.length) {
+        throw new MedusaError(
+          MedusaError.Types.NOT_FOUND,
+          `Production runs not found: ${missing.join(", ")}`
+        )
+      }
+
+      for (const [designId, runIds] of Object.entries(claimedRuns)) {
+        if (!input.design_ids.includes(designId)) {
+          throw new MedusaError(
+            MedusaError.Types.INVALID_DATA,
+            `production_run_ids names design ${designId}, which is not in design_ids`
+          )
+        }
+        for (const runId of runIds) {
+          const run = runById.get(runId)!
+          if (String(run.design_id || "") !== designId) {
+            throw new MedusaError(
+              MedusaError.Types.INVALID_DATA,
+              `Production run ${runId} is not a run of design ${designId}`
+            )
+          }
+          if (String(run.partner_id || "") !== input.partner_id) {
+            throw new MedusaError(
+              MedusaError.Types.NOT_ALLOWED,
+              `Production run ${runId} does not belong to this partner`
+            )
+          }
+          if (String(run.status || "") !== "completed") {
+            throw new MedusaError(
+              MedusaError.Types.INVALID_DATA,
+              `Production run ${runId} is not completed (${run.status})`
+            )
+          }
+        }
+      }
+
+      // Already paid for? A Rejected submission never paid anyone, so its
+      // lines release their runs; everything else — Draft, Pending,
+      // Under_Review, Approved, Paid — is a live claim on that run.
+      const submissionService: PaymentSubmissionsService = container.resolve(
+        PAYMENT_SUBMISSIONS_MODULE
+      )
+      const priorItems = await submissionService.listPaymentSubmissionItems(
+        { design_id: input.design_ids },
+        { relations: ["submission"] }
+      )
+      const billed = new Map<string, string>()
+      for (const item of (priorItems || []) as any[]) {
+        if (item.submission?.status === "Rejected") continue
+        for (const runId of (item.production_run_ids || []) as string[]) {
+          if (!billed.has(runId)) {
+            billed.set(runId, item.submission?.id || item.submission_id)
+          }
+        }
+      }
+      const duplicates = allClaimedRunIds.filter((id) => billed.has(id))
+      if (duplicates.length) {
+        throw new MedusaError(
+          MedusaError.Types.INVALID_DATA,
+          `Production runs already paid for: ${duplicates
+            .map((id) => `${id} (submission ${billed.get(id)})`)
+            .join(", ")}`
+        )
+      }
+    }
+
     const quantities = input.quantities || {}
     const unitAmounts = input.unit_amounts || {}
 
@@ -364,6 +483,9 @@ const validateDesignsForSubmissionStep = createStep(
         quantity: line.quantity,
         unit_amount: line.unit_amount,
         cost_breakdown: d.cost_breakdown,
+        production_run_ids: claimedRuns[d.id]?.length
+          ? [...new Set(claimedRuns[d.id])]
+          : null,
       }
     })
 
@@ -567,6 +689,15 @@ const createSubmissionRecordStep = createStep(
         quantity: design.quantity,
         unit_amount: design.unit_amount,
         cost_breakdown: design.cost_breakdown || null,
+        // Which finished runs this line paid for — the record that lets the
+        // NEXT submission refuse to pay for them again.
+        //
+        // Cast at the service boundary the same way `documents` is: the column
+        // is `model.json()`, which types as an object, and what we store is an
+        // ARRAY of run ids (a design line can pay for several runs at once).
+        production_run_ids: (design.production_run_ids ?? null) as unknown as
+          | Record<string, unknown>
+          | null,
         submission_id: submission.id,
       })
     }
@@ -584,6 +715,8 @@ const createSubmissionRecordStep = createStep(
         // than left to the column default so the row is unambiguous.
         quantity: 1,
         unit_amount: null,
+        // A task is not production output; there is no run behind it.
+        production_run_ids: null as unknown as Record<string, unknown> | null,
         cost_breakdown: task.cost_breakdown || null,
         submission_id: submission.id,
       })
@@ -769,6 +902,9 @@ export const createPaymentSubmissionWorkflow = createWorkflow(
       unit_amounts: costOverrides.designUnitAmounts,
       require_design_status: input.require_design_status,
       status: input.status,
+      // Straight through as a typed input — see the field's docs for why this
+      // one deliberately does not ride the metadata channel.
+      production_run_ids: input.production_run_ids,
     })
 
     const validatedTasks = validateTasksForSubmissionStep({

--- a/apps/backend/src/workflows/payment_submissions/lib/money-fields.ts
+++ b/apps/backend/src/workflows/payment_submissions/lib/money-fields.ts
@@ -44,6 +44,26 @@ export const paymentSubmissionMoneyFields = {
   cost_overrides: z.record(z.string(), z.number().positive()).optional(),
   /** Typed line total per task. */
   task_cost_overrides: z.record(z.string(), z.number().positive()).optional(),
+  /**
+   * WHICH completed production runs each design line is paying for, keyed by
+   * design id. An array because a line is keyed by design and one design can
+   * have several completed runs — they collapse into one item whose quantity
+   * is their sum.
+   *
+   * 🔑 Not money, but the PROVENANCE of money, and the thing that decides
+   * whether the same run can be billed twice. It lives beside the money fields
+   * for the same reason they are here: one vocabulary, two importers, no
+   * drift.
+   *
+   * ⚠️ Unlike the four above, this is NOT folded into `metadata` — it is
+   * passed straight through as a typed workflow input. The fold exists only
+   * because the partner form has always posted the money fields through
+   * `metadata` and must keep working; this field has no such legacy caller, so
+   * it never touches the untyped channel at all.
+   */
+  production_run_ids: z
+    .record(z.string(), z.array(z.string().min(1)).min(1))
+    .optional(),
 } as const
 
 export type PaymentSubmissionMoneyInput = {
@@ -51,6 +71,8 @@ export type PaymentSubmissionMoneyInput = {
   unit_amounts?: Record<string, number>
   cost_overrides?: Record<string, number>
   task_cost_overrides?: Record<string, number>
+  /** design id → the completed run ids that line pays for. */
+  production_run_ids?: Record<string, string[]>
 }
 
 /**

--- a/e2e/helpers/e2e-seed.ts
+++ b/e2e/helpers/e2e-seed.ts
@@ -585,6 +585,127 @@ async function seedParkedProductionRun(container: any): Promise<{
 }
 
 /**
+ * #1556 — a partner with COMPLETED, priced production runs, so the admin
+ * payment-submission screen can be driven through the runs tab.
+ *
+ * The fixture's whole point is the two numbers disagreeing:
+ *
+ *   - ordered 9, produced 4 — the screen must bill 4. Billing the ordered
+ *     figure is what `runPayableAmount` still does on the auto-draft path, so a
+ *     fixture where the two match cannot tell the paths apart.
+ *   - a rate on the RUN (1200/unit) that disagrees with the design's own
+ *     `estimated_cost` (5000). Pricing off the design would bill 45,000 for
+ *     work worth 4,800, and a fixture whose design cost equals the run rate
+ *     would pass whichever one the screen actually used.
+ *
+ * 🔑 The design is left in `Technical_Review` deliberately. That is where run
+ * completion puts a design, and it is NOT one of the statuses the hand-
+ * submission gate accepts — so the spec also proves the screen waives that gate
+ * for run-sourced payouts rather than requiring someone to edit a design's
+ * review status in order to release a payment.
+ *
+ * A second run of the same design is included with NO rate: it must render as
+ * unpayable rather than silently billing zero or vanishing from the list.
+ *
+ * ⚠️ THREE runs, not two, and deliberately so. Creating a submission consumes a
+ * run permanently — the run-level guard is the whole point — so a spec that
+ * billed the same run it also makes read-only assertions about would pass once
+ * and then fail on every re-run and on every CI RETRY. `billableRunId` is the
+ * sacrificial one; `payableRunId` is never billed and stays assertable.
+ */
+async function seedPayableProductionRuns(container: any): Promise<{
+  partnerId: string
+  partnerName: string
+  designId: string
+  designName: string
+  payableRunId: string
+  billableRunId: string
+  unpricedRunId: string
+}> {
+  const partnerModule: any = container.resolve("partner")
+  const designService: any = container.resolve("design")
+  const runService: any = container.resolve("production_runs")
+  const remoteLink: any = container.resolve(ContainerRegistrationKeys.LINK)
+
+  const stamp = Date.now()
+
+  const created = await partnerModule.createPartners({
+    name: `E2E Payout Partner ${stamp}`,
+    handle: `e2e-payout-${stamp}`,
+    status: "active",
+    is_verified: true,
+  })
+  const partner = Array.isArray(created) ? created[0] : created
+
+  const designName = `Payable Run Fixture (e2e ${stamp})`
+  const design = await designService.createDesigns({
+    name: designName,
+    description: "e2e #1556 payable production run fixture",
+    design_type: "Original",
+    // Where run completion leaves a design — see the note above.
+    status: "Technical_Review",
+    priority: "Medium",
+    // Deliberately NOT 1200: if the screen prices off the design instead of the
+    // run, the amount is visibly wrong rather than coincidentally right.
+    estimated_cost: 5000,
+  })
+  const designId = (Array.isArray(design) ? design[0] : design).id as string
+
+  // The submission workflow validates that the design belongs to the partner
+  // through this link, so the fixture is not payable without it.
+  await remoteLink.create({
+    design: { design_id: designId },
+    partner: { partner_id: partner.id },
+  })
+
+  const mkRun = async (overrides: Record<string, any>) => {
+    const run = await runService.createProductionRuns({
+      design_id: designId,
+      partner_id: partner.id,
+      run_type: "production",
+      status: "completed",
+      completed_at: new Date(),
+      snapshot: { design: { id: designId, name: designName } },
+      captured_at: new Date(),
+      ...overrides,
+    })
+    return (Array.isArray(run) ? run[0] : run).id as string
+  }
+
+  const payableRunId = await mkRun({
+    quantity: 9,
+    produced_quantity: 4,
+    partner_cost_estimate: 1200,
+    cost_type: "per_unit",
+  })
+
+  // Identical to `payableRunId`, and consumed by the spec that actually
+  // creates a submission. See the THREE-runs note above.
+  const billableRunId = await mkRun({
+    quantity: 9,
+    produced_quantity: 4,
+    partner_cost_estimate: 1200,
+    cost_type: "per_unit",
+  })
+
+  const unpricedRunId = await mkRun({
+    quantity: 2,
+    produced_quantity: 2,
+    partner_cost_estimate: null,
+  })
+
+  return {
+    partnerId: partner.id as string,
+    partnerName: partner.name as string,
+    designId,
+    designName,
+    payableRunId,
+    billableRunId,
+    unpricedRunId,
+  }
+}
+
+/**
  * #1363 — a design with a MULTI-ITEM bill of materials and an approvable run,
  * so the per-assignment material allocation can be driven through the admin UI.
  *
@@ -1283,6 +1404,9 @@ export default async function e2eSeed({ container }: ExecArgs) {
     gate.currencyCode
   )
 
+  logger.info("E2E seed: creating the #1556 payable production runs + partner...")
+  const payableRuns = await seedPayableProductionRuns(container)
+
   logger.info("E2E seed: creating the #1439 admin quote fixtures (active + superseded)...")
   const adminQuotes = await seedAdminQuotes(container)
 
@@ -1377,6 +1501,21 @@ export default async function e2eSeed({ container }: ExecArgs) {
     allocationMaterialCLabel: allocation.materialCLabel,
     allocationMaterialAId: allocation.materialAId,
     allocationMaterialCId: allocation.materialCId,
+    // #1556 payable production runs — consumed by
+    // payment-submission-payable-runs.spec.ts (admin, CI).
+    //
+    // ⚠️ `billableRunId` is SINGLE-USE: the spec creates a real payment
+    // submission against it, and the run-level guard then refuses to bill that
+    // run again — so that one case needs a fresh seed per suite run (which is
+    // what `pnpm e2e` does). `payableRunId` and `unpricedRunId` are never
+    // billed and survive a re-run.
+    payoutPartnerId: payableRuns.partnerId,
+    payoutPartnerName: payableRuns.partnerName,
+    payoutDesignId: payableRuns.designId,
+    payoutDesignName: payableRuns.designName,
+    payableRunId: payableRuns.payableRunId,
+    billableRunId: payableRuns.billableRunId,
+    unpricedRunId: payableRuns.unpricedRunId,
     // #1439 S3/S4 admin quote surface — consumed by admin-quote-surface.spec.ts
     // (admin, CI). NOT single-use: the spec cancels out of the revoke prompt
     // rather than confirming it, so a re-run finds the same active quote.

--- a/e2e/specs/payment-submission-payable-runs.spec.ts
+++ b/e2e/specs/payment-submission-payable-runs.spec.ts
@@ -1,0 +1,195 @@
+import { test, expect } from "@playwright/test"
+import * as fs from "fs"
+import * as path from "path"
+
+const SEED_FILE = path.resolve(__dirname, "../../apps/backend/.e2e-seed.json")
+
+/**
+ * #1556 — paying a partner for a production RUN, driven through the admin UI.
+ *
+ * The screen this covers used to list DESIGNS and had no quantity input
+ * anywhere on it. A design is a recipe carrying a per-unit cost, so the
+ * submission billed that per-unit figure exactly once: ₹850 for nine finished
+ * garments (#1554). The API half was fixed first — it has accepted `quantities`
+ * and `unit_amounts` since #1557 — but nothing in the UI could send them, so
+ * every admin-created payout still went out at one piece.
+ *
+ * These cases assert the UI half: that the screen lists runs, shows what it is
+ * billing and on what basis, bills the PRODUCED quantity rather than the
+ * ordered one, and refuses to pay for the same finished run twice.
+ *
+ * ⚠️ The seed carries THREE runs on purpose. Creating a submission consumes a
+ * run permanently — that is the guard working — so the case that bills one uses
+ * a dedicated `billableRunId` rather than the run the read-only cases assert
+ * against. Without that split, one pass would poison every re-run AND every CI
+ * retry, and a retry failing for that reason looks exactly like a real defect.
+ */
+test.describe("Payment submission from production runs (#1556)", () => {
+  let seed: {
+    email: string
+    password: string
+    payoutPartnerName: string
+    payoutDesignName: string
+    payableRunId: string
+    billableRunId: string
+    unpricedRunId: string
+  }
+
+  test.beforeAll(() => {
+    if (!fs.existsSync(SEED_FILE)) {
+      throw new Error(
+        `E2E seed file not found at ${SEED_FILE}. Run "pnpm e2e:seed" first.`
+      )
+    }
+    seed = JSON.parse(fs.readFileSync(SEED_FILE, "utf-8"))
+    // Fail loudly on a stale seed rather than passing against `undefined`,
+    // which every `toContain` would happily do.
+    if (!seed.payableRunId || !seed.billableRunId || !seed.payoutPartnerName) {
+      throw new Error(
+        "E2E seed missing the #1556 payable-run fixture — re-run the seed."
+      )
+    }
+  })
+
+  const login = async (page: any) => {
+    await page.goto("/app/login")
+    // `networkidle` never settles against `medusa develop` (the dev server
+    // holds long-lived connections open), so wait on the form itself.
+    await page.locator('input[name="email"]').waitFor({ timeout: 60000 })
+    await page.locator('input[name="email"]').fill(seed.email)
+    await page.locator('input[name="password"]').fill(seed.password)
+    await page.locator('button[type="submit"]').click()
+    await page.waitForURL(/\/app\/(?!login)/, { timeout: 15000 })
+  }
+
+  /** Open the create modal and pick the fixture partner. */
+  const openCreateForPartner = async (page: any) => {
+    await page.goto("/app/payment-submissions/create")
+    await expect(
+      page.getByRole("heading", { name: "New Payment Submission" })
+    ).toBeVisible({ timeout: 30000 })
+
+    await page.getByRole("combobox").first().click()
+    await page.getByRole("option", { name: seed.payoutPartnerName }).click()
+
+    // The runs list is fetched only once a partner is chosen.
+    await expect(page.getByText("payable", { exact: false }).first()).toBeVisible(
+      { timeout: 20000 }
+    )
+  }
+
+  /**
+   * ⚠️ Addressed by the FULL run id, not a truncated prefix. The seed's two
+   * runs are created in the same millisecond, so their ULIDs share a 16-char
+   * prefix and a `hasText` filter on it matches both rows — which is also why
+   * the row now renders a longer id.
+   */
+  const runRow = (page: any, runId: string) =>
+    page.locator(`[data-testid="payable-run-row"][data-run-id="${runId}"]`)
+
+  test("lists runs with the produced quantity and prices them from the run", async ({
+    page,
+  }) => {
+    await login(page)
+    await openCreateForPartner(page)
+
+    // The tab that opens is Production runs, not Designs.
+    await expect(
+      page.getByRole("tab", { name: /Production runs/i })
+    ).toHaveAttribute("data-state", "active")
+
+    const row = runRow(page, seed.payableRunId)
+    await expect(row).toBeVisible({ timeout: 15000 })
+
+    // 🔑 Both figures, stated. A screen that showed only one could not be
+    // checked for which of the two it was actually billing.
+    await expect(row).toContainText("Produced")
+    await expect(row).toContainText("4")
+    await expect(row).toContainText("of 9 ordered")
+
+    // Priced from the RUN (1200/unit), not from the design's own
+    // estimated_cost of 5000 — which would have read 5000 here and billed
+    // 45,000 for work worth 4,800.
+    await expect(
+      row.getByTestId(`run-amount-${seed.payableRunId}`)
+    ).toContainText("4 × 1,200 = 4,800")
+  })
+
+  test("shows an unpriced run as unpayable instead of billing zero for it", async ({
+    page,
+  }) => {
+    await login(page)
+    await openCreateForPartner(page)
+
+    // A run with no agreed rate is not a zero-value payout — it is a run whose
+    // price has not been settled. It has to be visible (an admin looking for it
+    // needs to see WHY it can't be billed) and not selectable.
+    const row = runRow(page, seed.unpricedRunId)
+    await expect(row).toBeVisible({ timeout: 15000 })
+    await expect(row).toContainText("No agreed rate")
+    await expect(row.getByRole("checkbox")).toBeDisabled()
+  })
+
+  test("bills the quantity an admin types, and creates the submission for it", async ({
+    page,
+  }) => {
+    await login(page)
+    await openCreateForPartner(page)
+
+    // The sacrificial run — see the THREE-runs note at the top.
+    const row = runRow(page, seed.billableRunId)
+    await row.getByRole("checkbox").click()
+
+    // The header total tracks the selection — 4 produced x 1200.
+    //
+    // Addressed by testid, not by text: the same amount can legitimately appear
+    // in the row AND the header, and a bare `getByText` then resolves to two
+    // elements. Widening it with `.first()` would hide which one was asserted.
+    const total = page.getByTestId("submission-total")
+    await expect(total).toHaveText("INR 4,800", { timeout: 10000 })
+
+    // The live correction this mirrors: a partner reported more output after
+    // the fact, so the payable quantity is retyped. Before #1556 there was no
+    // box to type it into at all.
+    const qty = row.getByRole("spinbutton", {
+      name: `Quantity for ${seed.payoutDesignName}`,
+    })
+    await qty.fill("7")
+
+    await expect(
+      row.getByTestId(`run-amount-${seed.billableRunId}`)
+    ).toContainText("7 × 1,200 = 8,400")
+    await expect(total).toHaveText("INR 8,400")
+
+    await page.getByRole("button", { name: "Create Submission" }).click()
+
+    // Lands on the submission detail page for the row it just created.
+    await page.waitForURL(/\/app\/payment-submissions\/[^/]+$/, {
+      timeout: 20000,
+    })
+    await expect(page.getByText("8,400").first()).toBeVisible({
+      timeout: 15000,
+    })
+
+    /**
+     * 🔑 The design behind this fixture sits in `Technical_Review` — where run
+     * completion leaves it, and NOT one of the statuses the hand-submission
+     * gate accepts. A submission existing at all proves the screen waives that
+     * gate for a run-sourced payout, rather than requiring someone to edit a
+     * design's review status in order to release a payment.
+     */
+  })
+
+  test("refuses to offer a run that has already been paid for", async ({
+    page,
+  }) => {
+    await login(page)
+    await openCreateForPartner(page)
+
+    // Depends on the previous case having created the payout against it.
+    const row = runRow(page, seed.billableRunId)
+    await expect(row).toBeVisible({ timeout: 15000 })
+    await expect(row).toContainText("Already paid")
+    await expect(row.getByRole("checkbox")).toBeDisabled()
+  })
+})


### PR DESCRIPTION
Closes the screen half of #1556. The API half shipped in #1557.

## The problem

The admin payment-submission screen listed **designs** and had **no quantity input anywhere on it**. A design is a recipe — produced many times — carrying a PER-UNIT cost, so the submission billed that per-unit figure exactly once: **₹850 for nine finished garments** (#1554).

#1557 gave the route typed `quantities` / `unit_amounts`, but nothing in the UI could send them, so every admin-created payout still went out at one piece.

## What changed

**`GET /admin/payment-submissions/payable-runs?partner_id=…`** — one row per completed run, priced from the **run**, not the design. Pricing off the design is not a near-miss:

| Design | From the design | From the run |
|---|---|---|
| Bakshi's Design | 11,530.80 | **7,650** |
| Denim Trouser | 0 (no design cost) | **2,300** |

**The screen** now opens on a Production runs tab that shows produced *and* ordered side by side, states which one it is billing, and takes an editable quantity and rate. It sends `require_design_status: false` for run-sourced payouts — run completion moves a design to `Technical_Review`, and the only way through used to be **editing a design's review status in order to release a payment**.

🔑 The quantity defaults to **PRODUCED**, not ordered. `runPayableAmount` still multiplies by `run.quantity` on the auto-draft path, so a run ordered 9 / produced 4 drafts nine units' worth unless a caller says otherwise.

**`payment_submission_item.production_run_ids`** (`Migration20260826210000`) records which runs a line paid for.

🔴 A real column, not a `metadata` key. This is what stops the same finished run being billed twice, and `metadata` is validated as `z.record(z.string(), z.any())` at every boundary — a misspelt key validates and the guard silently reads nothing. That is the exact shape #1557 took out of the money path. It is a typed workflow input and deliberately **not** folded onto the metadata channel; a unit test asserts that.

The design-level "already in an OPEN submission" check cannot do this job: it stops being true the moment a submission is Approved or Paid, after which the same completed run can be claimed again and the second claim looks exactly as legitimate as the first. A **Rejected** submission releases its runs — which is the path the Shramdaan correction took.

## Verification

- `pnpm test:integration:http:shared ./integration-tests/http/payment-submissions-api.spec.ts` → **58/58** (13 new). The double-pay guard was confirmed **load-bearing** by disabling it and watching that case go red.
- `pnpm e2e:seed && pnpm e2e:test payment-submission-payable-runs` → **4/4 in a real browser**. This screen is not shipping unrendered.
- Full CI-equivalent e2e: **40 passed, 1 failed** — `crm-contact-activity`, which needs `CRM_HYPERBEE=true` and is unwired on this box. Untouched by this branch.
- `pnpm check:prod-build` ✅ · tsc baseline unchanged at 79.

## Watch-outs

- ⚠️ **Carries a migration.** Don't merge anything else until its deploy lands.
- ⚠️ The e2e seed's `billableRunId` is single-use — creating a submission consumes it. Kept separate from the read-only `payableRunId` so a CI **retry** doesn't fail for that reason and look like a real defect.
- ⚠️ Lines written before this column record nothing, so a run paid for by one reads `billed: null`. `design_has_open_submission` is reported alongside as the older, weaker signal those rows do carry.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_0158wJMZ1DmjNxXf5uGuBrQD