### PR TITLE
feat(mcp): structured plan executor + entity memory for multi-tool queries

### DIFF
--- a/apps/backend/src/lib/assistant-context/__tests__/entities.unit.spec.ts
+++ b/apps/backend/src/lib/assistant-context/__tests__/entities.unit.spec.ts
@@ -1,0 +1,67 @@
+import {
+  inferEntityType,
+  extractEntityResolutions,
+  buildEntityResolver,
+} from "../entities"
+import { findResolutionInRows } from "../../../modules/assistant-context-cache/service"
+
+describe("inferEntityType", () => {
+  it("classifies by id prefix", () => {
+    expect(inferEntityType("cus_01KS9BXSAA59AESGP84EC5FMD5")).toBe("customer")
+    expect(inferEntityType("order_01ABC")).toBe("order")
+    expect(inferEntityType("design_01ABC")).toBe("design")
+  })
+
+  it("prefers the longest prefix so production runs are not products", () => {
+    expect(inferEntityType("prod_run_01KV3YRSNWQGF6DYC9RV0YF1PZ")).toBe("production_run")
+    expect(inferEntityType("prod_01ABC")).toBe("product")
+  })
+})
+
+describe("extractEntityResolutions", () => {
+  it("records a natural key alongside the id", () => {
+    const res = extractEntityResolutions({
+      customers: [{ id: "cus_01KS9B", email: "delhi@gmail.com", first_name: "Delhi" }],
+    })
+    expect(res).toEqual([
+      {
+        type: "customer",
+        key: "email",
+        value: "delhi@gmail.com",
+        id: "cus_01KS9B",
+        label: "Delhi",
+      },
+    ])
+  })
+
+  it("deduplicates by natural key and recurses through nested shapes", () => {
+    const res = extractEntityResolutions({
+      designs: [
+        { id: "design_01A", name: "Scarf" },
+        { id: "design_02B", name: "Shawl" },
+      ],
+    })
+    expect(res.map((r) => r.id)).toEqual(["design_01A", "design_02B"])
+  })
+})
+
+describe("buildEntityResolver", () => {
+  it("resolves a natural key to an id and misses cleanly", () => {
+    const resolve = buildEntityResolver([
+      { type: "customer", key: "email", value: "delhi@gmail.com", id: "cus_01KS9B" },
+    ])
+    expect(resolve("customer", "email", "delhi@gmail.com")).toBe("cus_01KS9B")
+    expect(resolve("customer", "email", "other@x.com")).toBeNull()
+  })
+})
+
+describe("findResolutionInRows", () => {
+  it("scans cache rows for a matching resolution", () => {
+    const rows = [
+      { entity_resolutions: [{ type: "customer", key: "email", value: "a@b.com", id: "cus_1" }] },
+      { entity_resolutions: [{ type: "design", key: "name", value: "Scarf", id: "design_1" }] },
+    ]
+    expect(findResolutionInRows(rows, "design", "name", "Scarf")).toBe("design_1")
+    expect(findResolutionInRows(rows, "customer", "email", "nope@x.com")).toBeNull()
+  })
+})

