### PR TITLE
fix(crm): the contact picker held the first 100 of 234 — and the board hid the rest (#1552)

### DIFF
--- a/apps/backend/src/admin/components/creates/create-crm-opportunity.tsx
+++ b/apps/backend/src/admin/components/creates/create-crm-opportunity.tsx
@@ -1,3 +1,4 @@
+import { useMemo } from "react";
 import { useForm } from "react-hook-form";
 import { z } from "@medusajs/framework/zod";
 import { zodResolver } from "@hookform/resolvers/zod";
@@ -10,6 +11,8 @@ import { RouteFocusModal } from "../modal/route-focus-modal";
 import { Form } from "../common/form";
 import { KeyboundForm } from "../utilitites/key-bound-form";
 import { sdk } from "../../lib/config";
+import { fetchAllCrm } from "../../lib/crm-list";
+import { Combobox } from "../inputs/combobox/combobox";
 import {
   CRM_OPPORTUNITY_DEFAULT_STAGE,
   CRM_OPPORTUNITY_STAGES,
@@ -74,26 +77,43 @@ export const CreateCrmOpportunityComponent = () => {
    * Contacts and companies as pickers rather than raw id fields. An id typed by
    * hand is how a deal ends up owned by nobody — the board resolves these ids
    * to names, and an unresolvable one renders as the ULID itself.
+   *
+   * PAGED, not `limit: 500`. The route clamps limit to 100 without complaining,
+   * so this dropdown used to hold the first 100 of 234 contacts: the other 134
+   * could not be picked at all, and arriving here from one of them prefilled an
+   * id with no matching option, which renders as the "Nobody yet" placeholder —
+   * indistinguishable from having chosen nobody.
    */
   const { data: refs } = useQuery({
     queryKey: ["crm-opportunity-refs"],
     queryFn: async () => {
       const [people, companies] = await Promise.all([
-        sdk.client.fetch<{ crm_people: CrmPerson[] }>("/admin/crm/people", {
-          query: { limit: 500 },
-        }),
-        sdk.client.fetch<{ crm_companies: CrmCompany[] }>(
-          "/admin/crm/companies",
-          { query: { limit: 200 } }
-        ),
+        fetchAllCrm<CrmPerson>("/admin/crm/people", "crm_people"),
+        fetchAllCrm<CrmCompany>("/admin/crm/companies", "crm_companies"),
       ])
-      return {
-        people: people.crm_people ?? [],
-        companies: companies.crm_companies ?? [],
-      }
+      return { people: people.rows, companies: companies.rows }
     },
     staleTime: 60_000,
   })
+
+  const personOptions = useMemo(
+    () =>
+      (refs?.people ?? []).map((p) => ({
+        label:
+          [p.first_name, p.last_name].filter(Boolean).join(" ").trim() || p.id,
+        value: p.id,
+      })),
+    [refs?.people]
+  )
+
+  const companyOptions = useMemo(
+    () =>
+      (refs?.companies ?? []).map((c) => ({
+        label: c.name || c.id,
+        value: c.id,
+      })),
+    [refs?.companies]
+  )
 
   const { mutateAsync, isPending } = useMutation({
     mutationFn: (body: Record<string, unknown>) =>
@@ -259,27 +279,29 @@ export const CreateCrmOpportunityComponent = () => {
                   </Form.Item>
                 )}
               />
+              {/* Searchable: 234 contacts is past the point where a plain
+                  dropdown is usable, and the name is what the user knows. */}
               <Form.Field
                 control={form.control}
                 name="owner_person_id"
-                render={({ field: { onChange, ...field } }) => (
+                render={({ field: { onChange, value, ref: _ref, ...field } }) => (
                   <Form.Item>
                     <Form.Label optional>Contact</Form.Label>
                     <Form.Control>
-                      <Select {...field} onValueChange={onChange}>
-                        <Select.Trigger>
-                          <Select.Value placeholder="Nobody yet" />
-                        </Select.Trigger>
-                        <Select.Content>
-                          {(refs?.people ?? []).map((p) => (
-                            <Select.Item key={p.id} value={p.id}>
-                              {[p.first_name, p.last_name]
-                                .filter(Boolean)
-                                .join(" ") || p.id}
-                            </Select.Item>
-                          ))}
-                        </Select.Content>
-                      </Select>
+                      {/* The wrapper carries the test hook: when a value is
+                          selected the Combobox hides its input and renders the
+                          chosen label in a SIBLING element, so anchoring a test
+                          on the input alone cannot see what is selected. */}
+                      <div data-testid="crm-opportunity-contact">
+                        <Combobox
+                          {...field}
+                          options={personOptions}
+                          value={value}
+                          onChange={(next) => onChange((next as string) || "")}
+                          allowClear
+                          placeholder="Search contacts"
+                        />
+                      </div>
                     </Form.Control>
                     <Form.ErrorMessage />
                   </Form.Item>
@@ -288,22 +310,20 @@ export const CreateCrmOpportunityComponent = () => {
               <Form.Field
                 control={form.control}
                 name="company_id"
-                render={({ field: { onChange, ...field } }) => (
+                render={({ field: { onChange, value, ref: _ref, ...field } }) => (
                   <Form.Item>
                     <Form.Label optional>Company</Form.Label>
                     <Form.Control>
-                      <Select {...field} onValueChange={onChange}>
-                        <Select.Trigger>
-                          <Select.Value placeholder="No company" />
-                        </Select.Trigger>
-                        <Select.Content>
-                          {(refs?.companies ?? []).map((c) => (
-                            <Select.Item key={c.id} value={c.id}>
-                              {c.name || c.id}
-                            </Select.Item>
-                          ))}
-                        </Select.Content>
-                      </Select>
+                      <div data-testid="crm-opportunity-company">
+                        <Combobox
+                          {...field}
+                          options={companyOptions}
+                          value={value}
+                          onChange={(next) => onChange((next as string) || "")}
+                          allowClear
+                          placeholder="Search companies"
+                        />
+                      </div>
                     </Form.Control>
                     <Form.ErrorMessage />
                   </Form.Item>

--- a/apps/backend/src/admin/lib/crm-list.ts
+++ b/apps/backend/src/admin/lib/crm-list.ts
@@ -1,0 +1,79 @@
+import { sdk } from "./config";
+
+/**
+ * Every CRM list route hard-clamps `limit` to 100:
+ *
+ *   const limit = Math.min(Math.max(Number(q.limit) || 20, 1), 100)
+ *
+ * It does not error on a larger ask — it silently serves 100. Both CRM screens
+ * asked for `limit: 500` and believed they had every row, which with 234
+ * contacts in production meant:
+ *
+ *  - the "Open a deal" contact dropdown listed the first 100 contacts, so 134
+ *    people simply could not be picked; and
+ *  - arriving from a contact BEYOND that 100 prefilled an id with no matching
+ *    option, so the field rendered its "Nobody yet" placeholder — the deal was
+ *    being opened against a contact the form could not show; and
+ *  - the pipeline board resolved `owner_person_id` through the same truncated
+ *    list, so a deal that DID carry a contact rendered with no contact line at
+ *    all (the card only renders that line when a name resolves).
+ *
+ * So: page, and use the `count` the route already returns. A caller that wants
+ * "all of them" must say so in a way the server cannot quietly reinterpret.
+ */
+export const CRM_LIST_PAGE_SIZE = 100;
+
+/** Refuses to spin forever; 50 pages = 5,000 rows. */
+const MAX_PAGES = 50;
+
+export type CrmListResult<T> = {
+  rows: T[];
+  /** The server's total. */
+  count: number;
+  /**
+   * True when we stopped at MAX_PAGES with rows still unread. A screen that
+   * filters client-side is then filtering over a subset, and must say so rather
+   * than present a short list as the whole truth.
+   */
+  truncated: boolean;
+};
+
+/**
+ * Read an entire CRM collection, one 100-row page at a time.
+ *
+ * `key` is the response envelope key (`crm_people`, `crm_companies`) — a wrong
+ * one reads as an empty collection with no error at all.
+ */
+export async function fetchAllCrm<T extends { id: string }>(
+  path: string,
+  key: string
+): Promise<CrmListResult<T>> {
+  const rows: T[] = [];
+  const seen = new Set<string>();
+  let count = 0;
+  let page = 0;
+
+  for (; page < MAX_PAGES; page++) {
+    const res = await sdk.client.fetch<Record<string, unknown>>(path, {
+      query: { limit: CRM_LIST_PAGE_SIZE, offset: rows.length },
+    });
+
+    const batch = (res?.[key] as T[] | undefined) ?? [];
+    count = typeof res?.count === "number" ? (res.count as number) : rows.length;
+
+    // A page that adds nothing new ends the walk. This is the guard against a
+    // backend that ignores `offset` and re-serves page one: without it we would
+    // loop MAX_PAGES times and hand back 5,000 duplicates of the same 100 rows.
+    let added = 0;
+    for (const row of batch) {
+      if (!row?.id || seen.has(row.id)) continue;
+      seen.add(row.id);
+      rows.push(row);
+      added++;
+    }
+    if (added === 0) break;
+    if (rows.length >= count) break;
+  }
+
+  return { rows, count, truncated: page >= MAX_PAGES && rows.length < count };
+}

--- a/apps/backend/src/admin/routes/crm/pipeline/page.tsx
+++ b/apps/backend/src/admin/routes/crm/pipeline/page.tsx
@@ -21,6 +21,7 @@ import {
   type CrmOpportunityStage,
 } from "../../../../modules/crm/stages";
 import { sdk } from "../../../lib/config";
+import { fetchAllCrm } from "../../../lib/crm-list";
 
 /**
  * The deal board. Columns come from the shared stage vocabulary in
@@ -70,23 +71,25 @@ const CrmPipelinePage = () => {
   const { data, isLoading } = useQuery({
     queryKey: ["crm-pipeline"],
     queryFn: async () => {
+      /**
+       * PAGED, all three. The route clamps `limit` to 100 and says nothing, so
+       * `limit: 500` was serving the first 100 of 234 contacts — and the owner
+       * line below only renders when the id RESOLVES to a name, so every deal
+       * whose contact sat past row 100 rendered as though it had no contact at
+       * all. The deal was fine; the lookup table was short.
+       */
       const [opps, people, companies] = await Promise.all([
-        sdk.client.fetch<{ crm_opportunities: CrmOpportunity[] }>(
+        fetchAllCrm<CrmOpportunity>(
           "/admin/crm/opportunities",
-          { query: { limit: 200 } }
+          "crm_opportunities"
         ),
-        sdk.client.fetch<{ crm_people: CrmPerson[] }>("/admin/crm/people", {
-          query: { limit: 500 },
-        }),
-        sdk.client.fetch<{ crm_companies: CrmCompany[] }>(
-          "/admin/crm/companies",
-          { query: { limit: 200 } }
-        ),
+        fetchAllCrm<CrmPerson>("/admin/crm/people", "crm_people"),
+        fetchAllCrm<CrmCompany>("/admin/crm/companies", "crm_companies"),
       ]);
       return {
-        opportunities: opps.crm_opportunities ?? [],
-        people: people.crm_people ?? [],
-        companies: companies.crm_companies ?? [],
+        opportunities: opps.rows,
+        people: people.rows,
+        companies: companies.rows,
       };
     },
     staleTime: 15_000,
@@ -222,16 +225,24 @@ const CrmPipelinePage = () => {
                 </div>
               ) : (
                 deals.map((o) => {
+                  /**
+                   * Falls back to the raw id rather than to nothing. A deal
+                   * that HAS a contact the lookup cannot name must not look
+                   * identical to a deal with no contact — those are different
+                   * facts, and silently collapsing them is what made a
+                   * correctly-created deal read as "no contact associated".
+                   */
                   const owner = o.owner_person_id
-                    ? nameById.get(o.owner_person_id)
+                    ? nameById.get(o.owner_person_id) || o.owner_person_id
                     : null;
                   const company = o.company_id
-                    ? companyById.get(o.company_id)
+                    ? companyById.get(o.company_id) || o.company_id
                     : null;
                   const amount = formatAmount(o.amount, o.currency);
                   return (
                     <div
                       key={o.id}
+                      data-testid="crm-deal-card"
                       className="flex flex-col gap-2 rounded-md border border-ui-border-base bg-ui-bg-base p-3"
                     >
                       {/* Deliberately not a link: there is no opportunity

--- a/e2e/specs/crm-open-a-deal.spec.ts
+++ b/e2e/specs/crm-open-a-deal.spec.ts
@@ -26,6 +26,14 @@ test.describe("Open a CRM deal (#1552)", () => {
   let contactName: string
   let contactId: string
   const stamp = Date.now()
+  /**
+   * ⚠️ Tracked so afterAll can remove them. The CRM store is a FILE that no
+   * snapshot restore resets, so contacts left behind here are permanent — and
+   * a hundred of them push every OTHER spec's fixtures off the first page of
+   * `/admin/crm/people`, which is what broke `crm-list-ordering`'s
+   * route-ordering case on the run that first added them.
+   */
+  const fillerIds: string[] = []
 
   test.beforeAll(async () => {
     if (!fs.existsSync(SEED_FILE)) {
@@ -53,6 +61,18 @@ test.describe("Open a CRM deal (#1552)", () => {
     })
     expect([200, 201]).toContain(person.status())
     contactId = (await person.json()).crm_person.id
+    await api.dispose()
+  })
+
+  test.afterAll(async () => {
+    if (!fillerIds.length) return
+    const api = await pwRequest.newContext({
+      baseURL: BASE,
+      extraHTTPHeaders: { Authorization: `Bearer ${token}` },
+    })
+    for (const id of fillerIds) {
+      await api.delete(`/admin/crm/people/${id}`)
+    }
     await api.dispose()
   })
 
@@ -134,7 +154,7 @@ test.describe("Open a CRM deal (#1552)", () => {
      * the service, and a workflow whose side effects fail can still leave the
      * caller a created row; the board is where that shows.
      */
-    await page.waitForURL(/\/app\/crm\/pipeline/, { timeout: 20000 })
+    await page.waitForURL(/\/app\/crm\/pipeline$/, { timeout: 20000 })
     await expect(page.getByText(title)).toBeVisible({ timeout: 20000 })
   })
 
@@ -160,15 +180,131 @@ test.describe("Open a CRM deal (#1552)", () => {
 
     /**
      * Pre-SELECTED, not merely present in the picker — asserted on the Contact
-     * field's own trigger. Anchoring on the name anywhere on the page would
-     * match the contact heading behind the modal and pass with the field left
-     * on "Nobody yet".
+     * field itself. Anchoring on the name anywhere on the page would match the
+     * contact heading behind the modal and pass with the field left empty.
      */
-    const contactField = page
-      .locator("form")
-      .getByRole("combobox")
-      .filter({ hasText: `${contactName} Buyer` })
-    await expect(contactField).toBeVisible({ timeout: 15000 })
+    /**
+     * ⚠️ Blur first, and assert the popover is shut. The Combobox renders its
+     * option list INSIDE this wrapper, so a wrapper that merely "contains the
+     * name" may just be showing an open dropdown with that contact somewhere
+     * in it — which is a different claim from the field being pre-selected,
+     * and passes in cases where the prefill did nothing. (The negative control
+     * for this file showed exactly that text: every option, concatenated.)
+     */
+    await page.getByLabel("Title").click()
+    await expect(page.getByRole("option")).toHaveCount(0)
+    await expect(
+      page.getByTestId("crm-opportunity-contact")
+    ).toContainText(`${contactName} Buyer`, { timeout: 15000 })
+  })
+
+  /**
+   * 🔴 The case above passes on a near-empty store no matter what the code
+   * does, because one seeded contact is always inside the first page. THIS is
+   * the case that reproduces what was reported from production.
+   *
+   * `/admin/crm/people` clamps `limit` to 100 and does not complain:
+   *
+   *   const limit = Math.min(Math.max(Number(q.limit) || 20, 1), 100)
+   *
+   * Both CRM screens asked for `limit: 500` and believed they had everything.
+   * With 234 contacts in production that meant the picker held the first 100,
+   * and a contact past that point could not be chosen — while arriving from
+   * their page prefilled an id with no matching option, which renders as an
+   * empty field. Verified against production: contact `crmp_2e6be87e006f` is
+   * not in the first 100 of 234, and the deal opened for them stored the
+   * owner correctly while the board showed no contact at all.
+   */
+  test("offers EVERY contact, not the first hundred", async ({ page }) => {
+    const api = await pwRequest.newContext({
+      baseURL: BASE,
+      extraHTTPHeaders: { Authorization: `Bearer ${token}` },
+    })
+
+    // Push the store past one page, so the assertion below is not vacuous.
+    // Bounded: only tops up to the threshold, and the store never resets.
+    const before = await api.get("/admin/crm/people?limit=1")
+    let total = (await before.json()).count
+    for (let i = total; i < 105; i++) {
+      const res = await api.post("/admin/crm/people", {
+        data: {
+          first_name: `Filler-${stamp}-${i}`,
+          last_name: "Contact",
+          email: `filler-${stamp}-${i}@jyt.test`,
+        },
+      })
+      expect([200, 201]).toContain(res.status())
+      fillerIds.push((await res.json()).crm_person.id)
+      total++
+    }
+    expect(total).toBeGreaterThan(100)
+
+    await login(page)
+    await page.goto("/app/crm/pipeline/create")
+    await expect(page.getByRole("heading", { name: "Open a deal" })).toBeVisible(
+      { timeout: 20000 }
+    )
+
+    const contact = page.getByTestId("crm-opportunity-contact")
+    await contact.getByRole("combobox").click()
+
+    /**
+     * Every contact, counted — not "the one I seeded is present". Presence
+     * alone passes on a truncated list whenever the fixture lands early; the
+     * count is what the truncation actually changes (100 vs 105+).
+     */
+    await expect
+      .poll(async () => await page.getByRole("option").count(), {
+        timeout: 20000,
+      })
+      .toBe(total)
+
+    // Searchable, which a 234-row dropdown has to be to be usable at all.
+    await contact.getByRole("combobox").fill(contactName)
+    await expect(page.getByRole("option")).toHaveCount(1)
+    await page.getByRole("option").first().click()
+
+    const title = `E2E Deal Search ${stamp}`
+    await page.getByLabel("Title").fill(title)
+    await page.getByRole("button", { name: "Open deal" }).click()
+
+    /**
+     * 🔴 Anchored to the END of the path. `/\/app\/crm\/pipeline/` also
+     * matches `/app/crm/pipeline/create`, which is where this click STARTS —
+     * so it returns instantly whether or not the deal was ever created, and
+     * the API read below then races the POST it is supposed to be checking.
+     * That is precisely how this case failed on its first run while the
+     * feature underneath it worked.
+     */
+    await page.waitForURL(/\/app\/crm\/pipeline$/, { timeout: 20000 })
+    await expect(page.getByText(title)).toBeVisible({ timeout: 20000 })
+
+    /**
+     * The reported symptom was "no contact is associated to it", so assert on
+     * the STORED record, not on the card. The board rendering the contact and
+     * the deal carrying one are different claims, and it was the rendering
+     * that failed in production.
+     */
+    const opps = await api.get("/admin/crm/opportunities?limit=100")
+    const created = (await opps.json()).crm_opportunities.find(
+      (o: any) => o.title === title
+    )
+    expect(created).toBeTruthy()
+    expect(created.owner_person_id).toBe(contactId)
+    await api.dispose()
+
+    // ...and the board NAMES them. This is the half that actually broke in
+    // production: the card only renders its contact line when the id resolves
+    // through the (truncated) people list, so a deal carrying a contact past
+    // row 100 rendered identically to one with no contact at all.
+    // Anchored on the CARD, not on any div containing the title — the success
+    // toast carries the title too, and `.last()` over bare divs picked the
+    // toast, which passes or fails for reasons that have nothing to do with
+    // the board.
+    const card = page
+      .getByTestId("crm-deal-card")
+      .filter({ hasText: title })
+    await expect(card).toContainText(`${contactName} Buyer`)
   })
 
 })


### PR DESCRIPTION
Reported: opening a deal did not fill the contact in, and the resulting deal showed no contact at all. Both symptoms are the same root cause, and the contact dropdown is now a searchable combobox as requested.

## What was wrong

`/admin/crm/people` clamps `limit` and says nothing:

```ts
const limit = Math.min(Math.max(Number(q.limit) || 20, 1), 100)
```

Both CRM screens asked for `limit: 500` and believed they had every row. With **234 contacts in production** that is the first 100 — which broke three things at once:

1. the picker could not offer 134 of the contacts at all;
2. arriving from one of those contacts' pages prefilled an id with **no matching option**, which renders as an empty field — indistinguishable from having chosen nobody;
3. the board resolves `owner_person_id` through the same short list and only renders its contact line when a name *resolves*, so a deal that carried a contact rendered exactly like one that didn't.

## Verified against production, not assumed

The reported deal `crmo_2e6be87e0001` stores `owner_person_id: crmp_2e6be87e006f` **correctly**, and that contact is **not** in the first 100 of 234. The record was always right; both screens were reading a truncated list.

## The fix

- `lib/crm-list.ts` — `fetchAllCrm` pages 100 at a time against the `count` the route already returns, and stops early if a page adds nothing new (a backend that ignored `offset` would otherwise return duplicates forever).
- Both screens use it.
- Contact and company are now the searchable `Combobox` — what a 234-row picker has to be to be usable.
- The board falls back to the raw id rather than to nothing. "Has a contact we cannot name" and "has no contact" are different facts.

## Browser-verified — the step that would have caught this originally

The new e2e case tops the store past one page, asserts the picker offers **every** contact (a *count*, not presence — presence passes on a truncated list whenever the fixture lands early), searches, selects, submits, then asserts the **stored** owner and the board's rendering as separate claims.

**Negative control, aimed at the cause:** UI unchanged, only the paging reverted →

```
Expected: 111
Received: 100
```

and the prefill case fails too. Both pass with paging on.

### Three defects the control exposed in my own test

- `waitForURL(/\/app\/crm\/pipeline/)` also matches `/pipeline/create`, where the submit *starts* — it returned instantly and the API read raced the POST it was checking. Now anchored to end-of-path.
- The Combobox renders its option list **inside** the field wrapper, so "wrapper contains the name" can just mean an open dropdown. The prefill case now blurs and asserts the popover is shut first.
- The 105 filler contacts are deleted in `afterAll`. The CRM store is a file no snapshot resets, and leaving them pushed other specs' fixtures off page one — which broke `crm-list-ordering`'s route case on the first run.

## Also found, not fixed here

- `crm_person.company_id` holds a company **name**, not an id: `"BY Marcha"`, `"O'Shen"` (2 of 234; 232 empty; **0** real ids, and production has 0 companies so no id could ever have been right). The prefill link forwards it, so the opportunity inherits a name in an id field.
- `crm-contact-activity` fails locally: the seed's CRM person is invisible to the dev server (a fresh seed yields `crmp_000063`, which the server 404s while holding 27 other rows). Reproduced with this branch stashed — pre-existing, filed separately.

## Verify

```bash
cd apps/backend
CRM_HYPERBEE=true pnpm e2e:seed          # with the dev server STOPPED
CRM_HYPERBEE=true pnpm e2e:test crm-open-a-deal crm-list-ordering
```

`pnpm check:prod-build` passes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01TLt1f38xqR8k2myCVxP8e4