### PR TITLE
feat(medias): visible-first textile extraction and rate-limited folder-wide feature extraction

### DIFF
--- a/apps/backend/integration-tests/http/textile-extract-features-stubbed.spec.ts
+++ b/apps/backend/integration-tests/http/textile-extract-features-stubbed.spec.ts
@@ -1,0 +1,464 @@
+/**
+ * Integration tests for textile feature extraction APIs with the AI
+ * generation process STUBBED.
+ *
+ * The real Mastra instance boots (as in every other spec) but
+ * `mastra.getWorkflow("textileProductExtractionWorkflow")` is monkey-patched
+ * to return a fake workflow whose `run.start()` resolves a canned extraction.
+ * No OpenRouter / vision-model traffic ever leaves the test process, while the
+ * full Medusa long-running workflow machinery (trigger → 202 → confirm →
+ * background processing → persistence → folder progress mirroring) is
+ * exercised end-to-end over HTTP.
+ *
+ * Covered:
+ * - POST /admin/medias/extract-features           (per-media, stubbed AI)
+ * - POST /admin/medias/folder/:id/extract-features (folder-wide, rate-limited, stubbed AI)
+ * - POST .../confirm and GET .../status
+ * - Validation and error paths (no images, unknown folder, invalid interval)
+ * - Per-photo failure isolation inside a folder run
+ */
+
+import { createAdminUser, getAuthHeaders } from "../helpers/create-admin-user"
+import { getSharedTestEnv, setupSharedTestSuite } from "./shared-test-setup"
+import { mastra } from "../../src/mastra"
+
+jest.setTimeout(120000)
+
+// ============================================
+// Stubbed AI generation
+// ============================================
+
+/**
+ * Pass-1 output of the feedback-oriented pipeline: what is VISIBLE only.
+ */
+const FAKE_VISUAL_OBSERVATIONS = {
+  visible_colors: ["indigo blue", "off-white"],
+  visible_pattern: "block-print",
+  pattern_description: "Repeating floral block-print motif, medium scale, all-over placement",
+  design_elements: ["woven border", "running-stitch embroidery"],
+  fabric: {
+    type_idea: "cotton-like",
+    texture: "matte",
+    weave_or_knit: "plain weave",
+    perceived_weight: "lightweight & drapey",
+    finish: "hand-dyed",
+  },
+  visible_item: "folded yardage of printed cloth",
+  visible_text: [],
+  shot_type: "flat lay",
+  not_visible_or_uncertain: ["fabric composition not visible", "no care label visible"],
+}
+
+/**
+ * Pass-2 output: product fields derived from the observations.
+ */
+const FAKE_EXTRACTION = {
+  title: "Indigo Block-Print Cotton Yardage",
+  description:
+    "Hand-printed cotton yardage in indigo and off-white with a repeating floral block-print and woven border.",
+  designer: null,
+  model_name: null,
+  cloth_type: "fabric",
+  pattern: "block-print",
+  fabric_weight: "lightweight",
+  care_instructions: ["Hand wash cold", "Do not bleach"],
+  season: ["spring", "summer"],
+  occasion: ["casual"],
+  colors: ["indigo blue", "off-white"],
+  category: "fabric",
+  suggested_price: { amount: 45, currency: "USD" },
+  seo_keywords: ["block print", "indigo cotton", "hand printed fabric"],
+  target_audience: "textile enthusiasts and boutique owners",
+  confidence: 0.92,
+  visual_observations: FAKE_VISUAL_OBSERVATIONS,
+  face_raw: null,
+  body_raw: null,
+  model_characteristics: null,
+}
+
+const makeFakeRunResult = () => ({
+  steps: {
+    observeVisibleFeatures: { status: "success", output: FAKE_VISUAL_OBSERVATIONS },
+    deriveProductFields: { status: "success", output: FAKE_EXTRACTION },
+    validateTextileExtraction: { status: "success", output: FAKE_EXTRACTION },
+  },
+})
+
+let mockRunStart: any
+
+// Point the Mastra registry's textile workflow at a fake whose run.start()
+// is a jest mock. Every other workflow keeps its real implementation.
+const realGetWorkflow = (mastra as any).getWorkflow.bind(mastra)
+
+setupSharedTestSuite(() => {
+  const { api, getContainer } = getSharedTestEnv()
+  let headers: any
+
+  beforeAll(() => {
+    mockRunStart = jest.fn()
+    ;(mastra as any).getWorkflow = (id: string) => {
+      if (id === "textileProductExtractionWorkflow") {
+        return { createRun: () => ({ start: mockRunStart }) }
+      }
+      return realGetWorkflow(id)
+    }
+  })
+
+  afterAll(() => {
+    ;(mastra as any).getWorkflow = realGetWorkflow
+  })
+
+  beforeEach(async () => {
+    const container = getContainer()
+    await createAdminUser(container)
+    headers = await getAuthHeaders(api)
+
+    mockRunStart.mockReset()
+    mockRunStart.mockImplementation(async () => makeFakeRunResult())
+  })
+
+  // ============================================
+  // Test helpers
+  // ============================================
+
+  const unique = () => `t${Date.now()}${Math.floor(Math.random() * 1e6)}`
+
+  const getMediaService = () => (getContainer().resolve("media") as any)
+
+  const seedImageMedia = async (folderId?: string) => {
+    const token = unique()
+    return getMediaService().createMediaFiles({
+      file_name: `${token}.jpg`,
+      original_name: `${token}.jpg`,
+      file_path: `https://cdn.example.com/${token}.jpg`,
+      file_type: "image",
+      mime_type: "image/jpeg",
+      file_size: 1024,
+      file_hash: `hash-${token}`,
+      extension: "jpg",
+      is_public: true,
+      ...(folderId ? { folder_id: folderId } : {}),
+    })
+  }
+
+  const seedFolderWithImages = async (imageCount: number) => {
+    const mediaService = getMediaService()
+    const token = unique()
+    const folder = await mediaService.createFolders({
+      name: `Extraction Test ${token}`,
+      slug: `extraction-test-${token}`,
+      path: `/extraction-test-${token}`,
+      level: 0,
+      sort_order: 0,
+      is_public: true,
+    })
+    const images: any[] = []
+    for (let i = 0; i < imageCount; i++) {
+      images.push(await seedImageMedia(folder.id))
+    }
+    return { folder, images }
+  }
+
+  const waitFor = async (
+    check: () => Promise<boolean>,
+    timeoutMs = 45000,
+    intervalMs = 500
+  ) => {
+    const start = Date.now()
+    while (Date.now() - start < timeoutMs) {
+      try {
+        if (await check()) return true
+      } catch {
+        // transient polling errors (e.g. while workflows are mid-flight)
+        // must not abort the wait loop
+      }
+      await new Promise((r) => setTimeout(r, intervalMs))
+    }
+    return false
+  }
+
+  const getMediaMetadata = async (mediaId: string) => {
+    const mediaService = getMediaService()
+    const [fresh] = await mediaService.listMediaFiles({ id: mediaId }, { take: 1 })
+    return fresh?.metadata || null
+  }
+
+  // ============================================
+  // Per-media extraction with stubbed generation
+  // ============================================
+
+  describe("POST /admin/medias/extract-features (stubbed generation)", () => {
+    it("initiates, confirms, and persists the stubbed extraction with visual_observations", async () => {
+      const media = await seedImageMedia()
+
+      // 1) Trigger
+      const extractRes = await api.post(
+        "/admin/medias/extract-features",
+        {
+          media_id: media.id,
+          hints: ["focus on weave structure"],
+          gender: "female",
+          persist: true,
+        },
+        headers
+      )
+
+      expect(extractRes.status).toBe(202)
+      expect(extractRes.data.transaction_id).toBeDefined()
+      expect(extractRes.data.status).toBe("pending_confirmation")
+
+      // The workflow is suspended at the wait step — the stub must NOT
+      // have been called yet.
+      expect(mockRunStart).not.toHaveBeenCalled()
+
+      // 2) Confirm to start background processing
+      const confirmRes = await api.post(
+        `/admin/medias/extract-features/${extractRes.data.transaction_id}/confirm`,
+        {},
+        headers
+      )
+      expect(confirmRes.status).toBe(200)
+      expect(confirmRes.data.success).toBe(true)
+
+      // 3) Wait for background persistence of the stubbed result
+      const persisted = await waitFor(async () => {
+        const metadata = await getMediaMetadata(media.id)
+        return !!metadata?.textile_extraction
+      })
+      expect(persisted).toBe(true)
+
+      // 4) The stub received the right inputs
+      expect(mockRunStart).toHaveBeenCalledTimes(1)
+      const stubInput = mockRunStart.mock.calls[0][0]?.inputData
+      expect(stubInput.image_url).toBe(media.file_path)
+      expect(stubInput.hints).toContain("focus on weave structure")
+      expect(stubInput.gender).toBe("female")
+
+      const metadata = await getMediaMetadata(media.id)
+      const extraction = metadata.textile_extraction
+
+      // Product fields derived by pass 2 (stubbed)
+      expect(extraction.title).toBe(FAKE_EXTRACTION.title)
+      expect(extraction.pattern).toBe("block-print")
+      expect(extraction.colors).toEqual(["indigo blue", "off-white"])
+
+      // Feedback trail: what was visible is preserved end-to-end
+      expect(extraction.visual_observations).toBeDefined()
+      expect(extraction.visual_observations.visible_pattern).toBe("block-print")
+      expect(extraction.visual_observations.fabric.type_idea).toBe("cotton-like")
+      expect(extraction.visual_observations.not_visible_or_uncertain).toContain(
+        "fabric composition not visible"
+      )
+      expect(metadata.extracted_at).toBeDefined()
+    })
+  })
+
+  // ============================================
+  // Folder-wide extraction with stubbed generation
+  // ============================================
+
+  describe("POST /admin/medias/folder/:id/extract-features (stubbed generation)", () => {
+    it("extracts every image in the folder sequentially at the configured rate and reports progress", async () => {
+      const { folder, images } = await seedFolderWithImages(2)
+
+      // 1) Trigger folder-wide extraction — 5s between photos for test speed
+      const extractRes = await api.post(
+        `/admin/medias/folder/${folder.id}/extract-features`,
+        {
+          persist: true,
+          interval_ms: 5000,
+          gender: "female",
+        },
+        headers
+      )
+
+      expect(extractRes.status).toBe(202)
+      expect(extractRes.data.transaction_id).toBeDefined()
+      expect(extractRes.data.folder_id).toBe(folder.id)
+      expect(extractRes.data.total_images).toBe(2)
+      expect(extractRes.data.status).toBe("pending_confirmation")
+
+      // 2) Status before confirmation: nothing has run yet
+      const statusBefore = await api.get(
+        `/admin/medias/folder/${folder.id}/extract-features/status`,
+        headers
+      )
+      expect(statusBefore.status).toBe(200)
+      expect(statusBefore.data.has_run).toBe(false)
+      expect(statusBefore.data.progress).toBeNull()
+
+      // 3) Confirm to start the rate-limited background run
+      const confirmRes = await api.post(
+        `/admin/medias/folder/${folder.id}/extract-features/${extractRes.data.transaction_id}/confirm`,
+        {},
+        headers
+      )
+      expect(confirmRes.status).toBe(200)
+      expect(confirmRes.data.success).toBe(true)
+
+      // 4) Poll the status endpoint until the run completes
+      const done = await waitFor(async () => {
+        const statusRes = await api.get(
+          `/admin/medias/folder/${folder.id}/extract-features/status`,
+          headers
+        )
+        return (
+          statusRes.status === 200 &&
+          statusRes.data.progress?.status === "completed"
+        )
+      })
+      expect(done).toBe(true)
+
+      const statusRes = await api.get(
+        `/admin/medias/folder/${folder.id}/extract-features/status`,
+        headers
+      )
+      const progress = statusRes.data.progress
+      expect(progress.total).toBe(2)
+      expect(progress.completed).toBe(2)
+      expect(progress.failed).toBe(0)
+      expect(progress.interval_ms).toBe(5000)
+      expect(progress.started_at).toBeDefined()
+      expect(progress.finished_at).toBeDefined()
+
+      // 5) The stub processed each photo with its own image URL
+      expect(mockRunStart).toHaveBeenCalledTimes(2)
+      const calledUrls = mockRunStart.mock.calls.map(
+        (c: any[]) => c[0]?.inputData?.image_url
+      )
+      for (const image of images) {
+        expect(calledUrls).toContain(image.file_path)
+      }
+      expect(mockRunStart.mock.calls[0][0]?.inputData.gender).toBe("female")
+
+      // 6) Both media persisted the stubbed extraction
+      for (const image of images) {
+        const metadata = await getMediaMetadata(image.id)
+        expect(metadata?.textile_extraction?.title).toBe(FAKE_EXTRACTION.title)
+        expect(metadata?.textile_extraction?.visual_observations.visible_colors).toEqual([
+          "indigo blue",
+          "off-white",
+        ])
+      }
+    })
+
+    it("records per-photo failures without aborting the folder run", async () => {
+      const { folder, images } = await seedFolderWithImages(2)
+
+      // First photo's generation fails; second succeeds (list is ordered
+      // by created_at ASC, so the first-seeded image fails)
+      mockRunStart.mockImplementationOnce(async () => {
+        throw new Error("AI provider down")
+      })
+
+      const extractRes = await api.post(
+        `/admin/medias/folder/${folder.id}/extract-features`,
+        {
+          persist: true,
+          interval_ms: 5000,
+        },
+        headers
+      )
+      expect(extractRes.status).toBe(202)
+      const transactionId = extractRes.data.transaction_id
+
+      const confirmRes = await api.post(
+        `/admin/medias/folder/${folder.id}/extract-features/${transactionId}/confirm`,
+        {},
+        headers
+      )
+      expect(confirmRes.status).toBe(200)
+
+      const done = await waitFor(async () => {
+        const statusRes = await api.get(
+          `/admin/medias/folder/${folder.id}/extract-features/status`,
+          headers
+        )
+        const p = statusRes.data.progress
+        return !!p && (p.status === "completed" || p.status === "failed")
+      })
+      expect(done).toBe(true)
+
+      const statusRes = await api.get(
+        `/admin/medias/folder/${folder.id}/extract-features/status`,
+        headers
+      )
+      const progress = statusRes.data.progress
+
+      // One failure did not abort the run — the second photo still completed
+      expect(progress.total).toBe(2)
+      expect(progress.completed).toBe(1)
+      expect(progress.failed).toBe(1)
+      expect(progress.status).toBe("completed")
+      expect(progress.errors).toHaveLength(1)
+      expect(progress.errors[0].error).toContain("AI provider down")
+      expect([images[0].id, images[1].id]).toContain(progress.errors[0].media_id)
+
+      // Failed photo has no extraction; the other one does
+      const failedId = progress.errors[0].media_id
+      const okImage = images.find((i) => i.id !== failedId)
+      const failedMetadata = await getMediaMetadata(failedId)
+      expect(failedMetadata?.textile_extraction).toBeUndefined()
+
+      const okMetadata = await getMediaMetadata(okImage!.id)
+      expect(okMetadata?.textile_extraction?.title).toBe(FAKE_EXTRACTION.title)
+    })
+
+    it("returns 400 when the folder has no image files", async () => {
+      const { folder } = await seedFolderWithImages(0)
+
+      try {
+        await api.post(
+          `/admin/medias/folder/${folder.id}/extract-features`,
+          { persist: true },
+          headers
+        )
+        fail("Should have rejected a folder with no images")
+      } catch (error: any) {
+        expect(error.response?.status).toBe(400)
+        expect(error.response?.data?.message).toContain("no image files")
+      }
+    })
+
+    it("returns 404 for a non-existent folder", async () => {
+      try {
+        await api.post(
+          "/admin/medias/folder/does-not-exist/extract-features",
+          { persist: true },
+          headers
+        )
+        fail("Should have rejected a non-existent folder")
+      } catch (error: any) {
+        expect(error.response?.status).toBe(404)
+      }
+    })
+
+    it("rejects invalid interval_ms values", async () => {
+      const { folder } = await seedFolderWithImages(1)
+
+      try {
+        await api.post(
+          `/admin/medias/folder/${folder.id}/extract-features`,
+          { interval_ms: 0 },
+          headers
+        )
+        fail("Should have rejected interval_ms <= 0")
+      } catch (error: any) {
+        expect([400, 422]).toContain(error.response?.status)
+      }
+    })
+
+    it("reports has_run=false for a folder that never ran", async () => {
+      const { folder } = await seedFolderWithImages(0)
+
+      const statusRes = await api.get(
+        `/admin/medias/folder/${folder.id}/extract-features/status`,
+        headers
+      )
+      expect(statusRes.status).toBe(200)
+      expect(statusRes.data.folder_id).toBe(folder.id)
+      expect(statusRes.data.has_run).toBe(false)
+      expect(statusRes.data.progress).toBeNull()
+    })
+  })
+})

