### PR TITLE
feat(inventory): buy finished fabric and finished goods, not just raw material (#1662)

### DIFF
--- a/apps/backend/integration-tests/http/inventory-catalog-products.spec.ts
+++ b/apps/backend/integration-tests/http/inventory-catalog-products.spec.ts
@@ -1,0 +1,251 @@
+import { setupSharedTestSuite, getSharedTestEnv } from "./shared-test-setup"
+import { createAdminUser, getAuthHeaders } from "../helpers/create-admin-user"
+
+jest.setTimeout(90 * 1000)
+
+/**
+ * #1662 — an inventory order can only contain raw materials.
+ *
+ * The write path is already generic: `create-inventory-orders` takes a plain
+ * `inventory_item_id`. The entire restriction lives in the picker's catalog
+ * query, `getAllInventoryWithRawMaterial`, whose `query.graph` ENTRY POINT is
+ * the raw-material link table — so a variant-backed inventory item cannot be
+ * emitted by it under any filter. On production that hides ~78 of 225 items.
+ *
+ * These cases pin both halves:
+ *
+ *   1. the gate itself — the raw-materials route omits a product-backed item,
+ *      which is why "just filter it" is not a fix (#1621's shape); and
+ *   2. the new catalog route returns BOTH kinds, tagged, from one enumeration
+ *      of `inventory_item`.
+ *
+ * The fixture creates the two kinds by their real paths — bulk-import for a
+ * raw material, a managed-inventory product variant for a product — so the
+ * linkage under test is the one production writes, not one the test asserts
+ * into place.
+ */
+setupSharedTestSuite(() => {
+  const { api, getContainer } = getSharedTestEnv()
+
+  describe("GET /admin/inventory-items/catalog (#1662)", () => {
+    let headers: { headers: Record<string, string> }
+    let stockLocationId: string
+    let shippingProfileId: string
+
+    const unique = () => `${Date.now()}-${Math.floor(Math.random() * 1e6)}`
+
+    beforeEach(async () => {
+      const container = getContainer()
+      await createAdminUser(container)
+      headers = await getAuthHeaders(api)
+
+      const loc = await api.post(
+        "/admin/stock-locations",
+        { name: `Catalog Warehouse ${unique()}` },
+        headers
+      )
+      stockLocationId = loc.data.stock_location.id
+
+      const profile = await api.post(
+        "/admin/shipping-profiles",
+        { name: `Catalog Profile ${unique()}`, type: "default" },
+        headers
+      )
+      shippingProfileId = profile.data.shipping_profile.id
+    })
+
+    /** A raw-material-linked inventory item — what the picker can see today. */
+    const seedRawMaterialItem = async (name: string) => {
+      const imported = await api.post(
+        "/admin/inventory-items/bulk-import",
+        {
+          items: [
+            {
+              name,
+              composition: "100% Cotton",
+              color: "Indigo",
+              unit_of_measure: "Meter",
+              material_type: "Cotton",
+            },
+          ],
+          stock_location_id: stockLocationId,
+        },
+        headers
+      )
+      expect(imported.status).toBe(201)
+      return imported.data.created[0].inventory_item.id as string
+    }
+
+    /**
+     * A finished good: a product with a managed-inventory variant. Medusa's
+     * create-variants flow makes the inventory item and the variant link — the
+     * item has NO raw material behind it, which is exactly why the picker
+     * cannot see it.
+     */
+    const seedProductItem = async (title: string, sku: string) => {
+      const created = await api.post(
+        "/admin/products",
+        {
+          title,
+          status: "published",
+          shipping_profile_id: shippingProfileId,
+          options: [{ title: "Size", values: ["M"] }],
+          variants: [
+            {
+              title: "M",
+              sku,
+              manage_inventory: true,
+              options: { Size: "M" },
+              prices: [{ amount: 1200, currency_code: "inr" }],
+            },
+          ],
+        },
+        headers
+      )
+      expect(created.status).toBe(200)
+
+      const productId = created.data.product.id
+      const detail = await api.get(
+        `/admin/products/${productId}?fields=variants.id,variants.sku,variants.inventory_items.inventory_item_id`,
+        headers
+      )
+      const variant = detail.data.product.variants[0]
+      const inventoryItemId = variant?.inventory_items?.[0]?.inventory_item_id
+      expect(inventoryItemId).toBeTruthy()
+
+      return {
+        productId,
+        variantId: variant.id as string,
+        inventoryItemId: inventoryItemId as string,
+      }
+    }
+
+    it("the raw-materials route cannot emit a product-backed item — the gate", async () => {
+      const rawItemId = await seedRawMaterialItem(`Kala Cotton ${unique()}`)
+      const { inventoryItemId } = await seedProductItem(
+        `Finished Scarf ${unique()}`,
+        `FIN-${unique()}`
+      )
+
+      const res = await api.get(
+        "/admin/inventory-items/raw-materials?limit=1000",
+        headers
+      )
+      expect(res.status).toBe(200)
+
+      const emitted = res.data.inventory_items.map(
+        (row: any) => row.inventory_item?.id ?? row.inventory_item_id
+      )
+      expect(emitted).toContain(rawItemId)
+      // The whole of #1662 in one assertion.
+      expect(emitted).not.toContain(inventoryItemId)
+    })
+
+    it("returns raw-material AND product-backed items, each tagged", async () => {
+      const rawItemId = await seedRawMaterialItem(`Handloom Silk ${unique()}`)
+      const { inventoryItemId, variantId } = await seedProductItem(
+        `Finished Stole ${unique()}`,
+        `FIN-${unique()}`
+      )
+
+      const res = await api.get(
+        "/admin/inventory-items/catalog?limit=1000",
+        headers
+      )
+      expect(res.status).toBe(200)
+
+      const byId = new Map(
+        res.data.inventory_items.map((r: any) => [r.id, r])
+      )
+
+      const rawRow: any = byId.get(rawItemId)
+      expect(rawRow).toBeDefined()
+      expect(rawRow.kind).toBe("raw_material")
+      expect(rawRow.raw_materials?.id).toBeTruthy()
+
+      const productRow: any = byId.get(inventoryItemId)
+      expect(productRow).toBeDefined()
+      expect(productRow.kind).toBe("product")
+      expect(productRow.raw_materials).toBeNull()
+      expect(productRow.variants.map((v: any) => v.id)).toContain(variantId)
+      expect(productRow.variants[0].product?.title).toBeTruthy()
+
+      // `scanned` is the whole catalog, so a narrow page can never read as a
+      // small catalog (no silent caps).
+      expect(res.data.scanned).toBeGreaterThanOrEqual(res.data.count)
+    })
+
+    it("searches product titles and skus, not just raw-material names", async () => {
+      const marker = unique()
+      const sku = `FIN-${marker}`
+      const { inventoryItemId } = await seedProductItem(
+        `Finished Throw ${marker}`,
+        sku
+      )
+
+      const bySku = await api.get(
+        `/admin/inventory-items/catalog?q=${encodeURIComponent(sku)}`,
+        headers
+      )
+      expect(bySku.status).toBe(200)
+      expect(bySku.data.inventory_items.map((r: any) => r.id)).toContain(
+        inventoryItemId
+      )
+
+      const byTitle = await api.get(
+        `/admin/inventory-items/catalog?q=${encodeURIComponent(
+          `Finished Throw ${marker}`
+        )}`,
+        headers
+      )
+      expect(byTitle.data.inventory_items.map((r: any) => r.id)).toContain(
+        inventoryItemId
+      )
+    })
+
+    it("an inventory order accepts a product-backed line", async () => {
+      const { inventoryItemId } = await seedProductItem(
+        `Finished Dupatta ${unique()}`,
+        `FIN-${unique()}`
+      )
+
+      const order = await api.post(
+        "/admin/inventory-orders",
+        {
+          order_lines: [
+            { inventory_item_id: inventoryItemId, quantity: 4, price: 900 },
+          ],
+          quantity: 4,
+          total_price: 3600,
+          status: "Pending",
+          expected_delivery_date: new Date().toISOString(),
+          order_date: new Date().toISOString(),
+          shipping_address: {},
+          stock_location_id: stockLocationId,
+        },
+        headers
+      )
+      expect(order.status).toBe(201)
+
+      const orderId = order.data.inventoryOrder.id
+      // The item is a module LINK, not a column on the line (the line model's
+      // "linking module links to order line with inventory and product"
+      // comment is aspirational — only the inventory link exists).
+      const detail = await api.get(
+        `/admin/inventory-orders/${orderId}?fields=id,orderlines.*,orderlines.inventory_items.*`,
+        headers
+      )
+      expect(detail.status).toBe(200)
+      const lines = detail.data.inventoryOrder?.orderlines ?? []
+      expect(lines.length).toBe(1)
+
+      const linked = Array.isArray(lines[0].inventory_items)
+        ? lines[0].inventory_items
+        : [lines[0].inventory_items].filter(Boolean)
+      expect(linked.map((i: any) => i?.id)).toContain(inventoryItemId)
+
+      // #817's material denormalization is nullable and simply no-ops here.
+      expect(lines[0].raw_material_id ?? null).toBeNull()
+    })
+  })
+})

--- a/apps/backend/integration-tests/http/inventory-catalog-products.spec.ts
+++ b/apps/backend/integration-tests/http/inventory-catalog-products.spec.ts
@@ -120,6 +120,52 @@ setupSharedTestSuite(() => {
       }
     }
 
+
+    /**
+     * The case #1662 actually exists for: a partner's fabric sold as a product
+     * whose variants do NOT track inventory. Core creates no inventory item for
+     * such a variant and can only ever turn tracking off — so there is nothing
+     * for an `inventory_item` sweep to find. Seeded through the ordinary
+     * product-create path, which is how these arrive in production.
+     */
+    const seedUntrackedVariantProduct = async (title: string, sku: string) => {
+      const created = await api.post(
+        "/admin/products",
+        {
+          title,
+          status: "published",
+          shipping_profile_id: shippingProfileId,
+          options: [{ title: "Size", values: ["M"] }],
+          variants: [
+            {
+              title: "M",
+              sku,
+              manage_inventory: false,
+              options: { Size: "M" },
+              prices: [{ amount: 1200, currency_code: "inr" }],
+            },
+          ],
+        },
+        headers
+      )
+      expect(created.status).toBe(200)
+
+      const productId = created.data.product.id
+      const detail = await api.get(
+        `/admin/products/${productId}?fields=variants.id,variants.sku,variants.manage_inventory,variants.inventory_items.inventory_item_id`,
+        headers
+      )
+      const variant = detail.data.product.variants[0]
+      // The premise of the whole slice: no item exists to be found.
+      const links = variant?.inventory_items
+      const existing = Array.isArray(links) ? links : [links].filter(Boolean)
+      expect(
+        existing.filter((l: any) => l?.inventory_item_id)
+      ).toHaveLength(0)
+
+      return { productId, variantId: variant.id as string }
+    }
+
     it("the raw-materials route cannot emit a product-backed item — the gate", async () => {
       const rawItemId = await seedRawMaterialItem(`Kala Cotton ${unique()}`)
       const { inventoryItemId } = await seedProductItem(
@@ -246,6 +292,147 @@ setupSharedTestSuite(() => {
 
       // #817's material denormalization is nullable and simply no-ops here.
       expect(lines[0].raw_material_id ?? null).toBeNull()
+    })
+
+    it("offers an untracked variant, which no inventory_item sweep could reach", async () => {
+      const marker = unique()
+      const { variantId } = await seedUntrackedVariantProduct(
+        `Greige Fabric ${marker}`,
+        `GRG-${marker}`
+      )
+
+      const res = await api.get(
+        "/admin/inventory-items/catalog?limit=1000",
+        headers
+      )
+      expect(res.status).toBe(200)
+
+      const row = res.data.inventory_items.find(
+        (r: any) => r.variant_id === variantId
+      )
+      expect(row).toBeDefined()
+      expect(row.kind).toBe("untracked_variant")
+      // It cannot be posted as an item, because there is no item.
+      expect(row.inventory_item_id).toBeNull()
+      expect(row.id).toBe(`untracked_variant:${variantId}`)
+    })
+
+    it("ordering an untracked variant creates its inventory item and links the line", async () => {
+      const marker = unique()
+      const { variantId } = await seedUntrackedVariantProduct(
+        `Partner Greige ${marker}`,
+        `PGR-${marker}`
+      )
+
+      const order = await api.post(
+        "/admin/inventory-orders",
+        {
+          // The line names the VARIANT — there is no item id to name yet.
+          order_lines: [{ variant_id: variantId, quantity: 40, price: 120 }],
+          quantity: 40,
+          total_price: 4800,
+          status: "Pending",
+          expected_delivery_date: new Date().toISOString(),
+          order_date: new Date().toISOString(),
+          shipping_address: {},
+          stock_location_id: stockLocationId,
+        },
+        headers
+      )
+      expect(order.status).toBe(201)
+
+      // The variant is tracked now, and has the item core would not create.
+      const detail = await api.get(
+        `/admin/products?fields=variants.id,variants.manage_inventory,variants.inventory_items.inventory_item_id&limit=1000`,
+        headers
+      )
+      const variant = detail.data.products
+        .flatMap((p: any) => p.variants ?? [])
+        .find((v: any) => v.id === variantId)
+      expect(variant.manage_inventory).toBe(true)
+
+      const links = Array.isArray(variant.inventory_items)
+        ? variant.inventory_items
+        : [variant.inventory_items].filter(Boolean)
+      const itemId = links.find((l: any) => l?.inventory_item_id)
+        ?.inventory_item_id
+      expect(itemId).toBeTruthy()
+
+      // And the order line points at that same item, not at nothing.
+      const orderId = order.data.inventoryOrder.id
+      const orderDetail = await api.get(
+        `/admin/inventory-orders/${orderId}?fields=id,orderlines.*,orderlines.inventory_items.*`,
+        headers
+      )
+      const lines = orderDetail.data.inventoryOrder?.orderlines ?? []
+      expect(lines.length).toBe(1)
+      const linked = Array.isArray(lines[0].inventory_items)
+        ? lines[0].inventory_items
+        : [lines[0].inventory_items].filter(Boolean)
+      expect(linked.map((i: any) => i?.id)).toContain(itemId)
+
+      // Nothing has been received, so the level at our location is 0 — the
+      // order must not invent stock it has not taken delivery of.
+      const levels = await api.get(
+        `/admin/inventory-items/${itemId}/location-levels`,
+        headers
+      )
+      expect(levels.status).toBe(200)
+      const level = (levels.data.inventory_levels ?? []).find(
+        (l: any) => l.location_id === stockLocationId
+      )
+      expect(Number(level?.stocked_quantity ?? 0)).toBe(0)
+
+      // Once tracked, it is an ordinary catalog row — not offered twice.
+      const after = await api.get(
+        "/admin/inventory-items/catalog?limit=1000",
+        headers
+      )
+      const rowsForVariant = after.data.inventory_items.filter(
+        (r: any) =>
+          r.variant_id === variantId ||
+          (r.variants ?? []).some((v: any) => v.id === variantId)
+      )
+      expect(rowsForVariant).toHaveLength(1)
+      expect(rowsForVariant[0].kind).toBe("product")
+    })
+
+    it("refuses a line that names both an item and a variant", async () => {
+      const marker = unique()
+      const { variantId } = await seedUntrackedVariantProduct(
+        `Ambiguous Fabric ${marker}`,
+        `AMB-${marker}`
+      )
+      const { inventoryItemId } = await seedProductItem(
+        `Other Good ${marker}`,
+        `OTH-${marker}`
+      )
+
+      const res = await api
+        .post(
+          "/admin/inventory-orders",
+          {
+            order_lines: [
+              {
+                inventory_item_id: inventoryItemId,
+                variant_id: variantId,
+                quantity: 1,
+                price: 10,
+              },
+            ],
+            quantity: 1,
+            total_price: 10,
+            status: "Pending",
+            expected_delivery_date: new Date().toISOString(),
+            order_date: new Date().toISOString(),
+            shipping_address: {},
+            stock_location_id: stockLocationId,
+          },
+          headers
+        )
+        .catch((e: any) => e.response)
+
+      expect(res.status).toBe(400)
     })
   })
 })

