### PR TITLE
test(quotes): the design picker spec pinned the contract #1588 removed (#1486)

### DIFF
--- a/apps/backend/integration-tests/http/partner-quote-design-lines.spec.ts
+++ b/apps/backend/integration-tests/http/partner-quote-design-lines.spec.ts
@@ -287,11 +287,30 @@ setupSharedTestSuite(() => {
       expect(backed?.quotable).toBe(true)
       expect(backed?.variant_id).toBe(seed.variantA.id)
 
-      // The unquotable one is LISTED, not hidden — with the reason on it.
+      /**
+       * A design with no product is LISTED, and it is no longer a problem.
+       *
+       * 🔴 This assertion used to demand the reason "no product behind it yet
+       * … create a product from the design first". That was the contract until
+       * custom designs became quotable: such a design is now MADE TO ORDER —
+       * ticking it mints the variant it will be quoted through, priced from
+       * comparable work.
+       *
+       * So `reason` is deliberately null. A reason string renders as an error
+       * in every UI that shows one, and there is nothing wrong with this row;
+       * the `made_to_order` FLAG is what the picker labels it with. Asserting
+       * the old words here would pin the behaviour the change exists to
+       * remove.
+       *
+       * ⚠️ `quotable` stays FALSE, and that is not a contradiction. It means
+       * "a variant backs this today". The two flags answer different questions
+       * and the picker renders them differently.
+       */
       const sketch = byId.get(sketchDesignId) as any
       expect(sketch).toBeTruthy()
       expect(sketch.quotable).toBe(false)
-      expect(String(sketch.reason)).toContain("no product behind it")
+      expect(sketch.made_to_order).toBe(true)
+      expect(sketch.reason).toBeNull()
     })
 
     const countQuotes = async () => {


### PR DESCRIPTION
**main is red at `138e90f6`** — the squash of #1588 — on **shard 4**. #1588's own checks were green because a PR runs one shard of eight, and this spec isn't in shard 1.

```
expect(String(sketch.reason)).toContain("no product behind it")
Received string: "null"
    at partner-quote-design-lines.spec.ts:294
```

The spec asserted that a design with no product behind it carries the reason *"no product behind it yet … create a product from the design first"*. That **was** the contract — and it's the exact contract #1588 removed: such a design is now **made-to-order**, and ticking it mints the variant it will be quoted through.

So `reason` is deliberately `null`. A reason string renders as an error in every UI that shows one, and there is nothing wrong with the row — the `made_to_order` flag is what the picker labels it with.

⚠️ The assertion now also pins that `quotable` stays **false**, which is not a contradiction: it means *"a variant backs this today"*. The two flags answer different questions and the picker renders them differently.

### 🔑 Why only one of the three assertions in this file broke

The other two — *"refuses a design with no product behind it, and writes nothing"* — still pass, and correctly. Minting is best-effort: a design the estimator cannot price gets no variant, the resolver still refuses the basket, and the 400 still carries those words. Only the **picker** changed, because the picker deliberately does not price (an estimator run per row is how a picker that feels fine against a seed becomes unusable against a real catalogue).

That the file split three ways under the change is the reassuring part: the refusal path is untouched and still proven.

### Verify

`test (4)` is the shard that matters here. Its previous run on main is the baseline: `1 failed, 51 passed`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01TLt1f38xqR8k2myCVxP8e4