### PR TITLE
fix(partner-ui): give the block-name field an accessible name, and correct #1576's diagnosis (#1576)

### DIFF
--- a/apps/partner-ui/src/components/block-editor/block-editor.tsx
+++ b/apps/partner-ui/src/components/block-editor/block-editor.tsx
@@ -1,5 +1,5 @@
 import { useCallback, useState } from "react"
-import { Text, Button, IconButton, Tooltip, Select, Badge, Label } from "@medusajs/ui"
+import { Text, Button, IconButton, Tooltip, Select, Badge } from "@medusajs/ui"
 import { Trash, Plus, Images, ChevronDown, ChevronRight, CursorArrowRays, ArrowUpMini, ArrowDownMini, ArrowsPointingOut } from "@medusajs/icons"
 import { ContentBlock } from "../../hooks/api/content"
 import { TipTapEditor, type TipTapActions } from "../tiptap-editor/tiptap-editor"

--- a/apps/partner-ui/src/components/block-editor/block-editor.tsx
+++ b/apps/partner-ui/src/components/block-editor/block-editor.tsx
@@ -28,15 +28,28 @@ const TextInput = ({
   value,
   onChange,
   placeholder,
+  ariaLabel,
 }: {
   value: string
   onChange: (v: string) => void
   placeholder?: string
+  /**
+   * 🔴 Without this the field has NO accessible name at all. `FieldLabel`
+   * renders a <Text> (a styled <span>), not a <label htmlFor>, and this input
+   * carries no id, name or placeholder — so nothing associates the two. A
+   * screen reader announces "edit text, blank", and a test cannot address it
+   * either: the #1576 spec fell back to `locator('input').first()`, which
+   * resolves to a hidden file input somewhere else on the page and asserts
+   * nothing. The unaddressable field and the meaningless selector are the
+   * same defect seen from two sides.
+   */
+  ariaLabel?: string
 }) => (
   <input
     className="w-full rounded-md border border-ui-border-base bg-ui-bg-field px-3 py-1.5 text-sm"
     value={value}
     placeholder={placeholder}
+    aria-label={ariaLabel}
     onChange={(e) => onChange(e.target.value)}
   />
 )
