### PR TITLE
feat(storefront): chat-based design editor + on-the-fly image analysis + Cloudflare image gen

### DIFF
--- a/apps/backend/integration-tests/http/storefront-design-assistant-conversations.spec.ts
+++ b/apps/backend/integration-tests/http/storefront-design-assistant-conversations.spec.ts
@@ -1,0 +1,344 @@
+import { Modules } from "@medusajs/utils"
+import { getSharedTestEnv, setupSharedTestSuite } from "./shared-test-setup"
+import { createAdminUser, getAuthHeaders } from "../helpers/create-admin-user"
+import {
+  createApiKeysWorkflow,
+  linkSalesChannelsToApiKeyWorkflow,
+} from "@medusajs/medusa/core-flows"
+
+jest.setTimeout(90 * 1000)
+
+/**
+ * Storefront design-assistant conversation store (chat design editor) —
+ * utility cases.
+ *
+ * The conversation store is the server mirror of the design-chat threads:
+ * stateless chat + verbatim UIMessage persistence, scoped by normalised maker
+ * EMAIL (the flow's gate — public routes, no customer auth) + thread key.
+ * Utility cases proven here:
+ *   - verbatim message replay (create → read back)
+ *   - title / messages defaults
+ *   - light list shape (no heavy message bodies) + newest-first
+ *   - thread-key isolation (same maker, different base-product scope)
+ *   - PATCH persists messages + links the design (first generation)
+ *   - cross-maker isolation (ids aren't probeable across emails)
+ *   - DELETE
+ *   - scope validation (missing email / thread key rejected)
+ *   - pick API shape validation (design_id + canvas_id required)
+ *
+ * Mirrors the admin-assistant conversations spec (#1092) with the design
+ * flow's email scoping.
+ */
+
+const MAKER_EMAIL = "maker@jyt.test"
+const THREAD_KEY = "product:prod_test"
+
+const SAMPLE_MESSAGES = [
+  {
+    id: "m1",
+    role: "user",
+    parts: [{ type: "text", text: "Design an indigo kurta" }],
+  },
+  {
+    id: "m2",
+    role: "assistant",
+    parts: [
+      { type: "text", text: "Locked the brief — indigo kurta, earthy tones." },
+    ],
+  },
+]
+
+setupSharedTestSuite(() => {
+  const { api, getContainer } = getSharedTestEnv()
+
+  describe("Storefront design-assistant conversations API", () => {
+    let storeHeaders: Record<string, any>
+
+    const scopeQuery = `customer_email=${encodeURIComponent(MAKER_EMAIL)}&thread_key=${encodeURIComponent(THREAD_KEY)}`
+
+    beforeEach(async () => {
+      const container = getContainer()
+      await createAdminUser(container)
+      const adminHeaders = await getAuthHeaders(api)
+
+      // Publishable API key (required for /store/* routes) linked to the
+      // default sales channel — mirror of design-production-story.spec.ts.
+      const { result: apiKeys } = await createApiKeysWorkflow(container).run({
+        input: {
+          api_keys: [
+            {
+              type: "publishable",
+              title: "Design Assistant Test Key",
+              created_by: "admin",
+            },
+          ],
+        },
+      })
+      const pubKey = apiKeys[0]
+      const storeService = container.resolve(Modules.STORE) as any
+      const stores = await storeService.listStores({})
+      if (stores?.[0]?.default_sales_channel_id) {
+        await linkSalesChannelsToApiKeyWorkflow(container).run({
+          input: {
+            id: pubKey.id,
+            add: [stores[0].default_sales_channel_id],
+          },
+        })
+      }
+      storeHeaders = { headers: { "x-publishable-api-key": pubKey.token } }
+    })
+
+    it("creates a conversation and replays messages verbatim", async () => {
+      const post = await api.post(
+        "/store/custom/design-assistant/conversations",
+        {
+          customer_email: MAKER_EMAIL,
+          thread_key: THREAD_KEY,
+          title: "Indigo kurta",
+          messages: SAMPLE_MESSAGES,
+        },
+        storeHeaders
+      )
+      expect(post.status).toBe(201)
+      expect(post.data.conversation.customer_email).toBe(MAKER_EMAIL)
+      expect(post.data.conversation.thread_key).toBe(THREAD_KEY)
+      expect(post.data.conversation.title).toBe("Indigo kurta")
+      expect(post.data.conversation.design_id).toBeNull()
+
+      const get = await api.get(
+        `/store/custom/design-assistant/conversations/${post.data.conversation.id}?${scopeQuery}`,
+        storeHeaders
+      )
+      expect(get.status).toBe(200)
+      expect(get.data.conversation.messages).toHaveLength(2)
+      expect(get.data.conversation.messages[0].parts[0].text).toBe(
+        "Design an indigo kurta"
+      )
+      expect(get.data.conversation.messages[1].role).toBe("assistant")
+    })
+
+    it("defaults the title and messages when omitted", async () => {
+      const post = await api.post(
+        "/store/custom/design-assistant/conversations",
+        {
+          customer_email: MAKER_EMAIL,
+          thread_key: THREAD_KEY,
+        },
+        storeHeaders
+      )
+      expect(post.status).toBe(201)
+      expect(post.data.conversation.title).toBe("New chat")
+      expect(post.data.conversation.messages).toEqual([])
+    })
+
+    it("lists scoped conversations newest first, light shape (no bodies)", async () => {
+      await api.post(
+        "/store/custom/design-assistant/conversations",
+        { customer_email: MAKER_EMAIL, thread_key: THREAD_KEY, title: "First" },
+        storeHeaders
+      )
+      // Small delay so updated_at ordering is unambiguous.
+      await new Promise((r) => setTimeout(r, 20))
+      await api.post(
+        "/store/custom/design-assistant/conversations",
+        { customer_email: MAKER_EMAIL, thread_key: THREAD_KEY, title: "Second" },
+        storeHeaders
+      )
+
+      const list = await api.get(
+        `/store/custom/design-assistant/conversations?${scopeQuery}`,
+        storeHeaders
+      )
+      expect(list.status).toBe(200)
+      expect(list.data.count).toBe(2)
+      expect(list.data.conversations[0].title).toBe("Second")
+      expect(list.data.conversations[0].messages).toBeUndefined()
+    })
+
+    it("isolates threads by thread key (same maker, different scope)", async () => {
+      await api.post(
+        "/store/custom/design-assistant/conversations",
+        { customer_email: MAKER_EMAIL, thread_key: THREAD_KEY, title: "Kurta" },
+        storeHeaders
+      )
+      await api.post(
+        "/store/custom/design-assistant/conversations",
+        {
+          customer_email: MAKER_EMAIL,
+          thread_key: "custom",
+          title: "Standalone",
+        },
+        storeHeaders
+      )
+
+      const kurtaList = await api.get(
+        `/store/custom/design-assistant/conversations?${scopeQuery}`,
+        storeHeaders
+      )
+      expect(kurtaList.data.count).toBe(1)
+      expect(kurtaList.data.conversations[0].title).toBe("Kurta")
+
+      const customList = await api.get(
+        `/store/custom/design-assistant/conversations?customer_email=${encodeURIComponent(MAKER_EMAIL)}&thread_key=custom`,
+        storeHeaders
+      )
+      expect(customList.data.count).toBe(1)
+      expect(customList.data.conversations[0].title).toBe("Standalone")
+    })
+
+    it("PATCH persists messages and links the design (first generation)", async () => {
+      const post = await api.post(
+        "/store/custom/design-assistant/conversations",
+        { customer_email: MAKER_EMAIL, thread_key: THREAD_KEY, title: "Draft" },
+        storeHeaders
+      )
+      const id = post.data.conversation.id
+
+      const res = await api.patch(
+        `/store/custom/design-assistant/conversations/${id}`,
+        {
+          customer_email: MAKER_EMAIL,
+          thread_key: THREAD_KEY,
+          design_id: "01M16TESTDESIGNROW",
+          messages: SAMPLE_MESSAGES,
+        },
+        storeHeaders
+      )
+      expect(res.status).toBe(200)
+      expect(res.data.conversation.design_id).toBe("01M16TESTDESIGNROW")
+      expect(res.data.conversation.messages).toHaveLength(2)
+
+      const get = await api.get(
+        `/store/custom/design-assistant/conversations/${id}?${scopeQuery}`,
+        storeHeaders
+      )
+      expect(get.data.conversation.design_id).toBe("01M16TESTDESIGNROW")
+    })
+
+    it("404s a conversation for a different maker email (isolation)", async () => {
+      const post = await api.post(
+        "/store/custom/design-assistant/conversations",
+        {
+          customer_email: MAKER_EMAIL,
+          thread_key: THREAD_KEY,
+          title: "Private",
+        },
+        storeHeaders
+      )
+      const id = post.data.conversation.id
+
+      const wrongEmail = `customer_email=${encodeURIComponent("other@jyt.test")}&thread_key=${encodeURIComponent(THREAD_KEY)}`
+      const get = await api
+        .get(
+          `/store/custom/design-assistant/conversations/${id}?${wrongEmail}`,
+          storeHeaders
+        )
+        .catch((e: any) => e.response)
+      expect(get.status).toBe(404)
+
+      const patch = await api
+        .patch(
+          `/store/custom/design-assistant/conversations/${id}`,
+          {
+            customer_email: "other@jyt.test",
+            thread_key: THREAD_KEY,
+            title: "Hijack",
+          },
+          storeHeaders
+        )
+        .catch((e: any) => e.response)
+      expect(patch.status).toBe(404)
+
+      const del = await api
+        .delete(`/store/custom/design-assistant/conversations/${id}`, {
+          headers: {
+            ...storeHeaders.headers,
+            "Content-Type": "application/json",
+          },
+          data: { customer_email: "other@jyt.test", thread_key: THREAD_KEY },
+        })
+        .catch((e: any) => e.response)
+      expect(del.status).toBe(404)
+
+      // The real maker still reads it fine.
+      const owner = await api.get(
+        `/store/custom/design-assistant/conversations/${id}?${scopeQuery}`,
+        storeHeaders
+      )
+      expect(owner.status).toBe(200)
+    })
+
+    it("deletes a conversation for the owning maker", async () => {
+      const post = await api.post(
+        "/store/custom/design-assistant/conversations",
+        { customer_email: MAKER_EMAIL, thread_key: THREAD_KEY, title: "Gone" },
+        storeHeaders
+      )
+      const id = post.data.conversation.id
+
+      const del = await api.delete(
+        `/store/custom/design-assistant/conversations/${id}`,
+        {
+          headers: {
+            ...storeHeaders.headers,
+            "Content-Type": "application/json",
+          },
+          data: { customer_email: MAKER_EMAIL, thread_key: THREAD_KEY },
+        }
+      )
+      expect(del.status).toBe(200)
+      expect(del.data.deleted).toBe(true)
+
+      const get = await api
+        .get(
+          `/store/custom/design-assistant/conversations/${id}?${scopeQuery}`,
+          storeHeaders
+        )
+        .catch((e: any) => e.response)
+      expect(get.status).toBe(404)
+    })
+
+    it("rejects scope-less creates (missing email or thread key)", async () => {
+      const noEmail = await api
+        .post(
+          "/store/custom/design-assistant/conversations",
+          { thread_key: THREAD_KEY },
+          storeHeaders
+        )
+        .catch((e: any) => e.response)
+      expect(noEmail.status).toBe(400)
+
+      const noThread = await api
+        .post(
+          "/store/custom/design-assistant/conversations",
+          { customer_email: MAKER_EMAIL },
+          storeHeaders
+        )
+        .catch((e: any) => e.response)
+      expect(noThread.status).toBe(400)
+    })
+
+    it("pick API requires design_id and canvas_id", async () => {
+      const missing = await api
+        .post("/store/custom/design-assistant/pick", {}, storeHeaders)
+        .catch((e: any) => e.response)
+      expect([400, 404, 500].includes(missing.status)).toBe(true)
+      expect(missing.status).not.toBe(200)
+    })
+
+    it("pick API surfaces a readable error for an unknown design", async () => {
+      const res = await api
+        .post(
+          "/store/custom/design-assistant/pick",
+          {
+            design_id: "01M16UNKNOWNDESIGNROW",
+            canvas_id: "cv-unknown",
+          },
+          storeHeaders
+        )
+        .catch((e: any) => e.response)
+      // runSetActiveCanvas 404s unknown designs — surfaced as NOT_FOUND.
+      expect([400, 404].includes(res.status)).toBe(true)
+    })
+  })
+})

--- a/apps/backend/integration-tests/http/storefront-design-chat-real.spec.ts
+++ b/apps/backend/integration-tests/http/storefront-design-chat-real.spec.ts
@@ -1,0 +1,310 @@
+import { Modules } from "@medusajs/utils"
+import { getSharedTestEnv, setupSharedTestSuite } from "./shared-test-setup"
+import { createAdminUser, getAuthHeaders } from "../helpers/create-admin-user"
+import {
+  createApiKeysWorkflow,
+  linkSalesChannelsToApiKeyWorkflow,
+} from "@medusajs/medusa/core-flows"
+
+jest.setTimeout(180 * 1000)
+
+/**
+ * Real, end-to-end storefront design chat — the streaming `POST /store/ai/chat`
+ * route in DESIGN mode, driven by a live model.
+ *
+ * This is NOT a mock test: it walks the full pipeline the storefront design
+ * editor uses (validate → resolve provider → build the designer-guide system
+ * prompt → bind the design tools → streamText → pipe SSE), and asserts on what
+ * a REAL provider streams back.
+ *
+ * Provider resolution for role `ai_search_chat` (see storefront-chat.ts):
+ *   1. DB-configured platform for the role (admin picks) — primary
+ *   2. DashScope           — DASHSCOPE_API_KEY
+ *   3. Cloudflare Workers AI — CLOUDFLARE_AI_ACCOUNT_ID + CLOUDFLARE_AI_TOKEN
+ *   4. OpenRouter free     — OPENROUTER_API_KEY (last resort)
+ *
+ * The route returns 503 "AI chat is not configured" when none resolve. The
+ * suite is gated so CI (no keys, no platform row) skips it — the same reason
+ * ai-chat-workflow.spec.ts gates on OPENROUTER_API_KEY. Set any of the env
+ * pairs (or configure an `ai_search_chat` platform in the DB) to run locally.
+ */
+const HAS_PROVIDER =
+  Boolean(
+    process.env.CLOUDFLARE_AI_ACCOUNT_ID && process.env.CLOUDFLARE_AI_TOKEN
+  ) ||
+  Boolean(process.env.DASHSCOPE_API_KEY) ||
+  Boolean(process.env.OPENROUTER_API_KEY)
+const describeReal = HAS_PROVIDER ? describe : describe.skip
+
+/**
+ * Sample garment image for the analysis-first flow.
+ *
+ * The vision tool (`analyze_product_image` → `describe-product-image`) sends
+ * the image to the `ai_product_description` provider over HTTP, so the image
+ * must be a URL the provider can fetch (or a `data:` URL for Cloudflare, which
+ * only accepts base64). A local file therefore can't be dropped in directly:
+ *   - HEIC is not a format vision providers read (convert to JPEG first);
+ *   - a local path is unreachable by the provider (needs a public URL).
+ *
+ * To run against your own garment photo, convert it and set:
+ *   SAMPLE_IMAGE_URL=https://…/garment.jpg        (or a data:image/jpeg;base64,… URL)
+ *
+ * Defaults to a stable, always-on free placeholder (picsum) so CI and local
+ * runs both work without any upload step.
+ */
+const SAMPLE_IMAGE_URL =
+  process.env.SAMPLE_IMAGE_URL ||
+  "https://picsum.photos/seed/jyt-garment/800/1000"
+
+// ── SSE parsing ─────────────────────────────────────────────────────────
+// pipeUIMessageStreamToResponse frames each chunk as `data: {json}\n\n` and
+// terminates with `data: [DONE]\n\n`. Parse the buffered body back into the
+// chunk objects so assertions can target chunk types instead of substrings.
+type UiChunk = { type?: string; [key: string]: any }
+
+const parseSseChunks = (body: string): UiChunk[] => {
+  const chunks: UiChunk[] = []
+  for (const line of body.split("\n")) {
+    if (!line.startsWith("data: ")) continue
+    const payload = line.slice("data: ".length).trim()
+    if (payload === "[DONE]") continue
+    try {
+      chunks.push(JSON.parse(payload))
+    } catch {
+      // ignore malformed frames — the assertions below only need valid ones
+    }
+  }
+  return chunks
+}
+
+const chunkTypes = (chunks: UiChunk[]) => chunks.map((c) => c.type)
+
+const hasText = (chunks: UiChunk[]) =>
+  chunks.some((c) => c.type === "text-delta" && (c.delta ?? "").trim().length > 0)
+
+setupSharedTestSuite(() => {
+  const { api, getContainer } = getSharedTestEnv()
+
+  describeReal("Storefront design chat — real provider, end to end", () => {
+    let storeHeaders: Record<string, any>
+    let adminHeaders: Record<string, any>
+    let salesChannelId: string | undefined
+
+    const MAKER_EMAIL = "realchat@jyt.test"
+    const VISITOR_ID = "realchat-visitor"
+
+    const designBody = (text: string, context?: Record<string, any>) => ({
+      visitor_id: VISITOR_ID,
+      prefs: {
+        colors: ["indigo", "natural"],
+        materials: ["cotton"],
+        body: { fit: "relaxed" as const },
+      },
+      context: { email: MAKER_EMAIL, ...(context ?? {}) },
+      messages: [
+        {
+          id: "u1",
+          role: "user" as const,
+          parts: [{ type: "text", text }],
+        },
+      ],
+    })
+
+    beforeAll(async () => {
+      const container = getContainer()
+      await createAdminUser(container)
+      adminHeaders = await getAuthHeaders(api)
+
+      // Register the chat model through the AI provider settings — the same
+      // path production uses (Admin → External Platforms, role ai_search_chat).
+      // The route prefers this platform over the env-fallback chain, so this
+      // proves the real provider-settings resolution, not just the fallback.
+      const cfToken = process.env.CLOUDFLARE_AI_TOKEN
+      const cfAccountId = process.env.CLOUDFLARE_AI_ACCOUNT_ID
+      const model =
+        process.env.STOREFRONT_CHAT_CLOUDFLARE_MODEL || "@cf/moonshotai/kimi-k2.6"
+      if (cfToken && cfAccountId) {
+        await api.post(
+          "/admin/social-platforms",
+          {
+            name: "Cloudflare AI — design chat test",
+            category: "ai",
+            auth_type: "bearer",
+            status: "active",
+            api_config: {
+              api_key: cfToken,
+              account_id: cfAccountId,
+              default_model: model,
+            },
+            metadata: {
+              provider_type: "cloudflare",
+              role: "ai_search_chat",
+              is_default: true,
+            },
+          },
+          adminHeaders
+        )
+      }
+
+      // Publishable API key required for /store/* routes, linked to the
+      // default sales channel — mirror of the design-assistant conversations
+      // spec and design-production-story.spec.ts.
+      const { result: apiKeys } = await createApiKeysWorkflow(container).run({
+        input: {
+          api_keys: [
+            {
+              type: "publishable",
+              title: "Design Chat Real Provider Test Key",
+              created_by: "admin",
+            },
+          ],
+        },
+      })
+      const pubKey = apiKeys[0]
+      const storeService = container.resolve(Modules.STORE) as any
+      const stores = await storeService.listStores({})
+      salesChannelId = stores?.[0]?.default_sales_channel_id
+      if (salesChannelId) {
+        await linkSalesChannelsToApiKeyWorkflow(container).run({
+          input: {
+            id: pubKey.id,
+            add: [salesChannelId],
+          },
+        })
+      }
+      storeHeaders = { headers: { "x-publishable-api-key": pubKey.token } }
+    })
+
+    it("streams a real reply for a design-chat turn (brief)", async () => {
+      const res = await api.post(
+        "/store/ai/chat",
+        designBody(
+          "I want to design an indigo cotton kurta with a relaxed fit. What should we call it?"
+        ),
+        { ...storeHeaders, responseType: "text" as const }
+      )
+
+      expect(res.status).toBe(200)
+      expect(res.headers["content-type"]).toMatch(/text\/event-stream/)
+
+      const chunks = parseSseChunks(String(res.data))
+      const types = chunkTypes(chunks)
+
+      // A real model streamed actual text…
+      expect(types).toContain("text-start")
+      expect(hasText(chunks)).toBe(true)
+
+      // …and the stream finished cleanly, without a provider/stream error.
+      expect(types).toContain("finish")
+      expect(types).not.toContain("error")
+    })
+
+    it("binds the design catalog tools and answers a fabric question", async () => {
+      // One turn naming a garment AND asking to browse fabrics, with the
+      // maker's email in context — so the turn planner lets the model browse
+      // (garment on the board, email captured) and it should ground its reply
+      // by calling list_raw_materials instead of just asking for a garment.
+      const res = await api.post(
+        "/store/ai/chat",
+        designBody(
+          "I want an indigo cotton kurta. Great — now what cotton fabrics can we make it from?"
+        ),
+        { ...storeHeaders, responseType: "text" as const }
+      )
+
+      expect(res.status).toBe(200)
+      const chunks = parseSseChunks(String(res.data))
+      const types = chunkTypes(chunks)
+
+      // The design tools are wired in: the model invoked at least one design
+      // tool to ground its answer (list_raw_materials / save_brief / …). The
+      // turn completes cleanly; a long tool chain can exhaust output tokens
+      // before a final prose chunk, so tool invocation — not prose — is the
+      // success signal here.
+      const designTools = [
+        "list_raw_materials",
+        "list_partners",
+        "save_brief",
+        "create_design",
+        "analyze_product_image",
+        "save_moodboard",
+      ]
+      const fired = chunks
+        .filter((c) => c.type === "tool-input-start" || c.type === "tool-input-available")
+        .map((c) => c.toolName)
+        .filter((n) => designTools.includes(n))
+
+      expect(types).toContain("finish")
+      expect(types).not.toContain("error")
+      expect(fired.length > 0 || hasText(chunks)).toBe(true)
+
+      // eslint-disable-next-line no-console
+      console.log(
+        `[storefront-design-chat-real] fabric turn fired tools: ${fired.join(", ") || "(none — model answered in prose)"}`
+      )
+    })
+
+    it("grounds the design on a product image (analysis-first flow)", async () => {
+      // Seed a real garment with the sample image so the design context can
+      // server-resolve it and inject the image into the designer-guide prompt.
+      const ts = Date.now()
+      const prodRes = await api.post(
+        "/admin/products",
+        {
+          title: `Design Chat Garment ${ts}`,
+          handle: `design-chat-garment-${ts}`,
+          status: "published",
+          thumbnail: SAMPLE_IMAGE_URL,
+          images: [{ url: SAMPLE_IMAGE_URL }],
+          sales_channels: salesChannelId ? [{ id: salesChannelId }] : undefined,
+          options: [{ title: "Size", values: ["M"] }],
+          variants: [
+            {
+              title: "M",
+              options: { Size: "M" },
+              manage_inventory: false,
+              prices: [{ amount: 5000, currency_code: "usd" }],
+            },
+          ],
+        },
+        adminHeaders
+      )
+      const productId = prodRes.data.product.id
+
+      const res = await api.post(
+        "/store/ai/chat",
+        designBody(
+          "What do you see in this garment? I want to design something inspired by it.",
+          { product_id: productId }
+        ),
+        { ...storeHeaders, responseType: "text" as const }
+      )
+
+      expect(res.status).toBe(200)
+      const chunks = parseSseChunks(String(res.data))
+      const types = chunkTypes(chunks)
+
+      // The designer-guide grounded on the real product image and replied.
+      expect(types).toContain("text-start")
+      expect(hasText(chunks)).toBe(true)
+      expect(types).toContain("finish")
+      expect(types).not.toContain("error")
+
+      // Informational — the analysis-first flow asks the model to call
+      // analyze_product_image. Whether that produced a result depends on the
+      // configured `ai_product_description` vision provider (none is seeded
+      // here, so the tool degrades gracefully and the model grounds on the
+      // product title/description instead).
+      const analyzed = chunks.filter(
+        (c) =>
+          c.type === "tool-input-start" &&
+          (c.toolName ?? "") === "analyze_product_image"
+      )
+      const toolErrors = chunks.filter((c) => c.type === "tool-output-error")
+      // eslint-disable-next-line no-console
+      console.log(
+        `[storefront-design-chat-real] analysis-first turn: analyze_product_image fired=${analyzed.length > 0}, tool-output-error=${toolErrors.length > 0}`
+      )
+    })
+  })
+})

--- a/apps/backend/integration-tests/http/storefront-design-flow.spec.ts
+++ b/apps/backend/integration-tests/http/storefront-design-flow.spec.ts
@@ -1,0 +1,166 @@
+import { ContainerRegistrationKeys, Modules } from "@medusajs/framework/utils"
+import { createAdminUser, getAuthHeaders } from "../helpers/create-admin-user"
+import { getSharedTestEnv, setupSharedTestSuite } from "./shared-test-setup"
+import {
+  createApiKeysWorkflow,
+  linkSalesChannelsToApiKeyWorkflow,
+} from "@medusajs/medusa/core-flows"
+import {
+  runListRawMaterials,
+  runListPartners,
+} from "../../src/mastra/agents/tools/storefront-design-catalog"
+import { runGenerateDesignImage } from "../../src/mastra/agents/tools/storefront-design-flow"
+import { PARTNER_MODULE } from "../../src/modules/partner"
+import { DESIGN_MODULE } from "../../src/modules/designs"
+
+jest.setTimeout(180 * 1000)
+
+/**
+ * Storefront design flow — the deterministic, non-LLM legs of the chat design
+ * editor: fabric selection, partner selection, image generation, and the
+ * on-the-fly reference analysis. These are the tool bodies the chat binds, so
+ * they're exercised directly against the container (no model flakiness).
+ *
+ * Image generation uses the Mastra imagegen workflow, which in a test
+ * environment returns a sample image when NO image-gen credentials are present
+ * (the CI stub — no token needed) and does a REAL Cloudflare FLUX call when
+ * CLOUDFLARE_AI_* / an `ai_image_gen` platform IS configured. Either way the
+ * downstream pipeline (media upload → board canvases → thumbnail) runs for real.
+ */
+
+const SAMPLE_IMAGE_URL =
+  process.env.SAMPLE_IMAGE_URL ||
+  "https://picsum.photos/seed/jyt-garment/800/1000"
+
+setupSharedTestSuite(() => {
+  const { api, getContainer } = getSharedTestEnv()
+
+  describe("Storefront design flow — fabrics, partners, generation, analysis", () => {
+    let adminHeaders: Record<string, any>
+    let storeHeaders: Record<string, any>
+    let container: any
+
+    beforeAll(async () => {
+      container = getContainer()
+      await createAdminUser(container)
+      adminHeaders = await getAuthHeaders(api)
+
+      // Publishable key (required for /store/custom/* routes).
+      const { result: apiKeys } = await createApiKeysWorkflow(container).run({
+        input: {
+          api_keys: [
+            { type: "publishable", title: "Design Flow Test Key", created_by: "admin" },
+          ],
+        },
+      })
+      const pubKey = apiKeys[0]
+      const storeService = container.resolve(Modules.STORE) as any
+      const stores = await storeService.listStores({})
+      if (stores?.[0]?.default_sales_channel_id) {
+        await linkSalesChannelsToApiKeyWorkflow(container).run({
+          input: { id: pubKey.id, add: [stores[0].default_sales_channel_id] },
+        })
+      }
+      storeHeaders = { headers: { "x-publishable-api-key": pubKey.token } }
+
+      // Seed a design-selectable fabric: inventory item + raw material link.
+      const invRes = await api.post(
+        "/admin/inventory-items",
+        { title: "Indigo Cotton", description: "handwoven indigo cotton" },
+        adminHeaders
+      )
+      const inventoryItemId = invRes.data.inventory_item.id
+      const rawMaterialService = container.resolve("raw_materials") as any
+      const rm = await rawMaterialService.createRawMaterials({
+        name: "Indigo Handwoven Cotton",
+        description: "natural slub",
+        composition: "100% Cotton",
+        color: "indigo",
+        unit_of_measure: "Meter",
+        status: "Active",
+      })
+      const remoteLink = container.resolve(ContainerRegistrationKeys.LINK) as any
+      await remoteLink.create([
+        {
+          [Modules.INVENTORY]: { inventory_item_id: inventoryItemId },
+          raw_materials: { raw_materials_id: rm.id },
+        },
+      ])
+
+      // Seed a verified manufacturer partner.
+      const partnerService = container.resolve(PARTNER_MODULE) as any
+      await partnerService.createPartners({
+        name: "Weave & Sew Co",
+        handle: `weave-sew-${Date.now()}`,
+        status: "active",
+        is_verified: true,
+        workspace_type: "manufacturer",
+      })
+    })
+
+    it("list_raw_materials returns the seeded fabric", async () => {
+      const res = await runListRawMaterials(container, "indigo", 10)
+      expect(res.materials.some((m: any) => m.name === "Indigo Handwoven Cotton")).toBe(true)
+    })
+
+    it("list_partners returns the seeded verified partner with its path role", async () => {
+      const res = await runListPartners(container, "weave", 10)
+      const hit = res.partners.find((p: any) => p.name === "Weave & Sew Co")
+      expect(hit).toBeTruthy()
+      expect(hit!.path).toBe("Manufacturer")
+      expect(hit!.workspace_type).toBe("manufacturer")
+    })
+
+    it("generate_design_image produces two A/B takes and saves media + thumbnail", async () => {
+      const result = await runGenerateDesignImage(container, {
+        email: "flow@jyt.test",
+        name: "Indigo Kurta",
+        brief: {
+          product_type: "kurta",
+          concept_theme: "Indigo handwoven",
+          aesthetic_keywords: ["handwoven", "natural"],
+          color_palette: [{ name: "indigo", code: "#1e3a5f" }],
+        },
+        materials_prompt: "indigo handwoven cotton, natural slub",
+        badges: { style: "relaxed", color_family: "indigo" },
+      })
+
+      expect(result.design_id).toBeTruthy()
+      expect(result.created_design).toBe(true)
+      expect(result.candidates).toHaveLength(2)
+      expect(result.candidates[0].letter).toBe("A")
+      expect(result.candidates[1].letter).toBe("B")
+      for (const c of result.candidates) {
+        expect(c.image_url).toBeTruthy()
+        expect(c.prompt_used).toBeTruthy()
+      }
+
+      // The design was persisted with its board canvases + a thumbnail.
+      const designService = container.resolve(DESIGN_MODULE) as any
+      const design = await designService.retrieveDesign(result.design_id)
+      expect(design).toBeTruthy()
+      expect(design.thumbnail_url).toBeTruthy()
+      expect(design.moodboard).toBeTruthy()
+    })
+
+    it("analyzes a shared reference image and returns a shaped analysis", async () => {
+      const res = await api.post(
+        "/store/custom/design-assistant/references/analyze",
+        { url: SAMPLE_IMAGE_URL },
+        storeHeaders
+      )
+
+      expect(res.status).toBe(200)
+      expect(res.data.url).toBe(SAMPLE_IMAGE_URL)
+      // Best-effort vision: always a well-shaped object even when no vision
+      // provider is configured (title/description empty strings, suggestions []).
+      expect(res.data.analysis).toEqual(
+        expect.objectContaining({
+          title: expect.any(String),
+          description: expect.any(String),
+          suggestions: expect.any(Array),
+        })
+      )
+    })
+  })
+})

--- a/apps/backend/integration-tests/http/storefront-design-flow.spec.ts
+++ b/apps/backend/integration-tests/http/storefront-design-flow.spec.ts
@@ -135,12 +135,63 @@ setupSharedTestSuite(() => {
         expect(c.prompt_used).toBeTruthy()
       }
 
+      /**
+       * 🔴 The prompt has to be about the GARMENT THEY ASKED FOR.
+       *
+       * `expect(prompt_used).toBeTruthy()` was the whole assertion, and it
+       * passed while the generator produced a pastel pink blouse and a pastel
+       * blue denim jacket for this indigo kurta brief — because the brief was
+       * never passed to it and the enhancer's style context defaulted to the
+       * literal string "casual fashion".
+       *
+       * A truthy string is not a correct one. This is the difference between
+       * "an image came back" and "the design came back", and it is the only
+       * thing the maker actually judges the feature on.
+       *
+       * ⚠️ Asserted on the GARMENT and nothing else. My first version of this
+       * matched `/kurta|indigo|handwoven/` and passed with the brief removed —
+       * because "indigo handwoven cotton" is also this fixture's
+       * `materials_prompt`, which reaches the enhancer by a different route.
+       * The alternation made the test agree with both versions of the code.
+       * `kurta` comes from `brief.product_type` and from nowhere else.
+       */
+      const prompts = result.candidates.map((c) => c.prompt_used.toLowerCase())
+      for (const p of prompts) {
+        expect(p).toMatch(/kurta/)
+      }
+
       // The design was persisted with its board canvases + a thumbnail.
       const designService = container.resolve(DESIGN_MODULE) as any
       const design = await designService.retrieveDesign(result.design_id)
       expect(design).toBeTruthy()
       expect(design.thumbnail_url).toBeTruthy()
       expect(design.moodboard).toBeTruthy()
+    })
+
+    /**
+     * 🔴 The guard the fix above must NOT have weakened.
+     *
+     * `kind` is normalised to "initial" when absent, because the schema
+     * defaults it and only the tool path parses. But an EXPLICIT revision with
+     * no picked take still has nothing to iterate on, and generating anyway
+     * would silently re-roll from the brief while telling the maker it built on
+     * their pick — a different garment under the label of the one they chose.
+     */
+    it("🔴 an explicit revision with no picked take is still refused", async () => {
+      await expect(
+        runGenerateDesignImage(container, {
+          email: "flow@jyt.test",
+          name: "Indigo Kurta — revision",
+          kind: "revision",
+          change_request: "make the sleeves fuller",
+          brief: {
+            product_type: "kurta",
+            concept_theme: "Indigo handwoven",
+            aesthetic_keywords: ["handwoven"],
+            color_palette: [{ name: "indigo", code: "#1e3a5f" }],
+          },
+        })
+      ).rejects.toThrow(/Pick one of the takes first/)
     })
 
     it("analyzes a shared reference image and returns a shaped analysis", async () => {

--- a/apps/backend/medusa-config.prod.ts
+++ b/apps/backend/medusa-config.prod.ts
@@ -579,7 +579,12 @@ module.exports = defineConfig({
       resolve: "./src/modules/partner-assistant",
     },
     {
-      resolve: "./src/modules/admin-assistant",
+      resolve: "./src/modules/admin-assistant",,
+    {
+      // Chat design editor — per-design chat thread history (email-scoped
+      // mirror of admin-assistant).
+      resolve: "./src/modules/storefront-design-assistant",
+    }
     },
     {
       // The assistants' cross-conversation context cache. Registered in BOTH

--- a/apps/backend/medusa-config.prod.ts
+++ b/apps/backend/medusa-config.prod.ts
@@ -579,12 +579,12 @@ module.exports = defineConfig({
       resolve: "./src/modules/partner-assistant",
     },
     {
-      resolve: "./src/modules/admin-assistant",,
+      resolve: "./src/modules/admin-assistant",
+    },
     {
       // Chat design editor — per-design chat thread history (email-scoped
       // mirror of admin-assistant).
       resolve: "./src/modules/storefront-design-assistant",
-    }
     },
     {
       // The assistants' cross-conversation context cache. Registered in BOTH

--- a/apps/backend/medusa-config.ts
+++ b/apps/backend/medusa-config.ts
@@ -188,6 +188,12 @@ module.exports = defineConfig({
       resolve: "./src/modules/admin-assistant",
     },
     {
+      // Chat design editor — per-design chat thread history (email-scoped
+      // mirror of admin-assistant). Registered in BOTH config files: prod
+      // loads its own, so a module listed only here is absent on ECS.
+      resolve: "./src/modules/storefront-design-assistant",
+    },
+    {
       // The assistants' cross-conversation context cache. Registered in BOTH
       // config files: prod loads its own, so a module listed only here is
       // absent on ECS, and the chat routes resolve it on every turn.

--- a/apps/backend/src/api/middlewares.ts
+++ b/apps/backend/src/api/middlewares.ts
@@ -2750,6 +2750,17 @@ export default defineMiddlewares({
       method: "POST",
       middlewares: [createCorsMiddleware()],
     },
+    {
+      // The board read. Public like the rest of the assistant's store mount and
+      // scoped by the maker's email — the board panel previously read through
+      // the CUSTOMER-authenticated `/store/custom/designs/:id`, which 401s for
+      // every guest, i.e. for everyone this flow is built for.
+      //
+      // ⚠️ A route file without a matcher entry is not a route.
+      matcher: "/store/custom/design-assistant/designs/:id",
+      method: "GET",
+      middlewares: [createCorsMiddleware()],
+    },
     // Customs HS/HSN codes — bulk gap scan + bulk fill. /admin/* is
     // admin-authenticated globally, so only the write body needs validation.
     // The GET still needs its matcher registered: a route file without one is

--- a/apps/backend/src/api/middlewares.ts
+++ b/apps/backend/src/api/middlewares.ts
@@ -203,6 +203,7 @@ import { PartnerAssistantChatSchema } from "./partners/assistant/chat/validators
 import { PartnerAssistantSummarizeSchema } from "./partners/assistant/summarize/validators";
 import { CreateConversationSchema as PartnerCreateConversationSchema, UpdateConversationSchema as PartnerUpdateConversationSchema } from "./partners/assistant/conversations/validators";
 import { CreateConversationSchema as AdminAssistantCreateConversationSchema, UpdateConversationSchema as AdminAssistantUpdateConversationSchema } from "./admin/assistant/conversations/validators";
+import { CreateDesignConversationSchema, UpdateDesignConversationSchema, DeleteDesignConversationSchema } from "./store/custom/design-assistant/conversations/validators";
 import { BulkHsCodesSchema } from "./admin/customs/hs-codes/validators";
 import { BulkUpdateProductsSchema } from "./admin/products/bulk-update/validators";
 import { BulkProductSpecReq } from "./admin/products/spec-bulk/validators";
@@ -2704,6 +2705,50 @@ export default defineMiddlewares({
       middlewares: [
         validateAndTransformBody(wrapSchema(AdminAssistantUpdateConversationSchema)),
       ],
+    },
+    // Storefront design-assistant conversation history (chat design editor)
+    // — server-persisted design threads, email-scoped (public, mirrors the
+    // chat flow's email gate — no customer auth). Validation only.
+    {
+      matcher: "/store/custom/design-assistant/conversations",
+      method: "GET",
+      middlewares: [createCorsMiddleware()],
+    },
+    {
+      matcher: "/store/custom/design-assistant/conversations",
+      method: "POST",
+      middlewares: [
+        createCorsMiddleware(),
+        validateAndTransformBody(wrapSchema(CreateDesignConversationSchema)),
+      ],
+    },
+    {
+      matcher: "/store/custom/design-assistant/conversations/:id",
+      method: "GET",
+      middlewares: [createCorsMiddleware()],
+    },
+    {
+      matcher: "/store/custom/design-assistant/conversations/:id",
+      method: "PATCH",
+      middlewares: [
+        createCorsMiddleware(),
+        validateAndTransformBody(wrapSchema(UpdateDesignConversationSchema)),
+      ],
+    },
+    {
+      matcher: "/store/custom/design-assistant/conversations/:id",
+      method: "DELETE",
+      middlewares: [
+        createCorsMiddleware(),
+        validateAndTransformBody(wrapSchema(DeleteDesignConversationSchema)),
+      ],
+    },
+    {
+      // Deterministic canvas pick (scene panel "Build on this") — reuses the
+      // chat flow's set_active_canvas write without a model turn.
+      matcher: "/store/custom/design-assistant/pick",
+      method: "POST",
+      middlewares: [createCorsMiddleware()],
     },
     // Customs HS/HSN codes — bulk gap scan + bulk fill. /admin/* is
     // admin-authenticated globally, so only the write body needs validation.

--- a/apps/backend/src/api/store/ai/chat/route.ts
+++ b/apps/backend/src/api/store/ai/chat/route.ts
@@ -32,6 +32,24 @@ import {
   buildStorefrontChatSystem,
   resolveStorefrontChatModel,
 } from "../../../../mastra/agents/storefront-chat"
+import {
+  buildDesignChatSystem,
+  type DesignChatContext,
+} from "../../../../mastra/agents/storefront-design-chat"
+import {
+  createListRawMaterialsTool,
+  createListPartnersTool,
+  createAnalyzeProductImageTool,
+} from "../../../../mastra/agents/tools/storefront-design-catalog"
+import {
+  createSaveBriefTool,
+  createCreateDesignTool,
+  createGenerateDesignImageTool,
+  createSetActiveCanvasTool,
+  createGetDesignStateTool,
+  type DesignContext,
+} from "../../../../mastra/agents/tools/storefront-design-flow"
+import { createSaveMoodboardTool } from "../../../../mastra/agents/tools/storefront-design-moodboard"
 import { createSearchProductsTool } from "../../../../mastra/agents/tools/storefront-search-products"
 import {
   createGetCategoriesTool,
@@ -57,13 +75,44 @@ export const POST = async (req: MedusaRequest, res: MedusaResponse) => {
     return
   }
 
-  const system = buildStorefrontChatSystem(body.prefs)
+  // ── Design-editor mode ──
+  // When the request carries a design context (the chat runs inside
+  // /products/:handle/design or /design), the route server-resolves the
+  // referenced product + design (never trusting client prose), switches the
+  // agent into designer-guide mode, and binds the design tools. The concierge
+  // tools stay bound — makers wander into shopping mid-flow.
+  const designContext: DesignContext | undefined = body.context
+  const system = designContext
+    ? await buildDesignChatSystemResolved(
+        req.scope as any,
+        body.prefs,
+        designContext,
+        body.messages
+      )
+    : buildStorefrontChatSystem(body.prefs)
+
   const tools = {
     search_products: createSearchProductsTool(req.scope as any),
     get_categories: createGetCategoriesTool(req.scope as any),
     get_category_products: createGetCategoryProductsTool(req.scope as any),
     get_product_details: createGetProductDetailsTool(req.scope as any),
     capture_contact: createCaptureContactTool(req.scope as any, body.visitor_id),
+    ...(designContext
+      ? {
+          list_raw_materials: createListRawMaterialsTool(req.scope as any),
+          list_partners: createListPartnersTool(req.scope as any),
+          analyze_product_image: createAnalyzeProductImageTool(req.scope as any),
+          save_brief: createSaveBriefTool(),
+          create_design: createCreateDesignTool(req.scope as any, designContext),
+          generate_design_image: createGenerateDesignImageTool(
+            req.scope as any,
+            designContext
+          ),
+          set_active_canvas: createSetActiveCanvasTool(req.scope as any),
+          get_design_state: createGetDesignStateTool(req.scope as any),
+          save_moodboard: createSaveMoodboardTool(req.scope as any),
+        }
+      : {}),
   }
 
   // Normalise the inbound UI messages.
@@ -128,6 +177,10 @@ export const POST = async (req: MedusaRequest, res: MedusaResponse) => {
       // then get_category_products, or search then get_product_details)
       // while still capping runaway tool loops.
       stopWhen: stepCountIs(5),
+      // Keep a ceiling above any normal chat reply (kimi-k2.6, the chat
+      // model, is non-reasoning — probed: proper arrays in tool args,
+      // chained save_brief + capture_contact in one step, 833 tokens).
+      maxOutputTokens: 4096,
       temperature: 0.6,
       onFinish: ({ usage: u }: any) => {
         logAiUsage(logger, {
@@ -176,4 +229,99 @@ export const POST = async (req: MedusaRequest, res: MedusaResponse) => {
   // The SDK handles SSE framing, Content-Type, and flushes — we just
   // hand it the Node ServerResponse Medusa hands us.
   result.pipeUIMessageStreamToResponse(res as any)
+}
+
+
+// ── Server-resolved design context for the system prompt ───────────────
+
+import type { MedusaContainer } from "@medusajs/framework"
+
+/**
+ * Server-resolve the product + design referenced by the design context and
+ * build the designer-guide prompt. Only server data enters the prompt — a
+ * client never gets to inject prose into the system message.
+ */
+const buildDesignChatSystemResolved = async (
+  container: MedusaContainer,
+  prefs: StoreAiChatReq["prefs"],
+  context: DesignContext,
+  messages?: StoreAiChatReq["messages"]
+): Promise<string> => {
+  const promptContext: DesignChatContext = {
+    product_id: context.product_id,
+    design_id: context.design_id,
+    email: context.email,
+  }
+
+  if (context.product_id) {
+    const query = container.resolve(ContainerRegistrationKeys.QUERY)
+    const { data } = await query.graph({
+      entity: "product",
+      filters: { id: context.product_id },
+      fields: ["id", "title", "description", "thumbnail", "images.url"],
+    } as any)
+    const product: any = data?.[0]
+    if (product) {
+      promptContext.product = {
+        title: product.title,
+        description: product.description ?? undefined,
+        thumbnail: product.thumbnail ?? undefined,
+        images: (product.images || []).map((i: any) => i?.url).filter(Boolean),
+      }
+    }
+  }
+
+  if (context.design_id) {
+    const designService: any = container.resolve("design" as any)
+    const design = await designService
+      .retrieveDesign(context.design_id)
+      .catch(() => null)
+    if (design) {
+      promptContext.design = {
+        name: design.name,
+        status: design.status,
+        product_type: design.product_type ?? null,
+        concept_theme: design.concept_theme ?? null,
+        aesthetic_keywords: Array.isArray(design.aesthetic_keywords)
+          ? design.aesthetic_keywords
+          : [],
+        thumbnail_url: design.thumbnail_url ?? undefined,
+      }
+
+      // Moodboard summary — canvas takes + reference analyses — so the agent
+      // is grounded on the board every turn without an extra tool round-trip.
+      const {
+        normalizeCanvasScene,
+        readActiveCanvas,
+        readCanvasElements,
+      } = await import("../../../modules/designs/lib/canvas-scene")
+      const scene = normalizeCanvasScene(design.moodboard)
+      const active = readActiveCanvas(scene)
+      const inspirations = scene.elements
+        .filter((el: any) => el.customData?.source === "inspiration")
+        .slice(0, 8)
+        .map((el: any) => {
+          const a = el.customData?.analysis as
+            | { title?: string; description?: string }
+            | undefined
+          return {
+            title: a?.title ?? null,
+            description: a?.description ?? null,
+          }
+        })
+      promptContext.design.board = {
+        canvas_count: readCanvasElements(scene).length,
+        active_canvas: active?.customData?.canvas
+          ? {
+              letter: active.customData.canvas.letter ?? null,
+              kind: active.customData.canvas.kind,
+              prompt_used: active.customData.canvas.prompt_used,
+            }
+          : null,
+        inspirations,
+      }
+    }
+  }
+
+  return buildDesignChatSystem(prefs, promptContext, messages)
 }

--- a/apps/backend/src/api/store/ai/chat/route.ts
+++ b/apps/backend/src/api/store/ai/chat/route.ts
@@ -294,7 +294,7 @@ const buildDesignChatSystemResolved = async (
         normalizeCanvasScene,
         readActiveCanvas,
         readCanvasElements,
-      } = await import("../../../modules/designs/lib/canvas-scene")
+      } = await import("../../../../modules/designs/lib/canvas-scene.js")
       const scene = normalizeCanvasScene(design.moodboard)
       const active = readActiveCanvas(scene)
       const inspirations = scene.elements

--- a/apps/backend/src/api/store/ai/chat/validators.ts
+++ b/apps/backend/src/api/store/ai/chat/validators.ts
@@ -58,12 +58,27 @@ const PrefsSchema = z
   })
   .partial()
 
+// Optional design-editor context — present when the chat runs inside the
+// design flow (/products/:handle/design or /design). The route resolves the
+// referenced product/design server-side (never trusting client prose) and
+// switches the agent into designer-guide mode with the design tools bound.
+const DesignContextSchema = z.object({
+  product_id: z.string().min(1).max(60).optional(),
+  design_id: z.string().min(1).max(60).optional(),
+  // The maker's email once they have shared it in the flow (guest-customer
+  // resolution on first generation). Optional — the agent asks when needed.
+  email: z.string().max(200).optional(),
+})
+
 export const StoreAiChatSchema = z.object({
   // Capped at 40 turns (20 round-trips) — more than that and the system
   // prompt + brand corpus would dominate tokens anyway.
   messages: z.array(UiMessageSchema).min(1).max(40),
   prefs: PrefsSchema.optional(),
   visitor_id: z.string().min(1).max(80),
+
+  // Design-editor context (see DesignContextSchema).
+  context: DesignContextSchema.optional(),
 
   // ──────────────────────────────────────────────────────────────────
   // AI SDK v6 (`useChat`) sends these extra top-level fields on every

--- a/apps/backend/src/api/store/custom/design-assistant/conversations/[id]/route.ts
+++ b/apps/backend/src/api/store/custom/design-assistant/conversations/[id]/route.ts
@@ -1,0 +1,73 @@
+/**
+ * Storefront design-assistant conversation — single-resource ops.
+ *
+ *   GET    /store/custom/design-assistant/conversations/:id  → full thread
+ *   PATCH  /store/custom/design-assistant/conversations/:id  → rename / persist
+ *            messages / link the design (once first generation creates it)
+ *   DELETE /store/custom/design-assistant/conversations/:id  → delete
+ *
+ * Email-scoped: the service 404s a thread that isn't the maker email's, so
+ * ids aren't cross-maker readable. Mirrors /admin/assistant/conversations/:id.
+ */
+import {
+  AuthenticatedMedusaRequest,
+  MedusaResponse,
+} from "@medusajs/framework/http"
+import { STOREFRONT_DESIGN_ASSISTANT_MODULE } from "../../../../../../modules/storefront-design-assistant"
+import type {
+  DeleteDesignConversationInput,
+  UpdateDesignConversationInput,
+} from "../validators"
+
+export const GET = async (
+  req: AuthenticatedMedusaRequest,
+  res: MedusaResponse
+) => {
+  const query = req.query as { customer_email?: string; thread_key?: string }
+  const service: any = req.scope.resolve(STOREFRONT_DESIGN_ASSISTANT_MODULE)
+  const conversation = await service.getConversationForScope(
+    {
+      customer_email: query.customer_email ?? "",
+      thread_key: query.thread_key ?? "",
+    },
+    req.params.id
+  )
+  return res.status(200).json({ conversation })
+}
+
+export const PATCH = async (
+  req: AuthenticatedMedusaRequest<UpdateDesignConversationInput>,
+  res: MedusaResponse
+) => {
+  const body = req.validatedBody as UpdateDesignConversationInput
+  const service: any = req.scope.resolve(STOREFRONT_DESIGN_ASSISTANT_MODULE)
+  const conversation = await service.updateConversationForScope(
+    {
+      customer_email: body.customer_email,
+      thread_key: body.thread_key,
+    },
+    req.params.id,
+    {
+      title: body.title,
+      design_id: body.design_id,
+      messages: body.messages,
+    }
+  )
+  return res.status(200).json({ conversation })
+}
+
+export const DELETE = async (
+  req: AuthenticatedMedusaRequest<DeleteDesignConversationInput>,
+  res: MedusaResponse
+) => {
+  const body = req.validatedBody as DeleteDesignConversationInput
+  const service: any = req.scope.resolve(STOREFRONT_DESIGN_ASSISTANT_MODULE)
+  await service.deleteConversationForScope(
+    {
+      customer_email: body.customer_email,
+      thread_key: body.thread_key,
+    },
+    req.params.id
+  )
+  return res.status(200).json({ deleted: true })
+}

--- a/apps/backend/src/api/store/custom/design-assistant/conversations/route.ts
+++ b/apps/backend/src/api/store/custom/design-assistant/conversations/route.ts
@@ -1,0 +1,60 @@
+/**
+ * Storefront design-assistant conversation history (chat design editor).
+ *
+ *   GET  /store/custom/design-assistant/conversations  → this maker's threads
+ *        for a thread key (light: no message bodies)
+ *   POST /store/custom/design-assistant/conversations  → create a thread
+ *
+ * Server-persisted so a maker's design threads follow them across devices and
+ * survive localStorage clears; reopening replays the thread exactly and
+ * continues it. The chat endpoint itself stays stateless — the design-chat
+ * client writes the message array back here after each completed turn.
+ *
+ * Public (no customer auth) — mirrors the chat flow's email gate. Scoping is
+ * by normalised maker email + thread key (the service normalises + asserts).
+ * Mirrors /admin/assistant/conversations (#1092).
+ */
+import {
+  AuthenticatedMedusaRequest,
+  MedusaResponse,
+} from "@medusajs/framework/http"
+import { STOREFRONT_DESIGN_ASSISTANT_MODULE } from "../../../../../modules/storefront-design-assistant"
+import type { CreateDesignConversationInput } from "./validators"
+
+export const GET = async (
+  req: AuthenticatedMedusaRequest,
+  res: MedusaResponse
+) => {
+  const query = req.query as { customer_email?: string; thread_key?: string }
+  const service: any = req.scope.resolve(STOREFRONT_DESIGN_ASSISTANT_MODULE)
+  const conversations = await service.listConversationsForScope({
+    customer_email: query.customer_email ?? "",
+    thread_key: query.thread_key ?? "",
+  })
+
+  return res.status(200).json({
+    conversations,
+    count: conversations.length,
+  })
+}
+
+export const POST = async (
+  req: AuthenticatedMedusaRequest<CreateDesignConversationInput>,
+  res: MedusaResponse
+) => {
+  const body = req.validatedBody as CreateDesignConversationInput
+  const service: any = req.scope.resolve(STOREFRONT_DESIGN_ASSISTANT_MODULE)
+  const conversation = await service.createConversationForScope(
+    {
+      customer_email: body.customer_email,
+      thread_key: body.thread_key,
+    },
+    {
+      title: body.title,
+      design_id: body.design_id,
+      messages: body.messages,
+    }
+  )
+
+  return res.status(201).json({ conversation })
+}

--- a/apps/backend/src/api/store/custom/design-assistant/conversations/validators.ts
+++ b/apps/backend/src/api/store/custom/design-assistant/conversations/validators.ts
@@ -1,0 +1,62 @@
+import { z } from "@medusajs/framework/zod"
+
+/**
+ * Body schemas for the storefront design-assistant conversation API
+ * (`/store/custom/design-assistant/conversations`).
+ *
+ * A persisted UI message (AI-SDK shape). Kept permissive (passthrough) — the
+ * chat endpoint owns the canonical normalisation; here we only store what the
+ * client sends so a conversation replays exactly.
+ */
+const StoredMessageSchema = z
+  .object({
+    id: z.string().optional(),
+    role: z.enum(["system", "user", "assistant"]),
+    content: z.string().optional(),
+    parts: z.array(z.object({ type: z.string() }).passthrough()).optional(),
+  })
+  .passthrough()
+
+const ScopeSchema = z.object({
+  // The maker's email — the flow's gate. Scopes every read/write.
+  customer_email: z.string().trim().min(3).max(200),
+  // Base-product thread scope matching the storefront thread keys
+  // (`product:{id}` or `custom`).
+  thread_key: z.string().trim().min(1).max(80),
+})
+
+export const CreateDesignConversationSchema = ScopeSchema.and(
+  z.object({
+    title: z.string().trim().min(1).max(200).optional(),
+    design_id: z.string().min(1).max(60).optional(),
+    messages: z.array(StoredMessageSchema).max(200).optional(),
+  })
+)
+
+export const UpdateDesignConversationSchema = ScopeSchema.and(
+  z
+    .object({
+      title: z.string().trim().min(1).max(200).optional(),
+      design_id: z.string().min(1).max(60).optional(),
+      messages: z.array(StoredMessageSchema).max(200).optional(),
+    })
+    .refine(
+      (v) =>
+        v.title !== undefined ||
+        v.design_id !== undefined ||
+        v.messages !== undefined,
+      { message: "Provide at least one of title, design_id or messages" }
+    )
+)
+
+export const DeleteDesignConversationSchema = ScopeSchema
+
+export type CreateDesignConversationInput = z.infer<
+  typeof CreateDesignConversationSchema
+>
+export type UpdateDesignConversationInput = z.infer<
+  typeof UpdateDesignConversationSchema
+>
+export type DeleteDesignConversationInput = z.infer<
+  typeof DeleteDesignConversationSchema
+>

--- a/apps/backend/src/api/store/custom/design-assistant/designs/[id]/route.ts
+++ b/apps/backend/src/api/store/custom/design-assistant/designs/[id]/route.ts
@@ -1,0 +1,103 @@
+/**
+ * Storefront design-assistant — read a maker's board.
+ *
+ *   GET /store/custom/design-assistant/designs/:id?customer_email=…
+ *
+ * ## Why this exists rather than reusing `/store/custom/designs/:id`
+ *
+ * 🔴 The board panel — the whole visible point of the chat editor — read the
+ * design through the CUSTOMER-authenticated route, in a flow whose entire
+ * premise is a guest identified only by an email. Every read answered
+ * `401 Customer authentication required`, the client swallowed it in a
+ * `catch {}` marked "best-effort", and the panel sat on "Your board is empty"
+ * while the chat itself rendered both takes a few pixels to the left.
+ *
+ * So the feature looked like it worked in the transcript and had never once
+ * worked on the board. Nothing failed loudly: 15 backend tests pass, the chat
+ * renders, and the only way to see it is to open the page.
+ *
+ * ## Ownership
+ *
+ * Scoped by the design↔customer link, resolved from the maker's email — the
+ * same fact the flow already establishes when `create_design` links the guest
+ * customer. That is deliberately stricter than the neighbouring `pick` route,
+ * which treats knowledge of a `design_id` as sufficient: flipping the active
+ * flag on a board you can already name is a much smaller disclosure than
+ * handing over the whole scene, every prompt used and every image URL.
+ *
+ * 🔑 The customer is looked up, NEVER created. A read that creates a customer
+ * row would let anyone mint guest accounts by GET, and would make the mere act
+ * of loading a board change the data it reports on.
+ */
+import {
+  AuthenticatedMedusaRequest,
+  MedusaResponse,
+} from "@medusajs/framework/http"
+import {
+  ContainerRegistrationKeys,
+  MedusaError,
+  Modules,
+} from "@medusajs/framework/utils"
+
+import designCustomerLink from "../../../../../../links/design-customer-link"
+import { DESIGN_MODULE } from "../../../../../../modules/designs"
+
+export const GET = async (
+  req: AuthenticatedMedusaRequest,
+  res: MedusaResponse
+) => {
+  const designId = String(req.params.id || "").trim()
+  const email = String((req.query as any)?.customer_email || "")
+    .trim()
+    .toLowerCase()
+
+  if (!email) {
+    throw new MedusaError(
+      MedusaError.Types.INVALID_DATA,
+      "customer_email is required to read a design board."
+    )
+  }
+
+  const customerService: any = req.scope.resolve(Modules.CUSTOMER)
+  const customers: any[] = await customerService
+    .listCustomers({ email }, { take: 10 })
+    .catch(() => [])
+
+  const query = req.scope.resolve(ContainerRegistrationKeys.QUERY) as any
+
+  /**
+   * 🔴 "Not yours" and "not there" answer identically. A distinguishable 403
+   * would turn a design id into an oracle for whether an email owns it — the
+   * same reason `resolveDesignVariants` collapses the two.
+   */
+  const notFound = () =>
+    res.status(404).json({ message: "Design not found" })
+
+  if (!customers.length) return notFound()
+
+  const { data: links = [] } = await query.graph({
+    entity: designCustomerLink.entryPoint,
+    fields: ["design_id", "customer_id"],
+    filters: {
+      design_id: designId,
+      customer_id: customers.map((c) => c.id),
+    },
+  })
+
+  if (!links?.length) return notFound()
+
+  const designService: any = req.scope.resolve(DESIGN_MODULE)
+  const design = await designService.retrieveDesign(designId).catch(() => null)
+  if (!design) return notFound()
+
+  // Only what the board renders. The design row carries costs and partner
+  // notes that a public read has no business returning.
+  return res.status(200).json({
+    design: {
+      id: design.id,
+      name: design.name ?? null,
+      thumbnail_url: design.thumbnail_url ?? null,
+      moodboard: design.moodboard ?? null,
+    },
+  })
+}

--- a/apps/backend/src/api/store/custom/design-assistant/pick/route.ts
+++ b/apps/backend/src/api/store/custom/design-assistant/pick/route.ts
@@ -1,0 +1,48 @@
+/**
+ * Storefront design-assistant — deterministic canvas pick.
+ *
+ *   POST /store/custom/design-assistant/pick
+ *   { design_id, canvas_id }
+ *
+ * The scene panel's "Build on this" action calls this directly (deterministic,
+ * no model turn required) — the same write `set_active_canvas` performs when
+ * the maker says "pick take B" in chat. Marks the canvas active in the
+ * Excalidraw scene on design.moodboard and stamps design.thumbnail_url.
+ *
+ * Reuses the chat flow's runSetActiveCanvas (single source of truth for the
+ * pick semantics). Public — mirrors the flow's email gate; ownership is
+ * enforced by the scene lookup (the canvas must be on the design's board).
+ */
+import {
+  AuthenticatedMedusaRequest,
+  MedusaResponse,
+} from "@medusajs/framework/http"
+import { MedusaError } from "@medusajs/framework/utils"
+import { runSetActiveCanvas } from "../../../../../mastra/agents/tools/storefront-design-flow"
+
+export const POST = async (
+  req: AuthenticatedMedusaRequest,
+  res: MedusaResponse
+) => {
+  const validated = (req as any).validatedBody
+  if (!validated?.design_id || !validated?.canvas_id) {
+    throw new MedusaError(
+      MedusaError.Types.INVALID_DATA,
+      "design_id and canvas_id are required"
+    )
+  }
+
+  try {
+    const result = await runSetActiveCanvas(req.scope as any, {
+      design_id: validated.design_id,
+      canvas_id: validated.canvas_id,
+    })
+    return res.status(200).json(result)
+  } catch (e: any) {
+    throw new MedusaError(
+      MedusaError.Types.NOT_FOUND,
+      e?.message || "Canvas pick failed"
+    )
+  }
+}
+

--- a/apps/backend/src/api/store/custom/design-assistant/references/analyze/route.ts
+++ b/apps/backend/src/api/store/custom/design-assistant/references/analyze/route.ts
@@ -1,0 +1,44 @@
+/**
+ * Storefront design-assistant — analyse an uploaded reference on the fly.
+ *
+ *   POST /store/custom/design-assistant/references/analyze
+ *
+ * The maker uploads a reference image (presign → S3 PUT). The client calls
+ * this the moment the upload finishes so the image is READ and described
+ * immediately — not deferred to whenever the model happens to call
+ * save_moodboard / generate_design_image. The vision result is:
+ *
+ *   1. returned to the client (shown on the thumbnail + sent with the message
+ *      so the model grounds on it), and
+ *   2. persisted on the MediaFile record (`metadata.vision_analysis`) so every
+ *      later turn / tool call reuses it without another vision call.
+ *
+ * Public (no customer auth) — analysis is a read of a URL the client already
+ * owns. Best-effort: a failed vision call still returns 200 with an empty
+ * analysis rather than blocking the maker.
+ */
+import { MedusaRequest, MedusaResponse } from "@medusajs/framework/http"
+import { z } from "@medusajs/framework/zod"
+import { analyzeReferenceImage } from "../../../../../../mastra/agents/tools/storefront-design-analysis"
+
+const AnalyzeReferenceSchema = z.object({
+  url: z.string().url().max(2000).describe("Public URL of the uploaded image."),
+  name: z.string().trim().min(1).max(200).optional(),
+  mime_type: z.string().trim().max(80).optional(),
+})
+
+export const POST = async (req: MedusaRequest, res: MedusaResponse) => {
+  const body = (req as any).validatedBody ?? (req.body as any)
+  const parsed = AnalyzeReferenceSchema.safeParse(body ?? {})
+
+  if (!parsed.success) {
+    return res.status(400).json({ message: parsed.error.issues?.[0]?.message ?? "Invalid body" })
+  }
+
+  const analysis = await analyzeReferenceImage(req.scope as any, parsed.data.url)
+
+  return res.status(200).json({
+    url: parsed.data.url,
+    analysis,
+  })
+}

--- a/apps/backend/src/mastra/agents/storefront-chat.ts
+++ b/apps/backend/src/mastra/agents/storefront-chat.ts
@@ -25,6 +25,10 @@ import { readFileSync } from "node:fs"
 import { join } from "node:path"
 import { dynamicFreeTextModel } from "../providers/dynamic-text-model"
 import { buildChatModel, getAiPlatformForRole } from "../services/ai-platforms"
+import {
+  buildDesignChatSystem,
+  type DesignChatContext,
+} from "./storefront-design-chat"
 
 // ── Brand knowledge corpus ─────────────────────────────────────────────
 
@@ -56,7 +60,7 @@ export type UserPrefs = {
   notes?: string
 }
 
-const formatPrefs = (prefs?: UserPrefs): string => {
+export const formatPrefs = (prefs?: UserPrefs): string => {
   if (!prefs) return "(no preferences captured yet — feel free to ask one short question to learn what they like)"
   const lines: string[] = []
   if (prefs.colors?.length) lines.push(`- colors: ${prefs.colors.join(", ")}`)
@@ -185,3 +189,11 @@ export const resolveStorefrontChatModel = async (
 
   return null
 }
+
+
+// ── Design-editor system prompt re-export ──────────────────────────────
+// The design flow reuses this module's model resolution (same role,
+// ai_search_chat) with a designer-guide prompt — see storefront-design-chat.ts.
+
+export { buildDesignChatSystem }
+export type { DesignChatContext }

--- a/apps/backend/src/mastra/agents/storefront-chat.ts
+++ b/apps/backend/src/mastra/agents/storefront-chat.ts
@@ -178,7 +178,7 @@ export const resolveStorefrontChatModel = async (
   if (cloudflare) {
     const modelId =
       process.env.STOREFRONT_CHAT_CLOUDFLARE_MODEL ||
-      "@cf/meta/llama-3.1-8b-instruct"
+      "@cf/moonshotai/kimi-k2.6"
     return { model: cloudflare(modelId), provider: `cloudflare:${modelId}` }
   }
 

--- a/apps/backend/src/mastra/agents/storefront-design-chat.ts
+++ b/apps/backend/src/mastra/agents/storefront-design-chat.ts
@@ -1,0 +1,248 @@
+/**
+ * Designer-guide system prompt for the shop's chat-based design editor.
+ *
+ * A sibling of `buildStorefrontChatSystem` (same model resolution, same
+ * ai_search_chat role) with a different contract: the agent walks a maker
+ * through designing a real product — brief → moodboard → fabrics → partner →
+ * generation → iteration — grounded in server-resolved product + design state.
+ *
+ * Analysis-first flow: when the design starts from an existing product's
+ * image, the agent analyses it FIRST (vision) and suggests design directions,
+ * then suggests what is possible with our existing fabrics, then guides to a
+ * production partner, then keeps the iteration loop going (revisions/layers).
+ *
+ * The route binds the design tools (see storefront-design-*.ts) when
+ * `context` is present — the prompt here describes the flow those tools
+ * implement. Tools write model-first data (Excalidraw scene on
+ * design.moodboard, brief on typed columns); NEVER design.metadata.
+ */
+import type { UserPrefs } from "./storefront-chat"
+import { formatPrefs } from "./storefront-chat"
+
+export type DesignChatContext = {
+  product_id?: string
+  design_id?: string
+  email?: string
+  // Server-resolved product summary (route injects — never client prose).
+  product?: {
+    title?: string
+    description?: string
+    thumbnail?: string
+    images?: string[]
+  } | null
+  // Server-resolved design state (route injects for existing designs).
+  design?: {
+    name?: string
+    status?: string
+    product_type?: string | null
+    concept_theme?: string | null
+    aesthetic_keywords?: string[]
+    thumbnail_url?: string
+    // Moodboard summary — so the agent is grounded on the board without an
+    // extra get_design_state round-trip.
+    board?: {
+      active_canvas?: {
+        letter?: string | null
+        kind?: string
+        prompt_used?: string
+      } | null
+      canvas_count?: number
+      inspirations?: Array<{
+        title?: string | null
+        description?: string | null
+      }>
+    }
+  } | null
+}
+
+const PRODUCT_CONTEXT = (ctx: DesignChatContext): string => {
+  const p = ctx.product
+  if (!p) return ""
+  const lines = ["", "# The product being designed (server-resolved, real catalogue data)"]
+  if (p.title) lines.push(`- Title: ${p.title}`)
+  if (p.description) lines.push(`- Description: ${p.description.slice(0, 600)}`)
+  if (p.thumbnail) lines.push(`- Image: ${p.thumbnail}`)
+  if (p.images?.length) lines.push(`- All images: ${p.images.join(", ")}`)
+  lines.push(
+    "",
+    "When designing from this product: it is a VARIANT of the real garment above. Generation seeds its image as the reference automatically — say so once so the maker knows the design builds on the real product. Use analyze_product_image FIRST for an image-grounded read (construction, palette, mood), then suggest concrete directions."
+  )
+  return lines.join("\n")
+}
+
+const DESIGN_CONTEXT = (ctx: DesignChatContext): string => {
+  const d = ctx.design
+  if (!d) return ""
+  const lines = ["", "# The design being edited (server-resolved)"]
+  if (d.name) lines.push(`- Name: ${d.name}`)
+  if (d.status) lines.push(`- Status: ${d.status}`)
+  if (d.product_type) lines.push(`- Garment type: ${d.product_type}`)
+  if (d.concept_theme) lines.push(`- Concept: ${d.concept_theme}`)
+  if (d.aesthetic_keywords?.length)
+    lines.push(`- Aesthetic keywords: ${d.aesthetic_keywords.join(", ")}`)
+  if (d.thumbnail_url) lines.push(`- Current design image: ${d.thumbnail_url}`)
+
+  // Moodboard summary — canvas takes + reference analyses, so the agent is
+  // grounded on the board without an extra get_design_state call.
+  const board = d.board
+  if (board) {
+    const boardLines: string[] = []
+    if (board.canvas_count != null) {
+      boardLines.push(`- Takes on the board: ${board.canvas_count}`)
+    }
+    if (board.active_canvas) {
+      const ac = board.active_canvas
+      const bits = [ac.letter ? `take ${ac.letter}` : "a take", ac.kind]
+        .filter(Boolean)
+        .join(", ")
+      boardLines.push(`- Active canvas: ${bits}`)
+      if (ac.prompt_used) boardLines.push(`  prompt: ${ac.prompt_used}`)
+    }
+    if (board.inspirations?.length) {
+      boardLines.push(
+        `- Uploaded references (already analysed — use these descriptions, don't re-analyse):`
+      )
+      for (const insp of board.inspirations) {
+        const desc = [insp.title, insp.description]
+          .filter(Boolean)
+          .join(" — ")
+        boardLines.push(`  - ${desc || "(unreadable reference)"}`)
+      }
+    }
+    if (boardLines.length) {
+      lines.push("")
+      lines.push("# Board state")
+      lines.push(...boardLines)
+    }
+  }
+
+  lines.push(
+    "",
+    "This design already exists — the board above is current. Iterations build on the ACTIVE canvas: pick before revising. You don't need to call get_design_state unless the maker asks for the full take history."
+  )
+  return lines.join("\n")
+}
+
+// ── Turn planner (query planner) ───────────────────────────────────────
+// Heuristic, route-computed from the conversation — no extra LLM turn. The
+// models kept firing save_brief without the two onboarding keys (garment
+// type + email), looping on the structured guidance instead of asking. The
+// planner emits a HARD directive block gating tool usage per turn.
+const GARMENT_KEYWORDS = [
+  "kurta", "kurta set", "shirt", "t-shirt", "tshirt", "trousers", "pants",
+  "saree", "sari", "dress", "gown", "jacket", "coat", "blazer", "stole",
+  "scarf", "dupatta", "shawl", "lehenga", "palazzo", "salwar", "kameez",
+  "top", "blouse", "kaftan", "caftan", "skirt", "skirt-set", "coordinates", "set", "hoodie", "sweater", "cardigan",
+  "tunic", "kimono", "robe", "vest", "shorts", "jumpsuit", "playsuit",
+]
+const EMAIL_RE = /[\w.+-]+@[\w-]+\.[\w.]{2,}/
+
+export type PlannedTurn = {
+  garment_type: string | null
+  has_email: boolean
+  directive: string
+}
+
+export const planDesignTurn = (
+  messages?: Array<{ role?: string; parts?: Array<any>; content?: string }>,
+  context?: DesignChatContext
+): PlannedTurn => {
+  const userText = (messages || [])
+    .filter((m) => m?.role === "user")
+    .map((m) =>
+      Array.isArray(m.parts)
+        ? m.parts.filter((p) => p?.type === "text").map((p) => p?.text ?? "").join(" ")
+        : String(m.content ?? "")
+    )
+    .join(" \n ")
+    .toLowerCase()
+
+  const garment = GARMENT_KEYWORDS.find((k) =>
+    new RegExp(`\\b${k.replace(/[-]/g, "\\-")}\\b`).test(userText)
+  )
+  const hasEmail = Boolean(context?.email) || EMAIL_RE.test(userText)
+
+  const lines: string[] = ["", "# TURN PLAN (route-computed — follow EXACTLY)"]
+  if (!garment) {
+    lines.push(
+      "- 🔴 ONBOARDING REQUIRED: no garment named anywhere in this conversation. Your ONLY move this turn is ONE short question asking what they are designing. Do NOT call save_brief, create_design, list_raw_materials, list_partners, analyze_product_image or generate_design_image until a garment is named."
+    )
+  } else {
+    lines.push(
+      `- Garment on the board: ${garment}. You may lock the brief with product_type='${garment}'. Still confirm style/keywords conversationally — but never re-ask the garment.`
+    )
+  }
+  if (!hasEmail) {
+    lines.push(
+      "- Email not shared yet: do NOT call create_design, capture_contact or generate_design_image (the design can't save). You may brief, browse fabrics and partners. Ask for the email once, naturally, right after the brief."
+    )
+  } else {
+    lines.push(
+      "- Email captured: once the brief is locked, call create_design (once) to save + associate the design, and capture_contact may run (once)."
+    )
+  }
+  lines.push(
+    "- 🔴 GENERATION GATE: NEVER call generate_design_image unless the maker has explicitly agreed THIS turn ('yes', 'go ahead', 'generate', 'do it'). Ask clearly first ('ready for me to generate two takes?') and wait for their yes."
+  )
+
+  return {
+    garment_type: garment ?? null,
+    has_email: has_email_safe(context?.email, userText),
+    directive: lines.join("\n"),
+  }
+}
+
+const has_email_safe = (contextEmail?: string, userText?: string): boolean =>
+  Boolean(contextEmail) || EMAIL_RE.test(userText ?? "")
+
+export const buildDesignChatSystem = (
+  prefs?: UserPrefs,
+  context?: DesignChatContext,
+  messages?: Array<{ role?: string; parts?: Array<any>; content?: string }>
+): string => {
+  const hasProduct = Boolean(context?.product)
+  const hasDesign = Boolean(context?.design)
+
+  return `You are Cici's designer — a warm, hands-on design guide for Cici Label, a slow-fashion brand under Jaal Yantra Textiles (JYT). You help a maker design a real garment: you ground everything in their product or brief, our fabrics, and our production partners, and you keep the iteration loop going until they love a take.
+
+# The flow (walk it in their order, never interrogate)
+0. Intro — on first touch, greet them and, in one breath, show how it works: brief → fabrics → partner → a couple of generated takes they pick from. Then ask what garment they're designing.
+1. Brief — what do they want? Lock the garment category (product_type — REQUIRED, estimates and production derive from it: ask once if unknown, never leave blank), concept theme, 3-5 aesthetic keywords, palette. 🔴 NEVER call save_brief until the maker has told you the garment type — a premature call returns needs='product_type' and wastes a turn. ASK, then call.
+2. Save it — once the brief is locked AND you have their email, call create_design. This registers the maker (a guest customer by email) and links them to the design BEFORE any generation. From here the design exists and everything else attaches to it.
+3. Moodboard — invite uploaded references ("upload a few inspirations and I'll pin them to your board"). Each uploaded reference is analysed on the fly and pinned with its description — board references shape generation.
+4. Fabrics — call list_raw_materials and suggest a SHORT list of what we can make it from (composition, color, swatch). Render fabric chips. Keep it to a handful (default 6) — only list more when the maker asks to see all fabrics.
+5. Partner — call list_partners to walk the production path: a Fabric Seller SOURCES the material, a Manufacturer CUTS & SEWS it. Each result carries its path role. Guide them source → make. Keep the list SHORT (default 6) — only list more when the maker asks to see all partners.
+6. Generate — 🔴 ONLY after the maker explicitly says to generate. Ask clearly ("Ready for me to generate two takes?") and wait for a YES before calling generate_design_image. Each call is long (~20s per image — say "Generating two takes…" first). Both takes land on their board; the maker picks one.
+7. Iterate — after the pick (set_active_canvas), keep the loop going: revision (re-imagine the active take) or layer (add a motif, change a detail). Ask before each generation, same as step 6.
+
+# How to behave
+- Analysis first: ${hasProduct ? "analyse the product image with analyze_product_image before suggesting anything — ground every direction in what you see (construction, palette, mood)." : "this flow has no base product — ground directions in the brief and any uploaded inspirations; generation creates the design from the brief."}
+- One suggestion at a time after the take lands ("the indigo take reads more utilitarian — want me to push the palette warmer, or layer a border motif?").
+- Render tool results as the UI cards (fabric chips, partner cards, canvas A/B) — never list them in prose by hand.
+- The board is the maker's: canvas takes, inspirations and the active pick all live on one Excalidraw board they can see. Describe state in board terms ("your board now has two takes — A indigo, B natural").
+- Uploaded references are pre-analysed (vision) and carry their description on the board — call get_design_state and read the inspirations' descriptions/suggestions instead of re-analysing the same image.
+- Email: ask for it EARLY — right after the brief, because the design saves under it. Ask once, naturally ("what email should I save this design under?"). Call create_design after they give it; call capture_contact once.
+- 🔴 NEVER auto-generate: image generation costs real quota and ~20s. Always ask for an explicit yes first ("ready for me to generate two takes on this?") and only call generate_design_image after they confirm. If they describe changes instead of confirming, treat it as a revision request and confirm again.
+- Estimates/checkout come later: once a take is active and fabric + partner are chosen, point them to Checkout (the estimate renders there from the design + selected fabric + partner). Don't fabricate prices.
+- Match their energy. Short paragraphs. You suggest; they decide.
+
+# Design tools (server-bound, write the maker's real design)
+- analyze_product_image — vision read of a garment image + design directions.
+- save_brief — validate the brief (product_type REQUIRED).
+- create_design — create the design record NOW (registers a guest customer by email + links them). Call after brief + email, BEFORE generation.
+- list_raw_materials — our fabrics (composition, color, swatch).
+- list_partners — verified partners across the path (Fabric Seller → source, Manufacturer → make, Designer, Independent). Returns a SHORT list (6) by default; use a higher limit only when the maker asks to see everyone.
+- generate_design_image — TWO A/B takes per call; requires an existing design + explicit maker consent; revision/layer build on the active take.
+- set_active_canvas — record their pick; it becomes the design's thumbnail.
+- get_design_state — board + brief state (call when resuming/editing).
+- capture_contact — save their email as a lead.
+- search_products — if they wander into shopping, search the catalogue (they may want a base product).
+${hasProduct ? PRODUCT_CONTEXT(context!) : ""}${hasDesign ? DESIGN_CONTEXT(context!) : ""}
+
+# Maker preferences (from onboarding)
+${formatPrefs(prefs)}
+${planDesignTurn(messages, context).directive}
+
+Weave preferences into every generation (badges) and fabric/partner suggestions. If empty, ask at most one short question at a time.
+`
+}

--- a/apps/backend/src/mastra/agents/storefront-design-chat.ts
+++ b/apps/backend/src/mastra/agents/storefront-design-chat.ts
@@ -157,8 +157,11 @@ export const planDesignTurn = (
     .join(" \n ")
     .toLowerCase()
 
+  const escapeRegExp = (value: string): string =>
+    value.replace(/[.*+?^${}()|[\]\\]/g, "\\$&")
+
   const garment = GARMENT_KEYWORDS.find((k) =>
-    new RegExp(`\\b${k.replace(/[-]/g, "\\-")}\\b`).test(userText)
+    new RegExp(`\\b${escapeRegExp(k)}\\b`).test(userText)
   )
   const hasEmail = Boolean(context?.email) || EMAIL_RE.test(userText)
 

--- a/apps/backend/src/mastra/agents/tools/storefront-capture-contact.ts
+++ b/apps/backend/src/mastra/agents/tools/storefront-capture-contact.ts
@@ -17,7 +17,7 @@
  */
 import type { MedusaContainer } from "@medusajs/framework"
 import { ContainerRegistrationKeys } from "@medusajs/framework/utils"
-import { tool } from "ai"
+import { tool, jsonSchema } from "ai"
 import { z } from "zod"
 import { PERSON_MODULE } from "../../../modules/person"
 import { splitName } from "../../../workflows/leads/lib/email-lead"
@@ -31,12 +31,10 @@ const CaptureArgsSchema = z.object({
     .email()
     .max(200)
     .describe("The shopper's email address, exactly as they typed it."),
-  name: z
-    .string()
-    .min(1)
-    .max(120)
-    .optional()
-    .describe("The shopper's name, if they gave one."),
+  name: z.preprocess(
+    (v) => (typeof v === "string" && !v.trim() ? undefined : v),
+    z.string().min(1).max(120).optional()
+  ).describe("The shopper's name, if they gave one."),
   interest: z
     .string()
     .max(280)
@@ -117,6 +115,32 @@ export const runCaptureContact = async (
   }
 }
 
+/**
+ * Hand-authored input schema — bound via jsonSchema() (admin/partner MCP
+ * chats' pattern). The SDK's PRE-EXECUTE validation runs against THIS, so
+ * `name` is a plain optional string (the model sends name:"" — the zod
+ * min(1) check hard-rejected that before execute could trim it).
+ * runCaptureContact tolerates the empty name via splitName.
+ */
+export const CAPTURE_CONTACT_INPUT_SCHEMA = {
+  type: "object",
+  properties: {
+    email: {
+      type: "string",
+      description: "The shopper's email address, exactly as they typed it.",
+    },
+    name: {
+      type: "string",
+      description: "The shopper's name, if they gave one. Omit rather than sending an empty string.",
+    },
+    interest: {
+      type: "string",
+      description: "A short note on which pieces or topics the shopper was interested in, for follow-up context.",
+    },
+  },
+  required: ["email"],
+}
+
 export const createCaptureContactTool = (
   container: MedusaContainer,
   visitorId?: string
@@ -124,6 +148,16 @@ export const createCaptureContactTool = (
   tool({
     description:
       "Save the shopper's name and email as a follow-up lead. Call this ONCE, and only after the shopper has actually shared an email address in the conversation — never before they've given one. It returns whether the contact was saved.",
-    inputSchema: CaptureArgsSchema,
-    execute: async (args) => runCaptureContact(args, container, visitorId),
+    inputSchema: jsonSchema(CAPTURE_CONTACT_INPUT_SCHEMA as any),
+    execute: async (args) =>
+      runCaptureContact(
+        {
+          ...(args as any),
+          // Normalise the model's empty-string name to undefined (zod never
+          // sees this — jsonSchema binding skips it).
+          name: (args as any)?.name?.trim() || undefined,
+        },
+        container,
+        visitorId
+      ),
   })

--- a/apps/backend/src/mastra/agents/tools/storefront-design-analysis.ts
+++ b/apps/backend/src/mastra/agents/tools/storefront-design-analysis.ts
@@ -1,0 +1,163 @@
+/**
+ * Design reference analysis — the chat editor's on-the-fly image reader.
+ *
+ * When the maker sends reference images (inspirations / garment photos), the
+ * design tools pin them to the board. This module analyses those images the
+ * moment they arrive and records the vision result so it's reusable:
+ *
+ *   1. `MediaFile.metadata.vision_analysis` — the durable store. Any LLM that
+ *      can query the media library reads a grounded, pre-computed description
+ *      of the image (title / description / design suggestions) without paying
+ *      for another vision call.
+ *   2. The scene element's `customData.analysis` — the shop's board renderer
+ *      and `get_design_state` surface it back into the chat on later turns.
+ *
+ * Analysis is BEST-EFFORT: a missing vision provider or a bad image must never
+ * stop the maker from pinning their references — we record `null` and move on.
+ */
+import type { MedusaContainer } from "@medusajs/framework"
+import { MEDIA_MODULE } from "../../../modules/media"
+import type MediaFileService from "../../../modules/media/service"
+import { runAnalyzeProductImage, type ImageAnalysis } from "./storefront-design-catalog"
+
+export type ReferenceAnalysis = ImageAnalysis & {
+  media_id: string | null
+  analyzed_at: string | null
+  /** True when the result came from a prior analysis (no fresh vision call). */
+  cached?: boolean
+}
+
+const resolveMediaService = (container: MedusaContainer): MediaFileService =>
+  container.resolve(MEDIA_MODULE) as unknown as MediaFileService
+
+const extensionFromUrl = (url: string): string => {
+  const clean = url.split("?")[0].split("#")[0]
+  const ext = clean.split(".").pop()?.toLowerCase() || ""
+  return /^[a-z0-9]{1,5}$/.test(ext) ? ext : "jpg"
+}
+
+const mimeFromExtension = (ext: string): string =>
+  ({ png: "image/png", jpg: "image/jpeg", jpeg: "image/jpeg", webp: "image/webp", gif: "image/gif" }[ext]) ?? "image/jpeg"
+
+/** Analyse one image and persist the result onto its MediaFile record. */
+const analyzeOne = async (
+  container: MedusaContainer,
+  url: string
+): Promise<ReferenceAnalysis> => {
+  const mediaService = resolveMediaService(container)
+
+  // Cache hit — the media was analysed before (upload time, or a prior pin).
+  // Return it verbatim instead of paying for another vision call.
+  try {
+    const existing = await mediaService
+      .listMediaFiles({ file_path: url } as any, { take: 1 })
+      .catch(() => [])
+    const cached: any = (existing?.[0]?.metadata as any)?.vision_analysis
+    if (cached?.title) {
+      return {
+        title: cached.title,
+        description: cached.description ?? "",
+        suggestions: Array.isArray(cached.suggestions) ? cached.suggestions : [],
+        media_id: existing[0].id ?? null,
+        analyzed_at: cached.analyzed_at ?? null,
+        cached: true,
+      }
+    }
+  } catch {
+    /* fall through to a fresh analysis */
+  }
+
+  let analysis: ImageAnalysis | null = null
+
+  try {
+    analysis = await runAnalyzeProductImage(container, url)
+  } catch (err: any) {
+    // Best-effort — the image still pins without an analysis.
+    console.warn(`[design-reference] vision analysis failed for ${url}: ${err?.message || err}`)
+  }
+
+  const analyzedAt = analysis ? new Date().toISOString() : null
+  const ext = extensionFromUrl(url)
+  const mimeType = mimeFromExtension(ext)
+
+  // Find-or-create the MediaFile record keyed on its public URL, then stamp
+  // the analysis into metadata + the human-readable content columns.
+  try {
+    const existing = await mediaService
+      .listMediaFiles({ file_path: url } as any, { take: 1 })
+      .catch(() => [])
+    const match: any = existing?.[0]
+
+    const payload = {
+      ...(analysis
+        ? {
+            title: analysis.title,
+            description: analysis.description,
+            alt_text: analysis.description,
+          }
+        : {}),
+      metadata: {
+        ...(match?.metadata ?? {}),
+        source: (match?.metadata as any)?.source ?? "design-reference",
+        vision_analysis: analysis
+          ? { ...analysis, analyzed_at: analyzedAt }
+          : null,
+      },
+    }
+
+    let media: any
+    if (match) {
+      media = await mediaService.updateMediaFiles({ id: match.id, ...payload })
+    } else {
+      media = await mediaService.createMediaFiles({
+        file_name: `reference-${Date.now()}.${ext}`,
+        original_name: url.split("/").pop()?.split("?")[0] || url,
+        file_path: url,
+        file_size: 0,
+        file_type: "image",
+        mime_type: mimeType,
+        extension: ext,
+        is_public: true,
+        ...payload,
+      })
+    }
+
+    return {
+      title: analysis?.title ?? "",
+      description: analysis?.description ?? "",
+      suggestions: analysis?.suggestions ?? [],
+      media_id: media?.id ?? null,
+      analyzed_at: analyzedAt,
+    }
+  } catch (err: any) {
+    // Media record write failed — still return the analysis (it lives on the
+    // scene element), just without a media link.
+    console.warn(`[design-reference] media persist failed for ${url}: ${err?.message || err}`)
+    return {
+      title: analysis?.title ?? "",
+      description: analysis?.description ?? "",
+      suggestions: analysis?.suggestions ?? [],
+      media_id: null,
+      analyzed_at: analyzedAt,
+    }
+  }
+}
+
+/**
+ * Analyse a batch of reference URLs in parallel and return a url → analysis
+ * map (an empty entry means the image was not analysable, not that it failed
+ * to pin).
+ */
+export const analyzeReferenceImages = async (
+  container: MedusaContainer,
+  urls: string[]
+): Promise<Map<string, ReferenceAnalysis>> => {
+  const unique = [...new Set(urls.filter((u) => typeof u === "string" && u.startsWith("http")))]
+  const results = await Promise.all(unique.map((url) => analyzeOne(container, url)))
+  const map = new Map<string, ReferenceAnalysis>()
+  unique.forEach((url, i) => map.set(url, results[i]))
+  return map
+}
+
+/** Single-image analysis — the entry point the upload endpoint calls. */
+export const analyzeReferenceImage = analyzeOne

--- a/apps/backend/src/mastra/agents/tools/storefront-design-catalog.ts
+++ b/apps/backend/src/mastra/agents/tools/storefront-design-catalog.ts
@@ -1,0 +1,276 @@
+/**
+ * Design catalog tools for the shop's chat-based design editor.
+ *
+ * Companions to the concierge tools that let the designer-guide walk a maker
+ * through the design flow:
+ *   - list_raw_materials   — "what fabrics do we have?" (design-selectable inventory)
+ *   - list_partners        — "who can make this?" (verified production partners)
+ *   - analyze_product_image— "what do you see in this garment?" (vision analysis →
+ *                            design suggestions, analysis-first flow)
+ *
+ * Same container-bound factory pattern as storefront-catalog-tools: in-process
+ * via the MedusaContainer (no HTTP hop), store shapes the chat UI renders.
+ */
+import type { MedusaContainer } from "@medusajs/framework"
+import { ContainerRegistrationKeys } from "@medusajs/framework/utils"
+import { tool } from "ai"
+import { z } from "zod"
+import { describeProductImageWorkflow } from "../../../workflows/ai/describe-product-image"
+import RawMaterialInventoryLink from "../../../links/raw-material-data-inventory"
+
+// ── list_raw_materials ─────────────────────────────────────────────────
+
+export type AgentRawMaterialHit = {
+  id: string
+  name: string | null
+  color: string | null
+  composition: string | null
+  thumbnail: string | null
+  category: string | null
+  inventory_item_id: string | null
+  sku: string | null
+}
+
+export const runListRawMaterials = async (
+  container: MedusaContainer,
+  q?: string,
+  limit = 20
+): Promise<{ materials: AgentRawMaterialHit[]; count: number }> => {
+  const query = container.resolve(ContainerRegistrationKeys.QUERY)
+
+  // Reuse the store API's inventory-with-raw-material join (same entry point
+  // as getAllInventoryWithRawMaterial — materials are design-selectable
+  // through their inventory item). Medusa v2 graph cannot filter on linked
+  // entity properties, so `q` post-filters app-side (same as the helper).
+  const { data } = await query.graph({
+    entity: RawMaterialInventoryLink.entryPoint,
+    fields: ["*", "raw_materials.*", "inventory_item.*"],
+  } as any)
+
+  const rows = data || []
+  const needle = typeof q === "string" ? q.toLowerCase().trim() : ""
+  const searched = needle
+    ? rows.filter((row: any) => {
+        const raw = row.raw_materials
+        const inv = row.inventory_item
+        return [raw?.name, raw?.color, raw?.composition, raw?.material_type?.name, raw?.material_type?.category, inv?.title, inv?.sku]
+          .some((v: any) => typeof v === "string" && v.toLowerCase().includes(needle))
+      })
+    : rows
+
+  const materials: AgentRawMaterialHit[] = searched
+    .filter((item: any) => item.raw_materials)
+    .map((item: any) => {
+      const raw = item.raw_materials
+      let mediaArray: any[] = []
+      const rawMedia = raw?.media
+      if (rawMedia?.files && Array.isArray(rawMedia.files)) {
+        mediaArray = rawMedia.files
+      } else if (Array.isArray(rawMedia)) {
+        mediaArray = rawMedia
+      }
+      const thumbnail =
+        mediaArray.find((m: any) => m?.isThumbnail)?.url ||
+        mediaArray[0]?.url ||
+        (typeof mediaArray[0] === "string" ? mediaArray[0] : null) ||
+        null
+
+      return {
+        id: raw.id,
+        name: raw.name ?? null,
+        color: raw.color ?? null,
+        composition: raw.composition ?? null,
+        thumbnail,
+        category: raw.material_type?.category ?? raw.material_type?.name ?? null,
+        inventory_item_id: item.inventory_item?.id ?? null,
+        sku: item.inventory_item?.sku ?? null,
+      }
+    })
+
+  return { materials: materials.slice(0, limit), count: searched.filter((item: any) => item.raw_materials).length }
+}
+
+const ListMaterialsSchema = z.object({
+  q: z
+    .string()
+    .max(120)
+    .optional()
+    .describe("Search filter — fabric name, composition ('cotton'), or color ('indigo'). Omit to browse (a short list is returned)."),
+  limit: z
+    .number()
+    .int()
+    .min(1)
+    .max(50)
+    .default(6)
+    .describe("How many to return. Keep it small (6 is good) unless the maker asks to see more."),
+})
+
+export const createListRawMaterialsTool = (container: MedusaContainer) =>
+  tool({
+    description:
+      "List a handful of fabrics / raw materials from inventory, with composition, color and a swatch. Call when the maker is choosing material — render fabric chips. Use q to filter; keep the list SHORT (default 6) and only return more when the maker explicitly asks to see all fabrics.",
+    inputSchema: ListMaterialsSchema,
+    execute: async (args) => runListRawMaterials(container, args.q, args.limit),
+  })
+
+// ── list_partners ──────────────────────────────────────────────────────
+
+export type AgentPartnerHit = {
+  id: string
+  name: string | null
+  company_name: string | null
+  logo: string | null
+  description: string | null
+  /** Friendly role along the production path. */
+  path: string | null
+  /** Raw workspace_type (seller | manufacturer | designer | individual). */
+  workspace_type: string | null
+}
+
+/**
+ * The production "path" each partner sits on. Fabric Sellers source the
+ * material; Manufacturers cut & sew it; Designers author; individuals are
+ * independent makers. The designer-guide walks these in order.
+ */
+const PARTNER_PATH_LABELS: Record<string, string> = {
+  seller: "Fabric Seller",
+  manufacturer: "Manufacturer",
+  designer: "Designer",
+  individual: "Independent maker",
+}
+
+export const runListPartners = async (
+  container: MedusaContainer,
+  q?: string,
+  limit = 20
+): Promise<{ partners: AgentPartnerHit[]; count: number }> => {
+  const query = container.resolve(ContainerRegistrationKeys.QUERY)
+  const { data } = await query.graph({
+    entity: "partner",
+    filters: { status: "active", is_verified: true },
+    fields: [
+      "id",
+      "name",
+      "company_name",
+      "logo_url",
+      "description",
+      "workspace_type",
+    ],
+  } as any)
+
+  const rows = (data || []).map((p: any) => ({
+    ...p,
+    path: PARTNER_PATH_LABELS[p.workspace_type] ?? p.workspace_type ?? null,
+  }))
+
+  let out = rows
+  const needle = typeof q === "string" ? q.toLowerCase().trim() : ""
+  if (needle) {
+    out = rows.filter(
+      (p: any) =>
+        p.name?.toLowerCase().includes(needle) ||
+        p.company_name?.toLowerCase().includes(needle) ||
+        p.description?.toLowerCase().includes(needle) ||
+        (p.path && String(p.path).toLowerCase().includes(needle)) ||
+        (p.workspace_type && String(p.workspace_type).toLowerCase().includes(needle))
+    )
+  }
+
+  return {
+    partners: out.slice(0, limit).map((p: any) => ({
+      id: p.id,
+      name: p.name ?? null,
+      company_name: p.company_name ?? null,
+      logo: p.logo_url ?? null,
+      description: p.description ?? null,
+      path: p.path ?? null,
+      workspace_type: p.workspace_type ?? null,
+    })),
+    count: out.length,
+  }
+}
+
+const ListPartnersSchema = z.object({
+  q: z
+    .string()
+    .max(120)
+    .optional()
+    .describe(
+      "Optional filter — partner name, role along the path ('fabric seller', 'manufacturer', 'designer'), or material focus ('embroidery', 'handloom'). Omit to browse (a short list is returned)."
+    ),
+  limit: z
+    .number()
+    .int()
+    .min(1)
+    .max(50)
+    .default(6)
+    .describe("How many to return. Keep it small (6 is good) unless the maker asks to see all partners."),
+})
+
+export const createListPartnersTool = (container: MedusaContainer) =>
+  tool({
+    description:
+      "List a handful of VERIFIED production partners across the path — Fabric Sellers (source material), Manufacturers (cut & sew), Designers, and independent makers. Each result carries its `path` role. Use q to filter by role or focus; keep the list SHORT (default 6) and only return more when the maker explicitly asks to see all partners.",
+    inputSchema: ListPartnersSchema,
+    execute: async (args) => runListPartners(container, args.q, args.limit),
+  })
+
+// ── analyze_product_image ──────────────────────────────────────────────
+
+export type ImageAnalysis = {
+  title: string
+  description: string
+  suggestions: string[]
+}
+
+const SUGGESTION_PROMPT = [
+  "You analyse a garment photo for a slow-fashion design assistant.",
+  "Given the image (and optional maker request), respond with JSON only, no prose:",
+  '{ "title": "short garment title, 4-8 words", "description": "2-3 sentences: what the garment is, its construction, palette and mood",',
+  '  "suggestions": ["3-5 concrete design directions the maker could explore with this garment as the base, one short sentence each, e.g. re-dye the palette, layer new motifs, vary the silhouette"] }',
+  "Ground every observation in what you can see. Never invent measurements or materials.",
+].join(" ")
+
+export const runAnalyzeProductImage = async (
+  container: MedusaContainer,
+  imageUrl: string,
+  makerRequest?: string
+): Promise<ImageAnalysis> => {
+  const { result, errors } = await describeProductImageWorkflow(container as any).run({
+    input: {
+      imageUrl,
+      hint: makerRequest,
+      // Design-analysis JSON contract instead of product copy — same vision
+      // provider resolution (ai_product_description role).
+      system_prompt: SUGGESTION_PROMPT,
+    },
+  })
+
+  if (errors?.length) {
+    throw errors[0]
+  }
+
+  return {
+    title: (result as any)?.title,
+    description: (result as any)?.description,
+    suggestions: (result as any)?.suggestions ?? [],
+  }
+}
+
+const AnalyzeImageSchema = z.object({
+  image_url: z.string().url().max(2000).describe("The garment image to analyse."),
+  maker_request: z
+    .string()
+    .max(500)
+    .optional()
+    .describe("What the maker said they want, so the suggestions are aimed at their ask."),
+})
+
+export const createAnalyzeProductImageTool = (container: MedusaContainer) =>
+  tool({
+    description:
+      "Analyse a garment image and suggest concrete design directions. Call this FIRST when the flow starts from an existing product's image — ground your follow-up in the analysis (construction, palette, mood) and present the suggestions so the maker can react.",
+    inputSchema: AnalyzeImageSchema,
+    execute: async (args) =>
+      runAnalyzeProductImage(container, args.image_url, args.maker_request),
+  })

--- a/apps/backend/src/mastra/agents/tools/storefront-design-flow.ts
+++ b/apps/backend/src/mastra/agents/tools/storefront-design-flow.ts
@@ -486,11 +486,33 @@ export type GenerateResult = {
 
 export const runGenerateDesignImage = async (
   container: MedusaContainer,
-  args: z.infer<typeof GenerateSchema>,
+  /**
+   * `z.input`, not `z.infer`. The output type marks `kind` as always present
+   * because the schema defaults it — true of the TOOL path, where the model's
+   * arguments are parsed, and false of every direct call, which is what this
+   * export exists for. Typing the parsed shape here told callers a guarantee
+   * the function does not actually receive.
+   */
+  args: z.input<typeof GenerateSchema>,
   context?: DesignContext
 ): Promise<GenerateResult> => {
   const designService = resolveDesignService(container)
   const missingSetup: string[] = []
+
+  /**
+   * 🔴 Normalised, not read raw. `GenerateSchema` declares `.default("initial")`
+   * so the TOOL path can never see `undefined` — but this function is exported
+   * and callable directly, and there the default has not run. Every use below
+   * was written as `args.kind !== "initial"`, which sends an ABSENT kind down
+   * the iterate branch: the very first generation, before any canvas exists,
+   * gets refused with "Pick one of the takes first".
+   *
+   * The first call is the one with nothing to compare against, and asking
+   * "is it not initial?" answers yes for `undefined` — the same shape as a
+   * first payment claim measured against a tally of prior claims (#1676).
+   * Asking positively instead means an unknown value fails safe.
+   */
+  const kind = args.kind ?? "initial"
 
   const productId = args.product_id ?? context?.product_id
   const email = args.email ?? context?.email
@@ -631,7 +653,7 @@ export const runGenerateDesignImage = async (
   let referenceUsed: string | null = null
   let referenceImages: Array<{ url: string; weight?: number; prompt?: string }> = []
 
-  if (args.kind !== "initial") {
+  if (kind === "revision" || kind === "layer") {
     // revision/layer build on the ACTIVE canvas — require one.
     if (!activeRef) {
       throw new Error(
@@ -679,6 +701,20 @@ export const runGenerateDesignImage = async (
         design_id: designId as string,
         mode: "commit",
         badges: args.badges,
+        /**
+         * 🔴 The brief was in hand here the whole time and was never passed.
+         * `save_brief` normalises it, `create_design` persists it, the system
+         * prompt reasons about it — and the generator, the one consumer that
+         * decides what the maker actually SEES, was handed only badges and a
+         * materials fragment. With neither, its style context defaulted to
+         * "casual fashion".
+         */
+        design_brief: {
+          product_type: brief.product_type,
+          concept_theme: brief.concept_theme,
+          aesthetic_keywords: brief.aesthetic_keywords,
+          color_palette: brief.color_palette,
+        },
         materials_prompt: materialsPrompt,
         reference_images: referenceImages.length ? referenceImages : undefined,
       },
@@ -713,7 +749,7 @@ export const runGenerateDesignImage = async (
 
   // ── Append BOTH candidates to the Excalidraw scene ──
   const parentCanvasId =
-    args.kind !== "initial" && readActiveCanvas(scene)
+    kind !== "initial" && readActiveCanvas(scene)
       ? (readActiveCanvas(scene) as any).customData.canvas.id
       : null
 
@@ -723,7 +759,7 @@ export const runGenerateDesignImage = async (
       {
         canvasId: candA.canvasId,
         letter: "A",
-        kind: args.kind,
+        kind,
         parentCanvasId,
         mediaId: outA?.media_id ?? null,
         imageUrl: candA.imageUrl,
@@ -734,7 +770,7 @@ export const runGenerateDesignImage = async (
       {
         canvasId: candB.canvasId,
         letter: "B",
-        kind: args.kind,
+        kind,
         parentCanvasId,
         mediaId: outB?.media_id ?? null,
         imageUrl: candB.imageUrl,
@@ -750,7 +786,7 @@ export const runGenerateDesignImage = async (
   return {
     design_id: designId as string,
     created_design: createdDesign,
-    kind: args.kind,
+    kind,
     reference_used: referenceUsed,
     candidates: [
       {

--- a/apps/backend/src/mastra/agents/tools/storefront-design-flow.ts
+++ b/apps/backend/src/mastra/agents/tools/storefront-design-flow.ts
@@ -142,7 +142,7 @@ const saveScene = async (
 // JSON into its visible reply). Coerce BEFORE validating.
 const coerceKeywords = (v: unknown): string[] | undefined => {
   if (v == null) return undefined
-  let arr: unknown = v
+  let arr: any = v
   if (typeof v === "string") {
     try {
       arr = JSON.parse(v)
@@ -161,7 +161,7 @@ const coercePalette = (
   v: unknown
 ): Array<{ name: string; code: string }> | undefined => {
   if (v == null) return undefined
-  let arr: unknown = v
+  let arr: any = v
   if (typeof v === "string") {
     try {
       arr = JSON.parse(v)
@@ -502,6 +502,9 @@ export const runGenerateDesignImage = async (
   let brief: DesignBrief
 
   const briefResult = await runSaveBrief(args.brief)
+  if (!briefResult.ok) {
+    throw new Error(briefResult.message)
+  }
   brief = briefResult.brief
 
   if (designId) {

--- a/apps/backend/src/mastra/agents/tools/storefront-design-flow.ts
+++ b/apps/backend/src/mastra/agents/tools/storefront-design-flow.ts
@@ -1,0 +1,927 @@
+/**
+ * Design flow tools — the core of the shop's chat-based design editor.
+ *
+ * The designer-guide walks a maker through: brief → moodboard → fabrics →
+ * partner → generation → iteration. These tools are the flow's write side:
+ *
+ *   - save_brief          — validate + normalise the brief (product_type is
+ *                           load-bearing: estimate + production spec derive from it)
+ *   - generate_design_image — THE heart: resolves or creates the design (first
+ *                           generation creates it — guest customer by email +
+ *                           product-design link + moodboard seed), generates TWO
+ *                           candidate canvases (A/B) and appends them to the
+ *                           Excalidraw scene on design.moodboard
+ *   - set_active_canvas   — the pick: scene marker + design.thumbnail_url
+ *   - get_design_state    — design + scene summary so the chat resumes with
+ *                           full context (editing an existing design)
+ *
+ * 🔴 Model-first, NEVER design.metadata (the #1486 metadata-replace lesson):
+ * canvases live as Excalidraw image elements on design.moodboard (see
+ * canvas-scene.ts); the only load-bearing column the flow touches is
+ * design.thumbnail_url (active pick).
+ *
+ * Generation runs generateDesignAiImageWorkflow twice (one run per candidate —
+ * each run does mastra imagegen + commit-mode media upload + design update).
+ * The active pick is what reaches production; the workflow's unconditional
+ * thumbnail stamp is corrected by set_active_canvas immediately after the pick.
+ */
+import type { MedusaContainer } from "@medusajs/framework"
+import { ContainerRegistrationKeys, Modules } from "@medusajs/framework/utils"
+import { tool, jsonSchema } from "ai"
+import { z } from "zod"
+import { DESIGN_MODULE } from "../../../modules/designs"
+import type DesignService from "../../../modules/designs/service"
+import {
+  normalizeCanvasScene,
+  readActiveCanvas,
+  readCanvasElements,
+  readGenerationReference,
+  appendCanvasElements,
+  markActiveCanvas,
+  type CanvasScene,
+  type CanvasMarker,
+} from "../../../modules/designs/lib/canvas-scene"
+import { normalizeProductType } from "../../../modules/designs/lib/product-type"
+import { createDesignWorkflow } from "../../../workflows/designs/create-design"
+import { linkProductWithDesignWorkflow } from "../../../workflows/products/link-unlink-products-with-designs"
+import { generateDesignAiImageWorkflow } from "../../../workflows/ai/generate-design-image"
+import { analyzeReferenceImages } from "./storefront-design-analysis"
+
+// ── Shared resolvers ───────────────────────────────────────────────────
+
+const resolveDesignService = (container: MedusaContainer): DesignService =>
+  container.resolve(DESIGN_MODULE) as unknown as DesignService
+
+/**
+ * Find-or-create the guest customer keyed on the maker's email.
+ * Pattern mirrors partner-quote mint-quote (#1507): exact email lookup,
+ * adopt-or-create, never overwrite an adopted profile.
+ */
+export const runEnsureGuestCustomer = async (
+  container: MedusaContainer,
+  email: string
+): Promise<{ customer_id: string; created: boolean }> => {
+  const normalized = email.trim().toLowerCase()
+  const customerService: any = container.resolve(Modules.CUSTOMER)
+
+  const existing: any[] = await customerService
+    .listCustomers({ email: normalized }, { take: 10 })
+    .catch(() => [])
+
+  const match = existing.find((c) => c?.has_account) ?? existing[0]
+  if (match) {
+    return { customer_id: match.id, created: false }
+  }
+
+  const created = await customerService.createCustomers({ email: normalized })
+  return { customer_id: created.id, created: true }
+}
+
+/** Resolve base product images for generation references (initial canvases). */
+const resolveProductImages = async (
+  container: MedusaContainer,
+  productId?: string
+): Promise<string[]> => {
+  if (!productId) return []
+  const query = container.resolve(ContainerRegistrationKeys.QUERY)
+  const { data } = await query.graph({
+    entity: "product",
+    filters: { id: productId },
+    fields: ["id", "images.url", "thumbnail"],
+  } as any)
+  const product: any = data?.[0]
+  if (!product) return []
+  const urls: string[] = (product.images || [])
+    .map((i: any) => i?.url)
+    .filter((u: any) => typeof u === "string" && u.startsWith("http"))
+  if (product.thumbnail && product.thumbnail.startsWith("http")) {
+    urls.unshift(product.thumbnail)
+  }
+  return [...new Set(urls)]
+}
+
+/** Design context the tools carry per-turn (from the chat request context). */
+export type DesignContext = {
+  product_id?: string
+  design_id?: string
+  email?: string
+}
+
+/** Load a design with its canvas scene (null when absent or not owned). */
+const loadDesignScene = async (
+  container: MedusaContainer,
+  designId: string
+): Promise<{ design: any; scene: CanvasScene } | null> => {
+  const designService = resolveDesignService(container)
+  const design = await designService
+    .retrieveDesign(designId)
+    .catch(() => null)
+  if (!design) return null
+  return { design, scene: normalizeCanvasScene(design.moodboard) }
+}
+
+/** Persist the scene back onto the design (moodboard typed column). */
+const saveScene = async (
+  container: MedusaContainer,
+  designId: string,
+  scene: CanvasScene
+): Promise<void> => {
+  const designService = resolveDesignService(container)
+  await designService.updateDesigns({
+    id: designId,
+    moodboard: scene as unknown as Record<string, unknown>,
+  })
+}
+
+// ── save_brief ─────────────────────────────────────────────────────────
+
+// ── Forgiving list coercion ────────────────────────────────────────────
+// The design models keep formatting aesthetic_keywords / color_palette as
+// JSON strings ('["handwoven", …]') or plain comma text instead of arrays —
+// a strict zod schema rejects those and the model fumbles (and leaks raw
+// JSON into its visible reply). Coerce BEFORE validating.
+const coerceKeywords = (v: unknown): string[] | undefined => {
+  if (v == null) return undefined
+  let arr: unknown = v
+  if (typeof v === "string") {
+    try {
+      arr = JSON.parse(v)
+    } catch {
+      arr = v.split(",").map((part) => part.trim()).filter(Boolean)
+    }
+  }
+  if (!Array.isArray(arr)) arr = [arr]
+  return arr
+    .map((k) => String(k).trim().replace(/^["'\[\]]+|["'\[\]]+$/g, ""))
+    .filter(Boolean)
+    .slice(0, 5)
+}
+
+const coercePalette = (
+  v: unknown
+): Array<{ name: string; code: string }> | undefined => {
+  if (v == null) return undefined
+  let arr: unknown = v
+  if (typeof v === "string") {
+    try {
+      arr = JSON.parse(v)
+    } catch {
+      arr = v.split(",").map((part) => part.trim()).filter(Boolean)
+    }
+  }
+  if (!Array.isArray(arr)) arr = [arr]
+  const palette = arr
+    .map((entry: any) => {
+      if (typeof entry === "string") {
+        // "blue:#1e3a5f" → name/code split; bare word → name only.
+        const [name, code] = entry.split(":").map((s) => s.trim())
+        return { name: name || "", code: code || "" }
+      }
+      if (entry && typeof entry === "object") {
+        return {
+          name: String(entry.name ?? "").trim(),
+          code: String(entry.code ?? entry.hex ?? "").trim(),
+        }
+      }
+      return null
+    })
+    .filter((e: any) => e && (e.name || e.code))
+    .slice(0, 8) as Array<{ name: string; code: string }>
+  return palette.length ? palette : undefined
+}
+
+export type DesignBrief = {
+  product_type: string | null
+  concept_theme: string | null
+  aesthetic_keywords: string[]
+  color_palette: Array<{ name: string; code: string }>
+}
+
+const BriefSchema = z.object({
+  product_type: z
+    .string()
+    .max(60)
+    .optional()
+    .describe(
+      "The garment category — 'trousers', 'saree', 'kurta'. REQUIRED before generation: estimates and production specs derive from it. Ask the maker if unknown — only call save_brief once they've told you."
+    ),
+  concept_theme: z
+    .string()
+    .max(300)
+    .optional()
+    .describe("Short story/title for the design ('90s Tokyo streetwear')."),
+  // ANY-typed + in-execute coercion: the AI-SDK validates model tool args
+  // PRE-EXECUTE against the generated JSON schema, and empirically (probed
+  // live across preprocess AND union+transform shapes) a strict array shape
+  // rejects the model's JSON-string payloads before the coercer runs. z.any()
+  // emits `{}` — accepts every shape the model sends — and runSaveBrief
+  // coerces to the strict shape inside execute (JSON strings, comma text,
+  // "name:#hex" splitting — probed).
+  aesthetic_keywords: z
+    .any()
+    .optional()
+    .describe("3-5 look-and-feel keywords ('utilitarian', 'sleek', 'nostalgic'). Pass as a JSON array of strings."),
+  color_palette: z
+    .any()
+    .optional()
+    .describe("Palette the design uses. Pass as a JSON array of { name, code } objects (code hex like '#1e3a5f')."),
+})
+
+export const runSaveBrief = async (
+  args: z.infer<typeof BriefSchema>
+): Promise<
+  | { ok: true; brief: DesignBrief }
+  | { ok: false; needs: "product_type"; message: string }
+> => {
+  // Validate + normalise here so the generate step always receives a usable
+  // type. The value is validated only — persistence happens at design
+  // creation (first generation), per the flow: design is created upon the
+  // first image generation.
+  //
+  // NON-throwing when the type is missing: a premature call returns structured
+  // guidance ("ask the maker") instead of a hard tool error the model retries
+  // blindly — the retry loop surfaced as "Brief needs a garment type" x N in
+  // live testing.
+  const productType = normalizeProductType(args.product_type)
+  if (!productType) {
+    return {
+      ok: false,
+      needs: "product_type",
+      message:
+        "STOP calling save_brief. You called it without a garment type. Write ONE short question to the maker asking what they are designing (a kurta, trousers, a saree…) and END YOUR TURN. Do not call save_brief again until they answer with a garment name.",
+    }
+  }
+  return {
+    ok: true,
+    brief: {
+      product_type: productType,
+      concept_theme: args.concept_theme?.trim() || null,
+      // Coerce defensively here TOO — the schema preprocess only ran on
+      // validated tool paths; direct callers (tests, internal reuse) may
+      // pass raw model shapes (JSON strings / comma text).
+      aesthetic_keywords:
+        coerceKeywords(args.aesthetic_keywords) ?? [],
+      color_palette: coercePalette(args.color_palette) ?? [],
+    },
+  }
+}
+
+/**
+ * Hand-authored input schema for save_brief — bound via jsonSchema() (the
+ * admin/partner MCP chats' pattern). The AI-SDK validates model args
+ * PRE-EXECUTE against THIS schema, so the list fields accept BOTH real
+ * arrays AND the double-encoded JSON strings the models keep emitting.
+ * runSaveBrief coerces to the strict shape inside execute.
+ */
+export const SAVE_BRIEF_INPUT_SCHEMA = {
+  type: "object",
+  properties: {
+    product_type: {
+      type: "string",
+      description:
+        "The garment category — 'trousers', 'saree', 'kurta'. REQUIRED before generation: estimates and production specs derive from it. Ask the maker if unknown — only call save_brief once they've told you.",
+    },
+    concept_theme: {
+      type: "string",
+      description: "Short story/title for the design ('90s Tokyo streetwear').",
+    },
+    aesthetic_keywords: {
+      type: ["array", "string"],
+      items: { type: "string" },
+      description:
+        "3-5 look-and-feel keywords. Pass as a real JSON array of strings (NOT a string-encoded array).",
+    },
+    color_palette: {
+      type: ["array", "string"],
+      description:
+        "Palette the design uses. Pass as a real JSON array of { name, code } objects (code hex like '#1e3a5f') (NOT a string-encoded array).",
+    },
+  },
+  required: [],
+}
+
+export const createSaveBriefTool = () =>
+  tool({
+    description:
+      "Validate and lock in the design brief before any generation. ONLY call this once the maker has told you the garment type (product_type) — if they haven't, ASK first and never call save_brief with a missing type (it returns needs='product_type'). Returns the normalised brief to carry into generation.",
+    inputSchema: jsonSchema(SAVE_BRIEF_INPUT_SCHEMA as any),
+    execute: async (args) => runSaveBrief(args as any),
+  })
+
+// ── create_design ──────────────────────────────────────────────────────
+//
+// Creates the design record EARLY — the moment the maker has expressed their
+// design (brief) and given an email — rather than lazily at first generation.
+// The email find-or-creates a guest customer and the workflow links it, so the
+// maker is "registered" + associated with the design before any expensive
+// image generation runs. Idempotent: if a design_id is already in context it
+// returns it without creating a duplicate.
+
+const CreateDesignSchema = z.object({
+  email: z
+    .string()
+    .max(200)
+    .optional()
+    .describe("The maker's email — REQUIRED to save + associate the design."),
+  name: z
+    .string()
+    .min(1)
+    .max(120)
+    .optional()
+    .describe("Design name ('Indigo Kurta')."),
+  brief: BriefSchema.describe("The normalised brief from save_brief."),
+})
+
+export type CreateDesignResult = {
+  design_id: string
+  created: boolean
+}
+
+export const runCreateDesign = async (
+  container: MedusaContainer,
+  args: z.infer<typeof CreateDesignSchema>,
+  context?: DesignContext
+): Promise<CreateDesignResult> => {
+  const existingId = context?.design_id
+  if (existingId) {
+    const designService = resolveDesignService(container)
+    const existing = await designService
+      .retrieveDesign(existingId)
+      .catch(() => null)
+    if (existing) return { design_id: existingId, created: false }
+  }
+
+  const email = (args.email ?? context?.email)?.trim().toLowerCase()
+  if (!email) {
+    throw new Error(
+      "I need your email to save the design before we go further. What email should I use?"
+    )
+  }
+
+  const briefResult = await runSaveBrief(args.brief)
+  if (!briefResult.ok) {
+    throw new Error(briefResult.message)
+  }
+  const brief = briefResult.brief
+
+  const { customer_id } = await runEnsureGuestCustomer(container, email)
+
+  const { result: designResult, errors: designErrors } = await createDesignWorkflow(
+    container as any
+  ).run({
+    input: {
+      name: args.name?.trim() || brief.concept_theme || `${brief.product_type} design`,
+      description: brief.concept_theme || undefined,
+      design_type: "Custom",
+      status: "Conceptual",
+      origin_source: "ai-other",
+      concept_theme: brief.concept_theme || undefined,
+      aesthetic_keywords: brief.aesthetic_keywords.length
+        ? (brief.aesthetic_keywords as unknown as Record<string, any>)
+        : undefined,
+      color_palette: brief.color_palette.length
+        ? (brief.color_palette as unknown as Record<string, any>)
+        : undefined,
+      customer_id_for_link: customer_id,
+      tags: ["custom", "customer-design", "chat-editor"],
+    },
+  })
+
+  if (designErrors?.length) {
+    throw designErrors[0]
+  }
+
+  return { design_id: (designResult as any).id, created: true }
+}
+
+export const createCreateDesignTool = (
+  container: MedusaContainer,
+  context?: DesignContext
+) =>
+  tool({
+    description:
+      "Create the maker's design record NOW (before any image generation). Call once the maker has expressed their design (brief) and given an email — it registers a guest customer by email and links them to the design. Idempotent — returns the existing design_id if one is already in context. Do NOT call generate_design_image until the design exists and the maker has explicitly said to generate.",
+    inputSchema: CreateDesignSchema,
+    execute: async (args) => runCreateDesign(container, args, context),
+  })
+
+// ── generate_design_image ──────────────────────────────────────────────
+
+const GenerateSchema = z.object({
+  design_id: z
+    .string()
+    .optional()
+    .describe("The design to generate canvases for. Omit to create the design now (first generation)."),
+  product_id: z
+    .string()
+    .optional()
+    .describe("Base product the design is a variant of (its image seeds initial generation)."),
+  email: z
+    .string()
+    .max(200)
+    .optional()
+    .describe("The maker's email — REQUIRED when creating the design now."),
+  name: z
+    .string()
+    .min(1)
+    .max(120)
+    .optional()
+    .describe("Design name when creating now ('Indigo Kurta — Take on the classic')."),
+  brief: BriefSchema.describe("The normalised brief from save_brief."),
+  kind: z
+    .enum(["initial", "revision", "layer"])
+    .default("initial")
+    .describe(
+      "initial — first generation (brief + base product/moodboard references); revision — re-imagine from the active canvas; layer — composite an addition on the active canvas."
+    ),
+  change_request: z
+    .string()
+    .max(1000)
+    .optional()
+    .describe("What this generation should do — the maker's ask for revision/layer."),
+  materials_prompt: z
+    .string()
+    .max(500)
+    .optional()
+    .describe("Selected fabric as a prompt fragment ('indigo handwoven cotton, natural slub')."),
+  material_inventory_id: z
+    .string()
+    .optional()
+    .describe("Selected fabric's inventory item id — linked to the design for production + estimate."),
+  partner_id: z
+    .string()
+    .optional()
+    .describe("Selected production partner — linked to the design for production."),
+  inspiration_images: z
+    .array(z.string().url().max(2000))
+    .max(8)
+    .optional()
+    .describe("Uploaded moodboard reference URLs (new designs) — seeded into the scene and used as generation references."),
+  badges: z
+    .object({
+      style: z.string().max(120).optional(),
+      color_family: z.string().max(200).optional(),
+      body_type: z.string().max(120).optional(),
+      embellishment_level: z.string().max(120).optional(),
+      occasion: z.string().max(200).optional(),
+    })
+    .optional()
+    .describe("Style preferences shaping the generation."),
+})
+
+export type GenerateResult = {
+  design_id: string
+  created_design: boolean
+  kind: string
+  reference_used: string | null
+  candidates: Array<{
+    canvas_id: string
+    letter: "A" | "B"
+    image_url: string
+    prompt_used: string
+  }>
+  quota_remaining: number | null
+  missing_setup?: string[]
+}
+
+export const runGenerateDesignImage = async (
+  container: MedusaContainer,
+  args: z.infer<typeof GenerateSchema>,
+  context?: DesignContext
+): Promise<GenerateResult> => {
+  const designService = resolveDesignService(container)
+  const missingSetup: string[] = []
+
+  const productId = args.product_id ?? context?.product_id
+  const email = args.email ?? context?.email
+
+  // ── Resolve or create the design ──
+  let designId = args.design_id ?? context?.design_id
+  let createdDesign = false
+  let scene: CanvasScene
+  let brief: DesignBrief
+
+  const briefResult = await runSaveBrief(args.brief)
+  brief = briefResult.brief
+
+  if (designId) {
+    const loaded = await loadDesignScene(container, designId)
+    if (!loaded) {
+      throw new Error(`Design ${designId} not found or not accessible.`)
+    }
+    scene = loaded.scene
+  } else {
+    // First generation creates the design — brief + email REQUIRED.
+    if (!email) {
+      throw new Error(
+        "I need your email to save the design before I can generate. What email should I use?"
+      )
+    }
+    missingSetup.push("design")
+    if (!productId) {
+      // Standalone design (no base product) still needs a name.
+    }
+    const { customer_id } = await runEnsureGuestCustomer(container, email)
+
+    // Seed the moodboard scene with the maker's inspirations. Each reference is
+    // analysed on the fly — the vision result is stamped onto the media's
+    // metadata and onto the element so the generation (and later turns) can
+    // ground on a pre-computed description.
+    let seedScene = normalizeCanvasScene(null)
+    if (args.inspiration_images?.length) {
+      const analyses = await analyzeReferenceImages(container, args.inspiration_images)
+      for (const url of args.inspiration_images) {
+        const fileId = `insp-${Date.now()}-${Math.random().toString(36).slice(2, 8)}`
+        const analysis = analyses.get(url)
+        seedScene.files[fileId] = {
+          id: fileId,
+          dataURL: url,
+          mimeType: "image/png",
+          created: Date.now(),
+          lastRetrieved: Date.now(),
+        }
+        seedScene.elements.push({
+          id: `el-${fileId}`,
+          type: "image",
+          x: 40 + (seedScene.elements.length % 2) * 300,
+          y: 40 + Math.floor(seedScene.elements.length / 2) * 300,
+          width: 260,
+          height: 260,
+          angle: 0,
+          strokeColor: "transparent",
+          backgroundColor: "transparent",
+          fillStyle: "solid",
+          strokeWidth: 1,
+          strokeStyle: "solid",
+          roughness: 1,
+          opacity: 100,
+          roundness: null,
+          isDeleted: false,
+          boundElements: null,
+          updated: Date.now(),
+          link: url,
+          locked: true,
+          fileId,
+          mimeType: "image/png",
+          customData: {
+            source: "inspiration",
+            ...(analysis
+              ? {
+                  media_id: analysis.media_id,
+                  analysis: {
+                    title: analysis.title,
+                    description: analysis.description,
+                    suggestions: analysis.suggestions,
+                    analyzed_at: analysis.analyzed_at,
+                  },
+                }
+              : {}),
+          },
+        })
+      }
+    }
+
+    const { result: designResult, errors: designErrors } = await createDesignWorkflow(
+      container as any
+    ).run({
+      input: {
+        name: args.name?.trim() || brief.concept_theme || `${brief.product_type} design`,
+        description: brief.concept_theme || undefined,
+        design_type: "Custom",
+        status: "Conceptual",
+        origin_source: "ai-other",
+        concept_theme: brief.concept_theme || undefined,
+        aesthetic_keywords: brief.aesthetic_keywords.length
+          ? (brief.aesthetic_keywords as unknown as Record<string, any>)
+          : undefined,
+        color_palette: brief.color_palette.length
+          ? (brief.color_palette as unknown as Record<string, any>)
+          : undefined,
+        moodboard: seedScene as unknown as Record<string, any>,
+        customer_id_for_link: customer_id,
+        tags: ["custom", "customer-design", "chat-editor"],
+      },
+    })
+
+    if (designErrors?.length) {
+      throw designErrors[0]
+    }
+    designId = (designResult as any).id
+    createdDesign = true
+    scene = seedScene
+
+    // Link the base product (variant designs) — first-class product-design
+    // link, NOT metadata.
+    if (productId) {
+      await linkProductWithDesignWorkflow(container as any)
+        .run({
+          input: { productId, designId: designId as string },
+        })
+        .catch((e: any) => {
+          // Link failure must not kill the generation — the design exists.
+        })
+    }
+  }
+
+  // ── Resolve generation references ──
+  const activeRef = readGenerationReference(scene)
+  let referenceUsed: string | null = null
+  let referenceImages: Array<{ url: string; weight?: number; prompt?: string }> = []
+
+  if (args.kind !== "initial") {
+    // revision/layer build on the ACTIVE canvas — require one.
+    if (!activeRef) {
+      throw new Error(
+        "Pick one of the takes first (set the active canvas) before I can iterate on it."
+      )
+    }
+    referenceUsed = activeRef
+    referenceImages = [
+      {
+        url: activeRef,
+        weight: 1,
+        prompt: args.change_request || "iterate on this garment",
+      },
+    ]
+  } else {
+    // initial: base product image seeds a variant of the real garment;
+    // standalone designs generate from brief + moodboard inspirations.
+    const productImages = createdDesign ? [] : await resolveProductImages(container, productId)
+    const inspirations = args.inspiration_images?.length
+      ? args.inspiration_images
+      : scene.elements
+          .filter((el) => el.customData?.source === "inspiration" && typeof el.link === "string")
+          .map((el) => el.link as string)
+
+    const refs = [...productImages, ...inspirations].filter((u) => u.startsWith("http"))
+    referenceUsed = refs[0] ?? null
+    referenceImages = refs.map((url, i) => ({
+      url,
+      weight: i === 0 ? 1 : 0.6,
+      prompt: args.change_request || undefined,
+    }))
+  }
+
+  // Link selected material + partner (design-inventory / design-partners links
+  // flow through the store update route on later edits; the generation itself
+  // only needs the prompt fragments).
+  const materialsPrompt = args.materials_prompt
+
+  // ── Generate TWO candidates (A/B) ──
+  const generatedAt = new Date().toISOString()
+  const runGeneration = async () =>
+    generateDesignAiImageWorkflow(container as any).run({
+      input: {
+        customer_id: (await runEnsureGuestCustomer(container, email as string)).customer_id,
+        design_id: designId as string,
+        mode: "commit",
+        badges: args.badges,
+        materials_prompt: materialsPrompt,
+        reference_images: referenceImages.length ? referenceImages : undefined,
+      },
+    })
+
+  const [runA, runB] = await Promise.all([runGeneration(), runGeneration()])
+  for (const e of [...(runA.errors ?? []), ...(runB.errors ?? [])]) {
+    if (e) throw e
+  }
+  const outA: any = runA.result
+  const outB: any = runB.result
+
+  const buildCandidate = async (
+    out: any,
+    letter: "A" | "B"
+  ): Promise<{ canvasId: string; imageUrl: string; promptUsed: string }> => {
+    const imageUrl = out?.preview_url || out?.image_url
+    if (!imageUrl) {
+      throw new Error(`Generation ${letter} failed — no image returned.`)
+    }
+    return {
+      canvasId: `cv-${Date.now()}-${letter}`,
+      imageUrl,
+      promptUsed: out?.prompt_used || "AI-generated design",
+    }
+  }
+
+  const [candA, candB] = await Promise.all([
+    buildCandidate(outA, "A"),
+    buildCandidate(outB, "B"),
+  ])
+
+  // ── Append BOTH candidates to the Excalidraw scene ──
+  const parentCanvasId =
+    args.kind !== "initial" && readActiveCanvas(scene)
+      ? (readActiveCanvas(scene) as any).customData.canvas.id
+      : null
+
+  scene = appendCanvasElements(
+    scene,
+    [
+      {
+        canvasId: candA.canvasId,
+        letter: "A",
+        kind: args.kind,
+        parentCanvasId,
+        mediaId: outA?.media_id ?? null,
+        imageUrl: candA.imageUrl,
+        promptUsed: candA.promptUsed,
+        materialsPrompt: materialsPrompt ?? null,
+        badges: args.badges ?? null,
+      },
+      {
+        canvasId: candB.canvasId,
+        letter: "B",
+        kind: args.kind,
+        parentCanvasId,
+        mediaId: outB?.media_id ?? null,
+        imageUrl: candB.imageUrl,
+        promptUsed: candB.promptUsed,
+        materialsPrompt: materialsPrompt ?? null,
+        badges: args.badges ?? null,
+      },
+    ],
+    generatedAt
+  )
+  await saveScene(container, designId as string, scene)
+
+  return {
+    design_id: designId as string,
+    created_design: createdDesign,
+    kind: args.kind,
+    reference_used: referenceUsed,
+    candidates: [
+      {
+        canvas_id: candA.canvasId,
+        letter: "A" as const,
+        image_url: candA.imageUrl,
+        prompt_used: candA.promptUsed,
+      },
+      {
+        canvas_id: candB.canvasId,
+        letter: "B" as const,
+        image_url: candB.imageUrl,
+        prompt_used: candB.promptUsed,
+      },
+    ],
+    quota_remaining: outB?.quota_remaining ?? outA?.quota_remaining ?? null,
+    missing_setup: missingSetup.length ? missingSetup : undefined,
+  }
+}
+
+export const createGenerateDesignImageTool = (container: MedusaContainer, context?: DesignContext) =>
+  tool({
+    description:
+      "Generate TWO candidate design canvases (A/B takes) and add them to the design board. The design is created on first generation (requires the maker's email). For revision/layer, pick an active canvas first — iteration builds on the picked take. Long-running (~20s each): tell the maker what you're doing before calling.",
+    inputSchema: GenerateSchema,
+    execute: async (args) => runGenerateDesignImage(container, args, context),
+  })
+
+// ── set_active_canvas ──────────────────────────────────────────────────
+
+const SetActiveSchema = z.object({
+  design_id: z.string().describe("The design whose board the canvas is on."),
+  canvas_id: z.string().describe("The canvas the maker picked (take A or B)."),
+})
+
+export const runSetActiveCanvas = async (
+  container: MedusaContainer,
+  args: z.infer<typeof SetActiveSchema>
+): Promise<{ ok: boolean; thumbnail_url: string | null }> => {
+  const loaded = await loadDesignScene(container, args.design_id)
+  if (!loaded) {
+    throw new Error(`Design ${args.design_id} not found or not accessible.`)
+  }
+
+  const target = readCanvasElements(loaded.scene).find(
+    (el) => el.customData?.canvas?.id === args.canvas_id
+  )
+  if (!target) {
+    throw new Error(`Canvas ${args.canvas_id} is not on this design's board.`)
+  }
+  const imageUrl =
+    (target.customData?.canvas && typeof target.link === "string" ? target.link : null) ??
+    target.link
+
+  const scene = markActiveCanvas(loaded.scene, args.canvas_id)
+  await saveScene(container, args.design_id, scene)
+
+  // The pick is load-bearing: thumbnail drives the account grid and what the
+  // partner sees.
+  const designService = resolveDesignService(container)
+  await designService.updateDesigns({
+    id: args.design_id,
+    thumbnail_url: typeof imageUrl === "string" ? imageUrl : null,
+  })
+
+  return { ok: true, thumbnail_url: typeof imageUrl === "string" ? imageUrl : null }
+}
+
+export const createSetActiveCanvasTool = (container: MedusaContainer) =>
+  tool({
+    description:
+      "Record the maker's pick of one canvas take (A or B) as the active design. Call this when they choose a take — it stamps the picked image as the design's thumbnail and future iterations build on it.",
+    inputSchema: SetActiveSchema,
+    execute: async (args) => runSetActiveCanvas(container, args),
+  })
+
+// ── get_design_state ───────────────────────────────────────────────────
+
+const GetStateSchema = z.object({
+  design_id: z.string().describe("The design to load."),
+})
+
+export type DesignStateSummary = {
+  design_id: string
+  name: string | null
+  status: string | null
+  product_type: string | null
+  concept_theme: string | null
+  aesthetic_keywords: string[]
+  color_palette: Array<{ name: string; code: string }>
+  thumbnail_url: string | null
+  active_canvas: { id: string; image_url: string } | null
+  canvases: Array<{
+    id: string
+    letter: string | null
+    kind: string
+    image_url: string
+    active: boolean
+  }>
+  inspirations: Array<{
+    id: string
+    image_url: string
+    title: string | null
+    description: string | null
+    suggestions: string[]
+  }>
+}
+
+export const runGetDesignState = async (
+  container: MedusaContainer,
+  designId: string
+): Promise<DesignStateSummary> => {
+  const loaded = await loadDesignScene(container, designId)
+  if (!loaded) {
+    throw new Error(`Design ${designId} not found or not accessible.`)
+  }
+  const { design, scene } = loaded
+  const active = readActiveCanvas(scene)
+
+  return {
+    design_id: design.id,
+    name: design.name ?? null,
+    status: design.status ?? null,
+    product_type: design.product_type ?? null,
+    concept_theme: design.concept_theme ?? null,
+    aesthetic_keywords: Array.isArray(design.aesthetic_keywords)
+      ? (design.aesthetic_keywords as unknown as string[])
+      : [],
+    color_palette: Array.isArray(design.color_palette)
+      ? (design.color_palette as unknown as Array<{ name: string; code: string }>)
+      : [],
+    thumbnail_url: design.thumbnail_url ?? null,
+    active_canvas: active
+      ? {
+          id: active.customData!.canvas!.id,
+          image_url:
+            (scene.files[active.fileId as string]?.dataURL as string) ??
+            (typeof active.link === "string" ? active.link : ""),
+        }
+      : null,
+    canvases: readCanvasElements(scene).map((el) => ({
+      id: el.customData!.canvas!.id,
+      letter: el.customData!.canvas!.letter ?? null,
+      kind: el.customData!.canvas!.kind,
+      image_url:
+        (scene.files[el.fileId as string]?.dataURL as string) ??
+        (typeof el.link === "string" ? el.link : ""),
+      active: Boolean(el.customData!.canvas!.active),
+    })),
+    inspirations: scene.elements
+      .filter((el) => el.customData?.source === "inspiration")
+      .map((el) => {
+        const analysis = el.customData?.analysis as
+          | { title?: string; description?: string; suggestions?: string[] }
+          | undefined
+        return {
+          id: el.id,
+          image_url:
+            (scene.files[el.fileId as string]?.dataURL as string) ??
+            (typeof el.link === "string" ? el.link : ""),
+          title: analysis?.title ?? null,
+          description: analysis?.description ?? null,
+          suggestions: Array.isArray(analysis?.suggestions)
+            ? analysis!.suggestions
+            : [],
+        }
+      }),
+  }
+}
+
+export const createGetDesignStateTool = (container: MedusaContainer) =>
+  tool({
+    description:
+      "Load a design's current state — brief, active canvas and the full take history on its board. Call this when resuming or editing an existing design so your guidance is grounded in what's already there.",
+    inputSchema: GetStateSchema,
+    execute: async (args) => runGetDesignState(container, args.design_id),
+  })

--- a/apps/backend/src/mastra/agents/tools/storefront-design-moodboard.ts
+++ b/apps/backend/src/mastra/agents/tools/storefront-design-moodboard.ts
@@ -1,0 +1,114 @@
+/**
+ * save_moodboard — inspiration elements for the chat design editor.
+ *
+ * Appends the maker's uploaded reference images into the Excalidraw scene on
+ * design.moodboard as inspiration elements (customData.source = "inspiration").
+ * The shop's scene panel renders them read-only; generation reads them as
+ * moodboard references (initial canvases reference the product image + these).
+ *
+ * For NEW designs the generate tool seeds inspirations at creation — this tool
+ * serves editing an existing design's board.
+ */
+import type { MedusaContainer } from "@medusajs/framework"
+import { tool } from "ai"
+import { z } from "zod"
+import type DesignService from "../../../modules/designs/service"
+import { DESIGN_MODULE } from "../../../modules/designs"
+import { normalizeCanvasScene, type CanvasScene } from "../../../modules/designs/lib/canvas-scene"
+import { analyzeReferenceImages } from "./storefront-design-analysis"
+
+const resolveDesignService = (container: MedusaContainer): DesignService =>
+  container.resolve(DESIGN_MODULE) as unknown as DesignService
+
+export const runSaveMoodboard = async (
+  container: MedusaContainer,
+  designId: string,
+  inspirationImages: string[]
+): Promise<{ added: number }> => {
+  const designService = resolveDesignService(container)
+  const design = await designService.retrieveDesign(designId).catch(() => null)
+  if (!design) {
+    throw new Error(`Design ${designId} not found or not accessible.`)
+  }
+
+  // Analyse the references on the fly — the vision result is stamped onto the
+  // media's metadata AND onto each inspiration element so later turns read a
+  // grounded description instead of paying for another vision call.
+  const analyses = await analyzeReferenceImages(container, inspirationImages)
+
+  const scene = normalizeCanvasScene(design.moodboard)
+  for (const url of inspirationImages) {
+    const fileId = `insp-${Date.now()}-${Math.random().toString(36).slice(2, 8)}`
+    const analysis = analyses.get(url)
+    scene.files[fileId] = {
+      id: fileId,
+      dataURL: url,
+      mimeType: "image/png",
+      created: Date.now(),
+      lastRetrieved: Date.now(),
+    }
+    scene.elements.push({
+      id: `el-${fileId}`,
+      type: "image",
+      x: 40 + (scene.elements.length % 2) * 300,
+      y: 40 + Math.floor(scene.elements.length / 2) * 300,
+      width: 260,
+      height: 260,
+      angle: 0,
+      strokeColor: "transparent",
+      backgroundColor: "transparent",
+      fillStyle: "solid",
+      strokeWidth: 1,
+      strokeStyle: "solid",
+      roughness: 1,
+      opacity: 100,
+      roundness: null,
+      isDeleted: false,
+      boundElements: null,
+      updated: Date.now(),
+      link: url,
+      locked: true,
+      fileId,
+      mimeType: "image/png",
+      customData: {
+        source: "inspiration",
+        ...(analysis
+          ? {
+              media_id: analysis.media_id,
+              analysis: {
+                title: analysis.title,
+                description: analysis.description,
+                suggestions: analysis.suggestions,
+                analyzed_at: analysis.analyzed_at,
+              },
+            }
+          : {}),
+      },
+    })
+  }
+
+  await designService.updateDesigns({
+    id: designId,
+    moodboard: scene as unknown as Record<string, unknown>,
+  })
+
+  return { added: inspirationImages.length }
+}
+
+const SaveMoodboardSchema = z.object({
+  design_id: z.string().describe("The design whose board gets the inspirations."),
+  inspiration_images: z
+    .array(z.string().url().max(2000))
+    .min(1)
+    .max(8)
+    .describe("Uploaded reference image URLs (persistent http URLs from the uploads API)."),
+})
+
+export const createSaveMoodboardTool = (container: MedusaContainer) =>
+  tool({
+    description:
+      "Add the maker's uploaded reference images to the design board as inspirations. Call this when they upload moodboard references for an existing design — they render on the board and shape generation.",
+    inputSchema: SaveMoodboardSchema,
+    execute: async (args) =>
+      runSaveMoodboard(container, args.design_id, args.inspiration_images),
+  })

--- a/apps/backend/src/mastra/workflows/imagegen/index.ts
+++ b/apps/backend/src/mastra/workflows/imagegen/index.ts
@@ -1,8 +1,14 @@
 // @ts-nocheck - Ignore all TypeScript errors in this file
 import { createWorkflow, createStep } from "@mastra/core/workflows";
 import { z } from "zod";
+import { generateText } from "ai";
+import { createOpenAI } from "@ai-sdk/openai";
 import { Agent } from "@mastra/core/agent";
 import { dynamicFreeTextModel } from "../../providers/dynamic-text-model";
+import {
+  generateWithCloudflare,
+  type CloudflareImageConfig,
+} from "./providers/cloudflare";
 
 // Import provider modules
 import {
@@ -103,6 +109,19 @@ export const triggerSchema = z.object({
   customer_id: z.string(),
   threadId: z.string().optional(),
   resourceId: z.string().optional(),
+  // Resolved image-gen platform config (from the Medusa container — the
+  // Mastra runtime has no container, so the caller hands us the credentials).
+  // provider_type "cloudflare" routes prompt-enhancement + image gen to
+  // Cloudflare Workers AI instead of the OpenRouter free fallback.
+  image_gen_config: z
+    .object({
+      provider_type: z.string().optional(),
+      api_key: z.string().optional(),
+      account_id: z.string().optional(),
+      base_url: z.string().optional(),
+      model: z.string().nullable().optional(),
+    })
+    .optional(),
 });
 
 // Final output schema (workflow output)
@@ -136,7 +155,19 @@ const step1OutputSchema = z.object({
   // Passthrough fields needed by subsequent steps
   mode: z.enum(["preview", "commit"]),
   customer_id: z.string(),
+  image_gen_config: z
+    .object({
+      provider_type: z.string().optional(),
+      api_key: z.string().optional(),
+      account_id: z.string().optional(),
+      base_url: z.string().optional(),
+      model: z.string().nullable().optional(),
+    })
+    .optional(),
 });
+
+/** Cloudflare text model for prompt enhancement (same account/token as image gen). */
+const CF_PROMPT_MODEL = "@cf/meta/llama-3.1-8b-instruct";
 
 const buildPromptStep = createStep({
   id: "buildPrompt",
@@ -147,10 +178,9 @@ const buildPromptStep = createStep({
       badges,
       materials_prompt,
       reference_images,
-      threadId,
-      resourceId,
       mode,
       customer_id,
+      image_gen_config,
     } = inputData;
 
     // Build initial style context from badges
@@ -179,7 +209,6 @@ const buildPromptStep = createStep({
       });
     }
 
-    // Use the agent to enhance the prompt
     const userPrompt =
       `Create an optimized image generation prompt for a fashion design with these specifications:\n\n` +
       `Style Preferences: ${styleContext}\n` +
@@ -198,38 +227,44 @@ const buildPromptStep = createStep({
         technical_details: "Test mode - no AI enhancement",
         mode,
         customer_id,
+        image_gen_config,
       };
     }
 
-    const promptOutputSchema = z.object({
-      enhanced_prompt: z
-        .string()
-        .describe("The optimized prompt for image generation"),
-      style_context: z.string().describe("Summary of the design style"),
-      technical_details: z
-        .string()
-        .optional()
-        .describe("Technical details about materials and construction"),
-    });
+    // Resolve the text model for prompt enhancement. When the caller handed us
+    // a Cloudflare image-gen platform we use the same account/token (Workers AI
+    // text model) instead of the OpenRouter free rotator.
+    let model = dynamicFreeTextModel;
+    if (image_gen_config?.provider_type === "cloudflare" && image_gen_config.api_key && image_gen_config.account_id) {
+      const cf = createOpenAI({
+        baseURL: `https://api.cloudflare.com/client/v4/accounts/${image_gen_config.account_id}/ai/v1`,
+        apiKey: image_gen_config.api_key,
+      });
+      model = cf.chat(CF_PROMPT_MODEL);
+    }
 
-    // Use the prompt enhancer agent (no image generation tool)
-    const response = await promptEnhancerAgent.generate(
-      [{ role: "user", content: userPrompt }],
-      {
-        output: promptOutputSchema,
-        threadId: threadId,
-        resourceId: resourceId || `design-gen:${customer_id}`,
-      } as any
-    );
-
-    const result: any = response.object || {};
+    let enhanced = userPrompt;
+    try {
+      const response = await generateText({
+        model,
+        prompt:
+          `You are a fashion design image-generation prompt writer. ` +
+          `Rewrite the following into ONE detailed text-to-image prompt (visual elements, textures, colors, construction). ` +
+          `Output only the prompt, no preamble or quotes:\n\n${userPrompt}`,
+      } as any);
+      const text = (response as any)?.text?.trim();
+      if (text) enhanced = text;
+    } catch (e) {
+      console.warn(`[ImageGen] prompt enhancement failed, using raw prompt: ${(e as any)?.message ?? e}`);
+    }
 
     return {
-      enhanced_prompt: result.enhanced_prompt || userPrompt,
-      style_context: result.style_context || styleContext,
-      technical_details: result.technical_details,
+      enhanced_prompt: enhanced,
+      style_context: styleContext,
+      technical_details: undefined,
       mode,
       customer_id,
+      image_gen_config,
     };
   },
 });
@@ -440,6 +475,7 @@ const generateImageStep = createStep({
       quota_allowed,
       quota_remaining,
       mode,
+      image_gen_config,
     } = inputData;
 
     if (!quota_allowed) {
@@ -466,8 +502,36 @@ const generateImageStep = createStep({
     }
 
     try {
-      console.log(`[ImageGen] Mode: ${mode}, Starting multi-provider generation...`);
+      console.log(`[ImageGen] Mode: ${mode}, Starting generation...`);
       console.log(`[ImageGen] Enhanced Prompt: ${enhanced_prompt.substring(0, 200)}...`);
+
+      // Cloudflare Workers AI is the configured provider (ai_image_gen platform)
+      // — try it FIRST, then fall back to the multi-provider chain.
+      if (
+        image_gen_config?.provider_type === "cloudflare" &&
+        image_gen_config.api_key &&
+        image_gen_config.account_id
+      ) {
+        const cfResult = await generateWithCloudflare(enhanced_prompt, {
+          api_key: image_gen_config.api_key,
+          account_id: image_gen_config.account_id,
+          model: image_gen_config.model ?? null,
+        } as CloudflareImageConfig);
+
+        if (cfResult.success && cfResult.imageUrl) {
+          console.log(`[ImageGen] Success via ${cfResult.modelUsed ?? "cloudflare"}`);
+          return {
+            image_url: cfResult.imageUrl,
+            enhanced_prompt,
+            style_context,
+            quota_remaining,
+            provider_used: "cloudflare",
+            error: undefined,
+          };
+        }
+
+        console.log(`[ImageGen] Cloudflare failed: ${cfResult.error} — falling back to provider chain`);
+      }
 
       // Use provider chain with automatic fallback
       const result = await generateWithProviderChain(enhanced_prompt);

--- a/apps/backend/src/mastra/workflows/imagegen/index.ts
+++ b/apps/backend/src/mastra/workflows/imagegen/index.ts
@@ -81,6 +81,34 @@ export const triggerSchema = z.object({
       custom: z.record(z.string(), z.any()).optional(),
     })
     .optional(),
+  /**
+   * 🔴 THE GARMENT. Absent until now, and its absence is why this workflow
+   * generated the wrong thing every single time.
+   *
+   * `styleContext` is built from `badges` alone and falls back to the literal
+   * string `"casual fashion"` when there are none. So a maker who spent three
+   * turns describing a heritage-indigo handwoven kurta — product type, concept
+   * theme, five aesthetic keywords, a two-colour palette, all of it normalised
+   * by `save_brief` and persisted on the design — had the image model asked
+   * for "casual fashion". It answered honestly: a pastel pink blouse, and a
+   * pastel blue denim jacket.
+   *
+   * Nothing failed. Two images came back, the board filled, the chat said
+   * "here are your two takes". The output was simply unrelated to the design,
+   * and no test can see that because every test asserts an image URL exists.
+   *
+   * The brief is the ONE input this workflow could least afford to be missing.
+   */
+  design_brief: z
+    .object({
+      product_type: z.string().nullish(),
+      concept_theme: z.string().nullish(),
+      aesthetic_keywords: z.array(z.string()).optional(),
+      color_palette: z
+        .array(z.object({ name: z.string().nullish(), code: z.string().nullish() }))
+        .optional(),
+    })
+    .optional(),
   materials_prompt: z.string().optional(),
   reference_images: z
     .array(
@@ -186,6 +214,7 @@ const buildPromptStep = createStep({
   execute: async ({ inputData }) => {
     const {
       badges,
+      design_brief,
       materials_prompt,
       reference_images,
       mode,
@@ -193,8 +222,24 @@ const buildPromptStep = createStep({
       image_gen_config,
     } = inputData;
 
-    // Build initial style context from badges
+    // Build initial style context — the BRIEF first, then badges.
+    //
+    // Order matters: the garment and its concept are what the image is OF;
+    // badges are adjustments to it. Appending the brief after the style
+    // preferences would bury "kurta" behind "Style: relaxed".
     const styleParts: string[] = [];
+    if (design_brief) {
+      if (design_brief.product_type)
+        styleParts.push(`Garment: ${String(design_brief.product_type).replace(/_/g, " ")}`);
+      if (design_brief.concept_theme)
+        styleParts.push(`Concept: ${design_brief.concept_theme}`);
+      const keywords = (design_brief.aesthetic_keywords ?? []).filter(Boolean);
+      if (keywords.length) styleParts.push(`Aesthetic: ${keywords.join(", ")}`);
+      const palette = (design_brief.color_palette ?? [])
+        .map((c) => [c?.name, c?.code].filter(Boolean).join(" "))
+        .filter(Boolean);
+      if (palette.length) styleParts.push(`Colours: ${palette.join(", ")}`);
+    }
     if (badges) {
       if (badges.style) styleParts.push(`Style: ${badges.style}`);
       if (badges.color_family)
@@ -207,6 +252,13 @@ const buildPromptStep = createStep({
         styleParts.push(`Budget: ${badges.budget_sensitivity}`);
     }
 
+    /**
+     * ⚠️ `"casual fashion"` is the fallback that made the failure invisible.
+     * With no brief and no badges the model was asked for generic casual wear
+     * and cheerfully produced it, so the pipeline looked healthy end to end
+     * while generating a garment nobody had described. It stays only as the
+     * last resort for a caller that supplies neither — and now says so.
+     */
     const styleContext =
       styleParts.length > 0 ? styleParts.join(", ") : "casual fashion";
 
@@ -221,7 +273,10 @@ const buildPromptStep = createStep({
 
     const userPrompt =
       `Create an optimized image generation prompt for a fashion design with these specifications:\n\n` +
-      `Style Preferences: ${styleContext}\n` +
+      // "Design brief", not "Style preferences" — this line now leads with the
+      // garment and its concept, and mislabelling it invites the model to treat
+      // the whole thing as optional styling.
+      `Design brief: ${styleContext}\n` +
       (materials_prompt ? `Materials: ${materials_prompt}\n` : "") +
       refContext +
       `\n\nGenerate a detailed, professional prompt suitable for a text-to-image AI model. ` +

--- a/apps/backend/src/mastra/workflows/imagegen/index.ts
+++ b/apps/backend/src/mastra/workflows/imagegen/index.ts
@@ -146,6 +146,16 @@ function isTestEnvironment(): boolean {
   return !!process.env.TEST_TYPE;
 }
 
+/**
+ * True when the caller handed down a usable Cloudflare image-gen platform
+ * (role ai_image_gen). In a test environment we still want REAL generation
+ * when credentials are present — the stub is only the no-credential fallback
+ * so CI (no token) exercises the full flow without an image call.
+ */
+function hasCfImageCreds(cfg?: { provider_type?: string; api_key?: string; account_id?: string }): boolean {
+  return !!(cfg && cfg.provider_type === "cloudflare" && cfg.api_key && cfg.account_id);
+}
+
 // Step 1: Build and enhance prompt using Mistral agent
 // Input: triggerSchema, Output: enhanced prompt data + passthrough fields
 const step1OutputSchema = z.object({
@@ -167,7 +177,7 @@ const step1OutputSchema = z.object({
 });
 
 /** Cloudflare text model for prompt enhancement (same account/token as image gen). */
-const CF_PROMPT_MODEL = "@cf/meta/llama-3.1-8b-instruct";
+const CF_PROMPT_MODEL = "@cf/meta/llama-3.3-70b-instruct-fp8-fast";
 
 const buildPromptStep = createStep({
   id: "buildPrompt",
@@ -218,8 +228,9 @@ const buildPromptStep = createStep({
       `Focus on visual elements, textures, colors, and design details. ` +
       `The prompt should be clear, specific, and optimized for high-quality fashion design generation.`;
 
-    // In test environment, skip the AI call to save credits
-    if (isTestEnvironment()) {
+    // In test environment WITHOUT image-gen credentials, skip the AI call to
+    // save credits (and so CI has no dependency on a token).
+    if (isTestEnvironment() && !hasCfImageCreds(image_gen_config)) {
       console.log(`[ImageGen] Test environment detected - returning mock prompt`);
       return {
         enhanced_prompt: `Test fashion design: ${styleContext}. ${materials_prompt || ""}`.trim(),
@@ -488,8 +499,9 @@ const generateImageStep = createStep({
       };
     }
 
-    // In test environment, return a sample image to avoid using AI credits
-    if (isTestEnvironment()) {
+    // In test environment WITHOUT image-gen credentials, return a sample image
+    // to avoid using AI credits (and so CI has no dependency on a token).
+    if (isTestEnvironment() && !hasCfImageCreds(image_gen_config)) {
       console.log(`[ImageGen] Test environment detected - returning sample image`);
       return {
         image_url: TEST_SAMPLE_IMAGE_BASE64,

--- a/apps/backend/src/mastra/workflows/imagegen/providers/cloudflare.ts
+++ b/apps/backend/src/mastra/workflows/imagegen/providers/cloudflare.ts
@@ -52,7 +52,7 @@ export const generateWithCloudflare = async (
         Authorization: `Bearer ${config.api_key}`,
         "Content-Type": "application/json",
       },
-      body: JSON.stringify({ prompt, num_steps: 4 }),
+      body: JSON.stringify({ prompt }),
       signal: controller.signal,
     })
   } catch (err: any) {

--- a/apps/backend/src/mastra/workflows/imagegen/providers/cloudflare.ts
+++ b/apps/backend/src/mastra/workflows/imagegen/providers/cloudflare.ts
@@ -1,0 +1,120 @@
+/**
+ * Cloudflare Workers AI image generation.
+ *
+ * Uses the `@cf/black-forest-labs/flux-1-schnell` text-to-image model through
+ * the Workers AI REST API (returns base64 PNG). Credentials come from the
+ * resolved `ai_image_gen` External Platform (Cloudflare) — account id + bearer
+ * token — passed down from the Medusa workflow (the Mastra runtime has no
+ * container, so the caller hands us the config).
+ *
+ * @see https://developers.cloudflare.com/workers-ai/models/flux-1-schnell/
+ */
+
+export type CloudflareImageConfig = {
+  api_key: string
+  account_id: string
+  /** Model id; defaults to the fast FLUX schnell model. */
+  model?: string | null
+}
+
+export type CloudflareGenerationResult = {
+  success: boolean
+  imageUrl?: string
+  provider: "cloudflare"
+  modelUsed?: string
+  error?: string
+  errorCode?: "RATE_LIMITED" | "SERVER_ERROR" | "NETWORK_ERROR" | "UNKNOWN"
+}
+
+const DEFAULT_MODEL = "@cf/black-forest-labs/flux-1-schnell"
+
+const classifyError = (status: number): CloudflareGenerationResult["errorCode"] => {
+  if (status === 429) return "RATE_LIMITED"
+  if (status >= 500) return "SERVER_ERROR"
+  return "UNKNOWN"
+}
+
+export const generateWithCloudflare = async (
+  prompt: string,
+  config: CloudflareImageConfig
+): Promise<CloudflareGenerationResult> => {
+  const model = config.model || DEFAULT_MODEL
+  const endpoint = `https://api.cloudflare.com/client/v4/accounts/${config.account_id}/ai/run/${model}`
+
+  const controller = new AbortController()
+  const timeout = setTimeout(() => controller.abort(), 60_000)
+
+  let resp: Response
+  try {
+    resp = await fetch(endpoint, {
+      method: "POST",
+      headers: {
+        Authorization: `Bearer ${config.api_key}`,
+        "Content-Type": "application/json",
+      },
+      body: JSON.stringify({ prompt, num_steps: 4 }),
+      signal: controller.signal,
+    })
+  } catch (err: any) {
+    clearTimeout(timeout)
+    return {
+      success: false,
+      provider: "cloudflare",
+      modelUsed: model,
+      error: err?.message || String(err),
+      errorCode: "NETWORK_ERROR",
+    }
+  }
+  clearTimeout(timeout)
+
+  if (!resp.ok) {
+    const text = await resp.text().catch(() => "")
+    const code = classifyError(resp.status)
+    if (code === "RATE_LIMITED") {
+      return {
+        success: false,
+        provider: "cloudflare",
+        modelUsed: model,
+        error: `Cloudflare rate limited (${resp.status}): ${text.slice(0, 200)}`,
+        errorCode: "RATE_LIMITED",
+      }
+    }
+    return {
+      success: false,
+      provider: "cloudflare",
+      modelUsed: model,
+      error: `Cloudflare returned ${resp.status}: ${text.slice(0, 200)}`,
+      errorCode: code,
+    }
+  }
+
+  const data = (await resp.json()) as any
+  const base64 = data?.result?.image as string | undefined
+
+  if (!base64 || typeof base64 !== "string") {
+    // Workers AI may return a URL for some models — accept either.
+    if (typeof data?.result?.image_url === "string") {
+      return {
+        success: true,
+        imageUrl: data.result.image_url,
+        provider: "cloudflare",
+        modelUsed: model,
+      }
+    }
+    return {
+      success: false,
+      provider: "cloudflare",
+      modelUsed: model,
+      error: "Cloudflare returned no image",
+      errorCode: "UNKNOWN",
+    }
+  }
+
+  const mime = base64.startsWith("data:") ? "" : "data:image/png;base64,"
+  return {
+    success: true,
+    imageUrl: `${mime}${base64}`,
+    provider: "cloudflare",
+    modelUsed: model,
+  }
+}

--- a/apps/backend/src/mastra/workflows/imagegen/providers/index.ts
+++ b/apps/backend/src/mastra/workflows/imagegen/providers/index.ts
@@ -12,7 +12,12 @@
  * Provider Priority: Google Imagen → Gemini Flash → Mistral → Fireworks → Out of credits
  */
 
-export type ImageProvider = "google" | "gemini-flash" | "mistral" | "fireworks";
+export type ImageProvider =
+  | "cloudflare"
+  | "google"
+  | "gemini-flash"
+  | "mistral"
+  | "fireworks";
 
 export type ProviderStatus = {
   available: boolean;

--- a/apps/backend/src/mastra/workflows/imagegen/rate-limit-manager.ts
+++ b/apps/backend/src/mastra/workflows/imagegen/rate-limit-manager.ts
@@ -48,6 +48,11 @@ const RATE_LIMITS: Record<ImageProvider, RateLimitConfig> = {
     windowDurationMs: 60000, // 1 minute window
     cooldownMs: 60000, // 1 minute cooldown on 429
   },
+  cloudflare: {
+    maxRequests: 50, // Conservative estimate for Workers AI (flux-1-schnell)
+    windowDurationMs: 60000, // 1 minute window
+    cooldownMs: 60000, // 1 minute cooldown on 429
+  },
 };
 
 /**
@@ -197,7 +202,7 @@ export function getProviderStatus(): Record<
     }
   > = {} as any;
 
-  const allProviders: ImageProvider[] = ["google", "gemini-flash", "mistral", "fireworks"];
+  const allProviders: ImageProvider[] = ["cloudflare", "google", "gemini-flash", "mistral", "fireworks"];
 
   for (const provider of allProviders) {
     const state = ensureState(provider);

--- a/apps/backend/src/modules/designs/lib/canvas-scene.ts
+++ b/apps/backend/src/modules/designs/lib/canvas-scene.ts
@@ -1,0 +1,375 @@
+/**
+ * Canvas scene utilities — server-side Excalidraw helpers for the chat editor.
+ *
+ * The Excalidraw moodboard on `design.moodboard` (typed json column) is THE
+ * canvas workspace for the shop's chat-based design editor:
+ *
+ *   - inspiration elements — the maker's curated references (moodboard v1)
+ *   - canvas elements      — generated garment images, one image element per
+ *                            generation, laid out in the canvas zone
+ *
+ * Each generation turn produces TWO candidate canvases (A/B). The shopper picks
+ * one; the pick sets `customData.canvas.active` on that element and stamps
+ * `design.thumbnail_url`. Unpicked candidates stay as alternatives in the
+ * scene's history strip.
+ *
+ * Everything here mirrors the scene conventions the partner-ui already renders
+ * (design-moodboard.tsx normalizeMoodboard): scene envelope
+ * { type: "excalidraw", version: 2, source, elements, appState, files },
+ * image elements with a `fileId` + persistent http `url`, and `customData`
+ * markers with `isDeleted` tombstones. The shop's scene panel loads these
+ * elements read-only — the tools write, the UI reads.
+ *
+ * 🔴 Model-first, NEVER design.metadata (the #1486 metadata-replace lesson):
+ * canvases live as scene elements; the only load-bearing design column touched
+ * is `thumbnail_url` (active pick).
+ */
+
+// ── Scene envelope ─────────────────────────────────────────────────────
+
+export type CanvasScene = {
+  type: "excalidraw"
+  version: 2
+  source: string
+  elements: SceneElement[]
+  appState: Record<string, any>
+  files: Record<string, SceneFile>
+}
+
+/** The subset of Excalidraw element shape the tools write and the shop renders. */
+export type SceneElement = {
+  id: string
+  type: "rectangle" | "text" | "image" | "frame"
+  x: number
+  y: number
+  width: number | null
+  height: number | null
+  angle: number
+  strokeColor: string
+  backgroundColor: string
+  fillStyle: string
+  strokeWidth: number
+  strokeStyle: string
+  roughness: number
+  opacity: number
+  roundness: Record<string, any> | null
+  isDeleted: boolean
+  boundElements: any[] | null
+  updated: number
+  link: string | null
+  locked: boolean
+  // image
+  fileId?: string
+  mimeType?: string
+  // text
+  text?: string
+  fontSize?: number
+  fontFamily?: number
+  textAlign?: string
+  verticalAlign?: string
+  containerId?: string | null
+  lineHeight?: number
+  // any element
+  customData?: {
+    source?: "inspiration" | "canvas" | "brief" | "system"
+    canvas?: CanvasMarker
+    [key: string]: any
+  } | null
+}
+
+export type SceneFile = {
+  id: string
+  dataURL: string // persistent http URL (mirrors MediaFile.file_path)
+  mimeType: string
+  created: number
+  lastRetrieved: number
+}
+
+/** Audit marker stamped on every generated canvas element. */
+export type CanvasMarker = {
+  id: string // canvas id (stable across scene rewrites)
+  letter: "A" | "B" | null // candidate pair position, null once superseded
+  kind: "initial" | "revision" | "layer"
+  parent_canvas_id: string | null // lineage — the canvas this was generated from
+  media_id: string | null // persisted MediaFile record
+  prompt_used: string
+  materials_prompt: string | null
+  badges: Record<string, any> | null
+  generated_at: string
+  active: boolean
+}
+
+/** Longest scene we will persist. Guards a runaway model appending forever. */
+export const MAX_CANVAS_ELEMENTS = 60
+
+/** Canvas zone geometry — generated canvases lay out in a grid to the right. */
+export const CANVAS_ZONE_X = 900
+export const CANVAS_ZONE_Y = 0
+export const CANVAS_WIDTH = 384
+export const CANVAS_HEIGHT = 512
+export const CANVAS_GAP = 24
+
+const CANVAS_SOURCE = "https://excalidraw.com"
+
+/**
+ * PURE. Parse any stored moodboard value into a well-formed scene, preserving
+ * every existing element (inspirations, brief cards, prior canvases).
+ *
+ * Accepts an object or a JSON string (legacy rows). Returns a fresh envelope
+ * when nothing is stored yet — a new design starts with an empty scene.
+ */
+export function normalizeCanvasScene(raw: unknown): CanvasScene {
+  let parsed: any = raw
+  if (typeof raw === "string") {
+    try {
+      parsed = JSON.parse(raw)
+    } catch {
+      parsed = null
+    }
+  }
+
+  const elements: SceneElement[] = Array.isArray(parsed?.elements)
+    ? parsed.elements
+    : []
+
+  const files: Record<string, SceneFile> =
+    parsed?.files && typeof parsed.files === "object" ? parsed.files : {}
+
+  // Old UI convention: image elements may carry url/src without a matching
+  // files entry — rebuild missing entries so the shop renderer can resolve them.
+  for (const el of elements) {
+    if (el?.type !== "image" || !el.fileId || files[el.fileId]) {
+      continue
+    }
+    const url = typeof el.link === "string" ? el.link : undefined
+    if (url && url.startsWith("http")) {
+      files[el.fileId] = {
+        id: el.fileId,
+        dataURL: url,
+        mimeType: el.mimeType || "image/png",
+        created: Date.now(),
+        lastRetrieved: Date.now(),
+      }
+    }
+  }
+
+  return {
+    type: "excalidraw",
+    version: 2,
+    source: CANVAS_SOURCE,
+    elements: elements.filter((el) => !el?.isDeleted),
+    appState: parsed?.appState && typeof parsed.appState === "object" ? parsed.appState : {},
+    files,
+  }
+}
+
+/**
+ * PURE. Compute the layout slot for the next canvas element — a 2-column grid
+ * (A left, B right) growing downward in the canvas zone.
+ */
+export function canvasSlot(index: number): { x: number; y: number } {
+  const column = index % 2
+  const row = Math.floor(index / 2)
+  return {
+    x: CANVAS_ZONE_X + column * (CANVAS_WIDTH + CANVAS_GAP),
+    y: CANVAS_ZONE_Y + row * (CANVAS_HEIGHT + CANVAS_GAP),
+  }
+}
+
+/** PURE. Count the canvas elements currently in the scene. */
+export function countCanvasElements(scene: CanvasScene): number {
+  return scene.elements.filter((el) => el.customData?.canvas).length
+}
+
+/** PURE. Read all canvas elements in scene order (history strip). */
+export function readCanvasElements(scene: CanvasScene): SceneElement[] {
+  return scene.elements.filter((el) => !el.isDeleted && el.customData?.canvas)
+}
+
+/** PURE. Read the currently active canvas element, if one is marked. */
+export function readActiveCanvas(scene: CanvasScene): SceneElement | null {
+  const marked = readCanvasElements(scene).find(
+    (el) => el.customData?.canvas?.active
+  )
+  return marked ?? null
+}
+
+/**
+ * PURE. Build one candidate canvas element (image) ready to append to the
+ * scene, with its files entry. The image is persisted media (commit mode):
+ * `imageUrl` mirrors MediaFile.file_path.
+ */
+export function buildCanvasElement(input: {
+  canvasId: string
+  letter: "A" | "B"
+  kind: CanvasMarker["kind"]
+  parentCanvasId: string | null
+  mediaId: string | null
+  imageUrl: string
+  mimeType?: string
+  promptUsed: string
+  materialsPrompt?: string | null
+  badges?: Record<string, any> | null
+  generatedAt: string
+  slotIndex: number
+}): { element: SceneElement; file: SceneFile } {
+  const slot = canvasSlot(input.slotIndex)
+  const fileId = `canvas-${input.canvasId}`
+  const label = `Take ${input.letter}`
+
+  return {
+    element: {
+      id: `el-${input.canvasId}`,
+      type: "image",
+      x: slot.x,
+      y: slot.y,
+      width: CANVAS_WIDTH,
+      height: CANVAS_HEIGHT,
+      angle: 0,
+      strokeColor: "transparent",
+      backgroundColor: "transparent",
+      fillStyle: "solid",
+      strokeWidth: 1,
+      strokeStyle: "solid",
+      roughness: 1,
+      opacity: 100,
+      roundness: null,
+      isDeleted: false,
+      boundElements: null,
+      updated: Date.now(),
+      link: input.imageUrl,
+      locked: true,
+      fileId,
+      mimeType: input.mimeType || "image/png",
+      customData: {
+        source: "canvas",
+        label,
+        canvas: {
+          id: input.canvasId,
+          letter: input.letter,
+          kind: input.kind,
+          parent_canvas_id: input.parentCanvasId,
+          media_id: input.mediaId,
+          prompt_used: input.promptUsed,
+          materials_prompt: input.materialsPrompt ?? null,
+          badges: input.badges ?? null,
+          generated_at: input.generatedAt,
+          active: false,
+        },
+      },
+    },
+    file: {
+      id: fileId,
+      dataURL: input.imageUrl,
+      mimeType: input.mimeType || "image/png",
+      created: Date.now(),
+      lastRetrieved: Date.now(),
+    },
+  }
+}
+
+/**
+ * PURE. Append candidate canvas elements to a scene.
+ *
+ * A generation turn appends TWO candidates (A/B) side by side. Tombstones
+ * nothing — appending is additive; the unpicked candidate stays as an
+ * alternative until the scene exceeds MAX_CANVAS_ELEMENTS, at which point the
+ * oldest inactive canvases are tombstoned (isDeleted) to bound scene size.
+ */
+export function appendCanvasElements(
+  scene: CanvasScene,
+  candidates: Array<{
+    canvasId: string
+    letter: "A" | "B"
+    kind: CanvasMarker["kind"]
+    parentCanvasId: string | null
+    mediaId: string | null
+    imageUrl: string
+    mimeType?: string
+    promptUsed: string
+    materialsPrompt?: string | null
+    badges?: Record<string, any> | null
+  }>,
+  generatedAt: string
+): CanvasScene {
+  const elements = [...scene.elements]
+  const files = { ...scene.files }
+  const slotIndex = countCanvasElements({ ...scene, elements })
+
+  for (const candidate of candidates) {
+    const built = buildCanvasElement({
+      canvasId: candidate.canvasId,
+      letter: candidate.letter,
+      kind: candidate.kind,
+      parentCanvasId: candidate.parentCanvasId,
+      mediaId: candidate.mediaId,
+      imageUrl: candidate.imageUrl,
+      mimeType: candidate.mimeType,
+      promptUsed: candidate.promptUsed,
+      materialsPrompt: candidate.materialsPrompt,
+      badges: candidate.badges,
+      generatedAt,
+      slotIndex,
+    })
+    elements.push(built.element)
+    files[built.file.id] = built.file
+  }
+
+  // Tombstone the oldest inactive canvases when over the cap — bound the scene.
+  let canvasCount = elements.filter((el) => el.customData?.canvas).length
+  let over = canvasCount - MAX_CANVAS_ELEMENTS
+  if (over > 0) {
+    const byAge = [...elements]
+      .filter((el) => el.customData?.canvas && !el.customData.canvas.active)
+      .sort((a, b) => a.updated - b.updated)
+    for (const el of byAge) {
+      if (over <= 0) break
+      el.isDeleted = true
+      canvasCount--
+      over--
+    }
+  }
+
+  return { ...scene, elements, files }
+}
+
+/**
+ * PURE. Mark one canvas element as the active pick; unmark every other canvas
+ * and flip its `letter` to null (the A/B pair is superseded by the pick).
+ */
+export function markActiveCanvas(
+  scene: CanvasScene,
+  canvasId: string
+): CanvasScene {
+  const elements = scene.elements.map((el) => {
+    const marker = el.customData?.canvas
+    if (!marker) return el
+    const isPick = marker.id === canvasId
+    return {
+      ...el,
+      customData: {
+        ...el.customData,
+        canvas: { ...marker, active: isPick, letter: isPick ? marker.letter : null },
+      },
+    }
+  })
+  return { ...scene, elements }
+}
+
+/**
+ * PURE. Resolve the generation reference for the next canvas:
+ * the active canvas image when one is picked (iteration builds on the picked
+ * garment), otherwise null (the tool layer falls back to the base product
+ * image, or brief-only for standalone designs).
+ */
+export function readGenerationReference(
+  scene: CanvasScene
+): string | null {
+  const active = readActiveCanvas(scene)
+  if (!active) return null
+  const file = active.fileId ? scene.files[active.fileId] : null
+  const url =
+    file?.dataURL ||
+    (typeof active.link === "string" ? active.link : null)
+  return url && url.startsWith("http") ? url : null
+}

--- a/apps/backend/src/modules/storefront-design-assistant/index.ts
+++ b/apps/backend/src/modules/storefront-design-assistant/index.ts
@@ -1,0 +1,8 @@
+import { Module } from "@medusajs/framework/utils"
+import StorefrontDesignAssistantService from "./service"
+
+export const STOREFRONT_DESIGN_ASSISTANT_MODULE = "storefront_design_assistant"
+
+export default Module(STOREFRONT_DESIGN_ASSISTANT_MODULE, {
+  service: StorefrontDesignAssistantService,
+})

--- a/apps/backend/src/modules/storefront-design-assistant/migrations/Migration20260829110000.ts
+++ b/apps/backend/src/modules/storefront-design-assistant/migrations/Migration20260829110000.ts
@@ -1,0 +1,28 @@
+import { Migration } from "@medusajs/framework/mikro-orm/migrations";
+
+/**
+ * Creates the storefront_design_conversation table (chat design editor —
+ * per-design chat history).
+ *
+ * Hand-written create migration mirroring what DML would generate for the
+ * model (same pattern as admin_assistant_conversation #1092): jsonb `messages`
+ * (default '[]'), nullable jsonb `metadata`, nullable `design_id` (threads
+ * start before the design row exists — design created at first generation),
+ * lookup index on (customer_email, thread_key) + design_id, standard
+ * deleted_at index. Distinct class name + timestamp to avoid the Medusa
+ * migration-name-collision hazard.
+ */
+export class Migration20260829110000 extends Migration {
+
+  override async up(): Promise<void> {
+    this.addSql(`create table if not exists "storefront_design_conversation" ("id" text not null, "customer_email" text not null, "design_id" text null, "thread_key" text not null, "title" text not null default 'New chat', "messages" jsonb not null default '[]', "metadata" jsonb null, "created_at" timestamptz not null default now(), "updated_at" timestamptz not null default now(), "deleted_at" timestamptz null, constraint "storefront_design_conversation_pkey" primary key ("id"));`);
+    this.addSql(`CREATE INDEX IF NOT EXISTS "IDX_storefront_design_conversation_email_thread" ON "storefront_design_conversation" ("customer_email", "thread_key") WHERE deleted_at IS NULL;`);
+    this.addSql(`CREATE INDEX IF NOT EXISTS "IDX_storefront_design_conversation_design_id" ON "storefront_design_conversation" ("design_id") WHERE deleted_at IS NULL;`);
+    this.addSql(`CREATE INDEX IF NOT EXISTS "IDX_storefront_design_conversation_deleted_at" ON "storefront_design_conversation" ("deleted_at") WHERE deleted_at IS NULL;`);
+  }
+
+  override async down(): Promise<void> {
+    this.addSql(`drop table if exists "storefront_design_conversation" cascade;`);
+  }
+
+}

--- a/apps/backend/src/modules/storefront-design-assistant/models/storefront-design-conversation.ts
+++ b/apps/backend/src/modules/storefront-design-assistant/models/storefront-design-conversation.ts
@@ -1,0 +1,55 @@
+import { model } from "@medusajs/framework/utils"
+
+/**
+ * A saved storefront design-assistant conversation.
+ *
+ * Mirror of `admin_assistant_conversation` (#1092) for the shop's chat-based
+ * design editor: the `/store/ai/chat` endpoint is stateless (the client sends
+ * the full message array each turn), so thread history lives here — one row
+ * per saved conversation, the whole AI-SDK UIMessage array persisted verbatim
+ * in `messages`. Reopening a thread replays it exactly and continues it.
+ *
+ * Scoping differs from the admin mirror: the design chat is public and gated
+ * on the maker's EMAIL (no login — designs create guest customers by email on
+ * first generation). So threads scope by normalised `customer_email`, NOT an
+ * auth actor id. Rows additionally carry a typed `design_id` (nullable — the
+ * design row is created at first generation, so pre-generation threads have
+ * none) and a `thread_key` (the base-product scope the storefront threads on:
+ * `product:{id}` or `custom`) so resume matches the client's thread keys.
+ */
+const StorefrontDesignConversation = model
+  .define("storefront_design_conversation", {
+    id: model.id().primaryKey(),
+
+    // Normalised maker email (the flow's gate). Scopes every read/write.
+    customer_email: model.text().searchable(),
+
+    // Design the thread produced/edits. Nullable: threads start before the
+    // design row exists (design is created upon first image generation).
+    design_id: model.text().nullable(),
+
+    // Base-product scope key matching the storefront thread keys
+    // (`product:{id}` or `custom`) so a reopen matches the client's thread.
+    thread_key: model.text().searchable(),
+
+    // Human-readable label shown in the thread list. Seeded from the first
+    // user message client-side.
+    title: model.text().default("New chat"),
+
+    // The AI-SDK UIMessage array, persisted verbatim (client-driven) after
+    // each completed stream. json column types as an object; the array is
+    // stored/read at runtime (DB default '[]' is the backstop).
+    messages: model.json(),
+
+    metadata: model.json().nullable(),
+  })
+  .indexes([
+    {
+      on: ["customer_email", "thread_key"],
+    },
+    {
+      on: ["design_id"],
+    },
+  ])
+
+export default StorefrontDesignConversation

--- a/apps/backend/src/modules/storefront-design-assistant/service.ts
+++ b/apps/backend/src/modules/storefront-design-assistant/service.ts
@@ -1,0 +1,143 @@
+import { MedusaError, MedusaService } from "@medusajs/framework/utils"
+import StorefrontDesignConversation from "./models/storefront-design-conversation"
+
+/**
+ * Storefront design-assistant conversation store — thin CRUD over saved chat
+ * threads for the shop's chat-based design editor.
+ *
+ * Mirror of AdminAssistantService with the design-flow scoping: threads scope
+ * by normalised maker EMAIL (the flow's gate — the chat is public, no login),
+ * NOT an auth actor id. Every helper normalises + asserts the email so a
+ * route can never read or mutate another maker's thread by passing ids.
+ *
+ * The heavy `messages` blob is excluded from list responses by default so the
+ * thread list stays light.
+ */
+export type DesignConversationScope = {
+  customer_email: string
+  thread_key: string
+}
+
+class StorefrontDesignAssistantService extends MedusaService({
+  StorefrontDesignConversation,
+}) {
+  /** Normalise an email for scoping — lowercase + trim, or throw. */
+  static normalizeEmail(email: string): string {
+    const normalized = String(email ?? "").trim().toLowerCase()
+    if (!normalized) {
+      throw new MedusaError(
+        MedusaError.Types.INVALID_DATA,
+        "customer_email is required to scope design conversations"
+      )
+    }
+    return normalized
+  }
+
+  /** The maker's conversations for one thread key, newest first. Excludes the
+   * heavy `messages` blob so the history list stays light. */
+  async listConversationsForScope(
+    scope: DesignConversationScope,
+    { withMessages = false }: { withMessages?: boolean } = {}
+  ) {
+    return this.listStorefrontDesignConversations(
+      {
+        customer_email: StorefrontDesignAssistantService.normalizeEmail(
+          scope.customer_email
+        ),
+        thread_key: scope.thread_key,
+      },
+      {
+        order: { updated_at: "DESC" },
+        ...(withMessages
+          ? {}
+          : {
+              select: [
+                "id",
+                "title",
+                "design_id",
+                "created_at",
+                "updated_at",
+              ] as any,
+            }),
+      }
+    )
+  }
+
+  /** Fetch one conversation, 404-ing if it doesn't exist OR isn't the email's —
+   * the same response either way so ids aren't probeable. */
+  async getConversationForScope(scope: DesignConversationScope, id: string) {
+    const [row] = await this.listStorefrontDesignConversations({
+      id,
+      customer_email: StorefrontDesignAssistantService.normalizeEmail(
+        scope.customer_email
+      ),
+    })
+    if (!row) {
+      throw new MedusaError(
+        MedusaError.Types.NOT_FOUND,
+        `Conversation ${id} not found`
+      )
+    }
+    return row
+  }
+
+  createConversationForScope(
+    scope: DesignConversationScope,
+    input: {
+      title?: string
+      design_id?: string
+      messages?: unknown[]
+    }
+  ) {
+    // `messages` is an array stored in a json column, which the generated
+    // create typing narrows to an object — cast at the boundary.
+    return this.createStorefrontDesignConversations({
+      customer_email: StorefrontDesignAssistantService.normalizeEmail(
+        scope.customer_email
+      ),
+      thread_key: scope.thread_key,
+      ...(input.title !== undefined ? { title: input.title } : {}),
+      ...(input.design_id !== undefined ? { design_id: input.design_id } : {}),
+      messages: (input.messages ?? []) as any,
+    })
+  }
+
+  /** Update title / messages / design link, first asserting the row is the
+   * email's. */
+  async updateConversationForScope(
+    scope: DesignConversationScope,
+    id: string,
+    input: {
+      title?: string
+      design_id?: string
+      messages?: unknown[]
+    }
+  ) {
+    await this.getConversationForScope(scope, id)
+    const [updated] = await this.updateStorefrontDesignConversations([
+      {
+        id,
+        ...(input.title !== undefined ? { title: input.title } : {}),
+        ...(input.design_id !== undefined
+          ? { design_id: input.design_id }
+          : {}),
+        // json column holds an array; cast past the object-narrowed typing.
+        ...(input.messages !== undefined
+          ? { messages: input.messages as any }
+          : {}),
+      },
+    ])
+    return updated
+  }
+
+  async deleteConversationForScope(
+    scope: DesignConversationScope,
+    id: string
+  ) {
+    await this.getConversationForScope(scope, id)
+    await this.deleteStorefrontDesignConversations(id)
+    return true
+  }
+}
+
+export default StorefrontDesignAssistantService

--- a/apps/backend/src/workflows/ai/describe-product-image.ts
+++ b/apps/backend/src/workflows/ai/describe-product-image.ts
@@ -16,6 +16,10 @@ export type DescribeProductImageInput = {
   // metadata.role first, then fall back to name (case-insensitive contains).
   providerRole?: string // default: "ai_product_description"
   providerNameContains?: string // default: "qwen"
+  // Optional replacement for the module-level product-copy prompt. Callers
+  // like the chat design editor swap in their own JSON contract (garment
+  // analysis + suggestions) against the same vision provider.
+  system_prompt?: string
 }
 
 export type DescribeProductImageOutput = {
@@ -101,10 +105,11 @@ const callVisionApiStep = createStep(
       }
       imageUrl: string
       hint?: string
+      systemPrompt: string
     },
     { container: _container }
   ) => {
-    const { providerInfo, imageUrl, hint } = input
+    const { providerInfo, imageUrl, hint, systemPrompt } = input
 
     const userParts: Array<Record<string, any>> = [
       { type: "image_url", image_url: { url: imageUrl } },
@@ -126,7 +131,7 @@ const callVisionApiStep = createStep(
       model: providerInfo.model,
       response_format: { type: "json_object" },
       messages: [
-        { role: "system", content: DEFAULT_SYSTEM_PROMPT },
+        { role: "system", content: systemPrompt || DEFAULT_SYSTEM_PROMPT },
         { role: "user", content: userParts },
       ],
       temperature: 0.2,
@@ -180,7 +185,14 @@ const callVisionApiStep = createStep(
       .replace(/```$/i, "")
       .trim()
 
-    let parsed: { title?: string; description?: string }
+    let parsed: {
+      title?: string
+      description?: string
+      // Custom contracts (e.g. the chat design editor's garment analysis)
+      // carry extra fields — passed through untouched so callers can read
+      // their own contract (suggestions, palette, …).
+      [key: string]: any
+    }
     try {
       parsed = JSON.parse(cleaned)
     } catch {
@@ -204,6 +216,7 @@ const callVisionApiStep = createStep(
       title,
       description,
       provider_platform_id: providerInfo.platformId,
+      ...(typeof parsed === "object" ? parsed : {}),
     })
   }
 )
@@ -216,6 +229,7 @@ export const describeProductImageWorkflow = createWorkflow(
       providerInfo,
       imageUrl: input.imageUrl,
       hint: input.hint,
+      systemPrompt: input.system_prompt || DEFAULT_SYSTEM_PROMPT,
     })
     return new WorkflowResponse(result)
   }

--- a/apps/backend/src/workflows/ai/generate-design-image.ts
+++ b/apps/backend/src/workflows/ai/generate-design-image.ts
@@ -13,6 +13,7 @@ import { DESIGN_MODULE } from "../../modules/designs";
 import DesignService from "../../modules/designs/service";
 import { MEDIA_MODULE } from "../../modules/media";
 import MediaFileService from "../../modules/media/service";
+import { getAiPlatformForRole } from "../../mastra/services/ai-platforms";
 
 type Badge = {
   style?: string;
@@ -65,12 +66,44 @@ type UploadResult = {
 // Step 1: Invoke Mastra workflow for image generation
 const invokeMastraImageGenStep = createStep(
   "invoke-mastra-image-gen-step",
-  async (input: GenerateDesignAiImageInput): Promise<StepResponse<MastraImageGenResult, { imageUrl?: string; mode: string }>> => {
+  async (input: GenerateDesignAiImageInput, { container }): Promise<StepResponse<MastraImageGenResult, { imageUrl?: string; mode: string }>> => {
     try {
       const workflow = mastra.getWorkflow("imageGenerationWorkflow");
 
       if (!workflow) {
         throw new Error("Image generation workflow not found in Mastra");
+      }
+
+      // Resolve the image-gen provider: admin-configured External Platform
+      // (ai_image_gen) first, then the Cloudflare env fallback. The Mastra
+      // runtime has no Medusa container, so we hand the credentials down.
+      let image_gen_config: any = null;
+      try {
+        const platform = await getAiPlatformForRole(container as any, "ai_image_gen");
+        if (platform) {
+          image_gen_config = {
+            provider_type: platform.providerType,
+            api_key: platform.apiKey,
+            account_id: platform.accountId,
+            base_url: platform.baseUrl,
+            model: platform.defaultModel,
+          };
+        }
+      } catch (e: any) {
+        console.warn(`[ai-imagegen] platform resolution failed: ${e?.message ?? e}`);
+      }
+
+      if (
+        !image_gen_config &&
+        process.env.CLOUDFLARE_AI_TOKEN &&
+        process.env.CLOUDFLARE_AI_ACCOUNT_ID
+      ) {
+        image_gen_config = {
+          provider_type: "cloudflare",
+          api_key: process.env.CLOUDFLARE_AI_TOKEN,
+          account_id: process.env.CLOUDFLARE_AI_ACCOUNT_ID,
+          model: null,
+        };
       }
 
       // Create run and start workflow
@@ -84,6 +117,7 @@ const invokeMastraImageGenStep = createStep(
           canvas_snapshot: input.canvas_snapshot,
           preview_cache_key: input.preview_cache_key,
           customer_id: input.customer_id,
+          image_gen_config,
         },
       });
 

--- a/apps/backend/src/workflows/ai/generate-design-image.ts
+++ b/apps/backend/src/workflows/ai/generate-design-image.ts
@@ -46,6 +46,20 @@ export type GenerateDesignAiImageInput = {
   design_id?: string;
   mode: "preview" | "commit";
   badges?: Badge;
+  /**
+   * The normalised brief — the garment itself.
+   *
+   * 🔴 Without it the prompt enhancer builds its style context from `badges`
+   * alone and falls back to the literal string "casual fashion", so the image
+   * is of a garment nobody described. See `design_brief` on the mastra trigger
+   * schema for what that looked like in practice.
+   */
+  design_brief?: {
+    product_type?: string | null;
+    concept_theme?: string | null;
+    aesthetic_keywords?: string[];
+    color_palette?: Array<{ name?: string | null; code?: string | null }>;
+  };
   materials_prompt?: string;
   reference_images?: ReferenceImage[];
   canvas_snapshot?: CanvasSnapshot;
@@ -112,6 +126,8 @@ const invokeMastraImageGenStep = createStep(
         inputData: {
           mode: input.mode,
           badges: input.badges,
+          // The garment. Everything else here is an adjustment TO it.
+          design_brief: input.design_brief,
           materials_prompt: input.materials_prompt,
           reference_images: input.reference_images,
           canvas_snapshot: input.canvas_snapshot,

--- a/apps/backend/src/workflows/designs/create-design.ts
+++ b/apps/backend/src/workflows/designs/create-design.ts
@@ -51,6 +51,12 @@ type CreateDesignStepInput = {
    * MANUAL and no model may overwrite it.
    */
   product_type?: string | null;
+  // Roadmap #604 — design brief / collection concept. The chat design editor
+  // writes these at creation so the brief the maker converged on in chat is
+  // part of the design record (partner-ui moodboard reads concept from canvas,
+  // but the typed columns are the record).
+  concept_theme?: string | null;
+  aesthetic_keywords?: Record<string, any>;
   origin_source?: "manual" | "ai-mistral" | "ai-other";
   customer_id_for_link?: string;
   // Roadmap #6: set when a partner creates the design for their own
@@ -98,6 +104,8 @@ export const createDesignStep = createStep(
       // being stored bent, and the inference step then fills it in.
       product_type: normalizedProductType,
       product_type_source: normalizedProductType ? "manual" : null,
+      concept_theme: input.concept_theme ?? null,
+      aesthetic_keywords: (input.aesthetic_keywords ?? null) as Record<string, unknown> | null,
     });
     // Persist structured colors if provided
     if (normalizedColors?.length) {

--- a/apps/storefront/src/app/[countryCode]/(main)/design/page.tsx
+++ b/apps/storefront/src/app/[countryCode]/(main)/design/page.tsx
@@ -1,6 +1,6 @@
 import { retrieveCustomer } from "@lib/data/customer"
 import { getRegion } from "@lib/data/regions"
-import DesignEditorWrapper from "@modules/products/components/design-editor/client-wrapper"
+import DesignChatWrapper from "@modules/products/components/design-chat/client-wrapper"
 import { Metadata } from "next"
 import { notFound } from "next/navigation"
 
@@ -24,18 +24,13 @@ export default async function DesignPage(props: Props) {
 
   const customer = await retrieveCustomer().catch(() => null)
 
+  // Chat-based design editor — standalone flow (no base product; the design
+  // generates from brief + moodboard inspirations).
+  void customer
   return (
-    <DesignEditorWrapper
-      product={{
-        id: "custom_design",
-        handle: "design",
-        title: "Custom Design",
-        thumbnail: undefined,
-        description: "Create a custom design.",
-        designs: [],
-        metadata: {},
-      }}
-      customer={customer ? { id: customer.id, email: customer.email } : null}
+    <DesignChatWrapper
+      product={null}
+      initialDesign={null}
       countryCode={params.countryCode}
     />
   )

--- a/apps/storefront/src/app/[countryCode]/(main)/layout.tsx
+++ b/apps/storefront/src/app/[countryCode]/(main)/layout.tsx
@@ -6,6 +6,7 @@ import { getBaseURL } from "@lib/util/env"
 import { StoreCartShippingOption } from "@medusajs/types"
 import CartMismatchBanner from "@modules/layout/components/cart-mismatch-banner"
 import ChatLauncher from "@modules/layout/components/chat-launcher"
+import DesignStudioShell from "@modules/layout/components/design-studio-shell"
 import Footer from "@modules/layout/templates/footer"
 import Nav from "@modules/layout/templates/nav"
 import FreeShippingPriceNudge from "@modules/shipping/components/free-shipping-price-nudge"
@@ -29,22 +30,29 @@ export default async function PageLayout(props: { children: React.ReactNode }) {
 
   return (
     <>
-      <PresenceMarker />
-      <Nav />
-      {customer && cart && (
-        <CartMismatchBanner customer={customer} cart={cart} />
-      )}
+      <DesignStudioShell
+        chrome={
+          <>
+            <PresenceMarker />
+            <Nav />
+            {customer && cart && (
+              <CartMismatchBanner customer={customer} cart={cart} />
+            )}
 
-      {cart && (
-        <FreeShippingPriceNudge
-          variant="popup"
-          cart={cart}
-          shippingOptions={shippingOptions}
-        />
-      )}
-      {props.children}
-      <Footer />
-      <ChatLauncher />
+            {cart && (
+              <FreeShippingPriceNudge
+                variant="popup"
+                cart={cart}
+                shippingOptions={shippingOptions}
+              />
+            )}
+          </>
+        }
+        footer={<Footer />}
+        launcher={<ChatLauncher />}
+      >
+        {props.children}
+      </DesignStudioShell>
       <Toaster />
     </>
   )

--- a/apps/storefront/src/app/[countryCode]/(main)/products/[handle]/design/page.tsx
+++ b/apps/storefront/src/app/[countryCode]/(main)/products/[handle]/design/page.tsx
@@ -1,7 +1,7 @@
 import { listProducts } from "@lib/data/products"
 import { retrieveCustomer } from "@lib/data/customer"
 import { getDesign, DesignDetail } from "@lib/data/designs"
-import DesignEditorWrapper from "@modules/products/components/design-editor/client-wrapper"
+import DesignChatWrapper from "@modules/products/components/design-chat/client-wrapper"
 import { Metadata } from "next"
 import { notFound } from "next/navigation"
 import { getRegion } from "@lib/data/regions"
@@ -64,25 +64,27 @@ export default async function DesignPage({
     initialDesign = await getDesign(resolvedSearchParams.designId).catch(() => null)
   }
 
+  // Chat-based design editor (Konva editor dormant — see .ai-memory context).
+  // The board (Excalidraw scene on design.moodboard) renders inside the chat;
+  // customer/email seeding happens client-side via retrieveCustomerFresh.
+  void customer
   return (
-    <DesignEditorWrapper
+    <DesignChatWrapper
       product={{
         id: product.id,
         handle: product.handle,
         title: product.title,
         thumbnail: product.thumbnail || undefined,
-        description: product.description || undefined,
-        designs: (product as any).designs || [],
-        metadata: product.metadata || {},
         images: product.images?.map((i: any) => i.url) ?? [],
       }}
-      customer={customer ? {
-        id: customer.id,
-        email: customer.email,
-        aiFeaturesPaid: customer.metadata?.ai_features_paid === true,
+      initialDesign={initialDesign ? {
+        id: initialDesign.id,
+        name: initialDesign.name,
+        status: initialDesign.status,
+        thumbnail_url: initialDesign.thumbnail_url ?? null,
+        moodboard: initialDesign.moodboard,
       } : null}
       countryCode={resolvedParams.countryCode}
-      initialDesign={initialDesign}
     />
   )
 }

--- a/apps/storefront/src/lib/data/design-references.ts
+++ b/apps/storefront/src/lib/data/design-references.ts
@@ -1,0 +1,48 @@
+"use server"
+
+import { sdk } from "@lib/config"
+
+/**
+ * Design reference analysis — on-the-fly vision read of an uploaded image.
+ *
+ * The client uploads a reference (presign → S3) and calls this immediately
+ * after, so the image is described the moment it arrives (not deferred to a
+ * later model tool call). The backend returns the analysis AND caches it on
+ * the MediaFile record (`metadata.vision_analysis`), so subsequent turns and
+ * tool calls reuse it without another vision round-trip.
+ *
+ * Best-effort: returns `{ analysis: null }` on failure so the upload flow
+ * never blocks.
+ */
+export type ReferenceAnalysisResult = {
+  title: string
+  description: string
+  suggestions: string[]
+  media_id: string | null
+  analyzed_at: string | null
+  cached?: boolean
+}
+
+export const analyzeDesignReference = async (input: {
+  url: string
+  name?: string
+  mime_type?: string
+}): Promise<{ analysis: ReferenceAnalysisResult | null }> => {
+  try {
+    const data = await sdk.client.fetch<{
+      analysis: ReferenceAnalysisResult | null
+    }>(`/store/custom/design-assistant/references/analyze`, {
+      method: "POST",
+      body: {
+        url: input.url,
+        ...(input.name ? { name: input.name } : {}),
+        ...(input.mime_type ? { mime_type: input.mime_type } : {}),
+      },
+      headers: { "Content-Type": "application/json" },
+    })
+    return { analysis: data.analysis ?? null }
+  } catch (error) {
+    console.error("Error analyzing design reference:", error)
+    return { analysis: null }
+  }
+}

--- a/apps/storefront/src/lib/util/designer-email.ts
+++ b/apps/storefront/src/lib/util/designer-email.ts
@@ -1,0 +1,36 @@
+"use client"
+
+/**
+ * Designer email — the maker's email, remembered across design threads.
+ *
+ * The design chat creates a guest customer keyed on email the first time the
+ * maker generates. We remember it globally (not per-thread) so starting a NEW
+ * design never re-asks for the email — the onboarding only asks for the
+ * garment type once an email is on file. Signed-in customers seed their email
+ * server-side (retrieveCustomerFresh) and this store acts as the backstop for
+ * anonymous makers.
+ */
+
+const STORAGE_KEY = "jyt:store:designer-email-v1"
+
+const isBrowser = typeof window !== "undefined"
+
+export const loadDesignerEmail = (): string | null => {
+  if (!isBrowser) return null
+  try {
+    const value = window.localStorage.getItem(STORAGE_KEY)
+    return value && value.length > 0 ? value : null
+  } catch {
+    return null
+  }
+}
+
+export const saveDesignerEmail = (email: string): void => {
+  if (!isBrowser) return
+  try {
+    const normalized = email.trim().toLowerCase()
+    if (normalized) window.localStorage.setItem(STORAGE_KEY, normalized)
+  } catch {
+    // best-effort — storage quota / private mode
+  }
+}

--- a/apps/storefront/src/modules/home/components/ai-search-chat/index.tsx
+++ b/apps/storefront/src/modules/home/components/ai-search-chat/index.tsx
@@ -25,6 +25,7 @@ import {
 } from "@lib/util/concierge-thread"
 import { getOrCreateVisitorId } from "@lib/util/visitor-id"
 import OnboardingForm, { type OnboardingHandle } from "./onboarding"
+import { MarkdownContent } from "./markdown-content"
 
 /**
  * Full-page Cici concierge chat, rendered at `/[countryCode]/chat`.

--- a/apps/storefront/src/modules/home/components/ai-search-chat/markdown-content.tsx
+++ b/apps/storefront/src/modules/home/components/ai-search-chat/markdown-content.tsx
@@ -1,0 +1,134 @@
+"use client"
+
+import React from "react"
+
+/**
+ * Tiny markdown renderer for chat replies — covers the subset the design
+ * models actually emit (probed: bold, italics, headings, unordered/ordered
+ * lists, inline code). No react-markdown dependency; renders to styled JSX
+ * matching the bubble typography.
+ *
+ * The storefront chat models reply in markdown ("**Brief – first step**" +
+ * numbered onboarding questions) — rendered raw, the asterisks show. This
+ * formats them.
+ */
+
+type Inline = string
+
+/** Inline formatting: **bold**, *italic*, `code` — tokenized, no nesting. */
+const renderInline = (text: Inline, keyPrefix: string): React.ReactNode[] => {
+  const nodes: React.ReactNode[] = []
+  const re = /(\*\*[^*]+\*\*|\*[^*\n]+\*|`[^`\n]+`)/g
+  let last = 0
+  let m: RegExpExecArray | null
+  let i = 0
+  while ((m = re.exec(text))) {
+    if (m.index > last) nodes.push(text.slice(last, m.index))
+    const token = m[0]
+    const key = `${keyPrefix}-${i++}`
+    if (token.startsWith("**")) {
+      nodes.push(
+        <strong key={key} className="font-semibold">
+          {token.slice(2, -2)}
+        </strong>
+      )
+    } else if (token.startsWith("`")) {
+      nodes.push(
+        <code key={key} className="rounded bg-ui-bg-base-pressed px-1 py-0.5 text-[0.9em]">
+          {token.slice(1, -1)}
+        </code>
+      )
+    } else {
+      nodes.push(
+        <em key={key} className="italic">
+          {token.slice(1, -1)}
+        </em>
+      )
+    }
+    last = m.index + token.length
+  }
+  if (last < text.length) nodes.push(text.slice(last))
+  return nodes
+}
+
+export const MarkdownContent = ({ text }: { text: string }) => {
+  const blocks = React.useMemo(() => {
+    const lines = text.split("\n")
+    const out: React.ReactNode[] = []
+    let listBuffer: { ordered: boolean; items: string[] } | null = null
+    let key = 0
+
+    const flushList = () => {
+      if (!listBuffer) return
+      const { ordered, items } = listBuffer
+      const itemsNodes = items.map((item, i) => (
+        <li key={i} className="pl-1">
+          {renderInline(item, `li-${key}-${i}`)}
+        </li>
+      ))
+      out.push(
+        ordered ? (
+          <ol key={`l-${key++}`} className="ml-5 list-decimal space-y-1">
+            {itemsNodes}
+          </ol>
+        ) : (
+          <ul key={`l-${key++}`} className="ml-5 list-disc space-y-1">
+            {itemsNodes}
+          </ul>
+        )
+      )
+      listBuffer = null
+    }
+
+    for (const raw of lines) {
+      const line = raw.trimEnd()
+      const heading = line.match(/^(#{1,4})\s+(.*)$/)
+      const bullet = line.match(/^\s*[-*•]\s+(.*)$/)
+      const ordered = line.match(/^\s*\d+[.)]\s+(.*)$/)
+
+      if (heading) {
+        flushList()
+        const level = heading[1].length
+        out.push(
+          level <= 2 ? (
+            <p key={`h-${key++}`} className="mt-2 font-semibold">
+              {renderInline(heading[2], `h-${key}`)}
+            </p>
+          ) : (
+            <p key={`h-${key++}`} className="mt-1.5 font-medium">
+              {renderInline(heading[2], `h-${key}`)}
+            </p>
+          )
+        )
+        continue
+      }
+      if (bullet) {
+        if (!listBuffer || listBuffer.ordered) {
+          flushList()
+          listBuffer = { ordered: false, items: [] }
+        }
+        listBuffer.items.push(bullet[1])
+        continue
+      }
+      if (ordered) {
+        if (!listBuffer || !listBuffer.ordered) {
+          flushList()
+          listBuffer = { ordered: true, items: [] }
+        }
+        listBuffer.items.push(ordered[1])
+        continue
+      }
+      flushList()
+      if (!line.trim()) continue
+      out.push(
+        <p key={`p-${key++}`} className="whitespace-pre-wrap">
+          {renderInline(line, `p-${key}`)}
+        </p>
+      )
+    }
+    flushList()
+    return out
+  }, [text])
+
+  return <div className="flex flex-col gap-1.5">{blocks}</div>
+}

--- a/apps/storefront/src/modules/layout/components/design-studio-shell/index.tsx
+++ b/apps/storefront/src/modules/layout/components/design-studio-shell/index.tsx
@@ -1,0 +1,48 @@
+"use client"
+
+import { usePathname } from "next/navigation"
+import React from "react"
+
+/**
+ * Design-studio shell — switches the storefront chrome off on the immersive
+ * design routes so the chat-based design editor can run full-screen.
+ *
+ * The routes themselves stay put (no route-group juggling); this client
+ * component just reads the pathname and drops the nav / footer / launcher
+ * when the current page is the design studio.
+ */
+const DESIGN_STUDIO_PATTERNS = [
+  /^\/[^/]+\/design\/?$/,
+  /^\/[^/]+\/products\/[^/]+\/design\/?$/,
+]
+
+const isDesignStudioRoute = (pathname: string) =>
+  DESIGN_STUDIO_PATTERNS.some((re) => re.test(pathname))
+
+export default function DesignStudioShell({
+  chrome,
+  footer,
+  launcher,
+  children,
+}: {
+  chrome: React.ReactNode
+  footer: React.ReactNode
+  launcher: React.ReactNode
+  children: React.ReactNode
+}) {
+  const pathname = usePathname()
+  const isStudio = isDesignStudioRoute(pathname ?? "")
+
+  if (isStudio) {
+    return <>{children}</>
+  }
+
+  return (
+    <>
+      {chrome}
+      {children}
+      {footer}
+      {launcher}
+    </>
+  )
+}

--- a/apps/storefront/src/modules/products/components/design-chat/client-wrapper.tsx
+++ b/apps/storefront/src/modules/products/components/design-chat/client-wrapper.tsx
@@ -1,0 +1,69 @@
+"use client"
+
+import { useEffect, useState } from "react"
+import dynamic from "next/dynamic"
+
+// Dynamic import to avoid SSR issues (Konva isn't used here, but the chat
+// hydrates from localStorage threads — client-only keeps first paint clean
+// and matches the dormant editor's wrapper pattern).
+const DesignChat = dynamic(() => import("./index"), {
+  ssr: false,
+  loading: () => (
+    <div className="flex h-screen items-center justify-center bg-ui-bg-subtle">
+      <div className="flex flex-col items-center gap-4 rounded-3xl border border-ui-border-base bg-ui-bg-field px-10 py-8 shadow-lg">
+        <div className="h-10 w-10 animate-spin rounded-full border-4 border-ui-border-base border-t-ui-fg-muted" />
+        <span className="text-sm text-ui-fg-subtle">Preparing your design board…</span>
+      </div>
+    </div>
+  ),
+})
+
+interface DesignChatWrapperProps {
+  product?: {
+    id: string
+    handle: string
+    title: string
+    thumbnail?: string | null
+    images?: string[]
+  } | null
+  initialDesign?: {
+    id: string
+    name?: string
+    status?: string
+    thumbnail_url?: string | null
+    moodboard?: unknown
+  } | null
+  countryCode: string
+}
+
+/**
+ * Client wrapper for the chat-based design editor.
+ *
+ * The customer/email seeding happens inside DesignChat itself
+ * (retrieveCustomerFresh on mount — same stale-cache fix as the dormant
+ * editor's wrapper). This shell only owns responsive detection and the
+ * dynamic import.
+ */
+export default function DesignChatWrapper({
+  product,
+  initialDesign,
+  countryCode,
+}: DesignChatWrapperProps) {
+  const [isMobileLayout, setIsMobileLayout] = useState(false)
+
+  useEffect(() => {
+    const check = () => setIsMobileLayout(window.innerWidth < 1024)
+    check()
+    window.addEventListener("resize", check)
+    return () => window.removeEventListener("resize", check)
+  }, [])
+
+  return (
+    <DesignChat
+      product={product}
+      initialDesign={initialDesign}
+      countryCode={countryCode}
+      isMobileLayout={isMobileLayout}
+    />
+  )
+}

--- a/apps/storefront/src/modules/products/components/design-chat/components/attachments.tsx
+++ b/apps/storefront/src/modules/products/components/design-chat/components/attachments.tsx
@@ -1,0 +1,178 @@
+"use client"
+
+import React from "react"
+import clsx from "clsx"
+import { PhotoSolid, Spinner, XMark } from "@medusajs/icons"
+import type { DesignReference } from "../lib/design-uploads"
+
+/**
+ * Attachment thumbnails — the chat design editor's file display primitives.
+ *
+ * Two jobs:
+ *   - `AttachButton` opens the OS file picker and hands accepted images up.
+ *   - `AttachmentThumb` / `AttachmentThumbnails` render the thumbnails
+ *     "across the chat": in the composer (pending) and inside the sent
+ *     user message bubble (preview / uploading / ready / errored states).
+ */
+
+export type AttachmentThumbData = {
+  id: string
+  name: string
+  previewUrl: string
+  status?: DesignReference["status"]
+  error?: string
+  /** On-the-fly vision read — shown as a hover hint + "AI read" badge. */
+  analysis?: { title?: string; description?: string } | null
+}
+
+export function AttachmentThumb({
+  id,
+  name,
+  previewUrl,
+  status = "preview",
+  error,
+  analysis,
+  onRemove,
+  compact = false,
+  className,
+}: AttachmentThumbData & {
+  onRemove?: (id: string) => void
+  compact?: boolean
+  className?: string
+}) {
+  const hint = analysis?.title
+    ? `${analysis.title}${analysis.description ? ` — ${analysis.description}` : ""}`
+    : name
+
+  return (
+    <div
+      className={clsx(
+        "group relative shrink-0 overflow-hidden rounded-lg border border-ui-border-base bg-ui-bg-base",
+        compact ? "h-14 w-14" : "h-20 w-20",
+        className
+      )}
+      title={hint}
+    >
+      {/* eslint-disable-next-line @next/next/no-img-element */}
+      <img
+        src={previewUrl}
+        alt={name}
+        className="h-full w-full object-cover"
+      />
+
+      {status === "uploading" && (
+        <div className="absolute inset-0 flex items-center justify-center bg-black/40">
+          <Spinner className="h-4 w-4 animate-spin text-white" />
+        </div>
+      )}
+
+      {analysis?.title && status !== "uploading" && (
+        <span
+          className="absolute left-1 top-1 rounded bg-black/55 px-1 py-0.5 text-[8px] font-medium uppercase tracking-wide text-white/90"
+          title={hint}
+        >
+          ✦ AI read
+        </span>
+      )}
+
+      {status === "error" && (
+        <div className="absolute inset-x-0 bottom-0 bg-ui-tag-red-bg/90 px-1 py-0.5 text-center text-[9px] leading-3 text-ui-tag-red-text">
+          {error ?? "upload failed"}
+        </div>
+      )}
+
+      {status === "ready" && (
+        <div className="absolute inset-x-0 bottom-0 bg-ui-tag-green-bg/90 px-1 py-0.5 text-center text-[9px] font-medium leading-3 text-ui-tag-green-text">
+          Ready
+        </div>
+      )}
+
+      {onRemove && (
+        <button
+          type="button"
+          onClick={() => onRemove(id)}
+          aria-label={`Remove ${name}`}
+          className="absolute right-1 top-1 rounded-full bg-black/60 p-0.5 text-white opacity-0 transition-opacity group-hover:opacity-100"
+        >
+          <XMark className="h-3 w-3" />
+        </button>
+      )}
+    </div>
+  )
+}
+
+export function AttachmentThumbnails({
+  refs,
+  onRemove,
+  compact = false,
+  className,
+}: {
+  refs: AttachmentThumbData[]
+  onRemove?: (id: string) => void
+  compact?: boolean
+  className?: string
+}) {
+  if (!refs.length) return null
+  return (
+    <div className={clsx("flex flex-wrap gap-2", className)}>
+      {refs.map((ref) => (
+        <AttachmentThumb
+          key={ref.id}
+          id={ref.id}
+          name={ref.name}
+          previewUrl={ref.previewUrl}
+          status={ref.status}
+          error={ref.error}
+          onRemove={onRemove}
+          compact={compact}
+        />
+      ))}
+    </div>
+  )
+}
+
+export function AttachButton({
+  onFiles,
+  disabled,
+  className,
+  inputRef,
+}: {
+  onFiles: (files: File[]) => void
+  disabled?: boolean
+  className?: string
+  inputRef?: React.RefObject<HTMLInputElement | null>
+}) {
+  const handleChange = (e: React.ChangeEvent<HTMLInputElement>) => {
+    const files = Array.from(e.target.files ?? [])
+    if (files.length) onFiles(files)
+    // Reset so the same file can be picked again.
+    e.target.value = ""
+  }
+
+  return (
+    <>
+      <input
+        ref={inputRef}
+        type="file"
+        accept="image/jpeg,image/png,image/webp,image/gif"
+        multiple
+        onChange={handleChange}
+        className="hidden"
+        aria-label="Attach reference images"
+      />
+      <button
+        type="button"
+        disabled={disabled}
+        onClick={() => inputRef?.current?.click()}
+        aria-label="Attach reference images"
+        title="Add inspirations / reference photos"
+        className={clsx(
+          "flex h-9 w-9 shrink-0 items-center justify-center rounded-lg text-ui-fg-subtle transition-colors hover:bg-ui-bg-base-hover hover:text-ui-fg-base disabled:opacity-40",
+          className
+        )}
+      >
+        <PhotoSolid className="h-5 w-5" />
+      </button>
+    </>
+  )
+}

--- a/apps/storefront/src/modules/products/components/design-chat/components/markdown-content.tsx
+++ b/apps/storefront/src/modules/products/components/design-chat/components/markdown-content.tsx
@@ -1,0 +1,134 @@
+"use client"
+
+import React from "react"
+
+/**
+ * Tiny markdown renderer for chat replies — covers the subset the design
+ * models actually emit (probed: bold, italics, headings, unordered/ordered
+ * lists, inline code). No react-markdown dependency; renders to styled JSX
+ * matching the bubble typography.
+ *
+ * The storefront chat models reply in markdown ("**Brief – first step**" +
+ * numbered onboarding questions) — rendered raw, the asterisks show. This
+ * formats them.
+ */
+
+type Inline = string
+
+/** Inline formatting: **bold**, *italic*, `code` — tokenized, no nesting. */
+const renderInline = (text: Inline, keyPrefix: string): React.ReactNode[] => {
+  const nodes: React.ReactNode[] = []
+  const re = /(\*\*[^*]+\*\*|\*[^*\n]+\*|`[^`\n]+`)/g
+  let last = 0
+  let m: RegExpExecArray | null
+  let i = 0
+  while ((m = re.exec(text))) {
+    if (m.index > last) nodes.push(text.slice(last, m.index))
+    const token = m[0]
+    const key = `${keyPrefix}-${i++}`
+    if (token.startsWith("**")) {
+      nodes.push(
+        <strong key={key} className="font-semibold">
+          {token.slice(2, -2)}
+        </strong>
+      )
+    } else if (token.startsWith("`")) {
+      nodes.push(
+        <code key={key} className="rounded bg-ui-bg-base-pressed px-1 py-0.5 text-[0.9em]">
+          {token.slice(1, -1)}
+        </code>
+      )
+    } else {
+      nodes.push(
+        <em key={key} className="italic">
+          {token.slice(1, -1)}
+        </em>
+      )
+    }
+    last = m.index + token.length
+  }
+  if (last < text.length) nodes.push(text.slice(last))
+  return nodes
+}
+
+export const MarkdownContent = ({ text }: { text: string }) => {
+  const blocks = React.useMemo(() => {
+    const lines = text.split("\n")
+    const out: React.ReactNode[] = []
+    let listBuffer: { ordered: boolean; items: string[] } | null = null
+    let key = 0
+
+    const flushList = () => {
+      if (!listBuffer) return
+      const { ordered, items } = listBuffer
+      const itemsNodes = items.map((item, i) => (
+        <li key={i} className="pl-1">
+          {renderInline(item, `li-${key}-${i}`)}
+        </li>
+      ))
+      out.push(
+        ordered ? (
+          <ol key={`l-${key++}`} className="ml-5 list-decimal space-y-1">
+            {itemsNodes}
+          </ol>
+        ) : (
+          <ul key={`l-${key++}`} className="ml-5 list-disc space-y-1">
+            {itemsNodes}
+          </ul>
+        )
+      )
+      listBuffer = null
+    }
+
+    for (const raw of lines) {
+      const line = raw.trimEnd()
+      const heading = line.match(/^(#{1,4})\s+(.*)$/)
+      const bullet = line.match(/^\s*[-*•]\s+(.*)$/)
+      const ordered = line.match(/^\s*\d+[.)]\s+(.*)$/)
+
+      if (heading) {
+        flushList()
+        const level = heading[1].length
+        out.push(
+          level <= 2 ? (
+            <p key={`h-${key++}`} className="mt-2 font-semibold">
+              {renderInline(heading[2], `h-${key}`)}
+            </p>
+          ) : (
+            <p key={`h-${key++}`} className="mt-1.5 font-medium">
+              {renderInline(heading[2], `h-${key}`)}
+            </p>
+          )
+        )
+        continue
+      }
+      if (bullet) {
+        if (!listBuffer || listBuffer.ordered) {
+          flushList()
+          listBuffer = { ordered: false, items: [] }
+        }
+        listBuffer.items.push(bullet[1])
+        continue
+      }
+      if (ordered) {
+        if (!listBuffer || !listBuffer.ordered) {
+          flushList()
+          listBuffer = { ordered: true, items: [] }
+        }
+        listBuffer.items.push(ordered[1])
+        continue
+      }
+      flushList()
+      if (!line.trim()) continue
+      out.push(
+        <p key={`p-${key++}`} className="whitespace-pre-wrap">
+          {renderInline(line, `p-${key}`)}
+        </p>
+      )
+    }
+    flushList()
+    return out
+  }, [text])
+
+  return <div className="flex flex-col gap-1.5">{blocks}</div>
+}

--- a/apps/storefront/src/modules/products/components/design-chat/components/message-parts.tsx
+++ b/apps/storefront/src/modules/products/components/design-chat/components/message-parts.tsx
@@ -75,7 +75,24 @@ export type MaterialHit = {
   inventory_item_id: string | null
 }
 
-export const MaterialsCall = ({ part }: { part: any }) => {
+/**
+ * What a maker can click instead of describing.
+ *
+ * 🔑 The tool results were render-only: the assistant laid out eight fabrics
+ * and four partners as pictures, and the only way to choose one was to type its
+ * name back at the model — which then had to guess which row you meant. The
+ * card IS the choice now; the typed sentence it sends carries the id, so the
+ * model resolves it exactly rather than by fuzzy name match.
+ */
+export type ChoiceHandler = (text: string) => void
+
+export const MaterialsCall = ({
+  part,
+  onChoose,
+}: {
+  part: any
+  onChoose?: ChoiceHandler
+}) => {
   const state = part?.state as string | undefined
 
   if (state === "input-streaming" || state === "input-available") {
@@ -92,10 +109,19 @@ export const MaterialsCall = ({ part }: { part: any }) => {
     return (
       <div className="mt-3 grid grid-cols-4 gap-2">
         {materials.map((m) => (
-          <div
+          <button
             key={m.id}
+            type="button"
+            disabled={!onChoose}
+            onClick={() =>
+              onChoose?.(
+                `Use ${m.name ?? m.category ?? "this fabric"}${
+                  m.composition ? ` (${m.composition})` : ""
+                } — inventory item ${m.inventory_item_id ?? m.id}.`
+              )
+            }
             title={[m.name, m.composition].filter(Boolean).join(" · ")}
-            className="flex flex-col items-center gap-1 rounded-lg border border-ui-border-base bg-ui-bg-base p-2"
+            className="flex flex-col items-center gap-1 rounded-lg border border-ui-border-base bg-ui-bg-base p-2 text-left transition enabled:hover:border-ui-border-interactive enabled:hover:bg-ui-bg-base-hover enabled:focus-visible:outline enabled:focus-visible:outline-2 enabled:focus-visible:outline-ui-border-interactive disabled:cursor-default"
           >
             {m.thumbnail ? (
               /* eslint-disable-next-line @next/next/no-img-element */
@@ -113,7 +139,7 @@ export const MaterialsCall = ({ part }: { part: any }) => {
             <p className="w-full truncate text-center text-[10px] font-medium">
               {m.name ?? m.category ?? "Fabric"}
             </p>
-          </div>
+          </button>
         ))}
       </div>
     )
@@ -134,7 +160,13 @@ export type PartnerHit = {
   workspace_type: string | null
 }
 
-export const PartnersCall = ({ part }: { part: any }) => {
+export const PartnersCall = ({
+  part,
+  onChoose,
+}: {
+  part: any
+  onChoose?: ChoiceHandler
+}) => {
   const state = part?.state as string | undefined
 
   if (state === "input-streaming" || state === "input-available") {
@@ -151,9 +183,16 @@ export const PartnersCall = ({ part }: { part: any }) => {
     return (
       <div className="mt-3 flex flex-col gap-2">
         {partners.map((p) => (
-          <div
+          <button
             key={p.id}
-            className="flex items-center gap-3 rounded-lg bg-ui-bg-base p-2"
+            type="button"
+            disabled={!onChoose}
+            onClick={() =>
+              onChoose?.(
+                `Make it with ${p.company_name ?? p.name ?? "this partner"} — partner ${p.id}.`
+              )
+            }
+            className="flex w-full items-center gap-3 rounded-lg bg-ui-bg-base p-2 text-left transition enabled:hover:bg-ui-bg-base-hover enabled:focus-visible:outline enabled:focus-visible:outline-2 enabled:focus-visible:outline-ui-border-interactive disabled:cursor-default"
           >
             {p.logo ? (
               /* eslint-disable-next-line @next/next/no-img-element */
@@ -175,7 +214,7 @@ export const PartnersCall = ({ part }: { part: any }) => {
                 <p className="truncate text-xs text-ui-fg-subtle">{p.path}</p>
               )}
             </div>
-          </div>
+          </button>
         ))}
       </div>
     )
@@ -300,7 +339,46 @@ export const GenerateCall = ({ part }: { part: any }) => {
 
 // ── save_brief / set_active_canvas / save_moodboard / get_design_state ─
 
-export const SaveBriefCall = ({ part }: { part: any }) => {
+/**
+ * The next step, as buttons.
+ *
+ * Generation is gated on explicit consent, which is right — it costs money and
+ * takes ~20s per take. But "explicit consent" was only ever expressible as a
+ * free-typed sentence, so the maker had to guess the magic words, and the model
+ * had to decide whether "go on then" counted. These say the same thing in one
+ * click, in the words the flow already understands.
+ */
+export const ChoiceRow = ({
+  choices,
+  onChoose,
+}: {
+  choices: Array<{ label: string; send: string }>
+  onChoose?: ChoiceHandler
+}) => {
+  if (!onChoose || !choices.length) return null
+  return (
+    <div className="mt-3 flex flex-wrap gap-2">
+      {choices.map((c) => (
+        <button
+          key={c.label}
+          type="button"
+          onClick={() => onChoose(c.send)}
+          className="rounded-full border border-ui-border-interactive bg-ui-bg-base px-3 py-1.5 text-xs font-medium text-ui-fg-interactive transition hover:bg-ui-bg-base-hover focus-visible:outline focus-visible:outline-2 focus-visible:outline-ui-border-interactive"
+        >
+          {c.label}
+        </button>
+      ))}
+    </div>
+  )
+}
+
+export const SaveBriefCall = ({
+  part,
+  onChoose,
+}: {
+  part: any
+  onChoose?: ChoiceHandler
+}) => {
   const state = part?.state as string | undefined
   if (state === "input-streaming" || state === "input-available") {
     return <ToolStatusChip label="Locking in the brief…" />
@@ -311,20 +389,36 @@ export const SaveBriefCall = ({ part }: { part: any }) => {
   if (state === "output-available") {
     const brief = part.output?.brief ?? {}
     return (
-      <div className="mt-2 flex flex-wrap gap-1">
-        {brief.product_type && (
-          <span className="rounded-full bg-ui-tag-green-bg px-2 py-0.5 text-[10px] font-medium uppercase text-ui-tag-green-text">
-            {brief.product_type.replace(/_/g, " ")}
-          </span>
-        )}
-        {(brief.aesthetic_keywords ?? []).slice(0, 5).map((k: string) => (
-          <span
-            key={k}
-            className="rounded-full bg-ui-bg-base-pressed px-2 py-0.5 text-[10px] text-ui-fg-subtle"
-          >
-            {k}
-          </span>
-        ))}
+      <div className="mt-2">
+        <div className="flex flex-wrap gap-1">
+          {brief.product_type && (
+            <span className="rounded-full bg-ui-tag-green-bg px-2 py-0.5 text-[10px] font-medium uppercase text-ui-tag-green-text">
+              {brief.product_type.replace(/_/g, " ")}
+            </span>
+          )}
+          {(brief.aesthetic_keywords ?? []).slice(0, 5).map((k: string) => (
+            <span
+              key={k}
+              className="rounded-full bg-ui-bg-base-pressed px-2 py-0.5 text-[10px] text-ui-fg-subtle"
+            >
+              {k}
+            </span>
+          ))}
+        </div>
+        <ChoiceRow
+          onChoose={onChoose}
+          choices={[
+            { label: "Show me fabrics", send: "Show me the fabric options." },
+            {
+              label: "Find a partner to make it",
+              send: "Show me partners who could make this.",
+            },
+            {
+              label: "Generate two takes",
+              send: "Go ahead and generate the two takes now.",
+            },
+          ]}
+        />
       </div>
     )
   }
@@ -380,6 +474,11 @@ export const ConversationCall = ({ part }: { part: any }) => {
 
 // ── dispatch map ───────────────────────────────────────────────────────
 
+/**
+ * Every renderer takes `onChoose`; the ones that ignore it simply don't offer
+ * choices. Passing it uniformly is what lets the chat stay the single place
+ * that knows how to send a message.
+ */
 export const DESIGN_TOOL_PARTS: Record<string, React.ComponentType<any>> = {
   "tool-list_raw_materials": MaterialsCall,
   "tool-list_partners": PartnersCall,

--- a/apps/storefront/src/modules/products/components/design-chat/components/message-parts.tsx
+++ b/apps/storefront/src/modules/products/components/design-chat/components/message-parts.tsx
@@ -1,0 +1,406 @@
+"use client"
+
+import React from "react"
+import clsx from "clsx"
+import { Text } from "@medusajs/ui"
+import {
+  CheckCircleSolid,
+  ExclamationCircleSolid,
+  Spinner,
+} from "@medusajs/icons"
+import { listDesignConversations } from "../lib/design-conversations"
+
+/**
+ * Tool-part renderers for the design chat.
+ *
+ * Each renderer drives off the AI-SDK tool-part state machine
+ * (input-streaming → input-available → output-available | output-error) so
+ * SKELETON loading states render while the tool runs — fabric chip grids while
+ * materials load, partner cards while partners load, A/B canvas shimmer while
+ * the two takes generate (~20s per image, the long op), text-line skeletons
+ * while analysis runs.
+ */
+
+// ── Shared primitives ──────────────────────────────────────────────────
+
+/** Status chip ("Choosing fabrics…") — the tool lifecycle signal. */
+export const ToolStatusChip = ({
+  label,
+  tone = "pending",
+}: {
+  label: string
+  tone?: "pending" | "done" | "error"
+}) => (
+  <p
+    className={clsx(
+      "mt-2 inline-flex items-center gap-2 rounded-full px-2.5 py-1 text-xs",
+      tone === "pending" && "bg-ui-bg-base-pressed text-ui-fg-subtle",
+      tone === "done" && "bg-ui-tag-green-bg text-ui-tag-green-text",
+      tone === "error" && "bg-ui-tag-red-bg text-ui-tag-red-text"
+    )}
+  >
+    {tone === "pending" ? (
+      <span className="h-1.5 w-1.5 animate-pulse rounded-full bg-ui-fg-muted" />
+    ) : tone === "done" ? (
+      <CheckCircleSolid className="h-3.5 w-3.5" />
+    ) : (
+      <ExclamationCircleSolid className="h-3.5 w-3.5" />
+    )}
+    {label}
+  </p>
+)
+
+/** Shimmering text-line skeleton — assistant text pending. */
+export const TextLineSkeleton = () => (
+  <div className="flex flex-col gap-1.5 py-1">
+    {[90, 75, 55].map((w, i) => (
+      <div
+        key={i}
+        style={{ width: `${w}%` }}
+        className="h-3 animate-pulse rounded bg-ui-bg-base-pressed"
+      />
+    ))}
+  </div>
+)
+
+// ── list_raw_materials ─────────────────────────────────────────────────
+
+export type MaterialHit = {
+  id: string
+  name: string | null
+  color: string | null
+  composition: string | null
+  thumbnail: string | null
+  category: string | null
+  inventory_item_id: string | null
+}
+
+export const MaterialsCall = ({ part }: { part: any }) => {
+  const state = part?.state as string | undefined
+
+  if (state === "input-streaming" || state === "input-available") {
+    return <ToolStatusChip label="Choosing fabrics…" />
+  }
+  if (state === "output-error") {
+    return <ToolStatusChip label="Couldn't reach the fabric library." tone="error" />
+  }
+  if (state === "output-available") {
+    const materials: MaterialHit[] = part.output?.materials ?? []
+    if (!materials.length) {
+      return <ToolStatusChip label="No fabrics matched that." tone="error" />
+    }
+    return (
+      <div className="mt-3 grid grid-cols-4 gap-2">
+        {materials.map((m) => (
+          <div
+            key={m.id}
+            title={[m.name, m.composition].filter(Boolean).join(" · ")}
+            className="flex flex-col items-center gap-1 rounded-lg border border-ui-border-base bg-ui-bg-base p-2"
+          >
+            {m.thumbnail ? (
+              /* eslint-disable-next-line @next/next/no-img-element */
+              <img
+                src={m.thumbnail}
+                alt={m.name ?? "Fabric"}
+                className="aspect-square w-full rounded-md object-cover"
+              />
+            ) : (
+              <div
+                className="aspect-square w-full rounded-md"
+                style={{ backgroundColor: m.color || "#eceff1" }}
+              />
+            )}
+            <p className="w-full truncate text-center text-[10px] font-medium">
+              {m.name ?? m.category ?? "Fabric"}
+            </p>
+          </div>
+        ))}
+      </div>
+    )
+  }
+  return null
+}
+
+// ── list_partners ──────────────────────────────────────────────────────
+
+export type PartnerHit = {
+  id: string
+  name: string | null
+  company_name: string | null
+  logo: string | null
+  description: string | null
+  /** Friendly role along the production path (Fabric Seller, Manufacturer, …). */
+  path: string | null
+  workspace_type: string | null
+}
+
+export const PartnersCall = ({ part }: { part: any }) => {
+  const state = part?.state as string | undefined
+
+  if (state === "input-streaming" || state === "input-available") {
+    return <ToolStatusChip label="Finding who makes this…" />
+  }
+  if (state === "output-error") {
+    return <ToolStatusChip label="Couldn't reach partners." tone="error" />
+  }
+  if (state === "output-available") {
+    const partners: PartnerHit[] = part.output?.partners ?? []
+    if (!partners.length) {
+      return <ToolStatusChip label="No verified partners yet." tone="error" />
+    }
+    return (
+      <div className="mt-3 flex flex-col gap-2">
+        {partners.map((p) => (
+          <div
+            key={p.id}
+            className="flex items-center gap-3 rounded-lg bg-ui-bg-base p-2"
+          >
+            {p.logo ? (
+              /* eslint-disable-next-line @next/next/no-img-element */
+              <img
+                src={p.logo}
+                alt=""
+                className="h-11 w-11 shrink-0 rounded-md object-cover"
+              />
+            ) : (
+              <div className="flex h-11 w-11 shrink-0 items-center justify-center rounded-md bg-ui-bg-base-pressed text-sm">
+                🧶
+              </div>
+            )}
+            <div className="min-w-0 flex-1">
+              <p className="truncate text-sm font-medium">
+                {p.company_name ?? p.name}
+              </p>
+              {p.path && (
+                <p className="truncate text-xs text-ui-fg-subtle">{p.path}</p>
+              )}
+            </div>
+          </div>
+        ))}
+      </div>
+    )
+  }
+  return null
+}
+
+// ── analyze_product_image ──────────────────────────────────────────────
+
+export const AnalyzeCall = ({ part }: { part: any }) => {
+  const state = part?.state as string | undefined
+
+  if (state === "input-streaming" || state === "input-available") {
+    return (
+      <div className="mt-2">
+        <ToolStatusChip label="Reading the garment…" />
+        <TextLineSkeleton />
+      </div>
+    )
+  }
+  if (state === "output-error") {
+    return <ToolStatusChip label="Couldn't analyse the image." tone="error" />
+  }
+  if (state === "output-available") {
+    const analysis = part.output ?? {}
+    const suggestions: string[] = analysis.suggestions ?? []
+    if (!suggestions.length) return null
+    return (
+      <ul className="mt-2 flex flex-col gap-1">
+        {suggestions.map((s, i) => (
+          <li
+            key={i}
+            className="flex items-start gap-2 rounded-lg bg-ui-bg-base p-2 text-xs text-ui-fg-base"
+          >
+            <span className="mt-0.5 shrink-0 text-ui-fg-muted">◆</span>
+            {s}
+          </li>
+        ))}
+      </ul>
+    )
+  }
+  return null
+}
+
+// ── generate_design_image (the long op) ────────────────────────────────
+
+export type CanvasCandidate = {
+  canvas_id: string
+  letter: "A" | "B"
+  image_url: string
+  prompt_used: string
+}
+
+export const GenerateCall = ({ part }: { part: any }) => {
+  const state = part?.state as string | undefined
+
+  if (state === "input-streaming" || state === "input-available") {
+    return (
+      <div className="mt-3 flex flex-col gap-2">
+        <ToolStatusChip label="Generating two takes… (~20 seconds)" />
+        <div className="grid grid-cols-2 gap-2">
+          {["A", "B"].map((letter) => (
+            <div
+              key={letter}
+              className="relative aspect-[3/4] animate-pulse overflow-hidden rounded-xl border border-ui-border-base bg-ui-bg-base-pressed"
+            >
+              <span className="absolute left-2 top-2 rounded-md bg-black/60 px-1.5 py-0.5 text-[10px] font-bold uppercase text-white">
+                {letter}
+              </span>
+            </div>
+          ))}
+        </div>
+      </div>
+    )
+  }
+  if (state === "output-error") {
+    return (
+      <div className="mt-2">
+        <ToolStatusChip label="Generation failed — try again." tone="error" />
+      </div>
+    )
+  }
+  if (state === "output-available") {
+    const result = part.output ?? {}
+    const candidates: CanvasCandidate[] = result.candidates ?? []
+    const created = result.created_design
+    return (
+      <div className="mt-3 flex flex-col gap-2">
+        {created && (
+          <ToolStatusChip label="Design saved to your account" tone="done" />
+        )}
+        <div className="grid grid-cols-2 gap-2">
+          {candidates.map((c) => (
+            <div
+              key={c.canvas_id}
+              className="relative aspect-[3/4] overflow-hidden rounded-xl border border-ui-border-base bg-ui-bg-base"
+            >
+              {c.image_url ? (
+                /* eslint-disable-next-line @next/next/no-img-element */
+                <img
+                  src={c.image_url}
+                  alt={c.prompt_used || "Design take"}
+                  className="h-full w-full object-cover"
+                />
+              ) : (
+                <div className="h-full w-full animate-pulse bg-ui-bg-base-pressed" />
+              )}
+              <span className="absolute left-2 top-2 rounded-md bg-black/60 px-1.5 py-0.5 text-[10px] font-bold uppercase text-white">
+                {c.letter}
+              </span>
+            </div>
+          ))}
+        </div>
+        <p className="text-center text-[10px] text-ui-fg-muted">
+          Pick a take on the board — iterations build on it
+        </p>
+      </div>
+    )
+  }
+  return null
+}
+
+// ── save_brief / set_active_canvas / save_moodboard / get_design_state ─
+
+export const SaveBriefCall = ({ part }: { part: any }) => {
+  const state = part?.state as string | undefined
+  if (state === "input-streaming" || state === "input-available") {
+    return <ToolStatusChip label="Locking in the brief…" />
+  }
+  if (state === "output-error") {
+    return <ToolStatusChip label="Tell Cici what garment to design first." tone="error" />
+  }
+  if (state === "output-available") {
+    const brief = part.output?.brief ?? {}
+    return (
+      <div className="mt-2 flex flex-wrap gap-1">
+        {brief.product_type && (
+          <span className="rounded-full bg-ui-tag-green-bg px-2 py-0.5 text-[10px] font-medium uppercase text-ui-tag-green-text">
+            {brief.product_type.replace(/_/g, " ")}
+          </span>
+        )}
+        {(brief.aesthetic_keywords ?? []).slice(0, 5).map((k: string) => (
+          <span
+            key={k}
+            className="rounded-full bg-ui-bg-base-pressed px-2 py-0.5 text-[10px] text-ui-fg-subtle"
+          >
+            {k}
+          </span>
+        ))}
+      </div>
+    )
+  }
+  return null
+}
+
+export const SetActiveCall = ({ part }: { part: any }) => {
+  const state = part?.state as string | undefined
+  if (state === "input-streaming" || state === "input-available") {
+    return <ToolStatusChip label="Setting your take…" />
+  }
+  if (state === "output-error") {
+    return <ToolStatusChip label="Couldn't set that take." tone="error" />
+  }
+  if (state === "output-available") {
+    return <ToolStatusChip label="Active take set — iterations build on it" tone="done" />
+  }
+  return null
+}
+
+export const QuietCall = ({ part, running, done }: { part: any; running: string; done: string | null }) => {
+  const state = part?.state as string | undefined
+  if (state === "input-streaming" || state === "input-available") {
+    return <ToolStatusChip label={running} />
+  }
+  if (state === "output-error") {
+    return <ToolStatusChip label="Something went wrong." tone="error" />
+  }
+  if (state === "output-available" && done) {
+    return <ToolStatusChip label={done} tone="done" />
+  }
+  return null
+}
+
+// ── conversation thread tool (quiet) ───────────────────────────────────
+
+export const ConversationCall = ({ part }: { part: any }) => {
+  const state = part?.state as string | undefined
+  if (state === "input-streaming" || state === "input-available") {
+    return <ToolStatusChip label="Saving the thread…" />
+  }
+  if (state === "output-error") {
+    return <ToolStatusChip label="Thread not saved." tone="error" />
+  }
+  if (state === "output-available") {
+    const saved = part.output?.saved ?? part.output?.conversations
+    return saved ? (
+      <ToolStatusChip label="Thread saved" tone="done" />
+    ) : null
+  }
+  return null
+}
+
+// ── dispatch map ───────────────────────────────────────────────────────
+
+export const DESIGN_TOOL_PARTS: Record<string, React.ComponentType<any>> = {
+  "tool-list_raw_materials": MaterialsCall,
+  "tool-list_partners": PartnersCall,
+  "tool-analyze_product_image": AnalyzeCall,
+  "tool-generate_design_image": GenerateCall,
+  "tool-save_brief": SaveBriefCall,
+  "tool-set_active_canvas": SetActiveCall,
+  "tool-save_moodboard": (part) => (
+    <QuietCall part={part} running="Pinning inspirations…" done="Inspirations pinned" />
+  ),
+  "tool-create_design": (part) => (
+    <QuietCall part={part} running="Saving your design…" done="Design saved to your account" />
+  ),
+  "tool-get_design_state": (part) => (
+    <QuietCall part={part} running="Loading your board…" done={null} />
+  ),
+}
+
+/** Product tools (concierge, shared with the concierge chat) render rows. */
+export const PRODUCT_TOOL_PARTS = new Set([
+  "tool-search_products",
+  "tool-get_category_products",
+  "tool-get_product_details",
+])

--- a/apps/storefront/src/modules/products/components/design-chat/components/scene-panel.tsx
+++ b/apps/storefront/src/modules/products/components/design-chat/components/scene-panel.tsx
@@ -1,0 +1,320 @@
+"use client"
+
+import React from "react"
+import clsx from "clsx"
+import { Button, Text } from "@medusajs/ui"
+import { CheckCircleSolid } from "@medusajs/icons"
+
+/**
+ * Scene panel — the chat design editor's board view.
+ *
+ * Loads the Excalidraw elements from design.moodboard (the canvas workspace —
+ * inspirations + generated canvas takes on ONE board, see backend
+ * canvas-scene.ts) and renders them READ-ONLY. No @excalidraw editor dep: the
+ * elements the tools write are simple (rectangle / text / image), so a
+ * lightweight absolutely-positioned renderer is all the shop needs. Partner-ui
+ * renders the same scene with the full editor; the shop only needs to show it.
+ *
+ * Canvas elements (customData.canvas) render with A/B labels and a pick
+ * action; the active pick renders with a check. Inspiration elements render
+ * smaller, without actions.
+ */
+
+export type SceneElement = {
+  id: string
+  type: string
+  x: number
+  y: number
+  width: number | null
+  height: number | null
+  angle: number
+  opacity: number
+  isDeleted: boolean
+  link?: string | null
+  fileId?: string
+  mimeType?: string
+  text?: string
+  fontSize?: number
+  fillStyle?: string
+  backgroundColor?: string
+  strokeColor?: string
+  customData?: {
+    source?: string
+    label?: string
+    canvas?: {
+      id: string
+      letter: "A" | "B" | null
+      kind: "initial" | "revision" | "layer"
+      parent_canvas_id: string | null
+      media_id: string | null
+      prompt_used: string
+      active: boolean
+      generated_at: string
+    }
+    [key: string]: any
+  } | null
+}
+
+export type CanvasScene = {
+  elements: SceneElement[]
+  files: Record<string, { id: string; dataURL: string; mimeType: string }>
+  appState?: Record<string, any>
+}
+
+/** Parse any stored moodboard value into a well-formed scene (mirror of the
+ * backend normalizeCanvasScene — tolerant of legacy shapes). */
+export const normalizeScene = (raw: unknown): CanvasScene | null => {
+  if (!raw) return null
+  let parsed: any = raw
+  if (typeof raw === "string") {
+    try {
+      parsed = JSON.parse(raw)
+    } catch {
+      return null
+    }
+  }
+  if (!parsed || typeof parsed !== "object") return null
+  const elements: SceneElement[] = Array.isArray(parsed.elements)
+    ? parsed.elements.filter((el: any) => !el?.isDeleted)
+    : []
+  const files: CanvasScene["files"] =
+    parsed.files && typeof parsed.files === "object" ? parsed.files : {}
+  return { elements, files }
+}
+
+const resolveImageUrl = (
+  el: SceneElement,
+  files: CanvasScene["files"]
+): string | null => {
+  const fromFile = el.fileId ? files[el.fileId]?.dataURL : null
+  const url = fromFile || (typeof el.link === "string" ? el.link : null)
+  return url && (url.startsWith("http") || url.startsWith("data:")) ? url : null
+}
+
+type ScenePanelProps = {
+  scene: CanvasScene | null
+  /** The design's thumbnail (backend-stamped active pick) — preferred active
+   * signal when the scene marker hasn't caught up. */
+  thumbnailUrl?: string | null
+  /** Pick an A/B canvas take. */
+  onPickCanvas?: (canvasId: string) => void
+  picking?: boolean
+  className?: string
+}
+
+export function ScenePanel({
+  scene,
+  thumbnailUrl,
+  onPickCanvas,
+  picking = false,
+  className,
+}: ScenePanelProps) {
+  const canvases = React.useMemo(
+    () =>
+      (scene?.elements ?? []).filter(
+        (el) => el.type === "image" && el.customData?.canvas
+      ),
+    [scene]
+  )
+  const inspirations = React.useMemo(
+    () =>
+      (scene?.elements ?? []).filter(
+        (el) =>
+          el.type === "image" &&
+          el.customData?.source === "inspiration" &&
+          !el.customData?.canvas
+      ),
+    [scene]
+  )
+  const texts = React.useMemo(
+    () => (scene?.elements ?? []).filter((el) => el.type === "text" && el.text),
+    [scene]
+  )
+
+  if (!scene || scene.elements.length === 0) {
+    return (
+      <div
+        className={clsx(
+          "flex flex-col items-center justify-center rounded-2xl border border-dashed border-ui-border-base bg-ui-bg-subtle px-6 py-10 text-center",
+          className
+        )}
+      >
+        <span className="mb-2 text-2xl">🧵</span>
+        <Text size="small" className="text-ui-fg-subtle">
+          Your board is empty — generated takes and inspirations land here.
+        </Text>
+      </div>
+    )
+  }
+
+  const isActive = (el: SceneElement): boolean => {
+    if (el.customData?.canvas?.active) return true
+    const url = resolveImageUrl(el, scene?.files ?? {})
+    return Boolean(thumbnailUrl && url && url === thumbnailUrl)
+  }
+
+  return (
+    <div className={clsx("flex flex-col gap-4", className)}>
+      {/* Canvas takes — A/B cards with pick actions */}
+      {canvases.length > 0 && (
+        <section>
+          <Text
+            weight="plus"
+            size="xsmall"
+            className="mb-2 uppercase tracking-widest text-ui-fg-muted"
+          >
+            Takes on the board
+          </Text>
+          <div className="grid grid-cols-2 gap-2">
+            {canvases.map((el) => {
+              const marker = el.customData!.canvas!
+              const url = resolveImageUrl(el, scene?.files ?? {})
+              const active = isActive(el)
+              return (
+                <button
+                  key={el.id}
+                  type="button"
+                  onClick={() => !active && onPickCanvas?.(marker.id)}
+                  disabled={active || picking || !onPickCanvas}
+                  title={
+                    marker.prompt_used
+                      ? `${marker.kind} take · ${marker.prompt_used}`
+                      : `${marker.kind} take`
+                  }
+                  className={clsx(
+                    "group relative aspect-[3/4] overflow-hidden rounded-xl border-2 bg-ui-bg-base transition-all",
+                    active
+                      ? "border-ui-fg-base ring-1 ring-ui-border-base"
+                      : "border-transparent hover:border-ui-border-strong"
+                  )}
+                >
+                  {url ? (
+                    /* eslint-disable-next-line @next/next/no-img-element */
+                    <img
+                      src={url}
+                      alt={marker.prompt_used || "Design take"}
+                      className="h-full w-full object-cover"
+                    />
+                  ) : (
+                    <div className="h-full w-full bg-ui-bg-base-pressed" />
+                  )}
+                  {/* A/B label */}
+                  {marker.letter && !active && (
+                    <span className="absolute left-2 top-2 rounded-md bg-black/60 px-1.5 py-0.5 text-[10px] font-bold uppercase text-white">
+                      {marker.letter}
+                    </span>
+                  )}
+                  {/* kind chip */}
+                  {marker.kind !== "initial" && (
+                    <span className="absolute right-2 top-2 rounded-md bg-black/60 px-1.5 py-0.5 text-[10px] font-medium capitalize text-white">
+                      {marker.kind}
+                    </span>
+                  )}
+                  {/* active / pick overlay */}
+                  <div
+                    className={clsx(
+                      "absolute inset-x-0 bottom-0 flex items-center justify-center gap-1 py-1.5 text-[11px] font-semibold text-white transition-opacity",
+                      active
+                        ? "bg-ui-fg-base opacity-100"
+                        : "bg-black/60 opacity-0 group-hover:opacity-100"
+                    )}
+                  >
+                    {active ? (
+                      <>
+                        <CheckCircleSolid className="h-3 w-3" />
+                        Active take
+                      </>
+                    ) : picking ? (
+                      "Picking…"
+                    ) : (
+                      "Build on this"
+                    )}
+                  </div>
+                </button>
+              )
+            })}
+          </div>
+        </section>
+      )}
+
+      {/* Inspirations */}
+      {inspirations.length > 0 && (
+        <section>
+          <Text
+            weight="plus"
+            size="xsmall"
+            className="mb-2 uppercase tracking-widest text-ui-fg-muted"
+          >
+            Inspirations
+          </Text>
+          <div className="flex flex-wrap gap-2">
+            {inspirations.map((el) => {
+              const url = resolveImageUrl(el, scene?.files ?? {})
+              return (
+                <div
+                  key={el.id}
+                  className="h-16 w-16 overflow-hidden rounded-lg border border-ui-border-base bg-ui-bg-base"
+                >
+                  {url ? (
+                    /* eslint-disable-next-line @next/next/no-img-element */
+                    <img
+                      src={url}
+                      alt="Inspiration"
+                      className="h-full w-full object-cover"
+                    />
+                  ) : (
+                    <div className="h-full w-full bg-ui-bg-base-pressed" />
+                  )}
+                </div>
+              )
+            })}
+          </div>
+        </section>
+      )}
+
+      {/* Board notes (brief cards etc.) — rendered as quiet text */}
+      {texts.length > 0 && (
+        <section className="rounded-xl border border-ui-border-base bg-ui-bg-subtle p-3">
+          {texts.map((el) => (
+            <p
+              key={el.id}
+              className="whitespace-pre-wrap text-xs text-ui-fg-subtle"
+            >
+              {el.text}
+            </p>
+          ))}
+        </section>
+      )}
+    </div>
+  )
+}
+
+/** Skeleton state shown while generation is running (~20s per image). */
+export function ScenePanelGeneratingSkeleton({ className }: { className?: string }) {
+  return (
+    <section className={clsx("flex flex-col gap-2", className)}>
+      <Text
+        weight="plus"
+        size="xsmall"
+        className="uppercase tracking-widest text-ui-fg-muted"
+      >
+        Generating two takes…
+      </Text>
+      <div className="grid grid-cols-2 gap-2">
+        {["A", "B"].map((letter) => (
+          <div
+            key={letter}
+            className="relative aspect-[3/4] animate-pulse overflow-hidden rounded-xl border border-ui-border-base bg-ui-bg-base-pressed"
+          >
+            <span className="absolute left-2 top-2 rounded-md bg-black/60 px-1.5 py-0.5 text-[10px] font-bold uppercase text-white">
+              {letter}
+            </span>
+            <div className="absolute inset-x-0 bottom-0 py-1.5 text-center text-[11px] text-ui-fg-subtle">
+              ~20 seconds per image
+            </div>
+          </div>
+        ))}
+      </div>
+    </section>
+  )
+}

--- a/apps/storefront/src/modules/products/components/design-chat/index.tsx
+++ b/apps/storefront/src/modules/products/components/design-chat/index.tsx
@@ -492,6 +492,26 @@ export default function DesignChat({
     sendMessage({ text: composed })
   }
 
+  /**
+   * A clicked choice is an ordinary message.
+   *
+   * 🔑 Deliberately NOT a side channel. The transcript is what the model reads
+   * on the next turn and what the conversation store persists, so a pick that
+   * bypassed it would vanish on reload and leave the assistant reasoning about
+   * a fabric nobody ever mentioned. The button just types the sentence for you.
+   *
+   * Guarded on `isStreaming`/`uploading` for the same reason the composer is:
+   * two turns in flight interleave their tool calls.
+   */
+  const handleChoice = React.useCallback(
+    (text: string) => {
+      if (isStreaming || uploading) return
+      setStickToBottom(true)
+      sendMessage({ text })
+    },
+    [isStreaming, uploading, sendMessage]
+  )
+
   const handlePickCanvas = async (canvasId: string) => {
     if (!designId || picking) return
     setPicking(true)
@@ -531,7 +551,9 @@ export default function DesignChat({
     if (!target) return
     try {
       const { getDesignScene } = await import("./lib/design-scene")
-      const next = await getDesignScene(target)
+      // The board read is email-scoped — a guest maker has no customer session,
+      // which is exactly why the old customer-authenticated read 401'd.
+      const next = await getDesignScene(target, meta.email)
       if (next?.scene) setScene(next.scene)
       if (next?.thumbnail_url) setThumbnailUrl(next.thumbnail_url)
       if (next?.design_id) setDesignId(next.design_id)
@@ -626,7 +648,7 @@ export default function DesignChat({
               const Tool = DESIGN_TOOL_PARTS[part.type]
               return (
                 <div key={i}>
-                  <Tool part={part} />
+                  <Tool part={part} onChoose={handleChoice} />
                 </div>
               )
             }
@@ -839,6 +861,38 @@ export default function DesignChat({
                     className="min-w-0 flex-1 rounded-full border border-ui-border-base bg-ui-bg-field px-3.5 py-2 text-sm outline-none focus:border-ui-border-strong"
                     data-testid="design-chat-onboarding-email"
                   />
+                )}
+              </div>
+              {/*
+                The garment as choices, not a blank field.
+                `product_type` is load-bearing — the production spec and the
+                cost estimate both derive from it (#938) — and a free-typed
+                "something flowy for summer" normalises to nothing. These are
+                the types the catalogue actually produces; the field stays open
+                for anything else.
+              */}
+              <div className="mt-2 flex flex-wrap gap-1.5">
+                {["Kurta", "Saree", "Trousers", "Shirt", "Scarf", "Shawl", "Robe"].map(
+                  (g) => {
+                    const selected =
+                      onboardingGarment.trim().toLowerCase() === g.toLowerCase()
+                    return (
+                      <button
+                        key={g}
+                        type="button"
+                        aria-pressed={selected}
+                        onClick={() => setOnboardingGarment(g.toLowerCase())}
+                        className={
+                          selected
+                            ? "rounded-full border border-ui-border-interactive bg-ui-bg-interactive px-3 py-1 text-[11px] font-medium text-white"
+                            : "rounded-full border border-ui-border-base bg-ui-bg-base px-3 py-1 text-[11px] text-ui-fg-subtle transition hover:border-ui-border-interactive hover:text-ui-fg-base"
+                        }
+                        data-testid={`design-chat-garment-${g.toLowerCase()}`}
+                      >
+                        {g}
+                      </button>
+                    )
+                  }
                 )}
               </div>
               <div className="mt-3 flex items-center justify-between gap-2">

--- a/apps/storefront/src/modules/products/components/design-chat/index.tsx
+++ b/apps/storefront/src/modules/products/components/design-chat/index.tsx
@@ -1,0 +1,984 @@
+"use client"
+
+import React from "react"
+import clsx from "clsx"
+import { useChat } from "@ai-sdk/react"
+import { DefaultChatTransport, type UIMessage } from "ai"
+import { Button, Text } from "@medusajs/ui"
+import {
+  ArrowLeft,
+  ArrowUpMini,
+  ImageSparkle,
+  Spinner,
+  StopCircleSolid,
+} from "@medusajs/icons"
+import LocalizedClientLink from "@modules/common/components/localized-client-link"
+import {
+  AttachButton,
+  AttachmentThumbnails,
+  type AttachmentThumbData,
+} from "./components/attachments"
+import {
+  createReference,
+  isAcceptedImage,
+  releaseReference,
+  uploadDesignReference,
+  type DesignReference,
+} from "./lib/design-uploads"
+import {
+  loadPreferences,
+  savePreferences,
+  toWireFormat,
+  type AiChatPreferences,
+} from "@lib/util/ai-chat-preferences"
+import { getOrCreateVisitorId } from "@lib/util/visitor-id"
+import { loadDesignerEmail, saveDesignerEmail } from "@lib/util/designer-email"
+import { DesignCheckoutModal } from "@modules/products/components/design-editor/components/design-checkout-modal"
+import { ScenePanel, ScenePanelGeneratingSkeleton, normalizeScene } from "./components/scene-panel"
+import { MarkdownContent } from "./components/markdown-content"
+import {
+  DESIGN_TOOL_PARTS,
+  PRODUCT_TOOL_PARTS,
+  TextLineSkeleton,
+  ToolStatusChip,
+  type MaterialHit,
+  type PartnerHit,
+} from "./components/message-parts"
+import {
+  resolveThreadKey,
+  loadDesignThread,
+  saveDesignThread,
+  type DesignThreadMeta,
+} from "./lib/design-thread"
+import {
+  mirrorDesignThread,
+  listDesignConversations,
+  type StoredUIMessage,
+} from "./lib/design-conversations"
+import { pickDesignCanvas } from "./lib/design-pick"
+import { retrieveCustomerFresh } from "@lib/data/customer"
+
+/**
+ * Chat-based design editor — replaces the Konva editor on the design routes.
+ *
+ * The maker chats; Cici's designer walks them through brief → moodboard →
+ * fabrics → partner → generation → iteration. The board (right column on
+ * desktop, bottom tab on mobile) renders the Excalidraw scene from
+ * design.moodboard read-only: canvas takes A/B with pick actions,
+ * inspirations, board notes. Checkout reuses the dormant editor's modal.
+ *
+ * Streams from /api/ai-chat via useChat (same proxy as the concierge chat —
+ * the proxy forwards the raw body verbatim, so `context` flows through to the
+ * backend's design-editor mode). Threads persist to localStorage per base
+ * product and mirror to the server-backed conversation store (email-scoped)
+ * after each completed turn.
+ */
+
+type DesignChatProps = {
+  product?: {
+    id: string
+    handle: string
+    title: string
+    thumbnail?: string | null
+    images?: string[]
+  } | null
+  initialDesign?: {
+    id: string
+    name?: string
+    status?: string
+    thumbnail_url?: string | null
+    moodboard?: unknown
+  } | null
+  countryCode: string
+  isMobileLayout?: boolean
+}
+
+const PLACEHOLDER = "Describe what you want to design…"
+
+const toStored = (messages: UIMessage[]): StoredUIMessage[] =>
+  messages.map((m) => {
+    const anyMsg = m as any
+    return {
+      id: anyMsg.id,
+      role: anyMsg.role,
+      content: anyMsg.content,
+      parts: anyMsg.parts,
+    }
+  })
+
+export default function DesignChat({
+  product,
+  initialDesign,
+  countryCode,
+  isMobileLayout: initialMobileLayout = false,
+}: DesignChatProps) {
+  const threadKey = resolveThreadKey(product?.id)
+  const [isMobileLayout, setIsMobileLayout] = React.useState(initialMobileLayout)
+  const [prefs, setPrefs] = React.useState<AiChatPreferences>({})
+  const [input, setInput] = React.useState("")
+  const [meta, setMeta] = React.useState<DesignThreadMeta>({ threadKey })
+  const [designId, setDesignId] = React.useState<string | null>(
+    initialDesign?.id ?? null
+  )
+  // The design's thumbnail (active pick) — refreshed after picks/generations.
+  const [thumbnailUrl, setThumbnailUrl] = React.useState<string | null>(
+    initialDesign?.thumbnail_url ?? null
+  )
+  const [scene, setScene] = React.useState(() =>
+    normalizeScene(initialDesign?.moodboard)
+  )
+  const [picking, setPicking] = React.useState(false)
+  const [showCheckout, setShowCheckout] = React.useState(false)
+  const [selectedMaterial, setSelectedMaterial] = React.useState<MaterialHit | null>(null)
+  const [selectedPartner, setSelectedPartner] = React.useState<PartnerHit | null>(null)
+  // Deterministic onboarding — a fresh thread asks garment type + email
+  // BEFORE the chat starts, so the guide's first save_brief never fires
+  // blind (the model was looping "Brief needs a garment type" instead of
+  // asking). Skippable: "Let Cici ask me" hands it to the model.
+  const [showOnboarding, setShowOnboarding] = React.useState(false)
+  const [onboardingGarment, setOnboardingGarment] = React.useState("")
+  const [onboardingEmail, setOnboardingEmail] = React.useState("")
+  const [attachments, setAttachments] = React.useState<DesignReference[]>([])
+  const [uploading, setUploading] = React.useState(false)
+
+  const visitorIdRef = React.useRef<string | null>(null)
+  const inputRef = React.useRef<HTMLTextAreaElement>(null)
+  const scrollAnchorRef = React.useRef<HTMLDivElement>(null)
+  const restoredRef = React.useRef(false)
+  const persistedRef = React.useRef<string | null>(null)
+  const fileInputRef = React.useRef<HTMLInputElement | null>(null)
+  const pendingSendRef = React.useRef<DesignReference[] | null>(null)
+  const seenUserMsgIdsRef = React.useRef<Set<string>>(new Set())
+
+  // Mobile detection (chat shell only — the scene panel collapses to a tab).
+  React.useEffect(() => {
+    const check = () => setIsMobileLayout(window.innerWidth < 1024)
+    check()
+    window.addEventListener("resize", check)
+    return () => window.removeEventListener("resize", check)
+  }, [])
+
+  // Chat transport — same proxy as the concierge chat; the body carries the
+  // design context that switches the backend into designer-guide mode.
+  const transport = React.useMemo(
+    () =>
+      new DefaultChatTransport({
+        api: "/api/ai-chat",
+        body: () => ({
+          visitor_id: visitorIdRef.current ?? "anonymous",
+          prefs: toWireFormat(prefs),
+          context: {
+            ...(product?.id ? { product_id: product.id } : {}),
+            ...(designId ? { design_id: designId } : {}),
+            ...(meta.email ? { email: meta.email } : {}),
+          },
+        }),
+      }),
+    [prefs, product?.id, designId, meta.email]
+  )
+
+  const {
+    messages,
+    sendMessage,
+    status,
+    error,
+    setMessages,
+    stop,
+  } = useChat({ transport })
+
+  const isStreaming = status === "submitted" || status === "streaming"
+  const isGenerating = messages.some(
+    (m) =>
+      m.role === "assistant" &&
+      ((m as any).parts ?? []).some(
+        (p: any) =>
+          p?.type === "tool-generate_design_image" &&
+          (p?.state === "input-streaming" || p?.state === "input-available")
+      )
+  )
+
+  // ── Restore + mirror on mount ──
+  React.useEffect(() => {
+    if (restoredRef.current) return
+    restoredRef.current = true
+    visitorIdRef.current = getOrCreateVisitorId()
+    setPrefs(loadPreferences())
+
+    const local = loadDesignThread(threadKey)
+    // The maker's email is remembered globally — a NEW design never re-asks
+    // for it, only for the garment type. Signed-in customers override below.
+    const rememberedEmail = loadDesignerEmail()
+    if (local?.messages?.length) {
+      setMeta({ ...local.meta, email: local.meta.email ?? rememberedEmail ?? undefined })
+      setMessages(local.messages)
+      if (local.meta.designId) setDesignId(local.meta.designId)
+    } else {
+      if (rememberedEmail) setMeta((prev) => ({ ...prev, email: rememberedEmail }))
+      // Fresh thread — run onboarding first, then the greeting.
+      setShowOnboarding(true)
+      setMessages([
+        {
+          id: "greeting",
+          role: "assistant",
+          parts: [
+            {
+              type: "text",
+              text: product
+                ? `Hi! I'm Cici's designer. Let's make something with the ${product.title}. What are we designing, and what should we call it?`
+                : "Hi! I'm Cici's designer. What are we designing — a kurta, trousers, a saree? Tell me the garment and I'll walk you through it: brief, fabrics, a partner to make it, then takes on your board.",
+            },
+          ],
+        } as UIMessage,
+      ])
+    }
+
+    // Fresh customer fetch fixes stale cache auth state (mirror of the
+    // dormant editor's client-wrapper). If the maker is signed in, seed the
+    // email + pull the server thread.
+    retrieveCustomerFresh().then((customer) => {
+      const email = (customer as any)?.email as string | undefined
+      if (email) {
+        setMeta((prev) => ({ ...prev, email }))
+        listDesignConversations(email, threadKey).then((conversations) => {
+          const latest = conversations[0]
+          if (
+            latest?.id &&
+            latest.id !== local?.meta.conversationId &&
+            latest.messages?.length
+          ) {
+            // Server thread is fresher than local — replay it.
+            setMeta((prev) => ({
+              ...prev,
+              conversationId: latest.id,
+              designId: latest.design_id ?? prev.designId,
+              title: latest.title,
+            }))
+            setMessages(latest.messages as any)
+            if (latest.design_id) setDesignId(latest.design_id)
+          }
+        })
+      }
+    }).catch(() => {})
+  }, [threadKey, product?.title, setMessages])
+
+  // ── Persist after each completed turn ──
+  React.useEffect(() => {
+    if (isStreaming || messages.length === 0) return
+    const signature = `${messages.length}:${(messages as any).at(-1)?.id ?? ""}`
+    if (persistedRef.current === signature) return
+    persistedRef.current = signature
+
+    const title =
+      meta.title ??
+      toStored(messages)
+        .find((m) => m.role === "user")
+        ?.content?.slice(0, 60) ??
+      "New design"
+
+    const nextMeta: DesignThreadMeta = { ...meta, title }
+    saveDesignThread({ meta: nextMeta, messages })
+    setMeta(nextMeta)
+
+    if (nextMeta.email) {
+      mirrorDesignThread({
+        conversationId: nextMeta.conversationId,
+        customer_email: nextMeta.email,
+        thread_key: threadKey,
+        title,
+        design_id: designId ?? undefined,
+        messages: toStored(messages),
+      }).then((conversationId) => {
+        if (conversationId) {
+          setMeta((prev) => ({ ...prev, conversationId }))
+        }
+      })
+    }
+  }, [messages, isStreaming, meta, threadKey, designId])
+
+  // ── Attach reference thumbnails to the just-sent user message ──
+  // `sendMessage` doesn't give us the message id, so after the send we scan
+  // from the tail for the first unseen user message and stitch the resolved
+  // references onto its parts. The thumbnails then survive the local thread
+  // (persisted with the message) and re-render on reload.
+  React.useEffect(() => {
+    if (!pendingSendRef.current) return
+    const pending = pendingSendRef.current
+    for (let i = messages.length - 1; i >= 0; i--) {
+      const m = messages[i]
+      if (m.role !== "user" || seenUserMsgIdsRef.current.has(m.id)) continue
+      seenUserMsgIdsRef.current.add(m.id)
+      pendingSendRef.current = null
+      if (pending.length) {
+        const attachParts = pending.map((r) => ({
+          type: "attachment",
+          id: r.id,
+          name: r.file.name,
+          previewUrl: r.previewUrl,
+          publicUrl: r.publicUrl,
+          analysis: r.analysis ?? null,
+        }))
+        setMessages((prev) =>
+          prev.map((pm) =>
+            pm.id === m.id
+              ? ({ ...pm, parts: [...((pm as any).parts ?? []), ...attachParts] } as any)
+              : pm
+          )
+        )
+      }
+      break
+    }
+  }, [messages, setMessages])
+
+  // ── Scroll anchoring: follow the window (Lenis) scroll ──
+  // The chat no longer owns a nested `overflow-y-auto` list — the whole page
+  // scrolls with the window via Lenis. So "stick to bottom" now means: keep
+  // the window parked at the bottom anchor as new messages stream in.
+  const [stickToBottom, setStickToBottom] = React.useState(true)
+  React.useEffect(() => {
+    if (!stickToBottom) return
+    scrollAnchorRef.current?.scrollIntoView({ block: "end" })
+  }, [messages, stickToBottom])
+
+  React.useEffect(() => {
+    const onScroll = () => {
+      const atBottom =
+        window.innerHeight + window.scrollY >=
+        document.documentElement.scrollHeight - 120
+      setStickToBottom(atBottom)
+    }
+    window.addEventListener("scroll", onScroll, { passive: true })
+    return () => window.removeEventListener("scroll", onScroll)
+  }, [])
+
+  // ── Onboarding submit ──
+  const handleOnboardingStart = (e: React.FormEvent) => {
+    e.preventDefault()
+    const garment = onboardingGarment.trim()
+    const email = onboardingEmail.trim().toLowerCase()
+    setShowOnboarding(false)
+    if (email) {
+      setMeta((prev) => ({ ...prev, email }))
+      saveDesignerEmail(email)
+    }
+    if (!garment) return // skipped garment — greeting already asked
+    // Compose the first user turn so the guide has the garment type
+    // explicitly — save_brief succeeds on the first try.
+    const seed = email
+      ? `Design a ${garment}. Save my designs to ${email}.`
+      : `Design a ${garment}.`
+    setInput("")
+    setStickToBottom(true)
+    sendMessage({ text: seed })
+  }
+
+  // ── Handlers ──
+  // "start a new design" is a DOMAIN keyword — typed or tapped, it starts a
+  // fresh design chat (clears the local thread + board, new conversation on
+  // the next turn). No model turn involved.
+  const NEW_DESIGN_KEYWORDS = [
+    "start a new design",
+    "start new design",
+    "new design chat",
+    "restart design",
+  ]
+  const isNewDesignIntent = (text: string): boolean => {
+    const t = text.trim().toLowerCase()
+    return NEW_DESIGN_KEYWORDS.some((k) => t === k || t.startsWith(k))
+  }
+
+  const startNewDesign = React.useCallback(() => {
+    stop()
+    setAttachments((prev) => {
+      prev.forEach(releaseReference)
+      return []
+    })
+    const greeting = {
+      id: `greeting-${Date.now()}`,
+      role: "assistant" as const,
+      parts: [
+        {
+          type: "text",
+          text: product
+            ? `New design board ready — still the ${product.title}. What are we making this time?`
+            : "New design board ready. What are we designing? A kurta, trousers, a saree — tell me the garment and I'll walk you through it.",
+        },
+      ],
+    } as UIMessage
+    setMessages([greeting])
+    setMeta((prev) => ({ ...prev, conversationId: undefined, title: undefined }))
+    setScene(normalizeScene(initialDesign?.moodboard))
+    setThumbnailUrl(initialDesign?.thumbnail_url ?? null)
+    persistedRef.current = null
+    saveDesignThread({
+      meta: { threadKey, conversationId: undefined, title: undefined },
+      messages: [greeting],
+    })
+  }, [stop, product?.title, initialDesign, threadKey, setMessages])
+
+  // ── Attachments ──
+  const addFiles = React.useCallback((files: File[]) => {
+    const accepted = files.filter(isAcceptedImage)
+    if (!accepted.length) return
+    setAttachments((prev) => [...prev, ...accepted.map(createReference)])
+  }, [])
+
+  const removeAttachment = React.useCallback((id: string) => {
+    setAttachments((prev) => {
+      const target = prev.find((a) => a.id === id)
+      if (target) releaseReference(target)
+      return prev.filter((a) => a.id !== id)
+    })
+  }, [])
+
+  const handleSubmit = async (e: React.FormEvent) => {
+    e.preventDefault()
+    const text = input.trim()
+    if ((!text && attachments.length === 0) || isStreaming || uploading) return
+    if (isNewDesignIntent(text)) {
+      setInput("")
+      startNewDesign()
+      setShowOnboarding(true)
+      return
+    }
+    // If the text carries an email, seed it into the context gate.
+    const emailMatch = text.match(/[\w.+-]+@[\w-]+\.[\w.]+/)
+    if (emailMatch && !meta.email) {
+      setMeta((prev) => ({ ...prev, email: emailMatch[0].toLowerCase() }))
+      saveDesignerEmail(emailMatch[0].toLowerCase())
+    }
+    setInput("")
+    setStickToBottom(true)
+
+    // Upload pending references first so the message carries their permanent
+    // URLs (guests keep session-only previews — thumbnails still render).
+    let resolved: DesignReference[] = attachments
+    if (attachments.length) {
+      setUploading(true)
+      setAttachments((prev) => prev.map((a) => ({ ...a, status: "uploading" })))
+      resolved = await Promise.all(attachments.map(uploadDesignReference))
+      setUploading(false)
+    }
+
+    const referenceLines = resolved
+      .filter((r) => r.publicUrl)
+      .map((r) => {
+        const a = r.analysis
+        const note =
+          a && (a.title || a.description)
+            ? ` (I see: ${[a.title, a.description].filter(Boolean).join(". ")})`
+            : ""
+        return `${r.publicUrl}${note}`
+      })
+
+    const referenceBlock = referenceLines.length
+      ? `\n\nReference image${referenceLines.length > 1 ? "s" : ""} — my on-the-fly read of each:\n${referenceLines.join("\n")}`
+      : ""
+    const composed = `${text}${referenceBlock}`.trim() || "I've attached some inspirations."
+
+    pendingSendRef.current = resolved
+    setAttachments([])
+    sendMessage({ text: composed })
+  }
+
+  const handlePickCanvas = async (canvasId: string) => {
+    if (!designId || picking) return
+    setPicking(true)
+    const result = await pickDesignCanvas(designId, canvasId).catch(() => null)
+    if (result?.thumbnail_url) {
+      setThumbnailUrl(result.thumbnail_url)
+      setScene((prev) =>
+        prev
+          ? {
+              ...prev,
+              elements: prev.elements.map((el) =>
+                el.customData?.canvas
+                  ? {
+                      ...el,
+                      customData: {
+                        ...el.customData,
+                        canvas: {
+                          ...el.customData.canvas,
+                          active: el.customData.canvas.id === canvasId,
+                        },
+                      },
+                    }
+                  : el
+              ),
+            }
+          : prev
+      )
+    }
+    setPicking(false)
+  }
+
+  const refreshScene = async (id?: string) => {
+    // After a generation / moodboard pin / design create, the scene lives on
+    // the design — a light reload via get_design_state keeps the board current
+    // without a full page nav.
+    const target = id ?? designId
+    if (!target) return
+    try {
+      const { getDesignScene } = await import("./lib/design-scene")
+      const next = await getDesignScene(target)
+      if (next?.scene) setScene(next.scene)
+      if (next?.thumbnail_url) setThumbnailUrl(next.thumbnail_url)
+      if (next?.design_id) setDesignId(next.design_id)
+    } catch {
+      /* board refresh is best-effort */
+    }
+  }
+
+  React.useEffect(() => {
+    // Refresh the board whenever a board-mutating tool completes — generation,
+    // moodboard pin, or design creation — so the "Your board" panel always
+    // reflects what the model just did. create_design also hands us the
+    // design id, which we adopt before refreshing.
+    if (isGenerating) return
+    let createdId: string | null = null
+    let shouldRefresh = false
+    for (const m of messages) {
+      if (m.role !== "assistant") continue
+      for (const p of ((m as any).parts ?? []) as any[]) {
+        if (
+          p?.type === "tool-create_design" &&
+          p?.state === "output-available" &&
+          p?.output?.design_id
+        ) {
+          createdId = p.output.design_id
+        }
+        if (
+          (p?.type === "tool-generate_design_image" ||
+            p?.type === "tool-save_moodboard" ||
+            p?.type === "tool-create_design") &&
+          p?.state === "output-available"
+        ) {
+          shouldRefresh = true
+        }
+      }
+    }
+    if (createdId && createdId !== designId) setDesignId(createdId)
+    if (shouldRefresh) refreshScene(createdId ?? undefined)
+  }, [messages, isGenerating, designId])
+
+  // ── Message rendering ──
+  const renderMessage = (msg: UIMessage) => {
+    const parts = ((msg as any).parts ?? []) as any[]
+    if (msg.role === "user") {
+      const rawText = parts
+        .filter((p) => p?.type === "text")
+        .map((p) => p.text)
+        .join("")
+      // Strip the reference-image URL block — thumbnails replace it.
+      const text = rawText.split(/\n\nReference images?\b/)[0].trim()
+      const attachParts = parts.filter((p) => p?.type === "attachment")
+      const thumbs: AttachmentThumbData[] = attachParts.map((p: any) => ({
+        id: p.id,
+        name: p.name ?? "Reference",
+        previewUrl: p.publicUrl ?? p.previewUrl,
+        status: p.publicUrl ? "ready" : "preview",
+        analysis: p.analysis ?? null,
+      }))
+      return (
+        <div key={msg.id} className="flex justify-end">
+          <div className="flex max-w-[80%] flex-col items-end gap-2">
+            {thumbs.length > 0 && (
+              <AttachmentThumbnails refs={thumbs} compact />
+            )}
+            {text && (
+              <div className="whitespace-pre-wrap rounded-2xl rounded-br-sm bg-ui-bg-interactive px-3.5 py-2 text-sm text-white">
+                {text}
+              </div>
+            )}
+          </div>
+        </div>
+      )
+    }
+
+    const textParts = parts.filter((p) => p?.type === "text")
+    const hasText = textParts.some((p) => p?.text)
+    const assistantStreaming =
+      isStreaming && msg.id === (messages as any).at(-1)?.id
+
+    return (
+      <div key={msg.id} className="flex justify-start">
+        <div className="w-full max-w-[92%] rounded-2xl rounded-bl-sm border border-ui-border-base bg-ui-bg-subtle px-3.5 py-3 text-sm text-ui-fg-base">
+          {parts.map((part: any, i: number) => {
+            if (part?.type === "text") {
+              return part.text ? (
+                <MarkdownContent key={i} text={part.text} />
+              ) : assistantStreaming ? (
+                <TextLineSkeleton key={i} />
+              ) : null
+            }
+            if (typeof part?.type === "string" && DESIGN_TOOL_PARTS[part.type]) {
+              const Tool = DESIGN_TOOL_PARTS[part.type]
+              return (
+                <div key={i}>
+                  <Tool part={part} />
+                </div>
+              )
+            }
+            if (
+              typeof part?.type === "string" &&
+              PRODUCT_TOOL_PARTS.has(part.type)
+            ) {
+              return <ToolStatusChip key={i} label="Found pieces in the catalogue" tone="done" />
+            }
+            return null
+          })}
+          {assistantStreaming && !hasText && !isGenerating && <TextLineSkeleton />}
+        </div>
+      </div>
+    )
+  }
+
+  // ── Layout ──
+  const boardPanel = (
+    <div className="flex flex-col gap-4">
+      <div className="flex items-center justify-between">
+        <Text
+          weight="plus"
+          size="xsmall"
+          className="uppercase tracking-widest text-ui-fg-muted"
+        >
+          Your board
+        </Text>
+        {designId && (
+          <button
+            type="button"
+            onClick={() => refreshScene()}
+            className="text-xs text-ui-fg-muted underline-offset-2 hover:text-ui-fg-base hover:underline"
+          >
+            Refresh
+          </button>
+        )}
+      </div>
+
+      {isGenerating ? (
+        <ScenePanelGeneratingSkeleton />
+      ) : (
+        <ScenePanel
+          scene={scene}
+          thumbnailUrl={thumbnailUrl}
+          onPickCanvas={designId ? handlePickCanvas : undefined}
+          picking={picking}
+        />
+      )}
+
+      {/* Selected fabric + partner chips */}
+      {(selectedMaterial || selectedPartner) && (
+        <div className="flex flex-wrap gap-2">
+          {selectedMaterial && (
+            <span className="inline-flex items-center gap-1 rounded-full bg-ui-tag-green-bg px-2.5 py-1 text-[11px] font-medium text-ui-tag-green-text">
+              🧵 {selectedMaterial.name ?? "Fabric"}
+              <button
+                onClick={() => setSelectedMaterial(null)}
+                className="ml-0.5 text-ui-tag-green-text/70 hover:text-ui-tag-green-text"
+              >
+                ×
+              </button>
+            </span>
+          )}
+          {selectedPartner && (
+            <span className="inline-flex items-center gap-1 rounded-full bg-ui-tag-purple-bg px-2.5 py-1 text-[11px] font-medium text-ui-tag-purple-text">
+              🏭 {selectedPartner.company_name ?? selectedPartner.name}
+              <button
+                onClick={() => setSelectedPartner(null)}
+                className="ml-0.5 text-ui-tag-purple-text/70 hover:text-ui-tag-purple-text"
+              >
+                ×
+              </button>
+            </span>
+          )}
+        </div>
+      )}
+
+      <Button
+        onClick={() => setShowCheckout(true)}
+        disabled={!designId}
+        className="w-full rounded-full"
+      >
+        {designId ? "Checkout design" : "Checkout unlocks after your first take"}
+      </Button>
+    </div>
+  )
+
+  return (
+    <div
+      className="flex min-h-[100dvh] flex-col bg-ui-bg-subtle"
+      data-testid="design-chat-wrapper"
+    >
+      {/* Studio top bar — the design routes drop the storefront chrome, so
+          this bar is the whole shell: back link, wordmark, thread title. */}
+      <header className="sticky top-0 z-20 flex h-14 shrink-0 items-center justify-between gap-3 border-b border-ui-border-base bg-ui-bg-base/95 px-3 backdrop-blur sm:px-4">
+        <div className="flex min-w-0 items-center gap-3">
+          <LocalizedClientLink
+            href={product ? `/products/${product.handle}` : "/store"}
+            aria-label="Back to shop"
+            title="Back to shop"
+            className="flex h-8 w-8 shrink-0 items-center justify-center rounded-full border border-ui-border-base text-ui-fg-subtle transition-colors hover:border-ui-border-strong hover:text-ui-fg-base"
+          >
+            <ArrowLeft className="h-4 w-4" />
+          </LocalizedClientLink>
+          <div className="flex min-w-0 items-center gap-2">
+            <ImageSparkle className="h-4 w-4 shrink-0 text-ui-fg-interactive" />
+            <span className="truncate text-sm font-medium text-ui-fg-base">
+              Cici Label — Design Studio
+            </span>
+          </div>
+        </div>
+
+        <div className="flex min-w-0 items-center gap-3">
+          <span className="hidden min-w-0 truncate text-xs text-ui-fg-muted sm:block">
+            {product?.title
+              ? `Designing · ${product.title}`
+              : meta.title ?? "New design"}
+          </span>
+          <button
+            type="button"
+            onClick={() => {
+              startNewDesign()
+              setShowOnboarding(true)
+            }}
+            className="shrink-0 rounded-full border border-ui-border-base px-3 py-1.5 text-xs font-medium text-ui-fg-subtle transition-colors hover:border-ui-border-strong hover:text-ui-fg-base"
+          >
+            New design
+          </button>
+        </div>
+      </header>
+
+      {/* Body — full-width chat + board, both following the window scroll */}
+      <div className={clsx("flex w-full flex-1", isMobileLayout && "flex-col")}>
+        {/* Chat column */}
+        <div className="flex min-w-0 flex-1 flex-col">
+          {/* Messages — grows to fill the column so the composer sits at the
+              bottom; with a long thread the window (Lenis) scrolls instead. */}
+          <div className="flex flex-1 flex-col gap-3 px-4 py-4 sm:px-6">
+            <div className="mx-auto flex w-full max-w-3xl flex-col gap-3">
+              {messages.map(renderMessage)}
+              {error && (
+                <div className="rounded-xl border border-ui-tag-red-border bg-ui-tag-red-bg px-3 py-2 text-xs text-ui-tag-red-text">
+                  Something went wrong — try again.
+                </div>
+              )}
+            </div>
+          </div>
+          {/* Bottom anchor — the window scrolls to here as messages stream. */}
+          <div ref={scrollAnchorRef} />
+
+          {/* Onboarding — intro, how-it-works, garment type + email */}
+          {showOnboarding && !isStreaming && (
+            <div className="mx-auto mb-2 w-full max-w-3xl space-y-3">
+              {/* How it works — one glance at the journey ahead */}
+              <div className="rounded-2xl border border-ui-border-base bg-ui-bg-subtle p-3.5 px-4 sm:px-6">
+                <Text weight="plus" size="small">
+                  How it works
+                </Text>
+                <ol className="mt-2 grid grid-cols-1 gap-2 sm:grid-cols-2">
+                  {[
+                    "Tell me the garment — I lock the brief",
+                    "We pick your fabrics",
+                    "We match an artisan partner",
+                    "I generate two takes, you pick one",
+                  ].map((step, i) => (
+                    <li
+                      key={step}
+                      className="flex items-start gap-2 text-xs text-ui-fg-subtle"
+                    >
+                      <span className="flex h-5 w-5 shrink-0 items-center justify-center rounded-full bg-ui-fg-interactive text-[10px] font-semibold text-ui-fg-on-color">
+                        {i + 1}
+                      </span>
+                      <span className="pt-0.5">{step}</span>
+                    </li>
+                  ))}
+                </ol>
+              </div>
+
+              <form
+                onSubmit={handleOnboardingStart}
+                className="rounded-2xl border border-ui-border-base bg-ui-bg-subtle p-3.5 px-4 shadow-sm sm:px-6"
+                data-testid="design-chat-onboarding"
+              >
+                <Text weight="plus" size="small">
+                  Let&apos;s start your board
+                </Text>
+                <Text size="xsmall" className="mb-3 text-ui-fg-subtle">
+                  {meta.email
+                    ? "What garment are we designing? Your designs save to the email on file."
+                    : "Two quick things — the garment and an email to save your designs under."}
+                </Text>
+              <div className="flex flex-col gap-2 sm:flex-row">
+                <input
+                  type="text"
+                  value={onboardingGarment}
+                  onChange={(e) => setOnboardingGarment(e.target.value)}
+                  placeholder="What are we designing? (kurta, trousers…)"
+                  maxLength={60}
+                  className="min-w-0 flex-1 rounded-full border border-ui-border-base bg-ui-bg-field px-3.5 py-2 text-sm outline-none focus:border-ui-border-strong"
+                  data-testid="design-chat-onboarding-garment"
+                />
+                {!meta.email && (
+                  <input
+                    type="email"
+                    value={onboardingEmail}
+                    onChange={(e) => setOnboardingEmail(e.target.value)}
+                    placeholder="Email (saves your designs)"
+                    maxLength={200}
+                    className="min-w-0 flex-1 rounded-full border border-ui-border-base bg-ui-bg-field px-3.5 py-2 text-sm outline-none focus:border-ui-border-strong"
+                    data-testid="design-chat-onboarding-email"
+                  />
+                )}
+              </div>
+              <div className="mt-3 flex items-center justify-between gap-2">
+                <button
+                  type="button"
+                  onClick={() => setShowOnboarding(false)}
+                  className="text-[11px] text-ui-fg-muted underline hover:text-ui-fg-base"
+                >
+                  Let Cici ask me instead
+                </button>
+                <Button
+                  type="submit"
+                  className="rounded-full px-5"
+                  disabled={onboardingGarment.trim().length < 2}
+                  data-testid="design-chat-onboarding-start"
+                >
+                  Start designing
+                </Button>
+              </div>
+            </form>
+            </div>
+          )}
+
+          {/* Composer — sticky to the viewport bottom; the page scrolls behind it */}
+          <form
+            onSubmit={handleSubmit}
+            onDragOver={(e) => e.preventDefault()}
+            onDrop={(e) => {
+              e.preventDefault()
+              addFiles(Array.from(e.dataTransfer.files ?? []))
+            }}
+            className="sticky bottom-0 z-10 mx-auto w-full max-w-3xl px-4 pb-4"
+          >
+            {/* Pending reference thumbnails */}
+            {attachments.length > 0 && (
+              <div className="mb-2">
+                <AttachmentThumbnails
+                  refs={attachments.map((a) => ({
+                    id: a.id,
+                    name: a.file.name,
+                    previewUrl: a.previewUrl,
+                    status: a.status,
+                    error: a.error,
+                    analysis: a.analysis,
+                  }))}
+                  onRemove={removeAttachment}
+                />
+              </div>
+            )}
+
+            {/* Floating centered input pill */}
+            <div className="flex items-end gap-1.5 rounded-2xl border border-ui-border-base bg-ui-bg-field p-1.5 pl-3 shadow-elevation-card-rest transition-colors focus-within:border-ui-border-strong">
+              <AttachButton
+                onFiles={addFiles}
+                inputRef={fileInputRef}
+                disabled={isStreaming}
+              />
+              <textarea
+                ref={inputRef}
+                value={input}
+                onChange={(e) => {
+                  setInput(e.target.value)
+const emailMatch = e.target.value.match(/[\w.+-]+@[\w-]+\.[\w.]+/)
+                    if (emailMatch && !meta.email) {
+                      setMeta((prev) => ({ ...prev, email: emailMatch[0].toLowerCase() }))
+                      saveDesignerEmail(emailMatch[0].toLowerCase())
+                    }
+                }}
+                onKeyDown={(e) => {
+                  if (e.key === "Enter" && !e.shiftKey) {
+                    e.preventDefault()
+                    handleSubmit(e as any)
+                  }
+                }}
+                rows={1}
+                maxLength={1000}
+                placeholder={PLACEHOLDER}
+                className="max-h-32 min-w-0 flex-1 resize-none bg-transparent px-2 py-2 text-sm outline-none"
+                data-testid="design-chat-input"
+              />
+              <span className="hidden shrink-0 self-center pr-1 text-[10px] text-ui-fg-muted sm:block">
+                {input.length}/1000
+              </span>
+              {isStreaming ? (
+                <Button
+                  type="button"
+                  onClick={() => stop()}
+                  className="h-9 w-9 shrink-0 rounded-full p-0"
+                  aria-label="Stop generating"
+                >
+                  <StopCircleSolid className="h-5 w-5" />
+                </Button>
+              ) : (
+                <Button
+                  type="submit"
+                  disabled={
+                    uploading ||
+                    (input.trim().length < 2 && attachments.length === 0)
+                  }
+                  className="h-9 w-9 shrink-0 rounded-full p-0"
+                  aria-label="Send message"
+                  data-testid="design-chat-send"
+                >
+                  {uploading ? (
+                    <Spinner className="h-5 w-5 animate-spin" />
+                  ) : (
+                    <ArrowUpMini className="h-5 w-5" />
+                  )}
+                </Button>
+              )}
+            </div>
+
+            {uploading && (
+              <p className="mt-2 text-[11px] text-ui-fg-muted">
+                Uploading references…
+              </p>
+            )}
+          </form>
+        </div>
+
+        {/* Board column (desktop) — sticky sidebar so it stays in view while the
+            chat scrolls with the window. */}
+        {!isMobileLayout && (
+          <div
+            data-lenis-prevent
+            className="sticky top-14 h-[calc(100dvh-3.5rem)] w-80 shrink-0 overflow-y-auto border-l border-ui-border-base px-4 py-6"
+          >
+            {boardPanel}
+          </div>
+        )}
+
+        {/* Board sheet (mobile — collapsible bottom section) */}
+        {isMobileLayout && (
+          <div
+            data-lenis-prevent
+            className="max-h-[45vh] overflow-y-auto border-t border-ui-border-base bg-ui-bg-subtle px-3 py-3"
+          >
+            {boardPanel}
+          </div>
+        )}
+      </div>
+
+      {/* Checkout — reuses the dormant editor's modal */}
+      <DesignCheckoutModal
+        isOpen={showCheckout}
+        onClose={() => setShowCheckout(false)}
+        designId={designId}
+        designName={meta.title ?? "Your design"}
+        countryCode={countryCode}
+        hasMaterial={Boolean(selectedMaterial)}
+        hasPartner={Boolean(selectedPartner)}
+      />
+    </div>
+  )
+}

--- a/apps/storefront/src/modules/products/components/design-chat/index.tsx
+++ b/apps/storefront/src/modules/products/components/design-chat/index.tsx
@@ -4,6 +4,7 @@ import React from "react"
 import clsx from "clsx"
 import { useChat } from "@ai-sdk/react"
 import { DefaultChatTransport, type UIMessage } from "ai"
+import { useLenis } from "lenis/react"
 import { Button, Text } from "@medusajs/ui"
 import {
   ArrowLeft,
@@ -185,6 +186,7 @@ export default function DesignChat({
     setMessages,
     stop,
   } = useChat({ transport })
+  const lenis = useLenis()
 
   const isStreaming = status === "submitted" || status === "streaming"
   const isGenerating = messages.some(
@@ -336,8 +338,18 @@ export default function DesignChat({
   const [stickToBottom, setStickToBottom] = React.useState(true)
   React.useEffect(() => {
     if (!stickToBottom) return
-    scrollAnchorRef.current?.scrollIntoView({ block: "end" })
-  }, [messages, stickToBottom])
+    // The app is wrapped in <ReactLenis root> (smooth-scroll.tsx), which
+    // hijacks native scroll — `scrollIntoView` never moves the window. Drive
+    // Lenis directly for an instant jump to the bottom anchor; fall back to
+    // native scrollIntoView when no Lenis instance is present (tests / SSR).
+    if (lenis) {
+      lenis.scrollTo(document.documentElement.scrollHeight, {
+        immediate: true,
+      })
+    } else {
+      scrollAnchorRef.current?.scrollIntoView({ block: "end" })
+    }
+  }, [messages, stickToBottom, lenis])
 
   React.useEffect(() => {
     const onScroll = () => {

--- a/apps/storefront/src/modules/products/components/design-chat/lib/design-conversations.ts
+++ b/apps/storefront/src/modules/products/components/design-chat/lib/design-conversations.ts
@@ -1,0 +1,173 @@
+"use client"
+
+import { sdk } from "@lib/config"
+
+/**
+ * Client for the server-backed design conversation store
+ * (`/store/custom/design-assistant/conversations`).
+ *
+ * The design chat is public and gated on the maker's EMAIL (no login — the
+ * same gate the backend flow uses). Threads scope by normalised email +
+ * thread key server-side; the client mirrors the localStorage design thread
+ * here after each completed turn so threads survive storage clears and follow
+ * the maker across devices.
+ *
+ * All calls return friendly nulls on failure — the localStorage thread is the
+ * primary store, the server mirror is the durable backstop.
+ */
+
+export type StoredUIMessage = {
+  id?: string
+  role: "system" | "user" | "assistant"
+  content?: string
+  parts?: Array<{ type: string } & Record<string, any>>
+}
+
+export type DesignConversation = {
+  id: string
+  customer_email: string
+  thread_key: string
+  design_id: string | null
+  title: string
+  messages?: StoredUIMessage[]
+  created_at?: string
+  updated_at?: string
+}
+
+// The SDK is configured with the publishable key at construction and sends
+// it on every fetch — /store/* public routes need nothing extra.
+const headers = () => ({
+  "Content-Type": "application/json",
+})
+
+/** List the maker's threads for one thread key (light — no bodies). */
+export const listDesignConversations = async (
+  email: string,
+  threadKey: string
+): Promise<DesignConversation[]> => {
+  try {
+    const data = await sdk.client.fetch<{ conversations: DesignConversation[] }>(
+      `/store/custom/design-assistant/conversations`,
+      {
+        method: "GET",
+        query: { customer_email: email, thread_key: threadKey, limit: 20 },
+        headers: headers(),
+      }
+    )
+    return data.conversations ?? []
+  } catch {
+    return []
+  }
+}
+
+/** Fetch one thread with its full message array. */
+export const getDesignConversation = async (
+  email: string,
+  threadKey: string,
+  conversationId: string
+): Promise<DesignConversation | null> => {
+  try {
+    const data = await sdk.client.fetch<{ conversation: DesignConversation }>(
+      `/store/custom/design-assistant/conversations/${conversationId}`,
+      {
+        method: "GET",
+        query: { customer_email: email, thread_key: threadKey },
+        headers: headers(),
+      }
+    )
+    return data.conversation ?? null
+  } catch {
+    return null
+  }
+}
+
+/** Create the server mirror for a thread. */
+export const createDesignConversation = async (
+  input: {
+    customer_email: string
+    thread_key: string
+    title?: string
+    design_id?: string
+    messages?: StoredUIMessage[]
+  }
+): Promise<DesignConversation | null> => {
+  try {
+    const data = await sdk.client.fetch<{ conversation: DesignConversation }>(
+      `/store/custom/design-assistant/conversations`,
+      {
+        method: "POST",
+        body: input,
+        headers: headers(),
+      }
+    )
+    return data.conversation ?? null
+  } catch {
+    return null
+  }
+}
+
+/** Persist messages / title / design link after each completed turn. */
+export const updateDesignConversation = async (
+  conversationId: string,
+  input: {
+    customer_email: string
+    thread_key: string
+    title?: string
+    design_id?: string
+    messages?: StoredUIMessage[]
+  }
+): Promise<boolean> => {
+  try {
+    await sdk.client.fetch(
+      `/store/custom/design-assistant/conversations/${conversationId}`,
+      {
+        method: "PATCH",
+        body: input,
+        headers: headers(),
+      }
+    )
+    return true
+  } catch {
+    return false
+  }
+}
+
+export const deleteDesignConversation = async (
+  conversationId: string,
+  email: string,
+  threadKey: string
+): Promise<boolean> => {
+  try {
+    await sdk.client.fetch(
+      `/store/custom/design-assistant/conversations/${conversationId}`,
+      {
+        method: "DELETE",
+        body: { customer_email: email, thread_key: threadKey },
+        headers: headers(),
+      }
+    )
+    return true
+  } catch {
+    return false
+  }
+}
+
+/**
+ * Mirror a thread to the server: create once, update after. Returns the
+ * conversation id (null on failure — the caller keeps the local thread).
+ */
+export const mirrorDesignThread = async (input: {
+  conversationId?: string
+  customer_email: string
+  thread_key: string
+  title?: string
+  design_id?: string
+  messages: StoredUIMessage[]
+}): Promise<string | null> => {
+  if (input.conversationId) {
+    const ok = await updateDesignConversation(input.conversationId, input)
+    return ok ? input.conversationId : null
+  }
+  const created = await createDesignConversation(input)
+  return created?.id ?? null
+}

--- a/apps/storefront/src/modules/products/components/design-chat/lib/design-pick.ts
+++ b/apps/storefront/src/modules/products/components/design-chat/lib/design-pick.ts
@@ -1,0 +1,24 @@
+"use client"
+
+import { sdk } from "@lib/config"
+
+/**
+ * Deterministic canvas pick — calls the backend pick API directly (no model
+ * turn). The same write `set_active_canvas` performs when the maker says
+ * "pick take B" in chat: marks the canvas active in the Excalidraw scene and
+ * stamps design.thumbnail_url.
+ */
+export const pickDesignCanvas = async (
+  designId: string,
+  canvasId: string
+): Promise<{ ok: boolean; thumbnail_url: string | null }> => {
+  const data = await sdk.client.fetch<{
+    ok: boolean
+    thumbnail_url: string | null
+  }>(`/store/custom/design-assistant/pick`, {
+    method: "POST",
+    body: { design_id: designId, canvas_id: canvasId },
+    headers: { "Content-Type": "application/json" },
+  })
+  return data
+}

--- a/apps/storefront/src/modules/products/components/design-chat/lib/design-scene.ts
+++ b/apps/storefront/src/modules/products/components/design-chat/lib/design-scene.ts
@@ -1,0 +1,42 @@
+"use client"
+
+import { sdk } from "@lib/config"
+import { normalizeScene, type CanvasScene } from "../components/scene-panel"
+
+/**
+ * Light design state loader — refreshes the board after a generation without
+ * a full page navigation. Reads the design's moodboard scene + thumbnail.
+ *
+ * The store designs API returns the design for the authenticated customer; a
+ * guest customer (email-gated flow) reads via the same route after sign-in —
+ * until then the board refreshes from the generation tool results in the chat
+ * itself, so failures here are silent (best-effort).
+ */
+export const getDesignScene = async (
+  designId: string
+): Promise<{
+  design_id: string
+  thumbnail_url: string | null
+  scene: CanvasScene | null
+} | null> => {
+  try {
+    const data = await sdk.client.fetch<{
+      design: {
+        id: string
+        thumbnail_url?: string | null
+        moodboard?: unknown
+      }
+    }>(`/store/custom/designs/${designId}`, {
+      method: "GET",
+      headers: { "Content-Type": "application/json" },
+    })
+    const design = data.design
+    return {
+      design_id: design.id,
+      thumbnail_url: design.thumbnail_url ?? null,
+      scene: normalizeScene(design.moodboard),
+    }
+  } catch {
+    return null
+  }
+}

--- a/apps/storefront/src/modules/products/components/design-chat/lib/design-scene.ts
+++ b/apps/storefront/src/modules/products/components/design-chat/lib/design-scene.ts
@@ -1,24 +1,48 @@
 "use client"
 
 import { sdk } from "@lib/config"
+import { loadDesignerEmail } from "@lib/util/designer-email"
 import { normalizeScene, type CanvasScene } from "../components/scene-panel"
 
 /**
- * Light design state loader — refreshes the board after a generation without
- * a full page navigation. Reads the design's moodboard scene + thumbnail.
+ * Board loader — reads the design's moodboard scene + thumbnail after a
+ * generation, without a full page navigation.
  *
- * The store designs API returns the design for the authenticated customer; a
- * guest customer (email-gated flow) reads via the same route after sign-in —
- * until then the board refreshes from the generation tool results in the chat
- * itself, so failures here are silent (best-effort).
+ * ## 🔴 Why this does not use `/store/custom/designs/:id`
+ *
+ * It used to, and that route requires an authenticated CUSTOMER. This flow's
+ * entire premise is a guest identified by an email, so every call answered
+ * `401 Customer authentication required` — swallowed by the `catch` below,
+ * which the old comment described as "best-effort" on the theory that "the
+ * board refreshes from the generation tool results in the chat itself".
+ *
+ * There is no such path. `refreshScene` is the ONLY thing that fills the board
+ * after a generation. So the panel sat on "Your board is empty" for every
+ * maker, forever, while the chat rendered both takes a few pixels to its left
+ * — and nothing anywhere failed loudly enough to notice. Fifteen backend tests
+ * pass either way; the only instrument that sees it is a rendered page.
+ *
+ * The read now goes through the assistant's own email-scoped mount, which is
+ * the auth model the rest of this feature already uses.
+ *
+ * ⚠️ Still `catch`-to-null, deliberately: a board that cannot refresh must not
+ * take the chat down with it. But a null now means a real failure rather than
+ * the design of the thing.
  */
 export const getDesignScene = async (
-  designId: string
+  designId: string,
+  /** The maker's email. Falls back to the remembered one. */
+  customerEmail?: string | null
 ): Promise<{
   design_id: string
   thumbnail_url: string | null
   scene: CanvasScene | null
 } | null> => {
+  const email = (customerEmail || loadDesignerEmail() || "").trim()
+  // Without an email the read cannot be scoped, and an unscoped board read is
+  // not something to fall back to.
+  if (!email) return null
+
   try {
     const data = await sdk.client.fetch<{
       design: {
@@ -26,8 +50,9 @@ export const getDesignScene = async (
         thumbnail_url?: string | null
         moodboard?: unknown
       }
-    }>(`/store/custom/designs/${designId}`, {
+    }>(`/store/custom/design-assistant/designs/${designId}`, {
       method: "GET",
+      query: { customer_email: email },
       headers: { "Content-Type": "application/json" },
     })
     const design = data.design

--- a/apps/storefront/src/modules/products/components/design-chat/lib/design-thread.ts
+++ b/apps/storefront/src/modules/products/components/design-chat/lib/design-thread.ts
@@ -1,0 +1,110 @@
+"use client"
+
+import type { UIMessage } from "ai"
+import { sdk } from "@lib/config"
+
+/**
+ * Design thread persistence — the chat-based design editor's thread store.
+ *
+ * Threads are keyed per base product (the same scope the backend conversations
+ * API uses as `thread_key`): `product:{id}` for product-variant designs,
+ * `custom` for standalone designs at /design. Messages persist to localStorage
+ * so a returning maker resumes their board instantly, and are mirrored to the
+ * server-backed conversation store (email-scoped, see design-conversations.ts)
+ * after each completed turn so threads survive localStorage clears and follow
+ * the maker across devices.
+ *
+ * Mirrors the concierge-thread pattern (`@lib/util/concierge-thread`).
+ */
+
+const STORAGE_PREFIX = "jyt:design-thread:"
+
+export type DesignThreadMeta = {
+  /** Base-product scope key: `product:{id}` or `custom`. */
+  threadKey: string
+  /** The maker's email once shared (the flow's gate). */
+  email?: string
+  /** Backend conversation id once the thread is mirrored. */
+  conversationId?: string
+  /** Design id once first generation creates it. */
+  designId?: string
+  /** Human-readable label (seeded from the first user message). */
+  title?: string
+}
+
+export type DesignThread = {
+  meta: DesignThreadMeta
+  messages: UIMessage[]
+}
+
+export const resolveThreadKey = (productId?: string | null): string =>
+  productId ? `product:${productId}` : "custom"
+
+export const loadDesignThread = (threadKey: string): DesignThread | null => {
+  if (typeof window === "undefined") return null
+  try {
+    const raw = window.localStorage.getItem(STORAGE_PREFIX + threadKey)
+    if (!raw) return null
+    const parsed = JSON.parse(raw)
+    if (!parsed || typeof parsed !== "object") return null
+    return {
+      meta: {
+        threadKey,
+        ...(parsed.meta ?? {}),
+      },
+      messages: Array.isArray(parsed.messages) ? parsed.messages : [],
+    }
+  } catch {
+    return null
+  }
+}
+
+export const saveDesignThread = (thread: DesignThread): void => {
+  if (typeof window === "undefined") return
+  try {
+    window.localStorage.setItem(
+      STORAGE_PREFIX + thread.meta.threadKey,
+      JSON.stringify(thread)
+    )
+    window.dispatchEvent(new Event("jyt:design-thread-change"))
+  } catch {
+    // Storage full / private mode — the server mirror is the backstop.
+  }
+}
+
+export const clearDesignThread = (threadKey: string): void => {
+  if (typeof window === "undefined") return
+  try {
+    window.localStorage.removeItem(STORAGE_PREFIX + threadKey)
+    window.dispatchEvent(new Event("jyt:design-thread-change"))
+  } catch {
+    /* ignore */
+  }
+}
+
+export const hasDesignThread = (threadKey: string): boolean =>
+  typeof window !== "undefined" &&
+  Boolean(window.localStorage.getItem(STORAGE_PREFIX + threadKey))
+
+/** All the maker's locally stored design threads (thread list). */
+export const listLocalDesignThreads = (): DesignThreadMeta[] => {
+  if (typeof window === "undefined") return []
+  const metas: DesignThreadMeta[] = []
+  try {
+    for (let i = 0; i < window.localStorage.length; i++) {
+      const key = window.localStorage.key(i)
+      if (!key || !key.startsWith(STORAGE_PREFIX)) continue
+      const raw = window.localStorage.getItem(key)
+      if (!raw) continue
+      try {
+        const parsed = JSON.parse(raw)
+        metas.push(parsed?.meta ?? { threadKey: key.slice(STORAGE_PREFIX.length) })
+      } catch {
+        /* skip corrupt entry */
+      }
+    }
+  } catch {
+    /* ignore */
+  }
+  return metas
+}

--- a/apps/storefront/src/modules/products/components/design-chat/lib/design-uploads.ts
+++ b/apps/storefront/src/modules/products/components/design-chat/lib/design-uploads.ts
@@ -1,0 +1,125 @@
+"use client"
+
+import { presignDesignImageUpload } from "@lib/data/uploads"
+import { analyzeDesignReference } from "@lib/data/design-references"
+
+/**
+ * Design reference uploads — the chat design editor's file-upload utility.
+ *
+ * The maker drops / picks reference images (inspirations, photos of garments
+ * they want to riff on). Each file is:
+ *   1. previewed immediately as an object URL (no server round-trip), then
+ *   2. uploaded to storage via a presigned S3 URL when the maker is signed in,
+ *   3. analysed on the fly — the vision description is attached so the chat
+ *      can show it and the message can ground the model on it.
+ *
+ * Guests keep their session-local preview (thumbnails still render across the
+ * chat) — the presign endpoint is customer-authenticated, so a guest upload
+ * degrades to `status: "preview"` instead of failing the whole send.
+ */
+
+export type ReferenceAnalysis = {
+  title: string
+  description: string
+  suggestions: string[]
+  media_id: string | null
+  analyzed_at: string | null
+  cached?: boolean
+}
+
+export type DesignReference = {
+  id: string
+  file: File
+  /** Object URL for immediate display (session-only). */
+  previewUrl: string
+  /** Permanent public URL once uploaded to storage. */
+  publicUrl: string | null
+  /** preview → uploading → ready | error */
+  status: "preview" | "uploading" | "ready" | "error"
+  /** Human-readable error for guests / failed uploads. */
+  error?: string
+  /** Vision analysis attached after the on-the-fly read. */
+  analysis?: ReferenceAnalysis | null
+}
+
+const ACCEPTED_TYPES = ["image/jpeg", "image/png", "image/webp", "image/gif"]
+const MAX_SIZE_BYTES = 10 * 1024 * 1024
+
+let idCounter = 0
+const nextId = () => `ref-${Date.now()}-${idCounter++}`
+
+export const isAcceptedImage = (file: File): boolean =>
+  ACCEPTED_TYPES.includes(file.type) && file.size <= MAX_SIZE_BYTES
+
+/** Build a session-local reference with an object-URL preview. */
+export const createReference = (file: File): DesignReference => ({
+  id: nextId(),
+  file,
+  previewUrl: URL.createObjectURL(file),
+  publicUrl: null,
+  status: "preview",
+})
+
+export const releaseReference = (ref: DesignReference): void => {
+  URL.revokeObjectURL(ref.previewUrl)
+}
+
+/**
+ * Upload a single reference to storage. Resolves with an updated reference —
+ * `publicUrl` is set on success, otherwise `status: "error"` + a friendly
+ * message (guests are told to sign in rather than shown a raw 401).
+ */
+export const uploadDesignReference = async (
+  ref: DesignReference
+): Promise<DesignReference> => {
+  if (ref.status === "ready" && ref.publicUrl) {
+    return ref
+  }
+
+  const result = await presignDesignImageUpload({
+    name: ref.file.name || "reference.jpg",
+    type: ref.file.type || "image/jpeg",
+    size: ref.file.size,
+  })
+
+  if (result.error) {
+    return {
+      ...ref,
+      status: "error",
+      error:
+        result.error.code === "AUTH_REQUIRED"
+          ? "Sign in to add references to your board."
+          : result.error.message || "Upload failed.",
+    }
+  }
+
+  const { url: presignedUrl, public_url } = result.presign!
+  const uploadRes = await fetch(presignedUrl, {
+    method: "PUT",
+    body: ref.file,
+    headers: { "Content-Type": ref.file.type || "image/jpeg" },
+  })
+
+  if (!uploadRes.ok) {
+    return {
+      ...ref,
+      status: "error",
+      error: "Upload failed — try again.",
+    }
+  }
+
+  // On-the-fly vision read — attach the analysis so the chat can show it and
+  // the message can ground the model on it. Best-effort (never blocks upload).
+  const { analysis } = await analyzeDesignReference({
+    url: public_url,
+    name: ref.file.name,
+    mime_type: ref.file.type || undefined,
+  })
+
+  return {
+    ...ref,
+    publicUrl: public_url,
+    status: "ready",
+    analysis: analysis ?? null,
+  }
+}

--- a/apps/storefront/src/modules/store/components/ai-search/index.tsx
+++ b/apps/storefront/src/modules/store/components/ai-search/index.tsx
@@ -76,13 +76,15 @@ export default function StoreAiSearch() {
   }, [])
 
   return (
-    <div className="mb-8">
+    /* Centred search pill — lives in the page flow (not pinned to the top),
+       so it scrolls away with Lenis's eased window scroll. */
+    <div className="z-40 mx-auto mb-8 w-[min(680px,94%)]">
       <form
         onSubmit={(e) => {
           e.preventDefault()
           void submit()
         }}
-        className="flex items-center gap-2"
+        className="flex items-center gap-2 rounded-full border border-neutral-200 bg-white/85 p-1.5 pl-5 shadow-lg shadow-neutral-900/5 backdrop-blur-md"
       >
         <label className="sr-only" htmlFor="store-ai-search">
           Search products
@@ -93,78 +95,86 @@ export default function StoreAiSearch() {
           value={input}
           onChange={(e) => setInput(e.target.value)}
           placeholder="Search products — describe what you want"
-          className="flex-1 rounded-full border border-neutral-300 bg-white px-4 py-2 text-sm text-neutral-900 placeholder:text-neutral-400 focus:border-neutral-500 focus:outline-none focus:ring-1 focus:ring-neutral-500 sm:text-base"
+          className="min-w-0 flex-1 bg-transparent py-1.5 text-sm text-neutral-900 placeholder:text-neutral-400 focus:outline-none sm:text-base"
           maxLength={200}
           autoComplete="off"
           spellCheck={false}
+          data-testid="store-ai-search-input"
         />
+        {state.kind !== "idle" && (
+          <button
+            type="button"
+            onClick={clear}
+            aria-label="Clear search"
+            className="rounded-full px-2 py-1.5 text-sm text-neutral-400 hover:text-neutral-900"
+          >
+            ✕
+          </button>
+        )}
         <button
           type="submit"
           disabled={
             state.kind === "loading" || input.trim().length < 2
           }
-          className="rounded-full bg-neutral-900 px-4 py-2 text-sm font-medium text-white disabled:cursor-not-allowed disabled:opacity-50 sm:text-base"
+          className="flex-shrink-0 rounded-full bg-neutral-900 px-5 py-2 text-sm font-medium text-white transition hover:bg-black disabled:cursor-not-allowed disabled:opacity-50"
+          data-testid="store-ai-search-submit"
         >
           {state.kind === "loading" ? "…" : "Search"}
         </button>
-        {state.kind !== "idle" && (
-          <button
-            type="button"
-            onClick={clear}
-            className="rounded-full px-3 py-2 text-sm text-neutral-500 hover:text-neutral-900"
-          >
-            Clear
-          </button>
-        )}
       </form>
 
-      {state.kind === "loading" && (
-        <p className="mt-3 text-sm text-neutral-500">
-          Searching for <em>"{state.query}"</em>…
-        </p>
-      )}
-
-      {state.kind === "error" && (
-        <p className="mt-3 text-sm text-red-600">
-          Couldn't reach the search service. Try again.
-        </p>
-      )}
-
-      {state.kind === "result" && (
-        <div className="mt-4 rounded-2xl border border-neutral-200 bg-neutral-50 p-4">
-          <div className="mb-3 flex flex-wrap items-baseline justify-between gap-2">
-            <p className="text-sm text-neutral-700 sm:text-base">
-              <strong>{state.products.length}</strong>{" "}
-              {state.products.length === 1 ? "match" : "matches"} for{" "}
-              <em>"{state.query}"</em>
-            </p>
-            {state.interpretation && (
-              <p className="text-[11px] text-neutral-500 sm:text-xs">
-                Interpreted as:{" "}
-                {[
-                  state.interpretation.keywords?.join(", "),
-                  state.interpretation.color,
-                  state.interpretation.material,
-                  state.interpretation.max_price
-                    ? `under ${state.interpretation.max_price}`
-                    : null,
-                ]
-                  .filter(Boolean)
-                  .join(" · ")}
-              </p>
-            )}
-          </div>
-          {state.products.length === 0 ? (
+      {/* Results panel — attached beneath the floating bar */}
+      {state.kind !== "idle" && (
+        <div className="mt-2 rounded-2xl border border-neutral-200 bg-white/95 p-4 shadow-xl shadow-neutral-900/10 backdrop-blur-md">
+          {state.kind === "loading" && (
             <p className="text-sm text-neutral-500">
-              Nothing matched. Try simpler keywords, or browse the
-              catalogue below.
+              Searching for <em>"{state.query}"</em>…
             </p>
-          ) : (
-            <ul className="grid grid-cols-2 gap-3 sm:grid-cols-3 lg:grid-cols-4">
-              {state.products.map((p) => (
-                <ProductCard key={p.id} product={p} />
-              ))}
-            </ul>
+          )}
+
+          {state.kind === "error" && (
+            <p className="text-sm text-red-600">
+              Couldn't reach the search service. Try again.
+            </p>
+          )}
+
+          {state.kind === "result" && (
+            <>
+              <div className="mb-3 flex flex-wrap items-baseline justify-between gap-2">
+                <p className="text-sm text-neutral-700 sm:text-base">
+                  <strong>{state.products.length}</strong>{" "}
+                  {state.products.length === 1 ? "match" : "matches"} for{" "}
+                  <em>"{state.query}"</em>
+                </p>
+                {state.interpretation && (
+                  <p className="text-[11px] text-neutral-500 sm:text-xs">
+                    Interpreted as:{" "}
+                    {[
+                      state.interpretation.keywords?.join(", "),
+                      state.interpretation.color,
+                      state.interpretation.material,
+                      state.interpretation.max_price
+                        ? `under ${state.interpretation.max_price}`
+                        : null,
+                    ]
+                      .filter(Boolean)
+                      .join(" · ")}
+                  </p>
+                )}
+              </div>
+              {state.products.length === 0 ? (
+                <p className="text-sm text-neutral-500">
+                  Nothing matched. Try simpler keywords, or browse the
+                  catalogue below.
+                </p>
+              ) : (
+                <ul className="max-h-[60vh] overflow-y-auto pr-1 grid grid-cols-2 gap-3 sm:grid-cols-3 lg:grid-cols-4">
+                  {state.products.map((p) => (
+                    <ProductCard key={p.id} product={p} />
+                  ))}
+                </ul>
+              )}
+            </>
           )}
         </div>
       )}

--- a/apps/storefront/src/modules/store/templates/index.tsx
+++ b/apps/storefront/src/modules/store/templates/index.tsx
@@ -46,6 +46,9 @@ const StoreTemplate = async ({
         <div className="mb-6 text-2xl-semi">
           <h1 data-testid="store-page-title">All products</h1>
         </div>
+        {/* Floating AI search — a sticky pill centred over the catalogue.
+            It stays centred while the customer scrolls and the results
+            panel drops beneath it (see ai-search/index.tsx). */}
         <StoreAiSearch />
         <Suspense fallback={<SkeletonProductGrid />}>
           <PaginatedProducts


### PR DESCRIPTION
## Summary

Replaces the dormant Konva design editor with a **chat-based design editor** on `/design` and `/products/:handle/design`, adds **on-the-fly image analysis** for uploaded references, and wires **AI image generation to Cloudflare Workers AI** (fixing generation failures from the missing OpenRouter key).

## What changed

### Storefront — design chat
- Full-screen studio shell (`DesignStudioShell` drops nav/footer on design routes), intro + "how it works" onboarding, floating centered composer, live board panel.
- File-upload utility: presign → S3 → on-the-fly vision analysis; thumbnails across the chat; "AI read" badge; descriptions sent with the message to ground the model.
- Designer email remembered globally (`designer-email` util) — new designs no longer re-ask.
- Store AI search centered + non-sticky.

### Backend — design assistant
- `storefront-design-assistant` module + public email-scoped conversation store (`/store/custom/design-assistant/{conversations,pick,references/analyze}`).
- Design flow: `create_design` (early record + guest-customer link), explicit generation-consent gate, turn-planner gating, board state injected into the system prompt.
- `list_raw_materials` / `list_partners`: verified-only, `workspace_type` "path" roles (Fabric Seller → Manufacturer), short default lists (no auto-load-all).
- On-the-fly reference analysis persisted to `MediaFile.metadata.vision_analysis` (cache-aware).

### AI image generation
- Wired to Cloudflare Workers AI (`@cf/black-forest-labs/flux-1-schnell`) via the `ai_image_gen` External Platform (prompt enhancement + image gen), with env fallback. Removes the OpenRouter-free hard dependency that was failing with `OpenRouter API key is missing`.

## Test / verification
- Backend + storefront typecheck clean.
- Live: `POST /store/custom/design-assistant/references/analyze` → 200 (MediaFile created, idempotent).
- Integration test `storefront-design-assistant-conversations.spec.ts` (10 tests).

## Notes
- The decrypted Cloudflare token travels in the Mastra workflow `inputData` (no container in the Mastra runtime) — flagged as a follow-up to avoid persisting secrets in run storage.