### PR TITLE
fix(e2e): the gate partner's store had no defaults, so every order page was a 404 (#1576)

### DIFF
--- a/e2e/helpers/e2e-seed.ts
+++ b/e2e/helpers/e2e-seed.ts
@@ -1449,9 +1449,52 @@ export async function seedShipmentGatePartner(
   // per partner (`defineLink(partner, { store, isList: true })`), so reusing an
   // already-linked store throws "Cannot create multiple links between 'partner'
   // and 'store'" the second time the seed runs.
+  //
+  /**
+   * 🔴 The three defaults are NOT decoration — the store is unusable without
+   * them, and the way it fails is the worst kind.
+   *
+   * `GET /partners/stores` throws `NOT_FOUND` when any of
+   * `default_sales_channel_id` / `default_location_id` / `default_region_id` is
+   * missing. The partner order-detail page requests it, the route error
+   * boundary paints a 404 for the whole page, and the ORDER never renders —
+   * even though every order request returned 200 and the action the spec just
+   * performed had succeeded.
+   *
+   * That is precisely how "completing step 2 marks the fulfillment shipped"
+   * failed on main: the shipment POST returned 200, the fulfillment WAS
+   * shipped, and the assertion then looked for "Shipped" on a page reading
+   * "404 - There is no page at this address". A seed defect wearing the costume
+   * of a broken screen — and the retries could never pass either, because the
+   * first attempt had already shipped the fulfillment.
+   */
+  const { data: gateRegions } = await query.graph({
+    entity: "region",
+    fields: ["id"],
+  })
+  const { data: gateChannels } = await query.graph({
+    entity: "sales_channel",
+    fields: ["id"],
+  })
+  const { data: gateLocations } = await query.graph({
+    entity: "stock_location",
+    fields: ["id"],
+  })
+  const gateRegionId = gateRegions?.[0]?.id
+  const gateChannelId = gateChannels?.[0]?.id
+  const gateLocationId = gateLocations?.[0]?.id
+  if (!gateRegionId || !gateChannelId || !gateLocationId) {
+    throw new Error(
+      `E2E seed: the gate partner's store needs a region (${gateRegionId}), a sales channel (${gateChannelId}) and a stock location (${gateLocationId}). Without all three, /partners/stores 404s and every partner order page renders as a 404. Run the demo seed first: \`medusa exec ./src/scripts/seed.ts\`.`
+    )
+  }
+
   const storeModule: any = container.resolve(Modules.STORE)
   const createdStore: any = await storeModule.createStores({
     name: `E2E Gate Store ${Date.now()}`,
+    default_sales_channel_id: gateChannelId,
+    default_location_id: gateLocationId,
+    default_region_id: gateRegionId,
   })
   const storeId = Array.isArray(createdStore)
     ? createdStore[0].id

--- a/e2e/specs/partner-shipment-carrier-modal.spec.ts
+++ b/e2e/specs/partner-shipment-carrier-modal.spec.ts
@@ -220,8 +220,30 @@ test.describe("Partner shipment carrier modal @partnerui", () => {
    * ⚠️ What this no longer covers: a waybill Shiprocket REJECTS. The stub
    * models success only, so "foreign AWB refused" has no test.
    */
-  // This is the case the shippable fixture exists for: before it, the shipment
-  // POST was refused as already created before a retry ever happened.
+  /**
+   * This is the case the shippable fixture exists for: before it, the shipment
+   * POST was refused as already created before a retry ever happened.
+   *
+   * 🔴 Red on main for three consecutive runs, and the cause was NOT here.
+   *
+   * The CI log says the shipment POST returned **200** — the fulfillment really
+   * was shipped. The failure was the assertion below finding no "Shipped",
+   * because the page it landed on was the app's own *"404 - There is no page at
+   * this address"*. Every order request had returned 200; what 404'd was
+   * `GET /partners/stores`, which the order-detail page requests and the route
+   * error boundary turns into a whole-page 404.
+   *
+   * `/partners/stores` throws NOT_FOUND when the store has no
+   * `default_sales_channel_id` / `default_location_id` / `default_region_id`,
+   * and `seedShipmentGatePartner` created its dedicated store with a name and
+   * nothing else. A seed defect wearing the costume of a broken screen — the
+   * same shape as the four stacked defects #1576 already worked through here.
+   *
+   * ⚠️ And it could never self-heal: attempt 1 ships the fulfillment, so both
+   * Playwright retries then get `400 Shipment has already been created` and
+   * fail at the URL assertion instead. A red retry here says nothing about the
+   * cause; read attempt 1.
+   */
   test("completing step 2 marks the fulfillment shipped", async ({ page }) => {
     await page.goto(SHIPMENT_URL)
 


### PR DESCRIPTION
## `completing step 2 marks the fulfillment shipped` — diagnosed, and it was the seed again

Main's e2e has been red on this one case for three runs. It is **not** the modal, the selector, or the Shiprocket stub.

**The CI log says the shipment POST returned `200`.** The fulfillment really was shipped:

```
13:00:02  POST /partners/orders/<id>/fulfillments/<ful>/shipment  (200)
```

The assertion then failed because the page it landed on was the app's own **"404 - There is no page at this address"** — visible in the run's `error-context.md` snapshot, which contains nothing but that 404. Every order request had returned 200. What 404'd was:

```
13:00:02  GET /partners/stores  (404)
          MedusaError: No default sales channel found for store store_01M11MK21G3GETYGY6YH11KT4F
```

`GET /partners/stores` throws `NOT_FOUND` when the store lacks any of `default_sales_channel_id` / `default_location_id` / `default_region_id` (`api/partners/stores/route.ts:290-309`). The partner order-detail page requests it, and the route error boundary turns that into a whole-page 404 — so the order never renders.

`seedShipmentGatePartner` created its dedicated store with a **name and nothing else**. A seed defect wearing the costume of a broken screen, which is the same shape as the four stacked defects this issue already worked through.

⚠️ And it could never self-heal: attempt 1 ships the fulfillment, so both Playwright retries then get `400 Shipment has already been created` and fail one line earlier, at the URL assertion. **A red retry here says nothing about the cause — read attempt 1.** That is why three runs looked deterministic and pointed at the wrong line.

### Fix

The gate store now gets all three defaults from the demo seed, and throws loudly naming the missing one if the demo seed has not been run — the convention this seed file already uses for its shippable fixture. The spec's docblock records the above so the next reader does not re-diagnose it.

**Not re-parked.** Session 22's guidance was to park it if the fix did not take at main scope; the cause turned out to be seed data, so parking would have hidden a fixable defect.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01TLt1f38xqR8k2myCVxP8e4