### PR TITLE
feat(payments): stop refusing a second claim on a design the run guard can settle (#1596)

### DIFF
--- a/apps/backend/integration-tests/http/payment-submissions-api.spec.ts
+++ b/apps/backend/integration-tests/http/payment-submissions-api.spec.ts
@@ -2908,9 +2908,26 @@ setupSharedTestSuite(() => {
       expect(String(res.data?.message || "")).toContain("not eligible")
     })
 
-    it("refuses to claim a run a live payout already covers", async () => {
+    /**
+     * ⚠️ Re-expressed, not relaxed. This case used to bill 4 then 4 of a run
+     * ORDERED FOR 9 and expect a refusal — and it got one, but from the
+     * design-level guard, which refused any second submission on a design
+     * whether or not the money overlapped. #1596 made 4-then-4-of-9 legitimate
+     * tranche billing, so the design guard now stands down where the run guard
+     * has the arithmetic (see `designsBlockedByOpenClaims`), and this case
+     * would have started passing for a reason it never meant.
+     *
+     * The intent — an overclaim is refused — is kept by asking for MORE than
+     * the run is worth. The sibling case below pins the half that is now
+     * allowed, so the loosening is stated rather than merely un-caught.
+     *
+     * This is the third test of this family; #1665 re-expressed two others the
+     * same way, at 4 + 7 = 11.
+     */
+    it("refuses to claim a run past what a live payout leaves of it", async () => {
       const d1 = await createDesign("Partner Double Claim Design")
       await linkDesignToPartner(d1, partnerId)
+      // Ordered for 9.
       const runId = await createCompletedRun(d1, "Partner Double Claim Design")
 
       const first = await api.post(
@@ -2931,7 +2948,8 @@ setupSharedTestSuite(() => {
           {
             design_ids: [d1],
             production_run_ids: { [d1]: [runId] },
-            quantities: { [d1]: 4 },
+            // 4 + 7 = 11 against a ceiling of 9.
+            quantities: { [d1]: 7 },
             unit_amounts: { [d1]: 1200 },
           },
           { headers: partnerHeaders }
@@ -2939,6 +2957,84 @@ setupSharedTestSuite(() => {
         .catch((e: any) => e.response)
 
       expect(second.status).toBe(400)
+    })
+
+    /**
+     * 🔴 The loosening, stated. The design-level guard used to refuse this
+     * outright; now the run's ORDERED quantity is the only thing standing
+     * between a partner and a second claim, and the guard cannot tell "the next
+     * 4" from "the same 4" — nothing in the data ever could. Recorded here so
+     * the change is visible rather than inferred from an absent refusal.
+     */
+    it("allows a second tranche of the same run while the first is still open (#1596)", async () => {
+      const d1 = await createDesign("Partner Tranche Design")
+      await linkDesignToPartner(d1, partnerId)
+      const runId = await createCompletedRun(d1, "Partner Tranche Design")
+
+      const first = await api.post(
+        "/partners/payment-submissions",
+        {
+          design_ids: [d1],
+          production_run_ids: { [d1]: [runId] },
+          quantities: { [d1]: 4 },
+          unit_amounts: { [d1]: 1200 },
+        },
+        { headers: partnerHeaders }
+      )
+      expect(first.status).toBe(201)
+
+      const second = await api
+        .post(
+          "/partners/payment-submissions",
+          {
+            design_ids: [d1],
+            production_run_ids: { [d1]: [runId] },
+            // 4 + 4 = 8, inside the run's ordered 9.
+            quantities: { [d1]: 4 },
+            unit_amounts: { [d1]: 1200 },
+          },
+          { headers: partnerHeaders }
+        )
+        .catch((e: any) => e.response)
+
+      expect(second.status).toBe(201)
+    })
+
+    /**
+     * And the half that must NOT loosen: an open prior that does not say which
+     * runs it paid for is invisible to the run guard, so the design-level
+     * refusal is still the only thing that can catch it.
+     */
+    it("still refuses when the open prior names no runs to diff against (#1596)", async () => {
+      const d1 = await createDesign("Partner Opaque Prior Design")
+      await linkDesignToPartner(d1, partnerId)
+      const runId = await createCompletedRun(d1, "Partner Opaque Prior Design")
+
+      // A claim that records no run evidence at all.
+      const first = await api.post(
+        "/partners/payment-submissions",
+        { design_ids: [d1] },
+        { headers: partnerHeaders }
+      )
+      expect(first.status).toBe(201)
+
+      const second = await api
+        .post(
+          "/partners/payment-submissions",
+          {
+            design_ids: [d1],
+            production_run_ids: { [d1]: [runId] },
+            quantities: { [d1]: 1 },
+            unit_amounts: { [d1]: 1200 },
+          },
+          { headers: partnerHeaders }
+        )
+        .catch((e: any) => e.response)
+
+      expect(second.status).toBe(400)
+      expect(String(second.data?.message || "")).toContain(
+        "already in an active payment submission"
+      )
     })
   })
 

--- a/apps/backend/src/workflows/payment_submissions/create-payment-submission.ts
+++ b/apps/backend/src/workflows/payment_submissions/create-payment-submission.ts
@@ -19,6 +19,10 @@ import {
   runlessResubmitMessage,
 } from "./lib/run-evidence-guard"
 import {
+  designsBlockedByOpenClaims,
+  designOpenClaimsMessage,
+} from "./lib/design-open-claims"
+import {
   assessRunClaims,
   listPartnerRunTallies,
   requestedRunQuantities,
@@ -683,13 +687,60 @@ const validateDesignsForSubmissionStep = createStep(
     })
 
     if (activeSubmissionDesigns.length) {
-      const ids = [
-        ...new Set(activeSubmissionDesigns.map((l) => l.design_id)),
-      ]
-      throw new MedusaError(
-        MedusaError.Types.INVALID_DATA,
-        `Designs already in an active payment submission: ${ids.join(", ")}`
+      /**
+       * #1596 — a design in an open submission no longer blocks OUTRIGHT.
+       * A run is claimed by quantity now, so billing 4 of a run ordered for 9
+       * and coming back for the rest is the whole point, and this design-level
+       * check refused it on the strength of the design alone.
+       *
+       * `designsBlockedByOpenClaims` stands the guard down in exactly one
+       * situation — both this claim and every open prior NAME their runs, which
+       * is when `assessRunClaims` in step 6 has the arithmetic to answer
+       * properly. Everything else, opaque priors included, still refuses.
+       */
+      const openByDesign = new Map<string, string[]>()
+      for (const link of activeSubmissionDesigns) {
+        const designId = String(link.design_id)
+        // `payment_submission.*` fetches the id; the link result type only
+        // declares `status`, so it is read off the runtime shape.
+        const submissionId = String(
+          (link.payment_submission as any)?.id || ""
+        )
+        // No "exclude self" here: create has no submission of its own yet.
+        if (!submissionId) {
+          continue
+        }
+        openByDesign.set(designId, [
+          ...new Set([...(openByDesign.get(designId) || []), submissionId]),
+        ])
+      }
+
+      const submissionService: PaymentSubmissionsService = container.resolve(
+        PAYMENT_SUBMISSIONS_MODULE
       )
+      const openPriorItems = (await submissionService.listPaymentSubmissionItems(
+        { design_id: input.design_ids },
+        { relations: ["submission"] }
+      )) as any[]
+
+      const blocked = designsBlockedByOpenClaims({
+        design_ids: input.design_ids,
+        claimed_runs: input.production_run_ids,
+        open_submissions_by_design: openByDesign,
+        prior_lines: (openPriorItems || []).map((item) => ({
+          design_id: item.design_id ? String(item.design_id) : null,
+          submission_id: String(item.submission?.id ?? item.submission_id ?? ""),
+          submission_status: item.submission?.status ?? null,
+          production_run_ids: (item.production_run_ids || []) as string[],
+        })),
+      })
+
+      if (blocked.length) {
+        throw new MedusaError(
+          MedusaError.Types.INVALID_DATA,
+          designOpenClaimsMessage(blocked)
+        )
+      }
     }
 
     /**

--- a/apps/backend/src/workflows/payment_submissions/lib/__tests__/design-open-claims.unit.spec.ts
+++ b/apps/backend/src/workflows/payment_submissions/lib/__tests__/design-open-claims.unit.spec.ts
@@ -1,0 +1,199 @@
+import {
+  designsBlockedByOpenClaims,
+  designOpenClaimsMessage,
+} from "../design-open-claims"
+
+/**
+ * #1596. This guard used to refuse any second submission on a design that had
+ * an open one. A run is claimed by QUANTITY now, so billing 4 of a run ordered
+ * for 9 and returning for the rest is legitimate — and the design-level check
+ * refused it on the strength of the design alone.
+ *
+ * 🔴 It is a MONEY guard, so the tests that matter most are the ones proving it
+ * still refuses. It stands down in exactly one situation: both this claim and
+ * every open prior name their runs, which is when `assessRunClaims` has the
+ * arithmetic. Everything else — an opaque prior, a claim naming no runs, an
+ * open submission whose lines we cannot see — must keep blocking.
+ */
+const openMap = (entries: Record<string, string[]>) =>
+  new Map(Object.entries(entries))
+
+describe("designsBlockedByOpenClaims (#1596)", () => {
+  it("lets a second run-named claim through when the open prior names its runs too", () => {
+    const blocked = designsBlockedByOpenClaims({
+      design_ids: ["design_1"],
+      claimed_runs: { design_1: ["run_b"] },
+      open_submissions_by_design: openMap({ design_1: ["sub_open"] }),
+      prior_lines: [
+        {
+          design_id: "design_1",
+          submission_id: "sub_open",
+          submission_status: "Pending",
+          production_run_ids: ["run_a"],
+        },
+      ],
+    })
+    expect(blocked).toEqual([])
+  })
+
+  it("lets a SECOND TRANCHE of the same run through — the run guard owns that arithmetic", () => {
+    const blocked = designsBlockedByOpenClaims({
+      design_ids: ["design_1"],
+      claimed_runs: { design_1: ["run_a"] },
+      open_submissions_by_design: openMap({ design_1: ["sub_open"] }),
+      prior_lines: [
+        {
+          design_id: "design_1",
+          submission_id: "sub_open",
+          submission_status: "Pending",
+          production_run_ids: ["run_a"],
+        },
+      ],
+    })
+    expect(blocked).toEqual([])
+  })
+
+  it("still refuses when THIS claim names no runs — nothing to diff on our side", () => {
+    const blocked = designsBlockedByOpenClaims({
+      design_ids: ["design_1"],
+      claimed_runs: {},
+      open_submissions_by_design: openMap({ design_1: ["sub_open"] }),
+      prior_lines: [
+        {
+          design_id: "design_1",
+          submission_id: "sub_open",
+          submission_status: "Pending",
+          production_run_ids: ["run_a"],
+        },
+      ],
+    })
+    expect(blocked).toHaveLength(1)
+    expect(blocked[0].reason).toBe("no_runs_claimed")
+  })
+
+  it("still refuses when the OPEN PRIOR names no runs — that claim is invisible to the run guard", () => {
+    const blocked = designsBlockedByOpenClaims({
+      design_ids: ["design_1"],
+      claimed_runs: { design_1: ["run_a"] },
+      open_submissions_by_design: openMap({ design_1: ["sub_open"] }),
+      prior_lines: [
+        {
+          design_id: "design_1",
+          submission_id: "sub_open",
+          submission_status: "Pending",
+          // `not_recorded`: pays for run work, records no evidence of which.
+          production_run_ids: [],
+        },
+      ],
+    })
+    expect(blocked).toHaveLength(1)
+    expect(blocked[0].reason).toBe("prior_claim_names_no_runs")
+  })
+
+  it("refuses when the open submission's lines cannot be seen at all — absence is not permission", () => {
+    const blocked = designsBlockedByOpenClaims({
+      design_ids: ["design_1"],
+      claimed_runs: { design_1: ["run_a"] },
+      open_submissions_by_design: openMap({ design_1: ["sub_open"] }),
+      prior_lines: [],
+    })
+    expect(blocked).toHaveLength(1)
+    expect(blocked[0].reason).toBe("prior_claim_names_no_runs")
+  })
+
+  it("refuses if ANY of several open priors is opaque, even when another names its runs", () => {
+    const blocked = designsBlockedByOpenClaims({
+      design_ids: ["design_1"],
+      claimed_runs: { design_1: ["run_c"] },
+      open_submissions_by_design: openMap({
+        design_1: ["sub_clean", "sub_opaque"],
+      }),
+      prior_lines: [
+        {
+          design_id: "design_1",
+          submission_id: "sub_clean",
+          submission_status: "Pending",
+          production_run_ids: ["run_a"],
+        },
+        {
+          design_id: "design_1",
+          submission_id: "sub_opaque",
+          submission_status: "Pending",
+          production_run_ids: [],
+        },
+      ],
+    })
+    expect(blocked).toHaveLength(1)
+    expect(blocked[0].submission_ids).toEqual(["sub_opaque"])
+  })
+
+  it("refuses when a prior line names runs but a SIBLING line on the same design does not", () => {
+    const blocked = designsBlockedByOpenClaims({
+      design_ids: ["design_1"],
+      claimed_runs: { design_1: ["run_c"] },
+      open_submissions_by_design: openMap({ design_1: ["sub_open"] }),
+      prior_lines: [
+        {
+          design_id: "design_1",
+          submission_id: "sub_open",
+          submission_status: "Pending",
+          production_run_ids: ["run_a"],
+        },
+        {
+          design_id: "design_1",
+          submission_id: "sub_open",
+          submission_status: "Pending",
+          production_run_ids: null,
+        },
+      ],
+    })
+    expect(blocked).toHaveLength(1)
+    expect(blocked[0].reason).toBe("prior_claim_names_no_runs")
+  })
+
+  it("ignores a prior line for a DIFFERENT design in the same submission", () => {
+    const blocked = designsBlockedByOpenClaims({
+      design_ids: ["design_1"],
+      claimed_runs: { design_1: ["run_c"] },
+      open_submissions_by_design: openMap({ design_1: ["sub_open"] }),
+      prior_lines: [
+        {
+          design_id: "design_1",
+          submission_id: "sub_open",
+          submission_status: "Pending",
+          production_run_ids: ["run_a"],
+        },
+        {
+          design_id: "design_2",
+          submission_id: "sub_open",
+          submission_status: "Pending",
+          production_run_ids: [],
+        },
+      ],
+    })
+    expect(blocked).toEqual([])
+  })
+
+  it("does not block a design with no open submission at all", () => {
+    const blocked = designsBlockedByOpenClaims({
+      design_ids: ["design_1"],
+      claimed_runs: {},
+      open_submissions_by_design: openMap({}),
+      prior_lines: [],
+    })
+    expect(blocked).toEqual([])
+  })
+
+  it("says what would make the refusal go away", () => {
+    const message = designOpenClaimsMessage([
+      {
+        design_id: "design_1",
+        submission_ids: ["sub_open"],
+        reason: "no_runs_claimed",
+      },
+    ])
+    expect(message).toContain("design_1")
+    expect(message).toContain("sub_open")
+    expect(message).toMatch(/name the production runs/)
+  })
+})

--- a/apps/backend/src/workflows/payment_submissions/lib/design-open-claims.ts
+++ b/apps/backend/src/workflows/payment_submissions/lib/design-open-claims.ts
@@ -1,0 +1,147 @@
+/**
+ * When does another OPEN submission on the same design still block this one?
+ *
+ * ## What this guard used to be
+ *
+ * "Is this design in a Pending/Under_Review submission? Then refuse." A design
+ * is produced many times, so that question was always a coarse proxy for the
+ * one that matters — *has this work already been claimed?* — and #1596 made the
+ * proxy actively wrong: a run is claimed by QUANTITY now. A partner who
+ * finishes 4 of a run ordered for 9, bills those 4, and comes back for the rest
+ * is doing exactly what that change exists to allow, and this guard refused it
+ * on the strength of the design alone.
+ *
+ * ## What replaces it
+ *
+ * The run-level guard (`assessRunClaims`) already answers the money question
+ * properly: partner-scoped, quantity-aware, blind to nothing — and it refuses
+ * on EVERY unattributable case (a claim that names several runs, a line with no
+ * usable quantity, a run whose ordered quantity cannot be read). So wherever
+ * that guard has the arithmetic, this one adds nothing but a false refusal.
+ *
+ * 🔴 It has the arithmetic in exactly one situation, and this function's whole
+ * job is to recognise it:
+ *
+ *   - this submission names production runs for the design, AND
+ *   - every open prior line for that design names production runs too.
+ *
+ * The second half is not a formality. `assessRunClaims` diffs against the
+ * tallies of lines that NAME runs; a live line that names none is invisible to
+ * it. Such a line pays for run work while recording no evidence of which work
+ * (`run_provenance: "not_recorded"` — the rows #1557/#1565 were about), so what
+ * it already took cannot be subtracted from anything. That is DOUBT, and doubt
+ * has to keep refusing.
+ *
+ * 🔑 Absence of evidence is the one thing this module must never read as room
+ * to bill. So the default here is to BLOCK: a design stops blocking only when
+ * the runs are on the record, on both sides.
+ */
+
+export type OpenPriorLine = {
+  design_id: string | null
+  submission_id: string | null
+  submission_status: string | null
+  production_run_ids?: string[] | null
+}
+
+export type DesignOpenClaim = {
+  design_id: string
+  submission_ids: string[]
+  /** Why it still blocks, for the refusal message. */
+  reason: "no_runs_claimed" | "prior_claim_names_no_runs"
+}
+
+const namesRuns = (ids?: string[] | null): boolean =>
+  Array.isArray(ids) && ids.filter(Boolean).length > 0
+
+/**
+ * PURE. Which of these designs are still blocked by an open prior submission.
+ *
+ * `openSubmissionsByDesign` is what the caller already knows from the
+ * design↔submission link: design id → the open submissions on it, this
+ * submission's own excluded. It is kept as the source of "is something open"
+ * rather than being re-derived from the lines, because an open submission whose
+ * lines we cannot see must still block — inferring "no lines, therefore no
+ * claim" is the same absence-as-permission mistake in a new place.
+ */
+export const designsBlockedByOpenClaims = (input: {
+  design_ids: string[]
+  /** design id → run ids THIS submission claims for it. */
+  claimed_runs: Record<string, string[]> | null | undefined
+  /** design id → open submission ids, excluding this submission. */
+  open_submissions_by_design: Map<string, string[]>
+  /** Every prior line for these designs, this submission's own excluded. */
+  prior_lines: OpenPriorLine[]
+}): DesignOpenClaim[] => {
+  const blocked: DesignOpenClaim[] = []
+
+  // submission id → whether ANY of its lines for the design names a run.
+  const linesBySubmission = new Map<string, OpenPriorLine[]>()
+  for (const line of input.prior_lines || []) {
+    const submissionId = String(line.submission_id || "")
+    if (!submissionId) {
+      continue
+    }
+    linesBySubmission.set(submissionId, [
+      ...(linesBySubmission.get(submissionId) || []),
+      line,
+    ])
+  }
+
+  for (const designId of input.design_ids || []) {
+    const openIds = input.open_submissions_by_design.get(String(designId)) || []
+    if (!openIds.length) {
+      continue
+    }
+
+    const claimedHere = (input.claimed_runs || {})[String(designId)] || []
+    if (!namesRuns(claimedHere)) {
+      // Nothing to diff on our side: the run guard will not even run for this
+      // design, so the old whole-design refusal is the only thing standing.
+      blocked.push({
+        design_id: String(designId),
+        submission_ids: openIds,
+        reason: "no_runs_claimed",
+      })
+      continue
+    }
+
+    const opaque = openIds.filter((submissionId) => {
+      const lines = (linesBySubmission.get(submissionId) || []).filter(
+        (l) => String(l.design_id || "") === String(designId)
+      )
+      // No visible lines at all ⇒ opaque. Never treat "we saw nothing" as
+      // "there is nothing".
+      if (!lines.length) {
+        return true
+      }
+      return lines.some((l) => !namesRuns(l.production_run_ids))
+    })
+
+    if (opaque.length) {
+      blocked.push({
+        design_id: String(designId),
+        submission_ids: opaque,
+        reason: "prior_claim_names_no_runs",
+      })
+    }
+  }
+
+  return blocked
+}
+
+/** The refusal, saying what would make it go away. */
+export const designOpenClaimsMessage = (
+  blocked: DesignOpenClaim[]
+): string => {
+  const detail = blocked
+    .map(({ design_id, submission_ids, reason }) => {
+      const holders = submission_ids.join(", ") || "unknown"
+      return reason === "no_runs_claimed"
+        ? `${design_id} (open in ${holders}; name the production runs this line pays for so the two claims can be told apart)`
+        : `${design_id} (open in ${holders}, which does not say which runs it pays for, so this claim cannot be diffed against it)`
+    })
+    .join("; ")
+
+  return `Designs already in an active payment submission: ${detail}`
+}

--- a/apps/backend/src/workflows/payment_submissions/submit-payment-submission.ts
+++ b/apps/backend/src/workflows/payment_submissions/submit-payment-submission.ts
@@ -20,6 +20,10 @@ import {
   requestedRunQuantities,
   runsOverclaimedMessage,
 } from "./lib/run-claims"
+import {
+  designsBlockedByOpenClaims,
+  designOpenClaimsMessage,
+} from "./lib/design-open-claims"
 
 /**
  * Turn a Draft payment submission into a real claim — Draft → Pending, in place.
@@ -213,20 +217,58 @@ const validateSubmissionForSubmitStep = createStep(
        *    would leave both stuck, which is the shape of #1605.
        */
       const OPEN_STATUSES = new Set(["Pending", "Under_Review"])
-      const openDesigns = [
-        ...new Set(
-          foreignPriors
-            .filter((item) =>
-              OPEN_STATUSES.has(String(item.submission?.status || ""))
-            )
-            .map((item) => String(item.design_id))
-            .filter((id) => designIds.includes(id))
-        ),
-      ]
-      if (openDesigns.length) {
+      const openPriors = foreignPriors.filter(
+        (item) =>
+          OPEN_STATUSES.has(String(item.submission?.status || "")) &&
+          designIds.includes(String(item.design_id))
+      )
+
+      const openByDesign = new Map<string, string[]>()
+      for (const item of openPriors) {
+        const designId = String(item.design_id)
+        const submissionId = String(
+          item.submission?.id || item.submission_id || ""
+        )
+        if (!submissionId) {
+          continue
+        }
+        openByDesign.set(designId, [
+          ...new Set([...(openByDesign.get(designId) || []), submissionId]),
+        ])
+      }
+
+      /**
+       * #1596 — same rule as create, from the same pure function: an open
+       * prior on the design only blocks when the arithmetic is unavailable.
+       * Where both sides name their runs, the quantity-aware run guard that
+       * already ran above is the one entitled to answer.
+       */
+      const claimedRunsHere: Record<string, string[]> = {}
+      for (const item of items) {
+        if (!item.design_id) continue
+        const designId = String(item.design_id)
+        claimedRunsHere[designId] = [
+          ...(claimedRunsHere[designId] || []),
+          ...((item.production_run_ids || []) as string[]).map(String),
+        ].filter(Boolean)
+      }
+
+      const blocked = designsBlockedByOpenClaims({
+        design_ids: designIds,
+        claimed_runs: claimedRunsHere,
+        open_submissions_by_design: openByDesign,
+        prior_lines: openPriors.map((item) => ({
+          design_id: item.design_id ? String(item.design_id) : null,
+          submission_id: String(item.submission?.id || item.submission_id || ""),
+          submission_status: item.submission?.status ?? null,
+          production_run_ids: (item.production_run_ids || []) as string[],
+        })),
+      })
+
+      if (blocked.length) {
         throw new MedusaError(
           MedusaError.Types.INVALID_DATA,
-          `Designs already in an active payment submission: ${openDesigns.join(", ")}`
+          designOpenClaimsMessage(blocked)
         )
       }
 


### PR DESCRIPTION
Second of the three items left on #1596: **the design-level guard that still refused two open claims on one design.**

## The problem

The guard asked *"is this design in a Pending/Under_Review submission?"* and refused on the answer. That was always a coarse proxy for *has this work already been claimed*, and #1596 made it actively wrong — a run is claimed by **quantity** now. A partner who finishes 4 of a run ordered for 9, bills those 4 and returns for the rest is doing exactly what that change exists to allow, and this guard refused it on the strength of the design alone.

## The rule

`assessRunClaims` already answers the money question properly: partner-scoped, quantity-aware, and refusing on **every** unattributable case (a claim naming several runs, a line with no usable quantity, a run whose ordered quantity cannot be read). The design guard now stands down in exactly one situation, which `designsBlockedByOpenClaims` exists to recognise:

- this submission names production runs for the design, **and**
- every open prior line for that design names production runs too.

The second half is load-bearing. `assessRunClaims` diffs against tallies of lines that **name** runs; a live line naming none is invisible to it. Such a line pays for run work while recording no evidence of which (`run_provenance: "not_recorded"` — the #1557/#1565 rows), so what it took cannot be subtracted from anything. That is doubt, and doubt keeps refusing. An open submission whose lines cannot be seen at all refuses too — *"we saw nothing"* must never become *"there is nothing"*.

One rule, one file, used by **both** `create` and `submit` — the two places that each carried their own copy of the old check.

## 🔴 This loosens a guard on money

Deliberately, following the same decision as #1665. Two integration cases now state both halves outright rather than leaving the change to be inferred from an absent refusal:

- a second tranche of the same run **is allowed** while the first is open (4 + 4 against 9);
- an open prior that names no runs **still refuses**.

## ⚠️ One existing test was re-expressed, not relaxed

`"refuses to claim a run a live payout already covers"` billed 4 then 4 of a run ordered for 9 and expected a refusal — and got one, but **from the design guard, not the money guard it names**. It now asks for 4 + 7 = 11 against a ceiling of 9, exactly as #1665 re-expressed two others. It is the third test of that family found passing for the wrong reason.

## Verification

- 10 new unit tests on the pure rule, most of them proving it still **refuses**.
- `payment-submissions-api.spec.ts` **107/107** green against the local DB (was 105, +2 stating the change).
- `payment-rate-breakdown` + `partner-payment-ledger` 17/17; 204 payment_submissions unit tests green.
- `check:prod-build` ✓; tsc 279 lines, at/below the 280 baseline.

Remaining on #1596 after this: the **short-close** and the **auto-draft** firing only on completion.