### PR TITLE
feat(payments): let a human create a per-piece breakdown (#1596)

### DIFF
--- a/apps/backend/src/admin/components/creates/create-payment-submission.tsx
+++ b/apps/backend/src/admin/components/creates/create-payment-submission.tsx
@@ -23,6 +23,14 @@ import {
   usePayableRuns,
   type PayableRun,
 } from "../../hooks/api/payment-submissions"
+/**
+ * 🔴 From `rate-breakdown-display`, NOT `rate-breakdown`. This is a Vite
+ * BROWSER bundle: the latter imports `MedusaError`, and pulling it in here
+ * dragged Node built-ins into the dashboard and killed it on
+ * `util.inherits is not a function` — login included — before a pixel
+ * rendered (#1596). The display file imports nothing, and must keep to that.
+ */
+import { groupIntoRateBands } from "../../../workflows/payment_submissions/lib/rate-breakdown-display"
 
 const ELIGIBLE_DESIGN_STATUSES = ["Commerce_Ready", "Approved"] as const
 const ELIGIBLE_TASK_STATUSES = ["completed"] as const
@@ -459,13 +467,46 @@ export const CreatePaymentSubmissionComponent = () => {
       const unitAmounts: Record<string, number> = {}
       const runCostOverrides: Record<string, number> = { ...designCostOverrides }
       const productionRunIds: Record<string, string[]> = {}
+      const rateBreakdown: Record<
+        string,
+        Array<{ quantity: number; unit_amount: number }>
+      > = {}
 
       for (const [designId, line] of runLinesByDesign.entries()) {
         quantities[designId] = line.quantity
         productionRunIds[designId] = line.runs.map((r) => r.run_id)
         if (line.rates.size === 1) {
           unitAmounts[designId] = [...line.rates][0]
+          continue
+        }
+
+        /**
+         * Two runs of one design at DIFFERENT agreed rates (#1596). This used
+         * to send the line TOTAL and stop there — the money right, and every
+         * account of how it was reached thrown away, leaving a line that says
+         * ₹3,750 with a null rate and nothing to explain it.
+         *
+         * The bands say it: "3 × 850 + 1 × 1200". The workflow folds them into
+         * the same total and keeps `unit_amount` NULL, because with two rates
+         * there is no single rate to state and an average is one nobody agreed
+         * to.
+         *
+         * 🔴 The bands are sent INSTEAD of the total, not alongside it. Two
+         * spellings of one figure must agree or the request is refused, and
+         * there is no reason to make the screen state it twice.
+         */
+        const bands = groupIntoRateBands(
+          line.runs.map((r) => ({
+            quantity: getRunQuantity(r),
+            unit_amount: getRunRate(r),
+          }))
+        )
+
+        if (bands) {
+          rateBreakdown[designId] = bands
         } else {
+          // Every rate dropped as unusable (a zero or a negative typed into a
+          // box). Fall back to the exact total rather than billing nothing.
           runCostOverrides[designId] = line.amount
         }
       }
@@ -490,6 +531,10 @@ export const CreatePaymentSubmissionComponent = () => {
         // The evidence behind the money: which finished runs this pays for, so
         // the next submission can refuse to pay for them again.
         production_run_ids: runDesignIds.length ? productionRunIds : undefined,
+        // Per-piece prices, when this selection has any (#1596).
+        rate_breakdown: Object.keys(rateBreakdown).length
+          ? rateBreakdown
+          : undefined,
         /**
          * 🔑 Paying out a COMPLETED RUN, whose proof of finished work is the
          * run itself. Completion moves a design to Technical_Review, so the

--- a/apps/backend/src/admin/hooks/api/payment-submissions.ts
+++ b/apps/backend/src/admin/hooks/api/payment-submissions.ts
@@ -142,6 +142,16 @@ export interface CreateAdminPaymentSubmissionPayload {
    * blob is one spelling mistake away from reading nothing.
    */
   production_run_ids?: Record<string, string[]>
+  /**
+   * Per-piece price bands per design line (#1596) — "3 × 850 + 1 × 1200".
+   *
+   * At least two bands: one is an ordinary priced line and belongs in
+   * `quantities` + `unit_amounts`. Sent INSTEAD of a `cost_overrides` entry for
+   * that design, never alongside one — the workflow refuses two statements of
+   * a line total that disagree, and there is no reason to make the screen state
+   * it twice.
+   */
+  rate_breakdown?: Record<string, Array<{ quantity: number; unit_amount: number }>>
   metadata?: Record<string, any>
 }
 

--- a/apps/backend/src/workflows/payment_submissions/__tests__/rate-breakdown.unit.spec.ts
+++ b/apps/backend/src/workflows/payment_submissions/__tests__/rate-breakdown.unit.spec.ts
@@ -4,6 +4,7 @@ import {
   assertBreakdownMatchesTotal,
   describeRateBreakdown,
   foldRateBreakdown,
+  groupIntoRateBands,
   readRateBreakdown,
 } from "../lib/rate-breakdown"
 
@@ -140,5 +141,114 @@ describe("describeRateBreakdown", () => {
   it("says nothing when there is nothing to say", () => {
     expect(describeRateBreakdown(null)).toBeNull()
     expect(describeRateBreakdown([])).toBeNull()
+  })
+})
+
+/**
+ * #1596, the writer half. The bands rendered from day one and NOTHING could
+ * produce one — both create screens hit the mixed-rate case and sent a typed
+ * line total instead, throwing the structure away. This is the grouping the two
+ * screens now share.
+ */
+describe("groupIntoRateBands (#1596)", () => {
+  it("merges runs at the same rate and orders the bands by rate", () => {
+    expect(
+      groupIntoRateBands([
+        { quantity: 1, unit_amount: 1200 },
+        { quantity: 2, unit_amount: 850 },
+        { quantity: 1, unit_amount: 850 },
+      ])
+    ).toEqual([
+      { quantity: 3, unit_amount: 850 },
+      { quantity: 1, unit_amount: 1200 },
+    ])
+  })
+
+  it("orders by rate, not by the order the runs were picked", () => {
+    // A Set iterates in insertion order, so grouping without a sort makes the
+    // payload depend on which run an admin ticked first — two spellings of one
+    // agreement.
+    const a = groupIntoRateBands([
+      { quantity: 1, unit_amount: 1200 },
+      { quantity: 3, unit_amount: 850 },
+    ])
+    const b = groupIntoRateBands([
+      { quantity: 3, unit_amount: 850 },
+      { quantity: 1, unit_amount: 1200 },
+    ])
+    expect(a).toEqual(b)
+  })
+
+  it("returns null when every run agrees on one rate", () => {
+    // One rate is an ordinary priced line. It belongs in quantity +
+    // unit_amount, where every existing reader already looks — and the
+    // validator refuses a single band anyway.
+    expect(
+      groupIntoRateBands([
+        { quantity: 3, unit_amount: 850 },
+        { quantity: 5, unit_amount: 850 },
+      ])
+    ).toBeNull()
+  })
+
+  it("returns null for nothing at all", () => {
+    expect(groupIntoRateBands([])).toBeNull()
+    expect(groupIntoRateBands(null)).toBeNull()
+    expect(groupIntoRateBands(undefined)).toBeNull()
+  })
+
+  it("drops figures the validator would refuse rather than sending a 400", () => {
+    // A zero or negative in a rate box would fail `.positive()` for the WHOLE
+    // submission, not just that run.
+    expect(
+      groupIntoRateBands([
+        { quantity: 3, unit_amount: 850 },
+        { quantity: 0, unit_amount: 1200 },
+        { quantity: 2, unit_amount: -5 },
+        { quantity: 1, unit_amount: 1200 },
+      ])
+    ).toEqual([
+      { quantity: 3, unit_amount: 850 },
+      { quantity: 1, unit_amount: 1200 },
+    ])
+  })
+
+  it("collapses to null when the surviving runs share one rate", () => {
+    expect(
+      groupIntoRateBands([
+        { quantity: 3, unit_amount: 850 },
+        { quantity: 1, unit_amount: 0 },
+      ])
+    ).toBeNull()
+  })
+
+  it("keeps a summed fractional quantity off the float's edge", () => {
+    // 0.1 + 0.2 is 0.30000000000000004, and the validator would record a
+    // quantity nobody typed.
+    expect(
+      groupIntoRateBands([
+        { quantity: 0.1, unit_amount: 850 },
+        { quantity: 0.2, unit_amount: 850 },
+        { quantity: 1, unit_amount: 1200 },
+      ])
+    ).toEqual([
+      { quantity: 0.3, unit_amount: 850 },
+      { quantity: 1, unit_amount: 1200 },
+    ])
+  })
+
+  it("folds back to exactly the total the collapsed line used to send", () => {
+    // The old behaviour sent Σ(qty × rate) as a typed total. The bands must
+    // reach the same number, or this change moves money.
+    const runs = [
+      { quantity: 3, unit_amount: 850 },
+      { quantity: 1, unit_amount: 1200 },
+    ]
+    const bands = groupIntoRateBands(runs)!
+    const oldTotal =
+      Math.round(runs.reduce((s, r) => s + r.quantity * r.unit_amount, 0) * 100) / 100
+    expect(foldRateBreakdown(bands).amount).toBe(oldTotal)
+    // …and states no single rate, because there isn't one.
+    expect(foldRateBreakdown(bands).unit_amount).toBeNull()
   })
 })

--- a/apps/backend/src/workflows/payment_submissions/lib/rate-breakdown-display.ts
+++ b/apps/backend/src/workflows/payment_submissions/lib/rate-breakdown-display.ts
@@ -59,3 +59,54 @@ export const readRateBreakdown = (item: any): RateSlice[] | null => {
 
   return slices.length >= 2 ? slices : null
 }
+
+/**
+ * Group priced work into the bands a line records (#1596).
+ *
+ * ## Why this is the WRITER's missing half
+ *
+ * The bands rendered from day one and nothing could produce them. Both create
+ * screens hit the mixed-rate case and threw the structure away: two runs of one
+ * design at ₹850 and ₹1,200 collapsed into a single typed TOTAL, and the line
+ * came out saying ₹3,750 with a null rate and no account of how it got there.
+ * The total was right and the explanation was gone — which is the whole of what
+ * #1596 asks for.
+ *
+ * Runs at the SAME rate merge into one band: three separate ₹850 runs are "3 ×
+ * 850", not three bands saying the same thing. Bands come back ordered by rate
+ * so the same selection always sends the same payload — a set's iteration order
+ * is insertion order, and two admins picking the same runs in a different order
+ * would otherwise write two different-looking breakdowns of one agreement.
+ *
+ * 🔴 Returns null below two distinct rates, matching the validator's `.min(2)`
+ * and `readRateBreakdown`'s floor. One rate is an ordinary priced line and
+ * belongs in `quantity` + `unit_amount`, where every existing reader already
+ * looks; sending it here would be a second spelling of a fact that has one.
+ * Zero and negative figures are dropped — the validator refuses them, so a
+ * screen that sends them turns a mistyped box into a 400 for the whole
+ * submission rather than one skipped run.
+ */
+export const groupIntoRateBands = (
+  entries: Array<{ quantity: number; unit_amount: number }> | null | undefined
+): RateSlice[] | null => {
+  const byRate = new Map<number, number>()
+
+  for (const entry of entries || []) {
+    const quantity = Number(entry?.quantity)
+    const rate = Number(entry?.unit_amount)
+    if (!Number.isFinite(quantity) || quantity <= 0) continue
+    if (!Number.isFinite(rate) || rate <= 0) continue
+    byRate.set(rate, (byRate.get(rate) || 0) + quantity)
+  }
+
+  if (byRate.size < 2) return null
+
+  return [...byRate.entries()]
+    .sort(([a], [b]) => a - b)
+    .map(([unit_amount, quantity]) => ({
+      // Guard the float: 0.1 + 0.2 pieces must not reach the validator as
+      // 0.30000000000000004 and read as a quantity nobody typed.
+      quantity: Math.round(quantity * 100) / 100,
+      unit_amount,
+    }))
+}

--- a/apps/backend/src/workflows/payment_submissions/lib/rate-breakdown.ts
+++ b/apps/backend/src/workflows/payment_submissions/lib/rate-breakdown.ts
@@ -41,6 +41,7 @@ import { MedusaError } from "@medusajs/framework/utils"
  */
 export {
   describeRateBreakdown,
+  groupIntoRateBands,
   readRateBreakdown,
 } from "./rate-breakdown-display"
 export type { RateSlice } from "./rate-breakdown-display"

--- a/apps/partner-ui/src/hooks/api/partner-payment-submissions.tsx
+++ b/apps/partner-ui/src/hooks/api/partner-payment-submissions.tsx
@@ -95,6 +95,14 @@ export type CreatePaymentSubmissionPayload = {
    * isn't the contract" shape #1571 exists to close.
    */
   production_run_ids?: Record<string, string[]>
+  /**
+   * Per-piece price bands per design line (#1596) — "3 × 850 + 1 × 1200".
+   *
+   * At least two bands, sent INSTEAD of a `cost_overrides` entry for that
+   * design: two statements of one line total must agree or the request is
+   * refused, and the bands already carry the total.
+   */
+  rate_breakdown?: Record<string, Array<{ quantity: number; unit_amount: number }>>
   metadata?: Record<string, any>
 }
 

--- a/apps/partner-ui/src/lib/__tests__/payment-submission-money.spec.ts
+++ b/apps/partner-ui/src/lib/__tests__/payment-submission-money.spec.ts
@@ -1,6 +1,7 @@
 import { describe, expect, it } from "vitest"
 
 import {
+  groupIntoRateBands,
   money,
   perUnit,
   provenanceLabel,
@@ -188,5 +189,93 @@ describe("perUnit — per-piece price bands", () => {
     )
 
     expect(text).toBeNull()
+  })
+})
+
+/**
+ * The partner create screen's half of #1596. It collapsed two runs of one
+ * design at different rates into a typed line TOTAL — the money right and the
+ * account of how it was reached discarded — because there was no way to send
+ * the bands. This is that grouping.
+ *
+ * 🔴 Mirrors `groupIntoRateBands` in the backend, which owns the shape. These
+ * cases exist so the two cannot drift apart silently: the backend validator
+ * refuses fewer than two bands and refuses a non-positive figure, and a screen
+ * that disagrees turns a mistyped box into a 400 for the whole submission.
+ */
+describe("groupIntoRateBands (#1596)", () => {
+  it("merges runs at the same rate and orders the bands by rate", () => {
+    expect(
+      groupIntoRateBands([
+        { quantity: 1, unit_amount: 1200 },
+        { quantity: 2, unit_amount: 850 },
+        { quantity: 1, unit_amount: 850 },
+      ])
+    ).toEqual([
+      { quantity: 3, unit_amount: 850 },
+      { quantity: 1, unit_amount: 1200 },
+    ])
+  })
+
+  it("does not depend on the order runs were ticked", () => {
+    expect(
+      groupIntoRateBands([
+        { quantity: 1, unit_amount: 1200 },
+        { quantity: 3, unit_amount: 850 },
+      ])
+    ).toEqual(
+      groupIntoRateBands([
+        { quantity: 3, unit_amount: 850 },
+        { quantity: 1, unit_amount: 1200 },
+      ])
+    )
+  })
+
+  it("returns null when one rate covers every run — that is an ordinary line", () => {
+    expect(
+      groupIntoRateBands([
+        { quantity: 3, unit_amount: 850 },
+        { quantity: 5, unit_amount: 850 },
+      ])
+    ).toBeNull()
+    expect(groupIntoRateBands([])).toBeNull()
+    expect(groupIntoRateBands(null)).toBeNull()
+  })
+
+  it("drops figures the backend validator would refuse", () => {
+    expect(
+      groupIntoRateBands([
+        { quantity: 3, unit_amount: 850 },
+        { quantity: 0, unit_amount: 1200 },
+        { quantity: 1, unit_amount: 1200 },
+      ])
+    ).toEqual([
+      { quantity: 3, unit_amount: 850 },
+      { quantity: 1, unit_amount: 1200 },
+    ])
+  })
+
+  it("keeps a summed fractional quantity off the float's edge", () => {
+    expect(
+      groupIntoRateBands([
+        { quantity: 0.1, unit_amount: 850 },
+        { quantity: 0.2, unit_amount: 850 },
+        { quantity: 1, unit_amount: 1200 },
+      ])
+    ).toEqual([
+      { quantity: 0.3, unit_amount: 850 },
+      { quantity: 1, unit_amount: 1200 },
+    ])
+  })
+
+  it("sums to exactly the total the collapsed line used to send", () => {
+    const runs = [
+      { quantity: 3, unit_amount: 850 },
+      { quantity: 1, unit_amount: 1200 },
+    ]
+    const bands = groupIntoRateBands(runs)!
+    const banded = bands.reduce((s, b) => s + b.quantity * b.unit_amount, 0)
+    const oldTotal = runs.reduce((s, r) => s + r.quantity * r.unit_amount, 0)
+    expect(Math.round(banded * 100) / 100).toBe(Math.round(oldTotal * 100) / 100)
   })
 })

