### PR TITLE
fix(mcp): surface stats-panel 400 details and make metric_sections AOV resolvable

### DIFF
--- a/apps/backend/integration-tests/http/platform-stats-panel.spec.ts
+++ b/apps/backend/integration-tests/http/platform-stats-panel.spec.ts
@@ -19,7 +19,7 @@
  *   commission   — partner_fee sum, all-time + trailing window
  *   subscription — partner_subscription: count_distinct partners + MRR
  *                  (monthly-normalized plan price, yearly / 12)
- *   aov          — avg order value over the trailing window (ALL orders)
+ *   aov          — avg captured amount per paid order over the trailing window
  *   arr          — DERIVED section: subscription.mrr × 12
  *
  * Assertions are before/after DELTAS for all-time counts/sums so the spec
@@ -85,10 +85,11 @@ const jpySections = {
     echo: { currency: true },
   },
   aov: {
-    entity: "order",
+    entity: "order_transaction",
+    filters: { reference: "capture" },
     currency_key: "currency_code",
     aggregates: {
-      amount: { fn: "avg", field: "total", range: { date_field: "created_at", last_days: 30 } },
+      amount: { fn: "avg", field: "amount", range: { date_field: "created_at", last_days: 30 } },
     },
     echo: { currency: true },
   },
@@ -229,8 +230,7 @@ setupSharedTestSuite(() => {
         captured: true,
       })
       // Not captured — no capture transaction, so it must be excluded from