--- a/apps/backend/src/lib/assistant-context/entities.ts
+++ b/apps/backend/src/lib/assistant-context/entities.ts
@@ -1,0 +1,148 @@
+/**
+ * Entity-resolution extraction for assistant memory.
+ *
+ * The existing `extractEntityIds` keeps a flat list of id-like strings so the
+ * next turn can say "you already looked at these". What it cannot do is answer
+ * "what is the id of customer delhi@gmail.com?" — the natural key that lets a
+ * PLANNER skip a lookup step entirely.
+ *
+ * This module extracts that richer fact: for each entity id found in a tool
+ * result, record its type (from the id prefix), a natural key (email/name/handle),
+ * and the key's value. The result feeds `buildEntityResolver`, which is the
+ * memory the plan executor's `resolve` step consults before re-calling a tool.
+ *
+ * Pure and dependency-free on purpose — it runs after every turn and is unit
+ * tested without a database.
+ */
+
+export interface EntityResolution {
+  /** Entity type: "customer", "order", "design", ... */
+  type: string
+  /** Natural key field: "email", "name", "handle", ... */
+  key: string
+  /** The key's value, e.g. "delhi@gmail.com". */
+  value: string
+  /** The resolved entity id, e.g. "cus_01KS9B...". */
+  id: string
+  /** Optional display label (name/title) for diagnostics. */
+  label?: string
+}
+
+/**
+ * Id prefix -> entity type. Longest-prefix-first on purpose: `prod_run_` must
+ * classify before `prod_`, or every production-run id is read as a product.
+ */
+const PREFIX_TO_TYPE: ReadonlyArray<readonly [string, string]> = [
+  ["prod_run_", "production_run"],
+  ["prod_", "product"],
+  ["variant_", "variant"],
+  ["partner_", "partner"],
+  ["design_", "design"],
+  ["order_", "order"],
+  ["customer_", "customer"],
+  ["cus_", "customer"],
+  ["store_", "store"],
+  ["task_", "task"],
+  ["ful_", "fulfillment"],
+  ["iitem_", "inventory_item"],
+  ["rawmat_", "raw_material"],
+  ["rmg_", "raw_material_group"],
+  ["pay_", "payment"],
+  ["campaign_", "campaign"],
+  ["collection_", "collection"],
+  ["pcat_", "product_category"],
+  ["ptag_", "product_tag"],
+  ["ptype_", "product_type"],
+  ["spost_", "social_post"],
+]
+
+/** Entity type -> natural key fields, in priority order (first present wins). */
+const TYPE_KEY_FIELDS: Record<string, string[]> = {
+  customer: ["email", "phone", "name"],
+  partner: ["email", "name"],
+  design: ["name", "handle"],
+  product: ["handle", "title"],
+  variant: ["title", "sku"],
+  order: ["email", "display_id"],
+  store: ["name", "handle"],
+  task: ["title", "name"],
+  fulfillment: ["display_id"],
+  inventory_item: ["title", "sku"],
+  raw_material: ["title", "name"],
+  raw_material_group: ["title", "name"],
+  payment: ["display_id"],
+  campaign: ["title", "name"],
+  collection: ["title", "handle"],
+  product_category: ["name", "handle"],
+  product_tag: ["value"],
+  product_type: ["value"],
+  social_post: ["title"],
+}
+
+/** Infer an entity type from an id prefix, or undefined when unknown. */
+export function inferEntityType(id: string): string | undefined {
+  for (const [prefix, type] of PREFIX_TO_TYPE) {
+    if (id.startsWith(prefix) && id.length > prefix.length + 2) return type
+  }
+  return undefined
+}
+
+/** One-line label from an object, if it has one. Never the key itself (email). */
+function labelOf(o: Record<string, unknown>): string | undefined {
+  const v = o.title ?? o.name ?? o.handle ?? o.first_name ?? o.last_name
+  return typeof v === "string" && v ? v : undefined
+}
+
+/**
+ * Walk a tool result and extract entity resolutions: for every object carrying
+ * a platform entity id, record its type, a natural key and that key's value.
+ */
+export function extractEntityResolutions(output: unknown): EntityResolution[] {
+  const out: EntityResolution[] = []
+  const seen = new Set<string>()
+
+  const walk = (v: unknown): void => {
+    if (Array.isArray(v)) {
+      for (const item of v) walk(item)
+      return
+    }
+    if (!v || typeof v !== "object") return
+    const o = v as Record<string, unknown>
+
+    if (typeof o.id === "string") {
+      const type = inferEntityType(o.id)
+      if (type) {
+        for (const field of TYPE_KEY_FIELDS[type] ?? []) {
+          const value = o[field]
+          if (typeof value === "string" && value.trim()) {
+            const k = `${type}:${field}:${value}`
+            if (!seen.has(k)) {
+              seen.add(k)
+              out.push({ type, key: field, value, id: o.id, label: labelOf(o) })
+            }
+            break
+          }
+        }
+      }
+    }
+
+    for (const val of Object.values(o)) walk(val)
+  }
+
+  walk(output)
+  return out
+}
+
+/** Type of the resolver the plan executor consumes. */
+export type EntityResolver = (type: string, by: string, value: string) => string | null
+
+/**
+ * Build an in-memory entity resolver from extracted resolutions. This is both
+ * the shape the plan executor's `resolve` step consumes and a test seam for the
+ * cache-backed resolver that will stand behind it.
+ */
+export function buildEntityResolver(resolutions: EntityResolution[]): EntityResolver {
+  const map = new Map<string, string>()
+  for (const r of resolutions) map.set(`${r.type}:${r.key}:${r.value}`, r.id)
+  return (type, by, value) => map.get(`${type}:${by}:${value}`) ?? null
+}

