### PR TITLE
feat(payments): a payout is a submission with a linked method, and `Paid` means settled (#1636, #1639)

### DIFF
--- a/apps/backend/integration-tests/http/payment-submissions-api.spec.ts
+++ b/apps/backend/integration-tests/http/payment-submissions-api.spec.ts
@@ -1883,16 +1883,22 @@ setupSharedTestSuite(() => {
       expect(reviewRes.data.paid_to).toBeDefined()
       expect(reviewRes.data.paid_to.id).toBe(paidToId)
 
-      // Verify submission status is now Paid
+      /**
+       * 🔴 Approval stops at `Approved` (#1639). The assertion this replaces
+       * demanded `Paid` here. In production the gap between approval and the
+       * money actually moving was 13 seconds, 8 minutes, 2 days, 6 days and
+       * 34 days — for 34 days a payout read `Paid` and the partner had been
+       * told so, while nothing had been sent.
+       */
       const detail = await api.get(
         `/admin/payment-submissions/${submissionId}`,
         adminHeaders
       )
-      expect(detail.data.payment_submission.status).toBe("Paid")
+      expect(detail.data.payment_submission.status).toBe("Approved")
       expect(detail.data.payment_submission.reviewed_at).toBeDefined()
       expect(detail.data.payment_submission.reviewed_by).toBeDefined()
-      // When money moved — distinct from `status: "Paid"`, which approval sets.
-      expect(detail.data.payment_submission.paid_at).toBeTruthy()
+      // Nothing has moved yet, so nothing claims it has.
+      expect(detail.data.payment_submission.paid_at).toBeFalsy()
 
       /**
        * And no `internal_payments` row appeared for it. Asserted by COUNT
@@ -1923,6 +1929,27 @@ setupSharedTestSuite(() => {
       expect(Number(recon.expected_amount)).toBe(10000)
       expect(Number(recon.actual_amount)).toBe(10000)
       expect(Number(recon.discrepancy)).toBe(0)
+
+      /**
+       * Settling is the moment money is recorded as having moved, and it
+       * carries the submission with it — one action, both records, so the two
+       * cannot drift into the disagreement #1636 was opened about.
+       */
+      const settled = await api.post(
+        `/admin/payment_reports/reconciliation/${recon.id}/settle`,
+        {},
+        adminHeaders
+      )
+      expect(settled.status).toBe(200)
+      expect(settled.data.reconciliation.status).toBe("Settled")
+      expect(settled.data.reconciliation.settled_at).toBeTruthy()
+
+      const afterSettle = await api.get(
+        `/admin/payment-submissions/${submissionId}`,
+        adminHeaders
+      )
+      expect(afterSettle.data.payment_submission.status).toBe("Paid")
+      expect(afterSettle.data.payment_submission.paid_at).toBeTruthy()
     })
 
     /**
@@ -3209,10 +3236,15 @@ setupSharedTestSuite(() => {
         )
         .catch((e: any) => e.response)
 
-      // Rewriting a paid row makes our record disagree with what was actually
-      // paid, without putting a rupee in anyone's hand.
+      // Rewriting a committed row makes our record disagree with what was
+      // actually agreed, without putting a rupee in anyone's hand.
+      //
+      // The status named here is `Approved`, not `Paid`: approval stops at
+      // Approved since #1639, and the line is locked from that moment — the
+      // amount is agreed even though the transfer has not been made yet.
       expect(res.status).toBe(400)
-      expect(res.data.message).toContain("Paid")
+      expect(res.data.message).toContain("Approved")
+      expect(res.data.message).toContain("cannot be edited")
     })
 
     it("refuses an empty body rather than writing nothing and returning 200", async () => {

--- a/apps/backend/integration-tests/http/payment-submissions-api.spec.ts
+++ b/apps/backend/integration-tests/http/payment-submissions-api.spec.ts
@@ -1848,7 +1848,7 @@ setupSharedTestSuite(() => {
   // ─── Admin: Approve Submission ────────────────────────────────────────────
 
   describe("POST /admin/payment-submissions/:id/review", () => {
-    it("should approve a submission and create payment + reconciliation", async () => {
+    it("should approve a submission into a payout on the submission itself, creating NO internal payment (#1636)", async () => {
       const d1 = await createDesign("Approve Design", { estimated_cost: 10000 })
       await linkDesignToPartner(d1, partnerId)
 
@@ -1871,10 +1871,17 @@ setupSharedTestSuite(() => {
 
       expect(reviewRes.status).toBe(200)
       expect(reviewRes.data.payment_submission).toBeDefined()
-      expect(reviewRes.data.payment).toBeDefined()
-      expect(reviewRes.data.payment.id).toBeDefined()
-      expect(Number(reviewRes.data.payment.amount)).toBe(10000)
-      expect(reviewRes.data.payment.status).toBe("Pending")
+
+      /**
+       * 🔴 The assertion this replaces required `reviewRes.data.payment.id` and
+       * a `Pending` payment of 10000. That payment row was the second of the
+       * three records one payout used to exist as, and nothing ever moved it
+       * off Pending — the submission said Paid at the same moment. Approval no
+       * longer creates it (#1636).
+       */
+      expect(reviewRes.data.payment).toBeNull()
+      expect(reviewRes.data.paid_to).toBeDefined()
+      expect(reviewRes.data.paid_to.id).toBe(paidToId)
 
       // Verify submission status is now Paid
       const detail = await api.get(
@@ -1884,6 +1891,21 @@ setupSharedTestSuite(() => {
       expect(detail.data.payment_submission.status).toBe("Paid")
       expect(detail.data.payment_submission.reviewed_at).toBeDefined()
       expect(detail.data.payment_submission.reviewed_by).toBeDefined()
+      // When money moved — distinct from `status: "Paid"`, which approval sets.
+      expect(detail.data.payment_submission.paid_at).toBeTruthy()
+
+      /**
+       * And no `internal_payments` row appeared for it. Asserted by COUNT
+       * across the whole list rather than by absence of a key: a wrong response
+       * key reads as a confident nothing, and this is exactly the claim the
+       * issue was opened about.
+       */
+      const paymentsAfter = await api.get("/admin/payments?limit=100", adminHeaders)
+      expect(paymentsAfter.status).toBe(200)
+      const matching = (paymentsAfter.data.payments || []).filter(
+        (pmt: any) => Number(pmt.amount) === 10000 && pmt.status === "Pending"
+      )
+      expect(matching).toHaveLength(0)
 
       // Verify reconciliation record was created
       const reconRes = await api.get(
@@ -1901,6 +1923,106 @@ setupSharedTestSuite(() => {
       expect(Number(recon.expected_amount)).toBe(10000)
       expect(Number(recon.actual_amount)).toBe(10000)
       expect(Number(recon.discrepancy)).toBe(0)
+    })
+
+    /**
+     * 🔴 The four-branch method resolution (#1636).
+     *
+     * Production motivated every branch: Sharlho has FOUR bank accounts under
+     * one partner, one per employee, and three of them have been paid at
+     * different times. The code this replaces took `methods[0]` — whichever row
+     * the link query returned first — so approving without naming a method did
+     * not risk the wrong account, it risked the wrong PERSON.
+     */
+    it("should REFUSE approval when a partner has several methods and none is default", async () => {
+      // A second method, so the partner now has two and neither is default.
+      const second = await api.post(
+        `/admin/payments/partners/${partnerId}/methods`,
+        {
+          type: "bank_account",
+          account_name: "Second Employee Account",
+          bank_name: "Other Bank",
+        },
+        adminHeaders
+      )
+      const secondId = second.data.paymentMethod.id
+
+      const d1 = await createDesign("Ambiguous Method Design", {
+        estimated_cost: 4000,
+      })
+      await linkDesignToPartner(d1, partnerId)
+      const createRes = await api.post(
+        "/partners/payment-submissions",
+        { design_ids: [d1] },
+        { headers: partnerHeaders }
+      )
+      const submissionId = createRes.data.payment_submission.id
+
+      // No paid_to_id, no default → must refuse rather than pick.
+      const refused = await api
+        .post(
+          `/admin/payment-submissions/${submissionId}/review`,
+          { action: "approve" },
+          adminHeaders
+        )
+        .catch((e: any) => e.response)
+
+      expect(refused.status).toBe(400)
+      expect(String(refused.data?.message)).toContain("none is marked default")
+
+      // The refusal must not have half-approved it.
+      const stillPending = await api.get(
+        `/admin/payment-submissions/${submissionId}`,
+        adminHeaders
+      )
+      expect(stillPending.data.payment_submission.status).not.toBe("Paid")
+      expect(stillPending.data.payment_submission.paid_at).toBeFalsy()
+
+      // Mark one default → the same approval now resolves to THAT method.
+      await api.post(
+        `/partners/${partnerId}/payments/methods/${secondId}`,
+        { is_default: true },
+        { headers: partnerHeaders }
+      )
+
+      const approved = await api.post(
+        `/admin/payment-submissions/${submissionId}/review`,
+        { action: "approve" },
+        adminHeaders
+      )
+      expect(approved.status).toBe(200)
+      expect(approved.data.paid_to.id).toBe(secondId)
+
+      // Exclusive: promoting the second must have demoted the first.
+      const methods = await api.get(
+        `/admin/payments/partners/${partnerId}/methods`,
+        adminHeaders
+      )
+      const first = methods.data.paymentMethods.find((m: any) => m.id === paidToId)
+      expect(first.is_default).toBe(false)
+    })
+
+    it("should reject a paid_to_id that belongs to a different partner", async () => {
+      const d1 = await createDesign("Foreign Method Design", {
+        estimated_cost: 1500,
+      })
+      await linkDesignToPartner(d1, partnerId)
+      const createRes = await api.post(
+        "/partners/payment-submissions",
+        { design_ids: [d1] },
+        { headers: partnerHeaders }
+      )
+
+      const refused = await api
+        .post(
+          `/admin/payment-submissions/${createRes.data.payment_submission.id}/review`,
+          { action: "approve", paid_to_id: "ipd_not_this_partners_method" },
+          adminHeaders
+        )
+        .catch((e: any) => e.response)
+
+      expect(refused.status).toBe(400)
+      expect(String(refused.data?.message)).toContain("not one of this partner")
     })
 
     it("should create a discrepant reconciliation when amount_override differs", async () => {
@@ -1926,7 +2048,12 @@ setupSharedTestSuite(() => {
       )
 
       expect(reviewRes.status).toBe(200)
-      expect(Number(reviewRes.data.payment.amount)).toBe(7000)
+      /**
+       * The overridden amount used to be read off the created payment row.
+       * There is no payment row now (#1636) — reconciliation's `actual_amount`
+       * below is where the override lands, and it is asserted there.
+       */
+      expect(reviewRes.data.payment).toBeNull()
 
       // Verify reconciliation shows discrepancy
       const reconRes = await api.get(

--- a/apps/backend/src/api/admin/inventory-orders/[id]/payments/fold.ts
+++ b/apps/backend/src/api/admin/inventory-orders/[id]/payments/fold.ts
@@ -35,10 +35,11 @@ export type SubmissionLike = {
 /**
  * The one status that means money has actually left.
  *
- * ⚠️ `Approved` is deliberately NOT here. An approved submission has a payment
- * record but `markSubmissionPaidStep` is what flips it to Paid; counting
- * Approved as paid would tell an order it is settled while the transfer is
- * still owed.
+ * ⚠️ `Approved` is deliberately NOT here, and since #1639 that is load-bearing
+ * rather than cautious. Approval now STOPS at `Approved`; `Paid` is written by
+ * settling the reconciliation, which is the moment money is recorded as having
+ * moved. Counting Approved as paid would tell an order it is settled while the
+ * transfer is still owed — in production that window ran to 34 days.
  */
 const PAID_STATUSES = new Set(["Paid"])
 

--- a/apps/backend/src/api/admin/ops/maintenance-jobs/__tests__/backfill-submission-paid-at.unit.spec.ts
+++ b/apps/backend/src/api/admin/ops/maintenance-jobs/__tests__/backfill-submission-paid-at.unit.spec.ts
@@ -1,0 +1,194 @@
+import { backfillSubmissionPaidAtJob } from "../backfill-submission-paid-at-job"
+
+/**
+ * #1639 — stamp `paid_at` on payouts settled before the column existed.
+ *
+ * Driven against a fake container so the WRITE SHAPE is asserted, not merely
+ * the decision to write. The job's central claim is about what it REFUSES to
+ * do: a payout with no settlement evidence must be left null rather than dated
+ * from whatever timestamp happens to be nearby.
+ */
+
+const SETTLED_AT = new Date("2026-08-28T08:38:20.733Z")
+
+type Recon = Record<string, any>
+type Sub = Record<string, any>
+
+const makeContainer = (opts: { recons: Recon[]; subs: Sub[] }) => {
+  const updatePaymentSubmissions = jest.fn().mockResolvedValue(undefined)
+
+  const listPaymentReconciliations = jest.fn(async (filters: any) => {
+    return opts.recons.filter(
+      (r) =>
+        r.reference_type === filters.reference_type &&
+        r.status === filters.status
+    )
+  })
+
+  const listPaymentSubmissions = jest.fn(async ({ id }: any) =>
+    opts.subs.filter((s) => id.includes(s.id))
+  )
+
+  return {
+    updatePaymentSubmissions,
+    container: {
+      resolve: (key: string) => {
+        if (key === "payment_reports") return { listPaymentReconciliations }
+        if (key === "payment_submissions") {
+          return { listPaymentSubmissions, updatePaymentSubmissions }
+        }
+        throw new Error(`unexpected resolve(${key})`)
+      },
+    },
+  }
+}
+
+const recon = (over: Partial<Recon> = {}): Recon => ({
+  id: "rec_1",
+  reference_type: "payment_submission",
+  reference_id: "sub_1",
+  status: "Settled",
+  settled_at: SETTLED_AT,
+  settled_by: "user_1",
+  ...over,
+})
+
+const sub = (over: Partial<Sub> = {}): Sub => ({
+  id: "sub_1",
+  status: "Paid",
+  paid_at: null,
+  ...over,
+})
+
+describe("backfill-submission-paid-at (#1639)", () => {
+  it("stamps paid_at from the reconciliation's settled_at", async () => {
+    const { container, updatePaymentSubmissions } = makeContainer({
+      recons: [recon()],
+      subs: [sub()],
+    })
+
+    const res = await backfillSubmissionPaidAtJob.run(container, {
+      dry_run: false,
+      params: {},
+    })
+
+    expect(res.changes).toHaveLength(1)
+    expect(res.changes[0]).toMatchObject({
+      entity: "payment_submission",
+      id: "sub_1",
+      field: "paid_at",
+      before: null,
+      after: SETTLED_AT,
+    })
+    expect(updatePaymentSubmissions).toHaveBeenCalledWith({
+      id: "sub_1",
+      paid_at: SETTLED_AT,
+    })
+    expect(res.applied).toBe(true)
+  })
+
+  it("writes NOTHING on a dry run, while still reporting what it would do", async () => {
+    const { container, updatePaymentSubmissions } = makeContainer({
+      recons: [recon()],
+      subs: [sub()],
+    })
+
+    const res = await backfillSubmissionPaidAtJob.run(container, {
+      dry_run: true,
+      params: {},
+    })
+
+    expect(res.changes).toHaveLength(1)
+    expect(res.applied).toBe(false)
+    expect(updatePaymentSubmissions).not.toHaveBeenCalled()
+  })
+
+  /**
+   * 🔴 The assertion the whole job exists to keep honest.
+   *
+   * An unsettled payout has no evidence of when its money moved. A null
+   * `paid_at` says exactly that; any date written here would read as fact.
+   */
+  it("skips a payout whose reconciliation is not Settled", async () => {
+    const { container, updatePaymentSubmissions } = makeContainer({
+      recons: [recon({ status: "Matched", settled_at: null })],
+      subs: [sub({ status: "Approved" })],
+    })
+
+    const res = await backfillSubmissionPaidAtJob.run(container, {
+      dry_run: false,
+      params: {},
+    })
+
+    expect(res.changes).toHaveLength(0)
+    expect(updatePaymentSubmissions).not.toHaveBeenCalled()
+  })
+
+  it("reports a Settled row carrying no settled_at instead of dating it from elsewhere", async () => {
+    const { container, updatePaymentSubmissions } = makeContainer({
+      recons: [recon({ settled_at: null })],
+      subs: [sub()],
+    })
+
+    const res = await backfillSubmissionPaidAtJob.run(container, {
+      dry_run: false,
+      params: {},
+    })
+
+    expect(res.changes).toHaveLength(0)
+    expect(updatePaymentSubmissions).not.toHaveBeenCalled()
+    expect(res.summary).toContain("settled WITHOUT a settled_at")
+    expect(res.summary).toContain("sub_1")
+  })
+
+  it("leaves a payout that already carries a paid_at alone, so it is safe to re-run", async () => {
+    const existing = new Date("2026-01-01T00:00:00.000Z")
+    const { container, updatePaymentSubmissions } = makeContainer({
+      recons: [recon()],
+      subs: [sub({ paid_at: existing })],
+    })
+
+    const res = await backfillSubmissionPaidAtJob.run(container, {
+      dry_run: false,
+      params: {},
+    })
+
+    expect(res.changes).toHaveLength(0)
+    expect(updatePaymentSubmissions).not.toHaveBeenCalled()
+    expect(res.summary).toContain("1 already carried one")
+  })
+
+  it("honours limit, so a first pass can be bounded", async () => {
+    const { container } = makeContainer({
+      recons: [
+        recon({ id: "rec_1", reference_id: "sub_1" }),
+        recon({ id: "rec_2", reference_id: "sub_2" }),
+        recon({ id: "rec_3", reference_id: "sub_3" }),
+      ],
+      subs: [sub({ id: "sub_1" }), sub({ id: "sub_2" }), sub({ id: "sub_3" })],
+    })
+
+    const res = await backfillSubmissionPaidAtJob.run(container, {
+      dry_run: true,
+      params: { limit: 2 },
+    })
+
+    expect(res.changes).toHaveLength(2)
+  })
+
+  it("states WHY each row was chosen, so a dry run can be argued with", async () => {
+    const { container } = makeContainer({
+      recons: [recon()],
+      subs: [sub()],
+    })
+
+    const res = await backfillSubmissionPaidAtJob.run(container, {
+      dry_run: true,
+      params: {},
+    })
+
+    expect(res.changes[0].note).toContain("rec_1")
+    expect(res.changes[0].note).toContain("Settled")
+    expect(res.changes[0].note).toContain("user_1")
+  })
+})

--- a/apps/backend/src/api/admin/ops/maintenance-jobs/backfill-submission-paid-at-job.ts
+++ b/apps/backend/src/api/admin/ops/maintenance-jobs/backfill-submission-paid-at-job.ts
@@ -1,0 +1,210 @@
+import { MedusaError } from "@medusajs/framework/utils"
+import { z } from "@medusajs/framework/zod"
+
+import { PAYMENT_REPORTS_MODULE } from "../../../../modules/payment_reports"
+import { PAYMENT_SUBMISSIONS_MODULE } from "../../../../modules/payment_submissions"
+import type PaymentSubmissionsService from "../../../../modules/payment_submissions/service"
+import type { MaintenanceChange, MaintenanceJob, MaintenanceJobResult } from "./registry"
+
+/**
+ * Data Plumbing — stamp `paid_at` on payouts settled BEFORE the column existed
+ * (#1639).
+ *
+ * `payment_submission.paid_at` was added by #1638 and is written from #1639
+ * onward by settling the reconciliation. The payouts already settled have a
+ * real settlement timestamp — `payment_reconciliation.settled_at` — but a null
+ * `paid_at`, so they read "paid, time unknown" beside every future payout that
+ * carries one.
+ *
+ * ⚠️ It records something that ALREADY HAPPENED. It changes no status, no
+ * amount, and no partner. It copies one timestamp that already exists onto the
+ * row that should have carried it.
+ *
+ * ## It transcribes; it does not deduce
+ *
+ * 🔴 `paid_at` is taken from the reconciliation's `settled_at` and from nowhere
+ * else. Not `updated_at`, not `reviewed_at`, not the payment's `payment_date` —
+ * those record when someone approved or when a row was touched, and writing one
+ * of them into a field that means "when money moved" would manufacture a fact.
+ * On production the approval→settlement gap ran from 13 seconds to 34 days, so
+ * the two are demonstrably not interchangeable.
+ *
+ * A submission whose reconciliation is not `Settled`, or which has no
+ * reconciliation at all, is SKIPPED. There is no evidence of when its money
+ * moved, and a null `paid_at` says exactly that. Guessing would be worse than
+ * the gap: an absent timestamp is visibly absent, a wrong one reads as fact.
+ *
+ * 🔑 No STATUS backfill is needed and none is performed. Probed on production
+ * 2026-08-29: the 5 `Paid` submissions are exactly the 5 settled
+ * reconciliations, id for id, and no submission sits in `Approved`. The new
+ * meaning of `Paid` — settled, not merely authorised — is already true of every
+ * existing row, which is why this job only fills in the timestamp.
+ *
+ * Idempotent: a submission that already has a `paid_at` is left alone, so it is
+ * safe to re-run.
+ */
+const paramsSchema = z.object({
+  /** One submission, for a spot check before a full pass. */
+  payment_submission_id: z.string().min(1).optional(),
+  /** Bound a first pass; omitted means every payout that needs one. */
+  limit: z.coerce.number().int().min(1).max(1000).optional(),
+})
+
+export const backfillSubmissionPaidAtJob: MaintenanceJob = {
+  id: "backfill-submission-paid-at",
+  label: "Stamp paid_at on payouts settled before the column existed",
+  description:
+    "Copy payment_reconciliation.settled_at onto payment_submission.paid_at for payouts settled before #1638 added the column. Records something that already happened: changes no status, no amount, no partner, and moves no money. The timestamp is read from the reconciliation's settled_at and from nowhere else — never updated_at, reviewed_at, or a payment's payment_date, which record when someone approved rather than when money moved; on production that gap ran from 13 seconds to 34 days, so they are demonstrably not interchangeable. A submission whose reconciliation is not Settled, or which has none, is skipped rather than guessed: a null paid_at truthfully says the time is unknown, while a wrong one reads as fact. No status backfill is performed and none is needed — probed 2026-08-29, the 5 Paid submissions are exactly the 5 settled reconciliations, id for id, and nothing sits in Approved. Idempotent: a submission that already carries a paid_at is left alone, so it is safe to re-run.",
+  params: [
+    {
+      name: "payment_submission_id",
+      type: "string",
+      required: false,
+      description: "Only this submission, e.g. for a spot check before a full pass.",
+    },
+    {
+      name: "limit",
+      type: "number",
+      required: false,
+      description: "Stop after this many stamps. Omit for every one that is missing.",
+    },
+  ],
+  run: async (container, { dry_run, params }): Promise<MaintenanceJobResult> => {
+    const parsed = paramsSchema.safeParse(params)
+    if (!parsed.success) {
+      throw new MedusaError(
+        MedusaError.Types.INVALID_DATA,
+        parsed.error.issues.map((i) => i.message).join("; ")
+      )
+    }
+
+    const submissionService: PaymentSubmissionsService = container.resolve(
+      PAYMENT_SUBMISSIONS_MODULE
+    )
+    const reportsService: any = container.resolve(PAYMENT_REPORTS_MODULE)
+
+    /**
+     * Driven from the RECONCILIATIONS, not from the submissions.
+     *
+     * The evidence is the settlement record; a submission is only a candidate
+     * because one names it. Starting from submissions would invite filling in
+     * the ones with no evidence.
+     */
+    const reconciliations = (await reportsService.listPaymentReconciliations({
+      reference_type: "payment_submission",
+      status: "Settled",
+    })) as any[]
+
+    const changes: MaintenanceChange[] = []
+    const errors: Array<{ id: string; message: string }> = []
+    /** Settled, but the reconciliation itself carries no `settled_at`. */
+    const noTimestamp: string[] = []
+    let alreadyStamped = 0
+    let missingSubmission = 0
+
+    const limit = parsed.data.limit ?? Number.POSITIVE_INFINITY
+
+    for (const recon of reconciliations || []) {
+      if (changes.length >= limit) break
+
+      const submissionId = recon?.reference_id ? String(recon.reference_id) : ""
+      if (!submissionId) continue
+      if (
+        parsed.data.payment_submission_id &&
+        submissionId !== parsed.data.payment_submission_id
+      ) {
+        continue
+      }
+
+      const settledAt = recon?.settled_at
+      if (!settledAt) {
+        // Settled with no timestamp — report it, never substitute another date.
+        noTimestamp.push(submissionId)
+        continue
+      }
+
+      let submission: any
+      try {
+        const rows = await submissionService.listPaymentSubmissions({
+          id: [submissionId],
+        })
+        submission = (rows as any[])?.[0]
+      } catch (e: any) {
+        errors.push({ id: submissionId, message: e?.message || "lookup failed" })
+        continue
+      }
+
+      if (!submission) {
+        missingSubmission++
+        continue
+      }
+      if (submission.paid_at) {
+        alreadyStamped++
+        continue
+      }
+
+      changes.push({
+        entity: "payment_submission",
+        id: submissionId,
+        field: "paid_at",
+        before: null,
+        after: settledAt,
+        note:
+          `reconciliation ${recon.id} is Settled with settled_at=${new Date(
+            settledAt
+          ).toISOString()}` +
+          ` (submission status ${submission.status}, settled_by ${recon.settled_by ?? "unknown"})`,
+      })
+
+      if (!dry_run) {
+        try {
+          await submissionService.updatePaymentSubmissions({
+            id: submissionId,
+            paid_at: settledAt,
+          })
+        } catch (e: any) {
+          errors.push({ id: submissionId, message: e?.message || "update failed" })
+        }
+      }
+    }
+
+    if (
+      parsed.data.payment_submission_id &&
+      !changes.length &&
+      !alreadyStamped &&
+      !noTimestamp.length
+    ) {
+      throw new MedusaError(
+        MedusaError.Types.NOT_FOUND,
+        `Payment submission ${parsed.data.payment_submission_id} has no settled reconciliation, so there is no evidence of when it was paid`
+      )
+    }
+
+    const bits = [
+      `${changes.length} payout${changes.length === 1 ? "" : "s"} ${
+        dry_run ? "would be" : "were"
+      } stamped with paid_at`,
+      `${alreadyStamped} already carried one`,
+    ]
+    if (noTimestamp.length) {
+      bits.push(
+        `${noTimestamp.length} settled WITHOUT a settled_at and were skipped rather than dated from another field (${noTimestamp.join(", ")})`
+      )
+    }
+    if (missingSubmission) {
+      bits.push(`${missingSubmission} named a submission that no longer exists`)
+    }
+    if (errors.length) {
+      bits.push(`${errors.length} failed`)
+    }
+
+    return {
+      job_id: "backfill-submission-paid-at",
+      dry_run,
+      applied: !dry_run && changes.length > 0 && errors.length < changes.length,
+      summary: bits.join("; "),
+      changes,
+      ...(errors.length ? { errors } : {}),
+    }
+  },
+}

--- a/apps/backend/src/api/admin/ops/maintenance-jobs/registry.ts
+++ b/apps/backend/src/api/admin/ops/maintenance-jobs/registry.ts
@@ -111,6 +111,7 @@ import { resetNegativeInventoryLevelsJob } from "./reset-negative-inventory-leve
 import { backfillDispatchedTemplateIdsJob } from "./backfill-dispatched-template-ids-job"
 import { backfillPaymentLineRunProvenanceJob } from "./backfill-payment-line-run-provenance-job"
 import { backfillInventoryOrderPaymentLinksJob } from "./backfill-inventory-order-payment-links-job"
+import { backfillSubmissionPaidAtJob } from "./backfill-submission-paid-at-job"
 import { clearUnpriceableDesignCostsJob } from "./clear-unpriceable-design-costs-job"
 import { recordPaymentLineRunJob } from "./record-payment-line-run-job"
 import { deduplicateTaskTemplateNamesJob } from "./deduplicate-task-template-names-job"
@@ -5877,6 +5878,7 @@ export const MAINTENANCE_JOBS: MaintenanceJob[] = [
   backfillDispatchedTemplateIdsJob,
   backfillPaymentLineRunProvenanceJob,
   backfillInventoryOrderPaymentLinksJob,
+  backfillSubmissionPaidAtJob,
   clearUnpriceableDesignCostsJob,
   recordPaymentLineRunJob,
   recordManualInventoryCorrectionJob,

--- a/apps/backend/src/api/admin/payment-submissions/[id]/review/route.ts
+++ b/apps/backend/src/api/admin/payment-submissions/[id]/review/route.ts
@@ -24,6 +24,13 @@ export const POST = async (req: MedusaRequest, res: MedusaResponse) => {
 
   return res.status(200).json({
     payment_submission: result.submission,
-    payment: result.payment || null,
+    /**
+     * `payment` is always null now — approval stops creating an
+     * `internal_payments` row and the submission IS the payout record (#1636).
+     * The key is kept so existing callers do not see their shape change; the
+     * method the payout went to is reported alongside it.
+     */
+    payment: null,
+    paid_to: (result as any).paid_to ?? null,
   })
 }

--- a/apps/backend/src/api/admin/payment_reports/reconciliation/[id]/settle/route.ts
+++ b/apps/backend/src/api/admin/payment_reports/reconciliation/[id]/settle/route.ts
@@ -1,45 +1,29 @@
 import type { MedusaRequest, MedusaResponse } from "@medusajs/framework/http"
-import { MedusaError } from "@medusajs/framework/utils"
-import { PAYMENT_REPORTS_MODULE } from "../../../../../../modules/payment_reports"
-import Payment_reportsService from "../../../../../../modules/payment_reports/service"
+import { settlePaymentReconciliationWorkflow } from "../../../../../../workflows/payment_reports/settle-payment-reconciliation"
 
-// POST /admin/payment_reports/reconciliation/:id/settle
+/**
+ * POST /admin/payment_reports/reconciliation/:id/settle
+ *
+ * Settling now also marks the payout's submission `Paid` and stamps `paid_at`,
+ * and it is what fires `payment_submission.paid` to the partner. Approval sets
+ * `Approved` and stops there (#1639) — it used to claim `Paid` up to 34 days
+ * before the money moved.
+ *
+ * The validation and the reconciliation write moved into the workflow so both
+ * records land in one compensatable transaction rather than two loose updates.
+ */
 export const POST = async (req: MedusaRequest, res: MedusaResponse) => {
   const { id } = req.params
   const body = (req.validatedBody || {}) as any
   const settledBy = (req as any).auth_context?.actor_id || "admin"
 
-  const service: Payment_reportsService = req.scope.resolve(
-    PAYMENT_REPORTS_MODULE
-  )
+  const { result } = await settlePaymentReconciliationWorkflow(req.scope).run({
+    input: {
+      reconciliation_id: id,
+      settled_by: settledBy,
+      notes: body.notes,
+    },
+  })
 
-  const existing = await service.listPaymentReconciliations({ id: [id] })
-  if (!existing[0]) {
-    throw new MedusaError(
-      MedusaError.Types.NOT_FOUND,
-      `Reconciliation record not found: ${id}`
-    )
-  }
-
-  if (existing[0].status === "Settled") {
-    throw new MedusaError(
-      MedusaError.Types.INVALID_DATA,
-      "This reconciliation is already settled"
-    )
-  }
-
-  const updateData: Record<string, any> = {
-    id,
-    status: "Settled",
-    settled_at: new Date(),
-    settled_by: settledBy,
-  }
-
-  if (body.notes) {
-    updateData.notes = body.notes
-  }
-
-  const updated = await service.updatePaymentReconciliations(updateData)
-
-  return res.status(200).json({ reconciliation: updated })
+  return res.status(200).json({ reconciliation: result.reconciliation })
 }

--- a/apps/backend/src/api/admin/payments/partners/[id]/methods/validators.ts
+++ b/apps/backend/src/api/admin/payments/partners/[id]/methods/validators.ts
@@ -20,5 +20,10 @@ export const CreatePaymentMethodForPartnerSchema = z.object({
   ifsc_code: z.string().optional(),
   wallet_id: z.string().optional(),
   metadata: z.record(z.string(), z.any()).nullish(),
+  /**
+   * Marks this the method a payout falls back to when the reviewer names none.
+   * Exclusive per owner — setting it unsets the owner's other methods.
+   */
+  is_default: z.boolean().optional(),
 })
 export type CreatePaymentMethodForPartner = z.infer<typeof CreatePaymentMethodForPartnerSchema>

--- a/apps/backend/src/api/partners/[id]/payments/methods/[methodId]/route.ts
+++ b/apps/backend/src/api/partners/[id]/payments/methods/[methodId]/route.ts
@@ -4,6 +4,7 @@ import { getPartnerFromAuthContext } from "../../../../helpers"
 import PartnerPaymentMethodsLink from "../../../../../../links/partner-payment-methods-link"
 import { updatePaymentDetailsWorkflow } from "../../../../../../workflows/internal_payments/update-payment-details"
 import { deletePaymentDetailsWorkflow } from "../../../../../../workflows/internal_payments/delete-payment-details"
+import { setDefaultPaymentMethodWorkflow } from "../../../../../../workflows/payment_methods/set-default-payment-method"
 
 // Verify the payment method belongs to the acting partner (prevents IDOR — a
 // partner must not be able to edit/delete another partner's payout method).
@@ -59,14 +60,35 @@ export const POST = async (
 ) => {
   await verifyOwnership(req)
 
+  const body = { ...((req.validatedBody as any) || {}) }
+
+  /**
+   * `is_default` is exclusive per owner, so it cannot ride along as a plain
+   * column write — promoting one method has to demote the partner's others.
+   * Routed to its own workflow and stripped from the field update.
+   */
+  const makeDefault = body.is_default === true
+  delete body.is_default
+
   const { result } = await updatePaymentDetailsWorkflow(req.scope).run({
     input: {
       id: req.params.methodId,
-      ...(req.validatedBody || {}),
+      ...body,
     },
   })
 
-  return res.status(200).json({ paymentMethod: result })
+  if (makeDefault) {
+    await setDefaultPaymentMethodWorkflow(req.scope).run({
+      input: {
+        payment_method_id: req.params.methodId,
+        partner_id: req.params.id,
+      },
+    })
+  }
+
+  return res.status(200).json({
+    paymentMethod: makeDefault ? { ...(result as any), is_default: true } : result,
+  })
 }
 
 export const DELETE = async (

--- a/apps/backend/src/api/partners/[id]/payments/validators.ts
+++ b/apps/backend/src/api/partners/[id]/payments/validators.ts
@@ -30,6 +30,11 @@ export const CreatePaymentMethodForPartnerSchema = z.object({
   ifsc_code: z.string().optional(),
   wallet_id: z.string().optional(),
   metadata: z.record(z.string(), z.any()).nullish(),
+  /**
+   * Marks this the method a payout falls back to when the reviewer names none.
+   * Exclusive per owner — setting it unsets the owner's other methods.
+   */
+  is_default: z.boolean().optional(),
 })
 export type CreatePaymentMethodForPartner = z.infer<typeof CreatePaymentMethodForPartnerSchema>
 export const CreatePaymentMethodForPartner = CreatePaymentMethodForPartnerSchema
@@ -43,6 +48,11 @@ export const UpdatePaymentMethodForPartnerSchema = z.object({
   ifsc_code: z.string().nullish(),
   wallet_id: z.string().nullish(),
   metadata: z.record(z.string(), z.any()).nullish(),
+  /**
+   * Marks this the method a payout falls back to when the reviewer names none.
+   * Exclusive per owner — setting it unsets the owner's other methods.
+   */
+  is_default: z.boolean().optional(),
 })
 export type UpdatePaymentMethodForPartner = z.infer<typeof UpdatePaymentMethodForPartnerSchema>
 export const UpdatePaymentMethodForPartner = UpdatePaymentMethodForPartnerSchema

--- a/apps/backend/src/links/submission-paid-to-method-link.ts
+++ b/apps/backend/src/links/submission-paid-to-method-link.ts
@@ -1,0 +1,39 @@
+import { defineLink } from "@medusajs/framework/utils"
+import PaymentSubmissionsModule from "../modules/payment_submissions"
+import InternalPaymentModule from "../modules/internal_payments"
+
+/**
+ * PaymentSubmission -> the payment METHOD it was paid to.
+ *
+ * Replaces `internal_payments.paid_to_id` on the approval path (#1636). The
+ * referent is unchanged — an `internal_payment_details` row, i.e. a bank/wallet
+ * record, not a payment record — so the dependency this preserves is the
+ * correct one.
+ *
+ * 🔴 The explicit `database.table` is load-bearing, not cosmetic.
+ *
+ * Medusa derives a link table's name as
+ * `<moduleA>_<entityA>_<moduleB>_<entityB>`. For this pair that is
+ *
+ *   payment_submissions_payment_submission_internal_payments_internal_payment_details
+ *
+ * — 80 characters, against Postgres's 63-byte identifier limit. Its sibling
+ * `submission-payment-link.ts` derives to 73 characters and its table exists in
+ * NEITHER the local nor the production schema, while every link table that did
+ * materialise here is 58 characters or shorter. That is the best explanation
+ * anyone has for why `query.graph` on that link returns rows carrying no
+ * `payments` key at all, under either spelling of the entity.
+ *
+ * Do not remove the override to "tidy up". Verify with:
+ *   \dt *paid_to*
+ */
+export default defineLink(
+  PaymentSubmissionsModule.linkable.paymentSubmission,
+  {
+    linkable: InternalPaymentModule.linkable.internalPaymentDetails,
+    field: "paid_to",
+  },
+  {
+    database: { table: "payment_submission_paid_to_method" },
+  }
+)

--- a/apps/backend/src/modules/internal_payments/migrations/.snapshot-internal-payments.json
+++ b/apps/backend/src/modules/internal_payments/migrations/.snapshot-internal-payments.json
@@ -22,8 +22,8 @@
           "enumItems": [],
           "mappedType": "text"
         },
-        "partner_id": {
-          "name": "partner_id",
+        "type": {
+          "name": "type",
           "type": "text",
           "unsigned": false,
           "autoincrement": false,
@@ -35,50 +35,15 @@
           "scale": null,
           "default": null,
           "comment": null,
-          "enumItems": [],
-          "mappedType": "text"
-        },
-        "status": {
-          "name": "status",
-          "type": "text",
-          "unsigned": false,
-          "autoincrement": false,
-          "primary": false,
-          "nullable": false,
-          "unique": false,
-          "length": null,
-          "precision": null,
-          "scale": null,
-          "default": "'Draft'",
-          "comment": null,
           "enumItems": [
-            "Draft",
-            "Pending",
-            "Under_Review",
-            "Approved",
-            "Rejected",
-            "Paid"
+            "bank_account",
+            "cash_account",
+            "digital_wallet"
           ],
           "mappedType": "enum"
         },
-        "total_amount": {
-          "name": "total_amount",
-          "type": "numeric",
-          "unsigned": false,
-          "autoincrement": false,
-          "primary": false,
-          "nullable": false,
-          "unique": false,
-          "length": null,
-          "precision": null,
-          "scale": null,
-          "default": null,
-          "comment": null,
-          "enumItems": [],
-          "mappedType": "decimal"
-        },
-        "currency": {
-          "name": "currency",
+        "account_name": {
+          "name": "account_name",
           "type": "text",
           "unsigned": false,
           "autoincrement": false,
@@ -88,45 +53,13 @@
           "length": null,
           "precision": null,
           "scale": null,
-          "default": "'inr'",
+          "default": null,
           "comment": null,
           "enumItems": [],
           "mappedType": "text"
         },
-        "submitted_at": {
-          "name": "submitted_at",
-          "type": "timestamptz",
-          "unsigned": false,
-          "autoincrement": false,
-          "primary": false,
-          "nullable": true,
-          "unique": false,
-          "length": 6,
-          "precision": null,
-          "scale": null,
-          "default": null,
-          "comment": null,
-          "enumItems": [],
-          "mappedType": "datetime"
-        },
-        "reviewed_at": {
-          "name": "reviewed_at",
-          "type": "timestamptz",
-          "unsigned": false,
-          "autoincrement": false,
-          "primary": false,
-          "nullable": true,
-          "unique": false,
-          "length": 6,
-          "precision": null,
-          "scale": null,
-          "default": null,
-          "comment": null,
-          "enumItems": [],
-          "mappedType": "datetime"
-        },
-        "reviewed_by": {
-          "name": "reviewed_by",
+        "account_number": {
+          "name": "account_number",
           "type": "text",
           "unsigned": false,
           "autoincrement": false,
@@ -141,24 +74,8 @@
           "enumItems": [],
           "mappedType": "text"
         },
-        "paid_at": {
-          "name": "paid_at",
-          "type": "timestamptz",
-          "unsigned": false,
-          "autoincrement": false,
-          "primary": false,
-          "nullable": true,
-          "unique": false,
-          "length": 6,
-          "precision": null,
-          "scale": null,
-          "default": null,
-          "comment": null,
-          "enumItems": [],
-          "mappedType": "datetime"
-        },
-        "rejection_reason": {
-          "name": "rejection_reason",
+        "bank_name": {
+          "name": "bank_name",
           "type": "text",
           "unsigned": false,
           "autoincrement": false,
@@ -173,8 +90,8 @@
           "enumItems": [],
           "mappedType": "text"
         },
-        "notes": {
-          "name": "notes",
+        "ifsc_code": {
+          "name": "ifsc_code",
           "type": "text",
           "unsigned": false,
           "autoincrement": false,
@@ -189,9 +106,9 @@
           "enumItems": [],
           "mappedType": "text"
         },
-        "documents": {
-          "name": "documents",
-          "type": "jsonb",
+        "wallet_id": {
+          "name": "wallet_id",
+          "type": "text",
           "unsigned": false,
           "autoincrement": false,
           "primary": false,
@@ -203,7 +120,23 @@
           "default": null,
           "comment": null,
           "enumItems": [],
-          "mappedType": "json"
+          "mappedType": "text"
+        },
+        "is_default": {
+          "name": "is_default",
+          "type": "boolean",
+          "unsigned": false,
+          "autoincrement": false,
+          "primary": false,
+          "nullable": false,
+          "unique": false,
+          "length": null,
+          "precision": null,
+          "scale": null,
+          "default": "false",
+          "comment": null,
+          "enumItems": [],
+          "mappedType": "boolean"
         },
         "metadata": {
           "name": "metadata",
@@ -212,22 +145,6 @@
           "autoincrement": false,
           "primary": false,
           "nullable": true,
-          "unique": false,
-          "length": null,
-          "precision": null,
-          "scale": null,
-          "default": null,
-          "comment": null,
-          "enumItems": [],
-          "mappedType": "json"
-        },
-        "raw_total_amount": {
-          "name": "raw_total_amount",
-          "type": "jsonb",
-          "unsigned": false,
-          "autoincrement": false,
-          "primary": false,
-          "nullable": false,
           "unique": false,
           "length": null,
           "precision": null,
@@ -286,20 +203,20 @@
           "mappedType": "datetime"
         }
       },
-      "name": "payment_submission",
+      "name": "internal_payment_details",
       "schema": "public",
       "indexes": [
         {
-          "keyName": "IDX_payment_submission_deleted_at",
+          "keyName": "IDX_internal_payment_details_deleted_at",
           "columnNames": [],
           "composite": false,
           "constraint": false,
           "primary": false,
           "unique": false,
-          "expression": "CREATE INDEX IF NOT EXISTS \"IDX_payment_submission_deleted_at\" ON \"payment_submission\" (\"deleted_at\") WHERE deleted_at IS NULL"
+          "expression": "CREATE INDEX IF NOT EXISTS \"IDX_internal_payment_details_deleted_at\" ON \"internal_payment_details\" (\"deleted_at\") WHERE deleted_at IS NULL"
         },
         {
-          "keyName": "payment_submission_pkey",
+          "keyName": "internal_payment_details_pkey",
           "columnNames": [
             "id"
           ],
@@ -331,139 +248,6 @@
           "enumItems": [],
           "mappedType": "text"
         },
-        "design_id": {
-          "name": "design_id",
-          "type": "text",
-          "unsigned": false,
-          "autoincrement": false,
-          "primary": false,
-          "nullable": true,
-          "unique": false,
-          "length": null,
-          "precision": null,
-          "scale": null,
-          "default": null,
-          "comment": null,
-          "enumItems": [],
-          "mappedType": "text"
-        },
-        "design_name": {
-          "name": "design_name",
-          "type": "text",
-          "unsigned": false,
-          "autoincrement": false,
-          "primary": false,
-          "nullable": true,
-          "unique": false,
-          "length": null,
-          "precision": null,
-          "scale": null,
-          "default": null,
-          "comment": null,
-          "enumItems": [],
-          "mappedType": "text"
-        },
-        "task_id": {
-          "name": "task_id",
-          "type": "text",
-          "unsigned": false,
-          "autoincrement": false,
-          "primary": false,
-          "nullable": true,
-          "unique": false,
-          "length": null,
-          "precision": null,
-          "scale": null,
-          "default": null,
-          "comment": null,
-          "enumItems": [],
-          "mappedType": "text"
-        },
-        "task_name": {
-          "name": "task_name",
-          "type": "text",
-          "unsigned": false,
-          "autoincrement": false,
-          "primary": false,
-          "nullable": true,
-          "unique": false,
-          "length": null,
-          "precision": null,
-          "scale": null,
-          "default": null,
-          "comment": null,
-          "enumItems": [],
-          "mappedType": "text"
-        },
-        "inventory_order_id": {
-          "name": "inventory_order_id",
-          "type": "text",
-          "unsigned": false,
-          "autoincrement": false,
-          "primary": false,
-          "nullable": true,
-          "unique": false,
-          "length": null,
-          "precision": null,
-          "scale": null,
-          "default": null,
-          "comment": null,
-          "enumItems": [],
-          "mappedType": "text"
-        },
-        "inventory_order_name": {
-          "name": "inventory_order_name",
-          "type": "text",
-          "unsigned": false,
-          "autoincrement": false,
-          "primary": false,
-          "nullable": true,
-          "unique": false,
-          "length": null,
-          "precision": null,
-          "scale": null,
-          "default": null,
-          "comment": null,
-          "enumItems": [],
-          "mappedType": "text"
-        },
-        "order_id": {
-          "name": "order_id",
-          "type": "text",
-          "unsigned": false,
-          "autoincrement": false,
-          "primary": false,
-          "nullable": true,
-          "unique": false,
-          "length": null,
-          "precision": null,
-          "scale": null,
-          "default": null,
-          "comment": null,
-          "enumItems": [],
-          "mappedType": "text"
-        },
-        "source_type": {
-          "name": "source_type",
-          "type": "text",
-          "unsigned": false,
-          "autoincrement": false,
-          "primary": false,
-          "nullable": false,
-          "unique": false,
-          "length": null,
-          "precision": null,
-          "scale": null,
-          "default": "'design'",
-          "comment": null,
-          "enumItems": [
-            "design",
-            "task",
-            "run",
-            "inventory_order"
-          ],
-          "mappedType": "enum"
-        },
         "amount": {
           "name": "amount",
           "type": "numeric",
@@ -480,72 +264,8 @@
           "enumItems": [],
           "mappedType": "decimal"
         },
-        "quantity": {
-          "name": "quantity",
-          "type": "real",
-          "unsigned": false,
-          "autoincrement": false,
-          "primary": false,
-          "nullable": false,
-          "unique": false,
-          "length": null,
-          "precision": null,
-          "scale": null,
-          "default": "1",
-          "comment": null,
-          "enumItems": [],
-          "mappedType": "float"
-        },
-        "unit_amount": {
-          "name": "unit_amount",
-          "type": "numeric",
-          "unsigned": false,
-          "autoincrement": false,
-          "primary": false,
-          "nullable": true,
-          "unique": false,
-          "length": null,
-          "precision": null,
-          "scale": null,
-          "default": null,
-          "comment": null,
-          "enumItems": [],
-          "mappedType": "decimal"
-        },
-        "cost_breakdown": {
-          "name": "cost_breakdown",
-          "type": "jsonb",
-          "unsigned": false,
-          "autoincrement": false,
-          "primary": false,
-          "nullable": true,
-          "unique": false,
-          "length": null,
-          "precision": null,
-          "scale": null,
-          "default": null,
-          "comment": null,
-          "enumItems": [],
-          "mappedType": "json"
-        },
-        "production_run_ids": {
-          "name": "production_run_ids",
-          "type": "jsonb",
-          "unsigned": false,
-          "autoincrement": false,
-          "primary": false,
-          "nullable": true,
-          "unique": false,
-          "length": null,
-          "precision": null,
-          "scale": null,
-          "default": null,
-          "comment": null,
-          "enumItems": [],
-          "mappedType": "json"
-        },
-        "run_provenance": {
-          "name": "run_provenance",
+        "status": {
+          "name": "status",
           "type": "text",
           "unsigned": false,
           "autoincrement": false,
@@ -555,14 +275,52 @@
           "length": null,
           "precision": null,
           "scale": null,
-          "default": "'not_recorded'",
+          "default": "'Pending'",
           "comment": null,
           "enumItems": [
-            "recorded",
-            "no_run",
-            "not_recorded"
+            "Pending",
+            "Processing",
+            "Completed",
+            "Failed",
+            "Cancelled"
           ],
           "mappedType": "enum"
+        },
+        "payment_type": {
+          "name": "payment_type",
+          "type": "text",
+          "unsigned": false,
+          "autoincrement": false,
+          "primary": false,
+          "nullable": false,
+          "unique": false,
+          "length": null,
+          "precision": null,
+          "scale": null,
+          "default": null,
+          "comment": null,
+          "enumItems": [
+            "Bank",
+            "Cash",
+            "Digital_Wallet"
+          ],
+          "mappedType": "enum"
+        },
+        "payment_date": {
+          "name": "payment_date",
+          "type": "timestamptz",
+          "unsigned": false,
+          "autoincrement": false,
+          "primary": false,
+          "nullable": false,
+          "unique": false,
+          "length": 6,
+          "precision": null,
+          "scale": null,
+          "default": null,
+          "comment": null,
+          "enumItems": [],
+          "mappedType": "datetime"
         },
         "metadata": {
           "name": "metadata",
@@ -580,13 +338,13 @@
           "enumItems": [],
           "mappedType": "json"
         },
-        "submission_id": {
-          "name": "submission_id",
+        "paid_to_id": {
+          "name": "paid_to_id",
           "type": "text",
           "unsigned": false,
           "autoincrement": false,
           "primary": false,
-          "nullable": false,
+          "nullable": true,
           "unique": false,
           "length": null,
           "precision": null,
@@ -603,22 +361,6 @@
           "autoincrement": false,
           "primary": false,
           "nullable": false,
-          "unique": false,
-          "length": null,
-          "precision": null,
-          "scale": null,
-          "default": null,
-          "comment": null,
-          "enumItems": [],
-          "mappedType": "json"
-        },
-        "raw_unit_amount": {
-          "name": "raw_unit_amount",
-          "type": "jsonb",
-          "unsigned": false,
-          "autoincrement": false,
-          "primary": false,
-          "nullable": true,
           "unique": false,
           "length": null,
           "precision": null,
@@ -677,29 +419,29 @@
           "mappedType": "datetime"
         }
       },
-      "name": "payment_submission_item",
+      "name": "internal_payments",
       "schema": "public",
       "indexes": [
         {
-          "keyName": "IDX_payment_submission_item_submission_id",
+          "keyName": "IDX_internal_payments_paid_to_id",
           "columnNames": [],
           "composite": false,
           "constraint": false,
           "primary": false,
           "unique": false,
-          "expression": "CREATE INDEX IF NOT EXISTS \"IDX_payment_submission_item_submission_id\" ON \"payment_submission_item\" (\"submission_id\") WHERE deleted_at IS NULL"
+          "expression": "CREATE INDEX IF NOT EXISTS \"IDX_internal_payments_paid_to_id\" ON \"internal_payments\" (\"paid_to_id\") WHERE deleted_at IS NULL"
         },
         {
-          "keyName": "IDX_payment_submission_item_deleted_at",
+          "keyName": "IDX_internal_payments_deleted_at",
           "columnNames": [],
           "composite": false,
           "constraint": false,
           "primary": false,
           "unique": false,
-          "expression": "CREATE INDEX IF NOT EXISTS \"IDX_payment_submission_item_deleted_at\" ON \"payment_submission_item\" (\"deleted_at\") WHERE deleted_at IS NULL"
+          "expression": "CREATE INDEX IF NOT EXISTS \"IDX_internal_payments_deleted_at\" ON \"internal_payments\" (\"deleted_at\") WHERE deleted_at IS NULL"
         },
         {
-          "keyName": "payment_submission_item_pkey",
+          "keyName": "internal_payments_pkey",
           "columnNames": [
             "id"
           ],
@@ -711,16 +453,245 @@
       ],
       "checks": [],
       "foreignKeys": {
-        "payment_submission_item_submission_id_foreign": {
-          "constraintName": "payment_submission_item_submission_id_foreign",
+        "internal_payments_paid_to_id_foreign": {
+          "constraintName": "internal_payments_paid_to_id_foreign",
           "columnNames": [
-            "submission_id"
+            "paid_to_id"
           ],
-          "localTableName": "public.payment_submission_item",
+          "localTableName": "public.internal_payments",
           "referencedColumnNames": [
             "id"
           ],
-          "referencedTableName": "public.payment_submission",
+          "referencedTableName": "public.internal_payment_details",
+          "deleteRule": "set null",
+          "updateRule": "cascade"
+        }
+      },
+      "nativeEnums": {}
+    },
+    {
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "unsigned": false,
+          "autoincrement": false,
+          "primary": true,
+          "nullable": false,
+          "unique": false,
+          "length": null,
+          "precision": null,
+          "scale": null,
+          "default": null,
+          "comment": null,
+          "enumItems": [],
+          "mappedType": "text"
+        },
+        "file_id": {
+          "name": "file_id",
+          "type": "text",
+          "unsigned": false,
+          "autoincrement": false,
+          "primary": false,
+          "nullable": false,
+          "unique": false,
+          "length": null,
+          "precision": null,
+          "scale": null,
+          "default": null,
+          "comment": null,
+          "enumItems": [],
+          "mappedType": "text"
+        },
+        "url": {
+          "name": "url",
+          "type": "text",
+          "unsigned": false,
+          "autoincrement": false,
+          "primary": false,
+          "nullable": false,
+          "unique": false,
+          "length": null,
+          "precision": null,
+          "scale": null,
+          "default": null,
+          "comment": null,
+          "enumItems": [],
+          "mappedType": "text"
+        },
+        "filename": {
+          "name": "filename",
+          "type": "text",
+          "unsigned": false,
+          "autoincrement": false,
+          "primary": false,
+          "nullable": true,
+          "unique": false,
+          "length": null,
+          "precision": null,
+          "scale": null,
+          "default": null,
+          "comment": null,
+          "enumItems": [],
+          "mappedType": "text"
+        },
+        "mime_type": {
+          "name": "mime_type",
+          "type": "text",
+          "unsigned": false,
+          "autoincrement": false,
+          "primary": false,
+          "nullable": true,
+          "unique": false,
+          "length": null,
+          "precision": null,
+          "scale": null,
+          "default": null,
+          "comment": null,
+          "enumItems": [],
+          "mappedType": "text"
+        },
+        "size": {
+          "name": "size",
+          "type": "integer",
+          "unsigned": false,
+          "autoincrement": false,
+          "primary": false,
+          "nullable": true,
+          "unique": false,
+          "length": null,
+          "precision": null,
+          "scale": null,
+          "default": null,
+          "comment": null,
+          "enumItems": [],
+          "mappedType": "integer"
+        },
+        "metadata": {
+          "name": "metadata",
+          "type": "jsonb",
+          "unsigned": false,
+          "autoincrement": false,
+          "primary": false,
+          "nullable": true,
+          "unique": false,
+          "length": null,
+          "precision": null,
+          "scale": null,
+          "default": null,
+          "comment": null,
+          "enumItems": [],
+          "mappedType": "json"
+        },
+        "payment_id": {
+          "name": "payment_id",
+          "type": "text",
+          "unsigned": false,
+          "autoincrement": false,
+          "primary": false,
+          "nullable": false,
+          "unique": false,
+          "length": null,
+          "precision": null,
+          "scale": null,
+          "default": null,
+          "comment": null,
+          "enumItems": [],
+          "mappedType": "text"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamptz",
+          "unsigned": false,
+          "autoincrement": false,
+          "primary": false,
+          "nullable": false,
+          "unique": false,
+          "length": 6,
+          "precision": null,
+          "scale": null,
+          "default": "now()",
+          "comment": null,
+          "enumItems": [],
+          "mappedType": "datetime"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamptz",
+          "unsigned": false,
+          "autoincrement": false,
+          "primary": false,
+          "nullable": false,
+          "unique": false,
+          "length": 6,
+          "precision": null,
+          "scale": null,
+          "default": "now()",
+          "comment": null,
+          "enumItems": [],
+          "mappedType": "datetime"
+        },
+        "deleted_at": {
+          "name": "deleted_at",
+          "type": "timestamptz",
+          "unsigned": false,
+          "autoincrement": false,
+          "primary": false,
+          "nullable": true,
+          "unique": false,
+          "length": 6,
+          "precision": null,
+          "scale": null,
+          "default": null,
+          "comment": null,
+          "enumItems": [],
+          "mappedType": "datetime"
+        }
+      },
+      "name": "internal_payment_attachment",
+      "schema": "public",
+      "indexes": [
+        {
+          "keyName": "IDX_internal_payment_attachment_payment_id",
+          "columnNames": [],
+          "composite": false,
+          "constraint": false,
+          "primary": false,
+          "unique": false,
+          "expression": "CREATE INDEX IF NOT EXISTS \"IDX_internal_payment_attachment_payment_id\" ON \"internal_payment_attachment\" (\"payment_id\") WHERE deleted_at IS NULL"
+        },
+        {
+          "keyName": "IDX_internal_payment_attachment_deleted_at",
+          "columnNames": [],
+          "composite": false,
+          "constraint": false,
+          "primary": false,
+          "unique": false,
+          "expression": "CREATE INDEX IF NOT EXISTS \"IDX_internal_payment_attachment_deleted_at\" ON \"internal_payment_attachment\" (\"deleted_at\") WHERE deleted_at IS NULL"
+        },
+        {
+          "keyName": "internal_payment_attachment_pkey",
+          "columnNames": [
+            "id"
+          ],
+          "composite": false,
+          "constraint": true,
+          "primary": true,
+          "unique": true
+        }
+      ],
+      "checks": [],
+      "foreignKeys": {
+        "internal_payment_attachment_payment_id_foreign": {
+          "constraintName": "internal_payment_attachment_payment_id_foreign",
+          "columnNames": [
+            "payment_id"
+          ],
+          "localTableName": "public.internal_payment_attachment",
+          "referencedColumnNames": [
+            "id"
+          ],
+          "referencedTableName": "public.internal_payments",
           "updateRule": "cascade"
         }
       },

--- a/apps/backend/src/modules/internal_payments/migrations/Migration20260829001518.ts
+++ b/apps/backend/src/modules/internal_payments/migrations/Migration20260829001518.ts
@@ -1,0 +1,24 @@
+import { Migration } from "@medusajs/framework/mikro-orm/migrations";
+
+/**
+ * `internal_payment_details.is_default` — the method approval falls back to
+ * when the reviewer names none (#1636).
+ *
+ * ⚠️ Hand-written. `medusa db:generate` emitted `create table if not exists`
+ * for all three of this module's tables instead of an ALTER, because the
+ * module has no MikroORM snapshot and the generator therefore believes the
+ * schema is empty. On any database where the tables already exist — local and
+ * production both — that generated migration adds NOTHING while recording
+ * itself as applied. The column would simply never have appeared.
+ */
+export class Migration20260829001518 extends Migration {
+
+  override async up(): Promise<void> {
+    this.addSql(`alter table if exists "internal_payment_details" add column if not exists "is_default" boolean not null default false;`);
+  }
+
+  override async down(): Promise<void> {
+    this.addSql(`alter table if exists "internal_payment_details" drop column if exists "is_default";`);
+  }
+
+}

--- a/apps/backend/src/modules/internal_payments/models/payment_details.ts
+++ b/apps/backend/src/modules/internal_payments/models/payment_details.ts
@@ -12,6 +12,14 @@ const PaymentDetail = model.define("internal_payment_details", {
   bank_name: model.text().nullable(),
   ifsc_code: model.text().nullable(),
   wallet_id: model.text().nullable(),
+  /**
+   * The method approval falls back to when the reviewer names none.
+   *
+   * Before this existed, `createPaymentOnApprovalStep` took `methods[0]` —
+   * whichever row the link query happened to return first. A partner with two
+   * bank accounts was paid to an arbitrary one, silently.
+   */
+  is_default: model.boolean().default(false),
   metadata: model.json().nullable(),
 });
 

--- a/apps/backend/src/modules/payment_submissions/migrations/Migration20260829001519.ts
+++ b/apps/backend/src/modules/payment_submissions/migrations/Migration20260829001519.ts
@@ -1,0 +1,24 @@
+import { Migration } from "@medusajs/framework/mikro-orm/migrations";
+
+/**
+ * `payment_submission.paid_at` — when money actually moved, as distinct from
+ * `status: "Paid"`, which approval sets before anything has demonstrably been
+ * sent (#1636).
+ *
+ * The generator also wanted to add five `payment_submission_item` columns
+ * (`quantity`, `unit_amount`, `production_run_ids`, `run_provenance`,
+ * `raw_unit_amount`). Those already exist in the live schema — an earlier
+ * hand-written migration added them and no snapshot was regenerated. Dropped
+ * from this migration rather than carried as `if not exists` no-ops.
+ */
+export class Migration20260829001519 extends Migration {
+
+  override async up(): Promise<void> {
+    this.addSql(`alter table if exists "payment_submission" add column if not exists "paid_at" timestamptz null;`);
+  }
+
+  override async down(): Promise<void> {
+    this.addSql(`alter table if exists "payment_submission" drop column if exists "paid_at";`);
+  }
+
+}

--- a/apps/backend/src/modules/payment_submissions/models/payment_submission.ts
+++ b/apps/backend/src/modules/payment_submissions/models/payment_submission.ts
@@ -12,6 +12,15 @@ const PaymentSubmission = model.define("payment_submission", {
   submitted_at: model.dateTime().nullable(),
   reviewed_at: model.dateTime().nullable(),
   reviewed_by: model.text().nullable(),
+  /**
+   * When money actually moved — as distinct from `status: "Paid"`, which
+   * approval sets before anything has demonstrably been sent (#1636 Q4).
+   *
+   * There is deliberately no `payment_type` column beside it: the payout's
+   * type is `internal_payment_details.type` on the linked method, and a second
+   * copy is a second thing to disagree with.
+   */
+  paid_at: model.dateTime().nullable(),
   rejection_reason: model.text().nullable(),
   notes: model.text().nullable(),
   documents: model.json().nullable(), // [{ id, url, filename, mimeType }] — partner bills/invoices

--- a/apps/backend/src/workflows/payment_methods/create-payment-method-and-link.ts
+++ b/apps/backend/src/workflows/payment_methods/create-payment-method-and-link.ts
@@ -1,4 +1,4 @@
-import { createStep, createWorkflow, StepResponse, WorkflowResponse, when } from "@medusajs/framework/workflows-sdk"
+import { createStep, createWorkflow, StepResponse, WorkflowResponse, transform, when } from "@medusajs/framework/workflows-sdk"
 import { ContainerRegistrationKeys } from "@medusajs/framework/utils"
 import { LinkDefinition } from "@medusajs/framework/types"
 import { INTERNAL_PAYMENTS_MODULE } from "../../modules/internal_payments"
@@ -6,6 +6,7 @@ import InternalPaymentService from "../../modules/internal_payments/service"
 import { PERSON_MODULE } from "../../modules/person"
 import { PARTNER_MODULE } from "../../modules/partner"
 import type { Link } from "@medusajs/modules-sdk"
+import { setDefaultPaymentMethodStep } from "./set-default-payment-method"
 
 export type CreatePaymentMethodInput = {
   type: "bank_account" | "cash_account" | "digital_wallet"
@@ -17,6 +18,12 @@ export type CreatePaymentMethodInput = {
   metadata?: Record<string, any> | null
   person_id?: string
   partner_id?: string
+  /**
+   * Make this the owner's default straight away. Applied AFTER linking, since
+   * "default" is exclusive per owner and the sibling set is resolved through
+   * the link table.
+   */
+  is_default?: boolean
 }
 
 const createPaymentMethodStep = createStep(
@@ -100,6 +107,19 @@ export const createPaymentMethodAndLinkWorkflow = createWorkflow(
         payment_method_id: method.id,
         partner_id: input.partner_id,
       }).config({ name: 'link-to-partner' })
+    })
+
+    // Only after the link exists — the sibling set it unsets is read from it.
+    const shouldDefault = transform(
+      { input },
+      (d) => Boolean(d.input.is_default) && Boolean(d.input.partner_id || d.input.person_id)
+    )
+    when(shouldDefault, (v) => v).then(() => {
+      setDefaultPaymentMethodStep({
+        payment_method_id: method.id,
+        partner_id: input.partner_id,
+        person_id: input.person_id,
+      })
     })
 
     return new WorkflowResponse(method)

--- a/apps/backend/src/workflows/payment_methods/set-default-payment-method.ts
+++ b/apps/backend/src/workflows/payment_methods/set-default-payment-method.ts
@@ -1,0 +1,118 @@
+import {
+  createStep,
+  createWorkflow,
+  StepResponse,
+  WorkflowResponse,
+} from "@medusajs/framework/workflows-sdk"
+import { ContainerRegistrationKeys, MedusaError } from "@medusajs/framework/utils"
+import { INTERNAL_PAYMENTS_MODULE } from "../../modules/internal_payments"
+import InternalPaymentService from "../../modules/internal_payments/service"
+import PartnerPaymentMethodsLink from "../../links/partner-payment-methods-link"
+import PersonPaymentMethodsLink from "../../links/person-payment-methods-link"
+
+export type SetDefaultPaymentMethodInput = {
+  payment_method_id: string
+  partner_id?: string
+  person_id?: string
+}
+
+/**
+ * Make one payment method the owner's default, and no other.
+ *
+ * "Default" is exclusive per OWNER, not global: `internal_payment_details` rows
+ * are reachable from a partner and from a person through two separate link
+ * tables, so the sibling set has to be resolved through whichever one applies.
+ *
+ * 🔴 Why an owner scope is mandatory rather than "unset every other row".
+ * Sharlho (`01K4PJMNMNRGMK0ZXMKBBDZDGD`) has FOUR bank accounts in production,
+ * one per employee — Shashi kumar, Shashi Kumar, Archana Thakur, Tenzin Norbu —
+ * and three of them have been paid at different times. A global unset would
+ * silently clear another partner's default while setting this one.
+ */
+export const setDefaultPaymentMethodStep = createStep(
+  "set-default-payment-method-step",
+  async (input: SetDefaultPaymentMethodInput, { container }) => {
+    const service: InternalPaymentService = container.resolve(
+      INTERNAL_PAYMENTS_MODULE
+    )
+    const query = container.resolve(ContainerRegistrationKeys.QUERY) as any
+
+    // Resolve the owner's full set of methods, so "default" can be exclusive.
+    let siblingIds: string[] = []
+
+    if (input.partner_id) {
+      const { data } = await query.graph({
+        entity: PartnerPaymentMethodsLink.entryPoint,
+        fields: ["internal_payment_details_id"],
+        filters: { partner_id: input.partner_id },
+      })
+      siblingIds = (data || []).map((r: any) => r.internal_payment_details_id)
+    } else if (input.person_id) {
+      const { data } = await query.graph({
+        entity: PersonPaymentMethodsLink.entryPoint,
+        fields: ["internal_payment_details_id"],
+        filters: { person_id: input.person_id },
+      })
+      siblingIds = (data || []).map((r: any) => r.internal_payment_details_id)
+    } else {
+      throw new MedusaError(
+        MedusaError.Types.INVALID_DATA,
+        "Cannot set a default payment method without a partner_id or person_id to scope it to."
+      )
+    }
+
+    if (!siblingIds.includes(input.payment_method_id)) {
+      throw new MedusaError(
+        MedusaError.Types.INVALID_DATA,
+        `Payment method ${input.payment_method_id} is not linked to this ${
+          input.partner_id ? "partner" : "person"
+        }, so it cannot be made their default.`
+      )
+    }
+
+    // Capture prior state before touching anything, for compensation.
+    const before = await service.listPaymentDetails({ id: siblingIds })
+    const previousDefaults = (before as any[])
+      .filter((m) => m.is_default)
+      .map((m) => m.id)
+
+    const toUnset = siblingIds.filter((id) => id !== input.payment_method_id)
+    if (toUnset.length) {
+      await service.updatePaymentDetails(
+        toUnset.map((id) => ({ id, is_default: false }))
+      )
+    }
+    await service.updatePaymentDetails({
+      id: input.payment_method_id,
+      is_default: true,
+    })
+
+    return new StepResponse(
+      { payment_method_id: input.payment_method_id },
+      { siblingIds, previousDefaults }
+    )
+  },
+  async (
+    rollback: { siblingIds: string[]; previousDefaults: string[] },
+    { container }
+  ) => {
+    if (!rollback) return
+    const service: InternalPaymentService = container.resolve(
+      INTERNAL_PAYMENTS_MODULE
+    )
+    await service.updatePaymentDetails(
+      rollback.siblingIds.map((id) => ({
+        id,
+        is_default: rollback.previousDefaults.includes(id),
+      }))
+    )
+  }
+)
+
+export const setDefaultPaymentMethodWorkflow = createWorkflow(
+  "set-default-payment-method",
+  (input: SetDefaultPaymentMethodInput) => {
+    const result = setDefaultPaymentMethodStep(input)
+    return new WorkflowResponse(result)
+  }
+)

--- a/apps/backend/src/workflows/payment_reports/settle-payment-reconciliation.ts
+++ b/apps/backend/src/workflows/payment_reports/settle-payment-reconciliation.ts
@@ -1,0 +1,271 @@
+import {
+  createStep,
+  createWorkflow,
+  StepResponse,
+  WorkflowResponse,
+  transform,
+  when,
+} from "@medusajs/framework/workflows-sdk"
+import {
+  ContainerRegistrationKeys,
+  MedusaError,
+  Modules,
+} from "@medusajs/framework/utils"
+import type { IEventBusModuleService } from "@medusajs/types"
+import { PAYMENT_REPORTS_MODULE } from "../../modules/payment_reports"
+import { PAYMENT_SUBMISSIONS_MODULE } from "../../modules/payment_submissions"
+import { INTERNAL_PAYMENTS_MODULE } from "../../modules/internal_payments"
+import Payment_reportsService from "../../modules/payment_reports/service"
+import PaymentSubmissionsService from "../../modules/payment_submissions/service"
+import InternalPaymentService from "../../modules/internal_payments/service"
+import SubmissionPaidToMethodLink from "../../links/submission-paid-to-method-link"
+
+export type SettlePaymentReconciliationInput = {
+  reconciliation_id: string
+  settled_by: string
+  notes?: string
+}
+
+/**
+ * Settling is the moment money is recorded as having MOVED.
+ *
+ * 🔴 This is the only such moment in the system, and it is the one prod
+ * actually performs: 5 of 5 reconciliations carry a real `settled_at`, by the
+ * same admin, while the `internal_payments` row approval used to create was
+ * left `Pending` 5 times out of 5. Approval no longer claims `Paid` (#1639);
+ * this does.
+ */
+const settleReconciliationStep = createStep(
+  "settle-reconciliation",
+  async (input: SettlePaymentReconciliationInput, { container }) => {
+    const service: Payment_reportsService = container.resolve(
+      PAYMENT_REPORTS_MODULE
+    )
+
+    const [existing] = await service.listPaymentReconciliations({
+      id: [input.reconciliation_id],
+    })
+    if (!existing) {
+      throw new MedusaError(
+        MedusaError.Types.NOT_FOUND,
+        `Reconciliation record not found: ${input.reconciliation_id}`
+      )
+    }
+    if (existing.status === "Settled") {
+      throw new MedusaError(
+        MedusaError.Types.INVALID_DATA,
+        "This reconciliation is already settled"
+      )
+    }
+
+    /**
+     * A `Discrepant` record settles like any other, deliberately. Discrepant
+     * means expected and actual disagree and BOTH are known — settling records
+     * that `actual_amount` was sent, which is exactly the fact being captured.
+     * Writing a payout off without sending it is `Waived`, a different value.
+     */
+    const settledAt = new Date()
+
+    const updateData: Record<string, any> = {
+      id: input.reconciliation_id,
+      status: "Settled",
+      settled_at: settledAt,
+      settled_by: input.settled_by,
+    }
+    if (input.notes) {
+      updateData.notes = input.notes
+    }
+
+    const updated = await service.updatePaymentReconciliations(updateData)
+
+    return new StepResponse(
+      {
+        reconciliation: updated,
+        settled_at: settledAt,
+        reference_type: existing.reference_type as string,
+        reference_id: (existing.reference_id as string) || null,
+        partner_id: (existing.partner_id as string) || null,
+        actual_amount: existing.actual_amount,
+      },
+      {
+        id: input.reconciliation_id,
+        previous_status: existing.status,
+        previous_settled_at: existing.settled_at,
+        previous_settled_by: existing.settled_by,
+        previous_notes: existing.notes,
+      }
+    )
+  },
+  async (rollback: any, { container }) => {
+    if (!rollback) return
+    const service: Payment_reportsService = container.resolve(
+      PAYMENT_REPORTS_MODULE
+    )
+    await service.updatePaymentReconciliations({
+      id: rollback.id,
+      status: rollback.previous_status,
+      settled_at: rollback.previous_settled_at,
+      settled_by: rollback.previous_settled_by,
+      notes: rollback.previous_notes,
+    })
+  }
+)
+
+/**
+ * Carry the same fact onto the submission, so the two records cannot disagree.
+ *
+ * The submission is the payout record (#1636); reconciliation is where the
+ * settle action already lives and is already used. Rather than ask for a second
+ * click, one action writes both.
+ */
+const markSubmissionPaidOnSettleStep = createStep(
+  "mark-submission-paid-on-settle",
+  async (
+    input: { submission_id: string; paid_at: Date },
+    { container }
+  ) => {
+    const service: PaymentSubmissionsService = container.resolve(
+      PAYMENT_SUBMISSIONS_MODULE
+    )
+
+    const [prev] = await service.listPaymentSubmissions({
+      id: [input.submission_id],
+    })
+    if (!prev) {
+      // A reconciliation may reference a submission that no longer exists;
+      // that must not block recording that the money moved.
+      return new StepResponse<{ skipped: true } | null>({ skipped: true }, null)
+    }
+
+    await service.updatePaymentSubmissions({
+      id: input.submission_id,
+      status: "Paid",
+      paid_at: input.paid_at,
+    })
+
+    return new StepResponse<{ skipped: true } | null>(null, {
+      submission_id: input.submission_id,
+      previous_status: prev.status,
+      previous_paid_at: prev.paid_at,
+    } as any)
+  },
+  async (rollback: any, { container }) => {
+    if (!rollback) return
+    const service: PaymentSubmissionsService = container.resolve(
+      PAYMENT_SUBMISSIONS_MODULE
+    )
+    await service.updatePaymentSubmissions({
+      id: rollback.submission_id,
+      status: rollback.previous_status,
+      paid_at: rollback.previous_paid_at,
+    })
+  }
+)
+
+/**
+ * Tell the partner they have been paid — now that they have been.
+ *
+ * The event name and payload are unchanged, so the seeded WhatsApp flow
+ * (`payment_submission.paid` → `jyt_payment_submission_paid_v1`) keeps working;
+ * only its timing moves. `payment_type` is read from the METHOD the payout was
+ * linked to at approval, spelled in the legacy enum subscribers expect.
+ */
+const emitSubmissionPaidStep = createStep(
+  "emit-submission-paid-on-settle",
+  async (
+    input: { submission_id: string; partner_id: string | null },
+    { container }
+  ) => {
+    const submissionService: PaymentSubmissionsService = container.resolve(
+      PAYMENT_SUBMISSIONS_MODULE
+    )
+    const [submission] = await submissionService.listPaymentSubmissions({
+      id: [input.submission_id],
+    })
+    if (!submission) {
+      return new StepResponse({ emitted: false })
+    }
+
+    let paymentType: string | null = null
+    try {
+      const query = container.resolve(ContainerRegistrationKeys.QUERY) as any
+      const { data } = await query.graph({
+        entity: SubmissionPaidToMethodLink.entryPoint,
+        fields: ["internal_payment_details_id"],
+        filters: { payment_submission_id: input.submission_id },
+      })
+      const methodId = (data || [])[0]?.internal_payment_details_id
+      if (methodId) {
+        const paymentService: InternalPaymentService = container.resolve(
+          INTERNAL_PAYMENTS_MODULE
+        )
+        const [method] = (await paymentService.listPaymentDetails({
+          id: [methodId],
+        })) as any[]
+        const map: Record<string, string> = {
+          bank_account: "Bank",
+          cash_account: "Cash",
+          digital_wallet: "Digital_Wallet",
+        }
+        paymentType = map[method?.type] ?? null
+      }
+    } catch {
+      // A payout settled without a resolvable method is still a settled payout.
+      paymentType = null
+    }
+
+    const eventService = container.resolve(
+      Modules.EVENT_BUS
+    ) as IEventBusModuleService
+
+    await eventService.emit([
+      {
+        name: "payment_submission.paid",
+        data: {
+          payment_submission_id: input.submission_id,
+          partner_id: input.partner_id ?? submission.partner_id,
+          total_amount: submission.total_amount,
+          currency: submission.currency,
+          rejection_reason: null,
+          payment_type: paymentType,
+          payment_id: null,
+        },
+      },
+    ])
+
+    return new StepResponse({ emitted: true })
+  }
+)
+
+export const settlePaymentReconciliationWorkflow = createWorkflow(
+  "settle-payment-reconciliation",
+  (input: SettlePaymentReconciliationInput) => {
+    const settled = settleReconciliationStep(input)
+
+    const submissionId = transform({ settled }, (d) =>
+      d.settled.reference_type === "payment_submission" && d.settled.reference_id
+        ? String(d.settled.reference_id)
+        : ""
+    )
+    const hasSubmission = transform(
+      { submissionId },
+      (d) => Boolean(d.submissionId)
+    )
+
+    when(hasSubmission, (v) => v).then(() =>
+      markSubmissionPaidOnSettleStep({
+        submission_id: submissionId,
+        paid_at: settled.settled_at,
+      })
+    )
+
+    when(hasSubmission, (v) => v).then(() =>
+      emitSubmissionPaidStep({
+        submission_id: submissionId,
+        partner_id: settled.partner_id,
+      })
+    )
+
+    return new WorkflowResponse({ reconciliation: settled.reconciliation })
+  }
+)

--- a/apps/backend/src/workflows/payment_submissions/review-payment-submission.ts
+++ b/apps/backend/src/workflows/payment_submissions/review-payment-submission.ts
@@ -332,35 +332,6 @@ const createReconciliationRecordStep = createStep(
   }
 )
 
-// Step 6: Mark submission as paid
-const markSubmissionPaidStep = createStep(
-  "mark-submission-paid",
-  async (input: { submission_id: string }, { container }) => {
-    const service: PaymentSubmissionsService = container.resolve(
-      PAYMENT_SUBMISSIONS_MODULE
-    )
-
-    await service.updatePaymentSubmissions({
-      id: input.submission_id,
-      status: "Paid",
-      paid_at: new Date(),
-    })
-
-    return new StepResponse(undefined, input.submission_id)
-  },
-  async (submissionId: string, { container }) => {
-    if (!submissionId) return
-    const service: PaymentSubmissionsService = container.resolve(
-      PAYMENT_SUBMISSIONS_MODULE
-    )
-    await service.updatePaymentSubmissions({
-      id: submissionId,
-      status: "Approved",
-      paid_at: null,
-    })
-  }
-)
-
 // Emit a payment_submission.* event after a successful status change.
 // Decoupled from the status-update step so emission only happens after
 // the entire workflow path that produced the new status has succeeded
@@ -412,7 +383,6 @@ const emitHandler = async (input: EmitInput, { container }: any) => {
   ])
   return new StepResponse({ emitted: true })
 }
-const emitPaidEventStep = createStep("emit-payment-submission-paid", emitHandler)
 const emitRejectedEventStep = createStep("emit-payment-submission-rejected", emitHandler)
 
 // Workflow
@@ -475,44 +445,26 @@ export const reviewPaymentSubmissionWorkflow = createWorkflow(
      * payments.ts` stays declared for the historical rows.
      */
 
-    when(isApproval, (val) => val).then(() =>
-      markSubmissionPaidStep({
-        submission_id: input.submission_id,
-      })
-    )
-
     /**
-     * The payout's type now comes from the METHOD it was paid to rather than
-     * from a reviewer-supplied field, so the two can no longer disagree. The
-     * event keeps the legacy `Bank`/`Cash`/`Digital_Wallet` spelling because
-     * subscribers already read it; `internal_payment_details.type` spells the
-     * same three values differently.
+     * 🔴 Approval STOPS at `Approved` (#1639). It used to continue to `Paid`
+     * in the same atomic workflow, and `payment_submission.paid` fired here.
+     *
+     * Production said that was untrue. All five reconciliations carry a real
+     * `settled_at`, and the gap from approval to settlement was 13 seconds,
+     * 8 minutes, 2 days, 6 days and **34 days**. For 34 days one payout read
+     * `Paid` and the partner had been told over WhatsApp they had been paid,
+     * while the money had not moved.
+     *
+     * `Paid` and `paid_at` are written by settling the reconciliation now —
+     * an action prod performs on 5 of 5 payouts, unlike the `internal_payments`
+     * row approval used to create, which was left `Pending` 5 times out of 5.
+     * The discipline was never missing; it was being spent on the record that
+     * had a UI.
+     *
+     * No `payment_submission.approved` event replaces it: there is no WhatsApp
+     * template for one, and inventing a notification is a separate decision
+     * from removing an untrue one.
      */
-    const paidPaymentType = transform({ paidToMethod }, (data) => {
-      const map: Record<string, string> = {
-        bank_account: "Bank",
-        cash_account: "Cash",
-        digital_wallet: "Digital_Wallet",
-      }
-      return map[data.paidToMethod?.type as string] ?? "Bank"
-    })
-
-    // Approval branch: now in Paid status — fire the event so the
-    // payment-status visual flow can WhatsApp the partner.
-    when(isApproval, (val) => val).then(() =>
-      emitPaidEventStep({
-        event_name: "payment_submission.paid",
-        submission_id: input.submission_id,
-        partner_id: submission.partner_id,
-        total_amount: paymentAmount,
-        currency: submission.currency,
-        payment_type: paidPaymentType,
-        // No payment row is created any more (#1636); the submission is the
-        // payout record. Left in the payload rather than removed so existing
-        // subscribers keep their shape.
-        payment_id: null,
-      })
-    )
 
     // Rejection branch: status is now Rejected. Fire the event so the
     // partner gets notified with the reason.

--- a/apps/backend/src/workflows/payment_submissions/review-payment-submission.ts
+++ b/apps/backend/src/workflows/payment_submissions/review-payment-submission.ts
@@ -133,102 +133,93 @@ const updateSubmissionStatusStep = createStep(
   }
 )
 
-// Step 3: Create internal payment on approval
-const createPaymentOnApprovalStep = createStep(
-  "create-payment-on-approval",
+/**
+ * Step 3: resolve the payment METHOD this payout goes to, and record it on the
+ * submission itself.
+ *
+ * 🔴 This step used to call `createPayments` and produce an `internal_payments`
+ * row (#1636). It no longer does. One payout used to exist as three records
+ * with three different answers to "has this partner been paid" — the submission
+ * said Paid, the payment said Pending forever because nothing ever moved it,
+ * and reconciliation said Settled. The submission is now the single payout
+ * record. Historical `internal_payments` rows are left exactly where they are;
+ * this only stops new ones being created.
+ *
+ * The method is still an `internal_payment_details` row — a payment METHOD, not
+ * a payment record — so the dependency that survives is the correct one. It is
+ * attached through the `payment_submission_paid_to_method` link rather than a
+ * `paid_to_id` column, because the two models live in different modules.
+ */
+const resolvePaidToMethodStep = createStep(
+  "resolve-paid-to-method",
   async (
     input: {
+      submission_id: string
       partner_id: string
-      amount: number
-      payment_type: "Bank" | "Cash" | "Digital_Wallet"
       paid_to_id?: string
     },
     { container }
   ) => {
+    const query = container.resolve(ContainerRegistrationKeys.QUERY) as any
+
+    const { data: linkData } = await query.graph({
+      entity: PartnerPaymentMethodsLink.entryPoint,
+      fields: ["internal_payment_details_id"],
+      filters: { partner_id: input.partner_id },
+    })
+    const methodIds = ((linkData || []) as any[]).map(
+      (r) => r.internal_payment_details_id
+    )
+
     const paymentService: InternalPaymentService = container.resolve(
       INTERNAL_PAYMENTS_MODULE
     )
+    const methods = methodIds.length
+      ? ((await paymentService.listPaymentDetails({ id: methodIds })) as any[])
+      : []
 
-    // Resolve paid_to_id: use provided value or auto-fetch partner's default payment method
-    let resolvedPaidToId = input.paid_to_id
-    if (!resolvedPaidToId && input.partner_id) {
-      const query = container.resolve(ContainerRegistrationKeys.QUERY) as any
-      const { data: linkData } = await query.graph({
-        entity: PartnerPaymentMethodsLink.entryPoint,
-        fields: ["internal_payment_details_id"],
-        filters: { partner_id: input.partner_id },
-      })
-      const methods = (linkData || []) as any[]
-      if (methods.length > 0) {
-        resolvedPaidToId = methods[0].internal_payment_details_id
+    /**
+     * Four branches, in order. The last one REFUSES rather than guessing.
+     *
+     * 🔴 The old code took `methods[0]` — whichever row the link query happened
+     * to return first. In production Sharlho has four bank accounts, one per
+     * employee, and three of them have received money at different times; two
+     * more partners have two methods each. Taking the first row there does not
+     * pay the wrong account, it pays the wrong PERSON. A partner with several
+     * methods and no default is a question for the reviewer, not something to
+     * resolve by ordering.
+     */
+    let resolved: any = null
+
+    if (input.paid_to_id) {
+      resolved = methods.find((m) => m.id === input.paid_to_id)
+      if (!resolved) {
+        throw new MedusaError(
+          MedusaError.Types.INVALID_DATA,
+          `Payment method ${input.paid_to_id} is not one of this partner's payment methods.`
+        )
       }
+    } else if (methods.some((m) => m.is_default)) {
+      resolved = methods.find((m) => m.is_default)
+    } else if (methods.length === 1) {
+      resolved = methods[0]
+    } else if (methods.length > 1) {
+      throw new MedusaError(
+        MedusaError.Types.INVALID_DATA,
+        `Cannot approve payment: partner has ${methods.length} payment methods and none is marked default. ` +
+          `Choose which one to pay, or mark one as the partner's default.`
+      )
     }
 
-    if (!resolvedPaidToId) {
+    if (!resolved) {
+      // Kept verbatim — approving a payout to a partner with no bank details
+      // approves something that cannot be paid.
       throw new MedusaError(
         MedusaError.Types.INVALID_DATA,
         "Cannot approve payment: partner has no payment method configured. Ask the partner to add their bank/wallet details first."
       )
     }
 
-    const paymentData: Record<string, any> = {
-      amount: input.amount,
-      status: "Pending",
-      payment_type: input.payment_type,
-      payment_date: new Date(),
-      paid_to_id: resolvedPaidToId,
-    }
-
-    const payment = await paymentService.createPayments(paymentData)
-
-    // Link payment to partner
-    const remoteLink = container.resolve(
-      ContainerRegistrationKeys.LINK
-    ) as Link
-
-    const partnerLink: LinkDefinition = {
-      [PARTNER_MODULE]: { partner_id: input.partner_id },
-      [INTERNAL_PAYMENTS_MODULE]: {
-        internal_payments_id: payment.id,
-      },
-      data: {
-        partner_id: input.partner_id,
-        payment_id: payment.id,
-        linked_with: "partner",
-      },
-    }
-
-    await remoteLink.create([partnerLink])
-
-    return new StepResponse(payment, {
-      payment_id: payment.id,
-      partner_link: partnerLink,
-    })
-  },
-  async (
-    rollbackData: { payment_id: string; partner_link: LinkDefinition },
-    { container }
-  ) => {
-    if (!rollbackData) return
-    const paymentService: InternalPaymentService = container.resolve(
-      INTERNAL_PAYMENTS_MODULE
-    )
-    await paymentService.softDeletePayments(rollbackData.payment_id)
-
-    const remoteLink = container.resolve(
-      ContainerRegistrationKeys.LINK
-    ) as Link
-    await remoteLink.dismiss([rollbackData.partner_link])
-  }
-)
-
-// Step 4: Link submission to the created payment
-const linkSubmissionToPaymentStep = createStep(
-  "link-submission-to-payment",
-  async (
-    input: { submission_id: string; payment_id: string },
-    { container }
-  ) => {
     const remoteLink = container.resolve(
       ContainerRegistrationKeys.LINK
     ) as Link
@@ -238,19 +229,26 @@ const linkSubmissionToPaymentStep = createStep(
         payment_submission_id: input.submission_id,
       },
       [INTERNAL_PAYMENTS_MODULE]: {
-        internal_payments_id: input.payment_id,
+        internal_payment_details_id: resolved.id,
       },
     }
-
     await remoteLink.create([link])
-    return new StepResponse(link, link)
+
+    return new StepResponse(
+      {
+        id: resolved.id,
+        type: resolved.type as string,
+        account_name: resolved.account_name as string,
+      },
+      link
+    )
   },
   async (rollbackLink: LinkDefinition, { container }) => {
     if (!rollbackLink) return
     const remoteLink = container.resolve(
       ContainerRegistrationKeys.LINK
     ) as Link
-    await remoteLink.dismiss([rollbackLink])
+    await remoteLink.dismiss([rollbackLink]).catch(() => {})
   }
 )
 
@@ -277,73 +275,6 @@ const resolveSubmissionSourceStep = createStep(
   }
 )
 
-/**
- * Link the payment to the INVENTORY ORDER it paid for.
- *
- * 🔴 `links/inventory-orders-internal-payments.ts` has existed all along and
- * nothing has ever written it. The consequence is visible on prod: open the
- * inventory order a payout was for and it shows no payment, because the only
- * link approval created pointed at the partner. The declaration was the
- * intended design; it was simply never wired.
- *
- * Best-effort and non-fatal, deliberately. The payment, the reconciliation and
- * the submission status are all already written by the time this runs, and a
- * failure to draw a navigational edge must not roll back a recorded payout.
- * Mirrors how the production-run link is created in `log-consumption`.
- */
-const linkPaymentToInventoryOrderStep = createStep(
-  "link-payment-to-inventory-order",
-  async (
-    input: { payment_id: string; inventory_order_id: string },
-    { container }
-  ) => {
-    if (!input.inventory_order_id || !input.payment_id) {
-      return new StepResponse<LinkDefinition | null>(null)
-    }
-
-    const remoteLink = container.resolve(
-      ContainerRegistrationKeys.LINK
-    ) as Link
-
-    const link: LinkDefinition = {
-      [ORDER_INVENTORY_MODULE]: {
-        inventory_orders_id: input.inventory_order_id,
-      },
-      [INTERNAL_PAYMENTS_MODULE]: {
-        internal_payments_id: input.payment_id,
-      },
-    }
-
-    try {
-      await remoteLink.create([link])
-    } catch (e: any) {
-      /**
-       * ⚠️ Assigned through `any` rather than chained off `container.resolve`.
-       * Medusa 2.19 types `resolve` as `unknown`, so `resolve(LOGGER).warn(…)`
-       * is `TS2571: Object is of type 'unknown'` — which broke the deploy of
-       * `24f12a1b5` while `check:prod-build` passed both locally and in CI,
-       * because the Docker build resolves a different @medusajs/types than
-       * either. Every other logger in this file is already assigned first.
-       */
-      const logger: any = container.resolve(ContainerRegistrationKeys.LOGGER)
-      logger?.warn?.(
-        `[review-payment-submission] payment ${input.payment_id} recorded but ` +
-          `could not be linked to inventory order ${input.inventory_order_id}: ${e?.message}`
-      )
-      return new StepResponse<LinkDefinition | null>(null)
-    }
-
-    return new StepResponse<LinkDefinition | null>(link, link)
-  },
-  async (link: LinkDefinition | null, { container }) => {
-    if (!link) return
-    const remoteLink = container.resolve(
-      ContainerRegistrationKeys.LINK
-    ) as Link
-    await remoteLink.dismiss([link]).catch(() => {})
-  }
-)
-
 // Step 5: Create reconciliation record
 const createReconciliationRecordStep = createStep(
   "create-reconciliation-record",
@@ -353,7 +284,6 @@ const createReconciliationRecordStep = createStep(
       partner_id: string
       expected_amount: number
       actual_amount: number
-      payment_id: string
       source_type: string | null
       source_id: string | null
     },
@@ -380,7 +310,15 @@ const createReconciliationRecordStep = createStep(
       actual_amount: input.actual_amount,
       discrepancy,
       status,
-      payment_id: input.payment_id,
+      /**
+       * 🔴 Vestigial for new payouts (#1636). `payment_id` was the only
+       * traversable route from a submission to its payment, and #1634 had just
+       * repaired a backfill to use it — but approval no longer creates a
+       * payment row, so there is nothing to point at. Nothing is lost:
+       * `reference_id` already names the submission, which IS the payout record
+       * now. The column still resolves the 5 historical rows.
+       */
+      payment_id: null,
     })
 
     return new StepResponse(reconciliation, reconciliation.id)
@@ -405,6 +343,7 @@ const markSubmissionPaidStep = createStep(
     await service.updatePaymentSubmissions({
       id: input.submission_id,
       status: "Paid",
+      paid_at: new Date(),
     })
 
     return new StepResponse(undefined, input.submission_id)
@@ -417,6 +356,7 @@ const markSubmissionPaidStep = createStep(
     await service.updatePaymentSubmissions({
       id: submissionId,
       status: "Approved",
+      paid_at: null,
     })
   }
 )
@@ -501,19 +441,11 @@ export const reviewPaymentSubmissionWorkflow = createWorkflow(
 
     const isApproval = transform(input, (i) => i.action === "approve")
 
-    const payment = when(isApproval, (val) => val).then(() =>
-      createPaymentOnApprovalStep({
-        partner_id: submission.partner_id,
-        amount: paymentAmount,
-        payment_type: (input.payment_type || "Bank") as "Bank" | "Cash" | "Digital_Wallet",
-        paid_to_id: input.paid_to_id,
-      })
-    )
-
-    when(isApproval, (val) => val).then(() =>
-      linkSubmissionToPaymentStep({
+    const paidToMethod = when(isApproval, (val) => val).then(() =>
+      resolvePaidToMethodStep({
         submission_id: input.submission_id,
-        payment_id: payment!.id,
+        partner_id: submission.partner_id,
+        paid_to_id: input.paid_to_id,
       })
     )
 
@@ -527,38 +459,43 @@ export const reviewPaymentSubmissionWorkflow = createWorkflow(
         partner_id: submission.partner_id,
         expected_amount: submission.total_amount,
         actual_amount: paymentAmount,
-        payment_id: payment!.id,
         source_type: source!.source_type,
         source_id: source!.source_id,
       })
     )
 
     /**
-     * Draw the edge the inventory order needs to show its payments.
+     * ⚠️ The payment → inventory-order link is deliberately gone (#1636).
      *
-     * Only for an inventory-order-sourced payout: `source_id` is the order id
-     * exactly when `source_type` is `inventory_order` and the submission names
-     * a single one. The step itself no-ops on an empty id, so a design-, task-,
-     * run- or mixed-sourced payout passes straight through.
+     * It was wired so an inventory order could show the payout it paid for, but
+     * it drew its edge from the `internal_payments` row that approval no longer
+     * creates. Nothing regresses: #1625 made payouts reachable from the order
+     * through the submission's LINES, which is why GOF's order already showed
+     * its ₹30,000 with no such link present. `links/inventory-orders-internal-
+     * payments.ts` stays declared for the historical rows.
      */
-    const inventoryOrderForPayment = transform({ source }, (data) =>
-      data.source?.source_type === "inventory_order" && data.source?.source_id
-        ? String(data.source.source_id)
-        : ""
-    )
-
-    when(isApproval, (val) => val).then(() =>
-      linkPaymentToInventoryOrderStep({
-        payment_id: payment!.id,
-        inventory_order_id: inventoryOrderForPayment,
-      })
-    )
 
     when(isApproval, (val) => val).then(() =>
       markSubmissionPaidStep({
         submission_id: input.submission_id,
       })
     )
+
+    /**
+     * The payout's type now comes from the METHOD it was paid to rather than
+     * from a reviewer-supplied field, so the two can no longer disagree. The
+     * event keeps the legacy `Bank`/`Cash`/`Digital_Wallet` spelling because
+     * subscribers already read it; `internal_payment_details.type` spells the
+     * same three values differently.
+     */
+    const paidPaymentType = transform({ paidToMethod }, (data) => {
+      const map: Record<string, string> = {
+        bank_account: "Bank",
+        cash_account: "Cash",
+        digital_wallet: "Digital_Wallet",
+      }
+      return map[data.paidToMethod?.type as string] ?? "Bank"
+    })
 
     // Approval branch: now in Paid status — fire the event so the
     // payment-status visual flow can WhatsApp the partner.
@@ -569,8 +506,11 @@ export const reviewPaymentSubmissionWorkflow = createWorkflow(
         partner_id: submission.partner_id,
         total_amount: paymentAmount,
         currency: submission.currency,
-        payment_type: input.payment_type ?? "Bank",
-        payment_id: payment!.id,
+        payment_type: paidPaymentType,
+        // No payment row is created any more (#1636); the submission is the
+        // payout record. Left in the payload rather than removed so existing
+        // subscribers keep their shape.
+        payment_id: null,
       })
     )
 
@@ -588,6 +528,6 @@ export const reviewPaymentSubmissionWorkflow = createWorkflow(
       })
     )
 
-    return new WorkflowResponse({ submission, payment })
+    return new WorkflowResponse({ submission, paid_to: paidToMethod })
   }
 )

--- a/apps/backend/src/workflows/whatsapp/whatsapp-admin-handler.ts
+++ b/apps/backend/src/workflows/whatsapp/whatsapp-admin-handler.ts
@@ -804,14 +804,34 @@ async function handleReviewPayment(
     return { handled: true, action: `${decision}_payment`, error: "missing_id" }
   }
 
-  await reviewPaymentSubmissionWorkflow(scope).run({
-    input: {
-      submission_id: submissionId,
-      action: decision === "approve" ? "approve" : "reject",
-      reviewed_by: admin.userId,
-      ...(reason ? { rejection_reason: reason } : {}),
-    },
-  })
+  /**
+   * ⚠️ This path names no `paid_to_id` — there is no picker over WhatsApp.
+   *
+   * It therefore depends entirely on the fallback, and since #1636 the fallback
+   * REFUSES when a partner has several payment methods and none is marked
+   * default. That is the point: Sharlho has four bank accounts, one per
+   * employee, and this path used to resolve them by taking whichever row the
+   * link query returned first — approving a payout to an arbitrary person from
+   * a chat message. Surface the refusal as a readable reply instead of an
+   * unhandled throw.
+   */
+  try {
+    await reviewPaymentSubmissionWorkflow(scope).run({
+      input: {
+        submission_id: submissionId,
+        action: decision === "approve" ? "approve" : "reject",
+        reviewed_by: admin.userId,
+        ...(reason ? { rejection_reason: reason } : {}),
+      },
+    })
+  } catch (e: any) {
+    const message = e?.message || "Unknown error"
+    await whatsapp.sendTextMessage(
+      phone,
+      `Could not ${decision} payment ${submissionId}.\n\n${message}`
+    )
+    return { handled: true, action: `${decision}_payment`, error: "review_failed" }
+  }
 
   const emoji = decision === "approve" ? "Approved" : "Rejected"
   const audit: WhatsAppAuditContext = {


### PR DESCRIPTION
Closes the forward-only half of **#1636** (steps 1–3, 6) and **#1639**.

Approval stops creating `internal_payments` rows, and stops claiming `Paid`. The submission is the payout record; settling the reconciliation is what says money moved. The 31 historical payment rows are left exactly where they are.

## What changed

| | |
|---|---|
| `payment_submission.paid_at` | when money moved — written at settlement |
| `internal_payment_details.is_default` | the method a payout falls back to; exclusive per owner |
| `submission-paid-to-method-link.ts` | the method the payout went to |
| `setDefaultPaymentMethodWorkflow` | promote one method, demote the owner's others |
| `settlePaymentReconciliationWorkflow` | settle → reconciliation **and** submission, one action |
| `backfill-submission-paid-at` | stamp `paid_at` on the 5 already-settled payouts |

No `payment_type` column. `internal_payment_details.type` already carries it, so it is derived from the linked method rather than stored a second time where the two could disagree.

## 🔴 The link needs an explicit table name

Medusa derives a link table as `<moduleA>_<entityA>_<moduleB>_<entityB>`. For this pair that is 80 characters, against Postgres's **63-byte** identifier limit.

This is the answer to the question #1636 was opened around. `submission-payment-link.ts` derives to 73 characters and its table exists in **neither the local nor the production schema**, while every link table that did materialise is ≤58. Confirmed by controlled comparison: one `db:migrate --execute-safe-links` run created this PR's 33-char table and **still** silently skipped the 73-char one, printing no error. It was never a data problem.

## 🔴 `methods[0]` was picking the wrong person

Resolution is four branches, and the last refuses:

1. reviewer's `paid_to_id` — now validated as belonging to that partner
2. the method flagged `is_default`
3. exactly one method
4. several with no default → **refuse**, naming the count

Prod: **Sharlho** has four bank accounts under one partner — one per employee — and three have been paid at different times. Parmar has two. The old fallback took whichever row the link query returned first. The **WhatsApp approve path** names no method at all, so `approve payment <id>` was resolving those four by ordering; it now refuses with a readable reply rather than an unhandled throw.

## 🔴 `Paid` at approval was untrue for up to 34 days

| payout | approved → settled |
|---|---|
| ₹8,974 | 13 seconds |
| ₹30,000 | 8 minutes |
| ₹2,500 | 2 days |
| ₹2,000 | 6 days |
| ₹4,500 | **34 days** |

During each window the submission said `Paid` and the partner had been told over WhatsApp they were paid.

The fix reuses an action that already exists **and is already performed**: 5 of 5 reconciliations are `Settled` with a real `settled_at`, by the same admin — while the `internal_payments` row approval created was left `Pending` 5 times out of 5. The discipline was never missing; it was being spent on the record that had a UI. Settling now writes both records in one compensatable workflow and fires `payment_submission.paid` from there. Event name and payload are unchanged, so the seeded WhatsApp flow keeps working — only its timing moves.

No `payment_submission.approved` replaces it: there is no template for one, and inventing a notification is a separate decision from removing an untrue one.

`fold.ts` needed no logic change — `PAID_STATUSES = {"Paid"}` and its comment on why `Approved` is excluded were already right, and become load-bearing.

## Backfill: timestamps only

Prod has 20 submissions (5 Paid, 14 Pending, 1 Rejected) and 5 reconciliations, all Settled. **The 5 `Paid` submissions are exactly the 5 settled reconciliations, id for id**, and nothing sits in `Approved` — so the new meaning of `Paid` is already true of every existing row and **no status backfill is needed or performed**.

Only `paid_at` is missing on those 5. `backfill-submission-paid-at` copies `settled_at` onto them and nothing else — never `updated_at`, `reviewed_at`, or a payment's `payment_date`, which record when someone *approved*; the 13-second-to-34-day spread proves they are not interchangeable. A payout with no settled reconciliation is skipped, because a null `paid_at` truthfully says the time is unknown while a wrong one reads as fact. Idempotent.

## ⚠️ Both migrations are hand-written

`medusa db:generate internal_payments` emitted `create table if not exists` for all three of that module's tables instead of an ALTER: the module had no MikroORM snapshot, so the generator believed the schema was empty. On any database where the tables already exist — local and prod both — it would have added **nothing** while recording itself as applied, and `is_default` would never have appeared. The missing snapshot is committed so the next generate diffs properly.

Migration names checked unique across all modules — #1635 was the second time two collided and prod silently skipped one.

## Retired on the approval path only

The submission→payment link, the payment→inventory-order link, and the partner→payment link. `payment_reconciliation.payment_id` writes `null`; `reference_id` already names the submission. #1625 made payouts reachable from the order through submission LINES.

## Verification

| | |
|---|---|
| `payment-submissions-api.spec.ts` | **101/101** |
| `payment-reports-api.spec.ts` | 35/35 |
| maintenance-jobs unit | 672/672 (60 suites) |
| `backfill-submission-paid-at` spec | 7/7 |
| `payment-methods` / `partner-payment-e2e` | 1/1, 9/9 |
| `check:prod-build` | ✓ |

Three existing tests asserted the old contracts and were updated — one failed first and caught the change. The line-edit guard test now asserts `Approved`; the guard itself never changed, only the status it names.

## ⚠️ Deploy note

Two migrations. Do not merge back-to-back with another PR — a cancelled deploy strands them.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01TLt1f38xqR8k2myCVxP8e4