--- a/apps/backend/src/admin/components/media/folders/folder-media-section.tsx
+++ b/apps/backend/src/admin/components/media/folders/folder-media-section.tsx
@@ -21,6 +21,7 @@ export const FolderMediaSection = ({ folder }: FolderMediaSectionProps) => {
   const [selection, setSelection] = useState<Record<string, true>>({})
   const [extractionModalOpen, setExtractionModalOpen] = useState(false)
   const [extractionMediaIds, setExtractionMediaIds] = useState<string[]>([])
+  const [extractionFolderId, setExtractionFolderId] = useState<string | undefined>(undefined)
   const [createProductModalOpen, setCreateProductModalOpen] = useState(false)
   const queryClient = useQueryClient()
   const selectedCount = useMemo(() => Object.keys(selection).length, [selection])
@@ -81,6 +82,7 @@ export const FolderMediaSection = ({ folder }: FolderMediaSectionProps) => {
       toast.error("No images selected. Extraction only works on image files.")
       return
     }
+    setExtractionFolderId(undefined)
     setExtractionMediaIds(selectedImageMediaIds)
     setExtractionModalOpen(true)
   }
@@ -90,7 +92,10 @@ export const FolderMediaSection = ({ folder }: FolderMediaSectionProps) => {
       toast.error("No images in this folder. Extraction only works on image files.")
       return
     }
-    setExtractionMediaIds(allImageMediaIds)
+    // Folder-wide extraction: single long-running, rate-limited workflow
+    // (1 photo per minute) instead of one workflow per photo.
+    setExtractionFolderId(folder.id)
+    setExtractionMediaIds([])
     setExtractionModalOpen(true)
   }
 
