### PR TITLE
fix(ops): the reconcile report compared a total against a rate (#1559)

### DIFF
--- a/apps/backend/src/api/admin/ops/maintenance-jobs/reconcile-consumption-vs-production-job.ts
+++ b/apps/backend/src/api/admin/ops/maintenance-jobs/reconcile-consumption-vs-production-job.ts
@@ -50,13 +50,15 @@ const paramsSchema = z.object({
   implausible_rate_below: z.number().positive().optional(),
   /** Only return designs carrying at least one flag. Default true. */
   flagged_only: z.boolean().optional(),
+  /** Basis to assume for legacy logs whose quantity_basis is null. */
+  assume_basis: z.enum(["total", "per_piece"]).optional(),
 })
 
 export const reconcileConsumptionVsProductionJob: MaintenanceJob = {
   id: "reconcile-consumption-vs-production",
   label: "Reconcile consumption against production (report-only)",
   description:
-    "Compare what each design PRODUCED against what it reported CONSUMING. Counts completed leaf runs only (#498) and excludes provenance runs minted from retail fulfillment — those shipped from stock and consumed nothing, so counting them invents material. Flags: production with zero material logged, consumption with no production, implausible metres/piece, and logs not attributed to a production run. Reports an expected/variance figure when a per-unit rate is supplied. NEVER writes — correct the log, then run the apply job.",
+    "Compare what each design PRODUCED against what it reported CONSUMING. Counts completed leaf runs only (#498) and excludes provenance runs minted from retail fulfillment — those shipped from stock and consumed nothing, so counting them invents material. Reads each log's quantity_basis and resolves a per_piece rate against the run's piece count before summing, as the apply job does; a log whose basis is unknown is reported as unknown_basis rather than guessed, and the verdicts that depend on a complete total are withheld for that design. Flags: production with zero material logged, consumption with no production, implausible metres/piece, logs not attributed to a production run, and unreadable logs. Reports an expected/variance figure when a per-unit rate is supplied. NEVER writes — correct the log, then run the apply job.",
   params: [
     {
       name: "design_id",
@@ -83,6 +85,13 @@ export const reconcileConsumptionVsProductionJob: MaintenanceJob = {
       required: false,
       description: "Return only designs with at least one flag (default true)",
     },
+    {
+      name: "assume_basis",
+      type: "string",
+      required: false,
+      description:
+        "total | per_piece — how to read logs written before the form recorded a basis. Omit and those logs are reported as unknown_basis rather than guessed.",
+    },
   ],
   run: async (container, { dry_run, params }): Promise<MaintenanceJobResult> => {
     const parsed = paramsSchema.safeParse(params)
@@ -92,8 +101,13 @@ export const reconcileConsumptionVsProductionJob: MaintenanceJob = {
         parsed.error.issues.map((i) => i.message).join("; ")
       )
     }
-    const { design_id, rate_per_unit, implausible_rate_below, flagged_only } =
-      parsed.data
+    const {
+      design_id,
+      rate_per_unit,
+      implausible_rate_below,
+      flagged_only,
+      assume_basis,
+    } = parsed.data
 
     const runService: any = container.resolve(PRODUCTION_RUNS_MODULE)
     const consumptionService: any = container.resolve(CONSUMPTION_LOG_MODULE)
@@ -128,6 +142,10 @@ export const reconcileConsumptionVsProductionJob: MaintenanceJob = {
       inventory_item_id: l.inventory_item_id ?? null,
       production_run_id: l.production_run_id ?? null,
       quantity: l.quantity ?? null,
+      // Projected explicitly: a field the query never fetched reads as
+      // `undefined`, which resolves to "basis unknown" and would report every
+      // design as unreadable.
+      quantity_basis: l.quantity_basis ?? null,
       is_committed: Boolean(l.is_committed),
     }))
 
@@ -136,6 +154,7 @@ export const reconcileConsumptionVsProductionJob: MaintenanceJob = {
       logs,
       ratePerUnit: rate_per_unit,
       implausibleRateBelow: implausible_rate_below,
+      assumeBasisWhenUnknown: assume_basis,
     })
     const rows = flagged_only === false ? all : all.filter((r) => r.flags.length)
 
