### PR TITLE
feat(shipping): finish DHL Express provider — flat fallback, spec fixes, mock + docs

### DIFF
--- a/apps/backend/.env.template
+++ b/apps/backend/.env.template
@@ -126,6 +126,25 @@ DTDC_TRACKING_PASSWORD=your_tracking_password
 # DTDC_SANDBOX=true
 # DTDC_DEFAULT_SERVICE_TYPE=GROUND EXPRESS
 
+# DHL Express (international). India-origin products P/Y/8; H/N are unavailable
+# out of India. `DHL_SANDBOX` routes to the test gateway (production creds don't
+# work against it and vice-versa).
+DHL_API_KEY=your_dhl_api_key
+DHL_API_SECRET=your_dhl_api_secret
+DHL_ACCOUNT_NUMBER=your_dhl_account_number
+# DHL_SANDBOX=false
+# What an UNQUOTABLE lane costs. Mirrors Shiprocket's fallback: without one,
+# calculatePrice answers 0 — free international freight wearing the shape of a
+# real quote. `US=3500` (ISO2=minor units); see
+# src/modules/shipping-providers/shiprocket/flat-fallback.ts.
+# DHL_FLAT_FALLBACK_AMOUNTS=US=3500
+# DHL_FLAT_FALLBACK_AMOUNT=3500
+# DHL mock server (https://api-mock.dhl.com/mydhlapi) — fixed test data, no
+# account gating. DHL publishes demo credentials; the full flow (incl.
+# createShipment) works against it. Used by `DHL_MOCK=true` in the integration test.
+# DHL_MOCK_API_KEY=demo-key
+# DHL_MOCK_API_SECRET=demo-secret
+
 # Workflow / step execution timeouts (#742). Both are millisecond windows that
 # were previously hardcoded at 10s — too short for real LLM/external-API work.
 # MASTRA_STEP_TIMEOUT_MS  — per-step executor timeout (default 60000).

--- a/apps/backend/medusa-config.prod.ts
+++ b/apps/backend/medusa-config.prod.ts
@@ -436,6 +436,16 @@ module.exports = defineConfig({
                     api_secret: process.env.DHL_API_SECRET,
                     account_number: process.env.DHL_ACCOUNT_NUMBER,
                     sandbox: process.env.DHL_SANDBOX === "true",
+                    // What an UNQUOTABLE lane costs. Mirrors Shiprocket's
+                    // fallback: without it, calculatePrice answers 0 — free
+                    // international freight wearing a real quote. `US=3500`
+                    // (ISO2=minor units); see shiprocket/flat-fallback.ts.
+                    flat_fallback_amounts: parseFlatFallbackAmounts(
+                      process.env.DHL_FLAT_FALLBACK_AMOUNTS
+                    ),
+                    flat_fallback_amount: process.env.DHL_FLAT_FALLBACK_AMOUNT
+                      ? Number(process.env.DHL_FLAT_FALLBACK_AMOUNT)
+                      : undefined,
                   },
                 },
               ]

--- a/apps/backend/medusa-config.ts
+++ b/apps/backend/medusa-config.ts
@@ -530,6 +530,16 @@ module.exports = defineConfig({
                           api_secret: process.env.DHL_API_SECRET,
                           account_number: process.env.DHL_ACCOUNT_NUMBER,
                           sandbox: process.env.DHL_SANDBOX === "true",
+                          // What an UNQUOTABLE lane costs. Mirrors Shiprocket's
+                          // fallback: without it, calculatePrice answers 0 — free
+                          // international freight wearing a real quote. `US=3500`
+                          // (ISO2=minor units); see shiprocket/flat-fallback.ts.
+                          flat_fallback_amounts: parseFlatFallbackAmounts(
+                            process.env.DHL_FLAT_FALLBACK_AMOUNTS
+                          ),
+                          flat_fallback_amount: process.env.DHL_FLAT_FALLBACK_AMOUNT
+                            ? Number(process.env.DHL_FLAT_FALLBACK_AMOUNT)
+                            : undefined,
                         },
                       },
                     ]