@@ -245,8 +250,12 @@ export const FolderMediaSection = ({ folder }: FolderMediaSectionProps) => {
       </CommandBar>
       <TextileExtractionModal
         open={extractionModalOpen}
-        onOpenChange={setExtractionModalOpen}
-        mediaIds={extractionMediaIds}
+        onOpenChange={(open) => {
+          setExtractionModalOpen(open)
+          if (!open) setExtractionFolderId(undefined)
+        }}
+        mediaIds={extractionFolderId ? [] : extractionMediaIds}
+        folderId={extractionFolderId}
         onSuccess={handleExtractionSuccess}
       />
       <CreateProductFromMediaModal

--- a/apps/backend/src/admin/components/media/textile-extraction-modal.tsx
+++ b/apps/backend/src/admin/components/media/textile-extraction-modal.tsx
@@ -15,6 +15,8 @@ import {
   useBatchExtractTextileFeatures,
   useExtractTextileFeatures,
   useConfirmExtraction,
+  useExtractFolderFeatures,
+  useConfirmFolderExtraction,
 } from "../../hooks/api/textile-extraction";
 import { Spinner } from "../ui/spinner";
 
@@ -28,6 +30,12 @@ interface TextileExtractionModalProps {
    */
   mediaIds: string | string[];
   /**
+   * When provided, extraction runs as a folder-wide long-running workflow
+   * that processes every image in the folder at 1 photo per minute
+   * (rate-limited) instead of firing one workflow per photo.
+   */
+  folderId?: string;
+  /**
    * Called after successful extraction initiation
    */
   onSuccess?: () => void;
@@ -37,6 +45,7 @@ export const TextileExtractionModal = ({
   open,
   onOpenChange,
   mediaIds,
+  folderId,
   onSuccess,
 }: TextileExtractionModalProps) => {
   const [hints, setHints] = useState("");
@@ -47,9 +56,13 @@ export const TextileExtractionModal = ({
   const singleExtractMutation = useExtractTextileFeatures();
   const confirmMutation = useConfirmExtraction();
   const batchExtractMutation = useBatchExtractTextileFeatures();
+  const folderExtractMutation = useExtractFolderFeatures();
+  const folderConfirmMutation = useConfirmFolderExtraction();
 
-  const isSingle = typeof mediaIds === "string";
-  const count = isSingle ? 1 : mediaIds.length;
+  // Folder mode: one long-running, rate-limited job for the whole folder
+  const isFolderMode = typeof folderId === "string" && folderId.length > 0;
+  const isSingle = typeof mediaIds === "string" && !isFolderMode;
+  const count = isFolderMode ? 0 : isSingle ? 1 : mediaIds.length;
 
   const handleExtract = async () => {
     const hintsArray = hints
@@ -57,7 +70,28 @@ export const TextileExtractionModal = ({
       .map((h) => h.trim())
       .filter(Boolean);
 
-    if (isSingle) {
+    if (isFolderMode) {
+      try {
+        const result = await folderExtractMutation.mutateAsync({
+          folderId: folderId!,
+          hints: hintsArray.length > 0 ? hintsArray : undefined,
+          gender,
+          persist,
+        });
+
+        if (autoConfirm && result.transaction_id) {
+          await folderConfirmMutation.mutateAsync({
+            folderId: folderId!,
+            transactionId: result.transaction_id,
+          });
+        }
+
+        handleClose();
+        onSuccess?.();
+      } catch (error) {
+        console.error("Folder extraction failed:", error);
+      }
+    } else if (isSingle) {
       try {
         const result = await singleExtractMutation.mutateAsync({
           media_id: mediaIds,
@@ -76,9 +110,10 @@ export const TextileExtractionModal = ({
         console.error("Extraction failed:", error);
       }
     } else {
+      const batchMediaIds = Array.isArray(mediaIds) ? mediaIds : [];
       try {
         await batchExtractMutation.mutateAsync({
-          media_ids: mediaIds,
+          media_ids: batchMediaIds,
           hints: hintsArray.length > 0 ? hintsArray : undefined,
           gender,
           persist,
@@ -104,7 +139,9 @@ export const TextileExtractionModal = ({
   const isLoading =
     singleExtractMutation.isPending ||
     confirmMutation.isPending ||
-    batchExtractMutation.isPending;
+    batchExtractMutation.isPending ||
+    folderExtractMutation.isPending ||
+    folderConfirmMutation.isPending;
 
   return (
     <FocusModal open={open} onOpenChange={onOpenChange}>
@@ -124,11 +161,26 @@ export const TextileExtractionModal = ({
               <InformationCircleSolid className="mt-0.5 shrink-0 text-ui-fg-interactive" />
               <div className="flex flex-col gap-y-0.5">
                 <Text size="small" weight="plus" className="text-ui-fg-base">
-                  Analyzing {count} {count === 1 ? "image" : "images"}
+                  {isFolderMode
+                    ? "Extracting all images in this folder"
+                    : `Analyzing ${count} ${count === 1 ? "image" : "images"}`}
                 </Text>
                 <Text size="xsmall" className="text-ui-fg-subtle">
-                  AI will extract two data sets: <strong>garment data</strong> for product catalog
-                  and <strong>raw internal data</strong> (face, body, model characteristics) for internal use.
+                  {isFolderMode ? (
+                    <>
+                      Runs as a long-running background job processing{" "}
+                      <strong>1 photo per minute</strong> so AI providers are never
+                      rate limited. Every image in the folder gets extracted —
+                      track progress from the folder page.
+                    </>
+                  ) : (
+                    <>
+                      AI first observes <strong>what is visible</strong> (colors,
+                      pattern, design, fabric) and then derives garment data for
+                      the product catalog plus raw internal data (face, body, model
+                      characteristics) for internal use.
+                    </>
+                  )}
                 </Text>
               </div>
             </div>
@@ -278,7 +330,11 @@ export const TextileExtractionModal = ({
               ) : (
                 <div className="flex items-center gap-x-2">
                   <Sparkles />
-                  Extract {count > 1 ? `${count} images` : "features"}
+                  {isFolderMode
+                    ? "Extract all (1 photo/min)"
+                    : count > 1
+                      ? `Extract ${count} images`
+                      : "Extract features"}
                 </div>
               )}
             </Button>

--- a/apps/backend/src/admin/hooks/api/textile-extraction.ts
+++ b/apps/backend/src/admin/hooks/api/textile-extraction.ts
@@ -1,4 +1,4 @@
-import { useMutation, useQueryClient } from "@tanstack/react-query";
+import { useMutation, useQuery, useQueryClient } from "@tanstack/react-query";
 import { sdk } from "../../lib/config";
 import { toast } from "@medusajs/ui";
 import { mediaFolderDetailQueryKeys } from "./media-folders/use-media-folder-detail";
@@ -214,5 +214,159 @@ export const useBatchExtractTextileFeatures = () => {
       toast.error("Failed to initiate batch extraction");
       console.error("[useBatchExtractTextileFeatures] Error:", error);
     },
+  });
+};
+
+// ============================================
+// Folder-wide (rate-limited) extraction hooks
+// ============================================
+
+export type ExtractFolderFeaturesRequest = {
+  hints?: string[];
+  gender?: "female" | "male" | "unisex";
+  persist?: boolean;
+  /** Milliseconds between photos. Default 60000 (1 photo per minute). */
+  interval_ms?: number;
+};
+
+export type ExtractFolderFeaturesResponse = {
+  message: string;
+  transaction_id: string;
+  status: "pending_confirmation";
+  folder_id: string;
+  total_images?: number;
+  summary?: any;
+};
+
+export type ConfirmFolderExtractionResponse = {
+  success: boolean;
+  message: string;
+  transaction_id: string;
+};
+
+export type FolderExtractionProgress = {
+  status: "running" | "completed" | "failed";
+  total: number;
+  completed: number;
+  failed: number;
+  interval_ms?: number;
+  started_at?: string;
+  updated_at?: string;
+  finished_at?: string | null;
+  last_media_id?: string | null;
+  errors?: Array<{ media_id: string; error: string }>;
+};
+
+export type ExtractFolderFeaturesStatusResponse = {
+  folder_id: string;
+  has_run: boolean;
+  progress: FolderExtractionProgress | null;
+};
+
+/**
+ * Hook to initiate folder-wide feature extraction.
+ * Runs as a long-running workflow processing 1 photo per minute
+ * (configurable via interval_ms) to avoid AI rate limits.
+ */
+export const useExtractFolderFeatures = () => {
+  const queryClient = useQueryClient();
+
+  return useMutation({
+    mutationFn: async ({
+      folderId,
+      ...payload
+    }: ExtractFolderFeaturesRequest & { folderId: string }) => {
+      const response = await fetch(
+        `/admin/medias/folder/${folderId}/extract-features`,
+        {
+          method: "POST",
+          headers: {
+            "Content-Type": "application/json",
+          },
+          body: JSON.stringify(payload),
+        }
+      );
+
+      if (!response.ok) {
+        const error = await response.json();
+        throw new Error(error.message || "Failed to initiate folder extraction");
+      }
+
+      return response.json() as Promise<ExtractFolderFeaturesResponse>;
+    },
+    onSuccess: () => {
+      queryClient.invalidateQueries({
+        queryKey: mediaFolderDetailQueryKeys.all,
+      });
+    },
+    onError: (error: any) => {
+      const message = error?.message || "Failed to initiate folder extraction";
+      toast.error(message);
+      console.error("[useExtractFolderFeatures] Error:", error);
+    },
+  });
+};
+
+/**
+ * Hook to confirm a pending folder extraction transaction
+ */
+export const useConfirmFolderExtraction = () => {
+  return useMutation({
+    mutationFn: async ({
+      folderId,
+      transactionId,
+    }: {
+      folderId: string;
+      transactionId: string;
+    }) => {
+      const response = await fetch(
+        `/admin/medias/folder/${folderId}/extract-features/${transactionId}/confirm`,
+        {
+          method: "POST",
+          headers: {
+            "Content-Type": "application/json",
+          },
+        }
+      );
+
+      if (!response.ok) {
+        const error = await response.json();
+        throw new Error(error.message || "Failed to confirm folder extraction");
+      }
+
+      return response.json() as Promise<ConfirmFolderExtractionResponse>;
+    },
+    onSuccess: (data) => {
+      toast.success(data.message || "Folder extraction confirmed and started");
+    },
+    onError: (error: any) => {
+      const message = error?.message || "Failed to confirm folder extraction";
+      toast.error(message);
+      console.error("[useConfirmFolderExtraction] Error:", error);
+    },
+  });
+};
+
+/**
+ * Hook to poll folder extraction progress (from folder metadata)
+ */
+export const useFolderExtractionStatus = (
+  folderId: string | undefined,
+  options?: { refetchInterval?: number; enabled?: boolean }
+) => {
+  return useQuery({
+    queryKey: ["folder-extraction-status", folderId],
+    queryFn: async (): Promise<ExtractFolderFeaturesStatusResponse> => {
+      const response = await fetch(
+        `/admin/medias/folder/${folderId}/extract-features/status`
+      );
+      if (!response.ok) {
+        const error = await response.json();
+        throw new Error(error.message || "Failed to fetch folder extraction status");
+      }
+      return response.json();
+    },
+    enabled: !!folderId && (options?.enabled ?? true),
+    refetchInterval: options?.refetchInterval,
   });
 };

--- a/apps/backend/src/api/admin/medias/folder/[id]/extract-features/[transaction_id]/confirm/route.ts
+++ b/apps/backend/src/api/admin/medias/folder/[id]/extract-features/[transaction_id]/confirm/route.ts
@@ -1,0 +1,83 @@
+/**
+ * @file Admin API route for confirming folder-wide textile extraction
+ * @description Confirms and starts the rate-limited folder extraction workflow
+ * @module API/Admin/Medias/Folder/ExtractFeatures/Confirm
+ */
+
+/**
+ * Confirm a folder-wide textile extraction transaction
+ * @route POST /admin/medias/folder/{id}/extract-features/{transaction_id}/confirm
+ * @group Media - Media management operations
+ *
+ * @param {string} transaction_id.path.required - The transaction ID from the initial request
+ * @returns {ConfirmResponse} 200 - Success confirmation
+ * @throws {MedusaError} 404 - Transaction not found
+ *
+ * @description
+ * Resumes the suspended folder extraction workflow. After confirmation the
+ * workflow processes every image in the folder sequentially in the background,
+ * one photo per minute by default.
+ */
+
+import { MedusaRequest, MedusaResponse } from "@medusajs/framework/http";
+import { ContainerRegistrationKeys } from "@medusajs/framework/utils";
+import { IWorkflowEngineService } from "@medusajs/framework/types";
+import { Modules, TransactionHandlerType } from "@medusajs/framework/utils";
+import { StepResponse } from "@medusajs/framework/workflows-sdk";
+import {
+  textileFolderExtractionWorkflowId,
+  waitConfirmationTextileFolderExtractionStepId,
+} from "../../../../../../../../workflows/ai/textile-folder-extraction";
+
+export const POST = async (req: MedusaRequest, res: MedusaResponse) => {
+  const logger: any = req.scope.resolve(ContainerRegistrationKeys.LOGGER);
+  try {
+    const workflowEngineService: IWorkflowEngineService = req.scope.resolve(
+      Modules.WORKFLOW_ENGINE
+    );
+    const transactionId = req.params.transaction_id;
+
+    if (!transactionId) {
+      return res.status(400).json({
+        success: false,
+        message: "Transaction ID is required",
+      });
+    }
+
+    // Resume the suspended workflow step
+    await workflowEngineService.setStepSuccess({
+      idempotencyKey: {
+        action: TransactionHandlerType.INVOKE,
+        transactionId,
+        stepId: waitConfirmationTextileFolderExtractionStepId,
+        workflowId: textileFolderExtractionWorkflowId,
+      },
+      stepResponse: new StepResponse(true),
+    });
+
+    return res.status(200).json({
+      success: true,
+      message: "Folder extraction confirmed. Processing started at 1 photo per minute.",
+      transaction_id: transactionId,
+    });
+  } catch (error) {
+    logger.error(`[FolderExtractFeatures/Confirm] Error: ${error}`, error);
+
+    // Check if it's a "workflow not found" type error
+    const errorMessage = (error as Error)?.message || "";
+    if (
+      errorMessage.includes("not found") ||
+      errorMessage.includes("does not exist")
+    ) {
+      return res.status(404).json({
+        success: false,
+        message: `Transaction not found or already processed: ${req.params.transaction_id}`,
+      });
+    }
+
+    return res.status(500).json({
+      success: false,
+      message: errorMessage || "Failed to confirm folder extraction",
+    });
+  }
+};

--- a/apps/backend/src/api/admin/medias/folder/[id]/extract-features/route.ts
+++ b/apps/backend/src/api/admin/medias/folder/[id]/extract-features/route.ts
@@ -1,0 +1,128 @@
+/**
+ * @file Admin API route for folder-wide textile feature extraction
+ * @description Kicks off a long-running, rate-limited extraction of every
+ *              image in a media folder (1 photo per minute by default).
+ * @module API/Admin/Medias/Folder/ExtractFeatures
+ */
+
+/**
+ * Extract features from all images in a media folder
+ * @route POST /admin/medias/folder/{id}/extract-features
+ * @group Media - Media management operations
+ *
+ * @param {ExtractFolderFeaturesRequest} request.body.optional - Extraction options
+ * @returns {ExtractFolderFeaturesResponse} 202 - Extraction initiated, returns transaction_id
+ * @throws {MedusaError} 404 - Folder not found
+ * @throws {MedusaError} 400 - Folder has no images / invalid request
+ *
+ * @example request
+ * POST /admin/medias/folder/folder_123/extract-features
+ * { "persist": true, "interval_ms": 60000 }
+ *
+ * @example response 202
+ * {
+ *   "message": "Folder-wide extraction initiated. Confirm to start processing.",
+ *   "transaction_id": "txn_abc123def456",
+ *   "status": "pending_confirmation",
+ *   "folder_id": "folder_123",
+ *   "total_images": 14
+ * }
+ *
+ * @description
+ * This endpoint initiates a long-running workflow that extracts textile
+ * product features from EVERY image in the folder. Processing is sequential
+ * and rate limited (default 1 photo per minute) to avoid AI provider rate
+ * limits. Progress can be polled via
+ * GET /admin/medias/folder/{id}/extract-features/status.
+ *
+ * Flow:
+ * 1. POST /admin/medias/folder/{id}/extract-features - Returns transaction_id
+ * 2. POST /admin/medias/folder/{id}/extract-features/{transaction_id}/confirm
+ * 3. Background processing runs one photo per minute until done
+ */
+
+import { MedusaRequest, MedusaResponse } from "@medusajs/framework/http";
+import { ContainerRegistrationKeys, MedusaError } from "@medusajs/framework/utils";
+import { ExtractFolderFeaturesRequestSchema, ExtractFolderFeaturesRequest } from "./validators";
+import { textileFolderExtractionMedusaWorkflow } from "../../../../../../workflows/ai/textile-folder-extraction";
+import MediaService from "../../../../../../modules/media/service";
+import { MEDIA_MODULE } from "../../../../../../modules/media";
+
+export const POST = async (
+  req: MedusaRequest<ExtractFolderFeaturesRequest>,
+  res: MedusaResponse
+) => {
+  const logger: any = req.scope.resolve(ContainerRegistrationKeys.LOGGER);
+  try {
+    // Validate request body
+    const parsed = ExtractFolderFeaturesRequestSchema.safeParse(
+      (req as any).validatedBody || req.body
+    );
+
+    if (!parsed.success) {
+      const message = parsed.error.issues.map((e) => e.message).join(", ");
+      throw new MedusaError(MedusaError.Types.INVALID_DATA, message || "Invalid request body");
+    }
+
+    const { hints, gender, persist, interval_ms } = parsed.data;
+    const folder_id = req.params.id;
+
+    // Verify folder exists and count extractable images for the response
+    const mediaService = req.scope.resolve(MEDIA_MODULE) as MediaService;
+    const folder = await mediaService.retrieveFolder(folder_id).catch(() => null);
+
+    if (!folder) {
+      throw new MedusaError(MedusaError.Types.NOT_FOUND, `Folder not found: ${folder_id}`);
+    }
+
+    const mediaFiles = await mediaService.listMediaFiles(
+      { folder_id },
+      { select: ["id", "file_type"] }
+    );
+    const imageCount = (mediaFiles || []).filter((f: any) => f.file_type === "image").length;
+
+    if (imageCount === 0) {
+      throw new MedusaError(
+        MedusaError.Types.INVALID_DATA,
+        `Folder ${folder_id} has no image files to extract features from`
+      );
+    }
+
+    // Run the long-running workflow
+    const { result, transaction } = await textileFolderExtractionMedusaWorkflow(req.scope).run({
+      input: {
+        folder_id,
+        hints,
+        gender,
+        persist,
+        interval_ms,
+      },
+    });
+
+    // Return 202 Accepted with transaction ID for confirmation
+    return res.status(202).json({
+      message: "Folder-wide extraction initiated. Confirm to start processing.",
+      transaction_id: transaction.transactionId,
+      status: "pending_confirmation",
+      folder_id,
+      total_images: imageCount,
+      summary: result,
+    });
+  } catch (error) {
+    logger.error(`[FolderExtractFeatures] Error: ${error}`, error);
+
+    if (error instanceof MedusaError) {
+      const status =
+        error.type === MedusaError.Types.INVALID_DATA
+          ? 400
+          : error.type === MedusaError.Types.NOT_FOUND
+            ? 404
+            : 500;
+      return res.status(status).json({ message: (error as Error).message });
+    }
+
+    return res.status(500).json({
+      message: (error as any)?.message || "An unexpected error occurred",
+    });
+  }
+};

--- a/apps/backend/src/api/admin/medias/folder/[id]/extract-features/status/route.ts
+++ b/apps/backend/src/api/admin/medias/folder/[id]/extract-features/status/route.ts
@@ -1,0 +1,69 @@
+/**
+ * @file Admin API route for folder-wide extraction progress
+ * @description Returns live progress of the folder feature extraction job
+ *              (mirrored into the folder's metadata by the workflow).
+ * @module API/Admin/Medias/Folder/ExtractFeatures/Status
+ */
+
+/**
+ * Get folder extraction progress
+ * @route GET /admin/medias/folder/{id}/extract-features/status
+ * @group Media - Media management operations
+ *
+ * @returns {ExtractFolderFeaturesStatusResponse} 200 - Progress info
+ * @throws {MedusaError} 404 - Folder not found
+ *
+ * @example response 200
+ * {
+ *   "folder_id": "folder_123",
+ *   "has_run": true,
+ *   "progress": {
+ *     "status": "running",
+ *     "total": 14,
+ *     "completed": 5,
+ *     "failed": 0,
+ *     "interval_ms": 60000,
+ *     "started_at": "2026-08-30T10:00:00.000Z",
+ *     "updated_at": "2026-08-30T10:05:12.000Z"
+ *   }
+ * }
+ */
+
+import { MedusaRequest, MedusaResponse } from "@medusajs/framework/http";
+import { ContainerRegistrationKeys, MedusaError } from "@medusajs/framework/utils";
+import MediaService from "../../../../../../../modules/media/service";
+import { MEDIA_MODULE } from "../../../../../../../modules/media";
+import { FolderExtractionProgress } from "../../../../../../../workflows/ai/textile-folder-extraction";
+
+export const GET = async (req: MedusaRequest, res: MedusaResponse) => {
+  const logger: any = req.scope.resolve(ContainerRegistrationKeys.LOGGER);
+  try {
+    const folder_id = req.params.id;
+
+    const mediaService = req.scope.resolve(MEDIA_MODULE) as MediaService;
+    const folder = await mediaService.retrieveFolder(folder_id).catch(() => null);
+
+    if (!folder) {
+      throw new MedusaError(MedusaError.Types.NOT_FOUND, `Folder not found: ${folder_id}`);
+    }
+
+    const progress = (folder.metadata?.folder_extraction as FolderExtractionProgress) || null;
+
+    return res.json({
+      folder_id,
+      has_run: !!progress,
+      progress,
+    });
+  } catch (error) {
+    logger.error(`[FolderExtractFeatures/Status] Error: ${error}`, error);
+
+    if (error instanceof MedusaError) {
+      const status = error.type === MedusaError.Types.NOT_FOUND ? 404 : 500;
+      return res.status(status).json({ message: (error as Error).message });
+    }
+
+    return res.status(500).json({
+      message: (error as any)?.message || "An unexpected error occurred",
+    });
+  }
+};

--- a/apps/backend/src/api/admin/medias/folder/[id]/extract-features/validators.ts
+++ b/apps/backend/src/api/admin/medias/folder/[id]/extract-features/validators.ts
@@ -1,0 +1,52 @@
+import { z } from "@medusajs/framework/zod";
+
+/**
+ * Request schema for POST /admin/medias/folder/:id/extract-features
+ * Initiates folder-wide, rate-limited textile feature extraction
+ */
+export const ExtractFolderFeaturesRequestSchema = z.object({
+  /** Optional hints to guide the extraction process for every photo */
+  hints: z.array(z.string()).optional(),
+  /** Gender context for correct interpretation of sizing, fit, and target audience */
+  gender: z.enum(["female", "male", "unisex"]).optional().default("unisex"),
+  /** Whether to persist extraction results to each media file's metadata */
+  persist: z.boolean().optional().default(false),
+  /**
+   * Milliseconds to wait between photos. Defaults to 60000 (1 photo per minute).
+   * Clamped between 5 seconds and 15 minutes.
+   */
+  interval_ms: z.number().int().positive().optional(),
+});
+
+export type ExtractFolderFeaturesRequest = z.infer<typeof ExtractFolderFeaturesRequestSchema>;
+
+/**
+ * Response schema for POST /admin/medias/folder/:id/extract-features
+ */
+export type ExtractFolderFeaturesResponse = {
+  message: string;
+  transaction_id: string;
+  status: "pending_confirmation";
+  folder_id: string;
+  total_images?: number;
+};
+
+/**
+ * Response schema for GET /admin/medias/folder/:id/extract-features/status
+ */
+export type ExtractFolderFeaturesStatusResponse = {
+  folder_id: string;
+  has_run: boolean;
+  progress: {
+    status: "running" | "completed" | "failed";
+    total: number;
+    completed: number;
+    failed: number;
+    interval_ms?: number;
+    started_at?: string;
+    updated_at?: string;
+    finished_at?: string | null;
+    last_media_id?: string | null;
+    errors?: Array<{ media_id: string; error: string }>;
+  } | null;
+};

--- a/apps/backend/src/api/middlewares.ts
+++ b/apps/backend/src/api/middlewares.ts
@@ -236,6 +236,7 @@ import { AdminImageExtractionReq } from "./admin/ai/image-extraction/validators"
 import { AdminSendPersonAgreementReq } from "./admin/persons/[id]/agreements/validators";
 import { folderSchema, uploadMediaSchema } from "./admin/medias/validator";
 import { ExtractFeaturesRequestSchema } from "./admin/medias/extract-features/validators";
+import { ExtractFolderFeaturesRequestSchema } from "./admin/medias/folder/[id]/extract-features/validators";
 import {
   AdminCreateFormSchema,
   AdminListFormResponsesQuerySchema,
@@ -4045,6 +4046,22 @@ export default defineMiddlewares({
     {
       matcher: "/admin/medias/extract-features/:transaction_id/confirm",
       method: "POST",
+      middlewares: [],
+    },
+    // Folder-wide (rate-limited) textile feature extraction endpoints
+    {
+      matcher: "/admin/medias/folder/:id/extract-features",
+      method: "POST",
+      middlewares: [validateAndTransformBody(wrapSchema(ExtractFolderFeaturesRequestSchema))],
+    },
+    {
+      matcher: "/admin/medias/folder/:id/extract-features/:transaction_id/confirm",
+      method: "POST",
+      middlewares: [],
+    },
+    {
+      matcher: "/admin/medias/folder/:id/extract-features/status",
+      method: "GET",
       middlewares: [],
     },
     // Person Types

--- a/apps/backend/src/mastra/workflows/textileProductExtraction/index.ts
+++ b/apps/backend/src/mastra/workflows/textileProductExtraction/index.ts
@@ -2,7 +2,6 @@
 import { createWorkflow, createStep } from "@mastra/core/workflows";
 import { z } from "zod";
 import {
-  createTextileExtractionAgent,
   createTextileAgentWithModel,
   getTextileFallbackModels,
   isRateLimitError,
@@ -42,6 +41,73 @@ export const triggerSchema = z.object({
   threadId: z.string().optional(),
   resourceId: z.string().optional(),
 });
+
+// ─────────────────────────────────────────────────────────────
+// Visual observations — the FEEDBACK-ORIENTED first pass.
+// Describes ONLY what is visible in the image. No inference,
+// no e-commerce fields. This becomes ground truth for pass 2.
+// ─────────────────────────────────────────────────────────────
+export const visualObservationsSchema = z.object({
+  visible_colors: z
+    .array(z.string())
+    .optional()
+    .default([])
+    .describe("Every color visibly present, be specific e.g. 'navy blue', 'off-white'"),
+  visible_pattern: z
+    .string()
+    .nullable()
+    .optional()
+    .describe("Surface pattern as seen: solid, stripes, checks, floral, ikat, block-print, abstract… or null"),
+  pattern_description: z
+    .string()
+    .nullable()
+    .optional()
+    .describe("One or two sentences describing how the pattern looks (scale, repeat, placement)"),
+  design_elements: z
+    .array(z.string())
+    .optional()
+    .default([])
+    .describe("Observable design details: motifs, embroidery, borders, seams, buttons, zippers, tassels, prints"),
+  fabric: z
+    .object({
+      type_idea: z
+        .string()
+        .nullable()
+        .optional()
+        .describe("Best guess of fabric family from visual cues only (e.g. 'cotton-like', 'silk sheen')"),
+      texture: z.string().nullable().optional().describe("Visible texture: matte, glossy, slubbed, ribbed, woven, knit…"),
+      weave_or_knit: z.string().nullable().optional().describe("Visible weave/knit structure if discernible"),
+      perceived_weight: z
+        .string()
+        .nullable()
+        .optional()
+        .describe("Visual weight impression: lightweight/drapey, medium, heavyweight/structured"),
+      finish: z.string().nullable().optional().describe("Visible finish: sheen, washed, raw edge, printed, dyed…"),
+    })
+    .optional(),
+  visible_item: z
+    .string()
+    .nullable()
+    .optional()
+    .describe("What the item physically appears to be, described from what is seen (e.g. 'long tunic with side slits')"),
+  visible_text: z
+    .array(z.string())
+    .optional()
+    .default([])
+    .describe("Any text visible in the image: labels, tags, watermarks, brand marks"),
+  shot_type: z
+    .string()
+    .nullable()
+    .optional()
+    .describe("Framing as seen: full body, half body, flat lay, close-up detail, mannequin"),
+  not_visible_or_uncertain: z
+    .array(z.string())
+    .optional()
+    .default([])
+    .describe("Things that CANNOT be seen or confirmed (e.g. 'fabric composition not visible', 'no tag visible')"),
+});
+
+export type VisualObservations = z.infer<typeof visualObservationsSchema>;
 
 // Raw face details — internal use only, never shown to customers
 const faceRawSchema = z
@@ -104,6 +170,9 @@ export const textileProductSchema = z.object({
   target_audience: z.string().nullable().optional(),
   confidence: z.number().min(0).max(1).optional(),
 
+  // ── Visual observations from the feedback-oriented first pass ─
+  visual_observations: visualObservationsSchema.nullable().optional(),
+
   // ── Raw internal fields — NOT for customer display ────────────
   face_raw: faceRawSchema,
   body_raw: bodyRawSchema,
@@ -129,78 +198,252 @@ const inferMime = (u: string): string => {
   return "";
 };
 
-// Step to extract textile product features from image
-const extractTextileFeaturesStep = createStep({
-  id: "extractTextileFeatures",
-  inputSchema: triggerSchema,
-  outputSchema: textileProductSchema,
-  execute: async ({ inputData }) => {
-    const { image_url, hints, gender, threadId, resourceId } = inputData;
+// Prepares an image URL/data-URI for the agent (download + sniff mime)
+const prepareImageForAgent = async (image_url: string): Promise<{ image: string; mimeType: string }> => {
+  let imageForAgent = image_url;
+  let mimeType = inferMime(image_url);
 
-    logger.info(`[TextileExtraction] Starting extraction for image: ${image_url.substring(0, 50)}...`);
+  if (image_url.startsWith("http")) {
+    try {
+      const resp = await fetch(image_url);
+      const buf = Buffer.from(await resp.arrayBuffer());
 
-    // Get fallback models
-    const availableModels = await getTextileFallbackModels();
-    logger.info(`[TextileExtraction] Available vision models: ${availableModels.slice(0, 5).join(", ")}`);
+      const isPng = buf[0] === 0x89 && buf[1] === 0x50 && buf[2] === 0x4e && buf[3] === 0x47;
+      const isJpeg = buf[0] === 0xff && buf[1] === 0xd8;
+      const isGif = buf[0] === 0x47 && buf[1] === 0x49 && buf[2] === 0x46 && buf[3] === 0x38;
+      const isWebp =
+        buf.slice(0, 4).toString("ascii") === "RIFF" && buf.slice(8, 12).toString("ascii") === "WEBP";
 
-    // Prepare image for agent
-    let imageForAgent = image_url;
-    let mimeType = inferMime(image_url);
+      if (isPng) mimeType = "image/png";
+      else if (isJpeg) mimeType = "image/jpeg";
+      else if (isGif) mimeType = "image/gif";
+      else if (isWebp) mimeType = "image/webp";
+      else {
+        const ct = resp.headers.get("content-type") || "";
+        if (ct.startsWith("image/")) mimeType = ct.split(";")[0].trim();
+      }
 
-    if (image_url.startsWith("http")) {
+      const b64 = buf.toString("base64");
+      imageForAgent = `data:${mimeType};base64,${b64}`;
+    } catch (err) {
+      logger.warn(`[TextileExtraction] Failed to fetch image, using URL directly: ${err}`);
+    }
+  }
+
+  if (!mimeType) mimeType = "image/jpeg";
+  return { image: imageForAgent, mimeType };
+};
+
+/**
+ * Runs a schema-constrained vision call across the fallback model ladder
+ * with retry/backoff on rate limits. Shared by every extraction pass.
+ */
+const runVisionExtraction = async <T>(
+  label: string,
+  messages: any[],
+  outputSchema: any,
+  context?: { threadId?: string; resourceId?: string }
+): Promise<T> => {
+  const availableModels = await getTextileFallbackModels();
+  logger.info(`[${label}] Available vision models: ${availableModels.slice(0, 5).join(", ")}`);
+
+  const stableResourceId =
+    context?.resourceId && !String(context.resourceId).startsWith("textile-extraction:http")
+      ? context.resourceId
+      : `textile-extraction:${label}`;
+
+  let lastError: any = null;
+  let modelIndex = 0;
+
+  while (modelIndex < availableModels.length) {
+    const currentModel = availableModels[modelIndex];
+    let retryCount = 0;
+
+    while (retryCount < MAX_RETRIES) {
       try {
-        const resp = await fetch(image_url);
-        const buf = Buffer.from(await resp.arrayBuffer());
+        const agent = await createTextileAgentWithModel(currentModel, false);
+        logger.info(`[${label}] Attempting with model: ${currentModel} (attempt ${retryCount + 1})`);
 
-        const isPng = buf[0] === 0x89 && buf[1] === 0x50 && buf[2] === 0x4e && buf[3] === 0x47;
-        const isJpeg = buf[0] === 0xff && buf[1] === 0xd8;
-        const isGif = buf[0] === 0x47 && buf[1] === 0x49 && buf[2] === 0x46 && buf[3] === 0x38;
-        const isWebp =
-          buf.slice(0, 4).toString("ascii") === "RIFF" && buf.slice(8, 12).toString("ascii") === "WEBP";
+        const response = await agent.generate(messages, {
+          output: outputSchema,
+        } as any);
 
-        if (isPng) mimeType = "image/png";
-        else if (isJpeg) mimeType = "image/jpeg";
-        else if (isGif) mimeType = "image/gif";
-        else if (isWebp) mimeType = "image/webp";
-        else {
-          const ct = resp.headers.get("content-type") || "";
-          if (ct.startsWith("image/")) mimeType = ct.split(";")[0].trim();
+        const parsed = readModelJsonOrThrow(response, `${label}(${currentModel})`) as T;
+        logger.info(`[${label}] Successfully extracted with model: ${currentModel}`);
+        return parsed;
+      } catch (error: any) {
+        lastError = error;
+        const errorMsg = error?.message || String(error);
+        logger.warn(`[${label}] Error with model ${currentModel} (attempt ${retryCount + 1}): ${errorMsg}`);
+
+        if (isRateLimitError(error)) {
+          retryCount++;
+          if (retryCount < MAX_RETRIES) {
+            const delay = Math.min(
+              INITIAL_RETRY_DELAY_MS * Math.pow(2, retryCount - 1) + Math.random() * 2000,
+              MAX_RETRY_DELAY_MS
+            );
+            logger.info(`[${label}] Rate limited. Waiting ${Math.round(delay / 1000)}s before retry...`);
+            await sleep(delay);
+          } else {
+            logger.warn(`[${label}] Max retries for ${currentModel}. Trying next model...`);
+            break;
+          }
+        } else {
+          logger.warn(`[${label}] Non-rate-limit error. Trying next model...`);
+          break;
         }
-
-        const b64 = buf.toString("base64");
-        imageForAgent = `data:${mimeType};base64,${b64}`;
-      } catch (err) {
-        logger.warn(`[TextileExtraction] Failed to fetch image, using URL directly: ${err}`);
       }
     }
 
-    if (!mimeType) mimeType = "image/jpeg";
+    modelIndex++;
+    if (modelIndex < availableModels.length) {
+      logger.info(`[${label}] Switching to fallback model: ${availableModels[modelIndex]}`);
+    }
+  }
 
-    const hintsText = hints && hints.length > 0 ? `\n\nAdditional hints:\n${hints.map((h) => `- ${h}`).join("\n")}` : "";
-    const genderContext = gender !== "unisex" ? `\nGender context: ${gender} — use this to interpret sizing, fit, and target audience correctly.` : "";
+  throw new Error(`[${label}] All vision models exhausted. Last error: ${lastError?.message || String(lastError)}`);
+};
 
-    const prompt = `You are a fashion and textile analysis expert. Analyze this image and return a single JSON object with ALL of the following fields.
+// ─────────────────────────────────────────────────────────────
+// STEP 1 — Observation pass: what is VISIBLE.
+// Deliberately does NOT ask for e-commerce fields so the model
+// reports what it sees instead of forcing generic answers.
+// ─────────────────────────────────────────────────────────────
+const observeVisibleFeaturesStep = createStep({
+  id: "observeVisibleFeatures",
+  inputSchema: triggerSchema,
+  outputSchema: visualObservationsSchema,
+  execute: async ({ inputData }) => {
+    const { image_url, hints } = inputData;
+
+    logger.info(`[TextileObservation] Starting visible-features observation for image: ${image_url.substring(0, 50)}...`);
+
+    const { image: imageForAgent, mimeType } = await prepareImageForAgent(image_url);
+
+    const hintsText =
+      hints && hints.length > 0
+        ? `\n\nAreas the requester specifically wants observed (still only if visible):\n${hints
+            .map((h) => `- ${h}`)
+            .join("\n")}`
+        : "";
+
+    const prompt = `You are a textile and fashion visual analyst. Look at this image and report ONLY what you can actually SEE.
+
+Do NOT infer e-commerce fields. Do NOT guess prices, target audience, seasons, SEO keywords, or product titles. Do NOT fabricate anything. If something is not visible, put it under "not_visible_or_uncertain" instead of guessing.
+
+Report what is visible:
+
+- **visible_colors**: Every color you can see, be specific ("navy blue", "off-white", "terracotta")
+- **visible_pattern**: The surface pattern as seen ("solid", "stripes", "checks", "floral", "ikat", "block-print", "abstract"), or null if plain/uniform
+- **pattern_description**: How the pattern looks — scale, repeat, placement, density. Or null.
+- **design_elements**: Observable design details — motifs, embroidery, borders, piping, seams, buttons, zippers, tassels, mirror work, prints, trims
+- **fabric**: What the fabric LOOKS like (visual idea only, not a lab analysis):
+  - type_idea: best visual guess of fabric family ("cotton-like", "silk sheen", "linen-like", "denim", "velvet")
+  - texture: matte / glossy / slubbed / ribbed / woven / knit / smooth
+  - weave_or_knit: visible weave or knit structure if discernible, else null
+  - perceived_weight: lightweight & drapey / medium / heavyweight & structured — based on how it hangs or folds
+  - finish: sheen, washed look, raw edges, printed, dyed, embroidered surface
+- **visible_item**: What the item physically appears to be, described from what you see ("long tunic with side slits", "folded yardage of printed cloth")
+- **visible_text**: Any text visible — labels, tags, watermarks, brand marks. Empty array if none.
+- **shot_type**: How the image is framed — full body, half body, flat lay, close-up detail, mannequin
+- **not_visible_or_uncertain**: List anything that CANNOT be seen or confirmed ("fabric composition not visible", "no care label visible", "back of garment not visible")
+${hintsText}
+
+Return ONLY a valid JSON object. Do not include markdown, commentary, or any text outside the JSON.`;
+
+    const messages = [
+      {
+        role: "user" as const,
+        content: [
+          {
+            type: "image" as const,
+            image: imageForAgent,
+            mimeType,
+          },
+          {
+            type: "text" as const,
+            text: prompt,
+          },
+        ],
+      },
+    ];
+
+    const observations = await runVisionExtraction<VisualObservations>(
+      "TextileObservation",
+      messages,
+      visualObservationsSchema,
+      { threadId: inputData.threadId, resourceId: inputData.resourceId }
+    );
+
+    return observations;
+  },
+});
+
+// ─────────────────────────────────────────────────────────────
+// STEP 2 — Feedback pass: derive product fields FROM the
+// observations. The observation JSON is fed back into the prompt
+// as ground truth so derived fields stay anchored to what was
+// actually visible rather than generic guesses.
+// ─────────────────────────────────────────────────────────────
+const deriveProductFieldsStep = createStep({
+  id: "deriveProductFields",
+  inputSchema: z.object({
+    image_url: triggerSchema.shape.image_url,
+    hints: z.array(z.string()).optional().default([]),
+    gender: z.enum(["female", "male", "unisex"]).optional().default("unisex"),
+    threadId: z.string().optional(),
+    resourceId: z.string().optional(),
+    observations: visualObservationsSchema,
+  }),
+  outputSchema: textileProductSchema,
+  execute: async ({ inputData }) => {
+    const { image_url, hints, gender, threadId, resourceId, observations } = inputData;
+
+    logger.info(`[TextileDerivation] Deriving product fields from observations for image: ${image_url.substring(0, 50)}...`);
+
+    const { image: imageForAgent, mimeType } = await prepareImageForAgent(image_url);
+
+    const genderContext =
+      gender !== "unisex"
+        ? `\nGender context: ${gender} — use this to interpret sizing, fit, and target audience correctly.`
+        : "";
+
+    const hintsText =
+      hints && hints.length > 0 ? `\n\nAdditional hints:\n${hints.map((h) => `- ${h}`).join("\n")}` : "";
+
+    const observationsText = JSON.stringify(observations, null, 2);
+
+    const prompt = `You are a fashion and textile product expert. A previous observation pass examined this image and recorded ONLY what is visible. That observation record is provided below as GROUND TRUTH.
+
+---
+## OBSERVATION RECORD (ground truth — do NOT contradict it)
+${observationsText}
+---
+
+Using these observations, return a single JSON object with ALL of the following fields. Ground every derived field in the observations. If the observations say something is "not visible or uncertain", leave the dependent field null/empty rather than guessing.
 
 ---
 ## PART 1 — Garment & Product Catalog Data
 Extract accurate product information for e-commerce listing:
 
-- **title**: Short, marketable product name (e.g. "Slim-fit Cotton Oxford Shirt")
-- **description**: Rich product description (2–3 sentences, mentions fabric feel, fit, styling)
-- **designer**: Brand or designer label visible in the image, or null
+- **title**: Short, marketable product name (e.g. "Slim-fit Cotton Oxford Shirt") — anchored in what was observed
+- **description**: Rich product description (2–3 sentences, mentions fabric feel, fit, styling) — reference observed colors, pattern and fabric
+- **designer**: Brand or designer label ONLY if it appears in visible_text or is clearly visible, otherwise null
 - **model_name**: Specific model/SKU name if visible, or null
-- **cloth_type**: Primary garment type (e.g. "shirt", "dress", "jacket", "trousers")
-- **pattern**: Surface pattern (e.g. "solid", "stripes", "floral", "checks", "abstract"), or null
-- **fabric_weight**: Perceived weight (e.g. "lightweight", "medium-weight", "heavyweight"), or null
-- **care_instructions**: Array of care symbols/instructions visible or inferable from fabric
-- **season**: Array of seasons (e.g. ["spring", "summer"])
-- **occasion**: Array of occasions (e.g. ["casual", "formal", "workwear"])
-- **colors**: Array of all visible colors (be specific: "navy blue", "off-white")
-- **category**: Broad clothing category ("tops", "bottoms", "outerwear", "dresses", "accessories")
-- **suggested_price**: Object { amount: number, currency: "USD" } based on perceived quality/brand, or null
-- **seo_keywords**: Array of 5–10 keywords for search optimization
+- **cloth_type**: Primary garment type consistent with "visible_item" (e.g. "shirt", "dress", "jacket", "trousers", "fabric")
+- **pattern**: Use "visible_pattern" as-is when present, or null
+- **fabric_weight**: Use the observed "perceived_weight" ("lightweight", "medium-weight", "heavyweight"), or null if uncertain
+- **care_instructions**: Array of care symbols/instructions visible or inferable from the observed fabric — empty if nothing supports them
+- **season**: Array of seasons consistent with the observed fabric weight/texture
+- **occasion**: Array of occasions consistent with the observed design and styling
+- **colors**: Copy "visible_colors" (be specific: "navy blue", "off-white")
+- **category**: Broad clothing category ("tops", "bottoms", "outerwear", "dresses", "accessories", "fabric")
+- **suggested_price**: Object { amount: number, currency: "USD" } based on observed quality/design complexity, or null
+- **seo_keywords**: Array of 5–10 keywords grounded in observed colors, pattern, fabric and design elements
 - **target_audience**: Description of intended customer (e.g. "women aged 25–40, professional")
 - **confidence**: Float 0–1 representing extraction confidence${genderContext}
+- **visual_observations**: Echo the observation record unchanged
 
 ---
 ## PART 2 — Raw Internal Data (for internal analysis only, NOT shown to customers)
@@ -226,7 +469,7 @@ Extract observable characteristics of any person/model visible in the image:
   - gender_presentation (e.g. "feminine", "masculine", "androgynous"), or null
   - styling (e.g. "editorial high-fashion", "casual street", "clean minimalist"), or null
   - overall_vibe (e.g. "luxury", "sporty", "bohemian", "classic"), or null
-  - shot_type (e.g. "full body", "half body", "flat lay", "detail shot"), or null
+  - shot_type: use the observed "shot_type", or null
   If no model is in the image (e.g. flat lay), set non-applicable fields to null.${hintsText}
 
 ---
@@ -249,74 +492,14 @@ Return ONLY a valid JSON object. Do not include markdown, commentary, or any tex
       },
     ];
 
-    // Stable resource ID
-    const stableResourceId =
-      resourceId && !String(resourceId).startsWith("textile-extraction:http")
-        ? resourceId
-        : "textile-extraction:product-analysis";
-
-    let lastError: any = null;
-    let modelIndex = 0;
-
-    while (modelIndex < availableModels.length) {
-      const currentModel = availableModels[modelIndex];
-      let retryCount = 0;
-
-      while (retryCount < MAX_RETRIES) {
-        try {
-          const agent = await createTextileAgentWithModel(currentModel, false);
-          logger.info(`[TextileExtraction] Attempting with model: ${currentModel} (attempt ${retryCount + 1})`);
-
-          const response = await agent.generate(messages, {
-            output: textileProductSchema,
-          } as any);
-
-          // Was a hand-rolled ladder here — the same problem three other
-          // workflows also hit. Its last resort, /\{[\s\S]*?"title"[\s\S]*?\}/,
-          // is lazy: on a response whose title is followed by any nested object
-          // it stops at the first "}" and parses a TRUNCATED product. The shared
-          // reader brace-matches and is string-literal aware.
-          const parsed = readModelJsonOrThrow(
-            response,
-            `textileProductExtraction(${currentModel})`
-          ) as TextileProductExtractionOutput;
-
-          logger.info(`[TextileExtraction] Successfully extracted with model: ${currentModel}`);
-          return parsed;
-        } catch (error: any) {
-          lastError = error;
-          const errorMsg = error?.message || String(error);
-          logger.warn(`[TextileExtraction] Error with model ${currentModel} (attempt ${retryCount + 1}): ${errorMsg}`);
-
-          if (isRateLimitError(error)) {
-            retryCount++;
-            if (retryCount < MAX_RETRIES) {
-              const delay = Math.min(
-                INITIAL_RETRY_DELAY_MS * Math.pow(2, retryCount - 1) + Math.random() * 2000,
-                MAX_RETRY_DELAY_MS
-              );
-              logger.info(`[TextileExtraction] Rate limited. Waiting ${Math.round(delay / 1000)}s before retry...`);
-              await sleep(delay);
-            } else {
-              logger.warn(`[TextileExtraction] Max retries for ${currentModel}. Trying next model...`);
-              break;
-            }
-          } else {
-            logger.warn(`[TextileExtraction] Non-rate-limit error. Trying next model...`);
-            break;
-          }
-        }
-      }
-
-      modelIndex++;
-      if (modelIndex < availableModels.length) {
-        logger.info(`[TextileExtraction] Switching to fallback model: ${availableModels[modelIndex]}`);
-      }
-    }
-
-    throw new Error(
-      `[TextileExtraction] All vision models exhausted. Last error: ${lastError?.message || String(lastError)}`
+    const product = await runVisionExtraction<TextileProductExtractionOutput>(
+      "TextileDerivation",
+      messages,
+      textileProductSchema,
+      { threadId, resourceId }
     );
+
+    return product;
   },
 });
 
@@ -354,6 +537,37 @@ const validateExtractionStep = createStep({
         typeof inputData.confidence === "number"
           ? Math.max(0, Math.min(1, inputData.confidence))
           : undefined,
+
+      // Visual observations — normalize but keep as-is (feedback trail)
+      visual_observations: inputData.visual_observations
+        ? {
+            visible_colors: Array.isArray(inputData.visual_observations.visible_colors)
+              ? inputData.visual_observations.visible_colors
+              : [],
+            visible_pattern: inputData.visual_observations.visible_pattern || null,
+            pattern_description: inputData.visual_observations.pattern_description || null,
+            design_elements: Array.isArray(inputData.visual_observations.design_elements)
+              ? inputData.visual_observations.design_elements
+              : [],
+            fabric: inputData.visual_observations.fabric
+              ? {
+                  type_idea: inputData.visual_observations.fabric.type_idea || null,
+                  texture: inputData.visual_observations.fabric.texture || null,
+                  weave_or_knit: inputData.visual_observations.fabric.weave_or_knit || null,
+                  perceived_weight: inputData.visual_observations.fabric.perceived_weight || null,
+                  finish: inputData.visual_observations.fabric.finish || null,
+                }
+              : undefined,
+            visible_item: inputData.visual_observations.visible_item || null,
+            visible_text: Array.isArray(inputData.visual_observations.visible_text)
+              ? inputData.visual_observations.visible_text
+              : [],
+            shot_type: inputData.visual_observations.shot_type || null,
+            not_visible_or_uncertain: Array.isArray(inputData.visual_observations.not_visible_or_uncertain)
+              ? inputData.visual_observations.not_visible_or_uncertain
+              : [],
+          }
+        : null,
 
       // Raw internal fields — normalize but keep as-is
       face_raw: inputData.face_raw
@@ -400,12 +614,28 @@ const validateExtractionStep = createStep({
 });
 
 // Create and export the workflow
+// Observation pass first (what is visible), then the observations are
+// fed back into the product-field derivation pass (feedback-oriented).
 export const textileProductExtractionWorkflow = createWorkflow({
   id: "textile-product-extraction",
   inputSchema: triggerSchema,
   outputSchema: textileProductSchema,
 })
-  .then(extractTextileFeaturesStep)
+  .then(observeVisibleFeaturesStep)
+  .map(async ({ inputData, getInitData }) => {
+    // inputData = observations from the visible-features pass.
+    // getInitData() = the original trigger input (image URL, hints, gender).
+    const init = getInitData() as TextileProductExtractionInput;
+    return {
+      image_url: init.image_url,
+      hints: init.hints || [],
+      gender: init.gender || "unisex",
+      threadId: init.threadId,
+      resourceId: init.resourceId,
+      observations: inputData,
+    };
+  })
+  .then(deriveProductFieldsStep)
   .then(validateExtractionStep)
   .commit();
 

--- a/apps/backend/src/workflows/ai/textile-folder-extraction.ts
+++ b/apps/backend/src/workflows/ai/textile-folder-extraction.ts
@@ -1,0 +1,472 @@
+/**
+ * Medusa Long-Running Workflow for Folder-Wide Textile Feature Extraction
+ *
+ * Extracts features from EVERY image in a media folder as one
+ * long-running, rate-limited background job:
+ *
+ * 1. Trigger API returns transaction_id (202 status)
+ * 2. Async step suspends workflow until confirmed
+ * 3. Confirm API resumes workflow
+ * 4. Processing runs in the background, one photo at a time with a
+ *    configurable interval (default: 1 photo per minute) so the AI
+ *    provider is never rate limited.
+ * 5. Progress is mirrored to the folder's metadata (folder_extraction)
+ *    so the admin UI can poll status while the job runs.
+ */
+
+import {
+  createStep,
+  createWorkflow,
+  StepResponse,
+  WorkflowResponse,
+  WorkflowData,
+  transform,
+} from "@medusajs/framework/workflows-sdk";
+import { MedusaError } from "@medusajs/framework/utils";
+import { notifyOnFailureStep, sendNotificationsStep } from "@medusajs/medusa/core-flows";
+import { MEDIA_MODULE } from "../../modules/media";
+import MediaService from "../../modules/media/service";
+import {
+  runTextileMastraExtraction,
+  persistTextileExtractionResult,
+  TextileProductExtractionOutput,
+} from "./textile-product-extraction";
+
+// ============================================
+// Types
+// ============================================
+
+export type TextileFolderExtractionInput = {
+  folder_id: string;
+  hints?: string[];
+  gender?: "female" | "male" | "unisex";
+  persist?: boolean;
+  /** Milliseconds to wait between photos. Default 60000 (1 photo/minute). */
+  interval_ms?: number;
+};
+
+export type FolderMediaItem = {
+  media_id: string;
+  image_url: string;
+};
+
+export type FolderMediaListOutput = {
+  folder_id: string;
+  folder_name: string;
+  media: FolderMediaItem[];
+  total: number;
+  interval_ms: number;
+  hints?: string[];
+  gender?: string;
+  persist: boolean;
+};
+
+export type FolderExtractionProgress = {
+  status: "running" | "completed" | "failed";
+  total: number;
+  completed: number;
+  failed: number;
+  interval_ms: number;
+  started_at: string;
+  updated_at: string;
+  finished_at?: string | null;
+  last_media_id?: string | null;
+  errors?: Array<{ media_id: string; error: string }>;
+};
+
+export type TextileFolderExtractionSummary = {
+  folder_id: string;
+  status: "pending_confirmation" | "processing";
+  message: string;
+  total_images?: number;
+};
+
+// ============================================
+// Rate limiting constants
+// ============================================
+
+/** Default pacing: 1 photo per minute */
+export const DEFAULT_FOLDER_EXTRACTION_INTERVAL_MS = 60 * 1000;
+/** Never go faster than this regardless of configuration */
+export const MIN_FOLDER_EXTRACTION_INTERVAL_MS = 5 * 1000;
+/** Never wait longer than this between photos */
+export const MAX_FOLDER_EXTRACTION_INTERVAL_MS = 15 * 60 * 1000;
+
+const clampInterval = (ms?: number): number => {
+  const value = typeof ms === "number" && !Number.isNaN(ms) ? ms : DEFAULT_FOLDER_EXTRACTION_INTERVAL_MS;
+  return Math.min(Math.max(value, MIN_FOLDER_EXTRACTION_INTERVAL_MS), MAX_FOLDER_EXTRACTION_INTERVAL_MS);
+};
+
+const sleep = (ms: number) => new Promise((resolve) => setTimeout(resolve, ms));
+
+// ============================================
+// Workflow IDs (exported for confirm endpoint)
+// ============================================
+
+export const textileFolderExtractionWorkflowId = "textile-folder-extraction";
+export const waitConfirmationTextileFolderExtractionStepId = "wait-confirmation-textile-folder-extraction";
+
+// ============================================
+// Steps — Parent Workflow
+// ============================================
+
+/**
+ * Async wait step - suspends workflow until confirmed.
+ * Long timeout because folder jobs may be reviewed before starting.
+ */
+export const waitConfirmationTextileFolderExtractionStep = createStep(
+  {
+    name: waitConfirmationTextileFolderExtractionStepId,
+    async: true,
+    // Timeout after 24 hours to prevent orphaned workflows
+    timeout: 60 * 60 * 24,
+  },
+  async () => {
+    // Empty body - step suspends here until workflowEngineService.setStepSuccess() is called
+  }
+);
+
+// ============================================
+// Steps — Background Processing Workflow
+// ============================================
+
+/**
+ * Lists all image media files belonging to the folder.
+ */
+const listFolderMediaStep = createStep(
+  "list-folder-media-for-extraction",
+  async (input: TextileFolderExtractionInput, { container }) => {
+    const mediaService: MediaService = container.resolve(MEDIA_MODULE);
+
+    const folder = await mediaService.retrieveFolder(input.folder_id).catch(() => null);
+    if (!folder) {
+      throw new MedusaError(MedusaError.Types.NOT_FOUND, `Folder not found: ${input.folder_id}`);
+    }
+
+    const mediaFiles = await mediaService.listMediaFiles(
+      { folder_id: input.folder_id },
+      { select: ["id", "file_path", "file_type"], order: { created_at: "ASC" } } as any
+    );
+
+    const images = (mediaFiles || []).filter((f: any) => f.file_type === "image" && f.file_path);
+
+    if (images.length === 0) {
+      throw new MedusaError(
+        MedusaError.Types.INVALID_DATA,
+        `Folder ${input.folder_id} has no image files to extract features from`
+      );
+    }
+
+    return new StepResponse({
+      folder_id: input.folder_id,
+      folder_name: folder.name,
+      media: images.map((f: any) => ({ media_id: f.id, image_url: f.file_path })),
+      total: images.length,
+      interval_ms: clampInterval(input.interval_ms),
+      hints: input.hints,
+      gender: input.gender,
+      persist: input.persist ?? false,
+    });
+  }
+);
+
+/**
+ * Initializes the folder_extraction progress metadata on the folder.
+ * Compensation clears the progress entry on rollback.
+ */
+const initFolderExtractionProgressStep = createStep(
+  "init-folder-extraction-progress",
+  async (input: FolderMediaListOutput, { container }) => {
+    const mediaService: MediaService = container.resolve(MEDIA_MODULE);
+    const folder = await mediaService.retrieveFolder(input.folder_id);
+
+    const progress: FolderExtractionProgress = {
+      status: "running",
+      total: input.total,
+      completed: 0,
+      failed: 0,
+      interval_ms: input.interval_ms,
+      started_at: new Date().toISOString(),
+      updated_at: new Date().toISOString(),
+      finished_at: null,
+      last_media_id: null,
+      errors: [],
+    };
+
+    await mediaService.updateFolders({
+      selector: { id: input.folder_id },
+      data: { metadata: { ...(folder.metadata || {}), folder_extraction: progress } },
+    });
+
+    return new StepResponse({ folder_id: input.folder_id, total: input.total }, { folder_id: input.folder_id });
+  },
+  // Compensation: remove the progress entry
+  async (data: { folder_id: string } | undefined, { container }) => {
+    if (!data?.folder_id) return;
+    try {
+      const mediaService: MediaService = container.resolve(MEDIA_MODULE);
+      const folder = await mediaService.retrieveFolder(data.folder_id);
+      const metadata = { ...(folder.metadata || {}) };
+      delete metadata.folder_extraction;
+      await mediaService.updateFolders({ selector: { id: data.folder_id }, data: { metadata } });
+    } catch {}
+  }
+);
+
+/**
+ * Processes every photo in the folder SEQUENTIALLY, sleeping
+ * `interval_ms` between photos (default 1 minute) so the vision
+ * provider is never rate limited. Each photo's result is persisted
+ * to the media metadata and progress is mirrored to the folder
+ * metadata after every item.
+ */
+const processFolderMediaSequentiallyStep = createStep(
+  "process-folder-media-sequentially",
+  async (input: FolderMediaListOutput, { container }) => {
+    const mediaService: MediaService = container.resolve(MEDIA_MODULE);
+
+    let completed = 0;
+    let failed = 0;
+    const errors: Array<{ media_id: string; error: string }> = [];
+    const results: Array<{ media_id: string; status: "completed" | "failed"; error?: string }> = [];
+
+    const writeProgress = async (patch: Partial<FolderExtractionProgress>) => {
+      try {
+        const folder = await mediaService.retrieveFolder(input.folder_id);
+        const existing = (folder.metadata?.folder_extraction as FolderExtractionProgress) || {};
+        await mediaService.updateFolders({
+          selector: { id: input.folder_id },
+          data: {
+            metadata: {
+              ...(folder.metadata || {}),
+              folder_extraction: {
+                ...existing,
+                ...patch,
+                total: input.total,
+                completed,
+                failed,
+                updated_at: new Date().toISOString(),
+              },
+            },
+          },
+        });
+      } catch (err) {
+        // Progress mirroring must never fail the extraction run
+        console.error(`[TextileFolderExtraction] Failed to update progress: ${err}`);
+      }
+    };
+
+    for (let i = 0; i < input.media.length; i++) {
+      const item = input.media[i];
+      const isLast = i === input.media.length - 1;
+
+      try {
+        const extraction: TextileProductExtractionOutput = await runTextileMastraExtraction({
+          image_url: item.image_url,
+          hints: input.hints,
+          gender: input.gender,
+          threadId: `textile-folder-${input.folder_id}-${item.media_id}`,
+          resourceId: `textile-extraction:folder:${input.folder_id}:${item.media_id}`,
+        });
+
+        if (input.persist) {
+          await persistTextileExtractionResult(mediaService, item.media_id, extraction);
+        }
+
+        completed++;
+        results.push({ media_id: item.media_id, status: "completed" });
+        await writeProgress({ last_media_id: item.media_id });
+      } catch (error: any) {
+        failed++;
+        const message = error?.message || String(error);
+        errors.push({ media_id: item.media_id, error: message });
+        if (errors.length > 20) errors.shift();
+        results.push({ media_id: item.media_id, status: "failed", error: message });
+        await writeProgress({
+          last_media_id: item.media_id,
+          errors: [...errors],
+        });
+      }
+
+      // Rate limiting: 1 photo per interval (default 1 minute).
+      // Only sleep BETWEEN photos, not after the last one.
+      if (!isLast) {
+        await sleep(input.interval_ms);
+      }
+    }
+
+    const summary = {
+      folder_id: input.folder_id,
+      total: input.total,
+      completed,
+      failed,
+    };
+
+    return new StepResponse({ ...summary, results }, summary);
+  }
+);
+
+/**
+ * Marks the folder extraction as completed (or failed if every item failed)
+ * in the folder metadata.
+ */
+const finalizeFolderExtractionStep = createStep(
+  "finalize-folder-extraction",
+  async (
+    input: { folder_id: string; total: number; completed: number; failed: number },
+    { container }
+  ) => {
+    const mediaService: MediaService = container.resolve(MEDIA_MODULE);
+    const folder = await mediaService.retrieveFolder(input.folder_id);
+    const existing = (folder.metadata?.folder_extraction as FolderExtractionProgress) || {};
+
+    const status: FolderExtractionProgress["status"] =
+      input.completed === 0 && input.failed > 0 ? "failed" : "completed";
+
+    const progress: FolderExtractionProgress = {
+      ...existing,
+      status,
+      total: input.total,
+      completed: input.completed,
+      failed: input.failed,
+      updated_at: new Date().toISOString(),
+      finished_at: new Date().toISOString(),
+    };
+
+    await mediaService.updateFolders({
+      selector: { id: input.folder_id },
+      data: { metadata: { ...(folder.metadata || {}), folder_extraction: progress } },
+    });
+
+    return new StepResponse({ ...input, status });
+  }
+);
+
+// ============================================
+// Background Processing Workflow
+// ============================================
+
+/**
+ * Internal workflow that lists folder media, initializes progress and
+ * processes every photo sequentially with rate limiting. Invoked via
+ * runAsStep with backgroundExecution: true.
+ */
+export const textileFolderExtractionProcessingWorkflow = createWorkflow(
+  "textile-folder-extraction-processing",
+  (input: WorkflowData<TextileFolderExtractionInput>) => {
+    const mediaList = listFolderMediaStep(input);
+
+    const progressInput = transform({ mediaList }, (data) => data.mediaList);
+
+    initFolderExtractionProgressStep(progressInput);
+
+    const processingSummary = processFolderMediaSequentiallyStep(progressInput);
+
+    const finalizeInput = transform({ processingSummary }, (data) => ({
+      folder_id: data.processingSummary.folder_id,
+      total: data.processingSummary.total,
+      completed: data.processingSummary.completed,
+      failed: data.processingSummary.failed,
+    }));
+
+    const finalized = finalizeFolderExtractionStep(finalizeInput);
+
+    return new WorkflowResponse(finalized);
+  }
+);
+
+// ============================================
+// Main Workflow Definition
+// ============================================
+
+/**
+ * Long-running workflow for folder-wide textile feature extraction.
+ *
+ * Usage:
+ * 1. Trigger via POST /admin/medias/folder/:id/extract-features
+ * 2. Returns transaction_id (202 Accepted)
+ * 3. Confirm via POST /admin/medias/folder/:id/extract-features/:transaction_id/confirm
+ * 4. Every image in the folder is extracted one at a time — 1 photo per
+ *    minute by default — in the background. Poll GET
+ *    /admin/medias/folder/:id/extract-features/status for progress.
+ *
+ * @example
+ * ```ts
+ * const { result, transaction } = await textileFolderExtractionMedusaWorkflow(container).run({
+ *   input: {
+ *     folder_id: "folder_123",
+ *     persist: true,
+ *     interval_ms: 60000, // 1 photo per minute
+ *   },
+ * });
+ * ```
+ */
+export const textileFolderExtractionMedusaWorkflow = createWorkflow(
+  {
+    name: textileFolderExtractionWorkflowId,
+    store: true, // Enable state persistence for long-running execution
+  },
+  (
+    input: WorkflowData<TextileFolderExtractionInput>
+  ): WorkflowResponse<TextileFolderExtractionSummary> => {
+    // Create initial summary for response before confirmation
+    const initialSummary = transform({ input }, (data) => ({
+      folder_id: data.input.folder_id,
+      status: "pending_confirmation" as const,
+      message: `Folder-wide textile extraction ready for folder ${data.input.folder_id}. Confirm to start processing all images at 1 photo per minute.`,
+    }));
+
+    // Wait for user confirmation (suspends workflow here)
+    waitConfirmationTextileFolderExtractionStep();
+
+    // Failure notification configuration
+    const failureNotification = transform({ input }, (data) => [
+      {
+        to: "",
+        channel: "feed" as const,
+        template: "admin-ui" as const,
+        data: {
+          title: "Folder Feature Extraction Failed",
+          description: `Failed to run folder-wide feature extraction for folder ${data.input.folder_id}`,
+        },
+      },
+    ]);
+
+    notifyOnFailureStep(failureNotification);
+
+    // Run folder processing in background (rate-limited, sequential)
+    const processingInput = transform({ input }, (data) => ({
+      folder_id: data.input.folder_id,
+      hints: data.input.hints,
+      gender: data.input.gender,
+      persist: data.input.persist ?? false,
+      interval_ms: data.input.interval_ms,
+    }));
+
+    // Use runAsStep with backgroundExecution for the long rate-limited run
+    textileFolderExtractionProcessingWorkflow
+      .runAsStep({ input: processingInput })
+      .config({ async: true, backgroundExecution: true });
+
+    // Success notification (will run after background processing completes)
+    const successNotification = transform({ input }, (data) => [
+      {
+        to: "",
+        channel: "feed" as const,
+        template: "admin-ui" as const,
+        data: {
+          title: "Folder Feature Extraction Finished",
+          description: `Finished extracting features from all images in folder ${data.input.folder_id}`,
+        },
+      },
+    ]);
+
+    sendNotificationsStep(successNotification);
+
+    // Return summary (this is what the initial trigger returns)
+    return new WorkflowResponse(initialSummary);
+  }
+);
+
+export default textileFolderExtractionMedusaWorkflow;
+

--- a/apps/backend/src/workflows/ai/textile-product-extraction.ts
+++ b/apps/backend/src/workflows/ai/textile-product-extraction.ts
@@ -36,6 +36,24 @@ export type TextileProductExtractionInput = {
   resourceId?: string;
 };
 
+export type VisualObservations = {
+  visible_colors?: string[];
+  visible_pattern?: string | null;
+  pattern_description?: string | null;
+  design_elements?: string[];
+  fabric?: {
+    type_idea?: string | null;
+    texture?: string | null;
+    weave_or_knit?: string | null;
+    perceived_weight?: string | null;
+    finish?: string | null;
+  };
+  visible_item?: string | null;
+  visible_text?: string[];
+  shot_type?: string | null;
+  not_visible_or_uncertain?: string[];
+};
+
 export type TextileProductExtractionOutput = {
   // Garment / product catalog fields
   title: string;
@@ -54,6 +72,9 @@ export type TextileProductExtractionOutput = {
   seo_keywords?: string[];
   target_audience?: string | null;
   confidence?: number;
+
+  // Visible-only observations from the feedback-oriented first pass
+  visual_observations?: VisualObservations | null;
 
   // Raw internal fields — not for customer display
   face_raw?: {
@@ -112,56 +133,70 @@ export const waitConfirmationTextileExtractionStep = createStep(
 );
 
 /**
+ * Shared runner for the Mastra textile extraction workflow.
+ * Used by the per-media workflow step and the folder-wide
+ * rate-limited extraction workflow.
+ */
+export const runTextileMastraExtraction = async (input: {
+  image_url: string;
+  hints?: string[];
+  gender?: string;
+  threadId?: string;
+  resourceId?: string;
+}): Promise<TextileProductExtractionOutput> => {
+  const workflow = mastra.getWorkflow("textileProductExtractionWorkflow");
+  const run = await workflow.createRun();
+
+  // Generate threadId and resourceId if not provided (required for Memory)
+  const threadId = input.threadId || `textile-thread-${Date.now()}`;
+  const resourceId = input.resourceId || `textile-extraction:${Date.now()}`;
+
+  // Execute the workflow
+  const workflowResult = await run.start({
+    inputData: {
+      image_url: input.image_url,
+      hints: input.hints || [],
+      gender: (input.gender as any) || "unisex",
+      threadId,
+      resourceId,
+    },
+  });
+
+  // Check validation step result
+  if (workflowResult.steps.validateTextileExtraction?.status === "success") {
+    const output = workflowResult.steps.validateTextileExtraction.output as TextileProductExtractionOutput;
+    return output;
+  }
+
+  // Fallback: check derivation step
+  if (workflowResult.steps.deriveProductFields?.status === "success") {
+    const output = workflowResult.steps.deriveProductFields.output as TextileProductExtractionOutput;
+    return output;
+  }
+
+  // Check for errors
+  const failedStep = Object.entries(workflowResult.steps).find(([, step]) => (step as any).status === "failed");
+  if (failedStep) {
+    throw new MedusaError(
+      MedusaError.Types.UNEXPECTED_STATE,
+      `Textile extraction failed at step ${failedStep[0]}: ${failedStep[1] || "Unknown error"}`
+    );
+  }
+
+  throw new MedusaError(
+    MedusaError.Types.UNEXPECTED_STATE,
+    "Textile extraction workflow completed but no valid output found"
+  );
+};
+
+/**
  * Step to run the Mastra textile extraction workflow
  */
 const runMastraTextileExtractionStep = createStep(
   "run-mastra-textile-extraction",
   async (input: { image_url: string; hints?: string[]; gender?: string; threadId?: string; resourceId?: string }) => {
     try {
-      // Get the Mastra workflow
-      const workflow = mastra.getWorkflow("textileProductExtractionWorkflow");
-      const run = await workflow.createRun();
-
-      // Generate threadId and resourceId if not provided (required for Memory)
-      const threadId = input.threadId || `textile-thread-${Date.now()}`;
-      const resourceId = input.resourceId || `textile-extraction:${Date.now()}`;
-
-      // Execute the workflow
-      const workflowResult = await run.start({
-        inputData: {
-          image_url: input.image_url,
-          hints: input.hints || [],
-          gender: (input.gender as any) || "unisex",
-          threadId,
-          resourceId,
-        },
-      });
-
-      // Check validation step result
-      if (workflowResult.steps.validateTextileExtraction?.status === "success") {
-        const output = workflowResult.steps.validateTextileExtraction.output as TextileProductExtractionOutput;
-        return new StepResponse(output);
-      }
-
-      // Fallback: check extraction step
-      if (workflowResult.steps.extractTextileFeatures?.status === "success") {
-        const output = workflowResult.steps.extractTextileFeatures.output as TextileProductExtractionOutput;
-        return new StepResponse(output);
-      }
-
-      // Check for errors
-      const failedStep = Object.entries(workflowResult.steps).find(([, step]) => (step as any).status === "failed");
-      if (failedStep) {
-        throw new MedusaError(
-          MedusaError.Types.UNEXPECTED_STATE,
-          `Textile extraction failed at step ${failedStep[0]}: ${failedStep[1] || "Unknown error"}`
-        );
-      }
-
-      throw new MedusaError(
-        MedusaError.Types.UNEXPECTED_STATE,
-        "Textile extraction workflow completed but no valid output found"
-      );
+      return new StepResponse(await runTextileMastraExtraction(input));
     } catch (error: any) {
       if (error instanceof MedusaError) throw error;
       throw new MedusaError(
@@ -175,6 +210,24 @@ const runMastraTextileExtractionStep = createStep(
     // No rollback needed for extraction
   }
 );
+
+/**
+ * Persist extraction results to a media file's metadata.
+ * Shared by the per-media workflow and the folder-wide workflow.
+ */
+export const persistTextileExtractionResult = async (
+  mediaService: MediaService,
+  media_id: string,
+  extraction: TextileProductExtractionOutput
+): Promise<void> => {
+  await mediaService.updateMediaFiles({
+    id: media_id,
+    metadata: {
+      textile_extraction: extraction,
+      extracted_at: new Date().toISOString(),
+    },
+  });
+};
 
 /**
  * Step to persist extraction results to media metadata (optional)


### PR DESCRIPTION
## Summary

Two related improvements to the textile **Extract Features** pipeline:

### 1. Feedback-oriented extraction (visible-first)
The single mega-prompt is now a two-pass Mastra pipeline:
- **Pass 1 — `observeVisibleFeatures`**: reports ONLY what is visible — colors, pattern (+ description), design elements (motifs/embroidery/borders), fabric idea (type guess, texture, weave/knit, perceived weight, finish), visible item/text, shot type — plus an explicit `not_visible_or_uncertain` list so the model never fabricates.
- **Pass 2 — `deriveProductFields`**: feeds the observation JSON **back into the prompt as ground truth** and derives the e-commerce catalog fields from it. Fields depending on something marked not-visible stay null instead of being guessed.
- Results persist `visual_observations` end-to-end (media metadata), preserving the visible-only trail.

### 2. Folder-wide, rate-limited extraction (long-running workflow)
New `textile-folder-extraction` Medusa long-running workflow:
- Trigger (202 + transaction_id) → confirm → background sequential processing of **every image in a media folder**
- **1 photo per minute by default** (`interval_ms` configurable, clamped 5s–15min) — no more firing one workflow per photo in parallel, which is what caused provider rate limits
- Per-photo failures are isolated (run continues, errors recorded, capped at last 20)
- Progress mirrored to `folder.metadata.folder_extraction` after each photo and finalized with totals on completion

### API
| Endpoint | Purpose |
|---|---|
| `POST /admin/medias/folder/:id/extract-features` | Trigger folder-wide extraction (202 + transaction_id, returns image count) |
| `POST .../extract-features/:transaction_id/confirm` | Resume the suspended workflow |
| `GET .../extract-features/status` | Live progress (polling) |

Shared `runTextileMastraExtraction()` + `persistTextileExtractionResult()` helpers are now reused by both the per-media and folder workflows.

### Admin UI
- **"Extract Features of All Media"** on a folder now runs the single rate-limited folder workflow (previously one long-running workflow per photo, all confirmed immediately)
- Extraction modal gains a folder mode with "1 photo/min" messaging
- New hooks: `useExtractFolderFeatures`, `useConfirmFolderExtraction`, `useFolderExtractionStatus`

## Test plan
- New integration spec `textile-extract-features-stubbed.spec.ts` stubs the Mastra generation (zero external AI traffic) and exercises the full HTTP long-running flow — **7/7 passing** against a live test DB:
  - per-media trigger → confirm → stubbed result persisted with `visual_observations`
  - folder run: 2 photos processed sequentially at 5s interval, status `running → completed` with totals
  - per-photo failure isolation (1 failed / 1 completed, error recorded, run not aborted)
  - validation: no images → 400, unknown folder → 404, invalid `interval_ms` → 400, never-run → `has_run: false`
- Scoped `tsc` clean on all touched files
- Verified the Mastra workflow graph builds: `observeVisibleFeatures → map → deriveProductFields → validateTextileExtraction`

## Notes
- The per-media API contract is unchanged (request schema identical; response/output type gained an **optional** `visual_observations` field), so existing callers/integration tests remain valid.
- Branch is cut from latest `origin/main`.