### PR TITLE
Create payouts from production runs and inventory orders, and stop payable-runs dropping runs without a design (#1612, #1598)

### DIFF
--- a/apps/backend/src/api/admin/payment-submissions/payable-runs/route.ts
+++ b/apps/backend/src/api/admin/payment-submissions/payable-runs/route.ts
@@ -5,6 +5,8 @@ import { PAYMENT_SUBMISSIONS_MODULE } from "../../../../modules/payment_submissi
 import PaymentSubmissionsService from "../../../../modules/payment_submissions/service"
 import { isProvenanceRun } from "../../../../workflows/consumption-logs/lib/reconcile-production-consumption"
 import { runUnitCost } from "../../../../workflows/production-runs/lib/run-payable"
+import { listPartnerSubmissionItems } from "../../../../workflows/payment_submissions/lib/run-claims"
+import { groupOrderBackedRuns } from "../../../../workflows/payment_submissions/lib/order-run-groups"
 
 /**
  * GET /admin/payment-submissions/payable-runs?partner_id=…
@@ -106,6 +108,11 @@ export const GET = async (req: MedusaRequest, res: MedusaResponse) => {
       "partner_cost_estimate",
       "cost_type",
       "completed_at",
+      // Needed to group the order-backed runs below, and to say which order a
+      // row belongs to.
+      "order_id",
+      "product_id",
+      "order_line_item_id",
       // Read by `isProvenanceRun` — a guard reading a field the query never
       // fetched is dead code that types perfectly (#1606).
       "metadata",
@@ -113,7 +120,94 @@ export const GET = async (req: MedusaRequest, res: MedusaResponse) => {
     filters: { partner_id: partnerId, status: "completed" },
   })
 
-  const designBackedRuns = ((runs || []) as any[]).filter((r) => !!r.design_id)
+  const allRuns = (runs || []) as any[]
+  const designBackedRuns = allRuns.filter((r) => !!r.design_id)
+
+  /**
+   * 🔴 Runs with no design were being dropped on the floor.
+   *
+   * `filter((r) => !!r.design_id)` was the first thing this endpoint did, and
+   * everything downstream is design-keyed, so a run without one simply ceased
+   * to exist here — no row, no exclusion, no count. The seven runs behind
+   * retail order #79 are exactly that: minted by `order.fulfillment_created`
+   * with `design_id: null`, completed, delivered, and never offered for payment
+   * by any screen (#1598).
+   *
+   * That contradicted this file's own rule for the provenance runs directly
+   * below — report what is held back and why, because "a screen that simply
+   * omits the row teaches nobody why the work vanished". A silent drop is worse
+   * than an exclusion: an exclusion at least says the work exists.
+   *
+   * These runs are real payable labour, so they are surfaced — grouped by the
+   * ORDER that commissioned them, because that is the unit the payout is
+   * agreed in. Order #79 is one payment of ₹8,974, not seven of ₹1,282.
+   */
+  const orderBackedRuns = allRuns.filter((r) => !r.design_id && !!r.order_id)
+
+  /**
+   * ⚠️ And runs with neither. Nothing can attribute these — no design to price
+   * from, no order to group by. They are reported rather than dropped for the
+   * same reason: an unattributable run is a data question someone must answer,
+   * not a row to hide.
+   */
+  const unattributableRuns = allRuns.filter((r) => !r.design_id && !r.order_id)
+
+  /**
+   * Prior payment lines for this PARTNER.
+   *
+   * 🔴 Was scoped `{ design_id: designIds }`, on the reasoning that a run
+   * belongs to one design so a prior billing of it could only sit on a line for
+   * that design. That stopped being true when a line could be sourced from a
+   * run or an inventory order (#1612): those carry `design_id: null` and were
+   * invisible here, so a run this screen offers as payable could already have
+   * been paid by a run-sourced line and the screen would never know.
+   *
+   * A run belongs to exactly one partner, so partner scope is equally exact and
+   * equally bounded, and survives a line being keyed on something else. See
+   * `workflows/payment_submissions/lib/run-claims`.
+   *
+   * Fetched BEFORE the design early-return below, because the order-backed rows
+   * need it too and they must not disappear just because no design run exists.
+   */
+  const service: PaymentSubmissionsService = req.scope.resolve(
+    PAYMENT_SUBMISSIONS_MODULE
+  )
+  const priorItems = await listPartnerSubmissionItems(service as any, partnerId)
+
+  /** Run id → the live line claiming it. Rejected lines release their runs. */
+  const claimedRunIds = new Map<string, { submission_id: string; status: string }>()
+  for (const item of priorItems || []) {
+    const status = String(item.submission?.status || "")
+    if (status === "Rejected") continue
+    for (const runId of (item.production_run_ids || []) as string[]) {
+      if (!claimedRunIds.has(String(runId))) {
+        claimedRunIds.set(String(runId), {
+          submission_id: String(item.submission?.id || item.submission_id || ""),
+          status,
+        })
+      }
+    }
+  }
+
+  /**
+   * Order-backed runs, grouped by the order that commissioned them.
+   *
+   * One group is one payout: the caller sends it to `POST
+   * /admin/payment-submissions` as a single `run_lines` entry naming every run
+   * id, which is why `run_ids` is given in full rather than a count.
+   *
+   * ⚠️ No `amount` is offered. These runs carry `partner_cost_estimate: null`
+   * — all seven of order #79's do — so any figure here would be a 0 dressed up
+   * as a price. The rate was agreed out of band and an operator must state it;
+   * `create` refuses a zero-value run line for the same reason.
+   */
+  const order_runs = groupOrderBackedRuns(orderBackedRuns, claimedRunIds)
+
+  const unattributable_runs = unattributableRuns.map((run) => ({
+    run_id: String(run.id),
+    completed_at: run.completed_at ?? null,
+    excluded_reason: "no_design_and_no_order" as const,
+  }))
 
   /**
    * A run minted by a retail fulfilment is not billable labour (#1606).
@@ -143,9 +237,18 @@ export const GET = async (req: MedusaRequest, res: MedusaResponse) => {
     }))
 
   if (!completedRuns.length) {
-    return res
-      .status(200)
-      .json({ payable_runs: [], count: 0, excluded_runs, excluded_count: excluded_runs.length })
+    // ⚠️ Still returns the order-backed rows. They are not design-backed, so a
+    // partner with no design runs at all can still have real payable work —
+    // which is precisely the case this endpoint used to render as "nothing".
+    return res.status(200).json({
+      payable_runs: [],
+      count: 0,
+      excluded_runs,
+      excluded_count: excluded_runs.length,
+      order_runs,
+      order_runs_count: order_runs.length,
+      unattributable_runs,
+    })
   }
 
   const designIds = [
@@ -160,17 +263,6 @@ export const GET = async (req: MedusaRequest, res: MedusaResponse) => {
   const designById = new Map(
     ((designs || []) as any[]).map((d) => [d.id, d])
   )
-
-  // Prior payment lines for these designs. Scoped to the designs in play rather
-  // than every line ever written: a run belongs to exactly one design, so a
-  // prior billing of it can only sit on a line for that design.
-  const service: PaymentSubmissionsService = req.scope.resolve(
-    PAYMENT_SUBMISSIONS_MODULE
-  )
-  const priorItems = (await service.listPaymentSubmissionItems(
-    { design_id: designIds },
-    { relations: ["submission"] }
-  )) as any[]
 
   const billedRuns = new Map<
     string,
@@ -359,5 +451,14 @@ export const GET = async (req: MedusaRequest, res: MedusaResponse) => {
     count: payable_runs.length,
     excluded_runs,
     excluded_count: excluded_runs.length,
+    /**
+     * Order-backed runs, as their own list rather than merged into
+     * `payable_runs`. They are a different shape — no design, no per-unit rate,
+     * grouped by order rather than one row per run — and folding them in would
+     * hand every existing consumer rows whose `design_id` is null.
+     */
+    order_runs,
+    order_runs_count: order_runs.length,
+    unattributable_runs,
   })
 }

