### PR TITLE
fix(payments): a re-bill that names no runs was billed twice (#1556)

### DIFF
--- a/apps/backend/src/workflows/payment_submissions/__tests__/run-evidence-guard.unit.spec.ts
+++ b/apps/backend/src/workflows/payment_submissions/__tests__/run-evidence-guard.unit.spec.ts
@@ -1,0 +1,147 @@
+/**
+ * A design could be billed, paid, and billed again — as long as the second
+ * claim named no runs. The design guard passes (nothing is open once it's
+ * Paid), the run guard never executes (nothing was claimed), and the same work
+ * is paid for twice with nothing in the record able to tell the claims apart.
+ */
+import {
+  designsBilledWithoutRunEvidence,
+  runlessResubmitMessage,
+  type PriorSubmissionLine,
+} from "../lib/run-evidence-guard"
+
+const prior = (over: Partial<PriorSubmissionLine> = {}): PriorSubmissionLine => ({
+  design_id: "des_1",
+  submission_status: "Paid",
+  submission_id: "ps_old",
+  run_provenance: "recorded",
+  ...over,
+})
+
+describe("designsBilledWithoutRunEvidence", () => {
+  it("🔴 catches a re-bill that names no runs after the first was Paid", () => {
+    const out = designsBilledWithoutRunEvidence({
+      design_ids: ["des_1"],
+      claimed_runs: undefined,
+      prior_lines: [prior()],
+    })
+    expect(out).toHaveLength(1)
+    expect(out[0].prior_submission_id).toBe("ps_old")
+    expect(out[0].prior_status).toBe("Paid")
+  })
+
+  it("also catches Approved, which the design guard stops covering", () => {
+    const out = designsBilledWithoutRunEvidence({
+      design_ids: ["des_1"],
+      claimed_runs: {},
+      prior_lines: [prior({ submission_status: "Approved" })],
+    })
+    expect(out).toHaveLength(1)
+  })
+
+  it("stands aside when the new claim NAMES its runs", () => {
+    // The run-level guard owns this design and is exact — two guards
+    // disagreeing about one design is worse than either alone.
+    const out = designsBilledWithoutRunEvidence({
+      design_ids: ["des_1"],
+      claimed_runs: { des_1: ["run_9"] },
+      prior_lines: [prior()],
+    })
+    expect(out).toEqual([])
+  })
+
+  it("treats an empty run list as naming nothing", () => {
+    const out = designsBilledWithoutRunEvidence({
+      design_ids: ["des_1"],
+      claimed_runs: { des_1: [] },
+      prior_lines: [prior()],
+    })
+    expect(out).toHaveLength(1)
+  })
+
+  it("lets a first-ever submission through", () => {
+    expect(
+      designsBilledWithoutRunEvidence({
+        design_ids: ["des_1"],
+        claimed_runs: undefined,
+        prior_lines: [],
+      })
+    ).toEqual([])
+  })
+
+  it("does not let another design's history block this one", () => {
+    const out = designsBilledWithoutRunEvidence({
+      design_ids: ["des_1"],
+      claimed_runs: undefined,
+      prior_lines: [prior({ design_id: "des_OTHER" })],
+    })
+    expect(out).toEqual([])
+  })
+
+  it("🔑 a Rejected prior releases its claim", () => {
+    // It never paid anyone, so it cannot be the thing being double-billed.
+    const out = designsBilledWithoutRunEvidence({
+      design_ids: ["des_1"],
+      claimed_runs: undefined,
+      prior_lines: [prior({ submission_status: "Rejected" })],
+    })
+    expect(out).toEqual([])
+  })
+
+  it("🔑 a prior that says `no_run` does NOT block", () => {
+    // `no_run` means nothing produced this work — it stakes no claim a run
+    // could duplicate, so blocking on it would invent a problem.
+    const out = designsBilledWithoutRunEvidence({
+      design_ids: ["des_1"],
+      claimed_runs: undefined,
+      prior_lines: [prior({ run_provenance: "no_run" })],
+    })
+    expect(out).toEqual([])
+  })
+
+  it("🔴 blocks on `not_recorded`, and on an absent value", () => {
+    // "Not written down" is not "no run". The model defaults to
+    // `not_recorded` precisely because a writer that said nothing has not told
+    // us there is no run — so the honest read is UNKNOWN, never clear.
+    for (const provenance of ["not_recorded", null, undefined as any]) {
+      const out = designsBilledWithoutRunEvidence({
+        design_ids: ["des_1"],
+        claimed_runs: undefined,
+        prior_lines: [prior({ run_provenance: provenance })],
+      })
+      expect(out).toHaveLength(1)
+    }
+  })
+
+  it("reports every conflicting design, not just the first", () => {
+    // A partner fixing one design per round-trip is how a screen stops being
+    // used — the same promise the readiness preflight makes.
+    const out = designsBilledWithoutRunEvidence({
+      design_ids: ["des_1", "des_2", "des_3"],
+      claimed_runs: { des_2: ["run_2"] },
+      prior_lines: [prior(), prior({ design_id: "des_3", submission_id: "ps_x" })],
+    })
+    expect(out.map((c) => c.design_id)).toEqual(["des_1", "des_3"])
+  })
+})
+
+describe("runlessResubmitMessage", () => {
+  it("names the design, the prior submission, and the fix", () => {
+    const msg = runlessResubmitMessage([
+      { design_id: "des_1", prior_submission_id: "ps_old", prior_status: "Paid" },
+    ])
+    expect(msg).toContain("des_1")
+    expect(msg).toContain("ps_old")
+    expect(msg).toContain("Paid")
+    // The refusal has to be actionable in one step, not a support ticket.
+    expect(msg).toMatch(/name the runs/i)
+  })
+
+  it("survives a prior with no id rather than printing undefined", () => {
+    const msg = runlessResubmitMessage([
+      { design_id: "des_1", prior_submission_id: null, prior_status: null },
+    ])
+    expect(msg).not.toContain("undefined")
+    expect(msg).toContain("unknown")
+  })
+})

--- a/apps/backend/src/workflows/payment_submissions/create-payment-submission.ts
+++ b/apps/backend/src/workflows/payment_submissions/create-payment-submission.ts
@@ -14,6 +14,10 @@ import { LinkDefinition } from "@medusajs/framework/types"
 import type { IEventBusModuleService } from "@medusajs/types"
 import type { Link } from "@medusajs/modules-sdk"
 import { PAYMENT_SUBMISSIONS_MODULE } from "../../modules/payment_submissions"
+import {
+  designsBilledWithoutRunEvidence,
+  runlessResubmitMessage,
+} from "./lib/run-evidence-guard"
 import { PARTNER_MODULE } from "../../modules/partner"
 import { DESIGN_MODULE } from "../../modules/designs"
 import { TASKS_MODULE } from "../../modules/tasks"
@@ -564,6 +568,52 @@ const validateDesignsForSubmissionStep = createStep(
           `Production runs already paid for: ${duplicates
             .map((id) => `${id} (submission ${billed.get(id)})`)
             .join(", ")}`
+        )
+      }
+    }
+
+    /**
+     * 7. The same question for a claim that names NO runs (#1556).
+     *
+     * 🔴 Step 6 is exact, and it is gated on `allClaimedRunIds.length` — it
+     * only runs when the new submission names runs. A submission that names
+     * none skips it entirely, and step 5 has already stopped being true once
+     * the first payout is Approved or Paid. So a design could be billed, paid,
+     * and billed again with no run ids, and NOTHING would object. The two
+     * claims are indistinguishable afterwards because the second recorded no
+     * evidence of what it was for.
+     *
+     * There is no arithmetic that rescues this: a claim naming nothing cannot
+     * be diffed against what was already paid. The model already takes the
+     * honest position — a line whose provenance is not `recorded` reads as
+     * UNKNOWN, never as clear — and paying twice is far harder to undo than a
+     * refusal a partner can act on in one step. The create screen has sent
+     * `production_run_ids` since #1579, so "name the runs" is a field away.
+     */
+    if (input.design_ids?.length) {
+      const submissionService: PaymentSubmissionsService = container.resolve(
+        PAYMENT_SUBMISSIONS_MODULE
+      )
+      const priorItems = (await submissionService.listPaymentSubmissionItems(
+        { design_id: input.design_ids },
+        { relations: ["submission"] }
+      )) as any[]
+
+      const conflicts = designsBilledWithoutRunEvidence({
+        design_ids: input.design_ids,
+        claimed_runs: input.production_run_ids,
+        prior_lines: (priorItems || []).map((item) => ({
+          design_id: item.design_id ? String(item.design_id) : null,
+          submission_status: item.submission?.status ?? null,
+          submission_id: item.submission?.id ?? item.submission_id ?? null,
+          run_provenance: item.run_provenance ?? null,
+        })),
+      })
+
+      if (conflicts.length) {
+        throw new MedusaError(
+          MedusaError.Types.INVALID_DATA,
+          runlessResubmitMessage(conflicts)
         )
       }
     }

