### PR TITLE
test(e2e): the Shiprocket stub had every endpoint but the one the attach route calls (#1576)

### DIFF
--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -172,8 +172,16 @@ jobs:
       - name: Run e2e
         working-directory: apps/backend
         # PARTNER_UI opts the @partnerui specs back in — see playwright.config.ts.
+        #
+        # SHIPROCKET_STUB injects the deterministic transport into the backend
+        # this step boots (#1576). Without it the carrier-modal specs call the
+        # LIVE Shiprocket API: `shiprocket-attach-awb` validates the waybill via
+        # `provider.track()` and throws, so those cases could not pass here
+        # whatever the selectors said. Scoped to this step rather than the job,
+        # so nothing else silently acquires a fake carrier.
         env:
           PARTNER_UI: "1"
+          SHIPROCKET_STUB: "1"
         run: pnpm run e2e
 
       - name: Upload Playwright report

--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -182,6 +182,15 @@ jobs:
         env:
           PARTNER_UI: "1"
           SHIPROCKET_STUB: "1"
+          # 🔴 The stub flag ALONE is not enough. `resolveShippingProvider`
+          # reads credentials and THROWS "Shiprocket credentials not
+          # configured" before it ever looks at SHIPROCKET_STUB — so the attach
+          # 500s and the stub never gets a chance. These are placeholders; the
+          # stub's /auth/login returns a token without validating them. Same
+          # pairing the integration specs use (retail-order-international-
+          # shiprocket.spec.ts sets all three).
+          SHIPROCKET_EMAIL: "e2e@shiprocket.example"
+          SHIPROCKET_PASSWORD: "e2e-stub-secret"
         run: pnpm run e2e
 
       - name: Upload Playwright report

--- a/apps/backend/src/modules/shipping-providers/shiprocket/__tests__/stub-track.unit.spec.ts
+++ b/apps/backend/src/modules/shipping-providers/shiprocket/__tests__/stub-track.unit.spec.ts
@@ -1,0 +1,68 @@
+import { ShiprocketClient } from "../client"
+import { createShiprocketStubFetch } from "../stub-fetch"
+
+/**
+ * #1576 — the Shiprocket stub can answer a tracking lookup.
+ *
+ * Two `partner-shipment-carrier-modal` e2e cases were parked as "stale
+ * selectors". They were not: `POST /partners/orders/:id/shiprocket-attach-awb`
+ * calls `provider.track({ awb })` against the LIVE API and throws twice over —
+ * once if the lookup fails, again if Shiprocket returns no shipment. The spec
+ * attaches a synthetic `E2E<timestamp>` waybill, so those cases could not pass
+ * ANYWHERE, credentials or not.
+ *
+ * The deterministic transport (`SHIPROCKET_STUB=1`) already existed but had no
+ * `/courier/track/awb/:awb` handler, so it 404'd the lookup and the client
+ * threw exactly as the live API would.
+ *
+ * 🔑 This proves the BACKEND half locally, so the only thing left to CI is the
+ * browser flow. Asserting the e2e green without this would be betting on two
+ * unverified halves at once.
+ *
+ * ⚠️ It lives beside the code it tests, under a `__tests__` directory with a
+ * `.unit.spec.ts` suffix, deliberately. Written first into
+ * `integration-tests/http/`, it matched NEITHER jest config and jest reported
+ * "No tests found" — a file that exists, looks like coverage, and never runs.
+ *
+ * (And do not write that testMatch glob out in a block comment: the `*` `*` `/`
+ * in it terminates the comment early and the prose below becomes code.)
+ */
+describe("Shiprocket stub — tracking lookup (#1576)", () => {
+  const client = () =>
+    new ShiprocketClient({
+      email: "test@shiprocket.example",
+      password: "secret",
+      // 🔴 The export is a FACTORY. Importing a non-existent name gave
+      // `undefined`, the client silently fell back to `globalThis.fetch`, and
+      // the failure was a REAL 403 from Shiprocket — a test that looked like it
+      // was exercising the stub while talking to the live API.
+      fetchImpl: createShiprocketStubFetch(),
+    } as any)
+
+  it("answers a track for an arbitrary AWB, so a synthetic waybill resolves", async () => {
+    const awb = `E2E${Date.now()}`
+    const tracking = await client().track({ awb })
+
+    // 🔑 It echoes the AWB it was ASKED about. A constant would let a route
+    // that ignores its input pass this test.
+    expect(tracking.awb).toBe(awb)
+    expect(tracking.current_status).toBeTruthy()
+    expect(tracking.events.length).toBeGreaterThan(0)
+  })
+
+  it("satisfies the guard the attach route applies", async () => {
+    // `attachExistingShiprocketAwb` rejects a lookup that returns no shipment:
+    //   hasShipment = tracking.awb || tracking.current_status || events.length
+    // Assert that predicate directly — it is the thing that was throwing.
+    const tracking = await client().track({ awb: "E2E-GUARD" })
+    const hasShipment =
+      !!tracking &&
+      (!!tracking.awb ||
+        !!tracking.current_status ||
+        (tracking.events || []).length > 0)
+    expect(hasShipment).toBe(true)
+
+    // And the shape the route reads its provider refs from.
+    expect((tracking.raw as any)?.shipment_track?.[0]?.awb).toBe("E2E-GUARD")
+  })
+})

--- a/apps/backend/src/modules/shipping-providers/shiprocket/stub-fetch.ts
+++ b/apps/backend/src/modules/shipping-providers/shiprocket/stub-fetch.ts
@@ -240,6 +240,55 @@ export function createShiprocketStubFetch(): FetchLike {
       })
     }
 