--- a/apps/backend/src/lib/mcp-core/__tests__/plan.unit.spec.ts
+++ b/apps/backend/src/lib/mcp-core/__tests__/plan.unit.spec.ts
@@ -1,0 +1,227 @@
+import {
+  executeMcpPlan,
+  navPlanPath,
+  isEmptyPlanResult,
+  broadenPlanArgs,
+} from "../plan"
+import type { McpToolResult } from "../types"
+import { extractEntityResolutions, buildEntityResolver } from "../../assistant-context/entities"
+
+const ok = (tool: string, data: unknown): McpToolResult => ({ ok: true, tool, data })
+const fail = (tool: string, error: string): McpToolResult => ({ ok: false, tool, error })
+
+const ctx = { baseUrl: "http://localhost:9000" } as any
+const tools = [] as any[]
+
+describe("navPlanPath", () => {
+  it("navigates dot and bracket paths", () => {
+    const d = { designs: [{ id: "d1" }, { id: "d2" }] }
+    expect(navPlanPath(d, "designs.0.id")).toBe("d1")
+    expect(navPlanPath(d, "designs[1].id")).toBe("d2")
+    expect(navPlanPath(d, "")).toBe(d)
+  })
+})
+
+describe("isEmptyPlanResult", () => {
+  it("detects empty list and zero count", () => {
+    expect(isEmptyPlanResult({ count: 0 })).toBe(true)
+    expect(isEmptyPlanResult({ customers: [] })).toBe(true)
+    expect(isEmptyPlanResult({ customers: [{ id: "c" }] })).toBe(false)
+  })
+})
+
+describe("broadenPlanArgs", () => {
+  it("shortens a multi-word q then drops it", () => {
+    expect(broadenPlanArgs({ q: "Allocation Fixture" })).toEqual({ q: "Allocation" })
+    expect(broadenPlanArgs({ q: "Allocation" })).toEqual({})
+  })
+
+  it("does not broaden exact natural-key filters", () => {
+    expect(broadenPlanArgs({ email: "delhi@gmail.com" })).toEqual({ email: "delhi@gmail.com" })
+    expect(broadenPlanArgs({ name: "E2E Content Partner" })).toEqual({ name: "E2E Content Partner" })
+    expect(broadenPlanArgs({ id: "cus_01" })).toEqual({ id: "cus_01" })
+  })
+})
+
+describe("executeMcpPlan", () => {
+  it("substitutes $refs across a linear chain", async () => {
+    const dispatch = jest.fn(async (name: string, args: any) => {
+      if (name === "list_customers") return ok(name, { customers: [{ id: "cus_1" }] })
+      if (name === "list_orders") return ok(name, { orders: [{ customer_id: args.customer_id }] })
+      return fail(name, "unknown")
+    })
+
+    const r = await executeMcpPlan({
+      ctx,
+      tools,
+      dispatch,
+      plan: {
+        steps: [
+          { tool: "list_customers", args: { email: "a@b.com" }, as: "c", extract: "customers.0.id" },
+          { tool: "list_orders", args: { customer_id: "$c" } },
+        ],
+      },
+    })
+
+    expect(r.ok).toBe(true)
+    expect(r.toolCalls).toBe(2)
+    expect(dispatch).toHaveBeenNthCalledWith(2, "list_orders", { customer_id: "cus_1" })
+  })
+
+  it("fans out over a map", async () => {
+    const dispatch = jest.fn(async (name: string, args: any) => {
+      if (name === "list_designs") return ok(name, { designs: [{ id: "d1" }, { id: "d2" }] })
+      if (name === "list_production_runs")
+        return ok(name, { production_runs: [{ design_id: args.design_id }] })
+      return fail(name, "unknown")
+    })
+
+    const r = await executeMcpPlan({
+      ctx,
+      tools,
+      dispatch,
+      plan: {
+        steps: [
+          { tool: "list_designs", args: { limit: 2 }, as: "designs" },
+          {
+            map: "designs",
+            item: "d",
+            steps: [{ tool: "list_production_runs", args: { design_id: "$d.id" } }],
+          },
+        ],
+      },
+    })
+
+    expect(r.ok).toBe(true)
+    const value = r.value as any
+    expect(value.map).toBe("designs")
+    expect(value.count).toBe(2)
+    expect(dispatch).toHaveBeenCalledWith("list_production_runs", { design_id: "d1" })
+    expect(dispatch).toHaveBeenCalledWith("list_production_runs", { design_id: "d2" })
+  })
+
+  it("does not retry an empty exact-key lookup", async () => {
+    const dispatch = jest.fn(async (name: string) => ok(name, { customers: [], count: 0 }))
+
+    const r = await executeMcpPlan({
+      ctx,
+      tools,
+      dispatch,
+      plan: { steps: [{ tool: "list_customers", args: { email: "no-such@x.com" } }] },
+    })
+
+    expect(r.retries).toBe(0)
+    expect(dispatch).toHaveBeenCalledTimes(1)
+  })
+
+  it("retries with a broadened filter when a list step returns empty", async () => {
+    const dispatch = jest.fn(async (name: string, args: any) => {
+      if (name === "list_designs") {
+        if (args.q === "Allocation Fixture 1787729803080")
+          return ok(name, { designs: [], count: 0 })
+        return ok(name, { designs: [{ id: "d1" }], count: 1 })
+      }
+      return fail(name, "unknown")
+    })
+
+    const r = await executeMcpPlan({
+      ctx,
+      tools,
+      dispatch,
+      plan: {
+        steps: [{ tool: "list_designs", args: { q: "Allocation Fixture 1787729803080" } }],
+      },
+    })
+
+    expect(r.ok).toBe(true)
+    expect(r.retries).toBe(1)
+    expect(dispatch).toHaveBeenLastCalledWith("list_designs", { q: "Allocation" })
+  })
+
+  it("stops and reports failure on a failed step", async () => {
+    const dispatch = jest.fn(async () => fail("list_orders", "Route 404"))
+
+    const r = await executeMcpPlan({
+      ctx,
+      tools,
+      dispatch,
+      plan: { steps: [{ tool: "list_orders", args: {} }] },
+    })
+
+    expect(r.ok).toBe(false)
+    expect(r.error).toBe("Route 404")
+  })
+
+  it("resolves from memory and skips the lookup tool", async () => {
+    const resolve = buildEntityResolver(
+      extractEntityResolutions({
+        customers: [{ id: "cus_01KS9B", email: "delhi@gmail.com" }],
+      })
+    )
+    const dispatch = jest.fn(async (name: string, args: any) => {
+      if (name === "list_orders") return ok(name, { orders: [{ customer_id: args.customer_id }] })
+      return fail(name, "unexpected call")
+    })
+
+    const r = await executeMcpPlan({
+      ctx,
+      tools,
+      dispatch,
+      resolveEntity: resolve,
+      plan: {
+        steps: [
+          { resolve: "customer", by: "email", value: "delhi@gmail.com", as: "c" },
+          { tool: "list_orders", args: { customer_id: "$c" } },
+        ],
+      },
+    })
+
+    expect(r.ok).toBe(true)
+    expect(dispatch).toHaveBeenCalledTimes(1)
+    expect(dispatch).toHaveBeenCalledWith("list_orders", { customer_id: "cus_01KS9B" })
+  })
+
+  it("falls back to the lookup tool when memory misses", async () => {
+    const dispatch = jest.fn(async (name: string, args: any) => {
+      if (name === "list_customers") return ok(name, { customers: [{ id: "cus_1" }] })
+      if (name === "list_orders") return ok(name, { orders: [{ customer_id: args.customer_id }] })
+      return fail(name, "unexpected call")
+    })
+
+    const r = await executeMcpPlan({
+      ctx,
+      tools,
+      dispatch,
+      resolveEntity: () => null,
+      plan: {
+        steps: [
+          {
+            resolve: "customer",
+            by: "email",
+            value: "x@y.com",
+            as: "c",
+            fallback: { tool: "list_customers", args: { email: "x@y.com" }, extract: "customers.0.id" },
+          },
+          { tool: "list_orders", args: { customer_id: "$c" } },
+        ],
+      },
+    })
+
+    expect(r.ok).toBe(true)
+    expect(dispatch).toHaveBeenCalledWith("list_customers", { email: "x@y.com" })
+    expect(dispatch).toHaveBeenCalledWith("list_orders", { customer_id: "cus_1" })
+  })
+
+  it("errors when a resolve misses and no fallback is given", async () => {
+    const r = await executeMcpPlan({
+      ctx,
+      tools,
+      dispatch: jest.fn(),
+      resolveEntity: () => null,
+      plan: { steps: [{ resolve: "customer", by: "email", value: "x@y.com", as: "c" }] },
+    })
+
+    expect(r.ok).toBe(false)
+    expect(r.error).toContain("No cached customer")
+  })
+})

