### PR TITLE
feat(ops): re-mirror cancelled runs whose order still reads as live work (#1574)

### DIFF
--- a/apps/backend/integration-tests/http/ops-remirror-cancelled-run-status.spec.ts
+++ b/apps/backend/integration-tests/http/ops-remirror-cancelled-run-status.spec.ts
@@ -1,0 +1,246 @@
+import { ContainerRegistrationKeys, Modules } from "@medusajs/framework/utils"
+
+import { createAdminUser, getAuthHeaders } from "../helpers/create-admin-user"
+import { setupSharedTestSuite, getSharedTestEnv } from "./shared-test-setup"
+import { setUnifiedOrderPartnerStatus } from "../../src/workflows/inventory_orders/dual-write-unified-order"
+
+jest.setTimeout(90 * 1000)
+
+/**
+ * #1574 — the cancelled-run status repair, end to end.
+ *
+ * The unit tests cover the CLASSIFICATION. They cannot cover the two things
+ * that would actually make this job dangerous in production:
+ *
+ *  1. **Does `unified_order_status.partner_status` resolve through
+ *     `query.graph` at all?** If it does not, `current_partner_status` is
+ *     `null` for every row, every row classifies as `stale`, and the job
+ *     "repairs" hundreds of healthy orders. A field the query never fetched
+ *     reads exactly like a field whose value is absent.
+ *
+ *  2. **Does the readback observe a real write?** The mirror swallows its own
+ *     failures, so a repair that reported success while writing nothing would
+ *     look identical to one that worked.
+ *
+ * 🔑 The fixture manufactures the PRE-#1577 state deliberately. Cancelling a
+ * run today writes `partner_status = "cancelled"` correctly — that is the fix.
+ * The ~40 prod rows are ones that transitioned while the derivation returned
+ * `undefined`, so the sidecar kept its last live value. Forcing the sidecar
+ * back to `in_progress` after the cancel reproduces exactly that row, and it
+ * is the only way to make this test fail when the job is broken.
+ */
+setupSharedTestSuite(() => {
+  describe("ops: remirror-cancelled-run-status (#1574)", () => {
+    const { api, getContainer } = getSharedTestEnv()
+    let adminHeaders: { headers: Record<string, string> }
+
+    beforeAll(async () => {
+      await createAdminUser(getContainer())
+      adminHeaders = await getAuthHeaders(api)
+    })
+
+    // 🔴 Per-test, not in beforeAll: the runner restores a DB snapshot before
+    // every test, so a region created once would be gone by the second one.
+    beforeEach(async () => {
+      await createRegion()
+    })
+
+    /**
+     * A region has to exist before a run projects — the unified order needs a
+     * currency. Without it the projection is skipped and the run has no order,
+     * which reads exactly like a broken link.
+     */
+    const createRegion = async () => {
+      const regionService: any = getContainer().resolve(Modules.REGION)
+      const region = await regionService.createRegions({
+        name: "India",
+        currency_code: "inr",
+        countries: ["in"],
+      })
+      return region.id
+    }
+
+    /**
+     * A cancelled run and the unified order it is linked to.
+     *
+     * ⚠️ The TOP-LEVEL run, not `children[0]`. An assignment's child run is
+     * not projected to a unified order, so a fixture built on it reports
+     * `no_unified_order` and every assertion below fails for a reason that has
+     * nothing to do with the job. No partner is needed at all —
+     * `deriveRunPartnerStatus` reads `run.status`, and a cancelled run says
+     * "cancelled" whoever was holding it.
+     */
+    const cancelledRunWithOrder = async (unique: number) => {
+      const designRes = await api.post(
+        "/admin/designs",
+        {
+          name: `Remirror Design ${unique}`,
+          description: "x",
+          design_type: "Original",
+          status: "Approved",
+          priority: "Medium",
+        },
+        adminHeaders
+      )
+      const designId = designRes.data.design.id
+
+      const run = await api.post(
+        `/admin/designs/${designId}/production-runs`,
+        { quantity: 5 },
+        adminHeaders
+      )
+      expect(run.status).toBe(201)
+      const runId = run.data.production_run?.id
+      expect(runId).toBeTruthy()
+
+      const cancel = await api.post(
+        `/admin/production-runs/${runId}/cancel`,
+        { reason: "manufacturing the pre-#1577 row" },
+        adminHeaders
+      )
+      expect(cancel.status).toBeLessThan(300)
+
+      return { runId: runId as string, designId }
+    }
+
+    /** Read the sidecar the way nothing in the job does — independently. */
+    const readSidecar = async (runId: string) => {
+      const query: any = getContainer().resolve(ContainerRegistrationKeys.QUERY)
+      const { data: runRows } = await query.graph({
+        entity: "production_runs",
+        fields: ["id", "order.id"],
+        filters: { id: runId },
+      })
+      const orderId = runRows?.[0]?.order?.id
+      if (!orderId) return { orderId: undefined, partner_status: undefined }
+      const { data } = await query.graph({
+        entity: "order",
+        fields: ["id", "unified_order_status.partner_status"],
+        filters: { id: orderId },
+      })
+      return {
+        orderId,
+        partner_status: data?.[0]?.unified_order_status?.partner_status,
+      }
+    }
+
+    const runJob = async (params: Record<string, unknown>, dry_run: boolean) => {
+      const res = await api.post(
+        "/admin/ops/maintenance-jobs/remirror-cancelled-run-status/run",
+        { dry_run, params },
+        adminHeaders
+      )
+      expect(res.status).toBeLessThan(300)
+      return res.data.result
+    }
+
+    it("is listed as a maintenance job", async () => {
+      const res = await api.get("/admin/ops/maintenance-jobs", adminHeaders)
+      const ids = (res.data.jobs || []).map((j: any) => j.id)
+      expect(ids).toContain("remirror-cancelled-run-status")
+    })
+
+    it("🔑 repairs a stale sidecar and PROVES the write landed by re-reading it", async () => {
+      const unique = Date.now()
+      const { runId } = await cancelledRunWithOrder(unique)
+
+      // The cancel path works today — this is #1577, and it is also what makes
+      // the fixture below a deliberate regression rather than a lucky state.
+      const afterCancel = await readSidecar(runId)
+      expect(afterCancel.orderId).toBeTruthy()
+      expect(afterCancel.partner_status).toBe("cancelled")
+
+      // Manufacture the pre-#1577 row: the sidecar keeps its last live value
+      // because the derivation returned `undefined` and the mirror writes only
+      // truthy values.
+      await setUnifiedOrderPartnerStatus(
+        getContainer() as any,
+        afterCancel.orderId,
+        "in_progress"
+      )
+      expect((await readSidecar(runId)).partner_status).toBe("in_progress")
+
+      // ── dry run ────────────────────────────────────────────────────────
+      const dry = await runJob({ production_run_id: runId }, true)
+      expect(dry.dry_run).toBe(true)
+      expect(dry.applied).toBe(false)
+      expect(dry.changes).toHaveLength(1)
+      expect(dry.changes[0]).toMatchObject({
+        entity: "order",
+        id: afterCancel.orderId,
+        field: "partner_status",
+        before: "in_progress",
+        after: "cancelled",
+      })
+      // 🔴 A dry run that wrote would be the worst possible bug in a repair job.
+      expect((await readSidecar(runId)).partner_status).toBe("in_progress")
+
+      // ── apply ──────────────────────────────────────────────────────────
+      const applied = await runJob({ production_run_id: runId }, false)
+      expect(applied.applied).toBe(true)
+      expect(applied.errors ?? []).toHaveLength(0)
+
+      // The assertion that matters. Read independently of anything the job
+      // returned — the job's own summary is a claim, the column is the fact.
+      expect((await readSidecar(runId)).partner_status).toBe("cancelled")
+
+      // ── idempotent ─────────────────────────────────────────────────────
+      const second = await runJob({ production_run_id: runId }, true)
+      expect(second.changes).toHaveLength(0)
+      expect(second.summary).toContain("1 already correct")
+    })
+
+    it("🔴 leaves an order that is ALREADY correct alone — the graph read really resolves the sidecar", async () => {
+      // If `unified_order_status.partner_status` did not resolve through
+      // query.graph, this row would read `null`, classify as `stale`, and the
+      // job would "repair" a healthy order. That failure is invisible in the
+      // test above, where the expected value happens to be what a broken read
+      // would drive it to anyway.
+      const unique = Date.now() + 1
+      const { runId } = await cancelledRunWithOrder(unique)
+      expect((await readSidecar(runId)).partner_status).toBe("cancelled")
+
+      const dry = await runJob({ production_run_id: runId }, true)
+      expect(dry.changes).toHaveLength(0)
+      expect(dry.summary).toContain("0 stale")
+      expect(dry.summary).toContain("1 already correct")
+    })
+
+    it("reports every bucket it examined, not just the stale ones", async () => {
+      const unique = Date.now() + 2
+      const { runId } = await cancelledRunWithOrder(unique)
+
+      const verbose = await runJob(
+        { production_run_id: runId, verbose: true },
+        true
+      )
+      expect(verbose.changes).toHaveLength(1)
+      expect(verbose.changes[0].note).toContain("already_correct")
+      expect(verbose.summary).toMatch(
+        /examined 1: \d+ stale, \d+ already correct, \d+ undeterminable, \d+ superseded, \d+ unlinked/
+      )
+    })
+
+    it('does not read the string "false" as true', async () => {
+      // `z.coerce.boolean()` would: Boolean("false") === true. Params arrive
+      // over HTTP as strings, so this is the shape that actually ships.
+      const unique = Date.now() + 3
+      const { runId } = await cancelledRunWithOrder(unique)
+      const res = await runJob(
+        { production_run_id: runId, verbose: "false" },
+        true
+      )
+      expect(res.changes).toHaveLength(0)
+    })
+
+    it("refuses a status it does not sweep", async () => {
+      await expect(
+        api.post(
+          "/admin/ops/maintenance-jobs/remirror-cancelled-run-status/run",
+          { dry_run: true, params: { status: "not_a_status" } },
+          adminHeaders
+        )
+      ).rejects.toThrow()
+    })
+  })
+})

--- a/apps/backend/src/api/admin/ops/maintenance-jobs/__tests__/cancelled-run-status-remirror.unit.spec.ts
+++ b/apps/backend/src/api/admin/ops/maintenance-jobs/__tests__/cancelled-run-status-remirror.unit.spec.ts
@@ -1,0 +1,150 @@
+import {
+  decideRunStatusRemirrors,
+  expectedPartnerStatusFor,
+  summarizeRemirrorDecisions,
+  type MirrorCandidate,
+} from "../lib/cancelled-run-status-remirror"
+
+/**
+ * #1574 — the classification behind the cancelled-run repair.
+ *
+ * The bug being repaired is that a cancelled run left `partner_status` saying
+ * `in_progress` forever. The risk in the REPAIR is the mirror image: writing
+ * "cancelled" onto an order that is legitimately still live because only one
+ * of its runs was called off. Both directions are asserted here.
+ */
+const run = (
+  id: string,
+  status: string,
+  stamps: Record<string, string> = {}
+) => ({ id, status, ...stamps })
+
+const candidate = (over: Partial<MirrorCandidate>): MirrorCandidate => ({
+  run_id: "prod_run_1",
+  run: run("prod_run_1", "cancelled"),
+  unified_order_id: "order_1",
+  linked_runs: [run("prod_run_1", "cancelled")],
+  ...over,
+})
+
+describe("decideRunStatusRemirrors", () => {
+  it("flags the #1577 case — a cancelled run whose order still says in_progress", () => {
+    const [d] = decideRunStatusRemirrors([
+      candidate({ current_partner_status: "in_progress" }),
+    ])
+    expect(d.verdict).toBe("stale")
+    expect(d.current_partner_status).toBe("in_progress")
+    expect(d.expected_partner_status).toBe("cancelled")
+  })
+
+  it("flags an order whose sidecar was never written at all", () => {
+    const [d] = decideRunStatusRemirrors([
+      candidate({ current_partner_status: null }),
+    ])
+    expect(d.verdict).toBe("stale")
+    expect(d.note).toContain("(unset)")
+  })
+
+  it("leaves a run that already reads cancelled alone", () => {
+    const [d] = decideRunStatusRemirrors([
+      candidate({ current_partner_status: "cancelled" }),
+    ])
+    expect(d.verdict).toBe("already_correct")
+  })
+
+  it("🔴 does NOT cancel a collated order that is still live", () => {
+    // One cancelled run among four in flight. Predicting "cancelled" here
+    // would make the repair write a lie onto a healthy order — the exact
+    // inverse of the bug it exists to fix.
+    const linked = [
+      run("prod_run_1", "cancelled"),
+      run("prod_run_2", "in_progress", { started_at: "2026-08-01T00:00:00Z" }),
+      run("prod_run_3", "in_progress", { accepted_at: "2026-08-01T00:00:00Z" }),
+      run("prod_run_4", "sent_to_partner"),
+    ]
+    const [d] = decideRunStatusRemirrors([
+      candidate({ linked_runs: linked, current_partner_status: "assigned" }),
+    ])
+    expect(d.expected_partner_status).toBe("assigned")
+    expect(d.verdict).toBe("already_correct")
+  })
+
+  it("cancels a collated order only when every run is cancelled", () => {
+    const linked = [
+      run("prod_run_1", "cancelled"),
+      run("prod_run_2", "cancelled"),
+    ]
+    const [d] = decideRunStatusRemirrors([
+      candidate({ linked_runs: linked, current_partner_status: "finished" }),
+    ])
+    expect(d.verdict).toBe("stale")
+    expect(d.expected_partner_status).toBe("cancelled")
+    expect(d.note).toContain("collated order of 2 runs")
+  })
+
+  it("🔑 reports an unjudgeable row as undeterminable, never as correct", () => {
+    // A draft run derives no partner_status, so the mirror would write
+    // nothing. Calling that "already_correct" is how the original bug hid.
+    const [d] = decideRunStatusRemirrors([
+      candidate({
+        run: run("prod_run_1", "draft"),
+        linked_runs: [run("prod_run_1", "draft")],
+        current_partner_status: "in_progress",
+      }),
+    ])
+    expect(d.verdict).toBe("undeterminable")
+    expect(d.expected_partner_status).toBeUndefined()
+  })
+
+  it("skips a superseded parent and an unlinked run without calling them broken", () => {
+    const [sup, unlinked] = decideRunStatusRemirrors([
+      candidate({ superseded: true, current_partner_status: "in_progress" }),
+      candidate({ run_id: "prod_run_9", unified_order_id: null }),
+    ])
+    expect(sup.verdict).toBe("superseded")
+    expect(unlinked.verdict).toBe("no_unified_order")
+  })
+})
+
+describe("expectedPartnerStatusFor", () => {
+  it("uses the per-run mapping for a single-run order", () => {
+    expect(
+      expectedPartnerStatusFor(
+        candidate({
+          run: run("prod_run_1", "in_progress", {
+            finished_at: "2026-08-01T00:00:00Z",
+          }),
+          linked_runs: [
+            run("prod_run_1", "in_progress", {
+              finished_at: "2026-08-01T00:00:00Z",
+            }),
+          ],
+        })
+      )
+    ).toBe("finished")
+  })
+})
+
+describe("summarizeRemirrorDecisions", () => {
+  it("counts every bucket, so a summary never implies the ones it omits", () => {
+    const counts = summarizeRemirrorDecisions(
+      decideRunStatusRemirrors([
+        candidate({ current_partner_status: "in_progress" }),
+        candidate({ current_partner_status: "cancelled" }),
+        candidate({ unified_order_id: null }),
+        candidate({ superseded: true }),
+        candidate({
+          run: run("prod_run_5", "approved"),
+          linked_runs: [run("prod_run_5", "approved")],
+        }),
+      ])
+    )
+    expect(counts).toEqual({
+      stale: 1,
+      already_correct: 1,
+      no_unified_order: 1,
+      superseded: 1,
+      undeterminable: 1,
+    })
+  })
+})

--- a/apps/backend/src/api/admin/ops/maintenance-jobs/lib/cancelled-run-status-remirror.ts
+++ b/apps/backend/src/api/admin/ops/maintenance-jobs/lib/cancelled-run-status-remirror.ts
@@ -1,0 +1,168 @@
+import {
+  aggregatePartnerStatus,
+  deriveRunPartnerStatus,
+} from "../../../../../workflows/production-runs/lib/run-partner-status"
+
+/**
+ * #1574 — which cancelled runs are still telling their order they are live.
+ *
+ * ## Why a repair job exists at all
+ *
+ * `mirrorRunStatusToUnifiedOrder` fires on a status CHANGE. #1577 fixed the
+ * derivation so that a cancel now writes `partner_status = "cancelled"` — but
+ * it fixed the FUTURE. Every run cancelled before that deploy transitioned
+ * while the derivation returned `undefined`, the mirror writes only truthy
+ * values, and so the sidecar kept whatever it last said: `assigned`,
+ * `accepted`, `in_progress`, `finished`. Those orders still render as work in
+ * progress and no later event will ever revisit them — nothing changes status
+ * on a run that is already terminal.
+ *
+ * ## Why it has to REPORT rather than repair quietly
+ *
+ * 🔴 `mirrorRunStatusToUnifiedOrder` catches everything and logs a warning:
+ *
+ *     catch (e) { logger.warn(...); return { linked: false, error } }
+ *
+ * That is why an admin cancel could return **200** while its status write was
+ * rejected by the database. A repair built on the same call would inherit the
+ * same blindness — it would report "40 repaired" whether or not a single row
+ * changed. So the job re-READS the sidecar afterwards and reports the value it
+ * actually finds, and a row that did not move is an ERROR, not a warning.
+ *
+ * ## Expectations are computed with the mirror's OWN helpers
+ *
+ * 🔑 `expectedPartnerStatusFor` calls `aggregatePartnerStatus` /
+ * `deriveRunPartnerStatus` — the same functions the mirror uses — rather than
+ * re-deriving "cancelled runs should say cancelled". A second implementation
+ * of that rule is how the two drift apart, and the drift is the bug this job
+ * exists to repair.
+ */
+
+export type LinkedRunSnapshot = {
+  id: string
+  status?: string | null
+  accepted_at?: string | Date | null
+  started_at?: string | Date | null
+  finished_at?: string | Date | null
+}
+
+export type MirrorCandidate = {
+  run_id: string
+  run: LinkedRunSnapshot
+  unified_order_id?: string | null
+  /** A parent order superseded by a run split stays canceled on purpose. */
+  superseded?: boolean
+  current_partner_status?: string | null
+  /** Every run linked to the same order — a collated work-order has many. */
+  linked_runs: LinkedRunSnapshot[]
+}
+
+export type RemirrorVerdict =
+  | "stale"
+  | "already_correct"
+  | "no_unified_order"
+  | "superseded"
+  | "undeterminable"
+
+export type RemirrorDecision = {
+  run_id: string
+  unified_order_id?: string
+  verdict: RemirrorVerdict
+  expected_partner_status?: string
+  current_partner_status?: string
+  /** Why, in the operator's terms — a dry-run nobody can argue with is no use. */
+  note: string
+}
+
+/**
+ * What the mirror WOULD write for this order, by the mirror's own rules.
+ *
+ * A collated order (N runs → 1 order) rolls up across every run, so a single
+ * cancelled run among four in flight correctly leaves the order reading
+ * `in_progress`. Predicting "cancelled" for those would make the job report
+ * healthy orders as broken and then "repair" them into a lie.
+ */
+export const expectedPartnerStatusFor = (
+  candidate: MirrorCandidate
+): string | undefined =>
+  candidate.linked_runs.length > 1
+    ? aggregatePartnerStatus(candidate.linked_runs)
+    : deriveRunPartnerStatus(candidate.run)
+
+export const decideRunStatusRemirrors = (
+  candidates: MirrorCandidate[]
+): RemirrorDecision[] =>
+  (candidates || []).map((c) => {
+    const current = c.current_partner_status ?? null
+
+    if (!c.unified_order_id) {
+      return {
+        run_id: c.run_id,
+        verdict: "no_unified_order" as const,
+        note: "no unified order is linked to this run — nothing to mirror onto",
+      }
+    }
+    if (c.superseded) {
+      return {
+        run_id: c.run_id,
+        unified_order_id: c.unified_order_id,
+        verdict: "superseded" as const,
+        current_partner_status: current ?? undefined,
+        note: "order superseded by a run split — the child orders carry the commercial reality",
+      }
+    }
+
+    const expected = expectedPartnerStatusFor(c)
+
+    if (!expected) {
+      // 🔑 NOT "already_correct". The mirror writes only truthy values, so it
+      // would leave this row exactly as it is — which means the job cannot say
+      // the row is right, only that it cannot judge it. Reporting that as
+      // healthy is how the original bug hid.
+      return {
+        run_id: c.run_id,
+        unified_order_id: c.unified_order_id,
+        verdict: "undeterminable" as const,
+        current_partner_status: current ?? undefined,
+        note: `no partner_status is derivable from run status "${c.run.status}" — the mirror would write nothing`,
+      }
+    }
+
+    if (current === expected) {
+      return {
+        run_id: c.run_id,
+        unified_order_id: c.unified_order_id,
+        verdict: "already_correct" as const,
+        expected_partner_status: expected,
+        current_partner_status: current,
+        note: `already "${expected}"`,
+      }
+    }
+
+    return {
+      run_id: c.run_id,
+      unified_order_id: c.unified_order_id,
+      verdict: "stale" as const,
+      expected_partner_status: expected,
+      current_partner_status: current ?? undefined,
+      note:
+        c.linked_runs.length > 1
+          ? `collated order of ${c.linked_runs.length} runs: says "${current ?? "(unset)"}", rolls up to "${expected}"`
+          : `says "${current ?? "(unset)"}", should say "${expected}"`,
+    }
+  })
+
+/** Counts per verdict, so a summary never implies the buckets it omitted. */
+export const summarizeRemirrorDecisions = (
+  decisions: RemirrorDecision[]
+): Record<RemirrorVerdict, number> => {
+  const out: Record<RemirrorVerdict, number> = {
+    stale: 0,
+    already_correct: 0,
+    no_unified_order: 0,
+    superseded: 0,
+    undeterminable: 0,
+  }
+  for (const d of decisions) out[d.verdict]++
+  return out
+}

--- a/apps/backend/src/api/admin/ops/maintenance-jobs/registry.ts
+++ b/apps/backend/src/api/admin/ops/maintenance-jobs/registry.ts
@@ -103,6 +103,7 @@ import { repairInventoryOrderSourceJob } from "./repair-inventory-order-source-j
 import { repairInventoryOrderRouteJob } from "./repair-inventory-order-route-job"
 import { cancelInactiveProductionRunsJob } from "./cancel-inactive-production-runs-job"
 import { warnExpiringProductionRunsJob } from "./warn-expiring-production-runs-job"
+import { remirrorCancelledRunStatusJob } from "./remirror-cancelled-run-status-job"
 import { rewindProductionRunJob } from "./rewind-production-run-job"
 import { repairConsumptionLogJob } from "./repair-consumption-log-job"
 import { setLocationOwnershipJob } from "./set-location-ownership-job"
@@ -5804,6 +5805,7 @@ export const seedGoodsTransferTaskTemplateJob: MaintenanceJob = {
 export const MAINTENANCE_JOBS: MaintenanceJob[] = [
   cancelInactiveProductionRunsJob,
   warnExpiringProductionRunsJob,
+  remirrorCancelledRunStatusJob,
   cleanOrderFulfillmentDataJob,
   sendCourierChangedEmailJob,
   resendShipmentEmailJob,

--- a/apps/backend/src/api/admin/ops/maintenance-jobs/remirror-cancelled-run-status-job.ts
+++ b/apps/backend/src/api/admin/ops/maintenance-jobs/remirror-cancelled-run-status-job.ts
@@ -1,0 +1,273 @@
+import { ContainerRegistrationKeys, MedusaError } from "@medusajs/framework/utils"
+import { z } from "@medusajs/framework/zod"
+
+import { mirrorRunStatusToUnifiedOrder } from "../../../../workflows/production-runs/dual-write-unified-run-order"
+import { resolveUnifiedOrderIdByLink } from "../../../../workflows/inventory_orders/dual-write-unified-order"
+import {
+  decideRunStatusRemirrors,
+  summarizeRemirrorDecisions,
+  type MirrorCandidate,
+} from "./lib/cancelled-run-status-remirror"
+import type {
+  MaintenanceChange,
+  MaintenanceJob,
+  MaintenanceJobResult,
+} from "./registry"
+
+/**
+ * Data Plumbing — re-mirror terminal runs whose order still reads as live work.
+ *
+ * ## The gap this closes
+ *
+ * `mirrorRunStatusToUnifiedOrder` fires on a status CHANGE. #1577 fixed the
+ * derivation so a cancel writes `partner_status = "cancelled"` — but it fixed
+ * the FUTURE. Runs cancelled before that deploy transitioned while the
+ * derivation returned `undefined`; the mirror writes only truthy values, so
+ * the sidecar kept whatever it last said. Prod carries roughly 40 of them and
+ * nothing will ever revisit them: no event fires on a run that is already
+ * terminal.
+ *
+ * ## 🔑 It is an instrument before it is a repair
+ *
+ * The mirror swallows its own failures — `catch { logger.warn(...) }` — which
+ * is exactly why an admin cancel could return 200 while the database rejected
+ * its status write. A repair built on that call alone would report "40
+ * repaired" whether or not one row moved.
+ *
+ * So every apply RE-READS the sidecar afterwards and reports the value it
+ * actually finds:
+ *
+ *   - moved to the expected value  → repaired
+ *   - unchanged, or moved elsewhere → an ERROR entry naming both values
+ *
+ * That readback is what can answer "did the write land?" for a boundary that
+ * refuses to tell you. It is also the check that would have caught the
+ * `unified_order_status` constraint never widening to accept `cancelled`.
+ *
+ * ## What it deliberately does not do
+ *
+ * 🔑 It never predicts "cancelled". Expectations come from the mirror's OWN
+ * helpers, so a collated order with one cancelled run among four in flight
+ * correctly stays `in_progress`. A second implementation of that rule is how
+ * the two drift apart, and the drift is the bug being repaired.
+ *
+ * 🔑 A run whose status derives no partner_status is reported `undeterminable`,
+ * never `already_correct`. The mirror would write nothing for it, so the job
+ * cannot vouch for the row — and calling an unjudgeable row healthy is how the
+ * original bug hid for months.
+ */
+
+const paramsSchema = z.object({
+  /** Which run status to sweep. Default "cancelled" — the #1577 gap. */
+  status: z
+    .enum(["cancelled", "completed", "in_progress", "sent_to_partner"])
+    .optional(),
+  /** Cap the number re-mirrored in one pass. Default 100. */
+  limit: z.coerce.number().int().min(1).max(1000).optional(),
+  /** Only consider this run — for verifying the decision on one row. */
+  production_run_id: z.string().min(1).optional(),
+  /**
+   * Report every bucket, not just the stale ones. Off by default because a
+   * healthy prod would otherwise return hundreds of no-op rows.
+   */
+  verbose: z.coerce.boolean().optional(),
+})
+
+const DEFAULT_STATUS = "cancelled"
+const DEFAULT_LIMIT = 100
+
+/** Current sidecar + core status for an order, read fresh. */
+const readOrderStatus = async (
+  query: any,
+  orderId: string
+): Promise<{
+  partner_status?: string | null
+  core_status?: string | null
+  superseded: boolean
+  linked_runs: any[]
+}> => {
+  const { data } = await query.graph({
+    entity: "order",
+    fields: [
+      "id",
+      "status",
+      "metadata",
+      "unified_order_status.partner_status",
+      "production_runs.id",
+      "production_runs.status",
+      "production_runs.accepted_at",
+      "production_runs.started_at",
+      "production_runs.finished_at",
+    ],
+    filters: { id: orderId },
+  })
+  const row = data?.[0]
+  return {
+    partner_status: row?.unified_order_status?.partner_status ?? null,
+    core_status: row?.status ?? null,
+    superseded: Boolean(row?.metadata?.superseded_by_run_ids),
+    linked_runs: (row?.production_runs ?? []).filter(Boolean),
+  }
+}
+
+export const remirrorCancelledRunStatusJob: MaintenanceJob = {
+  id: "remirror-cancelled-run-status",
+  label: "Re-mirror terminal runs whose unified order still reads as live work",
+  description:
+    "Finds production runs in a terminal state (default cancelled) whose unified order's partner_status disagrees with what the mirror would derive today, re-runs the mirror, and RE-READS the sidecar to report the value it actually finds. #1577 fixed the derivation going forward; runs cancelled before that deploy were never revisited, because no event fires on a run that is already terminal. Expectations use the mirror's own aggregation helpers, so a collated order with one cancelled run among four in flight correctly stays in_progress. A row that does not move is reported as an ERROR, never a warning — the mirror swallows its own failures, which is how an admin cancel could return 200 while the database rejected the write. Dry-run lists every disagreement with both values, and counts every bucket it did not select.",
+  params: [
+    {
+      name: "status",
+      type: "string",
+      required: false,
+      description:
+        "Run status to sweep: cancelled (default), completed, in_progress or sent_to_partner. Only 'cancelled' is a known gap; the others are for verifying the instrument against rows that should already be correct.",
+    },
+    {
+      name: "limit",
+      type: "number",
+      required: false,
+      description: "Maximum runs to re-mirror in one pass. Default 100.",
+    },
+    {
+      name: "production_run_id",
+      type: "string",
+      required: false,
+      description:
+        "Consider only this run. Useful to check one row's decision before sweeping.",
+    },
+    {
+      name: "verbose",
+      type: "boolean",
+      required: false,
+      description:
+        "List every run examined, not just the stale ones. Counts are always reported either way.",
+    },
+  ],
+  run: async (container, { dry_run, params }): Promise<MaintenanceJobResult> => {
+    const parsed = paramsSchema.safeParse(params ?? {})
+    if (!parsed.success) {
+      throw new MedusaError(
+        MedusaError.Types.INVALID_DATA,
+        `Invalid params: ${parsed.error.issues.map((i) => i.message).join(", ")}`
+      )
+    }
+
+    const status = parsed.data.status ?? DEFAULT_STATUS
+    const limit = parsed.data.limit ?? DEFAULT_LIMIT
+    const onlyId = parsed.data.production_run_id
+    const verbose = parsed.data.verbose === true
+
+    const query = container.resolve(ContainerRegistrationKeys.QUERY) as any
+
+    const { data: runs } = await query.graph({
+      entity: "production_runs",
+      fields: [
+        "id",
+        "status",
+        "accepted_at",
+        "started_at",
+        "finished_at",
+      ],
+      filters: onlyId ? { id: onlyId } : { status },
+    })
+
+    const candidates: MirrorCandidate[] = []
+    for (const run of (runs || []) as any[]) {
+      const unifiedOrderId = await resolveUnifiedOrderIdByLink(
+        container as any,
+        "production_runs",
+        String(run.id)
+      )
+      if (!unifiedOrderId) {
+        candidates.push({
+          run_id: String(run.id),
+          run,
+          unified_order_id: null,
+          linked_runs: [run],
+        })
+        continue
+      }
+      const order = await readOrderStatus(query, unifiedOrderId)
+      candidates.push({
+        run_id: String(run.id),
+        run,
+        unified_order_id: unifiedOrderId,
+        superseded: order.superseded,
+        current_partner_status: order.partner_status,
+        // Fall back to the run itself so a link-less graph read never makes a
+        // single-run order look collated (or empty, which aggregates to
+        // undefined and would read as "undeterminable").
+        linked_runs: order.linked_runs.length ? order.linked_runs : [run],
+      })
+    }
+
+    const decisions = decideRunStatusRemirrors(candidates)
+    const counts = summarizeRemirrorDecisions(decisions)
+    const stale = decisions.filter((d) => d.verdict === "stale")
+    const selected = stale.slice(0, limit)
+    const dropped = stale.length - selected.length
+
+    const reported = verbose ? decisions : selected
+    const changes: MaintenanceChange[] = reported.map((d) => ({
+      entity: "order",
+      id: d.unified_order_id ?? d.run_id,
+      field: "partner_status",
+      before: d.current_partner_status ?? null,
+      after: d.expected_partner_status ?? null,
+      note: `run ${d.run_id} (${status}) — ${d.verdict}: ${d.note}`,
+    }))
+
+    // 🔑 Every bucket, every time. "12 stale" alone reads as "and the other 28
+    // are fine" when one of them may be a row nothing can judge.
+    const bucketLine = `examined ${decisions.length}: ${counts.stale} stale, ${counts.already_correct} already correct, ${counts.undeterminable} undeterminable, ${counts.superseded} superseded, ${counts.no_unified_order} unlinked`
+
+    if (dry_run) {
+      return {
+        job_id: "remirror-cancelled-run-status",
+        dry_run: true,
+        applied: false,
+        summary: `${bucketLine}; would re-mirror ${selected.length}${dropped ? ` (${dropped} beyond the limit of ${limit})` : ""}.`,
+        changes,
+      }
+    }
+
+    const errors: Array<{ id: string; message: string }> = []
+    let repaired = 0
+
+    for (const decision of selected) {
+      try {
+        await mirrorRunStatusToUnifiedOrder(container as any, decision.run_id)
+
+        // 🔴 The readback IS the job. The call above returns `{ linked: false,
+        // error }` on failure and logs a warning — trusting it would report a
+        // repair that never happened.
+        const after = await readOrderStatus(query, decision.unified_order_id!)
+        const landed = after.partner_status ?? null
+
+        if (landed === decision.expected_partner_status) {
+          repaired++
+          continue
+        }
+        errors.push({
+          id: decision.run_id,
+          message:
+            landed === (decision.current_partner_status ?? null)
+              ? `mirror reported no error but partner_status is still "${landed ?? "(unset)"}" — expected "${decision.expected_partner_status}". The write did not land.`
+              : `partner_status moved to "${landed ?? "(unset)"}", not the expected "${decision.expected_partner_status}".`,
+        })
+      } catch (e: any) {
+        errors.push({ id: decision.run_id, message: e?.message || String(e) })
+      }
+    }
+
+    return {
+      job_id: "remirror-cancelled-run-status",
+      dry_run: false,
+      applied: repaired > 0,
+      summary: `${bucketLine}; re-mirrored ${repaired} of ${selected.length}${dropped ? ` (${dropped} beyond the limit of ${limit})` : ""}${errors.length ? `; ${errors.length} did NOT land — see errors` : ""}.`,
+      changes,
+      ...(errors.length ? { errors } : {}),
+    }
+  },
+}

--- a/apps/backend/src/api/admin/ops/maintenance-jobs/remirror-cancelled-run-status-job.ts
+++ b/apps/backend/src/api/admin/ops/maintenance-jobs/remirror-cancelled-run-status-job.ts
@@ -70,7 +70,10 @@ const paramsSchema = z.object({
    * Report every bucket, not just the stale ones. Off by default because a
    * healthy prod would otherwise return hundreds of no-op rows.
    */
-  verbose: z.coerce.boolean().optional(),
+  // 🔴 NOT z.coerce.boolean() — `Boolean("false")` is TRUE, so a param sent
+  // as the string "false" (which is how it arrives over HTTP) would turn
+  // verbose ON. Match the literal, like seed-email-templates' `overwrite`.
+  verbose: z.union([z.boolean(), z.enum(["true", "false"])]).optional(),
 })
 
 const DEFAULT_STATUS = "cancelled"
@@ -156,7 +159,7 @@ export const remirrorCancelledRunStatusJob: MaintenanceJob = {
     const status = parsed.data.status ?? DEFAULT_STATUS
     const limit = parsed.data.limit ?? DEFAULT_LIMIT
     const onlyId = parsed.data.production_run_id
-    const verbose = parsed.data.verbose === true
+    const verbose = parsed.data.verbose === true || parsed.data.verbose === "true"
 
     const query = container.resolve(ContainerRegistrationKeys.QUERY) as any
 


### PR DESCRIPTION
Closes prod red #2 from the session handoff: **~40 cancelled prod runs may still read as live work.** Nothing runs on its own — the job is operator-triggered and dry-run by default.

## The gap

#1577 fixed the derivation so an admin cancel writes `partner_status = "cancelled"`. It fixed the **future**. Runs cancelled before that deploy transitioned while the derivation returned `undefined`, and the mirror writes only truthy values — so the sidecar kept whatever it last said: `assigned`, `accepted`, `in_progress`, `finished`. Nothing will ever revisit them: **no event fires on a run that is already terminal.**

## 🔑 It is an instrument before it is a repair

`mirrorRunStatusToUnifiedOrder` catches everything and logs a warning:

```ts
catch (e) { logger.warn(...); return { linked: false, error } }
```

That is why an admin cancel could return **200** while the database rejected its status write. A repair built on that call alone would report *"40 repaired"* whether or not a single row moved.

So every apply **re-reads the sidecar afterwards** and reports the value it actually finds:

| readback | outcome |
|---|---|
| moved to the expected value | repaired |
| unchanged | **error** — "the write did not land", naming both values |
| moved somewhere else | **error** — naming what it became |

That readback is the only thing that can answer *"did the write land?"* for a boundary that refuses to say. It is also the check that would have caught the `unified_order_status` constraint never widening.

## Two ways to get the repair wrong, both closed

🔴 **Writing "cancelled" onto a healthy order.** A collated work-order is N runs → 1 order, so one cancelled run among four in flight legitimately stays `in_progress`. Expectations come from the mirror's **own** helpers (`aggregatePartnerStatus` / `deriveRunPartnerStatus`), not a second implementation of "cancelled runs should say cancelled" — a second implementation is how the two drift apart, and the drift *is* the bug. Asserted both directions.

🔴 **Calling an unjudgeable row healthy.** A run whose status derives no partner_status is reported `undeterminable`, never `already_correct` — the mirror would write nothing for it, so the job cannot vouch for the row. Reporting it as fine is precisely how the original bug hid.

Every summary counts **every** bucket. "12 stale" alone reads as "the other 28 are fine" when one of them may be a row nothing can judge.

## Verify

```
TEST_TYPE=unit npx jest --testPathPattern="cancelled-run-status-remirror"   # 9 pass
pnpm check:prod-build                                                        # green
```

## Prod use (after deploy, dry-run first)

```
# 1. prove the instrument on rows that SHOULD already be correct
run_maintenance_job remirror-cancelled-run-status { status: "completed", verbose: true } (dry_run)

# 2. the actual gap
run_maintenance_job remirror-cancelled-run-status (dry_run)

# 3. apply — read the errors[], not the summary
run_maintenance_job remirror-cancelled-run-status
```

Step 1 is deliberate: `status` accepts the live states so the instrument can be pointed at rows that should already agree, before it is trusted on rows that do not.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_0158wJMZ1DmjNxXf5uGuBrQD