@@ -144,7 +163,11 @@ export const reconcileConsumptionVsProductionJob: MaintenanceJob = {
     const changes: MaintenanceChange[] = rows.map((r) => ({
       entity: "design",
       id: r.design_id,
-      field: `produced ${r.produced} / shipped-from-stock ${r.shipped_from_stock} [${r.flags.join(", ")}]`,
+      field: `produced ${r.produced} / shipped-from-stock ${r.shipped_from_stock}${
+        r.unresolved_logs
+          ? ` / ${r.unresolved_logs} log(s) unreadable (raw ${r.unresolved_quantity})`
+          : ""
+      } [${r.flags.join(", ")}]`,
       before: r.expected ?? r.produced,
       after: r.consumed,
     }))

--- a/apps/backend/src/workflows/consumption-logs/__tests__/reconcile-production-consumption.unit.spec.ts
+++ b/apps/backend/src/workflows/consumption-logs/__tests__/reconcile-production-consumption.unit.spec.ts
@@ -37,6 +37,7 @@ const denimLogs: ReconcileLog[] = [
     inventory_item_id: "iitem_01KMEYT9C8JSK12TK7ZY0G3WXT",
     production_run_id: null,
     quantity: 2.15,
+    quantity_basis: "total",
     is_committed: true,
   },
 ]
@@ -94,6 +95,7 @@ describe("reconcileDesigns", () => {
           design_id: "d_bakshi",
           inventory_item_id: "iitem_x",
           quantity: 1.75,
+          quantity_basis: "total",
           is_committed: true,
         },
       ],
@@ -111,6 +113,7 @@ describe("reconcileDesigns", () => {
           design_id: "d_partner",
           inventory_item_id: "iitem_y",
           quantity: 2.5,
+          quantity_basis: "total",
           is_committed: true,
         },
       ],
@@ -134,6 +137,7 @@ describe("reconcileDesigns", () => {
           design_id: "d1",
           inventory_item_id: "iitem_z",
           quantity: 99,
+          quantity_basis: "total",
           is_committed: false,
         },
       ],
@@ -182,6 +186,132 @@ describe("reconcileDesigns", () => {
       logs: [],
     })
     expect(out.map((r) => r.design_id)).toEqual(["big", "small"])
