### PR TITLE
fix(payments): an unpriced run is a gap in the record, not unpayable work (#1556)

### DIFF
--- a/apps/backend/src/admin/components/creates/create-payment-submission.tsx
+++ b/apps/backend/src/admin/components/creates/create-payment-submission.tsx
@@ -116,10 +116,26 @@ export const CreatePaymentSubmissionComponent = () => {
   const { payable_runs: payableRuns, isPending: runsLoading } =
     usePayableRuns(partnerId || undefined)
 
-  /** Runs that can actually be billed now: priced, and not already paid for. */
+  /**
+   * Runs that can be billed now — everything not already paid for.
+   *
+   * 🔑 A missing rate does NOT disqualify a run. The rate lives on the run
+   * because that is where it SHOULD be recorded, but on prod 15 of 27 completed
+   * runs carry none — the partner completed the work and never entered a price.
+   * That is a gap in the record, not a statement that the work was free, and an
+   * admin who knows what was agreed must be able to pay it by typing the rate.
+   * Blocking here would have made real completed work permanently unpayable
+   * through the only screen that can pay it.
+   */
   const selectableRuns = useMemo(
-    () => payableRuns.filter((r) => r.payable && !r.billed),
+    () => payableRuns.filter((r) => !r.billed),
     [payableRuns]
+  )
+
+  /** Runs already carrying an agreed rate — what "Select All" may safely take. */
+  const pricedSelectableRuns = useMemo(
+    () => selectableRuns.filter((r) => r.payable),
+    [selectableRuns]
   )
 
   const eligibleDesigns = useMemo(
@@ -177,13 +193,19 @@ export const CreatePaymentSubmissionComponent = () => {
     })
   }, [])
 
