### PR TITLE
fix(quotes): the mint routes never read their body — every pick 400'd (#1486)

### DIFF
--- a/apps/backend/src/admin/routes/quotes/create/steps/products-step.tsx
+++ b/apps/backend/src/admin/routes/quotes/create/steps/products-step.tsx
@@ -175,6 +175,22 @@ export const ProductsStep = ({ form }: Props) => {
       return
     }
 
+    /**
+     * ⚠️ The form's `currency_code` starts EMPTY and is set on the buyer step.
+     * The wizard reaches this step after that one, so it is normally filled —
+     * but firing the request anyway when it is not turns a missing selection
+     * into a 400 from the server, which reads as a broken picker rather than
+     * an unfinished form.
+     */
+    if (!watchedCurrency) {
+      setMintErrors((prev) => ({
+        ...prev,
+        [design.id]:
+          "Choose the quote's currency on the buyer step first — a made-to-order variant has to be listed in it.",
+      }))
+      return
+    }
+
     setMinting(design.id)
     setMintErrors((prev) => {
       const next = { ...prev }

--- a/apps/backend/src/api/admin/quotes/designs/[designId]/variant/route.ts
+++ b/apps/backend/src/api/admin/quotes/designs/[designId]/variant/route.ts
@@ -16,21 +16,21 @@ import { ensureDesignQuoteVariantWorkflow } from "../../../../../../workflows/pa
  */
 export const POST = async (req: MedusaRequest, res: MedusaResponse) => {
   const designId = String(req.params.designId)
-  const currencyCode = String(
-    (req.validatedBody as any)?.currency_code ?? req.query.currency_code ?? ""
-  )
-
-  if (!currencyCode) {
-    return res.status(400).json({
-      error:
-        "currency_code is required — the variant has to be listed in the currency the quote is denominated in.",
-    })
-  }
+  /**
+   * 🔑 `validatedBody`, populated by `validateAndTransformBody` in
+   * `middlewares.ts` — and by nothing else. Both routes were registered
+   * without it, so this read was always undefined, the client's JSON sat in
+   * `req.body` unread, and every pick answered "currency_code is required".
+   * The schema now enforces the requirement, so there is no hand-rolled check
+   * here to drift from it.
+   */
+  const body = req.validatedBody as { currency_code: string; markup_percent?: number }
 
   const { result } = await ensureDesignQuoteVariantWorkflow(req.scope).run({
     input: {
       design_id: designId,
-      currency_code: currencyCode,
+      currency_code: body.currency_code,
+      markup_percent: body.markup_percent,
       partner_id: null,
     },
   })

--- a/apps/backend/src/api/middlewares.ts
+++ b/apps/backend/src/api/middlewares.ts
@@ -308,7 +308,7 @@ import { BulkImportSchema } from "./admin/inventory-items/bulk-import/validators
 import { PartnerCreateStoreReq } from "./partners/stores/validators";
 import { PartnerCreateProductReq, PartnerArtisanProductDetailReq, PartnerProductSpecReq, PartnerStoreCreateProductReq, PartnerQuickCreateProductReq } from "./partners/products/validators";
 import { PartnerCreatePriceListReq, PartnerUpdatePriceListReq } from "./partners/price-lists/validators";
-import { AdjustQuoteReq, PartnerMintQuoteReq, QuoteReadinessReq } from "./partners/quotes/validators";
+import { AdjustQuoteReq, MintDesignVariantReq, PartnerMintQuoteReq, QuoteReadinessReq } from "./partners/quotes/validators";
 import { PartnerPostInquiryAnswersReq, PartnerPostInquirySubmitReq, PartnerListInquiriesQuery, PartnerPostCapabilitySampleReq, PartnerListCapabilitySamplesQuery } from "./partners/inquiries/validators";
 import { AdminMintQuoteReq, AdminQuoteReadinessReq } from "./admin/quotes/validators";
 import { BATCH_VARIANT_FIELDS } from "../workflows/partner/batch-partner-variants";
@@ -5766,6 +5766,14 @@ export default defineMiddlewares({
       middlewares: [
         createCorsPartnerMiddleware(),
         authenticate("partner", ["session", "bearer"]),
+        /**
+         * 🔴 Without this the route reads NOTHING. `req.validatedBody` is
+         * populated by this middleware and by nothing else, so the client's
+         * JSON sat in `req.body` unread and every pick answered
+         * "currency_code is required" — a message that was true about the
+         * requirement and wrong about the cause.
+         */
+        validateAndTransformBody(wrapSchema(MintDesignVariantReq)),
       ],
     },
     // Admin quotes (#1389 S5). Same capability as the partner surface, but the
@@ -5782,12 +5790,16 @@ export default defineMiddlewares({
         validateAndTransformBody(wrapSchema(AdminQuoteReadinessReq)),
       ],
     },
-    // The admin twin of the made-to-order mint. No auth entry needed — the
-    // /admin surface authenticates globally, unlike /partners.
+    /**
+     * The admin twin of the made-to-order mint. No auth entry needed — the
+     * /admin surface authenticates globally, unlike /partners — but the body
+     * validator is NOT optional: an empty middleware list leaves
+     * `req.validatedBody` undefined and the route reads nothing.
+     */
     {
       matcher: "/admin/quotes/designs/:designId/variant",
       method: "POST",
-      middlewares: [],
+      middlewares: [validateAndTransformBody(wrapSchema(MintDesignVariantReq))],
     },
     // An admin corrects any quote in place, before acceptance. Same body as the
     // partner surface — the refusals live in `adjustQuote` so they cannot drift.

--- a/apps/backend/src/api/partners/quotes/__tests__/mint-design-variant-req.unit.spec.ts
+++ b/apps/backend/src/api/partners/quotes/__tests__/mint-design-variant-req.unit.spec.ts
@@ -1,0 +1,59 @@
+/**
+ * 🔴 The route reads `req.validatedBody`, which ONLY
+ * `validateAndTransformBody` populates. Both mint routes were registered
+ * without it, so that read was always `undefined`, the client's JSON sat in
+ * `req.body` unread, and every made-to-order pick answered:
+ *
+ *   400 "currency_code is required — the variant has to be listed in the
+ *        currency the quote is denominated in."
+ *
+ * The message was true about the requirement and wrong about the cause, which
+ * sends you looking at the form for a field the form was sending correctly.
+ *
+ * These cases pin the schema. They cannot pin the WIRING — a schema that is
+ * never referenced in `middlewares.ts` would pass every test here while the
+ * route reads nothing, which is exactly the state this fixes. The middleware
+ * entry is the other half and has to be read, not assumed.
+ */
+import { MintDesignVariantReq } from "../validators"
+
+describe("MintDesignVariantReq", () => {
+  it("accepts what the pickers actually post", () => {
+    const parsed = MintDesignVariantReq.parse({ currency_code: "inr" })
+    expect(parsed.currency_code).toBe("inr")
+  })
+
+  it("carries an optional markup for ops", () => {
+    expect(
+      MintDesignVariantReq.parse({ currency_code: "usd", markup_percent: 35 })
+        .markup_percent
+    ).toBe(35)
+  })
+
+  it("refuses a missing currency, with the words the UI shows", () => {
+    const result = MintDesignVariantReq.safeParse({})
+    expect(result.success).toBe(false)
+    if (result.success) throw new Error("unreachable")
+    expect(JSON.stringify(result.error.issues)).toContain("currency_code is required")
+  })
+
+  it("refuses an EMPTY currency, which is what an unfinished form sends", () => {
+    // The admin form's `currency_code` starts as "" and is set on the buyer
+    // step. An empty string is not a currency and must not reach the mint.
+    expect(MintDesignVariantReq.safeParse({ currency_code: "" }).success).toBe(false)
+  })
+
+  it("refuses a negative markup", () => {
+    expect(
+      MintDesignVariantReq.safeParse({ currency_code: "inr", markup_percent: -10 })
+        .success
+    ).toBe(false)
+  })
+
+  it("allows a zero markup — quoting at cost is a choice, not an error", () => {
+    expect(
+      MintDesignVariantReq.safeParse({ currency_code: "inr", markup_percent: 0 })
+        .success
+    ).toBe(true)
+  })
+})

--- a/apps/backend/src/api/partners/quotes/designs/[designId]/variant/route.ts
+++ b/apps/backend/src/api/partners/quotes/designs/[designId]/variant/route.ts
@@ -40,21 +40,21 @@ export const POST = async (
   }
 
   const designId = String(req.params.designId)
-  const currencyCode = String(
-    (req.validatedBody as any)?.currency_code ?? req.query.currency_code ?? ""
-  )
-
-  if (!currencyCode) {
-    return res.status(400).json({
-      error:
-        "currency_code is required — the variant has to be listed in the currency the quote is denominated in.",
-    })
-  }
+  /**
+   * 🔑 `validatedBody`, populated by `validateAndTransformBody` in
+   * `middlewares.ts` — and by nothing else. Both routes were registered
+   * without it, so this read was always undefined, the client's JSON sat in
+   * `req.body` unread, and every pick answered "currency_code is required".
+   * The schema now enforces the requirement, so there is no hand-rolled check
+   * here to drift from it.
+   */
+  const body = req.validatedBody as { currency_code: string; markup_percent?: number }
 
   const { result } = await ensureDesignQuoteVariantWorkflow(req.scope).run({
     input: {
       design_id: designId,
-      currency_code: currencyCode,
+      currency_code: body.currency_code,
+      markup_percent: body.markup_percent,
       // Scoped: a partner may only quote designs they own or are assigned to.
       partner_id: partner.id,
     },

--- a/apps/backend/src/api/partners/quotes/validators.ts
+++ b/apps/backend/src/api/partners/quotes/validators.ts
@@ -345,3 +345,49 @@ export const QuoteReadinessReq = QuoteReadinessShape.superRefine(
 )
 
 export type QuoteReadinessReqType = z.infer<typeof QuoteReadinessReq>
+
+/**
+ * Minting the made-to-order variant a custom design is quoted through (#1486).
+ *
+ * 🔴 This schema is not decoration — without it the route reads nothing at all.
+ * Both mint routes were registered with no `validateAndTransformBody`, so
+ * `req.validatedBody` was never populated; the client's JSON sat in `req.body`
+ * unread, the route fell through to a `currency_code` query param nobody sends,
+ * and every pick answered:
+ *
+ *   400 "currency_code is required — the variant has to be listed in the
+ *        currency the quote is denominated in."
+ *
+ * The message was true about the requirement and wrong about the cause, which
+ * is the worst kind: it sends you looking at the form for a field the form was
+ * sending correctly all along.
+ *
+ * ⚠️ `zodValidator` forces `.strict()`, so this rejects unknown keys. Keep it
+ * matching what the two pickers actually post.
+ */
+export const MintDesignVariantReq = z.object({
+  /**
+   * The quote's currency, not the design's. The estimate behind the price is
+   * denominated in the design's `cost_currency` and is converted on the way
+   * through — see `designQuoteUnitPrice`.
+   */
+  currency_code: z
+    .string({
+      // ⚠️ zod 4 — `error`, not `required_error`. Without it a MISSING key
+      // reports "expected string, received undefined", so the two ways a
+      // caller can omit a currency would explain themselves differently.
+      error:
+        "currency_code is required — the variant has to be listed in the currency the quote is denominated in.",
+    })
+    .min(
+      1,
+      "currency_code is required — the variant has to be listed in the currency the quote is denominated in."
+    ),
+  /**
+   * Override the default uplift on the estimated cost. The wizards do not send
+   * it; ops might.
+   */
+  markup_percent: z.number().min(0).optional(),
+})
+
+export type MintDesignVariantReqType = z.infer<typeof MintDesignVariantReq>

--- a/apps/partner-ui/src/routes/orders/quote-create/components/quote-create-form/quote-designs-panel.tsx
+++ b/apps/partner-ui/src/routes/orders/quote-create/components/quote-create-form/quote-designs-panel.tsx
@@ -79,6 +79,18 @@ export const QuoteDesignsPanel = ({
       return
     }
 
+    // The partner form defaults its currency, so this should never be empty —
+    // but a doomed request reads as a broken picker rather than an unfinished
+    // form, so it is refused here with something actionable instead.
+    if (!currencyCode) {
+      setMintErrors((prev) => ({
+        ...prev,
+        [design.id]:
+          "Choose the quote's currency first — a made-to-order variant has to be listed in it.",
+      }))
+      return
+    }
+
     setMinting(design.id)
     setMintErrors((prev) => {
       const next = { ...prev }


### PR DESCRIPTION
Picking a made-to-order design answered:

```
400 "currency_code is required — the variant has to be listed in the
     currency the quote is denominated in."
```

**The form was sending `currency_code` correctly the whole time.**

### 🔴 The routes never read their body

`req.validatedBody` is populated by `validateAndTransformBody` and by **nothing else**. Both mint routes were registered without it — the partner entry carried only CORS and auth, the admin entry an empty middleware list — so that read was always `undefined`. The client's JSON sat in `req.body` unread, the route fell through to a `currency_code` query param nobody sends, and the hand-rolled check fired on every request.

The message was true about the *requirement* and wrong about the *cause*, which is the worst kind: it sends you looking at the form for a field the form had.

**Both surfaces were broken**, not just admin — the partner route has the same two lines and the same missing middleware.

### The fix

A real schema, wired into both entries, so the requirement lives in one place rather than a hand-rolled check that can drift from it. The routes now read `validatedBody` and pass `markup_percent` through as well — the workflow accepted it and it was being silently dropped at the door, since nothing parsed the body at all.

⚠️ **zod 4**, so the missing-key message needs `error`, not `required_error`. Checked against the installed version rather than assumed — `required_error` yields *"expected string, received undefined"*, which would explain the two ways of omitting a currency differently.

### Also

Both pickers now refuse before sending when no currency is chosen. The admin form's `currency_code` starts **empty** and is set on the buyer step; the wizard reaches the picker after that step, so it is normally filled — but a doomed request reads as a broken picker rather than an unfinished form.

### ⚠️ What these tests cannot prove

They pin the **schema**. They cannot pin the **wiring**: a schema never referenced in `middlewares.ts` would pass every one of them while the route reads nothing — which is precisely the state being fixed. The middleware entry is the other half and has to be read, not assumed. (This is the #1571 shape again: a partner route's auth is per-entry, and `tsc` plus a green suite are both silent about it.)

### Verify

- 6 unit tests on the schema
- backend `tsc` at the 79 baseline, no error in any touched file

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01TLt1f38xqR8k2myCVxP8e4