### PR TITLE
feat(ops): a payment line's run can be corrected by hand (#1565)

### DIFF
--- a/apps/backend/integration-tests/http/payment-submissions-api.spec.ts
+++ b/apps/backend/integration-tests/http/payment-submissions-api.spec.ts
@@ -1124,6 +1124,203 @@ setupSharedTestSuite(() => {
     })
   })
 
+  /**
+   * Correcting a payment line's provenance by hand (#1565).
+   *
+   * 🔴 `/admin/payment-submissions/:id` exposes GET and `review` and nothing
+   * else — no route updates a submission or its items. For a line whose run is
+   * named only in free-text notes (which the backfill job refuses to parse),
+   * this job is the ONLY remedy short of rejecting a live payout and recreating
+   * it.
+   */
+  describe("record-payment-line-run maintenance job (#1565)", () => {
+    const RUN = "/admin/ops/maintenance-jobs/record-payment-line-run/run"
+
+    /** A design-sourced line with no run recorded, plus a run it could name. */
+    async function unrecordedLine(designName: string) {
+      const designId = await createDesign(designName, { estimated_cost: 1200 })
+      await linkDesignToPartner(designId, partnerId)
+      const runId = await createCompletedRun(designId, designName)
+
+      const sub = await api.post(
+        "/admin/payment-submissions",
+        {
+          partner_id: partnerId,
+          design_ids: [designId],
+          quantities: { [designId]: 4 },
+          unit_amounts: { [designId]: 1200 },
+        },
+        adminHeaders
+      )
+      expect(sub.status).toBe(201)
+      const detail = await api.get(
+        `/admin/payment-submissions/${sub.data.payment_submission.id}`,
+        adminHeaders
+      )
+      return {
+        designId,
+        runId,
+        itemId: detail.data.payment_submission.items[0].id,
+        submissionId: sub.data.payment_submission.id,
+      }
+    }
+
+    it("records the run an operator supplies, and the line then guards", async () => {
+      const { runId, itemId } = await unrecordedLine("Notes Only Payout")
+
+      const dry = await api.post(
+        RUN,
+        { dry_run: true, params: { payment_submission_item_id: itemId, production_run_id: runId } },
+        adminHeaders
+      )
+      expect(dry.status).toBe(200)
+      expect(dry.data.result.applied).toBe(false)
+      expect(dry.data.result.changes[0].after).toEqual([runId])
+
+      const applied = await api.post(
+        RUN,
+        { dry_run: false, params: { payment_submission_item_id: itemId, production_run_id: runId } },
+        adminHeaders
+      )
+      expect(applied.status).toBe(200)
+      expect(applied.data.result.applied).toBe(true)
+
+      // The EFFECT, not the summary: the run now reads as billed rather than
+      // unknown, which is the whole point of recording it.
+      const runs = await api.get(
+        `/admin/payment-submissions/payable-runs?partner_id=${partnerId}`,
+        adminHeaders
+      )
+      const row = runs.data.payable_runs.find((r: any) => r.run_id === runId)
+      expect(row.billing_status).toBe("billed")
+    })
+
+    it("refuses a run already recorded on another live payout", async () => {
+      // 🔴 Without this the job would be a hole straight through the double-pay
+      // guard it exists to arm: two lines could both claim the same garments.
+      const first = await unrecordedLine("Double Claim Design")
+      await api.post(
+        RUN,
+        {
+          dry_run: false,
+          params: { payment_submission_item_id: first.itemId, production_run_id: first.runId },
+        },
+        adminHeaders
+      )
+
+      // Close the first payout so the design-level "already in an open
+      // submission" guard is out of the way and ONLY the run-level guard is
+      // under test. This is also the realistic case: the run-level guard exists
+      // precisely because the design-level one goes false once a payout closes.
+      const approved = await api.post(
+        `/admin/payment-submissions/${first.submissionId}/review`,
+        { action: "approve", paid_to_id: paidToId },
+        adminHeaders
+      )
+      expect(approved.status).toBe(200)
+
+      // A second payout for the same design, pointed at the same run.
+      const second = await api.post(
+        "/admin/payment-submissions",
+        {
+          partner_id: partnerId,
+          design_ids: [first.designId],
+          quantities: { [first.designId]: 4 },
+          unit_amounts: { [first.designId]: 1200 },
+        },
+        adminHeaders
+      )
+      const secondDetail = await api.get(
+        `/admin/payment-submissions/${second.data.payment_submission.id}`,
+        adminHeaders
+      )
+      const secondItemId = secondDetail.data.payment_submission.items[0].id
+
+      const res = await api
+        .post(
+          RUN,
+          {
+            dry_run: false,
+            params: {
+              payment_submission_item_id: secondItemId,
+              production_run_id: first.runId,
+            },
+          },
+          adminHeaders
+        )
+        .catch((e: any) => e.response)
+
+      expect(res.status).toBeGreaterThanOrEqual(400)
+      expect(String(res.data?.message || "")).toMatch(/already recorded/i)
+    })
+
+    it("refuses a run belonging to a different design", async () => {
+      // An operator-supplied id is a claim, not a fact. A run belongs to exactly
+      // one design, so this one is describing different work entirely.
+      const target = await unrecordedLine("Wrong Design Target")
+      const otherDesign = await createDesign("Unrelated Design", {
+        estimated_cost: 1200,
+      })
+      await linkDesignToPartner(otherDesign, partnerId)
+      const otherRun = await createCompletedRun(otherDesign, "Unrelated Design")
+
+      const res = await api
+        .post(
+          RUN,
+          {
+            dry_run: false,
+            params: {
+              payment_submission_item_id: target.itemId,
+              production_run_id: otherRun,
+            },
+          },
+          adminHeaders
+        )
+        .catch((e: any) => e.response)
+
+      expect(res.status).toBeGreaterThanOrEqual(400)
+      expect(String(res.data?.message || "")).toMatch(/is a run of design/i)
+    })
+
+    it("refuses to overwrite a line that already records its run", async () => {
+      // Provenance written by a real submission path is better evidence than
+      // anything typed afterwards; correcting it is a different decision.
+      const d1 = await createDesign("Already Recorded", { estimated_cost: 1200 })
+      await linkDesignToPartner(d1, partnerId)
+      const runId = await createCompletedRun(d1, "Already Recorded")
+      const sub = await api.post(
+        "/admin/payment-submissions",
+        {
+          partner_id: partnerId,
+          design_ids: [d1],
+          quantities: { [d1]: 4 },
+          unit_amounts: { [d1]: 1200 },
+          production_run_ids: { [d1]: [runId] },
+        },
+        adminHeaders
+      )
+      const detail = await api.get(
+        `/admin/payment-submissions/${sub.data.payment_submission.id}`,
+        adminHeaders
+      )
+      const itemId = detail.data.payment_submission.items[0].id
+
+      const res = await api
+        .post(
+          RUN,
+          {
+            dry_run: false,
+            params: { payment_submission_item_id: itemId, production_run_id: runId },
+          },
+          adminHeaders
+        )
+        .catch((e: any) => e.response)
+
+      expect(res.status).toBeGreaterThanOrEqual(400)
+      expect(String(res.data?.message || "")).toMatch(/already records/i)
+    })
+  })
+
   describe("POST /admin/payment-submissions — run provenance (#1556)", () => {
     it("records which runs a line paid for, and reports them as billed", async () => {
       const d1 = await createDesign("Provenance Design", {

--- a/apps/backend/src/api/admin/ops/maintenance-jobs/record-payment-line-run-job.ts
+++ b/apps/backend/src/api/admin/ops/maintenance-jobs/record-payment-line-run-job.ts
@@ -1,0 +1,203 @@
+import { ContainerRegistrationKeys, MedusaError } from "@medusajs/framework/utils"
+import { z } from "@medusajs/framework/zod"
+
+import { PAYMENT_SUBMISSIONS_MODULE } from "../../../../modules/payment_submissions"
+import type PaymentSubmissionsService from "../../../../modules/payment_submissions/service"
+import type { MaintenanceChange, MaintenanceJob, MaintenanceJobResult } from "./registry"
+
+/**
+ * Data Plumbing — record WHICH run a payout covered, when only a human knows (#1565).
+ *
+ * `payment_submission_item.production_run_ids` is what stops the same finished
+ * run being paid for twice. `backfill-payment-line-run-provenance` recovers it
+ * wherever a submission already states it in `metadata`, but some lines say it
+ * only in their free-text `notes` — and that job refuses to parse prose, because
+ * a parser that is right about today's sentence is wrong about the one someone
+ * writes next month.
+ *
+ * 🔴 There is no other way to fix such a line. `/admin/payment-submissions/:id`
+ * exposes GET and `review` and nothing else: no route updates a submission or
+ * its items. Without this job the only remedy is rejecting a live payout and
+ * recreating it, which churns a real claim and changes its id.
+ *
+ * ⚠️ Records something that ALREADY happened. It changes no amount, approves
+ * nothing, and moves no money.
+ *
+ * ## The operator supplies the fact; the job still checks it
+ *
+ * An operator-asserted run id is NOT taken on trust. It must satisfy every rule
+ * the create path enforces — the run exists, is completed, belongs to the
+ * submission's partner, is a run of that line's design, and is not already
+ * recorded on another live payout. A wrong id here is worse than an empty
+ * column: empty reads `unknown` and stops a human, wrong reads `billed` and
+ * silently blocks a partner's real payout, or releases a run that was paid.
+ *
+ * Refuses to overwrite a line that already records runs — correcting one of
+ * those is a different decision, and a silent overwrite would erase provenance
+ * written by a real submission path.
+ */
+const paramsSchema = z.object({
+  /** The line to record against. */
+  payment_submission_item_id: z.string().min(1, "payment_submission_item_id is required"),
+  /** The completed run that line paid for. */
+  production_run_id: z.string().min(1, "production_run_id is required"),
+})
+
+export const recordPaymentLineRunJob: MaintenanceJob = {
+  id: "record-payment-line-run",
+  label: "Record which production run a payment line paid for",
+  description:
+    "Set production_run_ids on ONE payment submission line to a run id an operator supplies, for lines whose provenance exists only in free-text notes and so cannot be recovered automatically (#1565). This is the only way to correct such a line: /admin/payment-submissions/:id exposes GET and review and nothing else, so no route updates a submission or its items, and the alternative is rejecting a live payout and recreating it. The supplied id is NOT trusted — it must pass every check the create path enforces: the run exists, is completed, belongs to the submission's partner, is a run of that line's design, and is not already recorded on another non-Rejected payout. Refuses to overwrite a line that already records runs. Records something that already happened: changes no amount, approves nothing, moves no money. Dry-run previews the exact before/after.",
+  params: [
+    {
+      name: "payment_submission_item_id",
+      type: "string",
+      required: true,
+      description: "The payment submission LINE id (not the submission id).",
+    },
+    {
+      name: "production_run_id",
+      type: "string",
+      required: true,
+      description: "The completed production run that line paid for.",
+    },
+  ],
+  run: async (container, { dry_run, params }): Promise<MaintenanceJobResult> => {
+    const parsed = paramsSchema.safeParse(params)
+    if (!parsed.success) {
+      throw new MedusaError(
+        MedusaError.Types.INVALID_DATA,
+        parsed.error.issues.map((i) => i.message).join("; ")
+      )
+    }
+    const { payment_submission_item_id: itemId, production_run_id: runId } = parsed.data
+
+    const service: PaymentSubmissionsService = container.resolve(
+      PAYMENT_SUBMISSIONS_MODULE
+    )
+    const query: any = container.resolve(ContainerRegistrationKeys.QUERY)
+
+    const items = (await (service as any).listPaymentSubmissionItems(
+      { id: itemId },
+      { relations: ["submission"] }
+    )) as any[]
+    const item = (items || [])[0]
+
+    if (!item) {
+      throw new MedusaError(
+        MedusaError.Types.NOT_FOUND,
+        `Payment submission item ${itemId} not found`
+      )
+    }
+
+    const existing = (item.production_run_ids ?? []) as string[]
+    if (Array.isArray(existing) && existing.length) {
+      throw new MedusaError(
+        MedusaError.Types.NOT_ALLOWED,
+        `Payment line ${itemId} already records run(s) ${existing.join(", ")}. Overwriting recorded provenance is a different decision — reject and recreate the submission instead.`
+      )
+    }
+
+    // A task payout never had a run. Recording one would invent a relationship
+    // that does not exist, and `no_run` is already the correct answer for it.
+    if (!item.design_id || item.source_type === "task") {
+      throw new MedusaError(
+        MedusaError.Types.INVALID_DATA,
+        `Payment line ${itemId} is not sourced from a design (source_type=${item.source_type}); a task payout has no production run.`
+      )
+    }
+
+    const { data: runs } = await query.graph({
+      entity: "production_runs",
+      fields: ["id", "design_id", "partner_id", "status"],
+      filters: { id: [runId] },
+    })
+    const run = ((runs || []) as any[])[0]
+
+    if (!run) {
+      throw new MedusaError(
+        MedusaError.Types.NOT_FOUND,
+        `Production run ${runId} not found`
+      )
+    }
+
+    // A run belongs to exactly one design. If it is not a run of this line's
+    // design, the operator has named something else entirely.
+    if (String(run.design_id || "") !== String(item.design_id)) {
+      throw new MedusaError(
+        MedusaError.Types.INVALID_DATA,
+        `Production run ${runId} is a run of design ${run.design_id}, not ${item.design_id}`
+      )
+    }
+
+    const submissionPartnerId = String(item.submission?.partner_id || "")
+    if (submissionPartnerId && String(run.partner_id || "") !== submissionPartnerId) {
+      throw new MedusaError(
+        MedusaError.Types.NOT_ALLOWED,
+        `Production run ${runId} belongs to partner ${run.partner_id}, but the submission is partner ${submissionPartnerId}`
+      )
+    }
+
+    if (String(run.status || "") !== "completed") {
+      throw new MedusaError(
+        MedusaError.Types.INVALID_DATA,
+        `Production run ${runId} is not completed (${run.status})`
+      )
+    }
+
+    /**
+     * Already claimed by someone else? A Rejected submission never paid anyone,
+     * so its lines release their runs; every other status is a live claim.
+     *
+     * 🔴 The same rule the create path applies. Without it this job would be a
+     * hole straight through the double-pay guard it exists to arm.
+     */
+    const siblings = (await (service as any).listPaymentSubmissionItems(
+      { design_id: [String(item.design_id)] },
+      { relations: ["submission"] }
+    )) as any[]
+
+    for (const other of siblings || []) {
+      if (String(other.id) === String(itemId)) continue
+      if (String(other.submission?.status || "") === "Rejected") continue
+      for (const claimed of (other.production_run_ids || []) as string[]) {
+        if (String(claimed) === runId) {
+          throw new MedusaError(
+            MedusaError.Types.INVALID_DATA,
+            `Production run ${runId} is already recorded on payment line ${other.id} (submission ${other.submission?.id || other.submission_id}, status ${other.submission?.status}). Recording it here would claim the same finished work twice.`
+          )
+        }
+      }
+    }
+
+    const changes: MaintenanceChange[] = [
+      {
+        entity: "payment_submission_item",
+        id: itemId,
+        field: "production_run_ids",
+        before: null,
+        after: [runId],
+      },
+    ]
+
+    if (!dry_run) {
+      await (service as any).updatePaymentSubmissionItems({
+        id: itemId,
+        production_run_ids: [runId],
+        run_provenance: "recorded",
+      })
+    }
+
+    return {
+      job_id: "record-payment-line-run",
+      dry_run,
+      applied: !dry_run,
+      summary: `${
+        dry_run ? "Would record" : "Recorded"
+      } run ${runId} on payment line ${itemId} (design ${item.design_id}, submission ${
+        item.submission?.id || item.submission_id
+      }, status ${item.submission?.status}). Amount unchanged at ${item.amount}.`,
+      changes,
+    }
+  },
+}

--- a/apps/backend/src/api/admin/ops/maintenance-jobs/registry.ts
+++ b/apps/backend/src/api/admin/ops/maintenance-jobs/registry.ts
@@ -108,6 +108,7 @@ import { resetNegativeInventoryLevelsJob } from "./reset-negative-inventory-leve
 import { backfillDispatchedTemplateIdsJob } from "./backfill-dispatched-template-ids-job"
 import { backfillPaymentLineRunProvenanceJob } from "./backfill-payment-line-run-provenance-job"
 import { clearUnpriceableDesignCostsJob } from "./clear-unpriceable-design-costs-job"
+import { recordPaymentLineRunJob } from "./record-payment-line-run-job"
 import { deduplicateTaskTemplateNamesJob } from "./deduplicate-task-template-names-job"
 import { recordManualInventoryCorrectionJob } from "./record-manual-inventory-correction-job"
 import { applyCommittedConsumptionJob } from "./apply-committed-consumption-job"
@@ -5857,6 +5858,7 @@ export const MAINTENANCE_JOBS: MaintenanceJob[] = [
   backfillDispatchedTemplateIdsJob,
   backfillPaymentLineRunProvenanceJob,
   clearUnpriceableDesignCostsJob,
+  recordPaymentLineRunJob,
   recordManualInventoryCorrectionJob,
   applyCommittedConsumptionJob,
   backfillConsumptionAppliedColumnsJob,


### PR DESCRIPTION
Follow-up to #1566, closing the last piece of #1565.

`payment_submission_item.production_run_ids` is what stops the same finished run
being paid for twice. `backfill-payment-line-run-provenance` recovers it wherever
a submission states it in `metadata` — but one live payout on prod
(`01M0Y336YBE861KMS44QZ9NFR0`, Pending ₹8,400) names its run in free-text **notes
only**, and that job refuses to parse prose on purpose: a parser that is right
about today's sentence is wrong about the one someone writes next month.

## 🔴 There was no other way to fix such a line

`/admin/payment-submissions/:id` exposes `GET` and `review`. That is all — **no
route updates a submission or its items.** So the only remedy was rejecting a
live payout and recreating it, which churns a real claim and changes its id.

## The operator supplies the fact; the job still checks it

An asserted run id is not taken on trust. It must pass every rule the create
path enforces:

- the run exists and is **completed**
- it belongs to the **submission's partner**
- it is a run of **that line's design**
- it is **not already recorded** on another non-Rejected payout

A wrong id is worse than an empty column: empty reads `unknown` and stops a
human; wrong reads `billed` and silently blocks a partner's real payout, or
releases a run that was already paid.

It also refuses to **overwrite** a line that already records runs — provenance
written by a real submission path is better evidence than anything typed
afterwards — and refuses a **task** line outright, since a task payout never had
a run and `no_run` is already the correct answer for it.

## Verification

`68/68` on `payment-submissions-api.spec.ts`, `check:prod-build` green.

Four integration tests, three of which are the guards rather than the happy
path. Worth noting how one of them had to be built: the double-claim test
**approves the first payout before making the second**, because otherwise the
design-level "already in an open submission" guard 400s the create and the
run-level guard never gets exercised at all. That is also the realistic case —
the run-level guard exists precisely because the design-level one goes false the
moment a payout closes.

The happy-path test asserts the **effect** (`billing_status` flips `unknown` →
`billed` on the payable-runs screen), not the job's own summary.

## After merge

One prod call clears the #1565 tail:

```
record-payment-line-run  item=01M0Y336YBE861KMS44QZ9NFR0
                         run=prod_run_01KYPM4G2S85PX61HT25T8BFDT
```

⚠️ That is a live payout, so it stays a founder call — the run is corroborated
(the superseded predecessor carries it in `metadata`) but I am not recording it
unasked.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_0158wJMZ1DmjNxXf5uGuBrQD