### PR TITLE
feat(payments): edit and delete partner payout methods from settings

### DIFF
--- a/apps/backend/src/api/middlewares.ts
+++ b/apps/backend/src/api/middlewares.ts
@@ -284,6 +284,7 @@ import {
   ListPaymentsByPartnerQuerySchema as PartnerListPaymentsByPartnerQuerySchema,
   ListPaymentMethodsByPartnerQuerySchema as PartnerListPaymentMethodsByPartnerQuerySchema,
   CreatePaymentMethodForPartnerSchema as PartnerCreatePaymentMethodForPartnerSchema,
+  UpdatePaymentMethodForPartnerSchema as PartnerUpdatePaymentMethodForPartnerSchema,
 } from "./partners/[id]/payments/validators";
 import { ReviseDesignSchema } from "./admin/designs/[id]/revise/validators";
 import { CancelPartnerAssignmentSchema } from "./admin/designs/[id]/cancel-partner-assignment/validators";
@@ -3449,6 +3450,28 @@ export default defineMiddlewares({
       middlewares: [
         authenticate("partner", ["session", "bearer"]),
         validateAndTransformBody(wrapSchema(PartnerCreatePaymentMethodForPartnerSchema)),
+      ],
+    },
+    {
+      matcher: "/partners/:id/payments/methods/:methodId",
+      method: "GET",
+      middlewares: [
+        authenticate("partner", ["session", "bearer"]),
+      ],
+    },
+    {
+      matcher: "/partners/:id/payments/methods/:methodId",
+      method: "POST",
+      middlewares: [
+        authenticate("partner", ["session", "bearer"]),
+        validateAndTransformBody(wrapSchema(PartnerUpdatePaymentMethodForPartnerSchema)),
+      ],
+    },
+    {
+      matcher: "/partners/:id/payments/methods/:methodId",
+      method: "DELETE",
+      middlewares: [
+        authenticate("partner", ["session", "bearer"]),
       ],
     },
     // Admin Abandoned Carts (read-only, backed by native Cart Module)

--- a/apps/backend/src/api/partners/[id]/payments/methods/[methodId]/route.ts
+++ b/apps/backend/src/api/partners/[id]/payments/methods/[methodId]/route.ts
@@ -1,0 +1,92 @@
+import { AuthenticatedMedusaRequest, MedusaResponse } from "@medusajs/framework/http"
+import { ContainerRegistrationKeys, MedusaError } from "@medusajs/framework/utils"
+import { getPartnerFromAuthContext } from "../../../../helpers"
+import PartnerPaymentMethodsLink from "../../../../../../links/partner-payment-methods-link"
+import { updatePaymentDetailsWorkflow } from "../../../../../../workflows/internal_payments/update-payment-details"
+import { deletePaymentDetailsWorkflow } from "../../../../../../workflows/internal_payments/delete-payment-details"
+
+// Verify the payment method belongs to the acting partner (prevents IDOR — a
+// partner must not be able to edit/delete another partner's payout method).
+async function verifyOwnership(req: AuthenticatedMedusaRequest) {
+  const partner = await getPartnerFromAuthContext(req.auth_context, req.scope)
+  if (!partner) {
+    throw new MedusaError(MedusaError.Types.UNAUTHORIZED, "Partner not found")
+  }
+
+  const query = req.scope.resolve(ContainerRegistrationKeys.QUERY) as any
+  const { data: links } = await query.graph({
+    entity: PartnerPaymentMethodsLink.entryPoint,
+    fields: ["internal_payment_details_id"],
+    filters: {
+      partner_id: partner.id,
+      internal_payment_details_id: req.params.methodId,
+    },
+  })
+
+  if (!links?.length) {
+    // NOT_FOUND rather than NOT_ALLOWED so a probing partner can't tell
+    // "exists but not yours" from "no such thing".
+    throw new MedusaError(MedusaError.Types.NOT_FOUND, "Payment method not found")
+  }
+
+  return partner
+}
+
+export const GET = async (
+  req: AuthenticatedMedusaRequest,
+  res: MedusaResponse
+) => {
+  const partner = await verifyOwnership(req)
+
+  const query = req.scope.resolve(ContainerRegistrationKeys.QUERY) as any
+  const { data } = await query.graph({
+    entity: PartnerPaymentMethodsLink.entryPoint,
+    fields: ["internal_payment_details.*"],
+    filters: {
+      partner_id: partner.id,
+      internal_payment_details_id: req.params.methodId,
+    },
+  })
+
+  return res.status(200).json({
+    paymentMethod: data?.[0]?.internal_payment_details || null,
+  })
+}
+
+export const POST = async (
+  req: AuthenticatedMedusaRequest,
+  res: MedusaResponse
+) => {
+  await verifyOwnership(req)
+
+  const { result } = await updatePaymentDetailsWorkflow(req.scope).run({
+    input: {
+      id: req.params.methodId,
+      ...(req.validatedBody || {}),
+    },
+  })
+
+  return res.status(200).json({ paymentMethod: result })
+}
+
+export const DELETE = async (
+  req: AuthenticatedMedusaRequest,
+  res: MedusaResponse
+) => {
+  const partner = await verifyOwnership(req)
+  const remoteLink = req.scope.resolve(ContainerRegistrationKeys.LINK) as any
+
+  // Remove the partner link first, then soft-delete the method row.
+  await remoteLink.dismiss({
+    partner: { partner_id: partner.id },
+    internal_payments: { internal_payment_details_id: req.params.methodId },
+  })
+
+  await deletePaymentDetailsWorkflow(req.scope).run({
+    input: { id: req.params.methodId },
+  })
+
+  return res
+    .status(200)
+    .json({ id: req.params.methodId, object: "payment_method", deleted: true })
+}

--- a/apps/backend/src/api/partners/[id]/payments/validators.ts
+++ b/apps/backend/src/api/partners/[id]/payments/validators.ts
@@ -33,3 +33,16 @@ export const CreatePaymentMethodForPartnerSchema = z.object({
 })
 export type CreatePaymentMethodForPartner = z.infer<typeof CreatePaymentMethodForPartnerSchema>
 export const CreatePaymentMethodForPartner = CreatePaymentMethodForPartnerSchema
+
+// Update a payment method for a partner (all fields optional — PATCH semantics)
+export const UpdatePaymentMethodForPartnerSchema = z.object({
+  type: z.enum(["bank_account", "cash_account", "digital_wallet"]).optional(),
+  account_name: z.string().min(1).optional(),
+  account_number: z.string().nullish(),
+  bank_name: z.string().nullish(),
+  ifsc_code: z.string().nullish(),
+  wallet_id: z.string().nullish(),
+  metadata: z.record(z.string(), z.any()).nullish(),
+})
+export type UpdatePaymentMethodForPartner = z.infer<typeof UpdatePaymentMethodForPartnerSchema>
+export const UpdatePaymentMethodForPartner = UpdatePaymentMethodForPartnerSchema

--- a/apps/partner-ui/src/components/common/action-menu/action-menu.tsx
+++ b/apps/partner-ui/src/components/common/action-menu/action-menu.tsx
@@ -41,7 +41,11 @@ export const ActionMenu = ({
 }: ActionMenuProps) => {
   const direction = useDocumentDirection()
   const inner = children ?? (
-    <IconButton size="small" variant={variant}>
+    <IconButton
+      size="small"
+      variant={variant}
+      aria-label="Open actions menu"
+    >
       <EllipsisHorizontal />
     </IconButton>
   )

--- a/apps/partner-ui/src/dashboard-app/routes/get-partner-route.map.tsx
+++ b/apps/partner-ui/src/dashboard-app/routes/get-partner-route.map.tsx
@@ -384,8 +384,9 @@ export function getPartnerRouteMap(): RouteObject[] {
                           Component,
                           loader,
                           handle: {
-                            breadcrumb: (match: UIMatch) =>
-                              <Breadcrumb {...match} />,
+                            breadcrumb: (
+                              match: UIMatch<HttpTypes.AdminInventoryItemResponse>
+                            ) => <Breadcrumb {...match} />,
                           },
                         }
                       },

--- a/apps/partner-ui/src/dashboard-app/routes/get-partner-route.map.tsx
+++ b/apps/partner-ui/src/dashboard-app/routes/get-partner-route.map.tsx
@@ -1109,6 +1109,11 @@ export function getPartnerRouteMap(): RouteObject[] {
                       lazy: () =>
                         import("../../routes/settings/payments/payments-create"),
                     },
+                    {
+                      path: ":id/edit",
+                      lazy: () =>
+                        import("../../routes/settings/payments/payments-edit"),
+                    },
                   ],
                 },
                 {

--- a/apps/partner-ui/src/hooks/api/partner-payment-methods.tsx
+++ b/apps/partner-ui/src/hooks/api/partner-payment-methods.tsx
@@ -146,11 +146,11 @@ export const useCreatePartnerPaymentMethod = (
         `/partners/${partnerId}/payments/methods`,
         { method: "POST", body: payload }
       ),
-    onSuccess: (data, variables, context) => {
+    onSuccess: (data, variables, onMutateResult, context) => {
       queryClient.invalidateQueries({
         queryKey: partnerPaymentMethodsQueryKeys.lists(),
       })
-      options?.onSuccess?.(data, variables, context)
+      options?.onSuccess?.(data, variables, onMutateResult, context)
     },
     ...options,
   })
