### PR TITLE
fix(payments): payable-runs offered retail provenance runs as billable labour (#1606)

### DIFF
--- a/apps/backend/integration-tests/http/payment-submissions-api.spec.ts
+++ b/apps/backend/integration-tests/http/payment-submissions-api.spec.ts
@@ -1219,22 +1219,39 @@ setupSharedTestSuite(() => {
       )
       expect(approved.status).toBe(200)
 
-      // A second payout for the same design, pointed at the same run.
-      const second = await api.post(
-        "/admin/payment-submissions",
-        {
-          partner_id: partnerId,
-          design_ids: [first.designId],
-          quantities: { [first.designId]: 4 },
-          unit_amounts: { [first.designId]: 1200 },
-        },
-        adminHeaders
-      )
-      const secondDetail = await api.get(
-        `/admin/payment-submissions/${second.data.payment_submission.id}`,
-        adminHeaders
-      )
-      const secondItemId = secondDetail.data.payment_submission.items[0].id
+      /**
+       * A second payout for the same design, with an unrecorded line — the
+       * only shape this job acts on (it refuses to overwrite a line that
+       * already records runs).
+       *
+       * 🔴 Written through the module rather than the create route, and that is
+       * not a convenience. #1602 closed the runless re-bill hole, so creating a
+       * second submission for an already-billed design while naming no runs is
+       * now correctly REFUSED at the door — which is what turned this test red
+       * on main. The line still has to exist to test the JOB's guard, and lines
+       * in exactly this state exist on production, written before that guard
+       * did. So the fixture is built the way reality built them.
+       */
+      const container = getContainer()
+      const submissionService: any = container.resolve("payment_submissions")
+      const secondSubmission = await submissionService.createPaymentSubmissions({
+        partner_id: partnerId,
+        status: "Pending",
+        total_amount: 4800,
+        currency: "inr",
+        submitted_at: new Date(),
+      })
+      const secondItem = await submissionService.createPaymentSubmissionItems({
+        source_type: "design",
+        design_id: first.designId,
+        design_name: "Double Claim Design",
+        amount: 4800,
+        quantity: 4,
+        unit_amount: 1200,
+        run_provenance: "not_recorded",
+        submission_id: secondSubmission.id,
+      })
+      const secondItemId = secondItem.id
 
       const res = await api
         .post(
@@ -2523,6 +2540,60 @@ setupSharedTestSuite(() => {
   })
 
   // ─── Auth Guards ──────────────────────────────────────────────────────────
+
+  // ─── Provenance runs are not billable labour (#1606) ───────────────────────
+
+  describe("payable-runs excludes retail provenance runs (#1606)", () => {
+    /**
+     * A run minted by `reconcile-provenance-runs` when a design-backed retail
+     * order ships from stock passes every filter payable-runs applies:
+     * completed, a design, a partner, a cost. No shop-floor work happened
+     * inside it, so offering it as billable invents labour — the money-side
+     * twin of the material-side rule `reconcileDesigns` has applied since
+     * #1123.
+     */
+    it("holds a provenance run back and says why, on both surfaces", async () => {
+      const designId = await createDesign("Provenance Run Design")
+      await linkDesignToPartner(designId, partnerId)
+
+      const realRun = await createCompletedRun(designId, "Provenance Run Design")
+      const provenanceRun = await createCompletedRun(
+        designId,
+        "Provenance Run Design",
+        {
+          metadata: {
+            source: "order.fulfillment_created",
+            design_backed: true,
+          },
+        }
+      )
+
+      const admin = await api.get(
+        `/admin/payment-submissions/payable-runs?partner_id=${partnerId}`,
+        adminHeaders
+      )
+      expect(admin.status).toBe(200)
+      const adminIds = admin.data.payable_runs.map((r: any) => r.run_id)
+      expect(adminIds).toContain(realRun)
+      expect(adminIds).not.toContain(provenanceRun)
+      expect(admin.data.excluded_runs).toEqual([
+        expect.objectContaining({
+          run_id: provenanceRun,
+          excluded_reason: "provenance_run",
+        }),
+      ])
+
+      const partnerRes = await api.get(
+        "/partners/payment-submissions/payable-runs",
+        { headers: partnerHeaders }
+      )
+      expect(partnerRes.status).toBe(200)
+      const partnerIds = partnerRes.data.payable_runs.map((r: any) => r.run_id)
+      expect(partnerIds).toContain(realRun)
+      expect(partnerIds).not.toContain(provenanceRun)
+      expect(partnerRes.data.excluded_count).toBe(1)
+    })
+  })
 
   describe("Auth protection", () => {
     it("should reject unauthenticated partner endpoints", async () => {

--- a/apps/backend/src/api/admin/payment-submissions/payable-runs/route.ts
+++ b/apps/backend/src/api/admin/payment-submissions/payable-runs/route.ts
@@ -3,6 +3,7 @@ import { ContainerRegistrationKeys, MedusaError } from "@medusajs/framework/util
 
 import { PAYMENT_SUBMISSIONS_MODULE } from "../../../../modules/payment_submissions"
 import PaymentSubmissionsService from "../../../../modules/payment_submissions/service"
+import { isProvenanceRun } from "../../../../workflows/consumption-logs/lib/reconcile-production-consumption"
 import { runUnitCost } from "../../../../workflows/production-runs/lib/run-payable"
 
 /**
@@ -105,14 +106,46 @@ export const GET = async (req: MedusaRequest, res: MedusaResponse) => {
       "partner_cost_estimate",
       "cost_type",
       "completed_at",
+      // Read by `isProvenanceRun` — a guard reading a field the query never
+      // fetched is dead code that types perfectly (#1606).
+      "metadata",
     ],
     filters: { partner_id: partnerId, status: "completed" },
   })
 
-  const completedRuns = ((runs || []) as any[]).filter((r) => !!r.design_id)
+  const designBackedRuns = ((runs || []) as any[]).filter((r) => !!r.design_id)
+
+  /**
+   * A run minted by a retail fulfilment is not billable labour (#1606).
+   *
+   * `reconcile-provenance-runs` mints (or completes) a run when a design-backed
+   * retail order ships from stock. It carries a partner, a design, a quantity and
+   * `status: "completed"` — every filter this endpoint applies — but no
+   * shop-floor work happened inside it and nothing was consumed. Offering it as
+   * billable invents labour, exactly as counting it would invent material on the
+   * consumption side, which is why `reconcileDesigns` has excluded these since
+   * #1123. The money side never got the same treatment.
+   *
+   * 🔑 Reported rather than silently dropped. A partner DID make those goods —
+   * just not in that run — and a screen that simply omits the row teaches nobody
+   * why the work vanished. `excluded_runs` says which runs were held back and on
+   * what grounds, and leaves the open product question (whether made-to-stock
+   * work has any payout path at all) visible instead of buried.
+   */
+  const completedRuns = designBackedRuns.filter((r) => !isProvenanceRun(r))
+  const excluded_runs = designBackedRuns
+    .filter((r) => isProvenanceRun(r))
+    .map((r) => ({
+      run_id: String(r.id),
+      design_id: String(r.design_id),
+      completed_at: r.completed_at ?? null,
+      excluded_reason: "provenance_run" as const,
+    }))
 
   if (!completedRuns.length) {
-    return res.status(200).json({ payable_runs: [], count: 0 })
+    return res
+      .status(200)
+      .json({ payable_runs: [], count: 0, excluded_runs, excluded_count: excluded_runs.length })
   }
 
   const designIds = [
@@ -324,5 +357,7 @@ export const GET = async (req: MedusaRequest, res: MedusaResponse) => {
   return res.status(200).json({
     payable_runs,
     count: payable_runs.length,
+    excluded_runs,
+    excluded_count: excluded_runs.length,
   })
 }

--- a/apps/backend/src/api/partners/payment-submissions/payable-runs/route.ts
+++ b/apps/backend/src/api/partners/payment-submissions/payable-runs/route.ts
@@ -3,6 +3,7 @@ import { ContainerRegistrationKeys, MedusaError } from "@medusajs/framework/util
 
 import { PAYMENT_SUBMISSIONS_MODULE } from "../../../../modules/payment_submissions"
 import PaymentSubmissionsService from "../../../../modules/payment_submissions/service"
+import { isProvenanceRun } from "../../../../workflows/consumption-logs/lib/reconcile-production-consumption"
 import { runUnitCost } from "../../../../workflows/production-runs/lib/run-payable"
 import { getPartnerFromAuthContext } from "../../helpers"
 
@@ -51,14 +52,46 @@ export const GET = async (
       "partner_cost_estimate",
       "cost_type",
       "completed_at",
+      // Read by `isProvenanceRun` — a guard reading a field the query never
+      // fetched is dead code that types perfectly (#1606).
+      "metadata",
     ],
     filters: { partner_id: partner.id, status: "completed" },
   })
 
-  const completedRuns = ((runs || []) as any[]).filter((r) => !!r.design_id)
+  const designBackedRuns = ((runs || []) as any[]).filter((r) => !!r.design_id)
+
+  /**
+   * A run minted by a retail fulfilment is not billable labour (#1606).
+   *
+   * `reconcile-provenance-runs` mints (or completes) a run when a design-backed
+   * retail order ships from stock. It carries a partner, a design, a quantity and
+   * `status: "completed"` — every filter this endpoint applies — but no
+   * shop-floor work happened inside it and nothing was consumed. Offering it as
+   * billable invents labour, exactly as counting it would invent material on the
+   * consumption side, which is why `reconcileDesigns` has excluded these since
+   * #1123. The money side never got the same treatment.
+   *
+   * 🔑 Reported rather than silently dropped. A partner DID make those goods —
+   * just not in that run — and a screen that simply omits the row teaches nobody
+   * why the work vanished. `excluded_runs` says which runs were held back and on
+   * what grounds, and leaves the open product question (whether made-to-stock
+   * work has any payout path at all) visible instead of buried.
+   */
+  const completedRuns = designBackedRuns.filter((r) => !isProvenanceRun(r))
+  const excluded_runs = designBackedRuns
+    .filter((r) => isProvenanceRun(r))
+    .map((r) => ({
+      run_id: String(r.id),
+      design_id: String(r.design_id),
+      completed_at: r.completed_at ?? null,
+      excluded_reason: "provenance_run" as const,
+    }))
 
   if (!completedRuns.length) {
-    return res.status(200).json({ payable_runs: [], count: 0 })
+    return res
+      .status(200)
+      .json({ payable_runs: [], count: 0, excluded_runs, excluded_count: excluded_runs.length })
   }
 
   const designIds = [
@@ -207,5 +240,7 @@ export const GET = async (
   return res.status(200).json({
     payable_runs,
     count: payable_runs.length,
+    excluded_runs,
+    excluded_count: excluded_runs.length,
   })
 }

--- a/apps/backend/src/workflows/consumption-logs/lib/reconcile-production-consumption.ts
+++ b/apps/backend/src/workflows/consumption-logs/lib/reconcile-production-consumption.ts
@@ -121,7 +121,19 @@ export type ReconcileFlag =
  * would let exactly the design-attached ones through, which are the only kind
  * that can reach a design's reconciliation at all.
  */
-export function isProvenanceRun(run: ReconcileRun): boolean {
+/**
+ * ⚠️ Typed on the ONE field it reads rather than on `ReconcileRun`, so the
+ * payout side can ask the same question of a run shaped for payout (#1606).
+ * One owner for this test — a second place re-checking the metadata key is how
+ * the materials side and the money side come to disagree about what a
+ * provenance run is.
+ */
+export function isProvenanceRun(
+  run:
+    | { metadata?: Record<string, any> | null; [key: string]: any }
+    | null
+    | undefined
+): boolean {
   return run?.metadata?.source === "order.fulfillment_created"
 }
 

--- a/apps/backend/src/workflows/production-runs/__tests__/run-payable.unit.spec.ts
+++ b/apps/backend/src/workflows/production-runs/__tests__/run-payable.unit.spec.ts
@@ -142,6 +142,32 @@ describe("assessRunPayout", () => {
       reason: "run_not_found",
     })
   })
+
+  /**
+   * #1606 — a run minted by a retail fulfilment passes every other check here:
+   * completed, a design, a partner, a cost. It shipped from stock, so no
+   * shop-floor work happened inside it and paying for it invents labour.
+   *
+   * 🔑 Nothing emits `production_run.completed` for one today
+   * (`complete-provenance-run` deliberately stays silent), so this guard is
+   * defensive — it is what stops a phantom payout the day that changes.
+   */
+  it("refuses a run minted by a retail fulfilment", () => {
+    expect(
+      assessRunPayout({
+        ...completed,
+        metadata: { source: "order.fulfillment_created", design_backed: true },
+      })
+    ).toEqual({ eligible: false, reason: "provenance_run" })
+  })
+
+  it("still pays a real run that merely carries other metadata", () => {
+    const verdict = assessRunPayout({
+      ...completed,
+      metadata: { source: "partner_dispatch", note: "rush" },
+    })
+    expect(verdict.eligible).toBe(true)
+  })
 })
 
 /**

--- a/apps/backend/src/workflows/production-runs/lib/run-payable.ts
+++ b/apps/backend/src/workflows/production-runs/lib/run-payable.ts
@@ -11,6 +11,8 @@
 // dual-write, which both derive the unit price from `run.quantity`). Correcting
 // a partner's output figure therefore does NOT move the money — deliberately.
 
+import { isProvenanceRun } from "../../consumption-logs/lib/reconcile-production-consumption"
+
 export type RunForPayout = {
   id?: string
   design_id?: string | null
@@ -19,6 +21,12 @@ export type RunForPayout = {
   quantity?: number | null
   partner_cost_estimate?: number | null
   cost_type?: "per_unit" | "total" | null
+  /**
+   * Read ONLY to answer "was this run minted by a retail fulfilment" (#1606).
+   * ⚠️ Every caller must actually FETCH it — a guard reading a field the query
+   * never asked for is dead code that types perfectly.
+   */
+  metadata?: Record<string, any> | null
 }
 
 /**
@@ -106,6 +114,20 @@ export const assessRunPayout = (
   }
   if (!run.partner_id) {
     return { eligible: false, reason: "no_partner" }
+  }
+
+  /**
+   * A run born from a retail fulfilment shipped from stock: no shop-floor
+   * work, no consumption, no labour to pay for. Counting it invents labour,
+   * exactly as `reconcileDesigns` refuses to let it invent material (#1123).
+   *
+   * Defensive today rather than load-bearing: `complete-provenance-run`
+   * deliberately emits no `production_run.completed`, so no auto-draft
+   * currently reaches this for one. If that ever changes, this is what stops a
+   * phantom payout appearing with no guard in the way. #1606
+   */
+  if (isProvenanceRun(run)) {
+    return { eligible: false, reason: "provenance_run" }
   }
 
   const amount = runPayableAmount(run)


### PR DESCRIPTION
## The product question, answered from the code

> A partner *did* make the goods that were later sold retail — just not in that run. Made-to-stock work sold later may have no other run that ever pays them for it.

**It does have one, and the provenance run was never a candidate anyway — because the partner on it is the wrong partner.**

`reconcile-provenance-runs` sets `partner_id` from `resolveOwningPartnerId`, which resolves to **the partner who owns the sales channel the order came through** (`modules/partner_billing/resolve-retail-partner.ts:40-61`) — a *selling* partner, not the maker. So billing a provenance run pays whoever's storefront happened to sell the garment, for labour someone else performed, at a moment possibly years after the work.

That makes exclusion the only safe answer, on stronger grounds than "no work happened in this run":

1. **Made-to-stock labour is already paid, at the time it is made.** That stock only exists because a real run produced it, and `complete-production-run` fires `production_run.completed` → `auto-draft-payment-submission` drafts the payout then. The provenance run is a *second* record of the same garments; billing it pays twice.
2. **`complete-provenance-run` deliberately emits no `production_run.completed`**, so no auto-draft reaches one today. The `assessRunPayout` skip added here is defensive, exactly as the issue proposed.
3. The real residual gap is stock that entered inventory with **no run at all** — a manual adjustment, an import. That labour has no payout path today, and the provenance run is not the fix for it: wrong partner, wrong time.

## What shipped

- `payable-runs` (admin + partner) excludes provenance runs via the shared `isProvenanceRun` — with `metadata` **added to the query's field list**, since a guard reading a field the query never fetched is dead code that types perfectly.
- `assessRunPayout` skips with `reason: "provenance_run"`.
- 🔑 **Reported, not silently dropped.** Both routes now return `excluded_runs` + `excluded_count` alongside `payable_runs`. A screen that just omits the row teaches nobody why the work vanished, and it buries the open question above rather than answering it.
- `isProvenanceRun` is typed on the one field it reads so the payout side can ask the same question of a payout-shaped run — one owner for the test, rather than a second place re-checking the metadata key.
- Tests: 2 unit (`assessRunPayout` refuses a provenance run; still pays a run carrying other metadata) + 1 integration asserting a provenance run is held back on **both** surfaces while a real run beside it stays payable.

## Also in here

A test that has been **red on main since #1602**: `record-payment-line-run`'s *"refuses a run already recorded on another live payout"* built its fixture by creating a second runless submission for an already-billed design — which #1602 now correctly refuses at the door. The line still has to exist to test the *job's* guard, and lines in that state exist on production, so the fixture is now built the way reality built them. This spec file goes 84/84.

Closes #1606

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01TLt1f38xqR8k2myCVxP8e4