### PR TITLE
fix(ops): resolve a payout's payment from the reconciliation column (#1622)

### DIFF
--- a/apps/backend/src/api/admin/ops/maintenance-jobs/__tests__/backfill-inventory-order-payment-links.unit.spec.ts
+++ b/apps/backend/src/api/admin/ops/maintenance-jobs/__tests__/backfill-inventory-order-payment-links.unit.spec.ts
@@ -17,27 +17,32 @@ type Item = Record<string, any>
 
 const makeContainer = (opts: {
   items: Item[]
-  /** submission id → payment ids the submission↔payment link holds. */
+  /**
+   * submission id → the payment ids its RECONCILIATION rows name.
+   *
+   * `undefined` means NO reconciliation row exists — ignorance, not "no
+   * payment". `[]` means a row exists carrying no `payment_id`, which is a
+   * real answer: nothing was paid.
+   */
   payments?: Record<string, string[]>
   /** inventory order id → payment ids ALREADY linked to it. */
   linked?: Record<string, string[]>
 }) => {
   const linkCreate = jest.fn().mockResolvedValue(undefined)
 
+  const listPaymentReconciliations = jest.fn(async ({ reference_id }: any) => {
+    const ids = opts.payments?.[reference_id]
+    if (ids === undefined) return []
+    if (!ids.length) return [{ id: "rec_1", reference_id, payment_id: null }]
+    return ids.map((payment_id, i) => ({
+      id: `rec_${i}`,
+      reference_id,
+      payment_id,
+    }))
+  })
+
   const query = {
     graph: jest.fn(async ({ entity, filters }: any) => {
-      if (entity === "payment_submissions" || entity === "payment_submission") {
-        /**
-         * `undefined` in the fixture means the relation was DROPPED — the key
-         * is absent from the node, which is what a wrong entity/field spelling
-         * actually looks like on `query.graph`. Distinct from `[]`.
-         */
-        const ids = opts.payments?.[filters.id]
-        if (ids === undefined) {
-          return { data: [{ id: filters.id }] }
-        }
-        return { data: [{ id: filters.id, payments: ids.map((id) => ({ id })) }] }
-      }
       if (entity === "inventory_orders") {
         const ids = opts.linked?.[filters.id] ?? []
         return {
@@ -54,13 +59,14 @@ const makeContainer = (opts: {
     resolve: (key: string) => {
       if (key === "query") return query
       if (key === "link" || key === "remoteLink") return { create: linkCreate }
+      if (key === "payment_reports") return { listPaymentReconciliations }
       return {
         listPaymentSubmissionItems: jest.fn().mockResolvedValue(opts.items),
       }
     },
   } as any
 
-  return { container, linkCreate }
+  return { container, linkCreate, listPaymentReconciliations }
 }
 
 const line = (over: Item = {}): Item => ({
@@ -240,8 +246,8 @@ describe("backfill-inventory-order-payment-links", () => {
  * the job reported ignorance as a finding.
  */
 describe("could-not-look is not no-payment", () => {
-  it("reports UNRESOLVED, not 'no payment', when the relation is dropped", async () => {
-    // `payments` absent from the fixture ⇒ the key is missing on the node.
+  it("reports UNRESOLVED, not 'no payment', when NO reconciliation row exists", async () => {
+    // No row at all ⇒ nothing has told this job whether a payment exists.
     const { container, linkCreate } = makeContainer({ items: [line()] })
 
     const result = await backfillInventoryOrderPaymentLinksJob.run(container, {

--- a/apps/backend/src/api/admin/ops/maintenance-jobs/backfill-inventory-order-payment-links-job.ts
+++ b/apps/backend/src/api/admin/ops/maintenance-jobs/backfill-inventory-order-payment-links-job.ts
@@ -5,6 +5,7 @@ import type { Link } from "@medusajs/modules-sdk"
 
 import { INTERNAL_PAYMENTS_MODULE } from "../../../../modules/internal_payments"
 import { ORDER_INVENTORY_MODULE } from "../../../../modules/inventory_orders"
+import { PAYMENT_REPORTS_MODULE } from "../../../../modules/payment_reports"
 import { PAYMENT_SUBMISSIONS_MODULE } from "../../../../modules/payment_submissions"
 import type PaymentSubmissionsService from "../../../../modules/payment_submissions/service"
 import type { MaintenanceChange, MaintenanceJob, MaintenanceJobResult } from "./registry"
@@ -84,6 +85,8 @@ export const backfillInventoryOrderPaymentLinksJob: MaintenanceJob = {
     )
     const query: any = container.resolve(ContainerRegistrationKeys.QUERY)
     const remoteLink = container.resolve(ContainerRegistrationKeys.LINK) as Link
+    /** Holds the submission↔payment pairing as COLUMNS. See `paymentsFor`. */
+    const reportsService: any = container.resolve(PAYMENT_REPORTS_MODULE)
 
     /**
      * Lines that name an inventory order. Read from the LINE, which is where
@@ -147,32 +150,44 @@ export const backfillInventoryOrderPaymentLinksJob: MaintenanceJob = {
         return paymentsBySubmission.get(submissionId)!
       }
 
-      const read = async (entity: string): Promise<string[] | null> => {
-        try {
-          const { data } = await query.graph({
-            entity,
-            fields: ["id", "payments.id"],
-            filters: { id: submissionId },
-          })
-          const node = (data || [])[0]
-          if (!node) return null
-          // Key ABSENT — the relation was dropped, so this is ignorance.
-          if (!("payments" in node)) return null
-
-          const raw = (node as any).payments
-          return (!raw ? [] : Array.isArray(raw) ? raw : [raw])
-            .map((p: any) => p?.id)
-            .filter(Boolean) as string[]
-        } catch {
-          return null
-        }
+      /**
+       * 🔑 The RECONCILIATION's `payment_id`, a plain scalar column — not a
+       * link traversal.
+       *
+       * Both graph spellings (`payment_submissions` and `payment_submission`)
+       * returned rows carrying no `payments` key at all, so neither could
+       * answer. `payment_reconciliation` records `reference_id` (the
+       * submission) and `payment_id` (the payment) side by side as columns,
+       * written by the same review workflow that creates the payment. On prod
+       * that resolves GOF's `01M13MPTSC…` to payment `01M13QV30QSF…` —
+       * the exact record visible on the partner.
+       *
+       * A column cannot be silently dropped the way an unrecognised relation
+       * can, which is the whole reason to prefer it here.
+       */
+      let rows: any[]
+      try {
+        rows = (await reportsService.listPaymentReconciliations({
+          reference_type: "payment_submission",
+          reference_id: submissionId,
+        })) as any[]
+      } catch {
+        // Could not look at all.
+        return null
       }
 
-      // Plural first: it is the spelling the working graph calls in this
-      // codebase use. The singular is tried only as a fallback.
-      const ids = (await read("payment_submissions")) ?? (await read("payment_submission"))
+      /**
+       * ⚠️ NO reconciliation row is ignorance, not "no payment". The row is
+       * what records the pairing; without one this job has not been told
+       * anything about whether a payment exists.
+       */
+      if (!rows?.length) return null
 
-      if (ids) paymentsBySubmission.set(submissionId, ids)
+      const ids = Array.from(
+        new Set(rows.map((r) => r?.payment_id).filter(Boolean))
+      ) as string[]
+
+      paymentsBySubmission.set(submissionId, ids)
       return ids
     }
 


### PR DESCRIPTION
Follow-up to #1632, found by running it against production.

#1632 made the backfill **honest** — it says *"COULD NOT BE RESOLVED"* instead of claiming *"no payment"*. Re-running it on prod confirmed both the honesty and that it still could not do its job:

```
🔴 4 line(s) COULD NOT BE RESOLVED — the payment lookup returned no answer,
which is NOT the same as "no payment".
```

## Neither graph spelling works

`payment_submissions` (the module name, used by every working graph call in `workflows/whatsapp/*`) and `payment_submission` (the model name) **both** return rows carrying no `payments` key at all. No throw, no error — just an absent relation. That is why the original code read it as a data answer.

## Use the column instead

`payment_reconciliation` records the pairing as plain **columns**: `reference_id` (the submission) beside `payment_id` (the payment), written by the same review workflow that creates the payment.

Verified on prod — every payout resolves:

| submission | → payment | partner |
|---|---|---|
| `01M13MPTSC…` | `01M13QV30QSF…` | Ghosh and Organic Fashionary |
| `01M13RM1AT…` | `01M13SZWDD…` | Sharlho |

GOF's is the exact record visible on the partner page, which is what made the original "no payment" claim detectably false.

🔑 **A column cannot be silently dropped the way an unrecognised relation can.** That is the reason to prefer it here, and it is the same lesson as the other two absence-shaped bugs today.

## The three-way answer, sharpened

| state | reported as |
|---|---|
| reconciliation rows naming payments | those payments |
| a reconciliation row with no `payment_id` | genuinely none |
| **no reconciliation row at all** | unresolved, loudly |

The fixture now models those three states directly, so the tests exercise the same distinction the job makes. 11 green, `check:prod-build` passes.

⚠️ Still to be proven by running it: a green build is not a working job, as this PR itself demonstrates. I will dry-run it on prod after deploy and report the actual output before applying anything.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01TLt1f38xqR8k2myCVxP8e4