### PR TITLE
feat(assistant-context): surface entity resolutions in the cross-turn memory

### DIFF
--- a/apps/backend/src/api/admin/assistant/chat/route.ts
+++ b/apps/backend/src/api/admin/assistant/chat/route.ts
@@ -458,6 +458,7 @@ export const POST = async (
                   surface: "admin",
                   domain: entry.domain,
                   entityIds: entry.entityIds,
+                  resolutions: entry.resolutions,
                   summary: entry.summary,
                   conversationId: body.id ?? null,
                 })

--- a/apps/backend/src/api/partners/assistant/chat/route.ts
+++ b/apps/backend/src/api/partners/assistant/chat/route.ts
@@ -377,6 +377,7 @@ export const POST = async (
                   surface: "partner",
                   domain: entry.domain,
                   entityIds: entry.entityIds,
+                  resolutions: entry.resolutions,
                   summary: entry.summary,
                   conversationId: body.id ?? null,
                 })

--- a/apps/backend/src/lib/assistant-context/__tests__/extract.unit.spec.ts
+++ b/apps/backend/src/lib/assistant-context/__tests__/extract.unit.spec.ts
@@ -203,4 +203,25 @@ describe("assistant-context: extractContextFromTurn", () => {
     expect(entries).toHaveLength(1)
     expect(entries[0].summary.length).toBeLessThanOrEqual(200)
   })
+
+  it("extracts natural-key resolutions alongside entity ids", () => {
+    const entries = extractContextFromTurn([
+      {
+        toolName: "list_customers",
+        output: {
+          customers: [{ id: "cus_01KS9B", email: "delhi@gmail.com" }],
+        },
+      },
+    ])
+
+    expect(entries).toHaveLength(1)
+    expect(entries[0].domain).toBe("customers")
+    expect(entries[0].resolutions).toHaveLength(1)
+    expect(entries[0].resolutions[0]).toMatchObject({
+      type: "customer",
+      key: "email",
+      value: "delhi@gmail.com",
+      id: "cus_01KS9B",
+    })
+  })
 })

--- a/apps/backend/src/lib/assistant-context/__tests__/inject.unit.spec.ts
+++ b/apps/backend/src/lib/assistant-context/__tests__/inject.unit.spec.ts
@@ -94,6 +94,34 @@ describe("assistant-context: formatPriorContext", () => {
     expect(result!).not.toContain("Entity ids")
   })
 