--- a/apps/backend/src/modules/shipping-providers/dhl/__tests__/client.unit.spec.ts
+++ b/apps/backend/src/modules/shipping-providers/dhl/__tests__/client.unit.spec.ts
@@ -1,0 +1,343 @@
+import { DHLClient, dhlDateTime, normalizeDhlDocuments } from "../client"
+
+/**
+ * The DHL Express client carries `fetchImpl` injection specifically so the
+ * transport can be stubbed without patching the global. The stub below returns
+ * `{ ok, status, text }` because `request<T>()` reads `res.text()` and parses
+ * it itself (DHL errors come back as JSON `detail`).
+ */
+const clientWith = (status: number, body: any) => {
+  const calls: Array<{ url: string; init?: RequestInit }> = []
+  const fetchImpl = (async (url: string, init?: RequestInit) => {
+    calls.push({ url: String(url), init })
+    return {
+      ok: status >= 200 && status < 300,
+      status,
+      text: async () => (typeof body === "string" ? body : JSON.stringify(body)),
+    }
+  }) as unknown as typeof fetch
+  return {
+    client: new DHLClient({
+      api_key: "k",
+      api_secret: "s",
+      account_number: "777",
+      fetchImpl,
+    }),
+    calls,
+  }
+}
+
+describe("DHLClient", () => {
+  it("builds the rates URL with account, lane, weight and metric units", async () => {
+    const { client, calls } = clientWith(200, { products: [] })
+    await client.getRates({
+      origin_country: "IN",
+      origin_city: "Pune",
+      origin_postal_code: "411014",
+      dest_country: "US",
+      dest_city: "New York",
+      dest_postal_code: "10001",
+      weight: 1.2,
+    })
+    const url = calls[0].url
+    expect(url).toContain("accountNumber=777")
+    expect(url).toContain("originCountryCode=IN")
+    expect(url).toContain("destinationCountryCode=US")
+    expect(url).toContain("weight=1.2")
+    expect(url).toContain("unitOfMeasurement=metric")
+  })
+
+  it("address-validates a delivery lane with the delivery type", async () => {
+    const { client, calls } = clientWith(200, { address: [{ cityName: "Pune" }] })
+    await client.addressValidate({
+      type: "delivery",
+      country_code: "IN",
+      postal_code: "411014",
+      city: "Pune",
+    })
+    expect(calls[0].url).toContain("/address-validate")
+    expect(calls[0].url).toContain("type=delivery")
+    expect(calls[0].url).toContain("postalCode=411014")
+  })
+
+  it("builds a customs-declarable shipment body with declared value and line items", async () => {
+    const { client, calls } = clientWith(200, { shipmentTrackingNumber: "JD123" })
+    await client.createShipment({
+      shipper: {
+        name: "Warehouse",
+        address: { line1: "1 A", city: "Pune", postal_code: "411014", country_code: "IN" },
+      },
+      receiver: {
+        name: "Buyer",
+        address: { line1: "2 B", city: "Berlin", postal_code: "10115", country_code: "DE" },
+      },
+      packages: [{ weight: 1.2 }],
+      product_code: "P",
+      is_customs_declarable: true,
+      declared_value: 5000,
+      declared_value_currency: "EUR",
+      items: [
+        {
+          description: "Cotton shawl",
+          price: 50,
+          quantity: 2,
+          hs_code: "6304.92",
+          weight_kg: 0.6,
+          manufacturer_country: "IN",
+        },
+      ],
+    })
+    const body = JSON.parse(calls[0].init!.body as string)
+    expect(body.productCode).toBe("P")
+    expect(body.content.isCustomsDeclarable).toBe(true)
+    expect(body.content.declaredValue).toBe(5000)
+    expect(body.content.exportDeclaration.lineItems).toHaveLength(1)
+    expect(body.content.exportDeclaration.lineItems[0].commodityCodes).toEqual([
+      { typeCode: "outbound", value: "6304.92" },
+    ])
+  })
+
+  it("omits the export declaration for a non-declarable shipment", async () => {
+    const { client, calls } = clientWith(200, { shipmentTrackingNumber: "JD456" })
+    await client.createShipment({
+      shipper: {
+        name: "W",
+        address: { line1: "1", city: "Pune", postal_code: "411014", country_code: "IN" },
+      },
+      receiver: {
+        name: "B",
+        address: { line1: "2", city: "Mumbai", postal_code: "400001", country_code: "IN" },
+      },
+      packages: [{ weight: 0.5 }],
+      is_customs_declarable: false,
+    })
+    const body = JSON.parse(calls[0].init!.body as string)
+    expect(body.content.isCustomsDeclarable).toBe(false)
+    expect(body.content.exportDeclaration).toBeUndefined()
+  })
+
+  it("retrieves documents via the Get Image endpoint with type and pickup month", async () => {
+    const { client, calls } = clientWith(200, { documents: [] })
+    await client.getShipmentImage("JD123", {
+      typeCode: "commercial-invoice",
+      pickupYearAndMonth: "2026-08",
+    })
+    expect(calls[0].url).toContain("/shipments/JD123/get-image")
+    expect(calls[0].url).toContain("typeCode=commercial-invoice")
+    expect(calls[0].url).toContain("pickupYearAndMonth=2026-08")
+    expect(calls[0].url).toContain("shipperAccountNumber=777")
+  })
+
+  it("names a non-OK response with its status and DHL detail", async () => {
+    const { client } = clientWith(401, { detail: "invalid key" })
+    await expect(
+      client.getRates({
+        origin_country: "IN",
+        origin_city: "Pune",
+        origin_postal_code: "411014",
+        dest_country: "US",
+        dest_city: "New York",
+        dest_postal_code: "10001",
+        weight: 1,
+      })
+    ).rejects.toThrow(/401/)
+  })
+
+  it("surfaces DHL's additionalDetails field problems, not just the summary", async () => {
+    const { client } = clientWith(400, {
+      detail: "Multiple problems found, see Additional Details",
+      additionalDetails: ["200003: NetWeight KGM MEASUREMENT VALUE IS MISSING"],
+    })
+    await expect(
+      client.getRates({
+        origin_country: "IN",
+        origin_city: "Pune",
+        origin_postal_code: "411014",
+        dest_country: "US",
+        dest_city: "New York",
+        dest_postal_code: "10001",
+        weight: 1,
+      })
+    ).rejects.toThrow(/NetWeight KGM MEASUREMENT VALUE IS MISSING/)
+  })
+
+  it("sends each landed-cost line's net weight and a tariff rate type", async () => {
+    const { client, calls } = clientWith(200, { products: [] })
+    await client.landedCost({
+      shipper: {
+        name: "W",
+        address: { line1: "1", city: "Pune", postal_code: "411014", country_code: "IN" },
+      },
+      receiver: {
+        name: "B",
+        address: { line1: "2", city: "New York", postal_code: "10001", country_code: "US" },
+      },
+      weight: 1.2,
+      currency_code: "USD",
+      declared_value: 120,
+      items: [
+        { name: "Cotton Shawl", hs_code: "63049200", origin_country: "IN", quantity: 2, unit_price: 60, weight: 0.6 },
+      ],
+    })
+    const body = JSON.parse(calls[0].init!.body as string)
+    expect(body.items[0].weight).toBe(0.6)
+    expect(body.items[0].weightUnitOfMeasurement).toBe("metric")
+    expect(body.items[0].commodityCode).toBe("63049200")
+    // With a partial HS code the GTS calculator needs to know which end of the
+    // duty range to quote — the client defaults to the conservative upper bound.
+    expect(body.items[0].estimatedTariffRateType).toBe("highest_rate")
+  })
+
+  it("lets the caller pick the tariff rate type for a landed-cost line", async () => {
+    const { client, calls } = clientWith(200, { products: [] })
+    await client.landedCost({
+      shipper: {
+        name: "W",
+        address: { line1: "1", city: "Pune", postal_code: "411014", country_code: "IN" },
+      },
+      receiver: {
+        name: "B",
+        address: { line1: "2", city: "New York", postal_code: "10001", country_code: "US" },
+      },
+      weight: 1.2,
+      currency_code: "USD",
+      declared_value: 120,
+      items: [
+        {
+          name: "Cotton Shawl",
+          hs_code: "63049200",
+          origin_country: "IN",
+          quantity: 2,
+          unit_price: 60,
+          weight: 0.6,
+          estimated_tariff_rate_type: "preferential_rate",
+        },
+      ],
+    })
+    const body = JSON.parse(calls[0].init!.body as string)
+    expect(body.items[0].estimatedTariffRateType).toBe("preferential_rate")
+  })
+
+  it("builds a pickup body with an accounts ARRAY and shipper customerDetails", async () => {
+    const { client, calls } = clientWith(200, { dispatchConfirmationNumber: "PRG1" })
+    await client.createPickup({
+      shipper: {
+        name: "JYT Warehouse",
+        phone: "919999999999",
+        email: "w@e.com",
+        company_name: "JYT",
+        address: { line1: "1 A", city: "Pune", postal_code: "411014", country_code: "IN" },
+      },
+      close_time: "18:00",
+      location: "reception",
+      location_type: "business",
+      shipments: [
+        {
+          product_code: "P",
+          is_customs_declarable: true,
+          packages: [{ weight: 1.2 }],
+          shipment_tracking_number: "123456790",
+        },
+      ],
+    })
+    const body = JSON.parse(calls[0].init!.body as string)
+    expect(calls[0].url).toContain("/pickups")
+    // The old code sent a singular `account` and a `pickupLocation` — both
+    // rejected by the spec (which wants `accounts[]` + `customerDetails`).
+    expect(body.accounts).toEqual([{ typeCode: "shipper", number: "777" }])
+    expect(body.account).toBeUndefined()
+    expect(body.pickupLocation).toBeUndefined()
+    expect(body.customerDetails.shipperDetails.postalAddress.cityName).toBe("Pune")
+    expect(body.shipmentDetails[0].productCode).toBe("P")
+    expect(body.shipmentDetails[0].shipmentTrackingNumber).toBe("123456790")
+    expect(body.closeTime).toBe("18:00")
+  })
+
+  it("selects the mock server when mock is set, sandbox when sandbox is set", async () => {
+    const urls: string[] = []
+    const fetchImpl = (async (url: string) => {
+      urls.push(String(url))
+      return { ok: true, status: 200, text: async () => JSON.stringify({}) }
+    }) as unknown as typeof fetch
+
+    const mock = new DHLClient({ api_key: "k", api_secret: "s", mock: true, fetchImpl })
+    await mock.getRates({
+      origin_country: "IN", origin_city: "Pune", origin_postal_code: "411014",
+      dest_country: "US", dest_city: "NY", dest_postal_code: "10001", weight: 1,
+    })
+    expect(urls[urls.length - 1]).toContain("https://api-mock.dhl.com/mydhlapi")
+
+    const sandbox = new DHLClient({ api_key: "k", api_secret: "s", sandbox: true, fetchImpl })
+    await sandbox.getRates({
+      origin_country: "IN", origin_city: "Pune", origin_postal_code: "411014",
+      dest_country: "US", dest_city: "NY", dest_postal_code: "10001", weight: 1,
+    })
+    expect(urls[urls.length - 1]).toContain("https://express.api.dhl.com/mydhlapi/test")
+
+    const prod = new DHLClient({ api_key: "k", api_secret: "s", fetchImpl })
+    await prod.getRates({
+      origin_country: "IN", origin_city: "Pune", origin_postal_code: "411014",
+      dest_country: "US", dest_city: "NY", dest_postal_code: "10001", weight: 1,
+    })
+    expect(urls[urls.length - 1]).toContain("https://express.api.dhl.com/mydhlapi")
+    expect(urls[urls.length - 1]).not.toContain("/test")
+  })
+})
+
+describe("dhlDateTime", () => {
+  it("formats with an explicit GMT offset and no Z suffix", () => {
+    const out = dhlDateTime(new Date(Date.UTC(2026, 7, 29, 10, 30, 5)))
+    // The exact offset depends on the machine's TZ, but the shape is fixed:
+    // no `Z`, no fractional seconds, and a ` GMT±HH:MM` suffix.
+    expect(out).toMatch(/^\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2} GMT[+-]\d{2}:\d{2}$/)
+    expect(out).not.toContain("Z")
+  })
+
+  it("defaults to the current time in the same shape", () => {
+    expect(dhlDateTime()).toMatch(
+      /^\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2} GMT[+-]\d{2}:\d{2}$/
+    )
+  })
+})
+
+describe("normalizeDhlDocuments", () => {
+  it("flattens the create-shipment bare documents array (imageFormat vocabulary)", () => {
+    const res = {
+      documents: [
+        { typeCode: "label", imageFormat: "PDF", content: "AAA" },
+        { typeCode: "invoice", imageFormat: "PDF", content: "BBB" },
+      ],
+    }
+    expect(normalizeDhlDocuments(res)).toEqual([
+      { typeCode: "label", contentType: "pdf", content: "AAA" },
+      { typeCode: "invoice", contentType: "pdf", content: "BBB" },
+    ])
+  })
+
+  it("flattens the Get Image response (encodingFormat vocabulary)", () => {
+    const res = {
+      documents: [
+        { typeCode: "commercial-invoice", encodingFormat: "PDF", content: "CCC" },
+      ],
+    }
+    expect(normalizeDhlDocuments(res)).toEqual([
+      { typeCode: "commercial-invoice", contentType: "pdf", content: "CCC" },
+    ])
+  })
+
+  it("drops rows with no base64 content rather than returning a dead reference", () => {
+    const res = {
+      documents: [
+        { typeCode: "label", imageFormat: "PDF", content: "" },
+        { typeCode: "invoice", imageFormat: "PDF", content: "DDD" },
+      ],
+    }
+    expect(normalizeDhlDocuments(res)).toHaveLength(1)
+    expect(normalizeDhlDocuments(res)[0].typeCode).toBe("invoice")
+  })
+
+  it("returns an empty list for an unrecognised payload", () => {
+    expect(normalizeDhlDocuments(undefined)).toEqual([])
+    expect(normalizeDhlDocuments({ shipments: [] })).toEqual([])
+  })
+})

