### PR TITLE
fix(payments): a stored cost of 0 is not a cost — it billed nothing and passed (#1563)

### DIFF
--- a/apps/backend/integration-tests/http/payment-submissions-api.spec.ts
+++ b/apps/backend/integration-tests/http/payment-submissions-api.spec.ts
@@ -758,6 +758,57 @@ setupSharedTestSuite(() => {
 
   // ─── Payable runs (#1556) ─────────────────────────────────────────────────
 
+  describe("A stored cost of 0 is not a cost (#1563)", () => {
+    it("refuses a design whose stored cost is 0 rather than billing nothing", async () => {
+      // 🔴 `recalculate-cost` writes `total_estimated: 0` with
+      // `confidence: "estimated"` when the estimator finds no BOM and no
+      // inventory history — it reports "I found nothing" as "this costs
+      // nothing". Four prod designs were flipped from null to 0 that way.
+      //
+      // The old guard asked `=== null || === undefined`, so 0 passed it and the
+      // workflow produced a payment line billing 0 that looked like a real
+      // claim. "No cost recorded" must refuse, exactly as it did before anyone
+      // pressed recalculate.
+      const d1 = await createDesign("Zero Cost Design", { estimated_cost: 0 })
+      await linkDesignToPartner(d1, partnerId)
+
+      const res = await api
+        .post(
+          "/admin/payment-submissions",
+          { partner_id: partnerId, design_ids: [d1] },
+          adminHeaders
+        )
+        .catch((e: any) => e.response)
+
+      expect(res.status).toBe(400)
+      expect(res.data.message).toContain("Designs missing cost")
+    })
+
+    it("still bills a 0-cost design when a real rate is supplied", async () => {
+      // The refusal is about the absence of a figure, not a ban on the design.
+      // An admin who knows the agreed rate types it and the payout goes through
+      // — which is the whole point of the run-sourced screen.
+      const d1 = await createDesign("Zero Cost But Priced", {
+        estimated_cost: 0,
+      })
+      await linkDesignToPartner(d1, partnerId)
+
+      const res = await api.post(
+        "/admin/payment-submissions",
+        {
+          partner_id: partnerId,
+          design_ids: [d1],
+          quantities: { [d1]: 3 },
+          unit_amounts: { [d1]: 250 },
+        },
+        adminHeaders
+      )
+
+      expect(res.status).toBe(201)
+      expect(Number(res.data.payment_submission.total_amount)).toBe(750)
+    })
+  })
+
   describe("GET /admin/payment-submissions/payable-runs", () => {
     it("requires partner_id rather than listing every completed run", async () => {
       // An unfiltered variant would return every partner's runs. That exact

--- a/apps/backend/src/workflows/payment_submissions/create-payment-submission.ts
+++ b/apps/backend/src/workflows/payment_submissions/create-payment-submission.ts
@@ -293,16 +293,34 @@ const validateDesignsForSubmissionStep = createStep(
       }
     }
 
-    // 3. Validate all designs have a cost (estimated_cost, production_cost, a
-    // partner-entered total override, or a caller-supplied per-unit rate)
+    // 3. Validate all designs have a USABLE cost (estimated_cost,
+    // production_cost, a partner-entered total override, or a caller-supplied
+    // per-unit rate).
+    //
+    // 🔴 "Usable" means POSITIVE, not merely "not null". The guard used to ask
+    // `=== null || === undefined`, so a stored **0** sailed through it — and
+    // `resolveDesignLineAmount` then returns amount 0, creating a payment line
+    // that bills nothing while looking like a real claim.
+    //
+    // That is not hypothetical. `POST /admin/designs/:id/recalculate-cost`
+    // writes `total_estimated: 0` with `confidence: "estimated"` when the
+    // estimator finds no BOM and no inventory history — it reports "I found
+    // nothing" as "this costs nothing". Running it over nine designs on prod
+    // turned four of them from null into 0, which is how this was found. A
+    // design with no cost data must be REFUSED, exactly as it was before
+    // somebody pressed recalculate.
     const overrides = input.cost_overrides || {}
     const suppliedUnitAmounts = input.unit_amounts || {}
+    const isUsableCost = (value: unknown): boolean => {
+      const n = Number(value)
+      return Number.isFinite(n) && n > 0
+    }
     const noCost = typedDesigns.filter(
       (d) =>
         !overrides[d.id] &&
         !suppliedUnitAmounts[d.id] &&
-        (d.estimated_cost === null || d.estimated_cost === undefined) &&
-        ((d as any).production_cost === null || (d as any).production_cost === undefined)
+        !isUsableCost(d.estimated_cost) &&
+        !isUsableCost((d as any).production_cost)
     )
     if (noCost.length) {
       throw new MedusaError(


### PR DESCRIPTION
Found while running `recalculate-cost` over the nine designs that had no cost at all (requested before handoff). Five got real figures. **Four came back `0`** — and `0` is worse than `null`.

## The estimator reports "nothing found" as "costs nothing"

```json
{ "material_cost": 0, "production_cost": 0, "total_estimated": 0,
  "confidence": "estimated", "breakdown": { "materials": [] } }
```

No BOM, no inventory history — and it returns `0` with a confidence label saying it looked and got an answer.

## Which defeated the payment guard

The submission workflow asked `estimated_cost === null || === undefined`. A stored `0` is neither, so it sailed through — and `resolveDesignLineAmount` then returns `amount: 0`, creating a payment line that **bills nothing while looking like a real claim**.

Before anyone pressed recalculate those four designs were correctly refused with "Designs missing cost". Afterwards they would silently produce a zero-value payout. I opened that hole by running the recalcs, so it's fixed here.

The guard now requires a **positive** number. A design with a stored `0` stays perfectly payable when a real rate is supplied — the refusal is about the absence of a figure, not a ban on the design.

## Recalculation results (prod)

| Design | est | prod | mat |
|---|---|---|---|
| Ivory Prints | 1,100 | 1,100 | 0 |
| Jolly jungle | 2,180 | 680 | 1,500 |
| Floral Prints Open Jacket | 1,960 | 735 | 1,225 |
| Simple blue striped white dress | 1,680 | 630 | 1,050 |
| Trouts Trouser | 1,400 | 525 | 875 |
| Modern Lotus on White Fabric | **0** | 0 | 0 |
| Ketiya Silk Sample Embroidery | **0** | 0 | 0 |
| Jaam Dani Modern Touch | **0** | 0 | 0 |
| Jacket With Embroidery | **0** | 0 | 0 |

⚠️ The four zeros stay on prod: `/admin/designs/:id` validates `estimated_cost` as `z.number().optional()`, so `null` cannot be written back through the API. This change makes those rows harmless without needing a prod write.

## Not fixed here

The **estimator itself** should return `null` / a `"none"` confidence when it has no data, rather than `0` / `"estimated"`. That changes what every reader of a design cost sees — cost panels, the partner cost route, the new payable-runs suggestion — so it wants its own change, not a rider on a payment guard. Filing separately.

## Verification

- Integration → **60/60** (2 new)
- Confirmed **load-bearing**: restoring the old `!== null && !== undefined` semantics turns the new case red
- `check:prod-build` ✅

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_0158wJMZ1DmjNxXf5uGuBrQD