### PR TITLE
fix(consumption): reconcile product-anchored logs instead of dropping them (#1619)

### DIFF
--- a/apps/backend/src/api/admin/ops/maintenance-jobs/reconcile-consumption-vs-production-job.ts
+++ b/apps/backend/src/api/admin/ops/maintenance-jobs/reconcile-consumption-vs-production-job.ts
@@ -4,7 +4,7 @@ import { z } from "@medusajs/framework/zod"
 import { CONSUMPTION_LOG_MODULE } from "../../../../modules/consumption_log"
 import { PRODUCTION_RUNS_MODULE } from "../../../../modules/production_runs"
 import {
-  reconcileDesigns,
+  reconcileConsumption,
   type ReconcileLog,
   type ReconcileRun,
 } from "../../../../workflows/consumption-logs/lib/reconcile-production-consumption"
@@ -58,7 +58,7 @@ export const reconcileConsumptionVsProductionJob: MaintenanceJob = {
   id: "reconcile-consumption-vs-production",
   label: "Reconcile consumption against production (report-only)",
   description:
-    "Compare what each design PRODUCED against what it reported CONSUMING. Counts completed leaf runs only (#498) and excludes provenance runs minted from retail fulfillment — those shipped from stock and consumed nothing, so counting them invents material. Reads each log's quantity_basis and resolves a per_piece rate against the run's piece count before summing, as the apply job does; a log whose basis is unknown is reported as unknown_basis rather than guessed, and the verdicts that depend on a complete total are withheld for that design. Flags: production with zero material logged, consumption with no production, implausible metres/piece, logs not attributed to a production run, and unreadable logs. Reports an expected/variance figure when a per-unit rate is supplied. NEVER writes — correct the log, then run the apply job.",
+    "Compare what each ANCHOR — a design, or a product where no design backs the work (#1618) — PRODUCED against what it reported CONSUMING. A product-anchored log used to be dropped before it reached any bucket, which under-reported consumption and would tell an operator to correct data that was already correct (#1619); rows anchored to NEITHER are counted and named in the summary rather than silently omitted. Counts completed leaf runs only (#498) and excludes provenance runs minted from retail fulfillment — those shipped from stock and consumed nothing, so counting them invents material. Reads each log's quantity_basis and resolves a per_piece rate against the run's piece count before summing, as the apply job does; a log whose basis is unknown is reported as unknown_basis rather than guessed, and the verdicts that depend on a complete total are withheld for that design. Flags: production with zero material logged, consumption with no production, implausible metres/piece, logs not attributed to a production run, and unreadable logs. Reports an expected/variance figure when a per-unit rate is supplied. NEVER writes — correct the log, then run the apply job.",
   params: [
     {
       name: "design_id",
@@ -130,6 +130,9 @@ export const reconcileConsumptionVsProductionJob: MaintenanceJob = {
     const runs: ReconcileRun[] = ((rawRuns || []) as any[]).map((r) => ({
       id: r.id,
       design_id: r.design_id ?? null,
+      // Projected explicitly: a fold reading an anchor the query never fetched
+      // sees `undefined` and buckets the row as unattributable (#1619).
+      product_id: r.product_id ?? null,
       parent_run_id: r.parent_run_id ?? null,
       status: r.status ?? null,
       produced_quantity: r.produced_quantity ?? null,
@@ -139,6 +142,7 @@ export const reconcileConsumptionVsProductionJob: MaintenanceJob = {
     const logs: ReconcileLog[] = ((rawLogs || []) as any[]).map((l) => ({
       id: l.id,
       design_id: l.design_id ?? null,
+      product_id: l.product_id ?? null,
       inventory_item_id: l.inventory_item_id ?? null,
       production_run_id: l.production_run_id ?? null,
       quantity: l.quantity ?? null,
@@ -149,7 +153,12 @@ export const reconcileConsumptionVsProductionJob: MaintenanceJob = {
       is_committed: Boolean(l.is_committed),
     }))
 
-    const all = reconcileDesigns({
+    /**
+     * 🔴 `reconcileConsumption`, not `reconcileDesigns` — this job reports to a
+     * human, and the rows-only form cannot say what it could not look at.
+     * Silent truncation reads as "covered everything" (#1619).
+     */
+    const { rows: all, excluded } = reconcileConsumption({
       runs,
       logs,
       ratePerUnit: rate_per_unit,
@@ -161,8 +170,8 @@ export const reconcileConsumptionVsProductionJob: MaintenanceJob = {
     // Reported as `changes` purely so the ops UI renders the table; before/after
     // are the observation, not a proposed write.
     const changes: MaintenanceChange[] = rows.map((r) => ({
-      entity: "design",
-      id: r.design_id,
+      entity: r.anchor_type,
+      id: r.anchor_id,
       field: `produced ${r.produced} / shipped-from-stock ${r.shipped_from_stock}${
         r.unresolved_logs
           ? ` / ${r.unresolved_logs} log(s) unreadable (raw ${r.unresolved_quantity})`
@@ -179,14 +188,33 @@ export const reconcileConsumptionVsProductionJob: MaintenanceJob = {
       return acc
     }, {})
 
+    const byAnchor = all.reduce(
+      (acc, r) => {
+        acc[r.anchor_type] = (acc[r.anchor_type] ?? 0) + 1
+        return acc
+      },
+      {} as Record<string, number>
+    )
+
     const summary = [
-      `Reconciled ${all.length} design(s); ${rows.length} flagged`,
+      `Reconciled ${all.length} anchor(s) — ${byAnchor.design ?? 0} design, ${
+        byAnchor.product ?? 0
+      } product; ${rows.length} flagged`,
       Object.keys(counts).length
         ? Object.entries(counts)
             .sort((a, b) => b[1] - a[1])
             .map(([f, n]) => `${n}× ${f}`)
             .join("; ")
         : "no flags",
+      /**
+       * ⚠️ Said out loud even when zero. "0 excluded" is a claim about
+       * coverage; saying nothing is not.
+       */
+      `${excluded.logs} committed log(s) and ${excluded.runs} completed run(s) are anchored to NEITHER a design nor a product and are in no bucket${
+        excluded.log_quantity
+          ? ` (raw quantity ${excluded.log_quantity}, not a total of anything)`
+          : ""
+      }`,
       "report-only — no stock was moved",
     ].join(". ")
 

--- a/apps/backend/src/workflows/consumption-logs/__tests__/reconcile-production-consumption.unit.spec.ts
+++ b/apps/backend/src/workflows/consumption-logs/__tests__/reconcile-production-consumption.unit.spec.ts
@@ -1,6 +1,7 @@
 import {
   isProvenanceRun,
   leafRuns,
+  reconcileConsumption,
   reconcileDesigns,
   type ReconcileLog,
   type ReconcileRun,
@@ -328,5 +329,158 @@ describe("isProvenanceRun / leafRuns", () => {
       { id: "c", parent_run_id: "p" },
     ]
     expect(leafRuns(runs).map((r) => r.id)).toEqual(["c"])
+  })
+})
+
+/**
+ * #1619 — a consumption log can hang off a PRODUCT since #1618, and this fold
+ * dropped every log without a design before it reached any bucket.
+ *
+ * 🔴 The risk is the one #1559/#1600 already demonstrated: a report-only job's
+ * failure mode is a BAD INSTRUCTION. Showing consumption as missing when it was
+ * recorded against a product tells an operator to correct data that is already
+ * correct.
+ */
+describe("reconcileConsumption — product anchors (#1619)", () => {
+  const productRun = {
+    id: "prod_run_01KZ3DA8TV6SR2A90FR1Q1WGWW",
+    design_id: null,
+    product_id: "prod_01KKV2B0SF4SQHCW41RYX3TYJ5",
+    status: "completed",
+    produced_quantity: 2,
+    quantity: 2,
+  }
+
+  /** The real log committed on 2026-08-28: 3m Kala Cotton, product-anchored. */
+  const productLog = {
+    id: "01M13S4TFR1BMF6APEGT31VD7X",
+    design_id: null,
+    product_id: "prod_01KKV2B0SF4SQHCW41RYX3TYJ5",
+    inventory_item_id: "iitem_01KXZ5JZBQ961KPQ7ZRPV6D7BZ",
+    production_run_id: "prod_run_01KZ3DA8TV6SR2A90FR1Q1WGWW",
+    quantity: 3,
+    quantity_basis: "total" as const,
+    is_committed: true,
+  }
+
+  it("reports a product-anchored run and its log instead of dropping them", () => {
+    const { rows } = reconcileConsumption({
+      runs: [productRun],
+      logs: [productLog],
+    })
+
+    expect(rows).toHaveLength(1)
+    expect(rows[0].anchor_type).toBe("product")
+    expect(rows[0].anchor_id).toBe("prod_01KKV2B0SF4SQHCW41RYX3TYJ5")
+    expect(rows[0].design_id).toBeNull()
+    expect(rows[0].produced).toBe(2)
+    expect(rows[0].consumed).toBe(3)
+    // The whole point: NOT "produced without consumption".
+    expect(rows[0].flags).not.toContain("produced_without_consumption")
+  })
+
+  it("keeps a design row and a product row in SEPARATE buckets", () => {
+    const { rows } = reconcileConsumption({
+      runs: [
+        productRun,
+        {
+          id: "run_design",
+          design_id: "design_1",
+          status: "completed",
+          produced_quantity: 5,
+        },
+      ],
+      logs: [
+        productLog,
+        {
+          id: "log_design",
+          design_id: "design_1",
+          inventory_item_id: "iitem_2",
+          production_run_id: "run_design",
+          quantity: 10,
+          quantity_basis: "total" as const,
+          is_committed: true,
+        },
+      ],
+    })
+
+    expect(rows).toHaveLength(2)
+    const byProduct = rows.find((r) => r.anchor_type === "product")!
+    const byDesign = rows.find((r) => r.anchor_type === "design")!
+    expect(byProduct.consumed).toBe(3)
+    expect(byDesign.consumed).toBe(10)
+  })
+
+  it("prefers the DESIGN when a row carries both", () => {
+    // 4 of 122 prod runs carry both, and every rate and report is design-keyed.
+    // Preferring the product would silently move them into a new bucket.
+    const { rows } = reconcileConsumption({
+      runs: [{ ...productRun, design_id: "design_1" }],
+      logs: [{ ...productLog, design_id: "design_1" }],
+    })
+
+    expect(rows).toHaveLength(1)
+    expect(rows[0].anchor_type).toBe("design")
+    expect(rows[0].design_id).toBe("design_1")
+    expect(rows[0].product_id).toBeNull()
+  })
+
+  it("COUNTS a log anchored to neither rather than dropping it in silence", () => {
+    const { rows, excluded } = reconcileConsumption({
+      runs: [],
+      logs: [{ ...productLog, design_id: null, product_id: null, quantity: 7 }],
+    })
+
+    expect(rows).toHaveLength(0)
+    expect(excluded.logs).toBe(1)
+    expect(excluded.log_quantity).toBe(7)
+  })
+
+  it("counts a completed run anchored to neither", () => {
+    const { excluded } = reconcileConsumption({
+      runs: [{ ...productRun, design_id: null, product_id: null }],
+      logs: [],
+    })
+
+    expect(excluded.runs).toBe(1)
+  })
+
+  it("does not borrow a design's expected rate for a product row", () => {
+    // Rates have always been design ids. A product row has no rate until
+    // someone supplies one; inventing one would manufacture a variance.
+    const { rows } = reconcileConsumption({
+      runs: [productRun],
+      logs: [productLog],
+      ratePerUnit: { design_1: 5 },
+    })
+
+    expect(rows[0].expected).toBeNull()
+    expect(rows[0].flags).not.toContain("under_expected")
+  })
+
+  it("resolves leaf runs BEFORE anchoring, so a parent cannot be double-counted", () => {
+    // Filtering by anchor first would hide the parent from leafRuns and promote
+    // it back to a leaf, counting its children's output twice.
+    const { rows } = reconcileConsumption({
+      runs: [
+        {
+          id: "parent",
+          product_id: "prod_1",
+          status: "completed",
+          produced_quantity: 10,
+        },
+        {
+          id: "child",
+          parent_run_id: "parent",
+          product_id: "prod_1",
+          status: "completed",
+          produced_quantity: 10,
+        },
+      ],
+      logs: [],
+    })
+
+    expect(rows).toHaveLength(1)
+    expect(rows[0].produced).toBe(10)
   })
 })

--- a/apps/backend/src/workflows/consumption-logs/lib/reconcile-production-consumption.ts
+++ b/apps/backend/src/workflows/consumption-logs/lib/reconcile-production-consumption.ts
@@ -19,6 +19,11 @@
 export type ReconcileRun = {
   id: string
   design_id?: string | null
+  /**
+   * The product a run is anchored to when no design backs it (#1112, #1618).
+   * Of 122 production runs, 8 are product-only and 4 carry both.
+   */
+  product_id?: string | null
   parent_run_id?: string | null
   status?: string | null
   produced_quantity?: number | null
@@ -31,6 +36,16 @@ export type ConsumptionBasis = "total" | "per_piece"
 export type ReconcileLog = {
   id: string
   design_id?: string | null
+  /**
+   * The product a log is anchored to when no design backs it (#1618).
+   *
+   * 🔴 `design_id` used to be required here, and a log without one was dropped
+   * before it reached any bucket. Since #1618 a log can hang off a product, so
+   * that drop silently under-reported consumption — and the failure mode of a
+   * report-only job is a BAD INSTRUCTION: it shows material as missing when it
+   * was recorded, and tells someone to correct data that is already right.
+   */
+  product_id?: string | null
   inventory_item_id?: string | null
   production_run_id?: string | null
   quantity?: number | string | null
@@ -43,8 +58,22 @@ export type ReconcileLog = {
   is_committed?: boolean
 }
 
+export type ReconcileAnchorType = "design" | "product"
+
 export type DesignReconciliation = {
-  design_id: string
+  /**
+   * WHAT this row is about, and which kind of thing that is (#1619).
+   *
+   * A row is keyed by its anchor, not by a design: a product-only run has no
+   * design to group under, and grouping it under `null` would put every
+   * unrelated product-anchored row in one bucket.
+   */
+  anchor_type: ReconcileAnchorType
+  anchor_id: string
+  /** Null on a product-anchored row. Callers that print an id want `anchor_id`. */
+  design_id: string | null
+  /** Set on a product-anchored row; null when a design backs it. */
+  product_id: string | null
   /** Completed leaf-run output, provenance excluded — pieces we actually made. */
   produced: number
   /** Completed provenance quantity — shipped from stock, consumed nothing. */
@@ -164,7 +193,51 @@ const round = (n: number): number => Number(n.toFixed(6))
  * It is optional: with no rate we still report the IMPLIED rate, which is what
  * makes a 0.19 m/piece design visible without anyone having specified a spec.
  */
-export function reconcileDesigns(input: {
+/**
+ * What a run or a log is ABOUT, as a single key (#1619).
+ *
+ * 🔑 The design wins when both are present — 4 of 122 prod runs carry both, and
+ * every existing rate, report and expectation is design-keyed. Preferring the
+ * product for those would silently move them into a new bucket.
+ *
+ * Returns null when neither is set: that row is unattributable and is COUNTED
+ * rather than dropped.
+ */
+const anchorOf = (
+  row: { design_id?: string | null; product_id?: string | null } | null | undefined
+): { type: ReconcileAnchorType; id: string; key: string } | null => {
+  const design = row?.design_id ? String(row.design_id) : ""
+  if (design) return { type: "design", id: design, key: `design:${design}` }
+
+  const product = row?.product_id ? String(row.product_id) : ""
+  if (product) return { type: "product", id: product, key: `product:${product}` }
+
+  return null
+}
+
+/**
+ * What this reconciliation could NOT look at.
+ *
+ * 🔴 Returned, not logged. Silent truncation reads as "covered everything" when
+ * it didn't — and the whole hazard of a report-only job is that its output is
+ * read as an instruction. A caller that cannot see the exclusions cannot know
+ * its report is partial.
+ */
+export type ReconcileExclusions = {
+  /** Committed material logs anchored to neither a design nor a product. */
+  logs: number
+  /** Their raw `quantity` sum. Not a total of anything — a size, not a figure. */
+  log_quantity: number
+  /** Completed leaf runs anchored to neither. Their output is in no bucket. */
+  runs: number
+}
+
+export type ReconcileResult = {
+  rows: DesignReconciliation[]
+  excluded: ReconcileExclusions
+}
+
+export function reconcileConsumption(input: {
   runs: ReconcileRun[]
   logs: ReconcileLog[]
   ratePerUnit?: Record<string, number>
@@ -176,21 +249,42 @@ export function reconcileDesigns(input: {
    * report in the first place. Omitted, those logs stay unresolved.
    */
   assumeBasisWhenUnknown?: ConsumptionBasis
-}): DesignReconciliation[] {
+}): ReconcileResult {
   const implausibleBelow = input.implausibleRateBelow ?? 0.5
   const rates = input.ratePerUnit ?? {}
 
-  const leaves = leafRuns(
-    (input.runs || []).filter((r) => r?.design_id)
-  ).filter((r) => r.status === "completed")
+  /**
+   * ⚠️ Leaf resolution runs over ALL runs, before any anchor filter. Filtering
+   * first would hide a parent from `leafRuns` and promote its children's parent
+   * to a leaf, double-counting the output.
+   */
+  const leaves = leafRuns(input.runs || []).filter(
+    (r) => r.status === "completed"
+  )
+
+  /** Anchor key → what it is, so a row can name itself at the end. */
+  const anchors = new Map<string, { type: ReconcileAnchorType; id: string }>()
+  const remember = (a: { type: ReconcileAnchorType; id: string; key: string }) => {
+    if (!anchors.has(a.key)) anchors.set(a.key, { type: a.type, id: a.id })
+    return a.key
+  }
 
   const produced: Record<string, number> = {}
   const provenance: Record<string, number> = {}
   // Pieces per RUN, so a log attributed to one run is multiplied by that run's
-  // own yield rather than by everything the design ever made.
+  // own yield rather than by everything the anchor ever made.
   const piecesByRun: Record<string, number> = {}
+  let excludedRuns = 0
+
   for (const r of leaves) {
-    const d = String(r.design_id)
+    const anchor = anchorOf(r)
+    if (!anchor) {
+      // Anchored to nothing: no bucket exists for its output. Counted, never
+      // dropped — see ReconcileExclusions.
+      excludedRuns++
+      continue
+    }
+    const d = remember(anchor)
     // produced_quantity is the reported yield; fall back to the ordered
     // quantity only when the yield was never recorded.
     const q = num(r.produced_quantity ?? r.quantity)
@@ -206,14 +300,28 @@ export function reconcileDesigns(input: {
   const unattributed: Record<string, number> = {}
   const unresolvedCount: Record<string, number> = {}
   const unresolvedQty: Record<string, number> = {}
+  let excludedLogs = 0
+  let excludedLogQuantity = 0
+
   for (const l of input.logs || []) {
     // Labour (`Hour`) and energy (`kWh`) logs carry a raw_material_id instead of
     // an inventory item; they are not material and must not enter a metres-per-
     // piece rate.
-    if (!l?.is_committed || !l.inventory_item_id || !l.design_id) {
+    if (!l?.is_committed || !l.inventory_item_id) {
       continue
     }
-    const d = String(l.design_id)
+
+    /**
+     * 🔴 Was `|| !l.design_id`, which dropped every product-anchored log in
+     * silence from the moment #1618 made one possible.
+     */
+    const anchor = anchorOf(l)
+    if (!anchor) {
+      excludedLogs++
+      excludedLogQuantity = round(excludedLogQuantity + num(l.quantity))
+      continue
+    }
+    const d = remember(anchor)
     if (!l.production_run_id) {
       unattributed[d] = (unattributed[d] ?? 0) + 1
     }
@@ -247,7 +355,7 @@ export function reconcileDesigns(input: {
     consumed[d] = round((consumed[d] ?? 0) + raw * pieces)
   }
 
-  const designIds = new Set([
+  const anchorKeys = new Set([
     ...Object.keys(produced),
     ...Object.keys(provenance),
     ...Object.keys(consumed),
@@ -255,11 +363,18 @@ export function reconcileDesigns(input: {
   ])
 
   const out: DesignReconciliation[] = []
-  for (const design_id of designIds) {
+  for (const design_id of anchorKeys) {
+    const anchor = anchors.get(design_id)!
     const p = produced[design_id] ?? 0
     const c = consumed[design_id] ?? 0
     const unresolved = unresolvedCount[design_id] ?? 0
-    const rate = rates[design_id]
+    /**
+     * ⚠️ Rates are keyed by the anchor's own id, not by the composite key. They
+     * have always been design ids, and a product-anchored row simply has no
+     * rate until someone supplies one — `expected` stays null rather than
+     * borrowing a design's.
+     */
+    const rate = rates[anchor.id]
     const expected = rate != null && p > 0 ? round(rate * p) : null
     const implied = p > 0 && c > 0 ? round(c / p) : null
     const flags: ReconcileFlag[] = []
@@ -291,7 +406,10 @@ export function reconcileDesigns(input: {
     }
 
     out.push({
-      design_id,
+      anchor_type: anchor.type,
+      anchor_id: anchor.id,
+      design_id: anchor.type === "design" ? anchor.id : null,
+      product_id: anchor.type === "product" ? anchor.id : null,
       produced: p,
       shipped_from_stock: provenance[design_id] ?? 0,
       consumed: c,
@@ -305,6 +423,27 @@ export function reconcileDesigns(input: {
     })
   }
 
-  // Worst first: most produced with least accounted for.
-  return out.sort((a, b) => b.produced - a.produced || b.consumed - a.consumed)
+  return {
+    // Worst first: most produced with least accounted for.
+    rows: out.sort((a, b) => b.produced - a.produced || b.consumed - a.consumed),
+    excluded: {
+      logs: excludedLogs,
+      log_quantity: excludedLogQuantity,
+      runs: excludedRuns,
+    },
+  }
+}
+
+/**
+ * The rows only.
+ *
+ * ⚠️ A caller using this CANNOT SEE what was excluded, so anything that reports
+ * to a human must call `reconcileConsumption` and say so. Kept because the
+ * exclusions are a property of the pass, not of a row, and most tests only care
+ * about the arithmetic.
+ */
+export function reconcileDesigns(
+  input: Parameters<typeof reconcileConsumption>[0]
+): DesignReconciliation[] {
+  return reconcileConsumption(input).rows
 }


### PR DESCRIPTION
Closes #1619.

`reconcile-production-consumption` opened with

```ts
if (!l?.is_committed || !l.inventory_item_id || !l.design_id) continue
```

and filtered runs by `r.design_id` on the produced side. That was total before #1618. Since a consumption log can hang off a **product**, both halves of the comparison silently omitted product-anchored work — and the job grouped by `design_id`, so there was no bucket for it to land in.

🔴 The risk is the one #1559/#1600 already demonstrated: a report-only job's failure mode is a **bad instruction**. Showing material as missing when it was recorded against a product tells an operator to correct data that is already correct. The 3m Kala Cotton log committed to prod earlier today is exactly that row.

## What changed

- **Rows are keyed by an ANCHOR** — `design:<id>` or `product:<id>` — not by a design. The **design wins when both are present**: 4 of 122 prod runs carry both, and every rate, report and expectation is design-keyed, so preferring the product would silently move them into a new bucket.
- **`reconcileConsumption` returns `{ rows, excluded }`.** A run or log anchored to neither is counted and named in the job summary — said out loud *even when zero*, because "0 excluded" is a claim about coverage and saying nothing is not. `reconcileDesigns` stays as the rows-only form, documented as unfit for anything that reports to a human.
- **Leaf resolution runs over ALL runs before any anchor filter.** Filtering first would hide a parent from `leafRuns` and promote it back to a leaf, double-counting its children's output. There is a test for it.
- **A product row does not borrow a design's `ratePerUnit`.** `expected` stays null rather than manufacturing a variance.
- The job **projects `product_id`** on both runs and logs explicitly — a fold reading an anchor the query never fetched sees `undefined` and buckets every row as unattributable.

## Verification

7 new cases, 28 green in the suite. The first one **fails on the old code**: it returned no rows at all for a product-anchored run and its log, so `expect(rows).toHaveLength(1)` could not pass.

⚠️ Verified against **CI's** prod-build, not the local one. The local gate is currently failing on a **clean tree** with ~6 × TS2416 in `src/modules/payu-payment/service.ts` — cross-version type identity errors from four `@medusajs/types` copies coexisting in `node_modules/.pnpm` (2.14.2 / 2.18.0 / 2.19.0 ×2, all dated 15 Aug). Not this branch: `git stash -u` to a clean tree reproduces it, and CI's prod-build passed the same commit on #1629. Worth a `pnpm install` locally at some point.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01TLt1f38xqR8k2myCVxP8e4