### PR TITLE
feat(ops): backfill the payment→inventory-order links for payouts approved before #1621 (#1622)

### DIFF
--- a/apps/backend/src/api/admin/ops/maintenance-jobs/__tests__/backfill-inventory-order-payment-links.unit.spec.ts
+++ b/apps/backend/src/api/admin/ops/maintenance-jobs/__tests__/backfill-inventory-order-payment-links.unit.spec.ts
@@ -1,0 +1,223 @@
+import { backfillInventoryOrderPaymentLinksJob } from "../backfill-inventory-order-payment-links-job"
+
+/**
+ * #1622 — the edge from a payment to the inventory order it paid for, for the
+ * payouts approved before #1621 wired it into approval.
+ *
+ * Driven against a fake container so the WRITE SHAPE is asserted, not just the
+ * decision to write. `link.create` is not idempotent, so "would it write twice"
+ * is the question that matters most here.
+ */
+
+const ORDER_A = "inv_order_a"
+const ORDER_B = "inv_order_b"
+const PAYMENT = "pay_1"
+
+type Item = Record<string, any>
+
+const makeContainer = (opts: {
+  items: Item[]
+  /** submission id → payment ids the submission↔payment link holds. */
+  payments?: Record<string, string[]>
+  /** inventory order id → payment ids ALREADY linked to it. */
+  linked?: Record<string, string[]>
+}) => {
+  const linkCreate = jest.fn().mockResolvedValue(undefined)
+
+  const query = {
+    graph: jest.fn(async ({ entity, filters }: any) => {
+      if (entity === "payment_submission") {
+        const ids = opts.payments?.[filters.id] ?? []
+        return { data: [{ id: filters.id, payments: ids.map((id) => ({ id })) }] }
+      }
+      if (entity === "inventory_orders") {
+        const ids = opts.linked?.[filters.id] ?? []
+        return {
+          data: [
+            { id: filters.id, internal_payments: ids.map((id) => ({ id })) },
+          ],
+        }
+      }
+      return { data: [] }
+    }),
+  }
+
+  const container = {
+    resolve: (key: string) => {
+      if (key === "query") return query
+      if (key === "link" || key === "remoteLink") return { create: linkCreate }
+      return {
+        listPaymentSubmissionItems: jest.fn().mockResolvedValue(opts.items),
+      }
+    },
+  } as any
+
+  return { container, linkCreate }
+}
+
+const line = (over: Item = {}): Item => ({
+  id: "line_1",
+  inventory_order_id: ORDER_A,
+  submission: { id: "sub_1", status: "Paid", partner_id: "partner_1" },
+  ...over,
+})
+
+describe("backfill-inventory-order-payment-links", () => {
+  it("links a payment to the order its own line names", async () => {
+    const { container, linkCreate } = makeContainer({
+      items: [line()],
+      payments: { sub_1: [PAYMENT] },
+    })
+
+    const result = await backfillInventoryOrderPaymentLinksJob.run(container, {
+      dry_run: false,
+      params: {},
+    } as any)
+
+    expect(result.changes).toHaveLength(1)
+    expect(linkCreate).toHaveBeenCalledTimes(1)
+    expect(linkCreate.mock.calls[0][0]).toEqual([
+      {
+        inventory_orders: { inventory_orders_id: ORDER_A },
+        internal_payments: { internal_payments_id: PAYMENT },
+      },
+    ])
+  })
+
+  it("writes nothing on a dry run", async () => {
+    const { container, linkCreate } = makeContainer({
+      items: [line()],
+      payments: { sub_1: [PAYMENT] },
+    })
+
+    const result = await backfillInventoryOrderPaymentLinksJob.run(container, {
+      dry_run: true,
+      params: {},
+    } as any)
+
+    expect(result.changes).toHaveLength(1)
+    expect(result.applied).toBe(false)
+    expect(linkCreate).not.toHaveBeenCalled()
+  })
+
+  it("does NOT redraw an edge that already exists", async () => {
+    // 🔴 link.create is not idempotent — a second call is a duplicate row.
+    const { container, linkCreate } = makeContainer({
+      items: [line()],
+      payments: { sub_1: [PAYMENT] },
+      linked: { [ORDER_A]: [PAYMENT] },
+    })
+
+    const result = await backfillInventoryOrderPaymentLinksJob.run(container, {
+      dry_run: false,
+      params: {},
+    } as any)
+
+    expect(result.changes).toHaveLength(0)
+    expect(linkCreate).not.toHaveBeenCalled()
+    expect(result.summary).toContain("1 edge(s) already exist")
+  })
+
+  it("writes one edge when two lines name the SAME order in one pass", async () => {
+    // The in-memory view must be updated as it writes, or the second line
+    // re-reads a stale "not linked" and duplicates the row.
+    const { container, linkCreate } = makeContainer({
+      items: [line(), line({ id: "line_2" })],
+      payments: { sub_1: [PAYMENT] },
+    })
+
+    await backfillInventoryOrderPaymentLinksJob.run(container, {
+      dry_run: false,
+      params: {},
+    } as any)
+
+    expect(linkCreate).toHaveBeenCalledTimes(1)
+  })
+
+  it("links the payment to EVERY order a multi-source payout names", async () => {
+    // hrhandloom's real payout: two inventory orders, one submission. Linking
+    // only the first makes the second invisible from its own page again.
+    const { container, linkCreate } = makeContainer({
+      items: [line(), line({ id: "line_2", inventory_order_id: ORDER_B })],
+      payments: { sub_1: [PAYMENT] },
+    })
+
+    const result = await backfillInventoryOrderPaymentLinksJob.run(container, {
+      dry_run: false,
+      params: {},
+    } as any)
+
+    expect(result.changes.map((c) => c.id).sort()).toEqual([
+      `${ORDER_A}:${PAYMENT}`,
+      `${ORDER_B}:${PAYMENT}`,
+    ])
+    expect(linkCreate).toHaveBeenCalledTimes(2)
+  })
+
+  it("SKIPS a payout with no payment record, and says so", async () => {
+    // A Pending payout naming an order is a real state. The edge is
+    // payment→order and there is no payment; silence would read as "linked".
+    const { container, linkCreate } = makeContainer({
+      items: [line({ submission: { id: "sub_1", status: "Pending" } })],
+      payments: { sub_1: [] },
+    })
+
+    const result = await backfillInventoryOrderPaymentLinksJob.run(container, {
+      dry_run: false,
+      params: {},
+    } as any)
+
+    expect(result.changes).toHaveLength(0)
+    expect(linkCreate).not.toHaveBeenCalled()
+    expect(result.summary).toContain("no payment record yet")
+    expect(result.summary).toContain("sub_1 (Pending)")
+  })
+
+  it("ignores lines that name no inventory order", async () => {
+    const { container, linkCreate } = makeContainer({
+      items: [line({ inventory_order_id: null, design_id: "design_1" })],
+      payments: { sub_1: [PAYMENT] },
+    })
+
+    const result = await backfillInventoryOrderPaymentLinksJob.run(container, {
+      dry_run: false,
+      params: {},
+    } as any)
+
+    expect(result.changes).toHaveLength(0)
+    expect(linkCreate).not.toHaveBeenCalled()
+    expect(result.summary).toContain("No inventory order is missing its payment link")
+  })
+
+  it("stops at the limit", async () => {
+    const { container, linkCreate } = makeContainer({
+      items: [line(), line({ id: "line_2", inventory_order_id: ORDER_B })],
+      payments: { sub_1: [PAYMENT] },
+    })
+
+    await backfillInventoryOrderPaymentLinksJob.run(container, {
+      dry_run: false,
+      params: { limit: 1 },
+    } as any)
+
+    expect(linkCreate).toHaveBeenCalledTimes(1)
+  })
+
+  it("does not let one failure strand the rest of the pass", async () => {
+    const { container, linkCreate } = makeContainer({
+      items: [line(), line({ id: "line_2", inventory_order_id: ORDER_B })],
+      payments: { sub_1: [PAYMENT] },
+    })
+    linkCreate.mockRejectedValueOnce(new Error("link exploded"))
+
+    const result = await backfillInventoryOrderPaymentLinksJob.run(container, {
+      dry_run: false,
+      params: {},
+    } as any)
+
+    expect(result.errors).toHaveLength(1)
+    expect(result.errors?.[0]?.message).toBe("link exploded")
+    // The second order still got its edge.
+    expect(linkCreate).toHaveBeenCalledTimes(2)
+  })
+})