+  })
+})
+
+/**
+ * #1559. The prod row that exposed it: design "Embroidered jacket", one log of
+ * `quantity 2.5, quantity_basis per_piece`, against 4 finished pieces. Summing
+ * the raw column compared an expected TOTAL of 10 against a RATE of 2.5 and
+ * reported a 7.5 m shortfall that does not exist — an instruction to "correct"
+ * a log that is already right.
+ */
+describe("reconcileDesigns — quantity_basis (#1559)", () => {
+  const JACKET = "01KWKHSQ8FDGSKNW4FNY3K5FF0"
+  const jacketRuns: ReconcileRun[] = [
+    { id: "run_jacket", design_id: JACKET, status: "completed", produced_quantity: 4 },
+  ]
+  const perPieceLog = (over: Partial<ReconcileLog> = {}): ReconcileLog => ({
+    id: "l1",
+    design_id: JACKET,
+    inventory_item_id: "iitem_j",
+    quantity: 2.5,
+    quantity_basis: "per_piece",
+    is_committed: true,
+    ...over,
+  })
+
+  it("multiplies a per_piece rate by the pieces produced", () => {
+    const [r] = reconcileDesigns({
+      runs: jacketRuns,
+      logs: [perPieceLog()],
+      ratePerUnit: { [JACKET]: 2.5 },
+    })
+    // 2.5/pc x 4 pcs = 10, which is exactly the expected figure.
+    expect(r.consumed).toBe(10)
+    expect(r.expected).toBe(10)
+    expect(r.variance).toBe(0)
+    // The whole point: the old code reported this design as short by 7.5.
+    expect(r.flags).not.toContain("under_expected")
+    expect(r.implied_rate).toBe(2.5)
+  })
+
+  it("takes a `total` log at its word — no multiplication", () => {
+    const [r] = reconcileDesigns({
+      runs: jacketRuns,
+      logs: [perPieceLog({ quantity_basis: "total" })],
+      ratePerUnit: { [JACKET]: 2.5 },
+    })
+    expect(r.consumed).toBe(2.5)
+    expect(r.flags).toContain("under_expected")
+  })
+
+  it("multiplies by the log's OWN run, not everything the design made", () => {
+    const [r] = reconcileDesigns({
+      runs: [
+        ...jacketRuns,
+        { id: "run_other", design_id: JACKET, status: "completed", produced_quantity: 6 },
+      ],
+      logs: [perPieceLog({ production_run_id: "run_jacket" })],
+    })
+    // 2.5 x 4 (its run), not 2.5 x 10 (the design's whole output).
+    expect(r.produced).toBe(10)
+    expect(r.consumed).toBe(10)
+  })
+
+  it("does NOT guess a null basis — it reports the design as unreadable", () => {
+    const [r] = reconcileDesigns({
+      runs: jacketRuns,
+      logs: [perPieceLog({ quantity_basis: null })],
+      ratePerUnit: { [JACKET]: 2.5 },
+    })
+    expect(r.unresolved_logs).toBe(1)
+    expect(r.unresolved_quantity).toBe(2.5)
+    // Absent from consumed: it is not known to be 2.5 or 10.
+    expect(r.consumed).toBe(0)
+    expect(r.flags).toContain("unknown_basis")
+    // Withheld — every one of these compares against a total we do not have.
+    expect(r.flags).not.toContain("under_expected")
+    expect(r.flags).not.toContain("produced_without_consumption")
+    expect(r.flags).not.toContain("implausible_rate")
+  })
+
+  it("resolves a null basis only when the operator supplies one", () => {
+    const [r] = reconcileDesigns({
+      runs: jacketRuns,
+      logs: [perPieceLog({ quantity_basis: null })],
+      assumeBasisWhenUnknown: "per_piece",
+    })
+    expect(r.unresolved_logs).toBe(0)
+    expect(r.consumed).toBe(10)
+    expect(r.flags).not.toContain("unknown_basis")
+  })
+
+  it("cannot resolve a per_piece rate with nothing produced to multiply by", () => {
+    const [r] = reconcileDesigns({
+      runs: [],
+      logs: [perPieceLog()],
+    })
+    // The design still surfaces — a log that cannot be read must not vanish.
+    expect(r.design_id).toBe(JACKET)
+    expect(r.unresolved_logs).toBe(1)
+    expect(r.consumed).toBe(0)
+    expect(r.flags).toContain("unknown_basis")
+  })
+
+  it("still reports a per-piece log with no run attribution", () => {
+    const [r] = reconcileDesigns({ runs: jacketRuns, logs: [perPieceLog()] })
+    expect(r.unattributed_logs).toBe(1)
+    expect(r.flags).toContain("unattributed_consumption")
+  })
+
+  it("one unreadable log withholds the verdict for the whole design", () => {
+    const [r] = reconcileDesigns({
+      runs: jacketRuns,
+      logs: [
+        perPieceLog({ id: "l1", quantity_basis: "total", quantity: 9 }),
+        perPieceLog({ id: "l2", quantity_basis: null, quantity: 1 }),
+      ],
+      ratePerUnit: { [JACKET]: 2.5 },
+    })
+    // consumed is a FLOOR here (9 of an unknown total), so `under_expected`
+    // against an expected 10 would be an assertion we cannot make.
+    expect(r.consumed).toBe(9)
+    expect(r.unresolved_logs).toBe(1)
+    expect(r.flags).toEqual(
+      expect.arrayContaining(["unknown_basis", "unattributed_consumption"])
+    )
+    expect(r.flags).not.toContain("under_expected")
   })
 })
 

