### PR TITLE
test(mcp): declare update_design cost fields as deliberate omissions

### DIFF
--- a/apps/backend/src/lib/mcp-core/__tests__/route-validator-field-coverage.unit.spec.ts
+++ b/apps/backend/src/lib/mcp-core/__tests__/route-validator-field-coverage.unit.spec.ts
@@ -252,6 +252,10 @@ const DELIBERATELY_OMITTED: Record<string, Record<string, string>> = {
     feedback_history: "append-only log written by the review flow",
     origin_source: "provenance stamped by the creating surface",
     customer_id_for_link: "linking is a separate tool",
+    material_cost:
+      "computed by the recalculate-cost workflow (estimateDesignCostWorkflow) — not assistant-authored",
+    production_cost:
+      "as material_cost — the production half of the cost breakdown, recomputed from the BOM/order history",
   },
   "admin:create_design_production_run": {
     template_ids: "GAP (#1394): template selection by id, name-based is advertised",


### PR DESCRIPTION
## Summary

Fixes the red `route-validator-field-coverage` assertion on `main`.

The `admin:update_design` MCP tool's route validator (`UpdateDesignSchema`) accepts `material_cost` and `production_cost` — added so the recalculate-cost correction path could clear wrongly-stored breakdown values (#1564) — but the coverage test's `DELIBERATELY_OMITTED` list never named them, so `advertises every accepted field, or names it as a deliberate omission` was failing.

These two fields are **computed** by `estimateDesignCostWorkflow` (recalculate-cost) from the BOM/order history — not authored by the assistant — so they belong in the deliberate-omission list, not the tool's `bodyParams`.

## Change

`apps/backend/src/lib/mcp-core/__tests__/route-validator-field-coverage.unit.spec.ts` (+4): add `material_cost` / `production_cost` to `DELIBERATELY_OMITTED["admin:update_design"]` with reasons.

## Test plan

```
TEST_TYPE=unit NODE_OPTIONS=--experimental-vm-modules jest src/lib/mcp-core/__tests__/route-validator-field-coverage.unit.spec.ts --runInBand
```
8/8 passing (previously 1 failing).