-      // orders.processed. It IS an order, though, so the all-orders AOV
-      // (entity "order", avg(total)) counts it.
+      // both orders.processed and the AOV captured-amount average.
       await seedPaidOrder(container, {
         currency_code: "jpy",
         unit_price: 12345,
@@ -276,13 +276,14 @@ setupSharedTestSuite(() => {
       expect(d.arr.currency).toBe("JPY")
       expect(d.arr.amount - b.arr.amount).toBe(35988)
 
-      // aov — avg order value over ALL orders in the trailing window:
-      // (10000 + 10000 + 12345) / 3. jpy is only seeded here, so the
+      // aov — avg captured amount over PAID orders in the trailing window:
+      // (10000 + 10000) / 2 (the not-captured 12345 order has no capture
+      // transaction, so it is excluded). jpy is only seeded here, so the
       // baseline jpy AOV is 0/null — otherwise the exact check degrades
       // and we only assert structure.
       expect(d.aov.currency).toBe("JPY")
       if (b.aov.amount == null || b.aov.amount === 0) {
-        expect(d.aov.amount).toBe(10781.67)
+        expect(d.aov.amount).toBe(10000)
       } else {
         expect(d.aov.amount).toBeGreaterThan(0)
       }

--- a/apps/backend/src/api/admin/mcp/lib/registry.ts
+++ b/apps/backend/src/api/admin/mcp/lib/registry.ts
@@ -4292,7 +4292,7 @@ export const ADMIN_MCP_TOOLS: AdminMcpToolDef[] = [
   {
     name: "create_stats_panel",
     description:
-      "Create a stats panel on a dashboard, driven by operation_type + operation_options JSON. The panel's data resolves LIVE from the configured operation — nothing is stored as a number. For the dynamic metric_sections operation, pass operation_options = { currency, window_days, sections: { <name>: { entity, filters, aggregates: { <key>: { fn, field?, range?, normalize_interval? } }, currency_key?, echo? } | { derived: { ref, aggregate, multiply?, add? }, echo? } } }. Set metadata.public true only if the panel is safe to expose publicly (GET /web/stats/panels/:id/data).",
+      "Create a stats panel on a dashboard, driven by operation_type + operation_options JSON. The panel's data resolves LIVE from the configured operation — nothing is stored as a number. For the dynamic metric_sections operation, pass operation_options = { currency, window_days, sections: { <name>: { entity, filters, aggregates: { <key>: { fn, field?, range?, normalize_interval? } }, currency_key?, echo? } | { derived: { ref, aggregate, multiply?, add? }, echo? } } }. IMPORTANT: `echo` is an OBJECT of booleans like { window_days: true } or { currency: true } — it declares which context keys the section output carries; it is NOT text, and the section's label is the section NAME, so never send echo as a string. Set metadata.public true only if the panel is safe to expose publicly (GET /web/stats/panels/:id/data).",
     method: "POST",
     path: "/admin/stats/dashboards/:id/panels",
     pathParams: ["id"],
@@ -4318,7 +4318,7 @@ export const ADMIN_MCP_TOOLS: AdminMcpToolDef[] = [
         operation_options: {
           type: "object",
           description:
-            "Operation JSON. For metric_sections: { currency, window_days, sections: { name: { entity, filters, aggregates: { key: { fn, field?, range?, normalize_interval? } }, currency_key?, echo? } | { derived: { ref, aggregate, multiply?, add? }, echo? } } }.",
+            "Operation JSON. For metric_sections: { currency, window_days, sections: { name: { entity, filters, aggregates: { key: { fn, field?, range?, normalize_interval? } }, currency_key?, echo? } | { derived: { ref, aggregate, multiply?, add? }, echo? } } }. `echo` is an OBJECT of booleans ({ window_days: true }, { currency: true }) — not text; the section name is the label.",
         },
         display: {
           type: "object",

--- a/apps/backend/src/lib/mcp-core/proxy.ts
+++ b/apps/backend/src/lib/mcp-core/proxy.ts
@@ -93,11 +93,15 @@ export async function callMcpRoute({
     headers["x-publishable-api-key"] = publishableKey
   }
   if (context) {
-    // Truncate defensively — this is a header, not a payload.
-    headers["x-mcp-context"] = context.slice(0, 1024)
+    // Header values must be Latin-1 byte strings — undici rejects anything
+    // outside 0x00-0xFF ("Cannot convert argument to a ByteString"). The model
+    // often writes an em dash / curly quote into its intent, which would abort
+    // the fetch before it ever reaches the route. Collapse those to "?" and
+    // truncate defensively.
+    headers["x-mcp-context"] = context.replace(/[^\x00-\xFF]/g, "?").slice(0, 1024)
   }
   if (reason) {
-    headers["x-mcp-reason"] = reason.slice(0, 1024)
+    headers["x-mcp-reason"] = reason.replace(/[^\x00-\xFF]/g, "?").slice(0, 1024)
   }
 
   const init: RequestInit = { method, headers }
@@ -118,9 +122,16 @@ export async function callMcpRoute({
   }
 
   if (!resp.ok) {
-    const message = json?.message || json?.type || `HTTP ${resp.status}`
+    // Routes shape their failures inconsistently: some return `{ message }`,
+    // most of this repo's return `{ error }`, and zod-driven ones add a
+    // `details` array. Surfacing all three turns a bare "HTTP 400" into
+    // something the model can act on (and the observability log can be read
+    // without re-running the call).
+    const message = json?.message || json?.error || json?.type || `HTTP ${resp.status}`
+    const details = json?.details
     const err: McpProxyError = new Error(
-      `Route ${path} responded ${resp.status}: ${message}`
+      `Route ${path} responded ${resp.status}: ${message}` +
+        (details ? ` — ${JSON.stringify(details).slice(0, 500)}` : "")
     )
     err.status = resp.status
     err.body = json

--- a/apps/backend/src/modules/visual_flows/operations/metric-sections.ts
+++ b/apps/backend/src/modules/visual_flows/operations/metric-sections.ts
@@ -30,10 +30,11 @@ import { getValueByPath } from "./utils"
 //                           range: { date_field: "accrued_at", last_days: 30 } },
 //         },
 //         echo: { currency: true, window_days: true } },
-//       aov: { entity: "order", currency_key: "currency_code",
-//         aggregates: { amount: { fn: "avg", field: "total",
-//                                 range: { last_days: 30 } } },
-//         echo: { currency: true } },
+//       aov: { entity: "order_transaction", filters: { reference: "capture" },
+//              currency_key: "currency_code",
+//              aggregates: { amount: { fn: "avg", field: "amount",
+//                                      range: { last_days: 30 } } },
+//              echo: { currency: true } },
 //       subscription: { entity: "partner_subscription", currency_key: "plan.currency_code",
 //         filters: { status: "active" },
 //         aggregates: {
@@ -121,7 +122,9 @@ const entitySectionSpecSchema = z.object({
       window_days: z.boolean().optional(),
     })
     .optional()
-    .describe("Context keys to carry into this section's payload."),
+    .describe(
+      "Which context keys to carry into this section's payload — an OBJECT of booleans, e.g. { window_days: true } or { currency: true, window_days: true }. NOT text: the section's label is the section name itself. Omit for no echoed keys."
+    ),
   fetch_limit: z
     .number()
     .int()
@@ -141,7 +144,8 @@ const derivedSectionSpecSchema = z.object({
   }),
   echo: z
     .object({ currency: z.boolean().optional(), window_days: z.boolean().optional() })
-    .optional(),
+    .optional()
+    .describe("Which context keys to echo — an OBJECT of booleans, e.g. { currency: true }. NOT text."),
 })
 
 const sectionSpecSchema = z.union([entitySectionSpecSchema, derivedSectionSpecSchema])

--- a/apps/backend/src/scripts/seed-platform-stats-panel.ts
+++ b/apps/backend/src/scripts/seed-platform-stats-panel.ts
@@ -79,17 +79,19 @@ const OPERATION_OPTIONS = {
       },
       echo: { currency: true },
     },
-    // Average order value over the trailing window. AOV is the conventional
-    // sum(order totals) / count(orders) — over ALL orders, because the order
-    // module's model has no `payment_status` column to filter paid orders via
-    // query.graph (payment status is API-layer-derived from payment
-    // collections). Paid-only ordering lives in `orders.processed`, which
-    // counts capture transactions instead.
+    // Average amount captured per paid order over the trailing window. AOV is
+    // the captured payment amount (order_transaction with reference "capture"),
+    // NOT order.total: the order module computes total/subtotal/etc from
+    // shipping-method adjustments, and query.graph cannot fetch those computed
+    // money fields ("Shipping method version is required to load adjustments").
+    // Captured amount equals order value for full-payment orders, which is the
+    // only graph-fetchable per-order money signal.
     aov: {
-      entity: "order",
+      entity: "order_transaction",
+      filters: { reference: "capture" },
       currency_key: "currency_code",
       aggregates: {
-        amount: { fn: "avg", field: "total", range: { date_field: "created_at", last_days: 30 } },
+        amount: { fn: "avg", field: "amount", range: { date_field: "created_at", last_days: 30 } },
       },
       echo: { currency: true },
     },


### PR DESCRIPTION
## Summary

Diagnosed the `create_stats_panel` 400 from prod logs (CloudWatch `/copilot/jyt-prod-medusa-server`) plus a live `POST /admin/stats/panels/preview` probe. Four fixes:

### 1. Proxy surfaces the real error (root cause of the useless "HTTP 400")
The loopback proxy (`src/lib/mcp-core/proxy.ts`) read only `json.message || json.type` from the route response, but this repo's routes return `{ error }` (+ `{ details }` for zod). So the actual validation failure was swallowed and the assistant got a bare `HTTP 400` it couldn't self-correct. Now surfaces `error` + `details`.

### 2. Header byte-string crash
`x-mcp-context` / `x-mcp-reason` with an em dash (`\u2014`) made undici throw `Cannot convert argument to a ByteString` (seen in logs). Header values are now sanitized to Latin-1.

### 3. AOV is resolvable again
AOV was aggregating `order.total` via query.graph — the order module can't serve that (`Shipping method version is required to load adjustments` for `total`/`subtotal`/`item_total`/`item_subtotal`; `order_summary` isn't a top-level graph entity). Reverted AOV to `order_transaction.amount` over `reference: "capture"` — the only graph-fetchable per-order money signal (full-payment captures equal order value). Updated seed panel + integration test + docstrings.

### 4. `echo` was being sent as a string
The assistant sent `"echo": "Orders (last 30 days)"` — it read `echo` as a label. It's an object of booleans (`{ window_days: true }`). Clarified the zod `.describe()` and the tool description so the section NAME is understood as the label and `echo` as context keys.

## Live verification
- `metric_sections` resolves on prod: `orders.processed`, `commission.accrued`, `subscription.paying_artisans` all populated.
- `mrr = 0` is **correct** — all 15 active artisan subscriptions are on the single free plan (plan prices sum to 0 there; the 7 priced plans have no active subs).
- AOV via `order_transaction` resolves cleanly (no error) on prod.

## Files
- `src/lib/mcp-core/proxy.ts` — error surfacing + header sanitization
- `src/modules/visual_flows/operations/metric-sections.ts` — AOV docstring + `echo` descriptions
- `src/api/admin/mcp/lib/registry.ts` — `create_stats_panel` description clarity
- `src/scripts/seed-platform-stats-panel.ts` — AOV revert + comment
- `integration-tests/http/platform-stats-panel.spec.ts` — AOV revert (back to capture-amount, expected 10000)