--- a/apps/backend/src/workflows/consumption-logs/lib/reconcile-production-consumption.ts
+++ b/apps/backend/src/workflows/consumption-logs/lib/reconcile-production-consumption.ts
@@ -26,12 +26,20 @@ export type ReconcileRun = {
   metadata?: Record<string, any> | null
 }
 
+export type ConsumptionBasis = "total" | "per_piece"
+
 export type ReconcileLog = {
   id: string
   design_id?: string | null
   inventory_item_id?: string | null
   production_run_id?: string | null
   quantity?: number | string | null
+  /**
+   * What `quantity` MEASURES. `per_piece` makes it a rate, not a total — the
+   * whole reason this module cannot just sum the column. Null on logs written
+   * before the form asked, and never guessed.
+   */
+  quantity_basis?: ConsumptionBasis | null
   is_committed?: boolean
 }
 
@@ -51,6 +59,14 @@ export type DesignReconciliation = {
   variance: number | null
   /** Committed material logs not attributed to any production run. */
   unattributed_logs: number
+  /**
+   * Committed material logs whose total could NOT be resolved — a null basis
+   * with no assumption supplied, or a per-piece rate with no piece count to
+   * multiply by. Their quantity is absent from `consumed`.
+   */
+  unresolved_logs: number
+  /** The raw, UNRESOLVED `quantity` sum of those logs. Not a total of anything. */
+  unresolved_quantity: number
   flags: ReconcileFlag[]
 }
 