--- a/apps/backend/src/workflows/payment_submissions/lib/run-evidence-guard.ts
+++ b/apps/backend/src/workflows/payment_submissions/lib/run-evidence-guard.ts
@@ -1,0 +1,110 @@
+/**
+ * The other half of "already paid for" (#1556).
+ *
+ * ## The hole
+ *
+ * `create-payment-submission` has two guards and neither covers this case.
+ *
+ * The design-level guard asks "is this design in an OPEN submission" —
+ * Pending or Under_Review — which stops being true the moment the first payout
+ * is Approved or Paid.
+ *
+ * The run-level guard is the real one: it refuses any run already claimed by a
+ * non-Rejected submission, Paid included. But it is gated on
+ * `if (allClaimedRunIds.length)` — it only runs when the NEW submission names
+ * runs. A submission that names none skips it entirely.
+ *
+ * So: bill a design, get it Paid, then submit the same design again WITHOUT
+ * naming runs. The design guard passes (nothing is open), the run guard never
+ * executes (nothing was claimed), and the same work is billed twice. Nothing
+ * in the record can tell the two claims apart afterwards, because the second
+ * one recorded no evidence of what it was for.
+ *
+ * ## Why refusing is the right answer, rather than guessing
+ *
+ * There is no way to compute "unbilled quantity" for a claim that names
+ * nothing. The honest position is the one the model already takes: a line
+ * whose provenance is not `recorded` must be read as UNKNOWN, never as clear.
+ * Paying twice is far harder to undo than a refusal a partner can act on in
+ * one step — the create screen has sent `production_run_ids` since #1579, so
+ * "name the runs" is a field away, not a support ticket.
+ *
+ * 🔑 A prior line that says `no_run` does NOT block. That value means "this
+ * paid for something no run produced" — it makes no claim on any run, so it
+ * cannot be double-claimed by one. Only `recorded` and `not_recorded` describe
+ * run work.
+ */
+
+export type PriorSubmissionLine = {
+  design_id: string | null
+  /** The prior submission's status. `Rejected` never paid anyone. */
+  submission_status: string | null
+  submission_id: string | null
+  run_provenance: string | null
+}
+
+export type RunlessConflict = {
+  design_id: string
+  prior_submission_id: string | null
+  prior_status: string | null
+}
+
+/**
+ * PURE: which designs are being re-billed with no run evidence at all.
+ *
+ * A design is a conflict when the NEW submission names no runs for it AND some
+ * prior non-Rejected line for that design claims to have paid for run work.
+ */
+export function designsBilledWithoutRunEvidence(input: {
+  design_ids: string[]
+  /** design id → run ids, as the new submission claims them. */
+  claimed_runs: Record<string, string[]> | undefined
+  prior_lines: PriorSubmissionLine[]
+}): RunlessConflict[] {
+  const claimed = input.claimed_runs || {}
+  const conflicts: RunlessConflict[] = []
+
+  for (const designId of input.design_ids || []) {
+    // Named its runs — the run-level guard owns this design and is exact.
+    if ((claimed[designId] || []).filter(Boolean).length) continue
+
+    const prior = (input.prior_lines || []).find((line) => {
+      if (String(line.design_id || "") !== designId) return false
+
+      // A Rejected submission never paid anyone; its lines release their claim.
+      if (String(line.submission_status || "") === "Rejected") return false
+
+      /**
+       * 🔑 `no_run` is an explicit statement that no run produced this work, so
+       * it stakes no claim a run could duplicate. Everything else does —
+       * including the `not_recorded` default, which is the honest reading of a
+       * writer that told us nothing.
+       */
+      return String(line.run_provenance || "not_recorded") !== "no_run"
+    })
+
+    if (prior) {
+      conflicts.push({
+        design_id: designId,
+        prior_submission_id: prior.submission_id ?? null,
+        prior_status: prior.submission_status ?? null,
+      })
+    }
+  }
+
+  return conflicts
+}
+
+/** The refusal, in words a partner can act on. */
+export function runlessResubmitMessage(conflicts: RunlessConflict[]): string {
+  const parts = conflicts.map(
+    (c) =>
+      `${c.design_id} (already billed on submission ${c.prior_submission_id ?? "unknown"}${c.prior_status ? `, ${c.prior_status}` : ""})`
+  )
+
+  return (
+    `These designs have been billed before and this claim names no production runs, ` +
+    `so there is no way to tell it apart from the earlier one: ${parts.join(", ")}. ` +
+    `Name the runs this submission pays for and resubmit — the payment screen sends them automatically.`
+  )
+}