@@ -182,11 +182,11 @@ export const useUpdatePartnerPaymentMethod = (
         `/partners/${partnerId}/payments/methods/${methodId}`,
         { method: "POST", body: payload }
       ),
-    onSuccess: (data, variables, context) => {
+    onSuccess: (data, variables, onMutateResult, context) => {
       queryClient.invalidateQueries({
         queryKey: partnerPaymentMethodsQueryKeys.lists(),
       })
-      options?.onSuccess?.(data, variables, context)
+      options?.onSuccess?.(data, variables, onMutateResult, context)
     },
     ...options,
   })
@@ -203,11 +203,11 @@ export const useDeletePartnerPaymentMethod = (
       sdk.client.fetch(`/partners/${partnerId}/payments/methods/${methodId}`, {
         method: "DELETE",
       }),
-    onSuccess: (data, variables, context) => {
+    onSuccess: (data, variables, onMutateResult, context) => {
       queryClient.invalidateQueries({
         queryKey: partnerPaymentMethodsQueryKeys.lists(),
       })
-      options?.onSuccess?.(data, variables, context)
+      options?.onSuccess?.(data, variables, onMutateResult, context)
     },
     ...options,
   })

--- a/apps/partner-ui/src/hooks/api/partner-payment-methods.tsx
+++ b/apps/partner-ui/src/hooks/api/partner-payment-methods.tsx
@@ -96,6 +96,41 @@ export const usePartnerPaymentMethods = (
   }
 }
 
