### PR TITLE
fix(ops): the link backfill reported ignorance as "no payment" (#1622)

### DIFF
--- a/apps/backend/src/api/admin/ops/maintenance-jobs/__tests__/backfill-inventory-order-payment-links.unit.spec.ts
+++ b/apps/backend/src/api/admin/ops/maintenance-jobs/__tests__/backfill-inventory-order-payment-links.unit.spec.ts
@@ -26,8 +26,16 @@ const makeContainer = (opts: {
 
   const query = {
     graph: jest.fn(async ({ entity, filters }: any) => {
-      if (entity === "payment_submission") {
-        const ids = opts.payments?.[filters.id] ?? []
+      if (entity === "payment_submissions" || entity === "payment_submission") {
+        /**
+         * `undefined` in the fixture means the relation was DROPPED — the key
+         * is absent from the node, which is what a wrong entity/field spelling
+         * actually looks like on `query.graph`. Distinct from `[]`.
+         */
+        const ids = opts.payments?.[filters.id]
+        if (ids === undefined) {
+          return { data: [{ id: filters.id }] }
+        }
         return { data: [{ id: filters.id, payments: ids.map((id) => ({ id })) }] }
       }
       if (entity === "inventory_orders") {
@@ -219,5 +227,46 @@ describe("backfill-inventory-order-payment-links", () => {
     expect(result.errors?.[0]?.message).toBe("link exploded")
     // The second order still got its edge.
     expect(linkCreate).toHaveBeenCalledTimes(2)
+  })
+})
+
+/**
+ * 🔴 The defect the FIRST production dry-run exposed.
+ *
+ * It reported all four payouts as "no payment record yet" — including GOF,
+ * whose ₹30,000 payment demonstrably exists. On `query.graph` an unknown
+ * relation is silently DROPPED (the key is absent) while a real-but-empty one
+ * returns `[]`; reading `data?.[0]?.payments` collapsed those into "none", and
+ * the job reported ignorance as a finding.
+ */
+describe("could-not-look is not no-payment", () => {
+  it("reports UNRESOLVED, not 'no payment', when the relation is dropped", async () => {
+    // `payments` absent from the fixture ⇒ the key is missing on the node.
+    const { container, linkCreate } = makeContainer({ items: [line()] })
+
+    const result = await backfillInventoryOrderPaymentLinksJob.run(container, {
+      dry_run: false,
+      params: {},
+    } as any)
+
+    expect(linkCreate).not.toHaveBeenCalled()
+    expect(result.summary).toContain("COULD NOT BE RESOLVED")
+    // The claim it must NOT make.
+    expect(result.summary).not.toContain("no payment record yet")
+  })
+
+  it("still reports 'no payment' when it genuinely looked and found none", async () => {
+    const { container } = makeContainer({
+      items: [line({ submission: { id: "sub_1", status: "Pending" } })],
+      payments: { sub_1: [] },
+    })
+
+    const result = await backfillInventoryOrderPaymentLinksJob.run(container, {
+      dry_run: false,
+      params: {},
+    } as any)
+
+    expect(result.summary).toContain("no payment record yet")
+    expect(result.summary).not.toContain("COULD NOT BE RESOLVED")
   })
 })

--- a/apps/backend/src/api/admin/ops/maintenance-jobs/backfill-inventory-order-payment-links-job.ts
+++ b/apps/backend/src/api/admin/ops/maintenance-jobs/backfill-inventory-order-payment-links-job.ts
@@ -110,6 +110,12 @@ export const backfillInventoryOrderPaymentLinksJob: MaintenanceJob = {
     const errors: Array<{ id: string; message: string }> = []
     /** Named an order but the payout has no payment record yet. */
     const noPayment: Array<{ submission_id: string; status: string }> = []
+    /**
+     * Named an order and the payment lookup COULD NOT ANSWER. Kept apart from
+     * `noPayment` deliberately: reporting ignorance as "no payment" is how a
+     * report-only job turns into a wrong instruction.
+     */
+    const unresolved: Array<{ submission_id: string; status: string }> = []
     let alreadyLinked = 0
 
     /** submission id → its payment ids, resolved once per submission. */
@@ -117,20 +123,56 @@ export const backfillInventoryOrderPaymentLinksJob: MaintenanceJob = {
     /** inventory order id → the payment ids already linked to it. */
     const linkedByOrder = new Map<string, Set<string>>()
 
-    const paymentsFor = async (submissionId: string): Promise<string[]> => {
+    /**
+     * 🔴 `null` means COULD NOT LOOK; `[]` means looked and found none.
+     *
+     * The first dry-run on production reported all four payouts as "no payment
+     * record yet" — including GOF, whose ₹30,000 payment demonstrably exists.
+     * The cause is the trap this codebase keeps hitting: on `query.graph` an
+     * UNKNOWN relation is silently DROPPED, so the key is simply absent, while
+     * a real-but-empty one returns `[]`. Reading `data?.[0]?.payments` collapsed
+     * those two into "no payments", and the job then reported ignorance as an
+     * answer — the exact shape of #1557 and #1565.
+     *
+     * ⚠️ The module registers as `payment_submissions` (plural) — see the
+     * working graph calls in `workflows/whatsapp/*` — while the MODEL is
+     * `payment_submission`. The singular resolved without throwing and returned
+     * rows carrying no `payments` key at all, which is why this looked like a
+     * data answer rather than a spelling mistake.
+     */
+    const paymentsFor = async (
+      submissionId: string
+    ): Promise<string[] | null> => {
       if (paymentsBySubmission.has(submissionId)) {
         return paymentsBySubmission.get(submissionId)!
       }
-      const { data } = await query.graph({
-        entity: "payment_submission",
-        fields: ["id", "payments.id"],
-        filters: { id: submissionId },
-      })
-      const raw = (data || [])[0]?.payments
-      const ids = (!raw ? [] : Array.isArray(raw) ? raw : [raw])
-        .map((p: any) => p?.id)
-        .filter(Boolean) as string[]
-      paymentsBySubmission.set(submissionId, ids)
+
+      const read = async (entity: string): Promise<string[] | null> => {
+        try {
+          const { data } = await query.graph({
+            entity,
+            fields: ["id", "payments.id"],
+            filters: { id: submissionId },
+          })
+          const node = (data || [])[0]
+          if (!node) return null
+          // Key ABSENT — the relation was dropped, so this is ignorance.
+          if (!("payments" in node)) return null
+
+          const raw = (node as any).payments
+          return (!raw ? [] : Array.isArray(raw) ? raw : [raw])
+            .map((p: any) => p?.id)
+            .filter(Boolean) as string[]
+        } catch {
+          return null
+        }
+      }
+
+      // Plural first: it is the spelling the working graph calls in this
+      // codebase use. The singular is tried only as a fallback.
+      const ids = (await read("payment_submissions")) ?? (await read("payment_submission"))
+
+      if (ids) paymentsBySubmission.set(submissionId, ids)
       return ids
     }
 
@@ -162,12 +204,25 @@ export const backfillInventoryOrderPaymentLinksJob: MaintenanceJob = {
       try {
         const paymentIds = submissionId ? await paymentsFor(submissionId) : []
 
+        /**
+         * 🔴 COULD NOT LOOK. Never reported as "no payment": that is ignorance
+         * presented as a finding, and it would tell a reader this payout has no
+         * payment record when the truth is that the query could not answer.
+         */
+        if (paymentIds === null) {
+          unresolved.push({
+            submission_id: submissionId || "(unknown)",
+            status: String(item?.submission?.status || "unknown"),
+          })
+          continue
+        }
+
         if (!paymentIds.length) {
           /**
-           * No payment exists, so there is nothing to link. Reported rather
-           * than silently dropped: a Pending payout naming an order is a real
-           * state, and a reader must not mistake this job's silence about it
-           * for "already linked".
+           * Looked, and there is genuinely no payment yet. Reported rather than
+           * silently dropped: a Pending payout naming an order is a real state,
+           * and a reader must not mistake this job's silence for "already
+           * linked".
            */
           noPayment.push({
             submission_id: submissionId || "(unknown)",
@@ -223,6 +278,13 @@ export const backfillInventoryOrderPaymentLinksJob: MaintenanceJob = {
     if (noPayment.length) {
       parts.push(
         `${noPayment.length} line(s) name an inventory order but their payout has no payment record yet — nothing to link: ${noPayment
+          .map((n) => `${n.submission_id} (${n.status})`)
+          .join(", ")}`
+      )
+    }
+    if (unresolved.length) {
+      parts.push(
+        `🔴 ${unresolved.length} line(s) COULD NOT BE RESOLVED — the payment lookup returned no answer, which is NOT the same as "no payment". These may well have payments and are not covered by this run: ${unresolved
           .map((n) => `${n.submission_id} (${n.status})`)
           .join(", ")}`
       )


### PR DESCRIPTION
Found by running #1626's job against production, which is the only reason this surfaced at all.

## What happened

The first dry-run reported **all four** payouts as *"no payment record yet"* — including GOF (`01M13MPTSC…`, **Paid**), whose ₹30,000 payment `01M13QV30QSF…` demonstrably exists and is visible on the partner record.

The job was not looking where it thought. On `query.graph` an **unknown relation is silently DROPPED** — the key is simply absent from the node — while a **real-but-empty** one returns `[]`. Reading `data?.[0]?.payments` collapsed those two into "no payments", so a spelling mistake presented itself as a finding about the data.

⚠️ The module registers as **`payment_submissions`** (plural) — the spelling every working graph call in `workflows/whatsapp/*` uses — while the **model** is `payment_submission`. The singular resolved *without throwing* and returned rows carrying no `payments` key at all. That silence is why it read as an answer rather than a bad query.

## The fix

- `paymentsFor` returns `string[] | null`. **`null` is "could not look"; `[]` is "looked and found none."** The plural entity is tried first, the singular only as a fallback.
- A `null` goes to its own bucket and is reported loudly — never folded into "no payment record yet".

That distinction is the whole point. Ignorance stated as a finding is how a report-only job becomes a wrong instruction, which is the failure mode this file's own header already cites (#1557, #1565). I wrote the header and then made the mistake one function below it.

## Verification

2 new cases pin the three-way distinction, with the fixture modelling a **dropped key** (absent from the node) separately from an **empty list** — the two states the old code could not tell apart. 11 green. `check:prod-build` passes.

**Nothing was written by the bad run.** It was a dry-run, and it proposed no changes precisely because it believed there were no payments to link. I will re-run the dry-run after this deploys and report what it actually finds.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01TLt1f38xqR8k2myCVxP8e4