### PR TITLE
feat(payments): short-close UI, payable runs as a grid, and inventory orders on the payout screen

### DIFF
--- a/apps/backend/integration-tests/http/payment-submissions-api.spec.ts
+++ b/apps/backend/integration-tests/http/payment-submissions-api.spec.ts
@@ -3876,4 +3876,231 @@ setupSharedTestSuite(() => {
       }
     })
   })
+
+  /**
+   * GOODS, as opposed to work (#1612).
+   *
+   * `create` has accepted `inventory_order_lines` since the guard was written —
+   * validator, partner-ownership check, read-side resolution — and NOTHING ever
+   * sent one. On production no payment carries an `inventory_order_id` at all,
+   * because no screen offered them. `assessInventoryOrderClaims` says as much
+   * itself: "inventory-order-sourced payouts have no integration coverage at
+   * all", which is why its money decision was extracted to be testable without
+   * standing up a submission.
+   *
+   * This exercises the path end to end, through the endpoint the screen reads.
+   */
+  describe("GET /admin/payment-submissions/payable-inventory-orders (#1612)", () => {
+    /**
+     * A minimal orderable item. A line must name an inventory item or a
+     * variant — neither is optional, because a line naming nothing is a line
+     * nobody can receive against (#1662).
+     */
+    /**
+     * `send-to-partner` creates the partner's order tasks from three templates
+     * BY NAME and refuses outright when they are absent. The test database has
+     * no seeded templates, so the only way to link an order to a partner
+     * through the API is to make them exist first.
+     */
+    const seedOrderTaskTemplates = async () => {
+      // 🔴 NOT memoised. The runner restores a DB SNAPSHOT before every test,
+      // so a flag saying "already seeded" outlives the rows it describes and
+      // the second case finds no templates at all.
+      for (const name of [
+        "partner-order-sent",
+        "partner-order-received",
+        "partner-order-shipped",
+      ]) {
+        await api
+          .post(
+            "/admin/task-templates",
+            {
+              name,
+              description: `Inventory order step: ${name}`,
+              priority: "medium",
+              estimated_duration: 30,
+              eventable: false,
+              notifiable: false,
+            },
+            adminHeaders
+          )
+          .catch((e: any) => e.response)
+          .then((r: any) => {
+            // Loudly. A template that silently fails to be created surfaces
+            // three calls later as "send-to-partner 400", which says nothing
+            // about the actual cause.
+            if (r && r.status !== 201 && r.status !== 200) {
+              throw new Error(
+                `task-template ${name} failed ${r.status}: ${JSON.stringify(r.data)}`
+              )
+            }
+          })
+      }
+    }
+
+    /** A stock location to receive into — required on every order. */
+    const seedStockLocation = async () => {
+      // Same snapshot rule as the templates above — created per test.
+      const res = await api
+        .post(
+          "/admin/stock-locations",
+          { name: `Payable Goods Warehouse ${Date.now()}` },
+          adminHeaders
+        )
+        .catch((e: any) => e.response)
+      if (res.status !== 200 && res.status !== 201) {
+        throw new Error(`stock-location failed ${res.status}: ${JSON.stringify(res.data)}`)
+      }
+      return res.data.stock_location.id as string
+    }
+
+    const seedInventoryItem = async (tag: string) => {
+      const res = await api
+        .post(
+          "/admin/inventory-items",
+          { sku: `PAYIO-${tag}`, title: `Payable Goods ${tag}` },
+          adminHeaders
+        )
+        .catch((e: any) => e.response)
+      if (res.status !== 200 && res.status !== 201) {
+        throw new Error(`inventory-item failed ${res.status}: ${JSON.stringify(res.data)}`)
+      }
+      return res.data.inventory_item.id
+    }
+
+    const seedOrderForPartner = async (
+      partnerId: string,
+      tag: string,
+      opts?: { quantity?: number; price?: number }
+    ) => {
+      await seedOrderTaskTemplates()
+      const inventoryItemId = await seedInventoryItem(tag)
+      const stockLocationId = await seedStockLocation()
+      const quantity = opts?.quantity ?? 4
+      const price = opts?.price ?? 250
+
+      const created = await api
+        .post(
+          "/admin/inventory-orders",
+          {
+            order_lines: [
+              { inventory_item_id: inventoryItemId, quantity, price },
+            ],
+            quantity,
+            total_price: quantity * price,
+            status: "Pending",
+            expected_delivery_date: new Date().toISOString(),
+            order_date: new Date().toISOString(),
+            shipping_address: {},
+            stock_location_id: stockLocationId,
+          },
+          adminHeaders
+        )
+        .catch((e: any) => e.response)
+      if (created.status !== 201) {
+        throw new Error(
+          `inventory-order create failed ${created.status}: ${JSON.stringify(created.data)}`
+        )
+      }
+      const orderId = created.data.inventoryOrder.id
+
+      const sent = await api
+        .post(
+          `/admin/inventory-orders/${orderId}/send-to-partner`,
+          { partnerId },
+          adminHeaders
+        )
+        .catch((e: any) => e.response)
+      if (sent.status !== 200 && sent.status !== 201) {
+        throw new Error(`send-to-partner failed ${sent.status}: ${JSON.stringify(sent.data)}`)
+      }
+      return orderId
+    }
+
+    it("requires a partner_id rather than listing everyone's orders", async () => {
+      const res = await api
+        .get(
+          "/admin/payment-submissions/payable-inventory-orders",
+          adminHeaders
+        )
+        .catch((e: any) => e.response)
+
+      // 400 from the validator, not a 200 with somebody else's goods on it.
+      expect(res.status).toBe(400)
+    })
+
+    /**
+     * 🔴 Non-vacuously: an order really exists, and it is really withheld.
+     *
+     * `expect([]).toEqual([])` against a database with no inventory orders in
+     * it passes whatever the route does — a fixture tidier than reality
+     * certifies the wrong code. So an order is created and sent to partner A,
+     * and B is asked for it.
+     *
+     * The failure this guards is not hypothetical: an id that resolves to no
+     * filter returns EVERY row rather than none, which is how one dangling key
+     * once served every tenant's data to every tenant.
+     */
+    it("withholds another partner's inventory orders, and shows the owner theirs", async () => {
+      const stamp = Date.now()
+      const ownerAuth = await createPartnerWithAuth(stamp)
+      const otherAuth = await createPartnerWithAuth(stamp + 1)
+      const ownerId = ownerAuth.partnerId
+      const otherId = otherAuth.partnerId
+
+      const orderId = await seedOrderForPartner(ownerId, `own-${stamp}`)
+
+      const owner = await api.get(
+        `/admin/payment-submissions/payable-inventory-orders?partner_id=${ownerId}`,
+        adminHeaders
+      )
+      expect(owner.status).toBe(200)
+      const ownerIds = owner.data.payable_inventory_orders.map(
+        (o: any) => o.inventory_order_id
+      )
+      expect(ownerIds).toContain(orderId)
+
+      const other = await api.get(
+        `/admin/payment-submissions/payable-inventory-orders?partner_id=${otherId}`,
+        adminHeaders
+      )
+      expect(other.status).toBe(200)
+      expect(
+        other.data.payable_inventory_orders.map(
+          (o: any) => o.inventory_order_id
+        )
+      ).not.toContain(orderId)
+    })
+
+    /**
+     * The order above has NO receipts. It is listed rather than hidden — "why
+     * isn't this order here" is the question an operator arrives with — but it
+     * bills nothing, because no receipt is a gap in the record and not a
+     * statement that the goods were free (#1612).
+     */
+    it("lists an order with no receipts, and refuses to bill it", async () => {
+      const stamp = Date.now() + 2
+      const auth = await createPartnerWithAuth(stamp)
+      const partnerId2 = auth.partnerId
+
+      const orderId = await seedOrderForPartner(partnerId2, `norec-${stamp}`)
+
+      const res = await api.get(
+        `/admin/payment-submissions/payable-inventory-orders?partner_id=${partnerId2}`,
+        adminHeaders
+      )
+      const row = res.data.payable_inventory_orders.find(
+        (o: any) => o.inventory_order_id === orderId
+      )
+      expect(row).toBeDefined()
+
+      // 🔑 The ORDERED total is reported — it is the guard's ceiling — while
+      // the billable amount is zero. Reporting 1000 as payable here is the
+      // #1612 overpayment in miniature.
+      expect(row.ordered_total).toBe(1000)
+      expect(row.receipts_total).toBe(0)
+      expect(row.amount).toBe(0)
+      expect(row.payable).toBe(false)
+    })
+  })
 })

--- a/apps/backend/integration-tests/http/payment-submissions-api.spec.ts
+++ b/apps/backend/integration-tests/http/payment-submissions-api.spec.ts
@@ -891,6 +891,56 @@ setupSharedTestSuite(() => {
       expect(row.quantity_basis).toBe("ordered")
     })
 
