### PR TITLE
feat(quotes): a custom design is quotable before anyone makes a product (#1486)

### DIFF
--- a/apps/backend/src/admin/hooks/api/quotes.ts
+++ b/apps/backend/src/admin/hooks/api/quotes.ts
@@ -340,6 +340,12 @@ export type QuotableDesign = {
   status: string | null
   /** True when exactly one variant backs it, so a line can be built. */
   quotable: boolean
+  /**
+   * True when nothing backs it YET — a custom design whose production run is
+   * in the future. Picking it mints a made-to-order variant priced from what
+   * comparable work has cost. Not a promise that it can be priced.
+   */
+  made_to_order: boolean
   variant_id: string | null
   product_id: string | null
   candidates: Array<{
@@ -371,6 +377,50 @@ export type QuotableDesignsResponse = {
  * Returns unquotable designs too, with their reason. Hiding them would leave an
  * admin unable to learn why a design they can see is not offered.
  */
+export type MintedDesignVariant = {
+  design_id: string
+  variant_id: string | null
+  product_id: string | null
+  minted: boolean
+  unit_price: number | null
+  confidence: string | null
+  basis: string | null
+  reason: string | null
+}
+
+/**
+ * Mint the made-to-order variant a custom design will be quoted through.
+ *
+ * The admin twin of the partner hook. See
+ * `/admin/quotes/designs/:designId/variant` for why minting happens on PICK,
+ * and why a design that cannot be priced answers 422 rather than 200.
+ */
+export const useMintDesignVariant = (
+  options?: UseMutationOptions<
+    { design: MintedDesignVariant },
+    FetchError,
+    { design_id: string; currency_code: string }
+  >
+) => {
+  const queryClient = useQueryClient()
+
+  return useMutation({
+    mutationFn: async (payload: { design_id: string; currency_code: string }) =>
+      sdk.client.fetch<{ design: MintedDesignVariant }>(
+        `/admin/quotes/designs/${payload.design_id}/variant`,
+        { method: "POST", body: { currency_code: payload.currency_code } }
+      ),
+    onSuccess: (data, variables, _mutateResult, context) => {
+      // The design now resolves to a variant, so the picker's rows are stale.
+      queryClient.invalidateQueries({
+        queryKey: [...quoteQueryKeys.all, "quotable-designs"],
+      })
+      options?.onSuccess?.(data, variables, _mutateResult, context)
+    },
+    ...options,
+  })
+}
+
 export const useQuotableDesigns = (
   query?: { partner_id?: string | null; q?: string; limit?: number; offset?: number },
   options?: Omit<

--- a/apps/backend/src/admin/routes/quotes/create/steps/products-step.tsx
+++ b/apps/backend/src/admin/routes/quotes/create/steps/products-step.tsx
@@ -17,6 +17,7 @@ import { Thumbnail } from "../../../../components/common/thumbnail"
 import { useProducts } from "../../../../hooks/api/products"
 import { AdminQuoteCreateSchemaType } from "../schema"
 import {
+  useMintDesignVariant,
   useQuotableDesigns,
   type QuotableDesign,
 } from "../../../../hooks/api/quotes"
@@ -58,6 +59,14 @@ export const ProductsStep = ({ form }: Props) => {
   const discounts = useWatch({ control, name: "discounts" })
   const overrides = useWatch({ control, name: "overrides" })
   const designByVariant = useWatch({ control, name: "design_by_variant" })
+  // A made-to-order variant is LISTED in the quote's currency, not the
+  // design's cost currency — the estimate is converted on the way through.
+  const watchedCurrency = useWatch({ control, name: "currency_code" })
+
+  /** design_id → why its mint was refused. Cleared when it is retried. */
+  const [mintErrors, setMintErrors] = useState<Record<string, string>>({})
+  const [minting, setMinting] = useState<string | null>(null)
+  const { mutateAsync: mintDesignVariant } = useMintDesignVariant()
 
   /**
    * 🔑 Designs are listed UNSCOPED — every design, not just the chosen
@@ -152,6 +161,47 @@ export const ProductsStep = ({ form }: Props) => {
    * appears in the quantities step like any other, and records which design it
    * was so the mint carries the provenance.
    */
+  /**
+   * A made-to-order design has no variant until one is minted, and the whole
+   * basket below is keyed by variant — so the mint has to happen before the
+   * selection can be recorded.
+   *
+   * Un-ticking never mints, so a design whose mint failed can be un-ticked
+   * without trying again.
+   */
+  const pickDesign = async (design: QuotableDesign, isSelected: boolean) => {
+    if (!isSelected || design.variant_id || !design.made_to_order) {
+      toggleDesign(design, isSelected)
+      return
+    }
+
+    setMinting(design.id)
+    setMintErrors((prev) => {
+      const next = { ...prev }
+      delete next[design.id]
+      return next
+    })
+
+    try {
+      const { design: minted } = await mintDesignVariant({
+        design_id: design.id,
+        currency_code: watchedCurrency as string,
+      })
+      toggleDesign(
+        { ...design, quotable: true, variant_id: minted.variant_id, product_id: minted.product_id },
+        true
+      )
+    } catch (e: any) {
+      // 🔴 Rendered, not swallowed — the message names what is missing.
+      setMintErrors((prev) => ({
+        ...prev,
+        [design.id]: e?.message ?? "This design could not be priced yet.",
+      }))
+    } finally {
+      setMinting(null)
+    }
+  }
+
   const toggleDesign = (design: QuotableDesign, isSelected: boolean) => {
     if (!design.variant_id || !design.product_id) return
 
@@ -241,8 +291,11 @@ export const ProductsStep = ({ form }: Props) => {
             <Checkbox
               checked={pickedDesigns.has(design.id)}
               // Disabled, not hidden — the reason has to be readable.
-              disabled={!design.quotable}
-              onCheckedChange={(value) => toggleDesign(design, !!value)}
+              disabled={
+                (!design.quotable && !design.made_to_order) ||
+                minting === design.id
+              }
+              onCheckedChange={(value) => pickDesign(design, !!value)}
             />
           )
         },
@@ -268,9 +321,21 @@ export const ProductsStep = ({ form }: Props) => {
           const design = row.original as QuotableDesign
           // The reason, in the row, not behind a tooltip: it is the whole
           // instruction for making this design quotable.
-          return design.quotable ? (
-            "Yes"
-          ) : (
+          const mintError = mintErrors[design.id]
+          if (mintError) {
+            return <span className="text-ui-fg-error">{mintError}</span>
+          }
+          if (design.quotable) return "Yes"
+          if (design.made_to_order) {
+            return (
+              <span className="text-ui-fg-subtle">
+                {minting === design.id
+                  ? "Pricing…"
+                  : "Made to order — priced when picked"}
+              </span>
+            )
+          }
+          return (
             <span className="text-ui-fg-muted">
               {design.reason ?? "Cannot quote"}
             </span>
@@ -288,7 +353,7 @@ export const ProductsStep = ({ form }: Props) => {
           ),
       },
     ],
-    [pickedDesigns, selectedIds, quantities]
+    [pickedDesigns, selectedIds, quantities, mintErrors, minting, watchedCurrency]
   )
 
   const table = useDataTable({
@@ -304,8 +369,8 @@ export const ProductsStep = ({ form }: Props) => {
         return
       }
       const design = original as QuotableDesign
-      if (!design.quotable) return
-      toggleDesign(design, !pickedDesigns.has(design.id))
+      if (!design.quotable && !design.made_to_order) return
+      pickDesign(design, !pickedDesigns.has(design.id))
     },
     pagination: { state: pagination, onPaginationChange: setPagination },
     search: {

--- a/apps/backend/src/api/admin/quotes/designs/[designId]/variant/route.ts
+++ b/apps/backend/src/api/admin/quotes/designs/[designId]/variant/route.ts
@@ -1,0 +1,47 @@
+import { MedusaRequest, MedusaResponse } from "@medusajs/framework/http"
+
+import { ensureDesignQuoteVariantWorkflow } from "../../../../../../workflows/partner-quote/ensure-design-quote-variant"
+
+/**
+ * The admin twin of `/partners/quotes/designs/:designId/variant`.
+ *
+ * 🔑 Unscoped by partner, like the admin mint and the admin design picker: an
+ * admin legitimately quotes a design the producing partner does not own. The
+ * guard that matters on the admin surface is the catalogue assertion at mint
+ * time, which checks the resolved variant is in that partner's sales channel —
+ * and it applies to a minted variant exactly as it does to an existing one.
+ *
+ * See the partner route for why minting happens on PICK and why it has to be
+ * idempotent.
+ */
+export const POST = async (req: MedusaRequest, res: MedusaResponse) => {
+  const designId = String(req.params.designId)
+  const currencyCode = String(
+    (req.validatedBody as any)?.currency_code ?? req.query.currency_code ?? ""
+  )
+
+  if (!currencyCode) {
+    return res.status(400).json({
+      error:
+        "currency_code is required — the variant has to be listed in the currency the quote is denominated in.",
+    })
+  }
+
+  const { result } = await ensureDesignQuoteVariantWorkflow(req.scope).run({
+    input: {
+      design_id: designId,
+      currency_code: currencyCode,
+      partner_id: null,
+    },
+  })
+
+  // 422 rather than 200-with-nulls — see the partner route.
+  if (!(result as any)?.variant_id) {
+    return res.status(422).json({
+      error: (result as any)?.reason ?? "This design cannot be quoted yet.",
+      design: result,
+    })
+  }
+
+  res.json({ design: result })
+}

--- a/apps/backend/src/api/admin/quotes/readiness/route.ts
+++ b/apps/backend/src/api/admin/quotes/readiness/route.ts
@@ -6,6 +6,7 @@ import {
   withDesignIssues,
 } from "../../../../modules/partner-quote/lib/design-lines"
 import { assessQuoteReadiness } from "../../../../modules/partner-quote/lib/quote-readiness"
+import { makeDesignVariantPort } from "../../../../workflows/partner-quote/ensure-design-quote-variant"
 
 /**
  * Can this basket be quoted, on a named partner's behalf? (#1445)
@@ -74,6 +75,14 @@ export const POST = async (req: MedusaRequest, res: MedusaResponse) => {
   const designs = await resolveDesignLinesForReadiness(req.scope, {
     lines: body.lines,
     partner_id: null,
+    // Lets a design with no product be previewed as made-to-order rather than
+    // reported as a blocker. Prices nothing and creates nothing — the port is
+    // called with `dry_run: true` from the readiness path.
+    variant_port: makeDesignVariantPort(req.scope, {
+      currency_code: body.currency_code,
+      partner_id: null,
+    }),
+    currency_code: body.currency_code,
   })
 
   const readiness = await assessQuoteReadiness(req.scope, {

--- a/apps/backend/src/api/admin/quotes/route.ts
+++ b/apps/backend/src/api/admin/quotes/route.ts
@@ -9,6 +9,7 @@ import { resolveQuoteDesignLines } from "../../../modules/partner-quote/lib/desi
 import { deliverQuoteEmail } from "../../../workflows/partner-quote/deliver-quote-email"
 import { mintQuoteWorkflow } from "../../../workflows/partner-quote/mint-quote"
 import { assertVariantsInStore } from "./lib/assert-variants-in-store"
+import { makeDesignVariantPort } from "../../../workflows/partner-quote/ensure-design-quote-variant"
 
 /**
  * Admin quotes (#1389 S5).
@@ -109,6 +110,17 @@ export const POST = async (req: MedusaRequest, res: MedusaResponse) => {
   const lines = await resolveQuoteDesignLines(req.scope, {
     lines: body.lines,
     partner_id: null,
+    /**
+     * A design with no product behind it is minted a made-to-order variant
+     * here rather than refused. The currency is the quote's, because that is
+     * what the variant has to be listed in — the estimate behind it is
+     * denominated in the design's own cost currency and converted on the way
+     * through.
+     */
+    variant_port: makeDesignVariantPort(req.scope, {
+      currency_code: body.currency_code,
+      partner_id: null,
+    }),
   })
 
   // 🔴 An admin picks the partner from one dropdown and the variants from

--- a/apps/backend/src/api/middlewares.ts
+++ b/apps/backend/src/api/middlewares.ts
@@ -5751,6 +5751,23 @@ export default defineMiddlewares({
         authenticate("partner", ["session", "bearer"]),
       ],
     },
+    /**
+     * Minting the made-to-order variant a custom design is quoted through.
+     *
+     * 🔴 Named explicitly, and it has to be. The `/partners/*` wildcard entry
+     * carries CORS and locale only — authentication is per-route on this
+     * surface — so a route missing from this list authenticates nobody,
+     * `getPartnerFromAuthContext` finds no partner and every call 401s. Both
+     * `tsc` and a green test suite are silent about it (#1571).
+     */
+    {
+      matcher: "/partners/quotes/designs/:designId/variant",
+      method: "POST",
+      middlewares: [
+        createCorsPartnerMiddleware(),
+        authenticate("partner", ["session", "bearer"]),
+      ],
+    },
     // Admin quotes (#1389 S5). Same capability as the partner surface, but the
     // owning partner must be named — an admin has none of their own.
     {
@@ -5764,6 +5781,13 @@ export default defineMiddlewares({
       middlewares: [
         validateAndTransformBody(wrapSchema(AdminQuoteReadinessReq)),
       ],
+    },
+    // The admin twin of the made-to-order mint. No auth entry needed — the
+    // /admin surface authenticates globally, unlike /partners.
+    {
+      matcher: "/admin/quotes/designs/:designId/variant",
+      method: "POST",
+      middlewares: [],
     },
     // An admin corrects any quote in place, before acceptance. Same body as the
     // partner surface — the refusals live in `adjustQuote` so they cannot drift.

--- a/apps/backend/src/api/partners/quotes/designs/[designId]/variant/route.ts
+++ b/apps/backend/src/api/partners/quotes/designs/[designId]/variant/route.ts
@@ -1,0 +1,78 @@
+import {
+  AuthenticatedMedusaRequest,
+  MedusaResponse,
+} from "@medusajs/framework/http"
+
+import { ensureDesignQuoteVariantWorkflow } from "../../../../../../workflows/partner-quote/ensure-design-quote-variant"
+import { getPartnerFromAuthContext } from "../../../../helpers"
+
+/**
+ * Make a custom design pickable, by minting the variant it will be quoted
+ * through.
+ *
+ * ## Why the picker calls this rather than just selecting the design
+ *
+ * The wizard's basket is "selected products → their variants → quantities".
+ * Every downstream step — the readiness preflight, the minted price list, the
+ * accepted cart — is keyed on a variant. A design whose production run is in
+ * the FUTURE has neither a product nor a variant, so there is nothing for the
+ * basket to hold until one exists.
+ *
+ * Minting on PICK rather than at quote-create also puts the price in front of
+ * the partner while they can still do something about it. A figure derived
+ * from comparable work is a starting point they are meant to dial, and finding
+ * it out at mint time is finding it out too late.
+ *
+ * 🔑 Idempotent. A design that already resolves to one variant returns that
+ * variant and creates nothing — the picker is a list a partner can click
+ * twice, and a second mint would leave the design resolving to TWO variants,
+ * which makes it unquotable for the opposite reason.
+ */
+export const POST = async (
+  req: AuthenticatedMedusaRequest,
+  res: MedusaResponse
+) => {
+  const partner = await getPartnerFromAuthContext(req.auth_context, req.scope)
+  if (!partner) {
+    return res
+      .status(401)
+      .json({ error: "Partner authentication required - no partner found" })
+  }
+
+  const designId = String(req.params.designId)
+  const currencyCode = String(
+    (req.validatedBody as any)?.currency_code ?? req.query.currency_code ?? ""
+  )
+
+  if (!currencyCode) {
+    return res.status(400).json({
+      error:
+        "currency_code is required — the variant has to be listed in the currency the quote is denominated in.",
+    })
+  }
+
+  const { result } = await ensureDesignQuoteVariantWorkflow(req.scope).run({
+    input: {
+      design_id: designId,
+      currency_code: currencyCode,
+      // Scoped: a partner may only quote designs they own or are assigned to.
+      partner_id: partner.id,
+    },
+  })
+
+  /**
+   * 🔴 422, not 200-with-nulls. A design that could not be priced is a refusal
+   * the picker has to render as one — answering 200 would let a caller that
+   * does not check `variant_id` carry a null into the basket, and the null
+   * would surface at mint time as "variant missing", which names the wrong
+   * problem.
+   */
+  if (!(result as any)?.variant_id) {
+    return res.status(422).json({
+      error: (result as any)?.reason ?? "This design cannot be quoted yet.",
+      design: result,
+    })
+  }
+
+  res.json({ design: result })
+}

--- a/apps/backend/src/api/partners/quotes/readiness/route.ts
+++ b/apps/backend/src/api/partners/quotes/readiness/route.ts
@@ -9,6 +9,7 @@ import {
   withDesignIssues,
 } from "../../../../modules/partner-quote/lib/design-lines"
 import { assessQuoteReadiness } from "../../../../modules/partner-quote/lib/quote-readiness"
+import { makeDesignVariantPort } from "../../../../workflows/partner-quote/ensure-design-quote-variant"
 
 /**
  * Can this basket be quoted? (#1445)
@@ -39,6 +40,14 @@ export const POST = async (
   const designs = await resolveDesignLinesForReadiness(req.scope, {
     lines: body.lines,
     partner_id: partner.id,
+    // Lets a design with no product be previewed as made-to-order rather than
+    // reported as a blocker. Prices nothing and creates nothing — the port is
+    // called with `dry_run: true` from the readiness path.
+    variant_port: makeDesignVariantPort(req.scope, {
+      currency_code: body.currency_code,
+      partner_id: partner.id,
+    }),
+    currency_code: body.currency_code,
   })
 
   const readiness = await assessQuoteReadiness(req.scope, {

--- a/apps/backend/src/api/partners/quotes/route.ts
+++ b/apps/backend/src/api/partners/quotes/route.ts
@@ -9,6 +9,7 @@ import { totalQuotedQuantity } from "../../../modules/partner-quote/lib/quote-em
 import { deliverQuoteEmail } from "../../../workflows/partner-quote/deliver-quote-email"
 import { mintQuoteWorkflow } from "../../../workflows/partner-quote/mint-quote"
 import { getPartnerStore, tryGetPartnerStore } from "../helpers"
+import { makeDesignVariantPort } from "../../../workflows/partner-quote/ensure-design-quote-variant"
 
 /**
  * The partner's own quotes. Scoped by `partner_id`, never listed globally.
@@ -77,6 +78,17 @@ export const POST = async (
   const lines = await resolveQuoteDesignLines(req.scope, {
     lines: body.lines,
     partner_id: partner.id,
+    /**
+     * A design with no product behind it is minted a made-to-order variant
+     * here rather than refused. The currency is the quote's, because that is
+     * what the variant has to be listed in — the estimate behind it is
+     * denominated in the design's own cost currency and converted on the way
+     * through.
+     */
+    variant_port: makeDesignVariantPort(req.scope, {
+      currency_code: body.currency_code,
+      partner_id: partner.id,
+    }),
   })
 
   const { result } = await mintQuoteWorkflow(req.scope).run({

--- a/apps/backend/src/modules/partner-quote/__tests__/design-lines.unit.spec.ts
+++ b/apps/backend/src/modules/partner-quote/__tests__/design-lines.unit.spec.ts
@@ -1,5 +1,6 @@
 import {
   applyDesignResolutions,
+  designsNeedingAVariant,
   withDesignIssues,
   type DesignResolution,
 } from "../lib/design-lines"
@@ -204,7 +205,59 @@ describe("toQuotableDesign", () => {
   it("does not claim quotable when nothing resolved it at all", () => {
     const row = toQuotableDesign({ id: "des_9", name: "Unknown" }, undefined)
     expect(row.quotable).toBe(false)
+    expect(row.made_to_order).toBe(false)
     expect(row.candidates).toEqual([])
+  })
+
+  /**
+   * The case this whole change is about. A design with no product used to be
+   * greyed with "create a product from the design first" — a step that only
+   * exists because the resolver needs a variant to point at, and one nobody
+   * should have to do for work that has not been sold yet.
+   */
+  it("reads a design with no product as made-to-order, not as a problem", () => {
+    const row = toQuotableDesign(
+      { id: "des_2", name: "Custom Kurta" },
+      {
+        design_id: "des_2",
+        design_name: "Custom Kurta",
+        visible: true,
+        variant_id: null,
+        candidates: [],
+        reason: "has no product behind it yet",
+      }
+    )
+    expect(row.made_to_order).toBe(true)
+    // Still not `quotable`: it has no variant and no settled price YET. The
+    // two flags mean different things and the UI labels them differently.
+    expect(row.quotable).toBe(false)
+    // 🔴 No reason string. There is nothing wrong with this row, and a reason
+    // renders as a problem in every UI that shows one.
+    expect(row.reason).toBeNull()
+  })
+
+  it("still reports a reason for a design sold as several variants", () => {
+    const row = toQuotableDesign({ id: "des_1", name: "Kashida Shawl" }, ambiguous("des_1"))
+    expect(row.made_to_order).toBe(false)
+    expect(row.reason).toContain("pick the one")
+  })
+
+  it("still says nothing about a design this caller cannot see", () => {
+    const row = toQuotableDesign(
+      { id: "des_3", name: null },
+      {
+        design_id: "des_3",
+        design_name: null,
+        visible: false,
+        variant_id: null,
+        candidates: [],
+        reason: "Design des_3 does not exist.",
+      }
+    )
+    // Invisible must not become made-to-order — that would answer "not yours"
+    // by offering to create something.
+    expect(row.made_to_order).toBe(false)
+    expect(row.reason).toContain("does not exist")
   })
 })
 
@@ -238,5 +291,102 @@ describe("withDesignIssues", () => {
 
   it("returns the readiness untouched when there are no design issues", () => {
     expect(withDesignIssues(clean, [])).toBe(clean)
+  })
+})
+
+/**
+ * Made-to-order: a design with no product is quoted, not refused.
+ *
+ * The gate used to be "has someone created a product from this design", which
+ * is a step that only exists because the resolver needs a variant to point at.
+ * For custom work whose production run is in the FUTURE there is nothing to
+ * create a product from yet, so the answer was always no.
+ */
+describe("designsNeedingAVariant", () => {
+  const resolution = (over: Partial<DesignResolution> = {}): DesignResolution => ({
+    design_id: "d1",
+    design_name: "Custom Kurta",
+    visible: true,
+    variant_id: null,
+    candidates: [],
+    reason: null,
+    ...over,
+  })
+
+  const mapOf = (...rs: DesignResolution[]) =>
+    new Map(rs.map((r) => [r.design_id, r]))
+
+  it("names a visible design with no product at all", () => {
+    const out = designsNeedingAVariant(
+      [{ design_id: "d1", quantity: 10 }],
+      mapOf(resolution())
+    )
+    expect(out).toEqual(["d1"])
+  })
+
+  it("skips a design that already resolves to one variant", () => {
+    const out = designsNeedingAVariant(
+      [{ design_id: "d1", quantity: 10 }],
+      mapOf(
+        resolution({
+          variant_id: "v1",
+          candidates: [
+            { variant_id: "v1", title: null, sku: null, product_id: "p1", product_title: null },
+          ],
+        })
+      )
+    )
+    expect(out).toEqual([])
+  })
+
+  it("skips a design sold as several variants — that is the partner's choice", () => {
+    const out = designsNeedingAVariant(
+      [{ design_id: "d1", quantity: 10 }],
+      mapOf(
+        resolution({
+          candidates: [
+            { variant_id: "v1", title: "S", sku: null, product_id: "p1", product_title: null },
+            { variant_id: "v2", title: "M", sku: null, product_id: "p1", product_title: null },
+          ],
+        })
+      )
+    )
+    // 🔴 Minting a third would not answer "which size" — it would add one.
+    expect(out).toEqual([])
+  })
+
+  it("🔴 skips a line that already NAMES its own variant", () => {
+    const out = designsNeedingAVariant(
+      // The design has no product, but this line chose a variant explicitly.
+      [{ design_id: "d1", variant_id: "v-chosen", quantity: 10 }],
+      mapOf(resolution())
+    )
+    /**
+     * Minting here would attach a SECOND variant to the design, making it
+     * ambiguous — the one state that cannot be quoted at all. The fix would
+     * create the bug it exists to remove.
+     */
+    expect(out).toEqual([])
+  })
+
+  it("skips a design that is not visible to this caller", () => {
+    const out = designsNeedingAVariant(
+      [{ design_id: "d1", quantity: 10 }],
+      mapOf(resolution({ visible: false }))
+    )
+    // "Not yours" must not be answered by creating something.
+    expect(out).toEqual([])
+  })
+
+  it("de-duplicates a design that appears on several lines", () => {
+    const out = designsNeedingAVariant(
+      [
+        { design_id: "d1", quantity: 10 },
+        { design_id: "d1", quantity: 25 },
+      ],
+      mapOf(resolution())
+    )
+    // Two mints would leave the design resolving to two variants.
+    expect(out).toEqual(["d1"])
   })
 })

--- a/apps/backend/src/modules/partner-quote/__tests__/design-quote-price.unit.spec.ts
+++ b/apps/backend/src/modules/partner-quote/__tests__/design-quote-price.unit.spec.ts
@@ -1,0 +1,115 @@
+/**
+ * A cost is not a price, and "we could not price this" is not "free".
+ *
+ * Every refusal below is a case that has already reached production somewhere
+ * in this codebase in a different shape: a stored 0 charged as free (#1564), a
+ * remembered FX rate off by 24% (#1538), a null that got `?? 1`-ed away.
+ */
+import {
+  DEFAULT_CUSTOM_DESIGN_MARKUP_PERCENT,
+  designQuoteUnitPrice,
+} from "../lib/design-quote-price"
+
+describe("designQuoteUnitPrice", () => {
+  it("applies the 20% uplift to the estimated cost", () => {
+    const result = designQuoteUnitPrice({
+      total_estimated: 1000,
+      confidence: "estimated",
+    })
+    expect(result.unit_price).toBe(1200)
+    expect(result.basis).toBe(1000)
+    expect(result.markup_percent).toBe(DEFAULT_CUSTOM_DESIGN_MARKUP_PERCENT)
+    expect(result.reason).toBeNull()
+  })
+
+  it("converts before it marks up", () => {
+    // 1000 INR at 0.012 = 12 USD, then +20% = 14.40. Marking up first and
+    // converting after gives the same number here but not once rounding bites.
+    const result = designQuoteUnitPrice({
+      total_estimated: 1000,
+      confidence: "estimated",
+      fx_rate: 0.012,
+    })
+    expect(result.basis).toBe(12)
+    expect(result.unit_price).toBe(14.4)
+  })
+
+  it("honours a caller's own markup", () => {
+    const result = designQuoteUnitPrice({
+      total_estimated: 100,
+      confidence: "estimated",
+      markup_percent: 50,
+    })
+    expect(result.unit_price).toBe(150)
+  })
+
+  describe("refusals — every one returns null, never 0", () => {
+    it("refuses a null estimate (#1564)", () => {
+      const result = designQuoteUnitPrice({ total_estimated: null })
+      expect(result.unit_price).toBeNull()
+      expect(result.reason).toMatch(/nothing to price/i)
+    })
+
+    it("refuses a stored 0, which means 'found nothing' (#1563)", () => {
+      const result = designQuoteUnitPrice({
+        total_estimated: 0,
+        confidence: "estimated",
+      })
+      // 🔴 The one that matters. A 0 that survived to here would be minted as
+      // an active price row and charged.
+      expect(result.unit_price).toBeNull()
+      expect(result.reason).toMatch(/zero/i)
+    })
+
+    it("refuses an estimate whose confidence is 'none'", () => {
+      const result = designQuoteUnitPrice({
+        total_estimated: 500,
+        confidence: "none",
+      })
+      expect(result.unit_price).toBeNull()
+    })
+
+    it("refuses a FAILED conversion, and does not treat it as 'no conversion'", () => {
+      const result = designQuoteUnitPrice({
+        total_estimated: 1000,
+        confidence: "estimated",
+        fx_rate: null,
+      })
+      // Quoting 1000 INR as 1000 USD is the failure this prevents.
+      expect(result.unit_price).toBeNull()
+      expect(result.reason).toMatch(/exchange rate/i)
+    })
+
+    it("treats an omitted rate as same-currency, which is different from a failed one", () => {
+      const result = designQuoteUnitPrice({
+        total_estimated: 1000,
+        confidence: "estimated",
+      })
+      expect(result.unit_price).toBe(1200)
+    })
+
+    it("refuses a nonsense rate", () => {
+      expect(
+        designQuoteUnitPrice({
+          total_estimated: 1000,
+          confidence: "estimated",
+          fx_rate: 0,
+        }).unit_price
+      ).toBeNull()
+      expect(
+        designQuoteUnitPrice({
+          total_estimated: 1000,
+          confidence: "estimated",
+          fx_rate: -1,
+        }).unit_price
+      ).toBeNull()
+    })
+
+    it("refuses a negative estimate", () => {
+      expect(
+        designQuoteUnitPrice({ total_estimated: -5, confidence: "estimated" })
+          .unit_price
+      ).toBeNull()
+    })
+  })
+})

--- a/apps/backend/src/modules/partner-quote/lib/design-lines.ts
+++ b/apps/backend/src/modules/partner-quote/lib/design-lines.ts
@@ -260,6 +260,32 @@ async function describeVariants(
   }))
 }
 
+/**
+ * How this file reaches the made-to-order minter, without importing it.
+ *
+ * 🔑 An injected port rather than a direct call. This module is unit-tested
+ * with no Medusa runtime — `applyDesignResolutions` and friends are pure — and
+ * importing the workflow would drag the workflow SDK, the product-creation core
+ * flow and `model.define()` into that test's module graph. A lazy `await
+ * import()` was the other option and is worse: `--moduleResolution nodenext`
+ * demands a `.js` specifier that the dev transpiler may not resolve back to the
+ * `.ts` file, and a failed import inside quote creation is a 500 on the one
+ * route this feature exists to unblock.
+ *
+ * The routes own the wiring; `makeDesignVariantPort` builds one.
+ */
+export type DesignVariantPort = (input: {
+  design_id: string
+  /** Answer without creating anything. The readiness preflight passes true. */
+  dry_run: boolean
+}) => Promise<{
+  variant_id: string | null
+  unit_price: number | null
+  confidence: string | null
+  basis: string | null
+  reason: string | null
+} | null>
+
 export type QuoteLineInput = {
   variant_id?: string | null
   design_id?: string | null
@@ -332,6 +358,78 @@ export function applyDesignResolutions(
   return { lines: resolved, errors }
 }
 
+
+/**
+ * Mint a made-to-order variant for every design in the basket that has no
+ * product behind it. Returns whether anything was actually created.
+ *
+ * ⚠️ The workflow is imported LAZILY, and that is not a style choice. This file
+ * is unit-tested without a Medusa runtime — `applyDesignResolutions` and
+ * friends are pure — and a top-level import would pull the workflow SDK, the
+ * product-creation core flow and `model.define()` into that test's module
+ * graph. The estimator resolves its own dependency by string key for exactly
+ * the same reason.
+ *
+ * 🔑 Failures are collected per design and left to the resolver to report. A
+ * design that could not be priced comes back with no variant, and
+ * `applyDesignResolutions` already knows how to say so — throwing here would
+ * refuse the whole basket for one unpriceable line, and the promise this file
+ * makes is that a partner sees EVERY problem at once.
+ */
+async function mintMissingDesignVariants(input: {
+  resolutions: Map<string, DesignResolution>
+  lines: QuoteLineInput[]
+  port: DesignVariantPort
+}): Promise<boolean> {
+  const needing = designsNeedingAVariant(input.lines, input.resolutions)
+  if (!needing.length) return false
+
+  let mintedAny = false
+  for (const designId of needing) {
+    try {
+      const result = await input.port({ design_id: designId, dry_run: false })
+      if (result?.variant_id) mintedAny = true
+    } catch {
+      /**
+       * Left unresolved on purpose. A design that could not be minted comes
+       * back with no variant and `applyDesignResolutions` already knows how to
+       * say so — throwing here would refuse the whole basket over one line,
+       * and the promise this file makes is that a partner sees EVERY problem
+       * at once rather than one per round-trip.
+       */
+    }
+  }
+
+  return mintedAny
+}
+
+/**
+ * PURE: which designs in this basket still need a variant minted.
+ *
+ * 🔴 Only lines with no `variant_id` of their own. A line that named its
+ * variant is already answered, and minting for it would attach a SECOND
+ * variant to the design — making it ambiguous, which is the one state that
+ * cannot be quoted at all. The fix would create the bug.
+ *
+ * And only the no-candidate case. "Sold as several variants" is a question for
+ * the partner; a freshly minted sixth variant does not answer it.
+ */
+export function designsNeedingAVariant(
+  lines: QuoteLineInput[],
+  resolutions: Map<string, DesignResolution>
+): string[] {
+  return Array.from(
+    new Set(
+      (lines ?? [])
+        .filter((l) => l?.design_id && !l?.variant_id)
+        .map((l) => String(l.design_id))
+    )
+  ).filter((id) => {
+    const r = resolutions.get(id)
+    return Boolean(r?.visible && !r.variant_id && r.candidates.length === 0)
+  })
+}
+
 /**
  * Resolve a basket's design lines, or refuse the whole basket.
  *
@@ -340,7 +438,24 @@ export function applyDesignResolutions(
  */
 export async function resolveQuoteDesignLines(
   scope: any,
-  input: { lines: QuoteLineInput[]; partner_id?: string | null }
+  input: {
+    lines: QuoteLineInput[]
+    partner_id?: string | null
+    /**
+     * Mints a made-to-order variant for a design that has no product behind
+     * it, instead of the basket being refused.
+     *
+     * This IS the relaxation. A custom design whose production run is in the
+     * future is the normal case for bespoke work, and telling a partner to go
+     * and create a catalogue product for something nobody has bought yet is a
+     * step that existed only because the resolver needed a variant to point
+     * at. Omit the port and the old refusal is exactly what happens.
+     *
+     * Only the no-product case is minted. A design sold as several variants
+     * still makes the partner choose.
+     */
+    variant_port?: DesignVariantPort | null
+  }
 ): Promise<QuoteLineInput[]> {
   const designIds = (input.lines ?? [])
     // EVERY design named, not only the ones being resolved TO a variant: a
@@ -351,10 +466,26 @@ export async function resolveQuoteDesignLines(
 
   if (!designIds.length) return input.lines ?? []
 
-  const resolutions = await resolveDesignVariants(scope, {
+  let resolutions = await resolveDesignVariants(scope, {
     design_ids: designIds,
     partner_id: input.partner_id ?? null,
   })
+
+  if (input.variant_port) {
+    const minted = await mintMissingDesignVariants({
+      resolutions,
+      lines: input.lines,
+      port: input.variant_port,
+    })
+    // Re-resolve rather than patching the map by hand: minting created a link,
+    // and the resolver is the one thing that knows how to read it.
+    if (minted) {
+      resolutions = await resolveDesignVariants(scope, {
+        design_ids: designIds,
+        partner_id: input.partner_id ?? null,
+      })
+    }
+  }
 
   const { lines, errors } = applyDesignResolutions(input.lines, resolutions)
 
@@ -380,12 +511,22 @@ export async function resolveQuoteDesignLines(
  */
 export async function resolveDesignLinesForReadiness(
   scope: any,
-  input: { lines: QuoteLineInput[]; partner_id?: string | null }
+  input: {
+    lines: QuoteLineInput[]
+    partner_id?: string | null
+    /**
+     * Previews what a design with no product would be quoted at. Called with
+     * `dry_run: true`, so asking stays free of consequences.
+     */
+    variant_port?: DesignVariantPort | null
+    /** Only for the message. The port owns the arithmetic. */
+    currency_code?: string | null
+  }
 ): Promise<{
   lines: QuoteLineInput[]
   issues: Array<{
-    code: "design_unresolved"
-    severity: "blocking"
+    code: "design_unresolved" | "design_made_to_order"
+    severity: "blocking" | "warning"
     message: string
     design_id: string | null
     data?: Record<string, unknown>
@@ -423,26 +564,114 @@ export async function resolveDesignLinesForReadiness(
       .map((l) => String(l.design_id))
   )
 
-  const issues = designIds
+  const unresolved = designIds
     .map((id) => resolutions.get(id))
     .filter((r): r is DesignResolution => {
       if (!r) return false
       return resolvingIds.has(r.design_id) ? !r.variant_id : !r.visible
     })
-    .map((r) => ({
+
+  /**
+   * A design with NO product is no longer a problem — it is a made-to-order
+   * line, and the preflight's job is to say so and show the price it would
+   * carry.
+   *
+   * 🔑 Priced with `dry_run`, so opening the wizard creates nothing. The real
+   * mint happens on the create route; if it fails there, the basket is refused
+   * exactly as before.
+   *
+   * A design that STILL cannot be priced stays blocking, with the estimator's
+   * own reason — "no bill of materials, no completed run and no comparable
+   * work" is something a partner can act on; "cannot be quoted" is not.
+   */
+  const mintable = input.variant_port
+    ? await previewMadeToOrderDesigns(unresolved, input.variant_port)
+    : new Map<
+        string,
+        { unit_price: number | null; confidence: string | null; basis: string | null; reason: string | null }
+      >()
+
+  const issues = unresolved.map((r) => {
+    const preview = mintable.get(r.design_id)
+
+    if (preview?.unit_price != null) {
+      return {
+        code: "design_made_to_order" as const,
+        severity: "warning" as const,
+        message:
+          `"${r.design_name ?? r.design_id}" has no product yet, so it will be quoted as made-to-order at ` +
+          `${preview.unit_price} ${String(input.currency_code).toUpperCase()} per unit. ` +
+          `That figure is a ${preview.confidence ?? "guesstimate"} — dial it in if you know better.`,
+        design_id: r.design_id,
+        data: {
+          candidates: r.candidates,
+          unit_price: preview.unit_price,
+          confidence: preview.confidence,
+          basis: preview.basis,
+          made_to_order: true,
+        },
+      }
+    }
+
+    return {
       code: "design_unresolved" as const,
       severity: "blocking" as const,
-      message: r.reason ?? `Design ${r.design_id} cannot be quoted.`,
+      // The estimator's reason when there is one — it names what is missing.
+      message: preview?.reason ?? r.reason ?? `Design ${r.design_id} cannot be quoted.`,
       design_id: r.design_id,
       // The candidate list IS the fix for the ambiguous case — the wizard shows
       // it as a picker rather than making the partner go and look it up.
       data: { candidates: r.candidates },
-    }))
+    }
+  })
 
   return {
     lines: lines.filter((l) => Boolean(l.variant_id)),
     issues,
   }
+}
+
+/**
+ * What each unpriceable-looking design WOULD be quoted at, without creating
+ * anything. Only the no-product case is asked about: "sold as several
+ * variants" is a choice for the partner and minting a sixth would not help.
+ */
+async function previewMadeToOrderDesigns(
+  resolutions: DesignResolution[],
+  port: DesignVariantPort
+): Promise<
+  Map<
+    string,
+    { unit_price: number | null; confidence: string | null; basis: string | null; reason: string | null }
+  >
+> {
+  const out = new Map<
+    string,
+    { unit_price: number | null; confidence: string | null; basis: string | null; reason: string | null }
+  >()
+
+  // Only the no-product case is asked about — see `designsNeedingAVariant`.
+  const candidates = resolutions.filter(
+    (r) => r.visible && !r.variant_id && r.candidates.length === 0
+  )
+  if (!candidates.length) return out
+
+  for (const r of candidates) {
+    try {
+      const result = await port({ design_id: r.design_id, dry_run: true })
+      if (!result) continue
+      out.set(r.design_id, {
+        unit_price: result.unit_price ?? null,
+        confidence: result.confidence ?? null,
+        basis: result.basis ?? null,
+        reason: result.reason ?? null,
+      })
+    } catch {
+      // Falls through to the blocking issue with the resolver's own reason.
+    }
+  }
+
+  return out
 }
 
 /**

--- a/apps/backend/src/modules/partner-quote/lib/design-quote-price.ts
+++ b/apps/backend/src/modules/partner-quote/lib/design-quote-price.ts
@@ -1,0 +1,142 @@
+/**
+ * Turning an estimated COST into a quoted PRICE (#1486 follow-up).
+ *
+ * ## Why this file exists at all
+ *
+ * `design-lines.ts` says it plainly: a design's `estimated_cost` is not a
+ * price. It is what the work costs us, in `cost_currency`, with no margin, no
+ * tier and no FX — and quoting off it directly would be a second, parallel way
+ * to arrive at a number the buyer pays.
+ *
+ * That reasoning still holds, and this does not break it. The estimate never
+ * becomes a quote line's price directly: it becomes the PRICE OF A VARIANT that
+ * is then quoted through exactly the machinery every other line uses — tiers,
+ * the minted price list, freight weight, the accepted cart. This file is the
+ * one place that converts, so the conversion is auditable in one diff rather
+ * than re-derived at each call site.
+ *
+ * ## The three things a cost is missing
+ *
+ * 1. **Margin.** A cost quoted as a price is a zero-margin sale. Custom work
+ *    is small-batch and the estimate itself is a guess, so the uplift also
+ *    absorbs the error — see `DEFAULT_CUSTOM_DESIGN_MARKUP_PERCENT`.
+ * 2. **Currency.** The estimate is denominated in the design's `cost_currency`;
+ *    the quote is denominated in the buyer's. Converting is not optional and
+ *    not something a caller should be trusted to remember.
+ * 3. **An answer at all.** `total_estimated` is nullable for "we could not
+ *    price this" (#1564), and the recalculation path writes `0` for the same
+ *    thing (#1563). Both must refuse, and they must refuse in the same way.
+ */
+
+/**
+ * The uplift on a custom design's estimated cost.
+ *
+ * 20%, and deliberately not tuned per design. These are small quotes on
+ * one-off work: the estimate behind them is a `guesstimate` far more often
+ * than it is `exact`, so the uplift is carrying estimation error as much as
+ * margin. A partner who knows better dials the line in the wizard, which is
+ * why this is a STARTING figure and not a final one.
+ */
+export const DEFAULT_CUSTOM_DESIGN_MARKUP_PERCENT = 20
+
+export type DesignQuotePriceInput = {
+  /** `total_estimated` from the estimator. Per finished unit (#1554). */
+  total_estimated: number | null | undefined
+  /** The estimator's confidence. `none` is not an estimate at all. */
+  confidence?: string | null
+  /**
+   * Multiplier from the design's cost currency to the quote's. 1 when they
+   * match. Null means the conversion was ASKED FOR and failed, which is not
+   * the same as "no conversion needed" and must not price anything.
+   */
+  fx_rate?: number | null
+  markup_percent?: number
+}
+
+export type DesignQuotePrice = {
+  /** The quoted unit price, or null when the design cannot be priced. */
+  unit_price: number | null
+  /** Why not, in words for a partner. Null when priced. */
+  reason: string | null
+  /** What the uplift was applied to, in the quote's currency. For the UI. */
+  basis: number | null
+  markup_percent: number
+}
+
+const round2 = (n: number) => Math.round(n * 100) / 100
+
+/**
+ * PURE: cost → quoted unit price, or a refusal with a reason.
+ *
+ * 🔴 Every refusal returns `unit_price: null`, never 0. A zero here would not
+ * fail loudly — it would be minted as an ACTIVE price row that the cart
+ * happily charges, which is the exact failure `planQuotePrices` refuses to
+ * make and the one that reached a real storefront checkout in #1564.
+ */
+export function designQuoteUnitPrice(
+  input: DesignQuotePriceInput
+): DesignQuotePrice {
+  const markup = input.markup_percent ?? DEFAULT_CUSTOM_DESIGN_MARKUP_PERCENT
+  const refuse = (reason: string): DesignQuotePrice => ({
+    unit_price: null,
+    reason,
+    basis: null,
+    markup_percent: markup,
+  })
+
+  const estimated = Number(input.total_estimated)
+
+  if (input.total_estimated == null) {
+    return refuse(
+      "There is nothing to price this design from yet — no bill of materials, no completed run and no comparable work."
+    )
+  }
+
+  if (!Number.isFinite(estimated)) {
+    return refuse("The cost estimate for this design is not a number.")
+  }
+
+  /**
+   * 🔴 `> 0`, not `!= null`. The recalculation route stores 0 to mean "the
+   * estimator found nothing" (#1563), so a design carrying a stored 0 arrives
+   * here looking like a priced design that is free. Asking the question this
+   * way is the only form that both spellings answer correctly.
+   */
+  if (estimated <= 0) {
+    return refuse(
+      "This design's cost estimate is zero, which means the estimator found nothing to price rather than that the work is free."
+    )
+  }
+
+  // "none" is the ABSENCE of an estimate, not a weak one (#1564).
+  if (input.confidence === "none") {
+    return refuse(
+      "The cost estimate for this design has no basis, so it cannot be quoted."
+    )
+  }
+
+  /**
+   * ⚠️ `undefined` means no conversion was needed; `null` means one was
+   * attempted and failed. Collapsing them with `?? 1` would quietly quote a
+   * rupee figure as dollars — which is #1538's remembered-rate error with the
+   * arithmetic removed.
+   */
+  if (input.fx_rate === null) {
+    return refuse(
+      "The exchange rate needed to quote this design in the buyer's currency could not be fetched."
+    )
+  }
+
+  const rate = input.fx_rate === undefined ? 1 : Number(input.fx_rate)
+  if (!Number.isFinite(rate) || rate <= 0) {
+    return refuse("The exchange rate for this quote is not usable.")
+  }
+
+  const basis = round2(estimated * rate)
+  return {
+    unit_price: round2(basis * (1 + markup / 100)),
+    reason: null,
+    basis,
+    markup_percent: markup,
+  }
+}

--- a/apps/backend/src/modules/partner-quote/lib/quotable-designs.ts
+++ b/apps/backend/src/modules/partner-quote/lib/quotable-designs.ts
@@ -11,9 +11,24 @@ import { resolveDesignVariants, type DesignResolution } from "./design-lines"
  * product from it first". A picker that silently omits things is how a
  * five-minute task becomes a support message.
  *
- * The two unquotable cases are genuinely different and say so:
- * - no product behind the design at all — nothing to price;
- * - sold as several variants — pick one, and here they are.
+ * The two remaining cases are genuinely different and say so:
+ * - sold as several variants — pick one, and here they are;
+ * - not visible to this caller — indistinguishable from "does not exist", on
+ *   purpose, so an id cannot be probed.
+ *
+ * ## "No product behind it" is no longer a refusal
+ *
+ * It used to be the commonest reason a row was greyed, and it was the wrong
+ * answer for custom work: a design whose production run is in the FUTURE has
+ * no product by definition, and telling the partner to go and create a
+ * catalogue product for something nobody has bought is a step that existed
+ * only because the resolver needed a variant to point at.
+ *
+ * Such a row now reads as `made_to_order` — quotable, with the variant minted
+ * and priced from the estimator when it is actually added to a basket. The
+ * flag is separate from `quotable` rather than folded into it because the two
+ * mean different things to the UI: one has a variant and a settled price
+ * behind it, the other will have both a moment after it is picked.
  */
 export type QuotableDesign = {
   id: string
@@ -23,6 +38,17 @@ export type QuotableDesign = {
   status: string | null
   /** True when exactly one variant backs it, so a line can be built. */
   quotable: boolean
+  /**
+   * True when nothing backs it yet, but a made-to-order variant will be minted
+   * and priced when it is added to a basket.
+   *
+   * ⚠️ NOT a promise that it can be priced. The estimator may still find
+   * nothing to go on, and the readiness preflight is where that is reported —
+   * pricing every row of the picker would mean an estimator run per row, which
+   * is how a picker that feels fine against a seed becomes unusable against a
+   * real catalogue.
+   */
+  made_to_order: boolean
   /** The variant a line would be priced through. Null unless `quotable`. */
   variant_id: string | null
   /**
@@ -49,13 +75,25 @@ export function toQuotableDesign(
     product_type: design?.product_type ?? null,
     status: design?.status ?? null,
     quotable: Boolean(resolution?.variant_id),
+    made_to_order: Boolean(
+      resolution?.visible && !resolution.variant_id && resolution.candidates.length === 0
+    ),
     variant_id: resolution?.variant_id ?? null,
     product_id: resolution?.variant_id
       ? (resolution.candidates.find((c) => c.variant_id === resolution.variant_id)
           ?.product_id ?? null)
       : null,
     candidates: resolution?.candidates ?? [],
-    reason: resolution?.variant_id ? null : (resolution?.reason ?? null),
+    /**
+     * Silent for a made-to-order row: there is nothing wrong with it, and a
+     * reason string next to it renders as a problem in every UI that shows
+     * one. The made-to-order FLAG is what the picker should label it with.
+     */
+    reason:
+      resolution?.variant_id ||
+      (resolution?.visible && resolution.candidates.length === 0)
+        ? null
+        : (resolution?.reason ?? null),
   }
 }
 

--- a/apps/backend/src/workflows/designs/__tests__/estimate-design-cost.unit.spec.ts
+++ b/apps/backend/src/workflows/designs/__tests__/estimate-design-cost.unit.spec.ts
@@ -18,7 +18,12 @@ jest.mock("@medusajs/framework/utils", () => ({
   ContainerRegistrationKeys: { QUERY: "query" },
 }))
 
-import { computeCostBreakdown, resolveItemCost } from "../estimate-design-cost"
+import {
+  buildHistoricalComparables,
+  computeCostBreakdown,
+  medianOf,
+  resolveItemCost,
+} from "../estimate-design-cost"
 import type { MaterialCostItem } from "../estimate-design-cost"
 
 // ─── Fixtures ─────────────────────────────────────────────────────────────────
@@ -74,16 +79,32 @@ describe("computeCostBreakdown", () => {
       expect(result.total_estimated).toBe(25)    // material only
     })
 
-    it("splits admin estimate at 30% when no material data", () => {
+    /**
+     * 🔴 This test used to assert `total_estimated ≈ 30` for an estimate of
+     * 130 — the undercharge as the specification.
+     *
+     * The split is presentational: 130 becomes a 100 material share and a 30
+     * production share. But the total was assembled from `materialCost`, the
+     * sum of the BOM LINES, which is 0 here — so the 100 was computed, shown
+     * and dropped, and a figure a human typed came back 77% smaller. A design
+     * with no bill of materials is the normal case for custom work, and this
+     * number is persisted, quoted and charged.
+     */
+    it("splits admin estimate at 30% when no material data, and the total still equals it", () => {
       const result = computeCostBreakdown({
         ...base,
         adminEstimate: 130,
         materials: [],
       })
       // materialShare = 130 / 1.3 = 100; productionCost = 30
-      expect(result.material_cost).toBe(0)
+      expect(result.material_cost).toBeCloseTo(100, 1)
       expect(result.production_cost).toBeCloseTo(30, 1)
-      expect(result.total_estimated).toBeCloseTo(30, 1)
+      expect(result.total_estimated).toBeCloseTo(130, 1)
+      // The invariant that makes the breakdown readable at all.
+      expect(result.material_cost + result.production_cost + result.platform_fee)
+        .toBeCloseTo(result.total_estimated!, 1)
+      // No material LINES, which is how a reader tells implied from counted.
+      expect(result.breakdown.materials).toHaveLength(0)
     })
 
     it("uses similar design average for production when no admin estimate", () => {
@@ -684,5 +705,149 @@ describe("resolveItemCost", () => {
     const result = resolveItemCost(item, links)
     expect(result.cost).toBe(8)   // falls back to unit_cost
     expect(result.cost_source).toBe("unit_cost")
+  })
+})
+
+/**
+ * Comparable history as a LABELLED fallback for custom work.
+ *
+ * A design whose production run is in the future has no run, no sample and
+ * usually no bill of materials, so every rung of the waterfall misses and the
+ * honest answer is `total_estimated: null`. That is correct for the storefront
+ * — refusing to price is the whole point of #1564 — and useless for a partner
+ * about to send a quote, who needs a starting figure they can dial.
+ *
+ * So history prices it, but only for a caller that asked, and never quietly.
+ */
+describe("historical comparables (opt-in)", () => {
+  const base = { designId: "d1", similarDesigns: [], hasExactMaterialCosts: false }
+  const history = [
+    { id: "d2", name: "Kurta A", unit_amount: 1000, source: "design_estimate" as const },
+    { id: "d3", name: "Kurta B", unit_amount: 1300, source: "product_price" as const },
+    // An archive piece. The mean would be 3100; the median is 1300.
+    { id: "d4", name: "Heirloom", unit_amount: 7000, source: "product_price" as const },
+  ]
+
+  it("does NOT price from history unless the caller opted in", () => {
+    const result = computeCostBreakdown({
+      ...base,
+      adminEstimate: null,
+      materials: [],
+      historical: history,
+    })
+    // Unchanged for every existing caller: nothing here priced this design.
+    expect(result.total_estimated).toBeNull()
+    expect(result.confidence).toBe("none")
+  })
+
+  it("prices from history when opted in, and the total equals the basis", () => {
+    const result = computeCostBreakdown({
+      ...base,
+      adminEstimate: null,
+      materials: [],
+      historical: history,
+      allowHistoricalBasis: true,
+    })
+    // Median of 1000 / 1300 / 7000 — the outlier does not drag it.
+    expect(result.total_estimated).toBeCloseTo(1300, 1)
+    expect(result.breakdown.production_cost_source).toBe("historical_comparables")
+  })
+
+  it("is never presented as a settled price", () => {
+    const result = computeCostBreakdown({
+      ...base,
+      adminEstimate: null,
+      materials: [],
+      historical: history,
+      allowHistoricalBasis: true,
+    })
+    // Capped, exactly like a sample rate (#1568). This is what OTHER work
+    // cost; nobody has looked at this design.
+    expect(result.confidence).toBe("guesstimate")
+    expect(result.breakdown.historical).toHaveLength(3)
+  })
+
+  it("opting in with no history at all still refuses to price", () => {
+    const result = computeCostBreakdown({
+      ...base,
+      adminEstimate: null,
+      materials: [],
+      historical: [],
+      allowHistoricalBasis: true,
+    })
+    // 🔴 The flag is permission to use evidence, never a substitute for it.
+    expect(result.total_estimated).toBeNull()
+    expect(result.confidence).toBe("none")
+  })
+
+  it("counts real materials and takes only the production half from history", () => {
+    const result = computeCostBreakdown({
+      ...base,
+      adminEstimate: null,
+      materials: orderHistoryMaterials, // material = 25
+      historical: [
+        { id: "d2", name: "A", unit_amount: 40, source: "design_estimate" as const },
+      ],
+      allowHistoricalBasis: true,
+    })
+    // Materials are counted, not guessed: 25 real + (40 - 25) production.
+    expect(result.material_cost).toBe(25)
+    expect(result.production_cost).toBeCloseTo(15, 1)
+    expect(result.total_estimated).toBeCloseTo(40, 1)
+  })
+
+  it("loses to every rung that actually looked at this design", () => {
+    const result = computeCostBreakdown({
+      ...base,
+      adminEstimate: null,
+      materials: orderHistoryMaterials,
+      historical: history,
+      allowHistoricalBasis: true,
+      actualProductionCost: 50, // a real completed run
+    })
+    expect(result.breakdown.production_cost_source).toBe("actual_run")
+    expect(result.production_cost).toBe(50)
+  })
+})
+
+describe("buildHistoricalComparables", () => {
+  it("drops a stored 0, which means 'found nothing' rather than 'free' (#1563)", () => {
+    const out = buildHistoricalComparables({
+      designs: [
+        { id: "d1", name: "Priced", estimated_cost: 900 },
+        { id: "d2", name: "Never priced", estimated_cost: 0 },
+        { id: "d3", name: "Null", estimated_cost: null },
+      ],
+      productPrices: [],
+    })
+    expect(out).toHaveLength(1)
+    expect(out[0].id).toBe("d1")
+  })
+
+  it("drops a variant with no price in the design's currency", () => {
+    const out = buildHistoricalComparables({
+      designs: [],
+      // The step nulls the amount when no row matched the currency.
+      productPrices: [
+        { id: "v1", title: "Matched", amount: 1200 },
+        { id: "v2", title: "Wrong currency", amount: null },
+      ],
+    })
+    expect(out).toHaveLength(1)
+    expect(out[0].source).toBe("product_price")
+  })
+})
+
+describe("medianOf", () => {
+  it("takes the middle of an odd count", () => {
+    expect(medianOf([5, 1, 3])).toBe(3)
+  })
+
+  it("averages the two middles of an even count", () => {
+    expect(medianOf([1, 2, 3, 4])).toBe(2.5)
+  })
+
+  it("is 0 for nothing, so a caller must gate on length rather than value", () => {
+    expect(medianOf([])).toBe(0)
   })
 })

--- a/apps/backend/src/workflows/designs/create-product-from-design.ts
+++ b/apps/backend/src/workflows/designs/create-product-from-design.ts
@@ -28,8 +28,47 @@ import type { Link } from "@medusajs/modules-sdk";
 type CreateProductFromDesignInput = {
   design_id: string;
   estimated_cost: number;
-  customer_id: string;
+  /**
+   * Stamped onto the design↔variant link as provenance. Optional: the quote
+   * path mints a variant for work that has no buyer yet, which is the whole
+   * point of quoting it.
+   */
+  customer_id?: string;
   currency_code?: string;
+  /**
+   * Make this a MADE-TO-ORDER variant: something that will be produced after
+   * it is bought, rather than something sitting on a shelf.
+   *
+   * Two things change, and both are required for the variant to be quotable:
+   *
+   * - `status: "published"` instead of `"draft"`. A draft product's variant is
+   *   not purchasable, so an accepted quote would build a cart that cannot be
+   *   completed — and acceptance is the step where that would first be
+   *   noticed, by the buyer.
+   * - `manage_inventory: false`. The whole premise is that the production run
+   *   is in the FUTURE, so stock is zero and always will be until the run
+   *   happens. A managed variant at zero stock refuses the order.
+   *
+   * Off by default: the approve route creates a catalogue product that is
+   * reviewed before it goes live, and that behaviour is unchanged.
+   */
+  made_to_order?: boolean;
+  /**
+   * The price to list, ALREADY in major units and already in `currency_code`.
+   *
+   * ⚠️ Deliberately separate from `estimated_cost`, which this workflow has
+   * always multiplied by 100 before writing. Every other price in this
+   * codebase is a decimal — `accept-quote` writes `amount: freight` and the
+   * minted price list writes `quoted_unit_amount` raw — so that ×100 looks
+   * like a cent-conversion inherited from Medusa v1 that would make a listed
+   * price a hundred times too dear. Nothing tests it and nothing else reads
+   * it, so it is left exactly as it was rather than "fixed" blind on a live
+   * catalogue path; this input exists so the quote path does not inherit it.
+   *
+   * When given, it is written verbatim. `estimated_cost` is then only used for
+   * the legacy path.
+   */
+  unit_price?: number | null;
 };
 
 type CreateProductFromDesignOutput = {
@@ -49,6 +88,17 @@ const createProductAndVariantStep = createStep(
     const query = container.resolve(ContainerRegistrationKeys.QUERY) as any;
     const remoteLink = container.resolve(ContainerRegistrationKeys.LINK) as Link;
     const currencyCode = input.currency_code || "usd";
+    const madeToOrder = !!input.made_to_order;
+
+    // See `unit_price` above for why these two spellings differ.
+    const priceAmount =
+      input.unit_price != null
+        ? Number(input.unit_price)
+        : Math.round(input.estimated_cost * 100);
+
+    // A made-to-order variant is produced after it is sold, so there is no
+    // stock to manage and never will be before the run.
+    const manageInventory = !madeToOrder;
 
     // Get design with its linked products
     const { data: designs } = await query.graph({
@@ -128,11 +178,11 @@ const createProductAndVariantStep = createStep(
         product_id: product_id,
         title: `Custom - ${design.name}`,
         sku: `CUSTOM-${design.id}-${Date.now()}`,
-        manage_inventory: true,
+        manage_inventory: manageInventory,
         options: variantOptions,
         prices: [
           {
-            amount: Math.round(input.estimated_cost * 100),
+            amount: priceAmount,
             currency_code: currencyCode,
           },
         ],
@@ -175,7 +225,9 @@ const createProductAndVariantStep = createStep(
       const productInput = {
         title: `Custom Design - ${design.name}`,
         description: design.description || `Custom design: ${design.name}`,
-        status: "draft" as const,
+        // Draft is not purchasable. A made-to-order product has to be live for
+        // the cart an accepted quote builds to be completable at all.
+        status: (madeToOrder ? "published" : "draft") as "draft" | "published",
         is_giftcard: false,
         discountable: true,
         thumbnail: design.thumbnail_url,
@@ -198,13 +250,13 @@ const createProductAndVariantStep = createStep(
           {
             title: "Custom Design",
             sku: `CUSTOM-${design.id}`,
-            manage_inventory: true,
+            manage_inventory: manageInventory,
             options: {
               Type: "Custom",
             },
             prices: [
               {
-                amount: Math.round(input.estimated_cost * 100),
+                amount: priceAmount,
                 currency_code: currencyCode,
               },
             ],

--- a/apps/backend/src/workflows/designs/estimate-design-cost.ts
+++ b/apps/backend/src/workflows/designs/estimate-design-cost.ts
@@ -43,6 +43,23 @@ export type ProductionCostSource =
   | "sample_run"
   | "admin_estimate"
   | "similar_designs"
+  /**
+   * Comparable HISTORY priced this design because nothing else could: what
+   * designs of this type have actually settled at, and what products
+   * previously created from designs actually sell for.
+   *
+   * 🔴 Opt-in per caller (`allow_historical_basis`), and never a settled
+   * price. `similar_designs` above is deliberately NOT a pricing signal — see
+   * `hasPricingSignal` — because pricing one design off another's number is
+   * the silent substitution #1554 was. This rung is that same evidence used
+   * DELIBERATELY, by a caller that has no bill of materials to work from and
+   * has asked for a starting figure anyway, and it is labelled and capped at
+   * "guesstimate" exactly like the sample-run fallback (#1568).
+   *
+   * The storefront checkout and draft-order paths do not pass the flag, so
+   * their behaviour is unchanged (#1564).
+   */
+  | "historical_comparables"
   | "default_percent";
 
 export type MaterialCostItem = {
@@ -54,6 +71,21 @@ export type MaterialCostItem = {
   cost_source: "order_history" | "unit_cost" | "component_design" | "consumption_log" | "estimated" | "default";
   /** Per-material commission (line cost × platform_fee_percent). Set when a fee applies. */
   commission?: number;
+};
+
+/**
+ * One piece of evidence about what this KIND of work has cost before.
+ *
+ * `unit_amount` is always per finished unit, in the design's cost currency —
+ * the caller normalises, because a total divided by the wrong quantity is the
+ * #1554 family and must not be re-derived in three places.
+ */
+export type HistoricalComparable = {
+  /** Design id or product id, so a reader can go and look at the evidence. */
+  id: string;
+  name: string | null;
+  unit_amount: number;
+  source: "design_estimate" | "product_price";
 };
 
 type EstimateCostInput = {
@@ -77,6 +109,14 @@ type EstimateCostInput = {
    * unaffected; the partner recalc route passes DEFAULT_MATERIAL_COST.
    */
   default_material_cost?: number;
+  /**
+   * Let comparable history price the design when nothing else can. Opt-in per
+   * caller — defaults to false, so every existing caller is unaffected. The
+   * quote wizard passes it, because a custom design whose production run is in
+   * the future has no run, no sample and often no BOM, and "no answer" is not
+   * a useful thing to show a partner about to send a quote.
+   */
+  allow_historical_basis?: boolean;
 };
 
 export type EstimateCostOutput = {
@@ -102,6 +142,12 @@ export type EstimateCostOutput = {
     platform_fee_percent: number;
     /** Where the production half of the total came from. #1568 */
     production_cost_source: ProductionCostSource;
+    /**
+     * The comparable work the figure was derived from. Present only when
+     * `production_cost_source === "historical_comparables"`, so its presence is
+     * itself the signal that nothing about THIS design priced it.
+     */
+    historical?: HistoricalComparable[];
   };
   similar_designs?: Array<{
     id: string;
@@ -123,6 +169,19 @@ export const DEFAULT_PLATFORM_FEE_PERCENT = 10;
 export const DEFAULT_MATERIAL_COST = 600;
 
 const round2 = (n: number) => Math.round(n * 100) / 100;
+
+/** PURE: the middle value, averaging the two middles for an even count. */
+export function medianOf(values: number[]): number {
+  const sorted = (values ?? [])
+    .map((v) => Number(v))
+    .filter((v) => Number.isFinite(v))
+    .sort((a, b) => a - b);
+  if (!sorted.length) return 0;
+  const mid = Math.floor(sorted.length / 2);
+  return sorted.length % 2 === 1
+    ? sorted[mid]
+    : (sorted[mid - 1] + sorted[mid]) / 2;
+}
 
 // ─── Pure functions (exported for unit testing) ───────────────────────────────
 
@@ -196,10 +255,20 @@ export function computeCostBreakdown(input: {
   platformFeePercent?: number;
   /** Fallback per-unit cost for a material with no resolved cost. Default 0 (off). */
   defaultMaterialCost?: number;
+  /**
+   * What comparable work has actually cost — settled costs of designs of this
+   * type, and prices of products previously created from designs. Gathered
+   * regardless; it only PRICES anything under `allowHistoricalBasis`.
+   */
+  historical?: HistoricalComparable[];
+  /** Opt-in: let `historical` produce a figure when nothing else can. */
+  allowHistoricalBasis?: boolean;
 }): EstimateCostOutput {
   const { adminEstimate, similarDesigns } = input;
   const platformFeePercent = input.platformFeePercent ?? 0;
   const defaultMaterialCost = input.defaultMaterialCost ?? 0;
+  const historical = input.historical ?? [];
+  const allowHistoricalBasis = !!input.allowHistoricalBasis;
 
   // Resolve each BOM material: fall back to defaultMaterialCost when it has no
   // resolved price, and attach the per-material commission (its share of the
@@ -219,6 +288,28 @@ export function computeCostBreakdown(input: {
   let productionIsEstimated = true;
   /** Which rung of the waterfall below actually set `productionCost`. */
   let productionSource: ProductionCostSource = "default_percent";
+
+  /**
+   * The material half of a WHOLE-UNIT figure that did not come from the BOM.
+   *
+   * 🔴 This exists because the total was silently losing it. Some rungs below
+   * know a whole per-unit cost and split it into a material share and a
+   * production share for the breakdown — but the total was assembled as
+   * `materialCost + productionCost`, and `materialCost` is the sum of the BOM
+   * LINES, which is 0 when there is no bill of materials. So the material share
+   * was computed, shown, and then dropped out of the number that gets
+   * persisted, quoted and charged: an admin estimate of 1000 on a design with
+   * no BOM came back as `total_estimated: 230.77`, discarding 77% of the figure
+   * a human had typed in. A design whose production run is in the future is
+   * exactly the no-BOM case, so this had to be fixed before that case could be
+   * priced at all.
+   *
+   * It is folded into `material_cost` on the way out rather than kept separate,
+   * so that `material_cost + production_cost + platform_fee === total_estimated`
+   * stays true — the breakdown's empty `materials` list is what tells a reader
+   * the share was implied rather than counted.
+   */
+  let impliedMaterialCost = 0;
 
   if (input.productionCostOverride != null && input.productionCostOverride >= 0) {
     // Partner typed their production cost — authoritative, wins over everything.
@@ -243,6 +334,7 @@ export function computeCostBreakdown(input: {
     productionIsEstimated = false; // admin set a concrete estimate
   } else if (adminEstimate != null && adminEstimate > 0 && materialCost === 0) {
     const materialShare = adminEstimate / (1 + DEFAULT_PRODUCTION_PERCENT / 100);
+    impliedMaterialCost = materialShare;
     productionCost = adminEstimate - materialShare;
     productionPercent = DEFAULT_PRODUCTION_PERCENT;
     productionSource = "admin_estimate";
@@ -253,6 +345,31 @@ export function computeCostBreakdown(input: {
     productionCost = Math.min(impliedProduction, materialCost * 0.6);
     productionPercent = (productionCost / materialCost) * 100;
     productionSource = "similar_designs";
+  } else if (allowHistoricalBasis && historical.length > 0) {
+    /**
+     * Nothing priced this design, and the caller asked for history anyway.
+     *
+     * The MEDIAN, not the mean: one archive piece or one sample-priced outlier
+     * in a handful of comparables drags an average somewhere no real garment
+     * sits, and this figure is the starting point for a number a buyer signs.
+     *
+     * When there IS a bill of materials, history only supplies the production
+     * half — the materials are counted, not guessed. With no BOM the comparable
+     * is a whole-unit cost, so it is split on the same 30% rule of thumb the
+     * admin-estimate rung uses, with the material share carried in
+     * `impliedMaterialCost` so the total still equals the figure.
+     */
+    const basis = medianOf(historical.map((h) => h.unit_amount));
+    if (materialCost > 0) {
+      productionCost = Math.max(basis - materialCost, materialCost * 0.1);
+      productionPercent = (productionCost / materialCost) * 100;
+    } else {
+      const materialShare = basis / (1 + DEFAULT_PRODUCTION_PERCENT / 100);
+      impliedMaterialCost = materialShare;
+      productionCost = basis - materialShare;
+      productionPercent = DEFAULT_PRODUCTION_PERCENT;
+    }
+    productionSource = "historical_comparables";
   } else {
     productionCost = materialCost * (DEFAULT_PRODUCTION_PERCENT / 100);
     productionPercent = DEFAULT_PRODUCTION_PERCENT;
@@ -263,7 +380,8 @@ export function computeCostBreakdown(input: {
   const platformFee = round2(
     materials.reduce((sum, m) => sum + (m.commission ?? 0), 0)
   );
-  const totalEstimated = materialCost + productionCost + platformFee;
+  const effectiveMaterialCost = materialCost + impliedMaterialCost;
+  const totalEstimated = effectiveMaterialCost + productionCost + platformFee;
 
   const hasAnyRealData = materials.some(
     (m) =>
@@ -295,16 +413,34 @@ export function computeCostBreakdown(input: {
     (m) => m.cost_source === "default"
   );
 
+  /**
+   * ⚠️ `allowHistoricalBasis` is required, not merely `historical.length`.
+   * Comparables are gathered for every caller so the breakdown can show them;
+   * only a caller that has explicitly asked to be priced from history gets a
+   * NUMBER out of them. Without that gate this would quietly re-price the
+   * storefront checkout off other designs — which is #1554 wearing #1564's
+   * clothes.
+   */
+  const hasHistoricalSignal = allowHistoricalBasis && historical.length > 0;
+
   const hasPricingSignal =
     hasAnyRealData ||
     usedDefaultMaterialCost ||
     adminEstimate != null ||
     input.actualProductionCost != null ||
-    input.productionCostOverride != null;
+    input.productionCostOverride != null ||
+    hasHistoricalSignal;
 
   let confidence: ConfidenceLevel;
   if (!hasPricingSignal) {
     confidence = "none";
+  } else if (productionSource === "historical_comparables") {
+    /**
+     * Capped, whatever the materials look like — the same treatment a sample
+     * rate gets (#1568), and for the same reason. This is what OTHER work cost;
+     * nothing here has been priced by anyone who looked at this design.
+     */
+    confidence = "guesstimate";
   } else if (productionSource === "sample_run") {
     /**
      * 🔴 Capped, whatever the materials look like.
@@ -326,7 +462,7 @@ export function computeCostBreakdown(input: {
 
   return {
     design_id: input.designId,
-    material_cost: round2(materialCost),
+    material_cost: round2(effectiveMaterialCost),
     production_cost: round2(productionCost),
     platform_fee: platformFee,
     /**
@@ -341,6 +477,8 @@ export function computeCostBreakdown(input: {
       production_percent: Math.round(productionPercent),
       platform_fee_percent: platformFeePercent,
       production_cost_source: productionSource,
+      /** The evidence, when it is what produced the figure. */
+      historical: productionSource === "historical_comparables" ? historical : undefined,
     },
     similar_designs: similarDesigns.length > 0 ? similarDesigns : undefined,
   };
@@ -363,6 +501,9 @@ const getDesignWithInventoryStep = createStep(
         "estimated_cost",
         "material_cost",
         "production_cost",
+        // Needed to currency-match comparable variant prices — a median over
+        // mixed currencies is not a number.
+        "cost_currency",
         "cost_breakdown",
         "tags",
         "inventory_items.*",
@@ -729,6 +870,145 @@ const getActualProductionCostStep = createStep(
   }
 );
 
+
+// ─── Step 3c: What comparable work has actually cost ──────────────────────────
+
+/**
+ * PURE: fold the two evidence sources into one comparable list.
+ *
+ * 🔑 A design's `estimated_cost` is per finished UNIT (#1554) and a variant
+ * price is per unit by construction, so neither needs dividing — but both are
+ * filtered to strictly positive. A stored `0` on a design means "the estimator
+ * found nothing" (#1563), not "this is free", and averaging it in would drag
+ * every comparable figure toward zero while looking like more evidence.
+ */
+export function buildHistoricalComparables(input: {
+  designs: Array<{ id: string; name?: string | null; estimated_cost?: number | null }>;
+  productPrices: Array<{ id: string; title?: string | null; amount?: number | null }>;
+}): HistoricalComparable[] {
+  const fromDesigns: HistoricalComparable[] = (input.designs ?? [])
+    .filter((d) => d?.id && Number(d.estimated_cost) > 0)
+    .map((d) => ({
+      id: d.id,
+      name: d.name ?? null,
+      unit_amount: Number(d.estimated_cost),
+      source: "design_estimate" as const,
+    }));
+
+  const fromProducts: HistoricalComparable[] = (input.productPrices ?? [])
+    .filter((p) => p?.id && Number(p.amount) > 0)
+    .map((p) => ({
+      id: p.id,
+      name: p.title ?? null,
+      unit_amount: Number(p.amount),
+      source: "product_price" as const,
+    }));
+
+  return [...fromDesigns, ...fromProducts];
+}
+
+/**
+ * Gather what this KIND of work has cost before.
+ *
+ * Two sources, deliberately:
+ * - designs of the same `design_type` that carry a settled cost;
+ * - variants of products PREVIOUSLY CREATED FROM DESIGNS, which is a price a
+ *   buyer has actually been asked to pay rather than an internal cost.
+ *
+ * The second is the one worth having. A design's `estimated_cost` is our own
+ * estimate — averaging our estimates produces a very confident average of
+ * guesses — whereas a product minted from a design was priced, listed and in
+ * some cases sold. It is scoped to design-backed products for exactly that
+ * reason: the catalogue at large includes bought-in goods that say nothing
+ * about what making something costs.
+ */
+const getHistoricalComparablesStep = createStep(
+  "get-historical-comparables-step",
+  async (input: { design: any; currencyCode?: string | null }, { container }) => {
+    const query = container.resolve(ContainerRegistrationKeys.QUERY) as any;
+    const design = input.design;
+
+    let designs: any[] = [];
+    let productPrices: Array<{ id: string; title: string | null; amount: number | null }> = [];
+
+    try {
+      const filters: any = {
+        id: { $ne: design.id },
+        estimated_cost: { $ne: null },
+      };
+      // Same KIND of work, when we know what kind it is. Without this the
+      // comparables are "any design at all", which is not evidence.
+      if (design.design_type) filters.design_type = design.design_type;
+
+      const { data } = await query.graph({
+        entity: "design",
+        filters,
+        fields: ["id", "name", "estimated_cost"],
+        pagination: { take: 10 },
+      });
+      designs = data || [];
+    } catch {
+      // Non-fatal — comparables are a fallback, never a requirement.
+    }
+
+    try {
+      /**
+       * Every design-backed variant, via the same one-to-one link the quote
+       * resolver reads. Two hops rather than one: the link table holds ids
+       * only, so the prices come from a second query over those variants.
+       */
+      const { data: links = [] } = await query.graph({
+        entity: "design_product_variant",
+        fields: ["design_id", "product_variant_id"],
+        pagination: { take: 100 },
+      });
+
+      const variantIds = Array.from(
+        new Set(
+          (links as any[])
+            .filter((l) => l?.product_variant_id && l.design_id !== design.id)
+            .map((l) => String(l.product_variant_id))
+        )
+      ).slice(0, 50);
+
+      if (variantIds.length) {
+        const { data: variants = [] } = await query.graph({
+          entity: "product_variant",
+          fields: ["id", "title", "prices.amount", "prices.currency_code"],
+          filters: { id: variantIds },
+        });
+
+        const wanted = input.currencyCode ? String(input.currencyCode).toLowerCase() : null;
+
+        productPrices = (variants as any[]).map((v) => {
+          const prices = (v?.prices ?? []) as any[];
+          /**
+           * 🔴 Currency-matched, never "the first price". A variant carries a
+           * row per currency, so taking prices[0] mixes 1200 INR with 1200 USD
+           * into one median — the freight picker was wrong in precisely this
+           * way. When the design's currency has no row, the variant simply does
+           * not count as evidence.
+           */
+          const match = wanted
+            ? prices.find((pr) => String(pr?.currency_code ?? "").toLowerCase() === wanted)
+            : null;
+          return {
+            id: v.id,
+            title: v.title ?? null,
+            amount: match?.amount != null ? Number(match.amount) : null,
+          };
+        });
+      }
+    } catch {
+      // Non-fatal.
+    }
+
+    return new StepResponse({
+      historical: buildHistoricalComparables({ designs, productPrices }),
+    });
+  }
+);
+
 // ─── Step 4: Calculate total cost estimate ────────────────────────────────────
 
 const calculateTotalCostStep = createStep(
@@ -743,6 +1023,8 @@ const calculateTotalCostStep = createStep(
     productionCostOverride?: number | null;
     platformFeePercent?: number;
     defaultMaterialCost?: number;
+    historical?: HistoricalComparable[];
+    allowHistoricalBasis?: boolean;
   }) => {
     const design = input.design;
     const platformFeePercent = input.platformFeePercent ?? 0;
@@ -801,6 +1083,8 @@ const calculateTotalCostStep = createStep(
       productionCostOverride: input.productionCostOverride ?? null,
       platformFeePercent,
       defaultMaterialCost: input.defaultMaterialCost ?? 0,
+      historical: input.historical ?? [],
+      allowHistoricalBasis: !!input.allowHistoricalBasis,
     });
     return new StepResponse(result);
   }
@@ -833,6 +1117,11 @@ export const estimateDesignCostWorkflow = createWorkflow(
       design_id: input.design_id,
     });
 
+    const historicalResult = getHistoricalComparablesStep({
+      design: designResult.design,
+      currencyCode: designResult.design.cost_currency,
+    });
+
     const result = calculateTotalCostStep({
       design: designResult.design,
       materials: materialsResult.materials as unknown as MaterialCostItem[],
@@ -850,6 +1139,9 @@ export const estimateDesignCostWorkflow = createWorkflow(
         input.production_cost_override as unknown as number | null,
       platformFeePercent: input.platform_fee_percent as unknown as number,
       defaultMaterialCost: input.default_material_cost as unknown as number,
+      historical: historicalResult.historical as unknown as HistoricalComparable[],
+      allowHistoricalBasis:
+        input.allow_historical_basis as unknown as boolean,
     });
 
     return new WorkflowResponse(result);

--- a/apps/backend/src/workflows/partner-quote/ensure-design-quote-variant.ts
+++ b/apps/backend/src/workflows/partner-quote/ensure-design-quote-variant.ts
@@ -1,0 +1,296 @@
+import {
+  createWorkflow,
+  createStep,
+  StepResponse,
+  WorkflowResponse,
+} from "@medusajs/framework/workflows-sdk"
+import { ContainerRegistrationKeys, MedusaError } from "@medusajs/framework/utils"
+
+import { applyRate, fetchExchangeRate } from "../../lib/fx/exchange-rate"
+import { designQuoteUnitPrice } from "../../modules/partner-quote/lib/design-quote-price"
+import { resolveDesignVariants } from "../../modules/partner-quote/lib/design-lines"
+import { estimateDesignCostWorkflow } from "../designs/estimate-design-cost"
+import { createProductFromDesignWorkflow } from "../designs/create-product-from-design"
+
+/**
+ * Make a CUSTOM design quotable, without inventing a second pricing path.
+ *
+ * ## The problem this solves
+ *
+ * A design could only be quoted once a product existed behind it, because
+ * `resolveDesignVariants` resolves a design to the VARIANT it is sold through
+ * and everything downstream — tiers, the minted price list, freight weight,
+ * the accepted cart — is keyed on that variant. A design whose production run
+ * is in the FUTURE has no product, so the picker greyed it out and told the
+ * partner to go and create one, which is a real step they have to do by hand
+ * for work they have not sold yet.
+ *
+ * ## Why minting a variant rather than quoting the design directly
+ *
+ * The obvious alternative is a quote line that carries the design's estimated
+ * cost and no variant. It is the wrong shape:
+ *
+ * - `planQuotePrices` DROPS any line with no `variant_id`, deliberately, so the
+ *   quote would mint a price list that prices nothing;
+ * - `accept-quote` builds a real cart from `variant_id` line items, so there
+ *   would be nothing to accept;
+ * - and it would be the second way to arrive at a number the buyer pays, which
+ *   is exactly what `design-lines.ts` refuses.
+ *
+ * So the estimate becomes the PRICE OF A VARIANT, once, here — and from that
+ * point on a custom design is quoted by the same machinery as everything else.
+ *
+ * ## What it refuses
+ *
+ * 🔴 A design that cannot be priced does NOT get a variant. Minting one at a
+ * price of zero, or at "we could not tell", would put an active price row in
+ * front of a buyer — the #1564 failure with an extra step. The refusal carries
+ * the estimator's own words so the partner learns what is missing.
+ */
+
+export type EnsureDesignQuoteVariantInput = {
+  design_id: string
+  /** The currency the quote is denominated in. */
+  currency_code: string
+  /** Scopes visibility. Omit on the admin surface, as the picker does. */
+  partner_id?: string | null
+  /** Override the 20% uplift. The wizard does not; ops might. */
+  markup_percent?: number
+  /**
+   * Answer the question without creating anything.
+   *
+   * 🔑 The readiness preflight uses this. A preflight that MINTS a product as
+   * a side effect of being asked "would this work" leaves real catalogue rows
+   * behind every time a partner opens the wizard and changes their mind — and
+   * the whole reason readiness exists is that it is safe to ask.
+   */
+  dry_run?: boolean
+}
+
+export type EnsureDesignQuoteVariantOutput = {
+  design_id: string
+  variant_id: string | null
+  product_id: string | null
+  /** True when this call created the variant rather than finding it. */
+  minted: boolean
+  /** The listed unit price, in `currency_code`. Null when nothing was minted. */
+  unit_price: number | null
+  /** The estimator's confidence in the cost the price was built from. */
+  confidence: string | null
+  /** Which rung of the estimator produced the figure. */
+  basis: string | null
+  /** Why no variant exists, in words for a partner. Null on success. */
+  reason: string | null
+  /**
+   * True when a variant WOULD be minted but was not, because this was a dry
+   * run. `variant_id` is null and `unit_price` is the price it would carry.
+   */
+  mintable: boolean
+}
+
+const ensureVariantStep = createStep(
+  "ensure-design-quote-variant-step",
+  async (input: EnsureDesignQuoteVariantInput, { container }) => {
+    const query = container.resolve(ContainerRegistrationKeys.QUERY) as any
+
+    const resolutions = await resolveDesignVariants(container, {
+      design_ids: [input.design_id],
+      partner_id: input.partner_id ?? null,
+    })
+    const resolution = resolutions.get(input.design_id)
+
+    if (!resolution?.visible) {
+      throw new MedusaError(
+        MedusaError.Types.NOT_FOUND,
+        resolution?.reason ?? `Design ${input.design_id} does not exist.`
+      )
+    }
+
+    /**
+     * 🔑 Idempotent, and it has to be: this runs from a picker a partner can
+     * click twice, and `link.create` is not idempotent — a second mint would
+     * leave the design resolving to TWO variants, which makes it unquotable
+     * for the opposite reason to the one we came here to fix.
+     */
+    if (resolution.variant_id) {
+      const candidate = resolution.candidates.find(
+        (c) => c.variant_id === resolution.variant_id
+      )
+      return new StepResponse({
+        design_id: input.design_id,
+        variant_id: resolution.variant_id,
+        product_id: candidate?.product_id ?? null,
+        minted: false,
+        unit_price: null,
+        confidence: null,
+        basis: null,
+        reason: null,
+        mintable: false,
+      } as EnsureDesignQuoteVariantOutput)
+    }
+
+    /**
+     * Several candidates is NOT a case for minting. The partner has to pick,
+     * exactly as before — creating a sixth variant to sidestep the question
+     * would quote a size nobody chose on a document a buyer signs.
+     */
+    if (resolution.candidates.length > 1) {
+      return new StepResponse({
+        design_id: input.design_id,
+        variant_id: null,
+        product_id: null,
+        minted: false,
+        unit_price: null,
+        confidence: null,
+        basis: null,
+        reason: resolution.reason,
+        mintable: false,
+      } as EnsureDesignQuoteVariantOutput)
+    }
+
+    // ── No product at all. Price it, or refuse. ────────────────────────────
+    const { result: estimate } = await estimateDesignCostWorkflow(container).run({
+      input: {
+        design_id: input.design_id,
+        // The whole point: a design with no run, no sample and no BOM is
+        // priced from what comparable work has cost, labelled as a guess.
+        allow_historical_basis: true,
+      },
+    })
+
+    const { data: designs = [] } = await query.graph({
+      entity: "design",
+      fields: ["id", "name", "cost_currency"],
+      filters: { id: input.design_id },
+    })
+    const design = (designs as any[])[0]
+
+    const from = String(design?.cost_currency ?? input.currency_code).toLowerCase()
+    const to = String(input.currency_code).toLowerCase()
+
+    /**
+     * ⚠️ `undefined` means no conversion is needed; `null` means one was
+     * attempted and FAILED. `designQuoteUnitPrice` treats them differently on
+     * purpose — collapsing them would quote a rupee figure as dollars.
+     */
+    let fxRate: number | null | undefined = undefined
+    if (from && to && from !== to) {
+      try {
+        fxRate = await fetchExchangeRate(from, to)
+      } catch {
+        fxRate = null
+      }
+      if (!Number.isFinite(Number(fxRate)) || Number(fxRate) <= 0) fxRate = null
+    }
+
+    const priced = designQuoteUnitPrice({
+      total_estimated: estimate?.total_estimated,
+      confidence: estimate?.confidence,
+      fx_rate: fxRate,
+      markup_percent: input.markup_percent,
+    })
+
+    if (priced.unit_price === null) {
+      // 🔴 No variant. A design we cannot price must cost nothing and leave
+      // nothing behind, exactly like a variant that does not exist.
+      return new StepResponse({
+        design_id: input.design_id,
+        variant_id: null,
+        product_id: null,
+        minted: false,
+        unit_price: null,
+        confidence: estimate?.confidence ?? null,
+        basis: estimate?.breakdown?.production_cost_source ?? null,
+        reason: priced.reason,
+        mintable: false,
+      } as EnsureDesignQuoteVariantOutput)
+    }
+
+    /**
+     * Priced, and that is the whole answer a preflight needs. Stopping here
+     * keeps "would this work" free of consequences.
+     */
+    if (input.dry_run) {
+      return new StepResponse({
+        design_id: input.design_id,
+        variant_id: null,
+        product_id: null,
+        minted: false,
+        unit_price: priced.unit_price,
+        confidence: estimate?.confidence ?? null,
+        basis: estimate?.breakdown?.production_cost_source ?? null,
+        reason: null,
+        mintable: true,
+      } as EnsureDesignQuoteVariantOutput)
+    }
+
+    const { result: created } = await createProductFromDesignWorkflow(
+      container
+    ).run({
+      input: {
+        design_id: input.design_id,
+        // Legacy field. `unit_price` is what actually gets listed — see the
+        // docblock on that input for why the two differ.
+        estimated_cost: Number(estimate?.total_estimated ?? 0),
+        unit_price: priced.unit_price,
+        currency_code: to,
+        made_to_order: true,
+      } as any,
+    })
+
+    return new StepResponse({
+      design_id: input.design_id,
+      variant_id: (created as any)?.variant_id ?? null,
+      product_id: (created as any)?.product_id ?? null,
+      minted: true,
+      unit_price: priced.unit_price,
+      confidence: estimate?.confidence ?? null,
+      basis: estimate?.breakdown?.production_cost_source ?? null,
+      reason: null,
+      mintable: true,
+    } as EnsureDesignQuoteVariantOutput)
+  }
+)
+
+export const ensureDesignQuoteVariantWorkflow = createWorkflow(
+  "ensure-design-quote-variant",
+  (input: EnsureDesignQuoteVariantInput) => {
+    return new WorkflowResponse(ensureVariantStep(input))
+  }
+)
+
+/**
+ * Build the port `design-lines.ts` calls to mint or preview a made-to-order
+ * variant.
+ *
+ * It lives here, next to the workflow, because the routes already import
+ * workflows freely and `design-lines.ts` deliberately imports none — see
+ * `DesignVariantPort` for why that matters to its unit tests.
+ */
+export function makeDesignVariantPort(
+  scope: any,
+  config: { currency_code: string; partner_id?: string | null; markup_percent?: number }
+) {
+  return async (input: { design_id: string; dry_run: boolean }) => {
+    const { result } = await ensureDesignQuoteVariantWorkflow(scope).run({
+      input: {
+        design_id: input.design_id,
+        currency_code: config.currency_code,
+        partner_id: config.partner_id ?? null,
+        markup_percent: config.markup_percent,
+        dry_run: input.dry_run,
+      },
+    })
+
+    const out = result as EnsureDesignQuoteVariantOutput
+    return {
+      variant_id: out?.variant_id ?? null,
+      unit_price: out?.unit_price ?? null,
+      confidence: out?.confidence ?? null,
+      basis: out?.basis ?? null,
+      reason: out?.reason ?? null,
+    }
+  }
+}
+
+export default ensureDesignQuoteVariantWorkflow

--- a/apps/partner-ui/src/hooks/api/partner-quotes.tsx
+++ b/apps/partner-ui/src/hooks/api/partner-quotes.tsx
@@ -304,11 +304,11 @@ export const useMintPartnerQuote = (
         { method: "POST", body: payload }
       )
     },
-    onSuccess: async (data, variables, context) => {
+    onSuccess: async (data, variables, _mutateResult, context) => {
       await queryClient.invalidateQueries({
         queryKey: partnerQuotesQueryKeys.lists(),
       })
-      options?.onSuccess?.(data, variables, context)
+      options?.onSuccess?.(data, variables, _mutateResult, context)
     },
     ...options,
   })
@@ -384,6 +384,12 @@ export type QuotableDesign = {
   status: string | null
   /** True when exactly one variant backs it, so a line can be built. */
   quotable: boolean
+  /**
+   * True when nothing backs it YET — a custom design whose production run is
+   * in the future. Picking it mints a made-to-order variant priced from what
+   * comparable work has cost. Not a promise that it can be priced.
+   */
+  made_to_order: boolean
   variant_id: string | null
   product_id: string | null
   candidates: Array<{
@@ -411,6 +417,58 @@ export type QuotableDesignsResponse = {
  * rather than hiding them — a partner who knows a design exists and cannot find
  * it has no way to learn that the fix is "create a product from it first".
  */
+/**
+ * Mint the made-to-order variant a custom design will be quoted through.
+ *
+ * A design whose production run is in the FUTURE has no product behind it, so
+ * there is no variant for the wizard's basket to hold — the basket is
+ * "products → variants → quantities" all the way down to the accepted cart.
+ * This creates one, priced from what comparable work has cost, and returns it
+ * so the design can be picked like any other.
+ *
+ * 🔑 Idempotent server-side: a design that already resolves to one variant
+ * returns that variant and creates nothing. The picker is a list a partner can
+ * click twice.
+ *
+ * ⚠️ It answers **422** when the design cannot be priced — that is a refusal
+ * to render, not an error to swallow. The body carries the estimator's own
+ * words, which name what is missing.
+ */
+export const usePartnerMintDesignVariant = (
+  options?: UseMutationOptions<
+    { design: MintedDesignVariant },
+    FetchError,
+    { design_id: string; currency_code: string }
+  >
+) => {
+  return useMutation({
+    mutationFn: async (payload: { design_id: string; currency_code: string }) =>
+      await sdk.client.fetch<{ design: MintedDesignVariant }>(
+        `/partners/quotes/designs/${payload.design_id}/variant`,
+        { method: "POST", body: { currency_code: payload.currency_code } }
+      ),
+    onSuccess: (data, variables, _mutateResult, context) => {
+      // The design now resolves to a variant, so the picker's rows are stale.
+      queryClient.invalidateQueries({
+        queryKey: [...partnerQuotesQueryKeys.all, "quotable-designs"],
+      })
+      options?.onSuccess?.(data, variables, _mutateResult, context)
+    },
+    ...options,
+  })
+}
+
+export type MintedDesignVariant = {
+  design_id: string
+  variant_id: string | null
+  product_id: string | null
+  minted: boolean
+  unit_price: number | null
+  confidence: string | null
+  basis: string | null
+  reason: string | null
+}
+
 export const usePartnerQuotableDesigns = (
   params: { q?: string; limit?: number; offset?: number } = {},
   options?: Omit<

--- a/apps/partner-ui/src/routes/orders/quote-create/components/quote-create-form/quote-designs-panel.tsx
+++ b/apps/partner-ui/src/routes/orders/quote-create/components/quote-create-form/quote-designs-panel.tsx
@@ -4,6 +4,7 @@ import { useState } from "react"
 import { useTranslation } from "react-i18next"
 
 import {
+  usePartnerMintDesignVariant,
   usePartnerQuotableDesigns,
   type QuotableDesign,
 } from "../../../../../hooks/api/partner-quotes"
@@ -12,6 +13,12 @@ type QuoteDesignsPanelProps = {
   /** variant_id → design_id, as the form currently holds it. */
   designByVariant: Record<string, string>
   onToggle: (design: QuotableDesign, selected: boolean) => void
+  /**
+   * The quote's currency. A made-to-order variant has to be LISTED in it —
+   * the estimate behind it is denominated in the design's own cost currency
+   * and is converted on the way through.
+   */
+  currencyCode: string
 }
 
 /**
@@ -27,9 +34,20 @@ type QuoteDesignsPanelProps = {
  *
  * 🔑 Unquotable designs are shown, greyed, with the reason on them. Filtering
  * them out makes the picker lie: the partner knows the design exists, cannot
- * find it here, and never learns that the fix is "create a product from it
- * first". The two reasons are genuinely different — no product behind it at
- * all, versus sold as several variants — and each says which it is.
+ * find it here, and never learns why.
+ *
+ * ## Made-to-order rows
+ *
+ * "No product behind it" used to be the commonest reason a row was greyed, and
+ * it was the wrong answer for custom work: a design whose production run is in
+ * the FUTURE has no product by definition. Such a row is now pickable — ticking
+ * it MINTS the variant it will be quoted through, priced from what comparable
+ * work has cost, so the rest of the wizard sees an ordinary variant.
+ *
+ * ⚠️ The mint can still refuse, when the estimator has nothing at all to go on.
+ * That answer arrives as a 422 and is rendered on the row, because it names
+ * something the partner can actually fix — add a bill of materials, or price a
+ * sample — where "cannot be quoted" named nothing.
  *
  * Collapsed by default: most quotes are product quotes, and a panel that pushes
  * the product table off the screen for everyone would be a poor trade.
@@ -37,10 +55,71 @@ type QuoteDesignsPanelProps = {
 export const QuoteDesignsPanel = ({
   designByVariant,
   onToggle,
+  currencyCode,
 }: QuoteDesignsPanelProps) => {
   const { t } = useTranslation()
   const [open, setOpen] = useState(false)
   const [q, setQ] = useState("")
+  /** design_id → why its mint was refused. Cleared when it is retried. */
+  const [mintErrors, setMintErrors] = useState<Record<string, string>>({})
+  const [minting, setMinting] = useState<string | null>(null)
+
+  const { mutateAsync: mintVariant } = usePartnerMintDesignVariant()
+
+  /**
+   * Ticking a made-to-order row has to produce a variant BEFORE the parent can
+   * hold it: the form's basket is keyed by variant all the way down.
+   *
+   * Un-ticking never mints — it passes the row straight through, so a design
+   * whose mint failed can be un-ticked without trying again.
+   */
+  const handleToggle = async (design: QuotableDesign, selected: boolean) => {
+    if (!selected || design.variant_id || !design.made_to_order) {
+      onToggle(design, selected)
+      return
+    }
+
+    setMinting(design.id)
+    setMintErrors((prev) => {
+      const next = { ...prev }
+      delete next[design.id]
+      return next
+    })
+
+    try {
+      const { design: minted } = await mintVariant({
+        design_id: design.id,
+        currency_code: currencyCode,
+      })
+      // The row the parent gets is the row the server just made real.
+      onToggle(
+        {
+          ...design,
+          quotable: true,
+          variant_id: minted.variant_id,
+          product_id: minted.product_id,
+        },
+        true
+      )
+    } catch (e: any) {
+      /**
+       * 🔴 Rendered, not swallowed. The message is the estimator's own — "no
+       * bill of materials, no completed run and no comparable work" — and it
+       * is the only thing that tells the partner what to do next.
+       */
+      setMintErrors((prev) => ({
+        ...prev,
+        [design.id]:
+          e?.message ??
+          t(
+            "quotes.create.designs.mintFailed",
+            "This design could not be priced yet."
+          ),
+      }))
+    } finally {
+      setMinting(null)
+    }
+  }
 
   const { designs, isLoading } = usePartnerQuotableDesigns(
     { q: q.trim() || undefined, limit: 50 },
@@ -101,7 +180,9 @@ export const QuoteDesignsPanel = ({
                   key={design.id}
                   design={design}
                   selected={pickedDesignIds.has(design.id)}
-                  onToggle={onToggle}
+                  onToggle={handleToggle}
+                  minting={minting === design.id}
+                  mintError={mintErrors[design.id] ?? null}
                 />
               ))}
             </ul>
@@ -116,22 +197,30 @@ const DesignRow = ({
   design,
   selected,
   onToggle,
+  minting,
+  mintError,
 }: {
   design: QuotableDesign
   selected: boolean
   onToggle: (design: QuotableDesign, selected: boolean) => void
+  minting?: boolean
+  mintError?: string | null
 }) => {
+  // Pickable either because a variant already backs it, or because one will be
+  // minted the moment it is ticked.
+  const pickable = design.quotable || design.made_to_order
+
   const row = (
     <li
       className={`flex items-center gap-x-3 rounded-md px-2 py-2 ${
-        design.quotable ? "hover:bg-ui-bg-base" : "opacity-60"
+        pickable ? "hover:bg-ui-bg-base" : "opacity-60"
       }`}
     >
       <Checkbox
         checked={selected}
         // 🔴 Disabled rather than hidden. The partner has to be able to SEE the
         // design and read why it cannot be quoted.
-        disabled={!design.quotable}
+        disabled={!pickable || minting}
         onCheckedChange={(value) => onToggle(design, !!value)}
       />
       {design.thumbnail_url ? (
@@ -147,14 +236,37 @@ const DesignRow = ({
         <Text size="small" weight="plus" className="truncate">
           {design.name ?? design.id}
         </Text>
-        {design.reason ? (
+        {/*
+          One subtitle, in precedence order: a failed mint is the most recent
+          and most actionable thing that happened; a resolver reason is next;
+          the made-to-order note is a state, not a problem, and comes last.
+        */}
+        {mintError ? (
+          <Text size="xsmall" className="text-ui-fg-error">
+            {mintError}
+          </Text>
+        ) : design.reason ? (
           <Text size="xsmall" className="text-ui-fg-subtle">
             {design.reason}
           </Text>
+        ) : design.made_to_order ? (
+          <Text size="xsmall" className="text-ui-fg-subtle">
+            {minting
+              ? "Pricing from comparable work…"
+              : "No product yet — priced from comparable work when you pick it."}
+          </Text>
         ) : null}
       </div>
+      {design.made_to_order ? (
+        <Badge size="2xsmall" color="orange" className="ml-auto shrink-0">
+          Made to order
+        </Badge>
+      ) : null}
       {design.product_type ? (
-        <Badge size="2xsmall" className="ml-auto shrink-0">
+        <Badge
+          size="2xsmall"
+          className={design.made_to_order ? "shrink-0" : "ml-auto shrink-0"}
+        >
           {design.product_type}
         </Badge>
       ) : null}
@@ -162,5 +274,6 @@ const DesignRow = ({
   )
 
   // The reason is already on the row; the tooltip is for the truncated case.
-  return design.reason ? <Tooltip content={design.reason}>{row}</Tooltip> : row
+  const tip = mintError ?? design.reason
+  return tip ? <Tooltip content={tip}>{row}</Tooltip> : row
 }

--- a/apps/partner-ui/src/routes/orders/quote-create/components/quote-create-form/quote-products-form.tsx
+++ b/apps/partner-ui/src/routes/orders/quote-create/components/quote-create-form/quote-products-form.tsx
@@ -48,6 +48,8 @@ export const QuoteProductsForm = ({ form }: QuoteProductsFormProps) => {
   const selectedIds = useWatch({ control, name: "product_ids" })
   const quantities = useWatch({ control, name: "quantities" })
   const designByVariant = useWatch({ control, name: "design_by_variant" })
+  // The buyer step sets it; a made-to-order variant has to be listed in it.
+  const watchedCurrency = useWatch({ control, name: "currency_code" })
 
   const [rowSelection, setRowSelection] = useState<RowSelectionState>(
     getInitialSelection(selectedIds)
@@ -189,6 +191,9 @@ export const QuoteProductsForm = ({ form }: QuoteProductsFormProps) => {
       <QuoteDesignsPanel
         designByVariant={(designByVariant ?? {}) as Record<string, string>}
         onToggle={toggleDesign}
+        // A made-to-order variant is listed in the quote's currency, not the
+        // design's — see the panel.
+        currencyCode={watchedCurrency}
       />
       <_DataTable
         table={table}


### PR DESCRIPTION
Quoting a design required a product to already exist behind it. That gate is `resolveDesignVariants`, which resolves a design to the **variant** it is sold through — so a design whose production run is in the **future**, which is the normal shape of bespoke work, was greyed out in the picker and told the partner to *"create a product from the design first"*. A step that exists only because the resolver needed something to point at.

Now such a design mints a **made-to-order variant** when it is picked, priced from what comparable work has cost, and everything downstream — tiers, the minted price list, freight weight, the accepted cart — is the machinery that already exists and is already tested.

### Why mint a variant rather than quote the design directly

The obvious alternative — a quote line carrying the design's estimated cost and no variant — does not survive contact with the rest of the system:

- `planQuotePrices` **drops** any line with no `variant_id`, so the quote would mint a price list that prices nothing
- `accept-quote` builds a real cart from `variant_id` line items, so there would be nothing to accept
- it would be the second way to arrive at a number the buyer pays, which is precisely what `design-lines.ts` refuses

The estimate becomes the price of a variant once, in one file, and from there a custom design is quoted like anything else.

### 🔴 A design with no bill of materials was losing 77% of its estimate

`computeCostBreakdown` splits a whole-unit figure into a material share and a production share, then built the total as `materialCost + productionCost` — where `materialCost` is the sum of the BOM **lines**, which is `0` when there is no BOM. The material share was computed, shown, and dropped:

```
adminEstimate 1000 → materialShare 769.23 → production 230.77 → total_estimated 230.77
```

The existing unit test asserted that as the specification. A design with no BOM is exactly the custom case, so this had to be fixed before that case could be priced at all. The corrected test was **proven red on the old arithmetic** before being made green.

### The historical rung is opt-in and labelled

`similar_designs` was deliberately never a pricing signal — pricing one design off another's number is the silent substitution #1554 was. This adds that same evidence used **deliberately**, by a caller with nothing else to go on: comparable designs' settled costs plus prices of products previously created from designs, taken as a **median** so one archive piece cannot drag it.

Gated behind `allow_historical_basis`, capped at `guesstimate`, and labelled in the breakdown — the same treatment the sample-run fallback got in #1568. The storefront checkout and draft-order paths do not pass the flag, so #1564's refusal to price is untouched.

### The uplift

`designQuoteUnitPrice` applies 20% and refuses: a null estimate, a stored `0` ("found nothing", #1563), a `none` confidence, and a **failed** FX conversion — the last distinguished from "no conversion needed", because collapsing them quotes a rupee figure as dollars. Every refusal returns `null`, never `0`: a zero here would be minted as an active price row and charged.

### Also

- readiness previews the made-to-order price with `dry_run`, so opening the wizard creates nothing, and reports it as a **warning** rather than a blocker
- the new partner route is named in `middlewares.ts` — without it auth is never applied and every call 401s while `tsc` and the test suite stay silent (#1571)
- `create-product-from-design` gains `made_to_order`: **published** rather than draft (a draft variant is not purchasable, so the accepted cart could not be completed) and `manage_inventory: false` (there is no stock before the run)
- minting is idempotent and skips any line that already names its own variant — a second variant would make the design ambiguous, which is the one state that cannot be quoted at all

### ⚠️ Left alone deliberately

`create-product-from-design` multiplies its price by 100 while every other price in this codebase is a decimal (`accept-quote` writes `amount: freight`; the minted price list writes `quoted_unit_amount` raw). Nothing tests it and nothing else reads it, so it is **not** changed blind on a live catalogue path — the new `unit_price` input exists so the quote path does not inherit it. Worth a separate look.

### Verify

- `pnpm check:prod-build` — green (exit 0)
- backend `tsc --noEmit` — **byte-identical** to the 80-error baseline
- partner-ui `tsc -p tsconfig.ci.json` — 1117 errors, **none** in the three touched files (down 2: fixed a pre-existing arity error in a file this PR touches, since that check is changed-files-only)
- 385 unit tests green across `estimate-design-cost`, `design-quote-price`, `design-lines` and the rest of `partner-quote`

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01TLt1f38xqR8k2myCVxP8e4