### PR TITLE
feat(payments): filter payouts by partner and status, and stop showing ULIDs (#1622)

### DIFF
--- a/apps/backend/src/admin/hooks/api/payment-submissions.ts
+++ b/apps/backend/src/admin/hooks/api/payment-submissions.ts
@@ -86,6 +86,14 @@ export interface PaymentSubmissionsListResponse {
 export interface PaymentSubmissionsQuery {
   status?: string
   partner_id?: string
+  /**
+   * Free-text over the submission id.
+   *
+   * ⚠️ The list query is validated `.strict()`, so an undeclared key is a 400
+   * rather than an ignored extra — send only what is here, and omit rather
+   * than pass `undefined`.
+   */
+  q?: string
   limit?: number
   offset?: number
 }

--- a/apps/backend/src/admin/routes/payment-submissions/_components/submissions-tab.tsx
+++ b/apps/backend/src/admin/routes/payment-submissions/_components/submissions-tab.tsx
@@ -1,6 +1,14 @@
 import { useMemo, useState } from "react"
 import { Link, useNavigate } from "react-router-dom"
-import { Button, Container, StatusBadge, DataTable, useDataTable } from "@medusajs/ui"
+import {
+  Button,
+  Container,
+  StatusBadge,
+  DataTable,
+  createDataTableFilterHelper,
+  useDataTable,
+  type DataTableFilteringState,
+} from "@medusajs/ui"
 import { createColumnHelper } from "@tanstack/react-table"
 import { keepPreviousData } from "@tanstack/react-query"
 import {
@@ -11,6 +19,18 @@ import {
   paymentSubmissionStatusColor,
   paymentSubmissionStatusLabel,
 } from "../../../lib/payment-submission-status"
+import { RefLink } from "../../../components/payments/payment-line-links"
+import { usePartners } from "../../../hooks/api/partners-admin"
+
+/** Every status the enum offers, so the filter cannot silently omit one. */
+const SUBMISSION_STATUSES = [
+  "Draft",
+  "Pending",
+  "Under_Review",
+  "Approved",
+  "Rejected",
+  "Paid",
+] as const
 
 const columnHelper = createColumnHelper<PaymentSubmission>()
 
@@ -19,14 +39,41 @@ export const SubmissionsTab = () => {
   const navigate = useNavigate()
   const [pagination, setPagination] = useState({ pageIndex: 0, pageSize: 20 })
   const [search, setSearch] = useState<string>("")
+  const [filtering, setFiltering] = useState<DataTableFilteringState>({})
 
-  const query = useMemo(
-    () => ({
+  /**
+   * The partners a filter can offer. The list route has taken `partner_id`
+   * and `status` all along and this screen never sent either, so "what has this
+   * partner billed us" could only be answered by paging through everyone.
+   */
+  const { partners } = usePartners({ limit: 100, fields: ["id", "name"] }) as any
+
+  const partnerOptions = useMemo(
+    () =>
+      ((partners || []) as any[])
+        .map((p) => ({ label: p.name || p.id, value: p.id }))
+        .sort((a, b) => a.label.localeCompare(b.label)),
+    [partners]
+  )
+
+  const query = useMemo(() => {
+    const partnerFilter = filtering["partner_id"] as any
+    const statusFilter = filtering["status"] as any
+
+    /**
+     * ⚠️ `zodValidator` forces `.strict()` on the list query, so an undefined
+     * key must be OMITTED rather than sent as undefined — and the route rejects
+     * anything it has not declared. One value each: the schema types both as a
+     * scalar, and sending an array would 400 rather than widen the search.
+     */
+    return {
       limit: pagination.pageSize,
       offset: pagination.pageIndex * pagination.pageSize,
-    }),
-    [pagination]
-  )
+      ...(search ? { q: search } : {}),
+      ...(partnerFilter ? { partner_id: String(partnerFilter) } : {}),
+      ...(statusFilter ? { status: String(statusFilter) } : {}),
+    }
+  }, [pagination, search, filtering])
 
   const {
     payment_submissions,
@@ -36,6 +83,32 @@ export const SubmissionsTab = () => {
     placeholderData: keepPreviousData,
   })
 
+  const filterHelper = createDataTableFilterHelper<PaymentSubmission>()
+
+  const filters = useMemo(
+    () => [
+      filterHelper.accessor("partner_id", {
+        type: "select",
+        label: "Partner",
+        options: partnerOptions,
+      }),
+      filterHelper.accessor("status", {
+        type: "select",
+        label: "Status",
+        options: SUBMISSION_STATUSES.map((status) => ({
+          label: paymentSubmissionStatusLabel(status),
+          value: status,
+        })),
+      }),
+    ],
+    [partnerOptions]
+  )
+
+  /** A new filter or search re-pages from the start; page 3 of the old result
+   *  set is not page 3 of the new one. */
+  const resetToFirstPage = () =>
+    setPagination((p) => ({ ...p, pageIndex: 0 }))
+
   const columns = useMemo(
     () => [
       columnHelper.accessor("id", {
@@ -44,11 +117,23 @@ export const SubmissionsTab = () => {
           <span className="font-mono text-xs">{getValue().slice(0, 12)}...</span>
         ),
       }),
+      /**
+       * 🔴 Was `partner_id.slice(0, 12)` — twelve characters of a ULID,
+       * repeated down the column, on the screen whose whole job is to say who
+       * is owed what (#1622). Resolved by the list route now.
+       */
       columnHelper.accessor("partner_id", {
         header: "Partner",
-        cell: ({ getValue }) => (
-          <span className="font-mono text-xs">{getValue().slice(0, 12)}...</span>
-        ),
+        cell: ({ row }) =>
+          row.original.partner_id ? (
+            <RefLink
+              kind="partner"
+              refOrId={row.original.partner || row.original.partner_id}
+              className="text-ui-fg-interactive text-xs hover:underline"
+            />
+          ) : (
+            "—"
+          ),
       }),
       columnHelper.accessor("status", {
         header: "Status",
@@ -63,8 +148,10 @@ export const SubmissionsTab = () => {
         cell: ({ getValue, row }) =>
           `${row.original.currency?.toUpperCase() || "INR"} ${Number(getValue()).toLocaleString()}`,
       }),
+      // Counts LINES, not designs — an inventory-order or run line is not a
+      // design, and the detail page stopped saying otherwise in #1621.
       columnHelper.accessor("items", {
-        header: "Designs",
+        header: "Lines",
         cell: ({ getValue }) => (getValue() || []).length,
       }),
       columnHelper.accessor("submitted_at", {
@@ -88,15 +175,34 @@ export const SubmissionsTab = () => {
     onRowClick: (_, row) => navigate(`/payment-submissions/${row.id}`),
     rowCount: count ?? 0,
     isLoading,
+    filters,
     pagination: { state: pagination, onPaginationChange: setPagination },
-    search: { state: search, onSearchChange: setSearch },
+    search: {
+      state: search,
+      onSearchChange: (value: string) => {
+        setSearch(value)
+        resetToFirstPage()
+      },
+    },
+    filtering: {
+      state: filtering,
+      onFilteringChange: (value: DataTableFilteringState) => {
+        setFiltering(value)
+        resetToFirstPage()
+      },
+    },
   })
 
   return (
     <Container className="divide-y p-0">
       <DataTable instance={table}>
         <DataTable.Toolbar className="flex items-center justify-between px-4 py-3">
-          <DataTable.Search placeholder="Search submissions..." />
+          <div className="flex items-center gap-x-2">
+            <DataTable.FilterMenu tooltip="Filter" />
+            {/* The box has rendered since this screen existed and nothing ever
+                sent its value; `q` is honoured by the route now. */}
+            <DataTable.Search placeholder="Search by submission id..." />
+          </div>
           <Button size="small" asChild>
             <Link to="create">New Submission</Link>
           </Button>

--- a/apps/backend/src/api/admin/payment-submissions/route.ts
+++ b/apps/backend/src/api/admin/payment-submissions/route.ts
@@ -1,5 +1,7 @@
 import type { MedusaRequest, MedusaResponse } from "@medusajs/framework/http"
+import { ContainerRegistrationKeys } from "@medusajs/framework/utils"
 import { PAYMENT_SUBMISSIONS_MODULE } from "../../../modules/payment_submissions"
+import { resolvePaymentEntities } from "./lib/resolve-payment-entities"
 import PaymentSubmissionsService from "../../../modules/payment_submissions/service"
 import { createPaymentSubmissionWorkflow } from "../../../workflows/payment_submissions/create-payment-submission"
 import {
@@ -9,8 +11,8 @@ import {
 
 // GET /admin/payment-submissions — list all submissions with filters
 export const GET = async (req: MedusaRequest, res: MedusaResponse) => {
-  const { offset = 0, limit = 20, status, partner_id } = (req.validatedQuery ||
-    req.query) as any
+  const { offset = 0, limit = 20, status, partner_id, q } =
+    (req.validatedQuery || req.query) as any
 
   const service: PaymentSubmissionsService = req.scope.resolve(
     PAYMENT_SUBMISSIONS_MODULE
@@ -19,6 +21,8 @@ export const GET = async (req: MedusaRequest, res: MedusaResponse) => {
   const filters: any = {}
   if (status) filters.status = status
   if (partner_id) filters.partner_id = partner_id
+  // The search box on the list screen. See the validator for why it did nothing.
+  if (q) filters.id = { $ilike: `%${q}%` }
 
   const [submissions, count] = await service.listAndCountPaymentSubmissions(
     filters,
@@ -29,6 +33,25 @@ export const GET = async (req: MedusaRequest, res: MedusaResponse) => {
       relations: ["items"],
     }
   )
+
+  /**
+   * Who each payout is FOR, by name (#1622).
+   *
+   * The list rendered `partner_id.slice(0, 12)` — twelve characters of a ULID,
+   * repeated down the column, on the screen whose whole job is to tell you who
+   * is owed what. Best-effort per entity: a partner that cannot be resolved
+   * leaves one name absent rather than failing the list.
+   */
+  const query: any = req.scope.resolve(ContainerRegistrationKeys.QUERY)
+  const resolved = await resolvePaymentEntities(query, {
+    partnerIds: submissions.map((s: any) => s.partner_id),
+  })
+
+  for (const submission of submissions as any[]) {
+    submission.partner = submission.partner_id
+      ? resolved.partners.get(submission.partner_id) ?? null
+      : null
+  }
 
   return res.status(200).json({
     payment_submissions: submissions,

--- a/apps/backend/src/api/admin/payment-submissions/validators.ts
+++ b/apps/backend/src/api/admin/payment-submissions/validators.ts
@@ -14,6 +14,19 @@ export const AdminListPaymentSubmissionsQuerySchema = z.object({
     ])
     .optional(),
   partner_id: z.string().optional(),
+  /**
+   * Free-text search over the submission id.
+   *
+   * 🔴 The list screen has always rendered a search box, and nothing ever sent
+   * its value anywhere — a control that looks like it filters and does not is
+   * worse than no control, because an unchanged list reads as "no other
+   * results" (#1622). The box is now honoured.
+   *
+   * ⚠️ `zodValidator` forces `.strict()`, so a param that is not declared here
+   * is a 400 rather than an ignored extra. Declaring it is what makes the UI
+   * able to send it at all.
+   */
+  q: z.string().trim().min(1).optional(),
   limit: z.coerce.number().int().min(1).max(100).default(20).optional(),
   offset: z.coerce.number().int().min(0).default(0).optional(),
 })


### PR DESCRIPTION
The last item on #1612's list. The payout list route has taken `partner_id` and `status` since it was written, and the screen never sent either — so "what has this partner billed us" could only be answered by paging through everyone.

## What changed

- **Partner and Status filters**, wired to the query the route already accepts. Partner options come from `/admin/partners`, so they read as names.
- **The Partner column** was `partner_id.slice(0, 12)` — twelve characters of a ULID, repeated down the column, on the screen whose whole job is to say who is owed what. The list route resolves it now (same `resolvePaymentEntities` as the detail and reconciliation screens), and it links to the partner.
- **The search box did nothing.** It has rendered since this screen existed and its value was never sent anywhere. That is worse than having no box: an unchanged list reads as *no other results*. `q` is now declared on the query schema and matched against the submission id.
- **The "Designs" column counted LINES.** An inventory-order or run line is not a design — the detail page stopped saying otherwise in #1621; this is the same mislabel one screen over.

Changing a filter or the search re-pages from the start. Page 3 of the old result set is not page 3 of the new one.

## Worth knowing

⚠️ `zodValidator` forces `.strict()` on this list query, so `q` had to be **declared** before the UI could send it at all — an undeclared param is a 400, not an ignored extra. For the same reason each filter sends one scalar; an array would 400 rather than widen the search.

## Verification

`check:prod-build` passes. No new specs — this is filter wiring over a route contract that already existed, and the pure pieces it leans on (`resolvePaymentEntities`, `paymentSubmissionStatusLabel`) are covered where they live.

Note the filters are wired but have **not been exercised in a browser**; the honest state is that they typecheck and build.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01TLt1f38xqR8k2myCVxP8e4