+    /**
+     * Tracking lookup — `GET /courier/track/awb/:awb` (#1576).
+     *
+     * Without this the stub 404s the lookup, the client throws, and
+     * `attachExistingShiprocketAwb` throws in turn — which is why the two
+     * `partner-shipment-carrier-modal` cases could not pass ANYWHERE. That
+     * route calls `provider.track({ awb })` to validate the waybill belongs to
+     * this account, and an e2e attaches a synthetic `E2E<timestamp>` AWB that
+     * by construction exists on no real Shiprocket account.
+     *
+     * 🔑 It echoes back the AWB it was ASKED about rather than a fixed one, so
+     * a spec that attaches `E2E123` and then asserts `E2E123` is actually
+     * testing the round-trip. A constant would let a route that ignores its
+     * input still pass.
+     *
+     * ⚠️ This makes the shape valid, not the waybill real. It deliberately
+     * does NOT model a rejection, so nothing here covers "Shiprocket refused a
+     * foreign AWB" — that path still has no test.
+     */
+    const trackMatch = url.match(/\/courier\/track\/awb\/([^/?]+)/)
+    if (trackMatch) {
+      const awb = decodeURIComponent(trackMatch[1])
+      return json({
+        tracking_data: {
+          track_status: 1,
+          shipment_status: 6,
+          shipment_track: [
+            {
+              awb,
+              current_status: "IN TRANSIT",
+              shipment_status_id: 6,
+              origin: "Delhi",
+              destination: "Mumbai",
+              etd: null,
+            },
+          ],
+          shipment_track_activities: [
+            {
+              date: "2026-08-27 09:00:00",
+              status: "IN TRANSIT",
+              location: "Delhi Hub",
+              "sr-status": 6,
+              "sr-status-label": "IN TRANSIT",
+            },
+          ],
+        },
+      })
+    }
+
     return json({}, 404)
   }
 }

