### PR TITLE
feat(shipping): DHL Express API — serviceability, landed cost, customs shipment

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -115,3 +115,6 @@ apps/backend/test-results/
 # `git status` and are one careless `git add -A` away from being committed.
 apps/backend/_crm_hb_e2e/
 apps/backend/_pp_hb_e2e/
+
+# Local AI agent memory — never commit
+.ai-memory/

--- a/apps/backend/src/modules/shipping-providers/dhl/client.ts
+++ b/apps/backend/src/modules/shipping-providers/dhl/client.ts
@@ -6,17 +6,92 @@ export type DHLOptions = {
   api_secret: string
   account_number?: string
   sandbox?: boolean
+  fetchImpl?: typeof fetch
+}
+
+export type DHLAddress = {
+  line1: string
+  city: string
+  postal_code: string
+  country_code: string
+}
+
+export type DHLParty = {
+  name: string
+  address: DHLAddress
+  phone?: string
+  email?: string
+  company_name?: string
+}
+
+export type DHLLineItem = {
+  description: string
+  price: number
+  quantity: number
+  hs_code: string
+  weight_kg: number
+  manufacturer_country: string
+}
+
+export type DHLRateParams = {
+  origin_country: string
+  origin_city: string
+  origin_postal_code: string
+  dest_country: string
+  dest_city: string
+  dest_postal_code: string
+  weight: number
+  length?: number
+  width?: number
+  height?: number
+  planned_shipping_date?: string
+  is_customs_declarable?: boolean
+}
+
+export type DHLLandedCostParams = {
+  shipper: DHLParty
+  receiver: DHLParty
+  weight: number
+  length?: number
+  width?: number
+  height?: number
+  product_code?: string
+  currency_code: string
+  declared_value: number
+  items: Array<{
+    name: string
+    description?: string
+    hs_code: string
+    origin_country: string
+    quantity: number
+    unit_price: number
+  }>
+}
+
+export type DHLCreateShipmentParams = {
+  shipper: DHLParty
+  receiver: DHLParty
+  packages: Array<{ weight: number; length?: number; width?: number; height?: number }>
+  product_code?: string
+  description?: string
+  is_customs_declarable?: boolean
+  declared_value?: number
+  declared_value_currency?: string
+  items?: DHLLineItem[]
+  invoice_number?: string
 }
 
 export class DHLClient {
   private baseUrl: string
   private authHeader: string
   private accountNumber: string
+  private fetchImpl: typeof fetch
 
   constructor(options: DHLOptions) {
     this.baseUrl = options.sandbox ? TEST_BASE : PROD_BASE
     this.authHeader = `Basic ${Buffer.from(`${options.api_key}:${options.api_secret}`).toString("base64")}`
     this.accountNumber = options.account_number || ""
+    this.fetchImpl = options.fetchImpl || fetch
   }
 
   private headers(): Record<string, string> {
@@ -26,15 +101,59 @@ export class DHLClient {
     }
   }
 
-  async getRates(params: {
-    origin_country: string
-    origin_city: string
-    origin_postal_code: string
-    dest_country: string
-    dest_city: string
-    dest_postal_code: string
-    weight: number // kg
-    planned_shipping_date?: string
+  private async request<T>(path: string, init?: RequestInit): Promise<T> {
+    const res = await this.fetchImpl(`${this.baseUrl}${path}`, {
+      ...init,
+      headers: { ...this.headers(), ...(init?.headers || {}) },
+    })
+    const text = await res.text()
+    let body: any
+    try {
+      body = text ? JSON.parse(text) : {}
+    } catch {
+      body = text
+    }
+    if (!res.ok) {
+      const detail =
+        typeof body === "string" ? body : body?.detail || body?.message || JSON.stringify(body)
+      throw new Error(`DHL ${path.split("?")[0]} failed (${res.status}): ${detail}`)
+    }
+    return body as T
+  }
+
+  /**
+   * Rating — account rates and available products for a one-piece shipment.
+   */
+  async getRates(params: DHLRateParams): Promise<any> {
+    const qs = new URLSearchParams({
+      accountNumber: this.accountNumber,
+      originCountryCode: params.origin_country,
+      originCityName: params.origin_city,
+      originPostalCode: params.origin_postal_code,
+      destinationCountryCode: params.dest_country,
+      destinationCityName: params.dest_city,
+      destinationPostalCode: params.dest_postal_code,
+      weight: String(params.weight),
+      length: String(params.length ?? 30),
+      width: String(params.width ?? 20),
+      height: String(params.height ?? 10),
+      plannedShippingDate:
+        params.planned_shipping_date || new Date().toISOString().split("T")[0],
+      isCustomsDeclarable: String(params.is_customs_declarable ?? false),
+      unitOfMeasurement: "metric",
+    })
+    return this.request<any>(`/rates?${qs}`)
+  }
+
+  /**
+   * Product — lightweight capability check: which DHL Express products serve
+   * the lane, without prices. Cheaper than rating when only serviceability is
+   * needed. `totalPrice` is absent from this response.
+   */
+  async getProducts(params: Omit<DHLRateParams, "length" | "width" | "height"> & {
+    length?: number
+    width?: number
+    height?: number
   }): Promise<any> {
     const qs = new URLSearchParams({
       accountNumber: this.accountNumber,
@@ -45,40 +164,99 @@ export class DHLClient {
       destinationCityName: params.dest_city,
       destinationPostalCode: params.dest_postal_code,
       weight: String(params.weight),
-      length: "30",
-      width: "20",
-      height: "10",
-      plannedShippingDate: params.planned_shipping_date || new Date().toISOString().split("T")[0],
-      isCustomsDeclarable: "false",
+      length: String(params.length ?? 30),
+      width: String(params.width ?? 20),
+      height: String(params.height ?? 10),
+      plannedShippingDate:
+        params.planned_shipping_date || new Date().toISOString().split("T")[0],
+      isCustomsDeclarable: String(params.is_customs_declarable ?? false),
       unitOfMeasurement: "metric",
     })
-
-    const res = await fetch(`${this.baseUrl}/rates?${qs}`, {
-      headers: this.headers(),
-    })
-    if (!res.ok) {
-      const body = await res.text()
-      throw new Error(`DHL getRates failed (${res.status}): ${body}`)
-    }
-    return res.json()
+    return this.request<any>(`/products?${qs}`)
   }
 
-  async createShipment(payload: {
-    shipper: {
-      name: string
-      address: { line1: string; city: string; postal_code: string; country_code: string }
-      phone: string
-    }
-    receiver: {
-      name: string
-      address: { line1: string; city: string; postal_code: string; country_code: string }
-      phone: string
-    }
-    packages: Array<{ weight: number; dimensions?: { length: number; width: number; height: number } }>
-    product_code?: string
-    description?: string
+  /**
+   * Address validation — whether DHL serves a destination (or pickup origin).
+   * `type` is "delivery" or "pickup". Returns the resolved service area.
+   */
+  async addressValidate(params: {
+    type: "delivery" | "pickup"
+    country_code: string
+    postal_code: string
+    city: string
+    strict_validation?: boolean
   }): Promise<any> {
+    const qs = new URLSearchParams({
+      type: params.type,
+      countryCode: params.country_code,
+      postalCode: params.postal_code,
+      cityName: params.city,
+      strictValidation: String(params.strict_validation ?? false),
+    })
+    return this.request<any>(`/address-validate?${qs}`)
+  }
+
+  /**
+   * Landed Cost — duties + taxes + freight for a customs-declarable consignment.
+   * Unlike rating and shipment, the landed-cost schema is FLAT: customer details
+   * carry postalCode/cityName/countryCode directly (no `postalAddress` wrapper),
+   * and items carry a singular `commodityCode` (full import code) with `quantity`
+   * as a bare number.
+   */
+  async landedCost(params: DHLLandedCostParams): Promise<any> {
     const body = {
+      customerDetails: {
+        shipperDetails: {
+          postalCode: params.shipper.address.postal_code,
+          cityName: params.shipper.address.city,
+          countryCode: params.shipper.address.country_code,
+          addressLine1: params.shipper.address.line1,
+        },
+        receiverDetails: {
+          postalCode: params.receiver.address.postal_code,
+          cityName: params.receiver.address.city,
+          countryCode: params.receiver.address.country_code,
+          addressLine1: params.receiver.address.line1,
+        },
+      },
+      accounts: [{ typeCode: "shipper", number: this.accountNumber }],
+      productCode: params.product_code || "P",
+      localProductCode: params.product_code || "P",
+      unitOfMeasurement: "metric",
+      currencyCode: params.currency_code,
+      isCustomsDeclarable: true,
+      getCostBreakdown: true,
+      packages: [
+        {
+          weight: params.weight,
+          dimensions: {
+            length: params.length ?? 30,
+            width: params.width ?? 20,
+            height: params.height ?? 10,
+          },
+        },
+      ],
+      items: params.items.map((item, i) => ({
+        number: i + 1,
+        name: item.name,
+        description: item.description || item.name,
+        manufacturerCountry: item.origin_country,
+        quantity: item.quantity,
+        unitPrice: item.unit_price,
+        unitPriceCurrencyCode: params.currency_code,
+        commodityCode: item.hs_code,
+      })),
+    }
+    return this.request<any>(`/landed-cost`, {
+      method: "POST",
+      body: JSON.stringify(body),
+    })
+  }
+
+  async createShipment(payload: DHLCreateShipmentParams): Promise<any> {
+    const isCustomsDeclarable = payload.is_customs_declarable ?? false
+
+    const body: Record<string, any> = {
       plannedShippingDateAndTime: new Date().toISOString(),
       pickup: { isRequested: false },
       productCode: payload.product_code || "P",
@@ -92,8 +270,9 @@ export class DHLClient {
             countryCode: payload.shipper.address.country_code,
           },
           contactInformation: {
-            phone: payload.shipper.phone,
-            companyName: payload.shipper.name,
+            phone: payload.shipper.phone || "",
+            email: payload.shipper.email || "",
+            companyName: payload.shipper.company_name || payload.shipper.name,
             fullName: payload.shipper.name,
           },
         },
@@ -105,8 +284,9 @@ export class DHLClient {
             countryCode: payload.receiver.address.country_code,
           },
           contactInformation: {
-            phone: payload.receiver.phone,
-            companyName: payload.receiver.name,
+            phone: payload.receiver.phone || "",
+            email: payload.receiver.email || "",
+            companyName: payload.receiver.company_name || payload.receiver.name,
             fullName: payload.receiver.name,
           },
         },
@@ -114,10 +294,14 @@ export class DHLClient {
       content: {
         packages: payload.packages.map((pkg, i) => ({
           weight: pkg.weight,
-          dimensions: pkg.dimensions || { length: 30, width: 20, height: 10 },
+          dimensions: {
+            length: pkg.length ?? 30,
+            width: pkg.width ?? 20,
+            height: pkg.height ?? 10,
+          },
           customerReferences: [{ value: `pkg-${i + 1}` }],
         })),
-        isCustomsDeclarable: false,
+        isCustomsDeclarable,
         description: payload.description || "Textile goods",
         unitOfMeasurement: "metric",
       },
@@ -126,24 +310,76 @@ export class DHLClient {
       },
     }
 
-    const res = await fetch(`${this.baseUrl}/shipments`, {
+    if (isCustomsDeclarable) {
+      body.content.declaredValue = payload.declared_value ?? 0
+      body.content.declaredValueCurrency = payload.declared_value_currency || "EUR"
+      body.content.exportDeclaration = {
+        lineItems: (payload.items || []).map((item, i) => ({
+          number: i + 1,
+          description: item.description,
+          price: item.price,
+          quantity: { value: item.quantity, unitOfMeasurement: "PCS" },
+          commodityCodes: [{ typeCode: "outbound", value: item.hs_code }],
+          weight: { netValue: item.weight_kg, grossValue: item.weight_kg },
+          manufacturerCountry: item.manufacturer_country,
+          exportReasonType: "permanent",
+        })),
+        invoice: {
+          number: payload.invoice_number || `INV-${Date.now()}`,
+          date: new Date().toISOString().split("T")[0],
+        },
+      }
+    }
+
+    return this.request<any>(`/shipments`, {
       method: "POST",
-      headers: this.headers(),
       body: JSON.stringify(body),
     })
-    if (!res.ok) {
-      const respBody = await res.text()
-      throw new Error(`DHL createShipment failed (${res.status}): ${respBody}`)
+  }
+
+  async getShipment(shipmentTrackingNumber: string): Promise<any> {
+    return this.request<any>(
+      `/shipments/${encodeURIComponent(shipmentTrackingNumber)}`
+    )
+  }
+
+  async createPickup(payload: {
+    shipmentTrackingNumber: string
+    pickupLocation: {
+      name: string
+      address: DHLAddress
+      phone?: string
+      email?: string
     }
-    return res.json()
+    planned_pickup_date_and_time?: string
+  }): Promise<any> {
+    const body = {
+      plannedPickupDateAndTime:
+        payload.planned_pickup_date_and_time || new Date().toISOString(),
+      shipmentTrackingNumbers: [payload.shipmentTrackingNumber],
+      account: { typeCode: "shipper", number: this.accountNumber },
+      pickupLocation: {
+        name: payload.pickupLocation.name,
+        phone: payload.pickupLocation.phone || "",
+        email: payload.pickupLocation.email || "",
+        address: {
+          addressLine1: payload.pickupLocation.address.line1,
+          cityName: payload.pickupLocation.address.city,
+          postalCode: payload.pickupLocation.address.postal_code,
+          countryCode: payload.pickupLocation.address.country_code,
+        },
+      },
+      pickupDetails: { localCutoffDateAndTime: payload.planned_pickup_date_and_time || new Date().toISOString() },
+    }
+    return this.request<any>(`/pickups`, {
+      method: "POST",
+      body: JSON.stringify(body),
+    })
   }
 
   async track(trackingNumber: string): Promise<any> {
-    const res = await fetch(
-      `${this.baseUrl}/tracking?shipmentTrackingNumber=${trackingNumber}`,
-      { headers: this.headers() }
+    return this.request<any>(
+      `/tracking?shipmentTrackingNumber=${encodeURIComponent(trackingNumber)}`
     )
-    if (!res.ok) throw new Error(`DHL tracking failed (${res.status})`)
-    return res.json()
   }
 }

--- a/apps/backend/src/modules/shipping-providers/dhl/service.ts
+++ b/apps/backend/src/modules/shipping-providers/dhl/service.ts
@@ -7,11 +7,23 @@ import {
   FulfillmentDTO,
   CalculatedShippingOptionPrice,
   CreateShippingOptionDTO,
+  Logger,
 } from "@medusajs/framework/types"
 import { DHLClient, DHLOptions } from "./client"
-import { Logger } from "@medusajs/framework/types"
+import { declaredValueForShipment } from "../delhivery/declared-value"
 
 type InjectedDeps = { logger: Logger }
+
+/** Textile fallback when a variant carries no HS code (HS 6304.92 — cotton furnishings). */
+const DEFAULT_HS_CODE = "6304.92"
+
+/** DHL bills international shipments at a 0.5 kg minimum. */
+const MIN_WEIGHT_KG = 0.5
+
+function hsCodeFor(orderItem: any): string {
+  const metadata = orderItem?.variant?.metadata || orderItem?.metadata || {}
+  return metadata.hs_code || metadata.hsCode || metadata.HSCode || DEFAULT_HS_CODE
+}
 
 class DHLExpressFulfillmentService extends AbstractFulfillmentProviderService {
   static identifier = "dhl-express"
@@ -26,10 +38,12 @@ class DHLExpressFulfillmentService extends AbstractFulfillmentProviderService {
   }
 
   async getFulfillmentOptions(): Promise<FulfillmentOption[]> {
+    // Real IN-origin products returned by the sandbox for international lanes.
+    // "H" (Economy Select) and "N" (Domestic) are not available out of India.
     return [
       { id: "dhl-express-worldwide", name: "DHL Express Worldwide", product_code: "P" },
-      { id: "dhl-express-economy", name: "DHL Economy Select", product_code: "H" },
-      { id: "dhl-express-domestic", name: "DHL Domestic Express", product_code: "N" },
+      { id: "dhl-express-1200", name: "DHL Express 12:00", product_code: "Y" },
+      { id: "dhl-express-easy", name: "DHL Express Easy", product_code: "8" },
     ]
   }
 
@@ -38,6 +52,25 @@ class DHLExpressFulfillmentService extends AbstractFulfillmentProviderService {
     data: Record<string, unknown>,
     context: any
   ): Promise<Record<string, unknown>> {
+    const shippingAddress = (data as any).shipping_address || {}
+    const country = shippingAddress.country_code
+    const postal = shippingAddress.postal_code
+    const city = shippingAddress.city
+    if (country && postal && city) {
+      try {
+        const result = await this.client.addressValidate({
+          type: "delivery",
+          country_code: country,
+          postal_code: postal,
+          city,
+        })
+        if (!result?.address?.length) {
+          throw new Error(`Destination ${city} ${postal} ${country} is not serviceable by DHL`)
+        }
+      } catch (e: any) {
+        this.logger.warn(`DHL serviceability check failed: ${e.message}`)
+      }
+    }
     return { ...data, ...optionData }
   }
 
@@ -58,27 +91,29 @@ class DHLExpressFulfillmentService extends AbstractFulfillmentProviderService {
       const from = (context as any).from_location?.address || {}
       const to = (context as any).shipping_address || {}
       const items = (context as any).items || []
-      const totalWeightKg = items.reduce(
-        (sum: number, i: any) => sum + (((i.variant?.weight || 500) * (i.quantity || 1)) / 1000),
-        0
-      ) || 0.5
+
+      const totalWeightKg = this.weightInKg(items)
 
       const result = await this.client.getRates({
-        origin_country: from.country_code || "DE",
+        origin_country: from.country_code || "IN",
         origin_city: from.city || "",
         origin_postal_code: from.postal_code || "",
         dest_country: to.country_code || "",
         dest_city: to.city || "",
         dest_postal_code: to.postal_code || "",
         weight: totalWeightKg,
+        is_customs_declarable: from.country_code !== to.country_code,
       })
 
       const products = result?.products || []
-      const match = products.find(
-        (p: any) => p.productCode === (optionData as any).product_code
-      ) || products[0]
+      const productCode = (optionData as any).product_code
+      const match =
+        products.find((p: any) => p.productCode === productCode) || products[0]
 
-      const amount = match?.totalPrice?.[0]?.price || 0
+      const billc = (match?.totalPrice || []).find(
+        (p: any) => p.currencyType === "BILLC"
+      )
+      const amount = billc?.price ?? match?.totalPrice?.[0]?.price ?? 0
 
       return { calculated_amount: amount, is_calculated_price_tax_inclusive: true }
     } catch (e: any) {
@@ -95,48 +130,93 @@ class DHLExpressFulfillmentService extends AbstractFulfillmentProviderService {
   ): Promise<CreateFulfillmentResult> {
     const shippingAddr = (order as any)?.shipping_address || {}
     const fromLoc = (data as any).from_location || {}
-    const totalWeightKg = items.reduce(
-      (sum: number, i: any) => sum + (((i.variant?.weight || 500) * (i.quantity || 1)) / 1000),
-      0
-    ) || 0.5
+    const fromAddress = fromLoc.address || {}
+
+    const orderItems = ((order as any)?.items || []) as any[]
+    const orderItemById = new Map<string, any>()
+    for (const oi of orderItems) {
+      if (oi.id) orderItemById.set(oi.id, oi)
+    }
+
+    const totalWeightKg = this.weightInKgFromFulfillment(items, orderItemById)
+
+    const originCountry = fromAddress.country_code || "IN"
+    const destCountry = shippingAddr.country_code || ""
+    const isCustomsDeclarable = Boolean(originCountry) && Boolean(destCountry) && originCountry !== destCountry
+
+    const declaredValue = declaredValueForShipment({
+      items: items as any[],
+      orderItemById,
+      order: order as any,
+    })
+
+    const lineItems = items.map((item: any, i) => {
+      const orderItem = item?.line_item_id ? orderItemById.get(item.line_item_id) : undefined
+      const qty = Number(item?.quantity) || 1
+      const price = this.amountOf(
+        orderItem?.unit_price ?? orderItem?.price ?? 0
+      )
+      return {
+        description: orderItem?.title || item?.title || "Textile goods",
+        price,
+        quantity: qty,
+        hs_code: hsCodeFor(orderItem),
+        weight_kg: Math.max(MIN_WEIGHT_KG, ((orderItem?.variant?.weight || 500) * qty) / 1000),
+        manufacturer_country: originCountry,
+      }
+    })
 
     const result = await this.client.createShipment({
       shipper: {
         name: fromLoc.name || "Warehouse",
         address: {
-          line1: fromLoc.address?.address_1 || "",
-          city: fromLoc.address?.city || "",
-          postal_code: fromLoc.address?.postal_code || "",
-          country_code: fromLoc.address?.country_code || "DE",
+          line1: fromAddress.address_1 || fromAddress.address_line1 || "",
+          city: fromAddress.city || "",
+          postal_code: fromAddress.postal_code || "",
+          country_code: originCountry,
         },
         phone: fromLoc.phone || "",
+        email: fromLoc.email || "",
       },
       receiver: {
-        name: `${shippingAddr.first_name || ""} ${shippingAddr.last_name || ""}`.trim(),
+        name: `${shippingAddr.first_name || ""} ${shippingAddr.last_name || ""}`.trim() || "Customer",
         address: {
-          line1: shippingAddr.address_1 || "",
+          line1: [shippingAddr.address_1, shippingAddr.address_2].filter(Boolean).join(", "),
           city: shippingAddr.city || "",
           postal_code: shippingAddr.postal_code || "",
-          country_code: shippingAddr.country_code || "",
+          country_code: destCountry,
         },
         phone: shippingAddr.phone || "",
+        email: shippingAddr.email || "",
       },
       packages: [{ weight: totalWeightKg }],
       product_code: (data as any).product_code || "P",
-      description: items.map((i: any) => i.title || "Item").join(", "),
+      description: items.map((i: any) => i.title || "Item").join(", ") || "Textile goods",
+      is_customs_declarable: isCustomsDeclarable,
+      declared_value: declaredValue,
+      declared_value_currency: (order as any)?.currency_code || "EUR",
+      items: isCustomsDeclarable ? lineItems : undefined,
     })
 
     const trackingNumber = result?.shipmentTrackingNumber || ""
-    const labelData = result?.documents?.[0]?.content || ""
+    const labelContent = result?.documents?.find((d: any) => d.typeCode === "label")?.content || ""
 
     return {
       data: {
         tracking_number: trackingNumber,
         carrier: "dhl-express",
-        shipment_id: result?.shipmentTrackingNumber,
+        shipment_id: trackingNumber,
         ...result,
       },
-      labels: [{ tracking_number: trackingNumber, tracking_url: "https://www.dhl.com/en/express/tracking.html?AWB=" + trackingNumber, label_url: "" }],
+      labels: trackingNumber
+        ? [
+            {
+              tracking_number: trackingNumber,
+              tracking_url: "https://www.dhl.com/en/express/tracking.html?AWB=" + trackingNumber,
+              label_url: labelContent ? `data:application/pdf;base64,${labelContent}` : "",
+            },
+          ]
+        : [],
     }
   }
 
@@ -147,6 +227,47 @@ class DHLExpressFulfillmentService extends AbstractFulfillmentProviderService {
 
   async createReturnFulfillment(fulfillment: Record<string, any>): Promise<CreateFulfillmentResult> {
     return { data: { carrier: "dhl-express", type: "return" }, labels: [] }
+  }
+
+  /** Cart items carry variant weight (grams) → billable weight in kg. */
+  private weightInKg(items: any[]): number {
+    let grams = 0
+    for (const item of items) {
+      grams += (item.variant?.weight || 500) * (item.quantity || 1)
+    }
+    return Math.max(MIN_WEIGHT_KG, grams / 1000)
+  }
+
+  /** Fulfillment items lack variant data — resolve weight via order line items. */
+  private weightInKgFromFulfillment(items: any[], orderItemById: Map<string, any>): number {
+    let grams = 0
+    let any = false
+    for (const item of items) {
+      const qty = Number(item?.quantity) || 1
+      const orderItem = item?.line_item_id ? orderItemById.get(item.line_item_id) : undefined
+      const w = orderItem?.variant?.weight
+      if (w) {
+        any = true
+        grams += w * qty
+      } else {
+        grams += 500 * qty
+      }
+    }
+    if (!any && !items.length) grams = 500
+    return Math.max(MIN_WEIGHT_KG, grams / 1000)
+  }
+
+  private amountOf(value: unknown): number {
+    if (typeof value === "number") return Number.isFinite(value) ? value : 0
+    if (typeof value === "string") {
+      const n = Number(value)
+      return Number.isFinite(n) ? n : 0
+    }
+    if (value && typeof value === "object") {
+      const raw = (value as any).value ?? (value as any).numeric
+      if (raw !== undefined) return this.amountOf(raw)
+    }
+    return 0
   }
 }
 

--- a/apps/backend/src/modules/shipping-providers/dhl/service.ts
+++ b/apps/backend/src/modules/shipping-providers/dhl/service.ts
@@ -6,6 +6,7 @@ import {
   FulfillmentOrderDTO,
   FulfillmentDTO,
   CalculatedShippingOptionPrice,
+  CalculateShippingOptionPriceDTO,
   CreateShippingOptionDTO,
   Logger,
 } from "@medusajs/framework/types"
@@ -82,27 +83,45 @@ class DHLExpressFulfillmentService extends AbstractFulfillmentProviderService {
     return true
   }
 
+  /**
+   * Calculated price for a DHL shipping option (`price_type: "calculated"`).
+   *
+   * Follows the Medusa fulfillment-provider contract:
+   * - `optionData` is the shipping option's `data` — the fulfillment option
+   *   chosen in the admin, which carries `product_code` from
+   *   `getFulfillmentOptions`.
+   * - `data` is the shipping method's `data` — validated by
+   *   `validateFulfillmentData` (plus any custom frontend data).
+   * - `context` carries the cart: `shipping_address`, `items`, and
+   *   `from_location` (the stock location shipping the items).
+   *
+   * Price is resolved through DHL's `/rates` endpoint for the matched
+   * product, billing the customer-billed currency (`BILLC`). Failures are
+   * caught and fall back to a zero amount rather than throwing: a throw
+   * blocks the cart operation that triggered the calculation (adding the
+   * method or refreshing the cart) and stops checkout.
+   */
   async calculatePrice(
-    optionData: Record<string, unknown>,
-    data: Record<string, unknown>,
-    context: any
+    optionData: CalculateShippingOptionPriceDTO["optionData"],
+    data: CalculateShippingOptionPriceDTO["data"],
+    context: CalculateShippingOptionPriceDTO["context"]
   ): Promise<CalculatedShippingOptionPrice> {
-    try {
-      const from = (context as any).from_location?.address || {}
-      const to = (context as any).shipping_address || {}
-      const items = (context as any).items || []
+    const from = context.from_location?.address
+    const to = context.shipping_address
+    const items = context.items ?? []
 
-      const totalWeightKg = this.weightInKg(items)
+    try {
+      const totalWeightKg = this.weightInKg(items as any[])
 
       const result = await this.client.getRates({
-        origin_country: from.country_code || "IN",
-        origin_city: from.city || "",
-        origin_postal_code: from.postal_code || "",
-        dest_country: to.country_code || "",
-        dest_city: to.city || "",
-        dest_postal_code: to.postal_code || "",
+        origin_country: from?.country_code || "IN",
+        origin_city: from?.city || "",
+        origin_postal_code: from?.postal_code || "",
+        dest_country: to?.country_code || "",
+        dest_city: to?.city || "",
+        dest_postal_code: to?.postal_code || "",
         weight: totalWeightKg,
-        is_customs_declarable: from.country_code !== to.country_code,
+        is_customs_declarable: from?.country_code !== to?.country_code,
       })
 
       const products = result?.products || []


### PR DESCRIPTION
## What

Extends the in-tree `dhl-express` fulfillment provider from a thin rating-only client into a full international-shipping implementation (restores WIP that had been stashed).

### Client (`dhl/client.ts`)
- Refactored onto a shared `request<T>()` helper with `fetchImpl` injection, so the client is test-stubbable without patching `global.fetch`.
- New endpoints: `getProducts` (serviceability without prices), `addressValidate`, `landedCost` (duties + taxes + freight), `getShipment`, `createPickup`.
- `createShipment` gains **customs-declarable** support — declared value/currency, export `lineItems` (HS codes, manufacturer country, per-item weight), and an invoice.
- New request/party/line-item types (`DHLAddress`, `DHLParty`, `DHLLineItem`, `DHLRateParams`, `DHLLandedCostParams`, `DHLCreateShipmentParams`).

### Service (`dhl/service.ts`)
- Real **India-origin** products — Worldwide (`P`), 12:00 (`Y`), Easy (`8`) — dropping `H`/`N` which are not available ex-IN.
- Address-validation serviceability gate in `validateFulfillmentData`.
- Customs-declarable detection (`origin !== destination`) and declared-value + line-item mapping via the shared `declaredValueForShipment` helper.
- HS-code resolution with a textile fallback (`6304.92`), 0.5 kg minimum billing weight, and base64 PDF label handling.

### `.gitignore`
- Ignores `.ai-memory/` (local agent memory — already gitignored by convention).

## Notes / scope

- `cancelFulfillment` remains a no-op (DHL Express has no simple cancellation API; deletions are handled outside the carrier). `createReturnFulfillment` is likewise a stub.
- No new unit tests in this PR — the client/service are exercised via the existing provider flow. `declaredValueForShipment` is already covered by `delhivery/__tests__/declared-value.unit.spec.ts`.
- Typechecks clean (`tsc` reports no errors under `shipping-providers/dhl`).