### PR TITLE
feat(payments): payouts visible from the order, run and partner they paid for (#1622)

### DIFF
--- a/apps/backend/src/admin/components/inventory-orders/inventory-order-payments-section.tsx
+++ b/apps/backend/src/admin/components/inventory-orders/inventory-order-payments-section.tsx
@@ -1,12 +1,25 @@
-import { Badge, Container, Heading, Text, toast } from "@medusajs/ui";
+import { Badge, Container, Heading, StatusBadge, Text, toast } from "@medusajs/ui";
 import { Plus, Check, DocumentText } from "@medusajs/icons";
+import { Link } from "react-router-dom";
 import { ActionMenu } from "../common/action-menu";
 import { useUpdatePayment } from "../../hooks/api/payments";
+import {
+  useInventoryOrderPayments,
+  type InventoryOrderPayout,
+} from "../../hooks/api/inventory-orders";
+import { describePaymentLine } from "../../lib/payment-line-source";
+import {
+  paymentSubmissionStatusColor,
+  paymentSubmissionStatusLabel,
+} from "../../lib/payment-submission-status";
 import { useState } from "react";
 
 type InventoryOrderPaymentsSectionProps = {
   inventoryOrder: any;
 };
+
+const money = (amount: number | null | undefined, currency?: string | null) =>
+  `${(currency || "inr").toUpperCase()} ${Number(amount ?? 0).toLocaleString()}`;
 
 const PaymentRow = ({ p }: { p: any }) => {
   const { mutateAsync, isPending } = useUpdatePayment(p.id);
@@ -81,14 +94,72 @@ const PaymentRow = ({ p }: { p: any }) => {
   );
 };
 
+/**
+ * One partner payout that names THIS order.
+ *
+ * Shown at every status, not only once approved — a Pending payout is the
+ * answer to "have we billed for this yet", and it is the status the order most
+ * needs to show. `amount` is what this order contributes, which is not the
+ * submission total when the payout covers several orders.
+ */
+const PayoutRow = ({ payout }: { payout: InventoryOrderPayout }) => {
+  const source = describePaymentLine(payout);
+  const partial =
+    payout.submission_total != null &&
+    Number(payout.submission_total) !== Number(payout.amount);
+
+  return (
+    <div className="flex items-center justify-between py-3">
+      <div className="flex flex-col gap-y-1">
+        <div className="flex items-center gap-x-2">
+          <StatusBadge color={paymentSubmissionStatusColor(payout.submission_status)}>
+            {paymentSubmissionStatusLabel(payout.submission_status)}
+          </StatusBadge>
+          <Text size="small" className="text-ui-fg-base">{source.label}</Text>
+        </div>
+        <Link
+          to={`/payment-submissions/${payout.submission_id}`}
+          className="text-ui-fg-interactive font-mono text-xs hover:underline"
+        >
+          {payout.submission_id}
+        </Link>
+      </div>
+      <div className="flex flex-col items-end gap-y-1">
+        <Text size="small" className="text-ui-fg-base font-medium">
+          {money(payout.amount, payout.currency)}
+        </Text>
+        {partial && (
+          <Text size="xsmall" className="text-ui-fg-subtle">
+            of {money(payout.submission_total, payout.currency)} on this payout
+          </Text>
+        )}
+      </div>
+    </div>
+  );
+};
+
 export const InventoryOrderPaymentsSection = ({ inventoryOrder }: InventoryOrderPaymentsSectionProps) => {
-  const payments = inventoryOrder?.internal_payments || [];
+  const orderId = inventoryOrder?.id;
+  const { payouts, payments: linkedPayments, totals, isLoading, isError } =
+    useInventoryOrderPayments(orderId, { enabled: !!orderId });
+
+  /**
+   * 🔴 The recorded payments come from the route, not from
+   * `inventoryOrder.internal_payments`. The link behind that field is written
+   * only when a payout is APPROVED, and only since #1621 — reading it alone is
+   * what made an order with a Pending payout say "no payments to show yet".
+   */
+  const payments: any[] = linkedPayments || [];
+
+  const payoutList = payouts || [];
+  const total = payoutList.length + payments.length;
+
   return (
     <Container className="divide-y p-0">
       <div className="flex items-center justify-between px-6 py-4">
         <div className="flex items-center gap-x-2">
           <Heading level="h2">Payments</Heading>
-          <Badge size="2xsmall" className="ml-2">{payments.length || 0}</Badge>
+          <Badge size="2xsmall" className="ml-2">{total}</Badge>
         </div>
         <div className="flex items-center gap-x-4">
           <ActionMenu
@@ -106,15 +177,49 @@ export const InventoryOrderPaymentsSection = ({ inventoryOrder }: InventoryOrder
           />
         </div>
       </div>
-      {payments.length === 0 ? (
+
+      {isError && (
         <div className="px-6 py-4">
-          <Text size="small" className="text-ui-fg-subtle px-6 py-8 border-ui-border-base text-center">No payments to show yet.</Text>
+          <Text size="small" className="text-ui-fg-subtle">
+            Could not load what this order has been billed for. The recorded
+            payments below, if any, are still accurate.
+          </Text>
         </div>
-      ) : (
+      )}
+
+      {payoutList.length > 0 && (
         <div className="px-6 py-2 flex flex-col divide-y">
+          <div className="flex items-center justify-between py-2">
+            <Text size="small" weight="plus" className="text-ui-fg-subtle">
+              Partner payouts for this order
+            </Text>
+            <Text size="xsmall" className="text-ui-fg-subtle">
+              {money(totals?.paid, payoutList[0]?.currency)} paid of{" "}
+              {money(totals?.billed, payoutList[0]?.currency)} billed
+            </Text>
+          </div>
+          {payoutList.map((p) => (
+            <PayoutRow key={p.line_id} payout={p} />
+          ))}
+        </div>
+      )}
+
+      {payments.length > 0 && (
+        <div className="px-6 py-2 flex flex-col divide-y">
+          <Text size="small" weight="plus" className="text-ui-fg-subtle py-2">
+            Recorded payments
+          </Text>
           {payments.map((p: any) => (
             <PaymentRow key={p.id} p={p} />
           ))}
+        </div>
+      )}
+
+      {!isLoading && total === 0 && (
+        <div className="px-6 py-4">
+          <Text size="small" className="text-ui-fg-subtle px-6 py-8 border-ui-border-base text-center">
+            Nothing has been billed against this order yet.
+          </Text>
         </div>
       )}
     </Container>

--- a/apps/backend/src/admin/components/partners/partner-payouts-section.tsx
+++ b/apps/backend/src/admin/components/partners/partner-payouts-section.tsx
@@ -1,0 +1,132 @@
+import { Badge, Container, Heading, StatusBadge, Text } from "@medusajs/ui"
+import { Link } from "react-router-dom"
+
+import { usePaymentSubmissions } from "../../hooks/api/payment-submissions"
+import { describePaymentLine } from "../../lib/payment-line-source"
+import {
+  paymentSubmissionStatusColor,
+  paymentSubmissionStatusLabel,
+} from "../../lib/payment-submission-status"
+
+/**
+ * What we have paid this partner, and what we still owe (#1622).
+ *
+ * 🔴 Distinct from the `Payments` section above it, which lists
+ * `internal_payments` — the money-movement records. Those exist only once a
+ * payout is approved, and they say nothing about what the money was FOR. This
+ * reads the submissions themselves, so a Pending claim is visible from the
+ * moment the partner makes it, with the work each line covers named.
+ *
+ * The running totals answer the question the founder actually asks — "have we
+ * settled with them" — which neither a list of payments nor a list of designs
+ * could answer on its own.
+ */
+export const PartnerPayoutsSection = ({ partnerId }: { partnerId: string }) => {
+  const { payment_submissions: submissions, isPending } = usePaymentSubmissions(
+    { partner_id: partnerId, limit: 50 },
+    { enabled: !!partnerId }
+  ) as any
+
+  const rows: any[] = submissions || []
+
+  /**
+   * ⚠️ Rejected is excluded from both totals, not just from `paid`. A rejected
+   * claim never paid anyone and is not owed either — counting it as outstanding
+   * would overstate what this partner is due.
+   */
+  const live = rows.filter((s) => s.status !== "Rejected")
+  const sum = (list: any[]) =>
+    list.reduce((acc, s) => acc + Number(s.total_amount ?? 0), 0)
+  const paid = sum(live.filter((s) => s.status === "Paid"))
+  const outstanding = sum(live.filter((s) => s.status !== "Paid"))
+  const currency = (rows[0]?.currency || "inr").toUpperCase()
+
+  const money = (amount: number) =>
+    new Intl.NumberFormat("en-IN", {
+      style: "currency",
+      currency,
+      maximumFractionDigits: 2,
+    }).format(amount)
+
+  return (
+    <Container className="divide-y p-0">
+      <div className="flex items-center justify-between px-6 py-4">
+        <div className="flex items-center gap-x-2">
+          <Heading level="h2">Payouts</Heading>
+          <Badge size="2xsmall" className="ml-2">
+            {rows.length}
+          </Badge>
+        </div>
+        {rows.length > 0 && (
+          <Text size="small" className="text-ui-fg-subtle">
+            {money(paid)} paid · {money(outstanding)} outstanding
+          </Text>
+        )}
+      </div>
+
+      {!isPending && rows.length === 0 && (
+        <div className="px-6 py-8">
+          <Text size="small" className="text-ui-fg-subtle text-center">
+            This partner has never been billed.
+          </Text>
+        </div>
+      )}
+
+      {rows.length > 0 && (
+        <div className="flex flex-col divide-y px-6">
+          {rows.map((submission) => {
+            const items: any[] = submission.items || []
+            /**
+             * What the payout covered, in the shared vocabulary — never a
+             * per-screen guess. Repeated labels collapse, so seven runs on one
+             * order read as "Production runs" once rather than seven times.
+             */
+            const labels = Array.from(
+              new Set(items.map((item) => describePaymentLine(item).label))
+            )
+
+            return (
+              <div
+                key={submission.id}
+                className="flex items-center justify-between py-3"
+              >
+                <div className="flex flex-col gap-y-1">
+                  <div className="flex items-center gap-x-2">
+                    <StatusBadge
+                      color={paymentSubmissionStatusColor(submission.status)}
+                    >
+                      {paymentSubmissionStatusLabel(submission.status)}
+                    </StatusBadge>
+                    <Text size="small" className="text-ui-fg-subtle">
+                      {labels.length ? labels.join(", ") : "No lines"}
+                    </Text>
+                  </div>
+                  <Link
+                    to={`/payment-submissions/${submission.id}`}
+                    className="text-ui-fg-interactive font-mono text-xs hover:underline"
+                  >
+                    {submission.id}
+                  </Link>
+                </div>
+                <div className="flex flex-col items-end">
+                  <Text size="small" weight="plus">
+                    {new Intl.NumberFormat("en-IN", {
+                      style: "currency",
+                      currency: (submission.currency || "inr").toUpperCase(),
+                      maximumFractionDigits: 2,
+                    }).format(Number(submission.total_amount ?? 0))}
+                  </Text>
+                  <Text size="xsmall" className="text-ui-fg-subtle">
+                    {submission.submitted_at
+                      ? new Date(submission.submitted_at).toLocaleDateString()
+                      : "not submitted"}
+                  </Text>
+                </div>
+              </div>
+            )
+          })}
+        </div>
+      )}
+    </Container>
+  )
+}

--- a/apps/backend/src/admin/components/payments/payment-line-links.tsx
+++ b/apps/backend/src/admin/components/payments/payment-line-links.tsx
@@ -1,0 +1,162 @@
+import { Text } from "@medusajs/ui"
+import { Link } from "react-router-dom"
+
+import type { ResolvedRef } from "../../hooks/api/payment-submissions"
+
+/**
+ * The things a payout line paid for, as links (#1622).
+ *
+ * 🔴 Every payout screen rendered ULIDs. A run-sourced line said "7 run(s)" and
+ * gave no way to reach one of them; a design line showed a 26-character id in a
+ * monospace column. The ids were all correct and none of them was usable — you
+ * could not stand on a payout and get to the work it paid for.
+ *
+ * Names come from the route (`resolvePaymentEntities`); an id that could not be
+ * resolved still renders, as the id, because a payout must display even when
+ * the thing it paid for has been deleted.
+ */
+
+/** Where each kind of thing lives in the admin. */
+const HREF = {
+  design: (id: string) => `/designs/${id}`,
+  run: (id: string) => `/production-runs/${id}`,
+  order: (id: string) => `/orders/${id}`,
+  inventory_order: (id: string) => `/orders/inventory/${id}`,
+  partner: (id: string) => `/partners/${id}`,
+} as const
+
+export type RefKind = keyof typeof HREF
+
+export const RefLink = ({
+  kind,
+  refOrId,
+  className,
+}: {
+  kind: RefKind
+  refOrId: ResolvedRef | string | null | undefined
+  className?: string
+}) => {
+  if (!refOrId) return null
+
+  const ref: ResolvedRef =
+    typeof refOrId === "string" ? { id: refOrId, name: refOrId } : refOrId
+
+  return (
+    <Link
+      to={HREF[kind](ref.id)}
+      className={className || "text-ui-fg-interactive hover:underline"}
+      title={ref.detail ? `${ref.id} — ${ref.detail}` : ref.id}
+    >
+      {ref.name}
+    </Link>
+  )
+}
+
+/**
+ * Every source a single line names — a run-sourced line born from a retail
+ * order names BOTH, and showing only one of them loses half the provenance.
+ *
+ * `maxRuns` caps the run list rather than the whole cell: seven runs is a
+ * normal grouped payout and all seven are worth reaching, but a hundred is a
+ * wall. What is hidden is counted out loud — a silent truncation reads as
+ * "that's all of them".
+ */
+export const PaymentLineLinks = ({
+  item,
+  maxRuns = 8,
+}: {
+  item: {
+    design?: ResolvedRef | null
+    design_id?: string | null
+    order?: ResolvedRef | null
+    order_id?: string | null
+    inventory_order?: ResolvedRef | null
+    inventory_order_id?: string | null
+    runs?: ResolvedRef[] | null
+    production_run_ids?: string[] | null
+    task_id?: string | null
+    task_name?: string | null
+  }
+  maxRuns?: number
+}) => {
+  const runs: ResolvedRef[] =
+    item.runs && item.runs.length
+      ? item.runs
+      : (item.production_run_ids || []).map((id) => ({ id, name: id }))
+
+  const shownRuns = runs.slice(0, maxRuns)
+  const hiddenRuns = runs.length - shownRuns.length
+
+  const design = item.design || item.design_id || null
+  const order = item.order || item.order_id || null
+  const inventoryOrder = item.inventory_order || item.inventory_order_id || null
+
+  const nothing =
+    !design && !order && !inventoryOrder && !runs.length && !item.task_id
+
+  if (nothing) {
+    return (
+      <Text size="small" className="text-ui-fg-muted">
+        —
+      </Text>
+    )
+  }
+
+  const linkClass = "text-ui-fg-interactive text-xs hover:underline"
+
+  return (
+    <div className="flex flex-col gap-y-1">
+      {design && (
+        <div className="flex items-center gap-x-1">
+          <Text size="xsmall" className="text-ui-fg-muted">
+            Design
+          </Text>
+          <RefLink kind="design" refOrId={design} className={linkClass} />
+        </div>
+      )}
+      {inventoryOrder && (
+        <div className="flex items-center gap-x-1">
+          <Text size="xsmall" className="text-ui-fg-muted">
+            Inventory order
+          </Text>
+          <RefLink
+            kind="inventory_order"
+            refOrId={inventoryOrder}
+            className={linkClass}
+          />
+        </div>
+      )}
+      {order && (
+        <div className="flex items-center gap-x-1">
+          <Text size="xsmall" className="text-ui-fg-muted">
+            Order
+          </Text>
+          <RefLink kind="order" refOrId={order} className={linkClass} />
+        </div>
+      )}
+      {item.task_id && (
+        <div className="flex items-center gap-x-1">
+          <Text size="xsmall" className="text-ui-fg-muted">
+            Task
+          </Text>
+          <Text size="xsmall">{item.task_name || item.task_id}</Text>
+        </div>
+      )}
+      {shownRuns.length > 0 && (
+        <div className="flex flex-wrap items-center gap-x-2 gap-y-1">
+          <Text size="xsmall" className="text-ui-fg-muted">
+            Runs
+          </Text>
+          {shownRuns.map((run) => (
+            <RefLink key={run.id} kind="run" refOrId={run} className={linkClass} />
+          ))}
+          {hiddenRuns > 0 && (
+            <Text size="xsmall" className="text-ui-fg-muted">
+              +{hiddenRuns} more
+            </Text>
+          )}
+        </div>
+      )}
+    </div>
+  )
+}

--- a/apps/backend/src/admin/hooks/api/inventory-orders.ts
+++ b/apps/backend/src/admin/hooks/api/inventory-orders.ts
@@ -417,3 +417,66 @@ export const useUpdateInventoryOrderLines = (
     ...options,
   });
 };
+
+/**
+ * What this order has been billed for, and what was actually paid (#1622).
+ *
+ * Distinct from the order's `internal_payments`: those exist only once a payout
+ * is APPROVED, so a Pending payout naming this order is invisible on the order
+ * itself. `/payments` reads the submission lines, which name the order from the
+ * moment they are written, at every status.
+ */
+export type InventoryOrderPayout = {
+  line_id: string;
+  submission_id: string;
+  submission_status: string | null;
+  submission_total: number | null;
+  partner_id: string | null;
+  currency: string | null;
+  created_at: string | null;
+  reviewed_at: string | null;
+  amount: number;
+  quantity: number | null;
+  unit_amount: number | null;
+  notes: string | null;
+  source_type: string | null;
+  design_id: string | null;
+  design_name: string | null;
+  task_id: string | null;
+  task_name: string | null;
+  inventory_order_id: string | null;
+  inventory_order_name: string | null;
+  order_id: string | null;
+  production_run_ids: string[] | null;
+};
+
+export type InventoryOrderPaymentsResponse = {
+  payouts: InventoryOrderPayout[];
+  payments: any[];
+  totals: { billed: number; paid: number; recorded: number };
+  count: number;
+};
+
+export const useInventoryOrderPayments = (
+  id: string,
+  options?: Omit<
+    UseQueryOptions<
+      InventoryOrderPaymentsResponse,
+      FetchError,
+      InventoryOrderPaymentsResponse,
+      QueryKey
+    >,
+    "queryFn" | "queryKey"
+  >,
+) => {
+  const { data, ...rest } = useQuery({
+    queryKey: [INVENTORY_ORDER_QUERY_KEY, id, "payments"],
+    queryFn: async () =>
+      sdk.client.fetch<InventoryOrderPaymentsResponse>(
+        `/admin/inventory-orders/${id}/payments`,
+        { method: "GET" },
+      ),
+    ...options,
+  });
+  return { ...data, ...rest };
+};

--- a/apps/backend/src/admin/hooks/api/payment-submissions.ts
+++ b/apps/backend/src/admin/hooks/api/payment-submissions.ts
@@ -12,13 +12,37 @@ import { queryKeysFactory } from "../../lib/query-key-factory"
 
 // ─── Types ──────────────────────────────────────────────────────────────────
 
+/**
+ * An id resolved to something a human recognises (#1622). `name` is never an
+ * id — a caller that gets no ref shows the id itself.
+ */
+export interface ResolvedRef {
+  id: string
+  name: string
+  detail?: string | null
+}
+
 export interface PaymentSubmissionItem {
   id: string
-  source_type: "design" | "task"
+  /**
+   * ⚠️ FOUR values since #1614, not two. This type said `design | task` while
+   * the column had offered `run` and `inventory_order` for months — the same
+   * two-of-four blindness that made whole payouts render nowhere (#1621).
+   */
+  source_type: "design" | "task" | "run" | "inventory_order"
   design_id: string | null
   design_name: string | null
   task_id: string | null
   task_name: string | null
+  /** Inventory-order and retail-order sources (#1612, #1598). */
+  inventory_order_id: string | null
+  inventory_order_name: string | null
+  order_id: string | null
+  /** Resolved by the detail route so the screen shows names, not ULIDs. */
+  design?: ResolvedRef | null
+  order?: ResolvedRef | null
+  inventory_order?: ResolvedRef | null
+  runs?: ResolvedRef[]
   amount: number
   /** Units this line pays for, and the rate behind them. `unit_amount` is null
    *  when the total was typed rather than derived — see resolveDesignLineAmount. */
@@ -35,6 +59,8 @@ export interface PaymentSubmissionItem {
 export interface PaymentSubmission {
   id: string
   partner_id: string
+  /** Who is being paid, by name. Resolved by the detail route only (#1622). */
+  partner?: ResolvedRef | null
   status: "Draft" | "Pending" | "Under_Review" | "Approved" | "Rejected" | "Paid"
   total_amount: number
   currency: string
@@ -159,6 +185,16 @@ export interface PaymentReconciliation {
   reference_type: "payment_submission" | "inventory_order" | "manual"
   reference_id: string | null
   partner_id: string | null
+  /**
+   * WHERE the money came from, distinct from `reference_type` (#1614). `mixed`
+   * carries a null `source_id` on purpose: a payout naming several sources has
+   * no single one to point at.
+   */
+  source_type: string | null
+  source_id: string | null
+  /** Resolved by the list route (#1622). Null when there is nothing to name. */
+  partner?: ResolvedRef | null
+  source?: ResolvedRef | null
   expected_amount: number
   actual_amount: number | null
   discrepancy: number | null

--- a/apps/backend/src/admin/hooks/api/production-runs.ts
+++ b/apps/backend/src/admin/hooks/api/production-runs.ts
@@ -765,3 +765,48 @@ export const useAttachMediaToRun = (
     ...options,
   })
 }
+
+/**
+ * Whether this run has already been billed, and by which payout (#1622).
+ *
+ * `payable-runs` has always known this and only ever showed it on a screen
+ * listing OTHER runs. Same partner-scoped fold behind both, so the run page and
+ * the payable list cannot disagree about who holds a run.
+ */
+export type ProductionRunBilling = {
+  run_id: string
+  partner_id: string | null
+  /** Branch on this — `unknown` is not `clear`. See `runBillingStatus`. */
+  billing_status: "billed" | "unknown" | "clear"
+  claim: { submission_id: string; status: string; quantity: number } | null
+  unrecorded_claims: Array<{
+    submission_id: string
+    status: string
+    amount: number
+  }>
+  lines: any[]
+}
+
+export const useProductionRunPayments = (
+  id: string,
+  options?: Omit<
+    UseQueryOptions<
+      ProductionRunBilling,
+      FetchError,
+      ProductionRunBilling,
+      QueryKey
+    >,
+    "queryFn" | "queryKey"
+  >,
+) => {
+  const { data, ...rest } = useQuery({
+    queryKey: ["production-runs", id, "payments"],
+    queryFn: async () =>
+      sdk.client.fetch<ProductionRunBilling>(
+        `/admin/production-runs/${id}/payments`,
+        { method: "GET" },
+      ),
+    ...options,
+  })
+  return { ...data, ...rest }
+}

--- a/apps/backend/src/admin/lib/payment-submission-status.ts
+++ b/apps/backend/src/admin/lib/payment-submission-status.ts
@@ -1,0 +1,44 @@
+/**
+ * How a payout's status colours itself.
+ *
+ * PURE, and shared for the same reason `describePaymentLine` is: the moment
+ * each screen decides for itself, the screens disagree. `submissions-tab` had
+ * this switch inline; #1622 adds a second surface (the inventory order), and a
+ * copied switch is how two screens start disagreeing about what "Approved"
+ * looks like.
+ *
+ * ⚠️ SUBMISSION statuses only. `reconciliation-tab` carries its own vocabulary
+ * (Matched / Settled / Discrepant / Waived) and colours `Settled` blue where a
+ * submission would be green. It is not a copy of this one and must not be
+ * folded into it.
+ */
+export type PaymentSubmissionStatusColor =
+  | "green"
+  | "orange"
+  | "red"
+  | "grey"
+  | "blue"
+  | "purple"
+
+export const paymentSubmissionStatusColor = (
+  status: string | null | undefined
+): PaymentSubmissionStatusColor => {
+  switch (status) {
+    case "Paid":
+      return "green"
+    case "Approved":
+      return "blue"
+    case "Pending":
+    case "Under_Review":
+      return "orange"
+    case "Rejected":
+      return "red"
+    default:
+      return "grey"
+  }
+}
+
+/** Statuses as a human reads them — the enum uses an underscore. */
+export const paymentSubmissionStatusLabel = (
+  status: string | null | undefined
+): string => (status ? String(status).replace("_", " ") : "Unknown")

--- a/apps/backend/src/admin/routes/partners/[id]/page.tsx
+++ b/apps/backend/src/admin/routes/partners/[id]/page.tsx
@@ -6,6 +6,7 @@ import { TwoColumnPage } from "../../../components/pages/two-column-pages"
 import { PartnerGeneralSection } from "../../../components/partners/partner-general-section"
 import { PartnerAdminsSection } from "../../../components/partners/partner-admins-section"
 import { PartnerPaymentsSection } from "../../../components/partners/partner-payments-section"
+import { PartnerPayoutsSection } from "../../../components/partners/partner-payouts-section"
 import { PartnerTasksSection } from "../../../components/partners/partner-tasks-section"
 import { PartnerFeedbacksSection } from "../../../components/partners/partner-feedbacks-section"
 import { PartnerStorefrontSection } from "../../../components/partners/partner-storefront-section"
@@ -62,6 +63,10 @@ const PartnerDetailPage = () => {
           <PartnerPeopleSection partnerId={partner.id} />
           <PartnerAdminsSection partnerId={partner.id} admins={partner.admins || []} />
           <PartnerPaymentsSection partner={partner} />
+          {/* What we owe and have paid, by PAYOUT. The money-movement list
+              above exists only once a payout is approved and cannot say what
+              any of it was for (#1622). */}
+          <PartnerPayoutsSection partnerId={partner.id} />
           <PartnerTransactionFeesSection partnerId={partner.id} />
           <PartnerFeedbacksSection partnerId={partner.id} />
         </TwoColumnPage.Sidebar>

--- a/apps/backend/src/admin/routes/payment-submissions/[id]/page.tsx
+++ b/apps/backend/src/admin/routes/payment-submissions/[id]/page.tsx
@@ -21,25 +21,15 @@ import {
   type PaymentSubmission,
 } from "../../../hooks/api/payment-submissions"
 import { describePaymentLine } from "../../../lib/payment-line-source"
+import {
+  paymentSubmissionStatusColor,
+  paymentSubmissionStatusLabel,
+} from "../../../lib/payment-submission-status"
+import {
+  PaymentLineLinks,
+  RefLink,
+} from "../../../components/payments/payment-line-links"
 import { SubmissionDocuments } from "../_components/submission-documents"
-
-const statusColor = (
-  status: string
-): "green" | "orange" | "red" | "grey" | "blue" | "purple" => {
-  switch (status) {
-    case "Paid":
-      return "green"
-    case "Approved":
-      return "blue"
-    case "Pending":
-    case "Under_Review":
-      return "orange"
-    case "Rejected":
-      return "red"
-    default:
-      return "grey"
-  }
-}
 
 /**
  * ⚠️ `currency` is a real column that merely DEFAULTS to inr. Hardcoding ₹ told
@@ -125,8 +115,14 @@ const EditableLine = ({
         </Badge>
       </Table.Cell>
       <Table.Cell>{source.title}</Table.Cell>
+      {/**
+        * 🔴 Was a bare ULID in a monospace span. Every id a line names is now a
+        * link to the thing itself — the design, the retail order, the inventory
+        * order, and each run — so a payout can be checked against the work it
+        * paid for instead of being taken on trust (#1622).
+        */}
       <Table.Cell>
-        <span className="font-mono text-xs">{source.reference || "—"}</span>
+        <PaymentLineLinks item={item} />
       </Table.Cell>
       <Table.Cell>
         {editing ? (
@@ -269,8 +265,8 @@ const PaymentSubmissionDetailPage = () => {
           <div className="flex items-center justify-between px-6 py-4">
             <div className="flex items-center gap-3">
               <Heading>Submission {submission.id.slice(0, 8)}...</Heading>
-              <Badge color={statusColor(submission.status)}>
-                {submission.status.replace("_", " ")}
+              <Badge color={paymentSubmissionStatusColor(submission.status)}>
+                {paymentSubmissionStatusLabel(submission.status)}
               </Badge>
             </div>
             {isDraft && (
@@ -324,11 +320,21 @@ const PaymentSubmissionDetailPage = () => {
           {/* Metadata Grid */}
           <div className="px-6 py-4">
             <div className="grid grid-cols-2 gap-4 md:grid-cols-3">
+              {/**
+                * 🔴 The one field saying WHO is being paid used to render as a
+                * bare ULID. It is a name and a link to the partner now; the id
+                * survives underneath, because a partner that cannot be resolved
+                * must still be identifiable (#1622).
+                */}
               <div>
                 <Text size="small" className="text-ui-fg-subtle">
-                  Partner ID
+                  Partner
                 </Text>
-                <Text className="font-mono text-xs">
+                <RefLink
+                  kind="partner"
+                  refOrId={submission.partner || submission.partner_id}
+                />
+                <Text size="xsmall" className="text-ui-fg-muted font-mono">
                   {submission.partner_id}
                 </Text>
               </div>
@@ -434,7 +440,7 @@ const PaymentSubmissionDetailPage = () => {
                 <Table.Row>
                   <Table.HeaderCell>Source</Table.HeaderCell>
                   <Table.HeaderCell>For</Table.HeaderCell>
-                  <Table.HeaderCell>Reference</Table.HeaderCell>
+                  <Table.HeaderCell>Links</Table.HeaderCell>
                   {/* The breakdown, so a partner reads "9 x 850" rather than a
                       bare total they have to take on trust (#1554). */}
                   <Table.HeaderCell>Units</Table.HeaderCell>

--- a/apps/backend/src/admin/routes/payment-submissions/_components/reconciliation-tab.tsx
+++ b/apps/backend/src/admin/routes/payment-submissions/_components/reconciliation-tab.tsx
@@ -7,6 +7,7 @@ import {
   useReconciliations,
   type PaymentReconciliation,
 } from "../../../hooks/api/payment-submissions"
+import { RefLink } from "../../../components/payments/payment-line-links"
 
 const columnHelper = createColumnHelper<PaymentReconciliation>()
 
@@ -89,14 +90,59 @@ export const ReconciliationTab = () => {
           return <span className={color}>{num > 0 ? "+" : ""}{num.toLocaleString()}</span>
         },
       }),
+      /**
+       * 🔴 Was a truncated ULID — `01K4PJMNMNRG...` — repeated down the column.
+       * This is the screen where a discrepancy is chased, and a column of
+       * indistinguishable ids is the least useful place to be told nothing
+       * (#1622). Name and link now; the id is still the title attribute.
+       */
       columnHelper.accessor("partner_id", {
         header: "Partner",
-        cell: ({ getValue }) =>
-          getValue() ? (
-            <span className="font-mono text-xs">{getValue()!.slice(0, 12)}...</span>
+        cell: ({ row }) =>
+          row.original.partner_id ? (
+            <RefLink
+              kind="partner"
+              refOrId={row.original.partner || row.original.partner_id}
+              className="text-ui-fg-interactive text-xs hover:underline"
+            />
           ) : (
             "—"
           ),
+      }),
+      /**
+       * WHERE the money came from, not what kind of record this is — the two
+       * are separate columns on purpose (#1614). A `mixed` payout keeps a null
+       * source by design, so it shows its type and no link rather than being
+       * made to point at one of the several things it covered.
+       */
+      columnHelper.accessor("source_type", {
+        header: "Source",
+        cell: ({ row }) => {
+          const { source_type, source_id, source } = row.original
+          if (!source_type) return "—"
+
+          const kind =
+            source_type === "design"
+              ? "design"
+              : source_type === "run"
+                ? "run"
+                : source_type === "inventory_order"
+                  ? "inventory_order"
+                  : null
+
+          return (
+            <div className="flex items-center gap-x-2">
+              <Badge color="grey">{source_type.replace("_", " ")}</Badge>
+              {kind && source_id ? (
+                <RefLink
+                  kind={kind}
+                  refOrId={source || source_id}
+                  className="text-ui-fg-interactive text-xs hover:underline"
+                />
+              ) : null}
+            </div>
+          )
+        },
       }),
       columnHelper.accessor("created_at", {
         header: "Created",

--- a/apps/backend/src/admin/routes/payment-submissions/_components/submissions-tab.tsx
+++ b/apps/backend/src/admin/routes/payment-submissions/_components/submissions-tab.tsx
@@ -7,26 +7,13 @@ import {
   usePaymentSubmissions,
   type PaymentSubmission,
 } from "../../../hooks/api/payment-submissions"
+import {
+  paymentSubmissionStatusColor,
+  paymentSubmissionStatusLabel,
+} from "../../../lib/payment-submission-status"
 
 const columnHelper = createColumnHelper<PaymentSubmission>()
 
-const statusColor = (
-  status: string
-): "green" | "orange" | "red" | "grey" | "blue" | "purple" => {
-  switch (status) {
-    case "Paid":
-      return "green"
-    case "Approved":
-      return "blue"
-    case "Pending":
-    case "Under_Review":
-      return "orange"
-    case "Rejected":
-      return "red"
-    default:
-      return "grey"
-  }
-}
 
 export const SubmissionsTab = () => {
   const navigate = useNavigate()
@@ -66,7 +53,9 @@ export const SubmissionsTab = () => {
       columnHelper.accessor("status", {
         header: "Status",
         cell: ({ getValue }) => (
-          <StatusBadge color={statusColor(getValue())}>{getValue().replace("_", " ")}</StatusBadge>
+          <StatusBadge color={paymentSubmissionStatusColor(getValue())}>
+            {paymentSubmissionStatusLabel(getValue())}
+          </StatusBadge>
         ),
       }),
       columnHelper.accessor("total_amount", {

--- a/apps/backend/src/admin/routes/production-runs/[id]/page.tsx
+++ b/apps/backend/src/admin/routes/production-runs/[id]/page.tsx
@@ -41,6 +41,7 @@ import {
   useAdminStartRun,
   useCancelProductionRun,
   useProductionRun,
+  useProductionRunPayments,
   useProductionRuns,
   useUpdateProductionRun,
 } from "../../../hooks/api/production-runs"
@@ -75,6 +76,15 @@ const ProductionRunDetailPage = () => {
     { enabled: !!id }
   )
   const isParent = !!(children && children.length > 0)
+
+  /**
+   * Whether this run has already been billed (#1622).
+   *
+   * `payable-runs` has always computed this and only ever shown it on a screen
+   * listing OTHER runs, so the one place you could not learn that a run was
+   * already paid for was the run itself.
+   */
+  const billing = useProductionRunPayments(id || "", { enabled: !!id })
 
   const canCancel = run?.status && !["completed", "cancelled"].includes(run.status)
   const canEdit = run && run.status !== "completed" && run.status !== "cancelled"
@@ -383,6 +393,44 @@ const ProductionRunDetailPage = () => {
                       {run.snapshot?.provenance?.partner_name || run.partner_id}
                     </Text>
                   </Link>
+                ) : (
+                  <Text>-</Text>
+                )}
+              </div>
+            )}
+            {/**
+              * Billed, or not, or unknown — never "not billed" when the answer
+              * is unknown. A live payout that never recorded which run it paid
+              * for means this run MAY already be inside it, and reporting that
+              * as clean is how the same garments get paid for twice (#1565).
+              */}
+            {!isParent && (
+              <div>
+                <Text size="small" className="text-ui-fg-subtle">
+                  Billing
+                </Text>
+                {billing.billing_status === "billed" ? (
+                  <div className="flex items-center gap-x-2">
+                    <StatusBadge color="green">Billed</StatusBadge>
+                    {billing.claim?.submission_id && (
+                      <Link
+                        to={`/payment-submissions/${billing.claim.submission_id}`}
+                        className="text-ui-fg-interactive text-xs hover:underline"
+                      >
+                        {billing.claim.status} payout
+                      </Link>
+                    )}
+                  </div>
+                ) : billing.billing_status === "unknown" ? (
+                  <div className="flex flex-col gap-y-1">
+                    <StatusBadge color="orange">Unknown</StatusBadge>
+                    <Text size="xsmall" className="text-ui-fg-subtle">
+                      A live payout for this design records no run. This one may
+                      already be inside it.
+                    </Text>
+                  </div>
+                ) : billing.billing_status === "clear" ? (
+                  <StatusBadge color="grey">Not billed</StatusBadge>
                 ) : (
                   <Text>-</Text>
                 )}

--- a/apps/backend/src/admin/widgets/order-partner-payouts.tsx
+++ b/apps/backend/src/admin/widgets/order-partner-payouts.tsx
@@ -1,0 +1,131 @@
+import { defineWidgetConfig } from "@medusajs/admin-sdk"
+import { Container, Heading, StatusBadge, Text } from "@medusajs/ui"
+import { DetailWidgetProps } from "@medusajs/framework/types"
+import { useQuery } from "@tanstack/react-query"
+import { Link } from "react-router-dom"
+
+import { sdk } from "../lib/config"
+import { describePaymentLine } from "../lib/payment-line-source"
+import {
+  paymentSubmissionStatusColor,
+  paymentSubmissionStatusLabel,
+} from "../lib/payment-submission-status"
+import { PaymentLineLinks, RefLink } from "../components/payments/payment-line-links"
+
+/**
+ * What this order cost us in partner labour (#1622).
+ *
+ * 🔴 The runs behind an order are linked to it; the payout for those runs was
+ * not. Order #79 is seven production runs and one ₹8,974 payout, and standing
+ * on the order there was no way to see the second half of that.
+ *
+ * Renders nothing when no payout names this order — an order with no partner
+ * work behind it should not carry an empty card.
+ */
+
+type AdminOrder = { id: string }
+
+type OrderPayout = {
+  line_id: string
+  submission_id: string
+  submission_status: string | null
+  partner_id: string | null
+  partner?: { id: string; name: string } | null
+  amount: number
+  currency: string | null
+  source_type: string | null
+  design_id: string | null
+  design_name: string | null
+  task_id: string | null
+  task_name: string | null
+  inventory_order_id: string | null
+  inventory_order_name: string | null
+  order_id: string | null
+  production_run_ids: string[] | null
+  runs?: Array<{ id: string; name: string; detail?: string | null }>
+}
+
+type Response = {
+  payouts: OrderPayout[]
+  totals: { billed: number; paid: number }
+  count: number
+}
+
+const money = (amount: number | null | undefined, currency?: string | null) =>
+  new Intl.NumberFormat("en-IN", {
+    style: "currency",
+    currency: (currency || "inr").toUpperCase(),
+    maximumFractionDigits: 2,
+  }).format(Number(amount ?? 0))
+
+const OrderPartnerPayoutsWidget = ({ data }: DetailWidgetProps<AdminOrder>) => {
+  const { data: result } = useQuery({
+    queryKey: ["orders", data.id, "partner-payouts"],
+    queryFn: async () =>
+      sdk.client.fetch<Response>(
+        `/admin/orders/${data.id}/partner-payouts`,
+        { method: "GET" }
+      ),
+    enabled: !!data.id,
+  })
+
+  const payouts = result?.payouts || []
+  if (!payouts.length) return null
+
+  const currency = payouts[0]?.currency
+
+  return (
+    <Container className="divide-y p-0">
+      <div className="flex items-center justify-between px-6 py-4">
+        <Heading level="h2">Partner payouts</Heading>
+        <Text size="small" className="text-ui-fg-subtle">
+          {money(result?.totals?.paid, currency)} paid of{" "}
+          {money(result?.totals?.billed, currency)} billed
+        </Text>
+      </div>
+      <div className="flex flex-col divide-y px-6">
+        {payouts.map((payout) => {
+          const source = describePaymentLine(payout)
+
+          return (
+            <div key={payout.line_id} className="flex flex-col gap-y-2 py-3">
+              <div className="flex items-center justify-between">
+                <div className="flex items-center gap-x-2">
+                  <StatusBadge
+                    color={paymentSubmissionStatusColor(payout.submission_status)}
+                  >
+                    {paymentSubmissionStatusLabel(payout.submission_status)}
+                  </StatusBadge>
+                  <Text size="small">{source.label}</Text>
+                  {payout.partner_id && (
+                    <RefLink
+                      kind="partner"
+                      refOrId={payout.partner || payout.partner_id}
+                      className="text-ui-fg-interactive text-xs hover:underline"
+                    />
+                  )}
+                </div>
+                <Text size="small" weight="plus">
+                  {money(payout.amount, payout.currency)}
+                </Text>
+              </div>
+              <PaymentLineLinks item={payout} />
+              <Link
+                to={`/payment-submissions/${payout.submission_id}`}
+                className="text-ui-fg-interactive font-mono text-xs hover:underline"
+              >
+                {payout.submission_id}
+              </Link>
+            </div>
+          )
+        })}
+      </div>
+    </Container>
+  )
+}
+
+export const config = defineWidgetConfig({
+  zone: "order.details.after",
+})
+
+export default OrderPartnerPayoutsWidget

--- a/apps/backend/src/api/admin/inventory-orders/[id]/payments/__tests__/fold.unit.spec.ts
+++ b/apps/backend/src/api/admin/inventory-orders/[id]/payments/__tests__/fold.unit.spec.ts
@@ -1,0 +1,122 @@
+import { foldOrderPayouts } from "../fold"
+
+/**
+ * The order-side view of a payout (#1622). Every case here is a shape that
+ * actually exists on prod as of 2026-08-28 — a Pending payout, a payout
+ * covering two orders, and a line whose submission cannot be found.
+ */
+describe("foldOrderPayouts", () => {
+  const submission = (over: Record<string, any> = {}) => ({
+    id: "sub_1",
+    status: "Pending",
+    total_amount: 28670,
+    partner_id: "partner_1",
+    currency: "inr",
+    created_at: "2026-08-28T08:00:00.000Z",
+    ...over,
+  })
+
+  it("shows a PENDING payout — the link-based panel could not", () => {
+    const { payouts, billed, paid } = foldOrderPayouts(
+      [{ id: "line_1", submission_id: "sub_1", amount: 25670 }],
+      [submission()]
+    )
+
+    expect(payouts).toHaveLength(1)
+    expect(payouts[0].submission_status).toBe("Pending")
+    expect(billed).toBe(25670)
+    // Billed is not paid. An order with a pending payout owes the money.
+    expect(paid).toBe(0)
+  })
+
+  it("bills this order its own LINE, not the submission total", () => {
+    // hrhandloom's real payout: two inventory orders on one submission,
+    // 25,670 + 3,000 = 28,670. The order showing 28,670 would be a lie.
+    const { payouts, billed } = foldOrderPayouts(
+      [{ id: "line_1", submission_id: "sub_1", amount: 25670 }],
+      [submission()]
+    )
+
+    expect(payouts[0].amount).toBe(25670)
+    expect(payouts[0].submission_total).toBe(28670)
+    expect(billed).toBe(25670)
+  })
+
+  it("counts a Paid submission as paid, and an Approved one as not", () => {
+    const rows = [
+      { id: "line_paid", submission_id: "sub_paid", amount: 30000 },
+      { id: "line_appr", submission_id: "sub_appr", amount: 1000 },
+    ]
+    const subs = [
+      submission({ id: "sub_paid", status: "Paid", total_amount: 30000 }),
+      submission({ id: "sub_appr", status: "Approved", total_amount: 1000 }),
+    ]
+
+    const { billed, paid } = foldOrderPayouts(rows, subs)
+
+    expect(billed).toBe(31000)
+    // Approved has a payment record but the transfer is still owed —
+    // markSubmissionPaidStep is what makes it Paid.
+    expect(paid).toBe(30000)
+  })
+
+  it("keeps a line whose submission is missing, with a null status", () => {
+    // Absence must not delete the line: an order that was billed still shows
+    // the amount, flagged as unknown rather than silently dropped.
+    const { payouts, billed, paid } = foldOrderPayouts(
+      [{ id: "line_1", submission_id: "sub_gone", amount: 500 }],
+      []
+    )
+
+    expect(payouts).toHaveLength(1)
+    expect(payouts[0].submission_status).toBeNull()
+    expect(billed).toBe(500)
+    expect(paid).toBe(0)
+  })
+
+  it("carries the fields describePaymentLine reads", () => {
+    const { payouts } = foldOrderPayouts(
+      [
+        {
+          id: "line_1",
+          submission_id: "sub_1",
+          amount: 3000,
+          source_type: "inventory_order",
+          inventory_order_id: "inv_order_1",
+          inventory_order_name: "Inventory order inv_order_1",
+        },
+      ],
+      [submission()]
+    )
+
+    expect(payouts[0].source_type).toBe("inventory_order")
+    expect(payouts[0].inventory_order_name).toBe("Inventory order inv_order_1")
+  })
+
+  it("coerces bigNumber-ish string amounts rather than concatenating them", () => {
+    const { billed } = foldOrderPayouts(
+      [
+        { id: "a", submission_id: "sub_1", amount: "25670" },
+        { id: "b", submission_id: "sub_1", amount: "3000" },
+      ],
+      [submission()]
+    )
+
+    expect(billed).toBe(28670)
+  })
+
+  it("orders newest payout first", () => {
+    const { payouts } = foldOrderPayouts(
+      [
+        { id: "old", submission_id: "sub_old", amount: 1 },
+        { id: "new", submission_id: "sub_new", amount: 2 },
+      ],
+      [
+        submission({ id: "sub_old", created_at: "2026-01-01T00:00:00.000Z" }),
+        submission({ id: "sub_new", created_at: "2026-08-28T00:00:00.000Z" }),
+      ]
+    )
+
+    expect(payouts.map((p) => p.line_id)).toEqual(["new", "old"])
+  })
+})

--- a/apps/backend/src/api/admin/inventory-orders/[id]/payments/fold.ts
+++ b/apps/backend/src/api/admin/inventory-orders/[id]/payments/fold.ts
@@ -1,0 +1,105 @@
+/**
+ * Fold a set of payout LINES naming one inventory order into what the order
+ * page shows (#1622). Pure, so the arithmetic that says "paid of billed" can be
+ * tested without a database behind it.
+ */
+
+export type PayoutLineLike = {
+  id: string
+  submission_id?: string | null
+  amount?: number | string | null
+  quantity?: number | null
+  unit_amount?: number | string | null
+  source_type?: string | null
+  design_id?: string | null
+  design_name?: string | null
+  task_id?: string | null
+  task_name?: string | null
+  inventory_order_id?: string | null
+  inventory_order_name?: string | null
+  order_id?: string | null
+  production_run_ids?: string[] | null
+}
+
+export type SubmissionLike = {
+  id: string
+  status?: string | null
+  total_amount?: number | string | null
+  partner_id?: string | null
+  currency?: string | null
+  created_at?: string | Date | null
+  reviewed_at?: string | Date | null
+  notes?: string | null
+}
+
+/**
+ * The one status that means money has actually left.
+ *
+ * ⚠️ `Approved` is deliberately NOT here. An approved submission has a payment
+ * record but `markSubmissionPaidStep` is what flips it to Paid; counting
+ * Approved as paid would tell an order it is settled while the transfer is
+ * still owed.
+ */
+const PAID_STATUSES = new Set(["Paid"])
+
+const num = (v: unknown): number => {
+  const n = Number(v ?? 0)
+  return Number.isFinite(n) ? n : 0
+}
+
+export const foldOrderPayouts = (
+  items: PayoutLineLike[],
+  submissions: SubmissionLike[]
+) => {
+  const byId = new Map(submissions.map((s) => [s.id, s]))
+
+  const payouts = items
+    .map((item) => {
+      const submission = item.submission_id ? byId.get(item.submission_id) : undefined
+
+      return {
+        line_id: item.id,
+        submission_id: item.submission_id ?? null,
+        submission_status: submission?.status ?? null,
+        submission_total:
+          submission?.total_amount != null ? num(submission.total_amount) : null,
+        partner_id: submission?.partner_id ?? null,
+        currency: submission?.currency ?? null,
+        created_at: submission?.created_at ?? null,
+        reviewed_at: submission?.reviewed_at ?? null,
+        /** What THIS order contributes to that payout — not the total. */
+        amount: num(item.amount),
+        quantity: item.quantity ?? null,
+        unit_amount: item.unit_amount != null ? num(item.unit_amount) : null,
+        notes: submission?.notes ?? null,
+        /**
+         * Everything `describePaymentLine` needs, so the panel labels the line
+         * with the shared vocabulary rather than inventing its own. The last
+         * time each screen decided for itself, two of four source types
+         * rendered nowhere at all (#1621).
+         */
+        source_type: item.source_type ?? null,
+        design_id: item.design_id ?? null,
+        design_name: item.design_name ?? null,
+        task_id: item.task_id ?? null,
+        task_name: item.task_name ?? null,
+        inventory_order_id: item.inventory_order_id ?? null,
+        inventory_order_name: item.inventory_order_name ?? null,
+        order_id: item.order_id ?? null,
+        production_run_ids: item.production_run_ids ?? null,
+      }
+    })
+    .sort((a, b) =>
+      String(b.created_at || "").localeCompare(String(a.created_at || ""))
+    )
+
+  return {
+    payouts,
+    /** Everything billed against this order, at any status. */
+    billed: payouts.reduce((acc, p) => acc + p.amount, 0),
+    /** Of that, what a Paid submission covers. */
+    paid: payouts
+      .filter((p) => PAID_STATUSES.has(String(p.submission_status)))
+      .reduce((acc, p) => acc + p.amount, 0),
+  }
+}

--- a/apps/backend/src/api/admin/inventory-orders/[id]/payments/route.ts
+++ b/apps/backend/src/api/admin/inventory-orders/[id]/payments/route.ts
@@ -1,0 +1,90 @@
+/**
+ * @route /admin/inventory-orders/:id/payments
+ * @scope admin
+ *
+ * What we have paid, or owe, the partner FOR THIS ORDER (#1622).
+ *
+ * 🔴 Read off the submission LINES, not off the payment link.
+ *
+ * The order page already had a payments panel, and it already read
+ * `internal_payments` — the link `linkPaymentToInventoryOrderStep` writes. That
+ * link is drawn only when a payout is APPROVED, and only for payouts approved
+ * since #1621. So an order whose payout is still Pending shows nothing, an
+ * order paid before #1621 shows nothing, and in both cases the screen said
+ * "No payments to show yet" — which reads as *nobody has been billed*, not as
+ * *this surface cannot see it*. On prod that is 3 of the 4 payouts written on
+ * 2026-08-28.
+ *
+ * `payment_submission_item.inventory_order_id` has named the order from the
+ * moment the line was written, at every status. Reading that answers the
+ * question for Draft, Pending, Paid and pre-link rows alike, and needs no
+ * backfill. The link is still returned — as `payments` — because it carries
+ * the actual money movement (payment_type, date, attachments) that a line
+ * does not.
+ *
+ * ⚠️ A submission may name SEVERAL sources; reconciliation records such a
+ * payout as `mixed` with a null `source_id`. That is exactly why this queries
+ * items rather than reconciliations: a mixed payout must stay visible from
+ * every order it touches.
+ *
+ * Response: { payouts, payments, totals, count }
+ */
+import type { MedusaRequest, MedusaResponse } from "@medusajs/framework/http"
+import { ContainerRegistrationKeys } from "@medusajs/framework/utils"
+
+import { PAYMENT_SUBMISSIONS_MODULE } from "../../../../../modules/payment_submissions"
+import type PaymentSubmissionsService from "../../../../../modules/payment_submissions/service"
+import { foldOrderPayouts } from "./fold"
+
+export const GET = async (req: MedusaRequest, res: MedusaResponse) => {
+  const { id } = req.params
+
+  const service: PaymentSubmissionsService = req.scope.resolve(
+    PAYMENT_SUBMISSIONS_MODULE
+  )
+
+  const items = (await service.listPaymentSubmissionItems({
+    inventory_order_id: id,
+  })) as any[]
+
+  const submissionIds = Array.from(
+    new Set(items.map((i) => i.submission_id).filter(Boolean))
+  )
+
+  const submissions = submissionIds.length
+    ? ((await service.listPaymentSubmissions({ id: submissionIds })) as any[])
+    : []
+
+  const { payouts, billed, paid } = foldOrderPayouts(items, submissions)
+
+  /**
+   * The linked internal payments. Best-effort: a graph hiccup, or an order with
+   * no link yet, must not turn a page that CAN answer the billing question into
+   * an error.
+   */
+  let payments: any[] = []
+  try {
+    const query: any = req.scope.resolve(ContainerRegistrationKeys.QUERY)
+    const { data } = await query.graph({
+      entity: "inventory_orders",
+      fields: ["id", "internal_payments.*", "internal_payments.attachments.*"],
+      filters: { id },
+    })
+    const raw = data?.[0]?.internal_payments
+    payments = !raw ? [] : Array.isArray(raw) ? raw.filter(Boolean) : [raw]
+  } catch {
+    payments = []
+  }
+
+  return res.status(200).json({
+    payouts,
+    payments,
+    totals: {
+      billed,
+      paid,
+      /** Money actually recorded as moved, from the payment records. */
+      recorded: payments.reduce((acc, p) => acc + Number(p?.amount ?? 0), 0),
+    },
+    count: payouts.length,
+  })
+}

--- a/apps/backend/src/api/admin/orders/[id]/partner-payouts/route.ts
+++ b/apps/backend/src/api/admin/orders/[id]/partner-payouts/route.ts
@@ -1,0 +1,74 @@
+/**
+ * @route /admin/orders/:id/partner-payouts
+ * @scope admin
+ *
+ * What this retail order cost us in partner labour (#1622).
+ *
+ * 🔴 A retail order's runs are linked to it, and the payout for those runs is
+ * not. Order #79 is seven production runs and one ₹8,974 payout, and standing
+ * on the order there was no way to learn the second half of that sentence.
+ *
+ * `payment_submission_item.order_id` was denormalised onto the line precisely
+ * so a payout could be traced back to the order that caused it (#1598) — it
+ * has simply never been read from this direction. Reading it here means every
+ * status answers, Pending included, with no link and no backfill involved.
+ *
+ * Response: { payouts, totals, count }
+ */
+import type { MedusaRequest, MedusaResponse } from "@medusajs/framework/http"
+import { ContainerRegistrationKeys } from "@medusajs/framework/utils"
+
+import { PAYMENT_SUBMISSIONS_MODULE } from "../../../../../modules/payment_submissions"
+import type PaymentSubmissionsService from "../../../../../modules/payment_submissions/service"
+import { foldOrderPayouts } from "../../../inventory-orders/[id]/payments/fold"
+import {
+  collectLineRefs,
+  resolvePaymentEntities,
+} from "../../../payment-submissions/lib/resolve-payment-entities"
+
+export const GET = async (req: MedusaRequest, res: MedusaResponse) => {
+  const { id } = req.params
+
+  const service: PaymentSubmissionsService = req.scope.resolve(
+    PAYMENT_SUBMISSIONS_MODULE
+  )
+
+  const items = (await service.listPaymentSubmissionItems({
+    order_id: id,
+  })) as any[]
+
+  const submissionIds = Array.from(
+    new Set(items.map((i) => i.submission_id).filter(Boolean))
+  )
+
+  const submissions = submissionIds.length
+    ? ((await service.listPaymentSubmissions({ id: submissionIds })) as any[])
+    : []
+
+  const { payouts, billed, paid } = foldOrderPayouts(items, submissions)
+
+  /** Names for the partner and for each run the payout covers. */
+  const query: any = req.scope.resolve(ContainerRegistrationKeys.QUERY)
+  const resolved = await resolvePaymentEntities(query, {
+    partnerIds: submissions.map((s) => s.partner_id),
+    ...collectLineRefs(items),
+  })
+
+  const enriched = payouts.map((payout) => ({
+    ...payout,
+    partner: payout.partner_id
+      ? resolved.partners.get(payout.partner_id) ?? null
+      : null,
+    design: payout.design_id ? resolved.designs.get(payout.design_id) ?? null : null,
+    runs: (payout.production_run_ids || []).map(
+      (runId: string) =>
+        resolved.runs.get(runId) ?? { id: runId, name: runId, detail: null }
+    ),
+  }))
+
+  return res.status(200).json({
+    payouts: enriched,
+    totals: { billed, paid },
+    count: enriched.length,
+  })
+}

--- a/apps/backend/src/api/admin/payment-submissions/[id]/route.ts
+++ b/apps/backend/src/api/admin/payment-submissions/[id]/route.ts
@@ -1,10 +1,26 @@
 import type { MedusaRequest, MedusaResponse } from "@medusajs/framework/http"
-import { MedusaError } from "@medusajs/framework/utils"
+import { ContainerRegistrationKeys, MedusaError } from "@medusajs/framework/utils"
 import { PAYMENT_SUBMISSIONS_MODULE } from "../../../../modules/payment_submissions"
 import PaymentSubmissionsService from "../../../../modules/payment_submissions/service"
 import { deletePaymentSubmissionWorkflow } from "../../../../workflows/payment_submissions/delete-payment-submission"
+import {
+  collectLineRefs,
+  resolvePaymentEntities,
+} from "../lib/resolve-payment-entities"
 
-// GET /admin/payment-submissions/:id — get submission detail
+/**
+ * GET /admin/payment-submissions/:id — submission detail.
+ *
+ * 🔴 Resolved names come with it (#1622). The page rendered `partner_id` as a
+ * raw ULID — the one field saying WHO is being paid — and a run-sourced line
+ * as "7 run(s)" with no way to reach any of them. The ids were all correct and
+ * none of them was readable.
+ *
+ * ⚠️ This route uses `service.listPaymentSubmissions`, NOT `query.graph`, so
+ * `?fields=payments.id` is silently ignored here and links do not expand. That
+ * is why the names are resolved explicitly below rather than requested as
+ * relations.
+ */
 export const GET = async (req: MedusaRequest, res: MedusaResponse) => {
   const { id } = req.params
 
@@ -22,6 +38,41 @@ export const GET = async (req: MedusaRequest, res: MedusaResponse) => {
     throw new MedusaError(
       MedusaError.Types.NOT_FOUND,
       `Payment submission not found: ${id}`
+    )
+  }
+
+  const items: any[] = (submission as any).items || []
+
+  const query: any = req.scope.resolve(ContainerRegistrationKeys.QUERY)
+  const resolved = await resolvePaymentEntities(query, {
+    partnerIds: [(submission as any).partner_id],
+    ...collectLineRefs(items),
+  })
+
+  /**
+   * Attached alongside the ids, never in place of them. A screen that lost the
+   * id would have nothing to fall back to when a name cannot be resolved, and
+   * an unresolvable design is exactly the case that must still render.
+   */
+  ;(submission as any).partner =
+    resolved.partners.get((submission as any).partner_id) ?? null
+
+  for (const item of items) {
+    item.design = item.design_id
+      ? resolved.designs.get(item.design_id) ?? null
+      : null
+    item.order = item.order_id ? resolved.orders.get(item.order_id) ?? null : null
+    item.inventory_order = item.inventory_order_id
+      ? resolved.inventoryOrders.get(item.inventory_order_id) ?? null
+      : null
+    /**
+     * Every run this line pays for, in order, with the ones that could not be
+     * resolved kept as a bare id — a deleted run must not silently shrink the
+     * list a payout says it covers.
+     */
+    item.runs = ((item.production_run_ids || []) as string[]).map(
+      (runId) =>
+        resolved.runs.get(runId) ?? { id: runId, name: runId, detail: null }
     )
   }
 

--- a/apps/backend/src/api/admin/payment-submissions/lib/resolve-payment-entities.ts
+++ b/apps/backend/src/api/admin/payment-submissions/lib/resolve-payment-entities.ts
@@ -1,0 +1,168 @@
+/**
+ * Turn the ids on a payout into things a human recognises (#1622).
+ *
+ * 🔴 Every payout screen currently renders raw ULIDs. `partner_id` on the
+ * submission detail is the sharpest case: the one field naming WHO is being
+ * paid renders as `01K4PJMNMNRGMK0ZXMKBBDZDGD`, so the page cannot be read
+ * without a second lookup — and the reconciliation table repeats it per row.
+ *
+ * Best-effort, and per entity. A design that has since been deleted, or a link
+ * that never synced, must leave that one name unresolved rather than blanking
+ * the page: a payout is a record of money, and it has to render even when the
+ * thing it paid for is gone. Callers fall back to the id.
+ */
+
+export type ResolvedRef = {
+  id: string
+  /** What to show. Never an id — a caller that gets no name shows the id itself. */
+  name: string
+  /** Extra context worth putting next to the name, if the entity has any. */
+  detail?: string | null
+}
+
+export type ResolvedPaymentEntities = {
+  partners: Map<string, ResolvedRef>
+  designs: Map<string, ResolvedRef>
+  runs: Map<string, ResolvedRef>
+  orders: Map<string, ResolvedRef>
+  inventoryOrders: Map<string, ResolvedRef>
+}
+
+const empty = (): ResolvedPaymentEntities => ({
+  partners: new Map(),
+  designs: new Map(),
+  runs: new Map(),
+  orders: new Map(),
+  inventoryOrders: new Map(),
+})
+
+const uniq = (ids: (string | null | undefined)[]): string[] =>
+  Array.from(new Set(ids.filter((id): id is string => !!id)))
+
+/** One entity's lookup, isolated so a failure costs only that entity's names. */
+const lookup = async (
+  query: any,
+  entity: string,
+  ids: string[],
+  fields: string[]
+): Promise<any[]> => {
+  if (!ids.length) return []
+  try {
+    const { data } = await query.graph({
+      entity,
+      fields,
+      filters: { id: ids },
+    })
+    return (data || []) as any[]
+  } catch {
+    return []
+  }
+}
+
+export const resolvePaymentEntities = async (
+  query: any,
+  input: {
+    partnerIds?: (string | null | undefined)[]
+    designIds?: (string | null | undefined)[]
+    runIds?: (string | null | undefined)[]
+    orderIds?: (string | null | undefined)[]
+    inventoryOrderIds?: (string | null | undefined)[]
+  }
+): Promise<ResolvedPaymentEntities> => {
+  if (!query) return empty()
+
+  const [partners, designs, runs, orders, inventoryOrders] = await Promise.all([
+    lookup(query, "partners", uniq(input.partnerIds || []), [
+      "id",
+      "name",
+      "handle",
+    ]),
+    lookup(query, "designs", uniq(input.designIds || []), [
+      "id",
+      "name",
+      "status",
+    ]),
+    lookup(query, "production_runs", uniq(input.runIds || []), [
+      "id",
+      "status",
+      "quantity",
+      "produced_quantity",
+    ]),
+    lookup(query, "order", uniq(input.orderIds || []), ["id", "display_id"]),
+    lookup(query, "inventory_orders", uniq(input.inventoryOrderIds || []), [
+      "id",
+      "status",
+      "total_price",
+    ]),
+  ])
+
+  const out = empty()
+
+  for (const p of partners) {
+    out.partners.set(p.id, {
+      id: p.id,
+      name: p.name || p.handle || p.id,
+      detail: p.handle || null,
+    })
+  }
+
+  for (const d of designs) {
+    out.designs.set(d.id, {
+      id: d.id,
+      name: d.name || d.id,
+      detail: d.status || null,
+    })
+  }
+
+  for (const r of runs) {
+    /**
+     * Produced, not ordered — a run that shipped 7 of 9 is paid for 7, and the
+     * difference is the whole subject of #1596. Showing the ordered figure next
+     * to a payout would explain the wrong number.
+     */
+    const produced = Number(r.produced_quantity)
+    const ordered = Number(r.quantity)
+    const made = Number.isFinite(produced) && produced > 0 ? produced : null
+
+    out.runs.set(r.id, {
+      id: r.id,
+      name: `Run ${String(r.id).slice(-6)}`,
+      detail: [
+        r.status || null,
+        made != null
+          ? `${made} made${Number.isFinite(ordered) && ordered !== made ? ` of ${ordered}` : ""}`
+          : Number.isFinite(ordered)
+            ? `${ordered} ordered`
+            : null,
+      ]
+        .filter(Boolean)
+        .join(" · "),
+    })
+  }
+
+  for (const o of orders) {
+    out.orders.set(o.id, {
+      id: o.id,
+      name: o.display_id ? `Order #${o.display_id}` : `Order ${String(o.id).slice(-6)}`,
+      detail: null,
+    })
+  }
+
+  for (const io of inventoryOrders) {
+    out.inventoryOrders.set(io.id, {
+      id: io.id,
+      name: `Inventory order ${String(io.id).slice(-6)}`,
+      detail: io.status || null,
+    })
+  }
+
+  return out
+}
+
+/** The ids a set of payout LINES refers to, ready for `resolvePaymentEntities`. */
+export const collectLineRefs = (items: any[]) => ({
+  designIds: (items || []).map((i) => i?.design_id),
+  orderIds: (items || []).map((i) => i?.order_id),
+  inventoryOrderIds: (items || []).map((i) => i?.inventory_order_id),
+  runIds: (items || []).flatMap((i) => (i?.production_run_ids || []) as string[]),
+})

--- a/apps/backend/src/api/admin/payment-submissions/payable-runs/route.ts
+++ b/apps/backend/src/api/admin/payment-submissions/payable-runs/route.ts
@@ -7,6 +7,7 @@ import { isProvenanceRun } from "../../../../workflows/consumption-logs/lib/reco
 import { runUnitCost } from "../../../../workflows/production-runs/lib/run-payable"
 import { listPartnerSubmissionItems } from "../../../../workflows/payment_submissions/lib/run-claims"
 import { groupOrderBackedRuns } from "../../../../workflows/payment_submissions/lib/order-run-groups"
+import { foldPartnerBilling } from "../../../../workflows/payment_submissions/lib/run-billing"
 
 /**
  * GET /admin/payment-submissions/payable-runs?partner_id=…
@@ -264,63 +265,16 @@ export const GET = async (req: MedusaRequest, res: MedusaResponse) => {
     ((designs || []) as any[]).map((d) => [d.id, d])
   )
 
-  const billedRuns = new Map<
-    string,
-    { submission_id: string; status: string; quantity: number }
-  >()
-  const designsWithOpenSubmission = new Set<string>()
   /**
-   * Designs carrying a live payout that does not say which run it paid for.
-   *
-   * 🔴 These are the rows that made the guard a fiction. A line with
-   * `run_provenance: "not_recorded"` pays for run work, is not Rejected, and
-   * names no run — so for every completed run of that design, "is this already
-   * paid for?" has no answer. Reporting `billed: null` for those runs said
-   * "no", and the screen sorted them to the top as clean, payable work.
-   *
-   * A `no_run` line (a task payout) is deliberately NOT collected here: that
-   * is the one case where a missing run is an answer rather than a gap.
+   * 🔴 The fold lives in `lib/run-billing.ts`, not here. #1622 asks the same
+   * question from the run's own page, and a second copy of "is this run
+   * billed" is how two screens start disagreeing about whether someone gets
+   * paid twice. The rules — a Rejected submission releases its runs, the first
+   * live claim wins, a `not_recorded` line is DOUBT rather than a clearance —
+   * are stated there, once.
    */
-  const designsWithUnrecordedClaims = new Map<
-    string,
-    { submission_id: string; status: string; amount: number }[]
-  >()
-  const OPEN_STATUSES = new Set([
-    "Draft",
-    "Pending",
-    "Under_Review",
-  ])
-
-  for (const item of priorItems || []) {
-    const status = String(item.submission?.status || "")
-    // A Rejected submission never paid anyone — its lines release their runs.
-    if (status === "Rejected") continue
-
-    if (OPEN_STATUSES.has(status) && item.design_id) {
-      designsWithOpenSubmission.add(String(item.design_id))
-    }
-
-    if (item.run_provenance === "not_recorded" && item.design_id) {
-      const designId = String(item.design_id)
-      const claims = designsWithUnrecordedClaims.get(designId) || []
-      claims.push({
-        submission_id: String(item.submission?.id || item.submission_id || ""),
-        status,
-        amount: Number(item.amount ?? 0),
-      })
-      designsWithUnrecordedClaims.set(designId, claims)
-    }
-
-    for (const runId of (item.production_run_ids || []) as string[]) {
-      if (!billedRuns.has(runId)) {
-        billedRuns.set(runId, {
-          submission_id: String(item.submission?.id || item.submission_id || ""),
-          status,
-          quantity: Number(item.quantity ?? 1),
-        })
-      }
-    }
-  }
+  const { billedRuns, designsWithUnrecordedClaims, designsWithOpenSubmission } =
+    foldPartnerBilling(priorItems as any[])
 
   const payable_runs = completedRuns
     .map((run) => {

--- a/apps/backend/src/api/admin/payment_reports/reconciliation/route.ts
+++ b/apps/backend/src/api/admin/payment_reports/reconciliation/route.ts
@@ -1,7 +1,11 @@
 import type { MedusaRequest, MedusaResponse } from "@medusajs/framework/http"
-import { MedusaError } from "@medusajs/framework/utils"
+import {
+  ContainerRegistrationKeys,
+  MedusaError,
+} from "@medusajs/framework/utils"
 import { PAYMENT_REPORTS_MODULE } from "../../../../modules/payment_reports"
 import Payment_reportsService from "../../../../modules/payment_reports/service"
+import { resolvePaymentEntities } from "../../payment-submissions/lib/resolve-payment-entities"
 
 // GET /admin/payment_reports/reconciliation — list reconciliation records
 export const GET = async (req: MedusaRequest, res: MedusaResponse) => {
@@ -43,6 +47,54 @@ export const GET = async (req: MedusaRequest, res: MedusaResponse) => {
       if (period_end && created > new Date(period_end).getTime()) return false
       return true
     })
+  }
+
+  /**
+   * Resolved names alongside the ids (#1622).
+   *
+   * The table rendered `partner_id` and `source_id` as raw ULIDs, one per row —
+   * the reconciliation screen is where a discrepancy is chased, and a column of
+   * indistinguishable ids is the least useful place to do it. `source_id` is
+   * resolved by `source_type`, so an `inventory_order` row names the order and a
+   * `run` row names the run; a `mixed` payout keeps a null source by design and
+   * simply has no name to show.
+   *
+   * Best-effort throughout — see `resolvePaymentEntities`. A record of money
+   * must render even when what it paid for is gone.
+   */
+  const query: any = req.scope.resolve(ContainerRegistrationKeys.QUERY)
+  const resolved = await resolvePaymentEntities(query, {
+    partnerIds: filtered.map((r: any) => r.partner_id),
+    designIds: filtered
+      .filter((r: any) => r.source_type === "design")
+      .map((r: any) => r.source_id),
+    runIds: filtered
+      .filter((r: any) => r.source_type === "run")
+      .map((r: any) => r.source_id),
+    inventoryOrderIds: filtered
+      .filter((r: any) => r.source_type === "inventory_order")
+      .map((r: any) => r.source_id),
+  })
+
+  const sourceRef = (record: any) => {
+    if (!record.source_id) return null
+    switch (record.source_type) {
+      case "design":
+        return resolved.designs.get(record.source_id) ?? null
+      case "run":
+        return resolved.runs.get(record.source_id) ?? null
+      case "inventory_order":
+        return resolved.inventoryOrders.get(record.source_id) ?? null
+      default:
+        return null
+    }
+  }
+
+  for (const record of filtered as any[]) {
+    record.partner = record.partner_id
+      ? resolved.partners.get(record.partner_id) ?? null
+      : null
+    record.source = sourceRef(record)
   }
 
   return res.status(200).json({

--- a/apps/backend/src/api/admin/production-runs/[id]/payments/route.ts
+++ b/apps/backend/src/api/admin/production-runs/[id]/payments/route.ts
@@ -1,0 +1,119 @@
+/**
+ * @route /admin/production-runs/:id/payments
+ * @scope admin
+ *
+ * Whether this run has been billed, and by which payout (#1622).
+ *
+ * 🔴 The run does not know it has been billed. `payable-runs` computes exactly
+ * this and drops it the moment its list is rendered, so the only place to learn
+ * that a completed run was already paid for is a screen listing OTHER runs.
+ * Anyone standing on the run itself sees nothing.
+ *
+ * The answer comes from `foldPartnerBilling`, the same fold `payable-runs` now
+ * uses, so the two surfaces cannot disagree about who holds a run — and it is
+ * scoped by PARTNER, not design, because a run-sourced line carries
+ * `design_id: null` and a design-scoped query cannot see it (see `run-claims`).
+ *
+ * Response: { run_id, partner_id, billing_status, claim, unrecorded_claims, lines }
+ */
+import type { MedusaRequest, MedusaResponse } from "@medusajs/framework/http"
+import { MedusaError } from "@medusajs/framework/utils"
+
+import { PAYMENT_SUBMISSIONS_MODULE } from "../../../../../modules/payment_submissions"
+import type PaymentSubmissionsService from "../../../../../modules/payment_submissions/service"
+import { PRODUCTION_RUNS_MODULE } from "../../../../../modules/production_runs"
+import { listPartnerSubmissionItems } from "../../../../../workflows/payment_submissions/lib/run-claims"
+import {
+  foldPartnerBilling,
+  runBillingStatus,
+} from "../../../../../workflows/payment_submissions/lib/run-billing"
+
+export const GET = async (req: MedusaRequest, res: MedusaResponse) => {
+  const { id } = req.params
+
+  const runService: any = req.scope.resolve(PRODUCTION_RUNS_MODULE)
+  const run = await runService.retrieveProductionRun(id).catch(() => null)
+
+  if (!run) {
+    throw new MedusaError(
+      MedusaError.Types.NOT_FOUND,
+      `Production run ${id} not found`
+    )
+  }
+
+  /**
+   * ⚠️ No partner means the claim is UNKNOWABLE, not absent. A claim lives on a
+   * partner's submissions, so with no partner there is nowhere to look —
+   * and answering "unbilled" would be absence read as permission, which is the
+   * exact shape of #1557 and #1565. `unknown` already means "a human has to
+   * establish this before money moves", which is the right instruction here.
+   */
+  if (!run.partner_id) {
+    return res.status(200).json({
+      run_id: id,
+      partner_id: null,
+      billing_status: "unknown",
+      claim: null,
+      unrecorded_claims: [],
+      lines: [],
+    })
+  }
+
+  const service: PaymentSubmissionsService = req.scope.resolve(
+    PAYMENT_SUBMISSIONS_MODULE
+  )
+
+  const priorItems = await listPartnerSubmissionItems(
+    service as any,
+    run.partner_id
+  )
+
+  const { billedRuns, designsWithUnrecordedClaims } =
+    foldPartnerBilling(priorItems)
+
+  const claim = billedRuns.get(String(id)) ?? null
+  const unrecorded_claims = run.design_id
+    ? designsWithUnrecordedClaims.get(String(run.design_id)) ?? []
+    : []
+
+  /**
+   * Every line naming this run, not only the winning claim. A run billed on one
+   * submission and rejected on another has a history worth seeing, and the fold
+   * deliberately keeps only the first live claim.
+   */
+  const lines = (priorItems || [])
+    .filter((item: any) =>
+      ((item.production_run_ids || []) as string[]).includes(String(id))
+    )
+    .map((item: any) => ({
+      submission_id: item.submission?.id ?? item.submission_id ?? null,
+      submission_status: item.submission?.status ?? null,
+      amount: item.amount ?? null,
+      quantity: item.quantity ?? null,
+      unit_amount: item.unit_amount ?? null,
+      run_provenance: item.run_provenance ?? null,
+      /** What `describePaymentLine` needs, so the badge uses the shared words. */
+      source_type: item.source_type ?? null,
+      design_id: item.design_id ?? null,
+      design_name: item.design_name ?? null,
+      task_id: item.task_id ?? null,
+      task_name: item.task_name ?? null,
+      inventory_order_id: item.inventory_order_id ?? null,
+      inventory_order_name: item.inventory_order_name ?? null,
+      order_id: item.order_id ?? null,
+      production_run_ids: item.production_run_ids ?? null,
+    }))
+
+  return res.status(200).json({
+    run_id: id,
+    partner_id: run.partner_id,
+    /** Branch on this, never on `claim == null` — see `runBillingStatus`. */
+    billing_status: runBillingStatus({
+      billed: claim,
+      unrecordedClaims: unrecorded_claims,
+    }),
+    claim,
+    unrecorded_claims,
+    lines,
+  })
+}

--- a/apps/backend/src/workflows/payment_submissions/lib/__tests__/run-billing.unit.spec.ts
+++ b/apps/backend/src/workflows/payment_submissions/lib/__tests__/run-billing.unit.spec.ts
@@ -1,0 +1,122 @@
+import {
+  foldPartnerBilling,
+  runBillingStatus,
+} from "../run-billing"
+
+/**
+ * The fold `payable-runs` used inline and `/admin/production-runs/:id/payments`
+ * now shares (#1622). Every rule here decides whether someone is paid twice.
+ */
+describe("foldPartnerBilling", () => {
+  const line = (over: Record<string, any> = {}) => ({
+    submission: { id: "sub_1", status: "Pending" },
+    design_id: "design_1",
+    amount: 1000,
+    quantity: 1,
+    run_provenance: "recorded",
+    production_run_ids: ["run_1"],
+    ...over,
+  })
+
+  it("claims the runs a live line names", () => {
+    const { billedRuns } = foldPartnerBilling([line()])
+
+    expect(billedRuns.get("run_1")).toEqual({
+      submission_id: "sub_1",
+      status: "Pending",
+      quantity: 1,
+    })
+  })
+
+  it("releases the runs of a REJECTED submission", () => {
+    // A rejected payout never paid anyone, so its runs are billable again.
+    const { billedRuns } = foldPartnerBilling([
+      line({ submission: { id: "sub_1", status: "Rejected" } }),
+    ])
+
+    expect(billedRuns.has("run_1")).toBe(false)
+  })
+
+  it("keeps the FIRST live claim when two lines name one run", () => {
+    const { billedRuns } = foldPartnerBilling([
+      line({ submission: { id: "sub_first", status: "Paid" } }),
+      line({ submission: { id: "sub_second", status: "Pending" } }),
+    ])
+
+    expect(billedRuns.get("run_1")?.submission_id).toBe("sub_first")
+  })
+
+  it("collects a not_recorded line as DOUBT on its design", () => {
+    // The #1565 case: a live payout for run work that never said which run.
+    const { designsWithUnrecordedClaims, billedRuns } = foldPartnerBilling([
+      line({ run_provenance: "not_recorded", production_run_ids: [] }),
+    ])
+
+    expect(billedRuns.size).toBe(0)
+    expect(designsWithUnrecordedClaims.get("design_1")).toEqual([
+      { submission_id: "sub_1", status: "Pending", amount: 1000 },
+    ])
+  })
+
+  it("does NOT treat a task payout's missing run as doubt", () => {
+    // `no_run` is the one case where absence is an answer.
+    const { designsWithUnrecordedClaims } = foldPartnerBilling([
+      line({ run_provenance: "no_run", production_run_ids: [] }),
+    ])
+
+    expect(designsWithUnrecordedClaims.size).toBe(0)
+  })
+
+  it("ignores a REJECTED not_recorded line", () => {
+    const { designsWithUnrecordedClaims } = foldPartnerBilling([
+      line({
+        run_provenance: "not_recorded",
+        production_run_ids: [],
+        submission: { id: "sub_1", status: "Rejected" },
+      }),
+    ])
+
+    expect(designsWithUnrecordedClaims.size).toBe(0)
+  })
+
+  it("marks a design with an in-flight payout as open, and a Paid one as not", () => {
+    const open = foldPartnerBilling([
+      line({ submission: { id: "s", status: "Under_Review" } }),
+    ])
+    const settled = foldPartnerBilling([
+      line({ submission: { id: "s", status: "Paid" } }),
+    ])
+
+    expect(open.designsWithOpenSubmission.has("design_1")).toBe(true)
+    expect(settled.designsWithOpenSubmission.has("design_1")).toBe(false)
+  })
+
+  it("reads the submission id off the line when the relation is not expanded", () => {
+    const { billedRuns } = foldPartnerBilling([
+      line({ submission: null, submission_id: "sub_flat" }),
+    ])
+
+    // Status is unknown without the relation — but it is not Rejected, so the
+    // claim still holds. Dropping it would report billed work as billable.
+    expect(billedRuns.get("run_1")?.submission_id).toBe("sub_flat")
+  })
+})
+
+describe("runBillingStatus", () => {
+  it("says billed when a claim holds the run", () => {
+    expect(
+      runBillingStatus({ billed: { submission_id: "s" }, unrecordedClaims: [] })
+    ).toBe("billed")
+  })
+
+  it("says unknown — never clear — when a payout records no run", () => {
+    // 🔴 The whole point: ignorance must not be spelled the same way as "no".
+    expect(
+      runBillingStatus({ billed: null, unrecordedClaims: [{}] })
+    ).toBe("unknown")
+  })
+
+  it("says clear only when every live payout named its runs", () => {
+    expect(runBillingStatus({ billed: null, unrecordedClaims: [] })).toBe("clear")
+  })
+})

--- a/apps/backend/src/workflows/payment_submissions/lib/run-billing.ts
+++ b/apps/backend/src/workflows/payment_submissions/lib/run-billing.ts
@@ -1,0 +1,121 @@
+/**
+ * Whether a completed run has already been paid for — folded ONCE (#1622).
+ *
+ * 🔴 This loop was inline in `payable-runs`, which is the only screen that has
+ * ever known the answer. #1622 puts the same question on the run itself, and a
+ * second implementation of "is this run billed" is how two screens start
+ * disagreeing about whether someone gets paid twice. The rules — a Rejected
+ * submission releases its runs, first live claim wins, a `not_recorded` line is
+ * DOUBT rather than a clearance — are stated here and nowhere else.
+ *
+ * See `run-claims.ts` for why the scope is the PARTNER: a run-sourced line
+ * carries `design_id: null`, so a design-scoped query cannot see it.
+ */
+
+export type PartnerLineLike = {
+  submission_id?: string | null
+  submission?: { id?: string | null; status?: string | null } | null
+  design_id?: string | null
+  amount?: number | string | null
+  quantity?: number | string | null
+  run_provenance?: string | null
+  production_run_ids?: string[] | null
+}
+
+export type RunBillingClaim = {
+  submission_id: string
+  status: string
+  quantity: number
+}
+
+export type UnrecordedClaim = {
+  submission_id: string
+  status: string
+  amount: number
+}
+
+/** Statuses where a payout is still in flight rather than settled. */
+const OPEN_STATUSES = new Set(["Draft", "Pending", "Under_Review"])
+
+export type PartnerBilling = {
+  /** run id → the earliest live line naming it. */
+  billedRuns: Map<string, RunBillingClaim>
+  /**
+   * Designs carrying a live payout that does not say which run it paid for.
+   *
+   * 🔴 These are the rows that made the guard a fiction. A line with
+   * `run_provenance: "not_recorded"` pays for run work, is not Rejected, and
+   * names no run — so for every completed run of that design, "is this already
+   * paid for?" has no answer. Reporting it as unbilled says "no", which is how
+   * the same garments get paid for twice.
+   *
+   * A `no_run` line (a task payout) is deliberately NOT collected: that is the
+   * one case where a missing run is an answer rather than a gap.
+   */
+  designsWithUnrecordedClaims: Map<string, UnrecordedClaim[]>
+  designsWithOpenSubmission: Set<string>
+}
+
+/** PURE: fold one partner's prior submission lines into what they claim. */
+export const foldPartnerBilling = (
+  priorItems: PartnerLineLike[]
+): PartnerBilling => {
+  const billedRuns = new Map<string, RunBillingClaim>()
+  const designsWithOpenSubmission = new Set<string>()
+  const designsWithUnrecordedClaims = new Map<string, UnrecordedClaim[]>()
+
+  for (const item of priorItems || []) {
+    const status = String(item.submission?.status || "")
+    // A Rejected submission never paid anyone — its lines release their runs.
+    if (status === "Rejected") continue
+
+    const submissionId = String(item.submission?.id || item.submission_id || "")
+
+    if (OPEN_STATUSES.has(status) && item.design_id) {
+      designsWithOpenSubmission.add(String(item.design_id))
+    }
+
+    if (item.run_provenance === "not_recorded" && item.design_id) {
+      const designId = String(item.design_id)
+      const claims = designsWithUnrecordedClaims.get(designId) || []
+      claims.push({
+        submission_id: submissionId,
+        status,
+        amount: Number(item.amount ?? 0),
+      })
+      designsWithUnrecordedClaims.set(designId, claims)
+    }
+
+    for (const runId of (item.production_run_ids || []) as string[]) {
+      // First writer wins, so the reported claim is the earliest live one.
+      if (!billedRuns.has(runId)) {
+        billedRuns.set(runId, {
+          submission_id: submissionId,
+          status,
+          quantity: Number(item.quantity ?? 1),
+        })
+      }
+    }
+  }
+
+  return { billedRuns, designsWithUnrecordedClaims, designsWithOpenSubmission }
+}
+
+/**
+ * The single field a caller should branch on, so that "we don't know" cannot be
+ * spelled the same way as "no".
+ *
+ * - `billed`  — a payment line names this run. Do not pay again.
+ * - `unknown` — a live payout for this design records no run, so this run may
+ *               already be inside it. Needs a human before it is paid; #1565 is
+ *               the whole reason this value exists.
+ * - `clear`   — every live payout for this design says which runs it covered,
+ *               and none of them is this one. Safe to bill.
+ */
+export type RunBillingStatus = "billed" | "unknown" | "clear"
+
+export const runBillingStatus = (input: {
+  billed: unknown
+  unrecordedClaims: unknown[]
+}): RunBillingStatus =>
+  input.billed ? "billed" : input.unrecordedClaims?.length ? "unknown" : "clear"


### PR DESCRIPTION
Closes #1622.

Every payout now records what it is for. What was missing was the view from the other direction: standing on the thing the money was for and seeing the money. All four surfaces the issue names are here, plus the readability fix the founder asked for on the two screens that already existed.

## The four surfaces

| where | before | now |
|---|---|---|
| inventory order | a panel that read the approval-time link, so 3 of the 4 prod payouts rendered "No payments to show yet" | `GET /admin/inventory-orders/:id/payments` reads the submission LINES — every status, no backfill |
| production run | nothing; `payable-runs` knew and never said | `GET /admin/production-runs/:id/payments` + a Billing field on the run page |
| retail order | nothing | `GET /admin/orders/:id/partner-payouts` + a widget |
| partner | nothing | a Payouts section with paid / outstanding totals |

### Why lines, not links

`linkPaymentToInventoryOrderStep` draws its link only when a payout is **approved**, and only since #1621. `payment_submission_item.inventory_order_id` has named the order from the moment the line was written, at every status. Reading the line answers for Draft, Pending, Paid and pre-link rows alike — and the backfill #1622 called for is no longer needed for the read path.

Reading the ITEMS rather than the reconciliation is also what keeps a `mixed`-source payout visible from every order it touches, exactly as the issue warns.

## Stop rendering ULIDs

The founder's second ask. `resolvePaymentEntities` resolves partner, design, run, order and inventory order to names — best-effort per entity, so a deleted design leaves one name unresolved rather than blanking a record of money.

- Submission detail: `Partner ID: 01K4PJMNMN…` is a named link; the Reference column becomes **Links** — the design, the retail order, the inventory order, and *every* run, each reachable. A run-sourced line said "7 run(s)" and gave no way to reach one of them.
- Reconciliation: partner named and linked, plus a **Source** column resolving `source_id` by `source_type`. A `mixed` payout keeps its null source by design and shows the type alone rather than being made to point at one of the several things it covered.

## One rule, one place

- `foldPartnerBilling` (`lib/run-billing.ts`) — the "is this run billed" fold moves out of `payable-runs`, which now calls it. A second copy is how two screens start disagreeing about whether someone gets paid twice. 11 unit cases, including that `unknown` never renders as "not billed" (#1565).
- `foldOrderPayouts` — pure, 7 unit cases: a line bills the order its OWN amount rather than the submission total (hrhandloom's payout covers two orders); `Approved` is not counted as paid, since `markSubmissionPaidStep` is what makes it Paid; a line whose submission is missing is kept with a null status rather than dropped.
- `paymentSubmissionStatusColor` — `submissions-tab` had the switch inline and #1622 adds more surfaces. `reconciliation-tab` deliberately keeps its own vocabulary; it colours `Settled` differently and is not a copy.

## Fixed in passing

`PaymentSubmissionItem.source_type` in the admin types read `design | task` while the column has offered four values since #1614 — the same two-of-four blindness that made whole payouts render nowhere in #1621.

## Verification

- Targeted specs green (43 tests across the touched suites). Full suite left to CI.
- `tsc` at the 280-line baseline, confirmed by stashing to a clean tree.
- `check:prod-build` passes.
- Not yet exercised against prod — the routes are new, so verify after deploy by probing behaviour rather than the badge.

## Still open

- The inventory-order↔payment link backfill. No longer blocking the read path, but the link itself is still forward-only.
- `markSubmissionPaidStep` writes only `status: "Paid"` — never `paid_at`, `payment_type` or `paid_to_id`. All four prod payouts read Paid with those null.
- One payout is still three records with three statuses (#1622 does not reconcile them; that is a behaviour change and the founder's call).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01TLt1f38xqR8k2myCVxP8e4