### PR TITLE
feat(ops): recover the material identity pre-#817 order lines never got (#1613)

### DIFF
--- a/apps/backend/integration-tests/http/inventory-order-material-backfill.spec.ts
+++ b/apps/backend/integration-tests/http/inventory-order-material-backfill.spec.ts
@@ -1,0 +1,226 @@
+import { setupSharedTestSuite, getSharedTestEnv } from "./shared-test-setup"
+import { createAdminUser, getAuthHeaders } from "../helpers/create-admin-user"
+
+jest.setTimeout(90 * 1000)
+
+/**
+ * #1613 scope item 4 — populating the material identity that pre-#817 order
+ * lines never got.
+ *
+ * `color` / `material_name` / `raw_material_id` are denormalized onto a line at
+ * CREATE time from the linked inventory item's raw material. Lines written
+ * before that shipped hold NULL in all three, so the order cannot say what
+ * material any of its lines is for — all ten lines on
+ * `inv_order_01K36TE2WB5BQR1MS6KESXP7Q3` are in exactly that state.
+ *
+ * ## Why this drives the real job rather than asserting a clean dry run
+ *
+ * "Scanned N orders, found 0" passes on an empty database whatever the job
+ * does, including nothing. So the fixture MANUFACTURES the defect: create the
+ * order normally (so #817 populates the columns and the module link exists),
+ * then null the columns back out through the module service. That is the
+ * pre-#817 row, reachable in a test, and the assertion is that the values come
+ * back — from the link, not from anything the test told the job.
+ */
+setupSharedTestSuite(() => {
+  const { api, getContainer } = getSharedTestEnv()
+
+  describe("backfill-order-line-material (#1613)", () => {
+    let headers: { headers: Record<string, string> }
+    let stockLocationId: string
+
+    beforeEach(async () => {
+      const container = getContainer()
+      await createAdminUser(container)
+      headers = await getAuthHeaders(api)
+
+      const loc = await api.post(
+        "/admin/stock-locations",
+        { name: "Material Backfill Warehouse" },
+        headers
+      )
+      stockLocationId = loc.data.stock_location.id
+    })
+
+    /**
+     * An inventory item WITH a linked raw material, plus an order line that
+     * points at it — then the line's material columns nulled out.
+     *
+     * Returns the ids, and the values #817 had put there, so the assertion can
+     * compare against what the create path itself produced rather than against
+     * a string this test invented. If the backfill and the creator ever
+     * disagree, that is the failure worth catching.
+     */
+    const seedPreTagLine = async (color: string, name: string) => {
+      const imported = await api.post(
+        "/admin/inventory-items/bulk-import",
+        {
+          items: [
+            {
+              name,
+              composition: "100% Cotton",
+              color,
+              unit_of_measure: "Meter",
+              material_type: "Cotton",
+            },
+          ],
+          stock_location_id: stockLocationId,
+        },
+        headers
+      )
+      expect(imported.status).toBe(201)
+      const itemId = imported.data.created[0].inventory_item.id
+
+      const order = await api.post(
+        "/admin/inventory-orders",
+        {
+          order_lines: [{ inventory_item_id: itemId, quantity: 5, price: 300 }],
+          quantity: 5,
+          total_price: 1500,
+          status: "Pending",
+          expected_delivery_date: new Date().toISOString(),
+          order_date: new Date().toISOString(),
+          shipping_address: {},
+          stock_location_id: stockLocationId,
+        },
+        headers
+      )
+      expect(order.status).toBe(201)
+      const orderId = order.data.inventoryOrder.id
+
+      const service: any = getContainer().resolve("inventory_orders")
+      const [line] = await service.listInventoryOrderLines(
+        { inventory_orders_id: orderId },
+        { select: ["id", "color", "material_name", "raw_material_id"] }
+      )
+      expect(line).toBeDefined()
+
+      // What #817 wrote at creation — the answer the backfill has to reproduce.
+      const asCreated = {
+        color: line.color,
+        material_name: line.material_name,
+        raw_material_id: line.raw_material_id,
+      }
+      expect(asCreated.raw_material_id).toBeTruthy()
+
+      // …and now the pre-#817 row.
+      await service.updateOrderLines({
+        id: line.id,
+        color: null,
+        material_name: null,
+        raw_material_id: null,
+      })
+
+      return { orderId, lineId: line.id, itemId, asCreated, service }
+    }
+
+    it("reports the missing fields without writing when dry_run is true", async () => {
+      const { orderId, lineId } = await seedPreTagLine("Dusty Rose", "Organic Kala Cotton")
+
+      const res = await api.post(
+        "/admin/ops/maintenance-jobs/backfill-order-line-material/run",
+        { dry_run: true, params: { order_id: orderId } },
+        headers
+      )
+      expect(res.status).toBe(200)
+      expect(res.data.result.applied).toBe(false)
+      expect(res.data.result.summary).toContain("Nothing was changed")
+
+      const fields = res.data.result.changes
+        .filter((c: any) => c.id === lineId)
+        .map((c: any) => c.field)
+        .sort()
+      expect(fields).toEqual(["color", "material_name", "raw_material_id"])
+
+      // 🔴 And the row is untouched. A "dry run" that writes is the one failure
+      // this job must never have.
+      const service: any = getContainer().resolve("inventory_orders")
+      const [after] = await service.listInventoryOrderLines(
+        { id: lineId },
+        { select: ["id", "color", "material_name", "raw_material_id"] }
+      )
+      expect(after.color).toBeNull()
+      expect(after.material_name).toBeNull()
+      expect(after.raw_material_id).toBeNull()
+    })
+
+    it("writes exactly what the create path would have written", async () => {
+      const { orderId, lineId, asCreated, service } = await seedPreTagLine(
+        "Indigo",
+        "Handloom Muslin"
+      )
+
+      const res = await api.post(
+        "/admin/ops/maintenance-jobs/backfill-order-line-material/run",
+        { dry_run: false, params: { order_id: orderId } },
+        headers
+      )
+      expect(res.status).toBe(200)
+      expect(res.data.result.applied).toBe(true)
+      expect(res.data.result.errors).toBeUndefined()
+
+      const [after] = await service.listInventoryOrderLines(
+        { id: lineId },
+        { select: ["id", "color", "material_name", "raw_material_id"] }
+      )
+      // 🔑 Compared against what #817 itself produced, not against a literal
+      // this test chose. The backfill must not hold a second opinion.
+      expect(after.color).toBe(asCreated.color)
+      expect(after.material_name).toBe(asCreated.material_name)
+      expect(after.raw_material_id).toBe(asCreated.raw_material_id)
+    })
+
+    it("is idempotent — a second run finds nothing left to do", async () => {
+      const { orderId } = await seedPreTagLine("Madder Red", "Khadi Cotton")
+
+      await api.post(
+        "/admin/ops/maintenance-jobs/backfill-order-line-material/run",
+        { dry_run: false, params: { order_id: orderId } },
+        headers
+      )
+
+      const second = await api.post(
+        "/admin/ops/maintenance-jobs/backfill-order-line-material/run",
+        { dry_run: false, params: { order_id: orderId } },
+        headers
+      )
+      expect(second.data.result.changes).toEqual([])
+      expect(second.data.result.applied).toBe(false)
+    })
+
+    it("never overwrites a value someone already set", async () => {
+      // 🔴 A populated column is somebody's answer. The link is the source for
+      // a line that never got one, not a licence to correct one that did.
+      const { orderId, lineId, asCreated, service } = await seedPreTagLine(
+        "Ivory",
+        "Tussar Silk"
+      )
+      await service.updateOrderLines({ id: lineId, color: "Hand-corrected" })
+
+      await api.post(
+        "/admin/ops/maintenance-jobs/backfill-order-line-material/run",
+        { dry_run: false, params: { order_id: orderId } },
+        headers
+      )
+
+      const [after] = await service.listInventoryOrderLines(
+        { id: lineId },
+        { select: ["id", "color", "material_name", "raw_material_id"] }
+      )
+      expect(after.color).toBe("Hand-corrected")
+      // …while the fields that WERE empty are still filled.
+      expect(after.material_name).toBe(asCreated.material_name)
+      expect(after.raw_material_id).toBe(asCreated.raw_material_id)
+    })
+
+    it("404s on an unknown order rather than reporting a clean scan", async () => {
+      await expect(
+        api.post(
+          "/admin/ops/maintenance-jobs/backfill-order-line-material/run",
+          { dry_run: true, params: { order_id: "inv_order_does_not_exist" } },
+          headers
+        )
+      ).rejects.toMatchObject({ response: { status: 404 } })
+    })
+  })
+})

