### PR TITLE
feat(ops): report where the two records of a delivery disagree (#1613)

### DIFF
--- a/apps/backend/integration-tests/http/ops-maintenance-jobs.spec.ts
+++ b/apps/backend/integration-tests/http/ops-maintenance-jobs.spec.ts
@@ -119,6 +119,35 @@ setupSharedTestSuite(() => {
       )
     })
 
+    /**
+     * #1613 — the receipts audit. Registered AND reachable, and report-only in
+     * the strong sense: `dry_run: false` must still leave `applied` false,
+     * because the job has no write path at all. A job whose safety rests on a
+     * caller passing dry_run is one keystroke from writing.
+     */
+    it("POST audit-inventory-receipt-drift changes nothing even with dry_run=false", async () => {
+      const res = await api.post(
+        "/admin/ops/maintenance-jobs/audit-inventory-receipt-drift/run",
+        { dry_run: false, params: { limit: 50 } },
+        adminHeaders
+      )
+      expect(res.status).toBe(200)
+      expect(res.data.result.dry_run).toBe(false)
+      expect(res.data.result.applied).toBe(false)
+      expect(res.data.result.summary).toContain("Reports only")
+      expect(Array.isArray(res.data.result.changes)).toBe(true)
+    })
+
+    it("POST audit-inventory-receipt-drift 404s on an unknown order rather than reporting a clean scan", async () => {
+      await expect(
+        api.post(
+          "/admin/ops/maintenance-jobs/audit-inventory-receipt-drift/run",
+          { dry_run: true, params: { order_id: "inv_order_does_not_exist" } },
+          adminHeaders
+        )
+      ).rejects.toMatchObject({ response: { status: 404 } })
+    })
+
     it("GET lists the backfill-finished-run-consumption job (#697)", async () => {
       const res = await api.get("/admin/ops/maintenance-jobs", adminHeaders)
       expect(res.status).toBe(200)

--- a/apps/backend/src/api/admin/ops/maintenance-jobs/audit-inventory-receipt-drift-job.ts
+++ b/apps/backend/src/api/admin/ops/maintenance-jobs/audit-inventory-receipt-drift-job.ts
@@ -1,0 +1,201 @@
+import { ContainerRegistrationKeys, MedusaError } from "@medusajs/framework/utils"
+import { z } from "zod"
+
+import {
+  reconcileOrderReceipts,
+  type OrderReconciliation,
+} from "../../../../workflows/inventory_orders/lib/receipt-reconciliation"
+import type {
+  MaintenanceChange,
+  MaintenanceJob,
+  MaintenanceJobResult,
+} from "./registry"
+
+export const MAX_RECEIPT_AUDIT_SCAN = 1000
+
+const paramsSchema = z.object({
+  order_id: z.string().optional(),
+  limit: z.coerce
+    .number()
+    .int()
+    .positive()
+    .max(MAX_RECEIPT_AUDIT_SCAN, `limit cannot exceed ${MAX_RECEIPT_AUDIT_SCAN}`)
+    .optional(),
+})
+
+const money = (value: number): string =>
+  `₹${Math.abs(value).toLocaleString("en-IN", { maximumFractionDigits: 2 })}`
+
+/**
+ * Where the two records of a delivery disagree, and what that is worth.
+ *
+ * ## The dual write
+ *
+ * `partner-complete-inventory-order` writes every delivery twice: as typed
+ * `line_fulfillments` rows, and into `metadata.partner_delivered_lines` /
+ * `metadata.partner_delivery_history`. The typed rows GOVERN — the workflow's
+ * own over-delivery guard computes `remaining` from them.
+ *
+ * On `inv_order_01K36TE2WB5BQR1MS6KESXP7Q3` they disagree by ₹4,050: 69.5 typed
+ * units against 59.3 in the blob, including a whole 10-unit receipt (₹4,000)
+ * the blob never recorded.
+ *
+ * ## 🔴 Why this is more than a reporting problem
+ *
+ * `partner_delivered_lines` is OVERWRITTEN by the partner path and APPENDED to
+ * by the admin path — one key, two writers, two meanings — and two live readers
+ * move stock based on it:
+ *
+ *  - `computeAdminDeliveryPosting` posts `ordered − already`. Where the blob
+ *    understates, an admin pressing Deliver posts stock for goods already
+ *    received. `admin_would_overpost` measures exactly that, per line.
+ *  - `cancel-inventory-order` reverses stock from the same key.
+ *
+ * ## 🔴 Why it writes nothing, ever
+ *
+ * Two reasons, both from the data rather than from caution:
+ *
+ *  1. The sources disagree in BOTH directions. Where the TYPED side is the one
+ *     missing an entry, switching a reader to it makes `already` smaller and the
+ *     over-posting worse. A blind union or a blind switch is not a repair.
+ *  2. `metadata.reversal_note` on the order above reads "Reversed 9 incorrect
+ *     fulfillments on 2026-02-28 — lines were auto-filled by UI bug", and rows
+ *     sit on BOTH sides of that reversal. Which are corrected re-entries is not
+ *     decidable from the record. Those orders need a human, and they are
+ *     reported separately rather than folded into a total.
+ *
+ * So `dry_run: false` changes nothing here either. `applied` is always false.
+ */
+export const auditInventoryReceiptDriftJob: MaintenanceJob = {
+  id: "audit-inventory-receipt-drift",
+  label: "Find inventory orders whose typed receipts disagree with the metadata blob",
+  description:
+    `Compare the typed line_fulfillments receipts on every inventory order against metadata.partner_delivered_lines and metadata.partner_delivery_history, and report where they disagree, what the gap is worth at the line's per-unit price, and how much stock an admin "Deliver" would post today for goods already received. The typed rows govern — the partner workflow's own over-delivery guard reads them — but partner_delivered_lines is OVERWRITTEN on each partner submission while the admin path APPENDS to it, so the blob routinely understates (₹4,050 on inv_order_01K36TE2WB5BQR1MS6KESXP7Q3). 🔴 REPORTS ONLY, ALWAYS: dry_run=false changes nothing. The two sources disagree in BOTH directions, so a blind switch or union is not a repair; and orders carrying a metadata.reversal_note are reported separately because which of their rows are corrected re-entries is not decidable from the record. Scans up to 'limit' orders per call (default 200, max ${MAX_RECEIPT_AUDIT_SCAN}).`,
+  params: [
+    {
+      name: "order_id",
+      type: "string",
+      required: false,
+      description: "Restrict to one inventory order (default: all)",
+    },
+    {
+      name: "limit",
+      type: "number",
+      required: false,
+      description: `Max orders to scan in one call (default 200, max ${MAX_RECEIPT_AUDIT_SCAN})`,
+    },
+  ],
+  run: async (container, { dry_run, params }): Promise<MaintenanceJobResult> => {
+    const parsed = paramsSchema.safeParse(params)
+    if (!parsed.success) {
+      throw new MedusaError(
+        MedusaError.Types.INVALID_DATA,
+        parsed.error.issues.map((i) => i.message).join("; ")
+      )
+    }
+    const { order_id, limit } = parsed.data
+    const take = limit ?? 200
+
+    const logger: any = container.resolve(ContainerRegistrationKeys.LOGGER)
+    const query: any = container.resolve(ContainerRegistrationKeys.QUERY)
+
+    const { data: orders } = await query.graph({
+      entity: "inventory_orders",
+      fields: [
+        "id",
+        "status",
+        "total_price",
+        "metadata",
+        "orderlines.id",
+        "orderlines.quantity",
+        "orderlines.price",
+        "orderlines.material_name",
+        "orderlines.line_fulfillments.quantity_delta",
+      ],
+      ...(order_id ? { filters: { id: [order_id] } } : {}),
+      pagination: { take, skip: 0 },
+    })
+
+    if (order_id && !(orders || []).length) {
+      throw new MedusaError(
+        MedusaError.Types.NOT_FOUND,
+        `Inventory order ${order_id} not found`
+      )
+    }
+
+    const changes: MaintenanceChange[] = []
+    let disagreeing = 0
+    let undecidable = 0
+    let driftValue = 0
+    let overpost = 0
+
+    for (const order of (orders || []) as any[]) {
+      let result: OrderReconciliation
+      try {
+        result = reconcileOrderReceipts({
+          orderlines: order.orderlines,
+          metadata: order.metadata,
+        })
+      } catch (e: any) {
+        logger?.warn?.(
+          `[audit-inventory-receipt-drift] ${order.id}: ${e?.message ?? e}`
+        )
+        continue
+      }
+
+      if (!result.disagrees) continue
+
+      disagreeing++
+      driftValue += result.drift_value
+      overpost += result.admin_would_overpost
+      if (result.undecidable) undecidable++
+
+      /**
+       * Every disagreeing LINE is listed, not just the order total. A report
+       * that says "this order is out by ₹4,050" cannot be checked without
+       * re-deriving it; one that names the line, both figures and the rate can
+       * be argued with before anybody acts on it.
+       */
+      for (const line of result.lines.filter((l) => l.drift !== 0)) {
+        changes.push({
+          entity: "inventory_order_line",
+          id: line.line_id,
+          field: "line_fulfillments vs metadata.partner_delivered_lines",
+          before: { metadata_blob: line.blob, history: line.history },
+          after: { typed_receipts: line.typed },
+          note:
+            `order ${order.id} (${order.status})` +
+            ` · ordered ${line.ordered} @ ${money(line.unit_price)}/unit` +
+            ` · typed ${line.typed} vs blob ${line.blob}` +
+            ` · blob ${line.drift > 0 ? "understates" : "overstates"} by ${Math.abs(line.drift)} units` +
+            ` (${money(line.drift_value)})` +
+            (line.admin_would_overpost > 0
+              ? ` · 🔴 an admin Deliver would post ${line.admin_would_overpost} units already received`
+              : "") +
+            (result.undecidable
+              ? ` · ⚠️ UNDECIDABLE: ${result.reversal_note}`
+              : ""),
+        })
+      }
+    }
+
+    const summary =
+      `Scanned ${(orders || []).length} inventory order(s); ` +
+      `${disagreeing} disagree between the typed receipts and the metadata blob. ` +
+      `Net ${driftValue >= 0 ? "understated" : "overstated"} by ${money(driftValue)}. ` +
+      `An admin Deliver would post ${overpost} unit(s) of already-received stock across them. ` +
+      (undecidable
+        ? `⚠️ ${undecidable} carry a reversal_note and are NOT decidable from the record — they need a human. `
+        : "") +
+      `Reports only; nothing was changed.`
+
+    return {
+      job_id: "audit-inventory-receipt-drift",
+      dry_run,
+      // Never true: this job has no write path at all.
+      applied: false,
+      summary,
+      changes,
+    }
+  },
+}

--- a/apps/backend/src/api/admin/ops/maintenance-jobs/registry.ts
+++ b/apps/backend/src/api/admin/ops/maintenance-jobs/registry.ts
@@ -84,6 +84,7 @@ import { backfillStoreCurrenciesJob } from "./backfill-store-currencies-job"
 import { backfillShiprocketShippingOptionsJob } from "./backfill-shiprocket-shipping-options-job"
 import { backfillFreightOptionDataJob } from "./backfill-freight-option-data-job"
 import { recoverWhatsappMediaJob } from "./recover-whatsapp-media-job"
+import { auditInventoryReceiptDriftJob } from "./audit-inventory-receipt-drift-job"
 import { auditPartnerPayoutQuantityJob } from "./audit-partner-payout-quantity-job"
 import { capFreeShippingBandJob } from "./cap-free-shipping-band-job"
 import { deleteOrphanStoreJob } from "./delete-orphan-store-job"
@@ -5854,6 +5855,7 @@ export const MAINTENANCE_JOBS: MaintenanceJob[] = [
   backfillShiprocketShippingOptionsJob,
   backfillFreightOptionDataJob,
   recoverWhatsappMediaJob,
+  auditInventoryReceiptDriftJob,
   auditPartnerPayoutQuantityJob,
   capFreeShippingBandJob,
   deleteOrphanStoreJob,

--- a/apps/backend/src/workflows/inventory_orders/__tests__/receipt-reconciliation.unit.spec.ts
+++ b/apps/backend/src/workflows/inventory_orders/__tests__/receipt-reconciliation.unit.spec.ts
@@ -1,0 +1,202 @@
+import {
+  aggregateHistory,
+  aggregateRecords,
+  reconcileOrderReceipts,
+} from "../lib/receipt-reconciliation"
+
+/**
+ * Built on the real numbers from `inv_order_01K36TE2WB5BQR1MS6KESXP7Q3`
+ * (hrhandloom, Partial, 244.5 units, ₹88,885 ordered), as recorded in #1613 —
+ * a fixture tidier than that reality would certify the wrong arithmetic.
+ *
+ * | line          | ordered | typed      | blob      | rate |
+ * |---------------|---------|------------|-----------|------|
+ * | 01K36TE3TR…   | 16      | 16 (10+6)  | only the 6| 400  |
+ * | 01K36TE425…   | 31      | 10         | 10        | 430  |
+ * | 01K36TE4GX…   | 22      | 10.5       | 10.5      | 380  |
+ * | 01K36TE4RB…   | 21      | 21         | 21        | 380  |
+ * | 01K36TE56Y…   | 50      | 12         | 11.8      | 250  |
+ *
+ * Typed 69.5 units / ₹25,670 · blob 59.3 units / ₹21,620 → ₹4,050 understated.
+ */
+const realOrder = {
+  orderlines: [
+    {
+      id: "01K36TE3TR",
+      quantity: 16,
+      price: 400,
+      material_name: null,
+      // Two receipts. The blob kept only the second.
+      line_fulfillments: [{ quantity_delta: 10 }, { quantity_delta: 6 }],
+    },
+    {
+      id: "01K36TE425",
+      quantity: 31,
+      price: 430,
+      line_fulfillments: [{ quantity_delta: 10 }],
+    },
+    {
+      id: "01K36TE4GX",
+      quantity: 22,
+      price: 380,
+      line_fulfillments: [{ quantity_delta: 10.5 }],
+    },
+    {
+      id: "01K36TE4RB",
+      quantity: 21,
+      price: 380,
+      line_fulfillments: [{ quantity_delta: 21 }],
+    },
+    {
+      id: "01K36TE56Y",
+      quantity: 50,
+      price: 250,
+      line_fulfillments: [{ quantity_delta: 12 }],
+    },
+  ],
+  metadata: {
+    partner_delivered_lines: [
+      { order_line_id: "01K36TE3TR", quantity: 6 },
+      { order_line_id: "01K36TE425", quantity: 10 },
+      { order_line_id: "01K36TE4GX", quantity: 10.5 },
+      { order_line_id: "01K36TE4RB", quantity: 21 },
+      { order_line_id: "01K36TE56Y", quantity: 11.8 },
+    ],
+  },
+}
+
+describe("reconcileOrderReceipts", () => {
+  it("reproduces the ₹4,050 understatement on the real order", () => {
+    const result = reconcileOrderReceipts(realOrder)
+
+    expect(result.typed_total_units).toBeCloseTo(69.5, 5)
+    expect(result.blob_total_units).toBeCloseTo(59.3, 5)
+    expect(result.disagrees).toBe(true)
+    // 10 units × ₹400 = 4,000, plus 0.2 × ₹250 = 50.
+    expect(result.drift_value).toBeCloseTo(4050, 5)
+  })
+
+  it("names the receipt the blob never recorded", () => {
+    const result = reconcileOrderReceipts(realOrder)
+    const line = result.lines.find((l) => l.line_id === "01K36TE3TR")!
+
+    expect(line.typed).toBe(16)
+    expect(line.blob).toBe(6)
+    expect(line.drift).toBe(10)
+    expect(line.drift_value).toBe(4000)
+  })
+
+  /**
+   * 🔴 The load-bearing case, and the reason this is not merely a reporting
+   * problem. `computeAdminDeliveryPosting` posts `ordered − already` with
+   * `already` read from the blob. On this line that is 16 − 6 = 10 units of
+   * stock posted for goods already received, against a correct 16 − 16 = 0.
+   */
+  it("measures the stock an admin Deliver would post that was already received", () => {
+    const result = reconcileOrderReceipts(realOrder)
+    const line = result.lines.find((l) => l.line_id === "01K36TE3TR")!
+
+    expect(line.admin_would_overpost).toBe(10)
+    // 0.2 on the last line as well: 50−11.8 = 38.2 posted against 50−12 = 38.
+    expect(result.admin_would_overpost).toBeCloseTo(10.2, 5)
+  })
+
+  /**
+   * ⚠️ `quantity_delta` is a DELTA, and `adjust`/`correction` events can be
+   * negative. Reading the latest row, or counting rows, gets this wrong.
+   */
+  it("sums deltas rather than taking the last one, and honours negatives", () => {
+    const result = reconcileOrderReceipts({
+      orderlines: [
+        {
+          id: "line_1",
+          quantity: 10,
+          price: 100,
+          line_fulfillments: [
+            { quantity_delta: 8 },
+            { quantity_delta: -3 },
+            { quantity_delta: 1 },
+          ],
+        },
+      ],
+      metadata: { partner_delivered_lines: [{ order_line_id: "line_1", quantity: 6 }] },
+    })
+
+    expect(result.lines[0].typed).toBe(6)
+    expect(result.disagrees).toBe(false)
+  })
+
+  /**
+   * The two sources disagree in BOTH directions, which is exactly why no
+   * reader can simply be switched to the typed rows: where the typed side is
+   * the one missing an entry, `already` gets SMALLER and the over-posting gets
+   * worse. Measured, never corrected.
+   */
+  it("reports a blob that OVERstates as drift, with no over-posting exposure", () => {
+    const result = reconcileOrderReceipts({
+      orderlines: [
+        {
+          id: "line_1",
+          quantity: 10,
+          price: 100,
+          line_fulfillments: [{ quantity_delta: 4 }],
+        },
+      ],
+      metadata: { partner_delivered_lines: [{ order_line_id: "line_1", quantity: 9 }] },
+    })
+
+    expect(result.lines[0].drift).toBe(-5)
+    expect(result.lines[0].drift_value).toBe(-500)
+    // The admin path would post LESS than it should here, not more.
+    expect(result.admin_would_overpost).toBe(0)
+  })
+
+  it("flags an order carrying a reversal note as undecidable", () => {
+    const result = reconcileOrderReceipts({
+      ...realOrder,
+      metadata: {
+        ...realOrder.metadata,
+        reversal_note:
+          "Reversed 9 incorrect fulfillments on 2026-02-28 — lines were auto-filled by UI bug",
+      },
+    })
+
+    expect(result.undecidable).toBe(true)
+    expect(result.reversal_note).toContain("Reversed 9 incorrect fulfillments")
+  })
+
+  it("reports agreeing lines too, so 'agrees at zero' is distinguishable from unexamined", () => {
+    const result = reconcileOrderReceipts({
+      orderlines: [{ id: "line_1", quantity: 10, price: 100, line_fulfillments: [] }],
+      metadata: {},
+    })
+
+    expect(result.lines).toHaveLength(1)
+    expect(result.lines[0].typed).toBe(0)
+    expect(result.disagrees).toBe(false)
+  })
+})
+
+describe("aggregateRecords / aggregateHistory", () => {
+  it("sums repeated records for one line rather than keeping the last", () => {
+    expect(
+      aggregateRecords([
+        { order_line_id: "line_1", quantity: 4 },
+        { order_line_id: "line_1", quantity: 6 },
+      ])
+    ).toEqual({ line_1: 10 })
+  })
+
+  it("flattens every submission in the appended history", () => {
+    expect(
+      aggregateHistory([
+        { lines: [{ order_line_id: "line_1", quantity: 10 }] },
+        { lines: [{ order_line_id: "line_1", quantity: 6 }] },
+      ])
+    ).toEqual({ line_1: 16 })
+  })
+
+  it("ignores records with no line id rather than bucketing them together", () => {
+    expect(aggregateRecords([{ quantity: 5 }, { order_line_id: null, quantity: 3 }])).toEqual({})
+  })
+})

--- a/apps/backend/src/workflows/inventory_orders/lib/receipt-reconciliation.ts
+++ b/apps/backend/src/workflows/inventory_orders/lib/receipt-reconciliation.ts
@@ -1,0 +1,220 @@
+/**
+ * Reconcile the TWO records of what a partner delivered against an inventory
+ * order (#1613).
+ *
+ * `partner-complete-inventory-order` writes the same fact twice:
+ *
+ *  1. **Typed** — `line_fulfillments` rows (`quantity_delta`), linked to the
+ *     order line. These GOVERN: the workflow's own over-delivery guard computes
+ *     `remaining = requested − Σ quantity_delta` from them and refuses a
+ *     delivery that would exceed it.
+ *  2. **Metadata** — two keys on the order, with DIFFERENT write semantics:
+ *     - `partner_delivered_lines` is **overwritten** on every partner
+ *       submission (`:326`), so it holds only the most recent one;
+ *     - `partner_delivery_history` is **appended** (`:327`).
+ *     …and the ADMIN deliver path appends to `partner_delivered_lines`
+ *     (`update-inventory-orders.ts:398`) rather than overwriting it. One key,
+ *     two writers, two meanings.
+ *
+ * On `inv_order_01K36TE2WB5BQR1MS6KESXP7Q3` the two disagree by **₹4,050**: the
+ * typed rows total 69.5 units against the blob's 59.3, including a whole
+ * 10-unit receipt (₹4,000) the blob never recorded.
+ *
+ * 🔴 **This is not only a reporting problem.** Two live readers compute stock
+ * movements from the overwritten key:
+ *
+ *  - `computeAdminDeliveryPosting` posts `ordered − already`, where `already`
+ *    comes from `partner_delivered_lines`. Where the blob understates, an admin
+ *    pressing Deliver posts stock that was already received — phantom
+ *    inventory, in the warehouse's real numbers.
+ *  - `cancel-inventory-order` reverses stock from the same key, so a cancel
+ *    un-posts the wrong quantity in whichever direction the blob is wrong.
+ *
+ * ⚠️ And why the obvious fix is not simply "read the typed rows everywhere":
+ * the two sources disagree in BOTH directions. Where the typed side is the one
+ * missing an entry, switching a reader to it makes `already` smaller and the
+ * over-posting WORSE. That is why this file only measures, and why the job
+ * built on it writes nothing.
+ */
+
+export type DeliveredLineRecord = {
+  order_line_id?: string | null
+  quantity?: number | string | null
+}
+
+export type DeliveryHistoryEntry = {
+  lines?: DeliveredLineRecord[] | null
+  submitted_at?: string | null
+}
+
+export type FulfillmentRow = {
+  quantity_delta?: number | string | null
+}
+
+export type OrderLineForReconciliation = {
+  id: string
+  /** Ordered quantity. */
+  quantity?: number | string | null
+  /** 🔴 PER UNIT, never a line total. */
+  price?: number | string | null
+  material_name?: string | null
+  line_fulfillments?: FulfillmentRow[] | null
+}
+
+export type LineReconciliation = {
+  line_id: string
+  material_name: string | null
+  ordered: number
+  /** Σ of the typed `quantity_delta` rows — the operative record. */
+  typed: number
+  /** Aggregate of `metadata.partner_delivered_lines` (the overwritten key). */
+  blob: number
+  /** Aggregate of every entry in `metadata.partner_delivery_history`. */
+  history: number
+  unit_price: number
+  /** typed − blob, in units. Positive ⇒ the blob understates. */
+  drift: number
+  /** The drift priced at the line's per-unit price. */
+  drift_value: number
+  /**
+   * What an admin "Deliver" would post today (`ordered − blob`) minus what it
+   * should post (`ordered − typed`). Positive ⇒ that much phantom stock.
+   */
+  admin_would_overpost: number
+}
+
+export type OrderReconciliation = {
+  lines: LineReconciliation[]
+  typed_total_units: number
+  blob_total_units: number
+  /** Σ drift_value. Positive ⇒ the blob understates what was received. */
+  drift_value: number
+  /** True when any line disagrees at all. */
+  disagrees: boolean
+  /** Σ of the positive per-line over-posting exposure. */
+  admin_would_overpost: number
+  /**
+   * ⚠️ Set when the order carries a `reversal_note`. On the one order examined
+   * by hand it reads "Reversed 9 incorrect fulfillments on 2026-02-28 — lines
+   * were auto-filled by UI bug", and rows sit on BOTH sides of that reversal —
+   * so which are corrected re-entries is not decidable from the record. These
+   * need a human, not a job that guesses.
+   */
+  undecidable: boolean
+  reversal_note: string | null
+}
+
+const num = (value: unknown): number => {
+  const parsed = Number(value ?? 0)
+  return Number.isFinite(parsed) ? parsed : 0
+}
+
+/** Sum `{order_line_id, quantity}` records into `line id → units`. */
+export const aggregateRecords = (
+  records: DeliveredLineRecord[] | null | undefined
+): Record<string, number> => {
+  const totals: Record<string, number> = {}
+  for (const record of records || []) {
+    const lineId = record?.order_line_id
+    if (!lineId) continue
+    totals[String(lineId)] = (totals[String(lineId)] || 0) + num(record.quantity)
+  }
+  return totals
+}
+
+/** Every entry of the appended history, flattened and summed per line. */
+export const aggregateHistory = (
+  history: DeliveryHistoryEntry[] | null | undefined
+): Record<string, number> => {
+  const totals: Record<string, number> = {}
+  for (const entry of history || []) {
+    for (const [lineId, qty] of Object.entries(aggregateRecords(entry?.lines))) {
+      totals[lineId] = (totals[lineId] || 0) + qty
+    }
+  }
+  return totals
+}
+
+/**
+ * PURE. Compare the typed receipts against both metadata keys, per line.
+ *
+ * Reports every line the order has, not only the disagreeing ones — a line
+ * present in one record and absent from the other is the whole point, and a
+ * function that only returned mismatches could not tell "agrees at 0" from
+ * "never looked at".
+ */
+export function reconcileOrderReceipts(input: {
+  orderlines: OrderLineForReconciliation[] | null | undefined
+  metadata: Record<string, unknown> | null | undefined
+}): OrderReconciliation {
+  const metadata = input.metadata || {}
+  const blobByLine = aggregateRecords(
+    metadata.partner_delivered_lines as DeliveredLineRecord[] | undefined
+  )
+  const historyByLine = aggregateHistory(
+    metadata.partner_delivery_history as DeliveryHistoryEntry[] | undefined
+  )
+
+  const lines: LineReconciliation[] = []
+  let typedTotal = 0
+  let blobTotal = 0
+  let driftValue = 0
+  let overpost = 0
+
+  for (const line of (input.orderlines || []).filter(Boolean)) {
+    const lineId = String(line.id)
+    /**
+     * ⚠️ A SUM of deltas, never the latest row and never the row count: the
+     * event types include `adjust` and `correction`, and a negative delta
+     * legitimately reduces what was received.
+     */
+    const typed = (line.line_fulfillments || []).reduce(
+      (sum, row) => sum + num(row?.quantity_delta),
+      0
+    )
+    const blob = blobByLine[lineId] || 0
+    const history = historyByLine[lineId] || 0
+    const ordered = num(line.quantity)
+    const unitPrice = num(line.price)
+    const drift = typed - blob
+
+    // What the admin path would post today vs what it should. Clamped at 0 per
+    // line: a line where the blob OVERstates does not offset one where it
+    // understates — they are two separate wrong stock movements.
+    const wouldPost = Math.max(0, ordered - blob)
+    const shouldPost = Math.max(0, ordered - typed)
+    const lineOverpost = Math.max(0, wouldPost - shouldPost)
+
+    typedTotal += typed
+    blobTotal += blob
+    driftValue += drift * unitPrice
+    overpost += lineOverpost
+
+    lines.push({
+      line_id: lineId,
+      material_name: line.material_name ?? null,
+      ordered,
+      typed,
+      blob,
+      history,
+      unit_price: unitPrice,
+      drift,
+      drift_value: drift * unitPrice,
+      admin_would_overpost: lineOverpost,
+    })
+  }
+
+  const reversalNote =
+    typeof metadata.reversal_note === "string" ? metadata.reversal_note : null
+
+  return {
+    lines,
+    typed_total_units: typedTotal,
+    blob_total_units: blobTotal,
+    drift_value: driftValue,
+    disagrees: lines.some((l) => l.drift !== 0),
+    admin_would_overpost: overpost,
+    undecidable: reversalNote !== null,
+    reversal_note: reversalNote,
+  }
+}


### PR DESCRIPTION
Step one of #1613, which asks for a report before any write. Chasing it sharpened *why*.

## The dual write

`partner-complete-inventory-order` records every delivery twice: typed `line_fulfillments` rows, and `metadata.partner_delivered_lines` / `partner_delivery_history`. **The typed rows govern** — the workflow's own over-delivery guard computes `remaining` from them.

On `inv_order_01K36TE2WB5BQR1MS6KESXP7Q3` they disagree by **₹4,050**: 69.5 typed units against 59.3 in the blob, including a whole 10-unit receipt (₹4,000) the blob never recorded.

## 🔴 This is not only a reporting problem

`partner_delivered_lines` is **overwritten** by the partner path (`:326`) and **appended to** by the admin path (`update-inventory-orders.ts:398`). One key, two writers, two meanings — and two live readers move real stock from it:

- **`computeAdminDeliveryPosting`** posts `ordered − already`, with `already` read from the blob. On the line above that is `16 − 6 = 10` units posted for goods **already received**, against a correct `16 − 16 = 0`. Phantom inventory, in the warehouse's real numbers.
- **`cancel-inventory-order`** reverses stock from the same key, so a cancel un-posts the wrong quantity in whichever direction the blob is wrong.

The report measures that exposure per line (`admin_would_overpost`) rather than leaving it as a remark.

## 🔴 Why it writes nothing, ever

Not caution — the data says so:

1. **The two sources disagree in both directions.** Where the *typed* side is the one missing an entry, switching a reader to it makes `already` smaller and the over-posting **worse**. So "just read the typed rows everywhere" is not the safe fix it appears to be, and neither is a union.
2. **`metadata.reversal_note`** on that order reads *"Reversed 9 incorrect fulfillments on 2026-02-28 — lines were auto-filled by UI bug"*, with rows on **both sides** of it. Which are corrected re-entries is not decidable from the record. Those orders are reported separately, for a human.

`dry_run: false` therefore changes nothing and `applied` is always false — the job has no write path at all. That's asserted in an integration case, not promised in a docstring: a job whose safety rests on the caller passing `dry_run` is one keystroke from writing.

## Testing

The pure reconciliation is built on the **real order's** five lines and rates, not a tidy fixture — 10 unit cases covering:

- the ₹4,050 total, reproduced exactly;
- the 10-unit receipt the blob never recorded;
- the 10.2 units of admin over-posting exposure;
- a blob that **overstates**, which produces drift but *no* over-posting — the both-directions case that blocks the obvious fix;
- delta summing with negatives (`adjust`/`correction` events are real, so the latest row and the row count are both wrong answers);
- the undecidable flag.

Plus 2 integration cases through the ops endpoint. `ops-maintenance-jobs` suite green at 51; `check:prod-build` passes.

## Verify

```bash
curl -sS -X POST "$HOST/admin/ops/maintenance-jobs/audit-inventory-receipt-drift/run" \
  -H "Authorization: Bearer $TOKEN" -H 'content-type: application/json' \
  -d '{"dry_run":true,"params":{"limit":200}}'
```

## Next

Once this is deployed, run it against production to get the actual scope — how many orders drift, what it's worth, and how much phantom stock the admin path is exposed to. Then decide the reader fix and the backfill with those numbers in hand rather than from one order.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01TLt1f38xqR8k2myCVxP8e4