### PR TITLE
Payment submissions as the central payout registry: run + inventory-order sources, partner-scoped claim guards, resolved currency (#1612)

### DIFF
--- a/apps/backend/src/modules/fx_rates/__tests__/get-rate-live.unit.spec.ts
+++ b/apps/backend/src/modules/fx_rates/__tests__/get-rate-live.unit.spec.ts
@@ -1,0 +1,167 @@
+import FxRatesService from "../service"
+
+/**
+ * `getRateLive` is the reader that money goes through, so its failure modes
+ * matter more than its happy path:
+ *
+ *  - a stale cache must not be read silently (#1538 — a remembered rate 24% off)
+ *  - N concurrent lines must not cause N provider fetches (#1368 — unbounded
+ *    FX fanout OOM-killed production twice)
+ *  - a provider outage must not lose a payout that a cached rate could serve
+ *  - but a MISSING rate must still throw, because `convertAmount` treats the
+ *    absence of a rate as a refusal, never as 1
+ *
+ * The service is a MedusaService subclass, so the prototype is borrowed and the
+ * data accessors stubbed — this exercises the real `getRateLive` body rather
+ * than a reimplementation of it.
+ */
+const makeService = (overrides: Record<string, any>): any => {
+  const service: any = Object.create(FxRatesService.prototype)
+  service.refreshInFlight = null
+  Object.assign(service, overrides)
+  return service
+}
+
+const HOUR = 60 * 60 * 1000
+
+describe("getRateLive", () => {
+  it("returns 1 for the same currency without touching the cache or provider", async () => {
+    const getRate = jest.fn()
+    const refreshRatesFromProvider = jest.fn()
+    const service = makeService({
+      getRate,
+      refreshRatesFromProvider,
+      getLastFetchedAt: jest.fn(),
+    })
+
+    await expect(service.getRateLive("inr", "INR")).resolves.toBe(1)
+    expect(getRate).not.toHaveBeenCalled()
+    expect(refreshRatesFromProvider).not.toHaveBeenCalled()
+  })
+
+  it("serves a fresh cached rate without calling the provider", async () => {
+    const refreshRatesFromProvider = jest.fn()
+    const service = makeService({
+      getRate: jest.fn().mockResolvedValue(96.49),
+      getLastFetchedAt: jest.fn().mockResolvedValue(new Date(Date.now() - HOUR)),
+      refreshRatesFromProvider,
+    })
+
+    await expect(service.getRateLive("usd", "inr")).resolves.toBe(96.49)
+    expect(refreshRatesFromProvider).not.toHaveBeenCalled()
+  })
+
+  it("refreshes when the cache is older than the max age", async () => {
+    const getRate = jest
+      .fn()
+      .mockResolvedValueOnce(80) // the stale figure
+      .mockResolvedValueOnce(96.49) // after the refresh
+    const refreshRatesFromProvider = jest.fn().mockResolvedValue({})
+    const service = makeService({
+      getRate,
+      // A month old — the shape #1512 is about.
+      getLastFetchedAt: jest
+        .fn()
+        .mockResolvedValue(new Date(Date.now() - 30 * 24 * HOUR)),
+      refreshRatesFromProvider,
+    })
+
+    await expect(service.getRateLive("usd", "inr")).resolves.toBe(96.49)
+    expect(refreshRatesFromProvider).toHaveBeenCalledTimes(1)
+  })
+
+  it("refreshes when the pair is missing from the cache entirely", async () => {
+    const getRate = jest
+      .fn()
+      .mockRejectedValueOnce(new Error("no path from usd to inr"))
+      .mockResolvedValueOnce(96.49)
+    const refreshRatesFromProvider = jest.fn().mockResolvedValue({})
+    const service = makeService({
+      getRate,
+      getLastFetchedAt: jest.fn().mockResolvedValue(new Date()),
+      refreshRatesFromProvider,
+    })
+
+    await expect(service.getRateLive("usd", "inr")).resolves.toBe(96.49)
+    expect(refreshRatesFromProvider).toHaveBeenCalledTimes(1)
+  })
+
+  it("refreshes ONCE for many concurrent lines, not once each", async () => {
+    // #1368: unbounded FX fanout OOM-killed production twice.
+    let resolveFetch: (v: unknown) => void = () => {}
+    const refreshRatesFromProvider = jest.fn(
+      () => new Promise((res) => { resolveFetch = res })
+    )
+    const service = makeService({
+      getRate: jest.fn().mockResolvedValue(96.49),
+      getLastFetchedAt: jest.fn().mockResolvedValue(new Date(0)),
+      refreshRatesFromProvider,
+    })
+
+    const inflight = Promise.all(
+      Array.from({ length: 8 }, () => service.getRateLive("usd", "inr"))
+    )
+    // Let all eight reach the refresh before it settles.
+    await Promise.resolve()
+    await Promise.resolve()
+    resolveFetch({})
+    await inflight
+
+    expect(refreshRatesFromProvider).toHaveBeenCalledTimes(1)
+  })
+
+  it("falls back to the stale cached rate when the provider is unreachable", async () => {
+    const service = makeService({
+      getRate: jest.fn().mockResolvedValue(88),
+      getLastFetchedAt: jest.fn().mockResolvedValue(new Date(0)),
+      refreshRatesFromProvider: jest
+        .fn()
+        .mockRejectedValue(new Error("ECONNREFUSED")),
+    })
+
+    // A stale rate beats refusing a payout outright.
+    await expect(service.getRateLive("usd", "inr")).resolves.toBe(88)
+  })
+
+  it("still throws when the provider is unreachable AND nothing is cached", async () => {
+    // 🔴 The one case that must NOT resolve. `convertAmount` reads a missing
+    // rate as a refusal; anything returned here would be treated as real.
+    const service = makeService({
+      getRate: jest.fn().mockRejectedValue(new Error("no path")),
+      getLastFetchedAt: jest.fn().mockResolvedValue(null),
+      refreshRatesFromProvider: jest
+        .fn()
+        .mockRejectedValue(new Error("ECONNREFUSED")),
+    })
+
+    await expect(service.getRateLive("usd", "inr")).rejects.toThrow(
+      /ECONNREFUSED/
+    )
+  })
+
+  it("throws when the refresh succeeds but the pair still does not exist", async () => {
+    const service = makeService({
+      getRate: jest.fn().mockRejectedValue(new Error("no path from usd to xyz")),
+      getLastFetchedAt: jest.fn().mockResolvedValue(null),
+      refreshRatesFromProvider: jest.fn().mockResolvedValue({}),
+    })
+
+    await expect(service.getRateLive("usd", "xyz")).rejects.toThrow(/no path/)
+  })
+
+  it("honours an explicit maxAgeMs", async () => {
+    const refreshRatesFromProvider = jest.fn().mockResolvedValue({})
+    const service = makeService({
+      getRate: jest.fn().mockResolvedValue(96.49),
+      getLastFetchedAt: jest.fn().mockResolvedValue(new Date(Date.now() - 2 * HOUR)),
+      refreshRatesFromProvider,
+    })
+
+    // Two hours old: fine at the 24h default, stale at a 1h ceiling.
+    await service.getRateLive("usd", "inr")
+    expect(refreshRatesFromProvider).not.toHaveBeenCalled()
+
+    await service.getRateLive("usd", "inr", { maxAgeMs: HOUR })
+    expect(refreshRatesFromProvider).toHaveBeenCalledTimes(1)
+  })
+})

--- a/apps/backend/src/modules/fx_rates/service.ts
+++ b/apps/backend/src/modules/fx_rates/service.ts
@@ -96,6 +96,81 @@ class FxRatesService extends MedusaService({ FxRate, FxPriceMeta }) {
   }
 
   /**
+   * `getRate`, but a cache that is missing the pair or too old triggers ONE
+   * live provider fetch and a retry.
+   *
+   * `getRate` alone answers off a cache that is only as fresh as whoever last
+   * refreshed it, and it cannot tell "this pair does not exist" from "nobody
+   * has refreshed in a month" (#1512). For money that is about to be written —
+   * converting a payout line — reading a stale rate silently is the failure
+   * mode worth spending a network call to avoid. A remembered rate was once
+   * 24% wrong (#1538).
+   *
+   * 🔴 At most ONE refresh, ever, per service instance per concurrent burst.
+   * Unbounded FX fetching has OOM-killed production twice (#1368), so the
+   * in-flight promise is shared: N lines converting at once trigger one fetch,
+   * not N. A refresh that has already happened is not repeated for a pair the
+   * provider simply does not carry — otherwise every unknown currency becomes
+   * a fresh HTTP call.
+   *
+   * ⚠️ Falls back to the cached value if the provider fetch fails but the cache
+   * could answer. A stale rate beats no payout; a MISSING rate still throws,
+   * because `convertAmount` must never see a rate it can treat as 1.
+   */
+  async getRateLive(
+    from: string,
+    to: string,
+    options?: { maxAgeMs?: number }
+  ): Promise<number> {
+    const fromCode = from.toLowerCase()
+    const toCode = to.toLowerCase()
+    if (fromCode === toCode) return 1
+
+    // 24h by default: rates move slowly enough that a day-old figure is fine,
+    // and often enough that a month-old one is not.
+    const maxAgeMs = options?.maxAgeMs ?? 24 * 60 * 60 * 1000
+
+    let cached: number | null = null
+    try {
+      cached = await this.getRate(fromCode, toCode)
+    } catch {
+      cached = null
+    }
+
+    const lastFetchedAt = await this.getLastFetchedAt()
+    const isStale =
+      !lastFetchedAt || Date.now() - lastFetchedAt.getTime() > maxAgeMs
+
+    if (cached !== null && !isStale) return cached
+
+    try {
+      await this.refreshOnce()
+    } catch (e) {
+      // Provider unreachable. A stale cached rate is still better than
+      // refusing, but nothing is better than a wrong one.
+      if (cached !== null) return cached
+      throw e
+    }
+
+    return this.getRate(fromCode, toCode)
+  }
+
+  /**
+   * Shared in-flight refresh, so concurrent callers cause one provider fetch
+   * rather than one each. See the fanout note on `getRateLive`.
+   */
+  protected refreshInFlight: Promise<unknown> | null = null
+
+  protected async refreshOnce(): Promise<unknown> {
+    if (!this.refreshInFlight) {
+      this.refreshInFlight = this.refreshRatesFromProvider().finally(() => {
+        this.refreshInFlight = null
+      })
+    }
+    return this.refreshInFlight
+  }
+
+  /**
    * Fetch fresh rates from the configured provider and upsert into the
    * fx_rate table. Returns counts of inserts/updates.
    */

--- a/apps/backend/src/modules/payment_submissions/migrations/.snapshot-payment-submissions.json
+++ b/apps/backend/src/modules/payment_submissions/migrations/.snapshot-payment-submissions.json
@@ -394,7 +394,9 @@
           "comment": null,
           "enumItems": [
             "design",
-            "task"
+            "task",
+            "run",
+            "inventory_order"
           ],
           "mappedType": "enum"
         },