--- a/apps/backend/src/api/admin/ops/maintenance-jobs/backfill-inventory-order-payment-links-job.ts
+++ b/apps/backend/src/api/admin/ops/maintenance-jobs/backfill-inventory-order-payment-links-job.ts
@@ -1,0 +1,243 @@
+import { ContainerRegistrationKeys, MedusaError } from "@medusajs/framework/utils"
+import { z } from "@medusajs/framework/zod"
+import { LinkDefinition } from "@medusajs/framework/types"
+import type { Link } from "@medusajs/modules-sdk"
+
+import { INTERNAL_PAYMENTS_MODULE } from "../../../../modules/internal_payments"
+import { ORDER_INVENTORY_MODULE } from "../../../../modules/inventory_orders"
+import { PAYMENT_SUBMISSIONS_MODULE } from "../../../../modules/payment_submissions"
+import type PaymentSubmissionsService from "../../../../modules/payment_submissions/service"
+import type { MaintenanceChange, MaintenanceJob, MaintenanceJobResult } from "./registry"
+
+/**
+ * Data Plumbing — draw the edge from a payment to the inventory order it paid
+ * for, for the payouts approved BEFORE that edge existed (#1622).
+ *
+ * `links/inventory-orders-internal-payments.ts` was declared long ago and
+ * nothing ever wrote it. #1621 wired `linkPaymentToInventoryOrderStep` into
+ * approval, so every payout approved from then on draws its own edge — but the
+ * payouts already approved keep showing no payment on their order.
+ *
+ * ⚠️ It records something that ALREADY HAPPENED. It creates no submission,
+ * approves nothing, changes no amount, and moves no money. It draws a
+ * navigational edge between two rows that already exist.
+ *
+ * ## It transcribes; it does not deduce
+ *
+ * 🔴 The order comes from the submission's OWN LINES — `inventory_order_id` on
+ * `payment_submission_item`, which the create path wrote at the time. It is
+ * never guessed from an amount that happens to match, or from a partner who
+ * happens to have one open order. A wrong edge here says a specific order was
+ * paid for when it was not, which is worse than no edge at all: an absent edge
+ * is visibly absent, while a wrong one reads as fact.
+ *
+ * 🔴 A submission naming SEVERAL inventory orders links its payment to each of
+ * them. That is deliberate and matches what approval now does — the payment
+ * genuinely paid for all of them, and reconciliation already records such a
+ * payout as `mixed` with a null source precisely because no single one is the
+ * answer. Linking to only the first would make the rest invisible again.
+ *
+ * A submission with no payment record yet (Draft, Pending, Rejected) is
+ * SKIPPED, not linked: the link is payment→order, and there is no payment.
+ *
+ * Never duplicates an edge that already exists — `link.create` is NOT
+ * idempotent, so every candidate is checked against the order's existing
+ * payments first. Safe to re-run.
+ */
+const paramsSchema = z.object({
+  /** One submission, for a spot check before a full pass. */
+  payment_submission_id: z.string().min(1).optional(),
+  /** Bound a first pass; omitted means every payout that needs one. */
+  limit: z.coerce.number().int().min(1).max(1000).optional(),
+})
+
+export const backfillInventoryOrderPaymentLinksJob: MaintenanceJob = {
+  id: "backfill-inventory-order-payment-links",
+  label: "Link existing payouts to the inventory orders they paid for",
+  description:
+    "Draw the missing payment→inventory-order edge for payouts approved before #1621 wired it into approval. links/inventory-orders-internal-payments.ts was declared long ago and nothing ever wrote it, so an inventory order paid for earlier shows no payment on its own page. The order is read from the submission's own lines (payment_submission_item.inventory_order_id), never guessed from a matching amount or a partner's open orders — a wrong edge claims a specific order was paid for and reads as fact, which is worse than an absent one. A submission naming several inventory orders links its payment to each, matching what approval now does. A submission with no payment record yet (Draft, Pending, Rejected) is skipped rather than linked, because the edge is payment→order and there is no payment. Records something that already happened: creates no submission, approves nothing, changes no amount, moves no money. Never duplicates an existing edge — link.create is not idempotent, so each candidate is checked against the order's current payments first. Safe to re-run.",
+  params: [
+    {
+      name: "payment_submission_id",
+      type: "string",
+      required: false,
+      description: "Only this submission, e.g. for a spot check before a full pass.",
+    },
+    {
+      name: "limit",
+      type: "number",
+      required: false,
+      description: "Stop after this many edges. Omit for every one that is missing.",
+    },
+  ],
+  run: async (container, { dry_run, params }): Promise<MaintenanceJobResult> => {
+    const parsed = paramsSchema.safeParse(params)
+    if (!parsed.success) {
+      throw new MedusaError(
+        MedusaError.Types.INVALID_DATA,
+        parsed.error.issues.map((i) => i.message).join("; ")
+      )
+    }
+
+    const service: PaymentSubmissionsService = container.resolve(
+      PAYMENT_SUBMISSIONS_MODULE
+    )
+    const query: any = container.resolve(ContainerRegistrationKeys.QUERY)
+    const remoteLink = container.resolve(ContainerRegistrationKeys.LINK) as Link
+
+    /**
+     * Lines that name an inventory order. Read from the LINE, which is where
+     * the create path recorded it — the reconciliation record collapses a
+     * multi-source payout to `mixed` with a null source and cannot answer this.
+     */
+    const items = (await (service as any).listPaymentSubmissionItems(
+      parsed.data.payment_submission_id
+        ? { submission_id: parsed.data.payment_submission_id }
+        : {},
+      { relations: ["submission"], take: null }
+    )) as any[]
+
+    if (parsed.data.payment_submission_id && !(items || []).length) {
+      throw new MedusaError(
+        MedusaError.Types.NOT_FOUND,
+        `Payment submission ${parsed.data.payment_submission_id} has no line items`
+      )
+    }
+
+    const withOrder = (items || []).filter((i) => !!i?.inventory_order_id)
+
+    const changes: MaintenanceChange[] = []
+    const errors: Array<{ id: string; message: string }> = []
+    /** Named an order but the payout has no payment record yet. */
+    const noPayment: Array<{ submission_id: string; status: string }> = []
+    let alreadyLinked = 0
+
+    /** submission id → its payment ids, resolved once per submission. */
+    const paymentsBySubmission = new Map<string, string[]>()
+    /** inventory order id → the payment ids already linked to it. */
+    const linkedByOrder = new Map<string, Set<string>>()
+
+    const paymentsFor = async (submissionId: string): Promise<string[]> => {
+      if (paymentsBySubmission.has(submissionId)) {
+        return paymentsBySubmission.get(submissionId)!
+      }
+      const { data } = await query.graph({
+        entity: "payment_submission",
+        fields: ["id", "payments.id"],
+        filters: { id: submissionId },
+      })
+      const raw = (data || [])[0]?.payments
+      const ids = (!raw ? [] : Array.isArray(raw) ? raw : [raw])
+        .map((p: any) => p?.id)
+        .filter(Boolean) as string[]
+      paymentsBySubmission.set(submissionId, ids)
+      return ids
+    }
+
+    const linkedFor = async (orderId: string): Promise<Set<string>> => {
+      if (linkedByOrder.has(orderId)) return linkedByOrder.get(orderId)!
+      const { data } = await query.graph({
+        entity: "inventory_orders",
+        fields: ["id", "internal_payments.id"],
+        filters: { id: orderId },
+      })
+      const raw = (data || [])[0]?.internal_payments
+      const ids = new Set(
+        (!raw ? [] : Array.isArray(raw) ? raw : [raw])
+          .map((p: any) => p?.id)
+          .filter(Boolean) as string[]
+      )
+      linkedByOrder.set(orderId, ids)
+      return ids
+    }
+
+    for (const item of withOrder) {
+      if (parsed.data.limit && changes.length >= parsed.data.limit) break
+
+      const submissionId = String(
+        item?.submission?.id || item?.submission_id || ""
+      )
+      const orderId = String(item.inventory_order_id)
+
+      try {
+        const paymentIds = submissionId ? await paymentsFor(submissionId) : []
+
+        if (!paymentIds.length) {
+          /**
+           * No payment exists, so there is nothing to link. Reported rather
+           * than silently dropped: a Pending payout naming an order is a real
+           * state, and a reader must not mistake this job's silence about it
+           * for "already linked".
+           */
+          noPayment.push({
+            submission_id: submissionId || "(unknown)",
+            status: String(item?.submission?.status || "unknown"),
+          })
+          continue
+        }
+
+        const existing = await linkedFor(orderId)
+
+        for (const paymentId of paymentIds) {
+          if (existing.has(paymentId)) {
+            alreadyLinked++
+            continue
+          }
+
+          changes.push({
+            entity: "inventory_order_internal_payment_link",
+            id: `${orderId}:${paymentId}`,
+            field: "link",
+            before: null,
+            after: { inventory_order_id: orderId, payment_id: paymentId },
+          })
+
+          if (!dry_run) {
+            const link: LinkDefinition = {
+              [ORDER_INVENTORY_MODULE]: { inventory_orders_id: orderId },
+              [INTERNAL_PAYMENTS_MODULE]: { internal_payments_id: paymentId },
+            }
+            await remoteLink.create([link])
+            // Keep the in-memory view honest so a second line naming the same
+            // order in this same pass does not write the edge twice.
+            existing.add(paymentId)
+          }
+        }
+      } catch (e: any) {
+        // One unlinkable payout must not strand the rest of the pass.
+        errors.push({
+          id: `${submissionId}:${orderId}`,
+          message: e?.message ?? String(e),
+        })
+      }
+    }
+
+    const parts: string[] = []
+    parts.push(
+      changes.length
+        ? `${dry_run ? "Would link" : "Linked"} ${changes.length} payment(s) to the inventory order(s) they paid for: ${changes
+            .map((c) => c.id)
+            .join("; ")}`
+        : "No inventory order is missing its payment link"
+    )
+    if (noPayment.length) {
+      parts.push(
+        `${noPayment.length} line(s) name an inventory order but their payout has no payment record yet — nothing to link: ${noPayment
+          .map((n) => `${n.submission_id} (${n.status})`)
+          .join(", ")}`
+      )
+    }
+    if (alreadyLinked) {
+      parts.push(`${alreadyLinked} edge(s) already exist`)
+    }
+
+    return {
+      job_id: "backfill-inventory-order-payment-links",
+      dry_run,
+      applied: !dry_run && changes.length > 0,
+      summary: parts.join(". ") + ".",
+      changes,
+      errors,
+    }
+  },
+}