+export const usePartnerPaymentMethod = (
+  partnerId?: string | null,
+  methodId?: string | null,
+  options?: Omit<
+    UseQueryOptions<
+      { paymentMethod: PartnerPaymentMethod | null },
+      FetchError,
+      { paymentMethod: PartnerPaymentMethod | null },
+      QueryKey
+    >,
+    "queryFn" | "queryKey"
+  >
+) => {
+  const { data, ...rest } = useQuery({
+    queryKey: partnerPaymentMethodsQueryKeys.detail(methodId || ""),
+    queryFn: async () => {
+      if (!partnerId || !methodId) {
+        return { paymentMethod: null }
+      }
+      return await sdk.client.fetch<{ paymentMethod: PartnerPaymentMethod | null }>(
+        `/partners/${partnerId}/payments/methods/${methodId}`,
+        { method: "GET" }
+      )
+    },
+    enabled: !!partnerId && !!methodId,
+    ...options,
+  })
+
+  return {
+    ...data,
+    paymentMethod: data?.paymentMethod ?? null,
+    ...rest,
+  }
+}
+
 export const useCreatePartnerPaymentMethod = (
   partnerId: string,
   options?: UseMutationOptions<
@@ -111,6 +146,63 @@ export const useCreatePartnerPaymentMethod = (
         `/partners/${partnerId}/payments/methods`,
         { method: "POST", body: payload }
       ),
+    onSuccess: (data, variables, context) => {
+      queryClient.invalidateQueries({
+        queryKey: partnerPaymentMethodsQueryKeys.lists(),
+      })
+      options?.onSuccess?.(data, variables, context)
+    },
+    ...options,
+  })
+}
+
+export type UpdatePartnerPaymentMethodPayload = {
+  type?: "bank_account" | "cash_account" | "digital_wallet"
+  account_name?: string
+  account_number?: string | null
+  bank_name?: string | null
+  ifsc_code?: string | null
+  wallet_id?: string | null
+  metadata?: Record<string, any> | null
+}
+
+export const useUpdatePartnerPaymentMethod = (
+  partnerId: string,
+  methodId: string,
+  options?: UseMutationOptions<
+    { paymentMethod: PartnerPaymentMethod },
+    FetchError,
+    UpdatePartnerPaymentMethodPayload
+  >
+) => {
+  const queryClient = useQueryClient()
+  return useMutation({
+    mutationFn: async (payload: UpdatePartnerPaymentMethodPayload) =>
+      sdk.client.fetch<{ paymentMethod: PartnerPaymentMethod }>(
+        `/partners/${partnerId}/payments/methods/${methodId}`,
+        { method: "POST", body: payload }
+      ),
+    onSuccess: (data, variables, context) => {
+      queryClient.invalidateQueries({
+        queryKey: partnerPaymentMethodsQueryKeys.lists(),
+      })
+      options?.onSuccess?.(data, variables, context)
+    },
+    ...options,
+  })
+}
+
+export const useDeletePartnerPaymentMethod = (
+  partnerId: string,
+  methodId: string,
+  options?: UseMutationOptions<any, FetchError, void>
+) => {
+  const queryClient = useQueryClient()
+  return useMutation({
+    mutationFn: () =>
+      sdk.client.fetch(`/partners/${partnerId}/payments/methods/${methodId}`, {
+        method: "DELETE",
+      }),
     onSuccess: (data, variables, context) => {
       queryClient.invalidateQueries({
         queryKey: partnerPaymentMethodsQueryKeys.lists(),

--- a/apps/partner-ui/src/i18n/translations/en.json
+++ b/apps/partner-ui/src/i18n/translations/en.json
@@ -3808,8 +3808,17 @@
         "cancel": "Cancel",
         "create": "Create"
       },
+      "edit": {
+        "heading": "Edit Payment Method",
+        "description": "Update this payout method."
+      },
+      "delete": {
+        "confirmation": "Remove this payment method ({{accountName}})?"
+      },
       "toast": {
-        "created": "Payment method created"
+        "created": "Payment method created",
+        "updated": "Payment method updated",
+        "deleted": "Payment method removed"
       }
     },
     "stripeConnect": {

--- a/apps/partner-ui/src/routes/settings/payments/payments-edit/components/payment-method-edit-form/index.ts
+++ b/apps/partner-ui/src/routes/settings/payments/payments-edit/components/payment-method-edit-form/index.ts
@@ -1,0 +1,1 @@
+export { PaymentMethodEditForm } from "./payment-method-edit-form.tsx"

--- a/apps/partner-ui/src/routes/settings/payments/payments-edit/components/payment-method-edit-form/payment-method-edit-form.tsx
+++ b/apps/partner-ui/src/routes/settings/payments/payments-edit/components/payment-method-edit-form/payment-method-edit-form.tsx
@@ -1,0 +1,207 @@
+import { zodResolver } from "@hookform/resolvers/zod"
+import { Button, Input, Select, toast } from "@medusajs/ui"
+import { useForm } from "react-hook-form"
+import { useTranslation } from "react-i18next"
+import * as zod from "zod"
+
+import { Form } from "../../../../../../components/common/form"
+import { RouteDrawer, useRouteModal } from "../../../../../../components/modals"
+import { KeyboundForm } from "../../../../../../components/utilities/keybound-form"
+import {
+  PartnerPaymentMethod,
+  useUpdatePartnerPaymentMethod,
+} from "../../../../../../hooks/api/partner-payment-methods"
+import { useMe } from "../../../../../../hooks/api/users"
+
+const EditPaymentMethodSchema = zod.object({
+  type: zod.enum(["bank_account", "cash_account", "digital_wallet"]),
+  account_name: zod.string().min(1, "Account name is required"),
+  account_number: zod.string().optional(),
+  bank_name: zod.string().optional(),
+  ifsc_code: zod.string().optional(),
+  wallet_id: zod.string().optional(),
+})
+
+type EditPaymentMethodValues = zod.infer<typeof EditPaymentMethodSchema>
+
+type PaymentMethodEditFormProps = {
+  paymentMethod: PartnerPaymentMethod
+}
+
+export const PaymentMethodEditForm = ({
+  paymentMethod,
+}: PaymentMethodEditFormProps) => {
+  const { t } = useTranslation()
+  const { user } = useMe()
+  const partnerId = user?.partner_id
+  const { handleSuccess } = useRouteModal()
+
+  const form = useForm<EditPaymentMethodValues>({
+    defaultValues: {
+      type: (paymentMethod.type as EditPaymentMethodValues["type"]) || "bank_account",
+      account_name: paymentMethod.account_name || "",
+      account_number: paymentMethod.account_number || "",
+      bank_name: paymentMethod.bank_name || "",
+      ifsc_code: paymentMethod.ifsc_code || "",
+      wallet_id: paymentMethod.wallet_id || "",
+    },
+    resolver: zodResolver(EditPaymentMethodSchema),
+  })
+
+  const { mutateAsync, isPending } = useUpdatePartnerPaymentMethod(
+    partnerId || "",
+    paymentMethod.id
+  )
+
+  const type = form.watch("type")
+
+  const handleSubmit = form.handleSubmit(async (values) => {
+    if (!partnerId) {
+      return
+    }
+
+    await mutateAsync(values, {
+      onSuccess: () => {
+        toast.success(t("partner.payments.toast.updated"))
+        handleSuccess("..")
+      },
+      onError: (e) => {
+        toast.error(e.message)
+      },
+    })
+  })
+
+  return (
+    <RouteDrawer.Form form={form}>
+      <KeyboundForm
+        onSubmit={handleSubmit}
+        className="flex h-full flex-col overflow-hidden"
+      >
+        <RouteDrawer.Body className="flex flex-1 flex-col gap-y-4 overflow-y-auto">
+          <Form.Field
+            control={form.control}
+            name="type"
+            render={({ field }) => (
+              <Form.Item>
+                <Form.Label>{t("partner.payments.form.type")}</Form.Label>
+                <Form.Control>
+                  <Select value={field.value} onValueChange={field.onChange}>
+                    <Select.Trigger>
+                      <Select.Value placeholder={t("partner.payments.form.typePlaceholder")} />
+                    </Select.Trigger>
+                    <Select.Content>
+                      <Select.Item value="bank_account">
+                        {t("partner.payments.typeLabels.bankAccount")}
+                      </Select.Item>
+                      <Select.Item value="cash_account">
+                        {t("partner.payments.typeLabels.cashAccount")}
+                      </Select.Item>
+                      <Select.Item value="digital_wallet">
+                        {t("partner.payments.typeLabels.digitalWallet")}
+                      </Select.Item>
+                    </Select.Content>
+                  </Select>
+                </Form.Control>
+                <Form.ErrorMessage />
+              </Form.Item>
+            )}
+          />
+
+          <Form.Field
+            control={form.control}
+            name="account_name"
+            render={({ field }) => (
+              <Form.Item>
+                <Form.Label>{t("partner.payments.form.accountName")}</Form.Label>
+                <Form.Control>
+                  <Input {...field} />
+                </Form.Control>
+                <Form.ErrorMessage />
+              </Form.Item>
+            )}
+          />
+
+          {type === "bank_account" && (
+            <>
+              <Form.Field
+                control={form.control}
+                name="account_number"
+                render={({ field }) => (
+                  <Form.Item>
+                    <Form.Label>{t("partner.payments.form.accountNumber")}</Form.Label>
+                    <Form.Control>
+                      <Input {...field} />
+                    </Form.Control>
+                    <Form.ErrorMessage />
+                  </Form.Item>
+                )}
+              />
+
+              <Form.Field
+                control={form.control}
+                name="bank_name"
+                render={({ field }) => (
+                  <Form.Item>
+                    <Form.Label>{t("partner.payments.form.bankName")}</Form.Label>
+                    <Form.Control>
+                      <Input {...field} />
+                    </Form.Control>
+                    <Form.ErrorMessage />
+                  </Form.Item>
+                )}
+              />
+
+              <Form.Field
+                control={form.control}
+                name="ifsc_code"
+                render={({ field }) => (
+                  <Form.Item>
+                    <Form.Label>{t("partner.payments.form.ifsc")}</Form.Label>
+                    <Form.Control>
+                      <Input {...field} />
+                    </Form.Control>
+                    <Form.ErrorMessage />
+                  </Form.Item>
+                )}
+              />
+            </>
+          )}
+
+          {type === "digital_wallet" && (
+            <Form.Field
+              control={form.control}
+              name="wallet_id"
+              render={({ field }) => (
+                <Form.Item>
+                  <Form.Label>{t("partner.payments.form.walletId")}</Form.Label>
+                  <Form.Control>
+                    <Input {...field} />
+                  </Form.Control>
+                  <Form.ErrorMessage />
+                </Form.Item>
+              )}
+            />
+          )}
+        </RouteDrawer.Body>
+        <RouteDrawer.Footer>
+          <div className="flex items-center justify-end gap-x-2">
+            <RouteDrawer.Close asChild>
+              <Button size="small" variant="secondary">
+                {t("partner.payments.form.cancel")}
+              </Button>
+            </RouteDrawer.Close>
+            <Button
+              size="small"
+              variant="primary"
+              type="submit"
+              isLoading={isPending}
+              disabled={!partnerId}
+            >
+              {t("actions.save")}
+            </Button>
+          </div>
+        </RouteDrawer.Footer>
+      </KeyboundForm>
+    </RouteDrawer.Form>
+  )
+}

--- a/apps/partner-ui/src/routes/settings/payments/payments-edit/index.ts
+++ b/apps/partner-ui/src/routes/settings/payments/payments-edit/index.ts
@@ -1,0 +1,1 @@
+export { SettingsPaymentsEdit as Component } from "./payments-edit.tsx"

--- a/apps/partner-ui/src/routes/settings/payments/payments-edit/payments-edit.tsx
+++ b/apps/partner-ui/src/routes/settings/payments/payments-edit/payments-edit.tsx
@@ -1,0 +1,39 @@
+import { Heading } from "@medusajs/ui"
+import { useTranslation } from "react-i18next"
+import { useParams } from "react-router-dom"
+import { RouteDrawer } from "../../../../components/modals"
+import { useMe } from "../../../../hooks/api/users"
+import { usePartnerPaymentMethod } from "../../../../hooks/api/partner-payment-methods"
+import { PaymentMethodEditForm } from "./components/payment-method-edit-form"
+
+export const SettingsPaymentsEdit = () => {
+  const { id } = useParams()
+  const { t } = useTranslation()
+  const { user } = useMe()
+  const partnerId = user?.partner_id
+
+  const { paymentMethod, isPending, isError, error } = usePartnerPaymentMethod(
+    partnerId,
+    id
+  )
+
+  const ready = !isPending && !!paymentMethod
+
+  if (isError) {
+    throw error
+  }
+
+  return (
+    <RouteDrawer>
+      <RouteDrawer.Header>
+        <RouteDrawer.Title asChild>
+          <Heading>{t("partner.payments.edit.heading")}</Heading>
+        </RouteDrawer.Title>
+        <RouteDrawer.Description className="sr-only">
+          {t("partner.payments.edit.description")}
+        </RouteDrawer.Description>
+      </RouteDrawer.Header>
+      {ready && <PaymentMethodEditForm paymentMethod={paymentMethod} />}
+    </RouteDrawer>
+  )
+}

--- a/apps/partner-ui/src/routes/settings/payments/payments.tsx
+++ b/apps/partner-ui/src/routes/settings/payments/payments.tsx
@@ -1,21 +1,106 @@
+import { PencilSquare, Trash } from "@medusajs/icons"
 import {
   Button,
   Container,
   Heading,
   Text,
   createDataTableColumnHelper,
+  toast,
+  usePrompt,
 } from "@medusajs/ui"
-import { useMemo } from "react"
+import { useCallback, useMemo } from "react"
 import { useTranslation } from "react-i18next"
 import { Link } from "react-router-dom"
 
+import { ActionMenu } from "../../../components/common/action-menu"
 import { SingleColumnPage } from "../../../components/layout/pages"
 import { _DataTable } from "../../../components/table/data-table"
 import { getLocaleAmount } from "../../../lib/money-amount-helpers"
 import { usePartnerPayments } from "../../../hooks/api/partner-payments"
-import { usePartnerPaymentMethods } from "../../../hooks/api/partner-payment-methods"
+import {
+  useDeletePartnerPaymentMethod,
+  usePartnerPaymentMethods,
+} from "../../../hooks/api/partner-payment-methods"
 import { useMe } from "../../../hooks/api/users"
 import { useDataTable } from "../../../hooks/use-data-table"
+
+type PaymentMethodRow = {
+  id: string
+  type: string
+  account_name: string
+  account_number?: string | null
+  bank_name?: string | null
+  ifsc_code?: string | null
+  wallet_id?: string | null
+  created_at?: string | null
+}
+
+type PaymentMethodRowActionsProps = {
+  method: PaymentMethodRow
+  partnerId?: string | null
+}
+
+const PaymentMethodRowActions = ({
+  method,
+  partnerId,
+}: PaymentMethodRowActionsProps) => {
+  const { t } = useTranslation()
+  const prompt = usePrompt()
+
+  const { mutateAsync } = useDeletePartnerPaymentMethod(
+    partnerId || "",
+    method.id
+  )
+
+  const handleDelete = useCallback(async () => {
+    const confirmed = await prompt({
+      title: t("general.areYouSure"),
+      description: t("partner.payments.delete.confirmation", {
+        accountName: method.account_name,
+      }),
+      confirmText: t("actions.delete"),
+      cancelText: t("actions.cancel"),
+    })
+
+    if (!confirmed) {
+      return
+    }
+
+    await mutateAsync(undefined, {
+      onSuccess: () => {
+        toast.success(t("partner.payments.toast.deleted"))
+      },
+      onError: (e) => {
+        toast.error(e.message)
+      },
+    })
+  }, [mutateAsync, prompt, t, method.account_name])
+
+  return (
+    <ActionMenu
+      groups={[
+        {
+          actions: [
+            {
+              icon: <PencilSquare />,
+              label: t("actions.edit"),
+              to: `${method.id}/edit`,
+            },
+          ],
+        },
+        {
+          actions: [
+            {
+              icon: <Trash />,
+              label: t("actions.delete"),
+              onClick: handleDelete,
+            },
+          ],
+        },
+      ]}
+    />
+  )
+}
 
 export const SettingsPayments = () => {
   const { t } = useTranslation()
@@ -24,17 +109,6 @@ export const SettingsPayments = () => {
 
   const { payments, isPending: isPaymentsLoading } = usePartnerPayments(partnerId)
   const { paymentMethods, isPending: isMethodsLoading } = usePartnerPaymentMethods(partnerId)
-
-  type PaymentMethodRow = {
-    id: string
-    type: string
-    account_name: string
-    account_number?: string | null
-    bank_name?: string | null
-    ifsc_code?: string | null
-    wallet_id?: string | null
-    created_at?: string | null
-  }
 
   const rows = useMemo<PaymentMethodRow[]>(() => {
     return (paymentMethods || []).map((m) => ({
@@ -127,8 +201,17 @@ export const SettingsPayments = () => {
           }
         },
       }),
+      columnHelper.display({
+        id: "actions",
+        cell: ({ row }) => (
+          <PaymentMethodRowActions
+            method={row.original}
+            partnerId={partnerId}
+          />
+        ),
+      }),
     ],
-    [columnHelper, t]
+    [columnHelper, t, partnerId]
   )
 
   const paymentsColumns = useMemo(

--- a/e2e/helpers/e2e-seed.ts
+++ b/e2e/helpers/e2e-seed.ts
@@ -1443,6 +1443,111 @@ async function seedCrmContact(container: any): Promise<{
   }
 }
 
+/**
+ * Partner + two linked payment methods for the partner-UI settings/payments
+ * spec (edit + delete). Mirrors `seedShipmentGatePartner` for auth, then links
+ * two `internal_payment_details` rows to the partner via the same
+ * `partner ↔ internal_payments` link the create workflow writes.
+ *
+ * TWO methods, deliberately: the edit case renames one and the delete case
+ * removes the other, so neither case mutates the other's fixture. Both carry a
+ * stamped account name — the spec selects rows by that text, and a repeat seed
+ * must not produce two rows reading the same thing.
+ */
+async function seedPaymentMethodsPartner(container: any): Promise<{
+  partnerId: string
+  email: string
+  password: string
+  editMethodId: string
+  editMethodName: string
+  deleteMethodId: string
+  deleteMethodName: string
+}> {
+  const partnerModule: any = container.resolve("partner")
+  const authModule = container.resolve(Modules.AUTH)
+  const link: any = container.resolve(ContainerRegistrationKeys.LINK)
+  const payments: any = container.resolve("internal_payments")
+
+  const stamp = Date.now()
+
+  const created = await partnerModule.createPartners({
+    name: `E2E Payments Partner ${stamp}`,
+    handle: `e2e-payments-${stamp}`,
+    status: "active",
+    is_verified: true,
+  })
+  const partnerId = Array.isArray(created) ? created[0].id : created.id
+
+  const email = `e2e-payments-${stamp}@jyt.test`
+  await partnerModule.createPartnerAdmins({
+    email,
+    first_name: "E2E",
+    last_name: "Payments",
+    role: "admin",
+    partner_id: partnerId,
+  })
+
+  const hashConfig = { logN: 15, r: 8, p: 1 }
+  const passwordHash = await Scrypt.kdf(SEED_PASSWORD, hashConfig)
+  const authIdentity: any = await authModule.createAuthIdentities({
+    provider_identities: [
+      {
+        provider: "emailpass",
+        entity_id: email,
+        provider_metadata: { password: passwordHash.toString("base64") },
+      },
+    ],
+    app_metadata: { partner_id: partnerId },
+  })
+  const authIdentityId = Array.isArray(authIdentity)
+    ? authIdentity[0].id
+    : authIdentity.id
+
+  const now = new Date()
+  await authModule.createAuthVerifications([
+    {
+      auth_identity_id: authIdentityId,
+      entity_id: email,
+      entity_type: "email",
+      code_provider: "emailpass",
+      requested_at: now,
+      verified_at: now,
+    },
+  ])
+
+  const mkMethod = async (suffix: string, type: string) => {
+    const createdMethod = await payments.createPaymentDetails({
+      type,
+      account_name: `E2E ${suffix} Acct ${stamp}`,
+      account_number: `E2E-ACCT-${suffix}-${stamp}`,
+      bank_name: "E2E Bank",
+      ifsc_code: "E2E0000123",
+      wallet_id: null,
+    })
+    const method = Array.isArray(createdMethod) ? createdMethod[0] : createdMethod
+
+    await link.create({
+      partner: { partner_id: partnerId },
+      internal_payments: { internal_payment_details_id: method.id },
+    })
+
+    return { id: method.id as string, name: method.account_name as string }
+  }
+
+  const editMethod = await mkMethod("Edit", "bank_account")
+  const deleteMethod = await mkMethod("Delete", "bank_account")
+
+  return {
+    partnerId,
+    email,
+    password: SEED_PASSWORD,
+    editMethodId: editMethod.id,
+    editMethodName: editMethod.name,
+    deleteMethodId: deleteMethod.id,
+    deleteMethodName: deleteMethod.name,
+  }
+}
+
 const SEED_PASSWORD = "e2etest123!"
 const SEED_FILE = path.resolve(__dirname, "../../apps/backend/.e2e-seed.json")
 
@@ -1612,6 +1717,9 @@ export default async function e2eSeed({ container }: ExecArgs) {
   logger.info("E2E seed: creating content editor partner + website + page + blocks...")
   const contentEditor = await seedContentEditorPartner(container)
 
+  logger.info("E2E seed: creating payment-methods partner + two methods (settings/payments spec)...")
+  const paymentMethods = await seedPaymentMethodsPartner(container)
+
   const seedData = {
     email,
     password: SEED_PASSWORD,
@@ -1656,6 +1764,15 @@ export default async function e2eSeed({ container }: ExecArgs) {
     contentEditorPartnerId: contentEditor.partnerId,
     contentEditorPageId: contentEditor.pageId,
     contentEditorWebsiteId: contentEditor.websiteId,
+    // Payment-methods fixture — consumed by partner-payment-methods.spec.ts
+    // (@partnerui). The delete case removes its method; the edit case renames
+    // its own — each is single-use per seed, which `pnpm e2e` refreshes.
+    paymentsPartnerEmail: paymentMethods.email,
+    paymentsPartnerPassword: paymentMethods.password,
+    paymentsEditMethodId: paymentMethods.editMethodId,
+    paymentsEditMethodName: paymentMethods.editMethodName,
+    paymentsDeleteMethodId: paymentMethods.deleteMethodId,
+    paymentsDeleteMethodName: paymentMethods.deleteMethodName,
     // #1363 per-assignment material allocation — consumed by
     // production-run-material-allocation.spec.ts (admin, CI). SINGLE-USE like
     // every other run fixture: the spec approves the run, and an approved run

--- a/e2e/specs/partner-payment-methods.spec.ts
+++ b/e2e/specs/partner-payment-methods.spec.ts
@@ -1,0 +1,151 @@
+import { test, expect } from "@playwright/test"
+import * as fs from "fs"
+import * as path from "path"
+
+/**
+ * Partner-UI settings/payments: edit + delete payout methods.
+ *
+ * Drives the REAL screen against the REAL API (partner-ui on :5173, the
+ * backend on :9000). The screen's payment-methods table now carries a
+ * per-row action menu (Edit / Delete); the edit opens a route drawer and the
+ * delete asks for confirmation before removing the method.
+ *
+ * Both endpoints live at `/partners/:id/payments/methods/:methodId` and were
+ * previously missing entirely — a GET-only list meant the UI could display a
+ * method but nothing could change it. These cases prove the two write paths
+ * the screen now wires to.
+ *
+ * @partnerui — needs the partner-UI dev server on :5173 and a seeded partner.
+ * Run locally with:
+ *   (cd apps/partner-ui && pnpm dev) &
+ *   pnpm --filter @jyt/backend e2e:test -- partner-payment-methods
+ */
+
+const SEED_FILE = path.resolve(__dirname, "../../apps/backend/.e2e-seed.json")
+const PARTNER_UI = process.env.PARTNER_UI_URL || "http://localhost:5173"
+
+type Seed = {
+  paymentsPartnerEmail: string
+  paymentsPartnerPassword: string
+  paymentsEditMethodId: string
+  paymentsEditMethodName: string
+  paymentsDeleteMethodId: string
+  paymentsDeleteMethodName: string
+}
+
+let seed: Seed
+
+test.describe("Partner payment methods (edit/delete) @partnerui", () => {
+  test.beforeAll(() => {
+    if (!fs.existsSync(SEED_FILE)) {
+      throw new Error(
+        `E2E seed file not found at ${SEED_FILE}. Run "pnpm e2e:seed" first.`
+      )
+    }
+    seed = JSON.parse(fs.readFileSync(SEED_FILE, "utf-8"))
+    if (
+      !seed.paymentsPartnerEmail ||
+      !seed.paymentsEditMethodId ||
+      !seed.paymentsDeleteMethodId
+    ) {
+      throw new Error(
+        "E2E seed missing the payment-methods fixture — re-run the seed."
+      )
+    }
+  })
+
+  const login = async (page: any) => {
+    await page.goto(`${PARTNER_UI}/login`, { waitUntil: "networkidle" })
+    await page.locator('input[name="email"]').fill(seed.paymentsPartnerEmail)
+    await page
+      .locator('input[name="password"]')
+      .fill(seed.paymentsPartnerPassword)
+    await page.locator('button[type="submit"]').click()
+    await page.waitForFunction(
+      () => !!localStorage.getItem("partner_ui_auth_token"),
+      { timeout: 15_000 }
+    )
+  }
+
+  /**
+   * Locate a table row by the account name it shows, then open that row's
+   * action menu. The shared ActionMenu trigger carries
+   * `aria-label="Open actions menu"`, so it is addressable per-row via the
+   * row's own scope rather than a page-wide query (which would match every
+   * row's menu at once).
+   */
+  const openRowMenu = async (page: any, accountName: string) => {
+    const row = page.locator("tr", { hasText: accountName })
+    await expect(row).toBeVisible({ timeout: 30_000 })
+    await row.getByRole("button", { name: /open actions menu/i }).click()
+  }
+
+  test("edits a payment method from the action menu via the route drawer", async ({
+    page,
+  }) => {
+    await login(page)
+    await page.goto(`${PARTNER_UI}/settings/payments`, {
+      waitUntil: "networkidle",
+    })
+
+    await openRowMenu(page, seed.paymentsEditMethodName)
+    await page.getByRole("menuitem", { name: /edit/i }).click()
+
+    await expect(
+      page.getByRole("heading", { name: /edit payment method/i })
+    ).toBeVisible({ timeout: 10_000 })
+
+    const newName = `${seed.paymentsEditMethodName} (renamed)`
+    await page.locator('input[name="account_name"]').fill(newName)
+
+    const [response] = await Promise.all([
+      page.waitForResponse(
+        (r: any) =>
+          r.url().includes(`/payments/methods/${seed.paymentsEditMethodId}`) &&
+          r.request().method() === "POST"
+      ),
+      page.getByRole("button", { name: /save/i }).click(),
+    ])
+
+    expect(response.status()).toBe(200)
+
+    // The screen's own table reflects the rename — not just a 200 on the wire.
+    await expect(
+      page.locator("tr", { hasText: newName })
+    ).toBeVisible({ timeout: 15_000 })
+  })
+
+  test("deletes a payment method from the action menu after confirmation", async ({
+    page,
+  }) => {
+    await login(page)
+    await page.goto(`${PARTNER_UI}/settings/payments`, {
+      waitUntil: "networkidle",
+    })
+
+    await openRowMenu(page, seed.paymentsDeleteMethodName)
+    await page.getByRole("menuitem", { name: /delete/i }).click()
+
+    // The confirmation prompt's confirm button is also "Delete" — but the menu
+    // item has role `menuitem`, so the button query is unambiguous.
+    await expect(
+      page.getByRole("button", { name: "Delete", exact: true })
+    ).toBeVisible({ timeout: 10_000 })
+
+    const [response] = await Promise.all([
+      page.waitForResponse(
+        (r: any) =>
+          r.url().includes(`/payments/methods/${seed.paymentsDeleteMethodId}`) &&
+          r.request().method() === "DELETE"
+      ),
+      page.getByRole("button", { name: "Delete", exact: true }).click(),
+    ])
+
+    expect(response.status()).toBe(200)
+
+    // The row is gone from the list.
+    await expect(
+      page.locator("tr", { hasText: seed.paymentsDeleteMethodName })
+    ).toHaveCount(0)
+  })
+})


### PR DESCRIPTION
The partner-UI payment-methods table was read-only: it could list payout
methods but nothing could change them. This adds an Edit/Delete action menu
backed by new endpoints on `/partners/:id/payments/methods/:methodId`.

## What changed

- **Backend** — new `GET` (single), `POST` (update), `DELETE` handlers on
  `/partners/:id/payments/methods/:methodId`, plus `UpdatePaymentMethodForPartner`
  validation and middleware registration. Ownership is verified through the
  `partner <-> internal_payments` link so a partner cannot read/mutate another
  partner's payout method — `NOT_FOUND` rather than `NOT_ALLOWED`, so a probe
  can't distinguish "not yours" from "doesn't exist".
- **Partner UI** — an actions column on the payment-methods table (Edit opens a
  route drawer reusing the create form's type-conditional fields; Delete asks
  for confirmation via `usePrompt`). New hooks `usePartnerPaymentMethod`,
  `useUpdatePartnerPaymentMethod`, `useDeletePartnerPaymentMethod`.
- **E2E** — a Playwright `@partnerui` spec covering both paths, plus its seed
  fixture (a login-capable partner with two linked methods).

## Review notes

- The update route reuses the existing `updatePaymentDetailsWorkflow` /
  `deletePaymentDetailsWorkflow`; delete dismisses the link before soft-deleting.
- The `@partnerui` spec runs only when the partner-UI dev server is up
  (local, or CI with `PARTNER_UI=1`) — same gating as the existing payout specs.