### PR TITLE
fix(crm): an in-memory store per worker — the file lock made two specs mutually exclusive (#1648)

### DIFF
--- a/apps/backend/integration-tests/global-setup.js
+++ b/apps/backend/integration-tests/global-setup.js
@@ -2,22 +2,14 @@
 console.log('Setting up shared test environment...');
 
 /**
- * Where the embedded CRM store lives for this run (#1551/#1552).
- *
- * ⚠️ Chosen HERE rather than in setup.js because globalSetup and globalTeardown
- * share a process, and setup.js runs in each worker. A path computed in the
- * worker is invisible to teardown, so the directory was never cleaned up.
+ * The embedded CRM store is IN MEMORY, one per worker process (#1648) — set in
+ * setup.js, which runs in each worker. Nothing is written to disk, so there is
+ * no path for globalTeardown to clean up any more.
  */
-const crmStore = require('node:path').join(
-  require('node:os').tmpdir(),
-  `jyt-crm-store-${process.pid}`
-);
-process.env.CRM_HYPERBEE_STORE = process.env.CRM_HYPERBEE_STORE || crmStore;
+process.env.CRM_HYPERBEE_STORE = process.env.CRM_HYPERBEE_STORE || ":memory:";
 
 module.exports = async () => {
   // This runs once before all tests
   // We can initialize any global resources here if needed
   console.log('Global setup complete');
 };
-
-module.exports.crmStore = crmStore;

--- a/apps/backend/integration-tests/global-teardown.js
+++ b/apps/backend/integration-tests/global-teardown.js
@@ -8,9 +8,9 @@ module.exports = async () => {
   // Clean up any global resources
   resetSharedTestEnvironment();
 
-  // The embedded CRM store is a DIRECTORY under the temp dir, one per run
-  // (setup.js keys it on the pid). Postgres is reset by the runner; this is not,
-  // so without this it accumulates a corestore per local run forever.
+  // The CRM store is in memory now (#1648) and writes nothing. This sweep stays
+  // only to clear the per-run directories older checkouts left behind; it is a
+  // no-op on a machine that has only ever run the in-memory store.
   const os = require('node:os');
   const path = require('node:path');
   for (const name of require('node:fs').readdirSync(os.tmpdir())) {

--- a/apps/backend/integration-tests/setup.js
+++ b/apps/backend/integration-tests/setup.js
@@ -19,17 +19,20 @@ process.env.WHATSAPP_WEBHOOK_VERIFY_TOKEN =
 // this cannot break boot: the worst case is the module stays offline and the
 // CRM specs fail loudly, which is the correct outcome rather than a silent skip.
 //
-// ⚠️ The store is a FILE, not Postgres. The runner restores a DB snapshot before
-// every test; it does NOT reset this. CRM rows therefore ACCUMULATE across tests
-// in a run — a CRM spec must assert on rows it created, never on a total count.
+// ⚠️ The store is IN MEMORY, one per worker process (#1648). It is not Postgres:
+// the runner restores a DB snapshot before every test and does NOT reset this, so
+// CRM rows still ACCUMULATE across the tests of one worker — a CRM spec must
+// assert on rows it created, never on a total count. They no longer accumulate
+// ACROSS workers, and nothing is written to disk.
 //
-// The store PATH is chosen in global-setup.js, not here: globalSetup and
-// globalTeardown share a process while this file runs in each worker, so a path
-// computed here would be invisible to the cleanup.
+// It used to be a directory, shared by every worker. The store is single-writer
+// and its lock is a file, so the moment a second CRM spec landed in a second
+// worker the loader failed with "File descriptor could not be locked" and every
+// /admin/crm/* route in that worker answered 500. corestore@7.11 has no RAM
+// storage (hypercore-storage is RocksDB-only), so ":memory:" is handled above
+// Corestore, at the BeeLike boundary — see src/modules/crm/dal/memory-bee.ts.
 process.env.CRM_HYPERBEE = process.env.CRM_HYPERBEE || "true"
-process.env.CRM_HYPERBEE_STORE =
-  process.env.CRM_HYPERBEE_STORE ||
-  require("node:path").join(require("node:os").tmpdir(), "jyt-crm-store-worker")
+process.env.CRM_HYPERBEE_STORE = process.env.CRM_HYPERBEE_STORE || ":memory:"
 
 // Opt-in HTTP error tracing: `DEBUG_HTTP_ERRORS=1 pnpm test:integration:http:shared ...`
 //

--- a/apps/backend/src/modules/crm/dal/memory-bee.ts
+++ b/apps/backend/src/modules/crm/dal/memory-bee.ts
@@ -1,0 +1,77 @@
+import type { BeeLike } from "@jytextiles/mikrohyperbee";
+
+/**
+ * An in-memory `BeeLike` — the whole surface the CRM repositories use, backed by
+ * a sorted Map instead of a Hyperbee (#1648).
+ *
+ * WHY THIS EXISTS: the embedded store is single-writer and the lock is a FILE
+ * (`hypercore-storage` opens RocksDB with a `CORESTORE` device file). Every Jest
+ * worker shared one store path, so a second CRM spec landing in a second worker
+ * failed the whole module with "File descriptor could not be locked" and every
+ * `/admin/crm/*` route answered 500.
+ *
+ * ⚠️ There is NO RAM storage on this stack — corestore@7.11 → hypercore-storage@3
+ * is RocksDB-only, so the memory swap cannot live inside Corestore. It lives
+ * here, above it, where the DAL boundary is already a plain interface.
+ *
+ * Values are stored VERBATIM. Real Hyperbee subs are created with a valueEncoding
+ * (`binary` for records, `utf-8` for indexes), so a put returns the same type it
+ * was given; keeping values untouched reproduces that without encoding at all.
+ *
+ * Not durable, not for production — the loader only reaches this when the store
+ * is explicitly `:memory:`.
+ */
+class MemoryBee implements BeeLike {
+  constructor(
+    private readonly map: Map<string, any> = new Map(),
+    private readonly prefix: string = ""
+  ) {}
+
+  sub(name: string): BeeLike {
+    // Prefix, not a nested container: ranges are compared with the same prefix
+    // applied on both ends, so it cancels and ordering is preserved.
+    return new MemoryBee(this.map, `${this.prefix}${name}\x00`);
+  }
+
+  async put(key: string, value: any): Promise<void> {
+    this.map.set(this.prefix + key, value);
+  }
+
+  async get(key: string): Promise<{ key: string; value: any } | null> {
+    const k = this.prefix + key;
+    if (!this.map.has(k)) return null;
+    return { key, value: this.map.get(k) };
+  }
+
+  async del(key: string): Promise<void> {
+    this.map.delete(this.prefix + key);
+  }
+
+  async *createReadStream(range?: {
+    gte?: string;
+    lt?: string;
+    gt?: string;
+    lte?: string;
+  }): AsyncIterable<{ key: string; value: any }> {
+    const { gte, lt, gt, lte } = range || {};
+    const keys = [...this.map.keys()]
+      .filter((k) => k.startsWith(this.prefix))
+      .sort();
+    // Snapshot the key list first: callers delete while iterating.
+    for (const full of keys) {
+      const key = full.slice(this.prefix.length);
+      if (gte !== undefined && key < gte) continue;
+      if (gt !== undefined && key <= gt) continue;
+      if (lte !== undefined && key > lte) continue;
+      if (lt !== undefined && key >= lt) continue;
+      if (!this.map.has(full)) continue;
+      yield { key, value: this.map.get(full) };
+    }
+  }
+}
+
+export const MEMORY_STORE = ":memory:";
+
+export function createMemoryBee(): BeeLike {
+  return new MemoryBee();
+}

--- a/apps/backend/src/modules/crm/loaders/hyperbee-dal.ts
+++ b/apps/backend/src/modules/crm/loaders/hyperbee-dal.ts
@@ -4,6 +4,7 @@ import type { LoaderOptions } from "@medusajs/framework/types";
 
 import { createCrmProxyRepositories, type CrmRepositories } from "../dal/crm-proxy";
 import { createCrmRepositories } from "../dal/hyperbee-crm-service";
+import { createMemoryBee, MEMORY_STORE } from "../dal/memory-bee";
 
 /**
  * CRM DAL loader. Two modes, and it is FLAG-GATED + NON-FATAL — a CRM backend
@@ -65,6 +66,19 @@ export default async function hyperbeeDalLoader({ container }: LoaderOptions) {
     return;
   }
   const storeDir = process.env.CRM_HYPERBEE_STORE || "./.crm-store";
+
+  // ── In-memory store (tests) ────────────────────────────────────────────────
+  //
+  // The on-disk store is single-writer and its lock is a FILE, so two Jest
+  // workers opening one path fails the second with "File descriptor could not be
+  // locked" and leaves CRM offline for that worker (#1648). corestore@7.11 has no
+  // RAM storage, so the swap happens at the BeeLike boundary instead.
+  if (storeDir === MEMORY_STORE) {
+    registerCrm(container, createCrmRepositories(createMemoryBee()));
+    logger?.info("[crm] embedded in-memory DAL active — per-process, non-durable");
+    return;
+  }
+
   try {
     const [{ default: Corestore }, { default: Hyperbee }] = await Promise.all([
       import("corestore"),


### PR DESCRIPTION
Closes #1648. `main` is red on shards 1 and 2 — every CRM integration case 500s with `File descriptor could not be locked`.

## What was wrong

The embedded CRM store is single-writer and its lock is a **file**, but every Jest worker shared one store path. One CRM spec never exposed it; #1646 and #1647 each added one, so the pair became unrunnable — green alone, red together, and invisible to both PRs by construction.

## The RAM question, settled

The issue flagged that `random-access-memory` isn't in the tree and asked to confirm what RAM storage looks like on `corestore@7.11.0`. **There isn't one.** Corestore routes storage through `Hypercore.defaultStorage` → `hypercore-storage@3.2.0`, whose constructor is `new RocksDB(path.join(this.path, 'db'), { lock: this.deviceFile })` — a directory and a `CORESTORE` device file, unconditionally.

So the in-memory writer goes one level up, at the `BeeLike` boundary the DAL already talks to: `sub` / `put` / `get` / `del` / `createReadStream`, five methods over a sorted map.

- `src/modules/crm/dal/memory-bee.ts` — values stored verbatim (which is what the real subs' `binary`/`utf-8` encodings amount to from the caller's side); read streams snapshot their key list first, because callers delete while iterating.
- The loader accepts `CRM_HYPERBEE_STORE=":memory:"` and never imports Corestore on that path.
- Test setup sets it. Each worker boots an empty store, nothing touches disk, teardown has nothing left to clean.

## Verify

```bash
cd apps/backend
TEST_TYPE=integration:http NODE_OPTIONS="--experimental-vm-modules" \
  pnpm exec jest --testPathPattern="crm-(list-ordering|open-a-deal)"
```

- **With this change:** 2 suites, 18 tests, all pass in one run across workers.
- **Negative control** — `git stash -u` back to `main`, same command: 1 suite fails on the lock, 11 tests. The green is about this change.
- `pnpm check:prod-build` passes.

## Watch-outs

⚠️ Rows still accumulate across the tests of **one** worker — the runner's snapshot restore doesn't reset this store — so a CRM spec must still assert on rows it created, never on a total count. They no longer accumulate across workers, so any spec quietly relying on cross-worker accumulation would shift (neither current spec does).

🔎 **Seen, deliberately not fixed:** `personproperty` has the identical shared-path store (`./.person-property-store`) and hits the same lock in every worker but one. It falls back to Postgres, so it degrades quietly instead of 500ing. Left alone here because switching it would change which DAL those specs actually exercise — noted on #1648 instead.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01TLt1f38xqR8k2myCVxP8e4