### PR TITLE
test(e2e): the carrier modal shared a fulfillment with a spec that ships it (#1576)

### DIFF
--- a/e2e/helpers/e2e-seed.ts
+++ b/e2e/helpers/e2e-seed.ts
@@ -1556,6 +1556,28 @@ export default async function e2eSeed({ container }: ExecArgs) {
   logger.info("E2E seed: creating the #1195 gate partner (partner-UI spec)...")
   const gatePartner = await seedShipmentGatePartner(container, gate.orderId)
 
+  /**
+   * A SECOND gate order, for the carrier modal alone (#1576).
+   *
+   * 🔴 The carrier-modal spec used to share `gate` with
+   * `order-shipment-gate.spec.ts`, which marks that fulfillment shipped. Both
+   * suites now run on CI, so by the time the partner spec pressed "Mark as
+   * shipped" the backend answered `400 Shipment has already been created` —
+   * three times, once per Playwright retry — and the modal correctly stayed
+   * put. It reads exactly like a broken screen, and it is a fixture collision:
+   * a shipment is a once-only act, so one fulfillment cannot serve two specs
+   * that both ship it, and RETRIES cannot work either.
+   *
+   * The order is otherwise identical, so the `requires_shipping=false`
+   * assertion inside the seeder still guards this fixture too.
+   */
+  logger.info("E2E seed: creating the #1576 carrier-modal order (its OWN fulfillment)...")
+  const carrier = await seedShipmentGateOrder(container)
+  await (container.resolve(ContainerRegistrationKeys.LINK) as any).create({
+    partner: { partner_id: gatePartner.partnerId },
+    order: { order_id: carrier.orderId },
+  })
+
   logger.info("E2E seed: creating the HSN-gap product (customs specs)...")
   const hsnGap = await seedHsCodeGapProduct(container)
 
@@ -1624,6 +1646,9 @@ export default async function e2eSeed({ container }: ExecArgs) {
     // and partner-shipment-gate.spec.ts (@partnerui, local).
     gateOrderId: gate.orderId,
     gateFulfillmentId: gate.fulfillmentId,
+    // #1576 — the carrier modal's OWN order, because shipping is once-only.
+    carrierOrderId: carrier.orderId,
+    carrierFulfillmentId: carrier.fulfillmentId,
     gatePartnerEmail: gatePartner.email,
     gatePartnerPassword: gatePartner.password,
     gatePartnerId: gatePartner.partnerId,

--- a/e2e/specs/partner-shipment-carrier-modal.spec.ts
+++ b/e2e/specs/partner-shipment-carrier-modal.spec.ts
@@ -24,16 +24,30 @@ const SEED_FILE = path.resolve(__dirname, "../../apps/backend/.e2e-seed.json")
 const PARTNER_UI = process.env.PARTNER_UI_URL || "http://localhost:5173"
 
 type Seed = {
-  gateOrderId: string
-  gateFulfillmentId: string
+  /**
+   * 🔴 The CARRIER order, not the gate order.
+   *
+   * This spec used to point at `gateOrderId`, which it shared with
+   * `order-shipment-gate.spec.ts` — a spec that marks that fulfillment
+   * shipped. Once both suites ran on CI, the backend answered `400 Shipment
+   * has already been created` here, three times over (once per Playwright
+   * retry), and the modal correctly refused to move. It looks precisely like a
+   * broken screen.
+   *
+   * Shipping is a once-only act, so a fulfillment cannot be shared by two
+   * specs that both ship it — and no retry can ever pass on a fixture the
+   * first attempt consumed. This fixture is its own.
+   */
+  carrierOrderId: string
+  carrierFulfillmentId: string
   gatePartnerEmail: string
   gatePartnerPassword: string
 }
 
 const seed: Seed = JSON.parse(fs.readFileSync(SEED_FILE, "utf-8"))
 
-const ORDER_URL = `${PARTNER_UI}/orders/${seed.gateOrderId}`
-const SHIPMENT_URL = `${ORDER_URL}/${seed.gateFulfillmentId}/create-shipment`
+const ORDER_URL = `${PARTNER_UI}/orders/${seed.carrierOrderId}`
+const SHIPMENT_URL = `${ORDER_URL}/${seed.carrierFulfillmentId}/create-shipment`
 
 test.describe("Partner shipment carrier modal @partnerui", () => {
   test.beforeEach(async ({ page }) => {
@@ -110,9 +124,28 @@ test.describe("Partner shipment carrier modal @partnerui", () => {
     )
     await expect(page.getByLabel(/tracking number/i).first()).toHaveValue(awb)
 
-    // Bail out of the modal WITHOUT confirming the shipment.
+    /**
+     * Bail out of the modal WITHOUT confirming the shipment.
+     *
+     * 🔑 Two clicks, not one. The tracking number typed above makes the form
+     * DIRTY, and `RouteFocusModal.Form` installs a `useBlocker` that stops any
+     * path change on a dirty form and raises an unsaved-changes prompt. So
+     * Cancel does not navigate — it opens a dialog, and the URL stays on
+     * `/create-shipment` until that dialog is answered. Asserting the
+     * destination straight after the first click waits 15s on a page that was
+     * never going to move.
+     *
+     * ⚠️ The prompt's own dismiss button is ALSO named "Cancel", so the second
+     * click is scoped to the dialog and asks for Continue — the discard —
+     * rather than matching the button that opened it.
+     */
     await page.getByRole("button", { name: /^cancel$/i }).click()
-    await expect(page).toHaveURL(new RegExp(`orders/${seed.gateOrderId}$`))
+
+    const discardPrompt = page.getByRole("alertdialog")
+    await expect(discardPrompt).toBeVisible({ timeout: 15_000 })
+    await discardPrompt.getByRole("button", { name: /^continue$/i }).click()
+
+    await expect(page).toHaveURL(new RegExp(`orders/${seed.carrierOrderId}$`))
 
     // The whole point: still un-shipped. Assert on the status badge AND on the
     // action still being offered — a fulfillment that had been marked shipped
@@ -182,7 +215,7 @@ test.describe("Partner shipment carrier modal @partnerui", () => {
 
     await page.getByRole("button", { name: /mark as shipped/i }).click()
 
-    await expect(page).toHaveURL(new RegExp(`orders/${seed.gateOrderId}$`))
+    await expect(page).toHaveURL(new RegExp(`orders/${seed.carrierOrderId}$`))
     await expect(page.getByText(/^shipped$/i).first()).toBeVisible({
       timeout: 30_000,
     })


### PR DESCRIPTION
Stacked on #1586.

**#1586's stub fix works.** `POST /shiprocket-attach-awb` returned **200** in its CI run and step 2 activated — the whole diagnosis in that PR is confirmed. The two specs still failed, for two reasons it never touched.

### 🔴 One fulfillment, two specs that both ship it

`partner-shipment-carrier-modal.spec.ts` pointed at `gateFulfillmentId`, which it shared with `order-shipment-gate.spec.ts` — a spec that **marks that fulfillment shipped**. Only the admin suite ran on CI before; #1586 turned the `@partnerui` specs on, and the collision became real.

```
POST .../fulfillments/ful_01M118YE9S.../shipment → 400   (×3)
MedusaError: Shipment has already been created   type: not_allowed
```

Three 400s, one per Playwright retry — **including the first attempt**, which is the tell: the fixture was already consumed before this spec ran. The modal correctly stayed on `/create-shipment` and the URL assertion timed out, which reads exactly like a broken screen.

Shipping is a once-only act. A fulfillment cannot be shared by two specs that both ship it, and **no retry can ever pass on a fixture the first attempt consumed**. So the carrier modal gets its own order and its own fulfillment, seeded by the same function — the `requires_shipping=false` assertion inside it still guards this fixture too.

### 🔑 Cancel on a dirty form opens a dialog, it does not navigate

The tracking number the spec types makes the form **dirty**, and `RouteFocusModal.Form` installs a `useBlocker` that stops any path change on a dirty form and raises an unsaved-changes prompt. Cancel therefore does not leave the modal — it opens a dialog, and the URL stays put until that dialog is answered. The spec asserted the destination straight after the click and waited 15s on a page that was never going to move.

⚠️ The prompt's own dismiss button is **also** named "Cancel", so the second click is scoped to the dialog and asks for Continue. Both verified rather than assumed:
- `Prompt` is Radix `AlertDialog` in `@medusajs/ui@4.2.0` → `role="alertdialog"`
- `actions.continue` → `"Continue"` in the partner-UI translations

The "mark as shipped" path needs no such handling: `handleSuccess` navigates with `state: { isSubmitSuccessful: true }`, which the blocker explicitly lets through.

### Verify

e2e is the only check that means anything here — this is a spec + seed change and nothing else exercises it. Previous run: `2 failed · 1 flaky · 56 passed`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01TLt1f38xqR8k2myCVxP8e4