--- a/apps/backend/src/api/admin/ops/maintenance-jobs/registry.ts
+++ b/apps/backend/src/api/admin/ops/maintenance-jobs/registry.ts
@@ -110,6 +110,7 @@ import { setLocationOwnershipJob } from "./set-location-ownership-job"
 import { resetNegativeInventoryLevelsJob } from "./reset-negative-inventory-levels-job"
 import { backfillDispatchedTemplateIdsJob } from "./backfill-dispatched-template-ids-job"
 import { backfillPaymentLineRunProvenanceJob } from "./backfill-payment-line-run-provenance-job"
+import { backfillInventoryOrderPaymentLinksJob } from "./backfill-inventory-order-payment-links-job"
 import { clearUnpriceableDesignCostsJob } from "./clear-unpriceable-design-costs-job"
 import { recordPaymentLineRunJob } from "./record-payment-line-run-job"
 import { deduplicateTaskTemplateNamesJob } from "./deduplicate-task-template-names-job"
@@ -5875,6 +5876,7 @@ export const MAINTENANCE_JOBS: MaintenanceJob[] = [
   deduplicateTaskTemplateNamesJob,
   backfillDispatchedTemplateIdsJob,
   backfillPaymentLineRunProvenanceJob,
+  backfillInventoryOrderPaymentLinksJob,
   clearUnpriceableDesignCostsJob,
   recordPaymentLineRunJob,
   recordManualInventoryCorrectionJob,


### PR DESCRIPTION
The second item on #1612's list, after #1625.

`links/inventory-orders-internal-payments.ts` has existed all along and nothing ever wrote it. #1621 wired `linkPaymentToInventoryOrderStep` into approval, so every payout approved from then on draws its own edge — the ones already approved still show no payment on their order.

This adds `backfill-inventory-order-payment-links` to the maintenance-job registry.

## It transcribes; it does not deduce

The order comes from the submission's **own line** — `payment_submission_item.inventory_order_id`, which the create path wrote at the time. Never from an amount that happens to match, never from a partner who happens to have one open order. A wrong edge claims a specific order was paid for and reads as fact, which is worse than an absent one: an absent edge is visibly absent.

It records something that already happened — creates no submission, approves nothing, changes no amount, moves no money.

## The three decisions worth checking

| case | behaviour | why |
|---|---|---|
| a payout naming **several** orders | links its payment to **each** | matches what approval now does; hrhandloom's payout covers two orders, and linking only the first makes the second invisible again |
| a payout with **no payment record** (Draft/Pending/Rejected) | skipped **and reported** | the edge is payment→order and there is no payment; silence would read as "already linked" |
| an edge that **already exists** | not redrawn | `link.create` is not idempotent — a second call is a duplicate row |

The in-memory view of an order's payments is updated as it writes, or a second line naming the same order **in the same pass** re-reads a stale "not linked" and duplicates the row. Both that and the already-linked case are covered.

## Verification

- 9 unit cases against a fake container, so the write **shape** is asserted (`{inventory_orders: {inventory_orders_id}, internal_payments: {internal_payments_id}}`), not just the decision to write. A dry run writes nothing; one failure does not strand the rest of the pass.
- `check:prod-build` passes. Note it caught a `strictNullChecks` error in the spec that a plain `tsc -p tsconfig.json` did not — the gate is the gate.

## After deploy

Dry-run first, then apply:

```
POST /admin/ops/maintenance-jobs/backfill-inventory-order-payment-links/run
{"dry_run": true}
```

Expect edges for GOF (`01M13MPTSC…`) and, once approved, hrhandloom (`01M13T8NVJ…`, two orders) and Parmar (`01M13T9D9A…`). The latter two are still Pending, so today they should come back under "no payment record yet" rather than as edges — which is itself the check that the skip works.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01TLt1f38xqR8k2myCVxP8e4