### PR TITLE
fix(inventory): stock readers read BOTH records of a delivery (#1613)

### DIFF
--- a/apps/backend/integration-tests/http/inventory-orders-api.spec.ts
+++ b/apps/backend/integration-tests/http/inventory-orders-api.spec.ts
@@ -453,6 +453,24 @@ setupSharedTestSuite(() => {
         expect(orderGet.data.inventoryOrder.status).toBe("Delivered");
         const delivered = orderGet.data.inventoryOrder.metadata?.partner_delivered_lines || [];
         expect(delivered).toEqual([{ order_line_id: expect.any(String), quantity: 3 }]);
+
+        // #1613 — and into the TYPED record too. Writing only the metadata blob
+        // made the admin delivery invisible to every reader of
+        // `line_fulfillments`: the partner path's own over-delivery guard, the
+        // drift audit, and anything asking what this order actually received.
+        const { ContainerRegistrationKeys } = await import("@medusajs/framework/utils");
+        const query = getContainer().resolve(ContainerRegistrationKeys.QUERY) as any;
+        const { data: withReceipts } = await query.graph({
+          entity: "inventory_orders",
+          filters: { id: orderId },
+          fields: ["id", "orderlines.id", "orderlines.line_fulfillments.quantity_delta", "orderlines.line_fulfillments.event_type"],
+        });
+        const receipts = (withReceipts?.[0]?.orderlines || [])
+          .flatMap((l: any) => l.line_fulfillments || [])
+          .filter((f: any) => f?.quantity_delta != null);
+        expect(receipts).toEqual([
+          expect.objectContaining({ quantity_delta: 3, event_type: "received" }),
+        ]);
       });
 
 

--- a/apps/backend/integration-tests/http/send-to-partner-complete-workflow.spec.ts
+++ b/apps/backend/integration-tests/http/send-to-partner-complete-workflow.spec.ts
@@ -766,5 +766,112 @@ setupSharedTestSuite(() => {
         const requestedQty = newOrderPayload.quantity
         expect(totalStocked).toBe(requestedQty)
       })
+
+      /**
+       * #1613 at the HTTP boundary — the two records of a delivery, and a
+       * cancel that read the wrong one.
+       *
+       * `metadata.partner_delivered_lines` is OVERWRITTEN on every partner
+       * submission, so after two partial deliveries it holds only the second.
+       * The cancel workflow reversed stock from that key, so it un-posted the
+       * second submission and left the first sitting in the warehouse as stock
+       * for goods that were never received.
+       *
+       * Two submissions is the minimum that makes the two records disagree —
+       * with one, the blob and the typed rows say the same thing and the
+       * assertion would hold either way.
+       */
+      it("reverses BOTH partner submissions on cancel, not just the last one (#1613)", async () => {
+        const itemRes = await api.post(
+          "/admin/inventory-items",
+          { title: "Twice-Delivered Fabric", description: "#1613 cancel reversal" },
+          adminHeaders
+        )
+        expect(itemRes.status).toBe(200)
+        const itemId = itemRes.data.inventory_item.id
+
+        const orderRes = await api.post(
+          "/admin/inventory-orders",
+          {
+            order_lines: [{ inventory_item_id: itemId, quantity: 16, price: 400 }],
+            quantity: 16,
+            total_price: 6400,
+            status: "Pending",
+            expected_delivery_date: new Date(Date.now() + 3 * 24 * 60 * 60 * 1000).toISOString(),
+            order_date: new Date().toISOString(),
+            shipping_address: {
+              address_1: "1 Loom Road",
+              city: "Bhagalpur",
+              postal_code: "812001",
+              country_code: "IN",
+            },
+            stock_location_id: stockLocationId,
+            to_stock_location_id: stockLocationId,
+            from_stock_location_id: fromStockLocationId,
+            is_sample: false,
+          },
+          adminHeaders
+        )
+        expect(orderRes.status).toBe(201)
+        const orderId = orderRes.data.inventoryOrder.id
+
+        expect(
+          (await api.post(
+            `/admin/inventory-orders/${orderId}/send-to-partner`,
+            { partnerId, notes: "#1613 two-submission cancel" },
+            adminHeaders
+          )).status
+        ).toBe(200)
+        expect([200, 204]).toContain(
+          (await api.post(`/partners/inventory-orders/${orderId}/start`, {}, { headers: partnerHeaders })).status
+        )
+
+        const partnerView = await api.get(`/partners/inventory-orders/${orderId}`, { headers: partnerHeaders })
+        const lineId = partnerView.data.inventoryOrder.order_lines[0].id
+
+        // Two submissions on the SAME line: 10, then 6.
+        for (const quantity of [10, 6]) {
+          const res = await api.post(
+            `/partners/inventory-orders/${orderId}/complete`,
+            {
+              notes: `#1613 submission of ${quantity}`,
+              deliveryDate: new Date().toISOString(),
+              stock_location_id: stockLocationId,
+              lines: [{ order_line_id: lineId, quantity }],
+            },
+            { headers: partnerHeaders }
+          )
+          expect([200, 204]).toContain(res.status)
+        }
+
+        const container = getContainer()
+        const query = container.resolve(ContainerRegistrationKeys.QUERY)
+        const stockedAtDest = async () => {
+          const { data: levels } = await query.graph({
+            entity: "inventory_level",
+            fields: ["id", "location_id", "stocked_quantity"],
+            filters: { inventory_item_id: itemId },
+          })
+          return (levels || [])
+            .filter((l: any) => String(l.location_id) === String(stockLocationId))
+            .reduce((sum: number, l: any) => sum + (Number(l.stocked_quantity) || 0), 0)
+        }
+
+        // Both submissions posted, so all 16 units are on the shelf.
+        expect(await stockedAtDest()).toBe(16)
+
+        // 🔴 The blob now holds ONLY the second submission. If this were the
+        // whole record, the order would look 6 units delivered, not 16.
+        const orderView = await api.get(`/admin/inventory-orders/${orderId}?fields=id,status,metadata`, adminHeaders)
+        const blob = orderView.data.inventoryOrder.metadata?.partner_delivered_lines || []
+        expect(blob).toEqual([{ order_line_id: lineId, quantity: 6 }])
+
+        const cancelRes = await api.post(`/admin/inventory-orders/${orderId}/cancel`, { reason: "#1613" }, adminHeaders)
+        expect(cancelRes.status).toBe(200)
+
+        // Everything that was posted comes back off. Reading the blob alone
+        // reversed 6 and left 10 units of phantom stock behind.
+        expect(await stockedAtDest()).toBe(0)
+      })
     })
 })

