### PR TITLE
feat(production-runs): warn the partner before the inactivity sweep cancels their run (#1574)

### DIFF
--- a/.github/workflows/deploy-to-aws.yml
+++ b/.github/workflows/deploy-to-aws.yml
@@ -329,6 +329,8 @@ jobs:
             if [ "$MIGRATED" = "success" ]; then
               BEFORE=$(gh api "repos/${{ github.repository }}/actions/runs/${RUN_ID}" --jq '.head_sha' 2>/dev/null || true)
               echo "→ base = last MIGRATED sha ${BEFORE} (run ${RUN_ID})"
+              echo "base=${BEFORE}" >> "$GITHUB_OUTPUT"
+              echo "base_run=${RUN_ID}" >> "$GITHUB_OUTPUT"
               break
             fi
           done
@@ -397,11 +399,25 @@ jobs:
 
       - name: Skipped
         if: steps.gate.outputs.run != 'true'
-        # Names the base it compared against: "skipped" is only trustworthy if
-        # you can see what it was measured from (#1464 read as `success` for
-        # days precisely because it could not be).
+        # 🔑 A skip has to name the base it measured from, or it cannot be
+        # argued with. #1464 read as `success` for days precisely because
+        # "skipped" looked identical whether the base was right or catastrophic.
+        #
+        # The anchor is the last run that actually APPLIED migrations, not the
+        # last that deployed — the earlier wording said DEPLOYED and described a
+        # design we deliberately do not have.
+        env:
+          BASE_SHA: ${{ steps.gate.outputs.base }}
+          BASE_RUN: ${{ steps.gate.outputs.base_run }}
         run: |
-          echo "Migration task skipped — no schema-affecting changes since the last DEPLOYED commit."
+          echo "Migration task skipped — no migration/model/link/config path changed"
+          echo "since ${BASE_SHA:-<unknown>}, the last commit whose deploy actually"
+          echo "APPLIED migrations (run ${BASE_RUN:-<unknown>})."
+          echo
+          echo "Everything merged since that sha is still inside this diff, so a"
+          echo "migration stranded by a cancelled run stays visible until some run"
+          echo "applies it. If that sha looks far older than you expect, that is"
+          echo "correct — the anchor only advances when a migration truly ran."
 
   # ─────────────────────────────────────────────────────────────────────────
   # 3. Deploy server + worker in parallel via Copilot. Each deploy is its

--- a/apps/backend/src/api/admin/ops/maintenance-jobs/__tests__/inactive-run-cancellation.unit.spec.ts
+++ b/apps/backend/src/api/admin/ops/maintenance-jobs/__tests__/inactive-run-cancellation.unit.spec.ts
@@ -1,5 +1,8 @@
 import {
+  decideExpiringRunWarnings,
   decideInactiveRunCancellations,
+  expiryWarningIdempotencyKey,
+  inactivityCancelReason,
   lastActivityOf,
 } from "../lib/inactive-run-cancellation"
 
@@ -138,5 +141,118 @@ describe("decideInactiveRunCancellations", () => {
 
   it("skips a run with no usable timestamp rather than guessing", () => {
     expect(decide([{ id: "a", status: "in_progress" }])).toEqual([])
+  })
+})
+
+// ---------------------------------------------------------------------------
+// The warning that comes BEFORE the cancellation (#1574)
+// ---------------------------------------------------------------------------
+
+describe("decideExpiringRunWarnings", () => {
+  const warn = (runs: any[], days = 28, warnBeforeDays = 7) =>
+    decideExpiringRunWarnings(runs, { asOf: ASOF, days, warnBeforeDays })
+
+  const at = (daysAgo: number) =>
+    new Date(ASOF.getTime() - daysAgo * 24 * 60 * 60 * 1000).toISOString()
+
+  const run = (id: string, daysAgo: number, status = "in_progress") => ({
+    id,
+    status,
+    created_at: at(daysAgo),
+  })
+
+  it("warns inside the lead-time and names the cancellation date", () => {
+    const [d] = warn([run("r_24d", 24)])
+    expect(d.id).toBe("r_24d")
+    expect(d.inactive_days).toBe(24)
+    expect(d.days_until_cancel).toBe(4)
+    // 24 days idle + a 28-day window = cancellable four days from ASOF.
+    expect(d.cancel_on).toBe("2026-08-31")
+  })
+
+  it("stays silent on work that is still fresh", () => {
+    // Day 20 is outside a 7-day lead on a 28-day window.
+    expect(warn([run("r_20d", 20)])).toEqual([])
+  })
+
+  it("🔑 does NOT warn about a run the sweep would cancel in the same pass", () => {
+    // The two sets must be disjoint, or the partner is warned about a deadline
+    // that has already passed — a notice arriving after the verdict.
+    const runs = [run("r_81d", 81), run("r_28d", 28)]
+    expect(warn(runs)).toEqual([])
+    expect(decide(runs).map((d) => d.id)).toEqual(["r_81d", "r_28d"])
+  })
+
+  it("leaves admin-side and terminal states alone, like the sweep", () => {
+    expect(
+      warn([
+        run("r_approved", 24, "approved"),
+        run("r_reassign", 24, "awaiting_reassignment"),
+        run("r_completed", 24, "completed"),
+        run("r_cancelled", 24, "cancelled"),
+      ])
+    ).toEqual([])
+  })
+
+  it("measures from the last lifecycle stamp, not creation", () => {
+    // Re-dispatched 24 days ago: it is the dispatch that puts it in the window,
+    // and a warning quoting the 93-day creation date would be unanswerable.
+    const [d] = warn([
+      {
+        id: "r_redispatched",
+        status: "sent_to_partner",
+        created_at: at(93),
+        dispatch_started_at: at(24),
+      },
+    ])
+    expect(d.last_activity_field).toBe("dispatch_started_at")
+    expect(d.inactive_days).toBe(24)
+  })
+
+  it("clamps a lead-time that would reach back past day zero", () => {
+    // warn_before_days >= days would start the window at or before the moment
+    // of dispatch and warn about work handed over this morning.
+    expect(warn([run("r_today", 0)], 28, 999)).toEqual([])
+    expect(warn([run("r_today", 0)], 28, 28)).toEqual([])
+    // …while a run genuinely inside the widened window is still warned.
+    expect(warn([run("r_2d", 2)], 28, 27).map((d) => d.id)).toEqual(["r_2d"])
+  })
+
+  it("rounds days_until_cancel UP so a deadline never lands early", () => {
+    // 23.5 days idle ⇒ 4.5 days left. Saying "4" would expire the run half a
+    // day before the partner expects it to.
+    const [d] = warn([
+      { id: "r_half", status: "in_progress", created_at: at(23.5) },
+    ])
+    expect(d.days_until_cancel).toBe(5)
+  })
+
+  it("puts the most urgent first", () => {
+    expect(
+      warn([run("r_22d", 22), run("r_27d", 27), run("r_24d", 24)]).map(
+        (d) => d.id
+      )
+    ).toEqual(["r_27d", "r_24d", "r_22d"])
+  })
+})
+
+describe("expiryWarningIdempotencyKey", () => {
+  it("is keyed on the deadline, not the day it was sent", () => {
+    // Re-running the sweep must not re-mail; a NEW deadline must.
+    expect(expiryWarningIdempotencyKey("prod_run_1", "2026-08-31")).toBe(
+      "partner-run-expiring:prod_run_1:2026-08-31"
+    )
+    expect(expiryWarningIdempotencyKey("prod_run_1", "2026-08-31")).toBe(
+      expiryWarningIdempotencyKey("prod_run_1", "2026-08-31")
+    )
+    expect(expiryWarningIdempotencyKey("prod_run_1", "2026-09-14")).not.toBe(
+      expiryWarningIdempotencyKey("prod_run_1", "2026-08-31")
+    )
+  })
+})
+
+describe("inactivityCancelReason", () => {
+  it("states the run's own age — the prod case is 81 days, not the 28-day rule", () => {
+    expect(inactivityCancelReason(81)).toContain("81 days")
   })
 })

--- a/apps/backend/src/api/admin/ops/maintenance-jobs/cancel-inactive-production-runs-job.ts
+++ b/apps/backend/src/api/admin/ops/maintenance-jobs/cancel-inactive-production-runs-job.ts
@@ -145,16 +145,24 @@ export const cancelInactiveProductionRunsJob: MaintenanceJob = {
       }
     }
 
