### PR TITLE
fix(test): main's shard 2 has been red since #1555 — the payload had two defects

### DIFF
--- a/apps/backend/integration-tests/http/production-run-complete-yield.spec.ts
+++ b/apps/backend/integration-tests/http/production-run-complete-yield.spec.ts
@@ -254,11 +254,20 @@ setupSharedTestSuite(() => {
 
       // Complete with no yield fields — just like the old API. 3 were ordered
       // and this says nothing about how many were made.
+      //
+      // ⚠️ `cost_type` is sent even though this case is about OUTPUT, because
+      // the route-level cost-type guard (#1555) runs before the workflow's
+      // output check. Without it the payload has TWO defects, the guard refuses
+      // first, and the case passes on the wrong 400 — proving only that some
+      // refusal happened, not the one it names. The cost here is incidental
+      // scenery; it has to be VALID scenery so the missing output is the single
+      // thing under test.
       const completeErr = await api
         .post(
           `/partners/production-runs/${runId}/complete`,
           {
             partner_cost_estimate: 1500,
+            cost_type: "per_unit",
             notes: "Done",
           },
           { headers: partnerHeaders }


### PR DESCRIPTION
## What was red

`production-run-complete-yield.spec.ts` › **"should refuse a completion that says nothing about output"**, failing on main since `db9465c18` (#1555).

**PRs run only shard 1**, so no PR could see it. It survived three subsequent merges on faith.

## Why

The case posts a completion with a cost but no `produced_quantity`, and asserts the refusal names `produced_quantity`. #1555 added a route-level **cost-type guard that runs before** the workflow's output check — and this payload, written in August to mimic "the old API", sends `partner_cost_estimate: 1500` with **no `cost_type`**.

So the payload had **two** defects, the guard refused first, and the assertion read the wrong 400:

```
Expected substring: "produced_quantity is required"
Received string:    "cost_type is required whenever a cost is given: ..."
```

The guard is correct. The output check is correct. The **fixture was stale** — and every other payload in that file already sends `cost_type`. This was the one that predated it.

## The fix

Make the incidental cost **valid scenery**, so the missing output is the single thing under test.

Deliberately *not* fixed by widening the assertion to accept either message. Narrowing a test until it goes green is how a real regression gets buried (#1558 was the same lesson from the other direction), and "some 400 happened" is not what this case is named after.

## Verification

- `pnpm test:integration:http:shared ./integration-tests/http/production-run-complete-yield.spec.ts` → **9/9**
- Confirmed **still load-bearing**: adding `produced_quantity` back into the payload turns this case red again, so it is asserting the output check and not the cost guard.

## Note

There were **two** distinct main failures in this window, not one. `test (1)` failed at `649801fbf` and has since recovered on its own; only this `test (2)` failure was live. Nothing else outstanding after this.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_0158wJMZ1DmjNxXf5uGuBrQD