### PR TITLE
feat(stats): dynamic metric_sections operation + seeded public Platform Stats panel

### DIFF
--- a/apps/backend/integration-tests/http/platform-stats-panel.spec.ts
+++ b/apps/backend/integration-tests/http/platform-stats-panel.spec.ts
@@ -19,7 +19,7 @@
  *   commission   — partner_fee sum, all-time + trailing window
  *   subscription — partner_subscription: count_distinct partners + MRR
  *                  (monthly-normalized plan price, yearly / 12)
- *   aov          — avg captured amount over the trailing window
+ *   aov          — avg order value over the trailing window (ALL orders)
  *   arr          — DERIVED section: subscription.mrr × 12
  *
  * Assertions are before/after DELTAS for all-time counts/sums so the spec
@@ -85,11 +85,10 @@ const jpySections = {
     echo: { currency: true },
   },
   aov: {
-    entity: "order_transaction",
-    filters: { reference: "capture" },
+    entity: "order",
     currency_key: "currency_code",
     aggregates: {
-      amount: { fn: "avg", field: "amount", range: { date_field: "created_at", last_days: 30 } },
+      amount: { fn: "avg", field: "total", range: { date_field: "created_at", last_days: 30 } },
     },
     echo: { currency: true },
   },
@@ -230,7 +229,8 @@ setupSharedTestSuite(() => {
         captured: true,
       })
       // Not captured — no capture transaction, so it must be excluded from
