### PR TITLE
fix(payments): the money must not silently disagree with itself (#1571)

### DIFF
--- a/apps/backend/integration-tests/http/payment-submissions-api.spec.ts
+++ b/apps/backend/integration-tests/http/payment-submissions-api.spec.ts
@@ -1124,6 +1124,135 @@ setupSharedTestSuite(() => {
     })
   })
 
+  /**
+   * The typed money fields are the contract; `metadata` is a fallback (#1571).
+   *
+   * 🔴 The workflow used to read the money ONLY off `metadata`, so the typed
+   * fields were a validation façade over an untyped contract — post the blob
+   * directly and every typed guarantee was bypassed.
+   */
+  describe("money travels typed, not through metadata (#1571)", () => {
+    /**
+     * ⚠️ REGRESSION LOCK, not proof of the fix. This already passed before
+     * #1571, because the route's `foldMoneyFieldsIntoMetadata` overwrites the
+     * blob with the typed values on the way in. The workflow-level precedence
+     * added in #1571 is what makes it true for callers that reach the workflow
+     * DIRECTLY — the auto-draft subscriber — where no fold runs.
+     */
+    it("the typed field WINS over a conflicting metadata blob", async () => {
+      const d1 = await createDesign("Typed Wins Design", {
+        estimated_cost: 1200,
+      })
+      await linkDesignToPartner(d1, partnerId)
+
+      const res = await api.post(
+        "/admin/payment-submissions",
+        {
+          partner_id: partnerId,
+          design_ids: [d1],
+          quantities: { [d1]: 4 },
+          unit_amounts: { [d1]: 1200 },
+          // A stale blob claiming something different. The typed field is the
+          // caller's stated intent; an untyped channel must not overrule it.
+          metadata: {
+            design_quantities: { [d1]: 99 },
+            design_unit_amounts: { [d1]: 5 },
+          },
+        },
+        adminHeaders
+      )
+      expect(res.status).toBe(201)
+
+      const detail = await api.get(
+        `/admin/payment-submissions/${res.data.payment_submission.id}`,
+        adminHeaders
+      )
+      const item = detail.data.payment_submission.items[0]
+      expect(Number(item.quantity)).toBe(4)
+      expect(Number(item.unit_amount)).toBe(1200)
+      expect(Number(item.amount)).toBe(4800)
+    })
+
+    /** Also a regression lock: the legacy path must not change at all. */
+    it("still honours a caller that only posts metadata", async () => {
+      // 🔴 The legacy channel is deliberately kept. Dropping it would silently
+      // re-price such a caller's line off the design's stored cost — a money
+      // change nobody asked for is worse than the channel being untyped.
+      const d1 = await createDesign("Legacy Metadata Design", {
+        estimated_cost: 1200,
+      })
+      await linkDesignToPartner(d1, partnerId)
+
+      const res = await api.post(
+        "/admin/payment-submissions",
+        {
+          partner_id: partnerId,
+          design_ids: [d1],
+          metadata: {
+            design_quantities: { [d1]: 3 },
+            design_unit_amounts: { [d1]: 700 },
+          },
+        },
+        adminHeaders
+      )
+      expect(res.status).toBe(201)
+
+      const detail = await api.get(
+        `/admin/payment-submissions/${res.data.payment_submission.id}`,
+        adminHeaders
+      )
+      const item = detail.data.payment_submission.items[0]
+      expect(Number(item.quantity)).toBe(3)
+      expect(Number(item.amount)).toBe(2100)
+    })
+
+    it("REFUSES a misspelt money key instead of ignoring it", async () => {
+      // The #1554 defect, reachable by one letter: `design_quantites` validates
+      // cleanly, is read by nothing, and the line falls through to "absent
+      // means 1" — a per-unit rate billed once. There is no bad VALUE to
+      // reject, only a fact that never arrived, so the boundary is the only
+      // place it can be seen.
+      const d1 = await createDesign("Typo Key Design", { estimated_cost: 1200 })
+      await linkDesignToPartner(d1, partnerId)
+
+      const res = await api
+        .post(
+          "/admin/payment-submissions",
+          {
+            partner_id: partnerId,
+            design_ids: [d1],
+            metadata: { design_quantites: { [d1]: 9 } },
+          },
+          adminHeaders
+        )
+        .catch((e: any) => e.response)
+
+      expect(res.status).toBe(400)
+      expect(String(res.data?.message || "")).toMatch(/design_quantities/)
+    })
+
+    it("refuses the same typo on the partner route", async () => {
+      const d1 = await createDesign("Partner Typo Design", {
+        estimated_cost: 1200,
+      })
+      await linkDesignToPartner(d1, partnerId)
+
+      const res = await api
+        .post(
+          "/partners/payment-submissions",
+          {
+            design_ids: [d1],
+            metadata: { design_cost_override: { [d1]: 900 } },
+          },
+          { headers: partnerHeaders }
+        )
+        .catch((e: any) => e.response)
+
+      expect(res.status).toBe(400)
+      expect(String(res.data?.message || "")).toMatch(/design_cost_overrides/)
+    })
+  })
+
   describe("POST /admin/payment-submissions — run provenance (#1556)", () => {
     it("records which runs a line paid for, and reports them as billed", async () => {
       const d1 = await createDesign("Provenance Design", {

--- a/apps/backend/integration-tests/http/payment-submissions-api.spec.ts
+++ b/apps/backend/integration-tests/http/payment-submissions-api.spec.ts
@@ -1253,6 +1253,118 @@ setupSharedTestSuite(() => {
     })
   })
 
+  /**
+   * Correcting a run must re-price the Draft it pre-filled (#1571).
+   *
+   * 🔴 `auto-draft-payment-submission` writes a Draft at completion using the
+   * figures of that moment. Correcting the run afterwards changed nothing about
+   * it — and no route could fix it either, since `review` refuses anything that
+   * is not Pending or Under_Review. A reviewer would approve a figure that no
+   * longer matches the run it came from. This happened on prod:
+   * `prod_run_01KZWX801S8HBNZ8DYBVNJK5GZ` drafted at 1190 and corrected to 840.
+   */
+  describe("a run correction re-prices its unclaimed Draft", () => {
+    /** A completed run plus the Draft payout the subscriber pre-filled from it. */
+    async function runWithDraft(name: string) {
+      const designId = await createDesign(name, { estimated_cost: 1200 })
+      await linkDesignToPartner(designId, partnerId)
+      const runId = await createCompletedRun(designId, name, {
+        quantity: 1,
+        produced_quantity: 3,
+        partner_cost_estimate: 1190,
+        cost_type: "per_unit",
+      })
+
+      const sub = await api.post(
+        "/admin/payment-submissions",
+        {
+          partner_id: partnerId,
+          design_ids: [designId],
+          quantities: { [designId]: 1 },
+          unit_amounts: { [designId]: 1190 },
+          production_run_ids: { [designId]: [runId] },
+          status: "Draft",
+        },
+        adminHeaders
+      )
+      expect(sub.status).toBe(201)
+      return { designId, runId, submissionId: sub.data.payment_submission.id }
+    }
+
+    it("re-prices the Draft when the run's rate is corrected", async () => {
+      const { runId, submissionId } = await runWithDraft("Stale Draft Design")
+
+      const before = await api.get(
+        `/admin/payment-submissions/${submissionId}`,
+        adminHeaders
+      )
+      expect(Number(before.data.payment_submission.total_amount)).toBe(1190)
+
+      // The correction that used to leave the Draft stale.
+      const corrected = await api.post(
+        `/admin/production-runs/${runId}`,
+        { partner_cost_estimate: 840, cost_type: "total", produced_quantity: 1 },
+        adminHeaders
+      )
+      expect(corrected.status).toBe(200)
+
+      // The EFFECT, re-read rather than taken from the correction's response.
+      const after = await api.get(
+        `/admin/payment-submissions/${submissionId}`,
+        adminHeaders
+      )
+      expect(Number(after.data.payment_submission.total_amount)).toBe(840)
+      expect(Number(after.data.payment_submission.items[0].amount)).toBe(840)
+    })
+
+    /**
+     * ⚠️ Passes on the old code too — it never touched anything. Kept as the
+     * guard that stops this fix over-reaching: the refresh must never widen
+     * from Draft to a live claim.
+     */
+    it("REFUSES to touch a payout somebody has already claimed", async () => {
+      // 🔴 The guard that keeps this from being dangerous. A Pending submission
+      // is a partner saying "pay me this"; silently rewriting it would change
+      // what they are owed without them ever seeing it.
+      const designId = await createDesign("Claimed Payout Design", {
+        estimated_cost: 1200,
+      })
+      await linkDesignToPartner(designId, partnerId)
+      const runId = await createCompletedRun(designId, "Claimed Payout Design", {
+        quantity: 1,
+        produced_quantity: 3,
+        partner_cost_estimate: 1190,
+        cost_type: "per_unit",
+      })
+
+      const sub = await api.post(
+        "/admin/payment-submissions",
+        {
+          partner_id: partnerId,
+          design_ids: [designId],
+          quantities: { [designId]: 1 },
+          unit_amounts: { [designId]: 1190 },
+          production_run_ids: { [designId]: [runId] },
+          // Pending, not Draft — a live claim.
+        },
+        adminHeaders
+      )
+      const submissionId = sub.data.payment_submission.id
+
+      await api.post(
+        `/admin/production-runs/${runId}`,
+        { partner_cost_estimate: 840, cost_type: "total", produced_quantity: 1 },
+        adminHeaders
+      )
+
+      const after = await api.get(
+        `/admin/payment-submissions/${submissionId}`,
+        adminHeaders
+      )
+      expect(Number(after.data.payment_submission.total_amount)).toBe(1190)
+    })
+  })
+
   describe("POST /admin/payment-submissions — run provenance (#1556)", () => {
     it("records which runs a line paid for, and reports them as billed", async () => {
       const d1 = await createDesign("Provenance Design", {

--- a/apps/backend/src/api/admin/payment-submissions/route.ts
+++ b/apps/backend/src/api/admin/payment-submissions/route.ts
@@ -2,7 +2,10 @@ import type { MedusaRequest, MedusaResponse } from "@medusajs/framework/http"
 import { PAYMENT_SUBMISSIONS_MODULE } from "../../../modules/payment_submissions"
 import PaymentSubmissionsService from "../../../modules/payment_submissions/service"
 import { createPaymentSubmissionWorkflow } from "../../../workflows/payment_submissions/create-payment-submission"
-import { foldMoneyFieldsIntoMetadata } from "../../../workflows/payment_submissions/lib/money-fields"
+import {
+  assertNoNearMissMoneyKey,
+  foldMoneyFieldsIntoMetadata,
+} from "../../../workflows/payment_submissions/lib/money-fields"
 
 // GET /admin/payment-submissions — list all submissions with filters
 export const GET = async (req: MedusaRequest, res: MedusaResponse) => {
@@ -53,6 +56,8 @@ export const POST = async (req: MedusaRequest, res: MedusaResponse) => {
     metadata?: Record<string, any>
   }
 
+  assertNoNearMissMoneyKey(body.metadata)
+
   const { result } = await createPaymentSubmissionWorkflow(req.scope).run({
     input: {
       partner_id: body.partner_id,
@@ -65,6 +70,13 @@ export const POST = async (req: MedusaRequest, res: MedusaResponse) => {
       // Typed input, not folded into metadata — this is the double-pay guard's
       // evidence, and it must not be reachable by a misspelt JSON key.
       production_run_ids: body.production_run_ids,
+      // The money, as typed inputs. These are the contract; the fold below
+      // keeps the same values on `metadata` so the review UI and any existing
+      // reader still see original vs. requested exactly as before.
+      quantities: body.quantities,
+      unit_amounts: body.unit_amounts,
+      cost_overrides: (body as any).cost_overrides,
+      task_cost_overrides: (body as any).task_cost_overrides,
       metadata: {
         // Typed money fields win over the metadata channel and land on it —
         // see `foldMoneyFieldsIntoMetadata` for why the precedence is per-field

--- a/apps/backend/src/api/admin/production-runs/[id]/route.ts
+++ b/apps/backend/src/api/admin/production-runs/[id]/route.ts
@@ -98,6 +98,7 @@ import {
   setRunAllocation,
 } from "../../../../lib/production-run-allocation"
 import { costTypeGuardMessage } from "../../../../workflows/production-runs/lib/cost-type-guard"
+import { refreshUnclaimedDraftPayouts } from "../../../../workflows/payment_submissions/lib/refresh-draft-payouts"
 
 export const GET = async (req: MedusaRequest, res: MedusaResponse) => {
   const id = req.params.id
@@ -289,6 +290,35 @@ export const POST = async (req: MedusaRequest, res: MedusaResponse) => {
   await productionRunService.updateProductionRuns({ id, ...update })
   const updated = await productionRunService.retrieveProductionRun(id)
 
+  /**
+   * A correction to the money must reach the DRAFT payout this run pre-filled.
+   *
+   * 🔴 `auto-draft-payment-submission` writes that Draft at completion using the
+   * figures of the moment. Correcting the run afterwards changed nothing about
+   * it, so the Draft kept the old numbers and went on looking authoritative —
+   * and no route could fix it, since `review` refuses anything that is not
+   * Pending or Under_Review. A reviewer would have approved a figure that no
+   * longer matched the run it came from.
+   *
+   * ⚠️ Draft ONLY. Every other status is a live claim someone has made, and
+   * rewriting one silently would change what a partner is owed without them
+   * seeing it. Best-effort: the correction above is already persisted and must
+   * not be rolled back because a draft could not be re-priced.
+   */
+  let refreshedDrafts: string[] = []
+  const touchesMoney =
+    update.partner_cost_estimate !== undefined ||
+    update.cost_type !== undefined ||
+    update.produced_quantity !== undefined
+  if (touchesMoney) {
+    try {
+      const outcome = await refreshUnclaimedDraftPayouts(req.scope, id)
+      refreshedDrafts = outcome.refreshed
+    } catch {
+      // Non-fatal by design — see above.
+    }
+  }
+
   // Audit the output correction. Best-effort: the correction itself is already
   // persisted and must not be rolled back because the timeline write failed.
   if (producedCorrection !== undefined || rejectedCorrection !== undefined) {
@@ -351,5 +381,11 @@ export const POST = async (req: MedusaRequest, res: MedusaResponse) => {
     ...(touchesMaterials
       ? { materials: await readRunAllocation(req.scope, id) }
       : {}),
+    /**
+     * Which unclaimed Draft payouts were re-priced to match this correction.
+     * Stated so the caller can see the money moved with the run rather than
+     * having to go and check. Empty when nothing needed it.
+     */
+    ...(refreshedDrafts.length ? { refreshed_draft_submissions: refreshedDrafts } : {}),
   })
 }

--- a/apps/backend/src/api/partners/payment-submissions/route.ts
+++ b/apps/backend/src/api/partners/payment-submissions/route.ts
@@ -2,7 +2,10 @@ import { AuthenticatedMedusaRequest, MedusaResponse } from "@medusajs/framework"
 import { ContainerRegistrationKeys, MedusaError } from "@medusajs/framework/utils"
 import { getPartnerFromAuthContext } from "../helpers"
 import { createPaymentSubmissionWorkflow } from "../../../workflows/payment_submissions/create-payment-submission"
-import { foldMoneyFieldsIntoMetadata } from "../../../workflows/payment_submissions/lib/money-fields"
+import {
+  assertNoNearMissMoneyKey,
+  foldMoneyFieldsIntoMetadata,
+} from "../../../workflows/payment_submissions/lib/money-fields"
 import submissionPartnerLink from "../../../links/submission-partner-link"
 
 // GET /partners/payment-submissions — list partner's own submissions
@@ -73,6 +76,8 @@ export const POST = async (
 
   const body = req.validatedBody as any
 
+  assertNoNearMissMoneyKey(body.metadata)
+
   const { result } = await createPaymentSubmissionWorkflow(req.scope).run({
     input: {
       partner_id: partner.id,
@@ -82,6 +87,12 @@ export const POST = async (
       documents: body.documents,
       // Typed input, not folded into metadata — see the field's docs.
       production_run_ids: body.production_run_ids,
+      // The money, as typed inputs. The fold below keeps the same values on
+      // `metadata` so reviewers still see original vs. requested.
+      quantities: body.quantities,
+      unit_amounts: body.unit_amounts,
+      cost_overrides: body.cost_overrides,
+      task_cost_overrides: body.task_cost_overrides,
       // Typed money fields win over the metadata channel and land on it.
       metadata: foldMoneyFieldsIntoMetadata(body),
     },

--- a/apps/backend/src/subscribers/auto-draft-payment-submission.ts
+++ b/apps/backend/src/subscribers/auto-draft-payment-submission.ts
@@ -80,6 +80,19 @@ export default async function autoDraftPaymentSubmissionHandler({
          * readers that already parse it, but it is no longer the record. #1565
          */
         production_run_ids: { [payout.design_id]: [runId] },
+        /**
+         * The money, as typed inputs.
+         *
+         * 🔴 This subscriber was the last caller still stating what a partner
+         * is owed through `metadata` — the untyped channel that made #1554
+         * reachable by a spelling mistake. Both UIs had already moved; this had
+         * not, and it is the path that writes MOST of production's payouts.
+         *
+         * The same values still reach `metadata` (the route's fold does that
+         * for the review UI), but they no longer *depend* on landing there.
+         */
+        unit_amounts: { [payout.design_id]: payout.unit_amount },
+        quantities: { [payout.design_id]: payout.quantity },
         metadata: {
           auto_drafted: true,
           source: "production_run.completed",

--- a/apps/backend/src/workflows/payment_submissions/__tests__/near-miss-money-key.unit.spec.ts
+++ b/apps/backend/src/workflows/payment_submissions/__tests__/near-miss-money-key.unit.spec.ts
@@ -1,0 +1,81 @@
+import { nearMissMoneyKey } from "../lib/money-fields"
+
+/**
+ * The #1554-by-typo defence (#1571).
+ *
+ * 🔴 Typed fields protect a caller that uses them. They do nothing for one that
+ * posts `metadata.design_quantites`: that key validates cleanly against
+ * `z.record(z.string(), z.any())`, is read by nothing, and the line falls
+ * through to "absent means 1" — a per-unit rate billed once. There is no bad
+ * VALUE for a sanitizer to reject, only a fact that never arrived, so the
+ * boundary is the only place it is visible.
+ */
+describe("nearMissMoneyKey", () => {
+  it("catches the exact typo that motivated the typed fields", () => {
+    // One edit from `design_quantities`. This spelling billed ₹850 for nine
+    // garments and was invisible to tsc, to every test, and to the reviewer.
+    expect(nearMissMoneyKey({ design_quantites: { d1: 9 } })).toEqual({
+      key: "design_quantites",
+      meant: "design_quantities",
+    })
+  })
+
+  it("catches near-misses of each money key", () => {
+    const cases: Array<[string, string]> = [
+      ["design_cost_override", "design_cost_overrides"],
+      ["task_cost_override", "task_cost_overrides"],
+      ["design_unit_amount", "design_unit_amounts"],
+      ["design_quantity", "design_quantities"],
+    ]
+    for (const [typo, meant] of cases) {
+      expect(nearMissMoneyKey({ [typo]: {} })).toEqual({ key: typo, meant })
+    }
+  })
+
+  it("is case-insensitive", () => {
+    expect(nearMissMoneyKey({ Design_Quantities: {} })?.meant).toBe(
+      "design_quantities"
+    )
+  })
+
+  it("allows the canonical keys — that channel is still honoured", () => {
+    // 🔴 The legacy read is deliberately kept: dropping it would silently stop
+    // honouring callers still posting that way, re-pricing their lines off the
+    // design's stored cost. A money change nobody asked for is worse than the
+    // channel being untyped.
+    expect(
+      nearMissMoneyKey({
+        design_cost_overrides: { d1: 100 },
+        task_cost_overrides: { t1: 100 },
+        design_quantities: { d1: 9 },
+        design_unit_amounts: { d1: 850 },
+      })
+    ).toBeNull()
+  })
+
+  it("does not fire on ordinary metadata", () => {
+    // The guard must not become a reason to avoid `metadata` altogether — it is
+    // a legitimate free-form channel for everything that is not money.
+    expect(
+      nearMissMoneyKey({
+        created_by: "admin",
+        notes: "hello",
+        source: "production_run.completed",
+        auto_drafted: true,
+        quantity_basis: "produced",
+        source_production_run_id: "prod_run_1",
+        production_run_id: "prod_run_1",
+        payable_amount: 7650,
+        ordered_quantity: 9,
+        partner_cost_estimate: 850,
+        cost_type: "per_unit",
+      })
+    ).toBeNull()
+  })
+
+  it("handles no metadata at all", () => {
+    expect(nearMissMoneyKey(null)).toBeNull()
+    expect(nearMissMoneyKey(undefined)).toBeNull()
+    expect(nearMissMoneyKey({})).toBeNull()
+  })
+})

--- a/apps/backend/src/workflows/payment_submissions/create-payment-submission.ts
+++ b/apps/backend/src/workflows/payment_submissions/create-payment-submission.ts
@@ -29,7 +29,35 @@ export type CreatePaymentSubmissionInput = {
   task_ids?: string[]
   notes?: string
   documents?: Array<{ id?: string; url: string; filename?: string; mimeType?: string }>
+  /**
+   * ⚠️ Free-form, and NOT where the money lives any more.
+   *
+   * The four fields below used to reach this workflow only through here, and
+   * every route validates `metadata` as `z.record(z.string(), z.any())` — which
+   * accepts anything. `design_quantities` and `design_quantites` both validated
+   * cleanly, and the typo fell through to "absent means 1" and billed a
+   * per-unit rate once (#1554 by spelling mistake, #1557).
+   *
+   * Reading them off `metadata` is kept ONLY as a fallback for callers that
+   * still post that way; the typed fields win outright. See `moneyOf` below.
+   */
   metadata?: Record<string, any>
+  /**
+   * What the caller is asking to be paid, as typed inputs rather than blob keys.
+   *
+   * 🔑 These are the contract now. Each corresponds to a `metadata.design_*`
+   * key the workflow used to read, and an explicit field REPLACES the whole
+   * corresponding map rather than merging key-by-key — a caller that sends
+   * `quantities` must not still be overridden by a stale blob it never wrote.
+   */
+  /** Units billed per design. Absent means 1. */
+  quantities?: Record<string, number>
+  /** Agreed rate per unit, per design. Beats the design's stored cost. */
+  unit_amounts?: Record<string, number>
+  /** Typed line TOTAL per design. Wins outright; never multiplied by quantity. */
+  cost_overrides?: Record<string, number>
+  /** Typed line total per task. */
+  task_cost_overrides?: Record<string, number>
   /**
    * The status the submission lands in. "Pending" (the default) is a partner
    * saying "pay me for this". "Draft" is the system pre-filling one FOR the
@@ -915,14 +943,43 @@ export const createPaymentSubmissionWorkflow = createWorkflow(
   (input: CreatePaymentSubmissionInput) => {
     // The partner UI passes form-entered amounts via metadata so reviewers can
     // see original vs requested; honor them here as the submitted amounts.
-    const costOverrides = transform({ input }, (data) => ({
-      designs: sanitizeCostOverrides(data.input.metadata?.design_cost_overrides),
-      tasks: sanitizeCostOverrides(data.input.metadata?.task_cost_overrides),
-      // Units billed per design. Rides the same metadata channel as the cost
-      // overrides so both ends of the existing partner form keep one shape.
-      designQuantities: sanitizeQuantities(data.input.metadata?.design_quantities),
-      designUnitAmounts: sanitizeCostOverrides(data.input.metadata?.design_unit_amounts),
-    }))
+    /**
+     * The typed field wins; `metadata` is a fallback for callers that have not
+     * moved yet.
+     *
+     * 🔴 The precedence direction matters. `metadata` accepts anything, so a
+     * caller that states its intent in a typed field must not then be
+     * overridden by a blob — that would put the untyped channel back in charge
+     * of the money and hand #1557 its shape back. An explicit field replaces
+     * the WHOLE map rather than merging key-by-key, for the same reason.
+     *
+     * ⚠️ The fallback is deliberately kept rather than deleted. Dropping the
+     * metadata read outright would silently stop honouring any caller still
+     * posting that way — their line would quietly re-price off the design's
+     * stored cost, which is a money change nobody asked for. Near-miss keys are
+     * refused at the route boundary instead, which is what kills the typo class.
+     */
+    const costOverrides = transform({ input }, (data) => {
+      const moneyOf = (
+        typed: Record<string, number> | undefined,
+        legacy: unknown
+      ) => (typed !== undefined ? typed : legacy)
+
+      return {
+        designs: sanitizeCostOverrides(
+          moneyOf(data.input.cost_overrides, data.input.metadata?.design_cost_overrides)
+        ),
+        tasks: sanitizeCostOverrides(
+          moneyOf(data.input.task_cost_overrides, data.input.metadata?.task_cost_overrides)
+        ),
+        designQuantities: sanitizeQuantities(
+          moneyOf(data.input.quantities, data.input.metadata?.design_quantities)
+        ),
+        designUnitAmounts: sanitizeCostOverrides(
+          moneyOf(data.input.unit_amounts, data.input.metadata?.design_unit_amounts)
+        ),
+      }
+    })
 
     const validatedDesigns = validateDesignsForSubmissionStep({
       partner_id: input.partner_id,

--- a/apps/backend/src/workflows/payment_submissions/lib/money-fields.ts
+++ b/apps/backend/src/workflows/payment_submissions/lib/money-fields.ts
@@ -1,6 +1,7 @@
 // Plain "zod", matching both validators that spread this fragment. Mixing zod
 // instances across a spread makes the composed object's types disagree in ways
 // that surface as an unrelated-looking error in the consuming file.
+import { MedusaError } from "@medusajs/framework/utils"
 import { z } from "zod"
 
 /**
@@ -76,20 +77,116 @@ export type PaymentSubmissionMoneyInput = {
 }
 
 /**
- * Fold the typed fields onto the metadata channel the workflow reads.
+ * The `metadata` keys the workflow still reads money from, for callers that
+ * have not moved to the typed fields.
+ */
+export const LEGACY_MONEY_METADATA_KEYS = [
+  "design_cost_overrides",
+  "task_cost_overrides",
+  "design_quantities",
+  "design_unit_amounts",
+] as const
+
+/** Levenshtein distance, capped — we only care about "close". */
+const distance = (a: string, b: string): number => {
+  if (a === b) return 0
+  if (Math.abs(a.length - b.length) > 3) return 99
+  let prev = Array.from({ length: b.length + 1 }, (_, i) => i)
+  for (let i = 1; i <= a.length; i++) {
+    const row = [i]
+    for (let j = 1; j <= b.length; j++) {
+      row[j] = Math.min(
+        prev[j] + 1,
+        row[j - 1] + 1,
+        prev[j - 1] + (a[i - 1] === b[j - 1] ? 0 : 1)
+      )
+    }
+    prev = row
+  }
+  return prev[b.length]
+}
+
+/**
+ * PURE: a `metadata` key that is *almost* one of the money keys.
  *
- * The workflow lifts these off `metadata` (`metadata.design_quantities` and
- * friends), and changing that is a wider blast radius than this fix wants —
- * the partner form posts through metadata today and must keep working. So the
- * typed field is authoritative and lands in metadata on its way through, which
- * is what makes it genuinely take effect rather than being accepted-and-ignored
- * (a whole class of bug this repo has hit before).
+ * 🔴 This is the actual #1554-by-typo defence. The typed fields protect a
+ * caller that uses them; they do nothing for a caller that posts
+ * `metadata.design_quantites` — that key validates cleanly against
+ * `z.record(z.string(), z.any())`, is read by nothing, and the line silently
+ * falls through to the workflow's "absent means 1" default. The result is a
+ * per-unit rate billed once, invisible to tsc, to every test, and to the
+ * reviewer reading the diff.
+ *
+ * Sanitizers cannot catch this: there is no bad VALUE to reject, only a fact
+ * that never arrived. The only place it is visible is the boundary, by noticing
+ * that someone clearly meant a key we know.
+ *
+ * Exact matches are fine (that is the legacy channel, still honoured). Distant
+ * keys are fine (ordinary metadata). Only the near-misses are refused, and the
+ * message names the key they meant.
+ */
+export const nearMissMoneyKey = (
+  metadata: Record<string, unknown> | null | undefined
+): { key: string; meant: string } | null => {
+  for (const key of Object.keys(metadata || {})) {
+    if ((LEGACY_MONEY_METADATA_KEYS as readonly string[]).includes(key)) {
+      continue
+    }
+    for (const canonical of LEGACY_MONEY_METADATA_KEYS) {
+      const d = distance(key.toLowerCase(), canonical)
+      /**
+       * Up to 3 edits: a misspelling, not a different word. `design_quantites`
+       * is 1 away, `design_quantity` (singular) is 3, and `notes` is nowhere
+       * near anything.
+       *
+       * ⚠️ `d === 0` counts too. The exact-match check above already let the
+       * canonical keys through, so reaching here with distance 0 means the key
+       * differs only in CASE — and `metadata` lookups are case-sensitive, so
+       * `Design_Quantities` is read by nothing. That is a typo wearing a
+       * disguise, and the most confusing kind to debug.
+       */
+      if (d <= 3) {
+        return { key, meant: canonical }
+      }
+    }
+  }
+  return null
+}
+
+/**
+ * Refuse a request whose `metadata` misspells a money key.
+ *
+ * Throws rather than warns: the whole point is that the mistake is otherwise
+ * silent and shows up as an underpayment weeks later. A 400 naming the intended
+ * key costs the caller one minute; the alternative cost ₹850 for nine garments.
+ */
+export const assertNoNearMissMoneyKey = (
+  metadata: Record<string, unknown> | null | undefined
+): void => {
+  const miss = nearMissMoneyKey(metadata)
+  if (miss) {
+    throw new MedusaError(
+      MedusaError.Types.INVALID_DATA,
+      `metadata.${miss.key} is not a recognised field — did you mean "${miss.meant}"? A misspelt money key is accepted silently and then ignored, which bills the wrong amount. Prefer the typed fields (quantities / unit_amounts / cost_overrides / task_cost_overrides).`
+    )
+  }
+}
+
+/**
+ * Mirror the typed fields onto `metadata` for READERS, not for the workflow.
+ *
+ * ⚠️ This used to be load-bearing: the workflow read the money only off
+ * `metadata`, so folding was what made a typed field take effect at all. It no
+ * longer is — the workflow reads the typed input and treats metadata as a
+ * fallback (see `moneyOf` in create-payment-submission.ts).
+ *
+ * The fold is kept because the stored submission's `metadata` is what the
+ * review UI and existing consumers read to show "original vs. requested". A
+ * caller that sends nothing gets exactly the old behaviour, byte for byte.
  *
  * 🔑 Precedence is per-FIELD and one-way: an explicit field replaces the whole
- * corresponding map. It is deliberately not a per-key merge — a caller that
- * sends `quantities` would otherwise still be overridden key-by-key by a stale
- * metadata blob it never wrote. A caller that sends nothing gets exactly the
- * old behaviour, byte for byte, so no live caller is re-priced by this change.
+ * corresponding map, never a per-key merge — a caller that sends `quantities`
+ * must not still be overridden key-by-key by a stale blob it never wrote.
  */
 export const foldMoneyFieldsIntoMetadata = (
   body: PaymentSubmissionMoneyInput & { metadata?: Record<string, any> }

--- a/apps/backend/src/workflows/payment_submissions/lib/refresh-draft-payouts.ts
+++ b/apps/backend/src/workflows/payment_submissions/lib/refresh-draft-payouts.ts
@@ -1,0 +1,127 @@
+import { PAYMENT_SUBMISSIONS_MODULE } from "../../../modules/payment_submissions"
+import { assessRunPayout } from "../../production-runs/lib/run-payable"
+
+/**
+ * Re-price the unclaimed DRAFT payouts that were pre-filled from a run, after
+ * that run's money has been corrected.
+ *
+ * ## Why this exists
+ *
+ * `auto-draft-payment-submission` writes a Draft the moment a run completes,
+ * using the figures the partner entered at that moment. Correcting the run
+ * afterwards — a produced quantity, an agreed rate, a cost type — changed
+ * nothing about that Draft. It kept the old numbers and went on looking
+ * authoritative.
+ *
+ * On production: run `prod_run_01KZWX801S8HBNZ8DYBVNJK5GZ` was drafted at
+ * ₹1,190/unit, then its rate was corrected to ₹840 total and its produced
+ * quantity from 3 to 1. The Draft still said ₹1,190. Nothing in the system
+ * disagreed with it, and a reviewer would have approved a figure that no longer
+ * matched the run it came from.
+ *
+ * 🔴 There is no route that could have fixed it either. A submission has GET
+ * and `review`, and `review` refuses anything that is not Pending or
+ * Under_Review — so a stale Draft could not be edited, rejected, or discarded
+ * through the API at all. Re-pricing it here is the repair AND the prevention.
+ *
+ * ## Only Draft, and only ever Draft
+ *
+ * ⚠️ A Draft is system-written and unsubmitted: nobody has claimed it, so
+ * re-pricing it takes nothing away from anyone. Every other status is a live
+ * claim — a partner has asked for that amount, or it has been approved or paid
+ * — and silently rewriting one would change what somebody is owed without them
+ * seeing it. Those are left exactly as they are; the correcting admin can
+ * reject and re-raise if they need to.
+ *
+ * Uses `assessRunPayout`, the same function the subscriber drafted with, so a
+ * refresh cannot quietly change the BASIS of the figure (it bills ordered, not
+ * produced — see `runPayableAmount`). Only the inputs have changed, not the
+ * rule.
+ *
+ * Best-effort by contract: the run correction is already persisted and must
+ * never be rolled back because a downstream draft could not be re-priced.
+ */
+export const refreshUnclaimedDraftPayouts = async (
+  scope: any,
+  runId: string
+): Promise<{ refreshed: string[]; skipped: string[] }> => {
+  const refreshed: string[] = []
+  const skipped: string[] = []
+
+  const runService: any = scope.resolve("production_runs")
+  const run = await runService.retrieveProductionRun(runId)
+
+  const payout = assessRunPayout(run)
+  if (!payout.eligible) {
+    // No payable figure any more (rate cleared, run reopened). Leaving the
+    // Draft alone is safer than zeroing it: a zero payout reads as a decision
+    // that the work was worthless, which is exactly the #1564 mistake.
+    return { refreshed, skipped }
+  }
+
+  const service: any = scope.resolve(PAYMENT_SUBMISSIONS_MODULE)
+
+  const items = (await service.listPaymentSubmissionItems(
+    { design_id: [String(run.design_id)] },
+    { relations: ["submission"] }
+  )) as any[]
+
+  for (const item of items || []) {
+    const claims = (item?.production_run_ids ?? []) as string[]
+    if (!Array.isArray(claims) || !claims.includes(runId)) {
+      continue
+    }
+
+    const status = String(item?.submission?.status || "")
+    if (status !== "Draft") {
+      // A live claim. Recorded so the caller can say so rather than silently
+      // leaving a stale figure in place.
+      skipped.push(String(item.submission?.id || item.submission_id || ""))
+      continue
+    }
+
+    // A line can collapse several runs of one design; re-pricing from a single
+    // run would then be wrong. Those are left for a human.
+    if (claims.length > 1) {
+      skipped.push(String(item.submission?.id || item.submission_id || ""))
+      continue
+    }
+
+    const unchanged =
+      Number(item.amount) === payout.amount &&
+      Number(item.quantity) === payout.quantity &&
+      Number(item.unit_amount) === payout.unit_amount
+    if (unchanged) {
+      continue
+    }
+
+    await service.updatePaymentSubmissionItems({
+      id: item.id,
+      amount: payout.amount,
+      quantity: payout.quantity,
+      unit_amount: payout.unit_amount,
+    })
+
+    // The submission total is stored, not derived, so it has to move too — a
+    // line and a header that disagree is worse than either being wrong alone.
+    const submissionId = String(item.submission?.id || item.submission_id || "")
+    if (submissionId) {
+      const siblings = (await service.listPaymentSubmissionItems(
+        { submission_id: submissionId },
+        {}
+      )) as any[]
+      const total = (siblings || []).reduce(
+        (sum: number, s: any) =>
+          sum + (String(s.id) === String(item.id) ? payout.amount : Number(s.amount) || 0),
+        0
+      )
+      await service.updatePaymentSubmissions({
+        id: submissionId,
+        total_amount: Math.round(total * 100) / 100,
+      })
+      refreshed.push(submissionId)
+    }
+  }
+
+  return { refreshed, skipped }
+}


### PR DESCRIPTION
Two fixes, both from the same investigation: a payment figure that is wrong
while looking authoritative, and nothing in the system disagreeing with it.

---

# 1. The typed money fields were a façade over `metadata` (#1571)

`CreatePaymentSubmissionInput` had **no** typed money fields. The workflow read
all four off the blob:

```ts
designs:           metadata?.design_cost_overrides
tasks:             metadata?.task_cost_overrides
designQuantities:  metadata?.design_quantities
designUnitAmounts: metadata?.design_unit_amounts
```

Both routes accept the typed fields **and** `metadata: z.record(z.string(),
z.any())`, then fold the typed values into the blob on the way in. So the typed
layer validated at the door and handed the money to an untyped channel.

- **Typed workflow inputs**, and the typed value **wins**.
- **`metadata` stays as a fallback.** Deleting the read would silently stop
  honouring any caller still posting that way — their line would quietly
  re-price off the design's stored cost. A money change nobody asked for is
  worse than an untyped channel.
- **The auto-draft subscriber now passes typed fields** — the last caller
  stating a payout through `metadata`, and the path that writes most of
  production's payouts.
- 🔴 **A near-miss `metadata` key is refused at both routes**, 400 naming the
  key the caller meant.

### The guard is the part that matters

Typed fields protect a caller who uses them. They do nothing for one that posts
`metadata.design_quantites` — that key validates cleanly, is read by nothing,
and the line falls through to "absent means 1": a per-unit rate billed once.
**There is no bad VALUE for a sanitizer to reject, only a fact that never
arrived**, so the boundary is the only place it can be seen. That is #1554
reachable by one letter.

It also refuses a key differing only in **case** — `metadata` lookups are
case-sensitive, so `Design_Quantities` is read by nothing. ⚠️ I found that by
writing the test, not by designing for it; my first implementation let it
through.

---

# 2. Correcting a run left its Draft payout stale — and unfixable

`auto-draft-payment-submission` writes a Draft the moment a run completes, using
the figures of that moment. Correcting the run afterwards changed nothing about
it.

Live example, corrected on prod today: `prod_run_01KZWX801S8HBNZ8DYBVNJK5GZ`
was drafted at **1190**/unit, then its rate became **840 total** and its
produced quantity **3 → 1**. The Draft still said 1190. Nothing disagreed with
it, and a reviewer would have approved a figure that no longer matched the run
it came from.

🔴 **No route could fix it either.** A submission exposes `GET` and `review`, and
`review` refuses anything that is not Pending or Under_Review — so a stale Draft
could not be edited, rejected, or discarded through the API at all.

A money-relevant correction now re-prices the unclaimed Draft that run
pre-filled, via `assessRunPayout` — the same function the subscriber drafted
with, so a refresh cannot quietly change the **basis** of the figure (it bills
ordered, not produced). Only the inputs move, never the rule.

⚠️ **Draft only.** Every other status is a live claim; silently rewriting one
would change what somebody is owed without them seeing it. It also skips a line
collapsing several runs of one design, and leaves a Draft alone when the run no
longer yields a payable figure rather than zeroing it — a zero payout reads as a
decision that the work was worthless, which is #1564's mistake.

---

## Verification

`70/70` integration, `6/6` new unit, `check:prod-build` green.

⚠️ **Honest note on coverage.** Of six new integration tests, **three** fail on
the old code (the two near-miss guards and the Draft re-price). The other three
are regression **locks**, labelled as such in the spec:

- the two precedence tests already passed, because the route's fold gives typed
  values precedence at the door — the workflow-level change is what makes
  precedence true for callers reaching the workflow *directly* (the subscriber),
  where no fold runs;
- "refuses to touch a claimed payout" passes on old code too, since old code
  never touched anything — it exists to stop this fix over-reaching.

## Still open: the B half of #1571

The partner submission screen sends **no** `production_run_ids` and **no**
quantities — so every partner-created payout is `run_provenance: "not_recorded"`,
the double-pay guard is structurally blind to it, and a `cost_override` is a
TOTAL so a partner claiming for nine garments types one number. Needs
`apps/partner-ui` work (⚠️ no CI there).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_0158wJMZ1DmjNxXf5uGuBrQD