@@ -515,6 +528,7 @@ export const BlockEditor = ({
           <FieldLabel>Block Name</FieldLabel>
           <TextInput
             value={block.name}
+            ariaLabel="Block Name"
             onChange={(v) => onUpdate(block.id, { name: v })}
           />
         </div>

--- a/e2e/specs/partner-shipment-carrier-modal.spec.ts
+++ b/e2e/specs/partner-shipment-carrier-modal.spec.ts
@@ -58,6 +58,27 @@ test.describe("Partner shipment carrier modal @partnerui", () => {
    * executed here, so the case has to be opened in a browser before anyone can
    * say whether the selector is stale or the screen is broken. `fixme` rather
    * than a silent skip: the report names it every run.
+   *
+   * 🔴 #1576 UPDATE — the original diagnosis ("tab stays inactive, selector
+   * may be stale") was wrong on both counts, and the truth is worse: this case
+   * CANNOT PASS ANYWHERE, credentials or not.
+   *
+   * `POST /partners/orders/:id/shiprocket-attach-awb` calls
+   * `provider.track({ awb })` against the LIVE Shiprocket API, and throws twice
+   * over — once if the lookup fails, again if Shiprocket returns no shipment
+   * for the waybill. This spec attaches `E2E${Date.now()}`, a synthetic AWB
+   * that by construction exists on nobody's Shiprocket account. So the attach
+   * always throws, `onCarrierResolved` is never called, and step 2 never
+   * activates. The tab is found; it is simply never made active.
+   *
+   * ⚠️ The selector is FINE. `ProgressTabs.Trigger` renders a status icon that
+   * carries no aria-label or <title>, so the accessible name really is
+   * "Shipment" and `/^shipment$/i` matches — checked in @medusajs/ui, not
+   * assumed. Do not "fix" this by loosening the regex.
+   *
+   * To un-park it, one of: stub the shipping provider for e2e, or seed a
+   * known-good AWB on the test Shiprocket account. A tag-and-exclude (the
+   * `@llm` treatment) would only hide it.
    */
   test.fixme("attaching an AWB in step 1 does not mark the fulfillment shipped", async ({
     page,
@@ -106,6 +127,27 @@ test.describe("Partner shipment carrier modal @partnerui", () => {
    * executed here, so the case has to be opened in a browser before anyone can
    * say whether the selector is stale or the screen is broken. `fixme` rather
    * than a silent skip: the report names it every run.
+   *
+   * 🔴 #1576 UPDATE — the original diagnosis ("tab stays inactive, selector
+   * may be stale") was wrong on both counts, and the truth is worse: this case
+   * CANNOT PASS ANYWHERE, credentials or not.
+   *
+   * `POST /partners/orders/:id/shiprocket-attach-awb` calls
+   * `provider.track({ awb })` against the LIVE Shiprocket API, and throws twice
+   * over — once if the lookup fails, again if Shiprocket returns no shipment
+   * for the waybill. This spec attaches `E2E${Date.now()}`, a synthetic AWB
+   * that by construction exists on nobody's Shiprocket account. So the attach
+   * always throws, `onCarrierResolved` is never called, and step 2 never
+   * activates. The tab is found; it is simply never made active.
+   *
+   * ⚠️ The selector is FINE. `ProgressTabs.Trigger` renders a status icon that
+   * carries no aria-label or <title>, so the accessible name really is
+   * "Shipment" and `/^shipment$/i` matches — checked in @medusajs/ui, not
+   * assumed. Do not "fix" this by loosening the regex.
+   *
+   * To un-park it, one of: stub the shipping provider for e2e, or seed a
+   * known-good AWB on the test Shiprocket account. A tag-and-exclude (the
+   * `@llm` treatment) would only hide it.
    */
   test.fixme("completing step 2 marks the fulfillment shipped", async ({ page }) => {
     await page.goto(SHIPMENT_URL)

--- a/e2e/specs/partner-shipment-gate.spec.ts
+++ b/e2e/specs/partner-shipment-gate.spec.ts
@@ -66,6 +66,16 @@ test.describe("#1195 requires_shipping gate — partner UI @partnerui", () => {
    * executed here, so the case has to be opened in a browser before anyone can
    * say whether the selector is stale or the screen is broken. `fixme` rather
    * than a silent skip: the report names it every run.
+   *
+   * ⚠️ #1576 UPDATE — one thing RULED OUT, so nobody re-checks it: the issue
+   * guessed "the status copy may have moved". It has not.
+   * `order-fulfillment-section.tsx` still renders the literal "Awaiting
+   * shipping"; the only sibling is "Awaiting pickup", chosen when the
+   * fulfillment set type is Pickup. So either the seeded fulfillment resolves
+   * as a pickup, or the section never rendered at all — and those two look
+   * identical from a `getByText` timeout.
+   *
+   * This is the one case in #1576 that still needs the screen open.
    */
   test.fixme("offers the shipment action on a requires_shipping=false fulfillment", async ({
     page,

--- a/e2e/specs/visual-block-editor.spec.ts
+++ b/e2e/specs/visual-block-editor.spec.ts
@@ -103,13 +103,14 @@ test.describe("@partnerui Visual Block Editor (#1466)", () => {
   })
 
   /**
-   * ⚠️ Parked in #1576. Failed on the FIRST-EVER CI run of the @partnerui
-   * specs — this file was written against a partner UI that had never actually
-   * executed here, so the case has to be opened in a browser before anyone can
-   * say whether the selector is stale or the screen is broken. `fixme` rather
-   * than a silent skip: the report names it every run.
+   * #1576 — un-parked. Both failures were the SPEC, established by reading the
+   * component rather than the screen:
+   *   - the block-name assertion addressed "the first <input> on the page"
+   *     (a hidden file input); the field had no accessible name at all, which
+   *     is a real a11y defect and is fixed alongside this
+   *   - `SpacingControl` renders its label as "Padding", never "Padding (px)"
    */
-  test.fixme("selecting a block shows contextual inspector with type badge", async ({
+  test("selecting a block shows contextual inspector with type badge", async ({
     page,
   }) => {
     await page.goto(`${PARTNER_UI}/login`, { waitUntil: "networkidle" })
@@ -145,10 +146,15 @@ test.describe("@partnerui Visual Block Editor (#1466)", () => {
       page.getByText(/click text on the canvas/i).first()
     ).toBeVisible()
 
-    // Should show block name field
-    await expect(
-      page.locator('input').filter({ hasText: "" }).first()
-    ).toBeVisible()
+    // Should show block name field.
+    //
+    // 🔴 NOT `locator('input').filter({ hasText: "" }).first()`, which is what
+    // this asserted until #1576. `hasText: ""` matches everything and an
+    // <input> has no text content anyway, so it resolved to the FIRST input on
+    // the page — a hidden file input — and passed or failed for reasons
+    // unrelated to the inspector. The field had no accessible name to address
+    // it by; it has one now.
+    await expect(page.getByLabel("Block Name")).toBeVisible()
 
     // Advanced Settings should be collapsed by default
     await expect(
@@ -162,13 +168,14 @@ test.describe("@partnerui Visual Block Editor (#1466)", () => {
   })
 
   /**
-   * ⚠️ Parked in #1576. Failed on the FIRST-EVER CI run of the @partnerui
-   * specs — this file was written against a partner UI that had never actually
-   * executed here, so the case has to be opened in a browser before anyone can
-   * say whether the selector is stale or the screen is broken. `fixme` rather
-   * than a silent skip: the report names it every run.
+   * #1576 — un-parked. Both failures were the SPEC, established by reading the
+   * component rather than the screen:
+   *   - the block-name assertion addressed "the first <input> on the page"
+   *     (a hidden file input); the field had no accessible name at all, which
+   *     is a real a11y defect and is fixed alongside this
+   *   - `SpacingControl` renders its label as "Padding", never "Padding (px)"
    */
-  test.fixme("advanced settings expand to show background, padding, max width", async ({
+  test("advanced settings expand to show background, padding, max width", async ({
     page,
   }) => {
     await page.goto(`${PARTNER_UI}/login`, { waitUntil: "networkidle" })
@@ -201,7 +208,7 @@ test.describe("@partnerui Visual Block Editor (#1466)", () => {
       page.getByText("Background Color").first()
     ).toBeVisible({ timeout: 5_000 })
     await expect(
-      page.getByText("Padding (px)").first()
+      page.getByText("Padding").first()
     ).toBeVisible()
     await expect(
       page.getByText("Max Width").first()


### PR DESCRIPTION
Four of #1576's five parked cases turned out to be answerable by **reading the components** rather than opening a browser — and two of the issue's own diagnoses were wrong.

## ✅ Un-parked: both `visual-block-editor` cases

**`Padding (px)` never existed.** `SpacingControl` renders `label="Padding"`. Stale copy.

**The block-name assertion addressed the wrong element and asserted nothing:**

```ts
page.locator('input').filter({ hasText: "" }).first()
```

`hasText: ""` matches everything, and an `<input>` has no text content anyway — so it resolved to the **first input on the page**, a hidden file input elsewhere in the tree.

🔴 **But that selector was a symptom.** The field has *no accessible name at all*: `FieldLabel` renders a `<Text>` (a styled span), not a `<label htmlFor>`, and `TextInput` carries no id, name, or placeholder. Nothing associates them. A screen reader announces *"edit text, blank"*, and a test has nothing to address — the desperate `locator('input').first()` was the consequence, not the cause.

`aria-label` fixes both sides at once; the spec now uses `getByLabel("Block Name")`.

## ⛔ Still parked — but the reason was wrong, and it's worse

The issue read the carrier-modal failures as *"tab stays inactive, selector may be stale"*. Both halves are wrong, and the truth is that **those two cases cannot pass anywhere, credentials or not.**

`POST /partners/orders/:id/shiprocket-attach-awb` calls `provider.track({ awb })` against the **live Shiprocket API** and throws twice over — once if the lookup fails, again if Shiprocket returns no shipment. The spec attaches `E2E${Date.now()}`, a synthetic waybill that by construction exists on nobody's account. The attach always throws, `onCarrierResolved` is never called, step 2 never activates. The tab *is* found; it is simply never made active.

⚠️ **And the selector is fine.** I assumed `ProgressTabs.Trigger`'s status icon would poison the accessible name — the same shape as the count badge in #1571 — and it does not: the Medusa icon carries no `aria-*` or `<title>`, so the name really is `"Shipment"`. Checked in `@medusajs/ui`, not assumed. **Do not "fix" these by loosening the regex.**

Un-parking them needs a stubbed shipping provider or a known-good seeded AWB. Tagging-and-excluding (the `@llm` treatment) would only hide them.

## 🔍 One ruled out, so nobody re-checks it

`partner-shipment-gate` — the issue guessed *"the status copy may have moved"*. It has not: `order-fulfillment-section.tsx` still renders the literal `"Awaiting shipping"`. The only sibling is `"Awaiting pickup"`, chosen on fulfillment-set **type**. So either the seeded fulfillment resolves as a pickup, or the section never rendered — and those two are indistinguishable from a `getByText` timeout.

**This is the one case in #1576 that still needs the screen open.**

## Verify

Two pre-existing failures, both confirmed by stashing this branch and re-running on a clean tree:
- `tsc`: `'Label' is declared but its value is never read` — sitting four lines above the field that had no label
- `vitest`: 1 failed / 63 passed, an unrelated i18n schema check

The real proof is main's next e2e run: the two un-parked cases either pass or tell us the component reading was wrong.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_0158wJMZ1DmjNxXf5uGuBrQD