+  /**
+   * Select All takes only the PRICED runs. Bulk-selecting a run with no rate
+   * would add a line the submit guard then refuses, so the button would appear
+   * to work and then block the whole submission on rows the admin never chose.
+   * An unpriced run is selected deliberately, one at a time, with a rate typed.
+   */
   const selectAllRuns = useCallback(() => {
     setSelectedRunIds((prev) =>
-      prev.size === selectableRuns.length
+      prev.size === pricedSelectableRuns.length
         ? new Set()
-        : new Set(selectableRuns.map((r) => r.run_id))
+        : new Set(pricedSelectableRuns.map((r) => r.run_id))
     )
-  }, [selectableRuns])
+  }, [pricedSelectableRuns])
 
   /** Units billed for a run — the produced figure unless an admin retyped it. */
   const getRunQuantity = useCallback(
@@ -752,7 +774,12 @@ const RunsPanel = ({
       </div>
 
       {runs.map((run) => {
-        const isSelectable = run.payable && !run.billed
+        // Only an existing payout blocks. A missing rate is something to TYPE,
+        // not a reason the work cannot be paid for.
+        const isSelectable = !run.billed
+        const needsRate = !run.payable
+        const suggestion =
+          run.design_estimated_cost ?? run.design_production_cost ?? null
         const isSelected = selectedIds.has(run.run_id)
         const quantity = getQuantity(run)
         const rate = getRate(run)
@@ -800,9 +827,9 @@ const RunsPanel = ({
                       Already paid — {run.billed.status}
                     </Badge>
                   )}
-                  {!run.payable && (
-                    <Badge color="red" size="2xsmall">
-                      No agreed rate
+                  {needsRate && (
+                    <Badge color="orange" size="2xsmall">
+                      No agreed rate — enter one
                     </Badge>
                   )}
                 </div>
@@ -851,6 +878,23 @@ const RunsPanel = ({
                     {run.billed.quantity === 1 ? "" : "s"})
                   </Text>
                 )}
+                {needsRate && suggestion != null && (
+                  <Text size="xsmall" className="text-ui-fg-muted mt-1">
+                    {/* A starting point, explicitly labelled as coming from the
+                        design rather than from what was agreed. The box stays
+                        EMPTY — billing a design cost without someone typing it
+                        is the #1554 substitution. */}
+                    The design estimates {suggestion.toLocaleString()} per unit.
+                    That is the design's figure, not an agreed rate — check it
+                    before using it.
+                  </Text>
+                )}
+                {needsRate && suggestion == null && (
+                  <Text size="xsmall" className="text-ui-fg-muted mt-1">
+                    No cost recorded on the run or the design. Recalculate the
+                    design's cost, or enter the agreed rate here.
+                  </Text>
+                )}
                 {!run.billed && run.design_has_open_submission && (
                   <Text size="xsmall" className="text-ui-fg-warning mt-1">
                     This design is already in an open submission — creating
@@ -890,10 +934,16 @@ const RunsPanel = ({
                       size="small"
                       className="w-24 text-right"
                       aria-label={`Rate for ${run.design_name || run.run_id}`}
+                      // Empty, not "0", when the run carries no rate — a 0 in
+                      // the box reads as an agreed price of zero, and the
+                      // placeholder makes it obvious a number is wanted.
+                      placeholder={needsRate ? "rate" : undefined}
                       value={
                         rateOverrides[run.run_id] != null
                           ? String(rateOverrides[run.run_id])
-                          : String(run.unit_amount)
+                          : run.unit_amount > 0
+                            ? String(run.unit_amount)
+                            : ""
                       }
                       onChange={(e) => onRateChange(run.run_id, e.target.value)}
                       onClick={(e) => e.stopPropagation()}
@@ -910,8 +960,9 @@ const RunsPanel = ({
                       className="text-right"
                       data-testid={`run-amount-${run.run_id}`}
                     >
-                      {quantity} × {rate.toLocaleString()} ={" "}
-                      {amount.toLocaleString()}
+                      {rate > 0
+                        ? `${quantity} × ${rate.toLocaleString()} = ${amount.toLocaleString()}`
+                        : "—"}
                     </Text>
                   </div>
                 </div>

--- a/apps/backend/src/admin/hooks/api/payment-submissions.ts
+++ b/apps/backend/src/admin/hooks/api/payment-submissions.ts
@@ -128,8 +128,14 @@ export interface PayableRun {
   amount: number
   cost_type: "per_unit" | "total" | null
   partner_cost_estimate: number | null
-  /** False when no rate was ever agreed — not a zero-value payout. */
+  /**
+   * Whether the RUN carries an agreed rate. NOT "can this be paid" — an
+   * unpriced run is still payable by typing the rate. Only `billed` blocks.
+   */
   payable: boolean
+  /** The design's own cost, offered as a starting point. A suggestion, never a price. */
+  design_estimated_cost: number | null
+  design_production_cost: number | null
   billed: { submission_id: string; status: string; quantity: number } | null
   design_has_open_submission: boolean
 }

--- a/apps/backend/src/api/admin/payment-submissions/payable-runs/route.ts
+++ b/apps/backend/src/api/admin/payment-submissions/payable-runs/route.ts
@@ -190,11 +190,34 @@ export const GET = async (req: MedusaRequest, res: MedusaResponse) => {
             ? null
             : Number(run.partner_cost_estimate),
         /**
-         * A run with no agreed rate is NOT a zero-value payout — it is a run
-         * whose price hasn't been settled. Surfaced rather than hidden so the
-         * screen can say why it can't be billed.
+         * Whether the RUN carries an agreed rate.
+         *
+         * ⚠️ This is NOT "can this be paid". A run with no agreed rate is not a
+         * zero-value payout and it is not unpayable — it is a run whose price
+         * was never written down, and an admin who knows what was agreed must
+         * still be able to pay it by typing the rate. Only `billed` blocks.
          */
         payable: unit_amount > 0,
+        /**
+         * The DESIGN's own cost figures, offered as a starting point when the
+         * run carries no rate.
+         *
+         * 🔴 A suggestion, never a price. `design.estimated_cost` is per
+         * finished unit and routinely disagrees with what was actually agreed —
+         * pricing Bakshi's from the design would bill 11,530.80 against the
+         * run's 7,650. It is returned so the screen can SHOW it next to an
+         * empty rate box; nothing may bill from it without someone typing it in
+         * deliberately. That silent substitution is #1554.
+         */
+        design_estimated_cost:
+          design?.estimated_cost === null || design?.estimated_cost === undefined
+            ? null
+            : Number(design.estimated_cost),
+        design_production_cost:
+          design?.production_cost === null ||
+          design?.production_cost === undefined
+            ? null
+            : Number(design.production_cost),
         billed: billedRuns.get(String(run.id)) ?? null,
         design_has_open_submission: designsWithOpenSubmission.has(
           String(run.design_id)
@@ -202,8 +225,10 @@ export const GET = async (req: MedusaRequest, res: MedusaResponse) => {
       }
     })
     .sort((a, b) => {
-      // Unbilled first (that's the work), then newest completion.
+      // Unbilled first (that's the work), then priced before unpriced (those
+      // need a human to type a rate), then newest completion.
       if (!!a.billed !== !!b.billed) return a.billed ? 1 : -1
+      if (a.payable !== b.payable) return a.payable ? -1 : 1
       return (
         new Date(b.completed_at || 0).getTime() -
         new Date(a.completed_at || 0).getTime()

--- a/e2e/specs/payment-submission-payable-runs.spec.ts
+++ b/e2e/specs/payment-submission-payable-runs.spec.ts
@@ -115,19 +115,43 @@ test.describe("Payment submission from production runs (#1556)", () => {
     ).toContainText("4 × 1,200 = 4,800")
   })
 
-  test("shows an unpriced run as unpayable instead of billing zero for it", async ({
+  test("still lets an unpriced run be paid, by typing the rate", async ({
     page,
   }) => {
     await login(page)
     await openCreateForPartner(page)
 
-    // A run with no agreed rate is not a zero-value payout — it is a run whose
-    // price has not been settled. It has to be visible (an admin looking for it
-    // needs to see WHY it can't be billed) and not selectable.
+    /**
+     * 🔑 A missing rate is a gap in the RECORD, not a statement that the work
+     * was free. On prod 15 of 27 completed runs carry no rate — the partner
+     * finished the job and never entered a price. Blocking those would make
+     * real completed work permanently unpayable through the only screen that
+     * can pay it.
+     *
+     * So the row says a rate is needed, shows no amount until one is given,
+     * and is still selectable.
+     */
     const row = runRow(page, seed.unpricedRunId)
     await expect(row).toBeVisible({ timeout: 15000 })
     await expect(row).toContainText("No agreed rate")
-    await expect(row.getByRole("checkbox")).toBeDisabled()
+    await expect(row.getByRole("checkbox")).toBeEnabled()
+
+    // No amount asserted until someone supplies a rate — a "0" here would read
+    // as an agreed price of zero.
+    await expect(
+      row.getByTestId(`run-amount-${seed.unpricedRunId}`)
+    ).toHaveText("—")
+
+    await row.getByRole("checkbox").click()
+    await row
+      .getByRole("spinbutton", { name: `Rate for ${seed.payoutDesignName}` })
+      .fill("400")
+
+    // 2 produced x 400 typed by hand.
+    await expect(
+      row.getByTestId(`run-amount-${seed.unpricedRunId}`)
+    ).toContainText("2 × 400 = 800")
+    await expect(page.getByTestId("submission-total")).toHaveText("INR 800")
   })
 
   test("bills the quantity an admin types, and creates the submission for it", async ({


### PR DESCRIPTION
Follow-up to #1560, from a review catch by the founder.

## What was wrong

#1560 rendered a completed run with no `partner_cost_estimate` as **non-selectable** — badge "No agreed rate", checkbox disabled.

Prod says how wrong that was: **15 of 27 completed runs carry no rate.** The partner finished the work and never entered a price.

A missing rate is a gap in the **record**. It is not a statement that the work was free, and it must not make real completed work permanently unpayable through the only screen that can pay for it. An admin who knows what was agreed types it in.

## Changes

- **Only `billed` blocks selection.** `payable` keeps its meaning — "the run carries an agreed rate" — with docs that stop it being read as "can this be paid".
- **The rate box is empty** (placeholder `rate`), never pre-filled with `0`. A `0` in that box reads as an agreed price of zero. The amount renders `—` until a rate is supplied, and the existing submit guard still refuses a zero line.
- **The endpoint returns `design_estimated_cost` / `design_production_cost` as a labelled suggestion.** 🔴 Shown next to an empty box, never billed from: `design.estimated_cost` is per finished unit and routinely disagrees with what was agreed — pricing Bakshi's from the design bills 11,530.80 against the run's 7,650. Substituting it silently is #1554. Where neither exists, the row says so and points at recalculating the design's cost.
- **Select All takes only priced runs.** Bulk-selecting a rateless row would add a line the submit guard then refuses, blocking the whole submission on rows the admin never chose.
- Unpriced runs sort after priced ones — they need a human.

## Verification

- Integration → **58/58**
- e2e → **4/4 in a real browser**, including a new case that types a rate onto a rateless run and watches the total appear
- `check:prod-build` ✅

⚠️ The tsc baseline on this tree is **80**, not the 79 previously recorded — confirmed by stashing and re-running, not assumed. My changes add zero.

## Prod data touched alongside this

| Run | Change | Verified |
|---|---|---|
| Princess Highway `prod_run_01KWPVZ4R2…` | `produced_quantity` null → **1** | ✅ re-read |
| Ivory Prints `prod_run_01KXQFWCZT…` | rate set to 1,100 (by founder) | ✅ re-read |

Both now price correctly through the endpoint: Princess Highway `1 × 810`, Ivory Prints `1 × 1,100`, both on a `produced` basis.

⚠️ **`finished_at` cannot be set through any admin route.** Princess Highway has `finished_at: null` with `completed_at` set — it jumped from *started* straight to *completed*. Correcting that needs a new route or a maintenance job; flagged, not silently left.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_0158wJMZ1DmjNxXf5uGuBrQD