--- a/apps/backend/src/workflows/inventory_orders/__tests__/cancel-helpers.unit.spec.ts
+++ b/apps/backend/src/workflows/inventory_orders/__tests__/cancel-helpers.unit.spec.ts
@@ -2,6 +2,7 @@ import {
   assertCancellable,
   aggregateDeliveredByLine,
   buildReversalLevels,
+  resolveDeliveredByLine,
   computeStockReversalUpdates,
   selectOpenTaskIds,
 } from "../lib/cancel-helpers"
@@ -128,5 +129,64 @@ describe("selectOpenTaskIds (#778 C4)", () => {
         null,
       ] as any)
     ).toEqual(["t1", "t2", "t3", "t4"])
+  })
+})
+
+/**
+ * #1613 — a cancel reverses what a delivery posted. It read that quantity from
+ * `metadata.partner_delivered_lines`, the key the partner path OVERWRITES on
+ * every submission, so on a twice-delivered order it un-posted only the last
+ * submission and left the rest of the stock on the shelf for goods that were
+ * being sent back.
+ */
+describe("resolveDeliveredByLine + buildReversalLevels read both records (#1613)", () => {
+  const line = (id: string, itemId: string, typed: number[] | null) => ({
+    id,
+    inventory_items: [{ id: itemId, stock_locations: [] }],
+    ...(typed === null ? {} : { line_fulfillments: typed.map((quantity_delta) => ({ quantity_delta })) }),
+  })
+
+  it("takes the typed total when the overwritten blob holds only the last submission", () => {
+    expect(
+      resolveDeliveredByLine(
+        [line("ol_1", "iitem_1", [10, 6])],
+        [{ order_line_id: "ol_1", quantity: 6 }]
+      )
+    ).toEqual({ ol_1: 16 })
+  })
+
+  it("takes the blob when the typed record is the one missing the entry", () => {
+    expect(
+      resolveDeliveredByLine(
+        [line("ol_1", "iitem_1", [])],
+        [{ order_line_id: "ol_1", quantity: 62 }]
+      )
+    ).toEqual({ ol_1: 62 })
+  })
+
+  it("never sums the two — the same delivery in both records is one delivery", () => {
+    expect(
+      resolveDeliveredByLine(
+        [line("ol_1", "iitem_1", [12])],
+        [{ order_line_id: "ol_1", quantity: 12 }]
+      )
+    ).toEqual({ ol_1: 12 })
+  })
+
+  it("reverses the full typed quantity, not just the last submission", () => {
+    expect(
+      buildReversalLevels(
+        [line("ol_1", "iitem_1", [10, 6])],
+        [{ order_line_id: "ol_1", quantity: 6 }],
+        "sloc_dest"
+      )
+    ).toEqual([
+      { location_id: "sloc_dest", inventory_item_id: "iitem_1", quantity: 16 },
+    ])
+  })
+
+  it("leaves lines with neither record alone", () => {
+    expect(resolveDeliveredByLine([line("ol_1", "iitem_1", null)], [])).toEqual({ ol_1: 0 })
+    expect(buildReversalLevels([line("ol_1", "iitem_1", null)], [], "sloc_dest")).toEqual([])
   })
 })