--- a/apps/backend/src/admin/components/creates/__tests__/order-line-ref.unit.spec.ts
+++ b/apps/backend/src/admin/components/creates/__tests__/order-line-ref.unit.spec.ts
@@ -1,0 +1,39 @@
+import { toOrderLineRef, variantIdFromRef } from "../order-line-ref"
+
+/**
+ * #1662. The picker holds one value per row for two kinds of row. This is the
+ * only place that reads the synthetic id — the point of the test is that the
+ * synthetic string never leaves the client as an `inventory_item_id`.
+ */
+describe("toOrderLineRef", () => {
+  it("sends a real item id as inventory_item_id", () => {
+    expect(toOrderLineRef("iitem_01ABC")).toEqual({
+      inventory_item_id: "iitem_01ABC",
+    })
+  })
+
+  it("sends an untracked pick as variant_id, never as an item id", () => {
+    const ref = toOrderLineRef("untracked_variant:variant_01XYZ")
+    expect(ref).toEqual({ variant_id: "variant_01XYZ" })
+    expect(ref).not.toHaveProperty("inventory_item_id")
+  })
+
+  it("emits exactly one key, matching the validator's either/or rule", () => {
+    expect(Object.keys(toOrderLineRef("iitem_1")!)).toEqual(["inventory_item_id"])
+    expect(Object.keys(toOrderLineRef("untracked_variant:v_1")!)).toEqual([
+      "variant_id",
+    ])
+  })
+
+  it("returns null for an empty pick, so a blank row is dropped not sent", () => {
+    expect(toOrderLineRef("")).toBeNull()
+    expect(toOrderLineRef(undefined)).toBeNull()
+  })
+
+  it("treats a prefix with nothing after it as not a variant reference", () => {
+    expect(variantIdFromRef("untracked_variant:")).toBeNull()
+    expect(toOrderLineRef("untracked_variant:")).toEqual({
+      inventory_item_id: "untracked_variant:",
+    })
+  })
+})

--- a/apps/backend/src/admin/components/creates/create-inventory-order.tsx
+++ b/apps/backend/src/admin/components/creates/create-inventory-order.tsx
@@ -12,6 +12,7 @@ import { useStockLocations } from "../../hooks/api/stock_location";
 import { useInventoryCatalog } from "../../hooks/api/raw-materials";
 import { InventoryOrderLinesGrid } from "./inventory-order-lines-grid";
 import { AddMaterialGroupControl } from "../inventory-orders/add-material-group-control";
+import { toOrderLineRef } from "./order-line-ref";
 
 // Define a Zod schema for inventory order creation (scaffolded, update as per API contract)
 export const inventoryOrderFormSchema = z
