### PR TITLE
fix(designs): the estimator reported "found nothing" as "costs nothing" (#1564)

### DIFF
--- a/apps/backend/integration-tests/http/design-cost-propagation.spec.ts
+++ b/apps/backend/integration-tests/http/design-cost-propagation.spec.ts
@@ -485,5 +485,101 @@ setupSharedTestSuite(() => {
         confidence: estimate.confidence,
       })
     })
+
+    /**
+     * "Found nothing" must not be persisted, quoted or charged as zero (#1564).
+     *
+     * The estimator reported an empty search as `total_estimated: 0`. The
+     * recalculate route stored it, so designs whose cost was honestly unknown
+     * came out claiming to be free — five of them on production.
+     */
+    describe("a design with nothing to estimate from (#1564)", () => {
+      /**
+       * No bill of materials, no order history, no admin estimate — the exact
+       * state the five production designs were in.
+       *
+       * ⚠️ Created per-test, NOT in a nested `beforeAll`. The runner restores a
+       * DB snapshot before every test, so rows written by a nested `beforeAll`
+       * are gone by the time the test body runs.
+       */
+      async function createBarrenDesign(): Promise<string> {
+        const res: any = await api.post(
+          "/admin/designs",
+          {
+            name: "Barren Design",
+            description: "No BOM, no history — nothing to price from",
+            design_type: "Original",
+            status: "Conceptual",
+            priority: "Low",
+            target_completion_date: new Date().toISOString(),
+          },
+          adminHeaders
+        )
+        expect(res.status).toBe(201)
+        return res.data.design.id
+      }
+
+      it("recalculating reports no estimate and LEAVES THE STORED COST ALONE", async () => {
+        const barrenId = await createBarrenDesign()
+        const res = await api.post(
+          `/admin/designs/${barrenId}/recalculate-cost`,
+          {},
+          adminHeaders
+        )
+
+        expect(res.status).toBe(200)
+        // 🔴 null, not 0. A zero here is a claim that the work is free.
+        expect(res.data.cost_estimate.total_estimated).toBeNull()
+        expect(res.data.cost_estimate.confidence).toBe("none")
+        // A 200 must not be readable as "the design was updated".
+        expect(res.data.persisted).toBe(false)
+
+        // The effect, not the response: the design still has no stored cost.
+        const after = await api.get(`/admin/designs/${barrenId}`, adminHeaders)
+        expect(after.data.design.estimated_cost ?? null).toBeNull()
+      })
+
+      it("the order preview shows it as unpriceable rather than free", async () => {
+        const barrenId = await createBarrenDesign()
+        const res = await api.post(
+          `/admin/customers/${customerId}/design-order/preview`,
+          { design_ids: [barrenId] },
+          adminHeaders
+        )
+
+        expect(res.status).toBe(200)
+        expect(res.data.estimates[0].unit_price).toBeNull()
+        // The total must not silently absorb it as a zero-priced line.
+        expect(res.data.total_is_complete).toBe(false)
+        expect(res.data.unpriceable).toHaveLength(1)
+        expect(res.data.unpriceable[0].design_id).toBe(barrenId)
+      })
+
+      it("a cost can be CLEARED back to unknown once set", async () => {
+        const barrenId = await createBarrenDesign()
+        // 🔴 The repair path. `estimated_cost` was optional-but-not-nullable, so
+        // "no cost recorded" was a state the API could produce and never
+        // restore — the five zeroed production rows were unfixable through any
+        // route. Prove the null actually lands, rather than trusting the 200.
+        const set = await api.put(
+          `/admin/designs/${barrenId}`,
+          { estimated_cost: 999 },
+          adminHeaders
+        )
+        expect(set.status).toBe(200)
+        const midway = await api.get(`/admin/designs/${barrenId}`, adminHeaders)
+        expect(Number(midway.data.design.estimated_cost)).toBe(999)
+
+        const cleared = await api.put(
+          `/admin/designs/${barrenId}`,
+          { estimated_cost: null },
+          adminHeaders
+        )
+        expect(cleared.status).toBe(200)
+
+        const after = await api.get(`/admin/designs/${barrenId}`, adminHeaders)
+        expect(after.data.design.estimated_cost ?? null).toBeNull()
+      })
+    })
   })
 })

--- a/apps/backend/src/api/admin/customers/[id]/design-order/preview/route.ts
+++ b/apps/backend/src/api/admin/customers/[id]/design-order/preview/route.ts
@@ -10,8 +10,13 @@ type PreviewDesignOrderBody = {
 type EstimatePreviewItem = {
   design_id: string
   name: string
-  total_estimated: number
-  unit_price: number
+  /**
+   * null when the estimator had nothing to price from. Shown as a gap the admin
+   * must fill, never as a zero — this preview is what someone reads before
+   * deciding to bill a customer. #1564
+   */
+  total_estimated: number | null
+  unit_price: number | null
   confidence: string
   material_cost: number
   production_cost: number
@@ -55,11 +60,25 @@ export const POST = async (
     })
   }
 
-  const total = estimates.reduce((sum, e) => sum + e.unit_price, 0)
+  /**
+   * The total covers only what could actually be priced.
+   *
+   * ⚠️ Summing an unpriceable design as 0 would quietly understate the order —
+   * the admin sees a total that looks complete and is not. `unpriceable` names
+   * exactly what is missing from it, so the gap is visible rather than absorbed.
+   */
+  const unpriceable = estimates
+    .filter((e) => e.unit_price == null)
+    .map((e) => ({ design_id: e.design_id, name: e.name }))
+
+  const total = estimates.reduce((sum, e) => sum + (e.unit_price ?? 0), 0)
 
   res.json({
     estimates,
     currency_code: currency_code || "inr",
     total,
+    unpriceable,
+    /** False when any line has no price — the total is partial. */
+    total_is_complete: unpriceable.length === 0,
   })
 }