--- a/e2e/specs/partner-shipment-carrier-modal.spec.ts
+++ b/e2e/specs/partner-shipment-carrier-modal.spec.ts
@@ -59,9 +59,8 @@ test.describe("Partner shipment carrier modal @partnerui", () => {
    * say whether the selector is stale or the screen is broken. `fixme` rather
    * than a silent skip: the report names it every run.
    *
-   * 🔴 #1576 UPDATE — the original diagnosis ("tab stays inactive, selector
-   * may be stale") was wrong on both counts, and the truth is worse: this case
-   * CANNOT PASS ANYWHERE, credentials or not.
+   * 🔴 #1576 — un-parked. The original diagnosis ("tab stays inactive,
+   * selector may be stale") was wrong on both counts. The real cause:
    *
    * `POST /partners/orders/:id/shiprocket-attach-awb` calls
    * `provider.track({ awb })` against the LIVE Shiprocket API, and throws twice
@@ -76,11 +75,16 @@ test.describe("Partner shipment carrier modal @partnerui", () => {
    * "Shipment" and `/^shipment$/i` matches — checked in @medusajs/ui, not
    * assumed. Do not "fix" this by loosening the regex.
    *
-   * To un-park it, one of: stub the shipping provider for e2e, or seed a
-   * known-good AWB on the test Shiprocket account. A tag-and-exclude (the
-   * `@llm` treatment) would only hide it.
+   * Fixed by giving the existing `SHIPROCKET_STUB=1` transport a
+   * `/courier/track/awb/:awb` handler — it had every other endpoint but that
+   * one, so it 404'd the lookup and the client threw exactly as the live API
+   * would. The e2e job now sets it. The stub echoes back the AWB it was asked
+   * about, so this really does test the round-trip.
+   *
+   * ⚠️ What this no longer covers: a waybill Shiprocket REJECTS. The stub
+   * models success only, so "foreign AWB refused" has no test.
    */
-  test.fixme("attaching an AWB in step 1 does not mark the fulfillment shipped", async ({
+  test("attaching an AWB in step 1 does not mark the fulfillment shipped", async ({
     page,
   }) => {
     await page.goto(SHIPMENT_URL)
@@ -128,9 +132,8 @@ test.describe("Partner shipment carrier modal @partnerui", () => {
    * say whether the selector is stale or the screen is broken. `fixme` rather
    * than a silent skip: the report names it every run.
    *
-   * 🔴 #1576 UPDATE — the original diagnosis ("tab stays inactive, selector
-   * may be stale") was wrong on both counts, and the truth is worse: this case
-   * CANNOT PASS ANYWHERE, credentials or not.
+   * 🔴 #1576 — un-parked. The original diagnosis ("tab stays inactive,
+   * selector may be stale") was wrong on both counts. The real cause:
    *
    * `POST /partners/orders/:id/shiprocket-attach-awb` calls
    * `provider.track({ awb })` against the LIVE Shiprocket API, and throws twice
@@ -145,11 +148,16 @@ test.describe("Partner shipment carrier modal @partnerui", () => {
    * "Shipment" and `/^shipment$/i` matches — checked in @medusajs/ui, not
    * assumed. Do not "fix" this by loosening the regex.
    *
-   * To un-park it, one of: stub the shipping provider for e2e, or seed a
-   * known-good AWB on the test Shiprocket account. A tag-and-exclude (the
-   * `@llm` treatment) would only hide it.
+   * Fixed by giving the existing `SHIPROCKET_STUB=1` transport a
+   * `/courier/track/awb/:awb` handler — it had every other endpoint but that
+   * one, so it 404'd the lookup and the client threw exactly as the live API
+   * would. The e2e job now sets it. The stub echoes back the AWB it was asked
+   * about, so this really does test the round-trip.
+   *
+   * ⚠️ What this no longer covers: a waybill Shiprocket REJECTS. The stub
+   * models success only, so "foreign AWB refused" has no test.
    */
-  test.fixme("completing step 2 marks the fulfillment shipped", async ({ page }) => {
+  test("completing step 2 marks the fulfillment shipped", async ({ page }) => {
     await page.goto(SHIPMENT_URL)
 
     // Skip the carrier step — a partner shipping on their own account never


### PR DESCRIPTION
Un-parks the two `partner-shipment-carrier-modal` cases — the ones I said in #1584 needed "a stubbed provider or a seeded real AWB". The stub already existed; it was missing exactly one endpoint.

## What was actually wrong

`POST /partners/orders/:id/shiprocket-attach-awb` calls `provider.track({ awb })` to validate the waybill, and throws twice over — once if the lookup fails, again if Shiprocket returns no shipment. The spec attaches a synthetic `E2E<timestamp>` AWB, so those cases could not pass anywhere, credentials or not.

`SHIPROCKET_STUB=1` is already wired through `resolveShippingProvider`, and the stub answers login, adhoc create, serviceability, courier assign… **and 404s `/courier/track/awb/:awb`** — the one call this route makes. So it threw exactly as the live API would.

- stub gains that handler, echoing back the AWB it was **asked** about (a constant would let a route that ignores its input still pass)
- the e2e job sets `SHIPROCKET_STUB=1`, scoped to the run step rather than the job, so nothing else silently acquires a fake carrier
- both cases un-parked

⚠️ **What this does not cover:** a waybill Shiprocket *rejects*. The stub models success only, so "foreign AWB refused" still has no test.

## The backend half is proven locally, not guessed

`stub-track.unit.spec.ts` asserts the tracking round-trip **and the exact predicate the attach route guards on** (`tracking.awb || current_status || events.length`). Only the browser flow is left to CI — asserting an e2e green without this would bet on two unverified halves at once.

## 🔴 Three traps hit writing that one test file

1. Placed first in `integration-tests/http/`, it matched **neither** jest config and jest said *"No tests found"*. A file that exists, reads as coverage, and never runs.
2. It imported `shiprocketStubFetch`; the export is the factory `createShiprocketStubFetch`. The name resolved to `undefined`, the client fell back to `globalThis.fetch`, and the failure was a **real 403 from live Shiprocket** — a test that looked like it was exercising a stub while talking to production.
3. Its JSDoc spelled out the testMatch glob, whose `*` `*` `/` terminated the block comment early and turned the prose below into code.

## Verify

```
TEST_TYPE=unit npx jest --testPathPattern="stub-track"   # 2 pass
pnpm check:prod-build                                     # green
```

**This PR's own e2e check is the adjudicator** for the browser half. Not merging until it's green — the backend half is proven, the UI flow is not.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_0158wJMZ1DmjNxXf5uGuBrQD