--- a/apps/backend/src/api/admin/payment-submissions/route.ts
+++ b/apps/backend/src/api/admin/payment-submissions/route.ts
@@ -54,6 +54,20 @@ export const POST = async (req: MedusaRequest, res: MedusaResponse) => {
     status?: "Draft" | "Pending"
     require_design_status?: boolean
     metadata?: Record<string, any>
+    currency?: string
+    run_lines?: Array<{
+      run_ids: string[]
+      amount?: number
+      quantity?: number
+      order_id?: string
+      label?: string
+      currency?: string
+    }>
+    inventory_order_lines?: Array<{
+      inventory_order_id: string
+      amount?: number
+      currency?: string
+    }>
   }
 
   assertNoNearMissMoneyKey(body.metadata)
@@ -70,6 +84,12 @@ export const POST = async (req: MedusaRequest, res: MedusaResponse) => {
       // Typed input, not folded into metadata — this is the double-pay guard's
       // evidence, and it must not be reachable by a misspelt JSON key.
       production_run_ids: body.production_run_ids,
+      // 🔴 Forwarded explicitly. A field the validator accepts but the handler
+      // never passes on is dropped in SILENCE — the request succeeds, the line
+      // is simply not there, and no dry-run can reveal it.
+      run_lines: body.run_lines,
+      inventory_order_lines: body.inventory_order_lines,
+      currency: body.currency,
       // The money, as typed inputs. These are the contract; the fold below
       // keeps the same values on `metadata` so the review UI and any existing
       // reader still see original vs. requested exactly as before.

--- a/apps/backend/src/api/admin/payment-submissions/validators.ts
+++ b/apps/backend/src/api/admin/payment-submissions/validators.ts
@@ -75,6 +75,52 @@ export const CreateAdminPaymentSubmissionSchema = z
      */
     status: z.enum(["Draft", "Pending"]).optional(),
     /**
+     * What the payout is denominated in. Absent means the partner's own
+     * currency, then `inr` — see `lib/submission-currency`, which owns that
+     * precedence so two routes cannot disagree about it.
+     */
+    currency: z.string().min(1).optional(),
+    /**
+     * Payout lines sourced from production RUNS (#1612).
+     *
+     * 🔑 The only expression available for a run with `design_id: null` — one
+     * minted from `order.fulfillment_created` is not design-backed and never
+     * will be, so no `design_ids` entry can reach it.
+     *
+     * Grouping is deliberate: the seven runs behind order #79 are ONE payout of
+     * ₹8,974, not seven of ₹1,282, because that is how the money moved.
+     */
+    run_lines: z
+      .array(
+        z.object({
+          run_ids: z.array(z.string().min(1)).min(1),
+          amount: z.coerce.number().positive().optional(),
+          quantity: z.coerce.number().positive().optional(),
+          order_id: z.string().min(1).optional(),
+          label: z.string().optional(),
+          currency: z.string().min(1).optional(),
+        })
+      )
+      .optional(),
+    /**
+     * Payout lines sourced from INVENTORY ORDERS — material bought from the
+     * partner.
+     *
+     * ⚠️ `amount` is an OVERRIDE. Left absent, the workflow derives what is
+     * owed from the typed `line_fulfillments` receipts, because `total_price`
+     * is what was ordered: one `Partial` order is ordered at ₹88,885 with
+     * ₹25,670 actually received.
+     */
+    inventory_order_lines: z
+      .array(
+        z.object({
+          inventory_order_id: z.string().min(1),
+          amount: z.coerce.number().positive().optional(),
+          currency: z.string().min(1).optional(),
+        })
+      )
+      .optional(),
+    /**
      * Skip the design-status gate (must be Approved/Commerce_Ready).
      *
      * The run-completion auto-draft already passes `false` because its proof of
@@ -87,9 +133,15 @@ export const CreateAdminPaymentSubmissionSchema = z
     metadata: z.record(z.string(), z.any()).optional(),
   })
   .refine(
-    (data) => (data.design_ids?.length || 0) + (data.task_ids?.length || 0) > 0,
+    (data) =>
+      (data.design_ids?.length || 0) +
+        (data.task_ids?.length || 0) +
+        (data.run_lines?.length || 0) +
+        (data.inventory_order_lines?.length || 0) >
+      0,
     {
-      message: "At least one design or task is required",
+      message:
+        "At least one design, task, production run or inventory order is required",
       path: ["design_ids"],
     }
   )

--- a/apps/backend/src/workflows/payment_submissions/create-payment-submission.ts
+++ b/apps/backend/src/workflows/payment_submissions/create-payment-submission.ts
@@ -23,9 +23,19 @@ import {
   runsAlreadyClaimedMessage,
 } from "./lib/run-claims"
 import {
+  inventoryOrdersAlreadyClaimedMessage,
+  listPartnerClaims,
+} from "./lib/run-claims"
+import {
   normaliseCurrency,
   resolveSubmissionCurrency,
 } from "./lib/submission-currency"
+import { resolveRunLineAmount } from "./lib/run-line-amount"
+import {
+  describeInventoryOrderValue,
+  valueInventoryOrderByReceipts,
+} from "./lib/inventory-order-value"
+import { runPayableAmount } from "../production-runs/lib/run-payable"
 import { PARTNER_MODULE } from "../../modules/partner"
 import { DESIGN_MODULE } from "../../modules/designs"
 import { TASKS_MODULE } from "../../modules/tasks"
@@ -109,6 +119,41 @@ export type CreatePaymentSubmissionInput = {
    * is recorded on the line, never applied silently.
    */
   currency?: string
+  /**
+   * Payout lines sourced from production RUNS directly (#1612).
+   *
+   * Each entry becomes ONE line claiming the runs it names. Grouping is the
+   * caller's: the seven runs behind retail order #79 are one payout of ₹8,974,
+   * not seven of ₹1,282, because that is how the money actually moved.
+   *
+   * 🔑 This is the only expression available for a run with `design_id: null`
+   * — a run minted from `order.fulfillment_created` is not design-backed and
+   * never will be.
+   */
+  run_lines?: Array<{
+    run_ids: string[]
+    /** An explicit line TOTAL. Usually required — see `lib/run-line-amount`. */
+    amount?: number
+    quantity?: number
+    /** The commissioning retail order, denormalised onto the line (#1598). */
+    order_id?: string
+    /** What the line is called on a payout a partner reads. */
+    label?: string
+    /** The currency `amount` is stated in, if not the submission's. */
+    currency?: string
+  }>
+  /**
+   * Payout lines sourced from INVENTORY ORDERS — material we bought.
+   *
+   * The amount is DERIVED from what was actually received unless overridden:
+   * a `Partial` order's `total_price` is what was ordered, not what is owed.
+   * See `lib/inventory-order-value`.
+   */
+  inventory_order_lines?: Array<{
+    inventory_order_id: string
+    amount?: number
+    currency?: string
+  }>
 }
 
 type ValidatedDesign = {
@@ -797,6 +842,308 @@ const validateTasksForSubmissionStep = createStep(
 )
 
 // Step 2: Create the submission record with items (designs and/or tasks)
+export type ValidatedRunLine = {
+  run_ids: string[]
+  label: string
+  amount: number
+  quantity: number
+  unit_amount: number | null
+  order_id: string | null
+  cost_breakdown: Record<string, unknown>
+}
+
+export type ValidatedInventoryLine = {
+  inventory_order_id: string
+  inventory_order_name: string
+  amount: number
+  quantity: number
+  cost_breakdown: Record<string, unknown>
+}
+
+/**
+ * Run-sourced lines: the runs must be this partner's, completed, and not
+ * already claimed.
+ *
+ * The ownership checks mirror the design path's step 6 exactly, minus the
+ * "belongs to this design" check, which is meaningless here — these runs have
+ * no design. What replaces it is the `order_id` cross-check below: if a caller
+ * names a commissioning order, every run on the line must actually belong to
+ * it, or the line's provenance is decoration.
+ */
+const validateRunLinesStep = createStep(
+  "validate-run-lines-for-submission",
+  async (
+    input: {
+      partner_id: string
+      run_lines: NonNullable<CreatePaymentSubmissionInput["run_lines"]>
+    },
+    { container }
+  ) => {
+    const lines = input.run_lines || []
+    if (!lines.length) return new StepResponse<ValidatedRunLine[]>([])
+
+    const query: any = container.resolve(ContainerRegistrationKeys.QUERY)
+
+    const allRunIds = [
+      ...new Set(lines.flatMap((line) => line.run_ids || []).filter(Boolean)),
+    ]
+    if (!allRunIds.length) {
+      throw new MedusaError(
+        MedusaError.Types.INVALID_DATA,
+        "A run-sourced line must name at least one production run."
+      )
+    }
+
+    const { data: runs } = await query.graph({
+      entity: "production_runs",
+      fields: [
+        "id",
+        "partner_id",
+        "status",
+        "quantity",
+        "produced_quantity",
+        "partner_cost_estimate",
+        "cost_type",
+        "order_id",
+      ],
+      filters: { id: allRunIds },
+    })
+    const runById = new Map(
+      ((runs || []) as any[]).map((run) => [String(run.id), run])
+    )
+
+    const missing = allRunIds.filter((id) => !runById.has(id))
+    if (missing.length) {
+      throw new MedusaError(
+        MedusaError.Types.NOT_FOUND,
+        `Production runs not found: ${missing.join(", ")}`
+      )
+    }
+
+    for (const runId of allRunIds) {
+      const run = runById.get(runId)!
+      if (String(run.partner_id || "") !== input.partner_id) {
+        throw new MedusaError(
+          MedusaError.Types.NOT_ALLOWED,
+          `Production run ${runId} does not belong to this partner`
+        )
+      }
+      if (String(run.status || "") !== "completed") {
+        throw new MedusaError(
+          MedusaError.Types.INVALID_DATA,
+          `Production run ${runId} is not completed (${run.status})`
+        )
+      }
+    }
+
+    /**
+     * 🔴 The double-pay guard, partner-scoped. A run-sourced line and a
+     * design-sourced line can name the same run, and only a partner-scoped
+     * lookup sees both — see `lib/run-claims`.
+     */
+    const submissionService: PaymentSubmissionsService = container.resolve(
+      PAYMENT_SUBMISSIONS_MODULE
+    )
+    const billed = await listPartnerRunClaims(
+      submissionService as any,
+      input.partner_id
+    )
+    const duplicates = allRunIds.filter((id) => billed.has(id))
+    if (duplicates.length) {
+      throw new MedusaError(
+        MedusaError.Types.INVALID_DATA,
+        runsAlreadyClaimedMessage(duplicates, billed)
+      )
+    }
+
+    // A run may be claimed only once ACROSS the lines of this submission too —
+    // two lines naming the same run would each pass the prior-claim check above
+    // and bill it twice in a single request.
+    const seen = new Set<string>()
+    for (const line of lines) {
+      for (const runId of line.run_ids || []) {
+        if (seen.has(runId)) {
+          throw new MedusaError(
+            MedusaError.Types.INVALID_DATA,
+            `Production run ${runId} is claimed by more than one line of this submission`
+          )
+        }
+        seen.add(runId)
+      }
+    }
+
+    const validated: ValidatedRunLine[] = lines.map((line) => {
+      const lineRuns = (line.run_ids || []).map((id) => runById.get(id)!)
+
+      if (line.order_id) {
+        const foreign = lineRuns.filter(
+          (run) => String(run.order_id || "") !== String(line.order_id)
+        )
+        if (foreign.length) {
+          throw new MedusaError(
+            MedusaError.Types.INVALID_DATA,
+            `Runs ${foreign.map((r) => r.id).join(", ")} do not belong to order ${line.order_id}`
+          )
+        }
+      }
+
+      let resolved
+      try {
+        resolved = resolveRunLineAmount({
+          runs: lineRuns,
+          amount: line.amount,
+          quantity: line.quantity,
+          deriveAmount: (run) => runPayableAmount(run as any),
+        })
+      } catch (e: any) {
+        throw new MedusaError(MedusaError.Types.INVALID_DATA, e.message)
+      }
+
+      return {
+        run_ids: line.run_ids,
+        label:
+          line.label ||
+          (line.order_id
+            ? `Production for order ${line.order_id}`
+            : `Production runs (${line.run_ids.length})`),
+        amount: resolved.amount,
+        quantity: resolved.quantity,
+        unit_amount: resolved.unit_amount,
+        order_id: line.order_id ?? null,
+        cost_breakdown: resolved.cost_breakdown,
+      }
+    })
+
+    return new StepResponse(validated)
+  }
+)
+
+/**
+ * Inventory-order lines: the order must be this partner's, have receipts, and
+ * not already be claimed.
+ *
+ * ⚠️ The amount is derived from the TYPED `line_fulfillments` rows, never from
+ * `total_price` (what was ordered) and never from
+ * `metadata.partner_delivery_history` (which disagrees with the typed rows —
+ * #1613). See `lib/inventory-order-value`.
+ */
+const validateInventoryOrderLinesStep = createStep(
+  "validate-inventory-order-lines-for-submission",
+  async (
+    input: {
+      partner_id: string
+      inventory_order_lines: NonNullable<
+        CreatePaymentSubmissionInput["inventory_order_lines"]
+      >
+    },
+    { container }
+  ) => {
+    const lines = input.inventory_order_lines || []
+    if (!lines.length) return new StepResponse<ValidatedInventoryLine[]>([])
+
+    const query: any = container.resolve(ContainerRegistrationKeys.QUERY)
+    const orderIds = [
+      ...new Set(lines.map((l) => l.inventory_order_id).filter(Boolean)),
+    ]
+
+    if (orderIds.length !== lines.length) {
+      throw new MedusaError(
+        MedusaError.Types.INVALID_DATA,
+        "An inventory order may appear only once per submission — an order is claimed whole."
+      )
+    }
+
+    const { data: orders } = await query.graph({
+      entity: "inventory_orders",
+      fields: [
+        "id",
+        "status",
+        "total_price",
+        "currency_code",
+        "partner.id",
+        "orderlines.id",
+        "orderlines.quantity",
+        "orderlines.price",
+        "orderlines.material_name",
+        "orderlines.line_fulfillments.quantity_delta",
+      ],
+      filters: { id: orderIds },
+    })
+    const orderById = new Map(
+      ((orders || []) as any[]).map((order) => [String(order.id), order])
+    )
+
+    const missing = orderIds.filter((id) => !orderById.has(id))
+    if (missing.length) {
+      throw new MedusaError(
+        MedusaError.Types.NOT_FOUND,
+        `Inventory orders not found: ${missing.join(", ")}`
+      )
+    }
+
+    const submissionService: PaymentSubmissionsService = container.resolve(
+      PAYMENT_SUBMISSIONS_MODULE
+    )
+    const { inventoryOrders: claimed } = await listPartnerClaims(
+      submissionService as any,
+      input.partner_id
+    )
+    const duplicates = orderIds.filter((id) => claimed.has(id))
+    if (duplicates.length) {
+      throw new MedusaError(
+        MedusaError.Types.INVALID_DATA,
+        inventoryOrdersAlreadyClaimedMessage(duplicates, claimed)
+      )
+    }
+
+    const validated: ValidatedInventoryLine[] = lines.map((line) => {
+      const order = orderById.get(line.inventory_order_id)!
+
+      const ownerId = order.partner?.id ?? order.partner?.[0]?.id ?? null
+      if (ownerId && String(ownerId) !== input.partner_id) {
+        throw new MedusaError(
+          MedusaError.Types.NOT_ALLOWED,
+          `Inventory order ${line.inventory_order_id} does not belong to this partner`
+        )
+      }
+
+      const value = valueInventoryOrderByReceipts(order.orderlines || [])
+
+      const amount =
+        line.amount != null && Number.isFinite(Number(line.amount))
+          ? Math.round(Number(line.amount) * 100) / 100
+          : value.total
+
+      if (!(amount > 0)) {
+        throw new MedusaError(
+          MedusaError.Types.INVALID_DATA,
+          `Inventory order ${line.inventory_order_id} has no recorded receipts to bill ` +
+            `(status ${order.status}). Nothing has been delivered against it, so a payout ` +
+            `would be for nothing — record the delivery first, or send an explicit amount.`
+        )
+      }
+
+      return {
+        inventory_order_id: line.inventory_order_id,
+        inventory_order_name: `Inventory order ${line.inventory_order_id}`,
+        amount,
+        quantity: value.received_quantity || 1,
+        cost_breakdown: {
+          source: "inventory_order",
+          basis:
+            line.amount != null ? "explicit_total" : "received_x_unit_price",
+          ordered_total: Number(order.total_price ?? 0),
+          received_quantity: value.received_quantity,
+          lines: value.lines,
+          breakdown: describeInventoryOrderValue(value),
+        },
+      }
+    })
+
+    return new StepResponse(validated)
+  }
+)
+
 /**
  * Decide what the payout is denominated in, once, before anything is priced.
  *
@@ -859,6 +1206,8 @@ const createSubmissionRecordStep = createStep(
        * one place that decides it. See `lib/submission-currency`.
        */
       currency?: string
+      runLines?: ValidatedRunLine[]
+      inventoryLines?: ValidatedInventoryLine[]
     },
     { container }
   ) => {
@@ -871,12 +1220,26 @@ const createSubmissionRecordStep = createStep(
       0
     )
     const taskTotal = input.tasks.reduce((sum, t) => sum + t.amount, 0)
-    const total_amount = designTotal + taskTotal
+    const runTotal = (input.runLines || []).reduce((sum, l) => sum + l.amount, 0)
+    const inventoryTotal = (input.inventoryLines || []).reduce(
+      (sum, l) => sum + l.amount,
+      0
+    )
+    const total_amount =
+      Math.round(
+        (designTotal + taskTotal + runTotal + inventoryTotal) * 100
+      ) / 100
 
-    if ((input.designs.length + input.tasks.length) === 0) {
+    if (
+      input.designs.length +
+        input.tasks.length +
+        (input.runLines || []).length +
+        (input.inventoryLines || []).length ===
+      0
+    ) {
       throw new MedusaError(
         MedusaError.Types.INVALID_DATA,
-        "At least one design or task is required"
+        "At least one design, task, production run or inventory order is required"
       )
     }
 
@@ -960,6 +1323,64 @@ const createSubmissionRecordStep = createStep(
         production_run_ids: null as unknown as Record<string, unknown> | null,
         run_provenance: "no_run" as const,
         cost_breakdown: task.cost_breakdown || null,
+        submission_id: submission.id,
+      })
+    }
+
+    /**
+     * Run-sourced line items (#1612).
+     *
+     * `run_provenance` is `recorded` unconditionally: a run line exists BECAUSE
+     * it names runs, and the validation step refuses one that does not. There
+     * is no path here that leaves the provenance unknown.
+     */
+    for (const line of input.runLines || []) {
+      await service.createPaymentSubmissionItems({
+        source_type: "run",
+        design_id: null,
+        design_name: line.label,
+        task_id: null,
+        task_name: null,
+        inventory_order_id: null,
+        inventory_order_name: null,
+        order_id: line.order_id,
+        amount: line.amount,
+        quantity: line.quantity,
+        unit_amount: line.unit_amount,
+        cost_breakdown: line.cost_breakdown || null,
+        production_run_ids: line.run_ids as unknown as Record<
+          string,
+          unknown
+        > | null,
+        run_provenance: "recorded" as const,
+        submission_id: submission.id,
+      })
+    }
+
+    /**
+     * Inventory-order line items (#1612).
+     *
+     * `no_run` because material we bought is not production output — there was
+     * never a run behind it. This is the same case a task line is in: a missing
+     * run here is an ANSWER, not a gap, and may safely be read as "no run
+     * billed" (#1565).
+     */
+    for (const line of input.inventoryLines || []) {
+      await service.createPaymentSubmissionItems({
+        source_type: "inventory_order",
+        design_id: null,
+        design_name: null,
+        task_id: null,
+        task_name: null,
+        inventory_order_id: line.inventory_order_id,
+        inventory_order_name: line.inventory_order_name,
+        order_id: null,
+        amount: line.amount,
+        quantity: line.quantity,
+        unit_amount: null,
+        cost_breakdown: line.cost_breakdown || null,
+        production_run_ids: null as unknown as Record<string, unknown> | null,
+        run_provenance: "no_run" as const,
         submission_id: submission.id,
       })
     }
