### PR TITLE
feat(payments): claim a production run by QUANTITY, not as a boolean (#1596)

### DIFF
--- a/apps/backend/integration-tests/http/payment-submissions-api.spec.ts
+++ b/apps/backend/integration-tests/http/payment-submissions-api.spec.ts
@@ -1722,13 +1722,22 @@ setupSharedTestSuite(() => {
       )
       expect(approved.status).toBe(200)
 
+      /**
+       * ⚠️ 7 more, not another 4. Since #1596 a run is claimed by QUANTITY:
+       * 4 + 4 of a run ordered for 9 is legitimate tranche billing, and the
+       * ceiling is what stands between the partner and a second payment for
+       * the same work. 4 + 7 = 11 asks for more than was ever ordered, which
+       * is the double pay this case has always been about — and it still has
+       * to be refused with the first payout Approved and the design-level
+       * guard therefore out of the way.
+       */
       const second = await api
         .post(
           "/admin/payment-submissions",
           {
             partner_id: partnerId,
             design_ids: [d1],
-            quantities: { [d1]: 4 },
+            quantities: { [d1]: 7 },
             unit_amounts: { [d1]: 1200 },
             production_run_ids: { [d1]: [runId] },
           },
@@ -1739,6 +1748,7 @@ setupSharedTestSuite(() => {
       expect(second.status).toBe(400)
       expect(second.data.message).toContain("already paid for")
       expect(second.data.message).toContain(runId)
+      expect(second.data.message).toContain("5 remaining")
     })
 
     it("releases a run when its submission was rejected", async () => {
@@ -1782,6 +1792,160 @@ setupSharedTestSuite(() => {
 
       expect(replacement.status).toBe(201)
       expect(Number(replacement.data.payment_submission.total_amount)).toBe(8400)
+    })
+
+    it("bills 1 of 10 now and the other 9 later, at a different rate (#1596)", async () => {
+      /**
+       * The founder's case, and the whole reason the whole-run claim had to
+       * go: a partner finishes 1 of 10, submits, then submits the remaining 9
+       * at a DIFFERENT price. Under the old boolean claim the second submission
+       * was refused outright — the run had been "paid for" — which is what made
+       * reject-and-replace the only way to correct anything, and it only ever
+       * worked because the rates happened to match.
+       */
+      const d1 = await createDesign("Partial Claim Design", {
+        estimated_cost: 5000,
+      })
+      await linkDesignToPartner(d1, partnerId)
+      const runId = await createCompletedRun(d1, "Partial Claim Design", {
+        quantity: 10,
+        produced_quantity: 1,
+      })
+
+      const first = await api.post(
+        "/admin/payment-submissions",
+        {
+          partner_id: partnerId,
+          design_ids: [d1],
+          quantities: { [d1]: 1 },
+          unit_amounts: { [d1]: 1200 },
+          production_run_ids: { [d1]: [runId] },
+        },
+        adminHeaders
+      )
+      expect(first.status).toBe(201)
+      expect(Number(first.data.payment_submission.total_amount)).toBe(1200)
+
+      /**
+       * ⚠️ The first payout has to be CLOSED before the second is offered.
+       * Step 5 refuses a design that is already in an active submission, and
+       * that guard is about designs, not runs — it is not quantity-aware and
+       * fires first. So two OPEN claims on one design still cannot coexist;
+       * what #1596 unlocks is billing the rest once the first has been
+       * reviewed, which is the flow an operator actually follows.
+       */
+      const approved = await api.post(
+        `/admin/payment-submissions/${first.data.payment_submission.id}/review`,
+        { action: "approve", paid_to_id: paidToId },
+        adminHeaders
+      )
+      expect(approved.status).toBe(200)
+
+      // The rest, later, at a different rate — and crucially WITHOUT
+      // rejecting the first, which was the only way to do this before.
+      const second = await api.post(
+        "/admin/payment-submissions",
+        {
+          partner_id: partnerId,
+          design_ids: [d1],
+          quantities: { [d1]: 9 },
+          unit_amounts: { [d1]: 1400 },
+          production_run_ids: { [d1]: [runId] },
+        },
+        adminHeaders
+      )
+      expect(second.status).toBe(201)
+      expect(Number(second.data.payment_submission.total_amount)).toBe(12600)
+    })
+
+    it("refuses the piece that would take a run past what was ordered (#1596)", async () => {
+      // Partial claims are headroom, not a licence. 1 + 9 fills a run ordered
+      // for 10; the eleventh piece has nothing behind it.
+      const d1 = await createDesign("Overclaim Design", { estimated_cost: 5000 })
+      await linkDesignToPartner(d1, partnerId)
+      const runId = await createCompletedRun(d1, "Overclaim Design", {
+        quantity: 10,
+      })
+
+      const first = await api.post(
+        "/admin/payment-submissions",
+        {
+          partner_id: partnerId,
+          design_ids: [d1],
+          quantities: { [d1]: 9 },
+          unit_amounts: { [d1]: 1200 },
+          production_run_ids: { [d1]: [runId] },
+        },
+        adminHeaders
+      )
+      await api.post(
+        `/admin/payment-submissions/${first.data.payment_submission.id}/review`,
+        { action: "approve", paid_to_id: paidToId },
+        adminHeaders
+      )
+
+      const over = await api
+        .post(
+          "/admin/payment-submissions",
+          {
+            partner_id: partnerId,
+            design_ids: [d1],
+            quantities: { [d1]: 2 },
+            unit_amounts: { [d1]: 1200 },
+            production_run_ids: { [d1]: [runId] },
+          },
+          adminHeaders
+        )
+        .catch((e: any) => e.response)
+
+      expect(over.status).toBe(400)
+      expect(over.data.message).toContain("already paid for")
+      expect(over.data.message).toContain("1 remaining")
+    })
+
+    it("still refuses a second claim that states no quantity (#1596)", async () => {
+      // Saying nothing claims the WHOLE run, exactly as it always did — the
+      // partial path is opt-in, so nothing previously refused slips through.
+      const d1 = await createDesign("Silent Claim Design", {
+        estimated_cost: 5000,
+      })
+      await linkDesignToPartner(d1, partnerId)
+      const runId = await createCompletedRun(d1, "Silent Claim Design", {
+        quantity: 10,
+      })
+
+      const first = await api.post(
+        "/admin/payment-submissions",
+        {
+          partner_id: partnerId,
+          design_ids: [d1],
+          quantities: { [d1]: 1 },
+          unit_amounts: { [d1]: 1200 },
+          production_run_ids: { [d1]: [runId] },
+        },
+        adminHeaders
+      )
+      await api.post(
+        `/admin/payment-submissions/${first.data.payment_submission.id}/review`,
+        { action: "approve", paid_to_id: paidToId },
+        adminHeaders
+      )
+
+      const second = await api
+        .post(
+          "/admin/payment-submissions",
+          {
+            partner_id: partnerId,
+            design_ids: [d1],
+            unit_amounts: { [d1]: 1200 },
+            production_run_ids: { [d1]: [runId] },
+          },
+          adminHeaders
+        )
+        .catch((e: any) => e.response)
+
+      expect(second.status).toBe(400)
+      expect(second.data.message).toContain("already paid for")
     })
 
     it("refuses a run that belongs to another partner", async () => {
@@ -2985,7 +3149,14 @@ setupSharedTestSuite(() => {
         design_id: designId,
         design_name: "Contested Draft Run Design",
         amount: 1000,
-        quantity: 1,
+        /**
+         * ⚠️ The rival takes the WHOLE run — 9, its ordered quantity. Since
+         * #1596 a claim is quantity-aware, so a rival holding 1 of 9 leaves
+         * room the draft's own 4 units fit inside, and the transition would be
+         * right to allow it. What must still be refused is a draft claiming
+         * units nobody has left.
+         */
+        quantity: 9,
         production_run_ids: [runId],
         run_provenance: "recorded",
         submission_id: rival.id,

--- a/apps/backend/integration-tests/http/payment-submissions-api.spec.ts
+++ b/apps/backend/integration-tests/http/payment-submissions-api.spec.ts
@@ -1025,8 +1025,16 @@ setupSharedTestSuite(() => {
       const paid = res.data.payable_runs.find((r: any) => r.run_id === paidRun)
       const fresh = res.data.payable_runs.find((r: any) => r.run_id === freshRun)
 
-      expect(paid.billing_status).toBe("billed")
+      /**
+       * ⚠️ `partly_billed`, not `billed` — 4 of the 9 this run was ordered for
+       * (#1596). It is not `clear`, which is what this case is about: a
+       * recorded claim is never doubt. And the remainder is stated, because
+       * the write guard will accept it.
+       */
+      expect(paid.billing_status).toBe("partly_billed")
+      expect(paid.billable_remaining).toBe(5)
       expect(fresh.billing_status).toBe("clear")
+      expect(fresh.billable_remaining).toBeNull()
       expect(fresh.unrecorded_claims).toHaveLength(0)
     })
 
@@ -1185,14 +1193,18 @@ setupSharedTestSuite(() => {
       expect(applied.status).toBe(200)
       expect(applied.data.result.applied).toBe(true)
 
-      // The EFFECT, not the summary: the run now reads as billed rather than
-      // unknown, which is the whole point of recording it.
+      // The EFFECT, not the summary: the run now reads as claimed rather than
+      // unknown, which is the whole point of recording it. Which of the two
+      // claimed statuses it is depends on how much of the run the line covers
+      // (#1596); what matters here is that the doubt is gone.
       const runs = await api.get(
         `/admin/payment-submissions/payable-runs?partner_id=${partnerId}`,
         adminHeaders
       )
       const row = runs.data.payable_runs.find((r: any) => r.run_id === runId)
-      expect(row.billing_status).toBe("billed")
+      expect(["billed", "partly_billed"]).toContain(row.billing_status)
+      expect(row.billing_status).not.toBe("unknown")
+      expect(row.billed).not.toBeNull()
     })
 
     it("refuses a run already recorded on another live payout", async () => {
@@ -2736,8 +2748,13 @@ setupSharedTestSuite(() => {
 
       const row = res.data.payable_runs.find((r: any) => r.run_id === runId)
       expect(row).toBeDefined()
-      expect(row.billing_status).toBe("billed")
+      // ⚠️ `partly_billed` since #1596 — the line covers some of what the run
+      // was ordered for, and the rest is still billable. The point of the case
+      // is that it is NOT `clear`.
+      expect(row.billing_status).toBe("partly_billed")
+      expect(row.billing_status).not.toBe("clear")
       expect(row.billed).not.toBeNull()
+      expect(row.billable_remaining).toBeGreaterThan(0)
     })
   })
 

--- a/apps/backend/src/admin/hooks/api/production-runs.ts
+++ b/apps/backend/src/admin/hooks/api/production-runs.ts
@@ -777,8 +777,16 @@ export type ProductionRunBilling = {
   run_id: string
   partner_id: string | null
   /** Branch on this — `unknown` is not `clear`. See `runBillingStatus`. */
-  billing_status: "billed" | "unknown" | "clear"
-  claim: { submission_id: string; status: string; quantity: number } | null
+  billing_status: "billed" | "partly_billed" | "unknown" | "clear"
+  claim: {
+    submission_id: string
+    status: string
+    quantity: number
+    claimed_quantity: number
+    claimed_wholly: boolean
+  } | null
+  /** Units still billable, or null when there is no arithmetic behind it. */
+  billable_remaining: number | null
   unrecorded_claims: Array<{
     submission_id: string
     status: string

--- a/apps/backend/src/admin/routes/production-runs/[id]/page.tsx
+++ b/apps/backend/src/admin/routes/production-runs/[id]/page.tsx
@@ -421,6 +421,30 @@ const ProductionRunDetailPage = () => {
                       </Link>
                     )}
                   </div>
+                ) : billing.billing_status === "partly_billed" ? (
+                  /**
+                   * #1596 — part of this run is paid for and the rest is still
+                   * billable. Saying "Billed" here is what left the last units
+                   * of a short-completed run unbillable through any screen.
+                   */
+                  <div className="flex flex-col gap-y-1">
+                    <div className="flex items-center gap-x-2">
+                      <StatusBadge color="blue">Partly billed</StatusBadge>
+                      {billing.claim?.submission_id && (
+                        <Link
+                          to={`/payment-submissions/${billing.claim.submission_id}`}
+                          className="text-ui-fg-interactive text-xs hover:underline"
+                        >
+                          {billing.claim.status} payout
+                        </Link>
+                      )}
+                    </div>
+                    <Text size="xsmall" className="text-ui-fg-subtle">
+                      {billing.claim?.claimed_quantity} of{" "}
+                      {String(run.quantity ?? "-")} billed —{" "}
+                      {billing.billable_remaining} still billable.
+                    </Text>
+                  </div>
                 ) : billing.billing_status === "unknown" ? (
                   <div className="flex flex-col gap-y-1">
                     <StatusBadge color="orange">Unknown</StatusBadge>

--- a/apps/backend/src/api/admin/payment-submissions/payable-runs/route.ts
+++ b/apps/backend/src/api/admin/payment-submissions/payable-runs/route.ts
@@ -6,6 +6,10 @@ import PaymentSubmissionsService from "../../../../modules/payment_submissions/s
 import { isProvenanceRun } from "../../../../workflows/consumption-logs/lib/reconcile-production-consumption"
 import { runPayableOffer } from "../../../../workflows/production-runs/lib/run-payable"
 import { listPartnerSubmissionItems } from "../../../../workflows/payment_submissions/lib/run-claims"
+import {
+  runBillableRemaining,
+  runBillingStatus,
+} from "../../../../workflows/payment_submissions/lib/run-billing"
 import { groupOrderBackedRuns } from "../../../../workflows/payment_submissions/lib/order-run-groups"
 import { foldPartnerBilling } from "../../../../workflows/payment_submissions/lib/run-billing"
 
@@ -359,6 +363,16 @@ export const GET = async (req: MedusaRequest, res: MedusaResponse) => {
             : Number(design.production_cost),
         billed: billedRuns.get(String(run.id)) ?? null,
         /**
+         * Units still billable on this run (#1596). Null when the question has
+         * no arithmetic behind it — nobody has claimed it, a claim took it
+         * whole, or the run states no quantity — which is exactly when the
+         * write guard refuses. A number here is a promise `create` will keep.
+         */
+        billable_remaining: runBillableRemaining({
+          claim: billedRuns.get(String(run.id)),
+          ordered: run.quantity,
+        }),
+        /**
          * Live payouts against this design that never recorded a run.
          *
          * ⚠️ Non-empty means `billed: null` is IGNORANCE, not innocence — one
@@ -378,18 +392,25 @@ export const GET = async (req: MedusaRequest, res: MedusaResponse) => {
        * The single field a caller should branch on, so that "we don't know"
        * cannot be spelled the same way as "no".
        *
-       * - `billed`  — a payment line names this run. Do not pay again.
-       * - `unknown` — a live payout for this design records no run, so this
-       *               run may already be inside it. Needs a human before it is
-       *               paid; #1565 is the whole reason this value exists.
-       * - `clear`   — every live payout for this design says which runs it
-       *               covered, and none of them is this one. Safe to bill.
+       * - `billed`        — claimed in full. Do not pay again.
+       * - `partly_billed` — SOME of it is claimed and `billable_remaining`
+       *                     units are left (#1596). The write guard accepts
+       *                     the remainder, so this screen must offer it.
+       * - `unknown`       — a live payout for this design records no run, so
+       *                     this run may already be inside it. Needs a human
+       *                     before it is paid; #1565 is why this value exists.
+       * - `clear`         — every live payout for this design says which runs
+       *                     it covered, and none is this one. Safe to bill.
+       *
+       * 🔴 The values are produced by `runBillingStatus` in `lib/run-billing`,
+       * not spelled out here — this route and the run page must not be able to
+       * disagree about whether someone gets paid twice.
        */
-      billing_status: row.billed
-        ? ("billed" as const)
-        : row.unrecorded_claims.length
-          ? ("unknown" as const)
-          : ("clear" as const),
+      billing_status: runBillingStatus({
+        billed: row.billed,
+        unrecordedClaims: row.unrecorded_claims,
+        remaining: row.billable_remaining,
+      }),
     }))
     .sort((a, b) => {
       // Clear work first — that is what the screen is for. Then `unknown`,
@@ -400,7 +421,9 @@ export const GET = async (req: MedusaRequest, res: MedusaResponse) => {
       // 🔴 `unknown` deliberately does NOT rank with `clear`. Sorting an
       // unverifiable run to the top next to genuinely unpaid work is precisely
       // how a second payout for the same garments would get made.
-      const rank = { clear: 0, unknown: 1, billed: 2 }
+      // `partly_billed` ranks with the work, just behind `clear`: it IS
+      // billable, and it is the case an operator came here to finish.
+      const rank = { clear: 0, partly_billed: 1, unknown: 2, billed: 3 }
       if (rank[a.billing_status] !== rank[b.billing_status]) {
         return rank[a.billing_status] - rank[b.billing_status]
       }

--- a/apps/backend/src/api/admin/production-runs/[id]/payments/route.ts
+++ b/apps/backend/src/api/admin/production-runs/[id]/payments/route.ts
@@ -25,6 +25,7 @@ import { PRODUCTION_RUNS_MODULE } from "../../../../../modules/production_runs"
 import { listPartnerSubmissionItems } from "../../../../../workflows/payment_submissions/lib/run-claims"
 import {
   foldPartnerBilling,
+  runBillableRemaining,
   runBillingStatus,
 } from "../../../../../workflows/payment_submissions/lib/run-billing"
 
@@ -54,6 +55,7 @@ export const GET = async (req: MedusaRequest, res: MedusaResponse) => {
       partner_id: null,
       billing_status: "unknown",
       claim: null,
+      billable_remaining: null,
       unrecorded_claims: [],
       lines: [],
     })
@@ -104,6 +106,16 @@ export const GET = async (req: MedusaRequest, res: MedusaResponse) => {
       production_run_ids: item.production_run_ids ?? null,
     }))
 
+  /**
+   * Units still billable on this run (#1596). `retrieveProductionRun` returns
+   * the whole row, so `quantity` — the ceiling the write guard uses — is
+   * genuinely present rather than merely typed.
+   */
+  const billable_remaining = runBillableRemaining({
+    claim,
+    ordered: run.quantity,
+  })
+
   return res.status(200).json({
     run_id: id,
     partner_id: run.partner_id,
@@ -111,8 +123,10 @@ export const GET = async (req: MedusaRequest, res: MedusaResponse) => {
     billing_status: runBillingStatus({
       billed: claim,
       unrecordedClaims: unrecorded_claims,
+      remaining: billable_remaining,
     }),
     claim,
+    billable_remaining,
     unrecorded_claims,
     lines,
   })

--- a/apps/backend/src/api/partners/payment-submissions/payable-runs/route.ts
+++ b/apps/backend/src/api/partners/payment-submissions/payable-runs/route.ts
@@ -5,6 +5,11 @@ import { PAYMENT_SUBMISSIONS_MODULE } from "../../../../modules/payment_submissi
 import PaymentSubmissionsService from "../../../../modules/payment_submissions/service"
 import { isProvenanceRun } from "../../../../workflows/consumption-logs/lib/reconcile-production-consumption"
 import { runUnitCost } from "../../../../workflows/production-runs/lib/run-payable"
+import {
+  foldPartnerBilling,
+  runBillableRemaining,
+  runBillingStatus,
+} from "../../../../workflows/payment_submissions/lib/run-billing"
 import { getPartnerFromAuthContext } from "../../helpers"
 
 /**
@@ -116,51 +121,16 @@ export const GET = async (
     { relations: ["submission"] }
   )) as any[]
 
-  const billedRuns = new Map<
-    string,
-    { submission_id: string; status: string; quantity: number }
-  >()
-  const designsWithOpenSubmission = new Set<string>()
-  const designsWithUnrecordedClaims = new Map<
-    string,
-    { submission_id: string; status: string; amount: number }[]
-  >()
-  const OPEN_STATUSES = new Set([
-    "Draft",
-    "Pending",
-    "Under_Review",
-  ])
-
-  for (const item of priorItems || []) {
-    const status = String(item.submission?.status || "")
-    // A Rejected submission never paid anyone — its lines release their runs.
-    if (status === "Rejected") continue
-
-    if (OPEN_STATUSES.has(status) && item.design_id) {
-      designsWithOpenSubmission.add(String(item.design_id))
-    }
-
-    if (item.run_provenance === "not_recorded" && item.design_id) {
-      const designId = String(item.design_id)
-      const claims = designsWithUnrecordedClaims.get(designId) || []
-      claims.push({
-        submission_id: String(item.submission?.id || item.submission_id || ""),
-        status,
-        amount: Number(item.amount ?? 0),
-      })
-      designsWithUnrecordedClaims.set(designId, claims)
-    }
-
-    for (const runId of (item.production_run_ids || []) as string[]) {
-      if (!billedRuns.has(runId)) {
-        billedRuns.set(runId, {
-          submission_id: String(item.submission?.id || item.submission_id || ""),
-          status,
-          quantity: Number(item.quantity ?? 1),
-        })
-      }
-    }
-  }
+  /**
+   * 🔴 This route used to carry its OWN copy of the fold — the second
+   * implementation of "is this run billed" that `lib/run-billing` exists to
+   * prevent, and it had already drifted: it never learned the quantity-aware
+   * claim (#1596), so a run this partner had partly billed showed as fully
+   * billed here while the admin screen and the write guard said otherwise.
+   * One fold, used by both screens and the run page.
+   */
+  const { billedRuns, designsWithUnrecordedClaims, designsWithOpenSubmission } =
+    foldPartnerBilling(priorItems as any[])
 
   const payable_runs = completedRuns
     .map((run) => {
@@ -210,6 +180,12 @@ export const GET = async (
             ? null
             : Number(design.production_cost),
         billed: billedRuns.get(String(run.id)) ?? null,
+        // Units still billable (#1596). Null when there is no arithmetic
+        // behind the answer — which is exactly when `create` refuses.
+        billable_remaining: runBillableRemaining({
+          claim: billedRuns.get(String(run.id)),
+          ordered: run.quantity,
+        }),
         unrecorded_claims:
           designsWithUnrecordedClaims.get(String(run.design_id)) ?? [],
         design_has_open_submission: designsWithOpenSubmission.has(
@@ -219,14 +195,15 @@ export const GET = async (
     })
     .map((row) => ({
       ...row,
-      billing_status: row.billed
-        ? ("billed" as const)
-        : row.unrecorded_claims.length
-          ? ("unknown" as const)
-          : ("clear" as const),
+      billing_status: runBillingStatus({
+        billed: row.billed,
+        unrecordedClaims: row.unrecorded_claims,
+        remaining: row.billable_remaining,
+      }),
     }))
     .sort((a, b) => {
-      const rank = { clear: 0, unknown: 1, billed: 2 }
+      // `partly_billed` ranks just behind `clear` — it is billable work.
+      const rank = { clear: 0, partly_billed: 1, unknown: 2, billed: 3 }
       if (rank[a.billing_status] !== rank[b.billing_status]) {
         return rank[a.billing_status] - rank[b.billing_status]
       }

--- a/apps/backend/src/workflows/payment_submissions/create-payment-submission.ts
+++ b/apps/backend/src/workflows/payment_submissions/create-payment-submission.ts
@@ -19,8 +19,10 @@ import {
   runlessResubmitMessage,
 } from "./lib/run-evidence-guard"
 import {
-  listPartnerRunClaims,
-  runsAlreadyClaimedMessage,
+  assessRunClaims,
+  listPartnerRunTallies,
+  requestedRunQuantities,
+  runsOverclaimedMessage,
 } from "./lib/run-claims"
 import {
   assessInventoryOrderClaims,
@@ -382,6 +384,41 @@ export const resolveDesignLineAmount = (input: {
  * An explicit `quantity` combined with runs bills the RUNS' rate for that many
  * units: the caller is correcting how many, not what each one costs.
  */
+/**
+ * PURE: the units a request EXPLICITLY claims for one design, or null when it
+ * states none.
+ *
+ * The run-claim guard runs before the lines are priced, so it cannot read the
+ * resolved line — but it must agree with what that line will bill, or the
+ * guard and the money would be answering different questions. Both read the
+ * same two inputs, in the same precedence the pricer uses:
+ *
+ *   1. per-piece bands, whose folded quantity is the units they describe;
+ *   2. an explicit per-design `quantities` entry.
+ *
+ * Null when neither is stated — and null means "the whole run" to the guard,
+ * which is exactly what a caller who said nothing has always claimed.
+ */
+export const claimedQuantityForDesign = (
+  designId: string,
+  input: {
+    quantities?: Record<string, number> | null
+    rate_breakdown?: Record<string, RateSlice[]> | null
+  }
+): number | null => {
+  const slices = input.rate_breakdown?.[designId]
+  if (slices?.length) {
+    const folded = foldRateBreakdown(slices)
+    const banded = Number(folded.quantity)
+    if (Number.isFinite(banded) && banded > 0) {
+      return banded
+    }
+  }
+
+  const stated = Number(input.quantities?.[designId])
+  return Number.isFinite(stated) && stated > 0 ? stated : null
+}
+
 export const resolvePaymentLineAmount = (input: {
   runs?: Array<RunForPayout & { produced_quantity?: number | null }> | null
   unit_cost: number
@@ -761,15 +798,39 @@ const validateDesignsForSubmissionStep = createStep(
       const submissionService: PaymentSubmissionsService = container.resolve(
         PAYMENT_SUBMISSIONS_MODULE
       )
-      const billed = await listPartnerRunClaims(
+      /**
+       * #1596 — a run is claimed by QUANTITY, not as a boolean.
+       *
+       * A partner who finishes 1 of 10, bills it, and bills the other 9 later
+       * at a different rate was refused outright by the old whole-run claim,
+       * which is what made reject-and-replace the only way to correct a claim.
+       * Now: the units already claimed are summed and diffed against what the
+       * run was ordered for.
+       *
+       * ⚠️ Only an EXPLICIT quantity — stated per design, or implied by the
+       * per-piece bands — makes this claim partial. Saying nothing still claims
+       * the whole run, so nothing previously refused becomes allowed by
+       * accident.
+       */
+      const tallies = await listPartnerRunTallies(
         submissionService as any,
         input.partner_id
       )
-      const duplicates = allClaimedRunIds.filter((id) => billed.has(id))
-      if (duplicates.length) {
+      const requested = requestedRunQuantities(
+        Object.entries(claimedRuns).map(([designId, runIds]) => ({
+          production_run_ids: runIds,
+          quantity: claimedQuantityForDesign(designId, input),
+        }))
+      )
+      const overclaimed = assessRunClaims({
+        requestedByRun: requested,
+        runs: runById,
+        tallies,
+      })
+      if (overclaimed.length) {
         throw new MedusaError(
           MedusaError.Types.INVALID_DATA,
-          runsAlreadyClaimedMessage(duplicates, billed)
+          runsOverclaimedMessage(overclaimed)
         )
       }
     }
@@ -1120,15 +1181,26 @@ const validateRunLinesStep = createStep(
     const submissionService: PaymentSubmissionsService = container.resolve(
       PAYMENT_SUBMISSIONS_MODULE
     )
-    const billed = await listPartnerRunClaims(
+    const tallies = await listPartnerRunTallies(
       submissionService as any,
       input.partner_id
     )
-    const duplicates = allRunIds.filter((id) => billed.has(id))
-    if (duplicates.length) {
+    // #1596 — quantity-aware, same rule as the design path: a line naming one
+    // run for N units claims N of it, anything else claims the run whole.
+    const overclaimed = assessRunClaims({
+      requestedByRun: requestedRunQuantities(
+        lines.map((line) => ({
+          production_run_ids: line.run_ids,
+          quantity: (line as any).quantity,
+        }))
+      ),
+      runs: runById,
+      tallies,
+    })
+    if (overclaimed.length) {
       throw new MedusaError(
         MedusaError.Types.INVALID_DATA,
-        runsAlreadyClaimedMessage(duplicates, billed)
+        runsOverclaimedMessage(overclaimed)
       )
     }
 

--- a/apps/backend/src/workflows/payment_submissions/lib/__tests__/run-billing.unit.spec.ts
+++ b/apps/backend/src/workflows/payment_submissions/lib/__tests__/run-billing.unit.spec.ts
@@ -1,5 +1,6 @@
 import {
   foldPartnerBilling,
+  runBillableRemaining,
   runBillingStatus,
 } from "../run-billing"
 
@@ -25,6 +26,10 @@ describe("foldPartnerBilling", () => {
       submission_id: "sub_1",
       status: "Pending",
       quantity: 1,
+      // #1596 — the claim carries how MUCH of the run it took, so a screen can
+      // offer what is left instead of reporting the whole run as billed.
+      claimed_quantity: 1,
+      claimed_wholly: false,
     })
   })
 
@@ -118,5 +123,99 @@ describe("runBillingStatus", () => {
 
   it("says clear only when every live payout named its runs", () => {
     expect(runBillingStatus({ billed: null, unrecordedClaims: [] })).toBe("clear")
+  })
+})
+
+/**
+ * #1596 — how much of a run is left, and the status a screen branches on.
+ *
+ * The write guard accepts the remainder of a partly-claimed run. Reporting it
+ * as `billed` is what left the last units of a short-completed run unbillable
+ * through any screen: the workflow said yes and nothing would ask.
+ */
+describe("runBillableRemaining / runBillingStatus (#1596)", () => {
+  const line = (over: Record<string, any> = {}) => ({
+    submission: { id: "sub_1", status: "Pending" },
+    design_id: "design_1",
+    amount: 1000,
+    quantity: 1,
+    run_provenance: "recorded",
+    production_run_ids: ["run_1"],
+    ...over,
+  })
+
+  const claimOf = (over: Record<string, any> = {}) => ({
+    submission_id: "sub_1",
+    status: "Pending",
+    quantity: 4,
+    claimed_quantity: 4,
+    claimed_wholly: false,
+    ...over,
+  })
+
+  it("reports what is left of a partly claimed run", () => {
+    expect(runBillableRemaining({ claim: claimOf(), ordered: 9 })).toBe(5)
+    expect(
+      runBillingStatus({
+        billed: claimOf(),
+        unrecordedClaims: [],
+        remaining: 5,
+      })
+    ).toBe("partly_billed")
+  })
+
+  it("is `billed` once the ordered quantity is fully claimed", () => {
+    const claim = claimOf({ claimed_quantity: 9 })
+    expect(runBillableRemaining({ claim, ordered: 9 })).toBe(0)
+    expect(
+      runBillingStatus({ billed: claim, unrecordedClaims: [], remaining: 0 })
+    ).toBe("billed")
+  })
+
+  it("says NOTHING rather than 0 when the arithmetic is unavailable", () => {
+    // Null, never a number, in exactly the three cases `assessRunClaims`
+    // refuses — a number here is a promise the write guard has to keep.
+    expect(runBillableRemaining({ claim: null, ordered: 9 })).toBeNull()
+    expect(
+      runBillableRemaining({ claim: claimOf({ claimed_wholly: true }), ordered: 9 })
+    ).toBeNull()
+    expect(runBillableRemaining({ claim: claimOf(), ordered: null })).toBeNull()
+    expect(runBillableRemaining({ claim: claimOf(), ordered: 0 })).toBeNull()
+  })
+
+  it("a run claimed WHOLLY still reads as billed, not partly billed", () => {
+    const claim = claimOf({ claimed_wholly: true, claimed_quantity: 0 })
+    expect(
+      runBillingStatus({
+        billed: claim,
+        unrecordedClaims: [],
+        remaining: runBillableRemaining({ claim, ordered: 9 }),
+      })
+    ).toBe("billed")
+  })
+
+  it("sums every live line naming the run, not just the first", () => {
+    const { billedRuns } = foldPartnerBilling([
+      line({ quantity: 1 }),
+      line({ quantity: 3, submission: { id: "sub_2", status: "Approved" } }),
+    ])
+
+    const claim = billedRuns.get("run_1")!
+    // The DISPLAYED claim is still the earliest one, as before…
+    expect(claim.submission_id).toBe("sub_1")
+    // …but the units are everyone's.
+    expect(claim.claimed_quantity).toBe(4)
+    expect(runBillableRemaining({ claim, ordered: 9 })).toBe(5)
+  })
+
+  it("a line over several runs takes each of them whole", () => {
+    const { billedRuns } = foldPartnerBilling([
+      line({ quantity: 7, production_run_ids: ["run_1", "run_2"] }),
+    ])
+
+    expect(billedRuns.get("run_1")?.claimed_wholly).toBe(true)
+    expect(
+      runBillableRemaining({ claim: billedRuns.get("run_1"), ordered: 9 })
+    ).toBeNull()
   })
 })

--- a/apps/backend/src/workflows/payment_submissions/lib/__tests__/run-claim-quantities.unit.spec.ts
+++ b/apps/backend/src/workflows/payment_submissions/lib/__tests__/run-claim-quantities.unit.spec.ts
@@ -1,0 +1,239 @@
+import {
+  assessRunClaims,
+  foldRunClaimTallies,
+  requestedRunQuantities,
+  runsOverclaimedMessage,
+} from "../run-claims"
+
+/**
+ * #1596 — a run is claimed by QUANTITY, not as a boolean.
+ *
+ * The founder's case: a partner finishes 1 of 10, bills it, then bills the
+ * remaining 9 later at a different price. Under the old whole-run claim the
+ * second bill was refused outright, which is what made reject-and-replace the
+ * only way to correct a claim — `01M0Y336X9A6DJ9ESZ4HC0RXVM` reached
+ * "produced 7 of 9" by rejecting the whole prior claim twice (3 → 4 → 7), and
+ * survived only because 4 and 7 were at the same rate.
+ *
+ * The rule these cases pin is deliberately narrow. It allows exactly one thing
+ * that used to be refused: both sides attributable, and their sum inside what
+ * the run was ordered for. Every unattributable claim and every unreadable
+ * ceiling still refuses, because an absent number must never read as room to
+ * bill.
+ */
+
+const live = (
+  runIds: string[],
+  quantity: number | null,
+  status = "Pending"
+) => ({
+  submission_id: "sub_prior",
+  submission_status: status,
+  production_run_ids: runIds,
+  quantity,
+})
+
+describe("foldRunClaimTallies (#1596)", () => {
+  it("sums the units claimed by lines naming a single run", () => {
+    const tallies = foldRunClaimTallies([
+      live(["run_a"], 1),
+      { ...live(["run_a"], 3), submission_id: "sub_second" },
+    ])
+
+    expect(tallies.get("run_a")?.claimed_quantity).toBe(4)
+    expect(tallies.get("run_a")?.claimed_wholly).toBe(false)
+    expect(tallies.get("run_a")?.claims).toHaveLength(2)
+  })
+
+  it("treats a line over SEVERAL runs as claiming each one whole", () => {
+    // The line's quantity is their sum — order #79's ₹8,974 / qty 7 covers
+    // seven runs — so splitting it back out per run would be an invention.
+    const tallies = foldRunClaimTallies([live(["run_a", "run_b"], 7)])
+
+    expect(tallies.get("run_a")?.claimed_wholly).toBe(true)
+    expect(tallies.get("run_a")?.claimed_quantity).toBe(0)
+    expect(tallies.get("run_b")?.claimed_wholly).toBe(true)
+  })
+
+  it("treats a line with no usable quantity as claiming the run whole", () => {
+    expect(foldRunClaimTallies([live(["run_a"], null)]).get("run_a")).toEqual(
+      expect.objectContaining({ claimed_wholly: true, claimed_quantity: 0 })
+    )
+    expect(foldRunClaimTallies([live(["run_a"], 0)]).get("run_a")).toEqual(
+      expect.objectContaining({ claimed_wholly: true })
+    )
+  })
+
+  it("a Rejected submission releases its runs", () => {
+    const tallies = foldRunClaimTallies([live(["run_a"], 4, "Rejected")])
+    expect(tallies.has("run_a")).toBe(false)
+  })
+
+  it("a Draft is a live claim — only Rejected releases", () => {
+    expect(
+      foldRunClaimTallies([live(["run_a"], 2, "Draft")]).get("run_a")
+        ?.claimed_quantity
+    ).toBe(2)
+  })
+})
+
+describe("requestedRunQuantities (#1596)", () => {
+  it("attributes a stated quantity to a line naming one run", () => {
+    const requested = requestedRunQuantities([
+      { production_run_ids: ["run_a"], quantity: 1 },
+    ])
+    expect(requested.get("run_a")).toBe(1)
+  })
+
+  it("claims the whole run when the caller states no quantity", () => {
+    // Saying nothing has always claimed the whole run. Nothing previously
+    // refused may become allowed by accident.
+    expect(
+      requestedRunQuantities([
+        { production_run_ids: ["run_a"], quantity: null },
+      ]).get("run_a")
+    ).toBeNull()
+  })
+
+  it("claims each run whole when one line names several", () => {
+    expect(
+      requestedRunQuantities([
+        { production_run_ids: ["run_a", "run_b"], quantity: 7 },
+      ]).get("run_a")
+    ).toBeNull()
+  })
+
+  it("sums two lines of the same request that name the same run", () => {
+    expect(
+      requestedRunQuantities([
+        { production_run_ids: ["run_a"], quantity: 2 },
+        { production_run_ids: ["run_a"], quantity: 3 },
+      ]).get("run_a")
+    ).toBe(5)
+  })
+
+  it("a whole-run claim is STICKY across lines of one request", () => {
+    expect(
+      requestedRunQuantities([
+        { production_run_ids: ["run_a", "run_b"], quantity: 7 },
+        { production_run_ids: ["run_a"], quantity: 2 },
+      ]).get("run_a")
+    ).toBeNull()
+  })
+})
+
+describe("assessRunClaims (#1596)", () => {
+  const runs = new Map([["run_a", { quantity: 10 }]])
+
+  it("ALLOWS the founder's case: 1 of 10 now, the other 9 later", () => {
+    const tallies = foldRunClaimTallies([live(["run_a"], 1)])
+    const overclaimed = assessRunClaims({
+      requestedByRun: requestedRunQuantities([
+        { production_run_ids: ["run_a"], quantity: 9 },
+      ]),
+      runs,
+      tallies,
+    })
+    expect(overclaimed).toEqual([])
+  })
+
+  it("refuses the piece that would take the run past what was ordered", () => {
+    const tallies = foldRunClaimTallies([live(["run_a"], 9)])
+    const overclaimed = assessRunClaims({
+      requestedByRun: requestedRunQuantities([
+        { production_run_ids: ["run_a"], quantity: 2 },
+      ]),
+      runs,
+      tallies,
+    })
+    expect(overclaimed).toHaveLength(1)
+    expect(overclaimed[0]).toEqual(
+      expect.objectContaining({ ceiling: 10, claimed_quantity: 9, requested: 2 })
+    )
+  })
+
+  it("refuses a claim on a run somebody already took whole", () => {
+    const tallies = foldRunClaimTallies([live(["run_a", "run_b"], 7)])
+    const overclaimed = assessRunClaims({
+      requestedByRun: requestedRunQuantities([
+        { production_run_ids: ["run_a"], quantity: 1 },
+      ]),
+      runs,
+      tallies,
+    })
+    expect(overclaimed[0]?.claimed_wholly).toBe(true)
+  })
+
+  it("refuses a whole-run request against ANY prior claim — today's behaviour", () => {
+    const tallies = foldRunClaimTallies([live(["run_a"], 1)])
+    const overclaimed = assessRunClaims({
+      requestedByRun: requestedRunQuantities([
+        { production_run_ids: ["run_a"], quantity: null },
+      ]),
+      runs,
+      tallies,
+    })
+    expect(overclaimed).toHaveLength(1)
+    expect(overclaimed[0]?.requested).toBeNull()
+  })
+
+  it("refuses when the run states no quantity to divide", () => {
+    // No ceiling means no arithmetic. Allowing here would invent headroom on
+    // exactly the runs whose records are weakest.
+    const overclaimed = assessRunClaims({
+      requestedByRun: requestedRunQuantities([
+        { production_run_ids: ["run_a"], quantity: 1 },
+      ]),
+      runs: new Map([["run_a", { quantity: null }]]),
+      tallies: foldRunClaimTallies([live(["run_a"], 1)]),
+    })
+    expect(overclaimed).toHaveLength(1)
+    expect(overclaimed[0]?.ceiling).toBe(0)
+  })
+
+  it("says nothing about a run nobody has claimed", () => {
+    expect(
+      assessRunClaims({
+        requestedByRun: requestedRunQuantities([
+          { production_run_ids: ["run_a"], quantity: null },
+        ]),
+        runs,
+        tallies: new Map(),
+      })
+    ).toEqual([])
+  })
+
+  it("allows the exact final piece despite float dust", () => {
+    const tallies = foldRunClaimTallies([live(["run_a"], 9.999999)])
+    expect(
+      assessRunClaims({
+        requestedByRun: requestedRunQuantities([
+          { production_run_ids: ["run_a"], quantity: 0.000001 },
+        ]),
+        runs,
+        tallies,
+      })
+    ).toEqual([])
+  })
+})
+
+describe("runsOverclaimedMessage (#1596)", () => {
+  it("names the headroom and who holds the rest, not just the refusal", () => {
+    const tallies = foldRunClaimTallies([live(["run_a"], 9)])
+    const message = runsOverclaimedMessage(
+      assessRunClaims({
+        requestedByRun: requestedRunQuantities([
+          { production_run_ids: ["run_a"], quantity: 2 },
+        ]),
+        runs: new Map([["run_a", { quantity: 10 }]]),
+        tallies,
+      })
+    )
+
+    expect(message).toContain("ordered 10")
+    expect(message).toContain("already claimed 9")
+    expect(message).toContain("1 remaining")
+    expect(message).toContain("asks for 2")
+    expect(message).toContain("sub_prior")
+  })
+})

--- a/apps/backend/src/workflows/payment_submissions/lib/run-billing.ts
+++ b/apps/backend/src/workflows/payment_submissions/lib/run-billing.ts
@@ -25,7 +25,20 @@ export type PartnerLineLike = {
 export type RunBillingClaim = {
   submission_id: string
   status: string
+  /** Units the EARLIEST live line claimed — kept for display, as before. */
   quantity: number
+  /**
+   * Units claimed across EVERY live line naming this run (#1596). A run is
+   * claimed by quantity now, so "is it billed" has stopped being a yes/no —
+   * `01M0Y336X9A6DJ9ESZ4HC0RXVM`'s run was ordered for 9 and billed for 7.
+   */
+  claimed_quantity: number
+  /**
+   * A live line claims this run without an attributable quantity — it names
+   * several runs (their quantities are summed into one figure) or states none.
+   * Such a claim takes the run entirely, and no remainder can be offered.
+   */
+  claimed_wholly: boolean
 }
 
 export type UnrecordedClaim = {
@@ -86,14 +99,36 @@ export const foldPartnerBilling = (
       designsWithUnrecordedClaims.set(designId, claims)
     }
 
-    for (const runId of (item.production_run_ids || []) as string[]) {
-      // First writer wins, so the reported claim is the earliest live one.
-      if (!billedRuns.has(runId)) {
+    const runIds = ((item.production_run_ids || []) as string[]).filter(Boolean)
+    const lineQuantity = Number(item.quantity)
+    /**
+     * Attributable only when the line names exactly ONE run and states a usable
+     * quantity — the same rule the write guard uses (`lib/run-claims`), stated
+     * once per side so the screen and the refusal cannot disagree about how
+     * much of a run is left.
+     */
+    const attributable =
+      runIds.length === 1 && Number.isFinite(lineQuantity) && lineQuantity > 0
+
+    for (const runId of runIds) {
+      const existing = billedRuns.get(runId)
+
+      if (!existing) {
+        // First writer wins for the DISPLAYED claim, as before.
         billedRuns.set(runId, {
           submission_id: submissionId,
           status,
           quantity: Number(item.quantity ?? 1),
+          claimed_quantity: attributable ? lineQuantity : 0,
+          claimed_wholly: !attributable,
         })
+        continue
+      }
+
+      if (attributable) {
+        existing.claimed_quantity += lineQuantity
+      } else {
+        existing.claimed_wholly = true
       }
     }
   }
@@ -112,10 +147,65 @@ export const foldPartnerBilling = (
  * - `clear`   — every live payout for this design says which runs it covered,
  *               and none of them is this one. Safe to bill.
  */
-export type RunBillingStatus = "billed" | "unknown" | "clear"
+export type RunBillingStatus =
+  | "billed"
+  | "partly_billed"
+  | "unknown"
+  | "clear"
 
+/**
+ * PURE: how many units of a run are still billable, or null when that cannot
+ * be answered.
+ *
+ * Null — not 0, and not the ordered quantity — whenever the arithmetic is
+ * unavailable: nobody has claimed it (there is no remainder to speak of), a
+ * claim took the run whole, or the run states no quantity to divide. A number
+ * here is a promise the write guard will honour, so it must not be guessed;
+ * `assessRunClaims` refuses in exactly the same three cases.
+ */
+export const runBillableRemaining = (input: {
+  claim: RunBillingClaim | null | undefined
+  /** The run's ORDERED quantity — the ceiling the write guard uses. */
+  ordered: number | string | null | undefined
+}): number | null => {
+  const claim = input.claim
+  if (!claim || claim.claimed_wholly) {
+    return null
+  }
+
+  const ordered = Number(input.ordered)
+  if (!Number.isFinite(ordered) || ordered <= 0) {
+    return null
+  }
+
+  return Math.max(0, ordered - claim.claimed_quantity)
+}
+
+/**
+ * The single field a caller should branch on, so that "we don't know" cannot be
+ * spelled the same way as "no".
+ *
+ * - `billed`        — this run is claimed in full. Do not pay again.
+ * - `partly_billed` — a line claims SOME of it and units remain (#1596). The
+ *                     write guard will accept the remainder, so the screen has
+ *                     to offer it; reporting this as `billed` is what left the
+ *                     jacket run's last 2 units unbillable through any UI.
+ * - `unknown`       — a live payout for this design records no run, so this run
+ *                     may already be inside it. Needs a human before it is
+ *                     paid; #1565 is the whole reason this value exists.
+ * - `clear`         — every live payout for this design says which runs it
+ *                     covered, and none of them is this one. Safe to bill.
+ */
 export const runBillingStatus = (input: {
   billed: unknown
   unrecordedClaims: unknown[]
-}): RunBillingStatus =>
-  input.billed ? "billed" : input.unrecordedClaims?.length ? "unknown" : "clear"
+  /** Units still billable, from `runBillableRemaining`. */
+  remaining?: number | null
+}): RunBillingStatus => {
+  if (input.billed) {
+    return input.remaining != null && input.remaining > 0
+      ? "partly_billed"
+      : "billed"
+  }
+  return input.unrecordedClaims?.length ? "unknown" : "clear"
+}

--- a/apps/backend/src/workflows/payment_submissions/lib/run-claims.ts
+++ b/apps/backend/src/workflows/payment_submissions/lib/run-claims.ts
@@ -39,6 +39,8 @@
  * happens to be keyed on today.
  */
 
+import { ContainerRegistrationKeys } from "@medusajs/framework/utils"
+
 export type PriorRunLine = {
   submission_id: string | null
   submission_status: string | null
@@ -50,6 +52,14 @@ export type PriorRunLine = {
    * to compare a SUM against what the order is worth (#1617).
    */
   amount?: number | string | null
+  /**
+   * Units billed by this line. A run is no longer claimed as a boolean either
+   * (#1596): a partner can finish 1 of 10, bill it, and bill the other 9 later
+   * at a different rate. Only attributable when the line names exactly ONE run
+   * — a line naming several carries their SUM, and splitting that back out
+   * would be an invention.
+   */
+  quantity?: number | string | null
 }
 
 export type RunClaim = {
@@ -151,6 +161,252 @@ export function foldInventoryOrderClaims(
 }
 
 /**
+ * What a production run has been claimed for SO FAR.
+ *
+ * 🔴 A run used to be claimed WHOLLY: it appeared on any live line, therefore
+ * it was paid for, therefore refuse. That is what forces reject-and-replace as
+ * the only way to correct a claim — `01M0Y336X9A6DJ9ESZ4HC0RXVM` reached
+ * "produced 7 of 9" by rejecting the whole prior claim twice (3 → 4 → 7), and
+ * it only survived because 4 and 7 happened to be at the same rate.
+ *
+ * The founder's case (#1596) does not survive it at all: a partner finishes 1
+ * of 10, bills it, then bills the remaining 9 at a DIFFERENT price. Under a
+ * boolean claim the second bill is refused outright.
+ */
+export type RunClaimTally = {
+  /** Units claimed by live lines that name this run and nothing else. */
+  claimed_quantity: number
+  /**
+   * A live line claims this run WITHOUT an attributable quantity — it names
+   * several runs (their quantities are summed into one figure), or it carries
+   * no usable quantity at all. Such a claim consumes the run entirely, because
+   * splitting it back out would be an invention.
+   */
+  claimed_wholly: boolean
+  /** Every live claim, first writer first, for the refusal message. */
+  claims: RunClaim[]
+}
+
+/**
+ * PURE: fold prior lines into `run id → units claimed so far`.
+ *
+ * Same skip rule as `foldRunClaims`: a `Rejected` submission never paid
+ * anyone, so its lines release their runs.
+ */
+export function foldRunClaimTallies(
+  priorLines: PriorRunLine[]
+): Map<string, RunClaimTally> {
+  const tallies = new Map<string, RunClaimTally>()
+
+  for (const line of priorLines || []) {
+    if (String(line.submission_status || "") === "Rejected") continue
+
+    const runIds = (line.production_run_ids || []).filter(Boolean)
+    if (!runIds.length) continue
+
+    const quantity = Number(line.quantity)
+    /**
+     * Attributable only when the line names exactly ONE run AND states a
+     * usable quantity. A line over several runs carries their sum; a line with
+     * no quantity states nothing. In both cases the honest reading is "this
+     * claimed the run", not a number invented to fill the gap — inventing one
+     * here would manufacture headroom to bill against.
+     */
+    const attributable =
+      runIds.length === 1 && Number.isFinite(quantity) && quantity > 0
+
+    for (const runId of runIds) {
+      const existing = tallies.get(runId) ?? {
+        claimed_quantity: 0,
+        claimed_wholly: false,
+        claims: [],
+      }
+
+      if (attributable) {
+        existing.claimed_quantity += quantity
+      } else {
+        existing.claimed_wholly = true
+      }
+
+      existing.claims.push({
+        submission_id: line.submission_id,
+        submission_status: line.submission_status,
+      })
+      tallies.set(runId, existing)
+    }
+  }
+
+  return tallies
+}
+
+/**
+ * PURE: how many units a REQUEST claims per run.
+ *
+ * The same attribution rule as the prior-line fold, applied to the incoming
+ * lines — one rule, so the two sides of the comparison can never drift:
+ *
+ *   - a line naming exactly ONE run with a usable quantity claims that many;
+ *   - a line naming several runs, or stating no quantity, claims each of its
+ *     runs WHOLLY (`null`), because its figure covers all of them together and
+ *     splitting it back out would be an invention.
+ *
+ * 🔑 Only an explicitly stated quantity makes a claim partial. Saying nothing
+ * still claims the whole run, which is exactly what every caller meant before
+ * this existed — so nothing that used to be refused becomes allowed by
+ * accident.
+ *
+ * `null` is STICKY: once any line claims a run wholly, no later line's number
+ * can turn that back into a partial claim.
+ */
+export function requestedRunQuantities(
+  lines: Array<{
+    production_run_ids?: string[] | null
+    quantity?: number | string | null
+  }>
+): Map<string, number | null> {
+  const requested = new Map<string, number | null>()
+
+  for (const line of lines || []) {
+    const runIds = (line?.production_run_ids || []).filter(Boolean).map(String)
+    if (!runIds.length) continue
+
+    const quantity = Number(line?.quantity)
+    const attributable =
+      runIds.length === 1 && Number.isFinite(quantity) && quantity > 0
+
+    for (const runId of runIds) {
+      if (!requested.has(runId)) {
+        requested.set(runId, attributable ? quantity : null)
+        continue
+      }
+
+      const existing = requested.get(runId)
+      if (existing == null || !attributable) {
+        requested.set(runId, null)
+        continue
+      }
+
+      requested.set(runId, existing + quantity)
+    }
+  }
+
+  return requested
+}
+
+export type OverclaimedRun = {
+  run_id: string
+  /** Units the run is worth: its ORDERED quantity. */
+  ceiling: number
+  claimed_quantity: number
+  claimed_wholly: boolean
+  /** Units this request asks for, or null when it cannot be attributed. */
+  requested: number | null
+  /** Who holds the live claims, for the refusal message. */
+  claims: RunClaim[]
+}
+
+/**
+ * PURE: which of these claims would take a run past what it is worth.
+ *
+ * ⚠️ The ceiling is the run's **ORDERED** quantity, not its produced one. That
+ * is deliberate and matches `runPayableAmount`, which multiplies a per-unit
+ * rate by `run.quantity`; a produced-quantity ceiling would disagree with the
+ * money on day one, and would also refuse the very first partial claim, since
+ * `produced_quantity` is captured at completion and is null while the partner
+ * is still working. What ordered-quantity headroom does NOT decide is whether
+ * the remainder will ever be made — a run short-closed at 7 of 9 keeps 2 units
+ * billable until something closes it, which wants its own input rather than an
+ * inference here.
+ *
+ * This is strictly narrower than "refuse any prior claim" in exactly one case:
+ * both sides are attributable and their sum fits. Every unattributable claim,
+ * every unreadable ceiling, still refuses — an absent number must never read
+ * as room to bill.
+ */
+export function assessRunClaims(input: {
+  /** Units requested per run, or null where the request cannot be attributed. */
+  requestedByRun: Map<string, number | null>
+  runs: Map<string, { quantity?: number | string | null }>
+  tallies: Map<string, RunClaimTally>
+}): OverclaimedRun[] {
+  const overclaimed: OverclaimedRun[] = []
+
+  for (const [runId, requested] of input.requestedByRun) {
+    const tally = input.tallies.get(runId)
+    if (!tally) continue // nobody has claimed it — nothing to diff against.
+
+    const ordered = Number(input.runs.get(runId)?.quantity)
+    const ceiling = Number.isFinite(ordered) && ordered > 0 ? ordered : 0
+
+    const refuse = () =>
+      overclaimed.push({
+        run_id: runId,
+        ceiling,
+        claimed_quantity: tally.claimed_quantity,
+        claimed_wholly: tally.claimed_wholly,
+        requested,
+        claims: tally.claims,
+      })
+
+    // Somebody already claimed the whole run, or this request claims the whole
+    // run, or the run states no quantity to divide up. No arithmetic is
+    // available, so the old whole-run refusal stands.
+    if (tally.claimed_wholly || requested == null || !(ceiling > 0)) {
+      refuse()
+      continue
+    }
+
+    // A hundredth of a unit of tolerance: quantities are floats, and refusing
+    // a legitimate final piece over float dust is worse than allowing it.
+    if (tally.claimed_quantity + requested > ceiling + 0.005) {
+      refuse()
+    }
+  }
+
+  return overclaimed
+}
+
+/** The refusal, naming the headroom rather than only the refusal. */
+export function runsOverclaimedMessage(
+  overclaimed: OverclaimedRun[]
+): string {
+  const detail = overclaimed
+    .map(
+      ({ run_id, ceiling, claimed_quantity, claimed_wholly, requested, claims }) => {
+        const holders =
+          claims
+            .map(
+              (c) =>
+                `submission ${c.submission_id ?? "unknown"}${
+                  c.submission_status ? `, ${c.submission_status}` : ""
+                }`
+            )
+            .join("; ") || "no prior claim"
+
+        if (claimed_wholly) {
+          return `${run_id}: already claimed in full (${holders})`
+        }
+        if (!(ceiling > 0)) {
+          return (
+            `${run_id}: already claimed (${holders}), and the run states no` +
+            ` quantity to divide`
+          )
+        }
+
+        const remaining = Math.max(0, ceiling - claimed_quantity)
+        const asked = requested == null ? "the whole run" : String(requested)
+        return (
+          `${run_id}: ordered ${ceiling}, already claimed ${claimed_quantity}` +
+          ` (${holders}), ${remaining} remaining — this line asks for ${asked}`
+        )
+      }
+    )
+    .join(" | ")
+
+  return `Production runs already paid for: ${detail}`
+}
+
+/**
  * PURE: what is still billable on an order.
  *
  * `ceiling` is the AGREED total where one is recorded, falling back to the
@@ -227,7 +483,59 @@ export async function listPartnerPriorLines(
     production_run_ids: (item.production_run_ids || []) as string[],
     inventory_order_id: item.inventory_order_id ?? null,
     amount: item.amount ?? null,
+    quantity: item.quantity ?? null,
   }))
+}
+
+/**
+ * The partner's per-run tallies — the quantity-aware replacement for
+ * `listPartnerRunClaims` at every guard that has to answer "how much of this
+ * run is still billable" rather than "has it been touched".
+ */
+/**
+ * The ordered quantity of each run, for the claim ceiling.
+ *
+ * Lives here so every guard reads the ceiling from the same field. The two
+ * create-path guards already fetch the runs for other reasons and pass their
+ * own map; the submit and update guards do not, and would otherwise each grow
+ * their own query.
+ *
+ * ⚠️ Fetch `quantity` explicitly — a guard reading a field the query never
+ * asked for is a guard that always sees `undefined` and always refuses.
+ */
+export async function listRunOrderedQuantities(
+  container: { resolve: (key: string) => any },
+  runIds: string[]
+): Promise<Map<string, { quantity?: number | string | null }>> {
+  const ids = [...new Set((runIds || []).filter(Boolean).map(String))]
+  if (!ids.length) return new Map()
+
+  const query: any = container.resolve(ContainerRegistrationKeys.QUERY)
+  const { data } = await query.graph({
+    entity: "production_runs",
+    fields: ["id", "quantity"],
+    filters: { id: ids },
+  })
+
+  return new Map(
+    ((data || []) as any[]).map((run) => [
+      String(run.id),
+      { quantity: run.quantity },
+    ])
+  )
+}
+
+export async function listPartnerRunTallies(
+  service: {
+    listPaymentSubmissions: (filters: any, config?: any) => Promise<any[]>
+    listPaymentSubmissionItems: (filters: any, config?: any) => Promise<any[]>
+  },
+  partnerId: string,
+  options?: { excludeSubmissionId?: string }
+): Promise<Map<string, RunClaimTally>> {
+  return foldRunClaimTallies(
+    await listPartnerPriorLines(service, partnerId, options)
+  )
 }
 
 export async function listPartnerRunClaims(

--- a/apps/backend/src/workflows/payment_submissions/submit-payment-submission.ts
+++ b/apps/backend/src/workflows/payment_submissions/submit-payment-submission.ts
@@ -14,8 +14,11 @@ import {
   runlessResubmitMessage,
 } from "./lib/run-evidence-guard"
 import {
-  listPartnerRunClaims,
-  runsAlreadyClaimedMessage,
+  assessRunClaims,
+  listPartnerRunTallies,
+  listRunOrderedQuantities,
+  requestedRunQuantities,
+  runsOverclaimedMessage,
 } from "./lib/run-claims"
 
 /**
@@ -154,16 +157,32 @@ const validateSubmissionForSubmitStep = createStep(
     ].filter(Boolean)
 
     if (claimedRunIds.length) {
-      const billed = await listPartnerRunClaims(
+      const tallies = await listPartnerRunTallies(
         service as any,
         String(submission.partner_id || ""),
         { excludeSubmissionId: String(input.submission_id) }
       )
-      const duplicates = claimedRunIds.filter((id) => billed.has(id))
-      if (duplicates.length) {
+
+      /**
+       * #1596 — quantity-aware. What this submission's own lines claim is read
+       * off the lines themselves (a line naming one run for N units claims N),
+       * and diffed against what the run was ordered for.
+       */
+      const runs = await listRunOrderedQuantities(container, claimedRunIds)
+      const overclaimed = assessRunClaims({
+        requestedByRun: requestedRunQuantities(
+          items.map((i) => ({
+            production_run_ids: (i.production_run_ids || []).map(String),
+            quantity: (i as any).quantity,
+          }))
+        ),
+        runs,
+        tallies,
+      })
+      if (overclaimed.length) {
         throw new MedusaError(
           MedusaError.Types.INVALID_DATA,
-          runsAlreadyClaimedMessage(duplicates, billed)
+          runsOverclaimedMessage(overclaimed)
         )
       }
     }

--- a/apps/backend/src/workflows/payment_submissions/update-payment-submission-item.ts
+++ b/apps/backend/src/workflows/payment_submissions/update-payment-submission-item.ts
@@ -16,8 +16,11 @@ import {
   runlessResubmitMessage,
 } from "./lib/run-evidence-guard"
 import {
-  listPartnerRunClaims,
-  runsAlreadyClaimedMessage,
+  assessRunClaims,
+  listPartnerRunTallies,
+  listRunOrderedQuantities,
+  requestedRunQuantities,
+  runsOverclaimedMessage,
 } from "./lib/run-claims"
 import { resolveDesignLineAmount } from "./create-payment-submission"
 
@@ -140,6 +143,15 @@ const validateItemEditStep = createStep(
         ...new Set(input.production_run_ids.map(String).filter(Boolean)),
       ]
 
+      /**
+       * What this edited line will claim, for the quantity-aware run guard
+       * (#1596). The edit's quantity when it states one, otherwise the line's
+       * existing quantity — an edit that touches only the run ids has not
+       * changed how many units the line bills.
+       */
+      const claimedQuantity =
+        input.quantity !== undefined ? input.quantity : item.quantity
+
       if (runIds.length) {
         /**
          * 1. The runs must exist, be this partner's, be this design's, and be
@@ -214,16 +226,26 @@ const validateItemEditStep = createStep(
        * invisible to it. See `lib/run-claims`.
        */
       if (runIds.length) {
-        const billed = await listPartnerRunClaims(
+        const tallies = await listPartnerRunTallies(
           service as any,
           String(submission.partner_id || ""),
           { excludeSubmissionId: String(input.submission_id) }
         )
-        const duplicates = runIds.filter((id) => billed.has(id))
-        if (duplicates.length) {
+
+        // #1596 — quantity-aware, same rule as create and submit. The edited
+        // line's own quantity is what it claims; one run plus a quantity is a
+        // partial claim, anything else takes the run whole.
+        const overclaimed = assessRunClaims({
+          requestedByRun: requestedRunQuantities([
+            { production_run_ids: runIds, quantity: claimedQuantity },
+          ]),
+          runs: await listRunOrderedQuantities(container, runIds),
+          tallies,
+        })
+        if (overclaimed.length) {
           throw new MedusaError(
             MedusaError.Types.INVALID_DATA,
-            runsAlreadyClaimedMessage(duplicates, billed)
+            runsOverclaimedMessage(overclaimed)
           )
         }
       }

--- a/apps/partner-ui/src/hooks/api/partner-payable-runs.tsx
+++ b/apps/partner-ui/src/hooks/api/partner-payable-runs.tsx
@@ -32,7 +32,13 @@ export interface PayableRun {
     amount: number
   }>
   design_has_open_submission: boolean
-  billing_status: "clear" | "unknown" | "billed"
+  billing_status: "clear" | "partly_billed" | "unknown" | "billed"
+  /**
+   * Units still billable on this run (#1596), or null when there is no
+   * arithmetic behind the answer — which is exactly when the write guard
+   * refuses. A number here is a promise `create` will keep.
+   */
+  billable_remaining: number | null
 }
 
 export interface PayableRunsListResponse {

--- a/apps/partner-ui/src/routes/payment-submissions/payment-submission-create/payment-submission-create.tsx
+++ b/apps/partner-ui/src/routes/payment-submissions/payment-submission-create/payment-submission-create.tsx
@@ -82,6 +82,13 @@ export const PaymentSubmissionCreate = () => {
    */
   const runBlockedReason = useCallback(
     (r: PayableRun): string | null => {
+      /**
+       * ⚠️ `billed` blocks; `partly_billed` deliberately does NOT (#1596). A
+       * run claimed for 4 of the 9 it was ordered for still has 5 units the
+       * write guard will accept, and reporting that as "already paid" is what
+       * left the last pieces of a short-completed run unbillable through any
+       * screen — the workflow said yes and no screen would ask.
+       */
       if (r.billing_status === "billed") {
         return r.billed?.submission_id
           ? `Already paid · ${r.billed.submission_id}`
@@ -730,6 +737,15 @@ const RunRow = ({
           <Badge color="blue" size="2xsmall">
             Run
           </Badge>
+          {run.billing_status === "partly_billed" && !blocked && (
+            <Tooltip
+              content={`Part of this run has already been paid for. ${run.billable_remaining} of ${run.ordered_quantity} units are still billable.`}
+            >
+              <Badge color="blue" size="2xsmall">
+                {run.billable_remaining} left to bill
+              </Badge>
+            </Tooltip>
+          )}
           {run.billing_status === "unknown" && !blocked && (
             <Tooltip content="An earlier payout for this design did not record which runs it covered, so we cannot tell whether these pieces were already paid for.">
               <Badge color="orange" size="2xsmall">


### PR DESCRIPTION
The whole-run claim guard from #1596. Partially closes it — see "What is left" below.

## The problem

A run was claimed **wholly**: it appeared on any live payment line, therefore it was paid for, therefore refuse. That is what makes reject-and-replace the only way to correct a claim today. `01M0Y336X9A6DJ9ESZ4HC0RXVM` reached "produced 7 of 9" by rejecting the whole prior claim twice (3 → 4 → 7), and it survived only because 4 and 7 happened to be at the same rate.

The founder's case does not survive it at all: **a partner finishes 1 of 10, bills it, then bills the remaining 9 later at a different price.** Under a boolean claim the second bill is refused outright.

## The change

A run is now claimed by quantity, the way an inventory order has been since #1617: units already claimed are summed and diffed against what the run was **ordered** for. One rule in `lib/run-claims`, used by all four write guards — create's design path, create's run-sourced path, submit, and the line edit — so they cannot drift.

Attribution is identical on both sides of the comparison:

- a line naming exactly **one** run with a usable quantity claims that many;
- a line naming **several** runs claims each of them wholly, because its figure is their *sum* (order #79's ₹8,974 / qty 7 covers seven runs) and splitting it back out would be an invention;
- at create, **stating no quantity still claims the whole run**, so nothing previously refused becomes allowed by accident.

The ceiling is the run's **ordered** quantity, matching `runPayableAmount`'s multiplier. A produced-quantity ceiling would disagree with the money on day one, and would refuse the very first partial claim — `produced_quantity` is captured at completion.

## 🔴 This is a real loosening of a guard on money

Two existing cases had to be re-expressed because their *scenario* is now legitimate rather than a double pay. Calling that out rather than quietly editing them:

| case | was | now |
|---|---|---|
| "refuses to pay for the same run twice" | billed 4, then 4 more of a run ordered for 9 → refused | that is tranche billing. It asks for **7**, so 4 + 7 = 11 overruns what was ordered — still refused, with the first payout Approved |
| contested Draft | rival held **1** of 9 | rival takes all **9**; a rival holding 1 leaves room the draft's own 4 fit inside |

What stands between a partner and a second payment for the same work is now the **ordered-quantity ceiling**. Every unattributable claim and every unreadable ceiling still refuses outright — an absent number must never read as room to bill.

## What is left on #1596

1. ⚠️ **Two open claims on one design still cannot coexist.** Step 5 refuses a design already in an active submission; that guard is about designs, is not quantity-aware, and fires first. The first payout must be reviewed before the rest is billed — the flow an operator follows anyway, and what the new cases do.
2. **`payable-runs` still reports a partially-billed run as `billed`.** The guard would allow the remainder; the screen will not offer it. That is `foldPartnerBilling` in `lib/run-billing.ts` (shared with #1622's run page) and wants its own change — adding a fourth `billing_status` value without touching consumers is exactly the #1621 shape.
3. **The short-close.** A run billed 7 of 9 keeps 2 units billable until something says the rest will never be made. That wants an explicit input, not an inference — a column with no writer is a façade (#1617's `agreed_total`).

## Verification

- **24 unit cases**, mutation-checked: reverting the guard to whole-run turns exactly the two newly-allowed cases red (`ALLOWS the founder's case`, `allows the exact final piece despite float dust`) and leaves every refusal case green — so the tests are not vacuous and the change is narrow.
- **3 cases at the HTTP boundary**: the founder's 1-then-9 at different rates (₹1,200 then ₹12,600, no rejection of the first), the eleventh piece refused with a message naming `1 remaining`, and a silent second claim still refused.
- 105/105 `payment-submissions-api`, 9/9 `payment-rate-breakdown`, 9/9 `partner-payment-e2e`, 402 unit tests across 32 suites, `check:prod-build` green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01TLt1f38xqR8k2myCVxP8e4