### PR TITLE
fix(ops): the draft sweep called a breakdown backfill a re-pricing (#1556)

### DIFF
--- a/apps/backend/src/api/admin/ops/maintenance-jobs/__tests__/stale-draft-payout.unit.spec.ts
+++ b/apps/backend/src/api/admin/ops/maintenance-jobs/__tests__/stale-draft-payout.unit.spec.ts
@@ -134,6 +134,61 @@ describe("assessDraftLine", () => {
   })
 })
 
+/**
+ * 🔴 From the first real prod dry-run: 7 lines examined, "5 would be re-priced"
+ * — and four of the five had an identical before and after. Their amounts were
+ * right; only `unit_amount` (or a quantity of 1 standing in for 5 × 500) was
+ * missing. The summary sent an operator hunting four discrepancies that did not
+ * exist.
+ */
+describe("summarizeDraftSweep counts a breakdown backfill apart from a re-price", () => {
+  it("does not call an unchanged amount a re-pricing", () => {
+    const out = summarizeDraftSweep({
+      examined: 7,
+      stale: 5,
+      repriced: 1,
+      current: 2,
+      skipped: 0,
+      dryRun: true,
+    })
+
+    expect(out).toContain("1 would be re-priced")
+    expect(out).toContain(
+      "4 would gain a quantity/rate breakdown with no change to the amount"
+    )
+    // The old wording, which was the defect.
+    expect(out).not.toContain("5 would be re-priced")
+  })
+
+  it("says nothing about backfills when every stale line moves money", () => {
+    const out = summarizeDraftSweep({
+      examined: 3,
+      stale: 2,
+      repriced: 2,
+      current: 1,
+      skipped: 0,
+      dryRun: false,
+    })
+
+    expect(out).toContain("2 re-priced")
+    expect(out).not.toContain("breakdown")
+  })
+
+  it("keeps the old wording for a caller that does not split the two", () => {
+    // `repriced` is optional so an older caller reports what it always did,
+    // rather than silently claiming zero payouts changed.
+    const out = summarizeDraftSweep({
+      examined: 5,
+      stale: 2,
+      current: 3,
+      skipped: 0,
+      dryRun: true,
+    })
+    expect(out).toContain("2 would be re-priced")
+    expect(out).not.toContain("breakdown")
+  })
+})
+
 describe("summarizeDraftSweep", () => {
   it("says plainly when there was nothing to examine", () => {
     expect(

--- a/apps/backend/src/api/admin/ops/maintenance-jobs/lib/stale-draft-payout.ts
+++ b/apps/backend/src/api/admin/ops/maintenance-jobs/lib/stale-draft-payout.ts
@@ -148,9 +148,32 @@ const fmt = (n: unknown): string =>
  * A sweep that says "3 of 200 stale" while 150 were unknowable has told the
  * operator the opposite of the truth about its own coverage.
  */
+/**
+ * 🔴 `stale` is NOT the number of payouts whose money changes, and reporting it
+ * as such is a bad INSTRUCTION rather than a bad number.
+ *
+ * The first real prod dry-run examined 7 lines and said *"5 would be
+ * re-priced"*. Four of those five had an identical before and after: their
+ * amounts were correct and only the BREAKDOWN was missing — `unit_amount`
+ * unset, or a quantity of 1 standing in for 5 × 500. An operator reading
+ * "5 re-priced" concludes five artisans are being paid the wrong amount and
+ * goes looking for four discrepancies that do not exist. That is the #1559
+ * shape exactly: a report-only job's risk is what it tells a human to do.
+ *
+ * So the two are counted apart. Both are still written — a line that bills
+ * 2500 as "1 × unset" instead of "5 × 500" is a line a partner cannot check,
+ * and fixing that is the point of the breakdown columns. It is simply not a
+ * re-pricing.
+ */
 export function summarizeDraftSweep(input: {
   examined: number
   stale: number
+  /**
+   * Of `stale`, how many change the AMOUNT. The remainder only backfill the
+   * quantity/rate behind an amount that was already right. Optional so an older
+   * caller keeps today's wording rather than silently reporting zero.
+   */
+  repriced?: number
   current: number
   skipped: number
   dryRun: boolean
@@ -162,11 +185,21 @@ export function summarizeDraftSweep(input: {
   }
 
   const verb = dryRun ? "would be re-priced" : "re-priced"
+  const backfillVerb = dryRun
+    ? "would gain a quantity/rate breakdown with no change to the amount"
+    : "gained a quantity/rate breakdown with no change to the amount"
+
+  const repriced = input.repriced === undefined ? stale : input.repriced
+  const backfilled = Math.max(0, stale - repriced)
+
   const parts = [
     `${examined} draft line${examined === 1 ? "" : "s"} examined`,
-    `${stale} ${verb}`,
-    `${current} already current`,
+    `${repriced} ${verb}`,
   ]
+  if (backfilled) {
+    parts.push(`${backfilled} ${backfillVerb}`)
+  }
+  parts.push(`${current} already current`)
   if (skipped) {
     parts.push(`${skipped} skipped as unknowable or ambiguous (see changes)`)
   }

--- a/apps/backend/src/api/admin/ops/maintenance-jobs/refresh-stale-draft-payouts-job.ts
+++ b/apps/backend/src/api/admin/ops/maintenance-jobs/refresh-stale-draft-payouts-job.ts
@@ -99,6 +99,8 @@ export const refreshStaleDraftPayoutsJob: MaintenanceJob = {
 
     let examined = 0
     let stale = 0
+    /** Of `stale`, the lines whose AMOUNT actually moves. */
+    let repriced = 0
     let current = 0
     let skipped = 0
 
@@ -198,6 +200,14 @@ export const refreshStaleDraftPayoutsJob: MaintenanceJob = {
       }
 
       stale++
+      /**
+       * Whether this line's MONEY moves, or only the breakdown behind it.
+       * Counted apart because the summary must not call a `unit_amount`
+       * backfill a re-pricing — see `summarizeDraftSweep`.
+       */
+      if (Number(line.amount) !== Number(verdict.expected.amount)) {
+        repriced++
+      }
       changes.push({
         entity: "payment_submission_item",
         id: line.item_id,
@@ -255,6 +265,7 @@ export const refreshStaleDraftPayoutsJob: MaintenanceJob = {
       summary: summarizeDraftSweep({
         examined,
         stale,
+        repriced,
         current,
         skipped,
         dryRun: opts.dry_run,


### PR DESCRIPTION
## Found by finally running it against real data

`refresh-stale-draft-payouts` has been carried in every handoff since it shipped as *"has never run against real data — dry-run one `design_id` first."* Done, read-only, on production:

```
7 draft lines examined, 5 would be re-priced, 2 already current.
```

**Four of those five have an identical before and after.**

| line | before → after | reason |
|---|---|---|
| `01KZWTVWV5704RW4P2ZN70G6M7` | 1100 → **1110** | run now says 1100 → 1110 |
| `01KZWVPQXZBB1WMBVCAQBGF0V8` | 580 → 580 | unit unset → 580 |
| `01KZWW96QSWTHYB3PTM5HW67B9` | 900 → 900 | unit unset → 900 |
| `01KZWWT94ZZQ2DX55NG66895AV` | 1190 → 1190 | unit unset → 1190 |
| `01M0J26TPN6WHPR3GJX0F3HX7T` | 2500 → 2500 | quantity 1 → 5, unit → 500 |

Exactly **one** payout's money moves. The others gain a `unit_amount`, or a quantity of 1 corrected to the 5 × 500 that already summed to the right total.

An operator reading *"5 would be re-priced"* concludes five artisans are being paid the wrong amount, and goes hunting four discrepancies that do not exist. That is the #1559 shape exactly — a report-only job's risk is a bad **instruction**, not a wrong number.

## The change

Counted apart. Both kinds are still written: a line billing 2500 as "1 × unset" instead of "5 × 500" is a line a partner cannot check, and fixing that is what the breakdown columns are for — it is simply not a re-pricing.

`repriced` is optional so an older caller keeps today's wording rather than silently claiming zero payouts changed.

✅ Verified the load-bearing test **fails** against the old summary.

⚠️ Note for whoever applies this job for real: the ₹1,190 Draft an earlier session flagged as stale against a run since corrected to ₹840 is **not** re-priced by this sweep — its reason reads `unit unset → 1190`. That one still wants a human.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01TLt1f38xqR8k2myCVxP8e4