--- a/apps/backend/src/api/admin/designs/[id]/recalculate-cost/route.ts
+++ b/apps/backend/src/api/admin/designs/[id]/recalculate-cost/route.ts
@@ -29,27 +29,48 @@ export async function POST(
   // route stored only `estimated_cost`, so `material_cost`/`production_cost`/
   // `cost_breakdown` stayed null on admin-owned designs and material cost
   // never showed even when the linked BOM had a price. #456
-  try {
-    const designService = req.scope.resolve("design") as any
-    await designService.updateDesigns({
-      id: designId,
-      estimated_cost: result.total_estimated,
-      material_cost: result.material_cost,
-      production_cost: result.production_cost,
-      cost_breakdown: {
-        items: result.breakdown?.materials ?? [],
-        production_percent: result.breakdown?.production_percent,
-        confidence: result.confidence,
-        calculated_at: new Date().toISOString(),
-        source: "admin_recalculate",
-      },
-    })
-  } catch {
-    // Non-fatal — estimate was still calculated
+  /**
+   * 🔴 A recalculation that found nothing must not overwrite what is there.
+   *
+   * The estimator used to report "no BOM, no order history" as
+   * `total_estimated: 0`, and this route persisted it — turning designs whose
+   * cost was honestly UNKNOWN (null) into designs that state they are free.
+   * Running the recalculation was itself the damaging act: five designs on
+   * production now carry a stored 0 that nobody ever asserted.
+   *
+   * So a `none` result writes nothing at all. Not even the breakdown: an
+   * "I looked and found nothing" record would still leave `estimated_cost`
+   * unchanged while implying the figure beside it had been refreshed. #1564
+   */
+  const foundNothing = result.total_estimated == null
+
+  if (!foundNothing) {
+    try {
+      const designService = req.scope.resolve("design") as any
+      await designService.updateDesigns({
+        id: designId,
+        estimated_cost: result.total_estimated,
+        material_cost: result.material_cost,
+        production_cost: result.production_cost,
+        cost_breakdown: {
+          items: result.breakdown?.materials ?? [],
+          production_percent: result.breakdown?.production_percent,
+          confidence: result.confidence,
+          calculated_at: new Date().toISOString(),
+          source: "admin_recalculate",
+        },
+      })
+    } catch {
+      // Non-fatal — estimate was still calculated
+    }
   }
 
   res.status(200).json({
     cost_estimate: result,
-    message: `Cost recalculated: ${result.total_estimated} (${result.confidence})`,
+    /** Stated explicitly so a caller cannot read a 200 as "the design was updated". */
+    persisted: !foundNothing,
+    message: foundNothing
+      ? "No cost could be estimated — this design has no bill of materials and no cost history. The stored cost was left unchanged."
+      : `Cost recalculated: ${result.total_estimated} (${result.confidence})`,
   })
 }

--- a/apps/backend/src/api/admin/designs/validators.ts
+++ b/apps/backend/src/api/admin/designs/validators.ts
@@ -62,6 +62,7 @@ export const designSchema = z.object({
   custom_sizes: z.record(z.string(), z.any()).optional(),
   color_palette: colorPaletteSchema.optional(),
   tags: z.array(z.string()).optional(),
+  /** Per finished unit. See `UpdateDesignSchema` for why clearing is update-only. */
   estimated_cost: z.number().optional(),
   cost_currency: z.string().optional(),
   designer_notes: z.string().optional(),
@@ -81,7 +82,30 @@ export const designSchema = z.object({
   customer_id_for_link: z.string().optional(),
 });
 
-export const UpdateDesignSchema = designSchema.partial();
+/**
+ * Update accepts everything create does — plus the ability to CLEAR the cost
+ * fields.
+ *
+ * 🔴 `estimated_cost` was `z.number().optional()`: optional but not nullable, so
+ * "no cost recorded" was a state the API could produce but never restore. A
+ * design wrongly given a cost — the recalculation that stored 0 because it had
+ * nothing to estimate from, #1564 — could not be put back to unknown through
+ * any route. Omitting a field leaves it alone; sending null clears it.
+ *
+ * `material_cost` / `production_cost` were not in the schema at ALL, and the
+ * validator is strict, so they were rejected outright. The recalculate routes
+ * write them straight through the service and cost panels read them, which left
+ * two persisted money fields with no way to correct them.
+ *
+ * ⚠️ Nullable only on update, deliberately. On create, null and omitted mean
+ * the same thing, and widening the create input would push a `number | null`
+ * into `CreateDesignStepInput` for no gain.
+ */
+export const UpdateDesignSchema = designSchema.partial().extend({
+  estimated_cost: z.number().nullable().optional(),
+  material_cost: z.number().nullable().optional(),
+  production_cost: z.number().nullable().optional(),
+});
 
 export const ReadDesignsQuerySchema = z.object({
   fields: z.string().optional(),

--- a/apps/backend/src/api/admin/ops/maintenance-jobs/__tests__/clear-unpriceable-design-costs.unit.spec.ts
+++ b/apps/backend/src/api/admin/ops/maintenance-jobs/__tests__/clear-unpriceable-design-costs.unit.spec.ts
@@ -1,0 +1,43 @@
+import { hasZeroStoredCost } from "../clear-unpriceable-design-costs-job"
+
+/**
+ * Which designs are candidates for having their cost cleared (#1564).
+ *
+ * 🔴 The scope has to be exactly "stored cost is 0". A design whose cost is
+ * null is already correct, and a design with a real cost must never be a
+ * candidate — otherwise a mis-scoped run erases a price someone set by hand.
+ */
+describe("hasZeroStoredCost", () => {
+  it("selects a design whose stored cost is 0", () => {
+    // The residue of a recalculation that found nothing and wrote it down.
+    expect(hasZeroStoredCost({ estimated_cost: 0 })).toBe(true)
+  })
+
+  it("selects a 0 that arrives as a string", () => {
+    // The column comes back as a bigNumber-ish value; "0" is the same claim.
+    // Reading it as truthy-only would silently skip every row on prod.
+    expect(hasZeroStoredCost({ estimated_cost: "0" as any })).toBe(true)
+  })
+
+  it("does NOT select a design that is already null", () => {
+    // Already correct — "no cost recorded". Nothing to repair.
+    expect(hasZeroStoredCost({ estimated_cost: null })).toBe(false)
+    expect(hasZeroStoredCost({})).toBe(false)
+    expect(hasZeroStoredCost({ estimated_cost: undefined })).toBe(false)
+  })
+
+  it("does NOT select a design with a real cost", () => {
+    // 🔴 The assertion that keeps this job from being destructive. A price
+    // someone set deliberately must be untouchable by it.
+    expect(hasZeroStoredCost({ estimated_cost: 850 })).toBe(false)
+    expect(hasZeroStoredCost({ estimated_cost: "1200" as any })).toBe(false)
+    expect(hasZeroStoredCost({ estimated_cost: 0.5 })).toBe(false)
+  })
+
+  it("does not select unparseable junk", () => {
+    // NaN is not 0. Treating it as one would clear a row on the strength of a
+    // value nobody can interpret.
+    expect(hasZeroStoredCost({ estimated_cost: "abc" as any })).toBe(false)
+    expect(hasZeroStoredCost({ estimated_cost: {} as any })).toBe(false)
+  })
+})

--- a/apps/backend/src/api/admin/ops/maintenance-jobs/clear-unpriceable-design-costs-job.ts
+++ b/apps/backend/src/api/admin/ops/maintenance-jobs/clear-unpriceable-design-costs-job.ts
@@ -1,0 +1,181 @@
+import { MedusaError } from "@medusajs/framework/utils"
+import { z } from "@medusajs/framework/zod"
+
+import { DESIGN_MODULE } from "../../../../modules/designs"
+import { recomputeDesignCost } from "./registry"
+import type { MaintenanceChange, MaintenanceJob, MaintenanceJobResult } from "./registry"
+
+/**
+ * Data Plumbing — put back the "unknown" that a recalculation overwrote (#1564).
+ *
+ * `estimateDesignCostWorkflow` reported "no bill of materials, no order
+ * history, nothing to go on" as `total_estimated: 0`, and the recalculate paths
+ * persisted it. Designs whose cost was honestly NULL came out the other side
+ * stating that they cost nothing — and `0` is not a small number here, it is a
+ * claim that the work is free. Every downstream reader believed it: the payment
+ * guard (until #1563 required a positive number), the cost panels, and the
+ * storefront checkout, which turned it straight into a customer-facing price.
+ *
+ * Running the recalculation was itself the damaging act. This undoes it.
+ *
+ * ⚠️ Restores a field to the value it held BEFORE an automated write. It
+ * creates nothing, prices nothing, and touches no payment or order.
+ *
+ * ## It re-asks the question before clearing anything
+ *
+ * 🔴 A stored 0 is not sufficient grounds to null a design. The job re-runs the
+ * estimator on each candidate and clears it ONLY if the estimator still cannot
+ * price it. If the design has since gained a BOM or cost history, the estimator
+ * now returns a real figure — and the right repair is a recalculation, not a
+ * deletion. Those are reported as `repriceable` and left untouched, because
+ * silently writing the new figure would be this job making a pricing decision
+ * it has no mandate for.
+ *
+ * Only clears a design whose stored cost is exactly 0. A design with a real
+ * cost is never a candidate, so a mis-scoped run cannot erase a price someone
+ * set deliberately.
+ *
+ * Safe to re-run: once cleared, the fields are null and no longer 0.
+ */
+const paramsSchema = z.object({
+  /** One design, for a spot check before a full pass. */
+  design_id: z.string().min(1).optional(),
+  /** Bound a first pass; omitted means every design that needs one. */
+  limit: z.coerce.number().int().min(1).max(1000).optional(),
+})
+
+/**
+ * PURE: is this design's stored cost the residue of an empty estimate?
+ * Exported for tests.
+ *
+ * Requires `estimated_cost` to be exactly 0 — not null (already correct), not
+ * negative, not positive. `Number(...)` because the column comes back as a
+ * bigNumber-ish value, and `"0"` must count.
+ */
+export function hasZeroStoredCost(design: {
+  estimated_cost?: unknown
+}): boolean {
+  const raw = design?.estimated_cost
+  if (raw === null || raw === undefined) {
+    return false
+  }
+  const value = Number(raw)
+  return Number.isFinite(value) && value === 0
+}
+
+export const clearUnpriceableDesignCostsJob: MaintenanceJob = {
+  id: "clear-unpriceable-design-costs",
+  label: "Clear design costs that a recalculation zeroed",
+  description:
+    "Restore estimated_cost / material_cost / production_cost to NULL on designs where an earlier recalculation stored 0 because it had nothing to estimate from (#1564). A stored 0 says 'this work is free' and every reader believes it — the payment guard, the cost panels, and the storefront checkout, which turned it into a customer-facing price of zero. Running the recalculation was the damaging act; this undoes it. RE-ASKS THE QUESTION FIRST: each candidate is re-estimated, and cleared only if the estimator still cannot price it — a design that has since gained a bill of materials or cost history is reported as 'repriceable' and left alone, because the right repair there is a recalculation, not a deletion. Only ever touches a design whose stored cost is exactly 0, so a price someone set deliberately can never be erased. Creates nothing, prices nothing, touches no payment or order. Safe to re-run.",
+  params: [
+    {
+      name: "design_id",
+      type: "string",
+      required: false,
+      description: "Only this design, e.g. for a spot check before a full pass.",
+    },
+    {
+      name: "limit",
+      type: "number",
+      required: false,
+      description: "Stop after this many designs. Omit for every design that needs one.",
+    },
+  ],
+  run: async (container, { dry_run, params }): Promise<MaintenanceJobResult> => {
+    const parsed = paramsSchema.safeParse(params)
+    if (!parsed.success) {
+      throw new MedusaError(
+        MedusaError.Types.INVALID_DATA,
+        parsed.error.issues.map((i) => i.message).join("; ")
+      )
+    }
+
+    const designService: any = container.resolve(DESIGN_MODULE)
+
+    const designs = (await designService.listDesigns(
+      parsed.data.design_id ? { id: parsed.data.design_id } : {},
+      { take: null }
+    )) as any[]
+
+    if (parsed.data.design_id && !(designs || []).length) {
+      throw new MedusaError(
+        MedusaError.Types.NOT_FOUND,
+        `Design ${parsed.data.design_id} not found`
+      )
+    }
+
+    const candidates = (designs || []).filter(hasZeroStoredCost)
+
+    const changes: MaintenanceChange[] = []
+    const errors: Array<{ id: string; message: string }> = []
+    /** Now priceable — the estimator found data since. Left for a recalculation. */
+    const repriceable: Array<{ id: string; name: string; total: number }> = []
+
+    for (const design of candidates) {
+      if (parsed.data.limit && changes.length >= parsed.data.limit) {
+        break
+      }
+
+      try {
+        const { result } = await recomputeDesignCost(container, design.id)
+
+        if (result.total_estimated != null) {
+          // The estimator can price it now. Clearing would throw away a real
+          // answer; writing it would be this job deciding a price. Report it.
+          repriceable.push({
+            id: design.id,
+            name: design.name ?? "(unnamed)",
+            total: result.total_estimated,
+          })
+          continue
+        }
+
+        changes.push({
+          entity: "design",
+          id: design.id,
+          field: "estimated_cost",
+          before: 0,
+          after: null,
+        })
+
+        if (!dry_run) {
+          await designService.updateDesigns({
+            id: design.id,
+            estimated_cost: null,
+            material_cost: null,
+            production_cost: null,
+          })
+        }
+      } catch (e: any) {
+        // One unreadable design must not strand the rest of the pass.
+        errors.push({ id: design?.id ?? "(unknown)", message: e?.message ?? String(e) })
+      }
+    }
+
+    const parts: string[] = []
+    parts.push(
+      changes.length
+        ? `${dry_run ? "Would clear" : "Cleared"} the zeroed cost on ${
+            changes.length
+          } design(s): ${changes.map((c) => c.id).join(", ")}`
+        : "No design carries a cost of 0 that the estimator still cannot price"
+    )
+    if (repriceable.length) {
+      parts.push(
+        `${repriceable.length} design(s) can now be priced and were LEFT UNCHANGED — recalculate them instead: ${repriceable
+          .map((r) => `${r.id} (${r.name} → ${r.total})`)
+          .join("; ")}`
+      )
+    }
+
+    return {
+      job_id: "clear-unpriceable-design-costs",
+      dry_run,
+      applied: !dry_run && changes.length > 0,
+      summary: parts.join(". ") + ".",
+      changes,
+      errors,
+    }
+  },
+}

--- a/apps/backend/src/api/admin/ops/maintenance-jobs/registry.ts
+++ b/apps/backend/src/api/admin/ops/maintenance-jobs/registry.ts
@@ -107,6 +107,7 @@ import { setLocationOwnershipJob } from "./set-location-ownership-job"
 import { resetNegativeInventoryLevelsJob } from "./reset-negative-inventory-levels-job"
 import { backfillDispatchedTemplateIdsJob } from "./backfill-dispatched-template-ids-job"
 import { backfillPaymentLineRunProvenanceJob } from "./backfill-payment-line-run-provenance-job"
+import { clearUnpriceableDesignCostsJob } from "./clear-unpriceable-design-costs-job"
 import { deduplicateTaskTemplateNamesJob } from "./deduplicate-task-template-names-job"
 import { recordManualInventoryCorrectionJob } from "./record-manual-inventory-correction-job"
 import { applyCommittedConsumptionJob } from "./apply-committed-consumption-job"
@@ -222,7 +223,15 @@ export function diffCostFields(
 }
 
 type DesignCostEstimate = {
-  total_estimated: number
+  /**
+   * null when the estimator had nothing to price from.
+   *
+   * ⚠️ This is a hand-written mirror of `EstimateCostOutput`, reached through a
+   * cast — so it does NOT track the workflow's type automatically. When
+   * `total_estimated` became nullable upstream, tsc stayed silent here and this
+   * job carried on persisting zeros. Keep the two in step by hand. #1564
+   */
+  total_estimated: number | null
   material_cost: number
   production_cost: number
   confidence: string
@@ -325,7 +334,29 @@ export const recalculateDesignCostJob: MaintenanceJob = {
     const { design_id } = parsed.data
 
     const { current, result } = await recomputeDesignCost(container, design_id)
-    const changes = diffCostFields(design_id, current, result)
+
+    /**
+     * 🔴 Found nothing ⇒ change nothing.
+     *
+     * This job is how five production designs came to state that they cost 0:
+     * the estimator returned "no BOM, no history" as a zero and this wrote it
+     * over an honest null. A recalculation that learned nothing has no business
+     * editing the record. #1564
+     */
+    if (result.total_estimated == null) {
+      return {
+        job_id: recalculateDesignCostJob.id,
+        dry_run,
+        applied: false,
+        summary: `No cost could be estimated for design ${design_id} — no bill of materials and no cost history. Stored cost left unchanged.`,
+        changes: [],
+      }
+    }
+
+    const changes = diffCostFields(design_id, current, {
+      ...result,
+      total_estimated: result.total_estimated,
+    })
 
     if (!dry_run && changes.length > 0) {
       await persistDesignCost(container, design_id, result)
@@ -442,11 +473,24 @@ export const recalculateDesignCostBulkJob: MaintenanceJob = {
     const changes: MaintenanceChange[] = []
     const errors: Array<{ id: string; message: string }> = []
     const changedDesigns = new Set<string>()
+    /** Designs the estimator could not price. Reported, never written. #1564 */
+    const unpriceable: string[] = []
 
     for (const designId of ids) {
       try {
         const { current, result } = await recomputeDesignCost(container, designId)
-        const designChanges = diffCostFields(designId, current, result)
+
+        // Found nothing ⇒ change nothing. Skipping is what keeps an honest
+        // null from being overwritten with a zero that claims the work is free.
+        if (result.total_estimated == null) {
+          unpriceable.push(designId)
+          continue
+        }
+
+        const designChanges = diffCostFields(designId, current, {
+          ...result,
+          total_estimated: result.total_estimated,
+        })
         if (designChanges.length > 0) {
           changedDesigns.add(designId)
           changes.push(...designChanges)
@@ -463,13 +507,19 @@ export const recalculateDesignCostBulkJob: MaintenanceJob = {
       job_id: recalculateDesignCostBulkJob.id,
       dry_run,
       applied: !dry_run && changes.length > 0,
-      summary: summarizeBulkRecalc(
-        dry_run,
-        ids.length,
-        changedDesigns.size,
-        changes.length,
-        errors.length
-      ),
+      summary:
+        summarizeBulkRecalc(
+          dry_run,
+          ids.length,
+          changedDesigns.size,
+          changes.length,
+          errors.length
+        ) +
+        // Named rather than folded into "no changes": a design nobody can price
+        // is a gap someone has to fill, not a design that is already correct.
+        (unpriceable.length
+          ? `. ${unpriceable.length} design(s) could not be priced (no BOM, no cost history) and were left unchanged: ${unpriceable.join(", ")}`
+          : ""),
       changes,
       errors,
     }
@@ -5806,6 +5856,7 @@ export const MAINTENANCE_JOBS: MaintenanceJob[] = [
   deduplicateTaskTemplateNamesJob,
   backfillDispatchedTemplateIdsJob,
   backfillPaymentLineRunProvenanceJob,
+  clearUnpriceableDesignCostsJob,
   recordManualInventoryCorrectionJob,
   applyCommittedConsumptionJob,
   backfillConsumptionAppliedColumnsJob,

--- a/apps/backend/src/api/partners/designs/[designId]/recalculate-cost/route.ts
+++ b/apps/backend/src/api/partners/designs/[designId]/recalculate-cost/route.ts
@@ -61,31 +61,43 @@ export async function POST(
 
   // Persist the estimate so the design carries its latest cost. Mirrors
   // the admin route but stores the fuller breakdown too.
-  try {
-    const designService = req.scope.resolve(DESIGN_MODULE) as any
-    await designService.updateDesigns({
-      id: designId,
-      estimated_cost: result.total_estimated,
-      material_cost: result.material_cost,
-      production_cost: result.production_cost,
-      cost_breakdown: {
-        items: result.breakdown?.materials ?? [],
-        production_percent: result.breakdown?.production_percent,
-        platform_fee: result.platform_fee,
-        platform_fee_percent: result.breakdown?.platform_fee_percent,
-        production_cost_source:
-          productionCostOverride != null ? "partner_entered" : "estimated",
-        confidence: result.confidence,
-        calculated_at: new Date().toISOString(),
-        source: "partner_recalculate",
-      },
-    })
-  } catch {
-    // Non-fatal — the estimate was still computed + returned.
+  //
+  // 🔴 Unless the estimator found nothing to price from, in which case the
+  // stored cost is left exactly as it was. Writing a 0 here would convert an
+  // honest "unknown" into a claim that the partner's work is free. #1564
+  const foundNothing = result.total_estimated == null
+
+  if (!foundNothing) {
+    try {
+      const designService = req.scope.resolve(DESIGN_MODULE) as any
+      await designService.updateDesigns({
+        id: designId,
+        estimated_cost: result.total_estimated,
+        material_cost: result.material_cost,
+        production_cost: result.production_cost,
+        cost_breakdown: {
+          items: result.breakdown?.materials ?? [],
+          production_percent: result.breakdown?.production_percent,
+          platform_fee: result.platform_fee,
+          platform_fee_percent: result.breakdown?.platform_fee_percent,
+          production_cost_source:
+            productionCostOverride != null ? "partner_entered" : "estimated",
+          confidence: result.confidence,
+          calculated_at: new Date().toISOString(),
+          source: "partner_recalculate",
+        },
+      })
+    } catch {
+      // Non-fatal — the estimate was still computed + returned.
+    }
   }
 
   res.status(200).json({
     cost_estimate: result,
-    message: `Cost recalculated: ${result.total_estimated} (${result.confidence})`,
+    /** Stated explicitly so a 200 cannot be read as "the design was updated". */
+    persisted: !foundNothing,
+    message: foundNothing
+      ? "No cost could be estimated — this design has no bill of materials and no cost history. The stored cost was left unchanged."
+      : `Cost recalculated: ${result.total_estimated} (${result.confidence})`,
   })
 }

--- a/apps/backend/src/api/store/custom/designs/[id]/checkout/route.ts
+++ b/apps/backend/src/api/store/custom/designs/[id]/checkout/route.ts
@@ -79,6 +79,25 @@ export async function POST(
     throw new MedusaError(MedusaError.Types.UNEXPECTED_STATE, "Failed to estimate design cost");
   }
 
+  /**
+   * 🔴 Refuse rather than sell it for nothing.
+   *
+   * There was no check here at all. The estimator reported "no BOM, no order
+   * history, nothing to go on" as `total_estimated: 0`, and this route fed that
+   * straight into `unit_price` with `is_custom_price: true` — so a design
+   * nobody had ever costed went into a customer's cart FREE, with a line item
+   * that looks exactly like a legitimately-priced one.
+   *
+   * A cost of null is not a cheap design; it is an unanswered question, and the
+   * only safe thing to do with an unanswered question at the till is stop. #1564
+   */
+  if (costEstimate.total_estimated == null) {
+    throw new MedusaError(
+      MedusaError.Types.NOT_ALLOWED,
+      "This design cannot be priced automatically yet — it has no bill of materials and no cost history. Please contact us for a quote."
+    );
+  }
+
   const cartService = req.scope.resolve(Modules.CART) as any;
 
   // Determine the cart's currency so we can convert from store default

--- a/apps/backend/src/api/store/custom/designs/[id]/estimate/route.ts
+++ b/apps/backend/src/api/store/custom/designs/[id]/estimate/route.ts
@@ -86,7 +86,10 @@ export async function GET(
     const rate = await fetchExchangeRate(storeCurrency, targetCurrency);
     materialCost = applyRate(materialCost, rate);
     productionCost = applyRate(productionCost, rate);
-    totalEstimated = applyRate(totalEstimated, rate);
+    // A missing estimate stays missing in every currency. Converting null would
+    // produce a very confident 0. #1564
+    totalEstimated =
+      totalEstimated == null ? null : applyRate(totalEstimated, rate);
   }
 
   res.status(200).json({

--- a/apps/backend/src/workflows/designs/__tests__/estimate-design-cost.unit.spec.ts
+++ b/apps/backend/src/workflows/designs/__tests__/estimate-design-cost.unit.spec.ts
@@ -132,15 +132,83 @@ describe("computeCostBreakdown", () => {
       expect(result.breakdown.production_percent).toBe(30)
     })
 
-    it("returns zero production and zero total when no data at all", () => {
+    /**
+     * 🔴 This test used to assert `total_estimated === 0` and call it correct.
+     * It was describing the defect: "I found nothing" reported as "this is
+     * free". Five production designs carry a stored 0 because of it, and the
+     * storefront checkout turned that 0 into a customer-facing price. #1564
+     */
+    it("returns NO total — not zero — when there is nothing to price from", () => {
       const result = computeCostBreakdown({
         ...base,
         adminEstimate: null,
         materials: [],
       })
+      expect(result.total_estimated).toBeNull()
+      expect(result.confidence).toBe("none")
+      // The component sums stay numeric: they are honest sums of nothing. It is
+      // the field that gets persisted, quoted and charged that must say "no
+      // answer", and null is the only value that cannot be mistaken for money.
       expect(result.material_cost).toBe(0)
       expect(result.production_cost).toBe(0)
-      expect(result.total_estimated).toBe(0)
+    })
+
+    it("does not manufacture a price out of similar designs", () => {
+      // Comparable designs are a hint for a human, not a price for this one.
+      // Before the fix their mere existence flipped confidence to "estimated"
+      // while the total stayed 0 — a confident-looking zero, which is the exact
+      // combination seen on prod. They are still RETURNED, so a caller can show
+      // them; they just do not become the number.
+      const result = computeCostBreakdown({
+        ...base,
+        adminEstimate: null,
+        materials: [],
+        similarDesigns: [
+          { id: "d1", name: "Similar One", estimated_cost: 1200 },
+          { id: "d2", name: "Similar Two", estimated_cost: 1400 },
+        ],
+      })
+      expect(result.total_estimated).toBeNull()
+      expect(result.confidence).toBe("none")
+      expect(result.similar_designs).toHaveLength(2)
+    })
+
+    it("treats a fallback material cost as a price only where it was APPLIED", () => {
+      // The partner recalc route always passes `default_material_cost`, so a
+      // naive "was a default offered?" test would call every partner estimate
+      // priced — including one for a design with an empty bill of materials,
+      // where the fallback has no line to attach to and the total is still 0.
+      const empty = computeCostBreakdown({
+        ...base,
+        adminEstimate: null,
+        materials: [],
+        defaultMaterialCost: 600,
+      })
+      expect(empty.total_estimated).toBeNull()
+      expect(empty.confidence).toBe("none")
+
+      const applied = computeCostBreakdown({
+        ...base,
+        adminEstimate: null,
+        materials: [
+          { id: "m1", name: "Unpriced Fabric", quantity: 2, cost: 0, cost_source: "estimated" } as any,
+        ],
+        defaultMaterialCost: 600,
+      })
+      expect(applied.total_estimated).not.toBeNull()
+      expect(applied.confidence).not.toBe("none")
+    })
+
+    it("still prices normally when there IS a signal", () => {
+      // The guard must not swallow real estimates — an admin figure alone is
+      // enough to price from, with no materials at all.
+      const result = computeCostBreakdown({
+        ...base,
+        adminEstimate: 1000,
+        materials: [],
+      })
+      expect(result.total_estimated).not.toBeNull()
+      expect(result.confidence).not.toBe("none")
     })
   })
 
@@ -264,14 +332,34 @@ describe("computeCostBreakdown", () => {
   })
 
   describe("confidence levels", () => {
-    it("returns guesstimate when no real data", () => {
+    /**
+     * ⚠️ This case used to be `guesstimate` with a total of 0 — i.e. "I priced
+     * it weakly" when the truth was "I could not price it at all". `guesstimate`
+     * now means a real but weak price; the empty case is `none`. #1564
+     */
+    it("returns guesstimate when a price exists but rests on a fallback", () => {
+      const result = computeCostBreakdown({
+        ...base,
+        adminEstimate: null,
+        materials: [
+          { id: "m1", name: "Unpriced Fabric", quantity: 1, cost: 0, cost_source: "estimated" } as any,
+        ],
+        similarDesigns: [],
+        defaultMaterialCost: 600,
+      })
+      expect(result.confidence).toBe("guesstimate")
+      expect(result.total_estimated).not.toBeNull()
+    })
+
+    it("returns none — not guesstimate — when there is no data at all", () => {
       const result = computeCostBreakdown({
         ...base,
         adminEstimate: null,
         materials: [],
         similarDesigns: [],
       })
-      expect(result.confidence).toBe("guesstimate")
+      expect(result.confidence).toBe("none")
+      expect(result.total_estimated).toBeNull()
     })
 
     it("returns estimated when admin estimate is set", () => {

--- a/apps/backend/src/workflows/designs/create-draft-order-from-designs.ts
+++ b/apps/backend/src/workflows/designs/create-draft-order-from-designs.ts
@@ -78,6 +78,21 @@ const estimateDesignCostsStep = createStep(
           container
         ).run({ input: { design_id } }) as { result: EstimateCostOutput }
 
+        /**
+         * 🔴 Refuse rather than put a zero on an order line.
+         *
+         * `total_estimated` is null when the estimator had nothing to price
+         * from — no bill of materials, no order history. It used to be 0, which
+         * went onto the draft order as a real unit price and read as a
+         * deliberate freebie. The caller already has the remedy: pass this
+         * design in `overrides` with a price someone actually decided. #1564
+         */
+        if (costEstimate.total_estimated == null) {
+          throw new Error(
+            `Cannot price design "${design.name}" (${design_id}): it has no bill of materials and no cost history. Supply a price for it in overrides.`
+          )
+        }
+
         estimates.push({
           design_id,
           name: design.name,

--- a/apps/backend/src/workflows/designs/estimate-design-cost.ts
+++ b/apps/backend/src/workflows/designs/estimate-design-cost.ts
@@ -8,7 +8,18 @@ import { ContainerRegistrationKeys } from "@medusajs/framework/utils";
 
 // ─── Types ───────────────────────────────────────────────────────────────────
 
-type ConfidenceLevel = "exact" | "estimated" | "guesstimate";
+/**
+ * How much the returned figure is worth believing.
+ *
+ * 🔴 `none` is not a weaker estimate — it is the ABSENCE of one, and it is the
+ * only value for which `total_estimated` is null. The estimator used to report
+ * "I found nothing" as `total_estimated: 0` with `confidence: "estimated"`, as
+ * though it had looked and got an answer. `0` is not a small number here; it is
+ * a claim that the work is free, and every downstream reader believed it —
+ * including the storefront checkout, which turned it into a customer-facing
+ * price of zero. #1564
+ */
+type ConfidenceLevel = "exact" | "estimated" | "guesstimate" | "none";
 
 export type MaterialCostItem = {
   inventory_item_id?: string;
@@ -50,7 +61,16 @@ export type EstimateCostOutput = {
   production_cost: number;
   /** JYT platform commission (materialCost × platform_fee_percent). 0 when opted out. */
   platform_fee: number;
-  total_estimated: number;
+  /**
+   * What one finished unit is estimated to cost — or **null** when there was
+   * nothing to estimate from.
+   *
+   * 🔴 Nullable on purpose, so that "we could not price this" cannot be spelled
+   * the same way as "this is free". Every consumer must branch: a pricing path
+   * (checkout, draft order) has to REFUSE, and a persisting path has to skip
+   * the write rather than store a zero. #1564
+   */
+  total_estimated: number | null;
   confidence: ConfidenceLevel;
   breakdown: {
     materials: MaterialCostItem[];
@@ -210,8 +230,39 @@ export function computeCostBreakdown(input: {
       m.cost_source === "consumption_log"
   );
 
+  /**
+   * Did ANY input actually price something?
+   *
+   * 🔴 Note what is deliberately absent from this list: `similarDesigns`.
+   * Comparable designs are a hint for a human, not a price for this one —
+   * pricing from them is the silent substitution that #1554 was. They are still
+   * returned below so the caller can show them; they just do not manufacture a
+   * number. Before this, their mere existence flipped confidence to "estimated"
+   * while the total stayed 0, which is how prod ended up with designs stating
+   * that they cost nothing.
+   */
+  /**
+   * ⚠️ The fallback counts only where it was actually APPLIED, not merely
+   * offered. The partner recalc route always passes `default_material_cost`, so
+   * testing `defaultMaterialCost > 0` would call every partner estimate
+   * "priced" — including one for a design with an empty bill of materials,
+   * where the fallback has no line to attach to and the total is still 0.
+   */
+  const usedDefaultMaterialCost = materials.some(
+    (m) => m.cost_source === "default"
+  );
+
+  const hasPricingSignal =
+    hasAnyRealData ||
+    usedDefaultMaterialCost ||
+    adminEstimate != null ||
+    input.actualProductionCost != null ||
+    input.productionCostOverride != null;
+
   let confidence: ConfidenceLevel;
-  if (input.hasExactMaterialCosts && !productionIsEstimated) {
+  if (!hasPricingSignal) {
+    confidence = "none";
+  } else if (input.hasExactMaterialCosts && !productionIsEstimated) {
     confidence = "exact";
   } else if (hasAnyRealData || similarDesigns.length > 0 || adminEstimate != null) {
     confidence = "estimated";
@@ -224,7 +275,12 @@ export function computeCostBreakdown(input: {
     material_cost: round2(materialCost),
     production_cost: round2(productionCost),
     platform_fee: platformFee,
-    total_estimated: round2(totalEstimated),
+    /**
+     * null, not 0, when nothing priced this. The component figures above stay
+     * numeric — they are genuine sums of nothing — but the field that gets
+     * persisted, quoted and charged has to be able to say "no answer".
+     */
+    total_estimated: hasPricingSignal ? round2(totalEstimated) : null,
     confidence,
     breakdown: {
       materials,


### PR DESCRIPTION
Closes #1564.

`estimateDesignCostWorkflow` returned `total_estimated: 0` when a design had no
bill of materials and no order history, labelled `confidence: "estimated"` — as
though it had looked and got an answer. **`0` is not a small number here.** It
is a claim that the work is free, and every downstream reader believed it.

The recalculate paths persisted it over an honest null, so *running the
recalculation was itself the damaging act*. Five designs on production now state
that they cost nothing.

## 🔴 The finding the issue didn't have

`store/custom/designs/:id/checkout` has **no guard at all** between
`total_estimated` and `unit_price`:

```ts
const convertedEstimate = applyRate(costEstimate.total_estimated, rate);
// → unit_price: convertedEstimate, is_custom_price: true
```

A design nobody had ever costed went into a customer's cart **free**, as a line
item indistinguishable from a legitimately priced one. That is a storefront
hole, not an internal reporting problem, and it is why this fix pushes null all
the way through the type rather than patching the recalculate route.

## Changes

- **`total_estimated: number | null`**, `confidence` gains `"none"`. Null
  exactly when nothing priced anything.
- **Similar designs no longer manufacture a price.** Their mere existence used
  to flip confidence to `"estimated"` while the total stayed 0 — a
  confident-looking zero, which is precisely the prod symptom. They are a hint
  for a human, not a price for this design, and are still returned so a caller
  can show them.
- **A fallback material cost counts only where APPLIED**, not merely offered.
  The partner route always passes one, so testing `defaultMaterialCost > 0`
  would call every partner estimate "priced" — including a design with an empty
  BOM, where the fallback has no line to attach to and the total is still 0.
- **Pricing paths refuse**: checkout 400s with a quote-us message; the
  draft-order workflow names the design and points at `overrides`.
- **The order preview surfaces the gap**: `unpriceable` + `total_is_complete`,
  rather than summing an unpriceable line as 0 and showing a total that looks
  complete and isn't.
- **Both recalculate routes and both ops recalculate jobs skip the write** and
  report `persisted: false`.
- **`UpdateDesignSchema` accepts null** for `estimated_cost` / `material_cost` /
  `production_cost`. The first was optional-but-not-nullable; the other two were
  absent from the schema entirely and the validator is strict, so all three were
  unfixable through the API. Update-only — on create, null and omitted mean the
  same thing.
- **`clear-unpriceable-design-costs`** ops job to repair the five.

## The repair job re-asks the question

It never clears on the strength of a stored 0 alone: each candidate is
re-estimated, and cleared only if the estimator *still* cannot price it. A
design that has since gained a BOM is reported as `repriceable` and left alone —
the right repair there is a recalculation, and writing the new figure would be
the job making a pricing decision it has no mandate for. It only ever touches a
design whose stored cost is exactly 0, so a price set by hand is untouchable.

## Verification

- unit `49/49` (estimator + repair job), integration `7/7` on
  `design-cost-propagation`, plus `design-lifecycle`, `design-to-order-e2e`,
  `convert-design-order`, `design-to-cart-flow`, `customer-design-studio` — all
  green. `check:prod-build` green.
- 🔑 Each new test was run against the old code first. The four estimator tests
  and the null-round-trip test all fail without the fix.
- ⚠️ **An existing unit test asserted `total_estimated === 0` as correct.** It
  was describing the defect, not guarding against it. Rewritten, along with a
  `guesstimate` case that was really the empty case in disguise.

## Watch-out for review

`registry.ts` reaches the workflow through a hand-written `DesignCostEstimate`
type and a cast, so **tsc stayed silent** when `total_estimated` became
nullable — the ops jobs would have carried on persisting zeros. Both call sites
are now guarded and the type carries a note. Worth checking no other cast hides
the same edge.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_0158wJMZ1DmjNxXf5uGuBrQD