+    /**
+     * #1596 — the ROW says it is closed, not just the arithmetic.
+     *
+     * `short_closed_at` is fetched by this route to compute the ceiling, and it
+     * would have been easy to leave it there. But the picker prints "Produced 4
+     * of 9 ordered" either way, and the offer it acts on has quietly dropped
+     * from 9 to 4 — an unexplained reduction unless the row can say why. A
+     * screen branching on a field the API stopped sending renders "not closed"
+     * forever, in silence, which is the whole failure this asserts against.
+     */
+    it("says on the row that a run was short-closed, not just in the offer (#1596)", async () => {
+      const d1 = await createDesign("Closed Row Design", { estimated_cost: 100 })
+      await linkDesignToPartner(d1, partnerId)
+      const runId = await createCompletedRun(d1, "Closed Row Design", {
+        quantity: 9,
+        produced_quantity: 4,
+        partner_cost_estimate: 1200,
+        cost_type: "per_unit",
+      })
+
+      const before = await api.get(
+        `/admin/payment-submissions/payable-runs?partner_id=${partnerId}`,
+        adminHeaders
+      )
+      const openRow = before.data.payable_runs.find((r: any) => r.run_id === runId)
+      // Present and null — an absent key and "not closed" must not look alike
+      // to a screen reading it.
+      expect(openRow).toBeDefined()
+      expect(openRow.short_closed_at).toBeNull()
+
+      await api.post(
+        `/admin/production-runs/${runId}/short-close`,
+        { reason: "Partner confirmed no more will be made" },
+        adminHeaders
+      )
+
+      const after = await api.get(
+        `/admin/payment-submissions/payable-runs?partner_id=${partnerId}`,
+        adminHeaders
+      )
+      const closedRow = after.data.payable_runs.find((r: any) => r.run_id === runId)
+      expect(closedRow).toBeDefined()
+      expect(closedRow.short_closed_at).toBeTruthy()
+      // The ordered figure is still reported as ordered — the row shows what
+      // was agreed AND what is now offered, rather than rewriting history.
+      expect(closedRow.ordered_quantity).toBe(9)
+      expect(closedRow.produced_quantity).toBe(4)
+      expect(closedRow.payable_quantity).toBe(4)
+    })
+
     it("marks a run with no agreed rate unpayable instead of billing zero", async () => {
       // A run with no cost is not a zero-value payout — it is a run whose price
       // has not been settled. Surfaced, not silently dropped.

--- a/apps/backend/src/admin/components/creates/__tests__/run-line-pricing.unit.spec.ts
+++ b/apps/backend/src/admin/components/creates/__tests__/run-line-pricing.unit.spec.ts
@@ -1,0 +1,113 @@
+import {
+  runBillsVerbatimTotal,
+  runLineAmount,
+} from "../lib/run-line-pricing"
+
+/**
+ * #1596 / #1616 — the screen must bill what was agreed, and send it on a
+ * channel that means what it says.
+ *
+ * These are the two shapes that cost real money: a total-priced run billed as
+ * though its derived rate were a negotiated one, and a screen showing a figure
+ * the server then writes differently.
+ */
+describe("runLineAmount", () => {
+  const RUN_TOTAL = {
+    // ₹10,000 agreed for the job, 9 ordered, 7 made. The offer bills the
+    // produced figure, so its derived rate is 10000/7.
+    quantity: 7,
+    rate: 1428.57,
+    amount: 10000,
+    unit_is_derived: true,
+  }
+
+  it("bills a total-priced run its AGREED TOTAL, not quantity x derived rate", () => {
+    // 7 x 1428.57 = 9,999.99 — the paisa this test exists to refuse.
+    expect(runLineAmount({ ...RUN_TOTAL, hasTypedRate: false })).toBe(10000)
+  })
+
+  it("does not move a total-priced run's amount when the quantity changes", () => {
+    // The total was for the job. Billing 9 units of a derived rate would pay
+    // ₹12,857.13 for a ₹10,000 job; billing 4 would pay ₹5,714.28 for it.
+    expect(
+      runLineAmount({ ...RUN_TOTAL, quantity: 9, hasTypedRate: false })
+    ).toBe(10000)
+    expect(
+      runLineAmount({ ...RUN_TOTAL, quantity: 4, hasTypedRate: false })
+    ).toBe(10000)
+  })
+
+  it("multiplies once a human has TYPED a rate — that is a decision they made", () => {
+    // The documented way out: a typed rate outranks the stored figure, and
+    // from here the row is per-piece because someone said so.
+    expect(
+      runLineAmount({
+        ...RUN_TOTAL,
+        quantity: 7,
+        rate: 1500,
+        hasTypedRate: true,
+      })
+    ).toBe(10500)
+  })
+
+  it("multiplies a genuine per-unit run, where quantity IS the money", () => {
+    expect(
+      runLineAmount({
+        quantity: 4,
+        rate: 1200,
+        amount: 4800,
+        unit_is_derived: false,
+        hasTypedRate: false,
+      })
+    ).toBe(4800)
+  })
+
+  it("moves with the quantity on a per-unit run", () => {
+    expect(
+      runLineAmount({
+        quantity: 7,
+        rate: 1200,
+        amount: 4800,
+        unit_is_derived: false,
+        hasTypedRate: false,
+      })
+    ).toBe(8400)
+  })
+
+  it("bills nothing rather than NaN when a box is half-typed", () => {
+    expect(
+      runLineAmount({
+        quantity: Number.NaN,
+        rate: 1200,
+        amount: 0,
+        unit_is_derived: false,
+        hasTypedRate: true,
+      })
+    ).toBe(0)
+  })
+})
+
+describe("runBillsVerbatimTotal", () => {
+  it("is true only while the derived rate is untouched", () => {
+    expect(
+      runBillsVerbatimTotal({ unit_is_derived: true, hasTypedRate: false })
+    ).toBe(true)
+    expect(
+      runBillsVerbatimTotal({ unit_is_derived: true, hasTypedRate: true })
+    ).toBe(false)
+    expect(
+      runBillsVerbatimTotal({ unit_is_derived: false, hasTypedRate: false })
+    ).toBe(false)
+  })
+
+  it("treats a missing flag as NOT derived", () => {
+    // Absence is not a claim. A row with no flag is priced the ordinary way
+    // rather than silently pinned to whatever `amount` happened to hold.
+    expect(
+      runBillsVerbatimTotal({ unit_is_derived: undefined, hasTypedRate: false })
+    ).toBe(false)
+    expect(
+      runBillsVerbatimTotal({ unit_is_derived: null, hasTypedRate: false })
+    ).toBe(false)
+  })
+})

--- a/apps/backend/src/admin/components/creates/create-payment-submission.tsx
+++ b/apps/backend/src/admin/components/creates/create-payment-submission.tsx
@@ -23,6 +23,11 @@ import {
   usePayableRuns,
   type PayableRun,
 } from "../../hooks/api/payment-submissions"
+import { PayableRunsGrid } from "./payable-runs-grid"
+import {
+  runBillsVerbatimTotal as billsVerbatimTotal,
+  runLineAmount,
+} from "./lib/run-line-pricing"
 /**
  * 🔴 From `rate-breakdown-display`, NOT `rate-breakdown`. This is a Vite
  * BROWSER bundle: the latter imports `MedusaError`, and pulling it in here
@@ -76,6 +81,17 @@ export const CreatePaymentSubmissionComponent = () => {
   const navigate = useNavigate()
 
   const [partnerId, setPartnerId] = useState<string>("")
+  /**
+   * Two steps, because they are two different jobs.
+   *
+   * Choosing the partner decides WHOSE work is on the screen; everything after
+   * it is deciding what to pay for. Sharing one page meant the picker and its
+   * notes box sat above a spreadsheet forever, holding a third of the height
+   * and half the width for a decision already made — and the grid, which is the
+   * whole point of the screen, was squeezed into a 720px column beside them.
+   */
+  const [step, setStep] = useState<"partner" | "items">("partner")
+
   const [activeTab, setActiveTab] = useState<"runs" | "designs" | "tasks">(
     "runs"
   )
@@ -140,12 +156,6 @@ export const CreatePaymentSubmissionComponent = () => {
     [payableRuns]
   )
 
-  /** Runs already carrying an agreed rate — what "Select All" may safely take. */
-  const pricedSelectableRuns = useMemo(
-    () => selectableRuns.filter((r) => r.payable),
-    [selectableRuns]
-  )
-
   const eligibleDesigns = useMemo(
     () =>
       designs.filter((d) =>
@@ -180,8 +190,12 @@ export const CreatePaymentSubmissionComponent = () => {
   }
 
   const handlePartnerChange = (value: string) => {
+    // A different partner means a different set of runs, so anything already
+    // ticked refers to work this partner did not do.
+    if (value !== partnerId) {
+      resetSelection()
+    }
     setPartnerId(value)
-    resetSelection()
   }
 
   // ─── Selection handlers ─────────────────────────────────────────────
@@ -192,28 +206,6 @@ export const CreatePaymentSubmissionComponent = () => {
       return next
     })
   }, [])
-
-  const toggleRun = useCallback((id: string) => {
-    setSelectedRunIds((prev) => {
-      const next = new Set(prev)
-      next.has(id) ? next.delete(id) : next.add(id)
-      return next
-    })
-  }, [])
-
-  /**
-   * Select All takes only the PRICED runs. Bulk-selecting a run with no rate
-   * would add a line the submit guard then refuses, so the button would appear
-   * to work and then block the whole submission on rows the admin never chose.
-   * An unpriced run is selected deliberately, one at a time, with a rate typed.
-   */
-  const selectAllRuns = useCallback(() => {
-    setSelectedRunIds((prev) =>
-      prev.size === pricedSelectableRuns.length
-        ? new Set()
-        : new Set(pricedSelectableRuns.map((r) => r.run_id))
-    )
-  }, [pricedSelectableRuns])
 
   /** Units billed for a run — the produced figure unless an admin retyped it. */
   const getRunQuantity = useCallback(
@@ -233,10 +225,54 @@ export const CreatePaymentSubmissionComponent = () => {
     [runRateOverrides]
   )
 
+  /**
+   * Whether a human has typed a rate for this run.
+   *
+   * This is the line between "the system is showing you what was agreed" and
+   * "you have decided a new price". Everything below turns on it.
+   */
+  const runHasTypedRate = useCallback(
+    (run: PayableRun): boolean => runRateOverrides[run.run_id] != null,
+    [runRateOverrides]
+  )
+
+  /**
+   * What this run bills.
+   *
+   * 🔴 A `total` run's agreed figure is the price OF THE JOB, not a rate. Its
+   * `unit_amount` is `total / quantity`, derived purely so a screen can show a
+   * rate, and flagged `unit_is_derived` for exactly this reason: multiplying it
+   * back out does not reproduce the total. On a real run — ₹10,000 agreed, 9
+   * ordered, 7 made — that arithmetic bills ₹7,777.77, a 22% cut nobody
+   * decided, and even when the numbers line up it loses a paisa to rounding
+   * (₹9,999.99 for ₹10,000). 97 of 100 production runs are priced this way.
+   *
+   * So an untouched derived row bills its agreed total VERBATIM, and changing
+   * the quantity does not move it — the total was never per-piece.
+   *
+   * Typing a rate is the deliberate way out: a human who has decided a per-unit
+   * price outranks the stored figure, and from then on the row multiplies.
+   */
   const getRunAmount = useCallback(
     (run: PayableRun): number =>
-      Math.round(getRunQuantity(run) * getRunRate(run) * 100) / 100,
-    [getRunQuantity, getRunRate]
+      runLineAmount({
+        quantity: getRunQuantity(run),
+        rate: getRunRate(run),
+        amount: run.amount,
+        unit_is_derived: run.unit_is_derived,
+        hasTypedRate: runHasTypedRate(run),
+      }),
+    [getRunQuantity, getRunRate, runHasTypedRate]
+  )
+
+  /** A row still billing an agreed TOTAL rather than a rate it was given. */
+  const runBillsVerbatimTotal = useCallback(
+    (run: PayableRun): boolean =>
+      billsVerbatimTotal({
+        unit_is_derived: run.unit_is_derived,
+        hasTypedRate: runHasTypedRate(run),
+      }),
+    [runHasTypedRate]
   )
 
   const handleRunNumberChange = (
@@ -345,7 +381,23 @@ export const CreatePaymentSubmissionComponent = () => {
   const runLinesByDesign = useMemo(() => {
     const byDesign = new Map<
       string,
-      { runs: PayableRun[]; quantity: number; amount: number; rates: Set<number> }
+      {
+        runs: PayableRun[]
+        quantity: number
+        amount: number
+        rates: Set<number>
+        /**
+         * Whether any run on this line is still billing an agreed TOTAL.
+         *
+         * 🔴 This decides which channel the line is SENT on, and it is not a
+         * display concern. `create` prices in a fixed order — a typed line
+         * total wins outright, then a typed RATE, and only then the runs via
+         * `runPayableOffer`. Sending a derived rate as `unit_amounts` therefore
+         * OUTRANKS the one true pricer and makes the server multiply a figure
+         * that was never per-piece.
+         */
+        hasVerbatimTotal: boolean
+      }
     >()
 
     for (const run of selectedRuns) {
@@ -354,16 +406,25 @@ export const CreatePaymentSubmissionComponent = () => {
         quantity: 0,
         amount: 0,
         rates: new Set<number>(),
+        hasVerbatimTotal: false,
       }
       entry.runs.push(run)
       entry.quantity += getRunQuantity(run)
       entry.amount = Math.round((entry.amount + getRunAmount(run)) * 100) / 100
       entry.rates.add(getRunRate(run))
+      entry.hasVerbatimTotal =
+        entry.hasVerbatimTotal || runBillsVerbatimTotal(run)
       byDesign.set(run.design_id, entry)
     }
 
     return byDesign
-  }, [selectedRuns, getRunQuantity, getRunAmount, getRunRate])
+  }, [
+    selectedRuns,
+    getRunQuantity,
+    getRunAmount,
+    getRunRate,
+    runBillsVerbatimTotal,
+  ])
 
   const runsTotal = useMemo(
     () => selectedRuns.reduce((sum, r) => sum + getRunAmount(r), 0),
@@ -475,6 +536,22 @@ export const CreatePaymentSubmissionComponent = () => {
       for (const [designId, line] of runLinesByDesign.entries()) {
         quantities[designId] = line.quantity
         productionRunIds[designId] = line.runs.map((r) => r.run_id)
+
+        /**
+         * 🔴 An agreed TOTAL goes on the line-total channel, never as a rate.
+         *
+         * `cost_overrides` "wins outright; never multiplied by quantity" — the
+         * only channel that says what this is. Sending the derived rate in
+         * `unit_amounts` instead outranks `runPayableOffer` server-side and
+         * bills `quantity × total/quantity`: a 22% cut on a short run, and a
+         * lost paisa even on an exact one. What the screen shows and what gets
+         * written have to be the same number (#1616).
+         */
+        if (line.hasVerbatimTotal) {
+          runCostOverrides[designId] = line.amount
+          continue
+        }
+
         if (line.rates.size === 1) {
           unitAmounts[designId] = [...line.rates][0]
           continue
@@ -564,37 +641,80 @@ export const CreatePaymentSubmissionComponent = () => {
             </RouteFocusModal.Title>
             <RouteFocusModal.Description asChild>
               <Text size="small" className="text-ui-fg-subtle">
-                Create a submission on behalf of a partner
+                {step === "partner"
+                  ? "Step 1 of 2 — choose who is being paid"
+                  : `Step 2 of 2 — choose what to pay ${
+                      selectedPartner?.name || "them"
+                    } for`}
               </Text>
             </RouteFocusModal.Description>
           </div>
           <div className="flex items-center gap-3">
-            {totalSelected > 0 && (
-              <Text className="text-ui-fg-subtle">
-                {totalSelected} item{totalSelected !== 1 ? "s" : ""} ={" "}
-                <span
-                  className="font-semibold text-ui-fg-base"
-                  data-testid="submission-total"
+            {step === "items" && (
+              <>
+                {totalSelected > 0 && (
+                  <Text className="text-ui-fg-subtle">
+                    {totalSelected} item{totalSelected !== 1 ? "s" : ""} ={" "}
+                    <span
+                      className="font-semibold text-ui-fg-base"
+                      data-testid="submission-total"
+                    >
+                      INR {totalAmount.toLocaleString()}
+                    </span>
+                  </Text>
+                )}
+                {/* Back, not "change partner": switching partner from here
+                    would silently discard a grid full of ticked rows, so the
+                    way back is the way you came. */}
+                <Button
+                  variant="secondary"
+                  onClick={() => setStep("partner")}
+                  disabled={isCreating}
                 >
-                  INR {totalAmount.toLocaleString()}
-                </span>
-              </Text>
+                  Back
+                </Button>
+                <Button
+                  onClick={handleSubmit}
+                  isLoading={isCreating}
+                  disabled={!partnerId || totalSelected === 0}
+                >
+                  Create Submission
+                </Button>
+              </>
             )}
-            <Button
-              onClick={handleSubmit}
-              isLoading={isCreating}
-              disabled={!partnerId || totalSelected === 0}
-            >
-              Create Submission
-            </Button>
+            {step === "partner" && (
+              <Button
+                onClick={() => setStep("items")}
+                disabled={!partnerId}
+              >
+                Continue
+              </Button>
+            )}
           </div>
         </div>
       </RouteFocusModal.Header>
 
-      <RouteFocusModal.Body className="flex flex-col gap-y-6 overflow-y-auto p-6 md:p-16">
-        <div className="mx-auto w-full max-w-[720px]">
-          {/* Partner picker */}
-          <div className="mb-6">
+      {/*
+        Step 2 is a spreadsheet and takes the whole modal: 720px could not hold
+        six columns, and Rate and Amount — the two numbers the operator is
+        actually deciding between — fell off the right edge entirely. Step 1 is
+        two form fields and stays in a narrow column, where a full-bleed text
+        input would just be a very long line.
+      */}
+      <RouteFocusModal.Body
+        className={
+          step === "partner"
+            ? "flex flex-col gap-y-6 overflow-y-auto p-6 md:p-16"
+            : "flex flex-col gap-y-4 overflow-y-auto p-4 md:p-6"
+        }
+      >
+        <div
+          className={
+            step === "partner" ? "mx-auto w-full max-w-[720px]" : "w-full"
+          }
+        >
+          {/* Partner picker — step 1. */}
+          <div className={step === "partner" ? "mb-6" : "hidden"}>
             <Text size="small" weight="plus" className="mb-2">
               Partner *
             </Text>
@@ -629,8 +749,8 @@ export const CreatePaymentSubmissionComponent = () => {
             )}
           </div>
 
-          {/* Notes */}
-          <div className="mb-6">
+          {/* Notes — step 1, alongside the partner. */}
+          <div className={step === "partner" ? "mb-6" : "hidden"}>
             <Text size="small" weight="plus" className="mb-2">
               Notes (optional)
             </Text>
@@ -642,6 +762,13 @@ export const CreatePaymentSubmissionComponent = () => {
             />
           </div>
 
+          {/*
+            Kept MOUNTED across the step change rather than unmounted, so a rate
+            half-typed into the grid survives a trip back to the partner step.
+            An operator who steps back to re-read a note and loses their column
+            of figures will not use the second step again.
+          */}
+          <div className={step === "partner" ? "hidden" : ""}>
           {!partnerId ? (
             <Container className="p-8">
               <Text className="text-ui-fg-subtle text-center">
@@ -692,23 +819,35 @@ export const CreatePaymentSubmissionComponent = () => {
               </Tabs.List>
 
               <Tabs.Content value="runs" className="mt-4">
-                <RunsPanel
+                <PayableRunsGrid
                   runs={payableRuns}
                   isLoading={runsLoading}
                   selectedIds={selectedRunIds}
-                  onToggle={toggleRun}
-                  onSelectAll={selectAllRuns}
                   quantityOverrides={runQuantityOverrides}
                   rateOverrides={runRateOverrides}
+                  onSelectionChange={(id, selected) =>
+                    setSelectedRunIds((prev) => {
+                      const next = new Set(prev)
+                      if (selected) {
+                        next.add(id)
+                      } else {
+                        next.delete(id)
+                      }
+                      return next
+                    })
+                  }
                   onQuantityChange={(id, value) =>
                     handleRunNumberChange(setRunQuantityOverrides, id, value)
                   }
                   onRateChange={(id, value) =>
                     handleRunNumberChange(setRunRateOverrides, id, value)
                   }
+                  onClearSelection={() => setSelectedRunIds(new Set())}
                   getQuantity={getRunQuantity}
                   getRate={getRunRate}
                   getAmount={getRunAmount}
+                  billsVerbatimTotal={runBillsVerbatimTotal}
+                  hasTypedRate={runHasTypedRate}
                 />
               </Tabs.Content>
 
@@ -739,305 +878,10 @@ export const CreatePaymentSubmissionComponent = () => {
               </Tabs.Content>
             </Tabs>
           )}
+          </div>
         </div>
       </RouteFocusModal.Body>
     </>
-  )
-}
-
-// ─── Production runs panel ────────────────────────────────────────────
-/**
- * One row per completed RUN — the thing that actually carries a rate and a
- * piece count. The screen this replaces listed designs and had no quantity
- * input at all, which is how a per-unit rate came to be billed once (#1554).
- *
- * Rows that cannot be billed are shown rather than filtered away: a run with no
- * agreed rate, and a run already paid for, are both things an admin looking for
- * "why isn't this here" needs to SEE. They are visibly non-selectable instead.
- */
-const RunsPanel = ({
-  runs,
-  isLoading,
-  selectedIds,
-  onToggle,
-  onSelectAll,
-  quantityOverrides,
-  rateOverrides,
-  onQuantityChange,
-  onRateChange,
-  getQuantity,
-  getRate,
-  getAmount,
-}: {
-  runs: PayableRun[]
-  isLoading: boolean
-  selectedIds: Set<string>
-  onToggle: (id: string) => void
-  onSelectAll: () => void
-  quantityOverrides: Record<string, number>
-  rateOverrides: Record<string, number>
-  onQuantityChange: (id: string, value: string) => void
-  onRateChange: (id: string, value: string) => void
-  getQuantity: (run: PayableRun) => number
-  getRate: (run: PayableRun) => number
-  getAmount: (run: PayableRun) => number
-}) => {
-  if (isLoading) {
-    return (
-      <Container className="p-8">
-        <Text className="text-ui-fg-subtle text-center">
-          Loading production runs...
-        </Text>
-      </Container>
-    )
-  }
-
-  if (!runs.length) {
-    return (
-      <Container className="p-8">
-        <Text className="text-ui-fg-subtle text-center">
-          No completed production runs for this partner. A run has to be
-          completed before it can be paid for.
-        </Text>
-      </Container>
-    )
-  }
-
-  const selectable = runs.filter((r) => r.payable && !r.billed)
-
-  return (
-    <div className="flex flex-col gap-y-2">
-      <div className="mb-1 flex items-center justify-between">
-        <Heading level="h3">{selectable.length} payable</Heading>
-        {selectable.length > 0 && (
-          <Button variant="secondary" size="small" onClick={onSelectAll}>
-            {selectedIds.size === selectable.length
-              ? "Deselect All"
-              : "Select All"}
-          </Button>
-        )}
-      </div>
-
-      {runs.map((run) => {
-        // Only an existing payout blocks. A missing rate is something to TYPE,
-        // not a reason the work cannot be paid for.
-        const isSelectable = !run.billed
-        const needsRate = !run.payable
-        const suggestion =
-          run.design_estimated_cost ?? run.design_production_cost ?? null
-        const isSelected = selectedIds.has(run.run_id)
-        const quantity = getQuantity(run)
-        const rate = getRate(run)
-        const amount = getAmount(run)
-
-        // The two figures disagreeing is the normal case, not an error — it is
-        // the whole reason the basis is stated instead of assumed.
-        const shortfall =
-          run.produced_quantity !== null &&
-          run.ordered_quantity !== null &&
-          run.produced_quantity !== run.ordered_quantity
-
-        /**
-         * #1596 — the shortfall beside this row is SETTLED, not pending.
-         *
-         * "Produced 7 of 9 ordered" is the same sentence whether the last 2
-         * units are still being made or will never be made, and those are
-         * opposite situations for the person deciding what to pay. The offer
-         * already differs — the ceiling moved — so a screen that shows the new
-         * number without the reason presents it as an unexplained reduction.
-         */
-        const isShortClosed = !!run.short_closed_at
-
-        return (
-          <Container
-            key={run.run_id}
-            className={`p-4 transition ${
-              isSelected ? "ring-2 ring-ui-border-interactive" : ""
-            } ${isSelectable ? "" : "opacity-60"}`}
-            data-testid="payable-run-row"
-            data-run-id={run.run_id}
-          >
-            <div className="flex items-center gap-3">
-              <div
-                className={isSelectable ? "cursor-pointer" : "cursor-not-allowed"}
-                onClick={() => isSelectable && onToggle(run.run_id)}
-              >
-                <Checkbox checked={isSelected} disabled={!isSelectable} />
-              </div>
-
-              <div
-                className="flex-1 min-w-0"
-                onClick={() => isSelectable && onToggle(run.run_id)}
-              >
-                {/* flex-wrap deliberately: these badges are sentences, not
-                    words, and a row that cannot wrap clips them above and
-                    below the cell instead of pushing them onto a new line. */}
-                <div className="flex flex-wrap items-center gap-2">
-                  <Text weight="plus" className="truncate">
-                    {run.design_name || "Unnamed design"}
-                  </Text>
-                  {run.design_status && (
-                    <Badge color="grey" size="2xsmall">
-                      {run.design_status.replace(/_/g, " ")}
-                    </Badge>
-                  )}
-                  {run.billed && (
-                    <Badge color="orange" size="2xsmall">
-                      Already paid — {run.billed.status}
-                    </Badge>
-                  )}
-                  {needsRate && (
-                    <Badge color="orange" size="2xsmall">
-                      No agreed rate — enter one
-                    </Badge>
-                  )}
-                  {isShortClosed && (
-                    <Badge color="grey" size="2xsmall">
-                      short-closed
-                    </Badge>
-                  )}
-                </div>
-
-                <div className="mt-1 flex flex-wrap items-center gap-x-4 gap-y-1">
-                  {/* Produced vs ordered, side by side. Which one the amount is
-                      built from is stated, never inferred by the reader. */}
-                  <Text size="small" className="text-ui-fg-subtle">
-                    Produced{" "}
-                    <span className="font-semibold text-ui-fg-base">
-                      {run.produced_quantity ?? "—"}
-                    </span>{" "}
-                    of {run.ordered_quantity ?? "—"} ordered
-                  </Text>
-                  {run.quantity_basis === "ordered" && (
-                    <Text size="small" className="text-ui-fg-warning">
-                      no output recorded — billing the ordered quantity
-                    </Text>
-                  )}
-                  {shortfall && run.quantity_basis === "produced" && (
-                    <Text size="small" className="text-ui-fg-subtle">
-                      {isShortClosed
-                        ? "closed short — nothing further will be made"
-                        : "paying on produced"}
-                    </Text>
-                  )}
-                  {run.rejected_quantity ? (
-                    <Text size="small" className="text-ui-fg-subtle">
-                      {run.rejected_quantity} rejected
-                    </Text>
-                  ) : null}
-                  {/*
-                    Long enough to be UNAMBIGUOUS. Runs are created in
-                    parent/child pairs within the same millisecond, so their
-                    ULIDs share a long prefix — prod's own pair differs only at
-                    character 15. A shorter truncation renders two different
-                    runs as the same string.
-                  */}
-                  <Text size="small" className="text-ui-fg-muted font-mono">
-                    {run.run_id.slice(0, 24)}...
-                  </Text>
-                </div>
-
-                {run.billed && (
-                  <Text size="xsmall" className="text-ui-fg-muted mt-1">
-                    Paid for by submission {run.billed.submission_id} (
-                    {run.billed.quantity} unit
-                    {run.billed.quantity === 1 ? "" : "s"})
-                  </Text>
-                )}
-                {needsRate && suggestion != null && (
-                  <Text size="xsmall" className="text-ui-fg-muted mt-1">
-                    {/* A starting point, explicitly labelled as coming from the
-                        design rather than from what was agreed. The box stays
-                        EMPTY — billing a design cost without someone typing it
-                        is the #1554 substitution. */}
-                    The design estimates {suggestion.toLocaleString()} per unit.
-                    That is the design's figure, not an agreed rate — check it
-                    before using it.
-                  </Text>
-                )}
-                {needsRate && suggestion == null && (
-                  <Text size="xsmall" className="text-ui-fg-muted mt-1">
-                    No cost recorded on the run or the design. Recalculate the
-                    design's cost, or enter the agreed rate here.
-                  </Text>
-                )}
-                {!run.billed && run.design_has_open_submission && (
-                  <Text size="xsmall" className="text-ui-fg-warning mt-1">
-                    This design is already in an open submission — creating
-                    another will be refused until that one is resolved.
-                  </Text>
-                )}
-              </div>
-
-              {isSelectable && (
-                <div className="flex items-center gap-2 shrink-0">
-                  <div className="flex flex-col items-end gap-1">
-                    <Text size="xsmall" className="text-ui-fg-muted">
-                      Qty
-                    </Text>
-                    <Input
-                      type="number"
-                      size="small"
-                      className="w-20 text-right"
-                      aria-label={`Quantity for ${run.design_name || run.run_id}`}
-                      value={
-                        quantityOverrides[run.run_id] != null
-                          ? String(quantityOverrides[run.run_id])
-                          : String(run.payable_quantity)
-                      }
-                      onChange={(e) =>
-                        onQuantityChange(run.run_id, e.target.value)
-                      }
-                      onClick={(e) => e.stopPropagation()}
-                    />
-                  </div>
-                  <div className="flex flex-col items-end gap-1">
-                    <Text size="xsmall" className="text-ui-fg-muted">
-                      Rate
-                    </Text>
-                    <Input
-                      type="number"
-                      size="small"
-                      className="w-24 text-right"
-                      aria-label={`Rate for ${run.design_name || run.run_id}`}
-                      // Empty, not "0", when the run carries no rate — a 0 in
-                      // the box reads as an agreed price of zero, and the
-                      // placeholder makes it obvious a number is wanted.
-                      placeholder={needsRate ? "rate" : undefined}
-                      value={
-                        rateOverrides[run.run_id] != null
-                          ? String(rateOverrides[run.run_id])
-                          : run.unit_amount > 0
-                            ? String(run.unit_amount)
-                            : ""
-                      }
-                      onChange={(e) => onRateChange(run.run_id, e.target.value)}
-                      onClick={(e) => e.stopPropagation()}
-                    />
-                  </div>
-                  <div className="flex flex-col items-end gap-1 w-28">
-                    <Text size="xsmall" className="text-ui-fg-muted">
-                      Amount
-                    </Text>
-                    {/* The arithmetic, shown. A partner disputing a payment
-                        reads "7 × 1,200", not a bare 8,400. */}
-                    <Text
-                      weight="plus"
-                      className="text-right"
-                      data-testid={`run-amount-${run.run_id}`}
-                    >
-                      {rate > 0
-                        ? `${quantity} × ${rate.toLocaleString()} = ${amount.toLocaleString()}`
-                        : "—"}
-                    </Text>
-                  </div>
-                </div>
-              )}
-            </div>
-          </Container>
-        )
-      })}
-    </div>
   )
 }
 

--- a/apps/backend/src/admin/components/creates/create-payment-submission.tsx
+++ b/apps/backend/src/admin/components/creates/create-payment-submission.tsx
@@ -837,6 +837,17 @@ const RunsPanel = ({
           run.ordered_quantity !== null &&
           run.produced_quantity !== run.ordered_quantity
 
+        /**
+         * #1596 — the shortfall beside this row is SETTLED, not pending.
+         *
+         * "Produced 7 of 9 ordered" is the same sentence whether the last 2
+         * units are still being made or will never be made, and those are
+         * opposite situations for the person deciding what to pay. The offer
+         * already differs — the ceiling moved — so a screen that shows the new
+         * number without the reason presents it as an unexplained reduction.
+         */
+        const isShortClosed = !!run.short_closed_at
+
         return (
           <Container
             key={run.run_id}
@@ -858,7 +869,10 @@ const RunsPanel = ({
                 className="flex-1 min-w-0"
                 onClick={() => isSelectable && onToggle(run.run_id)}
               >
-                <div className="flex items-center gap-2">
+                {/* flex-wrap deliberately: these badges are sentences, not
+                    words, and a row that cannot wrap clips them above and
+                    below the cell instead of pushing them onto a new line. */}
+                <div className="flex flex-wrap items-center gap-2">
                   <Text weight="plus" className="truncate">
                     {run.design_name || "Unnamed design"}
                   </Text>
@@ -875,6 +889,11 @@ const RunsPanel = ({
                   {needsRate && (
                     <Badge color="orange" size="2xsmall">
                       No agreed rate — enter one
+                    </Badge>
+                  )}
+                  {isShortClosed && (
+                    <Badge color="grey" size="2xsmall">
+                      short-closed
                     </Badge>
                   )}
                 </div>
@@ -896,7 +915,9 @@ const RunsPanel = ({
                   )}
                   {shortfall && run.quantity_basis === "produced" && (
                     <Text size="small" className="text-ui-fg-subtle">
-                      paying on produced
+                      {isShortClosed
+                        ? "closed short — nothing further will be made"
+                        : "paying on produced"}
                     </Text>
                   )}
                   {run.rejected_quantity ? (

--- a/apps/backend/src/admin/components/creates/create-payment-submission.tsx
+++ b/apps/backend/src/admin/components/creates/create-payment-submission.tsx
@@ -20,10 +20,13 @@ import { usePartnerTasks, type AdminPartnerTask } from "../../hooks/api/partner-
 import { usePartners } from "../../hooks/api/partners-admin"
 import {
   useCreatePaymentSubmission,
+  usePayableInventoryOrders,
   usePayableRuns,
+  type PayableInventoryOrder,
   type PayableRun,
 } from "../../hooks/api/payment-submissions"
 import { PayableRunsGrid } from "./payable-runs-grid"
+import { PayableInventoryOrdersGrid } from "./payable-inventory-orders-grid"
 import {
   runBillsVerbatimTotal as billsVerbatimTotal,
   runLineAmount,
@@ -92,7 +95,9 @@ export const CreatePaymentSubmissionComponent = () => {
    */
   const [step, setStep] = useState<"partner" | "items">("partner")
 
-  const [activeTab, setActiveTab] = useState<"runs" | "designs" | "tasks">(
+  const [activeTab, setActiveTab] = useState<
+    "runs" | "inventory" | "designs" | "tasks"
+  >(
     "runs"
   )
   const [selectedRunIds, setSelectedRunIds] = useState<Set<string>>(new Set())
@@ -100,6 +105,17 @@ export const CreatePaymentSubmissionComponent = () => {
     Record<string, number>
   >({})
   const [runRateOverrides, setRunRateOverrides] = useState<
+    Record<string, number>
+  >({})
+  /**
+   * #1612 — GOODS, as opposed to work. `create` has accepted
+   * `inventory_order_lines` since the guard was written; no screen ever sent
+   * one, so no payment on production carries an `inventory_order_id`.
+   */
+  const [selectedInventoryOrderIds, setSelectedInventoryOrderIds] = useState<
+    Set<string>
+  >(new Set())
+  const [inventoryAmountOverrides, setInventoryAmountOverrides] = useState<
     Record<string, number>
   >({})
   const [selectedDesignIds, setSelectedDesignIds] = useState<Set<string>>(
@@ -139,6 +155,12 @@ export const CreatePaymentSubmissionComponent = () => {
   // Payable production runs — the primary source of truth for what to pay.
   const { payable_runs: payableRuns, isPending: runsLoading } =
     usePayableRuns(partnerId || undefined)
+
+  // Goods bought FROM this partner, as opposed to work done BY them (#1612).
+  const {
+    payable_inventory_orders: payableInventoryOrders,
+    isPending: inventoryLoading,
+  } = usePayableInventoryOrders(partnerId || undefined)
 
   /**
    * Runs that can be billed now — everything not already paid for.
@@ -183,6 +205,8 @@ export const CreatePaymentSubmissionComponent = () => {
     setSelectedRunIds(new Set())
     setRunQuantityOverrides({})
     setRunRateOverrides({})
+    setSelectedInventoryOrderIds(new Set())
+    setInventoryAmountOverrides({})
     setSelectedDesignIds(new Set())
     setSelectedTaskIds(new Set())
     setDesignCostOverrides({})
@@ -263,6 +287,39 @@ export const CreatePaymentSubmissionComponent = () => {
         hasTypedRate: runHasTypedRate(run),
       }),
     [getRunQuantity, getRunRate, runHasTypedRate]
+  )
+
+  /**
+   * What an inventory order bills.
+   *
+   * The offered figure is the RECEIPTS value capped at what the guard will
+   * still accept — see `payable-inventory-orders`. An operator may retype it;
+   * `create` takes the typed amount and the guard still refuses anything past
+   * the ordered total, so a typed figure cannot smuggle an overclaim through.
+   */
+  const getInventoryAmount = useCallback(
+    (order: PayableInventoryOrder): number =>
+      inventoryAmountOverrides[order.inventory_order_id] != null
+        ? inventoryAmountOverrides[order.inventory_order_id]
+        : order.amount,
+    [inventoryAmountOverrides]
+  )
+
+  const selectedInventoryOrders = useMemo(
+    () =>
+      payableInventoryOrders.filter((o) =>
+        selectedInventoryOrderIds.has(o.inventory_order_id)
+      ),
+    [payableInventoryOrders, selectedInventoryOrderIds]
+  )
+
+  const inventoryTotal = useMemo(
+    () =>
+      selectedInventoryOrders.reduce(
+        (sum, order) => sum + getInventoryAmount(order),
+        0
+      ),
+    [selectedInventoryOrders, getInventoryAmount]
   )
 
   /** A row still billing an agreed TOTAL rather than a rate it was given. */
@@ -443,7 +500,10 @@ export const CreatePaymentSubmissionComponent = () => {
   )
 
   const totalSelected =
-    selectedRuns.length + selectedDesignIds.size + selectedTaskIds.size
+    selectedRuns.length +
+    selectedInventoryOrders.length +
+    selectedDesignIds.size +
+    selectedTaskIds.size
 
   const totalAmount = useMemo(() => {
     const designTotal = eligibleDesigns
@@ -452,8 +512,9 @@ export const CreatePaymentSubmissionComponent = () => {
     const taskTotal = eligibleTasks
       .filter((t) => selectedTaskIds.has(t.id))
       .reduce((sum, t) => sum + getEffectiveTaskCost(t), 0)
-    return designTotal + taskTotal + runsTotal
+    return designTotal + taskTotal + runsTotal + inventoryTotal
   }, [
+    inventoryTotal,
     runsTotal,
     eligibleDesigns,
     selectedDesignIds,
@@ -470,7 +531,7 @@ export const CreatePaymentSubmissionComponent = () => {
       return
     }
     if (totalSelected === 0) {
-      toast.error("Select at least one run, design or task")
+      toast.error("Select at least one run, inventory order, design or task")
       return
     }
 
@@ -611,6 +672,20 @@ export const CreatePaymentSubmissionComponent = () => {
         // Per-piece prices, when this selection has any (#1596).
         rate_breakdown: Object.keys(rateBreakdown).length
           ? rateBreakdown
+          : undefined,
+        /**
+         * GOODS (#1612). An order is claimed by id with an explicit amount —
+         * the receipts value capped at what the guard still accepts, or a
+         * figure an operator retyped. Sending no amount would default the
+         * server to the raw receipts value, which on an over-delivered order
+         * sits ABOVE the ordered total and is refused (#1617).
+         */
+        inventory_order_lines: selectedInventoryOrders.length
+          ? selectedInventoryOrders.map((order) => ({
+              inventory_order_id: order.inventory_order_id,
+              amount: getInventoryAmount(order),
+              currency: order.currency_code || undefined,
+            }))
           : undefined,
         /**
          * 🔑 Paying out a COMPLETED RUN, whose proof of finished work is the
@@ -779,7 +854,7 @@ export const CreatePaymentSubmissionComponent = () => {
             <Tabs
               value={activeTab}
               onValueChange={(v) =>
-                setActiveTab(v as "runs" | "designs" | "tasks")
+                setActiveTab(v as "runs" | "inventory" | "designs" | "tasks")
               }
             >
               <Tabs.List>
@@ -791,6 +866,17 @@ export const CreatePaymentSubmissionComponent = () => {
                   {selectedRunIds.size > 0 && (
                     <Badge size="2xsmall" color="green" className="ml-1">
                       {selectedRunIds.size} picked
+                    </Badge>
+                  )}
+                </Tabs.Trigger>
+                <Tabs.Trigger value="inventory">
+                  Inventory orders{" "}
+                  <Badge size="2xsmall" color="grey" className="ml-2">
+                    {payableInventoryOrders.filter((o) => o.payable).length}
+                  </Badge>
+                  {selectedInventoryOrderIds.size > 0 && (
+                    <Badge size="2xsmall" color="green" className="ml-1">
+                      {selectedInventoryOrderIds.size} picked
                     </Badge>
                   )}
                 </Tabs.Trigger>
@@ -848,6 +934,39 @@ export const CreatePaymentSubmissionComponent = () => {
                   getAmount={getRunAmount}
                   billsVerbatimTotal={runBillsVerbatimTotal}
                   hasTypedRate={runHasTypedRate}
+                />
+              </Tabs.Content>
+
+              {/*
+                GOODS, as opposed to work. The founder's distinction: an
+                inventory order is stock coming IN, a production run is the
+                work and its expenses. Both are owed to a partner and only one
+                of them has ever been payable through a screen.
+              */}
+              <Tabs.Content value="inventory" className="mt-4">
+                <PayableInventoryOrdersGrid
+                  orders={payableInventoryOrders}
+                  isLoading={inventoryLoading}
+                  selectedIds={selectedInventoryOrderIds}
+                  amountOverrides={inventoryAmountOverrides}
+                  onSelectionChange={(id, selected) =>
+                    setSelectedInventoryOrderIds((prev) => {
+                      const next = new Set(prev)
+                      if (selected) {
+                        next.add(id)
+                      } else {
+                        next.delete(id)
+                      }
+                      return next
+                    })
+                  }
+                  onAmountChange={(id, value) =>
+                    handleRunNumberChange(setInventoryAmountOverrides, id, value)
+                  }
+                  onClearSelection={() =>
+                    setSelectedInventoryOrderIds(new Set())
+                  }
+                  getAmount={getInventoryAmount}
                 />
               </Tabs.Content>
 

--- a/apps/backend/src/admin/components/creates/lib/run-line-pricing.ts
+++ b/apps/backend/src/admin/components/creates/lib/run-line-pricing.ts
@@ -1,0 +1,74 @@
+/**
+ * What one payable run bills, and on which channel it must be SENT.
+ *
+ * ## The rule
+ *
+ * A run carries either a rate or a total, and `cost_type` says which. A
+ * `per_unit` run was agreed at so much per piece, so its amount is
+ * `quantity × rate` and moving the quantity moves the money — that is the whole
+ * meaning of per-unit.
+ *
+ * A `total` run was agreed at a price for the JOB. `payable-runs` still sends a
+ * `unit_amount` for it, derived as `total / quantity` purely so a screen can
+ * show a rate, and flags it `unit_is_derived` for exactly this reason:
+ * multiplying it back out does NOT reproduce the total. On a real run — ₹10,000
+ * agreed, 9 ordered, 7 made — that arithmetic bills ₹7,777.77, a 22% cut nobody
+ * decided, and even when ordered equals produced it loses a paisa to rounding
+ * (₹9,999.99). 97 of 100 production runs are priced this way.
+ *
+ * So an untouched total-priced run bills its agreed figure VERBATIM, and the
+ * quantity does not move it.
+ *
+ * ## Typing a rate is the way out
+ *
+ * A human who has decided a per-unit price outranks a stored figure — that is
+ * already `create`'s documented precedence. Once someone types a rate, the row
+ * is per-piece by their decision and multiplies from then on.
+ *
+ * ## Why this is its own file
+ *
+ * It decides displayed money AND which request field carries it, and those two
+ * must agree. `create` prices in a fixed order: a typed line total wins
+ * outright, then a typed RATE, and only then the runs via `runPayableOffer`.
+ * Sending a derived rate as `unit_amounts` therefore OUTRANKS the one true
+ * pricer and makes the server multiply a figure that was never per-piece — the
+ * screen would show one number and the submission would be written with
+ * another, which is #1616 exactly.
+ */
+
+export type RunLinePricingInput = {
+  /** `production_runs.quantity`-derived units being billed. */
+  quantity: number
+  /** The rate in the box: the run's own, or one an operator typed. */
+  rate: number
+  /** What `payable-runs` says is owed. For a total run, the agreed total. */
+  amount: number
+  /** Whether `rate` was computed rather than agreed. */
+  unit_is_derived?: boolean | null
+  /** Whether a human has typed a rate for this run. */
+  hasTypedRate: boolean
+}
+
+/**
+ * PURE. Whether this row still bills an agreed TOTAL rather than a rate.
+ *
+ * Both halves matter: a derived rate that somebody has since overtyped is no
+ * longer derived, and a genuine per-unit rate was never a total.
+ */
+export const runBillsVerbatimTotal = (
+  input: Pick<RunLinePricingInput, "unit_is_derived" | "hasTypedRate">
+): boolean => !input.hasTypedRate && !!input.unit_is_derived
+
+/** PURE. What this run bills. */
+export const runLineAmount = (input: RunLinePricingInput): number => {
+  if (runBillsVerbatimTotal(input)) {
+    // Verbatim. Not rounded, not re-derived, not multiplied.
+    return input.amount
+  }
+  const quantity = Number(input.quantity)
+  const rate = Number(input.rate)
+  if (!Number.isFinite(quantity) || !Number.isFinite(rate)) {
+    return 0
+  }
+  return Math.round(quantity * rate * 100) / 100
+}

--- a/apps/backend/src/admin/components/creates/payable-inventory-orders-grid.tsx
+++ b/apps/backend/src/admin/components/creates/payable-inventory-orders-grid.tsx
@@ -1,0 +1,403 @@
+import { useEffect, useMemo } from "react"
+import { useForm, useWatch } from "react-hook-form"
+import { Badge, CommandBar, Container, Text } from "@medusajs/ui"
+
+import { DataGrid } from "../data-grid/data-grid"
+import {
+  DataGridBooleanCell,
+  DataGridNumberCell,
+  DataGridReadOnlyCell,
+} from "../data-grid/components"
+import { createDataGridHelper } from "../data-grid/helpers/create-data-grid-column-helper"
+import { PayableInventoryOrder } from "../../hooks/api/payment-submissions"
+
+/**
+ * Inventory orders a partner may be paid for — GOODS, as opposed to work.
+ *
+ * A production run is the work and its expenses; an inventory order is stock
+ * coming IN. Both are things a partner is owed for, and `create` has accepted
+ * `inventory_order_lines` since #1612 — validator, partner-ownership guard,
+ * read-side resolution, the lot. Nothing ever sent one, because no screen
+ * offered them. On production, NO payment carries an `inventory_order_id`: a
+ * capability with no way to reach it is a capability nobody has.
+ *
+ * ## The two numbers that are not the same
+ *
+ * 🔴 What is OWED comes from the RECEIPTS, never from the ordered total. An
+ * order placed for ₹88,885 with ₹28,670 actually delivered is owed ₹28,670 —
+ * billing the ordered total there overpays by ₹60,215 (#1612).
+ *
+ * 🔴 But the guard's CEILING is the ordered total, and the receipts figure can
+ * legitimately sit above it (₹64,274 derived against ₹63,375.75 ordered on the
+ * order that opened #1617). So a row offers the receipts value CAPPED at what
+ * is left, says when the cap bit, and keeps the raw figure beside it. Offering
+ * the uncapped number would be a screen teaching the rule through a 400.
+ *
+ * ## What is shown rather than hidden
+ *
+ * An order with no receipts recorded is listed, marked, and not selectable.
+ * "Why isn't this order here" is the question an operator arrives with, and no
+ * receipt is a gap in the record — not a statement that the goods were free.
+ */
+
+type OrderRow = {
+  order: PayableInventoryOrder
+  index: number
+}
+
+type GridValues = {
+  rows: Array<{ selected: boolean; amount: number }>
+}
+
+const round2 = (n: number) => Math.round(n * 100) / 100
+
+export const PayableInventoryOrdersGrid = ({
+  orders,
+  isLoading,
+  selectedIds,
+  amountOverrides,
+  onSelectionChange,
+  onAmountChange,
+  onClearSelection,
+  getAmount,
+}: {
+  orders: PayableInventoryOrder[]
+  isLoading: boolean
+  selectedIds: Set<string>
+  amountOverrides: Record<string, number>
+  onSelectionChange: (orderId: string, selected: boolean) => void
+  onAmountChange: (orderId: string, value: string) => void
+  onClearSelection: () => void
+  getAmount: (order: PayableInventoryOrder) => number
+}) => {
+  const rows: OrderRow[] = useMemo(
+    () => orders.map((order, index) => ({ order, index })),
+    [orders]
+  )
+
+  const form = useForm<GridValues>({
+    defaultValues: {
+      rows: orders.map((order) => ({
+        selected: selectedIds.has(order.inventory_order_id),
+        amount: getAmount(order),
+      })),
+    },
+  })
+
+  /**
+   * Re-seed when a different partner's orders arrive. Keyed on the ids rather
+   * than the array, so a refetch cannot wipe a figure being typed.
+   */
+  const orderKey = orders.map((o) => o.inventory_order_id).join(",")
+  useEffect(() => {
+    form.reset({
+      rows: orders.map((order) => ({
+        selected: selectedIds.has(order.inventory_order_id),
+        amount: getAmount(order),
+      })),
+    })
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [orderKey])
+
+  const watched = useWatch({ control: form.control, name: "rows" }) as
+    | GridValues["rows"]
+    | undefined
+
+  useEffect(() => {
+    if (!watched) {
+      return
+    }
+    watched.forEach((row, index) => {
+      const order = orders[index]
+      if (!order) {
+        return
+      }
+
+      const nextSelected = !!row?.selected && order.payable
+      if (nextSelected !== selectedIds.has(order.inventory_order_id)) {
+        onSelectionChange(order.inventory_order_id, nextSelected)
+      }
+
+      const nextAmount = Number(row?.amount)
+      if (Number.isFinite(nextAmount) && nextAmount !== getAmount(order)) {
+        onAmountChange(order.inventory_order_id, String(nextAmount))
+      }
+    })
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [watched])
+
+  const columnHelper = createDataGridHelper<OrderRow, GridValues>()
+
+  const columns = useMemo(
+    () => [
+      columnHelper.column({
+        id: "selected",
+        name: "Bill",
+        header: "Bill",
+        field: (context: any) => `rows.${context.row.index}.selected`,
+        type: "boolean",
+        disableHiding: true,
+        cell: (context: any) => (
+          <DataGridBooleanCell
+            context={context}
+            // Nothing to bill: no receipt recorded, or the order is already
+            // fully claimed. Disabled rather than absent — the row still
+            // answers "where is this order".
+            disabled={!rows[context.row.index]?.order.payable}
+          />
+        ),
+      }),
+      columnHelper.column({
+        id: "order",
+        name: "Order",
+        header: "Order",
+        disableHiding: true,
+        cell: (context: any) => {
+          const order = rows[context.row.index]?.order
+          if (!order) {
+            return <DataGridReadOnlyCell context={context} />
+          }
+          return (
+            <DataGridReadOnlyCell context={context}>
+              {/* The id lives here — the grid renders its own rows and offers
+                  no hook for a per-row attribute. */}
+              <div
+                className="flex w-full items-center gap-x-2 overflow-hidden"
+                data-testid="payable-inventory-order-row"
+                data-inventory-order-id={order.inventory_order_id}
+              >
+                <Text size="small" className="truncate font-mono">
+                  {order.inventory_order_id.slice(0, 22)}…
+                </Text>
+                {order.status && (
+                  <Badge color="grey" size="2xsmall" className="shrink-0">
+                    {order.status}
+                  </Badge>
+                )}
+                {order.is_sample && (
+                  <Badge color="purple" size="2xsmall" className="shrink-0">
+                    sample
+                  </Badge>
+                )}
+                {order.claimed_total > 0 && (
+                  <Badge color="orange" size="2xsmall" className="shrink-0">
+                    part-paid
+                  </Badge>
+                )}
+                {!order.payable && (
+                  <Badge color="red" size="2xsmall" className="shrink-0">
+                    {order.receipts_total > 0 ? "fully paid" : "no receipts"}
+                  </Badge>
+                )}
+              </div>
+            </DataGridReadOnlyCell>
+          )
+        },
+      }),
+      columnHelper.column({
+        id: "received",
+        name: "Received",
+        header: "Received",
+        cell: (context: any) => {
+          const order = rows[context.row.index]?.order
+          if (!order) {
+            return <DataGridReadOnlyCell context={context} />
+          }
+          return (
+            <DataGridReadOnlyCell context={context}>
+              <Text size="small" className="truncate">
+                {order.received_quantity} unit
+                {order.received_quantity === 1 ? "" : "s"}
+                {order.lines.length
+                  ? ` · ${order.lines.length} line${order.lines.length === 1 ? "" : "s"}`
+                  : ""}
+              </Text>
+            </DataGridReadOnlyCell>
+          )
+        },
+      }),
+      columnHelper.column({
+        id: "worth",
+        name: "Delivered value",
+        header: "Delivered value",
+        cell: (context: any) => {
+          const order = rows[context.row.index]?.order
+          if (!order) {
+            return <DataGridReadOnlyCell context={context} />
+          }
+          /**
+           * Receipts against what was ordered, side by side. Which one the
+           * amount is built from is stated in "Basis" rather than inferred by
+           * the reader — the two are routinely different and that is normal,
+           * not an error.
+           */
+          return (
+            <DataGridReadOnlyCell context={context}>
+              <Text size="small" className="truncate tabular-nums">
+                {order.receipts_total.toLocaleString()} of{" "}
+                {order.ordered_total == null
+                  ? "—"
+                  : order.ordered_total.toLocaleString()}{" "}
+                ordered
+              </Text>
+            </DataGridReadOnlyCell>
+          )
+        },
+      }),
+      columnHelper.column({
+        id: "claimed",
+        name: "Already billed",
+        header: "Already billed",
+        cell: (context: any) => {
+          const order = rows[context.row.index]?.order
+          if (!order) {
+            return <DataGridReadOnlyCell context={context} />
+          }
+          return (
+            <DataGridReadOnlyCell context={context}>
+              <Text size="small" className="truncate tabular-nums">
+                {order.claimed_total > 0
+                  ? `${order.claimed_total.toLocaleString()} · ${
+                      order.remaining == null
+                        ? "—"
+                        : order.remaining.toLocaleString()
+                    } left`
+                  : "—"}
+              </Text>
+            </DataGridReadOnlyCell>
+          )
+        },
+      }),
+      columnHelper.column({
+        id: "amount",
+        name: "Amount",
+        header: "Amount",
+        field: (context: any) => `rows.${context.row.index}.amount`,
+        type: "number",
+        cell: (context: any) => (
+          // 🔴 NO `min` — a native constraint refuses the whole form before any
+          // handler runs, silently, with no submit event to observe (#1671).
+          <DataGridNumberCell context={context} />
+        ),
+      }),
+      columnHelper.column({
+        id: "basis",
+        name: "Basis",
+        header: "Basis",
+        cell: (context: any) => {
+          const order = rows[context.row.index]?.order
+          if (!order) {
+            return <DataGridReadOnlyCell context={context} />
+          }
+          return (
+            <DataGridReadOnlyCell context={context}>
+              <Text
+                size="small"
+                className="truncate"
+                data-testid={`inventory-basis-${order.inventory_order_id}`}
+              >
+                {!order.payable
+                  ? order.receipts_total > 0
+                    ? "already claimed in full"
+                    : "no receipts recorded"
+                  : order.capped_by_ceiling
+                    ? "capped at the ordered total"
+                    : "what was delivered"}
+              </Text>
+            </DataGridReadOnlyCell>
+          )
+        },
+      }),
+    ],
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+    [rows, amountOverrides]
+  )
+
+  const sizedColumns = useMemo(
+    () =>
+      columns.map((col: any) => {
+        if (col.id === "selected") return { ...col, size: 72, maxSize: 88 }
+        if (col.id === "order") return { ...col, size: 340, maxSize: 520 }
+        if (col.id === "received") return { ...col, size: 150, maxSize: 200 }
+        if (col.id === "worth") return { ...col, size: 220, maxSize: 300 }
+        if (col.id === "claimed") return { ...col, size: 180, maxSize: 240 }
+        if (col.id === "amount") return { ...col, size: 140, maxSize: 200 }
+        if (col.id === "basis") return { ...col, size: 210, maxSize: 280 }
+        return col
+      }),
+    [columns]
+  )
+
+  const selectedOrders = orders.filter((o) =>
+    selectedIds.has(o.inventory_order_id)
+  )
+  const selectedTotal = round2(
+    selectedOrders.reduce((sum, order) => sum + getAmount(order), 0)
+  )
+
+  if (isLoading) {
+    return (
+      <Container className="p-8">
+        <Text className="text-ui-fg-subtle text-center">
+          Loading inventory orders...
+        </Text>
+      </Container>
+    )
+  }
+
+  if (!orders.length) {
+    return (
+      <Container className="p-8">
+        <Text className="text-ui-fg-subtle text-center">
+          No inventory orders for this partner. These are goods you bought from
+          them — a production run is the work instead.
+        </Text>
+      </Container>
+    )
+  }
+
+  const billableCount = orders.filter((o) => o.payable).length
+
+  return (
+    <div className="flex flex-col gap-y-2">
+      <div className="flex items-center justify-between">
+        <Text size="small" className="text-ui-fg-subtle">
+          {billableCount} billable of {orders.length}
+        </Text>
+        <Text size="xsmall" className="text-ui-fg-muted">
+          Arrow keys to move · Enter to edit · ⇧↓ to extend · ⌘C/⌘V to fill down
+        </Text>
+      </div>
+
+      <DataGrid
+        data={rows}
+        columns={sizedColumns as any}
+        state={form}
+        multiColumnSelection
+      />
+
+      <Text size="xsmall" className="text-ui-fg-subtle">
+        An order bills what was DELIVERED, not what was ordered — the two are
+        routinely different and only receipts are money owed. An order can be
+        billed in tranches, so "already billed" is what previous submissions
+        took and the amount is capped at what is left.
+      </Text>
+
+      <CommandBar open={selectedOrders.length > 0}>
+        <CommandBar.Bar>
+          <CommandBar.Value>
+            {selectedOrders.length} order
+            {selectedOrders.length === 1 ? "" : "s"} ·{" "}
+            {selectedTotal.toLocaleString()}
+          </CommandBar.Value>
+          <CommandBar.Seperator />
+          <CommandBar.Command
+            action={onClearSelection}
+            label="Clear"
+            shortcut="c"
+          />
+        </CommandBar.Bar>
+      </CommandBar>
+    </div>
+  )
+}

--- a/apps/backend/src/admin/components/creates/payable-runs-grid.tsx
+++ b/apps/backend/src/admin/components/creates/payable-runs-grid.tsx
@@ -1,0 +1,461 @@
+import { useEffect, useMemo } from "react"
+import { useForm, useWatch } from "react-hook-form"
+import { Badge, CommandBar, Container, Text } from "@medusajs/ui"
+
+import { DataGrid } from "../data-grid/data-grid"
+import {
+  DataGridBooleanCell,
+  DataGridNumberCell,
+  DataGridReadOnlyCell,
+} from "../data-grid/components"
+import { createDataGridHelper } from "../data-grid/helpers/create-data-grid-column-helper"
+import { PayableRun } from "../../hooks/api/payment-submissions"
+
+/**
+ * The payable runs, as a spreadsheet.
+ *
+ * ## Why a grid
+ *
+ * This screen is where an operator decides what a partner gets paid, and the
+ * decision is made across rows rather than within one: is this rate the same as
+ * that rate, does this run's quantity match the one below it, which of these
+ * twelve am I billing today. The stacked cards it replaces put every row in its
+ * own box and every number in its own tab-stop, so comparing two runs meant
+ * scrolling between two cards and holding a figure in your head.
+ *
+ * A grid also brings the thing the card list could not: arrow-key navigation,
+ * shift-select down a column, and copy/paste — so setting the same rate on ten
+ * runs is one gesture rather than ten.
+ *
+ * ## The form is a mirror, not the source of truth
+ *
+ * The parent still owns selection and the overrides, because the submit path,
+ * the totals, and the design/task panels all read from there. This grid keeps a
+ * form shaped like its rows and reports changes UP. Making the form
+ * authoritative would mean rewriting the submit path at the same time as the
+ * table, and a payout screen is not where two rewrites should meet.
+ *
+ * 🔴 `selected` is a real grid column rather than a checkbox bolted to the left
+ * edge, precisely so it can be dragged and pasted like any other. That is the
+ * bulk selection the card list never had.
+ *
+ * ⚠️ A row that is already BILLED is rendered, not filtered — "why isn't this
+ * run here" is the question an operator arrives with — but its cells are
+ * read-only, so the grid cannot select something the submit guard will refuse.
+ */
+
+type RunRow = {
+  run: PayableRun
+  index: number
+}
+
+type GridValues = {
+  rows: Array<{
+    selected: boolean
+    quantity: number
+    rate: number
+  }>
+}
+
+const round2 = (n: number) => Math.round(n * 100) / 100
+
+export const PayableRunsGrid = ({
+  runs,
+  isLoading,
+  selectedIds,
+  quantityOverrides,
+  rateOverrides,
+  onSelectionChange,
+  onQuantityChange,
+  onRateChange,
+  onClearSelection,
+  getQuantity,
+  getRate,
+  getAmount,
+  billsVerbatimTotal,
+  hasTypedRate,
+}: {
+  runs: PayableRun[]
+  isLoading: boolean
+  selectedIds: Set<string>
+  quantityOverrides: Record<string, number>
+  rateOverrides: Record<string, number>
+  onSelectionChange: (runId: string, selected: boolean) => void
+  onQuantityChange: (runId: string, value: string) => void
+  onRateChange: (runId: string, value: string) => void
+  onClearSelection: () => void
+  getQuantity: (run: PayableRun) => number
+  getRate: (run: PayableRun) => number
+  getAmount: (run: PayableRun) => number
+  /** Whether this row still bills an agreed TOTAL rather than a typed rate. */
+  billsVerbatimTotal: (run: PayableRun) => boolean
+  /** Whether a human has typed a rate for this run. */
+  hasTypedRate: (run: PayableRun) => boolean
+}) => {
+  const rows: RunRow[] = useMemo(
+    () => runs.map((run, index) => ({ run, index })),
+    [runs]
+  )
+
+  const form = useForm<GridValues>({
+    defaultValues: {
+      rows: runs.map((run) => ({
+        selected: selectedIds.has(run.run_id),
+        quantity: getQuantity(run),
+        rate: getRate(run),
+      })),
+    },
+  })
+
+  /**
+   * Re-seed when the partner changes and a different set of runs arrives.
+   *
+   * Keyed on the run ids rather than on `runs` itself: the query refetches and
+   * hands back a new array for the same runs, and resetting on identity would
+   * wipe a rate an operator was halfway through typing.
+   */
+  const runKey = runs.map((r) => r.run_id).join(",")
+  useEffect(() => {
+    form.reset({
+      rows: runs.map((run) => ({
+        selected: selectedIds.has(run.run_id),
+        quantity: getQuantity(run),
+        rate: getRate(run),
+      })),
+    })
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [runKey])
+
+  const watched = useWatch({ control: form.control, name: "rows" }) as
+    | GridValues["rows"]
+    | undefined
+
+  /**
+   * Push grid edits back to the parent.
+   *
+   * Each field is compared against what the parent already holds before being
+   * reported, so a re-render cannot loop, and a value the operator did not
+   * touch is never announced as a change.
+   */
+  useEffect(() => {
+    if (!watched) {
+      return
+    }
+    watched.forEach((row, index) => {
+      const run = runs[index]
+      if (!run) {
+        return
+      }
+
+      const nextSelected = !!row?.selected && !run.billed
+      if (nextSelected !== selectedIds.has(run.run_id)) {
+        onSelectionChange(run.run_id, nextSelected)
+      }
+
+      const nextQty = Number(row?.quantity)
+      if (Number.isFinite(nextQty) && nextQty !== getQuantity(run)) {
+        onQuantityChange(run.run_id, String(nextQty))
+      }
+
+      const nextRate = Number(row?.rate)
+      if (Number.isFinite(nextRate) && nextRate !== getRate(run)) {
+        onRateChange(run.run_id, String(nextRate))
+      }
+    })
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [watched])
+
+  const columnHelper = createDataGridHelper<RunRow, GridValues>()
+
+  const columns = useMemo(
+    () => [
+      columnHelper.column({
+        id: "selected",
+        name: "Bill",
+        header: "Bill",
+        field: (context: any) => `rows.${context.row.index}.selected`,
+        type: "boolean",
+        disableHiding: true,
+        cell: (context: any) => (
+          <DataGridBooleanCell
+            context={context}
+            // An already-paid run cannot be billed again. Disabled rather than
+            // absent: the row still answers "where is this run".
+            disabled={!!rows[context.row.index]?.run.billed}
+          />
+        ),
+      }),
+      columnHelper.column({
+        id: "design",
+        name: "Design",
+        header: "Design",
+        disableHiding: true,
+        cell: (context: any) => {
+          const run = rows[context.row.index]?.run
+          if (!run) {
+            return <DataGridReadOnlyCell context={context} />
+          }
+          return (
+            <DataGridReadOnlyCell context={context}>
+              {/*
+                🔑 The run's identity lives on the DESIGN cell, because the grid
+                renders its own rows and there is no hook for a per-row
+                attribute. Tests address the row through this cell.
+                ⚠️ The FULL id: the seed's runs are created in the same
+                millisecond, so their ULIDs share a 16-char prefix and a
+                truncated match hits two different runs.
+              */}
+              <div
+                className="flex w-full items-center gap-x-2 overflow-hidden"
+                data-testid="payable-run-row"
+                data-run-id={run.run_id}
+              >
+                <Text size="small" className="truncate">
+                  {run.design_name || "Unnamed design"}
+                </Text>
+                {run.billed && (
+                  <Badge color="orange" size="2xsmall" className="shrink-0">
+                    paid
+                  </Badge>
+                )}
+                {!run.payable && !run.billed && (
+                  <Badge color="orange" size="2xsmall" className="shrink-0">
+                    no rate
+                  </Badge>
+                )}
+                {/* #1596 — the produced/ordered gap on this row is SETTLED. */}
+                {run.short_closed_at && (
+                  <Badge color="grey" size="2xsmall" className="shrink-0">
+                    closed
+                  </Badge>
+                )}
+                {/*
+                  🔴 An agreed TOTAL, not a rate. The Rate column beside it is
+                  a division done for display, and a grid invites copying a
+                  column down — so the row has to say which of its numbers was
+                  actually negotiated.
+                */}
+                {billsVerbatimTotal(run) && (
+                  <Badge color="blue" size="2xsmall" className="shrink-0">
+                    total
+                  </Badge>
+                )}
+              </div>
+            </DataGridReadOnlyCell>
+          )
+        },
+      }),
+      columnHelper.column({
+        id: "output",
+        name: "Output",
+        header: "Output",
+        cell: (context: any) => {
+          const run = rows[context.row.index]?.run
+          if (!run) {
+            return <DataGridReadOnlyCell context={context} />
+          }
+          return (
+            <DataGridReadOnlyCell context={context}>
+              <Text size="small" className="truncate">
+                {run.produced_quantity ?? "—"} of {run.ordered_quantity ?? "—"}
+                {run.quantity_basis === "ordered"
+                  ? " · no output recorded"
+                  : run.short_closed_at
+                    ? " · closed short"
+                    : ""}
+              </Text>
+            </DataGridReadOnlyCell>
+          )
+        },
+      }),
+      columnHelper.column({
+        id: "quantity",
+        name: "Qty",
+        header: "Qty",
+        field: (context: any) => `rows.${context.row.index}.quantity`,
+        type: "number",
+        cell: (context: any) => (
+          // 🔴 NO `min` here (#1671). It becomes a native `min` attribute, and
+          // native constraint validation refuses the whole form BEFORE any
+          // handler runs — silently, with no submit event to observe.
+          <DataGridNumberCell context={context} />
+        ),
+      }),
+      columnHelper.column({
+        id: "rate",
+        name: "Rate",
+        header: "Rate",
+        field: (context: any) => `rows.${context.row.index}.rate`,
+        type: "number",
+        cell: (context: any) => <DataGridNumberCell context={context} />,
+      }),
+      columnHelper.column({
+        id: "basis",
+        name: "Priced on",
+        header: "Priced on",
+        cell: (context: any) => {
+          const run = rows[context.row.index]?.run
+          if (!run) {
+            return <DataGridReadOnlyCell context={context} />
+          }
+          /**
+           * What the Rate box actually IS, in words.
+           *
+           * "derived" means the run was agreed as a total and the rate beside
+           * it is that total divided out — so changing the quantity does not
+           * change what is owed. Typing a rate is the deliberate way to make
+           * this row per-piece, and the label changes when you do.
+           */
+          return (
+            <DataGridReadOnlyCell context={context}>
+              <Text size="small" className="truncate">
+                {billsVerbatimTotal(run)
+                  ? "agreed total · rate derived"
+                  : hasTypedRate(run)
+                    ? "rate you typed"
+                    : run.payable
+                      ? "agreed rate"
+                      : // Not "rate you typed" — nobody has. The run finished
+                        // and no price was ever recorded, which is a gap in the
+                        // record rather than a price of zero (#1554).
+                        "no rate yet"}
+              </Text>
+            </DataGridReadOnlyCell>
+          )
+        },
+      }),
+      columnHelper.column({
+        id: "amount",
+        name: "Amount",
+        header: "Amount",
+        cell: (context: any) => {
+          const run = rows[context.row.index]?.run
+          if (!run) {
+            return <DataGridReadOnlyCell context={context} />
+          }
+          /**
+           * ⚠️ Derived from the CELLS, not from `run.amount`.
+           *
+           * For a `cost_type: "total"` run the agreed total is not
+           * quantity × rate, and the rate shown is divided back out for display
+           * (#1596). Once an operator retypes either box, the only honest
+           * amount is the one their own two numbers make — which is also the
+           * one the submit path writes.
+           */
+          const rate = getRate(run)
+          return (
+            <DataGridReadOnlyCell context={context}>
+              <Text
+                size="small"
+                className="truncate tabular-nums"
+                data-testid={`run-amount-${run.run_id}`}
+              >
+                {/*
+                  An em dash, not a zero, while no rate has been given. "0" here
+                  reads as an agreed price of nothing, which is a different
+                  claim from "nobody has said what this costs yet" (#1554).
+                */}
+                {rate > 0 ? getAmount(run).toLocaleString() : "—"}
+              </Text>
+            </DataGridReadOnlyCell>
+          )
+        },
+      }),
+    ],
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+    [rows, quantityOverrides, rateOverrides]
+  )
+
+  const sizedColumns = useMemo(
+    () =>
+      columns.map((col: any) => {
+        if (col.id === "selected") return { ...col, size: 72, maxSize: 88 }
+        if (col.id === "design") return { ...col, size: 320, maxSize: 520 }
+        if (col.id === "output") return { ...col, size: 220, maxSize: 300 }
+        if (col.id === "quantity") return { ...col, size: 120, maxSize: 160 }
+        if (col.id === "rate") return { ...col, size: 130, maxSize: 200 }
+        if (col.id === "basis") return { ...col, size: 200, maxSize: 260 }
+        if (col.id === "amount") return { ...col, size: 140, maxSize: 200 }
+        return col
+      }),
+    [columns]
+  )
+
+  const selectedRuns = runs.filter((r) => selectedIds.has(r.run_id))
+  const selectedTotal = round2(
+    selectedRuns.reduce((sum, run) => sum + getAmount(run), 0)
+  )
+
+  if (isLoading) {
+    return (
+      <Container className="p-8">
+        <Text className="text-ui-fg-subtle text-center">
+          Loading production runs...
+        </Text>
+      </Container>
+    )
+  }
+
+  if (!runs.length) {
+    return (
+      <Container className="p-8">
+        <Text className="text-ui-fg-subtle text-center">
+          No completed production runs for this partner. A run has to be
+          completed before it can be paid for.
+        </Text>
+      </Container>
+    )
+  }
+
+  const selectableCount = runs.filter((r) => !r.billed).length
+
+  return (
+    <div className="flex flex-col gap-y-2">
+      <div className="flex items-center justify-between">
+        <Text size="small" className="text-ui-fg-subtle">
+          {selectableCount} billable of {runs.length}
+        </Text>
+        <Text size="xsmall" className="text-ui-fg-muted">
+          Arrow keys to move · Enter to edit · ⇧↓ to extend · ⌘C/⌘V to fill down
+        </Text>
+      </div>
+
+      <DataGrid
+        data={rows}
+        columns={sizedColumns as any}
+        state={form}
+        multiColumnSelection
+      />
+
+      {runs.some((r) => billsVerbatimTotal(r)) && (
+        <Text size="xsmall" className="text-ui-fg-subtle">
+          Rows marked <span className="font-medium">total</span> were agreed as
+          a price for the job, not per piece. Their amount is that agreed total
+          and does not move with the quantity. Type a rate to price one per
+          piece instead.
+        </Text>
+      )}
+
+      {/*
+        The running total, where the decision is being made. The header's
+        Create button is the other end of the room from the rows being
+        chosen, and an operator selecting twelve runs had no way to see what
+        they added up to until after the submission existed.
+      */}
+      <CommandBar open={selectedRuns.length > 0}>
+        <CommandBar.Bar>
+          <CommandBar.Value>
+            {selectedRuns.length} run{selectedRuns.length === 1 ? "" : "s"} ·{" "}
+            {selectedTotal.toLocaleString()}
+          </CommandBar.Value>
+          <CommandBar.Seperator />
+          <CommandBar.Command
+            action={onClearSelection}
+            label="Clear"
+            shortcut="c"
+          />
+        </CommandBar.Bar>
+      </CommandBar>
+    </div>
+  )
+}

--- a/apps/backend/src/admin/components/production-runs/production-run-short-close-form.tsx
+++ b/apps/backend/src/admin/components/production-runs/production-run-short-close-form.tsx
@@ -1,0 +1,183 @@
+import { Alert, Button, Text, Textarea, toast } from "@medusajs/ui"
+import { z } from "@medusajs/framework/zod"
+import { zodResolver } from "@hookform/resolvers/zod"
+import { useForm } from "react-hook-form"
+
+import { Form } from "../common/form"
+import { KeyboundForm } from "../utilitites/key-bound-form"
+import { RouteDrawer } from "../modal/route-drawer/route-drawer"
+import { useRouteModal } from "../modal/use-route-modal"
+import {
+  AdminProductionRun,
+  useReopenProductionRun,
+  useShortCloseProductionRun,
+} from "../../hooks/api/production-runs"
+
+const schema = z.object({
+  reason: z.string().optional(),
+})
+
+type FormValues = z.infer<typeof schema>
+
+const asNumber = (value: unknown): number | null => {
+  const n = Number(value)
+  return Number.isFinite(n) ? n : null
+}
+
+/**
+ * ⚠️ `short_closed_quantity` is a float column, so it arrives as "4.000000" and
+ * printing it verbatim reads as a measurement precision nobody recorded.
+ */
+const fmt = (value: number | null): string => (value == null ? "—" : String(value))
+
+interface ShortCloseFormProps {
+  run: AdminProductionRun
+}
+
+/**
+ * #1596 — declare a run finished for good, or reverse that declaration.
+ *
+ * The screen's job here is to state the consequence in units before it is
+ * taken, because the consequence is somebody's money: closing a run ordered
+ * for 9 at 7 produced means those last 2 units stop being billable, through
+ * this screen and through the write guard alike.
+ *
+ * 🔑 It also states what closing does NOT do. Nothing is clawed back — a run
+ * already billed to 7 and then closed at 4 keeps the 7, the remainder clamps
+ * at zero, and only further claims are refused. An admin reading "close" as
+ * "reverse the overpayment" would be wrong, and this is the only place that
+ * misreading can be corrected before the click.
+ */
+export const ShortCloseRunForm = ({ run }: ShortCloseFormProps) => {
+  const { handleSuccess } = useRouteModal()
+  const isClosed = !!run.short_closed_at
+
+  const shortClose = useShortCloseProductionRun(run.id)
+  const reopen = useReopenProductionRun(run.id)
+
+  const form = useForm<FormValues>({
+    resolver: zodResolver(schema),
+    defaultValues: { reason: "" },
+  })
+
+  const ordered = asNumber(run.quantity)
+  const produced = asNumber(run.produced_quantity)
+  const forfeited =
+    ordered != null && produced != null && ordered > produced
+      ? Math.round((ordered - produced) * 100) / 100
+      : null
+
+  const onSubmit = form.handleSubmit(async (data) => {
+    const reason = data.reason?.trim() ? data.reason.trim() : null
+    try {
+      if (isClosed) {
+        await reopen.mutateAsync({ reason })
+        toast.success("Run reopened — billable to its ordered quantity again")
+      } else {
+        await shortClose.mutateAsync({ reason })
+        toast.success("Run short-closed")
+      }
+      handleSuccess()
+    } catch (e: any) {
+      toast.error(
+        e?.message ||
+          (isClosed ? "Failed to reopen the run" : "Failed to short-close the run")
+      )
+    }
+  })
+
+  const isPending = shortClose.isPending || reopen.isPending
+
+  return (
+    <RouteDrawer.Form form={form}>
+      <KeyboundForm onSubmit={onSubmit} className="flex flex-1 flex-col overflow-hidden">
+        <RouteDrawer.Body className="flex flex-1 flex-col gap-y-6 overflow-y-auto">
+          {isClosed ? (
+            <Alert variant="info">
+              <Text size="small">
+                This run is closed at{" "}
+                <strong>{fmt(asNumber(run.short_closed_quantity) ?? produced)}</strong>{" "}
+                of {fmt(ordered)} ordered. Reopening makes the ordered
+                quantity billable again — use it when the close was premature, or
+                when more work is genuinely coming.
+              </Text>
+            </Alert>
+          ) : (
+            <Alert variant="warning">
+              <Text size="small">
+                {produced == null || produced <= 0 ? (
+                  <>
+                    This run has no recorded output. Closing it would leave the
+                    ceiling at the ordered quantity — a decision that changes
+                    nothing. Record the produced quantity first.
+                  </>
+                ) : (
+                  <>
+                    Closing declares that no more will be made. This run bills to{" "}
+                    <strong>{produced}</strong> produced instead of{" "}
+                    <strong>{fmt(ordered)}</strong> ordered
+                    {forfeited != null ? (
+                      <>
+                        , so <strong>{forfeited}</strong> unit
+                        {forfeited === 1 ? "" : "s"} stop being billable
+                      </>
+                    ) : null}
+                    .
+                  </>
+                )}
+              </Text>
+            </Alert>
+          )}
+
+          {!isClosed && (
+            <Text size="xsmall" className="text-ui-fg-subtle">
+              Nothing is clawed back. Anything already claimed stays claimed —
+              only further claims are refused. An output correction that raises
+              the produced figure reopens the run automatically.
+            </Text>
+          )}
+
+          <Form.Field
+            control={form.control}
+            name="reason"
+            render={({ field }) => (
+              <Form.Item>
+                <Form.Label optional>Reason</Form.Label>
+                <Form.Control>
+                  <Textarea
+                    {...field}
+                    rows={3}
+                    placeholder={
+                      isClosed
+                        ? "Why is this run being reopened?"
+                        : "Why will no more be made? (recorded on the run's timeline)"
+                    }
+                  />
+                </Form.Control>
+                <Form.ErrorMessage />
+              </Form.Item>
+            )}
+          />
+        </RouteDrawer.Body>
+        <RouteDrawer.Footer>
+          <div className="flex items-center justify-end gap-x-2">
+            <RouteDrawer.Close asChild>
+              <Button size="small" variant="secondary" type="button">
+                Cancel
+              </Button>
+            </RouteDrawer.Close>
+            <Button
+              size="small"
+              type="submit"
+              variant={isClosed ? "secondary" : "danger"}
+              isLoading={isPending}
+              disabled={isPending || (!isClosed && (produced == null || produced <= 0))}
+            >
+              {isClosed ? "Reopen run" : "Short-close run"}
+            </Button>
+          </div>
+        </RouteDrawer.Footer>
+      </KeyboundForm>
+    </RouteDrawer.Form>
+  )
+}

--- a/apps/backend/src/admin/hooks/api/payment-submissions.ts
+++ b/apps/backend/src/admin/hooks/api/payment-submissions.ts
@@ -182,6 +182,21 @@ export interface PayableRun {
   payable_quantity: number
   quantity_basis: "produced" | "ordered"
   unit_amount: number
+  /**
+   * 🔴 Whether `unit_amount` was COMPUTED rather than agreed.
+   *
+   * True for every `cost_type: "total"` run — 97 of 100 on production — where
+   * the rate is `total / quantity` and `unit_amount * quantity` deliberately
+   * does NOT reproduce `amount`. A screen that multiplies it anyway bills a
+   * figure nobody agreed to: ₹7,777.77 against a ₹10,000 job on a short run,
+   * and ₹9,999.99 even on an exact one.
+   *
+   * ⚠️ The API has always sent this. It was missing from this type, so no
+   * screen could read it and none did — the flag existed and had no consumers
+   * for as long as it has been sent.
+   */
+  unit_is_derived: boolean
+  /** What is OWED. For a total-priced run this is the agreed total, verbatim. */
   amount: number
   cost_type: "per_unit" | "total" | null
   partner_cost_estimate: number | null

--- a/apps/backend/src/admin/hooks/api/payment-submissions.ts
+++ b/apps/backend/src/admin/hooks/api/payment-submissions.ts
@@ -152,6 +152,21 @@ export interface CreateAdminPaymentSubmissionPayload {
    * it twice.
    */
   rate_breakdown?: Record<string, Array<{ quantity: number; unit_amount: number }>>
+  /**
+   * GOODS bought from this partner (#1612). Accepted by `create` — with a
+   * validator, a partner-ownership guard and read-side resolution — since the
+   * guard was written; it was missing from THIS type, so no screen could send
+   * one and none did.
+   *
+   * ⚠️ Send the amount explicitly. Omitting it defaults the server to the raw
+   * receipts value, which on an over-delivered order sits ABOVE the ordered
+   * total and is refused by `assessInventoryOrderClaims` (#1617).
+   */
+  inventory_order_lines?: Array<{
+    inventory_order_id: string
+    amount?: number
+    currency?: string
+  }>
   metadata?: Record<string, any>
 }
 
@@ -337,6 +352,90 @@ export const usePayableRuns = (
     ...options,
   })
   return { payable_runs: data?.payable_runs ?? [], count: data?.count ?? 0, ...rest }
+}
+
+/**
+ * An inventory order a partner may be paid for — GOODS, as opposed to work.
+ *
+ * `create` has accepted `inventory_order_lines` since #1612, with a validator,
+ * a partner-ownership guard and read-side resolution. Nothing ever sent one,
+ * because no screen offered them: on production, NO payment carries an
+ * `inventory_order_id`.
+ */
+export interface PayableInventoryOrder {
+  inventory_order_id: string
+  status: string | null
+  is_sample: boolean
+  currency_code: string | null
+  /**
+   * What was ORDERED — and the guard's CEILING. Not what is billed: an order
+   * placed for ₹88,885 with ₹28,670 delivered is owed ₹28,670.
+   */
+  ordered_total: number | null
+  /** What the RECEIPTS are worth, before the ceiling is applied. */
+  receipts_total: number
+  received_quantity: number
+  lines: Array<{
+    line_id: string
+    material_name: string | null
+    received: number
+    ordered: number
+    unit_price: number
+    amount: number
+  }>
+  /** Already billed across every live submission — an order is claimed in tranches. */
+  claimed_total: number
+  /** What may still be billed; null when the order has no readable price. */
+  remaining: number | null
+  /** What this row bills if selected: the receipts value, capped at `remaining`. */
+  amount: number
+  /**
+   * ⚠️ Whether `amount` is BELOW `receipts_total` because the ordered total
+   * bit. The receipts figure can legitimately exceed what was ordered, and
+   * `assessInventoryOrderClaims` refuses that — so the cap is what makes the
+   * offer match what the guard accepts (#1617).
+   */
+  capped_by_ceiling: boolean
+  order_date: string | null
+  expected_delivery_date: string | null
+  payable: boolean
+  claims: Array<{ submission_id: string | null; status: string | null }>
+}
+
+export interface PayableInventoryOrdersResponse {
+  payable_inventory_orders: PayableInventoryOrder[]
+  count: number
+}
+
+export const usePayableInventoryOrders = (
+  partnerId: string | undefined,
+  options?: Omit<
+    UseQueryOptions<
+      PayableInventoryOrdersResponse,
+      FetchError,
+      PayableInventoryOrdersResponse,
+      QueryKey
+    >,
+    "queryFn" | "queryKey"
+  >
+) => {
+  const { data, ...rest } = useQuery({
+    queryFn: async () =>
+      sdk.client.fetch<PayableInventoryOrdersResponse>(
+        `/admin/payment-submissions/payable-inventory-orders`,
+        { method: "GET", query: { partner_id: partnerId } }
+      ) as Promise<PayableInventoryOrdersResponse>,
+    queryKey: paymentSubmissionQueryKeys.list({
+      payable_inventory_orders: partnerId,
+    }),
+    enabled: !!partnerId,
+    ...options,
+  })
+  return {
+    payable_inventory_orders: data?.payable_inventory_orders ?? [],
+    count: data?.count ?? 0,
+    ...rest,
+  }
 }
 
 export const usePaymentSubmission = (

--- a/apps/backend/src/admin/hooks/api/payment-submissions.ts
+++ b/apps/backend/src/admin/hooks/api/payment-submissions.ts
@@ -172,6 +172,12 @@ export interface PayableRun {
   /** Null when output was never recorded — distinct from "made zero". */
   produced_quantity: number | null
   rejected_quantity: number | null
+  /**
+   * #1596 — set means the run was declared finished for good, so the gap
+   * between produced and ordered is settled rather than pending. The offer on
+   * the row already reflects it; this is what lets the screen SAY so.
+   */
+  short_closed_at: string | null
   /** What this row bills for: produced, falling back to ordered. */
   payable_quantity: number
   quantity_basis: "produced" | "ordered"

--- a/apps/backend/src/admin/hooks/api/production-runs.ts
+++ b/apps/backend/src/admin/hooks/api/production-runs.ts
@@ -35,6 +35,18 @@ export type AdminProductionRun = Record<string, any> & {
   run_type?: "production" | "sample"
   partner_id?: string | null
   design_id?: string
+  /**
+   * #1596 — short close. Set means "no more will be made": the run's billable
+   * ceiling is its PRODUCED quantity from here, not its ordered one.
+   * `short_closed_by` is an admin actor id, or the literal "system" when the
+   * 30-day counter closed it. `short_closed_quantity` is what produced was
+   * believed to be at the moment of the decision — the ceiling itself is always
+   * re-derived from the live figure, so a later upward correction is honoured.
+   */
+  short_closed_at?: string | null
+  short_closed_by?: string | null
+  short_close_reason?: string | null
+  short_closed_quantity?: number | null
 }
 
 export type AdminCreateDesignProductionRunResponse =
@@ -817,4 +829,98 @@ export const useProductionRunPayments = (
     ...options,
   })
   return { ...data, ...rest }
+}
+
+/**
+ * SHORT CLOSE (#1596) — "no more will be made on this run."
+ *
+ * A run ordered for 9 and completed at 7 keeps 2 units billable, deliberately:
+ * output is captured at completion and a run can legitimately produce more
+ * afterwards. That headroom cannot tell "not made yet" from "never will be
+ * made", and this is the statement that settles it. From here the run bills to
+ * what it PRODUCED.
+ *
+ * 🔑 Invalidate the billing key too. The remainder shown beside "Partly billed"
+ * is computed by `/payments` from the same ceiling this moves, and a screen
+ * still offering units the write guard now refuses is how an admin learns about
+ * a rule from a 400.
+ */
+const invalidateRunBilling = (queryClient: ReturnType<typeof useQueryClient>, runId: string) => {
+  queryClient.invalidateQueries({ queryKey: productionRunQueryKeys.detail(runId) })
+  queryClient.invalidateQueries({ queryKey: productionRunQueryKeys.lists() })
+  queryClient.invalidateQueries({ queryKey: ["production-runs", runId, "payments"] })
+  queryClient.invalidateQueries({ queryKey: ["payable-runs"] })
+}
+
+export type AdminShortCloseRunPayload = {
+  reason?: string | null
+}
+
+export type AdminShortCloseRunResponse = {
+  production_run: AdminProductionRun
+  short_closed: boolean
+  /** `closed`, or `already_closed` when a repeat call found nothing to do. */
+  outcome: string
+}
+
+export const useShortCloseProductionRun = (
+  runId: string,
+  options?: UseMutationOptions<
+    AdminShortCloseRunResponse,
+    FetchError,
+    AdminShortCloseRunPayload
+  >
+) => {
+  const queryClient = useQueryClient()
+
+  return useMutation({
+    mutationFn: async (payload: AdminShortCloseRunPayload) =>
+      sdk.client.fetch<AdminShortCloseRunResponse>(
+        `/admin/production-runs/${runId}/short-close`,
+        { method: "POST", body: payload }
+      ),
+    onSuccess: (data, variables, _mutateResult, context) => {
+      invalidateRunBilling(queryClient, runId)
+      queryClient.invalidateQueries({
+        queryKey: [...productionRunQueryKeys.detail(runId), "activities"],
+      })
+      options?.onSuccess?.(data, variables, _mutateResult, context)
+    },
+    ...options,
+  })
+}
+
+export type AdminReopenRunResponse = {
+  production_run: AdminProductionRun
+  reopened: boolean
+}
+
+/**
+ * Reverse a short close — it was premature, or more work is coming.
+ *
+ * Reversal is always available; closing never is automatic on this screen. An
+ * upward output correction also reopens a closed run on the server, so this is
+ * the deliberate path rather than the only one.
+ */
+export const useReopenProductionRun = (
+  runId: string,
+  options?: UseMutationOptions<AdminReopenRunResponse, FetchError, AdminShortCloseRunPayload | void>
+) => {
+  const queryClient = useQueryClient()
+
+  return useMutation({
+    mutationFn: async (payload: AdminShortCloseRunPayload | void) =>
+      sdk.client.fetch<AdminReopenRunResponse>(
+        `/admin/production-runs/${runId}/short-close`,
+        { method: "DELETE", body: payload || {} }
+      ),
+    onSuccess: (data, variables, _mutateResult, context) => {
+      invalidateRunBilling(queryClient, runId)
+      queryClient.invalidateQueries({
+        queryKey: [...productionRunQueryKeys.detail(runId), "activities"],
+      })
+      options?.onSuccess?.(data, variables, _mutateResult, context)
+    },
+    ...options,
+  })
 }

--- a/apps/backend/src/admin/routes/production-runs/[id]/@short-close/page.tsx
+++ b/apps/backend/src/admin/routes/production-runs/[id]/@short-close/page.tsx
@@ -1,0 +1,65 @@
+import { Heading, Skeleton, Text } from "@medusajs/ui"
+import { useParams } from "react-router-dom"
+
+import { RouteDrawer } from "../../../../components/modal/route-drawer/route-drawer"
+import { ShortCloseRunForm } from "../../../../components/production-runs/production-run-short-close-form"
+import { useProductionRun } from "../../../../hooks/api/production-runs"
+
+/**
+ * #1596 — short-close a run, or reverse one. One drawer for both directions:
+ * the decision and its reversal are the same conversation, and splitting them
+ * across two screens is how the reversal ends up harder to find than the thing
+ * it reverses.
+ */
+export default function ShortCloseRunPage() {
+  const { id } = useParams()
+
+  const { production_run, isLoading, error } = useProductionRun(id || "", undefined, {
+    enabled: !!id,
+  })
+
+  if (isLoading || !production_run) {
+    return (
+      <RouteDrawer>
+        <RouteDrawer.Header>
+          <Skeleton className="h-6 w-40" />
+        </RouteDrawer.Header>
+        <div className="flex flex-1 flex-col gap-y-6 overflow-y-auto px-6 py-6">
+          <Skeleton className="h-20 w-full" />
+          <Skeleton className="h-20 w-full" />
+        </div>
+      </RouteDrawer>
+    )
+  }
+
+  if (error) {
+    return (
+      <RouteDrawer>
+        <RouteDrawer.Header>
+          <Heading>Error</Heading>
+        </RouteDrawer.Header>
+        <div className="px-6 py-6">
+          <Text className="text-ui-fg-subtle">{error.message}</Text>
+        </div>
+      </RouteDrawer>
+    )
+  }
+
+  const isClosed = !!production_run.short_closed_at
+
+  return (
+    <RouteDrawer>
+      <RouteDrawer.Header>
+        <div className="flex flex-col gap-y-0.5">
+          <Heading>{isClosed ? "Reopen run" : "Short-close run"}</Heading>
+          <Text size="xsmall" className="text-ui-fg-subtle">
+            {isClosed
+              ? "Make the ordered quantity billable again"
+              : "Declare that no more will be made on this run"}
+          </Text>
+        </div>
+      </RouteDrawer.Header>
+      <ShortCloseRunForm run={production_run} />
+    </RouteDrawer>
+  )
+}

--- a/apps/backend/src/admin/routes/production-runs/[id]/page.tsx
+++ b/apps/backend/src/admin/routes/production-runs/[id]/page.tsx
@@ -14,6 +14,7 @@ import {
   ArrowPath,
   CheckCircle,
   EllipsisHorizontal,
+  LockClosedSolid,
   PencilSquare,
   PlayMiniSolid,
   Trash,
@@ -48,6 +49,23 @@ import {
 import { productionRunStatusColor as statusColor } from "../../../lib/status-colors"
 
 const formatStatus = (s: string) => s.replace(/_/g, " ")
+
+/**
+ * Quantities for display.
+ *
+ * ⚠️ `short_closed_quantity` is a float COLUMN, so it arrives as the string
+ * "4.000000" and `String(...)` renders it verbatim — the screen read "Closed at
+ * 4.000000 of 9 ordered". Every quantity on this page goes through here rather
+ * than through String(), because which of them is a float and which an integer
+ * is a schema detail no reader of this file should have to remember.
+ */
+const formatQty = (value: unknown): string => {
+  if (value === null || value === undefined || value === "") {
+    return "—"
+  }
+  const n = Number(value)
+  return Number.isFinite(n) ? String(n) : String(value)
+}
 
 const ProductionRunDetailPage = () => {
   const { id } = useParams()
@@ -107,6 +125,41 @@ const ProductionRunDetailPage = () => {
     !isParent && hasPartner && notTerminal && !!run?.accepted_at && !run?.started_at
   const canFinish =
     !isParent && hasPartner && notTerminal && !!run?.started_at && !run?.finished_at
+
+  /**
+   * #1596 — SHORT CLOSE. A run ordered for 9 and completed at 7 keeps 2 units
+   * billable on purpose: output is captured at completion and a run can
+   * legitimately produce more afterwards. That headroom cannot tell "not made
+   * yet" from "never will be made" — this is where somebody says the latter,
+   * after which the run bills to what it produced.
+   *
+   * The offer is gated on the close actually MOVING the ceiling. With no
+   * output figure the server refuses outright, and at produced >= ordered the
+   * ceiling would not move, so offering it there would be a control that looks
+   * like a decision and changes nothing.
+   */
+  const isShortClosed = !!run?.short_closed_at
+  const producedQty = Number(run?.produced_quantity)
+  const orderedQty = Number(run?.quantity)
+  /**
+   * What may be billed IN TOTAL, mirroring `runBillableCeiling` on the server.
+   * Ordered quantity until the run is closed, then what it produced — and never
+   * a reduction inferred from missing data.
+   */
+  const billableCeiling =
+    !Number.isFinite(orderedQty) || orderedQty <= 0
+      ? null
+      : isShortClosed && Number.isFinite(producedQty) && producedQty > 0
+        ? Math.min(orderedQty, producedQty)
+        : orderedQty
+
+  const canShortClose =
+    !isParent &&
+    !isShortClosed &&
+    run?.status === "completed" &&
+    Number.isFinite(producedQty) &&
+    producedQty > 0 &&
+    (!Number.isFinite(orderedQty) || orderedQty <= 0 || producedQty < orderedQty)
 
   // #1228 — a run parked by the reminder cap (or a decline) has no partner and
   // no other control on this page; this is its only way back into production.
@@ -201,6 +254,11 @@ const ProductionRunDetailPage = () => {
                   {formatStatus(String(run.status || "-"))}
                 </StatusBadge>
                 {isParent && <Badge color="blue">parent</Badge>}
+                {isShortClosed && (
+                  <Badge color="orange" size="2xsmall">
+                    short-closed
+                  </Badge>
+                )}
               </div>
               <Text size="small" className="text-ui-fg-subtle">
                 {run.design_id ? (
@@ -344,6 +402,26 @@ const ProductionRunDetailPage = () => {
                       )}
                     </>
                   )}
+                  {/* #1596 — reversal is always offered; closing only when it
+                      would move the ceiling. */}
+                  {(canShortClose || isShortClosed) && (
+                    <>
+                      <DropdownMenu.Separator />
+                      <DropdownMenu.Item onClick={() => navigate("short-close")}>
+                        {isShortClosed ? (
+                          <>
+                            <ArrowPath className="mr-2" />
+                            Reopen run
+                          </>
+                        ) : (
+                          <>
+                            <LockClosedSolid className="mr-2" />
+                            Short-close run
+                          </>
+                        )}
+                      </DropdownMenu.Item>
+                    </>
+                  )}
                   {canCancel && (
                     <>
                       <DropdownMenu.Separator />
@@ -439,10 +517,19 @@ const ProductionRunDetailPage = () => {
                         </Link>
                       )}
                     </div>
+                    {/**
+                      * The denominator is the CEILING, not the ordered
+                      * quantity. Once short-closed those are different numbers,
+                      * and printing "3 of 9 billed" beside a remainder of 4
+                      * reads as arithmetic that does not add up — which is how
+                      * an admin concludes the remainder is wrong rather than
+                      * that the run was closed.
+                      */}
                     <Text size="xsmall" className="text-ui-fg-subtle">
                       {billing.claim?.claimed_quantity} of{" "}
-                      {String(run.quantity ?? "-")} billed —{" "}
-                      {billing.billable_remaining} still billable.
+                      {String(billableCeiling ?? run.quantity ?? "-")} billed —{" "}
+                      {billing.billable_remaining} still billable
+                      {isShortClosed ? " (short-closed)" : ""}.
                     </Text>
                   </div>
                 ) : billing.billing_status === "unknown" ? (
@@ -551,6 +638,40 @@ const ProductionRunDetailPage = () => {
                     {run.rejection_notes ? ` — ${run.rejection_notes}` : ""}
                   </Text>
                 )}
+              </div>
+            )}
+
+            {/**
+              * #1596 — the close, stated in units and attributed.
+              *
+              * "short-closed" alone answers none of the questions an admin
+              * actually has: closed at what, by whom, and what it did to what
+              * this partner may still claim. The counter closes runs too, so
+              * WHO is not rhetorical — "system" means a 30-day silence did it,
+              * not that anyone looked.
+              */}
+            {isShortClosed && (
+              <div className="col-span-2">
+                <Text size="small" className="text-ui-fg-subtle">
+                  Short close
+                </Text>
+                <div className="mt-1 flex flex-col gap-y-1">
+                  <Text size="small">
+                    Closed at{" "}
+                    {formatQty(run.short_closed_quantity ?? run.produced_quantity)} of{" "}
+                    {formatQty(run.quantity)} ordered — no further output
+                    expected, and the run bills to what it produced.
+                  </Text>
+                  <Text size="xsmall" className="text-ui-fg-subtle">
+                    {run.short_closed_by === "system"
+                      ? "Closed automatically after 30 days without a change to its output"
+                      : `Closed by ${run.short_closed_by || "an admin"}`}
+                    {run.short_closed_at
+                      ? ` on ${new Date(run.short_closed_at).toLocaleDateString()}`
+                      : ""}
+                    {run.short_close_reason ? ` — ${run.short_close_reason}` : ""}
+                  </Text>
+                </div>
               </div>
             )}
 

--- a/apps/backend/src/api/admin/payment-submissions/payable-inventory-orders/route.ts
+++ b/apps/backend/src/api/admin/payment-submissions/payable-inventory-orders/route.ts
@@ -1,0 +1,178 @@
+import { MedusaRequest, MedusaResponse } from "@medusajs/framework/http"
+import {
+  ContainerRegistrationKeys,
+  MedusaError,
+} from "@medusajs/framework/utils"
+
+import { PAYMENT_SUBMISSIONS_MODULE } from "../../../../modules/payment_submissions"
+import type PaymentSubmissionsService from "../../../../modules/payment_submissions/service"
+import { listPartnerClaims } from "../../../../workflows/payment_submissions/lib/run-claims"
+import { valueInventoryOrderByReceipts } from "../../../../workflows/payment_submissions/lib/inventory-order-value"
+
+/**
+ * GET /admin/payment-submissions/payable-inventory-orders?partner_id=…
+ *
+ * What a partner is owed for GOODS, as opposed to for work.
+ *
+ * ## Why this exists
+ *
+ * An inventory order is goods coming IN; a production run is the WORK. Both are
+ * things a partner is paid for, and `create` has accepted
+ * `inventory_order_lines` — with a validator, a partner-ownership guard and
+ * read-side resolution — since #1612. Nothing ever sent one, because no screen
+ * offered them: on production, NO payment carries an `inventory_order_id`. A
+ * capability with no way to reach it is a capability nobody has.
+ *
+ * ## What it offers, and what it refuses to invent
+ *
+ * The value is derived from RECEIPTS, never from `total_price`. An order placed
+ * for ₹88,885 with ₹28,670 actually delivered is owed ₹28,670 — billing the
+ * ordered total there overpays by ₹60,215, and asking an operator to work it
+ * out by hand invites it to be got wrong once per order (#1612).
+ *
+ * An order with no receipts is listed and marked `payable: false` rather than
+ * hidden. "Why isn't this order here" is the question an operator arrives with,
+ * and a delivered order that recorded no receipt is a gap in the record — not a
+ * statement that the goods were free.
+ *
+ * 🔑 Already-claimed orders come from `listPartnerClaims`, the same fold the
+ * write guard refuses on. A screen offering what the guard will reject teaches
+ * an operator about the rule through a 400.
+ */
+export const GET = async (req: MedusaRequest, res: MedusaResponse) => {
+  const partnerId = String(
+    (req.validatedQuery as any)?.partner_id ??
+      (req.query as any)?.partner_id ??
+      ""
+  ).trim()
+
+  if (!partnerId) {
+    throw new MedusaError(
+      MedusaError.Types.INVALID_DATA,
+      "partner_id is required"
+    )
+  }
+
+  const query: any = req.scope.resolve(ContainerRegistrationKeys.QUERY)
+
+  /**
+   * ⚠️ Reached through the PARTNER, not by filtering inventory orders on a
+   * partner column — there is no such column. `partner-inventory-order` is a
+   * list link, so the orders arrive nested.
+   */
+  const { data: partners } = await query.graph({
+    entity: "partner",
+    fields: [
+      "id",
+      "inventory_orders.id",
+      "inventory_orders.status",
+      "inventory_orders.total_price",
+      "inventory_orders.currency_code",
+      "inventory_orders.expected_delivery_date",
+      "inventory_orders.order_date",
+      "inventory_orders.is_sample",
+      "inventory_orders.orderlines.id",
+      "inventory_orders.orderlines.quantity",
+      "inventory_orders.orderlines.price",
+      "inventory_orders.orderlines.material_name",
+      // 🔴 The receipts. The typed rows, never `metadata.partner_delivery_history`
+      // — the two disagree by ₹4,050 on a real order and these are what the
+      // concurrency guard reads (#1613).
+      "inventory_orders.orderlines.line_fulfillments.quantity_delta",
+    ],
+    filters: { id: partnerId },
+  })
+
+  const partner = ((partners || []) as any[])[0]
+  const orders = (partner?.inventory_orders || []) as any[]
+
+  const submissionService: PaymentSubmissionsService = req.scope.resolve(
+    PAYMENT_SUBMISSIONS_MODULE
+  )
+  const { inventoryOrders: claims } = await listPartnerClaims(
+    submissionService as any,
+    partnerId
+  )
+
+  const payable_inventory_orders = orders
+    /**
+     * A cancelled order is not a debt. Everything else is listed — including
+     * Pending and Processing, because a receipt can legitimately be recorded
+     * before the status catches up, and an order with goods in it is payable
+     * whatever the workflow calls it.
+     */
+    .filter((order) => String(order?.status || "") !== "Cancelled")
+    .map((order) => {
+      const value = valueInventoryOrderByReceipts(order.orderlines || [])
+      const claim = claims.get(String(order.id)) ?? null
+      const claimedTotal = claim?.claimed_total ?? 0
+
+      /**
+       * 🔴 The CEILING is the ordered total, not the receipts value.
+       *
+       * `assessInventoryOrderClaims` refuses anything that would take an order
+       * past `total_price`, and the receipts figure can legitimately sit ABOVE
+       * it — ₹64,274 derived against ₹63,375.75 ordered on the order that
+       * opened #1617. An amountless line defaults to the receipts figure and is
+       * refused there. So the screen has to know BOTH numbers, or it offers a
+       * figure the guard rejects and the operator learns the rule from a 400.
+       */
+      const ordered = Number(order.total_price ?? 0)
+      const ceiling = Number.isFinite(ordered) && ordered > 0 ? ordered : null
+
+      const remaining =
+        ceiling == null
+          ? null
+          : Math.round(Math.max(0, ceiling - claimedTotal) * 100) / 100
+
+      /**
+       * What this row offers: the receipts value, capped at what is left.
+       *
+       * Capping rather than offering the raw figure is the whole point — but a
+       * silent cap is a reduction nobody decided, so `capped_by_ceiling` says
+       * it happened and the raw figure stays on the row beside it.
+       */
+      const uncapped = value.total
+      const amount =
+        remaining == null ? uncapped : Math.round(Math.min(uncapped, remaining) * 100) / 100
+
+      return {
+        inventory_order_id: String(order.id),
+        status: order.status ?? null,
+        is_sample: !!order.is_sample,
+        currency_code: order.currency_code ?? null,
+        /** What was ORDERED. This is the guard's ceiling. */
+        ordered_total: ceiling,
+        /** What the RECEIPTS are worth, before any cap. */
+        receipts_total: uncapped,
+        received_quantity: value.received_quantity,
+        lines: value.lines,
+        /** Already billed across every live submission. */
+        claimed_total: Math.round(claimedTotal * 100) / 100,
+        /** What may still be billed — `null` when the order has no readable price. */
+        remaining,
+        /** What this row bills if selected. */
+        amount,
+        /** Whether `amount` is below `receipts_total` because the ceiling bit. */
+        capped_by_ceiling: remaining != null && uncapped > remaining,
+        order_date: order.order_date ?? null,
+        expected_delivery_date: order.expected_delivery_date ?? null,
+        /**
+         * Whether there is anything to bill. False means either no receipt has
+         * been recorded — a gap in the record, not a price of zero — or the
+         * order is fully claimed already.
+         */
+        payable: amount > 0,
+        /** Who holds the live claims on this order, earliest first. */
+        claims: (claim?.claims || []).map((c) => ({
+          submission_id: c.submission_id,
+          status: c.submission_status,
+        })),
+      }
+    })
+
+  return res.status(200).json({
+    payable_inventory_orders,
+    count: payable_inventory_orders.length,
+  })
+}

--- a/apps/backend/src/api/admin/payment-submissions/payable-runs/route.ts
+++ b/apps/backend/src/api/admin/payment-submissions/payable-runs/route.ts
@@ -316,6 +316,17 @@ export const GET = async (req: MedusaRequest, res: MedusaResponse) => {
           run.rejected_quantity === null || run.rejected_quantity === undefined
             ? null
             : Number(run.rejected_quantity),
+        /**
+         * #1596 — set means this run has been declared finished for good, so
+         * the produced/ordered gap beside it is SETTLED rather than pending.
+         *
+         * The row already prints "Produced 7 of 9 ordered"; without this the
+         * screen cannot say whether those 2 units are still coming or will
+         * never be made — and `ordered_quantity` above is the raw ordered
+         * figure, deliberately, so the operator can still see what was agreed.
+         * The offer they act on comes from the ceiling, not from that number.
+         */
+        short_closed_at: run.short_closed_at ?? null,
         /** What this row bills for: produced, or ordered when output was never recorded. */
         payable_quantity,
         quantity_basis: offer.quantity_basis,

--- a/apps/backend/src/api/middlewares.ts
+++ b/apps/backend/src/api/middlewares.ts
@@ -3640,6 +3640,14 @@ export default defineMiddlewares({
       middlewares: [validateAndTransformQuery(wrapSchema(AdminPayableRunsQuerySchema), {})],
     },
     {
+      // Goods, as opposed to work (#1612). Declared before the ":id" entries
+      // for the same reason `payable-runs` is: first matching entry wins, and
+      // "payable-inventory-orders" also matches ":id".
+      matcher: "/admin/payment-submissions/payable-inventory-orders",
+      method: "GET",
+      middlewares: [validateAndTransformQuery(wrapSchema(AdminPayableRunsQuerySchema), {})],
+    },
+    {
       matcher: "/admin/payment-submissions/:id/review",
       method: "POST",
       middlewares: [validateAndTransformBody(wrapSchema(AdminReviewPaymentSubmissionSchema))],

--- a/apps/backend/src/workflows/payment_submissions/__tests__/run-line-pricing-contract.unit.spec.ts
+++ b/apps/backend/src/workflows/payment_submissions/__tests__/run-line-pricing-contract.unit.spec.ts
@@ -239,3 +239,75 @@ describe("resolveRunLinePrice", () => {
     expect(written?.quantity).toBe(1)
   })
 })
+
+/**
+ * #1596 — the ADMIN SCREEN's fold must reach the same figure as the server's.
+ *
+ * The screen does not just display an amount; it chooses which request field
+ * carries it, and `create` prices in a fixed order — a typed line total wins
+ * outright, then a typed RATE, and only then the runs. So a screen that sends a
+ * DERIVED rate as `unit_amounts` outranks `resolveRunLinePrice` and makes the
+ * server multiply a figure that was never per-piece.
+ *
+ * 🔴 That is what the admin create screen did for as long as it has existed.
+ * `payable-runs` has always sent `unit_is_derived`; the client type never
+ * declared it, so no screen could read it and none did.
+ */
+describe("the admin screen's fold agrees with the server's pricer", () => {
+  /** ₹10,000 agreed for the job, 9 ordered, 7 made. */
+  const TOTAL_PRICED_RUN = {
+    id: "prod_run_total",
+    design_id: "design_total",
+    partner_id: "partner_1",
+    status: "completed",
+    quantity: 9,
+    produced_quantity: 7,
+    partner_cost_estimate: 10000,
+    cost_type: "total" as const,
+  }
+
+  it("bills the agreed total, whichever end computes it", () => {
+    const offer = runPayableOffer(TOTAL_PRICED_RUN)
+    expect(offer.unit_is_derived).toBe(true)
+    expect(offer.amount).toBe(10000)
+
+    // What the screen now sends for such a line: the offer's amount as a line
+    // TOTAL, never the derived rate.
+    const asScreenSendsIt = resolvePaymentLineAmount({
+      runs: [TOTAL_PRICED_RUN],
+      unit_cost: 0,
+      quantity: offer.quantity,
+      override: offer.amount,
+      unit_override: null,
+    })
+    expect(asScreenSendsIt.amount).toBe(10000)
+
+    // And letting the server price it from the runs reaches the same figure,
+    // so the two ends cannot drift.
+    const asServerPricesIt = resolvePaymentLineAmount({
+      runs: [TOTAL_PRICED_RUN],
+      unit_cost: 0,
+      quantity: offer.quantity,
+      override: null,
+      unit_override: null,
+    })
+    expect(asServerPricesIt.amount).toBe(10000)
+  })
+
+  it("would have UNDERPAID had the derived rate been sent as a rate", () => {
+    // The defect this guards, stated as arithmetic. 7 x (10000/7) loses a
+    // paisa; the same rate against the ordered 9 invents ₹2,857 nobody agreed.
+    const offer = runPayableOffer(TOTAL_PRICED_RUN)
+
+    const sentAsRate = resolvePaymentLineAmount({
+      runs: [TOTAL_PRICED_RUN],
+      unit_cost: 0,
+      quantity: offer.quantity,
+      override: null,
+      unit_override: offer.unit_amount,
+    })
+
+    expect(sentAsRate.amount).not.toBe(10000)
+    expect(sentAsRate.amount).toBeLessThan(10000)
+  })
+})

--- a/e2e/specs/partner-mixed-rate-payout.spec.ts
+++ b/e2e/specs/partner-mixed-rate-payout.spec.ts
@@ -225,8 +225,23 @@ test.describe("Partner per-piece prices @partnerui (#1596)", () => {
     await page.getByRole("combobox").first().click()
     await page.getByRole("option", { name: seed.adminPartnerName }).click()
 
+    // The screen is two steps now: who is paid, then what for. The runs are a
+    // full-width grid on the second.
+    await page.getByRole("button", { name: "Continue" }).click()
+
+    /**
+     * One grid row. The run id lives on the DESIGN cell — the grid renders its
+     * own rows and offers no hook for a per-row attribute — so the row is
+     * reached by asking which row contains that cell.
+     */
     const row = (runId: string) =>
-      page.locator(`[data-testid="payable-run-row"][data-run-id="${runId}"]`)
+      page
+        .locator('[role="row"]')
+        .filter({
+          has: page.locator(
+            `[data-testid="payable-run-row"][data-run-id="${runId}"]`
+          ),
+        })
 
     await expect(row(seed.adminMixedRunAId)).toBeVisible({ timeout: 30_000 })
     await row(seed.adminMixedRunAId).getByRole("checkbox").click()

--- a/e2e/specs/payment-submission-payable-runs.spec.ts
+++ b/e2e/specs/payment-submission-payable-runs.spec.ts
@@ -62,7 +62,13 @@ test.describe("Payment submission from production runs (#1556)", () => {
     await page.waitForURL(/\/app\/(?!login)/, { timeout: 15000 })
   }
 
-  /** Open the create modal and pick the fixture partner. */
+  /**
+   * Open the create modal, pick the fixture partner, and advance to the grid.
+   *
+   * The screen is TWO steps now: choosing who is paid, then choosing what they
+   * are paid for. Step 1 is a partner and a notes box; the runs are a
+   * full-width spreadsheet on step 2, which is why they no longer share a page.
+   */
   const openCreateForPartner = async (page: any) => {
     await page.goto("/app/payment-submissions/create")
     await expect(
@@ -72,20 +78,43 @@ test.describe("Payment submission from production runs (#1556)", () => {
     await page.getByRole("combobox").first().click()
     await page.getByRole("option", { name: seed.payoutPartnerName }).click()
 
+    await page.getByRole("button", { name: "Continue" }).click()
+
     // The runs list is fetched only once a partner is chosen.
-    await expect(page.getByText("payable", { exact: false }).first()).toBeVisible(
-      { timeout: 20000 }
-    )
+    await expect(
+      page.getByText("billable of", { exact: false }).first()
+    ).toBeVisible({ timeout: 20000 })
   }
 
   /**
+   * One grid row.
+   *
    * ⚠️ Addressed by the FULL run id, not a truncated prefix. The seed's two
    * runs are created in the same millisecond, so their ULIDs share a 16-char
-   * prefix and a `hasText` filter on it matches both rows — which is also why
-   * the row now renders a longer id.
+   * prefix and a `hasText` filter on it matches both rows.
+   *
+   * 🔑 The id lives on the DESIGN cell — the grid renders its own rows and
+   * offers no hook for a per-row attribute — so the row is reached by asking
+   * which row contains that cell.
    */
   const runRow = (page: any, runId: string) =>
-    page.locator(`[data-testid="payable-run-row"][data-run-id="${runId}"]`)
+    page
+      .locator('[role="row"]')
+      .filter({
+        has: page.locator(
+          `[data-testid="payable-run-row"][data-run-id="${runId}"]`
+        ),
+      })
+
+  /**
+   * The editable boxes, addressed by POSITION within the row: Qty then Rate.
+   *
+   * A grid cell has no label of its own — the column header is the label, and
+   * it is not associated with the input. Position is the contract a spreadsheet
+   * actually offers, so it is stated here once rather than guessed at each use.
+   */
+  const qtyBox = (row: any) => row.getByRole("spinbutton").nth(0)
+  const rateBox = (row: any) => row.getByRole("spinbutton").nth(1)
 
   test("lists runs with the produced quantity and prices them from the run", async ({
     page,
@@ -102,17 +131,18 @@ test.describe("Payment submission from production runs (#1556)", () => {
     await expect(row).toBeVisible({ timeout: 15000 })
 
     // 🔑 Both figures, stated. A screen that showed only one could not be
-    // checked for which of the two it was actually billing.
-    await expect(row).toContainText("Produced")
-    await expect(row).toContainText("4")
-    await expect(row).toContainText("of 9 ordered")
+    // checked for which of the two it was actually billing — the Output column
+    // carries produced-of-ordered, and Qty carries what is being billed.
+    await expect(row).toContainText("4 of 9")
+    await expect(qtyBox(row)).toHaveValue("4")
 
     // Priced from the RUN (1200/unit), not from the design's own
     // estimated_cost of 5000 — which would have read 5000 here and billed
     // 45,000 for work worth 4,800.
+    await expect(rateBox(row)).toHaveValue("1200")
     await expect(
       row.getByTestId(`run-amount-${seed.payableRunId}`)
-    ).toContainText("4 × 1,200 = 4,800")
+    ).toHaveText("4,800")
   })
 
   test("still lets an unpriced run be paid, by typing the rate", async ({
@@ -133,7 +163,7 @@ test.describe("Payment submission from production runs (#1556)", () => {
      */
     const row = runRow(page, seed.unpricedRunId)
     await expect(row).toBeVisible({ timeout: 15000 })
-    await expect(row).toContainText("No agreed rate")
+    await expect(row).toContainText("no rate")
     await expect(row.getByRole("checkbox")).toBeEnabled()
 
     // No amount asserted until someone supplies a rate — a "0" here would read
@@ -143,14 +173,16 @@ test.describe("Payment submission from production runs (#1556)", () => {
     ).toHaveText("—")
 
     await row.getByRole("checkbox").click()
-    await row
-      .getByRole("spinbutton", { name: `Rate for ${seed.payoutDesignName}` })
-      .fill("400")
+    // ⚠️ The grid commits a cell on BLUR, as a spreadsheet does. Without the
+    // blur the box reads 400 and nothing downstream has heard about it, which
+    // is a passing-looking test asserting an uncommitted edit.
+    await rateBox(row).fill("400")
+    await rateBox(row).blur()
 
     // 2 produced x 400 typed by hand.
     await expect(
       row.getByTestId(`run-amount-${seed.unpricedRunId}`)
-    ).toContainText("2 × 400 = 800")
+    ).toHaveText("800")
     await expect(page.getByTestId("submission-total")).toHaveText("INR 800")
   })
 
@@ -175,14 +207,12 @@ test.describe("Payment submission from production runs (#1556)", () => {
     // The live correction this mirrors: a partner reported more output after
     // the fact, so the payable quantity is retyped. Before #1556 there was no
     // box to type it into at all.
-    const qty = row.getByRole("spinbutton", {
-      name: `Quantity for ${seed.payoutDesignName}`,
-    })
-    await qty.fill("7")
+    await qtyBox(row).fill("7")
+    await qtyBox(row).blur()
 
     await expect(
       row.getByTestId(`run-amount-${seed.billableRunId}`)
-    ).toContainText("7 × 1,200 = 8,400")
+    ).toHaveText("8,400")
     await expect(total).toHaveText("INR 8,400")
 
     // 🔴 Assert the POST itself, not just where the browser ends up. This case
@@ -236,7 +266,7 @@ test.describe("Payment submission from production runs (#1556)", () => {
     // Depends on the previous case having created the payout against it.
     const row = runRow(page, seed.billableRunId)
     await expect(row).toBeVisible({ timeout: 15000 })
-    await expect(row).toContainText("Already paid")
+    await expect(row).toContainText("paid")
     await expect(row.getByRole("checkbox")).toBeDisabled()
   })
 })


### PR DESCRIPTION
Three pieces of the payout screen, in order of how much money they touch.

## 1. A screen for short close (#1596)

#1677 shipped the rule and the 30-day counter with no way to reach either. A run could only be declared finished-for-good by curl, and once closed nothing said so — the offer on `payable-runs` had quietly dropped with no reason given.

A drawer for both directions (closing and reversing are the same conversation), a `short-closed` badge, and an attributed block saying closed at what, by whom, when, why. `"system"` means a 30-day silence did it, not that anyone looked.

The drawer states the consequence in units **before** it is taken — "bills to 4 produced instead of 9 ordered, so 5 units stop being billable" — and says what closing does *not* do: nothing is clawed back.

## 2. Payable runs as a grid, in two steps

Choosing a partner and choosing what to pay for are two jobs that shared one page. Now two steps, and step 2 is full-bleed. The cards are a `DataGrid`: `⇧↓` ticks four runs in one gesture, `⌘C/⌘V` fills a rate down, and a CommandBar carries the running total where the decision is made.

### 🔴 The money defect this surfaced

`payable-runs` sends `unit_is_derived` and always has. **No UI ever read it** — three producers, zero consumers, because the client's `PayableRun` type never declared the field.

A `total`-priced run was agreed at a price for the JOB. The screen multiplied its derived rate anyway:

| | billed | agreed |
|---|---|---|
| ₹10,000, 9 ordered, 7 made | ₹9,999.99 | ₹10,000 |
| …then retype qty to 9 | ₹12,857.13 | ₹10,000 |

Not cosmetic: `create` puts a typed **rate** above `runPayableOffer`, so the screen's derived rate *outranked the one true pricer*. `resolveRunLinePrice` has had the right rule all along and was being overruled by the screen. **97 of 100 production runs are priced this way**; locally 0 of 99 are short, which is why no fixture ever showed it.

Now an untouched total-priced row bills its agreed total verbatim, the quantity does not move it, and it is sent on the line-total channel. Typing a rate is the deliberate way out, and a "Priced on" column says which of the two you are looking at.

## 3. Inventory orders — paying for GOODS (#1612)

`create` has accepted `inventory_order_lines` since the guard was written. Nothing ever sent one; **no payment on production carries an `inventory_order_id`**.

New `GET /admin/payment-submissions/payable-inventory-orders` + a fourth tab. Value comes from **receipts**, never the ordered total (₹88,885 ordered / ₹28,670 delivered is owed ₹28,670) — but the guard's *ceiling* is the ordered total and receipts can legitimately exceed it, so a row offers the receipts value capped at what's left and says when the cap bit.

## Verified in a browser, not only by tests

Every screen here was rendered and driven against the local database:

- close → badge + block + toast; reopen → both gone
- `⇧↓` + space ticks four rows; editing a rate moves Amount, the header and the CommandBar together
- on a total-priced row, **Qty 7 → 9 holds the amount at ₹10,000**
- **a real submission created through the new tab** — `payment_submission_item.inventory_order_id` now has its first row, and the read-side resolution that had never run renders it correctly

Two defects were found only this way: `short_closed_quantity` is a float column so the page read "Closed at **4.000000** of 9 ordered", and the picker's badge row could not wrap.

## Tests

- `run-line-pricing` unit specs (new pure module, one home for the rule) — **mutation-checked**
- a contract test tying the screen's fold to the server's pricer so the two ends cannot drift
- `payable-runs` now asserts `short_closed_at` is on the row — mutation-checked
- three integration cases for inventory orders, previously **zero**. The tenancy one is mutation-checked *and* deliberately non-vacuous: an order is really created and really withheld, because `expect([]).toEqual([])` against an empty table passes whatever the route does.

## ⚠️ Reviewer notes

- The e2e specs are updated for the new contract (Continue step, row-by-cell addressing, positional Qty/Rate, blur-to-commit). They **could not be run locally** — the e2e job overwrites `.env` — so they are reviewed, not proven.
- Found but **not fixed**: the partner picker loads 200 partners with no search, so a partner beyond that is unreachable on this screen.
- `tsc` at the 280-line baseline; `check:prod-build` green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01TLt1f38xqR8k2myCVxP8e4