--- a/apps/backend/src/api/admin/ops/maintenance-jobs/backfill-order-line-material-job.ts
+++ b/apps/backend/src/api/admin/ops/maintenance-jobs/backfill-order-line-material-job.ts
@@ -1,0 +1,254 @@
+import { ContainerRegistrationKeys, MedusaError } from "@medusajs/framework/utils"
+import { z } from "zod"
+
+import { ORDER_INVENTORY_MODULE } from "../../../../modules/inventory_orders"
+import {
+  buildMaterialLookupByInventoryId,
+  planMaterialBackfill,
+  type MaterialInfo,
+} from "../../../../modules/inventory_orders/lib/create-helpers"
+import type {
+  MaintenanceChange,
+  MaintenanceJob,
+  MaintenanceJobResult,
+} from "./registry"
+
+export const MAX_MATERIAL_BACKFILL_SCAN = 1000
+
+const paramsSchema = z.object({
+  order_id: z.string().optional(),
+  limit: z.coerce
+    .number()
+    .int()
+    .positive()
+    .max(MAX_MATERIAL_BACKFILL_SCAN, `limit cannot exceed ${MAX_MATERIAL_BACKFILL_SCAN}`)
+    .optional(),
+})
+
+/**
+ * Populate `color` / `material_name` / `raw_material_id` on order lines written
+ * before #817 S2 (#1613, scope item 4).
+ *
+ * ## What is missing and why
+ *
+ * Those three columns are denormalized onto a line at CREATE time from the
+ * linked inventory item's raw material, so an order is self-describing without
+ * re-traversing line → inventory_item → raw_material. Lines written before that
+ * shipped have all three NULL — all ten on
+ * `inv_order_01K36TE2WB5BQR1MS6KESXP7Q3` do, which is why that order cannot say
+ * what material any of its lines is for. The 20 Jul 2026 order has them
+ * populated, so #817 works; this is a historical population only.
+ *
+ * ## Why this one is writable, when most of #1613 is not
+ *
+ * Nothing is inferred. The values come from `buildMaterialLookupByInventoryId`
+ * — the SAME function the create path uses — reading the module link that has
+ * been the source of truth throughout. A backfilled line ends up holding
+ * exactly what a line created today would hold, not a second opinion about it.
+ *
+ * Contrast the receipt drift in the same issue: there, two records of one
+ * delivery disagree in both directions and no rule can say which is right. Here
+ * there is one record and the line simply never copied it.
+ *
+ * ## What it will not do
+ *
+ *  - It never overwrites a value that is already present, per FIELD — a
+ *    populated column is someone's answer, and the link is the source for a
+ *    line that never got one, not a licence to correct one that did.
+ *  - It never writes a null over a null: an item with no linked raw material is
+ *    left alone, because absence there is not repairable.
+ *  - It never guesses which item a line belongs to. ⚠️ `query.graph` returns one
+ *    ALL-NULL row for an empty relation, so a line with no link at all comes
+ *    back with `inventory_items.length === 1`; the planner filters on a real
+ *    `id` rather than on length.
+ *
+ * ## Writes
+ *
+ * `dry_run: true` (the default) reports. `dry_run: false` writes and READS BACK
+ * every line before counting it — the update form on a module service can
+ * silently no-op, and a backfill that reports success while changing nothing is
+ * worse than one that fails loudly.
+ */
+export const backfillOrderLineMaterialJob: MaintenanceJob = {
+  id: "backfill-order-line-material",
+  label: "Populate material identity on order lines written before #817",
+  description:
+    `color / material_name / raw_material_id are denormalized onto an inventory order line at creation time from the linked inventory item's raw material (#817 S2). Lines created before that have all three NULL, so the order cannot say what material any line is for — all ten lines on inv_order_01K36TE2WB5BQR1MS6KESXP7Q3 are in that state. This copies the values from the module link that has been the source of truth all along, using the SAME lookup the create path uses, so a backfilled line holds exactly what a new one would. It never overwrites a value that is already there (checked per field, and an empty string counts as missing), never writes a null over a null, and never guesses which inventory item a line belongs to. dry_run=true reports; dry_run=false writes and READS BACK every line. Scans up to 'limit' orders (default 200, max ${MAX_MATERIAL_BACKFILL_SCAN}).`,
+  params: [
+    {
+      name: "order_id",
+      type: "string",
+      required: false,
+      description: "Restrict to one inventory order — the safe way to apply a single backfill",
+    },
+    {
+      name: "limit",
+      type: "number",
+      required: false,
+      description: `Max orders to scan in one call (default 200, max ${MAX_MATERIAL_BACKFILL_SCAN})`,
+    },
+  ],
+  run: async (container, { dry_run, params }): Promise<MaintenanceJobResult> => {
+    const parsed = paramsSchema.safeParse(params)
+    if (!parsed.success) {
+      throw new MedusaError(
+        MedusaError.Types.INVALID_DATA,
+        parsed.error.issues.map((i) => i.message).join("; ")
+      )
+    }
+    const { order_id, limit } = parsed.data
+    const take = limit ?? 200
+
+    const logger: any = container.resolve(ContainerRegistrationKeys.LOGGER)
+    const query: any = container.resolve(ContainerRegistrationKeys.QUERY)
+    const inventoryOrderService: any = container.resolve(ORDER_INVENTORY_MODULE)
+
+    const { data: orders } = await query.graph({
+      entity: "inventory_orders",
+      fields: [
+        "id",
+        "orderlines.id",
+        "orderlines.color",
+        "orderlines.material_name",
+        "orderlines.raw_material_id",
+        // The link that has been the source of truth the whole time.
+        "orderlines.inventory_items.id",
+      ],
+      ...(order_id ? { filters: { id: [order_id] } } : {}),
+      pagination: { take, skip: 0 },
+    })
+
+    if (order_id && !(orders || []).length) {
+      throw new MedusaError(
+        MedusaError.Types.NOT_FOUND,
+        `Inventory order ${order_id} not found`
+      )
+    }
+
+    /**
+     * Every inventory item any scanned line points at, resolved in ONE query.
+     * Per-line lookups would be a query per line for no better an answer.
+     */
+    const itemIds = Array.from(
+      new Set(
+        ((orders || []) as any[])
+          .flatMap((o) => o.orderlines || [])
+          .filter(Boolean)
+          .flatMap((l: any) => (l.inventory_items || []) as any[])
+          .map((i: any) => i?.id)
+          .filter(Boolean)
+          .map(String)
+      )
+    )
+
+    let lookup: Record<string, MaterialInfo> = {}
+    if (itemIds.length) {
+      const { data: items } = await query.graph({
+        entity: "inventory_item",
+        fields: ["id", "raw_materials.id", "raw_materials.color", "raw_materials.name"],
+        filters: { id: itemIds },
+      })
+      lookup = buildMaterialLookupByInventoryId(items as any)
+    }
+
+    const changes: MaintenanceChange[] = []
+    const errors: Array<{ id: string; message: string }> = []
+    let linesWritten = 0
+
+    for (const order of (orders || []) as any[]) {
+      const planned = planMaterialBackfill(order.orderlines, lookup)
+      if (!planned.length) continue
+
+      // One update per LINE, not per field: three columns on one row is one
+      // write, and reporting three changes but issuing three updates would
+      // race itself.
+      const byLine = new Map<string, typeof planned>()
+      for (const change of planned) {
+        const existing = byLine.get(change.line_id) || []
+        existing.push(change)
+        byLine.set(change.line_id, existing)
+      }
+
+      for (const [lineId, lineChanges] of byLine) {
+        const line = (order.orderlines || []).find(
+          (l: any) => String(l?.id) === lineId
+        )
+
+        for (const change of lineChanges) {
+          changes.push({
+            entity: "inventory_order_line",
+            id: lineId,
+            field: change.field,
+            before: line?.[change.field] ?? null,
+            after: change.after,
+            note:
+              `order ${order.id}` +
+              ` · from inventory item ${change.inventory_item_id}'s linked raw material`,
+          })
+        }
+
+        if (dry_run) continue
+
+        const update = Object.fromEntries(
+          lineChanges.map((c) => [c.field, c.after])
+        )
+
+        try {
+          await inventoryOrderService.updateOrderLines({ id: lineId, ...update })
+
+          /**
+           * 🔴 Read back. A module service's update form can silently no-op,
+           * and the entire value of this job is that the row afterwards says
+           * what the link says.
+           */
+          const [after] = await inventoryOrderService.listInventoryOrderLines(
+            { id: lineId },
+            { select: ["id", "color", "material_name", "raw_material_id"] }
+          )
+          const stuck = lineChanges.every(
+            (c) => String((after as any)?.[c.field] ?? "") === c.after
+          )
+          if (!after || !stuck) {
+            errors.push({
+              id: lineId,
+              message: `write did not stick: ${JSON.stringify(
+                lineChanges.map((c) => ({
+                  field: c.field,
+                  wanted: c.after,
+                  got: (after as any)?.[c.field] ?? null,
+                }))
+              )}`,
+            })
+            continue
+          }
+
+          linesWritten++
+        } catch (e: any) {
+          errors.push({ id: lineId, message: e?.message ?? String(e) })
+        }
+      }
+    }
+
+    const scanned = (orders || []).length
+    const lines = new Set(changes.map((c) => c.id)).size
+    const summary = dry_run
+      ? `Scanned ${scanned} order(s); ${lines} line(s) are missing material identity the module link can supply (${changes.length} field(s)). Nothing was changed.`
+      : `Scanned ${scanned} order(s); ${lines} line(s) needed material identity, ${linesWritten} written and read back (${changes.length} field(s)).` +
+        (errors.length ? ` ${errors.length} failed — see errors.` : "")
+
+    if (!dry_run && lines) {
+      logger?.info?.(
+        `[backfill-order-line-material] wrote ${linesWritten}/${lines} line(s)`
+      )
+    }
+
+    return {
+      job_id: "backfill-order-line-material",
+      dry_run,
+      applied: !dry_run && linesWritten > 0,
+      summary,
+      changes,
+      ...(errors.length ? { errors } : {}),
+    }
+  },
+}