@@ -1184,6 +1605,16 @@ export const createPaymentSubmissionWorkflow = createWorkflow(
       cost_overrides: costOverrides.tasks,
     })
 
+    const validatedRunLines = validateRunLinesStep({
+      partner_id: input.partner_id,
+      run_lines: input.run_lines || [],
+    })
+
+    const validatedInventoryLines = validateInventoryOrderLinesStep({
+      partner_id: input.partner_id,
+      inventory_order_lines: input.inventory_order_lines || [],
+    })
+
     const currency = resolveSubmissionCurrencyStep({
       partner_id: input.partner_id,
       currency: input.currency,
@@ -1198,6 +1629,8 @@ export const createPaymentSubmissionWorkflow = createWorkflow(
       metadata: input.metadata,
       status: input.status,
       currency,
+      runLines: validatedRunLines,
+      inventoryLines: validatedInventoryLines,
     })
 
     linkSubmissionToPartnerStep({

--- a/apps/backend/src/workflows/payment_submissions/lib/__tests__/order-run-groups.unit.spec.ts
+++ b/apps/backend/src/workflows/payment_submissions/lib/__tests__/order-run-groups.unit.spec.ts
@@ -1,0 +1,131 @@
+import { groupOrderBackedRuns, RunClaimInfo } from "../order-run-groups"
+
+/** The seven runs behind retail order #79, as read from production. */
+const ORDER_79 = "order_01KXWHFP132AM0H940WFD2P0XW"
+const ORDER_79_RUNS = [
+  "prod_run_01KZ3DA8EMPZPS7024E7S94M4P",
+  "prod_run_01KZ3DA8HA2V95V4S41WF8QKK8",
+  "prod_run_01KZ3DA8MSF5YDG4R257WY8J2Q",
+  "prod_run_01KZ3DA8QC7KEP8RYJBC1H8GJ6",
+  "prod_run_01KZ3DA8TV6SR2A90FR1Q1WGWW",
+  "prod_run_01KZ3DAA9AB2PQSN5PKE4AEH2R",
+  "prod_run_01KZ3DAAFPBRCCZEWCNXRZ524Y",
+].map((id) => ({
+  id,
+  order_id: ORDER_79,
+  quantity: 1,
+  produced_quantity: 1,
+  completed_at: "2026-08-03T08:54:44.436Z",
+}))
+
+const noClaims = new Map<string, RunClaimInfo>()
+
+describe("groupOrderBackedRuns", () => {
+  it("surfaces order #79's seven runs as ONE payable group", () => {
+    const groups = groupOrderBackedRuns(ORDER_79_RUNS, noClaims)
+
+    expect(groups).toHaveLength(1)
+    expect(groups[0].order_id).toBe(ORDER_79)
+    expect(groups[0].run_count).toBe(7)
+    expect(groups[0].run_ids).toHaveLength(7)
+    expect(groups[0].produced_quantity).toBe(7)
+    expect(groups[0].billing_status).toBe("clear")
+  })
+
+  /**
+   * 🔴 These runs carry `partner_cost_estimate: null`, so any computed figure
+   * would be a 0 dressed as a price — and 0 passes every `!= null` check
+   * downstream (#1563, #1564).
+   */
+  it("never offers an amount, and says why", () => {
+    const groups = groupOrderBackedRuns(ORDER_79_RUNS, noClaims)
+
+    expect(groups[0].amount).toBeNull()
+    expect(groups[0].amount_reason).toMatch(/must be stated by an operator/)
+  })
+
+  it("separates runs from different orders", () => {
+    const groups = groupOrderBackedRuns(
+      [
+        { id: "run_a", order_id: "order_1", produced_quantity: 1 },
+        { id: "run_b", order_id: "order_2", produced_quantity: 2 },
+        { id: "run_c", order_id: "order_1", produced_quantity: 3 },
+      ],
+      noClaims
+    )
+
+    expect(groups).toHaveLength(2)
+    expect(groups.find((g) => g.order_id === "order_1")?.run_count).toBe(2)
+    expect(groups.find((g) => g.order_id === "order_1")?.produced_quantity).toBe(4)
+  })
+
+  it("reports a fully claimed group as billed", () => {
+    const claims = new Map(
+      ORDER_79_RUNS.map((run) => [
+        run.id,
+        { submission_id: "sub_1", status: "Paid" },
+      ])
+    )
+
+    const groups = groupOrderBackedRuns(ORDER_79_RUNS, claims)
+
+    expect(groups[0].billing_status).toBe("billed")
+    expect(groups[0].claimed_by).toBe("sub_1")
+  })
+
+  /**
+   * 🔴 The load-bearing case. Collapsing this into `billed` hides money owed;
+   * collapsing it into `clear` invites a double payment on the claimed runs.
+   */
+  it("reports a partly claimed group as partly_billed, not as either extreme", () => {
+    const claims = new Map([
+      [ORDER_79_RUNS[0].id, { submission_id: "sub_1", status: "Paid" }],
+      [ORDER_79_RUNS[1].id, { submission_id: "sub_1", status: "Paid" }],
+    ])
+
+    const groups = groupOrderBackedRuns(ORDER_79_RUNS, claims)
+
+    expect(groups[0].billing_status).toBe("partly_billed")
+    expect(groups[0].billing_status).not.toBe("billed")
+    expect(groups[0].billing_status).not.toBe("clear")
+  })
+
+  it("ignores runs with no order at all", () => {
+    const groups = groupOrderBackedRuns(
+      [
+        { id: "run_a", order_id: null, produced_quantity: 1 },
+        { id: "run_b", order_id: ORDER_79, produced_quantity: 1 },
+      ],
+      noClaims
+    )
+
+    expect(groups).toHaveLength(1)
+    expect(groups[0].run_ids).toEqual(["run_b"])
+  })
+
+  it("falls back to ordered quantity when produced was never recorded", () => {
+    const groups = groupOrderBackedRuns(
+      [{ id: "run_a", order_id: "o1", quantity: 5, produced_quantity: null }],
+      noClaims
+    )
+
+    expect(groups[0].produced_quantity).toBe(5)
+  })
+
+  it("takes the LATEST completion across the group", () => {
+    const groups = groupOrderBackedRuns(
+      [
+        { id: "a", order_id: "o1", completed_at: "2026-08-01T00:00:00.000Z" },
+        { id: "b", order_id: "o1", completed_at: "2026-08-09T00:00:00.000Z" },
+        { id: "c", order_id: "o1", completed_at: "2026-08-05T00:00:00.000Z" },
+      ],
+      noClaims
+    )
+
+    expect(groups[0].completed_at).toBe("2026-08-09T00:00:00.000Z")
+  })
+
+  it("returns an empty list rather than throwing on no runs", () => {
+    expect(groupOrderBackedRuns([], noClaims)).toEqual([])
+  })
+})

--- a/apps/backend/src/workflows/payment_submissions/lib/__tests__/run-line-amount.unit.spec.ts
+++ b/apps/backend/src/workflows/payment_submissions/lib/__tests__/run-line-amount.unit.spec.ts
@@ -1,0 +1,143 @@
+import { resolveRunLineAmount } from "../run-line-amount"
+
+/** The seven runs behind retail order #79, as read from production. */
+const ORDER_79_RUNS = [
+  "prod_run_01KZ3DA8EMPZPS7024E7S94M4P",
+  "prod_run_01KZ3DA8HA2V95V4S41WF8QKK8",
+  "prod_run_01KZ3DA8MSF5YDG4R257WY8J2Q",
+  "prod_run_01KZ3DA8QC7KEP8RYJBC1H8GJ6",
+  "prod_run_01KZ3DA8TV6SR2A90FR1Q1WGWW",
+  "prod_run_01KZ3DAA9AB2PQSN5PKE4AEH2R",
+  "prod_run_01KZ3DAAFPBRCCZEWCNXRZ524Y",
+].map((id) => ({
+  id,
+  quantity: 1,
+  produced_quantity: 1,
+  partner_cost_estimate: null,
+  cost_type: "total",
+}))
+
+describe("resolveRunLineAmount", () => {
+  it("bills the order #79 payout as one line claiming all seven runs", () => {
+    const line = resolveRunLineAmount({ runs: ORDER_79_RUNS, amount: 8974 })
+
+    expect(line.amount).toBe(8974)
+    expect(line.quantity).toBe(7)
+    // A typed total carries no rate — 8974/7 = 1282 is a figure nobody agreed to.
+    expect(line.unit_amount).toBeNull()
+    expect(line.cost_breakdown.run_ids).toHaveLength(7)
+    expect(line.cost_breakdown.basis).toBe("explicit_total")
+  })
+
+  /**
+   * 🔴 The load-bearing test. All seven runs carry `partner_cost_estimate:
+   * null`, so derivation yields 0 — and 0 passes every `!= null` check, sums
+   * cleanly, and renders as a real payout of nothing (#1563, #1564).
+   */
+  it("REFUSES to write a zero line when the runs carry no cost", () => {
+    expect(() =>
+      resolveRunLineAmount({
+        runs: ORDER_79_RUNS,
+        deriveAmount: () => 0,
+      })
+    ).toThrow(/must bill a positive amount/)
+  })
+
+  it("names the runs in the refusal so an operator knows what to price", () => {
+    expect(() =>
+      resolveRunLineAmount({ runs: ORDER_79_RUNS, deriveAmount: () => 0 })
+    ).toThrow(/prod_run_01KZ3DA8EMPZPS7024E7S94M4P/)
+  })
+
+  it("refuses a negative explicit amount", () => {
+    expect(() =>
+      resolveRunLineAmount({ runs: ORDER_79_RUNS, amount: -100 })
+    ).toThrow(/must bill a positive amount/)
+  })
+
+  it("refuses a line naming no runs at all", () => {
+    expect(() => resolveRunLineAmount({ runs: [], amount: 100 })).toThrow(
+      /at least one production run/
+    )
+  })
+
+  it("derives from the runs when they do carry a cost", () => {
+    const line = resolveRunLineAmount({
+      runs: [
+        { id: "run_a", quantity: 1, produced_quantity: 1, partner_cost_estimate: 810 },
+        { id: "run_b", quantity: 1, produced_quantity: 1, partner_cost_estimate: 1110 },
+      ],
+      deriveAmount: (run) => Number(run.partner_cost_estimate ?? 0),
+    })
+
+    expect(line.amount).toBe(1920)
+    expect(line.quantity).toBe(2)
+    expect(line.unit_amount).toBe(960)
+    expect(line.cost_breakdown.basis).toBe("derived_from_runs")
+  })
+
+  /**
+   * The embroidered-jacket case: ordered 9, produced 7. Billing the ordered
+   * figure overpays by two garments — `runPayableAmount` multiplies by ordered,
+   * which is exactly the disagreement #1596 is about.
+   */
+  it("counts PRODUCED quantity, not ordered", () => {
+    const line = resolveRunLineAmount({
+      runs: [{ id: "run_a", quantity: 9, produced_quantity: 7 }],
+      amount: 10000,
+    })
+
+    expect(line.quantity).toBe(7)
+  })
+
+  it("falls back to ordered quantity when produced was never recorded", () => {
+    const line = resolveRunLineAmount({
+      runs: [{ id: "run_a", quantity: 4, produced_quantity: null }],
+      amount: 400,
+    })
+
+    expect(line.quantity).toBe(4)
+  })
+
+  it("treats a produced quantity of 0 as 0, not as unrecorded", () => {
+    // A run that produced nothing is not a run that forgot to say.
+    const line = resolveRunLineAmount({
+      runs: [
+        { id: "run_a", quantity: 5, produced_quantity: 0 },
+        { id: "run_b", quantity: 5, produced_quantity: 3 },
+      ],
+      amount: 300,
+    })
+
+    expect(line.quantity).toBe(3)
+  })
+
+  it("lets an explicit quantity override the derived one", () => {
+    const line = resolveRunLineAmount({
+      runs: [{ id: "run_a", quantity: 9, produced_quantity: 7 }],
+      amount: 10000,
+      quantity: 9,
+    })
+
+    expect(line.quantity).toBe(9)
+  })
+
+  it("never lets quantity fall to 0 and produce a divide-by-zero rate", () => {
+    const line = resolveRunLineAmount({
+      runs: [{ id: "run_a", quantity: 0, produced_quantity: 0 }],
+      amount: 500,
+    })
+
+    expect(line.quantity).toBe(1)
+    expect(Number.isFinite(line.amount)).toBe(true)
+  })
+
+  it("rounds an explicit amount to paise", () => {
+    const line = resolveRunLineAmount({
+      runs: ORDER_79_RUNS,
+      amount: 8973.567,
+    })
+
+    expect(line.amount).toBe(8973.57)
+  })
+})

--- a/apps/backend/src/workflows/payment_submissions/lib/order-run-groups.ts
+++ b/apps/backend/src/workflows/payment_submissions/lib/order-run-groups.ts
@@ -1,0 +1,123 @@
+/**
+ * Order-backed production runs, grouped into payable units (#1612, #1598).
+ *
+ * ## What was wrong
+ *
+ * `payable-runs` began with `filter((r) => !!r.design_id)` and everything after
+ * it was design-keyed, so a run without a design simply ceased to exist there —
+ * no row, no exclusion, no count. The seven runs behind retail order #79 are
+ * exactly that: minted by `order.fulfillment_created` with `design_id: null`,
+ * completed and delivered, and never offered for payment by any screen.
+ *
+ * That contradicted the same file's rule for provenance runs, which are
+ * REPORTED rather than dropped because "a screen that simply omits the row
+ * teaches nobody why the work vanished". A silent drop is worse than an
+ * exclusion — an exclusion at least says the work exists.
+ *
+ * ## Grouped by order, because that is the unit the money is agreed in
+ *
+ * Order #79 is one payment of ₹8,974, not seven of ₹1,282. The group carries
+ * every run id so a caller can send it as a single `run_lines` entry.
+ */
+
+export type OrderBackedRun = {
+  id: string
+  order_id?: string | null
+  quantity?: number | null
+  produced_quantity?: number | null
+  completed_at?: string | Date | null
+}
+
+export type RunClaimInfo = {
+  submission_id: string
+  status: string
+}
+
+export type OrderRunGroup = {
+  order_id: string
+  run_ids: string[]
+  run_count: number
+  produced_quantity: number
+  completed_at: string | null
+  billing_status: "clear" | "billed" | "partly_billed"
+  claimed_by: string | null
+  /** Always null — see the note in `groupOrderBackedRuns`. */
+  amount: null
+  amount_reason: string
+}
+
+const AMOUNT_REASON =
+  "Runs carry no partner_cost_estimate — the payout amount must be stated by an operator."
+
+/**
+ * PURE.
+ *
+ * ⚠️ No amount is ever offered. These runs carry `partner_cost_estimate: null`
+ * — all seven of order #79's do — so any figure computed here would be a 0
+ * dressed as a price, and 0 passes every `!= null` check downstream (#1563,
+ * #1564). The rate was agreed out of band; an operator must state it, and
+ * `create` refuses a zero-value run line for the same reason.
+ */
+export function groupOrderBackedRuns(
+  runs: OrderBackedRun[],
+  claims: Map<string, RunClaimInfo>
+): OrderRunGroup[] {
+  const groups = new Map<string, OrderBackedRun[]>()
+
+  for (const run of runs || []) {
+    if (!run?.order_id) continue
+    const orderId = String(run.order_id)
+    groups.set(orderId, [...(groups.get(orderId) || []), run])
+  }
+
+  return [...groups.entries()].map(([orderId, groupRuns]) => {
+    const claimed = groupRuns
+      .map((run) => claims.get(String(run.id)))
+      .filter(Boolean) as RunClaimInfo[]
+
+    const produced = groupRuns.reduce(
+      (sum, run) =>
+        sum +
+        (run.produced_quantity != null
+          ? Number(run.produced_quantity ?? 0)
+          : Number(run.quantity ?? 0)),
+      0
+    )
+
+    const completedAts = groupRuns
+      .map((run) =>
+        run.completed_at
+          ? new Date(run.completed_at).toISOString()
+          : null
+      )
+      .filter(Boolean)
+      .sort() as string[]
+
+    return {
+      order_id: orderId,
+      run_ids: groupRuns.map((run) => String(run.id)),
+      run_count: groupRuns.length,
+      produced_quantity: produced,
+      completed_at: completedAts.length
+        ? completedAts[completedAts.length - 1]
+        : null,
+      /**
+       * 🔴 `partly_billed` is its own answer, not a rounding of the other two.
+       * A group where some runs are claimed and some are not cannot be paid as
+       * a whole without double-paying part of it, and cannot be skipped without
+       * underpaying the rest. Collapsing it into `billed` hides money owed;
+       * collapsing it into `clear` invites a double payment. A human has to
+       * split it, and the status has to say so.
+       */
+      billing_status:
+        claimed.length === 0
+          ? "clear"
+          : claimed.length === groupRuns.length
+            ? "billed"
+            : "partly_billed",
+      claimed_by: claimed.length ? claimed[0].submission_id : null,
+      amount: null,
+      amount_reason: AMOUNT_REASON,
+    }
+  })
+}

--- a/apps/backend/src/workflows/payment_submissions/lib/run-claims.ts
+++ b/apps/backend/src/workflows/payment_submissions/lib/run-claims.ts
@@ -128,14 +128,21 @@ export function foldInventoryOrderClaims(
  * lines under them. An `excludeSubmissionId` drops the submission being edited,
  * so a line does not read its own claim as a conflict with itself.
  */
-export async function listPartnerPriorLines(
+/**
+ * The partner's prior submission lines, RAW.
+ *
+ * Callers that need more than the claim maps — `payable-runs` reads
+ * `run_provenance`, `design_id`, `amount` and `quantity` off these rows —
+ * take them from here rather than re-deriving the partner scope themselves.
+ */
+export async function listPartnerSubmissionItems(
   service: {
     listPaymentSubmissions: (filters: any, config?: any) => Promise<any[]>
     listPaymentSubmissionItems: (filters: any, config?: any) => Promise<any[]>
   },
   partnerId: string,
   options?: { excludeSubmissionId?: string }
-): Promise<PriorRunLine[]> {
+): Promise<any[]> {
   if (!partnerId) return []
 
   const submissions = await service.listPaymentSubmissions({
@@ -150,10 +157,21 @@ export async function listPartnerPriorLines(
 
   if (!submissionIds.length) return []
 
-  const items = await service.listPaymentSubmissionItems(
+  return (await service.listPaymentSubmissionItems(
     { submission_id: submissionIds },
     { relations: ["submission"] }
-  )
+  )) as any[]
+}
+
+export async function listPartnerPriorLines(
+  service: {
+    listPaymentSubmissions: (filters: any, config?: any) => Promise<any[]>
+    listPaymentSubmissionItems: (filters: any, config?: any) => Promise<any[]>
+  },
+  partnerId: string,
+  options?: { excludeSubmissionId?: string }
+): Promise<PriorRunLine[]> {
+  const items = await listPartnerSubmissionItems(service, partnerId, options)
 
   return ((items || []) as any[]).map((item) => ({
     submission_id: item.submission?.id ?? item.submission_id ?? null,

--- a/apps/backend/src/workflows/payment_submissions/lib/run-line-amount.ts
+++ b/apps/backend/src/workflows/payment_submissions/lib/run-line-amount.ts
@@ -1,0 +1,129 @@
+/**
+ * What a RUN-sourced payout line bills (#1612).
+ *
+ * A run-sourced line pays for one or more completed production runs directly,
+ * rather than for a design. It exists because runs minted from a retail order's
+ * fulfillment carry `design_id: null` and can never be expressed as a design
+ * line — see the seven runs behind order #79.
+ *
+ * ## Why the amount is usually explicit
+ *
+ * `runPayableAmount` derives a run's value from `partner_cost_estimate` and the
+ * ORDERED quantity. That works for a dispatched design run. It does not work
+ * here: **all seven order-#79 runs carry `partner_cost_estimate: null`**, so the
+ * derivation yields 0 for every one of them. The labour was real, agreed out of
+ * band and already paid; the number simply is not on the run.
+ *
+ * So an explicit `amount` is the normal path for this source, and derivation is
+ * the fallback for runs that do carry a cost.
+ *
+ * ## 🔴 Zero is refused, never written
+ *
+ * A derivation that finds nothing returns 0, and 0 is a number: it passes every
+ * `!= null` check, sums cleanly into a total, and renders as a real payout of
+ * nothing. That is how an estimator's "found nothing = 0" reached a storefront
+ * till (#1564), and how a `=== null` guard was defeated by a 0 written for
+ * "found nothing" (#1563).
+ *
+ * A line that cannot say what it bills is refused here, with a message naming
+ * the runs, so an operator supplies the figure instead of a silent zero being
+ * approved by someone reading a total.
+ */
+
+export type RunForLine = {
+  id: string
+  quantity?: number | null
+  produced_quantity?: number | null
+  partner_cost_estimate?: number | null
+  cost_type?: string | null
+}
+
+export type ResolvedRunLine = {
+  amount: number
+  quantity: number
+  /** Null when the total was typed rather than derived — there is no rate to show. */
+  unit_amount: number | null
+  cost_breakdown: Record<string, unknown>
+}
+
+const num = (value: unknown): number => {
+  const parsed = Number(value ?? 0)
+  return Number.isFinite(parsed) ? parsed : 0
+}
+
+/**
+ * PURE.
+ *
+ * `quantity` defaults to the total PRODUCED across the runs, not the ordered
+ * total. A run-sourced line pays for delivered work, and the two differ: the
+ * embroidered-jacket run was ordered 9 and produced 7, and billing the ordered
+ * figure overpaid by two garments (#1596). Where produced is not recorded the
+ * ordered quantity stands in, since something must.
+ */
+export function resolveRunLineAmount(input: {
+  runs: RunForLine[]
+  /** An explicit line TOTAL. Wins outright and is never multiplied. */
+  amount?: number | null
+  quantity?: number | null
+  deriveAmount?: (run: RunForLine) => number
+}): ResolvedRunLine {
+  const runs = input.runs || []
+
+  if (!runs.length) {
+    throw new Error("A run-sourced line must name at least one production run.")
+  }
+
+  const producedTotal = runs.reduce(
+    (sum, run) =>
+      sum +
+      (run.produced_quantity != null
+        ? num(run.produced_quantity)
+        : num(run.quantity)),
+    0
+  )
+
+  const quantity =
+    input.quantity != null && num(input.quantity) > 0
+      ? num(input.quantity)
+      : producedTotal > 0
+        ? producedTotal
+        : 1
+
+  const explicit = input.amount
+  const hasExplicit = explicit != null && Number.isFinite(Number(explicit))
+
+  const amount = hasExplicit
+    ? Math.round(Number(explicit) * 100) / 100
+    : Math.round(
+        runs.reduce((sum, run) => sum + (input.deriveAmount?.(run) ?? 0), 0) *
+          100
+      ) / 100
+
+  if (!(amount > 0)) {
+    throw new Error(
+      `A run-sourced line must bill a positive amount. ` +
+        `The runs it names (${runs.map((r) => r.id).join(", ")}) carry no cost ` +
+        `to derive one from — send an explicit amount. ` +
+        `Writing 0 would record a payout of nothing that reads as a real one.`
+    )
+  }
+
+  return {
+    amount,
+    quantity,
+    // A typed total carries no rate. Deriving one by dividing would invent a
+    // per-unit figure nobody agreed to — the same reason a corrected line
+    // clears `unit_amount` rather than back-computing it.
+    unit_amount: hasExplicit
+      ? null
+      : quantity > 0
+        ? Math.round((amount / quantity) * 100) / 100
+        : null,
+    cost_breakdown: {
+      source: "production_runs",
+      run_ids: runs.map((r) => r.id),
+      basis: hasExplicit ? "explicit_total" : "derived_from_runs",
+      produced_quantity: producedTotal,
+    },
+  }
+}


### PR DESCRIPTION
Builds on #1614 (merged and deployed — migration verified live on prod before this was opened). That PR added the schema and the guards; this one adds the paths that actually write money, and fixes the screen that was hiding the work.

## 1. Run-sourced payout lines

One line per entry, claiming the runs it names. Grouping is the caller's: the seven runs behind retail order #79 are **one payout of ₹8,974, not seven of ₹1,282**, because that is how the money moved.

This is the only expression available for a run with `design_id: null`. A run minted from `order.fulfillment_created` is not design-backed and never will be, so no `design_ids` entry can reach it.

### 🔴 Zero is refused, never written

`runPayableAmount` derives from `partner_cost_estimate`, and **all seven order-#79 runs carry NULL** — so derivation yields 0 for every one of them. 0 is a number: it passes `!= null`, sums cleanly into a total, and renders as a real payout of nothing. That is how an estimator's "found nothing = 0" reached a storefront till (#1564).

A line that cannot say what it bills is refused, with the run ids in the message so an operator supplies the figure instead of a silent zero being approved by someone reading a total.

Quantity counts **produced**, not ordered — `runPayableAmount` multiplying by ordered is the disagreement #1596 is about. An explicit total clears `unit_amount` rather than back-computing ₹8,974 ÷ 7 = ₹1,282, a rate nobody agreed to.

## 2. Inventory-order payout lines

Amount **derived** from the typed `line_fulfillments` receipts — not `total_price` (ordered, not owed: ₹88,885 vs ₹25,670 on one `Partial` order) and not `metadata.partner_delivery_history` (which disagrees with the typed rows by ₹4,050 — #1613). An explicit amount overrides. An order with no receipts is refused rather than billed at 0.

## 3. `payable-runs` was silently dropping runs

`filter((r) => !!r.design_id)` was the first thing the endpoint did, and everything downstream was design-keyed — so a run without a design did not get excluded, it **ceased to exist**. No row, no count, no reason.

This contradicted the same file's rule for provenance runs forty lines below, which are *reported* rather than dropped because *"a screen that simply omits the row teaches nobody why the work vanished"*. A silent drop is worse than an exclusion; an exclusion at least says the work exists.

Now surfaced as `order_runs` (grouped by order) and `unattributable_runs` (neither design nor order — a data question, not a row to hide), as separate lists so no existing consumer receives rows with a null `design_id`. No amount is offered, for the same zero-is-not-a-price reason as above.

**`partly_billed` is its own status.** A group where some runs are claimed and some are not cannot be paid whole without double-paying part of it, nor skipped without underpaying the rest. Collapsing it into `billed` hides money owed; into `clear` invites a double payment.

## ⚠️ Correcting #1614's description

That PR's body claimed all four claim guards were rescoped to the partner. **Three were** — create, submit, update-item. `payable-runs` still read `{ design_id: designIds }`; it is rescoped here. It matters for the same reason as the rest: a run this screen offers as payable could already have been paid by a run-sourced line carrying `design_id: null`, and the screen would not have seen it.

The prior-lines fetch also moves above the design early-return, so a partner with **no** design runs still gets their order-backed rows rather than "nothing" — which is exactly the case this endpoint used to render as empty.

## Guards added beyond #1614

- A run may be claimed only once **across the lines of one submission** — two lines naming the same run would each pass the prior-claim check and bill it twice in a single request.
- An inventory order may appear only once per submission, since an order is claimed whole.
- If a run line names a commissioning `order_id`, every run on it must belong to that order, or the provenance is decoration.

## Route

`run_lines`, `inventory_order_lines` and `currency` are forwarded **explicitly** from the handler. A field the validator accepts but the handler never passes on is dropped in silence — the request succeeds, the line is simply absent, and no dry-run reveals it.

## Testing

**21 new tests. 229 payment + fx unit tests green. tsc unchanged at its 279-line baseline with none of the output naming files in this PR** (verified the run was non-empty before trusting the filter). `check:prod-build` passes — run after the last edit.

Load-bearing tests, i.e. the ones that fail against the old behaviour:
- *"REFUSES to write a zero line when the runs carry no cost"* — the exact shape of all seven order-#79 runs.
- *"reports a partly claimed group as partly_billed, not as either extreme"*.
- *"surfaces order #79's seven runs as ONE payable group"* — the old code returned nothing at all for them.

Fixtures use the real production shapes throughout, awkward parts kept.

`groupOrderBackedRuns` is extracted as a pure function rather than left inline: it decides money and the route had no unit tests at all.

## Risk

Additive on the write side — no existing caller sends `run_lines` or `inventory_order_lines`, and design/task lines take the path they always did.

The read-side change to `payable-runs` is additive in its response (two new keys) but **does change `billing_status` for existing rows**: partner-scoped priors mean the endpoint now sees claims it previously could not. That can only move a run from `clear` toward `billed`/`unknown` — never the reverse — so the direction is strictly safer.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01TLt1f38xqR8k2myCVxP8e4
