### PR TITLE
fix(payments): price a payout line from the run it names, not the design's estimate (#1616)

### DIFF
--- a/apps/backend/src/api/admin/payment-submissions/payable-runs/route.ts
+++ b/apps/backend/src/api/admin/payment-submissions/payable-runs/route.ts
@@ -4,7 +4,7 @@ import { ContainerRegistrationKeys, MedusaError } from "@medusajs/framework/util
 import { PAYMENT_SUBMISSIONS_MODULE } from "../../../../modules/payment_submissions"
 import PaymentSubmissionsService from "../../../../modules/payment_submissions/service"
 import { isProvenanceRun } from "../../../../workflows/consumption-logs/lib/reconcile-production-consumption"
-import { runUnitCost } from "../../../../workflows/production-runs/lib/run-payable"
+import { runPayableOffer } from "../../../../workflows/production-runs/lib/run-payable"
 import { listPartnerSubmissionItems } from "../../../../workflows/payment_submissions/lib/run-claims"
 import { groupOrderBackedRuns } from "../../../../workflows/payment_submissions/lib/order-run-groups"
 import { foldPartnerBilling } from "../../../../workflows/payment_submissions/lib/run-billing"
@@ -280,19 +280,20 @@ export const GET = async (req: MedusaRequest, res: MedusaResponse) => {
     .map((run) => {
       const design = designById.get(String(run.design_id))
 
-      // The per-unit rate the partner agreed, derived from the run rather than
-      // the design. `runUnitCost` divides a "total" cost_type back out and
-      // takes a "per_unit" one verbatim — one place, one convention.
-      const unit_amount = runUnitCost(run)
+      /**
+       * 🔴 The offer comes from `runPayableOffer`, which `create` now prices
+       * from too. These were two different pricers over one run: this screen
+       * offered ₹810 and create wrote the design's ₹1,056.40 for the same run
+       * (#1616). A figure an operator reads must be the figure that gets
+       * written when they act on it.
+       */
+      const offer = runPayableOffer(run)
+      const unit_amount = offer.unit_amount
+      const payable_quantity = offer.quantity
 
       const produced = Number(run.produced_quantity)
       const hasProduced = Number.isFinite(produced) && produced > 0
       const ordered = Number(run.quantity)
-      const payable_quantity = hasProduced
-        ? produced
-        : Number.isFinite(ordered) && ordered > 0
-          ? ordered
-          : 1
 
       return {
         run_id: String(run.id),
@@ -308,9 +309,9 @@ export const GET = async (req: MedusaRequest, res: MedusaResponse) => {
             : Number(run.rejected_quantity),
         /** What this row bills for: produced, or ordered when output was never recorded. */
         payable_quantity,
-        quantity_basis: hasProduced ? "produced" : "ordered",
+        quantity_basis: offer.quantity_basis,
         unit_amount,
-        amount: Math.round(unit_amount * payable_quantity * 100) / 100,
+        amount: offer.amount,
         cost_type: run.cost_type ?? null,
         partner_cost_estimate:
           run.partner_cost_estimate === null ||

--- a/apps/backend/src/workflows/payment_submissions/__tests__/run-line-pricing-contract.unit.spec.ts
+++ b/apps/backend/src/workflows/payment_submissions/__tests__/run-line-pricing-contract.unit.spec.ts
@@ -1,0 +1,234 @@
+import { resolvePaymentLineAmount } from "../create-payment-submission"
+import {
+  runPayableOffer,
+  resolveRunLinePrice,
+} from "../../production-runs/lib/run-payable"
+
+/**
+ * #1616 — the offer screen and the create path were two different pricers over
+ * one run.
+ *
+ * `payable-runs` offered ₹810 for `prod_run_01KWPVZ4R2PWK6DW1X8X5DKNZE`
+ * ("Princess Highway", Sharlho). Creating the submission for that exact run,
+ * naming it in `production_run_ids`, wrote ₹1,056.40 — the DESIGN's
+ * `estimated_cost`. +30%, and invisible: `create` returns `items: []`, so the
+ * amount could not be seen until the submission was fetched again.
+ *
+ * 🔑 The contract these tests hold is the one the issue asked for: what the
+ * screen OFFERS is what `create` WRITES, for the same run.
+ */
+
+/** The real prod row that exposed the defect. */
+const PRINCESS_HIGHWAY = {
+  id: "prod_run_01KWPVZ4R2PWK6DW1X8X5DKNZE",
+  design_id: "design_1",
+  partner_id: "01K4PJMNMNRGMK0ZXMKBBDZDGD",
+  status: "completed",
+  quantity: 1,
+  produced_quantity: 1,
+  partner_cost_estimate: 810,
+  cost_type: "total" as const,
+}
+
+/** What the design says, and what `create` used to bill instead. */
+const DESIGN_ESTIMATED_COST = 1056.4
+
+describe("payable-runs offer === what create writes", () => {
+  it("prices the Princess Highway run at the OFFER, not the design estimate", () => {
+    const offer = runPayableOffer(PRINCESS_HIGHWAY)
+    const written = resolvePaymentLineAmount({
+      runs: [PRINCESS_HIGHWAY],
+      unit_cost: DESIGN_ESTIMATED_COST,
+    })
+
+    expect(offer.amount).toBe(810)
+    expect(written.amount).toBe(offer.amount)
+    // The exact overbill the issue reports, now impossible.
+    expect(written.amount).not.toBe(1056.4)
+  })
+
+  it("agrees for a per_unit run produced fewer times than ordered", () => {
+    const run = {
+      ...PRINCESS_HIGHWAY,
+      quantity: 9,
+      produced_quantity: 7,
+      partner_cost_estimate: 1200,
+      cost_type: "per_unit" as const,
+    }
+
+    const offer = runPayableOffer(run)
+    const written = resolvePaymentLineAmount({ runs: [run], unit_cost: 850 })
+
+    // Paid for what they MADE — 7 x 1200, not 9.
+    expect(offer.amount).toBe(8400)
+    expect(offer.quantity_basis).toBe("produced")
+    expect(written.amount).toBe(offer.amount)
+    expect(written.quantity).toBe(7)
+    expect(written.unit_amount).toBe(1200)
+  })
+
+  it("falls back to ordered when output was never recorded, on both sides", () => {
+    const run = {
+      ...PRINCESS_HIGHWAY,
+      quantity: 4,
+      produced_quantity: null,
+      partner_cost_estimate: 500,
+      cost_type: "per_unit" as const,
+    }
+
+    const offer = runPayableOffer(run)
+    const written = resolvePaymentLineAmount({ runs: [run], unit_cost: 850 })
+
+    expect(offer.quantity_basis).toBe("ordered")
+    expect(written.amount).toBe(offer.amount)
+    expect(written.amount).toBe(2000)
+  })
+
+  it("sums a line claiming several runs to the sum of their offers", () => {
+    const a = { ...PRINCESS_HIGHWAY, id: "run_a" }
+    const b = {
+      ...PRINCESS_HIGHWAY,
+      id: "run_b",
+      partner_cost_estimate: 810,
+      quantity: 1,
+      produced_quantity: 1,
+    }
+
+    const offered = runPayableOffer(a).amount + runPayableOffer(b).amount
+    const written = resolvePaymentLineAmount({
+      runs: [a, b],
+      unit_cost: DESIGN_ESTIMATED_COST,
+    })
+
+    expect(written.amount).toBe(offered)
+    expect(written.quantity).toBe(2)
+    expect(written.unit_amount).toBe(810)
+  })
+})
+
+describe("resolvePaymentLineAmount precedence", () => {
+  it("a typed TOTAL still wins over the runs", () => {
+    // The auto-draft passes runPayableAmount's already-multiplied figure here.
+    // Re-multiplying it is #456.
+    const written = resolvePaymentLineAmount({
+      runs: [PRINCESS_HIGHWAY],
+      unit_cost: DESIGN_ESTIMATED_COST,
+      override: 999,
+    })
+
+    expect(written.amount).toBe(999)
+    expect(written.unit_amount).toBeNull()
+  })
+
+  it("a typed RATE still wins over the runs", () => {
+    const written = resolvePaymentLineAmount({
+      runs: [PRINCESS_HIGHWAY],
+      unit_cost: DESIGN_ESTIMATED_COST,
+      unit_override: 100,
+      quantity: 3,
+    })
+
+    expect(written.amount).toBe(300)
+    expect(written.unit_amount).toBe(100)
+  })
+
+  it("bills the RUNS' rate for a caller-supplied quantity", () => {
+    // Correcting how many, not what each one costs.
+    const run = {
+      ...PRINCESS_HIGHWAY,
+      quantity: 9,
+      produced_quantity: 9,
+      partner_cost_estimate: 1200,
+      cost_type: "per_unit" as const,
+    }
+
+    const written = resolvePaymentLineAmount({
+      runs: [run],
+      unit_cost: DESIGN_ESTIMATED_COST,
+      quantity: 4,
+    })
+
+    expect(written.amount).toBe(4800)
+    expect(written.unit_amount).toBe(1200)
+  })
+
+  it("falls back to the DESIGN when a claimed run carries no agreed rate", () => {
+    // Not a refusal: billing a run whose price was agreed off-system is the
+    // documented flow, and payable-runs shows the design's figure the same way.
+    const run = { ...PRINCESS_HIGHWAY, partner_cost_estimate: null }
+
+    const written = resolvePaymentLineAmount({
+      runs: [run as any],
+      unit_cost: DESIGN_ESTIMATED_COST,
+    })
+
+    expect(written.amount).toBe(DESIGN_ESTIMATED_COST)
+    expect(written.unit_amount).toBe(DESIGN_ESTIMATED_COST)
+  })
+
+  it("is byte-for-byte today's behaviour for a line with NO runs", () => {
+    const written = resolvePaymentLineAmount({
+      runs: [],
+      unit_cost: 850,
+      quantity: 9,
+    })
+
+    expect(written).toEqual({ amount: 7650, quantity: 9, unit_amount: 850 })
+  })
+
+  it("records no rate when the claimed runs carry DIFFERENT rates", () => {
+    // There is no single rate behind such a line; dividing the total back out
+    // would invent one.
+    const cheap = { ...PRINCESS_HIGHWAY, id: "a", partner_cost_estimate: 100 }
+    const dear = { ...PRINCESS_HIGHWAY, id: "b", partner_cost_estimate: 900 }
+
+    const written = resolvePaymentLineAmount({
+      runs: [cheap, dear],
+      unit_cost: DESIGN_ESTIMATED_COST,
+    })
+
+    expect(written.amount).toBe(1000)
+    expect(written.unit_amount).toBeNull()
+  })
+
+  it("never zeroes a mixed-rate line just because a quantity was supplied", () => {
+    // 🔴 There is no rate to multiply by, but the summed total IS agreed.
+    // A 0 in front of a partner is the worst possible answer here.
+    const cheap = { ...PRINCESS_HIGHWAY, id: "a", partner_cost_estimate: 100 }
+    const dear = { ...PRINCESS_HIGHWAY, id: "b", partner_cost_estimate: 900 }
+
+    const written = resolvePaymentLineAmount({
+      runs: [cheap, dear],
+      unit_cost: DESIGN_ESTIMATED_COST,
+      quantity: 5,
+    })
+
+    expect(written.amount).toBe(1000)
+    expect(written.quantity).toBe(5)
+    expect(written.unit_amount).toBeNull()
+  })
+})
+
+describe("resolveRunLinePrice", () => {
+  it("returns null when NO claimed run carries a rate", () => {
+    const written = resolveRunLinePrice([
+      { ...PRINCESS_HIGHWAY, partner_cost_estimate: null } as any,
+    ])
+
+    expect(written).toBeNull()
+  })
+
+  it("ignores rate-less runs among priced ones rather than billing them at 0", () => {
+    const priced = PRINCESS_HIGHWAY
+    const unpriced = {
+      ...PRINCESS_HIGHWAY,
+      id: "b",
+      partner_cost_estimate: null,
+    }
+
+    const written = resolveRunLinePrice([priced, unpriced as any])
+
+    expect(written?.amount).toBe(810)
+    expect(written?.quantity).toBe(1)
+  })
+})

--- a/apps/backend/src/workflows/payment_submissions/create-payment-submission.ts
+++ b/apps/backend/src/workflows/payment_submissions/create-payment-submission.ts
@@ -35,7 +35,11 @@ import {
   describeInventoryOrderValue,
   valueInventoryOrderByReceipts,
 } from "./lib/inventory-order-value"
-import { runPayableAmount } from "../production-runs/lib/run-payable"
+import {
+  resolveRunLinePrice,
+  runPayableAmount,
+  type RunForPayout,
+} from "../production-runs/lib/run-payable"
 import { PARTNER_MODULE } from "../../modules/partner"
 import { DESIGN_MODULE } from "../../modules/designs"
 import { TASKS_MODULE } from "../../modules/tasks"
@@ -328,6 +332,92 @@ export const resolveDesignLineAmount = (input: {
   }
 }
 
+/**
+ * PURE: what one payout line bills, given the RUNS it names as well as the
+ * design behind it.
+ *
+ * 🔴 `resolveDesignLineAmount` alone was the #1616 defect. `payable-runs`
+ * offered ₹810 for the Princess Highway run; creating the submission for that
+ * exact run — naming it in `production_run_ids`, so there was no ambiguity —
+ * wrote ₹1,056.40, the DESIGN's `estimated_cost`. +30%, and nothing surfaced
+ * the difference: the create response returns `items: []`, so the amount was
+ * invisible until the submission was fetched again. Two pricers over one run,
+ * and the figure an operator reads was not the figure that got written.
+ *
+ * Precedence, and the reason for each step:
+ *
+ *  1. **A typed total wins outright.** Somebody typed it — the partner on the
+ *     form, or the auto-draft passing `runPayableAmount`'s already-multiplied
+ *     figure. Multiplying it again is #456.
+ *  2. **A typed rate next**, for the same reason: a human who knows the agreed
+ *     price outranks every stored estimate.
+ *  3. **Then the RUNS**, via `runPayableOffer` — the same helper `payable-runs`
+ *     offers from, so the screen and this path cannot disagree.
+ *  4. **Then the design's per-unit cost**, which is where a hand-picked design
+ *     line with no run behind it has always been priced.
+ *
+ * ⚠️ Step 4 still catches a claimed run carrying NO agreed rate. Refusing there
+ * would block the documented flow of billing a run whose price was agreed
+ * off-system; `payable-runs` flags such a run `payable: false` and shows the
+ * design's figure as a suggestion, which is the same treatment.
+ *
+ * An explicit `quantity` combined with runs bills the RUNS' rate for that many
+ * units: the caller is correcting how many, not what each one costs.
+ */
+export const resolvePaymentLineAmount = (input: {
+  runs?: Array<RunForPayout & { produced_quantity?: number | null }> | null
+  unit_cost: number
+  quantity?: number | null
+  override?: number | null
+  unit_override?: number | null
+}): { amount: number; quantity: number; unit_amount: number | null } => {
+  const runPrice = input.runs?.length ? resolveRunLinePrice(input.runs) : null
+
+  const explicitQty =
+    Number.isFinite(Number(input.quantity)) && Number(input.quantity) > 0
+      ? Number(input.quantity)
+      : null
+
+  const override = Number(input.override)
+  const unitOverride = Number(input.unit_override)
+  const hasOverride = Number.isFinite(override) && override > 0
+  const hasUnitOverride = Number.isFinite(unitOverride) && unitOverride > 0
+
+  /**
+   * The runs answer only when nobody typed a price. Their own quantity is used
+   * unless the caller supplied one — and when the runs carry DIFFERENT rates
+   * there is no single rate to record, so the total stands alone with a null
+   * `unit_amount` rather than an invented average.
+   */
+  if (runPrice && !hasOverride && !hasUnitOverride) {
+    if (runPrice.unit_amount == null) {
+      /**
+       * ⚠️ The supplied quantity is recorded but NOT multiplied — there is no
+       * rate to multiply by. The runs' summed total stands, which is the only
+       * figure that is actually agreed. Zeroing the line here because the
+       * arithmetic is unavailable would put a 0 in front of a partner.
+       */
+      return {
+        amount: runPrice.amount,
+        quantity: explicitQty ?? runPrice.quantity,
+        unit_amount: null,
+      }
+    }
+
+    return resolveDesignLineAmount({
+      unit_cost: runPrice.unit_amount,
+      quantity: explicitQty ?? runPrice.quantity,
+    })
+  }
+
+  return resolveDesignLineAmount({
+    unit_cost: input.unit_cost,
+    quantity: explicitQty ?? runPrice?.quantity,
+    override: input.override,
+    unit_override: input.unit_override,
+  })
+}
+
 // Step 1a: Validate all designs for submission eligibility
 const validateDesignsForSubmissionStep = createStep(
   "validate-designs-for-submission",
@@ -558,14 +648,36 @@ const validateDesignsForSubmissionStep = createStep(
       ...new Set(Object.values(claimedRuns).flat().filter(Boolean)),
     ]
 
+    /**
+     * The claimed runs, kept in scope so the LINE CAN BE PRICED FROM THEM
+     * below (#1616). Empty when nothing was claimed.
+     */
+    const runById = new Map<string, any>()
+
     if (allClaimedRunIds.length) {
       const { data: runs } = await query.graph({
         entity: "production_runs",
-        fields: ["id", "design_id", "partner_id", "status"],
+        fields: [
+          "id",
+          "design_id",
+          "partner_id",
+          "status",
+          /**
+           * ⚠️ The money fields are FETCHED, not merely typed. `runPayableOffer`
+           * reads all four, and a pricer reading a field the query never asked
+           * for silently prices everything at zero.
+           */
+          "quantity",
+          "produced_quantity",
+          "partner_cost_estimate",
+          "cost_type",
+        ],
         filters: { id: allClaimedRunIds },
       })
       const typedRuns = (runs || []) as unknown as ProductionRunGraphResult[]
-      const runById = new Map(typedRuns.map((r) => [r.id, r]))
+      for (const run of typedRuns) {
+        runById.set(run.id, run)
+      }
 
       const missing = allClaimedRunIds.filter((id) => !runById.has(id))
       if (missing.length) {
@@ -684,9 +796,12 @@ const validateDesignsForSubmissionStep = createStep(
     const unitAmounts = input.unit_amounts || {}
 
     const validated: ValidatedDesign[] = typedDesigns.map((d) => {
-      // `estimated_cost` / `production_cost` are PER FINISHED UNIT. Treating
-      // either as a line total is the #1554 defect this resolver exists to fix.
-      const line = resolveDesignLineAmount({
+      const line = resolvePaymentLineAmount({
+        runs: (claimedRuns[d.id] || [])
+          .map((runId) => runById.get(runId))
+          .filter(Boolean),
+        // `estimated_cost` / `production_cost` are PER FINISHED UNIT. Treating
+        // either as a line total is the #1554 defect (#1554).
         unit_cost: Number(d.estimated_cost || (d as any).production_cost || 0),
         quantity: quantities[d.id],
         override: overrides[d.id],
@@ -1383,6 +1498,28 @@ const createSubmissionRecordStep = createStep(
         run_provenance: "no_run" as const,
         submission_id: submission.id,
       })
+    }
+
+    /**
+     * 🔴 The lines are read back and returned WITH the submission (#1616).
+     *
+     * `create` returned a submission with `items: []`, so the amount it had
+     * just written was invisible until someone fetched the submission again.
+     * That is how a ₹1,056.40 line went out against an offered ₹810 and was
+     * caught only because a handoff happened to name the expected figure. An
+     * amount that cannot be seen at the moment it is written cannot be checked
+     * at the moment it is written.
+     *
+     * Best-effort: the submission and its lines are already committed by the
+     * time this runs, and a failure to read them back must not roll back a
+     * created payout.
+     */
+    try {
+      ;(submission as any).items = await service.listPaymentSubmissionItems({
+        submission_id: submission.id,
+      })
+    } catch {
+      // Leave whatever the create returned; the submission itself is written.
     }
 
     return new StepResponse(submission, submission.id)

--- a/apps/backend/src/workflows/production-runs/lib/run-payable.ts
+++ b/apps/backend/src/workflows/production-runs/lib/run-payable.ts
@@ -77,6 +77,97 @@ export const runUnitCost = (run: RunForPayout | null | undefined): number => {
   return Math.round((cost / units) * 100) / 100
 }
 
+/**
+ * What `payable-runs` OFFERS for one run — the figure an operator reads on the
+ * screen and then acts on.
+ *
+ * 🔴 Extracted because the offer screen and the create path were two different
+ * pricers over one run (#1616). `payable-runs` offered ₹810 for the Princess
+ * Highway run; creating the submission for that exact run, naming it in
+ * `production_run_ids`, wrote ₹1,056.40 — the DESIGN's `estimated_cost`, +30%.
+ * A figure an operator reads is not the figure that gets written, and the
+ * created Draft looks authoritative either way.
+ *
+ * ⚠️ The quantity is PRODUCED where output was recorded, ordered otherwise —
+ * which is deliberately NOT `runPayableAmount`'s multiplier. That function
+ * bills the ordered quantity (#456, and the unified-order dual-write depends on
+ * it); this one bills what the screen offers. The two answer different
+ * questions and the difference is stated in `quantity_basis` rather than
+ * papered over.
+ */
+export type RunPayableOffer = {
+  /** The agreed rate per finished unit, or 0 when the run carries none. */
+  unit_amount: number
+  /** Units billed — produced where recorded, else ordered, never below 1. */
+  quantity: number
+  quantity_basis: "produced" | "ordered"
+  /** unit_amount x quantity, to two decimals. */
+  amount: number
+  /**
+   * Whether the RUN carries an agreed rate.
+   *
+   * ⚠️ NOT "can this be paid". A run with no agreed rate is not a zero-value
+   * payout and it is not unpayable — it is a run whose price was never written
+   * down, and someone who knows what was agreed must still be able to type it.
+   */
+  payable: boolean
+}
+
+export const runPayableOffer = (
+  run: RunForPayout & { produced_quantity?: number | null }
+): RunPayableOffer => {
+  // `runUnitCost` divides a "total" cost_type back out and takes a "per_unit"
+  // one verbatim — one place, one convention.
+  const unit_amount = runUnitCost(run)
+
+  const produced = Number(run?.produced_quantity)
+  const hasProduced = Number.isFinite(produced) && produced > 0
+  const ordered = Number(run?.quantity)
+  const quantity = hasProduced
+    ? produced
+    : Number.isFinite(ordered) && ordered > 0
+      ? ordered
+      : 1
+
+  return {
+    unit_amount,
+    quantity,
+    quantity_basis: hasProduced ? "produced" : "ordered",
+    amount: Math.round(unit_amount * quantity * 100) / 100,
+    payable: unit_amount > 0,
+  }
+}
+
+/**
+ * What a payout line naming one or more runs bills, priced from THE RUNS.
+ *
+ * Returns `null` when no claimed run carries an agreed rate — the caller then
+ * falls back to whatever it did before. Pricing a rate-less run from the design
+ * is the silent substitution `payable-runs` already refuses ("a suggestion,
+ * never a price"), but refusing outright here would block the documented flow
+ * of billing a run whose price was agreed off-system, so the fallback stays and
+ * says which basis it used.
+ *
+ * 🔴 `unit_amount` is null when the claimed runs carry DIFFERENT rates. There
+ * is no single rate behind such a line, and dividing the total back out would
+ * invent one — the same reason a typed total records no rate.
+ */
+export const resolveRunLinePrice = (
+  runs: Array<RunForPayout & { produced_quantity?: number | null }>
+): { amount: number; quantity: number; unit_amount: number | null } | null => {
+  const offers = (runs || []).map(runPayableOffer).filter((o) => o.payable)
+  if (!offers.length) return null
+
+  const amount =
+    Math.round(offers.reduce((acc, o) => acc + o.amount, 0) * 100) / 100
+  const quantity = offers.reduce((acc, o) => acc + o.quantity, 0)
+
+  const rates = new Set(offers.map((o) => o.unit_amount))
+  const unit_amount = rates.size === 1 ? offers[0].unit_amount : null
+
+  return { amount, quantity, unit_amount }
+}
+
 export type PayoutEligibility =
   | {
       eligible: true


### PR DESCRIPTION
Closes #1616.

`payable-runs` offered **₹810** for `prod_run_01KWPVZ4R2PWK6DW1X8X5DKNZE` ("Princess Highway", Sharlho). Creating the submission for that exact run — naming it in `production_run_ids`, so there was no ambiguity about which run was being claimed — wrote **₹1,056.40**, the design's `estimated_cost`. An overbill of ₹246.40, **+30%**.

Two pricers over one run. The figure an operator reads on the offer screen was not the figure that got written when they acted on it, and the created Draft looked authoritative either way.

## One pricer

`runPayableOffer` is now the single source. `payable-runs` offers from it; `resolvePaymentLineAmount` writes from it. A contract test asserts the two agree for the same run — which is what the issue asked for, and what would have caught this.

Precedence, unchanged where it mattered:

| | wins | why |
|---|---|---|
| 1 | a typed **total** | somebody typed it, including the auto-draft passing `runPayableAmount`'s already-multiplied figure. Re-multiplying is #456 |
| 2 | a typed **rate** | a human who knows the agreed price outranks every stored estimate |
| 3 | the **runs** | ← the fix |
| 4 | the design's per-unit cost | where a hand-picked design line with no run behind it has always been priced |

Step 4 still catches a claimed run carrying **no agreed rate**. Refusing there would block the documented flow of billing a run whose price was agreed off-system — `payable-runs` flags such a run `payable: false` and offers the design's figure as a suggestion, which is the same treatment.

## Two things the tests pin

- Runs with **different rates** record no `unit_amount`. There is no single rate behind such a line, and dividing the total back out would invent one.
- Such a line is **never zeroed** because a quantity was supplied. There is no rate to multiply by, but the summed total IS agreed — and a `0` in front of a partner is the worst available answer.

## The invisibility, too

`create` returned `items: []`, so the amount it had just written could not be seen until the submission was fetched again. That is why this defect was caught only because a handoff happened to name the expected ₹810. The step now reads its lines back and returns them — best-effort, since the payout is already committed by then and a failed read-back must not roll one back.

## Verification

- 13 new cases: the contract (offer === written) across `total` / `per_unit` / produced-vs-ordered / multi-run, and the full precedence table.
- `is byte-for-byte today's behaviour for a line with NO runs` — the regression guard for every existing caller.
- 77 green across the payment-submission specs, 22 across `run-payable`. `check:prod-build` passes.

## Behaviour change to be aware of

A caller that passes `production_run_ids` **without** an override now gets the run's price instead of the design's. That is the fix, and it is the only path that changes. Note the run offer bills the **produced** quantity where output was recorded, while `runPayableAmount` (the auto-draft path) bills the **ordered** one — those two have disagreed since #456 and this PR does not merge them; it makes `create` agree with the screen the operator is looking at.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01TLt1f38xqR8k2myCVxP8e4