### PR DESCRIPTION
Closes the runless half of #1556.

## The hole

`create-payment-submission` has two guards and neither covers this case.

- The **design-level** guard asks *"is this design in an OPEN submission"* — Pending or Under_Review. That stops being true the moment the first payout is Approved or Paid.
- The **run-level** guard is the exact one — it refuses any run already claimed by a non-Rejected submission, Paid included. But it is gated on `if (allClaimedRunIds.length)`: it only executes when the new submission **names** runs. A submission that names none skips it entirely.

So: bill a design → get it Paid → submit the same design again **without naming runs**. The design guard passes (nothing is open), the run guard never executes (nothing was claimed), and the same work is billed twice. Worse, the two claims are indistinguishable afterwards, because the second one recorded no evidence of what it was for.

## Why it refuses rather than guesses

There is no arithmetic that rescues a claim naming nothing — it cannot be diffed against what was already paid. The model already takes the honest position (a line whose provenance is not `recorded` reads as UNKNOWN, never as clear), and paying twice is far harder to undo than a refusal a partner can act on in one step. The create screen has sent `production_run_ids` since #1579, so "name the runs" is a field away, not a support ticket.

The refusal names the design, the prior submission and its status, and says what to do.

## What deliberately does NOT block

- **`Rejected` prior** — never paid anyone, so it releases its claim.
- **`no_run`** — an explicit statement that no run produced this work. It stakes no claim a run could duplicate.
- **A design whose new claim names its runs** — the exact run-level guard owns that case.

`not_recorded` and an absent value both block: a writer that told us nothing is not evidence of nothing.

## ⚠️ This changes what partners can do

A partner who re-bills a previously-billed design and names no runs now gets a refusal instead of a submission. That is the intended behaviour change and the reason this sat unopened — flagging it explicitly rather than burying it.

## Verify

```
cd apps/backend && TEST_TYPE=unit npx jest --testPathPattern="run-evidence-guard"
```

12 pass, covering each branch above. `pnpm check:prod-build` green, re-run after the rebase onto current main.

**Gap worth naming:** the pure guard is well covered, but nothing asserts the *workflow* throws — the wiring is untested. The relation (`submission`) and column (`run_provenance`) were both verified against the model rather than assumed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01TLt1f38xqR8k2myCVxP8e4