### PR TITLE
fix(payments): a `total` run bills the agreed total, not a re-derived rate (#1596)

### DIFF
--- a/apps/backend/src/api/admin/payment-submissions/payable-runs/route.ts
+++ b/apps/backend/src/api/admin/payment-submissions/payable-runs/route.ts
@@ -311,6 +311,16 @@ export const GET = async (req: MedusaRequest, res: MedusaResponse) => {
         payable_quantity,
         quantity_basis: offer.quantity_basis,
         unit_amount,
+        /**
+         * ⚠️ Whether `unit_amount` was COMPUTED rather than agreed (#1596).
+         *
+         * True for every `cost_type: "total"` run — 97 of 100 on production —
+         * where the rate is `total / quantity` and `unit_amount * quantity`
+         * deliberately does NOT reproduce `amount`. A screen showing "7 ×
+         * ₹1,428.57" against a ₹10,000 line must say the rate is derived, or it
+         * is presenting arithmetic as a negotiated price.
+         */
+        unit_is_derived: offer.unit_is_derived,
         amount: offer.amount,
         cost_type: run.cost_type ?? null,
         partner_cost_estimate:

--- a/apps/backend/src/workflows/payment_submissions/__tests__/run-line-pricing-contract.unit.spec.ts
+++ b/apps/backend/src/workflows/payment_submissions/__tests__/run-line-pricing-contract.unit.spec.ts
@@ -102,7 +102,14 @@ describe("payable-runs offer === what create writes", () => {
 
     expect(written.amount).toBe(offered)
     expect(written.quantity).toBe(2)
-    expect(written.unit_amount).toBe(810)
+    /**
+     * ⚠️ Was `810`. Both runs are `cost_type: "total"`, so 810 is DERIVED —
+     * ₹810 agreed for one piece happens to divide to ₹810 — and #1596's rule is
+     * that a derived rate is never written down as an agreed one. Null here is
+     * the change, and it is the point: `unit_amount` states a price somebody
+     * agreed to, or nothing.
+     */
+    expect(written.unit_amount).toBeNull()
   })
 })
 