--- a/apps/backend/src/api/admin/ops/maintenance-jobs/registry.ts
+++ b/apps/backend/src/api/admin/ops/maintenance-jobs/registry.ts
@@ -86,6 +86,7 @@ import { backfillFreightOptionDataJob } from "./backfill-freight-option-data-job
 import { recoverWhatsappMediaJob } from "./recover-whatsapp-media-job"
 import { auditInventoryReceiptDriftJob } from "./audit-inventory-receipt-drift-job"
 import { repairRoundedReceiptQuantitiesJob } from "./repair-rounded-receipt-quantities-job"
+import { backfillOrderLineMaterialJob } from "./backfill-order-line-material-job"
 import { auditPartnerPayoutQuantityJob } from "./audit-partner-payout-quantity-job"
 import { capFreeShippingBandJob } from "./cap-free-shipping-band-job"
 import { deleteOrphanStoreJob } from "./delete-orphan-store-job"
@@ -5858,6 +5859,7 @@ export const MAINTENANCE_JOBS: MaintenanceJob[] = [
   recoverWhatsappMediaJob,
   auditInventoryReceiptDriftJob,
   repairRoundedReceiptQuantitiesJob,
+  backfillOrderLineMaterialJob,
   auditPartnerPayoutQuantityJob,
   capFreeShippingBandJob,
   deleteOrphanStoreJob,

--- a/apps/backend/src/modules/inventory_orders/__tests__/create-helpers.unit.spec.ts
+++ b/apps/backend/src/modules/inventory_orders/__tests__/create-helpers.unit.spec.ts
@@ -4,6 +4,7 @@ import {
   sumLineTotals,
   buildMaterialLookupByInventoryId,
   enrichOrderLinesWithMaterial,
+  planMaterialBackfill,
 } from "../lib/create-helpers"
 
 describe("sumLineTotals (#778 H9 — price is per-unit)", () => {
@@ -142,5 +143,129 @@ describe("buildInventoryLineLinkPairs (#778 C3)", () => {
 
   it("handles the empty case as an empty pairing", () => {
     expect(buildInventoryLineLinkPairs([], [])).toEqual([])
+  })
+})
+
+/**
+ * #1613 scope item 4 — the historical population of the #817 S2 columns.
+ *
+ * All ten lines on `inv_order_01K36TE2WB5BQR1MS6KESXP7Q3` are NULL on colour,
+ * material name and raw material id, so that order cannot say what material any
+ * of its lines is for. The values were always recoverable through the module
+ * link; the lines predate the code that copies them.
+ */
+describe("planMaterialBackfill (#1613 scope item 4)", () => {
+  const info = {
+    color: "Dusty Rose",
+    material_name: "Organic Kala Cotton",
+    raw_material_id: "rm_1",
+  }
+  const lookup = { iitem_1: info }
+
+  const line = (over: Record<string, any> = {}) => ({
+    id: "ol_1",
+    color: null,
+    material_name: null,
+    raw_material_id: null,
+    inventory_items: [{ id: "iitem_1" }],
+    ...over,
+  })
+
+  it("fills all three fields from the link when the line has none", () => {
+    expect(planMaterialBackfill([line()], lookup)).toEqual([
+      { line_id: "ol_1", inventory_item_id: "iitem_1", field: "color", after: "Dusty Rose" },
+      { line_id: "ol_1", inventory_item_id: "iitem_1", field: "material_name", after: "Organic Kala Cotton" },
+      { line_id: "ol_1", inventory_item_id: "iitem_1", field: "raw_material_id", after: "rm_1" },
+    ])
+  })
+
+  it("never overwrites a value that is already there — per FIELD, not per line", () => {
+    // 🔴 A populated column is somebody's answer. The link is the source for a
+    // line that never got one, not a licence to correct one that did. A line
+    // with a colour and no name must still get the name.
+    const planned = planMaterialBackfill(
+      [line({ color: "Indigo" })],
+      lookup
+    )
+    expect(planned.map((c) => c.field)).toEqual(["material_name", "raw_material_id"])
+  })
+
+  it("treats an EMPTY STRING as missing, not as an answer", () => {
+    // `'' ` passes `is not null`. A line holding "" is exactly as unable to say
+    // what it is for as one holding null, and `!= null` would skip it forever.
+    expect(
+      planMaterialBackfill([line({ material_name: "   " })], lookup).map((c) => c.field)
+    ).toEqual(["color", "material_name", "raw_material_id"])
+  })
+
+  it("writes nothing when the item has no linked raw material", () => {
+    // Writing null over null reports work and does none; absence here is not
+    // repairable.
+    expect(
+      planMaterialBackfill([line()], {
+        iitem_1: { color: null, material_name: null, raw_material_id: null },
+      })
+    ).toEqual([])
+  })
+
+  it("fills only the fields the link can actually supply", () => {
+    expect(
+      planMaterialBackfill([line()], {
+        iitem_1: { color: null, material_name: "Kala Cotton", raw_material_id: "rm_2" },
+      }).map((c) => c.field)
+    ).toEqual(["material_name", "raw_material_id"])
+  })
+
+  it("skips a line whose inventory link is the all-null placeholder row", () => {
+    // ⚠️ `query.graph` returns ONE row of nulls for an empty relation, so
+    // `inventory_items.length === 1` for a line with no link at all. Reading
+    // `[0].id` here would carry `undefined` into the lookup.
+    expect(
+      planMaterialBackfill([line({ inventory_items: [{ id: null }] })], lookup)
+    ).toEqual([])
+    expect(planMaterialBackfill([line({ inventory_items: [] })], lookup)).toEqual([])
+    expect(planMaterialBackfill([line({ inventory_items: null })], lookup)).toEqual([])
+  })
+
+  it("skips a line whose item is absent from the lookup entirely", () => {
+    expect(planMaterialBackfill([line()], {})).toEqual([])
+  })
+
+  it("agrees with what the CREATE path would have written", () => {
+    // 🔑 The point of the backfill: a repaired line must hold exactly what a
+    // line created today holds, not a second opinion. Both sides derive from
+    // `buildMaterialLookupByInventoryId`, so this pins them together.
+    const items = [
+      { id: "iitem_1", raw_materials: [{ id: "rm_1", color: "Dusty Rose", name: "Organic Kala Cotton" }] },
+    ]
+    const fromCreate = buildMaterialLookupByInventoryId(items as any)
+    const enriched = enrichOrderLinesWithMaterial(
+      [{ inventory_id: "iitem_1", quantity: 1, price: 300 } as any],
+      fromCreate
+    )[0] as any
+
+    const planned = planMaterialBackfill([line()], fromCreate)
+    for (const change of planned) {
+      expect(change.after).toBe(String(enriched[change.field]))
+    }
+    expect(planned).toHaveLength(3)
+  })
+
+  it("handles several lines, reporting each against its own item", () => {
+    const planned = planMaterialBackfill(
+      [
+        line(),
+        line({ id: "ol_2", inventory_items: [{ id: "iitem_2" }] }),
+      ],
+      {
+        ...lookup,
+        iitem_2: { color: null, material_name: "Muga Silk", raw_material_id: "rm_2" },
+      }
+    )
+    expect(planned.filter((c) => c.line_id === "ol_1")).toHaveLength(3)
+    expect(planned.filter((c) => c.line_id === "ol_2")).toEqual([
+      { line_id: "ol_2", inventory_item_id: "iitem_2", field: "material_name", after: "Muga Silk" },
+      { line_id: "ol_2", inventory_item_id: "iitem_2", field: "raw_material_id", after: "rm_2" },
+    ])
   })
 })

--- a/apps/backend/src/modules/inventory_orders/lib/create-helpers.ts
+++ b/apps/backend/src/modules/inventory_orders/lib/create-helpers.ts
@@ -159,3 +159,97 @@ export const buildInventoryLineLinkPairs = (
     inventory_item_id: order_lines[i].inventory_id,
   }))
 }