--- a/apps/partner-ui/src/lib/payment-submission-money.ts
+++ b/apps/partner-ui/src/lib/payment-submission-money.ts
@@ -102,6 +102,42 @@ const rateBands = (item: any): Array<{ quantity: number; unit_amount: number }> 
   return bands.length >= 2 ? bands : null
 }
 
+/**
+ * Group priced runs into the bands a line records (#1596).
+ *
+ * 🔴 Mirrors `groupIntoRateBands` in
+ * `apps/backend/src/workflows/payment_submissions/lib/rate-breakdown-display.ts`,
+ * which OWNS this shape — partner-ui cannot import across the app boundary, so
+ * the rule is restated. Keep the two in step: the backend validator refuses
+ * fewer than two bands and refuses a non-positive figure, so a screen that
+ * disagrees turns a mistyped box into a 400 for the whole submission.
+ *
+ * Runs at the same rate merge into one band, and bands come back ordered by
+ * rate so the same selection always sends the same payload.
+ */
+export const groupIntoRateBands = (
+  entries: Array<{ quantity: number; unit_amount: number }> | null | undefined
+): Array<{ quantity: number; unit_amount: number }> | null => {
+  const byRate = new Map<number, number>()
+
+  for (const entry of entries || []) {
+    const quantity = Number(entry?.quantity)
+    const rate = Number(entry?.unit_amount)
+    if (!Number.isFinite(quantity) || quantity <= 0) continue
+    if (!Number.isFinite(rate) || rate <= 0) continue
+    byRate.set(rate, (byRate.get(rate) || 0) + quantity)
+  }
+
+  if (byRate.size < 2) return null
+
+  return [...byRate.entries()]
+    .sort(([a], [b]) => a - b)
+    .map(([unit_amount, quantity]) => ({
+      quantity: Math.round(quantity * 100) / 100,
+      unit_amount,
+    }))
+}
+
 /** What the run-provenance note should say, or null for "say nothing". */
 export type ProvenanceLabel = { text: string; muted: boolean } | null
 

