### PR TITLE
fix(payments): a Draft prior must not block the submission it becomes (#1602)

### DIFF
--- a/apps/backend/src/workflows/payment_submissions/__tests__/run-evidence-guard.unit.spec.ts
+++ b/apps/backend/src/workflows/payment_submissions/__tests__/run-evidence-guard.unit.spec.ts
@@ -78,6 +78,79 @@ describe("designsBilledWithoutRunEvidence", () => {
     expect(out).toEqual([])
   })
 
+  /**
+   * The regression #1602 shipped, caught while tracing why 7 Draft submissions
+   * had piled up on prod.
+   *
+   * `auto-draft-payment-submission` drafts one on every completed run. The
+   * partner then submits by hand — and that hand submission CANNOT name the
+   * runs, because the Draft already holds a live claim on them (the run-level
+   * guard refuses it). Naming no runs was the only way through. Blocking it
+   * here left the design unbillable by any route: the Draft cannot be submitted
+   * (no such route), cannot be rejected (review requires Pending/Under_Review)
+   * and cannot be deleted (#1604).
+   */
+  it("🔴 a Draft prior does NOT block — it is the auto-draft being submitted", () => {
+    const conflicts = designsBilledWithoutRunEvidence({
+      design_ids: ["design_1"],
+      claimed_runs: {},
+      prior_lines: [
+        {
+          design_id: "design_1",
+          submission_status: "Draft",
+          submission_id: "sub_draft",
+          run_provenance: "recorded",
+        },
+      ],
+    })
+    // Before the fix this returned a conflict, and the partner had no route
+    // left to bill the design at all.
+    expect(conflicts).toEqual([])
+  })
+
+  it("a Draft alongside a Paid prior still blocks — the Paid one is the claim", () => {
+    const conflicts = designsBilledWithoutRunEvidence({
+      design_ids: ["design_1"],
+      claimed_runs: {},
+      prior_lines: [
+        {
+          design_id: "design_1",
+          submission_status: "Draft",
+          submission_id: "sub_draft",
+          run_provenance: "recorded",
+        },
+        {
+          design_id: "design_1",
+          submission_status: "Paid",
+          submission_id: "sub_paid",
+          run_provenance: "recorded",
+        },
+      ],
+    })
+    // Exempting Draft must not let a genuinely-paid prior through with it.
+    expect(conflicts).toHaveLength(1)
+    expect(conflicts[0].prior_submission_id).toBe("sub_paid")
+    expect(conflicts[0].prior_status).toBe("Paid")
+  })
+
+  it("still blocks every status that actually took money", () => {
+    for (const status of ["Pending", "Under_Review", "Approved", "Paid"]) {
+      const conflicts = designsBilledWithoutRunEvidence({
+        design_ids: ["design_1"],
+        claimed_runs: {},
+        prior_lines: [
+          {
+            design_id: "design_1",
+            submission_status: status,
+            submission_id: `sub_${status}`,
+            run_provenance: "recorded",
+          },
+        ],
+      })
+      expect(conflicts).toHaveLength(1)
+    }
+  })
+
   it("🔑 a Rejected prior releases its claim", () => {
     // It never paid anyone, so it cannot be the thing being double-billed.
     const out = designsBilledWithoutRunEvidence({

--- a/apps/backend/src/workflows/payment_submissions/lib/run-evidence-guard.ts
+++ b/apps/backend/src/workflows/payment_submissions/lib/run-evidence-guard.ts
@@ -33,6 +33,29 @@
  * paid for something no run produced" — it makes no claim on any run, so it
  * cannot be double-claimed by one. Only `recorded` and `not_recorded` describe
  * run work.
+ *
+ * 🔴 Nor does a prior in **Draft**, and that exemption is load-bearing rather
+ * than a nicety.
+ *
+ * `auto-draft-payment-submission` drafts a submission on every
+ * `production_run.completed`, and a Draft is explicitly "visible, editable, and
+ * NOT yet a claim on anyone" — nothing is billed without the partner's say-so.
+ * The partner then submits by hand, which `create-payment-submission` documents
+ * as the intended path: *"A partner submitting by hand is NOT blocked by their
+ * own draft — that's them turning the draft into a real submission."*
+ *
+ * That hand submission cannot name the runs (the Draft already holds a live
+ * claim on them, so the run-level guard refuses it), and there is no route that
+ * converts a Draft to Pending. So naming NO runs was the only way through — and
+ * blocking it here left the design unbillable by any route at all, with the
+ * Draft equally unrejectable (review requires Pending/Under_Review) and
+ * undeletable (#1604).
+ *
+ * A Draft has never been submitted, approved or paid, so exempting it costs the
+ * guard nothing: its real target is a prior that actually took money —
+ * Pending, Under_Review, Approved, Paid. The proper fix is a submit route that
+ * converts a Draft in place; until that exists this exemption is what keeps the
+ * documented flow working.
  */
 
 export type PriorSubmissionLine = {
@@ -71,8 +94,16 @@ export function designsBilledWithoutRunEvidence(input: {
     const prior = (input.prior_lines || []).find((line) => {
       if (String(line.design_id || "") !== designId) return false
 
-      // A Rejected submission never paid anyone; its lines release their claim.
-      if (String(line.submission_status || "") === "Rejected") return false
+      /**
+       * Neither of these ever took money, so neither stakes a claim a second
+       * submission could duplicate:
+       *   - `Rejected` — reviewed and refused; its lines release their runs.
+       *   - `Draft`    — never submitted at all. See the docblock above: this
+       *                  is the auto-draft the partner is in the middle of
+       *                  turning into a real submission.
+       */
+      const priorStatus = String(line.submission_status || "")
+      if (priorStatus === "Rejected" || priorStatus === "Draft") return false
 
       /**
        * 🔑 `no_run` is an explicit statement that no run produced this work, so


### PR DESCRIPTION
Fixes a regression I introduced in #1602, caught before it reached partners.

## What broke

#1602 made any prior non-Rejected line block a re-bill that names no runs. **A Draft is such a line** — and blocking it closed the only route the documented flow had.

Tracing a Draft on prod, it is a dead end in four directions:

| Action | Result |
|---|---|
| Partner submits the Draft | **No route exists** — only `create` and `review` workflows |
| Partner re-submits **naming the runs** | Refused — the Draft is a live claim on them (`create-payment-submission.ts:545`) |
| Partner re-submits **naming no runs** | **Refused as of #1602** ← this PR |
| Admin rejects the Draft to clear it | Refused — `REVIEWABLE_STATUSES = ["Pending", "Under_Review"]` |

And per #1604 nobody can delete it either. The design became unbillable by any route.

## Why naming no runs was load-bearing

`create-payment-submission.ts:451` states the intended flow outright:

> *"A partner submitting by hand is NOT blocked by their own draft — that's them turning the draft into a real submission."*

`auto-draft-payment-submission` drafts one on every `production_run.completed`, and that draft is *"visible, editable, and NOT yet a claim on anyone"*. The partner turning it into a real submission **cannot name the runs** — the Draft already claims them. So naming none was the path, and #1602 shut it.

I closed a real double-pay hole, but the hole *was* the flow.

## Exposure

**7 Draft submissions across 7 designs on prod**, every one carrying `run_provenance: recorded` — so all 7 would have been affected. The #1602 deploy was still in flight when this was found.

## The fix

A `Draft` prior is exempt, on the same reasoning as `Rejected`: it never took money. The guard's real target is a prior that did — and `Pending`, `Under_Review`, `Approved`, `Paid` all still block, **including when a Draft sits alongside them** (covered by a test, since that is how an exemption usually leaks).

The proper fix is a submit route converting a Draft in place, tracked in #1604. This keeps the documented flow working until that exists.

## Verify

```
cd apps/backend && TEST_TYPE=unit npx jest --testPathPattern="run-evidence-guard"
```

15 pass. The two new Draft cases were run against the **merged** #1602 code and both fail there — they reproduce the regression rather than describing the fix. `pnpm check:prod-build` green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01TLt1f38xqR8k2myCVxP8e4