-    const reason = inactivityCancelReason(days)
     const errors: Array<{ id: string; message: string }> = []
     let cancelled = 0
 
     for (const decision of selected) {
       try {
+        // 🔑 The run's OWN age, not the policy window. Prod carries one 81 days
+        // idle; telling that partner "cancelled after 28 days" reports the rule
+        // instead of what happened, and they cannot reconcile it with the run
+        // in front of them.
         const result = await cancelProductionRunCascade(
           container,
           decision.id,
-          reason
+          inactivityCancelReason(decision.inactive_days),
+          {
+            inactive_days: decision.inactive_days,
+            inactivity_window_days: days,
+            last_activity_at: decision.last_activity_at,
+          }
         )
         if (!result.skipped) cancelled++
       } catch (e: any) {

--- a/apps/backend/src/api/admin/ops/maintenance-jobs/lib/inactive-run-cancellation.ts
+++ b/apps/backend/src/api/admin/ops/maintenance-jobs/lib/inactive-run-cancellation.ts
@@ -129,3 +129,82 @@ export const decideInactiveRunCancellations = (
 /** The reason stamped on the run and sent to the partner. */
 export const inactivityCancelReason = (days: number): string =>
   `Cancelled automatically after ${days} days without activity. The work was not started or finished in time — it can be re-created and re-assigned if it is still needed.`
+
+// ---------------------------------------------------------------------------
+// The warning that has to come BEFORE the cancellation (#1574)
+// ---------------------------------------------------------------------------
+
+export type ExpiringRunDecision = InactiveRunDecision & {
+  /** Whole days left before this run reaches the cancellation window. */
+  days_until_cancel: number
+  /** The date (YYYY-MM-DD) it becomes cancellable. */
+  cancel_on: string
+}
+
+/** Default: warn a week out from the 28-day window. */
+export const DEFAULT_WARN_BEFORE_DAYS = 7
+
+/**
+ * The runs that are ABOUT to be cancelled — inactive long enough to be inside
+ * the warning lead-time, but not yet past the window.
+ *
+ * 🔑 The two sets are DISJOINT by construction: a run at or past `days` belongs
+ * to `decideInactiveRunCancellations` and is excluded here. That is what stops
+ * a partner being warned about a run that the very same sweep then cancels —
+ * the warning would arrive after the verdict and read as noise.
+ *
+ * ⚠️ `warnBeforeDays >= days` would make the window start at or before day 0
+ * and warn about work dispatched this morning. It is clamped, not rejected,
+ * because a nonsense lead-time must not silently widen the audience.
+ */
+export const decideExpiringRunWarnings = (
+  runs: RunForInactivity[],
+  opts: { asOf: Date; days: number; warnBeforeDays: number }
+): ExpiringRunDecision[] => {
+  const dayMs = 24 * 60 * 60 * 1000
+  const lead = Math.max(1, Math.min(opts.warnBeforeDays, opts.days - 1))
+  const now = opts.asOf.getTime()
+  // Inactive enough to be inside the lead-time…
+  const warnFrom = now - (opts.days - lead) * dayMs
+  // …but not yet inactive enough to be cancelled.
+  const cancelFrom = now - opts.days * dayMs
+
+  const out: ExpiringRunDecision[] = []
+
+  for (const run of runs || []) {
+    const status = String(run?.status ?? "")
+    if (!PARTNER_HELD_STATUSES.has(status)) continue
+
+    const last = lastActivityOf(run)
+    if (!last) continue
+    if (last.at > warnFrom) continue // too recent to warn about
+    if (last.at <= cancelFrom) continue // already cancellable — not a warning
+
+    const cancelAt = last.at + opts.days * dayMs
+    out.push({
+      id: String(run.id),
+      status,
+      last_activity_at: new Date(last.at).toISOString(),
+      last_activity_field: last.field,
+      inactive_days: Math.floor((now - last.at) / dayMs),
+      // Ceil, so "1 day" never means "in four hours". A warning that expires
+      // sooner than it claims is worse than one that is a few hours generous.
+      days_until_cancel: Math.max(1, Math.ceil((cancelAt - now) / dayMs)),
+      cancel_on: new Date(cancelAt).toISOString().slice(0, 10),
+    })
+  }
+
+  return out.sort((a, b) => a.days_until_cancel - b.days_until_cancel)
+}
+
+/**
+ * The idempotency key for one run's expiry warning.
+ *
+ * Keyed on the CANCEL DATE, not the day it was sent: re-running the sweep
+ * hourly must not re-mail the partner, but a run that is touched and then goes
+ * quiet again has a new cancel date and deserves a fresh warning.
+ */
+export const expiryWarningIdempotencyKey = (
+  runId: string,
+  cancelOn: string
+): string => `partner-run-expiring:${runId}:${cancelOn}`

--- a/apps/backend/src/api/admin/ops/maintenance-jobs/registry.ts
+++ b/apps/backend/src/api/admin/ops/maintenance-jobs/registry.ts
@@ -102,6 +102,7 @@ import { generateNewsletterWinbackTargetsJob } from "./generate-newsletter-winba
 import { repairInventoryOrderSourceJob } from "./repair-inventory-order-source-job"
 import { repairInventoryOrderRouteJob } from "./repair-inventory-order-route-job"
 import { cancelInactiveProductionRunsJob } from "./cancel-inactive-production-runs-job"
+import { warnExpiringProductionRunsJob } from "./warn-expiring-production-runs-job"
 import { rewindProductionRunJob } from "./rewind-production-run-job"
 import { repairConsumptionLogJob } from "./repair-consumption-log-job"
 import { setLocationOwnershipJob } from "./set-location-ownership-job"
@@ -5802,6 +5803,7 @@ export const seedGoodsTransferTaskTemplateJob: MaintenanceJob = {
 
 export const MAINTENANCE_JOBS: MaintenanceJob[] = [
   cancelInactiveProductionRunsJob,
+  warnExpiringProductionRunsJob,
   cleanOrderFulfillmentDataJob,
   sendCourierChangedEmailJob,
   resendShipmentEmailJob,

--- a/apps/backend/src/api/admin/ops/maintenance-jobs/warn-expiring-production-runs-job.ts
+++ b/apps/backend/src/api/admin/ops/maintenance-jobs/warn-expiring-production-runs-job.ts
@@ -1,0 +1,207 @@
+import {
+  ContainerRegistrationKeys,
+  MedusaError,
+  Modules,
+} from "@medusajs/framework/utils"
+import { z } from "@medusajs/framework/zod"
+
+import {
+  DEFAULT_WARN_BEFORE_DAYS,
+  decideExpiringRunWarnings,
+  expiryWarningIdempotencyKey,
+} from "./lib/inactive-run-cancellation"
+import type {
+  MaintenanceChange,
+  MaintenanceJob,
+  MaintenanceJobResult,
+} from "./registry"
+
+/**
+ * Data Plumbing — warn partners whose runs are about to be auto-cancelled.
+ *
+ * ## Why this exists separately from the sweep
+ *
+ * #1574 gave us a 28-day inactivity policy that cancels a run and emails the
+ * partner. On its own that is a verdict with no notice: the first the partner
+ * hears of a deadline is the mail saying it passed. The prod case is a run
+ * **81 days** idle — nobody was ever told it was counting.
+ *
+ * So the warning is its own job, and deliberately not a phase of the cancel
+ * sweep. Cancelling is a decision that needs a human behind it; warning is not,
+ * which means this one can be scheduled while the sweep stays operator-run.
+ *
+ * ## What stops it becoming spam
+ *
+ * 🔑 The send carries an idempotency key of `run + cancel_on`, and the
+ * notification module skips a key it has already delivered. Re-run this hourly
+ * and each partner still gets exactly ONE warning per deadline — but a run that
+ * moves and then goes quiet again earns a new deadline, and so a new warning.
+ * The key is not the date it was sent, which would re-mail daily.
+ *
+ * 🔑 The warning set and the cancellation set are DISJOINT (see
+ * `decideExpiringRunWarnings`). A run past the window is the sweep's, not this
+ * job's — a warning arriving after the cancellation would read as noise.
+ */
+
+const paramsSchema = z.object({
+  /** The inactivity window that will cancel the run. Default 28. */
+  days: z.coerce.number().int().min(2).max(3650).optional(),
+  /** How many days before that window to warn. Default 7. */
+  warn_before_days: z.coerce.number().int().min(1).max(3650).optional(),
+  /** Cap the number warned in one pass. Default 100. */
+  limit: z.coerce.number().int().min(1).max(500).optional(),
+  /** Only consider this run — for verifying the decision on one row. */
+  production_run_id: z.string().min(1).optional(),
+})
+
+const DEFAULT_DAYS = 28
+const DEFAULT_LIMIT = 100
+
+export const warnExpiringProductionRunsJob: MaintenanceJob = {
+  id: "warn-expiring-production-runs",
+  label: "Warn partners about runs approaching the inactivity cancellation",
+  description:
+    "Emails the partner for every run they are holding (sent_to_partner or in_progress) that is inside the warning lead-time for the inactivity policy — inactive for at least (days - warn_before_days) but not yet past days. The mail names how long it has been idle and the date it will be cancelled, and says that any activity resets the clock. Deliberately DISJOINT from cancel-inactive-production-runs: a run already past the window belongs to that job. Safe to re-run — each partner gets one warning per deadline, enforced by a notification idempotency key of run+cancel date. Dry-run lists every partner it would email, with the stamp the age was measured from.",
+  params: [
+    {
+      name: "days",
+      type: "number",
+      required: false,
+      description:
+        "The inactivity window that cancels a run. Default 28 — must match the cancel sweep or the warning names the wrong date.",
+    },
+    {
+      name: "warn_before_days",
+      type: "number",
+      required: false,
+      description:
+        "How many days of lead-time to give. Default 7. Clamped to days-1, so it can never warn about work dispatched today.",
+    },
+    {
+      name: "limit",
+      type: "number",
+      required: false,
+      description: "Maximum partners to email in one pass. Default 100.",
+    },
+    {
+      name: "production_run_id",
+      type: "string",
+      required: false,
+      description:
+        "Consider only this run, e.g. 'prod_run_01KTDS2N5DFWD6NNAPE220PD9T'. Useful to check the decision on a single row before sweeping.",
+    },
+  ],
+  run: async (container, { dry_run, params }): Promise<MaintenanceJobResult> => {
+    const parsed = paramsSchema.safeParse(params ?? {})
+    if (!parsed.success) {
+      throw new MedusaError(
+        MedusaError.Types.INVALID_DATA,
+        `Invalid params: ${parsed.error.issues.map((i) => i.message).join(", ")}`
+      )
+    }
+
+    const days = parsed.data.days ?? DEFAULT_DAYS
+    const warnBeforeDays =
+      parsed.data.warn_before_days ?? DEFAULT_WARN_BEFORE_DAYS
+    const limit = parsed.data.limit ?? DEFAULT_LIMIT
+    const onlyId = parsed.data.production_run_id
+
+    const query = container.resolve(ContainerRegistrationKeys.QUERY) as any
+
+    const { data: runs } = await query.graph({
+      entity: "production_runs",
+      fields: [
+        "id",
+        "status",
+        "partner_id",
+        "created_at",
+        "accepted_at",
+        "started_at",
+        "finished_at",
+        "dispatch_started_at",
+      ],
+      filters: onlyId
+        ? { id: onlyId }
+        : { status: ["sent_to_partner", "in_progress"] },
+    })
+
+    // Captured ONCE so every row in a pass is judged against the same instant
+    // and a dry-run can be reproduced exactly.
+    const asOf = new Date()
+    const decided = decideExpiringRunWarnings((runs || []) as any[], {
+      asOf,
+      days,
+      warnBeforeDays,
+    })
+
+    const selected = decided.slice(0, limit)
+    const dropped = decided.length - selected.length
+
+    const changes: MaintenanceChange[] = selected.map((d) => ({
+      entity: "production_run",
+      id: d.id,
+      field: "partner_notification",
+      before: "none",
+      after: "partner-production-run-expiring",
+      note: `inactive ${d.inactive_days}d since ${d.last_activity_field}=${d.last_activity_at}; cancels ${d.cancel_on} (in ${d.days_until_cancel}d)`,
+    }))
+
+    if (dry_run) {
+      return {
+        job_id: "warn-expiring-production-runs",
+        dry_run: true,
+        applied: false,
+        // States what was DROPPED — a silent top-N reads as "that was all of
+        // them" when it was not.
+        summary: `${decided.length} run(s) within ${warnBeforeDays} day(s) of the ${days}-day cancellation; would email ${selected.length}${dropped ? ` (${dropped} beyond the limit of ${limit})` : ""}.`,
+        changes,
+      }
+    }
+
+    const eventBus = container.resolve(Modules.EVENT_BUS) as any
+    const errors: Array<{ id: string; message: string }> = []
+    let warned = 0
+
+    for (const decision of selected) {
+      try {
+        await eventBus.emit([
+          {
+            name: "production_run.expiring",
+            data: {
+              id: decision.id,
+              production_run_id: decision.id,
+              action: "expiring",
+              inactive_days: decision.inactive_days,
+              inactivity_window_days: days,
+              days_until_cancel: decision.days_until_cancel,
+              cancel_on: decision.cancel_on,
+              last_activity_at: decision.last_activity_at,
+              idempotency_key: expiryWarningIdempotencyKey(
+                decision.id,
+                decision.cancel_on
+              ),
+            },
+          },
+        ])
+        warned++
+      } catch (e: any) {
+        // One bad row must not abort the pass — the rest are just as close to
+        // their deadline, and a partial run that names the failures is more
+        // useful than none.
+        errors.push({ id: decision.id, message: e?.message || String(e) })
+      }
+    }
+
+    return {
+      job_id: "warn-expiring-production-runs",
+      dry_run: false,
+      // 🔑 `applied` means the events were EMITTED, not that mail was
+      // delivered. The send is a subscriber and a partner with no active admin
+      // is skipped quietly there; this job cannot see that far.
+      applied: warned > 0,
+      summary: `Emitted ${warned} of ${selected.length} expiry warning(s) for runs inactive ${days - warnBeforeDays}–${days} days${dropped ? ` (${dropped} beyond the limit of ${limit})` : ""}${errors.length ? `; ${errors.length} failed` : ""}.`,
+      changes,
+      ...(errors.length ? { errors } : {}),
+    }
+  },
+}

--- a/apps/backend/src/scripts/__tests__/partner-production-run-email-templates.unit.spec.ts
+++ b/apps/backend/src/scripts/__tests__/partner-production-run-email-templates.unit.spec.ts
@@ -1,0 +1,156 @@
+import * as Handlebars from "handlebars"
+
+import { partnerEmailTemplates } from "../seed-partner-email-templates"
+import { buildPartnerProductionRunTemplateData } from "../../workflows/email/workflows/partner-production-run-email-lib"
+
+/**
+ * #1574 — render the SEED bodies, not a paraphrase of them.
+ *
+ * These templates live only in a database once seeded, so the body a partner
+ * actually receives is never exercised by any other test. A mis-nested
+ * `{{#if}}` renders as silence: Handlebars drops the whole branch and the mail
+ * still sends, still looks plausible, and simply omits the thing it existed to
+ * say. Compiling the real string and asserting the words is the only check that
+ * can tell.
+ */
+const templateFor = (key: string) => {
+  const def = partnerEmailTemplates.find((t) => t.template_key === key)
+  if (!def) throw new Error(`No seed template for "${key}"`)
+  return {
+    html: Handlebars.compile(def.html_content),
+    subject: Handlebars.compile(def.subject),
+  }
+}
+
+const partner = { name: "Acme Mills", handle: "acme" }
+const admin = { first_name: "Asha", last_name: "Rao" }
+const run = { id: "prod_run_1", status: "in_progress", quantity: 40 }
+
+describe("partner-production-run-expiring", () => {
+  const t = templateFor("partner-production-run-expiring")
+  const data = buildPartnerProductionRunTemplateData({
+    partner,
+    admin,
+    run,
+    action: "expiring",
+    inactivity: {
+      inactive_days: 24,
+      window_days: 28,
+      days_until_cancel: 4,
+      cancel_on: "2026-08-31",
+      last_activity_at: "2026-08-03T05:25:03.184Z",
+    },
+    runUrlBase: "https://partner.example.com/production-runs",
+    year: 2026,
+  })
+
+  it("says how long it has been idle and the date it will be cancelled", () => {
+    const html = t.html(data)
+    expect(html).toContain("24 days")
+    expect(html).toContain("2026-08-31")
+    expect(html).toContain("4 days")
+    expect(html).toContain("After 28 days without activity")
+  })
+
+  it("tells the partner what resets the clock", () => {
+    // A deadline with no stated remedy is a threat, not a notice.
+    const html = t.html(data)
+    expect(html).toMatch(/accept it, start it, or finish it/i)
+    expect(html).toMatch(/resets the clock/i)
+  })
+
+  it("puts the deadline in the subject line", () => {
+    expect(t.subject(data)).toBe(
+      "⏳ Run prod_run_1 will be cancelled in 4 days"
+    )
+  })
+
+  it("renders without a run_url or a last activity stamp", () => {
+    const sparse = buildPartnerProductionRunTemplateData({
+      partner,
+      admin,
+      run: { id: "prod_run_2" },
+      action: "expiring",
+      inactivity: { inactive_days: 22, window_days: 28, days_until_cancel: 6 },
+      year: 2026,
+    })
+    const html = t.html(sparse)
+    expect(html).toContain("22 days")
+    expect(html).toContain("shortly")
+    expect(html).not.toContain("Open run")
+    expect(html).not.toContain("Last activity")
+    expect(html).not.toContain("undefined")
+  })
+})
+
+describe("partner-production-run-cancelled", () => {
+  const t = templateFor("partner-production-run-cancelled")
+
+  it("explains the inactivity when the sweep cancelled it", () => {
+    const html = t.html(
+      buildPartnerProductionRunTemplateData({
+        partner,
+        admin,
+        run,
+        action: "cancelled",
+        notes: "Cancelled automatically after 81 days without activity.",
+        inactivity: {
+          inactive_days: 81,
+          window_days: 28,
+          last_activity_at: "2026-06-06T06:14:13.421Z",
+        },
+        year: 2026,
+      })
+    )
+    // The run's OWN age, which is the number the partner can reconcile with
+    // what they are looking at.
+    expect(html).toContain("81 days")
+    expect(html).toContain("28-day inactivity window")
+    expect(html).toContain("2026-06-06")
+    expect(html).toMatch(/re-create and re-assign/i)
+    // The generic branch must NOT also render — the two are exclusive.
+    expect(html).not.toContain("No further action is needed")
+  })
+
+  it("renders an ADMIN cancel exactly as it did before #1574", () => {
+    // Same template, no inactivity context: the whole block is gated off and
+    // the free-text reason is what the partner sees.
+    const html = t.html(
+      buildPartnerProductionRunTemplateData({
+        partner,
+        admin,
+        run,
+        action: "cancelled",
+        notes: "Buyer withdrew the order.",
+        year: 2026,
+      })
+    )
+    expect(html).toContain("Buyer withdrew the order.")
+    expect(html).toContain("No further action is needed")
+    expect(html).not.toContain("inactivity window")
+    expect(html).not.toContain("Idle for")
+    expect(html).not.toContain("undefined")
+  })
+})
+
+describe("the seed rows themselves", () => {
+  it("declares every variable the expiring body renders", () => {
+    const def = partnerEmailTemplates.find(
+      (t) => t.template_key === "partner-production-run-expiring"
+    )!
+    const used = new Set(
+      [...def.html_content.matchAll(/\{\{#?if\s+(\w+)\}\}|\{\{(\w+)\}\}/g)]
+        .map((m) => m[1] || m[2])
+        // `{{else}}` is a block keyword, not a variable.
+        .filter((v) => v && v !== "else")
+    )
+    for (const v of used) {
+      expect(Object.keys(def.variables)).toContain(v)
+    }
+  })
+
+  it("has no duplicate template keys", () => {
+    const keys = partnerEmailTemplates.map((t) => t.template_key)
+    expect(new Set(keys).size).toBe(keys.length)
+  })
+})

--- a/apps/backend/src/scripts/seed-partner-email-templates.ts
+++ b/apps/backend/src/scripts/seed-partner-email-templates.ts
@@ -6,8 +6,14 @@
  * `seed-email-templates.ts` (data inlined as a const, not a JSON import, so it
  * survives the prod `medusa build` with no asset-copy dependency).
  *
+ * ⚠️ Creating-only means an EDIT to a body here never reaches an environment
+ * that was already seeded. Push a changed body with:
+ *   TEMPLATE_KEYS=partner-production-run-cancelled DRY_RUN=1 \
+ *     npx medusa exec ./src/scripts/update-email-templates.ts
+ *
  * Covers the templates the merged workflows resolve by key:
- *   - partner-production-run-completed / -cancelled  (#576 slice B, email_partner)
+ *   - partner-production-run-completed / -cancelled / -expiring
+ *                                                    (#576 slice B, #1574, email_partner)
  *   - region-request-admin                           (#576 slice C, email)
  *   - partner-storefront-digest                      (#581, email_partner)
  *
@@ -60,8 +66,42 @@ export const partnerEmailTemplates = [
       notes: "Optional reason",
       run_url: "Link to the run",
       current_year: "Year",
+      // #1574 — present ONLY when the inactivity sweep cancelled the run. An
+      // admin cancel leaves them blank and the block below does not render.
+      inactive_days: "Days the run sat without activity",
+      inactivity_window_days: "The policy window that expired (28)",
+      last_activity_at: "ISO timestamp of the last lifecycle stamp",
     },
-    html_content: `<div style="font-family:-apple-system,Segoe UI,Roboto,Helvetica,Arial,sans-serif;max-width:560px;margin:0 auto;color:#18181b"><h1 style="font-size:18px;margin:0 0 12px">Hi {{partner_name}},</h1><p style="font-size:14px;line-height:1.6;color:#3f3f46">Production run <strong>{{run_id}}</strong> has been <strong style="color:#dc2626">cancelled</strong>.</p>{{#if notes}}<p style="font-size:13px;color:#71717a;background:#fef2f2;padding:10px 12px;border-radius:8px"><strong>Reason:</strong> {{notes}}</p>{{/if}}<p style="font-size:14px;line-height:1.6;color:#3f3f46">No further action is needed on the run. If this was unexpected, please reach out.</p>{{#if run_url}}<p style="margin:20px 0"><a href="{{run_url}}" style="background:#18181b;color:#fff;text-decoration:none;padding:10px 18px;border-radius:8px;font-size:14px;display:inline-block">View run</a></p>{{/if}}<p style="font-size:12px;color:#a1a1aa;margin-top:24px">Jaal Yantra Textiles · {{current_year}}</p></div>`,
+    html_content: `<div style="font-family:-apple-system,Segoe UI,Roboto,Helvetica,Arial,sans-serif;max-width:560px;margin:0 auto;color:#18181b"><h1 style="font-size:18px;margin:0 0 12px">Hi {{partner_name}},</h1><p style="font-size:14px;line-height:1.6;color:#3f3f46">Production run <strong>{{run_id}}</strong> has been <strong style="color:#dc2626">cancelled</strong>.</p>{{#if inactive_days}}<p style="font-size:14px;line-height:1.6;color:#3f3f46">This one closed itself. The run had no recorded activity for <strong>{{inactive_days}} days</strong>, past the {{inactivity_window_days}}-day inactivity window, so it was cancelled automatically.</p><table style="width:100%;border-collapse:collapse;font-size:14px;margin:16px 0"><tr><td style="padding:8px 0;border-bottom:1px solid #e4e4e7;color:#71717a">Idle for</td><td style="padding:8px 0;border-bottom:1px solid #e4e4e7;text-align:right;font-weight:600">{{inactive_days}} days</td></tr>{{#if last_activity_at}}<tr><td style="padding:8px 0;border-bottom:1px solid #e4e4e7;color:#71717a">Last activity</td><td style="padding:8px 0;border-bottom:1px solid #e4e4e7;text-align:right">{{last_activity_at}}</td></tr>{{/if}}<tr><td style="padding:8px 0;border-bottom:1px solid #e4e4e7;color:#71717a">Policy window</td><td style="padding:8px 0;border-bottom:1px solid #e4e4e7;text-align:right">{{inactivity_window_days}} days</td></tr></table><p style="font-size:14px;line-height:1.6;color:#3f3f46">Nothing about this counts against you, and no payment already submitted is affected. If the work is still wanted we will re-create and re-assign it — tell us and we will.</p>{{else}}{{#if notes}}<p style="font-size:13px;color:#71717a;background:#fef2f2;padding:10px 12px;border-radius:8px"><strong>Reason:</strong> {{notes}}</p>{{/if}}<p style="font-size:14px;line-height:1.6;color:#3f3f46">No further action is needed on the run. If this was unexpected, please reach out.</p>{{/if}}{{#if run_url}}<p style="margin:20px 0"><a href="{{run_url}}" style="background:#18181b;color:#fff;text-decoration:none;padding:10px 18px;border-radius:8px;font-size:14px;display:inline-block">View run</a></p>{{/if}}<p style="font-size:12px;color:#a1a1aa;margin-top:24px">Jaal Yantra Textiles · {{current_year}}</p></div>`,
+  },
+  {
+    // #1574 — the warning the inactivity sweep sends BEFORE it cancels.
+    //
+    // 🔑 The whole point of this mail is that it is ACTIONABLE: it names the
+    // date, and doing anything at all on the run resets the clock. A partner
+    // whose first news is the cancellation has been given a verdict, not a
+    // chance.
+    template_key: "partner-production-run-expiring",
+    name: "Partner — Production Run Expiring (inactivity)",
+    template_type: "partner",
+    from: "partner@partner.jaalyantra.com",
+    is_active: true,
+    subject:
+      "⏳ Run {{run_id}} will be cancelled in {{days_until_cancel}} days",
+    variables: {
+      partner_name: "Partner display name",
+      run_id: "Production run id",
+      run_status: "Run status (sent_to_partner | in_progress)",
+      run_quantity: "Planned quantity",
+      inactive_days: "Days the run has sat without activity",
+      days_until_cancel: "Days left before the sweep cancels it",
+      cancel_on: "Date (YYYY-MM-DD) it becomes cancellable",
+      inactivity_window_days: "The policy window in days (28)",
+      last_activity_at: "ISO timestamp of the last lifecycle stamp",
+      run_url: "Link to the run",
+      current_year: "Year",
+    },
+    html_content: `<div style="font-family:-apple-system,Segoe UI,Roboto,Helvetica,Arial,sans-serif;max-width:560px;margin:0 auto;color:#18181b"><h1 style="font-size:18px;margin:0 0 12px">Hi {{partner_name}},</h1><p style="font-size:14px;line-height:1.6;color:#3f3f46">We have not seen any movement on production run <strong>{{run_id}}</strong> for <strong>{{inactive_days}} days</strong>.</p><p style="font-size:14px;line-height:1.6;color:#3f3f46">After {{inactivity_window_days}} days without activity a run is cancelled automatically so the work can be re-assigned. This one is due to be cancelled {{#if cancel_on}}on <strong>{{cancel_on}}</strong>{{else}}shortly{{/if}} — <strong>{{days_until_cancel}} days</strong> from now.</p><table style="width:100%;border-collapse:collapse;font-size:14px;margin:16px 0"><tr><td style="padding:8px 0;border-bottom:1px solid #e4e4e7;color:#71717a">Run</td><td style="padding:8px 0;border-bottom:1px solid #e4e4e7;text-align:right;font-weight:600">{{run_id}}</td></tr>{{#if run_quantity}}<tr><td style="padding:8px 0;border-bottom:1px solid #e4e4e7;color:#71717a">Planned</td><td style="padding:8px 0;border-bottom:1px solid #e4e4e7;text-align:right;font-weight:600">{{run_quantity}}</td></tr>{{/if}}<tr><td style="padding:8px 0;border-bottom:1px solid #e4e4e7;color:#71717a">Idle for</td><td style="padding:8px 0;border-bottom:1px solid #e4e4e7;text-align:right;font-weight:600">{{inactive_days}} days</td></tr>{{#if last_activity_at}}<tr><td style="padding:8px 0;border-bottom:1px solid #e4e4e7;color:#71717a">Last activity</td><td style="padding:8px 0;border-bottom:1px solid #e4e4e7;text-align:right">{{last_activity_at}}</td></tr>{{/if}}{{#if cancel_on}}<tr><td style="padding:8px 0;border-bottom:1px solid #e4e4e7;color:#b45309">Cancels on</td><td style="padding:8px 0;border-bottom:1px solid #e4e4e7;text-align:right;font-weight:600;color:#b45309">{{cancel_on}}</td></tr>{{/if}}</table><p style="font-size:14px;line-height:1.6;color:#3f3f46"><strong>To keep it:</strong> open the run and record progress — accept it, start it, or finish it. Any of those resets the clock. If the work is blocked on us, reply to this email and it will not be cancelled.</p><p style="font-size:13px;color:#71717a;background:#f4f4f5;padding:10px 12px;border-radius:8px">If you would rather not do this run, doing nothing is fine. It will be cancelled on the date above and re-assigned — no penalty.</p>{{#if run_url}}<p style="margin:20px 0"><a href="{{run_url}}" style="background:#18181b;color:#fff;text-decoration:none;padding:10px 18px;border-radius:8px;font-size:14px;display:inline-block">Open run</a></p>{{/if}}<p style="font-size:12px;color:#a1a1aa;margin-top:24px">Jaal Yantra Textiles · {{current_year}}</p></div>`,
   },
   {
     template_key: "region-request-admin",
@@ -179,10 +219,17 @@ export default async function seedPartnerEmailTemplates({ container }: { contain
   let created = 0
   let skipped = 0
   for (const t of partnerEmailTemplates) {
+    // 🔴 NOT getTemplateByKey — it filters `is_active: true` AND `locale: "en"`,
+    // so a row someone deactivated in the admin reads as absent and the seed
+    // creates a SECOND row with the same key. getTemplateByKey then returns
+    // `templates[0]` of an unordered list, and which body a partner receives
+    // becomes a coin flip. Ask the table, not the reader.
     let exists = false
     try {
-      await svc.getTemplateByKey(t.template_key)
-      exists = true
+      const [rows] = await svc.listAndCountEmailTemplates({
+        template_key: t.template_key,
+      })
+      exists = (rows?.length ?? 0) > 0
     } catch {
       exists = false
     }

--- a/apps/backend/src/scripts/update-email-templates.ts
+++ b/apps/backend/src/scripts/update-email-templates.ts
@@ -2,6 +2,7 @@ import { ContainerRegistrationKeys } from "@medusajs/framework/utils"
 import { ExecArgs } from "@medusajs/framework/types"
 import { EMAIL_TEMPLATES_MODULE } from "../modules/email_templates"
 import { emailTemplatesData } from "./seed-email-templates"
+import { partnerEmailTemplates } from "./seed-partner-email-templates"
 
 /**
  * One-off ops job: UPDATE existing DB email templates in place from the
@@ -13,6 +14,12 @@ import { emailTemplatesData } from "./seed-email-templates"
  * the seed's subject / html_content / from / variables onto the live rows for a
  * chosen set of keys — scoped by TEMPLATE_KEYS so we never touch templates we
  * didn't mean to.
+ *
+ * 🔴 It must see EVERY seed array, not just the customer one. Until #1574 it
+ * read only `seed-email-templates.ts`, which meant no partner template could
+ * ever be updated in a seeded environment by any tool we had — an edit to a
+ * partner body was invisible on prod and silently so, because the seed skips
+ * and this job said "not found in seed data".
  *
  * Motivating case: the `order-placed` customer confirmation shipped as a stub
  * whose payload never matched its variables (empty "Hi ," / "Order #"). The
@@ -44,10 +51,15 @@ export default async function updateEmailTemplates({ container }: ExecArgs) {
   let updated = 0
   let missing = 0
 
+  // Customer + partner seeds are one namespace here: a template key resolves
+  // from whichever array declares it.
+  const allSeedTemplates = [
+    ...(emailTemplatesData as any[]),
+    ...(partnerEmailTemplates as any[]),
+  ]
+
   for (const key of keys) {
-    const def = (emailTemplatesData as any[]).find(
-      (t) => t.template_key === key
-    )
+    const def = allSeedTemplates.find((t) => t.template_key === key)
     if (!def) {
       logger.warn(
         `[update-email-templates] '${key}' not found in seed data — skip`

--- a/apps/backend/src/subscribers/production-run-partner-email.ts
+++ b/apps/backend/src/subscribers/production-run-partner-email.ts
@@ -12,6 +12,11 @@ import {
  * is completed or cancelled. Runs alongside the feed-only
  * production-run-notifications subscriber.
  *
+ * #1574 adds `production_run.expiring`: the warning the inactivity sweep sends
+ * BEFORE it cancels. Its payload carries the inactivity facts (how long idle,
+ * when it will be cancelled) and an `idempotency_key`, because a sweep is
+ * re-runnable and a partner must not be told once per operator run.
+ *
  * partner_id may be absent from the event payload (the admin cancel route emits
  * production_run.cancelled without it) — the workflow resolves the partner from
  * the run itself. Best-effort: a missing template/partner is logged + skipped,
@@ -26,6 +31,12 @@ export default async function productionRunPartnerEmailHandler({
   partner_id?: string
   action?: string
   notes?: string
+  inactive_days?: number
+  inactivity_window_days?: number
+  days_until_cancel?: number
+  cancel_on?: string
+  last_activity_at?: string
+  idempotency_key?: string
 }>) {
   const logger = container.resolve(ContainerRegistrationKeys.LOGGER) as Logger
   const data = event.data
@@ -49,6 +60,14 @@ export default async function productionRunPartnerEmailHandler({
         partnerId: data.partner_id,
         action,
         notes: data.notes,
+        inactivity: {
+          inactive_days: data.inactive_days,
+          window_days: data.inactivity_window_days,
+          days_until_cancel: data.days_until_cancel,
+          cancel_on: data.cancel_on,
+          last_activity_at: data.last_activity_at,
+        },
+        idempotencyKey: data.idempotency_key,
       },
     })
   } catch (e: any) {
@@ -59,5 +78,9 @@ export default async function productionRunPartnerEmailHandler({
 }
 
 export const config: SubscriberConfig = {
-  event: ["production_run.completed", "production_run.cancelled"],
+  event: [
+    "production_run.completed",
+    "production_run.cancelled",
+    "production_run.expiring",
+  ],
 }

--- a/apps/backend/src/workflows/email/workflows/partner-production-run-email-lib.ts
+++ b/apps/backend/src/workflows/email/workflows/partner-production-run-email-lib.ts
@@ -4,7 +4,33 @@
 //
 // Mirrors lib/partner-task-email.ts so partner task + run emails share one shape.
 
-export type ProductionRunEmailAction = "completed" | "cancelled"
+export type ProductionRunEmailAction = "completed" | "cancelled" | "expiring"
+
+/**
+ * The inactivity facts behind an expiry warning or an auto-cancellation.
+ *
+ * 🔑 `inactive_days` is the RUN's own age, never the policy window. The prod
+ * case that motivated this is 81 days idle against a 28-day policy; telling
+ * that partner "cancelled after 28 days" reports the rule instead of what
+ * happened to their work, and they cannot reconcile it with the run they are
+ * looking at.
+ *
+ * Every field is optional because the same two templates also serve the manual
+ * admin cancel, where none of it applies — the bodies gate the whole block on
+ * `{{#if inactive_days}}` so an admin cancel renders exactly as it did before.
+ */
+export interface ProductionRunInactivity {
+  /** Days since the run's last lifecycle stamp. */
+  inactive_days?: number | null
+  /** The policy window that will cancel it (28 by default). */
+  window_days?: number | null
+  /** Days left before the sweep would cancel it — the warning's whole point. */
+  days_until_cancel?: number | null
+  /** ISO date (YYYY-MM-DD) the run becomes cancellable. */
+  cancel_on?: string | null
+  /** ISO timestamp of the last activity, so the partner can argue with it. */
+  last_activity_at?: string | null
+}
 
 export interface PartnerProductionRunTemplateInput {
   partner: { name?: string | null; handle?: string | null }
@@ -19,6 +45,8 @@ export interface PartnerProductionRunTemplateInput {
     order_id?: string | null
   }
   action: ProductionRunEmailAction
+  /** Inactivity facts for the expiring / auto-cancelled bodies. */
+  inactivity?: ProductionRunInactivity | null
   /** Free-text notes/reason surfaced in the body (completion notes or cancel reason). */
   notes?: string | null
   /** Storefront URL (FRONTEND_URL) surfaced in the footer. */
@@ -31,14 +59,16 @@ export interface PartnerProductionRunTemplateInput {
 
 /**
  * DB template key for a production-run lifecycle email.
- * Only `completed` and `cancelled` have partner emails (#576 slice B); any other
- * action returns null so the workflow can skip without guessing a key.
+ * `completed` and `cancelled` are #576 slice B; `expiring` is the #1574
+ * inactivity warning sent BEFORE the sweep cancels. Any other action returns
+ * null so the workflow can skip without guessing a key.
  */
 export function resolvePartnerProductionRunTemplateKey(
   action: string | null | undefined
 ): string | null {
   if (action === "completed") return "partner-production-run-completed"
   if (action === "cancelled") return "partner-production-run-cancelled"
+  if (action === "expiring") return "partner-production-run-expiring"
   return null
 }
 
@@ -64,6 +94,7 @@ export function buildPartnerProductionRunTemplateData(
   input: PartnerProductionRunTemplateInput
 ): Record<string, string> {
   const { partner, admin, run, action } = input
+  const inactivity = input.inactivity || {}
   const adminName = `${admin.first_name || ""} ${admin.last_name || ""}`.trim()
   const runId = run.id || ""
   const base = (input.runUrlBase || "").replace(/\/$/, "")
@@ -86,6 +117,14 @@ export function buildPartnerProductionRunTemplateData(
     design_id: run.design_id || "",
     order_id: run.order_id || "",
     notes: input.notes || "",
+    // Blank (not "0"/"undefined") when there is no inactivity context, because
+    // the templates gate their inactivity block on `{{#if}}` and Handlebars
+    // treats only the empty string as absent.
+    inactive_days: numOrEmpty(inactivity.inactive_days),
+    inactivity_window_days: numOrEmpty(inactivity.window_days),
+    days_until_cancel: numOrEmpty(inactivity.days_until_cancel),
+    cancel_on: inactivity.cancel_on || "",
+    last_activity_at: inactivity.last_activity_at || "",
     run_url: runUrl,
     current_year: String(input.year ?? new Date().getFullYear()),
     store_url: input.storeUrl || "",

--- a/apps/backend/src/workflows/email/workflows/send-partner-production-run-email.ts
+++ b/apps/backend/src/workflows/email/workflows/send-partner-production-run-email.ts
@@ -18,7 +18,29 @@ import {
   derivePartnerFromEmail,
   resolvePartnerProductionRunTemplateKey,
   type ProductionRunEmailAction,
+  type ProductionRunInactivity,
 } from "./partner-production-run-email-lib"
+
+export interface SendPartnerProductionRunEmailInput {
+  productionRunId: string
+  partnerId?: string
+  action: ProductionRunEmailAction
+  notes?: string
+  /** Inactivity facts for the `expiring` warning and the auto-cancellation. */
+  inactivity?: ProductionRunInactivity
+  /**
+   * Suppresses a repeat send of the SAME notification.
+   *
+   * 🔑 Only the inactivity warning passes one. A sweep is re-runnable by
+   * design and a partner must not be mailed "your run expires in 5 days" once
+   * per operator run — but `completed` / `cancelled` fire on a terminal state
+   * change that cannot repeat, so giving them a key would only risk
+   * suppressing a genuine send. The notification module skips a key it has
+   * already sent successfully and RETRIES one whose last attempt failed, which
+   * is exactly the behaviour a warning wants.
+   */
+  idempotencyKey?: string
+}
 
 // ---------------------------------------------------------------------------
 // Step: resolve partner (from the run when the event omits partner_id) + active
@@ -32,15 +54,7 @@ import {
 // ---------------------------------------------------------------------------
 const sendPartnerProductionRunStep = createStep(
   { name: "send-partner-production-run-notification", store: true },
-  async (
-    input: {
-      productionRunId: string
-      partnerId?: string
-      action: ProductionRunEmailAction
-      notes?: string
-    },
-    { container }
-  ) => {
+  async (input: SendPartnerProductionRunEmailInput, { container }) => {
     const { productionRunId, action } = input
 
     const templateKey = resolvePartnerProductionRunTemplateKey(action)
@@ -132,6 +146,7 @@ const sendPartnerProductionRunStep = createStep(
         run,
         action,
         notes: input.notes,
+        inactivity: input.inactivity,
         storeUrl: process.env.FRONTEND_URL || "",
         runUrlBase,
       })
@@ -144,6 +159,11 @@ const sendPartnerProductionRunStep = createStep(
           to: admin.email,
           channel: "email_partner",
           template: templateKey,
+          // Per-ADMIN, so a partner with two admins still gets two emails and
+          // only a repeat of the same warning to the same person is skipped.
+          ...(input.idempotencyKey
+            ? { idempotency_key: `${input.idempotencyKey}:${admin.email}` }
+            : {}),
           data: {
             ...templateData,
             _template_subject: renderedSubject,
@@ -171,12 +191,7 @@ const sendPartnerProductionRunStep = createStep(
 
 export const sendPartnerProductionRunEmailWorkflow = createWorkflow(
   { name: "send-partner-production-run-email", store: true },
-  (input: {
-    productionRunId: string
-    partnerId?: string
-    action: ProductionRunEmailAction
-    notes?: string
-  }) => {
+  (input: SendPartnerProductionRunEmailInput) => {
     const result = sendPartnerProductionRunStep(input)
     return new WorkflowResponse(result)
   }

--- a/apps/backend/src/workflows/production-runs/lib/cancel-production-run-cascade.ts
+++ b/apps/backend/src/workflows/production-runs/lib/cancel-production-run-cascade.ts
@@ -81,11 +81,17 @@ export const cancelSingleRun = async (
  * admin feed entry — both keyed on `production_run.cancelled`, and both read
  * `notes` for the reason. A cancel that skipped the emit would be silent to
  * everyone it affects.
+ *
+ * `eventData` rides along into that payload. The inactivity sweep uses it to
+ * carry how long the run was actually idle, so the partner's email can say "no
+ * activity for 81 days" rather than restating the 28-day rule at them (#1574).
+ * An admin cancel passes nothing and the mail renders exactly as before.
  */
 export const cancelProductionRunCascade = async (
   container: any,
   runId: string,
-  reason: string
+  reason: string,
+  eventData?: Record<string, unknown>
 ): Promise<CancelRunResult> => {
   const productionRunService: ProductionRunService = container.resolve(
     PRODUCTION_RUNS_MODULE
@@ -181,6 +187,7 @@ export const cancelProductionRunCascade = async (
           production_run_id: runId,
           action: "cancelled",
           notes: reason,
+          ...(eventData || {}),
         },
       },
     ])


### PR DESCRIPTION
Closes part of #1574. **Nothing here runs on its own** — both jobs are operator-triggered and dry-run by default.

## Why

The 28-day inactivity policy shipped as a verdict with no notice: the first a partner hears of the deadline is the mail saying it passed. Prod's case is a run **81 days** idle — nobody was ever told it was counting.

And that mail would not have said 81. `inactivityCancelReason(days)` was called once with the **policy window**, so every partner is told "cancelled automatically after 28 days" whatever their run actually did. It reports the rule instead of what happened.

## What's in it

| | |
|---|---|
| `warn-expiring-production-runs` | New ops job. Emails partners whose run is inside the lead-time (default 7 days out from 28). |
| `partner-production-run-expiring` | New template: idle days, the cancellation date, and what resets the clock. |
| `partner-production-run-cancelled` | Gains a conditional inactivity block. An admin cancel renders exactly as before. |
| cancel sweep | Reason is now per-run (`81 days`), and carries the inactivity facts into the event. |

**🔑 The warning set and the cancellation set are disjoint by construction** — a run past the window belongs to the sweep, and a warning arriving after the verdict would read as noise. Asserted both ways.

**🔑 Re-runnable without spamming.** The send carries an idempotency key of `run + cancel_on` — the *deadline*, not the send date. The notification module skips a delivered key and retries a failed one. Run it hourly; one warning per deadline. A run that moves and goes quiet again earns a new deadline and a new warning.

## Two holes found on the way

- 🔴 **No partner template could be updated on prod by `update-email-templates` at all.** It read only `seed-email-templates.ts`, so every partner key answered *"not found in seed data"* — and the seed itself skips existing rows. An edit to a partner body was invisible, silently.
- 🔴 **The partner seeder's existence check was `getTemplateByKey`, which filters `is_active: true` AND `locale: "en"`.** A deactivated row reads as absent ⇒ the seed creates a **second row with the same key**, and `getTemplateByKey` then returns `templates[0]` of an unordered list. Which body a partner receives becomes a coin flip.

## On the templates being untestable

These bodies live **only in a database** once seeded, so nothing else exercises the string a partner actually receives. A mis-nested `{{#if}}` renders as *silence* — Handlebars drops the branch, the mail still sends, still looks plausible, and omits the thing it existed to say.

So the new spec compiles the real seed strings, and **the instrument was checked against a mutant**: `inactive_days` → `inactive_dayz` turns it red. A first attempt at that mutation silently failed to apply and the suite "passed" — which is exactly the shape the test exists to catch.

## Deploy observability

The migrate gate's `Skipped` step promised in its own comment to name the base it compared against, and didn't — it printed a fixed line calling that base *"the last DEPLOYED commit"*, describing a design we deliberately do not have (the anchor is the last run that **applied** migrations, #1464). It now prints the actual sha and run id.

**Verified while investigating: #1577's constraint migration DID apply on prod.** `✔ Migrated Migration20260827061500`, run 33038679988 at 04:24:08Z. The back-to-back-merge stranding suspicion is closed — the pushes were 18 and 28 minutes apart and the #1464 anchor held.

## Verify

```
TEST_TYPE=unit npx jest --testPathPattern="(inactive-run|partner-production-run)"   # 37 pass
pnpm check:prod-build                                                               # green
```
Full unit suite: 413/417 suites. The 4 red are **pre-existing** — confirmed by stashing this branch and re-running them on a clean tree (identical 5 failures).

## Prod rollout (nothing done yet)

```
# 1. seed the new template + push the rewritten cancelled body — dry-run first
run_maintenance_job seed-email-templates { set: "partner", only: "partner-production-run-expiring" }
run_maintenance_job seed-email-templates { set: "partner", only: "partner-production-run-cancelled", overwrite: true }

# 2. see who would be warned
run_maintenance_job warn-expiring-production-runs (dry_run)
```

⚠️ The 28-day sweep still needs the founder's explicit go-ahead — it cancels `prod_run_01KTDS2N5DFWD6NNAPE220PD9T` and emails that partner. This PR makes that mail say *81 days* instead of *28*, and gives future partners a week's notice, but it does not run anything.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_0158wJMZ1DmjNxXf5uGuBrQD