### PR TITLE
feat(payments): draft a payout when a completed run is priced, not only when it completes (#1596)

### DIFF
--- a/apps/backend/integration-tests/http/payment-submissions-api.spec.ts
+++ b/apps/backend/integration-tests/http/payment-submissions-api.spec.ts
@@ -1530,6 +1530,147 @@ setupSharedTestSuite(() => {
   })
 
   /**
+   * Pricing a completed run that never had a price must DRAFT its payout.
+   *
+   * 🔴 `auto-draft-payment-submission` fires on `production_run.completed`, and
+   * a run completed with no agreed rate is skipped as `no_cost` — after which
+   * nothing ever looked at it again. 97 of 215 completed runs on the local
+   * database carry no cost: the partner finished the job and no price was
+   * recorded. Setting that price afterwards through the cost drawer is the
+   * documented fix, and it produced no draft, so the work stayed unpaid unless
+   * somebody remembered to raise a submission by hand.
+   *
+   * `refreshUnclaimedDraftPayouts` already ran on this exact correction and
+   * re-priced a Draft that EXISTED. This is its missing other half.
+   */
+  describe("pricing an uncosted completed run drafts its payout (#1596)", () => {
+    /**
+     * Which submissions name this run, at any status.
+     *
+     * ⚠️ Listed by PARTNER, not by design — `zodValidator` forces `.strict()`
+     * on the list query, so an undeclared `design_id` param is a 400 rather
+     * than an ignored filter. Each submission is then re-read for its items,
+     * because the list does not expand them.
+     */
+    const submissionsNaming = async (_designId: string, runId: string) => {
+      const list = await api.get(
+        `/admin/payment-submissions?partner_id=${partnerId}`,
+        adminHeaders
+      )
+      const found: any[] = []
+      for (const summary of list.data.payment_submissions || []) {
+        const detail = await api.get(
+          `/admin/payment-submissions/${summary.id}`,
+          adminHeaders
+        )
+        const sub = detail.data.payment_submission
+        const names = (sub.items || []).some((item: any) =>
+          (item.production_run_ids || []).includes(runId)
+        )
+        if (names) {
+          found.push(sub)
+        }
+      }
+      return found
+    }
+
+    it("drafts one when the rate is recorded after completion", async () => {
+      const designId = await createDesign("Late Priced Design", {
+        estimated_cost: 1200,
+      })
+      await linkDesignToPartner(designId, partnerId)
+
+      // Finished, and nobody said what it cost. The state 97 of 215 completed
+      // runs are actually in.
+      const runId = await createCompletedRun(designId, "Late Priced Design", {
+        quantity: 5,
+        produced_quantity: 5,
+        partner_cost_estimate: null,
+        cost_type: null,
+      })
+
+      expect(await submissionsNaming(designId, runId)).toHaveLength(0)
+
+      const priced = await api.post(
+        `/admin/production-runs/${runId}`,
+        { partner_cost_estimate: 900, cost_type: "per_unit" },
+        adminHeaders
+      )
+      expect(priced.status).toBe(200)
+      // Reported on the response, so the caller can see the money followed the
+      // run rather than having to go and look.
+      expect(priced.data.auto_drafted_submission_id).toBeTruthy()
+
+      // 🔑 The EFFECT, re-read rather than taken from the write's own response.
+      const drafted = await submissionsNaming(designId, runId)
+      expect(drafted).toHaveLength(1)
+      expect(drafted[0].status).toBe("Draft")
+      // 5 ordered x 900. `runPayableAmount` bills the ORDERED quantity (#456).
+      expect(Number(drafted[0].total_amount)).toBe(4500)
+    })
+
+    it("does not draft a SECOND time when the price is corrected again", async () => {
+      const designId = await createDesign("Twice Priced Design", {
+        estimated_cost: 1200,
+      })
+      await linkDesignToPartner(designId, partnerId)
+      const runId = await createCompletedRun(designId, "Twice Priced Design", {
+        quantity: 5,
+        produced_quantity: 5,
+        partner_cost_estimate: null,
+        cost_type: null,
+      })
+
+      await api.post(
+        `/admin/production-runs/${runId}`,
+        { partner_cost_estimate: 900, cost_type: "per_unit" },
+        adminHeaders
+      )
+      const second = await api.post(
+        `/admin/production-runs/${runId}`,
+        { partner_cost_estimate: 950, cost_type: "per_unit" },
+        adminHeaders
+      )
+      expect(second.status).toBe(200)
+      expect(second.data.auto_drafted_submission_id).toBeNull()
+
+      // One draft, re-priced by `refreshUnclaimedDraftPayouts` — never two.
+      // Two pre-fills for one run is two answers to one question.
+      const subs = await submissionsNaming(designId, runId)
+      expect(subs).toHaveLength(1)
+      expect(Number(subs[0].total_amount)).toBe(4750)
+    })
+
+    /**
+     * ⚠️ The deliberate NON-trigger. `runPayableAmount` bills the ORDERED
+     * quantity (#456), so correcting what was produced does not change what is
+     * owed — and a correction that does not move the money must not manufacture
+     * a payout out of a run nobody has priced.
+     */
+    it("does not draft on an output correction alone", async () => {
+      const designId = await createDesign("Output Only Design", {
+        estimated_cost: 1200,
+      })
+      await linkDesignToPartner(designId, partnerId)
+      const runId = await createCompletedRun(designId, "Output Only Design", {
+        quantity: 5,
+        produced_quantity: 5,
+        partner_cost_estimate: null,
+        cost_type: null,
+      })
+
+      const corrected = await api.post(
+        `/admin/production-runs/${runId}`,
+        { produced_quantity: 3 },
+        adminHeaders
+      )
+      expect(corrected.status).toBe(200)
+      expect(corrected.data.auto_drafted_submission_id).toBeNull()
+      expect(await submissionsNaming(designId, runId)).toHaveLength(0)
+    })
+  })
+
+  /**
    * Correcting a run must re-price the Draft it pre-filled (#1571).
    *
    * 🔴 `auto-draft-payment-submission` writes a Draft at completion using the

--- a/apps/backend/src/api/admin/production-runs/[id]/route.ts
+++ b/apps/backend/src/api/admin/production-runs/[id]/route.ts
@@ -98,6 +98,7 @@ import {
   setRunAllocation,
 } from "../../../../lib/production-run-allocation"
 import { costTypeGuardMessage } from "../../../../workflows/production-runs/lib/cost-type-guard"
+import { autoDraftRunPayout } from "../../../../workflows/payment_submissions/lib/auto-draft-run-payout"
 import { refreshUnclaimedDraftPayouts } from "../../../../workflows/payment_submissions/lib/refresh-draft-payouts"
 import { reopenProductionRun } from "../../../../workflows/production-runs/lib/short-close-production-run"
 
@@ -321,6 +322,42 @@ export const POST = async (req: MedusaRequest, res: MedusaResponse) => {
   }
 
   /**
+   * The other half of that refresh: create a draft where none exists.
+   *
+   * 🔴 `auto-draft-payment-submission` fires on `production_run.completed`, and
+   * a run completed with NO agreed rate is skipped as `no_cost` — after which
+   * nothing ever looked at it again. 97 of 215 completed runs on the local
+   * database carry no cost: the partner finished the job and no price was
+   * recorded. Setting that price here, through the cost drawer, is the
+   * documented way to fix it, and it produced no draft. The work stayed unpaid
+   * unless somebody remembered to raise a submission by hand.
+   *
+   * Only when the PRICE moved. `runPayableAmount` bills the ORDERED quantity by
+   * design (#456), so an output correction does not change what is owed and
+   * must not manufacture a draft — `touchesMoney` above is deliberately wider
+   * than this condition, because re-pricing an existing draft and creating a
+   * new one are different questions.
+   *
+   * Best-effort and idempotent: `autoDraftRunPayout` asks whether the run is
+   * already claimed rather than relying on a guard to throw.
+   */
+  let autoDraftedSubmissionId: string | null = null
+  const touchesPrice =
+    update.partner_cost_estimate !== undefined || update.cost_type !== undefined
+  if (touchesPrice) {
+    try {
+      const outcome = await autoDraftRunPayout(
+        req.scope,
+        id,
+        "admin.production-run.priced"
+      )
+      autoDraftedSubmissionId = outcome.submission_id ?? null
+    } catch {
+      // Non-fatal by design — the correction is already persisted.
+    }
+  }
+
+  /**
    * #1596 — an upward output correction REOPENS a short-closed run.
    *
    * The close said "nothing more was made". A correction raising
@@ -414,6 +451,13 @@ export const POST = async (req: MedusaRequest, res: MedusaResponse) => {
     ...(touchesMaterials
       ? { materials: await readRunAllocation(req.scope, id) }
       : {}),
+    /**
+     * The Draft this correction CREATED, when pricing a completed run that had
+     * none. Stated for the same reason as `refreshed_draft_payouts` below: so
+     * the caller can see the money followed the run rather than having to go
+     * and look. Null when nothing was drafted.
+     */
+    auto_drafted_submission_id: autoDraftedSubmissionId,
     /**
      * Which unclaimed Draft payouts were re-priced to match this correction.
      * Stated so the caller can see the money moved with the run rather than

--- a/apps/backend/src/subscribers/auto-draft-payment-submission.ts
+++ b/apps/backend/src/subscribers/auto-draft-payment-submission.ts
@@ -1,25 +1,23 @@
-import { ContainerRegistrationKeys } from "@medusajs/framework/utils"
 import type { SubscriberArgs, SubscriberConfig } from "@medusajs/framework"
 
-import { createPaymentSubmissionWorkflow } from "../workflows/payment_submissions/create-payment-submission"
-import { assessRunPayout } from "../workflows/production-runs/lib/run-payable"
+import { autoDraftRunPayout } from "../workflows/payment_submissions/lib/auto-draft-run-payout"
 
 /**
  * When a production run completes, pre-fill the partner's payment submission.
  *
- * Completion is the moment every fact needed to bill for the work exists: the
- * design, the partner, the ordered quantity, and the cost the partner just
- * typed into the completion form. Until now the partner had to then go to
- * Payment Submissions, find that design in a list of everything they've ever
- * been assigned, re-enter the same amount, and submit — so the money step
+ * Completion is the moment most of the facts needed to bill for the work exist:
+ * the design, the partner, the ordered quantity, and the cost the partner just
+ * typed into the completion form. Until this existed the partner had to then go
+ * to Payment Submissions, find that design in a list of everything they have
+ * ever been assigned, re-enter the same amount, and submit — so the money step
  * lagged the work step by however long that took, or never happened.
  *
- * This drafts it for them: one design-sourced item, amount = the run's payable
- * total, landing as **Draft** — visible, editable, and NOT yet a claim on
- * anyone. The partner still reviews and submits, so nothing is billed on their
- * behalf without their say-so. See the `status` / `require_design_status`
- * options on createPaymentSubmissionWorkflow for why a draft is allowed to skip
- * the design-status gate that a hand-made submission must pass.
+ * ⚠️ Completion is not the moment they ALL exist. A run finished with no agreed
+ * rate is skipped as `no_cost`, and for as long as this was the only trigger,
+ * nothing looked at it again — the price could be recorded an hour later and no
+ * draft would ever appear. The admin update route now makes the same attempt
+ * when a completed run is priced; the behaviour lives in `autoDraftRunPayout`
+ * so the two callers cannot drift into drafting different things.
  *
  * Deliberately best-effort: a failure here must never look like the completion
  * failed (completion has already committed by the time this event fires), so
@@ -34,104 +32,7 @@ export default async function autoDraftPaymentSubmissionHandler({
     return
   }
 
-  const logger = container.resolve(ContainerRegistrationKeys.LOGGER)
-  const productionRunService = container.resolve("production_runs") as any
-
-  let run: any = null
-  try {
-    run = await productionRunService.retrieveProductionRun(runId)
-  } catch {
-    return
-  }
-
-  const payout = assessRunPayout(run)
-  if (!payout.eligible) {
-    logger.info(
-      `[auto-draft-payment-submission] run ${runId}: skipped (${payout.reason})`
-    )
-    return
-  }
-
-  try {
-    const { result } = await createPaymentSubmissionWorkflow(container).run({
-      input: {
-        partner_id: payout.partner_id,
-        design_ids: [payout.design_id],
-        status: "Draft",
-        // The completed run IS the proof of finished work — completion moves
-        // the design to Technical_Review, which the hand-submission gate would
-        // reject.
-        require_design_status: false,
-        notes: `Drafted automatically when production run ${runId} completed. Review the amount and submit when you're ready.`,
-        /**
-         * The run this draft pays for, in the column that guards the money.
-         *
-         * 🔴 This subscriber knows the run for certain — it is reacting to that
-         * run completing — and for months recorded it ONLY in `metadata` below.
-         * Every draft it wrote therefore reached the double-pay guard as "no
-         * run recorded", so the guard could never fire on the very rows it was
-         * built for: five of production's thirteen submissions. The admin
-         * screen had meanwhile started writing a SECOND spelling of the same
-         * fact (`metadata.source_production_run_id`), which is the #1557 shape
-         * exactly — one truth, two keys, neither of them load-bearing.
-         *
-         * Passing it here is what makes the line `run_provenance: "recorded"`.
-         * `metadata.production_run_id` stays for backwards compatibility with
-         * readers that already parse it, but it is no longer the record. #1565
-         */
-        production_run_ids: { [payout.design_id]: [runId] },
-        /**
-         * The money, as typed inputs.
-         *
-         * 🔴 This subscriber was the last caller still stating what a partner
-         * is owed through `metadata` — the untyped channel that made #1554
-         * reachable by a spelling mistake. Both UIs had already moved; this had
-         * not, and it is the path that writes MOST of production's payouts.
-         *
-         * The same values still reach `metadata` (the route's fold does that
-         * for the review UI), but they no longer *depend* on landing there.
-         */
-        unit_amounts: { [payout.design_id]: payout.unit_amount },
-        quantities: { [payout.design_id]: payout.quantity },
-        metadata: {
-          auto_drafted: true,
-          source: "production_run.completed",
-          production_run_id: runId,
-          cost_type: run?.cost_type ?? null,
-          ordered_quantity: run?.quantity ?? null,
-          partner_cost_estimate: run?.partner_cost_estimate ?? null,
-          /** The total the two fields below are expected to reproduce. */
-          payable_amount: payout.amount,
-          // The rate the partner entered at completion, and how many units it
-          // covers, rather than a single opaque total. The workflow multiplies
-          // them, so the draft bills exactly `runPayableAmount` — and the line
-          // item records the breakdown, so a partner querying the figure sees
-          // "9 x 850" instead of a 7650 they have to take on trust.
-          //
-          // 🔴 Deliberately NOT `design_cost_overrides`. A total override sets
-          // `unit_amount` to null (there is no recorded rate behind a typed
-          // total), which would have thrown away the very breakdown this
-          // subscriber is the one place that actually knows. #1554
-          design_unit_amounts: { [payout.design_id]: payout.unit_amount },
-          design_quantities: { [payout.design_id]: payout.quantity },
-        },
-      },
-    })
-
-    logger.info(
-      `[auto-draft-payment-submission] run ${runId}: drafted submission ${
-        (result as any)?.submission?.id
-      } for design ${payout.design_id} (${payout.quantity} x ${
-        payout.unit_amount
-      } = ${payout.amount})`
-    )
-  } catch (e: any) {
-    // The commonest "failure" is the design already sitting in an open
-    // submission — that's the guard doing its job, not an error worth paging on.
-    logger.info(
-      `[auto-draft-payment-submission] run ${runId}: no draft created — ${e?.message}`
-    )
-  }
+  await autoDraftRunPayout(container, runId, "production_run.completed")
 }
 
 export const config: SubscriberConfig = {

--- a/apps/backend/src/workflows/payment_submissions/lib/auto-draft-run-payout.ts
+++ b/apps/backend/src/workflows/payment_submissions/lib/auto-draft-run-payout.ts
@@ -1,0 +1,170 @@
+import { ContainerRegistrationKeys } from "@medusajs/framework/utils"
+import type { MedusaContainer } from "@medusajs/framework/types"
+
+import { PAYMENT_SUBMISSIONS_MODULE } from "../../../modules/payment_submissions"
+import { assessRunPayout } from "../../production-runs/lib/run-payable"
+import { createPaymentSubmissionWorkflow } from "../create-payment-submission"
+
+/**
+ * Pre-fill a partner's payment submission for one completed run.
+ *
+ * ## Why this is a function rather than a subscriber body
+ *
+ * It used to run in exactly one place: the moment `production_run.completed`
+ * fired. That is the moment MOST of the facts exist — the design, the partner,
+ * the ordered quantity, the cost the partner typed into the completion form —
+ * but it is not the moment they ALL do.
+ *
+ * 🔴 A run completed with no agreed rate is `no_cost`, and nothing ever looked
+ * at it again. On the local database 97 of 215 completed runs carry no cost;
+ * the partner finished the job and no price was recorded. An admin setting that
+ * price afterwards — through the cost drawer, which is the documented way —
+ * produced no draft, ever. The work stayed unpaid unless somebody remembered to
+ * raise a submission by hand.
+ *
+ * `refreshUnclaimedDraftPayouts` already runs on that same correction and
+ * re-prices a Draft that EXISTS. This is its missing other half: create one
+ * where none does. The two are deliberately adjacent in the update route.
+ *
+ * ⚠️ NOT triggered by an output correction. `runPayableAmount` bills the
+ * ORDERED quantity by design (#456), so correcting `produced_quantity` does not
+ * move this money and must not manufacture a draft.
+ *
+ * ## Idempotent, by asking rather than by catching
+ *
+ * The create workflow already refuses a design that sits in an open submission,
+ * and the run-claim guard refuses a run already claimed — so a second call was
+ * always safe. But relying on an exception means the log says "no draft
+ * created — <some guard's message>" and the caller cannot tell "already done"
+ * from "went wrong". This asks first, and says which.
+ */
+
+export type AutoDraftOutcome = {
+  drafted: boolean
+  /**
+   * `drafted`, `already_claimed`, or the `assessRunPayout` reason
+   * (`no_cost`, `no_partner`, `run_not_completed`, `provenance_run`, …).
+   */
+  reason: string
+  submission_id?: string
+  source: string
+}
+
+/**
+ * Whether any payment submission line already names this run.
+ *
+ * Every status counts, Draft included: a Draft is a pre-fill that already
+ * exists, and a second one would be two answers to one question.
+ */
+const runIsAlreadyClaimed = async (
+  container: MedusaContainer,
+  designId: string,
+  runId: string
+): Promise<boolean> => {
+  const service: any = container.resolve(PAYMENT_SUBMISSIONS_MODULE)
+  const items = (await service.listPaymentSubmissionItems(
+    { design_id: [designId] },
+    {}
+  )) as any[]
+
+  return (items || []).some((item) => {
+    const claims = item?.production_run_ids
+    return Array.isArray(claims) && claims.includes(runId)
+  })
+}
+
+export const autoDraftRunPayout = async (
+  container: MedusaContainer,
+  runId: string,
+  /** What caused this attempt — recorded on the draft so it can be traced. */
+  source: string = "production_run.completed"
+): Promise<AutoDraftOutcome> => {
+  const logger = container.resolve(ContainerRegistrationKeys.LOGGER)
+  const productionRunService: any = container.resolve("production_runs")
+
+  let run: any = null
+  try {
+    run = await productionRunService.retrieveProductionRun(runId)
+  } catch {
+    return { drafted: false, reason: "run_not_found", source }
+  }
+
+  const payout = assessRunPayout(run)
+  if (!payout.eligible) {
+    logger.info(
+      `[auto-draft-payment-submission] run ${runId}: skipped (${payout.reason}) via ${source}`
+    )
+    return { drafted: false, reason: payout.reason, source }
+  }
+
+  if (await runIsAlreadyClaimed(container, payout.design_id, runId)) {
+    logger.info(
+      `[auto-draft-payment-submission] run ${runId}: already claimed, nothing to draft (${source})`
+    )
+    return { drafted: false, reason: "already_claimed", source }
+  }
+
+  try {
+    const { result } = await createPaymentSubmissionWorkflow(container).run({
+      input: {
+        partner_id: payout.partner_id,
+        design_ids: [payout.design_id],
+        status: "Draft",
+        // The completed run IS the proof of finished work — completion moves
+        // the design to Technical_Review, which the hand-submission gate would
+        // reject.
+        require_design_status: false,
+        notes:
+          source === "production_run.completed"
+            ? `Drafted automatically when production run ${runId} completed. Review the amount and submit when you're ready.`
+            : `Drafted automatically when production run ${runId} was priced. Review the amount and submit when you're ready.`,
+        /**
+         * The run this draft pays for, in the column that guards the money.
+         * Recording it ONLY in `metadata` is what made every auto-draft reach
+         * the double-pay guard as "no run recorded" (#1565).
+         */
+        production_run_ids: { [payout.design_id]: [runId] },
+        /** The money, as typed inputs rather than through `metadata` (#1554). */
+        unit_amounts: { [payout.design_id]: payout.unit_amount },
+        quantities: { [payout.design_id]: payout.quantity },
+        metadata: {
+          auto_drafted: true,
+          source,
+          production_run_id: runId,
+          cost_type: run?.cost_type ?? null,
+          ordered_quantity: run?.quantity ?? null,
+          partner_cost_estimate: run?.partner_cost_estimate ?? null,
+          /** The total the two fields below are expected to reproduce. */
+          payable_amount: payout.amount,
+          /**
+           * 🔴 Deliberately NOT `design_cost_overrides`. A total override sets
+           * `unit_amount` to null — there is no recorded rate behind a typed
+           * total — which would throw away the very breakdown this path is the
+           * one place that actually knows (#1554).
+           */
+          design_unit_amounts: { [payout.design_id]: payout.unit_amount },
+          design_quantities: { [payout.design_id]: payout.quantity },
+        },
+      },
+    })
+
+    const submissionId = String((result as any)?.submission?.id ?? "")
+    logger.info(
+      `[auto-draft-payment-submission] run ${runId}: drafted submission ${submissionId} ` +
+        `for design ${payout.design_id} (${payout.quantity} x ${payout.unit_amount} = ${payout.amount}) via ${source}`
+    )
+    return {
+      drafted: true,
+      reason: "drafted",
+      submission_id: submissionId,
+      source,
+    }
+  } catch (e: any) {
+    // A guard refusing is the normal case, not an error worth paging on — the
+    // design may already sit in an open submission raised by hand.
+    logger.info(
+      `[auto-draft-payment-submission] run ${runId}: no draft created — ${e?.message}`
+    )
+    return { drafted: false, reason: "refused", source }
+  }
+}


### PR DESCRIPTION
The last item on #1596.

## The gap

`auto-draft-payment-submission` fires on `production_run.completed`. A run completed with no agreed rate is skipped as `no_cost` — and **nothing ever looked at it again**.

That isn't a corner case. On the local database **97 of 215 completed runs carry no cost**: the partner finished and no price was recorded at the moment the event fired. Recording it afterwards through the cost drawer — the documented way — produced no draft, ever. The work stayed unpaid unless someone remembered to raise a submission by hand, which is the exact friction the auto-draft exists to remove.

`refreshUnclaimedDraftPayouts` already runs on that same correction and re-prices a Draft that *exists*. This is its missing other half. The two are now adjacent in the update route, because "re-price the draft" and "there is no draft" are one event asking two questions.

## One home, two callers

The subscriber's body moves to `autoDraftRunPayout`, called by both the completion event and the update route. Two callers drafting subtly different things — a different `require_design_status`, a different `production_run_ids` spelling — is how one path's payouts become invisible to the double-pay guard. That is #1565 exactly.

Idempotent by **asking**, not by catching. The guards always made a second call safe, but relying on the exception meant the log said *"no draft created — &lt;some guard's message&gt;"* and the caller couldn't tell "already done" from "went wrong". It now reports `already_claimed`.

## The deliberate non-trigger

⚠️ An **output** correction does not draft. `runPayableAmount` bills the ORDERED quantity by design (#456), so correcting `produced_quantity` doesn't change what's owed — and a correction that doesn't move the money must not manufacture a payout for a run nobody has priced. `touchesMoney` (drives the refresh) is intentionally wider than `touchesPrice` (drives this).

📝 **This corrects my own handoff note**, which called the gap "auto-draft fires only on completion, not on a later output correction". An output correction was never the trigger — a late *price* is. I checked the data before building to the wrong spec.

## Tests

Three integration cases, mutation-checked: disabling `touchesPrice` fails the two positive ones. The third (output-only correction) passes either way **on purpose** — it's the guard against over-reach, not a proof of the fix, and its comment says so.

`auto_drafted_submission_id` comes back on the correction, for the same reason `refreshed_draft_payouts` does: so the caller can see the money followed the run.

Full payment-submissions suite green (117/117), `tsc` at the 280 baseline, `check:prod-build` passed. No migrations.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01TLt1f38xqR8k2myCVxP8e4