### PR TITLE
test(e2e): the payable-work filter is addressed by testid — its accessible name carries a count (#1571)

### DIFF
--- a/apps/partner-ui/src/routes/payment-submissions/payment-submission-create/payment-submission-create.tsx
+++ b/apps/partner-ui/src/routes/payment-submissions/payment-submission-create/payment-submission-create.tsx
@@ -495,6 +495,12 @@ export const PaymentSubmissionCreate = () => {
                   key={value}
                   type="button"
                   role="tab"
+                  // 🔑 A stable hook, because the accessible NAME of this
+                  // button is "Runs 3" — the count badge is part of it. Any
+                  // selector matching on the name is one dispatched run away
+                  // from breaking, which is exactly what happened to the
+                  // @partnerui payout specs on their first green CI run.
+                  data-testid={`work-filter-${value}`}
                   aria-selected={typeFilter === value}
                   data-state={typeFilter === value ? "active" : "inactive"}
                   onClick={() => setTypeFilter(value)}

--- a/e2e/specs/partner-payment-submission-runs.spec.ts
+++ b/e2e/specs/partner-payment-submission-runs.spec.ts
@@ -123,7 +123,13 @@ test.describe("Partner payment submission from runs @partnerui (#1571)", () => {
   }) => {
     // One table with an All/Runs/Tasks filter — the per-source tabs are gone
     // (#1571). "Runs" narrows it; "All" (the default) already shows them.
-    const tab = page.getByRole("tab", { name: /^runs$/i })
+    //
+    // 🔴 Addressed by testid, NOT by accessible name. The filter renders a
+    // count badge inside the button, so its name is "Runs 3" and the anchored
+    // `getByRole("tab", { name: /^runs$/i })` this spec first shipped with
+    // matched nothing — all four cases timed out on their first CI run while
+    // the screen itself was correct.
+    const tab = page.getByTestId("work-filter-runs")
     await expect(tab).toBeVisible({ timeout: 30_000 })
     await tab.click()
 
@@ -148,7 +154,7 @@ test.describe("Partner payment submission from runs @partnerui (#1571)", () => {
   test("shows a run with no agreed rate rather than hiding or zero-billing it", async ({
     page,
   }) => {
-    await page.getByRole("tab", { name: /^runs$/i }).click()
+    await page.getByTestId("work-filter-runs").click()
     const card = runCard(page, seed.unpricedRunId)
     await expect(card).toBeVisible({ timeout: 30_000 })
     await expect(card).toContainText("2 made")
@@ -166,7 +172,7 @@ test.describe("Partner payment submission from runs @partnerui (#1571)", () => {
   test("submits a payout that records the run and bills quantity x rate", async ({
     page,
   }) => {
-    await page.getByRole("tab", { name: /^runs$/i }).click()
+    await page.getByTestId("work-filter-runs").click()
     const card = runCard(page, seed.partnerBillableRunId)
     await expect(card).toBeVisible({ timeout: 30_000 })
     await card.getByRole("checkbox").click()
@@ -214,7 +220,7 @@ test.describe("Partner payment submission from runs @partnerui (#1571)", () => {
   test("sums the quantity when two runs of one design are billed together", async ({
     page,
   }) => {
-    await page.getByRole("tab", { name: /^runs$/i }).click()
+    await page.getByTestId("work-filter-runs").click()
 
     const a = runCard(page, seed.partnerSumRunAId)
     await expect(a).toBeVisible({ timeout: 30_000 })


### PR DESCRIPTION
Fixes the 4 red `@partnerui` cases in main's e2e run [33044112792](https://github.com/Jaal-Yantra-Textiles/v2/actions/runs/33044112792) — the run #1579 was merged without seeing.

## The failure

All four timed out on the same line:

```
getByRole("tab", { name: /^runs$/i })
```

**The screen was correct.** The filter *is* `role="tab"` — but the button renders a count badge inside itself, so its accessible name is **`"Runs 3"`**, and an anchored regex can never match it. The spec this replaced used an *unanchored* `/production runs/i`, which is why the old tabs worked and the anchors added in #1579 did not.

51 tests passed in that run. The four that failed shared one locator.

## The fix

Root, not regex. A selector keyed on a name that embeds a **live count** is one dispatched run away from breaking again — so the filter now carries `data-testid="work-filter-<value>"` and the spec addresses that. The row selector `[data-run-id]` was already testid-based and is untouched.

⚠️ Same shape as the `waitForURL` regex that matched `/create`: the failure pointed at the screen, and the fault was in how the spec addressed it.

## Not stale, before anyone deletes it

`payment-submission-payable-runs.spec.ts` still asserts a `Production runs` tab and still **passes**. It drives `/app/...` — the admin screen, which #1579 never touched. Two different apps, two different screens.

## Verify

`tsc -p tsconfig.ci.json` names 0 errors in the changed file (the full run emits 1922 lines of pre-existing output, so the instrument is demonstrably live). The real proof is main's next e2e run.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_0158wJMZ1DmjNxXf5uGuBrQD