### PR TITLE
feat(ops): sweep the Draft payouts no run correction ever revisited (#1556)

### DIFF
--- a/apps/backend/src/api/admin/ops/maintenance-jobs/__tests__/stale-draft-payout.unit.spec.ts
+++ b/apps/backend/src/api/admin/ops/maintenance-jobs/__tests__/stale-draft-payout.unit.spec.ts
@@ -1,0 +1,173 @@
+/**
+ * The sweep decides what to rewrite in a money column nobody is watching.
+ *
+ * Every "skipped" case below is one where a confident answer would rewrite
+ * what a partner is owed on a guess — which is why the sweep is a job with a
+ * dry run rather than a subscriber, and why silence is never the report.
+ */
+import {
+  assessDraftLine,
+  summarizeDraftSweep,
+  type DraftPayoutLine,
+  type ExpectedPayout,
+} from "../lib/stale-draft-payout"
+
+const line = (over: Partial<DraftPayoutLine> = {}): DraftPayoutLine => ({
+  item_id: "psi_1",
+  submission_id: "ps_1",
+  design_id: "des_1",
+  production_run_ids: ["run_1"],
+  run_provenance: "recorded",
+  amount: 3570,
+  quantity: 3,
+  unit_amount: 1190,
+  ...over,
+})
+
+const expected = (over: Partial<ExpectedPayout> = {}): ExpectedPayout => ({
+  eligible: true,
+  amount: 3570,
+  quantity: 3,
+  unit_amount: 1190,
+  ...over,
+})
+
+describe("assessDraftLine", () => {
+  it("leaves a line that still matches its run alone", () => {
+    expect(assessDraftLine(line(), expected()).verdict).toBe("current")
+  })
+
+  it("names the drift when the run's money has moved", () => {
+    // The prod case: drafted at 1190/unit × 3, run since corrected to 840
+    // total for 1. The draft still said 3570 and nothing disagreed with it.
+    const result = assessDraftLine(
+      line(),
+      expected({ amount: 840, quantity: 1, unit_amount: 840 })
+    )
+    expect(result.verdict).toBe("stale")
+    if (result.verdict !== "stale") throw new Error("unreachable")
+    expect(result.reason).toContain("run_1")
+    expect(result.reason).toContain("3570")
+    expect(result.reason).toContain("840")
+    expect(result.expected.amount).toBe(840)
+  })
+
+  it("catches a quantity-only correction", () => {
+    // Same rate, fewer pieces. The amount happens to be re-derived elsewhere,
+    // but a draft whose quantity disagrees with its run is still stale.
+    const result = assessDraftLine(
+      line({ amount: 1190, quantity: 3, unit_amount: 1190 }),
+      expected({ amount: 1190, quantity: 1, unit_amount: 1190 })
+    )
+    expect(result.verdict).toBe("stale")
+  })
+
+  it("tolerates a bigNumber round-trip rather than reporting a phantom drift", () => {
+    // Money is 2dp; a hair of float must not make every line look stale and
+    // bury the real ones in noise.
+    const result = assessDraftLine(
+      line({ amount: 3570.0000001 }),
+      expected()
+    )
+    expect(result.verdict).toBe("current")
+  })
+
+  it("🔴 does NOT treat a run with no payable figure as worth zero", () => {
+    // Rate cleared or run reopened. Writing 0 would read as a decision that
+    // the work was worthless — the #1564 mistake exactly.
+    const result = assessDraftLine(line(), expected({ eligible: false }))
+    expect(result.verdict).toBe("skipped")
+    if (result.verdict !== "skipped") throw new Error("unreachable")
+    expect(result.reason).toMatch(/worthless|payable/i)
+  })
+
+  it("🔴 refuses a line whose provenance is not `recorded`", () => {
+    // `not_recorded` means the run was never written down, so nothing here can
+    // say whether the line is stale. Guessing rewrites a payout blind.
+    for (const provenance of ["not_recorded", "no_run", null]) {
+      const result = assessDraftLine(
+        line({ run_provenance: provenance }),
+        expected({ amount: 1 })
+      )
+      expect(result.verdict).toBe("skipped")
+    }
+  })
+
+  it("🔴 does not infer provenance from the run ids", () => {
+    // The whole reason `run_provenance` exists is that `production_run_ids`
+    // meant three different things. A line naming runs but flagged
+    // `not_recorded` must still be skipped.
+    const result = assessDraftLine(
+      line({ run_provenance: "not_recorded", production_run_ids: ["run_1"] }),
+      expected({ amount: 1 })
+    )
+    expect(result.verdict).toBe("skipped")
+  })
+
+  it("refuses a `recorded` line that names no runs", () => {
+    const result = assessDraftLine(
+      line({ production_run_ids: [] }),
+      expected({ amount: 1 })
+    )
+    expect(result.verdict).toBe("skipped")
+    if (result.verdict !== "skipped") throw new Error("unreachable")
+    expect(result.reason).toMatch(/names no runs/i)
+  })
+
+  it("🔴 refuses a line that collapses several runs into one figure", () => {
+    // Re-pricing from one run's payout would bill one run's work as though it
+    // were all of it — #1554 arrived at from the other direction.
+    const result = assessDraftLine(
+      line({ production_run_ids: ["run_1", "run_2"] }),
+      expected({ amount: 840 })
+    )
+    expect(result.verdict).toBe("skipped")
+    if (result.verdict !== "skipped") throw new Error("unreachable")
+    expect(result.reason).toContain("2 runs")
+  })
+
+  it("treats a null amount as drift rather than as a match", () => {
+    // An unpriced draft line against an eligible run is exactly what the
+    // sweep is for; `null == 0` style leniency would hide it.
+    const result = assessDraftLine(line({ amount: null }), expected())
+    expect(result.verdict).toBe("stale")
+  })
+})
+
+describe("summarizeDraftSweep", () => {
+  it("says plainly when there was nothing to examine", () => {
+    expect(
+      summarizeDraftSweep({ examined: 0, stale: 0, current: 0, skipped: 0, dryRun: true })
+    ).toMatch(/no unclaimed draft/i)
+  })
+
+  it("🔴 reports skipped as its own number, not folded into examined", () => {
+    // "3 of 200 stale" while 150 were unknowable tells the operator the
+    // opposite of the truth about the sweep's own coverage.
+    const out = summarizeDraftSweep({
+      examined: 200,
+      stale: 3,
+      current: 47,
+      skipped: 150,
+      dryRun: true,
+    })
+    expect(out).toContain("150 skipped")
+    expect(out).toContain("3 would be re-priced")
+  })
+
+  it("says nothing about skipping when nothing was skipped", () => {
+    const out = summarizeDraftSweep({
+      examined: 10, stale: 1, current: 9, skipped: 0, dryRun: false,
+    })
+    expect(out).not.toMatch(/skipped/i)
+    expect(out).toContain("1 re-priced")
+  })
+
+  it("distinguishes a dry run from an apply in words, not just a flag", () => {
+    const dry = summarizeDraftSweep({ examined: 5, stale: 2, current: 3, skipped: 0, dryRun: true })
+    const wet = summarizeDraftSweep({ examined: 5, stale: 2, current: 3, skipped: 0, dryRun: false })
+    expect(dry).toContain("would be re-priced")
+    expect(wet).toContain("re-priced")
+    expect(wet).not.toContain("would be")
+  })
+})

--- a/apps/backend/src/api/admin/ops/maintenance-jobs/lib/stale-draft-payout.ts
+++ b/apps/backend/src/api/admin/ops/maintenance-jobs/lib/stale-draft-payout.ts
@@ -1,0 +1,174 @@
+/**
+ * Which unclaimed Draft payouts no longer match the run they were priced from.
+ *
+ * ## The gap this closes
+ *
+ * `refreshUnclaimedDraftPayouts` re-prices a Draft when a run's money is
+ * corrected — but it fires from exactly ONE place: the admin production-run
+ * PATCH route. So a Draft is only ever re-priced if somebody happens to correct
+ * that run through that route, in that session. Nothing sweeps.
+ *
+ * Every other way a run's figures move leaves the Draft untouched and looking
+ * authoritative: a correction made before that route existed, a run edited by
+ * an ops job, a `produced_quantity` written by run completion after the draft
+ * was raised. There is no event that revisits a Draft, and there is no route
+ * that could fix one either — a submission has GET and `review`, and `review`
+ * refuses anything that is not Pending or Under_Review.
+ *
+ * ## The decision is pure, and it is a COMPARISON, not a re-derivation
+ *
+ * The expected figures come from `assessRunPayout` — the same function the
+ * subscriber drafted with and the same one the correction path re-prices with.
+ * This file never computes a payout of its own. If it did, a sweep could
+ * quietly change the BASIS of a figure (it bills ordered, not produced) and
+ * report the difference as a repair.
+ */
+
+/** What a Draft line currently says. */
+export type DraftPayoutLine = {
+  item_id: string
+  submission_id: string
+  design_id: string | null
+  /** The runs this line claims to pay for. */
+  production_run_ids: string[]
+  run_provenance: string | null
+  amount: number | null
+  quantity: number | null
+  unit_amount: number | null
+}
+
+/** What the run says it should say. From `assessRunPayout`, never recomputed. */
+export type ExpectedPayout = {
+  eligible: boolean
+  amount: number
+  quantity: number
+  unit_amount: number
+}
+
+export type StaleDraftVerdict =
+  | { verdict: "stale"; reason: string; expected: ExpectedPayout }
+  | { verdict: "current" }
+  | { verdict: "skipped"; reason: string }
+
+const near = (a: unknown, b: unknown): boolean => {
+  const x = Number(a)
+  const y = Number(b)
+  if (!Number.isFinite(x) || !Number.isFinite(y)) return false
+  // Money is stored to 2dp; a bigNumber round-trip can leave a hair of float.
+  return Math.abs(x - y) < 0.005
+}
+
+/**
+ * PURE: does this Draft line still match its run?
+ *
+ * 🔴 Every ambiguous case is `skipped`, never `stale`. A sweep that repairs on
+ * a guess rewrites what somebody is owed, and the whole reason this is a job
+ * rather than a subscriber is that a human reads its dry run first.
+ */
+export function assessDraftLine(
+  line: DraftPayoutLine,
+  expected: ExpectedPayout
+): StaleDraftVerdict {
+  /**
+   * 🔴 `not_recorded` means "this paid for run work whose run was never
+   * written down" — the line cannot be matched to a run at all, so nothing
+   * here can say whether it is stale. `production_run_ids` being non-empty is
+   * NOT enough on its own: that column meant three different things before
+   * `run_provenance` existed, and re-deriving the distinction from it is
+   * exactly the ambiguity that column was added to end.
+   */
+  if (line.run_provenance !== "recorded") {
+    return {
+      verdict: "skipped",
+      reason: `run provenance is "${line.run_provenance ?? "unset"}" — this line cannot be matched to a run, so whether it is stale is unknowable.`,
+    }
+  }
+
+  if (!line.production_run_ids?.length) {
+    return {
+      verdict: "skipped",
+      reason:
+        'line claims "recorded" provenance but names no runs — it cannot back its own claim, so it is left for a human.',
+    }
+  }
+
+  /**
+   * A line can collapse SEVERAL runs of one design into one figure. Re-pricing
+   * that from a single run's payout would bill one run's work as though it
+   * were all of it — the same class of error as #1554, arrived at from the
+   * other direction.
+   */
+  if (line.production_run_ids.length > 1) {
+    return {
+      verdict: "skipped",
+      reason: `line collapses ${line.production_run_ids.length} runs into one figure; a single run's payout cannot re-price it.`,
+    }
+  }
+
+  /**
+   * 🔴 Not eligible is not "worth zero". A run whose rate was cleared or which
+   * was reopened has no payable figure at all, and writing 0 would read as a
+   * decision that the work was worthless — the #1564 mistake exactly.
+   */
+  if (!expected.eligible) {
+    return {
+      verdict: "skipped",
+      reason:
+        "the run no longer yields a payable figure (rate cleared, or reopened). Zeroing the draft would claim the work was worthless.",
+    }
+  }
+
+  const diffs: string[] = []
+  if (!near(line.amount, expected.amount)) {
+    diffs.push(`amount ${fmt(line.amount)} → ${fmt(expected.amount)}`)
+  }
+  if (!near(line.quantity, expected.quantity)) {
+    diffs.push(`quantity ${fmt(line.quantity)} → ${fmt(expected.quantity)}`)
+  }
+  if (!near(line.unit_amount, expected.unit_amount)) {
+    diffs.push(`unit ${fmt(line.unit_amount)} → ${fmt(expected.unit_amount)}`)
+  }
+
+  if (!diffs.length) return { verdict: "current" }
+
+  return {
+    verdict: "stale",
+    reason: `run ${line.production_run_ids[0]} now says ${diffs.join(", ")}`,
+    expected,
+  }
+}
+
+const fmt = (n: unknown): string =>
+  n === null || n === undefined ? "unset" : String(Number(n))
+
+/**
+ * PURE: one sentence an operator can act on.
+ *
+ * ⚠️ Skipped is reported as its own number rather than folded into "examined".
+ * A sweep that says "3 of 200 stale" while 150 were unknowable has told the
+ * operator the opposite of the truth about its own coverage.
+ */
+export function summarizeDraftSweep(input: {
+  examined: number
+  stale: number
+  current: number
+  skipped: number
+  dryRun: boolean
+}): string {
+  const { examined, stale, current, skipped, dryRun } = input
+
+  if (!examined) {
+    return "No unclaimed Draft payout lines to examine."
+  }
+
+  const verb = dryRun ? "would be re-priced" : "re-priced"
+  const parts = [
+    `${examined} draft line${examined === 1 ? "" : "s"} examined`,
+    `${stale} ${verb}`,
+    `${current} already current`,
+  ]
+  if (skipped) {
+    parts.push(`${skipped} skipped as unknowable or ambiguous (see changes)`)
+  }
+  return parts.join(", ") + "."
+}

--- a/apps/backend/src/api/admin/ops/maintenance-jobs/refresh-stale-draft-payouts-job.ts
+++ b/apps/backend/src/api/admin/ops/maintenance-jobs/refresh-stale-draft-payouts-job.ts
@@ -1,0 +1,266 @@
+import { PAYMENT_SUBMISSIONS_MODULE } from "../../../../modules/payment_submissions"
+import { assessRunPayout } from "../../../../workflows/production-runs/lib/run-payable"
+import {
+  assessDraftLine,
+  summarizeDraftSweep,
+  type DraftPayoutLine,
+  type ExpectedPayout,
+} from "./lib/stale-draft-payout"
+import type {
+  MaintenanceChange,
+  MaintenanceJob,
+  MaintenanceJobResult,
+} from "./registry"
+
+/**
+ * Data Plumbing — re-price unclaimed Draft payouts that no longer match their run.
+ *
+ * ## The gap this closes
+ *
+ * `refreshUnclaimedDraftPayouts` already exists and is correct. It fires from
+ * exactly ONE place: the admin production-run PATCH route. So a Draft is
+ * re-priced only if somebody happens to correct that run through that route.
+ * Nothing sweeps, and nothing ever revisits a Draft raised before a correction
+ * arrived by any other path — an ops job, run completion writing
+ * `produced_quantity`, or a correction made before that route existed.
+ *
+ * 🔴 There is no route that could repair one either. A submission has GET and
+ * `review`, and `review` refuses anything that is not Pending or Under_Review,
+ * so a stale Draft cannot be edited, rejected or discarded through the API at
+ * all. On production one such Draft sat at ₹1,190/unit against a run since
+ * corrected to ₹840 total — and a reviewer would have approved it.
+ *
+ * ## It is an instrument before it is a repair
+ *
+ * The dry run is the point. Every row states the run it measured against and
+ * the figures on both sides, so a wrong row is visible without re-deriving the
+ * sweep by hand. Rows it CANNOT judge are reported as their own count, not
+ * folded into "examined" — a sweep that says "3 of 200 stale" while 150 were
+ * unknowable has told the operator the opposite of the truth about its own
+ * coverage.
+ *
+ * ## Draft, and only ever Draft
+ *
+ * ⚠️ A Draft is system-written and unsubmitted: nobody has claimed it, so
+ * re-pricing takes nothing away from anyone. Every other status is a live claim
+ * — a partner has asked for that amount, or it has been approved or paid — and
+ * silently rewriting one would change what somebody is owed without them
+ * seeing it. Those are never touched, by this job or by the correction path.
+ *
+ * The expected figures come from `assessRunPayout`, the same function the
+ * subscriber drafted with and the correction path re-prices with, so a sweep
+ * cannot quietly change the BASIS of a figure (it bills ordered, not produced).
+ */
+export const refreshStaleDraftPayoutsJob: MaintenanceJob = {
+  id: "refresh-stale-draft-payouts",
+  label: "Re-price stale Draft payouts",
+  description:
+    "Find unclaimed DRAFT payment submissions whose figures no longer match the production run they were pre-filled from, and re-price them. Re-pricing already happens when a run is corrected through the admin route, but that is the only trigger there is — a draft raised before a correction arrived by any other path (an ops job, run completion writing produced_quantity) keeps its old numbers and goes on looking authoritative, and no route can fix it because `review` refuses anything that is not Pending or Under_Review. Expected figures come from `assessRunPayout`, the same function that drafted them, so the BASIS never changes — only the inputs. ONLY ever touches status Draft: every other status is a live claim somebody has made and must not be rewritten under them. Reports rows it cannot judge (a line collapsing several runs, a line whose run provenance is not `recorded`, a run with no payable figure) as skipped WITH the reason, rather than guessing. Creates nothing, pays nothing, emails nobody. Safe to re-run.",
+  params: [
+    {
+      name: "design_id",
+      type: "string",
+      required: false,
+      description:
+        "Limit to one design's draft lines. Omit to sweep every unclaimed draft.",
+    },
+    {
+      name: "limit",
+      type: "number",
+      required: false,
+      description: "Maximum draft lines to examine (default 500).",
+    },
+  ],
+
+  async run(container: any, opts): Promise<MaintenanceJobResult> {
+    const service: any = container.resolve(PAYMENT_SUBMISSIONS_MODULE)
+    const runService: any = container.resolve("production_runs")
+
+    const designId = opts.params?.design_id
+      ? String(opts.params.design_id)
+      : null
+    const limit = Math.min(Number(opts.params?.limit ?? 500) || 500, 2000)
+
+    const changes: MaintenanceChange[] = []
+    const errors: Array<{ id: string; message: string }> = []
+
+    /**
+     * 🔴 Filtered explicitly, never `{ design_id: undefined }`. That shape is
+     * NO filter rather than "no rows" (#1433) — here it would silently widen a
+     * one-design repair into a sweep of every draft on the platform.
+     */
+    const filters: Record<string, any> = {}
+    if (designId) filters.design_id = [designId]
+
+    const items = (await service.listPaymentSubmissionItems(filters, {
+      relations: ["submission"],
+      take: limit,
+    })) as any[]
+
+    let examined = 0
+    let stale = 0
+    let current = 0
+    let skipped = 0
+
+    // One run lookup per run, not per line — a design with many drafts would
+    // otherwise re-fetch the same run for each of them.
+    const payoutCache = new Map<string, ExpectedPayout | null>()
+
+    for (const item of items || []) {
+      // Draft is the only status this job may consider AT ALL, so the filter
+      // is here rather than in the verdict: a live claim must not even appear
+      // in the report as something that "would be re-priced".
+      if (String(item?.submission?.status || "") !== "Draft") continue
+
+      examined++
+
+      const line: DraftPayoutLine = {
+        item_id: String(item.id),
+        submission_id: String(item.submission?.id || item.submission_id || ""),
+        design_id: item.design_id ? String(item.design_id) : null,
+        production_run_ids: Array.isArray(item.production_run_ids)
+          ? (item.production_run_ids as string[]).map(String)
+          : [],
+        run_provenance: item.run_provenance ?? null,
+        amount: item.amount == null ? null : Number(item.amount),
+        quantity: item.quantity == null ? null : Number(item.quantity),
+        unit_amount: item.unit_amount == null ? null : Number(item.unit_amount),
+      }
+
+      const runId = line.production_run_ids[0]
+      let expected: ExpectedPayout = {
+        eligible: false,
+        amount: 0,
+        quantity: 0,
+        unit_amount: 0,
+      }
+
+      if (runId && line.run_provenance === "recorded") {
+        if (!payoutCache.has(runId)) {
+          try {
+            const run = await runService.retrieveProductionRun(runId)
+            const payout = assessRunPayout(run)
+            /**
+             * 🔑 Narrowed on `eligible`, because the ineligible branch of
+             * `PayoutEligibility` carries only a `reason` — it has no money
+             * fields at all. Reading `payout.amount` off the union would have
+             * been `undefined` at runtime and `Number(undefined) || 0` turns
+             * that into a confident ZERO, which is the one value this job must
+             * never write. tsc caught it; no test would have.
+             */
+            payoutCache.set(
+              runId,
+              payout.eligible
+                ? {
+                    eligible: true,
+                    amount: Number(payout.amount) || 0,
+                    quantity: Number(payout.quantity) || 0,
+                    unit_amount: Number(payout.unit_amount) || 0,
+                  }
+                : { eligible: false, amount: 0, quantity: 0, unit_amount: 0 }
+            )
+          } catch (e: any) {
+            // A named run we cannot read is a REPORTED failure, not a silent
+            // skip: the line claims that run and we could not check it.
+            payoutCache.set(runId, null)
+            errors.push({
+              id: line.submission_id || line.item_id,
+              message: `run ${runId} could not be read: ${e?.message ?? e}`,
+            })
+          }
+        }
+        const cached = payoutCache.get(runId)
+        if (cached === null) {
+          skipped++
+          continue
+        }
+        if (cached) expected = cached
+      }
+
+      const verdict = assessDraftLine(line, expected)
+
+      if (verdict.verdict === "current") {
+        current++
+        continue
+      }
+
+      if (verdict.verdict === "skipped") {
+        skipped++
+        changes.push({
+          entity: "payment_submission_item",
+          id: line.item_id,
+          field: "skipped",
+          before: line.amount,
+          after: line.amount,
+          reason: verdict.reason,
+        } as MaintenanceChange)
+        continue
+      }
+
+      stale++
+      changes.push({
+        entity: "payment_submission_item",
+        id: line.item_id,
+        field: "amount",
+        before: line.amount,
+        after: verdict.expected.amount,
+        reason: verdict.reason,
+      } as MaintenanceChange)
+
+      if (opts.dry_run) continue
+
+      try {
+        await service.updatePaymentSubmissionItems({
+          id: line.item_id,
+          amount: verdict.expected.amount,
+          quantity: verdict.expected.quantity,
+          unit_amount: verdict.expected.unit_amount,
+        })
+
+        /**
+         * The submission total is STORED, not derived, so it has to move too.
+         * A line and a header that disagree is worse than either being wrong
+         * alone — a reviewer reads the header.
+         */
+        if (line.submission_id) {
+          const siblings = (await service.listPaymentSubmissionItems(
+            { submission_id: line.submission_id },
+            {}
+          )) as any[]
+          const total = (siblings || []).reduce(
+            (sum: number, s: any) =>
+              sum +
+              (String(s.id) === line.item_id
+                ? verdict.expected.amount
+                : Number(s.amount) || 0),
+            0
+          )
+          await service.updatePaymentSubmissions({
+            id: line.submission_id,
+            total_amount: Math.round(total * 100) / 100,
+          })
+        }
+      } catch (e: any) {
+        errors.push({
+          id: line.submission_id || line.item_id,
+          message: `re-price failed: ${e?.message ?? e}`,
+        })
+      }
+    }
+
+    return {
+      job_id: "refresh-stale-draft-payouts",
+      dry_run: opts.dry_run,
+      applied: !opts.dry_run && stale > 0,
+      summary: summarizeDraftSweep({
+        examined,
+        stale,
+        current,
+        skipped,
+        dryRun: opts.dry_run,
+      }),
+      changes,
+      errors: errors.length ? errors : undefined,
+    }
+  },
+}

--- a/apps/backend/src/api/admin/ops/maintenance-jobs/registry.ts
+++ b/apps/backend/src/api/admin/ops/maintenance-jobs/registry.ts
@@ -130,6 +130,7 @@ import { normalizeArtisanProductsJob } from "./normalize-artisan-products-job"
 import { linkArtisanDetailRowsJob } from "./link-artisan-detail-rows-job"
 import { setPlatformTaxIdentityActiveJob } from "./set-platform-tax-identity-active-job"
 import { backfillFulfilledRetailRunsJob } from "./backfill-fulfilled-retail-runs-job"
+import { refreshStaleDraftPayoutsJob } from "./refresh-stale-draft-payouts-job"
 import {
   sweepAiPlatformsByCategory,
   AI_ROLES,
@@ -5806,6 +5807,7 @@ export const MAINTENANCE_JOBS: MaintenanceJob[] = [
   cancelInactiveProductionRunsJob,
   warnExpiringProductionRunsJob,
   remirrorCancelledRunStatusJob,
+  refreshStaleDraftPayoutsJob,
   cleanOrderFulfillmentDataJob,
   sendCourierChangedEmailJob,
   resendShipmentEmailJob,


### PR DESCRIPTION
`refreshUnclaimedDraftPayouts` is correct, and fires from exactly **one** place: the admin production-run PATCH route. So a Draft is re-priced only if somebody happens to correct that run through that route, in that session. **Nothing sweeps.**

Every other way a run's money moves leaves the Draft untouched and looking authoritative — a correction made by an ops job, run completion writing `produced_quantity` after the draft was raised, or anything predating the route. On production one such Draft sat at **₹1,190/unit** against a run since corrected to **₹840 total for 1 piece**. Nothing in the system disagreed with it, and a reviewer would have approved it.

### 🔴 And no route could repair one

A submission has `GET` and `review`, and `review` refuses anything that is not `Pending` or `Under_Review` — so a stale Draft cannot be edited, rejected or discarded through the API at all. A maintenance job isn't a convenience here; it's the only reachable surface.

### It is an instrument before it is a repair

The dry run is the point. Every row states the run it measured against and both figures, so a wrong row is visible without re-deriving the sweep by hand.

⚠️ Rows it **cannot** judge are counted separately, never folded into "examined". A sweep reporting *"3 of 200 stale"* while 150 were unknowable has told the operator the opposite of the truth about its own coverage.

### What it refuses to decide

| Case | Why it's skipped, not repaired |
|---|---|
| `run_provenance` is not `recorded` | The run was never written down, so whether the line is stale is unknowable. 🔴 **Not** inferred from `production_run_ids` — that column meant three different things, which is exactly why `run_provenance` exists; re-deriving it recreates the ambiguity. |
| Line collapses several runs | Re-pricing from one run's payout bills one run's work as though it were all of it — #1554 from the other direction. |
| Run has no payable figure | Writing `0` would claim the work was worthless (#1564). Left alone, loudly. |
| Anything not `Draft` | A Draft is system-written and unclaimed. Every other status is a live claim somebody made and must not be rewritten under them. |

Expected figures come from `assessRunPayout` — the same function the subscriber drafted with and the correction path re-prices with — so a sweep cannot quietly change the **basis** of a figure (it bills ordered, not produced). Only the inputs move.

### 🔑 tsc caught what no test would have

`PayoutEligibility` is a discriminated union whose ineligible branch carries only a `reason`. Reading `payout.amount` off the union was `undefined` at runtime, and `Number(undefined) || 0` turns that into a confident **zero** — the one value this job must never write. Narrowed on `eligible`.

### Verify

- 14 unit tests green over the pure decision logic (`stale-draft-payout.unit.spec.ts`)
- backend `tsc`: no error in any new file (79 total, inside the known 79/80 `.medusa`-dependent baseline)
- Run `dry_run` first. Point it at a single `design_id` before sweeping everything.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01TLt1f38xqR8k2myCVxP8e4