--- a/apps/partner-ui/src/routes/payment-submissions/payment-submission-create/payment-submission-create.tsx
+++ b/apps/partner-ui/src/routes/payment-submissions/payment-submission-create/payment-submission-create.tsx
@@ -23,6 +23,7 @@ import {
   usePartnerPayableRuns,
   type PayableRun,
 } from "../../../hooks/api/partner-payable-runs"
+import { groupIntoRateBands } from "../../../lib/payment-submission-money"
 
 const ELIGIBLE_TASK_STATUSES = ["completed"]
 
@@ -374,6 +375,14 @@ export const PaymentSubmissionCreate = () => {
       const costOverrides: Record<string, number> = {}
       const ratesByDesign: Record<string, Set<number>> = {}
       const exactTotals: Record<string, number> = {}
+      const pricedRuns: Record<
+        string,
+        Array<{ quantity: number; unit_amount: number }>
+      > = {}
+      const rateBreakdown: Record<
+        string,
+        Array<{ quantity: number; unit_amount: number }>
+      > = {}
 
       for (const run of eligibleRuns) {
         if (!selectedRunIds.has(run.run_id)) continue
@@ -385,6 +394,7 @@ export const PaymentSubmissionCreate = () => {
         quantities[designId] = (quantities[designId] ?? 0) + qty
         exactTotals[designId] = (exactTotals[designId] ?? 0) + qty * rate
         ;(ratesByDesign[designId] ||= new Set()).add(rate)
+        ;(pricedRuns[designId] ||= []).push({ quantity: qty, unit_amount: rate })
       }
 
       for (const [designId, rates] of Object.entries(ratesByDesign)) {
@@ -392,16 +402,28 @@ export const PaymentSubmissionCreate = () => {
           // One agreed rate across this design's runs — state it per unit, so
           // the reviewer sees the rate and the quantity that produced the sum.
           unitAmounts[designId] = [...rates][0]
+          continue
+        }
+
+        /**
+         * Two runs of one design at DIFFERENT agreed rates. A line carries a
+         * single `unit_amount`, so no per-unit figure is honest here — using
+         * either rate, or an average, misprices the work.
+         *
+         * This used to send the line TOTAL and stop: the money right, and every
+         * account of how it was reached discarded. The bands say it — "3 × 850
+         * + 1 × 1200" — and the workflow folds them into the same total while
+         * keeping `unit_amount` null, which is the truth: there isn't one.
+         *
+         * 🔴 Bands INSTEAD of the total, never both. Two spellings of one
+         * figure must agree or the request is refused.
+         */
+        const bands = groupIntoRateBands(pricedRuns[designId])
+        if (bands) {
+          rateBreakdown[designId] = bands
         } else {
-          /**
-           * Two runs of one design at DIFFERENT agreed rates. A line carries a
-           * single `unit_amount`, so no per-unit figure is honest here — using
-           * either rate, or an average, misprices the work.
-           *
-           * `cost_overrides` is the line TOTAL and wins outright without being
-           * multiplied by quantity, so the exact sum is billed while
-           * `unit_amount` stays null — which is the truth: there isn't one.
-           */
+          // Every rate unusable (a zero or negative in a box). Bill the exact
+          // sum rather than nothing.
           costOverrides[designId] = Math.round(exactTotals[designId] * 100) / 100
         }
       }
@@ -418,6 +440,10 @@ export const PaymentSubmissionCreate = () => {
         task_ids: Array.from(selectedTaskIds),
         notes: notes || undefined,
         production_run_ids: designIds.length ? productionRunIds : undefined,
+        // Per-piece prices, when this selection has any (#1596).
+        rate_breakdown: Object.keys(rateBreakdown).length
+          ? rateBreakdown
+          : undefined,
         quantities: Object.keys(quantities).length ? quantities : undefined,
         unit_amounts: Object.keys(unitAmounts).length ? unitAmounts : undefined,
         cost_overrides: Object.keys(costOverrides).length

--- a/e2e/helpers/e2e-seed.ts
+++ b/e2e/helpers/e2e-seed.ts
@@ -627,6 +627,12 @@ async function seedPayableProductionRuns(container: any): Promise<{
   partnerSumRunAId: string
   partnerSumRunBId: string
   sumDesignName: string
+  partnerMixedRunAId: string
+  partnerMixedRunBId: string
+  mixedDesignName: string
+  adminMixedRunAId: string
+  adminMixedRunBId: string
+  adminMixedDesignName: string
 }> {
   const partnerModule: any = container.resolve("partner")
   const designService: any = container.resolve("design")
@@ -857,6 +863,116 @@ async function seedPayableProductionRuns(container: any): Promise<{
     cost_type: "per_unit",
   })
 
+  /**
+   * #1596 — a pair of runs on one design at DIFFERENT agreed rates: the exact
+   * case the issue was opened for, "3 at ₹850 and 1 at ₹1,200".
+   *
+   * 🔴 Different rates is the whole fixture. The summing pair above is
+   * deliberately 1200 and 1200, so a screen that collapses two rates into one
+   * typed total passes it — the sum is right either way. Only a pair that
+   * DISAGREES can tell a breakdown from an average, and only then does the
+   * line's `unit_amount` have to come back null.
+   *
+   * ⚠️ Its own design again, for the reason the block above gives: a design
+   * already carrying a Pending submission is refused outright, so sharing one
+   * would fail this spec with a message about active submissions that says
+   * nothing about per-piece prices. And these runs are CONSUMED by the
+   * submitting spec — read attempt #1, never a retry.
+   */
+  const mixedDesignName = `Mixed Rate Fixture (e2e ${stamp})`
+  const mixedDesign = await designService.createDesigns({
+    name: mixedDesignName,
+    description: "e2e #1596 per-piece prices fixture",
+    design_type: "Original",
+    status: "Technical_Review",
+    priority: "Medium",
+    estimated_cost: 5000,
+  })
+  const mixedDesignId = (
+    Array.isArray(mixedDesign) ? mixedDesign[0] : mixedDesign
+  ).id as string
+  await remoteLink.create({
+    design: { design_id: mixedDesignId },
+    partner: { partner_id: partner.id },
+  })
+
+  const mkMixedRun = async (overrides: Record<string, any>) => {
+    const run = await runService.createProductionRuns({
+      design_id: mixedDesignId,
+      partner_id: partner.id,
+      run_type: "production",
+      status: "completed",
+      completed_at: new Date(),
+      snapshot: { design: { id: mixedDesignId, name: mixedDesignName } },
+      captured_at: new Date(),
+      ...overrides,
+    })
+    return (Array.isArray(run) ? run[0] : run).id as string
+  }
+
+  const partnerMixedRunAId = await mkMixedRun({
+    quantity: 3,
+    produced_quantity: 3,
+    partner_cost_estimate: 850,
+    cost_type: "per_unit",
+  })
+  const partnerMixedRunBId = await mkMixedRun({
+    quantity: 1,
+    produced_quantity: 1,
+    partner_cost_estimate: 1200,
+    cost_type: "per_unit",
+  })
+
+  /**
+   * The same case again for the ADMIN create screen. A separate design and a
+   * separate pair, because both screens CONSUME what they bill — sharing one
+   * would make whichever spec ran second fail on the double-pay guard, and that
+   * failure looks exactly like a real defect.
+   */
+  const adminMixedDesignName = `Admin Mixed Rate Fixture (e2e ${stamp})`
+  const adminMixedDesign = await designService.createDesigns({
+    name: adminMixedDesignName,
+    description: "e2e #1596 per-piece prices fixture (admin screen)",
+    design_type: "Original",
+    status: "Technical_Review",
+    priority: "Medium",
+    estimated_cost: 5000,
+  })
+  const adminMixedDesignId = (
+    Array.isArray(adminMixedDesign) ? adminMixedDesign[0] : adminMixedDesign
+  ).id as string
+  await remoteLink.create({
+    design: { design_id: adminMixedDesignId },
+    partner: { partner_id: partner.id },
+  })
+
+  const mkAdminMixedRun = async (overrides: Record<string, any>) => {
+    const run = await runService.createProductionRuns({
+      design_id: adminMixedDesignId,
+      partner_id: partner.id,
+      run_type: "production",
+      status: "completed",
+      completed_at: new Date(),
+      snapshot: { design: { id: adminMixedDesignId, name: adminMixedDesignName } },
+      captured_at: new Date(),
+      ...overrides,
+    })
+    return (Array.isArray(run) ? run[0] : run).id as string
+  }
+
+  const adminMixedRunAId = await mkAdminMixedRun({
+    quantity: 3,
+    produced_quantity: 3,
+    partner_cost_estimate: 850,
+    cost_type: "per_unit",
+  })
+  const adminMixedRunBId = await mkAdminMixedRun({
+    quantity: 1,
+    produced_quantity: 1,
+    partner_cost_estimate: 1200,
+    cost_type: "per_unit",
+  })
+
   return {
     partnerId: partner.id as string,
     partnerName: partner.name as string,
@@ -871,6 +987,12 @@ async function seedPayableProductionRuns(container: any): Promise<{
     partnerSumRunAId,
     partnerSumRunBId,
     sumDesignName,
+    partnerMixedRunAId,
+    partnerMixedRunBId,
+    mixedDesignName,
+    adminMixedRunAId,
+    adminMixedRunBId,
+    adminMixedDesignName,
   }
 }
 
@@ -2429,6 +2551,13 @@ export default async function e2eSeed({ container }: ExecArgs) {
     partnerSumRunAId: payableRuns.partnerSumRunAId,
     partnerSumRunBId: payableRuns.partnerSumRunBId,
     sumDesignName: payableRuns.sumDesignName,
+    partnerMixedRunAId: payableRuns.partnerMixedRunAId,
+    partnerMixedRunBId: payableRuns.partnerMixedRunBId,
+    mixedDesignName: payableRuns.mixedDesignName,
+    adminMixedRunAId: payableRuns.adminMixedRunAId,
+    adminMixedRunBId: payableRuns.adminMixedRunBId,
+    adminMixedDesignName: payableRuns.adminMixedDesignName,
+    adminPartnerName: payableRuns.partnerName,
     // #1439 S3/S4 admin quote surface — consumed by admin-quote-surface.spec.ts
     // (admin, CI). NOT single-use: the spec cancels out of the revoke prompt
     // rather than confirming it, so a re-run finds the same active quote.

--- a/e2e/playwright.config.ts
+++ b/e2e/playwright.config.ts
@@ -3,6 +3,10 @@ import * as path from "path"
 
 const BACKEND_DIR = path.resolve(__dirname, "../apps/backend")
 
+const BACKEND_PORT = Number(process.env.E2E_BACKEND_PORT || 9000)
+const BACKEND_URL =
+  process.env.E2E_BACKEND_URL || `http://localhost:${BACKEND_PORT}`
+
 export default defineConfig({
   testDir: path.resolve(__dirname, "specs"),
   fullyParallel: false,
@@ -42,9 +46,21 @@ export default defineConfig({
       : /@partnerui|@localstack|@llm/
     : undefined,
 
+  /**
+   * The backend the admin specs drive.
+   *
+   * 🔴 Overridable because `reuseExistingServer` cannot tell WHOSE server is on
+   * :9000. A second checkout of this repo running its own `medusa develop`
+   * satisfies the port check, and the whole suite then grades the current
+   * branch against somebody else's build — which has already happened: a run
+   * reported `Unrecognized fields: 'rate_breakdown'` against a stale tree while
+   * the branch under test accepted it perfectly. Set `E2E_BACKEND_PORT` (and
+   * `MEDUSA_BACKEND_URL` on the server, so the admin bundle calls itself) to
+   * take a port nobody else holds.
+   */
   webServer: {
     command: `pnpm exec medusa develop`,
-    port: 9000,
+    port: BACKEND_PORT,
     cwd: BACKEND_DIR,
     reuseExistingServer: !process.env.CI,
     stdout: "pipe",
@@ -53,7 +69,7 @@ export default defineConfig({
   },
 
   use: {
-    baseURL: "http://localhost:9000",
+    baseURL: BACKEND_URL,
     trace: "on-first-retry",
     screenshot: "only-on-failure",
     launchOptions: {

--- a/e2e/specs/partner-mixed-rate-payout.spec.ts
+++ b/e2e/specs/partner-mixed-rate-payout.spec.ts
@@ -1,0 +1,264 @@
+import { test, expect } from "@playwright/test"
+import * as fs from "fs"
+import * as path from "path"
+
+/**
+ * #1596 — per-piece prices, from the screen that has to produce them to the
+ * screen that has to explain them.
+ *
+ * ## What was missing
+ *
+ * The `rate_breakdown` column, its validator, the fold, and both renderers all
+ * shipped — and **nothing in any UI could create one**. Every writer was a
+ * curl. Both create screens hit the mixed-rate case and sent a typed line
+ * TOTAL instead: two runs of one design at ₹850 and ₹1,200 became "₹3,750, no
+ * rate", the money right and every account of how it was reached discarded.
+ * That is the shape #1552 closed for opportunities — a field that renders and
+ * nothing can produce.
+ *
+ * And the partner detail screen that renders bands had never been opened in a
+ * browser. It is the screen a partner uses to check what they were paid for,
+ * and the one place the rates they themselves quoted have to read back.
+ *
+ * ## Why a browser spec and not another API case
+ *
+ * The API case for `rate_breakdown` has been green since the column landed. It
+ * proves the route accepts bands; it says nothing about whether a human can
+ * send any. The defect lives entirely in the request the screen builds, so only
+ * a spec that drives the screen can see it.
+ *
+ * ⚠️ CONSUMES `partnerMixedRunAId` / `partnerMixedRunBId` permanently — the
+ * double-pay guard working as designed. A Playwright RETRY therefore fails with
+ * "already recorded on a live payout" whatever went wrong the first time.
+ * **Read attempt #1, never the retries.**
+ *
+ * @partnerui — needs the partner-UI dev server on :5173. Run locally with:
+ *   (cd apps/partner-ui && pnpm dev) &
+ *   pnpm --filter @jyt/backend e2e:test -- partner-mixed-rate-payout
+ */
+
+const SEED_FILE = path.resolve(__dirname, "../../apps/backend/.e2e-seed.json")
+const PARTNER_UI = process.env.PARTNER_UI_URL || "http://localhost:5173"
+/**
+ * The admin app is served by the backend, so it normally rides the config's
+ * `baseURL` and this stays empty. Set it when the backend is not on the default
+ * port — e.g. when another checkout already holds :9000, which is how the first
+ * run of this spec came to be graded against a stale build of somebody else's
+ * branch and reported a defect that did not exist.
+ */
+const ADMIN = process.env.ADMIN_URL || ""
+
+type Seed = {
+  payoutPartnerEmail: string
+  payoutPartnerPassword: string
+  partnerMixedRunAId: string
+  partnerMixedRunBId: string
+  mixedDesignName: string
+  /** Admin login. */
+  email: string
+  password: string
+  adminPartnerName: string
+  adminMixedRunAId: string
+  adminMixedRunBId: string
+  adminMixedDesignName: string
+}
+
+let seed: Seed
+
+const runCard = (page: any, runId: string) =>
+  page.locator(`[data-run-id="${runId}"]`)
+
+test.describe("Partner per-piece prices @partnerui (#1596)", () => {
+  test.beforeAll(() => {
+    if (!fs.existsSync(SEED_FILE)) {
+      throw new Error(
+        `E2E seed file not found at ${SEED_FILE}. Run "pnpm e2e:seed" first.`
+      )
+    }
+    seed = JSON.parse(fs.readFileSync(SEED_FILE, "utf-8"))
+    // A stale seed must fail loudly here rather than as an assertion against
+    // `undefined`, which a `toContain` would happily pass.
+    if (!seed.partnerMixedRunAId || !seed.partnerMixedRunBId) {
+      throw new Error(
+        "E2E seed missing the #1596 mixed-rate fixture — re-run the seed."
+      )
+    }
+  })
+
+  test.beforeEach(async ({ page }) => {
+    await page.goto(`${PARTNER_UI}/login`, { waitUntil: "networkidle" })
+    await page.locator('input[name="email"]').fill(seed.payoutPartnerEmail)
+    await page.locator('input[name="password"]').fill(seed.payoutPartnerPassword)
+    await page.locator('button[type="submit"]').click()
+    await page.waitForFunction(
+      () => !!localStorage.getItem("partner_ui_auth_token"),
+      { timeout: 15_000 }
+    )
+  })
+
+  /**
+   * The whole of #1596 in one pass: bill two runs of one design at different
+   * rates, then read the resulting line back on the screen the partner opens.
+   *
+   * It is one test rather than two because the second half needs a submission
+   * the first half creates, and the runs behind it can only be billed once.
+   * Splitting them would mean either a second fixture pair or a spec whose two
+   * halves must run in order — both worse than asserting twice here.
+   */
+  test("bills two rates as BANDS and reads them back on the detail screen", async ({
+    page,
+  }) => {
+    await page.goto(`${PARTNER_UI}/payment-submissions/create`, {
+      waitUntil: "networkidle",
+    })
+    await page.getByTestId("work-filter-runs").click()
+
+    const a = runCard(page, seed.partnerMixedRunAId)
+    await expect(a).toBeVisible({ timeout: 30_000 })
+    await a.getByRole("checkbox").click()
+    await runCard(page, seed.partnerMixedRunBId).getByRole("checkbox").click()
+
+    // 3 × 850 + 1 × 1200. Averaging the two rates over 4 pieces reaches the
+    // same 3,750, so the total alone cannot tell a breakdown from an average —
+    // which is exactly why the request body is asserted below.
+    await expect(page.getByTestId("submission-total")).toContainText(/3,?750/)
+
+    const [response] = await Promise.all([
+      page.waitForResponse(
+        (r: any) =>
+          r.url().includes("/partners/payment-submissions") &&
+          r.request().method() === "POST"
+      ),
+      page.getByRole("button", { name: /submit for payment/i }).click(),
+    ])
+
+    if (response.status() !== 201) {
+      // The message names which guard refused it; a bare status does not.
+      console.log("[#1596] refused:", await response.text())
+    }
+    expect(response.status()).toBe(201)
+
+    // ── The request the SCREEN built ──────────────────────────────────────
+    const sent = JSON.parse(response.request().postData() || "{}")
+    const designId = Object.keys(sent.production_run_ids || {})[0]
+    expect(designId).toBeTruthy()
+
+    // 🔴 The bands, sent by a human clicking two checkboxes. Before this, this
+    // key was absent from every request any UI has ever made.
+    expect(sent.rate_breakdown?.[designId]).toEqual([
+      { quantity: 3, unit_amount: 850 },
+      { quantity: 1, unit_amount: 1200 },
+    ])
+
+    // 🔴 And NOT also a typed total for the same line. Two spellings of one
+    // figure must agree or the workflow refuses the request outright, so a
+    // screen that sends both is one rounding cent away from a 400 nobody can
+    // explain.
+    expect(sent.cost_overrides?.[designId]).toBeUndefined()
+
+    // ── What the line records ─────────────────────────────────────────────
+    const body = await response.json()
+    const submissionId = body.payment_submission.id
+    // The bands fold to exactly what the collapsed typed total used to send.
+    expect(Number(body.payment_submission.total_amount)).toBe(3750)
+
+    // ── The screen a partner opens to check it ────────────────────────────
+    await page.goto(`${PARTNER_UI}/payment-submissions/${submissionId}`, {
+      waitUntil: "networkidle",
+    })
+    await expect(page.getByText(seed.mixedDesignName).first()).toBeVisible({
+      timeout: 30_000,
+    })
+
+    /**
+     * "3 × ₹850.00 + 1 × ₹1,200.00", not "4 × ₹937.50".
+     *
+     * Scoped to the line's OWN row — a page-wide search would also see the
+     * submission total and could pass on text that never reached this line.
+     *
+     * The pattern is deliberately loose about the currency symbol, the decimals
+     * and the grouping (`money()` renders through `Intl`, so all three depend
+     * on the runner's locale) and strict about everything that matters: both
+     * bands present, each with its own quantity, joined by "+", in that order.
+     * A screen that renders one band and drops the other cannot match it.
+     */
+    const row = page.locator("tr", { hasText: seed.mixedDesignName })
+    await expect(row).toContainText(/3\s*×[^+]*850[^+]*\+\s*1\s*×[^0-9]*1,?200/)
+
+    /**
+     * 🔴 And the average must be absent, not merely un-asserted. A mixed line's
+     * `unit_amount` is null by design — inventing 937.5 would present a rate
+     * nobody agreed to as one the partner had quoted.
+     */
+    await expect(page.getByText(/937\.5/)).toHaveCount(0)
+  })
+
+  /**
+   * The ADMIN create screen, which collapsed the same case the same way.
+   *
+   * 🔴 Verified in a browser rather than trusted to the shared helper's unit
+   * cases, because this screen is the one that has already gone down once for a
+   * reason no unit or integration case could see: it imported the display
+   * helpers from the module that pulls in `MedusaError`, dragging Node built-ins
+   * into the Vite bundle and killing the whole dashboard — login included — on
+   * `util.inherits is not a function`. Everything was green throughout.
+   *
+   * ⚠️ Its own runs, for the same single-use reason as the partner case.
+   */
+  test("the admin screen sends bands too, not a collapsed total", async ({
+    page,
+  }) => {
+    await page.goto(`${ADMIN}/app/login`)
+    // `networkidle` never settles against `medusa develop` (it holds long-lived
+    // connections open), so wait on the form itself.
+    await page.locator('input[name="email"]').waitFor({ timeout: 60_000 })
+    await page.locator('input[name="email"]').fill(seed.email)
+    await page.locator('input[name="password"]').fill(seed.password)
+    await page.locator('button[type="submit"]').click()
+    await page.waitForURL(/\/app\/(?!login)/, { timeout: 15_000 })
+
+    await page.goto(`${ADMIN}/app/payment-submissions/create`)
+    await expect(
+      page.getByRole("heading", { name: "New Payment Submission" })
+    ).toBeVisible({ timeout: 30_000 })
+
+    await page.getByRole("combobox").first().click()
+    await page.getByRole("option", { name: seed.adminPartnerName }).click()
+
+    const row = (runId: string) =>
+      page.locator(`[data-testid="payable-run-row"][data-run-id="${runId}"]`)
+
+    await expect(row(seed.adminMixedRunAId)).toBeVisible({ timeout: 30_000 })
+    await row(seed.adminMixedRunAId).getByRole("checkbox").click()
+    await row(seed.adminMixedRunBId).getByRole("checkbox").click()
+
+    // 3 × 850 + 1 × 1200 = 3,750 — the same figure an average would reach, so
+    // the request body below is what actually distinguishes them.
+    await expect(page.getByTestId("submission-total")).toHaveText("INR 3,750", {
+      timeout: 10_000,
+    })
+
+    const [response] = await Promise.all([
+      page.waitForResponse(
+        (r: any) =>
+          r.url().includes("/admin/payment-submissions") &&
+          r.request().method() === "POST"
+      ),
+      page.getByRole("button", { name: "Create Submission" }).click(),
+    ])
+    if (response.status() !== 201) {
+      console.log("[#1596][admin] refused:", await response.text())
+    }
+    expect(response.status()).toBe(201)
+
+    const sent = JSON.parse(response.request().postData() || "{}")
+    const designId = Object.keys(sent.production_run_ids || {})[0]
+    expect(sent.rate_breakdown?.[designId]).toEqual([
+      { quantity: 3, unit_amount: 850 },
+      { quantity: 1, unit_amount: 1200 },
+    ])
+    // Not also a typed total for the same line — see the partner case.
+    expect(sent.cost_overrides?.[designId]).toBeUndefined()
+    expect(Number(response.json ? (await response.json()).payment_submission.total_amount : 0)).toBe(3750)
+  })
+})


### PR DESCRIPTION
Closes the writer half of #1596 — the gap the last handoff called out first: **nothing in any UI could create a `rate_breakdown`.**

## The gap

The column, validator, fold and both renderers shipped in #1645. Every writer was a curl. Both create screens hit the mixed-rate case and threw the structure away:

```
two runs of one design, ₹850 and ₹1,200  →  cost_overrides = 3750, unit_amount = null
```

The money was right and the account of how it was reached was gone. A partner opening their payout saw a total with no rates — the rates they themselves had quoted.

They now send the bands: `rate_breakdown[designId] = [{3, 850}, {1, 1200}]`.

## The grouping rule

`groupIntoRateBands` is shared in shape by both apps (owned in `rate-breakdown-display.ts`, mirrored in partner-ui, which cannot import across the app boundary — the mirror has its own cases so the two cannot drift silently).

- Runs at the same rate **merge** into one band — three ₹850 runs are `3 × 850`, not three bands saying the same thing.
- Bands come back **ordered by rate**, so the same selection always sends the same payload. A `Set` iterates in insertion order, so without this two admins picking the same runs in a different order would write two different-looking breakdowns of one agreement.
- **Below two distinct rates it returns null** and the line stays an ordinary `quantity` + `unit_amount`, matching the validator's `.min(2)`.
- Zero/negative figures are dropped rather than sent: `.positive()` would 400 the *whole* submission, not skip one run.

🔴 **Bands instead of a `cost_overrides` entry for that design, never both.** Two spellings of one line total must agree or the workflow refuses the request outright. The fold reaches exactly the total the collapsed line used to send — a unit case pins that, so this change cannot move money — and leaves `unit_amount` null, because with two rates there is no rate to state and 937.50 is one nobody agreed to.

## Verification

**Partner path — browser, with a negative control.** `partner-mixed-rate-payout.spec.ts` bills the issue's own example through the real screen, asserts the request body the screen built, then reads the line back on the partner detail screen — which had **never been opened in a browser** until now. Against `main`'s `apps/partner-ui/src`:

```
Expected: [{"quantity": 3, "unit_amount": 850}, {"quantity": 1, "unit_amount": 1200}]
Received: undefined
```

`undefined` is the defect exactly: the key absent from every request any UI has ever made. Restored, it passes, and the detail row reads `3 × ₹850.00 + 1 × ₹1,200.00` with `937.5` asserted **absent**.

⚠️ **The admin case in that file has not run yet — CI is its first run, and I will not merge this until I have watched it pass.** It could not be run locally: the admin bundle bakes its API URL from `MEDUSA_BACKEND_URL` at boot, so served from a non-default port it calls :9000 and every request dies on CORS (which is why its partner picker rendered empty). Its wiring is unit-covered on both sides, but a unit case is not a browser — this is the screen that once took the whole dashboard down, login included, on an import no green suite could see.

- backend unit `rate-breakdown` — 22 passed
- partner-ui `payment-submission-money` — 27 passed
- `pnpm check:prod-build` — passed

## `playwright.config.ts` now takes `E2E_BACKEND_PORT` / `E2E_BACKEND_URL`

🔴 `reuseExistingServer` cannot tell **whose** server is on :9000. A second checkout of this repo running its own `medusa develop` satisfies the port check, and the suite then grades the current branch against somebody else's build. That happened while writing this: a run reported `Unrecognized fields: 'rate_breakdown'` against a stale tree while this branch accepted it perfectly. An escape hatch costs two lines.

## Still open on #1596

The whole-run claim guard — reject-and-replace is still the only way to correct a claimed run. Scoped alongside #1617 per the issue.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01TLt1f38xqR8k2myCVxP8e4