### PR TITLE
test(e2e): the partner carrier modal, adjudicated in a browser at last (#1576)

### DIFF
--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -172,8 +172,16 @@ jobs:
       - name: Run e2e
         working-directory: apps/backend
         # PARTNER_UI opts the @partnerui specs back in — see playwright.config.ts.
+        #
+        # SHIPROCKET_STUB injects the deterministic transport into the backend
+        # this step boots (#1576). Without it the carrier-modal specs call the
+        # LIVE Shiprocket API: `shiprocket-attach-awb` validates the waybill via
+        # `provider.track()` and throws, so those cases could not pass here
+        # whatever the selectors said. Scoped to this step rather than the job,
+        # so nothing else silently acquires a fake carrier.
         env:
           PARTNER_UI: "1"
+          SHIPROCKET_STUB: "1"
         run: pnpm run e2e
 
       - name: Upload Playwright report

--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -182,6 +182,15 @@ jobs:
         env:
           PARTNER_UI: "1"
           SHIPROCKET_STUB: "1"
+          # 🔴 The stub flag ALONE is not enough. `resolveShippingProvider`
+          # reads credentials and THROWS "Shiprocket credentials not
+          # configured" before it ever looks at SHIPROCKET_STUB — so the attach
+          # 500s and the stub never gets a chance. These are placeholders; the
+          # stub's /auth/login returns a token without validating them. Same
+          # pairing the integration specs use (retail-order-international-
+          # shiprocket.spec.ts sets all three).
+          SHIPROCKET_EMAIL: "e2e@shiprocket.example"
+          SHIPROCKET_PASSWORD: "e2e-stub-secret"
         run: pnpm run e2e
 
       - name: Upload Playwright report

--- a/apps/backend/src/modules/shipping-providers/shiprocket/__tests__/stub-track.unit.spec.ts
+++ b/apps/backend/src/modules/shipping-providers/shiprocket/__tests__/stub-track.unit.spec.ts
@@ -1,0 +1,68 @@
+import { ShiprocketClient } from "../client"
+import { createShiprocketStubFetch } from "../stub-fetch"
+
+/**
+ * #1576 — the Shiprocket stub can answer a tracking lookup.
+ *
+ * Two `partner-shipment-carrier-modal` e2e cases were parked as "stale
+ * selectors". They were not: `POST /partners/orders/:id/shiprocket-attach-awb`
+ * calls `provider.track({ awb })` against the LIVE API and throws twice over —
+ * once if the lookup fails, again if Shiprocket returns no shipment. The spec
+ * attaches a synthetic `E2E<timestamp>` waybill, so those cases could not pass
+ * ANYWHERE, credentials or not.
+ *
+ * The deterministic transport (`SHIPROCKET_STUB=1`) already existed but had no
+ * `/courier/track/awb/:awb` handler, so it 404'd the lookup and the client
+ * threw exactly as the live API would.
+ *
+ * 🔑 This proves the BACKEND half locally, so the only thing left to CI is the
+ * browser flow. Asserting the e2e green without this would be betting on two
+ * unverified halves at once.
+ *
+ * ⚠️ It lives beside the code it tests, under a `__tests__` directory with a
+ * `.unit.spec.ts` suffix, deliberately. Written first into
+ * `integration-tests/http/`, it matched NEITHER jest config and jest reported
+ * "No tests found" — a file that exists, looks like coverage, and never runs.
+ *
+ * (And do not write that testMatch glob out in a block comment: the `*` `*` `/`
+ * in it terminates the comment early and the prose below becomes code.)
+ */
+describe("Shiprocket stub — tracking lookup (#1576)", () => {
+  const client = () =>
+    new ShiprocketClient({
+      email: "test@shiprocket.example",
+      password: "secret",
+      // 🔴 The export is a FACTORY. Importing a non-existent name gave
+      // `undefined`, the client silently fell back to `globalThis.fetch`, and
+      // the failure was a REAL 403 from Shiprocket — a test that looked like it
+      // was exercising the stub while talking to the live API.
+      fetchImpl: createShiprocketStubFetch(),
+    } as any)
+
+  it("answers a track for an arbitrary AWB, so a synthetic waybill resolves", async () => {
+    const awb = `E2E${Date.now()}`
+    const tracking = await client().track({ awb })
+
+    // 🔑 It echoes the AWB it was ASKED about. A constant would let a route
+    // that ignores its input pass this test.
+    expect(tracking.awb).toBe(awb)
+    expect(tracking.current_status).toBeTruthy()
+    expect(tracking.events.length).toBeGreaterThan(0)
+  })
+
+  it("satisfies the guard the attach route applies", async () => {
+    // `attachExistingShiprocketAwb` rejects a lookup that returns no shipment:
+    //   hasShipment = tracking.awb || tracking.current_status || events.length
+    // Assert that predicate directly — it is the thing that was throwing.
+    const tracking = await client().track({ awb: "E2E-GUARD" })
+    const hasShipment =
+      !!tracking &&
+      (!!tracking.awb ||
+        !!tracking.current_status ||
+        (tracking.events || []).length > 0)
+    expect(hasShipment).toBe(true)
+
+    // And the shape the route reads its provider refs from.
+    expect((tracking.raw as any)?.shipment_track?.[0]?.awb).toBe("E2E-GUARD")
+  })
+})

--- a/apps/backend/src/modules/shipping-providers/shiprocket/stub-fetch.ts
+++ b/apps/backend/src/modules/shipping-providers/shiprocket/stub-fetch.ts
@@ -240,6 +240,55 @@ export function createShiprocketStubFetch(): FetchLike {
       })
     }
 