+
+/** One order line as the material backfill sees it (#1613 scope item 4). */
+export type OrderLineForMaterialBackfill = {
+  id: string
+  color?: string | null
+  material_name?: string | null
+  raw_material_id?: string | null
+  /** The linked inventory item, as `query.graph` returns the link. */
+  inventory_items?: Array<{ id?: string | null } | null> | null
+}
+
+/** A field the backfill would write on one line, and what it would write. */
+export type MaterialBackfillChange = {
+  line_id: string
+  inventory_item_id: string
+  field: keyof MaterialInfo
+  after: string
+}
+
+/**
+ * ⚠️ Missing, for a denormalized text column, is null OR the empty string.
+ *
+ * A CHECK that asked `is not null` once passed a row holding `''` (#1613's
+ * sibling lesson), and a line whose `material_name` is `""` is exactly as unable
+ * to say what it is for as one holding null — while `!= null` would call it
+ * populated and skip it forever.
+ */
+const isMissing = (value: unknown): boolean =>
+  value == null || String(value).trim() === ""
+
+/**
+ * PURE: what the material backfill would write, per line (#1613 scope item 4).
+ *
+ * ## The gap
+ *
+ * `color` / `material_name` / `raw_material_id` are denormalized onto the line
+ * at CREATE time (#817 S2) from the linked inventory item's raw material. Lines
+ * written before that shipped have all three NULL — all ten on
+ * `inv_order_01K36TE2WB5BQR1MS6KESXP7Q3` do — so the order cannot say what
+ * material any line is for. The 20 Jul 2026 order has them populated, which is
+ * how we know #817 works and this is a historical population only.
+ *
+ * ## Why it is safe to write, unlike the rest of #1613
+ *
+ * Nothing is inferred. The values come from `buildMaterialLookupByInventoryId`
+ * — the SAME function the create path uses — reading the module link that has
+ * been the source of truth all along. A backfilled line therefore holds exactly
+ * what a line created today would hold, rather than a second opinion about it.
+ *
+ * ## What it refuses to do
+ *
+ *  - **Never overwrite a value that is already there.** A populated field is
+ *    someone's answer; the link is the source of truth for a line that never
+ *    got one, not a licence to correct one that did. Per FIELD, not per line —
+ *    a line with a colour but no material name gets the name and keeps the
+ *    colour.
+ *  - **Never write a null.** An item with no linked raw material leaves the
+ *    line alone: absence there is not repairable, and writing null over null
+ *    is a change that reports work and does none.
+ *  - **Never guess the item.** A line whose link resolves to nothing is
+ *    skipped. ⚠️ `query.graph` returns ONE all-null row for an empty relation,
+ *    so `inventory_items.length` is 1 for a line with no link at all — the
+ *    filter below is what stops that phantom becoming an id of `"null"`.
+ */
+export const planMaterialBackfill = (
+  orderlines: OrderLineForMaterialBackfill[] | null | undefined,
+  lookup: Record<string, MaterialInfo>
+): MaterialBackfillChange[] => {
+  const changes: MaterialBackfillChange[] = []
+
+  for (const line of (orderlines || []).filter(Boolean)) {
+    const itemId = (line.inventory_items || []).find((i) => i?.id)?.id
+    if (!itemId) continue
+
+    const info = lookup[String(itemId)]
+    if (!info) continue
+
+    for (const field of ["color", "material_name", "raw_material_id"] as const) {
+      const proposed = info[field]
+      // Nothing to say, or the line already says something — leave it.
+      if (isMissing(proposed)) continue
+      if (!isMissing(line[field])) continue
+
+      changes.push({
+        line_id: String(line.id),
+        inventory_item_id: String(itemId),
+        field,
+        after: String(proposed),
+      })
+    }
+  }
+
+  return changes
+}


