### PR TITLE
fix(inventory): name the product on a finished-goods order line, not just its variant (#1662)

### DIFF
--- a/apps/backend/integration-tests/http/inventory-catalog-products.spec.ts
+++ b/apps/backend/integration-tests/http/inventory-catalog-products.spec.ts
@@ -371,6 +371,24 @@ setupSharedTestSuite(() => {
         : [lines[0].inventory_items].filter(Boolean)
       expect(linked.map((i: any) => i?.id)).toContain(itemId)
 
+      // The order DETAIL page names the line from product + variant, because a
+      // variant-made item's own title is just the variant's ("M", "Red"). That
+      // label rides on a three-hop traversal, and `query.graph` DROPS a
+      // relation it does not recognise in silence — so the hop is pinned here
+      // rather than trusted.
+      const withVariants = await api.get(
+        `/admin/inventory-orders/${orderId}?fields=id,orderlines.*,orderlines.inventory_items.*,orderlines.inventory_items.variants.id,orderlines.inventory_items.variants.title,orderlines.inventory_items.variants.product.id,orderlines.inventory_items.variants.product.title`,
+        headers
+      )
+      expect(withVariants.status).toBe(200)
+      const detailLine = withVariants.data.inventoryOrder.orderlines[0]
+      const detailItem = Array.isArray(detailLine.inventory_items)
+        ? detailLine.inventory_items[0]
+        : detailLine.inventory_items
+      const detailVariant = (detailItem.variants ?? []).find((v: any) => v?.id)
+      expect(detailVariant?.id).toBe(variantId)
+      expect(detailVariant?.product?.title).toBe(`Partner Greige ${marker}`)
+
       // Nothing has been received, so the level at our location is 0 — the
       // order must not invent stock it has not taken delivery of.
       const levels = await api.get(

--- a/apps/backend/src/admin/components/creates/inventory-order-lines-grid.tsx
+++ b/apps/backend/src/admin/components/creates/inventory-order-lines-grid.tsx
@@ -389,12 +389,15 @@ export const InventoryOrderLinesGrid = <T extends { id: string; title?: string; 
           : null
         const variant = (item?.variants ?? [])[0]
         const untracked = item?.kind === "untracked_variant"
+        // Kept to ONE word. The Type column is narrow: a three-word badge
+        // wrapped to three lines and overflowed the row, clipping itself above
+        // and below the cell. Seen only by rendering it.
         const label = item?.raw_materials
           ? "Material"
           : untracked
-          ? "Not stocked yet"
+          ? "Untracked"
           : variant
-          ? "Finished goods"
+          ? "Finished"
           : null
         const detail = item?.raw_materials
           ? null
@@ -403,19 +406,29 @@ export const InventoryOrderLinesGrid = <T extends { id: string; title?: string; 
                 .filter(Boolean)
                 .join(" · "),
               item?.partner?.name ? `from ${item.partner.name}` : "",
-              // Say what picking this row will DO. It turns tracking on for the
-              // variant at our location — a real side effect of placing the
-              // order, and one the buyer should not discover afterwards.
-              untracked ? "· we will start tracking it on order" : "",
             ]
               .filter(Boolean)
               .join(" ")
+
+        // Say what picking this row will DO — it turns tracking on for the
+        // variant at our location, a real side effect of placing the order.
+        // It rides on the badge's tooltip rather than in the cell, because the
+        // cell truncates and the sentence was never actually readable there.
+        const hint = untracked
+          ? "This variant does not track stock yet. Ordering it creates its inventory item at the destination location, starting at 0."
+          : item?.raw_materials
+          ? "Raw material."
+          : variant
+          ? "Finished goods bought in, not made."
+          : undefined
 
         return (
           <div className="flex h-full items-center gap-x-2 px-4">
             {label ? (
               <Badge
                 size="2xsmall"
+                className="whitespace-nowrap"
+                title={hint}
                 color={
                   item?.raw_materials ? "grey" : untracked ? "orange" : "blue"
                 }

--- a/apps/backend/src/admin/components/inventory-orders/inventory-order-lines-section.tsx
+++ b/apps/backend/src/admin/components/inventory-orders/inventory-order-lines-section.tsx
@@ -13,7 +13,21 @@ export const InventoryOrderLinesSection = ({ inventoryOrder }: { inventoryOrder:
   // color identity (#817 S2) lives on the base OrderLine type and rides along
   // with the orderlines.* field selection.
   type InventoryOrderLine = OrderLine & {
-    inventory_items: [{ id: string; sku: string; title?: string }];
+    inventory_items: [
+      {
+        id: string;
+        sku: string;
+        title?: string;
+        // #1662 — the variants this item backs, when it is a finished
+        // fabric/good rather than a raw material.
+        variants?: Array<{
+          id: string;
+          title?: string | null;
+          sku?: string | null;
+          product?: { id: string; title?: string | null } | null;
+        }>;
+      }
+    ];
   };
 
   // Only allow editing if status is Pending or Processing
@@ -66,17 +80,40 @@ export const InventoryOrderLinesSection = ({ inventoryOrder }: { inventoryOrder:
             }
             
             const link = `/inventory/${inventoryItem.id}`;
+
+            // #1662 — a line with no raw material fell back to the inventory
+            // item's title, which for a variant-made item is the VARIANT's
+            // title alone: an order full of lines reading "M" and "Red" with
+            // nothing saying what was bought. Name the product first.
+            const variant = inventoryItem.variants?.find((v) => v?.id);
+            const productTitle = variant?.product?.title;
+            const label =
+              line.material_name ||
+              (productTitle
+                ? [productTitle, variant?.title].filter(Boolean).join(" · ")
+                : inventoryItem.title) ||
+              inventoryItem.sku;
             
             const Inner = (
               <div className="shadow-elevation-card-rest bg-ui-bg-component rounded-md px-4 py-2 transition-colors">
                 <div className="flex items-center gap-3">
                   <div className="flex flex-1 flex-col overflow-hidden">
                     <span className="text-ui-fg-base font-medium">
-                      {line.material_name || inventoryItem.title}
+                      {label}
                     </span>
                     <div className="flex flex-wrap gap-2 mt-2">
                       {line.color && (
                         <Badge size="small" color="grey">{line.color}</Badge>
+                      )}
+                      {/* #1662 — say which kind of thing this line is, so a
+                          purchase of finished goods is not read as material. */}
+                      {!line.material_name && productTitle && (
+                        <Badge size="small" color="blue">Finished goods</Badge>
+                      )}
+                      {(variant?.sku || inventoryItem.sku) && (
+                        <Badge size="small" className="text-ui-fg-subtle">
+                          {variant?.sku || inventoryItem.sku}
+                        </Badge>
                       )}
                       <Badge size="small" className="text-ui-fg-subtle">Price: ${line.price}</Badge>
                       <Badge size="small" className="text-ui-fg-subtle">Quantity: {line.quantity}</Badge>

--- a/apps/backend/src/admin/routes/orders/inventory/[id]/constants.ts
+++ b/apps/backend/src/admin/routes/orders/inventory/[id]/constants.ts
@@ -1,1 +1,6 @@
-export const INVENTORY_ORDER_DETAIL_FIELDS = "orderlines.*, orderlines.inventory_items.*, stock_locations.*, stock_locations.address.*, +tasks.*, +partner.*";
+// #1662 — a line bought as finished fabric/goods has NO raw material, so
+// `material_name` is null and the fallback was the inventory item's title —
+// which for a variant-made item is the VARIANT's title alone ("M", "Red").
+// The product and variant are pulled through so the line can name what was
+// actually bought instead of a bare size or colour.
+export const INVENTORY_ORDER_DETAIL_FIELDS = "orderlines.*, orderlines.inventory_items.*, orderlines.inventory_items.variants.id, orderlines.inventory_items.variants.title, orderlines.inventory_items.variants.sku, orderlines.inventory_items.variants.product.id, orderlines.inventory_items.variants.product.title, orderlines.inventory_items.variants.product.thumbnail, stock_locations.*, stock_locations.address.*, +tasks.*, +partner.*";

--- a/apps/backend/src/admin/routes/orders/inventory/[id]/page.tsx
+++ b/apps/backend/src/admin/routes/orders/inventory/[id]/page.tsx
@@ -10,13 +10,23 @@ import { InventoryOrderPaymentsSection } from "../../../../components/inventory-
 import { InventoryOrderShipmentsSection } from "../../../../components/inventory-orders/inventory-order-shipments-section";
 import { InventoryOrderFeedbacksSection } from "../../../../components/inventory-orders/inventory-order-feedbacks-section";
 import { inventoryOrderLoader } from "./loader";
+import { INVENTORY_ORDER_DETAIL_FIELDS } from "./constants";
 import InventoryOrderIDSection from "../../../../components/inventory-orders/inventory-order-general-orderId";
 
 const InventoryOrderDetailPage = () => {
   const initialData = useLoaderData() as Awaited<AdminInventoryOrderResponse>
   const { id } = useParams();
+  // ⚠️ This list used to be an inline COPY of INVENTORY_ORDER_DETAIL_FIELDS, and
+  // the two drifted: adding the product/variant fields to the constant (#1662)
+  // changed the loader's prefetch but not the query this page actually renders
+  // from, so the fix looked applied and the line still showed a bare variant
+  // title. One home now; the payment fields this page needs are appended.
   const { inventoryOrder, isLoading, isError, error } = useInventoryOrder(id!, {
-    fields: ['orderlines.*', 'orderlines.inventory_items.*', 'stock_locations.*', 'stock_locations.address.*', '+tasks.*', '+partner.*', '+internal_payments.*', '+internal_payments.attachments.*']
+    fields: [
+      ...INVENTORY_ORDER_DETAIL_FIELDS.split(',').map((f) => f.trim()),
+      '+internal_payments.*',
+      '+internal_payments.attachments.*',
+    ]
   }, {
     initialData
   });


### PR DESCRIPTION
Follow-up to #1663, found by asking what the buyer sees *after* placing one of these orders.

## The defect

`inventory-order-lines-section.tsx` labelled each line:

```ts
{line.material_name || inventoryItem.title}
```

For a line bought as finished fabric or finished goods there is no raw material, so `material_name` is null (#817's denormalization is nullable by design) and the fallback takes over. For an inventory item made from a variant, that title is the **variant's** — `enableInventoryTracking` sets `title: variant.title`, and core does the same at variant-create time.

So an order placed through the flow #1663 just shipped rendered as a list of lines reading **"Natural", "Indigo", "M"** — nothing naming the product, and nothing marking it as a purchase of goods rather than material.

## The fix

The line now reads `<product> · <variant>`, carries a **Finished goods** badge, and shows the SKU. Raw-material lines are unchanged — `material_name` still wins.

## Why the test matters here

The label rides on a three-hop traversal, `orderlines.inventory_items.variants.product.title`. `query.graph` **drops a relation it does not recognise in silence** — a wrong name would fall back to the bare variant title and look exactly like the bug it is meant to fix. The hop is asserted in `inventory-catalog-products.spec.ts` instead of trusted.

## Verification

- `inventory-catalog-products.spec.ts` — **7/7 green** against the local DB, including the new traversal assertion.
- `check:prod-build` ✓; tsc at the 280-line baseline.
- 🔴 **Not rendered in a browser.** The local admin SPA would not load: `.env` sets `MEDUSA_BACKEND_URL=http://localhost:9000`, which is held by a *different* checkout, and pointing it at itself left the login screen showing "Register an auth provider in your Medusa config". A pre-existing local-config problem, unrelated to this change — but it means the JSX is type-checked and its data is proven, not visually confirmed.