### PR TITLE
feat(production-runs): short-close a run, explicitly and on a 30-day counter (#1596)

### DIFF
--- a/apps/backend/integration-tests/http/payment-submissions-api.spec.ts
+++ b/apps/backend/integration-tests/http/payment-submissions-api.spec.ts
@@ -2960,6 +2960,135 @@ setupSharedTestSuite(() => {
     })
 
     /**
+     * #1596 SHORT CLOSE. Until a run is closed, its ceiling is the ORDERED
+     * quantity on purpose — output is captured at completion and more can
+     * legitimately follow. Closing says no more will be made, and the ceiling
+     * becomes what was produced.
+     */
+    it("short-closing a run drops its ceiling from ordered to produced (#1596)", async () => {
+      const d1 = await createDesign("Short Close Design")
+      await linkDesignToPartner(d1, partnerId)
+      // Ordered 9, produced 4.
+      const runId = await createCompletedRun(d1, "Short Close Design")
+
+      // Before closing: the 5 unmade units are still billable.
+      const open = await api
+        .post(
+          "/partners/payment-submissions",
+          {
+            design_ids: [d1],
+            production_run_ids: { [d1]: [runId] },
+            quantities: { [d1]: 9 },
+            unit_amounts: { [d1]: 1200 },
+          },
+          { headers: partnerHeaders }
+        )
+        .catch((e: any) => e.response)
+      expect(open.status).toBe(201)
+
+      // A fresh run, this time closed before anyone bills it.
+      const d2 = await createDesign("Short Closed Design")
+      await linkDesignToPartner(d2, partnerId)
+      const closedRunId = await createCompletedRun(d2, "Short Closed Design")
+
+      const closeRes = await api.post(
+        `/admin/production-runs/${closedRunId}/short-close`,
+        { reason: "Partner confirmed no more will be made" },
+        adminHeaders
+      )
+      expect(closeRes.status).toBe(200)
+      expect(closeRes.data.short_closed).toBe(true)
+
+      // 5 is now over the ceiling of 4, though well under the ordered 9.
+      const over = await api
+        .post(
+          "/partners/payment-submissions",
+          {
+            design_ids: [d2],
+            production_run_ids: { [d2]: [closedRunId] },
+            quantities: { [d2]: 5 },
+            unit_amounts: { [d2]: 1200 },
+          },
+          { headers: partnerHeaders }
+        )
+        .catch((e: any) => e.response)
+      expect(over.status).toBe(400)
+
+      // And exactly the produced quantity still goes through.
+      const exact = await api.post(
+        "/partners/payment-submissions",
+        {
+          design_ids: [d2],
+          production_run_ids: { [d2]: [closedRunId] },
+          quantities: { [d2]: 4 },
+          unit_amounts: { [d2]: 1200 },
+        },
+        { headers: partnerHeaders }
+      )
+      expect(exact.status).toBe(201)
+    })
+
+    it("reopening a short-closed run restores the ordered ceiling (#1596)", async () => {
+      const d1 = await createDesign("Reopened Run Design")
+      await linkDesignToPartner(d1, partnerId)
+      const runId = await createCompletedRun(d1, "Reopened Run Design")
+
+      await api.post(
+        `/admin/production-runs/${runId}/short-close`,
+        {},
+        adminHeaders
+      )
+
+      const refused = await api
+        .post(
+          "/partners/payment-submissions",
+          {
+            design_ids: [d1],
+            production_run_ids: { [d1]: [runId] },
+            quantities: { [d1]: 9 },
+            unit_amounts: { [d1]: 1200 },
+          },
+          { headers: partnerHeaders }
+        )
+        .catch((e: any) => e.response)
+      expect(refused.status).toBe(400)
+
+      const reopen = await api.delete(
+        `/admin/production-runs/${runId}/short-close`,
+        adminHeaders
+      )
+      expect(reopen.status).toBe(200)
+      expect(reopen.data.reopened).toBe(true)
+
+      const allowed = await api.post(
+        "/partners/payment-submissions",
+        {
+          design_ids: [d1],
+          production_run_ids: { [d1]: [runId] },
+          quantities: { [d1]: 9 },
+          unit_amounts: { [d1]: 1200 },
+        },
+        { headers: partnerHeaders }
+      )
+      expect(allowed.status).toBe(201)
+    })
+
+    it("refuses to close a run that recorded no output, rather than pretending to (#1596)", async () => {
+      const d1 = await createDesign("No Output Design")
+      await linkDesignToPartner(d1, partnerId)
+      const runId = await createCompletedRun(d1, "No Output Design", {
+        produced_quantity: null,
+      })
+
+      const res = await api
+        .post(`/admin/production-runs/${runId}/short-close`, {}, adminHeaders)
+        .catch((e: any) => e.response)
+
+      expect(res.status).toBe(400)
+      expect(String(res.data?.message || "")).toContain("no recorded output")
+    })
+
+    /**
      * 🔴 The loosening, stated. The design-level guard used to refuse this
      * outright; now the run's ORDERED quantity is the only thing standing
      * between a partner and a second claim, and the guard cannot tell "the next

--- a/apps/backend/src/api/admin/payment-submissions/payable-runs/route.ts
+++ b/apps/backend/src/api/admin/payment-submissions/payable-runs/route.ts
@@ -12,6 +12,7 @@ import {
 } from "../../../../workflows/payment_submissions/lib/run-billing"
 import { groupOrderBackedRuns } from "../../../../workflows/payment_submissions/lib/order-run-groups"
 import { foldPartnerBilling } from "../../../../workflows/payment_submissions/lib/run-billing"
+import { runBillableCeiling } from "../../../../workflows/payment_submissions/lib/run-billable-ceiling"
 
 /**
  * GET /admin/payment-submissions/payable-runs?partner_id=…
@@ -109,6 +110,10 @@ export const GET = async (req: MedusaRequest, res: MedusaResponse) => {
       "status",
       "quantity",
       "produced_quantity",
+      // #1596 short-close. ⚠️ `runBillableCeiling` reads this; without it the
+      // ceiling silently falls back to the ORDERED quantity and the screen
+      // keeps offering units the write guard now refuses.
+      "short_closed_at",
       "rejected_quantity",
       "partner_cost_estimate",
       "cost_type",
@@ -370,7 +375,10 @@ export const GET = async (req: MedusaRequest, res: MedusaResponse) => {
          */
         billable_remaining: runBillableRemaining({
           claim: billedRuns.get(String(run.id)),
-          ordered: run.quantity,
+          // #1596 — the CEILING, not the raw ordered quantity: a short-closed
+          // run bills to what it produced, and this screen must offer exactly
+          // what the write guard will accept.
+          ordered: runBillableCeiling(run as any),
         }),
         /**
          * Live payouts against this design that never recorded a run.

--- a/apps/backend/src/api/admin/production-runs/[id]/route.ts
+++ b/apps/backend/src/api/admin/production-runs/[id]/route.ts
@@ -99,6 +99,7 @@ import {
 } from "../../../../lib/production-run-allocation"
 import { costTypeGuardMessage } from "../../../../workflows/production-runs/lib/cost-type-guard"
 import { refreshUnclaimedDraftPayouts } from "../../../../workflows/payment_submissions/lib/refresh-draft-payouts"
+import { reopenProductionRun } from "../../../../workflows/production-runs/lib/short-close-production-run"
 
 export const GET = async (req: MedusaRequest, res: MedusaResponse) => {
   const id = req.params.id
@@ -316,6 +317,38 @@ export const POST = async (req: MedusaRequest, res: MedusaResponse) => {
       refreshedDrafts = outcome.refreshed
     } catch {
       // Non-fatal by design — see above.
+    }
+  }
+
+  /**
+   * #1596 — an upward output correction REOPENS a short-closed run.
+   *
+   * The close said "nothing more was made". A correction raising
+   * `produced_quantity` is the evidence that it was wrong, and leaving the run
+   * closed would let a 30-day timer permanently cap a partner's claim on the
+   * strength of a figure that has since changed. Reversal is automatic;
+   * closing never is.
+   *
+   * Best-effort, and deliberately after the correction is persisted: failing to
+   * reopen must not roll back a figure an admin just corrected.
+   */
+  if (producedCorrection !== undefined && run.short_closed_at) {
+    const previousProduced = Number(run.produced_quantity)
+    const corrected = Number(producedCorrection)
+    const raised =
+      Number.isFinite(corrected) &&
+      (!Number.isFinite(previousProduced) || corrected > previousProduced)
+    if (raised) {
+      try {
+        await reopenProductionRun(req.scope, {
+          run_id: id,
+          actor_id: String((req as any).auth_context?.actor_id ?? "admin"),
+          actor_type: "admin",
+          reason: "Output corrected upward after the run was short-closed",
+        })
+      } catch {
+        /* non-fatal by design — see above */
+      }
     }
   }
 

--- a/apps/backend/src/api/admin/production-runs/[id]/short-close/route.ts
+++ b/apps/backend/src/api/admin/production-runs/[id]/short-close/route.ts
@@ -1,0 +1,89 @@
+import { MedusaRequest, MedusaResponse } from "@medusajs/framework/http"
+import { MedusaError } from "@medusajs/framework/utils"
+
+import {
+  shortCloseProductionRun,
+  reopenProductionRun,
+} from "../../../../../workflows/production-runs/lib/short-close-production-run"
+
+/**
+ * POST   /admin/production-runs/:id/short-close   — close it
+ * DELETE /admin/production-runs/:id/short-close   — reopen it
+ *
+ * #1596. A run ordered for 9 and completed at 7 keeps 2 units billable, because
+ * the ceiling is the ORDERED quantity and that number cannot tell "not made
+ * yet" from "never will be made". This says the latter, after which the run
+ * bills to what it produced.
+ *
+ * 🔑 The behaviour lives in `short-close-production-run`, shared with the
+ * 30-day counter. Two copies of a rule that decides how much a partner may
+ * claim is how the screen and the sweep start disagreeing about someone's
+ * money.
+ *
+ * Nothing is clawed back. A run legitimately billed to 7 and then closed at 4
+ * keeps those 7; the remainder clamps at zero and the write guard refuses more.
+ */
+export const POST = async (req: MedusaRequest, res: MedusaResponse) => {
+  const { id } = req.params
+  const reason =
+    typeof (req.body as any)?.reason === "string" &&
+    (req.body as any).reason.trim()
+      ? (req.body as any).reason.trim()
+      : null
+
+  const actorId = (req as any).auth_context?.actor_id ?? "admin"
+
+  let outcome
+  try {
+    outcome = await shortCloseProductionRun(req.scope, {
+      run_id: id,
+      actor_id: String(actorId),
+      actor_type: "admin",
+      reason,
+    })
+  } catch {
+    throw new MedusaError(MedusaError.Types.NOT_FOUND, "Production run not found")
+  }
+
+  if (!outcome.closed && outcome.reason === "no_output_figure") {
+    // Refused rather than performed: with no produced figure the ceiling would
+    // stay at the ordered quantity, so the close would look like a decision
+    // while changing nothing.
+    throw new MedusaError(
+      MedusaError.Types.INVALID_DATA,
+      "This run has no recorded output, so closing it would not change what is billable. Record the produced quantity first."
+    )
+  }
+
+  res.status(200).json({
+    production_run: outcome.run,
+    short_closed: outcome.closed,
+    /** `already_closed` when a repeat call found nothing to do. */
+    outcome: outcome.reason,
+  })
+}
+
+export const DELETE = async (req: MedusaRequest, res: MedusaResponse) => {
+  const { id } = req.params
+  const actorId = (req as any).auth_context?.actor_id ?? "admin"
+
+  let outcome
+  try {
+    outcome = await reopenProductionRun(req.scope, {
+      run_id: id,
+      actor_id: String(actorId),
+      actor_type: "admin",
+      reason:
+        typeof (req.body as any)?.reason === "string"
+          ? (req.body as any).reason
+          : null,
+    })
+  } catch {
+    throw new MedusaError(MedusaError.Types.NOT_FOUND, "Production run not found")
+  }
+
+  res.status(200).json({
+    production_run: outcome.run,
+    reopened: outcome.reopened,
+  })
+}

--- a/apps/backend/src/api/partners/payment-submissions/payable-runs/route.ts
+++ b/apps/backend/src/api/partners/payment-submissions/payable-runs/route.ts
@@ -11,6 +11,7 @@ import {
   runBillingStatus,
 } from "../../../../workflows/payment_submissions/lib/run-billing"
 import { getPartnerFromAuthContext } from "../../helpers"
+import { runBillableCeiling } from "../../../../workflows/payment_submissions/lib/run-billable-ceiling"
 
 /**
  * GET /partners/payment-submissions/payable-runs
@@ -53,6 +54,10 @@ export const GET = async (
       "status",
       "quantity",
       "produced_quantity",
+      // #1596 short-close. ⚠️ `runBillableCeiling` reads this; without it the
+      // ceiling silently falls back to the ORDERED quantity and the screen
+      // keeps offering units the write guard now refuses.
+      "short_closed_at",
       "rejected_quantity",
       "partner_cost_estimate",
       "cost_type",
@@ -184,7 +189,10 @@ export const GET = async (
         // behind the answer — which is exactly when `create` refuses.
         billable_remaining: runBillableRemaining({
           claim: billedRuns.get(String(run.id)),
-          ordered: run.quantity,
+          // #1596 — the CEILING, not the raw ordered quantity: a short-closed
+          // run bills to what it produced, and this screen must offer exactly
+          // what the write guard will accept.
+          ordered: runBillableCeiling(run as any),
         }),
         unrecorded_claims:
           designsWithUnrecordedClaims.get(String(run.design_id)) ?? [],

--- a/apps/backend/src/jobs/short-close-stale-production-runs.ts
+++ b/apps/backend/src/jobs/short-close-stale-production-runs.ts
@@ -1,0 +1,102 @@
+import type { MedusaContainer } from "@medusajs/framework/types"
+import { ContainerRegistrationKeys } from "@medusajs/framework/utils"
+
+import {
+  findRunsDueForShortClose,
+  shortCloseProductionRun,
+  SHORT_CLOSE_AFTER_DAYS,
+} from "../workflows/production-runs/lib/short-close-production-run"
+
+/**
+ * The 30-day counter (#1596).
+ *
+ * A run ordered for 9 and completed at 7 keeps 2 units billable, because the
+ * write guard's ceiling is the ORDERED quantity and that number cannot tell
+ * "not made yet" from "never will be made". Left alone those tails never close:
+ * nobody goes looking for a two-unit remainder on a run that finished months
+ * ago, and the screens keep offering it.
+ *
+ * The founder's decision (2026-08-30): close it explicitly, and on a counter
+ * "after seeing what's produced after a period of time". This is the counter —
+ * 30 days of silence after the last sign of production, then the ceiling
+ * becomes what was actually made.
+ *
+ * ## Why this one WRITES, when the neighbouring watchers do not
+ *
+ * `check-inventory-level-divergence` refuses to resolve anything because
+ * neither side of its comparison is authoritative — picking a winner is a
+ * judgement about what really happened. Here there is no such ambiguity: the
+ * produced quantity is a figure the partner reported and an admin can correct,
+ * and 30 days of silence after it is the statement. The decision is also
+ * cheaply reversible, which the divergence case is not.
+ *
+ * 🔴 The safeguards are in `shortCloseDecision`, and they are the point:
+ * a run with no output figure, or one reporting ZERO produced, is never closed
+ * by the counter — that would wipe a claim on the strength of a number nobody
+ * confirmed. A run whose last output CORRECTION is recent is not closed either,
+ * however long ago it completed; the counter waits for the evidence it exists
+ * to see. And an upward correction on a closed run reopens it automatically.
+ *
+ * ⚠️ Nothing is clawed back. A run legitimately billed to 7 and then closed at
+ * 4 keeps those 7 — `billable_remaining` clamps at zero and the write guard
+ * refuses anything further. The log names those runs so a human can look.
+ */
+export default async function shortCloseStaleProductionRuns(
+  container: MedusaContainer
+) {
+  const logger = container.resolve(ContainerRegistrationKeys.LOGGER)
+
+  try {
+    const { due, scanned, skipped } = await findRunsDueForShortClose(container)
+
+    /**
+     * ⚠️ The denominator and the skip reasons are logged on EVERY run. A sweep
+     * that closed nothing because there was nothing to close and one that
+     * closed nothing because it could not read a single run print identical
+     * lines otherwise — the shape of #1208's "success" on 42 broken migrations.
+     */
+    logger.info(
+      `[short-close-runs] scanned ${scanned} completed run(s); ${due.length} due after ${SHORT_CLOSE_AFTER_DAYS}d; skipped ${JSON.stringify(skipped)}`
+    )
+
+    if (!due.length) {
+      return
+    }
+
+    let closed = 0
+    const refused: string[] = []
+
+    for (const run of due) {
+      try {
+        const outcome = await shortCloseProductionRun(container, {
+          run_id: String(run.id),
+          actor_id: "system",
+          actor_type: "system",
+          reason: `No further output recorded for ${SHORT_CLOSE_AFTER_DAYS} days`,
+        })
+        if (outcome.closed) {
+          closed += 1
+        } else {
+          refused.push(`${run.id}:${outcome.reason}`)
+        }
+      } catch (e: any) {
+        // One bad run must not stop the sweep — and must not vanish either.
+        refused.push(`${run.id}:error(${e?.message ?? "unknown"})`)
+      }
+    }
+
+    logger.info(
+      `[short-close-runs] closed ${closed} of ${due.length}` +
+        (refused.length ? `; not closed: ${refused.join(", ")}` : "")
+    )
+  } catch (e: any) {
+    logger.error(`[short-close-runs] Error: ${e?.message}`)
+  }
+}
+
+export const config = {
+  name: "short-close-stale-production-runs",
+  // Daily, 04:00 UTC — before the divergence watcher, and well outside the
+  // window anyone is editing runs.
+  schedule: "0 4 * * *",
+}

--- a/apps/backend/src/modules/production_runs/migrations/Migration20260830150000.ts
+++ b/apps/backend/src/modules/production_runs/migrations/Migration20260830150000.ts
@@ -1,0 +1,54 @@
+import { Migration } from "@mikro-orm/migrations";
+
+/**
+ * #1596 — short-close a production run.
+ *
+ * A run ordered for 9 and completed at 7 keeps 2 units billable forever: the
+ * write guard's ceiling is the ORDERED quantity, and that number cannot tell
+ * "not made yet" from "never will be made". These columns carry the statement
+ * that settles it, after which the ceiling is the produced quantity instead.
+ *
+ * Typed columns, not metadata: this decides how much a partner may still claim
+ * (#1557 — a metadata blob is not a contract).
+ *
+ * All nullable and defaulted to NULL, so every existing run reads exactly as it
+ * did before: not short-closed, billable to its ordered quantity.
+ */
+export class Migration20260830150000 extends Migration {
+
+  override async up(): Promise<void> {
+    this.addSql(`
+      alter table if exists "production_runs"
+        add column if not exists "short_closed_at" timestamptz null,
+        add column if not exists "short_closed_by" text null,
+        add column if not exists "short_close_reason" text null,
+        add column if not exists "short_closed_quantity" numeric(20,6) null;
+    `);
+
+    // The counter sweeps for completed, not-yet-closed runs; this keeps that
+    // scan off a full table read as the run table grows.
+    this.addSql(`
+      create index if not exists "IDX_production_runs_short_close_sweep"
+        on "production_runs" ("status", "short_closed_at")
+        where "deleted_at" is null;
+    `);
+  }
+
+  /**
+   * Reversible: dropping the columns restores the ordered-quantity ceiling for
+   * every run, which is exactly the pre-migration behaviour. It DOES discard
+   * the record of who closed what and why — acceptable only because nothing
+   * downstream stores a decision that depends on it.
+   */
+  override async down(): Promise<void> {
+    this.addSql(`drop index if exists "IDX_production_runs_short_close_sweep";`);
+    this.addSql(`
+      alter table if exists "production_runs"
+        drop column if exists "short_closed_at",
+        drop column if exists "short_closed_by",
+        drop column if exists "short_close_reason",
+        drop column if exists "short_closed_quantity";
+    `);
+  }
+
+}

--- a/apps/backend/src/modules/production_runs/models/production-run.ts
+++ b/apps/backend/src/modules/production_runs/models/production-run.ts
@@ -62,6 +62,26 @@ const ProductionRun = model.define("production_runs", {
   rejection_reason: model.text().translatable().nullable(),
   rejection_notes: model.text().translatable().nullable(),
 
+  /**
+   * #1596 — SHORT CLOSE. A run ordered for 9 and completed at 7 keeps 2 units
+   * billable, because ordered-quantity headroom cannot tell "not made yet"
+   * from "never will be made". This is the statement that settles it: from
+   * here the billable ceiling is what was PRODUCED, not what was ordered.
+   *
+   * Typed columns rather than metadata: this decides how much money a partner
+   * may still claim, and a metadata blob is not a contract (#1557).
+   *
+   * `short_closed_by` is an admin actor id, or the literal "system" when the
+   * 30-day counter closed it. `short_closed_quantity` records what produced
+   * was BELIEVED to be at the moment of closing — the ceiling itself is always
+   * re-derived from the live `produced_quantity`, so a later upward correction
+   * is honoured rather than frozen out.
+   */
+  short_closed_at: model.dateTime().nullable(),
+  short_closed_by: model.text().nullable(),
+  short_close_reason: model.text().nullable(),
+  short_closed_quantity: model.float().nullable(),
+
   // Cost
   partner_cost_estimate: model.float().nullable(),
   cost_type: model.enum(["per_unit", "total"]).default("total").nullable(),

--- a/apps/backend/src/workflows/payment_submissions/create-payment-submission.ts
+++ b/apps/backend/src/workflows/payment_submissions/create-payment-submission.ts
@@ -785,6 +785,12 @@ const validateDesignsForSubmissionStep = createStep(
            */
           "quantity",
           "produced_quantity",
+          /**
+           * #1596 short-close — `runBillableCeiling` reads it. Without it here
+           * the ceiling silently stays the ORDERED quantity and every short
+           * close is ignored on this path.
+           */
+          "short_closed_at",
           "partner_cost_estimate",
           "cost_type",
         ],
@@ -1190,6 +1196,9 @@ const validateRunLinesStep = createStep(
         "status",
         "quantity",
         "produced_quantity",
+        // #1596 short-close — read by `runBillableCeiling` inside
+        // `assessRunClaims` below. Omit it and every close is ignored here.
+        "short_closed_at",
         "partner_cost_estimate",
         "cost_type",
         "order_id",

--- a/apps/backend/src/workflows/payment_submissions/lib/__tests__/run-billable-ceiling.unit.spec.ts
+++ b/apps/backend/src/workflows/payment_submissions/lib/__tests__/run-billable-ceiling.unit.spec.ts
@@ -1,0 +1,81 @@
+import { runBillableCeiling } from "../run-billable-ceiling"
+
+/**
+ * #1596 short-close. The ceiling decides how much a partner may still claim, so
+ * the cases that matter are the ones where it must NOT move.
+ */
+describe("runBillableCeiling", () => {
+  it("is the ORDERED quantity while the run is open, even when less was produced", () => {
+    // The whole reason short-close exists: produced is captured at completion
+    // and more can legitimately follow, so 7-of-9 keeps 2 units billable.
+    expect(
+      runBillableCeiling({ quantity: 9, produced_quantity: 7 })
+    ).toBe(9)
+  })
+
+  it("becomes the PRODUCED quantity once short-closed", () => {
+    expect(
+      runBillableCeiling({
+        quantity: 9,
+        produced_quantity: 7,
+        short_closed_at: new Date("2026-08-30"),
+      })
+    ).toBe(7)
+  })
+
+  it("does not reduce a closed run whose output figure cannot be read", () => {
+    // An absent number must never quietly cost a partner their claim.
+    expect(
+      runBillableCeiling({
+        quantity: 9,
+        produced_quantity: null,
+        short_closed_at: new Date("2026-08-30"),
+      })
+    ).toBe(9)
+    expect(
+      runBillableCeiling({
+        quantity: 9,
+        produced_quantity: 0,
+        short_closed_at: new Date("2026-08-30"),
+      })
+    ).toBe(9)
+  })
+
+  it("never raises the ceiling above what was ordered, even if more was produced", () => {
+    expect(
+      runBillableCeiling({
+        quantity: 9,
+        produced_quantity: 12,
+        short_closed_at: new Date("2026-08-30"),
+      })
+    ).toBe(9)
+  })
+
+  it("returns null when the run states no ordered quantity — no ceiling is a refusal, not room", () => {
+    expect(runBillableCeiling({ quantity: null })).toBeNull()
+    expect(runBillableCeiling({ quantity: 0 })).toBeNull()
+    expect(runBillableCeiling(null)).toBeNull()
+  })
+
+  it("reports a ceiling BELOW what may already have been billed, rather than hiding it", () => {
+    // Ordered 9, billed 7 under the open ceiling, then closed at 4. There is no
+    // clawback: the ceiling is honest and the write guard refuses anything more.
+    expect(
+      runBillableCeiling({
+        quantity: 9,
+        produced_quantity: 4,
+        short_closed_at: new Date("2026-08-30"),
+      })
+    ).toBe(4)
+  })
+
+  it("accepts the string quantities the DB hands back for numeric columns", () => {
+    expect(
+      runBillableCeiling({
+        quantity: "9",
+        produced_quantity: "7",
+        short_closed_at: "2026-08-30T00:00:00.000Z",
+      })
+    ).toBe(7)
+  })
+})

--- a/apps/backend/src/workflows/payment_submissions/lib/run-billable-ceiling.ts
+++ b/apps/backend/src/workflows/payment_submissions/lib/run-billable-ceiling.ts
@@ -1,0 +1,77 @@
+/**
+ * How many units of a run may be billed IN TOTAL.
+ *
+ * ## Why this is its own function
+ *
+ * The ceiling was the run's ORDERED quantity, read in three separate places —
+ * `listRunOrderedQuantities` (submit + update guards), `create-payment-submission`
+ * step 6, and `runBillableRemaining` on the payable-runs screen. Three readers
+ * of one rule is how a fix lands on two of them (#1662, #1616). Short-close
+ * changes that rule, so it gets one home first.
+ *
+ * ## The rule
+ *
+ * Ordered quantity, until somebody says no more will be made. A run ordered for
+ * 9 and completed at 7 keeps 2 units billable on purpose: `produced_quantity`
+ * is captured at completion and a run can legitimately produce more afterwards
+ * — that is what the audited correction route exists for. Inferring the close
+ * from `produced < ordered` would refuse a correction the system is built to
+ * accept.
+ *
+ * Once short-closed, the ceiling is what was PRODUCED.
+ *
+ * 🔴 Two things it deliberately does NOT do:
+ *
+ * 1. It never returns a ceiling BELOW what has already been claimed. Closing a
+ *    run at 4 that was legitimately billed to 7 (ordered 9) cannot un-bill
+ *    those 3 units — no clawback lives here. The caller clamps its remainder at
+ *    zero; this function reports the honest ceiling and lets `assessRunClaims`
+ *    refuse anything further.
+ * 2. It never reduces on missing data. A short-closed run whose
+ *    `produced_quantity` cannot be read falls back to the ordered quantity: an
+ *    absent number must not quietly cost a partner their claim, which is the
+ *    mirror of the rule everywhere else in this module — absence is never
+ *    permission, and it is never a penalty either.
+ */
+
+export type RunCeilingInput = {
+  /** Ordered quantity — `production_runs.quantity`. */
+  quantity?: number | string | null
+  produced_quantity?: number | string | null
+  short_closed_at?: Date | string | null
+}
+
+const finitePositive = (value: unknown): number | null => {
+  const n = Number(value)
+  return Number.isFinite(n) && n > 0 ? n : null
+}
+
+/**
+ * PURE. The total units billable for a run, or null when no ceiling can be
+ * read at all — which every guard treats as a refusal, not as room.
+ */
+export const runBillableCeiling = (run: RunCeilingInput | null | undefined): number | null => {
+  if (!run) {
+    return null
+  }
+
+  const ordered = finitePositive(run.quantity)
+
+  if (!run.short_closed_at) {
+    return ordered
+  }
+
+  const produced = finitePositive(run.produced_quantity)
+  if (produced == null) {
+    // Closed, but with no readable output figure. Do not invent a reduction.
+    return ordered
+  }
+
+  // A close can only ever LOWER the ceiling. If produced somehow exceeds what
+  // was ordered, the ordered quantity is still what was agreed to be paid for.
+  return ordered == null ? produced : Math.min(ordered, produced)
+}
+
+/** Whether a run has been declared finished-for-good. */
+export const isShortClosed = (run: RunCeilingInput | null | undefined): boolean =>
+  !!run?.short_closed_at

--- a/apps/backend/src/workflows/payment_submissions/lib/run-billing.ts
+++ b/apps/backend/src/workflows/payment_submissions/lib/run-billing.ts
@@ -165,7 +165,13 @@ export type RunBillingStatus =
  */
 export const runBillableRemaining = (input: {
   claim: RunBillingClaim | null | undefined
-  /** The run's ORDERED quantity — the ceiling the write guard uses. */
+  /**
+   * The run's BILLABLE CEILING — `runBillableCeiling(run)`, which is the
+   * ordered quantity until the run is short-closed and the produced quantity
+   * after (#1596). It must be the same number `assessRunClaims` compares
+   * against: a screen offering units the write guard will refuse is the defect
+   * this field exists to prevent.
+   */
   ordered: number | string | null | undefined
 }): number | null => {
   const claim = input.claim
@@ -173,12 +179,15 @@ export const runBillableRemaining = (input: {
     return null
   }
 
-  const ordered = Number(input.ordered)
-  if (!Number.isFinite(ordered) || ordered <= 0) {
+  const ceiling = Number(input.ordered)
+  if (!Number.isFinite(ceiling) || ceiling <= 0) {
     return null
   }
 
-  return Math.max(0, ordered - claim.claimed_quantity)
+  // Clamped at zero on purpose. A run short-closed BELOW what was already
+  // legitimately billed leaves no remainder and no clawback — a negative here
+  // would read as a debt somebody owes back.
+  return Math.max(0, ceiling - claim.claimed_quantity)
 }
 
 /**

--- a/apps/backend/src/workflows/payment_submissions/lib/run-claims.ts
+++ b/apps/backend/src/workflows/payment_submissions/lib/run-claims.ts
@@ -40,6 +40,7 @@
  */
 
 import { ContainerRegistrationKeys } from "@medusajs/framework/utils"
+import { runBillableCeiling } from "./run-billable-ceiling"
 
 export type PriorRunLine = {
   submission_id: string | null
@@ -293,6 +294,18 @@ export function requestedRunQuantities(
   return requested
 }
 
+/**
+ * What a run may be billed to, plus the figures it was derived from. The
+ * `ceiling` is the number every guard must compare against — `quantity` alone
+ * stopped being the answer when short-close arrived (#1596).
+ */
+export type RunCeiling = {
+  quantity?: number | string | null
+  produced_quantity?: number | string | null
+  short_closed_at?: Date | string | null
+  ceiling: number | null
+}
+
 export type OverclaimedRun = {
   run_id: string
   /** Units the run is worth: its ORDERED quantity. */
@@ -326,17 +339,64 @@ export type OverclaimedRun = {
 export function assessRunClaims(input: {
   /** Units requested per run, or null where the request cannot be attributed. */
   requestedByRun: Map<string, number | null>
-  runs: Map<string, { quantity?: number | string | null }>
+  /**
+   * The runs' BILLABLE CEILINGS. A caller may pass the raw run rows — the
+   * ceiling is re-derived from them when it is absent — but passing a bare
+   * `{ quantity }` after a short close would read the ordered figure and
+   * ignore the close, so the derivation lives here rather than at each call.
+   */
+  runs: Map<string, Partial<RunCeiling>>
   tallies: Map<string, RunClaimTally>
 }): OverclaimedRun[] {
   const overclaimed: OverclaimedRun[] = []
 
   for (const [runId, requested] of input.requestedByRun) {
     const tally = input.tallies.get(runId)
-    if (!tally) continue // nobody has claimed it — nothing to diff against.
+    const row = input.runs.get(runId)
 
-    const ordered = Number(input.runs.get(runId)?.quantity)
-    const ceiling = Number.isFinite(ordered) && ordered > 0 ? ordered : 0
+    if (!tally) {
+      /**
+       * Nobody has claimed it, so there is nothing to diff against — and a
+       * FIRST claim has never been compared to the run's own quantity. That is
+       * long-standing behaviour and is deliberately left alone here: a run can
+       * legitimately overproduce, and `payable-runs` offers the produced
+       * figure, so refusing on the ordered quantity would start rejecting
+       * honest claims.
+       *
+       * 🔴 Except once the run is SHORT-CLOSED (#1596). That is somebody
+       * stating outright that no more will be made, and it is the only reason
+       * the feature exists: without this branch a closed run's first claim
+       * could still bill the full ordered quantity and the close would mean
+       * nothing at all.
+       */
+      // ⚠️ Derive, never read `row.ceiling` directly: `create` passes RAW run
+      // rows whose `ceiling` is undefined, so reading the field would quietly
+      // skip this branch on the very path that creates most claims.
+      const closedCeiling = row?.short_closed_at
+        ? row.ceiling !== undefined
+          ? row.ceiling
+          : runBillableCeiling(row)
+        : null
+      if (
+        closedCeiling != null &&
+        requested != null &&
+        requested > closedCeiling + 0.005
+      ) {
+        overclaimed.push({
+          run_id: runId,
+          ceiling: closedCeiling,
+          claimed_quantity: 0,
+          claimed_wholly: false,
+          requested,
+          claims: [],
+        })
+      }
+      continue
+    }
+
+    const derived =
+      row?.ceiling !== undefined ? row.ceiling : runBillableCeiling(row)
+    const ceiling = derived != null && derived > 0 ? derived : 0
 
     const refuse = () =>
       overclaimed.push({
@@ -506,21 +566,32 @@ export async function listPartnerPriorLines(
 export async function listRunOrderedQuantities(
   container: { resolve: (key: string) => any },
   runIds: string[]
-): Promise<Map<string, { quantity?: number | string | null }>> {
+): Promise<Map<string, RunCeiling>> {
   const ids = [...new Set((runIds || []).filter(Boolean).map(String))]
   if (!ids.length) return new Map()
 
   const query: any = container.resolve(ContainerRegistrationKeys.QUERY)
   const { data } = await query.graph({
     entity: "production_runs",
-    fields: ["id", "quantity"],
+    /**
+     * ⚠️ `produced_quantity` and `short_closed_at` are fetched because
+     * `runBillableCeiling` reads them (#1596). A guard reading a field the
+     * query never asked for always sees `undefined` — here that would silently
+     * ignore every short close and keep offering units nobody will make.
+     */
+    fields: ["id", "quantity", "produced_quantity", "short_closed_at"],
     filters: { id: ids },
   })
 
   return new Map(
     ((data || []) as any[]).map((run) => [
       String(run.id),
-      { quantity: run.quantity },
+      {
+        quantity: run.quantity,
+        produced_quantity: run.produced_quantity,
+        short_closed_at: run.short_closed_at,
+        ceiling: runBillableCeiling(run),
+      },
     ])
   )
 }

--- a/apps/backend/src/workflows/production-runs/lib/__tests__/short-close-production-run.unit.spec.ts
+++ b/apps/backend/src/workflows/production-runs/lib/__tests__/short-close-production-run.unit.spec.ts
@@ -1,0 +1,146 @@
+import { shortCloseDecision } from "../short-close-production-run"
+
+/**
+ * #1596 short-close, the counter's half. This reduces what a partner may
+ * claim, automatically, so the cases that matter most are the ones where it
+ * must NOT fire.
+ */
+const asOf = new Date("2026-08-30T00:00:00.000Z")
+const daysAgo = (n: number) =>
+  new Date(asOf.getTime() - n * 86_400_000).toISOString()
+
+const completedRun = (over: Record<string, any> = {}) => ({
+  id: "run_1",
+  status: "completed",
+  quantity: 9,
+  produced_quantity: 7,
+  short_closed_at: null,
+  completed_at: daysAgo(31),
+  ...over,
+})
+
+describe("shortCloseDecision (#1596)", () => {
+  it("closes a run that produced less than ordered and has been quiet 30 days", () => {
+    expect(
+      shortCloseDecision({ run: completedRun(), lastOutputAt: null, asOf })
+    ).toBe("due")
+  })
+
+  it("waits while the run is still inside the window", () => {
+    expect(
+      shortCloseDecision({
+        run: completedRun({ completed_at: daysAgo(29) }),
+        lastOutputAt: null,
+        asOf,
+      })
+    ).toBe("too_recent")
+  })
+
+  it("measures from the LAST OUTPUT CORRECTION, not from completion", () => {
+    // Completed 90 days ago, but somebody corrected the output yesterday.
+    // Closing now would ignore exactly the evidence the counter is meant to
+    // wait for.
+    expect(
+      shortCloseDecision({
+        run: completedRun({ completed_at: daysAgo(90) }),
+        lastOutputAt: daysAgo(1),
+        asOf,
+      })
+    ).toBe("too_recent")
+  })
+
+  it("never closes a run with no output figure", () => {
+    expect(
+      shortCloseDecision({
+        run: completedRun({ produced_quantity: null }),
+        lastOutputAt: null,
+        asOf,
+      })
+    ).toBe("no_output_figure")
+  })
+
+  it("never closes a run that reported ZERO produced — that needs a human", () => {
+    // Closing at 0 would wipe the whole claim on the strength of a number
+    // nobody confirmed.
+    expect(
+      shortCloseDecision({
+        run: completedRun({ produced_quantity: 0 }),
+        lastOutputAt: null,
+        asOf,
+      })
+    ).toBe("no_output_figure")
+  })
+
+  it("does not close a run that produced everything it was ordered for", () => {
+    expect(
+      shortCloseDecision({
+        run: completedRun({ produced_quantity: 9 }),
+        lastOutputAt: null,
+        asOf,
+      })
+    ).toBe("nothing_to_close")
+  })
+
+  it("does not close a run that produced MORE than ordered", () => {
+    expect(
+      shortCloseDecision({
+        run: completedRun({ produced_quantity: 12 }),
+        lastOutputAt: null,
+        asOf,
+      })
+    ).toBe("nothing_to_close")
+  })
+
+  it("leaves an already-closed run alone, so a retry cannot re-stamp it", () => {
+    expect(
+      shortCloseDecision({
+        run: completedRun({ short_closed_at: daysAgo(2) }),
+        lastOutputAt: null,
+        asOf,
+      })
+    ).toBe("already_closed")
+  })
+
+  it("ignores runs that are not completed", () => {
+    for (const status of ["in_progress", "cancelled", "draft", "approved"]) {
+      expect(
+        shortCloseDecision({
+          run: completedRun({ status }),
+          lastOutputAt: null,
+          asOf,
+        })
+      ).toBe("not_completed")
+    }
+  })
+
+  it("does not treat a MISSING date as 'long ago'", () => {
+    expect(
+      shortCloseDecision({
+        run: completedRun({ completed_at: null }),
+        lastOutputAt: null,
+        asOf,
+      })
+    ).toBe("no_clock")
+  })
+
+  it("refuses a run with no readable ordered quantity rather than guessing one", () => {
+    expect(
+      shortCloseDecision({
+        run: completedRun({ quantity: null }),
+        lastOutputAt: null,
+        asOf,
+      })
+    ).toBe("nothing_to_close")
+  })
+
+  it("honours a caller-supplied window", () => {
+    expect(
+      shortCloseDecision({
+        run: completedRun({ completed_at: daysAgo(20) }),
+        lastOutputAt: null,
+        asOf,
+        afterDays: 14,
+      })
+    ).toBe("due")
+  })
+})

--- a/apps/backend/src/workflows/production-runs/lib/short-close-production-run.ts
+++ b/apps/backend/src/workflows/production-runs/lib/short-close-production-run.ts
@@ -1,0 +1,342 @@
+import { ContainerRegistrationKeys } from "@medusajs/framework/utils"
+import { MedusaContainer } from "@medusajs/framework/types"
+import { PRODUCTION_RUNS_MODULE } from "../../../modules/production_runs"
+
+/**
+ * SHORT CLOSE — "no more of this run will ever be made" (#1596).
+ *
+ * ## Why a run needs closing at all
+ *
+ * The billable ceiling is the run's ORDERED quantity, deliberately: output is
+ * captured at completion and a run can legitimately produce more afterwards,
+ * which is what the audited correction route exists for. The cost of that is a
+ * run ordered for 9 and completed at 7 keeping 2 units billable forever —
+ * ordered-quantity headroom cannot tell "not made yet" from "never will be".
+ *
+ * Two things close it, per the founder (2026-08-30):
+ *
+ *   1. an explicit admin action, and
+ *   2. a counter — after 30 days with no further sign of production, having
+ *      seen what was actually made.
+ *
+ * ## What closing does and does not do
+ *
+ * It moves the ceiling from ordered to produced. It does NOT claw anything
+ * back: a run legitimately billed to 7 and then closed at 4 keeps those 7,
+ * `billable_remaining` clamps at 0, and the write guard refuses anything more.
+ * There is no route here that un-pays a partner, and there should not be.
+ *
+ * 🔴 It is reversible, and reversal matters more than the close. An upward
+ * output correction on a closed run REOPENS it automatically — the close said
+ * "nothing more was made", and a correction is the evidence that it was wrong.
+ * Anything else would let a 30-day timer permanently cap a partner's claim on
+ * the strength of a figure that has since changed.
+ */
+
+export const SHORT_CLOSE_AFTER_DAYS = 30
+
+export type ShortCloseCandidate = {
+  id: string
+  status?: string | null
+  quantity?: number | string | null
+  produced_quantity?: number | string | null
+  short_closed_at?: Date | string | null
+  completed_at?: Date | string | null
+}
+
+const finite = (value: unknown): number | null => {
+  const n = Number(value)
+  return Number.isFinite(n) ? n : null
+}
+
+const asTime = (value: Date | string | null | undefined): number | null => {
+  if (!value) return null
+  const t = new Date(value).getTime()
+  return Number.isFinite(t) ? t : null
+}
+
+export type DueReason =
+  | "due"
+  | "already_closed"
+  | "not_completed"
+  | "no_output_figure"
+  | "nothing_to_close"
+  | "no_clock"
+  | "too_recent"
+
+/**
+ * PURE: should the counter close this run?
+ *
+ * `lastOutputAt` is the most recent sign of production — the later of the run's
+ * completion and its last audited output correction. Measuring from completion
+ * alone would close a run 30 days after it finished even if somebody corrected
+ * its output yesterday, which is precisely the case the founder described
+ * wanting to see first.
+ */
+export const shortCloseDecision = (input: {
+  run: ShortCloseCandidate
+  lastOutputAt: Date | string | null | undefined
+  asOf: Date
+  afterDays?: number
+}): DueReason => {
+  const { run } = input
+
+  if (run.short_closed_at) {
+    return "already_closed"
+  }
+  if (String(run.status || "") !== "completed") {
+    return "not_completed"
+  }
+
+  const produced = finite(run.produced_quantity)
+  // No figure, or a zero one. Closing at 0 would wipe a partner's whole claim
+  // on the strength of a number nobody confirmed — that needs a human, not a
+  // timer. Absence is not permission here, and it is not a penalty either.
+  if (produced == null || produced <= 0) {
+    return "no_output_figure"
+  }
+
+  const ordered = finite(run.quantity)
+  if (ordered == null || ordered <= 0 || produced >= ordered) {
+    // Nothing to close: the ceiling would not move.
+    return "nothing_to_close"
+  }
+
+  const since = asTime(input.lastOutputAt) ?? asTime(run.completed_at)
+  if (since == null) {
+    // A completed run with no completion timestamp has no clock to run. Do not
+    // treat a missing date as "long ago".
+    return "no_clock"
+  }
+
+  const days = (input.asOf.getTime() - since) / 86_400_000
+  return days >= (input.afterDays ?? SHORT_CLOSE_AFTER_DAYS) ? "due" : "too_recent"
+}
+
+/**
+ * Close a run. Idempotent: a run already closed is returned untouched rather
+ * than re-stamped, so a retrying job cannot rewrite who closed it or when.
+ */
+export const shortCloseProductionRun = async (
+  container: MedusaContainer,
+  input: {
+    run_id: string
+    /** Admin actor id, or "system" when the counter did it. */
+    actor_id: string
+    actor_type: "admin" | "system"
+    reason?: string | null
+  }
+): Promise<{ closed: boolean; run: any; reason: string }> => {
+  const service: any = container.resolve(PRODUCTION_RUNS_MODULE)
+  const run = await service.retrieveProductionRun(input.run_id)
+
+  if (run.short_closed_at) {
+    return { closed: false, run, reason: "already_closed" }
+  }
+
+  const produced = finite(run.produced_quantity)
+  if (produced == null || produced <= 0) {
+    // The explicit path refuses too. A close with no output figure would set a
+    // ceiling of "ordered" anyway (see `runBillableCeiling`), so it would be a
+    // decision that changes nothing while looking like it changed something.
+    return { closed: false, run, reason: "no_output_figure" }
+  }
+
+  const [updated] = await service.updateProductionRuns([
+    {
+      id: input.run_id,
+      short_closed_at: new Date(),
+      short_closed_by: input.actor_id,
+      short_close_reason: input.reason ?? null,
+      short_closed_quantity: produced,
+    },
+  ])
+
+  // Audit. Best-effort: the close is already persisted and must not be rolled
+  // back because a timeline write failed.
+  try {
+    await service.createProductionRunActivities({
+      production_run_id: input.run_id,
+      activity_type: "note",
+      kind: "short_closed",
+      actor_type: input.actor_type,
+      actor_id: input.actor_id,
+      partner_id: run.partner_id ?? null,
+      channel: null,
+      message_id: null,
+      template_name: null,
+      recipient: null,
+      summary: `Run short-closed at ${produced} of ${run.quantity ?? "—"} ordered — no further output expected.`,
+      payload: {
+        reason: input.reason ?? null,
+        ordered_quantity: run.quantity ?? null,
+        produced_quantity: produced,
+        source: input.actor_type === "system" ? "counter" : "admin",
+      },
+    })
+  } catch {
+    /* audit is best-effort */
+  }
+
+  return { closed: true, run: updated ?? run, reason: "closed" }
+}
+
+/**
+ * Reopen a run — the close was premature, or more work is coming.
+ *
+ * Called explicitly by an admin, and automatically when an output correction
+ * raises `produced_quantity` on a closed run.
+ */
+export const reopenProductionRun = async (
+  container: MedusaContainer,
+  input: {
+    run_id: string
+    actor_id: string
+    actor_type: "admin" | "system"
+    reason?: string | null
+  }
+): Promise<{ reopened: boolean; run: any }> => {
+  const service: any = container.resolve(PRODUCTION_RUNS_MODULE)
+  const run = await service.retrieveProductionRun(input.run_id)
+
+  if (!run.short_closed_at) {
+    return { reopened: false, run }
+  }
+
+  const [updated] = await service.updateProductionRuns([
+    {
+      id: input.run_id,
+      short_closed_at: null,
+      short_closed_by: null,
+      short_close_reason: null,
+      // `short_closed_quantity` is left in place deliberately: it records what
+      // was believed at the time of a decision that really happened.
+    },
+  ])
+
+  try {
+    await service.createProductionRunActivities({
+      production_run_id: input.run_id,
+      activity_type: "note",
+      kind: "short_close_reopened",
+      actor_type: input.actor_type,
+      actor_id: input.actor_id,
+      partner_id: run.partner_id ?? null,
+      channel: null,
+      message_id: null,
+      template_name: null,
+      recipient: null,
+      summary: `Short close reversed — the run is billable to its ordered quantity again.`,
+      payload: {
+        reason: input.reason ?? null,
+        was_closed_at: run.short_closed_at ?? null,
+        was_closed_quantity: run.short_closed_quantity ?? null,
+      },
+    })
+  } catch {
+    /* audit is best-effort */
+  }
+
+  return { reopened: true, run: updated ?? run }
+}
+
+/**
+ * The most recent sign of production per run: the later of completion and the
+ * last audited output correction.
+ */
+export const lastOutputSignalByRun = async (
+  container: MedusaContainer,
+  runIds: string[]
+): Promise<Map<string, Date>> => {
+  const byRun = new Map<string, Date>()
+  const ids = [...new Set((runIds || []).filter(Boolean).map(String))]
+  if (!ids.length) {
+    return byRun
+  }
+
+  const service: any = container.resolve(PRODUCTION_RUNS_MODULE)
+  try {
+    const activities = await service.listProductionRunActivities({
+      production_run_id: ids,
+      kind: "output_corrected",
+    })
+    for (const activity of (activities || []) as any[]) {
+      const runId = String(activity.production_run_id || "")
+      const at = activity.created_at ? new Date(activity.created_at) : null
+      if (!runId || !at || !Number.isFinite(at.getTime())) {
+        continue
+      }
+      const existing = byRun.get(runId)
+      if (!existing || at > existing) {
+        byRun.set(runId, at)
+      }
+    }
+  } catch {
+    // No activity history available ⇒ fall back to completion, which the
+    // decision does on its own. Never treat this as "no corrections ever".
+  }
+
+  return byRun
+}
+
+/**
+ * Every completed run the counter should close, as of `asOf`.
+ *
+ * Reports what it SKIPPED as well as what is due — a sweep that silently
+ * narrows its own candidate set reads as "nothing to do" when it means "I
+ * could not tell".
+ */
+export const findRunsDueForShortClose = async (
+  container: MedusaContainer,
+  options: { asOf?: Date; afterDays?: number; limit?: number } = {}
+): Promise<{
+  due: ShortCloseCandidate[]
+  scanned: number
+  skipped: Record<string, number>
+}> => {
+  const query: any = container.resolve(ContainerRegistrationKeys.QUERY)
+  const asOf = options.asOf ?? new Date()
+
+  const { data } = await query.graph({
+    entity: "production_runs",
+    fields: [
+      "id",
+      "status",
+      "quantity",
+      "produced_quantity",
+      "short_closed_at",
+      "completed_at",
+      "partner_id",
+    ],
+    filters: { status: "completed" },
+  })
+
+  const runs = (Array.isArray(data) ? data : []) as ShortCloseCandidate[]
+  const signals = await lastOutputSignalByRun(
+    container,
+    runs.map((r) => String(r.id))
+  )
+
+  const due: ShortCloseCandidate[] = []
+  const skipped: Record<string, number> = {}
+
+  for (const run of runs) {
+    const verdict = shortCloseDecision({
+      run,
+      lastOutputAt: signals.get(String(run.id)) ?? run.completed_at,
+      asOf,
+      afterDays: options.afterDays,
+    })
+    if (verdict === "due") {
+      due.push(run)
+      continue
+    }
+    skipped[verdict] = (skipped[verdict] ?? 0) + 1
+  }
+
+  return {
+    due: options.limit ? due.slice(0, options.limit) : due,
+    scanned: runs.length,
+    skipped,
+  }
+}


### PR DESCRIPTION
Last of the three items on #1596. A run ordered for 9 and completed at 7 kept 2 units billable forever — the ceiling is the ORDERED quantity, and that number cannot tell *"not made yet"* from *"never will be made"*.

Per your call (2026-08-30): **explicit close, plus a 30-day counter after seeing what was produced.** Once closed, the ceiling is the produced quantity.

## One home for the ceiling, first

It was read in three places — the submit/update guards via `listRunOrderedQuantities`, `create` step 6, and `runBillableRemaining` on both payable-runs screens. A rule with three readers is how a fix lands on two of them, so `runBillableCeiling` is now the single home and `assessRunClaims` compares against a ceiling rather than re-deriving one per caller.

⚠️ `short_closed_at` had to be added to **four** separate graph queries. A field the query never fetches makes a guard that silently ignores every close — I hit exactly that mid-build.

## 🔴 A defect this surfaced

`assessRunClaims` skips any run with no prior claim (*"nothing to diff against"*), so a **first** claim has never been compared to the run's own quantity. Short-close would have meant nothing — a closed run's first claim could still bill the full ordered amount.

Now checked, but **only for a short-closed run**: a run can legitimately overproduce and `payable-runs` offers the produced figure, so enforcing the ordered quantity on every first claim would start refusing honest ones. Filed as **#1676** with the data question that has to be answered first.

## The counter's safeguards are the point

All unit-tested, because this reduces what a partner can claim, automatically:

- a run with **no output figure**, or reporting **zero produced**, is never closed by the counter — that would wipe a claim on a number nobody confirmed;
- the clock runs from the **last output correction**, not from completion, so a run corrected yesterday is not closed because it finished in May;
- a missing timestamp is not read as *"long ago"*;
- an **upward correction on a closed run reopens it automatically** — the close said nothing more was made, and a correction is the evidence it was wrong.

## What it does not do

Claw anything back. A run legitimately billed to 7 and then closed at 4 keeps those 7; `billable_remaining` clamps at zero and the guard refuses more. There is no route here that un-pays a partner.

## Surface

- `POST /admin/production-runs/:id/short-close` — refuses a run with no recorded output rather than performing a close that would change nothing.
- `DELETE /admin/production-runs/:id/short-close` — reopen.
- `short-close-stale-production-runs` job, daily 04:00 UTC. Logs the denominator and every skip reason on each run, so "closed nothing because there was nothing" cannot print the same line as "closed nothing because I could not read a run".

## Verification

- 19 new unit tests (12 on the counter's decision, 7 on the ceiling), 223 green across the related suites.
- `payment-submissions-api.spec.ts` **110/110** against the local DB, including three new end-to-end cases: closing drops the ceiling, reopening restores it, and closing a run with no output is refused.
- `check:prod-build` ✓; tsc 279, at/below the 280 baseline.
- Typed columns + migration; no duplicate migration name across modules (checked — that silently skips one).

⚠️ **No UI yet.** The routes and counter work; nothing on the run page calls them. Say the word and I'll add the button and the closed-state badge.