### PR TITLE
Show every payout line, link payments to their source, and record where money came from (#1612, #938)

### DIFF
--- a/apps/backend/src/admin/hooks/api/payment-submissions.ts
+++ b/apps/backend/src/admin/hooks/api/payment-submissions.ts
@@ -398,6 +398,69 @@ export const useUpdatePaymentSubmissionItem = (
   })
 }
 
+/**
+ * Attach documents to a payout — at ANY status.
+ *
+ * The route APPENDS to what it reads, so this sends every file from one drop
+ * in a single call: two overlapping requests would each read the same array
+ * and the second would silently drop the first's attachments.
+ */
+export const useAttachPaymentSubmissionDocuments = (
+  options?: UseMutationOptions<
+    { documents: any[]; added: number },
+    FetchError,
+    {
+      id: string
+      documents: Array<{
+        id?: string
+        url: string
+        filename?: string
+        mimeType?: string
+        size?: number
+      }>
+    }
+  >
+) => {
+  const queryClient = useQueryClient()
+  return useMutation({
+    mutationFn: async ({ id, documents }) =>
+      sdk.client.fetch<{ documents: any[]; added: number }>(
+        `/admin/payment-submissions/${id}/documents`,
+        { method: "POST", body: { documents } }
+      ) as Promise<{ documents: any[]; added: number }>,
+    onSuccess: (data, variables, _mutateResult, context) => {
+      queryClient.invalidateQueries({ queryKey: paymentSubmissionQueryKeys.lists() })
+      queryClient.invalidateQueries({ queryKey: paymentSubmissionQueryKeys.detail(variables.id) })
+      options?.onSuccess?.(data, variables, _mutateResult, context)
+    },
+    ...options,
+  })
+}
+
+/** Remove one attachment by id. Never by index — the array is re-read on write. */
+export const useDeletePaymentSubmissionDocument = (
+  options?: UseMutationOptions<
+    { documents: any[] },
+    FetchError,
+    { id: string; document_id: string }
+  >
+) => {
+  const queryClient = useQueryClient()
+  return useMutation({
+    mutationFn: async ({ id, document_id }) =>
+      sdk.client.fetch<{ documents: any[] }>(
+        `/admin/payment-submissions/${id}/documents?document_id=${encodeURIComponent(document_id)}`,
+        { method: "DELETE" }
+      ) as Promise<{ documents: any[] }>,
+    onSuccess: (data, variables, _mutateResult, context) => {
+      queryClient.invalidateQueries({ queryKey: paymentSubmissionQueryKeys.lists() })
+      queryClient.invalidateQueries({ queryKey: paymentSubmissionQueryKeys.detail(variables.id) })
+      options?.onSuccess?.(data, variables, _mutateResult, context)
+    },
+    ...options,
+  })
+}
+
 /** Remove a machine-written Draft (#1604). Draft only — the route refuses the rest. */
 export const useDeletePaymentSubmission = (
   options?: UseMutationOptions<

--- a/apps/backend/src/admin/lib/__tests__/payment-line-source.unit.spec.ts
+++ b/apps/backend/src/admin/lib/__tests__/payment-line-source.unit.spec.ts
@@ -1,0 +1,145 @@
+import {
+  describePaymentLine,
+  paymentLineKind,
+} from "../payment-line-source"
+
+/**
+ * How a payout line describes itself on screen.
+ *
+ * 🔴 The defect this replaces: the submission page filtered lines into exactly
+ * two buckets, `design` and `task`. `source_type` has been
+ * `design | task | run | inventory_order` since #1614, so run- and
+ * inventory-order-sourced lines matched NEITHER filter and rendered NOWHERE —
+ * the GOF payout showed a ₹30,000 total with no line explaining it, under a
+ * stat tile that called an inventory order a "Design".
+ */
+describe("paymentLineKind", () => {
+  it("takes source_type when it is set", () => {
+    expect(paymentLineKind({ source_type: "inventory_order" })).toBe(
+      "inventory_order"
+    )
+  })
+
+  /** ⚠️ A missing source_type is NOT design — only the ids can say. */
+  it("infers from ids when source_type is absent", () => {
+    expect(paymentLineKind({ inventory_order_id: "inv_1" })).toBe("inventory_order")
+    expect(paymentLineKind({ production_run_ids: ["r"] })).toBe("run")
+    expect(paymentLineKind({ task_id: "t" })).toBe("task")
+    expect(paymentLineKind({ design_id: "d" })).toBe("design")
+  })
+
+  it("says unknown rather than guessing when there is nothing to go on", () => {
+    expect(paymentLineKind({})).toBe("unknown")
+  })
+})
+
+describe("describePaymentLine", () => {
+  it("describes an inventory-order line as an inventory order", () => {
+    expect(
+      describePaymentLine({
+        source_type: "inventory_order",
+        inventory_order_id: "inv_order_1",
+        inventory_order_name: "Inventory order inv_order_1",
+      })
+    ).toEqual({
+      kind: "inventory_order",
+      label: "Inventory order",
+      title: "Inventory order inv_order_1",
+      reference: "inv_order_1",
+    })
+  })
+
+  /**
+   * The grouping is the point: seven runs are ONE payout, so the line reports
+   * how many runs it covers rather than naming one of them as though the other
+   * six were something else.
+   */
+  it("describes a run line by its run COUNT, not by one run", () => {
+    const described = describePaymentLine({
+      source_type: "run",
+      order_id: "order_79",
+      production_run_ids: ["a", "b", "c", "d", "e", "f", "g"],
+    })
+
+    expect(described.label).toBe("Production runs")
+    expect(described.title).toBe("7 production runs")
+    expect(described.reference).toBe("order_79")
+  })
+
+  it("singularises a one-run line", () => {
+    expect(
+      describePaymentLine({ source_type: "run", production_run_ids: ["a"] }).title
+    ).toBe("1 production run")
+  })
+
+  it("prefers a stated label over the run count", () => {
+    expect(
+      describePaymentLine({
+        source_type: "run",
+        design_name: "Retail order #79 - 7 garments",
+        production_run_ids: ["a", "b"],
+      }).title
+    ).toBe("Retail order #79 - 7 garments")
+  })
+
+  it("falls back to a run id when the line names no order", () => {
+    expect(
+      describePaymentLine({
+        source_type: "run",
+        production_run_ids: ["prod_run_1"],
+      }).reference
+    ).toBe("prod_run_1")
+  })
+
+  it("describes a design line", () => {
+    expect(
+      describePaymentLine({
+        source_type: "design",
+        design_id: "design_1",
+        design_name: "Namtso Shirt",
+      })
+    ).toEqual({
+      kind: "design",
+      label: "Design",
+      title: "Namtso Shirt",
+      reference: "design_1",
+    })
+  })
+
+  it("describes a task line", () => {
+    expect(
+      describePaymentLine({ source_type: "task", task_id: "task_1" })
+    ).toEqual({
+      kind: "task",
+      label: "Task",
+      title: "Untitled task",
+      reference: "task_1",
+    })
+  })
+
+  /**
+   * An unattributable line must still RENDER. Returning nothing is how these
+   * lines disappeared in the first place.
+   */
+  it("still describes a line with no source at all", () => {
+    const described = describePaymentLine({})
+
+    expect(described.kind).toBe("unknown")
+    expect(described.title).toBe("Unattributed line")
+    expect(described.reference).toBeNull()
+  })
+
+  /** Every source type must produce a renderable description — no undefineds. */
+  it.each([
+    ["design", { source_type: "design" }],
+    ["task", { source_type: "task" }],
+    ["run", { source_type: "run" }],
+    ["inventory_order", { source_type: "inventory_order" }],
+    ["unknown", {}],
+  ])("gives %s a non-empty label and title", (_kind, line) => {
+    const described = describePaymentLine(line as any)
+
+    expect(described.label).toBeTruthy()
+    expect(described.title).toBeTruthy()
+  })
+})

--- a/apps/backend/src/admin/lib/payment-line-source.ts
+++ b/apps/backend/src/admin/lib/payment-line-source.ts
@@ -1,0 +1,102 @@
+/**
+ * How one payout line describes itself.
+ *
+ * PURE, and shared so a screen cannot invent its own vocabulary. The submission
+ * page previously hardcoded "Design" for every line and filtered on two of the
+ * four source types, which made run- and inventory-order-sourced payouts render
+ * nowhere while a stat tile counted them as designs.
+ */
+
+export type PaymentLineLike = {
+  source_type?: string | null
+  design_id?: string | null
+  design_name?: string | null
+  task_id?: string | null
+  task_name?: string | null
+  inventory_order_id?: string | null
+  inventory_order_name?: string | null
+  order_id?: string | null
+  production_run_ids?: string[] | null
+}
+
+export type PaymentLineSource = {
+  /** `design` | `task` | `run` | `inventory_order` | `unknown` */
+  kind: string
+  /** Human label for the source column — "Design", "Inventory order", … */
+  label: string
+  /** What this line is for, in words. Never an id. */
+  title: string
+  /** The id worth showing next to the title, if any. */
+  reference: string | null
+}
+
+/**
+ * A line's kind, falling back to its ids.
+ *
+ * ⚠️ A missing `source_type` is NOT "design". Rows written before #1614 have
+ * no source_type at all, and only their ids can say what they are — the old
+ * code's `!i.source_type && i.design_id` was right about that and it is kept.
+ */
+export const paymentLineKind = (line: PaymentLineLike): string => {
+  if (line.source_type) return String(line.source_type)
+  if (line.inventory_order_id) return "inventory_order"
+  if (line.production_run_ids?.length) return "run"
+  if (line.task_id) return "task"
+  if (line.design_id) return "design"
+  return "unknown"
+}
+
+export const describePaymentLine = (
+  line: PaymentLineLike
+): PaymentLineSource => {
+  const kind = paymentLineKind(line)
+
+  switch (kind) {
+    case "design":
+      return {
+        kind,
+        label: "Design",
+        title: line.design_name || "Untitled design",
+        reference: line.design_id || null,
+      }
+
+    case "task":
+      return {
+        kind,
+        label: "Task",
+        title: line.task_name || "Untitled task",
+        reference: line.task_id || null,
+      }
+
+    case "inventory_order":
+      return {
+        kind,
+        label: "Inventory order",
+        title: line.inventory_order_name || "Inventory order",
+        reference: line.inventory_order_id || null,
+      }
+
+    case "run": {
+      const runCount = line.production_run_ids?.length || 0
+
+      return {
+        kind,
+        label: "Production runs",
+        // The grouping is the point: order #79's seven runs are ONE payout,
+        // so the line says how many runs it covers rather than naming one.
+        title:
+          line.design_name ||
+          (runCount ? `${runCount} production run${runCount === 1 ? "" : "s"}` : "Production run"),
+        reference: line.order_id || line.production_run_ids?.[0] || null,
+      }
+    }
+
+    default:
+      return {
+        kind: "unknown",
+        label: "Unattributed",
+        title: "Unattributed line",
+        reference: null,
+      }
+  }
+}

--- a/apps/backend/src/admin/routes/payment-submissions/[id]/page.tsx
+++ b/apps/backend/src/admin/routes/payment-submissions/[id]/page.tsx
@@ -20,6 +20,8 @@ import {
   useUpdatePaymentSubmissionItem,
   type PaymentSubmission,
 } from "../../../hooks/api/payment-submissions"
+import { describePaymentLine } from "../../../lib/payment-line-source"
+import { SubmissionDocuments } from "../_components/submission-documents"
 
 const statusColor = (
   status: string
@@ -108,11 +110,23 @@ const EditableLine = ({
     }
   }
 
+  /**
+   * What this line is for, by its own source_type — not "design" for
+   * everything. A run- or inventory-order-sourced line used to render nowhere
+   * at all; now it renders here and says what it is.
+   */
+  const source = describePaymentLine(item)
+
   return (
     <Table.Row>
-      <Table.Cell>{item.design_name || "Unnamed design"}</Table.Cell>
       <Table.Cell>
-        <span className="font-mono text-xs">{item.design_id}</span>
+        <Badge size="2xsmall" color={source.kind === "unknown" ? "orange" : "grey"}>
+          {source.label}
+        </Badge>
+      </Table.Cell>
+      <Table.Cell>{source.title}</Table.Cell>
+      <Table.Cell>
+        <span className="font-mono text-xs">{source.reference || "—"}</span>
       </Table.Cell>
       <Table.Cell>
         {editing ? (
@@ -234,12 +248,17 @@ const PaymentSubmissionDetailPage = () => {
   /** Lines are editable only while the money has not moved. */
   const linesEditable = isDraft || submission.status === "Pending"
   const items: any[] = submission.items || []
-  const designItems = items.filter(
-    (i) => i.source_type === "design" || (!i.source_type && i.design_id)
-  )
-  const taskItems = items.filter(
-    (i) => i.source_type === "task" || (!i.source_type && i.task_id)
-  )
+  /**
+   * 🔴 One table over every line, not a filter per source type.
+   *
+   * The previous split kept only `design` and `task` buckets. `source_type`
+   * has been `design | task | run | inventory_order` since #1614, so run- and
+   * inventory-order-sourced lines matched NEITHER filter and rendered nowhere
+   * at all — the total said ₹30,000 while the line explaining it was invisible.
+   * Partitioning by source is what made a whole class of payout disappear, so
+   * the fix is to stop partitioning: every line is shown, and the source is a
+   * column rather than a reason to be excluded.
+   */
   const documents: any[] = submission.documents || []
 
   return (
@@ -383,8 +402,10 @@ const PaymentSubmissionDetailPage = () => {
             <Heading>{money(submission.total_amount, submission.currency)}</Heading>
           </Container>
           <Container className="p-4">
+            {/* Was "Designs" over items.length — which counted an inventory
+                order as a design. It counts LINES; say so. */}
             <Text size="small" className="text-ui-fg-subtle">
-              Designs
+              Lines
             </Text>
             <Heading>{items.length}</Heading>
           </Container>
@@ -402,17 +423,18 @@ const PaymentSubmissionDetailPage = () => {
           </Container>
         </div>
 
-        {/* Design Items Table */}
-        {designItems.length > 0 && (
+        {/* Payout lines — every source type, one table */}
+        {items.length > 0 && (
           <Container className="p-0">
             <div className="border-b border-ui-border-base px-4 py-3">
-              <Heading level="h3">Design Items</Heading>
+              <Heading level="h3">Payout Lines</Heading>
             </div>
             <Table>
               <Table.Header>
                 <Table.Row>
-                  <Table.HeaderCell>Design</Table.HeaderCell>
-                  <Table.HeaderCell>Design ID</Table.HeaderCell>
+                  <Table.HeaderCell>Source</Table.HeaderCell>
+                  <Table.HeaderCell>For</Table.HeaderCell>
+                  <Table.HeaderCell>Reference</Table.HeaderCell>
                   {/* The breakdown, so a partner reads "9 x 850" rather than a
                       bare total they have to take on trust (#1554). */}
                   <Table.HeaderCell>Units</Table.HeaderCell>
@@ -423,7 +445,7 @@ const PaymentSubmissionDetailPage = () => {
                 </Table.Row>
               </Table.Header>
               <Table.Body>
-                {designItems.map((item: any) => (
+                {items.map((item: any) => (
                   <EditableLine
                     key={item.id}
                     item={item}
@@ -431,41 +453,6 @@ const PaymentSubmissionDetailPage = () => {
                     currency={submission.currency}
                     editable={linesEditable}
                   />
-                ))}
-              </Table.Body>
-            </Table>
-          </Container>
-        )}
-
-        {/* Task Items Table */}
-        {taskItems.length > 0 && (
-          <Container className="p-0">
-            <div className="border-b border-ui-border-base px-4 py-3">
-              <Heading level="h3">Task Items</Heading>
-            </div>
-            <Table>
-              <Table.Header>
-                <Table.Row>
-                  <Table.HeaderCell>Task</Table.HeaderCell>
-                  <Table.HeaderCell>Task ID</Table.HeaderCell>
-                  <Table.HeaderCell>Amount</Table.HeaderCell>
-                </Table.Row>
-              </Table.Header>
-              <Table.Body>
-                {taskItems.map((item: any) => (
-                  <Table.Row key={item.id}>
-                    <Table.Cell>
-                      {item.task_name || "Untitled task"}
-                    </Table.Cell>
-                    <Table.Cell>
-                      <span className="font-mono text-xs">
-                        {item.task_id}
-                      </span>
-                    </Table.Cell>
-                    <Table.Cell>
-                      {money(item.amount, submission.currency)}
-                    </Table.Cell>
-                  </Table.Row>
                 ))}
               </Table.Body>
             </Table>
@@ -480,27 +467,12 @@ const PaymentSubmissionDetailPage = () => {
           </Container>
         )}
 
-        {/* Documents */}
-        {documents.length > 0 && (
-          <Container className="p-0">
-            <div className="border-b border-ui-border-base px-4 py-3">
-              <Heading level="h3">Documents</Heading>
-            </div>
-            <div className="flex flex-col gap-2 p-4">
-              {documents.map((doc: any, i: number) => (
-                <a
-                  key={i}
-                  href={doc.url}
-                  target="_blank"
-                  rel="noopener noreferrer"
-                  className="text-ui-fg-interactive underline text-sm"
-                >
-                  {doc.filename || doc.url}
-                </a>
-              ))}
-            </div>
-          </Container>
-        )}
+        {/* Documents — always rendered, and attachable at any status. The
+            receipt proving a payout happened arrives after it is Paid. */}
+        <SubmissionDocuments
+          submissionId={submission.id}
+          documents={documents}
+        />
       </div>
       {/**
         * A Draft is machine-written, so removing one is routine — but it is

--- a/apps/backend/src/admin/routes/payment-submissions/_components/submission-documents.tsx
+++ b/apps/backend/src/admin/routes/payment-submissions/_components/submission-documents.tsx
@@ -1,0 +1,176 @@
+import { useState } from "react"
+import { Container, Heading, IconButton, Text, toast } from "@medusajs/ui"
+import { DocumentText, Trash } from "@medusajs/icons"
+
+import { FileUpload } from "../../../components/common/file-upload"
+import { useFileUpload } from "../../../hooks/api/upload"
+import {
+  useAttachPaymentSubmissionDocuments,
+  useDeletePaymentSubmissionDocument,
+} from "../../../hooks/api/payment-submissions"
+
+export type SubmissionDocument = {
+  id?: string
+  url: string
+  filename?: string
+  mimeType?: string
+  size?: number
+  uploaded_at?: string
+}
+
+const readableSize = (size?: number) => {
+  if (!size || size < 0) return null
+  if (size < 1024) return `${size} B`
+  if (size < 1024 * 1024) return `${Math.round(size / 1024)} KB`
+  return `${(size / (1024 * 1024)).toFixed(1)} MB`
+}
+
+/**
+ * Attachments on a payout — bills, invoices, transfer receipts.
+ *
+ * 🔑 Rendered at EVERY status, and deliberately so. `documents` could only be
+ * set when the submission was created, but the document that proves a payout
+ * happened — the bank receipt — does not exist until after the money moves, by
+ * which point the submission is Approved or Paid. A record that closes at the
+ * moment its evidence starts arriving guarantees the evidence lives in
+ * somebody's inbox instead.
+ *
+ * Attaching cannot change what is owed: the route touches the documents array
+ * and nothing else, so none of the reasons the other write routes refuse a
+ * settled submission apply here.
+ */
+export const SubmissionDocuments = ({
+  submissionId,
+  documents,
+}: {
+  submissionId: string
+  documents: SubmissionDocument[]
+}) => {
+  const [uploading, setUploading] = useState(false)
+  const { mutateAsync: uploadFile } = useFileUpload()
+  const { mutateAsync: attach, isPending: isAttaching } =
+    useAttachPaymentSubmissionDocuments()
+  const { mutateAsync: removeDocument } = useDeletePaymentSubmissionDocument()
+
+  /**
+   * Upload first, then attach in ONE call.
+   *
+   * Attaching per file would leave a half-attached set behind any failure, and
+   * the route appends to what it reads — so two overlapping requests can each
+   * read the same array and the second would drop the first's file.
+   */
+  const onUploaded = async (files: { file: File; url: string }[]) => {
+    if (!files?.length) return
+
+    setUploading(true)
+    try {
+      const uploaded: SubmissionDocument[] = []
+
+      for (const { file } of files) {
+        const res = await uploadFile({ files: [file] })
+        const f = res.files?.[0]
+        if (f?.id && f?.url) {
+          uploaded.push({
+            id: f.id,
+            url: f.url,
+            filename: file.name,
+            mimeType: file.type || undefined,
+            size: typeof file.size === "number" ? file.size : undefined,
+          })
+        }
+      }
+
+      if (!uploaded.length) {
+        toast.error("Nothing was uploaded")
+        return
+      }
+
+      await attach({ id: submissionId, documents: uploaded })
+      toast.success(
+        `${uploaded.length} document${uploaded.length === 1 ? "" : "s"} attached`
+      )
+    } catch (e: any) {
+      toast.error(e?.message || "Could not attach the document")
+    } finally {
+      setUploading(false)
+    }
+  }
+
+  const onRemove = async (documentId?: string) => {
+    if (!documentId) {
+      // A legacy attachment written before ids were stored cannot be addressed
+      // individually, and deleting by index would race the array it reads.
+      toast.error("This attachment has no id and cannot be removed here")
+      return
+    }
+
+    try {
+      await removeDocument({ id: submissionId, document_id: documentId })
+      toast.success("Document removed")
+    } catch (e: any) {
+      toast.error(e?.message || "Could not remove the document")
+    }
+  }
+
+  return (
+    <Container className="p-0">
+      <div className="border-b border-ui-border-base px-4 py-3">
+        <Heading level="h3">Documents</Heading>
+        <Text size="small" className="text-ui-fg-subtle">
+          Bills, invoices and transfer receipts. Can be attached at any status.
+        </Text>
+      </div>
+
+      <div className="flex flex-col gap-y-3 p-4">
+        <FileUpload
+          label={uploading || isAttaching ? "Uploading..." : "Drop files here, or click to browse"}
+          hint="Bank receipts, partner invoices — PDF or image"
+          multiple
+          isLoading={uploading || isAttaching}
+          onUploaded={onUploaded}
+        />
+
+        {documents.length === 0 ? (
+          <Text size="small" className="text-ui-fg-muted">
+            No documents attached yet.
+          </Text>
+        ) : (
+          <div className="flex flex-col gap-y-1">
+            {documents.map((doc, i) => {
+              const size = readableSize(doc.size)
+
+              return (
+                <div
+                  key={doc.id || `${doc.url}-${i}`}
+                  className="flex items-center justify-between rounded-md border border-ui-border-base bg-ui-bg-subtle px-2 py-1"
+                >
+                  <a
+                    href={doc.url}
+                    target="_blank"
+                    rel="noopener noreferrer"
+                    className="flex items-center gap-x-2 text-ui-fg-interactive text-sm underline"
+                  >
+                    <DocumentText className="text-ui-fg-subtle" />
+                    <span>{doc.filename || doc.url}</span>
+                    {size && (
+                      <Text size="xsmall" className="text-ui-fg-muted">
+                        {size}
+                      </Text>
+                    )}
+                  </a>
+                  <IconButton
+                    size="small"
+                    variant="transparent"
+                    onClick={() => onRemove(doc.id)}
+                  >
+                    <Trash />
+                  </IconButton>
+                </div>
+              )
+            })}
+          </div>
+        )}
+      </div>
+    </Container>
+  )
+}

--- a/apps/backend/src/api/admin/payment-submissions/[id]/documents/route.ts
+++ b/apps/backend/src/api/admin/payment-submissions/[id]/documents/route.ts
@@ -1,0 +1,141 @@
+/**
+ * @route /admin/payment-submissions/:id/documents
+ * @scope admin
+ *
+ * Attach and remove supporting documents on a payout — bills, invoices,
+ * transfer receipts.
+ *
+ * 🔑 Deliberately NOT gated on status. `documents` could only ever be set at
+ * creation time, and the proof a payout actually happened — the bank receipt —
+ * only exists AFTER the money moves, by which point the submission is Approved
+ * or Paid and every other write is refused. A rule that locks the record at the
+ * moment evidence starts arriving guarantees the evidence lives somewhere else.
+ *
+ * This is an append/remove of attachments, not a re-opening of the payout: it
+ * cannot touch amounts, lines, status or claims. Nothing here changes what is
+ * owed, so the reasons the other routes refuse a settled submission do not
+ * apply.
+ *
+ * ⚠️ `documents` is a JSON column, so every write here re-reads and rewrites
+ * the whole array. That is exactly the footgun #1615's `metadata` notes warn
+ * about — a wholesale write erasing a sibling key — which is why POST appends
+ * to what it just read rather than accepting a full array from the caller.
+ */
+import { MedusaRequest, MedusaResponse } from "@medusajs/framework/http"
+import { MedusaError } from "@medusajs/framework/utils"
+
+import { PAYMENT_SUBMISSIONS_MODULE } from "../../../../../modules/payment_submissions"
+import type PaymentSubmissionsService from "../../../../../modules/payment_submissions/service"
+import { AdminAttachSubmissionDocumentsReq } from "./validators"
+
+type SubmissionDocument = {
+  id: string
+  url: string
+  filename?: string
+  mimeType?: string
+  size?: number
+  uploaded_at?: string
+}
+
+const readDocuments = (submission: any): SubmissionDocument[] => {
+  const raw = submission?.documents
+  return Array.isArray(raw) ? (raw as SubmissionDocument[]) : []
+}
+
+const retrieve = async (req: MedusaRequest) => {
+  const service: PaymentSubmissionsService = req.scope.resolve(
+    PAYMENT_SUBMISSIONS_MODULE
+  )
+
+  const [submission] = await service.listPaymentSubmissions({
+    id: [req.params.id],
+  })
+
+  if (!submission) {
+    throw new MedusaError(
+      MedusaError.Types.NOT_FOUND,
+      `Payment submission not found: ${req.params.id}`
+    )
+  }
+
+  return { service, submission }
+}
+
+export const GET = async (req: MedusaRequest, res: MedusaResponse) => {
+  const { submission } = await retrieve(req)
+
+  res.status(200).json({ documents: readDocuments(submission) })
+}
+
+export const POST = async (
+  req: MedusaRequest<AdminAttachSubmissionDocumentsReq>,
+  res: MedusaResponse
+) => {
+  const { service, submission } = await retrieve(req)
+
+  const existing = readDocuments(submission)
+  const seen = new Set(existing.map((d) => d.id).filter(Boolean))
+
+  const now = new Date().toISOString()
+  const added: SubmissionDocument[] = []
+
+  for (const doc of req.validatedBody.documents) {
+    // An id repeated across two uploads is the same file attached twice, which
+    // is noise rather than an error — skip it and report what actually landed.
+    if (doc.id && seen.has(doc.id)) continue
+    if (doc.id) seen.add(doc.id)
+
+    added.push({
+      id: doc.id || `doc_${now}_${added.length}`,
+      url: doc.url,
+      filename: doc.filename,
+      mimeType: doc.mimeType,
+      size: doc.size,
+      uploaded_at: now,
+    })
+  }
+
+  if (!added.length) {
+    return res
+      .status(200)
+      .json({ documents: existing, added: 0, message: "Nothing new to attach" })
+  }
+
+  const documents = [...existing, ...added]
+
+  await service.updatePaymentSubmissions({
+    id: req.params.id,
+    documents: documents as any,
+  })
+
+  res.status(201).json({ documents, added: added.length })
+}
+
+export const DELETE = async (req: MedusaRequest, res: MedusaResponse) => {
+  const { service, submission } = await retrieve(req)
+
+  const documentId = String((req.query as any)?.document_id || "")
+  if (!documentId) {
+    throw new MedusaError(
+      MedusaError.Types.INVALID_DATA,
+      "document_id is required — refusing to clear every attachment on this payout"
+    )
+  }
+
+  const existing = readDocuments(submission)
+  const documents = existing.filter((d) => d.id !== documentId)
+
+  if (documents.length === existing.length) {
+    throw new MedusaError(
+      MedusaError.Types.NOT_FOUND,
+      `No document ${documentId} on submission ${req.params.id}`
+    )
+  }
+
+  await service.updatePaymentSubmissions({
+    id: req.params.id,
+    documents: documents as any,
+  })
+
+  res.status(200).json({ documents })
+}

--- a/apps/backend/src/api/admin/payment-submissions/[id]/documents/validators.ts
+++ b/apps/backend/src/api/admin/payment-submissions/[id]/documents/validators.ts
@@ -1,0 +1,28 @@
+import { z } from "zod"
+
+/**
+ * Attaching documents to a payout.
+ *
+ * `documents` is an APPEND — the route adds to what is already stored rather
+ * than replacing it. A schema that accepted the full array would make "attach
+ * one receipt" a read-modify-write the caller has to get right, and a caller
+ * that got it wrong would silently drop every earlier attachment.
+ */
+export const AdminAttachSubmissionDocumentsReq = z.object({
+  documents: z
+    .array(
+      z.object({
+        /** The uploaded file's id, used to de-duplicate a re-attached file. */
+        id: z.string().optional(),
+        url: z.string().min(1),
+        filename: z.string().optional(),
+        mimeType: z.string().optional(),
+        size: z.number().nonnegative().optional(),
+      })
+    )
+    .min(1, "At least one document is required"),
+})
+
+export type AdminAttachSubmissionDocumentsReq = z.infer<
+  typeof AdminAttachSubmissionDocumentsReq
+>

--- a/apps/backend/src/api/middlewares.ts
+++ b/apps/backend/src/api/middlewares.ts
@@ -181,6 +181,7 @@ import { createBlocksSchema, ReadBlocksQuerySchema, updateBlockSchema } from "./
 import { AdminPostDesignInventoryReq, AdminDeleteDesignInventoryReq } from "./admin/designs/[id]/inventory/validators";
 import { AdminPostConsumptionLogReq, AdminPostCommitConsumptionReq } from "./admin/designs/[id]/consumption-logs/validators";
 import { AdminPostRunConsumptionLogReq, AdminPostRunCommitConsumptionReq } from "./admin/production-runs/[id]/consumption-logs/validators";
+import { AdminAttachSubmissionDocumentsReq } from "./admin/payment-submissions/[id]/documents/validators";
 import { AdminPostDesignInquiryReq, AdminPostDesignInquiryPreviewReq, AdminPostCloseDesignInquiryReq } from "./admin/designs/[id]/inquiries/validators";
 import { AdminCreateEnergyRateReq, AdminUpdateEnergyRateReq } from "./admin/energy-rates/validators";
 import { partnerSchema, partnerUpdateSchema } from "./partners/validators";
@@ -3651,6 +3652,14 @@ export default defineMiddlewares({
       matcher: "/admin/payment-submissions/:id/items/:itemId",
       method: "PATCH",
       middlewares: [validateAndTransformBody(wrapSchema(UpdatePaymentSubmissionItemSchema))],
+    },
+    {
+      // Attachments, at ANY status — the bank receipt proving a payout happened
+      // only exists after the money moves, when every other write is refused.
+      // Declared before the ":id" entries: first matching entry wins.
+      matcher: "/admin/payment-submissions/:id/documents",
+      method: "POST",
+      middlewares: [validateAndTransformBody(wrapSchema(AdminAttachSubmissionDocumentsReq))],
     },
     {
       matcher: "/admin/payment-submissions/:id",

--- a/apps/backend/src/modules/consumption_log/migrations/Migration20260828190000.ts
+++ b/apps/backend/src/modules/consumption_log/migrations/Migration20260828190000.ts
@@ -1,0 +1,49 @@
+import { Migration } from "@medusajs/framework/mikro-orm/migrations";
+
+/**
+ * Close the empty-string hole in the design-or-product CHECK.
+ *
+ * `Migration20260828164500` added
+ * `check ("design_id" is not null or "product_id" is not null)` to stop a
+ * consumption log being anchored to nothing. It does not hold: `''` is not
+ * null, so a row with `design_id = ''` satisfies the constraint while naming
+ * nothing at all.
+ *
+ * 🔴 Not hypothetical. Run `prod_run_01KZ3DA8TV6SR2A90FR1Q1WGWW` carries two
+ * COMMITTED logs written 2026-08-27 with `design_id = ''` — 20 @ 250 and
+ * 30 @ 9.5 — on a run whose own `design_id` is null. Something upstream
+ * coerced a missing id to an empty string instead of null, and every reader
+ * that asks `!l.design_id` (the reconciliation fold, line 213) already treats
+ * them as design-less. The schema was the only layer still calling them
+ * anchored.
+ *
+ * The application guard `anchorRefusalMessage` has always refused `''`; this
+ * brings the constraint up to the same rule so the two cannot disagree.
+ *
+ * ⚠️ Existing `''` rows are NOT rewritten here. They are committed records of
+ * material that was really consumed, and a migration that guessed their anchor
+ * — or deleted them to satisfy a constraint — would destroy production data.
+ * They are normalised by the `repair-consumption-log` ops job instead, where
+ * the change is a dry-run-able, reviewable decision rather than a silent
+ * side effect of a deploy. Which is why this is written as NOT VALID.
+ */
+export class Migration20260828190000 extends Migration {
+
+  override async up(): Promise<void> {
+    this.addSql(`alter table if exists "consumption_log" drop constraint if exists "consumption_log_design_or_product_check";`);
+
+    /**
+     * NOT VALID: enforced on every INSERT and UPDATE from now on, but existing
+     * rows are not re-checked. Without it this migration fails on any database
+     * already holding an empty-string row — including prod — and a deploy that
+     * cannot run its migration strands every later one behind it.
+     */
+    this.addSql(`alter table if exists "consumption_log" add constraint "consumption_log_design_or_product_check" check ((("design_id" is not null and "design_id" <> '') or ("product_id" is not null and "product_id" <> ''))) not valid;`);
+  }
+
+  override async down(): Promise<void> {
+    this.addSql(`alter table if exists "consumption_log" drop constraint if exists "consumption_log_design_or_product_check";`);
+    this.addSql(`alter table if exists "consumption_log" add constraint "consumption_log_design_or_product_check" check ("design_id" is not null or "product_id" is not null);`);
+  }
+
+}

--- a/apps/backend/src/modules/payment_reports/migrations/Migration20260828181500.ts
+++ b/apps/backend/src/modules/payment_reports/migrations/Migration20260828181500.ts
@@ -1,0 +1,37 @@
+import { Migration } from "@medusajs/framework/mikro-orm/migrations";
+
+/**
+ * Record WHERE a reconciled payout came from.
+ *
+ * `payment_reconciliation.reference_type` has offered `inventory_order` since
+ * the model was written, but the only writer hardcodes `"payment_submission"`.
+ * All four rows on prod say `payment_submission`; none has ever said anything
+ * else, so a distinction that was designed has never once been expressed — and
+ * a payout for an inventory order is indistinguishable from one for design work.
+ *
+ * 🔴 New columns rather than finally "using the enum properly". `reference_*`
+ * answers "what record is being reconciled" and must keep pointing at the
+ * submission; `source_*` answers "where did the money come from". Folding both
+ * into `reference_type` would leave one column meaning different things on
+ * different rows — the #1559 defect, where `quantity` was a rate or a total
+ * depending on a sibling column, and a report-only job consequently told
+ * operators to corrupt data that was already correct.
+ *
+ * Nullable and un-backfilled on purpose: the four existing rows have an
+ * unknowable source (their submissions predate `source_type` on items), and
+ * inventing one would be worse than admitting it. Readers must treat null as
+ * "not recorded", never as a default.
+ */
+export class Migration20260828181500 extends Migration {
+
+  override async up(): Promise<void> {
+    this.addSql(`alter table if exists "payment_reconciliation" add column if not exists "source_type" text null;`);
+    this.addSql(`alter table if exists "payment_reconciliation" add column if not exists "source_id" text null;`);
+  }
+
+  override async down(): Promise<void> {
+    this.addSql(`alter table if exists "payment_reconciliation" drop column if exists "source_type";`);
+    this.addSql(`alter table if exists "payment_reconciliation" drop column if exists "source_id";`);
+  }
+
+}

--- a/apps/backend/src/modules/payment_reports/models/payment_reconciliation.ts
+++ b/apps/backend/src/modules/payment_reports/models/payment_reconciliation.ts
@@ -6,6 +6,24 @@ const PaymentReconciliation = model.define("payment_reconciliation", {
     .enum(["payment_submission", "inventory_order", "manual"])
     .default("manual"),
   reference_id: model.text().nullable(),
+  /**
+   * WHERE THE MONEY CAME FROM — distinct from `reference_type`, which says what
+   * record is being reconciled.
+   *
+   * 🔴 Two facts, two columns, deliberately. `reference_type` already offers an
+   * `inventory_order` value, and overloading it to mean the source would leave
+   * one column meaning "the submission" on some rows and "the order" on others
+   * — the exact defect #1559 shipped, where `quantity` was a rate or a total
+   * depending on a sibling column and a report told operators to corrupt
+   * correct data.
+   *
+   * Mirrors `payment_submission_item.source_type`, so the vocabulary is the
+   * same at both ends: design | task | run | inventory_order, plus `mixed`
+   * for a submission whose lines do not agree — which is a real shape, not a
+   * failure, and must not be silently reported as whichever line came first.
+   */
+  source_type: model.text().nullable(),
+  source_id: model.text().nullable(),
   partner_id: model.text().nullable(),
   expected_amount: model.bigNumber(),
   actual_amount: model.bigNumber().nullable(),

--- a/apps/backend/src/workflows/payment_submissions/__tests__/submission-source.unit.spec.ts
+++ b/apps/backend/src/workflows/payment_submissions/__tests__/submission-source.unit.spec.ts
@@ -1,0 +1,153 @@
+import { resolveSubmissionSource } from "../lib/submission-source"
+
+/**
+ * Where a payout's money came from, folded from its lines.
+ *
+ * Context: `payment_reconciliation.reference_type` has offered an
+ * `inventory_order` value since the model was written, but the only writer
+ * hardcoded `"payment_submission"` — so all four rows on prod say the same
+ * thing and the distinction has never once been expressed.
+ */
+describe("resolveSubmissionSource", () => {
+  it("reads a single design-sourced submission", () => {
+    expect(
+      resolveSubmissionSource([{ source_type: "design", design_id: "design_1" }])
+    ).toEqual({ source_type: "design", source_id: "design_1" })
+  })
+
+  it("reads an inventory-order submission — the case that drove this", () => {
+    expect(
+      resolveSubmissionSource([
+        { source_type: "inventory_order", inventory_order_id: "inv_order_1" },
+      ])
+    ).toEqual({ source_type: "inventory_order", source_id: "inv_order_1" })
+  })
+
+  /**
+   * A run-sourced line resolves to its ORDER, not to a run. The line groups
+   * runs on purpose — order #79's seven runs are ONE payout of ₹8,974, not
+   * seven of ₹1,282 — so the order is what the money is for.
+   */
+  it("resolves a run line to its order, not to one of its runs", () => {
+    expect(
+      resolveSubmissionSource([
+        {
+          source_type: "run",
+          order_id: "order_79",
+          production_run_ids: ["run_a", "run_b", "run_c"],
+        },
+      ])
+    ).toEqual({ source_type: "run", source_id: "order_79" })
+  })
+
+  it("gives a run line with no order a type but no id", () => {
+    expect(
+      resolveSubmissionSource([
+        { source_type: "run", production_run_ids: ["run_a"] },
+      ])
+    ).toEqual({ source_type: "run", source_id: null })
+  })
+
+  describe("more than one source", () => {
+    /**
+     * 🔴 Mixed is a real shape, not a failure. Reporting whichever line came
+     * first would assert something untrue about every other line — the same
+     * defect as a column that means different things on different rows.
+     */
+    it("reports mixed rather than picking the first line's type", () => {
+      expect(
+        resolveSubmissionSource([
+          { source_type: "design", design_id: "design_1" },
+          { source_type: "inventory_order", inventory_order_id: "inv_order_1" },
+        ])
+      ).toEqual({ source_type: "mixed", source_id: null })
+    })
+
+    /**
+     * One TYPE but several ids is not mixed — and still has no single id. A
+     * column holding the first of three orders would be read as "this payout
+     * is for that order", which is false.
+     */
+    it("keeps the type but drops the id when one type names several ids", () => {
+      expect(
+        resolveSubmissionSource([
+          { source_type: "inventory_order", inventory_order_id: "inv_order_1" },
+          { source_type: "inventory_order", inventory_order_id: "inv_order_2" },
+        ])
+      ).toEqual({ source_type: "inventory_order", source_id: null })
+    })
+
+    it("collapses several lines naming the SAME id to that id", () => {
+      expect(
+        resolveSubmissionSource([
+          { source_type: "run", order_id: "order_79", production_run_ids: ["a"] },
+          { source_type: "run", order_id: "order_79", production_run_ids: ["b"] },
+        ])
+      ).toEqual({ source_type: "run", source_id: "order_79" })
+    })
+  })
+
+  describe("lines written before source_type existed (#1614)", () => {
+    /**
+     * ⚠️ A missing source_type is NOT design. Only the ids can say what an
+     * older row is, and guessing would mislabel every legacy payout.
+     */
+    it("infers inventory_order from the id alone", () => {
+      expect(
+        resolveSubmissionSource([{ inventory_order_id: "inv_order_1" }])
+      ).toEqual({ source_type: "inventory_order", source_id: "inv_order_1" })
+    })
+
+    it("infers run from production_run_ids alone", () => {
+      expect(
+        resolveSubmissionSource([
+          { production_run_ids: ["run_a"], order_id: "order_79" },
+        ])
+      ).toEqual({ source_type: "run", source_id: "order_79" })
+    })
+
+    it("infers design from design_id alone", () => {
+      expect(resolveSubmissionSource([{ design_id: "design_1" }])).toEqual({
+        source_type: "design",
+        source_id: "design_1",
+      })
+    })
+  })
+
+  describe("nothing to go on", () => {
+    it("returns nulls for no lines rather than inventing a source", () => {
+      expect(resolveSubmissionSource([])).toEqual({
+        source_type: null,
+        source_id: null,
+      })
+    })
+
+    it("returns nulls for null/undefined", () => {
+      expect(resolveSubmissionSource(null)).toEqual({
+        source_type: null,
+        source_id: null,
+      })
+      expect(resolveSubmissionSource(undefined)).toEqual({
+        source_type: null,
+        source_id: null,
+      })
+    })
+
+    it("ignores a line carrying no ids at all", () => {
+      expect(resolveSubmissionSource([{}])).toEqual({
+        source_type: null,
+        source_id: null,
+      })
+    })
+
+    /** An unattributable line must not drag a real one into `mixed`. */
+    it("ignores an empty line alongside a real one", () => {
+      expect(
+        resolveSubmissionSource([
+          {},
+          { source_type: "inventory_order", inventory_order_id: "inv_order_1" },
+        ])
+      ).toEqual({ source_type: "inventory_order", source_id: "inv_order_1" })
+    })
+  })
+})

--- a/apps/backend/src/workflows/payment_submissions/lib/submission-source.ts
+++ b/apps/backend/src/workflows/payment_submissions/lib/submission-source.ts
@@ -1,0 +1,103 @@
+/**
+ * WHERE a submission's money came from, folded from its lines.
+ *
+ * PURE: no container, no DB.
+ *
+ * A submission is a payout; its LINES carry the provenance. Reconciliation and
+ * every screen that says "what is this payment for" need one answer, and the
+ * honest answer is sometimes "more than one thing".
+ */
+
+export type SubmissionSourceLine = {
+  source_type?: string | null
+  design_id?: string | null
+  task_id?: string | null
+  inventory_order_id?: string | null
+  order_id?: string | null
+  production_run_ids?: string[] | null
+}
+
+export type SubmissionSource = {
+  /** design | task | run | inventory_order | mixed | null when nothing is recorded. */
+  source_type: string | null
+  /**
+   * The one id the source points at, when there is exactly one.
+   *
+   * Null for `mixed`, and null when a single-source submission names several
+   * ids (three inventory orders on one payout) — a column that held the first
+   * of three would be read as "this payout is for that order", which is false.
+   */
+  source_id: string | null
+}
+
+/**
+ * The id a line points at, by its own source_type.
+ *
+ * ⚠️ A run-sourced line resolves to its ORDER, not to a run id. The line
+ * deliberately groups runs — order #79's seven runs are ONE payout of ₹8,974,
+ * not seven of ₹1,282 — so the order is the thing the money is "for". A line
+ * with runs but no order has no single id, and says so.
+ */
+const lineSourceId = (line: SubmissionSourceLine): string | null => {
+  const type = inferLineType(line)
+
+  switch (type) {
+    case "design":
+      return line.design_id || null
+    case "task":
+      return line.task_id || null
+    case "inventory_order":
+      return line.inventory_order_id || null
+    case "run":
+      return line.order_id || null
+    default:
+      return null
+  }
+}
+
+/**
+ * A line's type, falling back to its ids for rows written before
+ * `source_type` existed (#1614). Absence is not "design" — it is unknown, and
+ * only the ids can say.
+ */
+const inferLineType = (line: SubmissionSourceLine): string | null => {
+  if (line.source_type) return String(line.source_type)
+  if (line.inventory_order_id) return "inventory_order"
+  if (line.production_run_ids?.length) return "run"
+  if (line.task_id) return "task"
+  if (line.design_id) return "design"
+  return null
+}
+
+export const resolveSubmissionSource = (
+  lines: SubmissionSourceLine[] | null | undefined
+): SubmissionSource => {
+  const types = new Set<string>()
+  const ids = new Set<string>()
+
+  for (const line of lines || []) {
+    const type = inferLineType(line)
+    if (!type) continue
+    types.add(type)
+
+    const id = lineSourceId(line)
+    if (id) ids.add(id)
+  }
+
+  if (types.size === 0) {
+    return { source_type: null, source_id: null }
+  }
+
+  if (types.size > 1) {
+    // Mixed is a real shape, not a failure. Reporting whichever line happened
+    // to come first would assert something untrue about the rest.
+    return { source_type: "mixed", source_id: null }
+  }
+
+  const [only] = Array.from(types)
+
+  return {
+    source_type: only,
+    source_id: ids.size === 1 ? Array.from(ids)[0] : null,
+  }
+}

--- a/apps/backend/src/workflows/payment_submissions/review-payment-submission.ts
+++ b/apps/backend/src/workflows/payment_submissions/review-payment-submission.ts
@@ -22,6 +22,8 @@ import PaymentSubmissionsService from "../../modules/payment_submissions/service
 import InternalPaymentService from "../../modules/internal_payments/service"
 import Payment_reportsService from "../../modules/payment_reports/service"
 import PartnerPaymentMethodsLink from "../../links/partner-payment-methods-link"
+import { ORDER_INVENTORY_MODULE } from "../../modules/inventory_orders"
+import { resolveSubmissionSource } from "./lib/submission-source"
 
 export type ReviewPaymentSubmissionInput = {
   submission_id: string
@@ -252,6 +254,89 @@ const linkSubmissionToPaymentStep = createStep(
   }
 )
 
+/**
+ * Where this payout's money came from, folded from the submission's LINES.
+ *
+ * A step of its own so reconciliation and the inventory-order link read the
+ * same answer. Derived from the lines rather than accepted from the reviewer:
+ * a review action knows nothing about provenance, and a source supplied by the
+ * caller could contradict the lines it claims to describe.
+ */
+const resolveSubmissionSourceStep = createStep(
+  "resolve-submission-source",
+  async (input: { submission_id: string }, { container }) => {
+    const service: PaymentSubmissionsService = container.resolve(
+      PAYMENT_SUBMISSIONS_MODULE
+    )
+
+    const items = await service.listPaymentSubmissionItems({
+      submission_id: input.submission_id,
+    })
+
+    return new StepResponse(resolveSubmissionSource(items as any[]))
+  }
+)
+
+/**
+ * Link the payment to the INVENTORY ORDER it paid for.
+ *
+ * 🔴 `links/inventory-orders-internal-payments.ts` has existed all along and
+ * nothing has ever written it. The consequence is visible on prod: open the
+ * inventory order a payout was for and it shows no payment, because the only
+ * link approval created pointed at the partner. The declaration was the
+ * intended design; it was simply never wired.
+ *
+ * Best-effort and non-fatal, deliberately. The payment, the reconciliation and
+ * the submission status are all already written by the time this runs, and a
+ * failure to draw a navigational edge must not roll back a recorded payout.
+ * Mirrors how the production-run link is created in `log-consumption`.
+ */
+const linkPaymentToInventoryOrderStep = createStep(
+  "link-payment-to-inventory-order",
+  async (
+    input: { payment_id: string; inventory_order_id: string },
+    { container }
+  ) => {
+    if (!input.inventory_order_id || !input.payment_id) {
+      return new StepResponse<LinkDefinition | null>(null)
+    }
+
+    const remoteLink = container.resolve(
+      ContainerRegistrationKeys.LINK
+    ) as Link
+
+    const link: LinkDefinition = {
+      [ORDER_INVENTORY_MODULE]: {
+        inventory_orders_id: input.inventory_order_id,
+      },
+      [INTERNAL_PAYMENTS_MODULE]: {
+        internal_payments_id: input.payment_id,
+      },
+    }
+
+    try {
+      await remoteLink.create([link])
+    } catch (e: any) {
+      container
+        .resolve(ContainerRegistrationKeys.LOGGER)
+        .warn(
+          `[review-payment-submission] payment ${input.payment_id} recorded but ` +
+            `could not be linked to inventory order ${input.inventory_order_id}: ${e?.message}`
+        )
+      return new StepResponse<LinkDefinition | null>(null)
+    }
+
+    return new StepResponse<LinkDefinition | null>(link, link)
+  },
+  async (link: LinkDefinition | null, { container }) => {
+    if (!link) return
+    const remoteLink = container.resolve(
+      ContainerRegistrationKeys.LINK
+    ) as Link
+    await remoteLink.dismiss([link]).catch(() => {})
+  }
+)
+
 // Step 5: Create reconciliation record
 const createReconciliationRecordStep = createStep(
   "create-reconciliation-record",
@@ -262,6 +347,8 @@ const createReconciliationRecordStep = createStep(
       expected_amount: number
       actual_amount: number
       payment_id: string
+      source_type: string | null
+      source_id: string | null
     },
     { container }
   ) => {
@@ -269,13 +356,18 @@ const createReconciliationRecordStep = createStep(
       PAYMENT_REPORTS_MODULE
     )
 
+
     const discrepancy = input.actual_amount - input.expected_amount
     const status =
       Math.abs(discrepancy) < 0.01 ? "Matched" : "Discrepant"
 
     const reconciliation = await service.createPaymentReconciliations({
+      // `reference_*` stays the record being reconciled; `source_*` says where
+      // the money came from. Two facts, two columns — see the model.
       reference_type: "payment_submission",
       reference_id: input.submission_id,
+      source_type: input.source_type,
+      source_id: input.source_id,
       partner_id: input.partner_id,
       expected_amount: input.expected_amount,
       actual_amount: input.actual_amount,
@@ -418,6 +510,10 @@ export const reviewPaymentSubmissionWorkflow = createWorkflow(
       })
     )
 
+    const source = when(isApproval, (val) => val).then(() =>
+      resolveSubmissionSourceStep({ submission_id: input.submission_id })
+    )
+
     when(isApproval, (val) => val).then(() =>
       createReconciliationRecordStep({
         submission_id: input.submission_id,
@@ -425,6 +521,29 @@ export const reviewPaymentSubmissionWorkflow = createWorkflow(
         expected_amount: submission.total_amount,
         actual_amount: paymentAmount,
         payment_id: payment!.id,
+        source_type: source!.source_type,
+        source_id: source!.source_id,
+      })
+    )
+
+    /**
+     * Draw the edge the inventory order needs to show its payments.
+     *
+     * Only for an inventory-order-sourced payout: `source_id` is the order id
+     * exactly when `source_type` is `inventory_order` and the submission names
+     * a single one. The step itself no-ops on an empty id, so a design-, task-,
+     * run- or mixed-sourced payout passes straight through.
+     */
+    const inventoryOrderForPayment = transform({ source }, (data) =>
+      data.source?.source_type === "inventory_order" && data.source?.source_id
+        ? String(data.source.source_id)
+        : ""
+    )
+
+    when(isApproval, (val) => val).then(() =>
+      linkPaymentToInventoryOrderStep({
+        payment_id: payment!.id,
+        inventory_order_id: inventoryOrderForPayment,
       })
     )
 


### PR DESCRIPTION
## What your approval actually did

Approving the GOF payout produced **three records with three different statuses**, none of them joined to what the money was for:

| record | id | status |
|---|---|---|
| `payment_submission` | `01M13MPTSC…` | **Paid** |
| `internal_payment` | `01M13QV30Q…` | **Pending** |
| `payment_reconciliation` | `01M13QV32T…` | **Settled** |

And opening the inventory order it settled showed no payment at all.

## 1. The submission page was hiding whole payouts

```ts
const designItems = items.filter((i) => i.source_type === "design" || (!i.source_type && i.design_id))
const taskItems  = items.filter((i) => i.source_type === "task"   || (!i.source_type && i.task_id))
```

`source_type` has been `design | task | run | inventory_order` since #1614. Run- and inventory-order-sourced lines matched **neither** filter and there was no third table — so they rendered **nowhere**. The GOF submission showed a ₹30,000 total with no line explaining it, under a stat tile reading **"Designs: 1"** that was counting an inventory order.

That is most of what #1615 just enabled: every run-sourced payout was invisible.

Replaced with **one table over every line**. Partitioning by source is precisely what made a class of payout disappear, so this stops partitioning — source becomes a column, not a reason to be excluded. An unrecognised source renders as `Unattributed` rather than vanishing.

## 2. Nothing ever linked a payment to its inventory order

`links/inventory-orders-internal-payments.ts` has existed all along with **zero writers**; approval linked the payment to the partner only. Confirmed on prod (`internal_payments: []`, with the instrument proved first — a recognised relation returns `[]`, an unrecognised one is dropped from the response entirely).

Now drawn on approval, **best-effort and non-fatal**: the payment, reconciliation and status are all written by then, and failing to draw a navigational edge must not roll back a recorded payout.

> Correction to an earlier claim: `submission-payment-link` **is** written, by `linkSubmissionToPaymentStep`, which builds it inline by module keys. It looked absent because the submission GET route uses `service.listPaymentSubmissions`, not `query.graph`, so `?fields=payments.id` is silently ignored.

## 3. Reconciliation never said where the money came from

`reference_type` has offered `inventory_order` since the model was written; the only writer hardcodes `"payment_submission"`. All 4 rows on prod say `payment_submission`; none has ever said anything else.

Adds `source_type`/`source_id` rather than repurposing `reference_*`. **Two facts, two columns** — `reference_*` answers "what record is being reconciled", `source_*` answers "where did the money come from". Folding them together leaves one column meaning different things on different rows, which is the #1559 defect where `quantity` was a rate or a total depending on a sibling column.

The fold is deliberately conservative:
- **`mixed`** when lines disagree — a real shape, not a failure. Reporting the first line's type would assert something untrue about the rest.
- **A single type naming several ids reports no id.** A column holding the first of three orders reads as "this payout is for that order", which is false.
- A run line resolves to its **order**, not a run — seven runs are one payout.

## 4. Documents at any status

`documents` could only be set at creation. But the document that proves a payout happened — the bank receipt — does not exist until *after* the money moves, by which point the submission is Approved or Paid and every other write is refused. A record that closes exactly when its evidence starts arriving guarantees the evidence lives in someone's inbox.

New `POST`/`GET`/`DELETE` touching the attachments array **and nothing else** — no amounts, lines, status or claims — so none of the reasons the other routes refuse a settled submission apply. Plus a drag-and-drop section modelled on the inventory-order add-payments UI. POST **appends to what it read**, and the UI sends one drop as one call: two overlapping requests would each read the same array and the second would drop the first's files.

## 5. Tightens the CHECK from #1618

`design_id is not null` passes for `''`. Not hypothetical — `prod_run_01KZ3DA8TV6SR2A90FR1Q1WGWW` carries **two committed logs with `design_id = ''`**, found while reading back the consumption log written today. The application guard always refused empty strings; the constraint did not.

Added `NOT VALID` so it enforces on every write from now on **without** failing the migration on existing rows — a migration that cannot run strands every later one behind it (#1464). Those rows are left to the repair job: they are committed records of material really consumed, and guessing their anchor or deleting them to satisfy a constraint would destroy production data.

## Verification

- **30 new unit tests** across the two extracted pure rules.
- **33 suites / 398 tests green** over payment + fx + consumption.
- `check:prod-build` passes; tsc unchanged at **280**.

## Watch-outs

- ⚠️ **The three statuses still disagree.** This PR makes the records findable and correctly labelled; it does not reconcile `Paid` / `Pending` / `Settled`. That is a behaviour change to what the approve button means and wants its own decision.
- ⚠️ The 4 existing reconciliation rows keep `source_*` **null** — their submissions predate `source_type` on items, so their source is genuinely unknowable and inventing one would be worse. Readers must treat null as "not recorded", never as a default.
- ⚠️ The submission GET route still uses the module service, so `payments` is not exposed on it even though the link exists.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01TLt1f38xqR8k2myCVxP8e4