### PR TITLE
fix(payments): unbreak the deploy — resolve(LOGGER) is `unknown` in 2.19

### DIFF
--- a/apps/backend/src/workflows/payment_submissions/review-payment-submission.ts
+++ b/apps/backend/src/workflows/payment_submissions/review-payment-submission.ts
@@ -317,12 +317,19 @@ const linkPaymentToInventoryOrderStep = createStep(
     try {
       await remoteLink.create([link])
     } catch (e: any) {
-      container
-        .resolve(ContainerRegistrationKeys.LOGGER)
-        .warn(
-          `[review-payment-submission] payment ${input.payment_id} recorded but ` +
-            `could not be linked to inventory order ${input.inventory_order_id}: ${e?.message}`
-        )
+      /**
+       * ⚠️ Assigned through `any` rather than chained off `container.resolve`.
+       * Medusa 2.19 types `resolve` as `unknown`, so `resolve(LOGGER).warn(…)`
+       * is `TS2571: Object is of type 'unknown'` — which broke the deploy of
+       * `24f12a1b5` while `check:prod-build` passed both locally and in CI,
+       * because the Docker build resolves a different @medusajs/types than
+       * either. Every other logger in this file is already assigned first.
+       */
+      const logger: any = container.resolve(ContainerRegistrationKeys.LOGGER)
+      logger?.warn?.(
+        `[review-payment-submission] payment ${input.payment_id} recorded but ` +
+          `could not be linked to inventory order ${input.inventory_order_id}: ${e?.message}`
+      )
       return new StepResponse<LinkDefinition | null>(null)
     }
 


### PR DESCRIPTION
🔴 **`main` is currently undeployable.** The deploy of `24f12a1b5` failed at Build & Push Image:

```
src/workflows/payment_submissions/review-payment-submission.ts:320:7
error TS2571: Object is of type 'unknown'.
```

One error, one line: `container.resolve(ContainerRegistrationKeys.LOGGER).warn(…)`, chained. Medusa 2.19 types `resolve` as `unknown`, so the chained call cannot compile. Every other logger in this file is assigned to a variable first; this one was written inline in #1621.

The fix assigns through `any` and uses optional calls, matching the file's own existing pattern.

## Why neither gate caught it

`check:prod-build` **passes locally and passed in CI** on this exact tree. The Docker build resolves a different `@medusajs/types` than either — and that is the version typing `resolve` as `unknown`. Same dependency drift behind today's local duplicate-`@medusajs/types` failures, where four copies (2.14.2 / 2.18.0 / 2.19.0 ×2) coexist in `node_modules/.pnpm`.

⚠️ **A green `check:prod-build` does not prove the image builds.** The authority for that is the Deploy workflow's own *Build & Push Image* job. That is worth knowing independently of this fix, because it means the gate I have been reporting as verification is weaker than I have been treating it.

## What this means for what is merged

Nothing has shipped since `acc2a2709`. **#1631 (editable payout notes) and #1632 (the backfill ignorance fix) are merged but NOT live** — they are in the image that failed to build. This PR unblocks all three together.

The prod work waiting on that deploy: re-running the backfill dry-run, and correcting the ₹10,000 note on `01M0Y336X9…`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01TLt1f38xqR8k2myCVxP8e4