### PR TITLE
fix(orders): an admin cancel never cleared partner_status (#1574)

### DIFF
--- a/apps/backend/integration-tests/http/designs-produce-no-customer.spec.ts
+++ b/apps/backend/integration-tests/http/designs-produce-no-customer.spec.ts
@@ -309,5 +309,122 @@ setupSharedTestSuite(() => {
         ])
       })
     })
+
+    /**
+     * #1574 — an admin cancels a run and the order goes on rendering as live
+     * work.
+     *
+     * `deriveRunPartnerStatus` returned `undefined` for an admin cancel and the
+     * mirror writes only truthy values, so `partner_status` was never cleared:
+     * it kept `assigned` / `accepted` / `in_progress` forever. The core
+     * `order.status` was always right — it is the sidecar the panels read that
+     * lied, which is why a cancelled order looked half-finished.
+     *
+     * ⚠️ ONE test, walking the whole sequence, deliberately. The runner restores
+     * a DB snapshot before every test, so a fixture built in a nested
+     * `beforeAll` is gone by the time the body runs — and each step here needs
+     * the previous step's cancel to have happened.
+     */
+    it("stops calling an order live once its runs are cancelled (#1574)", async () => {
+      const container = getContainer()
+      const unique = Date.now()
+      const ids: string[] = []
+      for (let i = 0; i < 2; i++) {
+        const res = await api.post(
+          "/admin/designs",
+          {
+            name: `Cancel Fixture Design ${unique}-${i}`,
+            description: "#1574 cancel fixture",
+            design_type: "Original",
+            status: "Approved",
+            priority: "Medium",
+            estimated_cost: 500,
+          },
+          adminHeaders
+        )
+        ids.push(res.data.design.id)
+      }
+
+      const produced = await produceDesignsAsWorkOrder(container, ids, partnerId)
+      const workOrderId = produced.work_order_id!
+      const runIds = produced.run_ids
+      expect(runIds).toHaveLength(2)
+
+      const readWorkOrder = async (qs = "") => {
+        const res = await api.get(
+          `/admin/design-work-orders?limit=100${qs}`,
+          adminHeaders
+        )
+        expect(res.status).toBe(200)
+        return res.data.design_work_orders.find((w: any) => w.id === workOrderId)
+      }
+
+      const readStatuses = async () => {
+        const q = container.resolve(ContainerRegistrationKeys.QUERY) as any
+        const { data } = await q.graph({
+          entity: "orders",
+          fields: ["id", "status", "unified_order_status.partner_status"],
+          filters: { id: workOrderId },
+        })
+        return {
+          core: data?.[0]?.status,
+          partner: data?.[0]?.unified_order_status?.partner_status ?? null,
+        }
+      }
+
+      expect((await readWorkOrder()).design_count).toBe(2)
+
+      // ── Cancel ONE of the two ───────────────────────────────────────────
+      expect(
+        (
+          await api.post(
+            `/admin/production-runs/${runIds[0]}/cancel`,
+            { reason: "test cancel" },
+            adminHeaders
+          )
+        ).status
+      ).toBe(200)
+
+      // 🔴 Fails on the old code: the cancelled run kept rendering as a design
+      // line and `design_count` kept counting it, so an order half called off
+      // still read as work in flight.
+      const afterOne = await readWorkOrder()
+      expect(afterOne.design_count).toBe(1)
+      expect(afterOne.runs.map((r: any) => r.id)).not.toContain(runIds[0])
+
+      // Hidden, not dropped — "what happened to this order" stays answerable.
+      const withCancelled = await readWorkOrder("&include_cancelled=true")
+      expect(withCancelled.design_count).toBe(2)
+      expect(withCancelled.runs.map((r: any) => r.id)).toContain(runIds[0])
+
+      // ⚠️ The counter-case that makes the fix safe to deploy: one cancelled run
+      // among live ones must NOT retire the order. If "cancelled" joined the
+      // progress ordering it would sort below everything and do exactly that.
+      expect((await readStatuses()).partner).toBe("assigned")
+
+      // ── Cancel the other ────────────────────────────────────────────────
+      expect(
+        (
+          await api.post(
+            `/admin/production-runs/${runIds[1]}/cancel`,
+            { reason: "test cancel" },
+            adminHeaders
+          )
+        ).status
+      ).toBe(200)
+
+      const { core, partner } = await readStatuses()
+      // The core status was never the bug — it mapped cancelled correctly all
+      // along. Asserted anyway so a regression names which of the two moved.
+      expect(core).toBe("canceled")
+      // 🔴 The assertion that fails on the old code: still "assigned", because
+      // an admin cancel derived `undefined` and the mirror skipped the write.
+      expect(partner).toBe("cancelled")
+
+      // And the fully-cancelled order leaves the list rather than rendering as
+      // a work-order with no designs left in it.
+      expect(await readWorkOrder()).toBeUndefined()
+      expect(await readWorkOrder("&include_cancelled=true")).toBeDefined()
+    })
   })
 })

