### PR TITLE
fix(designs): an approved design was listed at 100× its cost

### DIFF
--- a/apps/backend/src/workflows/designs/__tests__/create-product-from-design.unit.spec.ts
+++ b/apps/backend/src/workflows/designs/__tests__/create-product-from-design.unit.spec.ts
@@ -1,0 +1,52 @@
+import { resolveListedPrice } from "../create-product-from-design"
+
+/**
+ * The price a design is listed at. Medusa 2.x amounts are DECIMAL major units —
+ * the seed lists a €10 shirt as `amount: 10` through the same
+ * `createProductsWorkflow` this workflow calls.
+ */
+describe("resolveListedPrice", () => {
+  it("lists estimated_cost verbatim — NOT multiplied by 100", () => {
+    // The defect: `Math.round(estimated_cost * 100)` listed a ₹850 design at
+    // 85,000. This is the whole test.
+    expect(resolveListedPrice({ estimated_cost: 850 })).toBe(850)
+  })
+
+  it("keeps the decimal part instead of rounding it away", () => {
+    // The old code's Math.round applied AFTER the ×100, so 12.34 became 1234.
+    // Verbatim, the paise survive.
+    expect(resolveListedPrice({ estimated_cost: 12.34 })).toBe(12.34)
+  })
+
+  it("prefers unit_price when the quote path supplies one", () => {
+    expect(
+      resolveListedPrice({ estimated_cost: 850, unit_price: 999 })
+    ).toBe(999)
+  })
+
+  it("treats the two inputs identically now the multiply is gone", () => {
+    expect(resolveListedPrice({ estimated_cost: 850 })).toBe(
+      resolveListedPrice({ estimated_cost: 0, unit_price: 850 })
+    )
+  })
+
+  it("falls through to estimated_cost when unit_price is null or absent", () => {
+    expect(resolveListedPrice({ estimated_cost: 40, unit_price: null })).toBe(40)
+    expect(resolveListedPrice({ estimated_cost: 40 })).toBe(40)
+  })
+
+  it("takes an explicit unit_price of 0 at its word", () => {
+    // `!= null`, not truthiness: a deliberate 0 is not "unspecified".
+    expect(resolveListedPrice({ estimated_cost: 850, unit_price: 0 })).toBe(0)
+  })
+
+  it("floors nonsense at 0 rather than writing it into a price row", () => {
+    // The approve route passes `design.estimated_cost || 0`, but the quote path
+    // passes whatever the estimator produced.
+    expect(resolveListedPrice({ estimated_cost: NaN })).toBe(0)
+    expect(resolveListedPrice({ estimated_cost: -5 })).toBe(0)
+    expect(
+      resolveListedPrice({ estimated_cost: 10, unit_price: Number("nope") })
+    ).toBe(0)
+  })
+})

--- a/apps/backend/src/workflows/designs/create-product-from-design.ts
+++ b/apps/backend/src/workflows/designs/create-product-from-design.ts
@@ -54,19 +54,10 @@ type CreateProductFromDesignInput = {
    */
   made_to_order?: boolean;
   /**
-   * The price to list, ALREADY in major units and already in `currency_code`.
+   * The price to list, in major units and already in `currency_code`.
    *
-   * ⚠️ Deliberately separate from `estimated_cost`, which this workflow has
-   * always multiplied by 100 before writing. Every other price in this
-   * codebase is a decimal — `accept-quote` writes `amount: freight` and the
-   * minted price list writes `quoted_unit_amount` raw — so that ×100 looks
-   * like a cent-conversion inherited from Medusa v1 that would make a listed
-   * price a hundred times too dear. Nothing tests it and nothing else reads
-   * it, so it is left exactly as it was rather than "fixed" blind on a live
-   * catalogue path; this input exists so the quote path does not inherit it.
-   *
-   * When given, it is written verbatim. `estimated_cost` is then only used for
-   * the legacy path.
+   * Overrides `estimated_cost` when given. Both are now written verbatim —
+   * see `resolveListedPrice` for what changed and why.
    */
   unit_price?: number | null;
 };
@@ -77,6 +68,36 @@ type CreateProductFromDesignOutput = {
   price: number;
   is_new_product: boolean;
 };