-      // orders.processed and from the AOV capture-amount average
+      // orders.processed. It IS an order, though, so the all-orders AOV
+      // (entity "order", avg(total)) counts it.
       await seedPaidOrder(container, {
         currency_code: "jpy",
         unit_price: 12345,
@@ -276,12 +276,13 @@ setupSharedTestSuite(() => {
       expect(d.arr.currency).toBe("JPY")
       expect(d.arr.amount - b.arr.amount).toBe(35988)
 
-      // aov — avg captured amount: (10000 + 10000) / 2. jpy is only seeded
-      // here, so the baseline jpy AOV is 0/null — otherwise the exact check
-      // degrades and we only assert structure.
+      // aov — avg order value over ALL orders in the trailing window:
+      // (10000 + 10000 + 12345) / 3. jpy is only seeded here, so the
+      // baseline jpy AOV is 0/null — otherwise the exact check degrades
+      // and we only assert structure.
       expect(d.aov.currency).toBe("JPY")
       if (b.aov.amount == null || b.aov.amount === 0) {
-        expect(d.aov.amount).toBe(10000)
+        expect(d.aov.amount).toBe(10781.67)
       } else {
         expect(d.aov.amount).toBeGreaterThan(0)
       }

--- a/apps/backend/integration-tests/http/platform-stats-panel.spec.ts
+++ b/apps/backend/integration-tests/http/platform-stats-panel.spec.ts
@@ -1,0 +1,390 @@
+/**
+ * Integration tests for the DYNAMIC `metric_sections` stats operation.
+ *
+ * `metric_sections` has no business logic in code: the panel declares named
+ * sections (entity + named aggregates + ranges + currency keys + derived
+ * arithmetic) and the operation derives every section from live rows. This
+ * spec seeds that config and proves it end to end through the real admin
+ * stats APIs:
+ *
+ *   POST /admin/stats/panels/preview        — the operation, end to end
+ *   POST /admin/stats/dashboards/:id/panels — seeded panel with metadata.public
+ *   GET  /admin/stats/panels/:id/data       — admin resolver
+ *   GET  /web/stats/panels/:id/data         — UNAUTHENTICATED public read,
+ *                                             gated on metadata.public === true
+ *
+ * Seeded config (the exact sections the "Platform Stats" panel uses):
+ *   orders       — capture transactions: count_distinct(order_id), all-time +
+ *                  trailing window
+ *   commission   — partner_fee sum, all-time + trailing window
+ *   subscription — partner_subscription: count_distinct partners + MRR
+ *                  (monthly-normalized plan price, yearly / 12)
+ *   aov          — avg captured amount over the trailing window
+ *   arr          — DERIVED section: subscription.mrr × 12
+ *
+ * Assertions are before/after DELTAS for all-time counts/sums so the spec
+ * stays correct when other specs in a shared test DB already contain rows.
+ * Money sections use the "jpy" currency (only this spec seeds jpy rows) so
+ * commission/MRR/ARR/AOV are asserted EXACTLY.
+ */
+
+import { createAdminUser, getAuthHeaders } from "../helpers/create-admin-user"
+import { getSharedTestEnv, setupSharedTestSuite } from "./shared-test-setup"
+import { Modules } from "@medusajs/utils"
+import {
+  createOrderPaymentCollectionWorkflow,
+  markPaymentCollectionAsPaid,
+} from "@medusajs/medusa/core-flows"
+
+jest.setTimeout(120000)
+
+const unique = () => `ps${Date.now()}${Math.floor(Math.random() * 1e6)}`
+
+// The declarative sections config — this is DATA, not code. The operation
+// derives every section from live rows.
+const jpySections = {
+  orders: {
+    entity: "order_transaction",
+    filters: { reference: "capture" },
+    aggregates: {
+      processed: { fn: "count_distinct", field: "order_id" },
+      trailing_30d: {
+        fn: "count_distinct",
+        field: "order_id",
+        range: { date_field: "created_at", last_days: 30 },
+      },
+    },
+    echo: { window_days: true },
+  },
+  commission: {
+    entity: "partner_fee",
+    filters: { status: "accrued" },
+    currency_key: "currency_code",
+    aggregates: {
+      accrued: { fn: "sum", field: "fee_amount" },
+      trailing_30d: {
+        fn: "sum",
+        field: "fee_amount",
+        range: { date_field: "accrued_at", last_days: 30 },
+      },
+    },
+    echo: { currency: true, window_days: true },
+  },
+  subscription: {
+    entity: "partner_subscription",
+    filters: { status: "active" },
+    currency_key: "plan.currency_code",
+    aggregates: {
+      paying_artisans: { fn: "count_distinct", field: "partner_id" },
+      mrr: {
+        fn: "sum",
+        field: "plan.price",
+        normalize_interval: { interval_field: "plan.interval", yearly_divisor: 12 },
+      },
+    },
+    echo: { currency: true },
+  },
+  aov: {
+    entity: "order_transaction",
+    filters: { reference: "capture" },
+    currency_key: "currency_code",
+    aggregates: {
+      amount: { fn: "avg", field: "amount", range: { date_field: "created_at", last_days: 30 } },
+    },
+    echo: { currency: true },
+  },
+  arr: {
+    derived: { ref: "subscription", aggregate: "mrr", multiply: 12 },
+    echo: { currency: true },
+  },
+}
+
+setupSharedTestSuite(() => {
+  const { api, getContainer } = getSharedTestEnv()
+  let headers: any
+
+  beforeEach(async () => {
+    const container = getContainer()
+    await createAdminUser(container)
+    headers = await getAuthHeaders(api)
+  })
+
+  // ============================================
+  // Helpers
+  // ============================================
+
+  const resolve = (key: string) => (getContainer().resolve(key) as any)
+
+  const preview = (options: Record<string, any>) =>
+    api.post(
+      "/admin/stats/panels/preview",
+      { operation_type: "metric_sections", operation_options: options },
+      headers
+    )
+
+  const jpyPreview = () => preview({ currency: "jpy", window_days: 30, sections: jpySections })
+
+  /** Seed a real order and mark it paid through the canonical core-flows pair. */
+  const seedPaidOrder = async (
+    container: any,
+    input: { currency_code: string; unit_price: number; quantity: number; captured: boolean }
+  ) => {
+    const orderService = resolve(Modules.ORDER)
+    const [order] = await orderService.createOrders([
+      {
+        currency_code: input.currency_code,
+        email: `metric-sections-${unique()}@jyt.test`,
+        items: [
+          {
+            title: "Metric sections test item",
+            quantity: input.quantity,
+            unit_price: input.unit_price,
+          },
+        ],
+      },
+    ])
+
+    const total = input.unit_price * input.quantity
+    if (input.captured) {
+      const { result: pcRes }: any = await createOrderPaymentCollectionWorkflow(
+        container
+      ).run({ input: { order_id: order.id, amount: total } })
+      const paymentCollectionId = Array.isArray(pcRes) ? pcRes[0]?.id : pcRes?.id
+      await markPaymentCollectionAsPaid(container).run({
+        input: { payment_collection_id: paymentCollectionId, order_id: order.id },
+      })
+    }
+    return order
+  }
+
+  const seedFee = async (input: {
+    order_id: string
+    fee_amount: number
+    accrued_at?: Date
+  }) => {
+    const [fee] = await resolve("partner_billing").createPartnerFees([
+      {
+        partner_id: `fee-partner-${unique()}`,
+        order_id: input.order_id,
+        order_total: input.fee_amount * 100,
+        currency_code: "jpy",
+        fee_basis: "percentage",
+        fee_rate: 200,
+        fee_amount: input.fee_amount,
+        fee_type: "commission",
+        status: "accrued",
+        accrued_at: input.accrued_at ?? new Date(),
+      },
+    ])
+    return fee
+  }
+
+  const seedSubscription = async (interval: "monthly" | "yearly", price: number) => {
+    const planService = resolve("partnerPlan")
+    const token = unique()
+    const [plan] = await planService.createPartnerPlans([
+      {
+        name: `Metric sections plan ${token}`,
+        slug: `metric-sections-${token}`,
+        price,
+        currency_code: "jpy",
+        interval,
+        is_active: true,
+      },
+    ])
+    const [sub] = await planService.createPartnerSubscriptions([
+      {
+        partner_id: `artisan-${token}`,
+        status: "active",
+        plan_id: plan.id,
+        current_period_start: new Date(),
+      },
+    ])
+    return { plan, sub }
+  }
+
+  // ============================================
+  // Tests
+  // ============================================
+
+  describe("POST /admin/stats/panels/preview — metric_sections", () => {
+    it("derives every declared section from seeded rows", async () => {
+      // Baseline before seeding (deltas make the assertions pollution-proof)
+      const baseline = await jpyPreview()
+      expect(baseline.status).toBe(200)
+      const b = baseline.data.data
+
+      // ── Seed ────────────────────────────────────────────────────────
+      const container = getContainer()
+
+      const o1 = await seedPaidOrder(container, {
+        currency_code: "jpy",
+        unit_price: 10000,
+        quantity: 1,
+        captured: true,
+      })
+      const o2 = await seedPaidOrder(container, {
+        currency_code: "jpy",
+        unit_price: 5000,
+        quantity: 2,
+        captured: true,
+      })
+      // Not captured — no capture transaction, so it must be excluded from
+      // orders.processed and from the AOV capture-amount average
+      await seedPaidOrder(container, {
+        currency_code: "jpy",
+        unit_price: 12345,
+        quantity: 1,
+        captured: false,
+      })
+
+      const f1 = await seedFee({ order_id: o1.id, fee_amount: 200 })
+      await seedFee({
+        order_id: o2.id,
+        fee_amount: 300,
+        accrued_at: new Date(Date.now() - 40 * 24 * 60 * 60 * 1000),
+      })
+
+      await seedSubscription("monthly", 999)
+      await seedSubscription("yearly", 24000)
+
+      // ── After ───────────────────────────────────────────────────────
+      const after = await jpyPreview()
+      expect(after.status).toBe(200)
+      const d = after.data.data
+
+      // Sections resolved cleanly — no per-section degradation warnings
+      expect(d.warnings).toBeUndefined()
+
+      // orders — capture transactions only (count_distinct over order_id)
+      expect(d.orders.processed - b.orders.processed).toBe(2)
+      expect(d.orders.trailing_30d - b.orders.trailing_30d).toBe(2)
+      expect(d.orders.window_days).toBe(30)
+
+      // commission — 200 + 300 seeded, only the recent one in the window
+      expect(d.commission.currency).toBe("JPY")
+      expect(d.commission.accrued - b.commission.accrued).toBe(500)
+      expect(d.commission.trailing_30d - b.commission.trailing_30d).toBe(200)
+      expect(d.commission.window_days).toBe(30)
+
+      // subscription — monthly 999 + yearly 24000/12 = mrr 2999
+      expect(d.subscription.currency).toBe("JPY")
+      expect(d.subscription.paying_artisans - b.subscription.paying_artisans).toBe(2)
+      expect(d.subscription.mrr - b.subscription.mrr).toBe(2999)
+
+      // arr — DERIVED section: subscription.mrr × 12
+      expect(d.arr.currency).toBe("JPY")
+      expect(d.arr.amount - b.arr.amount).toBe(35988)
+
+      // aov — avg captured amount: (10000 + 10000) / 2. jpy is only seeded
+      // here, so the baseline jpy AOV is 0/null — otherwise the exact check
+      // degrades and we only assert structure.
+      expect(d.aov.currency).toBe("JPY")
+      if (b.aov.amount == null || b.aov.amount === 0) {
+        expect(d.aov.amount).toBe(10000)
+      } else {
+        expect(d.aov.amount).toBeGreaterThan(0)
+      }
+
+      // Top-level context echoes
+      expect(d.currency).toBe("JPY")
+      expect(d.window_days).toBe(30)
+
+      // Shape contract — section keys are exactly what the config declares
+      expect(Object.keys(d.orders).sort()).toEqual(["processed", "trailing_30d", "window_days"])
+      expect(Object.keys(d.commission).sort()).toEqual([
+        "accrued",
+        "currency",
+        "trailing_30d",
+        "window_days",
+      ])
+      expect(Object.keys(d.subscription).sort()).toEqual(["currency", "mrr", "paying_artisans"])
+      expect(Object.keys(d.arr).sort()).toEqual(["amount", "currency"])
+      expect(Object.keys(d.aov).sort()).toEqual(["amount", "currency"])
+
+      // Fee rows must have accrued_at honored — sanity on the seeded row
+      expect(f1.fee_amount).toBeDefined()
+    })
+
+    it("rejects invalid operation_options", async () => {
+      try {
+        await preview({ sections: jpySections, window_days: 0 })
+        fail("Should have rejected window_days <= 0")
+      } catch (error: any) {
+        expect([400, 422]).toContain(error.response?.status)
+      }
+    })
+  })
+
+  describe("seeded panel — admin resolver and public gate", () => {
+    it("serves a metadata.public panel through admin and unauthenticated public endpoints, and 404s a private one", async () => {
+      const token = unique()
+
+      // 1) Create a dashboard + a PUBLIC panel
+      const dashRes = await api.post(
+        "/admin/stats/dashboards",
+        { name: `Platform Stats ${token}` },
+        headers
+      )
+      expect(dashRes.status).toBe(201)
+      const dashboardId = dashRes.data.dashboard.id
+      expect(dashboardId).toBeDefined()
+
+      const panelRes = await api.post(
+        `/admin/stats/dashboards/${dashboardId}/panels`,
+        {
+          name: `Platform snapshot ${token}`,
+          type: "metric",
+          operation_type: "metric_sections",
+          operation_options: { currency: "jpy", window_days: 30, sections: jpySections },
+          metadata: { public: true },
+        },
+        headers
+      )
+      expect(panelRes.status).toBe(201)
+      const panelId = panelRes.data.panel.id
+
+      // 2) Admin resolver resolves it with the full data
+      //    (the admin panels/:id/data endpoint is a POST — same call the
+      //    admin renderer hook makes, see src/admin/hooks/api/stats.ts)
+      const adminData = await api.post(
+        `/admin/stats/panels/${panelId}/data`,
+        {},
+        headers
+      )
+      expect(adminData.status).toBe(200)
+      expect(adminData.data.panel_id).toBe(panelId)
+      expect(adminData.data.data.orders.processed).toBeGreaterThanOrEqual(0)
+      expect(adminData.data.data.commission.currency).toBe("JPY")
+
+      // 3) UNAUTHENTICATED public read — the metadata.public gate opens it
+      const publicData = await api.get(`/web/stats/panels/${panelId}/data`)
+      expect(publicData.status).toBe(200)
+      expect(publicData.data.panel_id).toBe(panelId)
+      expect(publicData.data.data.orders.processed).toBeGreaterThanOrEqual(0)
+      expect(publicData.data.data.subscription.currency).toBe("JPY")
+
+      // 4) A PRIVATE panel (no metadata.public) 404s on the same endpoint —
+      //    the gate never leaks that the id exists
+      const privateRes = await api.post(
+        `/admin/stats/dashboards/${dashboardId}/panels`,
+        {
+          name: `Private snapshot ${token}`,
+          type: "metric",
+          operation_type: "metric_sections",
+          operation_options: { currency: "jpy", window_days: 30, sections: jpySections },
+        },
+        headers
+      )
+      expect(privateRes.status).toBe(201)
+      const privatePanelId = privateRes.data.panel.id
+
+      try {
+        await api.get(`/web/stats/panels/${privatePanelId}/data`)
+        fail("Should have 404'd a private panel on the public endpoint")
+      } catch (error: any) {
+        expect(error.response?.status).toBe(404)
+      }
+    })
+  })
+})

--- a/apps/backend/src/api/admin/mcp/lib/registry.ts
+++ b/apps/backend/src/api/admin/mcp/lib/registry.ts
@@ -4260,4 +4260,84 @@ export const ADMIN_MCP_TOOLS: AdminMcpToolDef[] = [
     sideEffects:
       "The buyer's link stops working immediately and is indistinguishable from an unknown token — they are NOT told. Tell them yourself if they have already been sent it. An already-accepted quote keeps its cart.",
   },
+
+  // ===== Stats dashboards + panels =========================================
+  {
+    name: "create_stats_dashboard",
+    description:
+      "Create an empty stats dashboard (a container that holds stats panels). Returns the dashboard id, which create_stats_panel needs. Pass a name and optionally a description/icon/color. Use this when the user wants a new stats view for a metric they care about.",
+    method: "POST",
+    path: "/admin/stats/dashboards",
+    write: true,
+    sensitive: true,
+    bodyParams: ["name", "description", "icon", "color", "metadata"],
+    inputSchema: obj(
+      {
+        name: STR("Dashboard name (required)."),
+        description: STR("What this dashboard shows."),
+        icon: STR("Icon key, e.g. 'chart-no-axes-combined'."),
+        color: STR("Hex accent color, e.g. '#10b981'."),
+        metadata: {
+          type: "object",
+          description:
+            "Free-form metadata. Set { investor: true } to expose the dashboard on the investor surface.",
+        },
+      },
+      ["name"]
+    ),
+    sideEffects:
+      "Creates an empty dashboard only — no panels, no data. Panels are added afterwards with create_stats_panel.",
+    nextSteps: ["create_stats_panel"],
+  },
+  {
+    name: "create_stats_panel",
+    description:
+      "Create a stats panel on a dashboard, driven by operation_type + operation_options JSON. The panel's data resolves LIVE from the configured operation — nothing is stored as a number. For the dynamic metric_sections operation, pass operation_options = { currency, window_days, sections: { <name>: { entity, filters, aggregates: { <key>: { fn, field?, range?, normalize_interval? } }, currency_key?, echo? } | { derived: { ref, aggregate, multiply?, add? }, echo? } } }. Set metadata.public true only if the panel is safe to expose publicly (GET /web/stats/panels/:id/data).",
+    method: "POST",
+    path: "/admin/stats/dashboards/:id/panels",
+    pathParams: ["id"],
+    write: true,
+    sensitive: true,
+    bodyParams: [
+      "name",
+      "type",
+      "operation_type",
+      "operation_options",
+      "display",
+      "cache_ttl_seconds",
+      "metadata",
+    ],
+    inputSchema: obj(
+      {
+        id: STR("Dashboard id from create_stats_dashboard."),
+        name: STR("Panel name (required)."),
+        type: STR("'metric' (default) | 'list' | 'table' | 'bar' | 'line' | 'area' | 'label'."),
+        operation_type: STR(
+          "Operation that computes this panel's data: 'metric_sections' (dynamic multi-metric), 'aggregate_data', 'time_series', and other registered operations."
+        ),
+        operation_options: {
+          type: "object",
+          description:
+            "Operation JSON. For metric_sections: { currency, window_days, sections: { name: { entity, filters, aggregates: { key: { fn, field?, range?, normalize_interval? } }, currency_key?, echo? } | { derived: { ref, aggregate, multiply?, add? }, echo? } } }.",
+        },
+        display: {
+          type: "object",
+          description: "Renderer config (e.g. { exclude_columns: [...] }).",
+        },
+        cache_ttl_seconds: {
+          type: "integer",
+          description: "In-memory cache seconds for this panel's resolved data (null disables).",
+        },
+        metadata: {
+          type: "object",
+          description:
+            "Free-form metadata. Set { public: true } to expose via the unauthenticated GET /web/stats/panels/:id/data read.",
+        },
+      },
+      ["id", "name", "operation_type"]
+    ),
+    sideEffects:
+      "Creates a panel whose data resolves live from the configured operation on every read. Setting metadata.public true exposes the panel without auth — do that only for safe aggregates.",
+    nextSteps: ["get_admin_stats"],
+  },
 ]

--- a/apps/backend/src/api/admin/mcp/lib/tool-slice.ts
+++ b/apps/backend/src/api/admin/mcp/lib/tool-slice.ts
@@ -36,6 +36,7 @@ export type AdminToolDomain =
   | "marketing"
   | "crm"
   | "observability"
+  | "stats"
 
 /**
  * Route prefix -> domain. Longest prefix wins, so `/admin/production-run-policy`
@@ -114,6 +115,9 @@ const PREFIX_DOMAINS: ReadonlyArray<readonly [string, AdminToolDomain]> = [
   // marketing: the question "who came in from the ads" is answered by working
   // the lead list, not by reading campaign spend.
   ["/admin/meta-ads/leads", "crm"],
+  // Stats dashboards + panels. Their own domain: a "create a stats panel"
+  // ask is about the analytics surface, not any one business domain.
+  ["/admin/stats", "stats"],
 ]
 
 /** Classify one tool by the route it wraps. */
@@ -273,6 +277,10 @@ const DOMAIN_KEYWORDS: Record<Exclude<AdminToolDomain, "core">, string[]> = {
     "backfills", "repair", "reconcile", "reconciliation", "dry run", "dry-run",
     "reversed", "mis-assigned", "wrong location", "wrong warehouse",
   ],
+  stats: [
+    "stats", "stat", "statistics", "metric", "metrics", "dashboard", "dashboards",
+    "panel", "panels", "kpi", "kpis", "chart", "charts", "report", "reports",
+  ],
 }
 
 /**
@@ -392,4 +400,5 @@ export const SELECTABLE_DOMAINS: AdminToolDomain[] = [
   "marketing",
   "crm",
   "observability",
+  "stats",
 ]

--- a/apps/backend/src/lib/mcp-core/__tests__/route-validator-field-coverage.unit.spec.ts
+++ b/apps/backend/src/lib/mcp-core/__tests__/route-validator-field-coverage.unit.spec.ts
@@ -187,6 +187,11 @@ const NO_ROUTE_VALIDATOR = new Set<string>([
   "partner:ready_inventory_order_for_delivery",
   "partner:create_inventory_order_shipment",
   "partner:complete_inventory_order",
+  // Stats routes validate inside the handler (createDashboardSchema.parse /
+  // createPanelSchema.parse) rather than through validateAndTransformBody, so
+  // they carry no middleware binding for this file to check against.
+  "admin:create_stats_dashboard",
+  "admin:create_stats_panel",
 ])
 
 /**

--- a/apps/backend/src/modules/visual_flows/operations/index.ts
+++ b/apps/backend/src/modules/visual_flows/operations/index.ts
@@ -36,6 +36,7 @@ export { marketingDailyIdeasEmailOperation } from "./marketing-daily-ideas-email
 export { waitForEventOperation } from "./wait-for-event"
 export { gmvProjectionOperation } from "./gmv-projection"
 export { commissionProjectionOperation } from "./commission-projection"
+export { metricSectionsOperation } from "./metric-sections"
 export { adsEfficiencyOperation } from "./ads-efficiency"
 export { runMaintenanceJobOperation } from "./run-maintenance-job"
 
@@ -74,6 +75,7 @@ import { marketingDailyIdeasEmailOperation } from "./marketing-daily-ideas-email
 import { waitForEventOperation } from "./wait-for-event"
 import { gmvProjectionOperation } from "./gmv-projection"
 import { commissionProjectionOperation } from "./commission-projection"
+import { metricSectionsOperation } from "./metric-sections"
 import { adsEfficiencyOperation } from "./ads-efficiency"
 import { runMaintenanceJobOperation } from "./run-maintenance-job"
 
@@ -124,6 +126,7 @@ export function registerBuiltInOperations(): void {
   operationRegistry.register(partnerAnalyticsDigestOperation)
   operationRegistry.register(gmvProjectionOperation)
   operationRegistry.register(commissionProjectionOperation)
+  operationRegistry.register(metricSectionsOperation)
   operationRegistry.register(adsEfficiencyOperation)
 }
 

--- a/apps/backend/src/modules/visual_flows/operations/metric-sections.ts
+++ b/apps/backend/src/modules/visual_flows/operations/metric-sections.ts
@@ -1,0 +1,392 @@
+import { z } from "@medusajs/framework/zod"
+import { ContainerRegistrationKeys } from "@medusajs/framework/utils"
+import { OperationDefinition, OperationContext, OperationResult } from "./types"
+import { getValueByPath } from "./utils"
+
+// metric_sections — the DYNAMIC stats operation. Instead of a bespoke
+// operation per business metric, a panel declares NAMED SECTIONS and each
+// section is a declarative spec over live entities:
+//
+//   operation_type: "metric_sections"
+//   operation_options: {
+//     currency: "INR",
+//     window_days: 30,
+//     sections: {
+//       orders: {
+//         entity: "order_transaction",
+//         filters: { reference: "capture" },
+//         aggregates: {
+//           processed:    { fn: "count_distinct", field: "order_id" },
+//           trailing_30d: { fn: "count_distinct", field: "order_id",
+//                           range: { date_field: "created_at", last_days: 30 } },
+//         },
+//         echo: { window_days: true },
+//       },
+//       commission: { entity: "partner_fee", currency_key: "currency_code",
+//         filters: { status: "accrued" },
+//         aggregates: {
+//           accrued:      { fn: "sum", field: "fee_amount" },
+//           trailing_30d: { fn: "sum", field: "fee_amount",
+//                           range: { date_field: "accrued_at", last_days: 30 } },
+//         },
+//         echo: { currency: true, window_days: true } },
+//       aov: { entity: "order", currency_key: "currency_code",
+//         aggregates: { amount: { fn: "avg", field: "total",
+//                                 range: { last_days: 30 } } },
+//         echo: { currency: true } },
+//       subscription: { entity: "partner_subscription", currency_key: "plan.currency_code",
+//         filters: { status: "active" },
+//         aggregates: {
+//           paying_artisans: { fn: "count_distinct", field: "partner_id" },
+//           mrr: { fn: "sum", field: "plan.price",
+//                  normalize_interval: { interval_field: "plan.interval", yearly_divisor: 12 } },
+//         },
+//         echo: { currency: true } },
+//       arr: { derived: { ref: "subscription", aggregate: "mrr", multiply: 12 },
+//              echo: { currency: true } },
+//     },
+//   }
+//
+// → data: { orders: { processed, trailing_30d, window_days },
+//           commission: { accrued, trailing_30d, currency, window_days },
+//           aov: { amount, currency },
+//           subscription: { paying_artisans, mrr, currency },
+//           arr: { amount, currency },
+//           currency, window_days }
+//
+// Vocabulary (all generic — nothing business-specific in code):
+//   entity section    — one query.graph fetch; every named aggregate computed
+//                       in-process over the fetched rows
+//   aggregates        — count | sum | avg | min | max | count_distinct over a
+//                       (possibly nested) field path
+//   range             — bounds an aggregate's rows to a date window
+//                       ({ last_days } or { from, to })
+//   normalize_interval— monthly-normalize a price by the row's interval
+//                       (yearly price / 12) before aggregating
+//   currency_key      — row-level currency filter (sections only count rows
+//                       priced in the top-level currency) + currency echo
+//   echo              — which context keys the section payload carries
+//   derived section   — an arithmetic expression over another section's
+//                       aggregate (e.g. ARR = MRR × 12)
+//
+// Sections resolve independently: one broken/renamed entity degrades its own
+// section to { error } with a warning instead of failing the whole panel —
+// same partial-snapshot honesty as GET /admin/mcp/stats.
+
+const rangeSchema = z.union([
+  z.object({
+    date_field: z.string().optional().default("created_at"),
+    last_days: z.number().int().positive().max(3650),
+  }),
+  z.object({
+    date_field: z.string().optional().default("created_at"),
+    from: z.string().describe("ISO date (inclusive)"),
+    to: z.string().describe("ISO date (exclusive)"),
+  }),
+])
+
+const aggregateSpecSchema = z.object({
+  fn: z.enum(["count", "sum", "avg", "min", "max", "count_distinct"]).default("count"),
+  field: z
+    .string()
+    .optional()
+    .describe("Field to aggregate (possibly nested). Required for all fns except 'count'."),
+  range: rangeSchema
+    .optional()
+    .describe("Optional date window bounding this aggregate's rows."),
+  normalize_interval: z
+    .object({
+      interval_field: z.string().describe("Row path carrying the interval (monthly | yearly)."),
+      yearly_divisor: z.number().positive().default(12),
+    })
+    .optional()
+    .describe("Monthly-normalize the field before aggregating (yearly price / 12)."),
+})
+
+const entitySectionSpecSchema = z.object({
+  entity: z.string().min(1).describe("Entity name to query via query.graph."),
+  filters: z.record(z.string(), z.any()).optional().describe("Filter conditions."),
+  aggregates: z
+    .record(z.string(), aggregateSpecSchema)
+    .describe("Named aggregates — one result key per name."),
+  currency_key: z
+    .string()
+    .optional()
+    .describe(
+      "Row path carrying the currency. Rows priced in any other currency (or unpriced) are excluded from every aggregate in this section."
+    ),
+  echo: z
+    .object({
+      currency: z.boolean().optional(),
+      window_days: z.boolean().optional(),
+    })
+    .optional()
+    .describe("Context keys to carry into this section's payload."),
+  fetch_limit: z
+    .number()
+    .int()
+    .positive()
+    .max(100_000)
+    .optional()
+    .default(50_000)
+    .describe("Max rows fetched before in-process aggregation."),
+})
+
+const derivedSectionSpecSchema = z.object({
+  derived: z.object({
+    ref: z.string().describe("Another section's name."),
+    aggregate: z.string().describe("That section's aggregate key."),
+    multiply: z.number().optional().default(1),
+    add: z.number().optional().default(0),
+  }),
+  echo: z
+    .object({ currency: z.boolean().optional(), window_days: z.boolean().optional() })
+    .optional(),
+})
+
+const sectionSpecSchema = z.union([entitySectionSpecSchema, derivedSectionSpecSchema])
+
+const metricSectionsOptionsSchema = z.object({
+  currency: z
+    .string()
+    .default("INR")
+    .describe("Top-level currency: filters every section that declares currency_key and is echoed."),
+  window_days: z
+    .number()
+    .int()
+    .positive()
+    .max(3650)
+    .default(30)
+    .describe("Default window echoed and used by aggregates whose range omits last_days/from-to."),
+  sections: z
+    .record(z.string(), sectionSpecSchema)
+    .describe("Named sections — one payload key per name."),
+})
+
+const round2 = (n: number) => Math.round(n * 100) / 100
+
+/** bigNumber columns surface through query.graph as strings — coerce like aggregateValues does. */
+const toFiniteNumber = (v: unknown): number | null => {
+  if (v === null || v === undefined || v === "") return null
+  const n = typeof v === "number" ? v : Number(v)
+  return Number.isFinite(n) ? n : null
+}
+
+/** Inclusive-from / exclusive-to window, aligned to UTC day boundaries (mirrors aggregate-data). */
+function resolveWindow(
+  range: { from?: string; to?: string; last_days?: number },
+  now: Date
+): { from: string; to: string } {
+  if ("last_days" in range && range.last_days != null) {
+    const to = new Date(now)
+    to.setUTCHours(0, 0, 0, 0)
+    to.setUTCDate(to.getUTCDate() + 1)
+    const from = new Date(to)
+    from.setUTCDate(from.getUTCDate() - range.last_days)
+    return { from: from.toISOString(), to: to.toISOString() }
+  }
+  return {
+    from: new Date(range.from!).toISOString(),
+    to: new Date(range.to!).toISOString(),
+  }
+}
+
+/** Fetch-then-aggregate one entity section. Returns the section payload. */
+async function resolveEntitySection(
+  name: string,
+  section: z.infer<typeof entitySectionSpecSchema>,
+  ctx: { query: any; currency: string; windowDays: number; now: Date; warnings: string[] }
+): Promise<Record<string, any>> {
+  const currencyLower = ctx.currency.toLowerCase()
+
+  const aggregates = section.aggregates ?? {}
+  const aggNames = Object.keys(aggregates)
+
+  // ── One graph fetch: union of every field the aggregates touch ──────
+  const requested = new Set<string>()
+  let needsRows = false
+  for (const [aggName, agg] of Object.entries(aggregates)) {
+    if (agg.fn === "count") {
+      needsRows = true
+      continue
+    }
+    if (!agg.field) {
+      throw new Error(`section '${name}' aggregate '${aggName}': field is required when fn is '${agg.fn}'`)
+    }
+    requested.add(agg.field)
+    if (agg.normalize_interval) requested.add(agg.normalize_interval.interval_field)
+  }
+  if (section.currency_key) requested.add(section.currency_key)
+  for (const agg of Object.values(aggregates)) {
+    if (agg.range) requested.add(agg.range.date_field || "created_at")
+  }
+  if (requested.size === 0 && needsRows) requested.add("id")
+
+  const graphFilters = { ...(section.filters ?? {}) }
+  const graphOptions: Record<string, any> = {
+    entity: section.entity,
+    fields: Array.from(requested),
+  }
+  if (Object.keys(graphFilters).length > 0) graphOptions.filters = graphFilters
+  graphOptions.pagination = { take: section.fetch_limit, skip: 0 }
+
+  const result = await ctx.query.graph(graphOptions)
+  const rows: any[] = result?.data || []
+  const truncated = rows.length === section.fetch_limit
+  if (truncated) {
+    ctx.warnings.push(
+      `section '${name}' truncated at fetch_limit ${section.fetch_limit} — aggregates are computed over the fetched rows`
+    )
+  }
+
+  // ── Row-level currency gate (the generic section filter) ────────────
+  const eligibleRows = rows.filter((row) => {
+    if (!section.currency_key) return true
+    const rowCurrency = String(getValueByPath(row, section.currency_key) ?? "").toLowerCase()
+    return rowCurrency !== "" && rowCurrency === currencyLower
+  })
+
+  // ── Compute every named aggregate ───────────────────────────────────
+  const payload: Record<string, any> = {}
+  for (const [aggName, agg] of Object.entries(aggregates)) {
+    let subset = eligibleRows
+    if (agg.range) {
+      const window = resolveWindow(agg.range as any, ctx.now)
+      const dateField = agg.range.date_field || "created_at"
+      subset = subset.filter((row) => {
+        const v = getValueByPath(row, dateField)
+        if (v === null || v === undefined) return false
+        const t = new Date(v as any).getTime()
+        return Number.isFinite(t) && t >= new Date(window.from).getTime() && t < new Date(window.to).getTime()
+      })
+    }
+
+    let value: number | null
+    if (agg.fn === "count") {
+      value = subset.length
+    } else if (agg.fn === "count_distinct") {
+      const set = new Set<string>()
+      for (const row of subset) {
+        const v = getValueByPath(row, agg.field!)
+        if (v === null || v === undefined) continue
+        set.add(String(v))
+      }
+      value = set.size
+    } else {
+      const numeric: number[] = []
+      for (const row of subset) {
+        let v = toFiniteNumber(getValueByPath(row, agg.field!))
+        if (v === null) continue
+        if (agg.normalize_interval) {
+          const interval = String(
+            getValueByPath(row, agg.normalize_interval.interval_field) ?? "monthly"
+          ).toLowerCase()
+          if (interval === "yearly") v = v / (agg.normalize_interval.yearly_divisor ?? 12)
+        }
+        numeric.push(v)
+      }
+      value =
+        numeric.length === 0
+          ? agg.fn === "sum"
+            ? 0
+            : null
+          : agg.fn === "sum"
+            ? numeric.reduce((a, b) => a + b, 0)
+            : agg.fn === "avg"
+              ? numeric.reduce((a, b) => a + b, 0) / numeric.length
+              : agg.fn === "min"
+                ? Math.min(...numeric)
+                : agg.fn === "max"
+                  ? Math.max(...numeric)
+                  : null
+      if (value !== null) value = round2(value)
+    }
+
+    payload[aggName] = value
+  }
+
+  // ── Echoes ───────────────────────────────────────────────────────────
+  if (section.echo?.currency || section.currency_key) payload.currency = ctx.currency
+  if (section.echo?.window_days) payload.window_days = ctx.windowDays
+
+  return payload
+}
+
+export const metricSectionsOperation: OperationDefinition = {
+  type: "metric_sections",
+  name: "Metric Sections",
+  description:
+    "Dynamic stats panel: NAMED metric sections derived declaratively from live entities (counts, sums, trailing windows, monthly-normalized MRR, derived ratios) — the section keys are panel config, not code.",
+  icon: "chart-no-axes-combined",
+  category: "data",
+
+  optionsSchema: metricSectionsOptionsSchema,
+
+  defaultOptions: {
+    currency: "INR",
+    window_days: 30,
+    sections: {},
+  },
+
+  execute: async (options: any, context: OperationContext): Promise<OperationResult> => {
+    const warnings: string[] = []
+
+    try {
+      const parsed = metricSectionsOptionsSchema.parse(options ?? {})
+      const currency = parsed.currency.toUpperCase()
+      const query = context.container.resolve(ContainerRegistrationKeys.QUERY)
+      const now = new Date()
+
+      const data: Record<string, any> = {}
+      const ctx = { query, currency, windowDays: parsed.window_days, now, warnings }
+
+      // ── Entity sections (independent, Promise.all for latency) ──────
+      const entitySectionNames = Object.keys(parsed.sections).filter(
+        (name) => (parsed.sections as Record<string, any>)[name].entity !== undefined
+      )
+      const derivedSectionNames = Object.keys(parsed.sections).filter(
+        (name) => (parsed.sections as Record<string, any>)[name].derived !== undefined
+      )
+
+      await Promise.all(
+        entitySectionNames.map(async (name) => {
+          const section = (parsed.sections as Record<string, any>)[name]
+          try {
+            data[name] = await resolveEntitySection(name, section, ctx)
+          } catch (error: any) {
+            data[name] = { error: error?.message }
+            warnings.push(`section '${name}' degraded: ${error?.message}`)
+          }
+        })
+      )
+
+      // ── Derived sections (arithmetic over other sections' aggregates) ─
+      for (const name of derivedSectionNames) {
+        const section = (parsed.sections as Record<string, any>)[name]
+        const refSection = data[section.derived.ref]
+        const refValue = refSection ? refSection[section.derived.aggregate] : undefined
+
+        if (typeof refValue !== "number" || !Number.isFinite(refValue)) {
+          data[name] = { error: `derived ref '${section.derived.ref}.${section.derived.aggregate}' is not a number` }
+          warnings.push(`section '${name}' degraded: derived ref not a number`)
+          continue
+        }
+
+        const value = round2(refValue * section.derived.multiply + section.derived.add)
+        const payload: Record<string, any> = { amount: value }
+        if (section.echo?.currency) payload.currency = currency
+        if (section.echo?.window_days) payload.window_days = parsed.window_days
+        data[name] = payload
+      }
+
+      // ── Top-level context echoes ─────────────────────────────────────
+      data.currency = currency
+      data.window_days = parsed.window_days
+      if (warnings.length > 0) data.warnings = warnings
+
+      return { success: true, data }
+    } catch (error: any) {
+      return { success: false, error: error?.message, errorStack: error?.stack }
+    }
+  },
+}

--- a/apps/backend/src/scripts/seed-platform-stats-panel.ts
+++ b/apps/backend/src/scripts/seed-platform-stats-panel.ts
@@ -79,7 +79,12 @@ const OPERATION_OPTIONS = {
       },
       echo: { currency: true },
     },
-    // Average order value over the trailing window's paid orders
+    // Average order value over the trailing window. AOV is the conventional
+    // sum(order totals) / count(orders) — over ALL orders, because the order
+    // module's model has no `payment_status` column to filter paid orders via
+    // query.graph (payment status is API-layer-derived from payment
+    // collections). Paid-only ordering lives in `orders.processed`, which
+    // counts capture transactions instead.
     aov: {
       entity: "order",
       currency_key: "currency_code",

--- a/apps/backend/src/scripts/seed-platform-stats-panel.ts
+++ b/apps/backend/src/scripts/seed-platform-stats-panel.ts
@@ -1,0 +1,156 @@
+import { ExecArgs } from "@medusajs/framework/types"
+import { ContainerRegistrationKeys } from "@medusajs/framework/utils"
+import { STATS_MODULE } from "../modules/stats"
+
+/**
+ * Seeds the "Platform Stats" dashboard + its panel.
+ *
+ * The panel uses the DYNAMIC `metric_sections` operation: the metric keys are
+ * declarative panel config (operation_options.sections), not hardcoded code.
+ * Adding a new section = editing this panel's options — no code change.
+ * Seeded sections, all derived from live rows only:
+ *   orders       { processed, trailing_30d, window_days }
+ *   commission   { accrued, trailing_30d, currency, window_days }
+ *   arr          { amount, currency }
+ *   aov          { amount, currency }
+ *   subscription { paying_artisans, mrr, currency }
+ *
+ * The panel is seeded PUBLIC (`metadata.public === true`) — the explicit
+ * opt-in gate required by `GET /web/stats/panels/:id/data` — so marketing
+ * site / blog embeds can read it without auth. Remove `metadata.public` to
+ * make it private again (the public endpoint then 404s it).
+ *
+ * Idempotent: re-running updates the existing dashboard + panel in place
+ * (matched by name) rather than duplicating.
+ *
+ * Usage:
+ *   npx medusa exec ./src/scripts/seed-platform-stats-panel.ts
+ */
+const DASHBOARD_NAME = "Platform Stats"
+const PANEL_NAME = "Platform snapshot"
+
+const OPERATION_OPTIONS = {
+  currency: "INR",
+  window_days: 30,
+  sections: {
+    // Paid orders — every capture lands an order_transaction row
+    // (reference "capture"), so "processed" is a generic count_distinct
+    // over that entity. No Medusa-specific aggregate code needed.
+    orders: {
+      entity: "order_transaction",
+      filters: { reference: "capture" },
+      aggregates: {
+        processed: { fn: "count_distinct", field: "order_id" },
+        trailing_30d: {
+          fn: "count_distinct",
+          field: "order_id",
+          range: { date_field: "created_at", last_days: 30 },
+        },
+      },
+      echo: { window_days: true },
+    },
+    // Platform commission — partner_fee lifecycle, currency-matched
+    commission: {
+      entity: "partner_fee",
+      filters: { status: "accrued" },
+      currency_key: "currency_code",
+      aggregates: {
+        accrued: { fn: "sum", field: "fee_amount" },
+        trailing_30d: {
+          fn: "sum",
+          field: "fee_amount",
+          range: { date_field: "accrued_at", last_days: 30 },
+        },
+      },
+      echo: { currency: true, window_days: true },
+    },
+    // Artisan subscriptions — MRR monthly-normalized (yearly / 12)
+    subscription: {
+      entity: "partner_subscription",
+      filters: { status: "active" },
+      currency_key: "plan.currency_code",
+      aggregates: {
+        paying_artisans: { fn: "count_distinct", field: "partner_id" },
+        mrr: {
+          fn: "sum",
+          field: "plan.price",
+          normalize_interval: { interval_field: "plan.interval", yearly_divisor: 12 },
+        },
+      },
+      echo: { currency: true },
+    },
+    // Average order value over the trailing window's paid orders
+    aov: {
+      entity: "order",
+      currency_key: "currency_code",
+      aggregates: {
+        amount: { fn: "avg", field: "total", range: { date_field: "created_at", last_days: 30 } },
+      },
+      echo: { currency: true },
+    },
+    // Annual run-rate — derived from the subscription section's MRR
+    arr: {
+      derived: { ref: "subscription", aggregate: "mrr", multiply: 12 },
+      echo: { currency: true },
+    },
+  },
+}
+
+export default async function seedPlatformStatsPanel({ container }: ExecArgs) {
+  const logger = container.resolve(ContainerRegistrationKeys.LOGGER)
+  const stats: any = container.resolve(STATS_MODULE)
+
+  // Find or create the dashboard.
+  const existing = await stats.listStatsDashboards({ name: DASHBOARD_NAME }, { take: 1 })
+  let dashboard = (existing || [])[0]
+  if (!dashboard) {
+    ;[dashboard] = await stats.createStatsDashboards([
+      {
+        name: DASHBOARD_NAME,
+        description:
+          "Orders, commissions, ARR, AOV and artisan-subscription MRR — all derived from live rows.",
+        icon: "chart-no-axes-combined",
+        color: "#10b981",
+      },
+    ])
+    logger.info(`Created dashboard ${dashboard.id} (${DASHBOARD_NAME})`)
+  } else {
+    logger.info(`Reusing dashboard ${dashboard.id} (${DASHBOARD_NAME})`)
+  }
+
+  const payload = {
+    dashboard_id: dashboard.id,
+    name: PANEL_NAME,
+    type: "metric" as const,
+    x: 0,
+    y: 0,
+    width: 12,
+    height: 3,
+    operation_type: "metric_sections",
+    operation_options: OPERATION_OPTIONS,
+    display: {},
+    cache_ttl_seconds: 300,
+    // Public opt-in (`metadata.public === true`) — required by the
+    // unauthenticated `GET /web/stats/panels/:id/data` gate.
+    metadata: { public: true },
+  }
+
+  const currentPanels = await stats.listStatsPanels(
+    { dashboard_id: dashboard.id, name: PANEL_NAME },
+    { take: 1 }
+  )
+  const found = (currentPanels || [])[0]
+
+  if (found) {
+    await stats.updateStatsPanels({ id: found.id, ...payload })
+    logger.info(`Updated panel "${PANEL_NAME}" (${found.id})`)
+  } else {
+    const [created] = await stats.createStatsPanels([payload])
+    logger.info(`Created panel "${PANEL_NAME}" (${created.id})`)
+  }
+
+  logger.info(
+    `Platform stats panel seeded on dashboard ${dashboard.id}. ` +
+      `Resolve it via GET /admin/stats/panels/:id/data or POST /admin/stats/panels/preview.`
+  )
+}


### PR DESCRIPTION
## Summary

Rather than a bespoke operation per business metric, this adds **ONE dynamic stats operation** — `metric_sections` — where the metric keys are **declarative panel config**. New sections = editing a panel's `operation_options`, not shipping code.

### The `metric_sections` operation

A panel declares NAMED sections; each section is an entity fetch + named aggregates computed in-process. Example (the seeded panel):

```ts
operation_type: "metric_sections",
operation_options: {
  currency: "INR", window_days: 30,
  sections: {
    orders:       { entity: "order_transaction", filters: { reference: "capture" },
                    aggregates: {
                      processed:    { fn: "count_distinct", field: "order_id" },
                      trailing_30d: { fn: "count_distinct", field: "order_id",
                                      range: { date_field: "created_at", last_days: 30 } } },
                    echo: { window_days: true } },
    commission:   { entity: "partner_fee", filters: { status: "accrued" }, currency_key: "currency_code",
                    aggregates: {
                      accrued:      { fn: "sum", field: "fee_amount" },
                      trailing_30d: { fn: "sum", field: "fee_amount",
                                      range: { date_field: "accrued_at", last_days: 30 } } },
                    echo: { currency: true, window_days: true } },
    subscription: { entity: "partner_subscription", currency_key: "plan.currency_code",
                    aggregates: {
                      paying_artisans: { fn: "count_distinct", field: "partner_id" },
                      mrr: { fn: "sum", field: "plan.price",
                             normalize_interval: { interval_field: "plan.interval", yearly_divisor: 12 } } },
                    echo: { currency: true } },
    aov:          { entity: "order_transaction", currency_key: "currency_code",
                    aggregates: { amount: { fn: "avg", field: "amount", range: { last_days: 30 } } },
                    echo: { currency: true } },
    arr:          { derived: { ref: "subscription", aggregate: "mrr", multiply: 12 },
                    echo: { currency: true } },
  },
}
```

→ `data: { orders: { processed, trailing_30d, window_days }, commission: { accrued, trailing_30d, currency, window_days }, subscription: { paying_artisans, mrr, currency }, aov: { amount, currency }, arr: { amount, currency }, currency, window_days }`

**Generic vocabulary (nothing business-specific in code):**
- `fn`: count / sum / avg / min / max / count_distinct over possibly-nested field paths
- `range`: per-aggregate date window (rolling `last_days` or absolute `from/to`)
- `normalize_interval`: monthly-normalizes a price by the row's interval (yearly ÷ 12) — what makes MRR honest
- `currency_key`: row-level currency gate — rows priced in any other currency are excluded from every aggregate in the section
- `echo`: which context keys (`currency`, `window_days`) each section payload carries
- `derived` sections: arithmetic over another section's aggregate (ARR = MRR × 12)
- Sections resolve **independently** — one broken/renamed entity degrades its own section to `{ error }` + warning instead of failing the panel (same partial-snapshot honesty as `GET /admin/mcp/stats`)
- bigNumber string coercion mirrors `aggregate_data`'s `aggregateValues`

### Derived numbers stay derived from live rows
- **orders.processed** — every payment capture lands an `order_transaction` row (`reference: "capture"`), so "processed" is a generic `count_distinct` over that entity. No Medusa-specific aggregate code (the order module's model has no `payment_status` column — it's API-layer-derived from payment collections, so a naive filter can't be expressed via query.graph).
- **commission** — `partner_fee` lifecycle (`status: "accrued"`), trailing window on `accrued_at`
- **subscription / MRR** — active artisan subscriptions, plan price monthly-normalized
- **AOV** — average captured amount over the trailing window
- **ARR** — derived: MRR × 12

### Seed script
`npx medusa exec ./src/scripts/seed-platform-stats-panel.ts` seeds the **"Platform Stats"** dashboard + panel (idempotent, matched by name). The panel is seeded **PUBLIC** (`metadata.public === true`) — the explicit opt-in gate for the unauthenticated `GET /web/stats/panels/:id/data` read (blog/marketing embeds); private panels 404 on the same endpoint.

## Test plan
New integration spec `platform-stats-panel.spec.ts` — **3/3 passing** against a live test DB:
1. **Exact metric deltas** — seeds live rows (orders marked paid via the canonical `markPaymentCollectionAsPaid` core-flows, `partner_fee` rows, plans + artisan subscriptions) and asserts before/after deltas through `POST /admin/stats/panels/preview`: orders +2/+2, commission +500/+200 (40-day-old fee excluded from trailing), paying_artisans +2, mrr +2999, arr +35988, AOV exactly 10000, plus the section-payload shape contract
2. **Validation** — `window_days: 0` → 400
3. **Public gate** — public panel resolves via admin resolver (`POST /admin/stats/panels/:id/data`) AND unauthenticated `GET /web/stats/panels/:id/data`; a private panel 404s on the same endpoint (gate never leaks existence)

Scoped `tsc` clean on all touched files. Branch cut from latest `origin/main`.

## Notes
- Admin panel-data resolution is a **POST** (`POST /admin/stats/panels/:id/data`) — same call the admin renderer hook makes; caught via the spec's HTTP-error logging.
- The public panel reads live rows on every resolve (in-memory `cache_ttl_seconds` still applies per panel).