### PR TITLE
test(orders): the cancel spec asserted the #1574 bug as the specification (#1574)

### DIFF
--- a/apps/backend/integration-tests/http/orders-unification-design-dual-write.spec.ts
+++ b/apps/backend/integration-tests/http/orders-unification-design-dual-write.spec.ts
@@ -387,7 +387,7 @@ setupSharedTestSuite(() => {
       expect(childOrder.unified_order_status?.partner_status).not.toBe("declined")
     })
 
-    it("mirrors an admin cancel as canceled without touching partner_status", async () => {
+    it("mirrors an admin cancel as canceled AND says so on the sidecar (#1574)", async () => {
       await createRegion()
       const designId = await createDesign()
 
@@ -410,8 +410,22 @@ setupSharedTestSuite(() => {
 
       const unified = await fetchUnifiedOrder(unifiedOrderId)
       expect(unified.status).toBe("canceled")
-      // §5 defines no partner_status for an admin cancel
-      expect(unified.unified_order_status?.partner_status ?? null).toBeNull()
+
+      // 🔴 This asserted `toBeNull()` until #1577, under the comment "§5
+      // defines no partner_status for an admin cancel" — which is the exact
+      // misreading that WAS the bug, written down as the specification.
+      //
+      // The mirror writes only truthy values, so an `undefined` derivation
+      // meant "don't write" where it needed to mean "say it stopped". The
+      // sidecar kept whatever it last said — `assigned`, `accepted`,
+      // `in_progress`, `finished` — and the order went on rendering as live
+      // production forever. A partner then saw a Finish button on work that
+      // had been called off.
+      //
+      // `cancelled` is distinct from `declined` on purpose: declined is the
+      // PARTNER refusing. Showing "Declined" for an admin cancel accuses them
+      // of something they did not do.
+      expect(unified.unified_order_status?.partner_status).toBe("cancelled")
     })
 
     it("resolves the unified order via the link, not the metadata backref (D5-3)", async () => {


### PR DESCRIPTION
🔴 **`main` has been red since `4083b99af` (#1577, merged 04:12 today).** Four commits shipped on top of it, mine included.

```
FAIL integration-tests/http/orders-unification-design-dual-write.spec.ts
  ● mirrors an admin cancel as canceled without touching partner_status
Test Suites: 1 failed, 9 passed    Tests: 1 failed, 72 passed
```

One test, one shard. Green on `02155b5cf` immediately before #1577.

## The assertion was the bug, written down as the contract

```js
// §5 defines no partner_status for an admin cancel
expect(unified.unified_order_status?.partner_status ?? null).toBeNull()
```

That comment is **verbatim the misreading #1577's own commit message named as the defect**:

> `deriveRunPartnerStatus` returned `undefined` when an admin cancelled a run — on the reading that §5 defined no value for it

The mirror writes only truthy values, so `undefined` meant *"don't write"* where it needed to mean *"say it stopped"*. The sidecar kept `assigned` / `accepted` / `in_progress` / `finished`, the order rendered as live production forever, and a partner saw a Finish button on work that had been called off.

**So the test did not fail because #1577 broke something — it failed because #1577 fixed the thing this test was pinning in place.** Reversed, with the reasoning recorded inline so it cannot quietly regress.

⚠️ The sibling `toBeNull()` four lines up at line 189 is **correct and stays**: a `pending_review` run has no partner assigned yet and derives no partner_status. Only the cancel path changed. Checked rather than assumed.

## Why nobody saw it

**PRs run one shard of eight**, so #1577's green check never loaded this spec. `Test and Release` on main runs all eight — and **prod deploy is not gated on it**, so four commits deployed cleanly over a red suite. Everything that shipped is correct; only the test was stale.

I closed #1574 earlier today declaring it complete, with main red from that very change. That was mine to catch and I didn't.

## Verify

```
pnpm test:integration:http:shared ./integration-tests/http/orders-unification-design-dual-write.spec.ts
```
6/6, including the reversed case. It was the only failure in shard 7 and the only failing shard.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_0158wJMZ1DmjNxXf5uGuBrQD