### PR TITLE
docs(production-runs): auto-accept is retry-only by design — say so where people look (#1575)

### DIFF
--- a/apps/backend/src/api/partners/details/route.ts
+++ b/apps/backend/src/api/partners/details/route.ts
@@ -104,11 +104,19 @@ export const GET = async (
     }
 
     // #1228 — the partner's `auto_accept_production_runs` opt-in is gated a
-    // SECOND time by the platform's reassignment policy, and on prod that gate
-    // is off. Without shipping the gate's state the settings switch promises
-    // something the platform will not do: a partner turns it on, is told
-    // re-sent runs will be accepted for them, and they never are. Read-only,
-    // and deliberately just the one flag the partner UI can act on.
+    // SECOND time by the platform's reassignment policy. Without shipping the
+    // gate's state the settings switch can promise something the platform will
+    // not do: a partner turns it on, is told re-sent runs will be accepted for
+    // them, and they never are. Read-only, and deliberately just the one flag
+    // the partner UI can act on.
+    //
+    // ⚠️ This comment used to end "and on prod that gate is off". That was a
+    // STATE, not an invariant, and it drifted — prod reads
+    // `auto_accept_on_retry = true` (probed live, #1575). Someone reading it
+    // reasonably concluded the gate was why auto-accept never fires. It is not:
+    // nothing auto-accepts at DISPATCH at all, only inside the reminder RETRY
+    // branch, which is the agreed behaviour. Do not record a prod value here
+    // again; probe it.
     let productionRunPolicy: { auto_accept_on_retry: boolean } | null = null
     try {
         const policyService: ProductionPolicyService = req.scope.resolve(

--- a/apps/backend/src/workflows/production-runs/emit-production-run-reminder.ts
+++ b/apps/backend/src/workflows/production-runs/emit-production-run-reminder.ts
@@ -408,6 +408,19 @@ const processReminderStep = createStep(
         // run accepted on their behalf, so production moves instead of waiting
         // on a click that history says isn't coming. Both the policy AND the
         // partner's own opt-in must be true, and only ever on a retry.
+        //
+        // 🔑 THIS IS THE ONLY PLACE ANYTHING AUTO-ACCEPTS, and it is reached
+        // only from the reminder RETRY path. A first dispatch always waits for
+        // a human click — by design, reaffirmed in #1575: the partner setting
+        // reads "Accept re-sent runs for me" and says in as many words that a
+        // first dispatch is never auto-accepted.
+        //
+        // ⚠️ So "auto-accept is on and nothing happens" is EXPECTED on a fresh
+        // dispatch, and is not evidence that either flag is off. #1575 was
+        // opened on exactly that reading, and a stale comment in
+        // `api/partners/details/route.ts` claiming the prod gate was off sent
+        // the first investigation the wrong way. Check which PATH you are on
+        // before you check the flags.
         let autoAccepted = false
         if (reassignmentPolicy.auto_accept_on_retry && run.status === "sent_to_partner") {
           const partnerService: any = container.resolve(PARTNER_MODULE)


### PR DESCRIPTION
Closes #1575 as **working-as-intended, with the drift that made it look like a bug fixed.**

## Nothing is broken

Both switches really are on — partner `auto_accept_production_runs = true`, platform `auto_accept_on_retry = true`, **probed live on prod today**, not taken from the issue.

Auto-accept exists in exactly one place: the reminder **retry** branch of `emit-production-run-reminder`. Nothing auto-accepts at dispatch. And the partner UI already says so in as many words:

> **Accept re-sent runs for me** — … Your FIRST dispatch is never auto-accepted — you always get the chance to look at new work before taking it on.

So the issue's Option A ("relabel so it stops over-promising") was already done on the partner surface. What was left was the drift.

## The stale comment that sent the first investigation the wrong way

`api/partners/details/route.ts` said the partner opt-in

> *"is gated a SECOND time by the platform's reassignment policy, **and on prod that gate is off**"*

Prod reads `true`. That clause recorded a **state** as though it were an **invariant**, so a reader reasonably concluded the platform gate was the reason auto-accept never fires — and went looking at flags instead of at paths. Replaced, with an explicit instruction not to write a prod value into a comment again.

## A signpost at the only site that can accept

The retry branch now states that it is the only auto-accept in the system, that a first dispatch always waits for a click, and — the part that matters for the next report of this — that **"auto-accept is on and nothing happens" is EXPECTED on a fresh dispatch and is not evidence that either flag is off.** Check which path you are on before you check the flags.

## ⚠️ Deliberately not changed

Accepting on **first dispatch** — the founder's original expectation. It removes the partner's look-before-you-take-it step on every run, and the current copy promises them the opposite. That is a product call, not a code tweak. Confirmed this session to keep retry-only; the option stays open on #1575.

## Verify

```
GET /admin/production-run-policy   → auto_accept_on_retry = true   ✅ confirmed live
pnpm check:prod-build              → green
```

Comments only — no behaviour change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_0158wJMZ1DmjNxXf5uGuBrQD