### PR TITLE
fix(payments): "not billed" and "we can't tell" were the same value (#1565)

### DIFF
--- a/apps/backend/integration-tests/http/payment-submissions-api.spec.ts
+++ b/apps/backend/integration-tests/http/payment-submissions-api.spec.ts
@@ -938,6 +938,192 @@ setupSharedTestSuite(() => {
     })
   })
 
+  /**
+   * "We can't tell" must not be spelled the same way as "no" (#1565).
+   *
+   * Every payment line on production recorded no run at all, so the #1556 guard
+   * returned `billed: null` for all 13 submissions — and the screen sorted those
+   * runs to the top as clean, payable work. Absence read as permission.
+   */
+  describe("GET payable-runs — an unrecorded payout is UNKNOWN, not clear (#1565)", () => {
+    it("reports a run as unknown when a live payout for its design names no run", async () => {
+      const d1 = await createDesign("Unrecorded Claim Design", {
+        estimated_cost: 1200,
+      })
+      await linkDesignToPartner(d1, partnerId)
+      const runId = await createCompletedRun(d1, "Unrecorded Claim Design")
+
+      // A payout for the DESIGN with no `production_run_ids` — the shape every
+      // pre-#1556 submission has, and the shape the auto-draft subscriber wrote
+      // for months.
+      const sub = await api.post(
+        "/admin/payment-submissions",
+        {
+          partner_id: partnerId,
+          design_ids: [d1],
+          quantities: { [d1]: 4 },
+          unit_amounts: { [d1]: 1200 },
+        },
+        adminHeaders
+      )
+      expect(sub.status).toBe(201)
+      const submissionId = sub.data.payment_submission.id
+
+      // The line says so about itself rather than leaving a NULL to be
+      // interpreted — three different situations produce that NULL.
+      const detail = await api.get(
+        `/admin/payment-submissions/${submissionId}`,
+        adminHeaders
+      )
+      expect(detail.data.payment_submission.items[0].run_provenance).toBe(
+        "not_recorded"
+      )
+
+      const res = await api.get(
+        `/admin/payment-submissions/payable-runs?partner_id=${partnerId}`,
+        adminHeaders
+      )
+      const row = res.data.payable_runs.find((r: any) => r.run_id === runId)
+
+      // 🔴 The assertion that fails on the old code: `billed` is still null —
+      // no line NAMES this run — but that null is ignorance, not innocence.
+      // This payout may already have covered these very garments.
+      expect(row.billed).toBeNull()
+      expect(row.billing_status).toBe("unknown")
+      expect(row.unrecorded_claims).toHaveLength(1)
+      expect(row.unrecorded_claims[0].submission_id).toBe(submissionId)
+    })
+
+    it("leaves other runs of the design CLEAR when the payout did name its run", async () => {
+      // The counter-case. A `recorded` line is not a source of doubt: it says
+      // exactly what it covered, so the design's OTHER completed run is safe to
+      // bill. Without this, "unknown" would swallow the whole screen and the
+      // guard would be useless in the other direction.
+      const d1 = await createDesign("Recorded Claim Design", {
+        estimated_cost: 1200,
+      })
+      await linkDesignToPartner(d1, partnerId)
+      const paidRun = await createCompletedRun(d1, "Recorded Claim Design")
+      const freshRun = await createCompletedRun(d1, "Recorded Claim Design")
+
+      await api.post(
+        "/admin/payment-submissions",
+        {
+          partner_id: partnerId,
+          design_ids: [d1],
+          quantities: { [d1]: 4 },
+          unit_amounts: { [d1]: 1200 },
+          production_run_ids: { [d1]: [paidRun] },
+        },
+        adminHeaders
+      )
+
+      const res = await api.get(
+        `/admin/payment-submissions/payable-runs?partner_id=${partnerId}`,
+        adminHeaders
+      )
+      const paid = res.data.payable_runs.find((r: any) => r.run_id === paidRun)
+      const fresh = res.data.payable_runs.find((r: any) => r.run_id === freshRun)
+
+      expect(paid.billing_status).toBe("billed")
+      expect(fresh.billing_status).toBe("clear")
+      expect(fresh.unrecorded_claims).toHaveLength(0)
+    })
+
+    it("does not rank an unknown run above genuinely clear work", async () => {
+      // Sorting an unverifiable run alongside unpaid work is precisely how a
+      // second payout for the same garments gets made — the reviewer sees two
+      // rows that look identical and pays both.
+      // 🔴 The clean run is deliberately the OLDER of the two. The tie-break
+      // below `billing_status` is newest-completion-first, so a doubtful run
+      // completed later would sort above it on the old code — which is exactly
+      // the arrangement this test has to rule out. Build the fixture the other
+      // way round and it passes without the fix, proving nothing.
+      const clean = await createDesign("Clean Design", { estimated_cost: 1200 })
+      await linkDesignToPartner(clean, partnerId)
+      const cleanRun = await createCompletedRun(clean, "Clean Design")
+
+      const doubtful = await createDesign("Doubtful Design", {
+        estimated_cost: 1200,
+      })
+      await linkDesignToPartner(doubtful, partnerId)
+      const doubtfulRun = await createCompletedRun(doubtful, "Doubtful Design", {
+        completed_at: new Date(Date.now() + 60_000),
+      })
+      await api.post(
+        "/admin/payment-submissions",
+        {
+          partner_id: partnerId,
+          design_ids: [doubtful],
+          quantities: { [doubtful]: 4 },
+          unit_amounts: { [doubtful]: 1200 },
+        },
+        adminHeaders
+      )
+
+      const res = await api.get(
+        `/admin/payment-submissions/payable-runs?partner_id=${partnerId}`,
+        adminHeaders
+      )
+      const order = res.data.payable_runs.map((r: any) => r.run_id)
+      expect(order.indexOf(cleanRun)).toBeLessThan(order.indexOf(doubtfulRun))
+    })
+
+    it("a task payout casts no doubt — a task never had a run to record", async () => {
+      // `no_run` is the one case where a missing run is an ANSWER. If this
+      // read as "not recorded" too, every partner who was ever paid for a task
+      // would have all of their production runs stuck at `unknown` forever.
+      const d1 = await createDesign("Task Payout Design", {
+        estimated_cost: 1200,
+      })
+      await linkDesignToPartner(d1, partnerId)
+      const runId = await createCompletedRun(d1, "Task Payout Design")
+
+      // A REAL task payout for this partner, not an absent one — otherwise
+      // this test asserts `clear` about a partner with no payouts at all and
+      // would pass just as happily on code that got `no_run` wrong.
+      const container = getContainer()
+      const taskService = container.resolve("tasks") as any
+      const task = await taskService.createTasks({
+        title: "Paid Task Beside A Run",
+        status: "completed",
+        start_date: new Date(),
+      })
+      const remoteLink = container.resolve(
+        ContainerRegistrationKeys.LINK
+      ) as any
+      await remoteLink.create({
+        partner: { partner_id: partnerId },
+        tasks: { task_id: task.id },
+      })
+      const taskSub = await api.post(
+        "/partners/payment-submissions",
+        {
+          task_ids: [task.id],
+          metadata: { task_cost_overrides: { [task.id]: 1500 } },
+        },
+        { headers: partnerHeaders }
+      )
+      expect(taskSub.status).toBe(201)
+      // The partner create response carries no line items, so read the line
+      // back from the admin detail route rather than asserting on undefined.
+      const taskDetail = await api.get(
+        `/admin/payment-submissions/${taskSub.data.payment_submission.id}`,
+        adminHeaders
+      )
+      const taskItem = taskDetail.data.payment_submission.items[0]
+      expect(taskItem.source_type).toBe("task")
+      expect(taskItem.run_provenance).toBe("no_run")
+
+      const res = await api.get(
+        `/admin/payment-submissions/payable-runs?partner_id=${partnerId}`,
+        adminHeaders
+      )
+      const row = res.data.payable_runs.find((r: any) => r.run_id === runId)
+      expect(row.billing_status).toBe("clear")
+    })
+  })
+
   describe("POST /admin/payment-submissions — run provenance (#1556)", () => {
     it("records which runs a line paid for, and reports them as billed", async () => {
       const d1 = await createDesign("Provenance Design", {

--- a/apps/backend/src/api/admin/ops/maintenance-jobs/__tests__/backfill-payment-line-run-provenance.unit.spec.ts
+++ b/apps/backend/src/api/admin/ops/maintenance-jobs/__tests__/backfill-payment-line-run-provenance.unit.spec.ts
@@ -1,0 +1,88 @@
+import { recoverRunIdFromMetadata } from "../backfill-payment-line-run-provenance-job"
+
+/**
+ * The run id a payout already states — under whichever of the two spellings
+ * the writer happened to use (#1565).
+ *
+ * 🔴 Two writers recorded one fact two ways and neither reached the column that
+ * guards the money: `metadata.production_run_id` (the auto-draft subscriber)
+ * and `metadata.source_production_run_id` (the admin screen). That is #1557's
+ * shape — `metadata` validates as `z.record(z.string(), z.any())`, so both
+ * store cleanly and neither guards anything.
+ */
+describe("recoverRunIdFromMetadata", () => {
+  it("reads the auto-draft subscriber's spelling", () => {
+    expect(
+      recoverRunIdFromMetadata({ production_run_id: "prod_run_A" })
+    ).toEqual({ runId: "prod_run_A", key: "production_run_id", conflict: false })
+  })
+
+  it("reads the admin screen's spelling", () => {
+    // Five of production's thirteen submissions use the first key and four use
+    // this one. A job that knew only one spelling would silently leave the
+    // other four reporting "no run billed".
+    expect(
+      recoverRunIdFromMetadata({ source_production_run_id: "prod_run_B" })
+    ).toEqual({
+      runId: "prod_run_B",
+      key: "source_production_run_id",
+      conflict: false,
+    })
+  })
+
+  it("accepts both keys when they agree", () => {
+    expect(
+      recoverRunIdFromMetadata({
+        production_run_id: "prod_run_C",
+        source_production_run_id: "prod_run_C",
+      })
+    ).toEqual({
+      runId: "prod_run_C",
+      key: "production_run_id",
+      conflict: false,
+    })
+  })
+
+  it("refuses to choose when the two keys disagree", () => {
+    // 🔴 Two names for one payout's run that do not match is a contradiction,
+    // not a fact. Picking either would write a provenance nobody stated —
+    // and a WRONG run id is worse than none: it reports `billed` and silently
+    // blocks a partner's real payout.
+    expect(
+      recoverRunIdFromMetadata({
+        production_run_id: "prod_run_D",
+        source_production_run_id: "prod_run_E",
+      })
+    ).toEqual({ runId: null, key: null, conflict: true })
+  })
+
+  it("recovers nothing from metadata that never recorded a run", () => {
+    // The honest outcome for a genuinely unrecorded payout: the information was
+    // never created, and the job must not invent it. The line stays
+    // `not_recorded` — "not added to bills".
+    for (const md of [
+      null,
+      undefined,
+      {},
+      { created_by: "admin" },
+      { task_cost_overrides: { t1: 2500 } },
+    ]) {
+      expect(recoverRunIdFromMetadata(md as any)).toEqual({
+        runId: null,
+        key: null,
+        conflict: false,
+      })
+    }
+  })
+
+  it("ignores a key present but not a usable string", () => {
+    // An empty string is not an id, and a non-string would become "undefined"
+    // or "[object Object]" downstream — a run id that matches nothing while
+    // looking, in the column, exactly like a recorded one.
+    for (const bad of ["", null, 42, {}, []]) {
+      expect(recoverRunIdFromMetadata({ production_run_id: bad } as any)).toEqual(
+        { runId: null, key: null, conflict: false }
+      )
+    }
+  })
+})

--- a/apps/backend/src/api/admin/ops/maintenance-jobs/backfill-payment-line-run-provenance-job.ts
+++ b/apps/backend/src/api/admin/ops/maintenance-jobs/backfill-payment-line-run-provenance-job.ts
@@ -1,0 +1,296 @@
+import { ContainerRegistrationKeys, MedusaError } from "@medusajs/framework/utils"
+import { z } from "@medusajs/framework/zod"
+
+import { PAYMENT_SUBMISSIONS_MODULE } from "../../../../modules/payment_submissions"
+import type PaymentSubmissionsService from "../../../../modules/payment_submissions/service"
+import type { MaintenanceChange, MaintenanceJob, MaintenanceJobResult } from "./registry"
+
+/**
+ * Data Plumbing — move each payout's run id into the column that guards it (#1565).
+ *
+ * `payment_submission_item.production_run_ids` decides whether the same finished
+ * run can be billed twice. On production it was NULL on every one of the 13
+ * submissions, so the guard was inert while the payable-runs screen presented
+ * its silence as "nothing billed yet".
+ *
+ * Nine of those rows are not actually missing their run — they recorded it, just
+ * not where the guard looks. Two writers spelled one fact two ways:
+ *
+ *   - `metadata.production_run_id`         — the auto-draft subscriber
+ *   - `metadata.source_production_run_id`  — the admin submission screen
+ *
+ * That is #1557 exactly: a `metadata` key is validated as
+ * `z.record(z.string(), z.any())`, so either spelling stores cleanly and neither
+ * guards anything. This job copies the answer onto the real column.
+ *
+ * ⚠️ It records something that ALREADY HAPPENED. It creates no submission,
+ * approves nothing, moves no money, and changes no amount.
+ *
+ * ## It transcribes; it does not deduce
+ *
+ * 🔴 A recovered id is still CHECKED before it is trusted: the run must exist,
+ * belong to the submission's partner, and be a run of the line's own design. A
+ * wrong run id in this column is worse than an empty one — an empty column
+ * reports `unknown` and stops a human, while a wrong one reports `billed` and
+ * silently blocks a partner's real payout (or clears a run that was already
+ * paid). Anything that fails a check is skipped and reported, never written.
+ *
+ * 🔴 It never reads the run id out of `notes`. Prose is not a contract, and one
+ * production row states its run in the notes alone — that row is deliberately
+ * left for a human, because a parser that is right about it today is a parser
+ * that will be wrong about the sentence someone writes next month.
+ *
+ * A line with no recoverable run stays `not_recorded` — "not added to bills".
+ * That is the honest outcome, not a failure of this job: the information was
+ * never created, and inventing it here would be inventing payout provenance.
+ *
+ * Never overwrites a line that already records runs. Safe to re-run.
+ */
+const paramsSchema = z.object({
+  /** One submission, for a spot check before a full pass. */
+  payment_submission_id: z.string().min(1).optional(),
+  /** Bound a first pass; omitted means every line that needs one. */
+  limit: z.coerce.number().int().min(1).max(1000).optional(),
+})
+
+type SubmissionMetadata = {
+  production_run_id?: unknown
+  source_production_run_id?: unknown
+}
+
+/**
+ * PURE: the run id a submission already states, and under which spelling.
+ * Exported for tests.
+ *
+ * Both keys are read because both exist in production and mean the same thing.
+ * `production_run_id` wins only because it is the older writer; when a row
+ * somehow carries both AND they disagree, that is a contradiction rather than a
+ * fact, and the caller must skip it — hence `conflict`.
+ */
+export function recoverRunIdFromMetadata(
+  metadata: SubmissionMetadata | null | undefined
+): { runId: string | null; key: string | null; conflict: boolean } {
+  const md = (metadata ?? {}) as SubmissionMetadata
+
+  const fromSubscriber =
+    typeof md.production_run_id === "string" && md.production_run_id.length
+      ? md.production_run_id
+      : null
+  const fromAdmin =
+    typeof md.source_production_run_id === "string" &&
+    md.source_production_run_id.length
+      ? md.source_production_run_id
+      : null
+
+  if (fromSubscriber && fromAdmin && fromSubscriber !== fromAdmin) {
+    return { runId: null, key: null, conflict: true }
+  }
+
+  if (fromSubscriber) {
+    return { runId: fromSubscriber, key: "production_run_id", conflict: false }
+  }
+  if (fromAdmin) {
+    return {
+      runId: fromAdmin,
+      key: "source_production_run_id",
+      conflict: false,
+    }
+  }
+  return { runId: null, key: null, conflict: false }
+}
+
+export const backfillPaymentLineRunProvenanceJob: MaintenanceJob = {
+  id: "backfill-payment-line-run-provenance",
+  label: "Record which production run each existing payout paid for",
+  description:
+    "Copy the production run id that a payment submission ALREADY states in its metadata onto payment_submission_item.production_run_ids, the column the double-pay guard actually reads (#1565). Two writers spelled the same fact two different ways (metadata.production_run_id from the auto-draft subscriber, metadata.source_production_run_id from the admin screen) and the guard reads neither, so on production every payment line looked like 'no run billed' and the payable-runs screen ranked already-paid work as clean. Records something that already happened: creates no submission, approves nothing, changes no amount, moves no money. Each recovered id is VERIFIED before it is written — the run must exist, belong to the submission's partner, and be a run of that line's design — and anything failing a check is skipped and reported rather than written, because a wrong run id blocks a partner's real payout. Never reads the run id out of free-text notes. A line with no recoverable run is left as 'not_recorded' ('not added to bills'), which is the honest state, not a failure. Never overwrites a line that already records runs. Safe to re-run.",
+  params: [
+    {
+      name: "payment_submission_id",
+      type: "string",
+      required: false,
+      description: "Only this submission, e.g. for a spot check before a full pass.",
+    },
+    {
+      name: "limit",
+      type: "number",
+      required: false,
+      description: "Stop after this many lines. Omit for every line that needs one.",
+    },
+  ],
+  run: async (container, { dry_run, params }): Promise<MaintenanceJobResult> => {
+    const parsed = paramsSchema.safeParse(params)
+    if (!parsed.success) {
+      throw new MedusaError(
+        MedusaError.Types.INVALID_DATA,
+        parsed.error.issues.map((i) => i.message).join("; ")
+      )
+    }
+
+    const service: PaymentSubmissionsService = container.resolve(
+      PAYMENT_SUBMISSIONS_MODULE
+    )
+    const query: any = container.resolve(ContainerRegistrationKeys.QUERY)
+
+    const items = (await (service as any).listPaymentSubmissionItems(
+      parsed.data.payment_submission_id
+        ? { submission_id: parsed.data.payment_submission_id }
+        : {},
+      { relations: ["submission"], take: null }
+    )) as any[]
+
+    if (parsed.data.payment_submission_id && !(items || []).length) {
+      throw new MedusaError(
+        MedusaError.Types.NOT_FOUND,
+        `Payment submission ${parsed.data.payment_submission_id} has no line items`
+      )
+    }
+
+    const changes: MaintenanceChange[] = []
+    const errors: Array<{ id: string; message: string }> = []
+    /** Lines whose run is genuinely unrecoverable — the honest `not_recorded`. */
+    const noProvenance: string[] = []
+    /** Recovered an id, but it failed a check. Reported, never written. */
+    const rejected: Array<{ id: string; reason: string }> = []
+    let alreadyRecorded = 0
+    let notRunSourced = 0
+
+    for (const item of items || []) {
+      if (parsed.data.limit && changes.length >= parsed.data.limit) {
+        break
+      }
+
+      try {
+        const existing = (item?.production_run_ids ?? []) as string[]
+        if (Array.isArray(existing) && existing.length) {
+          // Written by a real submission path. Better evidence than anything
+          // recovered here.
+          alreadyRecorded++
+          continue
+        }
+
+        // A task payout never had a run. The migration already classified
+        // these; nothing to recover and nothing to report as a gap.
+        if (!item?.design_id || item?.source_type === "task") {
+          notRunSourced++
+          continue
+        }
+
+        const { runId, key, conflict } = recoverRunIdFromMetadata(
+          item?.submission?.metadata
+        )
+
+        if (conflict) {
+          rejected.push({
+            id: item.id,
+            reason:
+              "submission metadata names two different production runs; a contradiction is not a fact",
+          })
+          continue
+        }
+
+        if (!runId) {
+          // The information was never created. Leaving it `not_recorded` is the
+          // point — see the job doc.
+          noProvenance.push(item.id)
+          continue
+        }
+
+        const { data: runs } = await query.graph({
+          entity: "production_runs",
+          fields: ["id", "design_id", "partner_id", "status"],
+          filters: { id: [runId] },
+        })
+        const run = ((runs || []) as any[])[0]
+
+        if (!run) {
+          rejected.push({
+            id: item.id,
+            reason: `metadata.${key} names run ${runId}, which does not exist`,
+          })
+          continue
+        }
+
+        // A run belongs to exactly one design. If the stated run is not a run
+        // of this line's design, the metadata is describing something else and
+        // must not become this line's provenance.
+        if (String(run.design_id || "") !== String(item.design_id)) {
+          rejected.push({
+            id: item.id,
+            reason: `run ${runId} is a run of design ${run.design_id}, not ${item.design_id}`,
+          })
+          continue
+        }
+
+        const submissionPartnerId = String(item?.submission?.partner_id || "")
+        if (
+          submissionPartnerId &&
+          String(run.partner_id || "") !== submissionPartnerId
+        ) {
+          rejected.push({
+            id: item.id,
+            reason: `run ${runId} belongs to partner ${run.partner_id}, but the submission is partner ${submissionPartnerId}`,
+          })
+          continue
+        }
+
+        changes.push({
+          entity: "payment_submission_item",
+          id: item.id,
+          field: "production_run_ids",
+          before: null,
+          after: [runId],
+        })
+
+        if (!dry_run) {
+          await (service as any).updatePaymentSubmissionItems({
+            id: item.id,
+            production_run_ids: [runId],
+            run_provenance: "recorded",
+          })
+        }
+      } catch (e: any) {
+        // One unreadable line must not strand the rest of the pass.
+        errors.push({ id: item?.id ?? "(unknown)", message: e?.message ?? String(e) })
+      }
+    }
+
+    const parts: string[] = []
+    parts.push(
+      changes.length
+        ? `${dry_run ? "Would record" : "Recorded"} the production run for ${
+            changes.length
+          } payment line(s): ${changes
+            .map((c) => `${c.id} → ${(c.after as string[]).join(", ")}`)
+            .join("; ")}`
+        : "No payment line has a recoverable production run"
+    )
+    if (noProvenance.length) {
+      parts.push(
+        `${noProvenance.length} line(s) have no run recorded anywhere and stay "not_recorded" — not added to bills: ${noProvenance.join(", ")}`
+      )
+    }
+    if (rejected.length) {
+      parts.push(
+        `${rejected.length} line(s) SKIPPED — a recovered id failed verification: ${rejected
+          .map((r) => `${r.id} (${r.reason})`)
+          .join("; ")}`
+      )
+    }
+    if (alreadyRecorded) {
+      parts.push(`${alreadyRecorded} line(s) already record their run`)
+    }
+    if (notRunSourced) {
+      parts.push(`${notRunSourced} line(s) are not run-sourced (task payouts)`)
+    }
+
+    return {
+      job_id: "backfill-payment-line-run-provenance",
+      dry_run,
+      applied: !dry_run && changes.length > 0,
+      summary: parts.join(". ") + ".",
+      changes,
+      errors,
+    }
+  },
+}

--- a/apps/backend/src/api/admin/ops/maintenance-jobs/registry.ts
+++ b/apps/backend/src/api/admin/ops/maintenance-jobs/registry.ts
@@ -106,6 +106,7 @@ import { repairConsumptionLogJob } from "./repair-consumption-log-job"
 import { setLocationOwnershipJob } from "./set-location-ownership-job"
 import { resetNegativeInventoryLevelsJob } from "./reset-negative-inventory-levels-job"
 import { backfillDispatchedTemplateIdsJob } from "./backfill-dispatched-template-ids-job"
+import { backfillPaymentLineRunProvenanceJob } from "./backfill-payment-line-run-provenance-job"
 import { deduplicateTaskTemplateNamesJob } from "./deduplicate-task-template-names-job"
 import { recordManualInventoryCorrectionJob } from "./record-manual-inventory-correction-job"
 import { applyCommittedConsumptionJob } from "./apply-committed-consumption-job"
@@ -5804,6 +5805,7 @@ export const MAINTENANCE_JOBS: MaintenanceJob[] = [
   resetNegativeInventoryLevelsJob,
   deduplicateTaskTemplateNamesJob,
   backfillDispatchedTemplateIdsJob,
+  backfillPaymentLineRunProvenanceJob,
   recordManualInventoryCorrectionJob,
   applyCommittedConsumptionJob,
   backfillConsumptionAppliedColumnsJob,

--- a/apps/backend/src/api/admin/payment-submissions/payable-runs/route.ts
+++ b/apps/backend/src/api/admin/payment-submissions/payable-runs/route.ts
@@ -47,10 +47,32 @@ import { runUnitCost } from "../../../../workflows/production-runs/lib/run-payab
  * could be claimed again and the second claim would look exactly as legitimate
  * as the first.
  *
- * ⚠️ Lines written before `production_run_ids` existed record nothing, so a run
- * paid for by one of them reads `billed: null` here. `design_has_open_submission`
- * is reported alongside precisely so the screen can still warn: it is the older,
- * weaker signal, and it is the only one those rows carry.
+ * ## "Not billed" and "we can't tell" are different answers
+ *
+ * 🔴 Every payment line in production recorded no run at all, so this guard was
+ * inert on real data while the screen showed its output as fact: 13 of 13
+ * submissions returned `billed: null`, which the sort then ranked as clean,
+ * payable work. Absence read as permission — #1557's shape, on the field that
+ * decides whether someone is paid twice.
+ *
+ * So a run now reports `billing_status`, not just `billed`:
+ *
+ *   - `clear`   — every live payout for this design names the runs it covered,
+ *                 and this is not one of them.
+ *   - `unknown` — a live payout for this design is `run_provenance:
+ *                 "not_recorded"`: it pays for run work and never said which
+ *                 run. This run may already be inside it. A human has to
+ *                 establish what that payout covered before any money moves.
+ *   - `billed`  — a line names this run.
+ *
+ * A task payout (`run_provenance: "no_run"`) is not a source of doubt: there
+ * was never a run behind it. That distinction is the whole reason provenance is
+ * a stated column rather than something re-derived from a NULL. See
+ * `payment_submission_item.run_provenance` and #1565.
+ *
+ * ⚠️ `design_has_open_submission` remains reported alongside, but it is the
+ * older, weaker signal — it goes false the moment a submission is Approved.
+ * Branch on `billing_status`.
  */
 export const GET = async (req: MedusaRequest, res: MedusaResponse) => {
   const partnerId = String(
@@ -122,6 +144,22 @@ export const GET = async (req: MedusaRequest, res: MedusaResponse) => {
     { submission_id: string; status: string; quantity: number }
   >()
   const designsWithOpenSubmission = new Set<string>()
+  /**
+   * Designs carrying a live payout that does not say which run it paid for.
+   *
+   * 🔴 These are the rows that made the guard a fiction. A line with
+   * `run_provenance: "not_recorded"` pays for run work, is not Rejected, and
+   * names no run — so for every completed run of that design, "is this already
+   * paid for?" has no answer. Reporting `billed: null` for those runs said
+   * "no", and the screen sorted them to the top as clean, payable work.
+   *
+   * A `no_run` line (a task payout) is deliberately NOT collected here: that
+   * is the one case where a missing run is an answer rather than a gap.
+   */
+  const designsWithUnrecordedClaims = new Map<
+    string,
+    { submission_id: string; status: string; amount: number }[]
+  >()
   const OPEN_STATUSES = new Set([
     "Draft",
     "Pending",
@@ -135,6 +173,17 @@ export const GET = async (req: MedusaRequest, res: MedusaResponse) => {
 
     if (OPEN_STATUSES.has(status) && item.design_id) {
       designsWithOpenSubmission.add(String(item.design_id))
+    }
+
+    if (item.run_provenance === "not_recorded" && item.design_id) {
+      const designId = String(item.design_id)
+      const claims = designsWithUnrecordedClaims.get(designId) || []
+      claims.push({
+        submission_id: String(item.submission?.id || item.submission_id || ""),
+        status,
+        amount: Number(item.amount ?? 0),
+      })
+      designsWithUnrecordedClaims.set(designId, claims)
     }
 
     for (const runId of (item.production_run_ids || []) as string[]) {
@@ -219,15 +268,52 @@ export const GET = async (req: MedusaRequest, res: MedusaResponse) => {
             ? null
             : Number(design.production_cost),
         billed: billedRuns.get(String(run.id)) ?? null,
+        /**
+         * Live payouts against this design that never recorded a run.
+         *
+         * ⚠️ Non-empty means `billed: null` is IGNORANCE, not innocence — one
+         * of these may already have paid for this very run. Read with
+         * `billing_status` below rather than on its own.
+         */
+        unrecorded_claims:
+          designsWithUnrecordedClaims.get(String(run.design_id)) ?? [],
         design_has_open_submission: designsWithOpenSubmission.has(
           String(run.design_id)
         ),
       }
     })
+    .map((row) => ({
+      ...row,
+      /**
+       * The single field a caller should branch on, so that "we don't know"
+       * cannot be spelled the same way as "no".
+       *
+       * - `billed`  — a payment line names this run. Do not pay again.
+       * - `unknown` — a live payout for this design records no run, so this
+       *               run may already be inside it. Needs a human before it is
+       *               paid; #1565 is the whole reason this value exists.
+       * - `clear`   — every live payout for this design says which runs it
+       *               covered, and none of them is this one. Safe to bill.
+       */
+      billing_status: row.billed
+        ? ("billed" as const)
+        : row.unrecorded_claims.length
+          ? ("unknown" as const)
+          : ("clear" as const),
+    }))
     .sort((a, b) => {
-      // Unbilled first (that's the work), then priced before unpriced (those
-      // need a human to type a rate), then newest completion.
-      if (!!a.billed !== !!b.billed) return a.billed ? 1 : -1
+      // Clear work first — that is what the screen is for. Then `unknown`,
+      // which needs someone to establish what an old payout covered before any
+      // money moves, then already-billed. Within a bucket: priced before
+      // unpriced (those need a human to type a rate), then newest completion.
+      //
+      // 🔴 `unknown` deliberately does NOT rank with `clear`. Sorting an
+      // unverifiable run to the top next to genuinely unpaid work is precisely
+      // how a second payout for the same garments would get made.
+      const rank = { clear: 0, unknown: 1, billed: 2 }
+      if (rank[a.billing_status] !== rank[b.billing_status]) {
+        return rank[a.billing_status] - rank[b.billing_status]
+      }
       if (a.payable !== b.payable) return a.payable ? -1 : 1
       return (
         new Date(b.completed_at || 0).getTime() -

--- a/apps/backend/src/modules/payment_submissions/migrations/Migration20260826230000.ts
+++ b/apps/backend/src/modules/payment_submissions/migrations/Migration20260826230000.ts
@@ -1,0 +1,57 @@
+import { Migration } from "@medusajs/framework/mikro-orm/migrations";
+
+/**
+ * Say WHY a payment line has no run recorded, instead of leaving NULL to mean
+ * three incompatible things (#1565).
+ *
+ * `production_run_ids IS NULL` was true of every row in production — all 13
+ * submissions — so the double-pay guard added in #1556 was completely inert on
+ * real data while looking, from the screen, exactly like "nothing has been
+ * billed yet". Absence read as permission.
+ *
+ * But the nulls were not one population. They were three:
+ *
+ *   - **task payouts** — a task is not production output, so there was never a
+ *     run to record. NULL here is correct and permanent.
+ *   - **run payouts whose run was only ever stashed in `metadata`** — under
+ *     `metadata.production_run_id` (the auto-draft subscriber) or
+ *     `metadata.source_production_run_id` (the admin screen). Two spellings of
+ *     one fact, neither of them the column that guards the money. The run IS
+ *     knowable for these; see `backfill-payment-line-run-provenance-job`.
+ *   - **run payouts with no provenance anywhere** — genuinely not recorded.
+ *
+ * ## What this migration classifies, and what it refuses to
+ *
+ * It sets `no_run` where the row itself proves it: `task_id IS NOT NULL`. That
+ * is a fact on the row, not an inference. Everything else defaults to
+ * `not_recorded` — the honest reading of "we have not been told".
+ *
+ * 🔴 It deliberately does NOT read `metadata` to recover run ids, even though
+ * that is where nine of them live. A migration runs unattended on every deploy
+ * and gets no dry-run; recovering provenance that decides whether a partner is
+ * paid twice belongs in a job an operator can inspect first. A migration that
+ * guesses at money is a migration nobody can review.
+ *
+ * ⚠️ `not_recorded` is therefore the state of rows whose run is recoverable but
+ * not yet recovered. It is not a claim that the run is unknowable — it is a
+ * claim that this column does not know it. The backfill job upgrades them.
+ */
+export class Migration20260826230000 extends Migration {
+
+  override async up(): Promise<void> {
+    this.addSql(`alter table if exists "payment_submission_item" add column if not exists "run_provenance" text not null default 'not_recorded';`);
+    // A task line never had a run. The row proves this about itself, so it is
+    // classified rather than left to the default.
+    this.addSql(`update "payment_submission_item" set "run_provenance" = 'no_run' where "task_id" is not null;`);
+    // Belt and braces: any row that somehow already carries run ids is, by
+    // definition, recorded. (No such row exists in production today — every
+    // line predates #1556's column — but a migration should not depend on that
+    // remaining true between authoring and deploy.)
+    this.addSql(`update "payment_submission_item" set "run_provenance" = 'recorded' where "production_run_ids" is not null and jsonb_typeof("production_run_ids") = 'array' and jsonb_array_length("production_run_ids") > 0;`);
+  }
+
+  override async down(): Promise<void> {
+    this.addSql(`alter table if exists "payment_submission_item" drop column if exists "run_provenance";`);
+  }
+
+}

--- a/apps/backend/src/modules/payment_submissions/models/payment_submission_item.ts
+++ b/apps/backend/src/modules/payment_submissions/models/payment_submission_item.ts
@@ -61,9 +61,45 @@ const PaymentSubmissionItem = model.define("payment_submission_item", {
    *
    * NULL on every row written before this existed, and on any line that was
    * not sourced from a run (a hand-picked design, a task). Absent means "no
-   * run recorded", never "no run involved".
+   * run recorded", never "no run involved" — which is exactly why NULL alone
+   * cannot be read as an answer. See `run_provenance`.
    */
   production_run_ids: model.json().nullable(),
+  /**
+   * Whether this line's run provenance is known — and if not, why not.
+   *
+   * 🔴 `production_run_ids IS NULL` was doing the work of three different
+   * statements, and the guard could not tell them apart:
+   *
+   *   - a task payout, which never had a run to record;
+   *   - a line written before the column existed, whose run IS knowable but
+   *     was only ever stashed under a `metadata` key;
+   *   - a line that pays for run work with the run genuinely unrecorded.
+   *
+   * Only the third is a hole, and only the first is safe to treat as "not
+   * billed". Collapsing them into NULL meant the payable-runs screen showed
+   * every such run as clean, unbilled work — the double-pay guard reading
+   * absence as permission, which is the shape of #1557 all over again.
+   *
+   * ⚠️ Do NOT infer this from `production_run_ids` at read time. The whole
+   * point is that the three cases are indistinguishable from the column, so a
+   * reader that re-derives it has re-created the ambiguity it exists to end.
+   *
+   * - `recorded`      — `production_run_ids` names the runs. Guards.
+   * - `no_run`        — pays for something that is not production output (a
+   *                     task, a hand-picked design). Absence is correct and
+   *                     final; safe to read as "no run billed here".
+   * - `not_recorded`  — pays for run work whose run was never written down.
+   *                     "Not added to bills." Cannot guard, and any reader
+   *                     deciding whether a run is already paid for MUST treat
+   *                     a design carrying one of these as UNKNOWN, not clear.
+   *
+   * Defaults to `not_recorded` because that is the only honest default: a
+   * writer that says nothing has not told us there is no run.
+   */
+  run_provenance: model
+    .enum(["recorded", "no_run", "not_recorded"])
+    .default("not_recorded"),
   metadata: model.json().nullable(),
   submission: model.belongsTo(() => PaymentSubmission, {
     mappedBy: "items",

--- a/apps/backend/src/subscribers/auto-draft-payment-submission.ts
+++ b/apps/backend/src/subscribers/auto-draft-payment-submission.ts
@@ -63,6 +63,23 @@ export default async function autoDraftPaymentSubmissionHandler({
         // reject.
         require_design_status: false,
         notes: `Drafted automatically when production run ${runId} completed. Review the amount and submit when you're ready.`,
+        /**
+         * The run this draft pays for, in the column that guards the money.
+         *
+         * 🔴 This subscriber knows the run for certain — it is reacting to that
+         * run completing — and for months recorded it ONLY in `metadata` below.
+         * Every draft it wrote therefore reached the double-pay guard as "no
+         * run recorded", so the guard could never fire on the very rows it was
+         * built for: five of production's thirteen submissions. The admin
+         * screen had meanwhile started writing a SECOND spelling of the same
+         * fact (`metadata.source_production_run_id`), which is the #1557 shape
+         * exactly — one truth, two keys, neither of them load-bearing.
+         *
+         * Passing it here is what makes the line `run_provenance: "recorded"`.
+         * `metadata.production_run_id` stays for backwards compatibility with
+         * readers that already parse it, but it is no longer the record. #1565
+         */
+        production_run_ids: { [payout.design_id]: [runId] },
         metadata: {
           auto_drafted: true,
           source: "production_run.completed",

--- a/apps/backend/src/workflows/payment_submissions/create-payment-submission.ts
+++ b/apps/backend/src/workflows/payment_submissions/create-payment-submission.ts
@@ -716,6 +716,15 @@ const createSubmissionRecordStep = createStep(
         production_run_ids: (design.production_run_ids ?? null) as unknown as
           | Record<string, unknown>
           | null,
+        /**
+         * Stated, never inferred later. A design line with no runs named is
+         * `not_recorded` rather than `no_run`: the caller picked a DESIGN, and
+         * a design is produced many times, so we have not been told there is
+         * no run behind this money — only that nobody said which. #1565
+         */
+        run_provenance: design.production_run_ids?.length
+          ? "recorded"
+          : "not_recorded",
         submission_id: submission.id,
       })
     }
@@ -733,8 +742,11 @@ const createSubmissionRecordStep = createStep(
         // than left to the column default so the row is unambiguous.
         quantity: 1,
         unit_amount: null,
-        // A task is not production output; there is no run behind it.
+        // A task is not production output; there is no run behind it. This is
+        // the one case where a missing run is an ANSWER rather than a gap, so
+        // it is the one case that may be read as "nothing billed here". #1565
         production_run_ids: null as unknown as Record<string, unknown> | null,
+        run_provenance: "no_run" as const,
         cost_breakdown: task.cost_breakdown || null,
         submission_id: submission.id,
       })


### PR DESCRIPTION
Closes #1565.

`payment_submission_item.production_run_ids` (#1556) is what stops the same
finished run being paid for twice. It is **NULL on all 13 production
submissions**, so the guard has never once been able to fire — and the
payable-runs screen presented that silence as `billed: null`, sorting
already-paid work to the top as clean, payable work.

## The nulls were three statements wearing one value

| rows | what NULL meant | recoverable |
|---|---|---|
| 2 | task payout — never had a run | n/a, correct forever |
| 9 | run **is** recorded, just not in the guarded column | ✅ |
| 2 | no provenance anywhere | ❌ |

Only the first is safe to read as "not billed". The nine recorded their run
under a `metadata` key, with two writers spelling one fact two ways:
`metadata.production_run_id` (auto-draft subscriber, 5) and
`metadata.source_production_run_id` (admin screen, 4).

🔴 #1557 exactly — `metadata` validates as `z.record(z.string(), z.any())`, so
both spellings store cleanly and neither guards anything.

## Changes

- **`run_provenance`** on the line: `recorded` | `no_run` | `not_recorded`.
  Stated at write time; explicitly **not** re-derived from NULL, since
  re-deriving recreates the ambiguity it exists to end.
- **`billing_status`** on payable-runs: `clear` | `unknown` | `billed`. An
  `unknown` run does **not** rank beside genuinely unpaid work — sorting an
  unverifiable run next to clean work is how a second payout gets made.
- **The auto-draft subscriber now writes the guarded column.** It knew the run
  for certain the whole time (it reacts to that run completing) and recorded it
  only in metadata, so every draft it wrote was a self-inflicted gap. This also
  makes it genuinely idempotent: a repeated completion event now hits the
  duplicate guard and logs, instead of drafting twice.
- **`backfill-payment-line-run-provenance`** ops job for the nine.

## The job transcribes; it does not deduce

Each recovered id is **verified** before it is written — the run must exist,
belong to the submission's partner, and be a run of that line's design.
Anything failing a check is skipped and reported. A wrong run id is worse than
an empty one: an empty column reports `unknown` and stops a human, a wrong one
reports `billed` and silently blocks a partner's real payout.

It never parses `notes`. One production row states its run in prose alone and
is deliberately left for a human — a parser that is right about that sentence
today is one that will be wrong about the sentence someone writes next month.

Lines with no recoverable run stay `not_recorded` — "not added to bills". The
information was never created; inventing it here would be inventing payout
provenance.

## Verification

`64/64` in `payment-submissions-api.spec.ts`, `6/6` new unit tests,
`check:prod-build` green.

🔑 All four new integration tests were confirmed to **fail on the old code**.
The sort test initially passed without the fix — the clean run happened to be
newer, so the newest-first tie-break carried it — and the fixture was rebuilt
with the doubtful run completing *later* so it discriminates.

⚠️ Ships a migration (`Migration20260826230000`). It classifies only what the
row proves about itself (`task_id IS NOT NULL` → `no_run`) and deliberately
does **not** read metadata to recover run ids: a migration runs unattended with
no dry-run, and recovering provenance that decides whether a partner is paid
twice belongs in a job an operator can inspect first.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_0158wJMZ1DmjNxXf5uGuBrQD