@@ -175,10 +176,12 @@ export const CreateInventoryOrderComponent = () => {
       status: "Pending",
       shipping_address: {},
       is_sample: data.is_sample,
+      // #1662 — a picked row is either an existing inventory item or an
+      // untracked variant; `toOrderLineRef` sends the right field for each.
       order_lines: fields
         .filter((l: OrderLine) => l.inventory_item_id)
         .map(({ inventory_item_id, quantity, price, batch_number }: OrderLine) => ({
-          inventory_item_id,
+          ...toOrderLineRef(inventory_item_id),
           quantity: Number(quantity) || 0,
           price: Number(price) || 0,
           batch_number: batch_number ?? null,

--- a/apps/backend/src/admin/components/creates/create-inventory-order.tsx
+++ b/apps/backend/src/admin/components/creates/create-inventory-order.tsx
@@ -9,7 +9,7 @@ import { KeyboundForm } from "../utilitites/key-bound-form";
 import { Form } from "../common/form";
 import { useState, useEffect } from "react";
 import { useStockLocations } from "../../hooks/api/stock_location";
-import { useAllInventoryWithRawMaterials } from "../../hooks/api/raw-materials";
+import { useInventoryCatalog } from "../../hooks/api/raw-materials";
 import { InventoryOrderLinesGrid } from "./inventory-order-lines-grid";
 import { AddMaterialGroupControl } from "../inventory-orders/add-material-group-control";
 
@@ -120,7 +120,11 @@ export const CreateInventoryOrderComponent = () => {
   // closed the dropdown and wiped the query (the "search flickers / closes on
   // the earlier value" flakiness). A single large fetch + local narrowing is
   // stable and covers our catalog size.
-  const { inventory_items = [], isLoading } = useAllInventoryWithRawMaterials();
+  // #1662 — the catalog, not just the raw-material link table. Buying finished
+  // fabric or finished goods from a partner is an inventory order (a PURCHASE,
+  // not a make); the write path was always generic, only this query's entry
+  // point was not.
+  const { inventory_items = [], isLoading } = useInventoryCatalog();
 
   // Use Field Array for order lines
   const { fields, append, remove } = useFieldArray({

--- a/apps/backend/src/admin/components/creates/inventory-order-lines-grid.tsx
+++ b/apps/backend/src/admin/components/creates/inventory-order-lines-grid.tsx
@@ -14,6 +14,18 @@ import { firstMediaUrl } from "../../lib/utils/first-media-url";
 
 type PickerOption = { label: string; value: string; keywords?: string; disabled?: boolean };
 
+/** A picked catalog row: a material-backed item, a variant-backed one, or neither. */
+type PickedInventoryItem = InventoryItem & {
+  raw_materials?: RawMaterial | null
+  variants?: Array<{
+    id: string
+    title?: string | null
+    sku?: string | null
+    product?: { id: string; title?: string | null; thumbnail?: string | null } | null
+  }>
+  kind?: "raw_material" | "product" | "both" | "unclassified"
+}
+
 /**
  * Item picker cell — a real (ariakit) Combobox instead of a search box wedged
  * inside a Radix Select. The Select approach fought Radix's focus/typeahead and
@@ -222,13 +234,20 @@ export const InventoryOrderLinesGrid = <T extends { id: string; title?: string; 
     return mergedItems.map((item: any) => {
       const inv = item?.inventory_item ?? item
       const raw = item?.raw_materials
-      const baseLabel = raw?.name || inv?.title || inv?.sku || ""
+      // #1662 — an item can be variant-backed instead of material-backed
+      // (finished fabric / finished goods bought from a partner). Those have
+      // no raw-material name, so the product/variant is what names them.
+      const variant = (item?.variants ?? [])[0]
+      const productLabel = [variant?.product?.title, variant?.title]
+        .filter(Boolean)
+        .join(" · ")
+      const baseLabel = raw?.name || productLabel || inv?.title || inv?.sku || ""
       // #846 — many colors of one material share the same raw-material name
       // (e.g. 12 "Tangaliya weave suit piece"), which made the picker options
       // visually identical and read as "missing/duplicate items". Disambiguate
       // the visible label with color and SKU so every option is distinct.
       const color = raw?.color
-      const sku = inv?.sku
+      const sku = inv?.sku || variant?.sku
       // Don't re-append a color the name already carries (newer group colors
       // fold the color into the raw-material name at creation — #846).
       const showColor =
@@ -244,7 +263,16 @@ export const InventoryOrderLinesGrid = <T extends { id: string; title?: string; 
       const value = item?.inventory_item_id || inv?.id || item?.id
       // Searchable keywords beyond the visible name so the picker matches on
       // color / material / sku too (#831 — quick matching).
-      const keywords = [raw?.name, raw?.color, raw?.material_name, inv?.title, inv?.sku]
+      const keywords = [
+        raw?.name,
+        raw?.color,
+        raw?.material_name,
+        inv?.title,
+        inv?.sku,
+        variant?.title,
+        variant?.sku,
+        variant?.product?.title,
+      ]
         .filter(Boolean)
         .join(" ")
         .toLowerCase()
@@ -253,16 +281,24 @@ export const InventoryOrderLinesGrid = <T extends { id: string; title?: string; 
   }, [mergedItems])
 
   const inventoryItemMap = useMemo(() => {
-    const map = new Map<
-      string,
-      (InventoryItem & { raw_materials?: RawMaterial | null }) | null
-    >()
+    const map = new Map<string, PickedInventoryItem | null>()
     mergedItems.forEach((item: any) => {
       const inv = (item?.inventory_item ?? item) as InventoryItem | undefined
       const raw = item?.raw_materials as RawMaterial | undefined
       const value = item?.inventory_item_id || inv?.id || item?.id
       if (value) {
-        map.set(value, inv ? { ...inv, raw_materials: raw } : null)
+        map.set(
+          value,
+          inv
+            ? {
+                ...inv,
+                raw_materials: raw,
+                // #1662 — what the line is FOR, when it is not a material.
+                variants: item?.variants ?? [],
+                kind: item?.kind,
+              }
+            : null
+        )
       }
     })
     return map
@@ -321,6 +357,54 @@ export const InventoryOrderLinesGrid = <T extends { id: string; title?: string; 
         );
       },
       disableHiding: true,
+    }),
+    columnHelper.column({
+      id: "kind",
+      name: "Type",
+      header: "Type",
+      cell: (context: any) => {
+        // #1662 — a partner making a garment FOR us is a production run; a
+        // partner selling us finished stock is this. Once the picker can see
+        // both, the same real-world event could be recorded either way, so the
+        // distinction has to be visible on the line rather than left to
+        // whoever opened the form.
+        const inventoryItemId =
+          lineAt(context.row.index)?.inventory_item_id || ""
+        const item = inventoryItemId
+          ? inventoryItemMap.get(inventoryItemId)
+          : null
+        const variant = (item?.variants ?? [])[0]
+        const label = item?.raw_materials
+          ? "Material"
+          : variant
+          ? "Finished goods"
+          : null
+        const detail = item?.raw_materials
+          ? null
+          : [variant?.product?.title, variant?.title].filter(Boolean).join(" · ")
+
+        return (
+          <div className="flex h-full items-center gap-x-2 px-4">
+            {label ? (
+              <Badge
+                size="2xsmall"
+                color={item?.raw_materials ? "grey" : "blue"}
+              >
+                {label}
+              </Badge>
+            ) : (
+              <Text size="small" className="text-ui-fg-muted">
+                —
+              </Text>
+            )}
+            {detail ? (
+              <Text size="small" className="truncate text-ui-fg-subtle">
+                {detail}
+              </Text>
+            ) : null}
+          </div>
+        )
+      },
     }),
     columnHelper.column({
       id: "color",

--- a/apps/backend/src/admin/components/creates/inventory-order-lines-grid.tsx
+++ b/apps/backend/src/admin/components/creates/inventory-order-lines-grid.tsx
@@ -23,7 +23,15 @@ type PickedInventoryItem = InventoryItem & {
     sku?: string | null
     product?: { id: string; title?: string | null; thumbnail?: string | null } | null
   }>
-  kind?: "raw_material" | "product" | "both" | "unclassified"
+  kind?:
+    | "raw_material"
+    | "product"
+    | "both"
+    | "unclassified"
+    // #1662 — a partner variant that has no inventory item yet. Picking it is
+    // what creates one, at our location, when the order is written.
+    | "untracked_variant"
+  partner?: { id: string; name?: string | null } | null
 }
 
 /**
@@ -252,10 +260,14 @@ export const InventoryOrderLinesGrid = <T extends { id: string; title?: string; 
       // fold the color into the raw-material name at creation — #846).
       const showColor =
         color && !baseLabel.toLowerCase().includes(String(color).toLowerCase())
+      // #1662 — whose fabric is this? A buyer choosing between two partners'
+      // near-identical greige needs the owner on the option, not one click away.
+      const partnerName = item?.partner?.name
       const label = [
         baseLabel,
         showColor ? `— ${color}` : "",
         sku ? `(${sku})` : "",
+        partnerName ? `· ${partnerName}` : "",
       ]
         .filter(Boolean)
         .join(" ")
@@ -272,6 +284,7 @@ export const InventoryOrderLinesGrid = <T extends { id: string; title?: string; 
         variant?.title,
         variant?.sku,
         variant?.product?.title,
+        item?.partner?.name,
       ]
         .filter(Boolean)
         .join(" ")
@@ -296,6 +309,7 @@ export const InventoryOrderLinesGrid = <T extends { id: string; title?: string; 
                 // #1662 — what the line is FOR, when it is not a material.
                 variants: item?.variants ?? [],
                 kind: item?.kind,
+                partner: item?.partner ?? null,
               }
             : null
         )
@@ -374,21 +388,37 @@ export const InventoryOrderLinesGrid = <T extends { id: string; title?: string; 
           ? inventoryItemMap.get(inventoryItemId)
           : null
         const variant = (item?.variants ?? [])[0]
+        const untracked = item?.kind === "untracked_variant"
         const label = item?.raw_materials
           ? "Material"
+          : untracked
+          ? "Not stocked yet"
           : variant
           ? "Finished goods"
           : null
         const detail = item?.raw_materials
           ? null
-          : [variant?.product?.title, variant?.title].filter(Boolean).join(" · ")
+          : [
+              [variant?.product?.title, variant?.title]
+                .filter(Boolean)
+                .join(" · "),
+              item?.partner?.name ? `from ${item.partner.name}` : "",
+              // Say what picking this row will DO. It turns tracking on for the
+              // variant at our location — a real side effect of placing the
+              // order, and one the buyer should not discover afterwards.
+              untracked ? "· we will start tracking it on order" : "",
+            ]
+              .filter(Boolean)
+              .join(" ")
 
         return (
           <div className="flex h-full items-center gap-x-2 px-4">
             {label ? (
               <Badge
                 size="2xsmall"
-                color={item?.raw_materials ? "grey" : "blue"}
+                color={
+                  item?.raw_materials ? "grey" : untracked ? "orange" : "blue"
+                }
               >
                 {label}
               </Badge>

--- a/apps/backend/src/admin/components/creates/order-line-ref.ts
+++ b/apps/backend/src/admin/components/creates/order-line-ref.ts
@@ -1,0 +1,37 @@
+/**
+ * #1662 — how a picked catalog row becomes an order-line reference.
+ *
+ * The picker holds ONE value per row, but the catalog has two kinds of row:
+ * an inventory item that exists, and a product variant that has none yet
+ * (a partner's fabric or finished good, which core never gave an inventory
+ * item). The untracked rows carry a deliberately synthetic id so the two can
+ * never be confused — and this is the ONLY place that reads it. The API is
+ * sent `variant_id`, never the synthetic string, so the server-side contract
+ * stays two named fields rather than one overloaded one.
+ */
+export const UNTRACKED_VARIANT_PREFIX = "untracked_variant:"
+
+export const isUntrackedVariantRef = (value?: string | null): boolean =>
+  typeof value === "string" && value.startsWith(UNTRACKED_VARIANT_PREFIX)
+
+export const variantIdFromRef = (value?: string | null): string | null =>
+  isUntrackedVariantRef(value)
+    ? (value as string).slice(UNTRACKED_VARIANT_PREFIX.length) || null
+    : null
+
+/**
+ * Split one picked value into the field the API expects. Exactly one of the
+ * two keys is present, matching the validator's either/or rule.
+ */
+export const toOrderLineRef = (
+  value?: string | null
+): { inventory_item_id: string } | { variant_id: string } | null => {
+  if (!value) {
+    return null
+  }
+  const variantId = variantIdFromRef(value)
+  if (variantId) {
+    return { variant_id: variantId }
+  }
+  return { inventory_item_id: value }
+}

--- a/apps/backend/src/admin/components/inventory-orders/edit-order-lines.tsx
+++ b/apps/backend/src/admin/components/inventory-orders/edit-order-lines.tsx
@@ -5,7 +5,7 @@ import { Button, Heading, Text, toast } from "@medusajs/ui";
 import { useRouteModal } from "../modal/use-route-modal";
 import { RouteFocusModal } from "../modal/route-focus-modal";
 import { KeyboundForm } from "../utilitites/key-bound-form";
-import { useAllInventoryWithRawMaterials } from "../../hooks/api/raw-materials";
+import { useInventoryCatalog } from "../../hooks/api/raw-materials";
 import { InventoryOrderLinesGrid } from "../creates/inventory-order-lines-grid";
 import { AddMaterialGroupControl } from "./add-material-group-control";
 import { AdminInventoryOrder } from "../../hooks/api/inventory-orders";
@@ -76,7 +76,9 @@ export const EditOrderLines = ({ inventoryOrder }: EditOrderLinesProps) => {
   // was dropped: the per-keystroke refetch remounted the picker cell and made
   // search flaky). The fetch-all hook pages until the endpoint's true count is
   // reached so a large catalog no longer silently truncates (#947).
-  const { inventory_items = [], isLoading } = useAllInventoryWithRawMaterials();
+  // #1662 — same catalog as the create screen, so a product-backed line stays
+  // editable (and resolvable) instead of vanishing from the picker.
+  const { inventory_items = [], isLoading } = useInventoryCatalog();
 
   // Use Field Array for order lines.
   // keyName MUST NOT be the default "id": react-hook-form overwrites the row's

--- a/apps/backend/src/admin/components/inventory-orders/order-lines-payload.ts
+++ b/apps/backend/src/admin/components/inventory-orders/order-lines-payload.ts
@@ -15,6 +15,8 @@
  * These functions therefore assume existing rows carry their real DB id.
  */
 
+import { toOrderLineRef } from "../creates/order-line-ref";
+
 export interface EditableOrderLine {
   /** DB order-line id for existing lines; absent/undefined for brand-new rows. */
   id?: string;
@@ -29,6 +31,8 @@ export interface EditableOrderLine {
 export interface OrderLineUpdateEntry {
   id?: string;
   inventory_item_id?: string;
+  /** #1662 — set instead of `inventory_item_id` for an untracked variant row. */
+  variant_id?: string;
   quantity?: number;
   price?: number;
   batch_number?: number | null;
@@ -72,7 +76,9 @@ export function buildOrderLinesUpdatePayload(
 ): OrderLinesUpdatePayload {
   const keep: OrderLineUpdateEntry[] = currentLines.map((line) => ({
     id: line.isExisting && line.id ? line.id : undefined,
-    inventory_item_id: line.inventory_item_id,
+    // #1662 — an untracked-variant pick is sent as `variant_id`; the synthetic
+    // picker id never reaches the API.
+    ...toOrderLineRef(line.inventory_item_id),
     quantity: Number(line.quantity) || 0,
     price: Number(line.price) || 0,
     batch_number: line.batch_number ?? null,

--- a/apps/backend/src/admin/hooks/api/raw-materials.ts
+++ b/apps/backend/src/admin/hooks/api/raw-materials.ts
@@ -514,6 +514,13 @@ export type InventoryCatalogKind =
   | "product"
   | "both"
   | "unclassified"
+  /**
+   * #1662 — a product variant with NO inventory item. Not a gap in the data:
+   * core never creates an item for `manage_inventory: false`, and can only ever
+   * turn tracking off. These rows are pickable; the order write is what
+   * establishes the item, at our location.
+   */
+  | "untracked_variant"
 
 export type InventoryCatalogItem = InventoryItem & {
   raw_materials?: RawMaterial | null
@@ -524,6 +531,10 @@ export type InventoryCatalogItem = InventoryItem & {
     product?: { id: string; title?: string | null; thumbnail?: string | null } | null
   }>
   kind?: InventoryCatalogKind
+  /** Set on an `untracked_variant` row; null on a row backed by a real item. */
+  variant_id?: string | null
+  /** Which partner's product this is, when one owns it. */
+  partner?: { id: string; name?: string | null } | null
 }
 
 export interface InventoryCatalogResponse {

--- a/apps/backend/src/admin/hooks/api/raw-materials.ts
+++ b/apps/backend/src/admin/hooks/api/raw-materials.ts
@@ -499,3 +499,102 @@ export const useAllInventoryWithRawMaterials = (
 
   return { ...data, ...rest }
 };
+/**
+ * #1662 — the whole pickable catalog: raw-material-linked items AND the
+ * variant-backed ones an inventory order could never see, because
+ * `/admin/inventory-items/raw-materials` enumerates the raw-material LINK
+ * table and cannot emit an item that has no material behind it.
+ *
+ * Rows come back in the same shape that route emits (`raw_materials` is the
+ * single linked material, or null), plus `variants` and a derived `kind`, so
+ * the order-lines picker can swap its source without a second parsing rule.
+ */
+export type InventoryCatalogKind =
+  | "raw_material"
+  | "product"
+  | "both"
+  | "unclassified"
+
+export type InventoryCatalogItem = InventoryItem & {
+  raw_materials?: RawMaterial | null
+  variants?: Array<{
+    id: string
+    title?: string | null
+    sku?: string | null
+    product?: { id: string; title?: string | null; thumbnail?: string | null } | null
+  }>
+  kind?: InventoryCatalogKind
+}
+
+export interface InventoryCatalogResponse {
+  inventory_items: InventoryCatalogItem[]
+  count?: number
+  /** The whole catalog before `q`/`kinds` — so a narrow page never reads as a small catalog. */
+  scanned?: number
+  offset?: number
+  limit?: number
+}
+
+const INVENTORY_CATALOG_PAGE_SIZE = 200
+
+export const useInventoryCatalog = (
+  baseQuery?: Record<string, any>,
+  options?: Omit<
+    UseQueryOptions<
+      InventoryCatalogResponse,
+      FetchError,
+      InventoryCatalogResponse,
+      QueryKey
+    >,
+    "queryKey" | "queryFn"
+  >
+) => {
+  const query = { ...(baseQuery ?? {}) }
+  delete query.limit
+  delete query.offset
+
+  const { data, ...rest } = useQuery<
+    InventoryCatalogResponse,
+    FetchError,
+    InventoryCatalogResponse,
+    QueryKey
+  >({
+    queryKey: [...inventoryItemsRawMaterialQueryKeys.lists(), "catalog", query],
+    queryFn: async () => {
+      const accumulated: InventoryCatalogItem[] = []
+      let offset = 0
+      // Same guard as the raw-materials fetch-all: bound the round-trips, not
+      // the result — a page cap here would be the silent truncation of #947.
+      const maxPages = 500
+      for (let page = 0; page < maxPages; page++) {
+        const res = await sdk.client.fetch<InventoryCatalogResponse>(
+          `/admin/inventory-items/catalog`,
+          {
+            method: "GET",
+            query: {
+              ...query,
+              limit: INVENTORY_CATALOG_PAGE_SIZE,
+              offset,
+            },
+          }
+        )
+        const batch = res.inventory_items ?? []
+        accumulated.push(...batch)
+        const total = res.count ?? accumulated.length
+        offset += batch.length
+        if (batch.length === 0 || offset >= total) {
+          break
+        }
+      }
+      return {
+        inventory_items: accumulated,
+        count: accumulated.length,
+        offset: 0,
+        limit: accumulated.length,
+      }
+    },
+    ...options,
+  })
+
+  return { ...data, ...rest }
+}

--- a/apps/backend/src/api/admin/inventory-items/catalog/__tests__/helpers.unit.spec.ts
+++ b/apps/backend/src/api/admin/inventory-items/catalog/__tests__/helpers.unit.spec.ts
@@ -1,0 +1,201 @@
+import { getInventoryCatalog } from "../helpers"
+
+/**
+ * #1662. The catalog's first sweep enumerates `inventory_item`, which can only
+ * ever emit variants that ALREADY have one. The behaviours pinned here are the
+ * ones that would go wrong silently:
+ *
+ *  - an untracked variant appears at all (the fabric case: many variants, none
+ *    tracked, and no filter on the old sweep could reach them);
+ *  - it is judged on the ABSENCE OF AN ITEM, not on `manage_inventory` — a
+ *    tracked-but-itemless variant is just as unorderable;
+ *  - a variant that HAS an item is not emitted twice, once per source;
+ *  - the untracked row carries `variant_id` and a null `inventory_item_id`, so
+ *    the caller cannot post the synthetic display id as an item.
+ */
+
+const buildContainer = (opts: {
+  items?: any[]
+  products?: any[]
+  partners?: any[]
+  partnerThrows?: boolean
+}) => {
+  const graph = jest.fn(async ({ entity }: any) => {
+    if (entity === "inventory_item") {
+      return { data: opts.items ?? [] }
+    }
+    if (entity === "product") {
+      return { data: opts.products ?? [] }
+    }
+    if (entity === "partner") {
+      if (opts.partnerThrows) {
+        throw new Error("partner link unavailable")
+      }
+      return { data: opts.partners ?? [] }
+    }
+    return { data: [] }
+  })
+
+  return {
+    resolve: (key: string) => (key === "query" ? { graph } : {}),
+  } as any
+}
+
+const TRACKED_ITEM = {
+  id: "iitem_1",
+  title: "Tracked item",
+  sku: "SKU-T",
+  raw_materials: null,
+  variants: [
+    {
+      id: "variant_tracked",
+      title: "Blue",
+      sku: "SKU-T",
+      product: { id: "prod_1", title: "Fabric", thumbnail: null },
+    },
+  ],
+}
+
+const PRODUCT_WITH_MIXED_VARIANTS = {
+  id: "prod_1",
+  title: "Fabric",
+  thumbnail: "thumb.png",
+  variants: [
+    {
+      id: "variant_tracked",
+      title: "Blue",
+      sku: "SKU-T",
+      manage_inventory: true,
+      inventory_items: [
+        { inventory_item_id: "iitem_1", inventory: { id: "iitem_1" } },
+      ],
+    },
+    {
+      id: "variant_untracked",
+      title: "Red",
+      sku: "SKU-U",
+      manage_inventory: false,
+      inventory_items: [],
+    },
+  ],
+}
+
+describe("getInventoryCatalog — the second source (#1662)", () => {
+  it("emits a variant that has no inventory item, which the item sweep can never reach", async () => {
+    const container = buildContainer({
+      items: [TRACKED_ITEM],
+      products: [PRODUCT_WITH_MIXED_VARIANTS],
+    })
+
+    const { rows } = await getInventoryCatalog(container)
+
+    const untracked = rows.filter((r) => r.kind === "untracked_variant")
+    expect(untracked).toHaveLength(1)
+    expect(untracked[0].variant_id).toBe("variant_untracked")
+    expect(untracked[0].sku).toBe("SKU-U")
+  })
+
+  it("does not emit a variant twice when it already has an item", async () => {
+    const container = buildContainer({
+      items: [TRACKED_ITEM],
+      products: [PRODUCT_WITH_MIXED_VARIANTS],
+    })
+
+    const { rows } = await getInventoryCatalog(container)
+
+    const forTracked = rows.filter(
+      (r) =>
+        r.variant_id === "variant_tracked" ||
+        r.variants.some((v: any) => v.id === "variant_tracked")
+    )
+    expect(forTracked).toHaveLength(1)
+    expect(forTracked[0].inventory_item_id).toBe("iitem_1")
+  })
+
+  it("judges on the missing item, not on manage_inventory — a tracked variant with no item is still offered", async () => {
+    const container = buildContainer({
+      items: [],
+      products: [
+        {
+          id: "prod_2",
+          title: "Greige",
+          variants: [
+            {
+              id: "variant_tracked_no_item",
+              title: "Natural",
+              sku: "SKU-N",
+              // The flag says tracked; there is still nothing to stock.
+              manage_inventory: true,
+              inventory_items: [],
+            },
+          ],
+        },
+      ],
+    })
+
+    const { rows } = await getInventoryCatalog(container)
+
+    expect(rows).toHaveLength(1)
+    expect(rows[0].kind).toBe("untracked_variant")
+    expect(rows[0].variant_id).toBe("variant_tracked_no_item")
+  })
+
+  it("gives an untracked row a synthetic id and a null inventory_item_id, so it cannot be posted as an item", async () => {
+    const container = buildContainer({
+      items: [],
+      products: [PRODUCT_WITH_MIXED_VARIANTS],
+    })
+
+    const { rows } = await getInventoryCatalog(container)
+    const row = rows.find((r) => r.variant_id === "variant_untracked")!
+
+    expect(row.inventory_item_id).toBeNull()
+    expect(row.id).toBe("untracked_variant:variant_untracked")
+    expect(String(row.id).startsWith("iitem_")).toBe(false)
+  })
+
+  it("names the owning partner on both kinds of row, and matches a search on it", async () => {
+    const container = buildContainer({
+      items: [TRACKED_ITEM],
+      products: [PRODUCT_WITH_MIXED_VARIANTS],
+      partners: [
+        { id: "partner_1", name: "Sharlho", products: [{ id: "prod_1" }] },
+      ],
+    })
+
+    const { rows } = await getInventoryCatalog(container)
+    expect(rows.every((r) => r.partner?.name === "Sharlho")).toBe(true)
+
+    const { rows: searched } = await getInventoryCatalog(container, {
+      q: "sharlho",
+    })
+    expect(searched).toHaveLength(rows.length)
+  })
+
+  it("still returns the catalog when partner ownership cannot be read", async () => {
+    const container = buildContainer({
+      items: [TRACKED_ITEM],
+      products: [PRODUCT_WITH_MIXED_VARIANTS],
+      partnerThrows: true,
+    })
+
+    const { rows } = await getInventoryCatalog(container)
+
+    expect(rows.length).toBeGreaterThan(0)
+    expect(rows.every((r) => r.partner === null)).toBe(true)
+  })
+
+  it("counts both sources in `scanned`, so a narrowed page never reads as a small catalog", async () => {
+    const container = buildContainer({
+      items: [TRACKED_ITEM],
+      products: [PRODUCT_WITH_MIXED_VARIANTS],
+    })
+
+    const { rows, scanned } = await getInventoryCatalog(container, {
+      kinds: ["untracked_variant"],
+    })
+
+    expect(rows).toHaveLength(1)
+    expect(scanned).toBe(2)
+  })
+})

--- a/apps/backend/src/api/admin/inventory-items/catalog/helpers.ts
+++ b/apps/backend/src/api/admin/inventory-items/catalog/helpers.ts
@@ -11,23 +11,43 @@ import { MedusaContainer } from "@medusajs/framework/types"
  * `inventory_item` itself, the real population, and hangs the raw material and
  * the product variant off each row. Nothing is partitioned away: an item that
  * is neither is still returned, as `kind: "unclassified"`.
+ *
+ * ⚠️ And the same trap one level up: enumerating `inventory_item` can only ever
+ * emit variants that ALREADY have an item. A variant with
+ * `manage_inventory: false` has no item row at all — not hidden, never created
+ * — so the fabric case this issue exists for (one product, 37 variants, 0
+ * tracked) is invisible to that sweep under any filter. Hence the SECOND
+ * source below: product variants with no inventory item, emitted as
+ * `kind: "untracked_variant"`. They are pickable, and tracking is established
+ * when the order line is written (see `ensure-line-inventory-items.ts`).
  */
 export type InventoryCatalogKind =
   | "raw_material"
   | "product"
   | "both"
   | "unclassified"
+  | "untracked_variant"
 
 /**
  * Deliberately the SAME row shape the raw-materials route emits
  * (`raw_materials` is the single linked material, or null) so the picker can
  * swap its source without a second parsing rule — one home for the fact
  * (#1613's lesson), plus the variants the old route could never carry.
+ *
+ * `inventory_item_id` is the field a caller should send when ordering a row
+ * that is already tracked; `variant_id` is what it sends for an
+ * `untracked_variant` row. Exactly one of them is non-null on any row. `id` is
+ * a display/React key only — for an untracked row it is a deliberately
+ * synthetic `untracked_variant:<variant_id>`, which no link write can mistake
+ * for a real `iitem_…` and which fails loudly if one is attempted.
  */
 export type InventoryCatalogRow = Record<string, any> & {
   raw_materials: Record<string, any> | null
   variants: Record<string, any>[]
   kind: InventoryCatalogKind
+  inventory_item_id: string | null
+  variant_id: string | null
+  partner: { id: string; name: string | null } | null
 }
 
 const toRows = (value: unknown): Record<string, any>[] => {
@@ -61,6 +81,7 @@ const matchesQuery = (row: InventoryCatalogRow, needle: string): boolean => {
     row.description,
     row.raw_materials?.name,
     row.raw_materials?.color,
+    row.partner?.name,
     ...row.variants.flatMap((v) => [v?.title, v?.sku, v?.product?.title]),
   ]
 
@@ -69,25 +90,89 @@ const matchesQuery = (row: InventoryCatalogRow, needle: string): boolean => {
   )
 }
 
+/**
+ * product_id → owning partner.
+ *
+ * Traversed from the PARTNER side on purpose: `partner-product.ts` declares
+ * `field: "products"` on that side, so `products.id` is a name the link
+ * actually defines. The reverse field name is not declared anywhere, and a
+ * relation `query.graph` does not recognise is DROPPED in silence rather than
+ * erroring — a guess here would read as "no partner owns anything".
+ */
+const buildPartnerByProduct = async (
+  container: MedusaContainer
+): Promise<Map<string, { id: string; name: string | null }>> => {
+  const query = container.resolve(ContainerRegistrationKeys.QUERY)
+  const byProduct = new Map<string, { id: string; name: string | null }>()
+
+  try {
+    const { data } = await query.graph({
+      entity: "partner",
+      fields: ["id", "name", "products.id"],
+    })
+
+    for (const partner of (Array.isArray(data) ? data : []) as any[]) {
+      if (!partner?.id) {
+        continue
+      }
+      const owned = { id: String(partner.id), name: partner.name ?? null }
+      for (const product of toRows(partner.products)) {
+        byProduct.set(String(product.id), owned)
+      }
+    }
+  } catch (err) {
+    // Ownership is a display aid on the row, not the thing being ordered.
+    // Losing it must not cost the buyer the catalog.
+    console.warn(
+      `[inventory-catalog] partner ownership lookup skipped: ${
+        (err as any)?.message || err
+      }`
+    )
+  }
+
+  return byProduct
+}
+
 export const getInventoryCatalog = async (
   container: MedusaContainer,
   options: { q?: string; kinds?: InventoryCatalogKind[] } = {}
 ): Promise<{ rows: InventoryCatalogRow[]; scanned: number }> => {
   const query = container.resolve(ContainerRegistrationKeys.QUERY)
 
-  const { data } = await query.graph({
-    entity: "inventory_item",
-    fields: [
-      "*",
-      "raw_materials.*",
-      "variants.id",
-      "variants.title",
-      "variants.sku",
-      "variants.product.id",
-      "variants.product.title",
-      "variants.product.thumbnail",
-    ],
-  })
+  const [{ data }, { data: variantData }, partnerByProduct] = await Promise.all([
+    query.graph({
+      entity: "inventory_item",
+      fields: [
+        "*",
+        "raw_materials.*",
+        "variants.id",
+        "variants.title",
+        "variants.sku",
+        "variants.product.id",
+        "variants.product.title",
+        "variants.product.thumbnail",
+      ],
+    }),
+    // Entered from `product`, not `product_variant`, because these exact
+    // relation names are the ones `bulk-update-products.ts:526` already proves
+    // resolve. `query.graph` DROPS a relation it does not recognise in silence
+    // — a wrong name here would report every tracked variant as untracked.
+    query.graph({
+      entity: "product",
+      fields: [
+        "id",
+        "title",
+        "thumbnail",
+        "variants.id",
+        "variants.title",
+        "variants.sku",
+        "variants.manage_inventory",
+        "variants.inventory_items.inventory_item_id",
+        "variants.inventory_items.inventory.id",
+      ],
+    }),
+    buildPartnerByProduct(container),
+  ])
 
   const items = Array.isArray(data) ? data : []
 
@@ -98,18 +183,78 @@ export const getInventoryCatalog = async (
     // id, never on array length.
     const rawMaterials = toRows(item?.raw_materials)
     const variants = toRows(item?.variants)
+    const productId = variants.find((v) => v?.product?.id)?.product?.id
 
     return {
       ...item,
       raw_materials: rawMaterials[0] ?? null,
       variants,
       kind: kindOf(rawMaterials.length > 0, variants.length > 0),
+      inventory_item_id: String(item.id),
+      variant_id: null,
+      partner: productId ? partnerByProduct.get(String(productId)) ?? null : null,
     }
   })
 
-  const scanned = rows.length
+  // The second source. A variant qualifies on the ABSENCE OF AN ITEM, not on
+  // `manage_inventory` — locally one of the six tracked variants has no item
+  // either, and filtering on the flag would leave it just as unorderable while
+  // looking handled.
+  const untracked: InventoryCatalogRow[] = []
+  for (const product of (Array.isArray(variantData) ? variantData : []) as any[]) {
+    const productId = product?.id ? String(product.id) : null
+    const owner = productId ? partnerByProduct.get(productId) ?? null : null
 
-  let result = rows
+    for (const variant of toRows(product?.variants)) {
+      const links = Array.isArray(variant.inventory_items)
+        ? variant.inventory_items
+        : variant.inventory_items
+        ? [variant.inventory_items]
+        : []
+      const linkedItemId =
+        links.find((i: any) => i?.inventory?.id)?.inventory?.id ??
+        links.find((i: any) => i?.inventory_item_id)?.inventory_item_id ??
+        null
+
+      if (linkedItemId) {
+        continue
+      }
+
+      untracked.push({
+        // Synthetic, and deliberately not shaped like an `iitem_…`.
+        id: `untracked_variant:${variant.id}`,
+        inventory_item_id: null,
+        variant_id: String(variant.id),
+        title: variant.title ?? product?.title ?? null,
+        sku: variant.sku ?? null,
+        description: null,
+        thumbnail: product?.thumbnail ?? null,
+        manage_inventory: !!variant.manage_inventory,
+        raw_materials: null,
+        variants: [
+          {
+            id: variant.id,
+            title: variant.title,
+            sku: variant.sku,
+            product: productId
+              ? {
+                  id: productId,
+                  title: product.title,
+                  thumbnail: product.thumbnail,
+                }
+              : undefined,
+          },
+        ],
+        kind: "untracked_variant",
+        partner: owner,
+      })
+    }
+  }
+
+  const all = [...rows, ...untracked]
+  const scanned = all.length
+
+  let result = all
 
   if (options.kinds?.length) {
     const wanted = new Set(options.kinds)

--- a/apps/backend/src/api/admin/inventory-items/catalog/helpers.ts
+++ b/apps/backend/src/api/admin/inventory-items/catalog/helpers.ts
@@ -1,0 +1,125 @@
+import { ContainerRegistrationKeys } from "@medusajs/framework/utils"
+import { MedusaContainer } from "@medusajs/framework/types"
+
+/**
+ * The catalog an inventory order can pick from.
+ *
+ * ⚠️ Why this is not a filter on `/admin/inventory-items/raw-materials`:
+ * that route's `query.graph` entry point IS the raw-material link table, so an
+ * inventory item with no raw material behind it can never be emitted — under
+ * any filter (#1662, same shape as #1621). This one enumerates
+ * `inventory_item` itself, the real population, and hangs the raw material and
+ * the product variant off each row. Nothing is partitioned away: an item that
+ * is neither is still returned, as `kind: "unclassified"`.
+ */
+export type InventoryCatalogKind =
+  | "raw_material"
+  | "product"
+  | "both"
+  | "unclassified"
+
+/**
+ * Deliberately the SAME row shape the raw-materials route emits
+ * (`raw_materials` is the single linked material, or null) so the picker can
+ * swap its source without a second parsing rule — one home for the fact
+ * (#1613's lesson), plus the variants the old route could never carry.
+ */
+export type InventoryCatalogRow = Record<string, any> & {
+  raw_materials: Record<string, any> | null
+  variants: Record<string, any>[]
+  kind: InventoryCatalogKind
+}
+
+const toRows = (value: unknown): Record<string, any>[] => {
+  if (!value) {
+    return []
+  }
+  const arr = Array.isArray(value) ? value : [value]
+  return arr.filter((row: any) => row?.id)
+}
+
+const kindOf = (
+  hasRawMaterial: boolean,
+  hasVariant: boolean
+): InventoryCatalogKind => {
+  if (hasRawMaterial && hasVariant) {
+    return "both"
+  }
+  if (hasRawMaterial) {
+    return "raw_material"
+  }
+  if (hasVariant) {
+    return "product"
+  }
+  return "unclassified"
+}
+
+const matchesQuery = (row: InventoryCatalogRow, needle: string): boolean => {
+  const candidates: Array<string | undefined | null> = [
+    row.title,
+    row.sku,
+    row.description,
+    row.raw_materials?.name,
+    row.raw_materials?.color,
+    ...row.variants.flatMap((v) => [v?.title, v?.sku, v?.product?.title]),
+  ]
+
+  return candidates.some(
+    (c) => typeof c === "string" && c.toLowerCase().includes(needle)
+  )
+}
+
+export const getInventoryCatalog = async (
+  container: MedusaContainer,
+  options: { q?: string; kinds?: InventoryCatalogKind[] } = {}
+): Promise<{ rows: InventoryCatalogRow[]; scanned: number }> => {
+  const query = container.resolve(ContainerRegistrationKeys.QUERY)
+
+  const { data } = await query.graph({
+    entity: "inventory_item",
+    fields: [
+      "*",
+      "raw_materials.*",
+      "variants.id",
+      "variants.title",
+      "variants.sku",
+      "variants.product.id",
+      "variants.product.title",
+      "variants.product.thumbnail",
+    ],
+  })
+
+  const items = Array.isArray(data) ? data : []
+
+  const rows: InventoryCatalogRow[] = items.map((item: any) => {
+    // Two shapes to survive here: a to-one link comes back as an OBJECT
+    // (`raw_materials`), a to-many as an array — and `query.graph` returns a
+    // single all-null row for an empty to-many, so presence is judged on an
+    // id, never on array length.
+    const rawMaterials = toRows(item?.raw_materials)
+    const variants = toRows(item?.variants)
+
+    return {
+      ...item,
+      raw_materials: rawMaterials[0] ?? null,
+      variants,
+      kind: kindOf(rawMaterials.length > 0, variants.length > 0),
+    }
+  })
+
+  const scanned = rows.length
+
+  let result = rows
+
+  if (options.kinds?.length) {
+    const wanted = new Set(options.kinds)
+    result = result.filter((r) => wanted.has(r.kind))
+  }
+
+  const needle = options.q?.trim().toLowerCase()
+  if (needle) {
+    result = result.filter((r) => matchesQuery(r, needle))
+  }
+
+  return { rows: result, scanned }
+}

--- a/apps/backend/src/api/admin/inventory-items/catalog/route.ts
+++ b/apps/backend/src/api/admin/inventory-items/catalog/route.ts
@@ -1,0 +1,50 @@
+/**
+ * GET /admin/inventory-items/catalog
+ *
+ * Every inventory item an inventory order can be placed against — raw
+ * materials AND the finished fabric / finished goods a partner sells us
+ * (#1662). Each row carries its raw material (if any) and the product
+ * variants it backs (if any), plus a derived `kind` for display.
+ *
+ * Query parameters:
+ *   - limit?: number (default 20)
+ *   - offset?: number (default 0)
+ *   - q?: string       // matches item title/sku/description, raw-material
+ *                      // name, variant title/sku, product title
+ *   - kinds?: string   // comma-separated: raw_material,product,both,unclassified
+ *
+ * Response (200):
+ * {
+ *   inventory_items: InventoryCatalogRow[],
+ *   count: number,    // rows matching the query
+ *   scanned: number,  // rows in the whole catalog before q/kinds — so a
+ *                     // narrow result is never mistaken for a small catalog
+ *   offset: number,
+ *   limit: number
+ * }
+ */
+import { MedusaRequest, MedusaResponse } from "@medusajs/framework"
+import { getInventoryCatalog } from "./helpers"
+import type { ListInventoryCatalogQuery } from "./validators"
+
+export const GET = async (req: MedusaRequest, res: MedusaResponse) => {
+  const qv = ((req as any).validatequery ?? (req as any).validatedQuery) as
+    | Partial<ListInventoryCatalogQuery>
+    | undefined
+
+  const limit = Number(qv?.limit ?? 20)
+  const offset = Number(qv?.offset ?? 0)
+
+  const { rows, scanned } = await getInventoryCatalog(req.scope, {
+    q: qv?.q,
+    kinds: qv?.kinds,
+  })
+
+  res.status(200).json({
+    inventory_items: rows.slice(offset, offset + limit),
+    count: rows.length,
+    scanned,
+    offset,
+    limit,
+  })
+}

--- a/apps/backend/src/api/admin/inventory-items/catalog/validators.ts
+++ b/apps/backend/src/api/admin/inventory-items/catalog/validators.ts
@@ -1,0 +1,30 @@
+import { z } from "@medusajs/framework/zod"
+import { createFindParams } from "@medusajs/medusa/api/utils/validators"
+
+export const INVENTORY_CATALOG_KINDS = [
+  "raw_material",
+  "product",
+  "both",
+  "unclassified",
+] as const
+
+export const ListInventoryCatalogQuerySchema = createFindParams({
+  limit: 20,
+  offset: 0,
+}).extend({
+  q: z.string().optional(),
+  /**
+   * Optional narrowing for callers that genuinely want one kind. Omitted means
+   * the whole catalog — the default must never be a partition (#1662/#1621).
+   */
+  kinds: z
+    .preprocess(
+      (val) => (typeof val === "string" ? val.split(",") : val),
+      z.array(z.enum(INVENTORY_CATALOG_KINDS))
+    )
+    .optional(),
+})
+
+export type ListInventoryCatalogQuery = z.infer<
+  typeof ListInventoryCatalogQuerySchema
+>

--- a/apps/backend/src/api/admin/inventory-orders/validators.ts
+++ b/apps/backend/src/api/admin/inventory-orders/validators.ts
@@ -8,13 +8,35 @@ import {
 
 // Input schema for inventory order lines
 export const inventoryOrderLineInputSchema = z.object({
-  inventory_item_id: z.string().min(1, "Inventory item ID is required"),
+  // #1662 — a line names EITHER an existing inventory item or, for a partner's
+  // fabric/finished good whose variant core never gave an item, the variant
+  // itself. Exactly one, enforced below: accepting both would leave two
+  // sources for one fact and no rule for which wins.
+  inventory_item_id: z.string().min(1).optional(),
+  variant_id: z.string().min(1).optional(),
   // Allow decimal quantities >= 0 (0 allowed for empty seeded rows)
   quantity: z.number().nonnegative("Quantity must be zero or positive"),
   price: z.number().nonnegative("Price must be zero or positive"),
   // Optional batch tag for the "keep batches as separate lines" quick-add mode.
   batch_number: z.number().int().positive().nullish(),
   metadata: z.record(z.string(), z.unknown()).optional(),
+}).superRefine((val, ctx) => {
+  if (!val.inventory_item_id && !val.variant_id) {
+    ctx.addIssue({
+      code: z.ZodIssueCode.custom,
+      path: ["inventory_item_id"],
+      message:
+        "An order line needs either inventory_item_id or variant_id",
+    });
+  }
+  if (val.inventory_item_id && val.variant_id) {
+    ctx.addIssue({
+      code: z.ZodIssueCode.custom,
+      path: ["variant_id"],
+      message:
+        "Send inventory_item_id or variant_id, not both — variant_id is only for a variant that has no inventory item yet",
+    });
+  }
 });
 
 // Base ZodObject — kept separately so we can call .partial() on it for the
@@ -162,6 +184,8 @@ export const updateOrderLineSchema = z
   .object({
     id: z.string().optional(), // Existing lines have IDs
     inventory_item_id: z.string().optional(),
+    // #1662 — as on create: a NEW line may name an untracked variant instead.
+    variant_id: z.string().optional(),
     quantity: z.number().optional(),
     price: z.number().optional(),
     // Optional batch tag (see inventoryOrderLineInputSchema).
@@ -184,11 +208,21 @@ export const updateOrderLineSchema = z
       }
       return; // removals skip the create/update field requirements
     }
-    if (!val.inventory_item_id || val.inventory_item_id.length < 1) {
+    const hasItem = !!val.inventory_item_id && val.inventory_item_id.length > 0;
+    const hasVariant = !!val.variant_id && val.variant_id.length > 0;
+    if (!hasItem && !hasVariant) {
       ctx.addIssue({
         code: z.ZodIssueCode.custom,
         path: ["inventory_item_id"],
-        message: "Inventory item ID is required",
+        message: "An order line needs either inventory_item_id or variant_id",
+      });
+    }
+    if (hasItem && hasVariant) {
+      ctx.addIssue({
+        code: z.ZodIssueCode.custom,
+        path: ["variant_id"],
+        message:
+          "Send inventory_item_id or variant_id, not both — variant_id is only for a variant that has no inventory item yet",
       });
     }
     if (val.quantity == null || val.quantity < 1) {

--- a/apps/backend/src/api/middlewares.ts
+++ b/apps/backend/src/api/middlewares.ts
@@ -311,6 +311,7 @@ import { listPartnersQuerySchema, PostPartnerSchema } from "./admin/partners/val
 import { AdminBroadcastNotificationSchema } from "./admin/partners/notifications/broadcast/validators";
 import { ListIdentitiesQuerySchema } from "./admin/users/identities/validators";
 import { ListInventoryItemRawMaterialsQuerySchema } from "./admin/inventory-items/raw-materials/validators";
+import { ListInventoryCatalogQuerySchema } from "./admin/inventory-items/catalog/validators";
 import { BulkImportSchema } from "./admin/inventory-items/bulk-import/validators";
 import { PartnerCreateStoreReq } from "./partners/stores/validators";
 import { PartnerCreateProductReq, PartnerArtisanProductDetailReq, PartnerProductSpecReq, PartnerStoreCreateProductReq, PartnerQuickCreateProductReq } from "./partners/products/validators";
@@ -4995,6 +4996,13 @@ export default defineMiddlewares({
       matcher: "/admin/inventory-items/raw-materials",
       method: "GET",
       middlewares: [validateAndTransformQuery(wrapSchema(ListInventoryItemRawMaterialsQuerySchema), {})],
+    },
+
+    // #1662 — the whole pickable catalog, not just raw-material-linked items.
+    {
+      matcher: "/admin/inventory-items/catalog",
+      method: "GET",
+      middlewares: [validateAndTransformQuery(wrapSchema(ListInventoryCatalogQuerySchema), {})],
     },
 
     // Bulk Import Inventory

--- a/apps/backend/src/workflows/inventory_orders/create-inventory-orders.ts
+++ b/apps/backend/src/workflows/inventory_orders/create-inventory-orders.ts
@@ -21,11 +21,23 @@ import {
 } from "../../modules/inventory_orders/lib/create-helpers";
 import type { Link } from "@medusajs/modules-sdk";
 import { dualWriteUnifiedOrderStep } from "./dual-write-unified-order";
+import { ensureLineInventoryItems } from "./lib/ensure-line-inventory-items";
 export type InventoryOrder = InferTypeOf<typeof InventoryOrder>;
 
 // --- Interfaces for API Input ---
 export interface InventoryOrderLineInput {
-  inventory_item_id: string;
+  /**
+   * Optional ONLY because #1662 lets a line name an untracked variant instead
+   * (see `variant_id`). By the time the create step runs it is always set —
+   * `ensureOrderLineInventoryItemsStep` resolves the variant form first.
+   */
+  inventory_item_id?: string;
+  /**
+   * #1662 — a partner's fabric/finished-good variant that core never gave an
+   * inventory item. Tracking is established at OUR end when the order is
+   * placed; the resolved item id replaces this before anything is written.
+   */
+  variant_id?: string;
   quantity: number;
   price: number;
   batch_number?: number | null;
@@ -58,13 +70,27 @@ export const createInventoryOrderWithLinesStep = createStep(
     const { order_lines, ...orderData } = input;
 
     // Map to service's expected order line shape
-    const orderLinesForService = order_lines.map(line => ({
+    const orderLinesForService = order_lines.map(line => {
+      // By here every line has a real item id: the variant form is resolved by
+      // ensureOrderLineInventoryItemsStep, which runs first and throws rather
+      // than passing a line through unresolved. Assert it anyway — a line
+      // written with an undefined inventory id would link to nothing and read
+      // as an ordinary order (#1662).
+      if (!line.inventory_item_id) {
+        throw new Error(
+          `Order line has no inventory_item_id${
+            line.variant_id ? ` (variant ${line.variant_id} was not resolved)` : ""
+          }.`
+        );
+      }
+      return {
       inventory_id: line.inventory_item_id,
       quantity: line.quantity,
       price: line.price,
       batch_number: line.batch_number ?? null,
       metadata: line.metadata
-    }));
+    };
+    });
 
     // #817 S2 — denormalize color identity onto each line from its
     // inventory_item's linked raw_material, so the order is self-describing.
@@ -233,17 +259,57 @@ export const linkInventoryOrderWithFromStockLocation = createStep(
 
 
 
+/**
+ * #1662 — turn any line that names an untracked variant into one that names a
+ * real inventory item, creating the item at our end.
+ *
+ * Runs BEFORE the order is written so no line can ever be persisted pointing at
+ * a variant that has nothing to stock. Not compensated on purpose — see
+ * `ensureLineInventoryItems`.
+ */
+export const ensureOrderLineInventoryItemsStep = createStep(
+  "ensure-order-line-inventory-items-step",
+  async (input: CreateInventoryOrderInput, { container }) => {
+    const { lines, enabled_variant_ids } = await ensureLineInventoryItems(
+      container,
+      input.order_lines ?? [],
+      {
+        stock_location_id:
+          (input as any).to_stock_location_id || input.stock_location_id,
+      }
+    );
+
+    return new StepResponse({
+      order_lines: lines.map(({ enabled_variant_id, actions, variant_id, ...line }) => ({
+        ...line,
+        inventory_item_id: line.inventory_item_id,
+      })),
+      enabled_variant_ids,
+    });
+  }
+);
+
 export const createInventoryOrderWorkflow = createWorkflow(
   {
     name: "create-inventory-order-workflow",
     store: true,
   },
   (input: CreateInventoryOrderInput) => {
-    // Step 1: Create inventory order and lines
     // (validateInventoryStep removed — it ran independently of this step so Medusa
     //  could execute the transform before validation completed, causing crashes.
     //  Invalid inventory items will be caught by linkInventoryItemsWithLinesStep.)
-    const created = createInventoryOrderWithLinesStep(input);
+
+    // Step 0 (#1662): a line may name an untracked partner variant. Establish
+    // its inventory item first, so what gets written is always a real item id.
+    const ensured = ensureOrderLineInventoryItemsStep(input);
+
+    const createInput = transform({ input, ensured }, ({ input, ensured }) => ({
+      ...input,
+      order_lines: ensured.order_lines,
+    }));
+
+    // Step 1: Create inventory order and lines
+    const created = createInventoryOrderWithLinesStep(createInput as any);
 
     // Step 2: Use transform to shape input for linking step
     const linkInput = transform(
@@ -293,7 +359,9 @@ export const createInventoryOrderWorkflow = createWorkflow(
     dualWriteUnifiedOrderStep({
       order: linkInput.order,
       orderLines: linkInput.orderLines,
-      input,
+      // The RESOLVED input: its lines carry real inventory item ids, so the
+      // projected core order names the same items the legacy one does.
+      input: createInput as any,
     });
 
     // Step 3: Use transform to shape the final response

--- a/apps/backend/src/workflows/inventory_orders/lib/__tests__/ensure-line-inventory-items.unit.spec.ts
+++ b/apps/backend/src/workflows/inventory_orders/lib/__tests__/ensure-line-inventory-items.unit.spec.ts
@@ -1,0 +1,174 @@
+import { ensureLineInventoryItems } from "../ensure-line-inventory-items"
+
+const enableInventoryTracking = jest.fn()
+
+jest.mock("../../../products/bulk-update-products", () => ({
+  enableInventoryTracking: (...a: any[]) => enableInventoryTracking(...a),
+}))
+
+/**
+ * #1662. What must hold before an order line is written:
+ *
+ *  - a line naming an untracked variant comes back naming a REAL item id;
+ *  - a line that already names an item is left alone (no needless re-tracking);
+ *  - a variant that cannot be given an item THROWS, rather than letting a line
+ *    be written that links to nothing and reads as an ordinary order;
+ *  - the level seeded at our location is 0 — the receipt posts the stock, and
+ *    any other seed would be inventing goods we do not hold.
+ */
+
+const buildContainer = (opts: {
+  products?: any[]
+  levels?: any[]
+  createLevels?: jest.Mock
+}) => {
+  const graph = jest.fn(async ({ entity }: any) =>
+    entity === "product" ? { data: opts.products ?? [] } : { data: [] }
+  )
+
+  const inventoryService = {
+    listInventoryLevels: jest.fn(async () => opts.levels ?? []),
+    createInventoryLevels: opts.createLevels ?? jest.fn(async () => undefined),
+  }
+
+  return {
+    resolve: (key: string) => {
+      if (key === "query") return { graph }
+      if (key === "inventory") return inventoryService
+      return {}
+    },
+  } as any
+}
+
+const PRODUCT = {
+  id: "prod_1",
+  variants: [
+    {
+      id: "variant_untracked",
+      sku: "SKU-U",
+      title: "Red",
+      manage_inventory: false,
+      inventory_items: [],
+    },
+  ],
+}
+
+beforeEach(() => {
+  enableInventoryTracking.mockReset()
+})
+
+describe("ensureLineInventoryItems (#1662)", () => {
+  it("turns a variant reference into a real inventory item id", async () => {
+    enableInventoryTracking.mockImplementation(
+      async (_c: any, _v: any, actions: string[]) => {
+        actions.push("enable_manage_inventory", "create_inventory_item")
+        return "iitem_new"
+      }
+    )
+    const container = buildContainer({ products: [PRODUCT] })
+
+    const { lines, enabled_variant_ids } = await ensureLineInventoryItems(
+      container,
+      [{ variant_id: "variant_untracked", quantity: 3 } as any]
+    )
+
+    expect(lines[0].inventory_item_id).toBe("iitem_new")
+    expect(enabled_variant_ids).toEqual(["variant_untracked"])
+  })
+
+  it("leaves a line that already names an item untouched", async () => {
+    const container = buildContainer({ products: [] })
+
+    const { lines, enabled_variant_ids } = await ensureLineInventoryItems(
+      container,
+      [{ inventory_item_id: "iitem_existing", quantity: 1 } as any]
+    )
+
+    expect(lines[0].inventory_item_id).toBe("iitem_existing")
+    expect(enabled_variant_ids).toEqual([])
+    expect(enableInventoryTracking).not.toHaveBeenCalled()
+  })
+
+  it("throws rather than writing a line that links to nothing", async () => {
+    enableInventoryTracking.mockResolvedValue(null)
+    const container = buildContainer({ products: [PRODUCT] })
+
+    await expect(
+      ensureLineInventoryItems(container, [
+        { variant_id: "variant_untracked", quantity: 1 } as any,
+      ])
+    ).rejects.toThrow(/Could not establish an inventory item/)
+  })
+
+  it("throws when the variant does not exist at all", async () => {
+    const container = buildContainer({ products: [] })
+
+    await expect(
+      ensureLineInventoryItems(container, [
+        { variant_id: "variant_ghost", quantity: 1 } as any,
+      ])
+    ).rejects.toThrow(/does not exist/)
+  })
+
+  it("seeds the destination level at 0 — the receipt is what posts the stock", async () => {
+    const createLevels = jest.fn(async () => undefined)
+    enableInventoryTracking.mockImplementation(
+      async (_c: any, _v: any, actions: string[]) => {
+        actions.push("create_inventory_item")
+        return "iitem_new"
+      }
+    )
+    const container = buildContainer({
+      products: [PRODUCT],
+      levels: [],
+      createLevels,
+    })
+
+    await ensureLineInventoryItems(
+      container,
+      [{ variant_id: "variant_untracked", quantity: 40 } as any],
+      { stock_location_id: "sloc_ours" }
+    )
+
+    expect(createLevels).toHaveBeenCalledWith([
+      {
+        inventory_item_id: "iitem_new",
+        location_id: "sloc_ours",
+        stocked_quantity: 0,
+      },
+    ])
+  })
+
+  it("does not seed a level that already exists", async () => {
+    const createLevels = jest.fn(async () => undefined)
+    enableInventoryTracking.mockImplementation(
+      async (_c: any, _v: any, actions: string[]) => {
+        actions.push("create_inventory_item")
+        return "iitem_new"
+      }
+    )
+    const container = buildContainer({
+      products: [PRODUCT],
+      levels: [{ id: "ilev_1", stocked_quantity: 12 }],
+      createLevels,
+    })
+
+    await ensureLineInventoryItems(
+      container,
+      [{ variant_id: "variant_untracked", quantity: 1 } as any],
+      { stock_location_id: "sloc_ours" }
+    )
+
+    expect(createLevels).not.toHaveBeenCalled()
+  })
+
+  it("never coerces a missing reference into the string \"undefined\"", async () => {
+    const container = buildContainer({ products: [] })
+
+    const { lines } = await ensureLineInventoryItems(container, [
+      { quantity: 1 } as any,
+    ])
+
+    expect(lines[0].inventory_item_id).toBeUndefined()
+  })
+})

--- a/apps/backend/src/workflows/inventory_orders/lib/ensure-line-inventory-items.ts
+++ b/apps/backend/src/workflows/inventory_orders/lib/ensure-line-inventory-items.ts
@@ -1,0 +1,173 @@
+import { ContainerRegistrationKeys, Modules } from "@medusajs/framework/utils"
+import { MedusaContainer } from "@medusajs/framework/types"
+import { enableInventoryTracking } from "../../products/bulk-update-products"
+
+/**
+ * Give an order line's variant the inventory record core never created for it.
+ *
+ * #1662. A partner's fabric or finished good is often sold as a product whose
+ * variants have `manage_inventory: false` — and such a variant has NO inventory
+ * item row at all. Core can only ever turn tracking off, so nothing downstream
+ * can conjure one. The founder's call (2026-08-30): tracking is established at
+ * OUR end, silently, at the moment we place the inventory order — picking it is
+ * the intent, so there is no second confirmation step.
+ *
+ * Reuses `enableInventoryTracking` from `bulk-update-products` rather than
+ * carrying a second copy of it (#1654's two-homes lesson). It is idempotent:
+ * a variant that already has an item gets its existing id back.
+ *
+ * ⚠️ Deliberately NOT compensated. If a later step fails and the order rolls
+ * back, the inventory item stays. Deleting it would destroy a record other
+ * lines, levels or reservations may already point at, to undo something that
+ * costs nothing to leave — and a retry finds it and reuses it.
+ */
+export type LineItemRef = {
+  inventory_item_id?: string | null
+  variant_id?: string | null
+}
+
+export type EnsuredLine = {
+  inventory_item_id: string
+  /** Set only when this call is what made the variant trackable. */
+  enabled_variant_id?: string
+  actions?: string[]
+}
+
+export const ensureLineInventoryItems = async <T extends LineItemRef>(
+  container: MedusaContainer,
+  lines: T[],
+  options: { stock_location_id?: string | null } = {}
+): Promise<{ lines: (T & EnsuredLine)[]; enabled_variant_ids: string[] }> => {
+  const needsVariant = lines.filter((l) => !l.inventory_item_id && l.variant_id)
+
+  if (!needsVariant.length) {
+    // Cast, never coerce: a line with neither reference is a validator failure,
+    // and String(undefined) would smuggle the literal "undefined" through as an
+    // id that looks real until a link write silently matches nothing.
+    return {
+      lines: lines as (T & EnsuredLine)[],
+      enabled_variant_ids: [],
+    }
+  }
+
+  const query: any = container.resolve(ContainerRegistrationKeys.QUERY)
+  const variantIds = Array.from(
+    new Set(needsVariant.map((l) => String(l.variant_id)))
+  )
+
+  // Same relation names as bulk-update-products (`variants.inventory_items…`),
+  // read through `product` — the entry point those names are proven against.
+  const { data } = await query.graph({
+    entity: "product",
+    fields: [
+      "id",
+      "variants.id",
+      "variants.sku",
+      "variants.title",
+      "variants.manage_inventory",
+      "variants.hs_code",
+      "variants.origin_country",
+      "variants.mid_code",
+      "variants.material",
+      "variants.weight",
+      "variants.length",
+      "variants.height",
+      "variants.width",
+      "variants.inventory_items.inventory_item_id",
+      "variants.inventory_items.inventory.id",
+    ],
+    filters: { variants: { id: variantIds } },
+  })
+
+  const variantsById = new Map<string, any>()
+  for (const product of (Array.isArray(data) ? data : []) as any[]) {
+    for (const variant of (product?.variants ?? []) as any[]) {
+      if (variant?.id) {
+        variantsById.set(String(variant.id), variant)
+      }
+    }
+  }
+
+  const resolved = new Map<string, string>()
+  const enabled: string[] = []
+  const actionsByVariant = new Map<string, string[]>()
+
+  for (const variantId of variantIds) {
+    const variant = variantsById.get(variantId)
+    if (!variant) {
+      throw new Error(
+        `Order line references variant ${variantId}, which does not exist.`
+      )
+    }
+
+    const actions: string[] = []
+    const itemId = await enableInventoryTracking(container, variant, actions)
+
+    if (!itemId) {
+      throw new Error(
+        `Could not establish an inventory item for variant ${variantId}. The order line cannot be written without one.`
+      )
+    }
+
+    resolved.set(variantId, itemId)
+    actionsByVariant.set(variantId, actions)
+    if (actions.length) {
+      enabled.push(variantId)
+    }
+  }
+
+  // Seed a level at the destination so the newly tracked variant is visible at
+  // our location straight away. Quantity 0 on purpose: nothing has been
+  // received yet, and the receipt on completion is what posts the stock. Any
+  // other seed would be inventing goods we do not hold.
+  const locationId = options.stock_location_id
+  if (locationId && enabled.length) {
+    const inventoryService: any = container.resolve(Modules.INVENTORY)
+    for (const variantId of enabled) {
+      const itemId = resolved.get(variantId)!
+      try {
+        const levels = await inventoryService.listInventoryLevels({
+          inventory_item_id: itemId,
+          location_id: locationId,
+        })
+        if (!(levels as any[])?.length) {
+          await inventoryService.createInventoryLevels([
+            {
+              inventory_item_id: itemId,
+              location_id: locationId,
+              stocked_quantity: 0,
+            },
+          ])
+          actionsByVariant.get(variantId)?.push("create_level")
+        }
+      } catch (err) {
+        // Visibility only. The completion receipt creates the level if it is
+        // still missing, so losing this must not cost the buyer the order.
+        console.warn(
+          `[inventory-order] could not seed a 0 level for ${itemId} at ${locationId}: ${
+            (err as any)?.message || err
+          }`
+        )
+      }
+    }
+  }
+
+  return {
+    lines: lines.map((l) => {
+      if (l.inventory_item_id) {
+        return { ...l, inventory_item_id: String(l.inventory_item_id) }
+      }
+      if (!l.variant_id) {
+        return l as T & EnsuredLine
+      }
+      const variantId = String(l.variant_id)
+      return {
+        ...l,
+        inventory_item_id: resolved.get(variantId)!,
+        enabled_variant_id: enabled.includes(variantId) ? variantId : undefined,
+        actions: actionsByVariant.get(variantId),
+      }
+    }),
+    enabled_variant_ids: enabled,
+  }
+}

--- a/apps/backend/src/workflows/inventory_orders/update-inventory-orders.ts
+++ b/apps/backend/src/workflows/inventory_orders/update-inventory-orders.ts
@@ -27,6 +27,7 @@ import {
   buildMaterialLookupByInventoryId,
   type MaterialInfo,
 } from "../../modules/inventory_orders/lib/create-helpers";
+import { ensureLineInventoryItems } from "./lib/ensure-line-inventory-items";
 import {
   repointInventoryOrderFromLink,
   restoreInventoryOrderFromLink,
@@ -41,6 +42,12 @@ export type UpdateInventoryOrderLineInput = {
   // enforces these are present, so the create/update branches below can rely on
   // them at runtime.
   inventory_item_id?: string;
+  /**
+   * #1662 — a NEW line may instead name a partner variant that has no
+   * inventory item yet. Resolved to a real `inventory_item_id` at the top of
+   * the line step, before anything is written.
+   */
+  variant_id?: string;
   quantity?: number;
   price?: number;
   batch_number?: number | null; // Batch tag for separate-batch quick-add lines
@@ -143,6 +150,31 @@ export const updateOrderLinesStep = createStep(
     const currentOrder = await inventoryOrderService.retrieveInventoryOrder(input.order_id, { relations: ["orderlines"] });
     const currentOrderlines = currentOrder.orderlines || [];
     const byId = new Map<string, any>(currentOrderlines.map((l: any) => [l.id, l]));
+
+    // #1662 — a new line may name an untracked partner variant instead of an
+    // item. Establish the inventory item BEFORE anything below reads
+    // `inventory_item_id`, so every later branch sees a line of one shape.
+    // No level is seeded here: the completion receipt creates the level if it
+    // is missing, and this path does not carry the order's destination.
+    const newLines = input.order_lines.filter((l) => !l.remove && !l.id);
+    if (newLines.some((l) => !l.inventory_item_id && l.variant_id)) {
+      const { lines: resolvedNew } = await ensureLineInventoryItems(
+        container,
+        newLines
+      );
+      const resolvedByVariant = new Map<string, string>();
+      resolvedNew.forEach((l, i) => {
+        const variantId = newLines[i]?.variant_id;
+        if (variantId) {
+          resolvedByVariant.set(String(variantId), l.inventory_item_id);
+        }
+      });
+      for (const line of input.order_lines) {
+        if (!line.inventory_item_id && line.variant_id) {
+          line.inventory_item_id = resolvedByVariant.get(String(line.variant_id));
+        }
+      }
+    }
 
     // #817 S2 — resolve color identity for newly-added lines so they're
     // self-describing just like create-path lines. Existing lines keep their

--- a/apps/backend/src/workflows/products/bulk-update-products.ts
+++ b/apps/backend/src/workflows/products/bulk-update-products.ts
@@ -357,7 +357,7 @@ async function resolveTargetIds(
  * Returns the inventory item id to stock, or null when one could not be
  * established.
  */
-async function enableInventoryTracking(
+export async function enableInventoryTracking(
   container: MedusaContainer,
   variant: any,
   actions: string[]


### PR DESCRIPTION
Closes the gate half of #1662.

## The finding

The write path was never the restriction. `create-inventory-orders` takes a plain `inventory_item_id`, and #817's `color`/`material_name`/`raw_material_id` denormalization is nullable and no-ops when there is no material behind the item.

The entire gate is one query's **entry point**: `getAllInventoryWithRawMaterial` runs `query.graph` over the **raw-material link table**, so an inventory item with no raw material cannot be emitted — under any filter. On production that hides **~78 of 225** inventory items (121 material-linked, 81 variant-backed, 3 both).

Same shape as #1621: the fix is *what gets enumerated*, not a wider filter.

## What this adds

`GET /admin/inventory-items/catalog` enumerates `inventory_item` itself and hangs the raw material and product variants off each row with a derived `kind`.

- Nothing is partitioned away — an item that is neither comes back as `unclassified`. An enum that drops its unknowns is exactly #1621.
- `scanned` reports the whole catalog before `q`/`kinds`, so a narrow page can never read as a small catalog.
- Rows keep the shape `/admin/inventory-items/raw-materials` already emits (`raw_materials` = the single linked material, or null), so the picker needed no second parsing rule — one home for the fact (#1613's lesson).

The create and edit order-lines pickers read it, name a product-backed item by its product/variant, search on variant title/SKU/product title, and carry a **Type** column: a partner *making* a garment for us is a production run; a partner *selling* us finished stock is this. Once one picker can see both, the distinction has to be visible on the line rather than left to whoever opened the form.

## Verification

`integration-tests/http/inventory-catalog-products.spec.ts` — 4 cases, green, driven through the real create paths (bulk-import for a material, a managed-inventory product variant for a finished good):

- **the gate itself is pinned** — the raw-materials route emits the material item and omits the product-backed one, which is why filtering could never have fixed it
- the catalog returns both, correctly tagged, with the variant and its product resolved
- `q` matches product title and SKU, not just material names
- an inventory order **accepts a product-backed line**, links it to the item, and leaves the material columns correctly NULL

The first run 500'd because `raw_materials` arrives as an **object** and `variants` as an array; the normalization is now pinned by that same case rather than assumed.

`pnpm check:prod-build` green. `tsc` clean on every touched file.

## Downstream — what is and isn't covered

The issue flagged partner receipt / stock posting and `cancel-inventory-order` as untraced. They turn out to be already proven material-agnostic: `send-to-partner-complete-workflow.spec.ts` runs its entire partner deliver → cancel flow against an inventory item created with **no raw-material link** (`/admin/inventory-items` with just a title). Nothing on those paths reads a variant either.

⚠️ **Still open, and worth a decision:** a variant-backed inventory item is one a storefront may **sell**. A receipt against it now moves sellable stock. That is arguably the point of buying finished goods, but it is a new consequence of an inventory order and should be deliberate.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01TLt1f38xqR8k2myCVxP8e4