--- a/apps/backend/src/modules/shipping-providers/dhl/__tests__/service.unit.spec.ts
+++ b/apps/backend/src/modules/shipping-providers/dhl/__tests__/service.unit.spec.ts
@@ -1,0 +1,264 @@
+import DHLExpressFulfillmentService, {
+  dhlDocumentTypeCode,
+  dhlPickupYearMonth,
+} from "../service"
+import { DEFAULT_FLAT_FALLBACK } from "../../shiprocket/flat-fallback"
+
+const logger: any = {
+  info: jest.fn(),
+  warn: jest.fn(),
+  error: jest.fn(),
+  debug: jest.fn(),
+}
+
+const buildService = (options: any = {}, clientOverrides: any = {}) => {
+  const svc = new DHLExpressFulfillmentService(
+    { logger },
+    { api_key: "k", api_secret: "s", account_number: "777", ...options }
+  )
+  ;(svc as any).client = {
+    getRates: jest.fn(),
+    addressValidate: jest.fn(),
+    createShipment: jest.fn(),
+    getShipmentImage: jest.fn(),
+    ...clientOverrides,
+  }
+  return svc
+}
+
+const CONTEXT: any = {
+  from_location: {
+    address: { country_code: "IN", city: "Pune", postal_code: "411014" },
+  },
+  shipping_address: {
+    country_code: "DE",
+    city: "Berlin",
+    postal_code: "10115",
+  },
+  items: [{ variant: { weight: 600 }, quantity: 2 }],
+  currency_code: "eur",
+}
+
+describe("DHLExpressFulfillmentService", () => {
+  it("registers under the dhl-express identifier", () => {
+    expect(DHLExpressFulfillmentService.identifier).toBe("dhl-express")
+  })
+
+  it("offers the three India-origin products", async () => {
+    const opts = await buildService().getFulfillmentOptions()
+    expect(opts.map((o) => o.id)).toEqual([
+      "dhl-express-worldwide",
+      "dhl-express-1200",
+      "dhl-express-easy",
+    ])
+    expect(opts.map((o) => (o as any).product_code)).toEqual(["P", "Y", "8"])
+  })
+
+  it("prices the BILLC line of the matched product", async () => {
+    const svc = buildService(undefined, {
+      getRates: jest.fn().mockResolvedValue({
+        products: [
+          {
+            productCode: "P",
+            totalPrice: [
+              { currencyType: "BILLC", price: 1250.5 },
+              { currencyType: "BASE", price: 1000 },
+            ],
+          },
+        ],
+      }),
+    })
+    const result = await svc.calculatePrice(
+      { product_code: "P" },
+      {},
+      CONTEXT
+    )
+    expect(result).toEqual({
+      calculated_amount: 1250.5,
+      is_calculated_price_tax_inclusive: true,
+    })
+  })
+
+  it("falls back to the flat rate when DHL returns no rate", async () => {
+    const svc = buildService(undefined, {
+      getRates: jest.fn().mockResolvedValue({ products: [] }),
+    })
+    const result = await svc.calculatePrice(
+      { product_code: "P" },
+      {},
+      CONTEXT
+    )
+    expect(result.calculated_amount).toBe(DEFAULT_FLAT_FALLBACK)
+    expect(result.is_calculated_price_tax_inclusive).toBe(false)
+    expect(logger.warn).toHaveBeenCalled()
+  })
+
+  it("falls back to the flat rate when the carrier call throws", async () => {
+    const svc = buildService(undefined, {
+      getRates: jest.fn().mockRejectedValue(new Error("gateway down")),
+    })
+    const result = await svc.calculatePrice(
+      { product_code: "P" },
+      {},
+      CONTEXT
+    )
+    expect(result.calculated_amount).toBe(DEFAULT_FLAT_FALLBACK)
+    expect(result.is_calculated_price_tax_inclusive).toBe(false)
+  })
+
+  it("honours a per-country configured fallback instead of the default", async () => {
+    const svc = buildService(
+      { flat_fallback_amounts: { DE: 3500 } },
+      { getRates: jest.fn().mockRejectedValue(new Error("no rate")) }
+    )
+    const result = await svc.calculatePrice(
+      { product_code: "P" },
+      {},
+      CONTEXT
+    )
+    expect(result.calculated_amount).toBe(3500)
+  })
+
+  it("honours a per-currency fallback stamped on the option's data", async () => {
+    const svc = buildService(undefined, {
+      getRates: jest.fn().mockRejectedValue(new Error("no rate")),
+    })
+    const result = await svc.calculatePrice(
+      { product_code: "P", flat_fallback_amounts: { eur: 35 } },
+      {},
+      CONTEXT
+    )
+    expect(result.calculated_amount).toBe(35)
+  })
+
+  it("maps order line items onto a customs-declarable shipment and returns the label", async () => {
+    const createShipment = jest.fn().mockResolvedValue({
+      shipmentTrackingNumber: "JD123",
+      documents: [{ typeCode: "label", content: "abc" }],
+    })
+    const svc = buildService(undefined, { createShipment })
+
+    const result = await svc.createFulfillment(
+      {
+        from_location: {
+          name: "Pune Studio",
+          address: {
+            country_code: "IN",
+            city: "Pune",
+            postal_code: "411014",
+            address_1: "1 A",
+          },
+        },
+      },
+      [{ line_item_id: "item_1", title: "Cotton Shawl", quantity: 2 }],
+      {
+        id: "order_1",
+        currency_code: "EUR",
+        shipping_address: {
+          first_name: "Test",
+          last_name: "Buyer",
+          address_1: "12 MG Road",
+          city: "Berlin",
+          postal_code: "10115",
+          country_code: "DE",
+        },
+        items: [
+          { id: "item_1", title: "Cotton Shawl", unit_price: 2500, variant: { weight: 600 } },
+        ],
+      } as any,
+      { id: "ful_1" } as any
+    )
+
+    const payload = createShipment.mock.calls[0][0]
+    // IN → DE is cross-border, so customs fields must be present.
+    expect(payload.is_customs_declarable).toBe(true)
+    expect(payload.declared_value).toBeGreaterThan(0)
+    expect(payload.items).toHaveLength(1)
+    // No HS code on the variant → the textile fallback.
+    expect(payload.items[0].hs_code).toBe("6304.92")
+    expect(payload.items[0].quantity).toBe(2)
+    // 600 g × 2 → 1.2 kg billing weight.
+    expect(payload.packages[0].weight).toBe(1.2)
+
+    expect(result.data).toMatchObject({
+      tracking_number: "JD123",
+      carrier: "dhl-express",
+      shipment_id: "JD123",
+    })
+    expect(result.labels).toHaveLength(1)
+    expect(result.labels[0].label_url).toBe("data:application/pdf;base64,abc")
+  })
+
+  it("cancel is a documented no-op that still logs the tracking number", async () => {
+    const svc = buildService()
+    const out = await svc.cancelFulfillment({ data: { tracking_number: "JD123" } })
+    expect(out).toEqual({})
+    expect(logger.info).toHaveBeenCalledWith(
+      expect.stringContaining("JD123")
+    )
+  })
+
+  it("retrieveDocuments returns [] when the fulfillment carries no tracking number", async () => {
+    const svc = buildService()
+    await expect(svc.retrieveDocuments({})).resolves.toEqual([])
+  })
+
+  it("retrieveDocuments maps the document type and fetches via Get Image", async () => {
+    const svc = buildService(undefined, {
+      getShipmentImage: jest.fn().mockResolvedValue({
+        documents: [{ typeCode: "commercial-invoice", encodingFormat: "PDF", content: "EEE" }],
+      }),
+    })
+    const docs = await svc.retrieveDocuments(
+      { tracking_number: "JD123", shipped_at: "2026-08-10T10:00:00Z" },
+      "invoice"
+    )
+    expect(docs).toEqual([
+      { typeCode: "commercial-invoice", contentType: "pdf", content: "EEE" },
+    ])
+    expect((svc as any).client.getShipmentImage).toHaveBeenCalledWith("JD123", {
+      typeCode: "commercial-invoice",
+      pickupYearAndMonth: "2026-08",
+    })
+  })
+
+  it("getFulfillmentDocuments prefers what is already stored on the fulfillment", async () => {
+    const svc = buildService()
+    const docs = await svc.getFulfillmentDocuments({
+      documents: [{ typeCode: "label", imageFormat: "PDF", content: "FFF" }],
+    })
+    expect(docs).toEqual([
+      { typeCode: "label", contentType: "pdf", content: "FFF" },
+    ])
+    expect((svc as any).client.getShipmentImage).not.toHaveBeenCalled()
+  })
+})
+
+describe("dhlDocumentTypeCode", () => {
+  it("maps invoice and label onto DHL's Get Image type codes", () => {
+    expect(dhlDocumentTypeCode("invoice")).toBe("commercial-invoice")
+    expect(dhlDocumentTypeCode("commercial-invoice")).toBe("commercial-invoice")
+    expect(dhlDocumentTypeCode("label")).toBe("waybill")
+    expect(dhlDocumentTypeCode("waybill")).toBe("waybill")
+    expect(dhlDocumentTypeCode("proforma")).toBe("dhl-issued-proforma-invoice")
+  })
+
+  it("defaults an unknown type to the waybill (every shipment has a label)", () => {
+    expect(dhlDocumentTypeCode("")).toBe("waybill")
+    expect(dhlDocumentTypeCode(undefined)).toBe("waybill")
+    expect(dhlDocumentTypeCode("gibberish")).toBe("waybill")
+  })
+})
+
+describe("dhlPickupYearMonth", () => {
+  it("formats an ISO date as YYYY-MM", () => {
+    expect(dhlPickupYearMonth("2026-08-10T10:00:00Z")).toBe("2026-08")
+    expect(dhlPickupYearMonth(new Date(Date.UTC(2026, 0, 15)))).toBe("2026-01")
+  })
+
+  it("returns undefined for an absent or unparseable value", () => {
+    expect(dhlPickupYearMonth(undefined)).toBeUndefined()
+    expect(dhlPickupYearMonth("")).toBeUndefined()
+    expect(dhlPickupYearMonth("not-a-date")).toBeUndefined()
+  })
+})