@@ -525,6 +527,54 @@
           "comment": null,
           "enumItems": [],
           "mappedType": "datetime"
+        },
+        "inventory_order_id": {
+          "name": "inventory_order_id",
+          "type": "text",
+          "unsigned": false,
+          "autoincrement": false,
+          "primary": false,
+          "nullable": true,
+          "unique": false,
+          "length": null,
+          "precision": null,
+          "scale": null,
+          "default": null,
+          "comment": null,
+          "enumItems": [],
+          "mappedType": "text"
+        },
+        "inventory_order_name": {
+          "name": "inventory_order_name",
+          "type": "text",
+          "unsigned": false,
+          "autoincrement": false,
+          "primary": false,
+          "nullable": true,
+          "unique": false,
+          "length": null,
+          "precision": null,
+          "scale": null,
+          "default": null,
+          "comment": null,
+          "enumItems": [],
+          "mappedType": "text"
+        },
+        "order_id": {
+          "name": "order_id",
+          "type": "text",
+          "unsigned": false,
+          "autoincrement": false,
+          "primary": false,
+          "nullable": true,
+          "unique": false,
+          "length": null,
+          "precision": null,
+          "scale": null,
+          "default": null,
+          "comment": null,
+          "enumItems": [],
+          "mappedType": "text"
         }
       },
       "name": "payment_submission_item",

--- a/apps/backend/src/modules/payment_submissions/migrations/Migration20260828120000.ts
+++ b/apps/backend/src/modules/payment_submissions/migrations/Migration20260828120000.ts
@@ -1,0 +1,89 @@
+import { Migration } from "@medusajs/framework/mikro-orm/migrations";
+
+/**
+ * Payment submissions become the central payout registry (#1612): a line can
+ * now be sourced from a production RUN or an INVENTORY ORDER, not only a
+ * design or a task.
+ *
+ * ## Why the existing two values could not cover it
+ *
+ * **Runs.** The seven runs behind retail order #79 were minted from
+ * `order.fulfillment_created` and carry `design_id: null`. They are not
+ * design-backed and never will be, so no `design` line can express them —
+ * which is why `payable-runs`, whose first act is
+ * `runs.filter(r => !!r.design_id)`, cannot see a single one of them. The work
+ * was done, delivered and paid for out of band, and the system had nowhere to
+ * write it down.
+ *
+ * **Inventory orders.** A partner we BOUGHT material from is owed the order's
+ * `total_price`. That is not labour on a design and not a task, so it too had
+ * no home: ₹28,200 and ₹3,000 of delivered material sat unrecorded.
+ *
+ * ## 🔴 The check constraint is the load-bearing line here
+ *
+ * `source_type` is a `text` column with an inline
+ * `check ("source_type" in ('design', 'task'))` from Migration20260417120000.
+ * Widening the TypeScript enum alone compiles clean and then fails at INSERT
+ * against a constraint no type checker reads. The constraint is dropped and
+ * recreated below, and that — not the three new columns — is what actually
+ * unblocks the feature.
+ *
+ * ## What this migration does NOT do
+ *
+ * It adds columns and widens a constraint. It classifies nothing and back-fills
+ * nothing: every existing row is a `design` or `task` line and stays exactly as
+ * it is. Recording the unbilled retail and inventory payouts is an operator
+ * decision about money, and belongs in a route someone can inspect first — the
+ * same reasoning Migration20260826230000 gives for refusing to recover run ids
+ * from `metadata`. A migration that guesses at money is a migration nobody can
+ * review.
+ *
+ * ⚠️ Widening a source type is not a free extension. Every "already paid for"
+ * guard used to fetch priors with `{ design_id: [...] }`, so a line carrying
+ * `design_id: null` was invisible to it and its runs could be billed a second
+ * time from the design side. Those guards are scoped by PARTNER as of this
+ * change — see `workflows/payment_submissions/lib/run-claims`. Any future value
+ * added to this constraint must be checked against them first.
+ */
+export class Migration20260828120000 extends Migration {
+
+  override async up(): Promise<void> {
+    // 🔴 The actual unblocker. Postgres names an inline column check
+    // `<table>_<column>_check`; dropped by that name, and `if exists` keeps
+    // this idempotent on an environment where it has already been widened.
+    this.addSql(`alter table if exists "payment_submission_item" drop constraint if exists "payment_submission_item_source_type_check";`);
+    this.addSql(`alter table if exists "payment_submission_item" add constraint "payment_submission_item_source_type_check" check ("source_type" in ('design', 'task', 'run', 'inventory_order'));`);
+
+    // The material purchase a line pays for.
+    this.addSql(`alter table if exists "payment_submission_item" add column if not exists "inventory_order_id" text null;`);
+    this.addSql(`alter table if exists "payment_submission_item" add column if not exists "inventory_order_name" text null;`);
+
+    /**
+     * The commissioning retail order, for a run-sourced line. Denormalised
+     * rather than re-derived through the runs, so that "what did order #79 cost
+     * us in labour" is one query — the traceability gap #1598 is about.
+     */
+    this.addSql(`alter table if exists "payment_submission_item" add column if not exists "order_id" text null;`);
+  }
+
+  override async down(): Promise<void> {
+    /**
+     * ⚠️ Narrowing the constraint back would fail on any row written as `run`
+     * or `inventory_order` while it was open, so those rows are re-sourced to
+     * the closest surviving truth before the constraint is restored. A `down()`
+     * that throws on real data is a `down()` nobody can run.
+     *
+     * This is lossy by nature — the ids in the dropped columns are gone. That
+     * is the honest cost of reverting, and it is stated here rather than
+     * discovered.
+     */
+    this.addSql(`update "payment_submission_item" set "source_type" = 'design' where "source_type" in ('run', 'inventory_order');`);
+    this.addSql(`alter table if exists "payment_submission_item" drop constraint if exists "payment_submission_item_source_type_check";`);
+    this.addSql(`alter table if exists "payment_submission_item" add constraint "payment_submission_item_source_type_check" check ("source_type" in ('design', 'task'));`);
+
+    this.addSql(`alter table if exists "payment_submission_item" drop column if exists "inventory_order_id";`);
+    this.addSql(`alter table if exists "payment_submission_item" drop column if exists "inventory_order_name";`);
+    this.addSql(`alter table if exists "payment_submission_item" drop column if exists "order_id";`);
+  }
+
+}