--- a/apps/backend/src/workflows/production-runs/__tests__/run-payable.unit.spec.ts
+++ b/apps/backend/src/workflows/production-runs/__tests__/run-payable.unit.spec.ts
@@ -1,4 +1,10 @@
-import { assessRunPayout, runPayableAmount, runUnitCost } from "../lib/run-payable"
+import {
+  assessRunPayout,
+  resolveRunLinePrice,
+  runPayableAmount,
+  runPayableOffer,
+  runUnitCost,
+} from "../lib/run-payable"
 
 describe("runPayableAmount", () => {
   it("multiplies a per-unit cost by the ORDERED quantity", () => {
@@ -215,5 +221,111 @@ describe("runUnitCost", () => {
     expect(runUnitCost({ quantity: 5 })).toBe(0)
     expect(runUnitCost({ partner_cost_estimate: -5 })).toBe(0)
     expect(runUnitCost(null)).toBe(0)
+  })
+})
+
+/**
+ * #1596 — a `total` run must not be re-priced by dividing and re-multiplying.
+ *
+ * Founder's rule, 2026-08-29: the total was the price for the JOB. What was
+ * produced is reported as produced, and rounding must never move the money.
+ */
+describe("runPayableOffer — a total is the agreed price, verbatim", () => {
+  const totalRun = (over: Record<string, any> = {}) => ({
+    id: "run_1",
+    partner_cost_estimate: 10000,
+    cost_type: "total" as const,
+    quantity: 7,
+    produced_quantity: 7,
+    ...over,
+  })
+
+  it("bills the agreed total exactly — no rounding drift", () => {
+    // Was ₹9,999.99: 10000/7 = 1428.57, x7 = 9999.99. A paisa lost to a
+    // division nobody asked for.
+    const offer = runPayableOffer(totalRun())
+
+    expect(offer.amount).toBe(10000)
+    expect(offer.quantity).toBe(7)
+  })
+
+  it("does NOT discount a partially completed run", () => {
+    // 🔴 Was ₹7,777.77 on ₹10,000 agreed — a 22% cut nobody decided.
+    const offer = runPayableOffer(totalRun({ quantity: 9, produced_quantity: 7 }))
+
+    expect(offer.amount).toBe(10000)
+    // What was produced is still reported as produced.
+    expect(offer.quantity).toBe(7)
+    expect(offer.quantity_basis).toBe("produced")
+  })
+
+  it("reports the per-unit figure as DERIVED, for display only", () => {
+    const offer = runPayableOffer(totalRun())
+
+    expect(offer.unit_amount).toBe(1428.57)
+    expect(offer.unit_is_derived).toBe(true)
+    // The point of the flag: this does not reproduce the amount.
+    expect(offer.unit_amount * offer.quantity).not.toBe(offer.amount)
+  })
+
+  it("treats an ABSENT cost_type as a total, like every other reader", () => {
+    const offer = runPayableOffer(totalRun({ cost_type: null }))
+
+    expect(offer.amount).toBe(10000)
+    expect(offer.unit_is_derived).toBe(true)
+  })
+
+  it("still multiplies a per_unit rate by what was produced", () => {
+    const offer = runPayableOffer({
+      id: "run_1",
+      partner_cost_estimate: 1200,
+      cost_type: "per_unit",
+      quantity: 9,
+      produced_quantity: 7,
+    })
+
+    expect(offer.amount).toBe(8400)
+    expect(offer.unit_amount).toBe(1200)
+    expect(offer.unit_is_derived).toBe(false)
+  })
+
+  it("is not payable with no agreed cost, and bills nothing", () => {
+    const offer = runPayableOffer(totalRun({ partner_cost_estimate: null }))
+
+    expect(offer.payable).toBe(false)
+    expect(offer.amount).toBe(0)
+  })
+})
+
+describe("resolveRunLinePrice — a derived rate is never written down", () => {
+  it("records NO unit_amount for a total-priced run", () => {
+    // Writing 1428.57 would state a price nobody agreed to.
+    const price = resolveRunLinePrice([
+      {
+        id: "run_1",
+        partner_cost_estimate: 10000,
+        cost_type: "total",
+        quantity: 7,
+        produced_quantity: 7,
+      } as any,
+    ])
+
+    expect(price?.amount).toBe(10000)
+    expect(price?.unit_amount).toBeNull()
+  })
+
+  it("still records an agreed per_unit rate", () => {
+    const price = resolveRunLinePrice([
+      {
+        id: "run_1",
+        partner_cost_estimate: 1200,
+        cost_type: "per_unit",
+        quantity: 7,
+        produced_quantity: 7,
+      } as any,
+    ])
+
+    expect(price?.amount).toBe(8400)
+    expect(price?.unit_amount).toBe(1200)
   })
 })

--- a/apps/backend/src/workflows/production-runs/lib/run-payable.ts
+++ b/apps/backend/src/workflows/production-runs/lib/run-payable.ts
@@ -96,12 +96,30 @@ export const runUnitCost = (run: RunForPayout | null | undefined): number => {
  * papered over.
  */
 export type RunPayableOffer = {
-  /** The agreed rate per finished unit, or 0 when the run carries none. */
+  /**
+   * The rate per finished unit.
+   *
+   * ⚠️ For a `total` run this is DERIVED for display — `unit_is_derived` says
+   * so — and `unit_amount * quantity` deliberately does NOT reproduce `amount`.
+   * Read `amount` for the money; read this only to show a rate.
+   */
   unit_amount: number
+  /** Whether `unit_amount` was computed rather than agreed. */
+  unit_is_derived: boolean
   /** Units billed — produced where recorded, else ordered, never below 1. */
   quantity: number
   quantity_basis: "produced" | "ordered"
-  /** unit_amount x quantity, to two decimals. */
+  /**
+   * What is owed.
+   *
+   * 🔴 For `cost_type: "total"` this is the agreed total VERBATIM. It is not
+   * `unit_amount * quantity`: dividing a total by the ordered quantity and
+   * re-multiplying by the produced one silently RE-PRICES the job. On a real
+   * run — ₹10,000 agreed, 9 ordered, 7 made — that arithmetic billed ₹7,777.77,
+   * a 22% cut nobody decided, and even when ordered equalled produced it lost a
+   * paisa to rounding (₹9,999.99). The total was the price for the job; a
+   * shortfall in output is a conversation, not an automatic discount. (#1596)
+   */
   amount: number
   /**
    * Whether the RUN carries an agreed rate.
@@ -116,10 +134,6 @@ export type RunPayableOffer = {
 export const runPayableOffer = (
   run: RunForPayout & { produced_quantity?: number | null }
 ): RunPayableOffer => {
-  // `runUnitCost` divides a "total" cost_type back out and takes a "per_unit"
-  // one verbatim — one place, one convention.
-  const unit_amount = runUnitCost(run)
-
   const produced = Number(run?.produced_quantity)
   const hasProduced = Number.isFinite(produced) && produced > 0
   const ordered = Number(run?.quantity)
@@ -129,12 +143,53 @@ export const runPayableOffer = (
       ? ordered
       : 1
 
+  const agreed = Number(run?.partner_cost_estimate)
+  const hasAgreed = Number.isFinite(agreed) && agreed > 0
+
+  /**
+   * 🔑 `"per_unit"` is the ONLY value meaning per-unit; everything else,
+   * including an absent `cost_type`, is a TOTAL. Same convention as
+   * `runPayableAmount` and `runUnitCost`.
+   */
+  const isPerUnit = run?.cost_type === "per_unit"
+
+  if (!hasAgreed) {
+    return {
+      unit_amount: 0,
+      unit_is_derived: false,
+      quantity,
+      quantity_basis: hasProduced ? "produced" : "ordered",
+      amount: 0,
+      payable: false,
+    }
+  }
+
+  if (isPerUnit) {
+    // A rate the partner typed. Multiplying it by what they made is the whole
+    // meaning of "per unit".
+    return {
+      unit_amount: agreed,
+      unit_is_derived: false,
+      quantity,
+      quantity_basis: hasProduced ? "produced" : "ordered",
+      amount: Math.round(agreed * quantity * 100) / 100,
+      payable: true,
+    }
+  }
+
+  /**
+   * A TOTAL. The agreed figure stands verbatim — see `amount` above for why
+   * dividing and re-multiplying it is a silent re-pricing. The per-unit figure
+   * is derived purely so a screen can show a rate, and is flagged as such
+   * because `unit_amount * quantity` will not reproduce `amount`.
+   */
   return {
-    unit_amount,
+    unit_amount: Math.round((agreed / quantity) * 100) / 100,
+    unit_is_derived: true,
     quantity,
     quantity_basis: hasProduced ? "produced" : "ordered",
-    amount: Math.round(unit_amount * quantity * 100) / 100,
-    payable: unit_amount > 0,
+    amount: agreed,
+    payable: true,
   }
 }
 
@@ -162,8 +217,19 @@ export const resolveRunLinePrice = (
     Math.round(offers.reduce((acc, o) => acc + o.amount, 0) * 100) / 100
   const quantity = offers.reduce((acc, o) => acc + o.quantity, 0)
 
+  /**
+   * 🔴 A DERIVED rate is not recorded on the line.
+   *
+   * `payment_submission_item.unit_amount` means "the rate the total was built
+   * from" — and for a `total` run the total was not built from a rate, it WAS
+   * the agreed figure. Writing 1428.57 there would state a price nobody agreed
+   * to, and a reader multiplying it by 7 would get ₹9,999.99 against a line of
+   * ₹10,000. Null is the honest value; the screen can still show a derived rate
+   * from `runPayableOffer` without it being written down as fact. (#1596)
+   */
   const rates = new Set(offers.map((o) => o.unit_amount))
-  const unit_amount = rates.size === 1 ? offers[0].unit_amount : null
+  const anyDerived = offers.some((o) => o.unit_is_derived)
+  const unit_amount = !anyDerived && rates.size === 1 ? offers[0].unit_amount : null
 
   return { amount, quantity, unit_amount }
 }


### PR DESCRIPTION
Addresses the money half of #1596. Founder's rule, 2026-08-29: **the total was the price for the job**; what was produced is reported as produced, and rounding must never move the money.

## What was happening — measured, not reasoned

`runPayableOffer` computed `amount` as `unit_amount × quantity`, where `unit_amount` came from dividing the agreed total by the **ordered** quantity and `quantity` was the **produced** one:

```
ordered 7, produced 7, total ₹10,000  →  ₹9,999.99   (a paisa lost to rounding)
ordered 9, produced 7, total ₹10,000  →  ₹7,777.77   (a 22% cut)
```

The second is the serious one: a shortfall in output silently became a discount nobody decided.

**This is not an edge case.** On production: **97 of 100** runs carry `cost_type: "total"`, and **26** of those have quantity > 1.

## The rule now

| cost_type | amount |
|---|---|
| `total` (and absent, per the existing convention) | the agreed figure **verbatim** — never divided, so nothing to round |
| `per_unit` | unchanged: the typed rate × what was produced |

`quantity` still reports what was produced. A shortfall is a conversation, not an automatic re-price.

## unit_amount stays honest

This is #1596's fourth open question — *"a mixed-price run must not produce a `unit_amount` nobody agreed to"* — and it applies to every total-priced run, not just mixed ones.

- The offer carries **`unit_is_derived`**, true for every total-priced run, and `unit_amount × quantity` deliberately does **not** reproduce `amount`. `payable-runs` exposes it so a screen cannot present arithmetic as a negotiated price.
- 🔴 `resolveRunLinePrice` no longer **writes** a derived rate onto the payment line. `payment_submission_item.unit_amount` means *"the rate the total was built from"*; a total was not built from a rate. Writing 1428.57 there would state a price nobody agreed to, and multiplying it by 7 gives ₹9,999.99 against a ₹10,000 line. Null is the honest value.

## Scope

This is the **money** half. The schema question in #1596 — a table of per-piece rates below the run — is deliberately **not** done here, because the evidence does not support it yet: of 21 payout lines on production exactly **one** is a genuine mixed-per-piece case, and its total was already correct. The damage there is to explanation, not amount. Leaving #1596 open for that half.

## Behaviour change to be aware of

`payable-runs` will now offer the full agreed total for a partially completed total-priced run — e.g. ₹10,000 rather than ₹7,777.77. That is the intended fix, and it is the founder's call.

⚠️ One contract test changed its expectation from `810` to `null`. Both of its runs are total-priced, so 810 was derived; the new value is the fix, not a regression. Called out in the test itself.

99 green across the payment/run pricing suites. `check:prod-build` passes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01TLt1f38xqR8k2myCVxP8e4