+
+/**
+ * PURE: the amount written to `variant.prices[].amount`. Exported for tests.
+ *
+ * Medusa 2.x prices are DECIMAL major units — the seed lists a €10 shirt as
+ * `amount: 10` through this same `createProductsWorkflow`, `accept-quote`
+ * writes `amount: freight` raw, and the minted price list writes
+ * `quoted_unit_amount` raw. This workflow was the only place that multiplied,
+ * doing `Math.round(estimated_cost * 100)`: a cent conversion inherited from
+ * Medusa v1, where amounts really were minor units.
+ *
+ * So a design approved at ₹850 was listed at 85,000. Nothing downstream divided
+ * it back — and the workflow's own output reported `price: estimated_cost`, the
+ * UNMULTIPLIED figure, so it told its caller one price and listed another. That
+ * contradiction is the tell that the ×100 was a leftover and not a convention.
+ *
+ * `unit_price` was added by the quote path precisely to sidestep the multiply;
+ * with the multiply gone the two inputs mean the same thing, and `unit_price`
+ * simply wins when both are supplied.
+ */
+export function resolveListedPrice(input: {
+  estimated_cost: number;
+  unit_price?: number | null;
+}): number {
+  const raw = input.unit_price != null ? input.unit_price : input.estimated_cost;
+  const n = Number(raw);
+  // A NaN here would reach the price row and fail the write with nothing said
+  // about which design caused it.
+  return Number.isFinite(n) && n > 0 ? n : 0;
+}
 
 /**
  * Single step that handles all the product/variant creation logic
@@ -90,11 +111,7 @@ const createProductAndVariantStep = createStep(
     const currencyCode = input.currency_code || "usd";
     const madeToOrder = !!input.made_to_order;
 
-    // See `unit_price` above for why these two spellings differ.
-    const priceAmount =
-      input.unit_price != null
-        ? Number(input.unit_price)
-        : Math.round(input.estimated_cost * 100);
+    const priceAmount = resolveListedPrice(input);
 
     // A made-to-order variant is produced after it is sold, so there is no
     // stock to manage and never will be before the run.
@@ -404,7 +421,9 @@ const createProductAndVariantStep = createStep(
     const output: CreateProductFromDesignOutput = {
       product_id,
       variant_id,
-      price: input.estimated_cost,
+      // What was actually listed. This used to report `estimated_cost` while
+      // the row was written at ×100, so the workflow contradicted itself.
+      price: priceAmount,
       is_new_product,
     };
 


### PR DESCRIPTION
## The defect

`create-product-from-design` wrote `Math.round(estimated_cost * 100)` into `variant.prices[].amount`.

Medusa 2.x amounts are **decimal major units**. The evidence, all in this repo:

- `src/scripts/seed.ts` lists a €10 shirt as `amount: 10` — through the same `createProductsWorkflow` this workflow calls.
- `accept-quote` writes `amount: freight` raw.
- The minted price list writes `quoted_unit_amount` raw.
- `use-create-product-from-media` writes `Math.round(amount)` — no multiply.

This workflow was the only place that multiplied. It's a cent conversion inherited from Medusa v1, where amounts really were minor units. **A design approved at 850 was listed at 85,000**, and nothing downstream divides it back (`grep '/ *100'` across `src/api/admin/designs` and `src/workflows/designs` finds only percentage maths in the estimator).

The clincher is internal: the workflow's own output reported `price: input.estimated_cost` — the *unmultiplied* figure — while writing ×100. It told its caller one price and listed another. That contradiction is what makes this a leftover rather than a convention.

## Scope

`/admin/designs/:id/approve` is the only caller reaching the multiply. The quote path (`ensure-design-quote-variant`) added `unit_price` specifically to sidestep it, with a docblock saying so. With the multiply gone the two inputs mean the same thing; `unit_price` simply wins when both are supplied.

The output `price` now reports what was actually listed. Nothing reads that field — both call sites take only `product_id` / `variant_id` — so making it truthful is safe.

## Why it wasn't fixed before

The prior note on this input said it was left alone because *"nothing tests it and nothing else reads it"*, rather than fixed blind on a live catalogue path. So the decision is extracted as a pure `resolveListedPrice` and tested. **Four of the seven cases fail against the old formula** (verified by reinstating it), including the headline `850 → 850`.

`resolveListedPrice` also floors NaN and negatives at 0 rather than letting them reach a price row, where the write would fail with nothing said about which design caused it.

## ⚠️ Existing data

This fixes the code, not rows already written. Any product minted by the approve route before this carries a 100× price. They are identifiable — variant `metadata.is_custom_design: true` with `design_id`, SKU `CUSTOM-<design_id>-<ts>`. **I have not touched prod.** Worth a read-only check of how many exist before deciding whether a correction job is warranted.

## Verify

```
cd apps/backend && TEST_TYPE=unit npx jest --testPathPattern="create-product-from-design"
```

7 pass. `pnpm check:prod-build` green. The 2 failures in `brief-shaper.unit.spec.ts` under `--testPathPattern=designs` are pre-existing — confirmed red on a stashed tree.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01TLt1f38xqR8k2myCVxP8e4