+    /**
+     * Tracking lookup — `GET /courier/track/awb/:awb` (#1576).
+     *
+     * Without this the stub 404s the lookup, the client throws, and
+     * `attachExistingShiprocketAwb` throws in turn — which is why the two
+     * `partner-shipment-carrier-modal` cases could not pass ANYWHERE. That
+     * route calls `provider.track({ awb })` to validate the waybill belongs to
+     * this account, and an e2e attaches a synthetic `E2E<timestamp>` AWB that
+     * by construction exists on no real Shiprocket account.
+     *
+     * 🔑 It echoes back the AWB it was ASKED about rather than a fixed one, so
+     * a spec that attaches `E2E123` and then asserts `E2E123` is actually
+     * testing the round-trip. A constant would let a route that ignores its
+     * input still pass.
+     *
+     * ⚠️ This makes the shape valid, not the waybill real. It deliberately
+     * does NOT model a rejection, so nothing here covers "Shiprocket refused a
+     * foreign AWB" — that path still has no test.
+     */
+    const trackMatch = url.match(/\/courier\/track\/awb\/([^/?]+)/)
+    if (trackMatch) {
+      const awb = decodeURIComponent(trackMatch[1])
+      return json({
+        tracking_data: {
+          track_status: 1,
+          shipment_status: 6,
+          shipment_track: [
+            {
+              awb,
+              current_status: "IN TRANSIT",
+              shipment_status_id: 6,
+              origin: "Delhi",
+              destination: "Mumbai",
+              etd: null,
+            },
+          ],
+          shipment_track_activities: [
+            {
+              date: "2026-08-27 09:00:00",
+              status: "IN TRANSIT",
+              location: "Delhi Hub",
+              "sr-status": 6,
+              "sr-status-label": "IN TRANSIT",
+            },
+          ],
+        },
+      })
+    }
+
     return json({}, 404)
   }
 }

