### PR TITLE
fix(admin): the DataGrid stole focus and keystrokes from elements it did not own (#1654)

### DIFF
--- a/apps/backend/src/admin/components/data-grid/__tests__/foreign-focus.unit.spec.ts
+++ b/apps/backend/src/admin/components/data-grid/__tests__/foreign-focus.unit.spec.ts
@@ -1,0 +1,108 @@
+import { isForeignFocusTarget, shouldRestoreAnchorFocus } from "../utils"
+
+/**
+ * #1654 — the DataGrid took focus and keystrokes from elements that were not
+ * its own.
+ *
+ * The reported symptom was that typing "12345" into a plain input on a tab
+ * that also mounts the grid left the input holding `"1"`, with the caret in a
+ * grid cell's input. The cause was NOT the window keydown handlers (both have
+ * carried a foreign-input guard since #836) — it was the anchored cell's focus
+ * effect, which fired on every grid re-render and pulled focus to itself
+ * whenever focus was anywhere else. Typing on the tab causes that re-render,
+ * so the second character was always the one lost.
+ *
+ * These cases pin the ownership rule both handlers now share: an element is
+ * the grid's if it is inside a grid cell, and nobody else's element may be
+ * taken over.
+ */
+
+/** A DOM stand-in with just what the rule reads. */
+const makeEl = (
+  opts: {
+    tagName?: string
+    role?: string
+    isContentEditable?: boolean
+    insideGrid?: boolean
+  } = {}
+): any => {
+  const el: any = {
+    tagName: opts.tagName ?? "DIV",
+    isContentEditable: opts.isContentEditable ?? false,
+    getAttribute: (name: string) => (name === "role" ? opts.role ?? null : null),
+    closest: (selector: string) => {
+      if (selector.includes("data-cell-id")) {
+        return opts.insideGrid ? { id: "cell" } : null
+      }
+      return null
+    },
+  }
+  return el
+}
+
+describe("isForeignFocusTarget (#1654)", () => {
+  it("claims a plain text input beside the grid", () => {
+    expect(isForeignFocusTarget(makeEl({ tagName: "INPUT" }))).toBe(true)
+  })
+
+  it("claims a portaled popover element that has a role but is not an input", () => {
+    // The case the old inline check missed: it knew only `role="combobox"`,
+    // so a menu item or an option — a div with a role — fell through.
+    expect(isForeignFocusTarget(makeEl({ role: "menuitem" }))).toBe(true)
+    expect(isForeignFocusTarget(makeEl({ role: "option" }))).toBe(true)
+    expect(isForeignFocusTarget(makeEl({ role: "combobox" }))).toBe(true)
+  })
+
+  it("claims a contenteditable region", () => {
+    expect(isForeignFocusTarget(makeEl({ isContentEditable: true }))).toBe(true)
+  })
+
+  it("does NOT claim the grid's own cell input — the grid must keep working", () => {
+    expect(
+      isForeignFocusTarget(makeEl({ tagName: "INPUT", insideGrid: true }))
+    ).toBe(false)
+  })
+
+  it("does not claim a plain non-interactive element, or nothing at all", () => {
+    expect(isForeignFocusTarget(makeEl())).toBe(false)
+    expect(isForeignFocusTarget(null)).toBe(false)
+    expect(isForeignFocusTarget({} as any)).toBe(false)
+  })
+})
+
+describe("shouldRestoreAnchorFocus (#1654)", () => {
+  const container = (contains: boolean): any => ({
+    contains: () => contains,
+  })
+
+  it("does NOT steal focus from an input beside the grid — the reported bug", () => {
+    const typingHere = makeEl({ tagName: "INPUT" })
+    expect(shouldRestoreAnchorFocus(container(false), typingHere)).toBe(false)
+  })
+
+  it("does not steal focus from a portaled popover the user has open", () => {
+    expect(shouldRestoreAnchorFocus(container(false), makeEl({ role: "menuitem" }))).toBe(
+      false
+    )
+  })
+
+  it("still restores focus when nothing else holds it", () => {
+    // Arrow-key navigation between cells depends on this: the anchor moves,
+    // focus is on <body>, and the new anchor has to take it.
+    expect(shouldRestoreAnchorFocus(container(false), null)).toBe(true)
+    expect(shouldRestoreAnchorFocus(container(false), makeEl())).toBe(true)
+  })
+
+  it("still restores focus when the caret is in another grid cell", () => {
+    const otherCell = makeEl({ tagName: "INPUT", insideGrid: true })
+    expect(shouldRestoreAnchorFocus(container(false), otherCell)).toBe(true)
+  })
+
+  it("does nothing when focus is already inside this cell", () => {
+    expect(shouldRestoreAnchorFocus(container(true), makeEl())).toBe(false)
+  })
+
+  it("does nothing without a container", () => {
+    expect(shouldRestoreAnchorFocus(null, makeEl())).toBe(false)
+  })
+})

--- a/apps/backend/src/admin/components/data-grid/components/data-grid-root.tsx
+++ b/apps/backend/src/admin/components/data-grid/components/data-grid-root.tsx
@@ -45,7 +45,11 @@ import {
 } from "../hooks"
 import { DataGridMatrix } from "../models"
 import { DataGridCoordinates, GridColumnOption } from "../types"
-import { isCellMatch, isSpecialFocusKey } from "../utils"
+import {
+  isCellMatch,
+  isForeignFocusTarget,
+  isSpecialFocusKey,
+} from "../utils"
 import { DataGridKeyboardShortcutModal } from "./data-grid-keyboard-shortcut-modal"
 import { useCommandHistory } from "../hooks/use-command-history"
 export interface DataGridRootProps<
@@ -446,15 +450,10 @@ export const DataGridRoot = <
     const specialFocusHandler = (e: KeyboardEvent) => {
       // Ignore keystrokes typed into a foreign input (e.g. the item-picker
       // Combobox) so we don't start editing a grid cell from its keystrokes.
-      const t = e.target as HTMLElement | null
-      const tag = t?.tagName
-      if (
-        tag === "INPUT" ||
-        tag === "TEXTAREA" ||
-        tag === "SELECT" ||
-        t?.isContentEditable ||
-        t?.getAttribute?.("role") === "combobox"
-      ) {
+      // #1654 — the inline tag check this replaced knew only about
+      // `role="combobox"`, so a portaled menu or option (a `div` with a role,
+      // not an `<input>`) still fell through to the grid.
+      if (isForeignFocusTarget(e.target)) {
         return
       }
       if (isSpecialFocusKey(e)) {

--- a/apps/backend/src/admin/components/data-grid/components/data-grid-toggleable-number-cell.tsx
+++ b/apps/backend/src/admin/components/data-grid/components/data-grid-toggleable-number-cell.tsx
@@ -6,6 +6,7 @@ import { useCombinedRefs } from "../hooks/use-combined-refs"
 import { ConditionalTooltip } from "../../common/conditional-tooltip"
 import { useDataGridCell, useDataGridCellError } from "../hooks"
 import { DataGridCellProps, InputProps } from "../types"
+import { isForeignFocusTarget } from "../utils"
 import { DataGridCellContainer } from "./data-grid-cell-container"
 
 export const DataGridTogglableNumberCell = <TData, TValue = any>({
@@ -89,6 +90,12 @@ const OuterComponent = ({
 
   useEffect(() => {
     const handleKeyDown = (e: KeyboardEvent) => {
+      // #1654 — this is a DOCUMENT listener, so without the check an "x" typed
+      // into any input on the page toggles the anchor row's switch.
+      if (isForeignFocusTarget(e.target)) {
+        return
+      }
+
       if (isAnchor && e.key.toLowerCase() === "x") {
         e.preventDefault()
         buttonRef.current?.click()

--- a/apps/backend/src/admin/components/data-grid/hooks/use-data-grid-cell.tsx
+++ b/apps/backend/src/admin/components/data-grid/hooks/use-data-grid-cell.tsx
@@ -7,7 +7,11 @@ import {
   DataGridCellRenderProps,
   DataGridCoordinates,
 } from "../types"
-import { isCellMatch, isSpecialFocusKey } from "../utils"
+import {
+  isCellMatch,
+  isSpecialFocusKey,
+  shouldRestoreAnchorFocus,
+} from "../utils"
 
 type UseDataGridCellOptions<TData, TValue> = {
   context: CellContext<TData, TValue>
@@ -201,7 +205,18 @@ export const useDataGridCell = <TData, TValue>({
   }, [type])
 
   useEffect(() => {
-    if (isAnchor && !containerRef.current?.contains(document.activeElement)) {
+    if (!isAnchor) {
+      return
+    }
+
+    // #1654 — do NOT yank focus out of whatever the user is using. This effect
+    // re-runs whenever the anchor changes, and the anchor is recomputed on
+    // every grid re-render — which typing anywhere on the tab causes. Taking
+    // focus unconditionally is what ate the second keystroke of any word typed
+    // beside the grid: char 1 lands, the grid re-renders, this fires, and the
+    // rest is typed into a cell (the cell container's own keydown then moves
+    // focus into the cell's input, which is where the caret was found).
+    if (shouldRestoreAnchorFocus(containerRef.current, document.activeElement)) {
       containerRef.current?.focus()
     }
   }, [isAnchor])

--- a/apps/backend/src/admin/components/data-grid/utils.ts
+++ b/apps/backend/src/admin/components/data-grid/utils.ts
@@ -26,3 +26,90 @@ const SPECIAL_FOCUS_KEYS = [".", ","]
 export function isSpecialFocusKey(event: KeyboardEvent) {
   return SPECIAL_FOCUS_KEYS.includes(event.key) && event.ctrlKey && event.altKey
 }
+/**
+ * #1654 — an element the user is actively working in that is NOT part of a
+ * data grid.
+ *
+ * Grid cells mark themselves in the DOM (`data-cell-id` / `data-container-id`
+ * / `data-field`), so "inside a grid" is answerable from any element. Anything
+ * editable or interactive outside that — a search box beside the grid, a
+ * portaled combobox popover, a menu item, a batches field in a popover — is
+ * the user's, and the grid must not take focus or keystrokes from it.
+ *
+ * Roles are checked as well as tags because a portaled popover's focused
+ * element is often a `div` with a role, not an `<input>`.
+ */
+const FOREIGN_INTERACTIVE_ROLES = new Set([
+  "combobox",
+  "textbox",
+  "searchbox",
+  "listbox",
+  "option",
+  "menu",
+  "menuitem",
+  "menuitemcheckbox",
+  "menuitemradio",
+  "spinbutton",
+  "slider",
+  "switch",
+])
+
+const isInsideDataGrid = (el: Element | null): boolean => {
+  return !!el?.closest?.("[data-cell-id], [data-container-id], [data-field]")
+}
+
+export function isForeignFocusTarget(target: unknown): boolean {
+  const el = target as (HTMLElement & { isContentEditable?: boolean }) | null
+
+  if (!el || typeof (el as any).closest !== "function") {
+    return false
+  }
+
+  if (isInsideDataGrid(el)) {
+    return false
+  }
+
+  const tag = el.tagName
+  if (
+    tag === "INPUT" ||
+    tag === "TEXTAREA" ||
+    tag === "SELECT" ||
+    el.isContentEditable
+  ) {
+    return true
+  }
+
+  const role = el.getAttribute?.("role")
+  return !!role && FOREIGN_INTERACTIVE_ROLES.has(role)
+}
+
+/**
+ * Whether an anchored cell may pull focus to itself.
+ *
+ * The anchor is recomputed on every grid re-render, and a re-render happens
+ * whenever anything on the tab changes form state — including typing in an
+ * input that has nothing to do with the grid. An unconditional self-focus here
+ * is what ate the second keystroke of every word typed beside the grid
+ * (#1654): the first character lands, the grid re-renders, the anchored cell
+ * takes focus, and the rest of the word is typed into a cell.
+ */
+export function shouldRestoreAnchorFocus(
+  container: HTMLElement | null | undefined,
+  activeElement: Element | null
+): boolean {
+  if (!container) {
+    return false
+  }
+
+  // Focus is already in this cell — nothing to restore.
+  if (activeElement && container.contains(activeElement)) {
+    return false
+  }
+
+  // Focus is somewhere the user put it, and it isn't ours to take.
+  if (isForeignFocusTarget(activeElement)) {
+    return false
+  }
+
+  return true
+}

--- a/apps/partner-ui/src/components/data-grid/components/data-grid-root.tsx
+++ b/apps/partner-ui/src/components/data-grid/components/data-grid-root.tsx
@@ -47,7 +47,11 @@ import {
 } from "../hooks"
 import { DataGridMatrix } from "../models"
 import { DataGridCoordinates, GridColumnOption } from "../types"
-import { isCellMatch, isSpecialFocusKey } from "../utils"
+import {
+  isCellMatch,
+  isForeignFocusTarget,
+  isSpecialFocusKey,
+} from "../utils"
 import { DataGridKeyboardShortcutModal } from "./data-grid-keyboard-shortcut-modal"
 export interface DataGridRootProps<
   TData,
@@ -442,6 +446,13 @@ export const DataGridRoot = <
 
   useEffect(() => {
     const specialFocusHandler = (e: KeyboardEvent) => {
+      // #1654 — this fork never carried the foreign-input guard the admin copy
+      // got in #836, so a keystroke aimed at anything else on the page still
+      // reached the grid.
+      if (isForeignFocusTarget(e.target)) {
+        return
+      }
+
       if (isSpecialFocusKey(e)) {
         handleSpecialFocusKeys(e)
         return

--- a/apps/partner-ui/src/components/data-grid/components/data-grid-toggleable-number-cell.tsx
+++ b/apps/partner-ui/src/components/data-grid/components/data-grid-toggleable-number-cell.tsx
@@ -6,6 +6,7 @@ import { useCombinedRefs } from "../../../hooks/use-combined-refs"
 import { ConditionalTooltip } from "../../common/conditional-tooltip"
 import { useDataGridCell, useDataGridCellError } from "../hooks"
 import { DataGridCellProps, InputProps } from "../types"
+import { isForeignFocusTarget } from "../utils"
 import { DataGridCellContainer } from "./data-grid-cell-container"
 
 export const DataGridTogglableNumberCell = <TData, TValue = any>({
@@ -89,6 +90,12 @@ const OuterComponent = ({
 
   useEffect(() => {
     const handleKeyDown = (e: KeyboardEvent) => {
+      // #1654 — a DOCUMENT listener: without this, an "x" typed into any input
+      // on the page toggles the anchor row's switch.
+      if (isForeignFocusTarget(e.target)) {
+        return
+      }
+
       if (isAnchor && e.key.toLowerCase() === "x") {
         e.preventDefault()
         buttonRef.current?.click()

--- a/apps/partner-ui/src/components/data-grid/hooks/use-data-grid-cell.tsx
+++ b/apps/partner-ui/src/components/data-grid/hooks/use-data-grid-cell.tsx
@@ -7,7 +7,11 @@ import {
   DataGridCellRenderProps,
   DataGridCoordinates,
 } from "../types"
-import { isCellMatch, isSpecialFocusKey } from "../utils"
+import {
+  isCellMatch,
+  isSpecialFocusKey,
+  shouldRestoreAnchorFocus,
+} from "../utils"
 
 type UseDataGridCellOptions<TData, TValue> = {
   context: CellContext<TData, TValue>
@@ -201,7 +205,14 @@ export const useDataGridCell = <TData, TValue>({
   }, [type])
 
   useEffect(() => {
-    if (isAnchor && !containerRef.current?.contains(document.activeElement)) {
+    if (!isAnchor) {
+      return
+    }
+
+    // #1654 — do NOT yank focus out of whatever the user is using. This effect
+    // re-runs on every anchor change, and the anchor is recomputed on every
+    // grid re-render — which typing anywhere on the tab causes.
+    if (shouldRestoreAnchorFocus(containerRef.current, document.activeElement)) {
       containerRef.current?.focus()
     }
   }, [isAnchor])

--- a/apps/partner-ui/src/components/data-grid/hooks/use-data-grid-keydown-event.tsx
+++ b/apps/partner-ui/src/components/data-grid/hooks/use-data-grid-keydown-event.tsx
@@ -13,6 +13,7 @@ import {
   DataGridUpdateCommand,
 } from "../models"
 import { DataGridCoordinates } from "../types"
+import { isForeignFocusTarget } from "../utils"
 
 type UseDataGridKeydownEventOptions<TData, TFieldValues extends FieldValues> = {
   containerRef: React.RefObject<HTMLDivElement>
@@ -598,6 +599,13 @@ export const useDataGridKeydownEvent = <
 
   const handleKeyDownEvent = useCallback(
     (e: KeyboardEvent) => {
+      // #1654 — the grid registers this on `window`, so it fires for every
+      // keystroke on the page. Anything the user is typing into that is not a
+      // grid cell handles its own keyboard.
+      if (isForeignFocusTarget(e.target)) {
+        return
+      }
+
       if (ARROW_KEYS.includes(e.key)) {
         handleKeyboardNavigation(e)
         return

--- a/apps/partner-ui/src/components/data-grid/utils.ts
+++ b/apps/partner-ui/src/components/data-grid/utils.ts
@@ -26,3 +26,91 @@ const SPECIAL_FOCUS_KEYS = [".", ","]
 export function isSpecialFocusKey(event: KeyboardEvent) {
   return SPECIAL_FOCUS_KEYS.includes(event.key) && event.ctrlKey && event.altKey
 }
+
+/**
+ * #1654 — an element the user is actively working in that is NOT part of a
+ * data grid.
+ *
+ * Grid cells mark themselves in the DOM (`data-cell-id` / `data-container-id`
+ * / `data-field`), so "inside a grid" is answerable from any element. Anything
+ * editable or interactive outside that — a search box beside the grid, a
+ * portaled combobox popover, a menu item, a batches field in a popover — is
+ * the user's, and the grid must not take focus or keystrokes from it.
+ *
+ * Roles are checked as well as tags because a portaled popover's focused
+ * element is often a `div` with a role, not an `<input>`.
+ */
+const FOREIGN_INTERACTIVE_ROLES = new Set([
+  "combobox",
+  "textbox",
+  "searchbox",
+  "listbox",
+  "option",
+  "menu",
+  "menuitem",
+  "menuitemcheckbox",
+  "menuitemradio",
+  "spinbutton",
+  "slider",
+  "switch",
+])
+
+const isInsideDataGrid = (el: Element | null): boolean => {
+  return !!el?.closest?.("[data-cell-id], [data-container-id], [data-field]")
+}
+
+export function isForeignFocusTarget(target: unknown): boolean {
+  const el = target as (HTMLElement & { isContentEditable?: boolean }) | null
+
+  if (!el || typeof (el as any).closest !== "function") {
+    return false
+  }
+
+  if (isInsideDataGrid(el)) {
+    return false
+  }
+
+  const tag = el.tagName
+  if (
+    tag === "INPUT" ||
+    tag === "TEXTAREA" ||
+    tag === "SELECT" ||
+    el.isContentEditable
+  ) {
+    return true
+  }
+
+  const role = el.getAttribute?.("role")
+  return !!role && FOREIGN_INTERACTIVE_ROLES.has(role)
+}
+
+/**
+ * Whether an anchored cell may pull focus to itself.
+ *
+ * The anchor is recomputed on every grid re-render, and a re-render happens
+ * whenever anything on the tab changes form state — including typing in an
+ * input that has nothing to do with the grid. An unconditional self-focus here
+ * is what ate the second keystroke of every word typed beside the grid
+ * (#1654): the first character lands, the grid re-renders, the anchored cell
+ * takes focus, and the rest of the word is typed into a cell.
+ */
+export function shouldRestoreAnchorFocus(
+  container: HTMLElement | null | undefined,
+  activeElement: Element | null
+): boolean {
+  if (!container) {
+    return false
+  }
+
+  // Focus is already in this cell — nothing to restore.
+  if (activeElement && container.contains(activeElement)) {
+    return false
+  }
+
+  // Focus is somewhere the user put it, and it isn't ours to take.
+  if (isForeignFocusTarget(activeElement)) {
+    return false
+  }
+
+  return true
+}


### PR DESCRIPTION
Fixes #1654.

## The issue named the wrong culprit

`handleKeyDownEvent` has carried a foreign-input guard since **2026-07-02** (`8c19108af`, PR #836) — at `use-data-grid-keydown-event.tsx:25,640`, one file over from `data-grid-root.tsx` where the issue looked. Nothing in it starts editing on a printable key either; that path (`handleSpecialFocusKeys`) needs **ctrl+alt**. Applying the guard as written would have been a no-op.

## What actually steals the keystroke

The anchored cell's focus effect, `use-data-grid-cell.tsx:203`:

```ts
if (isAnchor && !containerRef.current?.contains(document.activeElement)) {
  containerRef.current?.focus()
}
```

It pulls focus to the anchor whenever focus is *anywhere else*, and it re-runs on every anchor change — which any grid re-render can produce, and typing anywhere on the tab causes a re-render.

So the reported sequence is:

1. `1` lands in the user's input
2. the grid re-renders; the anchored cell's effect fires and takes focus
3. `2345` now goes to the cell container, whose own `handleContainerKeyDown` moves the caret into the cell's `<input>` and types there

which is exactly the reported `activeElement` (`INPUT.txt-compact-small size-full bg-transparent outline-none`), and why "scoping the React re-render didn't help" — that removed one re-render source out of many.

## The fix

One ownership rule, shared by every handler (`utils.ts`):

- `isForeignFocusTarget` — a cell is the grid's if it sits inside `[data-cell-id] / [data-container-id] / [data-field]`. Anything editable or interactive **outside** that is the user's and may not be taken over. Roles are checked as well as tags, because a portaled popover's focused element is usually a `div` with a role, not an `<input>`.
- `shouldRestoreAnchorFocus` — the effect's condition, now target-aware. Navigation between cells is unaffected: focus on `<body>`, or in another cell, still restores.

Two more places were genuinely unguarded and now use the same rule:

- `data-grid-toggleable-number-cell.tsx` registers a **`document`** keydown where `x` clicks the anchor row's Switch — no target check at all.
- **`apps/partner-ui`'s grid is a pre-#836 fork carrying NEITHER window guard**, on screens that ship today (`product-stock`, price lists). Both are ported here.

The root's `specialFocusHandler` also knew only `role="combobox"`, so a portaled menu or option fell through.

## Verification

11 unit cases (`components/data-grid/__tests__/foreign-focus.unit.spec.ts`), and **mutation-checked**: reverting the guard turns exactly the two theft cases red —

```
✕ does NOT steal focus from an input beside the grid — the reported bug
✕ does not steal focus from a portaled popover the user has open
```

— while all four "must still work" cases stay green, so the fix is not the effect being disabled.

`pnpm check:prod-build` green; `tsc` clean on every touched admin file.

## Why now

#1654 was latent only because no screen put a text input beside the grid. That is no longer true — see the note on #1662 / #1663: with a product catalog in the picker, the inventory-order form's **batches** field (`#mg-batches`, in the Add-material-group popover) sits on the same tab as the grid, and buying finished goods means searching a 225-item catalog rather than recognising a short material list.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01TLt1f38xqR8k2myCVxP8e4