@@ -75,10 +91,19 @@ export type DesignReconciliation = {
  * design" (partner) logs 5 m against 5 pieces, which under the per-piece rule is
  * 25 m of real consumption against 5 m recorded.
  *
- * This module therefore does NOT multiply. Resolving it needs the basis recorded
- * explicitly on the log (`total` vs `per_piece`) plus a run attribution to supply
- * the piece count — most partner logs currently carry neither, and no
- * multiplication is safe until they do.
+ * That is now recorded: `consumption_log.quantity_basis` says which reading was
+ * meant, and this module resolves a `per_piece` log the way
+ * `apply-committed-consumption-to-inventory` does — rate × pieces — before
+ * summing. Summing the raw column instead compared an expected TOTAL against a
+ * RATE and reported a shortfall that did not exist, on every per-piece design
+ * (#1559). On a run of one the two readings coincide, which is how it survived.
+ *
+ * A NULL basis is still never guessed. Those logs are counted as `unresolved`
+ * and excluded from `consumed`, and any verdict that depends on knowing the
+ * total — `produced_without_consumption`, `implausible_rate`, `under_expected` —
+ * is withheld for that design in favour of `unknown_basis`. An operator who
+ * knows how a batch of legacy logs was entered passes `assumeBasisWhenUnknown`,
+ * exactly as the apply job's `assume_basis` works.
  */
 export type ReconcileFlag =
   | "produced_without_consumption"
@@ -86,6 +111,8 @@ export type ReconcileFlag =
   | "implausible_rate"
   | "unattributed_consumption"
   | "under_expected"
+  /** At least one log could not be read as a total — see `unresolved_logs`. */
+  | "unknown_basis"
 
 /**
  * A run minted from retail fulfillment: born terminal, no shop-floor work, no
@@ -131,6 +158,12 @@ export function reconcileDesigns(input: {
   ratePerUnit?: Record<string, number>
   /** Below this implied rate, flag the design. Default 0.5 (metres/piece). */
   implausibleRateBelow?: number
+  /**
+   * How to read logs written before the form recorded a basis. OPT-IN, and
+   * deliberately not defaulted: guessing `total` is what produced the wrong
+   * report in the first place. Omitted, those logs stay unresolved.
+   */
+  assumeBasisWhenUnknown?: ConsumptionBasis
 }): DesignReconciliation[] {
   const implausibleBelow = input.implausibleRateBelow ?? 0.5
   const rates = input.ratePerUnit ?? {}
@@ -141,6 +174,9 @@ export function reconcileDesigns(input: {
 
   const produced: Record<string, number> = {}
   const provenance: Record<string, number> = {}
+  // Pieces per RUN, so a log attributed to one run is multiplied by that run's
+  // own yield rather than by everything the design ever made.
+  const piecesByRun: Record<string, number> = {}
   for (const r of leaves) {
     const d = String(r.design_id)
     // produced_quantity is the reported yield; fall back to the ordered
@@ -149,12 +185,15 @@ export function reconcileDesigns(input: {
     if (isProvenanceRun(r)) {
       provenance[d] = round((provenance[d] ?? 0) + q)
     } else {
+      piecesByRun[String(r.id)] = q
       produced[d] = round((produced[d] ?? 0) + q)
     }
   }
 
   const consumed: Record<string, number> = {}
   const unattributed: Record<string, number> = {}
+  const unresolvedCount: Record<string, number> = {}
+  const unresolvedQty: Record<string, number> = {}
   for (const l of input.logs || []) {
     // Labour (`Hour`) and energy (`kWh`) logs carry a raw_material_id instead of
     // an inventory item; they are not material and must not enter a metres-per-
@@ -163,41 +202,80 @@ export function reconcileDesigns(input: {
       continue
     }
     const d = String(l.design_id)
-    consumed[d] = round((consumed[d] ?? 0) + num(l.quantity))
     if (!l.production_run_id) {
       unattributed[d] = (unattributed[d] ?? 0) + 1
     }
+
+    const raw = num(l.quantity)
+    const unresolved = () => {
+      unresolvedCount[d] = (unresolvedCount[d] ?? 0) + 1
+      unresolvedQty[d] = round((unresolvedQty[d] ?? 0) + raw)
+    }
+
+    const basis = l.quantity_basis ?? input.assumeBasisWhenUnknown
+    if (!basis) {
+      unresolved()
+      continue
+    }
+    if (basis === "total") {
+      consumed[d] = round((consumed[d] ?? 0) + raw)
+      continue
+    }
+    // per_piece: the column is a RATE. Pieces come from the log's own run when
+    // it has one, else from everything the design completed — the same order
+    // the apply job resolves them in, so the two jobs cannot disagree about
+    // what a log means.
+    const pieces =
+      (l.production_run_id ? piecesByRun[String(l.production_run_id)] : undefined) ??
+      produced[d]
+    if (!pieces || pieces <= 0) {
+      unresolved()
+      continue
+    }
+    consumed[d] = round((consumed[d] ?? 0) + raw * pieces)
   }
 
   const designIds = new Set([
     ...Object.keys(produced),
     ...Object.keys(provenance),
     ...Object.keys(consumed),
+    ...Object.keys(unresolvedCount),
   ])
 
   const out: DesignReconciliation[] = []
   for (const design_id of designIds) {
     const p = produced[design_id] ?? 0
     const c = consumed[design_id] ?? 0
+    const unresolved = unresolvedCount[design_id] ?? 0
     const rate = rates[design_id]
     const expected = rate != null && p > 0 ? round(rate * p) : null
+    const implied = p > 0 && c > 0 ? round(c / p) : null
     const flags: ReconcileFlag[] = []
 
-    if (p > 0 && c === 0) {
-      flags.push("produced_without_consumption")
+    // With an unreadable log in the mix, `consumed` is a floor and not a total.
+    // Every verdict below compares against it, so they are withheld rather than
+    // stated against a figure known to be short — a false `under_expected` is
+    // an instruction to "correct" a log that is already right.
+    if (unresolved > 0) {
+      flags.push("unknown_basis")
+    } else {
+      if (p > 0 && c === 0) {
+        flags.push("produced_without_consumption")
+      }
+      if (implied != null && implied < implausibleBelow) {
+        flags.push("implausible_rate")
+      }
+      if (expected != null && c < expected) {
+        flags.push("under_expected")
+      }
     }
+    // Production with no material at all is not in doubt either way: there is
+    // no log to have misread.
     if (p === 0 && c > 0) {
       flags.push("consumption_without_production")
     }
-    const implied = p > 0 && c > 0 ? round(c / p) : null
-    if (implied != null && implied < implausibleBelow) {
-      flags.push("implausible_rate")
-    }
     if ((unattributed[design_id] ?? 0) > 0) {
       flags.push("unattributed_consumption")
-    }
-    if (expected != null && c < expected) {
-      flags.push("under_expected")
     }
 
     out.push({
@@ -209,6 +287,8 @@ export function reconcileDesigns(input: {
       expected,
       variance: expected != null ? round(expected - c) : null,
       unattributed_logs: unattributed[design_id] ?? 0,
+      unresolved_logs: unresolved,
+      unresolved_quantity: unresolvedQty[design_id] ?? 0,
       flags,
     })
   }


### PR DESCRIPTION
Closes #1559.

## The defect

`reconcile-consumption-vs-production` never read `consumption_log.quantity_basis` — it summed the raw `quantity` column. `per_piece` makes that column a **rate**, not a total, which `apply-committed-consumption-to-inventory` has always known (it computes `per_piece × pieces`).

Observed on prod, design `01KWKHSQ…` ("Embroidered jacket"): one log of `quantity 2.5, quantity_basis per_piece`, 4 pieces produced.

```
before(expected) = 10, after(actual) = 2.5   →  [under_expected]
```

2.5 × 4 = 10, exactly the expected figure. The log was **correct**; the job invented a 7.5 m shortfall. Every per-piece design got the same false verdict. On a run of one the two readings coincide, which is presumably how it survived.

The job never writes, so the risk was never a bad write — it was a **bad instruction**. Its own description says *"correct the log, then run the apply job"*, and acting on it would have multiplied recorded consumption by the piece count.

## The fix

- Resolve each log the way the apply job does: `total` at its word, `per_piece × pieces`. Pieces come from the log's own run when it has one, else the design's completed non-provenance output — the same resolution order as the apply job, so the two cannot disagree about what a log means.
- A **null basis is never guessed**. Those logs become `unresolved_logs` / `unresolved_quantity`, stay out of `consumed`, and raise `unknown_basis`. The verdicts that depend on a complete total — `under_expected`, `implausible_rate`, `produced_without_consumption` — are withheld for that design rather than stated against a figure known to be short.
- `assume_basis` is the opt-in escape hatch, mirroring the apply job's param of the same name. Passing `total` reproduces today's behaviour exactly, deliberately.

The module's header comment claimed "this module therefore does NOT multiply … most partner logs currently carry neither [basis nor attribution]". The basis column now exists; that comment is replaced rather than left to mislead.

## Verify

```
cd apps/backend && TEST_TYPE=unit npx jest --testPathPattern="reconcile-production-consumption"
```

21 passing. The headline case was checked against the **old** lib and fails there (`Expected: 10, Received: 2.5`) — it is not vacuous. The four pre-existing tests whose fixtures carried no basis went red under the new code before their basis was declared, which is the same evidence from the other direction.

`pnpm check:prod-build` green.

## Not in scope

The issue also notes design `01KWKHSQ…`'s log has a null `production_run_id`, which `backfill-consumption-log-production-run-id` fixes. That is a prod data op, not a code change, and is left for a deliberate run.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01TLt1f38xqR8k2myCVxP8e4