--- a/apps/backend/src/workflows/inventory_orders/__tests__/deliver-helpers.unit.spec.ts
+++ b/apps/backend/src/workflows/inventory_orders/__tests__/deliver-helpers.unit.spec.ts
@@ -102,3 +102,104 @@ describe("computeAdminDeliveryPosting (#778 C2 admin-half)", () => {
     expect(deliveredRecords).toEqual([{ order_line_id: "ol_1", quantity: 7 }])
   })
 })
+
+/**
+ * #1613 — the admin deliver path posted `ordered − already`, where `already`
+ * came from `metadata.partner_delivered_lines` alone. That key is OVERWRITTEN
+ * by the partner path on every submission, so on production it under-counted by
+ * 58.8 units across five orders — stock posted a second time for goods already
+ * in the warehouse.
+ *
+ * These cases pin the merged read. Each one is written so it FAILS against the
+ * blob-only helper: the fixtures put the typed and blob records in genuine
+ * disagreement, in both directions, rather than agreeing at a number that would
+ * make the assertion vacuous.
+ */
+describe("computeAdminDeliveryPosting reads both receipt records (#1613)", () => {
+  const line = (
+    id: string,
+    quantity: number,
+    itemId: string,
+    typed: number[] = []
+  ) => ({
+    id,
+    quantity,
+    inventory_items: [{ id: itemId, stock_locations: [] }],
+    line_fulfillments: typed.map((quantity_delta) => ({ quantity_delta })),
+  })
+
+  it("uses the typed receipts when the blob understates them", () => {
+    // The partner submitted 10, then 6. The blob was overwritten and holds only
+    // the 6; the typed rows hold both. Blob-only posts 14 of a 16-unit line —
+    // 10 units of stock that is already on the shelf.
+    const { levels, deliveredRecords } = computeAdminDeliveryPosting(
+      [line("ol_1", 16, "iitem_1", [10, 6])],
+      [{ order_line_id: "ol_1", quantity: 6 }],
+      "sloc_dest"
+    )
+    expect(levels).toEqual([])
+    expect(deliveredRecords).toEqual([])
+  })
+
+  it("keeps the blob when the TYPED side is the one missing an entry", () => {
+    // `inv_order_01K3BAM50H…` in production: 62 units in the blob, zero typed
+    // rows. Switching outright to the typed record would post the whole line
+    // again — worse than the bug being fixed.
+    const { levels } = computeAdminDeliveryPosting(
+      [line("ol_1", 62, "iitem_1", [])],
+      [{ order_line_id: "ol_1", quantity: 62 }],
+      "sloc_dest"
+    )
+    expect(levels).toEqual([])
+  })
+
+  it("posts the genuine remainder when both records agree it is partial", () => {
+    const { levels, deliveredRecords } = computeAdminDeliveryPosting(
+      [line("ol_1", 31, "iitem_1", [10])],
+      [{ order_line_id: "ol_1", quantity: 10 }],
+      "sloc_dest"
+    )
+    expect(levels).toEqual([
+      { location_id: "sloc_dest", inventory_item_id: "iitem_1", stocked_quantity: 21 },
+    ])
+    expect(deliveredRecords).toEqual([{ order_line_id: "ol_1", quantity: 21 }])
+  })
+
+  it("sums typed deltas rather than taking the largest row", () => {
+    // A `correction` row is a negative delta and legitimately reduces the
+    // total. Taking max-of-rows would read 12 here and post 8 too little.
+    const { deliveredRecords } = computeAdminDeliveryPosting(
+      [line("ol_1", 30, "iitem_1", [12, -2])],
+      [],
+      "sloc_dest"
+    )
+    expect(deliveredRecords).toEqual([{ order_line_id: "ol_1", quantity: 20 }])
+  })
+
+  it("treats the all-null placeholder row query.graph returns for an empty relation as zero receipts", () => {
+    // ⚠️ `line_fulfillments.length === 1` does NOT mean one receipt: a line with
+    // none comes back as a single row of nulls.
+    const { deliveredRecords } = computeAdminDeliveryPosting(
+      [
+        {
+          id: "ol_1",
+          quantity: 9,
+          inventory_items: [{ id: "iitem_1", stock_locations: [] }],
+          line_fulfillments: [{ quantity_delta: null }],
+        },
+      ],
+      [],
+      "sloc_dest"
+    )
+    expect(deliveredRecords).toEqual([{ order_line_id: "ol_1", quantity: 9 }])
+  })
+
+  it("still behaves as before for lines carrying no typed record at all", () => {
+    const { deliveredRecords } = computeAdminDeliveryPosting(
+      [{ id: "ol_1", quantity: 10, inventory_items: [{ id: "iitem_1", stock_locations: [] }] }],
+      [{ order_line_id: "ol_1", quantity: 4 }],
+      "sloc_dest"
+    )
+    expect(deliveredRecords).toEqual([{ order_line_id: "ol_1", quantity: 6 }])
+  })
+})

