### PR TITLE
feat(shipping): add DTDC fulfillment provider plugin

### DIFF
--- a/.github/workflows/publish-dtdc-plugin.yml
+++ b/.github/workflows/publish-dtdc-plugin.yml
@@ -1,0 +1,91 @@
+name: Publish DTDC Plugin
+
+# Publishes @jytextiles/medusa-plugin-dtdc-shipping to npm when the plugin source
+# changes on main. Publish is gated on a version bump: the job is a no-op unless
+# the version in package.json is not yet on the registry, so unrelated pushes
+# (or re-runs) never error on "cannot publish over existing version".
+#
+# To cut a release: bump `version` in packages/medusa-plugin-dtdc-shipping/package.json
+# and merge to main. That's it.
+#
+# The FIRST publish is manual: npm Trusted Publishing (OIDC) must be configured
+# once on npmjs.com for this package before the workflow can mint an OIDC token —
+#   Package → Settings → Trusted publishing →
+#     Organization or user: Jaal-Yantra-Textiles
+#     Repository:           v2
+#     Workflow filename:    publish-dtdc-plugin.yml
+#     Allowed actions:      npm publish
+# Until that is set up (or for the very first release), publish by hand from
+# packages/medusa-plugin-dtdc-shipping after `pnpm build`.
+#
+# AUTH: npm Trusted Publishing (OIDC) — no long-lived token, nothing to rotate.
+# Provenance is generated automatically (no --provenance flag). Needs npm >= 11.5.1
+# (installed below) and Node >= 22.14.
+
+on:
+  push:
+    branches: [ main ]
+    paths:
+      - 'packages/medusa-plugin-dtdc-shipping/**'
+      - '.github/workflows/publish-dtdc-plugin.yml'
+  workflow_dispatch: {}
+
+# id-token is granted now so the move to OIDC Trusted Publishing later needs no
+# workflow change. contents:read is the least privilege for checkout.
+permissions:
+  contents: read
+  id-token: write
+
+concurrency:
+  group: publish-dtdc-plugin
+  cancel-in-progress: false
+
+jobs:
+  publish:
+    runs-on: ubuntu-latest
+    defaults:
+      run:
+        working-directory: packages/medusa-plugin-dtdc-shipping
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Install pnpm
+        uses: pnpm/action-setup@v4
+
+      - name: Use Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: '22'
+          registry-url: 'https://registry.npmjs.org'
+          cache: 'pnpm'
+
+      # Install at the workspace root so the plugin's devDeps (medusa CLI, etc.)
+      # are available for the build.
+      - name: Install dependencies
+        working-directory: .
+        run: pnpm install --frozen-lockfile
+
+      - name: Build plugin
+        run: pnpm build
+
+      - name: Test plugin
+        run: pnpm test
+
+      # Trusted Publishing (OIDC) requires npm >= 11.5.1; Node 22 ships npm 10.x.
+      - name: Upgrade npm for OIDC trusted publishing
+        # Pinned: npm 12.0.0 (2026-07-08) broke provenance publishing with
+        # "Cannot find module 'sigstore'". 11.18.0 is the last known-good that
+        # bundles sigstore for OIDC trusted publishing. Revisit when 12.x fixes it.
+        run: npm install -g npm@11.18.0
+
+      - name: Publish to npm via OIDC (only if version changed)
+        run: |
+          NAME=$(node -p "require('./package.json').name")
+          VERSION=$(node -p "require('./package.json').version")
+          if npm view "${NAME}@${VERSION}" version >/dev/null 2>&1; then
+            echo "::notice::${NAME}@${VERSION} is already published — skipping (bump the version to release)."
+            exit 0
+          fi
+          echo "Publishing ${NAME}@${VERSION} via trusted publishing…"
+          # No token + no --provenance: OIDC auth and provenance are automatic.
+          npm publish --access public

--- a/apps/backend/.env.template
+++ b/apps/backend/.env.template
@@ -107,6 +107,25 @@ BLUE_DART_CUSTOMER_CODE=000001
 # drops. Defaults to BLUE_DART_CLIENT_ID, already a valid DHL-API-Key.
 # DHL_UNIFIED_TRACKING_API_KEY=your_dhl_api_key
 
+# DTDC carrier. Domestic-only express/ground shipping. Two API surfaces with
+# SEPARATE auth, and both are required for a complete integration:
+#   1. booking/label/cancel — `api-key` header against pxapi.dtdc.in
+#   2. tracking — X-Access-Token minted from a username/password pair against
+#      blktracksvc.dtdc.com (or supplied directly via DTDC_TRACKING_ACCESS_TOKEN)
+# The customer code and api-key are issued together by DTDC. service_type_id is
+# one of "GROUND EXPRESS" (surface) or "PRIORITY" (air/express).
+DTDC_CUSTOMER_CODE=your_dtdc_customer_code
+DTDC_API_KEY=your_dtdc_api_key
+DTDC_TRACKING_USERNAME=your_tracking_username
+DTDC_TRACKING_PASSWORD=your_tracking_password
+# Pre-minted tracking token, when present this skips the authenticate call:
+# DTDC_TRACKING_ACCESS_TOKEN=your_x_access_token
+# ⚠️ DTDC has no sandbox for the tracking surface; the booking surface uses the
+# shipsy.io demo host when sandbox=true. Production credentials do NOT work
+# against it — set false for live.
+# DTDC_SANDBOX=true
+# DTDC_DEFAULT_SERVICE_TYPE=GROUND EXPRESS
+
 # Workflow / step execution timeouts (#742). Both are millisecond windows that
 # were previously hardcoded at 10s — too short for real LLM/external-API work.
 # MASTRA_STEP_TIMEOUT_MS  — per-step executor timeout (default 60000).

--- a/apps/backend/integration-tests/http/dtdc-shipping-e2e.spec.ts
+++ b/apps/backend/integration-tests/http/dtdc-shipping-e2e.spec.ts
@@ -1,0 +1,206 @@
+import { DtdcClient, isPincodeServiceable } from "@jytextiles/medusa-plugin-dtdc-shipping/lib/dtdc-client"
+import { DtdcProviderAdapter } from "@jytextiles/medusa-plugin-dtdc-shipping/providers/dtdc/adapter"
+
+jest.setTimeout(120000)
+
+/**
+ * End-to-end coverage against DTDC's REAL test environment.
+ *
+ * This spec does NOT stub the carrier — it books real consignments, tracks
+ * real waybills and cancels them against DTDC's test/demo hosts, using the
+ * test credentials below (GL018 is DTDC's test customer code).
+ *
+ * Run it explicitly:
+ *   TEST_TYPE=integration:http NODE_OPTIONS="--experimental-vm-modules" \
+ *     jest --testPathPattern="dtdc-shipping-e2e"
+ *
+ * The `sandbox: true` flag routes booking/label/cancel to DTDC's Shipsy demo
+ * host (alphademodashboardapi.shipsy.io) and tracking to the staging host
+ * (dtdcstagingapi.dtdc.com), so no live waybill is minted. Note the demo env
+ * has two known limitations, asserted below rather than glossed over:
+ *   - label streaming returns HTTP 403 ({"error": …})
+ *   - cancellation is rejected by the demo ERP ("REJECTED_BY_ERP_SERVER")
+ */
+
+const TEST_CREDENTIALS = {
+  customer_code: process.env.DTDC_CUSTOMER_CODE || "GL018",
+  api_key: process.env.DTDC_API_KEY || "f4ae602554b4a185d21695991885f0",
+  tracking_username: process.env.DTDC_TRACKING_USERNAME || "GL018_trk_json",
+  tracking_password: process.env.DTDC_TRACKING_PASSWORD || "chwzf",
+  tracking_access_token:
+    process.env.DTDC_TRACKING_ACCESS_TOKEN ||
+    "GL018_trk_json:bd45addb4aa09ea88364227a4f7b951b",
+}
+
+// A serviceable lane for the test key: Delhi origin → Salem destination.
+const ORIGIN_PIN = "110046"
+const DEST_PIN = "636010"
+
+// Normalized ShipmentAddress (adapter interface) — uses `address_1`/`address_2`.
+const TO_ADDRESS = {
+  name: "TEST CUSTOMER",
+  phone: "7894561230",
+  address_1: "3/658 pillayar nagar karattur",
+  address_2: "",
+  city: "SALEM",
+  state: "Tamil Nadu",
+  pincode: DEST_PIN,
+}
+
+const FROM_ADDRESS = {
+  name: "TEST ENTERPRISES",
+  phone: "9987456321",
+  address_1: "Upper Ground Chandra Park Old Palam Road",
+  address_2: "",
+  city: "New Delhi",
+  state: "Delhi",
+  pincode: ORIGIN_PIN,
+}
+
+// Raw DtdcAddress (client interface) — uses `address_line_1`/`address_line_2`.
+const RAW_ORIGIN = {
+  name: "TEST ENTERPRISES",
+  phone: "9987456321",
+  address_line_1: "Upper Ground Chandra Park Old Palam Road",
+  pincode: ORIGIN_PIN,
+  city: "New Delhi",
+  state: "Delhi",
+}
+
+const RAW_DEST = {
+  name: "TEST CUSTOMER",
+  phone: "7894561230",
+  address_line_1: "3/658 pillayar nagar karattur",
+  pincode: DEST_PIN,
+  city: "SALEM",
+  state: "Tamil Nadu",
+}
+
+describe("DTDC shipping end-to-end (real test environment)", () => {
+  let client: DtdcClient
+  let adapter: DtdcProviderAdapter
+
+  beforeAll(() => {
+    client = new DtdcClient({ ...TEST_CREDENTIALS, sandbox: true })
+    adapter = new DtdcProviderAdapter({ ...TEST_CREDENTIALS, sandbox: true })
+  })
+
+  describe("pincode serviceability", () => {
+    it("reports a Delhi → Salem lane serviceable", async () => {
+      const res = await client.checkPincodeServiceability(ORIGIN_PIN, DEST_PIN)
+      expect(isPincodeServiceable(res)).toBe(true)
+      // The response also lists the serviceable products and their TAT.
+      const products = (res?.SERV_LIST_DTLS ?? []).map((p: any) => p.NAME)
+      expect(products).toContain("PRIORITY")
+    })
+
+    it("adapter.checkServiceability returns true for the same lane", async () => {
+      const serviceable = await adapter.checkServiceability(DEST_PIN)
+      expect(serviceable).toBe(true)
+    })
+  })
+
+  describe("booking (softdata upload)", () => {
+    let awb: string
+
+    beforeAll(async () => {
+      const result = await adapter.createShipment({
+        reference_id: `e2e-dtdc-${Date.now()}`,
+        payment_mode: "prepaid",
+        pickup_location_name: "TEST ENTERPRISES",
+        to: TO_ADDRESS,
+        from: FROM_ADDRESS,
+        items: [{ name: "Test textile", quantity: 1, unit_price: 500 }],
+        weight_grams: 500,
+        dimensions_cm: { length: 30, width: 25, height: 5 },
+      })
+      expect(result.carrier).toBe("dtdc")
+      expect(result.awb).toBeTruthy()
+      awb = result.awb
+    })
+
+    it("books a consignment and returns a real AWB", async () => {
+      // awb was asserted non-empty in beforeAll; assert it looks like a DTDC
+      // consignment number (an alpha prefix followed by digits).
+      expect(awb).toMatch(/^[A-Z]+\d+/)
+    })
+
+    it("returns a tracking URL for the booked AWB", async () => {
+      const result = await adapter.createShipment({
+        reference_id: `e2e-dtdc-url-${Date.now()}`,
+        payment_mode: "prepaid",
+        pickup_location_name: "TEST ENTERPRISES",
+        to: TO_ADDRESS,
+        from: FROM_ADDRESS,
+        items: [{ name: "Test textile", quantity: 1, unit_price: 500 }],
+        weight_grams: 500,
+      })
+      expect(result.tracking_url).toContain(result.awb)
+    })
+
+    it("refuses an unsupported service type with a structured failure", async () => {
+      // The old client sent "B2C GROUND EXPRESS", which DTDC rejects for this
+      // lane — the client must surface it as an error, not a silent success.
+      await expect(
+        client.createShipment({
+          service_type_id: "B2C GROUND EXPRESS" as any,
+          length: 30,
+          width: 25,
+          height: 5,
+          weight: 0.5,
+          declared_value: 500,
+          origin: RAW_ORIGIN,
+          destination: RAW_DEST,
+          customer_reference_number: `e2e-dtdc-bad-${Date.now()}`,
+        })
+      ).rejects.toThrow(/booking failed|not applicable|TAT data not found/i)
+    })
+
+    describe("tracking (JSON pull)", () => {
+      it("returns the booked consignment's status", async () => {
+        const tracking = await adapter.track({ awb })
+        expect(tracking.carrier).toBe("dtdc")
+        expect(tracking.awb).toBe(awb)
+        // The demo books instantly; the shipment reports some non-empty status.
+        expect(tracking.current_status).toBeTruthy()
+      })
+
+      it("normalizes tracking scans into scan_type events", async () => {
+        // The demo books instantly but its tracking index can lag a beat, so
+        // poll briefly until the freshly-minted AWB shows scan events.
+        let tracking: any
+        for (let attempt = 0; attempt < 5; attempt++) {
+          tracking = await adapter.track({ awb })
+          if (tracking.events?.length) break
+          await new Promise((r) => setTimeout(r, 1000))
+        }
+        expect(Array.isArray(tracking.events)).toBe(true)
+        expect(tracking.events.length).toBeGreaterThan(0)
+        for (const event of tracking.events) {
+          expect(event.scan_type).toBeTruthy()
+          expect(event.status).toBeTruthy()
+        }
+      })
+    })
+
+    describe("label (demo limitation)", () => {
+      it("reaches the label endpoint (demo returns a structured 403)", async () => {
+        // The Shipsy demo does not stream labels — it answers JSON 403. The
+        // client surfaces that as a DtdcApiError rather than pretending a PDF
+        // arrived. On a live account this same call returns PDF bytes.
+        await expect(adapter.getLabel({ awb })).rejects.toThrow(/label/i)
+      })
+    })
+
+    describe("cancellation (demo limitation)", () => {
+      it("reaches the cancel endpoint (demo ERP rejects, but responds)", async () => {
+        // The demo ERP rejects cancellation after booking, returning
+        // { status:"OK", success:false, failures:[…] }. The client must return
+        // a structured result, not throw, so callers can see the carrier's
+        // answer.
+        const result = await adapter.cancelShipment({ awb })
+        expect(typeof result.success).toBe("boolean")
+      })
+    })
+  })
+})

--- a/apps/backend/medusa-config.prod.ts
+++ b/apps/backend/medusa-config.prod.ts
@@ -408,6 +408,24 @@ module.exports = defineConfig({
                 },
               ]
             : []),
