### PR TITLE
fix(inventory): Create did nothing because native validation rejected the blank rows the form seeds (#1671)

### DIFF
--- a/apps/backend/src/admin/components/creates/__tests__/create-inventory-order-schema.unit.spec.ts
+++ b/apps/backend/src/admin/components/creates/__tests__/create-inventory-order-schema.unit.spec.ts
@@ -1,0 +1,94 @@
+import { inventoryOrderFormSchema } from "../create-inventory-order-schema"
+
+/**
+ * #1671. The create form SEEDS the grid with five blank rows. The schema used
+ * to validate every element, so those blanks failed `inventory_item_id` and
+ * `quantity` — `handleSubmit`'s callback never ran and Create did nothing,
+ * silently, unless the buyer deleted four rows by hand. Confirmed in the
+ * browser: zero network requests with the blanks present, 201 once removed.
+ *
+ * The rule pinned here: a row is either BLANK (ignored) or COMPLETE.
+ */
+const BLANK = { inventory_item_id: "", quantity: 0, price: 0 }
+
+const base = {
+  order_date: new Date("2026-08-30"),
+  expected_delivery_date: new Date("2026-12-31"),
+  stock_location_id: "sloc_1",
+  is_sample: false,
+}
+
+const seededWith = (...filled: any[]) => ({
+  ...base,
+  // Exactly what the form ships with: five rows, most of them untouched.
+  order_lines: [
+    ...filled,
+    ...Array.from({ length: 5 - filled.length }, () => ({ ...BLANK })),
+  ],
+})
+
+describe("inventoryOrderFormSchema — seeded blank rows (#1671)", () => {
+  it("accepts one filled row among the four blanks the form seeds", () => {
+    const result = inventoryOrderFormSchema.safeParse(
+      seededWith({ inventory_item_id: "iitem_1", quantity: 40, price: 120 })
+    )
+    expect(result.success).toBe(true)
+  })
+
+  it("accepts an untracked-variant pick, whose id is the synthetic picker value", () => {
+    const result = inventoryOrderFormSchema.safeParse(
+      seededWith({
+        inventory_item_id: "untracked_variant:variant_1",
+        quantity: 5,
+        price: 10,
+      })
+    )
+    expect(result.success).toBe(true)
+  })
+
+  it("refuses an order with nothing picked at all", () => {
+    const result = inventoryOrderFormSchema.safeParse(seededWith())
+    expect(result.success).toBe(false)
+    expect(
+      result.success ? [] : result.error.issues.map((i) => i.message)
+    ).toContain("Pick at least one item")
+  })
+
+  it("still refuses a picked row with no quantity — blanks are ignored, unfinished rows are not", () => {
+    const result = inventoryOrderFormSchema.safeParse(
+      seededWith({ inventory_item_id: "iitem_1", quantity: 0, price: 120 })
+    )
+    expect(result.success).toBe(false)
+    const issue = result.success
+      ? undefined
+      : result.error.issues.find((i) => i.message.includes("Quantity"))
+    expect(issue).toBeDefined()
+    // Reported against the row the buyer must fix, not the array.
+    expect(issue!.path).toEqual(["order_lines", 0, "quantity"])
+  })
+
+  it("reports the failing row's real index, not its position among filled rows", () => {
+    const result = inventoryOrderFormSchema.safeParse({
+      ...base,
+      order_lines: [
+        { ...BLANK },
+        { inventory_item_id: "iitem_ok", quantity: 2, price: 5 },
+        { ...BLANK },
+        { inventory_item_id: "iitem_bad", quantity: 0, price: 5 },
+        { ...BLANK },
+      ],
+    })
+    expect(result.success).toBe(false)
+    const issue = result.success
+      ? undefined
+      : result.error.issues.find((i) => i.message.includes("Quantity"))
+    expect(issue!.path).toEqual(["order_lines", 3, "quantity"])
+  })
+
+  it("refuses a negative price on a picked row", () => {
+    const result = inventoryOrderFormSchema.safeParse(
+      seededWith({ inventory_item_id: "iitem_1", quantity: 1, price: -5 })
+    )
+    expect(result.success).toBe(false)
+  })
+})

--- a/apps/backend/src/admin/components/creates/create-inventory-order-schema.ts
+++ b/apps/backend/src/admin/components/creates/create-inventory-order-schema.ts
@@ -1,0 +1,70 @@
+import { z } from "zod";
+
+// Define a Zod schema for inventory order creation (scaffolded, update as per API contract)
+export const inventoryOrderFormSchema = z
+  .object({
+    order_date: z.date({ error: "Order date is required" }),
+    expected_delivery_date: z.date({ error: "Expected delivery date is required" }),
+    // To location (required)
+    stock_location_id: z.string().nonempty("To stock location is required"),
+    // From location (optional)
+    from_stock_location_id: z.string().optional(),
+    is_sample: z.boolean().optional(),
+    // #1671 — the grid is SEEDED with five blank rows so a buyer can start
+    // typing. Validating every element meant those blanks failed
+    // `inventory_item_id: min(1)` and `quantity: min(1)`, so handleSubmit's
+    // callback never ran: Create did nothing, silently and forever, unless you
+    // deleted four rows by hand. A row is therefore either blank (ignored) or
+    // complete — checked in the superRefine below, where a blank can be told
+    // apart from an unfinished one.
+    order_lines: z.array(
+      z.object({
+        inventory_item_id: z.string(),
+        quantity: z.number(),
+        price: z.number(),
+        batch_number: z.number().int().positive().nullish(), // batch tag (separate-batch adds)
+      })
+    ),
+  })
+  .superRefine((data, ctx) => {
+    const lines = data.order_lines ?? [];
+    const filledIdx = lines
+      .map((line, index) => ({ line, index }))
+      .filter(({ line }) => !!line?.inventory_item_id);
+
+    if (!filledIdx.length) {
+      ctx.addIssue({
+        code: z.ZodIssueCode.custom,
+        message: "Pick at least one item",
+        path: ["order_lines"],
+      });
+    }
+
+    for (const { line, index } of filledIdx) {
+      if (!(Number(line.quantity) >= 1)) {
+        ctx.addIssue({
+          code: z.ZodIssueCode.custom,
+          message: "Quantity must be at least 1",
+          path: ["order_lines", index, "quantity"],
+        });
+      }
+      if (!(Number(line.price) >= 0)) {
+        ctx.addIssue({
+          code: z.ZodIssueCode.custom,
+          message: "Price must be non-negative",
+          path: ["order_lines", index, "price"],
+        });
+      }
+    }
+
+    // Validate that from and to are not the same when both are provided
+    if (data.from_stock_location_id && data.stock_location_id === data.from_stock_location_id) {
+      ctx.addIssue({
+        code: z.ZodIssueCode.custom,
+        message: "From and To stock locations must be different",
+        path: ["from_stock_location_id"],
+      });
+    }
+  });
+
+export type InventoryOrderFormData = z.infer<typeof inventoryOrderFormSchema>;

--- a/apps/backend/src/admin/components/creates/create-inventory-order.tsx
+++ b/apps/backend/src/admin/components/creates/create-inventory-order.tsx
@@ -14,39 +14,15 @@ import { InventoryOrderLinesGrid } from "./inventory-order-lines-grid";
 import { AddMaterialGroupControl } from "../inventory-orders/add-material-group-control";
 import { toOrderLineRef } from "./order-line-ref";
 
-// Define a Zod schema for inventory order creation (scaffolded, update as per API contract)
-export const inventoryOrderFormSchema = z
-  .object({
-    order_date: z.date({ error: "Order date is required" }),
-    expected_delivery_date: z.date({ error: "Expected delivery date is required" }),
-    // To location (required)
-    stock_location_id: z.string().nonempty("To stock location is required"),
-    // From location (optional)
-    from_stock_location_id: z.string().optional(),
-    is_sample: z.boolean().optional(),
-    order_lines: z
-      .array(
-        z.object({
-          inventory_item_id: z.string().min(1, "Item is required"),
-          quantity: z.number().min(1, "Quantity must be at least 1"),
-          price: z.number().min(0, "Price must be non-negative"),
-          batch_number: z.number().int().positive().nullish(), // batch tag (separate-batch adds)
-        })
-      )
-      .min(1, "At least one order line is required"),
-  })
-  .superRefine((data, ctx) => {
-    // Validate that from and to are not the same when both are provided
-    if (data.from_stock_location_id && data.stock_location_id === data.from_stock_location_id) {
-      ctx.addIssue({
-        code: z.ZodIssueCode.custom,
-        message: "From and To stock locations must be different",
-        path: ["from_stock_location_id"],
-      });
-    }
-  });
+// The schema lives in its own module so it can be unit-tested: importing this
+// component pulls in `admin/lib/config`, which reads `import.meta.env` and
+// cannot be loaded by Jest (#1671).
+export { inventoryOrderFormSchema } from "./create-inventory-order-schema";
+import {
+  inventoryOrderFormSchema,
+  type InventoryOrderFormData,
+} from "./create-inventory-order-schema";
 
-type InventoryOrderFormData = z.infer<typeof inventoryOrderFormSchema>;
 
 interface OrderLine {
   inventory_item_id: string;
@@ -156,16 +132,22 @@ export const CreateInventoryOrderComponent = () => {
     },
   });
 