### PR DESCRIPTION
#1613 **scope item 4** — the last mechanical piece of that issue.

## What's missing

`color` / `material_name` / `raw_material_id` are denormalized onto an inventory order line at CREATE time from the linked inventory item's raw material (#817 S2). Lines written before that shipped hold NULL in all three, so **the order cannot say what material any of its lines is for** — all ten lines on `inv_order_01K36TE2WB5BQR1MS6KESXP7Q3` are in that state. The 20 Jul 2026 order has them populated, which is how we know #817 works and this is a historical population only.

## Why this one is writable when the rest of #1613 is not

Nothing is inferred. The values come from `buildMaterialLookupByInventoryId` — **the same function the create path uses** — reading the module link that has been the source of truth the whole time. A backfilled line ends up holding exactly what a line created today would hold, rather than a second opinion about it.

Contrast the receipt drift in the same issue: there, two records of one delivery disagree in both directions and no rule can say which is right. Here there is one record and the line simply never copied it.

## What it refuses to do

- **Never overwrites a value already present — per FIELD, not per line.** A populated column is somebody's answer; the link is the source for a line that never got one, not a licence to correct one that did. A line with a colour and no material name gets the name and keeps the colour.
- **`''` counts as missing.** A line holding a blank is exactly as unable to say what it is for as one holding null, and `!= null` would call it populated and skip it forever.
- **Never writes a null over a null.** An item with no linked raw material is left alone — absence there is not repairable, and that write would report work and do none.
- **Never guesses the item.** ⚠️ `query.graph` returns ONE all-null row for an empty relation, so a line with no link at all comes back with `inventory_items.length === 1`. The planner filters on a real `id`, not on length.

`dry_run: true` reports. `dry_run: false` writes and **reads back** every line — a module service's update form can silently no-op, and a backfill that claims success while changing nothing is worse than one that fails loudly.

## Verification

The integration spec **manufactures the defect** rather than asserting a clean scan — "scanned N, found 0" passes on an empty database whatever the job does, including nothing. It creates the order normally (so #817 populates the columns and the link exists), nulls the columns back out through the module service to produce a genuine pre-#817 row, then asserts that what comes back equals **what #817 itself wrote**, not a literal the test chose. If the backfill and the creator ever disagree, that is the failure worth catching.

Mutation-checked: dropping the overwrite guard from the planner turns `is idempotent` and `never overwrites a value someone already set` red, and leaves the others green — the right split.

- 24 unit (`create-helpers`), 5 integration (`inventory-order-material-backfill`), `pnpm check:prod-build`

## After this merges

I'd run it `dry_run: true` against prod first and post the counts on #1613 before writing anything.

## Still open on #1613 after this

Only the part that needs a human: `01KKB850WN…` (blob 3 vs one typed receipt of 1) and `01K36TE2WB…` (a February `reversal_note` with rows on both sides of the reversal) are undecidable from the data.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01TLt1f38xqR8k2myCVxP8e4