--- a/apps/backend/src/modules/shipping-providers/dhl/client.ts
+++ b/apps/backend/src/modules/shipping-providers/dhl/client.ts
@@ -1,11 +1,34 @@
 const PROD_BASE = "https://express.api.dhl.com/mydhlapi"
 const TEST_BASE = "https://express.api.dhl.com/mydhlapi/test"
+/** DHL's mock server — fixed test data, no account-authorization gating. */
+const MOCK_BASE = "https://api-mock.dhl.com/mydhlapi"
+
+/**
+ * Format a Date the way DHL's shipment/pickup schema demands:
+ * `2010-02-11T17:10:09 GMT+01:00` — NO `Z`, NO fractional seconds, an explicit
+ * `GMT` offset. `new Date().toISOString()` (`...T..:..Z`) is rejected by the
+ * test gateway with `#/plannedShippingDateAndTime is not well formatted`.
+ */
+export function dhlDateTime(date: Date = new Date()): string {
+  const pad = (n: number) => String(n).padStart(2, "0")
+  const offsetMin = -date.getTimezoneOffset() // minutes EAST of UTC
+  const sign = offsetMin >= 0 ? "+" : "-"
+  const abs = Math.abs(offsetMin)
+  return (
+    `${date.getFullYear()}-${pad(date.getMonth() + 1)}-${pad(date.getDate())}` +
+    `T${pad(date.getHours())}:${pad(date.getMinutes())}:${pad(date.getSeconds())}` +
+    ` GMT${sign}${pad(Math.floor(abs / 60))}:${pad(abs % 60)}`
+  )
+}
 
 export type DHLOptions = {
   api_key: string
   api_secret: string
   account_number?: string
+  /** Use the sandbox/test gateway (`/mydhlapi/test`). */
   sandbox?: boolean
+  /** Use DHL's mock server (fixed test data) — takes precedence over `sandbox`. */
+  mock?: boolean
   fetchImpl?: typeof fetch
 }
 