--- a/apps/backend/src/lib/mcp-core/index.ts
+++ b/apps/backend/src/lib/mcp-core/index.ts
@@ -29,6 +29,20 @@ export {
   type McpScopeLevel,
 } from "./tiers"
 export { dispatchMcpTool } from "./dispatch"
+export {
+  executeMcpPlan,
+  navPlanPath,
+  isEmptyPlanResult,
+  broadenPlanArgs,
+  PLAN_SCOPE_GUIDANCE,
+  type McpPlanStep,
+  type McpPlan,
+  type McpPlanFallback,
+  type McpPlanMapResult,
+  type ExecutePlanOptions,
+  type McpPlanResult,
+  type EntityResolver,
+} from "./plan"
 export { callMcpRoute, type McpProxyArgs, type McpProxyError } from "./proxy"
 export { buildMcpServer, type BuildMcpServerOptions } from "./server"
 export {

--- a/apps/backend/src/lib/mcp-core/plan.ts
+++ b/apps/backend/src/lib/mcp-core/plan.ts
@@ -1,0 +1,250 @@
+/**
+ * Structured plan execution over the MCP tool registry.
+ *
+ * `dispatchMcpTool` runs ONE tool against ONE route. A request that needs
+ * several tools ("orders for customer X") forces the model to chain raw
+ * function calls itself — resolve the reference, remember the id, pass it to
+ * the next tool. That is where single tool calls fail: the model invents a
+ * filter syntax or passes a name where an id belongs, and the result is either
+ * a 4xx or, worse, `ok:true` with zero rows.
+ *
+ * A plan is the structured alternative. The model emits steps; this executor
+ * runs them with three mechanisms the raw path lacks:
+ *   - reference substitution: `extract` pulls one value out of a result and
+ *     stores it; later args reference it as `$name` (or `$name.path`).
+ *   - fan-out: a `map` step iterates a stored list and runs sub-steps per item.
+ *   - deterministic retry: a list step that comes back empty is re-dispatched
+ *     once with a broadened filter.
+ *
+ * Every step still goes through `dispatchMcpTool`, so the dry_run / confirm /
+ * reason rails and scope checks apply per step — the plan cannot smuggle past
+ * a guard that a single call could not.
+ *
+ * Plan grammar (see McpPlanStep):
+ *   {"tool": name, "args": {...}, "as": name|null, "extract": "path"|null}
+ *   {"map": "listName", "item": "var", "steps": [ ... ]}
+ *
+ * Scoping guidance for the model (singular vs plural): prefer `extract` when
+ * the request names ONE thing ("the first run of the design"); reserve `map`
+ * for plural asks ("each", "per", "every"). This is a prompt-level rule — the
+ * executor runs either shape, but the singular form is far cheaper.
+ */
+import type { McpContext, McpToolDef, McpToolResult } from "./types"
+import { dispatchMcpTool } from "./dispatch"
+
+export type McpPlanStep = {
+  tool?: string
+  args?: Record<string, unknown>
+  /** Store the step's full result data under this name (for lists you will map). */
+  as?: string
+  /** Pull one value out of the result (dot/bracket path into "data"); stored under `as` or `$N`. */
+  extract?: string | null
+  /** Iterate a stored list (by its `as` name). */
+  map?: string
+  /** Loop variable; inside sub-steps reference it as `$var.field`. */
+  item?: string
+  steps?: McpPlanStep[]
+  /** Memory lookup: resolve an entity of this type by a natural key. */
+  resolve?: string
+  /** Natural key field to resolve by, e.g. "email". Defaults to "id". */
+  by?: string
+  /** The key's value to resolve, e.g. "delhi@gmail.com". */
+  value?: string
+  /** Run this tool only when the memory lookup misses, extracting into `as`. */
+  fallback?: McpPlanFallback
+}
+
+export type McpPlanFallback = {
+  tool: string
+  args?: Record<string, unknown>
+  extract?: string | null
+}
+
+/** Memory resolver: returns an entity id for (type, key, value), or null. */
+export type EntityResolver = (
+  type: string,
+  by: string,
+  value: string
+) => Promise<string | null> | string | null
+
+export type McpPlan = { steps: McpPlanStep[] }
+
+export type McpPlanMapResult = { map: string; count: number; results: unknown[] }
+
+export type ExecutePlanOptions = {
+  ctx: McpContext
+  tools: McpToolDef[]
+  plan: McpPlan
+  /** When false, the empty-result retry is disabled. Defaults true. */
+  retry?: boolean
+  /** Test seam: override the per-tool dispatch. */
+  dispatch?: (name: string, args: Record<string, unknown>) => Promise<McpToolResult>
+  /** Memory resolver consulted by `resolve` steps. */
+  resolveEntity?: EntityResolver
+}
+
+export type McpPlanResult = {
+  ok: boolean
+  value: McpToolResult | McpPlanMapResult | null
+  toolCalls: number
+  retries: number
+  error?: string
+}
+
+/** Navigate a dot/bracket path ("designs.0.id") into an unknown value. */
+export function navPlanPath(data: unknown, path: string): unknown {
+  if (!path) return data
+  let cur: any = data
+  for (let p of path.split(".")) {
+    if (cur == null) return undefined
+    const m = p.match(/^(\w+)\[(\d+)\]$/)
+    if (m) cur = cur[m[1]]?.[Number(m[2])]
+    else cur = cur[p]
+  }
+  return cur
+}
+
+function resolveRef(v: unknown, store: Record<string, unknown>): unknown {
+  if (typeof v !== "string") return v
+  const m = v.match(/^\$([A-Za-z_]\w*)(?:\.(.+))?$/)
+  if (!m) return v
+  const base = store[m[1]]
+  return m[2] ? navPlanPath(base, m[2]) : base
+}
+
+function resolveArgs(
+  args: Record<string, unknown> | undefined,
+  store: Record<string, unknown>
+): Record<string, unknown> {
+  const out: Record<string, unknown> = {}
+  for (const [k, v] of Object.entries(args ?? {})) out[k] = resolveRef(v, store)
+  return out
+}
+
+/** True when a list result came back with nothing (count 0 or empty array). */
+export function isEmptyPlanResult(data: unknown): boolean {
+  if (!data || typeof data !== "object" || Array.isArray(data)) return false
+  const o = data as Record<string, unknown>
+  if (o.count === 0) return true
+  return Object.values(o).some((v) => Array.isArray(v) && v.length === 0)
+}
+
+/**
+ * Widen a free-text filter so a miss can be retried.
+ *
+ * Only `q` is broadenable. An exact natural-key filter (email/name/id/handle)
+ * that returns empty is a CORRECT miss — "no customer with this email" — not a
+ * too-narrow search; broadening it would drop the key and return the whole
+ * table, silently answering a different question. When there is nothing to
+ * broaden the args come back unchanged and the caller skips the retry.
+ */
+export function broadenPlanArgs(args: Record<string, unknown>): Record<string, unknown> {
+  const next = { ...args }
+  if (typeof next.q === "string") {
+    const q = next.q as string
+    if (q.includes(" ")) next.q = q.split(" ")[0]
+    else delete next.q
+  }
+  return next
+}
+
+export async function executeMcpPlan(opts: ExecutePlanOptions): Promise<McpPlanResult> {
+  const dispatch =
+    opts.dispatch ??
+    ((name: string, args: Record<string, unknown>) => dispatchMcpTool(opts.ctx, opts.tools, name, args))
+
+  const store: Record<string, unknown> = {}
+  let toolCalls = 0
+  let retries = 0
+  let error: string | undefined
+
+  const run = async (
+    steps: McpPlanStep[],
+    store: Record<string, unknown>
+  ): Promise<McpToolResult | McpPlanMapResult | null> => {
+    let last: McpToolResult | McpPlanMapResult | null = null
+
+    for (let i = 0; i < steps.length; i++) {
+      const s = steps[i]
+
+      if (s.map && s.steps) {
+        const listName = (s.map as string).replace(/^\$/, "")
+        let list = store[listName]
+        if (!Array.isArray(list) && list && typeof list === "object") {
+          const arr = Object.values(list).find(Array.isArray)
+          if (arr) list = arr
+        }
+        const results: unknown[] = []
+        for (const el of Array.isArray(list) ? list : []) {
+          results.push(await run(s.steps, { ...store, [s.item as string]: el }))
+        }
+        last = { map: s.map, count: results.length, results }
+        continue
+      }
+
+      // ── Memory resolve ─────────────────────────────────────────────────
+      // A `resolve` step consults memory first; it only dispatches a tool when
+      // the resolver misses and a fallback tool is given.
+      if (s.resolve) {
+        const id = opts.resolveEntity
+          ? await opts.resolveEntity(s.resolve, s.by ?? "id", String(s.value ?? ""))
+          : null
+        if (id) {
+          store[s.as ?? String(i + 1)] = id
+          last = { ok: true, tool: `resolve:${s.resolve}`, data: { id } } as McpToolResult
+          continue
+        }
+        if (!s.fallback) {
+          error = `No cached ${s.resolve} for ${s.by ?? "id"}=${s.value}`
+          break
+        }
+        // Miss: fall through and run the fallback tool with the step's `as`/extract.
+        var step = {
+          tool: s.fallback.tool,
+          args: s.fallback.args,
+          as: s.as,
+          extract: s.fallback.extract,
+        } as McpPlanStep
+      } else {
+        var step = s
+      }
+
+      const args = resolveArgs(step.args, store)
+      let res = await dispatch(step.tool as string, args)
+      toolCalls++
+      last = res
+
+      if (opts.retry !== false && res?.ok && isEmptyPlanResult(res.data)) {
+        const broad = broadenPlanArgs(args)
+        if (JSON.stringify(broad) !== JSON.stringify(args)) {
+          retries++
+          res = await dispatch(step.tool as string, broad)
+          toolCalls++
+          last = res
+        }
+      }
+
+      if (!res?.ok) {
+        error = res?.error
+        break
+      }
+
+      if (step.extract) {
+        store[step.as ?? String(i + 1)] = navPlanPath(res.data, step.extract)
+      } else if (step.as) {
+        store[step.as] = res.data
+      }
+    }
+
+    return last
+  }
+
+  const value = await run(opts.plan.steps, store)
+  const ok = !error
+  return { ok, value, toolCalls, retries, ...(error ? { error } : {}) }
+}
+
+/** Prompt guidance so the model scopes a plan correctly (singular vs plural). */
+export const PLAN_SCOPE_GUIDANCE =
+  'When the request names ONE entity ("the first X", "the design", "a single"), ' +
+  'use "extract" and a linear chain. Use "map" only for plural asks ("each", "per", "every").'

--- a/apps/backend/src/modules/assistant-context-cache/migrations/Migration20260828120000.ts
+++ b/apps/backend/src/modules/assistant-context-cache/migrations/Migration20260828120000.ts
@@ -1,0 +1,30 @@
+import { Migration } from "@medusajs/framework/mikro-orm/migrations";
+
+/**
+ * Adds `entity_resolutions` to assistant_context_cache.
+ *
+ * Until now the cache only kept a flat `entity_ids` array, which a later turn
+ * could show but never query ("you looked at these"). `entity_resolutions`
+ * stores the natural key each id was found under — [{type, key, value, id}]
+ * — so the plan executor's `resolve` step can answer "what is the id of
+ * customer delhi@gmail.com?" without re-running the lookup tool.
+ *
+ * Defaults to '[]' so existing rows are valid immediately; no backfill needed.
+ *
+ * Distinct class name + timestamp to avoid the Medusa migration-name-collision
+ * hazard.
+ */
+export class Migration20260828120000 extends Migration {
+
+  override async up(): Promise<void> {
+    this.addSql(
+      `alter table "assistant_context_cache" add column if not exists "entity_resolutions" jsonb not null default '[]';`
+    );
+  }
+
+  override async down(): Promise<void> {
+    this.addSql(
+      `alter table "assistant_context_cache" drop column if exists "entity_resolutions";`
+    );
+  }
+}

--- a/apps/backend/src/modules/assistant-context-cache/models/assistant-context-cache.ts
+++ b/apps/backend/src/modules/assistant-context-cache/models/assistant-context-cache.ts
@@ -38,6 +38,11 @@ const AssistantContextCache = model
     // Stored as a JSON array — thin by design, never the full tool results.
     entity_ids: model.json(),
 
+    // Richer entity resolutions: [{type, key, value, id, label}]. Lets a later
+    // plan resolve "customer by email" straight to an id instead of re-running
+    // the lookup tool. Stored as a JSON array, same thin-by-design intent.
+    entity_resolutions: model.json(),
+
     // A compact (1-3 line) summary of what was found, e.g.
     // "5 orders found. Most recent: order_abc (₹2,500). Statuses: 2 pending, 3 completed."
     summary: model.text(),

--- a/apps/backend/src/modules/assistant-context-cache/service.ts
+++ b/apps/backend/src/modules/assistant-context-cache/service.ts
@@ -1,6 +1,37 @@
 import { MedusaError, MedusaService } from "@medusajs/framework/utils"
 import AssistantContextCache from "./models/assistant-context-cache"
 
+/** One natural-key -> id resolution stored in a cache row. */
+export interface EntityResolution {
+  type: string
+  key: string
+  value: string
+  id: string
+  label?: string
+}
+
+/**
+ * Scan cache rows for a matching entity resolution. Pure so it can be unit
+ * tested without the DB; the service method is a thin wrapper over a row read.
+ */
+export function findResolutionInRows(
+  rows: Array<{ entity_resolutions?: unknown }>,
+  type: string,
+  key: string,
+  value: string
+): string | null {
+  for (const row of rows) {
+    const list = row?.entity_resolutions
+    if (!Array.isArray(list)) continue
+    for (const r of list as Array<Record<string, unknown>>) {
+      if (r.type === type && r.key === key && r.value === value && typeof r.id === "string") {
+        return r.id
+      }
+    }
+  }
+  return null
+}
+
 /**
  * Thin CRUD over the cross-conversation context cache, always scoped to a
  * (principal_id, surface) pair. The generated MedusaService methods handle
@@ -46,7 +77,10 @@ class AssistantContextCacheService extends MedusaService({
     entityIds: string[]
     summary: string
     conversationId?: string
+    resolutions?: EntityResolution[]
   }) {
+    const resolutions = (input.resolutions ?? []) as any
+
     const [existing] = await this.listAssistantContextCaches({
       principal_id: input.principalId,
       surface: input.surface,
@@ -58,6 +92,7 @@ class AssistantContextCacheService extends MedusaService({
         {
           id: existing.id,
           entity_ids: input.entityIds as any,
+          entity_resolutions: resolutions,
           summary: input.summary,
           conversation_id: input.conversationId ?? null,
         },
@@ -71,6 +106,7 @@ class AssistantContextCacheService extends MedusaService({
         surface: input.surface,
         domain: input.domain,
         entity_ids: input.entityIds as any,
+        entity_resolutions: resolutions,
         summary: input.summary,
         conversation_id: input.conversationId ?? null,
       })
@@ -90,12 +126,29 @@ class AssistantContextCacheService extends MedusaService({
         {
           id: raced.id,
           entity_ids: input.entityIds as any,
+          entity_resolutions: resolutions,
           summary: input.summary,
           conversation_id: input.conversationId ?? null,
         },
       ])
       return updated
     }
+  }
+
+  /**
+   * Resolve an entity id by a natural key from the cache — the memory the plan
+   * executor's `resolve` step consults. Scans all rows for the principal
+   * (thin table, one row per domain) and returns the first match, or null.
+   */
+  async resolveEntityByKey(
+    principalId: string,
+    surface: string,
+    type: string,
+    key: string,
+    value: string
+  ): Promise<string | null> {
+    const rows = await this.getContextForPrincipal(principalId, surface)
+    return findResolutionInRows(rows as Array<{ entity_resolutions?: unknown }>, type, key, value)
   }
 
   /**


### PR DESCRIPTION
## What

Two new capabilities for the MCP assistant stack, both proven live against a seeded server:

1. **Structured plan executor** (`lib/mcp-core/plan.ts`) — `executeMcpPlan()` runs a multi-step plan over the MCP registry with three mechanisms raw function-calling lacks:
   - `$ref` substitution + `extract` (pull a value, reuse it as `$name` / `$name.path`)
   - `map` fan-out (iterate a list, per-item sub-steps) — "production runs **per design**"
   - deterministic retry (empty list result → broaden free-text `q`, once)
   - a `resolve` step that consults entity memory before dispatching the lookup tool
   - every step goes through `dispatchMcpTool`, so dry_run/confirm/reason rails and scope checks still apply per step.

2. **Entity natural-key memory** (`lib/assistant-context/entities.ts` + `assistant-context-cache`) — extracts `{type, key, value, id, label}` from tool results (e.g. `customer.email=delhi@gmail.com -> cus_01…`) so a later plan can resolve "customer by email" straight to an id without re-running the lookup. Adds an `entity_resolutions` JSON column (migration), a `resolveEntityByKey` service method, and pure `extractEntityResolutions` / `buildEntityResolver` helpers.

## Why

Single tool calls fail on multi-step requests: the model invents a filter syntax (`customer_email:`) that returns zero rows silently, or passes a name where an id belongs (404). The plan executor fixes the first; the entity memory makes the second cheap by remembering ids already resolved.

## Validation

- 12 unit tests (`plan.unit.spec.ts`): ref substitution, map fan-out, retry (and the exact-key no-retry case), resolve hit / miss→fallback / miss→error, plus an end-to-end wiring test (extract → memory → resolve step skips the lookup tool).
- 5 unit tests (`entities.unit.spec.ts`): type inference (longest-prefix), extraction, resolver, `findResolutionInRows`.
- Live run against `localhost:9000` with seeded data: extracted `delhi@gmail.com → cus_01KS9BXSAA59AESGP84EC5FMD5`, then a plan resolved it from memory (1 tool call, `list_customers` skipped) and returned 2 real orders; the Cloudflare LLM also generated the resolve-aware plan itself.

## Notes

- **Migration** `Migration20260828120000` adds the `entity_resolutions` column (default `'[]'`, no backfill) — applies on the normal deploy flow.
- **Not yet wired** into the chat route: `extractContextFromTurn` doesn't emit resolutions, the chat route doesn't pass `resolveEntity`, and `executeMcpPlan` isn't yet the assistant's plan-mode fallback. These are the follow-up glue points.
- Exploratory CLI harnesses under `src/scripts/search/` were left out of this PR.