### PR TITLE
feat(stats): wire window_days into metric_sections and expose real graph entities

### DIFF
--- a/apps/backend/integration-tests/http/platform-stats-panel.spec.ts
+++ b/apps/backend/integration-tests/http/platform-stats-panel.spec.ts
@@ -44,34 +44,34 @@ const unique = () => `ps${Date.now()}${Math.floor(Math.random() * 1e6)}`
 // derives every section from live rows.
 const jpySections = {
   orders: {
-    entity: "order_transaction",
+    entity: "order_transactions",
     filters: { reference: "capture" },
     aggregates: {
       processed: { fn: "count_distinct", field: "order_id" },
-      trailing_30d: {
+      trailing: {
         fn: "count_distinct",
         field: "order_id",
-        range: { date_field: "created_at", last_days: 30 },
+        range: { date_field: "created_at" },
       },
     },
     echo: { window_days: true },
   },
   commission: {
-    entity: "partner_fee",
+    entity: "partner_fees",
     filters: { status: "accrued" },
     currency_key: "currency_code",
     aggregates: {
       accrued: { fn: "sum", field: "fee_amount" },
-      trailing_30d: {
+      trailing: {
         fn: "sum",
         field: "fee_amount",
-        range: { date_field: "accrued_at", last_days: 30 },
+        range: { date_field: "accrued_at" },
       },
     },
     echo: { currency: true, window_days: true },
   },
   subscription: {
-    entity: "partner_subscription",
+    entity: "partner_subscriptions",
     filters: { status: "active" },
     currency_key: "plan.currency_code",
     aggregates: {
@@ -85,11 +85,11 @@ const jpySections = {
     echo: { currency: true },
   },
   aov: {
-    entity: "order_transaction",
+    entity: "order_transactions",
     filters: { reference: "capture" },
     currency_key: "currency_code",
     aggregates: {
-      amount: { fn: "avg", field: "amount", range: { date_field: "created_at", last_days: 30 } },
+      amount: { fn: "avg", field: "amount", range: { date_field: "created_at" } },
     },
     echo: { currency: true },
   },
@@ -258,13 +258,13 @@ setupSharedTestSuite(() => {
 
       // orders — capture transactions only (count_distinct over order_id)
       expect(d.orders.processed - b.orders.processed).toBe(2)
-      expect(d.orders.trailing_30d - b.orders.trailing_30d).toBe(2)
+      expect(d.orders.trailing - b.orders.trailing).toBe(2)
       expect(d.orders.window_days).toBe(30)
 
       // commission — 200 + 300 seeded, only the recent one in the window
       expect(d.commission.currency).toBe("JPY")
       expect(d.commission.accrued - b.commission.accrued).toBe(500)
-      expect(d.commission.trailing_30d - b.commission.trailing_30d).toBe(200)
+      expect(d.commission.trailing - b.commission.trailing).toBe(200)
       expect(d.commission.window_days).toBe(30)
 
       // subscription — monthly 999 + yearly 24000/12 = mrr 2999
@@ -293,11 +293,11 @@ setupSharedTestSuite(() => {
       expect(d.window_days).toBe(30)
 
       // Shape contract — section keys are exactly what the config declares
-      expect(Object.keys(d.orders).sort()).toEqual(["processed", "trailing_30d", "window_days"])
+      expect(Object.keys(d.orders).sort()).toEqual(["processed", "trailing", "window_days"])
       expect(Object.keys(d.commission).sort()).toEqual([
         "accrued",
         "currency",
-        "trailing_30d",
+        "trailing",
         "window_days",
       ])
       expect(Object.keys(d.subscription).sort()).toEqual(["currency", "mrr", "paying_artisans"])
@@ -306,6 +306,33 @@ setupSharedTestSuite(() => {
 
       // Fee rows must have accrued_at honored — sanity on the seeded row
       expect(f1.fee_amount).toBeDefined()
+    })
+
+    it("drives the trailing window from the panel's window_days (not a hardcoded 30)", async () => {
+      const container = getContainer()
+      const o1 = await seedPaidOrder(container, {
+        currency_code: "jpy",
+        unit_price: 10000,
+        quantity: 1,
+        captured: true,
+      })
+      // A fee accrued 40 days ago: outside a 30-day window, inside a 90-day one.
+      await seedFee({
+        order_id: o1.id,
+        fee_amount: 300,
+        accrued_at: new Date(Date.now() - 40 * 24 * 60 * 60 * 1000),
+      })
+
+      const narrow = await jpyPreview() // window_days: 30
+      const wide = await preview({ currency: "jpy", window_days: 90, sections: jpySections })
+
+      const narrowTrailing = narrow.data.data.commission.trailing
+      const wideTrailing = wide.data.data.commission.trailing
+
+      // The 40-day-old fee must be OUTSIDE the 30-day trailing window but
+      // INSIDE the 90-day one — proving window_days actually drives the range.
+      expect(wideTrailing).toBeGreaterThan(narrowTrailing)
+      expect(wide.data.data.commission.window_days).toBe(90)
     })
 
     it("rejects invalid operation_options", async () => {

--- a/apps/backend/src/api/admin/mcp/graph-entities/route.ts
+++ b/apps/backend/src/api/admin/mcp/graph-entities/route.ts
@@ -1,0 +1,117 @@
+/**
+ * GET /admin/mcp/graph-entities — the query.graph entity names available for
+ * stats panels (metric_sections / aggregate_data / time_series).
+ *
+ * The admin assistant hallucinated entity names ("orders", "subscriptions",
+ * "payments") because `metric_sections.entity` is a free string with no
+ * source of truth. This route is that source: a curated list of the REAL
+ * query.graph entity names, verified against prod (plural snake_case — the
+ * singular form of a few models does NOT resolve, so plural is canonical).
+ *
+ * Keep in sync with the DML `model.define(...)` names; the broader catalog is
+ * at GET /admin/visual-flows/metadata (which pluralizes + also misses the
+ * order-transaction and partner-plan sub-models below).
+ */
+import { MedusaRequest, MedusaResponse } from "@medusajs/framework/http"
+
+export type GraphEntity = {
+  name: string
+  type: "core" | "custom"
+  description: string
+  /** Key fields, for the entities a stats panel most commonly aggregates. */
+  fields?: string[]
+}
+
+const GRAPH_ENTITIES: GraphEntity[] = [
+  // ── Order / money (the "stats" entities) ──────────────────────────
+  {
+    name: "orders",
+    type: "core",
+    description:
+      "Customer orders. NOTE: money fields (total/subtotal/item_total) are NOT fetchable via query.graph — use order_transactions for captured amounts.",
+    fields: ["id", "status", "currency_code", "created_at"],
+  },
+  {
+    name: "order_transactions",
+    type: "core",
+    description:
+      "Payment transactions on orders. reference='capture' means paid. The only per-order money signal query.graph can fetch.",
+    fields: ["order_id", "amount", "currency_code", "reference", "created_at"],
+  },
+  {
+    name: "order_items",
+    type: "core",
+    description: "Line items on an order.",
+    fields: ["order_id", "title", "quantity", "unit_price"],
+  },
+
+  // ── Commission / billing ──────────────────────────────────────────
+  {
+    name: "partner_fees",
+    type: "custom",
+    description:
+      "Platform commission accrued per partner order. status ∈ accrued | invoiced | waived | reversed.",
+    fields: ["partner_id", "order_id", "fee_amount", "fee_type", "currency_code", "status", "accrued_at"],
+  },
+
+  // ── Subscriptions ─────────────────────────────────────────────────
+  {
+    name: "partner_subscriptions",
+    type: "custom",
+    description:
+      "Partner plan subscriptions. status ∈ active | canceled | expired | past_due. Nest plan.* for price/interval.",
+    fields: ["partner_id", "status", "plan.price", "plan.interval", "plan.currency_code"],
+  },
+  {
+    name: "partner_plans",
+    type: "custom",
+    description: "Partner subscription plan tiers. interval ∈ monthly | yearly.",
+    fields: ["name", "price", "interval", "currency_code", "is_active"],
+  },
+
+  // ── Catalog / customers / partners ────────────────────────────────
+  { name: "products", type: "core", description: "Products (catalog).", fields: ["id", "title", "status"] },
+  { name: "product_variants", type: "core", description: "Product variants." },
+  { name: "customers", type: "core", description: "Customer accounts." },
+  { name: "partners", type: "custom", description: "Partner (artisan/brand) records." },
+  { name: "partner_onboarding_profiles", type: "custom", description: "Partner onboarding profiles." },
+  { name: "partner_payment_configs", type: "custom", description: "Partner payment configs." },
+  { name: "designs", type: "custom", description: "Product designs." },
+
+  // ── Operations ────────────────────────────────────────────────────
+  { name: "production_runs", type: "custom", description: "Production runs." },
+  { name: "inventory_orders", type: "custom", description: "Inventory orders." },
+  { name: "inventory_items", type: "custom", description: "Inventory items." },
+  { name: "raw_materials", type: "custom", description: "Raw materials." },
+  { name: "tasks", type: "custom", description: "Tasks." },
+  { name: "people", type: "custom", description: "People / weaver directory (person module)." },
+  { name: "person_types", type: "custom", description: "Person types." },
+  { name: "notes", type: "custom", description: "Notes." },
+  { name: "unified_order_statuses", type: "custom", description: "Unified partner-facing order statuses." },
+
+  // ── Marketing / analytics / finance ───────────────────────────────
+  { name: "websites", type: "custom", description: "Marketing websites." },
+  { name: "marketing_metric_snapshots", type: "custom", description: "Daily marketing metrics.", fields: ["metric_key", "value", "captured_for_date"] },
+  { name: "analytics_daily_stats", type: "custom", description: "Daily analytics rollups.", fields: ["date", "unique_visitors"] },
+  { name: "company_expenses", type: "custom", description: "Company expenses.", fields: ["amount", "category", "recurrence", "status"] },
+  { name: "social_posts", type: "custom", description: "Social posts." },
+
+  // ── Core platform (less common for stats) ─────────────────────────
+  { name: "regions", type: "core", description: "Regions / markets." },
+  { name: "currencies", type: "core", description: "Currencies." },
+  { name: "stores", type: "core", description: "Stores." },
+  { name: "sales_channels", type: "core", description: "Sales channels." },
+  { name: "stock_locations", type: "core", description: "Stock locations." },
+  { name: "fulfillments", type: "core", description: "Fulfillments." },
+  { name: "payments", type: "core", description: "Payment records." },
+  { name: "payment_collections", type: "core", description: "Payment collections." },
+  { name: "promotions", type: "core", description: "Promotions / discounts." },
+  { name: "tax_rates", type: "core", description: "Tax rates." },
+  { name: "users", type: "core", description: "Admin users." },
+  { name: "api_keys", type: "core", description: "API keys." },
+  { name: "carts", type: "core", description: "Shopping carts." },
+]
+
+export const GET = async (_req: MedusaRequest, res: MedusaResponse) => {
+  res.json({ entities: GRAPH_ENTITIES })
+}

--- a/apps/backend/src/api/admin/mcp/lib/registry.ts
+++ b/apps/backend/src/api/admin/mcp/lib/registry.ts
@@ -151,6 +151,14 @@ export const ADMIN_MCP_TOOLS: AdminMcpToolDef[] = [
     path: "/admin/mcp/stats",
     inputSchema: obj({}),
   },
+  {
+    name: "list_graph_entities",
+    description:
+      "List the REAL query.graph entity names available for stats panels (metric_sections / aggregate_data / time_series), with descriptions and key fields. Call this to pick the correct `entity` value — do NOT invent entity names. Plural snake_case (e.g. 'order_transactions', 'partner_fees', 'partner_subscriptions').",
+    method: "GET",
+    path: "/admin/mcp/graph-entities",
+    inputSchema: obj({}),
+  },
 
   // ===== Orders ============================================================
   {
@@ -4292,7 +4300,7 @@ export const ADMIN_MCP_TOOLS: AdminMcpToolDef[] = [
   {
     name: "create_stats_panel",
     description:
-      "Create a stats panel on a dashboard, driven by operation_type + operation_options JSON. The panel's data resolves LIVE from the configured operation — nothing is stored as a number. For the dynamic metric_sections operation, pass operation_options = { currency, window_days, sections: { <name>: { entity, filters, aggregates: { <key>: { fn, field?, range?, normalize_interval? } }, currency_key?, echo? } | { derived: { ref, aggregate, multiply?, add? }, echo? } } }. IMPORTANT: `echo` is an OBJECT of booleans like { window_days: true } or { currency: true } — it declares which context keys the section output carries; it is NOT text, and the section's label is the section NAME, so never send echo as a string. Set metadata.public true only if the panel is safe to expose publicly (GET /web/stats/panels/:id/data).",
+      "Create a stats panel on a dashboard, driven by operation_type + operation_options JSON. The panel's data resolves LIVE from the configured operation — nothing is stored as a number. For the dynamic metric_sections operation, pass operation_options = { currency, window_days, sections: { <name>: { entity, filters, aggregates: { <key>: { fn, field?, range?, normalize_interval? } }, currency_key?, echo? } | { derived: { ref, aggregate, multiply?, add? }, echo? } } }. The `entity` MUST be a real query.graph name — call list_graph_entities first (plural snake_case, e.g. 'order_transactions' for paid orders, 'partner_fees' for commission, 'partner_subscriptions' for subscriptions); never invent names like 'orders'/'subscriptions'/'payments'. `echo` is an OBJECT of booleans like { window_days: true } or { currency: true } — it declares which context keys the section output carries; it is NOT text, and the section's label is the section NAME. A trailing-window aggregate uses `range: { date_field }` (no last_days) so it follows the panel's window_days. Set metadata.public true only if the panel is safe to expose publicly (GET /web/stats/panels/:id/data).",
     method: "POST",
     path: "/admin/stats/dashboards/:id/panels",
     pathParams: ["id"],

--- a/apps/backend/src/modules/visual_flows/operations/metric-sections.ts
+++ b/apps/backend/src/modules/visual_flows/operations/metric-sections.ts
@@ -13,29 +13,29 @@ import { getValueByPath } from "./utils"
 //     window_days: 30,
 //     sections: {
 //       orders: {
-//         entity: "order_transaction",
+//         entity: "order_transactions",
 //         filters: { reference: "capture" },
 //         aggregates: {
-//           processed:    { fn: "count_distinct", field: "order_id" },
-//           trailing_30d: { fn: "count_distinct", field: "order_id",
-//                           range: { date_field: "created_at", last_days: 30 } },
+//           processed: { fn: "count_distinct", field: "order_id" },
+//           trailing:  { fn: "count_distinct", field: "order_id",
+//                        range: { date_field: "created_at" } },
 //         },
 //         echo: { window_days: true },
 //       },
-//       commission: { entity: "partner_fee", currency_key: "currency_code",
+//       commission: { entity: "partner_fees", currency_key: "currency_code",
 //         filters: { status: "accrued" },
 //         aggregates: {
-//           accrued:      { fn: "sum", field: "fee_amount" },
-//           trailing_30d: { fn: "sum", field: "fee_amount",
-//                           range: { date_field: "accrued_at", last_days: 30 } },
+//           accrued:  { fn: "sum", field: "fee_amount" },
+//           trailing: { fn: "sum", field: "fee_amount",
+//                       range: { date_field: "accrued_at" } },
 //         },
 //         echo: { currency: true, window_days: true } },
-//       aov: { entity: "order_transaction", filters: { reference: "capture" },
+//       aov: { entity: "order_transactions", filters: { reference: "capture" },
 //              currency_key: "currency_code",
 //              aggregates: { amount: { fn: "avg", field: "amount",
-//                                      range: { last_days: 30 } } },
+//                                      range: { date_field: "created_at" } } },
 //              echo: { currency: true } },
-//       subscription: { entity: "partner_subscription", currency_key: "plan.currency_code",
+//       subscription: { entity: "partner_subscriptions", currency_key: "plan.currency_code",
 //         filters: { status: "active" },
 //         aggregates: {
 //           paying_artisans: { fn: "count_distinct", field: "partner_id" },
@@ -48,8 +48,8 @@ import { getValueByPath } from "./utils"
 //     },
 //   }
 //
-// → data: { orders: { processed, trailing_30d, window_days },
-//           commission: { accrued, trailing_30d, currency, window_days },
+// → data: { orders: { processed, trailing, window_days },
+//           commission: { accrued, trailing, currency, window_days },
 //           aov: { amount, currency },
 //           subscription: { paying_artisans, mrr, currency },
 //           arr: { amount, currency },
@@ -61,7 +61,9 @@ import { getValueByPath } from "./utils"
 //   aggregates        — count | sum | avg | min | max | count_distinct over a
 //                       (possibly nested) field path
 //   range             — bounds an aggregate's rows to a date window
-//                       ({ last_days } or { from, to })
+//                       ({ last_days } rolling, { from, to } absolute). When
+//                       last_days is omitted, it inherits the panel's
+//                       window_days, so "trailing" follows the panel window.
 //   normalize_interval— monthly-normalize a price by the row's interval
 //                       (yearly price / 12) before aggregating
 //   currency_key      — row-level currency filter (sections only count rows
@@ -74,17 +76,12 @@ import { getValueByPath } from "./utils"
 // section to { error } with a warning instead of failing the whole panel —
 // same partial-snapshot honesty as GET /admin/mcp/stats.
 
-const rangeSchema = z.union([
-  z.object({
-    date_field: z.string().optional().default("created_at"),
-    last_days: z.number().int().positive().max(3650),
-  }),
-  z.object({
-    date_field: z.string().optional().default("created_at"),
-    from: z.string().describe("ISO date (inclusive)"),
-    to: z.string().describe("ISO date (exclusive)"),
-  }),
-])
+const rangeSchema = z.object({
+  date_field: z.string().optional().default("created_at"),
+  last_days: z.number().int().positive().max(3650).optional(),
+  from: z.string().optional().describe("ISO date (inclusive). Overrides last_days when paired with `to`."),
+  to: z.string().optional().describe("ISO date (exclusive). Overrides last_days when paired with `from`."),
+})
 
 const aggregateSpecSchema = z.object({
   fn: z.enum(["count", "sum", "avg", "min", "max", "count_distinct"]).default("count"),
@@ -94,7 +91,9 @@ const aggregateSpecSchema = z.object({
     .describe("Field to aggregate (possibly nested). Required for all fns except 'count'."),
   range: rangeSchema
     .optional()
-    .describe("Optional date window bounding this aggregate's rows."),
+    .describe(
+      "Optional date window bounding this aggregate's rows. Omit last_days (e.g. just { date_field }) to inherit the panel's window_days; set { from, to } for an absolute window; set { last_days } to override."
+    ),
   normalize_interval: z
     .object({
       interval_field: z.string().describe("Row path carrying the interval (monthly | yearly)."),
@@ -176,23 +175,26 @@ const toFiniteNumber = (v: unknown): number | null => {
   return Number.isFinite(n) ? n : null
 }
 
-/** Inclusive-from / exclusive-to window, aligned to UTC day boundaries (mirrors aggregate-data). */
+/** Inclusive-from / exclusive-to window, aligned to UTC day boundaries (mirrors aggregate-data).
+ * When `range` has no `last_days` (and no `from`/`to`), it inherits the panel's `window_days`. */
 function resolveWindow(
   range: { from?: string; to?: string; last_days?: number },
-  now: Date
+  now: Date,
+  defaultLastDays: number
 ): { from: string; to: string } {
-  if ("last_days" in range && range.last_days != null) {
-    const to = new Date(now)
-    to.setUTCHours(0, 0, 0, 0)
-    to.setUTCDate(to.getUTCDate() + 1)
-    const from = new Date(to)
-    from.setUTCDate(from.getUTCDate() - range.last_days)
-    return { from: from.toISOString(), to: to.toISOString() }
+  if (range.from && range.to) {
+    return {
+      from: new Date(range.from).toISOString(),
+      to: new Date(range.to).toISOString(),
+    }
   }
-  return {
-    from: new Date(range.from!).toISOString(),
-    to: new Date(range.to!).toISOString(),
-  }
+  const lastDays = range.last_days ?? defaultLastDays
+  const to = new Date(now)
+  to.setUTCHours(0, 0, 0, 0)
+  to.setUTCDate(to.getUTCDate() + 1)
+  const from = new Date(to)
+  from.setUTCDate(from.getUTCDate() - lastDays)
+  return { from: from.toISOString(), to: to.toISOString() }
 }
 
 /** Fetch-then-aggregate one entity section. Returns the section payload. */
@@ -255,7 +257,7 @@ async function resolveEntitySection(
   for (const [aggName, agg] of Object.entries(aggregates)) {
     let subset = eligibleRows
     if (agg.range) {
-      const window = resolveWindow(agg.range as any, ctx.now)
+      const window = resolveWindow(agg.range as any, ctx.now, ctx.windowDays)
       const dateField = agg.range.date_field || "created_at"
       subset = subset.filter((row) => {
         const v = getValueByPath(row, dateField)

--- a/apps/backend/src/scripts/seed-platform-stats-panel.ts
+++ b/apps/backend/src/scripts/seed-platform-stats-panel.ts
@@ -8,9 +8,10 @@ import { STATS_MODULE } from "../modules/stats"
  * The panel uses the DYNAMIC `metric_sections` operation: the metric keys are
  * declarative panel config (operation_options.sections), not hardcoded code.
  * Adding a new section = editing this panel's options — no code change.
- * Seeded sections, all derived from live rows only:
- *   orders       { processed, trailing_30d, window_days }
- *   commission   { accrued, trailing_30d, currency, window_days }
+ * Seeded sections, all derived from live rows only (the `trailing` windows
+ * follow the panel's `window_days`):
+ *   orders       { processed, trailing, window_days }
+ *   commission   { accrued, trailing, currency, window_days }
  *   arr          { amount, currency }
  *   aov          { amount, currency }
  *   subscription { paying_artisans, mrr, currency }
@@ -33,40 +34,41 @@ const OPERATION_OPTIONS = {
   currency: "INR",
   window_days: 30,
   sections: {
-    // Paid orders — every capture lands an order_transaction row
+    // Paid orders — every capture lands an order_transactions row
     // (reference "capture"), so "processed" is a generic count_distinct
-    // over that entity. No Medusa-specific aggregate code needed.
+    // over that entity. No Medusa-specific aggregate code needed. Entity
+    // names are the query.graph names (see list_graph_entities).
     orders: {
-      entity: "order_transaction",
+      entity: "order_transactions",
       filters: { reference: "capture" },
       aggregates: {
         processed: { fn: "count_distinct", field: "order_id" },
-        trailing_30d: {
+        trailing: {
           fn: "count_distinct",
           field: "order_id",
-          range: { date_field: "created_at", last_days: 30 },
+          range: { date_field: "created_at" },
         },
       },
       echo: { window_days: true },
     },
-    // Platform commission — partner_fee lifecycle, currency-matched
+    // Platform commission — partner_fees lifecycle, currency-matched
     commission: {
-      entity: "partner_fee",
+      entity: "partner_fees",
       filters: { status: "accrued" },
       currency_key: "currency_code",
       aggregates: {
         accrued: { fn: "sum", field: "fee_amount" },
-        trailing_30d: {
+        trailing: {
           fn: "sum",
           field: "fee_amount",
-          range: { date_field: "accrued_at", last_days: 30 },
+          range: { date_field: "accrued_at" },
         },
       },
       echo: { currency: true, window_days: true },
     },
     // Artisan subscriptions — MRR monthly-normalized (yearly / 12)
     subscription: {
-      entity: "partner_subscription",
+      entity: "partner_subscriptions",
       filters: { status: "active" },
       currency_key: "plan.currency_code",
       aggregates: {
@@ -80,18 +82,18 @@ const OPERATION_OPTIONS = {
       echo: { currency: true },
     },
     // Average amount captured per paid order over the trailing window. AOV is
-    // the captured payment amount (order_transaction with reference "capture"),
+    // the captured payment amount (order_transactions with reference "capture"),
     // NOT order.total: the order module computes total/subtotal/etc from
     // shipping-method adjustments, and query.graph cannot fetch those computed
     // money fields ("Shipping method version is required to load adjustments").
     // Captured amount equals order value for full-payment orders, which is the
     // only graph-fetchable per-order money signal.
     aov: {
-      entity: "order_transaction",
+      entity: "order_transactions",
       filters: { reference: "capture" },
       currency_key: "currency_code",
       aggregates: {
-        amount: { fn: "avg", field: "amount", range: { date_field: "created_at", last_days: 30 } },
+        amount: { fn: "avg", field: "amount", range: { date_field: "created_at" } },
       },
       echo: { currency: true },
     },


### PR DESCRIPTION
## Summary

Two fixes for the `metric_sections` stats panel, diagnosed from prod (`v3.jaalyantra.com`).

### 1. `window_days` now actually drives the trailing windows
It was only **echoed** — every trailing aggregate still hardcoded `range.last_days: 30`, so a panel set to `window_days: 300` returned the same 30-day numbers (the bug you hit when changing to 300 days).

- An aggregate's `range` can now omit `last_days` (just `{ date_field }`) to **inherit the panel's `window_days`**; `{ last_days }` overrides and `{ from, to }` stays absolute.
- Seed panel + integration test updated: `trailing_30d` → `trailing`, ranges simplified to `{ date_field }`.
- New test proves a 40-day-old fee is outside a 30-day window but inside a 90-day one.

### 2. The assistant no longer invents entity names
It hallucinated `orders`/`subscriptions`/`payments` because `metric_sections.entity` is a free string with no source of truth.

- Added a **`list_graph_entities`** admin-MCP tool backed by `GET /admin/mcp/graph-entities` — a curated list of the **real query.graph entity names** (plural snake_case, verified against prod: `order_transactions`, `partner_fees`, `partner_subscriptions`, `partner_plans`, …) with descriptions + key fields.
- `create_stats_panel`'s description now tells the assistant to call it instead of guessing.
- Seed + test entity names pluralized to match. **Plural is canonical** — prod probes confirmed the singular form of some models (`production_run`, `inventory_order`, `analytics_daily_stat`) does NOT resolve.

## Verification
- Integration test `platform-stats-panel.spec.ts`: **4/4 passing** (incl. the new window_days-driven assertion).
- MCP invariant unit tests (tool-slice, scope-invariants, required-args): **76/76**.
- Scoped tsc clean.

## Notes
- The broader graph catalog lives at `GET /admin/visual-flows/metadata`, but it pluralizes + misses the order-transaction and partner-plan sub-models — hence the focused, prod-verified list here. The two should be reconciled in a follow-up if desired.
- `mrr` being 0 on prod is correct (all 15 active artisans are on the free plan).