-  // Calculate totals from order lines
-  const calculateTotals = () => {
-    const validLines = fields.filter((line: OrderLine) => line.inventory_item_id);
-    const totalQuantity = validLines.reduce((sum: number, line: OrderLine) => sum + (Number(line.quantity) || 0), 0);
-    const totalPrice = validLines.reduce((sum: number, line: OrderLine) => sum + (Number(line.price) || 0) * (Number(line.quantity) || 0), 0);
+  // #1671 — from the LIVE watched rows, never the `useFieldArray` snapshot:
+  // `fields` only refreshes on array operations, so an edited quantity or price
+  // was invisible here and the footer read 0 while a row plainly showed 40×120.
+  // `edit-order-lines.tsx` fixed exactly this and said so; this form did not.
+  const calculateTotals = (source?: OrderLine[]) => {
+    const rows = source ?? (watchedForGroup ?? []);
+    const validLines = rows.filter((line) => line?.inventory_item_id);
+    const totalQuantity = validLines.reduce((sum: number, line) => sum + (Number(line.quantity) || 0), 0);
+    const totalPrice = validLines.reduce((sum: number, line) => sum + (Number(line.price) || 0) * (Number(line.quantity) || 0), 0);
     return { totalQuantity, totalPrice };
   };
 
   const handleSubmit = form.handleSubmit(async (data) => {
-    const { totalQuantity, totalPrice } = calculateTotals();
+    // `data` is what the user actually typed. The `fields` snapshot is not.
+    const submittedLines = (data.order_lines ?? []) as OrderLine[];
+    const { totalQuantity, totalPrice } = calculateTotals(submittedLines);
 
     let payload: any = {
       quantity: totalQuantity,
@@ -178,7 +160,7 @@ export const CreateInventoryOrderComponent = () => {
       is_sample: data.is_sample,
       // #1662 — a picked row is either an existing inventory item or an
       // untracked variant; `toOrderLineRef` sends the right field for each.
-      order_lines: fields
+      order_lines: submittedLines
         .filter((l: OrderLine) => l.inventory_item_id)
         .map(({ inventory_item_id, quantity, price, batch_number }: OrderLine) => ({
           ...toOrderLineRef(inventory_item_id),
@@ -192,6 +174,21 @@ export const CreateInventoryOrderComponent = () => {
     }
     await mutateAsync(payload);
     // Navigation is now handled in the onSuccess callback
+  }, (errors) => {
+    // #1671 — array-level errors live on paths the DataGrid does not render, so
+    // a failed validation used to be indistinguishable from a dead button.
+    const lineErrors = (errors as any)?.order_lines;
+    const first =
+      lineErrors?.message ||
+      lineErrors?.root?.message ||
+      (Array.isArray(lineErrors)
+        ? lineErrors.find(Boolean) &&
+          Object.values(lineErrors.find(Boolean) as any)[0]
+        : undefined);
+    const message =
+      (typeof first === "string" ? first : (first as any)?.message) ||
+      "Check the order lines before creating this order.";
+    toast.error(message);
   });
 
   return (
@@ -385,7 +382,7 @@ export const CreateInventoryOrderComponent = () => {
                   </div>
                   <div className="flex justify-between items-center">
                     <Text weight="plus">Total Order Price:</Text>
-                    <Text weight="plus">${calculateTotals().totalPrice.toFixed(2)}</Text>
+                    <Text weight="plus">₹{calculateTotals().totalPrice.toFixed(2)}</Text>
                   </div>
                 </div>
               </div>

--- a/apps/backend/src/admin/components/creates/inventory-order-lines-grid.tsx
+++ b/apps/backend/src/admin/components/creates/inventory-order-lines-grid.tsx
@@ -505,7 +505,17 @@ export const InventoryOrderLinesGrid = <T extends { id: string; title?: string; 
         return (
           <DataGridNumberCell
             context={context}
-            min={1}
+            // 🔴 NO `min={1}` here (#1671). It becomes a native
+            // `<input type="number" min="1">`, and the form seeds FIVE blank
+            // rows whose quantity is 0. Native constraint validation then
+            // refuses to submit the whole form — before React Hook Form or zod
+            // is consulted, so no submit event fires at all — and because the
+            // offending inputs live inside a horizontally scrolled grid the
+            // browser cannot scroll to them to show its own bubble. The result
+            // was a Create button that did nothing, silently, forever.
+            // The rule still exists, in the schema, where a BLANK row can be
+            // told apart from an unfinished one and the error can be attached
+            // to the row the buyer must fix.
             step="any"
             placeholder=""
           />

--- a/apps/backend/src/admin/components/inventory-orders/inventory-order-lines-section.tsx
+++ b/apps/backend/src/admin/components/inventory-orders/inventory-order-lines-section.tsx
@@ -115,7 +115,7 @@ export const InventoryOrderLinesSection = ({ inventoryOrder }: { inventoryOrder:
                           {variant?.sku || inventoryItem.sku}
                         </Badge>
                       )}
-                      <Badge size="small" className="text-ui-fg-subtle">Price: ${line.price}</Badge>
+                      <Badge size="small" className="text-ui-fg-subtle">Price: ₹{line.price}</Badge>
                       <Badge size="small" className="text-ui-fg-subtle">Quantity: {line.quantity}</Badge>
                     </div>
                   </div>


### PR DESCRIPTION
Fixes #1671. **My diagnosis in that issue was wrong** — corrected below and in a comment on the issue.

## The real cause

The quantity cell rendered `<DataGridNumberCell min={1}>` — a native `<input type="number" min="1">` — and the form **seeds five blank rows** whose quantity is `0`. Native constraint validation refused the whole form **before React Hook Form or zod was ever consulted**, so no submit event fired at all. And because the offending inputs sit inside a horizontally scrolled grid, the browser could not scroll to them to show its own bubble.

The result: a Create button that did nothing — no request, no error, no navigation — unless the buyer deleted four rows by hand.

I first blamed the zod schema. It was a contributing problem but not the blocker: proven in the browser by `form.checkValidity()` returning `false` and naming `order_lines.1..4.quantity` — `"Value must be greater than or equal to 1."` — while no `submit` event was ever dispatched.

## What changed

- **`min` removed from the cell.** The rule lives in the schema instead, where a BLANK row can be told apart from an unfinished one and the error attaches to the row the buyer must fix.
- **Schema**: a row is either blank (ignored) or complete; an invalid submit now raises a toast instead of doing nothing.
- **Totals and payload** come from the live values, not the `useFieldArray` snapshot, which only refreshes on array operations. The footer read 0 while a row showed 25 × 90, and the payload was built from the same stale source. `edit-order-lines.tsx` had already fixed this and said so in a comment; the create form never got it.
- **Currency**: the footer and the order-line badge printed `$` for an INR order, beside grid cells printing the right symbol.
- The schema moved to its own module so it can be unit-tested: importing the component pulls in `admin/lib/config`, which reads `import.meta.env` and Jest cannot load it.

## Verification

- 6 new schema unit tests; 32 green across the related suites; `check:prod-build` ✓; tsc at the 280 baseline.
- **In a real browser**, with all four blank rows still present: picked an untracked partner variant, clicked Create → **201**, landed on the detail page, and confirmed the variant came back tracked with an inventory item.

## ⚠️ Not covered by a test

The native-validation defect only exists in a real browser and nothing in this repo renders one. The schema rule is tested; the absence of the `min` prop is held by a comment on the cell. Worth knowing before someone "tidies" it back.