### PR TITLE
fix(quotes,shipping): type a weight for an unweighable line, and never COD an international shipment

### DIFF
--- a/apps/backend/src/admin/routes/quotes/create/mint-quote-form.tsx
+++ b/apps/backend/src/admin/routes/quotes/create/mint-quote-form.tsx
@@ -119,6 +119,7 @@ export const MintQuoteForm = () => {
       discounts: {},
       overrides: {},
       design_by_variant: {},
+      weights: {},
       // Never on by default: a DDP promise nobody arranged clearance for tells
       // the buyer there is nothing to pay and then hands them a customs bill.
       duties_prepaid: false,
@@ -230,10 +231,16 @@ export const MintQuoteForm = () => {
         const override = data.overrides?.[variant_id]
         // #1486 — alongside the variant, never instead of it.
         const designId = data.design_by_variant?.[variant_id]
+        // Blank stays blank. See `weights` in schema.ts — a 0 here is a
+        // weightless consignment, not "unknown".
+        const weight = data.weights?.[variant_id]
         return {
           variant_id,
           quantity: qty as number,
           position: index,
+          ...(typeof weight === "number" && weight > 0
+            ? { unit_weight_grams: weight }
+            : {}),
           ...(designId ? { design_id: designId } : {}),
           ...(typeof discount === "number" && discount > 0
             ? { discount_percent: discount }
@@ -268,6 +275,10 @@ export const MintQuoteForm = () => {
         lines: lines.map((l) => ({
           variant_id: l.variant_id,
           quantity: l.quantity,
+          // Or the preflight refuses a basket the mint would have priced.
+          ...(l.unit_weight_grams
+            ? { unit_weight_grams: l.unit_weight_grams }
+            : {}),
         })),
         destination_country_code: data.destination_country_code,
         destination_postal_code: data.destination_postal_code || null,

--- a/apps/backend/src/admin/routes/quotes/create/schema.ts
+++ b/apps/backend/src/admin/routes/quotes/create/schema.ts
@@ -179,6 +179,21 @@ export const QuoteQuantitiesSchema = z.object({
    * than two that have to be kept in step.
    */
   design_by_variant: z.record(z.string(), z.string()).optional(),
+
+  /**
+   * variant_id → unit weight in grams, typed by the operator.
+   *
+   * 🔴 The only way to quote a line the catalogue cannot weigh. Freight is
+   * quoted against the summed basket weight and the estimate refuses the WHOLE
+   * basket on the first weightless line — so a design quoted before its garment
+   * was ever weighed could not be priced at all.
+   *
+   * Blank is not 0. A zero weight is a weightless consignment that every
+   * carrier rates at its floor, which is how a `0 INR` freight row once shipped
+   * bulk orders free (#1430) — so it is dropped from the payload rather than
+   * sent, and the estimate's own refusal stands.
+   */
+  weights: z.record(z.string(), z.number().nullish()).optional(),
 })
 
 /**
@@ -216,4 +231,4 @@ export const QuoteBuyerFields = [
   "ddp_fee_total",
   "duty_basis",
 ] as const
-export const QuoteProductFields = ["product_ids", "design_by_variant"] as const
+export const QuoteProductFields = ["product_ids", "design_by_variant", "weights"] as const

--- a/apps/backend/src/admin/routes/quotes/create/steps/quantities-step.tsx
+++ b/apps/backend/src/admin/routes/quotes/create/steps/quantities-step.tsx
@@ -26,13 +26,22 @@ const columnHelper = createDataGridHelper<Row, AdminQuoteCreateSchemaType>()
  * Mirrors the partner wizard's grid, including the two things that are easy to
  * drop when porting:
  *
- * 🔴 The weight column is not decoration. Freight is quoted against the summed
- * basket weight, and platform-wide most variants carry no weight at either
- * level — a line with no weight cannot be quoted at all, and the operator needs
- * to see that BEFORE minting rather than discover it in a quote that came back
- * short. Which LEVEL the weight came from matters too: a declared product
- * weight over-quotes a lighter variant, and at bulk quantities that can cross a
- * carrier slab.
+ * 🔴 The weight column is not decoration, and it is EDITABLE.
+ *
+ * Freight is quoted against the summed basket weight, and `buildShippingEstimate`
+ * refuses the whole basket on the first line it cannot weigh — 183 variants
+ * platform-wide carry no weight at either level, and a design quoted before its
+ * garment has ever been weighed has none by definition. Read-only, that made a
+ * design-led quote unpriceable with no way out of the wizard.
+ *
+ * So the operator types the weight they measured. It prices THIS quote and is
+ * never written back to the variant: a figure typed under time pressure must
+ * not become the catalogue's answer for every future basket.
+ *
+ * Which LEVEL the weight came from still matters and is still shown — a declared
+ * product weight over-quotes a lighter variant, and at bulk quantities that can
+ * cross a carrier slab. The catalogue figure is the PLACEHOLDER, so a typed
+ * number and an inherited one stay distinguishable.
  *
  * 🔴 The unit-price column is in the PARTNER STORE's currency, not the quote's,
  * and the header says so. A number typed against a USD quote is otherwise read
@@ -76,7 +85,14 @@ export const QuantitiesStep = ({ form }: Props) => {
       }),
       columnHelper.column({
         id: "weight",
-        header: "Unit weight",
+        name: "Unit weight (g)",
+        header: "Unit weight (g)",
+        field: (context: any) => {
+          const entity = context.row.original
+          if (isProductRow(entity)) return null
+          return `weights.${entity.id}` as const
+        },
+        type: "number",
         cell: (context: any) => {
           const entity = context.row.original
           if (isProductRow(entity)) {
@@ -90,21 +106,32 @@ export const QuantitiesStep = ({ form }: Props) => {
           const resolved = variantWeight ?? productWeight ?? null
           const source = variantWeight != null ? "variant" : "product"
 
+          /**
+           * 🔴 Editable, and blank does NOT mean zero.
+           *
+           * The catalogue figure is shown as the placeholder rather than
+           * prefilled: prefilling would send a catalogue weight as though an
+           * operator had vouched for it, and `quoted_weight_source` on the
+           * frozen line would then read `manual` for a number nobody typed.
+           * Leaving it blank keeps "the catalogue answered" and "a human
+           * answered" distinguishable on the document.
+           *
+           * A line with no catalogue weight says so in the placeholder. It used
+           * to read "No weight — cannot quote", which was true: the estimate
+           * refuses the WHOLE basket on the first line it cannot weigh, so a
+           * design quoted before its garment was ever weighed could not be
+           * priced at all. Now it can be, by typing the weight.
+           */
           return (
-            <DataGridReadonlyCell context={context} color="normal">
-              {resolved == null ? (
-                <span className="text-ui-fg-error truncate">
-                  No weight — cannot quote
-                </span>
-              ) : (
-                <span className="truncate">
-                  {resolved} g
-                  {source === "product" ? (
-                    <span className="text-ui-fg-subtle"> (product)</span>
-                  ) : null}
-                </span>
-              )}
-            </DataGridReadonlyCell>
+            <DataGridNumberCell
+              context={context}
+              min={1}
+              placeholder={
+                resolved == null
+                  ? "Enter to quote"
+                  : `${resolved}${source === "product" ? " (product)" : ""}`
+              }
+            />
           )
         },
       }),

--- a/apps/backend/src/api/partners/quotes/validators.ts
+++ b/apps/backend/src/api/partners/quotes/validators.ts
@@ -41,6 +41,27 @@ const QuoteLine = z
     discount_percent: z.number().min(0).max(100).nullish(),
     /** A flat unit price, in the partner store's default currency. */
     override_unit_amount: z.number().positive().nullish(),
+
+    /**
+     * The weight of ONE unit of this line, in grams, typed by the operator.
+     *
+     * 🔴 Exists because refusing was the only other answer. Freight is quoted
+     * against the summed basket weight and `buildShippingEstimate` refuses the
+     * WHOLE basket on the first line it cannot weigh — 183 variants platform-
+     * wide carry no weight at either level, and a design quoted before its
+     * garment has ever been weighed has none by definition. Without this, a
+     * design-led quote simply cannot be priced.
+     *
+     * 🔑 Positive, never 0. A zero here is a weightless consignment, which
+     * every carrier rates at its floor — the same shape as the `0 INR` freight
+     * row that shipped bulk orders free (#1430). Absent means "no figure",
+     * which the estimate already knows how to refuse loudly.
+     *
+     * Prices THIS quote and is never written back to the variant: a figure
+     * typed under time pressure must not become the catalogue's answer for
+     * every future basket.
+     */
+    unit_weight_grams: z.number().positive().max(1_000_000).nullish(),
   })
   .refine((l) => Boolean(l.variant_id) || Boolean(l.design_id), {
     message: "A line must name either a variant_id or a design_id.",

--- a/apps/backend/src/lib/__tests__/shipping-estimate.unit.spec.ts
+++ b/apps/backend/src/lib/__tests__/shipping-estimate.unit.spec.ts
@@ -33,6 +33,47 @@ describe("resolveUnitWeight", () => {
 
   it("refuses when neither level has a weight", () => {
     expect(resolveUnitWeight({ weight: null, product: { weight: null } })).toBeNull()
+  })
+
+  /**
+   * The operator's own figure, for a line the catalogue cannot weigh.
+   *
+   * 🔴 Freight is quoted against the summed basket weight and the estimate
+   * refuses the WHOLE basket on the first weightless line — so a design quoted
+   * before its garment was ever weighed could not be priced at all. Typing the
+   * measured weight is the only way through.
+   */
+  it("prefers a manual weight over both catalogue levels, and says a human gave it", () => {
+    expect(
+      resolveUnitWeight({ weight: 105, product: { weight: 115 } }, 250)
+    ).toEqual({ weight_grams: 250, weight_source: "manual" })
+  })
+
+  it("rescues a line the catalogue cannot weigh at all", () => {
+    expect(
+      resolveUnitWeight({ weight: null, product: { weight: null } }, 320)
+    ).toEqual({ weight_grams: 320, weight_source: "manual" })
+  })
+
+  /**
+   * 🔑 A blank cell is not a weightless parcel. `Number(undefined)` is NaN and
+   * `Number("")` is 0 — both must fall through to the catalogue rather than be
+   * taken as an answer, or every untouched row would quote at a carrier's floor
+   * the way the `0 INR` freight row shipped bulk orders free (#1430).
+   */
+  it.each([undefined, null, "", 0, -5, "abc"])(
+    "ignores %p and falls back to the catalogue",
+    (manual) => {
+      expect(
+        resolveUnitWeight({ weight: 105, product: { weight: 115 } }, manual)
+      ).toEqual({ weight_grams: 105, weight_source: "variant" })
+    }
+  )
+
+  it("still refuses when neither the catalogue nor the operator has a weight", () => {
+    expect(
+      resolveUnitWeight({ weight: null, product: { weight: null } }, 0)
+    ).toBeNull()
     expect(resolveUnitWeight({})).toBeNull()
   })
 

--- a/apps/backend/src/lib/shipping-estimate.ts
+++ b/apps/backend/src/lib/shipping-estimate.ts
@@ -58,6 +58,20 @@ import {
 export type ShippingEstimateLineInput = {
   variant_id: string
   quantity: number
+  /**
+   * A weight typed by the operator, in grams, for this line only.
+   *
+   * 🔴 Wins over the variant's and the product's, and it exists because
+   * refusing was the only other answer. 183 variants platform-wide carry no
+   * weight at either level, and a design quoted before its garment has ever
+   * been weighed has none by definition — so the operator either types the
+   * weight they measured or cannot quote the lane at all.
+   *
+   * It is NOT a default and never persists to the variant: it prices this one
+   * quote. Writing it back would let a guess made under time pressure become
+   * the catalogue's answer for every future basket.
+   */
+  unit_weight_grams?: number | null
 }
 
 export type ShippingEstimateInput = {
@@ -142,7 +156,7 @@ export type ShippingEstimateLine = {
   quantity: number
   unit_weight_grams: number
   /** Which level the unit weight came from. See the header. */
-  weight_source: "variant" | "product"
+  weight_source: "variant" | "product" | "manual"
   line_weight_grams: number
 }
 
@@ -198,12 +212,28 @@ export type ShippingEstimate = {
  * Split out so the rule that decides a buyer's freight number is testable
  * without a container, a carrier or a database.
  */
-export function resolveUnitWeight(variant: {
-  id?: string
-  title?: string | null
-  weight?: unknown
-  product?: { weight?: unknown } | null
-}): { weight_grams: number; weight_source: "variant" | "product" } | null {
+export function resolveUnitWeight(
+  variant: {
+    id?: string
+    title?: string | null
+    weight?: unknown
+    product?: { weight?: unknown } | null
+  },
+  /**
+   * The operator's own figure for this line, if they gave one. Checked FIRST:
+   * someone who has weighed the sample knows better than a catalogue field, and
+   * on a design-led quote the catalogue has no answer at all.
+   */
+  manualWeightGrams?: unknown
+): {
+  weight_grams: number
+  weight_source: "variant" | "product" | "manual"
+} | null {
+  const manual = Number(manualWeightGrams)
+  if (manual && !Number.isNaN(manual) && manual > 0) {
+    return { weight_grams: manual, weight_source: "manual" }
+  }
+
   const variantWeight = Number(variant?.weight)
   if (variantWeight && !Number.isNaN(variantWeight) && variantWeight > 0) {
     return { weight_grams: variantWeight, weight_source: "variant" }
@@ -459,14 +489,14 @@ export async function buildShippingEstimate(
       )
     }
 
-    const resolved = resolveUnitWeight(variant)
+    const resolved = resolveUnitWeight(variant, line.unit_weight_grams)
     if (!resolved) {
       // Deliberately a refusal, not a fallback, and it fails the WHOLE basket:
       // a landed total missing one line's freight is a wrong number wearing a
       // confident label. See the header.
       throw new MedusaError(
         MedusaError.Types.INVALID_DATA,
-        `Variant "${variant.title || variant.id}" has no shipping weight, and neither does its product, so freight cannot be quoted for it. Set a weight on the variant first.`
+        `Variant "${variant.title || variant.id}" has no shipping weight, and neither does its product, so freight cannot be quoted for it. Set a weight on the variant, or enter one for this quote.`
       )
     }
 

--- a/apps/backend/src/modules/partner-quote/lib/build-quote-view.ts
+++ b/apps/backend/src/modules/partner-quote/lib/build-quote-view.ts
@@ -136,6 +136,12 @@ export type BuildQuoteViewLine = {
   quantity: number
   position?: number
   note?: string | null
+  /**
+   * The operator's own unit weight in grams, for a line the catalogue cannot
+   * weigh. Feeds the freight estimate for THIS quote and is never written back
+   * to the variant.
+   */
+  unit_weight_grams?: number | null
 }
 
 export type BuildQuoteViewInput = {
@@ -309,7 +315,7 @@ export type QuoteViewLine = {
   quoted_subtotal: number | null
   unit_weight_grams: number | null
   /** Per line, because a basket can mix variant- and product-weighted items. */
-  weight_source: "variant" | "product" | null
+  weight_source: "variant" | "product" | "manual" | null
 }
 
 export type QuoteView = {
@@ -1003,7 +1009,7 @@ export async function buildQuoteView(
   let importEstimate: QuoteImportEstimate | null = null
   let weightByVariant = new Map<
     string,
-    { unit_weight_grams: number; weight_source: "variant" | "product" }
+    { unit_weight_grams: number; weight_source: "variant" | "product" | "manual" }
   >()
 
   /**
@@ -1112,6 +1118,7 @@ export async function buildQuoteView(
         lines: effectiveLines.map((l) => ({
           variant_id: l.variant_id,
           quantity: l.quantity,
+          unit_weight_grams: l.unit_weight_grams ?? null,
         })),
         destination_postal_code: String(input.destination_postal_code ?? ""),
         country_code: input.destination_country_code,

--- a/apps/backend/src/modules/partner-quote/lib/quote-readiness.ts
+++ b/apps/backend/src/modules/partner-quote/lib/quote-readiness.ts
@@ -170,7 +170,16 @@ export type QuoteReadinessResult = {
 }
 
 export type QuoteReadinessInput = {
-  lines: Array<{ variant_id: string; quantity: number }>
+  /**
+   * `unit_weight_grams` is the operator's own figure for a line the catalogue
+   * cannot weigh — a design-led quote, or one of the 183 variants carrying no
+   * weight at either level. Priced with, never persisted.
+   */
+  lines: Array<{
+    variant_id: string
+    quantity: number
+    unit_weight_grams?: number | null
+  }>
   store: {
     id?: string | null
     default_location_id?: string | null
@@ -362,6 +371,7 @@ export async function assessQuoteReadiness(
         lines: lines.map((l) => ({
           variant_id: l.variant_id,
           quantity: l.quantity,
+          unit_weight_grams: l.unit_weight_grams ?? null,
         })),
         destination_postal_code: String(input.destination_postal_code ?? ""),
         country_code: input.destination_country_code,

--- a/apps/backend/src/modules/shipping-providers/__tests__/carrier-capabilities.unit.spec.ts
+++ b/apps/backend/src/modules/shipping-providers/__tests__/carrier-capabilities.unit.spec.ts
@@ -37,10 +37,27 @@ describe("carrier capabilities", () => {
     expect(international.rating.map((c) => c.id)).toEqual(["shiprocket"])
   })
 
-  it("surfaces DTDC as un-integrated rather than hiding it", () => {
+  /**
+   * ⚠️ Was "surfaces DTDC as un-integrated rather than hiding it", asserting
+   * `integrated: false`. #1583 shipped the DTDC provider, so that premise is
+   * simply obsolete — the assertion went red on `main` when it merged.
+   *
+   * The distinction it exists to protect still matters and is what is asserted
+   * now: DTDC BOOKS but cannot RATE. A carrier that ships without quoting must
+   * never reach a rating list, or it wins a lane by returning no price at all.
+   */
+  it("has DTDC integrated for shipping but absent from every rating lane", () => {
     const dtdc = CARRIER_CAPABILITIES.find((c) => c.id === "dtdc")!
-    expect(dtdc.integrated).toBe(false)
-    expect(groupCarriersByLane().unavailable.map((c) => c.id)).toContain("dtdc")
+    expect(dtdc.integrated).toBe(true)
+    expect(dtdc.domestic.can_ship).toBe(true)
+    expect(dtdc.domestic.can_rate).toBe(false)
+    expect(dtdc.international.can_ship).toBe(false)
+
+    const grouped = groupCarriersByLane()
+    expect(grouped.unavailable.map((c) => c.id)).not.toContain("dtdc")
+    expect(grouped.domestic.shipping.map((c) => c.id)).toContain("dtdc")
+    expect(grouped.domestic.rating.map((c) => c.id)).not.toContain("dtdc")
+    expect(grouped.international.rating.map((c) => c.id)).not.toContain("dtdc")
   })
 })
 

--- a/apps/backend/src/modules/shipping-providers/shiprocket/__tests__/payment-mode.unit.spec.ts
+++ b/apps/backend/src/modules/shipping-providers/shiprocket/__tests__/payment-mode.unit.spec.ts
@@ -1,0 +1,126 @@
+import { resolveShipmentPaymentMode } from "../payment-mode"
+
+/**
+ * The rule that decides whether a parcel can be handed to Shiprocket at all.
+ *
+ * 🔴 The defect these cover: `payment_mode` came from `payment_status` alone,
+ * so anything that was not `captured`/`paid` became COD — including on a
+ * cross-border lane, where `buildInternationalCreateBody` THROWS on that value.
+ * The fallback never produced a COD shipment; it produced no shipment, and
+ * creating the fulfilment failed outright.
+ */
+describe("resolveShipmentPaymentMode", () => {
+  describe("international — there is no COD to fall back to", () => {
+    /**
+     * Every status that is not settled. Each one used to become `cod` and take
+     * the whole fulfilment down with it; `awaiting` and `authorized` are the
+     * ordinary states of a card that has not been captured yet.
+     */
+    const UNSETTLED = [
+      "awaiting",
+      "authorized",
+      "partially_captured",
+      "not_paid",
+      "requires_action",
+      undefined,
+      null,
+      "",
+    ]
+
+    it.each(UNSETTLED)(
+      "ships PREPAID with payment_status=%p rather than failing to ship",
+      (status) => {
+        const result = resolveShipmentPaymentMode({
+          payment_status: status,
+          destination_country_code: "US",
+          sub_total: 4500,
+        })
+
+        expect(result.payment_mode).toBe("prepaid")
+        // Never 0 — an amount of zero is still an amount, and COD is not on
+        // offer here at any value.
+        expect(result.cod_amount).toBeUndefined()
+        expect(result.international).toBe(true)
+      }
+    )
+
+    it("flags an unsettled international shipment so it is visible, not silent", () => {
+      const result = resolveShipmentPaymentMode({
+        payment_status: "awaiting",
+        destination_country_code: "GB",
+        sub_total: 4500,
+      })
+
+      expect(result.warn_uncaptured).toBe(true)
+    })
+
+    it("does not flag one whose payment has actually settled", () => {
+      const result = resolveShipmentPaymentMode({
+        payment_status: "captured",
+        destination_country_code: "GB",
+        sub_total: 4500,
+      })
+
+      expect(result.payment_mode).toBe("prepaid")
+      expect(result.warn_uncaptured).toBe(false)
+    })
+
+    it("is case- and whitespace-insensitive about the country", () => {
+      const result = resolveShipmentPaymentMode({
+        payment_status: "awaiting",
+        destination_country_code: "  us  ",
+        sub_total: 100,
+      })
+
+      expect(result.international).toBe(true)
+      expect(result.payment_mode).toBe("prepaid")
+    })
+  })
+
+  describe("domestic — COD is a real choice and stays available", () => {
+    it("still ships COD for the unsettled domestic order, collecting the subtotal", () => {
+      const result = resolveShipmentPaymentMode({
+        payment_status: "awaiting",
+        destination_country_code: "IN",
+        sub_total: 4500,
+      })
+
+      expect(result.payment_mode).toBe("cod")
+      expect(result.cod_amount).toBe(4500)
+      expect(result.international).toBe(false)
+      // Domestic COD is the intended flow, so there is nothing to warn about.
+      expect(result.warn_uncaptured).toBe(false)
+    })
+
+    it.each(["captured", "paid"])(
+      "ships prepaid once the money is in (%s)",
+      (status) => {
+        const result = resolveShipmentPaymentMode({
+          payment_status: status,
+          destination_country_code: "IN",
+          sub_total: 4500,
+        })
+
+        expect(result.payment_mode).toBe("prepaid")
+        expect(result.cod_amount).toBeUndefined()
+      }
+    )
+
+    /**
+     * 🔑 Must match `deriveShiprocketRateContext`, where an absent country is
+     * also domestic. One derivation saying "international" while the other says
+     * "domestic" is how a parcel gets quoted on one product and shipped on
+     * another.
+     */
+    it("treats an absent country as domestic, agreeing with the rate context", () => {
+      const result = resolveShipmentPaymentMode({
+        payment_status: "awaiting",
+        destination_country_code: "",
+        sub_total: 900,
+      })
+
+      expect(result.international).toBe(false)
+      expect(result.payment_mode).toBe("cod")
+    })
+  })
+})

--- a/apps/backend/src/modules/shipping-providers/shiprocket/payment-mode.ts
+++ b/apps/backend/src/modules/shipping-providers/shiprocket/payment-mode.ts
@@ -1,0 +1,91 @@
+import { isInternationalDestination } from "../destination"
+
+/**
+ * Which payment mode a Shiprocket shipment is created with — PURE, so the rule
+ * that decides whether a parcel can be handed over at all is testable without a
+ * container, an order or a live Shiprocket account.
+ *
+ * Split out for the same reason `deriveShiprocketRateContext` was: this was
+ * derived inline in `createFulfillment` and got something wrong that nothing
+ * could see.
+ *
+ * ## The defect
+ *
+ * The mode came from `payment_status` alone — `captured`/`paid` meant prepaid,
+ * and EVERYTHING else meant COD. On a domestic lane that is a real choice.
+ *
+ * On a cross-border lane it is not a choice at all. Shiprocket has no
+ * international COD product, and `buildInternationalCreateBody` throws
+ * `"Shiprocket does not support COD for international shipments"` the moment it
+ * sees that value. So the fallback never produced a COD shipment — it produced
+ * NO shipment. Creating the fulfilment failed outright for every international
+ * order whose payment had not settled to `captured` at that instant, which
+ * includes the ordinary authorised-but-uncaptured card.
+ *
+ * ## Why forcing prepaid is not papering over an unpaid order
+ *
+ * Prepaid is the only mode the lane supports. The alternatives were a prepaid
+ * shipment or no shipment — never a COD one. Nothing here touches the payment
+ * status, which still says exactly what it said; `warn_uncaptured` exists so an
+ * unsettled international shipment is visible rather than silent.
+ */
+export type ShipmentPaymentMode = {
+  payment_mode: "prepaid" | "cod"
+  /** The amount to collect. Undefined on prepaid — never 0, which is an amount. */
+  cod_amount?: number
+  /**
+   * International, and the payment has NOT settled. The shipment is still
+   * created — prepaid is the only option — but the caller should say so.
+   */
+  warn_uncaptured: boolean
+  international: boolean
+}
+
+/** The statuses that mean the money is actually in. */
+const SETTLED = new Set(["captured", "paid"])
+
+export function resolveShipmentPaymentMode(input: {
+  payment_status?: unknown
+  destination_country_code?: unknown
+  /** What COD would collect. Ignored on a prepaid shipment. */
+  sub_total: number
+}): ShipmentPaymentMode {
+  const destinationCountry = String(input.destination_country_code || "")
+    .trim()
+    .toUpperCase()
+
+  const international = isInternationalDestination(destinationCountry)
+  const settled = SETTLED.has(String(input.payment_status || ""))
+
+  /**
+   * 🔑 An ABSENT country counts as domestic, matching
+   * `deriveShiprocketRateContext` — `isInternationalDestination("")` is false.
+   * The two derivations must agree: one saying "international" while the other
+   * says "domestic" is how a parcel gets quoted on one product and shipped on
+   * another.
+   */
+  if (international) {
+    return {
+      payment_mode: "prepaid",
+      cod_amount: undefined,
+      warn_uncaptured: !settled,
+      international: true,
+    }
+  }
+
+  if (settled) {
+    return {
+      payment_mode: "prepaid",
+      cod_amount: undefined,
+      warn_uncaptured: false,
+      international: false,
+    }
+  }
+
+  return {
+    payment_mode: "cod",
+    cod_amount: input.sub_total,
+    warn_uncaptured: false,
+    international: false,
+  }
+}

--- a/apps/backend/src/modules/shipping-providers/shiprocket/service.ts
+++ b/apps/backend/src/modules/shipping-providers/shiprocket/service.ts
@@ -12,6 +12,7 @@ import {
 import { ShiprocketClient, ShiprocketOptions } from "./client"
 import { CreateShipmentInput, ShipmentItem } from "../provider-interface"
 import { deriveShiprocketRateContext } from "./rate-context"
+import { resolveShipmentPaymentMode } from "./payment-mode"
 import { FlatFallbackConfig, resolveFlatFallbackAmount } from "./flat-fallback"
 
 type InjectedDeps = { logger: Logger }
@@ -245,13 +246,30 @@ class ShiprocketFulfillmentService extends AbstractFulfillmentProviderService {
     }
 
     const paymentStatus = (order as any)?.payment_status
-    const isPrepaid = paymentStatus === "captured" || paymentStatus === "paid"
     const subTotal = shipItems.reduce((s, i) => s + i.unit_price * i.quantity, 0)
+
+    // The rule lives in `payment-mode.ts`, pure and unit-tested — an
+    // international lane has no COD product, so deriving this inline is how it
+    // silently became "no shipment at all". See that file's header.
+    const paymentMode = resolveShipmentPaymentMode({
+      payment_status: paymentStatus,
+      destination_country_code: shippingAddress?.country_code,
+      sub_total: subTotal,
+    })
+
+    if (paymentMode.warn_uncaptured) {
+      this.logger.warn(
+        `[shiprocket] order ${(order as any)?.id} ships to ` +
+          `${String(shippingAddress?.country_code || "").toUpperCase()} with ` +
+          `payment_status="${paymentStatus}". Sent as PREPAID because Shiprocket has ` +
+          `no international COD — the payment is not confirmed captured.`
+      )
+    }
 
     const input: CreateShipmentInput = {
       reference_id: (order as any)?.id || fulfillment.id || "",
-      payment_mode: isPrepaid ? "prepaid" : "cod",
-      cod_amount: isPrepaid ? undefined : subTotal,
+      payment_mode: paymentMode.payment_mode,
+      cod_amount: paymentMode.cod_amount,
       pickup_location_name:
         fromLocation.metadata?.shiprocket_pickup_location ||
         fromLocation.name ||

--- a/apps/backend/src/workflows/partner-quote/mint-quote.ts
+++ b/apps/backend/src/workflows/partner-quote/mint-quote.ts
@@ -67,6 +67,17 @@ export type MintQuoteInput = {
     discount_percent?: number | null
     /** A flat unit price, in the PARTNER STORE's default currency. */
     override_unit_amount?: number | null
+    /**
+     * The operator's own unit weight in grams, for a line the catalogue cannot
+     * weigh — a design quoted before its garment was ever weighed, or one of
+     * the 183 variants with no weight at either level.
+     *
+     * Prices this quote's freight only. It is frozen onto the line as
+     * `quoted_unit_weight_grams` with `quoted_weight_source: "manual"`, so the
+     * document records that a human supplied the figure, and it is never
+     * written back to the variant.
+     */
+    unit_weight_grams?: number | null
   }>
   destination_country_code: string
   destination_postal_code?: string | null


### PR DESCRIPTION
Two fixes, each for a case that was simply impossible to get through.

## 1. A design-led quote could not be priced at all

Freight is quoted against the summed basket weight, and `buildShippingEstimate` **refuses the whole basket** on the first line it cannot weigh. 183 variants platform-wide carry no weight at either level, and a design quoted before its garment has ever been weighed has none by definition. The wizard showed `No weight — cannot quote` in a **read-only** cell — an accurate message with no way out of it.

The weight column is now editable.

| | |
|---|---|
| precedence | typed → variant → product |
| carried as | `unit_weight_grams` on the line, through readiness **and** the mint |
| frozen as | `quoted_unit_weight_grams` + `quoted_weight_source: "manual"` |
| written back to the variant | **never** |

Those last two matter. The document records that a *human* supplied the figure, and a weight typed under time pressure does not become the catalogue's answer for every future basket.

The catalogue weight is the **placeholder**, not a prefill — prefilling would send an inherited number as though someone had vouched for it, and `quoted_weight_source` would then read `manual` for a figure nobody typed.

Blank is not zero. A `0` is a weightless consignment that every carrier rates at its floor — the same shape as the `0 INR` freight row that shipped bulk orders free (#1430) — so a blank cell is dropped from the payload and the estimate's own refusal stands.

## 2. 🔴 An international order fell back to COD, which is not a fallback

`createFulfillment` derived `payment_mode` from `payment_status` alone: `captured`/`paid` → prepaid, **everything else** → COD. Domestically that is a real choice. Cross-border it is not a choice at all — Shiprocket has no international COD product, and `buildInternationalCreateBody` **throws** `"Shiprocket does not support COD for international shipments"` on that value.

**So the fallback never produced a COD shipment. It produced no shipment.** Creating the fulfilment failed outright for every international order whose payment had not settled to `captured` at that instant — including the ordinary authorised-but-uncaptured card.

International is now always prepaid. That is not papering over an unpaid order: prepaid is the only mode the lane supports, so the alternatives were a prepaid shipment or no shipment, never a COD one. The payment status is untouched and still says what it says; an unsettled international shipment is now logged rather than silent. **Domestic COD is unchanged.**

The rule is extracted to a pure `payment-mode.ts` and unit-tested — the same reason `deriveShiprocketRateContext` was extracted: derived inline, it was wrong in a way nothing could see. An absent country counts as domestic in both, so the two derivations cannot disagree about which product a parcel is quoted and shipped on.

## 3. A red test on `main`

`carrier-capabilities` asserted DTDC was un-integrated. #1583 shipped the DTDC provider, so that assertion went red when it merged — unrelated to this work, fixed here rather than left.

Updated to the current truth *and* to the distinction actually worth protecting: DTDC **books but cannot rate**, so it must appear in the shipping lane and in no rating lane. A carrier that ships without quoting would otherwise win a lane by returning no price at all.

## Verification

| | |
|---|---|
| unit (quote/shipping/shiprocket/carrier) | **945 passed, 70 suites** |
| new `payment-mode` cases | 8 |
| new manual-weight cases | 4 |
| `check:prod-build` | ✓ |

The payment-mode cases cover every unsettled status (`awaiting`, `authorized`, `partially_captured`, `not_paid`, `requires_action`, absent) shipping prepaid internationally while domestic COD still collects the subtotal.

⚠️ `packages/medusa-plugin-dtdc-shipping` (from #1583) was never installed, so the shipping unit tests could not load at all locally until a `pnpm install`. No lockfile change — worth knowing if CI or another machine hits the same.

No migrations.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01TLt1f38xqR8k2myCVxP8e4