+          ...(process.env.DTDC_API_KEY
+            ? [
+                {
+                  resolve: "@jytextiles/medusa-plugin-dtdc-shipping/providers/dtdc",
+                  id: "dtdc",
+                  options: {
+                    customer_code: process.env.DTDC_CUSTOMER_CODE,
+                    api_key: process.env.DTDC_API_KEY,
+                    sandbox: process.env.DTDC_SANDBOX === "true",
+                    tracking_username: process.env.DTDC_TRACKING_USERNAME,
+                    tracking_password: process.env.DTDC_TRACKING_PASSWORD,
+                    tracking_access_token:
+                      process.env.DTDC_TRACKING_ACCESS_TOKEN,
+                    default_service_type: process.env.DTDC_DEFAULT_SERVICE_TYPE,
+                  },
+                },
+              ]
+            : []),
           ...(process.env.DHL_API_KEY
             ? [
                 {

--- a/apps/backend/medusa-config.ts
+++ b/apps/backend/medusa-config.ts
@@ -501,6 +501,25 @@ module.exports = defineConfig({
                       },
                     ]
                   : []),
+                ...(process.env.DTDC_API_KEY
+                  ? [
+                      {
+                        resolve: "@jytextiles/medusa-plugin-dtdc-shipping/providers/dtdc",
+                        id: "dtdc",
+                        options: {
+                          customer_code: process.env.DTDC_CUSTOMER_CODE,
+                          api_key: process.env.DTDC_API_KEY,
+                          sandbox: process.env.DTDC_SANDBOX === "true",
+                          tracking_username: process.env.DTDC_TRACKING_USERNAME,
+                          tracking_password: process.env.DTDC_TRACKING_PASSWORD,
+                          tracking_access_token:
+                            process.env.DTDC_TRACKING_ACCESS_TOKEN,
+                          default_service_type:
+                            process.env.DTDC_DEFAULT_SERVICE_TYPE,
+                        },
+                      },
+                    ]
+                  : []),
                 ...(process.env.DHL_API_KEY
                   ? [
                       {

--- a/apps/backend/package.json
+++ b/apps/backend/package.json
@@ -71,7 +71,7 @@
     "@hookform/resolvers": "^5.0.1",
     "@jytextiles/medusa-plugin-etsy-sync": "latest",
     "@jytextiles/medusa-plugin-faire-store-sync": "latest",
-    "@jytextiles/medusa-plugin-dtdc-shipping": "workspace:*",
+    "@jytextiles/medusa-plugin-dtdc-shipping": "latest",
     "@jytextiles/mikrohyperbee": "workspace:*",
     "@mastra/core": "latest",
     "@mastra/evals": "latest",

--- a/apps/backend/package.json
+++ b/apps/backend/package.json
@@ -71,6 +71,7 @@
     "@hookform/resolvers": "^5.0.1",
     "@jytextiles/medusa-plugin-etsy-sync": "latest",
     "@jytextiles/medusa-plugin-faire-store-sync": "latest",
+    "@jytextiles/medusa-plugin-dtdc-shipping": "workspace:*",
     "@jytextiles/mikrohyperbee": "workspace:*",
     "@mastra/core": "latest",
     "@mastra/evals": "latest",

--- a/apps/backend/src/modules/shipping-providers/carrier-capabilities.ts
+++ b/apps/backend/src/modules/shipping-providers/carrier-capabilities.ts
@@ -115,12 +115,13 @@ export const CARRIER_CAPABILITIES: CarrierCapability[] = [
   {
     id: "dtdc",
     label: "DTDC",
-    integrated: false,
-    platform_account: false,
-    domestic: { can_rate: false, can_ship: false },
+    integrated: true,
+    platform_account: true,
+    domestic: { can_rate: false, can_ship: true },
     international: { can_rate: false, can_ship: false },
     can_declare_ddp: false,
-    notes: "Not integrated. No adapter exists yet.",
+    notes:
+      "Domestic (express/ground) only. The integration books consignments, fetches labels, cancels and tracks (pull + webhook) through DTDC's pxapi.dtdc.in and blktracksvc.dtdc.com surfaces, but exposes no rate API — so it can only be used as a flat-priced or manually-priced option. International is not served by this API surface.",
   },
 ]
 

--- a/apps/backend/src/modules/shipping-providers/provider-interface.ts
+++ b/apps/backend/src/modules/shipping-providers/provider-interface.ts
@@ -326,4 +326,4 @@ export interface ShippingProviderClient {
 }
 
 /** Known carrier identifiers persisted on `fulfillment.data.carrier`. */
-export type CarrierId = "delhivery" | "shiprocket" | "bluedart"
+export type CarrierId = "delhivery" | "shiprocket" | "bluedart" | "dtdc"

--- a/apps/backend/src/modules/shipping-providers/resolver.ts
+++ b/apps/backend/src/modules/shipping-providers/resolver.ts
@@ -26,12 +26,14 @@ import { DelhiveryProviderAdapter } from "./delhivery/adapter"
 import { ShiprocketClient } from "./shiprocket/client"
 import { BlueDartProviderAdapter } from "./bluedart/adapter"
 import { DhlUnifiedTrackingClient } from "./dhl-unified-tracking"
+import { DtdcProviderAdapter } from "@jytextiles/medusa-plugin-dtdc-shipping/providers/dtdc/adapter"
 
 /** Carriers `resolveShippingProvider` can return a live client for. */
 export const SUPPORTED_CARRIERS: CarrierId[] = [
   "delhivery",
   "shiprocket",
   "bluedart",
+  "dtdc",
 ]
 
 /**
@@ -247,6 +249,40 @@ export async function resolveShippingProvider(
         ? new DhlUnifiedTrackingClient({ api_key: trackingKey })
         : undefined
     )
+  }
+
+  if (id === "dtdc") {
+    // Two API surfaces with SEPARATE auth, but both are env/plaintext — DTDC
+    // issues the customer_code + api-key pair for booking, and a
+    // username/password (or a pre-minted X-Access-Token) for tracking.
+    const customerCode =
+      cfg.customer_code || process.env.DTDC_CUSTOMER_CODE
+    const apiKey =
+      readSecret(cfg, "api_key", encryption) || process.env.DTDC_API_KEY
+    if (!customerCode || !apiKey) {
+      throw new MedusaError(
+        MedusaError.Types.UNEXPECTED_STATE,
+        "DTDC credentials not configured (no shipping platform record or DTDC_CUSTOMER_CODE + DTDC_API_KEY)"
+      )
+    }
+    return new DtdcProviderAdapter({
+      customer_code: customerCode!,
+      api_key: apiKey!,
+      sandbox:
+        (cfg.mode ? cfg.mode === "test" : undefined) ??
+        process.env.DTDC_SANDBOX === "true",
+      tracking_username:
+        cfg.tracking_username || process.env.DTDC_TRACKING_USERNAME,
+      tracking_password:
+        readSecret(cfg, "tracking_password", encryption) ||
+        process.env.DTDC_TRACKING_PASSWORD,
+      tracking_access_token:
+        readSecret(cfg, "tracking_access_token", encryption) ||
+        process.env.DTDC_TRACKING_ACCESS_TOKEN,
+      default_service_type:
+        (cfg.default_service_type as any) ||
+        process.env.DTDC_DEFAULT_SERVICE_TYPE,
+    } as any) as unknown as ShippingProviderClient
   }
 
   throw new MedusaError(

--- a/packages/medusa-plugin-dtdc-shipping/README.md
+++ b/packages/medusa-plugin-dtdc-shipping/README.md
@@ -1,0 +1,91 @@
+# @jytextiles/medusa-plugin-dtdc-shipping
+
+A [Medusa v2](https://medusajs.com) fulfillment provider for
+[DTDC](https://www.dtdc.in) — India's express parcel carrier. It wraps DTDC's
+two API surfaces (booking + tracking) into a Medusa fulfillment provider, so
+orders can be rated, booked, labelled, tracked and cancelled through the same
+path as the other JYT carriers.
+
+## Features
+
+- **Pincode serviceability** — `isPincodeServiceable()` checks whether a
+  destination pincode is B2C-serviceable before you quote or book.
+- **Booking** — create a consignment (Ground Express or Priority) against DTDC's
+  booking API (`pxapi.dtdc.in`, Shipsy demo host in sandbox).
+- **Label streaming** — fetch the shipping label / manifest PDF for a booked
+  waybill.
+- **Cancellation** — cancel a booked consignment by reference number.
+- **Tracking** — resolve tracking scans from DTDC's tracking API using either a
+  username/password pair or a pre-minted `X-Access-Token`.
+- **Sandbox mode** — `sandbox: true` routes booking/label/cancel to DTDC's Shipsy
+  demo host and tracking to the staging host, so no live waybill is minted.
+
+## Requirements
+
+- Medusa **2.x**
+- Node.js **>= 22**
+- A DTDC customer code + API key (booking), and tracking credentials
+  (username/password or `X-Access-Token`)
+
+## Install
+
+```bash
+npm install @jytextiles/medusa-plugin-dtdc-shipping
+# or
+pnpm add @jytextiles/medusa-plugin-dtdc-shipping
+```
+
+## Configure
+
+Register the provider in `medusa-config.ts` under the fulfillment module. It is
+gated on `DTDC_API_KEY` so dev/test stay clean without credentials:
+
+```ts
+import { Modules } from "@medusajs/framework/utils"
+
+{
+  resolve: "@medusajs/medusa/fulfillment",
+  options: {
+    providers: [
+      {
+        resolve: "@jytextiles/medusa-plugin-dtdc-shipping/providers/dtdc",
+        id: "dtdc",
+        options: {
+          customer_code: process.env.DTDC_CUSTOMER_CODE,
+          api_key: process.env.DTDC_API_KEY,
+          sandbox: process.env.DTDC_SANDBOX === "true",
+          tracking_username: process.env.DTDC_TRACKING_USERNAME,
+          tracking_password: process.env.DTDC_TRACKING_PASSWORD,
+          tracking_access_token: process.env.DTDC_TRACKING_ACCESS_TOKEN,
+          default_service_type: process.env.DTDC_DEFAULT_SERVICE_TYPE,
+        },
+      },
+    ],
+  },
+}
+```
+
+## Fulfillment options
+
+The provider exposes four options:
+
+| Option | Mode | Return |
+|---|---|---|
+| `dtdc-ground-express` | Surface | no |
+| `dtdc-ground-express-return` | Surface | yes |
+| `dtdc-priority` | Express | no |
+| `dtdc-priority-return` | Express | yes |
+
+## Shared client
+
+The booking/tracking client is exported for direct use outside the fulfillment
+provider (e.g. a carrier resolver that needs a pincode check before quoting):
+
+```ts
+import { DtdcClient, isPincodeServiceable } from "@jytextiles/medusa-plugin-dtdc-shipping/lib/dtdc-client"
+import { DtdcProviderAdapter } from "@jytextiles/medusa-plugin-dtdc-shipping/providers/dtdc/adapter"
+```
+
+## License
+
+MIT

--- a/packages/medusa-plugin-dtdc-shipping/jest.config.js
+++ b/packages/medusa-plugin-dtdc-shipping/jest.config.js
@@ -1,0 +1,17 @@
+module.exports = {
+  roots: ["<rootDir>/src"],
+  testMatch: ["**/__tests__/**/*.spec.ts"],
+  transform: {
+    "^.+\\.[jt]sx?$": [
+      "@swc/jest",
+      {
+        jsc: {
+          parser: { syntax: "typescript", decorators: true },
+          target: "es2021",
+        },
+        module: { type: "commonjs" },
+      },
+    ],
+  },
+  testEnvironment: "node",
+}

--- a/packages/medusa-plugin-dtdc-shipping/package.json
+++ b/packages/medusa-plugin-dtdc-shipping/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@jytextiles/medusa-plugin-dtdc-shipping",
-  "version": "0.1.0",
+  "version": "0.1.1",
   "publishConfig": {
     "access": "public",
     "registry": "https://registry.npmjs.org/"

--- a/packages/medusa-plugin-dtdc-shipping/package.json
+++ b/packages/medusa-plugin-dtdc-shipping/package.json
@@ -1,0 +1,61 @@
+{
+  "name": "@jytextiles/medusa-plugin-dtdc-shipping",
+  "version": "0.1.0",
+  "publishConfig": {
+    "access": "public",
+    "registry": "https://registry.npmjs.org/"
+  },
+  "description": "Medusa v2 plugin for DTDC shipping integration — pincode check, order booking, label generation, cancellation, and tracking.",
+  "keywords": [
+    "medusa-v2",
+    "medusa-plugin-fulfillment",
+    "dtdc",
+    "shipping",
+    "medusa",
+    "plugin"
+  ],
+  "license": "MIT",
+  "author": "Jaal Yantra Textiles",
+  "homepage": "https://github.com/Jaal-Yantra-Textiles/v2/tree/main/packages/medusa-plugin-dtdc-shipping#readme",
+  "repository": {
+    "type": "git",
+    "url": "git+https://github.com/Jaal-Yantra-Textiles/v2.git",
+    "directory": "packages/medusa-plugin-dtdc-shipping"
+  },
+  "bugs": {
+    "url": "https://github.com/Jaal-Yantra-Textiles/v2/issues"
+  },
+  "scripts": {
+    "build": "medusa plugin:build",
+    "dev": "medusa plugin:develop",
+    "test": "jest"
+  },
+  "exports": {
+    "./package.json": "./package.json",
+    "./providers/*": "./.medusa/server/src/providers/*/index.js",
+    "./providers/dtdc/adapter": "./.medusa/server/src/providers/dtdc/adapter.js",
+    "./lib/*": "./.medusa/server/src/lib/*.js",
+    "./*": "./.medusa/server/src/*.js"
+  },
+  "files": [
+    "src",
+    ".medusa"
+  ],
+  "devDependencies": {
+    "@medusajs/cli": "2.19.0",
+    "@medusajs/framework": "2.19.0",
+    "@medusajs/medusa": "2.19.0",
+    "@medusajs/types": "2.19.0",
+    "@swc/core": "1.5.7",
+    "@swc/jest": "0.2.37",
+    "@types/jest": "29.5.14",
+    "@types/node": "^20.0.0",
+    "jest": "29.7.0",
+    "typescript": "5.6.3"
+  },
+  "peerDependencies": {
+    "@medusajs/framework": "2.19.0",
+    "@medusajs/medusa": "2.19.0",
+    "@medusajs/types": "2.19.0"
+  }
+}

--- a/packages/medusa-plugin-dtdc-shipping/src/__tests__/dtdc-client.spec.ts
+++ b/packages/medusa-plugin-dtdc-shipping/src/__tests__/dtdc-client.spec.ts
@@ -1,0 +1,343 @@
+import {
+  DtdcClient,
+  DtdcApiError,
+  dtdcScanType,
+  normalizeDtdcWebhook,
+  assertDtdcBookingSucceeded,
+  isPincodeServiceable,
+} from "../lib/dtdc-client"
+
+const opts = {
+  customer_code: "GL018",
+  api_key: "f4ae602554b4a185d21695991885f0",
+  tracking_username: "GL018_trk_json",
+  tracking_password: "chwzf",
+}
+
+type FetchResult = {
+  status: number
+  ok: boolean
+  headers: { get: (k: string) => string | null }
+  text: () => Promise<string>
+  json: () => Promise<any>
+  arrayBuffer: () => Promise<ArrayBuffer>
+}
+
+const mockResponse = (
+  body: any,
+  opts: { status?: number; headers?: Record<string, string> } = {}
+): FetchResult => {
+  const status = opts.status ?? 200
+  const headers = opts.headers ?? {}
+  const text = () =>
+    Promise.resolve(typeof body === "string" ? body : JSON.stringify(body))
+  return {
+    status,
+    ok: status >= 200 && status < 300,
+    headers: {
+      get: (k: string) => headers[k.toLowerCase()] ?? null,
+    },
+    text,
+    json: async () => JSON.parse(await text()),
+    arrayBuffer: async () => new ArrayBuffer(0),
+  }
+}
+
+const mockFetch = (result: FetchResult) =>
+  jest.fn().mockResolvedValue(result) as any
+
+describe("DtdcClient", () => {
+  let client: DtdcClient
+
+  beforeEach(() => {
+    client = new DtdcClient({ ...opts, fetchImpl: jest.fn() as any })
+  })
+
+  afterEach(() => {
+    jest.restoreAllMocks()
+  })
+
+  describe("dtdcScanType", () => {
+    it("maps delivered codes", () => {
+      expect(dtdcScanType("DLD", "")).toBe("delivered")
+      expect(dtdcScanType("", "Delivered")).toBe("delivered")
+    })
+
+    it("maps return codes", () => {
+      expect(dtdcScanType("RTO", "")).toBe("rto")
+      expect(dtdcScanType("", "Returned to origin")).toBe("rto")
+    })
+
+    it("maps booking/pickup/transit text", () => {
+      expect(dtdcScanType("SPL", "Softdata Upload")).toBe("created")
+      expect(dtdcScanType("", "Booked")).toBe("created")
+      expect(dtdcScanType("PCAW", "Pickup Awaited")).toBe("picked_up")
+      expect(dtdcScanType("", "Out for delivery")).toBe("shipped")
+      expect(dtdcScanType("", "In transit")).toBe("in_transit")
+    })
+
+    it("falls back to in_transit for unknown", () => {
+      expect(dtdcScanType("XX", "something")).toBe("in_transit")
+    })
+  })
+
+  describe("isPincodeServiceable", () => {
+    it("is serviceable when ZIPCODE_RESP.SERV_COD is Y", () => {
+      expect(
+        isPincodeServiceable({ ZIPCODE_RESP: [{ SERV_COD: "Y" }] })
+      ).toBe(true)
+    })
+
+    it("is serviceable when SERV_LIST.b2C_SERVICEABLE is YES", () => {
+      expect(
+        isPincodeServiceable({ SERV_LIST: [{ b2C_SERVICEABLE: "YES" }] })
+      ).toBe(true)
+    })
+
+    it("is not serviceable when neither flag is set", () => {
+      expect(isPincodeServiceable({})).toBe(false)
+      expect(
+        isPincodeServiceable({
+          ZIPCODE_RESP: [{ SERV_COD: "N" }],
+          SERV_LIST: [{ b2C_SERVICEABLE: "NO" }],
+        })
+      ).toBe(false)
+    })
+  })
+
+  describe("normalizeDtdcWebhook", () => {
+    it("extracts awb, status and events from a trackHeader push", () => {
+      const payload = {
+        statusCode: 200,
+        status: "SUCCESS",
+        trackHeader: {
+          strShipmentNo: "X0012189541",
+          strStatus: "Pickup Awaited",
+          strCNProduct: "PRIORITY",
+          strExpectedDeliveryDate: "2026-08-29",
+        },
+        trackDetails: [
+          {
+            strCode: "SPL",
+            strAction: "Softdata Upload",
+            strOrigin: "GHAZIABAD APEX",
+            strActionDate: "27082026",
+            strActionTime: "0806",
+          },
+        ],
+      }
+      const result = normalizeDtdcWebhook(payload)
+      expect(result.carrier).toBe("dtdc")
+      expect(result.awb).toBe("X0012189541")
+      expect(result.current_status).toBe("Pickup Awaited")
+      expect(result.current_status_code).toBe("PRIORITY")
+      expect(result.events).toHaveLength(1)
+      expect(result.events[0].scan_type).toBe("created")
+      expect(result.events[0].location).toBe("GHAZIABAD APEX")
+    })
+
+    it("returns empty awb for an unrecognised payload", () => {
+      expect(normalizeDtdcWebhook({}).awb).toBe("")
+    })
+  })
+
+  describe("assertDtdcBookingSucceeded", () => {
+    it("passes a successful body", () => {
+      expect(() =>
+        assertDtdcBookingSucceeded({
+          status: "OK",
+          data: [{ success: true, reference_number: "X0012189541" }],
+        })
+      ).not.toThrow()
+    })
+
+    it("throws when a per-consignment success is false", () => {
+      expect(() =>
+        assertDtdcBookingSucceeded({
+          status: "OK",
+          data: [
+            { success: false, reason: "WRONG_INPUT", message: "bad pincode" },
+          ],
+        })
+      ).toThrow(DtdcApiError)
+    })
+
+    it("throws when no consignment data is returned", () => {
+      expect(() =>
+        assertDtdcBookingSucceeded({ status: "OK", data: [] })
+      ).toThrow(DtdcApiError)
+    })
+  })
+
+  describe("createShipment", () => {
+    it("sends api-key header and returns the awb", async () => {
+      const fetchMock = mockFetch(
+        mockResponse({
+          status: "OK",
+          data: [{ success: true, reference_number: "X0012189541" }],
+        })
+      )
+      client = new DtdcClient({ ...opts, fetchImpl: fetchMock })
+
+      const result = await client.createShipment({
+        length: 30,
+        width: 25,
+        height: 5,
+        weight: 0.5,
+        declared_value: 500,
+        origin: {
+          name: "Warehouse",
+          phone: "9987456321",
+          address_line_1: "Test address",
+          pincode: "110046",
+          city: "New Delhi",
+          state: "Delhi",
+        },
+        destination: {
+          name: "Customer",
+          phone: "7894561230",
+          address_line_1: "Dest address",
+          pincode: "636010",
+          city: "SALEM",
+          state: "Tamil Nadu",
+        },
+        customer_reference_number: "ORDER-1",
+      })
+
+      expect(fetchMock).toHaveBeenCalledTimes(1)
+      const [url, init] = fetchMock.mock.calls[0]
+      expect(url).toContain("/api/customer/integration/consignment/softdata")
+      expect(init.headers["api-key"]).toBe(opts.api_key)
+
+      const body = JSON.parse(init.body)
+      expect(body.consignments[0].customer_code).toBe("GL018")
+      expect(body.consignments[0].service_type_id).toBe("PRIORITY")
+      expect(body.consignments[0].weight).toBe("0.5")
+      expect(body.consignments[0].weight_unit).toBe("kg")
+
+      expect(result.data?.[0].reference_number).toBe("X0012189541")
+    })
+
+    it("uses the supplied service type and COD fields", async () => {
+      const fetchMock = mockFetch(
+        mockResponse({
+          status: "OK",
+          data: [{ success: true, reference_number: "X0012189542" }],
+        })
+      )
+      client = new DtdcClient({ ...opts, fetchImpl: fetchMock })
+
+      await client.createShipment({
+        service_type_id: "GROUND_EXPRESS",
+        length: 10,
+        width: 10,
+        height: 10,
+        weight: 1,
+        declared_value: 1000,
+        cod_collection_mode: "CASH",
+        cod_amount: 1000,
+        origin: {
+          name: "W",
+          phone: "1",
+          address_line_1: "a",
+          pincode: "110046",
+          city: "c",
+          state: "s",
+        },
+        destination: {
+          name: "C",
+          phone: "2",
+          address_line_1: "b",
+          pincode: "636010",
+          city: "c",
+          state: "s",
+        },
+        customer_reference_number: "ORDER-2",
+      })
+
+      const body = JSON.parse(fetchMock.mock.calls[0][1].body)
+      expect(body.consignments[0].service_type_id).toBe("GROUND_EXPRESS")
+      expect(body.consignments[0].cod_collection_mode).toBe("CASH")
+      expect(body.consignments[0].cod_amount).toBe("1000")
+    })
+  })
+
+  describe("cancelShipment", () => {
+    it("posts the awb and customer code", async () => {
+      const fetchMock = mockFetch(
+        mockResponse({ status: "OK", success: true, successConsignments: [] })
+      )
+      client = new DtdcClient({ ...opts, fetchImpl: fetchMock })
+
+      await client.cancelShipment("X0012189541")
+
+      const [url, init] = fetchMock.mock.calls[0]
+      expect(url).toContain("/api/customer/integration/consignment/cancel")
+      expect(JSON.parse(init.body)).toEqual({
+        AWBNo: ["X0012189541"],
+        customerCode: "GL018",
+      })
+    })
+  })
+
+  describe("generateTrackingToken", () => {
+    it("returns the pre-minted token when supplied", async () => {
+      const clientWithToken = new DtdcClient({
+        ...opts,
+        tracking_access_token: "pre-minted-token",
+        fetchImpl: jest.fn() as any,
+      })
+      const token = await clientWithToken.generateTrackingToken()
+      expect(token).toBe("pre-minted-token")
+    })
+
+    it("mints a token from username/password (plain-string response)", async () => {
+      const fetchMock = mockFetch(
+        mockResponse("GL018_trk_json:bd45addb4aa09ea88364227a4f7b951b")
+      )
+      client = new DtdcClient({ ...opts, fetchImpl: fetchMock })
+
+      const token = await client.generateTrackingToken()
+      expect(token).toBe("GL018_trk_json:bd45addb4aa09ea88364227a4f7b951b")
+      expect(fetchMock.mock.calls[0][0]).toContain(
+        "username=GL018_trk_json&password=chwzf"
+      )
+    })
+
+    it("tolerates a JSON-wrapped token if DTDC changes shape", async () => {
+      const fetchMock = mockFetch(
+        mockResponse({ data: { token: "json-wrapped-token" } })
+      )
+      client = new DtdcClient({ ...opts, fetchImpl: fetchMock })
+
+      const token = await client.generateTrackingToken()
+      expect(token).toBe("json-wrapped-token")
+    })
+  })
+
+  describe("trackShipment", () => {
+    it("parses trackHeader + trackDetails", async () => {
+      const fetchMock = mockFetch(
+        mockResponse({
+          statusCode: 200,
+          status: "SUCCESS",
+          trackHeader: { strShipmentNo: "X0012189541", strStatus: "Pickup Awaited" },
+          trackDetails: [],
+        })
+      )
+      client = new DtdcClient({
+        ...opts,
+        tracking_access_token: "pre-minted-token",
+        fetchImpl: fetchMock,
+      })
+
+      const result = await client.trackShipment("X0012189541")
+      expect(result.trackHeader?.strShipmentNo).toBe("X0012189541")
+      expect(result.trackHeader?.strStatus).toBe("Pickup Awaited")
+
+      const [url, init] = fetchMock.mock.calls[0]
+      expect(url).toContain("/JSONCnTrk/getTrackDetails")
+      expect(init.headers["X-Access-Token"]).toBe("pre-minted-token")
+    })
+  })
+})

--- a/packages/medusa-plugin-dtdc-shipping/src/lib/dtdc-client.ts
+++ b/packages/medusa-plugin-dtdc-shipping/src/lib/dtdc-client.ts
@@ -1,0 +1,501 @@
+import { MedusaError } from "@medusajs/framework/utils"
+import {
+  DtdcOptions,
+  DtdcFetchLike,
+  DtdcBookingRequest,
+  DtdcBookingResponse,
+  DtdcCancelRequest,
+  DtdcCancelResponse,
+  DtdcPincodeResponse,
+  DtdcTrackingRequest,
+  DtdcTrackingResponse,
+  DtdcServiceType,
+  DtdcLoadType,
+  DtdcConsignmentType,
+  DtdcAddress,
+} from "./types"
+
+const SANDBOX_BOOKING_BASE = "https://alphademodashboardapi.shipsy.io"
+const LIVE_BOOKING_BASE = "https://pxapi.dtdc.in"
+const SANDBOX_TRACKING_AUTH_BASE = "https://dtdcstagingapi.dtdc.com"
+const LIVE_TRACKING_AUTH_BASE = "https://blktracksvc.dtdc.com"
+// The staging tracking host nests the JSON tracking API under an extra
+// "dtdc-tracking-api" segment, unlike live ("blktracksvc") which serves it
+// straight off "dtdc-api". Both are full path prefixes up to /rest/….
+const SANDBOX_TRACKING_BASE = "https://dtdcstagingapi.dtdc.com/dtdc-tracking-api/dtdc-api"
+const LIVE_TRACKING_BASE = "https://blktracksvc.dtdc.com/dtdc-api"
+// The rate-calculator host is hyphenated ("smarttrack-ctbsplus") — the
+// un-hyphenated HTTPS host answers 200 with an empty body.
+const PINCODE_BASE = "https://smarttrack-ctbsplus.dtdc.com"
+
+export class DtdcApiError extends MedusaError {
+  readonly code?: string
+  readonly raw?: any
+
+  constructor(message: string, opts?: { code?: string; raw?: any }) {
+    super(MedusaError.Types.INVALID_DATA, message)
+    this.code = opts?.code
+    this.raw = opts?.raw
+  }
+}
+
+function sanitizeAddress(value: string): string {
+  return value.replace(/[&\#%;\\]/g, " ").replace(/\s+/g, " ").trim()
+}
+
+/** True when DTDC reports the destination pincode serviceable for B2C. */
+export function isPincodeServiceable(res: DtdcPincodeResponse | any): boolean {
+  const zip = res?.ZIPCODE_RESP?.[0]
+  const serv = res?.SERV_LIST?.[0]
+  const servCod = String(zip?.SERV_COD ?? "").trim().toUpperCase() === "Y"
+  const b2c = String(serv?.b2C_SERVICEABLE ?? "").trim().toUpperCase() === "YES"
+  return servCod || b2c
+}
+
+/**
+ * Map a DTDC tracking scan to the coarse scan_type the tracking sync switches
+ * on. DTDC codes are three-letter ("SPL", "PCSC", "PCAW", "DLD", …) and the
+ * free-text `strAction` is the reliable human signal.
+ */
+export function dtdcScanType(
+  statusCode?: string | null,
+  statusText?: string | null
+): string {
+  const code = String(statusCode || "").trim().toUpperCase()
+  if (code === "DLD" || code === "DD") return "delivered"
+  if (code === "RTO" || code === "RT") return "rto"
+
+  const text = String(statusText || "").trim().toLowerCase()
+  if (text.includes("delivered")) return "delivered"
+  if (text.includes("rto") || text.includes("return")) return "rto"
+  if (text.includes("booked") || text.includes("manifest") || text.includes("softdata")) {
+    return "created"
+  }
+  if (text.includes("pickup") || text.includes("picked")) return "picked_up"
+  if (text.includes("out for delivery")) return "shipped"
+  if (text.includes("in transit") || text.includes("in-transit")) return "in_transit"
+  return "in_transit"
+}
+
+/**
+ * Normalize a DTDC tracking-push payload into a TrackingResult-like shape.
+ *
+ * Pure and exported so the inbound webhook route can parse a push without
+ * carrier credentials, same as normalizeDelhiveryWebhook.
+ */
+export function normalizeDtdcWebhook(payload: any): {
+  carrier: string
+  awb: string
+  current_status: string
+  current_status_code?: string
+  estimated_delivery?: string | null
+  events: Array<{
+    timestamp: string
+    status: string
+    location: string
+    scan_type: string
+  }>
+  raw: any
+} {
+  const header = payload?.trackHeader ?? payload?.TrackHeader ?? payload ?? {}
+  const awb =
+    header?.strShipmentNo ??
+    payload?.strShipmentNo ??
+    payload?.awb_no ??
+    payload?.reference_number ??
+    ""
+  const status = header?.strStatus ?? payload?.strStatus ?? ""
+  const events = (payload?.trackDetails ?? payload?.TrackDetails ?? []).map(
+    (e: any) => {
+      const actionDate = e?.strActionDate ?? e?.strScanDate ?? ""
+      const actionTime = e?.strActionTime ?? e?.strScanTime ?? ""
+      return {
+        timestamp: actionDate ? `${actionDate} ${actionTime}`.trim() : "",
+        status: e?.strAction ?? e?.strScan ?? "",
+        location: e?.strOrigin ?? e?.strLocation ?? "",
+        scan_type: dtdcScanType(e?.strCode ?? e?.strStatusCode, e?.strAction ?? e?.strScan),
+      }
+    }
+  )
+  return {
+    carrier: "dtdc",
+    awb: String(awb || ""),
+    current_status: String(status || ""),
+    current_status_code: header?.strCNProduct || undefined,
+    estimated_delivery: header?.strExpectedDeliveryDate ?? null,
+    events,
+    raw: payload,
+  }
+}
+
+/**
+ * Throw unless DTDC actually accepted every consignment in the booking.
+ *
+ * DTDC's /softdata returns HTTP 200 with `data[].success: false` (and the
+ * reason in `message` / `reason`) on refusal, so a status check alone lets a
+ * failure through as if it had worked.
+ */
+export function assertDtdcBookingSucceeded(body: any): void {
+  const entries: any[] = Array.isArray(body?.data) ? body.data : []
+  if (!entries.length) {
+    throw new DtdcApiError(
+      "DTDC accepted the request but returned no consignment data.",
+      { raw: body }
+    )
+  }
+  const failed = entries.find((e) => e?.success === false)
+  if (failed) {
+    const detail =
+      failed?.message ||
+      failed?.reason ||
+      (failed?.success === false ? "consignment refused" : "unknown")
+    throw new DtdcApiError(`DTDC booking failed: ${detail}`, { raw: body })
+  }
+}
+
+export class DtdcClient {
+  private bookingBase: string
+  private trackingAuthBase: string
+  private trackingBase: string
+  private customerCode: string
+  private apiKey: string
+  private trackingUsername: string
+  private trackingPassword: string
+  private trackingAccessToken: string | null
+  private defaultServiceType: DtdcServiceType
+  private fetch_: DtdcFetchLike
+
+  constructor(options: DtdcOptions) {
+    this.customerCode = options.customer_code
+    this.apiKey = options.api_key
+    this.trackingUsername = options.tracking_username ?? ""
+    this.trackingPassword = options.tracking_password ?? ""
+    this.trackingAccessToken = options.tracking_access_token ?? null
+    this.defaultServiceType = options.default_service_type ?? "PRIORITY"
+
+    if (options.sandbox) {
+      this.bookingBase = SANDBOX_BOOKING_BASE
+      this.trackingAuthBase = SANDBOX_TRACKING_AUTH_BASE
+      this.trackingBase = SANDBOX_TRACKING_BASE
+    } else {
+      this.bookingBase = LIVE_BOOKING_BASE
+      this.trackingAuthBase = LIVE_TRACKING_AUTH_BASE
+      this.trackingBase = LIVE_TRACKING_BASE
+    }
+
+    this.fetch_ = options.fetchImpl ?? ((input, init) => fetch(input, init as any))
+  }
+
+  private bookingHeaders(): Record<string, string> {
+    return {
+      "api-key": this.apiKey,
+      "Content-Type": "application/json",
+    }
+  }
+
+  private async safeJson(res: any): Promise<any> {
+    const text = await res.text()
+    try {
+      return JSON.parse(text)
+    } catch {
+      return { raw: text }
+    }
+  }
+
+  /**
+   * Check pincode serviceability between origin and destination.
+   *
+   * POST https://smarttrack-ctbsplus.dtdc.com/ratecalapi/PincodeApiCall
+   * Body: { orgPincode, desPincode }
+   */
+  async checkPincodeServiceability(
+    originPincode: string,
+    destinationPincode: string
+  ): Promise<DtdcPincodeResponse> {
+    const res = await this.fetch_(
+      `${PINCODE_BASE}/ratecalapi/PincodeApiCall`,
+      {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({
+          orgPincode: originPincode,
+          desPincode: destinationPincode,
+        }),
+      }
+    )
+    if (!res.ok) {
+      throw new Error(`DTDC pincode check failed (${res.status})`)
+    }
+    return res.json()
+  }
+
+  /**
+   * Create a shipment / book a consignment with DTDC.
+   *
+   * POST {bookingBase}/api/customer/integration/consignment/softdata
+   * Auth: api-key header
+   */
+  async createShipment(params: {
+    service_type_id?: DtdcServiceType
+    load_type?: DtdcLoadType
+    consignment_type?: DtdcConsignmentType
+    length: number
+    width: number
+    height: number
+    weight: number
+    declared_value: number
+    num_pieces?: number
+    origin: DtdcAddress
+    destination: DtdcAddress
+    return_details?: DtdcAddress
+    customer_reference_number: string
+    cod_collection_mode?: string
+    cod_amount?: number
+    commodity_id?: string
+    description?: string
+    eway_bill?: string
+    invoice_number?: string
+    invoice_date?: string
+    reference_number?: string
+  }): Promise<DtdcBookingResponse> {
+    const consignment = {
+      customer_code: this.customerCode,
+      service_type_id: params.service_type_id ?? this.defaultServiceType,
+      load_type: params.load_type ?? "NON-DOCUMENT",
+      consignment_type: params.consignment_type ?? "Forward",
+      dimension_unit: "cm",
+      length: String(params.length),
+      width: String(params.width),
+      height: String(params.height),
+      weight_unit: "kg",
+      weight: String(params.weight),
+      declared_value: String(params.declared_value),
+      eway_bill: params.eway_bill ?? "",
+      invoice_number: params.invoice_number ?? "",
+      invoice_date: params.invoice_date ?? "",
+      num_pieces: String(params.num_pieces ?? 1),
+      origin_details: {
+        name: params.origin.name,
+        phone: params.origin.phone,
+        alternate_phone: params.origin.alternate_phone ?? "",
+        address_line_1: sanitizeAddress(params.origin.address_line_1),
+        address_line_2: params.origin.address_line_2 ?? "",
+        pincode: params.origin.pincode,
+        city: params.origin.city,
+        state: params.origin.state,
+      },
+      destination_details: {
+        name: params.destination.name,
+        phone: params.destination.phone,
+        alternate_phone: params.destination.alternate_phone ?? "",
+        address_line_1: sanitizeAddress(params.destination.address_line_1),
+        address_line_2: params.destination.address_line_2 ?? "",
+        pincode: params.destination.pincode,
+        city: params.destination.city,
+        state: params.destination.state,
+      },
+      ...(params.return_details
+        ? {
+            return_details: {
+              name: params.return_details.name,
+              phone: params.return_details.phone,
+              alternate_phone: params.return_details.alternate_phone ?? "",
+              address_line_1: sanitizeAddress(params.return_details.address_line_1),
+              address_line_2: params.return_details.address_line_2 ?? "",
+              pincode: params.return_details.pincode,
+              city: params.return_details.city,
+              state: params.return_details.state,
+              country: params.return_details.country ?? "India",
+              email: params.return_details.email ?? "",
+            },
+          }
+        : {}),
+      customer_reference_number: params.customer_reference_number,
+      cod_collection_mode: params.cod_collection_mode ?? "",
+      cod_amount: params.cod_amount != null ? String(params.cod_amount) : "",
+      commodity_id: params.commodity_id ?? "2",
+      description: params.description ?? "",
+      reference_number: params.reference_number ?? "",
+    }
+
+    const body: DtdcBookingRequest = { consignments: [consignment] }
+
+    const res = await this.fetch_(
+      `${this.bookingBase}/api/customer/integration/consignment/softdata`,
+      {
+        method: "POST",
+        headers: this.bookingHeaders(),
+        body: JSON.stringify(body),
+      }
+    )
+
+    if (!res.ok) {
+      const text = await res.text().catch(() => "")
+      throw new Error(`DTDC shipment creation failed (${res.status}): ${text}`)
+    }
+
+    const json = await this.safeJson(res)
+    assertDtdcBookingSucceeded(json)
+    return json
+  }
+
+  /**
+   * Fetch a shipping label as a PDF stream.
+   *
+   * GET {bookingBase}/api/customer/integration/consignment/shippinglabel/stream
+   *    ?reference_number=<awb>&label_code=SHIP_LABEL_4X6&label_format=pdf
+   * Auth: api-key header
+   *
+   * Returns base64-encoded PDF data. On a JSON error response (label not ready
+   * or the environment does not stream labels) the error is surfaced.
+   */
+  async getLabel(
+    awbNumber: string,
+    labelCode: string = "SHIP_LABEL_4X6",
+    labelFormat: string = "pdf"
+  ): Promise<{ data: string; format: string; raw?: any }> {
+    const url = `${this.bookingBase}/api/customer/integration/consignment/shippinglabel/stream?reference_number=${encodeURIComponent(awbNumber)}&label_code=${labelCode}&label_format=${labelFormat}`
+
+    const res = await this.fetch_(url, {
+      method: "GET",
+      headers: this.bookingHeaders(),
+    })
+
+    if (!res.ok) {
+      const text = await res.text().catch(() => "")
+      let detail = text
+      try {
+        const json = JSON.parse(text)
+        detail = json?.error?.message || json?.message || text
+      } catch {
+        /* not JSON */
+      }
+      throw new DtdcApiError(`DTDC label fetch failed (${res.status}): ${detail}`)
+    }
+
+    const contentType = String(res.headers?.get?.("content-type") || "")
+    if (contentType.includes("application/json")) {
+      const json = await res.json().catch(() => null)
+      throw new DtdcApiError(
+        `DTDC label response was JSON (not a PDF): ${json?.error?.message || json?.message || JSON.stringify(json)}`,
+        { raw: json }
+      )
+    }
+
+    const arrayBuffer = await res.arrayBuffer()
+    return {
+      data: Buffer.from(arrayBuffer).toString("base64"),
+      format: labelFormat,
+    }
+  }
+
+  /**
+   * Cancel a shipment / consignment.
+   *
+   * POST {bookingBase}/api/customer/integration/consignment/cancel
+   * Auth: api-key header
+   * Body: { AWBNo: ["<awb>"], customerCode: "<code>" }
+   */
+  async cancelShipment(awbNumber: string): Promise<DtdcCancelResponse> {
+    const body: DtdcCancelRequest = {
+      AWBNo: [awbNumber],
+      customerCode: this.customerCode,
+    }
+
+    const res = await this.fetch_(
+      `${this.bookingBase}/api/customer/integration/consignment/cancel`,
+      {
+        method: "POST",
+        headers: this.bookingHeaders(),
+        body: JSON.stringify(body),
+      }
+    )
+
+    if (!res.ok) {
+      const text = await res.text().catch(() => "")
+      throw new Error(`DTDC cancellation failed (${res.status}): ${text}`)
+    }
+
+    return this.safeJson(res)
+  }
+
+  /**
+   * Generate a tracking access token.
+   *
+   * GET {trackingAuthBase}/dtdc-api/api/dtdc/authenticate?username=<u>&password=<p>
+   *
+   * The endpoint returns the token as a PLAIN STRING (not JSON), e.g.
+   * "GL018_trk_json:bd45addb4aa09ea88364227a4f7b951b".
+   */
+  async generateTrackingToken(): Promise<string> {
+    if (this.trackingAccessToken) {
+      return this.trackingAccessToken
+    }
+
+    const url = `${this.trackingAuthBase}/dtdc-api/api/dtdc/authenticate?username=${encodeURIComponent(this.trackingUsername)}&password=${encodeURIComponent(this.trackingPassword)}`
+
+    const res = await this.fetch_(url, { method: "GET" })
+
+    if (!res.ok) {
+      throw new Error(`DTDC tracking auth failed (${res.status})`)
+    }
+
+    const text = (await res.text()).trim()
+    if (!text) {
+      throw new Error("DTDC tracking auth returned no token")
+    }
+
+    // Prefer the raw string (the real response shape); tolerate a JSON wrapper
+    // if DTDC ever changes it.
+    let token = text
+    if (text.startsWith("{") || text.startsWith("[")) {
+      try {
+        const json = JSON.parse(text)
+        token = json?.data?.token || json?.token || json?.access_token || ""
+      } catch {
+        token = ""
+      }
+    }
+    if (!token) {
+      throw new Error("DTDC tracking auth returned no token")
+    }
+
+    this.trackingAccessToken = token
+    return token
+  }
+
+  /**
+   * Track a shipment by AWB number (JSON pull).
+   *
+   * POST {trackingBase}/rest/JSONCnTrk/getTrackDetails
+   * Auth: X-Access-Token header
+   * Body: { trkType: "cnno", strcnno: "<awb>", addtnlDtl: "Y" }
+   */
+  async trackShipment(awbNumber: string): Promise<DtdcTrackingResponse> {
+    const token = await this.generateTrackingToken()
+
+    const body: DtdcTrackingRequest = {
+      trkType: "cnno",
+      strcnno: awbNumber,
+      addtnlDtl: "Y",
+    }
+
+    const res = await this.fetch_(
+      `${this.trackingBase}/rest/JSONCnTrk/getTrackDetails`,
+      {
+        method: "POST",
+        headers: {
+          "X-Access-Token": token,
+          "Content-Type": "application/json",
+        },
+        body: JSON.stringify(body),
+      }
+    )
+
+    if (!res.ok) {
+      throw new Error(`DTDC tracking failed (${res.status})`)
+    }
+
+    return this.safeJson(res)
+  }
+}

--- a/packages/medusa-plugin-dtdc-shipping/src/lib/provider-interface.ts
+++ b/packages/medusa-plugin-dtdc-shipping/src/lib/provider-interface.ts
@@ -1,0 +1,115 @@
+export type PaymentMode = "prepaid" | "cod"
+
+export type ShipmentAddress = {
+  name: string
+  phone: string
+  email?: string
+  address_1: string
+  address_2?: string
+  city: string
+  state: string
+  pincode: string
+  country?: string
+}
+
+export type ShipmentItem = {
+  name: string
+  sku?: string
+  quantity: number
+  unit_price: number
+  hsn?: string
+  tax?: number
+}
+
+export type Dimensions = {
+  length: number
+  width: number
+  height: number
+}
+
+export type CreateShipmentInput = {
+  reference_id: string
+  payment_mode: PaymentMode
+  cod_amount?: number
+  pickup_location_name: string
+  to: ShipmentAddress
+  from?: ShipmentAddress
+  items: ShipmentItem[]
+  weight_grams: number
+  dimensions_cm?: Dimensions
+  sub_total?: number
+  currency?: string
+  product_description?: string
+  tax_id?: string
+}
+
+export type ShipmentRef = {
+  awb?: string
+  provider_refs?: Record<string, any>
+}
+
+export type ShipmentResult = {
+  carrier: string
+  awb: string
+  tracking_number: string
+  tracking_url?: string
+  label_url?: string
+  provider_refs?: Record<string, any>
+  raw?: any
+}
+
+export type RateQuery = {
+  origin_pincode: string
+  destination_pincode: string
+  destination_country?: string
+  weight_grams: number
+  cod?: boolean
+  dimensions_cm?: Dimensions
+}
+
+export type RateOption = {
+  courier_id?: string | number
+  courier_name?: string
+  amount: number
+  currency_code: string
+  estimated_days?: number
+  cod_charges?: number
+  is_recommended?: boolean
+}
+
+export type TrackingEvent = {
+  timestamp: string
+  status: string
+  location: string
+  scan_type: string
+}
+
+export type TrackingResult = {
+  carrier: string
+  awb: string
+  current_status: string
+  current_status_code?: string | number
+  estimated_delivery?: string | null
+  origin?: string
+  destination?: string
+  events: TrackingEvent[]
+  raw?: any
+}
+
+export type LabelResult = {
+  label_url?: string
+  data?: string
+  format?: string
+  raw?: any
+}
+
+export interface ShippingProviderClient {
+  readonly carrier: string
+  checkServiceability?(destinationPincode: string): Promise<boolean>
+  getRates?(query: RateQuery): Promise<RateOption[]>
+  createShipment(input: CreateShipmentInput): Promise<ShipmentResult>
+  getLabel(ref: ShipmentRef): Promise<LabelResult>
+  track(ref: ShipmentRef): Promise<TrackingResult>
+  cancelShipment(ref: ShipmentRef): Promise<{ success: boolean; raw?: any }>
+  normalizeWebhook?(payload: any): TrackingResult
+}

--- a/packages/medusa-plugin-dtdc-shipping/src/lib/types.ts
+++ b/packages/medusa-plugin-dtdc-shipping/src/lib/types.ts
@@ -1,0 +1,177 @@
+export type DtdcServiceType = "PRIORITY" | "GROUND_EXPRESS"
+
+export type DtdcLoadType = "NON-DOCUMENT" | "DOCUMENT"
+
+export type DtdcConsignmentType = "Forward" | "Reverse"
+
+export type DtdcPaymentMode = "prepaid" | "cod"
+
+export type DtdcOptions = {
+  customer_code: string
+  api_key: string
+  sandbox?: boolean
+  tracking_username?: string
+  tracking_password?: string
+  tracking_access_token?: string
+  default_service_type?: DtdcServiceType
+  fetchImpl?: DtdcFetchLike
+}
+
+export type DtdcFetchLike = (
+  input: string,
+  init?: Record<string, any>
+) => Promise<any>
+
+export type DtdcAddress = {
+  name: string
+  phone: string
+  alternate_phone?: string
+  address_line_1: string
+  address_line_2?: string
+  pincode: string
+  city: string
+  state: string
+  country?: string
+  email?: string
+}
+
+export type DtdcConsignmentInput = {
+  customer_code: string
+  service_type_id: DtdcServiceType
+  load_type: DtdcLoadType
+  consignment_type: DtdcConsignmentType
+  dimension_unit: string
+  length: string
+  width: string
+  height: string
+  weight_unit: string
+  weight: string
+  declared_value: string
+  eway_bill?: string
+  invoice_number?: string
+  invoice_date?: string
+  num_pieces: string
+  origin_details: DtdcAddress
+  destination_details: DtdcAddress
+  return_details?: DtdcAddress
+  customer_reference_number: string
+  cod_collection_mode?: string
+  cod_amount?: string
+  commodity_id?: string
+  description?: string
+  reference_number?: string
+}
+
+export type DtdcBookingRequest = {
+  consignments: DtdcConsignmentInput[]
+}
+
+/**
+ * One entry in a booking response's `data` array. On success `success` is
+ * `true` and `reference_number` carries the DTDC AWB; on failure `success` is
+ * `false` with the reason in `message` / `reason`.
+ */
+export type DtdcBookingResponseEntry = {
+  success: boolean
+  reference_number?: string
+  reason?: string
+  message?: string
+  customer_reference_number?: string
+  chargeable_weight?: number
+  pieces?: Array<{ reference_number?: string; product_code?: string }>
+  [key: string]: any
+}
+
+export type DtdcBookingResponse = {
+  status?: string
+  data?: DtdcBookingResponseEntry[]
+  [key: string]: any
+}
+
+export type DtdcCancelRequest = {
+  AWBNo: string[]
+  customerCode: string
+}
+
+export type DtdcCancelFailure = {
+  message?: string
+  reason?: string
+  reference_number?: string
+  code?: string
+  [key: string]: any
+}
+
+export type DtdcCancelResponse = {
+  status?: string
+  success?: boolean
+  failures?: DtdcCancelFailure[]
+  successConsignments?: any[]
+  [key: string]: any
+}
+
+/**
+ * The pincode (rate calculator) response. `ZIPCODE_RESP[0].SERV_COD` is `"Y"`
+ * for serviceable pincodes; `SERV_LIST[0].b2C_SERVICEABLE` is `"YES"` when the
+ * B2C product serves the lane. `SERV_LIST_DTLS` lists the service codes and TAT.
+ */
+export type DtdcPincodeResponse = {
+  ZIPCODE_RESP?: Array<{
+    MESSAGE?: string
+    ORGPIN?: string
+    DESTPIN?: string
+    DESTCITY?: string
+    DESTSTATE?: string
+    SERV_COD?: string
+    SERVFLAG?: string
+  }>
+  SERV_LIST?: Array<{
+    b2C_SERVICEABLE?: string
+    b2C_COD_Serviceable?: string
+    COD_Serviceable?: string
+    b2B_SERVICEABLE?: string
+  }>
+  SERV_LIST_DTLS?: Array<{ CODE?: string; TAT?: string; NAME?: string }>
+  PIN_CITY?: Array<{ PIN?: string; CITY?: string; STATE_NAME?: string }>
+  [key: string]: any
+}
+
+export type DtdcTrackingHeader = {
+  strShipmentNo?: string
+  strRefNo?: string
+  strCNProduct?: string
+  strStatus?: string
+  strOrigin?: string
+  strDestination?: string
+  strWeight?: string
+  strPieces?: string
+  strBookedDate?: string
+  strExpectedDeliveryDate?: string
+  [key: string]: any
+}
+
+export type DtdcTrackingEvent = {
+  strCode?: string
+  strAction?: string
+  strOrigin?: string
+  strDestination?: string
+  strActionDate?: string
+  strActionTime?: string
+  sTrRemarks?: string
+  [key: string]: any
+}
+
+export type DtdcTrackingResponse = {
+  statusCode?: number
+  statusFlag?: boolean
+  status?: string
+  trackHeader?: DtdcTrackingHeader
+  trackDetails?: DtdcTrackingEvent[]
+  errorDetails?: any
+  [key: string]: any
+}
+
+export type DtdcTrackingRequest = {
+  trkType: string
+  strcnno: string
+  addtnlDtl: string
+}

--- a/packages/medusa-plugin-dtdc-shipping/src/providers/dtdc/adapter.ts
+++ b/packages/medusa-plugin-dtdc-shipping/src/providers/dtdc/adapter.ts
@@ -1,0 +1,161 @@
+import {
+  DtdcClient,
+  dtdcScanType,
+  normalizeDtdcWebhook,
+  isPincodeServiceable,
+} from "../../lib/dtdc-client"
+import { DtdcOptions, DtdcServiceType } from "../../lib/types"
+import {
+  CreateShipmentInput,
+  LabelResult,
+  ShipmentRef,
+  ShipmentResult,
+  ShippingProviderClient,
+  TrackingEvent,
+  TrackingResult,
+} from "../../lib/provider-interface"
+
+/** Service-type inference: large/heavy consignments go surface, else air. */
+function serviceTypeFor(input: CreateShipmentInput): DtdcServiceType {
+  const length = input.dimensions_cm?.length ?? 0
+  const heavy = input.weight_grams >= 10000 || length > 100
+  return heavy ? "GROUND_EXPRESS" : "PRIORITY"
+}
+
+export class DtdcProviderAdapter implements ShippingProviderClient {
+  readonly carrier = "dtdc"
+  private client: DtdcClient
+
+  constructor(options: DtdcOptions) {
+    this.client = new DtdcClient(options)
+  }
+
+  async checkServiceability(destinationPincode: string): Promise<boolean> {
+    try {
+      // The rate calculator wants an origin pincode. The adapter has no origin
+      // context on this call, so serviceability is checked destination-side
+      // with a known-good metro origin; callers that need origin accuracy pass
+      // the pincode through createShipment instead.
+      const result = await this.client.checkPincodeServiceability(
+        "110046",
+        destinationPincode
+      )
+      return isPincodeServiceable(result)
+    } catch {
+      return false
+    }
+  }
+
+  async createShipment(input: CreateShipmentInput): Promise<ShipmentResult> {
+    const result = await this.client.createShipment({
+      service_type_id: serviceTypeFor(input),
+      length: input.dimensions_cm?.length ?? 30,
+      width: input.dimensions_cm?.width ?? 25,
+      height: input.dimensions_cm?.height ?? 5,
+      weight: input.weight_grams / 1000,
+      declared_value: input.sub_total ?? input.cod_amount ?? 500,
+      num_pieces: input.items.reduce((s, i) => s + i.quantity, 0),
+      origin: input.from
+        ? {
+            name: input.from.name,
+            phone: input.from.phone,
+            address_line_1: input.from.address_1,
+            address_line_2: input.from.address_2,
+            pincode: input.from.pincode,
+            city: input.from.city,
+            state: input.from.state,
+          }
+        : {
+            name: "Warehouse",
+            phone: "",
+            address_line_1: "",
+            pincode: "",
+            city: "",
+            state: "",
+          },
+      destination: {
+        name: input.to.name,
+        phone: input.to.phone,
+        address_line_1: input.to.address_1,
+        address_line_2: input.to.address_2,
+        pincode: input.to.pincode,
+        city: input.to.city,
+        state: input.to.state,
+      },
+      customer_reference_number: input.reference_id,
+      cod_collection_mode: input.payment_mode === "cod" ? "CASH" : "",
+      cod_amount: input.payment_mode === "cod" ? input.cod_amount : undefined,
+      description:
+        input.product_description ||
+        input.items.map((i) => i.name).join(", "),
+    })
+
+    const awb = result?.data?.[0]?.reference_number || ""
+
+    return {
+      carrier: this.carrier,
+      awb,
+      tracking_number: awb,
+      tracking_url: awb
+        ? `https://www.dtdc.com/tracking.asp?awb=${awb}`
+        : undefined,
+      provider_refs: { awb },
+      raw: result,
+    }
+  }
+
+  async getLabel(ref: ShipmentRef): Promise<LabelResult> {
+    const awb = ref.awb || ref.provider_refs?.awb
+    if (!awb) throw new Error("DTDC getLabel requires an AWB number")
+    const label = await this.client.getLabel(awb)
+    return {
+      data: label.data,
+      format: label.format,
+      raw: label.raw,
+    }
+  }
+
+  async track(ref: ShipmentRef): Promise<TrackingResult> {
+    const awb = ref.awb || ref.provider_refs?.awb
+    if (!awb) throw new Error("DTDC track requires an AWB number")
+    const raw = await this.client.trackShipment(awb)
+    const header = raw?.trackHeader ?? {}
+    const trackDetails = raw?.trackDetails ?? []
+
+    const events: TrackingEvent[] = trackDetails.map((e: any) => ({
+      timestamp: `${e?.strActionDate ?? ""} ${e?.strActionTime ?? ""}`.trim(),
+      status: e?.strAction ?? "",
+      location: e?.strOrigin ?? "",
+      scan_type: dtdcScanType(e?.strCode, e?.strAction),
+    }))
+
+    events.sort(
+      (a, b) => new Date(b.timestamp).getTime() - new Date(a.timestamp).getTime()
+    )
+
+    return {
+      carrier: this.carrier,
+      awb: header?.strShipmentNo || awb,
+      current_status: header?.strStatus || "Unknown",
+      current_status_code: header?.strCNProduct,
+      estimated_delivery: header?.strExpectedDeliveryDate || null,
+      origin: header?.strOrigin || undefined,
+      destination: header?.strDestination || undefined,
+      events,
+      raw,
+    }
+  }
+
+  async cancelShipment(
+    ref: ShipmentRef
+  ): Promise<{ success: boolean; raw?: any }> {
+    const awb = ref.awb || ref.provider_refs?.awb
+    if (!awb) throw new Error("DTDC cancelShipment requires an AWB number")
+    const raw = await this.client.cancelShipment(awb)
+    return { success: raw?.success !== false, raw }
+  }
+
+  normalizeWebhook(payload: any): TrackingResult {
+    return normalizeDtdcWebhook(payload) as TrackingResult
+  }
+}

--- a/packages/medusa-plugin-dtdc-shipping/src/providers/dtdc/index.ts
+++ b/packages/medusa-plugin-dtdc-shipping/src/providers/dtdc/index.ts
@@ -1,0 +1,8 @@
+import { ModuleProvider, Modules } from "@medusajs/framework/utils"
+import DtdcFulfillmentService from "./service"
+
+export default ModuleProvider(Modules.FULFILLMENT, {
+  services: [DtdcFulfillmentService],
+})
+
+export { DtdcFulfillmentService }

--- a/packages/medusa-plugin-dtdc-shipping/src/providers/dtdc/service.ts
+++ b/packages/medusa-plugin-dtdc-shipping/src/providers/dtdc/service.ts
@@ -1,0 +1,244 @@
+import { AbstractFulfillmentProviderService } from "@medusajs/framework/utils"
+import {
+  CreateFulfillmentResult,
+  FulfillmentOption,
+  FulfillmentItemDTO,
+  FulfillmentOrderDTO,
+  FulfillmentDTO,
+  CalculatedShippingOptionPrice,
+  CreateShippingOptionDTO,
+} from "@medusajs/framework/types"
+import { DtdcClient } from "../../lib/dtdc-client"
+import { DtdcOptions } from "../../lib/types"
+import { Logger } from "@medusajs/framework/types"
+
+type InjectedDeps = { logger: Logger }
+
+/**
+ * DTDC fulfillment provider service.
+ *
+ * Extends AbstractFulfillmentProviderService so Medusa's fulfillment module
+ * can dispatch createFulfillment / cancelFulfillment through it. Mirrors the
+ * Delhivery service structure.
+ */
+class DtdcFulfillmentService extends AbstractFulfillmentProviderService {
+  static identifier = "dtdc"
+
+  protected client: DtdcClient
+  protected logger: Logger
+
+  constructor({ logger }: InjectedDeps, options: DtdcOptions) {
+    super()
+    this.logger = logger
+    this.client = new DtdcClient(options)
+  }
+
+  async getFulfillmentOptions(): Promise<FulfillmentOption[]> {
+    return [
+      {
+        id: "dtdc-ground-express",
+        name: "DTDC Ground Express",
+        mode: "Surface",
+        is_return: false,
+      },
+      {
+        id: "dtdc-ground-express-return",
+        name: "DTDC Ground Express - Return",
+        mode: "Surface",
+        is_return: true,
+      },
+      {
+        id: "dtdc-priority",
+        name: "DTDC Priority",
+        mode: "Express",
+        is_return: false,
+      },
+      {
+        id: "dtdc-priority-return",
+        name: "DTDC Priority - Return",
+        mode: "Express",
+        is_return: true,
+      },
+    ]
+  }
+
+  async validateFulfillmentData(
+    optionData: Record<string, unknown>,
+    data: Record<string, unknown>,
+    context: any
+  ): Promise<Record<string, unknown>> {
+    return { ...data, ...optionData }
+  }
+
+  async validateOption(data: Record<string, any>): Promise<boolean> {
+    return true
+  }
+
+  async canCalculate(data: CreateShippingOptionDTO): Promise<boolean> {
+    return true
+  }
+
+  async calculatePrice(
+    optionData: Record<string, unknown>,
+    data: Record<string, unknown>,
+    context: any
+  ): Promise<CalculatedShippingOptionPrice> {
+    return { calculated_amount: 0, is_calculated_price_tax_inclusive: false }
+  }
+
+  async createFulfillment(
+    data: Record<string, unknown>,
+    items: Partial<Omit<FulfillmentItemDTO, "fulfillment">>[],
+    order: Partial<FulfillmentOrderDTO> | undefined,
+    fulfillment: Partial<Omit<FulfillmentDTO, "provider_id" | "data" | "items">>
+  ): Promise<CreateFulfillmentResult> {
+    const shippingAddress = (order as any)?.shipping_address || {}
+    const fromLocation = (data as any).from_location || {}
+
+    try {
+      const productDesc = items.map((i: any) => i.title || "Item").join(", ")
+      const totalQuantity = items.reduce(
+        (sum: number, item: any) => sum + ((item as any).quantity || 1),
+        0
+      )
+
+      const orderItems = ((order as any)?.items || []) as any[]
+      const orderItemById = new Map<string, any>()
+      for (const oi of orderItems) {
+        if (oi.id) orderItemById.set(oi.id, oi)
+      }
+
+      let totalWeight = 0
+      let maxLength = 0
+      let maxWidth = 0
+      let maxHeight = 0
+      let hasActualWeight = false
+
+      for (const fItem of items) {
+        const qty = (fItem as any).quantity || 1
+        const orderItem = orderItemById.get((fItem as any).line_item_id)
+        const variant = orderItem?.variant
+
+        if (variant?.weight) {
+          hasActualWeight = true
+          totalWeight += variant.weight * qty
+        }
+
+        if (variant?.length && variant.length > maxLength) maxLength = variant.length
+        if (variant?.width && variant.width > maxWidth) maxWidth = variant.width
+        if (variant?.height) maxHeight += variant.height * qty
+      }
+
+      if (!hasActualWeight) {
+        if (totalQuantity <= 1) totalWeight = 400
+        else if (totalQuantity <= 2) totalWeight = 800
+        else if (totalQuantity <= 3) totalWeight = 1200
+        else if (totalQuantity <= 5) totalWeight = 2000
+        else if (totalQuantity <= 10) totalWeight = 3500
+        else totalWeight = totalQuantity * 500
+
+        if (!maxLength) maxLength = 30
+        if (!maxWidth) maxWidth = 25
+        if (!maxHeight) maxHeight = Math.max(3, totalQuantity * 2)
+
+        this.logger.warn(
+          `DTDC: no variant weight set — using bracket estimate: ` +
+          `${totalWeight}g for ${totalQuantity} items`
+        )
+      }
+
+      const paymentStatus = (order as any)?.payment_status
+      const isCod = paymentStatus !== "captured" && paymentStatus !== "paid"
+      const declaredValue = items.reduce((sum: number, item: any) => {
+        const oi = orderItemById.get((item as any).line_item_id)
+        const unitPrice = oi?.unit_price ?? oi?.variant?.price ?? 0
+        return sum + unitPrice * ((item as any).quantity || 1)
+      }, 0)
+
+      const serviceType = (data?.service_type as any) ?? "PRIORITY"
+      const result = await this.client.createShipment({
+        service_type_id: serviceType,
+        length: maxLength || 30,
+        width: maxWidth || 25,
+        height: maxHeight || 5,
+        weight: (totalWeight || 500) / 1000,
+        declared_value: declaredValue || 500,
+        num_pieces: totalQuantity,
+        origin: {
+          name: fromLocation.name || "Warehouse",
+          phone: fromLocation.address?.phone || "",
+          address_line_1: fromLocation.address?.address_1 || "",
+          address_line_2: fromLocation.address?.address_2 || "",
+          pincode: fromLocation.address?.postal_code || "",
+          city: fromLocation.address?.city || "",
+          state: fromLocation.address?.province || "",
+        },
+        destination: {
+          name: `${shippingAddress.first_name || ""} ${shippingAddress.last_name || ""}`.trim() || "Customer",
+          phone: shippingAddress.phone || "",
+          address_line_1: shippingAddress.address_1 || "",
+          address_line_2: shippingAddress.address_2 || "",
+          pincode: shippingAddress.postal_code || "",
+          city: shippingAddress.city || "",
+          state: shippingAddress.province || "",
+        },
+        customer_reference_number: (order as any)?.id || fulfillment.id || "",
+        cod_collection_mode: isCod ? "CASH" : "",
+        cod_amount: isCod ? declaredValue : undefined,
+        description: productDesc,
+      })
+
+      const awb =
+        result?.data?.[0]?.reference_number ||
+        result?.data?.[0]?.consignment_no ||
+        result?.data?.[0]?.awb_no ||
+        ""
+
+      this.logger.info(`DTDC shipment created: awb=${awb}`)
+
+      return {
+        data: {
+          waybill: awb,
+          tracking_number: awb,
+          carrier: "dtdc",
+          ...result,
+        },
+        labels: awb
+          ? [{
+              tracking_number: awb,
+              tracking_url: `https://www.dtdc.com/tracking.asp?awb=${awb}`,
+              label_url: "",
+            }]
+          : [],
+      }
+    } catch (e: any) {
+      this.logger.error(`DTDC createFulfillment error: ${e.message}`)
+      throw e
+    }
+  }
+
+  async cancelFulfillment(fulfillment: Record<string, any>): Promise<any> {
+    const awb = fulfillment.data?.waybill || fulfillment.data?.tracking_number
+    if (!awb) {
+      return {}
+    }
+
+    try {
+      const result = await this.client.cancelShipment(awb)
+      this.logger.info(`DTDC shipment cancelled: awb=${awb}`)
+      return result
+    } catch (e: any) {
+      this.logger.error(`DTDC cancelFulfillment error: ${e.message}`)
+      throw e
+    }
+  }
+
+  async createReturnFulfillment(fulfillment: Record<string, any>): Promise<CreateFulfillmentResult> {
+    return {
+      data: { carrier: "dtdc", type: "return" },
+      labels: [],
+    }
+  }
+}
+
+export default DtdcFulfillmentService

--- a/packages/medusa-plugin-dtdc-shipping/tsconfig.json
+++ b/packages/medusa-plugin-dtdc-shipping/tsconfig.json
@@ -1,0 +1,27 @@
+{
+  "compilerOptions": {
+    "target": "ES2021",
+    "esModuleInterop": true,
+    "module": "Node16",
+    "moduleResolution": "Node16",
+    "emitDecoratorMetadata": true,
+    "experimentalDecorators": true,
+    "skipLibCheck": true,
+    "skipDefaultLibCheck": true,
+    "declaration": false,
+    "sourceMap": false,
+    "inlineSourceMap": true,
+    "outDir": "./.medusa/server",
+    "rootDir": "./",
+    "forceConsistentCasingInFileNames": true,
+    "resolveJsonModule": true,
+    "checkJs": false,
+    "strictNullChecks": true,
+    "lib": ["ES2021", "DOM", "DOM.Iterable"]
+  },
+  "ts-node": {
+    "swc": true
+  },
+  "include": ["src/**/*"],
+  "exclude": ["node_modules", ".medusa"]
+}

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -155,6 +155,9 @@ importers:
       '@hookform/resolvers':
         specifier: ^5.0.1
         version: 5.2.2(react-hook-form@7.71.2(react@18.3.1))
+      '@jytextiles/medusa-plugin-dtdc-shipping':
+        specifier: workspace:*
+        version: link:../../packages/medusa-plugin-dtdc-shipping
       '@jytextiles/medusa-plugin-etsy-sync':
         specifier: latest
         version: 0.1.6(d7461c732c552c3be1976fbfbbf1e7a7)
@@ -340,7 +343,7 @@ importers:
         version: 2.5.6
       '@uploadthing/react':
         specifier: 7.1.0
-        version: 7.1.0(next@16.2.9(@babel/core@7.29.7)(@opentelemetry/api@1.9.0)(@playwright/test@1.61.1)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(sass@1.97.3))(react@18.3.1)(uploadthing@7.2.0(express@5.2.1)(next@16.2.9(@babel/core@7.29.7)(@opentelemetry/api@1.9.0)(@playwright/test@1.61.1)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(sass@1.97.3))(tailwindcss@3.4.19(tsx@4.21.0)(yaml@2.9.0)))
+        version: 7.1.0(next@16.2.9(@babel/core@8.0.1)(@opentelemetry/api@1.9.0)(@playwright/test@1.61.1)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(sass@1.97.3))(react@18.3.1)(uploadthing@7.2.0(express@5.2.1)(next@16.2.9(@babel/core@8.0.1)(@opentelemetry/api@1.9.0)(@playwright/test@1.61.1)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(sass@1.97.3))(tailwindcss@3.4.19(tsx@4.21.0)(yaml@2.9.0)))
       '@xenova/transformers':
         specifier: ^2.17.2
         version: 2.17.2
@@ -541,7 +544,7 @@ importers:
         version: 1.2.1
       uploadthing:
         specifier: 7.2.0
-        version: 7.2.0(express@5.2.1)(next@16.2.9(@babel/core@7.29.7)(@opentelemetry/api@1.9.0)(@playwright/test@1.61.1)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(sass@1.97.3))(tailwindcss@3.4.19(tsx@4.21.0)(yaml@2.9.0))
+        version: 7.2.0(express@5.2.1)(next@16.2.9(@babel/core@8.0.1)(@opentelemetry/api@1.9.0)(@playwright/test@1.61.1)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(sass@1.97.3))(tailwindcss@3.4.19(tsx@4.21.0)(yaml@2.9.0))
       use-file-picker:
         specifier: ^2.1.2
         version: 2.1.4(@types/react-dom@18.3.7(@types/react@18.3.28))(@types/react@18.3.28)(react@18.3.1)
@@ -1372,6 +1375,39 @@ importers:
         specifier: ^4.91.0
         version: 4.93.0(@cloudflare/workers-types@4.20260520.1)
 
+  packages/medusa-plugin-dtdc-shipping:
+    devDependencies:
+      '@medusajs/cli':
+        specifier: 2.19.0
+        version: 2.19.0(@types/node@20.19.34)
+      '@medusajs/framework':
+        specifier: 2.19.0
+        version: 2.19.0(@medusajs/cli@2.19.0(@types/node@20.19.34))(@types/node@20.19.34)(ioredis@5.9.3)(vite@7.3.6(@types/node@20.19.34)(jiti@1.21.7)(sass-embedded@1.97.3)(sass@1.97.3)(terser@5.46.0)(tsx@4.21.0)(yaml@2.9.0))(zod@4.2.0)
+      '@medusajs/medusa':
+        specifier: 2.19.0
+        version: 2.19.0(0404c9f56e237f8cc3ef991f1df290ec)
+      '@medusajs/types':
+        specifier: 2.19.0
+        version: 2.19.0(ioredis@5.9.3)(vite@7.3.6(@types/node@20.19.34)(jiti@1.21.7)(sass-embedded@1.97.3)(sass@1.97.3)(terser@5.46.0)(tsx@4.21.0)(yaml@2.9.0))
+      '@swc/core':
+        specifier: 1.5.7
+        version: 1.5.7(@swc/helpers@0.5.19)
+      '@swc/jest':
+        specifier: 0.2.37
+        version: 0.2.37(@swc/core@1.5.7(@swc/helpers@0.5.19))
+      '@types/jest':
+        specifier: 29.5.14
+        version: 29.5.14
+      '@types/node':
+        specifier: ^20.12.11
+        version: 20.19.34
+      jest:
+        specifier: 29.7.0
+        version: 29.7.0(@types/node@20.19.34)(ts-node@10.9.2(@swc/core@1.5.7(@swc/helpers@0.5.19))(@types/node@20.19.34)(typescript@5.6.3))
+      typescript:
+        specifier: 5.6.3
+        version: 5.6.3
+
   packages/medusa-plugin-etsy-sync:
     dependencies:
       react:
@@ -1431,7 +1467,7 @@ importers:
         version: 18.3.7(@types/react@18.3.28)
       jest:
         specifier: 29.7.0
-        version: 29.7.0(@types/node@20.19.34)(ts-node@10.9.2(@swc/core@1.7.28(@swc/helpers@0.5.19))(@types/node@20.19.34)(typescript@5.9.3))
+        version: 29.7.0(@types/node@20.19.34)(ts-node@10.9.2(@swc/core@1.5.7(@swc/helpers@0.5.19))(@types/node@20.19.34)(typescript@5.6.3))
       typescript:
         specifier: 5.6.3
         version: 5.6.3
@@ -1495,7 +1531,7 @@ importers:
         version: 18.3.7(@types/react@18.3.28)
       jest:
         specifier: 29.7.0
-        version: 29.7.0(@types/node@20.19.34)(ts-node@10.9.2(@swc/core@1.7.28(@swc/helpers@0.5.19))(@types/node@20.19.34)(typescript@5.9.3))
+        version: 29.7.0(@types/node@20.19.34)(ts-node@10.9.2(@swc/core@1.5.7(@swc/helpers@0.5.19))(@types/node@20.19.34)(typescript@5.6.3))
       typescript:
         specifier: 5.6.3
         version: 5.6.3
@@ -6408,12 +6444,6 @@ packages:
     peerDependencies:
       '@opentelemetry/api': '>=1.0.0 <1.10.0'
 
-  '@opentelemetry/context-async-hooks@2.7.1':
-    resolution: {integrity: sha512-OPFBYuXEn1E4ja3Y6eeA7O+ZnLBNcXTV5Cgsn1VaqBZ6hC5FnpZPLBNme1LJY8ZtF4aOujPKFoeWN4ik487KuQ==}
-    engines: {node: ^18.19.0 || >=20.6.0}
-    peerDependencies:
-      '@opentelemetry/api': '>=1.0.0 <1.10.0'
-
   '@opentelemetry/context-async-hooks@2.9.0':
     resolution: {integrity: sha512-OQ0vzvbZBiUhjqLnUaoNfYmP8553Crr3aggB4y0ZUi815mZ7idpdJXQmoKdeBKJelYttoBlLSSHubmyw3wvX4w==}
     engines: {node: ^18.19.0 || >=20.6.0}
@@ -6434,12 +6464,6 @@ packages:
 
   '@opentelemetry/core@2.5.1':
     resolution: {integrity: sha512-Dwlc+3HAZqpgTYq0MUyZABjFkcrKTePwuiFVLjahGD8cx3enqihmpAmdgNFO1R4m/sIe5afjJrA25Prqy4NXlA==}
-    engines: {node: ^18.19.0 || >=20.6.0}
-    peerDependencies:
-      '@opentelemetry/api': '>=1.0.0 <1.10.0'
-
-  '@opentelemetry/core@2.7.1':
-    resolution: {integrity: sha512-QAqIj32AtK6+pEVNG7EOVxHdE06RP+FM5qpiEJ4RtDcFIqKUZHYhl7/7UY5efhwmwNAg7j8QbJVBLxMerc0+gw==}
     engines: {node: ^18.19.0 || >=20.6.0}
     peerDependencies:
       '@opentelemetry/api': '>=1.0.0 <1.10.0'
@@ -6838,12 +6862,6 @@ packages:
     peerDependencies:
       '@opentelemetry/api': '>=1.3.0 <1.10.0'
 
-  '@opentelemetry/resources@2.7.1':
-    resolution: {integrity: sha512-DeT6KKolmC4e/dRQvMQ/RwlnzhaqeiFOXY5ngoOPJ07GgVVKxZOg9EcrNZb5aTzUn+iCrJldAgOfQm1O/QfPAQ==}
-    engines: {node: ^18.19.0 || >=20.6.0}
-    peerDependencies:
-      '@opentelemetry/api': '>=1.3.0 <1.10.0'
-
   '@opentelemetry/resources@2.9.0':
     resolution: {integrity: sha512-jyA5MBLQ+Dkl3+JsZkUoUvL7yHvU64kLsvpXKarWm6347Sl1t1bXFTFykUePNpT5WH5pm9a2Qtt03iIYQhZ1Fg==}
     engines: {node: ^18.19.0 || >=20.6.0}
@@ -6898,12 +6916,6 @@ packages:
     peerDependencies:
       '@opentelemetry/api': '>=1.3.0 <1.10.0'
 
-  '@opentelemetry/sdk-trace-base@2.7.1':
-    resolution: {integrity: sha512-NAYIlsF8MPUsKqJMiDQJTMPOmlbawC1Iz/omMLygZ1C9am8fTKYjTaI+OZM+WTY3t3Glo0wnOg/6/pac6RGPPw==}
-    engines: {node: ^18.19.0 || >=20.6.0}
-    peerDependencies:
-      '@opentelemetry/api': '>=1.3.0 <1.10.0'
-
   '@opentelemetry/sdk-trace-base@2.9.0':
     resolution: {integrity: sha512-cp9zmTl62R8PJrpvFcmc8N2JQU/xfa0S+61q511Nji+QxCfZ8Ifvg7H27G8cANe4crg4RTrWsVvanHiXjSp6ag==}
     engines: {node: ^18.19.0 || >=20.6.0}
@@ -6918,12 +6930,6 @@ packages:
 
   '@opentelemetry/sdk-trace-node@2.5.1':
     resolution: {integrity: sha512-9lopQ6ZoElETOEN0csgmtEV5/9C7BMfA7VtF4Jape3i954b6sTY2k3Xw3CxUTKreDck/vpAuJM+EDo4zheUw+A==}
-    engines: {node: ^18.19.0 || >=20.6.0}
-    peerDependencies:
-      '@opentelemetry/api': '>=1.0.0 <1.10.0'
-
-  '@opentelemetry/sdk-trace-node@2.7.1':
-    resolution: {integrity: sha512-pCpQxU68lV+I9s9svqMyVu5iHdDDUnqUpSxqwyCU8A9ejEsSnMPCbearwsUO4yk08ZJzAIUCFuReMdVQvHrdvg==}
     engines: {node: ^18.19.0 || >=20.6.0}
     peerDependencies:
       '@opentelemetry/api': '>=1.0.0 <1.10.0'
@@ -17256,9 +17262,6 @@ packages:
   path-to-regexp@6.3.0:
     resolution: {integrity: sha512-Yhpw4T9C6hPpgPeA28us07OJeqZ5EzQTkbfwuhsUg0c237RomFoETJgmp2sa3F/41gfLE6G5cqcYwznmeEeOlQ==}
 
-  path-to-regexp@8.3.0:
-    resolution: {integrity: sha512-7jdwVIRtsP8MYpdXSwOS0YdD0Du+qOoF/AEPIt88PcCFrZCzx41oxku1jD88hZBwbNUIEfpqvuhjFaMAqMTWnA==}
-
   path-to-regexp@8.4.2:
     resolution: {integrity: sha512-qRcuIdP69NPm4qbACK+aDogI5CBDMi1jKe0ry5rSQJz8JVLsC7jV8XpiJjGRLLol3N+R5ihGYcrPLTno6pAdBA==}
 
@@ -22806,7 +22809,7 @@ snapshots:
       '@babel/helper-replace-supers': 8.0.1(@babel/core@8.0.1)
       '@babel/helper-skip-transparent-expression-wrappers': 8.0.0
       '@babel/traverse': 8.0.4
-      semver: 7.7.4
+      semver: 7.8.5
 
   '@babel/helper-create-regexp-features-plugin@7.28.5(@babel/core@7.29.0)':
     dependencies:
@@ -26457,6 +26460,19 @@ snapshots:
       '@standard-schema/utils': 0.3.0
       react-hook-form: 7.71.2(react@18.3.1)
 
+  '@hookform/resolvers@5.5.7(@sinclair/typebox@0.34.48)(@standard-schema/spec@1.1.0)(ajv-formats@2.1.1(ajv@8.13.0))(ajv@8.13.0)(effect@3.19.19)(joi@17.13.3)(react-hook-form@7.83.0(react@18.3.1))(zod@4.2.0)':
+    dependencies:
+      '@standard-schema/utils': 0.3.0
+      react-hook-form: 7.83.0(react@18.3.1)
+    optionalDependencies:
+      '@sinclair/typebox': 0.34.48
+      '@standard-schema/spec': 1.1.0
+      ajv: 8.13.0
+      ajv-formats: 2.1.1(ajv@8.13.0)
+      effect: 3.19.19
+      joi: 17.13.3
+      zod: 4.2.0
+
   '@hookform/resolvers@5.5.7(@sinclair/typebox@0.34.48)(@standard-schema/spec@1.1.0)(ajv-formats@2.1.1(ajv@8.18.0))(ajv@8.18.0)(effect@3.19.19)(joi@17.13.3)(react-hook-form@7.83.0(react@18.3.1))(zod@4.2.0)':
     dependencies:
       '@standard-schema/utils': 0.3.0
@@ -26731,6 +26747,41 @@ snapshots:
       jest-message-util: 29.7.0
       jest-util: 29.7.0
       slash: 3.0.0
+
+  '@jest/core@29.7.0(ts-node@10.9.2(@swc/core@1.5.7(@swc/helpers@0.5.19))(@types/node@20.19.34)(typescript@5.6.3))':
+    dependencies:
+      '@jest/console': 29.7.0
+      '@jest/reporters': 29.7.0
+      '@jest/test-result': 29.7.0
+      '@jest/transform': 29.7.0
+      '@jest/types': 29.6.3
+      '@types/node': 20.19.34
+      ansi-escapes: 4.3.2
+      chalk: 4.1.2
+      ci-info: 3.9.0
+      exit: 0.1.2
+      graceful-fs: 4.2.11
+      jest-changed-files: 29.7.0
+      jest-config: 29.7.0(@types/node@20.19.34)(ts-node@10.9.2(@swc/core@1.5.7(@swc/helpers@0.5.19))(@types/node@20.19.34)(typescript@5.6.3))
+      jest-haste-map: 29.7.0
+      jest-message-util: 29.7.0
+      jest-regex-util: 29.6.3
+      jest-resolve: 29.7.0
+      jest-resolve-dependencies: 29.7.0
+      jest-runner: 29.7.0
+      jest-runtime: 29.7.0
+      jest-snapshot: 29.7.0
+      jest-util: 29.7.0
+      jest-validate: 29.7.0
+      jest-watcher: 29.7.0
+      micromatch: 4.0.8
+      pretty-format: 29.7.0
+      slash: 3.0.0
+      strip-ansi: 6.0.1
+    transitivePeerDependencies:
+      - babel-plugin-macros
+      - supports-color
+      - ts-node
 
   '@jest/core@29.7.0(ts-node@10.9.2(@swc/core@1.7.28(@swc/helpers@0.5.19))(@types/node@20.19.34)(typescript@5.9.3))':
     dependencies:
@@ -27388,8 +27439,66 @@ snapshots:
   '@medusajs/admin-bundler@2.19.0(@emotion/is-prop-valid@1.4.0)(@sinclair/typebox@0.34.48)(@standard-schema/spec@1.1.0)(@types/node@20.19.34)(@types/react-dom@18.3.7(@types/react@18.3.28))(@types/react@18.3.28)(ajv-formats@2.1.1(ajv@8.20.0))(ajv@8.20.0)(effect@3.19.19)(jiti@1.21.7)(joi@17.13.3)(sass-embedded@1.97.3)(sass@1.97.3)(terser@5.46.0)(tsx@4.21.0)(typescript@5.6.3)(yaml@2.9.0)':
     dependencies:
       '@medusajs/admin-shared': 2.19.0
-      '@medusajs/admin-vite-plugin': 2.19.0(vite@7.3.6(@types/node@20.19.34)(jiti@1.21.7)(sass-embedded@1.97.3)(sass@1.97.3)(terser@5.46.0)(tsx@4.21.0)(yaml@2.9.0))
+      '@medusajs/admin-vite-plugin': 2.19.0(picomatch@4.0.5)(vite@7.3.6(@types/node@20.19.34)(jiti@1.21.7)(sass-embedded@1.97.3)(sass@1.97.3)(terser@5.46.0)(tsx@4.21.0)(yaml@2.9.0))
       '@medusajs/dashboard': 2.19.0(@emotion/is-prop-valid@1.4.0)(@sinclair/typebox@0.34.48)(@standard-schema/spec@1.1.0)(@types/react-dom@18.3.7(@types/react@18.3.28))(@types/react@18.3.28)(ajv-formats@2.1.1(ajv@8.20.0))(ajv@8.20.0)(effect@3.19.19)(joi@17.13.3)(typescript@5.6.3)
+      '@vitejs/plugin-react': 5.2.0(vite@7.3.6(@types/node@20.19.34)(jiti@1.21.7)(sass-embedded@1.97.3)(sass@1.97.3)(terser@5.46.0)(tsx@4.21.0)(yaml@2.9.0))
+      autoprefixer: 10.4.27(postcss@8.5.26)
+      compression: 1.8.1
+      express: 4.22.1
+      get-port: 5.1.1
+      glob: 13.0.6
+      outdent: 0.8.0
+      postcss: 8.5.26
+      tailwindcss: 3.4.19(tsx@4.21.0)(yaml@2.9.0)
+      vite: 7.3.6(@types/node@20.19.34)(jiti@1.21.7)(sass-embedded@1.97.3)(sass@1.97.3)(terser@5.46.0)(tsx@4.21.0)(yaml@2.9.0)
+    transitivePeerDependencies:
+      - '@emotion/is-prop-valid'
+      - '@sinclair/typebox'
+      - '@standard-schema/spec'
+      - '@types/node'
+      - '@types/react'
+      - '@types/react-dom'
+      - '@typeschema/main'
+      - '@vinejs/vine'
+      - ajv
+      - ajv-errors
+      - ajv-formats
+      - arktype
+      - ata-validator
+      - class-transformer
+      - class-validator
+      - computed-types
+      - effect
+      - fluentvalidation-ts
+      - fp-ts
+      - io-ts
+      - jiti
+      - joi
+      - less
+      - lightningcss
+      - nope-validator
+      - picomatch
+      - react-native
+      - sass
+      - sass-embedded
+      - stylus
+      - sugarss
+      - superstruct
+      - supports-color
+      - terser
+      - tsx
+      - typanion
+      - typescript
+      - valibot
+      - vest
+      - yaml
+      - yup
+
+  '@medusajs/admin-bundler@2.19.0(@emotion/is-prop-valid@1.4.0)(@sinclair/typebox@0.34.48)(@standard-schema/spec@1.1.0)(@types/node@20.19.34)(@types/react-dom@19.0.3(@types/react@19.0.3))(@types/react@19.0.3)(ajv-formats@2.1.1(ajv@8.13.0))(ajv@8.13.0)(effect@3.19.19)(jiti@1.21.7)(joi@17.13.3)(sass-embedded@1.97.3)(sass@1.97.3)(terser@5.46.0)(tsx@4.21.0)(typescript@5.6.3)(yaml@2.9.0)':
+    dependencies:
+      '@medusajs/admin-shared': 2.19.0
+      '@medusajs/admin-vite-plugin': 2.19.0(picomatch@4.0.5)(vite@7.3.6(@types/node@20.19.34)(jiti@1.21.7)(sass-embedded@1.97.3)(sass@1.97.3)(terser@5.46.0)(tsx@4.21.0)(yaml@2.9.0))
+      '@medusajs/dashboard': 2.19.0(@emotion/is-prop-valid@1.4.0)(@sinclair/typebox@0.34.48)(@standard-schema/spec@1.1.0)(@types/react-dom@19.0.3(@types/react@19.0.3))(@types/react@19.0.3)(ajv-formats@2.1.1(ajv@8.13.0))(ajv@8.13.0)(effect@3.19.19)(joi@17.13.3)(typescript@5.6.3)
       '@vitejs/plugin-react': 5.2.0(vite@7.3.6(@types/node@20.19.34)(jiti@1.21.7)(sass-embedded@1.97.3)(sass@1.97.3)(terser@5.46.0)(tsx@4.21.0)(yaml@2.9.0))
       autoprefixer: 10.4.27(postcss@8.5.26)
       compression: 1.8.1
@@ -27489,26 +27598,11 @@ snapshots:
       '@babel/traverse': 7.25.6
       '@babel/types': 7.25.6
       '@medusajs/admin-shared': 2.19.0
-      fdir: 6.1.1(picomatch@4.0.4)
+      fdir: 6.1.1(picomatch@4.0.5)
       magic-string: 0.30.5
       outdent: 0.8.0
       picocolors: 1.1.1
       vite: 5.4.21(@types/node@20.19.34)(sass-embedded@1.97.3)(sass@1.97.3)(terser@5.46.0)
-    transitivePeerDependencies:
-      - picomatch
-      - supports-color
-
-  '@medusajs/admin-vite-plugin@2.19.0(vite@7.3.6(@types/node@20.19.34)(jiti@1.21.7)(sass-embedded@1.97.3)(sass@1.97.3)(terser@5.46.0)(tsx@4.21.0)(yaml@2.9.0))':
-    dependencies:
-      '@babel/parser': 7.25.6
-      '@babel/traverse': 7.25.6
-      '@babel/types': 7.25.6
-      '@medusajs/admin-shared': 2.19.0
-      fdir: 6.1.1(picomatch@4.0.4)
-      magic-string: 0.30.5
-      outdent: 0.8.0
-      picocolors: 1.1.1
-      vite: 7.3.6(@types/node@20.19.34)(jiti@1.21.7)(sass-embedded@1.97.3)(sass@1.97.3)(terser@5.46.0)(tsx@4.21.0)(yaml@2.9.0)
     transitivePeerDependencies:
       - picomatch
       - supports-color
@@ -27792,6 +27886,77 @@ snapshots:
       - vest
       - yup
 
+  '@medusajs/dashboard@2.19.0(@emotion/is-prop-valid@1.4.0)(@sinclair/typebox@0.34.48)(@standard-schema/spec@1.1.0)(@types/react-dom@19.0.3(@types/react@19.0.3))(@types/react@19.0.3)(ajv-formats@2.1.1(ajv@8.13.0))(ajv@8.13.0)(effect@3.19.19)(joi@17.13.3)(typescript@5.6.3)':
+    dependencies:
+      '@ariakit/react': 0.4.21(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
+      '@babel/runtime': 7.29.7
+      '@dnd-kit/core': 6.3.1(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
+      '@dnd-kit/sortable': 8.0.0(@dnd-kit/core@6.3.1(react-dom@18.3.1(react@18.3.1))(react@18.3.1))(react@18.3.1)
+      '@dnd-kit/utilities': 3.2.2(react@18.3.1)
+      '@hookform/error-message': 2.0.1(react-dom@18.3.1(react@18.3.1))(react-hook-form@7.83.0(react@18.3.1))(react@18.3.1)
+      '@hookform/resolvers': 5.5.7(@sinclair/typebox@0.34.48)(@standard-schema/spec@1.1.0)(ajv-formats@2.1.1(ajv@8.13.0))(ajv@8.13.0)(effect@3.19.19)(joi@17.13.3)(react-hook-form@7.83.0(react@18.3.1))(zod@4.2.0)
+      '@medusajs/admin-shared': 2.19.0
+      '@medusajs/icons': 2.19.0(react@18.3.1)
+      '@medusajs/js-sdk': 2.19.0
+      '@medusajs/ui': 4.2.1(@types/react-dom@19.0.3(@types/react@19.0.3))(@types/react@19.0.3)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(typescript@5.6.3)
+      '@radix-ui/react-dialog': 1.1.4(@types/react-dom@19.0.3(@types/react@19.0.3))(@types/react@19.0.3)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
+      '@radix-ui/react-dismissable-layer': 1.1.4(@types/react-dom@19.0.3(@types/react@19.0.3))(@types/react@19.0.3)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
+      '@tanstack/react-query': 5.90.21(react@18.3.1)
+      '@tanstack/react-table': 8.20.5(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
+      '@tanstack/react-virtual': 3.13.19(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
+      '@uiw/react-json-view': 2.0.0-alpha.41(@babel/runtime@7.29.7)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
+      cmdk: 0.2.1(@types/react@19.0.3)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
+      copy-to-clipboard: 3.3.3
+      date-fns: 3.6.0
+      i18next: 23.7.11
+      i18next-browser-languagedetector: 7.2.0
+      lodash.debounce: 4.0.8
+      lodash.isequal: 4.5.0
+      match-sorter: 6.4.0
+      motion: 11.18.2(@emotion/is-prop-valid@1.4.0)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
+      qrcode: 1.5.4
+      qs: 6.15.3
+      radix-ui: 1.1.2(@types/react-dom@19.0.3(@types/react@19.0.3))(@types/react@19.0.3)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
+      react: 18.3.1
+      react-country-flag: 3.1.0(react@18.3.1)
+      react-currency-input-field: 3.10.0(react@18.3.1)
+      react-dom: 18.3.1(react@18.3.1)
+      react-helmet-async: 2.0.5(react@18.3.1)
+      react-hook-form: 7.83.0(react@18.3.1)
+      react-i18next: 13.5.0(i18next@23.7.11)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
+      react-jwt: 1.3.0(react@18.3.1)
+      react-router-dom: 7.18.2(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
+      zod: 4.2.0
+    transitivePeerDependencies:
+      - '@emotion/is-prop-valid'
+      - '@sinclair/typebox'
+      - '@standard-schema/spec'
+      - '@types/react'
+      - '@types/react-dom'
+      - '@typeschema/main'
+      - '@vinejs/vine'
+      - ajv
+      - ajv-errors
+      - ajv-formats
+      - arktype
+      - ata-validator
+      - class-transformer
+      - class-validator
+      - computed-types
+      - effect
+      - fluentvalidation-ts
+      - fp-ts
+      - io-ts
+      - joi
+      - nope-validator
+      - react-native
+      - superstruct
+      - typanion
+      - typescript
+      - valibot
+      - vest
+      - yup
+
   '@medusajs/deps@2.19.0(@types/node@20.19.34)':
     dependencies:
       '@mikro-orm/cli': 6.6.14(pg@8.20.0)
@@ -27801,9 +27966,9 @@ snapshots:
       '@mikro-orm/postgresql': 6.6.14(@mikro-orm/core@6.6.14)
       '@opentelemetry/api': 1.9.0
       '@opentelemetry/instrumentation-pg': 0.52.0(@opentelemetry/api@1.9.0)
-      '@opentelemetry/resources': 2.7.1(@opentelemetry/api@1.9.0)
+      '@opentelemetry/resources': 2.9.0(@opentelemetry/api@1.9.0)
       '@opentelemetry/sdk-node': 0.220.0(@opentelemetry/api@1.9.0)
-      '@opentelemetry/sdk-trace-node': 2.7.1(@opentelemetry/api@1.9.0)
+      '@opentelemetry/sdk-trace-node': 2.9.0(@opentelemetry/api@1.9.0)
       awilix: 8.0.1
       pg: 8.20.0
       zod: 4.2.0
@@ -27843,6 +28008,59 @@ snapshots:
       '@medusajs/icons': 2.19.0(react@18.3.1)
       '@medusajs/test-utils': 2.19.0(@medusajs/core-flows@2.19.0(@medusajs/framework@2.19.0(@medusajs/cli@2.19.0(@types/node@20.19.34))(@types/node@20.19.34)(ioredis@5.9.3)(vite@7.3.6(@types/node@20.19.34)(jiti@1.21.7)(sass-embedded@1.97.3)(sass@1.97.3)(terser@5.46.0)(tsx@4.21.0)(yaml@2.9.0))(zod@4.2.0)))(@medusajs/framework@2.19.0(@medusajs/cli@2.19.0(@types/node@20.19.34))(@types/node@20.19.34)(ioredis@5.9.3)(vite@7.3.6(@types/node@20.19.34)(jiti@1.21.7)(sass-embedded@1.97.3)(sass@1.97.3)(terser@5.46.0)(tsx@4.21.0)(yaml@2.9.0))(zod@4.2.0))(@medusajs/medusa@2.19.0)
       '@medusajs/ui': 4.2.1(@types/react-dom@18.3.7(@types/react@18.3.28))(@types/react@18.3.28)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(typescript@5.6.3)
+      react: 18.3.1
+      react-dom: 18.3.1(react@18.3.1)
+      react-router-dom: 7.18.2(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
+    transitivePeerDependencies:
+      - '@sinclair/typebox'
+      - '@standard-schema/spec'
+      - '@types/react'
+      - '@types/react-dom'
+      - '@typeschema/main'
+      - '@vinejs/vine'
+      - ajv
+      - ajv-errors
+      - ajv-formats
+      - arktype
+      - ata-validator
+      - class-transformer
+      - class-validator
+      - computed-types
+      - effect
+      - fluentvalidation-ts
+      - fp-ts
+      - io-ts
+      - joi
+      - nope-validator
+      - superstruct
+      - typanion
+      - valibot
+      - vest
+      - yup
+
+  '@medusajs/draft-order@2.19.0(7b6c1d5e91336905aed7ef9ae6ca9ba3)':
+    dependencies:
+      '@ariakit/react': 0.4.21(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
+      '@babel/runtime': 7.29.7
+      '@hookform/resolvers': 5.5.7(@sinclair/typebox@0.34.48)(@standard-schema/spec@1.1.0)(ajv-formats@2.1.1(ajv@8.13.0))(ajv@8.13.0)(effect@3.19.19)(joi@17.13.3)(react-hook-form@7.83.0(react@18.3.1))(zod@4.2.0)
+      '@medusajs/framework': 2.19.0(@medusajs/cli@2.19.0(@types/node@20.19.34))(@types/node@20.19.34)(ioredis@5.9.3)(vite@7.3.6(@types/node@20.19.34)(jiti@1.21.7)(sass-embedded@1.97.3)(sass@1.97.3)(terser@5.46.0)(tsx@4.21.0)(yaml@2.9.0))(zod@4.2.0)
+      '@medusajs/js-sdk': 2.19.0
+      '@tanstack/react-query': 5.90.21(react@18.3.1)
+      '@uiw/react-json-view': 2.0.0-alpha.41(@babel/runtime@7.29.7)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
+      date-fns: 3.6.0
+      lodash.debounce: 4.0.8
+      lodash.isequal: 4.5.0
+      match-sorter: 6.4.0
+      radix-ui: 1.1.2(@types/react-dom@19.0.3(@types/react@19.0.3))(@types/react@19.0.3)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
+      react-hook-form: 7.83.0(react@18.3.1)
+      zod: 4.2.0
+    optionalDependencies:
+      '@medusajs/admin-sdk': 2.19.0
+      '@medusajs/cli': 2.19.0(@types/node@20.19.34)
+      '@medusajs/dashboard': 2.19.0(@emotion/is-prop-valid@1.4.0)(@sinclair/typebox@0.34.48)(@standard-schema/spec@1.1.0)(@types/react-dom@19.0.3(@types/react@19.0.3))(@types/react@19.0.3)(ajv-formats@2.1.1(ajv@8.13.0))(ajv@8.13.0)(effect@3.19.19)(joi@17.13.3)(typescript@5.6.3)
+      '@medusajs/icons': 2.19.0(react@18.3.1)
+      '@medusajs/test-utils': 2.19.0(@medusajs/core-flows@2.19.0(@medusajs/framework@2.19.0(@medusajs/cli@2.19.0(@types/node@20.19.34))(@types/node@20.19.34)(ioredis@5.9.3)(vite@7.3.6(@types/node@20.19.34)(jiti@1.21.7)(sass-embedded@1.97.3)(sass@1.97.3)(terser@5.46.0)(tsx@4.21.0)(yaml@2.9.0))(zod@4.2.0)))(@medusajs/framework@2.19.0(@medusajs/cli@2.19.0(@types/node@20.19.34))(@types/node@20.19.34)(ioredis@5.9.3)(vite@7.3.6(@types/node@20.19.34)(jiti@1.21.7)(sass-embedded@1.97.3)(sass@1.97.3)(terser@5.46.0)(tsx@4.21.0)(yaml@2.9.0))(zod@4.2.0))(@medusajs/medusa@2.19.0)
+      '@medusajs/ui': 4.2.1(@types/react-dom@19.0.3(@types/react@19.0.3))(@types/react@19.0.3)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(typescript@5.6.3)
       react: 18.3.1
       react-dom: 18.3.1(react@18.3.1)
       react-router-dom: 7.18.2(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
@@ -28166,6 +28384,139 @@ snapshots:
       - valibot
       - vest
       - yalc
+      - yaml
+      - yup
+
+  '@medusajs/medusa@2.19.0(0404c9f56e237f8cc3ef991f1df290ec)':
+    dependencies:
+      '@inquirer/checkbox': 2.5.0
+      '@inquirer/confirm': 2.0.17
+      '@inquirer/input': 2.3.0
+      '@medusajs/admin-bundler': 2.19.0(@emotion/is-prop-valid@1.4.0)(@sinclair/typebox@0.34.48)(@standard-schema/spec@1.1.0)(@types/node@20.19.34)(@types/react-dom@19.0.3(@types/react@19.0.3))(@types/react@19.0.3)(ajv-formats@2.1.1(ajv@8.13.0))(ajv@8.13.0)(effect@3.19.19)(jiti@1.21.7)(joi@17.13.3)(sass-embedded@1.97.3)(sass@1.97.3)(terser@5.46.0)(tsx@4.21.0)(typescript@5.6.3)(yaml@2.9.0)
+      '@medusajs/analytics': 2.19.0(@medusajs/framework@2.19.0(@medusajs/cli@2.19.0(@types/node@20.19.34))(@types/node@20.19.34)(ioredis@5.9.3)(vite@7.3.6(@types/node@20.19.34)(jiti@1.21.7)(sass-embedded@1.97.3)(sass@1.97.3)(terser@5.46.0)(tsx@4.21.0)(yaml@2.9.0))(zod@4.2.0))
+      '@medusajs/analytics-local': 2.19.0(@medusajs/framework@2.19.0(@medusajs/cli@2.19.0(@types/node@20.19.34))(@types/node@20.19.34)(ioredis@5.9.3)(vite@7.3.6(@types/node@20.19.34)(jiti@1.21.7)(sass-embedded@1.97.3)(sass@1.97.3)(terser@5.46.0)(tsx@4.21.0)(yaml@2.9.0))(zod@4.2.0))
+      '@medusajs/analytics-posthog': 2.19.0(@medusajs/framework@2.19.0(@medusajs/cli@2.19.0(@types/node@20.19.34))(@types/node@20.19.34)(ioredis@5.9.3)(vite@7.3.6(@types/node@20.19.34)(jiti@1.21.7)(sass-embedded@1.97.3)(sass@1.97.3)(terser@5.46.0)(tsx@4.21.0)(yaml@2.9.0))(zod@4.2.0))(posthog-node@5.41.0(rxjs@7.8.2))
+      '@medusajs/api-key': 2.19.0(@medusajs/framework@2.19.0(@medusajs/cli@2.19.0(@types/node@20.19.34))(@types/node@20.19.34)(ioredis@5.9.3)(vite@7.3.6(@types/node@20.19.34)(jiti@1.21.7)(sass-embedded@1.97.3)(sass@1.97.3)(terser@5.46.0)(tsx@4.21.0)(yaml@2.9.0))(zod@4.2.0))
+      '@medusajs/auth': 2.19.0(@medusajs/framework@2.19.0(@medusajs/cli@2.19.0(@types/node@20.19.34))(@types/node@20.19.34)(ioredis@5.9.3)(vite@7.3.6(@types/node@20.19.34)(jiti@1.21.7)(sass-embedded@1.97.3)(sass@1.97.3)(terser@5.46.0)(tsx@4.21.0)(yaml@2.9.0))(zod@4.2.0))
+      '@medusajs/auth-emailpass': 2.19.0(@medusajs/framework@2.19.0(@medusajs/cli@2.19.0(@types/node@20.19.34))(@types/node@20.19.34)(ioredis@5.9.3)(vite@7.3.6(@types/node@20.19.34)(jiti@1.21.7)(sass-embedded@1.97.3)(sass@1.97.3)(terser@5.46.0)(tsx@4.21.0)(yaml@2.9.0))(zod@4.2.0))
+      '@medusajs/auth-github': 2.19.0(@medusajs/framework@2.19.0(@medusajs/cli@2.19.0(@types/node@20.19.34))(@types/node@20.19.34)(ioredis@5.9.3)(vite@7.3.6(@types/node@20.19.34)(jiti@1.21.7)(sass-embedded@1.97.3)(sass@1.97.3)(terser@5.46.0)(tsx@4.21.0)(yaml@2.9.0))(zod@4.2.0))
+      '@medusajs/auth-google': 2.19.0(@medusajs/framework@2.19.0(@medusajs/cli@2.19.0(@types/node@20.19.34))(@types/node@20.19.34)(ioredis@5.9.3)(vite@7.3.6(@types/node@20.19.34)(jiti@1.21.7)(sass-embedded@1.97.3)(sass@1.97.3)(terser@5.46.0)(tsx@4.21.0)(yaml@2.9.0))(zod@4.2.0))
+      '@medusajs/auth-oidc': 2.19.0(@medusajs/framework@2.19.0(@medusajs/cli@2.19.0(@types/node@20.19.34))(@types/node@20.19.34)(ioredis@5.9.3)(vite@7.3.6(@types/node@20.19.34)(jiti@1.21.7)(sass-embedded@1.97.3)(sass@1.97.3)(terser@5.46.0)(tsx@4.21.0)(yaml@2.9.0))(zod@4.2.0))
+      '@medusajs/cache-inmemory': 2.19.0(@medusajs/framework@2.19.0(@medusajs/cli@2.19.0(@types/node@20.19.34))(@types/node@20.19.34)(ioredis@5.9.3)(vite@7.3.6(@types/node@20.19.34)(jiti@1.21.7)(sass-embedded@1.97.3)(sass@1.97.3)(terser@5.46.0)(tsx@4.21.0)(yaml@2.9.0))(zod@4.2.0))
+      '@medusajs/cache-redis': 2.19.0(@medusajs/framework@2.19.0(@medusajs/cli@2.19.0(@types/node@20.19.34))(@types/node@20.19.34)(ioredis@5.9.3)(vite@7.3.6(@types/node@20.19.34)(jiti@1.21.7)(sass-embedded@1.97.3)(sass@1.97.3)(terser@5.46.0)(tsx@4.21.0)(yaml@2.9.0))(zod@4.2.0))
+      '@medusajs/caching': 2.19.0(@medusajs/framework@2.19.0(@medusajs/cli@2.19.0(@types/node@20.19.34))(@types/node@20.19.34)(ioredis@5.9.3)(vite@7.3.6(@types/node@20.19.34)(jiti@1.21.7)(sass-embedded@1.97.3)(sass@1.97.3)(terser@5.46.0)(tsx@4.21.0)(yaml@2.9.0))(zod@4.2.0))(awilix@8.0.1)
+      '@medusajs/caching-redis': 2.19.0(@medusajs/framework@2.19.0(@medusajs/cli@2.19.0(@types/node@20.19.34))(@types/node@20.19.34)(ioredis@5.9.3)(vite@7.3.6(@types/node@20.19.34)(jiti@1.21.7)(sass-embedded@1.97.3)(sass@1.97.3)(terser@5.46.0)(tsx@4.21.0)(yaml@2.9.0))(zod@4.2.0))
+      '@medusajs/cart': 2.19.0(@medusajs/framework@2.19.0(@medusajs/cli@2.19.0(@types/node@20.19.34))(@types/node@20.19.34)(ioredis@5.9.3)(vite@7.3.6(@types/node@20.19.34)(jiti@1.21.7)(sass-embedded@1.97.3)(sass@1.97.3)(terser@5.46.0)(tsx@4.21.0)(yaml@2.9.0))(zod@4.2.0))
+      '@medusajs/core-flows': 2.19.0(@medusajs/framework@2.19.0(@medusajs/cli@2.19.0(@types/node@20.19.34))(@types/node@20.19.34)(ioredis@5.9.3)(vite@7.3.6(@types/node@20.19.34)(jiti@1.21.7)(sass-embedded@1.97.3)(sass@1.97.3)(terser@5.46.0)(tsx@4.21.0)(yaml@2.9.0))(zod@4.2.0))
+      '@medusajs/currency': 2.19.0(@medusajs/framework@2.19.0(@medusajs/cli@2.19.0(@types/node@20.19.34))(@types/node@20.19.34)(ioredis@5.9.3)(vite@7.3.6(@types/node@20.19.34)(jiti@1.21.7)(sass-embedded@1.97.3)(sass@1.97.3)(terser@5.46.0)(tsx@4.21.0)(yaml@2.9.0))(zod@4.2.0))
+      '@medusajs/customer': 2.19.0(@medusajs/framework@2.19.0(@medusajs/cli@2.19.0(@types/node@20.19.34))(@types/node@20.19.34)(ioredis@5.9.3)(vite@7.3.6(@types/node@20.19.34)(jiti@1.21.7)(sass-embedded@1.97.3)(sass@1.97.3)(terser@5.46.0)(tsx@4.21.0)(yaml@2.9.0))(zod@4.2.0))
+      '@medusajs/draft-order': 2.19.0(7b6c1d5e91336905aed7ef9ae6ca9ba3)
+      '@medusajs/event-bus-local': 2.19.0(@medusajs/framework@2.19.0(@medusajs/cli@2.19.0(@types/node@20.19.34))(@types/node@20.19.34)(ioredis@5.9.3)(vite@7.3.6(@types/node@20.19.34)(jiti@1.21.7)(sass-embedded@1.97.3)(sass@1.97.3)(terser@5.46.0)(tsx@4.21.0)(yaml@2.9.0))(zod@4.2.0))
+      '@medusajs/event-bus-redis': 2.19.0(@medusajs/framework@2.19.0(@medusajs/cli@2.19.0(@types/node@20.19.34))(@types/node@20.19.34)(ioredis@5.9.3)(vite@7.3.6(@types/node@20.19.34)(jiti@1.21.7)(sass-embedded@1.97.3)(sass@1.97.3)(terser@5.46.0)(tsx@4.21.0)(yaml@2.9.0))(zod@4.2.0))
+      '@medusajs/file': 2.19.0(@medusajs/framework@2.19.0(@medusajs/cli@2.19.0(@types/node@20.19.34))(@types/node@20.19.34)(ioredis@5.9.3)(vite@7.3.6(@types/node@20.19.34)(jiti@1.21.7)(sass-embedded@1.97.3)(sass@1.97.3)(terser@5.46.0)(tsx@4.21.0)(yaml@2.9.0))(zod@4.2.0))
+      '@medusajs/file-local': 2.19.0(@medusajs/framework@2.19.0(@medusajs/cli@2.19.0(@types/node@20.19.34))(@types/node@20.19.34)(ioredis@5.9.3)(vite@7.3.6(@types/node@20.19.34)(jiti@1.21.7)(sass-embedded@1.97.3)(sass@1.97.3)(terser@5.46.0)(tsx@4.21.0)(yaml@2.9.0))(zod@4.2.0))
+      '@medusajs/file-s3': 2.19.0(@medusajs/framework@2.19.0(@medusajs/cli@2.19.0(@types/node@20.19.34))(@types/node@20.19.34)(ioredis@5.9.3)(vite@7.3.6(@types/node@20.19.34)(jiti@1.21.7)(sass-embedded@1.97.3)(sass@1.97.3)(terser@5.46.0)(tsx@4.21.0)(yaml@2.9.0))(zod@4.2.0))
+      '@medusajs/framework': 2.19.0(@medusajs/cli@2.19.0(@types/node@20.19.34))(@types/node@20.19.34)(ioredis@5.9.3)(vite@7.3.6(@types/node@20.19.34)(jiti@1.21.7)(sass-embedded@1.97.3)(sass@1.97.3)(terser@5.46.0)(tsx@4.21.0)(yaml@2.9.0))(zod@4.2.0)
+      '@medusajs/fulfillment': 2.19.0(@medusajs/framework@2.19.0(@medusajs/cli@2.19.0(@types/node@20.19.34))(@types/node@20.19.34)(ioredis@5.9.3)(vite@7.3.6(@types/node@20.19.34)(jiti@1.21.7)(sass-embedded@1.97.3)(sass@1.97.3)(terser@5.46.0)(tsx@4.21.0)(yaml@2.9.0))(zod@4.2.0))
+      '@medusajs/fulfillment-manual': 2.19.0(@medusajs/framework@2.19.0(@medusajs/cli@2.19.0(@types/node@20.19.34))(@types/node@20.19.34)(ioredis@5.9.3)(vite@7.3.6(@types/node@20.19.34)(jiti@1.21.7)(sass-embedded@1.97.3)(sass@1.97.3)(terser@5.46.0)(tsx@4.21.0)(yaml@2.9.0))(zod@4.2.0))
+      '@medusajs/index': 2.19.0(@medusajs/framework@2.19.0(@medusajs/cli@2.19.0(@types/node@20.19.34))(@types/node@20.19.34)(ioredis@5.9.3)(vite@7.3.6(@types/node@20.19.34)(jiti@1.21.7)(sass-embedded@1.97.3)(sass@1.97.3)(terser@5.46.0)(tsx@4.21.0)(yaml@2.9.0))(zod@4.2.0))
+      '@medusajs/inventory': 2.19.0(@medusajs/framework@2.19.0(@medusajs/cli@2.19.0(@types/node@20.19.34))(@types/node@20.19.34)(ioredis@5.9.3)(vite@7.3.6(@types/node@20.19.34)(jiti@1.21.7)(sass-embedded@1.97.3)(sass@1.97.3)(terser@5.46.0)(tsx@4.21.0)(yaml@2.9.0))(zod@4.2.0))
+      '@medusajs/link-modules': 2.19.0(@medusajs/framework@2.19.0(@medusajs/cli@2.19.0(@types/node@20.19.34))(@types/node@20.19.34)(ioredis@5.9.3)(vite@7.3.6(@types/node@20.19.34)(jiti@1.21.7)(sass-embedded@1.97.3)(sass@1.97.3)(terser@5.46.0)(tsx@4.21.0)(yaml@2.9.0))(zod@4.2.0))
+      '@medusajs/locking': 2.19.0(@medusajs/framework@2.19.0(@medusajs/cli@2.19.0(@types/node@20.19.34))(@types/node@20.19.34)(ioredis@5.9.3)(vite@7.3.6(@types/node@20.19.34)(jiti@1.21.7)(sass-embedded@1.97.3)(sass@1.97.3)(terser@5.46.0)(tsx@4.21.0)(yaml@2.9.0))(zod@4.2.0))
+      '@medusajs/locking-postgres': 2.19.0(@medusajs/framework@2.19.0(@medusajs/cli@2.19.0(@types/node@20.19.34))(@types/node@20.19.34)(ioredis@5.9.3)(vite@7.3.6(@types/node@20.19.34)(jiti@1.21.7)(sass-embedded@1.97.3)(sass@1.97.3)(terser@5.46.0)(tsx@4.21.0)(yaml@2.9.0))(zod@4.2.0))
+      '@medusajs/locking-redis': 2.19.0(@medusajs/framework@2.19.0(@medusajs/cli@2.19.0(@types/node@20.19.34))(@types/node@20.19.34)(ioredis@5.9.3)(vite@7.3.6(@types/node@20.19.34)(jiti@1.21.7)(sass-embedded@1.97.3)(sass@1.97.3)(terser@5.46.0)(tsx@4.21.0)(yaml@2.9.0))(zod@4.2.0))
+      '@medusajs/notification': 2.19.0(@medusajs/framework@2.19.0(@medusajs/cli@2.19.0(@types/node@20.19.34))(@types/node@20.19.34)(ioredis@5.9.3)(vite@7.3.6(@types/node@20.19.34)(jiti@1.21.7)(sass-embedded@1.97.3)(sass@1.97.3)(terser@5.46.0)(tsx@4.21.0)(yaml@2.9.0))(zod@4.2.0))
+      '@medusajs/notification-local': 2.19.0(@medusajs/framework@2.19.0(@medusajs/cli@2.19.0(@types/node@20.19.34))(@types/node@20.19.34)(ioredis@5.9.3)(vite@7.3.6(@types/node@20.19.34)(jiti@1.21.7)(sass-embedded@1.97.3)(sass@1.97.3)(terser@5.46.0)(tsx@4.21.0)(yaml@2.9.0))(zod@4.2.0))
+      '@medusajs/notification-sendgrid': 2.19.0(@medusajs/framework@2.19.0(@medusajs/cli@2.19.0(@types/node@20.19.34))(@types/node@20.19.34)(ioredis@5.9.3)(vite@7.3.6(@types/node@20.19.34)(jiti@1.21.7)(sass-embedded@1.97.3)(sass@1.97.3)(terser@5.46.0)(tsx@4.21.0)(yaml@2.9.0))(zod@4.2.0))
+      '@medusajs/order': 2.19.0(@medusajs/framework@2.19.0(@medusajs/cli@2.19.0(@types/node@20.19.34))(@types/node@20.19.34)(ioredis@5.9.3)(vite@7.3.6(@types/node@20.19.34)(jiti@1.21.7)(sass-embedded@1.97.3)(sass@1.97.3)(terser@5.46.0)(tsx@4.21.0)(yaml@2.9.0))(zod@4.2.0))
+      '@medusajs/payment': 2.19.0(@medusajs/framework@2.19.0(@medusajs/cli@2.19.0(@types/node@20.19.34))(@types/node@20.19.34)(ioredis@5.9.3)(vite@7.3.6(@types/node@20.19.34)(jiti@1.21.7)(sass-embedded@1.97.3)(sass@1.97.3)(terser@5.46.0)(tsx@4.21.0)(yaml@2.9.0))(zod@4.2.0))(@types/node@20.19.34)
+      '@medusajs/payment-stripe': 2.19.0(@medusajs/framework@2.19.0(@medusajs/cli@2.19.0(@types/node@20.19.34))(@types/node@20.19.34)(ioredis@5.9.3)(vite@7.3.6(@types/node@20.19.34)(jiti@1.21.7)(sass-embedded@1.97.3)(sass@1.97.3)(terser@5.46.0)(tsx@4.21.0)(yaml@2.9.0))(zod@4.2.0))
+      '@medusajs/pricing': 2.19.0(@medusajs/framework@2.19.0(@medusajs/cli@2.19.0(@types/node@20.19.34))(@types/node@20.19.34)(ioredis@5.9.3)(vite@7.3.6(@types/node@20.19.34)(jiti@1.21.7)(sass-embedded@1.97.3)(sass@1.97.3)(terser@5.46.0)(tsx@4.21.0)(yaml@2.9.0))(zod@4.2.0))
+      '@medusajs/product': 2.19.0(@medusajs/framework@2.19.0(@medusajs/cli@2.19.0(@types/node@20.19.34))(@types/node@20.19.34)(ioredis@5.9.3)(vite@7.3.6(@types/node@20.19.34)(jiti@1.21.7)(sass-embedded@1.97.3)(sass@1.97.3)(terser@5.46.0)(tsx@4.21.0)(yaml@2.9.0))(zod@4.2.0))
+      '@medusajs/promotion': 2.19.0(@medusajs/framework@2.19.0(@medusajs/cli@2.19.0(@types/node@20.19.34))(@types/node@20.19.34)(ioredis@5.9.3)(vite@7.3.6(@types/node@20.19.34)(jiti@1.21.7)(sass-embedded@1.97.3)(sass@1.97.3)(terser@5.46.0)(tsx@4.21.0)(yaml@2.9.0))(zod@4.2.0))
+      '@medusajs/rbac': 2.19.0(@medusajs/framework@2.19.0(@medusajs/cli@2.19.0(@types/node@20.19.34))(@types/node@20.19.34)(ioredis@5.9.3)(vite@7.3.6(@types/node@20.19.34)(jiti@1.21.7)(sass-embedded@1.97.3)(sass@1.97.3)(terser@5.46.0)(tsx@4.21.0)(yaml@2.9.0))(zod@4.2.0))
+      '@medusajs/region': 2.19.0(@medusajs/framework@2.19.0(@medusajs/cli@2.19.0(@types/node@20.19.34))(@types/node@20.19.34)(ioredis@5.9.3)(vite@7.3.6(@types/node@20.19.34)(jiti@1.21.7)(sass-embedded@1.97.3)(sass@1.97.3)(terser@5.46.0)(tsx@4.21.0)(yaml@2.9.0))(zod@4.2.0))
+      '@medusajs/sales-channel': 2.19.0(@medusajs/framework@2.19.0(@medusajs/cli@2.19.0(@types/node@20.19.34))(@types/node@20.19.34)(ioredis@5.9.3)(vite@7.3.6(@types/node@20.19.34)(jiti@1.21.7)(sass-embedded@1.97.3)(sass@1.97.3)(terser@5.46.0)(tsx@4.21.0)(yaml@2.9.0))(zod@4.2.0))
+      '@medusajs/search': 2.19.0(@medusajs/framework@2.19.0(@medusajs/cli@2.19.0(@types/node@20.19.34))(@types/node@20.19.34)(ioredis@5.9.3)(vite@7.3.6(@types/node@20.19.34)(jiti@1.21.7)(sass-embedded@1.97.3)(sass@1.97.3)(terser@5.46.0)(tsx@4.21.0)(yaml@2.9.0))(zod@4.2.0))
+      '@medusajs/search-local': 2.19.0(@medusajs/framework@2.19.0(@medusajs/cli@2.19.0(@types/node@20.19.34))(@types/node@20.19.34)(ioredis@5.9.3)(vite@7.3.6(@types/node@20.19.34)(jiti@1.21.7)(sass-embedded@1.97.3)(sass@1.97.3)(terser@5.46.0)(tsx@4.21.0)(yaml@2.9.0))(zod@4.2.0))
+      '@medusajs/settings': 2.19.0(@medusajs/framework@2.19.0(@medusajs/cli@2.19.0(@types/node@20.19.34))(@types/node@20.19.34)(ioredis@5.9.3)(vite@7.3.6(@types/node@20.19.34)(jiti@1.21.7)(sass-embedded@1.97.3)(sass@1.97.3)(terser@5.46.0)(tsx@4.21.0)(yaml@2.9.0))(zod@4.2.0))
+      '@medusajs/stock-location': 2.19.0(@medusajs/framework@2.19.0(@medusajs/cli@2.19.0(@types/node@20.19.34))(@types/node@20.19.34)(ioredis@5.9.3)(vite@7.3.6(@types/node@20.19.34)(jiti@1.21.7)(sass-embedded@1.97.3)(sass@1.97.3)(terser@5.46.0)(tsx@4.21.0)(yaml@2.9.0))(zod@4.2.0))
+      '@medusajs/store': 2.19.0(@medusajs/framework@2.19.0(@medusajs/cli@2.19.0(@types/node@20.19.34))(@types/node@20.19.34)(ioredis@5.9.3)(vite@7.3.6(@types/node@20.19.34)(jiti@1.21.7)(sass-embedded@1.97.3)(sass@1.97.3)(terser@5.46.0)(tsx@4.21.0)(yaml@2.9.0))(zod@4.2.0))
+      '@medusajs/tax': 2.19.0(@medusajs/framework@2.19.0(@medusajs/cli@2.19.0(@types/node@20.19.34))(@types/node@20.19.34)(ioredis@5.9.3)(vite@7.3.6(@types/node@20.19.34)(jiti@1.21.7)(sass-embedded@1.97.3)(sass@1.97.3)(terser@5.46.0)(tsx@4.21.0)(yaml@2.9.0))(zod@4.2.0))
+      '@medusajs/telemetry': 2.19.0
+      '@medusajs/translation': 2.19.0(@medusajs/framework@2.19.0(@medusajs/cli@2.19.0(@types/node@20.19.34))(@types/node@20.19.34)(ioredis@5.9.3)(vite@7.3.6(@types/node@20.19.34)(jiti@1.21.7)(sass-embedded@1.97.3)(sass@1.97.3)(terser@5.46.0)(tsx@4.21.0)(yaml@2.9.0))(zod@4.2.0))
+      '@medusajs/user': 2.19.0(@medusajs/framework@2.19.0(@medusajs/cli@2.19.0(@types/node@20.19.34))(@types/node@20.19.34)(ioredis@5.9.3)(vite@7.3.6(@types/node@20.19.34)(jiti@1.21.7)(sass-embedded@1.97.3)(sass@1.97.3)(terser@5.46.0)(tsx@4.21.0)(yaml@2.9.0))(zod@4.2.0))
+      '@medusajs/workflow-engine-inmemory': 2.19.0(@medusajs/framework@2.19.0(@medusajs/cli@2.19.0(@types/node@20.19.34))(@types/node@20.19.34)(ioredis@5.9.3)(vite@7.3.6(@types/node@20.19.34)(jiti@1.21.7)(sass-embedded@1.97.3)(sass@1.97.3)(terser@5.46.0)(tsx@4.21.0)(yaml@2.9.0))(zod@4.2.0))
+      '@medusajs/workflow-engine-redis': 2.19.0(@medusajs/framework@2.19.0(@medusajs/cli@2.19.0(@types/node@20.19.34))(@types/node@20.19.34)(ioredis@5.9.3)(vite@7.3.6(@types/node@20.19.34)(jiti@1.21.7)(sass-embedded@1.97.3)(sass@1.97.3)(terser@5.46.0)(tsx@4.21.0)(yaml@2.9.0))(zod@4.2.0))
+      boxen: 5.1.2
+      chalk: 4.1.2
+      chokidar: 4.0.3
+      compression: 1.8.1
+      express: 4.22.1
+      fs-exists-cached: 1.0.0
+      jsonwebtoken: 9.0.3
+      multer: 2.2.0
+      node-schedule: 2.1.1
+      qs: 6.15.3
+      request-ip: 3.3.0
+      slugify: 1.6.6
+      uuid: 11.1.1
+    optionalDependencies:
+      '@swc/core': 1.5.7(@swc/helpers@0.5.19)
+      posthog-node: 5.41.0(rxjs@7.8.2)
+      react-dom: 18.3.1(react@18.3.1)
+      yalc: 1.0.0-pre.53
+    transitivePeerDependencies:
+      - '@emotion/is-prop-valid'
+      - '@medusajs/admin-sdk'
+      - '@medusajs/cli'
+      - '@medusajs/dashboard'
+      - '@medusajs/icons'
+      - '@medusajs/test-utils'
+      - '@medusajs/ui'
+      - '@sinclair/typebox'
+      - '@standard-schema/spec'
+      - '@types/node'
+      - '@types/react'
+      - '@types/react-dom'
+      - '@typeschema/main'
+      - '@vinejs/vine'
+      - ajv
+      - ajv-errors
+      - ajv-formats
+      - arktype
+      - ata-validator
+      - awilix
+      - aws-crt
+      - class-transformer
+      - class-validator
+      - computed-types
+      - debug
+      - effect
+      - fluentvalidation-ts
+      - fp-ts
+      - io-ts
+      - jiti
+      - joi
+      - less
+      - lightningcss
+      - nope-validator
+      - picomatch
+      - react
+      - react-native
+      - react-router-dom
+      - sass
+      - sass-embedded
+      - stylus
+      - sugarss
+      - superstruct
+      - supports-color
+      - terser
+      - tsx
+      - typanion
+      - typescript
+      - valibot
+      - vest
       - yaml
       - yup
 
@@ -28657,7 +29008,7 @@ snapshots:
       ulid: 2.4.0
     optionalDependencies:
       '@medusajs/core-flows': 2.19.0(@medusajs/framework@2.19.0(@medusajs/cli@2.19.0(@types/node@20.19.34))(@types/node@20.19.34)(ioredis@5.9.3)(vite@7.3.6(@types/node@20.19.34)(jiti@1.21.7)(sass-embedded@1.97.3)(sass@1.97.3)(terser@5.46.0)(tsx@4.21.0)(yaml@2.9.0))(zod@4.2.0))
-      '@medusajs/medusa': 2.19.0(91a2f19d1744c07c9c0a55b6ae822462)
+      '@medusajs/medusa': 2.19.0(0404c9f56e237f8cc3ef991f1df290ec)
     transitivePeerDependencies:
       - debug
       - supports-color
@@ -28868,6 +29219,34 @@ snapshots:
       prism-react-renderer: 2.4.1(react@18.3.1)
       prismjs: 1.30.0
       radix-ui: 1.1.2(@types/react-dom@19.0.3(@types/react@18.3.28))(@types/react@18.3.28)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
+      react: 18.3.1
+      react-aria: 3.46.0(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
+      react-currency-input-field: 3.10.0(react@18.3.1)
+      react-dom: 18.3.1(react@18.3.1)
+      react-stately: 3.44.0(react@18.3.1)
+      sonner: 1.7.4(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
+      tailwind-merge: 2.6.1
+    transitivePeerDependencies:
+      - '@types/react'
+      - '@types/react-dom'
+      - typescript
+
+  '@medusajs/ui@4.2.1(@types/react-dom@19.0.3(@types/react@19.0.3))(@types/react@19.0.3)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(typescript@5.6.3)':
+    dependencies:
+      '@dnd-kit/core': 6.3.1(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
+      '@dnd-kit/sortable': 8.0.0(@dnd-kit/core@6.3.1(react-dom@18.3.1(react@18.3.1))(react@18.3.1))(react@18.3.1)
+      '@dnd-kit/utilities': 3.2.2(react@18.3.1)
+      '@medusajs/icons': 2.19.0(react@18.3.1)
+      '@radix-ui/react-dialog': 1.1.4(@types/react-dom@19.0.3(@types/react@19.0.3))(@types/react@19.0.3)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
+      '@radix-ui/react-dismissable-layer': 1.1.4(@types/react-dom@19.0.3(@types/react@19.0.3))(@types/react@19.0.3)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
+      '@tanstack/react-table': 8.20.5(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
+      clsx: 2.1.1
+      copy-to-clipboard: 3.3.3
+      cva: 1.0.0-beta.1(typescript@5.6.3)
+      lodash.isequal: 4.5.0
+      prism-react-renderer: 2.4.1(react@18.3.1)
+      prismjs: 1.30.0
+      radix-ui: 1.1.2(@types/react-dom@19.0.3(@types/react@19.0.3))(@types/react@19.0.3)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
       react: 18.3.1
       react-aria: 3.46.0(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
       react-currency-input-field: 3.10.0(react@18.3.1)
@@ -29257,6 +29636,17 @@ snapshots:
 
   '@nolyfill/is-core-module@1.0.39': {}
 
+  '@oclif/command@1.8.36(@oclif/config@1.18.17)':
+    dependencies:
+      '@oclif/config': 1.18.17
+      '@oclif/errors': 1.3.6
+      '@oclif/help': 1.0.15(supports-color@8.1.1)
+      '@oclif/parser': 3.8.17
+      debug: 4.4.3(supports-color@8.1.1)
+      semver: 7.7.4
+    transitivePeerDependencies:
+      - supports-color
+
   '@oclif/command@1.8.36(@oclif/config@1.18.17)(supports-color@8.1.1)':
     dependencies:
       '@oclif/config': 1.18.17
@@ -29587,10 +29977,6 @@ snapshots:
     dependencies:
       '@opentelemetry/api': 1.9.0
 
-  '@opentelemetry/context-async-hooks@2.7.1(@opentelemetry/api@1.9.0)':
-    dependencies:
-      '@opentelemetry/api': 1.9.0
-
   '@opentelemetry/context-async-hooks@2.9.0(@opentelemetry/api@1.9.0)':
     dependencies:
       '@opentelemetry/api': 1.9.0
@@ -29606,11 +29992,6 @@ snapshots:
       '@opentelemetry/semantic-conventions': 1.39.0
 
   '@opentelemetry/core@2.5.1(@opentelemetry/api@1.9.0)':
-    dependencies:
-      '@opentelemetry/api': 1.9.0
-      '@opentelemetry/semantic-conventions': 1.39.0
-
-  '@opentelemetry/core@2.7.1(@opentelemetry/api@1.9.0)':
     dependencies:
       '@opentelemetry/api': 1.9.0
       '@opentelemetry/semantic-conventions': 1.39.0
@@ -29980,7 +30361,7 @@ snapshots:
   '@opentelemetry/instrumentation-pg@0.52.0(@opentelemetry/api@1.9.0)':
     dependencies:
       '@opentelemetry/api': 1.9.0
-      '@opentelemetry/core': 2.7.1(@opentelemetry/api@1.9.0)
+      '@opentelemetry/core': 2.9.0(@opentelemetry/api@1.9.0)
       '@opentelemetry/instrumentation': 0.200.0(@opentelemetry/api@1.9.0)
       '@opentelemetry/semantic-conventions': 1.39.0
       '@opentelemetry/sql-common': 0.41.2(@opentelemetry/api@1.9.0)
@@ -30179,12 +30560,6 @@ snapshots:
       '@opentelemetry/core': 2.5.1(@opentelemetry/api@1.9.0)
       '@opentelemetry/semantic-conventions': 1.39.0
 
-  '@opentelemetry/resources@2.7.1(@opentelemetry/api@1.9.0)':
-    dependencies:
-      '@opentelemetry/api': 1.9.0
-      '@opentelemetry/core': 2.7.1(@opentelemetry/api@1.9.0)
-      '@opentelemetry/semantic-conventions': 1.39.0
-
   '@opentelemetry/resources@2.9.0(@opentelemetry/api@1.9.0)':
     dependencies:
       '@opentelemetry/api': 1.9.0
@@ -30293,13 +30668,6 @@ snapshots:
       '@opentelemetry/resources': 2.5.1(@opentelemetry/api@1.9.0)
       '@opentelemetry/semantic-conventions': 1.39.0
 
-  '@opentelemetry/sdk-trace-base@2.7.1(@opentelemetry/api@1.9.0)':
-    dependencies:
-      '@opentelemetry/api': 1.9.0
-      '@opentelemetry/core': 2.7.1(@opentelemetry/api@1.9.0)
-      '@opentelemetry/resources': 2.7.1(@opentelemetry/api@1.9.0)
-      '@opentelemetry/semantic-conventions': 1.39.0
-
   '@opentelemetry/sdk-trace-base@2.9.0(@opentelemetry/api@1.9.0)':
     dependencies:
       '@opentelemetry/api': 1.9.0
@@ -30321,13 +30689,6 @@ snapshots:
       '@opentelemetry/context-async-hooks': 2.5.1(@opentelemetry/api@1.9.0)
       '@opentelemetry/core': 2.5.1(@opentelemetry/api@1.9.0)
       '@opentelemetry/sdk-trace-base': 2.5.1(@opentelemetry/api@1.9.0)
-
-  '@opentelemetry/sdk-trace-node@2.7.1(@opentelemetry/api@1.9.0)':
-    dependencies:
-      '@opentelemetry/api': 1.9.0
-      '@opentelemetry/context-async-hooks': 2.7.1(@opentelemetry/api@1.9.0)
-      '@opentelemetry/core': 2.7.1(@opentelemetry/api@1.9.0)
-      '@opentelemetry/sdk-trace-base': 2.7.1(@opentelemetry/api@1.9.0)
 
   '@opentelemetry/sdk-trace-node@2.9.0(@opentelemetry/api@1.9.0)':
     dependencies:
@@ -31223,6 +31584,28 @@ snapshots:
       react: 18.3.1
       react-dom: 18.3.1(react@18.3.1)
       react-remove-scroll: 2.5.4(@types/react@18.3.28)(react@18.3.1)
+    transitivePeerDependencies:
+      - '@types/react'
+
+  '@radix-ui/react-dialog@1.0.0(@types/react@19.0.3)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)':
+    dependencies:
+      '@babel/runtime': 7.29.7
+      '@radix-ui/primitive': 1.0.0
+      '@radix-ui/react-compose-refs': 1.0.0(react@18.3.1)
+      '@radix-ui/react-context': 1.0.0(react@18.3.1)
+      '@radix-ui/react-dismissable-layer': 1.0.0(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
+      '@radix-ui/react-focus-guards': 1.0.0(react@18.3.1)
+      '@radix-ui/react-focus-scope': 1.0.0(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
+      '@radix-ui/react-id': 1.0.0(react@18.3.1)
+      '@radix-ui/react-portal': 1.0.0(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
+      '@radix-ui/react-presence': 1.0.0(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
+      '@radix-ui/react-primitive': 1.0.0(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
+      '@radix-ui/react-slot': 1.0.0(react@18.3.1)
+      '@radix-ui/react-use-controllable-state': 1.0.0(react@18.3.1)
+      aria-hidden: 1.2.6
+      react: 18.3.1
+      react-dom: 18.3.1(react@18.3.1)
+      react-remove-scroll: 2.5.4(@types/react@19.0.3)(react@18.3.1)
     transitivePeerDependencies:
       - '@types/react'
 
@@ -38060,14 +38443,14 @@ snapshots:
 
   '@uploadthing/mime-types@0.3.1': {}
 
-  '@uploadthing/react@7.1.0(next@16.2.9(@babel/core@7.29.7)(@opentelemetry/api@1.9.0)(@playwright/test@1.61.1)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(sass@1.97.3))(react@18.3.1)(uploadthing@7.2.0(express@5.2.1)(next@16.2.9(@babel/core@7.29.7)(@opentelemetry/api@1.9.0)(@playwright/test@1.61.1)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(sass@1.97.3))(tailwindcss@3.4.19(tsx@4.21.0)(yaml@2.9.0)))':
+  '@uploadthing/react@7.1.0(next@16.2.9(@babel/core@8.0.1)(@opentelemetry/api@1.9.0)(@playwright/test@1.61.1)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(sass@1.97.3))(react@18.3.1)(uploadthing@7.2.0(express@5.2.1)(next@16.2.9(@babel/core@8.0.1)(@opentelemetry/api@1.9.0)(@playwright/test@1.61.1)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(sass@1.97.3))(tailwindcss@3.4.19(tsx@4.21.0)(yaml@2.9.0)))':
     dependencies:
       '@uploadthing/shared': 7.1.0
       file-selector: 0.6.0
       react: 18.3.1
-      uploadthing: 7.2.0(express@5.2.1)(next@16.2.9(@babel/core@7.29.7)(@opentelemetry/api@1.9.0)(@playwright/test@1.61.1)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(sass@1.97.3))(tailwindcss@3.4.19(tsx@4.21.0)(yaml@2.9.0))
+      uploadthing: 7.2.0(express@5.2.1)(next@16.2.9(@babel/core@8.0.1)(@opentelemetry/api@1.9.0)(@playwright/test@1.61.1)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(sass@1.97.3))(tailwindcss@3.4.19(tsx@4.21.0)(yaml@2.9.0))
     optionalDependencies:
-      next: 16.2.9(@babel/core@7.29.7)(@opentelemetry/api@1.9.0)(@playwright/test@1.61.1)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(sass@1.97.3)
+      next: 16.2.9(@babel/core@8.0.1)(@opentelemetry/api@1.9.0)(@playwright/test@1.61.1)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(sass@1.97.3)
 
   '@uploadthing/shared@7.1.0':
     dependencies:
@@ -38413,6 +38796,11 @@ snapshots:
   ajv-draft-04@1.0.0(ajv@8.20.0):
     optionalDependencies:
       ajv: 8.20.0
+
+  ajv-formats@2.1.1(ajv@8.13.0):
+    optionalDependencies:
+      ajv: 8.13.0
+    optional: true
 
   ajv-formats@2.1.1(ajv@8.18.0):
     optionalDependencies:
@@ -39148,7 +39536,7 @@ snapshots:
       http-errors: 2.0.1
       iconv-lite: 0.7.2
       on-finished: 2.4.1
-      qs: 6.15.0
+      qs: 6.15.3
       raw-body: 3.0.2
       type-is: 2.0.1
     transitivePeerDependencies:
@@ -39703,6 +40091,14 @@ snapshots:
     transitivePeerDependencies:
       - '@types/react'
 
+  cmdk@0.2.1(@types/react@19.0.3)(react-dom@18.3.1(react@18.3.1))(react@18.3.1):
+    dependencies:
+      '@radix-ui/react-dialog': 1.0.0(@types/react@19.0.3)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
+      react: 18.3.1
+      react-dom: 18.3.1(react@18.3.1)
+    transitivePeerDependencies:
+      - '@types/react'
+
   co@4.6.0: {}
 
   codecs@3.1.0:
@@ -40058,6 +40454,21 @@ snapshots:
     dependencies:
       crc-32: 1.2.2
       readable-stream: 4.7.0
+
+  create-jest@29.7.0(@types/node@20.19.34)(ts-node@10.9.2(@swc/core@1.5.7(@swc/helpers@0.5.19))(@types/node@20.19.34)(typescript@5.6.3)):
+    dependencies:
+      '@jest/types': 29.6.3
+      chalk: 4.1.2
+      exit: 0.1.2
+      graceful-fs: 4.2.11
+      jest-config: 29.7.0(@types/node@20.19.34)(ts-node@10.9.2(@swc/core@1.5.7(@swc/helpers@0.5.19))(@types/node@20.19.34)(typescript@5.6.3))
+      jest-util: 29.7.0
+      prompts: 2.4.2
+    transitivePeerDependencies:
+      - '@types/node'
+      - babel-plugin-macros
+      - supports-color
+      - ts-node
 
   create-jest@29.7.0(@types/node@20.19.34)(ts-node@10.9.2(@swc/core@1.7.28(@swc/helpers@0.5.19))(@types/node@20.19.34)(typescript@5.9.3)):
     dependencies:
@@ -41774,7 +42185,7 @@ snapshots:
       once: 1.4.0
       parseurl: 1.3.3
       proxy-addr: 2.0.7
-      qs: 6.15.0
+      qs: 6.15.3
       range-parser: 1.2.1
       router: 2.2.0
       send: 1.2.1
@@ -42356,7 +42767,7 @@ snapshots:
 
   glob@13.0.6:
     dependencies:
-      minimatch: 10.2.4
+      minimatch: 10.2.5
       minipass: 7.1.3
       path-scurry: 2.0.2
 
@@ -43636,6 +44047,25 @@ snapshots:
       - babel-plugin-macros
       - supports-color
 
+  jest-cli@29.7.0(@types/node@20.19.34)(ts-node@10.9.2(@swc/core@1.5.7(@swc/helpers@0.5.19))(@types/node@20.19.34)(typescript@5.6.3)):
+    dependencies:
+      '@jest/core': 29.7.0(ts-node@10.9.2(@swc/core@1.5.7(@swc/helpers@0.5.19))(@types/node@20.19.34)(typescript@5.6.3))
+      '@jest/test-result': 29.7.0
+      '@jest/types': 29.6.3
+      chalk: 4.1.2
+      create-jest: 29.7.0(@types/node@20.19.34)(ts-node@10.9.2(@swc/core@1.5.7(@swc/helpers@0.5.19))(@types/node@20.19.34)(typescript@5.6.3))
+      exit: 0.1.2
+      import-local: 3.2.0
+      jest-config: 29.7.0(@types/node@20.19.34)(ts-node@10.9.2(@swc/core@1.5.7(@swc/helpers@0.5.19))(@types/node@20.19.34)(typescript@5.6.3))
+      jest-util: 29.7.0
+      jest-validate: 29.7.0
+      yargs: 17.7.2
+    transitivePeerDependencies:
+      - '@types/node'
+      - babel-plugin-macros
+      - supports-color
+      - ts-node
+
   jest-cli@29.7.0(@types/node@20.19.34)(ts-node@10.9.2(@swc/core@1.7.28(@swc/helpers@0.5.19))(@types/node@20.19.34)(typescript@5.9.3)):
     dependencies:
       '@jest/core': 29.7.0(ts-node@10.9.2(@swc/core@1.7.28(@swc/helpers@0.5.19))(@types/node@20.19.34)(typescript@5.9.3))
@@ -43654,6 +44084,37 @@ snapshots:
       - babel-plugin-macros
       - supports-color
       - ts-node
+
+  jest-config@29.7.0(@types/node@20.19.34)(ts-node@10.9.2(@swc/core@1.5.7(@swc/helpers@0.5.19))(@types/node@20.19.34)(typescript@5.6.3)):
+    dependencies:
+      '@babel/core': 7.29.0
+      '@jest/test-sequencer': 29.7.0
+      '@jest/types': 29.6.3
+      babel-jest: 29.7.0(@babel/core@7.29.0)
+      chalk: 4.1.2
+      ci-info: 3.9.0
+      deepmerge: 4.3.1
+      glob: 7.2.3
+      graceful-fs: 4.2.11
+      jest-circus: 29.7.0
+      jest-environment-node: 29.7.0
+      jest-get-type: 29.6.3
+      jest-regex-util: 29.6.3
+      jest-resolve: 29.7.0
+      jest-runner: 29.7.0
+      jest-util: 29.7.0
+      jest-validate: 29.7.0
+      micromatch: 4.0.8
+      parse-json: 5.2.0
+      pretty-format: 29.7.0
+      slash: 3.0.0
+      strip-json-comments: 3.1.1
+    optionalDependencies:
+      '@types/node': 20.19.34
+      ts-node: 10.9.2(@swc/core@1.5.7(@swc/helpers@0.5.19))(@types/node@20.19.34)(typescript@5.6.3)
+    transitivePeerDependencies:
+      - babel-plugin-macros
+      - supports-color
 
   jest-config@29.7.0(@types/node@20.19.34)(ts-node@10.9.2(@swc/core@1.7.28(@swc/helpers@0.5.19))(@types/node@20.19.34)(typescript@5.9.3)):
     dependencies:
@@ -43922,6 +44383,18 @@ snapshots:
       jest-util: 29.7.0
       merge-stream: 2.0.0
       supports-color: 8.1.1
+
+  jest@29.7.0(@types/node@20.19.34)(ts-node@10.9.2(@swc/core@1.5.7(@swc/helpers@0.5.19))(@types/node@20.19.34)(typescript@5.6.3)):
+    dependencies:
+      '@jest/core': 29.7.0(ts-node@10.9.2(@swc/core@1.5.7(@swc/helpers@0.5.19))(@types/node@20.19.34)(typescript@5.6.3))
+      '@jest/types': 29.6.3
+      import-local: 3.2.0
+      jest-cli: 29.7.0(@types/node@20.19.34)(ts-node@10.9.2(@swc/core@1.5.7(@swc/helpers@0.5.19))(@types/node@20.19.34)(typescript@5.6.3))
+    transitivePeerDependencies:
+      - '@types/node'
+      - babel-plugin-macros
+      - supports-color
+      - ts-node
 
   jest@29.7.0(@types/node@20.19.34)(ts-node@10.9.2(@swc/core@1.7.28(@swc/helpers@0.5.19))(@types/node@20.19.34)(typescript@5.9.3)):
     dependencies:
@@ -45605,7 +46078,7 @@ snapshots:
       - '@babel/core'
       - babel-plugin-macros
 
-  next@16.2.9(@babel/core@7.29.7)(@opentelemetry/api@1.9.0)(@playwright/test@1.61.1)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(sass@1.97.3):
+  next@16.2.9(@babel/core@8.0.1)(@opentelemetry/api@1.9.0)(@playwright/test@1.61.1)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(sass@1.97.3):
     dependencies:
       '@next/env': 16.2.9
       '@swc/helpers': 0.5.15
@@ -45614,7 +46087,7 @@ snapshots:
       postcss: 8.4.31
       react: 18.3.1
       react-dom: 18.3.1(react@18.3.1)
-      styled-jsx: 5.1.6(@babel/core@7.29.7)(react@18.3.1)
+      styled-jsx: 5.1.6(@babel/core@8.0.1)(react@18.3.1)
     optionalDependencies:
       '@next/swc-darwin-arm64': 16.2.9
       '@next/swc-darwin-x64': 16.2.9
@@ -46254,8 +46727,6 @@ snapshots:
 
   path-to-regexp@6.3.0: {}
 
-  path-to-regexp@8.3.0: {}
-
   path-to-regexp@8.4.2: {}
 
   path-type@4.0.0: {}
@@ -46298,7 +46769,7 @@ snapshots:
 
   pg-god@1.0.12:
     dependencies:
-      '@oclif/command': 1.8.36(@oclif/config@1.18.17)(supports-color@8.1.1)
+      '@oclif/command': 1.8.36(@oclif/config@1.18.17)
       '@oclif/config': 1.18.17
       '@oclif/plugin-help': 3.3.1
       cli-ux: 5.6.7(@oclif/config@1.18.17)
@@ -47955,6 +48426,17 @@ snapshots:
     optionalDependencies:
       '@types/react': 18.3.28
 
+  react-remove-scroll@2.5.4(@types/react@19.0.3)(react@18.3.1):
+    dependencies:
+      react: 18.3.1
+      react-remove-scroll-bar: 2.3.8(@types/react@19.0.3)(react@18.3.1)
+      react-style-singleton: 2.2.3(@types/react@19.0.3)(react@18.3.1)
+      tslib: 2.8.1
+      use-callback-ref: 1.3.3(@types/react@19.0.3)(react@18.3.1)
+      use-sidecar: 1.1.3(@types/react@19.0.3)(react@18.3.1)
+    optionalDependencies:
+      '@types/react': 19.0.3
+
   react-remove-scroll@2.7.2(@types/react@18.3.28)(react@18.3.1):
     dependencies:
       react: 18.3.1
@@ -48764,7 +49246,7 @@ snapshots:
       depd: 2.0.0
       is-promise: 4.0.0
       parseurl: 1.3.3
-      path-to-regexp: 8.3.0
+      path-to-regexp: 8.4.2
     transitivePeerDependencies:
       - supports-color
 
@@ -49814,12 +50296,12 @@ snapshots:
     optionalDependencies:
       '@babel/core': 7.29.0
 
-  styled-jsx@5.1.6(@babel/core@7.29.7)(react@18.3.1):
+  styled-jsx@5.1.6(@babel/core@8.0.1)(react@18.3.1):
     dependencies:
       client-only: 0.0.1
       react: 18.3.1
     optionalDependencies:
-      '@babel/core': 7.29.7
+      '@babel/core': 8.0.1
     optional: true
 
   stylehacks@6.1.1(postcss@8.5.6):
@@ -50259,6 +50741,27 @@ snapshots:
   ts-dedent@2.2.0: {}
 
   ts-interface-checker@0.1.13: {}
+
+  ts-node@10.9.2(@swc/core@1.5.7(@swc/helpers@0.5.19))(@types/node@20.19.34)(typescript@5.6.3):
+    dependencies:
+      '@cspotcode/source-map-support': 0.8.1
+      '@tsconfig/node10': 1.0.12
+      '@tsconfig/node12': 1.0.11
+      '@tsconfig/node14': 1.0.3
+      '@tsconfig/node16': 1.0.4
+      '@types/node': 20.19.34
+      acorn: 8.16.0
+      acorn-walk: 8.3.5
+      arg: 4.1.3
+      create-require: 1.1.1
+      diff: 4.0.4
+      make-error: 1.3.6
+      typescript: 5.6.3
+      v8-compile-cache-lib: 3.0.1
+      yn: 3.1.1
+    optionalDependencies:
+      '@swc/core': 1.5.7(@swc/helpers@0.5.19)
+    optional: true
 
   ts-node@10.9.2(@swc/core@1.7.28(@swc/helpers@0.5.19))(@types/node@20.19.34)(typescript@5.9.3):
     dependencies:
@@ -50707,7 +51210,7 @@ snapshots:
       semver-diff: 4.0.0
       xdg-basedir: 5.1.0
 
-  uploadthing@7.2.0(express@5.2.1)(next@16.2.9(@babel/core@7.29.7)(@opentelemetry/api@1.9.0)(@playwright/test@1.61.1)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(sass@1.97.3))(tailwindcss@3.4.19(tsx@4.21.0)(yaml@2.9.0)):
+  uploadthing@7.2.0(express@5.2.1)(next@16.2.9(@babel/core@8.0.1)(@opentelemetry/api@1.9.0)(@playwright/test@1.61.1)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(sass@1.97.3))(tailwindcss@3.4.19(tsx@4.21.0)(yaml@2.9.0)):
     dependencies:
       '@effect/platform': 0.69.8(effect@3.19.19)
       '@uploadthing/mime-types': 0.3.1
@@ -50715,7 +51218,7 @@ snapshots:
       effect: 3.19.19
     optionalDependencies:
       express: 5.2.1
-      next: 16.2.9(@babel/core@7.29.7)(@opentelemetry/api@1.9.0)(@playwright/test@1.61.1)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(sass@1.97.3)
+      next: 16.2.9(@babel/core@8.0.1)(@opentelemetry/api@1.9.0)(@playwright/test@1.61.1)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(sass@1.97.3)
       tailwindcss: 3.4.19(tsx@4.21.0)(yaml@2.9.0)
 
   upper-case-first@2.0.2:

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -156,8 +156,8 @@ importers:
         specifier: ^5.0.1
         version: 5.2.2(react-hook-form@7.71.2(react@18.3.1))
       '@jytextiles/medusa-plugin-dtdc-shipping':
-        specifier: workspace:*
-        version: link:../../packages/medusa-plugin-dtdc-shipping
+        specifier: latest
+        version: 0.1.1(@medusajs/framework@2.19.0(@medusajs/cli@2.19.0(@types/node@20.19.34))(@types/node@20.19.34)(ioredis@5.9.3)(vite@7.3.6(@types/node@20.19.34)(jiti@1.21.7)(sass-embedded@1.97.3)(sass@1.97.3)(terser@5.46.0)(tsx@4.21.0)(yaml@2.9.0))(zod@4.2.0))(@medusajs/medusa@2.19.0)(@medusajs/types@2.19.0(ioredis@5.9.3)(vite@7.3.6(@types/node@20.19.34)(jiti@1.21.7)(sass-embedded@1.97.3)(sass@1.97.3)(terser@5.46.0)(tsx@4.21.0)(yaml@2.9.0)))
       '@jytextiles/medusa-plugin-etsy-sync':
         specifier: latest
         version: 0.1.6(d7461c732c552c3be1976fbfbbf1e7a7)
@@ -5244,6 +5244,13 @@ packages:
     engines: {node: '>=10.0'}
     peerDependencies:
       tslib: '2'
+
+  '@jytextiles/medusa-plugin-dtdc-shipping@0.1.1':
+    resolution: {integrity: sha512-dMJsY6dJhfZyYz1ERJkzL7mJSdNK0KctSquN6cdb2t6zfmOrQCU80jpjOzFZHugjwu5IGvcaEVVlHup2AvNAxA==}
+    peerDependencies:
+      '@medusajs/framework': 2.19.0
+      '@medusajs/medusa': 2.19.0
+      '@medusajs/types': 2.19.0
 
   '@jytextiles/medusa-plugin-etsy-sync@0.1.6':
     resolution: {integrity: sha512-lh1YdMjUMmYByArhqy4PvrAIFgctw1Xg5zNBwbA03OPQ/kpr0ftj4aEfnUlZSF4k9v3ZHAbKL4QZnVT9ujoIvA==}
@@ -13562,6 +13569,10 @@ packages:
     resolution: {integrity: sha512-kJezFj9YFAMLeORyi7aCLxLbD5/qWMQnoMVlVPyHIll7lgRJCc3JVln9Vgl9nwQi0YkMnhdGTMNn7CkRRAptMg==}
     engines: {node: '>=18.0.0'}
 
+  eventsource-parser@3.1.1:
+    resolution: {integrity: sha512-EKN1vKAMcZ8MlYMpaNuxN6R9yakzH6uajHcHVTqWJzvu5pWw9DyhbP35HH8MVBQ+dZjAfDxk+A8NiR9KWaXiyQ==}
+    engines: {node: '>=18.0.0'}
+
   eventsource@3.0.7:
     resolution: {integrity: sha512-CRT1WTyuQoD771GW56XEZFQ/ZoSfWid1alKGDYMmkt2yl8UXrVR4pspqWNEcqKvVIzg6PAltWjxcSSPrboA4iA==}
     engines: {node: '>=18.0.0'}
@@ -21527,7 +21538,7 @@ snapshots:
     dependencies:
       '@ai-sdk/provider': 2.0.3
       '@standard-schema/spec': 1.1.0
-      eventsource-parser: 3.1.0
+      eventsource-parser: 3.1.1
       zod: 4.2.0
 
   '@ai-sdk/provider-utils@4.0.15(zod@4.2.0)':
@@ -21541,7 +21552,7 @@ snapshots:
     dependencies:
       '@ai-sdk/provider': 3.0.14
       '@standard-schema/spec': 1.1.0
-      eventsource-parser: 3.1.0
+      eventsource-parser: 3.1.1
       zod: 4.2.0
 
   '@ai-sdk/provider-utils@5.0.11(zod@4.2.0)':
@@ -21549,7 +21560,7 @@ snapshots:
       '@ai-sdk/provider': 4.0.3
       '@standard-schema/spec': 1.1.0
       '@workflow/serde': 4.1.0
-      eventsource-parser: 3.1.0
+      eventsource-parser: 3.1.1
       zod: 4.2.0
 
   '@ai-sdk/provider@1.1.3':
@@ -27131,6 +27142,12 @@ snapshots:
       '@jsonjoy.com/codegen': 17.67.0(tslib@2.8.1)
       tslib: 2.8.1
 
+  '@jytextiles/medusa-plugin-dtdc-shipping@0.1.1(@medusajs/framework@2.19.0(@medusajs/cli@2.19.0(@types/node@20.19.34))(@types/node@20.19.34)(ioredis@5.9.3)(vite@7.3.6(@types/node@20.19.34)(jiti@1.21.7)(sass-embedded@1.97.3)(sass@1.97.3)(terser@5.46.0)(tsx@4.21.0)(yaml@2.9.0))(zod@4.2.0))(@medusajs/medusa@2.19.0)(@medusajs/types@2.19.0(ioredis@5.9.3)(vite@7.3.6(@types/node@20.19.34)(jiti@1.21.7)(sass-embedded@1.97.3)(sass@1.97.3)(terser@5.46.0)(tsx@4.21.0)(yaml@2.9.0)))':
+    dependencies:
+      '@medusajs/framework': 2.19.0(@medusajs/cli@2.19.0(@types/node@20.19.34))(@types/node@20.19.34)(ioredis@5.9.3)(vite@7.3.6(@types/node@20.19.34)(jiti@1.21.7)(sass-embedded@1.97.3)(sass@1.97.3)(terser@5.46.0)(tsx@4.21.0)(yaml@2.9.0))(zod@4.2.0)
+      '@medusajs/medusa': 2.19.0(91a2f19d1744c07c9c0a55b6ae822462)
+      '@medusajs/types': 2.19.0(ioredis@5.9.3)(vite@7.3.6(@types/node@20.19.34)(jiti@1.21.7)(sass-embedded@1.97.3)(sass@1.97.3)(terser@5.46.0)(tsx@4.21.0)(yaml@2.9.0))
+
   '@jytextiles/medusa-plugin-etsy-sync@0.1.6(d7461c732c552c3be1976fbfbbf1e7a7)':
     dependencies:
       '@medusajs/admin-sdk': 2.19.0
@@ -31407,7 +31424,7 @@ snapshots:
 
   '@radix-ui/react-collection@1.0.1(react-dom@18.3.1(react@18.3.1))(react@18.3.1)':
     dependencies:
-      '@babel/runtime': 7.29.7
+      '@babel/runtime': 7.28.6
       '@radix-ui/react-compose-refs': 1.0.0(react@18.3.1)
       '@radix-ui/react-context': 1.0.0(react@18.3.1)
       '@radix-ui/react-primitive': 1.0.1(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
@@ -31787,7 +31804,7 @@ snapshots:
 
   '@radix-ui/react-direction@1.0.0(react@18.3.1)':
     dependencies:
-      '@babel/runtime': 7.29.7
+      '@babel/runtime': 7.28.6
       react: 18.3.1
 
   '@radix-ui/react-direction@1.1.0(@types/react@18.3.28)(react@18.3.1)':
@@ -32853,7 +32870,7 @@ snapshots:
 
   '@radix-ui/react-primitive@1.0.1(react-dom@18.3.1(react@18.3.1))(react@18.3.1)':
     dependencies:
-      '@babel/runtime': 7.29.7
+      '@babel/runtime': 7.28.6
       '@radix-ui/react-slot': 1.0.1(react@18.3.1)
       react: 18.3.1
       react-dom: 18.3.1(react@18.3.1)
@@ -33017,7 +33034,7 @@ snapshots:
 
   '@radix-ui/react-roving-focus@1.0.2(react-dom@18.3.1(react@18.3.1))(react@18.3.1)':
     dependencies:
-      '@babel/runtime': 7.29.7
+      '@babel/runtime': 7.28.6
       '@radix-ui/primitive': 1.0.0
       '@radix-ui/react-collection': 1.0.1(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
       '@radix-ui/react-compose-refs': 1.0.0(react@18.3.1)
@@ -33402,7 +33419,7 @@ snapshots:
 
   '@radix-ui/react-slot@1.0.1(react@18.3.1)':
     dependencies:
-      '@babel/runtime': 7.29.7
+      '@babel/runtime': 7.28.6
       '@radix-ui/react-compose-refs': 1.0.0(react@18.3.1)
       react: 18.3.1
 
@@ -42037,6 +42054,8 @@ snapshots:
   eventsource-parser@3.0.6: {}
 
   eventsource-parser@3.1.0: {}
+
+  eventsource-parser@3.1.1: {}
 
   eventsource@3.0.7:
     dependencies:


### PR DESCRIPTION
## Summary

Adds a standalone DTDC shipping provider as a Medusa plugin package, wiring it into the existing carrier resolver and carrier-capabilities table.

## What's included

- **New package** `packages/medusa-plugin-dtdc-shipping` with:
  - `src/lib/dtdc-client.ts` — raw HTTP client for pincode serviceability, consignment booking (`softdata`), label generation, cancellation, and tracking (pull) across DTDC's staging/prod hosts.
  - `src/providers/dtdc/service.ts` — `AbstractFulfillmentProviderService` (create/cancel/return fulfillment).
  - `src/providers/dtdc/adapter.ts` — normalized `ShippingProviderClient` adapter for the resolver-driven routes.
  - `src/providers/dtdc/index.ts` — `ModuleProvider(Modules.FULFILLMENT, …)`.
  - 19 unit tests for the client (booking payload, tracking-token minting, scan-type mapping, pincode serviceability, error surfacing).
- **Integration**
  - `carrier-capabilities.ts` — DTDC marked `integrated` (domestic ship-only; no rate API).
  - `resolver.ts` — `resolveShippingProvider(…, "dtdc")` + `SUPPORTED_CARRIERS`.
  - `provider-interface.ts` — `CarrierId` includes `"dtdc"`.
  - `medusa-config.ts` / `medusa-config.prod.ts` — DTDC fulfillment provider (gated on `DTDC_API_KEY`).
  - `.env.template` — documented DTDC env vars.
- **E2E spec** `apps/backend/integration-tests/http/dtdc-shipping-e2e.spec.ts` — 9 tests against DTDC's real test environment (`GL018`): pincode, booking (real AWB), tracking, label, cancellation.

## Notes / decisions

- **No rate API.** The DTDC docs provide no freight/rate endpoint — pincode returns serviceability + TAT only. `can_rate` stays `false` (same situation as Blue Dart); DTDC is usable as a flat/manually-priced option. DTDC's rate calculator (`getBusinessTAT` on the OBB v2 portal) is a separate subscription requiring a customer-portal login session that `GL018` isn't provisioned for, so it is deliberately out of scope here.
- **Service types** `GROUND EXPRESS` / `PRIORITY` (per DTDC's docs; `B2C …` variants are rejected by the booking API).
- The E2E spec hits a live external test API and bakes in the `GL018` test credentials as env fallbacks (test/demo only, not production).
- `.medusa` build output is gitignored (consistent with the existing etsy/faire plugins); turbo's `build` task regenerates it.

## Testing

- `pnpm --filter @jytextiles/medusa-plugin-dtdc-shipping test` — 19 passing
- `TEST_TYPE=integration:http NODE_OPTIONS="--experimental-vm-modules" npx jest --testPathPattern="dtdc-shipping-e2e" --runInBand` — 9 passing (live)
- `pnpm --filter @jyt/backend check:prod-config` — passes