+  it("surfaces known id resolutions", () => {
+    const rows: ContextCacheRow[] = [
+      {
+        domain: "customers",
+        entity_ids: ["cus_01KS9B"],
+        entity_resolutions: [
+          { type: "customer", key: "email", value: "delhi@gmail.com", id: "cus_01KS9B" },
+        ],
+        summary: "list_customers: 1 customer",
+        updated_at: new Date().toISOString(),
+      },
+    ]
+    const result = formatPriorContext(rows)
+    expect(result!).toContain("Known: customer delhi@gmail.com = cus_01KS9B")
+  })
+
+  it("omits the Known line when there are no resolutions", () => {
+    const rows: ContextCacheRow[] = [
+      {
+        domain: "customers",
+        entity_ids: ["cus_01KS9B"],
+        summary: "list_customers: 1 customer",
+        updated_at: new Date().toISOString(),
+      },
+    ]
+    expect(formatPriorContext(rows)!).not.toContain("Known:")
+  })
+
   it("uses relative time formatting", () => {
     const cases: [number, string][] = [
       [0, "just now"],

--- a/apps/backend/src/lib/assistant-context/extract.ts
+++ b/apps/backend/src/lib/assistant-context/extract.ts
@@ -15,11 +15,14 @@
  *   harmless, a crash in onFinish is not.
  */
 import { toolNameToDomain, type AssistantSurface } from "./domains"
+import { extractEntityResolutions, type EntityResolution } from "./entities"
 
 export interface ExtractedContextEntry {
   domain: string
   entityIds: string[]
   summary: string
+  /** Natural-key -> id resolutions, so a later turn can resolve without re-looking up. */
+  resolutions: EntityResolution[]
 }
 
 /** Known entity-id prefixes on the JYT platform. */
@@ -126,7 +129,10 @@ export function extractContextFromTurn(
 ): ExtractedContextEntry[] {
   if (!toolResults?.length) return []
 
-  const byDomain = new Map<string, { entityIds: Set<string>; summaries: string[] }>()
+  const byDomain = new Map<
+    string,
+    { entityIds: Set<string>; summaries: string[]; resolutions: EntityResolution[] }
+  >()
 
   for (const tr of toolResults) {
     const toolName = tr?.toolName
@@ -139,23 +145,30 @@ export function extractContextFromTurn(
 
     const output = tr.output
     const ids = extractEntityIds(output)
+    const resolutions = extractEntityResolutions(output)
     const summary = buildToolSummary(toolName, output)
 
     let entry = byDomain.get(domain)
     if (!entry) {
-      entry = { entityIds: new Set(), summaries: [] }
+      entry = { entityIds: new Set(), summaries: [], resolutions: [] }
       byDomain.set(domain, entry)
     }
 
     for (const id of ids) entry.entityIds.add(id)
+    entry.resolutions.push(...resolutions)
     entry.summaries.push(summary)
   }
 
   const entries: ExtractedContextEntry[] = []
-  for (const [domain, { entityIds, summaries }] of byDomain) {
+  for (const [domain, { entityIds, summaries, resolutions }] of byDomain) {
     const allIds = [...entityIds].slice(0, MAX_ENTITY_IDS)
     const combined = summaries.join("; ").slice(0, MAX_SUMMARY_LEN)
-    entries.push({ domain, entityIds: allIds, summary: combined })
+    entries.push({
+      domain,
+      entityIds: allIds,
+      summary: combined,
+      resolutions: resolutions.slice(0, MAX_ENTITY_IDS),
+    })
   }
 
   return entries

--- a/apps/backend/src/lib/assistant-context/inject.ts
+++ b/apps/backend/src/lib/assistant-context/inject.ts
@@ -44,6 +44,8 @@ export function isFresh(row: ContextCacheRow, now = Date.now()): boolean {
 export interface ContextCacheRow {
   domain: string
   entity_ids: string[] | unknown
+  /** Natural-key -> id resolutions: [{type, key, value, id, label?}]. */
+  entity_resolutions?: unknown
   summary: string
   updated_at: string | Date
 }
@@ -72,6 +74,18 @@ export function formatPriorContext(rows: ContextCacheRow[]): string | undefined 
       `### ${row.domain} (${time})`,
       `- ${row.summary}`,
     ]
+    // Known id mappings — the whole point of the resolution column. Tells the
+    // model "you already know customer X = cus_...", so it can use the id
+    // directly instead of re-running the lookup tool. A pointer, like the rest
+    // of the block, never a source of truth.
+    const resolutions = Array.isArray(row.entity_resolutions) ? row.entity_resolutions : []
+    const resoList = resolutions
+      .slice(0, 6)
+      .map((r: any) => `${r?.type} ${r?.value} = ${r?.id}`)
+      .join("; ")
+    if (resoList) {
+      lines.push(`- Known: ${resoList}${resolutions.length > 6 ? `, +${resolutions.length - 6} more` : ""}`)
+    }
     if (idList) {
       lines.push(`- Entity ids: ${idList}${ids.length > 8 ? `, +${ids.length - 8} more` : ""}`)
     }


### PR DESCRIPTION
## What

Wires the entity-memory from #1623 into the actual chat path, end to end:

1. **Extraction** (`lib/assistant-context/extract.ts`) — `extractContextFromTurn` now records natural-key → id resolutions (`{type, key, value, id, label}`) alongside the flat id list, using the `extractEntityResolutions` helper from #1623.
2. **Persistence** — both chat routes' `onFinish` now pass `resolutions` into `upsertContextEntry`, so they're stored in the new `entity_resolutions` column.
3. **Injection** (`lib/assistant-context/inject.ts`) — `formatPriorContext` surfaces a `Known:` line in the prior-context block, e.g. `Known: customer delhi@gmail.com = cus_01KS9B`, so the model can reuse an id it already resolved instead of re-running the lookup tool.

This makes the memory useful *now*, through the existing injection path — no plan-mode needed for the model to benefit: it reads the id mapping from the prior-context block and skips the lookup on its own.

## Why

#1623 added the storage + query primitives but nothing in the chat path wrote or read the resolutions. This closes that loop: a turn that resolves "customer by email" persists the mapping, and a later turn sees it injected before the model acts.

## Validation

- 51 unit tests pass across `lib/assistant-context` (new: extraction emits resolutions, injection surfaces the `Known:` line and omits it when absent; existing wiring/staleness/domain-agreement tests unchanged).
- Typecheck clean on all touched files.

## Notes / follow-ups

- This is the plumbing half. The `resolveEntity` callback + `executeMcpPlan` **plan-mode fallback** (the trigger for when the assistant switches from single tool calls to a plan) is the remaining work and still needs a decision on the trigger — a separate PR.
- The migration from #1623 applies on the normal deploy flow.