### PR TITLE
feat(partner-ui): one table of payable work, and stop offering rows that cannot be submitted (#1571)

### DIFF
--- a/apps/partner-ui/src/routes/payment-submissions/payment-submission-create/payment-submission-create.tsx
+++ b/apps/partner-ui/src/routes/payment-submissions/payment-submission-create/payment-submission-create.tsx
@@ -2,14 +2,14 @@ import { useCallback, useMemo, useState } from "react"
 import { useNavigate } from "react-router-dom"
 import {
   Badge,
-  Button,
   Checkbox,
+  CommandBar,
   Container,
-  Heading,
   Input,
-  Tabs,
+  Table,
   Text,
   Textarea,
+  Tooltip,
   toast,
 } from "@medusajs/ui"
 
@@ -33,7 +33,21 @@ const getTaskCost = (t: PartnerAssignedTask): number =>
 
 export const PaymentSubmissionCreate = () => {
   const navigate = useNavigate()
-  const [activeTab, setActiveTab] = useState<"runs" | "tasks">("runs")
+  /**
+   * One table of payable WORK, filtered — not a tab per source.
+   *
+   * A partner is answering "what am I owed for?", and the answer is a mix: runs
+   * they finished and tasks they did. Splitting that across tabs made the total
+   * in the header the only place the two were ever added up, so the screen
+   * could show "0 items" on the tab you were looking at while you had picks on
+   * the other one.
+   *
+   * Tasks are NOT redundant with runs. Most hang off a run, but a partner can
+   * hold standalone ones, and this screen is the only place they can be billed.
+   */
+  const [typeFilter, setTypeFilter] = useState<"all" | "runs" | "tasks">("all")
+  /** Reveal the rows that cannot be submitted, greyed out, with the reason. */
+  const [showSubmitted, setShowSubmitted] = useState(false)
   const [selectedRunIds, setSelectedRunIds] = useState<Set<string>>(
     new Set()
   )
@@ -51,14 +65,51 @@ export const PaymentSubmissionCreate = () => {
   const { payable_runs = [], isPending: runsLoading } = usePartnerPayableRuns()
   const { tasks = [], isPending: tasksLoading } = usePartnerAssignedTasks()
 
-  // Filter to only clear and unknown runs (don't show already-billed)
-  const eligibleRuns = useMemo(
-    () =>
-      payable_runs.filter(
-        (r: PayableRun) => r.billing_status === "clear" || r.billing_status === "unknown"
-      ),
-    [payable_runs]
+  /**
+   * Why a run cannot be submitted right now, or null when it can.
+   *
+   * 🔴 `design_has_open_submission` is the one that used to get through. The
+   * endpoint computes it and this screen never read it, so a run whose design
+   * already sits in an open submission was offered, selected, and submitted —
+   * and the workflow refused the whole request with "Designs already in an
+   * active payment submission". A partner could not tell which row caused it,
+   * because nothing on the screen said any row was different.
+   *
+   * A payment line is keyed by DESIGN, so the block is per design, not per run:
+   * a second run of the same design is unbillable until the first submission is
+   * resolved, however clean that run looks on its own.
+   */
+  const runBlockedReason = useCallback(
+    (r: PayableRun): string | null => {
+      if (r.billing_status === "billed") {
+        return r.billed?.submission_id
+          ? `Already paid · ${r.billed.submission_id}`
+          : "Already paid"
+      }
+      if (r.design_has_open_submission) {
+        return "This design is already in an open submission"
+      }
+      return null
+    },
+    []
   )
+
+  const submittableRuns = useMemo(
+    () => payable_runs.filter((r: PayableRun) => !runBlockedReason(r)),
+    [payable_runs, runBlockedReason]
+  )
+
+  const blockedRuns = useMemo(
+    () => payable_runs.filter((r: PayableRun) => !!runBlockedReason(r)),
+    [payable_runs, runBlockedReason]
+  )
+
+  /**
+   * Only the submittable rows may ever be selected. Everything downstream —
+   * totals, validation, the payload — reads this, so a blocked row cannot reach
+   * the request even if it is on screen.
+   */
+  const eligibleRuns = submittableRuns
 
   const eligibleTasks = useMemo(
     () =>
@@ -90,21 +141,43 @@ export const PaymentSubmissionCreate = () => {
     })
   }, [])
 
-  const selectAllRuns = useCallback(() => {
-    if (selectedRunIds.size === eligibleRuns.length) {
-      setSelectedRunIds(new Set())
-    } else {
-      setSelectedRunIds(new Set(eligibleRuns.map((r: PayableRun) => r.run_id)))
-    }
-  }, [eligibleRuns, selectedRunIds.size])
+  /**
+   * Select-all acts on what is ON SCREEN, not on everything selectable.
+   *
+   * There used to be one per tab. With a single filtered table that would be a
+   * trap: pressing it while filtered to Tasks and having it also tick every run
+   * would bill work the partner never looked at, and the command bar total is
+   * the only place they would notice.
+   */
+  const visibleSelectableRuns = useMemo(
+    () => (typeFilter === "tasks" ? [] : eligibleRuns),
+    [typeFilter, eligibleRuns]
+  )
+  const visibleSelectableTasks = useMemo(
+    () => (typeFilter === "runs" ? [] : eligibleTasks),
+    [typeFilter, eligibleTasks]
+  )
 
-  const selectAllTasks = useCallback(() => {
-    if (selectedTaskIds.size === eligibleTasks.length) {
+  const allVisibleSelected =
+    visibleSelectableRuns.length + visibleSelectableTasks.length > 0 &&
+    visibleSelectableRuns.every((r: PayableRun) => selectedRunIds.has(r.run_id)) &&
+    visibleSelectableTasks.every((t: PartnerAssignedTask) =>
+      selectedTaskIds.has(t.id)
+    )
+
+  const toggleSelectAllVisible = useCallback(() => {
+    if (allVisibleSelected) {
+      setSelectedRunIds(new Set())
       setSelectedTaskIds(new Set())
-    } else {
-      setSelectedTaskIds(new Set(eligibleTasks.map((t) => t.id)))
+      return
     }
-  }, [eligibleTasks, selectedTaskIds.size])
+    setSelectedRunIds(
+      new Set(visibleSelectableRuns.map((r: PayableRun) => r.run_id))
+    )
+    setSelectedTaskIds(
+      new Set(visibleSelectableTasks.map((t: PartnerAssignedTask) => t.id))
+    )
+  }, [allVisibleSelected, visibleSelectableRuns, visibleSelectableTasks])
 
   // ─── Cost helpers ───────────────────────────────────────────────────
   const getEffectiveRunQuantity = useCallback(
@@ -199,6 +272,64 @@ export const PaymentSubmissionCreate = () => {
     selectedTaskIds,
     getEffectiveTaskCost,
   ])
+
+  const clearSelection = useCallback(() => {
+    setSelectedRunIds(new Set())
+    setSelectedTaskIds(new Set())
+  }, [])
+
+  // ─── Rows ───────────────────────────────────────────────────────────
+  const isLoading = runsLoading || tasksLoading
+
+  /**
+   * One list, runs and tasks together, in the order a partner reads them.
+   *
+   * Blocked rows are appended rather than interleaved: they cannot be acted on,
+   * so putting them among the selectable ones would make the list longer
+   * without making it more useful. They only appear at all when asked for.
+   */
+  type Row =
+    | { kind: "run"; run: PayableRun }
+    | { kind: "task"; task: PartnerAssignedTask }
+
+  const visibleRows = useMemo((): Row[] => {
+    const rows: Row[] = []
+    if (typeFilter !== "tasks") {
+      rows.push(...eligibleRuns.map((run: PayableRun) => ({ kind: "run" as const, run })))
+    }
+    if (typeFilter !== "runs") {
+      rows.push(
+        ...eligibleTasks.map((task: PartnerAssignedTask) => ({
+          kind: "task" as const,
+          task,
+        }))
+      )
+    }
+    if (showSubmitted && typeFilter !== "tasks") {
+      rows.push(...blockedRuns.map((run: PayableRun) => ({ kind: "run" as const, run })))
+    }
+    return rows
+  }, [typeFilter, eligibleRuns, eligibleTasks, showSubmitted, blockedRuns])
+
+  /**
+   * 🔑 An empty table must say WHICH kind of empty it is. "Nothing to bill" and
+   * "nothing of the kind you filtered to" are different answers, and a partner
+   * who has just filtered to Tasks and sees the generic message concludes their
+   * finished runs have vanished.
+   */
+  const emptyMessage = useMemo(() => {
+    if (typeFilter === "runs") {
+      return blockedRuns.length && !showSubmitted
+        ? `No runs left to bill — ${blockedRuns.length} are already submitted. Tick "Show already submitted" to see them.`
+        : "No payable production runs yet. Runs appear here once you complete them."
+    }
+    if (typeFilter === "tasks") {
+      return "No payable tasks. Completed tasks that are not part of a run appear here."
+    }
+    return blockedRuns.length && !showSubmitted
+      ? `Nothing left to bill — ${blockedRuns.length} item(s) are already submitted. Tick "Show already submitted" to see them.`
+      : "Nothing to bill yet. Completed runs and tasks appear here."
+  }, [typeFilter, blockedRuns.length, showSubmitted])
 
   // ─── Submit ─────────────────────────────────────────────────────────
   const handleSubmit = async () => {
@@ -310,25 +441,8 @@ export const PaymentSubmissionCreate = () => {
           <div>
             <RouteFocusModal.Title>New Payment Submission</RouteFocusModal.Title>
             <RouteFocusModal.Description>
-              Bundle completed designs or tasks into a payment request
+              Pick the runs and tasks you want paid for
             </RouteFocusModal.Description>
-          </div>
-          <div className="flex items-center gap-3">
-            {totalSelected > 0 && (
-              <Text className="text-ui-fg-subtle">
-                {totalSelected} item{totalSelected !== 1 ? "s" : ""} ={" "}
-                <span className="font-semibold text-ui-fg-base">
-                  INR {totalAmount.toLocaleString()}
-                </span>
-              </Text>
-            )}
-            <Button
-              onClick={handleSubmit}
-              isLoading={isCreating}
-              disabled={totalSelected === 0}
-            >
-              Submit for Payment
-            </Button>
           </div>
         </div>
       </RouteFocusModal.Header>
@@ -341,8 +455,19 @@ export const PaymentSubmissionCreate = () => {
           header, so the form still "worked" — you just couldn't see or pick
           anything past the fold). `min-h-0` lets the flex child actually shrink
           below its content height, which is what makes the scroll take effect. */}
-      <RouteFocusModal.Body className="flex min-h-0 flex-1 flex-col gap-y-6 overflow-y-auto p-6 md:p-16">
-        <div className="mx-auto w-full max-w-[720px]">
+      <RouteFocusModal.Body className="flex min-h-0 flex-1 flex-col gap-y-6 overflow-y-auto p-6 md:px-10 md:py-8">
+        {/*
+          Full width, not the 720px reading column this used to be.
+
+          720px is right for a form you read top-to-bottom, which is what this
+          screen was when it was a stack of cards. It is wrong for a table: five
+          columns — work, qty, rate, amount, and a checkbox — inside 720px means
+          the work column truncates the design name and the number inputs sit on
+          top of each other, on a modal that is already occupying the whole
+          screen. The container the content is in should be as wide as the thing
+          the user opened.
+        */}
+        <div className="w-full">
           {/* Notes */}
           <div className="mb-6">
             <Text size="small" weight="plus" className="mb-2">
@@ -356,457 +481,351 @@ export const PaymentSubmissionCreate = () => {
             />
           </div>
 
-          <Tabs
-            value={activeTab}
-            onValueChange={(v) => setActiveTab(v as "runs" | "tasks")}
-          >
-            <Tabs.List>
-              <Tabs.Trigger value="runs">
-                Production Runs{" "}
-                <Badge size="2xsmall" color="grey" className="ml-2">
-                  {eligibleRuns.length}
-                </Badge>
-                {selectedRunIds.size > 0 && (
-                  <Badge size="2xsmall" color="green" className="ml-1">
-                    {selectedRunIds.size} picked
+          {/* ── Filter ────────────────────────────────────────────── */}
+          <div className="mb-3 flex flex-wrap items-center justify-between gap-3">
+            <div className="flex items-center gap-1 rounded-lg bg-ui-bg-subtle p-1">
+              {(
+                [
+                  ["all", "All", eligibleRuns.length + eligibleTasks.length],
+                  ["runs", "Runs", eligibleRuns.length],
+                  ["tasks", "Tasks", eligibleTasks.length],
+                ] as const
+              ).map(([value, label, count]) => (
+                <button
+                  key={value}
+                  type="button"
+                  role="tab"
+                  aria-selected={typeFilter === value}
+                  data-state={typeFilter === value ? "active" : "inactive"}
+                  onClick={() => setTypeFilter(value)}
+                  className={
+                    typeFilter === value
+                      ? "txt-compact-small-plus rounded-md bg-ui-bg-base px-3 py-1 shadow-elevation-card-rest"
+                      : "txt-compact-small rounded-md px-3 py-1 text-ui-fg-subtle"
+                  }
+                >
+                  {label}
+                  <Badge size="2xsmall" color="grey" className="ml-2">
+                    {count}
                   </Badge>
-                )}
-              </Tabs.Trigger>
-              <Tabs.Trigger value="tasks">
-                Tasks{" "}
-                <Badge size="2xsmall" color="grey" className="ml-2">
-                  {eligibleTasks.length}
-                </Badge>
-                {selectedTaskIds.size > 0 && (
-                  <Badge size="2xsmall" color="green" className="ml-1">
-                    {selectedTaskIds.size} picked
-                  </Badge>
-                )}
-              </Tabs.Trigger>
-            </Tabs.List>
+                </button>
+              ))}
+            </div>
 
-            <Tabs.Content value="runs" className="mt-4">
-              <RunsPanel
-                eligibleRuns={eligibleRuns}
-                isLoading={runsLoading}
-                selectedIds={selectedRunIds}
-                onToggle={toggleRun}
-                onSelectAll={selectAllRuns}
-                quantities={runQuantities}
-                onQuantityChange={handleRunQuantityChange}
-                unitAmounts={runUnitAmounts}
-                onUnitAmountChange={handleRunUnitAmountChange}
-                getEffectiveQuantity={getEffectiveRunQuantity}
-                getEffectiveUnitAmount={getEffectiveRunUnitAmount}
-              />
-            </Tabs.Content>
+            {blockedRuns.length > 0 && (
+              <label className="flex items-center gap-2 text-ui-fg-subtle txt-compact-small">
+                <Checkbox
+                  checked={showSubmitted}
+                  onCheckedChange={(v) => setShowSubmitted(!!v)}
+                  aria-label="Show already submitted"
+                />
+                Show already submitted ({blockedRuns.length})
+              </label>
+            )}
+          </div>
 
-            <Tabs.Content value="tasks" className="mt-4">
-              <TasksPanel
-                eligibleTasks={eligibleTasks}
-                isLoading={tasksLoading}
-                selectedIds={selectedTaskIds}
-                onToggle={toggleTask}
-                onSelectAll={selectAllTasks}
-                costOverrides={taskCostOverrides}
-                onCostChange={handleTaskCostChange}
-                getEffectiveCost={getEffectiveTaskCost}
-              />
-            </Tabs.Content>
-          </Tabs>
+          {/* ── One table of payable work ──────────────────────────── */}
+          {isLoading && (
+            <Container className="p-4">
+              <Text size="small" className="text-ui-fg-subtle">
+                Loading your payable work…
+              </Text>
+            </Container>
+          )}
+
+          {!isLoading && visibleRows.length === 0 && (
+            <Container className="p-4">
+              <Text size="small" className="text-ui-fg-subtle">
+                {emptyMessage}
+              </Text>
+            </Container>
+          )}
+
+          {!isLoading && visibleRows.length > 0 && (
+          <Container className="overflow-x-auto p-0">
+            <Table>
+              <Table.Header>
+                <Table.Row>
+                  <Table.HeaderCell className="w-[44px]">
+                    <Checkbox
+                      checked={allVisibleSelected}
+                      onCheckedChange={toggleSelectAllVisible}
+                      aria-label="Select all shown"
+                    />
+                  </Table.HeaderCell>
+                  <Table.HeaderCell>Work</Table.HeaderCell>
+                  <Table.HeaderCell className="text-right">Qty</Table.HeaderCell>
+                  <Table.HeaderCell className="text-right">Rate</Table.HeaderCell>
+                  <Table.HeaderCell className="text-right">Amount</Table.HeaderCell>
+                </Table.Row>
+              </Table.Header>
+              <Table.Body>
+                {visibleRows.map((row) =>
+                  row.kind === "run" ? (
+                    <RunRow
+                      key={row.run.run_id}
+                      run={row.run}
+                      blockedReason={runBlockedReason(row.run)}
+                      selected={selectedRunIds.has(row.run.run_id)}
+                      onToggle={toggleRun}
+                      quantity={getEffectiveRunQuantity(row.run)}
+                      unitAmount={getEffectiveRunUnitAmount(row.run)}
+                      onQuantityChange={handleRunQuantityChange}
+                      onUnitAmountChange={handleRunUnitAmountChange}
+                    />
+                  ) : (
+                    <TaskRow
+                      key={row.task.id}
+                      task={row.task}
+                      selected={selectedTaskIds.has(row.task.id)}
+                      onToggle={toggleTask}
+                      cost={getEffectiveTaskCost(row.task)}
+                      onCostChange={handleTaskCostChange}
+                    />
+                  )
+                )}
+              </Table.Body>
+            </Table>
+          </Container>
+          )}
         </div>
       </RouteFocusModal.Body>
+
+      {/*
+        The command bar is where the selection lives now.
+        Before, the running total and Submit sat in the modal HEADER while the
+        list was tabbed below it — so the only place runs and tasks were ever
+        added together was off-screen from whichever tab you were on, and the
+        count could read zero while you had picks on the other tab. One list,
+        one selection, one total, stated against the rows it came from.
+      */}
+      <CommandBar open={totalSelected > 0}>
+        <CommandBar.Bar>
+          <CommandBar.Value>
+            <span data-testid="submission-total">
+              {totalSelected} selected · INR {totalAmount.toLocaleString()}
+            </span>
+          </CommandBar.Value>
+          <CommandBar.Seperator />
+          <CommandBar.Command
+            action={clearSelection}
+            label="Clear"
+            shortcut="c"
+          />
+          <CommandBar.Seperator />
+          <CommandBar.Command
+            action={handleSubmit}
+            label="Submit for payment"
+            shortcut="s"
+            disabled={isCreating}
+          />
+        </CommandBar.Bar>
+      </CommandBar>
     </RouteFocusModal>
   )
 }
 
-// ─── Runs panel ───────────────────────────────────────────────────────
-const RunsPanel = ({
-  eligibleRuns,
-  isLoading,
-  selectedIds,
-  onToggle,
-  onSelectAll,
-  quantities,
-  onQuantityChange,
-  unitAmounts,
-  onUnitAmountChange,
-  getEffectiveQuantity,
-  getEffectiveUnitAmount,
-}: {
-  eligibleRuns: PayableRun[]
-  isLoading: boolean
-  selectedIds: Set<string>
-  onToggle: (id: string) => void
-  onSelectAll: () => void
-  quantities: Record<string, number>
-  onQuantityChange: (id: string, value: string) => void
-  unitAmounts: Record<string, number>
-  onUnitAmountChange: (id: string, value: string) => void
-  getEffectiveQuantity: (run: PayableRun) => number
-  getEffectiveUnitAmount: (run: PayableRun) => number
-}) => {
-  if (isLoading) {
-    return (
-      <Container className="p-8">
-        <Text className="text-ui-fg-subtle text-center">
-          Loading production runs...
-        </Text>
-      </Container>
-    )
-  }
+// ─── Rows ─────────────────────────────────────────────────────────────
 
-  if (!eligibleRuns.length) {
-    return (
-      <Container className="p-8">
-        <Text className="text-ui-fg-subtle text-center">
-          No payable production runs. Production runs that have been completed
-          by the partner will appear here.
-        </Text>
-      </Container>
-    )
-  }
-
-  return (
-    <div className="flex flex-col gap-y-2">
-      <div className="mb-1 flex items-center justify-between">
-        <Heading level="h3">{eligibleRuns.length} eligible</Heading>
-        <Button variant="secondary" size="small" onClick={onSelectAll}>
-          {selectedIds.size === eligibleRuns.length
-            ? "Deselect All"
-            : "Select All"}
-        </Button>
-      </div>
-      {eligibleRuns.map((run: PayableRun) => {
-        const isSelected = selectedIds.has(run.run_id)
-        const effectiveQuantity = getEffectiveQuantity(run)
-        const effectiveUnitAmount = getEffectiveUnitAmount(run)
-
-        return (
-          <Container
-            key={run.run_id}
-            data-run-id={run.run_id}
-            className={`p-4 transition ${
-              isSelected ? "ring-2 ring-ui-border-interactive" : ""
-            }`}
-          >
-            <div className="flex items-center gap-3">
-              <div
-                className="cursor-pointer"
-                onClick={() => onToggle(run.run_id)}
-              >
-                <Checkbox checked={isSelected} />
-              </div>
-              <div
-                className="flex-1 min-w-0 cursor-pointer"
-                onClick={() => onToggle(run.run_id)}
-              >
-                <div className="flex items-center gap-2">
-                  <Text weight="plus" className="truncate">
-                    {run.design_name || "Unnamed design"}
-                  </Text>
-                  <Badge color="grey" size="2xsmall">
-                    {run.quantity_basis === "produced"
-                      ? `${run.produced_quantity} made`
-                      : `${run.ordered_quantity} ordered`}
-                  </Badge>
-                  {run.billing_status === "unknown" && (
-                    <Badge color="orange" size="2xsmall">
-                      Unknown billing
-                    </Badge>
-                  )}
-                </div>
-                <div className="flex items-center gap-4 mt-1">
-                  <Text size="small" className="text-ui-fg-subtle">
-                    Completed {new Date(run.completed_at || "").toLocaleDateString()}
-                  </Text>
-                  <Text
-                    size="small"
-                    className="text-ui-fg-muted font-mono"
-                  >
-                    {/*
-                      🔴 The TAIL of the id, not the head. `slice(0, 12)` renders
-                      "prod_run_01K…" for every single run: the `prod_run_`
-                      prefix eats 9 characters and a ULID's leading digits are a
-                      TIMESTAMP, so runs created in the same era are identical
-                      there. A partner with two completed runs of one design saw
-                      two cards bearing the same string — and that is precisely
-                      the case that matters, since runs of one design collapse
-                      into a single payment line whose quantity is their sum.
-
-                      The trailing characters are the random component and
-                      always differ. `title` carries the full id for anyone who
-                      needs to quote it.
-                    */}
-                    <span title={run.run_id}>…{run.run_id.slice(-8)}</span>
-                  </Text>
-                </div>
-              </div>
-              <RunCostInput
-                run={run}
-                quantity={quantities[run.run_id]}
-                unitAmount={unitAmounts[run.run_id]}
-                onQuantityChange={onQuantityChange}
-                onUnitAmountChange={onUnitAmountChange}
-                effectiveQuantity={effectiveQuantity}
-                effectiveUnitAmount={effectiveUnitAmount}
-              />
-            </div>
-          </Container>
-        )
-      })}
-    </div>
-  )
-}
-
-// ─── Tasks panel ──────────────────────────────────────────────────────
-const TasksPanel = ({
-  eligibleTasks,
-  isLoading,
-  selectedIds,
-  onToggle,
-  onSelectAll,
-  costOverrides,
-  onCostChange,
-  getEffectiveCost,
-}: {
-  eligibleTasks: PartnerAssignedTask[]
-  isLoading: boolean
-  selectedIds: Set<string>
-  onToggle: (id: string) => void
-  onSelectAll: () => void
-  costOverrides: Record<string, number>
-  onCostChange: (id: string, value: string) => void
-  getEffectiveCost: (t: PartnerAssignedTask) => number
-}) => {
-  if (isLoading) {
-    return (
-      <Container className="p-8">
-        <Text className="text-ui-fg-subtle text-center">
-          Loading tasks...
-        </Text>
-      </Container>
-    )
-  }
-
-  if (!eligibleTasks.length) {
-    return (
-      <Container className="p-8">
-        <Text className="text-ui-fg-subtle text-center">
-          No eligible tasks. Only completed tasks with a cost set can be
-          submitted for payment.
-        </Text>
-      </Container>
-    )
-  }
-
-  return (
-    <div className="flex flex-col gap-y-2">
-      <div className="mb-1 flex items-center justify-between">
-        <Heading level="h3">{eligibleTasks.length} eligible</Heading>
-        <Button variant="secondary" size="small" onClick={onSelectAll}>
-          {selectedIds.size === eligibleTasks.length
-            ? "Deselect All"
-            : "Select All"}
-        </Button>
-      </div>
-      {eligibleTasks.map((task) => {
-        const isSelected = selectedIds.has(task.id)
-        const defaultCost = Number(task.actual_cost ?? task.estimated_cost ?? 0)
-        const effectiveCost = getEffectiveCost(task)
-
-        return (
-          <Container
-            key={task.id}
-            className={`p-4 transition ${
-              isSelected ? "ring-2 ring-ui-border-interactive" : ""
-            }`}
-          >
-            <div className="flex items-center gap-3">
-              <div
-                className="cursor-pointer"
-                onClick={() => onToggle(task.id)}
-              >
-                <Checkbox checked={isSelected} />
-              </div>
-              <div
-                className="flex-1 min-w-0 cursor-pointer"
-                onClick={() => onToggle(task.id)}
-              >
-                <div className="flex items-center gap-2">
-                  <Text weight="plus" className="truncate">
-                    {task.title || "Untitled task"}
-                  </Text>
-                  <Badge color="green" size="2xsmall">
-                    {task.status}
-                  </Badge>
-                  {task.priority && (
-                    <Badge
-                      color={
-                        task.priority === "high"
-                          ? "orange"
-                          : task.priority === "medium"
-                          ? "blue"
-                          : "grey"
-                      }
-                      size="2xsmall"
-                    >
-                      {task.priority}
-                    </Badge>
-                  )}
-                </div>
-                <div className="flex items-center gap-4 mt-1">
-                  {task.completed_at && (
-                    <Text size="small" className="text-ui-fg-subtle">
-                      Completed{" "}
-                      {new Date(task.completed_at).toLocaleDateString()}
-                    </Text>
-                  )}
-                  <Text
-                    size="small"
-                    className="text-ui-fg-muted font-mono"
-                  >
-                    {task.id.slice(0, 12)}...
-                  </Text>
-                </div>
-              </div>
-              <CostInput
-                id={task.id}
-                defaultCost={defaultCost}
-                override={costOverrides[task.id]}
-                onChange={onCostChange}
-                effectiveCost={effectiveCost}
-              />
-            </div>
-          </Container>
-        )
-      })}
-    </div>
-  )
-}
-
-/**
- * The task cost input. Tasks are billed as a single line total, so this stays
- * the simple one-box control.
- *
- * 🔴 Restored after the runs rewrite deleted it: `RunCostInput` replaced it for
- * DESIGN lines, but `TasksPanel` still called `CostInput`. esbuild does not
- * type-check, so the bundle built cleanly and the Tasks tab threw a
- * ReferenceError the moment it rendered. tsc said so; nothing was reading tsc.
- */
-const CostInput = ({
-  id,
-  defaultCost,
-  override,
+const NumberCell = ({
+  value,
+  placeholder,
   onChange,
-  effectiveCost,
+  label,
+  disabled,
 }: {
-  id: string
-  defaultCost: number
-  override?: number
-  onChange: (id: string, value: string) => void
-  effectiveCost: number
-}) => {
-  return (
-    <div className="flex flex-col items-end gap-1 shrink-0">
-      <div className="flex items-center gap-2">
-        <Text size="xsmall" className="text-ui-fg-muted whitespace-nowrap">
-          INR
-        </Text>
-        <Input
-          type="number"
-          size="small"
-          className="w-28 text-right"
-          placeholder={defaultCost ? String(defaultCost) : "0"}
-          value={
-            override != null
-              ? String(override)
-              : defaultCost
-                ? String(defaultCost)
-                : ""
-          }
-          onChange={(e) => onChange(id, e.target.value)}
-          onClick={(e) => e.stopPropagation()}
-        />
-      </div>
-      {defaultCost > 0 && effectiveCost !== defaultCost && (
-        <Text size="xsmall" className="text-ui-fg-muted">
-          was {defaultCost.toLocaleString()}
-        </Text>
-      )}
-    </div>
-  )
-}
+  value?: number
+  placeholder: string
+  onChange: (v: string) => void
+  label: string
+  disabled?: boolean
+}) => (
+  <Input
+    type="number"
+    size="small"
+    className="w-24 text-right"
+    aria-label={label}
+    placeholder={placeholder}
+    disabled={disabled}
+    value={value != null ? String(value) : ""}
+    onChange={(e) => onChange(e.target.value)}
+    onClick={(e) => e.stopPropagation()}
+  />
+)
 
-// ─── Run cost input ───────────────────────────────────────────────────
-const RunCostInput = ({
+const RunRow = ({
   run,
+  blockedReason,
+  selected,
+  onToggle,
   quantity,
   unitAmount,
   onQuantityChange,
   onUnitAmountChange,
-  effectiveQuantity,
-  effectiveUnitAmount,
 }: {
   run: PayableRun
-  quantity?: number
-  unitAmount?: number
+  blockedReason: string | null
+  selected: boolean
+  onToggle: (id: string) => void
+  quantity: number
+  unitAmount: number
   onQuantityChange: (id: string, value: string) => void
   onUnitAmountChange: (id: string, value: string) => void
-  effectiveQuantity: number
-  effectiveUnitAmount: number
 }) => {
-  const total = effectiveQuantity * effectiveUnitAmount
+  const blocked = !!blockedReason
+  const total = quantity * unitAmount
 
   return (
-    <div className="flex flex-col items-end gap-2 shrink-0 w-60">
-      <div className="flex gap-2 w-full">
-        <div className="flex-1 flex flex-col items-end gap-1">
-          <Text size="xsmall" className="text-ui-fg-muted">
-            Qty
+    <Table.Row
+      data-run-id={run.run_id}
+      data-testid="payable-run-row"
+      className={blocked ? "opacity-60" : undefined}
+    >
+      <Table.Cell>
+        <Checkbox
+          checked={selected}
+          disabled={blocked}
+          onCheckedChange={() => !blocked && onToggle(run.run_id)}
+          aria-label={`Select ${run.design_name || run.run_id}`}
+        />
+      </Table.Cell>
+
+      <Table.Cell>
+        <div className="flex items-center gap-2">
+          <Text weight="plus" className="truncate">
+            {run.design_name || "Unnamed work"}
           </Text>
-          <Input
-            type="number"
-            size="small"
-            className="w-full text-right"
-            placeholder={String(run.payable_quantity)}
-            value={quantity != null ? String(quantity) : ""}
-            onChange={(e) => onQuantityChange(run.run_id, e.target.value)}
-            onClick={(e) => e.stopPropagation()}
-          />
+          <Badge color="blue" size="2xsmall">
+            Run
+          </Badge>
+          {run.billing_status === "unknown" && !blocked && (
+            <Tooltip content="An earlier payout for this design did not record which runs it covered, so we cannot tell whether these pieces were already paid for.">
+              <Badge color="orange" size="2xsmall">
+                Unknown billing
+              </Badge>
+            </Tooltip>
+          )}
+          {blocked && (
+            <Badge color="grey" size="2xsmall">
+              {blockedReason}
+            </Badge>
+          )}
         </div>
-        <div className="flex-1 flex flex-col items-end gap-1">
-          <Text size="xsmall" className="text-ui-fg-muted">
-            Rate (₹)
+        <div className="mt-1 flex items-center gap-3">
+          <Text size="small" className="text-ui-fg-subtle">
+            {run.quantity_basis === "produced"
+              ? `${run.produced_quantity} made of ${run.ordered_quantity} ordered`
+              : `${run.ordered_quantity} ordered`}
           </Text>
-          <Input
-            type="number"
-            size="small"
-            className="w-full text-right"
-            placeholder={String(run.unit_amount)}
-            value={unitAmount != null ? String(unitAmount) : ""}
-            onChange={(e) => onUnitAmountChange(run.run_id, e.target.value)}
-            onClick={(e) => e.stopPropagation()}
-          />
+          {/*
+            🔴 The TAIL of the id, not the head. `prod_run_` eats 9 characters
+            and a ULID's leading digits are a TIMESTAMP, so every run of one
+            design renders the same "prod_run_01K…" — and that is exactly the
+            case that matters, since runs of one design collapse into a single
+            payment line whose quantity is their sum.
+          */}
+          <Text size="small" className="font-mono text-ui-fg-muted">
+            <span title={run.run_id}>…{run.run_id.slice(-8)}</span>
+          </Text>
         </div>
-      </div>
-      <div className="w-full text-right">
-        <Text size="small" className="text-ui-fg-base font-semibold">
-          Total: ₹{total.toLocaleString()}
+      </Table.Cell>
+
+      <Table.Cell className="text-right">
+        <NumberCell
+          label={`Quantity for ${run.design_name || run.run_id}`}
+          placeholder={String(run.payable_quantity)}
+          value={quantity !== run.payable_quantity ? quantity : undefined}
+          disabled={blocked}
+          onChange={(v) => onQuantityChange(run.run_id, v)}
+        />
+      </Table.Cell>
+
+      <Table.Cell className="text-right">
+        <NumberCell
+          label={`Rate for ${run.design_name || run.run_id}`}
+          placeholder={String(run.unit_amount)}
+          value={unitAmount !== run.unit_amount ? unitAmount : undefined}
+          disabled={blocked}
+          onChange={(v) => onUnitAmountChange(run.run_id, v)}
+        />
+      </Table.Cell>
+
+      <Table.Cell className="text-right">
+        <Text
+          size="small"
+          weight="plus"
+          data-testid={`run-amount-${run.run_id}`}
+        >
+          {quantity.toLocaleString()} × {unitAmount.toLocaleString()} ={" "}
+          {total.toLocaleString()}
         </Text>
-      </div>
-      {run.payable_quantity !== effectiveQuantity && (
-        <Text size="xsmall" className="text-ui-fg-muted">
-          was {run.payable_quantity} units
-        </Text>
-      )}
-      {run.unit_amount !== effectiveUnitAmount && (
-        <Text size="xsmall" className="text-ui-fg-muted">
-          was ₹{run.unit_amount.toLocaleString()}/unit
-        </Text>
-      )}
-    </div>
+      </Table.Cell>
+    </Table.Row>
   )
 }
+
+const TaskRow = ({
+  task,
+  selected,
+  onToggle,
+  cost,
+  onCostChange,
+}: {
+  task: PartnerAssignedTask
+  selected: boolean
+  onToggle: (id: string) => void
+  cost: number
+  onCostChange: (id: string, value: string) => void
+}) => (
+  <Table.Row data-task-id={task.id} data-testid="payable-task-row">
+    <Table.Cell>
+      <Checkbox
+        checked={selected}
+        onCheckedChange={() => onToggle(task.id)}
+        aria-label={`Select ${task.title || task.id}`}
+      />
+    </Table.Cell>
+
+    <Table.Cell>
+      <div className="flex items-center gap-2">
+        <Text weight="plus" className="truncate">
+          {task.title || "Untitled task"}
+        </Text>
+        <Badge color="purple" size="2xsmall">
+          Task
+        </Badge>
+      </div>
+      <Text size="small" className="mt-1 text-ui-fg-subtle">
+        {task.status}
+      </Text>
+    </Table.Cell>
+
+    {/*
+      A task is one piece of work, not a quantity × rate. Stating "1" rather
+      than leaving the cell blank keeps the Amount column readable as the same
+      arithmetic in every row.
+    */}
+    <Table.Cell className="text-right">
+      <Text size="small" className="text-ui-fg-muted">
+        1
+      </Text>
+    </Table.Cell>
+
+    <Table.Cell className="text-right">
+      <NumberCell
+        label={`Cost for ${task.title || task.id}`}
+        placeholder="0"
+        value={cost || undefined}
+        onChange={(v) => onCostChange(task.id, v)}
+      />
+    </Table.Cell>
+
+    <Table.Cell className="text-right">
+      <Text size="small" weight="plus" data-testid={`task-amount-${task.id}`}>
+        {cost.toLocaleString()}
+      </Text>
+    </Table.Cell>
+  </Table.Row>
+)
 
 export const Component = PaymentSubmissionCreate

--- a/e2e/specs/partner-payment-submission-runs.spec.ts
+++ b/e2e/specs/partner-payment-submission-runs.spec.ts
@@ -121,7 +121,9 @@ test.describe("Partner payment submission from runs @partnerui (#1571)", () => {
   test("lists completed RUNS with their produced quantity and agreed rate", async ({
     page,
   }) => {
-    const tab = page.getByRole("tab", { name: /production runs/i })
+    // One table with an All/Runs/Tasks filter — the per-source tabs are gone
+    // (#1571). "Runs" narrows it; "All" (the default) already shows them.
+    const tab = page.getByRole("tab", { name: /^runs$/i })
     await expect(tab).toBeVisible({ timeout: 30_000 })
     await tab.click()
 
@@ -146,7 +148,7 @@ test.describe("Partner payment submission from runs @partnerui (#1571)", () => {
   test("shows a run with no agreed rate rather than hiding or zero-billing it", async ({
     page,
   }) => {
-    await page.getByRole("tab", { name: /production runs/i }).click()
+    await page.getByRole("tab", { name: /^runs$/i }).click()
     const card = runCard(page, seed.unpricedRunId)
     await expect(card).toBeVisible({ timeout: 30_000 })
     await expect(card).toContainText("2 made")
@@ -164,13 +166,17 @@ test.describe("Partner payment submission from runs @partnerui (#1571)", () => {
   test("submits a payout that records the run and bills quantity x rate", async ({
     page,
   }) => {
-    await page.getByRole("tab", { name: /production runs/i }).click()
+    await page.getByRole("tab", { name: /^runs$/i }).click()
     const card = runCard(page, seed.partnerBillableRunId)
     await expect(card).toBeVisible({ timeout: 30_000 })
     await card.getByRole("checkbox").click()
 
-    // The header total is the screen's own arithmetic: 4 x 1200.
-    await expect(page.getByText(/INR\s*4,?800/)).toBeVisible()
+    // The command bar's own arithmetic: 4 x 1200. It lives at the bottom of
+    // the screen now, not in the modal header (#1571) — and it only appears
+    // once something is selected, so this also asserts the click landed.
+    await expect(page.getByTestId("submission-total")).toContainText(
+      /INR\s*4,?800/
+    )
 
     const [response] = await Promise.all([
       page.waitForResponse(
@@ -208,7 +214,7 @@ test.describe("Partner payment submission from runs @partnerui (#1571)", () => {
   test("sums the quantity when two runs of one design are billed together", async ({
     page,
   }) => {
-    await page.getByRole("tab", { name: /production runs/i }).click()
+    await page.getByRole("tab", { name: /^runs$/i }).click()
 
     const a = runCard(page, seed.partnerSumRunAId)
     await expect(a).toBeVisible({ timeout: 30_000 })


### PR DESCRIPTION
The partner payment submission screen was two tabs of cards inside a 720px column. Now it is one filtered table.

## The defect underneath the redesign

`design_has_open_submission` is computed by `GET /partners/payment-submissions/payable-runs` and **this screen never read it**. A run whose design already sat in an open submission was shown, selectable, and submitted — and the workflow rejected the *whole request* with `Designs already in an active payment submission`. Nothing marked that row as different, so a partner had no way to tell which one caused it.

Those rows are now hidden, behind a **Show already submitted (N)** toggle that reveals them greyed with the reason. Hidden rather than dropped: a partner who expects to see a run and cannot find it deserves an answer on the page.

## What changed

| | |
|---|---|
| **One table, not tabs** | Runs and tasks are rows with an `All / Runs / Tasks` filter. Splitting them made the header total the only place they were ever added together — off-screen from whichever tab you were on, so the count could read zero while you had picks on the other. |
| **Command bar** | `N selected · INR X`, Clear, Submit. Replaces the header total. |
| **Full width** | 720px suits a form read top-to-bottom. It is wrong for five columns: the work name truncated and the qty/rate inputs crowded, inside a modal already filling the screen. |
| **Select-all is scoped to what's shown** | Otherwise pressing it while filtered to Tasks silently ticks every run, and only the command-bar total would show it. |

Tasks are **not** redundant with runs — most hang off one, but a partner can hold standalone tasks and this screen is the only place they can be billed. That is why the runs-only option was rejected.

## What deliberately did not change

⚠️ Designs are gone as an *organising concept*, but the **request is still design-keyed** — that is the workflow's contract. The grouping and summing that fixes #1554 is untouched: two runs of one design still collapse into one line whose quantity is their **sum**, and mixed rates still become a typed total rather than an invented per-unit rate.

## Verification

- `tsc -p tsconfig.ci.json`: **0 errors in this file**. The app has **1122** pre-existing errors and exits 1 — which is why its CI gate is changed-files-only, and why a filtered grep here proves nothing until you have seen the run emit something.
- Reviewed in a browser on the local stack by the founder.
- ⚠️ The `@partnerui` e2e specs address rows by `[data-run-id]`, which is preserved, but they click a `Production runs` **tab** that no longer exists. Those specs need updating — flagged, not yet done.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_0158wJMZ1DmjNxXf5uGuBrQD