@@ -48,6 +71,15 @@ export type DHLRateParams = {
   is_customs_declarable?: boolean
 }
 
+/** How DHL estimates the tariff rate for a (usually partial) HS code. */
+export type DHLTariffRateType =
+  | "default_rate"
+  | "derived_rate"
+  | "highest_rate"
+  | "center_rate"
+  | "lowest_rate"
+  | "preferential_rate"
+
 export type DHLLandedCostParams = {
   shipper: DHLParty
   receiver: DHLParty
@@ -65,6 +97,15 @@ export type DHLLandedCostParams = {
     origin_country: string
     quantity: number
     unit_price: number
+    /** Net weight per unit in kg. */
+    weight: number
+    /**
+     * REQUIRED in practice when the HS code is partial (6-digit or less): the
+     * GTS calculator cannot estimate a ballpark duty without knowing which end
+     * of the range to quote. Defaults to `highest_rate` (over- rather than
+     * under-quote a liability).
+     */
+    estimated_tariff_rate_type?: DHLTariffRateType
   }>
 }
 
@@ -81,6 +122,27 @@ export type DHLCreateShipmentParams = {
   invoice_number?: string
 }
 
+export type DHLPickupParams = {
+  planned_pickup_date_and_time?: string
+  /** Latest time the location can dispatch (HH:MM). */
+  close_time?: string
+  location?: string
+  location_type?: "business" | "residence"
+  /** The party DHL collects FROM — required. */
+  shipper: DHLParty
+  receiver?: DHLParty
+  remark?: string
+  special_instructions?: Array<{ value: string; type_code?: string }>
+  shipments: Array<{
+    product_code: string
+    is_customs_declarable: boolean
+    packages: Array<{ weight: number; length?: number; width?: number; height?: number }>
+    shipment_tracking_number?: string
+    declared_value?: number
+    declared_value_currency?: string
+  }>
+}
+
 export class DHLClient {
   private baseUrl: string
   private authHeader: string
@@ -88,7 +150,11 @@ export class DHLClient {
   private fetchImpl: typeof fetch
 
   constructor(options: DHLOptions) {
-    this.baseUrl = options.sandbox ? TEST_BASE : PROD_BASE
+    this.baseUrl = options.mock
+      ? MOCK_BASE
+      : options.sandbox
+        ? TEST_BASE
+        : PROD_BASE
     this.authHeader = `Basic ${Buffer.from(`${options.api_key}:${options.api_secret}`).toString("base64")}`
     this.accountNumber = options.account_number || ""
     this.fetchImpl = options.fetchImpl || fetch
@@ -114,8 +180,25 @@ export class DHLClient {
       body = text
     }
     if (!res.ok) {
-      const detail =
-        typeof body === "string" ? body : body?.detail || body?.message || JSON.stringify(body)
+      const parts: string[] = []
+      const head =
+        typeof body === "string" ? body : body?.detail || body?.message || ""
+      if (head) parts.push(head)
+      // DHL 400/422 errors bury the actual field problems in `additionalDetails`
+      // (an array of strings or `{message}` objects). Without them, "Multiple
+      // problems found, see Additional Details" tells you nothing.
+      const additional = body?.additionalDetails
+      if (Array.isArray(additional)) {
+        for (const a of additional) {
+          if (typeof a === "string") parts.push(a)
+          else if (a?.message) parts.push(a.message)
+        }
+      }
+      const detail = parts.length
+        ? parts.join(" | ")
+        : typeof body === "string"
+          ? body
+          : JSON.stringify(body)
       throw new Error(`DHL ${path.split("?")[0]} failed (${res.status}): ${detail}`)
     }
     return body as T
@@ -245,6 +328,13 @@ export class DHLClient {
         unitPrice: item.unit_price,
         unitPriceCurrencyCode: params.currency_code,
         commodityCode: item.hs_code,
+        weight: item.weight,
+        weightUnitOfMeasurement: "metric",
+        // With a partial (≤6-digit) HS code the GTS calculator has no single
+        // duty figure — without this it fails with a misleading
+        // "NetWeight KGM MEASUREMENT VALUE IS MISSING". `highest_rate` is the
+        // conservative default: better to over-quote than under-quote a duty.
+        estimatedTariffRateType: item.estimated_tariff_rate_type || "highest_rate",
       })),
     }
     return this.request<any>(`/landed-cost`, {
@@ -257,7 +347,7 @@ export class DHLClient {
     const isCustomsDeclarable = payload.is_customs_declarable ?? false
 
     const body: Record<string, any> = {
-      plannedShippingDateAndTime: new Date().toISOString(),
+      plannedShippingDateAndTime: dhlDateTime(),
       pickup: { isRequested: false },
       productCode: payload.product_code || "P",
       accounts: [{ typeCode: "shipper", number: this.accountNumber }],
@@ -337,40 +427,120 @@ export class DHLClient {
     })
   }
 
-  async getShipment(shipmentTrackingNumber: string): Promise<any> {
+  /**
+   * Documents for a shipment — DHL's "Get Image" service returns the label,
+   * waybill and commercial/customs invoice it produced at creation, base64.
+   *
+   * `typeCode` is one of DHL's document types (`waybill`,
+   * `commercial-invoice`, `customs-entry`, `transport-accompanying-document`,
+   * `generic-entry-summary`, `dhl-issued-proforma-invoice`). `pickupYearAndMonth`
+   * (`YYYY-MM`) and an account number are REQUIRED by DHL to locate the images.
+   * There is NO `GET /shipments/{id}/documents` endpoint in the DHL Express API.
+   */
+  async getShipmentImage(
+    shipmentTrackingNumber: string,
+    opts: {
+      typeCode: string
+      shipperAccountNumber?: string
+      pickupYearAndMonth?: string
+      encodingFormat?: "pdf" | "tiff"
+      allInOnePDF?: boolean
+      compressedPackage?: boolean
+    }
+  ): Promise<any> {
+    const qs = new URLSearchParams({
+      typeCode: opts.typeCode,
+      shipperAccountNumber: opts.shipperAccountNumber || this.accountNumber,
+    })
+    if (opts.pickupYearAndMonth) qs.set("pickupYearAndMonth", opts.pickupYearAndMonth)
+    if (opts.encodingFormat) qs.set("encodingFormat", opts.encodingFormat)
+    if (opts.allInOnePDF !== undefined) qs.set("allInOnePDF", String(opts.allInOnePDF))
+    if (opts.compressedPackage !== undefined) qs.set("compressedPackage", String(opts.compressedPackage))
     return this.request<any>(
-      `/shipments/${encodeURIComponent(shipmentTrackingNumber)}`
+      `/shipments/${encodeURIComponent(shipmentTrackingNumber)}/get-image?${qs}`
     )
   }
 
-  async createPickup(payload: {
-    shipmentTrackingNumber: string
-    pickupLocation: {
-      name: string
-      address: DHLAddress
-      phone?: string
-      email?: string
-    }
-    planned_pickup_date_and_time?: string
-  }): Promise<any> {
-    const body = {
+  /**
+   * Book a pickup. Matches `supermodelIoLogisticsExpressPickupRequest`: `accounts`
+   * is an ARRAY (not a singular `account`), the collection party is
+   * `customerDetails.shipperDetails`, and the shipment(s) to collect live under
+   * `shipmentDetails[]` (which requires `productCode`, `isCustomsDeclarable`,
+   * `unitOfMeasurement` and `packages` even when the AWB is already known).
+   */
+  async createPickup(payload: DHLPickupParams): Promise<any> {
+    const body: Record<string, any> = {
       plannedPickupDateAndTime:
-        payload.planned_pickup_date_and_time || new Date().toISOString(),
-      shipmentTrackingNumbers: [payload.shipmentTrackingNumber],
-      account: { typeCode: "shipper", number: this.accountNumber },
-      pickupLocation: {
-        name: payload.pickupLocation.name,
-        phone: payload.pickupLocation.phone || "",
-        email: payload.pickupLocation.email || "",
-        address: {
-          addressLine1: payload.pickupLocation.address.line1,
-          cityName: payload.pickupLocation.address.city,
-          postalCode: payload.pickupLocation.address.postal_code,
-          countryCode: payload.pickupLocation.address.country_code,
+        payload.planned_pickup_date_and_time || dhlDateTime(),
+      accounts: [{ typeCode: "shipper", number: this.accountNumber }],
+      customerDetails: {
+        shipperDetails: {
+          postalAddress: {
+            addressLine1: payload.shipper.address.line1,
+            cityName: payload.shipper.address.city,
+            postalCode: payload.shipper.address.postal_code,
+            countryCode: payload.shipper.address.country_code,
+          },
+          contactInformation: {
+            phone: payload.shipper.phone || "",
+            email: payload.shipper.email || "",
+            companyName: payload.shipper.company_name || payload.shipper.name,
+            fullName: payload.shipper.name,
+          },
         },
       },
-      pickupDetails: { localCutoffDateAndTime: payload.planned_pickup_date_and_time || new Date().toISOString() },
+      shipmentDetails: payload.shipments.map((s) => {
+        const detail: Record<string, any> = {
+          productCode: s.product_code,
+          isCustomsDeclarable: s.is_customs_declarable,
+          unitOfMeasurement: "metric",
+          packages: s.packages.map((p) => ({
+            weight: p.weight,
+            dimensions: {
+              length: p.length ?? 30,
+              width: p.width ?? 20,
+              height: p.height ?? 10,
+            },
+          })),
+        }
+        if (s.shipment_tracking_number) {
+          detail.shipmentTrackingNumber = s.shipment_tracking_number
+        }
+        if (s.declared_value !== undefined) {
+          detail.declaredValue = s.declared_value
+          detail.declaredValueCurrency = s.declared_value_currency || "EUR"
+        }
+        return detail
+      }),
     }
+
+    if (payload.close_time) body.closeTime = payload.close_time
+    if (payload.location) body.location = payload.location
+    if (payload.location_type) body.locationType = payload.location_type
+    if (payload.remark) body.remark = payload.remark
+    if (payload.receiver) {
+      body.customerDetails.receiverDetails = {
+        postalAddress: {
+          addressLine1: payload.receiver.address.line1,
+          cityName: payload.receiver.address.city,
+          postalCode: payload.receiver.address.postal_code,
+          countryCode: payload.receiver.address.country_code,
+        },
+        contactInformation: {
+          phone: payload.receiver.phone || "",
+          email: payload.receiver.email || "",
+          companyName: payload.receiver.company_name || payload.receiver.name,
+          fullName: payload.receiver.name,
+        },
+      }
+    }
+    if (payload.special_instructions?.length) {
+      body.specialInstructions = payload.special_instructions.map((si) => ({
+        value: si.value,
+        ...(si.type_code ? { typeCode: si.type_code } : {}),
+      }))
+    }
+
     return this.request<any>(`/pickups`, {
       method: "POST",
       body: JSON.stringify(body),
@@ -382,4 +552,40 @@ export class DHLClient {
       `/tracking?shipmentTrackingNumber=${encodeURIComponent(trackingNumber)}`
     )
   }
+}
+
+/** A DHL document reduced to what Medusa can actually download/render. */
+export type DHLDocument = {
+  typeCode: string
+  /** The document's format ("pdf", "tiff", "png", "zip") — DHL's own vocabulary. */
+  contentType: string
+  /** base64 (DHL returns label/invoice content as base64). */
+  content: string
+}
+
+/**
+ * Normalize DHL's document payloads onto one flat shape.
+ *
+ * DHL returns documents in different envelopes depending on the call — the
+ * create-shipment response carries a bare `documents[]` (fields `imageFormat`,
+ * `typeCode`, `content`), while the "Get Image" service returns
+ * `{ documents: [{ typeCode, encodingFormat, content }] }`. The FORMAT field
+ * name differs per call (`imageFormat` vs `encodingFormat`), so both are read.
+ * Rows with no base64 `content` are dropped — a document reference with nothing
+ * to download is worse than an empty list. Pure & exported for unit testing.
+ */
+export function normalizeDhlDocuments(res: any): DHLDocument[] {
+  const docs = Array.isArray(res)
+    ? res
+    : res?.documents ?? res?.shipments?.[0]?.documents ?? []
+  if (!Array.isArray(docs)) return []
+  return docs
+    .filter((d: any) => d && typeof d.content === "string" && d.content.length)
+    .map((d: any) => ({
+      typeCode: String(d.typeCode || d.documentType || ""),
+      contentType: String(
+        d.contentType || d.encodingFormat || d.imageFormat || "pdf"
+      ).toLowerCase(),
+      content: d.content,
+    }))
 }

--- a/apps/backend/src/modules/shipping-providers/dhl/service.ts
+++ b/apps/backend/src/modules/shipping-providers/dhl/service.ts
@@ -10,8 +10,9 @@ import {
   CreateShippingOptionDTO,
   Logger,
 } from "@medusajs/framework/types"
-import { DHLClient, DHLOptions } from "./client"
+import { DHLClient, DHLOptions, normalizeDhlDocuments } from "./client"
 import { declaredValueForShipment } from "../delhivery/declared-value"
+import { FlatFallbackConfig, resolveFlatFallbackAmount } from "../shiprocket/flat-fallback"
 
 type InjectedDeps = { logger: Logger }
 
@@ -26,16 +27,54 @@ function hsCodeFor(orderItem: any): string {
   return metadata.hs_code || metadata.hsCode || metadata.HSCode || DEFAULT_HS_CODE
 }
 
+/**
+ * Map a Medusa document type onto DHL's "Get Image" `typeCode` enum
+ * (`waybill`, `commercial-invoice`, `customs-entry`,
+ * `transport-accompanying-document`, `generic-entry-summary`,
+ * `dhl-issued-proforma-invoice`). Unknown types default to `waybill` (the label),
+ * which is the one document every shipment has.
+ */
+export function dhlDocumentTypeCode(documentType?: string): string {
+  const t = String(documentType || "").toLowerCase()
+  if (/proforma/.test(t)) return "dhl-issued-proforma-invoice"
+  if (/(invoice|commercial)/.test(t)) return "commercial-invoice"
+  if (/(label|waybill)/.test(t)) return "waybill"
+  if (/customs/.test(t)) return "customs-entry"
+  if (/transport/.test(t)) return "transport-accompanying-document"
+  if (/summary/.test(t)) return "generic-entry-summary"
+  return "waybill"
+}
+
+/**
+ * DHL's "Get Image" needs the pickup month (`YYYY-MM`) to locate a document.
+ * Read it from the fulfillment's timestamps, best-effort; the caller falls back
+ * to the current month when none is available (a wrong month is a 404, caught
+ * upstream — never a throw).
+ */
+export function dhlPickupYearMonth(value?: unknown): string | undefined {
+  if (value === null || value === undefined || value === "") return undefined
+  const d = value instanceof Date ? value : new Date(value as any)
+  if (Number.isNaN(d.getTime())) return undefined
+  const pad = (n: number) => String(n).padStart(2, "0")
+  return `${d.getFullYear()}-${pad(d.getMonth() + 1)}`
+}
+
 class DHLExpressFulfillmentService extends AbstractFulfillmentProviderService {
   static identifier = "dhl-express"
 
   protected client: DHLClient
   protected logger: Logger
+  /** What an unquotable lane costs. See `shiprocket/flat-fallback.ts`. */
+  protected fallbackConfig: FlatFallbackConfig
 
-  constructor({ logger }: InjectedDeps, options: DHLOptions) {
+  constructor({ logger }: InjectedDeps, options: DHLOptions & FlatFallbackConfig) {
     super()
     this.logger = logger
     this.client = new DHLClient(options)
+    this.fallbackConfig = {
+      flat_fallback_amounts: options?.flat_fallback_amounts,
+      flat_fallback_amount: options?.flat_fallback_amount,
+    }
   }
 
   async getFulfillmentOptions(): Promise<FulfillmentOption[]> {
@@ -96,10 +135,12 @@ class DHLExpressFulfillmentService extends AbstractFulfillmentProviderService {
    *   `from_location` (the stock location shipping the items).
    *
    * Price is resolved through DHL's `/rates` endpoint for the matched
-   * product, billing the customer-billed currency (`BILLC`). Failures are
-   * caught and fall back to a zero amount rather than throwing: a throw
-   * blocks the cart operation that triggered the calculation (adding the
-   * method or refreshing the cart) and stops checkout.
+   * product, billing the customer-billed currency (`BILLC`). A lane DHL will
+   * not quote — an empty product list, no matched product, no `BILLC` price,
+   * or a carrier/network error — resolves to the flat fallback rather than
+   * throwing or answering `0` (see `shiprocket/flat-fallback.ts` for why a
+   * silent zero is the bug, and why a throw here is worse than what it
+   * replaced: it would take the whole shipping options listing with it).
    */
   async calculatePrice(
     optionData: CalculateShippingOptionPriceDTO["optionData"],
@@ -109,6 +150,15 @@ class DHLExpressFulfillmentService extends AbstractFulfillmentProviderService {
     const from = context.from_location?.address
     const to = context.shipping_address
     const items = context.items ?? []
+    const destinationCountry = String(to?.country_code || "").toUpperCase()
+    /**
+     * 🔑 `calculated_amount` is denominated in the CART's currency, so the
+     * currency decides whether a fallback figure means anything at all. Read
+     * best-effort; when absent the resolver skips its per-currency map rather
+     * than guessing between €35 and ₹3200.
+     */
+    const currencyCode =
+      (context as any)?.currency_code ?? (context as any)?.cart?.currency_code ?? null
 
     try {
       const totalWeightKg = this.weightInKg(items as any[])
@@ -132,12 +182,59 @@ class DHLExpressFulfillmentService extends AbstractFulfillmentProviderService {
       const billc = (match?.totalPrice || []).find(
         (p: any) => p.currencyType === "BILLC"
       )
-      const amount = billc?.price ?? match?.totalPrice?.[0]?.price ?? 0
+      const amount = billc?.price ?? match?.totalPrice?.[0]?.price
 
-      return { calculated_amount: amount, is_calculated_price_tax_inclusive: true }
+      if (!Number.isFinite(Number(amount))) {
+        return this.flatFallback(
+          destinationCountry,
+          `DHL returned no rate for ${productCode || "any product"} to ${to?.city || ""} ${to?.postal_code || ""} ${to?.country_code || ""}`,
+          optionData,
+          currencyCode
+        )
+      }
+
+      return { calculated_amount: Number(amount), is_calculated_price_tax_inclusive: true }
     } catch (e: any) {
       this.logger.error(`DHL calculatePrice error: ${e.message}`)
-      return { calculated_amount: 0, is_calculated_price_tax_inclusive: false }
+      return this.flatFallback(destinationCountry, e.message, optionData, currencyCode)
+    }
+  }
+
+  /**
+   * The flat rate for a lane DHL would not quote.
+   *
+   * The `reason` is logged rather than returned: the buyer must not see a
+   * carrier's internal complaint, but an operator needs to know the lane fell
+   * back rather than quoting live — otherwise a carrier outage looks exactly
+   * like normal pricing. 🔑 That log line is the ONLY thing separating this from
+   * the silent zero it replaced, so it must never be dropped to reduce noise.
+   */
+  private flatFallback(
+    destinationCountry: string,
+    reason: string,
+    optionData?: Record<string, unknown>,
+    currencyCode?: string | null
+  ): CalculatedShippingOptionPrice {
+    const { amount, reason: unconfigured } = resolveFlatFallbackAmount(
+      this.fallbackConfig,
+      destinationCountry,
+      optionData,
+      currencyCode
+    )
+
+    this.logger.warn(
+      `[dhl-express] falling back to the flat rate ${amount} ${
+        currencyCode ? String(currencyCode).toUpperCase() : "(currency unknown)"
+      } for ${destinationCountry || "IN"} — ${reason}${
+        unconfigured ? ` (${unconfigured})` : ""
+      }`
+    )
+
+    return {
+      calculated_amount: amount!,
+      // A flat rate is a figure WE set, so it carries no carrier tax treatment
+      // to inherit. Claiming tax-inclusive here would quietly shrink it.
+      is_calculated_price_tax_inclusive: false,
     }
   }
 
@@ -239,13 +336,83 @@ class DHLExpressFulfillmentService extends AbstractFulfillmentProviderService {
     }
   }
 
+  /**
+   * Cancel a shipment with DHL Express.
+   *
+   * Deliberately a no-op: DHL's MyDHLAPI exposes **no programmatic cancel**
+   * endpoint. A cancellation is a manual action with DHL customer service (via
+   * the shipment's tracking number), so the honest behaviour is to record the
+   * request in the log and return — inventing an API call that doesn't exist,
+   * or throwing, would break the cancel workflow for nothing. The log line
+   * carries the tracking number so an operator chasing a cancel has the
+   * reference DHL needs.
+   */
   async cancelFulfillment(fulfillment: Record<string, any>): Promise<any> {
-    this.logger.info(`DHL cancellation requested for ${fulfillment.data?.tracking_number}`)
+    this.logger.info(`DHL cancellation requested for ${fulfillment.data?.tracking_number}; DHL Express has no API cancel — raise with DHL customer service`)
     return {}
   }
 
+  /**
+   * Return fulfillment — stubbed.
+   *
+   * DHL has no first-class "return this shipment" API op: a return is a NEW
+   * outbound shipment booked the normal way (the receiver becomes the shipper
+   * on a fresh waybill), which is `createFulfillment` again, not a separate
+   * method. Until a return flow exists that drives it, this returns the same
+   * carrier-marked stub Shiprocket uses, so a return fulfillment can at least
+   * be recorded without a carrier call.
+   */
   async createReturnFulfillment(fulfillment: Record<string, any>): Promise<CreateFulfillmentResult> {
     return { data: { carrier: "dhl-express", type: "return" }, labels: [] }
+  }
+
+  /**
+   * Documents for a fulfillment — the label and commercial/customs invoice DHL
+   * produced at create time. Prefer what's already stored on the fulfillment
+   * (the createShipment response is spread onto `data`); otherwise fetch fresh
+   * by tracking number.
+   */
+  async getFulfillmentDocuments(data: Record<string, any>): Promise<any> {
+    const stored = normalizeDhlDocuments(data?.documents)
+    if (stored.length) return stored
+    return this.retrieveDocuments(data)
+  }
+
+  /**
+   * Retrieve documents of a specific type for a fulfillment.
+   *
+   * The base `AbstractFulfillmentProviderService` throws from this method, so
+   * overriding it is required, not optional. Maps Medusa's `documentType`
+   * ("label", "invoice", …) onto DHL's "Get Image" service (`/shipments/{id}/get-image`)
+   * and returns the normalized rows; a carrier/network failure (or a stale pickup
+   * month) degrades to `[]` rather than throwing, so a document fetch can't wedge
+   * the caller.
+   */
+  async retrieveDocuments(
+    fulfillmentData: Record<string, any>,
+    documentType?: string
+  ): Promise<any> {
+    const trackingNumber =
+      fulfillmentData?.tracking_number ||
+      fulfillmentData?.shipment_id ||
+      fulfillmentData?.awb_number ||
+      ""
+    if (!trackingNumber) return []
+    try {
+      const res = await this.client.getShipmentImage(trackingNumber, {
+        typeCode: dhlDocumentTypeCode(documentType),
+        pickupYearAndMonth:
+          dhlPickupYearMonth(
+            fulfillmentData?.shipped_at ??
+              fulfillmentData?.pickup_at ??
+              fulfillmentData?.created_at
+          ) || new Date().toISOString().slice(0, 7),
+      })
+      return normalizeDhlDocuments(res)
+    } catch (e: any) {
+      this.logger.warn(`DHL document retrieval failed for ${trackingNumber}: ${e.message}`)
+      return []
+    }
   }
 
   /** Cart items carry variant weight (grams) → billable weight in kg. */


### PR DESCRIPTION
## Summary

Completes the DHL Express provider follow-ups from #1641 and corrects the client against the official OpenAPI spec (`dpdhl-express-api-3.3.1.yaml`), verified live against both the sandbox and DHL's mock server.

## #1641 follow-ups

- **Flat fallback** — `calculatePrice` no longer returns `0` on an unquotable lane. It reuses Shiprocket's `resolveFlatFallbackAmount` (currency-aware, logged), wired via `DHL_FLAT_FALLBACK_AMOUNTS` / `DHL_FLAT_FALLBACK_AMOUNT`.
- **`cancelFulfillment` / `createReturnFulfillment` documented** — MyDHLAPI has no cancel/return endpoint (confirmed against the spec); both are now documented no-op/stub rather than unexplained.
- **Unit tests** — new `client.unit.spec.ts` + `service.unit.spec.ts` (33 tests).

## Spec corrections found via live integration testing

- **Datetime format** — `new Date().toISOString()` is rejected (422); added `dhlDateTime()` → `YYYY-MM-DDTHH:mm:ss GMT±HH:MM`.
- **Landed-cost** — a partial HS code needs `estimatedTariffRateType` (GTS otherwise 400s with a misleading "NetWeight … MISSING"); added per-line `weight` + `estimatedTariffRateType` (default `highest_rate`).
- **Document retrieval** — `getShipmentDocuments` hit a nonexistent `/documents` endpoint; repointed to `/shipments/{id}/get-image` and normalized the differing `imageFormat`/`encodingFormat` fields. Removed the nonexistent `GET /shipments/{id}` (`getShipment`).
- **`createPickup`** — was sending a singular `account` + `pickupLocation` + `shipmentTrackingNumbers`, none of which exist; rewritten to `accounts[]` + `customerDetails.shipperDetails` + `shipmentDetails[]`.
- **Mock server** — added `mock` option on `DHLOptions` (mock > sandbox > prod); `https://api-mock.dhl.com/mydhlapi` exercises the full flow incl. `createShipment`.

## Verification

- 33 unit tests passing; typecheck clean; prod-config parity green.
- Live sandbox: `addressValidate`, `getProducts`, `getRates` (BILLC), `landedCost` all pass.
- Live mock: full flow incl. `createShipment` (label) and `createPickup` (201).

Addresses #1641.