--- a/e2e/helpers/e2e-seed.ts
+++ b/e2e/helpers/e2e-seed.ts
@@ -1556,6 +1556,28 @@ export default async function e2eSeed({ container }: ExecArgs) {
   logger.info("E2E seed: creating the #1195 gate partner (partner-UI spec)...")
   const gatePartner = await seedShipmentGatePartner(container, gate.orderId)
 
+  /**
+   * A SECOND gate order, for the carrier modal alone (#1576).
+   *
+   * 🔴 The carrier-modal spec used to share `gate` with
+   * `order-shipment-gate.spec.ts`, which marks that fulfillment shipped. Both
+   * suites now run on CI, so by the time the partner spec pressed "Mark as
+   * shipped" the backend answered `400 Shipment has already been created` —
+   * three times, once per Playwright retry — and the modal correctly stayed
+   * put. It reads exactly like a broken screen, and it is a fixture collision:
+   * a shipment is a once-only act, so one fulfillment cannot serve two specs
+   * that both ship it, and RETRIES cannot work either.
+   *
+   * The order is otherwise identical, so the `requires_shipping=false`
+   * assertion inside the seeder still guards this fixture too.
+   */
+  logger.info("E2E seed: creating the #1576 carrier-modal order (its OWN fulfillment)...")
+  const carrier = await seedShipmentGateOrder(container)
+  await (container.resolve(ContainerRegistrationKeys.LINK) as any).create({
+    partner: { partner_id: gatePartner.partnerId },
+    order: { order_id: carrier.orderId },
+  })
+
   logger.info("E2E seed: creating the HSN-gap product (customs specs)...")
   const hsnGap = await seedHsCodeGapProduct(container)
 
@@ -1624,6 +1646,9 @@ export default async function e2eSeed({ container }: ExecArgs) {
     // and partner-shipment-gate.spec.ts (@partnerui, local).
     gateOrderId: gate.orderId,
     gateFulfillmentId: gate.fulfillmentId,
+    // #1576 — the carrier modal's OWN order, because shipping is once-only.
+    carrierOrderId: carrier.orderId,
+    carrierFulfillmentId: carrier.fulfillmentId,
     gatePartnerEmail: gatePartner.email,
     gatePartnerPassword: gatePartner.password,
     gatePartnerId: gatePartner.partnerId,

--- a/e2e/specs/partner-shipment-carrier-modal.spec.ts
+++ b/e2e/specs/partner-shipment-carrier-modal.spec.ts
@@ -24,16 +24,30 @@ const SEED_FILE = path.resolve(__dirname, "../../apps/backend/.e2e-seed.json")
 const PARTNER_UI = process.env.PARTNER_UI_URL || "http://localhost:5173"
 
 type Seed = {
-  gateOrderId: string
-  gateFulfillmentId: string
+  /**
+   * 🔴 The CARRIER order, not the gate order.
+   *
+   * This spec used to point at `gateOrderId`, which it shared with
+   * `order-shipment-gate.spec.ts` — a spec that marks that fulfillment
+   * shipped. Once both suites ran on CI, the backend answered `400 Shipment
+   * has already been created` here, three times over (once per Playwright
+   * retry), and the modal correctly refused to move. It looks precisely like a
+   * broken screen.
+   *
+   * Shipping is a once-only act, so a fulfillment cannot be shared by two
+   * specs that both ship it — and no retry can ever pass on a fixture the
+   * first attempt consumed. This fixture is its own.
+   */
+  carrierOrderId: string
+  carrierFulfillmentId: string
   gatePartnerEmail: string
   gatePartnerPassword: string
 }
 
 const seed: Seed = JSON.parse(fs.readFileSync(SEED_FILE, "utf-8"))
 
-const ORDER_URL = `${PARTNER_UI}/orders/${seed.gateOrderId}`
-const SHIPMENT_URL = `${ORDER_URL}/${seed.gateFulfillmentId}/create-shipment`
+const ORDER_URL = `${PARTNER_UI}/orders/${seed.carrierOrderId}`
+const SHIPMENT_URL = `${ORDER_URL}/${seed.carrierFulfillmentId}/create-shipment`
 
 test.describe("Partner shipment carrier modal @partnerui", () => {
   test.beforeEach(async ({ page }) => {
@@ -110,9 +124,28 @@ test.describe("Partner shipment carrier modal @partnerui", () => {
     )
     await expect(page.getByLabel(/tracking number/i).first()).toHaveValue(awb)
 
-    // Bail out of the modal WITHOUT confirming the shipment.
+    /**
+     * Bail out of the modal WITHOUT confirming the shipment.
+     *
+     * 🔑 Two clicks, not one. The tracking number typed above makes the form
+     * DIRTY, and `RouteFocusModal.Form` installs a `useBlocker` that stops any
+     * path change on a dirty form and raises an unsaved-changes prompt. So
+     * Cancel does not navigate — it opens a dialog, and the URL stays on
+     * `/create-shipment` until that dialog is answered. Asserting the
+     * destination straight after the first click waits 15s on a page that was
+     * never going to move.
+     *
+     * ⚠️ The prompt's own dismiss button is ALSO named "Cancel", so the second
+     * click is scoped to the dialog and asks for Continue — the discard —
+     * rather than matching the button that opened it.
+     */
     await page.getByRole("button", { name: /^cancel$/i }).click()
-    await expect(page).toHaveURL(new RegExp(`orders/${seed.gateOrderId}$`))
+
+    const discardPrompt = page.getByRole("alertdialog")
+    await expect(discardPrompt).toBeVisible({ timeout: 15_000 })
+    await discardPrompt.getByRole("button", { name: /^continue$/i }).click()
+
+    await expect(page).toHaveURL(new RegExp(`orders/${seed.carrierOrderId}$`))
 
     // The whole point: still un-shipped. Assert on the status badge AND on the
     // action still being offered — a fulfillment that had been marked shipped
@@ -182,7 +215,7 @@ test.describe("Partner shipment carrier modal @partnerui", () => {
 
     await page.getByRole("button", { name: /mark as shipped/i }).click()
 
-    await expect(page).toHaveURL(new RegExp(`orders/${seed.gateOrderId}$`))
+    await expect(page).toHaveURL(new RegExp(`orders/${seed.carrierOrderId}$`))
     await expect(page.getByText(/^shipped$/i).first()).toBeVisible({
       timeout: 30_000,
     })

--- a/e2e/specs/partner-shipment-carrier-modal.spec.ts
+++ b/e2e/specs/partner-shipment-carrier-modal.spec.ts
@@ -59,9 +59,8 @@ test.describe("Partner shipment carrier modal @partnerui", () => {
    * say whether the selector is stale or the screen is broken. `fixme` rather
    * than a silent skip: the report names it every run.
    *
-   * 🔴 #1576 UPDATE — the original diagnosis ("tab stays inactive, selector
-   * may be stale") was wrong on both counts, and the truth is worse: this case
-   * CANNOT PASS ANYWHERE, credentials or not.
+   * 🔴 #1576 — un-parked. The original diagnosis ("tab stays inactive,
+   * selector may be stale") was wrong on both counts. The real cause:
    *
    * `POST /partners/orders/:id/shiprocket-attach-awb` calls
    * `provider.track({ awb })` against the LIVE Shiprocket API, and throws twice
@@ -76,11 +75,16 @@ test.describe("Partner shipment carrier modal @partnerui", () => {
    * "Shipment" and `/^shipment$/i` matches — checked in @medusajs/ui, not
    * assumed. Do not "fix" this by loosening the regex.
    *
-   * To un-park it, one of: stub the shipping provider for e2e, or seed a
-   * known-good AWB on the test Shiprocket account. A tag-and-exclude (the
-   * `@llm` treatment) would only hide it.
+   * Fixed by giving the existing `SHIPROCKET_STUB=1` transport a
+   * `/courier/track/awb/:awb` handler — it had every other endpoint but that
+   * one, so it 404'd the lookup and the client threw exactly as the live API
+   * would. The e2e job now sets it. The stub echoes back the AWB it was asked
+   * about, so this really does test the round-trip.
+   *
+   * ⚠️ What this no longer covers: a waybill Shiprocket REJECTS. The stub
+   * models success only, so "foreign AWB refused" has no test.
    */
-  test.fixme("attaching an AWB in step 1 does not mark the fulfillment shipped", async ({
+  test("attaching an AWB in step 1 does not mark the fulfillment shipped", async ({
     page,
   }) => {
     await page.goto(SHIPMENT_URL)
@@ -128,9 +132,8 @@ test.describe("Partner shipment carrier modal @partnerui", () => {
    * say whether the selector is stale or the screen is broken. `fixme` rather
    * than a silent skip: the report names it every run.
    *
-   * 🔴 #1576 UPDATE — the original diagnosis ("tab stays inactive, selector
-   * may be stale") was wrong on both counts, and the truth is worse: this case
-   * CANNOT PASS ANYWHERE, credentials or not.
+   * 🔴 #1576 — un-parked. The original diagnosis ("tab stays inactive,
+   * selector may be stale") was wrong on both counts. The real cause:
    *
    * `POST /partners/orders/:id/shiprocket-attach-awb` calls
    * `provider.track({ awb })` against the LIVE Shiprocket API, and throws twice
@@ -145,11 +148,16 @@ test.describe("Partner shipment carrier modal @partnerui", () => {
    * "Shipment" and `/^shipment$/i` matches — checked in @medusajs/ui, not
    * assumed. Do not "fix" this by loosening the regex.
    *
-   * To un-park it, one of: stub the shipping provider for e2e, or seed a
-   * known-good AWB on the test Shiprocket account. A tag-and-exclude (the
-   * `@llm` treatment) would only hide it.
+   * Fixed by giving the existing `SHIPROCKET_STUB=1` transport a
+   * `/courier/track/awb/:awb` handler — it had every other endpoint but that
+   * one, so it 404'd the lookup and the client threw exactly as the live API
+   * would. The e2e job now sets it. The stub echoes back the AWB it was asked
+   * about, so this really does test the round-trip.
+   *
+   * ⚠️ What this no longer covers: a waybill Shiprocket REJECTS. The stub
+   * models success only, so "foreign AWB refused" has no test.
    */
-  test.fixme("completing step 2 marks the fulfillment shipped", async ({ page }) => {
+  test("completing step 2 marks the fulfillment shipped", async ({ page }) => {
     await page.goto(SHIPMENT_URL)
 
     // Skip the carrier step — a partner shipping on their own account never


### PR DESCRIPTION
Supersedes #1586 and #1589 — it carries their commits plus the two fixes the CI run on #1586 revealed. Opened against `main` because **that is the only way e2e runs at all**: `e2e.yml` triggers on `pull_request: branches: [main]`, so #1589 stacked on #1586's branch reported nothing but Vercel and looked settled while the only check that matters had never started.

### What #1586's run proved

```
POST /partners/orders/.../shiprocket-attach-awb → 200
```

The stub fix **works**. The attach succeeds, step 2 activates, and that PR's diagnosis is confirmed. Its two specs still failed, for two reasons it never touched.

### 🔴 One fulfillment, two specs that both ship it

`partner-shipment-carrier-modal.spec.ts` pointed at `gateFulfillmentId`, shared with `order-shipment-gate.spec.ts` — a spec that **marks that fulfillment shipped**. Only the admin suite ran on CI before; #1586 turned the `@partnerui` specs on and the collision became real.

```
POST .../fulfillments/ful_01M118YE9S.../shipment → 400   (×3)
MedusaError: Shipment has already been created   type: not_allowed
```

Three 400s, one per Playwright retry — **including the first attempt**, which is the tell: the fixture was consumed before this spec ran. The modal stayed on `/create-shipment` and the URL assertion timed out, which reads exactly like a broken screen.

Shipping is once-only. A fulfillment cannot be shared by two specs that both ship it, and **no retry can pass on a fixture the first attempt consumed**. The carrier modal now gets its own order and fulfillment from the same seeder — so the `requires_shipping=false` assertion inside it still guards this fixture too.

### 🔑 Cancel on a dirty form opens a dialog, it does not navigate

The tracking number the spec types makes the form **dirty**, and `RouteFocusModal.Form` installs a `useBlocker` that stops any path change on a dirty form and raises an unsaved-changes prompt. Cancel opens a dialog; the URL stays put until it is answered. The spec asserted the destination straight after the click and waited 15s on a page that was never going to move — `34 × unexpected value`.

⚠️ The prompt's own dismiss button is **also** named "Cancel", so the second click is scoped to the dialog and asks for Continue. Both selectors verified, not assumed:
- `Prompt` is Radix `AlertDialog` in `@medusajs/ui@4.2.0` → `role="alertdialog"`
- `actions.continue` → `"Continue"` in the partner-UI translations

The "mark as shipped" path needs none of this: `handleSuccess` navigates with `state: { isSubmitSuccessful: true }`, which the blocker explicitly lets through.

### Verify

e2e is the only check that means anything here. Baseline to beat, from #1586's run: `2 failed · 1 flaky · 56 passed`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01TLt1f38xqR8k2myCVxP8e4