--- a/apps/backend/src/admin/lib/work-status.ts
+++ b/apps/backend/src/admin/lib/work-status.ts
@@ -18,6 +18,10 @@ export const PARTNER_STATUS_LABELS: Record<string, string> = {
   finished: "Finished",
   completed: "Completed",
   declined: "Declined",
+  // #1574 — an ADMIN cancel, as distinct from `declined`, which is the partner
+  // refusing the work. Both end the job; showing "Declined" for an admin cancel
+  // would accuse the partner of something they did not do.
+  cancelled: "Cancelled",
 }
 
 /** Resolve the partner work-status off the typed sidecar column. */

--- a/apps/backend/src/api/admin/design-work-orders/route.ts
+++ b/apps/backend/src/api/admin/design-work-orders/route.ts
@@ -26,6 +26,26 @@ export const GET = async (req: MedusaRequest, res: MedusaResponse) => {
   const sourceOrderFilter = ((req.query as any).source_order_id || "").trim()
   const partnerFilter = ((req.query as any).partner_id || "").trim()
   const runStatusFilter = ((req.query as any).run_status || "").trim()
+  /**
+   * #1574 — cancelled runs are hidden by default.
+   *
+   * A cancelled run kept rendering as a design line, so an order whose work was
+   * called off still read as partly-finished production: `design_count` counted
+   * it and the row rendered next to the live ones. What the admin needs to see
+   * here is work that is genuinely still in flight.
+   *
+   * Hidden, not dropped — `include_cancelled=true` brings them back, because
+   * "what happened to this order" is a real question and the answer must stay
+   * reachable. An explicit `run_status=cancelled` also overrides, since asking
+   * for them by name and getting nothing would be absurd.
+   */
+  const includeCancelled =
+    String((req.query as any).include_cancelled || "").trim() === "true" ||
+    runStatusFilter === "cancelled"
+  const visibleRuns = (runs: any[]) =>
+    includeCancelled
+      ? runs
+      : runs.filter((r: any) => String(r?.status) !== "cancelled")
 
   const [channel] = await scService.listSalesChannels({
     name: PARTNER_WORK_ORDERS_CHANNEL,
@@ -61,7 +81,10 @@ export const GET = async (req: MedusaRequest, res: MedusaResponse) => {
 
   const collated = (orders || []).filter((o: any) => {
     if (o?.metadata?.collated_design_order !== true) return false
-    const runs = o?.production_runs ?? []
+    // 🔴 Emptiness is tested on the VISIBLE runs, so an order whose every run
+    // was cancelled drops out of the list entirely rather than rendering as a
+    // work-order with no designs in it.
+    const runs = visibleRuns(o?.production_runs ?? [])
     if (!runs.length) return false
     if (idFilter && o.id !== idFilter) return false
     if (sourceOrderFilter && o?.metadata?.source_order_id !== sourceOrderFilter) {
@@ -83,7 +106,9 @@ export const GET = async (req: MedusaRequest, res: MedusaResponse) => {
   const designIds = Array.from(
     new Set(
       page.flatMap((o: any) =>
-        (o.production_runs || []).map((r: any) => r.design_id).filter(Boolean)
+        visibleRuns(o.production_runs || [])
+          .map((r: any) => r.design_id)
+          .filter(Boolean)
       )
     )
   )
@@ -130,8 +155,10 @@ export const GET = async (req: MedusaRequest, res: MedusaResponse) => {
     has_customer: !!o.email,
     partner_status: o.unified_order_status?.partner_status ?? null,
     source_order_id: o.metadata?.source_order_id ?? null,
-    design_count: (o.production_runs || []).length,
-    runs: o.production_runs || [],
+    // Counts what is rendered. A count that included the hidden rows would
+    // say "3 designs" above a list of one.
+    design_count: visibleRuns(o.production_runs || []).length,
+    runs: visibleRuns(o.production_runs || []),
   }))
 
   res.json({

--- a/apps/backend/src/api/admin/production-runs/[id]/cancel/route.ts
+++ b/apps/backend/src/api/admin/production-runs/[id]/cancel/route.ts
@@ -142,8 +142,13 @@ export const POST = async (req: MedusaRequest, res: MedusaResponse) => {
     }
   }
 
-  // #342 — best-effort mirror onto the unified orders (admin cancel carries
-  // no partner_status per §5; superseded parent orders are skipped inside)
+  // #342 — best-effort mirror onto the unified orders (superseded parent
+  // orders are skipped inside).
+  //
+  // 🔑 This DOES carry a partner_status now: `cancelled`. It used to carry
+  // none, on the reading that §5 defined no value for an admin cancel — and
+  // because the mirror writes only truthy values, the order kept whatever it
+  // last said and went on rendering as live work. #1574
   for (const runId of [id, ...cancelledChildren, run.parent_run_id].filter(Boolean)) {
     await mirrorRunStatusToUnifiedOrder(req.scope, runId)
   }

--- a/apps/backend/src/modules/unified_order_status/migrations/Migration20260827061500.ts
+++ b/apps/backend/src/modules/unified_order_status/migrations/Migration20260827061500.ts
@@ -1,0 +1,27 @@
+import { Migration } from "@medusajs/framework/mikro-orm/migrations";
+
+/**
+ * #1574 — `partner_status` gains "cancelled".
+ *
+ * The column is `text` with a check constraint listing the allowed values, so
+ * a new enum member is a constraint swap rather than a type change. Without
+ * this the model would accept "cancelled" and the INSERT would fail at the
+ * database, which is exactly the shape that turns a status fix into a silent
+ * write failure behind a swallow-and-warn boundary.
+ */
+export class Migration20260827061500 extends Migration {
+
+  override async up(): Promise<void> {
+    this.addSql(`alter table if exists "unified_order_status" drop constraint if exists "unified_order_status_partner_status_check";`);
+    this.addSql(`alter table if exists "unified_order_status" add constraint "unified_order_status_partner_status_check" check ("partner_status" in ('assigned', 'accepted', 'in_progress', 'finished', 'partial', 'completed', 'declined', 'cancelled'));`);
+  }
+
+  override async down(): Promise<void> {
+    // Rows already carrying the new value would violate the narrower
+    // constraint, so retire them to the nearest older meaning first.
+    this.addSql(`update "unified_order_status" set "partner_status" = 'declined' where "partner_status" = 'cancelled';`);
+    this.addSql(`alter table if exists "unified_order_status" drop constraint if exists "unified_order_status_partner_status_check";`);
+    this.addSql(`alter table if exists "unified_order_status" add constraint "unified_order_status_partner_status_check" check ("partner_status" in ('assigned', 'accepted', 'in_progress', 'finished', 'partial', 'completed', 'declined'));`);
+  }
+
+}

--- a/apps/backend/src/modules/unified_order_status/models/unified-order-status.ts
+++ b/apps/backend/src/modules/unified_order_status/models/unified-order-status.ts
@@ -27,6 +27,20 @@ const UnifiedOrderStatus = model.define("unified_order_status", {
     "partial",
     "completed",
     "declined",
+    /**
+     * An admin cancelled every run behind this order.
+     *
+     * Distinct from `declined`, which is a PARTNER refusing the work. Both end
+     * the job; only one of them is the partner's doing, and a partner panel
+     * that showed "declined" for an admin cancel would be accusing them of
+     * something they did not do.
+     *
+     * 🔑 Added because its absence was read as "no value to write". The mirror
+     * only writes truthy values, so an admin cancel left `partner_status` at
+     * whatever it last was — `accepted`, `in_progress`, `finished` — and the
+     * order went on rendering as live work. #1574
+     */
+    "cancelled",
   ]),
 })
 

--- a/apps/backend/src/workflows/production-runs/__tests__/run-partner-status.unit.spec.ts
+++ b/apps/backend/src/workflows/production-runs/__tests__/run-partner-status.unit.spec.ts
@@ -1,0 +1,103 @@
+import {
+  aggregatePartnerStatus,
+  deriveRunPartnerStatus,
+} from "../lib/run-partner-status"
+
+/**
+ * #1574 — an admin cancels a production run and the order goes on rendering as
+ * live work. `deriveRunPartnerStatus` returned `undefined` for that case, and
+ * the mirror writes only truthy values, so `partner_status` was never cleared:
+ * it kept `accepted` / `in_progress` / `finished` forever.
+ *
+ * `undefined` meant "don't write" where it needed to mean "say it stopped" —
+ * the #1565 shape again, one absent value standing for several answers.
+ *
+ * The core `order.status` was always right (`RUN_TO_CORE_STATUS` maps
+ * cancelled → canceled). It is the sidecar the partner panels read that lied,
+ * which is why the order looked half-finished rather than cancelled.
+ */
+describe("deriveRunPartnerStatus", () => {
+  it("says cancelled when an admin cancels — it used to say nothing at all", () => {
+    // 🔴 The assertion that fails on the old code: `undefined`, which the
+    // caller reads as "leave the last value alone".
+    expect(deriveRunPartnerStatus({ status: "cancelled" })).toBe("cancelled")
+  })
+
+  it("still says declined when the PARTNER refused the work", () => {
+    // Both end the job; only one of them is the partner's doing, and a panel
+    // showing "declined" for an admin cancel accuses them of something they
+    // did not do.
+    expect(
+      deriveRunPartnerStatus({ status: "cancelled" }, { declined: true })
+    ).toBe("declined")
+  })
+
+  it("leaves the live vocabulary untouched", () => {
+    expect(deriveRunPartnerStatus({ status: "sent_to_partner" })).toBe("assigned")
+    expect(
+      deriveRunPartnerStatus({ status: "in_progress", accepted_at: new Date() })
+    ).toBe("accepted")
+    expect(
+      deriveRunPartnerStatus({ status: "in_progress", started_at: new Date() })
+    ).toBe("in_progress")
+    expect(
+      deriveRunPartnerStatus({ status: "in_progress", finished_at: new Date() })
+    ).toBe("finished")
+    expect(deriveRunPartnerStatus({ status: "completed" })).toBe("completed")
+  })
+
+  it("says nothing for a run no partner has been given yet", () => {
+    // draft / approved / pending_review are absent from §5 on purpose — there
+    // is no partner-facing progress to report, which is a different answer
+    // from "the work stopped".
+    expect(deriveRunPartnerStatus({ status: "draft" })).toBeUndefined()
+    expect(deriveRunPartnerStatus({ status: "approved" })).toBeUndefined()
+  })
+})
+
+describe("aggregatePartnerStatus", () => {
+  it("cancels the order only when EVERY run is cancelled", () => {
+    // ⚠️ The multi-run half of the same hole: the old code mapped each run and
+    // did `.filter(Boolean)`, so an all-cancelled order produced an empty list
+    // ⇒ undefined ⇒ no write, exactly as in the single-run case.
+    expect(
+      aggregatePartnerStatus([{ status: "cancelled" }, { status: "cancelled" }])
+    ).toBe("cancelled")
+  })
+
+  it("does not let one cancelled run drag a live order backwards", () => {
+    // 🔴 The counter-case, and the one that makes the fix safe to deploy. Four
+    // runs in flight and one cancelled is an order still being worked on. If
+    // "cancelled" joined the progress ordering it would sort below everything
+    // and retire an order mid-production.
+    expect(
+      aggregatePartnerStatus([
+        { status: "cancelled" },
+        { status: "in_progress", started_at: new Date() },
+      ])
+    ).toBe("in_progress")
+  })
+
+  it("does not call an undispatched order cancelled", () => {
+    // 🔴 Why the all-cancelled test reads `run.status` rather than counting
+    // derived values. A draft run also derives `undefined`, so "the derived
+    // list is empty" could mean "all cancelled" OR "nothing dispatched yet" —
+    // and retiring an order nobody has started is the worse of the two.
+    expect(
+      aggregatePartnerStatus([{ status: "draft" }, { status: "approved" }])
+    ).toBeUndefined()
+  })
+
+  it("still reports the least-advanced run of a live order", () => {
+    expect(
+      aggregatePartnerStatus([
+        { status: "in_progress", finished_at: new Date() },
+        { status: "sent_to_partner" },
+      ])
+    ).toBe("assigned")
+  })
+
+  it("says nothing for an order with no runs", () => {
+    expect(aggregatePartnerStatus([])).toBeUndefined()
+  })
+})

--- a/apps/backend/src/workflows/production-runs/dual-write-unified-run-order.ts
+++ b/apps/backend/src/workflows/production-runs/dual-write-unified-run-order.ts
@@ -15,6 +15,10 @@ import {
   setUnifiedOrderPartnerStatus,
 } from "../inventory_orders/dual-write-unified-order"
 import { pickDefaultCurrency } from "../../lib/resolve-store-currency"
+import {
+  aggregatePartnerStatus,
+  deriveRunPartnerStatus,
+} from "./lib/run-partner-status"
 
 // #342 T3.2 — best-effort projection of production runs onto the core `order`
 // entity (kind=design = "the order↔production_run link exists"; Chunk 6 retired
@@ -40,36 +44,6 @@ const RUN_TO_CORE_STATUS: Record<string, string> = {
   in_progress: "pending",
   completed: "completed",
   cancelled: "canceled",
-}
-
-// §5 — the shared assigned→accepted→in_progress→finished→completed
-// vocabulary. The legacy run enum collapses accepted/started/finished into
-// one "in_progress" value; the lifecycle timestamps disambiguate. approved/
-// draft/pending_review are absent on purpose (no partner work yet), and
-// cancelled only maps to "declined" when the cancel came from a partner
-// decline — an admin cancel leaves the last value untouched (§5 table
-// defines no value for it).
-const deriveRunPartnerStatus = (
-  run: any,
-  opts: { declined?: boolean } = {}
-): string | undefined => {
-  switch (run.status) {
-    case "sent_to_partner":
-      return "assigned"
-    case "in_progress":
-      if (run.finished_at) return "finished"
-      if (run.started_at) return "in_progress"
-      if (run.accepted_at) return "accepted"
-      // Partner self-serve runs are born in_progress with no lifecycle
-      // timestamps — the partner is already working on it.
-      return "in_progress"
-    case "completed":
-      return "completed"
-    case "cancelled":
-      return opts.declined ? "declined" : undefined
-    default:
-      return undefined
-  }
 }
 
 type ProjectionResult = {
@@ -375,26 +349,6 @@ const aggregateCoreStatus = (runs: any[]): string => {
 // #826 S3a — aggregate partner_status for a collated design work-order: the
 // LEAST-advanced non-empty per-run status along assigned→accepted→in_progress→
 // finished→completed (the order isn't "completed" until every line is).
-const PARTNER_STATUS_ORDER = [
-  "assigned",
-  "accepted",
-  "in_progress",
-  "finished",
-  "completed",
-]
-const aggregatePartnerStatus = (runs: any[]): string | undefined => {
-  const perRun = runs
-    .map((r) => deriveRunPartnerStatus(r))
-    .filter((s): s is string => Boolean(s))
-  if (!perRun.length) return undefined
-  let minIdx = PARTNER_STATUS_ORDER.length - 1
-  for (const s of perRun) {
-    const idx = PARTNER_STATUS_ORDER.indexOf(s)
-    if (idx >= 0 && idx < minIdx) minIdx = idx
-  }
-  return PARTNER_STATUS_ORDER[minIdx]
-}
-
 type CollatedProjectionResult = ProjectionResult & { line_count?: number }
 
 /**

--- a/apps/backend/src/workflows/production-runs/lib/run-partner-status.ts
+++ b/apps/backend/src/workflows/production-runs/lib/run-partner-status.ts
@@ -1,0 +1,83 @@
+/**
+ * §5 partner-facing work-progress vocabulary, derived from a production run.
+ *
+ * A pure module so the mapping can be unit-tested without booting a container.
+ * It had no coverage at all when #1574 was found.
+ */
+
+// §5 — the shared assigned→accepted→in_progress→finished→completed
+// vocabulary. The legacy run enum collapses accepted/started/finished into
+// one "in_progress" value; the lifecycle timestamps disambiguate. approved/
+// draft/pending_review are absent on purpose (no partner work yet).
+//
+// 🔴 A cancelled run says "cancelled" unless the PARTNER declined it, in which
+// case it says "declined". It used to return `undefined` for an admin cancel —
+// "§5 defines no value for it" — and the mirror writes only truthy values, so
+// `partner_status` was never cleared: it kept `accepted` / `in_progress` /
+// `finished` and the order went on rendering as live work indefinitely.
+// `undefined` meant "don't write" where it needed to mean "say it stopped".
+// Same shape as #1565, where one NULL meant three different things. #1574
+export const deriveRunPartnerStatus = (
+  run: any,
+  opts: { declined?: boolean } = {}
+): string | undefined => {
+  switch (run.status) {
+    case "sent_to_partner":
+      return "assigned"
+    case "in_progress":
+      if (run.finished_at) return "finished"
+      if (run.started_at) return "in_progress"
+      if (run.accepted_at) return "accepted"
+      // Partner self-serve runs are born in_progress with no lifecycle
+      // timestamps — the partner is already working on it.
+      return "in_progress"
+    case "completed":
+      return "completed"
+    case "cancelled":
+      return opts.declined ? "declined" : "cancelled"
+    default:
+      return undefined
+  }
+}
+
+const PARTNER_STATUS_ORDER = [
+  "assigned",
+  "accepted",
+  "in_progress",
+  "finished",
+  "completed",
+]
+
+/**
+ * The least-advanced partner status across a collated order's runs.
+ *
+ * 🔴 A cancelled run must not drag a live order backwards, and it must not be
+ * invisible either. It is excluded from the progress ordering — one cancelled
+ * run alongside four in flight leaves the order reading `in_progress` — and
+ * the order only reads `cancelled` when EVERY run is.
+ *
+ * That last test asks `run.status` directly rather than counting the derived
+ * values. `deriveRunPartnerStatus` returns `undefined` for draft / approved /
+ * pending_review too, so a `.filter(Boolean)` that came up empty could mean
+ * "all cancelled" OR "none dispatched yet" — and calling the second one
+ * cancelled would retire an order nobody has started. #1574
+ */
+export const aggregatePartnerStatus = (runs: any[]): string | undefined => {
+  if (!runs.length) return undefined
+
+  if (runs.every((r) => String(r?.status) === "cancelled")) {
+    return "cancelled"
+  }
+
+  const perRun = runs
+    .map((r) => deriveRunPartnerStatus(r))
+    .filter((s): s is string => Boolean(s))
+    .filter((s) => s !== "cancelled" && s !== "declined")
+  if (!perRun.length) return undefined
+  let minIdx = PARTNER_STATUS_ORDER.length - 1
+  for (const s of perRun) {
+    const idx = PARTNER_STATUS_ORDER.indexOf(s)
+    if (idx >= 0 && idx < minIdx) minIdx = idx
+  }
+  return PARTNER_STATUS_ORDER[minIdx]
+}

--- a/apps/partner-ui/src/lib/work-status.ts
+++ b/apps/partner-ui/src/lib/work-status.ts
@@ -12,6 +12,10 @@ export const PARTNER_STATUS_LABELS: Record<string, string> = {
   finished: "Finished",
   completed: "Completed",
   declined: "Declined",
+  // #1574 — an ADMIN cancel, as distinct from `declined`, which is the partner
+  // refusing the work. Both end the job; showing "Declined" for an admin cancel
+  // would accuse the partner of something they did not do.
+  cancelled: "Cancelled",
 }
 
 /** Resolve the partner work-status off the typed sidecar column. */


### PR DESCRIPTION
Closes part of #1574.

## The bug

`deriveRunPartnerStatus` returned `undefined` when an admin cancelled a run, and the mirror writes only truthy values:

```ts
if (partnerStatus) { await setUnifiedOrderPartnerStatus(...) }
```

So `partner_status` was **never cleared**. It kept whatever it last said — `assigned`, `accepted`, `in_progress`, `finished` — and the order went on rendering as live work indefinitely.

`undefined` meant *"don't write"* where it needed to mean *"say it stopped"*. Same shape as #1565, where one NULL stood for three different answers.

The core `order.status` was never wrong — both paths map `cancelled → canceled`. It is the **sidecar the partner panels read** that lied, which is why a cancelled order looked half-finished.

## What changed

| | |
|---|---|
| `unified_order_status.partner_status` | gains `cancelled`, distinct from `declined` (the PARTNER refusing). Showing "Declined" for an admin cancel accuses them of something they did not do. `list-partner-designs` already spoke this value; the sidecar could not. |
| `aggregatePartnerStatus` | the multi-run half of the same hole — it `.filter(Boolean)`-ed derived values, so an all-cancelled order gave an empty list ⇒ `undefined` ⇒ no write |
| a cancelled run among live ones | excluded from the progress ordering, so it cannot drag a live order backwards |
| `/admin/design-work-orders` | hides cancelled runs and stops counting them; `include_cancelled=true` brings them back |
| `lib/run-partner-status.ts` | the helpers extracted to a pure module — they had **no coverage at all** |

The all-cancelled test reads `run.status` directly rather than counting derived values: a draft run also derives `undefined`, so an empty derived list could equally mean "nothing dispatched yet", and retiring an order nobody has started is the worse of the two mistakes.

## Verification

- 9 unit cases; the two behaviour-change ones go **red** on the pre-fix logic, the other 7 are regression locks
- 1 integration case walking a two-run work-order through both cancels — **red** pre-fix
- `check:prod-build` green

## ⚠️ Before merging

- **Carries a migration.** #1573 merged minutes ago and is deploying. Do not merge this until that deploy finishes, or the migration gate diffs only the newest push and this one is stranded.
- **Symptom 2 of #1574 is NOT fixed here** and does not follow from this bug. A cancelled run is already refused by the policy service before any workflow signalling, so the run that produced *"Transaction of the workflow not found"* was live by every guard. [Details in the issue comment.](https://github.com/Jaal-Yantra-Textiles/v2/issues/1574#issuecomment-5434111197)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_0158wJMZ1DmjNxXf5uGuBrQD