--- a/apps/backend/src/workflows/inventory_orders/cancel-inventory-order.ts
+++ b/apps/backend/src/workflows/inventory_orders/cancel-inventory-order.ts
@@ -50,6 +50,10 @@ export const loadOrderForCancelStep = createStep(
         "status",
         "metadata",
         "orderlines.id",
+        // #1613 — the TYPED receipt record, read alongside the metadata blob so
+        // a cancel reverses everything that was posted, not just the last
+        // partner submission.
+        "orderlines.line_fulfillments.quantity_delta",
         "orderlines.inventory_items.id",
         "orderlines.inventory_items.stock_locations.id",
         "stock_locations.id",

--- a/apps/backend/src/workflows/inventory_orders/lib/cancel-helpers.ts
+++ b/apps/backend/src/workflows/inventory_orders/lib/cancel-helpers.ts
@@ -9,10 +9,19 @@ import { MedusaError } from "@medusajs/framework/utils"
 
 export type DeliveredLine = { order_line_id: string; quantity: number }
 
+/** A typed receipt row (`line_fulfillments`) as fetched off an order line. */
+export type TypedReceiptRow = { quantity_delta?: number | string | null }
+
 export type OrderLineForReversal = {
   id: string
   inventory_items?: Array<{ id?: string; stock_locations?: Array<{ id?: string }> }>
   inventory_item_id?: string
+  /**
+   * The TYPED receipts for this line (#1613). Optional so every existing caller
+   * still type-checks; when absent the line falls back to the metadata blob
+   * alone, i.e. the pre-#1613 behaviour.
+   */
+  line_fulfillments?: Array<TypedReceiptRow | null> | null
 }
 
 export type ReversalLevel = {
@@ -67,6 +76,71 @@ export const aggregateDeliveredByLine = (
 }
 
 /**
+ * Σ of a line's typed `quantity_delta` rows — the operative receipt record.
+ *
+ * ⚠️ A SUM, never the row count and never the latest row: the event types
+ * include `adjust` and `correction`, and a negative delta legitimately reduces
+ * what was received.
+ *
+ * ⚠️ `query.graph` returns ONE all-null row for a line with NO receipts, so the
+ * relation's `length` is 1 for an empty relation. Summing nulls yields 0, which
+ * is the right answer either way, but the filter keeps that from being luck.
+ */
+export const sumTypedReceipts = (
+  line: { line_fulfillments?: Array<TypedReceiptRow | null> | null } | null | undefined
+): number =>
+  (line?.line_fulfillments || [])
+    .filter((row) => row && row.quantity_delta != null)
+    .reduce((sum, row) => sum + (Number(row!.quantity_delta) || 0), 0)
+
+/**
+ * How much of each line has ALREADY been delivered — reading BOTH records of
+ * that fact and taking the larger (#1613).
+ *
+ * There are two records and neither one is complete:
+ *
+ *  - **Typed** `line_fulfillments` rows. Written by the partner path on every
+ *    submission, so they accumulate. But the ADMIN deliver path historically
+ *    wrote no typed row at all, so anything an admin delivered is missing here.
+ *  - **`metadata.partner_delivered_lines`.** OVERWRITTEN by the partner path
+ *    with just the latest submission and APPENDED to by the admin path. So it
+ *    holds "last partner submission + admin appends since" — never the total.
+ *
+ * On production the two disagree in BOTH directions, which is why neither a
+ * blind switch to the typed rows nor a sum of the two is safe: a sum would
+ * double-count every quantity both records hold (which is most of them), and
+ * switching outright makes `already` SMALLER wherever the typed side is the one
+ * missing an entry — `inv_order_01K3BAM50H…` has 62 units in the blob and zero
+ * typed rows.
+ *
+ * `max` is the only combination that cannot regress either reader:
+ *
+ *  - Delivering posts `ordered − already`, so a too-small `already` posts stock
+ *    that was already received — phantom inventory in the warehouse's real
+ *    numbers. `max` can only make `already` LARGER than today, never smaller,
+ *    so it removes over-posting and can never introduce it.
+ *  - Cancelling reverses `already`, so a too-small `already` leaves posted
+ *    stock behind. `max` reverses at least as much as today, floored at 0 and
+ *    capped by the level that actually exists.
+ *
+ * It is deliberately NOT exact: an order whose blob was overwritten *after* an
+ * admin append still under-counts that append. Making it exact needs the admin
+ * path to write typed rows too — which it now does — so on orders written from
+ * here on the typed side is the complete record and `max` returns it.
+ */
+export const resolveDeliveredByLine = (
+  orderlines: OrderLineForReversal[] | undefined | null,
+  deliveredLines: DeliveredLine[] | undefined | null
+): Record<string, number> => {
+  const byLine = aggregateDeliveredByLine(deliveredLines)
+  for (const ol of (orderlines || []).filter(Boolean)) {
+    const id = String(ol.id)
+    byLine[id] = Math.max(byLine[id] || 0, sumTypedReceipts(ol))
+  }
+  return byLine
+}
+
+/**
  * Resolve which (item, location, qty) levels a cancel must reverse, mirroring
  * exactly how `partner-complete` posted them: per delivered order line, the
  * line's first linked inventory item at the order's destination location (or
@@ -78,7 +152,7 @@ export const buildReversalLevels = (
   deliveredLines: DeliveredLine[] | undefined | null,
   destLocationId: string | null | undefined
 ): ReversalLevel[] => {
-  const deliveredByLine = aggregateDeliveredByLine(deliveredLines)
+  const deliveredByLine = resolveDeliveredByLine(orderlines, deliveredLines)
   const levels: ReversalLevel[] = []
   for (const ol of (orderlines || []).filter(Boolean)) {
     const qty = deliveredByLine[ol.id]

--- a/apps/backend/src/workflows/inventory_orders/lib/deliver-helpers.ts
+++ b/apps/backend/src/workflows/inventory_orders/lib/deliver-helpers.ts
@@ -1,6 +1,6 @@
 import { MedusaError } from "@medusajs/framework/utils"
 import {
-  aggregateDeliveredByLine,
+  resolveDeliveredByLine,
   type DeliveredLine,
   type OrderLineForReversal,
 } from "./cancel-helpers"
@@ -16,7 +16,11 @@ import {
  * compute the stock to post when an admin actually delivers an order.
  */
 
-/** An order line shaped for delivery stock posting (mirrors the reversal shape). */
+/**
+ * An order line shaped for delivery stock posting (mirrors the reversal shape,
+ * including its optional `line_fulfillments` — the typed receipt record #1613
+ * makes this helper read alongside the metadata blob).
+ */
 export type OrderLineForDelivery = OrderLineForReversal & {
   /** Ordered quantity for the line (what a full delivery posts, minus prior deliveries). */
   quantity: number
@@ -84,7 +88,11 @@ export const computeAdminDeliveryPosting = (
   alreadyDelivered: DeliveredLine[] | undefined | null,
   destLocationId: string | null | undefined
 ): { levels: DeliveryLevelInput[]; deliveredRecords: DeliveredLine[] } => {
-  const deliveredByLine = aggregateDeliveredByLine(alreadyDelivered)
+  // #1613 — `already` reads BOTH records of what has been delivered (the typed
+  // `line_fulfillments` rows carried on the line, and the metadata blob) and
+  // takes the larger. Reading the blob alone under-counted every submission but
+  // the last, and posted the difference as stock that was already received.
+  const deliveredByLine = resolveDeliveredByLine(orderlines, alreadyDelivered)
   const levels: DeliveryLevelInput[] = []
   const deliveredRecords: DeliveredLine[] = []
 

--- a/apps/backend/src/workflows/inventory_orders/lib/receipt-reconciliation.ts
+++ b/apps/backend/src/workflows/inventory_orders/lib/receipt-reconciliation.ts
@@ -20,21 +20,26 @@
  * typed rows total 69.5 units against the blob's 59.3, including a whole
  * 10-unit receipt (₹4,000) the blob never recorded.
  *
- * 🔴 **This is not only a reporting problem.** Two live readers compute stock
+ * 🔴 **This was not only a reporting problem.** Two readers computed stock
  * movements from the overwritten key:
  *
  *  - `computeAdminDeliveryPosting` posts `ordered − already`, where `already`
- *    comes from `partner_delivered_lines`. Where the blob understates, an admin
+ *    came from `partner_delivered_lines`. Where the blob understates, an admin
  *    pressing Deliver posts stock that was already received — phantom
  *    inventory, in the warehouse's real numbers.
  *  - `cancel-inventory-order` reverses stock from the same key, so a cancel
- *    un-posts the wrong quantity in whichever direction the blob is wrong.
+ *    un-posted the wrong quantity in whichever direction the blob was wrong.
  *
- * ⚠️ And why the obvious fix is not simply "read the typed rows everywhere":
- * the two sources disagree in BOTH directions. Where the typed side is the one
- * missing an entry, switching a reader to it makes `already` smaller and the
- * over-posting WORSE. That is why this file only measures, and why the job
- * built on it writes nothing.
+ * ✅ Both now read `resolveDeliveredByLine` (`lib/cancel-helpers.ts`), which
+ * takes the LARGER of the two records per line — the only combination that
+ * cannot regress either reader, since the sources disagree in BOTH directions
+ * and a blind switch to the typed rows makes `already` smaller wherever the
+ * typed side is the one missing an entry. The admin deliver path also writes a
+ * typed receipt now, so the typed record is the complete one going forward.
+ *
+ * This file still only MEASURES: reconciling the historical rows is a separate,
+ * per-order decision (two orders on production are undecidable from the data),
+ * and the job built on it writes nothing.
  */
 
 export type DeliveredLineRecord = {

--- a/apps/backend/src/workflows/inventory_orders/update-inventory-orders.ts
+++ b/apps/backend/src/workflows/inventory_orders/update-inventory-orders.ts
@@ -12,6 +12,8 @@ import type { RemoteQueryFunction, UpdateInventoryLevelInput } from "@medusajs/t
 import { createInventoryLevelsWorkflow, updateInventoryLevelsWorkflow } from "@medusajs/medusa/core-flows";
 import { ORDER_INVENTORY_MODULE } from "../../modules/inventory_orders";
 import InventoryOrderService from "../../modules/inventory_orders/service";
+import { FULLFILLED_ORDERS_MODULE } from "../../modules/fullfilled_orders";
+import type Fullfilled_ordersService from "../../modules/fullfilled_orders/service";
 import { mirrorUnifiedOrderStatusStep } from "./dual-write-unified-order";
 import { reprojectInventoryMirrorItemsStep } from "./reproject-inventory-mirror-items";
 import { resolveExistingLevelsStep } from "./partner-complete-inventory-order";
@@ -349,6 +351,10 @@ export const loadDeliveryContextStep = createStep(
         "metadata",
         "orderlines.id",
         "orderlines.quantity",
+        // #1613 — the TYPED receipt record. Without it the posting helper sees
+        // only `metadata.partner_delivered_lines`, which holds the latest
+        // partner submission and nothing before it.
+        "orderlines.line_fulfillments.quantity_delta",
         "orderlines.inventory_items.id",
         "orderlines.inventory_items.stock_locations.id",
       ],
@@ -404,6 +410,73 @@ export const appendDeliveredLinesStep = createStep(
     if (!comp) return;
     const inventoryOrderService: InventoryOrderService = container.resolve(ORDER_INVENTORY_MODULE);
     await inventoryOrderService.updateInventoryOrders({ id: comp.id, metadata: comp.metadata });
+  }
+);
+
+/**
+ * Step 5b (#1613): record the admin-delivered quantities as TYPED receipts.
+ *
+ * The admin deliver path used to write its quantities to
+ * `metadata.partner_delivered_lines` and nowhere else, while the partner path
+ * wrote typed `line_fulfillments` rows AND overwrote that same key. So the two
+ * writers each held half the truth and neither held all of it — the whole of
+ * #1613.
+ *
+ * Writing a typed row here makes the typed record the complete one going
+ * forward: every subsequent reader (`resolveDeliveredByLine`, the partner
+ * path's own over-delivery guard, and any payout that asks what was received)
+ * sees the admin delivery too, instead of a gap the blob happens to cover until
+ * the next partner submission overwrites it.
+ *
+ * `event_type: "received"` matches the partner path. Best-effort is NOT
+ * acceptable here — a receipt that silently fails to record is the bug being
+ * fixed — so a failure rolls the step back and the compensation deletes any row
+ * already written.
+ */
+export const recordAdminReceiptsStep = createStep(
+  "record-admin-delivery-receipts-step",
+  async (
+    input: { id: string; records: DeliveredLine[] },
+    { container, context }
+  ) => {
+    const service = container.resolve(FULLFILLED_ORDERS_MODULE) as Fullfilled_ordersService;
+    const remoteLink = container.resolve(ContainerRegistrationKeys.LINK) as Link;
+
+    const createdIds: string[] = [];
+    for (const record of input.records || []) {
+      if (!record?.order_line_id || !(Number(record.quantity) > 0)) continue;
+      const entry = await (service as any).createLine_fulfillments({
+        quantity_delta: Number(record.quantity),
+        event_type: "received",
+        transaction_id: context.transactionId,
+        notes: "Recorded by admin delivery",
+        metadata: { source: "admin_delivery", inventory_order_id: input.id },
+      });
+      createdIds.push(entry.id);
+      await remoteLink.create([
+        {
+          [ORDER_INVENTORY_MODULE]: { inventory_order_line_id: record.order_line_id },
+          [FULLFILLED_ORDERS_MODULE]: { line_fulfillment_id: entry.id },
+        },
+        {
+          [ORDER_INVENTORY_MODULE]: { inventory_orders_id: input.id },
+          [FULLFILLED_ORDERS_MODULE]: { line_fulfillment_id: entry.id },
+        },
+      ]);
+    }
+
+    return new StepResponse({ created: createdIds.length }, { ids: createdIds });
+  },
+  async (comp: { ids: string[] } | undefined, { container }) => {
+    if (!comp?.ids?.length) return;
+    const service = container.resolve(FULLFILLED_ORDERS_MODULE) as Fullfilled_ordersService;
+    for (const id of comp.ids) {
+      try {
+        await (service as any).deleteLine_fulfillments(id);
+      } catch {
+        /* the row may already be gone; the rest still need deleting */
+      }
+    }
   }
 );
 
@@ -514,6 +587,9 @@ export const updateInventoryOrderWorkflow = createWorkflow(
     const shouldRecord = transform({ deliveredRecords }, ({ deliveredRecords }) => Array.isArray(deliveredRecords) && (deliveredRecords as any[]).length > 0);
     when(shouldRecord, (b) => Boolean(b)).then(() => {
       appendDeliveredLinesStep({ id: input.id, records: deliveredRecords as unknown as DeliveredLine[] });
+      // #1613 — the same fact into the TYPED record, so the admin delivery is
+      // not invisible to every reader of `line_fulfillments`.
+      recordAdminReceiptsStep({ id: input.id, records: deliveredRecords as unknown as DeliveredLine[] });
     });
 
     // #342 — best-effort §5 status mirror onto the unified core order


### PR DESCRIPTION
Closes the reader half of #1613 — the scope item that reads *"make every reader use `line_fulfillments`"*.

## The bug that is live today

`metadata.partner_delivered_lines` is **overwritten** by the partner path on every submission and **appended to** by the admin path. One key, two writers, two meanings — and both stock readers treated it as the cumulative record.

**Cancel is the reachable one.** `cancel-inventory-order` reverses `already` from that key, so an order the partner delivered twice un-posts only the *second* submission and leaves the first sitting in the warehouse as stock for goods being sent back. The new HTTP case delivers 10 then 6 against a 16-unit line, cancels, and asserts the destination returns to 0. Against `main`'s `src` it returns **10** — the first submission, stranded.

**Deliver is the narrower one.** `computeAdminDeliveryPosting` posts `ordered − already` from the same key, so where the blob understates, Deliver posts stock that was already received. ⚠️ Worth stating plainly: `evaluateAdminStatusTransition` only allows a Deliver from `Pending`/`Processing`, and any order carrying partner receipts is `Partial`/`Shipped`. So the audit job's **58.8 units of "admin would over-post"** is an upper bound on a path the status guard mostly blocks — it is not 58.8 units of live exposure, and I am not claiming this PR recovers it. The fix is still right, and it is the one that makes the number moot.

## Why not simply "read the typed rows"

The two sources disagree in **both** directions. Where the typed side is the one missing an entry — `inv_order_01K3BAM50H…` has 62 units in the blob and **zero** typed rows — switching outright makes `already` *smaller* and the over-posting worse. And summing them double-counts every delivery both records hold, which is most of them.

`resolveDeliveredByLine` takes the **larger** of the two per line. It is the only combination that cannot regress either reader: `already` can only grow, so Deliver can only post less (never phantom stock) and cancel can only reverse more (floored at 0, capped by the level that exists). It is deliberately not exact — an order whose blob was overwritten after an admin append still under-counts that append — which is what the second half fixes.

## Stopping the drift at the source

The admin deliver path wrote its quantities to the metadata blob and **nowhere else**, so every admin delivery was invisible to the typed record: to the partner path's own over-delivery guard, to the drift audit, and to anything asking what an order received. It now writes a typed `line_fulfillment` too (`event_type: "received"`, `metadata.source: "admin_delivery"`, with compensation). From here on the typed rows are the complete record and `max` simply returns them.

## Verification

Every new case was run against `git checkout main -- apps/backend/src` and confirmed to **fail**, then restored and confirmed to pass:

| case | on `main` |
|---|---|
| `reverses BOTH partner submissions on cancel` (HTTP) | ✕ expected 0, received 10 |
| admin Deliver writes a typed receipt (HTTP) | ✕ received `[]` |
| `uses the typed receipts when the blob understates them` | ✕ |
| `sums typed deltas rather than taking the largest row` | ✕ |
| `reverses the full typed quantity, not just the last submission` | ✕ |

The remaining new unit cases exercise `resolveDeliveredByLine` directly (new function) or assert *no* regression, so they pass both ways by design.

- `TEST_TYPE=unit jest cancel-helpers|deliver-helpers|receipt-reconciliation` — 49 passed
- `pnpm test:integration:http:shared ./integration-tests/http/send-to-partner-complete-workflow.spec.ts` — 5 passed
- `pnpm test:integration:http:shared ./integration-tests/http/inventory-orders-api.spec.ts` — 24 passed
- `pnpm check:prod-build` — passed

## Still open on #1613

Reconciling the **historical** rows. That stays a per-order decision, not a global rule: `01KKB850WN…` (blob 3 vs one typed receipt of 1) and `01K36TE2WB…` (a February `reversal_note` with rows on both sides of the reversal) are undecidable from the data and need a human.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01TLt1f38xqR8k2myCVxP8e4