--- a/apps/backend/src/modules/payment_submissions/models/payment_submission_item.ts
+++ b/apps/backend/src/modules/payment_submissions/models/payment_submission_item.ts
@@ -17,9 +17,44 @@ const PaymentSubmissionItem = model.define("payment_submission_item", {
   // Task source (nullable — may be a design-based item instead)
   task_id: model.text().nullable(),
   task_name: model.text().nullable(),
-  // Discriminator so consumers don't need to sniff which id is populated
+  /**
+   * Inventory-order source (#1612) — a partner we BOUGHT material from, rather
+   * than one who did labour for us. The payout is the order's `total_price`.
+   */
+  inventory_order_id: model.text().nullable(),
+  inventory_order_name: model.text().nullable(),
+  /**
+   * The commissioning retail order, for a `run`-sourced line.
+   *
+   * A run born from a customer order already carries `order_id`, `product_id`,
+   * `variant_id` and `order_line_item_id` — but nothing wrote the order onto
+   * the PAYOUT, so a payout could not be traced back to the order that caused
+   * it (#1598). Denormalised here rather than re-derived from the runs, since
+   * a reader asking "what did order #79 cost us in labour" should not have to
+   * fan out through every run to find out.
+   */
+  order_id: model.text().nullable(),
+  /**
+   * Discriminator so consumers don't need to sniff which id is populated.
+   *
+   * 🔴 Adding a value here is not a free extension. Every "already paid for"
+   * guard was keyed on `design_id`, so a line sourced from anything else was
+   * invisible to it and its runs could be billed a second time from the design
+   * side. Those guards are now scoped by PARTNER — see
+   * `workflows/payment_submissions/lib/run-claims`. A future source type MUST
+   * be checked against them before it is added, or it is a double-pay hole by
+   * construction.
+   *
+   * - `design`          — labour on a design. The original behaviour.
+   * - `task`            — a completed task. Never has a run.
+   * - `run`             — production runs directly, including runs minted from
+   *                       a retail order's fulfillment, which carry no
+   *                       `design_id` at all and so can never be a `design`
+   *                       line.
+   * - `inventory_order` — material we bought from the partner.
+   */
   source_type: model
-    .enum(["design", "task"])
+    .enum(["design", "task", "run", "inventory_order"])
     .default("design"),
   /**
    * What this line bills, in total. Authoritative — every reader sums `amount`

--- a/apps/backend/src/workflows/payment_submissions/create-payment-submission.ts
+++ b/apps/backend/src/workflows/payment_submissions/create-payment-submission.ts
@@ -22,6 +22,10 @@ import {
   listPartnerRunClaims,
   runsAlreadyClaimedMessage,
 } from "./lib/run-claims"
+import {
+  normaliseCurrency,
+  resolveSubmissionCurrency,
+} from "./lib/submission-currency"
 import { PARTNER_MODULE } from "../../modules/partner"
 import { DESIGN_MODULE } from "../../modules/designs"
 import { TASKS_MODULE } from "../../modules/tasks"
@@ -95,6 +99,16 @@ export type CreatePaymentSubmissionInput = {
    * spelling mistake away from reading nothing at all (#1557).
    */
   production_run_ids?: Record<string, string[]>
+  /**
+   * What the payout is denominated in. Absent means the partner's own
+   * `currency_code`, and `inr` if they have none — see
+   * `lib/submission-currency`, which owns that precedence.
+   *
+   * ⚠️ This is the currency of the SUBMISSION, not of its sources. A line
+   * priced in another currency is converted into this one at an FX rate that
+   * is recorded on the line, never applied silently.
+   */
+  currency?: string
 }
 
 type ValidatedDesign = {
@@ -783,6 +797,51 @@ const validateTasksForSubmissionStep = createStep(
 )
 
 // Step 2: Create the submission record with items (designs and/or tasks)
+/**
+ * Decide what the payout is denominated in, once, before anything is priced.
+ *
+ * A step rather than a `transform` because it has to READ the partner, and the
+ * precedence (explicit → partner's own → inr) belongs in one place — see
+ * `lib/submission-currency`. Scattering it across callers is how two routes
+ * come to disagree about what currency a partner is paid in.
+ *
+ * ⚠️ A partner whose `currency_code` is NULL is real (hrhandloom's is), so the
+ * lookup failing to produce one is an expected path, not an error.
+ */
+const resolveSubmissionCurrencyStep = createStep(
+  "resolve-submission-currency",
+  async (
+    input: { partner_id: string; currency?: string },
+    { container }
+  ) => {
+    if (normaliseCurrency(input.currency)) {
+      return new StepResponse(normaliseCurrency(input.currency))
+    }
+
+    let partnerCurrency: string | null = null
+    try {
+      const query: any = container.resolve(ContainerRegistrationKeys.QUERY)
+      const { data } = await query.graph({
+        entity: "partner",
+        fields: ["id", "currency_code"],
+        filters: { id: input.partner_id },
+      })
+      partnerCurrency = (data || [])[0]?.currency_code ?? null
+    } catch {
+      // A partner we cannot read is not a reason to refuse the payout; it just
+      // means we fall through to the default below.
+      partnerCurrency = null
+    }
+
+    return new StepResponse(
+      resolveSubmissionCurrency({
+        explicit: input.currency,
+        partnerCurrency,
+      })
+    )
+  }
+)
+
 const createSubmissionRecordStep = createStep(
   "create-submission-record",
   async (
@@ -794,6 +853,12 @@ const createSubmissionRecordStep = createStep(
       documents?: Array<{ id?: string; url: string; filename?: string; mimeType?: string }>
       metadata?: Record<string, any>
       status?: "Draft" | "Pending"
+      /**
+       * What the payout is denominated in. Resolved by the workflow (explicit
+       * → partner's own → inr) rather than defaulted here, so there is exactly
+       * one place that decides it. See `lib/submission-currency`.
+       */
+      currency?: string
     },
     { container }
   ) => {
@@ -825,7 +890,14 @@ const createSubmissionRecordStep = createStep(
       partner_id: input.partner_id,
       status,
       total_amount,
-      currency: "inr",
+      /**
+       * 🔴 Was hardcoded `"inr"`. Every submission ever written was INR, so
+       * nothing had exercised the alternative — but the retail payout for
+       * order #79 is derived in USD and settled in rupees, and partners exist
+       * whose own `currency_code` is NULL. Resolved upstream so a caller
+       * stating a currency is not silently overridden by a default.
+       */
+      currency: normaliseCurrency(input.currency) || "inr",
       submitted_at: status === "Draft" ? null : new Date(),
       notes: input.notes || null,
       documents: (input.documents || null) as Record<string, unknown> | null,
@@ -1112,6 +1184,11 @@ export const createPaymentSubmissionWorkflow = createWorkflow(
       cost_overrides: costOverrides.tasks,
     })
 
+    const currency = resolveSubmissionCurrencyStep({
+      partner_id: input.partner_id,
+      currency: input.currency,
+    })
+
     const submission = createSubmissionRecordStep({
       partner_id: input.partner_id,
       designs: validatedDesigns,
@@ -1120,6 +1197,7 @@ export const createPaymentSubmissionWorkflow = createWorkflow(
       documents: input.documents,
       metadata: input.metadata,
       status: input.status,
+      currency,
     })
 
     linkSubmissionToPartnerStep({

--- a/apps/backend/src/workflows/payment_submissions/create-payment-submission.ts
+++ b/apps/backend/src/workflows/payment_submissions/create-payment-submission.ts
@@ -18,6 +18,10 @@ import {
   designsBilledWithoutRunEvidence,
   runlessResubmitMessage,
 } from "./lib/run-evidence-guard"
+import {
+  listPartnerRunClaims,
+  runsAlreadyClaimedMessage,
+} from "./lib/run-claims"
 import { PARTNER_MODULE } from "../../modules/partner"
 import { DESIGN_MODULE } from "../../modules/designs"
 import { TASKS_MODULE } from "../../modules/tasks"
@@ -542,32 +546,31 @@ const validateDesignsForSubmissionStep = createStep(
         }
       }
 
-      // Already paid for? A Rejected submission never paid anyone, so its
-      // lines release their runs; everything else — Draft, Pending,
-      // Under_Review, Approved, Paid — is a live claim on that run.
+      /**
+       * Already paid for? A Rejected submission never paid anyone, so its
+       * lines release their runs; everything else — Draft, Pending,
+       * Under_Review, Approved, Paid — is a live claim on that run.
+       *
+       * 🔴 Scoped by PARTNER, not by design. This used to fetch priors with
+       * `{ design_id: input.design_ids }`, on the reasoning that a run belongs
+       * to one design so a prior billing of it could only sit on a line for
+       * that design. A line sourced from anything other than a design carries
+       * `design_id: null`, so that query could not see it, and the same run
+       * could be billed once from each side with neither claim visible to the
+       * other. See `lib/run-claims`.
+       */
       const submissionService: PaymentSubmissionsService = container.resolve(
         PAYMENT_SUBMISSIONS_MODULE
       )
-      const priorItems = await submissionService.listPaymentSubmissionItems(
-        { design_id: input.design_ids },
-        { relations: ["submission"] }
+      const billed = await listPartnerRunClaims(
+        submissionService as any,
+        input.partner_id
       )
-      const billed = new Map<string, string>()
-      for (const item of (priorItems || []) as any[]) {
-        if (item.submission?.status === "Rejected") continue
-        for (const runId of (item.production_run_ids || []) as string[]) {
-          if (!billed.has(runId)) {
-            billed.set(runId, item.submission?.id || item.submission_id)
-          }
-        }
-      }
       const duplicates = allClaimedRunIds.filter((id) => billed.has(id))
       if (duplicates.length) {
         throw new MedusaError(
           MedusaError.Types.INVALID_DATA,
-          `Production runs already paid for: ${duplicates
-            .map((id) => `${id} (submission ${billed.get(id)})`)
-            .join(", ")}`
+          runsAlreadyClaimedMessage(duplicates, billed)
         )
       }
     }

--- a/apps/backend/src/workflows/payment_submissions/lib/__tests__/inventory-order-value.unit.spec.ts
+++ b/apps/backend/src/workflows/payment_submissions/lib/__tests__/inventory-order-value.unit.spec.ts
@@ -1,0 +1,170 @@
+import {
+  describeInventoryOrderValue,
+  valueInventoryOrderByReceipts,
+} from "../inventory-order-value"
+
+/**
+ * The fixture is the REAL shape of `inv_order_01K36TE2WB5BQR1MS6KESXP7Q3` as
+ * read from production on 2026-08-28 — ten lines, five of them with receipts,
+ * `price` per unit, receipts as typed `line_fulfillments` deltas.
+ *
+ * 🔑 A fixture tidier than reality certifies the wrong code: the awkward parts
+ * here are the point. Two deltas on one line (10 + 6), a fractional receipt
+ * (10.5), a line ordered 80 with nothing delivered, and an order whose
+ * `total_price` (88,885) is nowhere near what is owed (25,670).
+ */
+const PARTIAL_ORDER_LINES = [
+  { id: "01K36TE34N", quantity: 4, price: 400, material_name: "Yellow cheque two by one", line_fulfillments: [] },
+  { id: "01K36TE3C0", quantity: 4.5, price: 450, material_name: "Brown Black cheque", line_fulfillments: [] },
+  { id: "01K36TE3KB", quantity: 5.5, price: 380, material_name: "Brown Dark Weft Line", line_fulfillments: [] },
+  {
+    id: "01K36TE3TR",
+    quantity: 16,
+    price: 400,
+    material_name: "Double Black Stripes Cheque over White Fabric",
+    line_fulfillments: [{ quantity_delta: 10 }, { quantity_delta: 6 }],
+  },
+  {
+    id: "01K36TE425",
+    quantity: 31,
+    price: 430,
+    material_name: "White & Black & Red cheque",
+    line_fulfillments: [{ quantity_delta: 10 }],
+  },
+  { id: "01K36TE49K", quantity: 10.5, price: 400, material_name: "White & Indigo cheque", line_fulfillments: [] },
+  {
+    id: "01K36TE4GX",
+    quantity: 22,
+    price: 380,
+    material_name: "Black & Red line  Cheque Over White Fabric",
+    line_fulfillments: [{ quantity_delta: 10.5 }],
+  },
+  {
+    id: "01K36TE4RB",
+    quantity: 21,
+    price: 380,
+    material_name: " Single Black Cheque Line Over White Fabric",
+    line_fulfillments: [{ quantity_delta: 21 }],
+  },
+  { id: "01K36TE4ZN", quantity: 80, price: 380, material_name: "Yellow cheque", line_fulfillments: [] },
+  {
+    id: "01K36TE56Y",
+    quantity: 50,
+    price: 250,
+    material_name: "Kala cotton white",
+    line_fulfillments: [{ quantity_delta: 12 }],
+  },
+]
+
+describe("valueInventoryOrderByReceipts", () => {
+  it("reproduces the hrhandloom partial order at 25,670", () => {
+    const value = valueInventoryOrderByReceipts(PARTIAL_ORDER_LINES)
+
+    expect(value.total).toBe(25670)
+    expect(value.received_quantity).toBe(69.5)
+  })
+
+  it("bills the ORDERED total on no line — 88,885 is not what is owed", () => {
+    const value = valueInventoryOrderByReceipts(PARTIAL_ORDER_LINES)
+
+    // The trap this helper exists to avoid: `total_price` overpays by 63,215.
+    expect(value.total).not.toBe(88885)
+  })
+
+  it("sums multiple deltas on one line rather than taking the latest", () => {
+    const value = valueInventoryOrderByReceipts(PARTIAL_ORDER_LINES)
+    const doubleLine = value.lines.find((l) => l.line_id === "01K36TE3TR")
+
+    // 10 + 6 = 16 received, at 400/unit. Taking the latest delta would bill
+    // 6 x 400 = 2,400 and underpay by 4,000.
+    expect(doubleLine?.received).toBe(16)
+    expect(doubleLine?.amount).toBe(6400)
+  })
+
+  it("treats price as PER UNIT, not as the line total", () => {
+    const value = valueInventoryOrderByReceipts(PARTIAL_ORDER_LINES)
+    const singleLine = value.lines.find((l) => l.line_id === "01K36TE4RB")
+
+    // 21 x 380. Reading `price` as the line total would bill 380.
+    expect(singleLine?.amount).toBe(7980)
+  })
+
+  it("drops lines with no receipt instead of billing them at zero", () => {
+    const value = valueInventoryOrderByReceipts(PARTIAL_ORDER_LINES)
+
+    expect(value.lines).toHaveLength(5)
+    expect(value.lines.map((l) => l.line_id)).not.toContain("01K36TE4ZN")
+  })
+
+  it("handles a fractional receipt without a floating-point tail", () => {
+    const value = valueInventoryOrderByReceipts([
+      { id: "l1", quantity: 22, price: 380, line_fulfillments: [{ quantity_delta: 10.4 }, { quantity_delta: 10.5 }] },
+    ])
+
+    expect(value.lines[0].received).toBe(20.9)
+    expect(value.lines[0].amount).toBe(7942)
+  })
+
+  it("lets a negative delta reduce what is owed", () => {
+    // `adjust` / `correction` events are real, and a correction that removes
+    // goods must remove the money with it.
+    const value = valueInventoryOrderByReceipts([
+      { id: "l1", quantity: 10, price: 100, line_fulfillments: [{ quantity_delta: 10 }, { quantity_delta: -4 }] },
+    ])
+
+    expect(value.lines[0].received).toBe(6)
+    expect(value.total).toBe(600)
+  })
+
+  it("values the delivered order at its full ordered price", () => {
+    // inv_order_01KXZP0DFD… — 10 units of Dusty Rose at 300, fully received.
+    const value = valueInventoryOrderByReceipts([
+      {
+        id: "01KXZP0DFE",
+        quantity: 10,
+        price: 300,
+        material_name: "Organic Kala Cotton — Dusty Rose",
+        line_fulfillments: [{ quantity_delta: 10 }],
+      },
+    ])
+
+    expect(value.total).toBe(3000)
+  })
+
+  it("returns zero for an order with no receipts at all", () => {
+    const value = valueInventoryOrderByReceipts([
+      { id: "l1", quantity: 5, price: 100, line_fulfillments: [] },
+    ])
+
+    expect(value.total).toBe(0)
+    expect(value.lines).toHaveLength(0)
+  })
+
+  it("tolerates null fulfillments and null price", () => {
+    const value = valueInventoryOrderByReceipts([
+      { id: "l1", quantity: 5, price: null, line_fulfillments: null },
+      { id: "l2", quantity: 5, price: null, line_fulfillments: [{ quantity_delta: 3 }] },
+    ])
+
+    expect(value.total).toBe(0)
+    expect(value.lines).toHaveLength(1)
+  })
+})
+
+describe("describeInventoryOrderValue", () => {
+  it("reads as something a partner can check against their delivery notes", () => {
+    const value = valueInventoryOrderByReceipts([
+      {
+        id: "01K36TE4RB",
+        quantity: 21,
+        price: 380,
+        material_name: "Single Black Cheque Line Over White Fabric",
+        line_fulfillments: [{ quantity_delta: 21 }],
+      },
+    ])
+
+    expect(describeInventoryOrderValue(value)).toBe(
+      "Single Black Cheque Line Over White Fabric: 21 x 380 = 7980"
+    )
+  })
+})

--- a/apps/backend/src/workflows/payment_submissions/lib/__tests__/run-claims.unit.spec.ts
+++ b/apps/backend/src/workflows/payment_submissions/lib/__tests__/run-claims.unit.spec.ts
@@ -1,0 +1,172 @@
+import {
+  foldRunClaims,
+  listPartnerRunClaims,
+  runsAlreadyClaimedMessage,
+} from "../run-claims"
+
+/**
+ * The defect these cover: every "is this run already paid for" guard fetched
+ * priors with `{ design_id: [...] }`, so a claim held by a line with
+ * `design_id: null` was invisible and the run could be billed twice.
+ *
+ * The load-bearing case is `finds a claim held by a line with no design_id`.
+ * Against the old design-scoped query that case CANNOT pass — the prior is
+ * simply not in the result set.
+ */
+describe("foldRunClaims", () => {
+  it("finds a claim held by a line with no design_id", () => {
+    const claims = foldRunClaims([
+      {
+        submission_id: "sub_run_sourced",
+        submission_status: "Paid",
+        production_run_ids: ["run_a", "run_b"],
+      },
+    ])
+
+    expect(claims.get("run_a")).toEqual({
+      submission_id: "sub_run_sourced",
+      submission_status: "Paid",
+    })
+    expect(claims.get("run_b")?.submission_id).toBe("sub_run_sourced")
+  })
+
+  it("ignores a Rejected submission — its lines release their runs", () => {
+    const claims = foldRunClaims([
+      {
+        submission_id: "sub_rejected",
+        submission_status: "Rejected",
+        production_run_ids: ["run_a"],
+      },
+    ])
+
+    expect(claims.has("run_a")).toBe(false)
+  })
+
+  it("treats a Draft as a live claim on a named run", () => {
+    // Unlike the runless guard, which exempts Draft so a partner can submit
+    // the auto-draft they were handed. A run NAMED by a draft is different.
+    const claims = foldRunClaims([
+      {
+        submission_id: "sub_draft",
+        submission_status: "Draft",
+        production_run_ids: ["run_a"],
+      },
+    ])
+
+    expect(claims.get("run_a")?.submission_status).toBe("Draft")
+  })
+
+  it("keeps the earliest claim when two lines name the same run", () => {
+    const claims = foldRunClaims([
+      {
+        submission_id: "sub_first",
+        submission_status: "Paid",
+        production_run_ids: ["run_a"],
+      },
+      {
+        submission_id: "sub_second",
+        submission_status: "Pending",
+        production_run_ids: ["run_a"],
+      },
+    ])
+
+    expect(claims.get("run_a")?.submission_id).toBe("sub_first")
+  })
+
+  it("tolerates a line with no runs at all", () => {
+    const claims = foldRunClaims([
+      {
+        submission_id: "sub_task",
+        submission_status: "Paid",
+        production_run_ids: null,
+      },
+    ])
+
+    expect(claims.size).toBe(0)
+  })
+})
+
+describe("listPartnerRunClaims", () => {
+  const service = (submissions: any[], items: any[]) => ({
+    listPaymentSubmissions: jest.fn().mockResolvedValue(submissions),
+    listPaymentSubmissionItems: jest.fn().mockResolvedValue(items),
+  })
+
+  it("sees a run-sourced claim that a design-scoped query would miss", async () => {
+    const svc = service(
+      [{ id: "sub_1" }],
+      [
+        {
+          submission_id: "sub_1",
+          submission: { id: "sub_1", status: "Paid" },
+          design_id: null, // ← the whole point
+          production_run_ids: ["run_order_79"],
+        },
+      ]
+    )
+
+    const claims = await listPartnerRunClaims(svc as any, "partner_1")
+
+    expect(claims.has("run_order_79")).toBe(true)
+    // Scoped by partner, so the submission lookup is the partner's, not a design's.
+    expect(svc.listPaymentSubmissions).toHaveBeenCalledWith({
+      partner_id: "partner_1",
+    })
+  })
+
+  it("excludes the submission being edited, so a claim cannot conflict with itself", async () => {
+    const svc = service(
+      [{ id: "sub_self" }, { id: "sub_other" }],
+      [
+        {
+          submission_id: "sub_other",
+          submission: { id: "sub_other", status: "Pending" },
+          production_run_ids: ["run_b"],
+        },
+      ]
+    )
+
+    await listPartnerRunClaims(svc as any, "partner_1", {
+      excludeSubmissionId: "sub_self",
+    })
+
+    expect(svc.listPaymentSubmissionItems).toHaveBeenCalledWith(
+      { submission_id: ["sub_other"] },
+      { relations: ["submission"] }
+    )
+  })
+
+  it("returns empty without querying items when the partner has no submissions", async () => {
+    const svc = service([], [])
+
+    const claims = await listPartnerRunClaims(svc as any, "partner_1")
+
+    expect(claims.size).toBe(0)
+    expect(svc.listPaymentSubmissionItems).not.toHaveBeenCalled()
+  })
+
+  it("returns empty for a missing partner id rather than querying every row", async () => {
+    const svc = service([{ id: "sub_1" }], [])
+
+    const claims = await listPartnerRunClaims(svc as any, "")
+
+    expect(claims.size).toBe(0)
+    expect(svc.listPaymentSubmissions).not.toHaveBeenCalled()
+  })
+})
+
+describe("runsAlreadyClaimedMessage", () => {
+  it("names the submission holding each run", () => {
+    const claims = foldRunClaims([
+      {
+        submission_id: "sub_1",
+        submission_status: "Paid",
+        production_run_ids: ["run_a"],
+      },
+    ])
+
+    expect(runsAlreadyClaimedMessage(["run_a"], claims)).toBe(
+      "Production runs already paid for: run_a (submission sub_1, Paid)"
+    )
+  })
+})

--- a/apps/backend/src/workflows/payment_submissions/lib/__tests__/submission-currency.unit.spec.ts
+++ b/apps/backend/src/workflows/payment_submissions/lib/__tests__/submission-currency.unit.spec.ts
@@ -1,0 +1,137 @@
+import {
+  convertAmount,
+  normaliseCurrency,
+  resolveSubmissionCurrency,
+  withConversion,
+} from "../submission-currency"
+
+describe("resolveSubmissionCurrency", () => {
+  it("prefers what the caller explicitly asked for", () => {
+    // An admin recording a payout already made in USD is stating a fact; the
+    // partner default must not silently override it.
+    expect(
+      resolveSubmissionCurrency({ explicit: "usd", partnerCurrency: "inr" })
+    ).toBe("usd")
+  })
+
+  it("falls back to the partner's own currency", () => {
+    expect(resolveSubmissionCurrency({ partnerCurrency: "USD" })).toBe("usd")
+  })
+
+  it("falls back to inr when the partner's currency is null", () => {
+    // hrhandloom's `currency_code` really is NULL on prod.
+    expect(resolveSubmissionCurrency({ partnerCurrency: null })).toBe("inr")
+  })
+
+  it("ignores blank and whitespace-only values rather than adopting them", () => {
+    expect(
+      resolveSubmissionCurrency({ explicit: "   ", partnerCurrency: "eur" })
+    ).toBe("eur")
+  })
+
+  it("normalises case", () => {
+    expect(normaliseCurrency("  INR ")).toBe("inr")
+  })
+})
+
+describe("convertAmount", () => {
+  it("passes an amount through untouched when the currencies match", () => {
+    const result = convertAmount({ amount: 8974, from: "inr", to: "inr" })
+
+    expect(result.amount).toBe(8974)
+    expect(result.conversion).toBeNull()
+  })
+
+  it("needs no rate for a same-currency line", () => {
+    expect(() =>
+      convertAmount({ amount: 100, from: "inr", to: "INR" })
+    ).not.toThrow()
+  })
+
+  /**
+   * 🔴 The load-bearing test. `amount * (rate ?? 1)` looks defensive and bills
+   * a USD figure as rupees — off by ~88x with nothing in the record showing a
+   * conversion was attempted. Refusing is the only safe answer.
+   */
+  it("REFUSES a cross-currency line with no rate rather than defaulting to 1", () => {
+    expect(() => convertAmount({ amount: 93, from: "usd", to: "inr" })).toThrow(
+      /without an exchange rate/
+    )
+  })
+
+  it("refuses a zero, negative, NaN or infinite rate", () => {
+    for (const rate of [0, -1, NaN, Infinity, null, undefined]) {
+      expect(() =>
+        convertAmount({ amount: 93, from: "usd", to: "inr", rate: rate as any })
+      ).toThrow(/without an exchange rate/)
+    }
+  })
+
+  it("converts and records the arithmetic so it can be replayed", () => {
+    // The order #79 payout: $93 settled as rupees.
+    const result = convertAmount({
+      amount: 93,
+      from: "usd",
+      to: "inr",
+      rate: 96.49,
+    })
+
+    expect(result.amount).toBe(8973.57)
+    expect(result.conversion).toEqual({
+      source_amount: 93,
+      source_currency: "usd",
+      target_currency: "inr",
+      rate: 96.49,
+      converted_amount: 8973.57,
+    })
+  })
+
+  it("rounds to paise rather than leaving a floating-point tail", () => {
+    const result = convertAmount({
+      amount: 0.1 + 0.2,
+      from: "usd",
+      to: "inr",
+      rate: 3,
+    })
+
+    expect(result.amount).toBe(0.9)
+  })
+
+  it("rejects a non-numeric amount instead of writing NaN", () => {
+    expect(() =>
+      convertAmount({ amount: undefined as any, from: "usd", to: "inr", rate: 90 })
+    ).toThrow(/non-numeric amount/)
+  })
+})
+
+describe("withConversion", () => {
+  it("preserves what the pricing step already recorded", () => {
+    const result = withConversion(
+      { basis: "produced_quantity", rate: 1200 },
+      {
+        source_amount: 93,
+        source_currency: "usd",
+        target_currency: "inr",
+        rate: 96.49,
+        converted_amount: 8973.57,
+      }
+    )
+
+    expect(result).toEqual({
+      basis: "produced_quantity",
+      rate: 1200,
+      fx: {
+        source_amount: 93,
+        source_currency: "usd",
+        target_currency: "inr",
+        rate: 96.49,
+        converted_amount: 8973.57,
+      },
+    })
+  })
+
+  it("leaves the breakdown alone when nothing was converted", () => {
+    expect(withConversion({ basis: "total" }, null)).toEqual({ basis: "total" })
+    expect(withConversion(null, null)).toBeNull()
+  })
+})

--- a/apps/backend/src/workflows/payment_submissions/lib/inventory-order-value.ts
+++ b/apps/backend/src/workflows/payment_submissions/lib/inventory-order-value.ts
@@ -1,0 +1,126 @@
+/**
+ * What a partner is owed for an inventory order, derived from what they
+ * actually delivered (#1612).
+ *
+ * ## Why this is derived rather than typed in
+ *
+ * `inventory_orders.total_price` is what was ORDERED. On a `Partial` order that
+ * is not what is owed: `inv_order_01K36TE2WB5BQR1MS6KESXP7Q3` was ordered at
+ * ₹88,885 and has ₹28,670 of goods actually received. Billing `total_price`
+ * would overpay by ₹60,215; asking an operator to type the right number invites
+ * the arithmetic below to be done by hand, per order, every time.
+ *
+ * ## Two traps this exists to avoid
+ *
+ * 🔴 **`price` is PER UNIT, not a line total.** Verified on the order above:
+ * Σ(quantity × price) over its ten lines = 88,885 = `total_price`, and Σquantity
+ * = 244.5 = `quantity`. A reader that treats `price` as the line's value
+ * underpays by orders of magnitude. Cf. the `quantity`-is-a-rate-or-a-total
+ * confusion that made a report tell operators to corrupt correct data (#1559).
+ *
+ * 🔴 **Receipts come from the typed `line_fulfillments` rows, NEVER from
+ * `metadata.partner_delivery_history`.** `partner-complete-inventory-order`
+ * dual-writes both, and on the one order examined by hand they DISAGREE: the
+ * typed rows total 69.5 units where the blob has 59.3, a ₹4,050 understatement,
+ * including a whole 10-unit receipt the blob never recorded. The typed rows are
+ * what the workflow's own concurrency guard reads to compute `remaining`, so
+ * they are the operative record. See #1613, which tracks reconciling the two.
+ *
+ * ⚠️ `quantity_delta` is a DELTA and the event types include `adjust` and
+ * `correction`, so a line's received quantity is the SUM of its deltas — not
+ * the latest one, and not the count of rows. A negative delta legitimately
+ * reduces what is owed.
+ */
+
+export type FulfillmentEvent = {
+  quantity_delta?: number | null
+}
+
+export type InventoryOrderLineForValue = {
+  id: string
+  /** Ordered quantity. Present for the shortfall report, not for the money. */
+  quantity?: number | null
+  /** 🔴 PER UNIT. */
+  price?: number | null
+  material_name?: string | null
+  line_fulfillments?: FulfillmentEvent[] | null
+}
+
+export type ValuedLine = {
+  line_id: string
+  material_name: string | null
+  received: number
+  ordered: number
+  unit_price: number
+  amount: number
+}
+
+export type InventoryOrderValue = {
+  lines: ValuedLine[]
+  /** Total owed — the sum of `amount` over lines with a non-zero receipt. */
+  total: number
+  /** Units received across the order, for the human-readable breakdown. */
+  received_quantity: number
+}
+
+const num = (value: unknown): number => {
+  const parsed = Number(value ?? 0)
+  return Number.isFinite(parsed) ? parsed : 0
+}
+
+/**
+ * PURE: value an inventory order by its receipts.
+ *
+ * Lines with no receipt are dropped rather than billed at zero — a line nobody
+ * delivered against is not a zero-value line, it is not part of this payout at
+ * all, and keeping it would pad the breakdown a partner reads with rows that
+ * say nothing.
+ */
+export function valueInventoryOrderByReceipts(
+  lines: InventoryOrderLineForValue[]
+): InventoryOrderValue {
+  const valued: ValuedLine[] = []
+
+  for (const line of lines || []) {
+    const received = (line.line_fulfillments || []).reduce(
+      (sum, event) => sum + num(event?.quantity_delta),
+      0
+    )
+
+    if (received === 0) continue
+
+    const unitPrice = num(line.price)
+
+    valued.push({
+      line_id: String(line.id),
+      material_name: line.material_name ?? null,
+      received,
+      ordered: num(line.quantity),
+      unit_price: unitPrice,
+      // Rounded to paise so a float delta (10.4 + 10.5) cannot leave a
+      // fraction-of-a-paisa tail on the money.
+      amount: Math.round(received * unitPrice * 100) / 100,
+    })
+  }
+
+  const total =
+    Math.round(valued.reduce((sum, line) => sum + line.amount, 0) * 100) / 100
+
+  return {
+    lines: valued,
+    total,
+    received_quantity:
+      Math.round(valued.reduce((sum, line) => sum + line.received, 0) * 100) /
+      100,
+  }
+}
+
+/** A breakdown a partner can check against their own delivery notes. */
+export function describeInventoryOrderValue(value: InventoryOrderValue): string {
+  return value.lines
+    .map(
+      (line) =>
+        `${line.material_name ?? line.line_id}: ${line.received} x ${line.unit_price} = ${line.amount}`
+    )
+    .join("; ")
+}

--- a/apps/backend/src/workflows/payment_submissions/lib/run-claims.ts
+++ b/apps/backend/src/workflows/payment_submissions/lib/run-claims.ts
@@ -1,0 +1,145 @@
+/**
+ * Who already claimed a production run — scoped by PARTNER, not by design.
+ *
+ * ## Why this exists
+ *
+ * Four separate guards answer "is this run already paid for", and every one of
+ * them fetched the prior lines the same way:
+ *
+ *     listPaymentSubmissionItems({ design_id: designIds }, …)
+ *
+ * — `create-payment-submission` step 6, `submit-payment-submission`,
+ * `update-payment-submission-item`, and both `payable-runs` routes.
+ *
+ * The justification was written down in step 6 and was true when it was
+ * written: *"a run belongs to exactly one design, so a prior billing of it can
+ * only live on a line for that design."*
+ *
+ * 🔴 That stops being true the moment a line can be sourced from something
+ * other than a design. A run-sourced line carries `design_id: null` — it is
+ * keyed by the runs it pays for — so a `design_id`-scoped query CANNOT SEE IT.
+ * A design-sourced claim of a run that a run-sourced line already paid for
+ * would find no prior, and bill it a second time. The guard would not fire, log,
+ * or fail; it would simply be looking somewhere the claim isn't.
+ *
+ * This is the same shape as every other absence-read-as-permission bug in this
+ * module (#1557, #1565): the query returned nothing, and nothing was taken to
+ * mean nobody.
+ *
+ * ## Why partner scope is the right replacement
+ *
+ * A run belongs to exactly one PARTNER — `production_run.partner_id`, the field
+ * the ownership guard already checks — and a submission is for exactly one
+ * partner. So a prior billing of a run can only live on a line of a submission
+ * for that run's partner. That is just as exact as the design claim was, just
+ * as bounded (one partner's submissions, not the whole table), and it holds no
+ * matter what a line is sourced FROM.
+ *
+ * 🔑 Scope by the thing the run actually belongs to, not by the thing the line
+ * happens to be keyed on today.
+ */
+
+export type PriorRunLine = {
+  submission_id: string | null
+  submission_status: string | null
+  production_run_ids: string[] | null
+}
+
+export type RunClaim = {
+  /** The submission holding the live claim. */
+  submission_id: string | null
+  submission_status: string | null
+}
+
+/**
+ * PURE: fold prior lines into `run id → the claim on it`.
+ *
+ * A `Rejected` submission never paid anyone, so its lines release their runs
+ * and it is skipped — the same rule the design-scoped guards already applied.
+ *
+ * ⚠️ Unlike the runless guard, `Draft` is NOT exempt here. That exemption
+ * exists so a partner can hand-submit the auto-draft they were given, which is
+ * a claim naming NO runs. A claim that names a run a Draft already holds is a
+ * different thing, and the run-level guard has always refused it.
+ *
+ * First writer wins, so the reported submission is the earliest live claim
+ * rather than an arbitrary one.
+ */
+export function foldRunClaims(
+  priorLines: PriorRunLine[]
+): Map<string, RunClaim> {
+  const claims = new Map<string, RunClaim>()
+
+  for (const line of priorLines || []) {
+    if (String(line.submission_status || "") === "Rejected") continue
+
+    for (const runId of line.production_run_ids || []) {
+      if (!runId || claims.has(runId)) continue
+      claims.set(runId, {
+        submission_id: line.submission_id,
+        submission_status: line.submission_status,
+      })
+    }
+  }
+
+  return claims
+}
+
+/**
+ * Every prior submission line belonging to one partner, in the shape
+ * `foldRunClaims` wants.
+ *
+ * Two queries rather than one because the partner lives on the SUBMISSION and
+ * the runs live on the ITEM: resolve the partner's submissions first, then the
+ * lines under them. An `excludeSubmissionId` drops the submission being edited,
+ * so a line does not read its own claim as a conflict with itself.
+ */
+export async function listPartnerRunClaims(
+  service: {
+    listPaymentSubmissions: (filters: any, config?: any) => Promise<any[]>
+    listPaymentSubmissionItems: (filters: any, config?: any) => Promise<any[]>
+  },
+  partnerId: string,
+  options?: { excludeSubmissionId?: string }
+): Promise<Map<string, RunClaim>> {
+  if (!partnerId) return new Map()
+
+  const submissions = await service.listPaymentSubmissions({
+    partner_id: partnerId,
+  })
+
+  const submissionIds = (submissions || [])
+    .map((s: any) => s?.id)
+    .filter(
+      (id: string) => !!id && id !== options?.excludeSubmissionId
+    )
+
+  if (!submissionIds.length) return new Map()
+
+  const items = await service.listPaymentSubmissionItems(
+    { submission_id: submissionIds },
+    { relations: ["submission"] }
+  )
+
+  return foldRunClaims(
+    ((items || []) as any[]).map((item) => ({
+      submission_id: item.submission?.id ?? item.submission_id ?? null,
+      submission_status: item.submission?.status ?? null,
+      production_run_ids: (item.production_run_ids || []) as string[],
+    }))
+  )
+}
+
+/** The refusal, naming who holds each run. */
+export function runsAlreadyClaimedMessage(
+  duplicates: string[],
+  claims: Map<string, RunClaim>
+): string {
+  const parts = duplicates.map((id) => {
+    const claim = claims.get(id)
+    const status = claim?.submission_status ? `, ${claim.submission_status}` : ""
+    return `${id} (submission ${claim?.submission_id ?? "unknown"}${status})`
+  })
+
+  return `Production runs already paid for: ${parts.join(", ")}`
+}

--- a/apps/backend/src/workflows/payment_submissions/lib/run-claims.ts
+++ b/apps/backend/src/workflows/payment_submissions/lib/run-claims.ts
@@ -43,6 +43,7 @@ export type PriorRunLine = {
   submission_id: string | null
   submission_status: string | null
   production_run_ids: string[] | null
+  inventory_order_id?: string | null
 }
 
 export type RunClaim = {
@@ -86,6 +87,39 @@ export function foldRunClaims(
 }
 
 /**
+ * PURE: the same fold for INVENTORY ORDERS.
+ *
+ * An inventory order is claimed WHOLE — unlike a run-sourced line, which names
+ * a set of run ids, a line pays for one order. So a second line naming the same
+ * `inventory_order_id` is a duplicate by construction.
+ *
+ * 🔴 This exists because a source type without a double-pay guard is a
+ * double-pay hole by construction, and `inventory_order_id` is a brand-new
+ * column that no existing guard reads. Runs got their guard the hard way, after
+ * the same work had already been billed twice; inventory orders get theirs
+ * before the first row is written.
+ */
+export function foldInventoryOrderClaims(
+  priorLines: PriorRunLine[]
+): Map<string, RunClaim> {
+  const claims = new Map<string, RunClaim>()
+
+  for (const line of priorLines || []) {
+    if (String(line.submission_status || "") === "Rejected") continue
+
+    const orderId = line.inventory_order_id
+    if (!orderId || claims.has(orderId)) continue
+
+    claims.set(orderId, {
+      submission_id: line.submission_id,
+      submission_status: line.submission_status,
+    })
+  }
+
+  return claims
+}
+
+/**
  * Every prior submission line belonging to one partner, in the shape
  * `foldRunClaims` wants.
  *
@@ -94,15 +128,15 @@ export function foldRunClaims(
  * lines under them. An `excludeSubmissionId` drops the submission being edited,
  * so a line does not read its own claim as a conflict with itself.
  */
-export async function listPartnerRunClaims(
+export async function listPartnerPriorLines(
   service: {
     listPaymentSubmissions: (filters: any, config?: any) => Promise<any[]>
     listPaymentSubmissionItems: (filters: any, config?: any) => Promise<any[]>
   },
   partnerId: string,
   options?: { excludeSubmissionId?: string }
-): Promise<Map<string, RunClaim>> {
-  if (!partnerId) return new Map()
+): Promise<PriorRunLine[]> {
+  if (!partnerId) return []
 
   const submissions = await service.listPaymentSubmissions({
     partner_id: partnerId,
@@ -114,32 +148,85 @@ export async function listPartnerRunClaims(
       (id: string) => !!id && id !== options?.excludeSubmissionId
     )
 
-  if (!submissionIds.length) return new Map()
+  if (!submissionIds.length) return []
 
   const items = await service.listPaymentSubmissionItems(
     { submission_id: submissionIds },
     { relations: ["submission"] }
   )
 
+  return ((items || []) as any[]).map((item) => ({
+    submission_id: item.submission?.id ?? item.submission_id ?? null,
+    submission_status: item.submission?.status ?? null,
+    production_run_ids: (item.production_run_ids || []) as string[],
+    inventory_order_id: item.inventory_order_id ?? null,
+  }))
+}
+
+export async function listPartnerRunClaims(
+  service: {
+    listPaymentSubmissions: (filters: any, config?: any) => Promise<any[]>
+    listPaymentSubmissionItems: (filters: any, config?: any) => Promise<any[]>
+  },
+  partnerId: string,
+  options?: { excludeSubmissionId?: string }
+): Promise<Map<string, RunClaim>> {
   return foldRunClaims(
-    ((items || []) as any[]).map((item) => ({
-      submission_id: item.submission?.id ?? item.submission_id ?? null,
-      submission_status: item.submission?.status ?? null,
-      production_run_ids: (item.production_run_ids || []) as string[],
-    }))
+    await listPartnerPriorLines(service, partnerId, options)
   )
 }
 
-/** The refusal, naming who holds each run. */
+/**
+ * Both claim maps from ONE pass over the partner's lines.
+ *
+ * Prefer this wherever a caller needs to check runs and inventory orders
+ * together — `listPartnerRunClaims` and a separate inventory lookup would walk
+ * the same rows twice.
+ */
+export async function listPartnerClaims(
+  service: {
+    listPaymentSubmissions: (filters: any, config?: any) => Promise<any[]>
+    listPaymentSubmissionItems: (filters: any, config?: any) => Promise<any[]>
+  },
+  partnerId: string,
+  options?: { excludeSubmissionId?: string }
+): Promise<{
+  runs: Map<string, RunClaim>
+  inventoryOrders: Map<string, RunClaim>
+}> {
+  const lines = await listPartnerPriorLines(service, partnerId, options)
+
+  return {
+    runs: foldRunClaims(lines),
+    inventoryOrders: foldInventoryOrderClaims(lines),
+  }
+}
+
+/** The refusal, naming who holds each claimed thing. */
+const claimedList = (
+  duplicates: string[],
+  claims: Map<string, RunClaim>
+): string =>
+  duplicates
+    .map((id) => {
+      const claim = claims.get(id)
+      const status = claim?.submission_status
+        ? `, ${claim.submission_status}`
+        : ""
+      return `${id} (submission ${claim?.submission_id ?? "unknown"}${status})`
+    })
+    .join(", ")
+
 export function runsAlreadyClaimedMessage(
   duplicates: string[],
   claims: Map<string, RunClaim>
 ): string {
-  const parts = duplicates.map((id) => {
-    const claim = claims.get(id)
-    const status = claim?.submission_status ? `, ${claim.submission_status}` : ""
-    return `${id} (submission ${claim?.submission_id ?? "unknown"}${status})`
-  })
+  return `Production runs already paid for: ${claimedList(duplicates, claims)}`
+}
 
-  return `Production runs already paid for: ${parts.join(", ")}`
+export function inventoryOrdersAlreadyClaimedMessage(
+  duplicates: string[],
+  claims: Map<string, RunClaim>
+): string {
+  return `Inventory orders already paid for: ${claimedList(duplicates, claims)}`
 }

--- a/apps/backend/src/workflows/payment_submissions/lib/submission-currency.ts
+++ b/apps/backend/src/workflows/payment_submissions/lib/submission-currency.ts
@@ -1,0 +1,147 @@
+/**
+ * What currency a payout is denominated in, and how a line reaches it (#1612).
+ *
+ * ## Why this is not just `currency: "inr"`
+ *
+ * `createSubmissionRecordStep` hardcoded `currency: "inr"`. Every submission
+ * ever written was INR, so nothing had exercised the alternative — but the
+ * retail payout for order #79 is derived in USD ($280.85 order, $47.75
+ * commission, $123.17 shipping) and settled in rupees, and the inventory
+ * sources bring in partners whose own `currency_code` is not always set at all
+ * (hrhandloom's is NULL).
+ *
+ * ## 🔴 The rule that matters: a missing rate is never 1
+ *
+ * The whole failure mode here is a conversion that silently doesn't happen.
+ * `amount * (rate ?? 1)` looks defensive and bills USD figures as rupees —
+ * off by ~88x, in the partner's favour or ours depending on direction, with
+ * nothing in the record showing a conversion was even attempted.
+ *
+ * So `convertAmount` REFUSES a cross-currency line without a positive finite
+ * rate rather than falling back. `FxRatesService.getRate` already throws when
+ * no path is cached, and that throw must be allowed to propagate: refusing to
+ * write a payout is recoverable, writing the wrong one is not. Cf. the
+ * remembered FX rate that was 24% wrong (#1538), and `?? 1`-shaped defaults
+ * generally.
+ *
+ * ## And the rate is RECORDED, not just applied
+ *
+ * A converted amount with no stored rate cannot be explained later — a partner
+ * disputing "why is this ₹8,974" gets a bare number, and nobody can tell a
+ * conversion from a typo. Every converted line carries its source amount,
+ * source currency and the exact rate used, so the arithmetic can be replayed.
+ */
+
+export type ConversionRecord = {
+  source_amount: number
+  source_currency: string
+  target_currency: string
+  rate: number
+  /** `amount` after conversion, rounded to 2dp. */
+  converted_amount: number
+}
+
+const isPositiveFinite = (value: unknown): value is number =>
+  typeof value === "number" && Number.isFinite(value) && value > 0
+
+export const normaliseCurrency = (code: unknown): string =>
+  String(code ?? "").trim().toLowerCase()
+
+/**
+ * The currency a submission is denominated in.
+ *
+ * Precedence: what the caller explicitly asked for, then the partner's own
+ * `currency_code`, then `inr`.
+ *
+ * ⚠️ The partner fallback is deliberately second, not first. An admin recording
+ * a payout they have already made in a particular currency is stating a fact,
+ * and a partner default must not silently override it.
+ *
+ * ⚠️ `inr` last because a partner's `currency_code` is genuinely NULL on real
+ * rows. A default is a guess, so it is the last resort rather than the first,
+ * and it is one place rather than scattered through the callers.
+ */
+export function resolveSubmissionCurrency(input: {
+  explicit?: string | null
+  partnerCurrency?: string | null
+  fallback?: string
+}): string {
+  return (
+    normaliseCurrency(input.explicit) ||
+    normaliseCurrency(input.partnerCurrency) ||
+    normaliseCurrency(input.fallback) ||
+    "inr"
+  )
+}
+
+/**
+ * PURE: convert one line's amount into the submission currency.
+ *
+ * Returns the amount unchanged, and `conversion: null`, when the currencies
+ * already match — the common case, and one that must not require a rate or an
+ * FX lookup.
+ *
+ * 🔴 Throws when the currencies differ and `rate` is not a positive finite
+ * number. This is the guard, not a formality: see the docblock above.
+ */
+export function convertAmount(input: {
+  amount: number
+  from: string
+  to: string
+  rate?: number | null
+}): { amount: number; conversion: ConversionRecord | null } {
+  const from = normaliseCurrency(input.from)
+  const to = normaliseCurrency(input.to)
+  const amount = Number(input.amount)
+
+  if (!Number.isFinite(amount)) {
+    throw new Error(
+      `Cannot convert a non-numeric amount (${input.amount}) from ${from} to ${to}`
+    )
+  }
+
+  if (!from || !to || from === to) {
+    return { amount, conversion: null }
+  }
+
+  if (!isPositiveFinite(input.rate)) {
+    throw new Error(
+      `Refusing to bill ${amount} ${from} as ${to} without an exchange rate. ` +
+        `A missing rate is not 1 — the amount would be written unconverted. ` +
+        `Ensure the FX cache has a path from ${from} to ${to}.`
+    )
+  }
+
+  const converted = Math.round(amount * input.rate * 100) / 100
+
+  return {
+    amount: converted,
+    conversion: {
+      source_amount: amount,
+      source_currency: from,
+      target_currency: to,
+      rate: input.rate,
+      converted_amount: converted,
+    },
+  }
+}
+
+/**
+ * Merge a conversion record into a line's `cost_breakdown`, preserving whatever
+ * the pricing step already put there.
+ *
+ * Kept as a real field rather than `metadata` for the reason that field exists:
+ * `metadata` is validated as `z.record(z.string(), z.any())` everywhere, so a
+ * misspelt key validates cleanly and the audit trail silently isn't there.
+ */
+export function withConversion(
+  costBreakdown: Record<string, unknown> | null | undefined,
+  conversion: ConversionRecord | null
+): Record<string, unknown> | null {
+  if (!conversion) return costBreakdown ?? null
+
+  return {
+    ...(costBreakdown || {}),
+    fx: conversion,
+  }
+}

--- a/apps/backend/src/workflows/payment_submissions/submit-payment-submission.ts
+++ b/apps/backend/src/workflows/payment_submissions/submit-payment-submission.ts
@@ -13,6 +13,10 @@ import {
   designsBilledWithoutRunEvidence,
   runlessResubmitMessage,
 } from "./lib/run-evidence-guard"
+import {
+  listPartnerRunClaims,
+  runsAlreadyClaimedMessage,
+} from "./lib/run-claims"
 
 /**
  * Turn a Draft payment submission into a real claim — Draft → Pending, in place.
@@ -132,6 +136,38 @@ const validateSubmissionForSubmitStep = createStep(
       ),
     ]
 
+    /**
+     * The run-level guard, lifted OUT of the `designIds.length` block below.
+     *
+     * 🔴 It used to sit inside it, so a submission carrying no design-sourced
+     * line at all — every line keyed on something else — skipped all three
+     * guards and submitted unchecked. The design gate belongs to the design
+     * questions; whether a run is already claimed is not one of them.
+     *
+     * Scoped by partner (see `lib/run-claims`) and excluding this submission,
+     * since a claim cannot conflict with itself.
+     */
+    const claimedRunIds = [
+      ...new Set(
+        items.flatMap((i) => (i.production_run_ids || []).map(String))
+      ),
+    ].filter(Boolean)
+
+    if (claimedRunIds.length) {
+      const billed = await listPartnerRunClaims(
+        service as any,
+        String(submission.partner_id || ""),
+        { excludeSubmissionId: String(input.submission_id) }
+      )
+      const duplicates = claimedRunIds.filter((id) => billed.has(id))
+      if (duplicates.length) {
+        throw new MedusaError(
+          MedusaError.Types.INVALID_DATA,
+          runsAlreadyClaimedMessage(duplicates, billed)
+        )
+      }
+    }
+
     if (designIds.length) {
       /**
        * Every prior line for these designs, this submission's own excluded —
@@ -176,40 +212,9 @@ const validateSubmissionForSubmitStep = createStep(
       }
 
       /**
-       * 2. The run-level guard. A Rejected prior released its runs; everything
-       *    else — Draft included, because another draft holding the same run
-       *    is a duplicate this one must not race — is a live claim.
+       * 2. The run-level guard has already run above, unconditionally and
+       *    scoped by partner. It is deliberately NOT repeated here.
        */
-      const claimedRunIds = [
-        ...new Set(
-          items.flatMap((i) => (i.production_run_ids || []).map(String))
-        ),
-      ].filter(Boolean)
-
-      if (claimedRunIds.length) {
-        const billed = new Map<string, string>()
-        for (const item of foreignPriors) {
-          if (String(item.submission?.status || "") === "Rejected") continue
-          for (const runId of (item.production_run_ids || []) as string[]) {
-            if (!billed.has(String(runId))) {
-              billed.set(
-                String(runId),
-                String(item.submission?.id || item.submission_id || "unknown")
-              )
-            }
-          }
-        }
-
-        const duplicates = claimedRunIds.filter((id) => billed.has(id))
-        if (duplicates.length) {
-          throw new MedusaError(
-            MedusaError.Types.INVALID_DATA,
-            `Production runs already paid for: ${duplicates
-              .map((id) => `${id} (submission ${billed.get(id)})`)
-              .join(", ")}`
-          )
-        }
-      }
 
       /**
        * 3. And the runless half of the same question (#1556). A draft line that

--- a/apps/backend/src/workflows/payment_submissions/update-payment-submission-item.ts
+++ b/apps/backend/src/workflows/payment_submissions/update-payment-submission-item.ts
@@ -15,6 +15,10 @@ import {
   designsBilledWithoutRunEvidence,
   runlessResubmitMessage,
 } from "./lib/run-evidence-guard"
+import {
+  listPartnerRunClaims,
+  runsAlreadyClaimedMessage,
+} from "./lib/run-claims"
 import { resolveDesignLineAmount } from "./create-payment-submission"
 
 /**
@@ -202,26 +206,24 @@ const validateItemEditStep = createStep(
           String(input.submission_id)
       )
 
+      /**
+       * 🔴 Scoped by PARTNER rather than by this line's design. `foreignPriors`
+       * above is design-scoped and stays that way for the runless check, which
+       * IS a question about designs — but a run claimed by a line sourced from
+       * something other than a design carries `design_id: null` and would be
+       * invisible to it. See `lib/run-claims`.
+       */
       if (runIds.length) {
-        const billed = new Map<string, string>()
-        for (const prior of foreignPriors) {
-          if (String(prior.submission?.status || "") === "Rejected") continue
-          for (const runId of (prior.production_run_ids || []) as string[]) {
-            if (!billed.has(String(runId))) {
-              billed.set(
-                String(runId),
-                String(prior.submission?.id || prior.submission_id || "unknown")
-              )
-            }
-          }
-        }
+        const billed = await listPartnerRunClaims(
+          service as any,
+          String(submission.partner_id || ""),
+          { excludeSubmissionId: String(input.submission_id) }
+        )
         const duplicates = runIds.filter((id) => billed.has(id))
         if (duplicates.length) {
           throw new MedusaError(
             MedusaError.Types.INVALID_DATA,
-            `Production runs already paid for: ${duplicates
-              .map((id) => `${id} (submission ${billed.get(id)})`)
-              .join(", ")}`
+            runsAlreadyClaimedMessage(duplicates, billed)
           )
         }
       }


### PR DESCRIPTION
Groundwork for #1612. This is the **backend foundation** — schema, guards, valuation, currency. The create paths, `payable-runs` changes and UI follow in a second PR; nothing here changes existing behaviour for design- or task-sourced payouts.

## Why

Two populations of real, delivered, unpaid work have nowhere to be recorded:

- **Retail runs.** The seven runs behind order #79 were minted from `order.fulfillment_created` and carry `design_id: null`. `payable-runs` opens with `runs.filter(r => !!r.design_id)`, so it cannot see one of them.
- **Inventory orders.** A partner we bought material from is owed the order's value. Not labour on a design, not a task — ₹28,200 (Parmar Mukeshbhai Lavjibhai) and ₹28,670 (hrhandloom) sat unrecordable.

## 🔴 The hole this would have opened, and closes instead

Every "already paid for" guard fetched priors with `{ design_id: input.design_ids }`, justified in create step 6 by: *"a run belongs to exactly one design, so a prior billing of it can only live on a line for that design."*

True when written. **False the moment a line can be sourced from anything else.** A run-sourced line carries `design_id: null`, so that query cannot see it — the same run could be billed once from each side with neither claim visible to the other. The guard would not fire, log, or fail; it would be looking somewhere the claim isn't. Absence read as permission, the shape of #1557 and #1565.

All four guards (create step 6, submit, update-item, and the payable-runs routes) now resolve priors **by partner**. A run belongs to exactly one partner, so this is as exact as the design scope was and just as bounded, but holds whatever a line is sourced from.

Separately: `submit-payment-submission` had all three of its guards inside `if (designIds.length)`, so a submission with no design-sourced line skipped the design check, the run check **and** the runless check entirely. The run-level guard is lifted out to run unconditionally.

Inventory orders get their double-pay guard **before** the first row is written, rather than after being billed twice.

## The check constraint, not the enum

`source_type` is a `text` column with an inline `check ("source_type" in ('design','task'))`. Widening the TypeScript enum alone compiles clean and then fails at INSERT against a constraint no type checker reads. Dropping and recreating it is what actually unblocks this.

`db:generate` could not run (no local DB), so the migration is hand-written and the MikroORM snapshot updated to match. `down()` re-sources `run`/`inventory_order` rows before narrowing — a `down()` that throws on real data is one nobody can run. It is lossy and says so.

The migration classifies and back-fills **nothing**: recording money is an operator decision that belongs in a route someone can inspect, not in something that runs unattended on every deploy.

## Valuing an inventory order

`total_price` is what was **ordered**. On a `Partial` order that is not what is owed: `inv_order_01K36TE2WB…` was ordered at ₹88,885 with ₹25,670 actually received — billing `total_price` overpays by ₹63,215.

`valueInventoryOrderByReceipts` sums typed `line_fulfillments` deltas per line and multiplies by that line's rate. Two traps:

- `inventory_order_line.price` is **per unit**, not a line total. Verified: Σ(quantity × price) over the order's ten lines = 88,885 = `total_price`.
- Receipts come from the typed rows, **never** from `metadata.partner_delivery_history`. The workflow dual-writes both and they disagree — typed totals 69.5 units where the blob has 59.3, a ₹4,050 understatement including a whole 10-unit receipt the blob never recorded. The typed rows are what the concurrency guard reads. **#1613** tracks reconciling them.

## Currency

`createSubmissionRecordStep` wrote `currency: "inr"` unconditionally. Precedence is now explicit → partner's own → `inr`, in one place. (`inr` last because a default is a guess; partners with a NULL `currency_code` are real.)

**A missing rate is never 1.** `amount * (rate ?? 1)` looks defensive and bills a USD figure as rupees — off by ~88×, with nothing showing a conversion was attempted. `convertAmount` refuses a cross-currency line without a positive finite rate, and rejects 0/negative/NaN/Infinity by the same check. Every converted line records source amount, source currency and the exact rate in `cost_breakdown.fx` so the arithmetic replays — in a real column, not `metadata`, which validates anything.

`getRateLive` refreshes from the provider when the cache is stale (24h) or missing the pair, sharing one in-flight fetch across concurrent callers (#1368: unbounded FX fanout OOM-killed prod twice). A provider outage falls back to a stale cached rate; a *missing* rate still throws.

## Testing

**44 new unit tests. 208 payment + fx unit tests green. tsc unchanged at its 279-line baseline, with none of the output naming files in this PR** (verified the run was non-empty before trusting the filter).

The load-bearing tests are the ones that cannot pass against the old code:
- *"sees a run-sourced claim that a design-scoped query would miss"* — the prior is not in the old query's result set.
- *"REFUSES a cross-currency line with no rate rather than defaulting to 1"*.
- *"refreshes ONCE for many concurrent lines"* — holds the fetch unresolved while eight callers arrive.

The inventory fixture is the **real** shape read from production, awkward parts kept deliberately: two deltas on one line, a fractional receipt, a line ordered at 80 with nothing delivered, and an order whose `total_price` is nowhere near what is owed. A fixture tidier than reality certifies the wrong code.

## Risk

Additive. No existing route sends the new fields; `getRate` is untouched; design and task lines take exactly the path they took before. The behaviour change for existing callers is that the four claim guards now see **more** prior claims than they did, which can only refuse more, never bill more.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01TLt1f38xqR8k2myCVxP8e4
