### PR TITLE
test(payments): pin both halves of #1616 at the HTTP boundary

### DIFF
--- a/apps/backend/integration-tests/http/payment-submissions-api.spec.ts
+++ b/apps/backend/integration-tests/http/payment-submissions-api.spec.ts
@@ -1579,6 +1579,74 @@ setupSharedTestSuite(() => {
     })
   })
 
+  /**
+   * #1616 — `payable-runs` offered ₹810 and `create` wrote ₹1,056.40, the
+   * DESIGN's `estimated_cost`, for the same run. Both halves of that fix are
+   * asserted here at the HTTP boundary:
+   *
+   *  1. what the offer screen shows is what `create` writes; and
+   *  2. `create` RETURNS the line it wrote.
+   *
+   * 🔴 The second matters as much as the first. `create` used to return
+   * `items: []`, so the amount could not be seen until the submission was
+   * fetched again — the overbill was found only because a handoff had named the
+   * expected figure. The read-back exists in the workflow but nothing at this
+   * boundary held it, so deleting it would have left every test green.
+   */
+  describe("POST /admin/payment-submissions — the offer is what gets written (#1616)", () => {
+    it("prices from the RUN, and returns the line it wrote", async () => {
+      // The shape of the prod row: a `total` run worth far less than the
+      // design's per-unit estimate.
+      const designId = await createDesign("Princess Highway", {
+        estimated_cost: 1056.4,
+      })
+      await linkDesignToPartner(designId, partnerId)
+      const runId = await createCompletedRun(designId, "Princess Highway", {
+        quantity: 1,
+        produced_quantity: 1,
+        partner_cost_estimate: 810,
+        cost_type: "total",
+      })
+
+      // What the operator is offered.
+      const offers = await api.get(
+        `/admin/payment-submissions/payable-runs?partner_id=${partnerId}`,
+        adminHeaders
+      )
+      expect(offers.status).toBe(200)
+      const offered = (offers.data.runs || offers.data.payable_runs || []).find(
+        (r: any) => r.id === runId || r.run_id === runId
+      )
+      expect(offered).toBeDefined()
+      expect(Number(offered.amount)).toBe(810)
+
+      // What acting on it actually writes — no explicit amount, so the pricer
+      // decides.
+      const res = await api.post(
+        "/admin/payment-submissions",
+        {
+          partner_id: partnerId,
+          design_ids: [designId],
+          production_run_ids: { [designId]: [runId] },
+        },
+        adminHeaders
+      )
+      expect(res.status).toBe(201)
+
+      // 🔴 Asserted on the CREATE response, not on a follow-up GET. That the
+      // amount is visible at the moment it is written is the fix.
+      const created = res.data.payment_submission
+      expect(Array.isArray(created.items)).toBe(true)
+      expect(created.items.length).toBe(1)
+      expect(Number(created.items[0].amount)).toBe(810)
+      // The exact overbill the issue reports.
+      expect(Number(created.items[0].amount)).not.toBe(1056.4)
+
+      // And the two agree, which is the contract.
+      expect(Number(created.items[0].amount)).toBe(Number(offered.amount))
+    })
+  })
+
   describe("POST /admin/payment-submissions — run provenance (#1556)", () => {
     it("records which runs a line paid for, and reports them as billed", async () => {
       const d1 = await createDesign("Provenance Design", {


### PR DESCRIPTION
#1616 is fixed — `resolvePaymentLineAmount` prices from the runs, and a unit contract test holds `payable-runs`' offer against it. I went to work on the issue, found it already closed, and checked rather than trusting either the state or my own notes.

What I found: **nothing at the HTTP boundary held either half, and the second half had no test at all.**

## Why the second half matters as much as the first

`create` used to return `items: []`, so the amount could not be seen until the submission was fetched again. That is why a **+30% overbill** (₹1,056.40 written against an offered ₹810) was caught only because a handoff happened to name the expected figure.

The workflow now reads the lines back — but that read-back could have been deleted with every test still green.

## The case

One test, using the prod row's shape: a `total` run worth ₹810 under a design estimated at ₹1,056.40.

- `payable-runs` offers **810**;
- `POST /admin/payment-submissions` with `production_run_ids` and **no explicit amount** writes **810**, not 1056.4;
- the **create response itself** carries the line — asserted there, not on a follow-up `GET`, because being visible at the moment it is written *is* the fix;
- and the two figures are asserted equal to each other, which is the contract the issue asked for.

## Mutation-checked, both halves

Both reproduce the original defect exactly:

| mutation | result |
|---|---|
| force `runPrice = null` | `Expected: 810, Received: 1056.4` |
| force `items = []` | `Expected: 1, Received: 0` |

The first is the issue's own numbers, reproduced by deleting the fix.

102 cases in `payment-submissions-api` green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01TLt1f38xqR8k2myCVxP8e4